### PR TITLE
RUE-1484: gazette builds the live rue-lang.dev corpus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,6 +366,26 @@ jobs:
           path: ${{ runner.temp }}/premerge-test-results.txt
           if-no-files-found: ignore
 
+      # ADR-0072 Decision 3's fairness rule is the constraint most able to
+      # silently invalidate the runtime benchmark, and it is the one no output
+      # check can catch: a navigation flattened out of the template and into
+      # host code emits the same link targets and the same visible text on
+      # every page, so determinism, the file set, and the semantic oracle all
+      # stay green. The spot goldens are what notices, because they hold the
+      # markup of a sidebar rendered over a real section tree with an active
+      # branch — and they are hermetic, need no Zola, and take seconds.
+      #
+      # They also pin the port against production drift, which ADR-0072's
+      # Consequences name as a risk and which nothing else checks.
+      #
+      # This lane, specifically: gazette is the only program in the tree that
+      # drives `std.fs`'s directory walk, `create_dir_all`, and file creation
+      # in anger, and RUE-1481's `O_DIRECTORY` defect showed that surface
+      # differs by architecture on Linux. Building a whole site here is the
+      # cheapest Linux exercise of it available.
+      - name: Check the gazette template port and its spot goldens
+        run: scripts/ci-timed "gazette goldens" -- scripts/gazette-corpus-diff.py golden
+
       - name: Run explicit cross-backend compilation and encoding coverage
         # Both the x86-64 and AArch64 encoders are host-independent Rust tests.
         # Keep this named step visible even though the broad suite also reaches

--- a/crates/rue-cli-tests/cases/examples_gazette.toml
+++ b/crates/rue-cli-tests/cases/examples_gazette.toml
@@ -1,15 +1,24 @@
-# RUE-1483: gazette's three text-processing libraries — TOML front matter, a
-# Markdown subset, and a template engine (ADR-0072 Phase 3).
+# gazette — a static site generator written in Rue (ADR-0072 Phases 3 and 4,
+# RUE-1483 and RUE-1484).
 #
 # The libraries' own construct-by-construct coverage lives in the program's
 # self-test, which the no-argument automatic example already runs. What these
 # cases add is the real driver path: files on disk, templates registered by the
-# name content refers to them by, and the exit code and diagnostics a caller
-# sees when content steps outside a documented subset.
+# name content refers to them by, a whole site built from a content tree, and
+# the exit code and diagnostics a caller sees when content steps outside a
+# documented subset.
+#
+# The `build` cases here are deliberately small. The corpus-scale checks —
+# determinism, the semantic oracle against Zola, the scale variants, and the
+# markup-level spot goldens — live in `scripts/gazette-corpus-diff.py`, which
+# needs the pinned Zola and a 500 KiB corpus and so cannot run inside the CLI
+# harness's per-case budget. What belongs here is the behaviour a CLI test can
+# pin exactly: the routes, the file set, section ordering, the feed, and the
+# redirect stub.
 [section]
 id = "cli.examples_gazette"
-name = "gazette front-matter, Markdown, and template libraries written in Rue"
-description = "exercise TOML front matter, the Markdown subset, shortcode expansion through the template engine, and loud rejection of out-of-subset constructs"
+name = "gazette, a static site generator written in Rue"
+description = "exercise TOML front matter, the Markdown subset, shortcode expansion through the template engine, a whole site build, and loud rejection of out-of-subset constructs"
 # Every case compiles the same maintained multi-module program, so the section
 # carries the bounded heavyweight contract, matching the automatic example.
 contract = "heavyweight"
@@ -27,6 +36,10 @@ stdout_contains = [
   "ok   three-level inheritance with nested block override",
   "ok   the eleven filters and the URL helper",
   "ok   shortcodes expand through the template engine",
+  # The genuine recursion check: a macro on a parent template calling itself
+  # through a nested tree, gated on a prefix test, with the exact nested
+  # output asserted. ADR-0072 Decision 3 forbids moving that decision out of
+  # the template, and this is the smallest executable statement of it.
   "ok   recursive macro with starts_with, defined on a parent template",
   "ok   runaway macro recursion is a diagnostic, not a crash",
   "ok   nesting past the depth guard is a diagnostic, not a crash",
@@ -53,10 +66,19 @@ exit_code = 1
 stdout_contains = ["nested deeper than the engine renders"]
 
 [[case]]
-name = "gazette_renders_a_recursive_navigation_macro"
-description = "a macro defined on a parent template, called with named arguments, recursing under a starts_with gate"
+name = "gazette_renders_a_macro_defined_on_a_parent_template"
+description = "a macro with named arguments and a default, invoked from a child template, plus the starts_with filter"
 source_path = "examples/gazette/main.rue"
 env = { RUE_STD_PATH = "${REAL_STD}" }
+# Deliberately NOT the recursion test, though it was once described as one
+# while its macro never called itself. What it pins is argument binding,
+# defaults, and the prefix filter. Genuine recursion needs a nested tree, and
+# the front-matter subset cannot express one — a page carries scalars, arrays
+# of scalars, and one level of table — so it is covered where a nested tree
+# actually exists: the self-test above builds one in Rue and asserts the exact
+# nested output, `gazette_stops_runaway_macro_recursion` below drives the
+# engine's depth guard, and the spot goldens render the production-shaped
+# sidebar over a real section tree with an active branch.
 files = [
   { path = "nav.html", source = """{% macro crumb(node, depth=0) %}<i>{{ node }}{% if depth %} at {{ depth }}{% endif %}</i>{% endmacro %}{{ self::crumb(node=page.title) }}{{ self::crumb(node=page.title, depth=2) }}{% if page.title | starts_with(prefix="Sco") %}<b>match</b>{% endif %}""" },
   { path = "page.md", source = """+++
@@ -69,6 +91,29 @@ body
 program_args = ["render", "-t", "nav.html=nav.html", "--template-out", "nav.html", "page.md"]
 exit_code = 0
 stdout_contains = ["<i>Scope</i><i>Scope at 2</i><b>match</b>"]
+
+[[case]]
+name = "gazette_stops_runaway_macro_recursion"
+description = "a macro with no base case reports and stops instead of overflowing the stack"
+source_path = "examples/gazette/main.rue"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+# The depth guard at the top of `render_macro_call` is the only thing between
+# a self-calling macro and a signal-killed process with a half-written output
+# tree, which ADR-0072 Decision 4's determinism check cannot interpret. The
+# Markdown depth guard has its own case; this one is the macro engine's, and
+# they are not the same guard.
+files = [
+  { path = "loop.html", source = """{% macro loopy(n) %}x{{ self::loopy(n=n) }}{% endmacro %}{{ self::loopy(n=1) }}""" },
+  { path = "page.md", source = """+++
+title = "Runaway"
++++
+
+body
+""" },
+]
+program_args = ["render", "-t", "loop.html=loop.html", "--template-out", "loop.html", "page.md"]
+exit_code = 1
+stdout_contains = ["macro calls are nested deeper than the engine renders (self::loopy)"]
 
 [[case]]
 name = "gazette_renders_a_page_with_front_matter_and_shortcodes"
@@ -155,6 +200,121 @@ stdout_contains = [
   "markdown:11: strikethrough is outside the subset",
   "markdown:14: nested lists are outside the subset",
 ]
+
+[[case]]
+name = "gazette_builds_a_site_tree"
+description = "content discovery, routes, section ordering, the feed, the redirect stub, and static passthrough, in one build"
+source_path = "examples/gazette/main.rue"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+  { path = "site/config.toml", source = """base_url = "https://example.test"
+title = "Site"
+description = "a site"
+""" },
+  { path = "site/templates/page.html", source = """<h1>{{ page.title }}</h1>{{ page.content | safe }}{% if page.lower %}<a href="{{ page.lower.permalink }}">prev</a>{% endif %}""" },
+  { path = "site/templates/section.html", source = """<h1>{{ section.title }}</h1>{% for pg in section.pages %}<a href="{{ pg.path }}">{{ pg.title }}</a>{% endfor %}{% for sub in section.subsections | sort %}<i>{{ sub }}</i>{% endfor %}""" },
+  { path = "site/templates/redirect.html", source = """<meta http-equiv="refresh" content="0; url={{ url | safe }}">""" },
+  { path = "site/templates/rss.xml", source = """<rss>{% for page in pages %}<item>{{ page.permalink | safe }}</item>{% endfor %}</rss>""" },
+  { path = "site/templates/shortcodes/rule.html", source = """<b id="r-{{ id }}">[{{ id }}]</b>""" },
+  { path = "site/static/asset.txt", source = "copied verbatim\n" },
+  { path = "site/content/_index.md", source = """+++
+title = "Home"
++++
+
+welcome
+""" },
+  # `sort_by = "date"`, so the newer note leads the index and the feed.
+  { path = "site/content/notes/_index.md", source = """+++
+title = "Notes"
+sort_by = "date"
+generate_feeds = true
++++
+
+notes
+""" },
+  { path = "site/content/notes/older.md", source = """+++
+title = "Older"
+date = 2026-01-01
++++
+
+first
+""" },
+  { path = "site/content/notes/newer.md", source = """+++
+title = "Newer"
+date = 2026-02-02
++++
+
+second
+""" },
+  # A redirecting section whose pages still render, and whose subsection is
+  # ordered by weight.
+  { path = "site/content/book/_index.md", source = """+++
+title = "Book"
+sort_by = "weight"
+redirect_to = "book/two"
++++
+
+book
+""" },
+  { path = "site/content/book/one.md", source = """+++
+title = "One"
+weight = 2
++++
+
+{{ rule(id="1:1") }}
+""" },
+  { path = "site/content/book/two.md", source = """+++
+title = "Two"
+weight = 1
++++
+
+two
+""" },
+]
+program_args = ["build", "site", "-o", "public", "--list"]
+exit_code = 0
+# The emitted set, in emission order: every ordinary page in content-tree
+# order, then each section's index — the redirecting one included — with its
+# feed beside it, then the static passthrough.
+stdout = """book/one/index.html
+book/two/index.html
+notes/newer/index.html
+notes/older/index.html
+index.html
+book/index.html
+notes/index.html
+notes/rss.xml
+asset.txt
+gazette: 4 pages, 3 sections, 9 files written
+"""
+
+[[case]]
+name = "gazette_refuses_a_content_directory_without_an_index"
+description = "a directory with no `_index.md` is a diagnostic, never an implicit section"
+source_path = "examples/gazette/main.rue"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+  { path = "site/config.toml", source = """base_url = "https://example.test"
+title = "Site"
+""" },
+  { path = "site/templates/page.html", source = """{{ page.content | safe }}""" },
+  { path = "site/templates/section.html", source = """{{ section.content | safe }}""" },
+  { path = "site/content/_index.md", source = """+++
+title = "Home"
++++
+
+home
+""" },
+  { path = "site/content/orphans/lost.md", source = """+++
+title = "Lost"
++++
+
+lost
+""" },
+]
+program_args = ["build", "site", "-o", "public"]
+exit_code = 1
+stdout_contains = ["this content directory has no `_index.md` (orphans/lost.md)"]
 
 [[case]]
 name = "gazette_rejects_an_unknown_shortcode"

--- a/crates/rue-frontend-diff/src/corpus_manifest.rs
+++ b/crates/rue-frontend-diff/src/corpus_manifest.rs
@@ -835,6 +835,7 @@ pub(crate) const ROOTS: &[(&str, &[&str])] = &[
             "gazette/main.rue",
             "gazette/markdown.rue",
             "gazette/pool.rue",
+            "gazette/site.rue",
             "gazette/text.rue",
             "gazette/tmpl_ast.rue",
             "gazette/tmpl_eval.rue",

--- a/docs/designs/0072-runtime-benchmarking-static-site-generator.md
+++ b/docs/designs/0072-runtime-benchmarking-static-site-generator.md
@@ -202,6 +202,39 @@ curve. Duplicated sections also tie on weight, title, and date, so the
 validation rules assert each tool's ordering tie-break is deterministic
 rather than assuming it.
 
+Phase 4 found a third honesty note, which follows from the first and is
+sharper than it. **The specification sidebar collapses on a duplicated
+page**, and it is worth quantifying rather than gesturing at. Both the
+recursion and the `active` class are gated on the current page's permalink
+prefixing a subsection's, and a copy's permalink prefixes nothing in the
+original tree that `get_section` returns, so both arms of the gate go cold.
+Measured over the 10x fixture's specification pages: the 70 originals render
+navigations of 2,540 to 6,205 bytes, mean 4,446, carrying 1.84 `active`
+markers each; all 630 duplicates render one byte-identical 2,534-byte
+navigation with zero `active` markers. That is 57% of the original mean on
+the majority page class, and at 100x it is 99% of all specification pages.
+
+The fixture therefore reproduces, at scale, exactly the page-invariant
+sidebar this Decision forbids an implementation from producing. The rule
+still holds, because the program evaluates the gate per page and the data
+says no match, and the cross-tool comparison is unaffected, because every
+tool builds the identical tree and sees the identical collapse. Two things
+follow for readers. The 10x and 100x points understate per-page templating
+work relative to 1x, so the curve is not "what a 1x page costs, times N".
+And the evidence that gazette's navigation is genuinely page-dependent — four
+live pages, four differently shaped sidebars — is **1x evidence**; at scale
+the input stops asking the question. `redirect_to` behaves the same way, and
+for the same reason: a duplicated section still redirects to the original
+target.
+
+The tie-break the validation asserts against is declared rather than
+discovered: every comparison ends in the content path, which is unique by
+construction, so the order is total. A missing `weight` and a missing `date`
+both sort last, matching Zola's treatment of an absent key rather than
+defaulting to zero and quietly promoting a page to the front. The validation
+recomputes that order independently from the source tree and compares, so
+"the tie-break is deterministic" is checked rather than assumed.
+
 Recording instead of pinning the corpus is a deliberate amendment to
 ADR-0067's identity discipline, not a reuse of it. ADR-0067 pins each
 workload's own sources precisely because they are not the product, and
@@ -278,6 +311,39 @@ all rather than the production templates directly: each port is the
 production template set minus the excluded pages and features, kept as close
 to production as the subset allows.
 
+Phase 4 made those carve-outs concrete, and the shape they took differs from
+the sentence above in ways worth recording:
+
+- **Two pages are excluded, not one**, and the second is this project's own.
+  RUE-1049's `runtime.md` renders the very series this workload produces, so
+  it is the same carve-out as `performance.md` for the same reason. Both are
+  removed at fixture-preparation time, and the excluded set is part of the
+  recorded fixture identity, so a page joining or leaving it moves the
+  identity and starts a new comparable segment rather than shifting an
+  existing one.
+- **`load_data` now bites the home page instead.** The dashboard pages moved
+  their data loading to the browser; the one remaining `load_data` on the site
+  is `index.html`'s Field Report panel, which reads a `status.json` two of
+  whose rows are derived from the performance store. The port drops that panel
+  and says so in the template.
+- **An exclusion is visible in the validation, not only in a comment.** The
+  navigation bar links to both excluded pages from every page of the site, so
+  excluding them necessarily leaves those links pointing at nothing. The
+  link check counts them under the exclusion that caused them rather than
+  either failing or ignoring them.
+
+**`redirect_to` is honoured.** `spec/_index.md` sets it, and RUE-1483 neither
+honoured nor rejected the key. Gazette now emits a redirect stub, from a
+`redirect.html` template in its port, at the section's own route; the
+section's pages and subsections render normally. Honouring it is what keeps
+the emitted file set equal to the peers', which is Decision 4's cross-tool
+criterion — refusing the key would leave gazette one output short at
+`/spec/index.html`, and rendering the section normally would put a page where
+Zola and Hugo serve a redirect. The stub's markup mirrors the pinned Zola's
+own rather than being invented: a redirect stub is not a page anyone reads,
+and the only thing that matters about it is that all three tools put the same
+file at the same route pointing at the same target.
+
 Fairness constrains gazette's implementation, not only the peers'
 configuration. The corpus is extremely skewed — 1,224 of its 1,225 shortcode
 invocations are `rule` — and a gazette that special-cased that shortcode as
@@ -322,6 +388,37 @@ speed:
 - **Spot goldens:** a small set of stable pages carries committed expected
   output per tool, changed only deliberately, covering the rendered
   markup-level form that the normalized oracle deliberately ignores.
+
+Phase 4 built the gazette-only half of this. Two notes on what it can and
+cannot anchor, because the difference matters:
+
+- **The body oracle's anchor is Zola, and it is one comparison rather than
+  six.** The normalized extraction — heading tree, visible text, link and
+  image targets, shortcode expansion results, in document order, with
+  entities decoded, whitespace collapsed, and presentational attributes
+  dropped — is computed for gazette's emitted page and for the pinned Zola's
+  body-only rendering of the same source, and the check is that the latter
+  appears *contiguously* inside the former. Contiguity is what makes it
+  strong: a dropped paragraph, a reordered heading, or one differently
+  resolved link fails it, and the template chrome around the body cannot
+  hide any of them. All three of the documented Zola-vs-gazette markup
+  divergences vanish under the extraction, so the oracle needs no
+  normalizer table of its own.
+- **The facets that depend on the template port are anchored by an
+  independent model instead.** Which metadata a page displays is a property
+  of a port, not of the corpus, so it cannot be checked across tools until
+  Phase 5. Routes, section membership, page ordering, feed ordering, the
+  emitted file set, and internal-link resolution are instead recomputed from
+  the source tree by a second implementation of the rules and compared. The
+  metadata check is deliberately the weaker one — the title as visible text
+  and the ISO date on a dated page — and says so.
+- **The spot goldens sit on a committed miniature site, not on live pages.**
+  Decision 2 keeps the corpus unfrozen, so a golden over a live page would
+  fail on every content change and be re-blessed rather than read, which is
+  the failure mode a golden exists to prevent. The miniature site uses
+  gazette's real template port and real configuration and exercises the
+  recursive navigation's active branch, the feed, and the redirect stub, so
+  the goldens remain sensitive to exactly what they are for.
 
 The file-set criterion carries a documented allowlist for tool-mandated
 differences — sitemap emission, feed filename mapping, static passthrough —
@@ -444,9 +541,19 @@ benchmark must never depend on a private fork of std behavior.
 Gazette joins the maintained scaling curve in `performance/scaling.toml`
 alongside ruelex, mosaic, harbor, and lattice. Compile-time measurement of
 gazette follows ADR-0067/0071 unchanged; this ADR adds the workload, not new
-compile-time policy. Adding it is a suite-revision event on the scaling
-manifest (currently revision 3), and the scaling workflow's time budget is
-re-checked for the added workload — both under ADR-0067's ordinary rules.
+compile-time policy. Adding it was a suite-revision event on the scaling
+manifest, which is now revision 4, and the scaling workflow's time budget
+was re-checked for the added workload — both under ADR-0067's ordinary
+rules. The re-check: the measured phase is `workloads x workers x samples`
+fresh compiler processes, so 4 x 5 x 3 = 60 became 5 x 5 x 3 = 75. Gazette
+is 6,524 lines, between mosaic's 6,108 and harbor's 9,000, and compiles in
+roughly half of lattice's wall time, so the added 15 compiles are the
+smaller half of one existing rung's contribution against a 60-minute budget
+whose bulk is the thin-LTO release build of the compiler itself. The
+arithmetic lives in the manifest, next to the revision it justifies.
+Gazette sits between mosaic and harbor in the manifest, not after them: the
+workload list is the report order and nothing sorts it downstream, so the
+ladder's ascending shape is that list's order.
 One program thereby feeds both series: the compiler suites answer "how fast
 does Rue compile a real text-processing program," and the runtime suite
 answers "how fast does that program run."
@@ -580,14 +687,30 @@ silently.
   manifest, stood up on the declared wordfreq workload** - RUE-1046
 - [x] **Phase 2: Standard-library prerequisites — directory enumeration and
   substring operations** - RUE-1481, RUE-1482
-- [ ] **Phase 3: Gazette libraries — TOML front matter, Markdown subset,
+- [x] **Phase 3: Gazette libraries — TOML front matter, Markdown subset,
   template engine** - RUE-1483
-- [ ] **Phase 4: Gazette, live-corpus fixture preparation, output validation,
+- [x] **Phase 4: Gazette, live-corpus fixture preparation, output validation,
   and the scaling-curve rung** - RUE-1484
-- [ ] **Phase 5: Cross-tool comparison — Hugo pin, parity configs, CI runs** -
-  RUE-1485
+- [ ] **Phase 5: Cross-tool comparison — Hugo pin, parity configs, CI runs;
+  and gazette's entry in `performance/runtime.toml`** - RUE-1485
 - [ ] **Phase 6: Website publication — comparison table, time series,
   side-by-side source** - RUE-1049
+
+Phase 4 delivered gazette, the fixture preparation, the scale variants, the
+recorded identity, and the whole validation stack, but deliberately did NOT
+add gazette to `performance/runtime.toml`. That entry is a runtime
+suite-revision event and needs schema work the wordfreq shape does not
+cover: `FixtureDeclaration` is a single struct describing a seeded generator,
+and gazette's fixture is a corpus tree with a scale factor and an exclusion
+set, so the declaration has to become a tagged form — which
+`rue-perf-schema` already anticipates in a comment — and the workload needs
+an oracle kind that is not `golden_stdout`. Landing the manifest entry ahead
+of that support would declare a workload the harness cannot prepare, so it
+sequences with Phase 5, which is also where the peer legs the same collection
+job runs are defined. Until then the fixture preparation, identity recording,
+and validation are driven by `scripts/gazette-corpus-diff.py site`, which is
+the reference implementation the harness mode should adopt rather than
+reinvent.
 
 The harness comes first, against a precisely declared workload that already
 exists. Phase 1's initial runtime workload is `wordfreq`, run over a large

--- a/docs/process/compiler-scaling.md
+++ b/docs/process/compiler-scaling.md
@@ -2,8 +2,16 @@
 
 The weekly compiler-scaling workflow measures the complete ADR-0071
 release-quality boundary as maintained Rue programs grow from Ruelex through
-Mosaic and Harbor to Lattice. Every workload is compiled at one, two, four,
-eight, and automatic workers. It complements the fast compiler-performance
+Mosaic, Gazette, and Harbor to Lattice. Every workload is compiled at one, two,
+four, eight, and automatic workers.
+
+The ladder is ascending by source size, and the manifest's workload order is
+the report order, so a rung belongs where its size puts it: Ruelex 2,222 lines,
+Mosaic 6,108, Gazette 6,524, Harbor 9,000, Lattice 13,030. Gazette joined at
+manifest revision 4 (ADR-0072 Decision 7); it is a static site generator, so it
+is the rung whose shape is parsing and string work rather than a broad domain
+model. Adding a workload is a suite-revision event, and revisions are not
+continuous with each other. It complements the fast compiler-performance
 headline; it does not contribute to that index.
 
 ## Measurement regime

--- a/examples/gazette/config.toml
+++ b/examples/gazette/config.toml
@@ -1,0 +1,22 @@
+# gazette's site configuration for the rue-lang.dev template port (ADR-0072).
+#
+# This is the gazette half of the "template ports and parity configurations"
+# Decision 2 versions in the repository; the Zola and Hugo halves are RUE-1485's.
+# Fixture preparation copies this file and `templates/` next to the assembled
+# content tree, and hashes both into the recorded fixture identity, so a change
+# here moves the identity and therefore starts a new comparable segment in the
+# series rather than silently shifting an existing one.
+#
+# It holds only keys gazette reads. The features the equivalence subset excludes
+# — syntax highlighting, the search index, HTML minification, Sass, Tailwind,
+# image processing, taxonomies, and pagination — have no switches here because
+# gazette implements none of them; the peers' parity configurations are where
+# those are turned OFF, which is the asymmetry Decision 3's published caption
+# exists to disclose.
+base_url = "https://rue-lang.dev"
+title = "Rue"
+description = "A systems programming language with memory safety and high-level ergonomics"
+
+[extra]
+github_url = "https://github.com/rue-language/rue"
+bluesky_url = "https://bsky.app/profile/rue-lang.dev"

--- a/examples/gazette/frontmatter.rue
+++ b/examples/gazette/frontmatter.rue
@@ -264,24 +264,22 @@ fn is_bare_key(borrow source: StrBuf, start: u64, end: u64) -> bool {
     true
 }
 
-// Parse the front matter at the head of `source`.
-//
-// A document with no `+++` opener is REJECTED rather than treated as an
-// all-body page: every file in the corpus has front matter, and silently
-// accepting a missing header would hide a truncated or mis-copied file.
-pub fn parse(inout arena: value.Arena, borrow source: StrBuf) -> Parsed {
+// Where a table scan stopped and what it found. Shared by the two entry points
+// below so the site's `config.toml` and a page's `+++` header go through ONE
+// TOML reader: a second one would be a second subset, and the subset is the
+// thing this module documents.
+struct Scan { root: u64, offset: u64, line: u64, ok: bool, closed: bool }
+
+// Read `key = value` lines and `[table]` headers from `offset` until a closing
+// `+++` fence or the end of input.
+fn scan_table(inout arena: value.Arena, borrow source: StrBuf, from: u64, first_line: u64) -> Scan {
     let mut root = value.Entries.new();
     let mut table = value.Entries.new();
     let mut table_key = value.NONE();
     let mut ok = true;
 
-    if !source.starts_with(borrow "+++") {
-        fail(inout arena, 1, "page does not open with a `+++` front-matter fence", value.NONE());
-        return Parsed { root: arena.null(), body_start: 0, body_line: 1, ok: false };
-    }
-
-    let mut offset = text.next_line(borrow source, 0);
-    let mut line: u64 = 2;
+    let mut offset = from;
+    let mut line = first_line;
     let mut closed = false;
     while offset < source.len() && !closed {
         let end = text.line_end(borrow source, offset);
@@ -381,10 +379,38 @@ pub fn parse(inout arena: value.Arena, borrow source: StrBuf) -> Parsed {
     if table_key != value.NONE() {
         root.push(value.Entry { key: table_key, value: arena.map(borrow table) });
     }
-    if !closed {
-        fail(inout arena, line, "front matter is not closed by a `+++` line", value.NONE());
+
+    Scan { root: arena.map(borrow root), offset: offset, line: line, ok: ok, closed: closed }
+}
+
+// Parse the front matter at the head of `source`.
+//
+// A document with no `+++` opener is REJECTED rather than treated as an
+// all-body page: every file in the corpus has front matter, and silently
+// accepting a missing header would hide a truncated or mis-copied file.
+pub fn parse(inout arena: value.Arena, borrow source: StrBuf) -> Parsed {
+    if !source.starts_with(borrow "+++") {
+        fail(inout arena, 1, "page does not open with a `+++` front-matter fence", value.NONE());
+        return Parsed { root: arena.null(), body_start: 0, body_line: 1, ok: false };
+    }
+    let scan = scan_table(inout arena, borrow source, text.next_line(borrow source, 0), 2);
+    let mut ok = scan.ok;
+    if !scan.closed {
+        fail(inout arena, scan.line, "front matter is not closed by a `+++` line", value.NONE());
         ok = false;
     }
+    Parsed { root: scan.root, body_start: scan.offset, body_line: scan.line, ok: ok }
+}
 
-    Parsed { root: arena.map(borrow root), body_start: offset, body_line: line, ok: ok }
+// Parse a whole TOML document — the site's `config.toml` — under the same
+// subset. Zola's configuration is bare TOML with no fence, so the reader takes
+// the document from byte zero and there is nothing to close.
+pub fn parse_document(inout arena: value.Arena, borrow source: StrBuf) -> Parsed {
+    let scan = scan_table(inout arena, borrow source, 0, 1);
+    let mut ok = scan.ok;
+    if scan.closed {
+        fail(inout arena, scan.line, "a `+++` fence has no meaning in a configuration file", value.NONE());
+        ok = false;
+    }
+    Parsed { root: scan.root, body_start: scan.offset, body_line: scan.line, ok: ok }
 }

--- a/examples/gazette/main.rue
+++ b/examples/gazette/main.rue
@@ -1,75 +1,56 @@
-// gazette libraries — TOML front matter, a Markdown subset, and a template
-// engine, written in Rue (ADR-0072 Phase 3, RUE-1483).
+// gazette — a static site generator written in Rue (ADR-0072, RUE-1483 and
+// RUE-1484).
 //
-// These are the three text-processing components the gazette static site
-// generator needs to build the live rue-lang.dev corpus, and ADR-0072
-// Decision 1 keeps them as modules inside the example: promoting any of them
-// into `std` is a separate, later decision that nothing here presumes.
-//
-// This root is the libraries' driver, NOT gazette itself — content discovery,
-// the page model, section indexes, the RSS feed, and the output tree are
-// RUE-1484. What lives here is a self-test that exercises every construct in
-// the three documented subsets, and a `render` mode that runs one Markdown
-// file through the real pipeline so the libraries can be checked against the
-// actual corpus.
+// Gazette walks a content tree, parses TOML front matter, renders a documented
+// Markdown subset, expands shortcodes and applies templates through its own
+// engine, generates section index pages and an RSS feed, copies static assets,
+// and writes the output tree. ADR-0072 Decision 1 keeps its supporting
+// libraries as modules inside the example rather than in `std`: promoting any
+// of them is a separate, later decision that nothing here presumes.
 //
 //   gazette                                     run the self-test
+//   gazette build SITE_DIR -o OUTPUT_DIR [--list]
 //   gazette render [-t NAME=PATH]… [-u URL] [--template-out NAME] FILE.md
 //
-// `-t` registers a template under the name content refers to it by, which is
-// how the `render` mode gets `shortcodes/rule.html` without a directory walk;
-// `-u` supplies the page's permalink, which fragment and relative links in the
-// page's own content resolve against; `--template-out` renders the page
-// through a registered template instead of emitting the Markdown body alone.
+// `build` is the whole program: SITE_DIR holds `config.toml`, `content/`,
+// `templates/`, and optionally `static/`, exactly as a Zola site does, and
+// OUTPUT_DIR receives the rendered tree. This is the mode ADR-0072's runtime
+// benchmark measures, spawn to exit. `--list` additionally prints every
+// emitted path, which is how a test asserts the file set; it is off by
+// default because nine thousand lines of stdout would be measured work in a
+// run whose whole purpose is to measure the build.
 //
-// `scripts/gazette-corpus-diff.py` drives the body-only mode over the whole
-// live corpus and diffs it against the pinned Zola, which is how the Markdown
-// library's fidelity claim is checked rather than asserted.
+// `render` runs ONE Markdown file through the same pipeline and prints it. It
+// exists because the Markdown library's fidelity claim is checked against the
+// live corpus page by page rather than asserted:
+// `scripts/gazette-corpus-diff.py body` drives it over all 96 files and diffs
+// the result against the pinned Zola. `-t` registers a template under the name
+// content refers to it by; `-u` supplies the page's permalink, which fragment
+// and relative links resolve against; `--template-out` renders the page
+// through a registered template instead of emitting the body alone.
 //
-// Each module documents its own subset in its header; each rejects constructs
-// outside that subset with a diagnostic rather than wrong output, which is the
-// dogfooding pressure ADR-0072 Decision 3 asks for.
+// The no-argument self-test exercises every construct in the documented
+// subsets. Each module documents its own subset in its header and rejects
+// constructs outside it with a diagnostic rather than wrong output, which is
+// the dogfooding pressure ADR-0072 Decision 3 asks for.
 //
 // The modules: text.rue (byte helpers), pool.rue (string interning),
 // value.rue (the shared value arena and diagnostics), frontmatter.rue,
 // tmpl_ast.rue / tmpl_parse.rue / tmpl_eval.rue (the template engine),
-// markdown.rue (blocks, inlines, and the shortcode pass), this root (I/O and
-// the self-test).
+// markdown.rue (blocks, inlines, and the shortcode pass), site.rue (content
+// discovery, the page and section model, and the output tree), this root
+// (argument handling and the self-test).
 const std = @import("std");
 const ast = @import("tmpl_ast.rue");
 const frontmatter = @import("frontmatter.rue");
 const markdown = @import("markdown.rue");
+const site = @import("site.rue");
 const text = @import("text.rue");
 const tmpl_eval = @import("tmpl_eval.rue");
 const tmpl_parse = @import("tmpl_parse.rue");
 const value = @import("value.rue");
 const StrBuf = std.strbuf.StrBuf;
-const Bytes = std.arraybuf.ArrayBuf(u8);
 const OptStr = std.option.Option(StrBuf);
-const FileRes = std.result.Result(std.fs.File, std.fs.FileError);
-const ReadRes = std.result.Result(u64, std.fs.FileError);
-
-struct FileInput { data: StrBuf, ok: bool }
-
-fn read_file(borrow path: StrBuf) -> FileInput {
-    let mut raw = Bytes.new();
-    let mut f = match std.fs.File.open(borrow path) {
-        FileRes.Ok(file) => file,
-        FileRes.Err(_e) => { return FileInput { data: StrBuf.new(), ok: false }; },
-    };
-    let mut ok = true;
-    let chunk: u64 = 65536;
-    loop {
-        raw.reserve(chunk);
-        let n = match f.read(inout raw) {
-            ReadRes.Ok(k) => k,
-            ReadRes.Err(_e) => { ok = false; 0 },
-        };
-        if n == 0 { break; }
-    }
-    let _ = f.close();
-    FileInput { data: StrBuf.from_bytes(borrow raw), ok: ok }
-}
 
 fn str_eq(borrow a: StrBuf, flag: StrBuf) -> bool {
     StrBuf.equals_borrowed(borrow a, borrow flag)
@@ -116,7 +97,7 @@ fn bind_page_url(inout eng: ast.Engine, borrow url: StrBuf) {
 // template reads. The page model that builds that map from a real content tree
 // is RUE-1484; this is the libraries' driver, not that model.
 fn render_mode(inout eng: ast.Engine, borrow path: StrBuf, template_out: u64) -> bool {
-    let input = read_file(borrow path);
+    let input = site.read_file(borrow path);
     if !input.ok {
         let mut message = StrBuf.new();
         message.push_str("gazette: cannot read ");
@@ -560,15 +541,29 @@ fn main() -> i32 {
     bind_site(inout eng, "https://rue-lang.dev");
 
     let mut mode_render = false;
+    let mut mode_build = false;
     let mut template_out = ast.NONE();
     let mut target = StrBuf.new();
     let mut have_target = false;
+    let mut output = StrBuf.new();
+    let mut have_output = false;
+    let mut list_output = false;
     let mut i: u64 = 1;
     while i < argc {
         match std.env.arg(i) {
             OptStr.Some(a) => {
                 if str_eq(borrow a, "render") {
                     mode_render = true;
+                } else if str_eq(borrow a, "build") {
+                    mode_build = true;
+                } else if str_eq(borrow a, "--list") {
+                    list_output = true;
+                } else if str_eq(borrow a, "-o") {
+                    i += 1;
+                    match std.env.arg(i) {
+                        OptStr.Some(dir) => { output = dir; have_output = true; },
+                        OptStr.None => { return 2; },
+                    }
                 } else if str_eq(borrow a, "-u") {
                     i += 1;
                     match std.env.arg(i) {
@@ -592,7 +587,7 @@ fn main() -> i32 {
                             }
                             let name = text.slice(borrow spec, 0, eq);
                             let path = text.slice(borrow spec, eq + 1, spec.len());
-                            let loaded = read_file(borrow path);
+                            let loaded = site.read_file(borrow path);
                             if !loaded.ok {
                                 let mut message = StrBuf.new();
                                 message.push_str("gazette: cannot read template ");
@@ -615,8 +610,24 @@ fn main() -> i32 {
         i += 1;
     }
 
+    if mode_build {
+        if !have_target || !have_output {
+            print("usage: gazette build SITE_DIR -o OUTPUT_DIR [--list]\n");
+            return 2;
+        }
+        let mut report = StrBuf.new();
+        // A site build binds its own base URL from `config.toml`, so the
+        // placeholder bound above is replaced rather than consulted.
+        let ok = site.build(inout eng, borrow target, borrow output, list_output, inout report);
+        let mut diagnostics = StrBuf.new();
+        eng.arena.append_diagnostics(inout diagnostics);
+        if diagnostics.len() > 0 { print(diagnostics); }
+        print(report);
+        return if ok { 0 } else { 1 };
+    }
+
     if !mode_render || !have_target {
-        print("usage: gazette [render [-t NAME=PATH]... [-u URL] [--template-out NAME] FILE.md]\n");
+        print("usage: gazette [build SITE_DIR -o OUTPUT_DIR [--list]] [render [-t NAME=PATH]... [-u URL] [--template-out NAME] FILE.md]\n");
         return 2;
     }
 

--- a/examples/gazette/site.rue
+++ b/examples/gazette/site.rue
@@ -1,0 +1,1292 @@
+// gazette the static site generator: content discovery, the page and section
+// model, template application, section indexes, the RSS feed, static
+// passthrough, and the output tree (ADR-0072 Phase 4, RUE-1484).
+//
+// RUE-1483 delivered the three text-processing libraries this builds on. What
+// this module adds is everything between "a Markdown file" and "a site": which
+// files exist, what route each one takes, which section it belongs to, what
+// order a section's pages are in, which template renders it, and where the
+// bytes land.
+//
+// THE SHAPE IS ZOLA'S, because the corpus is a Zola site and ADR-0072
+// Decision 3's work-equivalence claim is only honest if the job is the same
+// job:
+//
+//   routes        `_index.md` is its directory's section; `<name>.md` becomes
+//                 `<name>/index.html`; the content root's `_index.md` is `/`
+//   sections      every content directory is a section and MUST carry an
+//                 `_index.md` — a directory without one is a diagnostic, not
+//                 an implicit section, for the same documented-subset reason
+//                 the libraries reject unknown Markdown
+//   ordering      `sort_by = "weight" | "date"`, else content-path order
+//   templates     a page's own `template`, else its section's `page_template`,
+//                 else `page.html`; a section's own `template`, else
+//                 `section.html`
+//   feeds         a section with `generate_feeds = true` emits `rss.xml`
+//                 beside its index
+//   redirects     a section with `redirect_to` emits Zola's redirect stub
+//                 instead of its own index page — see below
+//   static        everything under `static/` is copied to the output root
+//
+// ORDERING TIE-BREAKS ARE TOTAL AND DECLARED. ADR-0072 Decision 2's scale
+// variants duplicate the corpus under path prefixes, so the duplicated
+// sections tie on weight, on title, and on date — every field a comparison
+// would naturally use. Each comparison here therefore ends in the content
+// path, which is unique by construction, so the order is a total order and two
+// runs over the same tree cannot disagree. A missing `weight` sorts last and a
+// missing `date` sorts last, matching Zola's treatment of an absent key rather
+// than defaulting it to zero and quietly promoting the page to the front.
+//
+// NOTHING HERE KNOWS THE CORPUS. No page name, section name, shortcode name,
+// or template name from rue-lang.dev appears in this file; the template set is
+// discovered from the site directory and the shortcodes are resolved by the
+// Markdown library's general `shortcodes/<name>.html` mapping. That is
+// ADR-0072 Decision 3's fairness rule, and it binds the site model exactly as
+// it binds the engine: a build that special-cased the site it was measured on
+// would beat Zola while passing every output check.
+//
+// THE ACTIVE-NAVIGATION DECISION LIVES IN THE TEMPLATES, not here. The
+// production sidebar is a recursive macro gated on a prefix test, and the port
+// in `templates/` keeps it that way: this module hands the engine the section
+// tree and the current page's permalink and nothing else. Flattening the nav
+// host-side would move measured work out of the measured program and would
+// pass every check ADR-0072 Decision 4 defines, which is exactly why the rule
+// is written down rather than left to the validator.
+const std = @import("std");
+const ast = @import("tmpl_ast.rue");
+const frontmatter = @import("frontmatter.rue");
+const markdown = @import("markdown.rue");
+const text = @import("text.rue");
+const tmpl_eval = @import("tmpl_eval.rue");
+const tmpl_parse = @import("tmpl_parse.rue");
+const value = @import("value.rue");
+const StrBuf = std.strbuf.StrBuf;
+const Bytes = std.arraybuf.ArrayBuf(u8);
+const FileRes = std.result.Result(std.fs.File, std.fs.FileError);
+const ReadRes = std.result.Result(u64, std.fs.FileError);
+const WriteRes = std.result.Result((), std.fs.FileError);
+const DirRes = std.result.Result(std.fs.DirEntries, std.fs.FileError);
+const UnitRes = std.result.Result((), std.fs.FileError);
+
+fn NONE() -> u64 { ast.NONE() }
+
+pub fn SORT_NONE() -> u64 { 0 }
+pub fn SORT_WEIGHT() -> u64 { 1 }
+pub fn SORT_DATE() -> u64 { 2 }
+
+// ---------------------------------------------------------------------------
+// File I/O
+// ---------------------------------------------------------------------------
+
+pub struct FileInput { data: StrBuf, ok: bool }
+
+pub fn read_file(borrow path: StrBuf) -> FileInput {
+    let mut raw = Bytes.new();
+    let mut f = match std.fs.File.open(borrow path) {
+        FileRes.Ok(file) => file,
+        FileRes.Err(_e) => { return FileInput { data: StrBuf.new(), ok: false }; },
+    };
+    let mut ok = true;
+    let chunk: u64 = 65536;
+    loop {
+        raw.reserve(chunk);
+        let n = match f.read(inout raw) {
+            ReadRes.Ok(k) => k,
+            ReadRes.Err(_e) => { ok = false; 0 },
+        };
+        if n == 0 { break; }
+    }
+    let _ = f.close();
+    FileInput { data: StrBuf.from_bytes(borrow raw), ok: ok }
+}
+
+fn write_file(borrow path: StrBuf, borrow body: StrBuf) -> bool {
+    let mut file = match std.fs.File.create(borrow path) {
+        FileRes.Ok(f) => f,
+        FileRes.Err(_e) => { return false; },
+    };
+    let bytes = body.to_bytes();
+    let ok = match file.write_all(borrow bytes) {
+        WriteRes.Ok(_unit) => true,
+        WriteRes.Err(_e) => false,
+    };
+    let _ = file.close();
+    ok
+}
+
+// Everything up to and including the last `/`, or the empty string. Used both
+// for the directory a page belongs to and for the directory an output file
+// needs created before it can be written.
+fn dir_of(borrow path: StrBuf) -> StrBuf {
+    let mut i = path.len();
+    while i > 0 {
+        if text.byte_of(borrow path, i - 1) == 47 { return text.slice(borrow path, 0, i); }
+        i -= 1;
+    }
+    StrBuf.new()
+}
+
+fn join_path(borrow base: StrBuf, borrow rest: StrBuf) -> StrBuf {
+    let mut out = text.slice(borrow base, 0, base.len());
+    if out.len() > 0 && text.byte_of(borrow out, out.len() - 1) != 47 { out.push(47); }
+    out.append_borrowed(borrow rest);
+    out
+}
+
+// Write `body` to `path`, creating the directories above it first. Output
+// directories are created on demand rather than pre-computed because the route
+// set is not known until discovery has run, and `create_dir_all` is idempotent.
+fn write_output(borrow path: StrBuf, borrow body: StrBuf) -> bool {
+    let parent = dir_of(borrow path);
+    if parent.len() > 0 {
+        let trimmed = text.slice(borrow parent, 0, parent.len() - 1);
+        match std.fs.create_dir_all(borrow trimmed) {
+            UnitRes.Ok(_u) => {},
+            UnitRes.Err(_e) => { return false; },
+        }
+    }
+    write_file(borrow path, borrow body)
+}
+
+// ---------------------------------------------------------------------------
+// The model
+// ---------------------------------------------------------------------------
+
+// Every key the site model interns, done once. Interning inside the render
+// loops would hash the same dozen names once per page; at ADR-0072's 100x
+// scale variant that is nine thousand repetitions of a constant.
+pub struct Keys {
+    title: u64,
+    date: u64,
+    weight: u64,
+    description: u64,
+    extra: u64,
+    template: u64,
+    page_template: u64,
+    sort_by: u64,
+    generate_feeds: u64,
+    redirect_to: u64,
+    content: u64,
+    permalink: u64,
+    path: u64,
+    summary: u64,
+    pages: u64,
+    subsections: u64,
+    lower: u64,
+    higher: u64,
+    page: u64,
+    section: u64,
+    config: u64,
+    url: u64,
+    feed_url: u64,
+    sections_global: u64,
+    page_url_global: u64,
+    base_url_global: u64,
+}
+
+fn intern_keys(inout eng: ast.Engine) -> Keys {
+    Keys {
+        title: eng.key("title"),
+        date: eng.key("date"),
+        weight: eng.key("weight"),
+        description: eng.key("description"),
+        extra: eng.key("extra"),
+        template: eng.key("template"),
+        page_template: eng.key("page_template"),
+        sort_by: eng.key("sort_by"),
+        generate_feeds: eng.key("generate_feeds"),
+        redirect_to: eng.key("redirect_to"),
+        content: eng.key("content"),
+        permalink: eng.key("permalink"),
+        path: eng.key("path"),
+        summary: eng.key("summary"),
+        pages: eng.key("pages"),
+        subsections: eng.key("subsections"),
+        lower: eng.key("lower"),
+        higher: eng.key("higher"),
+        page: eng.key("page"),
+        section: eng.key("section"),
+        config: eng.key("config"),
+        url: eng.key("url"),
+        feed_url: eng.key("feed_url"),
+        sections_global: eng.key("__sections"),
+        page_url_global: eng.key("__page_url"),
+        base_url_global: eng.key("__base_url"),
+    }
+}
+
+// One content file. String fields are pool ids, so a duplicated corpus costs
+// one copy of each distinct path component rather than one per page.
+pub struct Page {
+    rel: u64,
+    route: u64,
+    permalink: u64,
+    source: u64,
+    front: u64,
+    body_start: u64,
+    body_line: u64,
+    section: u64,
+    is_index: bool,
+    weight: u64,
+    template: u64,
+    content: u64,
+    summary: u64,
+    entry: u64,
+    object: u64,
+}
+
+pub fn empty_page() -> Page {
+    Page {
+        rel: NONE(), route: NONE(), permalink: NONE(), source: NONE(), front: NONE(),
+        body_start: 0, body_line: 1, section: NONE(), is_index: false, weight: NONE(),
+        template: NONE(), content: NONE(), summary: NONE(), entry: NONE(), object: NONE(),
+    }
+}
+
+// One section: its `_index.md`, its place in the tree, and the ranges of
+// `section_pages` / `section_subs` holding its sorted children.
+pub struct Section {
+    page: u64,
+    key: u64,
+    dir: u64,
+    parent: u64,
+    sort_by: u64,
+    generate_feeds: bool,
+    redirect_to: u64,
+    page_start: u64,
+    page_count: u64,
+    sub_start: u64,
+    sub_count: u64,
+    object: u64,
+}
+
+pub fn empty_section() -> Section {
+    Section {
+        page: NONE(), key: NONE(), dir: NONE(), parent: NONE(), sort_by: SORT_NONE(),
+        generate_feeds: false, redirect_to: NONE(), page_start: 0, page_count: 0,
+        sub_start: 0, sub_count: 0, object: NONE(),
+    }
+}
+
+pub const Pages = std.arraybuf.ArrayBuf(Page);
+pub const Sections = std.arraybuf.ArrayBuf(Section);
+
+pub struct Site {
+    keys: Keys,
+    pages: Pages,
+    sections: Sections,
+    section_pages: value.U64s,
+    section_subs: value.U64s,
+    // Section directory pool ids, ascending, with the parallel section index.
+    // Two identical directory strings intern to the same id, so an EQUALITY
+    // lookup is a binary search over integers — which keeps assigning nine
+    // thousand pages to fourteen hundred sections linearithmic rather than the
+    // product of the two.
+    dir_ids: value.U64s,
+    dir_index: value.U64s,
+    config: u64,
+    root: StrBuf,
+    content_root: StrBuf,
+    output_root: StrBuf,
+    pages_rendered: u64,
+    files_written: u64,
+    // `--list` records every emitted path, in emission order. Off by default:
+    // at ADR-0072's 100x scale that is nine and a half thousand lines of
+    // stdout, which would be measured work in a run that exists to measure the
+    // build. It is what makes the emitted file set assertable from a CLI test.
+    list: bool,
+    listing: StrBuf,
+
+    fn new() -> Self {
+        Self {
+            keys: Keys {
+                title: 0, date: 0, weight: 0, description: 0, extra: 0, template: 0,
+                page_template: 0, sort_by: 0, generate_feeds: 0, redirect_to: 0,
+                content: 0, permalink: 0, path: 0, summary: 0, pages: 0,
+                subsections: 0, lower: 0, higher: 0, page: 0, section: 0, config: 0,
+                url: 0, feed_url: 0, sections_global: 0, page_url_global: 0,
+                base_url_global: 0,
+            },
+            pages: Pages.new(),
+            sections: Sections.new(),
+            section_pages: value.U64s.new(),
+            section_subs: value.U64s.new(),
+            dir_ids: value.U64s.new(),
+            dir_index: value.U64s.new(),
+            config: 0,
+            root: StrBuf.new(),
+            content_root: StrBuf.new(),
+            output_root: StrBuf.new(),
+            pages_rendered: 0,
+            files_written: 0,
+            list: false,
+            listing: StrBuf.new(),
+        }
+    }
+
+    fn page_at(borrow self, i: u64) -> Page { self.pages.get_or(i, empty_page()) }
+    fn section_at(borrow self, i: u64) -> Section { self.sections.get_or(i, empty_section()) }
+}
+
+fn fail(inout eng: ast.Engine, detail: StrBuf, subject: u64) {
+    eng.error(value.E_TEMPLATE(), 0, detail, subject);
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+// Read `config.toml` and bind the globals every later stage reads. The site's
+// base URL is the one input the route model cannot derive, so a config that
+// fails to parse stops the build here rather than producing a site of relative
+// links that happen to work locally.
+fn load_config(inout site: Site, inout eng: ast.Engine) -> bool {
+    let path = join_path(borrow site.root, borrow "config.toml");
+    let input = read_file(borrow path);
+    if !input.ok {
+        let subject = eng.arena.strings.intern(borrow path);
+        fail(inout eng, "cannot read the site configuration", subject);
+        return false;
+    }
+    let parsed = frontmatter.parse_document(inout eng.arena, borrow input.data);
+    site.config = parsed.root;
+    if !parsed.ok { return false; }
+
+    let base_url_key = eng.key("base_url");
+    let base = eng.arena.map_get(site.config, base_url_key);
+    if eng.arena.tag(base) != value.V_STR() {
+        fail(inout eng, "the site configuration has no `base_url` string", NONE());
+        return false;
+    }
+    let base_text = eng.arena.scalar(base);
+    let base_value = eng.arena.string(borrow base_text);
+    eng.set_global(site.keys.base_url_global, base_value);
+    eng.set_global(site.keys.config, site.config);
+    true
+}
+
+// ---------------------------------------------------------------------------
+// Templates
+// ---------------------------------------------------------------------------
+
+// Register every template in `templates/` under the name content and other
+// templates refer to it by — its path relative to that directory, which is
+// exactly Zola's rule. The walk is `std.fs`'s deterministic one, so a template
+// set is registered in the same order on every machine.
+fn load_templates(inout site: Site, inout eng: ast.Engine) -> bool {
+    let root = join_path(borrow site.root, borrow "templates");
+    let entries = match std.fs.walk(borrow root) {
+        DirRes.Ok(list) => list,
+        DirRes.Err(_e) => {
+            let subject = eng.arena.strings.intern(borrow root);
+            fail(inout eng, "cannot read the template directory", subject);
+            return false;
+        },
+    };
+    let prefix = root.len() + 1;
+    let mut i: u64 = 0;
+    let mut ok = true;
+    while i < entries.len() {
+        if entries.is_file(i) {
+            let path = entries.path(i);
+            if path.ends_with(borrow ".html") || path.ends_with(borrow ".xml") {
+                let name = text.slice(borrow path, prefix, path.len());
+                let input = read_file(borrow path);
+                if !input.ok {
+                    let subject = eng.arena.strings.intern(borrow path);
+                    fail(inout eng, "cannot read a template", subject);
+                    ok = false;
+                } else {
+                    let _ = tmpl_parse.parse_template(inout eng, name, borrow input.data);
+                }
+            }
+        }
+        i += 1;
+    }
+    ok
+}
+
+// ---------------------------------------------------------------------------
+// Discovery
+// ---------------------------------------------------------------------------
+
+// Read every `.md` file under `content/`, parse its front matter, and record
+// the route it takes. `content_route` is the same function the Markdown link
+// renderer uses to resolve a `@/…` destination, so a link to a page and the
+// page's own route cannot disagree.
+fn discover(inout site: Site, inout eng: ast.Engine) -> bool {
+    let entries = match std.fs.walk(borrow site.content_root) {
+        DirRes.Ok(list) => list,
+        DirRes.Err(_e) => {
+            let subject = eng.arena.strings.intern(borrow site.content_root);
+            fail(inout eng, "cannot read the content directory", subject);
+            return false;
+        },
+    };
+    let prefix = site.content_root.len() + 1;
+    let mut i: u64 = 0;
+    let mut ok = true;
+    while i < entries.len() {
+        if entries.is_file(i) {
+            let path = entries.path(i);
+            if path.ends_with(borrow ".md") {
+                let rel = text.slice(borrow path, prefix, path.len());
+                let input = read_file(borrow path);
+                if !input.ok {
+                    let subject = eng.arena.strings.intern(borrow path);
+                    fail(inout eng, "cannot read a content file", subject);
+                    ok = false;
+                } else {
+                    if !add_page(inout site, inout eng, borrow rel, borrow input.data) { ok = false; }
+                }
+            }
+        }
+        i += 1;
+    }
+    if site.pages.len() == 0 {
+        fail(inout eng, "the content directory holds no Markdown", NONE());
+        return false;
+    }
+    ok
+}
+
+fn add_page(inout site: Site, inout eng: ast.Engine, borrow rel: StrBuf, borrow source: StrBuf) -> bool {
+    let front = frontmatter.parse(inout eng.arena, borrow source);
+    let route = tmpl_eval.content_route(borrow rel, 0);
+    let permalink = tmpl_eval.join_base(inout eng, borrow route);
+
+    let rel_id = eng.arena.strings.intern(borrow rel);
+    let route_id = eng.arena.strings.intern(borrow route);
+    let permalink_id = eng.arena.strings.intern(borrow permalink);
+    let source_id = eng.arena.strings.intern(borrow source);
+
+    let is_index = rel.ends_with(borrow "_index.md");
+    let weight_value = eng.arena.map_get(front.root, site.keys.weight);
+    let weight = if eng.arena.tag(weight_value) == value.V_INT() {
+        eng.arena.at(weight_value).num
+    } else {
+        // Absent, so it sorts last rather than as a zero that would silently
+        // promote the page to the front of a weighted section.
+        NONE()
+    };
+
+    site.pages.push(Page {
+        rel: rel_id,
+        route: route_id,
+        permalink: permalink_id,
+        source: source_id,
+        front: front.root,
+        body_start: front.body_start,
+        body_line: front.body_line,
+        section: NONE(),
+        is_index: is_index,
+        weight: weight,
+        template: NONE(),
+        content: NONE(),
+        summary: NONE(),
+        entry: NONE(),
+        object: NONE(),
+    });
+    front.ok
+}
+
+// ---------------------------------------------------------------------------
+// The section tree
+// ---------------------------------------------------------------------------
+
+fn sort_kind(inout eng: ast.Engine, front: u64, key: u64) -> u64 {
+    let v = eng.arena.map_get(front, key);
+    if eng.arena.tag(v) != value.V_STR() { return SORT_NONE(); }
+    if eng.arena.strings.equals_literal(eng.arena.at(v).num, "weight") { return SORT_WEIGHT(); }
+    if eng.arena.strings.equals_literal(eng.arena.at(v).num, "date") { return SORT_DATE(); }
+    if eng.arena.strings.equals_literal(eng.arena.at(v).num, "none") { return SORT_NONE(); }
+    let subject = eng.arena.at(v).num;
+    fail(inout eng, "sort_by is outside the subset (weight, date, none)", subject);
+    SORT_NONE()
+}
+
+// Build one section per `_index.md`, then link every section and every page to
+// its directory. A content directory with no `_index.md` is REFUSED rather
+// than turned into an implicit section: gazette's whole discipline is that
+// content outside the documented subset breaks the build visibly, and an
+// implicit section would silently change a page's ordering and its template.
+fn build_sections(inout site: Site, inout eng: ast.Engine) -> bool {
+    let mut ok = true;
+    let mut i: u64 = 0;
+    while i < site.pages.len() {
+        let page = site.page_at(i);
+        if page.is_index {
+            let key = page.rel;
+            let dir = page.route;
+            let front = page.front;
+            let redirect_value = eng.arena.map_get(front, site.keys.redirect_to);
+            let redirect = if eng.arena.tag(redirect_value) == value.V_STR() {
+                eng.arena.at(redirect_value).num
+            } else {
+                NONE()
+            };
+            let feeds_value = eng.arena.map_get(front, site.keys.generate_feeds);
+            let feeds = eng.arena.truthy(feeds_value);
+            let kind = sort_kind(inout eng, front, site.keys.sort_by);
+            site.sections.push(Section {
+                page: i,
+                key: key,
+                dir: dir,
+                parent: NONE(),
+                sort_by: kind,
+                generate_feeds: feeds,
+                redirect_to: redirect,
+                page_start: 0, page_count: 0, sub_start: 0, sub_count: 0,
+                object: NONE(),
+            });
+        }
+        i += 1;
+    }
+
+    build_dir_index(inout site);
+
+    // Parents, by the directory one level up. The root section's directory is
+    // the empty string and has no parent.
+    let mut s: u64 = 0;
+    while s < site.sections.len() {
+        let mut section = site.section_at(s);
+        let dir = eng.arena.strings.copy(section.dir);
+        if dir.len() > 0 {
+            let above = parent_dir(borrow dir);
+            let above_id = eng.arena.strings.intern(borrow above);
+            let parent = find_section_for_dir(borrow site, above_id);
+            if parent == NONE() {
+                fail(inout eng, "a content directory above this section has no `_index.md`", section.dir);
+                ok = false;
+            }
+            section.parent = parent;
+            site.sections.set(s, section);
+        }
+        s += 1;
+    }
+
+    // Pages, by their own directory.
+    let mut p: u64 = 0;
+    while p < site.pages.len() {
+        let mut page = site.page_at(p);
+        let rel = eng.arena.strings.copy(page.rel);
+        let dir = dir_of(borrow rel);
+        let dir_id = eng.arena.strings.intern(borrow dir);
+        let owner = find_section_for_dir(borrow site, dir_id);
+        if owner == NONE() {
+            fail(inout eng, "this content directory has no `_index.md`", page.rel);
+            ok = false;
+        }
+        page.section = owner;
+        site.pages.set(p, page);
+        p += 1;
+    }
+    ok
+}
+
+// `spec/03-types/` -> `spec/`; `spec/` -> ``.
+fn parent_dir(borrow dir: StrBuf) -> StrBuf {
+    if dir.len() == 0 { return StrBuf.new(); }
+    let inner = text.slice(borrow dir, 0, dir.len() - 1);
+    dir_of(borrow inner)
+}
+
+// Sort the section directory ids so the per-page lookup is a binary search.
+fn build_dir_index(inout site: Site) {
+    let mut ids = value.U64s.new();
+    let mut index = value.U64s.new();
+    let mut i: u64 = 0;
+    while i < site.sections.len() {
+        ids.push(site.section_at(i).dir);
+        index.push(i);
+        i += 1;
+    }
+    let mut k: u64 = 1;
+    while k < ids.len() {
+        let id = ids.get_or(k, 0);
+        let at = index.get_or(k, 0);
+        let mut j = k;
+        while j > 0 && ids.get_or(j - 1, 0) > id {
+            ids.set(j, ids.get_or(j - 1, 0));
+            index.set(j, index.get_or(j - 1, 0));
+            j -= 1;
+        }
+        ids.set(j, id);
+        index.set(j, at);
+        k += 1;
+    }
+    site.dir_ids = ids;
+    site.dir_index = index;
+}
+
+fn find_section_for_dir(borrow site: Site, dir_id: u64) -> u64 {
+    let mut low: u64 = 0;
+    let mut high = site.dir_ids.len();
+    while low < high {
+        let mid = low + (high - low) / 2;
+        let probe = site.dir_ids.get_or(mid, 0);
+        if probe == dir_id { return site.dir_index.get_or(mid, NONE()); }
+        if probe < dir_id { low = mid + 1; } else { high = mid; }
+    }
+    NONE()
+}
+
+// ---------------------------------------------------------------------------
+// Ordering
+// ---------------------------------------------------------------------------
+
+// Whether page `a` sorts before page `b` under `kind`. Every branch ends in
+// the content path, which is unique, so this is a total order and the scale
+// variants' ties on weight, title, and date cannot make the result depend on
+// discovery order.
+fn page_before(borrow site: Site, borrow eng: ast.Engine, a: u64, b: u64, kind: u64) -> bool {
+    let pa = site.page_at(a);
+    let pb = site.page_at(b);
+    if kind == SORT_WEIGHT() {
+        if pa.weight != pb.weight { return pa.weight < pb.weight; }
+    } else if kind == SORT_DATE() {
+        let da = date_id(borrow site, borrow eng, a);
+        let db = date_id(borrow site, borrow eng, b);
+        let order = eng.arena.strings.compare(da, db);
+        // Newest first, and an absent date is the empty string, which compares
+        // below every real date and therefore lands last.
+        if order != 1 { return order == 2; }
+    }
+    eng.arena.strings.compare(pa.rel, pb.rel) == 0
+}
+
+fn date_id(borrow site: Site, borrow eng: ast.Engine, index: u64) -> u64 {
+    let page = site.page_at(index);
+    let v = eng.arena.map_get(page.front, site.keys.date);
+    if eng.arena.tag(v) != value.V_STR() { return eng.arena.empty_string; }
+    eng.arena.at(v).num
+}
+
+fn sort_pages(borrow site: Site, borrow eng: ast.Engine, inout list: value.U64s, kind: u64) {
+    let mut k: u64 = 1;
+    while k < list.len() {
+        let current = list.get_or(k, 0);
+        let mut j = k;
+        while j > 0 {
+            let prior = list.get_or(j - 1, 0);
+            if !page_before(borrow site, borrow eng, current, prior, kind) { break; }
+            list.set(j, prior);
+            j -= 1;
+        }
+        list.set(j, current);
+        k += 1;
+    }
+}
+
+// Bucket a list of owners into contiguous per-owner ranges in ONE pass, by
+// counting sort: `owner_of` is already recorded on every element, so a second
+// pass over every element per owner is avoidable and must be avoided. Scanning
+// all pages once per section is quadratic IN THE CORPUS — fifteen sections over
+// ninety-five pages is nothing, but ADR-0072's 100x variant is fifteen hundred
+// sections over nine and a half thousand pages, and this program is the thing
+// being measured, so a scan that grows with the product of the two would be
+// measuring the harness's accident rather than the language.
+struct Buckets { starts: value.U64s, items: value.U64s }
+
+fn bucket_by_owner(borrow owners: value.U64s, groups: u64) -> Buckets {
+    let mut counts = value.U64s.new();
+    let mut i: u64 = 0;
+    while i < groups { counts.push(0); i += 1; }
+    let mut e: u64 = 0;
+    while e < owners.len() {
+        let owner = owners.get_or(e, NONE());
+        if owner != NONE() { counts.set(owner, counts.get_or(owner, 0) + 1); }
+        e += 1;
+    }
+    let mut starts = value.U64s.new();
+    let mut cursors = value.U64s.new();
+    let mut running: u64 = 0;
+    let mut g: u64 = 0;
+    while g < groups {
+        starts.push(running);
+        cursors.push(running);
+        running += counts.get_or(g, 0);
+        g += 1;
+    }
+    starts.push(running);
+
+    let mut items = value.U64s.new();
+    let mut k: u64 = 0;
+    while k < running { items.push(NONE()); k += 1; }
+    let mut f: u64 = 0;
+    while f < owners.len() {
+        let owner = owners.get_or(f, NONE());
+        if owner != NONE() {
+            let at = cursors.get_or(owner, 0);
+            items.set(at, f);
+            cursors.set(owner, at + 1);
+        }
+        f += 1;
+    }
+    Buckets { starts: starts, items: items }
+}
+
+// Collect and sort each section's direct pages and subsections.
+fn order_sections(inout site: Site, inout eng: ast.Engine) {
+    let count = site.sections.len();
+
+    let mut page_owner = value.U64s.new();
+    let mut p: u64 = 0;
+    while p < site.pages.len() {
+        let page = site.page_at(p);
+        page_owner.push(if page.is_index { NONE() } else { page.section });
+        p += 1;
+    }
+    let by_section = bucket_by_owner(borrow page_owner, count);
+
+    let mut sub_owner = value.U64s.new();
+    let mut c: u64 = 0;
+    while c < count { sub_owner.push(site.section_at(c).parent); c += 1; }
+    let by_parent = bucket_by_owner(borrow sub_owner, count);
+
+    let mut s: u64 = 0;
+    while s < count {
+        let mut section = site.section_at(s);
+
+        let mut own = value.U64s.new();
+        let mut i = by_section.starts.get_or(s, 0);
+        let page_end = by_section.starts.get_or(s + 1, 0);
+        while i < page_end { own.push(by_section.items.get_or(i, NONE())); i += 1; }
+        sort_pages(borrow site, borrow eng, inout own, section.sort_by);
+        section.page_start = site.section_pages.len();
+        section.page_count = own.len();
+        let mut a: u64 = 0;
+        while a < own.len() { site.section_pages.push(own.get_or(a, 0)); a += 1; }
+
+        let mut subs = value.U64s.new();
+        let mut j = by_parent.starts.get_or(s, 0);
+        let sub_end = by_parent.starts.get_or(s + 1, 0);
+        while j < sub_end { subs.push(by_parent.items.get_or(j, NONE())); j += 1; }
+        sort_subsections(borrow site, borrow eng, inout subs);
+        section.sub_start = site.section_subs.len();
+        section.sub_count = subs.len();
+        let mut b: u64 = 0;
+        while b < subs.len() { site.section_subs.push(subs.get_or(b, 0)); b += 1; }
+
+        site.sections.set(s, section);
+        s += 1;
+    }
+}
+
+// Subsections order by their content path, which is what Zola does and what
+// the numbered specification chapters rely on.
+fn sort_subsections(borrow site: Site, borrow eng: ast.Engine, inout list: value.U64s) {
+    let mut k: u64 = 1;
+    while k < list.len() {
+        let current = list.get_or(k, 0);
+        let current_key = site.section_at(current).key;
+        let mut j = k;
+        while j > 0 {
+            let prior = list.get_or(j - 1, 0);
+            let prior_key = site.section_at(prior).key;
+            if eng.arena.strings.compare(prior_key, current_key) != 2 { break; }
+            list.set(j, prior);
+            j -= 1;
+        }
+        list.set(j, current);
+        k += 1;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Markdown
+// ---------------------------------------------------------------------------
+
+// Render every page's body once. Section index templates show their pages'
+// summaries, so every body must be rendered before any template runs.
+fn render_bodies(inout site: Site, inout eng: ast.Engine) {
+    let mut i: u64 = 0;
+    while i < site.pages.len() {
+        let mut page = site.page_at(i);
+        let permalink = eng.arena.strings.copy(page.permalink);
+        let url_value = eng.arena.string(borrow permalink);
+        eng.set_global(site.keys.page_url_global, url_value);
+
+        let source = eng.arena.strings.copy(page.source);
+        let expanded = markdown.expand_shortcodes(
+            inout eng, borrow source, page.body_start, page.body_line,
+        );
+        let doc = markdown.render(inout eng, borrow expanded, page.body_line);
+        page.content = eng.arena.string(borrow doc.html);
+        // Zola's `page.summary` exists only when the body carries a
+        // `<!-- more -->` marker; the templates gate on its presence, so a
+        // whole-body fallback would print every post in full on the index.
+        if doc.summary_end < doc.html.len() {
+            let cut = text.slice(borrow doc.html, 0, doc.summary_end);
+            page.summary = eng.arena.string(borrow cut);
+        } else {
+            page.summary = eng.arena.null();
+        }
+        site.pages.set(i, page);
+        i += 1;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Template-visible objects
+// ---------------------------------------------------------------------------
+
+fn copy_front(inout eng: ast.Engine, front: u64, inout fields: value.Entries) {
+    let mut i: u64 = 0;
+    while i < eng.arena.length(front) {
+        fields.push(eng.arena.entry_at(front, i));
+        i += 1;
+    }
+}
+
+fn put(inout fields: value.Entries, key: u64, v: u64) {
+    fields.push(value.Entry { key: key, value: v });
+}
+
+// The lightweight object a page presents to OTHER pages: what a section index,
+// a feed entry, and a prev/next link read. It deliberately carries no `lower`,
+// `higher`, or `content`, which is also what keeps the object graph finite —
+// a page's neighbour holding the page holding the neighbour has no end.
+fn build_entry(inout site: Site, inout eng: ast.Engine, index: u64) -> u64 {
+    let page = site.page_at(index);
+    let mut fields = value.Entries.new();
+    copy_front(inout eng, page.front, inout fields);
+    let permalink = eng.arena.string_id(page.permalink);
+    put(inout fields, site.keys.permalink, permalink);
+    let route = eng.arena.strings.copy(page.route);
+    let mut path = StrBuf.new();
+    path.push(47);
+    path.append_borrowed(borrow route);
+    let path_value = eng.arena.string(borrow path);
+    put(inout fields, site.keys.path, path_value);
+    put(inout fields, site.keys.summary, page.summary);
+    eng.arena.map(borrow fields)
+}
+
+// The object bound as `page` while its own template renders: everything the
+// entry has, plus the rendered body and the ordered neighbours.
+fn build_object(inout site: Site, inout eng: ast.Engine, index: u64, lower: u64, higher: u64) -> u64 {
+    let page = site.page_at(index);
+    let mut fields = value.Entries.new();
+    copy_front(inout eng, page.front, inout fields);
+    let permalink = eng.arena.string_id(page.permalink);
+    put(inout fields, site.keys.permalink, permalink);
+    let route = eng.arena.strings.copy(page.route);
+    let mut path = StrBuf.new();
+    path.push(47);
+    path.append_borrowed(borrow route);
+    let path_value = eng.arena.string(borrow path);
+    put(inout fields, site.keys.path, path_value);
+    put(inout fields, site.keys.summary, page.summary);
+    put(inout fields, site.keys.content, page.content);
+    put(inout fields, site.keys.lower, lower);
+    put(inout fields, site.keys.higher, higher);
+    eng.arena.map(borrow fields)
+}
+
+// Build every page entry, then every page object, then every section object,
+// then the `__sections` map `get_section` reads. The order is forced: an entry
+// is an input to the section that lists it, and a section object is an input
+// to the navigation macro that walks it.
+fn build_objects(inout site: Site, inout eng: ast.Engine) {
+    let mut i: u64 = 0;
+    while i < site.pages.len() {
+        let mut page = site.page_at(i);
+        page.entry = build_entry(inout site, inout eng, i);
+        site.pages.set(i, page);
+        i += 1;
+    }
+
+    let mut s: u64 = 0;
+    while s < site.sections.len() {
+        let section = site.section_at(s);
+        let mut k: u64 = 0;
+        while k < section.page_count {
+            let index = site.section_pages.get_or(section.page_start + k, NONE());
+            let lower = if k == 0 {
+                eng.arena.null()
+            } else {
+                let before = site.section_pages.get_or(section.page_start + k - 1, NONE());
+                site.page_at(before).entry
+            };
+            let higher = if k + 1 == section.page_count {
+                eng.arena.null()
+            } else {
+                let after = site.section_pages.get_or(section.page_start + k + 1, NONE());
+                site.page_at(after).entry
+            };
+            let mut page = site.page_at(index);
+            page.object = build_object(inout site, inout eng, index, lower, higher);
+            site.pages.set(index, page);
+            k += 1;
+        }
+        s += 1;
+    }
+
+    let mut sections_map = value.Entries.new();
+    let mut t: u64 = 0;
+    while t < site.sections.len() {
+        let mut section = site.section_at(t);
+        section.object = build_section_object(borrow site, inout eng, t);
+        let key = section.key;
+        let object = section.object;
+        site.sections.set(t, section);
+        put(inout sections_map, key, object);
+        t += 1;
+    }
+    let sections_value = eng.arena.map(borrow sections_map);
+    eng.set_global(site.keys.sections_global, sections_value);
+}
+
+fn build_section_object(borrow site: Site, inout eng: ast.Engine, index: u64) -> u64 {
+    let section = site.section_at(index);
+    let page = site.page_at(section.page);
+    let mut fields = value.Entries.new();
+    copy_front(inout eng, page.front, inout fields);
+    let permalink = eng.arena.string_id(page.permalink);
+    put(inout fields, site.keys.permalink, permalink);
+    let route = eng.arena.strings.copy(page.route);
+    let mut path = StrBuf.new();
+    path.push(47);
+    path.append_borrowed(borrow route);
+    let path_value = eng.arena.string(borrow path);
+    put(inout fields, site.keys.path, path_value);
+    put(inout fields, site.keys.content, page.content);
+
+    let mut listed = value.U64s.new();
+    let mut k: u64 = 0;
+    while k < section.page_count {
+        let child = site.section_pages.get_or(section.page_start + k, NONE());
+        listed.push(site.page_at(child).entry);
+        k += 1;
+    }
+    let pages_value = eng.arena.array(borrow listed);
+    put(inout fields, site.keys.pages, pages_value);
+
+    // Subsections are content PATHS, not objects, exactly as Zola presents
+    // them: the production sidebar reads `section.subsections | sort` and
+    // resolves each one with `get_section`, and the port keeps that shape so
+    // the same lookup work happens in both tools.
+    let mut subs = value.U64s.new();
+    let mut j: u64 = 0;
+    while j < section.sub_count {
+        let child = site.section_subs.get_or(section.sub_start + j, NONE());
+        let key = site.section_at(child).key;
+        subs.push(eng.arena.string_id(key));
+        j += 1;
+    }
+    let subs_value = eng.arena.array(borrow subs);
+    put(inout fields, site.keys.subsections, subs_value);
+    eng.arena.map(borrow fields)
+}
+
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+
+fn output_path(borrow site: Site, borrow eng: ast.Engine, route_id: u64, name: StrBuf) -> StrBuf {
+    let route = eng.arena.strings.copy(route_id);
+    let mut path = join_path(borrow site.output_root, borrow route);
+    if path.len() > 0 && text.byte_of(borrow path, path.len() - 1) != 47 { path.push(47); }
+    path.push_str(name);
+    path
+}
+
+fn render_named(inout site: Site, inout eng: ast.Engine, name: u64, route: u64, file: StrBuf) -> bool {
+    let mut out = StrBuf.new();
+    if !tmpl_eval.render(inout eng, name, inout out) { return false; }
+    // Only when listing: this runs once per emitted file, and an unconditional
+    // copy would be an allocation the measured build pays nine thousand times
+    // for a flag it was not given.
+    let listed = if site.list { file.clone() } else { StrBuf.new() };
+    let path = output_path(borrow site, borrow eng, route, file);
+    if !write_output(borrow path, borrow out) {
+        let subject = eng.arena.strings.intern(borrow path);
+        fail(inout eng, "cannot write an output file", subject);
+        return false;
+    }
+    site.files_written += 1;
+    if site.list {
+        let route_text = eng.arena.strings.copy(route);
+        site.listing.append_borrowed(borrow route_text);
+        site.listing.push_str(listed);
+        site.listing.push_str("\n");
+    }
+    true
+}
+
+// A page's template: its own `template`, else its section's `page_template`,
+// else `page.html`. A section's is its own `template`, else `section.html`.
+fn template_for(inout site: Site, inout eng: ast.Engine, index: u64) -> u64 {
+    let page = site.page_at(index);
+    let own = eng.arena.map_get(page.front, site.keys.template);
+    if eng.arena.tag(own) == value.V_STR() { return eng.arena.at(own).num; }
+    if page.is_index { return eng.key("section.html"); }
+    if page.section != NONE() {
+        let owner = site.section_at(page.section);
+        let owner_page = site.page_at(owner.page);
+        let inherited = eng.arena.map_get(owner_page.front, site.keys.page_template);
+        if eng.arena.tag(inherited) == value.V_STR() { return eng.arena.at(inherited).num; }
+    }
+    eng.key("page.html")
+}
+
+fn bind_page(inout site: Site, inout eng: ast.Engine, page_value: u64, section_value: u64, url: u64) {
+    eng.set_global(site.keys.page, page_value);
+    eng.set_global(site.keys.section, section_value);
+    eng.set_global(site.keys.page_url_global, url);
+}
+
+// Render every page and every section index, then every feed.
+fn emit(inout site: Site, inout eng: ast.Engine) -> bool {
+    let mut ok = true;
+    let null = eng.arena.null();
+
+    let mut i: u64 = 0;
+    while i < site.pages.len() {
+        let page = site.page_at(i);
+        if !page.is_index {
+            let name = template_for(inout site, inout eng, i);
+            if eng.find_template(name) == NONE() {
+                fail(inout eng, "a page names a template the site does not have", name);
+                ok = false;
+            } else {
+                let url = eng.arena.string_id(page.permalink);
+                bind_page(inout site, inout eng, page.object, null, url);
+                if !render_named(inout site, inout eng, name, page.route, "index.html") { ok = false; }
+                site.pages_rendered += 1;
+            }
+        }
+        i += 1;
+    }
+
+    let mut s: u64 = 0;
+    while s < site.sections.len() {
+        let section = site.section_at(s);
+        let page = site.page_at(section.page);
+        let url = eng.arena.string_id(page.permalink);
+        if section.redirect_to != NONE() {
+            if !emit_redirect(inout site, inout eng, s) { ok = false; }
+        } else {
+            let name = template_for(inout site, inout eng, section.page);
+            if eng.find_template(name) == NONE() {
+                fail(inout eng, "a section names a template the site does not have", name);
+                ok = false;
+            } else {
+                bind_page(inout site, inout eng, null, section.object, url);
+                if !render_named(inout site, inout eng, name, page.route, "index.html") { ok = false; }
+            }
+        }
+        if section.generate_feeds {
+            if !emit_feed(inout site, inout eng, s) { ok = false; }
+        }
+        s += 1;
+    }
+    ok
+}
+
+// A `redirect_to` section emits Zola's redirect stub in place of its own index
+// page, and its pages and subsections still render.
+//
+// ADR-0072 left this undecided and RUE-1483 neither honoured nor rejected it,
+// which made `spec/_index.md` the one page the corpus differential had to
+// exclude. Honouring it is the choice that keeps the emitted FILE SET equal to
+// Zola's, which is Decision 4's cross-tool criterion: refusing the key would
+// leave gazette one output file short of every peer, and rendering the section
+// normally would put a page at a route Zola serves a redirect from. The stub's
+// markup is the port's `redirect.html`, so the decision is visible in a
+// template rather than buried in host code, and the URL resolves through the
+// same `@/…`-aware join every other link uses.
+fn emit_redirect(inout site: Site, inout eng: ast.Engine, index: u64) -> bool {
+    let section = site.section_at(index);
+    let page = site.page_at(section.page);
+    let name = eng.key("redirect.html");
+    if eng.find_template(name) == NONE() {
+        fail(inout eng, "a section sets `redirect_to` but the site has no `redirect.html`", section.key);
+        return false;
+    }
+    let target = eng.arena.strings.copy(section.redirect_to);
+    let mut resolved = tmpl_eval.join_base(inout eng, borrow target);
+    if resolved.len() > 0 && text.byte_of(borrow resolved, resolved.len() - 1) != 47 { resolved.push(47); }
+    let url_value = eng.arena.string(borrow resolved);
+    eng.push_scope();
+    eng.bind(site.keys.url, url_value);
+    let rendered = render_named(inout site, inout eng, name, page.route, "index.html");
+    eng.pop_scope();
+    rendered
+}
+
+// A section's feed. The template is the port's `rss.xml`; nothing in it varies
+// with the clock, which is what lets ADR-0072 Decision 4's determinism check
+// hold byte-exactly over repeated samples. Gazette has no clock to read, so
+// this is a property of the port rather than a stripping step.
+fn emit_feed(inout site: Site, inout eng: ast.Engine, index: u64) -> bool {
+    let section = site.section_at(index);
+    let page = site.page_at(section.page);
+    let name = eng.key("rss.xml");
+    if eng.find_template(name) == NONE() {
+        fail(inout eng, "a section sets `generate_feeds` but the site has no `rss.xml`", section.key);
+        return false;
+    }
+    let mut listed = value.U64s.new();
+    let mut k: u64 = 0;
+    while k < section.page_count {
+        let child = site.section_pages.get_or(section.page_start + k, NONE());
+        listed.push(site.page_at(child).entry);
+        k += 1;
+    }
+    let pages_value = eng.arena.array(borrow listed);
+    let feed_path = output_feed_url(borrow site, inout eng, page.route);
+    let null = eng.arena.null();
+    let url = eng.arena.string_id(page.permalink);
+    bind_page(inout site, inout eng, null, section.object, url);
+    eng.push_scope();
+    eng.bind(site.keys.pages, pages_value);
+    eng.bind(site.keys.feed_url, feed_path);
+    let rendered = render_named(inout site, inout eng, name, page.route, "rss.xml");
+    eng.pop_scope();
+    rendered
+}
+
+fn output_feed_url(borrow site: Site, inout eng: ast.Engine, route_id: u64) -> u64 {
+    let route = eng.arena.strings.copy(route_id);
+    let mut rel = text.slice(borrow route, 0, route.len());
+    rel.push_str("rss.xml");
+    let resolved = tmpl_eval.join_base(inout eng, borrow rel);
+    eng.arena.string(borrow resolved)
+}
+
+// ---------------------------------------------------------------------------
+// Static passthrough
+// ---------------------------------------------------------------------------
+
+// Copy `static/` into the output root. This is measured work for every tool in
+// ADR-0072's comparison and its inputs are part of the recorded fixture
+// identity, so it happens inside the build rather than in the harness around
+// it.
+//
+// A site may legitimately have no `static/` directory, so `NotFound` is
+// success — but ONLY `NotFound`. An unreadable one is a failure, and the
+// distinction matters more here than the shrug it replaced suggests: static
+// passthrough is measured work, so a permission or I/O error that returned
+// "nothing to copy" would produce a fast build missing a megabyte of output,
+// which is precisely the wrong-but-fast result Decision 4 exists to refuse.
+fn copy_static(inout site: Site, inout eng: ast.Engine) -> bool {
+    let root = join_path(borrow site.root, borrow "static");
+    let entries = match std.fs.walk(borrow root) {
+        DirRes.Ok(list) => list,
+        DirRes.Err(e) => {
+            match e {
+                std.fs.FileError.NotFound => { return true; },
+                _ => {},
+            }
+            let subject = eng.arena.strings.intern(borrow root);
+            fail(inout eng, "the static directory exists but cannot be read", subject);
+            return false;
+        },
+    };
+    let prefix = root.len() + 1;
+    let mut ok = true;
+    let mut i: u64 = 0;
+    while i < entries.len() {
+        if entries.is_file(i) {
+            let path = entries.path(i);
+            let rel = text.slice(borrow path, prefix, path.len());
+            let target = join_path(borrow site.output_root, borrow rel);
+            if !copy_one(borrow path, borrow target) {
+                let subject = eng.arena.strings.intern(borrow rel);
+                fail(inout eng, "cannot copy a static asset", subject);
+                ok = false;
+            } else {
+                site.files_written += 1;
+                if site.list {
+                    site.listing.append_borrowed(borrow rel);
+                    site.listing.push_str("\n");
+                }
+            }
+        }
+        i += 1;
+    }
+    ok
+}
+
+fn copy_one(borrow from: StrBuf, borrow to: StrBuf) -> bool {
+    let mut raw = Bytes.new();
+    let mut source = match std.fs.File.open(borrow from) {
+        FileRes.Ok(f) => f,
+        FileRes.Err(_e) => { return false; },
+    };
+    let mut ok = true;
+    loop {
+        raw.reserve(65536);
+        let n = match source.read(inout raw) {
+            ReadRes.Ok(k) => k,
+            ReadRes.Err(_e) => { ok = false; 0 },
+        };
+        if n == 0 { break; }
+    }
+    let _ = source.close();
+    if !ok { return false; }
+
+    let parent = dir_of(borrow to);
+    if parent.len() > 0 {
+        let trimmed = text.slice(borrow parent, 0, parent.len() - 1);
+        match std.fs.create_dir_all(borrow trimmed) {
+            UnitRes.Ok(_u) => {},
+            UnitRes.Err(_e) => { return false; },
+        }
+    }
+    let mut target = match std.fs.File.create(borrow to) {
+        FileRes.Ok(f) => f,
+        FileRes.Err(_e) => { return false; },
+    };
+    let wrote = match target.write_all(borrow raw) {
+        WriteRes.Ok(_unit) => true,
+        WriteRes.Err(_e) => false,
+    };
+    let _ = target.close();
+    wrote
+}
+
+// ---------------------------------------------------------------------------
+// Driver
+// ---------------------------------------------------------------------------
+
+// Build the site rooted at `root` into `output`. The stages are ordered by
+// their real dependencies and each one refuses to continue past a failure that
+// would make the next stage's output meaningless, so a broken site produces
+// diagnostics rather than a partial tree that looks like a successful build.
+pub fn build(
+    inout eng: ast.Engine,
+    borrow root: StrBuf,
+    borrow output: StrBuf,
+    list: bool,
+    inout report: StrBuf,
+) -> bool {
+    let mut site = Site.new();
+    site.list = list;
+    site.keys = intern_keys(inout eng);
+    site.root = text.slice(borrow root, 0, root.len());
+    site.content_root = join_path(borrow root, borrow "content");
+    site.output_root = text.slice(borrow output, 0, output.len());
+
+    if !load_config(inout site, inout eng) { return false; }
+    if !load_templates(inout site, inout eng) { return false; }
+    if !discover(inout site, inout eng) { return false; }
+    if !build_sections(inout site, inout eng) { return false; }
+    order_sections(inout site, inout eng);
+    render_bodies(inout site, inout eng);
+    build_objects(inout site, inout eng);
+    let emitted = emit(inout site, inout eng);
+    let copied = copy_static(inout site, inout eng);
+
+    if site.list { report.append_borrowed(borrow site.listing); }
+    report.push_str("gazette: ");
+    report.push_str(text.decimal(site.pages_rendered));
+    report.push_str(" pages, ");
+    report.push_str(text.decimal(site.sections.len()));
+    report.push_str(" sections, ");
+    report.push_str(text.decimal(site.files_written));
+    report.push_str(" files written\n");
+    emitted && copied && eng.arena.error_count() == 0
+}

--- a/examples/gazette/templates/base.html
+++ b/examples/gazette/templates/base.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}{{ config.title }}{% endblock %}</title>
+    <meta name="description" content="{{ config.description }}">
+    <link rel="stylesheet" href="{{ get_url(path='style.css') }}">
+    <link rel="icon" href="{{ get_url(path='favicon.svg') }}" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="{{ get_url(path='brand/apple-touch-icon.png') }}">
+    <link rel="alternate" type="application/rss+xml" title="Rue Blog RSS" href="{{ get_url(path='blog/rss.xml') }}">
+    <script>
+        // Check for saved theme preference or default to system preference
+        const isDark = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (isDark) {
+            document.documentElement.classList.add('dark');
+        }
+        // Write syntax theme stylesheets with correct initial disabled state
+        document.write('<link rel="stylesheet" href="{{ get_url(path='syntax-light.css') }}" id="syntax-light"' + (isDark ? ' disabled' : '') + '>');
+        document.write('<link rel="stylesheet" href="{{ get_url(path='syntax-dark.css') }}" id="syntax-dark"' + (isDark ? '' : ' disabled') + '>');
+
+        function updateSyntaxTheme() {
+            const syntaxLight = document.getElementById('syntax-light');
+            const syntaxDark = document.getElementById('syntax-dark');
+            if (syntaxLight && syntaxDark) {
+                const dark = document.documentElement.classList.contains('dark');
+                syntaxLight.disabled = dark;
+                syntaxDark.disabled = !dark;
+            }
+        }
+    </script>
+</head>
+<body class="min-h-screen flex flex-col">
+    <!-- engraved rue sprig (Ruta graveolens), referenced site-wide via <use> -->
+    <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+      <defs>
+        <g id="rue-sprig" fill="none" stroke="currentColor" stroke-width="1.5"
+           stroke-linecap="round" stroke-linejoin="round">
+          <path d="M16 30 C 16 24, 15.4 18, 16 10"/>
+          <path d="M15.7 22 C 12.5 20.5, 10 19, 8 16.5"/>
+          <path d="M8 16.5 c -2.6 -0.4 -4 -2.4 -3.4 -4.4 c 1.8 -1 4 -0.2 4.6 2 c 0.3 1 0 1.8 -1.2 2.4 z"/>
+          <path d="M11.5 19.2 c -2.4 0.6 -4.3 -0.6 -4.5 -2.6"/>
+          <path d="M16 17.5 C 19.5 16, 22 14.5, 23.8 12"/>
+          <path d="M23.8 12 c 2.6 -0.2 3.9 -2.2 3.2 -4.2 c -1.9 -0.9 -4 0.1 -4.4 2.3 c -0.2 1 0.1 1.7 1.2 1.9 z"/>
+          <path d="M20.4 14.6 c 2.4 0.4 4.2 -0.8 4.3 -2.8"/>
+          <path d="M16 10 c -0.4 -2.8 1 -4.6 3.2 -4.6 c 1.2 1.8 0.5 4 -1.6 4.9 c -0.7 0.3 -1.2 0.2 -1.6 -0.3 z"/>
+          <g stroke="none" fill="var(--color-gold)">
+            <circle cx="12.2" cy="7.4" r="1.15"/>
+            <circle cx="9.9"  cy="9.4" r="1.15"/>
+            <circle cx="12.6" cy="10.6" r="1.15"/>
+            <circle cx="14.4" cy="8.7" r="1.15"/>
+          </g>
+          <circle cx="12.4" cy="9" r="0.8" stroke="none" fill="currentColor"/>
+          <path d="M15.9 13.5 C 14.8 11.8, 13.6 10.6, 12.6 10.4"/>
+        </g>
+      </defs>
+    </svg>
+
+    <div class="colophon-bar">
+        <em>Ruta graveolens</em> &nbsp;·&nbsp; notes from a language experiment &nbsp;·&nbsp; cultivated since 2025
+    </div>
+
+    <nav>
+        <div class="masthead">
+            <a href="{{ get_url(path='/') }}" class="wordmark">
+                <svg class="sprig" viewBox="0 0 32 32"><use href="#rue-sprig"/></svg>
+                Rue
+            </a>
+            <!-- Desktop navigation -->
+            <div class="nav-desktop flex items-center gap-6">
+                <ul class="flex gap-6">
+                    <li><a href="{{ get_url(path='tutorial') }}" class="nav-link">Tutorial</a></li>
+<!-- Hardcoded path: spec pages are copied into Zola content at build time -->
+                    <li><a href="/spec/" class="nav-link">Specification</a></li>
+                    <li><a href="{{ get_url(path='performance') }}" class="nav-link">Performance</a></li>
+                    <li><a href="{{ get_url(path='runtime') }}" class="nav-link">Runtime</a></li>
+                    <li><a href="{{ get_url(path='blog') }}" class="nav-link">Lab Notes</a></li>
+                    <li><a href="{{ config.extra.github_url }}" class="nav-link ext">GitHub</a></li>
+                    <li><a href="{{ config.extra.bluesky_url }}" class="nav-link ext">Bluesky</a></li>
+                </ul>
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+            </div>
+            <!-- Mobile navigation controls -->
+            <div class="nav-mobile-controls flex items-center gap-4">
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+                <button onclick="toggleMobileMenu()" class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false">
+                    <svg class="icon-menu w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                    <svg class="icon-close w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+        <!-- Mobile menu overlay -->
+        <div id="mobile-menu" class="mobile-menu">
+            <ul class="mobile-menu-list">
+                <li><a href="{{ get_url(path='/') }}" class="mobile-menu-link">Home</a></li>
+                <li><a href="{{ get_url(path='tutorial') }}" class="mobile-menu-link">Tutorial</a></li>
+                <li><a href="/spec/" class="mobile-menu-link">Specification</a></li>
+                <li><a href="{{ get_url(path='performance') }}" class="mobile-menu-link">Performance</a></li>
+                <li><a href="{{ get_url(path='runtime') }}" class="mobile-menu-link">Runtime</a></li>
+                <li><a href="{{ get_url(path='blog') }}" class="mobile-menu-link">Lab Notes</a></li>
+                <li><a href="{{ config.extra.github_url }}" class="mobile-menu-link">GitHub</a></li>
+                <li><a href="{{ config.extra.bluesky_url }}" class="mobile-menu-link">Bluesky</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <main class="flex-1">
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer class="footer-colophon">
+        <div class="inner">
+            <span>© 2025–2026 The Rue Authors · MIT/Apache-2.0</span>
+            <span><em>rue</em>, n. — a hardy evergreen herb; also, what we hope you won’t do after choosing this language.</span>
+        </div>
+    </footer>
+
+    <script>
+        function toggleTheme() {
+            if (document.documentElement.classList.contains('dark')) {
+                document.documentElement.classList.remove('dark');
+                localStorage.theme = 'light';
+            } else {
+                document.documentElement.classList.add('dark');
+                localStorage.theme = 'dark';
+            }
+            updateSyntaxTheme();
+        }
+
+        function toggleMobileMenu() {
+            const menu = document.getElementById('mobile-menu');
+            const toggle = document.querySelector('.mobile-menu-toggle');
+            const isOpen = menu.classList.toggle('open');
+            toggle.classList.toggle('active', isOpen);
+            toggle.setAttribute('aria-expanded', isOpen);
+        }
+
+        // Close mobile menu when clicking a link
+        document.querySelectorAll('.mobile-menu-link').forEach(link => {
+            link.addEventListener('click', () => {
+                const menu = document.getElementById('mobile-menu');
+                const toggle = document.querySelector('.mobile-menu-toggle');
+                menu.classList.remove('open');
+                toggle.classList.remove('active');
+                toggle.setAttribute('aria-expanded', 'false');
+            });
+        });
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/elasticlunr/0.9.5/elasticlunr.min.js"></script>
+    <script src="{{ get_url(path='search.js') }}"></script>
+</body>
+</html>

--- a/examples/gazette/templates/blog-page.html
+++ b/examples/gazette/templates/blog-page.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} | Lab Notes | {{ config.title }}{% endblock %}
+
+{% block content %}
+<article class="py-12">
+    <div class="max-w-3xl mx-auto px-6">
+        <header class="mb-8">
+            <h1 style="font-family: var(--font-display); font-weight: 460; font-size: 2.3rem; line-height: 1.15;" class="mb-3">{{ page.title }}</h1>
+            <div class="text-muted flex flex-wrap gap-1" style="font-style: italic;">
+                <time datetime="{{ page.date }}" class="note-date" style="font-style: normal;">{{ page.date | date(format="%Y · %m · %d") }}</time>
+                {% if page.extra.authors %}
+                <span class="before:content-['·'] before:mr-1">
+                    by {% for author in page.extra.authors %}{% if loop.index > 1 %}{% if loop.last %} and {% else %}, {% endif %}{% endif %}{% if author == "steve" %}<a href="https://steveklabnik.com">Steve</a>{% elif author == "claude" %}<a href="https://claude.ai">Claude</a>{% elif author == "codex" %}<a href="https://openai.com/codex/">Codex</a>{% else %}{{ author }}{% endif %}{% endfor %}
+                </span>
+                {% endif %}
+            </div>
+            {% if page.extra.prompt %}
+            <details class="mt-4 prompt-details">
+                <summary class="text-muted cursor-pointer hover:text-fg select-none">View the prompt</summary>
+                <div class="mt-3 p-4 bg-surface border border-themed rounded-lg">
+                    <pre class="whitespace-pre-wrap text-sm m-0! p-0! bg-transparent! border-none!">{{ page.extra.prompt }}</pre>
+                </div>
+            </details>
+            {% endif %}
+        </header>
+        <div class="prose">
+            {{ page.content | safe }}
+        </div>
+    </div>
+</article>
+{% endblock %}

--- a/examples/gazette/templates/blog.html
+++ b/examples/gazette/templates/blog.html
@@ -1,0 +1,51 @@
+{#
+  Port of `website/templates/blog.html` (ADR-0072 Decision 3).
+
+  Pagination is outside the equivalence subset for every tool, so this port
+  lists `section.pages` directly where production writes
+  `{% set pages = paginator.pages | default(value=section.pages) %}`, and drops
+  the Newer/Older navigation the paginator drives. The corpus has eight posts
+  against a `paginate_by = 10`, so production renders exactly one page of them
+  today and the listing itself is unchanged; the difference is that this port
+  cannot grow a second page, which is what "pagination is out of scope" means.
+#}
+{% extends "base.html" %}
+
+{% block title %}Lab Notes | {{ config.title }}{% endblock %}
+
+{% block content %}
+<section class="py-12">
+    <div class="max-w-3xl mx-auto px-6">
+        <header class="mb-10">
+            <h1 style="font-family: var(--font-display); font-weight: 460; font-size: 2.3rem;" class="mb-2">{{ section.title }}</h1>
+            <p class="text-muted mb-4" style="font-style: italic;">{{ section.content | safe }}</p>
+            <a href="{{ get_url(path='blog/rss.xml') }}" class="inline-flex items-center gap-2 text-muted text-sm hover:text-[var(--color-accent)]">
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                    <circle cx="6.18" cy="17.82" r="2.18"/>
+                    <path d="M4 4.44v2.83c7.03 0 12.73 5.7 12.73 12.73h2.83c0-8.59-6.97-15.56-15.56-15.56zm0 5.66v2.83c3.9 0 7.07 3.17 7.07 7.07h2.83c0-5.47-4.43-9.9-9.9-9.9z"/>
+                </svg>
+                RSS Feed
+            </a>
+        </header>
+
+        <ul class="note-list">
+            {% for page in section.pages %}
+            <li>
+                <span class="note-date"><time datetime="{{ page.date }}">{{ page.date | date(format="%Y · %m · %d") }}</time></span>
+                <div>
+                    <a class="note-title" href="{{ page.permalink }}">{{ page.title }}</a>
+                    {% if page.extra.authors %}
+                    <span class="text-faint text-sm" style="font-style: italic;">
+                        — {% for author in page.extra.authors %}{% if loop.index > 1 %}{% if loop.last %} and {% else %}, {% endif %}{% endif %}{% if author == "steve" %}Steve{% elif author == "claude" %}Claude{% elif author == "codex" %}Codex{% else %}{{ author }}{% endif %}{% endfor %}
+                    </span>
+                    {% endif %}
+                    {% if page.summary %}
+                    <p class="note-summary">{{ page.summary | safe }}</p>
+                    {% endif %}
+                </div>
+            </li>
+            {% endfor %}
+        </ul>
+    </div>
+</section>
+{% endblock %}

--- a/examples/gazette/templates/index.html
+++ b/examples/gazette/templates/index.html
@@ -1,0 +1,102 @@
+{#
+  Port of `website/templates/index.html` (ADR-0072 Decision 3).
+
+  The production page opens with `{% set status = load_data(path=
+  "static/status.json", format="json") %}` and renders a "Field Report" panel
+  from it. Two of that panel's rows are derived from the performance store, so
+  rendering it here would make the benchmark's own output an input to the
+  benchmark's workload — the same reason Decision 3 carves the performance
+  dashboard page out of the corpus entirely. `load_data` is therefore outside
+  the equivalence subset for every tool, and this port drops the panel rather
+  than faking a data file for it. The carve-out is stated here and in
+  `scripts/gazette-corpus-diff.py`'s exclusion table rather than left as a
+  silent difference between the port and the page it derives from.
+#}
+{% extends "base.html" %}
+
+{% block content %}
+<section class="hero max-w-5xl mx-auto px-6 pt-14 pb-12 grid grid-cols-1 md:grid-cols-12 gap-12 items-start">
+    <div class="md:col-span-7 reveal d1">
+        <h1 style="font-family: var(--font-display); font-weight: 420; font-size: clamp(2.1rem, 4.6vw, 3.2rem); line-height: 1.12; letter-spacing: -0.01em;" class="mb-6">
+            Rust proved memory safety without garbage collection is possible.<br>
+            <em style="font-weight: 460; color: var(--color-accent);">Can it also be easy?</em>
+        </h1>
+        <p class="text-lg mb-4" style="color: var(--color-muted); max-width: 30rem;">
+            <strong style="color: var(--color-fg);">We don’t know yet.</strong>
+            Rue is an early-stage research language exploring that question — a
+            systems language aiming for the same destination by a gentler path.
+            It is not ready for real projects, but the whole experiment runs in
+            the open, and you can watch.
+        </p>
+        <p class="mb-8" style="font-style: italic; color: var(--color-faint); max-width: 30rem; font-size: 0.95rem;">
+            Designed by <a href="https://steveklabnik.com" style="color: inherit;">Steve Klabnik</a>.
+            Implemented primarily by Claude, an AI. The field report is an
+            illustrative preview while live project reporting is rebuilt.
+        </p>
+        <div class="flex gap-4 flex-wrap">
+            <a href="{{ get_url(path='tutorial') }}" class="btn-primary">Begin the tutorial</a>
+<!-- Hardcoded path: spec pages are copied into Zola content at build time -->
+            <a href="/spec/" class="btn-secondary">Read the spec</a>
+        </div>
+    </div>
+</section>
+
+<section class="max-w-5xl mx-auto px-6 pb-14 grid grid-cols-1 md:grid-cols-12 gap-12 items-start">
+    <figure class="md:col-span-7 reveal d2" style="margin: 0;">
+        <div class="specimen">
+            <div class="specimen-head">
+                <span class="no">Specimen №&thinsp;1</span>
+                <span>fib.rue</span>
+            </div>
+            {{ section.content | safe }}
+        </div>
+        <figcaption class="specimen-caption">
+            <b>Fig. 1.</b> Compiles to a small static binary.
+            No VM, no interpreter, no garbage collector.
+        </figcaption>
+    </figure>
+
+    <div class="md:col-span-5 reveal d3">
+        <h3 style="font-family: var(--font-display); font-weight: 480; font-size: 1.5rem;" class="mb-3">
+            Familiar on the surface, careful underneath.
+        </h3>
+        <p class="mb-4" style="color: var(--color-muted); font-size: 0.98rem;">
+            If you know Rust, Go, or C, the syntax will feel like home. Underneath,
+            Rue is exploring linear types, compile-time evaluation, and drop
+            tracking — the machinery of memory safety — while trying to keep the
+            learning curve shallow enough to walk up, not climb.
+        </p>
+        <p class="mb-5" style="color: var(--color-muted); font-size: 0.98rem;">
+            The compiler is written in Rust and emits x86-64 and ARM64 machine
+            code directly: no LLVM, direct syscalls, static ELF and Mach-O
+            executables.
+        </p>
+        <div class="run-line"><span class="prompt">$</span> rue fib.rue -o fib && ./fib</div>
+    </div>
+</section>
+
+<div class="sprig-divider" role="presentation">
+    <svg viewBox="0 0 32 32"><use href="#rue-sprig"/></svg>
+</div>
+
+<section class="max-w-5xl mx-auto px-6 pt-12 pb-14">
+    <h2 class="section-title">Recent lab notes</h2>
+    {% set blog = get_section(path="blog/_index.md") %}
+    <ul class="note-list">
+        {% for post in blog.pages | slice(end=3) %}
+        <li>
+            <span class="note-date">{{ post.date | date(format="%Y · %m · %d") }}</span>
+            <div>
+                <a class="note-title" href="{{ post.permalink }}">{{ post.title }}</a>
+                {% if post.description %}
+                <p class="note-summary">{{ post.description }}</p>
+                {% elif post.summary %}
+                <p class="note-summary">{{ post.summary | striptags | truncate(length=180) }}</p>
+                {% endif %}
+            </div>
+        </li>
+        {% endfor %}
+    </ul>
+    <p class="mt-6" style="font-size: 0.9rem;"><a href="{{ get_url(path='blog') }}">All lab notes →</a></p>
+</section>
+{% endblock %}

--- a/examples/gazette/templates/page.html
+++ b/examples/gazette/templates/page.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} | {{ config.title }}{% endblock %}
+
+{% block content %}
+<article class="py-12">
+    <div class="max-w-3xl mx-auto px-6 prose">
+        <h1>{{ page.title }}</h1>
+        {{ page.content | safe }}
+    </div>
+</article>
+{% endblock %}

--- a/examples/gazette/templates/redirect.html
+++ b/examples/gazette/templates/redirect.html
@@ -1,0 +1,36 @@
+{#
+  The stub a section with `redirect_to` emits instead of its own index page,
+  modelled on Zola's built-in `redirect.html`.
+
+  `docs/spec/src/_index.md` sets `redirect_to = "spec/01-introduction"`, which
+  RUE-1483 neither honoured nor rejected — it was the single page
+  `scripts/gazette-corpus-diff.py` had to exclude, because Zola emits this
+  instead of a rendered body and there was nothing to compare. Honouring the
+  key is what keeps gazette's emitted FILE SET equal to its peers', which is
+  ADR-0072 Decision 4's cross-tool criterion: refusing it would leave gazette
+  one output short at `/spec/index.html`, and rendering the section normally
+  would put a page where the peers serve a redirect.
+
+  The markup mirrors the pinned Zola's own redirect output rather than being
+  invented: a redirect stub is not a page anyone reads, and the thing that
+  matters about it is that all three tools put the same file at the same route
+  pointing at the same target. Everywhere else the ports are idiomatic to their
+  tool and cross-tool markup equality is a non-goal; here matching costs
+  nothing and keeps the file-set and semantic checks honest.
+
+  The URL arrives already resolved against the site's base URL, trailing slash
+  included, which is how Zola resolves `redirect_to`. `| safe` is required, not
+  stylistic: gazette auto-escapes every `{{ … }}`, and an escaped `&#x2F;`
+  inside a script string or a `meta refresh` is not decoded by a browser.
+#}<!doctype html>
+<meta charset="utf-8">
+<title>Redirect</title>
+<script>
+  const target = "{{ url | safe }}";
+  const hash = window.location.hash || "";
+  window.location.replace(target + hash);
+</script>
+<noscript>
+  <meta http-equiv="refresh" content="0; url={{ url | safe }}">
+</noscript>
+<p><a href="{{ url | safe }}">Click here</a> to be redirected.</p>

--- a/examples/gazette/templates/rss.xml
+++ b/examples/gazette/templates/rss.xml
@@ -1,0 +1,38 @@
+{#
+  The feed a section with `generate_feeds = true` emits, modelled on Zola's
+  built-in `rss.xml`.
+
+  It carries NO build timestamp. Zola's feed writes `<lastBuildDate>` from the
+  clock and Hugo writes both that and a `<generator>` line, which ADR-0072
+  Decision 4 names as the known build-time-varying output the ports strip so
+  the determinism check can hold byte-exactly across repeated samples. Gazette
+  has no clock to read, so here that is a property of the program rather than
+  a stripping step — but the port says so, because a future gazette that grew
+  one would silently break every determinism check with no other warning.
+
+  URLs carry `| safe`, as Zola's own feed template does: Tera auto-escapes by
+  file type and gazette auto-escapes everything, so without it a permalink
+  would reach the feed as `https:&#x2F;&#x2F;…` and no reader would follow it.
+
+  Entry order is the section's own sorted page order, which for a `sort_by =
+  "date"` section is newest first with the content path as the final tie-break
+  (`site.rue`). ADR-0072 Decision 2's scale variants tie every duplicated post
+  on date, so the tie-break is what makes this feed's order reproducible at
+  all, and the validation asserts it rather than assuming it.
+#}<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+        <title>{{ config.title }}</title>
+        <link>{{ section.permalink | safe }}</link>
+        <description>{{ section.description | default(value=config.description) }}</description>
+        <language>en</language>
+        <atom:link href="{{ feed_url | safe }}" rel="self" type="application/rss+xml"/>
+{% for page in pages %}        <item>
+            <title>{{ page.title }}</title>
+            <pubDate>{{ page.date }}</pubDate>
+            <link>{{ page.permalink | safe }}</link>
+            <guid>{{ page.permalink | safe }}</guid>
+            <description>{{ page.description | default(value="") }}</description>
+        </item>
+{% endfor %}    </channel>
+</rss>

--- a/examples/gazette/templates/shortcodes/preview_feature.html
+++ b/examples/gazette/templates/shortcodes/preview_feature.html
@@ -1,0 +1,5 @@
+<div class="preview-notice">
+    <strong>Preview Feature</strong>:
+    This feature requires <code>--preview {{ feature }}</code> to use.
+    {% if adr %}See <a href="/designs/{{ adr | lower }}">{{ adr | upper }}</a> for the design.{% endif %}
+</div>

--- a/examples/gazette/templates/shortcodes/rule.html
+++ b/examples/gazette/templates/shortcodes/rule.html
@@ -1,0 +1,1 @@
+<div class="rule" id="r-{{ id }}"><a class="rule-link" href="#r-{{ id }}">[{{ id }}]</a></div>

--- a/examples/gazette/templates/spec/base.html
+++ b/examples/gazette/templates/spec/base.html
@@ -1,0 +1,107 @@
+{#
+  Port of `website/templates/spec/base.html` (ADR-0072 Decision 3).
+
+  The sidebar is the whole reason this file matters. Production renders it
+  through a recursive macro whose `active` class and whose own recursion are
+  both gated on a prefix test against the CURRENT PAGE's permalink, so the
+  sidebar is a different document on every page and the expansion work scales
+  with the section tree. The port keeps that structure exactly. Two spellings
+  differ and nothing else does:
+
+    * Tera's test `current_path is starting_with(sub.permalink)` is gazette's
+      filter `current_path | starts_with(prefix=sub.permalink)`. Both are
+      evaluated BY THE ENGINE, which is the constraint that matters: computing
+      the active branch host-side would move measured work out of the measured
+      program, and no output check in ADR-0072 Decision 4 would notice, since a
+      flattened nav emits the same link targets and the same visible text on
+      every page.
+
+    * The macro's `depth` parameter is dropped. Gazette's expression grammar
+      has no arithmetic, so `depth=depth + 1` cannot be written, and the
+      parameter is never read for output in production either — the sibling
+      `tutorial/base.html` and `std/base.html` macros declare no depth at all.
+      Nothing rendered depends on it.
+#}
+{% extends "base.html" %}
+
+{% block title %}{{ page.title | default(value=section.title) }} - Rue Language Specification{% endblock %}
+
+{% block content %}
+<div class="spec-layout">
+    {# Sidebar #}
+    <aside class="spec-sidebar">
+        <div class="spec-sidebar-inner">
+            <div class="spec-sidebar-header">
+                <a href="{{ get_url(path='spec') }}" class="spec-title">Rue Specification</a>
+            </div>
+            <div class="spec-search">
+                <div class="spec-search-input-wrapper">
+                    <input type="text" id="spec-search-input" placeholder="Search..." autocomplete="off">
+                    <kbd class="spec-search-shortcut"><span class="spec-search-shortcut-mod"></span>K</kbd>
+                </div>
+                <div id="spec-search-results" class="spec-search-results"></div>
+            </div>
+            <nav class="spec-nav">
+                {% set spec_section = get_section(path="spec/_index.md") %}
+                {% set current = page.permalink | default(value=section.permalink) | default(value="") %}
+                {{ self::render_nav(section=spec_section, current_path=current) }}
+            </nav>
+        </div>
+    </aside>
+
+    {# Main content #}
+    <div class="spec-main">
+        <article class="spec-content">
+            {% block spec_content %}{% endblock %}
+        </article>
+
+        {# Prev/Next navigation #}
+        {% block prev_next %}
+        <nav class="spec-page-nav">
+            {% if page.lower %}
+            <a href="{{ page.lower.permalink }}" class="spec-nav-prev">
+                <span class="spec-nav-label">Previous</span>
+                <span class="spec-nav-title">{{ page.lower.title }}</span>
+            </a>
+            {% else %}
+            <span></span>
+            {% endif %}
+            {% if page.higher %}
+            <a href="{{ page.higher.permalink }}" class="spec-nav-next">
+                <span class="spec-nav-label">Next</span>
+                <span class="spec-nav-title">{{ page.higher.title }}</span>
+            </a>
+            {% endif %}
+        </nav>
+        {% endblock %}
+    </div>
+</div>
+{% endblock %}
+
+{# Recursive macro for navigation - handles a section and its content #}
+{% macro render_nav(section, current_path) %}
+<ul class="spec-nav-list">
+    {# Render direct pages in this section (already sorted by weight) #}
+    {% for pg in section.pages %}
+    <li class="spec-nav-item">
+        <a href="{{ pg.permalink }}" class="spec-nav-link {% if pg.permalink == current_path %}active{% endif %}">
+            {{ pg.title }}
+        </a>
+    </li>
+    {% endfor %}
+
+    {# Subsections paths are already sorted alphabetically by Zola, which works for
+       our numbered chapters (02-lexical-structure, 03-types, etc.) #}
+    {% for sub_path in section.subsections | sort %}
+        {% set sub = get_section(path=sub_path) %}
+    <li class="spec-nav-section">
+        <a href="{{ sub.permalink }}" class="spec-nav-section-title {% if current_path | starts_with(prefix=sub.permalink) %}active{% endif %}">
+            {{ sub.title }}
+        </a>
+        {% if current_path | starts_with(prefix=sub.permalink) %}
+        {{ self::render_nav(section=sub, current_path=current_path) }}
+        {% endif %}
+    </li>
+    {% endfor %}
+</ul>
+{% endmacro %}

--- a/examples/gazette/templates/spec/page.html
+++ b/examples/gazette/templates/spec/page.html
@@ -1,0 +1,5 @@
+{% extends "spec/base.html" %}
+
+{% block spec_content %}
+{{ page.content | safe }}
+{% endblock %}

--- a/examples/gazette/templates/spec/section.html
+++ b/examples/gazette/templates/spec/section.html
@@ -1,0 +1,31 @@
+{% extends "spec/base.html" %}
+
+{% block spec_content %}
+<h1>{{ section.title }}</h1>
+
+{{ section.content | safe }}
+
+{# List child pages #}
+{% if section.pages %}
+<h2>In this section</h2>
+<ul class="spec-section-toc">
+    {% for page in section.pages %}
+    <li><a href="{{ page.path }}">{{ page.title }}</a></li>
+    {% endfor %}
+</ul>
+{% endif %}
+
+{# List subsections #}
+{% if section.subsections %}
+<ul class="spec-section-toc">
+    {% for subsection_path in section.subsections %}
+        {% set subsection = get_section(path=subsection_path) %}
+    <li><a href="{{ subsection.permalink }}">{{ subsection.title }}</a></li>
+    {% endfor %}
+</ul>
+{% endif %}
+{% endblock %}
+
+{% block prev_next %}
+{# Sections don't have prev/next by default #}
+{% endblock %}

--- a/examples/gazette/templates/std/base.html
+++ b/examples/gazette/templates/std/base.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title | default(value=section.title) }} - Standard Library{% endblock %}
+
+{% block content %}
+<div class="spec-layout">
+    {# Sidebar - reuses spec-sidebar styles #}
+    <aside class="spec-sidebar">
+        <div class="spec-sidebar-inner">
+            <div class="spec-sidebar-header">
+                <a href="{{ get_url(path='std') }}" class="spec-title">Standard Library</a>
+            </div>
+            <nav class="spec-nav">
+                {% set std_section = get_section(path="std/_index.md") %}
+                {% set current = page.permalink | default(value=section.permalink) | default(value="") %}
+                {{ self::render_nav(section=std_section, current_path=current) }}
+            </nav>
+        </div>
+    </aside>
+
+    {# Main content #}
+    <div class="spec-main">
+        <article class="spec-content std-content">
+            {% block std_content %}{% endblock %}
+        </article>
+
+        {# Prev/Next navigation #}
+        {% block prev_next %}
+        <nav class="spec-page-nav">
+            {% if page.lower %}
+            <a href="{{ page.lower.permalink }}" class="spec-nav-prev">
+                <span class="spec-nav-label">Previous</span>
+                <span class="spec-nav-title">{{ page.lower.title }}</span>
+            </a>
+            {% else %}
+            <span></span>
+            {% endif %}
+            {% if page.higher %}
+            <a href="{{ page.higher.permalink }}" class="spec-nav-next">
+                <span class="spec-nav-label">Next</span>
+                <span class="spec-nav-title">{{ page.higher.title }}</span>
+            </a>
+            {% endif %}
+        </nav>
+        {% endblock %}
+    </div>
+</div>
+{% endblock %}
+
+{# Recursive macro for navigation #}
+{% macro render_nav(section, current_path) %}
+<ul class="spec-nav-list">
+    {% for pg in section.pages %}
+    <li class="spec-nav-item">
+        <a href="{{ pg.permalink }}" class="spec-nav-link {% if pg.permalink == current_path %}active{% endif %}">
+            {{ pg.title }}
+        </a>
+    </li>
+    {% endfor %}
+</ul>
+{% endmacro %}

--- a/examples/gazette/templates/std/page.html
+++ b/examples/gazette/templates/std/page.html
@@ -1,0 +1,5 @@
+{% extends "std/base.html" %}
+
+{% block std_content %}
+{{ page.content | safe }}
+{% endblock %}

--- a/examples/gazette/templates/std/section.html
+++ b/examples/gazette/templates/std/section.html
@@ -1,0 +1,20 @@
+{% extends "std/base.html" %}
+
+{% block std_content %}
+<h1>{{ section.title }}</h1>
+
+{{ section.content | safe }}
+
+{% if section.pages %}
+<h2>Modules</h2>
+<ul class="spec-section-toc">
+    {% for page in section.pages %}
+    <li><a href="{{ page.path }}">{{ page.title }}</a></li>
+    {% endfor %}
+</ul>
+{% endif %}
+{% endblock %}
+
+{% block prev_next %}
+{# Section index doesn't have prev/next #}
+{% endblock %}

--- a/examples/gazette/templates/tutorial/base.html
+++ b/examples/gazette/templates/tutorial/base.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title | default(value=section.title) }} - Learn Rue{% endblock %}
+
+{% block content %}
+<div class="spec-layout">
+    {# Sidebar - reuses spec-sidebar styles #}
+    <aside class="spec-sidebar">
+        <div class="spec-sidebar-inner">
+            <div class="spec-sidebar-header">
+                <a href="{{ get_url(path='tutorial') }}" class="spec-title">Learn Rue</a>
+            </div>
+            <nav class="spec-nav">
+                {% set tutorial_section = get_section(path="tutorial/_index.md") %}
+                {% set current = page.permalink | default(value=section.permalink) | default(value="") %}
+                {{ self::render_nav(section=tutorial_section, current_path=current) }}
+            </nav>
+        </div>
+    </aside>
+
+    {# Main content #}
+    <div class="spec-main">
+        <article class="spec-content tutorial-content">
+            {% block tutorial_content %}{% endblock %}
+        </article>
+
+        {# Prev/Next navigation #}
+        {% block prev_next %}
+        <nav class="spec-page-nav">
+            {% if page.lower %}
+            <a href="{{ page.lower.permalink }}" class="spec-nav-prev">
+                <span class="spec-nav-label">Previous</span>
+                <span class="spec-nav-title">{{ page.lower.title }}</span>
+            </a>
+            {% else %}
+            <span></span>
+            {% endif %}
+            {% if page.higher %}
+            <a href="{{ page.higher.permalink }}" class="spec-nav-next">
+                <span class="spec-nav-label">Next</span>
+                <span class="spec-nav-title">{{ page.higher.title }}</span>
+            </a>
+            {% endif %}
+        </nav>
+        {% endblock %}
+    </div>
+</div>
+{% endblock %}
+
+{# Recursive macro for navigation #}
+{% macro render_nav(section, current_path) %}
+<ul class="spec-nav-list">
+    {% for pg in section.pages %}
+    <li class="spec-nav-item">
+        <a href="{{ pg.permalink }}" class="spec-nav-link {% if pg.permalink == current_path %}active{% endif %}">
+            {{ pg.title }}
+        </a>
+    </li>
+    {% endfor %}
+</ul>
+{% endmacro %}

--- a/examples/gazette/templates/tutorial/page.html
+++ b/examples/gazette/templates/tutorial/page.html
@@ -1,0 +1,5 @@
+{% extends "tutorial/base.html" %}
+
+{% block tutorial_content %}
+{{ page.content | safe }}
+{% endblock %}

--- a/examples/gazette/templates/tutorial/section.html
+++ b/examples/gazette/templates/tutorial/section.html
@@ -1,0 +1,20 @@
+{% extends "tutorial/base.html" %}
+
+{% block tutorial_content %}
+<h1>{{ section.title }}</h1>
+
+{{ section.content | safe }}
+
+{% if section.pages %}
+<h2>Chapters</h2>
+<ul class="spec-section-toc">
+    {% for page in section.pages %}
+    <li><a href="{{ page.path }}">{{ page.title }}</a></li>
+    {% endfor %}
+</ul>
+{% endif %}
+{% endblock %}
+
+{% block prev_next %}
+{# Section index doesn't have prev/next #}
+{% endblock %}

--- a/performance/fixtures/gazette/README.md
+++ b/performance/fixtures/gazette/README.md
@@ -1,0 +1,45 @@
+# gazette spot goldens
+
+ADR-0072 Decision 4 asks for "a small set of stable pages carrying committed
+expected output", covering the rendered markup-level form that the normalized
+semantic oracle deliberately ignores. This directory is that check.
+
+`site/` is a miniature Zola-shaped site — thirteen content files — and
+`expected/` is gazette's byte-exact output for it, built with gazette's real
+template port (`examples/gazette/templates/`) and real configuration
+(`examples/gazette/config.toml`).
+
+    scripts/gazette-corpus-diff.py golden            # compare
+    scripts/gazette-corpus-diff.py golden --bless    # rewrite after a
+                                                     # deliberate port change
+
+## Why a miniature site and not live corpus pages
+
+Decision 2 keeps the benchmark corpus deliberately unfrozen: it is the live
+rue-lang.dev content, and it changes with every blog post. A golden over a
+live page would therefore fail on every content change and be re-blessed
+rather than read, which is precisely the failure mode a golden exists to
+prevent — a check that is always red teaches its reader to bless it unseen.
+
+The miniature site is stable by construction and exercises the same templates,
+so the goldens stay sensitive to what they are actually for: a change in the
+template port, the escaping, the routing, or the feed shape. The live corpus is
+covered by the layers that tolerate its motion — determinism, the file set, the
+independently modelled section and feed ordering, and the semantic oracle
+against Zola, all in `scripts/gazette-corpus-diff.py site`.
+
+## What the miniature site is chosen to exercise
+
+Every template in the port, and every emitted file kind:
+
+- the recursive specification navigation **with an active branch**, which is
+  the fairness-critical construct: `spec/02-things/` is a subsection with two
+  pages, so a page inside it expands the sidebar that a page outside it leaves
+  collapsed. A nav that had been flattened host-side would render identically
+  on both, and this is where that shows up;
+- `redirect_to` on `spec/_index.md`, so the redirect stub is goldened;
+- `generate_feeds` on a `sort_by = "date"` section, so the feed and its
+  newest-first ordering are goldened;
+- `sort_by = "weight"` sections, prev/next neighbours, both shortcodes, a
+  `<!-- more -->` summary, a pipe table with an escaped cell, a multi-line
+  `prompt`, an `[extra]` author list, and a static asset.

--- a/performance/fixtures/gazette/expected/blog/first-note/index.html
+++ b/performance/fixtures/gazette/expected/blog/first-note/index.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>First Note | Lab Notes | Rue</title>
+    <meta name="description" content="A systems programming language with memory safety and high-level ergonomics">
+    <link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;style.css">
+    <link rel="icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;favicon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;brand&#x2F;apple-touch-icon.png">
+    <link rel="alternate" type="application/rss+xml" title="Rue Blog RSS" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog&#x2F;rss.xml">
+    <script>
+        // Check for saved theme preference or default to system preference
+        const isDark = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (isDark) {
+            document.documentElement.classList.add('dark');
+        }
+        // Write syntax theme stylesheets with correct initial disabled state
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-light.css" id="syntax-light"' + (isDark ? ' disabled' : '') + '>');
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-dark.css" id="syntax-dark"' + (isDark ? '' : ' disabled') + '>');
+
+        function updateSyntaxTheme() {
+            const syntaxLight = document.getElementById('syntax-light');
+            const syntaxDark = document.getElementById('syntax-dark');
+            if (syntaxLight && syntaxDark) {
+                const dark = document.documentElement.classList.contains('dark');
+                syntaxLight.disabled = dark;
+                syntaxDark.disabled = !dark;
+            }
+        }
+    </script>
+</head>
+<body class="min-h-screen flex flex-col">
+    <!-- engraved rue sprig (Ruta graveolens), referenced site-wide via <use> -->
+    <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+      <defs>
+        <g id="rue-sprig" fill="none" stroke="currentColor" stroke-width="1.5"
+           stroke-linecap="round" stroke-linejoin="round">
+          <path d="M16 30 C 16 24, 15.4 18, 16 10"/>
+          <path d="M15.7 22 C 12.5 20.5, 10 19, 8 16.5"/>
+          <path d="M8 16.5 c -2.6 -0.4 -4 -2.4 -3.4 -4.4 c 1.8 -1 4 -0.2 4.6 2 c 0.3 1 0 1.8 -1.2 2.4 z"/>
+          <path d="M11.5 19.2 c -2.4 0.6 -4.3 -0.6 -4.5 -2.6"/>
+          <path d="M16 17.5 C 19.5 16, 22 14.5, 23.8 12"/>
+          <path d="M23.8 12 c 2.6 -0.2 3.9 -2.2 3.2 -4.2 c -1.9 -0.9 -4 0.1 -4.4 2.3 c -0.2 1 0.1 1.7 1.2 1.9 z"/>
+          <path d="M20.4 14.6 c 2.4 0.4 4.2 -0.8 4.3 -2.8"/>
+          <path d="M16 10 c -0.4 -2.8 1 -4.6 3.2 -4.6 c 1.2 1.8 0.5 4 -1.6 4.9 c -0.7 0.3 -1.2 0.2 -1.6 -0.3 z"/>
+          <g stroke="none" fill="var(--color-gold)">
+            <circle cx="12.2" cy="7.4" r="1.15"/>
+            <circle cx="9.9"  cy="9.4" r="1.15"/>
+            <circle cx="12.6" cy="10.6" r="1.15"/>
+            <circle cx="14.4" cy="8.7" r="1.15"/>
+          </g>
+          <circle cx="12.4" cy="9" r="0.8" stroke="none" fill="currentColor"/>
+          <path d="M15.9 13.5 C 14.8 11.8, 13.6 10.6, 12.6 10.4"/>
+        </g>
+      </defs>
+    </svg>
+
+    <div class="colophon-bar">
+        <em>Ruta graveolens</em> &nbsp;·&nbsp; notes from a language experiment &nbsp;·&nbsp; cultivated since 2025
+    </div>
+
+    <nav>
+        <div class="masthead">
+            <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="wordmark">
+                <svg class="sprig" viewBox="0 0 32 32"><use href="#rue-sprig"/></svg>
+                Rue
+            </a>
+            <!-- Desktop navigation -->
+            <div class="nav-desktop flex items-center gap-6">
+                <ul class="flex gap-6">
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="nav-link">Tutorial</a></li>
+<!-- Hardcoded path: spec pages are copied into Zola content at build time -->
+                    <li><a href="/spec/" class="nav-link">Specification</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="nav-link">Performance</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="nav-link">Runtime</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="nav-link">Lab Notes</a></li>
+                    <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="nav-link ext">GitHub</a></li>
+                    <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="nav-link ext">Bluesky</a></li>
+                </ul>
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+            </div>
+            <!-- Mobile navigation controls -->
+            <div class="nav-mobile-controls flex items-center gap-4">
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+                <button onclick="toggleMobileMenu()" class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false">
+                    <svg class="icon-menu w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                    <svg class="icon-close w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+        <!-- Mobile menu overlay -->
+        <div id="mobile-menu" class="mobile-menu">
+            <ul class="mobile-menu-list">
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="mobile-menu-link">Home</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="mobile-menu-link">Tutorial</a></li>
+                <li><a href="/spec/" class="mobile-menu-link">Specification</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="mobile-menu-link">Performance</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="mobile-menu-link">Runtime</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="mobile-menu-link">Lab Notes</a></li>
+                <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="mobile-menu-link">GitHub</a></li>
+                <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="mobile-menu-link">Bluesky</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <main class="flex-1">
+        
+<article class="py-12">
+    <div class="max-w-3xl mx-auto px-6">
+        <header class="mb-8">
+            <h1 style="font-family: var(--font-display); font-weight: 460; font-size: 2.3rem; line-height: 1.15;" class="mb-3">First Note</h1>
+            <div class="text-muted flex flex-wrap gap-1" style="font-style: italic;">
+                <time datetime="2026-01-02" class="note-date" style="font-style: normal;">2026 · 01 · 02</time>
+                
+                <span class="before:content-['·'] before:mr-1">
+                    by <a href="https://steveklabnik.com">Steve</a> and <a href="https://claude.ai">Claude</a>
+                </span>
+                
+            </div>
+            
+            <details class="mt-4 prompt-details">
+                <summary class="text-muted cursor-pointer hover:text-fg select-none">View the prompt</summary>
+                <div class="mt-3 p-4 bg-surface border border-themed rounded-lg">
+                    <pre class="whitespace-pre-wrap text-sm m-0! p-0! bg-transparent! border-none!">write the first note
+</pre>
+                </div>
+            </details>
+            
+        </header>
+        <div class="prose">
+            <p>An opening paragraph with <strong>strong</strong> text and a <code>code span</code>.</p>
+<span id="continue-reading"></span>
+<p>The rest of the note, with an <a href="https://rue-lang.dev/spec/01-introduction/#scope">internal link</a>
+and an <a href="https://example.test/x">external one</a>.</p>
+
+        </div>
+    </div>
+</article>
+
+    </main>
+
+    <footer class="footer-colophon">
+        <div class="inner">
+            <span>© 2025–2026 The Rue Authors · MIT/Apache-2.0</span>
+            <span><em>rue</em>, n. — a hardy evergreen herb; also, what we hope you won’t do after choosing this language.</span>
+        </div>
+    </footer>
+
+    <script>
+        function toggleTheme() {
+            if (document.documentElement.classList.contains('dark')) {
+                document.documentElement.classList.remove('dark');
+                localStorage.theme = 'light';
+            } else {
+                document.documentElement.classList.add('dark');
+                localStorage.theme = 'dark';
+            }
+            updateSyntaxTheme();
+        }
+
+        function toggleMobileMenu() {
+            const menu = document.getElementById('mobile-menu');
+            const toggle = document.querySelector('.mobile-menu-toggle');
+            const isOpen = menu.classList.toggle('open');
+            toggle.classList.toggle('active', isOpen);
+            toggle.setAttribute('aria-expanded', isOpen);
+        }
+
+        // Close mobile menu when clicking a link
+        document.querySelectorAll('.mobile-menu-link').forEach(link => {
+            link.addEventListener('click', () => {
+                const menu = document.getElementById('mobile-menu');
+                const toggle = document.querySelector('.mobile-menu-toggle');
+                menu.classList.remove('open');
+                toggle.classList.remove('active');
+                toggle.setAttribute('aria-expanded', 'false');
+            });
+        });
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/elasticlunr/0.9.5/elasticlunr.min.js"></script>
+    <script src="https:&#x2F;&#x2F;rue-lang.dev&#x2F;search.js"></script>
+</body>
+</html>

--- a/performance/fixtures/gazette/expected/blog/index.html
+++ b/performance/fixtures/gazette/expected/blog/index.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Lab Notes | Rue</title>
+    <meta name="description" content="A systems programming language with memory safety and high-level ergonomics">
+    <link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;style.css">
+    <link rel="icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;favicon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;brand&#x2F;apple-touch-icon.png">
+    <link rel="alternate" type="application/rss+xml" title="Rue Blog RSS" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog&#x2F;rss.xml">
+    <script>
+        // Check for saved theme preference or default to system preference
+        const isDark = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (isDark) {
+            document.documentElement.classList.add('dark');
+        }
+        // Write syntax theme stylesheets with correct initial disabled state
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-light.css" id="syntax-light"' + (isDark ? ' disabled' : '') + '>');
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-dark.css" id="syntax-dark"' + (isDark ? '' : ' disabled') + '>');
+
+        function updateSyntaxTheme() {
+            const syntaxLight = document.getElementById('syntax-light');
+            const syntaxDark = document.getElementById('syntax-dark');
+            if (syntaxLight && syntaxDark) {
+                const dark = document.documentElement.classList.contains('dark');
+                syntaxLight.disabled = dark;
+                syntaxDark.disabled = !dark;
+            }
+        }
+    </script>
+</head>
+<body class="min-h-screen flex flex-col">
+    <!-- engraved rue sprig (Ruta graveolens), referenced site-wide via <use> -->
+    <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+      <defs>
+        <g id="rue-sprig" fill="none" stroke="currentColor" stroke-width="1.5"
+           stroke-linecap="round" stroke-linejoin="round">
+          <path d="M16 30 C 16 24, 15.4 18, 16 10"/>
+          <path d="M15.7 22 C 12.5 20.5, 10 19, 8 16.5"/>
+          <path d="M8 16.5 c -2.6 -0.4 -4 -2.4 -3.4 -4.4 c 1.8 -1 4 -0.2 4.6 2 c 0.3 1 0 1.8 -1.2 2.4 z"/>
+          <path d="M11.5 19.2 c -2.4 0.6 -4.3 -0.6 -4.5 -2.6"/>
+          <path d="M16 17.5 C 19.5 16, 22 14.5, 23.8 12"/>
+          <path d="M23.8 12 c 2.6 -0.2 3.9 -2.2 3.2 -4.2 c -1.9 -0.9 -4 0.1 -4.4 2.3 c -0.2 1 0.1 1.7 1.2 1.9 z"/>
+          <path d="M20.4 14.6 c 2.4 0.4 4.2 -0.8 4.3 -2.8"/>
+          <path d="M16 10 c -0.4 -2.8 1 -4.6 3.2 -4.6 c 1.2 1.8 0.5 4 -1.6 4.9 c -0.7 0.3 -1.2 0.2 -1.6 -0.3 z"/>
+          <g stroke="none" fill="var(--color-gold)">
+            <circle cx="12.2" cy="7.4" r="1.15"/>
+            <circle cx="9.9"  cy="9.4" r="1.15"/>
+            <circle cx="12.6" cy="10.6" r="1.15"/>
+            <circle cx="14.4" cy="8.7" r="1.15"/>
+          </g>
+          <circle cx="12.4" cy="9" r="0.8" stroke="none" fill="currentColor"/>
+          <path d="M15.9 13.5 C 14.8 11.8, 13.6 10.6, 12.6 10.4"/>
+        </g>
+      </defs>
+    </svg>
+
+    <div class="colophon-bar">
+        <em>Ruta graveolens</em> &nbsp;·&nbsp; notes from a language experiment &nbsp;·&nbsp; cultivated since 2025
+    </div>
+
+    <nav>
+        <div class="masthead">
+            <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="wordmark">
+                <svg class="sprig" viewBox="0 0 32 32"><use href="#rue-sprig"/></svg>
+                Rue
+            </a>
+            <!-- Desktop navigation -->
+            <div class="nav-desktop flex items-center gap-6">
+                <ul class="flex gap-6">
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="nav-link">Tutorial</a></li>
+<!-- Hardcoded path: spec pages are copied into Zola content at build time -->
+                    <li><a href="/spec/" class="nav-link">Specification</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="nav-link">Performance</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="nav-link">Runtime</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="nav-link">Lab Notes</a></li>
+                    <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="nav-link ext">GitHub</a></li>
+                    <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="nav-link ext">Bluesky</a></li>
+                </ul>
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+            </div>
+            <!-- Mobile navigation controls -->
+            <div class="nav-mobile-controls flex items-center gap-4">
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+                <button onclick="toggleMobileMenu()" class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false">
+                    <svg class="icon-menu w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                    <svg class="icon-close w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+        <!-- Mobile menu overlay -->
+        <div id="mobile-menu" class="mobile-menu">
+            <ul class="mobile-menu-list">
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="mobile-menu-link">Home</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="mobile-menu-link">Tutorial</a></li>
+                <li><a href="/spec/" class="mobile-menu-link">Specification</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="mobile-menu-link">Performance</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="mobile-menu-link">Runtime</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="mobile-menu-link">Lab Notes</a></li>
+                <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="mobile-menu-link">GitHub</a></li>
+                <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="mobile-menu-link">Bluesky</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <main class="flex-1">
+        
+<section class="py-12">
+    <div class="max-w-3xl mx-auto px-6">
+        <header class="mb-10">
+            <h1 style="font-family: var(--font-display); font-weight: 460; font-size: 2.3rem;" class="mb-2">Lab Notes</h1>
+            <p class="text-muted mb-4" style="font-style: italic;"><p>Field notes, in miniature.</p>
+</p>
+            <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog&#x2F;rss.xml" class="inline-flex items-center gap-2 text-muted text-sm hover:text-[var(--color-accent)]">
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                    <circle cx="6.18" cy="17.82" r="2.18"/>
+                    <path d="M4 4.44v2.83c7.03 0 12.73 5.7 12.73 12.73h2.83c0-8.59-6.97-15.56-15.56-15.56zm0 5.66v2.83c3.9 0 7.07 3.17 7.07 7.07h2.83c0-5.47-4.43-9.9-9.9-9.9z"/>
+                </svg>
+                RSS Feed
+            </a>
+        </header>
+
+        <ul class="note-list">
+            
+            <li>
+                <span class="note-date"><time datetime="2026-02-03">2026 · 02 · 03</time></span>
+                <div>
+                    <a class="note-title" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog&#x2F;second-note&#x2F;">Second Note</a>
+                    
+                    <span class="text-faint text-sm" style="font-style: italic;">
+                        — Codex
+                    </span>
+                    
+                    
+                </div>
+            </li>
+            
+            <li>
+                <span class="note-date"><time datetime="2026-01-02">2026 · 01 · 02</time></span>
+                <div>
+                    <a class="note-title" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog&#x2F;first-note&#x2F;">First Note</a>
+                    
+                    <span class="text-faint text-sm" style="font-style: italic;">
+                        — Steve and Claude
+                    </span>
+                    
+                    
+                    <p class="note-summary"><p>An opening paragraph with <strong>strong</strong> text and a <code>code span</code>.</p>
+</p>
+                    
+                </div>
+            </li>
+            
+        </ul>
+    </div>
+</section>
+
+    </main>
+
+    <footer class="footer-colophon">
+        <div class="inner">
+            <span>© 2025–2026 The Rue Authors · MIT/Apache-2.0</span>
+            <span><em>rue</em>, n. — a hardy evergreen herb; also, what we hope you won’t do after choosing this language.</span>
+        </div>
+    </footer>
+
+    <script>
+        function toggleTheme() {
+            if (document.documentElement.classList.contains('dark')) {
+                document.documentElement.classList.remove('dark');
+                localStorage.theme = 'light';
+            } else {
+                document.documentElement.classList.add('dark');
+                localStorage.theme = 'dark';
+            }
+            updateSyntaxTheme();
+        }
+
+        function toggleMobileMenu() {
+            const menu = document.getElementById('mobile-menu');
+            const toggle = document.querySelector('.mobile-menu-toggle');
+            const isOpen = menu.classList.toggle('open');
+            toggle.classList.toggle('active', isOpen);
+            toggle.setAttribute('aria-expanded', isOpen);
+        }
+
+        // Close mobile menu when clicking a link
+        document.querySelectorAll('.mobile-menu-link').forEach(link => {
+            link.addEventListener('click', () => {
+                const menu = document.getElementById('mobile-menu');
+                const toggle = document.querySelector('.mobile-menu-toggle');
+                menu.classList.remove('open');
+                toggle.classList.remove('active');
+                toggle.setAttribute('aria-expanded', 'false');
+            });
+        });
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/elasticlunr/0.9.5/elasticlunr.min.js"></script>
+    <script src="https:&#x2F;&#x2F;rue-lang.dev&#x2F;search.js"></script>
+</body>
+</html>

--- a/performance/fixtures/gazette/expected/blog/rss.xml
+++ b/performance/fixtures/gazette/expected/blog/rss.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+        <title>Rue</title>
+        <link>https://rue-lang.dev/blog/</link>
+        <description>A systems programming language with memory safety and high-level ergonomics</description>
+        <language>en</language>
+        <atom:link href="https://rue-lang.dev/blog/rss.xml" rel="self" type="application/rss+xml"/>
+        <item>
+            <title>Second Note</title>
+            <pubDate>2026-02-03</pubDate>
+            <link>https://rue-lang.dev/blog/second-note/</link>
+            <guid>https://rue-lang.dev/blog/second-note/</guid>
+            <description></description>
+        </item>
+        <item>
+            <title>First Note</title>
+            <pubDate>2026-01-02</pubDate>
+            <link>https://rue-lang.dev/blog/first-note/</link>
+            <guid>https://rue-lang.dev/blog/first-note/</guid>
+            <description>the earlier post</description>
+        </item>
+    </channel>
+</rss>

--- a/performance/fixtures/gazette/expected/blog/second-note/index.html
+++ b/performance/fixtures/gazette/expected/blog/second-note/index.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Second Note | Lab Notes | Rue</title>
+    <meta name="description" content="A systems programming language with memory safety and high-level ergonomics">
+    <link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;style.css">
+    <link rel="icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;favicon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;brand&#x2F;apple-touch-icon.png">
+    <link rel="alternate" type="application/rss+xml" title="Rue Blog RSS" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog&#x2F;rss.xml">
+    <script>
+        // Check for saved theme preference or default to system preference
+        const isDark = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (isDark) {
+            document.documentElement.classList.add('dark');
+        }
+        // Write syntax theme stylesheets with correct initial disabled state
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-light.css" id="syntax-light"' + (isDark ? ' disabled' : '') + '>');
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-dark.css" id="syntax-dark"' + (isDark ? '' : ' disabled') + '>');
+
+        function updateSyntaxTheme() {
+            const syntaxLight = document.getElementById('syntax-light');
+            const syntaxDark = document.getElementById('syntax-dark');
+            if (syntaxLight && syntaxDark) {
+                const dark = document.documentElement.classList.contains('dark');
+                syntaxLight.disabled = dark;
+                syntaxDark.disabled = !dark;
+            }
+        }
+    </script>
+</head>
+<body class="min-h-screen flex flex-col">
+    <!-- engraved rue sprig (Ruta graveolens), referenced site-wide via <use> -->
+    <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+      <defs>
+        <g id="rue-sprig" fill="none" stroke="currentColor" stroke-width="1.5"
+           stroke-linecap="round" stroke-linejoin="round">
+          <path d="M16 30 C 16 24, 15.4 18, 16 10"/>
+          <path d="M15.7 22 C 12.5 20.5, 10 19, 8 16.5"/>
+          <path d="M8 16.5 c -2.6 -0.4 -4 -2.4 -3.4 -4.4 c 1.8 -1 4 -0.2 4.6 2 c 0.3 1 0 1.8 -1.2 2.4 z"/>
+          <path d="M11.5 19.2 c -2.4 0.6 -4.3 -0.6 -4.5 -2.6"/>
+          <path d="M16 17.5 C 19.5 16, 22 14.5, 23.8 12"/>
+          <path d="M23.8 12 c 2.6 -0.2 3.9 -2.2 3.2 -4.2 c -1.9 -0.9 -4 0.1 -4.4 2.3 c -0.2 1 0.1 1.7 1.2 1.9 z"/>
+          <path d="M20.4 14.6 c 2.4 0.4 4.2 -0.8 4.3 -2.8"/>
+          <path d="M16 10 c -0.4 -2.8 1 -4.6 3.2 -4.6 c 1.2 1.8 0.5 4 -1.6 4.9 c -0.7 0.3 -1.2 0.2 -1.6 -0.3 z"/>
+          <g stroke="none" fill="var(--color-gold)">
+            <circle cx="12.2" cy="7.4" r="1.15"/>
+            <circle cx="9.9"  cy="9.4" r="1.15"/>
+            <circle cx="12.6" cy="10.6" r="1.15"/>
+            <circle cx="14.4" cy="8.7" r="1.15"/>
+          </g>
+          <circle cx="12.4" cy="9" r="0.8" stroke="none" fill="currentColor"/>
+          <path d="M15.9 13.5 C 14.8 11.8, 13.6 10.6, 12.6 10.4"/>
+        </g>
+      </defs>
+    </svg>
+
+    <div class="colophon-bar">
+        <em>Ruta graveolens</em> &nbsp;·&nbsp; notes from a language experiment &nbsp;·&nbsp; cultivated since 2025
+    </div>
+
+    <nav>
+        <div class="masthead">
+            <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="wordmark">
+                <svg class="sprig" viewBox="0 0 32 32"><use href="#rue-sprig"/></svg>
+                Rue
+            </a>
+            <!-- Desktop navigation -->
+            <div class="nav-desktop flex items-center gap-6">
+                <ul class="flex gap-6">
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="nav-link">Tutorial</a></li>
+<!-- Hardcoded path: spec pages are copied into Zola content at build time -->
+                    <li><a href="/spec/" class="nav-link">Specification</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="nav-link">Performance</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="nav-link">Runtime</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="nav-link">Lab Notes</a></li>
+                    <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="nav-link ext">GitHub</a></li>
+                    <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="nav-link ext">Bluesky</a></li>
+                </ul>
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+            </div>
+            <!-- Mobile navigation controls -->
+            <div class="nav-mobile-controls flex items-center gap-4">
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+                <button onclick="toggleMobileMenu()" class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false">
+                    <svg class="icon-menu w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                    <svg class="icon-close w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+        <!-- Mobile menu overlay -->
+        <div id="mobile-menu" class="mobile-menu">
+            <ul class="mobile-menu-list">
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="mobile-menu-link">Home</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="mobile-menu-link">Tutorial</a></li>
+                <li><a href="/spec/" class="mobile-menu-link">Specification</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="mobile-menu-link">Performance</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="mobile-menu-link">Runtime</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="mobile-menu-link">Lab Notes</a></li>
+                <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="mobile-menu-link">GitHub</a></li>
+                <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="mobile-menu-link">Bluesky</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <main class="flex-1">
+        
+<article class="py-12">
+    <div class="max-w-3xl mx-auto px-6">
+        <header class="mb-8">
+            <h1 style="font-family: var(--font-display); font-weight: 460; font-size: 2.3rem; line-height: 1.15;" class="mb-3">Second Note</h1>
+            <div class="text-muted flex flex-wrap gap-1" style="font-style: italic;">
+                <time datetime="2026-02-03" class="note-date" style="font-style: normal;">2026 · 02 · 03</time>
+                
+                <span class="before:content-['·'] before:mr-1">
+                    by <a href="https://openai.com/codex/">Codex</a>
+                </span>
+                
+            </div>
+            
+        </header>
+        <div class="prose">
+            <table><thead><tr><th>Column</th><th>Meaning</th></tr></thead><tbody>
+<tr><td><code>a</code></td><td>first</td></tr>
+<tr><td><code>|</code></td><td>a pipe</td></tr>
+</tbody></table>
+<ul>
+<li>one</li>
+<li>two</li>
+</ul>
+<blockquote>
+<p>quoted</p>
+</blockquote>
+
+        </div>
+    </div>
+</article>
+
+    </main>
+
+    <footer class="footer-colophon">
+        <div class="inner">
+            <span>© 2025–2026 The Rue Authors · MIT/Apache-2.0</span>
+            <span><em>rue</em>, n. — a hardy evergreen herb; also, what we hope you won’t do after choosing this language.</span>
+        </div>
+    </footer>
+
+    <script>
+        function toggleTheme() {
+            if (document.documentElement.classList.contains('dark')) {
+                document.documentElement.classList.remove('dark');
+                localStorage.theme = 'light';
+            } else {
+                document.documentElement.classList.add('dark');
+                localStorage.theme = 'dark';
+            }
+            updateSyntaxTheme();
+        }
+
+        function toggleMobileMenu() {
+            const menu = document.getElementById('mobile-menu');
+            const toggle = document.querySelector('.mobile-menu-toggle');
+            const isOpen = menu.classList.toggle('open');
+            toggle.classList.toggle('active', isOpen);
+            toggle.setAttribute('aria-expanded', isOpen);
+        }
+
+        // Close mobile menu when clicking a link
+        document.querySelectorAll('.mobile-menu-link').forEach(link => {
+            link.addEventListener('click', () => {
+                const menu = document.getElementById('mobile-menu');
+                const toggle = document.querySelector('.mobile-menu-toggle');
+                menu.classList.remove('open');
+                toggle.classList.remove('active');
+                toggle.setAttribute('aria-expanded', 'false');
+            });
+        });
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/elasticlunr/0.9.5/elasticlunr.min.js"></script>
+    <script src="https:&#x2F;&#x2F;rue-lang.dev&#x2F;search.js"></script>
+</body>
+</html>

--- a/performance/fixtures/gazette/expected/index.html
+++ b/performance/fixtures/gazette/expected/index.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Rue</title>
+    <meta name="description" content="A systems programming language with memory safety and high-level ergonomics">
+    <link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;style.css">
+    <link rel="icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;favicon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;brand&#x2F;apple-touch-icon.png">
+    <link rel="alternate" type="application/rss+xml" title="Rue Blog RSS" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog&#x2F;rss.xml">
+    <script>
+        // Check for saved theme preference or default to system preference
+        const isDark = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (isDark) {
+            document.documentElement.classList.add('dark');
+        }
+        // Write syntax theme stylesheets with correct initial disabled state
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-light.css" id="syntax-light"' + (isDark ? ' disabled' : '') + '>');
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-dark.css" id="syntax-dark"' + (isDark ? '' : ' disabled') + '>');
+
+        function updateSyntaxTheme() {
+            const syntaxLight = document.getElementById('syntax-light');
+            const syntaxDark = document.getElementById('syntax-dark');
+            if (syntaxLight && syntaxDark) {
+                const dark = document.documentElement.classList.contains('dark');
+                syntaxLight.disabled = dark;
+                syntaxDark.disabled = !dark;
+            }
+        }
+    </script>
+</head>
+<body class="min-h-screen flex flex-col">
+    <!-- engraved rue sprig (Ruta graveolens), referenced site-wide via <use> -->
+    <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+      <defs>
+        <g id="rue-sprig" fill="none" stroke="currentColor" stroke-width="1.5"
+           stroke-linecap="round" stroke-linejoin="round">
+          <path d="M16 30 C 16 24, 15.4 18, 16 10"/>
+          <path d="M15.7 22 C 12.5 20.5, 10 19, 8 16.5"/>
+          <path d="M8 16.5 c -2.6 -0.4 -4 -2.4 -3.4 -4.4 c 1.8 -1 4 -0.2 4.6 2 c 0.3 1 0 1.8 -1.2 2.4 z"/>
+          <path d="M11.5 19.2 c -2.4 0.6 -4.3 -0.6 -4.5 -2.6"/>
+          <path d="M16 17.5 C 19.5 16, 22 14.5, 23.8 12"/>
+          <path d="M23.8 12 c 2.6 -0.2 3.9 -2.2 3.2 -4.2 c -1.9 -0.9 -4 0.1 -4.4 2.3 c -0.2 1 0.1 1.7 1.2 1.9 z"/>
+          <path d="M20.4 14.6 c 2.4 0.4 4.2 -0.8 4.3 -2.8"/>
+          <path d="M16 10 c -0.4 -2.8 1 -4.6 3.2 -4.6 c 1.2 1.8 0.5 4 -1.6 4.9 c -0.7 0.3 -1.2 0.2 -1.6 -0.3 z"/>
+          <g stroke="none" fill="var(--color-gold)">
+            <circle cx="12.2" cy="7.4" r="1.15"/>
+            <circle cx="9.9"  cy="9.4" r="1.15"/>
+            <circle cx="12.6" cy="10.6" r="1.15"/>
+            <circle cx="14.4" cy="8.7" r="1.15"/>
+          </g>
+          <circle cx="12.4" cy="9" r="0.8" stroke="none" fill="currentColor"/>
+          <path d="M15.9 13.5 C 14.8 11.8, 13.6 10.6, 12.6 10.4"/>
+        </g>
+      </defs>
+    </svg>
+
+    <div class="colophon-bar">
+        <em>Ruta graveolens</em> &nbsp;·&nbsp; notes from a language experiment &nbsp;·&nbsp; cultivated since 2025
+    </div>
+
+    <nav>
+        <div class="masthead">
+            <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="wordmark">
+                <svg class="sprig" viewBox="0 0 32 32"><use href="#rue-sprig"/></svg>
+                Rue
+            </a>
+            <!-- Desktop navigation -->
+            <div class="nav-desktop flex items-center gap-6">
+                <ul class="flex gap-6">
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="nav-link">Tutorial</a></li>
+<!-- Hardcoded path: spec pages are copied into Zola content at build time -->
+                    <li><a href="/spec/" class="nav-link">Specification</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="nav-link">Performance</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="nav-link">Runtime</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="nav-link">Lab Notes</a></li>
+                    <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="nav-link ext">GitHub</a></li>
+                    <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="nav-link ext">Bluesky</a></li>
+                </ul>
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+            </div>
+            <!-- Mobile navigation controls -->
+            <div class="nav-mobile-controls flex items-center gap-4">
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+                <button onclick="toggleMobileMenu()" class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false">
+                    <svg class="icon-menu w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                    <svg class="icon-close w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+        <!-- Mobile menu overlay -->
+        <div id="mobile-menu" class="mobile-menu">
+            <ul class="mobile-menu-list">
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="mobile-menu-link">Home</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="mobile-menu-link">Tutorial</a></li>
+                <li><a href="/spec/" class="mobile-menu-link">Specification</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="mobile-menu-link">Performance</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="mobile-menu-link">Runtime</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="mobile-menu-link">Lab Notes</a></li>
+                <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="mobile-menu-link">GitHub</a></li>
+                <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="mobile-menu-link">Bluesky</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <main class="flex-1">
+        
+<section class="hero max-w-5xl mx-auto px-6 pt-14 pb-12 grid grid-cols-1 md:grid-cols-12 gap-12 items-start">
+    <div class="md:col-span-7 reveal d1">
+        <h1 style="font-family: var(--font-display); font-weight: 420; font-size: clamp(2.1rem, 4.6vw, 3.2rem); line-height: 1.12; letter-spacing: -0.01em;" class="mb-6">
+            Rust proved memory safety without garbage collection is possible.<br>
+            <em style="font-weight: 460; color: var(--color-accent);">Can it also be easy?</em>
+        </h1>
+        <p class="text-lg mb-4" style="color: var(--color-muted); max-width: 30rem;">
+            <strong style="color: var(--color-fg);">We don’t know yet.</strong>
+            Rue is an early-stage research language exploring that question — a
+            systems language aiming for the same destination by a gentler path.
+            It is not ready for real projects, but the whole experiment runs in
+            the open, and you can watch.
+        </p>
+        <p class="mb-8" style="font-style: italic; color: var(--color-faint); max-width: 30rem; font-size: 0.95rem;">
+            Designed by <a href="https://steveklabnik.com" style="color: inherit;">Steve Klabnik</a>.
+            Implemented primarily by Claude, an AI. The field report is an
+            illustrative preview while live project reporting is rebuilt.
+        </p>
+        <div class="flex gap-4 flex-wrap">
+            <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="btn-primary">Begin the tutorial</a>
+<!-- Hardcoded path: spec pages are copied into Zola content at build time -->
+            <a href="/spec/" class="btn-secondary">Read the spec</a>
+        </div>
+    </div>
+</section>
+
+<section class="max-w-5xl mx-auto px-6 pb-14 grid grid-cols-1 md:grid-cols-12 gap-12 items-start">
+    <figure class="md:col-span-7 reveal d2" style="margin: 0;">
+        <div class="specimen">
+            <div class="specimen-head">
+                <span class="no">Specimen №&thinsp;1</span>
+                <span>fib.rue</span>
+            </div>
+            <pre><code class="language-rue">fn main() -&gt; i32 { 0 }
+</code></pre>
+
+        </div>
+        <figcaption class="specimen-caption">
+            <b>Fig. 1.</b> Compiles to a small static binary.
+            No VM, no interpreter, no garbage collector.
+        </figcaption>
+    </figure>
+
+    <div class="md:col-span-5 reveal d3">
+        <h3 style="font-family: var(--font-display); font-weight: 480; font-size: 1.5rem;" class="mb-3">
+            Familiar on the surface, careful underneath.
+        </h3>
+        <p class="mb-4" style="color: var(--color-muted); font-size: 0.98rem;">
+            If you know Rust, Go, or C, the syntax will feel like home. Underneath,
+            Rue is exploring linear types, compile-time evaluation, and drop
+            tracking — the machinery of memory safety — while trying to keep the
+            learning curve shallow enough to walk up, not climb.
+        </p>
+        <p class="mb-5" style="color: var(--color-muted); font-size: 0.98rem;">
+            The compiler is written in Rust and emits x86-64 and ARM64 machine
+            code directly: no LLVM, direct syscalls, static ELF and Mach-O
+            executables.
+        </p>
+        <div class="run-line"><span class="prompt">$</span> rue fib.rue -o fib && ./fib</div>
+    </div>
+</section>
+
+<div class="sprig-divider" role="presentation">
+    <svg viewBox="0 0 32 32"><use href="#rue-sprig"/></svg>
+</div>
+
+<section class="max-w-5xl mx-auto px-6 pt-12 pb-14">
+    <h2 class="section-title">Recent lab notes</h2>
+    
+    <ul class="note-list">
+        
+        <li>
+            <span class="note-date">2026 · 02 · 03</span>
+            <div>
+                <a class="note-title" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog&#x2F;second-note&#x2F;">Second Note</a>
+                
+            </div>
+        </li>
+        
+        <li>
+            <span class="note-date">2026 · 01 · 02</span>
+            <div>
+                <a class="note-title" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog&#x2F;first-note&#x2F;">First Note</a>
+                
+                <p class="note-summary">the earlier post</p>
+                
+            </div>
+        </li>
+        
+    </ul>
+    <p class="mt-6" style="font-size: 0.9rem;"><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog">All lab notes →</a></p>
+</section>
+
+    </main>
+
+    <footer class="footer-colophon">
+        <div class="inner">
+            <span>© 2025–2026 The Rue Authors · MIT/Apache-2.0</span>
+            <span><em>rue</em>, n. — a hardy evergreen herb; also, what we hope you won’t do after choosing this language.</span>
+        </div>
+    </footer>
+
+    <script>
+        function toggleTheme() {
+            if (document.documentElement.classList.contains('dark')) {
+                document.documentElement.classList.remove('dark');
+                localStorage.theme = 'light';
+            } else {
+                document.documentElement.classList.add('dark');
+                localStorage.theme = 'dark';
+            }
+            updateSyntaxTheme();
+        }
+
+        function toggleMobileMenu() {
+            const menu = document.getElementById('mobile-menu');
+            const toggle = document.querySelector('.mobile-menu-toggle');
+            const isOpen = menu.classList.toggle('open');
+            toggle.classList.toggle('active', isOpen);
+            toggle.setAttribute('aria-expanded', isOpen);
+        }
+
+        // Close mobile menu when clicking a link
+        document.querySelectorAll('.mobile-menu-link').forEach(link => {
+            link.addEventListener('click', () => {
+                const menu = document.getElementById('mobile-menu');
+                const toggle = document.querySelector('.mobile-menu-toggle');
+                menu.classList.remove('open');
+                toggle.classList.remove('active');
+                toggle.setAttribute('aria-expanded', 'false');
+            });
+        });
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/elasticlunr/0.9.5/elasticlunr.min.js"></script>
+    <script src="https:&#x2F;&#x2F;rue-lang.dev&#x2F;search.js"></script>
+</body>
+</html>

--- a/performance/fixtures/gazette/expected/marker.txt
+++ b/performance/fixtures/gazette/expected/marker.txt
@@ -1,0 +1,2 @@
+Static passthrough is measured work for every tool in ADR-0072's comparison,
+so the miniature site carries an asset to prove gazette copies one.

--- a/performance/fixtures/gazette/expected/spec/01-introduction/index.html
+++ b/performance/fixtures/gazette/expected/spec/01-introduction/index.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Introduction - Rue Language Specification</title>
+    <meta name="description" content="A systems programming language with memory safety and high-level ergonomics">
+    <link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;style.css">
+    <link rel="icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;favicon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;brand&#x2F;apple-touch-icon.png">
+    <link rel="alternate" type="application/rss+xml" title="Rue Blog RSS" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog&#x2F;rss.xml">
+    <script>
+        // Check for saved theme preference or default to system preference
+        const isDark = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (isDark) {
+            document.documentElement.classList.add('dark');
+        }
+        // Write syntax theme stylesheets with correct initial disabled state
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-light.css" id="syntax-light"' + (isDark ? ' disabled' : '') + '>');
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-dark.css" id="syntax-dark"' + (isDark ? '' : ' disabled') + '>');
+
+        function updateSyntaxTheme() {
+            const syntaxLight = document.getElementById('syntax-light');
+            const syntaxDark = document.getElementById('syntax-dark');
+            if (syntaxLight && syntaxDark) {
+                const dark = document.documentElement.classList.contains('dark');
+                syntaxLight.disabled = dark;
+                syntaxDark.disabled = !dark;
+            }
+        }
+    </script>
+</head>
+<body class="min-h-screen flex flex-col">
+    <!-- engraved rue sprig (Ruta graveolens), referenced site-wide via <use> -->
+    <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+      <defs>
+        <g id="rue-sprig" fill="none" stroke="currentColor" stroke-width="1.5"
+           stroke-linecap="round" stroke-linejoin="round">
+          <path d="M16 30 C 16 24, 15.4 18, 16 10"/>
+          <path d="M15.7 22 C 12.5 20.5, 10 19, 8 16.5"/>
+          <path d="M8 16.5 c -2.6 -0.4 -4 -2.4 -3.4 -4.4 c 1.8 -1 4 -0.2 4.6 2 c 0.3 1 0 1.8 -1.2 2.4 z"/>
+          <path d="M11.5 19.2 c -2.4 0.6 -4.3 -0.6 -4.5 -2.6"/>
+          <path d="M16 17.5 C 19.5 16, 22 14.5, 23.8 12"/>
+          <path d="M23.8 12 c 2.6 -0.2 3.9 -2.2 3.2 -4.2 c -1.9 -0.9 -4 0.1 -4.4 2.3 c -0.2 1 0.1 1.7 1.2 1.9 z"/>
+          <path d="M20.4 14.6 c 2.4 0.4 4.2 -0.8 4.3 -2.8"/>
+          <path d="M16 10 c -0.4 -2.8 1 -4.6 3.2 -4.6 c 1.2 1.8 0.5 4 -1.6 4.9 c -0.7 0.3 -1.2 0.2 -1.6 -0.3 z"/>
+          <g stroke="none" fill="var(--color-gold)">
+            <circle cx="12.2" cy="7.4" r="1.15"/>
+            <circle cx="9.9"  cy="9.4" r="1.15"/>
+            <circle cx="12.6" cy="10.6" r="1.15"/>
+            <circle cx="14.4" cy="8.7" r="1.15"/>
+          </g>
+          <circle cx="12.4" cy="9" r="0.8" stroke="none" fill="currentColor"/>
+          <path d="M15.9 13.5 C 14.8 11.8, 13.6 10.6, 12.6 10.4"/>
+        </g>
+      </defs>
+    </svg>
+
+    <div class="colophon-bar">
+        <em>Ruta graveolens</em> &nbsp;·&nbsp; notes from a language experiment &nbsp;·&nbsp; cultivated since 2025
+    </div>
+
+    <nav>
+        <div class="masthead">
+            <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="wordmark">
+                <svg class="sprig" viewBox="0 0 32 32"><use href="#rue-sprig"/></svg>
+                Rue
+            </a>
+            <!-- Desktop navigation -->
+            <div class="nav-desktop flex items-center gap-6">
+                <ul class="flex gap-6">
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="nav-link">Tutorial</a></li>
+<!-- Hardcoded path: spec pages are copied into Zola content at build time -->
+                    <li><a href="/spec/" class="nav-link">Specification</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="nav-link">Performance</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="nav-link">Runtime</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="nav-link">Lab Notes</a></li>
+                    <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="nav-link ext">GitHub</a></li>
+                    <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="nav-link ext">Bluesky</a></li>
+                </ul>
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+            </div>
+            <!-- Mobile navigation controls -->
+            <div class="nav-mobile-controls flex items-center gap-4">
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+                <button onclick="toggleMobileMenu()" class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false">
+                    <svg class="icon-menu w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                    <svg class="icon-close w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+        <!-- Mobile menu overlay -->
+        <div id="mobile-menu" class="mobile-menu">
+            <ul class="mobile-menu-list">
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="mobile-menu-link">Home</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="mobile-menu-link">Tutorial</a></li>
+                <li><a href="/spec/" class="mobile-menu-link">Specification</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="mobile-menu-link">Performance</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="mobile-menu-link">Runtime</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="mobile-menu-link">Lab Notes</a></li>
+                <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="mobile-menu-link">GitHub</a></li>
+                <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="mobile-menu-link">Bluesky</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <main class="flex-1">
+        
+<div class="spec-layout">
+    
+    <aside class="spec-sidebar">
+        <div class="spec-sidebar-inner">
+            <div class="spec-sidebar-header">
+                <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;spec" class="spec-title">Rue Specification</a>
+            </div>
+            <div class="spec-search">
+                <div class="spec-search-input-wrapper">
+                    <input type="text" id="spec-search-input" placeholder="Search..." autocomplete="off">
+                    <kbd class="spec-search-shortcut"><span class="spec-search-shortcut-mod"></span>K</kbd>
+                </div>
+                <div id="spec-search-results" class="spec-search-results"></div>
+            </div>
+            <nav class="spec-nav">
+                
+                
+                
+<ul class="spec-nav-list">
+    
+    
+    <li class="spec-nav-item">
+        <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;spec&#x2F;01-introduction&#x2F;" class="spec-nav-link active">
+            Introduction
+        </a>
+    </li>
+    
+
+    
+    
+        
+    <li class="spec-nav-section">
+        <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;spec&#x2F;02-things&#x2F;" class="spec-nav-section-title ">
+            Things
+        </a>
+        
+    </li>
+    
+</ul>
+
+            </nav>
+        </div>
+    </aside>
+
+    
+    <div class="spec-main">
+        <article class="spec-content">
+            
+<h1 id="scope">Scope</h1>
+<div class="rule" id="r-1.1:1"><a class="rule-link" href="#r-1.1:1">[1.1:1]</a></div>
+<p>A conforming implementation <strong>MUST</strong> do the thing.</p>
+
+
+        </article>
+
+        
+        
+        <nav class="spec-page-nav">
+            
+            <span></span>
+            
+            
+        </nav>
+        
+    </div>
+</div>
+
+    </main>
+
+    <footer class="footer-colophon">
+        <div class="inner">
+            <span>© 2025–2026 The Rue Authors · MIT/Apache-2.0</span>
+            <span><em>rue</em>, n. — a hardy evergreen herb; also, what we hope you won’t do after choosing this language.</span>
+        </div>
+    </footer>
+
+    <script>
+        function toggleTheme() {
+            if (document.documentElement.classList.contains('dark')) {
+                document.documentElement.classList.remove('dark');
+                localStorage.theme = 'light';
+            } else {
+                document.documentElement.classList.add('dark');
+                localStorage.theme = 'dark';
+            }
+            updateSyntaxTheme();
+        }
+
+        function toggleMobileMenu() {
+            const menu = document.getElementById('mobile-menu');
+            const toggle = document.querySelector('.mobile-menu-toggle');
+            const isOpen = menu.classList.toggle('open');
+            toggle.classList.toggle('active', isOpen);
+            toggle.setAttribute('aria-expanded', isOpen);
+        }
+
+        // Close mobile menu when clicking a link
+        document.querySelectorAll('.mobile-menu-link').forEach(link => {
+            link.addEventListener('click', () => {
+                const menu = document.getElementById('mobile-menu');
+                const toggle = document.querySelector('.mobile-menu-toggle');
+                menu.classList.remove('open');
+                toggle.classList.remove('active');
+                toggle.setAttribute('aria-expanded', 'false');
+            });
+        });
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/elasticlunr/0.9.5/elasticlunr.min.js"></script>
+    <script src="https:&#x2F;&#x2F;rue-lang.dev&#x2F;search.js"></script>
+</body>
+</html>

--- a/performance/fixtures/gazette/expected/spec/02-things/01-first-thing/index.html
+++ b/performance/fixtures/gazette/expected/spec/02-things/01-first-thing/index.html
@@ -1,0 +1,264 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>First Thing - Rue Language Specification</title>
+    <meta name="description" content="A systems programming language with memory safety and high-level ergonomics">
+    <link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;style.css">
+    <link rel="icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;favicon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;brand&#x2F;apple-touch-icon.png">
+    <link rel="alternate" type="application/rss+xml" title="Rue Blog RSS" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog&#x2F;rss.xml">
+    <script>
+        // Check for saved theme preference or default to system preference
+        const isDark = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (isDark) {
+            document.documentElement.classList.add('dark');
+        }
+        // Write syntax theme stylesheets with correct initial disabled state
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-light.css" id="syntax-light"' + (isDark ? ' disabled' : '') + '>');
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-dark.css" id="syntax-dark"' + (isDark ? '' : ' disabled') + '>');
+
+        function updateSyntaxTheme() {
+            const syntaxLight = document.getElementById('syntax-light');
+            const syntaxDark = document.getElementById('syntax-dark');
+            if (syntaxLight && syntaxDark) {
+                const dark = document.documentElement.classList.contains('dark');
+                syntaxLight.disabled = dark;
+                syntaxDark.disabled = !dark;
+            }
+        }
+    </script>
+</head>
+<body class="min-h-screen flex flex-col">
+    <!-- engraved rue sprig (Ruta graveolens), referenced site-wide via <use> -->
+    <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+      <defs>
+        <g id="rue-sprig" fill="none" stroke="currentColor" stroke-width="1.5"
+           stroke-linecap="round" stroke-linejoin="round">
+          <path d="M16 30 C 16 24, 15.4 18, 16 10"/>
+          <path d="M15.7 22 C 12.5 20.5, 10 19, 8 16.5"/>
+          <path d="M8 16.5 c -2.6 -0.4 -4 -2.4 -3.4 -4.4 c 1.8 -1 4 -0.2 4.6 2 c 0.3 1 0 1.8 -1.2 2.4 z"/>
+          <path d="M11.5 19.2 c -2.4 0.6 -4.3 -0.6 -4.5 -2.6"/>
+          <path d="M16 17.5 C 19.5 16, 22 14.5, 23.8 12"/>
+          <path d="M23.8 12 c 2.6 -0.2 3.9 -2.2 3.2 -4.2 c -1.9 -0.9 -4 0.1 -4.4 2.3 c -0.2 1 0.1 1.7 1.2 1.9 z"/>
+          <path d="M20.4 14.6 c 2.4 0.4 4.2 -0.8 4.3 -2.8"/>
+          <path d="M16 10 c -0.4 -2.8 1 -4.6 3.2 -4.6 c 1.2 1.8 0.5 4 -1.6 4.9 c -0.7 0.3 -1.2 0.2 -1.6 -0.3 z"/>
+          <g stroke="none" fill="var(--color-gold)">
+            <circle cx="12.2" cy="7.4" r="1.15"/>
+            <circle cx="9.9"  cy="9.4" r="1.15"/>
+            <circle cx="12.6" cy="10.6" r="1.15"/>
+            <circle cx="14.4" cy="8.7" r="1.15"/>
+          </g>
+          <circle cx="12.4" cy="9" r="0.8" stroke="none" fill="currentColor"/>
+          <path d="M15.9 13.5 C 14.8 11.8, 13.6 10.6, 12.6 10.4"/>
+        </g>
+      </defs>
+    </svg>
+
+    <div class="colophon-bar">
+        <em>Ruta graveolens</em> &nbsp;·&nbsp; notes from a language experiment &nbsp;·&nbsp; cultivated since 2025
+    </div>
+
+    <nav>
+        <div class="masthead">
+            <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="wordmark">
+                <svg class="sprig" viewBox="0 0 32 32"><use href="#rue-sprig"/></svg>
+                Rue
+            </a>
+            <!-- Desktop navigation -->
+            <div class="nav-desktop flex items-center gap-6">
+                <ul class="flex gap-6">
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="nav-link">Tutorial</a></li>
+<!-- Hardcoded path: spec pages are copied into Zola content at build time -->
+                    <li><a href="/spec/" class="nav-link">Specification</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="nav-link">Performance</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="nav-link">Runtime</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="nav-link">Lab Notes</a></li>
+                    <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="nav-link ext">GitHub</a></li>
+                    <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="nav-link ext">Bluesky</a></li>
+                </ul>
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+            </div>
+            <!-- Mobile navigation controls -->
+            <div class="nav-mobile-controls flex items-center gap-4">
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+                <button onclick="toggleMobileMenu()" class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false">
+                    <svg class="icon-menu w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                    <svg class="icon-close w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+        <!-- Mobile menu overlay -->
+        <div id="mobile-menu" class="mobile-menu">
+            <ul class="mobile-menu-list">
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="mobile-menu-link">Home</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="mobile-menu-link">Tutorial</a></li>
+                <li><a href="/spec/" class="mobile-menu-link">Specification</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="mobile-menu-link">Performance</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="mobile-menu-link">Runtime</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="mobile-menu-link">Lab Notes</a></li>
+                <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="mobile-menu-link">GitHub</a></li>
+                <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="mobile-menu-link">Bluesky</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <main class="flex-1">
+        
+<div class="spec-layout">
+    
+    <aside class="spec-sidebar">
+        <div class="spec-sidebar-inner">
+            <div class="spec-sidebar-header">
+                <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;spec" class="spec-title">Rue Specification</a>
+            </div>
+            <div class="spec-search">
+                <div class="spec-search-input-wrapper">
+                    <input type="text" id="spec-search-input" placeholder="Search..." autocomplete="off">
+                    <kbd class="spec-search-shortcut"><span class="spec-search-shortcut-mod"></span>K</kbd>
+                </div>
+                <div id="spec-search-results" class="spec-search-results"></div>
+            </div>
+            <nav class="spec-nav">
+                
+                
+                
+<ul class="spec-nav-list">
+    
+    
+    <li class="spec-nav-item">
+        <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;spec&#x2F;01-introduction&#x2F;" class="spec-nav-link ">
+            Introduction
+        </a>
+    </li>
+    
+
+    
+    
+        
+    <li class="spec-nav-section">
+        <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;spec&#x2F;02-things&#x2F;" class="spec-nav-section-title active">
+            Things
+        </a>
+        
+        
+<ul class="spec-nav-list">
+    
+    
+    <li class="spec-nav-item">
+        <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;spec&#x2F;02-things&#x2F;01-first-thing&#x2F;" class="spec-nav-link active">
+            First Thing
+        </a>
+    </li>
+    
+    <li class="spec-nav-item">
+        <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;spec&#x2F;02-things&#x2F;02-second-thing&#x2F;" class="spec-nav-link ">
+            Second Thing
+        </a>
+    </li>
+    
+
+    
+    
+</ul>
+
+        
+    </li>
+    
+</ul>
+
+            </nav>
+        </div>
+    </aside>
+
+    
+    <div class="spec-main">
+        <article class="spec-content">
+            
+<div class="rule" id="r-2.1:1"><a class="rule-link" href="#r-2.1:1">[2.1:1]</a></div>
+<p>The first thing, which links to
+<a href="https://rue-lang.dev/spec/01-introduction/#scope">the introduction</a>.</p>
+
+
+        </article>
+
+        
+        
+        <nav class="spec-page-nav">
+            
+            <span></span>
+            
+            
+            <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;spec&#x2F;02-things&#x2F;02-second-thing&#x2F;" class="spec-nav-next">
+                <span class="spec-nav-label">Next</span>
+                <span class="spec-nav-title">Second Thing</span>
+            </a>
+            
+        </nav>
+        
+    </div>
+</div>
+
+    </main>
+
+    <footer class="footer-colophon">
+        <div class="inner">
+            <span>© 2025–2026 The Rue Authors · MIT/Apache-2.0</span>
+            <span><em>rue</em>, n. — a hardy evergreen herb; also, what we hope you won’t do after choosing this language.</span>
+        </div>
+    </footer>
+
+    <script>
+        function toggleTheme() {
+            if (document.documentElement.classList.contains('dark')) {
+                document.documentElement.classList.remove('dark');
+                localStorage.theme = 'light';
+            } else {
+                document.documentElement.classList.add('dark');
+                localStorage.theme = 'dark';
+            }
+            updateSyntaxTheme();
+        }
+
+        function toggleMobileMenu() {
+            const menu = document.getElementById('mobile-menu');
+            const toggle = document.querySelector('.mobile-menu-toggle');
+            const isOpen = menu.classList.toggle('open');
+            toggle.classList.toggle('active', isOpen);
+            toggle.setAttribute('aria-expanded', isOpen);
+        }
+
+        // Close mobile menu when clicking a link
+        document.querySelectorAll('.mobile-menu-link').forEach(link => {
+            link.addEventListener('click', () => {
+                const menu = document.getElementById('mobile-menu');
+                const toggle = document.querySelector('.mobile-menu-toggle');
+                menu.classList.remove('open');
+                toggle.classList.remove('active');
+                toggle.setAttribute('aria-expanded', 'false');
+            });
+        });
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/elasticlunr/0.9.5/elasticlunr.min.js"></script>
+    <script src="https:&#x2F;&#x2F;rue-lang.dev&#x2F;search.js"></script>
+</body>
+</html>

--- a/performance/fixtures/gazette/expected/spec/02-things/02-second-thing/index.html
+++ b/performance/fixtures/gazette/expected/spec/02-things/02-second-thing/index.html
@@ -1,0 +1,264 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Second Thing - Rue Language Specification</title>
+    <meta name="description" content="A systems programming language with memory safety and high-level ergonomics">
+    <link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;style.css">
+    <link rel="icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;favicon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;brand&#x2F;apple-touch-icon.png">
+    <link rel="alternate" type="application/rss+xml" title="Rue Blog RSS" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog&#x2F;rss.xml">
+    <script>
+        // Check for saved theme preference or default to system preference
+        const isDark = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (isDark) {
+            document.documentElement.classList.add('dark');
+        }
+        // Write syntax theme stylesheets with correct initial disabled state
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-light.css" id="syntax-light"' + (isDark ? ' disabled' : '') + '>');
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-dark.css" id="syntax-dark"' + (isDark ? '' : ' disabled') + '>');
+
+        function updateSyntaxTheme() {
+            const syntaxLight = document.getElementById('syntax-light');
+            const syntaxDark = document.getElementById('syntax-dark');
+            if (syntaxLight && syntaxDark) {
+                const dark = document.documentElement.classList.contains('dark');
+                syntaxLight.disabled = dark;
+                syntaxDark.disabled = !dark;
+            }
+        }
+    </script>
+</head>
+<body class="min-h-screen flex flex-col">
+    <!-- engraved rue sprig (Ruta graveolens), referenced site-wide via <use> -->
+    <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+      <defs>
+        <g id="rue-sprig" fill="none" stroke="currentColor" stroke-width="1.5"
+           stroke-linecap="round" stroke-linejoin="round">
+          <path d="M16 30 C 16 24, 15.4 18, 16 10"/>
+          <path d="M15.7 22 C 12.5 20.5, 10 19, 8 16.5"/>
+          <path d="M8 16.5 c -2.6 -0.4 -4 -2.4 -3.4 -4.4 c 1.8 -1 4 -0.2 4.6 2 c 0.3 1 0 1.8 -1.2 2.4 z"/>
+          <path d="M11.5 19.2 c -2.4 0.6 -4.3 -0.6 -4.5 -2.6"/>
+          <path d="M16 17.5 C 19.5 16, 22 14.5, 23.8 12"/>
+          <path d="M23.8 12 c 2.6 -0.2 3.9 -2.2 3.2 -4.2 c -1.9 -0.9 -4 0.1 -4.4 2.3 c -0.2 1 0.1 1.7 1.2 1.9 z"/>
+          <path d="M20.4 14.6 c 2.4 0.4 4.2 -0.8 4.3 -2.8"/>
+          <path d="M16 10 c -0.4 -2.8 1 -4.6 3.2 -4.6 c 1.2 1.8 0.5 4 -1.6 4.9 c -0.7 0.3 -1.2 0.2 -1.6 -0.3 z"/>
+          <g stroke="none" fill="var(--color-gold)">
+            <circle cx="12.2" cy="7.4" r="1.15"/>
+            <circle cx="9.9"  cy="9.4" r="1.15"/>
+            <circle cx="12.6" cy="10.6" r="1.15"/>
+            <circle cx="14.4" cy="8.7" r="1.15"/>
+          </g>
+          <circle cx="12.4" cy="9" r="0.8" stroke="none" fill="currentColor"/>
+          <path d="M15.9 13.5 C 14.8 11.8, 13.6 10.6, 12.6 10.4"/>
+        </g>
+      </defs>
+    </svg>
+
+    <div class="colophon-bar">
+        <em>Ruta graveolens</em> &nbsp;·&nbsp; notes from a language experiment &nbsp;·&nbsp; cultivated since 2025
+    </div>
+
+    <nav>
+        <div class="masthead">
+            <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="wordmark">
+                <svg class="sprig" viewBox="0 0 32 32"><use href="#rue-sprig"/></svg>
+                Rue
+            </a>
+            <!-- Desktop navigation -->
+            <div class="nav-desktop flex items-center gap-6">
+                <ul class="flex gap-6">
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="nav-link">Tutorial</a></li>
+<!-- Hardcoded path: spec pages are copied into Zola content at build time -->
+                    <li><a href="/spec/" class="nav-link">Specification</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="nav-link">Performance</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="nav-link">Runtime</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="nav-link">Lab Notes</a></li>
+                    <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="nav-link ext">GitHub</a></li>
+                    <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="nav-link ext">Bluesky</a></li>
+                </ul>
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+            </div>
+            <!-- Mobile navigation controls -->
+            <div class="nav-mobile-controls flex items-center gap-4">
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+                <button onclick="toggleMobileMenu()" class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false">
+                    <svg class="icon-menu w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                    <svg class="icon-close w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+        <!-- Mobile menu overlay -->
+        <div id="mobile-menu" class="mobile-menu">
+            <ul class="mobile-menu-list">
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="mobile-menu-link">Home</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="mobile-menu-link">Tutorial</a></li>
+                <li><a href="/spec/" class="mobile-menu-link">Specification</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="mobile-menu-link">Performance</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="mobile-menu-link">Runtime</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="mobile-menu-link">Lab Notes</a></li>
+                <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="mobile-menu-link">GitHub</a></li>
+                <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="mobile-menu-link">Bluesky</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <main class="flex-1">
+        
+<div class="spec-layout">
+    
+    <aside class="spec-sidebar">
+        <div class="spec-sidebar-inner">
+            <div class="spec-sidebar-header">
+                <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;spec" class="spec-title">Rue Specification</a>
+            </div>
+            <div class="spec-search">
+                <div class="spec-search-input-wrapper">
+                    <input type="text" id="spec-search-input" placeholder="Search..." autocomplete="off">
+                    <kbd class="spec-search-shortcut"><span class="spec-search-shortcut-mod"></span>K</kbd>
+                </div>
+                <div id="spec-search-results" class="spec-search-results"></div>
+            </div>
+            <nav class="spec-nav">
+                
+                
+                
+<ul class="spec-nav-list">
+    
+    
+    <li class="spec-nav-item">
+        <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;spec&#x2F;01-introduction&#x2F;" class="spec-nav-link ">
+            Introduction
+        </a>
+    </li>
+    
+
+    
+    
+        
+    <li class="spec-nav-section">
+        <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;spec&#x2F;02-things&#x2F;" class="spec-nav-section-title active">
+            Things
+        </a>
+        
+        
+<ul class="spec-nav-list">
+    
+    
+    <li class="spec-nav-item">
+        <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;spec&#x2F;02-things&#x2F;01-first-thing&#x2F;" class="spec-nav-link ">
+            First Thing
+        </a>
+    </li>
+    
+    <li class="spec-nav-item">
+        <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;spec&#x2F;02-things&#x2F;02-second-thing&#x2F;" class="spec-nav-link active">
+            Second Thing
+        </a>
+    </li>
+    
+
+    
+    
+</ul>
+
+        
+    </li>
+    
+</ul>
+
+            </nav>
+        </div>
+    </aside>
+
+    
+    <div class="spec-main">
+        <article class="spec-content">
+            
+<div class="preview-notice">
+    <strong>Preview Feature</strong>:
+    This feature requires <code>--preview second_thing</code> to use.
+</div>
+<p>The second thing.</p>
+
+
+        </article>
+
+        
+        
+        <nav class="spec-page-nav">
+            
+            <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;spec&#x2F;02-things&#x2F;01-first-thing&#x2F;" class="spec-nav-prev">
+                <span class="spec-nav-label">Previous</span>
+                <span class="spec-nav-title">First Thing</span>
+            </a>
+            
+            
+        </nav>
+        
+    </div>
+</div>
+
+    </main>
+
+    <footer class="footer-colophon">
+        <div class="inner">
+            <span>© 2025–2026 The Rue Authors · MIT/Apache-2.0</span>
+            <span><em>rue</em>, n. — a hardy evergreen herb; also, what we hope you won’t do after choosing this language.</span>
+        </div>
+    </footer>
+
+    <script>
+        function toggleTheme() {
+            if (document.documentElement.classList.contains('dark')) {
+                document.documentElement.classList.remove('dark');
+                localStorage.theme = 'light';
+            } else {
+                document.documentElement.classList.add('dark');
+                localStorage.theme = 'dark';
+            }
+            updateSyntaxTheme();
+        }
+
+        function toggleMobileMenu() {
+            const menu = document.getElementById('mobile-menu');
+            const toggle = document.querySelector('.mobile-menu-toggle');
+            const isOpen = menu.classList.toggle('open');
+            toggle.classList.toggle('active', isOpen);
+            toggle.setAttribute('aria-expanded', isOpen);
+        }
+
+        // Close mobile menu when clicking a link
+        document.querySelectorAll('.mobile-menu-link').forEach(link => {
+            link.addEventListener('click', () => {
+                const menu = document.getElementById('mobile-menu');
+                const toggle = document.querySelector('.mobile-menu-toggle');
+                menu.classList.remove('open');
+                toggle.classList.remove('active');
+                toggle.setAttribute('aria-expanded', 'false');
+            });
+        });
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/elasticlunr/0.9.5/elasticlunr.min.js"></script>
+    <script src="https:&#x2F;&#x2F;rue-lang.dev&#x2F;search.js"></script>
+</body>
+</html>

--- a/performance/fixtures/gazette/expected/spec/02-things/index.html
+++ b/performance/fixtures/gazette/expected/spec/02-things/index.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Things - Rue Language Specification</title>
+    <meta name="description" content="A systems programming language with memory safety and high-level ergonomics">
+    <link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;style.css">
+    <link rel="icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;favicon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;brand&#x2F;apple-touch-icon.png">
+    <link rel="alternate" type="application/rss+xml" title="Rue Blog RSS" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog&#x2F;rss.xml">
+    <script>
+        // Check for saved theme preference or default to system preference
+        const isDark = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (isDark) {
+            document.documentElement.classList.add('dark');
+        }
+        // Write syntax theme stylesheets with correct initial disabled state
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-light.css" id="syntax-light"' + (isDark ? ' disabled' : '') + '>');
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-dark.css" id="syntax-dark"' + (isDark ? '' : ' disabled') + '>');
+
+        function updateSyntaxTheme() {
+            const syntaxLight = document.getElementById('syntax-light');
+            const syntaxDark = document.getElementById('syntax-dark');
+            if (syntaxLight && syntaxDark) {
+                const dark = document.documentElement.classList.contains('dark');
+                syntaxLight.disabled = dark;
+                syntaxDark.disabled = !dark;
+            }
+        }
+    </script>
+</head>
+<body class="min-h-screen flex flex-col">
+    <!-- engraved rue sprig (Ruta graveolens), referenced site-wide via <use> -->
+    <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+      <defs>
+        <g id="rue-sprig" fill="none" stroke="currentColor" stroke-width="1.5"
+           stroke-linecap="round" stroke-linejoin="round">
+          <path d="M16 30 C 16 24, 15.4 18, 16 10"/>
+          <path d="M15.7 22 C 12.5 20.5, 10 19, 8 16.5"/>
+          <path d="M8 16.5 c -2.6 -0.4 -4 -2.4 -3.4 -4.4 c 1.8 -1 4 -0.2 4.6 2 c 0.3 1 0 1.8 -1.2 2.4 z"/>
+          <path d="M11.5 19.2 c -2.4 0.6 -4.3 -0.6 -4.5 -2.6"/>
+          <path d="M16 17.5 C 19.5 16, 22 14.5, 23.8 12"/>
+          <path d="M23.8 12 c 2.6 -0.2 3.9 -2.2 3.2 -4.2 c -1.9 -0.9 -4 0.1 -4.4 2.3 c -0.2 1 0.1 1.7 1.2 1.9 z"/>
+          <path d="M20.4 14.6 c 2.4 0.4 4.2 -0.8 4.3 -2.8"/>
+          <path d="M16 10 c -0.4 -2.8 1 -4.6 3.2 -4.6 c 1.2 1.8 0.5 4 -1.6 4.9 c -0.7 0.3 -1.2 0.2 -1.6 -0.3 z"/>
+          <g stroke="none" fill="var(--color-gold)">
+            <circle cx="12.2" cy="7.4" r="1.15"/>
+            <circle cx="9.9"  cy="9.4" r="1.15"/>
+            <circle cx="12.6" cy="10.6" r="1.15"/>
+            <circle cx="14.4" cy="8.7" r="1.15"/>
+          </g>
+          <circle cx="12.4" cy="9" r="0.8" stroke="none" fill="currentColor"/>
+          <path d="M15.9 13.5 C 14.8 11.8, 13.6 10.6, 12.6 10.4"/>
+        </g>
+      </defs>
+    </svg>
+
+    <div class="colophon-bar">
+        <em>Ruta graveolens</em> &nbsp;·&nbsp; notes from a language experiment &nbsp;·&nbsp; cultivated since 2025
+    </div>
+
+    <nav>
+        <div class="masthead">
+            <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="wordmark">
+                <svg class="sprig" viewBox="0 0 32 32"><use href="#rue-sprig"/></svg>
+                Rue
+            </a>
+            <!-- Desktop navigation -->
+            <div class="nav-desktop flex items-center gap-6">
+                <ul class="flex gap-6">
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="nav-link">Tutorial</a></li>
+<!-- Hardcoded path: spec pages are copied into Zola content at build time -->
+                    <li><a href="/spec/" class="nav-link">Specification</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="nav-link">Performance</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="nav-link">Runtime</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="nav-link">Lab Notes</a></li>
+                    <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="nav-link ext">GitHub</a></li>
+                    <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="nav-link ext">Bluesky</a></li>
+                </ul>
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+            </div>
+            <!-- Mobile navigation controls -->
+            <div class="nav-mobile-controls flex items-center gap-4">
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+                <button onclick="toggleMobileMenu()" class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false">
+                    <svg class="icon-menu w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                    <svg class="icon-close w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+        <!-- Mobile menu overlay -->
+        <div id="mobile-menu" class="mobile-menu">
+            <ul class="mobile-menu-list">
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="mobile-menu-link">Home</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="mobile-menu-link">Tutorial</a></li>
+                <li><a href="/spec/" class="mobile-menu-link">Specification</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="mobile-menu-link">Performance</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="mobile-menu-link">Runtime</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="mobile-menu-link">Lab Notes</a></li>
+                <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="mobile-menu-link">GitHub</a></li>
+                <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="mobile-menu-link">Bluesky</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <main class="flex-1">
+        
+<div class="spec-layout">
+    
+    <aside class="spec-sidebar">
+        <div class="spec-sidebar-inner">
+            <div class="spec-sidebar-header">
+                <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;spec" class="spec-title">Rue Specification</a>
+            </div>
+            <div class="spec-search">
+                <div class="spec-search-input-wrapper">
+                    <input type="text" id="spec-search-input" placeholder="Search..." autocomplete="off">
+                    <kbd class="spec-search-shortcut"><span class="spec-search-shortcut-mod"></span>K</kbd>
+                </div>
+                <div id="spec-search-results" class="spec-search-results"></div>
+            </div>
+            <nav class="spec-nav">
+                
+                
+                
+<ul class="spec-nav-list">
+    
+    
+    <li class="spec-nav-item">
+        <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;spec&#x2F;01-introduction&#x2F;" class="spec-nav-link ">
+            Introduction
+        </a>
+    </li>
+    
+
+    
+    
+        
+    <li class="spec-nav-section">
+        <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;spec&#x2F;02-things&#x2F;" class="spec-nav-section-title active">
+            Things
+        </a>
+        
+        
+<ul class="spec-nav-list">
+    
+    
+    <li class="spec-nav-item">
+        <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;spec&#x2F;02-things&#x2F;01-first-thing&#x2F;" class="spec-nav-link ">
+            First Thing
+        </a>
+    </li>
+    
+    <li class="spec-nav-item">
+        <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;spec&#x2F;02-things&#x2F;02-second-thing&#x2F;" class="spec-nav-link ">
+            Second Thing
+        </a>
+    </li>
+    
+
+    
+    
+</ul>
+
+        
+    </li>
+    
+</ul>
+
+            </nav>
+        </div>
+    </aside>
+
+    
+    <div class="spec-main">
+        <article class="spec-content">
+            
+<h1>Things</h1>
+
+<p>Things have parts.</p>
+
+
+
+
+<h2>In this section</h2>
+<ul class="spec-section-toc">
+    
+    <li><a href="&#x2F;spec&#x2F;02-things&#x2F;01-first-thing&#x2F;">First Thing</a></li>
+    
+    <li><a href="&#x2F;spec&#x2F;02-things&#x2F;02-second-thing&#x2F;">Second Thing</a></li>
+    
+</ul>
+
+
+
+
+
+        </article>
+
+        
+        
+
+
+    </div>
+</div>
+
+    </main>
+
+    <footer class="footer-colophon">
+        <div class="inner">
+            <span>© 2025–2026 The Rue Authors · MIT/Apache-2.0</span>
+            <span><em>rue</em>, n. — a hardy evergreen herb; also, what we hope you won’t do after choosing this language.</span>
+        </div>
+    </footer>
+
+    <script>
+        function toggleTheme() {
+            if (document.documentElement.classList.contains('dark')) {
+                document.documentElement.classList.remove('dark');
+                localStorage.theme = 'light';
+            } else {
+                document.documentElement.classList.add('dark');
+                localStorage.theme = 'dark';
+            }
+            updateSyntaxTheme();
+        }
+
+        function toggleMobileMenu() {
+            const menu = document.getElementById('mobile-menu');
+            const toggle = document.querySelector('.mobile-menu-toggle');
+            const isOpen = menu.classList.toggle('open');
+            toggle.classList.toggle('active', isOpen);
+            toggle.setAttribute('aria-expanded', isOpen);
+        }
+
+        // Close mobile menu when clicking a link
+        document.querySelectorAll('.mobile-menu-link').forEach(link => {
+            link.addEventListener('click', () => {
+                const menu = document.getElementById('mobile-menu');
+                const toggle = document.querySelector('.mobile-menu-toggle');
+                menu.classList.remove('open');
+                toggle.classList.remove('active');
+                toggle.setAttribute('aria-expanded', 'false');
+            });
+        });
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/elasticlunr/0.9.5/elasticlunr.min.js"></script>
+    <script src="https:&#x2F;&#x2F;rue-lang.dev&#x2F;search.js"></script>
+</body>
+</html>

--- a/performance/fixtures/gazette/expected/spec/index.html
+++ b/performance/fixtures/gazette/expected/spec/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Redirect</title>
+<script>
+  const target = "https://rue-lang.dev/spec/01-introduction/";
+  const hash = window.location.hash || "";
+  window.location.replace(target + hash);
+</script>
+<noscript>
+  <meta http-equiv="refresh" content="0; url=https://rue-lang.dev/spec/01-introduction/">
+</noscript>
+<p><a href="https://rue-lang.dev/spec/01-introduction/">Click here</a> to be redirected.</p>

--- a/performance/fixtures/gazette/expected/std/01-math/index.html
+++ b/performance/fixtures/gazette/expected/std/01-math/index.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>math - Standard Library</title>
+    <meta name="description" content="A systems programming language with memory safety and high-level ergonomics">
+    <link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;style.css">
+    <link rel="icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;favicon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;brand&#x2F;apple-touch-icon.png">
+    <link rel="alternate" type="application/rss+xml" title="Rue Blog RSS" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog&#x2F;rss.xml">
+    <script>
+        // Check for saved theme preference or default to system preference
+        const isDark = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (isDark) {
+            document.documentElement.classList.add('dark');
+        }
+        // Write syntax theme stylesheets with correct initial disabled state
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-light.css" id="syntax-light"' + (isDark ? ' disabled' : '') + '>');
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-dark.css" id="syntax-dark"' + (isDark ? '' : ' disabled') + '>');
+
+        function updateSyntaxTheme() {
+            const syntaxLight = document.getElementById('syntax-light');
+            const syntaxDark = document.getElementById('syntax-dark');
+            if (syntaxLight && syntaxDark) {
+                const dark = document.documentElement.classList.contains('dark');
+                syntaxLight.disabled = dark;
+                syntaxDark.disabled = !dark;
+            }
+        }
+    </script>
+</head>
+<body class="min-h-screen flex flex-col">
+    <!-- engraved rue sprig (Ruta graveolens), referenced site-wide via <use> -->
+    <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+      <defs>
+        <g id="rue-sprig" fill="none" stroke="currentColor" stroke-width="1.5"
+           stroke-linecap="round" stroke-linejoin="round">
+          <path d="M16 30 C 16 24, 15.4 18, 16 10"/>
+          <path d="M15.7 22 C 12.5 20.5, 10 19, 8 16.5"/>
+          <path d="M8 16.5 c -2.6 -0.4 -4 -2.4 -3.4 -4.4 c 1.8 -1 4 -0.2 4.6 2 c 0.3 1 0 1.8 -1.2 2.4 z"/>
+          <path d="M11.5 19.2 c -2.4 0.6 -4.3 -0.6 -4.5 -2.6"/>
+          <path d="M16 17.5 C 19.5 16, 22 14.5, 23.8 12"/>
+          <path d="M23.8 12 c 2.6 -0.2 3.9 -2.2 3.2 -4.2 c -1.9 -0.9 -4 0.1 -4.4 2.3 c -0.2 1 0.1 1.7 1.2 1.9 z"/>
+          <path d="M20.4 14.6 c 2.4 0.4 4.2 -0.8 4.3 -2.8"/>
+          <path d="M16 10 c -0.4 -2.8 1 -4.6 3.2 -4.6 c 1.2 1.8 0.5 4 -1.6 4.9 c -0.7 0.3 -1.2 0.2 -1.6 -0.3 z"/>
+          <g stroke="none" fill="var(--color-gold)">
+            <circle cx="12.2" cy="7.4" r="1.15"/>
+            <circle cx="9.9"  cy="9.4" r="1.15"/>
+            <circle cx="12.6" cy="10.6" r="1.15"/>
+            <circle cx="14.4" cy="8.7" r="1.15"/>
+          </g>
+          <circle cx="12.4" cy="9" r="0.8" stroke="none" fill="currentColor"/>
+          <path d="M15.9 13.5 C 14.8 11.8, 13.6 10.6, 12.6 10.4"/>
+        </g>
+      </defs>
+    </svg>
+
+    <div class="colophon-bar">
+        <em>Ruta graveolens</em> &nbsp;·&nbsp; notes from a language experiment &nbsp;·&nbsp; cultivated since 2025
+    </div>
+
+    <nav>
+        <div class="masthead">
+            <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="wordmark">
+                <svg class="sprig" viewBox="0 0 32 32"><use href="#rue-sprig"/></svg>
+                Rue
+            </a>
+            <!-- Desktop navigation -->
+            <div class="nav-desktop flex items-center gap-6">
+                <ul class="flex gap-6">
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="nav-link">Tutorial</a></li>
+<!-- Hardcoded path: spec pages are copied into Zola content at build time -->
+                    <li><a href="/spec/" class="nav-link">Specification</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="nav-link">Performance</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="nav-link">Runtime</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="nav-link">Lab Notes</a></li>
+                    <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="nav-link ext">GitHub</a></li>
+                    <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="nav-link ext">Bluesky</a></li>
+                </ul>
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+            </div>
+            <!-- Mobile navigation controls -->
+            <div class="nav-mobile-controls flex items-center gap-4">
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+                <button onclick="toggleMobileMenu()" class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false">
+                    <svg class="icon-menu w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                    <svg class="icon-close w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+        <!-- Mobile menu overlay -->
+        <div id="mobile-menu" class="mobile-menu">
+            <ul class="mobile-menu-list">
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="mobile-menu-link">Home</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="mobile-menu-link">Tutorial</a></li>
+                <li><a href="/spec/" class="mobile-menu-link">Specification</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="mobile-menu-link">Performance</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="mobile-menu-link">Runtime</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="mobile-menu-link">Lab Notes</a></li>
+                <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="mobile-menu-link">GitHub</a></li>
+                <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="mobile-menu-link">Bluesky</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <main class="flex-1">
+        
+<div class="spec-layout">
+    
+    <aside class="spec-sidebar">
+        <div class="spec-sidebar-inner">
+            <div class="spec-sidebar-header">
+                <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;std" class="spec-title">Standard Library</a>
+            </div>
+            <nav class="spec-nav">
+                
+                
+                
+<ul class="spec-nav-list">
+    
+    <li class="spec-nav-item">
+        <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;std&#x2F;01-math&#x2F;" class="spec-nav-link active">
+            math
+        </a>
+    </li>
+    
+</ul>
+
+            </nav>
+        </div>
+    </aside>
+
+    
+    <div class="spec-main">
+        <article class="spec-content std-content">
+            
+<p>Arithmetic helpers.</p>
+
+
+        </article>
+
+        
+        
+        <nav class="spec-page-nav">
+            
+            <span></span>
+            
+            
+        </nav>
+        
+    </div>
+</div>
+
+    </main>
+
+    <footer class="footer-colophon">
+        <div class="inner">
+            <span>© 2025–2026 The Rue Authors · MIT/Apache-2.0</span>
+            <span><em>rue</em>, n. — a hardy evergreen herb; also, what we hope you won’t do after choosing this language.</span>
+        </div>
+    </footer>
+
+    <script>
+        function toggleTheme() {
+            if (document.documentElement.classList.contains('dark')) {
+                document.documentElement.classList.remove('dark');
+                localStorage.theme = 'light';
+            } else {
+                document.documentElement.classList.add('dark');
+                localStorage.theme = 'dark';
+            }
+            updateSyntaxTheme();
+        }
+
+        function toggleMobileMenu() {
+            const menu = document.getElementById('mobile-menu');
+            const toggle = document.querySelector('.mobile-menu-toggle');
+            const isOpen = menu.classList.toggle('open');
+            toggle.classList.toggle('active', isOpen);
+            toggle.setAttribute('aria-expanded', isOpen);
+        }
+
+        // Close mobile menu when clicking a link
+        document.querySelectorAll('.mobile-menu-link').forEach(link => {
+            link.addEventListener('click', () => {
+                const menu = document.getElementById('mobile-menu');
+                const toggle = document.querySelector('.mobile-menu-toggle');
+                menu.classList.remove('open');
+                toggle.classList.remove('active');
+                toggle.setAttribute('aria-expanded', 'false');
+            });
+        });
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/elasticlunr/0.9.5/elasticlunr.min.js"></script>
+    <script src="https:&#x2F;&#x2F;rue-lang.dev&#x2F;search.js"></script>
+</body>
+</html>

--- a/performance/fixtures/gazette/expected/std/index.html
+++ b/performance/fixtures/gazette/expected/std/index.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Standard Library - Standard Library</title>
+    <meta name="description" content="A systems programming language with memory safety and high-level ergonomics">
+    <link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;style.css">
+    <link rel="icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;favicon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;brand&#x2F;apple-touch-icon.png">
+    <link rel="alternate" type="application/rss+xml" title="Rue Blog RSS" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog&#x2F;rss.xml">
+    <script>
+        // Check for saved theme preference or default to system preference
+        const isDark = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (isDark) {
+            document.documentElement.classList.add('dark');
+        }
+        // Write syntax theme stylesheets with correct initial disabled state
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-light.css" id="syntax-light"' + (isDark ? ' disabled' : '') + '>');
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-dark.css" id="syntax-dark"' + (isDark ? '' : ' disabled') + '>');
+
+        function updateSyntaxTheme() {
+            const syntaxLight = document.getElementById('syntax-light');
+            const syntaxDark = document.getElementById('syntax-dark');
+            if (syntaxLight && syntaxDark) {
+                const dark = document.documentElement.classList.contains('dark');
+                syntaxLight.disabled = dark;
+                syntaxDark.disabled = !dark;
+            }
+        }
+    </script>
+</head>
+<body class="min-h-screen flex flex-col">
+    <!-- engraved rue sprig (Ruta graveolens), referenced site-wide via <use> -->
+    <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+      <defs>
+        <g id="rue-sprig" fill="none" stroke="currentColor" stroke-width="1.5"
+           stroke-linecap="round" stroke-linejoin="round">
+          <path d="M16 30 C 16 24, 15.4 18, 16 10"/>
+          <path d="M15.7 22 C 12.5 20.5, 10 19, 8 16.5"/>
+          <path d="M8 16.5 c -2.6 -0.4 -4 -2.4 -3.4 -4.4 c 1.8 -1 4 -0.2 4.6 2 c 0.3 1 0 1.8 -1.2 2.4 z"/>
+          <path d="M11.5 19.2 c -2.4 0.6 -4.3 -0.6 -4.5 -2.6"/>
+          <path d="M16 17.5 C 19.5 16, 22 14.5, 23.8 12"/>
+          <path d="M23.8 12 c 2.6 -0.2 3.9 -2.2 3.2 -4.2 c -1.9 -0.9 -4 0.1 -4.4 2.3 c -0.2 1 0.1 1.7 1.2 1.9 z"/>
+          <path d="M20.4 14.6 c 2.4 0.4 4.2 -0.8 4.3 -2.8"/>
+          <path d="M16 10 c -0.4 -2.8 1 -4.6 3.2 -4.6 c 1.2 1.8 0.5 4 -1.6 4.9 c -0.7 0.3 -1.2 0.2 -1.6 -0.3 z"/>
+          <g stroke="none" fill="var(--color-gold)">
+            <circle cx="12.2" cy="7.4" r="1.15"/>
+            <circle cx="9.9"  cy="9.4" r="1.15"/>
+            <circle cx="12.6" cy="10.6" r="1.15"/>
+            <circle cx="14.4" cy="8.7" r="1.15"/>
+          </g>
+          <circle cx="12.4" cy="9" r="0.8" stroke="none" fill="currentColor"/>
+          <path d="M15.9 13.5 C 14.8 11.8, 13.6 10.6, 12.6 10.4"/>
+        </g>
+      </defs>
+    </svg>
+
+    <div class="colophon-bar">
+        <em>Ruta graveolens</em> &nbsp;·&nbsp; notes from a language experiment &nbsp;·&nbsp; cultivated since 2025
+    </div>
+
+    <nav>
+        <div class="masthead">
+            <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="wordmark">
+                <svg class="sprig" viewBox="0 0 32 32"><use href="#rue-sprig"/></svg>
+                Rue
+            </a>
+            <!-- Desktop navigation -->
+            <div class="nav-desktop flex items-center gap-6">
+                <ul class="flex gap-6">
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="nav-link">Tutorial</a></li>
+<!-- Hardcoded path: spec pages are copied into Zola content at build time -->
+                    <li><a href="/spec/" class="nav-link">Specification</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="nav-link">Performance</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="nav-link">Runtime</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="nav-link">Lab Notes</a></li>
+                    <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="nav-link ext">GitHub</a></li>
+                    <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="nav-link ext">Bluesky</a></li>
+                </ul>
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+            </div>
+            <!-- Mobile navigation controls -->
+            <div class="nav-mobile-controls flex items-center gap-4">
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+                <button onclick="toggleMobileMenu()" class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false">
+                    <svg class="icon-menu w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                    <svg class="icon-close w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+        <!-- Mobile menu overlay -->
+        <div id="mobile-menu" class="mobile-menu">
+            <ul class="mobile-menu-list">
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="mobile-menu-link">Home</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="mobile-menu-link">Tutorial</a></li>
+                <li><a href="/spec/" class="mobile-menu-link">Specification</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="mobile-menu-link">Performance</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="mobile-menu-link">Runtime</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="mobile-menu-link">Lab Notes</a></li>
+                <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="mobile-menu-link">GitHub</a></li>
+                <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="mobile-menu-link">Bluesky</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <main class="flex-1">
+        
+<div class="spec-layout">
+    
+    <aside class="spec-sidebar">
+        <div class="spec-sidebar-inner">
+            <div class="spec-sidebar-header">
+                <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;std" class="spec-title">Standard Library</a>
+            </div>
+            <nav class="spec-nav">
+                
+                
+                
+<ul class="spec-nav-list">
+    
+    <li class="spec-nav-item">
+        <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;std&#x2F;01-math&#x2F;" class="spec-nav-link ">
+            math
+        </a>
+    </li>
+    
+</ul>
+
+            </nav>
+        </div>
+    </aside>
+
+    
+    <div class="spec-main">
+        <article class="spec-content std-content">
+            
+<h1>Standard Library</h1>
+
+<p>Modules.</p>
+
+
+
+<h2>Modules</h2>
+<ul class="spec-section-toc">
+    
+    <li><a href="&#x2F;std&#x2F;01-math&#x2F;">math</a></li>
+    
+</ul>
+
+
+        </article>
+
+        
+        
+
+
+    </div>
+</div>
+
+    </main>
+
+    <footer class="footer-colophon">
+        <div class="inner">
+            <span>© 2025–2026 The Rue Authors · MIT/Apache-2.0</span>
+            <span><em>rue</em>, n. — a hardy evergreen herb; also, what we hope you won’t do after choosing this language.</span>
+        </div>
+    </footer>
+
+    <script>
+        function toggleTheme() {
+            if (document.documentElement.classList.contains('dark')) {
+                document.documentElement.classList.remove('dark');
+                localStorage.theme = 'light';
+            } else {
+                document.documentElement.classList.add('dark');
+                localStorage.theme = 'dark';
+            }
+            updateSyntaxTheme();
+        }
+
+        function toggleMobileMenu() {
+            const menu = document.getElementById('mobile-menu');
+            const toggle = document.querySelector('.mobile-menu-toggle');
+            const isOpen = menu.classList.toggle('open');
+            toggle.classList.toggle('active', isOpen);
+            toggle.setAttribute('aria-expanded', isOpen);
+        }
+
+        // Close mobile menu when clicking a link
+        document.querySelectorAll('.mobile-menu-link').forEach(link => {
+            link.addEventListener('click', () => {
+                const menu = document.getElementById('mobile-menu');
+                const toggle = document.querySelector('.mobile-menu-toggle');
+                menu.classList.remove('open');
+                toggle.classList.remove('active');
+                toggle.setAttribute('aria-expanded', 'false');
+            });
+        });
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/elasticlunr/0.9.5/elasticlunr.min.js"></script>
+    <script src="https:&#x2F;&#x2F;rue-lang.dev&#x2F;search.js"></script>
+</body>
+</html>

--- a/performance/fixtures/gazette/expected/tutorial/01-start/index.html
+++ b/performance/fixtures/gazette/expected/tutorial/01-start/index.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Getting Started - Learn Rue</title>
+    <meta name="description" content="A systems programming language with memory safety and high-level ergonomics">
+    <link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;style.css">
+    <link rel="icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;favicon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;brand&#x2F;apple-touch-icon.png">
+    <link rel="alternate" type="application/rss+xml" title="Rue Blog RSS" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog&#x2F;rss.xml">
+    <script>
+        // Check for saved theme preference or default to system preference
+        const isDark = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (isDark) {
+            document.documentElement.classList.add('dark');
+        }
+        // Write syntax theme stylesheets with correct initial disabled state
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-light.css" id="syntax-light"' + (isDark ? ' disabled' : '') + '>');
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-dark.css" id="syntax-dark"' + (isDark ? '' : ' disabled') + '>');
+
+        function updateSyntaxTheme() {
+            const syntaxLight = document.getElementById('syntax-light');
+            const syntaxDark = document.getElementById('syntax-dark');
+            if (syntaxLight && syntaxDark) {
+                const dark = document.documentElement.classList.contains('dark');
+                syntaxLight.disabled = dark;
+                syntaxDark.disabled = !dark;
+            }
+        }
+    </script>
+</head>
+<body class="min-h-screen flex flex-col">
+    <!-- engraved rue sprig (Ruta graveolens), referenced site-wide via <use> -->
+    <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+      <defs>
+        <g id="rue-sprig" fill="none" stroke="currentColor" stroke-width="1.5"
+           stroke-linecap="round" stroke-linejoin="round">
+          <path d="M16 30 C 16 24, 15.4 18, 16 10"/>
+          <path d="M15.7 22 C 12.5 20.5, 10 19, 8 16.5"/>
+          <path d="M8 16.5 c -2.6 -0.4 -4 -2.4 -3.4 -4.4 c 1.8 -1 4 -0.2 4.6 2 c 0.3 1 0 1.8 -1.2 2.4 z"/>
+          <path d="M11.5 19.2 c -2.4 0.6 -4.3 -0.6 -4.5 -2.6"/>
+          <path d="M16 17.5 C 19.5 16, 22 14.5, 23.8 12"/>
+          <path d="M23.8 12 c 2.6 -0.2 3.9 -2.2 3.2 -4.2 c -1.9 -0.9 -4 0.1 -4.4 2.3 c -0.2 1 0.1 1.7 1.2 1.9 z"/>
+          <path d="M20.4 14.6 c 2.4 0.4 4.2 -0.8 4.3 -2.8"/>
+          <path d="M16 10 c -0.4 -2.8 1 -4.6 3.2 -4.6 c 1.2 1.8 0.5 4 -1.6 4.9 c -0.7 0.3 -1.2 0.2 -1.6 -0.3 z"/>
+          <g stroke="none" fill="var(--color-gold)">
+            <circle cx="12.2" cy="7.4" r="1.15"/>
+            <circle cx="9.9"  cy="9.4" r="1.15"/>
+            <circle cx="12.6" cy="10.6" r="1.15"/>
+            <circle cx="14.4" cy="8.7" r="1.15"/>
+          </g>
+          <circle cx="12.4" cy="9" r="0.8" stroke="none" fill="currentColor"/>
+          <path d="M15.9 13.5 C 14.8 11.8, 13.6 10.6, 12.6 10.4"/>
+        </g>
+      </defs>
+    </svg>
+
+    <div class="colophon-bar">
+        <em>Ruta graveolens</em> &nbsp;·&nbsp; notes from a language experiment &nbsp;·&nbsp; cultivated since 2025
+    </div>
+
+    <nav>
+        <div class="masthead">
+            <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="wordmark">
+                <svg class="sprig" viewBox="0 0 32 32"><use href="#rue-sprig"/></svg>
+                Rue
+            </a>
+            <!-- Desktop navigation -->
+            <div class="nav-desktop flex items-center gap-6">
+                <ul class="flex gap-6">
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="nav-link">Tutorial</a></li>
+<!-- Hardcoded path: spec pages are copied into Zola content at build time -->
+                    <li><a href="/spec/" class="nav-link">Specification</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="nav-link">Performance</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="nav-link">Runtime</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="nav-link">Lab Notes</a></li>
+                    <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="nav-link ext">GitHub</a></li>
+                    <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="nav-link ext">Bluesky</a></li>
+                </ul>
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+            </div>
+            <!-- Mobile navigation controls -->
+            <div class="nav-mobile-controls flex items-center gap-4">
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+                <button onclick="toggleMobileMenu()" class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false">
+                    <svg class="icon-menu w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                    <svg class="icon-close w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+        <!-- Mobile menu overlay -->
+        <div id="mobile-menu" class="mobile-menu">
+            <ul class="mobile-menu-list">
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="mobile-menu-link">Home</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="mobile-menu-link">Tutorial</a></li>
+                <li><a href="/spec/" class="mobile-menu-link">Specification</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="mobile-menu-link">Performance</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="mobile-menu-link">Runtime</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="mobile-menu-link">Lab Notes</a></li>
+                <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="mobile-menu-link">GitHub</a></li>
+                <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="mobile-menu-link">Bluesky</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <main class="flex-1">
+        
+<div class="spec-layout">
+    
+    <aside class="spec-sidebar">
+        <div class="spec-sidebar-inner">
+            <div class="spec-sidebar-header">
+                <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="spec-title">Learn Rue</a>
+            </div>
+            <nav class="spec-nav">
+                
+                
+                
+<ul class="spec-nav-list">
+    
+    <li class="spec-nav-item">
+        <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial&#x2F;01-start&#x2F;" class="spec-nav-link active">
+            Getting Started
+        </a>
+    </li>
+    
+</ul>
+
+            </nav>
+        </div>
+    </aside>
+
+    
+    <div class="spec-main">
+        <article class="spec-content tutorial-content">
+            
+<p>Install it, then run it.</p>
+
+
+        </article>
+
+        
+        
+        <nav class="spec-page-nav">
+            
+            <span></span>
+            
+            
+        </nav>
+        
+    </div>
+</div>
+
+    </main>
+
+    <footer class="footer-colophon">
+        <div class="inner">
+            <span>© 2025–2026 The Rue Authors · MIT/Apache-2.0</span>
+            <span><em>rue</em>, n. — a hardy evergreen herb; also, what we hope you won’t do after choosing this language.</span>
+        </div>
+    </footer>
+
+    <script>
+        function toggleTheme() {
+            if (document.documentElement.classList.contains('dark')) {
+                document.documentElement.classList.remove('dark');
+                localStorage.theme = 'light';
+            } else {
+                document.documentElement.classList.add('dark');
+                localStorage.theme = 'dark';
+            }
+            updateSyntaxTheme();
+        }
+
+        function toggleMobileMenu() {
+            const menu = document.getElementById('mobile-menu');
+            const toggle = document.querySelector('.mobile-menu-toggle');
+            const isOpen = menu.classList.toggle('open');
+            toggle.classList.toggle('active', isOpen);
+            toggle.setAttribute('aria-expanded', isOpen);
+        }
+
+        // Close mobile menu when clicking a link
+        document.querySelectorAll('.mobile-menu-link').forEach(link => {
+            link.addEventListener('click', () => {
+                const menu = document.getElementById('mobile-menu');
+                const toggle = document.querySelector('.mobile-menu-toggle');
+                menu.classList.remove('open');
+                toggle.classList.remove('active');
+                toggle.setAttribute('aria-expanded', 'false');
+            });
+        });
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/elasticlunr/0.9.5/elasticlunr.min.js"></script>
+    <script src="https:&#x2F;&#x2F;rue-lang.dev&#x2F;search.js"></script>
+</body>
+</html>

--- a/performance/fixtures/gazette/expected/tutorial/index.html
+++ b/performance/fixtures/gazette/expected/tutorial/index.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Learn - Learn Rue</title>
+    <meta name="description" content="A systems programming language with memory safety and high-level ergonomics">
+    <link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;style.css">
+    <link rel="icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;favicon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;brand&#x2F;apple-touch-icon.png">
+    <link rel="alternate" type="application/rss+xml" title="Rue Blog RSS" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog&#x2F;rss.xml">
+    <script>
+        // Check for saved theme preference or default to system preference
+        const isDark = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (isDark) {
+            document.documentElement.classList.add('dark');
+        }
+        // Write syntax theme stylesheets with correct initial disabled state
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-light.css" id="syntax-light"' + (isDark ? ' disabled' : '') + '>');
+        document.write('<link rel="stylesheet" href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;syntax-dark.css" id="syntax-dark"' + (isDark ? '' : ' disabled') + '>');
+
+        function updateSyntaxTheme() {
+            const syntaxLight = document.getElementById('syntax-light');
+            const syntaxDark = document.getElementById('syntax-dark');
+            if (syntaxLight && syntaxDark) {
+                const dark = document.documentElement.classList.contains('dark');
+                syntaxLight.disabled = dark;
+                syntaxDark.disabled = !dark;
+            }
+        }
+    </script>
+</head>
+<body class="min-h-screen flex flex-col">
+    <!-- engraved rue sprig (Ruta graveolens), referenced site-wide via <use> -->
+    <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+      <defs>
+        <g id="rue-sprig" fill="none" stroke="currentColor" stroke-width="1.5"
+           stroke-linecap="round" stroke-linejoin="round">
+          <path d="M16 30 C 16 24, 15.4 18, 16 10"/>
+          <path d="M15.7 22 C 12.5 20.5, 10 19, 8 16.5"/>
+          <path d="M8 16.5 c -2.6 -0.4 -4 -2.4 -3.4 -4.4 c 1.8 -1 4 -0.2 4.6 2 c 0.3 1 0 1.8 -1.2 2.4 z"/>
+          <path d="M11.5 19.2 c -2.4 0.6 -4.3 -0.6 -4.5 -2.6"/>
+          <path d="M16 17.5 C 19.5 16, 22 14.5, 23.8 12"/>
+          <path d="M23.8 12 c 2.6 -0.2 3.9 -2.2 3.2 -4.2 c -1.9 -0.9 -4 0.1 -4.4 2.3 c -0.2 1 0.1 1.7 1.2 1.9 z"/>
+          <path d="M20.4 14.6 c 2.4 0.4 4.2 -0.8 4.3 -2.8"/>
+          <path d="M16 10 c -0.4 -2.8 1 -4.6 3.2 -4.6 c 1.2 1.8 0.5 4 -1.6 4.9 c -0.7 0.3 -1.2 0.2 -1.6 -0.3 z"/>
+          <g stroke="none" fill="var(--color-gold)">
+            <circle cx="12.2" cy="7.4" r="1.15"/>
+            <circle cx="9.9"  cy="9.4" r="1.15"/>
+            <circle cx="12.6" cy="10.6" r="1.15"/>
+            <circle cx="14.4" cy="8.7" r="1.15"/>
+          </g>
+          <circle cx="12.4" cy="9" r="0.8" stroke="none" fill="currentColor"/>
+          <path d="M15.9 13.5 C 14.8 11.8, 13.6 10.6, 12.6 10.4"/>
+        </g>
+      </defs>
+    </svg>
+
+    <div class="colophon-bar">
+        <em>Ruta graveolens</em> &nbsp;·&nbsp; notes from a language experiment &nbsp;·&nbsp; cultivated since 2025
+    </div>
+
+    <nav>
+        <div class="masthead">
+            <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="wordmark">
+                <svg class="sprig" viewBox="0 0 32 32"><use href="#rue-sprig"/></svg>
+                Rue
+            </a>
+            <!-- Desktop navigation -->
+            <div class="nav-desktop flex items-center gap-6">
+                <ul class="flex gap-6">
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="nav-link">Tutorial</a></li>
+<!-- Hardcoded path: spec pages are copied into Zola content at build time -->
+                    <li><a href="/spec/" class="nav-link">Specification</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="nav-link">Performance</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="nav-link">Runtime</a></li>
+                    <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="nav-link">Lab Notes</a></li>
+                    <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="nav-link ext">GitHub</a></li>
+                    <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="nav-link ext">Bluesky</a></li>
+                </ul>
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+            </div>
+            <!-- Mobile navigation controls -->
+            <div class="nav-mobile-controls flex items-center gap-4">
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+                <button onclick="toggleMobileMenu()" class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false">
+                    <svg class="icon-menu w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                    <svg class="icon-close w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+        <!-- Mobile menu overlay -->
+        <div id="mobile-menu" class="mobile-menu">
+            <ul class="mobile-menu-list">
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;" class="mobile-menu-link">Home</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="mobile-menu-link">Tutorial</a></li>
+                <li><a href="/spec/" class="mobile-menu-link">Specification</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;performance" class="mobile-menu-link">Performance</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;runtime" class="mobile-menu-link">Runtime</a></li>
+                <li><a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;blog" class="mobile-menu-link">Lab Notes</a></li>
+                <li><a href="https:&#x2F;&#x2F;github.com&#x2F;rue-language&#x2F;rue" class="mobile-menu-link">GitHub</a></li>
+                <li><a href="https:&#x2F;&#x2F;bsky.app&#x2F;profile&#x2F;rue-lang.dev" class="mobile-menu-link">Bluesky</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <main class="flex-1">
+        
+<div class="spec-layout">
+    
+    <aside class="spec-sidebar">
+        <div class="spec-sidebar-inner">
+            <div class="spec-sidebar-header">
+                <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial" class="spec-title">Learn Rue</a>
+            </div>
+            <nav class="spec-nav">
+                
+                
+                
+<ul class="spec-nav-list">
+    
+    <li class="spec-nav-item">
+        <a href="https:&#x2F;&#x2F;rue-lang.dev&#x2F;tutorial&#x2F;01-start&#x2F;" class="spec-nav-link ">
+            Getting Started
+        </a>
+    </li>
+    
+</ul>
+
+            </nav>
+        </div>
+    </aside>
+
+    
+    <div class="spec-main">
+        <article class="spec-content tutorial-content">
+            
+<h1>Learn</h1>
+
+<p>Start here.</p>
+
+
+
+<h2>Chapters</h2>
+<ul class="spec-section-toc">
+    
+    <li><a href="&#x2F;tutorial&#x2F;01-start&#x2F;">Getting Started</a></li>
+    
+</ul>
+
+
+        </article>
+
+        
+        
+
+
+    </div>
+</div>
+
+    </main>
+
+    <footer class="footer-colophon">
+        <div class="inner">
+            <span>© 2025–2026 The Rue Authors · MIT/Apache-2.0</span>
+            <span><em>rue</em>, n. — a hardy evergreen herb; also, what we hope you won’t do after choosing this language.</span>
+        </div>
+    </footer>
+
+    <script>
+        function toggleTheme() {
+            if (document.documentElement.classList.contains('dark')) {
+                document.documentElement.classList.remove('dark');
+                localStorage.theme = 'light';
+            } else {
+                document.documentElement.classList.add('dark');
+                localStorage.theme = 'dark';
+            }
+            updateSyntaxTheme();
+        }
+
+        function toggleMobileMenu() {
+            const menu = document.getElementById('mobile-menu');
+            const toggle = document.querySelector('.mobile-menu-toggle');
+            const isOpen = menu.classList.toggle('open');
+            toggle.classList.toggle('active', isOpen);
+            toggle.setAttribute('aria-expanded', isOpen);
+        }
+
+        // Close mobile menu when clicking a link
+        document.querySelectorAll('.mobile-menu-link').forEach(link => {
+            link.addEventListener('click', () => {
+                const menu = document.getElementById('mobile-menu');
+                const toggle = document.querySelector('.mobile-menu-toggle');
+                menu.classList.remove('open');
+                toggle.classList.remove('active');
+                toggle.setAttribute('aria-expanded', 'false');
+            });
+        });
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/elasticlunr/0.9.5/elasticlunr.min.js"></script>
+    <script src="https:&#x2F;&#x2F;rue-lang.dev&#x2F;search.js"></script>
+</body>
+</html>

--- a/performance/fixtures/gazette/site/content/_index.md
+++ b/performance/fixtures/gazette/site/content/_index.md
@@ -1,0 +1,11 @@
++++
+title = "Miniature"
+template = "index.html"
+
+[extra]
+tagline = "a site small enough to read"
++++
+
+```rue
+fn main() -> i32 { 0 }
+```

--- a/performance/fixtures/gazette/site/content/blog/_index.md
+++ b/performance/fixtures/gazette/site/content/blog/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Lab Notes"
+sort_by = "date"
+generate_feeds = true
+template = "blog.html"
++++
+
+Field notes, in miniature.

--- a/performance/fixtures/gazette/site/content/blog/first-note.md
+++ b/performance/fixtures/gazette/site/content/blog/first-note.md
@@ -1,0 +1,19 @@
++++
+title = "First Note"
+date = 2026-01-02
+description = "the earlier post"
+template = "blog-page.html"
+
+[extra]
+authors = ["steve", "claude"]
+prompt = """
+write the first note
+"""
++++
+
+An opening paragraph with **strong** text and a `code span`.
+
+<!-- more -->
+
+The rest of the note, with an [internal link](@/spec/01-introduction.md#scope)
+and an [external one](https://example.test/x).

--- a/performance/fixtures/gazette/site/content/blog/second-note.md
+++ b/performance/fixtures/gazette/site/content/blog/second-note.md
@@ -1,0 +1,18 @@
++++
+title = "Second Note"
+date = 2026-02-03
+template = "blog-page.html"
+
+[extra]
+authors = ["codex"]
++++
+
+| Column | Meaning |
+|--------|---------|
+| `a`    | first   |
+| `\|`   | a pipe  |
+
+- one
+- two
+
+> quoted

--- a/performance/fixtures/gazette/site/content/spec/01-introduction.md
+++ b/performance/fixtures/gazette/site/content/spec/01-introduction.md
@@ -1,0 +1,11 @@
++++
+title = "Introduction"
+weight = 1
+template = "spec/page.html"
++++
+
+# Scope
+
+{{ rule(id="1.1:1") }}
+
+A conforming implementation **MUST** do the thing.

--- a/performance/fixtures/gazette/site/content/spec/02-things/01-first-thing.md
+++ b/performance/fixtures/gazette/site/content/spec/02-things/01-first-thing.md
@@ -1,0 +1,10 @@
++++
+title = "First Thing"
+weight = 1
+template = "spec/page.html"
++++
+
+{{ rule(id="2.1:1") }}
+
+The first thing, which links to
+[the introduction](@/spec/01-introduction.md#scope).

--- a/performance/fixtures/gazette/site/content/spec/02-things/02-second-thing.md
+++ b/performance/fixtures/gazette/site/content/spec/02-things/02-second-thing.md
@@ -1,0 +1,9 @@
++++
+title = "Second Thing"
+weight = 2
+template = "spec/page.html"
++++
+
+{{ preview_feature(feature="second_thing") }}
+
+The second thing.

--- a/performance/fixtures/gazette/site/content/spec/02-things/_index.md
+++ b/performance/fixtures/gazette/site/content/spec/02-things/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Things"
+weight = 2
+sort_by = "weight"
+template = "spec/section.html"
+page_template = "spec/page.html"
++++
+
+Things have parts.

--- a/performance/fixtures/gazette/site/content/spec/_index.md
+++ b/performance/fixtures/gazette/site/content/spec/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Specification"
+sort_by = "weight"
+template = "spec/section.html"
+page_template = "spec/page.html"
+redirect_to = "spec/01-introduction"
++++
+
+The specification index redirects, so this body is never rendered.

--- a/performance/fixtures/gazette/site/content/std/01-math.md
+++ b/performance/fixtures/gazette/site/content/std/01-math.md
@@ -1,0 +1,7 @@
++++
+title = "math"
+weight = 1
+template = "std/page.html"
++++
+
+Arithmetic helpers.

--- a/performance/fixtures/gazette/site/content/std/_index.md
+++ b/performance/fixtures/gazette/site/content/std/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Standard Library"
+sort_by = "weight"
+template = "std/section.html"
+page_template = "std/page.html"
++++
+
+Modules.

--- a/performance/fixtures/gazette/site/content/tutorial/01-start.md
+++ b/performance/fixtures/gazette/site/content/tutorial/01-start.md
@@ -1,0 +1,7 @@
++++
+title = "Getting Started"
+weight = 1
+template = "tutorial/page.html"
++++
+
+Install it, then run it.

--- a/performance/fixtures/gazette/site/content/tutorial/_index.md
+++ b/performance/fixtures/gazette/site/content/tutorial/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Learn"
+sort_by = "weight"
+template = "tutorial/section.html"
+page_template = "tutorial/page.html"
++++
+
+Start here.

--- a/performance/fixtures/gazette/site/static/marker.txt
+++ b/performance/fixtures/gazette/site/static/marker.txt
@@ -1,0 +1,2 @@
+Static passthrough is measured work for every tool in ADR-0072's comparison,
+so the miniature site carries an asset to prove gazette copies one.

--- a/performance/scaling.toml
+++ b/performance/scaling.toml
@@ -5,8 +5,29 @@
 # startup probe's calibrated sample counts or enter the fast headline index.
 # Every sample launches the canonical compiler binary in a fresh process. The
 # compiled program is never run.
+#
+# REVISION 4 adds gazette (ADR-0072 Decision 7, RUE-1484). Adding a workload
+# changes what the curve measures, so it is a suite-revision event under
+# ADR-0067's ordinary rules and revision 3's observations are not continuous
+# with revision 4's.
+#
+# The 60-minute job budget was re-checked for it. The measured work is
+# `workloads x workers x samples` fresh compiler processes: 4 x 5 x 3 = 60
+# before, 5 x 5 x 3 = 75 after. Gazette is 6,524 lines, between mosaic's 6,108
+# and harbor's 9,000, and compiles in roughly half of lattice's wall time, so
+# the added 15 compiles are the smaller half of one existing rung's
+# contribution. Even at lattice's rate the whole measured phase is a few
+# minutes against a budget whose bulk is the thin-LTO release build of the
+# compiler itself. The margin is large rather than marginal; if that ever
+# stops being true the answer is a longer timeout, not a quieter curve.
+#
+# THESE ARE THE ONLY RECORDED COMPILE-TIME MEASUREMENTS OF GAZETTE. ADR-0072's
+# per-push runtime leg also compiles gazette, because it has to run it, and
+# that compile's timing is deliberately not recorded anywhere: a one-sample
+# compile from the runtime job matches no declared epoch here or in
+# `manifest.toml`, and ADR-0067's validation would rightly refuse to append it.
 schema_version = 3
-revision = 3
+revision = 4
 samples = 3
 args = []
 compiler_build_profile = "release_thin_lto"
@@ -23,6 +44,15 @@ question = "How does the compiler handle a small maintained compiler frontend?"
 id = "mosaic"
 source = "examples/mosaic/main.rue"
 question = "How does compilation scale to a medium multi-module application?"
+
+# Between mosaic and harbor, not after them. `workloads` is in report order and
+# nothing sorts it downstream, so the ladder's ascending shape is this list's
+# order: 2,222 -> 6,108 -> 6,524 -> 9,000 -> 13,030 lines. Placed anywhere else
+# the published curve zigzags and stops reading as a scale curve at all.
+[[workloads]]
+id = "gazette"
+source = "examples/gazette/main.rue"
+question = "How does compilation scale to a real text-processing program — parsers, a template engine, and a site model?"
 
 [[workloads]]
 id = "harbor"

--- a/scripts/gazette-corpus-diff.py
+++ b/scripts/gazette-corpus-diff.py
@@ -1,26 +1,36 @@
 #!/usr/bin/env python3
-"""Differential check of gazette's Markdown rendering against pinned Zola.
+"""Corpus-driven checks of gazette against the LIVE rue-lang.dev corpus.
 
-ADR-0072 Phase 3 (RUE-1483) delivers gazette's three text-processing libraries.
-The correctness bar for the Markdown one is the LIVE rue-lang.dev corpus, not
-the CommonMark suite, so the only honest check is to render that corpus with
-both tools and compare. This is that check, kept in the repository because the
-claim "gazette agrees with Zola on the corpus" is worthless if reproducing it
-means rebuilding the apparatus from scratch. ADR-0072 Decision 4 needs the same
-comparison for its semantic oracle, so Phase 4 inherits this rather than
-starting over.
+Two modes, one apparatus. Both assemble the corpus exactly as
+`website/build.sh` does — site content plus the copied specification, with the
+spec's internal links rewritten — because ADR-0072 Decision 2 measures the site
+as it actually exists rather than a frozen snapshot.
 
-WHAT IS COMPARED is the rendered Markdown body of every content page — Zola's
-`page.content` — and nothing else. Template application, section indexes, and
-the feed are RUE-1484's, and the template ports are RUE-1485's. Both tools are
-therefore driven with body-only templates.
+    scripts/gazette-corpus-diff.py body
+        RUE-1483's Markdown differential. Renders every content page's BODY
+        with gazette and with the pinned Zola and compares byte for byte. The
+        correctness bar for the Markdown library is this corpus, not the
+        CommonMark suite, so the only honest check is to render it with both
+        tools and compare.
 
-THE COMPARISON IS BYTE-FOR-BYTE, and that is the point. An earlier structural
-comparison normalized HTML entities and collapsed whitespace, which silently
-erased two entire classes of real difference. Here every difference must be
-either byte-identical or attributable to one NAMED, documented divergence class
-below; anything else fails the run. The structural view is still reported, as a
-second and weaker layer, never as the headline.
+    scripts/gazette-corpus-diff.py site [--scale N]
+        RUE-1484's whole-site validation. Prepares a fixture (corpus, static
+        assets, template port, and the deterministic scale variants), records
+        the fixture identity, builds it with gazette several times, and judges
+        the result: determinism, file set, the semantic oracle on every emitted
+        page, spot goldens, and the wall-clock/RSS/binary-size metrics
+        ADR-0072 Decision 5 records per sample.
+
+    scripts/gazette-corpus-diff.py golden [--bless]
+        The markup-level spot goldens, over the committed miniature site in
+        `performance/fixtures/gazette/`.
+
+WHAT `body` COMPARES is the rendered Markdown body of every content page —
+Zola's `page.content` — and nothing else. THE COMPARISON IS BYTE-FOR-BYTE, and
+that is the point. An earlier structural comparison normalized HTML entities
+and collapsed whitespace, which silently erased two entire classes of real
+difference. Here every difference must be either byte-identical or attributable
+to one NAMED, documented divergence class below; anything else fails the run.
 
 DOCUMENTED DIVERGENCE CLASSES, all three from Zola's side of the comparison:
 
@@ -55,28 +65,62 @@ DOCUMENTED DIVERGENCE CLASSES, all three from Zola's side of the comparison:
       pulldown-cmark writer asymmetry rather than a rule. Cross-tool whitespace
       is a non-goal (ADR-0072 Terminology).
 
-EXCLUDED PAGES are listed in EXCLUSIONS with a reason each. There is exactly
-one, and it is excluded because Zola does not render it at all.
-
-Usage:
-    scripts/gazette-corpus-diff.py [--gazette PATH] [--keep] [--verbose]
+None of the three survives the structural extraction the `site` oracle uses:
+entity references are decoded, whitespace is collapsed, and `class`/`data-lang`
+attributes are not kept. That is why the oracle needs no normalizer table of
+its own — it compares what the two tools genuinely have to agree on.
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import html.parser
+import json
 import os
+import platform
 import re
 import shutil
 import subprocess
 import sys
 import tempfile
+import time
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_URL = "https://rue-lang.dev"
 
-# Pages Zola emits no rendered body for. Each entry must name the reason.
+# The gazette half of ADR-0072 Decision 2's "template ports and parity
+# configurations". The DIGEST below is the authoritative identity — it is
+# computed from the bytes and cannot drift — and this integer is the
+# human-legible label a maintainer bumps when changing the port deliberately,
+# so a reader of two observations can say "the port moved" without diffing two
+# hashes. Both ride every recorded identity.
+PORT_REVISION = 1
+PORT_ROOTS = [
+    "examples/gazette/config.toml",
+    "examples/gazette/templates",
+]
+
+# The production template set the port derives from, as it stood when
+# PORT_REVISION was last set. ADR-0072's Consequences name the risk this
+# discharges: "Production drift away from the ports quietly erodes the live
+# framing, so website-template changes should include a port review." A comment
+# asking for a review is not a review, so the digest is pinned and the `golden`
+# mode fails when it moves.
+#
+# When it fires, the fix is to look at what changed in `website/templates/`,
+# decide whether the port should follow, change the port if it should, then
+# advance PORT_REVISION and paste the new digest here. Advancing the revision
+# is not busywork: it is what moves the recorded fixture identity, which is
+# what starts a new comparable segment in the series rather than shifting an
+# existing one under a reader.
+PRODUCTION_TEMPLATE_ROOT = "website/templates"
+PRODUCTION_TEMPLATE_DIGEST = (
+    "47d52cd447662e02d6f7a76b7d14eafffc1b4602788b8e9547a303be528d87ec"
+)
+
+# Pages Zola emits no rendered body for, so `body` mode has nothing to compare
+# against. Each entry must name the reason.
 EXCLUSIONS = {
     "spec/_index.md": (
         "front matter sets `redirect_to`, so Zola emits a redirect stub instead "
@@ -84,13 +128,61 @@ EXCLUSIONS = {
     ),
 }
 
+# Content EXCLUDED FROM THE BENCHMARK CORPUS, visibly rather than silently
+# (ADR-0072 Decision 3). Both entries are the same carve-out: a page whose
+# template reads derived benchmark data at build time would make the benchmark
+# an input to its own workload. `performance.md` is the carve-out the ADR names;
+# `runtime.md` is RUE-1049's page and is the same page in every respect that
+# matters here.
+#
+# The exclusion is applied at fixture-preparation time and the excluded set is
+# part of the recorded identity, so a page joining or leaving this table moves
+# the fixture identity and starts a new comparable segment.
+CORPUS_EXCLUSIONS = {
+    "performance.md": (
+        "the performance dashboard renders derived benchmark data, so building "
+        "it would make the benchmark an input to its own workload (ADR-0072 "
+        "Decision 3)"
+    ),
+    "runtime.md": (
+        "the runtime dashboard is the same carve-out as performance.md: it "
+        "renders the very series this workload produces"
+    ),
+}
+
+# Internal links the LIVE CONTENT gets wrong, which Zola resolves exactly the
+# same way and emits exactly as dead. Gazette's job is to reproduce the routing,
+# not to repair the corpus, so each one is allowed here with its reason rather
+# than either failing the benchmark or being swept under a permissive rule.
+#
+# Each entry declares HOW MANY TIMES the dead route is expected to appear per
+# copy of the corpus, and the count is asserted. AGENTS.md sets the convention
+# for `known_bug` markers — when the bug is fixed, find its cases and remove
+# the marker — and an allowlist that could only ever grow would be the opposite
+# convention. So the check fails two ways: an entry that stops appearing is
+# stale and must go, and an entry that starts appearing MORE is new breakage
+# hiding behind an old excuse.
+KNOWN_BROKEN_LINKS = {
+    "std/math/": (
+        1,
+        "the standard-library index links `math/` relative to `/std/`, but the "
+        "page is `01-math.md` and so routes to `/std/01-math/`",
+    ),
+}
+
+# Links per page into the two excluded pages: the desktop navigation bar names
+# both, and the mobile menu names both again. Asserted rather than printed, for
+# the reason the count exists at all — an exclusion is only "visible rather
+# than silent" if a change in its blast radius is visible too.
+EXCLUDED_LINKS_PER_PAGE = 4
+
 
 # ---------------------------------------------------------------------------
 # Corpus assembly — exactly what website/build.sh does
 # ---------------------------------------------------------------------------
 
 
-def assemble_corpus(dest: str) -> list[str]:
+def assemble_corpus(dest: str, exclude: dict | None = None) -> list[str]:
     """Copy site content plus the specification, rewriting spec-internal links."""
     shutil.copytree(os.path.join(REPO, "website", "content"), dest)
     spec_dest = os.path.join(dest, "spec")
@@ -108,6 +200,11 @@ def assemble_corpus(dest: str) -> list[str]:
                 body = handle.read()
             with open(path, "w", encoding="utf-8") as handle:
                 handle.write(pattern.sub(r"@/spec/\1", body))
+
+    for rel in exclude or {}:
+        victim = os.path.join(dest, rel)
+        if os.path.exists(victim):
+            os.remove(victim)
 
     pages = []
     for dirpath, _dirs, files in os.walk(dest):
@@ -307,16 +404,7 @@ def structure(page: str) -> list:
     return parser.events
 
 
-# ---------------------------------------------------------------------------
-
-
-def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--gazette", help="prebuilt gazette binary")
-    parser.add_argument("--keep", action="store_true", help="keep the work tree")
-    parser.add_argument("--verbose", action="store_true", help="print every page")
-    options = parser.parse_args()
-
+def body_mode(options) -> int:
     work = tempfile.mkdtemp(prefix="gazette-corpus-")
     try:
         corpus = os.path.join(work, "content")
@@ -413,6 +501,948 @@ def main() -> int:
             print("\nwork tree kept at %s" % work)
         else:
             shutil.rmtree(work, ignore_errors=True)
+
+
+# ===========================================================================
+# site mode — ADR-0072 Phase 4 (RUE-1484)
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# An independent model of the corpus
+# ---------------------------------------------------------------------------
+#
+# Everything below re-derives, from the source tree, what the emitted site
+# ought to contain. It is deliberately a SECOND implementation of gazette's
+# routing, section, and ordering rules rather than a reading of gazette's
+# output: an oracle that asked the program under test what the answer was would
+# check nothing. It covers exactly the front-matter subset gazette documents,
+# and only the keys the model needs.
+
+FRONT_MATTER = re.compile(r"\A\+\+\+\r?\n(.*?)^\+\+\+\r?\n", re.S | re.M)
+SCALAR = re.compile(r'^([A-Za-z0-9_-]+)\s*=\s*(.+?)\s*$', re.M)
+
+
+def read_front_matter(path: str) -> dict:
+    text = open(path, encoding="utf-8").read()
+    found = FRONT_MATTER.match(text)
+    if not found:
+        raise SystemExit("%s does not open with a `+++` fence" % path)
+    fields: dict = {}
+    table = None
+    for line in found.group(1).splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("[") and stripped.endswith("]"):
+            table = stripped[1:-1]
+            fields[table] = {}
+            continue
+        pair = SCALAR.match(stripped)
+        if not pair:
+            continue
+        key, raw = pair.group(1), pair.group(2)
+        # Strip a trailing comment outside quotes, as gazette's reader does.
+        if '"' not in raw:
+            raw = raw.split("#", 1)[0].strip()
+        if raw.startswith('"""'):
+            value = "<multiline>"
+        elif raw.startswith('"'):
+            value = raw[1:].split('"')[0]
+        elif raw in ("true", "false"):
+            value = raw == "true"
+        elif raw.isdigit():
+            value = int(raw)
+        elif raw.startswith("["):
+            value = [p.strip().strip('"') for p in raw[1:-1].split(",") if p.strip()]
+        else:
+            value = raw
+        if table is None:
+            fields[key] = value
+        else:
+            fields[table][key] = value
+    return fields
+
+
+class Model:
+    """Routes, sections, orderings, and feeds, computed from the source tree."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.pages: dict[str, dict] = {}
+        for dirpath, _dirs, files in os.walk(content):
+            for name in sorted(files):
+                if not name.endswith(".md"):
+                    continue
+                rel = os.path.relpath(os.path.join(dirpath, name), content)
+                rel = rel.replace(os.sep, "/")
+                self.pages[rel] = read_front_matter(os.path.join(content, rel))
+
+        self.sections = {rel: front for rel, front in self.pages.items()
+                         if rel.endswith("_index.md")}
+        self.members: dict[str, list[str]] = {key: [] for key in self.sections}
+        for rel in self.pages:
+            if rel.endswith("_index.md"):
+                continue
+            directory = rel.rsplit("/", 1)[0] + "/" if "/" in rel else ""
+            key = directory + "_index.md"
+            if key not in self.members:
+                raise SystemExit("no `_index.md` for %s" % rel)
+            self.members[key].append(rel)
+        for key, listed in self.members.items():
+            self.members[key] = self.order(key, listed)
+
+        self.subsections: dict[str, list[str]] = {key: [] for key in self.sections}
+        for key in self.sections:
+            directory = key[: -len("_index.md")]
+            if directory == "":
+                continue
+            above = directory[:-1].rsplit("/", 1)[0] + "/" if "/" in directory[:-1] else ""
+            self.subsections[above + "_index.md"].append(key)
+        for key in self.subsections:
+            self.subsections[key].sort()
+
+    def order(self, key: str, listed: list[str]) -> list[str]:
+        """The declared ordering, tie-broken by content path.
+
+        The tie-break is the point. ADR-0072 Decision 2's scale variants
+        duplicate the corpus under path prefixes, so every duplicated page ties
+        with its original on weight, on title, and on date; a rule that stopped
+        at those fields would leave the order up to discovery, and this oracle
+        would then be asserting whatever gazette happened to do. Ending in the
+        path makes the order total, and comparing against it is what turns
+        "the tools' tie-breaks are deterministic" from an assumption into a
+        check.
+        """
+        sort_by = self.sections[key].get("sort_by")
+        if sort_by == "weight":
+            # A missing weight sorts last, never as a zero.
+            return sorted(listed, key=lambda r: (self.pages[r].get("weight", 1 << 62), r))
+        if sort_by == "date":
+            return sorted(listed, key=lambda r: (self._inverse_date(r), r))
+        return sorted(listed)
+
+    def _inverse_date(self, rel: str) -> str:
+        date = str(self.pages[rel].get("date", ""))
+        # Newest first: invert each byte so an ascending sort is descending by
+        # date, and an absent date (the empty string) still lands last.
+        return "".join(chr(255 - ord(c)) for c in date) if date else chr(0)
+
+    def routes(self) -> dict[str, str]:
+        return {rel: route_of(rel) for rel in self.pages}
+
+    def feeds(self) -> list[str]:
+        return sorted(key for key, front in self.sections.items()
+                      if front.get("generate_feeds") is True)
+
+    def redirects(self) -> list[str]:
+        return sorted(key for key, front in self.sections.items()
+                      if front.get("redirect_to"))
+
+    def expected_files(self, static_files: list[str]) -> set[str]:
+        expected = {route_of(rel) + "index.html" for rel in self.pages}
+        for key in self.feeds():
+            expected.add(route_of(key) + "rss.xml")
+        return expected | set(static_files)
+
+
+# ---------------------------------------------------------------------------
+# Fixture preparation and identity
+# ---------------------------------------------------------------------------
+
+
+def walk_files(root: str) -> list[str]:
+    found = []
+    for dirpath, _dirs, files in os.walk(root):
+        for name in files:
+            rel = os.path.relpath(os.path.join(dirpath, name), root)
+            found.append(rel.replace(os.sep, "/"))
+    return sorted(found)
+
+
+def tree_digest(root: str, files: list[str] | None = None) -> tuple[str, int, int]:
+    """A hash over paths, sizes, and contents — the recorded input identity.
+
+    Paths are included, so a file that only moved changes the digest; sizes are
+    included, so no content can be silently truncated to another file's bytes.
+    """
+    listed = walk_files(root) if files is None else files
+    digest = hashlib.sha256()
+    total = 0
+    for rel in listed:
+        path = os.path.join(root, rel)
+        blob = open(path, "rb").read()
+        total += len(blob)
+        digest.update(rel.encode("utf-8"))
+        digest.update(b"\0%d\0" % len(blob))
+        digest.update(blob)
+    return digest.hexdigest(), len(listed), total
+
+
+def duplicate_corpus(content: str, scale: int) -> None:
+    """The deterministic path-prefixed duplication of ADR-0072 Decision 2.
+
+    The originals stay in place and `scale - 1` copies join them under `xN-KK/`
+    prefixes, so the result is exactly `scale` times the page count.
+
+    TWO HONESTY NOTES, both of which the published charts must carry.
+
+    First, this scales PER-PAGE WORK BUT NOT SITE SHAPE. Internal `@/…` links
+    and every `get_section(path=…)` in the templates still name the ORIGINAL
+    content, because the copies are byte-identical to the originals and a copy
+    has no way to refer to itself. Cross-reference resolution therefore stays
+    constant while page count grows. It is a page-count curve, not a
+    site-size curve. `redirect_to` behaves the same way: a duplicated
+    `spec/_index.md` still redirects to the ORIGINAL introduction page, because
+    its front matter names an absolute content path and a copy cannot rewrite
+    itself.
+
+    Second, and following from the first: the specification sidebar COLLAPSES on
+    a duplicated page, and the magnitude is worth stating rather than gesturing
+    at. Its recursion and its `active` class are both gated on the current
+    page's permalink prefixing a subsection's, and a copy's permalink prefixes
+    nothing in the original tree that `get_section` returns, so BOTH arms of the
+    gate go cold. Measured over the 10x fixture's spec pages: the 70 originals
+    render navigations of 2,540 to 6,205 bytes, mean 4,446, with 1.84 `active`
+    markers each; all 630 duplicates render a single byte-identical 2,534-byte
+    navigation with ZERO `active` markers. That is 57% of the original mean, on
+    the majority page class, and at 100x it is 99% of all spec pages.
+
+    So the fixture reproduces, at scale, exactly the page-invariant sidebar
+    ADR-0072 Decision 3 forbids a gazette implementation from producing. The
+    RULE still holds — the program evaluates the gate per page and the data
+    says "no match" — and the cross-tool comparison is unaffected, since every
+    tool builds the identical tree and sees the identical collapse. What it
+    means is that the 10x and 100x points understate per-page templating work
+    relative to 1x, so the curve cannot be read as "what a 1x page costs, times
+    N", and the fairness evidence that the navigation is page-dependent is 1x
+    evidence.
+    """
+    if scale <= 1:
+        return
+    original = tempfile.mkdtemp(prefix="gazette-1x-")
+    shutil.rmtree(original)
+    shutil.copytree(content, original)
+    try:
+        for index in range(scale - 1):
+            shutil.copytree(original, os.path.join(content, "x%d-%02d" % (scale, index)))
+    finally:
+        shutil.rmtree(original, ignore_errors=True)
+
+
+def prepare_fixture(root: str, scale: int) -> dict:
+    """Assemble a complete gazette site and record its input identity.
+
+    Everything here happens OUTSIDE the measured window (ADR-0071's boundary
+    discipline): the corpus assembly, the scale duplication, and the hashing
+    are fixture preparation, and only the build that follows is timed.
+    """
+    content = os.path.join(root, "content")
+    assemble_corpus(content, CORPUS_EXCLUSIONS)
+    content_digest, content_files, content_bytes = tree_digest(content)
+    duplicate_corpus(content, scale)
+
+    shutil.copytree(os.path.join(REPO, "examples", "gazette", "templates"),
+                    os.path.join(root, "templates"))
+    shutil.copy(os.path.join(REPO, "examples", "gazette", "config.toml"),
+                os.path.join(root, "config.toml"))
+
+    static_source = os.path.join(REPO, "website", "static")
+    static_files = [rel for rel in walk_files(static_source)
+                    # Derived at site-build time and never committed; including
+                    # it would make the fixture identity move with every
+                    # collection run rather than with the site.
+                    if rel != "performance-data.json"]
+    static_digest, static_count, static_bytes = tree_digest(static_source, static_files)
+    shutil.copytree(static_source, os.path.join(root, "static"),
+                    ignore=shutil.ignore_patterns("performance-data.json"))
+
+    port_digest = hashlib.sha256()
+    port_files = 0
+    port_bytes = 0
+    for entry in PORT_ROOTS:
+        path = os.path.join(REPO, entry)
+        if os.path.isdir(path):
+            digest, count, size = tree_digest(path)
+        else:
+            digest, count, size = tree_digest(os.path.dirname(path),
+                                              [os.path.basename(path)])
+        port_digest.update(entry.encode("utf-8"))
+        port_digest.update(digest.encode("ascii"))
+        port_files += count
+        port_bytes += size
+
+    identity = {
+        "scale": scale,
+        "content_digest": content_digest,
+        "content_files": content_files,
+        "content_bytes": content_bytes,
+        "static_digest": static_digest,
+        "static_files": static_count,
+        "static_bytes": static_bytes,
+        "port_revision": PORT_REVISION,
+        "port_digest": port_digest.hexdigest(),
+        "port_files": port_files,
+        "port_bytes": port_bytes,
+        "excluded": sorted(CORPUS_EXCLUSIONS),
+    }
+    # One digest over all of it, so an observation can be matched to a segment
+    # with a single comparison. Every input class is inside it: no static asset,
+    # template, or configuration change can alter the measured job without
+    # changing this value.
+    fingerprint = hashlib.sha256()
+    for key in sorted(identity):
+        fingerprint.update(("%s=%s;" % (key, identity[key])).encode("utf-8"))
+    identity["fixture_digest"] = fingerprint.hexdigest()
+    return identity
+
+
+# ---------------------------------------------------------------------------
+# Measurement
+# ---------------------------------------------------------------------------
+
+
+def rss_bytes(raw: int) -> int:
+    """`ru_maxrss` in bytes. Kilobytes on Linux, bytes on Darwin."""
+    return raw if platform.system() == "Darwin" else raw * 1024
+
+
+def run_build(gazette: str, root: str, out: str) -> dict:
+    """One measured build: wall clock and THIS CHILD's peak RSS, spawn to exit.
+
+    The rusage is reaped from the child itself with `wait4`, and that detail is
+    the whole of the measurement's honesty. `getrusage(RUSAGE_CHILDREN)` is a
+    cumulative high-water mark over every child the process has ever reaped, so
+    reading it around a spawn reports the largest child so far rather than this
+    one — and this script's default path has just run the Rue compiler at
+    roughly 210 MiB to produce the binary it is about to measure. Every sample
+    at every scale then reported the compiler's footprint: 210.9, 210.1, and
+    206.9 MiB where gazette's true peaks are 4.4, 11.3, and 104.9. The reported
+    figure was not merely wrong, it was FLAT and slightly decreasing across a
+    range over which the real one grows 24x, which is exactly the shape a
+    reader would conclude something from.
+
+    Two properties follow from `wait4` that the old reading could not have.
+    The number is this process's alone, so it is unaffected by anything built
+    or measured before it; and it is per sample rather than a running maximum,
+    which is what ADR-0072 Decision 5 records.
+    """
+    start = time.perf_counter()
+    process = subprocess.Popen([gazette, "build", root, "-o", out],
+                               stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                               text=True)
+    # Drain before reaping: `wait4` does not consume the pipes, and a child
+    # that filled one would block forever waiting for a reader.
+    stdout = process.stdout.read()
+    stderr = process.stderr.read()
+    _pid, status, usage = os.wait4(process.pid, 0)
+    wall = time.perf_counter() - start
+    # The child is already reaped, so `Popen` must be told rather than left to
+    # call `waitpid` on a pid that no longer exists.
+    process.returncode = os.waitstatus_to_exitcode(status)
+    process.stdout.close()
+    process.stderr.close()
+    return {
+        "wall_seconds": wall,
+        "peak_rss_bytes": rss_bytes(usage.ru_maxrss),
+        "exit_code": process.returncode,
+        "stdout": stdout,
+        "stderr": stderr,
+    }
+
+
+def tree_hash(root: str) -> str:
+    digest, _count, _bytes = tree_digest(root)
+    return digest
+
+
+# ---------------------------------------------------------------------------
+# The semantic oracle
+# ---------------------------------------------------------------------------
+
+SEP = "\x1e"
+
+
+def event_text(events: list) -> str:
+    return SEP + SEP.join("%s\x1f%s" % (tag, extra) for tag, extra in events) + SEP
+
+
+def contains_run(page_events: list, body_events: list) -> bool:
+    """Whether the body's event stream appears CONTIGUOUSLY inside the page's.
+
+    This is the load-bearing half of ADR-0072 Decision 4's semantic oracle, and
+    it is one comparison rather than six because the event stream already IS
+    the normalized extraction: heading tree, visible text, link targets, image
+    targets, and shortcode expansion results, in document order, with entities
+    decoded, whitespace collapsed, and presentational attributes dropped.
+
+    Contiguity is what makes it strong. A renderer that consistently dropped
+    body content from every page would pass determinism, the file set, and
+    every structural count, and would fail here on the first page — and so
+    would one that dropped a single paragraph, reordered two headings, or
+    resolved one link differently.
+    """
+    if not body_events:
+        return True
+    return event_text(page_events).find(event_text(body_events)) >= 0
+
+
+def diagnose(page_events: list, body_events: list) -> str:
+    """Which facet diverged, for a page whose body run was not found."""
+    def headings(events):
+        out, capture, level = [], None, None
+        for tag, extra in events:
+            if capture is not None:
+                if tag == ">" + level:
+                    out.append((level, capture))
+                    capture, level = None, None
+                elif tag == "#text":
+                    capture = (capture + " " + extra).strip()
+            elif tag in ("<h1", "<h2", "<h3", "<h4", "<h5", "<h6"):
+                level, capture = tag[1:], ""
+        return out
+
+    def links(events):
+        return [dict(extra).get("href") for tag, extra in events
+                if tag == "<a" and dict(extra).get("href")]
+
+    def words(events):
+        return [extra for tag, extra in events if tag == "#text"]
+
+    faults = []
+    for name, extract in (("headings", headings), ("links", links), ("text", words)):
+        want, have = extract(body_events), extract(page_events)
+        missing = [item for item in want if item not in have]
+        if missing:
+            faults.append("%s: %d of %d missing, first %r"
+                          % (name, len(missing), len(want), missing[0]))
+    return "; ".join(faults) or "body events present but not contiguous"
+
+
+def check_semantics(out: str, corpus: str, model: Model, gazette: str,
+                    work: str, verbose: bool) -> tuple[int, list[str]]:
+    """Compare every emitted page's body semantics against Zola's rendering.
+
+    The anchor is deliberately an OTHER TOOL. Phase 5 (RUE-1485) compares the
+    full page across three tools; what is available here is Zola rendering the
+    same corpus through body-only templates, which is exactly the independent
+    authority this check needs and is already built for `body` mode. It runs at
+    1x only: the scale variants' pages are the same documents at different
+    permalinks, so a second and third Zola build of 960 and 9,600 copies would
+    buy nothing the 1x run has not already established, and the peer leg is
+    Phase 5's to schedule.
+    """
+    pages = sorted(model.pages)
+    public = render_with_zola(corpus, pages, os.path.join(work, "zola-oracle"))
+    redirects = set(model.redirects())
+    checked = 0
+    failures = []
+    for rel in pages:
+        if rel in redirects:
+            # Zola emits its redirect stub here rather than a body, so there is
+            # no body semantics to compare. `check_redirects` asserts the thing
+            # that actually matters about the page — its target — and the spot
+            # goldens cover its markup.
+            continue
+        route = route_of(rel)
+        emitted = os.path.join(out, route, "index.html")
+        reference = os.path.join(public, route, "index.html")
+        if not os.path.exists(reference):
+            # Zola emits its own redirect stub here and no body; gazette emits
+            # its port's stub. The file set check covers the page's existence,
+            # and the redirect target is checked separately.
+            continue
+        if not os.path.exists(emitted):
+            failures.append("%s: gazette emitted no page" % rel)
+            continue
+        page_events = structure(open(emitted, encoding="utf-8").read())
+        body_events = structure(open(reference, encoding="utf-8").read())
+        checked += 1
+        if not contains_run(page_events, body_events):
+            failures.append("%s: %s" % (rel, diagnose(page_events, body_events)))
+        elif verbose:
+            print("  oracle ok  %s (%d body events)" % (rel, len(body_events)))
+    return checked, failures
+
+
+def check_metadata(out: str, model: Model) -> list[str]:
+    """Front-matter metadata reaches the page it describes.
+
+    Weaker than the body oracle by construction: WHICH metadata a page shows is
+    a property of the template port rather than of the corpus, so this asserts
+    only what every port template provably surfaces — the title as visible text,
+    and the ISO date on a dated page. The full normalized metadata rides the
+    recorded oracle digest, so a change in it is visible in the data even where
+    it is not asserted here.
+    """
+    faults = []
+    for rel, front in sorted(model.pages.items()):
+        if rel in model.redirects():
+            continue
+        path = os.path.join(out, route_of(rel), "index.html")
+        if not os.path.exists(path):
+            continue
+        page = open(path, encoding="utf-8").read()
+        text = " ".join(word for tag, word in structure(page) if tag == "#text")
+        title = str(front.get("title", ""))
+        if title and title not in text and html_unescape(title) not in text:
+            faults.append("%s: title %r absent from the emitted page" % (rel, title))
+        date = str(front.get("date", ""))
+        if date and date not in page:
+            faults.append("%s: date %r absent from the emitted page" % (rel, date))
+    return faults
+
+
+def html_unescape(value: str) -> str:
+    import html as html_module
+    return html_module.unescape(value)
+
+
+def check_membership(out: str, model: Model) -> list[str]:
+    """Every section index links its own pages, in the declared order.
+
+    The emitted page carries the sidebar's copy of the list as well as the
+    index's, so the assertion is that the model's ordered routes appear as a
+    CONTIGUOUS RUN among the links into that section, and that no link into the
+    section names a page the model does not place there. That catches a page
+    filed under the wrong section, a page dropped from an index, and a
+    reordering, without depending on how many times a template chooses to
+    render the list.
+    """
+    faults = []
+    redirects = set(model.redirects())
+    for key, listed in sorted(model.members.items()):
+        if not listed or key in redirects:
+            # A redirect section emits a stub in place of an index, so it lists
+            # nothing to check. `check_redirects` covers it.
+            continue
+        path = os.path.join(out, route_of(key), "index.html")
+        if not os.path.exists(path):
+            faults.append("%s: no emitted section index" % key)
+            continue
+        wanted = [route_of(rel) for rel in listed]
+        owned = set(wanted)
+        # Only links INTO this section are collected. A link out of it —
+        # including a relative one the content itself got wrong — is the
+        # dangling-link check's business, not this one's.
+        seen = []
+        for tag, extra in structure(open(path, encoding="utf-8").read()):
+            if tag != "<a":
+                continue
+            href = dict(extra).get("href")
+            if not href:
+                continue
+            route = href_route(href)
+            if route is None:
+                continue
+            if route in owned:
+                seen.append(route)
+        if not run_within(seen, wanted):
+            faults.append("%s: expected order %s, emitted %s"
+                          % (key, wanted[:4], seen[:8]))
+    return faults
+
+
+def run_within(haystack: list[str], needle: list[str]) -> bool:
+    if not needle:
+        return True
+    for start in range(len(haystack) - len(needle) + 1):
+        if haystack[start:start + len(needle)] == needle:
+            return True
+    return False
+
+
+def href_route(href: str) -> str | None:
+    """The site route an href names, or None when it names something else."""
+    if href.startswith(BASE_URL):
+        rest = href[len(BASE_URL):]
+    elif href.startswith("/") and not href.startswith("//"):
+        rest = href
+    else:
+        return None
+    rest = rest.split("#", 1)[0].split("?", 1)[0]
+    return rest.lstrip("/")
+
+
+SCALE_PREFIX = re.compile(r"^x\d+-\d\d/")
+
+
+def unprefixed(route: str) -> str:
+    """A route with any scale-variant path prefix removed.
+
+    The copies are byte-identical to the originals, so anything true of an
+    original route is true of every copy of it, and a table keyed on original
+    routes should not need one entry per duplication factor.
+    """
+    return SCALE_PREFIX.sub("", route)
+
+
+def route_exists(route: str, emitted: set, directories: set) -> bool:
+    """Whether a route names something the site emitted.
+
+    A route is accepted with or without its trailing slash. `get_url(path=
+    'tutorial')` produces an unslashed URL in Zola too, and the real site
+    serves it by redirect, so treating the two forms as different would report
+    every navigation link in the corpus as broken.
+    """
+    key = route.rstrip("/")
+    if key == "":
+        return "index.html" in emitted
+    return (key in emitted
+            or key + "/index.html" in emitted
+            or key + "/" in directories)
+
+
+def check_links(out: str, model: Model, scale: int) -> tuple[int, int, int, list[str]]:
+    """No internal link points at a route the site does not emit.
+
+    Two categories are tolerated, and BOTH are asserted rather than merely
+    counted, because a tolerated category whose size nobody checks is how an
+    allowlist turns into a blindfold.
+
+    Links into EXCLUDED content: the two carve-outs are named by the navigation
+    bar and again by the mobile menu, so dropping them from the corpus
+    necessarily leaves four dead links on every page that has a navigation. The
+    expected total is therefore a product of the page count, not a magic
+    number, which is what lets it survive the corpus growing while still
+    failing if a template stops linking them or starts linking them twice.
+
+    Links in KNOWN_BROKEN_LINKS: each entry declares its occurrences per corpus
+    copy, and a count that has fallen to zero means the content was fixed and
+    the entry is stale.
+
+    KNOWN LIMIT: only hrefs beginning with the site's base URL are resolved.
+    Root-relative ones are skipped, which today is right — the corpus's are
+    `/spec/` and the `preview_feature` shortcode's `/designs/…`, the latter
+    naming a route no tool emits — but a template that started emitting
+    relative links would lose coverage silently rather than loudly. The
+    `checked` count printed alongside is what would show it.
+    """
+    emitted = set(walk_files(out))
+    directories = {rel.rsplit("/", 1)[0] + "/" for rel in emitted if "/" in rel}
+    excluded_routes = {route_of(rel).rstrip("/") for rel in CORPUS_EXCLUSIONS}
+    faults = []
+    checked = 0
+    into_excluded = 0
+    known_broken = {route: 0 for route in KNOWN_BROKEN_LINKS}
+    with_navigation = 0
+    redirects = set(model.redirects())
+    for rel in sorted(model.pages):
+        path = os.path.join(out, route_of(rel), "index.html")
+        if not os.path.exists(path):
+            continue
+        # A redirect stub carries no navigation, so it is not one of the pages
+        # the excluded-link arithmetic below counts over.
+        if rel not in redirects:
+            with_navigation += 1
+        for tag, extra in structure(open(path, encoding="utf-8").read()):
+            if tag not in ("<a", "<link", "<img", "<script"):
+                continue
+            fields = dict(extra)
+            href = fields.get("href") or fields.get("src")
+            if not href or not href.startswith(BASE_URL):
+                continue
+            checked += 1
+            route = href_route(href)
+            if route is not None and route_exists(route, emitted, directories):
+                continue
+            if route is not None and route.rstrip("/") in excluded_routes:
+                into_excluded += 1
+                continue
+            if route is not None and unprefixed(route) in known_broken:
+                known_broken[unprefixed(route)] += 1
+                continue
+            faults.append("%s: dangling internal link %s" % (rel, href))
+
+    wanted_excluded = with_navigation * EXCLUDED_LINKS_PER_PAGE
+    if into_excluded != wanted_excluded:
+        faults.append(
+            "links into excluded content: %d, expected %d (%d pages with a "
+            "navigation x %d links each). Either a template changed how it "
+            "links the excluded pages, or EXCLUDED_LINKS_PER_PAGE is stale."
+            % (into_excluded, wanted_excluded, with_navigation,
+               EXCLUDED_LINKS_PER_PAGE))
+    for route, (per_copy, why) in sorted(KNOWN_BROKEN_LINKS.items()):
+        found = known_broken[route]
+        wanted = per_copy * scale
+        if found == wanted:
+            continue
+        if found == 0:
+            faults.append(
+                "KNOWN_BROKEN_LINKS entry %s is stale: it no longer appears, so "
+                "the content was fixed and the entry should be removed (%s)"
+                % (route, why))
+        else:
+            faults.append(
+                "KNOWN_BROKEN_LINKS entry %s appears %d times, expected %d "
+                "(%d per corpus copy x %d): new breakage is hiding behind an "
+                "old allowance" % (route, found, wanted, per_copy, scale))
+    return checked, into_excluded, sum(known_broken.values()), faults
+
+
+def check_feeds(out: str, model: Model) -> list[str]:
+    """Feed entry order equals the section's declared order, exactly."""
+    faults = []
+    for key in model.feeds():
+        path = os.path.join(out, route_of(key), "rss.xml")
+        if not os.path.exists(path):
+            faults.append("%s: declares generate_feeds but no rss.xml was emitted" % key)
+            continue
+        feed = open(path, encoding="utf-8").read()
+        emitted = re.findall(r"<link>([^<]*)</link>", feed)[1:]
+        wanted = ["%s/%s" % (BASE_URL, route_of(rel)) for rel in model.members[key]]
+        if emitted != wanted:
+            faults.append("%s: feed order %s, expected %s" % (key, emitted[:3], wanted[:3]))
+    return faults
+
+
+def check_redirects(out: str, model: Model) -> list[str]:
+    faults = []
+    for key in model.redirects():
+        path = os.path.join(out, route_of(key), "index.html")
+        if not os.path.exists(path):
+            faults.append("%s: sets redirect_to but no page was emitted" % key)
+            continue
+        page = open(path, encoding="utf-8").read()
+        target = "%s/%s/" % (BASE_URL, str(model.sections[key]["redirect_to"]).strip("/"))
+        if target not in page:
+            faults.append("%s: redirect stub does not point at %s" % (key, target))
+    return faults
+
+
+# ---------------------------------------------------------------------------
+# Spot goldens
+# ---------------------------------------------------------------------------
+
+GOLDEN_SITE = os.path.join(REPO, "performance", "fixtures", "gazette", "site")
+GOLDEN_EXPECTED = os.path.join(REPO, "performance", "fixtures", "gazette", "expected")
+
+
+def check_port_sync() -> list[str]:
+    """The production template set has not moved without a port review.
+
+    This is the only automated guard on ADR-0072's stated risk that production
+    drift erodes the ports. It cannot tell a cosmetic change from a structural
+    one — nothing can — so it does the one thing a machine can do honestly:
+    refuse to let the question go unasked.
+    """
+    digest, count, size = tree_digest(os.path.join(REPO, PRODUCTION_TEMPLATE_ROOT))
+    if digest == PRODUCTION_TEMPLATE_DIGEST:
+        return []
+    return ["%s changed (now %d files, %d bytes, digest %s) without a port "
+            "review: check whether examples/gazette/templates/ should follow, "
+            "then advance PORT_REVISION and PRODUCTION_TEMPLATE_DIGEST in "
+            "scripts/gazette-corpus-diff.py"
+            % (PRODUCTION_TEMPLATE_ROOT, count, size, digest)]
+
+
+def port_sync_report() -> str:
+    digest, count, size = tree_digest(os.path.join(REPO, PRODUCTION_TEMPLATE_ROOT))
+    return ("production templates: %d files, %d bytes, digest %s%s"
+            % (count, size, digest,
+               "" if digest == PRODUCTION_TEMPLATE_DIGEST else "  (PINNED DIGEST IS STALE)"))
+
+
+def golden_mode(options) -> int:
+    """The markup-level check ADR-0072 Decision 4 asks spot goldens for.
+
+    The goldens sit on a committed MINIATURE site rather than on live corpus
+    pages, and the reason is Decision 2: the corpus is deliberately not frozen,
+    so a golden over a live page would fail on every content change and be
+    re-blessed rather than read — which is the failure mode a golden exists to
+    avoid. The miniature site uses gazette's real template port and real
+    configuration, so the goldens are sensitive to exactly what they are for:
+    the rendered markup-level form the normalized oracle deliberately ignores,
+    including the recursive navigation's active branch, the feed, and the
+    redirect stub.
+    """
+    gazette = options.gazette or build_gazette()
+    work = tempfile.mkdtemp(prefix="gazette-golden-")
+    try:
+        root = os.path.join(work, "site")
+        shutil.copytree(GOLDEN_SITE, root)
+        shutil.copytree(os.path.join(REPO, "examples", "gazette", "templates"),
+                        os.path.join(root, "templates"))
+        shutil.copy(os.path.join(REPO, "examples", "gazette", "config.toml"),
+                    os.path.join(root, "config.toml"))
+        out = os.path.join(work, "public")
+        result = run_build(gazette, root, out)
+        if result["exit_code"] != 0:
+            print(result["stdout"] + result["stderr"])
+            return 1
+
+        emitted = walk_files(out)
+        if options.bless:
+            print(port_sync_report())
+            if os.path.exists(GOLDEN_EXPECTED):
+                shutil.rmtree(GOLDEN_EXPECTED)
+            shutil.copytree(out, GOLDEN_EXPECTED)
+            print("blessed %d file(s) into %s"
+                  % (len(emitted), os.path.relpath(GOLDEN_EXPECTED, REPO)))
+            return 0
+
+        expected = walk_files(GOLDEN_EXPECTED)
+        failures = []
+        failures += check_port_sync()
+        if emitted != expected:
+            failures.append("file set differs: only emitted %s; only expected %s"
+                            % (sorted(set(emitted) - set(expected)),
+                               sorted(set(expected) - set(emitted))))
+        for rel in sorted(set(emitted) & set(expected)):
+            ours = open(os.path.join(out, rel), "rb").read()
+            theirs = open(os.path.join(GOLDEN_EXPECTED, rel), "rb").read()
+            if ours != theirs:
+                failures.append("%s differs from its golden" % rel)
+        print("goldens: %d file(s) compared" % len(set(emitted) & set(expected)))
+        for fault in failures:
+            print("  FAIL %s" % fault)
+        print("\n%s" % ("FAILED" if failures else "OK"))
+        return 1 if failures else 0
+    finally:
+        if options.keep:
+            print("\nwork tree kept at %s" % work)
+        else:
+            shutil.rmtree(work, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+
+
+def site_mode(options) -> int:
+    gazette = options.gazette or build_gazette()
+    work = tempfile.mkdtemp(prefix="gazette-site-")
+    try:
+        root = os.path.join(work, "site")
+        os.makedirs(root)
+        identity = prepare_fixture(root, options.scale)
+        model = Model(os.path.join(root, "content"))
+
+        print("fixture identity (recorded with every observation, ADR-0072 Decision 2)")
+        for key in sorted(identity):
+            print("  %-16s %s" % (key, identity[key]))
+        print("  %-16s %d" % ("pages", len(model.pages)))
+        print("  %-16s %d" % ("sections", len(model.sections)))
+        print("excluded from the corpus:")
+        for rel, why in sorted(CORPUS_EXCLUSIONS.items()):
+            print("  %s — %s" % (rel, why))
+
+        # --- determinism, and the metrics ---------------------------------
+        samples = []
+        hashes = []
+        outputs = []
+        for index in range(options.samples):
+            out = os.path.join(work, "public-%d" % index)
+            outputs.append(out)
+            sample = run_build(gazette, root, out)
+            if sample["exit_code"] != 0:
+                print("\ngazette build failed (exit %d):" % sample["exit_code"])
+                print(sample["stdout"] + sample["stderr"])
+                return 1
+            samples.append(sample)
+            hashes.append(tree_hash(out))
+
+        print("\nmeasurement (fixture preparation and judging are outside the window)")
+        for index, sample in enumerate(samples):
+            print("  sample %d  %.3fs  peak RSS %.1f MiB"
+                  % (index, sample["wall_seconds"],
+                     sample["peak_rss_bytes"] / (1024 * 1024)))
+        print("  binary size %d bytes" % os.path.getsize(gazette))
+        print("  %-16s %s" % ("output_digest", hashes[0]))
+
+        failures = []
+        if len(set(hashes)) != 1:
+            failures.append("samples are not byte-identical: %s" % hashes)
+
+        out = outputs[0]
+        emitted = set(walk_files(out))
+        expected = model.expected_files(
+            [rel for rel in walk_files(os.path.join(root, "static"))])
+        if emitted != expected:
+            extra = sorted(emitted - expected)[:6]
+            absent = sorted(expected - emitted)[:6]
+            failures.append("file set differs: %d extra %s, %d missing %s"
+                            % (len(emitted - expected), extra,
+                               len(expected - emitted), absent))
+
+        failures += check_membership(out, model)
+        failures += check_feeds(out, model)
+        failures += check_redirects(out, model)
+        failures += check_metadata(out, model)
+        link_count, into_excluded, known_broken, link_faults = check_links(
+            out, model, options.scale)
+        failures += link_faults
+
+        oracle_checked = 0
+        if options.zola:
+            oracle_checked, oracle_faults = check_semantics(
+                out, os.path.join(root, "content"), model, gazette, work,
+                options.verbose)
+            failures += oracle_faults
+
+        print("\nvalidation")
+        print("  determinism:        %d sample(s), %d distinct output tree(s)"
+              % (len(hashes), len(set(hashes))))
+        print("  file set:           %d emitted, %d expected" % (len(emitted), len(expected)))
+        print("  section membership: %d section(s)" % len(model.members))
+        print("  feed ordering:      %d feed(s)" % len(model.feeds()))
+        print("  redirects:          %d" % len(model.redirects()))
+        print("  internal links:     %d checked, %d into excluded content, "
+              "%d known-broken in the corpus" % (link_count, into_excluded, known_broken))
+        for route, (per_copy, why) in sorted(KNOWN_BROKEN_LINKS.items()):
+            print("      %s (%d per corpus copy) — %s" % (route, per_copy, why))
+        if options.zola:
+            print("  semantic oracle:    %d page(s) compared against Zola" % oracle_checked)
+        else:
+            print("  semantic oracle:    SKIPPED (--no-zola)")
+
+        for fault in failures[:20]:
+            print("  FAIL %s" % fault)
+        if len(failures) > 20:
+            print("  ... and %d more" % (len(failures) - 20))
+        print("\n%s" % ("FAILED" if failures else "OK"))
+        if options.identity_out:
+            identity["output_digest"] = hashes[0]
+            identity["pages"] = len(model.pages)
+            with open(options.identity_out, "w", encoding="utf-8") as handle:
+                json.dump(identity, handle, indent=2, sort_keys=True)
+        return 1 if failures else 0
+    finally:
+        if options.keep:
+            print("\nwork tree kept at %s" % work)
+        else:
+            shutil.rmtree(work, ignore_errors=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--gazette", help="prebuilt gazette binary")
+    parser.add_argument("--keep", action="store_true", help="keep the work tree")
+    parser.add_argument("--verbose", action="store_true", help="print every page")
+    modes = parser.add_subparsers(dest="mode", required=True)
+
+    modes.add_parser("body", help="RUE-1483's Markdown differential against Zola")
+
+    site = modes.add_parser("site", help="RUE-1484's whole-site validation")
+    site.add_argument("--scale", type=int, default=1, choices=(1, 10, 100),
+                      help="corpus scale variant (ADR-0072 Decision 2)")
+    site.add_argument("--samples", type=int, default=3,
+                      help="builds per run; determinism needs at least two")
+    site.add_argument("--no-zola", dest="zola", action="store_false",
+                      help="skip the cross-tool semantic oracle")
+    site.add_argument("--identity-out", help="write the recorded identity as JSON")
+
+    golden = modes.add_parser("golden", help="markup-level spot goldens")
+    golden.add_argument("--bless", action="store_true",
+                        help="rewrite the committed goldens from this build")
+
+    options = parser.parse_args()
+    if options.mode == "body":
+        return body_mode(options)
+    if options.mode == "golden":
+        return golden_mode(options)
+    return site_mode(options)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes RUE-1484.

ADR-0072 Phase 4: gazette becomes a maintained Rue static site generator that builds the live rue-lang.dev corpus, with recorded fixture identity, deterministic scale variants, per-page output validation, and a new rung on the compiler scaling curve.

`examples/gazette/site.rue` adds content discovery over `std.fs.walk`, the page and section model, routing, ordering, template selection, section indexes, RSS, `redirect_to`, static passthrough, and the output tree. `main.rue` gains `gazette build SITE_DIR -o OUT`. One TOML reader now serves both `+++` front matter and `config.toml` — a refactor of the existing parser rather than a second one.

**On the real corpus: 95 pages in 0.245s at 4.4 MiB.** The 10x variant is 2.1s; the 100x variant is 9,500 pages in 20.6s at 104.9 MiB, byte-identical across samples. Scaling is sub-linear — 84x wall time for 100x pages.

## The fairness rule, and the one place validation cannot help

Decision 3 forbids corpus-specific fast paths. Phase 4 introduces a shortcut the ADR's own oracle provably cannot catch: a **page-invariant sidebar** produces identical link targets and identical visible text on every page, differing only in the `active` class — which "link targets" does not cover.

The port therefore keeps production's recursive `render_nav` macro and its prefix gate, changing only the spelling (`current_path | starts_with(prefix=…)` for Tera's `is starting_with`), evaluated by the engine per page. The macro's `depth` parameter is dropped because gazette has no arithmetic, so `depth + 1` is unwritable — and production never renders it; `std/base.html` and `tutorial/base.html` do not declare it at all.

Since no automated check covers this, it was verified directly: 84 pages carry a spec nav and produce **84 distinct nav bodies** across 25 distinct sizes, with no memoization anywhere in the evaluator. A Types page marks two entries `active` and expands only its own branch.

Because the rule is load-bearing and unguarded, this change also adds guards. **`golden` mode now runs in `linux-premerge`** — hermetic, no Zola needed, seconds — so flattening the macro engine fails CI. A **`PRODUCTION_TEMPLATE_DIGEST`** pin over `website/templates/**` fails when production moves without `PORT_REVISION` moving, discharging the "production drift away from the ports" consequence the ADR names explicitly.

## Peak RSS measured the compiler, not gazette

The first revision of the comparison script derived peak RSS from `RUSAGE_CHILDREN.ru_maxrss` — a cumulative high-water mark across every child the process has reaped — immediately after building gazette with the Rue compiler at ~210 MiB. It also computed `max(after - before, after)`, which collapses to `after` for any non-negative `before`, making the subtraction dead code.

Against `/usr/bin/time -l`: 1x real 4.4 MiB reported as 210.9; 10x real 11.3 reported as 210.1; 100x real 104.9 reported as 206.9. True RSS grows 24x across the range while the reported figure sat flat and slightly *decreasing*. Passing a prebuilt binary skipped the contamination, which is why hand-run figures looked correct while the default path — the one CI and any other reader hits — reported the compiler's memory.

`run_build` now spawns with `Popen`, drains the pipes, and reaps with `os.wait4`, taking `ru_maxrss` from that child alone. The default path reports 4.4 / 11.3 / 104.9 MiB, matching `time -l` exactly, and per-sample rather than as a running max, as Decision 5 requires. The docstring records the defect and the three wrong numbers beside the three real ones.

## Validation

**Determinism** at all three scales: 3 samples each, byte-identical output trees (130 / 994 / 9,634 files).

**A semantic oracle on every emitted page**, computed outside the timed window and anchored on pinned Zola's body-only rendering: heading tree, visible text, link and image targets, and shortcode results in document order, entities decoded, whitespace collapsed, presentational attributes dropped. The extraction must appear contiguously in the emitted stream — extra chrome before or after is permitted, everything else is not. Mutation-tested: dropping a paragraph, reordering headings, retargeting a link, dropping a heading, altering one word, and dropping a text run all fail. 94 pages compared, 0 failures.

Port-dependent facets get an **independent Python model** of the routing, section, and ordering rules rather than trusting gazette's own: file set, section membership and order, feed order, redirect targets, and 3,136 internal links. Ordering tie-breaks are asserted rather than assumed — `page_before` falls through to a comparison on `rel`, which is unique by construction, and the model recomputes the order independently.

**Spot goldens** sit on a committed miniature site (`performance/fixtures/gazette/`, 13 content files, 15 goldens) rather than live pages. Decision 4 asks for stable pages; Decision 2 guarantees no live page is stable, so a live golden would be re-blessed rather than read. The miniature site covers what the normalized oracle deliberately drops: code-block classes, 1,004 escaped entities, a two-level active nav branch, the feed, the redirect stub, both shortcodes, a summary marker, and a GFM table.

## Scale variants and their three honesty caveats

Deterministic path-prefixed 10x and 100x duplications, derived at fixture-prep time outside the measured window. The ADR already named two caveats: duplication scales per-page work but not site shape, so internal `@/…` links resolve to the originals and this is a **page-count curve, not a site-size curve**; and duplicated sections tie on weight, title, and date, so ordering tie-breaks must be asserted.

A third is added here, found while building the variants. **The spec sidebar collapses on duplicated pages** — a copy's permalink prefixes nothing in the original tree that `get_section` returns. Measured at 10x: originals n=70, nav bytes min 2,540 / max 6,205 / mean 4,446, averaging 1.84 `active` markers; duplicates n=630, **min = max = 2,534, one distinct size, zero `active`**. Both arms of the prefix gate go cold, at 57% of the original mean nav bytes, on the majority page class.

The consequence is stated plainly in Decision 2 and in `duplicate_corpus`: at 100x, 99% of spec pages emit exactly the page-invariant sidebar Decision 3 forbids. The *rule* still holds, because the program evaluates the gate per page — but the fairness evidence above is **1x evidence**, because at scale the input stops asking the question.

## Fixture identity and exclusions

Recorded per observation: content, static, and port digests with file counts and bytes, `port_revision`, scale, the exclusion list, and a single `fixture_digest` over all of it, plus the output digest. `performance-data.json` is excluded from the static set — it is build-derived and would churn identity every collection run.

`performance.md` and `runtime.md` are excluded as the `load_data` carve-out. The nav links to both from every page, so those links are counted rather than ignored or failed: 376, asserted as `pages_with_navigation × 4` so the assertion survives corpus growth but fails if a template changes how it links them. The exclusion set is folded into `fixture_digest`, so it cannot move invisibly.

`KNOWN_BROKEN_LINKS` entries carry an expected occurrence count asserted against `per_copy × scale`, so a stale entry fails loudly once the content is fixed and new breakage cannot hide behind an old allowance. One entry exists: `website/content/std/_index.md` links `math/` where the page routes to `/std/01-math/`. Pinned Zola emits the same dead link — gazette reproduces the site's routing rather than repairing its content.

## Compile-time rung

Gazette joins `performance/scaling.toml` as revision 4, placed between mosaic (6,108 lines) and harbor (9,000) at 6,524 — the manifest list is the report order and nothing sorts it downstream, so the ladder stays monotonic. `docs/process/compiler-scaling.md` is updated to name it.

These are the **only** recorded compile-time measurements of gazette. The runtime leg compiles gazette because it must run it, but that compile matches no declared epoch and enters no compile-time series.

The 60-minute budget re-check is reasoned rather than measured: the timed phase goes from 4×5×3 = 60 compiles to 5×5×3 = 75, against a budget dominated by the thin-LTO compiler build. There is no hosted-runner duration to check against; a wrong estimate costs one timed-out scheduled run rather than bad data.

## Not done here

Gazette is **not** registered in `performance/runtime.toml`, and cannot be yet: `FixtureDeclaration` is `deny_unknown_fields` with non-optional `seed` and `vocabulary_size`, validation hard-fails any multi-file recorded input, and `prepare_fixture` refuses any generator that is not the seeded text generator. `OracleKind` also has one variant, which gazette's per-page oracle is not. Declaring the workload ahead of that schema work would declare something the harness cannot prepare. The work is sequenced with Phase 5 and recorded on RUE-1485.

`scripts/rue quick` 31/31 · `scripts/rue cli examples_gazette` 9/9 · `golden` 15/15 · `site` 1x and 100x OK · `rue-oracle-diff` 0 disagreements · `validate-release-configuration.py`, `validate-ci-gate.py`, `validate-tier-ci-selectors.py` valid.
