### PR TITLE
RUE-1498: add local runtime epochs for the non-x86-64-Linux targets

### DIFF
--- a/crates/rue-perf-schema/src/runtime.rs
+++ b/crates/rue-perf-schema/src/runtime.rs
@@ -3127,6 +3127,67 @@ samples = 5
         );
     }
 
+    #[test]
+    fn every_collected_platform_has_a_local_reproduction_epoch() {
+        // RUE-1498. A `local` epoch builds for its own `target` and then
+        // EXECUTES what it built, so a matrix row whose target no local epoch
+        // names can only be reproduced by pushing and waiting for CI. That was
+        // the state this test closes: both `local` epochs targeted x86-64
+        // Linux, which is not what this project's maintainers develop on.
+        //
+        // Stated as an invariant over whatever is collecting rather than as a
+        // list of ids, because the failure it guards against is drift. Suite
+        // revisions supersede one another while every earlier revision stays
+        // declared forever, so a local epoch pinned to a retired revision goes
+        // on parsing, goes on running, and quietly reproduces a contract the
+        // matrix no longer measures. Matching the revision as well as the
+        // target makes that a build break at the moment the new revision
+        // arrives, which is when someone can still act on it.
+        let manifest = RuntimeManifest::parse(CHECKED_IN_MANIFEST).expect("checked-in manifest");
+        let collecting: Vec<&RuntimeEpoch> = manifest
+            .epochs()
+            .iter()
+            .filter(|epoch| epoch.collection)
+            .collect();
+        assert!(
+            !collecting.is_empty(),
+            "the matrix collects nothing; this invariant would hold vacuously"
+        );
+        for reference in collecting {
+            let local = manifest
+                .epochs()
+                .iter()
+                .find(|epoch| {
+                    epoch.platform == "local"
+                        && epoch.target == reference.target
+                        && epoch.suite_revision == reference.suite_revision
+                })
+                .unwrap_or_else(|| {
+                    panic!(
+                        "platform {} collects epoch {} at suite revision {} for target {}, but no \
+                         `local` epoch reproduces that target at that revision; declare one with \
+                         its own id, `collection = false`, and the `local` environment policy",
+                        reference.platform,
+                        reference.id,
+                        reference.suite_revision,
+                        reference.target
+                    )
+                });
+            // The two fields that keep a laptop's numbers out of a reference
+            // series. Asserted here rather than left to the manifest's prose:
+            // a `local` epoch that collected, or one whose environment policy
+            // admitted a hosted runner, would be a reproduction path that had
+            // quietly become a collection row.
+            assert!(
+                !local.collection,
+                "local epoch {} collects; a development epoch must not",
+                local.id
+            );
+            assert_eq!(local.environment.runner_label, "local");
+            assert_eq!(local.environment.runner_image, "local");
+        }
+    }
+
     fn fingerprint() -> EnvironmentFingerprint {
         EnvironmentFingerprint {
             runner_label: "github-hosted".to_string(),

--- a/performance/runtime.toml
+++ b/performance/runtime.toml
@@ -66,7 +66,9 @@ description = "32 MiB of deterministic ASCII word text with Zipf-distributed wor
 # The committed golden was produced by running the compiled program over the
 # fixture these pins describe, and independently cross-checked against a
 # reference word count of the same bytes. Regenerate it — under a new suite
-# revision — only when a pin above deliberately changes the workload:
+# revision — only when a pin above deliberately changes the workload. Epoch 1
+# targets x86-64 Linux, so on another host pass that host's own local epoch in
+# its place; the expected bytes are a function of the fixture pins alone:
 #
 #     rue-bench runtime --platform local --epoch 1 \
 #       --compiler "$(scripts/rue-bin)" --commit "$(git rev-parse HEAD)" \
@@ -479,11 +481,11 @@ samples = 9
 # target: its environment policy admits only `local`, so a hosted runner cannot
 # append to it, and a laptop cannot append to the reference series.
 #
-# It is the one x86-64-Linux-only thing left in a matrix that otherwise covers
-# every platform Rue targets, so `--platform local` does not work on an Apple
-# Silicon or arm64 Linux machine. Left as it is deliberately: a second `local`
-# epoch is a maintainer convenience rather than part of this matrix, and it
-# would need its own id and a `--epoch` to select it.
+# The first of the `local` rows. A local run builds for its epoch's `target`
+# and then executes what it built, so the epoch a maintainer selects with
+# `--epoch` is the one whose target their own host can run; the block at the
+# end of this file declares one per target for the revision that collects, and
+# lists every local epoch (RUE-1498).
 [[epoch]]
 id = 1
 platform = "local"
@@ -924,6 +926,143 @@ canary_scale = 1
 # versions its peer legs were configured by — including a canary-only one,
 # which measures a single tool and must still say what the others were pinned
 # at, or a bump whose full leg never succeeded leaves no trace in the data.
+records_comparison_identity = true
+
+[epoch.peers.gazette_10x]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 10
+records_comparison_identity = true
+
+# ===========================================================================
+# THE OTHER TWO LOCAL TARGETS (RUE-1498).
+#
+# `local` is not a platform Rue targets. It is the pseudo-platform a
+# maintainer's own machine runs under, and a local run builds for its epoch's
+# `target` and then EXECUTES what it built, so one local epoch can only ever
+# be reproducible on one architecture. Every local row above targets x86-64
+# Linux, which left the local reproduction path for gazette, the peer legs,
+# and the oracle unavailable on Apple Silicon — the machine this project's
+# maintainers develop on, and the platform whose CI row is the expensive one
+# to iterate against.
+#
+# So the revision that collects gets one local epoch per target, each with its
+# own id and selected with `--epoch`:
+#
+#     epoch 1   x86-64-linux    suite revision 1
+#     epoch 2   x86-64-linux    suite revision 2
+#     epoch 3   x86-64-linux    suite revision 3
+#     epoch 4   aarch64-macos   suite revision 3
+#     epoch 5   aarch64-linux   suite revision 3
+#
+#     rue-bench runtime --platform local --epoch 4 \
+#       --compiler "$(scripts/rue-bin)" --commit "$(git rev-parse HEAD)" \
+#       --out /tmp/runtime.json --workdir /tmp/runtime-work
+#
+# Suite revision 3 and nothing else. Revisions 1 and 2 stay declared because
+# records in the store name them, but nothing collects them, and a local path
+# for a contract nothing collects would be prose to keep true for no reader.
+# That is the rule rather than these two ids: per target, for the revision
+# that collects.
+#
+# Everything below except `id` and `target` is copied from epoch 3 rather than
+# chosen again — sampling, both peer rungs, and `records_comparison_identity`
+# on each. A local epoch exists to reproduce what CI measures, so the local
+# rows should differ from one another in the target alone; a policy that
+# drifted per host would make two maintainers' runs incomparable for a reason
+# that has nothing to do with their machines.
+#
+# `collection = false` and the `local`-only environment policy on both, as on
+# every local row: a record from these names platform `local` and is grouped
+# into a series of its own. The fingerprint that policy matches comes from
+# `RUE_BENCH_RUNNER_LABEL` and `RUE_BENCH_RUNNER_IMAGE`, which only CI sets,
+# so no accidental local run can satisfy a reference epoch's hosted policy.
+# ===========================================================================
+
+# Apple Silicon. The motivating row: `aarch64-macos` is a platform the matrix
+# collects, and before this epoch the only way to run its workloads at all was
+# to push and wait for the daily macOS job.
+[[epoch]]
+id = 4
+platform = "local"
+suite_revision = 3
+target = "aarch64-macos"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = false
+
+[epoch.environment]
+runner_label = "local"
+runner_image = "local"
+
+[epoch.sampling.wordfreq]
+samples = 2
+
+[epoch.sampling.gazette]
+samples = 2
+
+[epoch.sampling.gazette_10x]
+samples = 2
+
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+records_comparison_identity = true
+
+[epoch.peers.gazette_10x]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 10
+records_comparison_identity = true
+
+# arm64 Linux, and it costs nothing beyond this entry to declare. The compiler
+# already targets it, the reference row already collects it per push, and the
+# pinned peer shims at the repository root already carry `linux-aarch64`
+# artifacts for both Zola and Hugo — so a maintainer on an arm64 Linux box
+# gets both peer rungs, against the same pinned peer versions the hosted row
+# uses. Trunk called a second local epoch a maintainer convenience needing its
+# own id and an `--epoch` to select it, which was true; what it undercounted
+# is that the convenience is the reproduction path for the platforms the
+# matrix collects, so the ids are declared here.
+[[epoch]]
+id = 5
+platform = "local"
+suite_revision = 3
+target = "aarch64-linux"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = false
+
+[epoch.environment]
+runner_label = "local"
+runner_image = "local"
+
+[epoch.sampling.wordfreq]
+samples = 2
+
+[epoch.sampling.gazette]
+samples = 2
+
+[epoch.sampling.gazette_10x]
+samples = 2
+
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
 records_comparison_identity = true
 
 [epoch.peers.gazette_10x]


### PR DESCRIPTION
Closes RUE-1498.

`performance/runtime.toml` declared every `local` epoch with
`target = "x86-64-linux"`, so `rue-bench runtime --platform local` built for a
target the host could not execute on an Apple Silicon or arm64 Linux machine —
the machines this project's maintainers develop on. The local reproduction
path for gazette, the peer legs, and the oracle was Linux-only, on a workload
whose most expensive CI row is macOS.

This adds local epoch 4 (`aarch64-macos`) and local epoch 5
(`aarch64-linux`), both at suite revision 3, both `collection = false` with the
`local`-only environment policy. Together with the existing local epoch 3 they
give every collecting platform a reproduction path at the revision that
actually collects.

`aarch64-linux` needed nothing beyond the manifest entry: the compiler accepts
the target, the reference row already collects it, and both root DotSlash
shims carry `linux-aarch64` artifacts, so an arm64 Linux maintainer gets the
same peer comparison the hosted row runs.

## The invariant is a test, not a comment

`every_collected_platform_has_a_local_reproduction_epoch` requires, for each
epoch with `collection = true`, a `local` epoch matching **both** its `target`
and its `suite_revision`, with `collection = false` and a `local` environment
policy. Nothing is hard-coded — no id, revision, or platform name — so the next
suite revision that lands without matching local rows fails the build rather
than quietly leaving `--platform local` reproducing a retired contract.

It was verified by breaking it, not by watching it pass: deleting the
`aarch64-macos` row, stranding an epoch on a retired revision with a manifest
that still parses, and widening a local policy to `github-hosted` each produce
a failure naming the platform, revision and target at fault.

## Why the rows are copied from local epoch 3

Everything but `id` and `target` is verbatim from the existing revision-3 local
epoch, and that choice is load-bearing rather than cosmetic. Revision 3's
epochs declare peers on **both** rungs with `records_comparison_identity =
true`, where revision 2 declared only the 1x rung and no comparison identity. A
row shaped from revision 2 would have parsed, run, and silently recorded no
comparison identity — the hole the new revision exists to close.

Revision-2 rows for the new targets are deliberately not added. Keeping the
existing revision-2 local epoch is forced by the append-only store, since
stored records name it; nothing forces declaring a *new* one for a contract
that no longer collects, and a local path for such a contract is prose to keep
true for no reader.

## A local epoch still cannot enter a reference series

Verified in source rather than taken from the manifest's own comment. Four
independent mechanisms: `derive` groups runtime reports by `(platform, epoch)`
and a local run's platform is `local`; the environment policy requires an exact
`runner_label`/`runner_image` match, with `a_local_run_cannot_enter_the_hosted_series`
already covering it; `check_epochs` permits at most one collecting epoch per
platform and `no_platform_outside_the_v1_matrix_collects` pins the collecting
set; and the collect workflow hard-codes its matrix with
`RUE_BENCH_RUNNER_LABEL: github-hosted`, which the local policy refuses.

The manifest's prose is corrected to match what is enforced. It previously said
a local run's fingerprint could *never* satisfy a hosted policy; the
fingerprint is read from environment variables that only CI sets, so what is
true is that no *accidental* local run can. The underlying behaviour is tracked
separately.

## Verified on the host the issue is about

Before, `--platform local --epoch 2` on an M1 Max built
`ELF 64-bit LSB executable, x86-64` and every workload exited 126.

After, `--platform local --epoch 4` exits 0, the program is
`Mach-O 64-bit executable arm64`, all three workloads sample twice, all three
oracles report `match`, `failures []`, and the peer matrix runs natively on
both rungs — zola canary plus the full matrix at scale 1 and scale 10 — with a
comparison identity recorded on both gazette workloads.

Epoch 5 resolves and compiles to `ELF 64-bit LSB ARM aarch64` on this host and
then exits 126, as it must: it is the arm64 Linux maintainer's epoch.

## Verification

`scripts/rue unit perf-schema` 220 passed · `scripts/rue unit bench` 127
passed, 2 ignored · `gazette-corpus-diff.py golden` OK ·
`scripts/validate-release-configuration.py` clean · `scripts/rue fmt` no
changes.
