### PR TITLE
RUE-1504: run the performance-staleness gate beside premerge, not inside it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,12 +229,13 @@ jobs:
     needs: affected-targets
     steps:
       - uses: actions/checkout@v6
-        with:
-          # The performance-staleness gate counts trunk commits merged since the
-          # newest plotted measurement, so it needs the measured commit in local
-          # history. The default depth-1 checkout has none of them, and a gate
-          # that cannot see the history fails rather than passing. (RUE-1258)
-          fetch-depth: 0
+        # A depth-1 checkout is enough for this lane: nothing it runs reads git
+        # history. Two of its steps do shell out to git — `provision-build-cache`
+        # lists worktrees, and `affected-targets build-scope` prunes them in its
+        # exit trap — but both ask only about the checkout in front of them, and
+        # the pin gate below is decided from file contents. The gate that does
+        # count commits is the `performance-staleness` job, which takes its own
+        # `fetch-depth: 0` checkout for the purpose (RUE-1258, RUE-1504).
 
       - name: Install dotslash
         uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
@@ -429,9 +430,12 @@ jobs:
         # the target, so platform responsibility cannot become implicit.
         run: scripts/ci-timed "cross-backend codegen" -- ./buck2 test //crates/rue-codegen:rue-codegen-test
 
-      # RUE-1258. Both performance gates live here because this job already has
-      # a built compiler and runner; a dedicated job would pay for a second
-      # compiler build to answer two cheap questions.
+      # RUE-1258's two performance gates deliberately live in different jobs,
+      # because they cost two orders of magnitude apart. This one is decidable
+      # from the tree alone and is about a second of hashing next to a compiler
+      # this lane has already built, so it belongs where the build is. Its
+      # sibling reads the published series, costs minutes, and shares nothing
+      # with this lane but `rue-bench`; it is the `performance-staleness` job.
       #
       # Neither gate has a bypass. The remedy for either is declaring the next
       # epoch, which is a small manifest change, and a genuine emergency is
@@ -450,6 +454,95 @@ jobs:
             --repo-root . \
             --compiler "$RUE"
 
+      # The Actions job-log API serves a truncated tail, so a failing target
+      # whose output scrolled past the cap is undiagnosable after the fact
+      # (RUE-1268). ci-timed preserves each failed command's complete output;
+      # keep it as an artifact.
+      - name: Upload failing-suite output
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: premerge-linux-x64-failure-logs
+          path: ${{ runner.temp }}/rue-ci-failed-logs
+          if-no-files-found: ignore
+
+  # RUE-1504. The staleness gate asks a question about the repository, not about
+  # the diff: is the published series *already* stalled? It reads nothing the
+  # premerge lane builds and nothing this diff touches, so the only thing it
+  # shared with that lane was a compiled `rue-bench`. It sits in its own job
+  # because `premerge (linux-x64)` is required CI's critical path — the longest
+  # job in 89 of 94 sampled runs — and this step added a flat ~156s median to it
+  # whatever the diff contained, 46% of the job on a pull request touching no
+  # compiler crate.
+  #
+  # This job is NOT cheaper than the step it replaced, and it is not smaller
+  # than the lane it left. It pays the gate's own ~156s plus a deep checkout
+  # (~11s), dotslash (~4s), job setup, and a `rue-bench` build that inside
+  # premerge was free because `Build all targets` had already done it:
+  # ~185-195s with the shared cache, ~250-270s cold on a fork pull request,
+  # against ~152s for premerge once the step is gone. So on a cheap pull request
+  # this job becomes the run's longest; on a compiler pull request, where
+  # premerge runs 9-10 minutes, it finishes far inside it. The change still pays
+  # in both regimes, because the two now overlap rather than serialize — the run
+  # goes from ~308s to ~190s at the median — but it is a p90 win first, and the
+  # floor under the whole run is `compiler reproducibility` at ~181.5s either
+  # way. Do not re-derive a saving here by assuming this job is free.
+  #
+  # Coverage moved slightly up, not sideways. As a premerge step the gate was
+  # skipped whenever an earlier step in that job failed, which happened in 1 of
+  # 14 sampled runs; standing alone it runs unconditionally. It still has no
+  # bypass and still blocks the merge: `ci-success` requires it by name, and
+  # `scripts/ci-required-results.py` is the inventory both the aggregate and the
+  # CI contract evaluate against.
+  #
+  # Deliberately ungated by `affected-targets`. A stalled series is a
+  # repository-wide condition that no diff causes and no diff can be shown not
+  # to be affected by, so there is no impacted-target closure that could
+  # correctly deselect this job.
+  performance-staleness:
+    runs-on: ubuntu-latest
+    name: performance staleness (linux-x64)
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # The gate counts trunk commits merged since the newest plotted
+          # measurement, so it needs the measured commit in local history. The
+          # default depth-1 checkout has none of them, and a gate that cannot
+          # see the history fails rather than passing. (RUE-1258)
+          fetch-depth: 0
+
+      - name: Install dotslash
+        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
+
+      # Same dotslash cache as the other Linux lanes; see linux-premerge for
+      # why these are the only paths worth caching (RUE-144).
+      - name: Cache dotslash artifacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/dotslash
+            ~/Library/Caches/dotslash
+          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          restore-keys: |
+            dotslash-linux-x64-
+
+      # BuildBuddy remote action cache (RUE-316/RUE-1006/RUE-1019); see the
+      # clippy job for the secret-availability contract. This lane builds the
+      # same `rue-bench` other Linux lanes do, so where the key is present the
+      # build is mostly cache hits rather than a second cold compile. Where it
+      # is not — a fork pull request — this job compiles the whole thing from
+      # scratch, which is the ~250-270s case noted above.
+      - name: Provision remote build cache
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          if [ -z "${BUILDBUDDY_API_KEY:-}" ]; then
+            echo "BUILDBUDDY_API_KEY unavailable (fork PR or unset); building without the remote cache."
+            exit 0
+          fi
+          scripts/provision-build-cache install
+          scripts/provision-build-cache apply
+
       - name: Check the performance series is still advancing
         # Is the series *already* stalled? A repository-wide condition, so this
         # fails every pull request rather than only the one that caused it: a
@@ -462,6 +555,14 @@ jobs:
         # flag and a triage item, never a repository-wide block.
         run: |
           set -euo pipefail
+          # Build in the open, then read the path. `--show-simple-output` with
+          # stderr discarded prints NOTHING when the build fails, so under
+          # `set -e` the step would abort having said only its own name — and
+          # this is the one build in this job, cold whenever the cache key is
+          # absent. Building through ci-timed first puts the compiler error in
+          # the log and in the preserved artifact below; the second invocation
+          # is then a warm no-op whose only job is to name the binary.
+          scripts/ci-timed "rue-bench build" -- ./buck2 build //crates/rue-bench:rue-bench
           BENCH="$(./buck2 build //crates/rue-bench:rue-bench --show-simple-output 2>/dev/null | tail -1)"
           git fetch --no-tags origin trunk
           git fetch --no-tags origin performance-data-v1
@@ -478,15 +579,15 @@ jobs:
             --repo . \
             --ref origin/trunk
 
-      # The Actions job-log API serves a truncated tail, so a failing target
-      # whose output scrolled past the cap is undiagnosable after the fact
-      # (RUE-1268). ci-timed preserves each failed command's complete output;
-      # keep it as an artifact.
+      # RUE-1268: the job-log API serves a truncated tail, so a build whose
+      # output scrolled past the cap is undiagnosable after the fact. This lane
+      # builds the compiler cold whenever the cache key is absent, which is
+      # exactly when that output matters most.
       - name: Upload failing-suite output
         if: failure()
         uses: actions/upload-artifact@v6
         with:
-          name: premerge-linux-x64-failure-logs
+          name: performance-staleness-failure-logs
           path: ${{ runner.temp }}/rue-ci-failed-logs
           if-no-files-found: ignore
 
@@ -1178,6 +1279,7 @@ jobs:
       - remote-execution
       - rust-project
       - linux-premerge
+      - performance-staleness
       - native-platforms
       - compiler-reproducibility
       - rue-program-digests

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -82,6 +82,40 @@ real slow targets nightly with a release compiler, compiling each application
 once and reusing the executable across runtime scenarios. Manual dispatch can
 select either full program and may select the separate 4x stress tier.
 
+ADR-0067's two performance gates are required but no longer share a job
+(RUE-1504). `premerge (linux-x64)` keeps `check-pins`, which asks whether this
+tree would stop runs entering their series — decidable from the tree alone, and
+about a second of hashing next to a build the lane already paid for.
+`performance staleness (linux-x64)` owns the other gate: whether the published
+series is *already* stalled. That question is repository-wide rather than
+diff-shaped, so the job is ungated by the determinator and takes a
+`fetch-depth: 0` checkout, without which it counts no trunk commits and fails
+instead of passing (RUE-1258). It stays compile-time only; ADR-0072 Decision 9
+deliberately leaves the runtime series out of it, and the CI contract now fails
+on a `--runtime-manifest` appearing there, on a `continue-on-error` bypass, and
+on the gate reappearing as a premerge step.
+
+The split is a scheduling change, and the gate is listed in
+`scripts/ci-required-results.py`, so `CI success` blocks the merge on it exactly
+as it did when it was a step. One thing did change, in the safe direction: as a
+step it was skipped whenever an earlier step in the premerge job failed (1 of 14
+sampled runs), and standing alone it always runs.
+
+It moved because it cost a flat ~156s median on the job that was the run's
+longest in 89 of 94 sampled runs — 46% of that job on a pull request touching no
+compiler crate. **The new job is not cheap, and is not smaller than the lane it
+left.** It pays the gate's own ~156s plus job setup, an ~11s `fetch-depth: 0`
+checkout, ~4s of dotslash, and a `rue-bench` build that inside premerge was free
+because `Build all targets` had already produced it: **~185–195s** with the
+shared action cache, **~250–270s** cold on a fork pull request where no key is
+available, against **~152s** for premerge with the step removed. On a cheap pull
+request the gate job is therefore the run's longest; on a compiler pull request,
+where premerge runs 9–10 minutes, it finishes far inside it. The win comes from
+overlap rather than from the work getting cheaper — median run wall time ~308s →
+~190s, newly floored by `compiler reproducibility (linux-x64)` at ~181.5s — so
+it is a p90 win first and a smaller p50 win. Do not re-derive a saving from an
+assumption that this job is free.
+
 Production `debug_assert*` use is governed by
 `scripts/validate-debug-assert-policy.py`, run by required formatting CI and
 `scripts/rue quick`. Every surviving call has an exact per-file allowance and

--- a/scripts/ci-required-results.py
+++ b/scripts/ci-required-results.py
@@ -14,6 +14,10 @@ EXPECTED_REQUIRED_JOBS = (
     "remote-execution",
     "rust-project",
     "linux-premerge",
+    # RUE-1504: the performance-staleness gate runs beside the premerge lane
+    # rather than inside it. It is required exactly as it was when it was a
+    # step, so moving it cost no coverage.
+    "performance-staleness",
     "native-platforms",
     "compiler-reproducibility",
     "rue-program-digests",

--- a/scripts/test-validate-ci-gate.py
+++ b/scripts/test-validate-ci-gate.py
@@ -157,6 +157,91 @@ class GateValidatorTests(unittest.TestCase):
         )
 
 
+    # RUE-1504: the staleness gate moved out of the premerge lane into its own
+    # job. Moving required work is only safe while the contract moves with it.
+    def test_staleness_gate_without_a_deep_checkout_fails(self):
+        changed = SOURCE.read_text().replace(
+            "          # measurement, so it needs the measured commit in local history. The\n"
+            "          # default depth-1 checkout has none of them, and a gate that cannot\n"
+            "          # see the history fails rather than passing. (RUE-1258)\n"
+            "          fetch-depth: 0\n",
+            "",
+            1,
+        )
+        self.assertNotEqual(changed, SOURCE.read_text(), "splice anchor no longer matches ci.yml")
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("performance-staleness responsibility missing 'fetch-depth: 0'", errors)
+
+    def test_dropping_the_staleness_step_fails(self):
+        changed = SOURCE.read_text().replace(
+            "          scripts/validate-performance-stall.py \\\n", "", 1
+        )
+        self.assertNotEqual(changed, SOURCE.read_text(), "splice anchor no longer matches ci.yml")
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn(
+            "performance-staleness responsibility missing "
+            "'scripts/validate-performance-stall.py'",
+            errors,
+        )
+
+    def test_returning_the_staleness_gate_to_the_premerge_lane_fails(self):
+        changed = SOURCE.read_text().replace(
+            "        run: scripts/ci-timed \"gazette goldens\" -- scripts/gazette-corpus-diff.py golden\n",
+            "        run: scripts/ci-timed \"gazette goldens\" -- scripts/gazette-corpus-diff.py golden\n"
+            "      - name: Check the performance series is still advancing\n"
+            "        run: scripts/validate-performance-stall.py --data d --repo . --ref origin/trunk\n",
+            1,
+        )
+        self.assertNotEqual(changed, SOURCE.read_text(), "splice anchor no longer matches ci.yml")
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("the staleness gate belongs to performance-staleness", errors)
+
+    def test_runtime_series_cannot_be_folded_into_the_staleness_gate(self):
+        # ADR-0072 Decision 9. A stalled runtime series is a triage item, not a
+        # repository-wide block, and the difference is one flag.
+        changed = SOURCE.read_text().replace(
+            "            --manifest performance/manifest.toml \\\n"
+            "            --data-root \"$DATA\" \\\n",
+            "            --manifest performance/manifest.toml \\\n"
+            "            --runtime-manifest performance/runtime.toml \\\n"
+            "            --data-root \"$DATA\" \\\n",
+            1,
+        )
+        self.assertNotEqual(changed, SOURCE.read_text(), "splice anchor no longer matches ci.yml")
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("must stay compile-time only", errors)
+
+    def test_continue_on_error_voids_the_staleness_gate(self):
+        # The gate has no bypass, and `continue-on-error` is a one-line bypass
+        # that leaves the required check reporting success.
+        for splice in (
+            "  performance-staleness:\n    runs-on: ubuntu-latest\n"
+            "    continue-on-error: true\n",
+            "  performance-staleness:\n    runs-on: ubuntu-latest\n"
+            "    steps:\n      - continue-on-error: true\n",
+        ):
+            changed = SOURCE.read_text().replace(
+                "  performance-staleness:\n    runs-on: ubuntu-latest\n", splice, 1
+            )
+            self.assertNotEqual(
+                changed, SOURCE.read_text(), "splice anchor no longer matches ci.yml"
+            )
+            errors = "\n".join(self.validate_text(changed))
+            self.assertIn(
+                "performance-staleness must not use continue-on-error", errors
+            )
+
+    def test_gating_the_staleness_job_on_another_fails(self):
+        changed = SOURCE.read_text().replace(
+            "  performance-staleness:\n    runs-on: ubuntu-latest\n",
+            "  performance-staleness:\n    runs-on: ubuntu-latest\n"
+            "    needs:\n      - affected-targets\n",
+            1,
+        )
+        self.assertNotEqual(changed, SOURCE.read_text(), "splice anchor no longer matches ci.yml")
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("performance-staleness must not depend on another CI job", errors)
+
     def test_undeclared_need_output_fails_closed(self):
         # RUE-1130 regression. GitHub resolves an undeclared job output to the
         # empty string instead of failing, so a lane gate reading it would see

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -248,18 +248,65 @@ def validate(
         "./test.sh",
         "Run explicit cross-backend compilation and encoding coverage",
         "//crates/rue-codegen:rue-codegen-test",
-        # RUE-1258: both performance gates. Losing either restores the silence
-        # that let the published series freeze for ten days while every job
-        # stayed green, so their presence is part of the CI contract rather
-        # than a step someone may quietly drop.
+        # RUE-1258: the pin gate. Losing it restores the silence that let the
+        # published series freeze for ten days while every job stayed green,
+        # so its presence is part of the CI contract rather than a step someone
+        # may quietly drop. Its sibling staleness gate is pinned below, in the
+        # job RUE-1504 moved it to.
         "check-pins",
-        "scripts/validate-performance-stall.py",
-        # The staleness gate counts trunk commits back to the newest measured
-        # one, which a depth-1 checkout cannot reach.
-        "fetch-depth: 0",
     ):
         if required not in linux:
             errors.append(f"linux-premerge responsibility missing {required!r}")
+    if "scripts/validate-performance-stall.py" in linux:
+        errors.append(
+            "the staleness gate belongs to performance-staleness (RUE-1504); "
+            "running it inside linux-premerge puts ~1m50s back on the critical path"
+        )
+
+    # RUE-1504. The staleness gate is required work that merely stopped being
+    # premerge's work, so the contract follows it rather than relaxing. Both
+    # halves matter: the step itself, and the deep checkout without which it
+    # fails instead of passing.
+    staleness = jobs.get("performance-staleness", "")
+    for required in (
+        "runs-on: ubuntu-latest",
+        "scripts/validate-performance-stall.py",
+        "//crates/rue-bench:rue-bench",
+        # The gate counts trunk commits back to the newest measured one, which
+        # a depth-1 checkout cannot reach (RUE-1258).
+        "fetch-depth: 0",
+    ):
+        if required not in staleness:
+            errors.append(f"performance-staleness responsibility missing {required!r}")
+    # ADR-0072 Decision 9 keeps the runtime series outside this gate on purpose:
+    # its remedy is parser work rather than a manifest edit, so a stalled
+    # runtime series is a triage item, never a repository-wide block. The step
+    # says so in a comment, so only an executable line counts as a violation.
+    if any(
+        "--runtime-manifest" in line and not line.lstrip().startswith("#")
+        for line in staleness.splitlines()
+    ):
+        errors.append(
+            "performance-staleness must stay compile-time only; ADR-0072 "
+            "Decision 9 keeps the runtime series out of this gate"
+        )
+    if "    needs:" in staleness:
+        errors.append(
+            "performance-staleness must not depend on another CI job; it asks a "
+            "repository-wide question and gains nothing by waiting"
+        )
+    # A required check that cannot fail is not a gate. `continue-on-error` is
+    # the one-line version of that, on the job or on the step: the run stays
+    # green and `ci-required-results.py` still sees `success`, so nothing
+    # downstream notices. The gate used to be one step among many in a busy
+    # lane; it is now alone in a small job where such a line would be easy to
+    # add and hard to see.
+    if "continue-on-error" in staleness:
+        errors.append(
+            "performance-staleness must not use continue-on-error; the gate has "
+            "no bypass, and a required check that reports success regardless of "
+            "the gate's result is one"
+        )
 
     # RUE-1163: the corpora that own a platform-corpus job are marked in BUCK
     # with `rue_ci_dedicated_lane`, and test.sh subtracts that label on CI. The


### PR DESCRIPTION
Moves `Check the performance series is still advancing` out of `premerge (linux-x64)` into its own required job, `performance staleness (linux-x64)`, so it stops sitting on the critical path.

## Why

`premerge` is the CI long pole — the slowest job in 89 of 94 runs sampled over 2026-08-13/14, p90 9m41s. The staleness gate is a flat ~156s of that on *every* run, because it is a repository-wide condition that does not depend on the diff. On a non-compiler PR it is 46% of the whole job.

## What this actually buys, measured

The gate's cost does not disappear — it moves. Measured over 14 recent runs:

| | after the split |
| --- | --- |
| `premerge (linux-x64)` | ~152s (was ~308s) |
| `performance staleness (linux-x64)` | ~185–195s cached, ~250–270s cold on a fork PR |

The new job pays the 156s gate plus job setup, an ~11s deep checkout, ~4s dotslash, and a `rue-bench` build that was previously free inside premerge. So it becomes the longest job on cheap PRs, while finishing far inside premerge on compiler PRs where that lane runs 9–10 minutes. Run wall time goes ~308s → ~190s, newly floored by `compiler reproducibility` at ~181.5s. This is a p90 win first, with a smaller p50 win.

## Coverage

Unchanged, except slightly upward. The job is in `ci-success`'s `needs:` and in `EXPECTED_REQUIRED_JOBS`, so it gates merges exactly as the step did; skipped, cancelled, and missing all fail closed. In 1 of 14 sampled runs the step was `skipped` because an earlier premerge step failed — split out, it always runs.

`premerge` loses `fetch-depth: 0`, which the moved gate was the only consumer of. Every remaining step in that job was traced, including transitively: no Rust code shells out to git, and the two git callers that remain (`provision-build-cache` listing worktrees, `affected-targets build-scope` pruning them) are depth-independent. Incidental win: premerge's checkout drops from 11s to ~3s.

## Contract

`validate-ci-gate.py` moves the `validate-performance-stall.py` and `fetch-depth: 0` pins to a new `performance-staleness` block and adds failures for the gate reappearing inside premerge, a `--runtime-manifest` appearing here (ADR-0072 Decision 9 keeps the runtime series outside this gate), the job acquiring a `needs:`, and `continue-on-error` appearing anywhere in the block. Six new regression tests.

The `rue-bench` build now runs through `scripts/ci-timed`, so a build failure in this job produces a diagnosable log rather than a red required check with an empty one — it is the only build in the job, and cold on fork PRs.

Closes RUE-1504.