### PR TITLE
RUE-1493: close the peer evidence and publication gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,10 +401,27 @@ jobs:
       # the numbers are already collected. Two samples per tool, because
       # determinism needs at least two; the peers' default-parallel row is
       # skipped because it answers a measurement question, not this one.
+      #
+      # AT 2x, NOT 1x (RUE-1493), and the reason is a defect this lane could not
+      # have seen. Hugo picks a page's layout from its PATH, so every copy under
+      # a scale prefix fell out of the specification layout and rendered with no
+      # sidebar — nine tenths of the corpus at 10x, the port's most expensive
+      # template skipped — while the emitted file set and the page count stayed
+      # exactly right. Only the 10x run found it, and required CI ran 1x alone,
+      # where nothing is duplicated and the question is never asked.
+      #
+      # The fixture is 2x rather than 10x because ADR-0072 Decision 9 makes CI
+      # cost a first-class constraint: 2x is the SMALLEST duplicated corpus, and
+      # duplication is the whole of what 1x cannot exercise. The comparison
+      # covers every original page and one copy of each, so it strictly includes
+      # what the 1x run checked and adds the duplicated layout, type, and feed
+      # selection on top, for roughly twice the build work rather than ten
+      # times. 2x is deliberately not a rung of the published curve and never
+      # enters `performance/runtime.toml`; it exists to be checked, not plotted.
       - name: Check cross-tool work equivalence against pinned Zola and Hugo
         run: >-
           scripts/ci-timed "gazette peers" --
-          scripts/gazette-corpus-diff.py peers --samples 2 --no-secondary
+          scripts/gazette-corpus-diff.py peers --samples 2 --no-secondary --scale 2
 
       - name: Run explicit cross-backend compilation and encoding coverage
         # Both the x86-64 and AArch64 encoders are host-independent Rust tests.

--- a/crates/rue-bench/src/derive.rs
+++ b/crates/rue-bench/src/derive.rs
@@ -21,9 +21,10 @@ use std::path::Path;
 
 use rue_perf_schema::{
     Band, Completeness, FIXTURE_INPUT_NAME, Manifest, Metric, PeerRole, PeerThreadPolicy,
-    RunObject, RuntimeCompleteness, RuntimeManifest, RuntimeMetric, StoredRun, StoredRuntimeReport,
-    Summary, flags_movement, geometric_mean, median_absolute_deviation, ratio, sample_value,
-    summarize, validate_run, validate_runtime_report,
+    RunObject, RuntimeCompleteness, RuntimeManifest, RuntimeMetric, RuntimeValidationOutcome,
+    StoredRun, StoredRuntimeReport, Summary, flags_movement, geometric_mean,
+    median_absolute_deviation, ratio, sample_value, summarize, validate_run,
+    validate_runtime_report,
 };
 use serde::Serialize;
 
@@ -214,6 +215,57 @@ pub struct RuntimePointData {
     pub complete: bool,
     /// Per-workload figures, keyed by workload id.
     pub workloads: BTreeMap<String, RuntimeWorkloadPoint>,
+    /// What went wrong during the run, whether or not it stopped the report
+    /// entering the series.
+    ///
+    /// The record has carried these since Phase 1 and nothing read them. That
+    /// was survivable while every failure either sank the report — where the
+    /// reason surfaces under `rejected` — or lost the canary, which shows as an
+    /// unpublished point. RUE-1493 added a third kind: a peer row refused for
+    /// work equivalence is dropped from a report that stays complete and
+    /// publishable, so without this the row would simply be absent from the
+    /// table with nothing anywhere saying why.
+    pub failures: Vec<RuntimeFailureNote>,
+}
+
+/// One thing that went wrong during a run, as the page renders it.
+#[derive(Debug, Serialize)]
+pub struct RuntimeFailureNote {
+    /// Which kind of failure, in the record's own vocabulary.
+    pub kind: String,
+    /// The workload it belongs to.
+    pub workload: String,
+    /// The evidence the runner recorded.
+    pub detail: String,
+}
+
+impl RuntimeFailureNote {
+    fn of(failure: &rue_perf_schema::RuntimeFailure) -> RuntimeFailureNote {
+        use rue_perf_schema::RuntimeFailure;
+        let (kind, detail) = match failure {
+            RuntimeFailure::CompileFailed { detail, .. } => ("compile_failed", detail.clone()),
+            RuntimeFailure::FixturePreparationFailed { detail, .. } => {
+                ("fixture_preparation_failed", detail.clone())
+            }
+            RuntimeFailure::ProgramCrashed {
+                sample_index,
+                detail,
+                ..
+            } => (
+                "program_crashed",
+                format!("sample {sample_index}: {detail}"),
+            ),
+            RuntimeFailure::WrongOutput { detail, .. } => ("wrong_output", detail.clone()),
+            RuntimeFailure::ValidationRejected { detail, .. } => {
+                ("validation_rejected", detail.clone())
+            }
+        };
+        RuntimeFailureNote {
+            kind: kind.to_string(),
+            workload: failure.workload().to_string(),
+            detail,
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -943,6 +995,7 @@ fn derive_runtime_epoch(
             finished_at: identity.finished_at.clone(),
             complete: matches!(outcome.completeness, RuntimeCompleteness::Complete),
             workloads,
+            failures: report.failures.iter().map(RuntimeFailureNote::of).collect(),
         });
     }
 
@@ -1002,50 +1055,66 @@ fn derive_runtime_epoch(
 ///     same job on the same machine. This is the same-run denominator Decision
 ///     9 exists to provide.
 ///   * Every other peer configuration is JOINED from the latest run that
-///     carried a full peer leg, and only when its fixture identity matches the
-///     newest run's for that workload. A matching identity means the two runs
-///     built literally the same input, which is what makes the join meaningful;
-///     a differing one means the peer leg is due and has not run, and stale
-///     rows are dropped rather than published against a corpus they never saw.
+///     carried a full peer leg, and only when both recorded identities match
+///     the newest run's for that workload. Matching WORKLOAD identities mean
+///     the two runs built literally the same input; matching COMPARISON
+///     identities mean they configured the peers the same way, down to the peer
+///     ports and the versions they were pinned at. A differing one of either
+///     means the peer leg is due and has not run, and stale rows are dropped
+///     rather than published against a corpus or a pin they never saw.
+///
+/// TWO RULES ABOUT THE NEWEST RUN, both of which this got wrong before RUE-1493
+/// and both of which decide whether a published ratio is evidence:
+///
+///   * The table is built from the newest run's PUBLISHABLE observations, not
+///     from its appendable ones. A report missing its required canary is
+///     deliberately appendable-but-partial — the evidence is kept and no point
+///     publishes — and a report with a truncated Rue observation is suppressed
+///     by `derive_runtime_epoch` for the same reason. Publishing a ratio from
+///     either would route around both decisions.
+///   * If the newest run has no publishable peer observation, the answer is the
+///     empty state, not an older table. Reaching back would show a comparison
+///     that reads as current, dated by an older commit that a reader has no
+///     reason to notice, while the thing it actually says — this run has no
+///     valid denominator — goes unsaid.
 fn latest_comparison(
     manifest: &RuntimeManifest,
     stored: &[&StoredRuntimeReport],
 ) -> Option<RuntimeComparison> {
-    let mut appendable: Vec<&&StoredRuntimeReport> = stored
+    let mut appendable: Vec<(&&StoredRuntimeReport, RuntimeValidationOutcome)> = stored
         .iter()
-        .filter(|report| validate_runtime_report(manifest, report.record()).is_appendable())
+        .map(|report| (report, validate_runtime_report(manifest, report.record())))
+        .filter(|(_, outcome)| outcome.is_appendable())
         .collect();
-    appendable.sort_by(|left, right| {
+    appendable.sort_by(|(left, _), (right, _)| {
         left.record()
             .identity
             .finished_at
             .cmp(&right.record().identity.finished_at)
+            .then_with(|| left.address().cmp(right.address()))
     });
 
-    let base = appendable
-        .iter()
-        .rev()
-        .find(|report| {
-            report
-                .record()
-                .workloads
-                .iter()
-                .any(|observation| !observation.peers.is_empty())
-        })
-        .copied();
-    let full = appendable
-        .iter()
-        .rev()
-        .find(|report| {
-            report.record().workloads.iter().any(|observation| {
-                observation
+    // Publishable, per workload: an observation that publishes no median has no
+    // ratio either, and the numerator of every row here is that median.
+    fn carries_publishable_full_leg(
+        report: &StoredRuntimeReport,
+        outcome: &RuntimeValidationOutcome,
+    ) -> bool {
+        report.record().workloads.iter().any(|observation| {
+            outcome.publishes_workload(&observation.workload)
+                && observation
                     .peers
                     .iter()
                     .any(|peer| peer.role == PeerRole::Full)
-            })
         })
-        .copied();
-    let base = base.or(full)?;
+    }
+
+    let (base, base_outcome) = appendable.last()?;
+    let base = *base;
+    let full = appendable
+        .iter()
+        .rev()
+        .find(|(report, outcome)| carries_publishable_full_leg(report, outcome));
 
     let mut rows: Vec<RuntimeComparisonRow> = Vec::new();
     let mut fixture = String::new();
@@ -1053,6 +1122,7 @@ fn latest_comparison(
         .record()
         .workloads
         .iter()
+        .filter(|observation| base_outcome.publishes_workload(&observation.workload))
         .filter(|observation| !observation.peers.is_empty())
         .collect();
     // Ascending by the scale the peers built, so the table reads as a
@@ -1075,6 +1145,7 @@ fn latest_comparison(
             .map(|peer| peer.scale)
             .unwrap_or_default();
         let identity = fixture_identity(observation);
+        let comparison = comparison_identity(observation);
         if fixture.is_empty() {
             fixture = short_digest(&identity);
         }
@@ -1146,10 +1217,21 @@ fn latest_comparison(
             &mut seen,
         );
 
-        if let Some(full) = full
-            && !std::ptr::eq(*full, *base)
+        // BOTH identities, and the second is the one RUE-1493 added. Matching
+        // workload identities say the two runs built the same input; they say
+        // nothing about the peers, because the workload identity deliberately
+        // no longer moves when a peer port does. The comparison identity is
+        // what covers the peer ports and the peer versions, so without it a
+        // bumped peer whose full leg failed would go on being joined in — the
+        // row self-labelled with the version it was measured under, which
+        // misattributes no number and hides the fact that the pinned version
+        // has never successfully run.
+        if let Some((full, full_outcome)) = full
+            && !std::ptr::eq(**full, *base)
+            && full_outcome.publishes_workload(&observation.workload)
             && let Some(earlier) = full.record().observation(&observation.workload)
             && fixture_identity(earlier) == identity
+            && comparison_identity(earlier) == comparison
         {
             push_peers(
                 &mut rows,
@@ -1179,6 +1261,21 @@ fn fixture_identity(observation: &rue_perf_schema::RuntimeObservation) -> String
         .find(|input| input.name == FIXTURE_INPUT_NAME)
         .map(|input| input.identity_sha256.clone())
         .unwrap_or_default()
+}
+
+/// The comparison configuration one observation was taken under.
+///
+/// `None` for an observation from an epoch that recorded none, and comparing
+/// two `None`s equal is deliberate: those records were collected under a join
+/// condition of the workload identity alone, and re-judging them by a rule
+/// their epoch never declared would rewrite history rather than correct it.
+/// Within an epoch that pins the identity, validation guarantees both sides
+/// carry one, so the comparison is between two real digests.
+fn comparison_identity(observation: &rue_perf_schema::RuntimeObservation) -> Option<String> {
+    observation
+        .comparison
+        .as_ref()
+        .map(|comparison| comparison.identity_sha256.clone())
 }
 
 /// A digest abbreviated for a human, never for comparison.
@@ -2203,6 +2300,7 @@ samples = 3
                     })
                     .collect(),
                 peers: Vec::new(),
+                comparison: None,
             }],
             failures: Vec::new(),
         }
@@ -2362,16 +2460,34 @@ primary_thread_policy = "pinned_single_thread"
 secondary_thread_policy = "tool_default_parallel"
 canary_tool = "zola"
 canary_scale = 1
+records_comparison_identity = true
 "#;
 
-    fn peer_sample(elapsed: u64) -> rue_perf_schema::RuntimeSample {
-        rue_perf_schema::RuntimeSample {
-            process_elapsed_ns: elapsed,
-            peak_memory_bytes: 1024,
-            exit_code: 0,
-            stdout_bytes: 0,
-            stdout_sha256: "a".repeat(64),
-            artifact_sha256: Some("8".repeat(64)),
+    /// The epoch's own sample count, because a peer taken under another
+    /// sampling policy is not a comparable denominator (RUE-1493).
+    fn peer_samples(elapsed: u64) -> Vec<rue_perf_schema::RuntimeSample> {
+        (0..3)
+            .map(|index| rue_perf_schema::RuntimeSample {
+                process_elapsed_ns: elapsed + index,
+                peak_memory_bytes: 1024,
+                exit_code: 0,
+                stdout_bytes: 0,
+                stdout_sha256: "a".repeat(64),
+                artifact_sha256: Some("8".repeat(64)),
+            })
+            .collect()
+    }
+
+    /// The comparison configuration the peer legs were taken under.
+    ///
+    /// Distinct from the workload identity on purpose: the join now requires
+    /// both to match, and a test that reused one digest for both could not tell
+    /// which rule it was exercising.
+    fn comparison_identity(digest: char) -> rue_perf_schema::ComparisonIdentity {
+        rue_perf_schema::ComparisonIdentity {
+            identity_sha256: std::iter::repeat_n(digest, 64).collect(),
+            peer_port_revision: 3,
+            peer_versions: BTreeMap::from([("zola".to_string(), "0.21.0".to_string())]),
         }
     }
 
@@ -2439,7 +2555,7 @@ canary_scale = 1
                     scale: 1,
                     output_sha256: "8".repeat(64),
                     emitted_files: 131,
-                    samples: vec![peer_sample(2_000_000_000)],
+                    samples: peer_samples(2_000_000_000),
                 },
                 PeerObservation {
                     tool: "zola".to_string(),
@@ -2447,11 +2563,15 @@ canary_scale = 1
                     role: PeerRole::Full,
                     thread_policy: PeerThreadPolicy::ToolDefaultParallel,
                     scale: 1,
+                    // The same tree as the pinned row above: the same tool on
+                    // the same corpus does the same work, and RUE-1493 refuses
+                    // a secondary row that does not.
                     output_sha256: "8".repeat(64),
                     emitted_files: 131,
-                    samples: vec![peer_sample(1_000_000_000)],
+                    samples: peer_samples(1_000_000_000),
                 },
             ],
+            comparison: Some(comparison_identity('a')),
         }];
         report
     }
@@ -2564,6 +2684,165 @@ canary_scale = 1
             comparison.rows
         );
         assert!(comparison.rows.iter().all(|row| !row.joined));
+    }
+
+    #[test]
+    fn a_joined_row_is_dropped_when_the_peers_it_measured_are_not_these_peers() {
+        // The other half of the join condition, and the one RUE-1493 added.
+        // The corpus is identical here — the workload identity matches exactly,
+        // as it now does across a peer-port or peer-version change, since
+        // neither is an input to gazette. What differs is the comparison
+        // configuration, which is the only thing that can say so.
+        //
+        // The failure this prevents: bump the Hugo shim, watch the full leg
+        // fail, and every subsequent canary-only run splices in a peer row
+        // measured under a version the project no longer pins. The row names
+        // its own version, so no number is misattributed — and the table goes
+        // on publishing against a pin that has never successfully run.
+        let manifest = RuntimeManifest::parse(RUNTIME_PEER_MANIFEST).expect("peer manifest");
+        let mut full = gazette_peer_report();
+        full.identity.commit = "1".repeat(40);
+        full.identity.finished_at = "2026-08-13T00:01:00Z".to_string();
+
+        let mut canary_only = gazette_peer_report();
+        canary_only.identity.commit = "2".repeat(40);
+        canary_only.identity.finished_at = "2026-08-13T00:02:00Z".to_string();
+        canary_only.workloads[0]
+            .peers
+            .retain(|peer| peer.role == rue_perf_schema::PeerRole::Canary);
+        // Same corpus, different peer configuration.
+        canary_only.workloads[0].comparison = Some(comparison_identity('b'));
+        assert_eq!(
+            canary_only.workloads[0].recorded_inputs[0].identity_sha256,
+            full.workloads[0].recorded_inputs[0].identity_sha256,
+            "the workload identity is deliberately unmoved by a peer change"
+        );
+
+        let data = derive_runtime(&manifest, &stored_runtime([full, canary_only]), &[]);
+        let comparison = data.platforms[0].epochs[0]
+            .comparison
+            .as_ref()
+            .expect("a comparison");
+        assert_eq!(
+            comparison.rows.len(),
+            2,
+            "only the same-run rows survive a peer-configuration change: {:?}",
+            comparison.rows
+        );
+        assert!(comparison.rows.iter().all(|row| !row.joined));
+    }
+
+    #[test]
+    fn a_run_that_lost_its_canary_publishes_no_comparison() {
+        // ADR-0072 Decision 9 makes a canary-less observation appendable and
+        // NOT publishable: the evidence is kept and the ratio it was meant to
+        // anchor is exactly what cannot be computed. Before RUE-1493 this
+        // function filtered on appendability alone, so a report deliberately
+        // held back from the series still published a full cross-tool table
+        // from whatever peers it happened to carry.
+        let manifest = RuntimeManifest::parse(RUNTIME_PEER_MANIFEST).expect("peer manifest");
+        let mut report = gazette_peer_report();
+        // The full leg ran and the canary did not, which is the state a
+        // canary failure leaves behind: both rows are legitimate measurements
+        // and neither is the same-run denominator Decision 9 requires.
+        for peer in &mut report.workloads[0].peers {
+            peer.role = rue_perf_schema::PeerRole::Full;
+        }
+        let stored = stored_runtime([report]);
+        let outcome = validate_runtime_report(&manifest, stored[0].record());
+        assert!(outcome.is_appendable(), "{:?}", outcome.errors);
+        assert!(
+            !outcome.publishes_workload("gazette"),
+            "deliberately partial"
+        );
+
+        let data = derive_runtime(&manifest, &stored, &[]);
+        assert!(
+            data.platforms[0].epochs[0].comparison.is_none(),
+            "a partial observation publishes no median, so it has no ratio either"
+        );
+    }
+
+    #[test]
+    fn a_truncated_observation_publishes_no_comparison_either() {
+        // The same rule reached the other way. `derive_runtime_epoch` already
+        // suppresses a median over a truncated sample set; a ratio computed
+        // from the same samples would be that suppressed median with a
+        // denominator attached.
+        let manifest = RuntimeManifest::parse(RUNTIME_PEER_MANIFEST).expect("peer manifest");
+        let mut report = gazette_peer_report();
+        report.workloads[0].samples.truncate(1);
+        let data = derive_runtime(&manifest, &stored_runtime([report]), &[]);
+        let epoch = &data.platforms[0].epochs[0];
+        assert!(epoch.points[0].workloads.is_empty());
+        assert!(epoch.comparison.is_none());
+    }
+
+    #[test]
+    fn a_newest_run_without_peers_shows_no_table_rather_than_an_older_one() {
+        // The fallback this replaces reached back to the newest run that
+        // carried any peer at all, so a run whose peer leg produced nothing
+        // rendered an older comparison that reads as current. What the reader
+        // needs to know in that state is precisely that this run has no valid
+        // denominator, and an older table is the one thing that cannot say it.
+        let manifest = RuntimeManifest::parse(RUNTIME_PEER_MANIFEST).expect("peer manifest");
+        let mut full = gazette_peer_report();
+        full.identity.commit = "1".repeat(40);
+        full.identity.finished_at = "2026-08-13T00:01:00Z".to_string();
+
+        let mut peerless = gazette_peer_report();
+        peerless.identity.commit = "2".repeat(40);
+        peerless.identity.finished_at = "2026-08-13T00:02:00Z".to_string();
+        // Every peer build failed. The comparison configuration is still
+        // recorded — the preparer laid the peers' sites out and read their
+        // versions before anything was measured — so the record says which
+        // peers this run WOULD have compared against and carries not one of
+        // their measurements.
+        peerless.workloads[0].peers.clear();
+
+        let data = derive_runtime(&manifest, &stored_runtime([full, peerless]), &[]);
+        assert!(
+            data.platforms[0].epochs[0].comparison.is_none(),
+            "the newest run has no denominator, and an older table would hide that"
+        );
+    }
+
+    #[test]
+    fn a_failure_inside_an_appendable_report_reaches_the_page() {
+        // RUE-1493. A peer row refused for work equivalence is dropped from a
+        // report that stays complete and publishable, so the table loses a row
+        // and nothing else changes. The record carried the runner's reason all
+        // along and no consumer read it; without this the only trace of a
+        // default-parallel row that built a different site would be a job log
+        // nobody keeps.
+        let manifest = RuntimeManifest::parse(RUNTIME_PEER_MANIFEST).expect("peer manifest");
+        let mut report = gazette_peer_report();
+        report.workloads[0]
+            .peers
+            .retain(|peer| peer.thread_policy == PeerThreadPolicy::PinnedSingleThread);
+        report
+            .failures
+            .push(rue_perf_schema::RuntimeFailure::ValidationRejected {
+                workload: "gazette".to_string(),
+                detail: "peer zola at 1x under ToolDefaultParallel emitted a different tree"
+                    .to_string(),
+            });
+
+        let data = derive_runtime(&manifest, &stored_runtime([report]), &[]);
+        let point = &data.platforms[0].epochs[0].points[0];
+        assert!(point.complete, "the Rue measurement is untouched");
+        assert!(
+            data.platforms[0].epochs[0].comparison.is_some(),
+            "the ratio still publishes; only the labelled secondary row is gone"
+        );
+        assert_eq!(point.failures.len(), 1);
+        assert_eq!(point.failures[0].kind, "validation_rejected");
+        assert_eq!(point.failures[0].workload, "gazette");
+        assert!(
+            point.failures[0].detail.contains("different tree"),
+            "{:?}",
+            point.failures[0].detail
+        );
     }
 
     #[test]

--- a/crates/rue-bench/src/runtime.rs
+++ b/crates/rue-bench/src/runtime.rs
@@ -458,6 +458,19 @@ fn measure_workload(
         });
     }
 
+    // The configuration the peer legs were taken under, recorded on EVERY
+    // observation that has a peer policy — including a canary-only one, which
+    // measures one tool and must still say what the others were pinned at
+    // (ADR-0072 Decision 2, RUE-1493). The preparer composed it; nothing is
+    // recomposed here.
+    let comparison = peer_policy
+        .and(prepared.description.as_ref())
+        .map(|description| rue_perf_schema::ComparisonIdentity {
+            identity_sha256: description.identity.comparison_digest.clone(),
+            peer_port_revision: description.identity.peer_port_revision,
+            peer_versions: description.peer_versions.clone(),
+        });
+
     Ok(RuntimeObservation {
         workload: workload.id.clone(),
         source: workload.source.clone(),
@@ -471,6 +484,7 @@ fn measure_workload(
         oracle,
         samples,
         peers,
+        comparison,
     })
 }
 
@@ -566,6 +580,9 @@ fn measure_peers(
     // cross-tool checks read. The parallel leg builds the same site, so judging
     // both would compare a tool with itself.
     let mut trees: BTreeMap<String, PathBuf> = BTreeMap::new();
+    // The digest of that judged tree, per tool and scale. A secondary row is
+    // held to it below.
+    let mut primary_digests: BTreeMap<(String, u32), String> = BTreeMap::new();
     for (tool, thread_policy, scale, role) in wanted {
         match measure_one_peer(
             options,
@@ -578,8 +595,61 @@ fn measure_peers(
             samples_wanted,
             workdir,
         ) {
+            // WORK EQUIVALENCE FOR THE DEFAULT-PARALLEL ROW (ADR-0072
+            // Decision 4, RUE-1493). Only the primary-policy tree is kept for
+            // the semantic oracle, so before this check a secondary row was
+            // proved deterministic with itself and nothing more: a parallel
+            // build that reproducibly emitted a different site would publish
+            // as the number a user would actually experience. It is the same
+            // tool on the same corpus, so requiring its digest to equal the
+            // judged one closes the hole without a second oracle pass over a
+            // tree that is supposed to be identical.
+            //
+            // THE ROW IS DROPPED AND THE OBSERVATION STAYS PUBLISHABLE, which
+            // is a deliberate choice between two tierings. A lost canary makes
+            // the workload incomplete because the canary is the ratio's
+            // denominator and no ratio can be computed without it; a secondary
+            // row is published BESIDE the ratio and never as it (Decision 5),
+            // so suppressing the Rue median and the same-run canary over a
+            // defect in a labelled extra row would discard good evidence to
+            // report a different problem. What must not happen is that the row
+            // vanishes silently, so the failure is recorded here and the derive
+            // step now carries it to the page.
+            //
+            // The peer-state file is deliberately not written when this fires,
+            // so the full leg is due again on the next push. That is a real
+            // cost — a tool genuinely nondeterministic under parallelism would
+            // pay a peer leg per push until someone fixed it — and it is the
+            // right side to err on: the state file's meaning is "this
+            // comparison configuration has been fully measured", which is
+            // exactly what did not happen, and a run that stopped retrying
+            // would also stop re-reporting.
+            Ok((observation, _))
+                if thread_policy != policy.primary_thread_policy
+                    && primary_digests.get(&(tool.clone(), scale))
+                        != Some(&observation.output_sha256) =>
+            {
+                failures.push(RuntimeFailure::ValidationRejected {
+                    workload: workload.id.clone(),
+                    detail: match primary_digests.get(&(tool.clone(), scale)) {
+                        Some(primary) => format!(
+                            "peer {tool} at {scale}x under {thread_policy:?} emitted {} where \
+                             its judged {:?} build emitted {primary}; the same tool on the \
+                             same corpus did different work",
+                            observation.output_sha256, policy.primary_thread_policy
+                        ),
+                        None => format!(
+                            "peer {tool} at {scale}x under {thread_policy:?} has no judged \
+                             {:?} build to be equivalent to",
+                            policy.primary_thread_policy
+                        ),
+                    },
+                });
+            }
             Ok((observation, tree)) => {
                 if thread_policy == policy.primary_thread_policy {
+                    primary_digests
+                        .insert((tool.clone(), scale), observation.output_sha256.clone());
                     trees.insert(tool.clone(), tree);
                 }
                 observations.push(observation);
@@ -610,12 +680,19 @@ fn measure_peers(
             .count()
             + 1
             == wanted_count;
-    if complete_full_leg && let Some(directory) = options.peer_state.as_deref() {
-        let state = serde_json::json!({
-            "fixture_digest": description.identity.fixture_digest,
-            "peer_versions": description.peer_versions,
-            "epoch": options.epoch_label,
-        });
+    if complete_full_leg
+        && let Some(directory) = options.peer_state.as_deref()
+        // No state to record means the preparer was never asked the event
+        // question, so there is nothing to answer it with next time. Writing a
+        // placeholder would be worse than writing nothing: the next run would
+        // read it, find no identity, and have to decide what an empty state
+        // means.
+        && let Some(state) = description
+            .peer_event
+            .as_ref()
+            .map(|event| &event.state)
+            .filter(|state| !state.is_null())
+    {
         let path = directory.join(format!("{}.json", workload.id));
         if let Err(error) = std::fs::create_dir_all(directory)
             .and_then(|()| std::fs::write(&path, format!("{state:#}\n")))
@@ -833,9 +910,17 @@ pub struct PrepareDescription {
 }
 
 /// The identity fields this runner records from the preparer's report.
+///
+/// TWO IDENTITIES (ADR-0072 Decision 2 as amended by RUE-1493). `fixture_digest`
+/// is the WORKLOAD identity — everything gazette consumes, including gazette's
+/// own template port and excluding the peers' — and it is what segments Rue's
+/// longitudinal series. `comparison_digest` is the COMPARISON-CONFIGURATION
+/// identity — the workload identity plus every peer port, the peer preparer's
+/// own digest and revision, every peer version, and the epoch — and it is what
+/// a joined peer row is published against.
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct FixtureIdentity {
-    /// One digest over every input class the tools consume.
+    /// One digest over every input class gazette consumes.
     pub fixture_digest: String,
     /// Files and bytes of the corpus as identified — before duplication, so a
     /// scale variant of an unchanged corpus does not look like a content
@@ -852,16 +937,24 @@ pub struct FixtureIdentity {
     pub static_files: u64,
     /// Their total bytes.
     pub static_bytes: u64,
-    /// Template-port and parity-config files.
-    pub port_files: u64,
+    /// Gazette's own template-port and configuration files.
+    pub gazette_port_files: u64,
     /// Their total bytes.
-    pub port_bytes: u64,
-    /// The port revision a maintainer bumps deliberately.
-    pub port_revision: u32,
+    pub gazette_port_bytes: u64,
+    /// The gazette-port revision a maintainer bumps deliberately.
+    pub gazette_port_revision: u32,
     /// The scale variant assembled.
     pub scale: u32,
     /// The content paths excluded from the corpus.
     pub excluded: Vec<String>,
+    /// The comparison-configuration identity, present when the peers' sites
+    /// were laid out. Absent for a run with no peer policy, which has no
+    /// comparison to configure.
+    #[serde(default)]
+    pub comparison_digest: String,
+    /// The peer-port revision that identity was configured by.
+    #[serde(default)]
+    pub peer_port_revision: u32,
 }
 
 /// One tool's measured invocation, as the preparer laid it out.
@@ -881,6 +974,16 @@ pub struct PeerEvent {
     pub due: bool,
     /// Which one, for the log and for the annotation.
     pub reason: String,
+    /// The state the NEXT run asks its event question against, exactly as the
+    /// preparer composed it.
+    ///
+    /// Carried through rather than rebuilt here: the preparer owns what the
+    /// comparison identity is made of, and a second construction of the same
+    /// shape in this file is a second thing to fall out of step with it — which
+    /// is how a peer-port change could stop firing the leg while the derive
+    /// step went on joining on an identity that had moved.
+    #[serde(default)]
+    pub state: serde_json::Value,
 }
 
 /// Prepare a workload's fixture and record the identity of what it consumed.
@@ -1076,30 +1179,44 @@ fn prepare_corpus_tree(
     // matches an observation to its segment by.
     eprintln!(
         "rue-bench runtime: prepared the {}x corpus for {}: {} page(s) from {} content file(s) \
-         and {} bytes of Markdown, template-port revision {}, fixture digest {}",
+         and {} bytes of Markdown, gazette-port revision {}, workload identity {}, \
+         comparison identity {}",
         identity.scale,
         workload.id,
         description_report.pages,
         identity.content_files,
         identity.content_bytes,
-        identity.port_revision,
-        identity.fixture_digest
+        identity.gazette_port_revision,
+        identity.fixture_digest,
+        if identity.comparison_digest.is_empty() {
+            "none (no peer leg)"
+        } else {
+            identity.comparison_digest.as_str()
+        }
     );
 
-    // Every input class the tools consume, counted together: the Markdown
+    // Every input class GAZETTE consumes, counted together: the Markdown
     // content, the static passthrough (more bytes than the Markdown itself),
-    // and the versioned template ports and parity configurations. The digest is
-    // the preparer's own fixture digest, which covers all three plus the
-    // exclusion set, so no input class can change the measured job without
-    // changing the value that segments the series.
+    // and gazette's own versioned template port and configuration. The digest
+    // is the preparer's workload identity, which covers all three plus the
+    // assembly rules and the exclusion set, so no input class can change the
+    // measured job without changing the value that segments the series.
+    //
+    // The PEER ports are deliberately outside both the count and the digest:
+    // gazette never reads them, so a Hugo layout edit is not a change to what
+    // this observation measured. They ride the comparison identity instead.
     Ok(PreparedFixture {
         recorded: RecordedInput {
             name: FIXTURE_INPUT_NAME.to_string(),
             category: *category,
             description: description.clone(),
             identity_sha256: identity.fixture_digest.clone(),
-            files: identity.scaled_content_files + identity.static_files + identity.port_files,
-            bytes: identity.scaled_content_bytes + identity.static_bytes + identity.port_bytes,
+            files: identity.scaled_content_files
+                + identity.static_files
+                + identity.gazette_port_files,
+            bytes: identity.scaled_content_bytes
+                + identity.static_bytes
+                + identity.gazette_port_bytes,
             provenance: None,
             tree: Some(CorpusTreeProvenance {
                 preparer: preparer.clone(),

--- a/crates/rue-perf-schema/src/lib.rs
+++ b/crates/rue-perf-schema/src/lib.rs
@@ -83,16 +83,17 @@ pub use run::{
     RunIdentity, RunObject, Sample, WorkloadObservation,
 };
 pub use runtime::{
-    CorpusTreeProvenance, FIXTURE_ARGUMENT, FIXTURE_INPUT_NAME, FixtureDeclaration, FlagPosture,
-    GeneratedProvenance, HardwareCounterPolicy, InputCategory, OUTPUT_ARGUMENT, OracleDeclaration,
-    OracleKind, OracleOutcome, OracleVerdict, PeerObservation, PeerPolicy, PeerRole,
-    PeerThreadPolicy, ProgramIdentity, RUNTIME_MANIFEST_SCHEMA_VERSION, RUNTIME_RECORD_KIND,
-    RUNTIME_REPORT_SCHEMA_VERSION, RecordedInput, RuntimeBoundary, RuntimeCalibration,
-    RuntimeCompleteness, RuntimeEpoch, RuntimeFailure, RuntimeFlagging, RuntimeFlaggingPolicy,
-    RuntimeIdentity, RuntimeInvalidSample, RuntimeInvalidSampleReason, RuntimeManifest,
-    RuntimeMetric, RuntimeObservation, RuntimeRegime, RuntimeReport, RuntimeSample,
-    RuntimeSamplingPolicy, RuntimeSuiteRevision, RuntimeValidationError, RuntimeValidationOutcome,
-    RuntimeWorkload, ThreadPolicy, runtime_sample_value, summarize, validate_runtime_report,
+    ComparisonIdentity, CorpusTreeProvenance, FIXTURE_ARGUMENT, FIXTURE_INPUT_NAME,
+    FixtureDeclaration, FlagPosture, GeneratedProvenance, HardwareCounterPolicy, InputCategory,
+    OUTPUT_ARGUMENT, OracleDeclaration, OracleKind, OracleOutcome, OracleVerdict, PeerObservation,
+    PeerPolicy, PeerRole, PeerThreadPolicy, ProgramIdentity, RUNTIME_MANIFEST_SCHEMA_VERSION,
+    RUNTIME_RECORD_KIND, RUNTIME_REPORT_SCHEMA_VERSION, RecordedInput, RuntimeBoundary,
+    RuntimeCalibration, RuntimeCompleteness, RuntimeEpoch, RuntimeFailure, RuntimeFlagging,
+    RuntimeFlaggingPolicy, RuntimeIdentity, RuntimeInvalidSample, RuntimeInvalidSampleReason,
+    RuntimeManifest, RuntimeMetric, RuntimeObservation, RuntimeRegime, RuntimeReport,
+    RuntimeSample, RuntimeSamplingPolicy, RuntimeSuiteRevision, RuntimeValidationError,
+    RuntimeValidationOutcome, RuntimeWorkload, ThreadPolicy, runtime_sample_value, summarize,
+    validate_runtime_report,
 };
 pub use scaling::{
     CfgLocalEpochWork, CfgMaterializationWork, CfgPrerequisiteWork, CfgRetainedChargeWork,

--- a/crates/rue-perf-schema/src/runtime.rs
+++ b/crates/rue-perf-schema/src/runtime.rs
@@ -547,6 +547,23 @@ pub struct PeerPolicy {
     /// The corpus scale the canary builds. 1x, because the canary is meant to
     /// be cheap enough to ride a per-push job.
     pub canary_scale: u32,
+    /// Whether observations under this epoch must record the
+    /// comparison-configuration identity (ADR-0072 Decision 2, RUE-1493).
+    ///
+    /// Declared per epoch rather than required outright BECAUSE THE STORE IS
+    /// APPEND-ONLY. Records written before that identity existed carry no such
+    /// field, and a validator that demanded it of them would invalidate
+    /// evidence nobody can rewrite. This is the same mechanism that retired
+    /// epoch 1 while keeping it declared: a new requirement arrives with a new
+    /// epoch, and the epoch a record names goes on describing the run it
+    /// describes.
+    ///
+    /// One direction only. An epoch that sets this may never unset it, because
+    /// the derive step's join reads the identity from both sides and an epoch
+    /// that stopped recording it would silently fall back to joining on the
+    /// workload identity alone — which is precisely the hole this closes.
+    #[serde(default)]
+    pub records_comparison_identity: bool,
 }
 
 impl RuntimeEpoch {
@@ -1177,6 +1194,50 @@ pub struct PeerObservation {
     pub samples: Vec<RuntimeSample>,
 }
 
+/// The configuration a cross-tool comparison was taken under.
+///
+/// ADR-0072 Decision 2 records TWO identities per observation, and the split is
+/// the whole of RUE-1493. The workload identity — the fixture's
+/// `identity_sha256` — is what gazette consumed: corpus, static assets,
+/// assembly rules, and gazette's own template port. It segments Rue's
+/// longitudinal series. This is the other one: the workload identity plus every
+/// peer template port, every peer version, and the epoch. It is what a joined
+/// peer row must match, and nothing else.
+///
+/// One identity could not do both jobs, and did neither correctly. Composed as
+/// it was, editing a Hugo template moved the digest that segments GAZETTE's own
+/// wall-clock series, for a change that cannot alter what gazette does — while
+/// bumping the Hugo shim moved no recorded identity at all, so a failed full
+/// peer leg left the next canary-only run joining a Hugo row taken under a
+/// version the project no longer pins. The row self-labelled its version, so no
+/// number was misattributed, but the table went on publishing against a pin
+/// that had never successfully run, and nothing in the data said so.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ComparisonIdentity {
+    /// Digest over the workload identity, the peer ports, the peer PREPARER's
+    /// own digest and revision, the peer versions, and the epoch. The join
+    /// condition, and nothing a consumer has to reassemble from parts.
+    ///
+    /// The preparer's digest is in there because the peer half of the harness
+    /// is its own file: the respelling, the invocations, the thread parity, and
+    /// the cross-tool oracle all decide what a peer measurement means, and none
+    /// of them can move the WORKLOAD identity without segmenting Rue's series
+    /// for a change no gazette build can observe.
+    pub identity_sha256: String,
+    /// The peer-port revision this comparison was configured by: the
+    /// human-legible label beside the digest, as the workload identity's port
+    /// revision is beside its own.
+    pub peer_port_revision: u32,
+    /// EVERY pinned peer's version, on every observation — including a
+    /// canary-only one, which measures a single peer and must still record
+    /// what the others were pinned at. Without that, a bumped peer whose full
+    /// leg never succeeded is invisible: the canary run says nothing about the
+    /// tool it did not run, and the joined row names the version it was
+    /// measured under rather than the version now pinned.
+    pub peer_versions: BTreeMap<String, String>,
+}
+
 /// Raw measurements of one program.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -1205,6 +1266,15 @@ pub struct RuntimeObservation {
     /// unchanged by this field existing.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub peers: Vec<PeerObservation>,
+    /// The comparison configuration this observation was taken under.
+    ///
+    /// Present exactly when the epoch's peer policy declares
+    /// `records_comparison_identity`. Optional in the wire form for the reason
+    /// that field exists: the store is append-only, and records written before
+    /// this identity existed must go on validating unchanged. Omitted when
+    /// absent, so no existing record's content address moves.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub comparison: Option<ComparisonIdentity>,
 }
 
 /// Identity of one runtime report.
@@ -1557,6 +1627,19 @@ pub enum RuntimeValidationError {
         /// What is wrong.
         detail: String,
     },
+    /// The comparison-configuration identity is missing, malformed, or
+    /// contradicted by the peer observations stored beside it.
+    ///
+    /// Separate from a peer-policy violation because it is a claim about the
+    /// CONFIGURATION rather than about a measurement: the peers may each be
+    /// impeccable and the record still unable to say which peer pins they were
+    /// taken under, which is what a joined row is published against.
+    ComparisonIdentityViolation {
+        /// The workload.
+        workload: String,
+        /// What is wrong.
+        detail: String,
+    },
 }
 
 /// Why a stored runtime sample may not contribute to a statistic.
@@ -1730,6 +1813,11 @@ impl std::fmt::Display for RuntimeValidationError {
                 f,
                 "workload {workload:?} carries a peer observation its epoch does not \
                  admit: {detail}"
+            ),
+            RuntimeValidationError::ComparisonIdentityViolation { workload, detail } => write!(
+                f,
+                "workload {workload:?} does not record the comparison configuration its \
+                 epoch pins: {detail}"
             ),
         }
     }
@@ -2265,8 +2353,35 @@ fn check_observation(
 ///
 /// Peers are the denominator of a published ratio, so every property the ratio
 /// depends on is checked from the record rather than trusted from the runner:
-/// which tool, which version, which thread configuration, which scale, and
-/// whether the peer's own repeated samples agreed with each other.
+/// which tool, which version, which thread configuration, which scale, how many
+/// samples, whether each of those samples is a measurement at all, and whether
+/// the peer's own repeated builds agreed with each other.
+///
+/// THE PEER SAMPLES ANSWER TO THE SAME SANITY RULES AS THE RUE SAMPLES, and
+/// RUE-1493 is why that sentence is here rather than assumed. This function
+/// once checked only that every peer sample's artifact digest matched the
+/// recorded output digest, which a one-sample, zero-duration, non-zero-exit
+/// canary satisfies trivially — and `latest_comparison` would have published
+/// its median as the denominator of the headline ratio. A peer sample is judged
+/// harder than a Rue sample rather than more leniently: an invalid Rue sample
+/// is a measurement failure that keeps its evidence and publishes nothing
+/// (see [`collect_invalid_samples`]), while a peer observation carrying one
+/// cannot have come from this runner at all — `measure_one_peer` aborts the leg
+/// on a non-zero exit and never records a partial one — so it is a broken or
+/// dishonest producer, which is exactly what appendability exists to refuse.
+///
+/// The asymmetry is deliberate and it does cost something: one runner defect in
+/// a peer leg sinks the whole report, including the Rue observations of every
+/// other workload in it. Two things make that the right side. A peer row is
+/// judged as a RECORD rather than as a measurement — it is the configuration a
+/// published ratio divides by, and every other property of it (its tool, its
+/// version, its thread policy, its digests) is already appendability-checked
+/// here, so tiering the sample rules alone would leave the blast radius
+/// unchanged for most defects while making the loudest ones quiet. And a Rue
+/// sample is the evidence being collected, which is why a truncated one is kept
+/// and unpublished; a peer sample the runner would never have written is
+/// evidence of the producer, not of the workload, and the store cannot delete
+/// what it accepts.
 ///
 /// A peer whose build FAILED is not represented here at all — the runner
 /// records a [`RuntimeFailure`] instead — so an observation missing its canary
@@ -2289,11 +2404,54 @@ fn check_peers(
                 observation.peers.len()
             ));
         }
+        if observation.comparison.is_some() {
+            errors.push(RuntimeValidationError::ComparisonIdentityViolation {
+                workload: workload.id.clone(),
+                detail: "a comparison configuration is recorded, but this epoch declares no \
+                         peer policy for the workload; there is no comparison to configure"
+                    .to_string(),
+            });
+        }
         flush(errors, workload, details);
         return;
     };
 
+    // The scale every non-canary row must have built. The peers build the
+    // WORKLOAD's own fixture — a 1x denominator under a 10x numerator would not
+    // be a ratio of anything — so this is the workload's declared scale rather
+    // than a free field. The canary's is checked against the policy below,
+    // which the manifest already holds to the same number.
+    let declared_scale = match &workload.fixture {
+        FixtureDeclaration::CorpusTree { scale, .. } => Some(*scale),
+        FixtureDeclaration::SeededGenerator { .. } => None,
+    };
+    let expected_samples = epoch
+        .sampling
+        .get(&workload.id)
+        .map(|sampling| sampling.samples);
+
     let mut canaries = 0;
+    // The configuration key, checked as a UNIT rather than field by field:
+    // tool, scale, thread policy. ROLE IS DELIBERATELY NOT PART OF IT. The
+    // derive step keys a published row on (tool, thread policy) and keeps
+    // whichever it reaches first, so a canary and a full row of the same tool
+    // and policy are two denominators for one cell of the table with array
+    // order deciding between them — the thing this check exists to refuse,
+    // not an exception to it.
+    //
+    // The key here carries one field the table's does not, and the two are
+    // equivalent only because SCALE CANNOT VARY WITHIN AN OBSERVATION: the
+    // manifest holds a canary's scale to the workload's own (`check_epochs`),
+    // the canary's scale is checked against the policy below, and every other
+    // row's is checked against the workload's declared fixture scale. Those
+    // three are why keeping scale here is free rather than a mismatch. Do not
+    // "reconcile" the two keys by adding scale to the derive key or dropping
+    // it here without first checking that those pins still hold — the safety
+    // is in the pins, not in the spelling.
+    let mut configurations: BTreeSet<(&str, u32, String)> = BTreeSet::new();
+    // One emitted tree per (tool, scale), across thread policies: see the
+    // work-equivalence check after the loop.
+    let mut primary_trees: BTreeMap<(&str, u32), &str> = BTreeMap::new();
     for peer in &observation.peers {
         if !policy.tools.contains(&peer.tool) {
             details.push(format!(
@@ -2316,6 +2474,71 @@ fn check_peers(
                  nor its published secondary thread policy",
                 peer.tool, peer.thread_policy
             ));
+        }
+        if !configurations.insert((
+            peer.tool.as_str(),
+            peer.scale,
+            format!("{:?}", peer.thread_policy),
+        )) {
+            details.push(format!(
+                "two observations claim the same configuration — {:?} at {}x under {:?} — so \
+                 one cell of the published table has two denominators and no rule says which; \
+                 a differing role does not separate them, because the table does not key on \
+                 role",
+                peer.tool, peer.scale, peer.thread_policy
+            ));
+        }
+        if peer.thread_policy == policy.primary_thread_policy {
+            primary_trees.insert(
+                (peer.tool.as_str(), peer.scale),
+                peer.output_sha256.as_str(),
+            );
+        }
+        if peer.emitted_files == 0 {
+            details.push(format!(
+                "the {:?} observation emitted no files; a tool that built nothing is not a \
+                 denominator, however quickly it did it",
+                peer.tool
+            ));
+        }
+        // The epoch's sample count, exactly — the same protocol rule the Rue
+        // observation answers to. Fewer is a leg this runner would never have
+        // recorded, since it aborts rather than storing a short one, and more
+        // was not taken under the policy the series compares against.
+        if let Some(wanted) = expected_samples
+            && peer.samples.len() as u32 != wanted
+        {
+            details.push(format!(
+                "the {:?} observation stores {} sample(s) where this epoch's policy for the \
+                 workload is {wanted}; a denominator taken under another sampling policy is \
+                 not comparable with the numerator beside it",
+                peer.tool,
+                peer.samples.len()
+            ));
+        }
+        for (index, sample) in peer.samples.iter().enumerate() {
+            if !is_measurable_duration(sample.process_elapsed_ns) {
+                details.push(format!(
+                    "the {:?} observation's sample {index} elapsed zero ns; a monotonic clock \
+                     read either side of a process that ran cannot produce that, and it is \
+                     exactly the value that would make a peer look infinitely fast",
+                    peer.tool
+                ));
+            }
+            if sample.exit_code != 0 {
+                details.push(format!(
+                    "the {:?} observation's sample {index} exited with code {}; a build that \
+                     failed measured nothing",
+                    peer.tool, sample.exit_code
+                ));
+            }
+            if !is_sha256_digest(&sample.stdout_sha256) {
+                errors.push(RuntimeValidationError::MalformedDigest {
+                    workload: workload.id.clone(),
+                    field: format!("peers/{}/samples/{index}/stdout_sha256", peer.tool),
+                    found: sample.stdout_sha256.clone(),
+                });
+            }
         }
         if peer.samples.is_empty() {
             details.push(format!(
@@ -2371,6 +2594,15 @@ fn check_peers(
                     peer.thread_policy, policy.primary_thread_policy
                 ));
             }
+        } else if let Some(scale) = declared_scale
+            && peer.scale != scale
+        {
+            details.push(format!(
+                "the {:?} observation built the {}x corpus, but this workload's fixture is \
+                 the {scale}x one; the peers build the workload's own corpus or the ratio \
+                 divides two different jobs",
+                peer.tool, peer.scale
+            ));
         }
     }
     if canaries > 1 {
@@ -2379,7 +2611,117 @@ fn check_peers(
              must be one measurement, not a choice between several"
         ));
     }
+
+    // WORK EQUIVALENCE FOR THE DEFAULT-PARALLEL ROW (RUE-1493). The semantic
+    // oracle reads one emitted tree per tool — the primary-policy one — so a
+    // secondary row was previously proved only to be deterministic WITH
+    // ITSELF: a parallel build that reproducibly emitted a different site
+    // published as the number a user would actually experience. It is the same
+    // tool on the same corpus, so the check that closes it needs no second
+    // oracle pass, only the digest the oracle already judged.
+    for peer in &observation.peers {
+        if peer.thread_policy == policy.primary_thread_policy {
+            continue;
+        }
+        match primary_trees.get(&(peer.tool.as_str(), peer.scale)) {
+            Some(primary) if *primary == peer.output_sha256 => {}
+            Some(primary) => details.push(format!(
+                "the {:?} observation under {:?} emitted {} where its own {:?} build — the \
+                 one the semantic oracle judged — emitted {}; the same tool on the same \
+                 corpus did different work, so the secondary row is not the same job \
+                 measured with more threads",
+                peer.tool,
+                peer.thread_policy,
+                peer.output_sha256,
+                policy.primary_thread_policy,
+                primary
+            )),
+            None => details.push(format!(
+                "the {:?} observation under {:?} has no {:?} build at {}x beside it, so the \
+                 tree it emitted was never judged against anything",
+                peer.tool, peer.thread_policy, policy.primary_thread_policy, peer.scale
+            )),
+        }
+    }
+
+    errors.extend(check_comparison_identity(observation, workload, policy));
     flush(errors, workload, details);
+}
+
+/// Hold the comparison-configuration identity to the epoch that pins it.
+///
+/// The identity is what a joined peer row is published against (ADR-0072
+/// Decision 9), so the record has to carry it, carry it well-formed, and carry
+/// a peer-version table that agrees with the peer rows stored beside it. A row
+/// self-labelling a version the run did not pin is the exact shape of the
+/// staleness RUE-1493 closes.
+fn check_comparison_identity(
+    observation: &RuntimeObservation,
+    workload: &RuntimeWorkload,
+    policy: &PeerPolicy,
+) -> Vec<RuntimeValidationError> {
+    let mut errors: Vec<RuntimeValidationError> = Vec::new();
+    let violation = |detail: String| RuntimeValidationError::ComparisonIdentityViolation {
+        workload: workload.id.clone(),
+        detail,
+    };
+    let Some(comparison) = &observation.comparison else {
+        if policy.records_comparison_identity {
+            errors.push(violation(
+                "this epoch pins the comparison configuration, and the observation records \
+                 none; a peer row joined to it would be published against peer ports and \
+                 peer versions nobody can name"
+                    .to_string(),
+            ));
+        }
+        // An epoch that does not pin it is one whose records predate it. They
+        // stay valid, and the derive step joins them exactly as it did while
+        // they were being collected.
+        return errors;
+    };
+    if !is_sha256_digest(&comparison.identity_sha256) {
+        errors.push(RuntimeValidationError::MalformedDigest {
+            workload: workload.id.clone(),
+            field: "comparison/identity_sha256".to_string(),
+            found: comparison.identity_sha256.clone(),
+        });
+    }
+    // EVERY declared peer, not only the ones this run measured. A canary-only
+    // observation measures one tool and must still say what the others were
+    // pinned at, or a bump whose full leg never succeeded leaves no trace in
+    // the data at all.
+    let declared: BTreeSet<&str> = policy.tools.iter().map(String::as_str).collect();
+    let recorded: BTreeSet<&str> = comparison
+        .peer_versions
+        .keys()
+        .map(String::as_str)
+        .collect();
+    if declared != recorded {
+        errors.push(violation(format!(
+            "the recorded peer versions cover {recorded:?}, but this epoch pins {declared:?}; \
+             every declared peer's version rides every observation, including a canary-only \
+             one that measured none of them"
+        )));
+    }
+    for (tool, version) in &comparison.peer_versions {
+        if version.trim().is_empty() {
+            errors.push(violation(format!(
+                "the recorded version of {tool:?} is empty; an unnamed pin is not a pin"
+            )));
+        }
+    }
+    for peer in &observation.peers {
+        if let Some(pinned) = comparison.peer_versions.get(&peer.tool)
+            && pinned != &peer.version
+        {
+            errors.push(violation(format!(
+                "the {:?} observation reports version {:?}, but this run pinned {pinned:?}; a \
+                 measurement and the configuration it was taken under cannot disagree",
+                peer.tool, peer.version
+            )));
+        }
+    }
+    errors
 }
 
 /// Turn collected peer complaints into validation errors.
@@ -2712,7 +3054,7 @@ samples = 5
         let epoch = manifest
             .collection_epoch("aarch64-linux")
             .expect("aarch64-linux is a row of the v1 platform matrix");
-        assert_eq!(epoch.suite_revision, 2);
+        assert_eq!(epoch.suite_revision, 3);
         assert_eq!(epoch.target, "aarch64-linux");
         assert_eq!(epoch.optimization, OptimizationLevel::O3);
         assert_eq!(epoch.thread_policy, ThreadPolicy::SingleThreaded);
@@ -2740,7 +3082,7 @@ samples = 5
         let epoch = manifest
             .collection_epoch("aarch64-macos")
             .expect("aarch64-macos is the scheduled row of the v1 platform matrix");
-        assert_eq!(epoch.suite_revision, 2);
+        assert_eq!(epoch.suite_revision, 3);
         assert_eq!(epoch.target, "aarch64-macos");
         assert_eq!(epoch.optimization, OptimizationLevel::O3);
         assert_eq!(epoch.thread_policy, ThreadPolicy::SingleThreaded);
@@ -2872,6 +3214,7 @@ samples = 5
                     })
                     .collect(),
                 peers: Vec::new(),
+                comparison: None,
             }],
             failures: Vec::new(),
         }
@@ -3576,6 +3919,7 @@ primary_thread_policy = "pinned_single_thread"
 secondary_thread_policy = "tool_default_parallel"
 canary_tool = "zola"
 canary_scale = 1
+records_comparison_identity = true
 "#;
 
     fn gazette_manifest() -> RuntimeManifest {
@@ -3593,6 +3937,22 @@ canary_scale = 1
         }
     }
 
+    /// A peer sample, taken by the same harness and the same clock as the Rue
+    /// program's — and answering to the same sanity rules (RUE-1493).
+    fn peer_sample(elapsed: u64, tree: &str) -> RuntimeSample {
+        RuntimeSample {
+            process_elapsed_ns: elapsed,
+            peak_memory_bytes: 60 * 1024 * 1024,
+            exit_code: 0,
+            stdout_bytes: 64,
+            stdout_sha256: "a".repeat(64),
+            artifact_sha256: Some(tree.repeat(64)),
+        }
+    }
+
+    /// The per-run canary: the epoch's own sample count, because a denominator
+    /// taken under another sampling policy is not comparable with the numerator
+    /// beside it.
     fn canary() -> PeerObservation {
         PeerObservation {
             tool: "zola".to_string(),
@@ -3602,14 +3962,21 @@ canary_scale = 1
             scale: 1,
             output_sha256: "8".repeat(64),
             emitted_files: 131,
-            samples: vec![RuntimeSample {
-                process_elapsed_ns: 200_000_000,
-                peak_memory_bytes: 60 * 1024 * 1024,
-                exit_code: 0,
-                stdout_bytes: 64,
-                stdout_sha256: "a".repeat(64),
-                artifact_sha256: Some("8".repeat(64)),
-            }],
+            samples: (0..3)
+                .map(|index| peer_sample(200_000_000 + index, "8"))
+                .collect(),
+        }
+    }
+
+    /// The comparison configuration a gazette observation is taken under.
+    fn comparison() -> ComparisonIdentity {
+        ComparisonIdentity {
+            identity_sha256: "a".repeat(64),
+            peer_port_revision: 3,
+            peer_versions: BTreeMap::from([
+                ("zola".to_string(), "0.21.0".to_string()),
+                ("hugo".to_string(), "0.152.2".to_string()),
+            ]),
         }
     }
 
@@ -3659,6 +4026,7 @@ canary_scale = 1
                 .map(|index| site_sample(2_000_000_000 + index))
                 .collect(),
             peers: vec![canary()],
+            comparison: Some(comparison()),
         }];
         report
     }
@@ -3902,6 +4270,276 @@ canary_scale = 1
         );
     }
 
+    // -----------------------------------------------------------------------
+    // RUE-1493: the peer evidence a published ratio rests on.
+    //
+    // Every test below constructs a record that WAS appendable and must not be.
+    // The common shape is a peer observation that satisfies the one rule this
+    // module used to check — every sample's artifact digest equals the recorded
+    // output digest — while failing to be a measurement at all.
+    // -----------------------------------------------------------------------
+
+    /// A peer complaint mentioning `needle`, or a panic naming what was found.
+    fn refused_because(outcome: &RuntimeValidationOutcome, needle: &str) {
+        assert!(!outcome.is_appendable(), "the record was accepted");
+        assert!(
+            outcome
+                .errors
+                .iter()
+                .any(|error| error.to_string().contains(needle)),
+            "no error mentions {needle:?}: {:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn a_zero_length_peer_sample_cannot_anchor_a_ratio() {
+        // The headline case. A one-sample canary whose process elapsed zero ns
+        // used to be appendable — its artifact digest matched — and the derive
+        // step would have published its median as the denominator of the
+        // ratio, where a zero divides into anything.
+        let mut report = gazette_report();
+        report.workloads[0].peers[0].samples[0].process_elapsed_ns = 0;
+        refused_because(
+            &validate_runtime_report(&gazette_manifest(), &report),
+            "elapsed zero ns",
+        );
+    }
+
+    #[test]
+    fn a_peer_build_that_failed_cannot_anchor_a_ratio() {
+        // This runner aborts a peer leg on a non-zero exit and records a
+        // failure rather than a short observation, so a record carrying one did
+        // not come from it — which is exactly the producer appendability exists
+        // to refuse.
+        let mut report = gazette_report();
+        report.workloads[0].peers[0].samples[1].exit_code = 2;
+        refused_because(
+            &validate_runtime_report(&gazette_manifest(), &report),
+            "exited with code 2",
+        );
+    }
+
+    #[test]
+    fn a_peer_taken_under_another_sampling_policy_is_refused() {
+        // The epoch declares three samples of this workload, and the peer legs
+        // take the same count. A single-sample denominator has no spread and
+        // was not taken under the policy the numerator beside it was.
+        let mut report = gazette_report();
+        report.workloads[0].peers[0].samples.truncate(1);
+        refused_because(
+            &validate_runtime_report(&gazette_manifest(), &report),
+            "stores 1 sample(s) where this epoch's policy",
+        );
+    }
+
+    #[test]
+    fn a_peer_that_emitted_nothing_is_refused() {
+        let mut report = gazette_report();
+        report.workloads[0].peers[0].emitted_files = 0;
+        refused_because(
+            &validate_runtime_report(&gazette_manifest(), &report),
+            "emitted no files",
+        );
+    }
+
+    #[test]
+    fn a_full_peer_row_at_another_scale_is_refused() {
+        // The canary's scale was checked and a full row's was not, so a Hugo
+        // row could claim to have built a corpus this workload never assembled
+        // — a ratio dividing two different jobs.
+        let mut report = gazette_report();
+        report.workloads[0].peers.push(PeerObservation {
+            tool: "hugo".to_string(),
+            version: "0.152.2".to_string(),
+            role: PeerRole::Full,
+            thread_policy: PeerThreadPolicy::PinnedSingleThread,
+            scale: 10,
+            output_sha256: "9".repeat(64),
+            emitted_files: 131,
+            samples: (0..3)
+                .map(|index| peer_sample(300_000_000 + index, "9"))
+                .collect(),
+        });
+        refused_because(
+            &validate_runtime_report(&gazette_manifest(), &report),
+            "this workload's fixture is the 1x one",
+        );
+    }
+
+    #[test]
+    fn two_rows_claiming_one_configuration_are_refused() {
+        // The configuration key is (tool, scale, thread policy), checked as a
+        // unit: two rows sharing it are two denominators for one cell of the
+        // published table, and the derive step's deduplication would silently
+        // keep whichever it reached first.
+        //
+        // A DIFFERING ROLE DOES NOT SEPARATE THEM, and that is the case this
+        // test is really about. The table keys a row on tool and thread policy
+        // and nothing else, so a canary and a full row of the same tool at the
+        // same policy collapse into one cell — array order deciding which
+        // median publishes and which is silently discarded. Cloning the canary
+        // as a full row with a ten-times-slower measurement was accepted before
+        // role left the key.
+        let mut report = gazette_report();
+        let slow = PeerObservation {
+            role: PeerRole::Full,
+            samples: (0..3)
+                .map(|index| peer_sample(2_000_000_000 + index, "8"))
+                .collect(),
+            ..report.workloads[0].peers[0].clone()
+        };
+        report.workloads[0].peers.push(slow);
+        refused_because(
+            &validate_runtime_report(&gazette_manifest(), &report),
+            "two observations claim the same configuration",
+        );
+    }
+
+    #[test]
+    fn a_parallel_row_that_built_a_different_site_is_refused() {
+        // ADR-0072 Decision 4 for the SECONDARY row (RUE-1493). Only the
+        // primary-policy tree reaches the semantic oracle, so a deterministic
+        // parallel build emitting a different site satisfied every check there
+        // was and published as the number a user would actually experience. It
+        // is the same tool on the same corpus, so its digest must equal the one
+        // the oracle judged.
+        let mut report = gazette_report();
+        report.workloads[0].peers.push(PeerObservation {
+            tool: "zola".to_string(),
+            version: "0.21.0".to_string(),
+            role: PeerRole::Full,
+            thread_policy: PeerThreadPolicy::ToolDefaultParallel,
+            scale: 1,
+            output_sha256: "9".repeat(64),
+            emitted_files: 131,
+            samples: (0..3)
+                .map(|index| peer_sample(100_000_000 + index, "9"))
+                .collect(),
+        });
+        refused_because(
+            &validate_runtime_report(&gazette_manifest(), &report),
+            "did different work",
+        );
+
+        // And the same row agreeing with its judged primary build is fine,
+        // which is what makes the check about work equivalence rather than
+        // about there being a secondary row at all.
+        let mut agreeing = gazette_report();
+        agreeing.workloads[0].peers.push(PeerObservation {
+            tool: "zola".to_string(),
+            version: "0.21.0".to_string(),
+            role: PeerRole::Full,
+            thread_policy: PeerThreadPolicy::ToolDefaultParallel,
+            scale: 1,
+            output_sha256: "8".repeat(64),
+            emitted_files: 131,
+            samples: (0..3)
+                .map(|index| peer_sample(100_000_000 + index, "8"))
+                .collect(),
+        });
+        let outcome = validate_runtime_report(&gazette_manifest(), &agreeing);
+        assert_eq!(outcome.errors, Vec::new());
+    }
+
+    #[test]
+    fn a_parallel_row_with_no_judged_primary_build_is_refused() {
+        // The tree of a secondary row is never handed to the oracle, so
+        // without its own tool's primary-policy build beside it there is
+        // nothing its digest could have been judged against.
+        let mut report = gazette_report();
+        report.workloads[0].peers = vec![
+            canary(),
+            PeerObservation {
+                tool: "hugo".to_string(),
+                version: "0.152.2".to_string(),
+                role: PeerRole::Full,
+                thread_policy: PeerThreadPolicy::ToolDefaultParallel,
+                scale: 1,
+                output_sha256: "9".repeat(64),
+                emitted_files: 131,
+                samples: (0..3)
+                    .map(|index| peer_sample(100_000_000 + index, "9"))
+                    .collect(),
+            },
+        ];
+        refused_because(
+            &validate_runtime_report(&gazette_manifest(), &report),
+            "never judged against anything",
+        );
+    }
+
+    #[test]
+    fn an_observation_that_records_no_comparison_configuration_is_refused() {
+        // ADR-0072 Decision 2 as amended: the epoch pins the identity a joined
+        // peer row is published against, so an observation that records none
+        // cannot be joined to and is not appendable under that epoch.
+        let mut report = gazette_report();
+        report.workloads[0].comparison = None;
+        refused_because(
+            &validate_runtime_report(&gazette_manifest(), &report),
+            "the observation records none",
+        );
+    }
+
+    #[test]
+    fn a_canary_only_observation_records_every_peer_version() {
+        // THE DATA GAP RUE-1493 NAMES. A canary-only run measures one tool, and
+        // recording only that tool's version is how a Hugo bump whose full leg
+        // failed became invisible: nothing in the store said which Hugo the run
+        // pinned, so nothing could say the joined row's Hugo was no longer it.
+        let mut report = gazette_report();
+        report.workloads[0]
+            .comparison
+            .as_mut()
+            .unwrap()
+            .peer_versions
+            .remove("hugo");
+        refused_because(
+            &validate_runtime_report(&gazette_manifest(), &report),
+            "every declared peer's version rides every observation",
+        );
+    }
+
+    #[test]
+    fn a_peer_row_may_not_disagree_with_the_pin_it_ran_under() {
+        let mut report = gazette_report();
+        report.workloads[0].peers[0].version = "0.20.0".to_string();
+        refused_because(
+            &validate_runtime_report(&gazette_manifest(), &report),
+            "this run pinned",
+        );
+    }
+
+    #[test]
+    fn a_comparison_identity_without_a_peer_policy_is_refused() {
+        // The symmetric rule to peer observations without a policy: wordfreq
+        // has no comparison to configure, so a record describing one is
+        // describing a leg its epoch never declared.
+        let mut report = report();
+        report.workloads[0].comparison = Some(comparison());
+        refused_because(
+            &validate_runtime_report(&manifest(), &report),
+            "there is no comparison to configure",
+        );
+    }
+
+    #[test]
+    fn a_record_from_an_epoch_that_predates_the_comparison_identity_still_validates() {
+        // THE APPEND-ONLY RULE. Records taken before the comparison identity
+        // existed carry none and never could, and the store cannot delete them.
+        // An epoch that does not pin the identity therefore keeps accepting
+        // records without one — the same mechanism that retired epoch 1 in
+        // RUE-1485 while keeping it declared, so its records stayed valid.
+        let text = GAZETTE_MANIFEST.replace("records_comparison_identity = true\n", "");
+        let earlier = RuntimeManifest::parse(&text).expect("an epoch that pins no identity");
+        let mut report = gazette_report();
+        report.workloads[0].comparison = None;
+        let outcome = validate_runtime_report(&earlier, &report);
+        assert_eq!(outcome.errors, Vec::new());
+        assert!(outcome.publishes_workload("gazette"));
+    }
+
     #[test]
     fn a_fixture_table_still_refuses_unknown_fields_after_being_tagged() {
         // The tagging must not have bought its flexibility by accepting
@@ -4008,6 +4646,151 @@ canary_scale = 1
             assert!(suite.workload("gazette_10x").is_some());
             assert!(suite.workload("gazette_100x").is_none());
         }
+    }
+
+    /// A complete report against the CHECKED-IN manifest, as the runner writes
+    /// one: every declared workload, the canary each peer policy requires, and
+    /// the fixture provenance the suite revision pins.
+    ///
+    /// Parameterized by epoch because that is the whole point of it. The store
+    /// is append-only, so a record written under a retired epoch has to go on
+    /// validating against the manifest as it stands today.
+    fn shipped_report(epoch: u32, suite_revision: u32, preparer_revision: u32) -> RuntimeReport {
+        let comparison = (epoch >= 3).then(comparison);
+        let corpus = |scale: u32, samples: u32| RuntimeObservation {
+            workload: if scale == 1 {
+                "gazette".to_string()
+            } else {
+                format!("gazette_{scale}x")
+            },
+            source: "examples/gazette/main.rue".to_string(),
+            question: "How fast does a compiled Rue program build the real rue-lang.dev site, \
+                       against the production tools that build sites for a living?"
+                .to_string(),
+            program_args: vec![
+                "build".to_string(),
+                FIXTURE_ARGUMENT.to_string(),
+                "-o".to_string(),
+                OUTPUT_ARGUMENT.to_string(),
+            ],
+            recorded_inputs: vec![RecordedInput {
+                name: FIXTURE_INPUT_NAME.to_string(),
+                category: InputCategory::Recorded,
+                description: "the live corpus".to_string(),
+                identity_sha256: "f".repeat(64),
+                files: 130 * u64::from(scale),
+                bytes: 1_800_000 * u64::from(scale),
+                provenance: None,
+                tree: Some(CorpusTreeProvenance {
+                    preparer: "scripts/gazette-corpus-diff.py".to_string(),
+                    preparer_revision,
+                    scale,
+                    excluded: vec!["performance.md".to_string(), "runtime.md".to_string()],
+                }),
+            }],
+            program: ProgramIdentity {
+                binary_bytes: 1_048_576,
+                sha256: "b".repeat(64),
+            },
+            oracle: OracleOutcome {
+                kind: OracleKind::SemanticSitePages,
+                reference: "scripts/gazette-corpus-diff.py".to_string(),
+                reference_sha256: "d".repeat(64),
+                observed_sha256: "7".repeat(64),
+                verdict: OracleVerdict::Match,
+                deterministic_across_samples: true,
+                detail: String::new(),
+            },
+            samples: (0..u64::from(samples))
+                .map(|index| site_sample(2_000_000_000 + index))
+                .collect(),
+            peers: vec![PeerObservation {
+                tool: "zola".to_string(),
+                version: "0.21.0".to_string(),
+                role: PeerRole::Canary,
+                thread_policy: PeerThreadPolicy::PinnedSingleThread,
+                scale,
+                output_sha256: "8".repeat(64),
+                emitted_files: 131,
+                samples: (0..u64::from(samples))
+                    .map(|index| peer_sample(200_000_000 + index, "8"))
+                    .collect(),
+            }],
+            comparison: comparison.clone(),
+        };
+
+        let mut report = report();
+        report.identity.suite_revision = suite_revision;
+        report.identity.epoch = epoch;
+        report.identity.workload_source_hashes = BTreeMap::from([
+            ("wordfreq".to_string(), "3".repeat(64)),
+            ("gazette".to_string(), "4".repeat(64)),
+            ("gazette_10x".to_string(), "4".repeat(64)),
+        ]);
+        report.regime.target = "x86-64-linux".to_string();
+        report.workloads[0].recorded_inputs[0].bytes = 33_554_432;
+        report.workloads[0]
+            .recorded_inputs
+            .iter_mut()
+            .for_each(|input| {
+                if let Some(provenance) = input.provenance.as_mut() {
+                    provenance.vocabulary_size = 65_536;
+                }
+            });
+        report.workloads.push(corpus(1, 5));
+        report.workloads.push(corpus(10, 3));
+        report
+            .workloads
+            .sort_by(|left, right| left.workload.cmp(&right.workload));
+        report
+    }
+
+    #[test]
+    fn a_record_from_the_retired_epoch_validates_beside_one_from_the_new_epoch() {
+        // THE APPEND-ONLY EVIDENCE, against the manifest the repository ships
+        // rather than a fixture written to agree with it. RUE-1485 proved this
+        // shape by deriving an epoch-1 record beside two epoch-2 records with
+        // none rejected; RUE-1493 changes what an observation RECORDS, so the
+        // same proof is owed again.
+        //
+        // Epoch 2's records carry preparer revision 1 and no comparison
+        // identity, because neither existed when they were written. Epoch 3's
+        // carry revision 2 and the identity, because its peer policy pins it.
+        // Both must be appendable, and both must publish, or this change would
+        // have invalidated evidence nobody can rewrite.
+        let manifest = RuntimeManifest::parse(CHECKED_IN_MANIFEST).expect("checked-in manifest");
+        for (epoch, suite_revision, preparer_revision) in [(2, 2, 1), (3, 3, 2)] {
+            let report = shipped_report(epoch, suite_revision, preparer_revision);
+            let outcome = validate_runtime_report(&manifest, &report);
+            assert_eq!(
+                outcome.errors,
+                Vec::new(),
+                "the epoch-{epoch} record was refused"
+            );
+            assert_eq!(outcome.completeness, RuntimeCompleteness::Complete);
+            for workload in ["wordfreq", "gazette", "gazette_10x"] {
+                assert!(
+                    outcome.publishes_workload(workload),
+                    "epoch {epoch} publishes {workload}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_new_epoch_refuses_a_record_written_without_the_comparison_identity() {
+        // The other half of the same rule: epoch 3 pins the identity, so a
+        // runner that skipped it is refused HERE rather than at the point
+        // someone reads a joined row and cannot say which peer pins it names.
+        let manifest = RuntimeManifest::parse(CHECKED_IN_MANIFEST).expect("checked-in manifest");
+        let mut report = shipped_report(3, 3, 2);
+        for observation in &mut report.workloads {
+            observation.comparison = None;
+        }
+        refused_because(
+            &validate_runtime_report(&manifest, &report),
+            "the observation records none",
+        );
     }
 
     #[test]

--- a/docs/designs/0072-runtime-benchmarking-static-site-generator.md
+++ b/docs/designs/0072-runtime-benchmarking-static-site-generator.md
@@ -9,7 +9,7 @@ accepted: 2026-08-13
 implemented:
 spec-sections: []
 superseded-by:
-relates: ["RUE-487", "RUE-945", "RUE-1045", "RUE-1046", "RUE-1047", "RUE-1049", "RUE-1481", "RUE-1482", "RUE-1483", "RUE-1484", "RUE-1485", "RUE-1488", "RUE-1495", "ADR-0006", "ADR-0057", "ADR-0067", "ADR-0068", "ADR-0070", "ADR-0071"]
+relates: ["RUE-487", "RUE-945", "RUE-1045", "RUE-1046", "RUE-1047", "RUE-1049", "RUE-1481", "RUE-1482", "RUE-1483", "RUE-1484", "RUE-1485", "RUE-1488", "RUE-1493", "RUE-1495", "ADR-0006", "ADR-0057", "ADR-0067", "ADR-0068", "ADR-0070", "ADR-0071"]
 ---
 
 # ADR-0072: Runtime performance benchmarking anchored by a Rue static site generator
@@ -169,7 +169,7 @@ benchmark a progressively staler site.
 
 Corpus drift is handled by measurement discipline instead of pinning:
 
-- **Recorded identity.** Every observation records the complete
+- **Recorded identity, in two parts.** Every observation records the complete
   fixture-input identity: a tree hash over everything the tools consume —
   the Markdown content tree, the static passthrough assets (currently 33
   files, ~1.2 MiB: more bytes than the Markdown itself), and the versioned
@@ -177,6 +177,58 @@ Corpus drift is handled by measurement discipline instead of pinning:
   bytes. Any movement in a series is thereby attributable to compiler,
   workload, or input from the data alone, and no input class can change
   work without changing the recorded identity.
+
+  Phase 5's review found that one identity cannot carry that sentence for
+  both of the questions it is asked, and RUE-1493 split it in two. The
+  reason is that "everything the tools consume" is not one set: gazette
+  consumes its own template port, and the peers consume theirs, and a
+  change to one of those is not a change to the other's work.
+
+  - **The workload identity** — corpus content, static assets, the
+    preparer's own revision and digest, and **gazette's own template port
+    and configuration** — is what segments Rue's longitudinal series. It
+    must not move when a peer port moves, because a Hugo layout edit cannot
+    change what gazette does, and opening a new comparable segment for one
+    would discard Rue's own history for a change outside the program. Peer
+    parity work is ongoing rather than finished — Phase 5 fixed three Hugo
+    port defects, and highlighting, search-index, and minification parity
+    are Future Work — so this is a recurring event, not a hypothetical one.
+
+    **The preparer is therefore two files, not one**, and that is a
+    consequence of the identity rather than a tidying of the code. The
+    workload identity contains a digest of the whole preparer, deliberately
+    over-sensitive so that no assembly rule can change what gazette consumes
+    without moving it — which means any peer knob sharing that file moves
+    it too. All three Hugo port defects Phase 5 found were fixed inside the
+    corpus respelling, and the port-review procedure asks a maintainer to
+    bump a peer port revision by hand; under one file, each of those would
+    still have discarded Rue's history. The peer half — the pinned tools and
+    versions, the peer ports, the respelling, the invocations and thread
+    parity, and the cross-tool oracle — lives in its own module whose digest
+    rides the comparison identity alone, and the corpus rules it borrows are
+    passed to it rather than copied, so the two files cannot disagree about
+    a route.
+  - **The comparison-configuration identity** — the workload identity plus
+    **every peer template port, the peer preparer's own digest, every peer
+    version, and the epoch** — is recorded on every observation and is the
+    join condition for the event-driven full peer leg (Decision 9). Peer versions are *inside* it
+    rather than beside it, which is the half the single identity was
+    missing: a peer toolchain bump moved no recorded identity at all, so if
+    the full leg it triggered then failed, every subsequent canary-only run
+    joined in a peer row measured under a version the project no longer
+    pins. The row labels its own version, so no number was misattributed —
+    and the table went on publishing against a pin that had never
+    successfully run, with nothing in the data saying so. Because the peer
+    leg is event-driven and the canary is not, joined rows are the normal
+    state of the published table rather than an edge case.
+
+  A canary-only observation records **every** declared peer's version, not
+  only the canary's. It measures one tool and must still say what the others
+  were pinned at, or the bump above leaves no trace in the store at all.
+
+  Both identities are recorded raw, per observation, exactly as before; what
+  changed is that a consumer can now tell a change in the measured program's
+  input from a change in what it is being compared against.
 - **Annotated events.** Corpus changes appear as annotated events on the
   published charts, alongside compiler releases and peer tool bumps.
 - **Peers as the corpus control.** The peer tools are version-pinned, so a
@@ -421,6 +473,22 @@ cannot anchor, because the difference matters:
   recursive navigation's active branch, the feed, and the redirect stub, so
   the goldens remain sensitive to exactly what they are for.
 
+The semantic oracle reads one emitted tree per tool: the primary,
+single-threaded one. The **default-parallel secondary row** is therefore held
+to that tool's judged digest rather than to a second oracle pass — it is the
+same tool on the same corpus, so its output tree must be the one the oracle
+already examined. Without that equality a secondary row was proved only to be
+deterministic with itself, and a parallel build that reproducibly emitted a
+different site would publish as the number a user would actually experience
+(RUE-1493).
+
+Peer samples answer to the same sanity rules as Rue's, and to the epoch's
+sample count, for the same reason: a peer is the denominator of a published
+ratio, and a zero-duration, non-zero-exit, or single-sample denominator is not
+a measurement of anything. A peer observation carrying one cannot have come
+from the harness — it abandons a leg rather than recording a partial one — so
+it is refused outright rather than tiered as an invalid sample.
+
 The file-set criterion carries a documented allowlist for tool-mandated
 differences — sitemap emission, feed filename mapping, static passthrough —
 rather than an unstated assumption of exact equality. Static passthrough is
@@ -640,13 +708,17 @@ website-publish pipeline rather than adding a new schedule:
   which loses a whole run object. It is the concrete thing to watch when
   Decision 9's cost review happens.
 - **Peers are re-measured on events, not on a clock.** Pinned Zola and Hugo
-  results move only when their inputs move, so the full peer leg runs only
-  when the recorded fixture identity changes (content, static assets,
-  template ports, parity configs), a peer toolchain is bumped, or the
-  runner regime starts a new epoch. The per-push job detects an identity
-  change at fixture-preparation time and runs the peer leg in that same
+  results move only when their inputs move, so the full peer leg runs
+  exactly when the recorded **comparison-configuration identity** changes:
+  the workload identity (content, static assets, assembly rules, gazette's
+  port), a peer template port or parity config, the peer preparer itself,
+  a peer toolchain version, or the runner epoch. That identity is composed
+  of precisely those components (Decision 2), so the event question is one
+  digest comparison and cannot fall out of step with the join condition
+  below. The per-push job
+  asks it at fixture-preparation time and runs the peer leg in that same
   run. Between events, the derive step joins gazette observations against
-  the latest full peer observation with matching fixture identity.
+  the latest full peer observation whose **both** identities match.
 - **A peer canary rides every run.** One single-threaded Zola build of the
   1x corpus runs alongside every gazette observation — cheap on this
   corpus, and enough to give every observation a same-run ratio
@@ -663,11 +735,21 @@ website-publish pipeline rather than adding a new schedule:
   expensive leaves per-push collection with its canary.
 
   Between events, the derived comparison table JOINS each observation to the
-  latest full peer leg with a matching fixture identity, and marks which rows
-  came from which run. Without that join the table is whatever the newest run
-  happened to carry, which is the canary alone — one peer, one thread policy —
-  so the three-tool comparison this ADR promises would appear for one push
-  after each event and then disappear.
+  latest full peer leg whose workload identity AND comparison-configuration
+  identity both match, and marks which rows came from which run. Without that
+  join the table is whatever the newest run happened to carry, which is the
+  canary alone — one peer, one thread policy — so the three-tool comparison
+  this ADR promises would appear for one push after each event and then
+  disappear.
+
+  The table is built from the newest run's **publishable** observations, and
+  from no older run. Two rules follow, and RUE-1493 added both after the
+  first implementation published around them. A report deliberately held back
+  from the series — one that lost its canary, or whose Rue observation was
+  truncated — publishes no median, so it has no ratio either. And a newest run
+  with no valid denominator renders the empty state rather than an older
+  table: reaching back would show a comparison that reads as current while
+  the one thing the reader needs to know goes unsaid.
 - **Scale variants have a safety valve.** The 1x corpus runs per push; if
   the 10x/100x variants prove too expensive for per-push collection, they
   move to a scheduled cadence without changing any other policy.
@@ -781,6 +863,17 @@ because each changes what a later reader should expect.
   one copy of every page as well as every original, and fixture preparation
   gives each page its type explicitly, which is the same translation the corpus
   already performs for Zola through `template`.
+
+  Required CI could not see that class either, because it ran the cross-tool
+  check at 1x, where nothing is duplicated and the question is never asked.
+  RUE-1493 moved it to a **2x** fixture: the smallest DUPLICATED corpus, which
+  covers every original page plus one copy of each, so it strictly includes
+  what the 1x lane checked and adds the duplicated layout, type, and feed
+  selection for roughly twice the build work rather than ten times. 2x is not a
+  rung of the published curve and is deliberately absent from
+  `performance/runtime.toml`; it exists to be checked, not plotted. Verified by
+  reverting the page-type translation above: the 1x lane still passed and the
+  2x lane failed on 260 duplicated pages.
 - **Hugo is pinned at v0.152.2 rather than at the newest release**, because
   from v0.153.0 Hugo publishes macOS only as a `.pkg` installer, which DotSlash
   cannot extract, and `aarch64-macos` is a row of this matrix.
@@ -944,7 +1037,8 @@ by this ADR and stays in the project as future scope.
 - [ADR-0071: Release-quality compiler performance contract](0071-release-quality-compiler-performance-contract.md)
 - Linear: Runtime performance benchmarking project — RUE-1045 (this ADR),
   RUE-1046, RUE-1047, RUE-1048, RUE-1049, RUE-1481, RUE-1482, RUE-1483,
-  RUE-1484, RUE-1485, RUE-1488 (this amendment's platform matrix).
+  RUE-1484, RUE-1485, RUE-1488 (the platform matrix), RUE-1493 (Decision 2's
+  identity split, and the peer-evidence rules that gate publication).
 - Linear: RUE-945 — the `@syscall` carry-flag normalization on
   `aarch64-macos` that the deferred macOS row was waiting for.
 - Prior art: the Computer Language Benchmarks Game (comparison layout,

--- a/performance/runtime.toml
+++ b/performance/runtime.toml
@@ -210,9 +210,124 @@ description = "the same corpus at ten copies, by deterministic path-prefixed dup
 kind = "semantic_site_pages"
 path = "scripts/gazette-corpus-diff.py"
 
-# The pinned reference regime. Epoch 1 implements suite revision 1 and no
-# longer collects; epoch 2 implements revision 2 and does. Declaring a new
-# epoch rather than moving epoch 1 to the new revision is what keeps every
+# ===========================================================================
+# SUITE REVISION 3 (RUE-1493) pins preparer revision 2: the identity split.
+#
+# The workloads are revision 2's, unchanged in what they measure. What changed
+# is the preparer, and therefore what an observation RECORDS. ADR-0072
+# Decision 2 now asks for two identities rather than one:
+#
+#   * the WORKLOAD identity — corpus, static assets, assembly rules, and
+#     gazette's own template port — which segments Rue's longitudinal series
+#     and must not move when a peer port does; and
+#   * the COMPARISON-CONFIGURATION identity — that, plus every peer port, the
+#     peer preparer's own digest and revision, every peer version, and the
+#     epoch — which is what a joined peer row is published against.
+#
+# Revision 2's single identity did both jobs and did neither correctly: a Hugo
+# template edit opened a new segment in gazette's own series, while a Hugo shim
+# bump moved no recorded identity at all, so a failed full peer leg left the
+# next canary-only run joining a row measured under a version no longer pinned.
+#
+# The preparer is two files as of this revision, and the second is why the peer
+# digest is in the list above: `scripts/gazette_peer_ports.py` holds the peer
+# ports, the corpus respelling, the peers' invocations and thread parity, and
+# the cross-tool oracle. It is separate precisely so a change to any of them
+# moves the comparison identity and not the workload one — the `preparer`
+# pinned below is hashed into the WORKLOAD identity, so a peer knob sharing
+# that file would segment Rue's series for a change no gazette build reads.
+#
+# `preparer_revision` is bumped rather than the digest left to move on its own,
+# for the reason ADR-0067 gives for every pin: a harness running the older
+# preparer would produce records with no comparison identity, and refusing that
+# at preparation time is clearer than discovering it as an unappendable record.
+#
+# REVISION 2 STAYS DECLARED, and so do 1 and the epochs that implement them.
+# Records already in the store name their suite revision and their epoch, and a
+# manifest that forgot either could not validate them. That is the same reason
+# epoch 1 was retired rather than repointed at revision 2.
+# ===========================================================================
+[[suite]]
+revision = 3
+protocol_version = 1
+measured_boundary = "spawn_to_exit_v1"
+
+[[suite.workloads]]
+id = "wordfreq"
+source = "examples/wordfreq/main.rue"
+question = "How fast does a compiled Rue program tokenize and count words in tens of MiB of text?"
+program_args = ["{fixture}"]
+
+[suite.workloads.fixture]
+kind = "seeded_generator"
+category = "recorded"
+generator = "zipf_ascii_text"
+generator_revision = 1
+seed = 20260813
+bytes = 33554432
+vocabulary_size = 65536
+file_name = "wordfreq-input.txt"
+description = "32 MiB of deterministic ASCII word text with Zipf-distributed word ranks"
+
+[suite.workloads.oracle]
+kind = "golden_stdout"
+path = "performance/fixtures/wordfreq/expected-stdout.txt"
+
+[[suite.workloads]]
+id = "gazette"
+source = "examples/gazette/main.rue"
+question = "How fast does a compiled Rue program build the real rue-lang.dev site, against the production tools that build sites for a living?"
+program_args = ["build", "{fixture}", "-o", "{output}"]
+
+[suite.workloads.fixture]
+kind = "corpus_tree"
+category = "recorded"
+preparer = "scripts/gazette-corpus-diff.py"
+preparer_revision = 2
+scale = 1
+excluded = ["performance.md", "runtime.md"]
+root_name = "gazette-site"
+description = "the live rue-lang.dev content plus the copied specification, as website/build.sh assembles it, minus the two pages whose templates read derived benchmark data"
+
+# `path` LOCATES AND INVOKES the judge rather than digesting it, which is why
+# it stays one path while the judge became two files in this revision. The
+# gazette-side half is the script named here, and its digest rides
+# `oracle.reference_sha256` on every observation; the cross-tool half is
+# `scripts/gazette_peer_ports.py`, whose digest rides the comparison identity
+# instead. Each half's identity is recorded next to the thing it can
+# invalidate — the workload's judgement, and the comparison's — which is the
+# same partition the two preparers make.
+[suite.workloads.oracle]
+kind = "semantic_site_pages"
+path = "scripts/gazette-corpus-diff.py"
+
+# The 10x rung, unchanged from revision 2 but for the preparer pin. The two
+# honesty notes revision 2 records about this axis — it is a page-count curve,
+# and the specification sidebar collapses on a duplicated page — apply here
+# exactly as they did there.
+[[suite.workloads]]
+id = "gazette_10x"
+source = "examples/gazette/main.rue"
+question = "How does a compiled Rue site build scale with page count, at ten copies of the corpus?"
+program_args = ["build", "{fixture}", "-o", "{output}"]
+
+[suite.workloads.fixture]
+kind = "corpus_tree"
+category = "recorded"
+preparer = "scripts/gazette-corpus-diff.py"
+preparer_revision = 2
+scale = 10
+excluded = ["performance.md", "runtime.md"]
+root_name = "gazette-site-10x"
+description = "the same corpus at ten copies, by deterministic path-prefixed duplication"
+
+[suite.workloads.oracle]
+kind = "semantic_site_pages"
+path = "scripts/gazette-corpus-diff.py"
+
+# The pinned reference regime. Epoch 1 implements suite revision 1, epoch 2
+# revision 2, and epoch 3 revision 3; only the last collects. Declaring a new
+# epoch rather than moving an old one to the new revision is what keeps every
 # record already in the store valid: a stored report names the epoch it ran
 # under, and that epoch must go on describing the run it describes.
 [[epoch]]
@@ -388,7 +503,8 @@ runner_image = "local"
 samples = 2
 
 # ===========================================================================
-# EPOCH 2: suite revision 2, the epoch that collects (RUE-1485).
+# EPOCH 2: suite revision 2 (RUE-1485). SUPERSEDED by epoch 3 and kept
+# declared, because the records taken under it name it.
 #
 # One new thing is declared per platform beyond the added workloads: the peer
 # policy. Thread policy belongs to the epoch rather than the suite because it
@@ -416,7 +532,10 @@ compiler_args = ["-O3"]
 optimization = "o3"
 thread_policy = "single_threaded"
 hardware_counters = "unavailable_on_hosted_runner"
-collection = true
+# Superseded by epoch 3, which implements suite revision 3 and pins the
+# comparison-configuration identity. Kept declared so the reports already
+# stored under it stay readable and valid.
+collection = false
 
 [epoch.environment]
 runner_label = "github-hosted"
@@ -470,7 +589,10 @@ compiler_args = ["-O3"]
 optimization = "o3"
 thread_policy = "single_threaded"
 hardware_counters = "unavailable_on_hosted_runner"
-collection = true
+# Superseded by epoch 3, which implements suite revision 3 and pins the
+# comparison-configuration identity. Kept declared so the reports already
+# stored under it stay readable and valid.
+collection = false
 
 [epoch.environment]
 runner_label = "github-hosted"
@@ -516,7 +638,10 @@ compiler_args = ["-O3"]
 optimization = "o3"
 thread_policy = "single_threaded"
 hardware_counters = "unavailable_on_hosted_runner"
-collection = true
+# Superseded by epoch 3, which implements suite revision 3 and pins the
+# comparison-configuration identity. Kept declared so the reports already
+# stored under it stay readable and valid.
+collection = false
 
 [epoch.environment]
 runner_label = "github-hosted"
@@ -590,3 +715,221 @@ primary_thread_policy = "pinned_single_thread"
 secondary_thread_policy = "tool_default_parallel"
 canary_tool = "zola"
 canary_scale = 1
+
+# ===========================================================================
+# EPOCH 3: suite revision 3, the epoch that collects (RUE-1493).
+#
+# Everything about how these platforms run the workload is epoch 2's — same
+# runners, same sampling policies, same thread parity, same canary. One thing
+# is new, and it is the reason the epoch is new rather than epoch 2 being
+# edited: `records_comparison_identity`.
+#
+# ADR-0072 Decision 2 now records TWO identities per observation. The workload
+# identity segments Rue's own series and covers only what gazette consumes;
+# the comparison-configuration identity covers the peer ports, the peer
+# preparer's own digest, every peer version, and this epoch, and is what the
+# derive step joins a canary-only run to an earlier full peer leg on. Requiring it closes two holes at once: a
+# peer port change no longer segments gazette's wall-clock series, and a peer
+# VERSION bump can no longer leave a stale row joined in behind a failed full
+# leg.
+#
+# THE STORE IS APPEND-ONLY, so the requirement arrives with a new epoch rather
+# than as a rule applied backwards. Epoch 2's records carry no comparison
+# identity and never could; they stay valid, keep publishing, and keep joining
+# on the workload identity alone, which is the condition they were collected
+# under. This is the mechanism that retired epoch 1 in RUE-1485, used again
+# for the same reason.
+# ===========================================================================
+
+[[epoch]]
+id = 3
+platform = "x86_64-linux"
+suite_revision = 3
+target = "x86-64-linux"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = true
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+# Unchanged from epoch 2: five samples of each per-push workload, three at
+# 10x. No `[epoch.calibration]` and no `[epoch.flagging]` either — calibration
+# is a property of a workload on a platform and is never inherited, not from
+# the compiler suites and not from this platform's own earlier epoch, so
+# gazette arrives advisory here exactly as it did there.
+[epoch.sampling.wordfreq]
+samples = 5
+
+[epoch.sampling.gazette]
+samples = 5
+
+[epoch.sampling.gazette_10x]
+samples = 3
+
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+# The declaration that makes the comparison identity mandatory here. Every
+# observation of this workload must record which peer ports and which peer
+# versions its peer legs were configured by — including a canary-only one,
+# which measures a single tool and must still say what the others were pinned
+# at, or a bump whose full leg never succeeded leaves no trace in the data.
+records_comparison_identity = true
+
+[epoch.peers.gazette_10x]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 10
+records_comparison_identity = true
+
+[[epoch]]
+id = 3
+platform = "aarch64-linux"
+suite_revision = 3
+target = "aarch64-linux"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = true
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+# The runner is `ubuntu-24.04-arm`; the image it reports is `ubuntu-24.04`,
+# which is how ADR-0067's aarch64-linux epochs already record this regime.
+[epoch.sampling.wordfreq]
+samples = 5
+
+[epoch.sampling.gazette]
+samples = 5
+
+[epoch.sampling.gazette_10x]
+samples = 3
+
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+# The declaration that makes the comparison identity mandatory here. Every
+# observation of this workload must record which peer ports and which peer
+# versions its peer legs were configured by — including a canary-only one,
+# which measures a single tool and must still say what the others were pinned
+# at, or a bump whose full leg never succeeded leaves no trace in the data.
+records_comparison_identity = true
+
+[epoch.peers.gazette_10x]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 10
+records_comparison_identity = true
+
+[[epoch]]
+id = 3
+platform = "aarch64-macos"
+suite_revision = 3
+target = "aarch64-macos"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = true
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "macos-15"
+
+# Nine, as in epoch 2, and for the same reason: this row is off the per-push
+# path, has no calibration of its own, and a larger n per observation makes
+# the dispersion estimate that calibration will be built from converge sooner.
+[epoch.sampling.wordfreq]
+samples = 9
+
+[epoch.sampling.gazette]
+samples = 9
+
+[epoch.sampling.gazette_10x]
+samples = 3
+
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+# The declaration that makes the comparison identity mandatory here. Every
+# observation of this workload must record which peer ports and which peer
+# versions its peer legs were configured by — including a canary-only one,
+# which measures a single tool and must still say what the others were pinned
+# at, or a bump whose full leg never succeeded leaves no trace in the data.
+records_comparison_identity = true
+
+[epoch.peers.gazette_10x]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 10
+records_comparison_identity = true
+
+[[epoch]]
+id = 3
+platform = "local"
+suite_revision = 3
+target = "x86-64-linux"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = false
+
+[epoch.environment]
+runner_label = "local"
+runner_image = "local"
+
+# The development epoch for local runs, at suite revision 3. Not a collection
+# target: its environment policy admits only `local`, so a hosted runner
+# cannot append to it and a laptop cannot append to the reference series.
+[epoch.sampling.wordfreq]
+samples = 2
+
+[epoch.sampling.gazette]
+samples = 2
+
+[epoch.sampling.gazette_10x]
+samples = 2
+
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+# The declaration that makes the comparison identity mandatory here. Every
+# observation of this workload must record which peer ports and which peer
+# versions its peer legs were configured by — including a canary-only one,
+# which measures a single tool and must still say what the others were pinned
+# at, or a bump whose full leg never succeeded leaves no trace in the data.
+records_comparison_identity = true
+
+[epoch.peers.gazette_10x]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 10
+records_comparison_identity = true

--- a/scripts/gazette-corpus-diff.py
+++ b/scripts/gazette-corpus-diff.py
@@ -104,67 +104,137 @@ import time
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_URL = "https://rue-lang.dev"
 
-# The gazette half of ADR-0072 Decision 2's "template ports and parity
-# configurations". The DIGEST below is the authoritative identity — it is
-# computed from the bytes and cannot drift — and this integer is the
-# human-legible label a maintainer bumps when changing the port deliberately,
-# so a reader of two observations can say "the port moved" without diffing two
-# hashes. Both ride every recorded identity.
-# REVISION 2 (RUE-1485) adds the two peer ports. All three ride one revision
-# and one digest deliberately: the peer leg is event-driven on the recorded
-# fixture identity (ADR-0072 Decision 9), so a change to the Zola or Hugo port
-# has to move that identity or the next collection would join fresh gazette
-# observations to peer numbers taken under a port that no longer exists.
-PORT_REVISION = 2
+# The peer half of the comparison, in its own file so that its digest rides the
+# COMPARISON identity and not the workload one (RUE-1493). `sys.path` already
+# has this directory when the script is run directly; naming it explicitly
+# keeps a `-P`-style invocation from turning a design decision into an
+# ImportError.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import gazette_peer_ports as peer_ports  # noqa: E402
+
+# ADR-0072 Decision 2's "template ports and parity configurations", split in
+# two because they answer two different questions (RUE-1493).
+#
+# THE PARTITION IS THE POINT. Gazette's own port is an input to the program
+# under measurement: change a gazette template and gazette does different work,
+# so the change must open a new segment in Rue's longitudinal series. The Zola
+# and Hugo ports are not inputs to gazette at all — no gazette build reads them
+# — so a Hugo layout edit that cannot change what gazette does must NOT segment
+# gazette's series. Revision 2 rode all three on one digest, which was wrong in
+# both directions at once: too aggressive for Rue's series, and (since peer
+# VERSIONS were outside the identity entirely) too weak for the peer join.
+#
+# The split is a FILE split and not only a digest one, because this file's own
+# digest is inside the workload identity: peer pins that lived here would move
+# that identity every time a maintainer bumped one. The peer half is
+# `gazette_peer_ports.py`, whose digest rides the comparison identity alone.
+#
+# The DIGESTS are authoritative, computed from the bytes and unable to drift;
+# the revisions are the human-legible labels a maintainer bumps when changing a
+# port deliberately, so a reader of two observations can say "the port moved"
+# without diffing two hashes.
+#
+# The revision stays at 2 through RUE-1493: no gazette template changed here,
+# and a label that advanced anyway would tell a reader diffing two observations
+# that the port moved when it did not. What changed is the COMPOSITION of the
+# identities, which `PREPARER_REVISION` records.
+GAZETTE_PORT_REVISION = 2
 
 # The revision of the FIXTURE ASSEMBLY this script implements, which
-# `performance/runtime.toml` pins for the gazette workloads. It is not the port
-# revision: the port is what the tools render, and this is how the tree they
-# render is built — the corpus assembly, the exclusions, the normalizations, and
-# the scale duplication. Bump it whenever any of those changes what a tool
-# consumes, so a manifest pinning an assembly this script no longer implements
-# is refused rather than silently measuring a different job. The seeded
-# generator's `generator_revision` is checked the same way and for the same
-# reason.
-PREPARER_REVISION = 1
+# `performance/runtime.toml` pins for the gazette workloads. It is not a port
+# revision: a port is what a tool renders, and this is how the tree they render
+# is built — the corpus assembly, the exclusions, the normalizations, the scale
+# duplication, and the composition of the identities recorded with every
+# observation. Bump it whenever any of those changes what a tool consumes or
+# what an observation records, so a manifest pinning an assembly this script no
+# longer implements is refused rather than silently measuring a different job.
+# The seeded generator's `generator_revision` is checked the same way and for
+# the same reason.
+#
+# REVISION 2 (RUE-1493) splits the recorded identity in two: `fixture_digest`
+# now covers only what gazette consumes, and `comparison_digest` covers the
+# peer ports and peer versions beside it. A harness pinning revision 1 would
+# get no comparison identity at all, so it is refused here rather than left to
+# produce records that cannot join.
+PREPARER_REVISION = 2
 
-PORT_ROOTS = [
+# What gazette itself renders. Inside the workload identity. The peers' roots
+# are `peer_ports.PEER_PORT_ROOTS`, deliberately in the other file.
+GAZETTE_PORT_ROOTS = [
     "examples/gazette/config.toml",
     "examples/gazette/templates",
-    "performance/ports/zola/config.toml",
-    "performance/ports/zola/templates",
-    "performance/ports/hugo/hugo.toml",
-    "performance/ports/hugo/layouts",
 ]
 
-# The production template set the port derives from, as it stood when
-# PORT_REVISION was last set. ADR-0072's Consequences name the risk this
-# discharges: "Production drift away from the ports quietly erodes the live
-# framing, so website-template changes should include a port review." A comment
-# asking for a review is not a review, so the digest is pinned and the `golden`
-# mode fails when it moves.
+# The corpus rules the peer half borrows: the base URL it strips from a link
+# target, the front-matter fence it re-fences a respelled page with, the
+# scale-prefix rule, the file walk, and the route rule. Passed rather than
+# duplicated — two spellings of `route_of` is exactly the silent divergence
+# Decision 2 exists to prevent — and passed rather than imported back, so the
+# dependency runs one way and the peer file can be hashed on its own.
+def corpus_rules() -> peer_ports.CorpusRules:
+    return peer_ports.CorpusRules(
+        base_url=BASE_URL,
+        front_matter=FRONT_MATTER,
+        unprefixed=unprefixed,
+        walk_files=walk_files,
+        route_of=route_of,
+    )
+
+# The production template set the ports derive from, as it stood at the last
+# review. ADR-0072's Consequences name the risk this discharges: "Production
+# drift away from the ports quietly erodes the live framing, so website-template
+# changes should include a port review." A comment asking for a review is not a
+# review, so the digest is pinned and the `golden` mode fails when it moves.
+#
+# IT STAYS ON THE WORKLOAD SIDE of the RUE-1493 split, in this file, even though
+# the review it forces covers all three ports. Two reasons. It is not an input
+# to either recorded identity — no observation carries it, and it changes no
+# measurement — so it is a review gate rather than an identity, and putting a
+# gate in the comparison file would make a production-template edit move the
+# comparison digest and re-run the peer leg for a change no tool consumed. And
+# `website/templates` is GAZETTE's production source: the peer ports are ports
+# OF gazette's port, so the review starts here and reaches them through it.
 #
 # When it fires, the fix is to look at what changed in `website/templates/`,
-# decide whether the port should follow, change the port if it should, then
-# advance PORT_REVISION and paste the new digest here. Advancing the revision
-# is not busywork: it is what moves the recorded fixture identity, which is
-# what starts a new comparable segment in the series rather than shifting an
-# existing one under a reader.
+# decide whether each port should follow, change the ports that should, then
+# advance the revision of each port that moved and paste the new digest here.
+# Advancing a revision is not busywork, and it is now two separate decisions:
+# GAZETTE_PORT_REVISION is what moves the WORKLOAD identity, PEER_PORT_REVISION
+# (in `gazette_peer_ports.py`) is what moves the COMPARISON identity, and a
+# moved identity starts a new comparable segment in that series rather than
+# shifting an existing one under a reader. A re-pin on its own advances
+# neither: the digest tracks the tree it was measured in, and the revisions
+# track the ports.
 #
-# The digest below was re-pinned for RUE-1495, and the review it records went
-# this way: the change was again to `runtime.html`, the template of a page
-# EXCLUDED from the benchmark corpus, so no port template derives from it and
-# none should follow. It moved because that page gained the side-by-side source
-# panel ADR-0072 Decision 8 asks for. `PORT_REVISION` did NOT advance, which is
-# the difference from the entry this one replaces: RUE-1485 advanced it because
-# the peer ports joined the fixture identity in that same change, not because a
-# re-pin requires it. Advancing it here would move the recorded fixture identity
-# — opening a new comparable segment in the published series — to record a
-# presentation change no port followed, which is the cost the paragraph above
-# says the revision exists to buy deliberately.
+# THE LEDGER OF REVIEWS, newest last. Each entry records what moved and what
+# followed, because the conclusion "no port follows" is the part a later reader
+# needs and the part a bare digest cannot carry.
+#
+#   RUE-1485. `runtime.html` moved: the cross-tool table it renders gained data
+#   and the captions for the scale axis. It is the template of a page EXCLUDED
+#   from the benchmark corpus, so no port template derives from it and none
+#   followed. The port revision advanced anyway, for an unrelated reason in the
+#   same change — the peer ports joined the fixture identity.
+#
+#   RUE-1495. `runtime.html` again, for the side-by-side source panel ADR-0072
+#   Decision 8 asks for. Same conclusion, no port followed, and the revision
+#   deliberately did NOT advance: advancing it would have opened a new
+#   comparable segment to record a presentation change no port followed, which
+#   is exactly the cost the paragraph above says a revision exists to buy
+#   deliberately.
+#
+#   RUE-1493. `runtime.html` again, and the same conclusion for the third time:
+#   an excluded page's template, no port follows. It moved because the empty
+#   state now says what a newest run that publishes no denominator means, and
+#   because a joined row is now published against the peer configuration as well
+#   as the corpus. Neither port revision advanced FOR this: no port's bytes
+#   moved in this change, and a revision that advanced anyway would tell a
+#   reader diffing two observations that a port moved when it did not. What did
+#   change is the COMPOSITION of the identities, which PREPARER_REVISION
+#   records.
 PRODUCTION_TEMPLATE_ROOT = "website/templates"
 PRODUCTION_TEMPLATE_DIGEST = (
-    "42fba7bb7afa44ac63e3846e244fde959cea2fc21a80194b07fa238d8f7dd4e5"
+    "9fca5d6f31b479ca98b3db44e010bf1893556ac6b2030dc4661db0eb7d4acf8d"
 )
 
 # Pages Zola emits no rendered body for, so `body` mode has nothing to compare
@@ -820,6 +890,34 @@ def tree_digest(root: str, files: list[str] | None = None) -> tuple[str, int, in
     return digest.hexdigest(), len(listed), total
 
 
+# The scale variants this script can assemble.
+#
+# 1, 10, and 100 are ADR-0072 Decision 2's page-count rungs; 1 and 10 are the
+# collected suite and 100 is the safety valve held in reserve. 2 IS NOT A RUNG
+# OF THE PUBLISHED CURVE and never enters `performance/runtime.toml` — it is
+# the smallest fixture that is DUPLICATED, and duplication is the property
+# required CI needs to exercise (RUE-1493).
+#
+# The failure class it exists for is real and was found the expensive way:
+# Hugo picks a page's layout from its PATH, so every copy under an `xN-KK/`
+# prefix fell out of the specification layout and rendered with no sidebar,
+# while the emitted file set and the page count stayed exactly right at every
+# scale. Nothing at 1x can see that, because at 1x nothing is duplicated. A 2x
+# fixture asks the same question as a 10x one — is a copy translated into each
+# tool's dialect the way its original is — for a fifth of the corpus work,
+# which is what keeps it inside a required lane's budget (Decision 9's cost
+# valve).
+#
+# ITS RESIDUAL, stated rather than left to be discovered: one copy answers "is a
+# copy treated like its original", and nothing else. A defect that needs SEVERAL
+# copies — a collision between two copies' routes, a cache keyed on something
+# only many copies collide on, a threshold an aggregation crosses at some page
+# count — is invisible here exactly as it was at 1x. The 10x rung still runs on
+# the collection regime and the 100x variant is still available from this
+# script, which is where a defect of that shape would surface.
+SCALES = (1, 2, 10, 100)
+
+
 def duplicate_corpus(content: str, scale: int) -> None:
     """The deterministic path-prefixed duplication of ADR-0072 Decision 2.
 
@@ -908,20 +1006,7 @@ def prepare_fixture(root: str, scale: int) -> dict:
     shutil.copytree(static_source, os.path.join(root, "static"),
                     ignore=shutil.ignore_patterns("performance-data.json"))
 
-    port_digest = hashlib.sha256()
-    port_files = 0
-    port_bytes = 0
-    for entry in PORT_ROOTS:
-        path = os.path.join(REPO, entry)
-        if os.path.isdir(path):
-            digest, count, size = tree_digest(path)
-        else:
-            digest, count, size = tree_digest(os.path.dirname(path),
-                                              [os.path.basename(path)])
-        port_digest.update(entry.encode("utf-8"))
-        port_digest.update(digest.encode("ascii"))
-        port_files += count
-        port_bytes += size
+    port_digest, port_files, port_bytes = port_identity(GAZETTE_PORT_ROOTS)
 
     identity = {
         "scale": scale,
@@ -954,21 +1039,56 @@ def prepare_fixture(root: str, scale: int) -> dict:
         "static_digest": static_digest,
         "static_files": static_count,
         "static_bytes": static_bytes,
-        "port_revision": PORT_REVISION,
-        "port_digest": port_digest.hexdigest(),
-        "port_files": port_files,
-        "port_bytes": port_bytes,
+        # GAZETTE's port alone. The peer ports are not inputs to gazette — no
+        # gazette build reads them — so including them here would open a new
+        # segment in Rue's own wall-clock series for a Hugo template edit that
+        # cannot change what gazette does. They ride the comparison identity
+        # instead (ADR-0072 Decision 2, RUE-1493).
+        "gazette_port_revision": GAZETTE_PORT_REVISION,
+        "gazette_port_digest": port_digest,
+        "gazette_port_files": port_files,
+        "gazette_port_bytes": port_bytes,
         "excluded": sorted(CORPUS_EXCLUSIONS),
     }
     # One digest over all of it, so an observation can be matched to a segment
-    # with a single comparison. Every input class is inside it: no static asset,
-    # template, or configuration change can alter the measured job without
-    # changing this value.
-    fingerprint = hashlib.sha256()
-    for key in sorted(identity):
-        fingerprint.update(("%s=%s;" % (key, identity[key])).encode("utf-8"))
-    identity["fixture_digest"] = fingerprint.hexdigest()
+    # with a single comparison. Every input class GAZETTE consumes is inside it:
+    # no content, static asset, gazette template, configuration, or assembly-rule
+    # change can alter the measured job without changing this value.
+    identity["fixture_digest"] = compose_digest(identity)
     return identity
+
+
+def port_identity(roots: list[str]) -> tuple[str, int, int]:
+    """One digest, file count, and byte count over a set of port roots."""
+    digest = hashlib.sha256()
+    files = 0
+    total = 0
+    for entry in roots:
+        path = os.path.join(REPO, entry)
+        if os.path.isdir(path):
+            entry_digest, count, size = tree_digest(path)
+        else:
+            entry_digest, count, size = tree_digest(os.path.dirname(path),
+                                                    [os.path.basename(path)])
+        digest.update(entry.encode("utf-8"))
+        digest.update(entry_digest.encode("ascii"))
+        files += count
+        total += size
+    return digest.hexdigest(), files, total
+
+
+def compose_digest(fields: dict) -> str:
+    """One digest over a set of identity fields, in sorted key order.
+
+    Deliberately over-sensitive — editing a comment in this file moves
+    `preparer_digest` and so moves the workload identity — because the failure
+    it prevents is silent and the failure it causes is a visible discontinuity
+    in a series read for order of magnitude.
+    """
+    fingerprint = hashlib.sha256()
+    for key in sorted(fields):
+        fingerprint.update(("%s=%s;" % (key, fields[key])).encode("utf-8"))
+    return fingerprint.hexdigest()
 
 
 # ---------------------------------------------------------------------------
@@ -1405,8 +1525,8 @@ def check_port_sync() -> list[str]:
         return []
     return ["%s changed (now %d files, %d bytes, digest %s) without a port "
             "review: check whether examples/gazette/templates/ should follow, "
-            "then advance PORT_REVISION and PRODUCTION_TEMPLATE_DIGEST in "
-            "scripts/gazette-corpus-diff.py"
+            "then advance GAZETTE_PORT_REVISION and PRODUCTION_TEMPLATE_DIGEST "
+            "in scripts/gazette-corpus-diff.py"
             % (PRODUCTION_TEMPLATE_ROOT, count, size, digest)]
 
 
@@ -1478,237 +1598,23 @@ def golden_mode(options) -> int:
         else:
             shutil.rmtree(work, ignore_errors=True)
 
-
 # ===========================================================================
-# The cross-tool leg — ADR-0072 Phase 5 (RUE-1485)
+# The cross-tool leg — ADR-0072 Phase 5 (RUE-1485), Phase 5's identity split
+# (RUE-1493)
 # ===========================================================================
 #
-# Three tools build the identical corpus and are judged against each other.
-# Everything in this section serves one of the three rules the comparison rests
-# on, and each is a rule an unfair benchmark would break quietly:
+# The peers' half of it lives in `gazette_peer_ports.py` and not here, because
+# this file's digest is inside the WORKLOAD identity. Everything about what the
+# peers do — the pinned tools, their ports, Hugo's dialect of the corpus, the
+# invocations, the thread parity, and the cross-tool oracle — belongs to the
+# COMPARISON identity instead, and sharing a file would have meant sharing a
+# digest: bumping a peer port revision, or fixing a Hugo respelling defect,
+# would open a new segment in Rue's own wall-clock series for a change no
+# gazette build can observe (ADR-0072 Decision 2).
 #
-#   WORK EQUIVALENCE (Decision 4). Identical emitted file sets, per-tool
-#   determinism, page counts, non-empty pages, and a normalized semantic
-#   comparison of every page across all three tools. A peer that skipped work
-#   would beat gazette and fail here.
-#
-#   THREAD PARITY (Decision 5). Rue has no concurrency and hosted runners have
-#   four vCPUs, so the primary published ratio pins the peers to one worker
-#   thread. Their default parallel configuration is measured too and published
-#   as a clearly labelled secondary row — never hidden, never primary.
-#
-#   FAIRNESS OF CONFIGURATION (Decision 3). The peers are configured to skip
-#   the same work gazette skips, not less and not more. The parity configs are
-#   versioned beside the ports and hashed into the recorded fixture identity.
-
-# The pinned peers, as repository-root dotslash shims.
-PEERS = ("zola", "hugo")
-
-# Thread policies a peer is measured under. The FIRST is the primary published
-# ratio's denominator; the second is the secondary row.
-#
-# `RAYON_NUM_THREADS` is Zola's rendering pool; `GOMAXPROCS` is Hugo's
-# scheduler. Neither is a fairness fudge in gazette's favour — pinning the
-# peers to one thread makes the comparison per unit of work rather than per
-# core, and the four-way-parallel numbers are published beside it so the figure
-# a user would actually experience is never hidden.
-THREAD_POLICIES = ("pinned_single_thread", "tool_default_parallel")
-
-PEER_THREAD_ENV = {
-    "zola": {"pinned_single_thread": {"RAYON_NUM_THREADS": "1"},
-             "tool_default_parallel": {}},
-    "hugo": {"pinned_single_thread": {"GOMAXPROCS": "1"},
-             "tool_default_parallel": {}},
-}
-
-# The documented allowlist ADR-0072 Decision 4 requires for tool-mandated
-# differences in the emitted file set. It is deliberately as small as the tools
-# allow, because every entry is a place a tool could skip a page and hide
-# behind an excuse — so a difference that CAN be configured away is configured
-# away in the parity configs rather than allowed here. Three candidates were
-# removed that way and are named so the absence is legible rather than
-# accidental: Hugo's sitemap and robots.txt (`disableKinds`), Hugo's per-section
-# and site-wide feeds (`[outputs]`), and the feed FILENAME mapping the ADR
-# anticipated — `[outputFormats.rss] baseName` puts Hugo's feed at the same
-# route Zola's and gazette's occupy, so the routes themselves are compared.
-#
-# Static passthrough is the third difference the ADR names and needs no entry
-# either: all three tools copy the same `website/static` tree, and its bytes
-# are part of the recorded fixture identity.
-FILE_SET_ALLOWLIST = {
-    "zola": {
-        "404.html": (
-            "Zola always writes a 404 page, from a built-in template when the "
-            "site has none, and offers no switch to suppress it. Hugo emits "
-            "one only when a layout exists, and the Hugo port deliberately has "
-            "none, so this is the one difference no configuration can remove"
-        ),
-    },
-    "hugo": {},
-}
-
-
-def peer_binary(tool: str) -> str:
-    return os.path.join(REPO, tool)
-
-
-def peer_version(tool: str) -> str:
-    """The pinned peer's own version string, recorded with every observation."""
-    argv = [peer_binary(tool), "--version" if tool == "zola" else "version"]
-    result = subprocess.run(argv, capture_output=True, text=True)
-    if result.returncode != 0:
-        raise SystemExit("could not read %s's version:\n%s" % (tool, result.stderr))
-    text = result.stdout.strip().splitlines()[0]
-    if tool == "zola":
-        return text.split()[-1]
-    # `hugo v0.152.2-6abdac… darwin/arm64 BuildDate=…`
-    return text.split()[1].split("-")[0].lstrip("v")
-
-
-# ---------------------------------------------------------------------------
-# Hugo's dialect of the same corpus
-# ---------------------------------------------------------------------------
-#
-# The corpus is written in Zola's dialect, so the Hugo leg needs it respelled:
-# Hugo cannot read `{{ rule(id="…") }}` or `@/path.md` any more than Zola could
-# read `{{< rule id="…" >}}`. The translation is mechanical, deterministic, and
-# happens at fixture-preparation time, outside every measured window.
-#
-# WHAT IT MAY NOT DO is the part worth stating. It respells calls; it never
-# performs them. `@/spec/03-types.md` becomes `{{< relref "/spec/03-types.md" >}}`
-# rather than a resolved URL, so Hugo still resolves the link itself; shortcode
-# invocations keep their arguments and are still expanded by Hugo's shortcode
-# machinery. Resolving either host-side would move measured work out of the
-# measured program, and no output check would notice, because the resolved page
-# looks the same either way.
-
-SHORTCODE_CALL = re.compile(r"\{\{\s*([a-z_]+)\((.*?)\)\s*\}\}", re.S)
-SHORTCODE_ARG = re.compile(r'([a-z_]+)\s*=\s*("[^"]*")')
-INTERNAL_LINK = re.compile(r"\]\(@/([^)\s]+)\)")
-
-
-def hugoize(corpus: str) -> None:
-    """Respell the corpus in Hugo's dialect, in place."""
-    for dirpath, _dirs, files in os.walk(corpus):
-        for name in sorted(files):
-            if not name.endswith(".md"):
-                continue
-            path = os.path.join(dirpath, name)
-            with open(path, encoding="utf-8") as handle:
-                text = handle.read()
-            found = FRONT_MATTER.match(text)
-            if not found:
-                raise SystemExit("%s does not open with a `+++` fence" % path)
-            front, body = found.group(1), text[found.end():]
-
-            added = []
-            # WHICH TEMPLATE RENDERS THIS PAGE, in Hugo's spelling. The corpus
-            # already tells Zola, in `template` and `page_template`; Hugo's
-            # equivalent is the page's type, and translating one into the other
-            # is the same kind of respelling as the shortcode syntax below.
-            #
-            # It is also load-bearing, which is why it is not left to Hugo's
-            # default. Hugo derives an untyped page's layout from its PATH, and
-            # ADR-0072 Decision 2's scale variants live under `xN-KK/` prefixes
-            # — so at 10x every copy of a specification page fell out of
-            # `layouts/spec/` and rendered through the plain page layout, with
-            # no sidebar at all: 17,940 bytes where gazette and Zola emit
-            # 22,443 and 22,630. Nine tenths of the corpus, with the most
-            # expensive template in the port skipped, while the file set and
-            # the page count stayed exactly right. Setting the type from the
-            # UNPREFIXED path makes a copy render as its original does.
-            section = unprefixed(
-                os.path.relpath(path, corpus).replace(os.sep, "/"))
-            if "/" in section:
-                added.append('type = "%s"' % section.split("/", 1)[0])
-            # Zola asks for a section feed with `generate_feeds`; Hugo asks for
-            # one by naming the section's output formats. Same feed, same
-            # route, each tool's own spelling.
-            if re.search(r"^generate_feeds = true", front, re.M):
-                added.append('outputs = ["html", "rss"]')
-            # Zola acts on `redirect_to` natively; Hugo selects a layout by
-            # name. The TARGET is still resolved by Hugo's template.
-            if re.search(r"^redirect_to = ", front, re.M):
-                added.append('layout = "redirect"')
-            # The corpus's root `_index.md` names the landing-page template
-            # explicitly, and Zola and gazette honour that key wherever the page
-            # sits. Hugo reserves its home layout for the site root, so a
-            # DUPLICATED root — `x10-00/_index.md`, one per copy at scale — is
-            # an ordinary section to it and rendered as one, dropping the hero,
-            # the specimen, and the recent-notes list the other two tools build.
-            # Naming the layout is the same translation as `redirect_to` above.
-            elif re.search(r'^template = "index\.html"', front, re.M):
-                added.append('layout = "landing"')
-
-            body = SHORTCODE_CALL.sub(
-                lambda match: "{{< %s %s >}}" % (
-                    match.group(1),
-                    " ".join("%s=%s" % pair
-                             for pair in SHORTCODE_ARG.findall(match.group(2)))),
-                body)
-            body = INTERNAL_LINK.sub(
-                lambda match: '](%s)' % ('{{< relref "/%s" >}}' % match.group(1)),
-                body)
-            # Zola's summary marker spelled Hugo's way.
-            body = body.replace("<!-- more -->", "<!--more-->")
-
-            # PREPENDED, not appended, and the difference is not cosmetic: TOML
-            # binds a bare key to the last table header above it, and the blog
-            # posts' front matter ends with an `[extra]` table. Appending put
-            # `type` inside it, where Hugo never looks, so every duplicated blog
-            # post silently rendered through the generic page layout — no
-            # byline, no title block. Top-level keys go above the first table.
-            trailer = "\n".join(added) + "\n" if added else ""
-            with open(path, "w", encoding="utf-8") as handle:
-                handle.write("+++\n" + trailer + front + "+++\n" + body)
-
-
-# ---------------------------------------------------------------------------
-# Preparing all three sites from one corpus
-# ---------------------------------------------------------------------------
-
-
-def prepare_peer_site(tool: str, root: str, corpus: str, static: str) -> str:
-    """Lay out one peer's site root beside gazette's, from the same corpus."""
-    site = os.path.join(root, tool)
-    os.makedirs(site)
-    shutil.copytree(corpus, os.path.join(site, "content"))
-    if tool == "zola":
-        shutil.copytree(os.path.join(REPO, "performance/ports/zola/templates"),
-                        os.path.join(site, "templates"))
-        shutil.copy(os.path.join(REPO, "performance/ports/zola/config.toml"),
-                    os.path.join(site, "config.toml"))
-    else:
-        shutil.copytree(os.path.join(REPO, "performance/ports/hugo/layouts"),
-                        os.path.join(site, "layouts"))
-        shutil.copy(os.path.join(REPO, "performance/ports/hugo/hugo.toml"),
-                    os.path.join(site, "hugo.toml"))
-        hugoize(os.path.join(site, "content"))
-    shutil.copytree(static, os.path.join(site, "static"))
-    return site
-
-
-def peer_command(tool: str, site: str, out: str, work: str) -> list[str]:
-    """The measured invocation, identical in shape for both peers.
-
-    Hugo's cache is pointed at a path inside this run's own work directory, so
-    nothing survives from a previous run or from a developer's home directory —
-    which is what would otherwise make the first sample of a run do work the
-    rest do not. It is shared BETWEEN this run's samples, and that is fine here
-    because it stays empty: nothing in the equivalence subset populates it, and
-    the emitted trees are byte-identical across samples, which is the property
-    the determinism check asserts. `--noBuildLock` keeps a lock left by a killed
-    sample from stalling the next one.
-    """
-    if tool == "zola":
-        # `--root` is Zola's global flag and has to precede the subcommand.
-        return [peer_binary("zola"), "--root", site, "build", "--output-dir", out]
-    return [peer_binary("hugo"),
-            "--source", site,
-            "--destination", out,
-            "--cacheDir", os.path.join(work, "hugo-cache"),
-            "--noBuildLock"]
-
+# What stays here is what measures ALL THREE tools with one clock and one
+# reaping, because a comparison whose tools were timed differently measures the
+# harness.
 
 def run_process(argv: list[str], environment: dict) -> dict:
     """One measured process, spawn to exit, with THIS child's peak RSS.
@@ -1737,283 +1643,36 @@ def run_process(argv: list[str], environment: dict) -> dict:
     }
 
 
-# ---------------------------------------------------------------------------
-# The cross-tool semantic oracle
-# ---------------------------------------------------------------------------
-
-SKIP_TEXT_IN = {"script", "style"}
-
-
-class Facets(html.parser.HTMLParser):
-    """The normalized extraction ADR-0072 Decision 4 compares across tools.
-
-    Exactly the facets the Decision names — the heading tree, visible text, and
-    link and image targets, in document order — and nothing else. What it
-    deliberately drops is what three different renderers and three different
-    template languages are entitled to disagree about: element structure, class
-    and id attributes, whitespace, and entity spelling.
-
-    That is a weaker comparison than the gazette-vs-Zola body oracle, which
-    compares the full event stream contiguously, and it is weaker for a stated
-    reason rather than a convenient one: Goldmark and pulldown-cmark do not
-    emit the same markup for the same Markdown, and requiring them to would
-    make the check fail on every page for a difference ADR-0072's Terminology
-    already calls a non-goal. What it still catches is every way a tool can do
-    LESS WORK: a dropped paragraph, a missing heading, an unexpanded shortcode,
-    an unresolved link, a page whose sidebar was not rendered for that page.
-    """
-
-    def __init__(self, route: str = "") -> None:
-        super().__init__(convert_charrefs=True)
-        self.route = route
-        self.headings: list = []
-        self.text: list = []
-        self.links: list = []
-        self._skip = 0
-        self._heading = None
-
-    def handle_starttag(self, tag, attrs):
-        fields = dict(attrs)
-        if tag in SKIP_TEXT_IN:
-            self._skip += 1
-        if tag in ("h1", "h2", "h3", "h4", "h5", "h6"):
-            self._heading = [tag, ""]
-        if tag == "a" and fields.get("href"):
-            self.links.append(normalize_target(fields["href"], self.route))
-        if tag == "img" and fields.get("src"):
-            self.links.append(normalize_target(fields["src"], self.route))
-
-    def handle_endtag(self, tag):
-        if tag in SKIP_TEXT_IN and self._skip:
-            self._skip -= 1
-        if tag in ("h1", "h2", "h3", "h4", "h5", "h6") and self._heading:
-            self.headings.append((self._heading[0], self._heading[1].strip()))
-            self._heading = None
-
-    def handle_data(self, data):
-        if self._skip:
-            return
-        squashed = " ".join(data.split())
-        if not squashed:
-            return
-        self.text.append(squashed)
-        if self._heading is not None:
-            self._heading[1] += " " + squashed
-
-
-def normalize_target(href: str, route: str = "") -> str:
-    """A link target in the one spelling every tool can be held to.
-
-    THE SAME DESTINATION, WRITTEN THREE WAYS, is not three destinations, and
-    the three tools genuinely write it three ways:
-
-      * Absolute or root-relative. Hugo's `absURL` and Zola's `get_url` do not
-        always agree about which to emit, and a browser cannot tell them apart.
-
-      * A bare fragment. The corpus writes `[Directives](#directives)`; Zola
-        resolves it against the page's own permalink and Hugo leaves it as
-        CommonMark wrote it. Both land on the same place.
-
-      * Relative. `[math](01-math/)` on the standard-library index resolves
-        against the page in every browser, and Zola resolves it at build time
-        while Hugo does not. It is the corpus's ONLY page-relative destination
-        — the `../…` ones are parent-relative and every tool leaves those as
-        authored — so it is the single case that makes this bullet load-
-        bearing rather than hypothetical. Until RUE-1492 it read `math/` and
-        named a route no tool emits, and what the comparison showed then was
-        that all three agreed on the dead route; what it shows now is that all
-        three agree on the live one. Either way the agreement only exists once
-        both spellings are resolved, which is this function's job.
-
-    Resolving here rather than allowing three spellings is what lets the
-    comparison stay a strict equality: a link that genuinely moved still fails.
-    """
-    target = href.strip()
-    if target.startswith(BASE_URL):
-        target = target[len(BASE_URL):] or "/"
-    if "://" in target.split("?", 1)[0].split("#", 1)[0] or target.startswith("mailto:"):
-        return target
-    if target.startswith("//"):
-        return target
-    if target.startswith("#"):
-        target = "/" + route + target
-    elif not target.startswith("/"):
-        target = "/" + route + target
-    fragment = ""
-    if "#" in target:
-        target, fragment = target.split("#", 1)
-        fragment = "#" + fragment
-    return target.rstrip("/") + "/" + fragment if target != "/" else "/" + fragment
-
-
-def facets(page: str, route: str = "") -> dict:
-    parser = Facets(route)
-    parser.feed(page)
-    return {
-        "headings": parser.headings,
-        "text": parser.text,
-        "links": parser.links,
-    }
-
-
-def compare_facets(reference: dict, other: dict, name: str, peer: str) -> list[str]:
-    faults = []
-    for facet in ("headings", "text", "links"):
-        want, have = reference[facet], other[facet]
-        if want == have:
-            continue
-        missing = [item for item in want if item not in have]
-        extra = [item for item in have if item not in want]
-        faults.append(
-            "%s: %s differs from gazette's (%d vs %d; %d missing, %d extra%s)"
-            % (name, facet, len(want), len(have), len(missing), len(extra),
-               "; first missing %r" % (missing[0],) if missing else ""))
-    return ["%s %s" % (peer, fault) for fault in faults]
-
-
-def cross_tool_check(gazette_out: str, peer_outs: dict, model: Model,
-                     scale: int) -> tuple[dict, list[str]]:
-    """Work equivalence across the three tools (ADR-0072 Decision 4)."""
-    faults: list[str] = []
-    report: dict = {}
-
-    emitted = {"gazette": set(walk_files(gazette_out))}
-    for tool, out in sorted(peer_outs.items()):
-        emitted[tool] = set(walk_files(out))
-
-    # 1. The emitted file sets, with the documented allowlist.
-    for tool, files in sorted(emitted.items()):
-        if tool == "gazette":
-            continue
-        allowed = FILE_SET_ALLOWLIST.get(tool, {})
-        extra = sorted(files - emitted["gazette"] - set(allowed))
-        absent = sorted(emitted["gazette"] - files)
-        unused = sorted(set(allowed) - files)
-        if extra:
-            faults.append("%s emits %d file(s) gazette does not, none of them "
-                          "allowlisted: %s" % (tool, len(extra), extra[:6]))
-        if absent:
-            faults.append("%s emits %d fewer file(s) than gazette: %s"
-                          % (tool, len(absent), absent[:6]))
-        for rel in unused:
-            faults.append(
-                "the file-set allowlist entry %s/%s no longer applies: the tool "
-                "stopped emitting it, so the entry is stale and must go" % (tool, rel))
-
-    # 2. Page counts and non-emptiness. A tool cannot win by writing stubs.
-    #
-    # The redirect stub is the one page that IS a stub in all three tools, by
-    # design and byte for byte, so it is named here rather than raising the
-    # threshold until nothing trips it.
-    stubs = {route_of(key) + "index.html" for key in model.redirects()}
-    pages = {}
-    for tool, files in sorted(emitted.items()):
-        out = gazette_out if tool == "gazette" else peer_outs[tool]
-        html_files = sorted(rel for rel in files if rel.endswith("index.html"))
-        pages[tool] = len(html_files)
-        empty = [rel for rel in html_files
-                 if rel not in stubs
-                 and os.path.getsize(os.path.join(out, rel)) < 512]
-        if empty:
-            faults.append("%s emitted %d page(s) under 512 bytes: %s"
-                          % (tool, len(empty), empty[:6]))
-    wanted_pages = len(model.pages) * 1
-    for tool, count in sorted(pages.items()):
-        if count != wanted_pages:
-            faults.append("%s emitted %d page(s); the corpus has %d"
-                          % (tool, count, wanted_pages))
-    report["pages"] = pages
-
-    # 3. The semantic oracle, across all three tools: every original page, plus
-    #    ONE COPY OF EACH at scale.
-    #
-    #    Comparing all 9,600 copies at 100x would buy nothing — they are the
-    #    same documents at other permalinks — but comparing NONE of them was a
-    #    blind spot with a defect already sitting in it. Hugo picks a page's
-    #    layout from its path unless told otherwise, so every duplicate fell
-    #    out of the specification layout and rendered without a sidebar: nine
-    #    tenths of the corpus, with the port's most expensive template skipped,
-    #    while the emitted file set and the page count stayed exactly right.
-    #    One copy of each page costs a second and closes the hole, and the
-    #    copies are byte-identical to each other so one is as good as all.
-    prefix = "" if scale == 1 else "x%d-00/" % scale
-    compared = 0
-    redirects = set(model.redirects())
-    for pass_prefix in ("",) if scale == 1 else ("", prefix):
-        for rel in sorted(model.pages):
-            if not rel.startswith(pass_prefix) or (
-                pass_prefix == "" and SCALE_PREFIX.match(rel)
-            ):
-                continue
-            if rel in redirects:
-                # A stub carries no page semantics; `check_redirects` asserts
-                # the thing that matters about it, which is its target.
-                continue
-            route = route_of(rel)
-            reference_path = os.path.join(gazette_out, route, "index.html")
-            if not os.path.exists(reference_path):
-                continue
-            reference = facets(open(reference_path, encoding="utf-8").read(), route)
-            for tool, out in sorted(peer_outs.items()):
-                path = os.path.join(out, route, "index.html")
-                if not os.path.exists(path):
-                    faults.append("%s emitted no page for %s" % (tool, rel))
-                    continue
-                faults += compare_facets(
-                    reference, facets(open(path, encoding="utf-8").read(), route), rel, tool)
-            compared += 1
-    report["oracle_pages"] = compared
-
-    # 4. The feed, across tools: same entries, same order, and the same fields
-    #    carried per entry.
-    #
-    #    The last of those is not fussiness. Zola's BUILT-IN feed — which it
-    #    falls back to when a site ships no `rss.xml` template, as this port
-    #    once did — renders every post's full rendered body into its
-    #    `<description>`, which is Markdown rendering and escaping that the
-    #    other two tools do not perform. Comparing `<link>` order alone said
-    #    the feeds agreed while one tool was doing twice the work, growing with
-    #    every post. So the emptiness PATTERN of the descriptions is compared
-    #    too: which entries carry one is a property of the corpus, and any tool
-    #    disagreeing about it is doing a different job.
-    for key in model.feeds():
-        route = route_of(key)
-        wanted = ["%s/%s" % (BASE_URL, route_of(rel)) for rel in model.members[key]]
-        shapes = {}
-        for tool, out in sorted({**peer_outs, "gazette": gazette_out}.items()):
-            path = os.path.join(out, route, "rss.xml")
-            if not os.path.exists(path):
-                faults.append("%s emitted no feed at %srss.xml" % (tool, route))
-                continue
-            feed = open(path, encoding="utf-8").read()
-            entries = [normalize_target(link)
-                       for link in re.findall(r"<link>([^<]*)</link>", feed)[1:]]
-            if entries != [normalize_target(link) for link in wanted]:
-                faults.append("%s feed order %s, expected %s"
-                              % (tool, entries[:3], wanted[:3]))
-            shapes[tool] = [bool(body.strip()) for body in
-                            re.findall(r"<description>(.*?)</description>", feed, re.S)[1:]]
-        if "gazette" in shapes:
-            for tool, shape in sorted(shapes.items()):
-                if tool != "gazette" and shape != shapes["gazette"]:
-                    faults.append(
-                        "%s's feed carries descriptions on %d of %d entries where "
-                        "gazette carries them on %d: one tool is rendering post "
-                        "bodies into the feed that the others are not"
-                        % (tool, sum(shape), len(shape), sum(shapes["gazette"])))
-    return report, faults
-
 
 # ---------------------------------------------------------------------------
 # Fixture preparation for the whole comparison
 # ---------------------------------------------------------------------------
 
 
-def prepare_comparison(root: str, scale: int, peers: bool) -> dict:
-    """Assemble every tool's site from one corpus and record the identity.
+def prepare_comparison(root: str, scale: int, peers: bool, epoch: str = "") -> dict:
+    """Assemble every tool's site from one corpus and record both identities.
 
     All of it is outside the measured window: assembly, duplication, the
     peers' respelling, and the hashing. Only the builds that follow are timed.
+
+    TWO IDENTITIES, not one (ADR-0072 Decision 2, as amended by RUE-1493):
+
+      * The WORKLOAD identity — `identity["fixture_digest"]` — is everything
+        gazette consumes: the corpus, the static passthrough, the assembly
+        rules, and gazette's own port. It segments Rue's longitudinal series,
+        and it must not move when a peer port does.
+      * The COMPARISON identity — `identity["comparison_digest"]` — is the
+        workload identity plus every peer port, the peer preparer's own digest
+        and revision, every peer version, and the runner epoch. It is what the
+        derive step joins a canary-only run to an earlier full peer leg on, and
+        it is what the peer-leg event question below is asked against.
+
+    The peer VERSIONS are inside the comparison identity rather than beside
+    it, which is the half revision 2 was missing: a Hugo shim bump moved no
+    recorded identity at all, so a failed full leg left the next canary-only
+    run joining a Hugo row measured under a version the project no longer
+    pins — self-labelled, and therefore not a misattributed number, but a row
+    published against a pin that had never successfully run.
     """
     identity = prepare_fixture(root, scale)
     description = {
@@ -2021,16 +1680,57 @@ def prepare_comparison(root: str, scale: int, peers: bool) -> dict:
         "scale": scale,
         "roots": {"gazette": root},
         "peer_versions": {},
-        "thread_policies": list(THREAD_POLICIES),
+        "epoch": epoch,
+        "thread_policies": list(peer_ports.THREAD_POLICIES),
     }
     if not peers:
         return description
 
     corpus = os.path.join(root, "content")
     static = os.path.join(root, "static")
-    for tool in PEERS:
-        description["roots"][tool] = prepare_peer_site(tool, root, corpus, static)
-        description["peer_versions"][tool] = peer_version(tool)
+    for tool in peer_ports.PEERS:
+        description["roots"][tool] = peer_ports.prepare_peer_site(
+            tool, root, corpus, static, corpus_rules())
+        description["peer_versions"][tool] = peer_ports.peer_version(tool)
+
+    peer_digest, peer_files, peer_bytes = port_identity(
+        peer_ports.PEER_PORT_ROOTS)
+    identity["peer_port_revision"] = peer_ports.PEER_PORT_REVISION
+    identity["peer_port_digest"] = peer_digest
+    identity["peer_port_files"] = peer_files
+    identity["peer_port_bytes"] = peer_bytes
+    # The peer PREPARER's own digest, the mirror of `preparer_digest` in the
+    # workload identity and the reason the two files exist. What decides what
+    # the peers DO — the respelling, the invocations, the thread parity, the
+    # cross-tool oracle, and the port pins above — is in that file, so this
+    # digest moves when any of them does and the workload identity does not.
+    # Over-sensitive for the same reason its counterpart is: editing a comment
+    # there opens a new comparable segment for the COMPARISON, and the failure
+    # it prevents is a joined row published against rules that changed under it.
+    #
+    # ONE PIECE STAYED BEHIND, and the claim above is bounded by it. `peer_event`
+    # decides whether the peers run at all, and it reads the identity composed
+    # here, so moving it would invert the one-way dependency the split bought.
+    # Editing it therefore still moves `preparer_digest` and still segments
+    # Rue's series for a peer-side change — the residual of finding 3 rather
+    # than an oversight, named here so a later reader weighs it rather than
+    # rediscovers it.
+    identity["peer_preparer"] = os.path.relpath(peer_ports.__file__, REPO)
+    identity["peer_preparer_digest"] = tree_digest(
+        os.path.dirname(os.path.abspath(peer_ports.__file__)),
+        [os.path.basename(peer_ports.__file__)],
+    )[0]
+    identity["peer_versions"] = json.dumps(description["peer_versions"],
+                                           sort_keys=True)
+    identity["comparison_epoch"] = epoch
+    identity["comparison_digest"] = compose_digest({
+        "fixture_digest": identity["fixture_digest"],
+        "peer_port_revision": peer_ports.PEER_PORT_REVISION,
+        "peer_port_digest": peer_digest,
+        "peer_preparer_digest": identity["peer_preparer_digest"],
+        "peer_versions": identity["peer_versions"],
+        "epoch": epoch,
+    })
     return description
 
 
@@ -2053,9 +1753,33 @@ CANARY_SCALE = 1
 
 
 def peer_event(description: dict, epoch: str, state_path: str | None) -> dict:
-    """Whether the full peer leg is due, and why."""
+    """Whether the full peer leg is due, and why.
+
+    ONE QUESTION, asked of the comparison identity: did anything the joined
+    rows depend on move? That identity is composed of exactly what a joined row
+    depends on — the workload identity, the peer ports and their revision, the
+    peer preparer's own digest, the peer versions, and the epoch — so the
+    verdict is a single digest comparison and cannot fall out of step with what
+    the derive step joins on. The components are still compared individually,
+    but only to say WHICH one moved; the digest decides, and a move it sees
+    that no component explains still runs the leg.
+
+    THIS FUNCTION STAYS ON THE WORKLOAD SIDE, and it is the one thing about the
+    peers that does. It reads the composed comparison identity, so moving it
+    into `gazette_peer_ports.py` would invert the one-way dependency the file
+    split bought. The residual is real and worth naming: editing the Decision 9
+    event logic here moves `preparer_digest`, and so opens a new segment in
+    Rue's own series for a change that only decides whether the peers run. It
+    is bounded by being one function that changes rarely, where the peer
+    respelling and the ports it was separated from change with every parity
+    expansion.
+    """
+    identity = description["identity"]
     current = {
-        "fixture_digest": description["identity"]["fixture_digest"],
+        "comparison_digest": identity.get("comparison_digest", ""),
+        "fixture_digest": identity["fixture_digest"],
+        "peer_port_digest": identity.get("peer_port_digest", ""),
+        "peer_preparer_digest": identity.get("peer_preparer_digest", ""),
         "peer_versions": description["peer_versions"],
         "epoch": epoch,
     }
@@ -2078,16 +1802,32 @@ def peer_event(description: dict, epoch: str, state_path: str | None) -> dict:
                 "state": current}
     reasons = []
     if previous.get("fixture_digest") != current["fixture_digest"]:
-        reasons.append("the recorded fixture identity moved")
+        reasons.append("the recorded workload identity moved")
+    if previous.get("peer_port_digest") != current["peer_port_digest"]:
+        reasons.append("a peer template port moved")
+    if previous.get("peer_preparer_digest") != current["peer_preparer_digest"]:
+        reasons.append("the peer preparer moved")
     if previous.get("peer_versions") != current["peer_versions"]:
         reasons.append("a peer toolchain version moved (%s -> %s)"
                        % (previous.get("peer_versions"), current["peer_versions"]))
     if previous.get("epoch") != current["epoch"]:
         reasons.append("the runner epoch changed (%s -> %s)"
                        % (previous.get("epoch"), current["epoch"]))
-    return {"due": bool(reasons),
+    moved = previous.get("comparison_digest") != current["comparison_digest"]
+    if moved and not reasons:
+        # The digest is authoritative; a move it sees and the components above
+        # do not means the identity's own composition changed, which is a
+        # preparer change and just as much an event.
+        reasons.append("the comparison identity moved (%s -> %s)"
+                       % (str(previous.get("comparison_digest"))[:12],
+                          current["comparison_digest"][:12]))
+    # `or reasons` runs the leg when a component moved and the digest did not,
+    # which can only be a composition defect. The conservative direction costs
+    # a redundant peer run; the other costs a segment of joined ratios.
+    return {"due": moved or bool(reasons),
             "reason": "; ".join(reasons) or
-                      "fixture identity, peer versions, and epoch are unchanged",
+                      "workload identity, peer ports, peer preparer, peer "
+                      "versions, and epoch are unchanged",
             "state": current}
 
 
@@ -2101,15 +1841,22 @@ def peers_mode(options) -> int:
     try:
         root = os.path.join(work, "site")
         os.makedirs(root)
-        description = prepare_comparison(root, options.scale, peers=True)
+        # This mode runs wherever it was invoked rather than on a pinned
+        # regime, so it has no runner epoch to name. The comparison identity it
+        # prints is therefore the epoch-less one and will not equal a
+        # collection run's; the workload identity above it is the same value
+        # collection records, since the epoch is not one of its inputs.
+        description = prepare_comparison(root, options.scale, peers=True,
+                                         epoch=options.epoch)
         identity = description["identity"]
         model = Model(os.path.join(root, "content"))
 
-        print("fixture identity (recorded with every observation, ADR-0072 Decision 2)")
+        print("recorded identities (both ride every observation, ADR-0072 "
+              "Decision 2)")
         for key in sorted(identity):
-            print("  %-16s %s" % (key, identity[key]))
+            print("  %-22s %s" % (key, identity[key]))
         print("peers (pinned; every observation records both versions)")
-        for tool in PEERS:
+        for tool in peer_ports.PEERS:
             print("  %-16s %s" % (tool, description["peer_versions"][tool]))
 
         measurements: dict = {}
@@ -2147,18 +1894,18 @@ def peers_mode(options) -> int:
             "gazette-out")
 
         peer_outs = {}
-        for tool in PEERS:
-            for policy in THREAD_POLICIES:
-                if policy != THREAD_POLICIES[0] and not options.secondary:
+        for tool in peer_ports.PEERS:
+            for policy in peer_ports.THREAD_POLICIES:
+                if policy != peer_ports.THREAD_POLICIES[0] and not options.secondary:
                     continue
                 label = "%s/%s" % (tool, policy)
                 out, _ = measure(
                     label,
-                    lambda out, tool=tool: peer_command(
+                    lambda out, tool=tool: peer_ports.peer_command(
                         tool, description["roots"][tool], out, work),
-                    PEER_THREAD_ENV[tool][policy],
+                    peer_ports.PEER_THREAD_ENV[tool][policy],
                     label.replace("/", "-") + "-out")
-                if policy == THREAD_POLICIES[0] and out is not None:
+                if policy == peer_ports.THREAD_POLICIES[0] and out is not None:
                     peer_outs[tool] = out
 
         # DIAGNOSTIC TIMINGS, never published. The published series is taken by
@@ -2177,9 +1924,9 @@ def peers_mode(options) -> int:
                   % (label, median(times), rss / (1024 * 1024),
                      " ".join("%.3f" % value for value in times)))
 
-        if gazette_out is not None and len(peer_outs) == len(PEERS):
-            report, cross_faults = cross_tool_check(
-                gazette_out, peer_outs, model, options.scale)
+        if gazette_out is not None and len(peer_outs) == len(peer_ports.PEERS):
+            report, cross_faults = peer_ports.cross_tool_check(
+                gazette_out, peer_outs, model, options.scale, corpus_rules())
             faults += cross_faults
             print("\nwork equivalence (ADR-0072 Decision 4)")
             print("  page count:         %s" % report["pages"])
@@ -2187,7 +1934,7 @@ def peers_mode(options) -> int:
                   % report["oracle_pages"])
             print("  file-set allowlist: %s"
                   % ({tool: sorted(entries) for tool, entries in
-                      FILE_SET_ALLOWLIST.items() if entries}))
+                      peer_ports.FILE_SET_ALLOWLIST.items() if entries}))
         else:
             faults.append("not every tool produced a build, so work equivalence "
                           "could not be judged")
@@ -2203,7 +1950,7 @@ def peers_mode(options) -> int:
                 if label == "gazette":
                     continue
                 other = median([sample["wall_seconds"] for sample in measurements[label]])
-                marker = "" if label.endswith(THREAD_POLICIES[0]) else "   [secondary]"
+                marker = "" if label.endswith(peer_ports.THREAD_POLICIES[0]) else "   [secondary]"
                 print("  %-32s %.2fx%s" % (label, other / base, marker))
 
         for fault in faults[:20]:
@@ -2273,17 +2020,18 @@ def median(values: list[float]) -> float:
 
 def prepare_mode(options) -> int:
     os.makedirs(options.root, exist_ok=True)
-    description = prepare_comparison(options.root, options.scale, options.peers)
+    description = prepare_comparison(options.root, options.scale, options.peers,
+                                     options.epoch)
     description["commands"] = {
         "gazette": {"argv": ["{program}", "build", options.root, "-o", "{out}"],
                     "env": {}},
     }
-    for tool in PEERS if options.peers else ():
-        for policy in THREAD_POLICIES:
+    for tool in peer_ports.PEERS if options.peers else ():
+        for policy in peer_ports.THREAD_POLICIES:
             description["commands"]["%s/%s" % (tool, policy)] = {
-                "argv": peer_command(tool, description["roots"][tool],
+                "argv": peer_ports.peer_command(tool, description["roots"][tool],
                                      "{out}", options.root),
-                "env": PEER_THREAD_ENV[tool][policy],
+                "env": peer_ports.PEER_THREAD_ENV[tool][policy],
             }
     description["canary"] = {"tool": CANARY_TOOL, "scale": CANARY_SCALE}
     description["preparer_revision"] = PREPARER_REVISION
@@ -2324,13 +2072,14 @@ def judge_mode(options) -> int:
     failures += link_faults
 
     peer_outs = {}
-    for tool in PEERS:
+    for tool in peer_ports.PEERS:
         directory = getattr(options, "%s_out" % tool)
         if directory:
             peer_outs[tool] = directory
     report = {}
     if peer_outs:
-        report, cross_faults = cross_tool_check(out, peer_outs, model, options.scale)
+        report, cross_faults = peer_ports.cross_tool_check(
+            out, peer_outs, model, options.scale, corpus_rules())
         failures += cross_faults
 
     verdict = {
@@ -2363,11 +2112,12 @@ def site_mode(options) -> int:
         identity = prepare_fixture(root, options.scale)
         model = Model(os.path.join(root, "content"))
 
-        print("fixture identity (recorded with every observation, ADR-0072 Decision 2)")
+        print("workload identity (recorded with every observation, ADR-0072 "
+              "Decision 2)")
         for key in sorted(identity):
-            print("  %-16s %s" % (key, identity[key]))
-        print("  %-16s %d" % ("pages", len(model.pages)))
-        print("  %-16s %d" % ("sections", len(model.sections)))
+            print("  %-22s %s" % (key, identity[key]))
+        print("  %-22s %d" % ("pages", len(model.pages)))
+        print("  %-22s %d" % ("sections", len(model.sections)))
         print("excluded from the corpus:")
         for rel, why in sorted(CORPUS_EXCLUSIONS.items()):
             print("  %s — %s" % (rel, why))
@@ -2472,7 +2222,7 @@ def main() -> int:
     modes.add_parser("body", help="RUE-1483's Markdown differential against Zola")
 
     site = modes.add_parser("site", help="RUE-1484's whole-site validation")
-    site.add_argument("--scale", type=int, default=1, choices=(1, 10, 100),
+    site.add_argument("--scale", type=int, default=1, choices=SCALES,
                       help="corpus scale variant (ADR-0072 Decision 2)")
     site.add_argument("--samples", type=int, default=3,
                       help="builds per run; determinism needs at least two")
@@ -2486,18 +2236,22 @@ def main() -> int:
 
     peers = modes.add_parser(
         "peers", help="RUE-1485's cross-tool comparison against Zola and Hugo")
-    peers.add_argument("--scale", type=int, default=1, choices=(1, 10, 100),
+    peers.add_argument("--scale", type=int, default=1, choices=SCALES,
                        help="corpus scale variant (ADR-0072 Decision 2)")
     peers.add_argument("--samples", type=int, default=3,
                        help="builds per tool; determinism needs at least two")
     peers.add_argument("--no-secondary", dest="secondary", action="store_false",
                        help="skip the peers' default-parallel secondary row")
+    peers.add_argument("--epoch", default="",
+                       help="the runner epoch the comparison identity is scoped "
+                            "to; this mode measures nothing publishable, so it "
+                            "defaults to none")
     peers.add_argument("--out", help="write the comparison as JSON")
 
     prepare = modes.add_parser(
         "prepare", help="assemble every tool's fixture and print its identity")
     prepare.add_argument("--root", required=True, help="directory to build the fixture in")
-    prepare.add_argument("--scale", type=int, default=1, choices=(1, 10, 100))
+    prepare.add_argument("--scale", type=int, default=1, choices=SCALES)
     prepare.add_argument("--out", required=True, help="where to write the description")
     prepare.add_argument("--peers", action="store_true",
                          help="also lay out the Zola and Hugo sites")
@@ -2514,7 +2268,7 @@ def main() -> int:
     judge.add_argument("--gazette-out", required=True, help="gazette's emitted tree")
     judge.add_argument("--zola-out", help="Zola's emitted tree, when the peer leg ran")
     judge.add_argument("--hugo-out", help="Hugo's emitted tree, when the peer leg ran")
-    judge.add_argument("--scale", type=int, default=1, choices=(1, 10, 100))
+    judge.add_argument("--scale", type=int, default=1, choices=SCALES)
     judge.add_argument("--out", help="write the verdict as JSON")
 
     options = parser.parse_args()

--- a/scripts/gazette_peer_ports.py
+++ b/scripts/gazette_peer_ports.py
@@ -1,0 +1,557 @@
+"""The peer half of ADR-0072's cross-tool comparison (RUE-1493).
+
+A SEPARATE FILE BECAUSE IT IS A SEPARATE IDENTITY. `gazette-corpus-diff.py`
+composes the WORKLOAD identity, and a digest of that whole file is inside it —
+deliberately over-sensitive, because a rule change that decides what gazette
+consumes must never be able to move the measured job without moving the
+recorded identity.
+
+That is exactly why the peer half cannot live there. Everything in this module
+decides what the PEERS do and nothing about what gazette does: the pinned
+tools and their versions, the peer template ports, Hugo's dialect of the
+corpus, the peers' invocations and thread parity, and the cross-tool oracle
+that judges all three. Sharing a file with the workload rules meant sharing a
+digest with them, so bumping `PEER_PORT_REVISION` — which the port-review
+comment instructs a maintainer to do whenever a peer port moves — opened a new
+segment in Rue's own wall-clock series. So did any edit to `hugoize`, which is
+where ALL THREE Hugo port defects RUE-1485 found were fixed: the page-type
+translation, the duplicated landing page, and the prepend-not-append front
+matter. Those are the very changes ADR-0072 Decision 2 now cites as the reason
+the identity was split, and under one file they would still discard Rue's
+history.
+
+This module's digest therefore rides the COMPARISON identity alone
+(`comparison_digest`), beside the peer ports and the peer versions, and the
+workload identity is blind to it — as it should be, since no gazette build
+reads a line of it.
+
+The dependency runs one way. This module imports nothing from the workload
+preparer; the few corpus rules it needs — the base URL, the front-matter
+fence, the scale-prefix rule, the file walk, and the route rule — arrive as an
+explicit [`CorpusRules`] from the caller. Copying them here would be worse than
+passing them: two spellings of `route_of` is precisely the silent divergence
+Decision 2 exists to prevent, and it would show up as a cross-tool fault
+nobody could attribute.
+"""
+
+from __future__ import annotations
+
+import collections
+import html.parser
+import os
+import re
+import shutil
+import subprocess
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# The corpus rules this module borrows from the workload preparer, passed in
+# rather than duplicated. Every one of them is a property of the CORPUS, so the
+# workload preparer owns it and this module is a consumer.
+CorpusRules = collections.namedtuple(
+    "CorpusRules",
+    ["base_url", "front_matter", "unprefixed", "walk_files", "route_of"])
+
+# The revision of the PEER PREPARATION this file implements — the ports, the
+# respelling, the invocations, and the cross-tool oracle. It is the
+# human-legible label beside this file's digest in the comparison identity, the
+# way the workload preparer's revision sits beside its own; the digest is
+# authoritative because it cannot be forgotten.
+#
+# It stays at 2 through RUE-1493: the identity split moved this code between
+# files without changing a rule of it, and neither peer port's bytes moved. The
+# composition change is recorded by the workload preparer's revision, which is
+# what the manifest pins.
+PEER_PORT_REVISION = 2
+
+# What the PEERS render, and nothing gazette reads. Inside the comparison
+# identity alone.
+PEER_PORT_ROOTS = [
+    "performance/ports/zola/config.toml",
+    "performance/ports/zola/templates",
+    "performance/ports/hugo/hugo.toml",
+    "performance/ports/hugo/layouts",
+]
+
+
+PEERS = ("zola", "hugo")
+
+# Thread policies a peer is measured under. The FIRST is the primary published
+# ratio's denominator; the second is the secondary row.
+#
+# `RAYON_NUM_THREADS` is Zola's rendering pool; `GOMAXPROCS` is Hugo's
+# scheduler. Neither is a fairness fudge in gazette's favour — pinning the
+# peers to one thread makes the comparison per unit of work rather than per
+# core, and the four-way-parallel numbers are published beside it so the figure
+# a user would actually experience is never hidden.
+THREAD_POLICIES = ("pinned_single_thread", "tool_default_parallel")
+
+PEER_THREAD_ENV = {
+    "zola": {"pinned_single_thread": {"RAYON_NUM_THREADS": "1"},
+             "tool_default_parallel": {}},
+    "hugo": {"pinned_single_thread": {"GOMAXPROCS": "1"},
+             "tool_default_parallel": {}},
+}
+
+# The documented allowlist ADR-0072 Decision 4 requires for tool-mandated
+# differences in the emitted file set. It is deliberately as small as the tools
+# allow, because every entry is a place a tool could skip a page and hide
+# behind an excuse — so a difference that CAN be configured away is configured
+# away in the parity configs rather than allowed here. Three candidates were
+# removed that way and are named so the absence is legible rather than
+# accidental: Hugo's sitemap and robots.txt (`disableKinds`), Hugo's per-section
+# and site-wide feeds (`[outputs]`), and the feed FILENAME mapping the ADR
+# anticipated — `[outputFormats.rss] baseName` puts Hugo's feed at the same
+# route Zola's and gazette's occupy, so the routes themselves are compared.
+#
+# Static passthrough is the third difference the ADR names and needs no entry
+# either: all three tools copy the same `website/static` tree, and its bytes
+# are part of the recorded fixture identity.
+FILE_SET_ALLOWLIST = {
+    "zola": {
+        "404.html": (
+            "Zola always writes a 404 page, from a built-in template when the "
+            "site has none, and offers no switch to suppress it. Hugo emits "
+            "one only when a layout exists, and the Hugo port deliberately has "
+            "none, so this is the one difference no configuration can remove"
+        ),
+    },
+    "hugo": {},
+}
+
+
+def peer_binary(tool: str) -> str:
+    return os.path.join(REPO, tool)
+
+
+def peer_version(tool: str) -> str:
+    """The pinned peer's own version string, recorded with every observation."""
+    argv = [peer_binary(tool), "--version" if tool == "zola" else "version"]
+    result = subprocess.run(argv, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise SystemExit("could not read %s's version:\n%s" % (tool, result.stderr))
+    text = result.stdout.strip().splitlines()[0]
+    if tool == "zola":
+        return text.split()[-1]
+    # `hugo v0.152.2-6abdac… darwin/arm64 BuildDate=…`
+    return text.split()[1].split("-")[0].lstrip("v")
+
+
+# ---------------------------------------------------------------------------
+# Hugo's dialect of the same corpus
+# ---------------------------------------------------------------------------
+#
+# The corpus is written in Zola's dialect, so the Hugo leg needs it respelled:
+# Hugo cannot read `{{ rule(id="…") }}` or `@/path.md` any more than Zola could
+# read `{{< rule id="…" >}}`. The translation is mechanical, deterministic, and
+# happens at fixture-preparation time, outside every measured window.
+#
+# WHAT IT MAY NOT DO is the part worth stating. It respells calls; it never
+# performs them. `@/spec/03-types.md` becomes `{{< relref "/spec/03-types.md" >}}`
+# rather than a resolved URL, so Hugo still resolves the link itself; shortcode
+# invocations keep their arguments and are still expanded by Hugo's shortcode
+# machinery. Resolving either host-side would move measured work out of the
+# measured program, and no output check would notice, because the resolved page
+# looks the same either way.
+
+SHORTCODE_CALL = re.compile(r"\{\{\s*([a-z_]+)\((.*?)\)\s*\}\}", re.S)
+SHORTCODE_ARG = re.compile(r'([a-z_]+)\s*=\s*("[^"]*")')
+INTERNAL_LINK = re.compile(r"\]\(@/([^)\s]+)\)")
+
+
+def hugoize(corpus: str, rules: CorpusRules) -> None:
+    """Respell the corpus in Hugo's dialect, in place."""
+    for dirpath, _dirs, files in os.walk(corpus):
+        for name in sorted(files):
+            if not name.endswith(".md"):
+                continue
+            path = os.path.join(dirpath, name)
+            with open(path, encoding="utf-8") as handle:
+                text = handle.read()
+            found = rules.front_matter.match(text)
+            if not found:
+                raise SystemExit("%s does not open with a `+++` fence" % path)
+            front, body = found.group(1), text[found.end():]
+
+            added = []
+            # WHICH TEMPLATE RENDERS THIS PAGE, in Hugo's spelling. The corpus
+            # already tells Zola, in `template` and `page_template`; Hugo's
+            # equivalent is the page's type, and translating one into the other
+            # is the same kind of respelling as the shortcode syntax below.
+            #
+            # It is also load-bearing, which is why it is not left to Hugo's
+            # default. Hugo derives an untyped page's layout from its PATH, and
+            # ADR-0072 Decision 2's scale variants live under `xN-KK/` prefixes
+            # — so at 10x every copy of a specification page fell out of
+            # `layouts/spec/` and rendered through the plain page layout, with
+            # no sidebar at all: 17,940 bytes where gazette and Zola emit
+            # 22,443 and 22,630. Nine tenths of the corpus, with the most
+            # expensive template in the port skipped, while the file set and
+            # the page count stayed exactly right. Setting the type from the
+            # UNPREFIXED path makes a copy render as its original does.
+            section = rules.unprefixed(
+                os.path.relpath(path, corpus).replace(os.sep, "/"))
+            if "/" in section:
+                added.append('type = "%s"' % section.split("/", 1)[0])
+            # Zola asks for a section feed with `generate_feeds`; Hugo asks for
+            # one by naming the section's output formats. Same feed, same
+            # route, each tool's own spelling.
+            if re.search(r"^generate_feeds = true", front, re.M):
+                added.append('outputs = ["html", "rss"]')
+            # Zola acts on `redirect_to` natively; Hugo selects a layout by
+            # name. The TARGET is still resolved by Hugo's template.
+            if re.search(r"^redirect_to = ", front, re.M):
+                added.append('layout = "redirect"')
+            # The corpus's root `_index.md` names the landing-page template
+            # explicitly, and Zola and gazette honour that key wherever the page
+            # sits. Hugo reserves its home layout for the site root, so a
+            # DUPLICATED root — `x10-00/_index.md`, one per copy at scale — is
+            # an ordinary section to it and rendered as one, dropping the hero,
+            # the specimen, and the recent-notes list the other two tools build.
+            # Naming the layout is the same translation as `redirect_to` above.
+            elif re.search(r'^template = "index\.html"', front, re.M):
+                added.append('layout = "landing"')
+
+            body = SHORTCODE_CALL.sub(
+                lambda match: "{{< %s %s >}}" % (
+                    match.group(1),
+                    " ".join("%s=%s" % pair
+                             for pair in SHORTCODE_ARG.findall(match.group(2)))),
+                body)
+            body = INTERNAL_LINK.sub(
+                lambda match: '](%s)' % ('{{< relref "/%s" >}}' % match.group(1)),
+                body)
+            # Zola's summary marker spelled Hugo's way.
+            body = body.replace("<!-- more -->", "<!--more-->")
+
+            # PREPENDED, not appended, and the difference is not cosmetic: TOML
+            # binds a bare key to the last table header above it, and the blog
+            # posts' front matter ends with an `[extra]` table. Appending put
+            # `type` inside it, where Hugo never looks, so every duplicated blog
+            # post silently rendered through the generic page layout — no
+            # byline, no title block. Top-level keys go above the first table.
+            trailer = "\n".join(added) + "\n" if added else ""
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write("+++\n" + trailer + front + "+++\n" + body)
+
+
+# ---------------------------------------------------------------------------
+# Preparing all three sites from one corpus
+# ---------------------------------------------------------------------------
+
+
+def prepare_peer_site(tool: str, root: str, corpus: str, static: str,
+                      rules: CorpusRules) -> str:
+    """Lay out one peer's site root beside gazette's, from the same corpus."""
+    site = os.path.join(root, tool)
+    os.makedirs(site)
+    shutil.copytree(corpus, os.path.join(site, "content"))
+    if tool == "zola":
+        shutil.copytree(os.path.join(REPO, "performance/ports/zola/templates"),
+                        os.path.join(site, "templates"))
+        shutil.copy(os.path.join(REPO, "performance/ports/zola/config.toml"),
+                    os.path.join(site, "config.toml"))
+    else:
+        shutil.copytree(os.path.join(REPO, "performance/ports/hugo/layouts"),
+                        os.path.join(site, "layouts"))
+        shutil.copy(os.path.join(REPO, "performance/ports/hugo/hugo.toml"),
+                    os.path.join(site, "hugo.toml"))
+        hugoize(os.path.join(site, "content"), rules)
+    shutil.copytree(static, os.path.join(site, "static"))
+    return site
+
+
+def peer_command(tool: str, site: str, out: str, work: str) -> list[str]:
+    """The measured invocation, identical in shape for both peers.
+
+    Hugo's cache is pointed at a path inside this run's own work directory, so
+    nothing survives from a previous run or from a developer's home directory —
+    which is what would otherwise make the first sample of a run do work the
+    rest do not. It is shared BETWEEN this run's samples, and that is fine here
+    because it stays empty: nothing in the equivalence subset populates it, and
+    the emitted trees are byte-identical across samples, which is the property
+    the determinism check asserts. `--noBuildLock` keeps a lock left by a killed
+    sample from stalling the next one.
+    """
+    if tool == "zola":
+        # `--root` is Zola's global flag and has to precede the subcommand.
+        return [peer_binary("zola"), "--root", site, "build", "--output-dir", out]
+    return [peer_binary("hugo"),
+            "--source", site,
+            "--destination", out,
+            "--cacheDir", os.path.join(work, "hugo-cache"),
+            "--noBuildLock"]
+
+
+# ---------------------------------------------------------------------------
+# The cross-tool semantic oracle
+# ---------------------------------------------------------------------------
+
+SKIP_TEXT_IN = {"script", "style"}
+
+
+class Facets(html.parser.HTMLParser):
+    """The normalized extraction ADR-0072 Decision 4 compares across tools.
+
+    Exactly the facets the Decision names — the heading tree, visible text, and
+    link and image targets, in document order — and nothing else. What it
+    deliberately drops is what three different renderers and three different
+    template languages are entitled to disagree about: element structure, class
+    and id attributes, whitespace, and entity spelling.
+
+    That is a weaker comparison than the gazette-vs-Zola body oracle, which
+    compares the full event stream contiguously, and it is weaker for a stated
+    reason rather than a convenient one: Goldmark and pulldown-cmark do not
+    emit the same markup for the same Markdown, and requiring them to would
+    make the check fail on every page for a difference ADR-0072's Terminology
+    already calls a non-goal. What it still catches is every way a tool can do
+    LESS WORK: a dropped paragraph, a missing heading, an unexpanded shortcode,
+    an unresolved link, a page whose sidebar was not rendered for that page.
+    """
+
+    def __init__(self, rules: CorpusRules, route: str = "") -> None:
+        super().__init__(convert_charrefs=True)
+        self.rules = rules
+        self.route = route
+        self.headings: list = []
+        self.text: list = []
+        self.links: list = []
+        self._skip = 0
+        self._heading = None
+
+    def handle_starttag(self, tag, attrs):
+        fields = dict(attrs)
+        if tag in SKIP_TEXT_IN:
+            self._skip += 1
+        if tag in ("h1", "h2", "h3", "h4", "h5", "h6"):
+            self._heading = [tag, ""]
+        if tag == "a" and fields.get("href"):
+            self.links.append(
+                normalize_target(self.rules, fields["href"], self.route))
+        if tag == "img" and fields.get("src"):
+            self.links.append(
+                normalize_target(self.rules, fields["src"], self.route))
+
+    def handle_endtag(self, tag):
+        if tag in SKIP_TEXT_IN and self._skip:
+            self._skip -= 1
+        if tag in ("h1", "h2", "h3", "h4", "h5", "h6") and self._heading:
+            self.headings.append((self._heading[0], self._heading[1].strip()))
+            self._heading = None
+
+    def handle_data(self, data):
+        if self._skip:
+            return
+        squashed = " ".join(data.split())
+        if not squashed:
+            return
+        self.text.append(squashed)
+        if self._heading is not None:
+            self._heading[1] += " " + squashed
+
+
+def normalize_target(rules: CorpusRules, href: str, route: str = "") -> str:
+    """A link target in the one spelling every tool can be held to.
+
+    THE SAME DESTINATION, WRITTEN THREE WAYS, is not three destinations, and
+    the three tools genuinely write it three ways:
+
+      * Absolute or root-relative. Hugo's `absURL` and Zola's `get_url` do not
+        always agree about which to emit, and a browser cannot tell them apart.
+
+      * A bare fragment. The corpus writes `[Directives](#directives)`; Zola
+        resolves it against the page's own permalink and Hugo leaves it as
+        CommonMark wrote it. Both land on the same place.
+
+      * Relative. `[math](01-math/)` on the standard-library index resolves
+        against the page in every browser, and Zola resolves it at build time
+        while Hugo does not. It is the corpus's ONLY page-relative destination
+        — the `../…` ones are parent-relative and every tool leaves those as
+        authored — so it is the single case that makes this bullet load-
+        bearing rather than hypothetical. Until RUE-1492 it read `math/` and
+        named a route no tool emits, and what the comparison showed then was
+        that all three agreed on the dead route; what it shows now is that all
+        three agree on the live one. Either way the agreement only exists once
+        both spellings are resolved, which is this function's job.
+
+    Resolving here rather than allowing three spellings is what lets the
+    comparison stay a strict equality: a link that genuinely moved still fails.
+    """
+    target = href.strip()
+    if target.startswith(rules.base_url):
+        target = target[len(rules.base_url):] or "/"
+    if "://" in target.split("?", 1)[0].split("#", 1)[0] or target.startswith("mailto:"):
+        return target
+    if target.startswith("//"):
+        return target
+    if target.startswith("#"):
+        target = "/" + route + target
+    elif not target.startswith("/"):
+        target = "/" + route + target
+    fragment = ""
+    if "#" in target:
+        target, fragment = target.split("#", 1)
+        fragment = "#" + fragment
+    return target.rstrip("/") + "/" + fragment if target != "/" else "/" + fragment
+
+
+def facets(rules: CorpusRules, page: str, route: str = "") -> dict:
+    parser = Facets(rules, route)
+    parser.feed(page)
+    return {
+        "headings": parser.headings,
+        "text": parser.text,
+        "links": parser.links,
+    }
+
+
+def compare_facets(reference: dict, other: dict, name: str, peer: str) -> list[str]:
+    faults = []
+    for facet in ("headings", "text", "links"):
+        want, have = reference[facet], other[facet]
+        if want == have:
+            continue
+        missing = [item for item in want if item not in have]
+        extra = [item for item in have if item not in want]
+        faults.append(
+            "%s: %s differs from gazette's (%d vs %d; %d missing, %d extra%s)"
+            % (name, facet, len(want), len(have), len(missing), len(extra),
+               "; first missing %r" % (missing[0],) if missing else ""))
+    return ["%s %s" % (peer, fault) for fault in faults]
+
+
+def cross_tool_check(gazette_out: str, peer_outs: dict, model,
+                     scale: int, rules: CorpusRules) -> tuple[dict, list[str]]:
+    """Work equivalence across the three tools (ADR-0072 Decision 4)."""
+    faults: list[str] = []
+    report: dict = {}
+
+    emitted = {"gazette": set(rules.walk_files(gazette_out))}
+    for tool, out in sorted(peer_outs.items()):
+        emitted[tool] = set(rules.walk_files(out))
+
+    # 1. The emitted file sets, with the documented allowlist.
+    for tool, files in sorted(emitted.items()):
+        if tool == "gazette":
+            continue
+        allowed = FILE_SET_ALLOWLIST.get(tool, {})
+        extra = sorted(files - emitted["gazette"] - set(allowed))
+        absent = sorted(emitted["gazette"] - files)
+        unused = sorted(set(allowed) - files)
+        if extra:
+            faults.append("%s emits %d file(s) gazette does not, none of them "
+                          "allowlisted: %s" % (tool, len(extra), extra[:6]))
+        if absent:
+            faults.append("%s emits %d fewer file(s) than gazette: %s"
+                          % (tool, len(absent), absent[:6]))
+        for rel in unused:
+            faults.append(
+                "the file-set allowlist entry %s/%s no longer applies: the tool "
+                "stopped emitting it, so the entry is stale and must go" % (tool, rel))
+
+    # 2. Page counts and non-emptiness. A tool cannot win by writing stubs.
+    #
+    # The redirect stub is the one page that IS a stub in all three tools, by
+    # design and byte for byte, so it is named here rather than raising the
+    # threshold until nothing trips it.
+    stubs = {rules.route_of(key) + "index.html" for key in model.redirects()}
+    pages = {}
+    for tool, files in sorted(emitted.items()):
+        out = gazette_out if tool == "gazette" else peer_outs[tool]
+        html_files = sorted(rel for rel in files if rel.endswith("index.html"))
+        pages[tool] = len(html_files)
+        empty = [rel for rel in html_files
+                 if rel not in stubs
+                 and os.path.getsize(os.path.join(out, rel)) < 512]
+        if empty:
+            faults.append("%s emitted %d page(s) under 512 bytes: %s"
+                          % (tool, len(empty), empty[:6]))
+    wanted_pages = len(model.pages) * 1
+    for tool, count in sorted(pages.items()):
+        if count != wanted_pages:
+            faults.append("%s emitted %d page(s); the corpus has %d"
+                          % (tool, count, wanted_pages))
+    report["pages"] = pages
+
+    # 3. The semantic oracle, across all three tools: every original page, plus
+    #    ONE COPY OF EACH at scale.
+    #
+    #    Comparing all 9,600 copies at 100x would buy nothing — they are the
+    #    same documents at other permalinks — but comparing NONE of them was a
+    #    blind spot with a defect already sitting in it. Hugo picks a page's
+    #    layout from its path unless told otherwise, so every duplicate fell
+    #    out of the specification layout and rendered without a sidebar: nine
+    #    tenths of the corpus, with the port's most expensive template skipped,
+    #    while the emitted file set and the page count stayed exactly right.
+    #    One copy of each page costs a second and closes the hole, and the
+    #    copies are byte-identical to each other so one is as good as all.
+    prefix = "" if scale == 1 else "x%d-00/" % scale
+    compared = 0
+    redirects = set(model.redirects())
+    for pass_prefix in ("",) if scale == 1 else ("", prefix):
+        for rel in sorted(model.pages):
+            if not rel.startswith(pass_prefix) or (
+                pass_prefix == "" and rules.unprefixed(rel) != rel
+            ):
+                continue
+            if rel in redirects:
+                # A stub carries no page semantics; `check_redirects` asserts
+                # the thing that matters about it, which is its target.
+                continue
+            route = rules.route_of(rel)
+            reference_path = os.path.join(gazette_out, route, "index.html")
+            if not os.path.exists(reference_path):
+                continue
+            reference = facets(
+                rules, open(reference_path, encoding="utf-8").read(), route)
+            for tool, out in sorted(peer_outs.items()):
+                path = os.path.join(out, route, "index.html")
+                if not os.path.exists(path):
+                    faults.append("%s emitted no page for %s" % (tool, rel))
+                    continue
+                faults += compare_facets(
+                    reference,
+                    facets(rules, open(path, encoding="utf-8").read(), route),
+                    rel, tool)
+            compared += 1
+    report["oracle_pages"] = compared
+
+    # 4. The feed, across tools: same entries, same order, and the same fields
+    #    carried per entry.
+    #
+    #    The last of those is not fussiness. Zola's BUILT-IN feed — which it
+    #    falls back to when a site ships no `rss.xml` template, as this port
+    #    once did — renders every post's full rendered body into its
+    #    `<description>`, which is Markdown rendering and escaping that the
+    #    other two tools do not perform. Comparing `<link>` order alone said
+    #    the feeds agreed while one tool was doing twice the work, growing with
+    #    every post. So the emptiness PATTERN of the descriptions is compared
+    #    too: which entries carry one is a property of the corpus, and any tool
+    #    disagreeing about it is doing a different job.
+    for key in model.feeds():
+        route = rules.route_of(key)
+        wanted = ["%s/%s" % (rules.base_url, rules.route_of(rel))
+                  for rel in model.members[key]]
+        shapes = {}
+        for tool, out in sorted({**peer_outs, "gazette": gazette_out}.items()):
+            path = os.path.join(out, route, "rss.xml")
+            if not os.path.exists(path):
+                faults.append("%s emitted no feed at %srss.xml" % (tool, route))
+                continue
+            feed = open(path, encoding="utf-8").read()
+            entries = [normalize_target(rules, link)
+                       for link in re.findall(r"<link>([^<]*)</link>", feed)[1:]]
+            if entries != [normalize_target(rules, link) for link in wanted]:
+                faults.append("%s feed order %s, expected %s"
+                              % (tool, entries[:3], wanted[:3]))
+            shapes[tool] = [bool(body.strip()) for body in
+                            re.findall(r"<description>(.*?)</description>", feed, re.S)[1:]]
+        if "gazette" in shapes:
+            for tool, shape in sorted(shapes.items()):
+                if tool != "gazette" and shape != shapes["gazette"]:
+                    faults.append(
+                        "%s's feed carries descriptions on %d of %d entries where "
+                        "gazette carries them on %d: one tool is rendering post "
+                        "bodies into the feed that the others are not"
+                        % (tool, sum(shape), len(shape), sum(shapes["gazette"])))
+    return report, faults

--- a/website/static/runtime.js
+++ b/website/static/runtime.js
@@ -814,21 +814,28 @@
     // inside the figure, so this function can only ever add rows to a table
     // that already carries them (ADR-0072 Decision 3).
     //
-    // The rows come from ONE run of the selected platform — the newest one that
-    // measured peers, which is not always the newest run, because peers are
-    // re-measured on events rather than on a clock. That is the honest table to
-    // publish: both sides of every ratio were measured on the same machine in
-    // the same job. An absent comparison renders as the empty state below,
-    // never as an estimate.
+    // The rows come from ONE run of the selected platform: the newest run of
+    // its NEWEST EPOCH, joined to that epoch's latest full peer leg. Both sides
+    // of every ratio were therefore measured on the same machine in the same
+    // job, and every joined row was measured on the same corpus under the same
+    // peer configuration.
+    //
+    // THE NEWEST EPOCH, AND NO OLDER ONE. This walked backwards through the
+    // epochs and drew the first table it found, which was harmless only while
+    // one epoch had peer data. The derive step now returns no comparison
+    // whenever the newest run has no publishable denominator — a lost canary, a
+    // truncated observation, a refused peer row — so a fallback would answer
+    // that state by rendering a RETIRED epoch's table: a different suite
+    // revision, a different workload identity, an older commit, presented as
+    // current, with the empty note that explains the real state hidden behind
+    // it. An absent comparison is the answer, not a prompt to look for another.
     function drawComparison() {
       var figure = document.getElementById("rt-comparison");
       var body = document.getElementById("rt-comparison-rows");
       var emptyNote = document.getElementById("rt-comparison-empty");
       var epochs = current().epochs || [];
-      var comparison = null;
-      for (var i = epochs.length - 1; i >= 0 && !comparison; i--) {
-        comparison = epochs[i].comparison;
-      }
+      var newest = epochs.length ? epochs[epochs.length - 1] : null;
+      var comparison = newest && newest.comparison;
       var rows = (comparison && comparison.rows) || [];
       body.textContent = "";
       if (!rows.length) {
@@ -867,12 +874,14 @@
       if (provenance) {
         var joined = rows.filter(function (entry) { return entry.joined; }).length;
         var text = "Rue and the marked same-run peer were measured together at commit " +
-          shortHash(comparison.commit) + ", against fixture " + comparison.fixture + ".";
+          shortHash(comparison.commit) + ", against workload identity " +
+          comparison.fixture + ".";
         if (joined) {
           text += " " + joined + " row" + (joined === 1 ? " was" : "s were") +
-            " joined from the most recent full peer run on the same fixture, which is " +
-            "why the peers are not re-measured on every commit; those rows control for " +
-            "the input but not for the machine.";
+            " joined from the most recent full peer run on the same corpus AND the same " +
+            "peer configuration — same peer ports, same pinned versions — which is why " +
+            "the peers are not re-measured on every commit; those rows control for the " +
+            "input but not for the machine.";
         }
         provenance.textContent = text;
       }
@@ -894,6 +903,25 @@
           item.textContent = shortHash(note.commit) + " — " + subject +
             note.kind.replace(/_/g, " ") + ", " + note.detail + ". " + meaning;
           list.appendChild(item);
+        });
+      });
+      // What the runner recorded as having gone wrong, on runs that were stored
+      // anyway. A report refused outright is reported under `rejected` with its
+      // reasons; these are the failures inside reports that DID enter the
+      // series — a crashed sample, a fixture that would not prepare, or a peer
+      // row dropped for work equivalence, which leaves a complete and
+      // publishable report with one fewer row in its table and belongs in a
+      // maintainer's view rather than only in a job log.
+      current().epochs.forEach(function (epoch) {
+        (epoch.points || []).forEach(function (point) {
+          (point.failures || []).forEach(function (failure) {
+            any = true;
+            var item = document.createElement("li");
+            item.textContent = shortHash(point.commit) + " — " +
+              (failure.workload ? failure.workload + ": " : "") +
+              failure.kind.replace(/_/g, " ") + ", " + failure.detail;
+            list.appendChild(item);
+          });
         });
       });
       // Absent rather than empty: the peer leg has never run, so "no peer

--- a/website/templates/runtime.html
+++ b/website/templates/runtime.html
@@ -308,11 +308,14 @@
       </figcaption>
     </figure>
     <p id="rt-comparison-empty" style="color: var(--color-muted); max-width: 42rem; margin-top: 0.75rem;">
-      No peer measurements have been collected on this platform yet. The peer
-      leg runs when the recorded fixture identity, a pinned peer's version, or
-      the runner epoch changes, and the per-run canary rides every observation
-      after that; this table fills in with the first such run. Nothing is
-      estimated here in the meantime.
+      No peer measurements are publishable for this platform's newest run. The
+      peer leg runs when the recorded comparison configuration changes — the
+      corpus, a template port, a pinned peer's version, or the runner epoch —
+      and the per-run canary rides every observation after that; this table
+      fills in with the first such run whose measurement is complete. A run
+      that lost its canary, or whose own observation was truncated, publishes
+      nothing here rather than an older table. Nothing is estimated in the
+      meantime.
     </p>
 
     <h2 style="margin-top: 2.5rem;">Field notes</h2>


### PR DESCRIPTION
Closes RUE-1493.

Responds to the review of #2386. Five gaps in the peer evidence path, none of
them live — no ratio is published yet — but all of them gating publication
before peer ratios enter the durable store.

## 1. Peer samples now receive the validation Rue samples receive

`check_peers` required a non-empty sample vector and checked each sample's
artifact digest, and nothing else. A one-sample, zero-duration or nonzero-exit
canary with a matching digest was appendable, and its median was publishable.

Every peer sample now answers to `is_measurable_duration`, `exit_code == 0`,
and a well-formed `stdout_sha256`; the observation must carry exactly the
epoch's sample count and non-zero `emitted_files`; and the configuration key is
checked as a unit rather than field by field. Refusal tests cover the
zero-elapsed canary, the non-zero exit, the wrong sample count, zero emitted
files, a full row at another scale, and a duplicate configuration.

## 2. `latest_comparison` no longer publishes past the completeness gate

It filtered on `is_appendable()` alone and fell back across reports, so a run
missing its required canary could still publish ratios, and a newest run with
no peers silently rendered an older comparison.

The base is now the newest appendable report and only observations where
`outcome.publishes_workload(...)` contribute.

**The same fallback existed one level up, in the page.** `runtime.js` walked
backwards across epochs and rendered the first non-null comparison it found —
harmless while epoch 2 was the only epoch with peer data, and not harmless
once this change adds epoch 3 and makes the empty state reachable. It now
reads the newest epoch only. Verified on a real store: with the newest
epoch-3 record's peer builds failed, the old code rendered ten rows from an
earlier commit and the new code renders the empty state.

## 3. The identity split

`fixture_digest` was doing two jobs: it included all three tools' ports, so a
Hugo template edit segmented Rue's longitudinal series, and it excluded peer
versions, so a failed peer-version transition let the join splice a stale row
into the new table.

The first attempt partitioned by directory, which was necessary and not
sufficient — `fixture_digest` also hashes the preparer script, and the
peer-only logic lived there. Bumping `PEER_PORT_REVISION` still moved the
workload identity, and so did editing `hugoize()`, which is where all three
Hugo port defects this ADR cites as motivation were actually fixed.

So the peer half moved to `scripts/gazette_peer_ports.py`: the pinned tools and
versions, the port roots and revision, the respelling, `prepare_peer_site` and
`peer_command`, thread parity, the file-set allowlist, and the cross-tool
oracle. Its digest enters the comparison identity as `peer_preparer_digest`.
The dependency runs one way — the module imports stdlib only, and the corpus
rules it needs arrive as an explicit `CorpusRules` namedtuple so `route_of`
keeps one spelling.

Measured, prepared from scratch each time:

| perturbation | workload identity | comparison identity |
| --- | --- | --- |
| baseline | `79009f6b` | `1fee5b77` |
| `PEER_PORT_REVISION` bumped | unchanged | moves |
| `hugoize()` edited | unchanged | moves |
| a Hugo port template edited | unchanged | moves |
| a gazette template edited | **moves** | moves |

`ComparisonIdentity` is `Option` with `skip_serializing_if`, so no existing
record's content address moves, and it is required only where the epoch
declares it. Canary-only observations now record every declared peer version,
which was the data gap behind the stale join.

One residual is named rather than hidden: `peer_event`, which decides whether
the peers run at all, stays in the workload-identity file, because it reads the
composed comparison identity and moving it would invert the one-way dependency.
Editing the Decision 9 event logic therefore still segments the series. That is
documented at the site.

## 4. Default-parallel rows are checked for work equivalence

`measure_peers` kept only the primary-policy tree, so a deterministic parallel
build emitting a different tree published as the user-experienced comparison. A
secondary row whose `output_sha256` differs from that tool's judged primary
digest is now dropped by the runner and refused by validation.

The observation stays publishable rather than becoming partial: a lost canary
suppresses the workload because the canary *is* the denominator, while a
secondary row is published beside the ratio and never as it. Suppressing Rue's
median over a labelled extra row would discard good evidence to report a
different problem. Instead `report.failures` — which had no consumer at all —
now reaches `RuntimePointData` and renders in Field notes.

## 5. Required CI exercises a duplicated corpus

The equivalence step ran only at 1x, though the 10x-only failure this ADR
records had every 1x check green. The lane now runs `--scale 2`: the smallest
duplicated corpus, covering every original plus one copy of each, for about
1.4× the build cost rather than 10×. Verified it sees the class — reverting
Hugo's `type` translation leaves 1x passing and fails 2x. Its residual, that
one copy cannot catch a defect needing several, is documented where `SCALES` is
defined.

## Append-only

`PREPARER_REVISION` 1→2 forces suite revision 3 and epoch 3 per platform, with
epoch 2 retired to `collection = false` and still declared. Both port revisions
stay at 2, because no port's bytes moved; the composition change is what
`PREPARER_REVISION` records.

Verified against the real store (`performance-data-v1` at `b8d5b3cd`, 1,083
records) by deriving with a binary built from this branch and one built from
`trunk`: 41 runtime points across 2 platforms and 1,041 compile-time points
across 3, **0 rejected on both sides**, and the derived JSON is identical apart
from the added `failures` field, which is empty on all 41 existing points. No
stored record newly rejects and no derived point disappears.

## Verification

`scripts/rue unit perf-schema` 219 passed · `scripts/rue unit bench` 126 passed
· `scripts/rue quick` 31 targets · clippy and fmt-check clean ·
`gazette-corpus-diff.py` `golden` OK and `peers --samples 2 --no-secondary
--scale 2` OK (190 pages per tool, 188 compared across three tools) · `judge`
OK · a real `rue-bench runtime --platform local` run writes the peer-state file
in the new shape with both identities logged.
