### PR TITLE
RUE-1488: ADR-0072 runtime platform matrix, aarch64-macos and aarch64-linux

### DIFF
--- a/.github/workflows/performance-collect.yml
+++ b/.github/workflows/performance-collect.yml
@@ -1,11 +1,13 @@
 # Performance collection (ADR-0067 Phase 5, RUE-1188; ADR-0072 Phase 1,
 # RUE-1046).
 #
-# Measures each platform's collection epoch on every trunk commit and appends
-# the raw records to the `performance-data-v1` orphan branch.
+# Measures each platform's collection epoch and appends the raw records to the
+# `performance-data-v1` orphan branch. Every leg but one runs on each trunk
+# commit; the `aarch64-macos` runtime leg runs on the daily schedule below, for
+# the cost reasons stated at that job.
 #
 # Two record kinds ride this workflow. The `measure` jobs answer how fast Rue
-# *compiles*; the `runtime` job answers how fast the programs it produces
+# *compiles*; the `runtime` jobs answer how fast the programs it produces
 # *run*. They share the runner regime, the publish path, and the store, and
 # nothing else: separate manifests, separate epochs, separate directories on
 # the data branch, and a separate posture — the runtime series is advisory and
@@ -31,6 +33,26 @@ name: Performance collection
 on:
   push:
     branches: [trunk]
+  # The daily cadence of the `aarch64-macos` runtime leg (ADR-0072 Decision 9,
+  # RUE-1488). Only that job runs on this trigger: the compile-time legs and the
+  # two Linux runtime legs are per-push instruments, and firing them again on a
+  # clock would append a second observation at a commit they already measured.
+  schedule:
+    - cron: "23 6 * * *"
+  # Dispatched from `trunk`, every leg runs — a manual re-collection at trunk's
+  # head. Dispatched from any other ref, only the macOS runtime leg runs, which
+  # is how a day's commit range is narrowed: point a branch at the trunk commit
+  # in question and dispatch there.
+  #
+  # That asymmetry is a guard, not a convenience. The compile-time legs feed
+  # ADR-0067's stall gate, which takes each platform's newest point by
+  # `finished_at` and fails EVERY pull request, with no bypass, when trunk has
+  # moved more than five commits past it. A compile-time record published from a
+  # branch head is newer than every trunk point and is not on trunk, so it trips
+  # that gate for the whole repository and keeps tripping it — and if the branch
+  # is later deleted, the gate cannot even resolve the commit. The runtime series
+  # is deliberately outside that gate, so the macOS leg is safe to dispatch
+  # anywhere.
   workflow_dispatch:
 
 # Measurement jobs only read. The publish job re-declares the write it needs.
@@ -40,12 +62,33 @@ permissions:
 # Never cancel in progress. A cancelled measurement wastes a runner; a cancelled
 # publish can leave the branch describing a run object it does not contain.
 # Queueing is the point, not a limitation.
+#
+# The queue is one deep, and that has a price the daily schedule raises. GitHub
+# holds at most one *pending* run per group and evicts the previously pending
+# one, so while a run occupies this group, the second of two queued runs
+# displaces the first. Both directions can lose an observation: a scheduled
+# macOS run holding the group means a push landing behind another push loses the
+# earlier commit's collection entirely, and a pending scheduled run displaced by
+# pushes means macOS collects nothing that day and reports "cancelled" rather
+# than failing. Accepted rather than solved: the alternative is a second writer
+# group, and two publish jobs racing for `index.json` would lose a whole run
+# object instead of a queue slot. Watch it — a run cancelled here is a hole in a
+# series, not a retry (ADR-0072 Decision 9).
 concurrency:
   group: performance-collection
   cancel-in-progress: false
 
 jobs:
   measure:
+    # Per push, or dispatched from trunk. Never on the schedule (that is the
+    # macOS leg's trigger alone), and never from another ref: a compile-time
+    # record published at a non-trunk commit trips the no-bypass stall gate for
+    # every pull request. See the `workflow_dispatch` note above. The event has
+    # to be tested as well as the ref, because a scheduled run also reports
+    # `refs/heads/trunk`.
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/trunk')
     strategy:
       fail-fast: false
       matrix:
@@ -154,26 +197,44 @@ jobs:
 
   # Runtime performance of compiled Rue programs (ADR-0072 Phase 1, RUE-1046).
   #
-  # Rides this workflow rather than adding a schedule, so a runtime regression
-  # surfaces attached to the compiler change that caused it. The v1 platform
-  # matrix is exactly one row: `x86_64-linux` on the pinned `ubuntu-24.04`
-  # image. `aarch64-linux` joins once ADR-0072's Phase 2 standard-library work
-  # is CI-verified there, and macOS stays deferred behind the `@syscall`
-  # error-detection gap.
+  # The per-push half of the platform matrix: both Linux rows, measured on every
+  # trunk commit so a runtime regression surfaces attached to the compiler
+  # change that caused it. `aarch64-linux` collects here because
+  # `ubuntu-24.04-arm` is the same hosted-runner class as `ubuntu-24.04` and
+  # this workflow already pays for one on every push above; `aarch64-macos` is
+  # the scheduled row below, where the runner is not cheap.
   #
   # A failure here fails this job and nothing else. The runtime series sits
   # deliberately outside ADR-0067's required-CI gates, including the no-bypass
   # stall gate: a stalled runtime series is a dashboard staleness flag and a
   # maintainer triage item, never a repository-wide pull-request block.
   runtime:
-    runs-on: ubuntu-24.04
-    name: runtime (x86_64-linux)
+    # Same trigger as the compile-time legs. These records do not feed the stall
+    # gate, but a runtime observation at a commit that is not on trunk is still
+    # a point in a longitudinal series that no history explains.
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/trunk')
+    strategy:
+      # One platform's broken runtime series must not cancel the other's
+      # measurement; a partial sweep is still evidence.
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            platform: x86_64-linux
+            image: ubuntu-24.04
+          - os: ubuntu-24.04-arm
+            platform: aarch64-linux
+            image: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
+    name: runtime (${{ matrix.platform }})
     # The measured work is small — five samples of a 32 MiB text workload plus
     # one release-quality build of it, on the order of a minute. The job's
     # actual cost is dominated by building `rue` and `rue-bench` under
-    # //platforms:release on a fourth runner. Wall clock is unaffected, since
-    # this runs alongside the three `measure` legs, but it is a runner's worth
-    # of compute per trunk push and the budget below is sized for the build.
+    # //platforms:release. Wall clock is unaffected, since these run alongside
+    # the `measure` legs, but each row is a runner's worth of compute per trunk
+    # push and the budget below is sized for the build.
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
@@ -189,7 +250,7 @@ jobs:
       - name: Measure compiled-program runtime
         env:
           RUE_BENCH_RUNNER_LABEL: github-hosted
-          RUE_BENCH_RUNNER_IMAGE: ubuntu-24.04
+          RUE_BENCH_RUNNER_IMAGE: ${{ matrix.image }}
         run: |
           set -euo pipefail
           mkdir -p runtime-collected
@@ -202,11 +263,11 @@ jobs:
           set +e
           "$BENCH" runtime \
             --manifest performance/runtime.toml \
-            --platform x86_64-linux \
+            --platform "${{ matrix.platform }}" \
             --compiler "$RUE" \
             --commit "${{ github.sha }}" \
             --repo-root . \
-            --out runtime-collected/runtime-x86_64-linux.json
+            --out "runtime-collected/runtime-${{ matrix.platform }}.json"
           status=$?
           set -e
           echo "runner exit status: $status"
@@ -214,7 +275,7 @@ jobs:
             echo "::error::the runtime runner could not produce a report"
             exit 1
           fi
-          echo "status=$status" > runtime-collected/runtime-x86_64-linux.status
+          echo "status=$status" > "runtime-collected/runtime-${{ matrix.platform }}.status"
 
       - name: Upload the runtime report
         # Always, so a report that cannot enter its series is still kept as
@@ -222,14 +283,119 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: runtime-x86_64-linux
+          name: runtime-${{ matrix.platform }}
           path: runtime-collected/
           retention-days: 30
 
       - name: Report the runtime series' health
         run: |
           set -euo pipefail
-          status="$(cut -d= -f2 runtime-collected/runtime-x86_64-linux.status)"
+          status="$(cut -d= -f2 "runtime-collected/runtime-${{ matrix.platform }}.status")"
+          if [ "$status" -eq 3 ]; then
+            echo "::error::the runtime report cannot enter its series. The most" \
+                 "likely cause is a compiled program producing output that does" \
+                 "not match its committed golden, which fails regardless of speed."
+            exit 1
+          fi
+          if [ "$status" -eq 5 ]; then
+            echo "::error::the runtime report is appendable but a workload did" \
+                 "not complete; the series has a hole at this commit."
+            exit 1
+          fi
+
+  # The scheduled row of the runtime matrix: Apple Silicon (ADR-0072
+  # Decisions 5 and 9, RUE-1488).
+  #
+  # macOS is measured rather than deferred. The deferral this leg replaces named
+  # the `@syscall` carry-flag error-detection gap, which RUE-945 closed on
+  # aarch64-macos; the gap that remains is in the x86-64 backend, and
+  # `x86-64-macos` is not a Rue target at all.
+  #
+  # Daily rather than per push, and for the price of the runner alone. Hosted
+  # macOS is the most expensive and most concurrency-limited class in the pool,
+  # unlike the two Linux rows above; this platform also has no calibration, so
+  # its flags are advisory whatever the cadence, and a macOS runner on every
+  # trunk commit would buy attribution nothing can act on yet. The other rows
+  # are per push because their runners are cheap and an observation at a commit
+  # cannot be collected retroactively — that argument stops at this price.
+  # The trade is that a movement here names a day's commit range rather
+  # than one commit; narrow it by pointing a branch at the trunk commit in
+  # question and dispatching there, which runs this leg alone. A day in which
+  # trunk did not move repeats the measurement at the same commit, which is
+  # exactly the repeated-sample evidence the absent calibration needs. The
+  # schedule's own cost — holding the single writer group daily, in a queue one
+  # run deep — is at the `concurrency` block above.
+  runtime-macos:
+    if: github.event_name != 'push'
+    runs-on: macos-15
+    name: runtime (aarch64-macos)
+    # Sized for the release build of `rue` and `rue-bench` on a hosted macOS
+    # runner, which dominates this job as it does its Linux sibling; the nine
+    # measured samples of a seconds-long workload are the small part.
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+
+      # The same Xcode the compile-time macOS leg pins. It does not touch the
+      # measured executables — Rue emits Mach-O through its own linker and
+      # `rue-bench` passes the compiler nothing but `-o`, the epoch's arguments,
+      # and `--target` — but it does build `rue` and `rue-bench` themselves, and
+      # the two macOS legs should not sit on different toolchains.
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+
+      - name: Install dotslash
+        uses: facebook/install-dotslash@v2
+
+      - name: Build the compiler and the runner
+        run: |
+          ./buck2 build //crates/rue:rue //crates/rue-bench:rue-bench \
+            --target-platforms //platforms:release
+
+      - name: Measure compiled-program runtime
+        env:
+          RUE_BENCH_RUNNER_LABEL: github-hosted
+          RUE_BENCH_RUNNER_IMAGE: macos-15
+        run: |
+          set -euo pipefail
+          mkdir -p runtime-collected
+          RUE="$(scripts/rue-bin --target-platforms //platforms:release)"
+          BENCH="$(./buck2 build //crates/rue-bench:rue-bench \
+            --target-platforms //platforms:release --show-simple-output 2>/dev/null | tail -1)"
+
+          # No --epoch, for the same reason the other legs omit it: the manifest
+          # marks its own collection epoch per platform.
+          set +e
+          "$BENCH" runtime \
+            --manifest performance/runtime.toml \
+            --platform aarch64-macos \
+            --compiler "$RUE" \
+            --commit "${{ github.sha }}" \
+            --repo-root . \
+            --out runtime-collected/runtime-aarch64-macos.json
+          status=$?
+          set -e
+          echo "runner exit status: $status"
+          if [ "$status" -eq 2 ]; then
+            echo "::error::the runtime runner could not produce a report"
+            exit 1
+          fi
+          echo "status=$status" > runtime-collected/runtime-aarch64-macos.status
+
+      - name: Upload the runtime report
+        # Always, so a report that cannot enter its series is still kept as
+        # evidence when the next step fails the job.
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: runtime-aarch64-macos
+          path: runtime-collected/
+          retention-days: 30
+
+      - name: Report the runtime series' health
+        run: |
+          set -euo pipefail
+          status="$(cut -d= -f2 runtime-collected/runtime-aarch64-macos.status)"
           if [ "$status" -eq 3 ]; then
             echo "::error::the runtime report cannot enter its series. The most" \
                  "likely cause is a compiled program producing output that does" \
@@ -243,10 +409,13 @@ jobs:
           fi
 
   publish:
-    needs: [measure, runtime]
+    needs: [measure, runtime, runtime-macos]
     # Runs even when a platform failed: a partial sweep still has valid runs
     # worth storing, and a platform that is persistently broken should be
-    # visible in the data rather than absent from it.
+    # visible in the data rather than absent from it. `always()` also covers
+    # the legs a trigger skips — a scheduled run publishes the macOS runtime
+    # report alone — and the single writer group above keeps a scheduled
+    # publish and a per-push publish from racing for `index.json`.
     if: always()
     runs-on: ubuntu-24.04
     name: publish

--- a/crates/rue-perf-schema/src/runtime.rs
+++ b/crates/rue-perf-schema/src/runtime.rs
@@ -1892,7 +1892,7 @@ samples = 5
         let manifest = RuntimeManifest::parse(CHECKED_IN_MANIFEST).expect("checked-in manifest");
         let epoch = manifest
             .collection_epoch("x86_64-linux")
-            .expect("the v1 platform matrix is exactly x86_64-linux");
+            .expect("x86_64-linux is the per-push row of the v1 platform matrix");
         assert_eq!(epoch.optimization, OptimizationLevel::O3);
         assert_eq!(epoch.thread_policy, ThreadPolicy::SingleThreaded);
         assert_eq!(
@@ -1919,17 +1919,86 @@ samples = 5
     }
 
     #[test]
-    fn no_platform_outside_the_v1_matrix_collects_yet() {
-        // aarch64-linux joins once ADR-0072's Phase 2 std work is CI-verified
-        // there; macOS stays deferred behind the `@syscall` gap.
+    fn the_checked_in_manifest_measures_arm64_linux_per_push() {
+        // RUE-1488. `aarch64-linux` joined on the condition ADR-0072 set for
+        // it: the Phase 2 standard-library work CI-verified on that hardware,
+        // which RUE-1481 and RUE-1482 satisfied. Same runner class as the
+        // x86-64 row, so same cadence and same sampling policy.
         let manifest = RuntimeManifest::parse(CHECKED_IN_MANIFEST).expect("checked-in manifest");
-        let collecting: Vec<&str> = manifest
+        let epoch = manifest
+            .collection_epoch("aarch64-linux")
+            .expect("aarch64-linux is a row of the v1 platform matrix");
+        assert_eq!(epoch.suite_revision, 1);
+        assert_eq!(epoch.target, "aarch64-linux");
+        assert_eq!(epoch.optimization, OptimizationLevel::O3);
+        assert_eq!(epoch.thread_policy, ThreadPolicy::SingleThreaded);
+        assert_eq!(
+            epoch.hardware_counters,
+            HardwareCounterPolicy::UnavailableOnHostedRunner
+        );
+        // The exact policy, not a relation to another row: a policy that only
+        // has to compare equal to its neighbour is satisfied by moving both.
+        // The environment is pinned the same way — a row whose label slipped to
+        // `local` parses fine and fails at collection time instead.
+        assert_eq!(epoch.environment.runner_label, "github-hosted");
+        assert_eq!(epoch.environment.runner_image, "ubuntu-24.04");
+        assert_eq!(epoch.sampling["wordfreq"].samples, 5);
+        assert_eq!(epoch.flag_posture("wordfreq"), FlagPosture::Advisory);
+    }
+
+    #[test]
+    fn the_checked_in_manifest_measures_apple_silicon_without_calibration() {
+        // RUE-1488. macOS is measured rather than deferred: the deferral named
+        // the `@syscall` carry-flag error-detection gap, and RUE-945 closed
+        // that on aarch64-macos. The row rides a daily schedule rather than
+        // per-push collection, for cost (ADR-0072 Decision 9).
+        let manifest = RuntimeManifest::parse(CHECKED_IN_MANIFEST).expect("checked-in manifest");
+        let epoch = manifest
+            .collection_epoch("aarch64-macos")
+            .expect("aarch64-macos is the scheduled row of the v1 platform matrix");
+        assert_eq!(epoch.suite_revision, 1);
+        assert_eq!(epoch.target, "aarch64-macos");
+        assert_eq!(epoch.optimization, OptimizationLevel::O3);
+        assert_eq!(epoch.thread_policy, ThreadPolicy::SingleThreaded);
+        assert_eq!(
+            epoch.hardware_counters,
+            HardwareCounterPolicy::UnavailableOnHostedRunner
+        );
+        // Pinned exactly, environment included. A row whose label slipped to
+        // `local` parses, passes a laxer test, and then refuses every hosted
+        // observation at collection time.
+        assert_eq!(epoch.environment.runner_label, "github-hosted");
+        assert_eq!(epoch.environment.runner_image, "macos-15");
+        // Nine is a starting point pending this workload's own calibration
+        // here, not a calibrated value; the assertion exists so changing it is
+        // a deliberate edit rather than a drift.
+        assert_eq!(epoch.sampling["wordfreq"].samples, 9);
+        // Never inherited from a row already collecting, however long it has
+        // been running: dispersion is a property of a workload on a platform,
+        // so this one's flags are advisory until it has calibrated its own
+        // repeated samples.
+        assert_eq!(epoch.flag_posture("wordfreq"), FlagPosture::Advisory);
+    }
+
+    #[test]
+    fn no_platform_outside_the_v1_matrix_collects() {
+        // The matrix is every platform Rue targets and nothing else. A fourth
+        // row could only be a target this compiler does not have, so a new
+        // entry here should be a deliberate change to that list rather than a
+        // manifest edit — `x86-64-macos` in particular is out of scope for the
+        // project as a whole.
+        let manifest = RuntimeManifest::parse(CHECKED_IN_MANIFEST).expect("checked-in manifest");
+        let mut collecting: Vec<&str> = manifest
             .epochs()
             .iter()
             .filter(|epoch| epoch.collection)
             .map(|epoch| epoch.platform.as_str())
             .collect();
-        assert_eq!(collecting, vec!["x86_64-linux"]);
+        collecting.sort_unstable();
+        assert_eq!(
+            collecting,
+            vec!["aarch64-linux", "aarch64-macos", "x86_64-linux"]
+        );
     }
 
     fn fingerprint() -> EnvironmentFingerprint {

--- a/docs/designs/0072-runtime-benchmarking-static-site-generator.md
+++ b/docs/designs/0072-runtime-benchmarking-static-site-generator.md
@@ -9,7 +9,7 @@ accepted:
 implemented:
 spec-sections: []
 superseded-by:
-relates: ["RUE-487", "RUE-1045", "RUE-1046", "RUE-1047", "RUE-1049", "RUE-1481", "RUE-1482", "RUE-1483", "RUE-1484", "RUE-1485", "ADR-0006", "ADR-0057", "ADR-0067", "ADR-0068", "ADR-0070", "ADR-0071"]
+relates: ["RUE-487", "RUE-945", "RUE-1045", "RUE-1046", "RUE-1047", "RUE-1049", "RUE-1481", "RUE-1482", "RUE-1483", "RUE-1484", "RUE-1485", "RUE-1488", "ADR-0006", "ADR-0057", "ADR-0067", "ADR-0068", "ADR-0070", "ADR-0071"]
 ---
 
 # ADR-0072: Runtime performance benchmarking anchored by a Rue static site generator
@@ -342,23 +342,68 @@ microbenchmark tier needs it; v1 is whole-process only.
 
 Rue builds of runtime workloads are release-quality (`-O3`), matching
 ADR-0071's definition of the product. The v1 runtime platform matrix is
-exact and deliberately narrow: `x86_64-linux` on the pinned `ubuntu-24.04`
-regime. `aarch64-linux` joins once the Phase 2 std work is CI-verified
-there; macOS stays deferred behind the known `@syscall` error-detection
-gap. Calibration does not transfer from the compiler suites: dispersion is
-a property of the workload, so each runtime workload is calibrated per
+exact, and it is every platform Rue targets:
+
+| Platform | Regime | Cadence |
+| --- | --- | --- |
+| `x86_64-linux` | `ubuntu-24.04` | every trunk push |
+| `aarch64-linux` | `ubuntu-24.04-arm` | every trunk push |
+| `aarch64-macos` | `macos-15` | daily (Decision 9) |
+
+`aarch64-linux` joined on the condition this ADR set for it — the Phase 2
+standard-library work CI-verified there — which RUE-1481 and RUE-1482
+satisfied. The verification was worth waiting for rather than nominal:
+RUE-1481's first arm64 run failed every directory-listing case because
+`O_DIRECTORY` differs between x86-64 and aarch64 on Linux while the code
+dispatched on OS alone. That is precisely the class of defect a per-platform
+leg exists to catch, and it is why a platform joins this matrix on evidence
+from its own hardware rather than on an argument that the code looks
+portable.
+
+macOS is measured rather than deferred, and the correction is worth stating
+because the deferral this ADR first recorded named a defect that no longer
+exists on the macOS Rue supports. `@syscall` used to present Darwin's
+failure convention — a positive errno in `x0` with the carry flag set — as
+though it were a small successful return, so a program could not tell a
+failed `openat` from a file descriptor. RUE-945 closed that on
+`aarch64-macos`: the AArch64 backend normalizes the carry-set result to the
+negative-errno convention `@syscall` exposes everywhere, and an assertion
+test pins the `svc #0x80` → `b.lo` → `neg x0, x0` ordering so no scheduling
+change can separate the syscall from its flag test. Every runtime workload
+does file I/O, and file I/O on `aarch64-macos` now detects errors as it does
+on Linux.
+
+The gap is genuinely still open in the x86-64 backend, whose `@syscall`
+lowering performs neither the carry normalization nor Darwin's
+syscall-class OR. That defers nothing here: `x86-64-macos` is not a Rue
+target and is out of scope for the project as a whole, so the only macOS
+this project can measure is the one where the gap is closed. What keeps the
+macOS row off per-push collection is the price of its runner, not
+capability, and Decision 9 carries that reasoning.
+
+Calibration does not transfer from the compiler suites: dispersion is a
+property of the workload, so each runtime workload is calibrated per
 platform from its own repeated samples, and regression flags on a platform
-are advisory until that calibration exists. The order-of-magnitude
-comparison claim tolerates hosted-runner dispersion either way.
+are advisory until that calibration exists. A platform joining the matrix
+therefore starts with no calibration at all and inherits none from a row
+already collecting, however long that row has been running. That is the
+rule for every arrival, stated once: `aarch64-linux` and `aarch64-macos`
+both begin advisory exactly as `x86_64-linux` did in Phase 1, and the
+manifest carries a note saying so for each rather than leaving the reader
+to infer it from an absent table. The order-of-magnitude comparison claim
+tolerates hosted-runner dispersion either way.
 
 ### 6. Close standard-library gaps on the canonical path
 
 The two prerequisite capabilities are built in `std`, not in the benchmark:
 
 - **Directory enumeration** (RUE-1481): `read_dir` plus a deterministic
-  recursive walk, built on `getdents64` through `@syscall`, pure Rue like the
-  rest of ADR-0057's fs surface. Linux first; the known macOS syscall
-  error-detection gap is tracked separately and does not block this project.
+  recursive walk, pure Rue through `@syscall` like the rest of ADR-0057's fs
+  surface — `getdents64` on Linux, `getdirentries64` on Darwin, with both
+  record layouts decoded in `std`. It landed on every target Rue has, and
+  its CLI cases run on `aarch64-macos` alongside the two Linux targets, so
+  no platform in Decision 5's matrix is short a standard-library
+  prerequisite.
 - **Substring operations** (RUE-1482): index-returning substring find,
   split, replace, join, and a lines helper, with byte-string semantics
   consistent with ADR-0035.
@@ -412,6 +457,52 @@ website-publish pipeline rather than adding a new schedule:
   then run it against the current corpus. Runtime regressions therefore
   surface attached to the compiler change that caused them, and the website
   rebuild that already follows performance collection publishes them.
+- **Per push is the default cadence; the macOS row is the exception, on
+  runner cost.** Per-push collection buys attribution to a single commit,
+  and that attribution is banked whether or not it can be acted on today: a
+  raw observation at every commit becomes readable the moment a platform's
+  calibration lands, and it cannot be collected retroactively. So a runtime
+  leg runs per push wherever a runner is cheap, which is both Linux rows —
+  `ubuntu-24.04-arm` is the same hosted class as `ubuntu-24.04`, and this
+  workflow already pays for an arm64 Linux runner on every push for the
+  compile-time legs.
+
+  Hosted macOS is not that class. It is the most expensive and most
+  concurrency-limited pool GitHub offers and the most environment-churned —
+  ADR-0067 raised exactly that churn as its open question about whether
+  macOS belonged in the compiler suites' initial epochs. At that price the
+  banked-attribution argument stops carrying: the platform has no
+  calibration, so its flags are advisory at any cadence, and daily sampling
+  already resolves a real movement on a series read for order of magnitude.
+  The macOS runtime leg therefore runs daily against trunk's head. This is
+  the scale-variant safety valve below, applied in advance rather than a
+  second policy — the valve exists to move work to a schedule when its cost
+  outgrows per-push collection, and the same lever runs the other way once
+  this platform's cost and dispersion are known.
+
+  Three consequences of the schedule are accepted deliberately, and the
+  third is a cost rather than a trade. A macOS movement is attributable to
+  a day's commit range rather than to one commit, and is narrowed by
+  pointing a branch at the trunk commit in question and dispatching there —
+  which runs the macOS leg alone, because a compile-time record published
+  from a non-trunk commit would trip ADR-0067's no-bypass stall gate for
+  every pull request. A day in which trunk did not move still produces an
+  observation at the same commit as the day before — repeated samples at a
+  fixed compiler revision, which is exactly the evidence this platform's
+  missing calibration is waiting for.
+
+  And the schedule occupies the collection workflow's single writer group
+  for the length of a macOS job. That group queues one run deep: a second
+  pending run displaces the first, so a push landing behind another push
+  while the scheduled run holds the group loses the earlier commit's
+  collection outright, and a pending scheduled run displaced by pushes
+  loses that day's macOS observation. This is the same "cannot be collected
+  retroactively" loss used above to argue for per-push collection, now
+  charged against the schedule that avoids the macOS runner. It is accepted
+  rather than solved because the alternative — a second writer group —
+  trades a lost queue slot for two publish jobs racing for `index.json`,
+  which loses a whole run object. It is the concrete thing to watch when
+  Decision 9's cost review happens.
 - **Peers are re-measured on events, not on a clock.** Pinned Zola and Hugo
   results move only when their inputs move, so the full peer leg runs only
   when the recorded fixture identity changes (content, static assets,
@@ -459,7 +550,7 @@ silently.
 
 - [x] **Phase 1: rue-bench runtime measurement mode and the runtime
   manifest, stood up on the declared wordfreq workload** - RUE-1046
-- [ ] **Phase 2: Standard-library prerequisites — directory enumeration and
+- [x] **Phase 2: Standard-library prerequisites — directory enumeration and
   substring operations** - RUE-1481, RUE-1482
 - [ ] **Phase 3: Gazette libraries — TOML front matter, Markdown subset,
   template engine** - RUE-1483
@@ -541,8 +632,13 @@ by this ADR and stays in the project as future scope.
   different times, since peers re-measure only on events; hosted-runner
   day-to-day variance is absorbed into the order-of-magnitude claim rather
   than controlled by same-run measurement.
-- Per-push collection gains a runtime leg, so its wall-clock cost grows;
-  the scale-variant safety valve bounds this, but the cost must be watched.
+- Per-push collection gains a runtime leg per Linux platform, so its
+  wall-clock cost grows and its runner count grows with the matrix; the
+  scale-variant safety valve bounds this, but the cost must be watched. The
+  macOS row is scheduled rather than per-push for the same reason, and pays
+  for it in attribution: a movement there names a day's commits rather than
+  one commit, and the rows are sampled at different cadences and cannot be
+  read as one series.
 
 ### Neutral
 
@@ -605,7 +701,10 @@ by this ADR and stays in the project as future scope.
 - Incremental-rebuild benchmarking (change one page, rebuild) — the runtime
   counterpart of ADR-0068, and a scenario where Hugo and Zola both invest
   heavily.
-- macOS runtime measurement, once the `@syscall` error-detection gap closes.
+- Per-push `aarch64-macos` runtime collection, once the scheduled leg's
+  measured cost and dispersion justify a macOS runner on every trunk
+  commit. The cadence is a cost decision, not a capability one
+  (Decisions 5 and 9).
 - A regression ratchet for the runtime series, modeled on ADR-0071, once
   dispersion is understood — this is the point at which a frozen corpus for
   the gated series becomes a prerequisite (Decision 2).
@@ -621,6 +720,8 @@ by this ADR and stays in the project as future scope.
 - [ADR-0071: Release-quality compiler performance contract](0071-release-quality-compiler-performance-contract.md)
 - Linear: Runtime performance benchmarking project — RUE-1045 (this ADR),
   RUE-1046, RUE-1047, RUE-1048, RUE-1049, RUE-1481, RUE-1482, RUE-1483,
-  RUE-1484, RUE-1485.
+  RUE-1484, RUE-1485, RUE-1488 (this amendment's platform matrix).
+- Linear: RUE-945 — the `@syscall` carry-flag normalization on
+  `aarch64-macos` that the deferred macOS row was waiting for.
 - Prior art: the Computer Language Benchmarks Game (comparison layout,
   tuned-track ethos); perf.rust-lang.org (longitudinal dashboard).

--- a/performance/runtime.toml
+++ b/performance/runtime.toml
@@ -19,10 +19,11 @@
 # outside the timed window (ADR-0071's boundary discipline), and a run that
 # produces wrong output fails regardless of how fast it was.
 #
-# The v1 platform matrix is exactly `x86_64-linux` on `ubuntu-24.04`.
-# `aarch64-linux` joins once ADR-0072's Phase 2 standard-library work is
-# CI-verified there; macOS stays deferred behind the known `@syscall`
-# error-detection gap.
+# The v1 platform matrix is every platform Rue targets (ADR-0072 Decisions 5
+# and 9; RUE-1488): `x86_64-linux` on `ubuntu-24.04` and `aarch64-linux` on
+# `ubuntu-24.04-arm`, both collected on every trunk push, and `aarch64-macos` on
+# `macos-15`, collected daily because its runner is the expensive one. No
+# platform inherits another's calibration, so a row arrives advisory and says so.
 schema_version = 1
 
 [[suite]]
@@ -110,9 +111,111 @@ samples = 5
 # suites — so until this workload's own repeated samples on this regime have
 # been analysed, every regression flag on it is advisory.
 
+# The arm64 Linux reference regime, on the pinned `ubuntu-24.04-arm` image.
+#
+# It joins on the condition ADR-0072 set for it — the Phase 2 standard-library
+# work CI-verified on this hardware — which RUE-1481 and RUE-1482 satisfied. That
+# verification was not a formality: the first arm64 run of RUE-1481 failed every
+# directory-listing case because `O_DIRECTORY` differs between x86-64 and aarch64
+# on Linux while the code dispatched on OS alone.
+#
+# Per push, like the x86-64 row and for the same reason: `ubuntu-24.04-arm` is
+# the same hosted-runner class as `ubuntu-24.04`, this workflow already pays for
+# one on every push for the compile-time legs, and an observation at every commit
+# cannot be collected retroactively once calibration makes it readable.
+[[epoch]]
+id = 1
+platform = "aarch64-linux"
+suite_revision = 1
+target = "aarch64-linux"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = true
+
+# The runner is `ubuntu-24.04-arm`; the image it reports is `ubuntu-24.04`,
+# which is how ADR-0067's aarch64-linux epochs already record this regime. The
+# architecture is not lost — it rides every record's environment fingerprint,
+# and a run built for another target could not satisfy this epoch's `target`.
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+# Five, matching the x86-64 row: same runner class, same expected dispersion,
+# and the two Linux series are easiest to read against each other when their
+# sampling policies differ in nothing.
+[epoch.sampling.wordfreq]
+samples = 5
+
+# No `[epoch.calibration]`. A new platform has none of its own and inherits none
+# from the row already collecting, so every flag here is advisory.
+
+# The Apple Silicon reference regime, on the pinned `macos-15` image.
+#
+# This row is measured, not deferred. The deferral it replaces named the
+# `@syscall` carry-flag error-detection gap, which no longer describes the macOS
+# Rue supports: RUE-945 taught the AArch64 backend to normalize Darwin's
+# carry-set positive errno to the negative convention `@syscall` presents
+# everywhere, so `wordfreq`'s open/read loop distinguishes a failure from a small
+# successful return here exactly as it does on Linux. The gap does remain open in
+# the x86-64 backend, but `x86-64-macos` is not a Rue target at all and is out of
+# scope for the project, so it defers nothing.
+#
+# Collected daily rather than per push (ADR-0072 Decision 9). Hosted macOS
+# runners are the most expensive and most concurrency-limited class in the pool,
+# and per-push attribution buys precision this platform cannot act on while its
+# flags are advisory. The schedule also gives the missing calibration the input
+# it needs: a day in which trunk did not move repeats the measurement at the
+# same compiler revision.
+[[epoch]]
+id = 1
+platform = "aarch64-macos"
+suite_revision = 1
+target = "aarch64-macos"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = true
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "macos-15"
+
+# Nine, where the reference Linux regime takes five. This is an arbitrary
+# starting point pending calibration, and it is recorded as one rather than
+# dressed up: nothing has measured this workload's dispersion on this regime, so
+# no sample count here can be justified by data yet. What the number is chosen
+# *for* is reaching that data sooner — this row is off the per-push path, so four
+# extra fresh processes of a seconds-long workload cost a fraction of the release
+# build the job already pays for, and a larger n per observation makes the
+# dispersion estimate calibration will be built from converge faster.
+#
+# It is deliberately not the compiler suites' nine. `performance/manifest.toml`
+# gives every platform nine samples of the startup probe, and that is a different
+# workload on a different boundary with a batching factor this suite does not
+# have; borrowing it would be exactly the inheritance the note below refuses.
+# ADR-0067 gives the sampling policy to the epoch so that changing this one is a
+# visible event on this platform alone.
+[epoch.sampling.wordfreq]
+samples = 9
+
+# No `[epoch.calibration]` here either, and not because it was forgotten.
+# Calibration is never inherited — not from the compiler suites, and not from a
+# runtime row already collecting, however long it has been running — so every
+# regression flag on this platform is advisory until its own repeated samples on
+# this regime have been analysed.
+
 # A development epoch for local runs on an x86-64 Linux host. Not a collection
 # target: its environment policy admits only `local`, so a hosted runner cannot
 # append to it, and a laptop cannot append to the reference series.
+#
+# It is the one x86-64-Linux-only thing left in a matrix that otherwise covers
+# every platform Rue targets, so `--platform local` does not work on an Apple
+# Silicon or arm64 Linux machine. Left as it is deliberately: a second `local`
+# epoch is a maintainer convenience rather than part of this matrix, and it
+# would need its own id and a `--epoch` to select it.
 [[epoch]]
 id = 1
 platform = "local"


### PR DESCRIPTION
Closes RUE-1488.

ADR-0072 deferred macOS runtime measurement behind the `@syscall` carry-flag error-detection gap. That rationale was stale: RUE-945 closed the gap on `aarch64-macos` in July, normalizing Darwin's carry-set positive errno to the negative convention with a codegen test pinning the `svc #0x80` → `b.lo` → `neg x0, x0` ordering. Per maintainer ruling, macOS is no longer deferred and joins the matrix.

## The matrix

| platform | image | cadence |
| --- | --- | --- |
| `x86_64-linux` | ubuntu-24.04 | per push |
| `aarch64-linux` | ubuntu-24.04-arm | per push |
| `aarch64-macos` | macos-15 | daily |

`aarch64-linux` joins because ADR-0072's stated condition — Phase 2 std work CI-verified there — is now satisfied by RUE-1481 and RUE-1482, both on trunk and green on `native (linux-arm64)`. That verification is meaningful rather than nominal: RUE-1481's first run failed all nine directory-listing cases on arm64 because `O_DIRECTORY` is architecture-specific on Linux and x86-64 and aarch64 swap it with `O_DIRECT`.

The x86-64 backend does still lack carry normalization, but `x86-64-macos` is not a Rue target and is out of project scope, so it cannot be a reason to defer anything.

## Cadence

Per push is the default because a raw observation at a commit cannot be collected retroactively — once calibration makes the series readable, the commits measured before it exist or they do not. That argument holds wherever the runner is cheap, so both Linux rows are per push; the workflow already pays for a hosted Linux runner on every push for the compile-time legs.

It stops carrying at macOS pricing: the most expensive, most concurrency-limited, most churn-prone pool, on a platform whose flags are advisory at any cadence. macOS is therefore daily — the scale-variant safety valve of Decision 9 applied in advance, and reversible in either direction.

Both costs are stated in the ADR rather than only in review. macOS movement attributes to a day's commit range rather than a single commit. And because the concurrency queue is one deep, a scheduled run holding the group means a push arriving behind another push loses that commit's collection outright, while a pending scheduled run displaced by pushes means macOS collects nothing that day and reads "cancelled" rather than failed. That is the same retroactivity loss used to argue *for* per-push, now charged against the schedule; it is accepted because a second writer group would trade a lost queue slot for two publishes racing `index.json`, which loses a whole run object.

## Calibration

Neither new epoch declares a calibration block, and both say so explicitly rather than by omission. Per Decision 5 calibration is runtime-specific and per-platform and never inherited, so a platform with no collected observations has advisory flags on arrival. `samples = 9` on macOS is named as an arbitrary starting point pending calibration — it is deliberately *not* the compiler suites' nine, which covers a different workload and boundary and carries a batching factor this suite lacks. The only justification kept is that being off the per-push path makes a larger *n* affordable, reaching a dispersion estimate sooner. `aarch64-linux` uses 5, matching the reference row's runner class and policy.

## Workflow

A `schedule:` trigger is added and the legs gated so each trigger collects exactly what it should:

| trigger | measure | runtime | runtime-macos |
| --- | --- | --- | --- |
| push (trunk) | yes | yes | no |
| schedule | no | no | yes |
| dispatch on trunk | yes | yes | yes |
| dispatch on a branch | no | no | yes |

The last row matters. ADR-0072 documents dispatching on a branch to narrow a macOS attribution window, and the compile-time legs must not publish a record at a non-trunk commit when that happens: `validate-performance-stall.py` takes each platform's newest point by completion time and counts commits from there to `origin/trunk`, so a branch commit would exceed the threshold and fail that gate on every PR, with — per its own docstring — deliberately no bypass. The gate is a ref condition rather than a workflow input because an input can be set wrong and a ref cannot. The event is tested too, since a scheduled run also reports `refs/heads/trunk`.

`publish` still needs all three legs and runs `if: always()`, consuming no job results, so a skipped leg is not a failed one. The single non-cancelling writer group is unchanged.

## Verification

`rue-bench runtime --platform aarch64-macos` was run end to end on Apple Silicon. Run honestly it exits 3 — `not appendable: the run was taken on local/local, which the epoch's github-hosted/macos-15 policy does not admit` — which is the environment gate working as designed. What it does demonstrate: wordfreq builds at `-O3` for `aarch64-macos`, nine fresh processes complete, output is deterministic across samples, and its digest equals the committed golden that the x86-64 Linux row validates against. The workload's output is therefore host-independent across both an architecture and an OS boundary. This is not evidence the CI leg will be green; only a hosted `macos-15` runner can show that. `aarch64-linux` cross-compiles to a static ARM aarch64 ELF here and has no local execution evidence; first collection is its real test, and a failure there fails only that job.

Adversarial review confirmed the gating truth table, single-writer discipline, absence of artifact collisions, content-addressed naming making a quiet-day repeat safe, and that both epochs genuinely declare no calibration. It also caught three correct decisions carrying wrong reasons, all corrected here: the Decision 6 clause justifying Linux-first directory enumeration by a Darwin syscall gap that RUE-1481 had already closed; a sampling count justified by macOS noise the repo's own calibration data contradicts; and an Xcode-pin comment claiming the toolchain links the measured executables, when Rue emits Mach-O through its own linker and the pin only affects building the tools. A proposed rule letting a platform sit on an older suite revision was removed rather than fixed — it amended ADR-0067's "new epochs on every participating platform" without saying so, nothing enforced it, and with the Decision 6 correction its motivating example no longer existed.

Tests pin values rather than relations, verified by mutation: dropping the macOS `runner_label` to `local`, or changing `samples` from 9 to 5, each fail a specific assertion.

`scripts/rue unit perf-schema` 179 passed. `scripts/rue unit bench` 108 passed. `scripts/rue quick` 31 targets, 0 failures. `validate-adrs.py` 73 records valid, plus the release-configuration, shell-pipefail, timeout-contract, and container-pin validators.
