### PR TITLE
RUE-1496: teach gazette to slugify content paths into routes

### DIFF
--- a/crates/rue-cli-tests/cases/examples_gazette.toml
+++ b/crates/rue-cli-tests/cases/examples_gazette.toml
@@ -288,6 +288,130 @@ asset.txt
 gazette: 4 pages, 3 sections, 9 files written
 """
 
+# RUE-1496. A content path becomes a route through the slug rule ADR-0072
+# Decision 3 documents, and these three cases are its hermetic statement: the
+# corpus checks in `scripts/gazette-corpus-diff.py` need the pinned Zola and the
+# live site, and the live site could rename its three upper-case files without
+# anyone noticing the capability had gone unexercised.
+[[case]]
+name = "gazette_slugifies_a_file_stem_into_a_link_target"
+description = "an `@/…` link to an upper-case content path resolves to the route the page is served at"
+source_path = "examples/gazette/main.rue"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+# The corpus's own case, by name: nothing in the live content links to these
+# three, but a link and the page's own route come from one function, so a link
+# is the cheapest way to assert what that function does with a fragment and a
+# section beside a page.
+files = [
+  { path = "page.md", source = """+++
+title = "Links"
++++
+
+[grammar](@/spec/appendices/A-grammar.md), [limits](@/spec/appendices/C-implementation-limits.md#rules), [all](@/spec/appendices/_index.md)
+""" },
+]
+program_args = ["render", "page.md"]
+exit_code = 0
+# The directories keep their case and the file stem loses it, which is Zola's
+# own asymmetry rather than a simplification of it; a section's route is its
+# directories, so nothing in it is slugified at all.
+stdout = """<p><a href="https://rue-lang.dev/spec/appendices/a-grammar/">grammar</a>, <a href="https://rue-lang.dev/spec/appendices/c-implementation-limits/#rules">limits</a>, <a href="https://rue-lang.dev/spec/appendices/">all</a></p>
+"""
+
+[[case]]
+name = "gazette_routes_an_upper_case_page_to_its_slug"
+description = "an upper-case file stem is emitted at its slugified route, and the section around it is not slugified"
+source_path = "examples/gazette/main.rue"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+  { path = "site/config.toml", source = """base_url = "https://example.test"
+title = "Site"
+""" },
+  { path = "site/templates/page.html", source = """{{ page.content | safe }}""" },
+  { path = "site/templates/section.html", source = """{{ section.content | safe }}""" },
+  { path = "site/content/_index.md", source = """+++
+title = "Home"
++++
+
+home
+""" },
+  { path = "site/content/appendices/_index.md", source = """+++
+title = "Appendices"
++++
+
+appendices
+""" },
+  { path = "site/content/appendices/A-Grammar.md", source = """+++
+title = "Grammar"
++++
+
+grammar
+""" },
+]
+program_args = ["build", "site", "-o", "public", "--list"]
+exit_code = 0
+stdout = """appendices/a-grammar/index.html
+index.html
+appendices/index.html
+gazette: 1 pages, 2 sections, 3 files written
+"""
+
+[[case]]
+name = "gazette_refuses_a_content_path_outside_the_slug_subset"
+description = "a path the documented slug subset does not cover fails the build instead of routing by guess, in a directory component as well as a file stem"
+source_path = "examples/gazette/main.rue"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+# THE WHOLE ROUTE IS CONSTRAINED, not only the stem that folds, and both halves
+# are pinned here because ADR-0072 Decision 3's enumeration is load-bearing: a
+# reader has to be able to tell that `Docs/page.md` fails.
+#
+# Each of these is a path the two pinned peers route differently. Zola's `slug`
+# crate folds `my_page` to `my-page` while Hugo keeps the underscore; Zola
+# copies `Docs` verbatim while Hugo lower-cases it. No rule gazette could
+# implement matches both, so the subset stops where they agree and the build
+# stops here — which is also why the section's own route is named separately
+# from its page's: `Docs/` is refused as a section route, where nothing folds
+# at all.
+files = [
+  { path = "site/config.toml", source = """base_url = "https://example.test"
+title = "Site"
+""" },
+  { path = "site/templates/page.html", source = """{{ page.content | safe }}""" },
+  { path = "site/templates/section.html", source = """{{ section.content | safe }}""" },
+  { path = "site/content/_index.md", source = """+++
+title = "Home"
++++
+
+home
+""" },
+  { path = "site/content/my_page.md", source = """+++
+title = "Mine"
++++
+
+mine
+""" },
+  { path = "site/content/Docs/_index.md", source = """+++
+title = "Docs"
++++
+
+docs
+""" },
+  { path = "site/content/Docs/page.md", source = """+++
+title = "Page"
++++
+
+page
+""" },
+]
+program_args = ["build", "site", "-o", "public"]
+exit_code = 1
+stdout_contains = [
+  "content path is outside the slug subset",
+  "(my_page)",
+  "(Docs/page)",
+  "(Docs/)",
+]
+
 [[case]]
 name = "gazette_refuses_a_content_directory_without_an_index"
 description = "a directory with no `_index.md` is a diagnostic, never an implicit section"

--- a/crates/rue-perf-schema/src/runtime.rs
+++ b/crates/rue-perf-schema/src/runtime.rs
@@ -3054,7 +3054,7 @@ samples = 5
         let epoch = manifest
             .collection_epoch("aarch64-linux")
             .expect("aarch64-linux is a row of the v1 platform matrix");
-        assert_eq!(epoch.suite_revision, 3);
+        assert_eq!(epoch.suite_revision, 4);
         assert_eq!(epoch.target, "aarch64-linux");
         assert_eq!(epoch.optimization, OptimizationLevel::O3);
         assert_eq!(epoch.thread_policy, ThreadPolicy::SingleThreaded);
@@ -3082,7 +3082,7 @@ samples = 5
         let epoch = manifest
             .collection_epoch("aarch64-macos")
             .expect("aarch64-macos is the scheduled row of the v1 platform matrix");
-        assert_eq!(epoch.suite_revision, 3);
+        assert_eq!(epoch.suite_revision, 4);
         assert_eq!(epoch.target, "aarch64-macos");
         assert_eq!(epoch.optimization, OptimizationLevel::O3);
         assert_eq!(epoch.thread_policy, ThreadPolicy::SingleThreaded);
@@ -4811,16 +4811,19 @@ records_comparison_identity = true
         // THE APPEND-ONLY EVIDENCE, against the manifest the repository ships
         // rather than a fixture written to agree with it. RUE-1485 proved this
         // shape by deriving an epoch-1 record beside two epoch-2 records with
-        // none rejected; RUE-1493 changes what an observation RECORDS, so the
-        // same proof is owed again.
+        // none rejected; RUE-1493 changed what an observation RECORDS and
+        // RUE-1496 changed the assembly rule an observation is taken under, so
+        // the same proof is owed each time.
         //
-        // Epoch 2's records carry preparer revision 1 and no comparison
-        // identity, because neither existed when they were written. Epoch 3's
-        // carry revision 2 and the identity, because its peer policy pins it.
-        // Both must be appendable, and both must publish, or this change would
-        // have invalidated evidence nobody can rewrite.
+        // Each row carries the preparer revision its epoch was collected under:
+        // epoch 2's records carry revision 1 and no comparison identity,
+        // because neither existed when they were written; epoch 3's carry
+        // revision 2 and the identity its peer policy pins; epoch 4's carry
+        // revision 3, the corpus no longer lower-cased. All must be appendable,
+        // and all must publish, or one of these changes would have invalidated
+        // evidence nobody can rewrite.
         let manifest = RuntimeManifest::parse(CHECKED_IN_MANIFEST).expect("checked-in manifest");
-        for (epoch, suite_revision, preparer_revision) in [(2, 2, 1), (3, 3, 2)] {
+        for (epoch, suite_revision, preparer_revision) in [(2, 2, 1), (3, 3, 2), (4, 4, 3)] {
             let report = shipped_report(epoch, suite_revision, preparer_revision);
             let outcome = validate_runtime_report(&manifest, &report);
             assert_eq!(
@@ -4840,11 +4843,12 @@ records_comparison_identity = true
 
     #[test]
     fn the_new_epoch_refuses_a_record_written_without_the_comparison_identity() {
-        // The other half of the same rule: epoch 3 pins the identity, so a
-        // runner that skipped it is refused HERE rather than at the point
-        // someone reads a joined row and cannot say which peer pins it names.
+        // The other half of the same rule: the collecting epoch pins the
+        // identity, so a runner that skipped it is refused HERE rather than at
+        // the point someone reads a joined row and cannot say which peer pins
+        // it names.
         let manifest = RuntimeManifest::parse(CHECKED_IN_MANIFEST).expect("checked-in manifest");
-        let mut report = shipped_report(3, 3, 2);
+        let mut report = shipped_report(4, 4, 3);
         for observation in &mut report.workloads {
             observation.comparison = None;
         }

--- a/docs/designs/0072-runtime-benchmarking-static-site-generator.md
+++ b/docs/designs/0072-runtime-benchmarking-static-site-generator.md
@@ -9,7 +9,7 @@ accepted: 2026-08-13
 implemented:
 spec-sections: []
 superseded-by:
-relates: ["RUE-487", "RUE-945", "RUE-1045", "RUE-1046", "RUE-1047", "RUE-1049", "RUE-1481", "RUE-1482", "RUE-1483", "RUE-1484", "RUE-1485", "RUE-1488", "RUE-1493", "RUE-1495", "ADR-0006", "ADR-0057", "ADR-0067", "ADR-0068", "ADR-0070", "ADR-0071"]
+relates: ["RUE-487", "RUE-945", "RUE-1045", "RUE-1046", "RUE-1047", "RUE-1049", "RUE-1481", "RUE-1482", "RUE-1483", "RUE-1484", "RUE-1485", "RUE-1488", "RUE-1493", "RUE-1495", "RUE-1496", "ADR-0006", "ADR-0057", "ADR-0067", "ADR-0068", "ADR-0070", "ADR-0071"]
 ---
 
 # ADR-0072: Runtime performance benchmarking anchored by a Rue static site generator
@@ -396,6 +396,52 @@ Zola and Hugo serve a redirect. The stub's markup mirrors the pinned Zola's
 own rather than being invented: a redirect stub is not a page anyone reads,
 and the only thing that matters about it is that all three tools put the same
 file at the same route pointing at the same target.
+
+**Content paths are slugified into routes**, and the subset of that is
+documented here for the same reason the Markdown constructs above are: gazette
+rejects a path outside it rather than routing it by guess, so a reader must be
+able to tell from this list which content paths build. The rule constrains the
+**whole route**, not only the part that folds:
+
+- every **directory component** must already be ASCII lower-case letters,
+  digits, or `-`, and is emitted verbatim;
+- a page's **file stem** may also carry upper-case ASCII, which folds to lower
+  case; a section's route is its directories, so nothing folds there;
+- anything else, anywhere in the route, fails the build.
+
+So `spec/appendices/A-grammar.md` is served at `/spec/appendices/a-grammar/`,
+which is what the live site serves, while `Docs/page.md` and `notes/my_page.md`
+are refused rather than routed.
+
+The subset is drawn there because **it is exactly where the two pinned peers
+agree**, measured against both binaries:
+
+| content path | Zola 0.21.0 | Hugo 0.152.2 | |
+| --- | --- | --- | --- |
+| `plain/A-Grammar.md` | `/plain/a-grammar/` | `/plain/a-grammar/` | agree |
+| `plain/Under_Score.md` | `/plain/under-score/` | `/plain/under_score/` | differ |
+| `plain/Dots.v2.md` | `/plain/dots-v2/` | `/plain/dots.v2/` | differ |
+| `UPPER/lower.md` | `/UPPER/lower/` | `/upper/lower/` | differ |
+| `Mixed/Sub/_index.md` | `/Mixed/Sub/` | `/mixed/sub/` | differ |
+| `Dir_Under/p.md` | `/Dir_Under/p/` | `/dir_under/p/` | differ |
+
+Zola slugifies the file stem with the `slug` crate — folding case, but also
+transliterating non-ASCII, turning every other byte into `-`, collapsing runs
+and trimming — and copies directories exactly as authored. Hugo lower-cases the
+whole path, directories included, and touches nothing else. The two agree on one
+thing: an ASCII letter's case in a file stem. On every other input no rule
+gazette could implement would match both, so Decision 4's file-set equality
+could not hold whichever side gazette picked — which makes refusing the only
+answer that does not pick one silently, rather than caution about unimplemented
+work. Widening this subset means a peer changed, or the parity configurations
+gained a setting that makes them agree somewhere new.
+
+The corpus is comfortably inside it: its 96 file stems are lower-case but for
+three specification appendices (`A-grammar.md`, `B-undefined-behavior.md`,
+`C-implementation-limits.md`), which need case folding and nothing more.
+RUE-1485 handled those three by lower-casing the corpus for all three tools
+instead; RUE-1496 replaced that with the rule above, which is why the emitted
+file sets agree without the input being rewritten.
 
 Fairness constrains gazette's implementation, not only the peers'
 configuration. The corpus is extremely skewed — 1,224 of its 1,225 shortcode
@@ -813,27 +859,38 @@ Phase 5 landed the comparison, and four things it found are worth recording
 because each changes what a later reader should expect.
 
 - **The corpus, not the configurations, is where equivalence is won — and one
-  of those normalizations hides a Rue gap.** Two differences were fixed by
-  normalizing the corpus for all three tools at fixture-preparation time rather
-  than by configuring one of them. `paginate_by` is the one excluded feature the
-  content turns on, and Zola honours it by emitting a paginated view no other
-  tool builds. Three upper-case file names route differently, and here **gazette
-  is the odd tool out**: Zola slugifies a content path into its route and Hugo
-  lower-cases it into its page identity, so both agree with the production site,
-  while gazette does not slugify at all. Lower-casing the three names buys an
-  exact file-set check instead of an allowlist entry that a tool dropping a page
-  could later hide behind, at the cost of suppressing a genuine two-against-one
-  difference in which Rue is the outlier. The work either way is one pass over
-  96 paths and cannot move a measurement; teaching gazette to slugify would
-  close it properly. Both normalizations, and the two excluded pages, are
-  disclosed on the published page rather than only here.
+  of those normalizations hid a Rue gap until RUE-1496 closed it.** Two
+  differences were fixed by normalizing the corpus for all three tools at
+  fixture-preparation time rather than by configuring one of them. `paginate_by`
+  is the one excluded feature the content turns on, and Zola honours it by
+  emitting a paginated view no other tool builds; it is still stripped, and for
+  that reason.
 
-  Neither normalization is visible in the content digest, since that digest is
-  taken over the tree the rules have already rewritten. The preparer's own
-  revision and digest are therefore inside the recorded fixture identity, so a
-  change to an assembly rule opens a new comparable segment exactly as a content
-  change does — without that, Decision 2's segmentation mechanism would not fire
-  for the rules that decide what every tool consumes.
+  The second was three upper-case file names, and there **gazette was the odd
+  tool out**: Zola slugifies a content path's file stem into its route and Hugo
+  lower-cases it into its page identity, so both agreed with the production
+  site, while gazette did not slugify at all. Lower-casing the three names
+  bought an exact file-set check instead of an allowlist entry that a tool
+  dropping a page could later hide behind — but it bought it by rewriting the
+  input until the check was exact, which suppressed a genuine two-against-one
+  difference in which Rue was the outlier, and which no amount of validation
+  over the rewritten tree could then see. It also applied to *any* upper-case
+  name, so future content would have inherited the same suppression silently.
+
+  Gazette slugifies now (Decision 3), the rule is gone, and the three tools
+  agree on those three routes with the corpus as it stands. That moved the
+  preparer to revision 3 and the suite to revision 4, which is the right
+  outcome rather than a cost: a change to what every tool consumes should open a
+  new comparable segment. The remaining normalization and the two excluded pages
+  are disclosed on the published page rather than only here.
+
+  Neither normalization was ever visible in the content digest, since that
+  digest is taken over the tree the rules have already rewritten. The preparer's
+  own revision and digest are therefore inside the recorded fixture identity, so
+  a change to an assembly rule opens a new comparable segment exactly as a
+  content change does — without that, Decision 2's segmentation mechanism would
+  not have fired for the rules that decide what every tool consumes, and would
+  not have fired for their removal either.
 - **The allowlist has one entry, and the rest were configured away.** Zola
   always writes a `404.html` and offers no switch; Hugo emits one only with a
   layout, and the port has none. Everything else the ADR anticipated — Hugo's
@@ -1038,7 +1095,8 @@ by this ADR and stays in the project as future scope.
 - Linear: Runtime performance benchmarking project — RUE-1045 (this ADR),
   RUE-1046, RUE-1047, RUE-1048, RUE-1049, RUE-1481, RUE-1482, RUE-1483,
   RUE-1484, RUE-1485, RUE-1488 (the platform matrix), RUE-1493 (Decision 2's
-  identity split, and the peer-evidence rules that gate publication).
+  identity split, and the peer-evidence rules that gate publication), RUE-1496
+  (content-path slugification, and the corpus normalization it retired).
 - Linear: RUE-945 — the `@syscall` carry-flag normalization on
   `aarch64-macos` that the deferred macOS row was waiting for.
 - Prior art: the Computer Language Benchmarks Game (comparison layout,

--- a/examples/gazette/site.rue
+++ b/examples/gazette/site.rue
@@ -413,7 +413,9 @@ fn load_templates(inout site: Site, inout eng: ast.Engine) -> bool {
 // Read every `.md` file under `content/`, parse its front matter, and record
 // the route it takes. `content_route` is the same function the Markdown link
 // renderer uses to resolve a `@/…` destination, so a link to a page and the
-// page's own route cannot disagree.
+// page's own route cannot disagree — including about the slugification it
+// applies to a file stem, which is why the route is not computed from the file
+// name here.
 fn discover(inout site: Site, inout eng: ast.Engine) -> bool {
     let entries = match std.fs.walk(borrow site.content_root) {
         DirRes.Ok(list) => list,
@@ -452,7 +454,7 @@ fn discover(inout site: Site, inout eng: ast.Engine) -> bool {
 
 fn add_page(inout site: Site, inout eng: ast.Engine, borrow rel: StrBuf, borrow source: StrBuf) -> bool {
     let front = frontmatter.parse(inout eng.arena, borrow source);
-    let route = tmpl_eval.content_route(borrow rel, 0);
+    let route = tmpl_eval.content_route(inout eng, borrow rel, 0);
     let permalink = tmpl_eval.join_base(inout eng, borrow route);
 
     let rel_id = eng.arena.strings.intern(borrow rel);

--- a/examples/gazette/tmpl_eval.rue
+++ b/examples/gazette/tmpl_eval.rue
@@ -197,7 +197,7 @@ pub fn join_base(inout eng: ast.Engine, borrow path: StrBuf) -> StrBuf {
     let mut out = text.slice(borrow base, 0, base_end);
 
     let rest = if path.starts_with(borrow "@/") {
-        content_route(borrow path, 2)
+        content_route(inout eng, borrow path, 2)
     } else {
         text.slice(borrow path, 0, path.len())
     };
@@ -251,8 +251,11 @@ fn has_scheme(borrow raw: StrBuf) -> bool {
 
 // `@/spec/03-types/_index.md#anchor` -> `spec/03-types/#anchor`, matching
 // Zola's route for a content file: `_index.md` is the section itself, any other
-// `.md` becomes a directory-style route.
-pub fn content_route(borrow raw: StrBuf, from: u64) -> StrBuf {
+// `.md` becomes a directory-style route whose file stem is SLUGIFIED.
+//
+// One function for a page's own route and for a `@/…` link to it, so a link and
+// its target cannot disagree about a name's spelling.
+pub fn content_route(inout eng: ast.Engine, borrow raw: StrBuf, from: u64) -> StrBuf {
     let hash = text.find_byte(borrow raw, 35, from);
     let body = text.slice(borrow raw, from, hash);
     let mut end = hash;
@@ -264,11 +267,101 @@ pub fn content_route(borrow raw: StrBuf, from: u64) -> StrBuf {
     } else if body.ends_with(borrow ".md") {
         end = hash - 3;
         add_slash = true;
+    } else {
+        // A destination naming no content file at all. Left exactly as
+        // authored and deliberately NOT put through the slug rule: that rule
+        // governs how a CONTENT PATH becomes a route, and refusing
+        // `@/assets/paper.pdf` for its `.` would be a wider refusal than the
+        // rule it implements. The corpus has no such destination today, so
+        // this is about not quietly widening the subset rather than about
+        // anything the benchmark builds.
+        return text.slice(borrow raw, from, raw.len());
     }
-    let mut out = text.slice(borrow raw, from, end);
+    let path = text.slice(borrow raw, from, end);
+    // `add_slash` is set exactly for an ordinary page, which is exactly where
+    // the peers agree that a stem folds; a section's route is its directories,
+    // and those are copied as authored.
+    let mut out = slug_route(inout eng, borrow path, add_slash);
     if add_slash { out.push(47); }
     let fragment = text.slice(borrow raw, hash, raw.len());
     out.append_borrowed(borrow fragment);
+    out
+}
+
+// A content path in the spelling it is SERVED at, over the slug subset ADR-0072
+// Decision 3 documents for this corpus. THE WHOLE ROUTE IS CONSTRAINED, not
+// only the part that folds:
+//
+//   * every DIRECTORY component must already be ASCII lower-case letters,
+//     digits, or `-`, and is copied verbatim;
+//   * a page's FILE STEM may also carry upper-case ASCII, which folds to lower
+//     case — and a section's route is its directories, so nothing folds there;
+//   * anything else, anywhere in the route, is a diagnostic.
+//
+// So `spec/appendices/A-grammar.md` routes to `spec/appendices/a-grammar/`,
+// which is what the live site serves, and `Docs/page.md` FAILS THE BUILD rather
+// than routing to `/Docs/page/` or `/docs/page/`.
+//
+// THE SUBSET IS EXACTLY WHERE THE TWO PEERS AGREE, which is why it is this
+// narrow and why it is drawn here rather than at Zola's own rule. Measured
+// against both pinned binaries:
+//
+//     content path           zola 0.21.0          hugo 0.152.2
+//     plain/A-Grammar.md     /plain/a-grammar/    /plain/a-grammar/    agree
+//     plain/Under_Score.md   /plain/under-score/  /plain/under_score/  differ
+//     plain/Dots.v2.md       /plain/dots-v2/      /plain/dots.v2/      differ
+//     UPPER/lower.md         /UPPER/lower/        /upper/lower/        differ
+//     Mixed/Sub/_index.md    /Mixed/Sub/          /mixed/sub/          differ
+//     Dir_Under/p.md         /Dir_Under/p/        /dir_under/p/        differ
+//
+// Zola slugifies the file stem with the `slug` crate — folding case, but also
+// transliterating non-ASCII, turning every other byte into `-`, collapsing runs
+// and trimming — and copies the directories exactly as authored. Hugo
+// lower-cases the whole path, directories included, and touches nothing else.
+// The two therefore agree on one thing only: an ASCII letter's case in a file
+// stem. On every other input NO RULE GAZETTE COULD IMPLEMENT would match both,
+// so ADR-0072 Decision 4's file-set equality could not hold whichever side
+// gazette picked — and picking one silently is precisely what this corpus's
+// three appendices were being lower-cased to hide.
+//
+// Refusing is therefore not caution about unimplemented work; it is the only
+// answer that does not pick a side. Widening the subset means a peer changed,
+// or the parity configurations gained a `[slugify]` setting that makes them
+// agree somewhere new, and it is a deliberate change here, in `route_of`, and
+// in Decision 3 — the same discipline the Markdown and front-matter libraries
+// apply to a construct they do not document.
+fn slug_route(inout eng: ast.Engine, borrow path: StrBuf, slug_stem: bool) -> StrBuf {
+    // Where the file stem starts. Zero when the path has no directory at all.
+    let mut stem: u64 = 0;
+    let mut i: u64 = 0;
+    while i < path.len() {
+        if text.byte_of(borrow path, i) == 47 { stem = i + 1; }
+        i += 1;
+    }
+    let mut out = StrBuf.new();
+    let mut outside = false;
+    i = 0;
+    while i < path.len() {
+        let b = text.byte_of(borrow path, i);
+        if slug_stem && i >= stem && b >= 65 && b <= 90 {
+            out.push(text.lower_byte(b));
+        } else {
+            // Reported once for the whole path rather than once per byte: the
+            // name is the thing to fix, and a diagnostic per character would
+            // bury it.
+            if !(b == 47 || b == 45 || text.is_digit(b) || (b >= 97 && b <= 122)) {
+                outside = true;
+            }
+            out.push(b);
+        }
+        i += 1;
+    }
+    if outside {
+        let subject = eng.arena.strings.intern(borrow path);
+        eng.error(value.E_ROUTE(), 0,
+            "content path is outside the slug subset (lower-case ASCII letters, digits, and `-`, with case folded in a page's file stem)",
+            subject);
+    }
     out
 }
 

--- a/examples/gazette/value.rue
+++ b/examples/gazette/value.rue
@@ -52,6 +52,11 @@ pub fn E_FRONT_MATTER() -> u64 { 1 }
 pub fn E_MARKDOWN() -> u64 { 2 }
 pub fn E_TEMPLATE() -> u64 { 3 }
 pub fn E_SHORTCODE() -> u64 { 4 }
+// A content path that cannot be turned into a route. Its own code rather than
+// one of the four above because it is neither a document's syntax nor a
+// template's: the file NAME is the input that failed, and the fix is to rename
+// the file or to widen the documented slug subset (RUE-1496).
+pub fn E_ROUTE() -> u64 { 5 }
 
 pub const Values = std.arraybuf.ArrayBuf(Value);
 pub const Entries = std.arraybuf.ArrayBuf(Entry);
@@ -276,5 +281,6 @@ pub fn code_name(code: u64) -> StrBuf {
     else if code == E_MARKDOWN() { "markdown" }
     else if code == E_TEMPLATE() { "template" }
     else if code == E_SHORTCODE() { "shortcode" }
+    else if code == E_ROUTE() { "route" }
     else { "unknown" }
 }

--- a/performance/ports/hugo/hugo.toml
+++ b/performance/ports/hugo/hugo.toml
@@ -58,12 +58,14 @@ description = "A systems programming language with memory safety and high-level 
 github_url = "https://github.com/rue-language/rue"
 bluesky_url = "https://bsky.app/profile/rue-lang.dev"
 
-# Nothing here changes Hugo's routing: the corpus's three upper-case file names
-# are lower-cased during fixture preparation, for every tool at once, because
-# `disablePathToLower` does not survive into the route in this Hugo — the page
-# identity it builds is lower-case regardless. Aligning the corpus rather than
-# one tool is what keeps Decision 4's file-set check exact, and it lands all
-# three tools on the route the production site already serves.
+# Nothing here changes Hugo's routing, and nothing needs to. Hugo lower-cases a
+# content path into its page identity — `disablePathToLower` does not survive
+# into the route in this Hugo — so the corpus's three upper-case file names land
+# on the route the production site already serves without a knob. Zola slugifies
+# the file stem to the same place, and gazette does too as of RUE-1496; until
+# then the corpus was lower-cased during fixture preparation for every tool at
+# once, to spare Decision 4's file-set check an allowlist entry that gazette
+# alone would have needed.
 
 [markup]
   [markup.goldmark.renderer]

--- a/performance/ports/zola/config.toml
+++ b/performance/ports/zola/config.toml
@@ -51,15 +51,15 @@ generate_robots_txt = false
 # Zola's `[slugify]` defaults are deliberately left alone, so this port routes
 # exactly as the production site does.
 #
-# The corpus's three upper-case file names are lower-cased during fixture
-# preparation instead, and the reason is worth stating plainly rather than
-# leaving to a digest: Zola slugifies a content path into its route and Hugo
-# lower-cases it into its page identity, so BOTH PEERS agree with production,
-# and gazette — which does not slugify at all — is the one tool that would emit
-# a different route. The normalization spares the file-set check an allowlist
-# entry, and it suppresses a real difference in which Rue is the outlier. The
-# work is one pass over 96 paths and cannot move a measurement; closing the gap
-# in gazette is a later change.
+# THAT IS NOW THE WHOLE STORY, and it was not until RUE-1496. The corpus's three
+# upper-case file names used to be lower-cased during fixture preparation,
+# because Zola slugifies a content path's file stem into its route and Hugo
+# lower-cases it into its page identity — so both peers agreed with production,
+# and gazette, which did not slugify at all, was the one tool that would emit a
+# different route. Rewriting the input bought the file-set check its exactness
+# and suppressed a real difference in which Rue was the outlier. Gazette
+# slugifies now, so the three tools agree on those routes from the names the
+# repository carries, and this port needs no help to be one of them.
 
 [markdown]
 # The single most important line in this file. Zola renders fenced code through

--- a/performance/runtime.toml
+++ b/performance/runtime.toml
@@ -327,11 +327,116 @@ description = "the same corpus at ten copies, by deterministic path-prefixed dup
 kind = "semantic_site_pages"
 path = "scripts/gazette-corpus-diff.py"
 
+# ===========================================================================
+# SUITE REVISION 4 (RUE-1496) pins preparer revision 3: the corpus is no longer
+# lower-cased.
+#
+# The workloads are revision 3's and the job they measure is the same job. What
+# changed is one ASSEMBLY RULE, which belongs to this suite because the preparer
+# revision is pinned here: `assemble_corpus` used to lower-case every content
+# file name before any tool saw the tree.
+#
+# It did that for three files — `spec/appendices/A-grammar.md` and its two
+# siblings — and for one tool. Zola slugifies a content path's file stem into
+# its route and Hugo lower-cases it into its page identity, so both served what
+# the production site serves, while gazette did not slugify at all. The rule
+# bought ADR-0072 Decision 4's exact file-set check by rewriting the input until
+# the check was exact, and what it cost was a genuine two-against-one difference
+# in which Rue was the outlier.
+#
+# Gazette slugifies now, so the three tools agree on those routes with the
+# corpus as it stands. The tree every tool consumes therefore differs from
+# revision 3's, and the WORKLOAD identity moves with it — which is the right
+# outcome rather than a cost, since a new comparable segment is exactly what a
+# change to what every tool consumes should open. Revision 3's observations are
+# not continuous with revision 4's, for the same reason revision 2's were not
+# continuous with revision 3's.
+#
+# REVISIONS 1, 2, AND 3 STAY DECLARED, and so do the epochs that implement
+# them. Records already in the store name their suite revision and their epoch,
+# and a manifest that forgot either could not validate them.
+# ===========================================================================
+[[suite]]
+revision = 4
+protocol_version = 1
+measured_boundary = "spawn_to_exit_v1"
+
+# Unchanged from revision 3, and untouched by the assembly-rule change: this
+# workload's fixture is a seeded generator, not the corpus tree.
+[[suite.workloads]]
+id = "wordfreq"
+source = "examples/wordfreq/main.rue"
+question = "How fast does a compiled Rue program tokenize and count words in tens of MiB of text?"
+program_args = ["{fixture}"]
+
+[suite.workloads.fixture]
+kind = "seeded_generator"
+category = "recorded"
+generator = "zipf_ascii_text"
+generator_revision = 1
+seed = 20260813
+bytes = 33554432
+vocabulary_size = 65536
+file_name = "wordfreq-input.txt"
+description = "32 MiB of deterministic ASCII word text with Zipf-distributed word ranks"
+
+[suite.workloads.oracle]
+kind = "golden_stdout"
+path = "performance/fixtures/wordfreq/expected-stdout.txt"
+
+[[suite.workloads]]
+id = "gazette"
+source = "examples/gazette/main.rue"
+question = "How fast does a compiled Rue program build the real rue-lang.dev site, against the production tools that build sites for a living?"
+program_args = ["build", "{fixture}", "-o", "{output}"]
+
+[suite.workloads.fixture]
+kind = "corpus_tree"
+category = "recorded"
+preparer = "scripts/gazette-corpus-diff.py"
+preparer_revision = 3
+scale = 1
+excluded = ["performance.md", "runtime.md"]
+root_name = "gazette-site"
+description = "the live rue-lang.dev content plus the copied specification, as website/build.sh assembles it, minus the two pages whose templates read derived benchmark data"
+
+[suite.workloads.oracle]
+kind = "semantic_site_pages"
+path = "scripts/gazette-corpus-diff.py"
+
+# The 10x rung, unchanged from revision 3 but for the preparer pin. The two
+# honesty notes revision 2 records about this axis — it is a page-count curve,
+# and the specification sidebar collapses on a duplicated page — apply here
+# exactly as they did there.
+[[suite.workloads]]
+id = "gazette_10x"
+source = "examples/gazette/main.rue"
+question = "How does a compiled Rue site build scale with page count, at ten copies of the corpus?"
+program_args = ["build", "{fixture}", "-o", "{output}"]
+
+[suite.workloads.fixture]
+kind = "corpus_tree"
+category = "recorded"
+preparer = "scripts/gazette-corpus-diff.py"
+preparer_revision = 3
+scale = 10
+excluded = ["performance.md", "runtime.md"]
+root_name = "gazette-site-10x"
+description = "the same corpus at ten copies, by deterministic path-prefixed duplication"
+
+[suite.workloads.oracle]
+kind = "semantic_site_pages"
+path = "scripts/gazette-corpus-diff.py"
+
 # The pinned reference regime. Epoch 1 implements suite revision 1, epoch 2
-# revision 2, and epoch 3 revision 3; only the last collects. Declaring a new
-# epoch rather than moving an old one to the new revision is what keeps every
-# record already in the store valid: a stored report names the epoch it ran
-# under, and that epoch must go on describing the run it describes.
+# revision 2, epoch 3 revision 3, and epoch 4 revision 4; only the last
+# collects. Declaring a new epoch rather than moving an old one to the new
+# revision is what keeps every record already in the store valid: a stored
+# report names the epoch it ran under, and that epoch must go on describing the
+# run it describes.
+#
+# The `local` rows are numbered in one sequence with these but declared at the
+# end of the file, one per target for the revision that collects (RUE-1498).
 [[epoch]]
 id = 1
 platform = "x86_64-linux"
@@ -752,7 +857,8 @@ compiler_args = ["-O3"]
 optimization = "o3"
 thread_policy = "single_threaded"
 hardware_counters = "unavailable_on_hosted_runner"
-collection = true
+# Superseded by epoch 4, which implements suite revision 4.
+collection = false
 
 [epoch.environment]
 runner_label = "github-hosted"
@@ -802,7 +908,8 @@ compiler_args = ["-O3"]
 optimization = "o3"
 thread_policy = "single_threaded"
 hardware_counters = "unavailable_on_hosted_runner"
-collection = true
+# Superseded by epoch 4, which implements suite revision 4.
+collection = false
 
 [epoch.environment]
 runner_label = "github-hosted"
@@ -849,7 +956,8 @@ compiler_args = ["-O3"]
 optimization = "o3"
 thread_policy = "single_threaded"
 hardware_counters = "unavailable_on_hosted_runner"
-collection = true
+# Superseded by epoch 4, which implements suite revision 4.
+collection = false
 
 [epoch.environment]
 runner_label = "github-hosted"
@@ -937,7 +1045,162 @@ canary_scale = 10
 records_comparison_identity = true
 
 # ===========================================================================
-# THE OTHER TWO LOCAL TARGETS (RUE-1498).
+# EPOCH 4: suite revision 4, the epoch that collects (RUE-1496).
+#
+# Everything about how these platforms run the workload is epoch 3's — same
+# runners, same sampling policies, same thread parity, same canary, same
+# `records_comparison_identity`. The epoch is new only because the suite
+# revision it implements is new: revision 4 pins preparer revision 3, and an
+# epoch names exactly one revision.
+#
+# THE STORE IS APPEND-ONLY, so epoch 3's records stay valid, keep publishing,
+# and keep joining under the conditions they were collected: preparer revision
+# 2, a lower-cased corpus, and the routes that came with it. What they must not
+# do is share a segment with revision 4's, and the workload identity's move is
+# what keeps them apart. This is the mechanism that retired epoch 2 in
+# RUE-1493, used again for the same reason.
+#
+# The local rows that reproduce these three are epochs 6, 7, and 8, at the end
+# of the file with the rest of them.
+# ===========================================================================
+
+[[epoch]]
+id = 4
+platform = "x86_64-linux"
+suite_revision = 4
+target = "x86-64-linux"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = true
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+# Unchanged from epoch 3: five samples of each per-push workload, three at 10x.
+# No `[epoch.calibration]` and no `[epoch.flagging]` either — calibration is a
+# property of a workload on a platform and is never inherited, not from the
+# compiler suites and not from this platform's own earlier epoch, so gazette
+# arrives advisory here exactly as it did there.
+[epoch.sampling.wordfreq]
+samples = 5
+
+[epoch.sampling.gazette]
+samples = 5
+
+[epoch.sampling.gazette_10x]
+samples = 3
+
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+# The declaration that makes the comparison identity mandatory here. Every
+# observation of this workload must record which peer ports and which peer
+# versions its peer legs were configured by — including a canary-only one,
+# which measures a single tool and must still say what the others were pinned
+# at, or a bump whose full leg never succeeded leaves no trace in the data.
+records_comparison_identity = true
+
+[epoch.peers.gazette_10x]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 10
+records_comparison_identity = true
+
+[[epoch]]
+id = 4
+platform = "aarch64-linux"
+suite_revision = 4
+target = "aarch64-linux"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = true
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+# The runner is `ubuntu-24.04-arm`; the image it reports is `ubuntu-24.04`,
+# which is how ADR-0067's aarch64-linux epochs already record this regime.
+[epoch.sampling.wordfreq]
+samples = 5
+
+[epoch.sampling.gazette]
+samples = 5
+
+[epoch.sampling.gazette_10x]
+samples = 3
+
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+records_comparison_identity = true
+
+[epoch.peers.gazette_10x]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 10
+records_comparison_identity = true
+
+[[epoch]]
+id = 4
+platform = "aarch64-macos"
+suite_revision = 4
+target = "aarch64-macos"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = true
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "macos-15"
+
+# Nine, as in epoch 3, and for the same reason: this row is off the per-push
+# path, has no calibration of its own, and a larger n per observation makes the
+# dispersion estimate that calibration will be built from converge sooner.
+[epoch.sampling.wordfreq]
+samples = 9
+
+[epoch.sampling.gazette]
+samples = 9
+
+[epoch.sampling.gazette_10x]
+samples = 3
+
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+records_comparison_identity = true
+
+[epoch.peers.gazette_10x]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 10
+records_comparison_identity = true
+
+# ===========================================================================
+# THE LOCAL ROWS, ONE PER TARGET (RUE-1498, extended by RUE-1496).
 #
 # `local` is not a platform Rue targets. It is the pseudo-platform a
 # maintainer's own machine runs under, and a local run builds for its epoch's
@@ -956,23 +1219,38 @@ records_comparison_identity = true
 #     epoch 3   x86-64-linux    suite revision 3
 #     epoch 4   aarch64-macos   suite revision 3
 #     epoch 5   aarch64-linux   suite revision 3
+#     epoch 6   x86-64-linux    suite revision 4
+#     epoch 7   aarch64-macos   suite revision 4
+#     epoch 8   aarch64-linux   suite revision 4
 #
-#     rue-bench runtime --platform local --epoch 4 \
+#     rue-bench runtime --platform local --epoch 7 \
 #       --compiler "$(scripts/rue-bin)" --commit "$(git rev-parse HEAD)" \
 #       --out /tmp/runtime.json --workdir /tmp/runtime-work
 #
-# Suite revision 3 and nothing else. Revisions 1 and 2 stay declared because
-# records in the store name them, but nothing collects them, and a local path
-# for a contract nothing collects would be prose to keep true for no reader.
-# That is the rule rather than these two ids: per target, for the revision
-# that collects.
+# THE RULE IS "PER TARGET, FOR THE REVISION THAT COLLECTS", not a list of ids,
+# and RUE-1496 is the first change to exercise it. That change advanced the
+# preparer to revision 3 and the suite to revision 4, and
+# `crates/rue-bench/src/runtime.rs` refuses fixture preparation when the
+# checked-in preparer's revision differs from the pin its epoch's suite carries
+# — so epochs 4 and 5 above, which pin revision 3, can no longer prepare the
+# gazette workloads at all. They stay declared, because records in the store
+# name them and revision 3 is still readable, and epochs 6 through 8 are what a
+# maintainer runs today. `every_collected_platform_has_a_local_reproduction_epoch`
+# is what turned that from a thing to remember into a build break: it fired on
+# all three collecting rows the moment revision 4 arrived.
+#
+# Suite revisions 1 through 3 keep only the local epochs they already had.
+# Nothing collects them, and a local path for a contract nothing collects would
+# be prose to keep true for no reader.
 #
 # Everything below except `id` and `target` is copied from epoch 3 rather than
 # chosen again — sampling, both peer rungs, and `records_comparison_identity`
 # on each. A local epoch exists to reproduce what CI measures, so the local
 # rows should differ from one another in the target alone; a policy that
 # drifted per host would make two maintainers' runs incomparable for a reason
-# that has nothing to do with their machines.
+# that has nothing to do with their machines. The revision-4 rows are copied
+# from their revision-3 counterparts for the same reason, and differ from them
+# in `suite_revision` alone.
 #
 # `collection = false` and the `local`-only environment policy on both, as on
 # every local row: a record from these names platform `local` and is grouped
@@ -1037,6 +1315,135 @@ records_comparison_identity = true
 id = 5
 platform = "local"
 suite_revision = 3
+target = "aarch64-linux"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = false
+
+[epoch.environment]
+runner_label = "local"
+runner_image = "local"
+
+[epoch.sampling.wordfreq]
+samples = 2
+
+[epoch.sampling.gazette]
+samples = 2
+
+[epoch.sampling.gazette_10x]
+samples = 2
+
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+records_comparison_identity = true
+
+[epoch.peers.gazette_10x]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 10
+records_comparison_identity = true
+
+# The revision-4 rows (RUE-1496), one per collecting target. Same three
+# targets, same policies, one suite revision later — and they are what a
+# maintainer selects today, because the preparer revision suite 4 pins is the
+# one the checked-in script implements.
+
+# x86-64 Linux at revision 4, the counterpart of epoch 3.
+[[epoch]]
+id = 6
+platform = "local"
+suite_revision = 4
+target = "x86-64-linux"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = false
+
+[epoch.environment]
+runner_label = "local"
+runner_image = "local"
+
+[epoch.sampling.wordfreq]
+samples = 2
+
+[epoch.sampling.gazette]
+samples = 2
+
+[epoch.sampling.gazette_10x]
+samples = 2
+
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+records_comparison_identity = true
+
+[epoch.peers.gazette_10x]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 10
+records_comparison_identity = true
+
+# Apple Silicon at revision 4, the counterpart of epoch 4 and the row this
+# project's maintainers actually run.
+[[epoch]]
+id = 7
+platform = "local"
+suite_revision = 4
+target = "aarch64-macos"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = false
+
+[epoch.environment]
+runner_label = "local"
+runner_image = "local"
+
+[epoch.sampling.wordfreq]
+samples = 2
+
+[epoch.sampling.gazette]
+samples = 2
+
+[epoch.sampling.gazette_10x]
+samples = 2
+
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+records_comparison_identity = true
+
+[epoch.peers.gazette_10x]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 10
+records_comparison_identity = true
+
+# arm64 Linux at revision 4, the counterpart of epoch 5.
+[[epoch]]
+id = 8
+platform = "local"
+suite_revision = 4
 target = "aarch64-linux"
 compiler_args = ["-O3"]
 optimization = "o3"

--- a/scripts/gazette-corpus-diff.py
+++ b/scripts/gazette-corpus-diff.py
@@ -156,7 +156,15 @@ GAZETTE_PORT_REVISION = 2
 # peer ports and peer versions beside it. A harness pinning revision 1 would
 # get no comparison identity at all, so it is refused here rather than left to
 # produce records that cannot join.
-PREPARER_REVISION = 2
+#
+# REVISION 3 (RUE-1496) drops the lower-casing pass from `assemble_corpus`.
+# Gazette slugifies a content path now, so the three tools agree on the three
+# upper-case file names without the input being rewritten — which means the
+# tools consume a different tree than they did under revision 2, however
+# slightly, and the WORKLOAD identity has to move for it. That is the correct
+# outcome rather than a cost: a new comparable segment is exactly what a change
+# to what every tool consumes should open.
+PREPARER_REVISION = 3
 
 # What gazette itself renders. Inside the workload identity. The peers' roots
 # are `peer_ports.PEER_PORT_ROOTS`, deliberately in the other file.
@@ -232,9 +240,19 @@ def corpus_rules() -> peer_ports.CorpusRules:
 #   reader diffing two observations that a port moved when it did not. What did
 #   change is the COMPOSITION of the identities, which PREPARER_REVISION
 #   records.
+#
+#   RUE-1496. `runtime.html` a fourth time, and the fourth identical conclusion:
+#   an excluded page's template, no port follows. It moved because the
+#   disclosure it renders said three file names are lower-cased before any tool
+#   sees the corpus, which stopped being true when gazette learned to slugify a
+#   content path. GAZETTE_PORT_REVISION did not advance — no gazette template's
+#   bytes moved — and PEER_PORT_REVISION did not either, for a reason argued
+#   beside it in `gazette_peer_ports.py`: both peer configurations lost the same
+#   stale comment, and neither peer's rendering changed. What did change is an
+#   assembly rule, which PREPARER_REVISION records.
 PRODUCTION_TEMPLATE_ROOT = "website/templates"
 PRODUCTION_TEMPLATE_DIGEST = (
-    "9fca5d6f31b479ca98b3db44e010bf1893556ac6b2030dc4661db0eb7d4acf8d"
+    "be481eb70d83cbd0a5443027f22005ddf476dd375f1b658c9e2635db68350d9c"
 )
 
 # Pages Zola emits no rendered body for, so `body` mode has nothing to compare
@@ -306,32 +324,10 @@ PAGINATE_BY = re.compile(r"^paginate_by = .*\n", re.M)
 def assemble_corpus(dest: str, exclude: dict | None = None) -> list[str]:
     """Copy site content plus the specification, rewriting spec-internal links.
 
-    Two normalizations are applied to the assembled tree, both outside any
-    measured window and both applied to EVERY tool's copy of it, because
-    ADR-0072 Decision 4's cross-tool criterion is that the tools consume the
-    identical corpus and emit the identical file set.
-
-    Content paths are lower-cased, and the honest way to say why is that
-    GAZETTE IS THE ODD TOOL OUT. Three files in the corpus have an upper-case
-    name (`spec/appendices/A-grammar.md` and its two siblings). Zola slugifies a
-    content path into its route by default and Hugo lower-cases it into its page
-    identity, so both serve `/spec/appendices/a-grammar/` — which is what the
-    production site serves today. Gazette does not slugify at all, so it alone
-    would emit `/spec/appendices/A-grammar/`. That is a Rue capability gap, not
-    a peer quirk, and an earlier version of this note framed it as Hugo's.
-
-    Normalizing here keeps all three tools on production's own route and keeps
-    Decision 4's file-set check exact rather than needing an allowlist entry
-    that excuses three files — which is the entry a tool silently dropping a
-    page would later hide behind. What it costs is honesty about a real
-    two-against-one difference, so the difference is stated here, in the peers'
-    parity configurations, in the ADR, and on the published page rather than
-    only in a digest. The work involved either way is one pass over 96 paths
-    and cannot move a measurement; teaching gazette to slugify would close the
-    gap properly and is left to a later change.
-
-    Nothing links to the three by name, so no link rewrite is needed; the walk
-    below asserts that rather than trusting it.
+    ONE normalization is applied to the assembled tree, outside any measured
+    window and applied to EVERY tool's copy of it, because ADR-0072 Decision 4's
+    cross-tool criterion is that the tools consume the identical corpus and emit
+    the identical file set.
 
     One key is stripped from the assembled front matter: `paginate_by`.
     Pagination is outside the equivalence subset for every tool (ADR-0072
@@ -342,11 +338,26 @@ def assemble_corpus(dest: str, exclude: dict | None = None) -> list[str]:
     keeps the sentence "every tool builds the identical corpus within a run"
     true.
 
-    NEITHER NORMALIZATION IS VISIBLE IN THE CONTENT DIGEST, and an earlier
+    THERE WERE TWO UNTIL RUE-1496, and what the second one was is worth
+    recording because it is now a closed gap rather than a live one. Every
+    content file name was lower-cased here, for the three files in the corpus
+    that have an upper-case one (`spec/appendices/A-grammar.md` and its two
+    siblings). Zola slugifies a content path's file stem into its route and Hugo
+    lower-cases it into its page identity, so both served
+    `/spec/appendices/a-grammar/` — what the production site serves — while
+    gazette, which did not slugify at all, would have emitted
+    `/spec/appendices/A-grammar/`. That was a Rue capability gap suppressed by
+    rewriting the input for all three tools, and the exact file-set check it
+    bought was exact only because the input had been changed to make it so.
+    Gazette slugifies now (`content_route` in `examples/gazette/tmpl_eval.rue`),
+    so the three tools agree on those routes with the corpus as it stands, and
+    `route_of` below is the independent model of the same rule.
+
+    THE NORMALIZATION IS NOT VISIBLE IN THE CONTENT DIGEST, and an earlier
     version of this docstring wrongly claimed otherwise. The digest is taken
-    over the tree these rules have already rewritten, so a new section adopting
+    over the tree this rule has already rewritten, so a new section adopting
     `paginate_by` produces byte-identical assembled content and an unchanged
-    digest. What records them is `prepare_fixture`'s `preparer_revision` and
+    digest. What records it is `prepare_fixture`'s `preparer_revision` and
     `preparer_digest`, which are inside the fixture identity for exactly this
     reason: the rules are as much an input to the measured job as the bytes are.
     """
@@ -372,28 +383,6 @@ def assemble_corpus(dest: str, exclude: dict | None = None) -> list[str]:
         if os.path.exists(victim):
             os.remove(victim)
 
-    lowercased = []
-    for dirpath, _dirs, files in os.walk(dest, topdown=False):
-        for name in files:
-            if name == name.lower():
-                continue
-            source = os.path.join(dirpath, name)
-            os.rename(source, os.path.join(dirpath, name.lower()))
-            lowercased.append(os.path.relpath(source, dest).replace(os.sep, "/"))
-    for rel in lowercased:
-        stem = rel[: -len(".md")] if rel.endswith(".md") else rel
-        for dirpath, _dirs, files in os.walk(dest):
-            for name in files:
-                if not name.endswith(".md"):
-                    continue
-                path = os.path.join(dirpath, name)
-                if "@/" + stem in open(path, encoding="utf-8").read():
-                    raise SystemExit(
-                        "%s links to %s by its upper-case name, which corpus "
-                        "assembly has lower-cased; teach assemble_corpus to "
-                        "rewrite the link before renaming the file"
-                        % (os.path.relpath(path, dest), stem))
-
     for dirpath, _dirs, files in os.walk(dest):
         for name in files:
             if not name.endswith(".md"):
@@ -415,14 +404,66 @@ def assemble_corpus(dest: str, exclude: dict | None = None) -> list[str]:
     return sorted(pages)
 
 
+# The route subset, as the independent model of it. THE WHOLE ROUTE is checked,
+# directories included, and not only the file stem that folds: every component
+# must be ASCII lower-case letters, digits, and `-` once a page's stem has been
+# case-folded. `Docs/page.md` is refused rather than routed.
+#
+# THIS IS THE SECOND IMPLEMENTATION OF ONE RULE, deliberately (ADR-0072
+# Decision 4): gazette computes a route in `content_route`, and the validation
+# recomputes it here from the source tree and compares. So the subset has to be
+# the same subset — a model that quietly slugified more than gazette does would
+# turn a real gap into a passing check, which is the failure RUE-1496 closed.
+ROUTE_SUBSET = re.compile(r"^[a-z0-9/-]*$")
+
+
 def route_of(rel: str) -> str:
-    """Zola's route for a content path, which is also the page's permalink."""
+    """Zola's route for a content path, which is also the page's permalink.
+
+    A page's FILE STEM folds case; DIRECTORY COMPONENTS are copied as authored
+    and must already be lower-case, and a section's route is its directories, so
+    nothing folds there. `spec/appendices/A-grammar.md` routes to
+    `spec/appendices/a-grammar/`; `Docs/page.md` is refused.
+
+    THE SUBSET IS EXACTLY WHERE THE TWO PEERS AGREE, measured against both
+    pinned binaries rather than read off Zola's documentation:
+
+        content path           zola 0.21.0          hugo 0.152.2
+        plain/A-Grammar.md     /plain/a-grammar/    /plain/a-grammar/    agree
+        plain/Under_Score.md   /plain/under-score/  /plain/under_score/  differ
+        plain/Dots.v2.md       /plain/dots-v2/      /plain/dots.v2/      differ
+        UPPER/lower.md         /UPPER/lower/        /upper/lower/        differ
+        Mixed/Sub/_index.md    /Mixed/Sub/          /mixed/sub/          differ
+        Dir_Under/p.md         /Dir_Under/p/        /dir_under/p/        differ
+
+    Zola slugifies the stem with the `slug` crate and copies directories
+    verbatim; Hugo lower-cases the whole path and touches nothing else. They
+    agree on one thing: an ASCII letter's case in a file stem. Everywhere else
+    no single rule can satisfy both, so Decision 4's file-set equality could not
+    hold whichever side gazette picked, and refusing is the only answer that
+    does not pick one silently.
+    """
     stem = rel[: -len(".md")]
     if stem == "_index":
         return ""
     if stem.endswith("/_index"):
-        return stem[: -len("_index")]
-    return stem + "/"
+        return checked_route(stem[: -len("_index")], rel)
+    head, sep, name = stem.rpartition("/")
+    return checked_route(head + sep + name.lower(), rel) + "/"
+
+
+def checked_route(route: str, rel: str) -> str:
+    if not ROUTE_SUBSET.match(route):
+        raise SystemExit(
+            "%s routes to /%s, which is outside the slug subset gazette "
+            "implements: every component must be lower-case ASCII letters, "
+            "digits, and `-`, and only a page's file stem folds case. That is "
+            "where the pinned Zola and Hugo agree, and they route everything "
+            "else differently — so widen it only when they stop disagreeing, "
+            "in `content_route`, here, and in ADR-0072 Decision 3, or rename "
+            "the file. A preparer that modelled more than gazette implements "
+            "would hide the difference rather than surface it" % (rel, route))
+    return route
 
 
 # ---------------------------------------------------------------------------
@@ -1011,11 +1052,13 @@ def prepare_fixture(root: str, scale: int) -> dict:
     identity = {
         "scale": scale,
         # The ASSEMBLY RULES, not just the assembled bytes. `assemble_corpus`
-        # excludes two pages, strips `paginate_by`, lower-cases three file
-        # names, and rewrites the specification's internal links — decisions
-        # that change what all three tools consume and that no other field
-        # here can see, because the digests below are taken over the tree AFTER
-        # they have been applied. Without these two entries, editing an
+        # excludes two pages, strips `paginate_by`, and rewrites the
+        # specification's internal links — decisions that change what all three
+        # tools consume and that no other field here can see, because the
+        # digests below are taken over the tree AFTER they have been applied.
+        # (It lower-cased three file names too, until gazette learned to
+        # slugify and the rule stopped being needed; that removal is the reason
+        # the revision is 3.) Without these two entries, editing an
         # assembly rule would change the measured job while leaving the
         # recorded identity untouched, and Decision 2's whole mechanism —
         # a moved identity opens a new comparable segment — would not fire.

--- a/scripts/gazette_peer_ports.py
+++ b/scripts/gazette_peer_ports.py
@@ -62,6 +62,17 @@ CorpusRules = collections.namedtuple(
 # files without changing a rule of it, and neither peer port's bytes moved. The
 # composition change is recorded by the workload preparer's revision, which is
 # what the manifest pins.
+#
+# It stays at 2 through RUE-1496 as well, and that case is the harder one to
+# state. Both peer configurations changed bytes — each carried a comment
+# explaining that the corpus was lower-cased for gazette's benefit, and the
+# corpus is not lower-cased any more — so `peer_port_digest` moves. Nothing
+# either peer RENDERS moved: Zola still slugifies, Hugo still lower-cases, and
+# both route the three appendices exactly where they did. The revision is the
+# label for a deliberate change to what a port renders, so advancing it here
+# would tell a reader diffing two observations that a peer's output changed
+# when only a comment did. The digest is the authoritative half and it records
+# the edit either way.
 PEER_PORT_REVISION = 2
 
 # What the PEERS render, and nothing gazette reads. Inside the comparison

--- a/website/templates/runtime.html
+++ b/website/templates/runtime.html
@@ -260,8 +260,13 @@
         {#
           The corpus modifications, disclosed here rather than only in the ADR
           and the preparer's source. A reader told only about configuration
-          switches would reasonably assume the input was the site as it stands,
-          and one of these three is a place where Rue is the tool out of step.
+          switches would reasonably assume the input was the site as it stands.
+
+          There were three until RUE-1496, and the third was the one worth
+          reading closely: file names were lower-cased to hide the fact that
+          gazette did not slugify. Removing a disclosure is only honest when the
+          thing disclosed is gone, so the sentence that replaces it says what
+          the tools now agree on unaided.
         #}
         <p>
           <strong>The corpus is modified before any tool sees it, identically
@@ -270,10 +275,12 @@
           would make this benchmark an input to itself. The blog's
           <code>paginate_by</code> key is stripped, because pagination is
           outside the subset and only one tool would otherwise build a paginated
-          view. And three specification appendix filenames are lower-cased:
-          Zola and Hugo both route them the way the live site does, and gazette,
-          which does not slugify paths, is the tool out of step — so this one
-          hides a Rue gap rather than a peer quirk.
+          view. The specification's internal links are rewritten as it is copied
+          in, which is what the real site build does too. What is no longer done
+          is renaming: the three specification appendices with upper-case file
+          names were lower-cased here until gazette learned to slugify a content
+          path, and all three tools now route them where the live site does,
+          from the names the repository actually carries.
         </p>
         <p>
           <strong>This compares a corpus-specialized Rue program against


### PR DESCRIPTION
Closes RUE-1496.

Zola routes a content path by slugifying it; gazette did not slugify at all, so
it alone would emit `/spec/appendices/A-grammar/` for the corpus's three
upper-case appendix names. The corpus preparer hid that by lower-casing every
content file name at fixture-preparation time, for all three tools — so
Decision 4's file-set equality was exact only because the input had been
rewritten to make it exact, and the gap it hid is a real Rue one: gazette is
the north-star candidate for building rue-lang.dev itself, and a generator that
cannot reproduce the site's routes cannot take that path.

Gazette now slugifies. The preparer's renaming pass is gone.

## What Zola actually does, measured rather than read

Probed against the pinned `./zola` 0.21.0: **only the file stem is slugified;
directories are copied verbatim**, underscores and case included, and a
section's route is its directories unchanged.

| content path | Zola 0.21.0 | Hugo 0.152.2 | |
| --- | --- | --- | --- |
| `plain/A-Grammar.md` | `/plain/a-grammar/` | `/plain/a-grammar/` | **agree** |
| `plain/Under_Score.md` | `/plain/under-score/` | `/plain/under_score/` | differ |
| `plain/Dots.v2.md` | `/plain/dots-v2/` | `/plain/dots.v2/` | differ |
| `UPPER/lower.md` | `/UPPER/lower/` | `/upper/lower/` | differ |
| `Mixed/Sub/_index.md` | `/Mixed/Sub/` | `/mixed/sub/` | differ |

The corpus cannot distinguish these rules — it has no upper-case directories —
so this had to be established against the binaries rather than inferred from
the input.

## The subset is the intersection of the two peers

Gazette folds ASCII case in a page's **file stem** and nothing else. Every
directory component must already be `[a-z0-9-]`, and a path outside that fails
the build with a new `E_ROUTE` diagnostic naming the path.

That boundary is not a guess about how far to go: it is exactly where Zola and
Hugo still agree. On every refused input above the two peers emit different
routes, so Decision 4's file-set equality could not hold whichever side gazette
picked. Refusing is the only answer that does not silently choose one peer over
the other, and it is what Decision 3's documented-subset rule asks for.

The Python `route_of` mirrors it exactly, including the refusals — a model more
permissive than gazette would turn a real gap into a passing check. It remains
one spelling, reaching the peer module through `CorpusRules`.

## Evidence

With the corpus **not rewritten** — `A-grammar.md`, `B-undefined-behavior.md`
and `C-implementation-limits.md` on disk as named — all three tools emit:

```
/spec/appendices/a-grammar/index.html
/spec/appendices/b-undefined-behavior/index.html
/spec/appendices/c-implementation-limits/index.html
/spec/appendices/index.html
```

and `judge` across all three trees reports `match: 0 check failure(s)`.

Three CLI cases pin the capability hermetically, because otherwise only the
live corpus exercises it and renaming those three appendices would drop the
coverage silently: a stem fold, a link target, and a refusal covering both a
non-conforming stem and a non-conforming directory.

## Identity and migration

Both identities move, correctly. The renaming was a corpus assembly rule, so
`preparer_digest` and `content_digest` both move, so `fixture_digest` moves;
the comparison identity is composed from it, so the peers' full leg re-runs —
right, because the tree they consume changed too. Both port revisions stay at 2:
no template's rendering changed.

`PREPARER_REVISION` 2→3 forces suite revision 4 and epoch 4 per platform, with
epoch 3 retired and still declared. Local epochs 6, 7 and 8 are added at
revision 4 for the three targets, because a local epoch pins a suite revision
and therefore a preparer revision — without them, the aarch64 reproduction
paths added in the previous change would still parse but could no longer
prepare a fixture.

`every_collected_platform_has_a_local_reproduction_epoch` was probed four ways
and fires on each: a missing local row, a row stranded on the retired revision,
a local row that collects, and the duplicate-id shape a naive rebase produces.

Verified against the real store that records from suite revisions 1, 2 and 3
still validate and publish, with nothing newly rejected.

## Also here

`E_ROUTE` governs content paths only — an `@/…` destination naming no `.md`
file returns early, so a link to a static asset is unaffected.

The runtime page's disclosure no longer says "nothing else is changed". It
names the specification link rewrite, which the real site build performs too,
and claims only that the renaming has stopped.

## Verification

`golden` 15 files (`PRODUCTION_TEMPLATE_DIGEST` recomputed, ledger entry
appended) · `body` 96 pages, 0 unexplained · `site` 130/130, 34 static files,
94-page oracle · `judge` match · `peers --samples 2 --no-secondary --scale 2`
190 pages per tool, 188 compared, allowlist still only Zola's `404.html` ·
`scripts/rue unit perf-schema` 220 · `unit bench` 127 · `quick` 31 ·
`cli examples_gazette` 12.
