### PR TITLE
RUE-1487: std.fs path stat selects Darwin's 64-bit-inode fstatat trap

### DIFF
--- a/crates/rue-cli-tests/cases/fs_file_io.toml
+++ b/crates/rue-cli-tests/cases/fs_file_io.toml
@@ -4,9 +4,16 @@
 # create/remove. The `fs_mkdir_` group also covers `create_dir_all` (RUE-995):
 # nested creation, idempotent re-creation, the separator shapes its byte scan has
 # to collapse, and the EEXIST-but-not-a-directory case.
-# They are `only_on` the two Linux targets: this repo's CI host is
-# Linux, and the macOS `struct stat` layout plus the Darwin *at/stat syscall
-# numbers are the DOCUMENTED, not-yet-device-verified follow-up (see std/fs.rue).
+# They are UNGATED, like the v0 group, because each one issues a syscall whose
+# number and struct layout are per-target data in std/fs.rue and only an
+# executing lane pins that table. They carried an `only_on` Linux gate until
+# RUE-1487: `_sys_newfstatat` selected Darwin's 32-bit-inode `fstatat` trap
+# against 64-bit-inode field offsets, so `fs.metadata` reported size 0 and
+# neither is_file nor is_dir for every path on macOS, and the gate meant no lane
+# ever ran the case that would have said so.
+# Naming the three current targets explicitly would reintroduce that failure in
+# slower motion: a fourth target would be SKIPPED by an unmatched `only_on`
+# rather than run, which is the same silence. No gate fails loudly instead.
 # Seek offsets are bound to an `i64` value before the call to dodge a caller-side
 # literal-typing limitation for imported functions (see File.seek's doc comment).
 #
@@ -19,13 +26,10 @@
 # AT_FDCWD, and errno tables are all selected by a @target_arch()/@target_os()
 # match, with no Rust runtime helper. The success-path cases run on every target
 # (openat/read/write/close all return non-error values that are interpreted the
-# same way everywhere). The ERROR-DETECTION cases run on every target too:
-# a failed syscall uniformly returns -errno since RUE-945 normalized Darwin's
-# carry-flag convention in the @syscall lowering, and the
-# current @syscall lowering discards the carry flag, so a failed syscall is
-# indistinguishable from a small-valued success on macOS (ADR-0057, "macOS
-# error-detection gap"; codegen follow-up tracked separately). Linux error paths
-# are correct and validated here on Linux CI.
+# same way everywhere). The ERROR-DETECTION cases run on every target too: a
+# failed syscall uniformly returns -errno, because the @syscall lowering
+# normalizes Darwin's carry-flag convention into the negative-errno one
+# (RUE-945).
 
 [section]
 id = "cli.fs_file_io"
@@ -121,6 +125,63 @@ fn main() -> i32 {
     if inb.get_or(1, 0) != 66 { return 72; }
     if inb.get_or(2, 0) != 67 { return 73; }
     if inb.get_or(3, 0) != 68 { return 74; }
+    @intCast(nr)
+}
+""" }]
+exit_code = 4
+
+# O_TRUNC: `File.create` over a LONGER existing file must discard the old
+# contents, not overwrite them in place. Write 12 'L' bytes, close, then create
+# the same path again and write 4 'S' bytes. A correct O_TRUNC leaves a 4-byte
+# file; a wrong or absent one leaves 12 bytes — "SSSS" followed by 8 stale 'L's —
+# so the read count alone separates the two. This is the ONLY case that pins
+# `_o_trunc`: every other create here writes over a shorter file or a new path,
+# where truncation changes nothing observable (RUE-1487).
+[[case]]
+name = "fs_create_truncates_longer_existing_file"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let WR = std.result.Result(u64, FE);
+    let CR = std.result.Result((), FE);
+    let Buf = std.arraybuf.ArrayBuf(u8);
+
+    let mut path = std.strbuf.StrBuf.new();
+    path.push_str("trunc.dat");
+
+    // 12 'L' bytes.
+    let mut long = Buf.new();
+    let mut i: u64 = 0;
+    while i < 12 { long.push(76); i = i + 1; }
+    let mut f = match F.create(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 81; } };
+    match f.write_all(borrow long) { CR.Ok(_u) => {}, CR.Err(_e) => { return 82; } };
+    match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 83; } };
+
+    // 4 'S' bytes over the same path: O_TRUNC must drop the other 8.
+    let mut short = Buf.new();
+    let mut j: u64 = 0;
+    while j < 4 { short.push(83); j = j + 1; }
+    let mut g = match F.create(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 84; } };
+    match g.write_all(borrow short) { CR.Ok(_u) => {}, CR.Err(_e) => { return 85; } };
+    match g.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 86; } };
+
+    let mut h = match F.open(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 87; } };
+    let mut inb = Buf.with_capacity(64);
+    let nr = match h.read(inout inb) { WR.Ok(n) => n, WR.Err(_e) => { return 88; } };
+    match h.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 89; } };
+
+    // Exactly the 4 new bytes, with no stale tail behind them.
+    if nr != 4 { return 70; }
+    let mut k: u64 = 0;
+    while k < nr {
+        if inb.get_or(k, 0) != 83 { return 71; }
+        k = k + 1;
+    }
     @intCast(nr)
 }
 """ }]
@@ -445,7 +506,6 @@ exit_code = 0
 # it. Exit code is the read count (6).
 [[case]]
 name = "fs_seek_set_read_back"
-only_on = ["x86-64-linux", "aarch64-linux"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -492,7 +552,6 @@ exit_code = 6
 # value first (caller literal-typing limitation). Exit code is the final offset (7).
 [[case]]
 name = "fs_seek_cur_end_relative"
-only_on = ["x86-64-linux", "aarch64-linux"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -539,7 +598,6 @@ exit_code = 7
 # size==13, is_file()==true, is_dir()==false. Exit code is the reported size (13).
 [[case]]
 name = "fs_stat_size_and_is_file"
-only_on = ["x86-64-linux", "aarch64-linux"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -576,7 +634,6 @@ exit_code = 13
 # path — size==9 and is_file. Exit code is the size (9).
 [[case]]
 name = "fs_metadata_by_path_size"
-only_on = ["x86-64-linux", "aarch64-linux"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -612,7 +669,6 @@ exit_code = 9
 # back. Exit code 0 on the full success path.
 [[case]]
 name = "fs_rename_old_gone_new_present"
-only_on = ["x86-64-linux", "aarch64-linux"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -661,7 +717,6 @@ exit_code = 0
 # NotFound. Exit code 0 on the full success path.
 [[case]]
 name = "fs_remove_file_then_open_notfound"
-only_on = ["x86-64-linux", "aarch64-linux"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -697,7 +752,6 @@ exit_code = 0
 # the full success path.
 [[case]]
 name = "fs_mkdir_stat_is_dir_then_rmdir"
-only_on = ["x86-64-linux", "aarch64-linux"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -733,7 +787,6 @@ exit_code = 0
 # does. Exit code is the read count so a short read cannot pass as success.
 [[case]]
 name = "fs_mkdir_then_file_roundtrip_inside"
-only_on = ["x86-64-linux", "aarch64-linux"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -787,7 +840,6 @@ exit_code = 14
 # through the full nested path. The trailing byte check is 'd' (100) of "deep".
 [[case]]
 name = "fs_mkdir_all_nested_levels_usable"
-only_on = ["x86-64-linux", "aarch64-linux"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -850,7 +902,6 @@ exit_code = 0
 # unified them would flip exactly one of these @dbg lines.
 [[case]]
 name = "fs_mkdir_double_create_flat_errs_recursive_ok"
-only_on = ["x86-64-linux", "aarch64-linux"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -887,7 +938,6 @@ exit_code = 0
 # anything, and the empty path must be NotFound rather than a silent success.
 [[case]]
 name = "fs_mkdir_all_separator_shapes"
-only_on = ["x86-64-linux", "aarch64-linux"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -930,7 +980,6 @@ exit_code = 0
 # behind the EEXIST check, the second match here would wrongly report Ok.
 [[case]]
 name = "fs_mkdir_all_file_in_the_way_errs"
-only_on = ["x86-64-linux", "aarch64-linux"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");

--- a/crates/rue-cli-tests/cases/fs_read_dir.toml
+++ b/crates/rue-cli-tests/cases/fs_read_dir.toml
@@ -24,13 +24,18 @@
 #      filesystem order would pass a single-directory ordering check on many
 #      filesystems and fail this one.
 #
-# PLATFORMS. These run on the two Linux targets AND on aarch64-macos. Linux uses
+# PLATFORMS. These are UNGATED, so they run wherever the suite runs. Linux uses
 # getdents64 with `struct linux_dirent64`; macOS uses the `getdirentries64` BSD
 # trap with Darwin's `struct dirent`, and std.fs carries both layouts. Every line
 # above the syscall — record walking, name extraction, `.`/`..` filtering, path
 # joining, sorting, and the walk's pre-order traversal — is shared, so the macOS
-# leg exercises the same logic through the other syscall. x86-64 macOS is
-# excluded because Rue has no x86-64 macOS compiler target.
+# leg exercises the same logic through the other syscall.
+#
+# An `only_on` naming today's three targets would be equivalent right up until a
+# fourth appears, at which point it SKIPS these cases rather than running them.
+# That silence is the failure mode RUE-1487 was: a Linux-only gate on the stat
+# cases meant no lane ran the one that would have reported Darwin's `fstatat`
+# trap decoding against the wrong struct layout. No gate fails loudly instead.
 #
 # SYMLINKS come from the harness's `symlinks` fixture list, not from the program:
 # `std.fs` has no `symlinkat`, and a `files` entry can only produce a regular
@@ -50,7 +55,6 @@ description = "read_dir over getdents64 and the deterministic recursive walk, ag
 # implementation reports 2 and 4 here.
 [[case]]
 name = "read_dir_empty_then_dot_entries_skipped"
-only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -104,7 +108,6 @@ exit_code = 0
 # each entry's kind, and that `path(i)` is the parent joined with the name.
 [[case]]
 name = "read_dir_mixed_files_and_dirs_sorted"
-only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -185,7 +188,6 @@ exit_code = 0
 # string-shaped assertion above.
 [[case]]
 name = "read_dir_entry_path_is_openable"
-only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -245,7 +247,6 @@ exit_code = 17
 # comparison and output filename subtly wrong.
 [[case]]
 name = "read_dir_trailing_separator_joins_once"
-only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -292,7 +293,6 @@ exit_code = 0
 # or append-at-the-end traversal produces a different sequence and fails.
 [[case]]
 name = "walk_nested_tree_is_depth_first_preorder"
-only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -366,7 +366,6 @@ exit_code = 0
 # sorted-look check on some filesystems and fail here on all of them.
 [[case]]
 name = "read_dir_order_is_creation_order_independent"
-only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -460,7 +459,6 @@ exit_code = 0
 # for the count (600 does not fit an exit status); stdout carries it.
 [[case]]
 name = "read_dir_refill_loop_600_entries"
-only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -557,7 +555,6 @@ exit_code = 0
 # std/fs.rue.
 [[case]]
 name = "read_dir_missing_and_not_a_directory_err"
-only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -619,7 +616,6 @@ exit_code = 0
 # about it.
 [[case]]
 name = "read_dir_through_a_directory_symlink"
-only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 symlinks = [{ link = "dir_link", target = "real_dir" }]
 files = [
@@ -676,7 +672,6 @@ exit_code = 0
 # count: the case would hang or fail the sequence, not merely disagree.
 [[case]]
 name = "walk_does_not_descend_into_symlinks"
-only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 symlinks = [
     { link = "tree/dir_link", target = "sub" },

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -104,9 +104,9 @@ const ENTRIES: &[Entry] = &[
     // std.fs File IO v0 (RUE-712, ADR-0057): pure-Rue fs over @syscall. The
     // oracle model cannot execute the raw-pointer/syscall substrate (StrBuf/
     // ArrayBuf `@int_to_ptr` prologue, `@alloc`, `@syscall`), so every
-    // case is accepted debt, exactly like the arraybuf/strbuf CLI cases. The
-    // two error-detection cases run `only_on` Linux (macOS carry-flag gap,
-    // ADR-0057 §3a), so their gap registration is Linux-scoped to match.
+    // case is accepted debt, exactly like the arraybuf/strbuf CLI cases. The v0
+    // group is ungated in the case file, so its gap registrations are unscoped
+    // to match.
     Entry::new(
         "cli.fs_file_io",
         "fs_roundtrip",
@@ -116,6 +116,12 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.fs_file_io",
         "fs_append",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_create_truncates_longer_existing_file",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
@@ -165,50 +171,50 @@ const ENTRIES: &[Entry] = &[
     // metadata, rename, unlink, and directory create/remove. Same raw-pointer
     // substrate as v0; with heap allocation and inout forwarding modeled, the
     // oracle reaches the still-unmodeled byte-copy intrinsic. These cases are
-    // `only_on` the two Linux targets (macOS stat layout + Darwin *at syscall
-    // numbers are a documented, unverified follow-up), so their scope is
-    // Linux-only to match.
+    // ungated in the case file — they pin per-target syscall numbers and struct
+    // layouts, so every lane must run them (RUE-1487) — and their scope is
+    // unrestricted to match.
     Entry::new(
         "cli.fs_file_io",
         "fs_seek_set_read_back",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
-        &["aarch64-linux", "x86-64-linux"],
+        &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_seek_cur_end_relative",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
-        &["aarch64-linux", "x86-64-linux"],
+        &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_stat_size_and_is_file",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
-        &["aarch64-linux", "x86-64-linux"],
+        &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_metadata_by_path_size",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
-        &["aarch64-linux", "x86-64-linux"],
+        &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_rename_old_gone_new_present",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
-        &["aarch64-linux", "x86-64-linux"],
+        &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_remove_file_then_open_notfound",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
-        &["aarch64-linux", "x86-64-linux"],
+        &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_mkdir_stat_is_dir_then_rmdir",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
-        &["aarch64-linux", "x86-64-linux"],
+        &[],
     ),
     // RUE-995: the `create_dir_all` cases reach the same `@byte_copy` gap as the
     // rest of the std.fs group — every one of them marshals a path through
@@ -218,37 +224,36 @@ const ENTRIES: &[Entry] = &[
         "cli.fs_file_io",
         "fs_mkdir_then_file_roundtrip_inside",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
-        &["aarch64-linux", "x86-64-linux"],
+        &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_mkdir_all_nested_levels_usable",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
-        &["aarch64-linux", "x86-64-linux"],
+        &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_mkdir_double_create_flat_errs_recursive_ok",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
-        &["aarch64-linux", "x86-64-linux"],
+        &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_mkdir_all_separator_shapes",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
-        &["aarch64-linux", "x86-64-linux"],
+        &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_mkdir_all_file_in_the_way_errs",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
-        &["aarch64-linux", "x86-64-linux"],
+        &[],
     ),
     // RUE-1481: directory enumeration (`read_dir`/`walk`) reaches the same
     // `@byte_copy` gap as the rest of the std.fs group — every entry's path is
-    // pooled through StrBuf, which copies bytes in bulk. These cases also run on
-    // aarch64-macos, unlike the v1 group above, because the Darwin dirent path
-    // is exercised rather than merely documented; their scope matches.
+    // pooled through StrBuf, which copies bytes in bulk. Ungated in the case
+    // file like the groups above, so their scope is unrestricted to match.
     //
     // The two symlink cases are absent on purpose, not overlooked: they stage
     // their directory trees as extra `files` entries, so the harness classifies
@@ -259,49 +264,49 @@ const ENTRIES: &[Entry] = &[
         "cli.fs_read_dir",
         "read_dir_empty_then_dot_entries_skipped",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
-        &["aarch64-linux", "aarch64-macos", "x86-64-linux"],
+        &[],
     ),
     Entry::new(
         "cli.fs_read_dir",
         "read_dir_entry_path_is_openable",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
-        &["aarch64-linux", "aarch64-macos", "x86-64-linux"],
+        &[],
     ),
     Entry::new(
         "cli.fs_read_dir",
         "read_dir_missing_and_not_a_directory_err",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
-        &["aarch64-linux", "aarch64-macos", "x86-64-linux"],
+        &[],
     ),
     Entry::new(
         "cli.fs_read_dir",
         "read_dir_mixed_files_and_dirs_sorted",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
-        &["aarch64-linux", "aarch64-macos", "x86-64-linux"],
+        &[],
     ),
     Entry::new(
         "cli.fs_read_dir",
         "read_dir_order_is_creation_order_independent",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
-        &["aarch64-linux", "aarch64-macos", "x86-64-linux"],
+        &[],
     ),
     Entry::new(
         "cli.fs_read_dir",
         "read_dir_refill_loop_600_entries",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
-        &["aarch64-linux", "aarch64-macos", "x86-64-linux"],
+        &[],
     ),
     Entry::new(
         "cli.fs_read_dir",
         "read_dir_trailing_separator_joins_once",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
-        &["aarch64-linux", "aarch64-macos", "x86-64-linux"],
+        &[],
     ),
     Entry::new(
         "cli.fs_read_dir",
         "walk_nested_tree_is_depth_first_preorder",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
-        &["aarch64-linux", "aarch64-macos", "x86-64-linux"],
+        &[],
     ),
     // RUE-682: only the std.hash cases that route bytes through StrBuf or
     // ArrayBuf(u8) hit the `@byte_copy` gap. The three that hash `str` views

--- a/docs/designs/0057-file-io-v0.md
+++ b/docs/designs/0057-file-io-v0.md
@@ -283,9 +283,9 @@ Implemented under RUE-712 on 2026-07-16:
 ### Negative
 - Syscall-number, open-flag, and errno tables are hand-maintained per target; a
   new target adds rows to all three.
-- **macOS error detection is broken until the `@syscall` lowering negates on the
-  Darwin carry flag** (§3a) — a real hole, scoped out of RUE-712 and filed as a
-  codegen follow-up; macOS error tests are Linux-gated meanwhile.
+- Correct error detection depends on the `@syscall` lowering normalizing
+  Darwin's carry flag into the negative-errno convention (§3a). That landed in
+  RUE-945, so the tables here are read the same way on every target.
 - Until RUE-591, an ignored `close()` `Result` is silently dropped.
 - v0 is minimal: no seek/stat/dirs/rename/buffering.
 - The buffer API is on `ArrayBuf(u8)` and pays a temporary-copy per read/write;

--- a/std/fs.rue
+++ b/std/fs.rue
@@ -25,14 +25,18 @@
 // Buffering and stdin/stdout unification remain deferred (out of ADR-0057 scope).
 //
 // PER-TARGET STAT LAYOUT: `stat` is the fiddliest v1 piece because the kernel's
-// `struct stat` byte layout differs per OS AND per arch. This module decodes
-// only two fields (st_mode, st_size) at documented offsets (see the stat
-// section below). x86-64-linux and aarch64-linux offsets are exercised by CI
-// here; the macOS 64-bit-inode offsets and Darwin stat/at-syscall numbers are
-// the DOCUMENTED, NOT-YET-CI-VERIFIED follow-up (this host is Linux). New v1
-// CLI cases are therefore `only_on` the two Linux targets, mirroring how v0's
-// error-detection cases were Linux-scoped until a macOS device could confirm.
-// Darwin stat decoding is in fact broken today — the open issue is RUE-1487.
+// `struct stat` byte layout differs per OS AND per arch, and a trap number and a
+// field-offset table that disagree produce plausible garbage rather than an
+// error. This module decodes only two fields (st_mode, st_size) at documented
+// offsets (see the stat section below).
+//
+// Darwin exposes BOTH inode widths as separate traps: `fstat`/`fstatat` fill the
+// legacy 32-bit-inode `struct stat`, while `fstat64`/`fstatat64` fill the
+// 64-bit-inode layout. The offsets here (st_mode @4, st_size @96) are the
+// 64-bit-inode layout, so `_sys_fstat` and `_sys_newfstatat` must both select
+// the `*64` trap; pairing them with the 32-bit-inode trap decodes unrelated
+// bytes and reports size 0 for every file. The macOS rows are exercised by the
+// `fs_stat_`/`fs_metadata_` CLI cases, which run on aarch64-macos.
 //
 // PATHS are byte-string `StrBuf`s; the syscall boundary copies the bytes into a
 // NUL-terminated buffer and never exposes that terminator to the caller.
@@ -41,17 +45,14 @@
 // escapes. Linux and macOS give the same logical error different integers
 // (e.g. EAGAIN is 11 on Linux, 35 on macOS), so the tables are per-OS.
 //
-// PLATFORM ERROR-DETECTION CAVEAT (ADR-0057, "macOS error-detection gap"):
-// error detection here relies on a failed syscall returning `-errno` (a
-// negative value). Linux does exactly that. macOS/Darwin instead returns a
-// POSITIVE errno and signals failure with the carry flag — and the current
-// `@syscall` codegen lowering discards the carry flag (it just moves x0),
-// so on macOS a failed syscall is indistinguishable from a success that
-// returns a small value (a failed openat returning ENOENT=2 looks exactly
-// like a successful openat returning fd 2). Success paths are correct on
-// macOS; error DETECTION is not, until the `@syscall` lowering is taught to
-// negate-on-carry the way the Rust runtime wrappers already do. Tracked as a
-// codegen follow-up (see ADR-0057). Linux behavior is correct and CI-validated.
+// ERROR DETECTION relies on a failed syscall returning `-errno` (a negative
+// value), which is the Linux convention directly. macOS/Darwin instead returns
+// a POSITIVE errno and signals failure with the carry flag, so a raw Darwin
+// return is ambiguous on its own — a failed openat returning ENOENT=2 is
+// bit-identical to a successful openat returning fd 2. The `@syscall` lowering
+// closes that gap in codegen rather than here: on Mach-O it branches on carry
+// after the trap and negates x0, so every target this module compiles for
+// presents the same negative-errno convention (RUE-945).
 
 const result = @import("result.rue");
 const option = @import("option.rue");
@@ -198,7 +199,7 @@ fn _sys_write() -> u64 {
 }
 
 // lseek(2) — reposition the file offset. Linux: 8 (x86-64), 62 (aarch64,
-// asm-generic). macOS raw BSD trap 199 (DOCUMENTED, not CI-verified here).
+// asm-generic). macOS raw BSD trap 199.
 fn _sys_lseek() -> u64 {
     match @target_arch() {
         Arch.X86_64 => {
@@ -217,7 +218,8 @@ fn _sys_lseek() -> u64 {
 }
 
 // fstat(2) — stat an open fd. Linux: 5 (x86-64), 80 (aarch64). macOS raw BSD
-// fstat64 trap 339 (DOCUMENTED, not CI-verified — see the stat-layout note).
+// `fstat64` trap 339: the 64-bit-inode variant, matching the field offsets this
+// module decodes (see the stat-layout note at the top of this file).
 fn _sys_fstat() -> u64 {
     match @target_arch() {
         Arch.X86_64 => {
@@ -237,20 +239,23 @@ fn _sys_fstat() -> u64 {
 
 // newfstatat(2)/fstatat — stat a path relative to a dirfd. Used uniformly with
 // AT_FDCWD for path-based stat (aarch64 Linux has no bare `stat`, exactly like
-// openat). Linux: 262 (x86-64), 79 (aarch64). macOS raw BSD fstatat trap 469
-// (DOCUMENTED, not CI-verified).
+// openat). Linux: 262 (x86-64), 79 (aarch64). macOS raw BSD `fstatat64` trap
+// 470 — the 64-bit-inode variant, matching the layout `_stat_mode_offset`/
+// `_stat_size_offset` decode and pairing with the `fstat64` trap `_sys_fstat`
+// uses. Darwin also has a `fstatat` trap at 469, but that one fills the legacy
+// 32-bit-inode `struct stat`, whose fields sit at different offsets.
 fn _sys_newfstatat() -> u64 {
     match @target_arch() {
         Arch.X86_64 => {
             match @target_os() {
                 Os.Linux => 262,
-                Os.Macos => 469,
+                Os.Macos => 470,
             }
         },
         Arch.Aarch64 => {
             match @target_os() {
                 Os.Linux => 79,
-                Os.Macos => 469,
+                Os.Macos => 470,
             }
         },
     }
@@ -258,7 +263,7 @@ fn _sys_newfstatat() -> u64 {
 
 // renameat(2) — rename oldpath to newpath, both relative to a dirfd. Used with
 // AT_FDCWD for both ends. Linux: 264 (x86-64), 38 (aarch64). macOS raw BSD
-// renameat trap 465 (DOCUMENTED, not CI-verified).
+// renameat trap 465.
 fn _sys_renameat() -> u64 {
     match @target_arch() {
         Arch.X86_64 => {
@@ -279,7 +284,7 @@ fn _sys_renameat() -> u64 {
 // unlinkat(2) — remove a path relative to a dirfd; with AT_REMOVEDIR it removes
 // a directory instead of a file. Used with AT_FDCWD for both `remove` and
 // `remove_dir`. Linux: 263 (x86-64), 35 (aarch64). macOS raw BSD unlinkat trap
-// 472 (DOCUMENTED, not CI-verified).
+// 472.
 fn _sys_unlinkat() -> u64 {
     match @target_arch() {
         Arch.X86_64 => {
@@ -298,8 +303,7 @@ fn _sys_unlinkat() -> u64 {
 }
 
 // mkdirat(2) — create a directory relative to a dirfd. Used with AT_FDCWD.
-// Linux: 258 (x86-64), 34 (aarch64). macOS raw BSD mkdirat trap 475
-// (DOCUMENTED, not CI-verified).
+// Linux: 258 (x86-64), 34 (aarch64). macOS raw BSD mkdirat trap 475.
 fn _sys_mkdirat() -> u64 {
     match @target_arch() {
         Arch.X86_64 => {
@@ -368,6 +372,9 @@ fn _o_creat() -> u64 {
     }
 }
 
+// Pinned by `fs_create_truncates_longer_existing_file`, which is the only case
+// that creates over a LONGER existing file — the one shape where a wrong value
+// is observable, as a stale tail behind the new contents.
 fn _o_trunc() -> u64 {
     match @target_os() {
         Os.Linux => 512,  // 0o1000
@@ -414,9 +421,15 @@ fn _o_append() -> u64 {
 // changes, dropping the flag entirely would be invisible to a test, so `read_dir`
 // on a regular file pins the behavior and not this constant.
 //
-// The constant itself is pinned by `read_dir_through_a_directory_symlink`, which
-// is what caught the swap above: a wrong value here fails a listing THROUGH a
-// symlinked directory while leaving every error path looking correct.
+// The LINUX rows are pinned by `read_dir_through_a_directory_symlink`, which is
+// what caught the swap above: a wrong value there fails a listing THROUGH a
+// symlinked directory while leaving every error path looking correct. That works
+// because a wrong aarch64 value is O_DIRECT, which the open rejects outright.
+//
+// The macOS row is NOT pinned — Darwin has no O_DIRECT for a wrong value to
+// collide with, so a bad flag is simply ignored and every case still passes.
+// It is header-checked (BSD 0x00100000 on both arches) and unvalidated by test,
+// like `_at_symlink_nofollow` below.
 fn _o_directory() -> u64 {
     match @target_arch() {
         Arch.X86_64 => {
@@ -441,8 +454,7 @@ fn _create_mode() -> u64 { 420 }
 fn _dir_mode() -> u64 { 493 }
 
 // AT_REMOVEDIR: the unlinkat flag that makes it remove a directory (like rmdir)
-// instead of a file. Linux 0x200=512 (asm-generic, both arches); macOS 0x80=128
-// (DOCUMENTED, not CI-verified).
+// instead of a file. Linux 0x200=512 (asm-generic, both arches); macOS 0x80=128.
 fn _at_removedir() -> u64 {
     match @target_os() {
         Os.Linux => 512,
@@ -451,7 +463,10 @@ fn _at_removedir() -> u64 {
 }
 
 // AT_SYMLINK_NOFOLLOW: the *at flag that stats the LINK rather than its target.
-// Linux 0x100=256; macOS 0x0020=32 (DOCUMENTED, not CI-verified). Genuinely
+// Linux 0x100=256; macOS 0x0020=32. Header-checked but NOT pinned by a test on
+// any target: its only caller is the DT_UNKNOWN fallback below, and every
+// filesystem CI runs on (ext4, tmpfs, APFS) populates `d_type`, so no case
+// reaches it. Treat a change here as unvalidated. Genuinely
 // arch-independent on Linux, unlike the `O_*` flags: the `AT_*` values live in
 // `include/uapi/linux/fcntl.h`, which has no per-arch variant to override them
 // (see `_o_directory` for the flags that do). Used only by the
@@ -494,7 +509,8 @@ fn _i64_bits(x: i64) -> u64 {
 //     st_mode  unsigned int  @ 16     st_size  long  @ 48
 //   macOS (Darwin `struct stat`, _DARWIN_FEATURE_64_BIT_INODE, sys/stat.h):
 //     st_mode  __uint16_t    @ 4      st_size  __int64_t  @ 96
-//     (DOCUMENTED, not CI-verified on this Linux host.)
+//     Filled by the `fstat64`/`fstatat64` traps only — see the stat-layout note
+//     at the top of this file for the 32-bit-inode traps these must not use.
 //
 // st_mode is read as a little-endian u16 (the file-type bits fit the low 16
 // bits on every target); st_size is read as a little-endian u64.
@@ -1172,12 +1188,6 @@ pub fn remove_dir(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
 // `FileKind.Other` rather than failing the whole listing; `Other` is the "not a
 // file, not a directory, do not descend" answer, which is the safe reading of an
 // entry that no longer exists.
-//
-// KNOWN LIMIT OF THAT FALLBACK ON macOS. Darwin `stat` decoding is broken here —
-// the open issue is RUE-1487, and the stat-layout note at the top of this file
-// has the details — so a DT_UNKNOWN entry on macOS degrades to `FileKind.Other`
-// rather than resolving. APFS and HFS+ both populate `d_type`, so the fallback
-// is unreachable there in practice; the Linux path is unaffected.
 //
 // ORDERING IS PART OF THE CONTRACT, not a nicety (ADR-0072 Decision 6): the
 // kernel returns entries in filesystem order, which varies with creation history


### PR DESCRIPTION
Closes RUE-1487.

On `aarch64-macos`, `fs.metadata(path)` returned garbage for a real file — `size=0`, `is_file()==false`, `is_dir()==false` for a 5-byte 0644 regular file.

## Root cause

`_sys_newfstatat` used Darwin trap **469** (`SYS_fstatat`), which fills the 32-bit-inode `struct stat`, while the module decodes at the 64-bit-inode offsets (`st_mode @4`, `st_size @96`). Trap and layout disagreed, so `st_mode` was read from the wrong field entirely. The module already used `339 = SYS_fstat64` correctly for the fd-based path, so it was internally inconsistent with itself.

A raw `svc #0x80` probe against a known file, decoding at the module's own offsets:

```
trap 469 -> mode=0137406  size=0     (mode actually lands at offset 8)
trap 470 -> mode=0100644  size=13    matches stat(1)
```

`0xbf06 & S_IFMT = 0xb000` is neither `S_IFREG` nor `S_IFDIR`, which is exactly the reported symptom. The fix is `469` → `470`.

The offsets themselves were verified correct with a compiled probe (`sizeof(struct stat)=144, st_mode@4, st_size@96`), so fixing only the trap does not leave a subtler bug behind. Note that on arm64 `__DARWIN_ONLY_64_BIT_INO_T=1`, so `struct stat64` is not a distinct userspace type — `struct stat` *is* the 64-bit-inode layout. The kernel traps remain distinct regardless, which is what the probe demonstrates.

This is pre-existing rather than a regression: the same probe against `git archive trunk std` produces byte-identical broken output.

## Why it survived this long, and what changes

The Darwin rows were labelled "DOCUMENTED, not CI-verified" and the `fs_metadata` cases were gated to Linux. The gating is what hid the bug, so the gating is the substantive half of this change.

The `only_on` lists are dropped from both fs case files. They had come to enumerate every valid target, which is equivalent to no gate — except that a fourth target would *silently skip* these cases rather than run them, which is the same failure mode in slower motion. Coverage was verified to survive the ungating rather than merely still compile: a read_dir-dependent mutation (`_dirent_name_offset` macOS 21 → 19) produces 9 failures with identical case names both before and after, and the original trap mutation still produces exactly 5.

`scripts/rue cli fs_` now reports **32 passed, 0 failed, 0 ignored**. The zero is the point: a skipped case and a passing case are indistinguishable in a summary line, and that is how this bug hid.

Reverting the trap fails 5 cases — `fs_metadata_by_path_size`, `fs_mkdir_stat_is_dir_then_rmdir`, and three `create_dir_all` cases that stat internally for idempotency. Notably `fs_stat_size_and_is_file` still *passes* while broken, because it routes through `File.metadata`/`fstat64`, which was always correct. Un-gating the existing cases alone would therefore have left the path-stat trap unpinned.

## Neighbourhood audit

Every Darwin constant was checked by function against the SDK headers and a compiled probe, not by grepping values: traps `read 3, write 4, close 6, lseek 199, fstat64 339, getdirentries64 344, openat 463, renameat 465, unlinkat 472, mkdirat 475`; `struct stat` (144 bytes, mode @4, size @96); `struct dirent` (reclen @16, type @20, name @21); and the `O_*`, `AT_*`, `S_IF*`, `DT_*` sets. `fstatat` was the only wrong one.

Each label upgraded from "not CI-verified" was then mutation-tested individually to confirm a test actually pins it — `mkdirat` 13 failures, `AT_FDCWD` 31, `O_CREAT` 25, `getdirentries64` 9, and so on. Two constants are *not* pinned and are now labelled honestly rather than inheriting a claim they have not earned:

- **`AT_SYMLINK_NOFOLLOW`** — its only caller is the DT_UNKNOWN fallback, and ext4, tmpfs, and APFS all populate `d_type`, so nothing reaches it.
- **`_o_directory` on macOS** — Darwin has no `O_DIRECT` at all, and `0x4000` is unassigned in its `O_*` space, so a wrong value is an unrecognized flag the kernel ignores. The Linux pin works precisely *because* a wrong aarch64 value collides with `O_DIRECT` and the open is rejected.

`_o_trunc` was found in the same position — unpinned on every target, with a wrong value leaving stale trailing bytes when creating over a longer existing file. Rather than only correcting the comment, this adds `fs_create_truncates_longer_existing_file`: write 12 bytes, re-create, write 4, read back. The read count alone separates correct from broken, so it does not depend on the stat machinery beside it. Mutating `_o_trunc` to 0 on both rows, or to 512 on macOS, fails exactly that one case.

## Documentation

The "KNOWN LIMIT ON macOS" paragraph in the `read_dir` DT_UNKNOWN section is removed — with the trap fixed, the fallback resolves correctly rather than degrading to `FileKind.Other`.

ADR-0057's `### Negative` consequences bullet asserted that "macOS error detection is broken until the `@syscall` lowering negates on the Darwin carry flag" and that "macOS error tests are Linux-gated meanwhile." Both halves are now false — RUE-945 landed the carry normalization, and this change removes the gating — so the bullet is rewritten as a live dependency rather than an open hole. §3a is left alone: it is a decision record and already self-updates.

`scripts/rue quick` 31 targets, 0 failures. `rue-oracle-diff` 0 disagreements with the new case registered.
