### PR TITLE
RUE-1473: reuse qualified callable name buffers

### DIFF
--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -107,6 +107,13 @@ fn append_member_callable_name(mut owner: String, method: &str, has_self: bool) 
     owner
 }
 
+fn append_file_callable_name(mut module_path: String, name: &str) -> String {
+    module_path.reserve(1 + name.len());
+    module_path.push('$');
+    module_path.push_str(name);
+    module_path
+}
+
 #[cfg(test)]
 #[test]
 fn synthetic_argument_names_match_the_canonical_spelling_without_a_heap_buffer() {
@@ -127,6 +134,15 @@ fn member_callable_names_extend_the_owned_owner_spelling() {
     assert_eq!(
         append_member_callable_name("Owner".to_owned(), "make", false),
         "Owner::make"
+    );
+}
+
+#[cfg(test)]
+#[test]
+fn file_callable_names_extend_the_owned_module_path() {
+    assert_eq!(
+        append_file_callable_name("pkg/support.rue".to_owned(), "build"),
+        "pkg/support.rue$build"
     );
 }
 
@@ -1186,9 +1202,10 @@ where
         }
         let module = self.modules_by_file.borrow().get(&file)?.clone();
         let name = self.interner.resolve(&source_symbol);
-        let internal = self
-            .interner
-            .get_or_intern(&format!("{}${name}", self.source.module_path(&module)));
+        let internal = self.interner.get_or_intern(append_file_callable_name(
+            self.source.module_path(&module),
+            name,
+        ));
         if self.function_infos.borrow().contains_key(&internal) {
             return Some(internal);
         }


### PR DESCRIPTION
Summary:
- extend the owned module path in place when spelling cross-file callable symbols
- preserve the canonical `module_path$name` interner lookup and all retry behavior
- avoid adding a positive cache because the measured reuse volume did not meet its threshold

Evidence:
- frozen Lattice classified 6,164 formatted cross-file probes: 1,841 first registrations, 4,323 reuses, and 0 misses
- removes 6,164 separate formatting buffers and 65,973 bytes of duplicate module-prefix copying; no wall-time claim
- focused unit and qualified cross-module behavior tests pass; `scripts/rue quick` passes
- release ThinLTO Lattice outputs remain byte-exact on x86-64 Linux and AArch64 macOS

Refs RUE-1473.