### PR TITLE
RUE-1497: calibrate runtime dispersion from stored runtime reports

### DIFF
--- a/.github/workflows/performance-calibration.yml
+++ b/.github/workflows/performance-calibration.yml
@@ -1,30 +1,73 @@
-# Noise calibration for the compiler-performance suite (ADR-0067 Phase 4).
+# Noise calibration for the performance suites (ADR-0067 Phase 4; ADR-0072
+# Decision 5).
 #
-# Repeatedly measures ONE unchanged compiler revision on each hosted platform,
-# then reports what the hardware's noise implies for sampling counts, batching
-# factors, and the flagging rule.
+# Two lanes, one method. The `calibrate` job repeatedly measures ONE unchanged
+# compiler revision on each hosted platform and reports what the hardware's
+# noise implies for sampling counts, batching factors, and the flagging rule.
+# The `calibrate-runtime` job does the same for the runtime suite: how fast the
+# programs the compiler produces run, over ADR-0072's own record kind.
 #
-# The method rests on measuring the same revision every time: nothing real is
-# changing, so any difference the flagging rule reports is a false positive by
-# construction, and `k` can be chosen as the smallest multiplier producing none.
+# The method rests on measuring something that is not changing, so any
+# difference the flagging rule reports is a false positive by construction and
+# `k` can be chosen as the smallest multiplier producing none. What must be held
+# constant differs between the lanes, and that is not a detail. The compiler
+# lane pins the compiler revision, because the compiler is the product under
+# measurement. The runtime lane's product is the executable the compiler
+# emitted, whose digest rides every observation — so the runtime calibrator
+# holds the PROGRAM digest and the recorded WORKLOAD identity constant, and a
+# repetition here satisfies both by construction.
 #
 # NOTHING THIS WORKFLOW PRODUCES MAY ENTER A SERIES. Output is uploaded as
-# workflow artifacts and never written to the data branch. This workflow holds
-# no write permission, so that is structural rather than a convention: there is
-# no path from a calibration artifact to published history.
+# workflow artifacts and never written to the data branch. Three things make
+# that structural rather than a convention, and all three are needed:
+#
+#   * this workflow declares `contents: read` and no job re-declares it, unlike
+#     `performance-collect.yml`'s publish job, which is where the write lives;
+#   * the only writer of `performance-data-v1` is that publish job, and it takes
+#     its input from `actions/download-artifact` WITHIN ITS OWN RUN, so an
+#     artifact produced here is not visible to it; and
+#   * every path `rue-bench` and `rue-bench runtime` write is one this job named
+#     — the `--out` record, the `--peer-state-dir` event state, and a work
+#     directory holding the prepared fixtures and compiled programs — all of
+#     them inside the runner's workspace. Neither subcommand touches a remote.
+#
+# There is no path from a calibration artifact to published history.
 name: Performance calibration
 
 on:
   workflow_dispatch:
     inputs:
       repetitions:
-        description: Calibration runs per platform
+        description: Compiler-suite calibration runs per platform (0 skips the lane)
         required: false
         default: "12"
       epoch:
         description: Manifest epoch to calibrate on every platform
         required: false
         default: "3"
+      runtime_repetitions:
+        description: Runtime-suite calibration runs per platform (0 skips the lane)
+        required: false
+        # Twenty, and the number is the sweep's arithmetic rather than a round
+        # figure. A trailing window of length W yields N - W comparisons from N
+        # observations, and the analysis declines to cite a pairing resting on
+        # fewer than ten. Twenty gives 17, 15, and 10 at the three swept
+        # windows: the smallest count at which all three candidates can be
+        # recommended from at all. Twelve, the compiler lane's figure, would
+        # leave the longest window with two.
+        #
+        # BE CLEAR WHAT THAT BUYS, because the nominal count flatters itself.
+        # Successive comparisons at window W share W - 1 observations, so twenty
+        # observations hold roughly five INDEPENDENT comparisons at window 3 and
+        # about two at window 10. Buying ten independent trials at the longest
+        # window would take of the order of a hundred repetitions, which is not
+        # a sensible use of a hosted macOS runner for a series whose flags are
+        # advisory. So twenty is a deliberate floor rather than a sufficiency
+        # claim: the report states the independent count beside every
+        # recommendation, the longest-window row is always the weakest, and a
+        # maintainer who wants a stronger answer raises this number knowing what
+        # it costs.
+        default: "20"
 
 # Read-only. Calibration must not be able to publish.
 permissions:
@@ -39,6 +82,8 @@ concurrency:
 
 jobs:
   calibrate:
+    # Each lane is hours of runner time, so either can be dispatched alone.
+    if: inputs.repetitions != '0'
     strategy:
       fail-fast: false
       matrix:
@@ -125,4 +170,128 @@ jobs:
             calibration-runs/
             calibration-${{ matrix.platform }}.md
             calibration-${{ matrix.platform }}.json
+          retention-days: 30
+
+  # The runtime suite's calibration lane (ADR-0072 Decision 5, RUE-1497).
+  #
+  # This is the only thing that can produce the calibration `runtime.toml`
+  # leaves empty on every platform row. The store accumulates one observation
+  # per push, so a series long enough to sweep a flagging rule over takes weeks
+  # of trunk activity and arrives interleaved with corpus changes, each of which
+  # ends a segment; this job produces the same evidence in one dispatch, at one
+  # checkout, with the corpus and the emitted executables identical throughout.
+  #
+  # It runs the platform's COLLECTION epoch rather than a calibration-only one,
+  # unlike the compiler lane. There is no non-collection hosted runtime epoch to
+  # use — `performance/runtime.toml`'s only such epoch is `local`, whose
+  # environment policy a hosted runner cannot satisfy — and the regime worth
+  # calibrating is the one that collects anyway. The reports are still artifacts
+  # and nothing else: see the header for the three reasons that is structural.
+  calibrate-runtime:
+    if: inputs.runtime_repetitions != '0'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            platform: x86_64-linux
+            image: ubuntu-24.04
+          - os: ubuntu-24.04-arm
+            platform: aarch64-linux
+            image: ubuntu-24.04
+          - os: macos-15
+            platform: aarch64-macos
+            image: macos-15
+    runs-on: ${{ matrix.os }}
+    name: calibrate runtime (${{ matrix.platform }})
+    # Longer than the compiler lane's budget, and for two reasons that add up.
+    # Twenty repetitions rather than twelve, and each repetition prepares the
+    # corpus, builds three programs' worth of measured processes, and runs the
+    # peer canary — on top of the release build of `rue` and `rue-bench` that
+    # dominates every job in these workflows.
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Select Xcode 16.2
+        if: runner.os == 'macOS'
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+
+      # Fetches the pinned peers as well as Rue's own tools: `zola` and `hugo`
+      # at the repository root are dotslash shims, and the runtime harness runs
+      # the canary against the same corpus gazette builds.
+      - name: Install dotslash
+        uses: facebook/install-dotslash@v2
+
+      - name: Build the compiler and the runner
+        run: |
+          ./buck2 build //crates/rue:rue //crates/rue-bench:rue-bench \
+            --target-platforms //platforms:release
+
+      - name: Run the runtime calibration repetitions
+        env:
+          # Declared rather than detected, exactly as the collection workflow
+          # declares it: a run must never be able to claim quietly that it
+          # satisfied an environment policy it did not.
+          RUE_BENCH_RUNNER_LABEL: github-hosted
+          RUE_BENCH_RUNNER_IMAGE: ${{ matrix.image }}
+        run: |
+          set -euo pipefail
+          mkdir -p runtime-calibration-reports runtime-peer-state
+          RUE="$(scripts/rue-bin --target-platforms //platforms:release)"
+          BENCH="$(./buck2 build //crates/rue-bench:rue-bench \
+            --target-platforms //platforms:release --show-simple-output 2>/dev/null | tail -1)"
+          COMMIT="${{ github.sha }}"
+
+          for index in $(seq 1 "${{ inputs.runtime_repetitions }}"); do
+            echo "::group::runtime calibration run $index"
+            # Exit 3 is "written but not appendable" and 5 is "appendable but a
+            # workload did not complete". Both are recorded and analysed: the
+            # calibrator judges each observation on the record's own evidence —
+            # the oracle's verdict and whether the samples agreed — and reports
+            # what it excluded. Only a runner failure (2) stops the sweep, since
+            # after one there is nothing to analyse.
+            #
+            # The peer-state directory is local to this job and deliberately not
+            # restored from a cache. The first repetition finds no state and
+            # runs one full peer leg; every repetition after it joins on an
+            # unmoved comparison identity and pays for the canary alone, which
+            # is what keeps twenty repetitions affordable.
+            set +e
+            "$BENCH" runtime \
+              --manifest performance/runtime.toml \
+              --platform "${{ matrix.platform }}" \
+              --compiler "$RUE" \
+              --commit "$COMMIT" \
+              --repo-root . \
+              --peer-state-dir runtime-peer-state \
+              --out "runtime-calibration-reports/run-$(printf '%03d' "$index").json"
+            status=$?
+            set -e
+            if [ "$status" -eq 2 ]; then
+              echo "the runtime runner failed to produce a report; stopping"
+              exit 1
+            fi
+            echo "::endgroup::"
+          done
+
+      - name: Analyse
+        run: |
+          BENCH="$(./buck2 build //crates/rue-bench:rue-bench \
+            --target-platforms //platforms:release --show-simple-output 2>/dev/null | tail -1)"
+          "$BENCH" calibrate \
+            --runtime-reports runtime-calibration-reports \
+            --report "runtime-calibration-${{ matrix.platform }}.md"
+
+      - name: Upload runtime calibration artifacts
+        # Always, so a sweep stopped partway is still readable evidence about
+        # the regime that stopped it.
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: runtime-calibration-${{ matrix.platform }}
+          path: |
+            runtime-calibration-reports/
+            runtime-calibration-${{ matrix.platform }}.md
+            runtime-calibration-${{ matrix.platform }}.json
           retention-days: 30

--- a/crates/rue-bench/src/calibrate.rs
+++ b/crates/rue-bench/src/calibrate.rs
@@ -11,13 +11,26 @@
 //! chosen as the smallest multiplier that produces none. That is a measurement
 //! of the hardware's noise rather than a guess dressed up as a threshold.
 //!
+//! ADR-0072's runtime suite asks the same four questions of a different record
+//! kind, and gets different answers to two of them. [`calibrate_runtime`] is
+//! that half. It shares this file because the method is the same one — measure
+//! something that is not changing, and read the spread as noise — and because
+//! the flagging sweep is literally the same sweep over the same
+//! [`SweepPoint`]s. What it cannot share is the run shape: a runtime
+//! observation has no batching factor to recommend, its five samples are far
+//! fewer than the compile-time twelve, and what must be held constant for a
+//! difference to be false by construction is not the compiler revision.
+//!
 //! Nothing produced here may enter a series. These are workflow artifacts; the
 //! collector never reads them.
 
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use rue_perf_schema::{Metric, RunObject, Summary, flags_movement, sample_value};
+use rue_perf_schema::{
+    FIXTURE_INPUT_NAME, Metric, OracleVerdict, RunObject, RuntimeMetric, RuntimeObservation,
+    RuntimeReport, StoredRuntimeReport, Summary, flags_movement, sample_value, summarize,
+};
 
 /// Candidate multipliers swept when choosing `k`.
 const K_CANDIDATES: &[f64] = &[1.0, 1.5, 2.0, 2.5, 3.0, 4.0, 5.0, 6.0, 8.0, 10.0];
@@ -65,7 +78,7 @@ pub struct WorkloadCalibration {
 }
 
 /// One point of the multiplier sweep.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, Copy, serde::Serialize)]
 pub struct SweepPoint {
     /// The trailing-window length.
     pub window: usize,
@@ -400,6 +413,1157 @@ pub fn render(report: &CalibrationReport) -> String {
     out
 }
 
+// ---------------------------------------------------------------------------
+// The ADR-0072 runtime suite
+// ---------------------------------------------------------------------------
+
+/// The fewest constant-condition observations any dispersion figure may rest
+/// on.
+///
+/// Eight, and the reason is the estimator rather than the sweep. Both figures
+/// below are medians over per-observation quantities — the within-observation
+/// one over each observation's own relative MAD, the run-to-run one over
+/// observation medians — and a median over fewer than a handful of coarse
+/// inputs is itself coarse. The sweep's sufficiency is a separate question with
+/// its own floor at [`MINIMUM_SWEEP_COMPARISONS`], which eight observations do
+/// NOT satisfy at any window; the two are not derived from each other and
+/// neither implies the other.
+const MINIMUM_CALIBRATION_OBSERVATIONS: usize = 8;
+
+/// The fewest samples per observation a *within-observation* dispersion figure
+/// may rest on.
+///
+/// A MAD includes the deviation of the median from itself, which is zero. At
+/// three samples the MAD is therefore the smaller of the two remaining
+/// deviations, biased low by construction — and a dispersion figure biased low
+/// produces a threshold that is too tight and a flag that is too eager, which
+/// is the direction that trains a reader to ignore the word.
+///
+/// This suite genuinely collects below that floor and does so deliberately:
+/// `performance/runtime.toml` declares `samples = 3` for `gazette_10x` on every
+/// hosted epoch, because that rung exists for the shape of the curve rather
+/// than for a tight median, and its cost is a maintainer decision under
+/// ADR-0072 Decision 9 rather than a calibration one. So this floor gates the
+/// within-observation figure and [`RuntimeWorkloadCalibration::recommended_samples`]
+/// ALONE. It deliberately does not gate the flagging sweep, which stays valid
+/// at three samples for the reason
+/// [`RuntimeWorkloadCalibration::flagging_confidence`] gives: the sweep computes
+/// each observation's summary exactly as the dashboard does, from the same
+/// samples, so whatever bias the sample count carries is carried identically by
+/// the rule being calibrated and by the rule as it will be applied.
+const MINIMUM_CALIBRATION_SAMPLES: u32 = 5;
+
+/// How far run-to-run dispersion must exceed within-observation dispersion
+/// before sampling harder stops being the answer.
+///
+/// Twice: at that point over three quarters of the variance a published median
+/// carries comes from between-run terms that no sample count touches.
+const RUN_TO_RUN_DOMINANCE: f64 = 2.0;
+
+/// The fewest comparisons a clean `(window, k)` pairing may rest on.
+///
+/// Ten, from the rule of three — no event in ten trials bounds the rate at
+/// roughly 30% and no better — with one correction that makes even that
+/// optimistic, and it is stated here rather than left for a reader to notice.
+/// **Successive comparisons are not independent trials.** At window `W` each
+/// comparison shares `W - 1` observations with the one before it, so a segment
+/// of `S` observations yields `S - W` nominal comparisons containing roughly
+/// `S / (W + 1)` independent ones. Twenty observations at window 10 give ten
+/// nominal comparisons and about two independent ones; at window 3 they give
+/// seventeen and about five.
+///
+/// So this is the floor at which a recommendation is worth *making*, not the
+/// point at which it becomes a threshold, and the longest-window row of a sweep
+/// is always its weakest. That is exactly why the analysis feeds ADR-0072's
+/// open question 4 rather than answering it, and why the remedy for a thin
+/// sweep is more repetitions rather than a rounder number.
+const MINIMUM_SWEEP_COMPARISONS: usize = 10;
+
+/// Roughly how many independent trials a run of overlapping comparisons holds.
+///
+/// A comparison at window `W` consumes `W + 1` observations, and consecutive
+/// comparisons reuse all but one of them, so non-overlapping blocks are what an
+/// independence claim can be made about. Reported beside the nominal count so a
+/// recommendation cannot read as stronger than it is.
+fn independent_comparisons(segment_length: usize, window: usize) -> usize {
+    segment_length / (window + 1)
+}
+
+/// What the flagging sweep found, beyond the pairing it did or did not pick.
+///
+/// The distinctions matter because they call for different actions, and a
+/// single absent recommendation conflates all of them: "nothing to compare"
+/// asks for more collection, "clean but barely tried" asks for a longer sweep,
+/// and "never clean" asks whether this platform can carry a flag at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FlaggingVerdict {
+    /// A pairing flagged nothing across enough comparisons to be worth citing.
+    Recommended,
+    /// The dispersion figures behind the sweep are too thin to recommend from,
+    /// whatever the sweep found.
+    EvidenceTooThin,
+    /// No constant-condition segment is longer than the shortest swept window,
+    /// so no comparison could be drawn at all.
+    NoComparisons,
+    /// Some pairing flagged nothing, but across too few comparisons to mean it.
+    TooFewComparisons,
+    /// Every pairing flagged something, including the largest multiplier swept.
+    NeverClean,
+}
+
+/// How far a dispersion figure can be trusted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DispersionConfidence {
+    /// Enough repeated observations of an unchanged program, at enough samples
+    /// each, for the figure to be read as a number.
+    Sufficient,
+    /// Not enough of either. The figure is reported so a reader can see what
+    /// there is, and nothing is recommended from it.
+    Thin,
+}
+
+/// One machine class's share of a workload's run-to-run dispersion.
+///
+/// A hosted pool hands out several CPU models, and a series sampled across them
+/// has a run-to-run MAD that is a MIXTURE statistic: it is neither the noise of
+/// one machine nor the size of the jump between machines, and reporting it
+/// alone overstates the first while understating the second. On the real
+/// `x86_64-linux` epoch 1 the pooled figure is 3.6% while each individual model
+/// sits below 0.7% and the largest excursion is 32%.
+///
+/// This decomposition is presentation, not segmentation. The sweep deliberately
+/// keeps measuring across machines, because production `derive` segments on the
+/// fixture and workload-source identities alone and its trailing windows
+/// therefore span machines too — a `k` calibrated on same-machine windows could
+/// not survive real collection.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct EnvironmentDispersion {
+    /// The CPU model the runner reported.
+    pub cpu_model: String,
+    /// Observations of this workload taken on it, within the longest segment.
+    pub observations: usize,
+    /// Median wall time on this machine class, in nanoseconds.
+    pub median_wall_clock_ns: u64,
+    /// Dispersion of observation medians within this machine class, or `None`
+    /// when too few landed on it to have one.
+    pub run_to_run_relative_mad: Option<f64>,
+}
+
+/// One observation that could not feed a dispersion estimate.
+///
+/// Reported rather than silently dropped: a calibration that quietly excluded
+/// half its evidence would produce a tighter answer than the platform deserves,
+/// and the exclusion is the more interesting half of the finding.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SkippedObservation {
+    /// The workload.
+    pub workload: String,
+    /// The record's own name.
+    pub report: String,
+    /// Why it was not used.
+    pub reason: String,
+}
+
+/// What calibration recommends for one runtime workload on one platform.
+///
+/// Deliberately not [`WorkloadCalibration`]. That shape carries a batching
+/// factor, and [`rue_perf_schema::RuntimeSamplingPolicy`] has none: these
+/// workloads run for seconds, so there is no measurement floor to batch above,
+/// and batching would average away the per-run dispersion this exists to
+/// measure. It also carries no segmentation, because a compile-time workload's
+/// input cannot move.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RuntimeWorkloadCalibration {
+    /// The workload calibrated.
+    pub workload: String,
+    /// Observations that contributed.
+    pub observations: usize,
+    /// Constant-condition segments they fell into.
+    pub segments: usize,
+    /// The longest segment's length, which is what the figures below rest on.
+    pub longest_segment: usize,
+    /// Fewest samples any contributing observation carried.
+    pub min_samples_per_observation: u32,
+    /// Most samples any contributing observation carried.
+    pub max_samples_per_observation: u32,
+    /// Median wall time over the longest constant-condition segment, in
+    /// nanoseconds.
+    ///
+    /// Taken within one segment rather than over everything, because a median
+    /// pooled across a corpus change would be a median of two workloads.
+    pub median_wall_clock_ns: u64,
+    /// Dispersion inside a single observation, as the median of each
+    /// observation's own relative MAD.
+    pub within_observation_relative_mad: f64,
+    /// How far that figure can be trusted.
+    ///
+    /// `Thin` below [`MINIMUM_CALIBRATION_SAMPLES`] samples an observation or
+    /// [`MINIMUM_CALIBRATION_OBSERVATIONS`] observations. Separate from
+    /// `flagging_confidence` because the two figures fail for different reasons
+    /// and one failing does not implicate the other.
+    pub within_observation_confidence: DispersionConfidence,
+    /// Dispersion of observation medians inside a constant-condition segment.
+    ///
+    /// Taken only over segments of at least [`MINIMUM_CALIBRATION_OBSERVATIONS`]
+    /// observations, so this figure is never itself the three-point estimate the
+    /// sample floor above exists to refuse. Absent when no segment is that long.
+    ///
+    /// Read it beside `max_relative_excursion` and `by_cpu_model` rather than
+    /// alone: on a heterogeneous pool it is a mixture of within-machine noise
+    /// and between-machine jumps and describes neither.
+    pub run_to_run_relative_mad: Option<f64>,
+    /// Observations behind that figure.
+    pub run_to_run_observations: usize,
+    /// The largest single deviation from the segment median, as a fraction of
+    /// it.
+    ///
+    /// The half a MAD is built to discard. A minority of excursions moves a MAD
+    /// hardly at all — which is exactly why the published median is robust and
+    /// exactly why a dispersion figure alone cannot tell a reader how far a
+    /// hosted runner actually strays.
+    pub max_relative_excursion: Option<f64>,
+    /// Run-to-run dispersion broken down by machine class.
+    ///
+    /// Empty when the pool reported one CPU model, where the pooled figure is
+    /// already the whole story.
+    pub by_cpu_model: Vec<EnvironmentDispersion>,
+    /// Whether run-to-run dispersion dwarfs the within-observation figure.
+    ///
+    /// When it does, `recommended_samples` is answering a question nobody is
+    /// asking. More samples inside one observation tighten that observation's
+    /// median and do nothing to the spread *between* observations, so a series
+    /// whose noise is mostly between-run cannot be improved by sampling
+    /// harder — the remedy is a quieter regime, or accepting the bound. On a
+    /// hosted pool this is the usual state and not the exception.
+    pub run_to_run_dominates: bool,
+    /// Samples needed for the median's relative uncertainty to reach the
+    /// target, or `None` when the evidence is too thin to say.
+    ///
+    /// Never below [`MINIMUM_CALIBRATION_SAMPLES`]. A recommendation under that
+    /// floor would advise a sampling policy this very method then refuses to
+    /// calibrate from, which is the one thing a calibration tool must not do.
+    pub recommended_samples: Option<u32>,
+    /// The flagging sweep for this workload.
+    ///
+    /// Per workload, unlike the compile-time sweep, because
+    /// `performance/runtime.toml` declares `k` and `window` per workload per
+    /// platform. One pooled sweep would recommend a constant no epoch table can
+    /// express.
+    pub flagging: FlaggingRecommendation,
+    /// How far the sweep can be trusted.
+    ///
+    /// Gated on the observation count alone, and NOT on the sample count. The
+    /// sweep summarizes each observation exactly as `derive` does, from the same
+    /// samples the epoch declares, so a three-sample workload's downward-biased
+    /// MAD is present identically on both sides: the rule being calibrated and
+    /// the rule as the dashboard will apply it are the same rule over the same
+    /// numbers. That is what keeps `gazette_10x` — three samples on every hosted
+    /// epoch by deliberate cost policy — calibratable for the thing
+    /// `[epoch.calibration]` actually declares, which is `k` and `window` and
+    /// not a sample count.
+    pub flagging_confidence: DispersionConfidence,
+    /// What that sweep amounts to.
+    pub flagging_verdict: FlaggingVerdict,
+    /// Roughly how many *independent* comparisons back the recommended pairing.
+    ///
+    /// The sweep's own count treats overlapping trailing windows as separate
+    /// trials, and they are not: see [`MINIMUM_SWEEP_COMPARISONS`]. This is the
+    /// number a strength claim about the recommendation may actually use, and
+    /// it is usually a small fraction of the nominal one.
+    pub recommended_independent_comparisons: Option<usize>,
+}
+
+/// The runtime calibration report for one platform's epoch.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RuntimeCalibrationReport {
+    /// The platform calibrated.
+    pub platform: String,
+    /// The epoch these reports were taken under.
+    pub epoch: u32,
+    /// The suite revision that epoch implements.
+    ///
+    /// Carried so a reader can see that a figure belongs to one workload
+    /// contract. Pooling across suite revisions would be pooling across a
+    /// change in what is measured, and partitioning by epoch prevents it: an
+    /// epoch implements exactly one revision.
+    pub suite_revision: u32,
+    /// How many reports were analysed.
+    pub reports: usize,
+    /// How many distinct environment fingerprints appeared across them.
+    pub distinct_environments: usize,
+    /// The distinct CPU models those fingerprints named, sorted.
+    ///
+    /// The count alone understates this on a runtime suite. A compile-time
+    /// calibration run is a burst on one runner; a runtime series is months of
+    /// hosted allocations, and if the pool hands out several CPU models the
+    /// dominant term in the dispersion below is which machine the job landed
+    /// on. A maintainer reading a large `k` needs to know whether it is the
+    /// workload or the pool.
+    pub cpu_models: Vec<String>,
+    /// Per-workload recommendations.
+    pub workloads: Vec<RuntimeWorkloadCalibration>,
+    /// Observations excluded, with the reason.
+    pub skipped: Vec<SkippedObservation>,
+}
+
+/// Load every runtime report in a directory.
+///
+/// Takes the directory of records itself rather than the store root, so the
+/// same call reads a workflow's freshly written reports and a checkout of
+/// `performance-data-v1/runtime`.
+///
+/// A record this build cannot read is an error here, unlike in the derive step.
+/// The store's reader must tolerate a record from a future schema forever,
+/// because it cannot be removed from an append-only branch; a calibration is a
+/// one-off analysis whose operator can narrow the directory, and silently
+/// analysing a subset would report a dispersion for evidence it did not read.
+pub fn load_runtime_reports(
+    directory: &Path,
+) -> Result<Vec<StoredRuntimeReport>, CalibrationError> {
+    let listing = std::fs::read_dir(directory).map_err(|error| {
+        CalibrationError(format!("could not read {}: {error}", directory.display()))
+    })?;
+    let mut reports = Vec::new();
+    for entry in listing {
+        let entry = entry.map_err(|error| CalibrationError(error.to_string()))?;
+        let path = entry.path();
+        if path.extension().is_none_or(|extension| extension != "json") {
+            continue;
+        }
+        let text = std::fs::read_to_string(&path).map_err(|error| {
+            CalibrationError(format!("could not read {}: {error}", path.display()))
+        })?;
+        let stored = StoredRuntimeReport::read(&text).map_err(|error| {
+            CalibrationError(format!(
+                "{} is not a runtime report: {error}",
+                path.display()
+            ))
+        })?;
+        reports.push(stored);
+    }
+    Ok(reports)
+}
+
+/// One usable observation, reduced to what calibration reads.
+struct RuntimePoint {
+    /// Chronological key.
+    finished_at: String,
+    /// What has to be constant for a difference between two points to be noise.
+    condition: ConstantCondition,
+    /// The machine class this observation landed on. Not part of the condition
+    /// — see [`EnvironmentDispersion`] for why it decomposes but never
+    /// segments.
+    cpu_model: String,
+    /// Wall-clock summary over this observation's own samples.
+    summary: Summary,
+}
+
+/// Everything that must be equal for two observations to differ only by noise.
+///
+/// This is the runtime answer to the compile-time calibrator's "all runs must
+/// measure the same compiler revision". The parts are not the same, and only
+/// one of them is an identity ADR-0072 Decision 2 defines.
+///
+/// The **workload identity** — the fixture's own digest — is the corpus, the
+/// static assets, the preparer's assembly rules, and gazette's template port.
+/// It is what `derive` segments the published Rue series on, and it is the
+/// right key here for the same reason: it is exactly what gazette consumes. The
+/// COMPARISON identity is deliberately not used. It adds the peer ports, the
+/// peer preparer, every peer version, and the epoch — none of which any gazette
+/// process can observe — so segmenting on it would discard Rue's own repeated
+/// samples every time a peer moved, and produce a thinner and more optimistic
+/// dispersion estimate from fewer points.
+///
+/// The **workload source digest** is the second half of `derive`'s key, kept so
+/// that the segments a calibration reasons over are the segments the dashboard
+/// draws.
+///
+/// The **program digest** is this calibration's own addition, and it replaces
+/// the compile-time rule rather than supplementing it. That rule pins the
+/// compiler revision because the compiler is the thing being measured. Here the
+/// compiler is a tool and the measured thing is the executable it produced,
+/// whose digest every observation already records. Two observations with equal
+/// program and fixture digests ran a byte-identical program over byte-identical
+/// input, so any difference between them is noise by construction — which is
+/// what the method needs, and is strictly stronger than equal commits, since
+/// most trunk commits do not change a given program's code at all.
+#[derive(Clone, PartialEq, Eq)]
+struct ConstantCondition {
+    /// The workload identity: `recorded_inputs["fixture"].identity_sha256`.
+    fixture: String,
+    /// The workload's own source closure digest.
+    source: String,
+    /// The digest of the release-quality executable that was measured.
+    program: String,
+}
+
+/// Why this observation cannot contribute, if it cannot.
+///
+/// Judged from the record's own evidence rather than by running
+/// `validate_runtime_report`. A calibration lane deliberately measures one
+/// commit repeatedly, so several of its reports are unappendable for reasons
+/// that say nothing about dispersion — a sample count that is not the epoch's,
+/// an environment policy a local run does not satisfy. What does matter is
+/// whether the program produced the right answer, and the record says so.
+fn runtime_observation_defect(
+    report: &RuntimeReport,
+    observation: &RuntimeObservation,
+) -> Option<String> {
+    if let Some(failure) = report
+        .failures
+        .iter()
+        .find(|failure| failure.workload() == observation.workload)
+    {
+        return Some(format!("the report records a failure: {failure:?}"));
+    }
+    match observation.oracle.verdict {
+        OracleVerdict::Match => {}
+        verdict => {
+            return Some(format!(
+                "the oracle returned {verdict:?}; timing a program that produced the \
+                 wrong answer measures the wrong program"
+            ));
+        }
+    }
+    if !observation.oracle.deterministic_across_samples {
+        return Some(
+            "the samples did not agree on their output, so they did not do the same work"
+                .to_string(),
+        );
+    }
+    if observation.samples.len() < 2 {
+        return Some(format!(
+            "{} sample(s); dispersion needs at least two",
+            observation.samples.len()
+        ));
+    }
+    None
+}
+
+/// Analyse stored runtime reports, one report per platform epoch.
+///
+/// Partitioned rather than refused, unlike [`calibrate`]. That function reads a
+/// directory a workflow just wrote for one platform; this one must also read
+/// the durable store, which holds every platform and every epoch in one
+/// directory, and erroring on the mixture would make the store unreadable.
+/// Nothing is pooled across a partition, which is the property that mattered.
+pub fn calibrate_runtime(
+    reports: &[StoredRuntimeReport],
+) -> Result<Vec<RuntimeCalibrationReport>, CalibrationError> {
+    if reports.is_empty() {
+        return Err(CalibrationError(
+            "no runtime reports were supplied".to_string(),
+        ));
+    }
+
+    let mut partitions: BTreeMap<(String, u32), Vec<&StoredRuntimeReport>> = BTreeMap::new();
+    for stored in reports {
+        let identity = &stored.record().identity;
+        partitions
+            .entry((identity.platform.clone(), identity.epoch))
+            .or_default()
+            .push(stored);
+    }
+
+    Ok(partitions
+        .into_values()
+        .map(|mut partition| {
+            // The trailing window is a window in time, so the order the store
+            // happened to list files in must not decide it.
+            partition.sort_by(|left, right| {
+                left.record()
+                    .identity
+                    .finished_at
+                    .cmp(&right.record().identity.finished_at)
+                    .then_with(|| left.address().cmp(right.address()))
+            });
+            calibrate_runtime_partition(&partition)
+        })
+        .collect())
+}
+
+fn calibrate_runtime_partition(partition: &[&StoredRuntimeReport]) -> RuntimeCalibrationReport {
+    let first = partition[0].record();
+
+    let mut fingerprints: Vec<String> = partition
+        .iter()
+        .filter_map(|stored| stored.record().identity.environment.fingerprint_id().ok())
+        .collect();
+    fingerprints.sort();
+    fingerprints.dedup();
+
+    let mut cpu_models: Vec<String> = partition
+        .iter()
+        .map(|stored| stored.record().identity.environment.cpu_model.clone())
+        .collect();
+    cpu_models.sort();
+    cpu_models.dedup();
+
+    let mut skipped: Vec<SkippedObservation> = Vec::new();
+    let mut series: BTreeMap<String, Vec<RuntimePoint>> = BTreeMap::new();
+    for stored in partition {
+        let report = stored.record();
+        for observation in &report.workloads {
+            if let Some(reason) = runtime_observation_defect(report, observation) {
+                skipped.push(SkippedObservation {
+                    workload: observation.workload.clone(),
+                    report: stored.address().to_string(),
+                    reason,
+                });
+                continue;
+            }
+            let Some(summary) = summarize(observation, RuntimeMetric::WallClock) else {
+                continue;
+            };
+            let fixture = observation
+                .recorded_inputs
+                .iter()
+                .find(|input| input.name == FIXTURE_INPUT_NAME)
+                .map(|input| input.identity_sha256.clone())
+                .unwrap_or_default();
+            let source = report
+                .identity
+                .workload_source_hashes
+                .get(&observation.workload)
+                .cloned()
+                .unwrap_or_default();
+            series
+                .entry(observation.workload.clone())
+                .or_default()
+                .push(RuntimePoint {
+                    finished_at: report.identity.finished_at.clone(),
+                    condition: ConstantCondition {
+                        fixture,
+                        source,
+                        program: observation.program.sha256.clone(),
+                    },
+                    cpu_model: report.identity.environment.cpu_model.clone(),
+                    summary,
+                });
+        }
+    }
+
+    let workloads = series
+        .into_iter()
+        .filter_map(|(workload, mut points)| {
+            points.sort_by(|left, right| left.finished_at.cmp(&right.finished_at));
+            calibrate_runtime_workload(&workload, &points)
+        })
+        .collect();
+
+    RuntimeCalibrationReport {
+        platform: first.identity.platform.clone(),
+        epoch: first.identity.epoch,
+        suite_revision: first.identity.suite_revision,
+        reports: partition.len(),
+        distinct_environments: fingerprints.len(),
+        cpu_models,
+        workloads,
+        skipped,
+    }
+}
+
+/// The median of a set of relative dispersions.
+///
+/// `rue_perf_schema::median` is over integers, which every stored measurement
+/// is; a relative MAD is a ratio and has no integer form to take a median of.
+/// Even-sized sets average the two central values, as that one does.
+fn median_of(values: &[f64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|left, right| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal));
+    let middle = sorted.len() / 2;
+    Some(if sorted.len() % 2 == 1 {
+        sorted[middle]
+    } else {
+        (sorted[middle - 1] + sorted[middle]) / 2.0
+    })
+}
+
+/// Split a chronological series into maximal runs of unchanging condition.
+///
+/// Maximal *consecutive* runs, matching `derive`: a corpus that changes and
+/// later changes back opens a second segment rather than rejoining the first,
+/// because the trailing window between them spans the change.
+fn constant_condition_segments(points: &[RuntimePoint]) -> Vec<&[RuntimePoint]> {
+    let mut segments = Vec::new();
+    let mut start = 0;
+    for index in 1..points.len() {
+        if points[index].condition != points[index - 1].condition {
+            segments.push(&points[start..index]);
+            start = index;
+        }
+    }
+    if !points.is_empty() {
+        segments.push(&points[start..]);
+    }
+    segments
+}
+
+fn calibrate_runtime_workload(
+    workload: &str,
+    points: &[RuntimePoint],
+) -> Option<RuntimeWorkloadCalibration> {
+    if points.is_empty() {
+        return None;
+    }
+    let segments = constant_condition_segments(points);
+    let longest = segments
+        .iter()
+        .max_by_key(|segment| segment.len())
+        .copied()?;
+
+    // Relative dispersion is comparable across corpora — that is what makes it
+    // relative — so the within-observation figure pools every point. The median
+    // of many coarse per-observation MADs is the estimate; a mean would carry a
+    // descheduled sample straight into it.
+    let within: Vec<f64> = points
+        .iter()
+        .map(|point| point.summary.relative_mad())
+        .collect();
+    let within_observation_relative_mad = median_of(&within).unwrap_or(0.0);
+
+    // Run-to-run dispersion is not comparable across corpora, so it is taken
+    // inside a segment — and only inside one long enough that this figure is
+    // not itself the three-point estimate the sample floor exists to refuse.
+    // Admitting shorter segments produced exactly that: a "0.17%" computed from
+    // three observations, indistinguishable in the table from one computed from
+    // sixteen, and `run_to_run_dominates` decided from it.
+    let qualifying: Vec<&&[RuntimePoint]> = segments
+        .iter()
+        .filter(|segment| segment.len() >= MINIMUM_CALIBRATION_OBSERVATIONS)
+        .collect();
+    let per_segment: Vec<f64> = qualifying
+        .iter()
+        .filter_map(|segment| {
+            let medians: Vec<u64> = segment.iter().map(|point| point.summary.median).collect();
+            Summary::of(&medians).map(|summary| summary.relative_mad())
+        })
+        .collect();
+    let run_to_run_relative_mad = median_of(&per_segment);
+    let run_to_run_observations: usize = qualifying.iter().map(|segment| segment.len()).sum();
+
+    let min_samples = points
+        .iter()
+        .map(|point| point.summary.count as u32)
+        .min()
+        .unwrap_or(0);
+    let max_samples = points
+        .iter()
+        .map(|point| point.summary.count as u32)
+        .max()
+        .unwrap_or(0);
+
+    let enough_observations = longest.len() >= MINIMUM_CALIBRATION_OBSERVATIONS;
+    // Two confidences, because the two figures fail for different reasons. The
+    // sample count bites the within-observation MAD and nothing else: the sweep
+    // reads observation MEDIANS and each observation's own summary, computed
+    // exactly as `derive` computes them, so it is self-consistent at any sample
+    // count the epoch declares.
+    let within_observation_confidence =
+        if enough_observations && min_samples >= MINIMUM_CALIBRATION_SAMPLES {
+            DispersionConfidence::Sufficient
+        } else {
+            DispersionConfidence::Thin
+        };
+    let flagging_confidence = if enough_observations {
+        DispersionConfidence::Sufficient
+    } else {
+        DispersionConfidence::Thin
+    };
+
+    let segment_medians: Vec<u64> = longest.iter().map(|point| point.summary.median).collect();
+    let median_wall_clock_ns = rue_perf_schema::median(&segment_medians).unwrap_or(0);
+    let max_relative_excursion = (median_wall_clock_ns != 0).then(|| {
+        segment_medians
+            .iter()
+            .map(|median| {
+                median.abs_diff(median_wall_clock_ns) as f64 / median_wall_clock_ns as f64
+            })
+            .fold(0.0, f64::max)
+    });
+
+    let sweep = sweep_runtime_flagging(&segments);
+    let (flagging, flagging_verdict, recommended_independent_comparisons) =
+        recommend_from_sweep(sweep, flagging_confidence, &segments);
+
+    Some(RuntimeWorkloadCalibration {
+        workload: workload.to_string(),
+        observations: points.len(),
+        segments: segments.len(),
+        longest_segment: longest.len(),
+        min_samples_per_observation: min_samples,
+        max_samples_per_observation: max_samples,
+        median_wall_clock_ns,
+        within_observation_relative_mad,
+        within_observation_confidence,
+        run_to_run_relative_mad,
+        run_to_run_observations,
+        max_relative_excursion,
+        by_cpu_model: dispersion_by_cpu_model(longest),
+        run_to_run_dominates: run_to_run_relative_mad.is_some_and(|between| {
+            between > RUN_TO_RUN_DOMINANCE * within_observation_relative_mad
+        }),
+        // A recommendation from evidence this thin would be a number with a
+        // decimal point and nothing behind it, which is worse than the absence.
+        recommended_samples: (within_observation_confidence == DispersionConfidence::Sufficient)
+            .then(|| recommended_runtime_samples(within_observation_relative_mad)),
+        flagging,
+        flagging_confidence,
+        flagging_verdict,
+        recommended_independent_comparisons,
+    })
+}
+
+/// Samples the median needs, floored at what this method can calibrate from.
+///
+/// [`recommended_samples`] clamps at three, which is right for the compile-time
+/// suites and wrong here: three samples is precisely the count
+/// [`MINIMUM_CALIBRATION_SAMPLES`] refuses to estimate a within-observation
+/// dispersion from, so recommending it would advise a sampling policy that
+/// makes the workload permanently uncalibratable by this very tool. A tool must
+/// not advise its way into its own refusal.
+///
+/// The floor binds often rather than rarely: these workloads run for seconds
+/// and their within-observation dispersion is a fraction of a percent, so the
+/// uncertainty target is met by a handful of samples and the honest reading of
+/// the recommendation is "the sampling policy is not what limits this series".
+fn recommended_runtime_samples(relative_mad: f64) -> u32 {
+    recommended_samples(relative_mad).max(MINIMUM_CALIBRATION_SAMPLES)
+}
+
+/// Decompose a segment's run-to-run dispersion by machine class.
+///
+/// Empty for a homogeneous pool, where the pooled figure already is the whole
+/// story and a one-row table would only imply otherwise.
+fn dispersion_by_cpu_model(segment: &[RuntimePoint]) -> Vec<EnvironmentDispersion> {
+    let mut grouped: BTreeMap<&str, Vec<u64>> = BTreeMap::new();
+    for point in segment {
+        grouped
+            .entry(point.cpu_model.as_str())
+            .or_default()
+            .push(point.summary.median);
+    }
+    if grouped.len() < 2 {
+        return Vec::new();
+    }
+    grouped
+        .into_iter()
+        .map(|(cpu_model, medians)| EnvironmentDispersion {
+            cpu_model: cpu_model.to_string(),
+            observations: medians.len(),
+            median_wall_clock_ns: rue_perf_schema::median(&medians).unwrap_or(0),
+            // Three, not the calibration floor: this figure is published as a
+            // decomposition to be read against the pooled one, never as a bound
+            // to calibrate from, and suppressing the small groups would hide
+            // the very machines a mixture is a mixture of. The observation
+            // count rides beside it so a reader can weigh it.
+            run_to_run_relative_mad: (medians.len() >= 3)
+                .then(|| Summary::of(&medians).map(|summary| summary.relative_mad()))
+                .flatten(),
+        })
+        .collect()
+}
+
+/// Choose a pairing from a sweep, or say why none was chosen.
+///
+/// Split from the sweep itself so the sweep table is always published whole. A
+/// report that hid its evidence whenever it declined to recommend would leave a
+/// maintainer with an opinion and nothing to check it against.
+fn recommend_from_sweep(
+    sweep: Vec<SweepPoint>,
+    confidence: DispersionConfidence,
+    segments: &[&[RuntimePoint]],
+) -> (FlaggingRecommendation, FlaggingVerdict, Option<usize>) {
+    let tried: usize = sweep
+        .iter()
+        .map(|point| point.comparisons)
+        .max()
+        .unwrap_or(0);
+    let clean = sweep
+        .iter()
+        .filter(|point| point.comparisons > 0 && point.false_flags == 0)
+        // Prefer the shortest window that works, then the smallest multiplier:
+        // a shorter window reacts sooner, and a smaller multiplier detects
+        // more. The shortest window is also the one whose comparisons overlap
+        // least, so this preference happens to pick the best-supported row of
+        // the sweep as well as the most responsive rule.
+        .min_by(|left, right| {
+            left.window.cmp(&right.window).then(
+                left.k
+                    .partial_cmp(&right.k)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+            )
+        })
+        .copied();
+
+    let citable = clean.filter(|point| point.comparisons >= MINIMUM_SWEEP_COMPARISONS);
+    let verdict = match (confidence, tried, clean, citable) {
+        (DispersionConfidence::Thin, ..) => FlaggingVerdict::EvidenceTooThin,
+        (_, 0, ..) => FlaggingVerdict::NoComparisons,
+        (_, _, None, _) => FlaggingVerdict::NeverClean,
+        (_, _, Some(_), None) => FlaggingVerdict::TooFewComparisons,
+        (_, _, Some(_), Some(_)) => FlaggingVerdict::Recommended,
+    };
+    let chosen = matches!(verdict, FlaggingVerdict::Recommended)
+        .then_some(citable)
+        .flatten();
+
+    // How much of the chosen pairing's evidence is actually independent. The
+    // nominal count is what the sweep tried; this is what it is entitled to
+    // claim, and the gap between them widens with the window.
+    let independent = chosen.map(|point| {
+        segments
+            .iter()
+            .map(|segment| independent_comparisons(segment.len(), point.window))
+            .sum()
+    });
+
+    (
+        FlaggingRecommendation {
+            recommended_window: chosen.map(|point| point.window),
+            recommended_k: chosen.map(|point| point.k),
+            sweep,
+        },
+        verdict,
+        independent,
+    )
+}
+
+/// Sweep `(window, k)` over one workload's constant-condition segments.
+///
+/// The same sweep as [`sweep_flagging`], over the same [`SweepPoint`]s. What
+/// differs is where a comparison may be drawn: only inside a segment, and never
+/// across one. A comparison spanning a corpus change would count a real
+/// difference as a false flag, and every such miscount pushes the recommended
+/// multiplier up — so the failure mode is a bound too loose to detect anything,
+/// arrived at from data that looked plentiful.
+fn sweep_runtime_flagging(segments: &[&[RuntimePoint]]) -> Vec<SweepPoint> {
+    let mut sweep = Vec::new();
+    for &window in WINDOW_CANDIDATES {
+        for &k in K_CANDIDATES {
+            let mut false_flags = 0;
+            let mut comparisons = 0;
+            for segment in segments {
+                if segment.len() <= window {
+                    continue;
+                }
+                for index in window..segment.len() {
+                    let trailing: Vec<u64> = segment[index - window..index]
+                        .iter()
+                        .map(|point| point.summary.median)
+                        .collect();
+                    let Some(window_summary) = Summary::of(&trailing) else {
+                        continue;
+                    };
+                    comparisons += 1;
+                    if flags_movement(segment[index].summary, window_summary, k) {
+                        false_flags += 1;
+                    }
+                }
+            }
+            sweep.push(SweepPoint {
+                window,
+                k,
+                false_flags,
+                comparisons,
+            });
+        }
+    }
+    sweep
+}
+
+/// Mark a figure whose evidence does not support recommending from it.
+fn thin_marked(rendered: String, confidence: DispersionConfidence) -> String {
+    match confidence {
+        DispersionConfidence::Sufficient => rendered,
+        DispersionConfidence::Thin => format!("{rendered} †"),
+    }
+}
+
+/// Render the runtime reports as reviewable prose.
+pub fn render_runtime(reports: &[RuntimeCalibrationReport]) -> String {
+    let mut out = String::new();
+    out.push_str(
+        "# Runtime calibration (ADR-0072 Decision 5)\n\n\
+         Dispersion is a property of the workload, so nothing here transfers from the compiler \
+         suites, from another platform, or from another workload on this one. Each figure below \
+         is measured from one workload's own repeated samples on one platform's epoch.\n\n\
+         THIS RECOMMENDS; IT DOES NOT DECIDE. What `k` and `window` should be is ADR-0072's open \
+         question 4 and a maintainer's call. Writing a recommendation into \
+         `performance/runtime.toml` is a reviewed edit that cites this analysis, and until one \
+         happens every runtime flag stays advisory.\n\n",
+    );
+
+    for report in reports {
+        out.push_str(&format!(
+            "## {} epoch {} (suite revision {})\n\n{} report(s), {} distinct environment \
+             fingerprint(s).\n\n",
+            report.platform,
+            report.epoch,
+            report.suite_revision,
+            report.reports,
+            report.distinct_environments,
+        ));
+        // Said whatever the CPU models look like, because a fingerprint covers
+        // the runner image, kernel, and OS version too — and on a platform that
+        // reports its CPU as `unknown`, drift in those is the only evidence of
+        // a moving pool there is.
+        if report.distinct_environments > 1 {
+            out.push_str(&format!(
+                "The hosted environment changed underneath this series: {} distinct fingerprints \
+                 across {} report(s). Some of the dispersion below is that drift rather than the \
+                 workload.\n\n",
+                report.distinct_environments, report.reports,
+            ));
+        }
+        if report.cpu_models.len() > 1 {
+            out.push_str(&format!(
+                "The runner pool handed out {} different CPU models: {}. On a series sampled over \
+                 months this is usually the largest term in the dispersion below, and it is not \
+                 the workload — a multiplier chosen to absorb it is absorbing the pool. The \
+                 per-workload decompositions below separate the two.\n\n",
+                report.cpu_models.len(),
+                report.cpu_models.join(", "),
+            ));
+        }
+
+        out.push_str(
+            "| workload | median | within-obs. rel. MAD | run-to-run rel. MAD | max excursion | \
+             samples/obs. | obs. | segments | longest | rec. samples |\n\
+             | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n",
+        );
+        for workload in &report.workloads {
+            let samples =
+                if workload.min_samples_per_observation == workload.max_samples_per_observation {
+                    workload.min_samples_per_observation.to_string()
+                } else {
+                    format!(
+                        "{}–{}",
+                        workload.min_samples_per_observation, workload.max_samples_per_observation
+                    )
+                };
+            out.push_str(&format!(
+                "| {} | {:.1} ms | {} | {} | {} | {} | {} | {} | {} | {} |\n",
+                workload.workload,
+                workload.median_wall_clock_ns as f64 / 1e6,
+                // Marked rather than hidden when thin: the number is evidence
+                // about how little there is, and only the recommendation
+                // derived from it is withheld.
+                thin_marked(
+                    format!("{:.2}%", workload.within_observation_relative_mad * 100.0),
+                    workload.within_observation_confidence,
+                ),
+                workload
+                    .run_to_run_relative_mad
+                    .map(|value| format!("{:.2}%", value * 100.0))
+                    .unwrap_or_else(|| "—".to_string()),
+                workload
+                    .max_relative_excursion
+                    .map(|value| format!("{:.1}%", value * 100.0))
+                    .unwrap_or_else(|| "—".to_string()),
+                samples,
+                workload.observations,
+                workload.segments,
+                workload.longest_segment,
+                workload
+                    .recommended_samples
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "—".to_string()),
+            ));
+        }
+        out.push_str(
+            "\nA figure marked † rests on too little evidence to recommend from; see each \
+             workload below. `max excursion` is the largest single deviation from the segment \
+             median — the half a MAD is built to discard, and the one that says how far a hosted \
+             runner actually strays.\n\n",
+        );
+
+        for workload in &report.workloads {
+            out.push_str(&format!("### {}\n\n", workload.workload));
+
+            if workload.min_samples_per_observation < MINIMUM_CALIBRATION_SAMPLES {
+                out.push_str(&format!(
+                    "**This workload collects {} sample(s) per observation, and its \
+                     within-observation dispersion therefore cannot be estimated by this method \
+                     at any number of repetitions.** A MAD includes the median's own zero \
+                     deviation, so at {} samples it is the smaller of the two that remain and is \
+                     biased low by construction. The remedy would be raising `samples` in \
+                     `performance/runtime.toml`, which ADR-0072 Decision 9 makes a runner-cost \
+                     decision rather than a calibration one — `gazette_10x` carries three by \
+                     deliberate policy, because that rung exists for the shape of the curve \
+                     rather than for a tight median.\n\n\
+                     Its FLAGGING rule is unaffected and is calibrated below. The sweep \
+                     summarizes each observation exactly as the dashboard's derive step does, \
+                     from these same {} samples, so whatever bias the count carries is carried \
+                     identically by the rule being calibrated and by the rule as it will be \
+                     applied. What `[epoch.calibration]` declares is `k` and `window`, not a \
+                     sample count.\n\n",
+                    workload.min_samples_per_observation,
+                    workload.min_samples_per_observation,
+                    workload.min_samples_per_observation,
+                ));
+            }
+
+            if !workload.by_cpu_model.is_empty() {
+                let excursion = workload
+                    .max_relative_excursion
+                    .map(|value| format!("{:.1}%", value * 100.0))
+                    .unwrap_or_else(|| "unknown".to_string());
+                // Two wordings, because the strong one is a claim about a
+                // pooled figure and there is not always a pooled figure to make
+                // it about.
+                match workload.run_to_run_relative_mad {
+                    Some(pooled) => out.push_str(&format!(
+                        "Its run-to-run figure is a MIXTURE and reads as neither of the things it \
+                         mixes. Pooled it is {:.2}%; within one machine class the series is \
+                         quieter than that, and across classes it jumps further, the largest \
+                         single excursion being {excursion}. The sweep deliberately keeps \
+                         measuring across machines, because production `derive` segments on the \
+                         fixture and workload-source identities alone and its trailing windows \
+                         span machines too — a bound calibrated on same-machine windows could not \
+                         survive real collection. This table is how to read the one above, not a \
+                         second segmentation.\n\n",
+                        pooled * 100.0,
+                    )),
+                    None => out.push_str(&format!(
+                        "Observations of this workload landed on more than one machine class, so \
+                         any dispersion here would be a mixture of within-machine noise and \
+                         between-machine jumps. There are too few for a pooled figure at all; the \
+                         medians below are what there is, and the largest single excursion is \
+                         {excursion}.\n\n",
+                    )),
+                }
+                out.push_str(
+                    "| CPU model | obs. | median | run-to-run rel. MAD |\n\
+                     | --- | ---: | ---: | ---: |\n",
+                );
+                for environment in &workload.by_cpu_model {
+                    out.push_str(&format!(
+                        "| {} | {} | {:.1} ms | {} |\n",
+                        environment.cpu_model,
+                        environment.observations,
+                        environment.median_wall_clock_ns as f64 / 1e6,
+                        environment
+                            .run_to_run_relative_mad
+                            .map(|value| format!("{:.2}%", value * 100.0))
+                            .unwrap_or_else(|| "—".to_string()),
+                    ));
+                }
+                out.push('\n');
+            }
+
+            // Only where a sample count was recommended, since the note is
+            // about what that count does and does not buy.
+            if workload.run_to_run_dominates && workload.recommended_samples.is_some() {
+                out.push_str(&format!(
+                    "Run-to-run dispersion ({:.2}%) is more than {RUN_TO_RUN_DOMINANCE:.0}x the \
+                     dispersion inside one observation ({:.2}%). A larger sample count tightens \
+                     the second and leaves the first exactly where it is, so the recommended \
+                     sample count above is answering the smaller question — and it is a floor \
+                     rather than a target: it never drops below the {MINIMUM_CALIBRATION_SAMPLES} \
+                     this method itself needs. What a flagging bound must absorb here is the \
+                     between-run term.\n\n",
+                    workload.run_to_run_relative_mad.unwrap_or_default() * 100.0,
+                    workload.within_observation_relative_mad * 100.0,
+                ));
+            }
+
+            match workload.flagging_verdict {
+                FlaggingVerdict::Recommended => out.push_str(&format!(
+                    "Smallest swept pairing with no false flag inside a constant-condition \
+                     segment: k = {}, window = {}. It rests on at least \
+                     {MINIMUM_SWEEP_COMPARISONS} comparisons, of which roughly {} are \
+                     independent — successive comparisons at window {} share {} observations. A \
+                     recommendation to review, not a threshold to apply.\n\n",
+                    workload.flagging.recommended_k.unwrap_or_default(),
+                    workload.flagging.recommended_window.unwrap_or_default(),
+                    workload.recommended_independent_comparisons.unwrap_or(0),
+                    workload.flagging.recommended_window.unwrap_or_default(),
+                    workload
+                        .flagging
+                        .recommended_window
+                        .unwrap_or_default()
+                        .saturating_sub(1),
+                )),
+                FlaggingVerdict::EvidenceTooThin => out.push_str(&format!(
+                    "Evidence is too thin to recommend from: the longest run of observations \
+                     measuring an unchanged program over an unchanged corpus is {} and needs \
+                     {MINIMUM_CALIBRATION_OBSERVATIONS}. The sweep is below for inspection and \
+                     nothing is chosen from it. The remedy is repeated collection of one \
+                     unchanged program, which is what the calibration workflow's runtime lane \
+                     produces.\n\n",
+                    workload.longest_segment,
+                )),
+                FlaggingVerdict::NoComparisons => out.push_str(
+                    "No comparison was possible: no constant-condition segment is longer than \
+                     the shortest swept window. This workload's calibration is waiting on \
+                     repeated observations of an unchanged program.\n\n",
+                ),
+                FlaggingVerdict::TooFewComparisons => out.push_str(&format!(
+                    "A pairing flagged nothing, and it is not citable: every clean pairing rests \
+                     on fewer than {MINIMUM_SWEEP_COMPARISONS} comparisons, and no event in a \
+                     handful of trials bounds a rate at anything useful — the fewer still once \
+                     overlapping windows are discounted. Run the calibration lane for more \
+                     repetitions rather than reading the table below as an answer.\n\n",
+                )),
+                FlaggingVerdict::NeverClean => out.push_str(
+                    "No swept pairing eliminated false flags, including the largest multiplier \
+                     swept. The runner is noisier than this workload can absorb; the honest \
+                     answers are a quieter regime, more observations, or accepting that this \
+                     platform carries no flag — a multiplier beyond the sweep is not one of \
+                     them.\n\n",
+                ),
+            }
+            let rows: Vec<&SweepPoint> = workload
+                .flagging
+                .sweep
+                .iter()
+                .filter(|point| point.comparisons > 0)
+                .collect();
+            if !rows.is_empty() {
+                out.push_str(
+                    "| window | k | false flags | comparisons | ~independent |\n\
+                     | ---: | ---: | ---: | ---: | ---: |\n",
+                );
+                for point in rows {
+                    out.push_str(&format!(
+                        "| {} | {} | {} | {} | {} |\n",
+                        point.window,
+                        point.k,
+                        point.false_flags,
+                        point.comparisons,
+                        independent_comparisons(workload.longest_segment, point.window),
+                    ));
+                }
+                out.push('\n');
+            }
+        }
+
+        if !report.skipped.is_empty() {
+            out.push_str(&format!(
+                "### Excluded observations ({})\n\n| workload | report | reason |\n\
+                 | --- | --- | --- |\n",
+                report.skipped.len()
+            ));
+            for skipped in &report.skipped {
+                out.push_str(&format!(
+                    "| {} | {} | {} |\n",
+                    skipped.workload,
+                    &skipped.report[..skipped.report.len().min(12)],
+                    skipped.reason
+                ));
+            }
+            out.push('\n');
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -644,6 +1808,727 @@ mod tests {
                 "2026-07-28T00:01:00Z",
                 "2026-07-28T00:02:00Z"
             ]
+        );
+    }
+}
+
+#[cfg(test)]
+mod runtime_tests {
+    use super::*;
+    use rue_perf_schema::{
+        EnvironmentFingerprint, GeneratedProvenance, HardwareCounterPolicy, InputCategory,
+        OptimizationLevel, OracleKind, OracleOutcome, ProgramIdentity, RUNTIME_RECORD_KIND,
+        RUNTIME_REPORT_SCHEMA_VERSION, RecordedInput, RuntimeBoundary, RuntimeIdentity,
+        RuntimeRegime, RuntimeSample, ThreadPolicy,
+    };
+
+    /// What one synthetic observation varies.
+    ///
+    /// Every field here is one the calibration reasons about, so a test says
+    /// what it is holding constant by leaving the default in place.
+    #[derive(Clone)]
+    struct Observation {
+        platform: &'static str,
+        epoch: u32,
+        suite_revision: u32,
+        /// Distinct per observation by default: per-push collection never
+        /// repeats one, and the calibration must not need it to.
+        commit: char,
+        minute: u32,
+        /// The WORKLOAD identity.
+        fixture: char,
+        /// The workload's own source closure.
+        source: char,
+        /// The measured executable.
+        program: char,
+        /// The COMPARISON identity, which must not segment anything.
+        comparison: Option<char>,
+        cpu_model: &'static str,
+        runner_image_version: &'static str,
+        samples: Vec<u64>,
+        verdict: OracleVerdict,
+        deterministic: bool,
+    }
+
+    impl Default for Observation {
+        fn default() -> Self {
+            Observation {
+                platform: "x86_64-linux",
+                epoch: 3,
+                suite_revision: 3,
+                commit: 'a',
+                minute: 0,
+                fixture: 'f',
+                source: 's',
+                program: 'p',
+                comparison: None,
+                cpu_model: "AMD EPYC 7763",
+                runner_image_version: "1",
+                samples: vec![1_000, 1_010, 990, 1_000, 1_005],
+                verdict: OracleVerdict::Match,
+                deterministic: true,
+            }
+        }
+    }
+
+    fn report(observation: &Observation) -> RuntimeReport {
+        RuntimeReport {
+            record_kind: RUNTIME_RECORD_KIND.to_string(),
+            schema_version: RUNTIME_REPORT_SCHEMA_VERSION,
+            identity: RuntimeIdentity {
+                suite_revision: observation.suite_revision,
+                epoch: observation.epoch,
+                platform: observation.platform.to_string(),
+                commit: std::iter::repeat_n(observation.commit, 40).collect(),
+                compiler_version: "rue 0.1.0".to_string(),
+                started_at: format!("2026-08-13T00:{:02}:00Z", observation.minute),
+                finished_at: format!("2026-08-13T00:{:02}:30Z", observation.minute),
+                toolchain_hash: "1".repeat(64),
+                stdlib_hash: "2".repeat(64),
+                workload_source_hashes: BTreeMap::from([(
+                    "gazette".to_string(),
+                    std::iter::repeat_n(observation.source, 64).collect(),
+                )]),
+                environment: EnvironmentFingerprint {
+                    runner_label: "github-hosted".to_string(),
+                    runner_image: "ubuntu-24.04".to_string(),
+                    runner_image_version: observation.runner_image_version.to_string(),
+                    cpu_model: observation.cpu_model.to_string(),
+                    core_count: 4,
+                    memory_bytes: 1,
+                    kernel_version: "probe".to_string(),
+                    os_version: "probe".to_string(),
+                    architecture: "x86_64".to_string(),
+                },
+            },
+            regime: RuntimeRegime {
+                measured_boundary: RuntimeBoundary::SpawnToExitV1,
+                program_state: "fresh_process".to_string(),
+                os_page_cache: "uncontrolled".to_string(),
+                fixture_preparation_measured: false,
+                oracle_comparison_measured: false,
+                optimization: OptimizationLevel::O3,
+                compiler_args: vec!["-O3".to_string()],
+                target: "x86-64-linux".to_string(),
+                thread_policy: ThreadPolicy::SingleThreaded,
+                hardware_counters: HardwareCounterPolicy::UnavailableOnHostedRunner,
+            },
+            workloads: vec![RuntimeObservation {
+                workload: "gazette".to_string(),
+                source: "examples/gazette/main.rue".to_string(),
+                question: "How fast does compiled Rue build the site?".to_string(),
+                program_args: vec!["build".to_string()],
+                recorded_inputs: vec![RecordedInput {
+                    name: FIXTURE_INPUT_NAME.to_string(),
+                    category: InputCategory::Recorded,
+                    description: "the live corpus".to_string(),
+                    identity_sha256: std::iter::repeat_n(observation.fixture, 64).collect(),
+                    files: 96,
+                    bytes: 525_479,
+                    provenance: Some(GeneratedProvenance {
+                        generator: "probe".to_string(),
+                        generator_revision: 1,
+                        seed: 1,
+                        vocabulary_size: 1,
+                    }),
+                    tree: None,
+                }],
+                program: ProgramIdentity {
+                    binary_bytes: 65_536,
+                    sha256: std::iter::repeat_n(observation.program, 64).collect(),
+                },
+                oracle: OracleOutcome {
+                    kind: OracleKind::GoldenStdout,
+                    reference: "probe".to_string(),
+                    reference_sha256: "c".repeat(64),
+                    observed_sha256: "c".repeat(64),
+                    verdict: observation.verdict,
+                    deterministic_across_samples: observation.deterministic,
+                    detail: String::new(),
+                },
+                samples: observation
+                    .samples
+                    .iter()
+                    .map(|process_elapsed_ns| RuntimeSample {
+                        process_elapsed_ns: *process_elapsed_ns,
+                        peak_memory_bytes: 1024,
+                        exit_code: 0,
+                        stdout_bytes: 0,
+                        stdout_sha256: "c".repeat(64),
+                        artifact_sha256: None,
+                    })
+                    .collect(),
+                peers: Vec::new(),
+                comparison: observation.comparison.map(|digest| {
+                    rue_perf_schema::ComparisonIdentity {
+                        identity_sha256: std::iter::repeat_n(digest, 64).collect(),
+                        peer_port_revision: 1,
+                        peer_versions: BTreeMap::from([("zola".to_string(), "0.21.0".to_string())]),
+                    }
+                }),
+            }],
+            failures: Vec::new(),
+        }
+    }
+
+    fn stored(observations: &[Observation]) -> Vec<StoredRuntimeReport> {
+        observations
+            .iter()
+            .map(|observation| {
+                let text = rue_perf_schema::canonical_json(&report(observation)).unwrap();
+                StoredRuntimeReport::read(&text).unwrap()
+            })
+            .collect()
+    }
+
+    /// `count` observations, each at its own commit and minute, otherwise
+    /// identical. The shape a calibration lane produces, and the shape a quiet
+    /// per-push series produces too.
+    fn repeated(count: u32) -> Vec<Observation> {
+        (0..count)
+            .map(|index| Observation {
+                commit: char::from(b'a' + (index % 26) as u8),
+                minute: index,
+                ..Observation::default()
+            })
+            .collect()
+    }
+
+    fn only(reports: Vec<RuntimeCalibrationReport>) -> RuntimeCalibrationReport {
+        assert_eq!(reports.len(), 1, "expected one platform epoch");
+        reports.into_iter().next().unwrap()
+    }
+
+    fn gazette(report: &RuntimeCalibrationReport) -> &RuntimeWorkloadCalibration {
+        report
+            .workloads
+            .iter()
+            .find(|workload| workload.workload == "gazette")
+            .expect("the gazette workload")
+    }
+
+    #[test]
+    fn a_moving_comparison_identity_does_not_segment_rues_own_series() {
+        // THE LOAD-BEARING TEST. ADR-0072 Decision 2 splits the recorded
+        // identity in two, and only the workload half describes what gazette
+        // consumed. A peer template edit or a Hugo version bump moves the
+        // comparison identity and cannot move one instruction gazette executes,
+        // so segmenting on it would throw away Rue's own repeated samples every
+        // time a peer moved — leaving a thinner and more optimistic dispersion
+        // estimate from fewer points, with nothing in the report saying so.
+        let mut observations = repeated(14);
+        for (index, observation) in observations.iter_mut().enumerate() {
+            // The peers move three times across the series. Nothing gazette
+            // reads moves at all.
+            observation.comparison = Some(char::from(b'0' + (index / 4) as u8));
+        }
+        let report = only(calibrate_runtime(&stored(&observations)).unwrap());
+        let workload = gazette(&report);
+        assert_eq!(workload.segments, 1, "the peers are not gazette's input");
+        assert_eq!(workload.observations, 14);
+        assert_eq!(workload.longest_segment, 14);
+        assert_eq!(workload.flagging_verdict, FlaggingVerdict::Recommended);
+    }
+
+    #[test]
+    fn a_corpus_change_opens_a_new_segment_and_no_comparison_crosses_it() {
+        // The other direction of the same rule: the fixture digest IS what
+        // gazette consumed, and a comparison spanning a change in it would
+        // count a real difference as noise.
+        let mut observations = repeated(14);
+        for observation in observations.iter_mut().skip(7) {
+            observation.fixture = 'g';
+        }
+        let report = only(calibrate_runtime(&stored(&observations)).unwrap());
+        let workload = gazette(&report);
+        assert_eq!(workload.segments, 2);
+        assert_eq!(workload.longest_segment, 7);
+        // Seven observations per segment: window 3 yields four comparisons in
+        // each, and none of the eight straddles the boundary at index seven.
+        let window_three = workload
+            .flagging
+            .sweep
+            .iter()
+            .find(|point| point.window == 3 && point.k == 1.0)
+            .unwrap();
+        assert_eq!(window_three.comparisons, 8);
+    }
+
+    #[test]
+    fn a_recompiled_program_opens_a_new_segment() {
+        // The runtime replacement for the compile-time rule that every run
+        // measure one compiler revision. What must be constant is the thing
+        // measured, and here that is the executable.
+        let mut observations = repeated(14);
+        for observation in observations.iter_mut().skip(9) {
+            observation.program = 'q';
+        }
+        let report = only(calibrate_runtime(&stored(&observations)).unwrap());
+        assert_eq!(gazette(&report).segments, 2);
+        assert_eq!(gazette(&report).longest_segment, 9);
+    }
+
+    #[test]
+    fn differing_commits_over_one_unchanged_program_stay_one_segment() {
+        // Why the commit is not the constancy key. Every observation here is at
+        // its own commit — per-push collection never repeats one — and the
+        // program digest says the measured executable never changed, so all
+        // fourteen are repeated measurements of one thing. Requiring equal
+        // commits would find no evidence at all in a store full of it.
+        let observations = repeated(14);
+        let commits: std::collections::BTreeSet<char> =
+            observations.iter().map(|entry| entry.commit).collect();
+        assert_eq!(commits.len(), 14, "the fixture must actually vary commits");
+
+        let report = only(calibrate_runtime(&stored(&observations)).unwrap());
+        assert_eq!(gazette(&report).segments, 1);
+        assert_eq!(
+            gazette(&report).flagging_confidence,
+            DispersionConfidence::Sufficient
+        );
+    }
+
+    #[test]
+    fn quiet_repeated_observations_recommend_the_shortest_window_and_smallest_k() {
+        let report = only(calibrate_runtime(&stored(&repeated(14))).unwrap());
+        let workload = gazette(&report);
+        assert_eq!(workload.flagging_verdict, FlaggingVerdict::Recommended);
+        assert_eq!(workload.flagging.recommended_window, Some(3));
+        assert_eq!(workload.flagging.recommended_k, Some(1.0));
+        assert_eq!(workload.median_wall_clock_ns, 1_000);
+        assert!(workload.recommended_samples.is_some());
+        // Fourteen observations at window 3 give eleven nominal comparisons and
+        // three independent ones, and the report may only claim the latter.
+        assert_eq!(workload.recommended_independent_comparisons, Some(3));
+        assert!(
+            render_runtime(&[report]).contains("roughly 3 are independent"),
+            "the recommendation must state what it actually rests on"
+        );
+    }
+
+    #[test]
+    fn a_recommended_sample_count_never_falls_below_what_this_method_can_calibrate() {
+        // The defect this floor exists for. The compile-time clamp bottoms out
+        // at three, and three samples is exactly the count
+        // MINIMUM_CALIBRATION_SAMPLES refuses to estimate a within-observation
+        // dispersion from — so the unclamped path advised a sampling policy
+        // that would make the workload permanently uncalibratable by this very
+        // tool. These workloads are quiet inside one observation, so the floor
+        // binds on real data rather than in principle.
+        assert_eq!(recommended_samples(0.0038), 3, "the compile-time clamp");
+        assert_eq!(
+            recommended_runtime_samples(0.0038),
+            MINIMUM_CALIBRATION_SAMPLES
+        );
+        // A genuinely noisy workload still gets a real recommendation.
+        assert!(recommended_runtime_samples(0.05) > MINIMUM_CALIBRATION_SAMPLES);
+
+        let report = only(calibrate_runtime(&stored(&repeated(14))).unwrap());
+        let recommended = gazette(&report).recommended_samples.unwrap();
+        assert!(
+            recommended >= MINIMUM_CALIBRATION_SAMPLES,
+            "recommended {recommended}"
+        );
+    }
+
+    #[test]
+    fn three_samples_an_observation_block_the_sample_figure_but_not_the_flagging_rule() {
+        // `gazette_10x` collects three samples on EVERY hosted epoch, by
+        // deliberate cost policy under ADR-0072 Decision 9, and this issue
+        // exists to give every declared workload a route out of advisory. A
+        // blanket sample floor took that route away from one of the three.
+        //
+        // The split: a three-sample MAD is biased low, so no within-observation
+        // dispersion and no sample count are reported. The sweep is unaffected,
+        // because it summarizes each observation exactly as `derive` does from
+        // these same three samples — the rule being calibrated and the rule as
+        // applied are the same rule over the same numbers.
+        let observations: Vec<Observation> = repeated(14)
+            .into_iter()
+            .map(|observation| Observation {
+                samples: vec![1_000, 1_010, 990],
+                ..observation
+            })
+            .collect();
+        let report = only(calibrate_runtime(&stored(&observations)).unwrap());
+        let workload = gazette(&report);
+        assert_eq!(
+            workload.within_observation_confidence,
+            DispersionConfidence::Thin
+        );
+        assert_eq!(workload.recommended_samples, None);
+
+        assert_eq!(
+            workload.flagging_confidence,
+            DispersionConfidence::Sufficient
+        );
+        assert_eq!(workload.flagging_verdict, FlaggingVerdict::Recommended);
+        assert_eq!(workload.flagging.recommended_k, Some(1.0));
+
+        let rendered = render_runtime(&[report]);
+        assert!(rendered.contains("cannot be estimated by this method"));
+        assert!(rendered.contains("Its FLAGGING rule is unaffected"));
+    }
+
+    #[test]
+    fn too_few_observations_are_too_thin_to_recommend_from() {
+        let report = only(calibrate_runtime(&stored(&repeated(4))).unwrap());
+        let workload = gazette(&report);
+        assert_eq!(workload.longest_segment, 4);
+        assert_eq!(
+            workload.within_observation_confidence,
+            DispersionConfidence::Thin
+        );
+        assert_eq!(workload.flagging_confidence, DispersionConfidence::Thin);
+        assert_eq!(workload.recommended_samples, None);
+        assert_eq!(workload.flagging_verdict, FlaggingVerdict::EvidenceTooThin);
+        // The observation count is the only criterion that failed, so it is the
+        // only one the prose cites.
+        let rendered = render_runtime(&[report]);
+        assert!(rendered.contains("is 4 and needs 8"));
+        assert!(!rendered.contains("sample(s) each (needs"));
+    }
+
+    #[test]
+    fn a_clean_pairing_resting_on_too_few_comparisons_is_not_cited() {
+        // Nine observations clear the confidence floor, and the shortest window
+        // then yields six comparisons. Six trials with no false flag bound the
+        // false-flag rate at roughly half, which is not a recommendation.
+        let report = only(calibrate_runtime(&stored(&repeated(9))).unwrap());
+        let workload = gazette(&report);
+        assert_eq!(
+            workload.flagging_confidence,
+            DispersionConfidence::Sufficient
+        );
+        assert_eq!(
+            workload.flagging_verdict,
+            FlaggingVerdict::TooFewComparisons
+        );
+        assert_eq!(workload.recommended_independent_comparisons, None);
+        assert_eq!(workload.flagging.recommended_k, None);
+        let window_three = workload
+            .flagging
+            .sweep
+            .iter()
+            .find(|point| point.window == 3 && point.k == 1.0)
+            .unwrap();
+        assert_eq!(window_three.comparisons, 6);
+        assert_eq!(window_three.false_flags, 0);
+    }
+
+    #[test]
+    fn a_noisy_runner_that_never_flags_clean_says_so_rather_than_reaching_higher() {
+        // The real x86_64-linux shape: a mostly quiet series in which the
+        // hosted pool occasionally hands out a different machine, on an
+        // unchanged program. Every excursion is a false flag at every swept
+        // multiplier, because a quiet trailing window has almost no dispersion
+        // for one to be measured against. The honest report is that this regime
+        // cannot carry a flag — not a larger number.
+        //
+        // Note what the run-to-run figure does here: a MAD ignores a minority
+        // of excursions entirely, so it stays near zero while the sweep is
+        // full of false flags. The two figures answer different questions and
+        // this is the case that shows it.
+        let observations: Vec<Observation> = repeated(14)
+            .into_iter()
+            .enumerate()
+            .map(|(index, observation)| Observation {
+                samples: if index % 4 == 3 {
+                    vec![3_000, 3_002, 2_998, 3_000, 3_001]
+                } else {
+                    vec![1_000, 1_002, 998, 1_000, 1_001]
+                },
+                ..observation
+            })
+            .collect();
+        let report = only(calibrate_runtime(&stored(&observations)).unwrap());
+        let workload = gazette(&report);
+        assert_eq!(workload.flagging_verdict, FlaggingVerdict::NeverClean);
+        assert_eq!(workload.flagging.recommended_k, None);
+        assert!(
+            workload
+                .flagging
+                .sweep
+                .iter()
+                .all(|point| point.comparisons == 0 || point.false_flags > 0)
+        );
+        assert!(render_runtime(&[report]).contains("noisier than this workload can absorb"));
+    }
+
+    #[test]
+    fn run_to_run_dispersion_is_reported_beside_the_within_observation_figure() {
+        // The two are different quantities and the difference is the whole
+        // reason a sample count is not always the remedy.
+        let observations: Vec<Observation> = repeated(14)
+            .into_iter()
+            .enumerate()
+            .map(|(index, observation)| Observation {
+                // Tight inside a run, loose between runs.
+                samples: vec![
+                    1_000 + index as u64 * 20,
+                    1_001 + index as u64 * 20,
+                    999 + index as u64 * 20,
+                    1_000 + index as u64 * 20,
+                    1_000 + index as u64 * 20,
+                ],
+                ..observation
+            })
+            .collect();
+        let report = only(calibrate_runtime(&stored(&observations)).unwrap());
+        let workload = gazette(&report);
+        let between = workload
+            .run_to_run_relative_mad
+            .expect("a between-run figure");
+        assert!(
+            between > workload.within_observation_relative_mad,
+            "{between} vs {}",
+            workload.within_observation_relative_mad
+        );
+        assert!(workload.run_to_run_dominates);
+        assert_eq!(workload.run_to_run_observations, 14);
+    }
+
+    #[test]
+    fn a_run_to_run_figure_is_never_itself_a_three_point_estimate() {
+        // The same objection this file raises against a three-SAMPLE MAD
+        // applies to a three-OBSERVATION one, and the first implementation
+        // admitted the latter: a segment of three published a run-to-run figure
+        // indistinguishable in the table from one computed over sixteen, and
+        // `run_to_run_dominates` was then decided from it.
+        let mut observations = repeated(6);
+        for (index, observation) in observations.iter_mut().enumerate() {
+            // Two segments of three, so nothing reaches the floor.
+            observation.fixture = if index < 3 { 'f' } else { 'g' };
+        }
+        let report = only(calibrate_runtime(&stored(&observations)).unwrap());
+        let workload = gazette(&report);
+        assert_eq!(workload.segments, 2);
+        assert_eq!(workload.longest_segment, 3);
+        assert_eq!(workload.run_to_run_relative_mad, None);
+        assert_eq!(workload.run_to_run_observations, 0);
+        assert!(!workload.run_to_run_dominates);
+    }
+
+    #[test]
+    fn a_heterogeneous_pools_dispersion_is_decomposed_rather_than_reported_as_one_number() {
+        // The real x86_64-linux shape, and the reason a single figure misleads
+        // twice over: pooled it reads far noisier than any one machine, while
+        // the excursion that actually moved the series is larger than the
+        // pooled figure by an order of magnitude, because a MAD discards a
+        // minority.
+        let observations: Vec<Observation> = repeated(14)
+            .into_iter()
+            .enumerate()
+            .map(|(index, observation)| {
+                let slow = index % 4 == 3;
+                Observation {
+                    cpu_model: if slow { "SLOW-MODEL" } else { "FAST-MODEL" },
+                    samples: if slow {
+                        vec![2_000, 2_002, 1_998, 2_000, 2_001]
+                    } else {
+                        vec![1_000, 1_002, 998, 1_000, 1_001]
+                    },
+                    ..observation
+                }
+            })
+            .collect();
+        let report = only(calibrate_runtime(&stored(&observations)).unwrap());
+        let workload = gazette(&report);
+
+        // Each machine class is quiet on its own.
+        assert_eq!(workload.by_cpu_model.len(), 2);
+        for environment in &workload.by_cpu_model {
+            assert!(
+                environment.run_to_run_relative_mad.unwrap() < 0.01,
+                "{environment:?}"
+            );
+        }
+        // The excursion the MAD discarded is the one worth knowing about.
+        let excursion = workload.max_relative_excursion.expect("an excursion");
+        assert!(excursion > 0.9, "{excursion}");
+        assert!(excursion > workload.run_to_run_relative_mad.unwrap_or(0.0));
+
+        let rendered = render_runtime(&[report]);
+        assert!(rendered.contains("MIXTURE"));
+        assert!(rendered.contains("SLOW-MODEL"));
+        assert!(rendered.contains("max excursion"));
+    }
+
+    #[test]
+    fn a_homogeneous_pool_gets_no_decomposition_table() {
+        // A one-row table would imply a comparison there is nothing to make.
+        let report = only(calibrate_runtime(&stored(&repeated(14))).unwrap());
+        assert!(gazette(&report).by_cpu_model.is_empty());
+        assert!(!render_runtime(&[report]).contains("MIXTURE"));
+    }
+
+    #[test]
+    fn a_wrong_answer_is_excluded_from_the_dispersion_and_reported() {
+        // Timing a program that produced the wrong output measures a different
+        // program. Excluding it silently would be worse than including it.
+        let mut observations = repeated(14);
+        observations[5].verdict = OracleVerdict::Mismatch;
+        let report = only(calibrate_runtime(&stored(&observations)).unwrap());
+        assert_eq!(gazette(&report).observations, 13);
+        assert_eq!(report.skipped.len(), 1);
+        assert!(
+            report.skipped[0].reason.contains("Mismatch"),
+            "{:?}",
+            report.skipped
+        );
+        // The neighbours close over the gap rather than splitting: the program
+        // and the corpus either side of the excluded point are the same ones,
+        // so the observations that remain are still repeated measurements of
+        // one thing. What must not happen is that the exclusion goes unsaid.
+        assert_eq!(gazette(&report).segments, 1);
+        assert!(render_runtime(&[report]).contains("Excluded observations"));
+    }
+
+    #[test]
+    fn samples_that_disagreed_on_their_output_are_excluded() {
+        let mut observations = repeated(14);
+        observations[3].deterministic = false;
+        let report = only(calibrate_runtime(&stored(&observations)).unwrap());
+        assert_eq!(gazette(&report).observations, 13);
+        assert_eq!(report.skipped.len(), 1);
+        assert!(report.skipped[0].reason.contains("did not agree"));
+    }
+
+    #[test]
+    fn platform_epochs_are_analysed_apart_and_never_pooled() {
+        // An epoch implements exactly one suite revision, so partitioning by
+        // epoch is what stops a sweep pooling across a change in what is
+        // measured. Epochs 1 and 2 are retired and still declared; records
+        // naming them are still in the store.
+        let mut observations = repeated(10);
+        for observation in observations.iter_mut().skip(5) {
+            observation.epoch = 2;
+            observation.suite_revision = 2;
+        }
+        observations.push(Observation {
+            platform: "aarch64-macos",
+            minute: 40,
+            ..Observation::default()
+        });
+
+        let reports = calibrate_runtime(&stored(&observations)).unwrap();
+        assert_eq!(reports.len(), 3);
+        let described: Vec<(String, u32, u32, usize)> = reports
+            .iter()
+            .map(|report| {
+                (
+                    report.platform.clone(),
+                    report.epoch,
+                    report.suite_revision,
+                    report.reports,
+                )
+            })
+            .collect();
+        assert_eq!(
+            described,
+            vec![
+                ("aarch64-macos".to_string(), 3, 3, 1),
+                ("x86_64-linux".to_string(), 2, 2, 5),
+                ("x86_64-linux".to_string(), 3, 3, 5),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_heterogeneous_runner_pool_is_named_rather_than_absorbed() {
+        // The real x86_64-linux store hands out four CPU models and the wall
+        // times track them. A maintainer reading a large multiplier has to be
+        // able to tell the pool from the workload.
+        let observations: Vec<Observation> = repeated(14)
+            .into_iter()
+            .enumerate()
+            .map(|(index, observation)| Observation {
+                cpu_model: if index % 2 == 0 {
+                    "AMD EPYC 7763"
+                } else {
+                    "INTEL(R) XEON(R) PLATINUM 8573C"
+                },
+                ..observation
+            })
+            .collect();
+        let report = only(calibrate_runtime(&stored(&observations)).unwrap());
+        assert_eq!(report.cpu_models.len(), 2);
+        assert!(report.distinct_environments > 1);
+        let rendered = render_runtime(&[report]);
+        assert!(rendered.contains("different CPU models"));
+        assert!(rendered.contains("8573C"));
+    }
+
+    #[test]
+    fn environment_drift_is_surfaced_even_where_the_cpu_model_is_unknown() {
+        // Every aarch64-linux record in the real store reports `cpu_model:
+        // "unknown"`, so the CPU-model warning can never fire there — while
+        // three and four distinct fingerprints went past unremarked. The
+        // fingerprint covers the runner image, kernel, and OS version too, and
+        // on that platform it is the only evidence of a moving pool there is.
+        let observations: Vec<Observation> = repeated(14)
+            .into_iter()
+            .enumerate()
+            .map(|(index, observation)| Observation {
+                cpu_model: "unknown",
+                runner_image_version: if index % 2 == 0 { "1" } else { "2" },
+                ..observation
+            })
+            .collect();
+        let report = only(calibrate_runtime(&stored(&observations)).unwrap());
+        assert_eq!(report.cpu_models, vec!["unknown".to_string()]);
+        assert_eq!(report.distinct_environments, 2);
+        let rendered = render_runtime(&[report]);
+        assert!(rendered.contains("hosted environment changed underneath"));
+        assert!(!rendered.contains("different CPU models"));
+    }
+
+    #[test]
+    fn the_report_says_it_does_not_decide_the_policy() {
+        // ADR-0072's open question 4 is a maintainer's, and a tool that reads
+        // as though it had answered it would be answering it.
+        let rendered = render_runtime(&calibrate_runtime(&stored(&repeated(14))).unwrap());
+        assert!(rendered.contains("THIS RECOMMENDS; IT DOES NOT DECIDE"));
+        assert!(rendered.contains("advisory"));
+        assert!(rendered.contains("x86_64-linux epoch 3 (suite revision 3)"));
+    }
+
+    #[test]
+    fn an_empty_directory_is_refused_rather_than_reported_as_quiet() {
+        assert!(calibrate_runtime(&[]).is_err());
+    }
+
+    #[test]
+    fn reports_are_analysed_in_chronological_order_not_filesystem_order() {
+        // The trailing window is a window in time, and a content-addressed
+        // store lists its records in digest order.
+        let directory = tempfile::tempdir().unwrap();
+        for index in [2u32, 0, 1] {
+            let observation = Observation {
+                minute: index,
+                commit: char::from(b'a' + index as u8),
+                ..Observation::default()
+            };
+            std::fs::write(
+                directory.path().join(format!("{index}.json")),
+                rue_perf_schema::canonical_json(&report(&observation)).unwrap(),
+            )
+            .unwrap();
+        }
+        let loaded = load_runtime_reports(directory.path()).unwrap();
+        let analysed = only(calibrate_runtime(&loaded).unwrap());
+        assert_eq!(analysed.reports, 3);
+        assert_eq!(gazette(&analysed).segments, 1);
+    }
+
+    #[test]
+    fn a_record_this_build_cannot_read_is_an_error_rather_than_a_thinner_answer() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(directory.path().join("broken.json"), "{}").unwrap();
+        let error = load_runtime_reports(directory.path()).unwrap_err();
+        assert!(
+            error.to_string().contains("not a runtime report"),
+            "{error}"
         );
     }
 }

--- a/crates/rue-bench/src/main.rs
+++ b/crates/rue-bench/src/main.rs
@@ -101,6 +101,14 @@ Subcommands:
                        batching factors, and the flagging rule. Produces
                        artifacts only; nothing here enters a series.
 
+  calibrate --runtime-reports <dir> [--report <path>]
+                       the same analysis for the ADR-0072 runtime suite, over
+                       stored runtime reports: per workload and per platform
+                       epoch, the dispersion of an unchanged program over an
+                       unchanged corpus, and a flagging recommendation. Reads
+                       a workflow's freshly written reports or a checkout of
+                       performance-data-v1/runtime. Artifacts only.
+
   scaling --manifest <path> --compiler <path> --commit <sha> --out <path>
                        measure maintained programs with independent fresh
                        compiler processes; also writes a Markdown report.
@@ -206,6 +214,7 @@ fn main() -> ExitCode {
 /// and a recommendation for a maintainer, not a measurement.
 fn run_calibration() -> Result<(), String> {
     let mut runs_dir = None;
+    let mut runtime_dir = None;
     let mut report_path = None;
     let mut args = std::env::args().skip(2);
     while let Some(flag) = args.next() {
@@ -215,22 +224,56 @@ fn run_calibration() -> Result<(), String> {
         };
         match flag.as_str() {
             "--runs" => runs_dir = Some(PathBuf::from(value()?)),
+            "--runtime-reports" => runtime_dir = Some(PathBuf::from(value()?)),
             "--report" => report_path = Some(PathBuf::from(value()?)),
             other => return Err(format!("unrecognized argument {other:?}")),
         }
     }
-    let runs_dir = runs_dir.ok_or("calibrate requires --runs <directory>")?;
 
-    let runs = calibrate::load_runs(&runs_dir).map_err(|error| error.to_string())?;
-    let report = calibrate::calibrate(&runs).map_err(|error| error.to_string())?;
-    let rendered = calibrate::render(&report);
+    // One record kind per invocation. The two analyses answer the same
+    // questions about different measurements, and a single report holding both
+    // would invite reading one suite's dispersion as the other's — which is
+    // exactly the transfer ADR-0072 Decision 5 forbids.
+    let (rendered, encoded) = match (runs_dir, runtime_dir) {
+        (Some(_), Some(_)) => {
+            return Err(
+                "calibrate takes --runs or --runtime-reports, not both: they are different \
+                 record kinds and their dispersions do not transfer"
+                    .to_string(),
+            );
+        }
+        (Some(runs_dir), None) => {
+            let runs = calibrate::load_runs(&runs_dir).map_err(|error| error.to_string())?;
+            let report = calibrate::calibrate(&runs).map_err(|error| error.to_string())?;
+            (
+                calibrate::render(&report),
+                serde_json::to_string_pretty(&report),
+            )
+        }
+        (None, Some(runtime_dir)) => {
+            let reports =
+                calibrate::load_runtime_reports(&runtime_dir).map_err(|error| error.to_string())?;
+            let analyses =
+                calibrate::calibrate_runtime(&reports).map_err(|error| error.to_string())?;
+            (
+                calibrate::render_runtime(&analyses),
+                serde_json::to_string_pretty(&analyses),
+            )
+        }
+        (None, None) => {
+            return Err(
+                "calibrate requires --runs <directory> or --runtime-reports <directory>"
+                    .to_string(),
+            );
+        }
+    };
 
     if let Some(path) = report_path {
         std::fs::write(&path, &rendered)
             .map_err(|error| format!("could not write {}: {error}", path.display()))?;
         let json = path.with_extension("json");
-        let encoded = serde_json::to_string_pretty(&report)
-            .map_err(|error| format!("could not serialize the report: {error}"))?;
+        let encoded =
+            encoded.map_err(|error| format!("could not serialize the report: {error}"))?;
         std::fs::write(&json, encoded)
             .map_err(|error| format!("could not write {}: {error}", json.display()))?;
         eprintln!("rue-bench: wrote {} and {}", path.display(), json.display());

--- a/performance/runtime.toml
+++ b/performance/runtime.toml
@@ -24,6 +24,15 @@
 # `ubuntu-24.04-arm`, both collected on every trunk push, and `aarch64-macos` on
 # `macos-15`, collected daily because its runner is the expensive one. No
 # platform inherits another's calibration, so a row arrives advisory and says so.
+#
+# The route out of advisory is `rue-bench calibrate --runtime-reports <dir>`
+# (RUE-1497), over this store's records or over the repeated reports the
+# `calibrate-runtime` lane of `.github/workflows/performance-calibration.yml`
+# produces. It reports each workload's dispersion on each platform and sweeps
+# `(k, window)` for the smallest pairing that flags nothing while nothing is
+# changing. What it emits is a recommendation to review; declaring an
+# `[epoch.calibration]` table below remains a maintainer's edit, because
+# ADR-0072's open question 4 is a maintainer's question.
 schema_version = 1
 
 [[suite]]


### PR DESCRIPTION
Closes RUE-1497.

ADR-0072 Decision 5 says calibration never transfers from the compiler suites,
so each runtime workload is calibrated per platform from its own repeated
samples and flags stay advisory until that calibration exists. Nothing could
produce it: `performance-calibration.yml` read `manifest.toml` only, and
`rue-bench calibrate` loaded compile-time `RunObject`s and could not read a
runtime report. Three platform rows were accumulating evidence with nothing
able to read it.

`rue-bench calibrate --runtime-reports <dir>` now reads stored runtime reports
and emits per-workload, per-platform dispersion and a flagging sweep, and the
calibration workflow gains a `calibrate-runtime` lane.

**It recommends; it does not decide.** Open Question 4 stays open: no
`[epoch.calibration]` or `[epoch.flagging]` table is written anywhere, the
workflow pins no `k` or `window`, and `performance/runtime.toml` gains nine
lines of header comment naming the route out of advisory and leaving the
declaration to a reviewed maintainer edit.

## Segmentation

On the **workload identity**, plus the workload source digest and the compiled
program's digest — not the comparison identity. `derive` segments Rue's series
on the fixture identity and `workload_source_hashes`, clearing the trailing
window when either moves; the comparison identity is read only by the peer
join. A sweep keyed on it would discard Rue's own repeated samples every time
a peer version moved, yielding a thinner and more optimistic estimate from
fewer points. A test moves the comparison identity four times across fourteen
observations and asserts one segment.

The compile-time calibrator refuses runs at differing commits; this path keys
on `program.sha256` instead. The product here is the emitted executable, and an
equal program digest over an equal fixture digest is a byte-identical binary
over byte-identical input. It is also the only rule that finds any evidence:
the store holds 24 distinct commits and no platform sees one twice, so an
equal-commit rule would produce segments of length one.

## What it refuses to claim

Confidence is split, because the sample count bites exactly one of the two
figures:

- **within-observation** needs ≥5 samples and ≥8 observations. A MAD includes
  the median's own zero deviation, so at 3 samples it is the smaller of the two
  that remain and is biased low — the direction that makes a bound too tight
  and a flag too eager.
- **flagging** needs ≥8 observations and nothing about the sample count. The
  sweep summarizes each observation exactly as `derive` does, from the same
  declared samples, so any bias the count carries is carried identically by the
  rule being calibrated and the rule as applied.

That split matters for `gazette_10x`, which declares `samples = 3` on every
hosted epoch by deliberate cost policy. Its within-observation dispersion
cannot be estimated by this method at any number of repetitions, and the report
says so in those words; its flagging rule is calibrated normally. Raising that
sample count is a Decision 9 runner-cost decision, not a calibration one, so
the manifest is untouched.

Recommended sample counts never fall below what the method itself needs, and
are labelled a floor rather than a target.

## Dispersion is reported as the mixture it is

A single run-to-run figure would be dishonest on a pooled runner. On
`x86_64-linux` epoch 1 the pooled figure is 3.59%, while per CPU model it is
0.44% and 0.67% — so pooling overstates same-machine noise several times over,
and a MAD simultaneously discards the excursion that matters: the fastest
observation sits 32.4% below the segment median.

So the report carries a `max excursion` column beside the MAD, decomposes by
CPU model where the pool handed out more than one, and warns on environment
drift independently of CPU model (every aarch64 record carries `cpu_model:
"unknown"`, so a model-only check would never fire there).

This is presentation, not a second segmentation. Production `derive` segments
on fixture and source alone, so a real trailing window spans machines too;
splitting the sweep on environment would recommend a `k` that could not survive
collection.

Overlapping trailing windows are not independent trials — successive
comparisons at window W share W−1 observations — so every sweep table carries
an `~independent` column and the rule-of-three floor says which number it is
applying.

## Against the real store

45 runtime records across 6 platform epochs. Both Linux epoch-1 rows land on
`TooFewComparisons` rather than a recommendation: the only clean pairings rest
on 3–6 comparisons, roughly 1–2 independent. That is the honest answer, and it
is why the lane defaults to 20 repetitions — a deliberate floor, not a
sufficiency claim, since ten independent trials at window 10 would need ~100.

No `aarch64-macos` records exist yet, so the daily schedule has so far produced
nothing to read.

## The lane cannot write to a series

`permissions: contents: read` at workflow level with no job re-declaring it;
the only `contents: write` is `performance-collect.yml`'s publish job, which
sources artifacts from its own run with no `run-id`. `calibrate` writes
nothing; the runtime run writes only `--out`, the peer-state directory, and its
work directory, all inside the workspace.

## Verification

`scripts/rue unit bench` 150 passed · `scripts/rue unit perf-schema` 220 passed
· `scripts/rue quick` 31 targets · clippy and fmt-check clean · actionlint
clean across all workflows · run end to end against the real store.
