### PR TITLE
RUE-1485: cross-tool comparison of gazette against pinned Zola and Hugo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,6 +386,26 @@ jobs:
       - name: Check the gazette template port and its spot goldens
         run: scripts/ci-timed "gazette goldens" -- scripts/gazette-corpus-diff.py golden
 
+      # The cross-tool work-equivalence check (ADR-0072 Decisions 3 and 4,
+      # RUE-1485). Builds the live corpus with gazette, the pinned Zola, and the
+      # pinned Hugo, and asserts the three emit the same file set, the same page
+      # count, and the same normalized page semantics.
+      #
+      # This is a CORRECTNESS lane, not a measurement one: it runs on a shared
+      # CI runner and its timings are discarded, exactly as the ADR's boundary
+      # discipline requires of anything not taken on the pinned regime. What it
+      # exists to catch is drift in the parity configurations and the template
+      # ports — a peer left doing work gazette skips, or a port quietly doing
+      # less — which is the failure that would make the published comparison
+      # dishonest rather than merely wrong, and which nothing else checks before
+      # the numbers are already collected. Two samples per tool, because
+      # determinism needs at least two; the peers' default-parallel row is
+      # skipped because it answers a measurement question, not this one.
+      - name: Check cross-tool work equivalence against pinned Zola and Hugo
+        run: >-
+          scripts/ci-timed "gazette peers" --
+          scripts/gazette-corpus-diff.py peers --samples 2 --no-secondary
+
       - name: Run explicit cross-backend compilation and encoding coverage
         # Both the x86-64 and AArch64 encoders are host-independent Rust tests.
         # Keep this named step visible even though the broad suite also reaches

--- a/.github/workflows/performance-collect.yml
+++ b/.github/workflows/performance-collect.yml
@@ -229,9 +229,10 @@ jobs:
             image: ubuntu-24.04
     runs-on: ${{ matrix.os }}
     name: runtime (${{ matrix.platform }})
-    # The measured work is small — five samples of a 32 MiB text workload plus
-    # one release-quality build of it, on the order of a minute. The job's
-    # actual cost is dominated by building `rue` and `rue-bench` under
+    # The measured work is small — five samples of a 32 MiB text workload, five
+    # site builds of the live corpus, three of it at ten copies, plus the peer
+    # legs below and one release-quality build of each program. The job's actual
+    # cost is dominated by building `rue` and `rue-bench` under
     # //platforms:release. Wall clock is unaffected, since these run alongside
     # the `measure` legs, but each row is a runner's worth of compute per trunk
     # push and the budget below is sized for the build.
@@ -239,6 +240,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Fetches `rue`'s pinned peers as well as its own tools: `zola` and `hugo`
+      # at the repository root are dotslash shims, and the runtime leg runs both
+      # against the same corpus gazette builds (ADR-0072 Decision 5).
       - name: Install dotslash
         uses: facebook/install-dotslash@v2
 
@@ -247,13 +251,32 @@ jobs:
           ./buck2 build //crates/rue:rue //crates/rue-bench:rue-bench \
             --target-platforms //platforms:release
 
+      # The peer-event state of ADR-0072 Decision 9: the fixture identity, peer
+      # versions, and epoch the last FULL peer leg ran under. The per-run canary
+      # rides every observation regardless; this decides whether the rest of the
+      # peer matrix runs, and it is read at fixture-preparation time inside this
+      # same job.
+      #
+      # A cache miss costs one redundant peer leg and nothing else, which is the
+      # right direction to fail in: the alternative to a full leg is joining
+      # this run's gazette numbers to a peer sample the store may not have.
+      # Restore keys are prefix-matched newest-first, so the state survives the
+      # per-commit key changing on every push.
+      - name: Restore the peer-leg state
+        uses: actions/cache/restore@v4
+        with:
+          path: runtime-peer-state
+          key: runtime-peer-state-${{ matrix.platform }}-${{ github.sha }}
+          restore-keys: |
+            runtime-peer-state-${{ matrix.platform }}-
+
       - name: Measure compiled-program runtime
         env:
           RUE_BENCH_RUNNER_LABEL: github-hosted
           RUE_BENCH_RUNNER_IMAGE: ${{ matrix.image }}
         run: |
           set -euo pipefail
-          mkdir -p runtime-collected
+          mkdir -p runtime-collected runtime-peer-state
           RUE="$(scripts/rue-bin --target-platforms //platforms:release)"
           BENCH="$(./buck2 build //crates/rue-bench:rue-bench \
             --target-platforms //platforms:release --show-simple-output 2>/dev/null | tail -1)"
@@ -267,6 +290,7 @@ jobs:
             --compiler "$RUE" \
             --commit "${{ github.sha }}" \
             --repo-root . \
+            --peer-state-dir runtime-peer-state \
             --out "runtime-collected/runtime-${{ matrix.platform }}.json"
           status=$?
           set -e
@@ -302,6 +326,27 @@ jobs:
                  "not complete; the series has a hole at this commit."
             exit 1
           fi
+
+      # Saved only when the runner recorded one, which it does only after a full
+      # peer leg completed, AND only when the report it belongs to is
+      # appendable. A half-finished leg, or a leg whose report validation
+      # refused, leaves the previous state in place and the next run tries
+      # again.
+      #
+      # One ordering risk is accepted rather than solved: the record reaches
+      # `performance-data-v1` in the publish job below, so a publish failure
+      # leaves this state ahead of the store, and no full leg runs until the
+      # next event. It is bounded, because the derived comparison joins each
+      # observation to the latest full peer leg with a matching fixture
+      # identity — an unchanged identity means the previous leg's rows still
+      # describe this corpus, so the table keeps its peers rather than losing
+      # them. Clearing this cache key forces a fresh leg if that is ever wrong.
+      - name: Save the peer-leg state
+        if: success()
+        uses: actions/cache/save@v4
+        with:
+          path: runtime-peer-state
+          key: runtime-peer-state-${{ matrix.platform }}-${{ github.sha }}
 
   # The scheduled row of the runtime matrix: Apple Silicon (ADR-0072
   # Decisions 5 and 9, RUE-1488).
@@ -352,13 +397,24 @@ jobs:
           ./buck2 build //crates/rue:rue //crates/rue-bench:rue-bench \
             --target-platforms //platforms:release
 
+      # The same peer-event state the Linux rows keep, on its own key: peer
+      # measurements are per platform, so this row's full leg is due on this
+      # row's events (ADR-0072 Decision 9).
+      - name: Restore the peer-leg state
+        uses: actions/cache/restore@v4
+        with:
+          path: runtime-peer-state
+          key: runtime-peer-state-aarch64-macos-${{ github.sha }}
+          restore-keys: |
+            runtime-peer-state-aarch64-macos-
+
       - name: Measure compiled-program runtime
         env:
           RUE_BENCH_RUNNER_LABEL: github-hosted
           RUE_BENCH_RUNNER_IMAGE: macos-15
         run: |
           set -euo pipefail
-          mkdir -p runtime-collected
+          mkdir -p runtime-collected runtime-peer-state
           RUE="$(scripts/rue-bin --target-platforms //platforms:release)"
           BENCH="$(./buck2 build //crates/rue-bench:rue-bench \
             --target-platforms //platforms:release --show-simple-output 2>/dev/null | tail -1)"
@@ -372,6 +428,7 @@ jobs:
             --compiler "$RUE" \
             --commit "${{ github.sha }}" \
             --repo-root . \
+            --peer-state-dir runtime-peer-state \
             --out runtime-collected/runtime-aarch64-macos.json
           status=$?
           set -e
@@ -407,6 +464,15 @@ jobs:
                  "not complete; the series has a hole at this commit."
             exit 1
           fi
+
+      # Conditional for the reason the Linux rows' step states: state that says
+      # "the full leg is done" must not outlive a run whose report was refused.
+      - name: Save the peer-leg state
+        if: success()
+        uses: actions/cache/save@v4
+        with:
+          path: runtime-peer-state
+          key: runtime-peer-state-aarch64-macos-${{ github.sha }}
 
   publish:
     needs: [measure, runtime, runtime-macos]

--- a/crates/rue-bench/src/derive.rs
+++ b/crates/rue-bench/src/derive.rs
@@ -20,10 +20,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use rue_perf_schema::{
-    Band, Completeness, FIXTURE_INPUT_NAME, Manifest, Metric, RunObject, RuntimeCompleteness,
-    RuntimeManifest, RuntimeMetric, StoredRun, StoredRuntimeReport, Summary, flags_movement,
-    geometric_mean, median_absolute_deviation, ratio, sample_value, summarize, validate_run,
-    validate_runtime_report,
+    Band, Completeness, FIXTURE_INPUT_NAME, Manifest, Metric, PeerRole, PeerThreadPolicy,
+    RunObject, RuntimeCompleteness, RuntimeManifest, RuntimeMetric, StoredRun, StoredRuntimeReport,
+    Summary, flags_movement, geometric_mean, median_absolute_deviation, ratio, sample_value,
+    summarize, validate_run, validate_runtime_report,
 };
 use serde::Serialize;
 
@@ -114,6 +114,57 @@ pub struct RuntimeEpochData {
     pub annotations: Vec<RuntimeAnnotation>,
     /// Points in measurement order.
     pub points: Vec<RuntimePointData>,
+    /// The cross-tool comparison from the newest run that measured peers.
+    ///
+    /// Absent when no peer measurement exists in this epoch, and the page then
+    /// renders the honest empty state rather than an estimate. Never a mixture
+    /// of runs: a ratio whose two sides came from different commits on a hosted
+    /// runner is a ratio of two different machines' moods, which is exactly
+    /// what ADR-0072 Decision 9's per-run canary exists to prevent.
+    pub comparison: Option<RuntimeComparison>,
+}
+
+/// The cross-tool table one run produced.
+#[derive(Debug, Serialize)]
+pub struct RuntimeComparison {
+    /// The commit whose run these rows come from.
+    pub commit: String,
+    /// The fixture identity every row in the table was measured against.
+    pub fixture: String,
+    /// Rows, Rue first and then its peers, ascending by corpus scale.
+    pub rows: Vec<RuntimeComparisonRow>,
+}
+
+/// One row of the cross-tool comparison.
+#[derive(Debug, Serialize)]
+pub struct RuntimeComparisonRow {
+    /// The tool, as a reader knows it.
+    pub tool: String,
+    /// The corpus scale this row built, `1x` or `10x`.
+    pub scale: String,
+    /// The thread configuration, spelled for a reader rather than as an enum.
+    pub threads: String,
+    /// Median whole-process wall time, in nanoseconds.
+    pub median_ns: u64,
+    /// This row's median over the Rue program's median at the same scale.
+    ///
+    /// `None` on the Rue rows themselves and wherever the same-scale
+    /// denominator is missing — never a 1.0 standing in for "unknown".
+    pub ratio: Option<f64>,
+    /// The tool's version.
+    pub version: String,
+    /// Whether this row is the primary published ratio or the labelled
+    /// secondary one (ADR-0072 Decision 5).
+    pub secondary: bool,
+    /// The commit whose run this row was measured in.
+    pub commit: String,
+    /// Whether this row was joined from an earlier full peer leg rather than
+    /// measured in the same run as the Rue figure it is compared against.
+    ///
+    /// Published per row rather than inferred, because the two kinds of row
+    /// carry different weight: a same-run ratio controls for the machine, and a
+    /// joined one only controls for the input.
+    pub joined: bool,
 }
 
 /// The rule one workload's movement is judged against, as published.
@@ -916,6 +967,8 @@ fn derive_runtime_epoch(
         })
         .collect();
 
+    let comparison = latest_comparison(manifest, stored);
+
     RuntimeEpochData {
         epoch: epoch.id,
         suite_revision: epoch.suite_revision,
@@ -925,7 +978,207 @@ fn derive_runtime_epoch(
         flagging,
         annotations,
         points,
+        comparison,
     }
+}
+
+/// The cross-tool table, joining this epoch's newest run to its latest full
+/// peer leg.
+///
+/// THE JOIN IS THE POINT, and leaving it out is how this table silently became
+/// a two-tool one. Peers are re-measured on events rather than on a clock
+/// (ADR-0072 Decision 9), while the canary — one single-threaded build by one
+/// peer — rides *every* run. So the newest run carrying any peer observation is
+/// almost always canary-only, and a table built from it alone would show
+/// gazette against Zola-pinned and nothing else: no Hugo, no default-parallel
+/// row, no second scale. The three-tool table would appear for exactly one push
+/// after each event and then vanish, falsifying both the page's caption and
+/// Decision 5's promise that the parallel figures are published rather than
+/// hidden.
+///
+/// So rows come from two places, and each row says which:
+///
+///   * The Rue program and the canary come from the NEWEST run, measured in the
+///     same job on the same machine. This is the same-run denominator Decision
+///     9 exists to provide.
+///   * Every other peer configuration is JOINED from the latest run that
+///     carried a full peer leg, and only when its fixture identity matches the
+///     newest run's for that workload. A matching identity means the two runs
+///     built literally the same input, which is what makes the join meaningful;
+///     a differing one means the peer leg is due and has not run, and stale
+///     rows are dropped rather than published against a corpus they never saw.
+fn latest_comparison(
+    manifest: &RuntimeManifest,
+    stored: &[&StoredRuntimeReport],
+) -> Option<RuntimeComparison> {
+    let mut appendable: Vec<&&StoredRuntimeReport> = stored
+        .iter()
+        .filter(|report| validate_runtime_report(manifest, report.record()).is_appendable())
+        .collect();
+    appendable.sort_by(|left, right| {
+        left.record()
+            .identity
+            .finished_at
+            .cmp(&right.record().identity.finished_at)
+    });
+
+    let base = appendable
+        .iter()
+        .rev()
+        .find(|report| {
+            report
+                .record()
+                .workloads
+                .iter()
+                .any(|observation| !observation.peers.is_empty())
+        })
+        .copied();
+    let full = appendable
+        .iter()
+        .rev()
+        .find(|report| {
+            report.record().workloads.iter().any(|observation| {
+                observation
+                    .peers
+                    .iter()
+                    .any(|peer| peer.role == PeerRole::Full)
+            })
+        })
+        .copied();
+    let base = base.or(full)?;
+
+    let mut rows: Vec<RuntimeComparisonRow> = Vec::new();
+    let mut fixture = String::new();
+    let mut observations: Vec<&rue_perf_schema::RuntimeObservation> = base
+        .record()
+        .workloads
+        .iter()
+        .filter(|observation| !observation.peers.is_empty())
+        .collect();
+    // Ascending by the scale the peers built, so the table reads as a
+    // page-count ladder rather than in workload-id order.
+    observations.sort_by_key(|observation| {
+        observation
+            .peers
+            .first()
+            .map(|peer| peer.scale)
+            .unwrap_or_default()
+    });
+
+    for observation in observations {
+        let Some(rue) = summarize(observation, RuntimeMetric::WallClock) else {
+            continue;
+        };
+        let scale = observation
+            .peers
+            .first()
+            .map(|peer| peer.scale)
+            .unwrap_or_default();
+        let identity = fixture_identity(observation);
+        if fixture.is_empty() {
+            fixture = short_digest(&identity);
+        }
+        rows.push(RuntimeComparisonRow {
+            tool: format!("gazette ({})", observation.workload),
+            scale: format!("{scale}x"),
+            // Not a policy choice: Rue has no concurrency, which is the whole
+            // reason the peers are pinned to one thread for the primary ratio.
+            threads: "1 (Rue has no concurrency)".to_string(),
+            median_ns: rue.median,
+            ratio: None,
+            version: base.record().identity.compiler_version.clone(),
+            secondary: false,
+            commit: base.record().identity.commit.clone(),
+            joined: false,
+        });
+
+        let mut seen: BTreeSet<(String, String)> = BTreeSet::new();
+        let push_peers = |rows: &mut Vec<RuntimeComparisonRow>,
+                          peers: &[rue_perf_schema::PeerObservation],
+                          commit: &str,
+                          joined: bool,
+                          seen: &mut BTreeSet<(String, String)>| {
+            let mut ordered: Vec<&rue_perf_schema::PeerObservation> = peers.iter().collect();
+            ordered.sort_by(|left, right| {
+                (&left.tool, format!("{:?}", left.thread_policy))
+                    .cmp(&(&right.tool, format!("{:?}", right.thread_policy)))
+            });
+            for peer in ordered {
+                let key = (peer.tool.clone(), format!("{:?}", peer.thread_policy));
+                if !seen.insert(key) {
+                    // Already covered by the same-run rows. A joined row can
+                    // only ever ADD a configuration, never replace a
+                    // measurement taken beside the Rue number it divides.
+                    continue;
+                }
+                let values: Vec<u64> = peer
+                    .samples
+                    .iter()
+                    .map(|sample| sample.process_elapsed_ns)
+                    .collect();
+                let Some(summary) = Summary::of(&values) else {
+                    continue;
+                };
+                rows.push(RuntimeComparisonRow {
+                    tool: peer.tool.clone(),
+                    scale: format!("{}x", peer.scale),
+                    threads: match peer.thread_policy {
+                        PeerThreadPolicy::PinnedSingleThread => "1 (pinned)".to_string(),
+                        PeerThreadPolicy::ToolDefaultParallel => {
+                            "tool default (parallel)".to_string()
+                        }
+                    },
+                    median_ns: summary.median,
+                    ratio: (rue.median > 0).then(|| summary.median as f64 / rue.median as f64),
+                    version: peer.version.clone(),
+                    secondary: peer.thread_policy != PeerThreadPolicy::PinnedSingleThread,
+                    commit: commit.to_string(),
+                    joined,
+                });
+            }
+        };
+
+        push_peers(
+            &mut rows,
+            &observation.peers,
+            &base.record().identity.commit,
+            false,
+            &mut seen,
+        );
+
+        if let Some(full) = full
+            && !std::ptr::eq(*full, *base)
+            && let Some(earlier) = full.record().observation(&observation.workload)
+            && fixture_identity(earlier) == identity
+        {
+            push_peers(
+                &mut rows,
+                &earlier.peers,
+                &full.record().identity.commit,
+                true,
+                &mut seen,
+            );
+        }
+    }
+    if rows.is_empty() {
+        return None;
+    }
+    Some(RuntimeComparison {
+        commit: base.record().identity.commit.clone(),
+        fixture,
+        rows,
+    })
+}
+
+/// The digest of the input one observation consumed, or empty when it recorded
+/// none — in which case no join is possible, which is the safe answer.
+fn fixture_identity(observation: &rue_perf_schema::RuntimeObservation) -> String {
+    observation
+        .recorded_inputs
+        .iter()
+        .find(|input| input.name == FIXTURE_INPUT_NAME)
+        .map(|input| input.identity_sha256.clone())
+        .unwrap_or_default()
 }
 
 /// A digest abbreviated for a human, never for comparison.
@@ -1832,6 +2085,7 @@ question = "How fast does compiled Rue count words?"
 program_args = ["{fixture}"]
 
 [suite.workloads.fixture]
+kind = "seeded_generator"
 category = "recorded"
 generator = "zipf_ascii_text"
 generator_revision = 1
@@ -1922,6 +2176,7 @@ samples = 3
                         seed: 20260813,
                         vocabulary_size: 256,
                     }),
+                    tree: None,
                 }],
                 program: ProgramIdentity {
                     binary_bytes: 65_536,
@@ -1944,8 +2199,10 @@ samples = 3
                         exit_code: 0,
                         stdout_bytes: 8,
                         stdout_sha256: "c".repeat(64),
+                        artifact_sha256: None,
                     })
                     .collect(),
+                peers: Vec::new(),
             }],
             failures: Vec::new(),
         }
@@ -2046,6 +2303,280 @@ samples = 3
         let workload = &data.platforms[0].epochs[0].points[0].workloads["wordfreq"];
         assert_eq!(workload.fixture_identity, "f".repeat(64));
         assert_eq!(workload.source_identity, "3".repeat(64));
+    }
+
+    /// A manifest whose workload is a corpus tree with peers, for the
+    /// cross-tool table. Separate from `RUNTIME_MANIFEST` deliberately: a peer
+    /// policy on a workload that builds no site is refused by the schema, and
+    /// adding gazette to the seeded manifest would make every other test in
+    /// this module report a workload it never measured.
+    const RUNTIME_PEER_MANIFEST: &str = r#"
+schema_version = 1
+
+[[suite]]
+revision = 1
+protocol_version = 1
+measured_boundary = "spawn_to_exit_v1"
+
+[[suite.workloads]]
+id = "gazette"
+source = "examples/gazette/main.rue"
+question = "How fast does compiled Rue build the real site?"
+program_args = ["build", "{fixture}", "-o", "{output}"]
+
+[suite.workloads.fixture]
+kind = "corpus_tree"
+category = "recorded"
+preparer = "scripts/gazette-corpus-diff.py"
+preparer_revision = 1
+scale = 1
+excluded = []
+root_name = "gazette-site"
+description = "the live corpus"
+
+[suite.workloads.oracle]
+kind = "semantic_site_pages"
+path = "scripts/gazette-corpus-diff.py"
+
+[[epoch]]
+id = 1
+platform = "probe"
+suite_revision = 1
+target = "x86-64-linux"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = true
+
+[epoch.environment]
+runner_label = "probe"
+runner_image = "probe"
+
+[epoch.sampling.gazette]
+samples = 3
+
+[epoch.peers.gazette]
+tools = ["zola"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+"#;
+
+    fn peer_sample(elapsed: u64) -> rue_perf_schema::RuntimeSample {
+        rue_perf_schema::RuntimeSample {
+            process_elapsed_ns: elapsed,
+            peak_memory_bytes: 1024,
+            exit_code: 0,
+            stdout_bytes: 0,
+            stdout_sha256: "a".repeat(64),
+            artifact_sha256: Some("8".repeat(64)),
+        }
+    }
+
+    /// A gazette report carrying the canary and the secondary peer row.
+    fn gazette_peer_report() -> rue_perf_schema::RuntimeReport {
+        use rue_perf_schema::*;
+        let mut report = runtime_report('a', [4, 4, 4]);
+        report.identity.workload_source_hashes =
+            BTreeMap::from([("gazette".to_string(), "3".repeat(64))]);
+        let samples: Vec<RuntimeSample> = (0..3)
+            .map(|index| RuntimeSample {
+                process_elapsed_ns: 4_000_000_000 + index,
+                peak_memory_bytes: 1024,
+                exit_code: 0,
+                stdout_bytes: 0,
+                stdout_sha256: "e".repeat(64),
+                artifact_sha256: Some("7".repeat(64)),
+            })
+            .collect();
+        report.workloads = vec![RuntimeObservation {
+            workload: "gazette".to_string(),
+            source: "examples/gazette/main.rue".to_string(),
+            question: "How fast does compiled Rue build the real site?".to_string(),
+            program_args: vec![
+                "build".to_string(),
+                FIXTURE_ARGUMENT.to_string(),
+                "-o".to_string(),
+                OUTPUT_ARGUMENT.to_string(),
+            ],
+            recorded_inputs: vec![RecordedInput {
+                name: FIXTURE_INPUT_NAME.to_string(),
+                category: InputCategory::Recorded,
+                description: "the live corpus".to_string(),
+                identity_sha256: "f".repeat(64),
+                files: 130,
+                bytes: 1_800_000,
+                provenance: None,
+                tree: Some(CorpusTreeProvenance {
+                    preparer: "scripts/gazette-corpus-diff.py".to_string(),
+                    preparer_revision: 1,
+                    scale: 1,
+                    excluded: Vec::new(),
+                }),
+            }],
+            program: ProgramIdentity {
+                binary_bytes: 1_048_576,
+                sha256: "b".repeat(64),
+            },
+            oracle: OracleOutcome {
+                kind: OracleKind::SemanticSitePages,
+                reference: "scripts/gazette-corpus-diff.py".to_string(),
+                reference_sha256: "d".repeat(64),
+                observed_sha256: "7".repeat(64),
+                verdict: OracleVerdict::Match,
+                deterministic_across_samples: true,
+                detail: String::new(),
+            },
+            samples,
+            peers: vec![
+                PeerObservation {
+                    tool: "zola".to_string(),
+                    version: "0.21.0".to_string(),
+                    role: PeerRole::Canary,
+                    thread_policy: PeerThreadPolicy::PinnedSingleThread,
+                    scale: 1,
+                    output_sha256: "8".repeat(64),
+                    emitted_files: 131,
+                    samples: vec![peer_sample(2_000_000_000)],
+                },
+                PeerObservation {
+                    tool: "zola".to_string(),
+                    version: "0.21.0".to_string(),
+                    role: PeerRole::Full,
+                    thread_policy: PeerThreadPolicy::ToolDefaultParallel,
+                    scale: 1,
+                    output_sha256: "8".repeat(64),
+                    emitted_files: 131,
+                    samples: vec![peer_sample(1_000_000_000)],
+                },
+            ],
+        }];
+        report
+    }
+
+    #[test]
+    fn the_cross_tool_table_comes_from_one_run_and_names_its_thread_policy() {
+        // ADR-0072 Decisions 5 and 9. Two properties are asserted because both
+        // are easy to break and each breaks the published claim: the primary
+        // ratio's denominator is the peer PINNED TO ONE THREAD, and the peers'
+        // default parallel row is published beside it, labelled, rather than
+        // dropped or promoted.
+        let manifest = RuntimeManifest::parse(RUNTIME_PEER_MANIFEST).expect("peer manifest");
+        let report = gazette_peer_report();
+        let data = derive_runtime(&manifest, &stored_runtime([report]), &[]);
+        let comparison = data.platforms[0].epochs[0]
+            .comparison
+            .as_ref()
+            .expect("a run carrying peers publishes a comparison");
+        assert_eq!(comparison.rows.len(), 3);
+        assert_eq!(comparison.rows[0].tool, "gazette (gazette)");
+        assert_eq!(
+            comparison.rows[0].ratio, None,
+            "the Rue row is the baseline"
+        );
+        let pinned = &comparison.rows[1];
+        assert_eq!(pinned.threads, "1 (pinned)");
+        assert!(!pinned.secondary);
+        assert_eq!(pinned.version, "0.21.0");
+        let parallel = &comparison.rows[2];
+        assert_eq!(parallel.threads, "tool default (parallel)");
+        assert!(
+            parallel.secondary,
+            "the default-parallel row is published as a labelled secondary, never as the ratio"
+        );
+        // The pinned peer took twice the parallel one's time here, so the two
+        // ratios must differ — a table that published one number for both would
+        // be publishing core count as though it were per-unit work.
+        assert!(pinned.ratio.unwrap() > parallel.ratio.unwrap());
+    }
+
+    #[test]
+    fn a_canary_only_run_keeps_the_three_tool_table_by_joining_the_last_full_leg() {
+        // The regression this join exists to prevent, and the one the first
+        // implementation shipped: the canary rides EVERY run and the full peer
+        // matrix runs only on events, so the newest peers-carrying run is
+        // almost always canary-only. Without the join the published table lost
+        // Hugo and both default-parallel rows on the very next push, one push
+        // after each event — falsifying the page's own caption.
+        let manifest = RuntimeManifest::parse(RUNTIME_PEER_MANIFEST).expect("peer manifest");
+        let mut full = gazette_peer_report();
+        full.identity.commit = "1".repeat(40);
+        full.identity.finished_at = "2026-08-13T00:01:00Z".to_string();
+
+        let mut canary_only = gazette_peer_report();
+        canary_only.identity.commit = "2".repeat(40);
+        canary_only.identity.finished_at = "2026-08-13T00:02:00Z".to_string();
+        canary_only.workloads[0]
+            .peers
+            .retain(|peer| peer.role == rue_perf_schema::PeerRole::Canary);
+        assert_eq!(canary_only.workloads[0].peers.len(), 1);
+
+        let data = derive_runtime(&manifest, &stored_runtime([full, canary_only]), &[]);
+        let comparison = data.platforms[0].epochs[0]
+            .comparison
+            .as_ref()
+            .expect("a comparison");
+        // Rue, the same-run canary, and the joined parallel row.
+        assert_eq!(comparison.rows.len(), 3);
+        // The same-run rows come from the newest run; the joined one names the
+        // run it was actually measured in, so the page can say so.
+        assert_eq!(comparison.commit, "2".repeat(40));
+        assert!(!comparison.rows[0].joined);
+        assert!(!comparison.rows[1].joined, "the canary is a same-run row");
+        assert_eq!(comparison.rows[1].commit, "2".repeat(40));
+        let joined = &comparison.rows[2];
+        assert!(joined.joined, "the parallel row survives by being joined");
+        assert!(joined.secondary);
+        assert_eq!(joined.commit, "1".repeat(40));
+    }
+
+    #[test]
+    fn a_joined_row_is_dropped_when_the_corpus_it_measured_is_not_this_one() {
+        // The join's whole licence is a matching fixture identity: it means the
+        // two runs built literally the same input. A differing identity means
+        // the peer leg is due and has not run, and publishing the older rows
+        // would compare this corpus against a peer's time on another one.
+        let manifest = RuntimeManifest::parse(RUNTIME_PEER_MANIFEST).expect("peer manifest");
+        let mut full = gazette_peer_report();
+        full.identity.commit = "1".repeat(40);
+        full.identity.finished_at = "2026-08-13T00:01:00Z".to_string();
+
+        let mut canary_only = gazette_peer_report();
+        canary_only.identity.commit = "2".repeat(40);
+        canary_only.identity.finished_at = "2026-08-13T00:02:00Z".to_string();
+        canary_only.workloads[0]
+            .peers
+            .retain(|peer| peer.role == rue_perf_schema::PeerRole::Canary);
+        // The corpus moved between the two runs.
+        canary_only.workloads[0].recorded_inputs[0].identity_sha256 = "c".repeat(64);
+
+        let data = derive_runtime(&manifest, &stored_runtime([full, canary_only]), &[]);
+        let comparison = data.platforms[0].epochs[0]
+            .comparison
+            .as_ref()
+            .expect("a comparison");
+        assert_eq!(
+            comparison.rows.len(),
+            2,
+            "only the same-run rows survive a corpus change: {:?}",
+            comparison.rows
+        );
+        assert!(comparison.rows.iter().all(|row| !row.joined));
+    }
+
+    #[test]
+    fn a_store_with_no_peer_measurement_publishes_no_comparison() {
+        // The honest empty state: nothing is estimated, and the page renders
+        // "no peer measurements have been collected yet" rather than a table.
+        let manifest = RuntimeManifest::parse(RUNTIME_MANIFEST).expect("runtime manifest");
+        let data = derive_runtime(
+            &manifest,
+            &stored_runtime([runtime_report('a', [7, 5, 6])]),
+            &[],
+        );
+        assert!(data.platforms[0].epochs[0].comparison.is_none());
     }
 
     /// A report placed explicitly in the series, with the identities that decide
@@ -2316,6 +2847,7 @@ question = "How fast does compiled Rue count words?"
 program_args = ["{fixture}"]
 
 [suite.workloads.fixture]
+kind = "seeded_generator"
 category = "recorded"
 generator = "zipf_ascii_text"
 generator_revision = 1

--- a/crates/rue-bench/src/digest.rs
+++ b/crates/rue-bench/src/digest.rs
@@ -22,6 +22,57 @@ pub fn sha256_file(path: &Path) -> Result<String, String> {
         .map_err(|error| format!("could not hash {}: {error}", path.display()))
 }
 
+/// Every file in a tree, by relative path, size, and contents.
+///
+/// The name of an artifact a workload EMITS rather than one it reads, so it
+/// answers the questions such an artifact raises: paths are hashed, so a file
+/// that only moved changes the digest, and sizes are hashed, so no file can be
+/// truncated to another's bytes unnoticed. One traversal order — sorted
+/// relative paths — because two orderings would be two digests for one tree.
+pub fn sha256_tree(root: &Path) -> Result<String, String> {
+    let mut files = Vec::new();
+    collect(root, root, &mut files)?;
+    files.sort();
+    let mut hasher = Sha256::new();
+    for relative in &files {
+        let path = root.join(relative);
+        let bytes = std::fs::read(&path)
+            .map_err(|error| format!("could not hash {}: {error}", path.display()))?;
+        hasher.update(relative.as_bytes());
+        hasher.update(format!("\0{}\0", bytes.len()).as_bytes());
+        hasher.update(&bytes);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// How many files a tree holds, for the structural checks a record carries.
+pub fn count_tree(root: &Path) -> Result<u64, String> {
+    let mut files = Vec::new();
+    collect(root, root, &mut files)?;
+    Ok(files.len() as u64)
+}
+
+fn collect(root: &Path, directory: &Path, found: &mut Vec<String>) -> Result<(), String> {
+    let entries = std::fs::read_dir(directory)
+        .map_err(|error| format!("could not read {}: {error}", directory.display()))?;
+    for entry in entries {
+        let entry = entry.map_err(|error| format!("could not read a directory entry: {error}"))?;
+        let path = entry.path();
+        let kind = entry
+            .file_type()
+            .map_err(|error| format!("could not stat {}: {error}", path.display()))?;
+        if kind.is_dir() {
+            collect(root, &path, found)?;
+        } else {
+            let relative = path
+                .strip_prefix(root)
+                .map_err(|_| format!("{} escaped its root", path.display()))?;
+            found.push(relative.to_string_lossy().replace('\\', "/"));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rue-bench/src/runtime.rs
+++ b/crates/rue-bench/src/runtime.rs
@@ -32,11 +32,12 @@ use std::process::{Command, Stdio};
 use std::time::Instant;
 
 use rue_perf_schema::{
-    FIXTURE_ARGUMENT, FIXTURE_INPUT_NAME, GeneratedProvenance, OracleOutcome, OracleVerdict,
-    ProgramIdentity, RUNTIME_RECORD_KIND, RUNTIME_REPORT_SCHEMA_VERSION, RecordedInput,
-    RuntimeCompleteness, RuntimeEpoch, RuntimeFailure, RuntimeIdentity, RuntimeManifest,
-    RuntimeObservation, RuntimeRegime, RuntimeReport, RuntimeSample, RuntimeSuiteRevision,
-    RuntimeWorkload, validate_runtime_report,
+    CorpusTreeProvenance, FIXTURE_ARGUMENT, FIXTURE_INPUT_NAME, FixtureDeclaration,
+    GeneratedProvenance, OUTPUT_ARGUMENT, OracleKind, OracleOutcome, OracleVerdict,
+    PeerObservation, PeerPolicy, PeerRole, PeerThreadPolicy, ProgramIdentity, RUNTIME_RECORD_KIND,
+    RUNTIME_REPORT_SCHEMA_VERSION, RecordedInput, RuntimeCompleteness, RuntimeEpoch,
+    RuntimeFailure, RuntimeIdentity, RuntimeManifest, RuntimeObservation, RuntimeRegime,
+    RuntimeReport, RuntimeSample, RuntimeSuiteRevision, RuntimeWorkload, validate_runtime_report,
 };
 
 use crate::digest::sha256_bytes as sha256;
@@ -70,6 +71,15 @@ struct Options {
     std_root: Option<PathBuf>,
     output: PathBuf,
     workdir: Option<PathBuf>,
+    /// Directory holding the previous peer run's recorded state, one file per
+    /// workload, for the event question of ADR-0072 Decision 9. An absent file
+    /// means "no peer observation is recorded" and the full leg runs — the
+    /// conservative answer, since a comparison that has never been taken cannot
+    /// be joined to. A missing directory therefore costs a peer run rather than
+    /// a wrong join.
+    peer_state: Option<PathBuf>,
+    /// `platform/epoch`, so a new epoch is itself a peer-leg event.
+    epoch_label: String,
 }
 
 fn parse_args() -> Result<Options, String> {
@@ -82,6 +92,7 @@ fn parse_args() -> Result<Options, String> {
     let mut repo_root = None;
     let mut std_root = None;
     let mut workdir = None;
+    let mut peer_state = None;
 
     let mut args = std::env::args().skip(2);
     while let Some(flag) = args.next() {
@@ -105,6 +116,7 @@ fn parse_args() -> Result<Options, String> {
             "--repo-root" => repo_root = Some(PathBuf::from(value()?)),
             "--std-root" => std_root = Some(PathBuf::from(value()?)),
             "--workdir" => workdir = Some(PathBuf::from(value()?)),
+            "--peer-state-dir" => peer_state = Some(PathBuf::from(value()?)),
             other => return Err(format!("unrecognized argument {other:?}")),
         }
     }
@@ -115,9 +127,16 @@ fn parse_args() -> Result<Options, String> {
         candidate.is_dir().then_some(candidate)
     });
 
+    let platform = platform.ok_or("runtime requires --platform")?;
+    let epoch_label = format!(
+        "{platform}/{}",
+        epoch
+            .map(|id| id.to_string())
+            .unwrap_or_else(|| "collection".to_string())
+    );
     Ok(Options {
         manifest: manifest.unwrap_or_else(|| repo_root.join("performance/runtime.toml")),
-        platform: platform.ok_or("runtime requires --platform")?,
+        platform,
         epoch,
         compiler: compiler.ok_or("runtime requires --compiler")?,
         commit: commit.ok_or("runtime requires --commit")?,
@@ -125,12 +144,14 @@ fn parse_args() -> Result<Options, String> {
         repo_root,
         std_root,
         workdir,
+        peer_state,
+        epoch_label,
     })
 }
 
 /// Run the runtime suite for one platform epoch.
 pub fn run() -> Result<u8, String> {
-    let options = parse_args()?;
+    let mut options = parse_args()?;
     let text = std::fs::read_to_string(&options.manifest)
         .map_err(|error| format!("could not read {}: {error}", options.manifest.display()))?;
     let manifest = RuntimeManifest::parse(&text)?;
@@ -156,6 +177,10 @@ pub fn run() -> Result<u8, String> {
                 )
             })?,
     };
+    // The epoch a run actually measured, not the one the command line named:
+    // collection passes no `--epoch`, and a new epoch is itself an event that
+    // makes the full peer leg due (ADR-0072 Decision 9).
+    options.epoch_label = format!("{}/{}", options.platform, epoch.id);
     let suite = manifest.suite(epoch.suite_revision).ok_or_else(|| {
         format!(
             "runtime suite revision {} is not declared",
@@ -333,25 +358,13 @@ fn measure_workload(
 
     // Outside the timed window, deliberately and structurally: nothing below
     // starts a clock until the fixture already exists on disk.
-    let fixture_path = workdir.join(&workload.fixture.file_name);
-    let recorded_fixture = prepare_fixture(workload, &fixture_path).map_err(|detail| {
+    let peer_policy = epoch.peers.get(&workload.id);
+    let prepared = prepare_fixture(options, workload, workdir, peer_policy).map_err(|detail| {
         RuntimeFailure::FixturePreparationFailed {
             workload: workload.id.clone(),
             detail,
         }
     })?;
-
-    let arguments: Vec<String> = workload
-        .program_args
-        .iter()
-        .map(|argument| {
-            if argument == FIXTURE_ARGUMENT {
-                fixture_path.display().to_string()
-            } else {
-                argument.clone()
-            }
-        })
-        .collect();
 
     let samples_wanted = epoch
         .sampling
@@ -360,13 +373,26 @@ fn measure_workload(
         .unwrap_or(0);
     let mut samples: Vec<RuntimeSample> = Vec::with_capacity(samples_wanted as usize);
     let mut outputs: Vec<Vec<u8>> = Vec::with_capacity(samples_wanted as usize);
+    let mut trees: Vec<PathBuf> = Vec::new();
     for index in 0..samples_wanted {
         eprintln!(
             "rue-bench runtime: {} sample {}/{samples_wanted}",
             workload.id,
             index + 1
         );
-        match run_sample(&binary, &arguments, workdir) {
+        // Every sample writes to its own destination. Sharing one would let a
+        // later sample find a warm tree and skip work an earlier one did, which
+        // is the incremental-rebuild scenario rather than this one, and would
+        // also make the determinism check compare a tree with itself.
+        let destination = workdir.join(format!("{}-out-{index}", workload.id));
+        let arguments = resolve_arguments(workload, &prepared.path, &destination);
+        match run_sample(
+            &binary,
+            &arguments,
+            workdir,
+            workload.oracle.kind,
+            &destination,
+        ) {
             Ok((sample, stdout)) => {
                 if sample.exit_code != 0 {
                     failures.push(RuntimeFailure::ProgramCrashed {
@@ -382,6 +408,7 @@ fn measure_workload(
                 }
                 samples.push(sample);
                 outputs.push(stdout);
+                trees.push(destination);
             }
             Err(detail) => {
                 failures.push(RuntimeFailure::ProgramCrashed {
@@ -396,8 +423,34 @@ fn measure_workload(
 
     // The clock has stopped for every sample; judging output costs whatever it
     // costs.
-    let golden_path = options.repo_root.join(&workload.oracle.path);
-    let oracle = judge(workload, &golden_path, &outputs);
+    // The peer legs, measured by this runner and this clock so no part of the
+    // published ratio comes from a different measurement apparatus. They run
+    // BEFORE judgement, because the trees they emit are half of what Decision 4
+    // judges: the file sets, page counts, and per-page semantics of all three
+    // tools are compared against each other, so a collection run cannot publish
+    // a ratio whose denominator built a smaller site.
+    let (peers, peer_trees) = match (peer_policy, &prepared.description) {
+        (Some(policy), Some(description)) => measure_peers(
+            options,
+            workload,
+            policy,
+            description,
+            samples_wanted,
+            workdir,
+            failures,
+        ),
+        _ => (Vec::new(), BTreeMap::new()),
+    };
+
+    let oracle = match workload.oracle.kind {
+        OracleKind::GoldenStdout => {
+            let golden_path = options.repo_root.join(&workload.oracle.path);
+            judge(workload, &golden_path, &outputs)
+        }
+        OracleKind::SemanticSitePages => {
+            judge_site(options, workload, &prepared, &samples, &trees, &peer_trees)
+        }
+    };
     if oracle.verdict != OracleVerdict::Match {
         failures.push(RuntimeFailure::WrongOutput {
             workload: workload.id.clone(),
@@ -413,11 +466,282 @@ fn measure_workload(
         // names a temporary directory, and storing it would make two identical
         // measurements produce two different records.
         program_args: workload.program_args.clone(),
-        recorded_inputs: vec![recorded_fixture],
+        recorded_inputs: vec![prepared.recorded.clone()],
         program,
         oracle,
         samples,
+        peers,
     })
+}
+
+/// Substitute the declared placeholders with this sample's real paths.
+fn resolve_arguments(
+    workload: &RuntimeWorkload,
+    fixture: &Path,
+    destination: &Path,
+) -> Vec<String> {
+    workload
+        .program_args
+        .iter()
+        .map(|argument| {
+            if argument == FIXTURE_ARGUMENT {
+                fixture.display().to_string()
+            } else if argument == OUTPUT_ARGUMENT {
+                destination.display().to_string()
+            } else {
+                argument.clone()
+            }
+        })
+        .collect()
+}
+
+/// Measure the peer tools building the identical corpus (ADR-0072 Decision 5).
+///
+/// Two legs, and the difference between them is the whole of Decision 9's
+/// cadence. The CANARY — one single-threaded build of the 1x corpus by the
+/// declared canary tool — runs beside every observation, so the ratio published
+/// for this commit has a same-run denominator. The FULL leg — the second peer,
+/// the scale variants, and the default-parallel secondary row — runs only when
+/// the preparer reports an event: the recorded fixture identity moved, a peer
+/// version moved, or the epoch changed. Between events, the derive step joins
+/// this observation to the latest full peer observation with a matching fixture
+/// identity.
+fn measure_peers(
+    options: &Options,
+    workload: &RuntimeWorkload,
+    policy: &PeerPolicy,
+    description: &PrepareDescription,
+    samples_wanted: u32,
+    workdir: &Path,
+    failures: &mut Vec<RuntimeFailure>,
+) -> (Vec<PeerObservation>, BTreeMap<String, PathBuf>) {
+    let due = description
+        .peer_event
+        .as_ref()
+        .map(|event| event.due)
+        .unwrap_or(true);
+    if let Some(event) = &description.peer_event {
+        eprintln!(
+            "rue-bench runtime: full peer leg {}: {}",
+            if event.due { "due" } else { "not due" },
+            event.reason
+        );
+    }
+
+    let mut wanted: Vec<(String, PeerThreadPolicy, u32, PeerRole)> = vec![(
+        policy.canary_tool.clone(),
+        policy.primary_thread_policy,
+        policy.canary_scale,
+        PeerRole::Canary,
+    )];
+    if due {
+        // The peers build this workload's own fixture, at the scale it was
+        // prepared at, so the matrix is tools by thread policies. The canary
+        // has already covered one cell of it.
+        let scale = description.identity.scale;
+        for tool in &policy.tools {
+            for thread_policy in [
+                Some(policy.primary_thread_policy),
+                policy.secondary_thread_policy,
+            ]
+            .into_iter()
+            .flatten()
+            {
+                let already_measured = *tool == policy.canary_tool
+                    && thread_policy == policy.primary_thread_policy
+                    && scale == policy.canary_scale;
+                if already_measured {
+                    // Measuring the identical configuration twice would publish
+                    // two denominators for one run.
+                    continue;
+                }
+                wanted.push((tool.clone(), thread_policy, scale, PeerRole::Full));
+            }
+        }
+    }
+
+    let wanted_count = wanted.len();
+    let mut observations = Vec::new();
+    // One emitted tree per tool, from its single-threaded leg: what the
+    // cross-tool checks read. The parallel leg builds the same site, so judging
+    // both would compare a tool with itself.
+    let mut trees: BTreeMap<String, PathBuf> = BTreeMap::new();
+    for (tool, thread_policy, scale, role) in wanted {
+        match measure_one_peer(
+            options,
+            workload,
+            description,
+            &tool,
+            thread_policy,
+            scale,
+            role,
+            samples_wanted,
+            workdir,
+        ) {
+            Ok((observation, tree)) => {
+                if thread_policy == policy.primary_thread_policy {
+                    trees.insert(tool.clone(), tree);
+                }
+                observations.push(observation);
+            }
+            Err(detail) => {
+                // A peer that could not be measured is recorded as a failure
+                // and omitted, never synthesized from an earlier run. If it was
+                // the canary, validation marks the workload incomplete: the
+                // evidence is kept and no ratio publishes.
+                failures.push(RuntimeFailure::ValidationRejected {
+                    workload: workload.id.clone(),
+                    detail: format!("peer {tool} at {scale}x ({thread_policy:?}): {detail}"),
+                });
+            }
+        }
+    }
+
+    // Record the state the NEXT run asks its event question against, and only
+    // when a full leg actually completed. Written after the fact rather than
+    // before, so a leg that failed halfway leaves the previous state in place
+    // and the next run tries again — the conservative direction, since the cost
+    // of a redundant peer run is a minute and the cost of a wrongly skipped one
+    // is a segment of ratios joined to a peer sample that never existed.
+    let complete_full_leg = due
+        && observations
+            .iter()
+            .filter(|observation| observation.role == PeerRole::Full)
+            .count()
+            + 1
+            == wanted_count;
+    if complete_full_leg && let Some(directory) = options.peer_state.as_deref() {
+        let state = serde_json::json!({
+            "fixture_digest": description.identity.fixture_digest,
+            "peer_versions": description.peer_versions,
+            "epoch": options.epoch_label,
+        });
+        let path = directory.join(format!("{}.json", workload.id));
+        if let Err(error) = std::fs::create_dir_all(directory)
+            .and_then(|()| std::fs::write(&path, format!("{state:#}\n")))
+        {
+            eprintln!(
+                "rue-bench runtime: could not record the peer state at {}: {error}",
+                path.display()
+            );
+        }
+    }
+    (observations, trees)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn measure_one_peer(
+    options: &Options,
+    workload: &RuntimeWorkload,
+    description: &PrepareDescription,
+    tool: &str,
+    thread_policy: PeerThreadPolicy,
+    scale: u32,
+    role: PeerRole,
+    samples_wanted: u32,
+    workdir: &Path,
+) -> Result<(PeerObservation, PathBuf), String> {
+    if scale != description.identity.scale {
+        // The preparer laid out one scale; another would need its own
+        // preparation, which is the event-driven leg's business rather than
+        // something to improvise from the tree at hand.
+        return Err(format!(
+            "the prepared fixture is {}x, so a {scale}x peer build has no fixture to build",
+            description.identity.scale
+        ));
+    }
+    let policy_name = match thread_policy {
+        PeerThreadPolicy::PinnedSingleThread => "pinned_single_thread",
+        PeerThreadPolicy::ToolDefaultParallel => "tool_default_parallel",
+    };
+    let key = format!("{tool}/{policy_name}");
+    let command = description
+        .commands
+        .get(&key)
+        .ok_or_else(|| format!("the preparer laid out no {key} invocation"))?;
+    let version = description
+        .peer_versions
+        .get(tool)
+        .cloned()
+        .ok_or_else(|| format!("the preparer recorded no version for {tool}"))?;
+
+    let mut samples = Vec::new();
+    let mut digest = String::new();
+    let mut emitted_files = 0;
+    let mut first_tree = PathBuf::new();
+    for index in 0..samples_wanted {
+        // The thread policy is part of the name, not decoration: the canary and
+        // the secondary row are the same tool at the same scale, and Zola
+        // refuses to write into a directory that already exists — so without it
+        // the second leg of every full run failed on a collision.
+        let destination = workdir.join(format!(
+            "{}-{tool}-{policy_name}-{scale}x-{index}",
+            workload.id
+        ));
+        let arguments: Vec<String> = command
+            .argv
+            .iter()
+            .skip(1)
+            .map(|argument| argument.replace("{out}", &destination.display().to_string()))
+            .collect();
+        let program = PathBuf::from(&command.argv[0]);
+        let mut invocation = Command::new(&program);
+        invocation
+            .args(&arguments)
+            .current_dir(workdir)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        for (name, value) in &command.env {
+            invocation.env(name, value);
+        }
+        let started = Instant::now();
+        let reaped = spawn_and_reap(&mut invocation).map_err(|error| error.to_string())?;
+        let elapsed = u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX);
+        if !libc_exited_cleanly(reaped.status) {
+            return Err(format!(
+                "the build did not exit successfully; stderr tail:\n{}",
+                String::from_utf8_lossy(&reaped.stderr)
+                    .lines()
+                    .rev()
+                    .take(5)
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            ));
+        }
+        let tree = crate::digest::sha256_tree(&destination)?;
+        if index == 0 {
+            digest = tree.clone();
+            emitted_files = crate::digest::count_tree(&destination)?;
+            first_tree = destination.clone();
+        }
+        samples.push(RuntimeSample {
+            process_elapsed_ns: elapsed,
+            peak_memory_bytes: reaped.peak_memory_bytes,
+            exit_code: 0,
+            stdout_bytes: reaped.stdout.len() as u64,
+            stdout_sha256: sha256(&reaped.stdout),
+            artifact_sha256: Some(tree),
+        });
+    }
+    let _ = options;
+    Ok((
+        PeerObservation {
+            tool: tool.to_string(),
+            version,
+            role,
+            thread_policy,
+            scale,
+            output_sha256: digest,
+            emitted_files,
+            samples,
+        },
+        first_tree,
+    ))
+}
+
+fn libc_exited_cleanly(status: i32) -> bool {
+    libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0
 }
 
 /// Compile one workload at release quality and describe the executable.
@@ -466,52 +790,326 @@ fn build_program(
     })
 }
 
-/// Generate a workload's fixture and record the identity of the bytes produced.
+/// What preparing one workload's fixture produced.
+#[derive(Debug)]
+pub struct PreparedFixture {
+    /// The path the program receives in place of [`FIXTURE_ARGUMENT`] — a file
+    /// for a seeded fixture, a directory for a corpus tree.
+    pub path: PathBuf,
+    /// The identity recorded with the observation.
+    pub recorded: RecordedInput,
+    /// What the corpus preparer reported, when there was one.
+    pub description: Option<PrepareDescription>,
+}
+
+/// The corpus preparer's report: what it laid out, and what it found.
+///
+/// ADR-0072 names `scripts/gazette-corpus-diff.py` the reference
+/// implementation of corpus assembly, identity, and validation, and says the
+/// harness mode should adopt it rather than reinvent it. This runner does
+/// exactly that: it asks the preparer to lay out every tool's fixture and to
+/// answer the peer-event question, and keeps for itself the one thing a second
+/// implementation would genuinely damage — the measurement, so every tool's
+/// time comes from one clock and every tool's memory from one reaping.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct PrepareDescription {
+    /// The recorded fixture identity, as the preparer computed it.
+    pub identity: FixtureIdentity,
+    /// Each pinned peer's own version string.
+    #[serde(default)]
+    pub peer_versions: BTreeMap<String, String>,
+    /// The measured invocation for each tool and thread policy.
+    #[serde(default)]
+    pub commands: BTreeMap<String, PreparedCommand>,
+    /// Whether the full peer leg is due, and why.
+    #[serde(default)]
+    pub peer_event: Option<PeerEvent>,
+    /// How many content pages the assembled corpus holds.
+    #[serde(default)]
+    pub pages: u64,
+    /// The fixture-assembly revision the preparer implements.
+    #[serde(default)]
+    pub preparer_revision: u32,
+}
+
+/// The identity fields this runner records from the preparer's report.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct FixtureIdentity {
+    /// One digest over every input class the tools consume.
+    pub fixture_digest: String,
+    /// Files and bytes of the corpus as identified — before duplication, so a
+    /// scale variant of an unchanged corpus does not look like a content
+    /// change.
+    pub content_files: u64,
+    /// Total bytes of that content.
+    pub content_bytes: u64,
+    /// Files and bytes of the corpus AS BUILT, after the scale duplication.
+    /// What the record states, because it is what the tools read.
+    pub scaled_content_files: u64,
+    /// Total bytes of the corpus as built.
+    pub scaled_content_bytes: u64,
+    /// Static passthrough files, which are measured work for every tool.
+    pub static_files: u64,
+    /// Their total bytes.
+    pub static_bytes: u64,
+    /// Template-port and parity-config files.
+    pub port_files: u64,
+    /// Their total bytes.
+    pub port_bytes: u64,
+    /// The port revision a maintainer bumps deliberately.
+    pub port_revision: u32,
+    /// The scale variant assembled.
+    pub scale: u32,
+    /// The content paths excluded from the corpus.
+    pub excluded: Vec<String>,
+}
+
+/// One tool's measured invocation, as the preparer laid it out.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct PreparedCommand {
+    /// The argument vector, with `{out}` standing for the destination.
+    pub argv: Vec<String>,
+    /// Environment the thread policy requires — `RAYON_NUM_THREADS` for Zola,
+    /// `GOMAXPROCS` for Hugo.
+    pub env: BTreeMap<String, String>,
+}
+
+/// Whether the full peer leg is due this run (ADR-0072 Decision 9).
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct PeerEvent {
+    /// Whether an event fired.
+    pub due: bool,
+    /// Which one, for the log and for the annotation.
+    pub reason: String,
+}
+
+/// Prepare a workload's fixture and record the identity of what it consumed.
+///
+/// Outside the timed window, structurally: nothing here starts a clock, and
+/// every caller has the fixture on disk before it does.
+fn prepare_fixture(
+    options: &Options,
+    workload: &RuntimeWorkload,
+    workdir: &Path,
+    peers: Option<&PeerPolicy>,
+) -> Result<PreparedFixture, String> {
+    match &workload.fixture {
+        FixtureDeclaration::SeededGenerator { .. } => {
+            prepare_seeded_fixture(workload, workdir.join(workload.fixture.work_name()))
+        }
+        FixtureDeclaration::CorpusTree { .. } => {
+            prepare_corpus_tree(options, workload, workdir, peers)
+        }
+    }
+}
+
+/// Generate a seeded fixture and record the identity of the bytes produced.
 ///
 /// The generator's revision is checked against the declaration rather than
 /// assumed: the committed golden output is a function of the produced bytes, so
 /// a manifest asking for a revision this binary does not implement would
 /// produce a confusing oracle mismatch instead of a clear refusal.
-fn prepare_fixture(workload: &RuntimeWorkload, path: &Path) -> Result<RecordedInput, String> {
-    let declaration = &workload.fixture;
-    if declaration.generator != fixture::ZIPF_ASCII_TEXT {
+fn prepare_seeded_fixture(
+    workload: &RuntimeWorkload,
+    path: PathBuf,
+) -> Result<PreparedFixture, String> {
+    let FixtureDeclaration::SeededGenerator {
+        category,
+        generator,
+        generator_revision,
+        seed,
+        bytes: declared_bytes,
+        vocabulary_size,
+        description,
+        ..
+    } = &workload.fixture
+    else {
+        return Err("a seeded fixture was expected".to_string());
+    };
+    if generator != fixture::ZIPF_ASCII_TEXT {
         return Err(format!(
-            "this runner implements the {:?} fixture generator, not {:?}",
+            "this runner implements the {:?} fixture generator, not {generator:?}",
             fixture::ZIPF_ASCII_TEXT,
-            declaration.generator
         ));
     }
-    if declaration.generator_revision != fixture::ZIPF_ASCII_TEXT_REVISION {
+    if *generator_revision != fixture::ZIPF_ASCII_TEXT_REVISION {
         return Err(format!(
-            "the manifest pins {} revision {}, but this runner implements revision {}",
-            declaration.generator,
-            declaration.generator_revision,
+            "the manifest pins {generator} revision {generator_revision}, but this runner \
+             implements revision {}",
             fixture::ZIPF_ASCII_TEXT_REVISION
         ));
     }
-    let bytes = fixture::generate_zipf_ascii_text(
-        declaration.seed,
-        declaration.bytes,
-        declaration.vocabulary_size,
-    );
-    std::fs::write(path, &bytes)
+    let bytes = fixture::generate_zipf_ascii_text(*seed, *declared_bytes, *vocabulary_size);
+    std::fs::write(&path, &bytes)
         .map_err(|error| format!("could not write {}: {error}", path.display()))?;
-    Ok(RecordedInput {
-        name: FIXTURE_INPUT_NAME.to_string(),
-        category: declaration.category,
-        description: declaration.description.clone(),
-        // Over the bytes the program will actually read, not over the
-        // declaration that asked for them. That is what makes a generator whose
-        // output drifted from its declaration visible in the data.
-        identity_sha256: sha256(&bytes),
-        files: 1,
-        bytes: bytes.len() as u64,
-        provenance: Some(GeneratedProvenance {
-            generator: declaration.generator.clone(),
-            generator_revision: declaration.generator_revision,
-            seed: declaration.seed,
-            vocabulary_size: declaration.vocabulary_size,
-        }),
+    Ok(PreparedFixture {
+        recorded: RecordedInput {
+            name: FIXTURE_INPUT_NAME.to_string(),
+            category: *category,
+            description: description.clone(),
+            // Over the bytes the program will actually read, not over the
+            // declaration that asked for them. That is what makes a generator
+            // whose output drifted from its declaration visible in the data.
+            identity_sha256: sha256(&bytes),
+            files: 1,
+            bytes: bytes.len() as u64,
+            provenance: Some(GeneratedProvenance {
+                generator: generator.clone(),
+                generator_revision: *generator_revision,
+                seed: *seed,
+                vocabulary_size: *vocabulary_size,
+            }),
+            tree: None,
+        },
+        path,
+        description: None,
+    })
+}
+
+/// Assemble a corpus tree through the checked-in preparer the suite pins.
+///
+/// The scale variants, the exclusions, the peers' sites, and the identity all
+/// come from that one implementation. What this function adds is the check the
+/// manifest can make and the script cannot: that the tree the preparer built is
+/// the tree the suite declared, at the declared scale with the declared pages
+/// excluded. A record whose scale or exclusion set drifted from the manifest is
+/// measuring a different workload, and it fails here rather than publishing a
+/// point into a series it does not belong to.
+fn prepare_corpus_tree(
+    options: &Options,
+    workload: &RuntimeWorkload,
+    workdir: &Path,
+    peers: Option<&PeerPolicy>,
+) -> Result<PreparedFixture, String> {
+    let FixtureDeclaration::CorpusTree {
+        category,
+        preparer,
+        preparer_revision,
+        scale,
+        excluded,
+        description,
+        ..
+    } = &workload.fixture
+    else {
+        return Err("a corpus-tree fixture was expected".to_string());
+    };
+    let root = workdir.join(workload.fixture.work_name());
+    let report = workdir.join(format!("{}-fixture.json", workload.id));
+    let preparer_path = options.repo_root.join(preparer);
+
+    let mut command = Command::new("python3");
+    command
+        .arg(&preparer_path)
+        .arg("prepare")
+        .arg("--root")
+        .arg(&root)
+        .arg("--scale")
+        .arg(scale.to_string())
+        .arg("--out")
+        .arg(&report)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    // The peers' sites are laid out only where the epoch declares peers. A run
+    // that will not measure them should not pay to assemble them.
+    if peers.is_some() {
+        command.arg("--peers");
+        command.arg("--epoch").arg(&options.epoch_label);
+        if let Some(state) = options.peer_state.as_deref() {
+            command
+                .arg("--peer-state")
+                .arg(state.join(format!("{}.json", workload.id)));
+        }
+    }
+    let output = command
+        .output()
+        .map_err(|error| format!("could not run {}: {error}", preparer_path.display()))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "the corpus preparer exited unsuccessfully ({}); stderr tail:\n{}",
+            output.status,
+            stderr.lines().rev().take(10).collect::<Vec<_>>().join("\n")
+        ));
+    }
+    let text = std::fs::read_to_string(&report)
+        .map_err(|error| format!("could not read {}: {error}", report.display()))?;
+    let description_report: PrepareDescription = serde_json::from_str(&text)
+        .map_err(|error| format!("could not read the preparer's report: {error}"))?;
+    let identity = &description_report.identity;
+
+    // Checked exactly as the seeded generator's revision is: the assembly is
+    // what every tool consumes, so a manifest pinning one this script no longer
+    // implements would measure a different job and say nothing about it.
+    if description_report.preparer_revision != *preparer_revision {
+        return Err(format!(
+            "the manifest pins {preparer} revision {preparer_revision}, but the checked-in \
+             preparer implements revision {}",
+            description_report.preparer_revision
+        ));
+    }
+    if identity.scale != *scale {
+        return Err(format!(
+            "the preparer assembled the {}x corpus, but the suite declares {scale}x",
+            identity.scale
+        ));
+    }
+    let mut prepared_exclusions = identity.excluded.clone();
+    let mut declared_exclusions = excluded.clone();
+    prepared_exclusions.sort();
+    declared_exclusions.sort();
+    if prepared_exclusions != declared_exclusions {
+        return Err(format!(
+            "the preparer excluded {prepared_exclusions:?}, but the suite declares \
+             {declared_exclusions:?}; a page joining or leaving that set changes the \
+             measured job and is a suite-revision event"
+        ));
+    }
+    if !root.is_dir() {
+        return Err(format!(
+            "the preparer reported success but {} is not a directory",
+            root.display()
+        ));
+    }
+    // Logged because a collection run's log is where a maintainer looks first
+    // when a series moves: the page count and the port revision are the two
+    // numbers that say whether the JOB changed, and the digest is what a reader
+    // matches an observation to its segment by.
+    eprintln!(
+        "rue-bench runtime: prepared the {}x corpus for {}: {} page(s) from {} content file(s) \
+         and {} bytes of Markdown, template-port revision {}, fixture digest {}",
+        identity.scale,
+        workload.id,
+        description_report.pages,
+        identity.content_files,
+        identity.content_bytes,
+        identity.port_revision,
+        identity.fixture_digest
+    );
+
+    // Every input class the tools consume, counted together: the Markdown
+    // content, the static passthrough (more bytes than the Markdown itself),
+    // and the versioned template ports and parity configurations. The digest is
+    // the preparer's own fixture digest, which covers all three plus the
+    // exclusion set, so no input class can change the measured job without
+    // changing the value that segments the series.
+    Ok(PreparedFixture {
+        recorded: RecordedInput {
+            name: FIXTURE_INPUT_NAME.to_string(),
+            category: *category,
+            description: description.clone(),
+            identity_sha256: identity.fixture_digest.clone(),
+            files: identity.scaled_content_files + identity.static_files + identity.port_files,
+            bytes: identity.scaled_content_bytes + identity.static_bytes + identity.port_bytes,
+            provenance: None,
+            tree: Some(CorpusTreeProvenance {
+                preparer: preparer.clone(),
+                preparer_revision: *preparer_revision,
+                scale: *scale,
+                excluded: prepared_exclusions,
+            }),
+        },
+        path: root,
+        description: Some(description_report),
     })
 }
 
@@ -520,6 +1118,8 @@ fn run_sample(
     binary: &Path,
     arguments: &[String],
     workdir: &Path,
+    oracle: OracleKind,
+    destination: &Path,
 ) -> Result<(RuntimeSample, Vec<u8>), String> {
     let mut command = Command::new(binary);
     command
@@ -545,14 +1145,139 @@ fn run_sample(
         -1
     };
 
+    // The digest of what this sample EMITTED, for a workload whose answer is a
+    // tree rather than a stream. Computed after the clock has stopped, and
+    // stored per sample rather than once, because it is what makes both the
+    // determinism check and the oracle's verdict provable from the record for a
+    // program whose stdout is empty by design.
+    let artifact_sha256 = match oracle {
+        OracleKind::GoldenStdout => None,
+        OracleKind::SemanticSitePages if exit_code == 0 => {
+            Some(crate::digest::sha256_tree(destination)?)
+        }
+        OracleKind::SemanticSitePages => None,
+    };
+
     let sample = RuntimeSample {
         process_elapsed_ns,
         peak_memory_bytes: reaped.peak_memory_bytes,
         exit_code,
         stdout_bytes: reaped.stdout.len() as u64,
         stdout_sha256: sha256(&reaped.stdout),
+        artifact_sha256,
     };
     Ok((sample, reaped.stdout))
+}
+
+/// Judge an emitted site through the checked-in comparison the suite names.
+///
+/// The judgement is the script's, for the reason the fixture's preparation is:
+/// ADR-0072 names it the reference implementation, and a second implementation
+/// of routing, section membership, ordering, and the semantic oracle would be a
+/// second implementation to disagree. What this function contributes is the
+/// part a record needs and a script cannot supply — the digests, so a reader of
+/// the store can check the verdict against the samples rather than believe it.
+fn judge_site(
+    options: &Options,
+    workload: &RuntimeWorkload,
+    prepared: &PreparedFixture,
+    samples: &[RuntimeSample],
+    trees: &[PathBuf],
+    peer_trees: &BTreeMap<String, PathBuf>,
+) -> OracleOutcome {
+    let kind = workload.oracle.kind;
+    let reference = workload.oracle.path.clone();
+    let judge_path = options.repo_root.join(&workload.oracle.path);
+    // The oracle's own identity, recorded with the observation: the judgement
+    // is only as stable as the judge, so a change to it must be visible in the
+    // data rather than only in a commit log.
+    let reference_sha256 = crate::digest::sha256_file(&judge_path).unwrap_or_default();
+    let observed_sha256 = samples
+        .first()
+        .and_then(|sample| sample.artifact_sha256.clone())
+        .unwrap_or_default();
+    let deterministic = samples
+        .iter()
+        .all(|sample| sample.artifact_sha256 == samples[0].artifact_sha256);
+
+    let Some(tree) = trees.first() else {
+        return OracleOutcome {
+            kind,
+            reference,
+            reference_sha256,
+            observed_sha256,
+            verdict: OracleVerdict::Indeterminate,
+            deterministic_across_samples: deterministic,
+            detail: "no sample emitted a site to judge".to_string(),
+        };
+    };
+
+    let report = tree.with_extension("judgement.json");
+    let mut command = Command::new("python3");
+    command
+        .arg(&judge_path)
+        .arg("judge")
+        .arg("--root")
+        .arg(&prepared.path)
+        .arg("--gazette-out")
+        .arg(tree)
+        .arg("--scale")
+        .arg(
+            prepared
+                .description
+                .as_ref()
+                .map(|description| description.identity.scale)
+                .unwrap_or(1)
+                .to_string(),
+        )
+        .arg("--out")
+        .arg(&report)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for (tool, tree) in peer_trees {
+        command.arg(format!("--{tool}-out")).arg(tree);
+    }
+    let output = match command.output() {
+        Ok(output) => output,
+        Err(error) => {
+            return OracleOutcome {
+                kind,
+                reference,
+                reference_sha256,
+                observed_sha256,
+                verdict: OracleVerdict::Indeterminate,
+                deterministic_across_samples: deterministic,
+                detail: format!("could not run the oracle: {error}"),
+            };
+        }
+    };
+    let detail = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .chain(String::from_utf8_lossy(&output.stderr).lines())
+        .filter(|line| line.contains("FAIL") || line.contains("mismatch"))
+        .take(5)
+        .collect::<Vec<_>>()
+        .join("; ");
+    let verdict = if output.status.success() {
+        OracleVerdict::Match
+    } else {
+        OracleVerdict::Mismatch
+    };
+    OracleOutcome {
+        kind,
+        reference,
+        reference_sha256,
+        observed_sha256,
+        verdict,
+        deterministic_across_samples: deterministic,
+        detail: if verdict == OracleVerdict::Match {
+            String::new()
+        } else if detail.is_empty() {
+            format!("the oracle refused the emitted site ({})", output.status)
+        } else {
+            detail
+        },
+    }
 }
 
 /// Compare what the program printed with what it was supposed to print.
@@ -688,7 +1413,7 @@ mod tests {
             source: "examples/wordfreq/main.rue".to_string(),
             question: "How fast does compiled Rue count words?".to_string(),
             program_args: vec![FIXTURE_ARGUMENT.to_string()],
-            fixture: FixtureDeclaration {
+            fixture: FixtureDeclaration::SeededGenerator {
                 category: InputCategory::Recorded,
                 generator: fixture::ZIPF_ASCII_TEXT.to_string(),
                 generator_revision: fixture::ZIPF_ASCII_TEXT_REVISION,
@@ -794,7 +1519,8 @@ mod tests {
     fn preparing_a_fixture_records_the_digest_of_the_bytes_written() {
         let temporary = tempfile::tempdir().unwrap();
         let path = temporary.path().join("input.txt");
-        let recorded = prepare_fixture(&workload(), &path).expect("prepared");
+        let prepared = prepare_seeded_fixture(&workload(), path.clone()).expect("prepared");
+        let recorded = prepared.recorded;
         let written = std::fs::read(&path).unwrap();
         assert_eq!(recorded.bytes, 4096);
         assert_eq!(written.len(), 4096);
@@ -815,8 +1541,15 @@ mod tests {
         // mismatch instead of a clear refusal.
         let temporary = tempfile::tempdir().unwrap();
         let mut workload = workload();
-        workload.fixture.generator_revision = fixture::ZIPF_ASCII_TEXT_REVISION + 1;
-        let error = prepare_fixture(&workload, &temporary.path().join("input.txt")).unwrap_err();
+        let FixtureDeclaration::SeededGenerator {
+            generator_revision, ..
+        } = &mut workload.fixture
+        else {
+            unreachable!("the fixture above is a seeded one")
+        };
+        *generator_revision = fixture::ZIPF_ASCII_TEXT_REVISION + 1;
+        let error =
+            prepare_seeded_fixture(&workload, temporary.path().join("input.txt")).unwrap_err();
         assert!(error.contains("revision"), "{error}");
     }
 
@@ -824,8 +1557,12 @@ mod tests {
     fn a_fixture_pinned_to_an_unknown_generator_is_refused() {
         let temporary = tempfile::tempdir().unwrap();
         let mut workload = workload();
-        workload.fixture.generator = "some_future_generator".to_string();
-        let error = prepare_fixture(&workload, &temporary.path().join("input.txt")).unwrap_err();
+        let FixtureDeclaration::SeededGenerator { generator, .. } = &mut workload.fixture else {
+            unreachable!("the fixture above is a seeded one")
+        };
+        *generator = "some_future_generator".to_string();
+        let error =
+            prepare_seeded_fixture(&workload, temporary.path().join("input.txt")).unwrap_err();
         assert!(error.contains("some_future_generator"), "{error}");
     }
 

--- a/crates/rue-perf-schema/src/lib.rs
+++ b/crates/rue-perf-schema/src/lib.rs
@@ -83,9 +83,10 @@ pub use run::{
     RunIdentity, RunObject, Sample, WorkloadObservation,
 };
 pub use runtime::{
-    FIXTURE_ARGUMENT, FIXTURE_INPUT_NAME, FixtureDeclaration, FlagPosture, GeneratedProvenance,
-    HardwareCounterPolicy, InputCategory, OracleDeclaration, OracleKind, OracleOutcome,
-    OracleVerdict, ProgramIdentity, RUNTIME_MANIFEST_SCHEMA_VERSION, RUNTIME_RECORD_KIND,
+    CorpusTreeProvenance, FIXTURE_ARGUMENT, FIXTURE_INPUT_NAME, FixtureDeclaration, FlagPosture,
+    GeneratedProvenance, HardwareCounterPolicy, InputCategory, OUTPUT_ARGUMENT, OracleDeclaration,
+    OracleKind, OracleOutcome, OracleVerdict, PeerObservation, PeerPolicy, PeerRole,
+    PeerThreadPolicy, ProgramIdentity, RUNTIME_MANIFEST_SCHEMA_VERSION, RUNTIME_RECORD_KIND,
     RUNTIME_REPORT_SCHEMA_VERSION, RecordedInput, RuntimeBoundary, RuntimeCalibration,
     RuntimeCompleteness, RuntimeEpoch, RuntimeFailure, RuntimeFlagging, RuntimeFlaggingPolicy,
     RuntimeIdentity, RuntimeInvalidSample, RuntimeInvalidSampleReason, RuntimeManifest,

--- a/crates/rue-perf-schema/src/runtime.rs
+++ b/crates/rue-perf-schema/src/runtime.rs
@@ -124,6 +124,44 @@ pub enum HardwareCounterPolicy {
 pub enum OracleKind {
     /// The program's stdout must equal a committed golden file, byte for byte.
     GoldenStdout,
+    /// The program's emitted output TREE is judged, page by page, by the
+    /// checked-in comparison the oracle declaration names.
+    ///
+    /// Gazette's oracle (ADR-0072 Decision 4). A site build's answer is not a
+    /// line of stdout: it is 96 pages, a feed, and a redirect stub, and the
+    /// thing that makes it right is that every page's normalized semantics —
+    /// heading tree, visible text, link targets, shortcode expansions, section
+    /// membership, feed order — agree with an independent authority. A byte
+    /// golden over live corpus output would fail on every content change and be
+    /// re-blessed rather than read, which is the failure a golden exists to
+    /// prevent (Decision 2), so the reference here is the JUDGE rather than an
+    /// expected output, its own identity is recorded with every observation,
+    /// and the digest compared across samples is the emitted tree's.
+    SemanticSitePages,
+}
+
+impl OracleKind {
+    /// Which per-sample digest this oracle's verdict is a claim about.
+    ///
+    /// The whole of the producer/validator separation rests on there being a
+    /// stored per-sample digest of the thing that was judged. A stdout oracle
+    /// judges stdout; a site oracle judges the emitted tree, and reading
+    /// stdout for it would check the emptiness of an empty stream while the
+    /// output tree went unexamined.
+    pub fn judged_digest(self, sample: &RuntimeSample) -> Option<&str> {
+        match self {
+            OracleKind::GoldenStdout => Some(sample.stdout_sha256.as_str()),
+            OracleKind::SemanticSitePages => sample.artifact_sha256.as_deref(),
+        }
+    }
+
+    /// The name of the digest field this oracle judges, for diagnostics.
+    pub const fn judged_field(self) -> &'static str {
+        match self {
+            OracleKind::GoldenStdout => "stdout_sha256",
+            OracleKind::SemanticSitePages => "artifact_sha256",
+        }
+    }
 }
 
 /// What the oracle said.
@@ -191,32 +229,107 @@ impl RuntimeMetric {
 
 /// How one workload's data fixture is produced.
 ///
+/// Tagged, because the suite now has two genuinely different kinds of input and
+/// a single struct could only describe both by making most of its fields
+/// optional — which is the shape that lets a wordfreq record omit its seed and
+/// still validate. Each variant carries exactly the fields its own shape
+/// requires, and validation holds a record to the variant its workload
+/// declares.
+///
 /// The declaration is pinned by the suite revision; the bytes it produces are
 /// recorded per observation. Both halves matter: the pin makes the fixture
 /// reproducible from the repository, and the recording makes any drift between
 /// the pin and the bytes visible in the data rather than only in review.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct FixtureDeclaration {
-    /// Which discipline governs this input's identity. Runtime fixtures are
-    /// recorded; the field exists so a future pinned fixture cannot be added
-    /// without saying so.
-    pub category: InputCategory,
-    /// Name of the checked-in generator that produces the fixture.
-    pub generator: String,
-    /// Revision of that generator. Bumped whenever its output changes, which
-    /// invalidates any committed golden derived from it.
-    pub generator_revision: u32,
-    /// Seed handed to the generator.
-    pub seed: u64,
-    /// Exact size of the produced fixture, in bytes.
-    pub bytes: u64,
-    /// Number of distinct tokens the generator's vocabulary contains.
-    pub vocabulary_size: u32,
-    /// File name the fixture is written under inside the work directory.
-    pub file_name: String,
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum FixtureDeclaration {
+    /// One file, generated deterministically from a pinned seed.
+    SeededGenerator {
+        /// Which discipline governs this input's identity. Runtime fixtures are
+        /// recorded; the field exists so a future pinned fixture cannot be added
+        /// without saying so.
+        category: InputCategory,
+        /// Name of the checked-in generator that produces the fixture.
+        generator: String,
+        /// Revision of that generator. Bumped whenever its output changes,
+        /// which invalidates any committed golden derived from it.
+        generator_revision: u32,
+        /// Seed handed to the generator.
+        seed: u64,
+        /// Exact size of the produced fixture, in bytes.
+        bytes: u64,
+        /// Number of distinct tokens the generator's vocabulary contains.
+        vocabulary_size: u32,
+        /// File name the fixture is written under inside the work directory.
+        file_name: String,
+        /// What this fixture is, for a reader of the manifest.
+        description: String,
+    },
+    /// A tree of files assembled from the repository at preparation time, at a
+    /// declared scale factor and with a declared set of exclusions.
+    ///
+    /// Gazette's corpus (ADR-0072 Decision 2). Its bytes are expected to move —
+    /// it is the live rue-lang.dev content — so the *bytes* are recorded rather
+    /// than pinned, exactly as the seeded fixture's are. What is pinned is
+    /// everything about how the tree is assembled: which preparer, at which
+    /// revision, at which scale, with which pages excluded. A record whose
+    /// scale or exclusion set differs from the declaration is measuring a
+    /// different workload, and validation refuses it for the same reason a
+    /// wordfreq record generated from another seed is refused.
+    CorpusTree {
+        /// Which discipline governs this input's identity.
+        category: InputCategory,
+        /// Repository-relative path of the checked-in preparer that assembles
+        /// the tree. ADR-0072 names `scripts/gazette-corpus-diff.py` as the
+        /// reference implementation the harness adopts rather than reinvents,
+        /// so the harness names it here instead of carrying a second copy of
+        /// the corpus-assembly, routing, and validation rules.
+        preparer: String,
+        /// Revision of that preparer. Bumped when its assembly changes.
+        preparer_revision: u32,
+        /// The scale variant this workload measures: 1x is the corpus as it
+        /// stands, 10x and 100x are the deterministic path-prefixed
+        /// duplications. Published curves over this axis are PAGE-COUNT curves
+        /// and must say so (Decision 2).
+        scale: u32,
+        /// Content paths removed from the corpus before any tool sees it, each
+        /// of which must be justified where the preparer declares it. Part of
+        /// the declaration because a page joining or leaving the set changes
+        /// the measured job.
+        excluded: Vec<String>,
+        /// Directory name the assembled fixture is written under inside the
+        /// work directory.
+        root_name: String,
+        /// What this fixture is, for a reader of the manifest.
+        description: String,
+    },
+}
+
+impl FixtureDeclaration {
+    /// Which identity discipline governs this fixture.
+    pub fn category(&self) -> InputCategory {
+        match self {
+            FixtureDeclaration::SeededGenerator { category, .. }
+            | FixtureDeclaration::CorpusTree { category, .. } => *category,
+        }
+    }
+
     /// What this fixture is, for a reader of the manifest.
-    pub description: String,
+    pub fn description(&self) -> &str {
+        match self {
+            FixtureDeclaration::SeededGenerator { description, .. }
+            | FixtureDeclaration::CorpusTree { description, .. } => description,
+        }
+    }
+
+    /// The name this fixture occupies in the work directory — a file for the
+    /// seeded shape, a directory for the corpus tree.
+    pub fn work_name(&self) -> &str {
+        match self {
+            FixtureDeclaration::SeededGenerator { file_name, .. } => file_name,
+            FixtureDeclaration::CorpusTree { root_name, .. } => root_name,
+        }
+    }
 }
 
 /// The committed expected result a workload's output is judged against.
@@ -243,10 +356,11 @@ pub struct RuntimeWorkload {
     pub question: String,
     /// Arguments passed to the compiled program, in order.
     ///
-    /// [`FIXTURE_ARGUMENT`] stands for the prepared fixture's path. The
-    /// placeholder rather than the resolved path is what the record stores: the
-    /// resolved path names a temporary directory and would make two identical
-    /// measurements differ.
+    /// [`FIXTURE_ARGUMENT`] stands for the prepared fixture's path and
+    /// [`OUTPUT_ARGUMENT`] for the directory a workload that emits a tree
+    /// writes into. The placeholders rather than the resolved paths are what
+    /// the record stores: a resolved path names a temporary directory and
+    /// would make two identical measurements differ.
     pub program_args: Vec<String>,
     /// How the workload's data is produced.
     pub fixture: FixtureDeclaration,
@@ -256,6 +370,13 @@ pub struct RuntimeWorkload {
 
 /// The token in `program_args` replaced by the prepared fixture's path.
 pub const FIXTURE_ARGUMENT: &str = "{fixture}";
+
+/// The token in `program_args` replaced by the directory the program writes to.
+///
+/// Required of a workload whose oracle judges an emitted tree: a site build
+/// that was never told where to write produced no artifact to judge, and the
+/// manifest refuses it rather than leaving the runner to discover it.
+pub const OUTPUT_ARGUMENT: &str = "{output}";
 
 /// The platform-independent contract: which programs are measured, with which
 /// arguments, over which fixtures, judged how.
@@ -397,6 +518,35 @@ pub struct RuntimeEpoch {
     /// Whether scheduled collection measures this epoch.
     #[serde(default)]
     pub collection: bool,
+    /// The cross-tool comparison this epoch runs, per workload that has one.
+    ///
+    /// Thread policy is part of the epoch rather than the suite because it is a
+    /// property of how a platform runs the workload (ADR-0072 Decision 5) — the
+    /// same reason `thread_policy` above is here. An epoch that declares no
+    /// peer policy for a workload must carry no peer observations for it, and
+    /// one that declares a canary must carry it in every observation.
+    #[serde(default)]
+    pub peers: BTreeMap<String, PeerPolicy>,
+}
+
+/// The peer legs one workload runs in one epoch.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PeerPolicy {
+    /// The pinned peer tools, by the name of their repository-root shim.
+    pub tools: Vec<String>,
+    /// The thread configuration the primary published ratio is taken under.
+    pub primary_thread_policy: PeerThreadPolicy,
+    /// The configuration published beside it as a labelled secondary row.
+    /// `None` publishes no secondary row at all rather than a hidden one.
+    #[serde(default)]
+    pub secondary_thread_policy: Option<PeerThreadPolicy>,
+    /// The peer whose build rides every observation as the same-run ratio
+    /// denominator (Decision 9).
+    pub canary_tool: String,
+    /// The corpus scale the canary builds. 1x, because the canary is meant to
+    /// be cheap enough to ride a per-push job.
+    pub canary_scale: u32,
 }
 
 impl RuntimeEpoch {
@@ -509,22 +659,112 @@ impl RuntimeManifest {
                         workload.id
                     ));
                 }
-                if workload.fixture.bytes == 0 {
-                    return Err(format!(
-                        "runtime workload {:?} declares an empty fixture",
-                        workload.id
-                    ));
+                // Every rule below is per shape. Generalizing the declaration
+                // must not relax the seeded shape by one field: RUE-1046's
+                // review found nine of ten fabricated wordfreq records being
+                // accepted, and the checks that closed that are these.
+                match &workload.fixture {
+                    FixtureDeclaration::SeededGenerator {
+                        generator,
+                        bytes,
+                        vocabulary_size,
+                        file_name,
+                        ..
+                    } => {
+                        if generator.trim().is_empty() {
+                            return Err(format!(
+                                "runtime workload {:?} names no fixture generator",
+                                workload.id
+                            ));
+                        }
+                        if *bytes == 0 {
+                            return Err(format!(
+                                "runtime workload {:?} declares an empty fixture",
+                                workload.id
+                            ));
+                        }
+                        if *vocabulary_size == 0 {
+                            return Err(format!(
+                                "runtime workload {:?} declares an empty fixture vocabulary",
+                                workload.id
+                            ));
+                        }
+                        if file_name.contains('/') {
+                            return Err(format!(
+                                "runtime workload {:?} fixture file name must be a bare name",
+                                workload.id
+                            ));
+                        }
+                    }
+                    FixtureDeclaration::CorpusTree {
+                        preparer,
+                        scale,
+                        excluded,
+                        root_name,
+                        ..
+                    } => {
+                        if preparer.is_empty() || preparer.starts_with('/') {
+                            return Err(format!(
+                                "runtime workload {:?} must name a repository-relative \
+                                 fixture preparer",
+                                workload.id
+                            ));
+                        }
+                        // 1x is the corpus as it stands; anything smaller is
+                        // not a scale variant of it.
+                        if *scale == 0 {
+                            return Err(format!(
+                                "runtime workload {:?} declares corpus scale 0",
+                                workload.id
+                            ));
+                        }
+                        if root_name.contains('/') {
+                            return Err(format!(
+                                "runtime workload {:?} fixture root name must be a bare name",
+                                workload.id
+                            ));
+                        }
+                        for path in excluded {
+                            if path.is_empty() || path.starts_with('/') {
+                                return Err(format!(
+                                    "runtime workload {:?} excludes {path:?}, which is not a \
+                                     corpus-relative path",
+                                    workload.id
+                                ));
+                            }
+                        }
+                        // A tree-emitting workload that is never told where to
+                        // write produces nothing its oracle can judge.
+                        if !workload
+                            .program_args
+                            .iter()
+                            .any(|argument| argument == OUTPUT_ARGUMENT)
+                        {
+                            return Err(format!(
+                                "runtime workload {:?} emits an output tree but never receives \
+                                 a destination; one argument must be {OUTPUT_ARGUMENT:?}",
+                                workload.id
+                            ));
+                        }
+                    }
                 }
-                if workload.fixture.vocabulary_size == 0 {
+                // The oracle has to be able to judge what the workload
+                // produces. A stdout golden over a program whose answer is a
+                // directory would compare two empty streams and pass.
+                let tree_shaped = matches!(workload.fixture, FixtureDeclaration::CorpusTree { .. });
+                let tree_oracle = workload.oracle.kind == OracleKind::SemanticSitePages;
+                if tree_shaped != tree_oracle {
                     return Err(format!(
-                        "runtime workload {:?} declares an empty fixture vocabulary",
-                        workload.id
-                    ));
-                }
-                if workload.fixture.file_name.contains('/') {
-                    return Err(format!(
-                        "runtime workload {:?} fixture file name must be a bare name",
-                        workload.id
+                        "runtime workload {:?} pairs a {:?} fixture with a {:?} oracle; a \
+                         corpus-tree workload is judged by its emitted tree and a seeded \
+                         one by its stdout",
+                        workload.id,
+                        if tree_shaped {
+                            "corpus_tree"
+                        } else {
+                            "seeded_generator"
+                        },
+                        workload.oracle.kind
                     ));
                 }
                 // Wrong output must fail regardless of speed, so a workload
@@ -637,6 +877,68 @@ impl RuntimeManifest {
                     ));
                 }
             }
+            for (workload, policy) in &epoch.peers {
+                if !declared.contains(workload.as_str()) {
+                    return Err(format!(
+                        "runtime epoch {} on {} declares a peer policy for undeclared \
+                         workload {workload:?}",
+                        epoch.id, epoch.platform
+                    ));
+                }
+                if policy.tools.is_empty() {
+                    return Err(format!(
+                        "runtime epoch {} on {} declares a peer policy for {workload:?} with \
+                         no peer tools",
+                        epoch.id, epoch.platform
+                    ));
+                }
+                // A canary that is not one of the declared peers would be an
+                // unpinned denominator, and the ratio it anchors would compare
+                // against a tool the record does not describe.
+                if !policy.tools.contains(&policy.canary_tool) {
+                    return Err(format!(
+                        "runtime epoch {} on {} names {:?} as the peer canary for {workload:?}, \
+                         which is not one of its peer tools {:?}",
+                        epoch.id, epoch.platform, policy.canary_tool, policy.tools
+                    ));
+                }
+                if policy.canary_scale == 0 {
+                    return Err(format!(
+                        "runtime epoch {} on {} declares a canary at scale 0 for {workload:?}",
+                        epoch.id, epoch.platform
+                    ));
+                }
+                // The peers build the workload's OWN fixture, so a canary
+                // at another scale would be a denominator for a corpus nobody
+                // built. Declaring the scale here anyway, and checking it,
+                // keeps the manifest legible without letting it lie.
+                match suite.workload(workload).map(|declared| &declared.fixture) {
+                    Some(FixtureDeclaration::CorpusTree { scale, .. }) => {
+                        if policy.canary_scale != *scale {
+                            return Err(format!(
+                                "runtime epoch {} on {} declares a {}x canary for {workload:?}, \
+                                 whose fixture is the {scale}x corpus",
+                                epoch.id, epoch.platform, policy.canary_scale
+                            ));
+                        }
+                    }
+                    _ => {
+                        return Err(format!(
+                            "runtime epoch {} on {} declares peers for {workload:?}, which does \
+                             not build a corpus tree; there is nothing for a peer to build",
+                            epoch.id, epoch.platform
+                        ));
+                    }
+                }
+                if policy.secondary_thread_policy == Some(policy.primary_thread_policy) {
+                    return Err(format!(
+                        "runtime epoch {} on {} publishes the same thread policy for \
+                         {workload:?} as both the primary ratio and the secondary row; a \
+                         secondary row that repeats the primary informs nobody",
+                        epoch.id, epoch.platform
+                    ));
+                }
+            }
         }
         Ok(())
     }
@@ -720,8 +1022,36 @@ pub struct RecordedInput {
     /// Its total size in bytes.
     pub bytes: u64,
     /// How it was produced, when it was generated rather than collected.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provenance: Option<GeneratedProvenance>,
+    /// How it was assembled, when it is a collected tree rather than generated
+    /// bytes.
+    ///
+    /// Exactly one of the two is present, and which one is decided by the
+    /// workload's declared fixture shape rather than by whichever happens to
+    /// parse: a record carrying neither, or carrying the other shape's, is
+    /// describing an input its suite did not declare.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tree: Option<CorpusTreeProvenance>,
+}
+
+/// How a collected recorded input was assembled.
+///
+/// "Recorded" is not "unpinned". The corpus's BYTES are expected to move, and
+/// the digest beside these fields is what makes a movement visible; everything
+/// about how the tree was built is still a contract, and a report that changed
+/// scale or quietly dropped another page is measuring a different workload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CorpusTreeProvenance {
+    /// Repository-relative path of the preparer that assembled the tree.
+    pub preparer: String,
+    /// Its revision at the time of assembly.
+    pub preparer_revision: u32,
+    /// The scale variant assembled.
+    pub scale: u32,
+    /// The content paths excluded from the corpus, sorted.
+    pub excluded: Vec<String>,
 }
 
 /// The executable that was measured.
@@ -773,6 +1103,78 @@ pub struct RuntimeSample {
     /// Digest of those bytes, so a nondeterministic run is provable from the
     /// record rather than only from the runner's summary.
     pub stdout_sha256: String,
+    /// Digest of the output TREE this sample emitted, for a workload whose
+    /// answer is an artifact rather than a stream.
+    ///
+    /// Absent for a stdout workload, and required for a tree one: it is what
+    /// makes determinism and the oracle's verdict provable from the stored
+    /// samples for a program whose stdout is empty by design. Omitted from the
+    /// serialized form when absent, so a stdout record's content address is
+    /// unchanged by this field existing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_sha256: Option<String>,
+}
+
+/// Which of the two published thread configurations a peer ran under.
+///
+/// ADR-0072 Decision 5. Rue has no concurrency and hosted runners have four
+/// vCPUs, so a default-configuration comparison would publish thread count as
+/// though it were per-unit work. The primary ratio pins the peers to one
+/// worker thread; their default parallel configuration is measured too and
+/// published as a clearly labelled secondary row, so the number a user would
+/// actually experience is never hidden.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PeerThreadPolicy {
+    /// One worker thread: `RAYON_NUM_THREADS=1` for Zola, `GOMAXPROCS=1` for
+    /// Hugo. The primary published ratio's denominator.
+    PinnedSingleThread,
+    /// The peer's own default. Published as a secondary row, never as the
+    /// primary ratio.
+    ToolDefaultParallel,
+}
+
+/// Why a peer measurement was taken.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PeerRole {
+    /// The per-run canary (Decision 9): one single-threaded build of the 1x
+    /// corpus, riding every gazette observation so the ratio published for it
+    /// has a SAME-RUN denominator rather than a stale or singleton one.
+    Canary,
+    /// A leg of the full peer matrix, which runs only on an event: the recorded
+    /// fixture identity moved, a peer version moved, or the epoch changed.
+    Full,
+}
+
+/// One peer tool's measurement of the same corpus, in the same run.
+///
+/// Peer samples live inside the gazette observation they are the denominator
+/// for. The alternative — a separate record kind joined after the fact — is
+/// what Decision 9's canary exists to avoid: a ratio whose two sides were
+/// measured on different days on a hosted runner is a ratio of two different
+/// machines' moods.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PeerObservation {
+    /// The peer, for example `zola`.
+    pub tool: String,
+    /// Its pinned version, recorded with every observation so a bump is an
+    /// annotated event rather than a silent shift.
+    pub version: String,
+    /// Why this measurement was taken.
+    pub role: PeerRole,
+    /// The thread configuration in force.
+    pub thread_policy: PeerThreadPolicy,
+    /// The corpus scale variant built.
+    pub scale: u32,
+    /// Digest of the tree this peer emitted.
+    pub output_sha256: String,
+    /// How many files it emitted.
+    pub emitted_files: u64,
+    /// Independent raw fresh-process measurements, taken by the same harness
+    /// and the same clock as the Rue program's.
+    pub samples: Vec<RuntimeSample>,
 }
 
 /// Raw measurements of one program.
@@ -795,6 +1197,14 @@ pub struct RuntimeObservation {
     pub oracle: OracleOutcome,
     /// Independent raw fresh-process measurements.
     pub samples: Vec<RuntimeSample>,
+    /// Peer tools' measurements of the same corpus in the same run.
+    ///
+    /// Empty for a workload with no peers, and empty is the honest state:
+    /// nothing here is ever synthesized from an earlier run. Omitted from the
+    /// serialized form when empty, so a wordfreq record's content address is
+    /// unchanged by this field existing.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub peers: Vec<PeerObservation>,
 }
 
 /// Identity of one runtime report.
@@ -1127,6 +1537,26 @@ pub enum RuntimeValidationError {
         /// Why.
         detail: String,
     },
+    /// The oracle that judged the run is not the one the suite declares.
+    ///
+    /// Separate from a reference mismatch: this is the wrong KIND of judgement,
+    /// and a stdout comparison over a program whose answer is a directory
+    /// compares two empty streams and reports a match.
+    OracleKindMismatch {
+        /// The workload.
+        workload: String,
+        /// What the record carries.
+        found: OracleKind,
+        /// What the suite declares.
+        expected: OracleKind,
+    },
+    /// A peer observation does not match the epoch's declared peer policy.
+    PeerPolicyViolation {
+        /// The workload.
+        workload: String,
+        /// What is wrong.
+        detail: String,
+    },
 }
 
 /// Why a stored runtime sample may not contribute to a statistic.
@@ -1287,6 +1717,20 @@ impl std::fmt::Display for RuntimeValidationError {
                     "workload {workload:?} program identity is impossible: {detail}"
                 )
             }
+            RuntimeValidationError::OracleKindMismatch {
+                workload,
+                found,
+                expected,
+            } => write!(
+                f,
+                "workload {workload:?} was judged by a {found:?} oracle, \
+                 but the suite declares {expected:?}"
+            ),
+            RuntimeValidationError::PeerPolicyViolation { workload, detail } => write!(
+                f,
+                "workload {workload:?} carries a peer observation its epoch does not \
+                 admit: {detail}"
+            ),
         }
     }
 }
@@ -1426,7 +1870,7 @@ pub fn validate_runtime_report(
             missing.push(workload.id.clone());
             continue;
         };
-        check_observation(observation, workload, &mut errors);
+        check_observation(observation, workload, epoch, &mut errors);
 
         if let Some(policy) = policy
             && let Some(actual) = samples_beyond_policy(observation.samples.len(), policy.samples)
@@ -1445,8 +1889,14 @@ pub fn validate_runtime_report(
         // every one of those samples is valid — the same tiering ADR-0067 uses,
         // so a truncated or partly broken observation keeps its evidence and
         // publishes no median.
-        let complete =
-            observation.samples.len() as u32 == expected_samples && invalid_samples.len() == before;
+        // The canary joins that tiering rather than blocking the report
+        // (ADR-0072 Decision 9). A run whose peer build failed still holds a
+        // valid Rue measurement worth storing, and the ratio it was meant to
+        // anchor is exactly what cannot be computed — so the evidence is kept,
+        // no point publishes, and collection health shows the hole.
+        let complete = observation.samples.len() as u32 == expected_samples
+            && invalid_samples.len() == before
+            && has_required_canary(observation, workload, epoch);
         if !complete {
             missing.push(workload.id.clone());
         }
@@ -1631,6 +2081,7 @@ fn check_regime(
 fn check_observation(
     observation: &RuntimeObservation,
     workload: &RuntimeWorkload,
+    epoch: &RuntimeEpoch,
     errors: &mut Vec<RuntimeValidationError>,
 ) {
     if observation.program_args != workload.program_args {
@@ -1664,50 +2115,104 @@ fn check_observation(
             mismatch(
                 "category",
                 format!("{:?}", input.category),
-                format!("{:?}", workload.fixture.category),
+                format!("{:?}", workload.fixture.category()),
             );
-            mismatch(
-                "bytes",
-                input.bytes.to_string(),
-                workload.fixture.bytes.to_string(),
-            );
-            // A `FixtureDeclaration` names exactly one `file_name`, so a
-            // single-file fixture claiming any other count is describing an
-            // input the suite did not declare. A multi-file recorded input —
-            // gazette's corpus — arrives with its own declaration kind.
-            mismatch("files", input.files.to_string(), 1.to_string());
-            match &input.provenance {
-                None => mismatch(
-                    "provenance",
-                    "none".to_string(),
-                    format!(
-                        "{} revision {} seed {}",
-                        workload.fixture.generator,
-                        workload.fixture.generator_revision,
-                        workload.fixture.seed
-                    ),
-                ),
-                Some(provenance) => {
-                    mismatch(
-                        "generator",
-                        provenance.generator.clone(),
-                        workload.fixture.generator.clone(),
-                    );
-                    mismatch(
-                        "generator_revision",
-                        provenance.generator_revision.to_string(),
-                        workload.fixture.generator_revision.to_string(),
-                    );
-                    mismatch(
-                        "seed",
-                        provenance.seed.to_string(),
-                        workload.fixture.seed.to_string(),
-                    );
-                    mismatch(
-                        "vocabulary_size",
-                        provenance.vocabulary_size.to_string(),
-                        workload.fixture.vocabulary_size.to_string(),
-                    );
+            match &workload.fixture {
+                FixtureDeclaration::SeededGenerator {
+                    generator,
+                    generator_revision,
+                    seed,
+                    bytes,
+                    vocabulary_size,
+                    ..
+                } => {
+                    mismatch("bytes", input.bytes.to_string(), bytes.to_string());
+                    // A seeded `FixtureDeclaration` names exactly one
+                    // `file_name`, so a single-file fixture claiming any other
+                    // count is describing an input the suite did not declare.
+                    // The corpus-tree shape below relaxes this and NOTHING
+                    // else: the seeded rules are the ones RUE-1046's review
+                    // tightened after nine of ten fabricated records were
+                    // accepted, and generalizing the declaration must not
+                    // loosen a single one of them.
+                    mismatch("files", input.files.to_string(), 1.to_string());
+                    if input.tree.is_some() {
+                        mismatch(
+                            "tree",
+                            "a corpus-tree provenance".to_string(),
+                            "none, for a seeded fixture".to_string(),
+                        );
+                    }
+                    match &input.provenance {
+                        None => mismatch(
+                            "provenance",
+                            "none".to_string(),
+                            format!("{generator} revision {generator_revision} seed {seed}"),
+                        ),
+                        Some(provenance) => {
+                            mismatch("generator", provenance.generator.clone(), generator.clone());
+                            mismatch(
+                                "generator_revision",
+                                provenance.generator_revision.to_string(),
+                                generator_revision.to_string(),
+                            );
+                            mismatch("seed", provenance.seed.to_string(), seed.to_string());
+                            mismatch(
+                                "vocabulary_size",
+                                provenance.vocabulary_size.to_string(),
+                                vocabulary_size.to_string(),
+                            );
+                        }
+                    }
+                }
+                FixtureDeclaration::CorpusTree {
+                    preparer,
+                    preparer_revision,
+                    scale,
+                    excluded,
+                    ..
+                } => {
+                    // The tree's SIZE is recorded rather than declared — that
+                    // is the whole of Decision 2 — but a fixture of no files
+                    // or no bytes is not a corpus that moved, it is a
+                    // preparation that failed.
+                    if input.files == 0 {
+                        mismatch("files", "0".to_string(), "at least one".to_string());
+                    }
+                    if input.bytes == 0 {
+                        mismatch("bytes", "0".to_string(), "more than zero".to_string());
+                    }
+                    if input.provenance.is_some() {
+                        mismatch(
+                            "provenance",
+                            "a generated provenance".to_string(),
+                            "none, for a collected tree".to_string(),
+                        );
+                    }
+                    match &input.tree {
+                        None => mismatch(
+                            "tree",
+                            "none".to_string(),
+                            format!("{preparer} revision {preparer_revision} at scale {scale}x"),
+                        ),
+                        Some(tree) => {
+                            mismatch("preparer", tree.preparer.clone(), preparer.clone());
+                            mismatch(
+                                "preparer_revision",
+                                tree.preparer_revision.to_string(),
+                                preparer_revision.to_string(),
+                            );
+                            mismatch("scale", tree.scale.to_string(), scale.to_string());
+                            // Sorted on both sides: an exclusion set that
+                            // differs only in order is the same set, and one
+                            // that differs in membership is a different job.
+                            let mut found = tree.excluded.clone();
+                            let mut expected = excluded.clone();
+                            found.sort();
+                            expected.sort();
+                            mismatch("excluded", format!("{found:?}"), format!("{expected:?}"));
+                        }
+                    }
                 }
             }
             // The digest is the only thing that makes two raw medians
@@ -1723,6 +2228,8 @@ fn check_observation(
         }
     }
 
+    check_peers(observation, workload, epoch, errors);
+
     if !is_sha256_digest(&observation.program.sha256) {
         errors.push(RuntimeValidationError::MalformedDigest {
             workload: workload.id.clone(),
@@ -1737,6 +2244,13 @@ fn check_observation(
         });
     }
 
+    if observation.oracle.kind != workload.oracle.kind {
+        errors.push(RuntimeValidationError::OracleKindMismatch {
+            workload: workload.id.clone(),
+            found: observation.oracle.kind,
+            expected: workload.oracle.kind,
+        });
+    }
     if observation.oracle.reference != workload.oracle.path {
         errors.push(RuntimeValidationError::OracleReferenceMismatch {
             workload: workload.id.clone(),
@@ -1745,6 +2259,159 @@ fn check_observation(
         });
     }
     check_oracle_against_samples(observation, workload, errors);
+}
+
+/// Hold peer observations to the epoch's declared peer policy.
+///
+/// Peers are the denominator of a published ratio, so every property the ratio
+/// depends on is checked from the record rather than trusted from the runner:
+/// which tool, which version, which thread configuration, which scale, and
+/// whether the peer's own repeated samples agreed with each other.
+///
+/// A peer whose build FAILED is not represented here at all — the runner
+/// records a [`RuntimeFailure`] instead — so an observation missing its canary
+/// is handled as incompleteness, where the evidence is kept and no ratio
+/// publishes, rather than as a malformed record.
+fn check_peers(
+    observation: &RuntimeObservation,
+    workload: &RuntimeWorkload,
+    epoch: &RuntimeEpoch,
+    errors: &mut Vec<RuntimeValidationError>,
+) {
+    // Collected rather than pushed directly, so the digest checks below can
+    // borrow `errors` in the same scope.
+    let mut details: Vec<String> = Vec::new();
+    let Some(policy) = epoch.peers.get(&workload.id) else {
+        if !observation.peers.is_empty() {
+            details.push(format!(
+                "{} peer observation(s) are stored, but this epoch declares no peer policy \
+                 for the workload",
+                observation.peers.len()
+            ));
+        }
+        flush(errors, workload, details);
+        return;
+    };
+
+    let mut canaries = 0;
+    for peer in &observation.peers {
+        if !policy.tools.contains(&peer.tool) {
+            details.push(format!(
+                "{:?} is not one of the epoch's peer tools {:?}",
+                peer.tool, policy.tools
+            ));
+        }
+        if peer.version.trim().is_empty() {
+            details.push(format!(
+                "the {:?} observation records no version; a peer whose version is unknown \
+                 cannot anchor a comparable ratio",
+                peer.tool
+            ));
+        }
+        let admitted = peer.thread_policy == policy.primary_thread_policy
+            || Some(peer.thread_policy) == policy.secondary_thread_policy;
+        if !admitted {
+            details.push(format!(
+                "the {:?} observation ran under {:?}, which is neither this epoch's primary \
+                 nor its published secondary thread policy",
+                peer.tool, peer.thread_policy
+            ));
+        }
+        if peer.samples.is_empty() {
+            details.push(format!(
+                "the {:?} observation stores no sample to have measured",
+                peer.tool
+            ));
+        }
+        if !is_sha256_digest(&peer.output_sha256) {
+            errors.push(RuntimeValidationError::MalformedDigest {
+                workload: workload.id.clone(),
+                field: format!("peers/{}/output_sha256", peer.tool),
+                found: peer.output_sha256.clone(),
+            });
+        }
+        // Decided from the stored per-sample digests, never from a flag: a peer
+        // whose repeated builds disagree is a denominator nobody should divide
+        // by, and the ports strip build-time-varying output precisely so this
+        // holds byte-exactly.
+        if let Some(index) = peer
+            .samples
+            .iter()
+            .position(|sample| sample.artifact_sha256.as_deref() != Some(&peer.output_sha256))
+        {
+            details.push(format!(
+                "the {:?} observation's sample {index} emitted {:?} rather than the recorded \
+                 {:?}; a peer that does not build the same tree twice cannot anchor a ratio",
+                peer.tool,
+                peer.samples[index]
+                    .artifact_sha256
+                    .as_deref()
+                    .unwrap_or("nothing"),
+                peer.output_sha256
+            ));
+        }
+        if peer.role == PeerRole::Canary {
+            canaries += 1;
+            if peer.tool != policy.canary_tool {
+                details.push(format!(
+                    "the canary is {:?}, but this epoch's canary is {:?}",
+                    peer.tool, policy.canary_tool
+                ));
+            }
+            if peer.scale != policy.canary_scale {
+                details.push(format!(
+                    "the canary built the {}x corpus, but this epoch's canary builds {}x",
+                    peer.scale, policy.canary_scale
+                ));
+            }
+            if peer.thread_policy != policy.primary_thread_policy {
+                details.push(format!(
+                    "the canary ran under {:?}, but the primary ratio it anchors is taken \
+                     under {:?}",
+                    peer.thread_policy, policy.primary_thread_policy
+                ));
+            }
+        }
+    }
+    if canaries > 1 {
+        details.push(format!(
+            "{canaries} observations claim to be the per-run canary; the ratio's denominator \
+             must be one measurement, not a choice between several"
+        ));
+    }
+    flush(errors, workload, details);
+}
+
+/// Turn collected peer complaints into validation errors.
+fn flush(
+    errors: &mut Vec<RuntimeValidationError>,
+    workload: &RuntimeWorkload,
+    details: Vec<String>,
+) {
+    for detail in details {
+        errors.push(RuntimeValidationError::PeerPolicyViolation {
+            workload: workload.id.clone(),
+            detail,
+        });
+    }
+}
+
+/// Whether an observation carries the same-run peer denominator its epoch asks
+/// for (ADR-0072 Decision 9).
+fn has_required_canary(
+    observation: &RuntimeObservation,
+    workload: &RuntimeWorkload,
+    epoch: &RuntimeEpoch,
+) -> bool {
+    let Some(policy) = epoch.peers.get(&workload.id) else {
+        return true;
+    };
+    observation.peers.iter().any(|peer| {
+        peer.role == PeerRole::Canary
+            && peer.tool == policy.canary_tool
+            && peer.scale == policy.canary_scale
+            && !peer.samples.is_empty()
+    })
 }
 
 /// Check the producer's summary of a run against the samples stored beside it.
@@ -1778,6 +2445,11 @@ fn check_oracle_against_samples(
         });
     }
 
+    // Which digest a verdict is a claim about depends on what the oracle
+    // judges: stdout for a stdout golden, the emitted tree for a site oracle.
+    // Reading stdout for gazette would compare two empty streams and report a
+    // match while the 96 pages went unexamined.
+    let kind = workload.oracle.kind;
     for (index, sample) in observation.samples.iter().enumerate() {
         if !is_sha256_digest(&sample.stdout_sha256) {
             errors.push(RuntimeValidationError::MalformedDigest {
@@ -1786,13 +2458,21 @@ fn check_oracle_against_samples(
                 found: sample.stdout_sha256.clone(),
             });
         }
+        match kind.judged_digest(sample) {
+            Some(digest) if is_sha256_digest(digest) => {}
+            other => errors.push(RuntimeValidationError::MalformedDigest {
+                workload: workload.id.clone(),
+                field: format!("samples/{index}/{}", kind.judged_field()),
+                found: other.unwrap_or("absent").to_string(),
+            }),
+        }
     }
 
     // Determinism is decided by the digests, never by the flag.
     let distinct: BTreeSet<&str> = observation
         .samples
         .iter()
-        .map(|sample| sample.stdout_sha256.as_str())
+        .map(|sample| kind.judged_digest(sample).unwrap_or_default())
         .collect();
     let observed_deterministic = distinct.len() <= 1;
     if oracle.deterministic_across_samples != observed_deterministic {
@@ -1848,7 +2528,13 @@ fn check_oracle_against_samples(
             });
         }
     }
-    if oracle.observed_sha256 != oracle.reference_sha256 {
+    // Only a golden comparison claims that the two digests are equal. A site
+    // oracle's `reference_sha256` is the identity of the JUDGE — the checked-in
+    // comparison that read every emitted page — so requiring it to equal the
+    // digest of the tree it judged would be requiring a program to equal its
+    // own output. What the site oracle's verdict claims instead is checked
+    // below: that every sample produced the tree that was judged.
+    if kind == OracleKind::GoldenStdout && oracle.observed_sha256 != oracle.reference_sha256 {
         contradiction(
             errors,
             &workload.id,
@@ -1864,7 +2550,7 @@ fn check_oracle_against_samples(
     if let Some(index) = observation
         .samples
         .iter()
-        .position(|sample| sample.stdout_sha256 != oracle.observed_sha256)
+        .position(|sample| kind.judged_digest(sample) != Some(oracle.observed_sha256.as_str()))
     {
         contradiction(
             errors,
@@ -1872,7 +2558,9 @@ fn check_oracle_against_samples(
             "verdict",
             format!(
                 "a match was declared, but sample {index} produced {} rather than the judged {}",
-                observation.samples[index].stdout_sha256, oracle.observed_sha256
+                kind.judged_digest(&observation.samples[index])
+                    .unwrap_or("nothing"),
+                oracle.observed_sha256
             ),
         );
     }
@@ -1937,6 +2625,7 @@ question = "How fast does compiled Rue count words in a large text?"
 program_args = ["{fixture}"]
 
 [suite.workloads.fixture]
+kind = "seeded_generator"
 category = "recorded"
 generator = "zipf_ascii_text"
 generator_revision = 1
@@ -1999,10 +2688,13 @@ samples = 5
         let workload = suite
             .workload("wordfreq")
             .expect("wordfreq is a permanent member of this suite");
-        assert_eq!(workload.fixture.category, InputCategory::Recorded);
+        assert_eq!(workload.fixture.category(), InputCategory::Recorded);
         assert_eq!(workload.oracle.kind, OracleKind::GoldenStdout);
+        let FixtureDeclaration::SeededGenerator { bytes, .. } = &workload.fixture else {
+            panic!("wordfreq's fixture is one file from a seeded generator");
+        };
         assert!(
-            workload.fixture.bytes >= 16 * 1024 * 1024,
+            *bytes >= 16 * 1024 * 1024,
             "the fixture must be large enough that the run measures counting \
              rather than process startup"
         );
@@ -2020,7 +2712,7 @@ samples = 5
         let epoch = manifest
             .collection_epoch("aarch64-linux")
             .expect("aarch64-linux is a row of the v1 platform matrix");
-        assert_eq!(epoch.suite_revision, 1);
+        assert_eq!(epoch.suite_revision, 2);
         assert_eq!(epoch.target, "aarch64-linux");
         assert_eq!(epoch.optimization, OptimizationLevel::O3);
         assert_eq!(epoch.thread_policy, ThreadPolicy::SingleThreaded);
@@ -2048,7 +2740,7 @@ samples = 5
         let epoch = manifest
             .collection_epoch("aarch64-macos")
             .expect("aarch64-macos is the scheduled row of the v1 platform matrix");
-        assert_eq!(epoch.suite_revision, 1);
+        assert_eq!(epoch.suite_revision, 2);
         assert_eq!(epoch.target, "aarch64-macos");
         assert_eq!(epoch.optimization, OptimizationLevel::O3);
         assert_eq!(epoch.thread_policy, ThreadPolicy::SingleThreaded);
@@ -2154,6 +2846,7 @@ samples = 5
                         seed: 20260813,
                         vocabulary_size: 256,
                     }),
+                    tree: None,
                 }],
                 program: ProgramIdentity {
                     binary_bytes: 262_144,
@@ -2175,8 +2868,10 @@ samples = 5
                         exit_code: 0,
                         stdout_bytes: 42,
                         stdout_sha256: "c".repeat(64),
+                        artifact_sha256: None,
                     })
                     .collect(),
+                peers: Vec::new(),
             }],
             failures: Vec::new(),
         }
@@ -2199,7 +2894,7 @@ samples = 5
         // record can never be ambiguous about which discipline governed it.
         let manifest = manifest();
         let workload = manifest.suite(1).unwrap().workload("wordfreq").unwrap();
-        assert_eq!(workload.fixture.category, InputCategory::Recorded);
+        assert_eq!(workload.fixture.category(), InputCategory::Recorded);
     }
 
     #[test]
@@ -2818,6 +3513,501 @@ samples = 5
     fn a_malformed_record_is_reported_rather_than_guessed_at() {
         assert!(crate::StoredRuntimeReport::read("{").is_err());
         assert!(crate::StoredRuntimeReport::read(r#"{"record_kind":"runtime_v1"}"#).is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // The corpus-tree fixture shape, gazette's oracle, and the peer legs
+    // (ADR-0072 Phase 5, RUE-1485).
+    //
+    // The first three tests below are the ones that matter most: generalizing a
+    // declaration is exactly how a validator gets quietly weakened, so each
+    // asserts that the new shape's relaxation applies to the new shape ALONE.
+    // -----------------------------------------------------------------------
+
+    const GAZETTE_MANIFEST: &str = r#"
+schema_version = 1
+
+[[suite]]
+revision = 1
+protocol_version = 1
+measured_boundary = "spawn_to_exit_v1"
+
+[[suite.workloads]]
+id = "gazette"
+source = "examples/gazette/main.rue"
+question = "How fast does compiled Rue build the real site?"
+program_args = ["build", "{fixture}", "-o", "{output}"]
+
+[suite.workloads.fixture]
+kind = "corpus_tree"
+category = "recorded"
+preparer = "scripts/gazette-corpus-diff.py"
+preparer_revision = 1
+scale = 1
+excluded = ["performance.md", "runtime.md"]
+root_name = "gazette-site"
+description = "the live corpus"
+
+[suite.workloads.oracle]
+kind = "semantic_site_pages"
+path = "scripts/gazette-corpus-diff.py"
+
+[[epoch]]
+id = 1
+platform = "x86_64-linux"
+suite_revision = 1
+target = "x86_64-unknown-linux-gnu"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = true
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+[epoch.sampling.gazette]
+samples = 3
+
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+"#;
+
+    fn gazette_manifest() -> RuntimeManifest {
+        RuntimeManifest::parse(GAZETTE_MANIFEST).expect("gazette manifest")
+    }
+
+    fn site_sample(elapsed: u64) -> RuntimeSample {
+        RuntimeSample {
+            process_elapsed_ns: elapsed,
+            peak_memory_bytes: 8 * 1024 * 1024,
+            exit_code: 0,
+            stdout_bytes: 0,
+            stdout_sha256: "e".repeat(64),
+            artifact_sha256: Some("7".repeat(64)),
+        }
+    }
+
+    fn canary() -> PeerObservation {
+        PeerObservation {
+            tool: "zola".to_string(),
+            version: "0.21.0".to_string(),
+            role: PeerRole::Canary,
+            thread_policy: PeerThreadPolicy::PinnedSingleThread,
+            scale: 1,
+            output_sha256: "8".repeat(64),
+            emitted_files: 131,
+            samples: vec![RuntimeSample {
+                process_elapsed_ns: 200_000_000,
+                peak_memory_bytes: 60 * 1024 * 1024,
+                exit_code: 0,
+                stdout_bytes: 64,
+                stdout_sha256: "a".repeat(64),
+                artifact_sha256: Some("8".repeat(64)),
+            }],
+        }
+    }
+
+    fn gazette_report() -> RuntimeReport {
+        let mut report = report();
+        report.identity.workload_source_hashes =
+            BTreeMap::from([("gazette".to_string(), "3".repeat(64))]);
+        report.workloads = vec![RuntimeObservation {
+            workload: "gazette".to_string(),
+            source: "examples/gazette/main.rue".to_string(),
+            question: "How fast does compiled Rue build the real site?".to_string(),
+            program_args: vec![
+                "build".to_string(),
+                FIXTURE_ARGUMENT.to_string(),
+                "-o".to_string(),
+                OUTPUT_ARGUMENT.to_string(),
+            ],
+            recorded_inputs: vec![RecordedInput {
+                name: FIXTURE_INPUT_NAME.to_string(),
+                category: InputCategory::Recorded,
+                description: "the live corpus".to_string(),
+                identity_sha256: "f".repeat(64),
+                files: 130,
+                bytes: 1_800_000,
+                provenance: None,
+                tree: Some(CorpusTreeProvenance {
+                    preparer: "scripts/gazette-corpus-diff.py".to_string(),
+                    preparer_revision: 1,
+                    scale: 1,
+                    excluded: vec!["performance.md".to_string(), "runtime.md".to_string()],
+                }),
+            }],
+            program: ProgramIdentity {
+                binary_bytes: 1_048_576,
+                sha256: "b".repeat(64),
+            },
+            oracle: OracleOutcome {
+                kind: OracleKind::SemanticSitePages,
+                reference: "scripts/gazette-corpus-diff.py".to_string(),
+                reference_sha256: "d".repeat(64),
+                observed_sha256: "7".repeat(64),
+                verdict: OracleVerdict::Match,
+                deterministic_across_samples: true,
+                detail: String::new(),
+            },
+            samples: (0..3)
+                .map(|index| site_sample(2_000_000_000 + index))
+                .collect(),
+            peers: vec![canary()],
+        }];
+        report
+    }
+
+    #[test]
+    fn a_corpus_tree_workload_is_appendable() {
+        let outcome = validate_runtime_report(&gazette_manifest(), &gazette_report());
+        assert_eq!(outcome.errors, Vec::new());
+        assert_eq!(outcome.completeness, RuntimeCompleteness::Complete);
+        assert!(outcome.publishes_workload("gazette"));
+    }
+
+    #[test]
+    fn the_multi_file_relaxation_applies_to_the_corpus_tree_alone() {
+        // The whole risk of this generalization in one test. A corpus tree may
+        // record 130 files; wordfreq may not record 2, and RUE-1046's review —
+        // which found nine of ten fabricated records being accepted — is the
+        // reason. Both halves are asserted, because a change that relaxed the
+        // seeded shape would still pass the first half alone.
+        let mut tree = gazette_report();
+        tree.workloads[0].recorded_inputs[0].files = 130;
+        assert!(
+            validate_runtime_report(&gazette_manifest(), &tree).is_appendable(),
+            "a corpus tree is many files by definition"
+        );
+
+        let mut seeded = report();
+        seeded.workloads[0].recorded_inputs[0].files = 130;
+        assert!(
+            validate_runtime_report(&manifest(), &seeded).errors.iter().any(|error| matches!(
+                error,
+                RuntimeValidationError::FixtureProvenanceMismatch { field, .. } if field == "files"
+            )),
+            "a seeded fixture is exactly one file, and still is"
+        );
+    }
+
+    #[test]
+    fn a_seeded_record_may_not_borrow_the_corpus_tree_s_shape() {
+        // The other direction of the same risk: a wordfreq record that dropped
+        // its generated provenance and claimed a tree provenance instead would,
+        // under a declaration with every field optional, describe an input no
+        // seed produced. Both substitutions are refused.
+        let mut report = report();
+        report.workloads[0].recorded_inputs[0].provenance = None;
+        report.workloads[0].recorded_inputs[0].tree = Some(CorpusTreeProvenance {
+            preparer: "scripts/gazette-corpus-diff.py".to_string(),
+            preparer_revision: 1,
+            scale: 1,
+            excluded: Vec::new(),
+        });
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(!outcome.is_appendable());
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                RuntimeValidationError::FixtureProvenanceMismatch { field, .. }
+                    if field == "provenance"
+            )),
+            "{:?}",
+            outcome.errors
+        );
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                RuntimeValidationError::FixtureProvenanceMismatch { field, .. } if field == "tree"
+            )),
+            "{:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn a_corpus_tree_at_another_scale_is_a_different_workload() {
+        // Recorded is not unpinned. The corpus's BYTES may move; the scale it
+        // was duplicated to may not, or a 10x observation would land in the 1x
+        // series and read as a tenfold regression.
+        let mut report = gazette_report();
+        report.workloads[0].recorded_inputs[0]
+            .tree
+            .as_mut()
+            .unwrap()
+            .scale = 10;
+        assert!(validate_runtime_report(&gazette_manifest(), &report).errors.iter().any(
+            |error| matches!(
+                error,
+                RuntimeValidationError::FixtureProvenanceMismatch { field, .. } if field == "scale"
+            )
+        ));
+    }
+
+    #[test]
+    fn a_corpus_tree_that_excluded_another_page_is_a_different_workload() {
+        let mut report = gazette_report();
+        report.workloads[0].recorded_inputs[0]
+            .tree
+            .as_mut()
+            .unwrap()
+            .excluded
+            .push("tutorial/_index.md".to_string());
+        assert!(
+            validate_runtime_report(&gazette_manifest(), &report)
+                .errors
+                .iter()
+                .any(|error| matches!(
+                    error,
+                    RuntimeValidationError::FixtureProvenanceMismatch { field, .. }
+                        if field == "excluded"
+                ))
+        );
+    }
+
+    #[test]
+    fn a_site_oracle_judges_the_emitted_tree_rather_than_empty_stdout() {
+        // Gazette writes nothing to stdout, so every sample's stdout digest is
+        // the digest of nothing and agrees with every other. A verdict read
+        // from stdout would therefore report determinism and a match for a run
+        // whose 96 pages were never looked at. This is the case that proves the
+        // verdict follows the ORACLE KIND: the trees differ, the stdouts do
+        // not, and the record is refused.
+        let mut report = gazette_report();
+        report.workloads[0].samples[1].artifact_sha256 = Some("9".repeat(64));
+        let distinct_stdout: BTreeSet<&str> = report.workloads[0]
+            .samples
+            .iter()
+            .map(|sample| sample.stdout_sha256.as_str())
+            .collect();
+        assert_eq!(distinct_stdout.len(), 1, "the stdouts agree, as they will");
+        let outcome = validate_runtime_report(&gazette_manifest(), &report);
+        assert!(!outcome.is_appendable());
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                RuntimeValidationError::NondeterministicOutput { .. }
+            )),
+            "{:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn a_site_workload_with_no_artifact_digest_is_refused() {
+        let mut report = gazette_report();
+        report.workloads[0].samples[0].artifact_sha256 = None;
+        let outcome = validate_runtime_report(&gazette_manifest(), &report);
+        assert!(!outcome.is_appendable());
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                RuntimeValidationError::MalformedDigest { field, .. }
+                    if field.ends_with("artifact_sha256")
+            )),
+            "{:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn an_oracle_of_the_wrong_kind_is_refused() {
+        let mut report = gazette_report();
+        report.workloads[0].oracle.kind = OracleKind::GoldenStdout;
+        assert!(
+            validate_runtime_report(&gazette_manifest(), &report)
+                .errors
+                .iter()
+                .any(|error| matches!(error, RuntimeValidationError::OracleKindMismatch { .. }))
+        );
+    }
+
+    #[test]
+    fn an_observation_without_its_canary_publishes_nothing_but_is_kept() {
+        // ADR-0072 Decision 9: the canary is the same-run ratio denominator. A
+        // run that lost it holds a valid Rue measurement worth storing and a
+        // ratio that cannot be computed, so the evidence is kept and no point
+        // publishes — the same tiering a truncated observation gets.
+        let mut report = gazette_report();
+        report.workloads[0].peers.clear();
+        let outcome = validate_runtime_report(&gazette_manifest(), &report);
+        assert!(outcome.is_appendable(), "{:?}", outcome.errors);
+        assert!(!outcome.publishes_workload("gazette"));
+    }
+
+    #[test]
+    fn a_peer_measured_under_an_undeclared_thread_policy_is_refused() {
+        // The fairness property the record has to carry. A canary taken with
+        // Zola's default rayon pool on a four-vCPU runner would publish thread
+        // count as though it were per-unit work.
+        let mut report = gazette_report();
+        report.workloads[0].peers[0].thread_policy = PeerThreadPolicy::ToolDefaultParallel;
+        let outcome = validate_runtime_report(&gazette_manifest(), &report);
+        assert!(!outcome.is_appendable());
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                RuntimeValidationError::PeerPolicyViolation { detail, .. }
+                    if detail.contains("primary ratio it anchors")
+            )),
+            "{:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn a_peer_whose_samples_disagree_cannot_anchor_a_ratio() {
+        // The determinism trap ADR-0072 Decision 4 names: Hugo's built-in feed
+        // emits `lastBuildDate` and `generator`, so a port that kept it would
+        // produce a different tree on every sample. Decided from the stored
+        // digests rather than from any flag.
+        let mut report = gazette_report();
+        let second = RuntimeSample {
+            artifact_sha256: Some("1".repeat(64)),
+            ..report.workloads[0].peers[0].samples[0].clone()
+        };
+        report.workloads[0].peers[0].samples.push(second);
+        let outcome = validate_runtime_report(&gazette_manifest(), &report);
+        assert!(!outcome.is_appendable());
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                RuntimeValidationError::PeerPolicyViolation { detail, .. }
+                    if detail.contains("same tree twice")
+            )),
+            "{:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn peer_observations_without_a_declared_policy_are_refused() {
+        // wordfreq has no peers. A record carrying some would publish a ratio
+        // against a tool this epoch never declared it would run.
+        let mut report = report();
+        report.workloads[0].peers.push(canary());
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(!outcome.is_appendable());
+        assert!(
+            outcome
+                .errors
+                .iter()
+                .any(|error| matches!(error, RuntimeValidationError::PeerPolicyViolation { .. }))
+        );
+    }
+
+    #[test]
+    fn a_fixture_table_still_refuses_unknown_fields_after_being_tagged() {
+        // The tagging must not have bought its flexibility by accepting
+        // anything. A key nobody reads in a fixture declaration is how a
+        // maintainer comes to believe a pin is in force that is not: a
+        // misspelled `vocabulary_sizes` would sit in the manifest looking
+        // authoritative while the generator ran on a default.
+        let text = MANIFEST.replace(
+            "file_name = \"input.txt\"",
+            "file_name = \"input.txt\"\nvocabulary_sizes = 512",
+        );
+        let error = RuntimeManifest::parse(&text).unwrap_err();
+        assert!(error.contains("unknown field"), "{error}");
+
+        // And a field belonging to the OTHER shape is exactly as unknown, so
+        // neither declaration can quietly grow the other's fields.
+        let text = GAZETTE_MANIFEST.replace(
+            "preparer_revision = 1",
+            "preparer_revision = 1\nseed = 20260813",
+        );
+        let error = RuntimeManifest::parse(&text).unwrap_err();
+        assert!(error.contains("unknown field"), "{error}");
+    }
+
+    #[test]
+    fn a_manifest_pairing_a_site_fixture_with_a_stdout_oracle_is_refused() {
+        let text =
+            GAZETTE_MANIFEST.replace("kind = \"semantic_site_pages\"", "kind = \"golden_stdout\"");
+        let error = RuntimeManifest::parse(&text).unwrap_err();
+        assert!(error.contains("corpus-tree workload is judged"), "{error}");
+    }
+
+    #[test]
+    fn a_site_workload_that_is_never_told_where_to_write_is_refused() {
+        let text = GAZETTE_MANIFEST.replace(
+            r#"program_args = ["build", "{fixture}", "-o", "{output}"]"#,
+            r#"program_args = ["build", "{fixture}"]"#,
+        );
+        let error = RuntimeManifest::parse(&text).unwrap_err();
+        assert!(error.contains("never receives a destination"), "{error}");
+    }
+
+    #[test]
+    fn a_canary_outside_the_declared_peer_tools_is_refused_by_the_manifest() {
+        let text =
+            GAZETTE_MANIFEST.replace(r#"canary_tool = "zola""#, r#"canary_tool = "eleventy""#);
+        let error = RuntimeManifest::parse(&text).unwrap_err();
+        assert!(error.contains("not one of its peer tools"), "{error}");
+    }
+
+    #[test]
+    fn a_secondary_row_that_repeats_the_primary_is_refused() {
+        let text = GAZETTE_MANIFEST.replace(
+            r#"secondary_thread_policy = "tool_default_parallel""#,
+            r#"secondary_thread_policy = "pinned_single_thread""#,
+        );
+        let error = RuntimeManifest::parse(&text).unwrap_err();
+        assert!(error.contains("informs nobody"), "{error}");
+    }
+
+    #[test]
+    fn the_checked_in_manifest_measures_gazette_against_pinned_peers() {
+        // The Phase 5 entry itself: gazette in the collected suite, with the
+        // thread parity and the per-run canary ADR-0072 Decisions 5 and 9
+        // require, and advisory flags because no platform inherits calibration.
+        let manifest = RuntimeManifest::parse(CHECKED_IN_MANIFEST).expect("checked-in manifest");
+        for platform in ["x86_64-linux", "aarch64-linux", "aarch64-macos"] {
+            let epoch = manifest
+                .collection_epoch(platform)
+                .unwrap_or_else(|| panic!("{platform} collects"));
+            let suite = manifest.suite(epoch.suite_revision).expect("suite");
+            let workload = suite.workload("gazette").expect("gazette is measured");
+            let FixtureDeclaration::CorpusTree {
+                scale, excluded, ..
+            } = &workload.fixture
+            else {
+                panic!("gazette's fixture is a corpus tree");
+            };
+            assert_eq!(*scale, 1);
+            assert_eq!(excluded, &["performance.md", "runtime.md"]);
+            assert_eq!(workload.oracle.kind, OracleKind::SemanticSitePages);
+
+            let peers = epoch.peers.get("gazette").expect("a peer policy");
+            assert_eq!(peers.tools, vec!["zola", "hugo"]);
+            assert_eq!(
+                peers.primary_thread_policy,
+                PeerThreadPolicy::PinnedSingleThread,
+                "the primary published ratio pins the peers to one worker thread"
+            );
+            assert_eq!(
+                peers.secondary_thread_policy,
+                Some(PeerThreadPolicy::ToolDefaultParallel),
+                "the peers' default parallel configuration is published, not hidden"
+            );
+            assert_eq!(peers.canary_tool, "zola");
+            assert_eq!(peers.canary_scale, 1);
+            // Each rung's peers build that rung's own corpus, so the 10x
+            // workload's canary is a 10x peer build rather than a 1x one
+            // borrowed from the row above.
+            assert_eq!(epoch.peers["gazette_10x"].canary_scale, 10);
+            assert_eq!(epoch.flag_posture("gazette"), FlagPosture::Advisory);
+            // The 10x rung is measured for Rue; the 100x one is the safety
+            // valve of Decision 9 and is deliberately not collected yet.
+            assert!(suite.workload("gazette_10x").is_some());
+            assert!(suite.workload("gazette_100x").is_none());
+        }
     }
 
     #[test]

--- a/docs/designs/0072-runtime-benchmarking-static-site-generator.md
+++ b/docs/designs/0072-runtime-benchmarking-static-site-generator.md
@@ -653,6 +653,20 @@ website-publish pipeline rather than adding a new schedule:
   peer sample. The full peer matrix (Hugo, scale variants, the
   default-parallel secondary row) stays event-driven; the canary falls
   under the same cost safety valve as the scale variants.
+
+  Phase 5 refined "the 1x corpus" to "the workload's own corpus": each
+  measured rung carries its own canary, so the 10x rung's denominator is a
+  10x peer build. A 1x denominator for a 10x numerator would not be a
+  ratio of anything. The cost is the reason the wording started where it
+  did, and it is bounded by the same valve — a rung that becomes too
+  expensive leaves per-push collection with its canary.
+
+  Between events, the derived comparison table JOINS each observation to the
+  latest full peer leg with a matching fixture identity, and marks which rows
+  came from which run. Without that join the table is whatever the newest run
+  happened to carry, which is the canary alone — one peer, one thread policy —
+  so the three-tool comparison this ADR promises would appear for one push
+  after each event and then disappear.
 - **Scale variants have a safety valve.** The 1x corpus runs per push; if
   the 10x/100x variants prove too expensive for per-push collection, they
   move to a scheduled cadence without changing any other policy.
@@ -691,7 +705,7 @@ silently.
   template engine** - RUE-1483
 - [x] **Phase 4: Gazette, live-corpus fixture preparation, output validation,
   and the scaling-curve rung** - RUE-1484
-- [ ] **Phase 5: Cross-tool comparison — Hugo pin, parity configs, CI runs;
+- [x] **Phase 5: Cross-tool comparison — Hugo pin, parity configs, CI runs;
   and gazette's entry in `performance/runtime.toml`** - RUE-1485
 - [ ] **Phase 6: Website publication — comparison table, time series,
   side-by-side source** - RUE-1049
@@ -711,6 +725,64 @@ job runs are defined. Until then the fixture preparation, identity recording,
 and validation are driven by `scripts/gazette-corpus-diff.py site`, which is
 the reference implementation the harness mode should adopt rather than
 reinvent.
+
+Phase 5 landed the comparison, and four things it found are worth recording
+because each changes what a later reader should expect.
+
+- **The corpus, not the configurations, is where equivalence is won — and one
+  of those normalizations hides a Rue gap.** Two differences were fixed by
+  normalizing the corpus for all three tools at fixture-preparation time rather
+  than by configuring one of them. `paginate_by` is the one excluded feature the
+  content turns on, and Zola honours it by emitting a paginated view no other
+  tool builds. Three upper-case file names route differently, and here **gazette
+  is the odd tool out**: Zola slugifies a content path into its route and Hugo
+  lower-cases it into its page identity, so both agree with the production site,
+  while gazette does not slugify at all. Lower-casing the three names buys an
+  exact file-set check instead of an allowlist entry that a tool dropping a page
+  could later hide behind, at the cost of suppressing a genuine two-against-one
+  difference in which Rue is the outlier. The work either way is one pass over
+  96 paths and cannot move a measurement; teaching gazette to slugify would
+  close it properly. Both normalizations, and the two excluded pages, are
+  disclosed on the published page rather than only here.
+
+  Neither normalization is visible in the content digest, since that digest is
+  taken over the tree the rules have already rewritten. The preparer's own
+  revision and digest are therefore inside the recorded fixture identity, so a
+  change to an assembly rule opens a new comparable segment exactly as a content
+  change does — without that, Decision 2's segmentation mechanism would not fire
+  for the rules that decide what every tool consumes.
+- **The allowlist has one entry, and the rest were configured away.** Zola
+  always writes a `404.html` and offers no switch; Hugo emits one only with a
+  layout, and the port has none. Everything else the ADR anticipated — Hugo's
+  sitemap, its robots.txt, its per-section feeds, and the feed *filename*
+  mapping — is handled in the parity configurations, so the emitted file sets
+  are compared as equal sets rather than through excuses.
+- **The cross-tool oracle compares the facets Decision 4 names, not the event
+  stream.** Goldmark and pulldown-cmark do not emit the same markup for the
+  same Markdown, so the three-way comparison is the heading tree, visible text,
+  and link and image targets, with link targets resolved to one spelling —
+  Zola resolves a bare `#fragment` and a relative `math/` against the page and
+  Hugo leaves both as written. That is weaker than the gazette-vs-Zola body
+  oracle, which stays as it was, and it still catches every way a tool can do
+  less work. It caught two real port defects: Hugo's URL escaping turned every
+  one of the corpus's 1,224 rule anchors into a link to a target that does not
+  exist, and `.PrevInSection`/`.NextInSection` are the opposite way round from
+  Zola's `page.lower`/`page.higher`, so the port sent every reader backwards.
+- **The scale variants needed the oracle too, and a real defect was sitting in
+  the gap.** The cross-tool comparison first ran at 1x only, on the argument
+  that the copies are the same documents at other permalinks. They are not the
+  same documents to a tool that picks templates by PATH: Hugo routed every
+  duplicated page out of the specification layout and rendered it with no
+  sidebar — nine tenths of the corpus at 10x, the port's most expensive
+  template skipped — and fell back to its built-in feed for the duplicated blog
+  sections, which renders every post body into the feed. The emitted file set
+  and the page count were exactly right throughout. The comparison now checks
+  one copy of every page as well as every original, and fixture preparation
+  gives each page its type explicitly, which is the same translation the corpus
+  already performs for Zola through `template`.
+- **Hugo is pinned at v0.152.2 rather than at the newest release**, because
+  from v0.153.0 Hugo publishes macOS only as a `.pkg` installer, which DotSlash
+  cannot extract, and `aarch64-macos` is a row of this matrix.
 
 The harness comes first, against a precisely declared workload that already
 exists. Phase 1's initial runtime workload is `wordfreq`, run over a large

--- a/hugo
+++ b/hugo
@@ -1,0 +1,74 @@
+#!/usr/bin/env dotslash
+
+// The second peer of ADR-0072's cross-tool comparison, pinned exactly as `zola`
+// and `tailwindcss` are. Peer toolchain versions are bumped deliberately and
+// recorded as annotated events on the published series, never silently: every
+// runtime observation carries both peer versions, so a bump here starts a new
+// comparable stretch rather than shifting an existing one.
+//
+// v0.152.2 rather than the newest release, and for a reason worth stating:
+// from v0.153.0 Hugo publishes macOS only as a `.pkg` installer, which
+// DotSlash cannot extract. v0.152.2 is the newest release that ships a macOS
+// archive, and `aarch64-macos` is a row of this project's platform matrix
+// (ADR-0072 Decision 5), so a pin that covered only Linux would leave one
+// measured platform without a peer. Revisit when Hugo ships macOS archives
+// again or when DotSlash learns `.pkg`.
+//
+// The plain build, not `hugo_extended`. The extended build's addition is
+// embedded Sass, which the equivalence subset excludes for every tool
+// (Decision 3), so the extended binary would carry a capability the parity
+// configuration then turns off.
+
+{
+  "name": "hugo",
+  "platforms": {
+    "macos-aarch64": {
+      "size": 35660498,
+      "hash": "blake3",
+      "digest": "1129b1bbe07b284228cda7cdc54b9ed1f64e2dc8405b725445bd86cf5938ef54",
+      "format": "tar.gz",
+      "path": "hugo",
+      "providers": [
+        {
+          "url": "https://github.com/gohugoio/hugo/releases/download/v0.152.2/hugo_0.152.2_darwin-universal.tar.gz"
+        }
+      ]
+    },
+    "macos-x86_64": {
+      "size": 35660498,
+      "hash": "blake3",
+      "digest": "1129b1bbe07b284228cda7cdc54b9ed1f64e2dc8405b725445bd86cf5938ef54",
+      "format": "tar.gz",
+      "path": "hugo",
+      "providers": [
+        {
+          "url": "https://github.com/gohugoio/hugo/releases/download/v0.152.2/hugo_0.152.2_darwin-universal.tar.gz"
+        }
+      ]
+    },
+    "linux-x86_64": {
+      "size": 18177513,
+      "hash": "blake3",
+      "digest": "245704455f9d68be1d963f65bac0f078caa911e286fd53a05767911c94a496cb",
+      "format": "tar.gz",
+      "path": "hugo",
+      "providers": [
+        {
+          "url": "https://github.com/gohugoio/hugo/releases/download/v0.152.2/hugo_0.152.2_linux-amd64.tar.gz"
+        }
+      ]
+    },
+    "linux-aarch64": {
+      "size": 16585847,
+      "hash": "blake3",
+      "digest": "8b36fbe1bf0bb17e17cd0806b1d059cdae08638cfb22a711116af880eea48f84",
+      "format": "tar.gz",
+      "path": "hugo",
+      "providers": [
+        {
+          "url": "https://github.com/gohugoio/hugo/releases/download/v0.152.2/hugo_0.152.2_linux-arm64.tar.gz"
+        }
+      ]
+    }
+  }
+}

--- a/performance/ports/hugo/hugo.toml
+++ b/performance/ports/hugo/hugo.toml
@@ -1,0 +1,115 @@
+# The Hugo parity configuration (ADR-0072 Decisions 3 and 5, RUE-1485).
+#
+# This file and `layouts/` are the Hugo half of "template ports and parity
+# configurations", versioned beside gazette's port at `examples/gazette/` and
+# Zola's at `performance/ports/zola/`. Fixture preparation copies them next to
+# the assembled corpus and hashes them into the recorded fixture identity, so a
+# change here starts a new comparable segment rather than silently shifting an
+# existing one.
+#
+# The switches below fall into three groups, and the distinction matters more
+# than any individual line:
+#
+#   1. FEATURES THE EQUIVALENCE SUBSET EXCLUDES, turned off here because
+#      gazette implements none of them and Zola's parity config turns off the
+#      same list: syntax highlighting, search indexing, minification, Sass,
+#      image processing, taxonomies, pagination, live reload.
+#
+#   2. OUTPUTS THE OTHER TOOLS DO NOT EMIT, turned off so the emitted file sets
+#      are equal without an allowlist entry excusing them: sitemap, robots.txt,
+#      per-section and site-wide feeds other than the blog's.
+#
+#   3. DIALECT ALIGNMENT, where Hugo's Markdown or routing default differs from
+#      the corpus's own dialect. Each of these makes Hugo render what the
+#      corpus means rather than making Hugo do less work.
+#
+# Nothing here turns off work gazette does. That direction of unfairness is the
+# easier one to commit and the harder one to notice.
+baseURL = "https://rue-lang.dev/"
+title = "Rue"
+languageCode = "en"
+
+# Group 2. Hugo emits a sitemap, a robots.txt, and a 404 page by default;
+# gazette emits none of the three and Zola's parity config turns off the first
+# two. The 404 is the one difference no configuration can remove from Zola, so
+# it stays on here as well and is the single documented file-set allowlist
+# entry — symmetric between the peers rather than removed from one of them.
+disableKinds = ["taxonomy", "term", "sitemap", "robotsTXT"]
+
+# Group 1 and 2 together: a section's default outputs include RSS, which would
+# give every section of the corpus a feed. Only the blog has one in the other
+# two tools, so feeds are opt-in per section; fixture preparation writes
+# `outputs = ["html", "rss"]` into the front matter of exactly the sections
+# whose `generate_feeds = true` already asks Zola for one.
+[outputs]
+home = ["html"]
+section = ["html"]
+page = ["html"]
+
+# Zola writes the blog feed to `blog/rss.xml`; Hugo's RSS format defaults to
+# `index.xml`. Renaming the output format is how Hugo spells the same
+# destination, which is better than an allowlist entry mapping one name onto
+# the other: the file-set check then compares the routes themselves.
+[outputFormats.rss]
+baseName = "rss"
+
+[params]
+description = "A systems programming language with memory safety and high-level ergonomics"
+github_url = "https://github.com/rue-language/rue"
+bluesky_url = "https://bsky.app/profile/rue-lang.dev"
+
+# Nothing here changes Hugo's routing: the corpus's three upper-case file names
+# are lower-cased during fixture preparation, for every tool at once, because
+# `disablePathToLower` does not survive into the route in this Hugo — the page
+# identity it builds is lower-case regardless. Aligning the corpus rather than
+# one tool is what keeps Decision 4's file-set check exact, and it lands all
+# three tools on the route the production site already serves.
+
+[markup]
+  [markup.goldmark.renderer]
+    # Raw HTML passes through, as CommonMark specifies and as the other two
+    # renderers do. Hugo filters it by default, which would silently DROP
+    # content rather than render it differently.
+    #
+    # MEASURED, because an earlier version of this comment claimed the oracle
+    # failed without it: on today's corpus the two settings produce a
+    # BYTE-IDENTICAL tree. The corpus's angle brackets all sit inside code
+    # spans, which are escaped either way, and its one HTML block is the
+    # `<!-- more -->` marker, which Hugo consumes as the summary divider before
+    # the renderer sees it. The setting is kept because it is the correct one
+    # for the documented subset — ADR-0072 Decision 3 lists raw inline HTML and
+    # HTML blocks as in scope — and because the day a page uses either outside
+    # a code span, the default would drop it. It buys nothing today and it is
+    # not a performance setting in either direction.
+    unsafe = true
+  [markup.goldmark.extensions]
+    # Group 3, and both are dialect rather than feature. Goldmark's typographer
+    # rewrites quotes and dashes into typographic forms; pulldown-cmark, and so
+    # Zola and gazette, do not. Linkify turns bare URLs into links, which the
+    # other two also do not. Left on, either would make Hugo's visible text
+    # differ from the other tools' on pages neither renderer got wrong.
+    typographer.disable = true
+    linkify = false
+    # GFM tables ARE in the subset: 17 of them across the specification and the
+    # tutorial, and all three tools render them.
+    table = true
+  [markup.highlight]
+    # Group 1, and the single most important line in this file. With code
+    # fences highlighted, Hugo would run Chroma over roughly 1,200 code blocks
+    # and emit per-token markup — work gazette does not do and cannot do.
+    # Leaving it on is the specific unfairness Decision 3 names.
+    codeFences = false
+  [markup.tableOfContents]
+    # Nothing in the ports renders `.TableOfContents`, and Hugo builds it
+    # lazily, so this only bounds it if a future port template asks for one.
+    startLevel = 2
+    endLevel = 3
+
+# Group 1. Hugo's build-time image processing, its asset pipeline, and its
+# development server are all outside the subset; none is reachable from these
+# layouts, and the cache directory is pinned so a run cannot pick up state from
+# a previous one. `noBuildLock` keeps a stale lock from a killed sample out of
+# the next sample's way.
+[caches]
+  [caches.modules]
+    maxAge = 0

--- a/performance/ports/hugo/layouts/_partials/authors.html
+++ b/performance/ports/hugo/layouts/_partials/authors.html
@@ -1,0 +1,24 @@
+{{/*
+  The byline the blog listing and the blog page both render.
+
+  The production template writes this inline twice, once linked and once not;
+  Go templates make a partial the natural way to say it, and that is the sort
+  of difference a native port is allowed to have. What must not differ is the
+  VISIBLE TEXT — "Steve, Claude and Codex" — because the cross-tool semantic
+  oracle compares exactly that.
+*/}}
+{{- $authors := .authors -}}
+{{- $linked := .linked -}}
+{{- $count := len $authors -}}
+{{- range $index, $author := $authors -}}
+{{- if gt $index 0 }}{{ if eq $index (sub $count 1) }} and {{ else }}, {{ end }}{{ end -}}
+{{- if eq $author "steve" -}}
+{{- if $linked }}<a href="https://steveklabnik.com">Steve</a>{{ else }}Steve{{ end -}}
+{{- else if eq $author "claude" -}}
+{{- if $linked }}<a href="https://claude.ai">Claude</a>{{ else }}Claude{{ end -}}
+{{- else if eq $author "codex" -}}
+{{- if $linked }}<a href="https://openai.com/codex/">Codex</a>{{ else }}Codex{{ end -}}
+{{- else -}}
+{{- $author -}}
+{{- end -}}
+{{- end -}}

--- a/performance/ports/hugo/layouts/_partials/landing.html
+++ b/performance/ports/hugo/layouts/_partials/landing.html
@@ -1,0 +1,95 @@
+{{/*
+  The landing page's body, in a partial so two layouts can share it.
+
+  Hugo reserves its home layout for the SITE ROOT, and the corpus's root
+  `_index.md` names its template explicitly — a key Zola and gazette honour
+  wherever that page sits, including the duplicated roots the scale variants
+  create. Fixture preparation therefore points those copies at `layout =
+  "landing"`, and both entry points render this.
+*/}}
+<section class="hero max-w-5xl mx-auto px-6 pt-14 pb-12 grid grid-cols-1 md:grid-cols-12 gap-12 items-start">
+    <div class="md:col-span-7 reveal d1">
+        <h1 style="font-family: var(--font-display); font-weight: 420; font-size: clamp(2.1rem, 4.6vw, 3.2rem); line-height: 1.12; letter-spacing: -0.01em;" class="mb-6">
+            Rust proved memory safety without garbage collection is possible.<br>
+            <em style="font-weight: 460; color: var(--color-accent);">Can it also be easy?</em>
+        </h1>
+        <p class="text-lg mb-4" style="color: var(--color-muted); max-width: 30rem;">
+            <strong style="color: var(--color-fg);">We don’t know yet.</strong>
+            Rue is an early-stage research language exploring that question — a
+            systems language aiming for the same destination by a gentler path.
+            It is not ready for real projects, but the whole experiment runs in
+            the open, and you can watch.
+        </p>
+        <p class="mb-8" style="font-style: italic; color: var(--color-faint); max-width: 30rem; font-size: 0.95rem;">
+            Designed by <a href="https://steveklabnik.com" style="color: inherit;">Steve Klabnik</a>.
+            Implemented primarily by Claude, an AI. The field report is an
+            illustrative preview while live project reporting is rebuilt.
+        </p>
+        <div class="flex gap-4 flex-wrap">
+            <a href="{{ "tutorial" | absURL }}" class="btn-primary">Begin the tutorial</a>
+<!-- Hardcoded path: spec pages are copied into the content tree at build time -->
+            <a href="/spec/" class="btn-secondary">Read the spec</a>
+        </div>
+    </div>
+</section>
+
+<section class="max-w-5xl mx-auto px-6 pb-14 grid grid-cols-1 md:grid-cols-12 gap-12 items-start">
+    <figure class="md:col-span-7 reveal d2" style="margin: 0;">
+        <div class="specimen">
+            <div class="specimen-head">
+                <span class="no">Specimen №&thinsp;1</span>
+                <span>fib.rue</span>
+            </div>
+            {{ .Content }}
+        </div>
+        <figcaption class="specimen-caption">
+            <b>Fig. 1.</b> Compiles to a small static binary.
+            No VM, no interpreter, no garbage collector.
+        </figcaption>
+    </figure>
+
+    <div class="md:col-span-5 reveal d3">
+        <h3 style="font-family: var(--font-display); font-weight: 480; font-size: 1.5rem;" class="mb-3">
+            Familiar on the surface, careful underneath.
+        </h3>
+        <p class="mb-4" style="color: var(--color-muted); font-size: 0.98rem;">
+            If you know Rust, Go, or C, the syntax will feel like home. Underneath,
+            Rue is exploring linear types, compile-time evaluation, and drop
+            tracking — the machinery of memory safety — while trying to keep the
+            learning curve shallow enough to walk up, not climb.
+        </p>
+        <p class="mb-5" style="color: var(--color-muted); font-size: 0.98rem;">
+            The compiler is written in Rust and emits x86-64 and ARM64 machine
+            code directly: no LLVM, direct syscalls, static ELF and Mach-O
+            executables.
+        </p>
+        <div class="run-line"><span class="prompt">$</span> rue fib.rue -o fib &amp;&amp; ./fib</div>
+    </div>
+</section>
+
+<div class="sprig-divider" role="presentation">
+    <svg viewBox="0 0 32 32"><use href="#rue-sprig"/></svg>
+</div>
+
+<section class="max-w-5xl mx-auto px-6 pt-12 pb-14">
+    <h2 class="section-title">Recent lab notes</h2>
+    {{ $blog := site.GetPage "/blog" }}
+    <ul class="note-list">
+        {{ range first 3 $blog.Pages }}
+        <li>
+            <span class="note-date">{{ .Date.Format "2006 · 01 · 02" }}</span>
+            <div>
+                <a class="note-title" href="{{ .Permalink }}">{{ .Title }}</a>
+                {{ with .Params.description }}
+                <p class="note-summary">{{ . }}</p>
+                {{ else }}
+                {{ with .Summary }}
+                <p class="note-summary">{{ . | plainify | truncate 180 }}</p>
+                {{ end }}
+                {{ end }}
+            </div>
+        </li>
+        {{ end }}
+    </ul>
+    <p class="mt-6" style="font-size: 0.9rem;"><a href="{{ "blog" | absURL }}">All lab notes →</a></p>
+</section>

--- a/performance/ports/hugo/layouts/_partials/section-body.html
+++ b/performance/ports/hugo/layouts/_partials/section-body.html
@@ -1,0 +1,29 @@
+{{/*
+  The inner body of a section index: its title, its own Markdown, its pages,
+  and — where the section has them — its subsections. Shared by the
+  specification, standard-library, and tutorial layouts, which differ only in
+  the heading above the page list and in whether they list subsections at all.
+*/}}
+{{- $page := .page -}}
+<h1>{{ $page.Title }}</h1>
+
+{{ $page.Content }}
+
+{{ with $page.RegularPages }}
+<h2>{{ $.heading }}</h2>
+<ul class="spec-section-toc">
+    {{ range . }}
+    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+    {{ end }}
+</ul>
+{{ end }}
+
+{{ if .subsections }}
+{{ with $page.Sections }}
+<ul class="spec-section-toc">
+    {{ range sort . "Path" }}
+    <li><a href="{{ .Permalink }}">{{ .Title }}</a></li>
+    {{ end }}
+</ul>
+{{ end }}
+{{ end }}

--- a/performance/ports/hugo/layouts/_partials/sidebar-shell.html
+++ b/performance/ports/hugo/layouts/_partials/sidebar-shell.html
@@ -1,0 +1,75 @@
+{{/*
+  The two-column shell the specification, standard library, and tutorial pages
+  render into — Hugo's answer to the Tera ports' `spec/base.html`,
+  `std/base.html`, and `tutorial/base.html`.
+
+  Go templates have no second level of `extends`, so the shell is a partial the
+  four leaf layouts call rather than a base they inherit. Dict keys:
+
+    page      the page or section being rendered
+    root      the section whose tree the sidebar draws
+    title     the sidebar heading and its link text
+    search    whether to render the specification's search box
+    body      the already-rendered inner HTML
+    prevnext  whether to render the previous/next pair
+
+  Prev/next comes from `.PrevInSection`/`.NextInSection`, Hugo's own neighbours
+  within the section's ordering, which is the same relation Zola spells
+  `page.lower`/`page.higher`.
+*/}}
+{{- $page := .page -}}
+{{- $current := $page.Permalink -}}
+<div class="spec-layout">
+    <aside class="spec-sidebar">
+        <div class="spec-sidebar-inner">
+            <div class="spec-sidebar-header">
+                <a href="{{ .root.Permalink }}" class="spec-title">{{ .title }}</a>
+            </div>
+            {{ if .search }}
+            <div class="spec-search">
+                <div class="spec-search-input-wrapper">
+                    <input type="text" id="spec-search-input" placeholder="Search..." autocomplete="off">
+                    <kbd class="spec-search-shortcut"><span class="spec-search-shortcut-mod"></span>K</kbd>
+                </div>
+                <div id="spec-search-results" class="spec-search-results"></div>
+            </div>
+            {{ end }}
+            <nav class="spec-nav">
+                {{ partial "spec-nav.html" (dict "section" .root "current" $current) }}
+            </nav>
+        </div>
+    </aside>
+
+    <div class="spec-main">
+        <article class="spec-content{{ with .contentClass }} {{ . }}{{ end }}">
+            {{ .body }}
+        </article>
+
+        {{ if .prevnext }}
+        {{/*
+          Hugo's `.NextInSection` is the page BEFORE this one in the section's
+          ordering and `.PrevInSection` the one after — the opposite way round
+          from Zola's `page.lower`/`page.higher`, which is a genuine trap rather
+          than a naming quibble: read the obvious way, every specification page
+          in this port sent its reader backwards. The cross-tool comparison of
+          visible text is what caught it.
+        */}}
+        <nav class="spec-page-nav">
+            {{ with $page.NextInSection }}
+            <a href="{{ .Permalink }}" class="spec-nav-prev">
+                <span class="spec-nav-label">Previous</span>
+                <span class="spec-nav-title">{{ .Title }}</span>
+            </a>
+            {{ else }}
+            <span></span>
+            {{ end }}
+            {{ with $page.PrevInSection }}
+            <a href="{{ .Permalink }}" class="spec-nav-next">
+                <span class="spec-nav-label">Next</span>
+                <span class="spec-nav-title">{{ .Title }}</span>
+            </a>
+            {{ end }}
+        </nav>
+        {{ end }}
+    </div>
+</div>

--- a/performance/ports/hugo/layouts/_partials/spec-nav.html
+++ b/performance/ports/hugo/layouts/_partials/spec-nav.html
@@ -1,0 +1,45 @@
+{{/*
+  The recursive specification sidebar, and the single most fairness-sensitive
+  template in the Hugo port (ADR-0072 Decisions 3 and 5).
+
+  Both the `active` class and the recursion are gated on a prefix test against
+  the CURRENT page's permalink, exactly as the production Tera macro and the
+  gazette port are. That is what makes the sidebar a different document on
+  every page, and what makes its cost scale with the section tree.
+
+  The test is `strings.HasPrefix`, evaluated BY THE TEMPLATE ENGINE. Computing
+  the open branch outside the template — in the content, in a data file, or by
+  precomputing a map once per build — would move measured work out of the
+  measured program, and no check in Decision 4 would notice: a flattened
+  sidebar emits the same link targets and the same visible text on every page.
+  The same rule binds all three ports.
+
+  `partial` recursing on itself is Go templates' equivalent of Tera's
+  `self::render_nav`; the depth parameter production carries is not read for
+  output there either.
+*/}}
+{{- $current := .current -}}
+<ul class="spec-nav-list">
+    {{ range .section.RegularPages }}
+    <li class="spec-nav-item">
+        <a href="{{ .Permalink }}" class="spec-nav-link {{ if eq .Permalink $current }}active{{ end }}">
+            {{ .Title }}
+        </a>
+    </li>
+    {{ end }}
+
+    {{/* Sorted by path, as the Tera macro sorts `section.subsections`. The
+         corpus's numbered chapter directories make that the reading order, and
+         it stays total on the duplicated corpus of the scale variants, where
+         every copy ties with its original on weight and on title. */}}
+    {{ range sort .section.Sections "Path" }}
+    <li class="spec-nav-section">
+        <a href="{{ .Permalink }}" class="spec-nav-section-title {{ if strings.HasPrefix $current .Permalink }}active{{ end }}">
+            {{ .Title }}
+        </a>
+        {{ if strings.HasPrefix $current .Permalink }}
+        {{ partial "spec-nav.html" (dict "section" . "current" $current) }}
+        {{ end }}
+    </li>
+    {{ end }}
+</ul>

--- a/performance/ports/hugo/layouts/_shortcodes/preview_feature.html
+++ b/performance/ports/hugo/layouts/_shortcodes/preview_feature.html
@@ -1,0 +1,6 @@
+{{- /* Hugo port of `website/templates/shortcodes/preview_feature.html`. */ -}}
+<div class="preview-notice">
+    <strong>Preview Feature</strong>:
+    This feature requires <code>--preview {{ .Get "feature" }}</code> to use.
+    {{ with .Get "adr" }}See <a href="/designs/{{ . | lower }}">{{ . | upper }}</a> for the design.{{ end }}
+</div>

--- a/performance/ports/hugo/layouts/_shortcodes/rule.html
+++ b/performance/ports/hugo/layouts/_shortcodes/rule.html
@@ -1,0 +1,17 @@
+{{- /*
+  Hugo port of `website/templates/shortcodes/rule.html`.
+
+  1,224 of the corpus's 1,225 shortcode invocations are this one, which is
+  exactly why ADR-0072 Decision 3 forbids any tool from special-casing it. It
+  is an ordinary shortcode in each of the three ports: Hugo expands it through
+  its shortcode machinery, Zola through Tera's, and gazette through its general
+  engine.
+*/ -}}
+{{- /*
+  `safeURL` is load-bearing rather than decorative. Rule ids carry a colon —
+  `1.1:1` — and Go's HTML template escapes it inside an `href`, so without this
+  the anchor points at `#r-1.1%3a1` while the element it targets is `r-1.1:1`.
+  Every one of the corpus's 1,224 rule links would be broken, and only a check
+  that compares LINK TARGETS across tools would notice.
+*/ -}}
+<div class="rule" id="r-{{ .Get "id" }}"><a class="rule-link" href="{{ printf "#r-%s" (.Get "id") | safeURL }}">[{{ .Get "id" }}]</a></div>

--- a/performance/ports/hugo/layouts/baseof.html
+++ b/performance/ports/hugo/layouts/baseof.html
@@ -1,0 +1,181 @@
+{{/*
+  Hugo port of `website/templates/base.html` (ADR-0072 Decisions 3 and 5).
+
+  The Hugo port is a NATIVE implementation of the same job rather than a
+  transliteration of the Tera one: Go templates, Hugo's page model, Hugo's own
+  shortcodes and feed. Benchmarks-Game rules — same job, each tool's own idiom.
+  What the ports owe each other is the emitted file set, the page set, and the
+  normalized page semantics of Decision 4, never markup equality.
+
+  The inert chrome — the sprig, the theme-toggle icons, the scripts — is
+  carried rather than trimmed. None of it is interesting work, but all of it is
+  BYTES EACH TOOL WRITES, and a port that dropped a kilobyte of markup from
+  every one of 96 pages would be measuring a smaller job while passing every
+  semantic check, since none of it contributes visible text or a link target.
+*/}}<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
+    <meta name="description" content="{{ .Site.Params.description }}">
+    <link rel="stylesheet" href="{{ "style.css" | absURL }}">
+    <link rel="icon" href="{{ "favicon.svg" | absURL }}" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="{{ "brand/apple-touch-icon.png" | absURL }}">
+    <link rel="alternate" type="application/rss+xml" title="Rue Blog RSS" href="{{ "blog/rss.xml" | absURL }}">
+    <script>
+        const isDark = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (isDark) {
+            document.documentElement.classList.add('dark');
+        }
+        document.write('<link rel="stylesheet" href="{{ "syntax-light.css" | absURL }}" id="syntax-light"' + (isDark ? ' disabled' : '') + '>');
+        document.write('<link rel="stylesheet" href="{{ "syntax-dark.css" | absURL }}" id="syntax-dark"' + (isDark ? '' : ' disabled') + '>');
+
+        function updateSyntaxTheme() {
+            const syntaxLight = document.getElementById('syntax-light');
+            const syntaxDark = document.getElementById('syntax-dark');
+            if (syntaxLight && syntaxDark) {
+                const dark = document.documentElement.classList.contains('dark');
+                syntaxLight.disabled = dark;
+                syntaxDark.disabled = !dark;
+            }
+        }
+    </script>
+</head>
+<body class="min-h-screen flex flex-col">
+    <!-- engraved rue sprig (Ruta graveolens), referenced site-wide via <use> -->
+    <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+      <defs>
+        <g id="rue-sprig" fill="none" stroke="currentColor" stroke-width="1.5"
+           stroke-linecap="round" stroke-linejoin="round">
+          <path d="M16 30 C 16 24, 15.4 18, 16 10"/>
+          <path d="M15.7 22 C 12.5 20.5, 10 19, 8 16.5"/>
+          <path d="M8 16.5 c -2.6 -0.4 -4 -2.4 -3.4 -4.4 c 1.8 -1 4 -0.2 4.6 2 c 0.3 1 0 1.8 -1.2 2.4 z"/>
+          <path d="M11.5 19.2 c -2.4 0.6 -4.3 -0.6 -4.5 -2.6"/>
+          <path d="M16 17.5 C 19.5 16, 22 14.5, 23.8 12"/>
+          <path d="M23.8 12 c 2.6 -0.2 3.9 -2.2 3.2 -4.2 c -1.9 -0.9 -4 0.1 -4.4 2.3 c -0.2 1 0.1 1.7 1.2 1.9 z"/>
+          <path d="M20.4 14.6 c 2.4 0.4 4.2 -0.8 4.3 -2.8"/>
+          <path d="M16 10 c -0.4 -2.8 1 -4.6 3.2 -4.6 c 1.2 1.8 0.5 4 -1.6 4.9 c -0.7 0.3 -1.2 0.2 -1.6 -0.3 z"/>
+          <g stroke="none" fill="var(--color-gold)">
+            <circle cx="12.2" cy="7.4" r="1.15"/>
+            <circle cx="9.9"  cy="9.4" r="1.15"/>
+            <circle cx="12.6" cy="10.6" r="1.15"/>
+            <circle cx="14.4" cy="8.7" r="1.15"/>
+          </g>
+          <circle cx="12.4" cy="9" r="0.8" stroke="none" fill="currentColor"/>
+          <path d="M15.9 13.5 C 14.8 11.8, 13.6 10.6, 12.6 10.4"/>
+        </g>
+      </defs>
+    </svg>
+
+    <div class="colophon-bar">
+        <em>Ruta graveolens</em> &nbsp;·&nbsp; notes from a language experiment &nbsp;·&nbsp; cultivated since 2025
+    </div>
+
+    <nav>
+        <div class="masthead">
+            <a href="{{ "/" | absURL }}" class="wordmark">
+                <svg class="sprig" viewBox="0 0 32 32"><use href="#rue-sprig"/></svg>
+                Rue
+            </a>
+            <!-- Desktop navigation -->
+            <div class="nav-desktop flex items-center gap-6">
+                <ul class="flex gap-6">
+                    <li><a href="{{ "tutorial" | absURL }}" class="nav-link">Tutorial</a></li>
+<!-- Hardcoded path: spec pages are copied into the content tree at build time -->
+                    <li><a href="/spec/" class="nav-link">Specification</a></li>
+                    <li><a href="{{ "performance" | absURL }}" class="nav-link">Performance</a></li>
+                    <li><a href="{{ "runtime" | absURL }}" class="nav-link">Runtime</a></li>
+                    <li><a href="{{ "blog" | absURL }}" class="nav-link">Lab Notes</a></li>
+                    <li><a href="{{ .Site.Params.github_url }}" class="nav-link ext">GitHub</a></li>
+                    <li><a href="{{ .Site.Params.bluesky_url }}" class="nav-link ext">Bluesky</a></li>
+                </ul>
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+            </div>
+            <!-- Mobile navigation controls -->
+            <div class="nav-mobile-controls flex items-center gap-4">
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+                <button onclick="toggleMobileMenu()" class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false">
+                    <svg class="icon-menu w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                    <svg class="icon-close w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+        <!-- Mobile menu overlay -->
+        <div id="mobile-menu" class="mobile-menu">
+            <ul class="mobile-menu-list">
+                <li><a href="{{ "/" | absURL }}" class="mobile-menu-link">Home</a></li>
+                <li><a href="{{ "tutorial" | absURL }}" class="mobile-menu-link">Tutorial</a></li>
+                <li><a href="/spec/" class="mobile-menu-link">Specification</a></li>
+                <li><a href="{{ "performance" | absURL }}" class="mobile-menu-link">Performance</a></li>
+                <li><a href="{{ "runtime" | absURL }}" class="mobile-menu-link">Runtime</a></li>
+                <li><a href="{{ "blog" | absURL }}" class="mobile-menu-link">Lab Notes</a></li>
+                <li><a href="{{ .Site.Params.github_url }}" class="mobile-menu-link">GitHub</a></li>
+                <li><a href="{{ .Site.Params.bluesky_url }}" class="mobile-menu-link">Bluesky</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <main class="flex-1">
+        {{ block "main" . }}{{ end }}
+    </main>
+
+    <footer class="footer-colophon">
+        <div class="inner">
+            <span>© 2025–2026 The Rue Authors · MIT/Apache-2.0</span>
+            <span><em>rue</em>, n. — a hardy evergreen herb; also, what we hope you won’t do after choosing this language.</span>
+        </div>
+    </footer>
+
+    <script>
+        function toggleTheme() {
+            if (document.documentElement.classList.contains('dark')) {
+                document.documentElement.classList.remove('dark');
+                localStorage.theme = 'light';
+            } else {
+                document.documentElement.classList.add('dark');
+                localStorage.theme = 'dark';
+            }
+            updateSyntaxTheme();
+        }
+
+        function toggleMobileMenu() {
+            const menu = document.getElementById('mobile-menu');
+            const toggle = document.querySelector('.mobile-menu-toggle');
+            const isOpen = menu.classList.toggle('open');
+            toggle.classList.toggle('active', isOpen);
+            toggle.setAttribute('aria-expanded', isOpen);
+        }
+
+        document.querySelectorAll('.mobile-menu-link').forEach(link => {
+            link.addEventListener('click', () => {
+                const menu = document.getElementById('mobile-menu');
+                const toggle = document.querySelector('.mobile-menu-toggle');
+                menu.classList.remove('open');
+                toggle.classList.remove('active');
+                toggle.setAttribute('aria-expanded', 'false');
+            });
+        });
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/elasticlunr/0.9.5/elasticlunr.min.js"></script>
+    <script src="{{ "search.js" | absURL }}"></script>
+</body>
+</html>

--- a/performance/ports/hugo/layouts/blog/page.html
+++ b/performance/ports/hugo/layouts/blog/page.html
@@ -1,0 +1,30 @@
+{{/* Hugo port of `website/templates/blog-page.html`. */}}
+{{ define "title" }}{{ .Title }} | Lab Notes | {{ .Site.Title }}{{ end }}
+{{ define "main" }}
+<article class="py-12">
+    <div class="max-w-3xl mx-auto px-6">
+        <header class="mb-8">
+            <h1 style="font-family: var(--font-display); font-weight: 460; font-size: 2.3rem; line-height: 1.15;" class="mb-3">{{ .Title }}</h1>
+            <div class="text-muted flex flex-wrap gap-1" style="font-style: italic;">
+                <time datetime="{{ .Date.Format "2006-01-02" }}" class="note-date" style="font-style: normal;">{{ .Date.Format "2006 · 01 · 02" }}</time>
+                {{ with .Params.extra.authors }}
+                <span class="before:content-['·'] before:mr-1">
+                    by {{ partial "authors.html" (dict "authors" . "linked" true) }}
+                </span>
+                {{ end }}
+            </div>
+            {{ with .Params.extra.prompt }}
+            <details class="mt-4 prompt-details">
+                <summary class="text-muted cursor-pointer hover:text-fg select-none">View the prompt</summary>
+                <div class="mt-3 p-4 bg-surface border border-themed rounded-lg">
+                    <pre class="whitespace-pre-wrap text-sm m-0! p-0! bg-transparent! border-none!">{{ . }}</pre>
+                </div>
+            </details>
+            {{ end }}
+        </header>
+        <div class="prose">
+            {{ .Content }}
+        </div>
+    </div>
+</article>
+{{ end }}

--- a/performance/ports/hugo/layouts/blog/section.html
+++ b/performance/ports/hugo/layouts/blog/section.html
@@ -1,0 +1,53 @@
+{{/*
+  Hugo port of `website/templates/blog.html` (ADR-0072 Decision 3).
+
+  Pagination is outside the equivalence subset for every tool, so this lists
+  `.Pages` directly rather than `.Paginator.Pages`, exactly as the Zola and
+  gazette ports list the section's pages directly. The corpus's eight posts sit
+  under a `paginate_by = 10` that fixture preparation strips for all three
+  tools, so no tool builds a paginated view.
+
+  Ordering is Hugo's own default page order for a section — weight, then date
+  descending, then title, then file path — which resolves to newest-first here
+  because no post carries a weight. The final tie-break on path is what makes
+  the order total on the duplicated corpus of the scale variants, where every
+  copy of a post ties with its original on date; the validation recomputes that
+  order from the source tree rather than assuming it.
+*/}}
+{{ define "title" }}Lab Notes | {{ .Site.Title }}{{ end }}
+{{ define "main" }}
+<section class="py-12">
+    <div class="max-w-3xl mx-auto px-6">
+        <header class="mb-10">
+            <h1 style="font-family: var(--font-display); font-weight: 460; font-size: 2.3rem;" class="mb-2">{{ .Title }}</h1>
+            <p class="text-muted mb-4" style="font-style: italic;">{{ .Content }}</p>
+            <a href="{{ "blog/rss.xml" | absURL }}" class="inline-flex items-center gap-2 text-muted text-sm hover:text-[var(--color-accent)]">
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                    <circle cx="6.18" cy="17.82" r="2.18"/>
+                    <path d="M4 4.44v2.83c7.03 0 12.73 5.7 12.73 12.73h2.83c0-8.59-6.97-15.56-15.56-15.56zm0 5.66v2.83c3.9 0 7.07 3.17 7.07 7.07h2.83c0-5.47-4.43-9.9-9.9-9.9z"/>
+                </svg>
+                RSS Feed
+            </a>
+        </header>
+
+        <ul class="note-list">
+            {{ range .Pages }}
+            <li>
+                <span class="note-date"><time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "2006 · 01 · 02" }}</time></span>
+                <div>
+                    <a class="note-title" href="{{ .Permalink }}">{{ .Title }}</a>
+                    {{ with .Params.extra.authors }}
+                    <span class="text-faint text-sm" style="font-style: italic;">
+                        — {{ partial "authors.html" (dict "authors" . "linked" false) }}
+                    </span>
+                    {{ end }}
+                    {{ with .Summary }}
+                    <p class="note-summary">{{ . }}</p>
+                    {{ end }}
+                </div>
+            </li>
+            {{ end }}
+        </ul>
+    </div>
+</section>
+{{ end }}

--- a/performance/ports/hugo/layouts/blog/section.rss.xml
+++ b/performance/ports/hugo/layouts/blog/section.rss.xml
@@ -1,0 +1,35 @@
+{{- /*
+  The blog feed, written out rather than inherited from Hugo's built-in RSS
+  template, and the reason is ADR-0072 Decision 4's determinism rule.
+
+  Hugo's built-in feed emits `<lastBuildDate>` from the clock and a
+  `<generator>` element naming the build's own version and date. Both move
+  between two builds of an unchanged corpus, so with the built-in template
+  every repeated sample would produce a different output tree and the
+  byte-identical determinism check would fail on every single run — the known
+  trap this port exists to avoid. `.Site.LastChange` is deliberately absent for
+  the same reason: it is derived from page dates today, but it is one
+  front-matter edit away from moving for a reason the corpus digest already
+  records.
+
+  The shape mirrors Zola's built-in feed and gazette's `rss.xml` port, because
+  the feed is one of the outputs Decision 4 compares across tools: same file,
+  same route, same entries, same order.
+*/ -}}
+{{ printf "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+        <title>{{ .Site.Title }}</title>
+        <link>{{ .Permalink }}</link>
+        <description>{{ with .Params.description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}</description>
+        <language>en</language>
+        <atom:link href="{{ with .OutputFormats.Get "rss" }}{{ .Permalink }}{{ end }}" rel="self" type="application/rss+xml"/>
+{{ range .Pages }}        <item>
+            <title>{{ .Title }}</title>
+            <pubDate>{{ .Date.Format "2006-01-02" }}</pubDate>
+            <link>{{ .Permalink }}</link>
+            <guid>{{ .Permalink }}</guid>
+            <description>{{ with .Params.description }}{{ . }}{{ end }}</description>
+        </item>
+{{ end }}    </channel>
+</rss>

--- a/performance/ports/hugo/layouts/home.html
+++ b/performance/ports/hugo/layouts/home.html
@@ -1,0 +1,16 @@
+{{/*
+  Hugo port of `website/templates/index.html` (ADR-0072 Decision 3).
+
+  The production page's Field Report panel is dropped here for the reason every
+  port drops it: it is rendered from `load_data`, which is outside the
+  equivalence subset for every tool, and two of its rows are derived from the
+  performance store — so rendering it would make the benchmark an input to its
+  own workload. Dropping it in one port and keeping it in another would be the
+  fairness bug Decision 3 exists to prevent.
+
+  `.Content` is the home page's own Markdown body: the corpus's `_index.md`
+  carries the fib.rue specimen, so this is a real render rather than chrome.
+*/}}
+{{ define "main" }}
+{{ partial "landing.html" . }}
+{{ end }}

--- a/performance/ports/hugo/layouts/landing.html
+++ b/performance/ports/hugo/layouts/landing.html
@@ -1,0 +1,10 @@
+{{/*
+  The landing page as an ordinary section layout, for the duplicated roots the
+  scale variants create (`x10-00/_index.md` and its siblings). Hugo renders the
+  site root through `home.html`; these are sections to it, and without this they
+  rendered as plain section listings while gazette and Zola built the whole
+  landing page — a page class per copy, skipped.
+*/}}
+{{ define "main" }}
+{{ partial "landing.html" . }}
+{{ end }}

--- a/performance/ports/hugo/layouts/page.html
+++ b/performance/ports/hugo/layouts/page.html
@@ -1,0 +1,10 @@
+{{/* Hugo port of `website/templates/page.html`: the plain page. */}}
+{{ define "title" }}{{ .Title }} | {{ .Site.Title }}{{ end }}
+{{ define "main" }}
+<article class="py-12">
+    <div class="max-w-3xl mx-auto px-6 prose">
+        <h1>{{ .Title }}</h1>
+        {{ .Content }}
+    </div>
+</article>
+{{ end }}

--- a/performance/ports/hugo/layouts/redirect.html
+++ b/performance/ports/hugo/layouts/redirect.html
@@ -1,0 +1,28 @@
+{{/*
+  The stub a section with `redirect_to` emits instead of its own index page.
+
+  Standalone by construction: it defines no blocks, so Hugo renders it without
+  `baseof.html` and the stub carries no site chrome — which is what Zola's
+  built-in redirect output and gazette's `redirect.html` both emit. The markup
+  mirrors those rather than being invented, for the reason gazette's port
+  states: a redirect stub is not a page anyone reads, and the only thing that
+  matters about it is that all three tools put the same file at the same route
+  pointing at the same target.
+
+  The target is resolved here, by the template, from the corpus's own
+  `redirect_to` value. Resolving it during fixture preparation would move work
+  out of the measured program.
+*/}}
+{{- $target := printf "%s/" (strings.TrimSuffix "/" (absURL .Params.redirect_to)) -}}
+<!doctype html>
+<meta charset="utf-8">
+<title>Redirect</title>
+<script>
+  const target = "{{ $target | safeJSStr }}";
+  const hash = window.location.hash || "";
+  window.location.replace(target + hash);
+</script>
+<noscript>
+  <meta http-equiv="refresh" content="0; url={{ $target | safeURL }}">
+</noscript>
+<p><a href="{{ $target | safeURL }}">Click here</a> to be redirected.</p>

--- a/performance/ports/hugo/layouts/section.html
+++ b/performance/ports/hugo/layouts/section.html
@@ -1,0 +1,23 @@
+{{/*
+  Fallback section layout. Every section in this corpus declares a template of
+  its own — blog, spec, std, tutorial — so nothing reaches this today. It
+  exists so that a new section added to the site renders as a page with its own
+  listing rather than failing the build, which is what Zola's `section.html`
+  fallback does for the same corpus.
+*/}}
+{{ define "title" }}{{ .Title }} | {{ .Site.Title }}{{ end }}
+{{ define "main" }}
+<article class="py-12">
+    <div class="max-w-3xl mx-auto px-6 prose">
+        <h1>{{ .Title }}</h1>
+        {{ .Content }}
+        {{ with .Pages }}
+        <ul class="spec-section-toc">
+            {{ range . }}
+            <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+            {{ end }}
+        </ul>
+        {{ end }}
+    </div>
+</article>
+{{ end }}

--- a/performance/ports/hugo/layouts/spec/page.html
+++ b/performance/ports/hugo/layouts/spec/page.html
@@ -1,0 +1,11 @@
+{{/* Hugo port of `website/templates/spec/page.html`. */}}
+{{ define "title" }}{{ .Title }} - Rue Language Specification{{ end }}
+{{ define "main" }}
+{{ partial "sidebar-shell.html" (dict
+     "page" .
+     "root" (site.GetPage "/spec")
+     "title" "Rue Specification"
+     "search" true
+     "prevnext" true
+     "body" .Content) }}
+{{ end }}

--- a/performance/ports/hugo/layouts/spec/section.html
+++ b/performance/ports/hugo/layouts/spec/section.html
@@ -1,0 +1,22 @@
+{{/*
+  Hugo port of `website/templates/spec/section.html`.
+
+  A section that declares `redirect_to` renders through `layouts/redirect.html`
+  instead of this file — Hugo selects that by the `layout` key, which is Hugo's
+  own idiom for the choice Zola makes natively from `redirect_to` and gazette
+  makes by reaching for its `redirect.html`. `docs/spec/src/_index.md` is the
+  corpus's one case. Honouring the key at all is what keeps the three tools'
+  emitted file sets equal at `/spec/index.html` (Decision 4): refusing it would
+  leave a hole and rendering the section normally would put a page where the
+  peers serve a redirect.
+*/}}
+{{ define "title" }}{{ .Title }} - Rue Language Specification{{ end }}
+{{ define "main" }}
+{{ partial "sidebar-shell.html" (dict
+     "page" .
+     "root" (site.GetPage "/spec")
+     "title" "Rue Specification"
+     "search" true
+     "prevnext" false
+     "body" (partial "section-body.html" (dict "page" . "heading" "In this section" "subsections" true))) }}
+{{ end }}

--- a/performance/ports/hugo/layouts/std/page.html
+++ b/performance/ports/hugo/layouts/std/page.html
@@ -1,0 +1,12 @@
+{{/* Hugo port of `website/templates/std/page.html`. */}}
+{{ define "title" }}{{ .Title }} - Standard Library{{ end }}
+{{ define "main" }}
+{{ partial "sidebar-shell.html" (dict
+     "page" .
+     "root" (site.GetPage "/std")
+     "title" "Standard Library"
+     "search" false
+     "prevnext" true
+     "contentClass" "std-content"
+     "body" .Content) }}
+{{ end }}

--- a/performance/ports/hugo/layouts/std/section.html
+++ b/performance/ports/hugo/layouts/std/section.html
@@ -1,0 +1,12 @@
+{{/* Hugo port of `website/templates/std/section.html`. */}}
+{{ define "title" }}{{ .Title }} - Standard Library{{ end }}
+{{ define "main" }}
+{{ partial "sidebar-shell.html" (dict
+     "page" .
+     "root" (site.GetPage "/std")
+     "title" "Standard Library"
+     "search" false
+     "prevnext" false
+     "contentClass" "std-content"
+     "body" (partial "section-body.html" (dict "page" . "heading" "Modules" "subsections" false))) }}
+{{ end }}

--- a/performance/ports/hugo/layouts/tutorial/page.html
+++ b/performance/ports/hugo/layouts/tutorial/page.html
@@ -1,0 +1,11 @@
+{{/* Hugo port of `website/templates/tutorial/page.html`. */}}
+{{ define "title" }}{{ .Title }} - Learn Rue{{ end }}
+{{ define "main" }}
+{{ partial "sidebar-shell.html" (dict
+     "page" .
+     "root" (site.GetPage "/tutorial")
+     "title" "Learn Rue"
+     "search" false
+     "prevnext" true
+     "body" .Content) }}
+{{ end }}

--- a/performance/ports/hugo/layouts/tutorial/section.html
+++ b/performance/ports/hugo/layouts/tutorial/section.html
@@ -1,0 +1,11 @@
+{{/* Hugo port of `website/templates/tutorial/section.html`. */}}
+{{ define "title" }}{{ .Title }} - Learn Rue{{ end }}
+{{ define "main" }}
+{{ partial "sidebar-shell.html" (dict
+     "page" .
+     "root" (site.GetPage "/tutorial")
+     "title" "Learn Rue"
+     "search" false
+     "prevnext" false
+     "body" (partial "section-body.html" (dict "page" . "heading" "Chapters" "subsections" false))) }}
+{{ end }}

--- a/performance/ports/zola/config.toml
+++ b/performance/ports/zola/config.toml
@@ -1,0 +1,80 @@
+# The Zola parity configuration (ADR-0072 Decisions 3 and 5, RUE-1485).
+#
+# This file and `templates/` are the Zola half of "template ports and parity
+# configurations", versioned in the repository beside gazette's port at
+# `examples/gazette/` and Hugo's at `performance/ports/hugo/`. Fixture
+# preparation copies them next to the assembled corpus and hashes them into the
+# recorded fixture identity, so a change here starts a new comparable segment
+# rather than silently shifting an existing one.
+#
+# EVERY LINE BELOW EXISTS TO MAKE ZOLA DO THE SAME JOB, not a smaller one. The
+# fairness rule runs in both directions: a parity config that left Zola
+# highlighting code would make Rue look good for a false reason, and one that
+# turned off work gazette actually does would make Zola look good for a false
+# reason. Each switch is therefore paired below with the reason gazette does not
+# do that work either.
+#
+# Derived from `website/config.toml`, which is the production configuration for
+# this same corpus. The diff against it is exactly the equivalence subset:
+# highlighting, search, and minification off; feeds and everything else the same.
+base_url = "https://rue-lang.dev"
+title = "Rue"
+description = "A systems programming language with memory safety and high-level ergonomics"
+
+# --- The equivalence subset (Decision 3, "out of scope for v1") -------------
+#
+# Production sets `minify_html = true`, `build_search_index = true`, and
+# `highlight_code = true`. Gazette implements none of the three, so the peers
+# are configured to skip them; each is an intended parity expansion, and each
+# widens the subset for all three tools at once under a new suite revision.
+compile_sass = false
+minify_html = false
+build_search_index = false
+
+# The feed IS in the subset: gazette generates one and its port carries an
+# `rss.xml` template, so turning Zola's off would be a peer doing less work.
+# What is turned off here is the SITE-WIDE feed at the root, which gazette does
+# not emit; the blog section's own `generate_feeds = true` front matter still
+# produces `blog/rss.xml`, and the file-set check asserts that it does.
+generate_feeds = false
+feed_filenames = ["rss.xml"]
+
+# Neither of these is in the subset, and neither is a feature: they are outputs
+# gazette does not emit at all. Left on, Zola would write a sitemap over every
+# page of the corpus and a robots.txt, which is work the other two tools never
+# do — and the file-set equality check of Decision 4 would then need an
+# allowlist entry for each. Turning them off makes the emitted file set exactly
+# equal across the three tools, which is a stronger check than an allowlist.
+generate_sitemap = false
+generate_robots_txt = false
+
+# Zola's `[slugify]` defaults are deliberately left alone, so this port routes
+# exactly as the production site does.
+#
+# The corpus's three upper-case file names are lower-cased during fixture
+# preparation instead, and the reason is worth stating plainly rather than
+# leaving to a digest: Zola slugifies a content path into its route and Hugo
+# lower-cases it into its page identity, so BOTH PEERS agree with production,
+# and gazette — which does not slugify at all — is the one tool that would emit
+# a different route. The normalization spares the file-set check an allowlist
+# entry, and it suppresses a real difference in which Rue is the outlier. The
+# work is one pass over 96 paths and cannot move a measurement; closing the gap
+# in gazette is a later change.
+
+[markdown]
+# The single most important line in this file. Zola renders fenced code through
+# its own writer either way, but with highlighting on it would also load
+# Sublime syntax definitions and emit per-token markup for 1,200-odd code blocks
+# — work gazette does not do and cannot do. Leaving this true is the specific
+# unfairness ADR-0072 Decision 3 names.
+highlight_code = false
+
+# `extra_syntaxes_and_themes` and `highlight_themes_css` from the production
+# configuration are deliberately absent rather than set empty: with
+# highlighting off they would load syntax definitions for nothing.
+
+[extra]
+# Read by `base.html` for the two masthead links. Same values as production, so
+# the port renders the same navigation the corpus's pages link into.
+github_url = "https://github.com/rue-language/rue"
+bluesky_url = "https://bsky.app/profile/rue-lang.dev"

--- a/performance/ports/zola/templates/base.html
+++ b/performance/ports/zola/templates/base.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}{{ config.title }}{% endblock %}</title>
+    <meta name="description" content="{{ config.description }}">
+    <link rel="stylesheet" href="{{ get_url(path='style.css') }}">
+    <link rel="icon" href="{{ get_url(path='favicon.svg') }}" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="{{ get_url(path='brand/apple-touch-icon.png') }}">
+    <link rel="alternate" type="application/rss+xml" title="Rue Blog RSS" href="{{ get_url(path='blog/rss.xml') }}">
+    <script>
+        // Check for saved theme preference or default to system preference
+        const isDark = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (isDark) {
+            document.documentElement.classList.add('dark');
+        }
+        // Write syntax theme stylesheets with correct initial disabled state
+        document.write('<link rel="stylesheet" href="{{ get_url(path='syntax-light.css') }}" id="syntax-light"' + (isDark ? ' disabled' : '') + '>');
+        document.write('<link rel="stylesheet" href="{{ get_url(path='syntax-dark.css') }}" id="syntax-dark"' + (isDark ? '' : ' disabled') + '>');
+
+        function updateSyntaxTheme() {
+            const syntaxLight = document.getElementById('syntax-light');
+            const syntaxDark = document.getElementById('syntax-dark');
+            if (syntaxLight && syntaxDark) {
+                const dark = document.documentElement.classList.contains('dark');
+                syntaxLight.disabled = dark;
+                syntaxDark.disabled = !dark;
+            }
+        }
+    </script>
+</head>
+<body class="min-h-screen flex flex-col">
+    <!-- engraved rue sprig (Ruta graveolens), referenced site-wide via <use> -->
+    <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+      <defs>
+        <g id="rue-sprig" fill="none" stroke="currentColor" stroke-width="1.5"
+           stroke-linecap="round" stroke-linejoin="round">
+          <path d="M16 30 C 16 24, 15.4 18, 16 10"/>
+          <path d="M15.7 22 C 12.5 20.5, 10 19, 8 16.5"/>
+          <path d="M8 16.5 c -2.6 -0.4 -4 -2.4 -3.4 -4.4 c 1.8 -1 4 -0.2 4.6 2 c 0.3 1 0 1.8 -1.2 2.4 z"/>
+          <path d="M11.5 19.2 c -2.4 0.6 -4.3 -0.6 -4.5 -2.6"/>
+          <path d="M16 17.5 C 19.5 16, 22 14.5, 23.8 12"/>
+          <path d="M23.8 12 c 2.6 -0.2 3.9 -2.2 3.2 -4.2 c -1.9 -0.9 -4 0.1 -4.4 2.3 c -0.2 1 0.1 1.7 1.2 1.9 z"/>
+          <path d="M20.4 14.6 c 2.4 0.4 4.2 -0.8 4.3 -2.8"/>
+          <path d="M16 10 c -0.4 -2.8 1 -4.6 3.2 -4.6 c 1.2 1.8 0.5 4 -1.6 4.9 c -0.7 0.3 -1.2 0.2 -1.6 -0.3 z"/>
+          <g stroke="none" fill="var(--color-gold)">
+            <circle cx="12.2" cy="7.4" r="1.15"/>
+            <circle cx="9.9"  cy="9.4" r="1.15"/>
+            <circle cx="12.6" cy="10.6" r="1.15"/>
+            <circle cx="14.4" cy="8.7" r="1.15"/>
+          </g>
+          <circle cx="12.4" cy="9" r="0.8" stroke="none" fill="currentColor"/>
+          <path d="M15.9 13.5 C 14.8 11.8, 13.6 10.6, 12.6 10.4"/>
+        </g>
+      </defs>
+    </svg>
+
+    <div class="colophon-bar">
+        <em>Ruta graveolens</em> &nbsp;·&nbsp; notes from a language experiment &nbsp;·&nbsp; cultivated since 2025
+    </div>
+
+    <nav>
+        <div class="masthead">
+            <a href="{{ get_url(path='/') }}" class="wordmark">
+                <svg class="sprig" viewBox="0 0 32 32"><use href="#rue-sprig"/></svg>
+                Rue
+            </a>
+            <!-- Desktop navigation -->
+            <div class="nav-desktop flex items-center gap-6">
+                <ul class="flex gap-6">
+                    <li><a href="{{ get_url(path='tutorial') }}" class="nav-link">Tutorial</a></li>
+<!-- Hardcoded path: spec pages are copied into Zola content at build time -->
+                    <li><a href="/spec/" class="nav-link">Specification</a></li>
+                    <li><a href="{{ get_url(path='performance') }}" class="nav-link">Performance</a></li>
+                    <li><a href="{{ get_url(path='runtime') }}" class="nav-link">Runtime</a></li>
+                    <li><a href="{{ get_url(path='blog') }}" class="nav-link">Lab Notes</a></li>
+                    <li><a href="{{ config.extra.github_url }}" class="nav-link ext">GitHub</a></li>
+                    <li><a href="{{ config.extra.bluesky_url }}" class="nav-link ext">Bluesky</a></li>
+                </ul>
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+            </div>
+            <!-- Mobile navigation controls -->
+            <div class="nav-mobile-controls flex items-center gap-4">
+                <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                    <svg class="icon-sun w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="icon-moon w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+                <button onclick="toggleMobileMenu()" class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false">
+                    <svg class="icon-menu w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                    <svg class="icon-close w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+        <!-- Mobile menu overlay -->
+        <div id="mobile-menu" class="mobile-menu">
+            <ul class="mobile-menu-list">
+                <li><a href="{{ get_url(path='/') }}" class="mobile-menu-link">Home</a></li>
+                <li><a href="{{ get_url(path='tutorial') }}" class="mobile-menu-link">Tutorial</a></li>
+                <li><a href="/spec/" class="mobile-menu-link">Specification</a></li>
+                <li><a href="{{ get_url(path='performance') }}" class="mobile-menu-link">Performance</a></li>
+                <li><a href="{{ get_url(path='runtime') }}" class="mobile-menu-link">Runtime</a></li>
+                <li><a href="{{ get_url(path='blog') }}" class="mobile-menu-link">Lab Notes</a></li>
+                <li><a href="{{ config.extra.github_url }}" class="mobile-menu-link">GitHub</a></li>
+                <li><a href="{{ config.extra.bluesky_url }}" class="mobile-menu-link">Bluesky</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <main class="flex-1">
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer class="footer-colophon">
+        <div class="inner">
+            <span>© 2025–2026 The Rue Authors · MIT/Apache-2.0</span>
+            <span><em>rue</em>, n. — a hardy evergreen herb; also, what we hope you won’t do after choosing this language.</span>
+        </div>
+    </footer>
+
+    <script>
+        function toggleTheme() {
+            if (document.documentElement.classList.contains('dark')) {
+                document.documentElement.classList.remove('dark');
+                localStorage.theme = 'light';
+            } else {
+                document.documentElement.classList.add('dark');
+                localStorage.theme = 'dark';
+            }
+            updateSyntaxTheme();
+        }
+
+        function toggleMobileMenu() {
+            const menu = document.getElementById('mobile-menu');
+            const toggle = document.querySelector('.mobile-menu-toggle');
+            const isOpen = menu.classList.toggle('open');
+            toggle.classList.toggle('active', isOpen);
+            toggle.setAttribute('aria-expanded', isOpen);
+        }
+
+        // Close mobile menu when clicking a link
+        document.querySelectorAll('.mobile-menu-link').forEach(link => {
+            link.addEventListener('click', () => {
+                const menu = document.getElementById('mobile-menu');
+                const toggle = document.querySelector('.mobile-menu-toggle');
+                menu.classList.remove('open');
+                toggle.classList.remove('active');
+                toggle.setAttribute('aria-expanded', 'false');
+            });
+        });
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/elasticlunr/0.9.5/elasticlunr.min.js"></script>
+    <script src="{{ get_url(path='search.js') }}"></script>
+</body>
+</html>

--- a/performance/ports/zola/templates/blog-page.html
+++ b/performance/ports/zola/templates/blog-page.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} | Lab Notes | {{ config.title }}{% endblock %}
+
+{% block content %}
+<article class="py-12">
+    <div class="max-w-3xl mx-auto px-6">
+        <header class="mb-8">
+            <h1 style="font-family: var(--font-display); font-weight: 460; font-size: 2.3rem; line-height: 1.15;" class="mb-3">{{ page.title }}</h1>
+            <div class="text-muted flex flex-wrap gap-1" style="font-style: italic;">
+                <time datetime="{{ page.date }}" class="note-date" style="font-style: normal;">{{ page.date | date(format="%Y · %m · %d") }}</time>
+                {% if page.extra.authors %}
+                <span class="before:content-['·'] before:mr-1">
+                    by {% for author in page.extra.authors %}{% if loop.index > 1 %}{% if loop.last %} and {% else %}, {% endif %}{% endif %}{% if author == "steve" %}<a href="https://steveklabnik.com">Steve</a>{% elif author == "claude" %}<a href="https://claude.ai">Claude</a>{% elif author == "codex" %}<a href="https://openai.com/codex/">Codex</a>{% else %}{{ author }}{% endif %}{% endfor %}
+                </span>
+                {% endif %}
+            </div>
+            {% if page.extra.prompt %}
+            <details class="mt-4 prompt-details">
+                <summary class="text-muted cursor-pointer hover:text-fg select-none">View the prompt</summary>
+                <div class="mt-3 p-4 bg-surface border border-themed rounded-lg">
+                    <pre class="whitespace-pre-wrap text-sm m-0! p-0! bg-transparent! border-none!">{{ page.extra.prompt }}</pre>
+                </div>
+            </details>
+            {% endif %}
+        </header>
+        <div class="prose">
+            {{ page.content | safe }}
+        </div>
+    </div>
+</article>
+{% endblock %}

--- a/performance/ports/zola/templates/blog.html
+++ b/performance/ports/zola/templates/blog.html
@@ -1,0 +1,56 @@
+{#
+  Zola port of `website/templates/blog.html` (ADR-0072 Decision 3).
+
+  The carve-out below is taken here because it is taken in every port. Keeping
+  `paginator` for Zola alone would have one tool building views the others
+  never build, which is the fairness bug Decision 3 exists to prevent — the
+  peers must skip the same work gazette skips, not less and not more.
+
+  Pagination is outside the equivalence subset for every tool, so this port
+  lists `section.pages` directly where production writes
+  `{% set pages = paginator.pages | default(value=section.pages) %}`, and drops
+  the Newer/Older navigation the paginator drives. The corpus has eight posts
+  against a `paginate_by = 10`, so production renders exactly one page of them
+  today and the listing itself is unchanged; the difference is that this port
+  cannot grow a second page, which is what "pagination is out of scope" means.
+#}
+{% extends "base.html" %}
+
+{% block title %}Lab Notes | {{ config.title }}{% endblock %}
+
+{% block content %}
+<section class="py-12">
+    <div class="max-w-3xl mx-auto px-6">
+        <header class="mb-10">
+            <h1 style="font-family: var(--font-display); font-weight: 460; font-size: 2.3rem;" class="mb-2">{{ section.title }}</h1>
+            <p class="text-muted mb-4" style="font-style: italic;">{{ section.content | safe }}</p>
+            <a href="{{ get_url(path='blog/rss.xml') }}" class="inline-flex items-center gap-2 text-muted text-sm hover:text-[var(--color-accent)]">
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                    <circle cx="6.18" cy="17.82" r="2.18"/>
+                    <path d="M4 4.44v2.83c7.03 0 12.73 5.7 12.73 12.73h2.83c0-8.59-6.97-15.56-15.56-15.56zm0 5.66v2.83c3.9 0 7.07 3.17 7.07 7.07h2.83c0-5.47-4.43-9.9-9.9-9.9z"/>
+                </svg>
+                RSS Feed
+            </a>
+        </header>
+
+        <ul class="note-list">
+            {% for page in section.pages %}
+            <li>
+                <span class="note-date"><time datetime="{{ page.date }}">{{ page.date | date(format="%Y · %m · %d") }}</time></span>
+                <div>
+                    <a class="note-title" href="{{ page.permalink }}">{{ page.title }}</a>
+                    {% if page.extra.authors %}
+                    <span class="text-faint text-sm" style="font-style: italic;">
+                        — {% for author in page.extra.authors %}{% if loop.index > 1 %}{% if loop.last %} and {% else %}, {% endif %}{% endif %}{% if author == "steve" %}Steve{% elif author == "claude" %}Claude{% elif author == "codex" %}Codex{% else %}{{ author }}{% endif %}{% endfor %}
+                    </span>
+                    {% endif %}
+                    {% if page.summary %}
+                    <p class="note-summary">{{ page.summary | safe }}</p>
+                    {% endif %}
+                </div>
+            </li>
+            {% endfor %}
+        </ul>
+    </div>
+</section>
+{% endblock %}

--- a/performance/ports/zola/templates/index.html
+++ b/performance/ports/zola/templates/index.html
@@ -1,0 +1,107 @@
+{#
+  Zola port of `website/templates/index.html` (ADR-0072 Decision 3).
+
+  The Field Report panel is dropped here for exactly the reason the gazette
+  port drops it: `load_data` is outside the equivalence subset for every tool,
+  and a panel rendered by one tool alone would be measured work the others
+  never do.
+
+  The production page opens with `{% set status = load_data(path=
+  "static/status.json", format="json") %}` and renders a "Field Report" panel
+  from it. Two of that panel's rows are derived from the performance store, so
+  rendering it here would make the benchmark's own output an input to the
+  benchmark's workload — the same reason Decision 3 carves the performance
+  dashboard page out of the corpus entirely. `load_data` is therefore outside
+  the equivalence subset for every tool, and this port drops the panel rather
+  than faking a data file for it. The carve-out is stated here and in
+  `scripts/gazette-corpus-diff.py`'s exclusion table rather than left as a
+  silent difference between the port and the page it derives from.
+#}
+{% extends "base.html" %}
+
+{% block content %}
+<section class="hero max-w-5xl mx-auto px-6 pt-14 pb-12 grid grid-cols-1 md:grid-cols-12 gap-12 items-start">
+    <div class="md:col-span-7 reveal d1">
+        <h1 style="font-family: var(--font-display); font-weight: 420; font-size: clamp(2.1rem, 4.6vw, 3.2rem); line-height: 1.12; letter-spacing: -0.01em;" class="mb-6">
+            Rust proved memory safety without garbage collection is possible.<br>
+            <em style="font-weight: 460; color: var(--color-accent);">Can it also be easy?</em>
+        </h1>
+        <p class="text-lg mb-4" style="color: var(--color-muted); max-width: 30rem;">
+            <strong style="color: var(--color-fg);">We don’t know yet.</strong>
+            Rue is an early-stage research language exploring that question — a
+            systems language aiming for the same destination by a gentler path.
+            It is not ready for real projects, but the whole experiment runs in
+            the open, and you can watch.
+        </p>
+        <p class="mb-8" style="font-style: italic; color: var(--color-faint); max-width: 30rem; font-size: 0.95rem;">
+            Designed by <a href="https://steveklabnik.com" style="color: inherit;">Steve Klabnik</a>.
+            Implemented primarily by Claude, an AI. The field report is an
+            illustrative preview while live project reporting is rebuilt.
+        </p>
+        <div class="flex gap-4 flex-wrap">
+            <a href="{{ get_url(path='tutorial') }}" class="btn-primary">Begin the tutorial</a>
+<!-- Hardcoded path: spec pages are copied into Zola content at build time -->
+            <a href="/spec/" class="btn-secondary">Read the spec</a>
+        </div>
+    </div>
+</section>
+
+<section class="max-w-5xl mx-auto px-6 pb-14 grid grid-cols-1 md:grid-cols-12 gap-12 items-start">
+    <figure class="md:col-span-7 reveal d2" style="margin: 0;">
+        <div class="specimen">
+            <div class="specimen-head">
+                <span class="no">Specimen №&thinsp;1</span>
+                <span>fib.rue</span>
+            </div>
+            {{ section.content | safe }}
+        </div>
+        <figcaption class="specimen-caption">
+            <b>Fig. 1.</b> Compiles to a small static binary.
+            No VM, no interpreter, no garbage collector.
+        </figcaption>
+    </figure>
+
+    <div class="md:col-span-5 reveal d3">
+        <h3 style="font-family: var(--font-display); font-weight: 480; font-size: 1.5rem;" class="mb-3">
+            Familiar on the surface, careful underneath.
+        </h3>
+        <p class="mb-4" style="color: var(--color-muted); font-size: 0.98rem;">
+            If you know Rust, Go, or C, the syntax will feel like home. Underneath,
+            Rue is exploring linear types, compile-time evaluation, and drop
+            tracking — the machinery of memory safety — while trying to keep the
+            learning curve shallow enough to walk up, not climb.
+        </p>
+        <p class="mb-5" style="color: var(--color-muted); font-size: 0.98rem;">
+            The compiler is written in Rust and emits x86-64 and ARM64 machine
+            code directly: no LLVM, direct syscalls, static ELF and Mach-O
+            executables.
+        </p>
+        <div class="run-line"><span class="prompt">$</span> rue fib.rue -o fib && ./fib</div>
+    </div>
+</section>
+
+<div class="sprig-divider" role="presentation">
+    <svg viewBox="0 0 32 32"><use href="#rue-sprig"/></svg>
+</div>
+
+<section class="max-w-5xl mx-auto px-6 pt-12 pb-14">
+    <h2 class="section-title">Recent lab notes</h2>
+    {% set blog = get_section(path="blog/_index.md") %}
+    <ul class="note-list">
+        {% for post in blog.pages | slice(end=3) %}
+        <li>
+            <span class="note-date">{{ post.date | date(format="%Y · %m · %d") }}</span>
+            <div>
+                <a class="note-title" href="{{ post.permalink }}">{{ post.title }}</a>
+                {% if post.description %}
+                <p class="note-summary">{{ post.description }}</p>
+                {% elif post.summary %}
+                <p class="note-summary">{{ post.summary | striptags | truncate(length=180) }}</p>
+                {% endif %}
+            </div>
+        </li>
+        {% endfor %}
+    </ul>
+    <p class="mt-6" style="font-size: 0.9rem;"><a href="{{ get_url(path='blog') }}">All lab notes →</a></p>
+</section>
+{% endblock %}

--- a/performance/ports/zola/templates/page.html
+++ b/performance/ports/zola/templates/page.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} | {{ config.title }}{% endblock %}
+
+{% block content %}
+<article class="py-12">
+    <div class="max-w-3xl mx-auto px-6 prose">
+        <h1>{{ page.title }}</h1>
+        {{ page.content | safe }}
+    </div>
+</article>
+{% endblock %}

--- a/performance/ports/zola/templates/rss.xml
+++ b/performance/ports/zola/templates/rss.xml
@@ -1,0 +1,41 @@
+{#
+  The Zola port's feed, and the reason it exists at all is a fairness bug this
+  port shipped without it.
+
+  Zola falls back to its BUILT-IN feed template when a site provides none, and
+  that feed is a different job from the one the other two ports do: it renders
+  every post's full body into `<description>`, escaped, plus RFC-822 dates, a
+  `<generator>`, and author elements. On today's corpus that is 6,838 bytes
+  against 2,998 for gazette's and Hugo's — Markdown rendering and escaping of
+  eight whole posts that the other two tools never perform, growing with every
+  post added. The measured cost sits inside run-to-run noise at 1x today, but
+  the parity claim in `config.toml` was untrue, the difference scales with the
+  corpus, and it is the direction that flatters Rue.
+
+  The cross-tool feed check could not see it either: comparing `<link>` order
+  says nothing about what a `<description>` contains. That check now compares
+  which entries carry a description as well, so this cannot regress silently.
+
+  The shape mirrors `examples/gazette/templates/rss.xml` and the Hugo port's
+  `blog/section.rss.xml` deliberately: the feed is one of the outputs Decision 4
+  compares across tools, so the three should emit the same entries with the same
+  fields. `| safe` on URLs is required rather than stylistic — Tera escapes by
+  file type, and a permalink reaching a feed reader as `https:&#x2F;&#x2F;…` is
+  a link nobody can follow.
+#}<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+        <title>{{ config.title }}</title>
+        <link>{{ section.permalink | safe }}</link>
+        <description>{{ section.description | default(value=config.description) }}</description>
+        <language>en</language>
+        <atom:link href="{{ feed_url | safe }}" rel="self" type="application/rss+xml"/>
+{% for page in pages %}        <item>
+            <title>{{ page.title }}</title>
+            <pubDate>{{ page.date }}</pubDate>
+            <link>{{ page.permalink | safe }}</link>
+            <guid>{{ page.permalink | safe }}</guid>
+            <description>{{ page.description | default(value="") }}</description>
+        </item>
+{% endfor %}    </channel>
+</rss>

--- a/performance/ports/zola/templates/shortcodes/preview_feature.html
+++ b/performance/ports/zola/templates/shortcodes/preview_feature.html
@@ -1,0 +1,5 @@
+<div class="preview-notice">
+    <strong>Preview Feature</strong>:
+    This feature requires <code>--preview {{ feature }}</code> to use.
+    {% if adr %}See <a href="/designs/{{ adr | lower }}">{{ adr | upper }}</a> for the design.{% endif %}
+</div>

--- a/performance/ports/zola/templates/shortcodes/rule.html
+++ b/performance/ports/zola/templates/shortcodes/rule.html
@@ -1,0 +1,1 @@
+<div class="rule" id="r-{{ id }}"><a class="rule-link" href="#r-{{ id }}">[{{ id }}]</a></div>

--- a/performance/ports/zola/templates/spec/base.html
+++ b/performance/ports/zola/templates/spec/base.html
@@ -1,0 +1,101 @@
+{#
+  Zola port of `website/templates/spec/base.html` (ADR-0072 Decisions 3 and 5).
+
+  This file is the production template unchanged, and that is the point: the
+  Zola leg of the cross-tool comparison must be Zola doing Zola's own work in
+  Tera's own spelling, so the recursive macro, the `is starting_with` test, and
+  the `depth` parameter are all production's rather than the gazette port's
+  equivalents. `examples/gazette/templates/spec/base.html` documents the two
+  spellings that differ between the two ports and why neither can be
+  precomputed host-side.
+
+  The sidebar is the reason the file matters at all: both the `active` class
+  and the recursion are gated on a prefix test against the CURRENT page's
+  permalink, so every page renders a different sidebar and the expansion work
+  scales with the section tree. Any port that flattened it would emit the same
+  link targets and the same visible text on every page, and no output check in
+  Decision 4 would notice the missing work.
+#}
+{% extends "base.html" %}
+
+{% block title %}{{ page.title | default(value=section.title) }} - Rue Language Specification{% endblock %}
+
+{% block content %}
+<div class="spec-layout">
+    {# Sidebar #}
+    <aside class="spec-sidebar">
+        <div class="spec-sidebar-inner">
+            <div class="spec-sidebar-header">
+                <a href="{{ get_url(path='spec') }}" class="spec-title">Rue Specification</a>
+            </div>
+            <div class="spec-search">
+                <div class="spec-search-input-wrapper">
+                    <input type="text" id="spec-search-input" placeholder="Search..." autocomplete="off">
+                    <kbd class="spec-search-shortcut"><span class="spec-search-shortcut-mod"></span>K</kbd>
+                </div>
+                <div id="spec-search-results" class="spec-search-results"></div>
+            </div>
+            <nav class="spec-nav">
+                {% set spec_section = get_section(path="spec/_index.md") %}
+                {% set current = page.permalink | default(value=section.permalink) | default(value="") %}
+                {{ self::render_nav(section=spec_section, current_path=current, depth=0) }}
+            </nav>
+        </div>
+    </aside>
+
+    {# Main content #}
+    <div class="spec-main">
+        <article class="spec-content">
+            {% block spec_content %}{% endblock %}
+        </article>
+
+        {# Prev/Next navigation #}
+        {% block prev_next %}
+        <nav class="spec-page-nav">
+            {% if page.lower %}
+            <a href="{{ page.lower.permalink }}" class="spec-nav-prev">
+                <span class="spec-nav-label">Previous</span>
+                <span class="spec-nav-title">{{ page.lower.title }}</span>
+            </a>
+            {% else %}
+            <span></span>
+            {% endif %}
+            {% if page.higher %}
+            <a href="{{ page.higher.permalink }}" class="spec-nav-next">
+                <span class="spec-nav-label">Next</span>
+                <span class="spec-nav-title">{{ page.higher.title }}</span>
+            </a>
+            {% endif %}
+        </nav>
+        {% endblock %}
+    </div>
+</div>
+{% endblock %}
+
+{# Recursive macro for navigation - handles a section and its content #}
+{% macro render_nav(section, current_path, depth) %}
+<ul class="spec-nav-list">
+    {# Render direct pages in this section (already sorted by weight) #}
+    {% for pg in section.pages %}
+    <li class="spec-nav-item">
+        <a href="{{ pg.permalink }}" class="spec-nav-link {% if pg.permalink == current_path %}active{% endif %}">
+            {{ pg.title }}
+        </a>
+    </li>
+    {% endfor %}
+
+    {# Subsections paths are already sorted alphabetically by Zola, which works for
+       our numbered chapters (02-lexical-structure, 03-types, etc.) #}
+    {% for sub_path in section.subsections | sort %}
+        {% set sub = get_section(path=sub_path) %}
+    <li class="spec-nav-section">
+        <a href="{{ sub.permalink }}" class="spec-nav-section-title {% if current_path is starting_with(sub.permalink) %}active{% endif %}">
+            {{ sub.title }}
+        </a>
+        {% if current_path is starting_with(sub.permalink) %}
+        {{ self::render_nav(section=sub, current_path=current_path, depth=depth + 1) }}
+        {% endif %}
+    </li>
+    {% endfor %}
+</ul>
+{% endmacro %}

--- a/performance/ports/zola/templates/spec/page.html
+++ b/performance/ports/zola/templates/spec/page.html
@@ -1,0 +1,5 @@
+{% extends "spec/base.html" %}
+
+{% block spec_content %}
+{{ page.content | safe }}
+{% endblock %}

--- a/performance/ports/zola/templates/spec/section.html
+++ b/performance/ports/zola/templates/spec/section.html
@@ -1,0 +1,31 @@
+{% extends "spec/base.html" %}
+
+{% block spec_content %}
+<h1>{{ section.title }}</h1>
+
+{{ section.content | safe }}
+
+{# List child pages #}
+{% if section.pages %}
+<h2>In this section</h2>
+<ul class="spec-section-toc">
+    {% for page in section.pages %}
+    <li><a href="{{ page.path }}">{{ page.title }}</a></li>
+    {% endfor %}
+</ul>
+{% endif %}
+
+{# List subsections #}
+{% if section.subsections %}
+<ul class="spec-section-toc">
+    {% for subsection_path in section.subsections %}
+        {% set subsection = get_section(path=subsection_path) %}
+    <li><a href="{{ subsection.permalink }}">{{ subsection.title }}</a></li>
+    {% endfor %}
+</ul>
+{% endif %}
+{% endblock %}
+
+{% block prev_next %}
+{# Sections don't have prev/next by default #}
+{% endblock %}

--- a/performance/ports/zola/templates/std/base.html
+++ b/performance/ports/zola/templates/std/base.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title | default(value=section.title) }} - Standard Library{% endblock %}
+
+{% block content %}
+<div class="spec-layout">
+    {# Sidebar - reuses spec-sidebar styles #}
+    <aside class="spec-sidebar">
+        <div class="spec-sidebar-inner">
+            <div class="spec-sidebar-header">
+                <a href="{{ get_url(path='std') }}" class="spec-title">Standard Library</a>
+            </div>
+            <nav class="spec-nav">
+                {% set std_section = get_section(path="std/_index.md") %}
+                {% set current = page.permalink | default(value=section.permalink) | default(value="") %}
+                {{ self::render_nav(section=std_section, current_path=current) }}
+            </nav>
+        </div>
+    </aside>
+
+    {# Main content #}
+    <div class="spec-main">
+        <article class="spec-content std-content">
+            {% block std_content %}{% endblock %}
+        </article>
+
+        {# Prev/Next navigation #}
+        {% block prev_next %}
+        <nav class="spec-page-nav">
+            {% if page.lower %}
+            <a href="{{ page.lower.permalink }}" class="spec-nav-prev">
+                <span class="spec-nav-label">Previous</span>
+                <span class="spec-nav-title">{{ page.lower.title }}</span>
+            </a>
+            {% else %}
+            <span></span>
+            {% endif %}
+            {% if page.higher %}
+            <a href="{{ page.higher.permalink }}" class="spec-nav-next">
+                <span class="spec-nav-label">Next</span>
+                <span class="spec-nav-title">{{ page.higher.title }}</span>
+            </a>
+            {% endif %}
+        </nav>
+        {% endblock %}
+    </div>
+</div>
+{% endblock %}
+
+{# Recursive macro for navigation #}
+{% macro render_nav(section, current_path) %}
+<ul class="spec-nav-list">
+    {% for pg in section.pages %}
+    <li class="spec-nav-item">
+        <a href="{{ pg.permalink }}" class="spec-nav-link {% if pg.permalink == current_path %}active{% endif %}">
+            {{ pg.title }}
+        </a>
+    </li>
+    {% endfor %}
+</ul>
+{% endmacro %}

--- a/performance/ports/zola/templates/std/page.html
+++ b/performance/ports/zola/templates/std/page.html
@@ -1,0 +1,5 @@
+{% extends "std/base.html" %}
+
+{% block std_content %}
+{{ page.content | safe }}
+{% endblock %}

--- a/performance/ports/zola/templates/std/section.html
+++ b/performance/ports/zola/templates/std/section.html
@@ -1,0 +1,20 @@
+{% extends "std/base.html" %}
+
+{% block std_content %}
+<h1>{{ section.title }}</h1>
+
+{{ section.content | safe }}
+
+{% if section.pages %}
+<h2>Modules</h2>
+<ul class="spec-section-toc">
+    {% for page in section.pages %}
+    <li><a href="{{ page.path }}">{{ page.title }}</a></li>
+    {% endfor %}
+</ul>
+{% endif %}
+{% endblock %}
+
+{% block prev_next %}
+{# Section index doesn't have prev/next #}
+{% endblock %}

--- a/performance/ports/zola/templates/tutorial/base.html
+++ b/performance/ports/zola/templates/tutorial/base.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title | default(value=section.title) }} - Learn Rue{% endblock %}
+
+{% block content %}
+<div class="spec-layout">
+    {# Sidebar - reuses spec-sidebar styles #}
+    <aside class="spec-sidebar">
+        <div class="spec-sidebar-inner">
+            <div class="spec-sidebar-header">
+                <a href="{{ get_url(path='tutorial') }}" class="spec-title">Learn Rue</a>
+            </div>
+            <nav class="spec-nav">
+                {% set tutorial_section = get_section(path="tutorial/_index.md") %}
+                {% set current = page.permalink | default(value=section.permalink) | default(value="") %}
+                {{ self::render_nav(section=tutorial_section, current_path=current) }}
+            </nav>
+        </div>
+    </aside>
+
+    {# Main content #}
+    <div class="spec-main">
+        <article class="spec-content tutorial-content">
+            {% block tutorial_content %}{% endblock %}
+        </article>
+
+        {# Prev/Next navigation #}
+        {% block prev_next %}
+        <nav class="spec-page-nav">
+            {% if page.lower %}
+            <a href="{{ page.lower.permalink }}" class="spec-nav-prev">
+                <span class="spec-nav-label">Previous</span>
+                <span class="spec-nav-title">{{ page.lower.title }}</span>
+            </a>
+            {% else %}
+            <span></span>
+            {% endif %}
+            {% if page.higher %}
+            <a href="{{ page.higher.permalink }}" class="spec-nav-next">
+                <span class="spec-nav-label">Next</span>
+                <span class="spec-nav-title">{{ page.higher.title }}</span>
+            </a>
+            {% endif %}
+        </nav>
+        {% endblock %}
+    </div>
+</div>
+{% endblock %}
+
+{# Recursive macro for navigation #}
+{% macro render_nav(section, current_path) %}
+<ul class="spec-nav-list">
+    {% for pg in section.pages %}
+    <li class="spec-nav-item">
+        <a href="{{ pg.permalink }}" class="spec-nav-link {% if pg.permalink == current_path %}active{% endif %}">
+            {{ pg.title }}
+        </a>
+    </li>
+    {% endfor %}
+</ul>
+{% endmacro %}

--- a/performance/ports/zola/templates/tutorial/page.html
+++ b/performance/ports/zola/templates/tutorial/page.html
@@ -1,0 +1,5 @@
+{% extends "tutorial/base.html" %}
+
+{% block tutorial_content %}
+{{ page.content | safe }}
+{% endblock %}

--- a/performance/ports/zola/templates/tutorial/section.html
+++ b/performance/ports/zola/templates/tutorial/section.html
@@ -1,0 +1,20 @@
+{% extends "tutorial/base.html" %}
+
+{% block tutorial_content %}
+<h1>{{ section.title }}</h1>
+
+{{ section.content | safe }}
+
+{% if section.pages %}
+<h2>Chapters</h2>
+<ul class="spec-section-toc">
+    {% for page in section.pages %}
+    <li><a href="{{ page.path }}">{{ page.title }}</a></li>
+    {% endfor %}
+</ul>
+{% endif %}
+{% endblock %}
+
+{% block prev_next %}
+{# Section index doesn't have prev/next #}
+{% endblock %}

--- a/performance/runtime.toml
+++ b/performance/runtime.toml
@@ -50,6 +50,7 @@ program_args = ["{fixture}"]
 # them changes the expected output and is therefore a suite-revision event, not
 # a tuning knob.
 [suite.workloads.fixture]
+kind = "seeded_generator"
 category = "recorded"
 generator = "zipf_ascii_text"
 generator_revision = 1
@@ -76,8 +77,144 @@ description = "32 MiB of deterministic ASCII word text with Zipf-distributed wor
 kind = "golden_stdout"
 path = "performance/fixtures/wordfreq/expected-stdout.txt"
 
-# The pinned reference regime. This is the only epoch scheduled collection
-# measures, and the only one whose numbers are comparable over time.
+# ===========================================================================
+# SUITE REVISION 2 (ADR-0072 Phase 5, RUE-1485) adds gazette.
+#
+# Adding a workload changes what the suite measures, so it is a suite-revision
+# event under ADR-0067's ordinary rules and revision 1's observations are not
+# continuous with revision 2's. Revision 1 stays declared: records already in
+# the store name it, and a manifest that forgot it could not validate them.
+#
+# Gazette could not join before this revision because the schema could not
+# express its fixture. `FixtureDeclaration` described exactly one shape — a
+# single file from a seeded generator — and gazette's input is a tree of ~96
+# Markdown files assembled from the live site at a declared scale with two
+# pages excluded. The declaration is now tagged, the corpus-tree shape relaxes
+# the single-file rule for ITSELF ALONE, and a second oracle kind judges an
+# emitted site rather than a line of stdout.
+# ===========================================================================
+[[suite]]
+revision = 2
+protocol_version = 1
+measured_boundary = "spawn_to_exit_v1"
+
+# Unchanged from revision 1. A permanent member of this suite, and the reason
+# the two shapes now sit side by side: whatever the corpus-tree shape needed,
+# wordfreq's declaration and its validation are exactly what they were.
+[[suite.workloads]]
+id = "wordfreq"
+source = "examples/wordfreq/main.rue"
+question = "How fast does a compiled Rue program tokenize and count words in tens of MiB of text?"
+program_args = ["{fixture}"]
+
+[suite.workloads.fixture]
+kind = "seeded_generator"
+category = "recorded"
+generator = "zipf_ascii_text"
+generator_revision = 1
+seed = 20260813
+bytes = 33554432
+vocabulary_size = 65536
+file_name = "wordfreq-input.txt"
+description = "32 MiB of deterministic ASCII word text with Zipf-distributed word ranks"
+
+[suite.workloads.oracle]
+kind = "golden_stdout"
+path = "performance/fixtures/wordfreq/expected-stdout.txt"
+
+# The anchor workload of ADR-0072: a static site generator written in Rue,
+# building the live rue-lang.dev corpus as the real site build assembles it.
+[[suite.workloads]]
+id = "gazette"
+source = "examples/gazette/main.rue"
+question = "How fast does a compiled Rue program build the real rue-lang.dev site, against the production tools that build sites for a living?"
+program_args = ["build", "{fixture}", "-o", "{output}"]
+
+# The corpus is deliberately NOT frozen (ADR-0072 Decision 2). What is pinned
+# here is everything about how the tree is assembled — which preparer, at which
+# revision, at which scale, with which pages excluded — and what is recorded
+# per observation is the digest of the bytes every tool actually consumed. A
+# content change is then a discontinuity in the series rather than an invalid
+# run, and it is visible in the data rather than only in a commit log.
+#
+# `preparer` names the checked-in script rather than duplicating its rules in
+# the runner. ADR-0072 calls that script the reference implementation the
+# harness mode should adopt rather than reinvent, and a second implementation
+# of corpus assembly, routing, exclusion, and validation would be a second
+# implementation to disagree — with the peers' fixtures, which it also lays
+# out, silently diverging from gazette's.
+[suite.workloads.fixture]
+kind = "corpus_tree"
+category = "recorded"
+preparer = "scripts/gazette-corpus-diff.py"
+preparer_revision = 1
+scale = 1
+excluded = ["performance.md", "runtime.md"]
+root_name = "gazette-site"
+description = "the live rue-lang.dev content plus the copied specification, as website/build.sh assembles it, minus the two pages whose templates read derived benchmark data"
+
+# A site build's answer is not a line of stdout: it is 96 pages, a feed, and a
+# redirect stub. The oracle is the checked-in comparison named here, run
+# outside the timed window, which judges every emitted page's normalized
+# semantics — heading tree, visible text, link targets, shortcode expansion,
+# section membership, feed order — against an independent authority, and at
+# Phase 5 against the two peer tools building the identical corpus.
+#
+# A committed byte golden over live corpus output would fail on every content
+# change and be re-blessed rather than read, which is the failure a golden
+# exists to prevent; the markup-level goldens live on the committed miniature
+# site in `performance/fixtures/gazette/` instead, where they stay sensitive.
+[suite.workloads.oracle]
+kind = "semantic_site_pages"
+path = "scripts/gazette-corpus-diff.py"
+
+# The 10x rung of the page-count curve. Same program, same corpus, ten copies
+# of it under path prefixes.
+#
+# The 100x variant is deliberately NOT declared here. It is the scale-variant
+# safety valve of ADR-0072 Decision 9 applied in advance: 9,600 pages per
+# sample, per push, on every Linux row is a cost nobody has measured yet, and
+# the valve exists to move a rung to a schedule rather than to discover the
+# bill in a timeout. It remains available from the harness
+# (`scripts/gazette-corpus-diff.py peers --scale 100`) and joins the collected
+# suite when the 10x rung's cost here is known.
+#
+# TWO HONESTY NOTES ride every published chart over this axis, and they are
+# recorded here because the manifest is what declares the axis exists. It is a
+# PAGE-COUNT curve, not a site-size curve: duplication scales per-page work but
+# not site shape, so internal links and `get_section` still resolve into the
+# original tree and cross-reference resolution stays constant. And the
+# specification sidebar COLLAPSES on a duplicated page — a copy's permalink
+# prefixes nothing in the original tree, so both arms of the navigation's gate
+# go cold — which at 10x is 630 of 700 spec pages rendering one 2,534-byte
+# navigation where the 70 originals average 4,446 bytes. The rung therefore
+# understates per-page templating work by roughly 57% of mean nav bytes on the
+# majority page class, and cannot be read as "what a 1x page costs, times ten".
+[[suite.workloads]]
+id = "gazette_10x"
+source = "examples/gazette/main.rue"
+question = "How does a compiled Rue site build scale with page count, at ten copies of the corpus?"
+program_args = ["build", "{fixture}", "-o", "{output}"]
+
+[suite.workloads.fixture]
+kind = "corpus_tree"
+category = "recorded"
+preparer = "scripts/gazette-corpus-diff.py"
+preparer_revision = 1
+scale = 10
+excluded = ["performance.md", "runtime.md"]
+root_name = "gazette-site-10x"
+description = "the same corpus at ten copies, by deterministic path-prefixed duplication"
+
+[suite.workloads.oracle]
+kind = "semantic_site_pages"
+path = "scripts/gazette-corpus-diff.py"
+
+# The pinned reference regime. Epoch 1 implements suite revision 1 and no
+# longer collects; epoch 2 implements revision 2 and does. Declaring a new
+# epoch rather than moving epoch 1 to the new revision is what keeps every
+# record already in the store valid: a stored report names the epoch it ran
+# under, and that epoch must go on describing the run it describes.
 [[epoch]]
 id = 1
 platform = "x86_64-linux"
@@ -93,7 +230,9 @@ thread_policy = "single_threaded"
 # GitHub-hosted runners expose no PMU. Counters are gated on a future
 # controlled-hardware epoch (ADR-0072 Decision 5) rather than quietly missing.
 hardware_counters = "unavailable_on_hosted_runner"
-collection = true
+# Superseded by epoch 2, which implements suite revision 2. Kept declared so
+# the reports already stored under it stay readable and valid.
+collection = false
 
 [epoch.environment]
 runner_label = "github-hosted"
@@ -144,7 +283,8 @@ compiler_args = ["-O3"]
 optimization = "o3"
 thread_policy = "single_threaded"
 hardware_counters = "unavailable_on_hosted_runner"
-collection = true
+# Superseded by epoch 2, which implements suite revision 2.
+collection = false
 
 # The runner is `ubuntu-24.04-arm`; the image it reports is `ubuntu-24.04`,
 # which is how ADR-0067's aarch64-linux epochs already record this regime. The
@@ -189,7 +329,8 @@ compiler_args = ["-O3"]
 optimization = "o3"
 thread_policy = "single_threaded"
 hardware_counters = "unavailable_on_hosted_runner"
-collection = true
+# Superseded by epoch 2, which implements suite revision 2.
+collection = false
 
 [epoch.environment]
 runner_label = "github-hosted"
@@ -245,3 +386,207 @@ runner_image = "local"
 
 [epoch.sampling.wordfreq]
 samples = 2
+
+# ===========================================================================
+# EPOCH 2: suite revision 2, the epoch that collects (RUE-1485).
+#
+# One new thing is declared per platform beyond the added workloads: the peer
+# policy. Thread policy belongs to the epoch rather than the suite because it
+# is a property of how a platform runs the workload, and on a four-vCPU hosted
+# runner it is the difference between measuring per-unit work and measuring
+# core count. Rue has no concurrency, so the PRIMARY published ratio pins Zola
+# to one rayon thread and Hugo to one `GOMAXPROCS`; their default parallel
+# configuration is measured too and published as a clearly labelled SECONDARY
+# row, so the number a user would actually experience is never hidden.
+#
+# The canary is Decision 9's: one single-threaded Zola build of the 1x corpus
+# rides every gazette observation, taking the workload's own sample count, so
+# every observation has a same-run ratio denominator instead of leaning on a
+# stale or singleton peer sample. The rest of the peer matrix — Hugo, the scale
+# variants, the secondary row — is event-driven, and the event is detected at
+# fixture-preparation time in this same job: the recorded fixture identity
+# moved, a peer version moved, or the epoch changed.
+# ===========================================================================
+[[epoch]]
+id = 2
+platform = "x86_64-linux"
+suite_revision = 2
+target = "x86-64-linux"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = true
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+[epoch.sampling.wordfreq]
+samples = 5
+
+# Five, matching wordfreq: same runner class, same fresh-process boundary, and
+# two series on one platform are easiest to read against each other when their
+# sampling policies differ in nothing.
+[epoch.sampling.gazette]
+samples = 5
+
+# Three at 10x. The rung exists for the shape of the curve rather than for a
+# tight median, and it is ten times the per-sample work of the 1x row on a job
+# that already pays for a release build of the compiler.
+[epoch.sampling.gazette_10x]
+samples = 3
+
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+
+# The 10x rung's peers ride the 10x fixture: the peers build the workload's own
+# corpus, so the canary that anchors this rung's ratio is a 10x Zola build. The
+# event-driven half — Hugo and the default-parallel secondary row — is the same
+# leg as the 1x row's and fires on the same events.
+[epoch.peers.gazette_10x]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 10
+
+# No `[epoch.calibration]` and no `[epoch.flagging]` for either new workload.
+# Calibration is a property of a workload on a platform and is never inherited
+# — not from the compiler suites, not from wordfreq on this same runner — so
+# gazette arrives advisory exactly as wordfreq did, and says so here rather
+# than leaving a reader to infer it from an absent table.
+
+[[epoch]]
+id = 2
+platform = "aarch64-linux"
+suite_revision = 2
+target = "aarch64-linux"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = true
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+[epoch.sampling.wordfreq]
+samples = 5
+
+[epoch.sampling.gazette]
+samples = 5
+
+[epoch.sampling.gazette_10x]
+samples = 3
+
+# The peer shims are dotslash files covering both Linux architectures, so this
+# row runs the same comparison as the x86-64 one against the same pinned peer
+# versions. Nothing about the comparison is inherited across platforms, though:
+# each row measures its own peers on its own hardware.
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+
+# The 10x rung's peers ride the 10x fixture: the peers build the workload's own
+# corpus, so the canary that anchors this rung's ratio is a 10x Zola build. The
+# event-driven half — Hugo and the default-parallel secondary row — is the same
+# leg as the 1x row's and fires on the same events.
+[epoch.peers.gazette_10x]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 10
+
+[[epoch]]
+id = 2
+platform = "aarch64-macos"
+suite_revision = 2
+target = "aarch64-macos"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = true
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "macos-15"
+
+[epoch.sampling.wordfreq]
+samples = 9
+
+# Nine, as this row's wordfreq policy is nine, and for the same reason: the
+# platform is off the per-push path, has no calibration of its own, and a
+# larger n per observation makes the dispersion estimate that calibration will
+# be built from converge sooner.
+[epoch.sampling.gazette]
+samples = 9
+
+[epoch.sampling.gazette_10x]
+samples = 3
+
+# Hugo is pinned for macOS at v0.152.2, the newest release that ships a macOS
+# archive DotSlash can extract; from v0.153.0 Hugo publishes macOS only as a
+# `.pkg`. That pin is why this row can run the same comparison as the Linux
+# rows rather than a Linux-only one.
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+
+# The 10x rung's peers ride the 10x fixture: the peers build the workload's own
+# corpus, so the canary that anchors this rung's ratio is a 10x Zola build. The
+# event-driven half — Hugo and the default-parallel secondary row — is the same
+# leg as the 1x row's and fires on the same events.
+[epoch.peers.gazette_10x]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 10
+
+# The development epoch for local runs, at suite revision 2. Not a collection
+# target: its environment policy admits only `local`, so a hosted runner cannot
+# append to it and a laptop cannot append to the reference series.
+[[epoch]]
+id = 2
+platform = "local"
+suite_revision = 2
+target = "x86-64-linux"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = false
+
+[epoch.environment]
+runner_label = "local"
+runner_image = "local"
+
+[epoch.sampling.wordfreq]
+samples = 2
+
+[epoch.sampling.gazette]
+samples = 2
+
+[epoch.sampling.gazette_10x]
+samples = 2
+
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1

--- a/scripts/gazette-corpus-diff.py
+++ b/scripts/gazette-corpus-diff.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Corpus-driven checks of gazette against the LIVE rue-lang.dev corpus.
 
-Two modes, one apparatus. Both assemble the corpus exactly as
+Several modes, one apparatus. All of them assemble the corpus exactly as
 `website/build.sh` does — site content plus the copied specification, with the
 spec's internal links rewritten — because ADR-0072 Decision 2 measures the site
 as it actually exists rather than a frozen snapshot.
@@ -24,6 +24,21 @@ as it actually exists rather than a frozen snapshot.
     scripts/gazette-corpus-diff.py golden [--bless]
         The markup-level spot goldens, over the committed miniature site in
         `performance/fixtures/gazette/`.
+
+    scripts/gazette-corpus-diff.py peers [--scale N]
+        RUE-1485's cross-tool comparison. Builds the identical corpus with
+        gazette, the pinned Zola, and the pinned Hugo — each through its own
+        native template port and parity configuration — under the thread parity
+        ADR-0072 Decision 5 requires, and judges work equivalence across all
+        three before reporting a single number.
+
+    scripts/gazette-corpus-diff.py prepare --root DIR --out JSON [--peers]
+    scripts/gazette-corpus-diff.py judge --root DIR --gazette-out DIR [...]
+        The two halves `rue-bench runtime` calls, either side of the measured
+        window. `prepare` assembles every tool's fixture and records the
+        identity; `judge` runs the whole validation stack over emitted trees.
+        Measurement itself belongs to `rue-bench`, so every tool's time comes
+        from one clock and every tool's memory from one reaping.
 
 WHAT `body` COMPARES is the rendered Markdown body of every content page —
 Zola's `page.content` — and nothing else. THE COMPARISON IS BYTE-FOR-BYTE, and
@@ -95,10 +110,31 @@ BASE_URL = "https://rue-lang.dev"
 # human-legible label a maintainer bumps when changing the port deliberately,
 # so a reader of two observations can say "the port moved" without diffing two
 # hashes. Both ride every recorded identity.
-PORT_REVISION = 1
+# REVISION 2 (RUE-1485) adds the two peer ports. All three ride one revision
+# and one digest deliberately: the peer leg is event-driven on the recorded
+# fixture identity (ADR-0072 Decision 9), so a change to the Zola or Hugo port
+# has to move that identity or the next collection would join fresh gazette
+# observations to peer numbers taken under a port that no longer exists.
+PORT_REVISION = 2
+
+# The revision of the FIXTURE ASSEMBLY this script implements, which
+# `performance/runtime.toml` pins for the gazette workloads. It is not the port
+# revision: the port is what the tools render, and this is how the tree they
+# render is built — the corpus assembly, the exclusions, the normalizations, and
+# the scale duplication. Bump it whenever any of those changes what a tool
+# consumes, so a manifest pinning an assembly this script no longer implements
+# is refused rather than silently measuring a different job. The seeded
+# generator's `generator_revision` is checked the same way and for the same
+# reason.
+PREPARER_REVISION = 1
+
 PORT_ROOTS = [
     "examples/gazette/config.toml",
     "examples/gazette/templates",
+    "performance/ports/zola/config.toml",
+    "performance/ports/zola/templates",
+    "performance/ports/hugo/hugo.toml",
+    "performance/ports/hugo/layouts",
 ]
 
 # The production template set the port derives from, as it stood when
@@ -114,9 +150,17 @@ PORT_ROOTS = [
 # is not busywork: it is what moves the recorded fixture identity, which is
 # what starts a new comparable segment in the series rather than shifting an
 # existing one under a reader.
+#
+# The digest below was re-pinned for RUE-1485, and the review it records went
+# this way: the change was to `runtime.html`, which is the template of a page
+# EXCLUDED from the benchmark corpus, so no port template derives from it and
+# none should follow. It moved because the cross-tool table it renders now has
+# data to render and captions for the scale axis to carry. `PORT_REVISION`
+# advanced anyway, because the peer ports joined the identity in the same
+# change.
 PRODUCTION_TEMPLATE_ROOT = "website/templates"
 PRODUCTION_TEMPLATE_DIGEST = (
-    "47d52cd447662e02d6f7a76b7d14eafffc1b4602788b8e9547a303be528d87ec"
+    "536f7c68bf169ca1e2d32c67f2118c05d988a071fd2712b485eae5056b6d3d83"
 )
 
 # Pages Zola emits no rendered body for, so `body` mode has nothing to compare
@@ -181,9 +225,57 @@ EXCLUDED_LINKS_PER_PAGE = 4
 # Corpus assembly — exactly what website/build.sh does
 # ---------------------------------------------------------------------------
 
+# The one excluded feature the corpus itself turns on. See `assemble_corpus`.
+PAGINATE_BY = re.compile(r"^paginate_by = .*\n", re.M)
+
 
 def assemble_corpus(dest: str, exclude: dict | None = None) -> list[str]:
-    """Copy site content plus the specification, rewriting spec-internal links."""
+    """Copy site content plus the specification, rewriting spec-internal links.
+
+    Two normalizations are applied to the assembled tree, both outside any
+    measured window and both applied to EVERY tool's copy of it, because
+    ADR-0072 Decision 4's cross-tool criterion is that the tools consume the
+    identical corpus and emit the identical file set.
+
+    Content paths are lower-cased, and the honest way to say why is that
+    GAZETTE IS THE ODD TOOL OUT. Three files in the corpus have an upper-case
+    name (`spec/appendices/A-grammar.md` and its two siblings). Zola slugifies a
+    content path into its route by default and Hugo lower-cases it into its page
+    identity, so both serve `/spec/appendices/a-grammar/` — which is what the
+    production site serves today. Gazette does not slugify at all, so it alone
+    would emit `/spec/appendices/A-grammar/`. That is a Rue capability gap, not
+    a peer quirk, and an earlier version of this note framed it as Hugo's.
+
+    Normalizing here keeps all three tools on production's own route and keeps
+    Decision 4's file-set check exact rather than needing an allowlist entry
+    that excuses three files — which is the entry a tool silently dropping a
+    page would later hide behind. What it costs is honesty about a real
+    two-against-one difference, so the difference is stated here, in the peers'
+    parity configurations, in the ADR, and on the published page rather than
+    only in a digest. The work involved either way is one pass over 96 paths
+    and cannot move a measurement; teaching gazette to slugify would close the
+    gap properly and is left to a later change.
+
+    Nothing links to the three by name, so no link rewrite is needed; the walk
+    below asserts that rather than trusting it.
+
+    One key is stripped from the assembled front matter: `paginate_by`.
+    Pagination is outside the equivalence subset for every tool (ADR-0072
+    Decision 3), and it is the one excluded feature the CORPUS turns on rather
+    than a configuration file — so leaving it in place would have Zola emitting
+    `blog/page/1/index.html` for a paginated view gazette and the Hugo port
+    never build. Stripping it here rather than in one tool's fixture is what
+    keeps the sentence "every tool builds the identical corpus within a run"
+    true.
+
+    NEITHER NORMALIZATION IS VISIBLE IN THE CONTENT DIGEST, and an earlier
+    version of this docstring wrongly claimed otherwise. The digest is taken
+    over the tree these rules have already rewritten, so a new section adopting
+    `paginate_by` produces byte-identical assembled content and an unchanged
+    digest. What records them is `prepare_fixture`'s `preparer_revision` and
+    `preparer_digest`, which are inside the fixture identity for exactly this
+    reason: the rules are as much an input to the measured job as the bytes are.
+    """
     shutil.copytree(os.path.join(REPO, "website", "content"), dest)
     spec_dest = os.path.join(dest, "spec")
     if os.path.exists(spec_dest):
@@ -205,6 +297,40 @@ def assemble_corpus(dest: str, exclude: dict | None = None) -> list[str]:
         victim = os.path.join(dest, rel)
         if os.path.exists(victim):
             os.remove(victim)
+
+    lowercased = []
+    for dirpath, _dirs, files in os.walk(dest, topdown=False):
+        for name in files:
+            if name == name.lower():
+                continue
+            source = os.path.join(dirpath, name)
+            os.rename(source, os.path.join(dirpath, name.lower()))
+            lowercased.append(os.path.relpath(source, dest).replace(os.sep, "/"))
+    for rel in lowercased:
+        stem = rel[: -len(".md")] if rel.endswith(".md") else rel
+        for dirpath, _dirs, files in os.walk(dest):
+            for name in files:
+                if not name.endswith(".md"):
+                    continue
+                path = os.path.join(dirpath, name)
+                if "@/" + stem in open(path, encoding="utf-8").read():
+                    raise SystemExit(
+                        "%s links to %s by its upper-case name, which corpus "
+                        "assembly has lower-cased; teach assemble_corpus to "
+                        "rewrite the link before renaming the file"
+                        % (os.path.relpath(path, dest), stem))
+
+    for dirpath, _dirs, files in os.walk(dest):
+        for name in files:
+            if not name.endswith(".md"):
+                continue
+            path = os.path.join(dirpath, name)
+            with open(path, encoding="utf-8") as handle:
+                body = handle.read()
+            stripped = PAGINATE_BY.sub("", body)
+            if stripped != body:
+                with open(path, "w", encoding="utf-8") as handle:
+                    handle.write(stripped)
 
     pages = []
     for dirpath, _dirs, files in os.walk(dest):
@@ -231,13 +357,22 @@ def route_of(rel: str) -> str:
 
 
 def build_gazette() -> str:
+    """Compile gazette at RELEASE QUALITY, as `performance/runtime.toml` does.
+
+    `-O3` is not decoration here. ADR-0072 Decision 5 defines the measured
+    product as the release build and the manifest pins `-O3` for every runtime
+    epoch, while the compiler's own default is `-O0`. A script reporting numbers
+    taken at `-O0` would be measuring something the contract does not describe,
+    whatever the measured difference happened to be on the day — and this script
+    is what the CI work-equivalence lane runs.
+    """
     binary = subprocess.run(
         [os.path.join(REPO, "scripts", "rue-bin")],
         capture_output=True, text=True, check=True,
     ).stdout.strip()
     out = os.path.join(tempfile.mkdtemp(prefix="gazette-bin-"), "gazette")
     subprocess.run(
-        [binary, os.path.join(REPO, "examples", "gazette", "main.rue"), "-o", out],
+        [binary, os.path.join(REPO, "examples", "gazette", "main.rue"), "-O3", "-o", out],
         check=True, capture_output=True, text=True,
         env={**os.environ, "RUE_STD_PATH": os.path.join(REPO, "std")},
     )
@@ -317,13 +452,8 @@ def render_with_zola(corpus: str, pages: list[str], root: str) -> str:
         with open(path, "w", encoding="utf-8") as handle:
             handle.write("")
 
-    content = os.path.join(root, "content")
-    for rel in pages:
-        path = os.path.join(content, rel)
-        body = open(path, encoding="utf-8").read()
-        body = re.sub(r"^paginate_by = .*\n", "", body, flags=re.M)
-        open(path, "w", encoding="utf-8").write(body)
-
+    # `paginate_by` is already stripped by `assemble_corpus`, for every tool at
+    # once rather than for this renderer alone.
     result = subprocess.run(
         [os.path.join(REPO, "zola"), "build"], cwd=root, capture_output=True, text=True
     )
@@ -624,8 +754,16 @@ class Model:
     def _inverse_date(self, rel: str) -> str:
         date = str(self.pages[rel].get("date", ""))
         # Newest first: invert each byte so an ascending sort is descending by
-        # date, and an absent date (the empty string) still lands last.
-        return "".join(chr(255 - ord(c)) for c in date) if date else chr(0)
+        # date. An absent date sorts LAST, matching the `weight` path above and
+        # Zola's treatment of an absent key: `chr(255)` is above every inverted
+        # date byte, since inverting a digit or a dash cannot exceed 210.
+        #
+        # This returned `chr(0)` until RUE-1485, which sorted an undated page
+        # FIRST and contradicted both this method's docstring and ADR-0072
+        # Decision 2. It was latent only because every post in the corpus is
+        # dated: the first undated one would have failed `check_membership` and
+        # stalled collection over an oracle bug rather than a tool bug.
+        return "".join(chr(255 - ord(c)) for c in date) if date else chr(255)
 
     def routes(self) -> dict[str, str]:
         return {rel: route_of(rel) for rel in self.pages}
@@ -740,6 +878,16 @@ def prepare_fixture(root: str, scale: int) -> dict:
     assemble_corpus(content, CORPUS_EXCLUSIONS)
     content_digest, content_files, content_bytes = tree_digest(content)
     duplicate_corpus(content, scale)
+    # The corpus AS BUILT, after duplication. The digest above identifies the
+    # corpus and is deliberately taken before the copies — a scale variant of an
+    # unchanged corpus should not look like a content change — but a record that
+    # reported 95 files for a 950-page build would be describing the wrong job
+    # to anyone reading the store, so both are carried.
+    scaled_files = 0
+    scaled_bytes = 0
+    for rel in walk_files(content):
+        scaled_files += 1
+        scaled_bytes += os.path.getsize(os.path.join(content, rel))
 
     shutil.copytree(os.path.join(REPO, "examples", "gazette", "templates"),
                     os.path.join(root, "templates"))
@@ -773,9 +921,32 @@ def prepare_fixture(root: str, scale: int) -> dict:
 
     identity = {
         "scale": scale,
+        # The ASSEMBLY RULES, not just the assembled bytes. `assemble_corpus`
+        # excludes two pages, strips `paginate_by`, lower-cases three file
+        # names, and rewrites the specification's internal links — decisions
+        # that change what all three tools consume and that no other field
+        # here can see, because the digests below are taken over the tree AFTER
+        # they have been applied. Without these two entries, editing an
+        # assembly rule would change the measured job while leaving the
+        # recorded identity untouched, and Decision 2's whole mechanism —
+        # a moved identity opens a new comparable segment — would not fire.
+        #
+        # The revision is the human-legible label; the digest is the
+        # authoritative one, since it cannot be forgotten. The digest is
+        # deliberately over-sensitive — editing a comment in this file opens a
+        # new segment — because the failure it prevents is silent and the
+        # failure it causes is a visible discontinuity in a series read for
+        # order of magnitude.
+        "preparer_revision": PREPARER_REVISION,
+        "preparer_digest": tree_digest(
+            os.path.dirname(os.path.abspath(__file__)),
+            [os.path.basename(os.path.abspath(__file__))],
+        )[0],
         "content_digest": content_digest,
         "content_files": content_files,
         "content_bytes": content_bytes,
+        "scaled_content_files": scaled_files,
+        "scaled_content_bytes": scaled_bytes,
         "static_digest": static_digest,
         "static_files": static_count,
         "static_bytes": static_bytes,
@@ -1304,6 +1475,873 @@ def golden_mode(options) -> int:
             shutil.rmtree(work, ignore_errors=True)
 
 
+# ===========================================================================
+# The cross-tool leg — ADR-0072 Phase 5 (RUE-1485)
+# ===========================================================================
+#
+# Three tools build the identical corpus and are judged against each other.
+# Everything in this section serves one of the three rules the comparison rests
+# on, and each is a rule an unfair benchmark would break quietly:
+#
+#   WORK EQUIVALENCE (Decision 4). Identical emitted file sets, per-tool
+#   determinism, page counts, non-empty pages, and a normalized semantic
+#   comparison of every page across all three tools. A peer that skipped work
+#   would beat gazette and fail here.
+#
+#   THREAD PARITY (Decision 5). Rue has no concurrency and hosted runners have
+#   four vCPUs, so the primary published ratio pins the peers to one worker
+#   thread. Their default parallel configuration is measured too and published
+#   as a clearly labelled secondary row — never hidden, never primary.
+#
+#   FAIRNESS OF CONFIGURATION (Decision 3). The peers are configured to skip
+#   the same work gazette skips, not less and not more. The parity configs are
+#   versioned beside the ports and hashed into the recorded fixture identity.
+
+# The pinned peers, as repository-root dotslash shims.
+PEERS = ("zola", "hugo")
+
+# Thread policies a peer is measured under. The FIRST is the primary published
+# ratio's denominator; the second is the secondary row.
+#
+# `RAYON_NUM_THREADS` is Zola's rendering pool; `GOMAXPROCS` is Hugo's
+# scheduler. Neither is a fairness fudge in gazette's favour — pinning the
+# peers to one thread makes the comparison per unit of work rather than per
+# core, and the four-way-parallel numbers are published beside it so the figure
+# a user would actually experience is never hidden.
+THREAD_POLICIES = ("pinned_single_thread", "tool_default_parallel")
+
+PEER_THREAD_ENV = {
+    "zola": {"pinned_single_thread": {"RAYON_NUM_THREADS": "1"},
+             "tool_default_parallel": {}},
+    "hugo": {"pinned_single_thread": {"GOMAXPROCS": "1"},
+             "tool_default_parallel": {}},
+}
+
+# The documented allowlist ADR-0072 Decision 4 requires for tool-mandated
+# differences in the emitted file set. It is deliberately as small as the tools
+# allow, because every entry is a place a tool could skip a page and hide
+# behind an excuse — so a difference that CAN be configured away is configured
+# away in the parity configs rather than allowed here. Three candidates were
+# removed that way and are named so the absence is legible rather than
+# accidental: Hugo's sitemap and robots.txt (`disableKinds`), Hugo's per-section
+# and site-wide feeds (`[outputs]`), and the feed FILENAME mapping the ADR
+# anticipated — `[outputFormats.rss] baseName` puts Hugo's feed at the same
+# route Zola's and gazette's occupy, so the routes themselves are compared.
+#
+# Static passthrough is the third difference the ADR names and needs no entry
+# either: all three tools copy the same `website/static` tree, and its bytes
+# are part of the recorded fixture identity.
+FILE_SET_ALLOWLIST = {
+    "zola": {
+        "404.html": (
+            "Zola always writes a 404 page, from a built-in template when the "
+            "site has none, and offers no switch to suppress it. Hugo emits "
+            "one only when a layout exists, and the Hugo port deliberately has "
+            "none, so this is the one difference no configuration can remove"
+        ),
+    },
+    "hugo": {},
+}
+
+
+def peer_binary(tool: str) -> str:
+    return os.path.join(REPO, tool)
+
+
+def peer_version(tool: str) -> str:
+    """The pinned peer's own version string, recorded with every observation."""
+    argv = [peer_binary(tool), "--version" if tool == "zola" else "version"]
+    result = subprocess.run(argv, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise SystemExit("could not read %s's version:\n%s" % (tool, result.stderr))
+    text = result.stdout.strip().splitlines()[0]
+    if tool == "zola":
+        return text.split()[-1]
+    # `hugo v0.152.2-6abdac… darwin/arm64 BuildDate=…`
+    return text.split()[1].split("-")[0].lstrip("v")
+
+
+# ---------------------------------------------------------------------------
+# Hugo's dialect of the same corpus
+# ---------------------------------------------------------------------------
+#
+# The corpus is written in Zola's dialect, so the Hugo leg needs it respelled:
+# Hugo cannot read `{{ rule(id="…") }}` or `@/path.md` any more than Zola could
+# read `{{< rule id="…" >}}`. The translation is mechanical, deterministic, and
+# happens at fixture-preparation time, outside every measured window.
+#
+# WHAT IT MAY NOT DO is the part worth stating. It respells calls; it never
+# performs them. `@/spec/03-types.md` becomes `{{< relref "/spec/03-types.md" >}}`
+# rather than a resolved URL, so Hugo still resolves the link itself; shortcode
+# invocations keep their arguments and are still expanded by Hugo's shortcode
+# machinery. Resolving either host-side would move measured work out of the
+# measured program, and no output check would notice, because the resolved page
+# looks the same either way.
+
+SHORTCODE_CALL = re.compile(r"\{\{\s*([a-z_]+)\((.*?)\)\s*\}\}", re.S)
+SHORTCODE_ARG = re.compile(r'([a-z_]+)\s*=\s*("[^"]*")')
+INTERNAL_LINK = re.compile(r"\]\(@/([^)\s]+)\)")
+
+
+def hugoize(corpus: str) -> None:
+    """Respell the corpus in Hugo's dialect, in place."""
+    for dirpath, _dirs, files in os.walk(corpus):
+        for name in sorted(files):
+            if not name.endswith(".md"):
+                continue
+            path = os.path.join(dirpath, name)
+            with open(path, encoding="utf-8") as handle:
+                text = handle.read()
+            found = FRONT_MATTER.match(text)
+            if not found:
+                raise SystemExit("%s does not open with a `+++` fence" % path)
+            front, body = found.group(1), text[found.end():]
+
+            added = []
+            # WHICH TEMPLATE RENDERS THIS PAGE, in Hugo's spelling. The corpus
+            # already tells Zola, in `template` and `page_template`; Hugo's
+            # equivalent is the page's type, and translating one into the other
+            # is the same kind of respelling as the shortcode syntax below.
+            #
+            # It is also load-bearing, which is why it is not left to Hugo's
+            # default. Hugo derives an untyped page's layout from its PATH, and
+            # ADR-0072 Decision 2's scale variants live under `xN-KK/` prefixes
+            # — so at 10x every copy of a specification page fell out of
+            # `layouts/spec/` and rendered through the plain page layout, with
+            # no sidebar at all: 17,940 bytes where gazette and Zola emit
+            # 22,443 and 22,630. Nine tenths of the corpus, with the most
+            # expensive template in the port skipped, while the file set and
+            # the page count stayed exactly right. Setting the type from the
+            # UNPREFIXED path makes a copy render as its original does.
+            section = unprefixed(
+                os.path.relpath(path, corpus).replace(os.sep, "/"))
+            if "/" in section:
+                added.append('type = "%s"' % section.split("/", 1)[0])
+            # Zola asks for a section feed with `generate_feeds`; Hugo asks for
+            # one by naming the section's output formats. Same feed, same
+            # route, each tool's own spelling.
+            if re.search(r"^generate_feeds = true", front, re.M):
+                added.append('outputs = ["html", "rss"]')
+            # Zola acts on `redirect_to` natively; Hugo selects a layout by
+            # name. The TARGET is still resolved by Hugo's template.
+            if re.search(r"^redirect_to = ", front, re.M):
+                added.append('layout = "redirect"')
+            # The corpus's root `_index.md` names the landing-page template
+            # explicitly, and Zola and gazette honour that key wherever the page
+            # sits. Hugo reserves its home layout for the site root, so a
+            # DUPLICATED root — `x10-00/_index.md`, one per copy at scale — is
+            # an ordinary section to it and rendered as one, dropping the hero,
+            # the specimen, and the recent-notes list the other two tools build.
+            # Naming the layout is the same translation as `redirect_to` above.
+            elif re.search(r'^template = "index\.html"', front, re.M):
+                added.append('layout = "landing"')
+
+            body = SHORTCODE_CALL.sub(
+                lambda match: "{{< %s %s >}}" % (
+                    match.group(1),
+                    " ".join("%s=%s" % pair
+                             for pair in SHORTCODE_ARG.findall(match.group(2)))),
+                body)
+            body = INTERNAL_LINK.sub(
+                lambda match: '](%s)' % ('{{< relref "/%s" >}}' % match.group(1)),
+                body)
+            # Zola's summary marker spelled Hugo's way.
+            body = body.replace("<!-- more -->", "<!--more-->")
+
+            # PREPENDED, not appended, and the difference is not cosmetic: TOML
+            # binds a bare key to the last table header above it, and the blog
+            # posts' front matter ends with an `[extra]` table. Appending put
+            # `type` inside it, where Hugo never looks, so every duplicated blog
+            # post silently rendered through the generic page layout — no
+            # byline, no title block. Top-level keys go above the first table.
+            trailer = "\n".join(added) + "\n" if added else ""
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write("+++\n" + trailer + front + "+++\n" + body)
+
+
+# ---------------------------------------------------------------------------
+# Preparing all three sites from one corpus
+# ---------------------------------------------------------------------------
+
+
+def prepare_peer_site(tool: str, root: str, corpus: str, static: str) -> str:
+    """Lay out one peer's site root beside gazette's, from the same corpus."""
+    site = os.path.join(root, tool)
+    os.makedirs(site)
+    shutil.copytree(corpus, os.path.join(site, "content"))
+    if tool == "zola":
+        shutil.copytree(os.path.join(REPO, "performance/ports/zola/templates"),
+                        os.path.join(site, "templates"))
+        shutil.copy(os.path.join(REPO, "performance/ports/zola/config.toml"),
+                    os.path.join(site, "config.toml"))
+    else:
+        shutil.copytree(os.path.join(REPO, "performance/ports/hugo/layouts"),
+                        os.path.join(site, "layouts"))
+        shutil.copy(os.path.join(REPO, "performance/ports/hugo/hugo.toml"),
+                    os.path.join(site, "hugo.toml"))
+        hugoize(os.path.join(site, "content"))
+    shutil.copytree(static, os.path.join(site, "static"))
+    return site
+
+
+def peer_command(tool: str, site: str, out: str, work: str) -> list[str]:
+    """The measured invocation, identical in shape for both peers.
+
+    Hugo's cache is pointed at a path inside this run's own work directory, so
+    nothing survives from a previous run or from a developer's home directory —
+    which is what would otherwise make the first sample of a run do work the
+    rest do not. It is shared BETWEEN this run's samples, and that is fine here
+    because it stays empty: nothing in the equivalence subset populates it, and
+    the emitted trees are byte-identical across samples, which is the property
+    the determinism check asserts. `--noBuildLock` keeps a lock left by a killed
+    sample from stalling the next one.
+    """
+    if tool == "zola":
+        # `--root` is Zola's global flag and has to precede the subcommand.
+        return [peer_binary("zola"), "--root", site, "build", "--output-dir", out]
+    return [peer_binary("hugo"),
+            "--source", site,
+            "--destination", out,
+            "--cacheDir", os.path.join(work, "hugo-cache"),
+            "--noBuildLock"]
+
+
+def run_process(argv: list[str], environment: dict) -> dict:
+    """One measured process, spawn to exit, with THIS child's peak RSS.
+
+    The same `wait4` reaping `run_build` documents, and the same function for
+    every tool on purpose: a comparison in which one tool's time came from a
+    different clock, or one tool's memory from a cumulative high-water mark,
+    would be measuring the harness rather than the tools.
+    """
+    start = time.perf_counter()
+    process = subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                               text=True, env={**os.environ, **environment})
+    stdout = process.stdout.read()
+    stderr = process.stderr.read()
+    _pid, status, usage = os.wait4(process.pid, 0)
+    wall = time.perf_counter() - start
+    process.returncode = os.waitstatus_to_exitcode(status)
+    process.stdout.close()
+    process.stderr.close()
+    return {
+        "wall_seconds": wall,
+        "peak_rss_bytes": rss_bytes(usage.ru_maxrss),
+        "exit_code": process.returncode,
+        "stdout": stdout,
+        "stderr": stderr,
+    }
+
+
+# ---------------------------------------------------------------------------
+# The cross-tool semantic oracle
+# ---------------------------------------------------------------------------
+
+SKIP_TEXT_IN = {"script", "style"}
+
+
+class Facets(html.parser.HTMLParser):
+    """The normalized extraction ADR-0072 Decision 4 compares across tools.
+
+    Exactly the facets the Decision names — the heading tree, visible text, and
+    link and image targets, in document order — and nothing else. What it
+    deliberately drops is what three different renderers and three different
+    template languages are entitled to disagree about: element structure, class
+    and id attributes, whitespace, and entity spelling.
+
+    That is a weaker comparison than the gazette-vs-Zola body oracle, which
+    compares the full event stream contiguously, and it is weaker for a stated
+    reason rather than a convenient one: Goldmark and pulldown-cmark do not
+    emit the same markup for the same Markdown, and requiring them to would
+    make the check fail on every page for a difference ADR-0072's Terminology
+    already calls a non-goal. What it still catches is every way a tool can do
+    LESS WORK: a dropped paragraph, a missing heading, an unexpanded shortcode,
+    an unresolved link, a page whose sidebar was not rendered for that page.
+    """
+
+    def __init__(self, route: str = "") -> None:
+        super().__init__(convert_charrefs=True)
+        self.route = route
+        self.headings: list = []
+        self.text: list = []
+        self.links: list = []
+        self._skip = 0
+        self._heading = None
+
+    def handle_starttag(self, tag, attrs):
+        fields = dict(attrs)
+        if tag in SKIP_TEXT_IN:
+            self._skip += 1
+        if tag in ("h1", "h2", "h3", "h4", "h5", "h6"):
+            self._heading = [tag, ""]
+        if tag == "a" and fields.get("href"):
+            self.links.append(normalize_target(fields["href"], self.route))
+        if tag == "img" and fields.get("src"):
+            self.links.append(normalize_target(fields["src"], self.route))
+
+    def handle_endtag(self, tag):
+        if tag in SKIP_TEXT_IN and self._skip:
+            self._skip -= 1
+        if tag in ("h1", "h2", "h3", "h4", "h5", "h6") and self._heading:
+            self.headings.append((self._heading[0], self._heading[1].strip()))
+            self._heading = None
+
+    def handle_data(self, data):
+        if self._skip:
+            return
+        squashed = " ".join(data.split())
+        if not squashed:
+            return
+        self.text.append(squashed)
+        if self._heading is not None:
+            self._heading[1] += " " + squashed
+
+
+def normalize_target(href: str, route: str = "") -> str:
+    """A link target in the one spelling every tool can be held to.
+
+    THE SAME DESTINATION, WRITTEN THREE WAYS, is not three destinations, and
+    the three tools genuinely write it three ways:
+
+      * Absolute or root-relative. Hugo's `absURL` and Zola's `get_url` do not
+        always agree about which to emit, and a browser cannot tell them apart.
+
+      * A bare fragment. The corpus writes `[Directives](#directives)`; Zola
+        resolves it against the page's own permalink and Hugo leaves it as
+        CommonMark wrote it. Both land on the same place.
+
+      * Relative. `[math](math/)` on the standard-library index resolves
+        against the page in every browser, and Zola resolves it at build time
+        while Hugo does not. This one is a KNOWN BROKEN LINK in the content, so
+        the interesting thing about it is that all three tools agree on which
+        dead route it names — which they only do once both are resolved.
+
+    Resolving here rather than allowing three spellings is what lets the
+    comparison stay a strict equality: a link that genuinely moved still fails.
+    """
+    target = href.strip()
+    if target.startswith(BASE_URL):
+        target = target[len(BASE_URL):] or "/"
+    if "://" in target.split("?", 1)[0].split("#", 1)[0] or target.startswith("mailto:"):
+        return target
+    if target.startswith("//"):
+        return target
+    if target.startswith("#"):
+        target = "/" + route + target
+    elif not target.startswith("/"):
+        target = "/" + route + target
+    fragment = ""
+    if "#" in target:
+        target, fragment = target.split("#", 1)
+        fragment = "#" + fragment
+    return target.rstrip("/") + "/" + fragment if target != "/" else "/" + fragment
+
+
+def facets(page: str, route: str = "") -> dict:
+    parser = Facets(route)
+    parser.feed(page)
+    return {
+        "headings": parser.headings,
+        "text": parser.text,
+        "links": parser.links,
+    }
+
+
+def compare_facets(reference: dict, other: dict, name: str, peer: str) -> list[str]:
+    faults = []
+    for facet in ("headings", "text", "links"):
+        want, have = reference[facet], other[facet]
+        if want == have:
+            continue
+        missing = [item for item in want if item not in have]
+        extra = [item for item in have if item not in want]
+        faults.append(
+            "%s: %s differs from gazette's (%d vs %d; %d missing, %d extra%s)"
+            % (name, facet, len(want), len(have), len(missing), len(extra),
+               "; first missing %r" % (missing[0],) if missing else ""))
+    return ["%s %s" % (peer, fault) for fault in faults]
+
+
+def cross_tool_check(gazette_out: str, peer_outs: dict, model: Model,
+                     scale: int) -> tuple[dict, list[str]]:
+    """Work equivalence across the three tools (ADR-0072 Decision 4)."""
+    faults: list[str] = []
+    report: dict = {}
+
+    emitted = {"gazette": set(walk_files(gazette_out))}
+    for tool, out in sorted(peer_outs.items()):
+        emitted[tool] = set(walk_files(out))
+
+    # 1. The emitted file sets, with the documented allowlist.
+    for tool, files in sorted(emitted.items()):
+        if tool == "gazette":
+            continue
+        allowed = FILE_SET_ALLOWLIST.get(tool, {})
+        extra = sorted(files - emitted["gazette"] - set(allowed))
+        absent = sorted(emitted["gazette"] - files)
+        unused = sorted(set(allowed) - files)
+        if extra:
+            faults.append("%s emits %d file(s) gazette does not, none of them "
+                          "allowlisted: %s" % (tool, len(extra), extra[:6]))
+        if absent:
+            faults.append("%s emits %d fewer file(s) than gazette: %s"
+                          % (tool, len(absent), absent[:6]))
+        for rel in unused:
+            faults.append(
+                "the file-set allowlist entry %s/%s no longer applies: the tool "
+                "stopped emitting it, so the entry is stale and must go" % (tool, rel))
+
+    # 2. Page counts and non-emptiness. A tool cannot win by writing stubs.
+    #
+    # The redirect stub is the one page that IS a stub in all three tools, by
+    # design and byte for byte, so it is named here rather than raising the
+    # threshold until nothing trips it.
+    stubs = {route_of(key) + "index.html" for key in model.redirects()}
+    pages = {}
+    for tool, files in sorted(emitted.items()):
+        out = gazette_out if tool == "gazette" else peer_outs[tool]
+        html_files = sorted(rel for rel in files if rel.endswith("index.html"))
+        pages[tool] = len(html_files)
+        empty = [rel for rel in html_files
+                 if rel not in stubs
+                 and os.path.getsize(os.path.join(out, rel)) < 512]
+        if empty:
+            faults.append("%s emitted %d page(s) under 512 bytes: %s"
+                          % (tool, len(empty), empty[:6]))
+    wanted_pages = len(model.pages) * 1
+    for tool, count in sorted(pages.items()):
+        if count != wanted_pages:
+            faults.append("%s emitted %d page(s); the corpus has %d"
+                          % (tool, count, wanted_pages))
+    report["pages"] = pages
+
+    # 3. The semantic oracle, across all three tools: every original page, plus
+    #    ONE COPY OF EACH at scale.
+    #
+    #    Comparing all 9,600 copies at 100x would buy nothing — they are the
+    #    same documents at other permalinks — but comparing NONE of them was a
+    #    blind spot with a defect already sitting in it. Hugo picks a page's
+    #    layout from its path unless told otherwise, so every duplicate fell
+    #    out of the specification layout and rendered without a sidebar: nine
+    #    tenths of the corpus, with the port's most expensive template skipped,
+    #    while the emitted file set and the page count stayed exactly right.
+    #    One copy of each page costs a second and closes the hole, and the
+    #    copies are byte-identical to each other so one is as good as all.
+    prefix = "" if scale == 1 else "x%d-00/" % scale
+    compared = 0
+    redirects = set(model.redirects())
+    for pass_prefix in ("",) if scale == 1 else ("", prefix):
+        for rel in sorted(model.pages):
+            if not rel.startswith(pass_prefix) or (
+                pass_prefix == "" and SCALE_PREFIX.match(rel)
+            ):
+                continue
+            if rel in redirects:
+                # A stub carries no page semantics; `check_redirects` asserts
+                # the thing that matters about it, which is its target.
+                continue
+            route = route_of(rel)
+            reference_path = os.path.join(gazette_out, route, "index.html")
+            if not os.path.exists(reference_path):
+                continue
+            reference = facets(open(reference_path, encoding="utf-8").read(), route)
+            for tool, out in sorted(peer_outs.items()):
+                path = os.path.join(out, route, "index.html")
+                if not os.path.exists(path):
+                    faults.append("%s emitted no page for %s" % (tool, rel))
+                    continue
+                faults += compare_facets(
+                    reference, facets(open(path, encoding="utf-8").read(), route), rel, tool)
+            compared += 1
+    report["oracle_pages"] = compared
+
+    # 4. The feed, across tools: same entries, same order, and the same fields
+    #    carried per entry.
+    #
+    #    The last of those is not fussiness. Zola's BUILT-IN feed — which it
+    #    falls back to when a site ships no `rss.xml` template, as this port
+    #    once did — renders every post's full rendered body into its
+    #    `<description>`, which is Markdown rendering and escaping that the
+    #    other two tools do not perform. Comparing `<link>` order alone said
+    #    the feeds agreed while one tool was doing twice the work, growing with
+    #    every post. So the emptiness PATTERN of the descriptions is compared
+    #    too: which entries carry one is a property of the corpus, and any tool
+    #    disagreeing about it is doing a different job.
+    for key in model.feeds():
+        route = route_of(key)
+        wanted = ["%s/%s" % (BASE_URL, route_of(rel)) for rel in model.members[key]]
+        shapes = {}
+        for tool, out in sorted({**peer_outs, "gazette": gazette_out}.items()):
+            path = os.path.join(out, route, "rss.xml")
+            if not os.path.exists(path):
+                faults.append("%s emitted no feed at %srss.xml" % (tool, route))
+                continue
+            feed = open(path, encoding="utf-8").read()
+            entries = [normalize_target(link)
+                       for link in re.findall(r"<link>([^<]*)</link>", feed)[1:]]
+            if entries != [normalize_target(link) for link in wanted]:
+                faults.append("%s feed order %s, expected %s"
+                              % (tool, entries[:3], wanted[:3]))
+            shapes[tool] = [bool(body.strip()) for body in
+                            re.findall(r"<description>(.*?)</description>", feed, re.S)[1:]]
+        if "gazette" in shapes:
+            for tool, shape in sorted(shapes.items()):
+                if tool != "gazette" and shape != shapes["gazette"]:
+                    faults.append(
+                        "%s's feed carries descriptions on %d of %d entries where "
+                        "gazette carries them on %d: one tool is rendering post "
+                        "bodies into the feed that the others are not"
+                        % (tool, sum(shape), len(shape), sum(shapes["gazette"])))
+    return report, faults
+
+
+# ---------------------------------------------------------------------------
+# Fixture preparation for the whole comparison
+# ---------------------------------------------------------------------------
+
+
+def prepare_comparison(root: str, scale: int, peers: bool) -> dict:
+    """Assemble every tool's site from one corpus and record the identity.
+
+    All of it is outside the measured window: assembly, duplication, the
+    peers' respelling, and the hashing. Only the builds that follow are timed.
+    """
+    identity = prepare_fixture(root, scale)
+    description = {
+        "identity": identity,
+        "scale": scale,
+        "roots": {"gazette": root},
+        "peer_versions": {},
+        "thread_policies": list(THREAD_POLICIES),
+    }
+    if not peers:
+        return description
+
+    corpus = os.path.join(root, "content")
+    static = os.path.join(root, "static")
+    for tool in PEERS:
+        description["roots"][tool] = prepare_peer_site(tool, root, corpus, static)
+        description["peer_versions"][tool] = peer_version(tool)
+    return description
+
+
+# ---------------------------------------------------------------------------
+# The per-run peer canary and the event-driven full peer leg (Decision 9)
+# ---------------------------------------------------------------------------
+#
+# The canary is one single-threaded Zola build of the 1x corpus, run beside
+# every gazette observation. It is cheap on this corpus and it is what gives
+# every observation a SAME-RUN ratio denominator, so no segment's ratio ever
+# leans on a stale or singleton peer sample.
+#
+# The full peer leg — Hugo, the scale variants, the default-parallel secondary
+# row — runs only on an event: the recorded fixture identity moved, a peer
+# version moved, or the runner epoch changed. `peer_event` is what the
+# collection job asks at fixture-preparation time, in the same run.
+
+CANARY_TOOL = "zola"
+CANARY_SCALE = 1
+
+
+def peer_event(description: dict, epoch: str, state_path: str | None) -> dict:
+    """Whether the full peer leg is due, and why."""
+    current = {
+        "fixture_digest": description["identity"]["fixture_digest"],
+        "peer_versions": description["peer_versions"],
+        "epoch": epoch,
+    }
+    previous = None
+    unreadable = ""
+    if state_path and os.path.exists(state_path):
+        try:
+            with open(state_path, encoding="utf-8") as handle:
+                previous = json.load(handle)
+        except (OSError, ValueError) as error:
+            # A half-restored Actions cache is a MISSING state, not a fatal
+            # one. Falling through costs one redundant peer leg; propagating
+            # would abort a whole collection run over a file whose only job is
+            # to save a minute.
+            previous = None
+            unreadable = " (%s could not be read: %s)" % (state_path, error)
+    if previous is None:
+        return {"due": True,
+                "reason": "no previous peer observation is recorded" + unreadable,
+                "state": current}
+    reasons = []
+    if previous.get("fixture_digest") != current["fixture_digest"]:
+        reasons.append("the recorded fixture identity moved")
+    if previous.get("peer_versions") != current["peer_versions"]:
+        reasons.append("a peer toolchain version moved (%s -> %s)"
+                       % (previous.get("peer_versions"), current["peer_versions"]))
+    if previous.get("epoch") != current["epoch"]:
+        reasons.append("the runner epoch changed (%s -> %s)"
+                       % (previous.get("epoch"), current["epoch"]))
+    return {"due": bool(reasons),
+            "reason": "; ".join(reasons) or
+                      "fixture identity, peer versions, and epoch are unchanged",
+            "state": current}
+
+
+# ---------------------------------------------------------------------------
+
+
+def peers_mode(options) -> int:
+    """Build the identical corpus with all three tools and judge the result."""
+    gazette = options.gazette or build_gazette()
+    work = tempfile.mkdtemp(prefix="gazette-peers-")
+    try:
+        root = os.path.join(work, "site")
+        os.makedirs(root)
+        description = prepare_comparison(root, options.scale, peers=True)
+        identity = description["identity"]
+        model = Model(os.path.join(root, "content"))
+
+        print("fixture identity (recorded with every observation, ADR-0072 Decision 2)")
+        for key in sorted(identity):
+            print("  %-16s %s" % (key, identity[key]))
+        print("peers (pinned; every observation records both versions)")
+        for tool in PEERS:
+            print("  %-16s %s" % (tool, description["peer_versions"][tool]))
+
+        measurements: dict = {}
+        digests: dict = {}
+        faults: list[str] = []
+
+        def measure(label, argv, environment, out_prefix):
+            samples = []
+            trees = []
+            for index in range(options.samples):
+                out = os.path.join(work, "%s-%d" % (out_prefix, index))
+                sample = run_process(argv(out), environment)
+                if sample["exit_code"] != 0:
+                    faults.append("%s build failed (exit %d): %s"
+                                  % (label, sample["exit_code"],
+                                     (sample["stdout"] + sample["stderr"])[-800:]))
+                    return None, None
+                samples.append(sample)
+                trees.append((out, tree_hash(out)))
+            hashes = {digest for _out, digest in trees}
+            if len(hashes) != 1:
+                faults.append(
+                    "%s is not deterministic: %d distinct output trees across %d "
+                    "samples. A port that emits a build timestamp — Hugo's feed "
+                    "`lastBuildDate` and `generator` are the known cases — fails "
+                    "exactly here." % (label, len(hashes), len(samples)))
+            measurements[label] = samples
+            digests[label] = sorted(hashes)[0]
+            return trees[0][0], samples
+
+        gazette_out, _ = measure(
+            "gazette",
+            lambda out: [gazette, "build", root, "-o", out],
+            {},
+            "gazette-out")
+
+        peer_outs = {}
+        for tool in PEERS:
+            for policy in THREAD_POLICIES:
+                if policy != THREAD_POLICIES[0] and not options.secondary:
+                    continue
+                label = "%s/%s" % (tool, policy)
+                out, _ = measure(
+                    label,
+                    lambda out, tool=tool: peer_command(
+                        tool, description["roots"][tool], out, work),
+                    PEER_THREAD_ENV[tool][policy],
+                    label.replace("/", "-") + "-out")
+                if policy == THREAD_POLICIES[0] and out is not None:
+                    peer_outs[tool] = out
+
+        # DIAGNOSTIC TIMINGS, never published. The published series is taken by
+        # `rue-bench runtime` on the pinned regime; these run wherever this
+        # script was invoked, usually beside a compiler build. Every sample is
+        # printed rather than only the median, because the first build of a run
+        # is cold — the binary was just compiled and the fixture just written —
+        # and a reader who cannot see that cannot discount it.
+        print("\nmeasurement (diagnostic only; fixture preparation and judging "
+              "are outside the window)")
+        for label in sorted(measurements):
+            samples = measurements[label]
+            times = [sample["wall_seconds"] for sample in samples]
+            rss = max(sample["peak_rss_bytes"] for sample in samples)
+            print("  %-32s median %.3fs  peak RSS %.1f MiB  samples %s"
+                  % (label, median(times), rss / (1024 * 1024),
+                     " ".join("%.3f" % value for value in times)))
+
+        if gazette_out is not None and len(peer_outs) == len(PEERS):
+            report, cross_faults = cross_tool_check(
+                gazette_out, peer_outs, model, options.scale)
+            faults += cross_faults
+            print("\nwork equivalence (ADR-0072 Decision 4)")
+            print("  page count:         %s" % report["pages"])
+            print("  semantic oracle:    %d page(s) compared across three tools"
+                  % report["oracle_pages"])
+            print("  file-set allowlist: %s"
+                  % ({tool: sorted(entries) for tool, entries in
+                      FILE_SET_ALLOWLIST.items() if entries}))
+        else:
+            faults.append("not every tool produced a build, so work equivalence "
+                          "could not be judged")
+
+        # The primary ratio, and the secondary row beside it rather than
+        # instead of it.
+        if "gazette" in measurements:
+            base = median([sample["wall_seconds"] for sample in measurements["gazette"]])
+            print("\nratios at scale %dx (gazette = 1.00) — DIAGNOSTIC, not the "
+                  "published comparison, which is derived from records taken on "
+                  "the pinned regime" % options.scale)
+            for label in sorted(measurements):
+                if label == "gazette":
+                    continue
+                other = median([sample["wall_seconds"] for sample in measurements[label]])
+                marker = "" if label.endswith(THREAD_POLICIES[0]) else "   [secondary]"
+                print("  %-32s %.2fx%s" % (label, other / base, marker))
+
+        for fault in faults[:20]:
+            print("  FAIL %s" % fault)
+        if len(faults) > 20:
+            print("  ... and %d more" % (len(faults) - 20))
+        print("\n%s" % ("FAILED" if faults else "OK"))
+
+        if options.out:
+            payload = {
+                "identity": identity,
+                "peer_versions": description["peer_versions"],
+                "scale": options.scale,
+                "output_digests": digests,
+                "measurements": {
+                    label: [{"wall_seconds": sample["wall_seconds"],
+                             "peak_rss_bytes": sample["peak_rss_bytes"]}
+                            for sample in samples]
+                    for label, samples in measurements.items()
+                },
+                "faults": faults,
+            }
+            with open(options.out, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2, sort_keys=True)
+        return 1 if faults else 0
+    finally:
+        if options.keep:
+            print("\nwork tree kept at %s" % work)
+        else:
+            shutil.rmtree(work, ignore_errors=True)
+
+
+def median(values: list[float]) -> float:
+    """The median, averaging the two middles — `rue_perf_schema::median`'s rule.
+
+    This took the UPPER of two middles until RUE-1485's review, and the
+    difference was not academic. Combined with the first sample of a run being
+    cold — the binary was just compiled and the fixture just written, so the
+    first build pays page-cache costs the rest do not — a two-sample run
+    reported the cold sample as its median. That is where this script's quoted
+    gazette figure of 0.44s came from against the harness's 0.246s on the same
+    machine: not `-O0`, not host speed, but a warm-up sample promoted to the
+    headline by a median that rounded the wrong way.
+
+    Two defences now: the convention matches the harness, and `peers` prints
+    every sample so a cold first one is visible rather than averaged into a
+    number nobody can question.
+    """
+    ordered = sorted(values)
+    middle = len(ordered) // 2
+    if len(ordered) % 2 == 1:
+        return ordered[middle]
+    return (ordered[middle - 1] + ordered[middle]) / 2
+
+
+# ---------------------------------------------------------------------------
+# The harness interface: prepare, judge, and the peer-event question
+# ---------------------------------------------------------------------------
+#
+# `rue-bench runtime` owns measurement — it starts the clock, reaps the child,
+# and writes the record — and calls these two modes for everything either side
+# of the measured window. ADR-0072 names this script the reference
+# implementation the harness mode should ADOPT rather than reinvent, and two
+# implementations of corpus assembly, routing, and validation would be two
+# implementations to disagree.
+
+
+def prepare_mode(options) -> int:
+    os.makedirs(options.root, exist_ok=True)
+    description = prepare_comparison(options.root, options.scale, options.peers)
+    description["commands"] = {
+        "gazette": {"argv": ["{program}", "build", options.root, "-o", "{out}"],
+                    "env": {}},
+    }
+    for tool in PEERS if options.peers else ():
+        for policy in THREAD_POLICIES:
+            description["commands"]["%s/%s" % (tool, policy)] = {
+                "argv": peer_command(tool, description["roots"][tool],
+                                     "{out}", options.root),
+                "env": PEER_THREAD_ENV[tool][policy],
+            }
+    description["canary"] = {"tool": CANARY_TOOL, "scale": CANARY_SCALE}
+    description["preparer_revision"] = PREPARER_REVISION
+    model = Model(os.path.join(options.root, "content"))
+    description["pages"] = len(model.pages)
+    if options.peer_state or options.peer_event_out:
+        event = peer_event(description, options.epoch, options.peer_state)
+        description["peer_event"] = event
+        if options.peer_event_out:
+            with open(options.peer_event_out, "w", encoding="utf-8") as handle:
+                json.dump(event, handle, indent=2, sort_keys=True)
+    with open(options.out, "w", encoding="utf-8") as handle:
+        json.dump(description, handle, indent=2, sort_keys=True)
+    print("prepared %dx fixture in %s (%d pages, fixture digest %s)"
+          % (options.scale, options.root, description["pages"],
+             description["identity"]["fixture_digest"][:12]))
+    return 0
+
+
+def judge_mode(options) -> int:
+    """Judge emitted output trees. Never times anything; never builds anything."""
+    root = options.root
+    model = Model(os.path.join(root, "content"))
+    failures: list[str] = []
+    out = options.gazette_out
+
+    emitted = set(walk_files(out))
+    expected = model.expected_files(walk_files(os.path.join(root, "static")))
+    if emitted != expected:
+        failures.append("file set differs: %d extra %s, %d missing %s"
+                        % (len(emitted - expected), sorted(emitted - expected)[:6],
+                           len(expected - emitted), sorted(expected - emitted)[:6]))
+    failures += check_membership(out, model)
+    failures += check_feeds(out, model)
+    failures += check_redirects(out, model)
+    failures += check_metadata(out, model)
+    _links, _excluded, _known, link_faults = check_links(out, model, options.scale)
+    failures += link_faults
+
+    peer_outs = {}
+    for tool in PEERS:
+        directory = getattr(options, "%s_out" % tool)
+        if directory:
+            peer_outs[tool] = directory
+    report = {}
+    if peer_outs:
+        report, cross_faults = cross_tool_check(out, peer_outs, model, options.scale)
+        failures += cross_faults
+
+    verdict = {
+        "verdict": "match" if not failures else "mismatch",
+        "detail": "; ".join(failures[:5]),
+        "failures": failures,
+        "output_digest": tree_hash(out),
+        "pages": len(model.pages),
+        "peers_judged": sorted(peer_outs),
+        "cross_tool": report,
+    }
+    if options.out:
+        with open(options.out, "w", encoding="utf-8") as handle:
+            json.dump(verdict, handle, indent=2, sort_keys=True)
+    print("%s: %d check failure(s)" % (verdict["verdict"], len(failures)))
+    for failure in failures[:20]:
+        print("  FAIL %s" % failure)
+    return 1 if failures else 0
+
+
 # ---------------------------------------------------------------------------
 
 
@@ -1437,11 +2475,50 @@ def main() -> int:
     golden.add_argument("--bless", action="store_true",
                         help="rewrite the committed goldens from this build")
 
+    peers = modes.add_parser(
+        "peers", help="RUE-1485's cross-tool comparison against Zola and Hugo")
+    peers.add_argument("--scale", type=int, default=1, choices=(1, 10, 100),
+                       help="corpus scale variant (ADR-0072 Decision 2)")
+    peers.add_argument("--samples", type=int, default=3,
+                       help="builds per tool; determinism needs at least two")
+    peers.add_argument("--no-secondary", dest="secondary", action="store_false",
+                       help="skip the peers' default-parallel secondary row")
+    peers.add_argument("--out", help="write the comparison as JSON")
+
+    prepare = modes.add_parser(
+        "prepare", help="assemble every tool's fixture and print its identity")
+    prepare.add_argument("--root", required=True, help="directory to build the fixture in")
+    prepare.add_argument("--scale", type=int, default=1, choices=(1, 10, 100))
+    prepare.add_argument("--out", required=True, help="where to write the description")
+    prepare.add_argument("--peers", action="store_true",
+                         help="also lay out the Zola and Hugo sites")
+    prepare.add_argument("--epoch", default="",
+                         help="the runner epoch, for the peer-event question")
+    prepare.add_argument("--peer-state",
+                         help="the previous peer run's recorded state, as JSON")
+    prepare.add_argument("--peer-event-out",
+                         help="write the peer-event answer as JSON")
+
+    judge = modes.add_parser(
+        "judge", help="judge emitted output trees; times nothing, builds nothing")
+    judge.add_argument("--root", required=True, help="the prepared fixture root")
+    judge.add_argument("--gazette-out", required=True, help="gazette's emitted tree")
+    judge.add_argument("--zola-out", help="Zola's emitted tree, when the peer leg ran")
+    judge.add_argument("--hugo-out", help="Hugo's emitted tree, when the peer leg ran")
+    judge.add_argument("--scale", type=int, default=1, choices=(1, 10, 100))
+    judge.add_argument("--out", help="write the verdict as JSON")
+
     options = parser.parse_args()
     if options.mode == "body":
         return body_mode(options)
     if options.mode == "golden":
         return golden_mode(options)
+    if options.mode == "peers":
+        return peers_mode(options)
+    if options.mode == "prepare":
+        return prepare_mode(options)
+    if options.mode == "judge":
+        return judge_mode(options)
     return site_mode(options)
 
 

--- a/website/static/runtime.js
+++ b/website/static/runtime.js
@@ -357,7 +357,7 @@
       drawWorkloads(points);
       drawChart(data, entries);
       drawSegments(entries);
-      drawComparison(runtime);
+      drawComparison();
       drawNotes();
       drawDisclosures(runtime, entries);
     }
@@ -814,15 +814,22 @@
     // inside the figure, so this function can only ever add rows to a table
     // that already carries them (ADR-0072 Decision 3).
     //
-    // Nothing populates it yet: the peer leg needs gazette, a pinned Hugo, and
-    // the parity configurations, none of which exist. When it does, its rows
-    // arrive as `runtime.comparison` and are rendered here — an empty or absent
-    // comparison renders as the honest empty state, never as an estimate.
-    function drawComparison(runtime) {
+    // The rows come from ONE run of the selected platform — the newest one that
+    // measured peers, which is not always the newest run, because peers are
+    // re-measured on events rather than on a clock. That is the honest table to
+    // publish: both sides of every ratio were measured on the same machine in
+    // the same job. An absent comparison renders as the empty state below,
+    // never as an estimate.
+    function drawComparison() {
       var figure = document.getElementById("rt-comparison");
       var body = document.getElementById("rt-comparison-rows");
       var emptyNote = document.getElementById("rt-comparison-empty");
-      var rows = (runtime.comparison && runtime.comparison.rows) || [];
+      var epochs = current().epochs || [];
+      var comparison = null;
+      for (var i = epochs.length - 1; i >= 0 && !comparison; i--) {
+        comparison = epochs[i].comparison;
+      }
+      var rows = (comparison && comparison.rows) || [];
       body.textContent = "";
       if (!rows.length) {
         figure.hidden = true;
@@ -833,8 +840,17 @@
       emptyNote.hidden = true;
       rows.forEach(function (entry) {
         var row = document.createElement("tr");
+        // The secondary label travels with the row rather than sitting in the
+        // caption: Decision 5 requires the peers' default parallel figures to
+        // be published and clearly labelled, and a caption claiming one thread
+        // policy for the whole table would be false the moment they are.
+        var label = entry.secondary
+          ? ' <span style="color:var(--color-muted);">(secondary)</span>' : "";
+        if (entry.joined) {
+          label += ' <span style="color:var(--color-muted);">(joined)</span>';
+        }
         row.innerHTML =
-          "<td>" + escapeHtml(entry.tool || "") + "</td>" +
+          "<td>" + escapeHtml(entry.tool || "") + label + "</td>" +
           "<td>" + escapeHtml(entry.scale || "") + "</td>" +
           "<td>" + escapeHtml(entry.threads || "") + "</td>" +
           '<td class="figure">' + fmtTime(entry.median_ns || 0) + "</td>" +
@@ -843,6 +859,23 @@
           "<td>" + escapeHtml(entry.version || "") + "</td>";
         body.appendChild(row);
       });
+      // Which rows were measured beside the Rue figure they divide, and which
+      // were joined from the last full peer leg. Peers re-measure on events,
+      // so most tables are a mixture, and the distinction is the difference
+      // between controlling for the machine and only controlling for the input.
+      var provenance = document.getElementById("rt-comparison-provenance");
+      if (provenance) {
+        var joined = rows.filter(function (entry) { return entry.joined; }).length;
+        var text = "Rue and the marked same-run peer were measured together at commit " +
+          shortHash(comparison.commit) + ", against fixture " + comparison.fixture + ".";
+        if (joined) {
+          text += " " + joined + " row" + (joined === 1 ? " was" : "s were") +
+            " joined from the most recent full peer run on the same fixture, which is " +
+            "why the peers are not re-measured on every commit; those rows control for " +
+            "the input but not for the machine.";
+        }
+        provenance.textContent = text;
+      }
     }
 
     // 6. Field notes: the annotated events ADR-0072 Decision 2 asks for.

--- a/website/templates/runtime.html
+++ b/website/templates/runtime.html
@@ -117,8 +117,8 @@
       </p>
       <p>
         The cross-segment signal ADR-0072 defines is the ratio of Rue's time to a
-        pinned peer tool's time on the same corpus. That needs the peer leg,
-        which is not collected yet — see below.
+        pinned peer tool's time on the same corpus, measured in the same run —
+        see the comparison below, and the caveats that travel with it.
       </p>
     </details>
     <figure style="margin-top: 0.75rem;">
@@ -214,6 +214,24 @@
           and pagination. The parity configurations are versioned in the
           repository beside the template ports.
         </p>
+        {#
+          The corpus modifications, disclosed here rather than only in the ADR
+          and the preparer's source. A reader told only about configuration
+          switches would reasonably assume the input was the site as it stands,
+          and one of these three is a place where Rue is the tool out of step.
+        #}
+        <p>
+          <strong>The corpus is modified before any tool sees it, identically
+          for all three.</strong> Two pages are removed — the performance and
+          runtime dashboards, whose templates read derived benchmark data, which
+          would make this benchmark an input to itself. The blog's
+          <code>paginate_by</code> key is stripped, because pagination is
+          outside the subset and only one tool would otherwise build a paginated
+          view. And three specification appendix filenames are lower-cased:
+          Zola and Hugo both route them the way the live site does, and gazette,
+          which does not slugify paths, is the tool out of step — so this one
+          hides a Rue gap rather than a peer quirk.
+        </p>
         <p>
           <strong>This compares a corpus-specialized Rue program against
           general-purpose tools.</strong> Gazette implements the subset of
@@ -223,13 +241,35 @@
           but a subset engine is structurally leaner than a general one, and no
           amount of validation removes that asymmetry.
         </p>
+        {#
+          The scale caveats live here, in the figure, for the same reason the
+          two captions above do: the rows are written by a script, and a table
+          with a 10x row in it must not be renderable without them. All three
+          are findings rather than hedges — the third was measured in Phase 4.
+        #}
+        <p>
+          <strong>The corpus-scale column is a page-count axis, not a
+          site-size one.</strong> The 10x rows build ten copies of the same
+          corpus under path prefixes, so per-page work scales while site shape
+          does not: internal links and section lookups still resolve into the
+          original tree, and cross-reference resolution stays constant.
+          A duplicated section also still redirects to the original target.
+          And the specification sidebar <em>collapses</em> on a duplicated page,
+          because a copy's permalink prefixes nothing in the original tree that
+          the section lookup returns — at 10x, 630 of 700 specification pages
+          render one 2,534-byte navigation where the 70 originals average 4,446.
+          A 10x row therefore understates per-page templating work relative to
+          1x, and cannot be read as "the 1x figure, times ten".
+        </p>
+        <p id="rt-comparison-provenance"></p>
       </figcaption>
     </figure>
     <p id="rt-comparison-empty" style="color: var(--color-muted); max-width: 42rem; margin-top: 0.75rem;">
-      No peer measurements have been collected yet. Gazette, the pinned Hugo
-      toolchain, and the parity configurations do not exist in the repository
-      yet; this table fills in when the cross-tool leg of collection first runs.
-      Nothing is estimated here in the meantime.
+      No peer measurements have been collected on this platform yet. The peer
+      leg runs when the recorded fixture identity, a pinned peer's version, or
+      the runner epoch changes, and the per-run canary rides every observation
+      after that; this table fills in with the first such run. Nothing is
+      estimated here in the meantime.
     </p>
 
     <h2 style="margin-top: 2.5rem;">Field notes</h2>


### PR DESCRIPTION
Closes RUE-1485.

ADR-0072 Phase 5: the first cross-language runtime comparison — gazette against pinned Zola and Hugo building the identical corpus, tool-vs-tool rather than translated microbenchmarks. Plus the runtime-schema generalization deferred from Phase 4, which is what lets gazette be a measured workload at all.

## Peers

Hugo is pinned as a `/hugo` dotslash shim, same shape as `zola` and `tailwindcss`, four platforms. **v0.152.2 rather than the newest release**: from v0.153.0 Hugo ships macOS only as a `.pkg`, which DotSlash cannot extract, and `aarch64-macos` is a row of the matrix. Plain rather than extended, since extended adds Sass and the equivalence subset excludes it.

Each tool builds the corpus with its own idiomatic templates — Tera for Zola, Go templates for Hugo, gazette's engine for Rue — in `performance/ports/`, hashed into the recorded fixture identity because the peer leg is event-driven on that identity.

## Parity was derived by measurement, not by reading documentation

Every config switch is paired in-file with the reason gazette does not do that work, and every observed difference was either configured away or driven into the corpus. Disabled in both peers: highlighting, search index, minification, Sass. Hugo additionally: sitemap, robots.txt, per-section and site feeds, typographer, linkify. Zola additionally: sitemap and robots.txt generation. Feed filename mapping is solved with `[outputFormats.rss] baseName`, so routes are compared rather than excused.

**The file-set allowlist has exactly one entry** — Zola's mandatory `404.html`. Everything else was configured away, which is a stronger check than an excuse. Verified by building all three trees: gazette 130 files, Hugo 130 identical, Zola 131.

Three normalizations are applied to the corpus itself, at fixture-prep time, to **all** tools: `paginate_by` stripped (pagination is an explicit ADR carve-out, and Zola alone emitted `blog/page/1/`), three upper-case filenames lower-cased, and two `load_data` pages excluded. These are disclosed on the published page, not only in source. `preparer_revision` and a digest of the preparer script are inside the recorded identity, so an assembly-rule change opens a new comparable segment rather than silently altering what all three tools consume.

The lower-casing deserves naming precisely: **gazette is the odd tool out.** Zola and Hugo both slugify as the production site does; gazette routes on the path as written. That is a Rue capability gap, and closing it in gazette is the real fix — the normalization is a stopgap, and the ADR, the script, and the config now say so.

## Work equivalence is enforced, and the enforcement was tested by breaking things

Deliberately broken ports were used to confirm the checks fire before any clean run was trusted: dropping `.Content` from Hugo's spec pages failed the oracle on 169 facets; disabling section kinds produced "hugo emits 15 fewer file(s)", "emitted 81 page(s); the corpus has 95", and a named missing section.

That apparatus then caught three real defects that timing alone would never surface:

- **Go's URL escaper** turned all 1,224 rule anchors into `#r-1.1%3a1`, making every one a dead link. Fixed in the shared shortcode with `safeURL`, not per instance.
- **`.PrevInSection`/`.NextInSection` are inverted** relative to Zola's `page.lower`/`page.higher`, so every spec page sent readers backwards. Fixed in the shared partial.
- **Hugo picks layouts by path**, so at scale every duplicated page fell out of `layouts/spec/` and rendered **with no sidebar** — 17,940 bytes against gazette's 22,443 and Zola's 22,630 — while the file set and page count stayed exactly right. Nine tenths of the corpus at 10x, with the port's most expensive template skipped. Found only because the oracle was widened to compare one copy of each page at scale rather than 1x alone. Fixed by translating Zola's `template` key into Hugo's `type`/`layout`.

That third one is the shape of failure this whole validation layer exists for: a peer doing measurably less work while every structural check stays green.

## Thread parity and the canary

`PeerThreadPolicy` lives in the epoch: the primary pins `RAYON_NUM_THREADS=1` and `GOMAXPROCS=1`, the secondary is tool-default, and validation refuses a manifest whose secondary repeats the primary or a canary taken under the non-primary policy. This is not decorative — measured, parallel peers are 2.0x to 2.3x faster, which is most of a published ratio.

A single-threaded Zola build of the workload's own corpus rides every observation as the same-run ratio denominator. A missing canary makes the workload *incomplete* — evidence kept, no ratio published — rather than unappendable.

The full peer leg is event-driven on fixture identity, peer versions, or epoch, detected at fixture-prep time. **The derive step joins** same-run rows from the newest run with the remaining peer configurations from the latest full leg, and only when fixture identity matches; joined rows are marked as such on the page. Without that join the table degraded to gazette-vs-Zola on the first canary-only push, losing Hugo and both default-parallel rows entirely — verified against a real two-run store, and now covered by tests for both the canary-after-full case and the identity-mismatch case.

## Schema generalization

`FixtureDeclaration` is now tagged: the existing `seeded_generator` shape plus a `corpus_tree` shape carrying scale and exclusion set. The single-file recorded-input rule is relaxed **for the corpus-tree shape alone** — a seeded record that borrows the corpus tree's leniency is refused, as are a zero-byte fixture, a zero vocabulary, a slash in `file_name`, a blank generator, and a seeded fixture paired with the new oracle kind. RUE-1046's crafted-record tests all still pass; that tightening was hard-won and is intact.

`OracleKind::SemanticSitePages` decides determinism and the verdict from a per-sample digest of the **emitted tree**. Gazette writes an output tree and prints nothing, so a stdout-reading oracle would have compared two empty streams and passed everything. An empty tree cannot pass.

Gazette and gazette_10x are registered under suite revision 2, epoch 2 per platform; epoch 1 is retired but kept declared so stored records stay valid, which was verified by deriving an epoch-1 record alongside two epoch-2 records with none rejected. 100x is deliberately out of the collected suite as Decision 9's cost valve.

## No ratio is published yet

Local diagnostic medians on `aarch64-macos` are gazette 0.248s, Zola 0.191s, Hugo 0.165s — Rue roughly 1.3x slower than Zola and 1.5x slower than Hugo, the same order of magnitude, which is the question ADR-0072 set out to answer. They are labelled diagnostic and a hosted-runner record is what the published table will use.

An earlier revision quoted gazette at 0.44s. That was a cold first sample promoted by a median that returned the upper of two middles at `--samples 2`, so the warm-up *was* the median. The first build of a run pays page-cache costs for the freshly compiled binary and freshly written fixture; the peers run afterwards and were unaffected, which is why only gazette's figure moved. `median()` now matches `rue_perf_schema::median`, and every sample is printed.

`build_gazette()` also compiled at `-O0` where Decision 5 requires release quality. The manifest always pinned `-O3`; the reference script did not. Measured difference on this workload was null, but the number was not taken under the contract's rule.

## Verification

`scripts/rue unit perf-schema` 203 passed · `scripts/rue unit bench` 121 passed · `scripts/rue quick` 31 targets · `gazette-corpus-diff.py` in `body`, `site`, `golden`, and `peers` modes at 1x and 10x under both thread policies · two full end-to-end harness runs into a store with derive · `rue-oracle-diff` 0 disagreements · clippy and fmt-check clean · all six workflow validators pass.

Not verified: CI on hosted runners — the peer-state cache, `--peer-state-dir`, and the premerge `peers` lane ran only in local equivalents. The end-to-end collection was local with the runner label declared so the full validation path executed; the record was discarded. Linux peer behaviour is untested on that hardware, though the peers are pinned prebuilt binaries and the shim resolves all four platforms.
