### PR TITLE
RUE-1492: point the std index math link at its real route

### DIFF
--- a/docs/designs/0072-runtime-benchmarking-static-site-generator.md
+++ b/docs/designs/0072-runtime-benchmarking-static-site-generator.md
@@ -761,8 +761,8 @@ because each changes what a later reader should expect.
   stream.** Goldmark and pulldown-cmark do not emit the same markup for the
   same Markdown, so the three-way comparison is the heading tree, visible text,
   and link and image targets, with link targets resolved to one spelling —
-  Zola resolves a bare `#fragment` and a relative `math/` against the page and
-  Hugo leaves both as written. That is weaker than the gazette-vs-Zola body
+  Zola resolves a bare `#fragment` and a relative `01-math/` against the page
+  and Hugo leaves both as written. That is weaker than the gazette-vs-Zola body
   oracle, which stays as it was, and it still catches every way a tool can do
   less work. It caught two real port defects: Hugo's URL escaping turned every
   one of the corpus's 1,224 rule anchors into a link to a target that does not

--- a/scripts/gazette-corpus-diff.py
+++ b/scripts/gazette-corpus-diff.py
@@ -206,13 +206,13 @@ CORPUS_EXCLUSIONS = {
 # convention. So the check fails two ways: an entry that stops appearing is
 # stale and must go, and an entry that starts appearing MORE is new breakage
 # hiding behind an old excuse.
-KNOWN_BROKEN_LINKS = {
-    "std/math/": (
-        1,
-        "the standard-library index links `math/` relative to `/std/`, but the "
-        "page is `01-math.md` and so routes to `/std/01-math/`",
-    ),
-}
+#
+# The table is empty, and staying empty is the point rather than an accident of
+# there being nothing to say. Its one entry was `std/math/` — the standard-
+# library index linked `math/` relative to `/std/`, but the page is
+# `01-math.md` and routes to `/std/01-math/` — and RUE-1492 fixed the content
+# instead, so the entry went stale by its own rule and was removed with the fix.
+KNOWN_BROKEN_LINKS = {}
 
 # Links per page into the two excluded pages: the desktop navigation bar names
 # both, and the mobile menu names both again. Asserted rather than printed, for
@@ -1810,11 +1810,16 @@ def normalize_target(href: str, route: str = "") -> str:
         resolves it against the page's own permalink and Hugo leaves it as
         CommonMark wrote it. Both land on the same place.
 
-      * Relative. `[math](math/)` on the standard-library index resolves
+      * Relative. `[math](01-math/)` on the standard-library index resolves
         against the page in every browser, and Zola resolves it at build time
-        while Hugo does not. This one is a KNOWN BROKEN LINK in the content, so
-        the interesting thing about it is that all three tools agree on which
-        dead route it names — which they only do once both are resolved.
+        while Hugo does not. It is the corpus's ONLY page-relative destination
+        — the `../…` ones are parent-relative and every tool leaves those as
+        authored — so it is the single case that makes this bullet load-
+        bearing rather than hypothetical. Until RUE-1492 it read `math/` and
+        named a route no tool emits, and what the comparison showed then was
+        that all three agreed on the dead route; what it shows now is that all
+        three agree on the live one. Either way the agreement only exists once
+        both spellings are resolved, which is this function's job.
 
     Resolving here rather than allowing three spellings is what lets the
     comparison stay a strict equality: a link that genuinely moved still fails.

--- a/website/content/std/_index.md
+++ b/website/content/std/_index.md
@@ -51,7 +51,7 @@ pub const math = @import("math.rue");
 
 | Module | Description |
 |--------|-------------|
-| [`math`](math/) | Mathematical functions: `abs`, `min`, `max`, `clamp` |
+| [`math`](01-math/) | Mathematical functions: `abs`, `min`, `max`, `clamp` |
 
 ## Future Modules
 


### PR DESCRIPTION
Closes RUE-1492.

`website/content/std/_index.md` linked `math/` relative to `/std/`, but the
page is `01-math.md` and Zola routes it to `/std/01-math/`, so the link was
dead on the live site.

The route was confirmed against rendered output rather than inferred from the
filename: pinned Zola 0.21.0 does not strip a numeric filename prefix, there
is no `slugify`/`path`/`slug` override in `website/config.toml` or the page's
front matter, and the emitted tree is `public/std/01-math/`.

## The link stays page-relative, deliberately

Zola's internal `@/std/01-math.md` spelling resolves to the same href and
would additionally fail the build if the target moved — a real benefit. It
was not used, because `math/` is the corpus's **only** page-relative
destination. The other six relative destinations are parent-relative `../…`,
which every tool leaves as authored, and every template emits absolute or
root-relative hrefs. Respelling this one would take the page-relative count
to zero.

That is the single form where the three generators genuinely disagree — Zola
and gazette resolve it at build time, Hugo leaves it as authored — and
reconciling that disagreement is work ADR-0072 Decision 4 names explicitly.
The case is verified still live end to end: for this link Hugo emits
`href="01-math/"` where Zola emits `href="https://rue-lang.dev/std/01-math/"`,
and the peers oracle reconciles them through `normalize_target`.

## Prose corrected alongside

- `KNOWN_BROKEN_LINKS` carried this link. The table's own rule is that an
  entry which stops appearing is stale and must go, so leaving it would have
  failed the check — and suppressing a link that is no longer broken is the
  weakening that rule exists to prevent. The table stays in place, empty, with
  its mechanism and history recorded.
- `normalize_target`'s docstring used this link as its worked example of a
  relative destination and called it a known broken link, which it no longer
  is.
- ADR-0072 Decision 4 named `math/` as its literal example and now names
  `01-math/`.

## Sweep

A sweep of the assembled corpus — website content plus the copied
specification, 4,677 internal links across 100 pages, resolving
base-URL-absolute, root-relative, and page-relative hrefs, with fragments
checked against the ids the target pages carry — found no other route of this
shape.

It did find one unrelated dead link, `/designs/adr-0062`, emitted by
`website/templates/shortcodes/preview_feature.html` for a site section that
does not exist. That is a different defect class needing a content-architecture
decision, and it is tracked separately in Linear rather than fixed here.

## Verification

`scripts/gazette-corpus-diff.py` passes in all four modes against the changed
corpus:

- `site --samples 2` — 130/130 file set, semantic oracle 94 pages vs Zola,
  `0 known-broken in the corpus`
- `peers --samples 2 --no-secondary` (the required CI lane) — page count
  `{'gazette': 95, 'hugo': 95, 'zola': 95}`, oracle 94 pages across three tools
- `golden` — 15 files
- `body` — 96 pages, 0 unexplained differences

The whole-site output digest is byte-identical between the `@/` and relative
spellings, confirming the choice is a coverage decision rather than an output
one.
