### PR TITLE
RUE-1499: accept ADR-0072

### DIFF
--- a/docs/designs/0072-runtime-benchmarking-static-site-generator.md
+++ b/docs/designs/0072-runtime-benchmarking-static-site-generator.md
@@ -1,11 +1,11 @@
 ---
 id: 0072
 title: "Runtime performance benchmarking anchored by a Rue static site generator"
-status: proposal
+status: accepted
 tags: [performance, benchmarking, process, examples, stdlib]
 feature-flag: null
 created: 2026-08-13
-accepted:
+accepted: 2026-08-13
 implemented:
 spec-sections: []
 superseded-by:
@@ -16,7 +16,8 @@ relates: ["RUE-487", "RUE-945", "RUE-1045", "RUE-1046", "RUE-1047", "RUE-1049", 
 
 ## Status
 
-Proposal. This ADR is the design document requested by RUE-1045 and defines the
+Accepted 2026-08-13, with Phases 1 through 5 landed and Phase 6 open. This ADR
+is the design document requested by RUE-1045 and defines the
 Runtime performance benchmarking project as a whole. It deliberately narrows
 that project's first concrete deliverable to one realistic workload — a static
 site generator written in Rue — compared tool-vs-tool against Zola and Hugo.

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -234,5 +234,5 @@ The table is generated from ADR frontmatter. Run
 | [0069](0069-ci-work-scheduling.md) | CI work scheduling for a compiler monorepo | Accepted | process, ci, testing, build, performance |
 | [0070](0070-rue-program-build-actions.md) | Rue program compilation as declared Buck actions | Accepted | build, ci, testing, tooling |
 | [0071](0071-release-quality-compiler-performance-contract.md) | Release-quality compiler performance contract | Accepted | architecture, compiler, performance, process |
-| [0072](0072-runtime-benchmarking-static-site-generator.md) | Runtime performance benchmarking anchored by a Rue static site generator | Proposal | performance, benchmarking, process, examples, stdlib |
+| [0072](0072-runtime-benchmarking-static-site-generator.md) | Runtime performance benchmarking anchored by a Rue static site generator | Accepted | performance, benchmarking, process, examples, stdlib |
 <!-- ADR-INDEX:END -->


### PR DESCRIPTION
Phases 1 through 5 of ADR-0072 have landed. `performance/runtime.toml` epoch 2 collects on every trunk push across all three platform rows, and required CI runs the gazette goldens and the cross-tool work-equivalence check on every pull request. The ADR governing all of it still read `status: proposal` — "under discussion, not yet approved", per the lifecycle table in `docs/designs/README.md`. ADR-0071 was marked accepted the same way, with its phases still in flight.

This change:

- sets `status: accepted` and `accepted: 2026-08-13` in the frontmatter;
- rewrites the Status section's opening line to say which phases have landed;
- regenerates the README index row with `scripts/validate-adrs.py --write`.

The status stops at accepted. Phase 6 is still open — the runtime page has no side-by-side gazette source and template port panel yet (RUE-1495).

Documentation only; no behaviour change. `scripts/validate-adrs.py` passes with 73 records.

Closes RUE-1499