### PR TITLE
RUE-1495: add the side-by-side gazette source and template-port panel

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -17,6 +17,12 @@ on:
       # cases, so a case or a rule marker changes the published board even
       # though no file under website/ moved.
       - 'crates/rue-spec/**'
+      # The runtime page cuts its side-by-side port excerpts out of the gazette
+      # and peer sources when the site is built, so an edit to either one
+      # changes the published page with no file under website/ moving. The peer
+      # ports are already covered by the performance/** entry above.
+      - 'examples/gazette/**'
+      - 'scripts/extract-source-excerpts.py'
       - 'scripts/generate-site-status.py'
       - '.github/workflows/deploy-website.yml'
   # PRs still build (no deploy — that's trunk-only) on spec changes too, so a
@@ -31,6 +37,12 @@ on:
       # cases, so a case or a rule marker changes the published board even
       # though no file under website/ moved.
       - 'crates/rue-spec/**'
+      # The runtime page cuts its side-by-side port excerpts out of the gazette
+      # and peer sources when the site is built, so an edit to either one
+      # changes the published page with no file under website/ moving. The peer
+      # ports are already covered by the performance/** entry above.
+      - 'examples/gazette/**'
+      - 'scripts/extract-source-excerpts.py'
       - 'scripts/generate-site-status.py'
       - '.github/workflows/deploy-website.yml'
   # The dashboard's other input is the `performance-data-v1` branch, which is

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,11 @@ __pycache__/
 # with the observations it came from, and the stored copy is the one that would
 # be believed.
 website/static/performance-data.json
+
+# Cut from the checked-in gazette and peer-port sources at site build time
+# (ADR-0072 Decision 8). Never committed, for the same reason: a stored copy
+# could disagree with the ports the benchmark actually runs, and the stored copy
+# is the one the page would publish. It lives beside `config.toml` rather than
+# under `static/`, because `static/` is inside the recorded fixture identity and
+# a derived file there would move the identity on every build.
+website/source-excerpts.json

--- a/BUCK
+++ b/BUCK
@@ -982,6 +982,23 @@ rue_sh_test(
     },
 )
 
+# RUE-1495: the runtime page publishes excerpts of the template ports the
+# benchmark actually runs, so the property worth a test is that a declaration
+# which has stopped describing its source FAILS rather than rendering something
+# else — a wrong excerpt looks exactly like a right one. The last two cases run
+# against the real ports in the tree, so the shipped declarations are checked
+# here rather than only when the site is built.
+rue_sh_test(
+    name = "source-excerpt-tool-tests",
+    test = "scripts/test-extract-source-excerpts.py",
+    resources = [
+        "scripts/extract-source-excerpts.py",
+    ],
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+    },
+)
+
 # RUE-1194: the §11 tooltip needs a commit's subject and its distance from the
 # previous measurement, neither of which a run object carries. The ordinal
 # follows trunk's first parents, so these tests pin the one property that makes

--- a/docs/designs/0072-runtime-benchmarking-static-site-generator.md
+++ b/docs/designs/0072-runtime-benchmarking-static-site-generator.md
@@ -9,16 +9,16 @@ accepted: 2026-08-13
 implemented:
 spec-sections: []
 superseded-by:
-relates: ["RUE-487", "RUE-945", "RUE-1045", "RUE-1046", "RUE-1047", "RUE-1049", "RUE-1481", "RUE-1482", "RUE-1483", "RUE-1484", "RUE-1485", "RUE-1488", "ADR-0006", "ADR-0057", "ADR-0067", "ADR-0068", "ADR-0070", "ADR-0071"]
+relates: ["RUE-487", "RUE-945", "RUE-1045", "RUE-1046", "RUE-1047", "RUE-1049", "RUE-1481", "RUE-1482", "RUE-1483", "RUE-1484", "RUE-1485", "RUE-1488", "RUE-1495", "ADR-0006", "ADR-0057", "ADR-0067", "ADR-0068", "ADR-0070", "ADR-0071"]
 ---
 
 # ADR-0072: Runtime performance benchmarking anchored by a Rue static site generator
 
 ## Status
 
-Accepted 2026-08-13, with Phases 1 through 5 landed and Phase 6 open. This ADR
-is the design document requested by RUE-1045 and defines the
-Runtime performance benchmarking project as a whole. It deliberately narrows
+Accepted 2026-08-13, with Phases 1 through 6 landed. This ADR is the design
+document requested by RUE-1045 and defines the Runtime performance
+benchmarking project as a whole. It deliberately narrows
 that project's first concrete deliverable to one realistic workload — a static
 site generator written in Rue — compared tool-vs-tool against Zola and Hugo.
 Other comparison programs, the microbenchmark tier, and per-benchmark peer
@@ -708,8 +708,8 @@ silently.
   and the scaling-curve rung** - RUE-1484
 - [x] **Phase 5: Cross-tool comparison — Hugo pin, parity configs, CI runs;
   and gazette's entry in `performance/runtime.toml`** - RUE-1485
-- [ ] **Phase 6: Website publication — comparison table, time series,
-  side-by-side source** - RUE-1049
+- [x] **Phase 6: Website publication — comparison table, time series,
+  side-by-side source** - RUE-1049, RUE-1495
 
 Phase 4 delivered gazette, the fixture preparation, the scale variants, the
 recorded identity, and the whole validation stack, but deliberately did NOT

--- a/scripts/extract-source-excerpts.py
+++ b/scripts/extract-source-excerpts.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Extract the runtime page's side-by-side source excerpts (ADR-0072 Decision 8).
+
+The runtime dashboard publishes a ratio between gazette and two general-purpose
+site generators, and Decision 8 asks it to show "side-by-side source and
+template excerpts" so that "a corpus-specialized Rue program against
+general-purpose tools" is something a reader can look at rather than only read
+in a caption. This script produces those excerpts, and `website/build.sh` runs
+it before Zola so the page renders them server-side.
+
+WHY EXTRACTION RATHER THAN A PASTE
+----------------------------------
+The ports are the benchmark's actual input. Every other claim on the page is
+guarded against drifting from them — the fixture identity digests the port
+trees, the spot goldens digest the production templates they derive from, and
+the cross-tool lane rebuilds the corpus with all three tools. A hand-pasted
+excerpt would be the one thing on that page with no such guard, and the way it
+would fail is the worst kind: it would keep rendering, keep looking right, and
+describe a port that no longer exists.
+
+WHY ANCHORS RATHER THAN MARKERS OR LINE RANGES
+----------------------------------------------
+Three mechanisms were available.
+
+A LINE-RANGE MANIFEST is rejected outright: inserting a line above a range
+silently slides it, so the page renders the wrong lines and nothing fails. That
+is exactly the failure this script exists to prevent.
+
+MARKER COMMENTS in the source files are robust, but they cannot be paid for
+here. `examples/gazette/templates`, `performance/ports/zola/templates`, and
+`performance/ports/hugo/layouts` are all inside `PORT_ROOTS` in
+`scripts/gazette-corpus-diff.py`, and that digest is part of the recorded
+fixture identity. Its comment is explicit that the sensitivity is deliberate:
+"editing a comment in this file opens a new segment". So adding a marker comment
+to a port template would end the current comparable stretch of the published
+series — a discontinuity in the measurements, bought with a presentation
+change. No excerpt is worth that.
+
+CONTENT ANCHORS are what is used. Each excerpt names a start and an end
+substring, each of which must match EXACTLY ONE line of the file. The excerpt is
+the lines between them, inclusive. Nothing is written into the sources, so no
+digest moves; and because the excerpt is always recomputed from the file's
+current bytes, the page cannot show stale text. What it can show is text whose
+framing moved, and that is what `must_contain` is for.
+
+HOW STALENESS FAILS
+-------------------
+Every one of these is a non-zero exit, and `website/build.sh` runs under
+`set -e`, so each one fails the site build rather than publishing a wrong or
+partial panel:
+
+  * a declared file does not exist;
+  * an anchor matches no line — the block was renamed, moved to another file,
+    or deleted;
+  * an anchor matches more than one line — it stopped being an anchor, so
+    which block it names is now ambiguous;
+  * the end anchor matches above the start anchor;
+  * a `must_contain` string is gone — the excerpt still extracts, but a claim
+    the page makes about it no longer holds. This is the guard against the one
+    failure anchors alone cannot catch: the block keeps its name and loses its
+    substance. Every entry below is a sentence the page actually says.
+
+The page reads the result through Zola's `load_data`, which is itself a hard
+error when the file is missing, so a site built without this step fails too.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# The excerpts the runtime page publishes.
+#
+# CHOICE OF SLICE. All four show one job: the recursive specification sidebar.
+# It is the right slice for three reasons, and the alternatives were weighed
+# against them. It is where the work is — roughly 700 of the corpus's ~800
+# pages are specification pages, and the sidebar is re-rendered for every one of
+# them, because both the `active` class and the recursion are gated on a prefix
+# test against the CURRENT page's permalink. It is the one template all three
+# ports had to solve rather than transcribe, so the three genuinely correspond
+# and differ exactly where the languages do: a Tera macro recursing through
+# `self::`, a Go partial recursing through `partial`, and gazette's port of the
+# first. And it is where the subset shows: gazette has no `is` tests and no
+# arithmetic, so the same test is spelled as a filter and the macro's unused
+# `depth` parameter is gone.
+#
+# The blog byline was the other candidate and was rejected: gazette's dialect is
+# close enough to Tera that its listing template is byte-identical to the Zola
+# port's, so two of the three columns would have shown the same text.
+EXCERPTS = [
+    {
+        "id": "sidebar-gazette",
+        "tool": "gazette",
+        "language": "Tera subset",
+        "file": "examples/gazette/templates/spec/base.html",
+        "start": "{% macro render_nav(",
+        "end": "{% endmacro %}",
+        # The page says the prefix test is evaluated by the engine and that the
+        # recursion is gated on it. Both are the fairness constraint ADR-0072
+        # Decision 3 puts on this template, and both are visible right here.
+        "must_contain": [
+            "starts_with(prefix=",
+            "self::render_nav(",
+            "section.subsections | sort",
+        ],
+    },
+    {
+        "id": "sidebar-zola",
+        "tool": "Zola",
+        "language": "Tera",
+        "file": "performance/ports/zola/templates/spec/base.html",
+        "start": "{% macro render_nav(",
+        "end": "{% endmacro %}",
+        # `is starting_with` rather than the filter: the Zola port is the
+        # production template unchanged, which is the whole point of the leg.
+        "must_contain": [
+            "is starting_with(",
+            "self::render_nav(",
+            "section.subsections | sort",
+        ],
+    },
+    {
+        "id": "sidebar-hugo",
+        "tool": "Hugo",
+        "language": "Go text/template",
+        "file": "performance/ports/hugo/layouts/_partials/spec-nav.html",
+        "start": "$current := .current",
+        "end": "</ul>",
+        "must_contain": [
+            "strings.HasPrefix",
+            'partial "spec-nav.html"',
+            'sort .section.Sections "Path"',
+        ],
+    },
+    {
+        # The fourth excerpt is not a fourth port. It is the answer to the
+        # question the first three raise — the peers bring a general-purpose
+        # template engine, so what does gazette bring? — and it is the
+        # concrete form of "corpus-specialized": the filter chain ends in a
+        # diagnostic rather than a pass-through, so the engine implements the
+        # filters this corpus uses and refuses every other one.
+        "id": "engine-starts-with",
+        "tool": "gazette",
+        "language": "Rue",
+        "file": "examples/gazette/tmpl_eval.rue",
+        "start": "// Tera spells this as the test",
+        "end": 'fail(inout eng, line, "unknown filter", name);',
+        "must_contain": [
+            'equals_literal(name, "starts_with")',
+            "unknown filter",
+        ],
+    },
+]
+
+
+class ExcerptError(Exception):
+    """A declaration that no longer describes its source file."""
+
+
+def sole_line(lines: list[str], needle: str, role: str, path: str) -> int:
+    """The index of the one line containing `needle`, or an error.
+
+    Both "no match" and "several matches" are failures, and the second is the
+    less obvious one: an anchor that matches twice has stopped identifying a
+    block, and picking the first match would quietly publish whichever one
+    happened to sort earlier.
+    """
+    hits = [i for i, line in enumerate(lines) if needle in line]
+    if not hits:
+        raise ExcerptError(
+            "%s: no line contains the %s anchor %r. The block was renamed, "
+            "moved, or deleted; update the declaration in "
+            "scripts/extract-source-excerpts.py to name the block as it is now."
+            % (path, role, needle))
+    if len(hits) > 1:
+        raise ExcerptError(
+            "%s: the %s anchor %r matches %d lines (%s), so it no longer "
+            "identifies one block. Choose a substring unique to the block."
+            % (path, role, needle, len(hits),
+               ", ".join(str(i + 1) for i in hits)))
+    return hits[0]
+
+
+def dedent(lines: list[str]) -> list[str]:
+    """Drop the indentation the whole block shares.
+
+    A block lifted out of a function would otherwise render with its enclosing
+    indentation, which reads as a formatting mistake in a narrow column.
+    """
+    widths = [len(line) - len(line.lstrip()) for line in lines if line.strip()]
+    common = min(widths) if widths else 0
+    return [line[common:] if line.strip() else "" for line in lines]
+
+
+def extract(text: str, declaration: dict, path: str) -> dict:
+    lines = text.splitlines()
+    start = sole_line(lines, declaration["start"], "start", path)
+    end = sole_line(lines, declaration["end"], "end", path)
+    if end < start:
+        raise ExcerptError(
+            "%s: the end anchor %r is on line %d, above the start anchor %r on "
+            "line %d. The block was reordered; the declaration no longer "
+            "describes it."
+            % (path, declaration["end"], end + 1, declaration["start"], start + 1))
+
+    body = lines[start:end + 1]
+    while body and not body[-1].strip():
+        body.pop()
+    excerpt = "\n".join(dedent(body))
+
+    missing = [needle for needle in declaration.get("must_contain", [])
+               if needle not in excerpt]
+    if missing:
+        raise ExcerptError(
+            "%s: the excerpt %r no longer contains %s. The page states this as "
+            "a fact about the port; either the port changed and the runtime "
+            "page's caption must follow, or the declaration is naming the "
+            "wrong block."
+            % (path, declaration["id"],
+               ", ".join(repr(needle) for needle in missing)))
+
+    return {
+        "tool": declaration["tool"],
+        "language": declaration["language"],
+        "path": declaration["file"],
+        # Resolved rather than declared, so citing them on the page cannot go
+        # stale: they are wherever the anchors were found in this build.
+        "first_line": start + 1,
+        "last_line": end + 1,
+        "lines": len(body),
+        "text": excerpt,
+    }
+
+
+def build(repo: str, declarations: list[dict]) -> dict:
+    excerpts = {}
+    for declaration in declarations:
+        path = os.path.join(repo, declaration["file"])
+        if not os.path.exists(path):
+            raise ExcerptError(
+                "%s does not exist, but the runtime page publishes an excerpt "
+                "from it. Update scripts/extract-source-excerpts.py."
+                % declaration["file"])
+        with open(path, "r", encoding="utf-8") as handle:
+            text = handle.read()
+        excerpts[declaration["id"]] = extract(text, declaration, declaration["file"])
+    return {
+        "generator": "scripts/extract-source-excerpts.py",
+        "excerpts": excerpts,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=REPO,
+                        help="repository root the excerpt paths resolve against")
+    parser.add_argument("--out", required=True,
+                        help="JSON file the runtime template reads with load_data")
+    options = parser.parse_args()
+
+    try:
+        payload = build(options.repo, EXCERPTS)
+    except ExcerptError as failure:
+        sys.stderr.write("source excerpts: %s\n" % failure)
+        return 1
+
+    with open(options.out, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    print("  extracted %d source excerpt(s)" % len(payload["excerpts"]))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gazette-corpus-diff.py
+++ b/scripts/gazette-corpus-diff.py
@@ -151,16 +151,20 @@ PORT_ROOTS = [
 # what starts a new comparable segment in the series rather than shifting an
 # existing one under a reader.
 #
-# The digest below was re-pinned for RUE-1485, and the review it records went
-# this way: the change was to `runtime.html`, which is the template of a page
+# The digest below was re-pinned for RUE-1495, and the review it records went
+# this way: the change was again to `runtime.html`, the template of a page
 # EXCLUDED from the benchmark corpus, so no port template derives from it and
-# none should follow. It moved because the cross-tool table it renders now has
-# data to render and captions for the scale axis to carry. `PORT_REVISION`
-# advanced anyway, because the peer ports joined the identity in the same
-# change.
+# none should follow. It moved because that page gained the side-by-side source
+# panel ADR-0072 Decision 8 asks for. `PORT_REVISION` did NOT advance, which is
+# the difference from the entry this one replaces: RUE-1485 advanced it because
+# the peer ports joined the fixture identity in that same change, not because a
+# re-pin requires it. Advancing it here would move the recorded fixture identity
+# — opening a new comparable segment in the published series — to record a
+# presentation change no port followed, which is the cost the paragraph above
+# says the revision exists to buy deliberately.
 PRODUCTION_TEMPLATE_ROOT = "website/templates"
 PRODUCTION_TEMPLATE_DIGEST = (
-    "536f7c68bf169ca1e2d32c67f2118c05d988a071fd2712b485eae5056b6d3d83"
+    "42fba7bb7afa44ac63e3846e244fde959cea2fc21a80194b07fa238d8f7dd4e5"
 )
 
 # Pages Zola emits no rendered body for, so `body` mode has nothing to compare

--- a/scripts/test-extract-source-excerpts.py
+++ b/scripts/test-extract-source-excerpts.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Tests for the runtime page's source-excerpt extractor (RUE-1495).
+
+The property under test is the one the mechanism was chosen for: an excerpt
+declaration that has stopped describing its source file must FAIL, not render
+something else. A wrong excerpt on the runtime page is worse than no excerpt,
+because it looks exactly like a right one.
+
+The last two tests run against the real repository, so the declarations shipped
+in the extractor are checked against the ports as they stand rather than only
+against fixtures.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+SPEC = importlib.util.spec_from_file_location(
+    "extract_source_excerpts",
+    Path(__file__).resolve().parent / "extract-source-excerpts.py",
+)
+ex = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ex)
+
+REPO = Path(__file__).resolve().parent.parent
+
+SOURCE = "\n".join([
+    "{# a comment above the block #}",
+    "{% macro render_nav(section, current_path) %}",
+    "<ul>",
+    "    {% if current_path | starts_with(prefix=sub.permalink) %}",
+    "    {{ self::render_nav(section=sub) }}",
+    "    {% endif %}",
+    "</ul>",
+    "{% endmacro %}",
+    "",
+    "{# trailing content #}",
+])
+
+DECLARATION = {
+    "id": "sidebar",
+    "tool": "gazette",
+    "language": "Tera subset",
+    "file": "templates/spec/base.html",
+    "start": "{% macro render_nav(",
+    "end": "{% endmacro %}",
+    "must_contain": ["starts_with(prefix=", "self::render_nav("],
+}
+
+
+def declaration(**overrides) -> dict:
+    merged = dict(DECLARATION)
+    merged.update(overrides)
+    return merged
+
+
+def fails(source: str, decl: dict) -> str:
+    try:
+        ex.extract(source, decl, decl["file"])
+    except ex.ExcerptError as failure:
+        return str(failure)
+    raise AssertionError("expected an ExcerptError, got an excerpt")
+
+
+# ---- the happy path --------------------------------------------------------
+
+def test_the_block_between_the_anchors_is_extracted_inclusively() -> None:
+    excerpt = ex.extract(SOURCE, DECLARATION, DECLARATION["file"])
+    assert excerpt["text"].startswith("{% macro render_nav(")
+    assert excerpt["text"].endswith("{% endmacro %}")
+    assert "{# a comment above the block #}" not in excerpt["text"]
+    assert "{# trailing content #}" not in excerpt["text"]
+
+
+def test_the_cited_line_numbers_are_resolved_not_declared() -> None:
+    # The page cites where the excerpt lives. Citing a declared range would be
+    # the line-range manifest this mechanism exists to avoid, so the numbers
+    # come from where the anchors were actually found.
+    excerpt = ex.extract(SOURCE, DECLARATION, DECLARATION["file"])
+    assert excerpt["first_line"] == 2
+    assert excerpt["last_line"] == 8
+    assert excerpt["lines"] == 7
+
+    shifted = "\n".join(["{# one more line #}"] * 5 + [SOURCE])
+    moved = ex.extract(shifted, DECLARATION, DECLARATION["file"])
+    assert moved["first_line"] == 7
+    assert moved["text"] == excerpt["text"]
+
+
+def test_insertions_above_the_block_do_not_move_the_excerpt() -> None:
+    # The whole reason a line-range manifest was rejected.
+    shifted = "{# inserted #}\n{# inserted #}\n" + SOURCE
+    assert (ex.extract(shifted, DECLARATION, DECLARATION["file"])["text"]
+            == ex.extract(SOURCE, DECLARATION, DECLARATION["file"])["text"])
+
+
+def test_shared_indentation_is_dropped() -> None:
+    nested = "\n".join([
+        "fn eval_filter() {",
+        '    // Tera spells this as the test',
+        '    if equals_literal(name, "starts_with") {',
+        "        return true;",
+        "    }",
+        '    fail(inout eng, line, "unknown filter", name);',
+        "}",
+    ])
+    excerpt = ex.extract(nested, declaration(
+        start="// Tera spells this as the test",
+        end='fail(inout eng, line, "unknown filter", name);',
+        must_contain=["unknown filter"],
+    ), "tmpl_eval.rue")
+    assert excerpt["text"].startswith("// Tera spells")
+    # The block's own shared indent goes; the nesting inside it stays.
+    assert '\nif equals_literal(name, "starts_with") {\n' in excerpt["text"]
+    assert "\n    return true;\n" in excerpt["text"]
+
+
+# ---- staleness fails -------------------------------------------------------
+
+def test_a_renamed_block_fails() -> None:
+    renamed = SOURCE.replace("{% macro render_nav(", "{% macro render_sidebar(")
+    assert "no line contains the start anchor" in fails(renamed, DECLARATION)
+
+
+def test_an_ambiguous_anchor_fails() -> None:
+    # Two matches is a failure rather than a first-match win: the anchor has
+    # stopped naming one block, and silently choosing one would publish
+    # whichever happened to come first.
+    twice = SOURCE + "\n" + SOURCE
+    assert "matches 2 lines" in fails(twice, DECLARATION)
+
+
+def test_a_reordered_block_fails() -> None:
+    reordered = "\n".join([
+        "{% endmacro %}",
+        "{% macro render_nav(section, current_path) %}",
+    ])
+    assert "above the start anchor" in fails(reordered, DECLARATION)
+
+
+def test_losing_a_claimed_substring_fails() -> None:
+    # The guard anchors cannot provide: the block keeps its name and loses the
+    # thing the page says about it. Precomputing the prefix test outside the
+    # template is exactly the fairness break ADR-0072 Decision 3 forbids, and
+    # it would leave the excerpt extracting perfectly.
+    flattened = SOURCE.replace(
+        "{% if current_path | starts_with(prefix=sub.permalink) %}",
+        "{% if sub.active %}")
+    failure = fails(flattened, DECLARATION)
+    assert "no longer contains" in failure
+    assert "starts_with(prefix=" in failure
+
+
+def test_a_missing_file_fails() -> None:
+    try:
+        ex.build(str(REPO), [declaration(file="performance/ports/nowhere.html")])
+    except ex.ExcerptError as failure:
+        assert "does not exist" in str(failure)
+    else:
+        raise AssertionError("expected an ExcerptError for a missing file")
+
+
+# ---- the shipped declarations, against the real ports ----------------------
+
+def test_the_shipped_declarations_still_describe_the_real_sources() -> None:
+    payload = ex.build(str(REPO), ex.EXCERPTS)
+    assert set(payload["excerpts"]) == {
+        "sidebar-gazette", "sidebar-zola", "sidebar-hugo", "engine-starts-with"}
+    for excerpt in payload["excerpts"].values():
+        assert excerpt["lines"] > 0
+        assert excerpt["text"].strip()
+
+
+def test_the_three_sidebar_ports_are_three_different_texts() -> None:
+    # A panel whose columns agree would be making no point. Gazette's template
+    # dialect is a Tera subset, so this is a real risk: `blog-page.html` — the
+    # byline template — IS byte-identical between the gazette and Zola ports,
+    # which is why the sidebar was chosen instead.
+    #
+    # Distinctness alone is too weak a guard: three texts differing by one
+    # character would satisfy it while the panel silently stopped making its
+    # point. What the page claims is that the three say the prefix test three
+    # ways, so that is what is asserted.
+    payload = ex.build(str(REPO), ex.EXCERPTS)["excerpts"]
+    texts = [payload[name]["text"]
+             for name in ("sidebar-gazette", "sidebar-zola", "sidebar-hugo")]
+    assert len(set(texts)) == 3
+    for name, spelling in (
+        ("sidebar-gazette", "starts_with(prefix="),
+        ("sidebar-zola", "is starting_with("),
+        ("sidebar-hugo", "strings.HasPrefix"),
+    ):
+        assert spelling in payload[name]["text"], (
+            f"{name} no longer spells the prefix test as {spelling!r}; the "
+            "panel's claim that the three ports say it three ways is stale"
+        )
+
+
+def main() -> int:
+    tests = [value for name, value in sorted(globals().items()) if name.startswith("test_")]
+    for test in tests:
+        test()
+    print(f"ok: {len(tests)} test(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/website/build.sh
+++ b/website/build.sh
@@ -99,6 +99,20 @@ python3 "$ROOT/scripts/generate-site-status.py" \
     --performance-data "$ROOT/website/static/performance-data.json"
 rm -f "$TRACEABILITY_JSON"
 
+# Cut the runtime page's side-by-side source excerpts out of the checked-in
+# ports (ADR-0072 Decision 8).
+#
+# The ports are the benchmark's actual input, so an excerpt pasted into the
+# template would be the one claim on that page with nothing checking it — and it
+# would fail by continuing to render. This is deliberately not optional and not
+# guarded: the extractor exits non-zero when a declaration has stopped
+# describing its source file, and `set -e` turns that into a failed site build
+# rather than a page published with a stale port on it.
+echo "Extracting source excerpts..."
+python3 "$ROOT/scripts/extract-source-excerpts.py" \
+    --repo "$ROOT" \
+    --out "$ROOT/website/source-excerpts.json"
+
 # Build Tailwind CSS
 echo "Building Tailwind CSS..."
 cd website

--- a/website/templates/runtime.html
+++ b/website/templates/runtime.html
@@ -58,6 +58,49 @@
     #rt-root td.figure { font-variant-numeric: tabular-nums; }
     /* Wide tables scroll inside their own box rather than the page. */
     .rt-scroll { overflow-x: auto; }
+
+    /* The side-by-side ports. `minmax(0, 1fr)` rather than `1fr`, because a
+       grid track's automatic minimum is its content, and one 144-column
+       template line would otherwise push the other two columns off the page. */
+    #rt-source-ports { display: grid; gap: 1rem; grid-template-columns: 1fr; }
+    /* The grid stretches the figures to a common height and the box inside
+       grows to fill it, so the three captions sit on one line and the reader
+       is comparing ports rather than box heights. */
+    #rt-source-ports figure {
+      margin: 0; min-width: 0; display: flex; flex-direction: column;
+    }
+    #rt-source-ports .specimen { flex: 1; }
+    /* A path is one unbreakable token and these are long enough to run out of
+       a column and into its neighbour's caption. */
+    #rt-source-ports figcaption { overflow-wrap: anywhere; }
+    /* In the narrowest three-column case the tool name and the language would
+       otherwise collide on one line. */
+    #rt-source .specimen-head { flex-wrap: wrap; gap: 0.4rem 1rem; }
+    #rt-source .specimen pre {
+      /* Wrapped rather than scrolled, which is the opposite of the choice the
+         tables above make and for a reason that does not apply to them: three
+         columns cannot be scrolled in step, so a horizontal scrollbar would
+         hide a different part of each port. A reader comparing three ports
+         needs every line present at once more than the original line breaks. */
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      font-size: 0.72rem;
+      line-height: 1.55;
+      padding: 0.85rem 0.95rem;
+    }
+    @media (min-width: 60rem) {
+      #rt-source-ports { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    }
+    /* Wider than the reading measure, because three columns of source are not
+       prose and do not shrink to a prose column. Only the grid breaks out; the
+       captions around it stay on the page's measure, and below this width
+       nothing moves at all. */
+    @media (min-width: 82rem) {
+      #rt-source-ports {
+        width: min(82rem, calc(100vw - 4rem));
+        margin-left: calc(50% - min(41rem, calc(50vw - 2rem)));
+      }
+    }
   </style>
 
   <noscript>
@@ -331,6 +374,111 @@
       <p id="rt-empty-rejected-summary" style="color: #b45309; max-width: 42rem;"></p>
       <ul id="rt-empty-rejected-list" style="margin-top: 0.5rem; line-height: 1.7;"></ul>
     </div>
+  </div>
+
+  {#
+    The side-by-side ports (ADR-0072 Decision 8).
+
+    Outside `#rt-root` on purpose. Everything above this point is a measurement
+    and hides itself when there is none; this is the one part of the page that
+    is true before the first run and stays true after the last one, and it is
+    most worth reading exactly when the table above has nothing in it. It also
+    needs no script, so it survives the noscript path the charts do not.
+
+    The excerpts are cut from the checked-in files at build time by
+    `scripts/extract-source-excerpts.py`, which `website/build.sh` runs before
+    Zola. `load_data` is a hard error on a missing file and the extractor is a
+    hard error on a declaration that no longer describes its source, so the two
+    failure modes that matter — an excerpt that drifted from the port, and a
+    page built without extracting one — both fail the build instead of
+    publishing something that merely looks right.
+  #}
+  {% set source = load_data(path="source-excerpts.json", format="json") %}
+  <div id="rt-source" style="margin-top: 3rem;">
+    <h2>The ports, side by side</h2>
+    <p style="color: var(--color-muted); max-width: 42rem;">
+      The ratio above divides one tool's time by another's; this is what the two
+      sides are made of. All three excerpts render the specification sidebar,
+      which is where this corpus's work is — 71 of the roughly 96 pages the
+      tools build at 1x are specification pages, and both the <code>active</code>
+      class and the recursion are gated on a prefix test against the
+      <em>current</em> page's permalink, so at 1x the sidebar is a different
+      document on every page. That is a claim about the original corpus only:
+      as the caption above records, duplication collapses it, and at 10x most
+      specification pages share one navigation.
+    </p>
+    <p style="color: var(--color-muted); max-width: 42rem; margin-top: 0.75rem;">
+      The three say it differently, which is the other reason to put them side
+      by side. Zola runs the production template unchanged — that is what the
+      port is for. Gazette needs four substitutions to say the same thing in a
+      smaller dialect: it has no arithmetic, so the depth parameter goes, and
+      the prefix test is spelled as a filter rather than a test. Only Hugo
+      restates the recursion outright — Go templates have no macros, so what
+      Tera calls on itself as <code>self::render_nav</code> becomes a partial
+      invoking itself with a <code>dict</code>.
+    </p>
+    <p style="color: var(--color-muted); max-width: 42rem; margin-top: 0.75rem;">
+      Each excerpt is cut from the checked-in file when this page is built,
+      never pasted, and the line numbers below are wherever the block was found
+      in that build. Rename it, split it, or precompute the prefix test out of
+      it, and the extraction fails and this page does not build.
+    </p>
+
+    <div id="rt-source-ports" style="margin-top: 1rem;">
+      {% for id in ["sidebar-gazette", "sidebar-zola", "sidebar-hugo"] %}
+      {% set excerpt = source.excerpts | get(key=id) %}
+      <figure>
+        <div class="specimen">
+          <div class="specimen-head">
+            <span class="no">{{ excerpt.tool }}</span>
+            <span>{{ excerpt.language }}</span>
+          </div>
+          <pre><code>{{ excerpt.text }}</code></pre>
+        </div>
+        <figcaption class="specimen-caption">
+          <b>{{ excerpt.path }}</b>, lines {{ excerpt.first_line }}–{{ excerpt.last_line }}.
+        </figcaption>
+      </figure>
+      {% endfor %}
+    </div>
+
+    {#
+      The fourth excerpt answers the question the first three raise. Three
+      template ports look like three equivalent pieces of work; the asymmetry
+      the comparison table's caption declares is not in the templates at all,
+      it is in what reads them.
+    #}
+    <h3 style="margin-top: 2.5rem;">And what reads them</h3>
+    <p style="color: var(--color-muted); max-width: 42rem;">
+      Zola and Hugo each arrive with a general-purpose template engine. Gazette
+      arrives with this. The prefix test the sidebar gates on is spelled as a
+      filter because gazette's grammar has no <code>is</code> tests, and it runs
+      where Tera's and Go's do — inside the program being measured. Computing
+      the open branch outside the template would move measured work out of the
+      benchmark, and no output check would catch it: a flattened sidebar emits
+      the same links and the same visible text on every page.
+    </p>
+    <p style="color: var(--color-muted); max-width: 42rem; margin-top: 0.75rem;">
+      The last line is what <strong>corpus-specialized</strong> means, stated in
+      source rather than in a caption. The filter chain ends in a diagnostic:
+      gazette implements the filters this corpus uses and refuses every other
+      one, where Zola and Hugo implement all of theirs. That is the structural
+      asymmetry the comparison table above discloses, and this is the line it
+      refers to.
+    </p>
+    {% set engine = source.excerpts | get(key="engine-starts-with") %}
+    <figure style="margin-top: 1rem; max-width: 52rem;">
+      <div class="specimen">
+        <div class="specimen-head">
+          <span class="no">{{ engine.tool }}</span>
+          <span>{{ engine.language }}</span>
+        </div>
+        <pre><code>{{ engine.text }}</code></pre>
+      </div>
+      <figcaption class="specimen-caption">
+        <b>{{ engine.path }}</b>, lines {{ engine.first_line }}–{{ engine.last_line }}.
+      </figcaption>
+    </figure>
   </div>
 </section>
 


### PR DESCRIPTION
Closes RUE-1495.

ADR-0072 Decision 8 asks the runtime page to carry "side-by-side source and
template excerpts", and it was the one item in that Decision's list with no
element on the page — `runtime.html` had no excerpt block and `runtime.js`
rendered none. This adds the panel and ticks Phase 6, which was the last
unticked box.

## What the panel shows

All four excerpts render the specification sidebar. It is where this corpus's
work is — 71 of the roughly 96 pages built at 1x are specification pages — and
both the `active` class and the recursion are gated on a prefix test against
the current page's permalink, so at 1x the sidebar is a different document on
every page.

That page-dependence is a 1x claim and the panel says so. As the comparison
figure above it already records, duplication collapses the sidebar: at 10x
most specification pages share one navigation. The panel carries the caveat
rather than borrowing the 10x page count to make a stronger-sounding claim.

The three ports say the same thing differently, which is the other reason to
put them side by side:

- **Zola** runs the production template unchanged — that is what the port is
  for, and its own header says so.
- **gazette** needs four substitutions to say it in a smaller dialect: no
  arithmetic, so the depth parameter goes, and the prefix test is spelled as a
  filter rather than a test.
- **Hugo** restates the recursion outright. Go templates have no macros, so
  what Tera calls on itself as `self::render_nav` becomes a partial invoking
  itself with a `dict`.

A fourth excerpt shows the gazette engine arm that reads the filter, ending in
its `fail(…, "unknown filter", …)` — "corpus-specialized" stated in source
rather than in a caption.

## Excerpts are extracted, never pasted

`scripts/extract-source-excerpts.py` declares per excerpt a start and end
substring that must **each match exactly one line**, and `website/build.sh`
runs it before Zola into a gitignored `website/source-excerpts.json` that the
template reads with `load_data`. The rendered line numbers are wherever the
block was found in that build.

Line ranges were rejected because they slide silently when a line is inserted
above them — the exact failure this exists to prevent. Marker comments in the
sources were rejected for a sharper reason: all three template trees are
inside `PORT_ROOTS`, whose digest is part of the recorded fixture identity, so
writing a marker into a port would end the current comparable segment of the
published series to buy a presentation change.

Staleness fails the build rather than rendering wrong. Renaming the block,
making an anchor ambiguous, deleting the file, or precomputing the prefix test
out of a port each exit non-zero with a specific message, `build.sh` runs
under `set -e`, and `load_data` is itself a hard error — a JSON that is
present but missing one excerpt id fails too. There is no path that renders an
empty or partial panel.

`must_contain` entries guard what anchors cannot: each names a sentence the
page asserts, so precomputing a prefix test out of a port keeps the excerpt
extractable and still fails the build.

## Template pin

`PRODUCTION_TEMPLATE_DIGEST` is re-pinned, and the comment above it now
records this review in place of RUE-1485's. `PORT_REVISION` is deliberately
**not** advanced: `runtime.md` is in `CORPUS_EXCLUSIONS`, so no port template
derives from `runtime.html` and none should follow. RUE-1485 advanced the
revision alongside its re-pin because the peer ports joined the fixture
identity in that same change, not because re-pinning requires it. Advancing it
here would move the recorded fixture identity — opening a new comparable
segment — to record a presentation change no port followed.

## Verification

- `website/build.sh` — 82 pages, internal-link check green, "extracted 4
  source excerpt(s)"; panel renders at 1440, 1000, and 390 px in both themes,
  outside `#rt-root` so it needs no JS and shows on the current no-data page
- `scripts/gazette-corpus-diff.py golden` — OK, 15 files
- `scripts/validate-adrs.py` — ADR registry valid, 73 records
- extractor suite — 11 tests, including an assertion that each port still
  spells the prefix test its own way, verified to fail when pointed at the
  wrong spelling
- `scripts/rue quick` — 31 targets

`website/static/style.css` is deliberately not included. Tailwind regenerates
it on every build and emitted three utilities nothing references; that file
feeds `static_digest` and therefore the fixture identity, so committing it
would move the identity for dead CSS.
