### PR TITLE
RUE-1506: run the narrowed suite on the Bash macOS actually ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,16 @@ jobs:
       - name: Check shell pipefail pipelines
         run: scripts/validate-shell-pipefail-pipelines.py
 
+      # macOS runs `#!/usr/bin/env bash` scripts with Bash 3.2, so a Bash 4
+      # builtin is exit 127 on every developer Mac while this Linux-only lane
+      # stays green -- which is precisely how `mapfile` in test.sh's narrowing
+      # path went unnoticed (RUE-1506). The scan is static, so it finds that
+      # from here. It also covers the `run:` steps of jobs that can land on a
+      # macOS runner; the `mapfile` this job itself uses above is NOT one of
+      # them, and is correct, because this job only ever runs on ubuntu-latest.
+      - name: Check shell Bash 3.2 baseline
+        run: scripts/validate-shell-bash-baseline.py
+
       - name: Validate Buck test-tier ownership
         run: ./buck2 bxl //test_tiers.bxl:validate
 
@@ -722,6 +732,18 @@ jobs:
             done <<< "$narrowed"
           fi
           scripts/ci-timed "$LANE_NAME native units" -- ./buck2 test "${targets[@]}"
+
+      # RUE-1506. The Bash 3.2 baseline policy's demonstrations — `mapfile`
+      # exiting 127, `"${empty[@]}"` unbound under `set -u`, `read` assigning
+      # nothing when it fails — need a 3.2 to demonstrate anything, and this is
+      # the only lane whose /bin/bash is one. Everywhere else they skip, so
+      # premerge alone would leave them a test that cannot fail. Unnarrowed:
+      # the policy scans the whole tree, so any diff can invalidate it.
+      - name: Demonstrate the Bash 3.2 baseline on the stock macOS Bash
+        if: steps.sel.outputs.run == 'true' && runner.os == 'macOS'
+        run: scripts/ci-timed "$LANE_NAME bash baseline" -- ./buck2 test //:shell-bash-baseline-tool-tests
+        env:
+          LANE_NAME: ${{ matrix.name }}
 
       - name: Run every declaratively platform-scoped spec and CLI case
         if: steps.sel.outputs.run == 'true'

--- a/BUCK
+++ b/BUCK
@@ -854,6 +854,15 @@ rue_sh_test(
 )
 
 rue_sh_test(
+    name = "shell-bash-baseline-tool-tests",
+    test = "scripts/test-validate-shell-bash-baseline.py",
+    resources = ["scripts/validate-shell-bash-baseline.py"],
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+    },
+)
+
+rue_sh_test(
     name = "release-configuration-tool-tests",
     test = "scripts/test-release-configuration.py",
     env = {

--- a/scripts/test-affected-targets.sh
+++ b/scripts/test-affected-targets.sh
@@ -325,6 +325,42 @@ check_narrow "a narrowed suite keeps its tier and deferral filters" \
   "--include rue_test_tier_premerge --exclude rue_ci_dedicated_lane" \
   "RUE_TEST_TARGETS_FILE=$narrow_root/one"
 
+# RUE-1506. test.sh read this list with `mapfile`, a Bash 4 builtin macOS does
+# not have, so every narrowed run on a Mac exited 127 while this suite stayed
+# green on Linux CI — the only place it runs. These cases pin the reading
+# itself, in behavior a Bash 5 host can also see: each expectation below is
+# wrong under `mapfile -t`, or under a read loop missing one of its guards, so
+# a reintroduction fails here rather than only on a developer's machine.
+
+# A blank line is not a target. `mapfile` keeps it and buck2 receives an empty
+# argument between the two real ones.
+printf '//crates/rue-span:rue-span-test\n\n//crates/rue-parser:rue-parser-test\n' >"$narrow_root/blank-line"
+check_narrow "blank lines in the list are not passed to buck2" \
+  "ARGS: //crates/rue-span:rue-span-test //crates/rue-parser:rue-parser-test --always-exclude" \
+  "RUE_TEST_TARGETS_FILE=$narrow_root/blank-line"
+
+# The producer's `sed '/^$/d'` drops empty lines but not whitespace-only ones,
+# so this is the reachable half: it must fall open, not narrow to " ".
+printf '   \n\t\n' >"$narrow_root/whitespace"
+check_narrow "a whitespace-only list runs the full pattern" \
+  "ARGS: //... toolchains//..." \
+  "RUE_TEST_TARGETS_FILE=$narrow_root/whitespace"
+
+# A file whose last line has no newline. `mapfile` keeps that line; a plain
+# `while read` loop silently drops it, dropping a target from the run.
+printf '//crates/rue-span:rue-span-test' >"$narrow_root/unterminated"
+check_narrow "a final line without a newline is still a target" \
+  "ARGS: //crates/rue-span:rue-span-test --always-exclude" \
+  "RUE_TEST_TARGETS_FILE=$narrow_root/unterminated"
+
+# A directory passes -r and -s, and `read` fails on it without assigning, which
+# left the loop's `-n` fallback expanding an unset variable: `set -u` killed the
+# whole suite over an input the fail-open contract says must fall back.
+mkdir -p "$narrow_root/a-directory"
+check_narrow "a directory runs the full pattern instead of failing the suite" \
+  "ARGS: //... toolchains//..." \
+  "RUE_TEST_TARGETS_FILE=$narrow_root/a-directory"
+
 # The workflow-facing adapter must reserve `run=false` for the gate's explicit
 # deselection status. A gate crash or missing executable runs the corpus.
 decision_root="$(mktemp -d)"

--- a/scripts/test-validate-shell-bash-baseline.py
+++ b/scripts/test-validate-shell-bash-baseline.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Focused tests for the Bash 3.2 baseline policy."""
+
+from __future__ import annotations
+
+import importlib.util
+import platform
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("validate-shell-bash-baseline.py")
+SPEC = importlib.util.spec_from_file_location("bash_baseline", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+policy = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(policy)
+
+BASELINE_BASH = "/bin/bash"
+
+
+def baseline_bash_version() -> int | None:
+    """The major version of /bin/bash, or None when there is no /bin/bash."""
+    if not Path(BASELINE_BASH).exists():
+        return None
+    result = subprocess.run(
+        [BASELINE_BASH, "-c", 'echo "${BASH_VERSINFO[0]}"'],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return int(result.stdout.strip())
+
+
+class ScanTests(unittest.TestCase):
+    def scan(self, body: str) -> list[str]:
+        source = "#!/usr/bin/env bash\nset -euo pipefail\n" + textwrap.dedent(body)
+        return [finding.rule.construct for finding in policy.scan(source, "probe.sh")]
+
+    def test_flags_the_builtin_that_caused_rue_1506(self) -> None:
+        self.assertEqual(
+            self.scan('mapfile -t targets <"$file"\n'),
+            ["the `mapfile`/`readarray` builtin"],
+        )
+        self.assertEqual(
+            self.scan("readarray -t targets < <(list)\n"),
+            ["the `mapfile`/`readarray` builtin"],
+        )
+
+    def test_flags_the_remaining_bash4_constructs(self) -> None:
+        cases = {
+            "declare -A seen\n": "an associative array",
+            "local -Ar seen=()\n": "an associative array",
+            'echo "${name^^}"\n': "`${var^^}`/`${var,,}` case modification",
+            'echo "${name,,}"\n': "`${var^^}`/`${var,,}` case modification",
+            # Positional and special parameters take the same expansions.
+            'echo "${1^^}"\n': "`${var^^}`/`${var,,}` case modification",
+            'echo "${1@Q}"\n': "a `${var@X}` parameter transformation",
+            # A syntax error on 3.2: the script never starts.
+            "case $x in a) run ;;& b) run ;; esac\n": "a `;;&`/`;&` case terminator",
+            "case $x in a) run ;& b) run ;; esac\n": "a `;;&`/`;&` case terminator",
+            "run &>>log\n": "the `&>>` append redirection",
+            "coproc reader { cat f; }\n": "the `coproc` keyword",
+            "shopt -s globstar\n": "a `shopt` option newer than the baseline",
+            "read -t 0.5 -r line\n": "a fractional `read -t` timeout",
+            "exec {log}>out\n": "a `{fd}` automatic file-descriptor assignment",
+            # Silently returns empty on 3.2 -- a wrong answer, not an error.
+            "v=${w:1:-1}\n": "a negative substring length",
+            'echo "${a[-1]}"\n': "a negative array subscript",
+            'echo "${#a[-1]}"\n': "a negative array subscript",
+            "a[-1]=x\n": "a negative array subscript",
+            "[[ -v name ]] && echo set\n": "the `-v` set-variable test",
+            "[[ ! -v name ]] && echo unset\n": "the `-v` set-variable test",
+            "[ -v name ] && echo set\n": "the `-v` set-variable test",
+            "declare -g total=0\n": "a `declare -g` global declaration",
+            "printf '%(%Y)T\\n' -1\n": "a `printf '%(fmt)T'` time format",
+            "declare -n alias=target\n": "a nameref declaration",
+            "wait -n\n": "`wait -n`",
+            'echo "$EPOCHREALTIME"\n': "the `EPOCHSECONDS`/`EPOCHREALTIME` variable",
+        }
+        for body, construct in cases.items():
+            with self.subTest(body=body.strip()):
+                self.assertIn(construct, self.scan(body))
+
+    def test_accepts_the_portable_spellings(self) -> None:
+        # The RUE-1506 fix itself, plus the Bash 3.x constructs whose spelling
+        # is one character away from a banned one.
+        self.assertEqual(
+            self.scan(
+                """
+                targets=()
+                while :; do
+                    target=""
+                    IFS= read -r target || [[ -n "$target" ]] || break
+                    targets+=("$target")
+                done <"$file"
+                declare -a indexed
+                local -r pinned=1
+                printf -v stamp '%s' "$now"
+                run >>log 2>&1
+                read -t 5 -r answer
+                echo "${#targets[@]}" "${!targets[@]}" "${target:-}" "${!name}"
+                echo "${targets[$((${#targets[@]} - 1))]}"
+                echo "${path%%/*}" "${path##*/}" "${text//a/b}" "${v: -3}"
+                log="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/run.log"
+                [[ -n "${name+set}" ]] && wait "$pid"
+                case $x in a) run ;; b) run ;; esac
+                cmd1 ; cmd2 &
+                """
+            ),
+            [],
+        )
+
+    def test_ignores_a_construct_named_in_a_string(self) -> None:
+        # A construct inside a string is text: `strip_comment` alone would have
+        # flagged all three of these.
+        self.assertEqual(self.scan('echo "use mapfile here"\n'), [])
+        self.assertEqual(self.scan("die 'readarray unavailable'\n"), [])
+        # ...but an expansion inside a double-quoted string is still code.
+        self.assertEqual(
+            self.scan('echo "the name is ${name^^}"\n'),
+            ["`${var^^}`/`${var,,}` case modification"],
+        )
+
+    def test_does_not_flag_buck2_test_dash_v(self) -> None:
+        # The line this repository is full of, one character from `[ -v x ]`.
+        self.assertEqual(self.scan("./buck2 test -v 2 //...\n"), [])
+
+    def test_ignores_the_construct_named_in_a_comment(self) -> None:
+        self.assertEqual(self.scan("# mapfile is unavailable on Bash 3.2\n"), [])
+        self.assertEqual(self.scan("read -r x  # not mapfile: Bash 3.2\n"), [])
+
+    def test_heredoc_bodies_are_data_but_still_expand(self) -> None:
+        # A quoted delimiter makes the body literal text.
+        self.assertEqual(
+            self.scan("cat <<'EOF'\nmapfile -t a <f\nEOF\n"),
+            [],
+        )
+        # An unquoted one does not: the shell expands the body, so a Bash 4
+        # expansion in it fails exactly as it would in code.
+        self.assertEqual(
+            self.scan("cat <<EOF\n${name^^}\nEOF\n"),
+            ["`${var^^}`/`${var,,}` case modification"],
+        )
+        # A `<<<` herestring is not a heredoc; the line after it is code.
+        self.assertEqual(
+            self.scan('grep -q x <<<"$text"\nmapfile -t a <f\n'),
+            ["the `mapfile`/`readarray` builtin"],
+        )
+
+    def test_honours_a_reviewed_allowance(self) -> None:
+        self.assertEqual(
+            self.scan("mapfile -t a <f  # bash-baseline-ok: linux-only helper\n"), []
+        )
+
+    def test_an_allowance_inside_a_string_does_not_silence_the_line(self) -> None:
+        self.assertEqual(
+            self.scan('X="# bash-baseline-ok: fake"; mapfile -t a <f\n'),
+            ["the `mapfile`/`readarray` builtin"],
+        )
+
+
+class WorkflowTests(unittest.TestCase):
+    """`run:` steps are held to the baseline on macOS runners only."""
+
+    WORKFLOW = textwrap.dedent(
+        """\
+        name: ci
+        jobs:
+          fmt:
+            runs-on: ubuntu-latest
+            steps:
+              - name: Check formatting
+                run: |
+                  mapfile -t TARGETS < <(list)
+                  echo "${#TARGETS[@]}"
+          native-platforms:
+            strategy:
+              matrix:
+                include:
+                  - os: ubuntu-24.04-arm
+                  - os: macos-15
+            runs-on: ${{ matrix.os }}
+            steps:
+              - name: Run native units
+                run: |
+                  mapfile -t targets <<<"$scope"
+              - name: Inline
+                run: declare -A seen
+        """
+    )
+
+    def findings(self, source: str) -> list[tuple[int, str]]:
+        return [
+            (finding.line, finding.rule.construct)
+            for finding in policy.scan_workflow(source, "ci.yml")
+        ]
+
+    def test_flags_a_macos_run_step_and_spares_the_linux_one(self) -> None:
+        # The Linux `mapfile` at line 8 is correct on ubuntu-latest; the macOS
+        # ones at 20 and 22 are the bug that started this policy.
+        self.assertEqual(
+            self.findings(self.WORKFLOW),
+            [
+                (20, "the `mapfile`/`readarray` builtin"),
+                (22, "an associative array"),
+            ],
+        )
+
+    def test_a_job_naming_a_macos_runner_directly_is_covered(self) -> None:
+        source = self.WORKFLOW.replace("runs-on: ${{ matrix.os }}", "runs-on: macos-15")
+        self.assertIn((20, "the `mapfile`/`readarray` builtin"), self.findings(source))
+
+    def test_an_all_linux_workflow_has_no_findings(self) -> None:
+        source = self.WORKFLOW.replace("- os: macos-15", "- os: ubuntu-latest").replace(
+            "runs-on: ${{ matrix.os }}", "runs-on: ${{ matrix.os }}"
+        )
+        self.assertEqual(self.findings(source), [])
+
+    def test_the_repository_workflows_are_clean(self) -> None:
+        root = SCRIPT.resolve().parent.parent
+        workflow = root / ".github/workflows/ci.yml"
+        if not workflow.exists():
+            self.skipTest("not a repository checkout")
+        source = workflow.read_text()
+        # The one macOS-capable job is the lane that hit this bug first.
+        jobs = policy.macos_runner_jobs(source)
+        lines = source.splitlines()
+        self.assertEqual([lines[begin].strip() for begin, _ in jobs], ["native-platforms:"])
+        self.assertEqual(policy.scan_workflow(source, "ci.yml"), [])
+
+
+class DiscoveryTests(unittest.TestCase):
+    def discover(self, files: dict[str, str]) -> tuple[list[str], list[str]]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for relative, contents in files.items():
+                path = root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(contents)
+            scripts, workflows = policy.sources(root)
+            found = [p.relative_to(root).as_posix() for p in scripts + workflows]
+            findings = [str(f) for f in policy.validate(root)[0]]
+        return found, findings
+
+    BAD = "#!/usr/bin/env bash\nmapfile -t a <f\n"
+
+    def test_skips_build_output_and_vendored_trees(self) -> None:
+        found, findings = self.discover(
+            {f"{skipped}/nested/probe.sh": self.BAD for skipped in policy.SKIP_DIRECTORIES}
+        )
+        self.assertEqual(found, [])
+        self.assertEqual(findings, [])
+
+    def test_skips_nested_checkouts(self) -> None:
+        # The working agreement puts sibling worktrees under `.claude/`, and
+        # reporting `.claude/worktrees/rue-1265/test.sh` as a path in THIS tree
+        # is worse than not scanning it.
+        found, findings = self.discover(
+            {
+                ".claude/worktrees/other/.git": "gitdir: elsewhere\n",
+                ".claude/worktrees/other/test.sh": self.BAD,
+                ".claude/hooks/guard.sh": "#!/usr/bin/env bash\ntrue\n",
+            }
+        )
+        self.assertEqual(found, [".claude/hooks/guard.sh"])
+        self.assertEqual(findings, [])
+
+    def test_finds_extensionless_scripts_by_shebang(self) -> None:
+        found, findings = self.discover({"scripts/tool": self.BAD})
+        self.assertEqual(found, ["scripts/tool"])
+        self.assertEqual(len(findings), 1)
+
+    def test_accepts_every_bash_shebang_spelling(self) -> None:
+        for shebang in ("#!/bin/bash", "#!/usr/bin/env bash", "#!/usr/bin/env -S bash -eu"):
+            with self.subTest(shebang=shebang):
+                found, _ = self.discover({"tool": f"{shebang}\ntrue\n"})
+                self.assertEqual(found, ["tool"])
+
+    def test_ignores_non_bash_interpreters(self) -> None:
+        # A `sh` script has a POSIX problem, not a Bash-version one.
+        found, _ = self.discover(
+            {
+                "posix.sh": "#!/bin/sh\nmapfile -t a <f\n",
+                "tool.py": "#!/usr/bin/env python3\n# mapfile\n",
+            }
+        )
+        self.assertEqual(found, [])
+
+    def test_workflows_are_scanned_as_workflows(self) -> None:
+        found, _ = self.discover(
+            {".github/workflows/ci.yml": "jobs:\n  a:\n    runs-on: ubuntu-latest\n"}
+        )
+        self.assertEqual(found, [".github/workflows/ci.yml"])
+
+
+class RepositoryTests(unittest.TestCase):
+    def test_repository_is_clean(self) -> None:
+        # Under Buck this test runs from a sandbox holding only the validator,
+        # where a whole-tree scan would find nothing and pass vacuously -- the
+        # exact shape of fail-open this policy exists to prevent. Skip loudly
+        # instead; the authoritative scan is the `fmt` job's CI step.
+        root = SCRIPT.resolve().parent.parent
+        if not (root / "AGENTS.md").exists():
+            self.skipTest("not a repository checkout; scan runs as a CI step")
+        findings, _ = policy.validate(root)
+        self.assertEqual([str(finding) for finding in findings], [])
+
+
+class MechanismTests(unittest.TestCase):
+    """The failures this policy exists to prevent, demonstrated end to end.
+
+    These need a Bash 3.2 to demonstrate anything, so they run on macOS and
+    skip elsewhere. That is why ci.yml runs this target on the macos-15 leg of
+    native-platforms: premerge alone would leave the demonstrations skipped on
+    every runner, which is a test that cannot fail.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        version = baseline_bash_version()
+        if version is None or version >= 4:
+            raise unittest.SkipTest(
+                f"/bin/bash is {version}.x, not the 3.2 baseline these demonstrate"
+            )
+
+    def run_bash(self, body: str) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            script = Path(directory) / "probe.sh"
+            script.write_text(
+                "#!/usr/bin/env bash\nset -euo pipefail\n" + textwrap.dedent(body)
+            )
+            # `cwd` matters: these probes write scratch input files, and
+            # without it they land in the caller's working directory.
+            return subprocess.run(
+                [BASELINE_BASH, str(script)],
+                cwd=directory,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+    def test_mapfile_is_a_command_not_found(self) -> None:
+        result = self.run_bash('printf "a\\n" >f\nmapfile -t a <f\necho "${a[0]}"\n')
+        self.assertEqual(result.returncode, 127)
+        self.assertIn("mapfile: command not found", result.stderr)
+
+    def test_the_portable_read_loop_reads_the_same_lines(self) -> None:
+        result = self.run_bash(
+            """
+            printf 'x\\ny' >f
+            a=()
+            while :; do
+                line=""
+                IFS= read -r line || [[ -n "$line" ]] || break
+                a+=("$line")
+            done <f
+            echo "${#a[@]}:${a[*]}"
+            """
+        )
+        self.assertEqual(result.stdout.strip(), "2:x y")
+
+    def test_empty_array_expansion_is_unbound_under_set_u(self) -> None:
+        # The second Bash 3.2 hazard, which no scanner can see: this is why the
+        # narrowing keeps its full-pattern fallback until the list is non-empty.
+        result = self.run_bash('a=()\necho "${a[@]}"\n')
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unbound variable", result.stderr)
+
+    def test_read_assigns_nothing_when_it_fails(self) -> None:
+        # The third: `read` clears its variable at EOF but leaves it untouched
+        # on an error, so `read x || [[ -n "$x" ]]` needs `x` cleared first --
+        # otherwise it is either unbound or the previous line, read twice.
+        result = self.run_bash(
+            'v=preset\nread -r v <. 2>/dev/null || true\necho "[$v]"\n'
+        )
+        self.assertEqual(result.stdout.strip(), "[preset]")
+
+
+class HostTests(unittest.TestCase):
+    def test_a_mac_always_has_the_baseline_interpreter(self) -> None:
+        # Guards the skip above: on a macOS host the demonstrations MUST run,
+        # so a silently-skipping suite cannot become the normal state there.
+        if platform.system() != "Darwin":
+            self.skipTest("not macOS")
+        self.assertEqual(baseline_bash_version(), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-validate-shell-pipefail-pipelines.py
+++ b/scripts/test-validate-shell-pipefail-pipelines.py
@@ -102,6 +102,20 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(scanned, [])
         self.assertEqual(findings, [])
 
+    def test_skips_nested_checkouts(self) -> None:
+        # A sibling worktree carries its own copy of every script, and the
+        # working agreement puts those under `.claude/worktrees/` -- inside the
+        # tree this gate walks (RUE-1506).
+        scanned, findings = self.discover(
+            {
+                ".claude/worktrees/other/.git": "gitdir: elsewhere\n",
+                ".claude/worktrees/other/probe.sh": self.BAD,
+                ".claude/hooks/guard.sh": "#!/usr/bin/env bash\ntrue\n",
+            }
+        )
+        self.assertEqual(scanned, [".claude/hooks/guard.sh"])
+        self.assertEqual(findings, [])
+
     def test_finds_extensionless_scripts_by_shebang(self) -> None:
         scanned, findings = self.discover({"scripts/tool": self.BAD})
         self.assertEqual(scanned, ["scripts/tool"])
@@ -119,7 +133,10 @@ class RepositoryTests(unittest.TestCase):
         # exact shape of fail-open this policy exists to prevent. Skip loudly
         # instead; the authoritative scan is the `fmt` job's CI step.
         root = SCRIPT.resolve().parent.parent
-        if not (root / "clippy.sh").exists():
+        # `clippy.sh` used to be the sentinel; it was deleted, so this test
+        # skipped in real checkouts too and stopped scanning anything at all
+        # (RUE-1506). AGENTS.md is the repository's own canonical file.
+        if not (root / "AGENTS.md").exists():
             self.skipTest("not a repository checkout; scan runs as a CI step")
         findings = policy.validate(root)
         self.assertEqual([str(finding) for finding in findings], [])

--- a/scripts/validate-shell-bash-baseline.py
+++ b/scripts/validate-shell-bash-baseline.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""Ban Bash 4+ constructs in shell that runs on macOS's Bash 3.2.
+
+macOS ships GNU Bash 3.2.57 as `/bin/bash` and has since 2007, because Bash 4
+is GPLv3. `#!/usr/bin/env bash` resolves to it on a stock Mac, and a GitHub
+`macos-*` runner's default step shell is that same interpreter. A Bash 4
+builtin is therefore not a portability nicety here: it is `command not found`,
+exit 127, before the script does any of its work -- or, worse, a construct like
+`${v:1:-1}` that Bash 3.2 parses and answers WRONGLY.
+
+That is exactly how it has failed, twice. `mapfile -t` in test.sh's narrowing
+path made //:affected-targets-tool-tests fail two premerge checks on every Mac
+while CI stayed green, because the only place that sets RUE_TEST_TARGETS_FILE
+is the Linux premerge job (RUE-1506). The same builtin had already killed every
+narrowed macOS run in ci.yml's native lane. Twice is a policy.
+
+The portable spellings:
+
+    mapfile -t a <f          ->  a=(); while IFS= read -r l || [[ -n "$l" ]]
+                                 do a+=("$l"); done <f
+    declare -A m             ->  parallel arrays, or a `case`
+    "${v^^}" / "${v,,}"      ->  tr '[:lower:]' '[:upper:]'
+    "${v:1:-1}"              ->  "${v:1:$((${#v} - 2))}"
+    case x in a) ;;& b) ;;   ->  repeat the body, or restructure the `case`
+    cmd &>>log               ->  cmd >>log 2>&1
+    "${a[-1]}"               ->  "${a[$((${#a[@]} - 1))]}"
+
+Bash 3.2 has a second trap this scanner cannot see and reviewers must: under
+`set -u`, expanding an EMPTY array as `"${a[@]}"` is an unbound-variable error,
+not an empty list. Keep a fallback in the array or guard on `${#a[@]}`, which
+is always safe. `read` is a third: it assigns nothing when it FAILS, as against
+reaching EOF, so `read x || [[ -n "$x" ]]` needs `x` cleared before each read.
+
+WHAT IS SCANNED. Files carrying a bash shebang, and the `run:` steps of any
+workflow job that can land on a macOS runner -- that job is where this bug was
+first reported, so excluding workflow YAML wholesale would leave the original
+crime scene unguarded. A `run:` step in a `ubuntu-*` job is NOT scanned: it
+executes on Bash 5 and `mapfile` there is correct, which is why ci.yml's fmt
+job may use the builtin sixteen lines above the step that runs this gate. A
+`#!/bin/sh` script is a different policy (POSIX, not a Bash version).
+
+Annotate a reviewed exception with `# bash-baseline-ok: <reason>`. It has to
+sit in a real comment -- inside a string it is text, not an annotation -- and
+it silences its whole line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Build outputs and vendored trees are not ours to police, and `buck-out` in
+# particular makes the scan's cost and result depend on whether a build has run.
+SKIP_DIRECTORIES = {
+    ".buckd",
+    ".git",
+    ".jj",
+    "buck-out",
+    "buck2-bin",
+    "node_modules",
+    "target",
+    "third-party",
+}
+
+# `#!/usr/bin/env bash`, `#!/bin/bash`, `#!/usr/bin/env -S bash -eu`.
+BASH_SHEBANG = re.compile(r"^#!\s*\S*(?:\s+-\S+)*\s*(?:\S*/)?bash\b|^#!\S*/bash\b")
+
+ALLOW = re.compile(r"#\s*bash-baseline-ok:\s*(?P<reason>\S.*?)\s*$")
+
+# A parameter name, including the positional and special parameters: `${1^^}`
+# and `${@Q}` are as unavailable on 3.2 as `${name^^}` is.
+NAME = r"(?:[A-Za-z_]\w*|\d+|[@*#?$!-])"
+
+
+class Rule(NamedTuple):
+    pattern: re.Pattern[str]
+    since: str
+    construct: str
+    fix: str
+    # An expansion still fires inside an unquoted heredoc body, where the shell
+    # expands but does not execute. A command does not.
+    expansion: bool = False
+    # A construct that lives inside a quoted string -- a `printf` format -- and
+    # so has to be matched before literal text is blanked out.
+    quoted: bool = False
+
+
+# Only constructs whose introducing version is unambiguous. A rule that has to
+# hedge would be answered with an annotation rather than a fix, which teaches
+# reviewers to ignore the gate.
+RULES = (
+    Rule(
+        re.compile(r"(?<![\w./-])(?:mapfile|readarray)(?![\w-])"),
+        "4.0",
+        "the `mapfile`/`readarray` builtin",
+        'read the lines with `while IFS= read -r line || [[ -n "$line" ]]`',
+    ),
+    Rule(
+        re.compile(r"(?<![\w-])(?:declare|typeset|local|readonly)\s+-[A-Za-z]*A[A-Za-z]*(?![\w-])"),
+        "4.0",
+        "an associative array",
+        "use parallel indexed arrays or a `case`",
+    ),
+    Rule(
+        re.compile(r"\$\{[!#]?" + NAME + r"(?:\[[^]]*\])?(?:\^\^?|,,?)"),
+        "4.0",
+        "`${var^^}`/`${var,,}` case modification",
+        "pipe through `tr '[:lower:]' '[:upper:]'`",
+        expansion=True,
+    ),
+    Rule(
+        # `;;&` resumes matching, `;&` falls through. Both are a SYNTAX error on
+        # 3.2, so the script dies at parse time rather than at the branch.
+        re.compile(r";;?&(?!&)"),
+        "4.0",
+        "a `;;&`/`;&` case terminator",
+        "repeat the body, or restructure the `case`",
+    ),
+    Rule(
+        re.compile(r"&>>"),
+        "4.0",
+        "the `&>>` append redirection",
+        "write `>>file 2>&1`",
+    ),
+    Rule(
+        re.compile(r"(?<![\w-])coproc(?![\w-])"),
+        "4.0",
+        "the `coproc` keyword",
+        "use explicit FIFOs or a background job",
+    ),
+    Rule(
+        re.compile(r"(?<![\w-])shopt\s+-[a-z]*s\b[^\n]*(?<![\w-])(?:globstar|lastpipe)(?![\w-])"),
+        "4.0",
+        "a `shopt` option newer than the baseline",
+        "use `find`, or restructure the pipeline",
+    ),
+    Rule(
+        # Integer `-t` is ancient; a fractional timeout is 4.0.
+        re.compile(r"(?<![\w-])read\s+(?:-\S+\s+)*-t\s*\d*\.\d"),
+        "4.0",
+        "a fractional `read -t` timeout",
+        "round the timeout to whole seconds",
+    ),
+    Rule(
+        re.compile(r"(?<![\w-])exec\s+[^#\n]*(?<![$])\{[A-Za-z_]\w*\}\s*[<>]"),
+        "4.1",
+        "a `{fd}` automatic file-descriptor assignment",
+        "name the descriptor explicitly (`exec 3>...`)",
+    ),
+    Rule(
+        # `${v:off:-len}`. A negative OFFSET (`${v: -3}`) is fine on 3.2; a
+        # negative LENGTH is 4.2, and 3.2 answers it as empty rather than
+        # failing -- a wrong answer, not a crash.
+        re.compile(
+            r"\$\{[!#]?" + NAME + r"(?:\[[^]]*\])?:\s*(?![-=?+])[^:{}]*:\s*-\s*\d"
+        ),
+        "4.2",
+        "a negative substring length",
+        "compute the length: `${v:1:$((${#v} - 2))}`",
+        expansion=True,
+    ),
+    Rule(
+        re.compile(r"\$\{[!#]?[A-Za-z_]\w*\[\s*-\s*\d"),
+        "4.2",
+        "a negative array subscript",
+        'index from the length: `"${a[$((${#a[@]} - 1))]}"`',
+        expansion=True,
+    ),
+    Rule(
+        re.compile(r"(?<![\w-])[A-Za-z_]\w*\[\s*-\s*\d+\s*\]\s*="),
+        "4.2",
+        "a negative array subscript",
+        "index from the length",
+    ),
+    Rule(
+        # `[[ -v x ]]`, `[ -v x ]`, `[[ ! -v x ]]`. A bare `test -v` is left to
+        # review: `./buck2 test -v ...` is the far more common line in this
+        # repository, and a rule that flagged it would be turned off.
+        re.compile(r"\[\[?\s+(?:!\s+)?-v\s"),
+        "4.2",
+        "the `-v` set-variable test",
+        'test `[[ -n "${var+set}" ]]`',
+    ),
+    Rule(
+        re.compile(r"(?<![\w-])(?:declare|typeset)\s+-[A-Za-z]*g[A-Za-z]*(?![\w-])"),
+        "4.2",
+        "a `declare -g` global declaration",
+        "assign at the top level, or drop the declaration",
+    ),
+    Rule(
+        re.compile(r"%\([^)]*\)T"),
+        "4.2",
+        "a `printf '%(fmt)T'` time format",
+        "call `date`",
+        quoted=True,
+    ),
+    Rule(
+        re.compile(r"(?<![\w-])(?:declare|typeset|local)\s+-[A-Za-z]*n[A-Za-z]*(?![\w-])"),
+        "4.3",
+        "a nameref declaration",
+        "pass the value, or use indirect `${!name}` expansion",
+    ),
+    Rule(
+        re.compile(r"(?<![\w-])wait\s+-n(?![\w-])"),
+        "4.3",
+        "`wait -n`",
+        "wait on recorded PIDs individually",
+    ),
+    Rule(
+        re.compile(r"\$\{[!#]?" + NAME + r"(?:\[[^]]*\])?@[QEPAKaLUu]\}"),
+        "4.4",
+        "a `${var@X}` parameter transformation",
+        "use `printf %q` or an explicit expansion",
+        expansion=True,
+    ),
+    Rule(
+        re.compile(r"(?<![\w-])EPOCH(?:SECONDS|REALTIME)(?![\w-])"),
+        "5.0",
+        "the `EPOCHSECONDS`/`EPOCHREALTIME` variable",
+        "call `date +%s`",
+        expansion=True,
+    ),
+)
+
+# `<<WORD`, `<<-WORD`, `<<'WORD'`. Not `<<<`, which is a herestring.
+HEREDOC = re.compile(r"<<(?!<)(-?)\s*(['\"]?)([A-Za-z_]\w*)\2")
+
+
+class Finding(NamedTuple):
+    path: str
+    line: int
+    rule: Rule
+
+    def __str__(self) -> str:
+        return (
+            f"{self.path}:{self.line}: {self.rule.construct} needs Bash "
+            f"{self.rule.since}; macOS runs this with Bash 3.2, where it fails. "
+            f"Instead, {self.rule.fix} -- or annotate with "
+            "`# bash-baseline-ok: <reason>`"
+        )
+
+
+def split_code(line: str) -> tuple[str, str]:
+    """Return the line's executable text and its trailing comment.
+
+    Literal text is blanked out, because a construct named in a string is not
+    a construct: `die "readarray unavailable"` is a fine Bash 3.2 line, and so
+    is this policy's own prose. An expansion or command substitution INSIDE a
+    double-quoted string is code again -- `"${v^^}"` is how case modification
+    is almost always written -- so quoting is tracked as a stack rather than a
+    flag. A `#` only opens a comment in code context, never inside `${v#pat}`.
+    """
+    code: list[str] = []
+    stack: list[str] = []
+    index = 0
+    while index < len(line):
+        character = line[index]
+        top = stack[-1] if stack else ""
+        literal = top in ("'", '"')
+        if top == "'":
+            code.append(" ")
+            if character == "'":
+                stack.pop()
+            index += 1
+            continue
+        if character == "\\":
+            code.append(" " if literal else character)
+            if index + 1 < len(line):
+                code.append(" " if literal else line[index + 1])
+            index += 2
+            continue
+        if literal and character == "$":
+            # A plain `$NAME` inside double quotes is an expansion, not text.
+            name = re.match(r"\$(?:[A-Za-z_]\w*|[0-9@*#?!])", line[index:])
+            if name:
+                code.append(name.group(0))
+                index += len(name.group(0))
+                continue
+        if line[index : index + 2] in ("$(", "${"):
+            stack.append(")" if line[index + 1] == "(" else "}")
+            code.append(line[index : index + 2])
+            index += 2
+            continue
+        if top in (")", "}") and character == top:
+            stack.pop()
+            code.append(character)
+            index += 1
+            continue
+        if character in "'\"":
+            if character == top:
+                stack.pop()
+            else:
+                stack.append(character)
+            code.append(" ")
+            index += 1
+            continue
+        if not stack and character == "#" and (index == 0 or line[index - 1].isspace()):
+            return "".join(code), line[index:]
+        code.append(" " if literal else character)
+        index += 1
+    return "".join(code), ""
+
+
+def scan(source: str, path: str) -> list[Finding]:
+    """Findings in one shell script."""
+    findings: list[Finding] = []
+    # A heredoc body is data, not code, so `mapfile` inside one is a string.
+    # An UNQUOTED delimiter still expands, though, so `${v^^}` in that body is
+    # a real 3.2 failure and the expansion rules stay live.
+    terminator = ""
+    expands = False
+    for number, raw in enumerate(source.splitlines(), start=1):
+        if terminator:
+            if raw.strip() == terminator:
+                terminator = ""
+            elif expands:
+                findings.extend(
+                    Finding(path, number, rule)
+                    for rule in RULES
+                    if rule.expansion and rule.pattern.search(raw)
+                )
+            continue
+        code, comment = split_code(raw)
+        # The delimiter is matched on the raw line -- `<<'EOF'` quotes it, so
+        # the blanked code holds only `<<` -- but only once the code says a
+        # redirection is there at all, so a `<<EOF` inside a string or comment
+        # cannot swallow the lines that follow it.
+        heredoc = HEREDOC.search(raw) if "<<" in code else None
+        if heredoc:
+            terminator = heredoc.group(3)
+            expands = heredoc.group(2) == ""
+        if ALLOW.search(comment):
+            continue
+        # A `quoted` rule matches the line with only its comment removed: a
+        # `printf '%(%F)T'` format is inside a string by construction, so the
+        # blanked code would never show it.
+        uncommented = raw[: len(raw) - len(comment)] if comment else raw
+        findings.extend(
+            Finding(path, number, rule)
+            for rule in RULES
+            if rule.pattern.search(uncommented if rule.quoted else code)
+        )
+    return findings
+
+
+def macos_runner_jobs(source: str) -> list[tuple[int, int]]:
+    """Line ranges of workflow jobs that can execute on a macOS runner.
+
+    Determining that is the "per-job runner analysis" a whole-file scan would
+    need, and in this repository it is a literal `os:` key: jobs either name
+    their runner or take it from a matrix that lists one per entry.
+    """
+    lines = source.splitlines()
+    jobs: list[tuple[int, int]] = []
+    start = None
+    in_jobs = False
+    for index, line in enumerate(lines):
+        if re.match(r"^jobs:\s*$", line):
+            in_jobs = True
+            continue
+        top_level = bool(line) and not line[0].isspace() and not line.startswith("#")
+        header = bool(re.match(r"^  [A-Za-z0-9_-]+:\s*$", line))
+        if start is not None and (header or top_level):
+            jobs.append((start, index))
+            start = None
+        if top_level:
+            in_jobs = False
+        if in_jobs and header:
+            start = index
+    if start is not None:
+        jobs.append((start, len(lines)))
+
+    macos: list[tuple[int, int]] = []
+    for begin, end in jobs:
+        body = "\n".join(lines[begin:end])
+        runners = re.findall(r"^\s*(?:- )?(?:runs-on|os):\s*(\S+)", body, re.MULTILINE)
+        if any("macos" in runner for runner in runners):
+            macos.append((begin, end))
+    return macos
+
+
+def scan_workflow(source: str, path: str) -> list[Finding]:
+    """Findings in the `run:` steps of a workflow's macOS-capable jobs.
+
+    A GitHub `run:` step with no `shell:` key runs under `bash -e {0}`, which
+    on a `macos-*` image is /bin/bash -- 3.2. That is the interpreter that
+    killed the native lane's narrowed run, so these steps are held to the same
+    baseline as a checked-in script.
+    """
+    lines = source.splitlines()
+    findings: list[Finding] = []
+    for begin, end in macos_runner_jobs(source):
+        index = begin
+        while index < end:
+            match = re.match(r"^(\s+)run:\s*(.*)$", lines[index])
+            if not match:
+                index += 1
+                continue
+            indent, inline = match.group(1), match.group(2).strip()
+            body: list[tuple[int, str]] = []
+            if inline in ("|", "|-", "|+", ">", ">-", ">+"):
+                index += 1
+                while index < end:
+                    line = lines[index]
+                    if line.strip() and not line.startswith(indent + " "):
+                        break
+                    body.append((index + 1, line))
+                    index += 1
+            else:
+                body.append((index + 1, inline))
+                index += 1
+            step = "\n".join(text for _, text in body)
+            for finding in scan(step, path):
+                findings.append(Finding(path, body[finding.line - 1][0], finding.rule))
+    return findings
+
+
+def _prune(directory: Path, names: list[str]) -> list[str]:
+    """Directory names to descend into.
+
+    Nested checkouts are pruned by their own VCS marker rather than by name:
+    the working agreement puts sibling worktrees under `.claude/worktrees/`,
+    and reporting `.claude/worktrees/rue-1265/test.sh` as though it were a path
+    in THIS tree is worse than not scanning it -- that copy has its own gate.
+    """
+    kept = []
+    for name in sorted(names):
+        if name in SKIP_DIRECTORIES:
+            continue
+        path = directory / name
+        if (path / ".git").exists() or (path / ".jj").exists():
+            continue
+        kept.append(name)
+    return kept
+
+
+def sources(root: Path) -> tuple[list[Path], list[Path]]:
+    """Every bash script and workflow file under `root`."""
+    scripts: list[Path] = []
+    workflows: list[Path] = []
+    for directory, names, files in os.walk(root):
+        here = Path(directory)
+        names[:] = _prune(here, names)
+        for name in sorted(files):
+            path = here / name
+            if path.is_symlink() or not path.is_file():
+                continue
+            if path.suffix in (".yml", ".yaml") and (
+                here.name == "workflows" and here.parent.name == ".github"
+            ):
+                workflows.append(path)
+                continue
+            if path.suffix and path.suffix != ".sh":
+                continue
+            try:
+                with path.open("r", encoding="utf-8", errors="strict") as handle:
+                    first = handle.readline()
+            except (OSError, UnicodeDecodeError):
+                continue
+            # Unlike the pipefail policy, the shebang is the whole question: it
+            # decides which bash runs the file, so a `.sh` without one is not
+            # this gate's business.
+            if BASH_SHEBANG.match(first):
+                scripts.append(path)
+    return sorted(scripts), sorted(workflows)
+
+
+def validate(root: Path) -> tuple[list[Finding], int]:
+    findings: list[Finding] = []
+    scripts, workflows = sources(root)
+    for path in scripts:
+        relative = path.relative_to(root).as_posix()
+        findings.extend(scan(path.read_text(encoding="utf-8"), relative))
+    for path in workflows:
+        relative = path.relative_to(root).as_posix()
+        findings.extend(scan_workflow(path.read_text(encoding="utf-8"), relative))
+    return findings, len(scripts) + len(workflows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", nargs="?", type=Path, default=ROOT)
+    args = parser.parse_args()
+
+    findings, scanned = validate(args.root)
+    if findings:
+        for finding in findings:
+            print(f"error: {finding}", file=sys.stderr)
+        return 1
+
+    print(f"bash baseline policy valid: {scanned} file(s) scanned")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate-shell-pipefail-pipelines.py
+++ b/scripts/validate-shell-pipefail-pipelines.py
@@ -152,7 +152,18 @@ def shell_scripts(root: Path) -> list[Path]:
     # Prune while walking rather than filtering afterwards: `buck-out` alone
     # holds enough build output to dominate the gate's runtime.
     for directory, names, files in os.walk(root):
-        names[:] = sorted(name for name in names if name not in SKIP_DIRECTORIES)
+        # Nested checkouts are pruned by their own VCS marker as well as by
+        # name: the working agreement puts sibling worktrees under
+        # `.claude/worktrees/`, and reporting a finding there as though it were
+        # a path in THIS tree is worse than not scanning it -- that copy runs
+        # its own gate (RUE-1506).
+        names[:] = sorted(
+            name
+            for name in names
+            if name not in SKIP_DIRECTORIES
+            and not (Path(directory) / name / ".git").exists()
+            and not (Path(directory) / name / ".jj").exists()
+        )
         for name in sorted(files):
             path = Path(directory) / name
             if path.is_symlink() or not path.is_file():

--- a/test.sh
+++ b/test.sh
@@ -126,13 +126,49 @@ if [[ $# -eq 0 ]]; then
     local_targets=(//... toolchains//...)
     narrow_file="${RUE_TEST_TARGETS_FILE:-}"
     if [[ -n "$narrow_file" ]]; then
-        if [[ ! -r "$narrow_file" ]]; then
+        # A directory passes both -r and -s, and `read` fails on it without
+        # assigning, so it is classified as unreadable here rather than left to
+        # crash the loop below.
+        if [[ ! -r "$narrow_file" || -d "$narrow_file" ]]; then
             echo "test.sh: RUE_TEST_TARGETS_FILE='$narrow_file' is unreadable; running the full pattern" >&2
         elif [[ ! -s "$narrow_file" ]]; then
             echo "test.sh: no narrowed target list supplied; running the full pattern"
         else
-            mapfile -t local_targets <"$narrow_file"
-            echo "test.sh: narrowed to ${#local_targets[@]} impacted target(s) by the affected-targets determinator"
+            # Read with `while read`, not `mapfile`: macOS ships Bash 3.2 as
+            # /bin/bash, which has no `mapfile` builtin, so a narrowed run on a
+            # developer machine died with exit 127 before it tested anything
+            # (RUE-1506); ci.yml's native-units lane hit the same builtin first.
+            # `|| [[ -n ]]` keeps a final line that carries no newline.
+            #
+            # Bash 3.2 also treats `"${empty[@]}"` as an unbound variable under
+            # `set -u`, so build the list in its own array and leave the full
+            # pattern in place unless it ends up non-empty.
+            #
+            # Blank and whitespace-only lines are dropped rather than passed on
+            # as arguments: the producer strips empty lines already (ci.yml's
+            # `sed '/^$/d'`) but not whitespace-only ones, and a `buck2 test "
+            # "` argument is a confusing failure, not a narrowing. A list that
+            # holds nothing else therefore reaches the same fail-open fallback
+            # an empty file does. This is the one place the fix does not match
+            # `mapfile -t`, which would have kept those lines.
+            narrowed=()
+            while :; do
+                # Cleared before each read, not once before the loop: `read`
+                # assigns nothing when it FAILS (as against reaching EOF, which
+                # empties the variable), so the `-n` fallback would otherwise
+                # see either an unset variable — `set -u`, exit 1 — or the
+                # previous line, and append it twice.
+                narrowed_target=""
+                IFS= read -r narrowed_target || [[ -n "$narrowed_target" ]] || break
+                [[ "$narrowed_target" =~ [^[:space:]] ]] || continue
+                narrowed+=("$narrowed_target")
+            done <"$narrow_file"
+            if [[ ${#narrowed[@]} -eq 0 ]]; then
+                echo "test.sh: no narrowed target list supplied; running the full pattern"
+            else
+                local_targets=("${narrowed[@]}")
+                echo "test.sh: narrowed to ${#local_targets[@]} impacted target(s) by the affected-targets determinator"
+            fi
         fi
     fi
 


### PR DESCRIPTION
`test.sh`'s RUE-1130 narrowing path used `mapfile`, a Bash 4+ builtin. macOS ships Bash 3.2.57 as `/bin/bash`, so on any Mac the one input that is supposed to narrow was the only one that killed the run:

```
./test.sh: line 134: mapfile: command not found
=== TEST SUITE: FAILED (exit 127) ===
```

`//:affected-targets-tool-tests` carries `rue_test_tier_premerge`, so the premerge suite was broken for every macOS developer while CI stayed green — `RUE_TEST_TARGETS_FILE` is set in exactly one place, the Linux-only `linux-premerge` job.

The repo had already hit this and fixed it in one place only: `ci.yml`'s native-lane narrowing carries the scar ("exit 127 killed every narrowed macOS run"). `test.sh` never got the same treatment.

## The fix

A read loop, with two Bash 3.2 hazards handled. `read` leaves its variable at the *previous* value on error — not empty — so the variable is cleared before each read rather than once before the loop, which would have duplicated the final line. A directory passes both `-r` and `-s`, so it is classified as unreadable up front where the contract already has a message, instead of reaching the loop and dying on `set -u`.

Lines that are blank or whitespace-only are dropped, and a list of nothing else falls back to the full pattern. That is deliberate drift from `mapfile -t`, which would have produced empty arguments to `buck2`. It is unreachable in production anyway — the producer at `ci.yml:296` pipes through `sed '/^$/d'` — but `sed` does not strip whitespace-only lines, which is the half that was live.

The documented fail-open contract now holds for every input: unset, unreadable, empty, whitespace-only, and a directory all run the full pattern.

## Keeping it fixed

Four `check_narrow` cases (92 checks, was 88) cover blank lines, whitespace-only, an unterminated final line, and the directory case. Three of the four fail against `mapfile -t` semantics, so they discriminate rather than merely pass.

`scripts/validate-shell-bash-baseline.py` flags Bash 4+ constructs in bash-shebang files, modeled on the existing pipefail policy gate, with `# bash-baseline-ok: <reason>` for reviewed exceptions. It covers the constructs that fail hardest — `;;&` is a Bash 4.0 *syntax* error and `${v:1:-1}` silently returns the wrong answer. Parsing is quote- and heredoc-aware so string literals mentioning `mapfile` do not flag.

It also scans workflow `run:` steps **for jobs that can reach a macOS runner**, resolving `runs-on:` and matrix `os:` values — on this repo, exactly `native-platforms`. That is where the original bug lived. The `fmt` job's `mapfile` on `ubuntu-latest` is correctly left alone.

Its mechanism tests run in the `native-platforms` macOS lane, the only lane whose `/bin/bash` is 3.2, with a host assertion so a macOS run cannot silently skip them.

Two incidental fixes: both validators now prune nested checkouts by VCS marker, so a sibling worktree's files are not reported as repo-relative; and the pipefail policy's `test_repository_is_clean` was gated on a `clippy.sh` deleted some time ago, so it had been skipping and scanning nothing — re-pointed at `AGENTS.md`.

Closes RUE-1506.