### PR TITLE
RUE-1489: collapse the boundary digest predicate onto the shared rule

### DIFF
--- a/crates/rue-perf-schema/src/boundary.rs
+++ b/crates/rue-perf-schema/src/boundary.rs
@@ -8,6 +8,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::CompilerWork;
+use crate::sanity::is_sha256_digest;
 
 /// The complete product boundary measured by one compiler process.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -510,7 +511,7 @@ impl BuildBoundaryEvidence {
     ) -> Result<(), String> {
         policy.validate()?;
         let runner = &self.runner;
-        if !is_sha256(&runner.compiler_binary_sha256) {
+        if !is_sha256_digest(&runner.compiler_binary_sha256) {
             return Err("runner reported an invalid compiler binary SHA-256".to_string());
         }
         if !runner.fresh_state_directory || !runner.fresh_output_directory {
@@ -529,7 +530,7 @@ impl BuildBoundaryEvidence {
                 "compiler did not exit successfully with verified native output".to_string(),
             );
         }
-        if !is_sha256(&runner.output_sha256) {
+        if !is_sha256_digest(&runner.output_sha256) {
             return Err("runner reported an invalid output SHA-256".to_string());
         }
         if runner.output_size_bytes == 0 {
@@ -588,7 +589,7 @@ impl BuildBoundaryEvidence {
                 compiler.artifact_hits
             ));
         }
-        if !is_sha256(&compiler.emitted_output_sha256)
+        if !is_sha256_digest(&compiler.emitted_output_sha256)
             || compiler.emitted_output_sha256 != runner.output_sha256
             || compiler.emitted_output_size_bytes != runner.output_size_bytes
         {
@@ -604,7 +605,7 @@ impl BuildBoundaryEvidence {
                     input.class
                 ));
             }
-            if input.logical_identity.is_empty() || !is_sha256(&input.sha256) {
+            if input.logical_identity.is_empty() || !is_sha256_digest(&input.sha256) {
                 return Err("compiler reported malformed input provenance".to_string());
             }
             let identity = (&input.class, input.logical_identity.as_str());
@@ -867,10 +868,6 @@ impl BuildBoundaryEvidence {
         }
         Ok(())
     }
-}
-
-fn is_sha256(value: &str) -> bool {
-    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 #[cfg(test)]
@@ -1309,6 +1306,69 @@ mod tests {
                 .validate_against(&policy, "x86-64-linux")
                 .is_err()
         );
+    }
+
+    #[test]
+    fn every_boundary_digest_answers_to_the_one_digest_spelling() {
+        // Uppercase hexadecimal is a well-formed SHA-256; it is a *second*
+        // spelling of one, and two spellings give one measured artifact two
+        // content addresses. Boundary evidence is what a sample's admissibility
+        // is decided on, so the boundary must not be the one place a second
+        // spelling can enter a store that cannot delete it.
+        let policy = BuildBoundaryPolicy::fresh_source_to_native_v1(WorkerSetting::One);
+
+        let mut binary = evidence();
+        binary.runner.compiler_binary_sha256 =
+            binary.runner.compiler_binary_sha256.to_ascii_uppercase();
+        assert_eq!(
+            binary
+                .validate_against(&policy, "x86-64-linux")
+                .unwrap_err(),
+            "runner reported an invalid compiler binary SHA-256"
+        );
+
+        // Runner and compiler still name the same output as each other here, so
+        // the spelling is the only thing left to reject.
+        let mut output = evidence();
+        output.runner.output_sha256 = output.runner.output_sha256.to_ascii_uppercase();
+        output.compiler.emitted_output_sha256 =
+            output.compiler.emitted_output_sha256.to_ascii_uppercase();
+        assert_eq!(
+            output
+                .validate_against(&policy, "x86-64-linux")
+                .unwrap_err(),
+            "runner reported an invalid output SHA-256"
+        );
+
+        // This case pins the mismatch branch rather than the spelling one. The
+        // two share an error, and the runner's own digest is untouched and
+        // still lowercase, so a respelled compiler digest is caught as a
+        // disagreement whichever predicate is in force. It is here because the
+        // field is one of the four, not because it can tell the rules apart.
+        let mut emitted = evidence();
+        emitted.compiler.emitted_output_sha256 =
+            emitted.compiler.emitted_output_sha256.to_ascii_uppercase();
+        assert_eq!(
+            emitted
+                .validate_against(&policy, "x86-64-linux")
+                .unwrap_err(),
+            "compiler and runner output evidence disagrees"
+        );
+
+        let mut input = evidence();
+        input.compiler.accepted_inputs[0].sha256 = input.compiler.accepted_inputs[0]
+            .sha256
+            .to_ascii_uppercase();
+        assert_eq!(
+            input.validate_against(&policy, "x86-64-linux").unwrap_err(),
+            "compiler reported malformed input provenance"
+        );
+
+        // The lowercase spelling the compiler and runner actually emit is the
+        // one that passes; the fixture is otherwise unchanged.
+        evidence()
+            .validate_against(&policy, "x86-64-linux")
+            .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Closes RUE-1489.

`crates/rue-perf-schema/src/sanity.rs` decides once, for every record kind,
what a measurement is — including digest spelling. A fourth copy of the
SHA-256 predicate remained in `boundary.rs` and accepted uppercase hex where
the shared `is_sha256_digest` requires lowercase. Two predicates disagreed
silently and neither explained itself.

The local `fn is_sha256` is deleted and all four boundary digest fields now
answer to the shared rule: `runner.compiler_binary_sha256`,
`runner.output_sha256`, `compiler.emitted_output_sha256`, and
`input.sha256`. The len-40 commit-revision predicates are a different rule
and are deliberately untouched.

## Why this needed evidence rather than reasoning

This tightens ADR-0067's compiler-evidence validation, and the tightening is
**retroactive**. `rue-bench derive` (`crates/rue-bench/src/derive.rs:487`)
re-runs `validate_run` over every stored record at every dashboard build, so
a stricter predicate re-judges the entire append-only store — and a record
that newly fails is not a loud failure. It lands in `rejected` and drops out
of its series, visible only as a counter.

So the bar was to prove no stored record moves:

- **Emission sites.** Every producer formats with `{:x}`:
  `crates/rue-bench/src/digest.rs:15,45` (feeding `measure.rs:268,348,361`)
  and `crates/rue/src/main.rs:934,993,1044`. A repository-wide search for
  `{:X}`, `encode_upper`, and `to_uppercase` on these paths returns nothing.
  The collection workflow builds the compiler from the repository at the
  measured commit, so there is no third-party producer.
- **The durable store.** `performance-data-v1` at `b7562a44`, confirmed
  against `git ls-remote upstream` rather than a local ref: 1,058 JSON files,
  1,066,849 sixty-four-character hex literals, **zero** containing an
  uppercase character. A structured scan deliberately broader than the four
  guarded fields — every key whose name contains `sha256`, `digest`, or
  `hash` — finds no digest-shaped value anywhere in the store that the
  tightened rule rejects.
- **The repository.** 8,186 files, 8,767 hex literals, zero uppercase. No
  checked-in fixture or golden record breaks.
- **End to end.** `rue-bench derive` over the whole store, built before and
  after the change, reports `derived 1026 point(s) across 3 platform(s); 0
  run(s) rejected` both times, and the derived dashboard JSON is
  byte-identical.
- **A real collection**, per the issue's acceptance bar: 18 fresh-process
  proofs carrying 552 digests, all lowercase, validating as appendable.

## Test coverage

`every_boundary_digest_answers_to_the_one_digest_spelling` uppercases each of
the four fields in turn and asserts the exact rejection, plus an unchanged
fixture that still passes. Three of the four assertions fail if the old
predicate is restored. The fourth — a respelled `emitted_output_sha256` —
cannot distinguish the two rules, because the runner's own digest is
untouched and the mismatch and spelling branches share an error; the test
says so at that case rather than implying coverage it does not have.

## Verification

`scripts/rue unit perf-schema` 204 passed · `scripts/rue unit bench` 121
passed, 2 ignored · `scripts/rue quick` 31/31 · `scripts/rue fmt` applied.
