### PR TITLE
RUE-1473: prefer anonymous identity reuse hits

### DIFF
--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -1006,6 +1006,10 @@ where
     ) where
         M: Clone,
     {
+        debug_assert!(
+            !self.anonymous_poisoned.contains_key(&key),
+            "a poisoned anonymous identity cannot be registered as successful"
+        );
         self.record_anonymous_identity(key, ty);
     }
 
@@ -1626,13 +1630,16 @@ where
         // consult, registration) sees the canonical producer form.
         let key = key.with_canonical_producer();
         let key = key.as_ref();
-        if let Some(error) = self.anonymous_poisoned.get(key) {
-            return Err(error.clone());
-        }
         // Producer-nominal dedup: a key already minted resolves by lookup, so a
         // repeat consult re-mints nothing (the epoch's `anon_*_identities.get`).
         if let Some(&ty) = self.anon_nominals.get(key) {
             return Ok(ty);
+        }
+        // Successful and poisoned identities are disjoint: failed mints roll
+        // their recursive shell back before publishing the error, and the
+        // alternate registration entry point checks the invariant in debug builds.
+        if let Some(error) = self.anonymous_poisoned.get(key) {
+            return Err(error.clone());
         }
 
         let shape = self
@@ -4383,10 +4390,14 @@ mod tests {
             [],
         );
 
-        assert_eq!(
-            pool.find_or_create_anon(&outer),
-            Err(IdentityMintError::MissingAnonymousShape)
-        );
+        let expected = Err(IdentityMintError::MissingAnonymousShape);
+        assert_eq!(pool.find_or_create_anon(&outer), expected);
+        assert_eq!(pool.anonymous_poisoned.get(&outer), expected.as_ref().err());
+        assert!(!pool.anon_nominals.contains_key(&outer));
+        assert!(pool.anonymous_identities.is_empty());
+
+        assert_eq!(pool.find_or_create_anon(&outer), expected);
+        assert_eq!(pool.anonymous_poisoned.get(&outer), expected.as_ref().err());
         assert!(!pool.anon_nominals.contains_key(&outer));
         assert!(pool.anonymous_identities.is_empty());
     }

--- a/scripts/validate-debug-assert-policy.py
+++ b/scripts/validate-debug-assert-policy.py
@@ -40,7 +40,7 @@ ALLOWANCES = {
     "crates/rue-air/src/sema/analysis/ownership.rs": Allowance(1, "redundant non-negative arena-index check"),
     "crates/rue-air/src/sema/binding_manifest.rs": Allowance(2, "redundant binding-manifest construction checks"),
     "crates/rue-air/src/sema/body_identity.rs": Allowance(
-        1, "redundant anonymous-identity publication check"
+        2, "redundant anonymous-identity publication and disjointness checks"
     ),
     "crates/rue-air/src/sema/comptime_eval.rs": Allowance(2, "redundant semantic phase preconditions"),
     "crates/rue-air/src/sema/declaration_index.rs": Allowance(4, "redundant declaration indexing counters"),


### PR DESCRIPTION
## Summary

- consult successful anonymous identities before poisoned failures
- make successful/poisoned map disjointness explicit at the alternate registration boundary
- lock down failed-mint rollback and repeat-poison behavior

## Evidence

- frozen Lattice classifies 35,555 anonymous identity lookups: 21,732 success hits, 0 poison hits, 13,823 uncached
- success-first ordering removes exactly 21,732 full structural-key probes/hashes
- focused semantic identity regressions: 59 passed
- `scripts/rue quick`: 31 targets passed, 0 failed
- release ThinLTO Lattice outputs remain byte-exact on x86-64 Linux and AArch64 macOS

Refs RUE-1473.