### PR TITLE
RUE-1491: close the unclosed rue fence in 09-destructors.md

### DIFF
--- a/docs/spec/src/03-types/09-destructors.md
+++ b/docs/spec/src/03-types/09-destructors.md
@@ -337,3 +337,4 @@ fn main() -> i32 {
     0
 }
 // prints: 100, 2, 1  (values drop in reverse declaration order at scope exit)
+```


### PR DESCRIPTION
Closes RUE-1491.

`docs/spec/src/03-types/09-destructors.md` had 21 fence markers — an odd
number. The `3.9:43` example opened a ```rue block at line 323 and never
closed it, so everything from there to end of file was inside a code block.

CommonMark §4.5 closes an open fenced block at end of input, so both Zola
(via pulldown-cmark) and gazette already rendered the page correctly. The
defect is latent rather than visible: any prose appended to this page would
have silently become code, with no error from any tool.

## Where the fence closes

At end of file, after `// prints: 100, 2, 1 …`. That comment belongs inside
the snippet, not after it — the sibling example `3.9:40` uses the same
convention, with its `// prints:` line inside the fence. Closing before the
comment would have changed the rendered page; closing at end of file
preserves it.

## Verification

- Fence count is now even (22).
- Rendered HTML is byte-identical before and after, built with the
  repository's pinned Zola 0.21.0 against the real site templates. This
  confirms the change is inert on the live site.
- `scripts/rue spec 3.9` — 52 passed.
- `./buck2 test //:spec-traceability` — pass; coverage report unchanged.
  `crates/rue-spec/src/traceability.rs` has no code-block state tracking, so
  fence state cannot affect traceability in either direction — which is also
  why this gate was never going to catch the open fence.

## Sweep

The issue asked for a check for the same defect elsewhere in
`docs/spec/src/`. A CommonMark-aware scan — backtick and tilde fences, up to
three spaces of indentation, closing-fence length, character, and
info-string rules — reports 71 files with one unclosed fence before this
change and none after. `09-destructors.md` was the only affected file.
