### PR TITLE
RUE-1265: fail CI when one test is scheduled twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,6 +327,22 @@ jobs:
             echo "no impacted //crates/... targets; this step has nothing to build"
           fi
 
+      # ADR-0069 §2 / RUE-1265. Every other gate compares target lists; this one
+      # compares test *contents*, so a target that is a strict superset of
+      # another fails here instead of quietly costing a lane 223s (RUE-1262).
+      #
+      # It runs only when the lane is not narrowed, and that is the whole cost
+      # argument: on a full or merge-group run every test binary is already
+      # built by the step above, so the gate pays only its `--list` invocations
+      # — 0.29s wall for 73 of them. On a narrowed peripheral run it would have
+      # to build the unimpacted binaries itself, which is exactly the cost
+      # RUE-1130's narrowing exists to avoid, and the property is a fact about
+      # the graph rather than about the diff — so the authoritative merge_group
+      # run is the right place to prove it.
+      - name: Check nothing executes twice
+        if: steps.narrow.outputs.count == '0'
+        run: scripts/ci-timed "duplication gate" -- scripts/validate-test-duplication.py
+
       - name: Run complete target-independent premerge suite
         # RUE-1163: the corpora with their own platform-corpus job carry the
         # `rue_ci_dedicated_lane` label in BUCK, and test.sh subtracts that label

--- a/BUCK
+++ b/BUCK
@@ -892,6 +892,28 @@ rue_sh_test(
     },
 )
 
+# RUE-1265 / ADR-0069 §2. The duplication gate itself needs the live Buck graph
+# and every test binary, so it runs as a step in the premerge lane rather than
+# as a target inside the graph it interrogates. What belongs here is its
+# decision logic, pinned the way //:cli-shard-coverage-tool-tests pins the
+# shard gate: the RUE-1262 superset shape is checked in as a fixture, and the
+# gate must fail on it and name both owning targets.
+#
+# `scripts/affected-targets` is a declared resource because the gate reads its
+# corpus and lane inventories rather than keeping a second copy — a lane added
+# there must be classified here or the gate refuses to run.
+rue_sh_test(
+    name = "test-duplication-tool-tests",
+    test = "scripts/test-validate-test-duplication.py",
+    resources = [
+        "scripts/affected-targets",
+        "scripts/validate-test-duplication.py",
+    ],
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+    },
+)
+
 # RUE-1117: the declared inputs of the tier CI-selector gate. The tier
 # vocabulary and every workflow that is registered as deliberately selecting a
 # tier are inputs, so an edit to any of them re-runs the gate.
@@ -964,6 +986,10 @@ rue_sh_test(
     resources = [
         "scripts/ci-required-results.py",
         "scripts/run-native-platform-corpus.sh",
+        # RUE-1265: NATIVE_CLI_FILTERS is imported from here, so the two gates
+        # cannot disagree about which `scripts/rue cli` steps the native lanes
+        # run.
+        "scripts/validate-test-duplication.py",
     ],
 )
 
@@ -1038,6 +1064,7 @@ rue_sh_test(
         "scripts/ci-required-results.py",
         "scripts/run-native-platform-corpus.sh",
         "scripts/validate-ci-gate.py",
+        "scripts/validate-test-duplication.py",
     ],
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",

--- a/docs/designs/0069-ci-work-scheduling.md
+++ b/docs/designs/0069-ci-work-scheduling.md
@@ -9,7 +9,7 @@ accepted: 2026-08-09
 implemented:
 spec-sections: []
 superseded-by:
-relates: ["RUE-1250", "RUE-1262", "RUE-1164", "RUE-1130", "RUE-1131", "RUE-1222", "RUE-1116", "RUE-1118", "RUE-1119", "RUE-1157", "RUE-1163"]
+relates: ["RUE-1250", "RUE-1262", "RUE-1265", "RUE-1164", "RUE-1130", "RUE-1131", "RUE-1222", "RUE-1116", "RUE-1118", "RUE-1119", "RUE-1157", "RUE-1163"]
 ---
 
 # ADR-0069: CI work scheduling for a compiler monorepo
@@ -17,7 +17,8 @@ relates: ["RUE-1250", "RUE-1262", "RUE-1164", "RUE-1130", "RUE-1131", "RUE-1222"
 ## Status
 
 Accepted. Phase 2 (determination on every lane, RUE-1130) is implemented in
-the same change that accepted this ADR; the remaining phases are unstarted.
+the same change that accepted this ADR. Phase 1 (RUE-1262) and Phase 3
+(the duplication gate, RUE-1265) have since landed; Phases 4-6 are unstarted.
 
 ## Summary
 
@@ -69,7 +70,10 @@ The finding that motivates this ADR is concentration, not imbalance:
 - Both native lanes are one step, and that step is **99.1%**
   `rue-compiler-test`, contradicting `docs/process/ci.md:46` ("Linux ARM64 and
   macOS ARM64 deliberately do not repeat the broad unit suite") while
-  `scripts/validate-ci-gate.py:204` pins the repetition in place.
+  `scripts/validate-ci-gate.py:204` pins the repetition in place. RUE-1265
+  resolved the contradiction in the only direction available without a coverage
+  ruling: the contract now describes what runs, and names Phase 4 as the work
+  that makes the original claim true again.
 - Inside that target, **one test function is 181.7s** against a 5.7s runner-up.
   It is compiled into two targets and runs on three platforms: **four executions
   per CI run**, together 56–59% of the critical path (RUE-1262).
@@ -228,6 +232,28 @@ binaries — cheap, exact, and how the superset above was found) and fails on an
 test scheduled twice without an explicit allowance. That gate is what converts
 "we fixed this instance" into "this class cannot recur."
 
+**Landed as `scripts/validate-test-duplication.py` (RUE-1265).** Against the
+graph on 2026-08-14 the three violations stand as: the scaling-matrix superset
+is **gone** — RUE-1262 rebuilt that target as an `sh_test` selecting three
+`#[ignore]`d rows out of the one binary, and the gate confirms the two targets
+are now disjoint; the other two are **declared allowances with written
+reasons**, marked provisional because both need a ruling this gate is not
+positioned to make. Measured cost with the binaries already built: 0.29s wall
+for 73 `--list` invocations.
+
+Two things the implementation established that this section did not anticipate.
+**`--list` is not a universal protocol**, and probing for it is not free: two
+corpus harnesses are shell scripts that ignore their arguments and run their
+whole suite, so a gate that asks them to list executes two premerge suites a
+second time — the failure this very section names, caused by its own enforcement.
+Whether a target can be listed is therefore settled from the graph before
+anything runs. And **the largest overlap in the repository is one this gate
+cannot score**: the oracle differentials re-execute the entire CLI and
+specification corpora against the reference interpreter, several thousand cases,
+in the same run on the same platform. That is defensible as a differential and
+is far larger than the `release-smoke` case §2 does name; it is recorded as
+provisional in `NOT_LISTABLE` rather than quietly omitted.
+
 ### 3. Determinate every lane, and say which regime the run is in
 
 Extend `affected-targets` from gating one job to planning every lane, and have it
@@ -369,6 +395,7 @@ from the graph later, or gated so that drift fails closed rather than silently:
 | `RUE_AFFECTED_NARROW_LIMIT` (600) | a threshold nobody revisits | unmeasured; should follow measurement |
 | the platform responsibility matrix | a responsibility silently moves | gated (`validate-ci-gate.py`) |
 | `shard-weights.json` refresh | weights go stale, shards skew | manual (RUE-1222); guard is vacuous (§6) |
+| the duplication gate's `ALLOWANCES` ledger | a duplication outlives its reason | **self-gating** (RUE-1265): an entry matching nothing fails |
 
 The pattern the ledger is meant to enforce: a list that must exist is paired
 with a gate that fails closed, and a list that need not exist is deleted in
@@ -384,7 +411,7 @@ Ordered by measured value, with the packer deliberately last: until the earlier
 phases land it would be optimizing a distribution that is about to change
 completely.
 
-- [ ] **Phase 1: Eliminate the duplicated critical path** — RUE-1262.
+- [x] **Phase 1: Eliminate the duplicated critical path** — RUE-1262.
       56–59% of the critical path, no new machinery, needs one coverage ruling.
 - [x] **Phase 2: Determination on every lane, by gating or by narrowing** —
       RUE-1130, whose "make it discriminate or remove it" question this ADR
@@ -395,8 +422,16 @@ completely.
       impacted closure instead, so an unimpacted test binary is neither built
       nor run. Reporting the saved share per run is still to do, and is what
       turns the change-mix question from an argument into a measurement.
-- [ ] **Phase 3: Duplication gate** — new. Cheap, and it is what stops the class
-      from recurring; lands while the evidence is fresh.
+- [x] **Phase 3: Duplication gate** — RUE-1265.
+      `scripts/validate-test-duplication.py` enumerates each lane from the live
+      graph, collects identities with `--list`, and fails on any test scheduled
+      more than once per platform per run without a declared allowance. It runs
+      as a step in the premerge lane, where the binaries it lists are already
+      built, and costs 0.29s wall. `docs/process/ci.md` now states the invariant
+      — with the scope it actually checks, and a section naming where it cannot
+      see — and no longer claims the native lanes skip the broad unit suite;
+      that repetition is a declared, provisional allowance until Phase 4
+      removes it.
 - [ ] **Phase 4: Platform scope as a target attribute** — new (RUE-1262 scope C).
       Removes the `validate-ci-gate.py:204` pin and the per-test/per-target
       granularity error. Phase 2 already stops peripheral changes from reaching
@@ -458,7 +493,9 @@ same fixed-cost problem this ADR names in the compiler-cold regime.
   lane pays it. Build-once-and-fan-out serializes it ahead of the lanes and
   measures worse; is there a third option (RUE-1131 is adjacent)?
 - Should `release-smoke`'s debug/release double execution be kept? It is
-  defensible coverage that nobody appears to have decided.
+  defensible coverage that nobody appears to have decided. RUE-1265's gate now
+  measures it — 25 differential-opt cases the CLI shards also run — and carries
+  it as a provisional allowance rather than settling it.
 
 ## Future Work
 

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -43,11 +43,34 @@ instead of silently shrinking coverage.
 | macOS ARM64 | The same native responsibilities on Mach-O/macOS, including host-conditional compiler/archive tests, every applicable `only_on` case, native linker/runtime execution, and output publication |
 | Linux cross-backend step | Explicit host-independent x86-64 and AArch64 compilation/encoding unit coverage |
 
-Linux ARM64 and macOS ARM64 deliberately do not repeat the broad unit suite or
-the specification corpus. Backend encoding logic is still tested explicitly
-for both architectures on Linux, while native ARM64 lanes prove the host ABI,
+Linux ARM64 and macOS ARM64 do not repeat the specification corpus. Through
+`scripts/run-native-platform-corpus.sh` they register only the `only_on` cases
+of the manifest-driven corpora — but that is not the whole of what they run
+from those corpora: the three explicit `scripts/rue cli` filters below use the
+developer entry point, which sets neither `RUE_CLI_CASE_TIER` nor
+`RUE_PLATFORM_CASE_SELECTION`, so every case matching `abi`, `cli.linker`, or
+`cli.fs_file_io` runs whatever its tier and whether or not it declares
+`only_on`. `cases/abi.toml` declares none, so those cases do run on all three
+platforms. That is the responsibility matrix working as written, and the
+duplication gate scores it as a declared allowance rather than leaving it to
+this paragraph. Backend encoding logic is still tested explicitly for both
+architectures on Linux, while native ARM64 lanes prove the host ABI,
 object/linker path, runtime archive, syscalls, and platform behavior that
 cross-compilation cannot.
+
+They **do** repeat the broad compiler unit suite, and that is a defect rather
+than the design. This paragraph used to claim otherwise while
+`scripts/validate-ci-gate.py` pinned `//crates/rue-compiler:rue-compiler-test`
+into both native lanes; the two statements contradicted each other for weeks
+because nothing compared them (ADR-0069 "What was measured"). What the native
+lanes want is that binary's ~27 host-conditional sites; what they pay for is
+all 850 of its tests, because platform scope is declared per target while it is
+a property of individual tests. ADR-0069 Phase 4 (RUE-1262 scope C) moves the
+host-conditional tests into their own target — the precedent
+`rue-compiler-public-api-test` already sets in the same crate — and the
+repetition ends there rather than by dropping coverage now. Until then it is a
+declared allowance in the duplication gate below, so the cost stays visible
+and priced.
 
 The native lanes set `RUE_PLATFORM_CASE_SELECTION=native` through
 `scripts/run-native-platform-corpus.sh`. Both manifest-driven harnesses then
@@ -326,6 +349,105 @@ multiple independent times. It uploads per-run logs and a summary, continues
 after a failure only to gather flake evidence, and exits failed if *any*
 repetition failed; a later pass never masks an earlier failure. Required
 correctness jobs do not automatically retry failed cases.
+
+## Nothing executes twice (ADR-0069 §2)
+
+**No test the gate can enumerate executes more than once per platform per run
+without a declared reason.** `scripts/validate-test-duplication.py`
+(`//:test-duplication-tool-tests` pins its logic) is the gate, and it runs as
+the `Check nothing executes twice` step of the `premerge (linux-x64)` job.
+
+The qualifier is load-bearing, and "Where it cannot see" below says exactly
+where it applies. A gate that claimed more than it checks would be the same
+kind of defect it exists to catch.
+
+It exists because every other gate here compares *target lists*.
+`//:cli-shard-coverage-validation` compares BUCK's shards with the matrix,
+`scripts/validate-ci-gate.py` compares jobs with the responsibility matrix, and
+`//test_tiers.bxl:validate` compares tier labels with the test graph — so a
+target that becomes a strict superset of another is invisible to all of them.
+That is how `//crates/rue-compiler:scaling-matrix-test` came to re-run 813 of
+`rue-compiler-test`'s tests, in the same lane, to gain three, for weeks, with
+every check green (RUE-1262).
+
+How it decides:
+
+- **Lane membership is queried, not transcribed.** The premerge lane is
+  `attrfilter(labels, 'rue_test_tier_premerge', set(//... toolchains//...))`
+  minus the `rue_cli_shard` and `rue_ci_dedicated_lane` sets; the corpus and
+  gated-lane inventories come from `scripts/affected-targets corpus-targets`
+  and `lane-targets`, which are the lists CI's determinator already consults.
+  A lane added to `SELECTABLE_LANES` and not classified by the gate fails it,
+  so this adds no unwatched row to ADR-0069's ledger.
+- **Identities come from `--list`.** Each target is listed with the exact args
+  and env its own Buck target carries, so the scaling matrix's
+  `--ignored scaling_matrix` selection lists three tests and the CLI shards
+  list their own slices. `#[ignore]`d tests are subtracted from `rust_test`
+  binaries, because an ignored test is not scheduled work.
+- **Whether a target can be listed is decided before anything runs.** The
+  `--list` protocol is not universal and probing for it is not free:
+  `scripts/test-reproducible-output.sh` and
+  `scripts/oracle-diff-generated-smoke.sh` do no argument handling at all, so
+  handed `--list` they run their entire premerge suite and exit 0. The graph
+  answers instead — only a Rust binary can carry libtest — and a Rust harness
+  that *does* refuse `--list` must be declared in `NOT_LISTABLE` with a reason
+  stating what its opacity hides. An undeclared refusal fails the gate, because
+  the alternative is 850 tests silently collapsing into one opaque unit under a
+  green check.
+- **Allowances are declared with a reason** in the script's `ALLOWANCES`
+  ledger. An entry is either `per-target` — a roster of targets that each
+  repeat across the named platforms on their own — or `between-targets`, an
+  exact set that overlaps. Nothing matches by subset in either direction, so a
+  roster cannot vouch for a *new* overlap between two of its own members, and a
+  two-target entry cannot absorb a duplication between two CLI shards.
+  Rosters go stale per target, not per entry. Absence never implies permission.
+
+Five duplications are declared today. The native lanes' repetition of the eight
+platform unit targets, and their `scripts/rue cli abi|cli.linker|cli.fs_file_io`
+steps re-running cases the CLI shards run, are both the platform responsibility
+matrix doing its job. Three are provisional and await a maintainer ruling:
+`rue-compiler-test`'s whole suite on three platforms (above); `//:release-smoke`
+running its 25 differential-opt cases three times on linux-x64 — once in the
+shards under `//platforms:debug`, once in the `release` job under
+`//platforms:release`, and once more inside `linux-premerge`, which carries no
+release configuration and looks like an oversight; and the single case that
+falls in the intersection of those two.
+
+Cost, measured on a 4-core-class host with the binaries already built: **0.29s
+wall for 73 `--list` invocations**, 1.6s of process time run concurrently. The
+gate materializes only what a listing consults, which deliberately excludes
+`RUE_CLI_STAGED_PROGRAMS`: `//:cli-staged-programs` stages ten `rue_program`
+compiles that discovery never reads, the premerge lane does not otherwise build
+it, and the shards that do consume it run on other runners. The step is skipped
+on a narrowed pull-request run, where it would have to build unimpacted test
+binaries and spend the wall time RUE-1130's narrowing exists to save;
+duplication is a property of the graph rather than of the diff, and the
+authoritative merge-group run always evaluates it.
+
+### Where it cannot see
+
+Every run prints an `opaque:` line counting the units whose contents the
+comparison cannot reach, so a passing log says how much of the graph the
+verdict covers. Three groups:
+
+- **The manifest-driven corpora on the native lanes.** Those lanes register the
+  `only_on` cases for their own host, which a linux-x64 gate cannot enumerate.
+  The RUE-1161 platform responsibility gate covers that surface instead.
+- **Harnesses that are not libtest.** `//:reproducible-programs`,
+  `//:oracle-diff-generated-smoke`, `//:frontend-diff-test`, and
+  `//:spec-traceability` each count as one unit.
+- **The oracle differentials**, and this is the largest known gap:
+  `//crates/rue-oracle-diff:oracle-diff-test` and `:oracle-diff-spec-test` drive
+  every runnable CLI and specification case through the reference interpreter
+  and compare it against the compiler, so they re-execute the same ~1,858- and
+  ~2,100-case corpora that the CLI shards and `//:spec-tests` run in the same
+  run on the same platform. That is far larger than the 25-case release-smoke
+  overlap the ledger does score. It is a differential rather than a repetition
+  — the assertion is agreement between two implementations, which no single
+  execution can make — but nobody has priced it, and the gate cannot, because
+  the harness owns its own argument grammar. Making it listable would move it
+  from this list into `ALLOWANCES`, where a written reason would have to stand
+  up. Recorded in `NOT_LISTABLE` as provisional in the meantime.
 
 ## Affected-corpus selection on pull requests (RUE-1119)
 

--- a/scripts/affected-targets
+++ b/scripts/affected-targets
@@ -38,6 +38,8 @@
 #                      deliberately added here.
 #   is-selectable-lane Exit 0 only for a gated workflow lane (RUE-1130).
 #   lane-targets       Print the Buck targets a gated lane executes.
+#   corpus-targets     Print the corpus targets the platform-corpus matrix runs.
+#   lanes              Print the gated workflow lane names.
 #   intersect          Print a lane's targets that appear in an impacted list.
 #   build-scope        Print the impacted targets a `//crates/...` lane may
 #                      build. Narrowing must stay inside the lane's own scope.
@@ -205,6 +207,20 @@ is_selectable() {
         [[ "$target" == "$wanted" ]] && return 0
     done
     return 1
+}
+
+# RUE-1265: the duplication gate needs the same two inventories the gating logic
+# above consults — which corpora own a `platform-corpus` job, and which lanes
+# exist at all — and reading them from here rather than transcribing them keeps
+# ADR-0069's ledger from gaining a row. `lanes` deliberately omits
+# `linux-premerge`, which is narrowed rather than gated and so is not in
+# SELECTABLE_LANES; consumers that care about it add it explicitly.
+corpus_targets() {
+    printf '%s\n' "${SELECTABLE_CORPUS[@]}"
+}
+
+lanes() {
+    printf '%s\n' "${SELECTABLE_LANES[@]}"
 }
 
 # Emit `key=value` to $GITHUB_OUTPUT when running under Actions; harmless
@@ -502,8 +518,12 @@ main() {
         lane-targets)
             [[ $# -eq 2 ]] || { echo "usage: scripts/affected-targets lane-targets LANE" >&2; exit 2; }
             lane_targets "$2" ;;
+        corpus-targets)
+            corpus_targets ;;
+        lanes)
+            lanes ;;
         *)
-            echo "usage: scripts/affected-targets [decide|force-full-match|status-paths|is-selectable|is-selectable-lane|lane-targets|intersect|build-scope]" >&2
+            echo "usage: scripts/affected-targets [decide|force-full-match|status-paths|is-selectable|is-selectable-lane|lane-targets|corpus-targets|lanes|intersect|build-scope]" >&2
             exit 2 ;;
     esac
 }

--- a/scripts/test-affected-targets.sh
+++ b/scripts/test-affected-targets.sh
@@ -191,6 +191,30 @@ else
   fail "lane: corpus gating regressed"
 fi
 
+# RUE-1265: the duplication gate reads this script's corpus and lane
+# inventories instead of keeping a second copy of either. `lanes` must stay
+# complete — a lane missing from it is a lane the duplication gate never learns
+# to classify — and `corpus-targets` must stay non-empty, since an empty
+# platform-corpus inventory would silently remove that lane from the gate's
+# view of what runs.
+TESTS=$((TESTS + 1))
+if [ "$("${AFFECTED[@]}" lanes | sort | tr '\n' ' ')" \
+    = "asan compiler-reproducibility native-linux-arm64 native-macos-arm64 release rue-program-digests valgrind " ]; then
+  pass "lanes: the gated lane inventory is exposed in full"
+else
+  fail "lanes: printed $("${AFFECTED[@]}" lanes | tr '\n' ' ')"
+fi
+
+TESTS=$((TESTS + 1))
+# Capture first: `grep -q` behind a pipe under `set -o pipefail` kills the
+# producer with EPIPE on its first match (RUE-1011/RUE-1155).
+corpus_inventory="$("${AFFECTED[@]}" corpus-targets)"
+if grep -q '^//:spec-tests$' <<<"$corpus_inventory"; then
+  pass "corpus-targets: the platform-corpus inventory is exposed"
+else
+  fail "corpus-targets: //:spec-tests is missing from the exposed inventory"
+fi
+
 # The asan harness is outside the Buck graph, so BTD cannot see it; its sources
 # must force a full run rather than relying on a representative target.
 expect_full "crates/rue-runtime-asan/src/main.rs"

--- a/scripts/test-validate-ci-gate.py
+++ b/scripts/test-validate-ci-gate.py
@@ -133,6 +133,19 @@ class GateValidatorTests(unittest.TestCase):
         errors = "\n".join(self.validate_text(changed))
         self.assertIn("RUE_CI_DEFER_HEAVY_SUITES is retired", errors)
 
+    # RUE-1265: the duplication gate is the only check that reads test contents
+    # rather than target lists, so dropping its step restores a blind spot no
+    # other gate can cover.
+    def test_dropping_the_duplication_gate_step_fails(self):
+        changed = SOURCE.read_text().replace(
+            "scripts/validate-test-duplication.py", "true", 1
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn(
+            "linux-premerge responsibility missing 'scripts/validate-test-duplication.py'",
+            errors,
+        )
+
     def test_dedicated_lane_corpus_without_a_job_fails(self):
         # spec-tests is skipped by the premerge suite because it carries the
         # label, so dropping its platform-corpus entry would drop it entirely.

--- a/scripts/test-validate-test-duplication.py
+++ b/scripts/test-validate-test-duplication.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+"""Focused tests for the CI duplication gate (RUE-1265, ADR-0069 §2).
+
+The fixture that matters is `RUE_1262_SHAPE`: a target whose tests are a
+strict superset of another's, in the same lane, on the same platform. That is
+the defect this gate exists for, and it is reproduced here as data so the gate
+is proven to fail on it rather than asserted to.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("validate-test-duplication.py")
+SPEC = importlib.util.spec_from_file_location("validate_test_duplication", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+GATE = importlib.util.module_from_spec(SPEC)
+sys.modules["validate_test_duplication"] = GATE
+SPEC.loader.exec_module(GATE)
+
+COMPILER = "//crates/rue-compiler:rue-compiler-test"
+SCALING = "//crates/rue-compiler:scaling-matrix-test"
+# One namespace, because the pre-RUE-1262 scaling-matrix target compiled the
+# same crate sources under a different `--cfg`.
+CRATE = "srcs:0123456789ab"
+
+
+def scheduled(platform, lane, target, names, namespace=CRATE, owner=None):
+    return GATE.Scheduled(
+        platform=platform,
+        lane=lane,
+        target=target,
+        owner=owner or target,
+        identities=frozenset(f"{namespace}\t{name}" for name in names),
+    )
+
+
+SHARED = [f"pipeline_tests::tests::case_{index}" for index in range(813)]
+
+# The RUE-1262 defect, as data: 816 tests against 813, all 813 shared, both in
+# the premerge lane on linux-x64.
+RUE_1262_SHAPE = [
+    scheduled("linux-x64", "linux-premerge", COMPILER, SHARED),
+    scheduled(
+        "linux-x64",
+        "linux-premerge",
+        SCALING,
+        SHARED + ["scaling_harness::scaling_matrix_identity_invariant"],
+    ),
+]
+
+
+class DuplicateDetectionTests(unittest.TestCase):
+    def test_superset_target_in_one_lane_is_a_duplicate_set(self):
+        duplicates = GATE.duplicate_sets(RUE_1262_SHAPE)
+        self.assertEqual(len(duplicates), 1)
+        duplicate = duplicates[0]
+        self.assertEqual(duplicate.targets, (COMPILER, SCALING))
+        self.assertEqual(duplicate.platforms, ("linux-x64",))
+        self.assertEqual(len(duplicate.identities), 813)
+        # The three tests the superset uniquely owns are not duplicates.
+        self.assertNotIn(
+            f"{CRATE}\tscaling_harness::scaling_matrix_identity_invariant",
+            duplicate.identities,
+        )
+
+    def test_the_gate_fails_on_that_fixture_and_names_both_targets(self):
+        errors = GATE.review(GATE.duplicate_sets(RUE_1262_SHAPE), allowances=())
+        self.assertEqual(len(errors), 1)
+        self.assertIn("undeclared duplication", errors[0])
+        self.assertIn(COMPILER, errors[0])
+        self.assertIn(SCALING, errors[0])
+        # A reader must be able to act without re-deriving the overlap: which
+        # lane scheduled each copy, and an example of what overlaps.
+        self.assertIn("linux-premerge", errors[0])
+        self.assertIn("pipeline_tests::tests::case_0", errors[0])
+
+    def test_disjoint_targets_are_not_duplicates(self):
+        schedule = [
+            scheduled("linux-x64", "linux-premerge", COMPILER, SHARED),
+            scheduled(
+                "linux-x64",
+                "linux-premerge",
+                SCALING,
+                ["scaling_harness::scaling_matrix_identity_invariant"],
+            ),
+        ]
+        self.assertEqual(GATE.duplicate_sets(schedule), [])
+        self.assertEqual(GATE.review([], allowances=()), [])
+
+    def test_same_test_name_in_two_crates_is_not_a_duplicate(self):
+        # `tests::empty_program` is an ordinary name; two crates owning one is
+        # not a duplication, so identities are namespaced by compiled sources.
+        schedule = [
+            scheduled(
+                "linux-x64", "linux-premerge", "//crates/rue-lexer:rue-lexer-test",
+                ["tests::empty_program"], namespace="srcs:aaaaaaaaaaaa",
+            ),
+            scheduled(
+                "linux-x64", "linux-premerge", "//crates/rue-parser:rue-parser-test",
+                ["tests::empty_program"], namespace="srcs:bbbbbbbbbbbb",
+            ),
+        ]
+        self.assertEqual(GATE.duplicate_sets(schedule), [])
+
+    def test_cross_platform_repetition_is_reported_as_one_set(self):
+        schedule = [
+            scheduled(platform, lane, COMPILER, SHARED)
+            for platform, lane in (
+                ("linux-x64", "linux-premerge"),
+                ("linux-arm64", "native-linux-arm64"),
+                ("macos-arm64", "native-macos-arm64"),
+            )
+        ]
+        duplicates = GATE.duplicate_sets(schedule)
+        self.assertEqual(len(duplicates), 1)
+        self.assertEqual(duplicates[0].targets, (COMPILER,))
+        self.assertEqual(
+            duplicates[0].platforms, ("linux-arm64", "linux-x64", "macos-arm64")
+        )
+
+
+class AllowanceTests(unittest.TestCase):
+    def allowance(self, targets, platforms=("linux-x64",), kind="between-targets"):
+        return GATE.Allowance(
+            targets=tuple(targets),
+            platforms=tuple(platforms),
+            kind=kind,
+            reason="under test",
+        )
+
+    def test_declared_allowance_suppresses_the_failure(self):
+        errors = GATE.review(
+            GATE.duplicate_sets(RUE_1262_SHAPE),
+            allowances=(self.allowance([COMPILER, SCALING]),),
+        )
+        self.assertEqual(errors, [])
+
+    def test_allowance_for_other_platforms_does_not_apply(self):
+        errors = GATE.review(
+            GATE.duplicate_sets(RUE_1262_SHAPE),
+            allowances=(self.allowance([COMPILER, SCALING], ("linux-arm64",)),),
+        )
+        self.assertTrue(any("undeclared duplication" in error for error in errors), errors)
+
+    def test_allowance_must_name_every_target_involved(self):
+        # Naming only one side is exactly the review that would have missed the
+        # superset, so a partial allowance must not cover it.
+        errors = GATE.review(
+            GATE.duplicate_sets(RUE_1262_SHAPE),
+            allowances=(self.allowance([COMPILER]),),
+        )
+        self.assertTrue(any("undeclared duplication" in error for error in errors), errors)
+
+    def test_a_superset_allowance_does_not_absorb_a_smaller_overlap(self):
+        # The defect an adversarial review found: subset matching let a
+        # `between-targets` entry vouch for any subset of its own targets, so
+        # an overlap between two shards — which attributes to the single owner
+        # //:cli-tests — slid under the two-target release-smoke entry.
+        schedule = [
+            scheduled("linux-x64", "platform-corpus", "//:cli-tests-shard-0",
+                      SHARED, owner="//:cli-tests"),
+            scheduled("linux-x64", "platform-corpus", "//:cli-tests-shard-1",
+                      SHARED, owner="//:cli-tests"),
+        ]
+        duplicates = GATE.duplicate_sets(schedule)
+        # The fold onto //:cli-tests is undone, because undoing it is the only
+        # way the report can name what actually overlaps.
+        self.assertEqual(
+            duplicates[0].targets, ("//:cli-tests-shard-0", "//:cli-tests-shard-1")
+        )
+        errors = GATE.review(
+            duplicates,
+            allowances=(self.allowance(["//:cli-tests", "//:release-smoke"]),),
+        )
+        self.assertTrue(any("undeclared duplication" in error for error in errors), errors)
+
+    def test_a_roster_does_not_cover_an_overlap_between_its_own_members(self):
+        # The same defect from the other side: eight targets that each repeat
+        # across three platforms must not license a NEW overlap between two of
+        # them, which is the RUE-1262 shape reproduced inside an allowance.
+        platforms = ("linux-arm64", "linux-x64", "macos-arm64")
+        roster = self.allowance(["//a:one-test", "//b:two-test"], platforms, "per-target")
+        overlap = [
+            scheduled(platform, lane, target, ["tests::x"])
+            for target, (platform, lane) in zip(
+                ("//a:one-test", "//b:two-test"),
+                (("linux-x64", "premerge"), ("linux-x64", "premerge")),
+            )
+        ]
+        overlap += [
+            scheduled(platform, lane, "//a:one-test", ["tests::x"])
+            for platform, lane in (("linux-arm64", "n-arm"), ("macos-arm64", "n-mac"))
+        ]
+        errors = GATE.review(GATE.duplicate_sets(overlap), allowances=(roster,))
+        self.assertTrue(any("undeclared duplication" in error for error in errors), errors)
+
+    def test_one_roster_entry_covers_several_single_target_repetitions(self):
+        platforms = ("linux-arm64", "linux-x64", "macos-arm64")
+        schedule = []
+        for index, target in enumerate(("//a:one-test", "//b:two-test")):
+            for platform, lane in zip(platforms, ("n-arm", "premerge", "n-mac")):
+                schedule.append(
+                    scheduled(
+                        platform, lane, target, ["tests::x"],
+                        namespace=f"srcs:{index}0000000000",
+                    )
+                )
+        duplicates = GATE.duplicate_sets(schedule)
+        self.assertEqual(len(duplicates), 2)
+        self.assertEqual(
+            GATE.review(
+                duplicates,
+                allowances=(
+                    self.allowance(
+                        ["//a:one-test", "//b:two-test"], platforms, "per-target"
+                    ),
+                ),
+            ),
+            [],
+        )
+
+    def test_a_roster_goes_stale_per_target_not_per_entry(self):
+        # Seven of eight targets can stop running while the eighth keeps the
+        # entry "matched", leaving seven written reasons vouching for nothing.
+        platforms = ("linux-arm64", "linux-x64", "macos-arm64")
+        alive = [
+            scheduled(platform, lane, "//a:one-test", ["tests::x"])
+            for platform, lane in zip(platforms, ("n-arm", "premerge", "n-mac"))
+        ]
+        errors = GATE.review(
+            GATE.duplicate_sets(alive),
+            allowances=(
+                self.allowance(
+                    ["//a:one-test", "//b:gone-test"], platforms, "per-target"
+                ),
+            ),
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("stale allowance", errors[0])
+        self.assertIn("//b:gone-test", errors[0])
+
+    def test_allowance_matching_nothing_is_an_error(self):
+        errors = GATE.review([], allowances=(self.allowance([COMPILER, SCALING]),))
+        self.assertEqual(len(errors), 1)
+        self.assertIn("stale allowance", errors[0])
+
+    def test_the_declared_ledger_carries_a_reason_for_every_entry(self):
+        for allowance in GATE.ALLOWANCES:
+            self.assertTrue(allowance.targets, allowance)
+            self.assertTrue(allowance.platforms, allowance)
+            self.assertIn(allowance.kind, ("per-target", "between-targets"), allowance)
+            # An allowance is a written decision, not a suppression switch.
+            self.assertGreater(len(allowance.reason), 80, allowance.targets)
+            self.assertEqual(
+                tuple(sorted(allowance.platforms)), allowance.platforms, allowance
+            )
+
+    def test_every_not_listable_entry_says_what_its_opacity_hides(self):
+        # A NOT_LISTABLE entry removes a target from the comparison entirely,
+        # which is a larger claim than an allowance makes. The reason has to
+        # carry it.
+        for target, reason in GATE.NOT_LISTABLE.items():
+            self.assertTrue(target.startswith("//"), target)
+            self.assertGreater(len(reason), 120, target)
+
+
+class InventoryTests(unittest.TestCase):
+    def test_shards_are_attributed_to_the_corpus_they_slice(self):
+        shards = {f"//:cli-tests-shard-{index}" for index in range(4)}
+        self.assertEqual(GATE.owner_of("//:cli-tests-shard-2", shards), "//:cli-tests")
+        self.assertEqual(GATE.owner_of("//:release-smoke", shards), "//:release-smoke")
+        # A target that merely looks sharded but carries no shard label keeps
+        # its own name.
+        self.assertEqual(GATE.owner_of("//:other-shard-1", shards), "//:other-shard-1")
+
+    def test_a_target_reached_through_a_suite_and_directly_runs_once(self):
+        expansion = {
+            "//:repository-quality-gates": ["//:adr-registry-validation", "//:spec-traceability"],
+            "//:spec-traceability": ["//:spec-traceability"],
+        }
+        units = GATE.lane_units(
+            ["//:repository-quality-gates", "//:spec-traceability"], expansion
+        )
+        self.assertEqual(units, ["//:adr-registry-validation", "//:spec-traceability"])
+
+    def test_list_output_is_parsed_and_the_trailer_is_not_a_test(self):
+        lines = [
+            "pipeline_tests::tests::wide_batches: test",
+            "bench_module::throughput: bench",
+            "",
+            "2 tests, 1 benchmarks",
+        ]
+        names = [
+            match.group("name")
+            for match in (GATE.LIST_LINE_RE.match(line) for line in lines)
+            if match
+        ]
+        self.assertEqual(names, ["pipeline_tests::tests::wide_batches", "bench_module::throughput"])
+
+    def test_a_wrapper_whose_harness_cannot_be_read_is_loud(self):
+        # The one failure this gate cannot absorb: a wrapper that lists 850
+        # tests degrading to "one opaque unit" would make its duplication
+        # disappear into a pass.
+        class PartialBuck:
+            root = Path(".")
+
+            def uquery(self, expression, attributes):
+                if "//:hidden-harness" in expression:
+                    return {}
+                return {
+                    "//:wrapper-test": {
+                        "buck.type": "sh_test",
+                        "test": "root//:hidden-harness",
+                        "args": [],
+                    }
+                }
+
+        inventory = GATE.resolve_inventory(PartialBuck(), {"//:wrapper-test"})
+        self.assertIn("//:wrapper-test", inventory.unresolved)
+        self.assertIn("//:hidden-harness", inventory.unresolved["//:wrapper-test"])
+
+    def test_a_wrapper_around_a_non_test_target_is_ordinary_opaque_work(self):
+        # //:adr-registry-validation runs a script through a `test` attribute
+        # that is a source path, and the clippy gates wrap a non-test binary.
+        # Neither is a resolution failure; each is one unit of work.
+        class ScriptBuck:
+            root = Path(".")
+
+            def uquery(self, expression, attributes):
+                if "//:clippy-gate" in expression:
+                    return {"//:clippy-gate": {"buck.type": "sh_binary"}}
+                return {
+                    "//:script-test": {
+                        "buck.type": "sh_test",
+                        "test": "root///scripts/validate-adrs.py",
+                        "args": [],
+                    },
+                    "//:clippy-test": {
+                        "buck.type": "sh_test",
+                        "test": "root//:clippy-gate",
+                        "args": [],
+                    },
+                }
+
+        inventory = GATE.resolve_inventory(
+            ScriptBuck(), {"//:script-test", "//:clippy-test"}
+        )
+        self.assertEqual(inventory.unresolved, {})
+        self.assertEqual(inventory.opaque, {"//:script-test", "//:clippy-test"})
+
+    def test_a_shell_corpus_harness_is_classified_from_the_graph_not_probed(self):
+        # The cheapest possible answer: a `sh_binary` cannot be libtest, and
+        # asking one anyway runs its whole suite.
+        class ShellCorpusBuck:
+            root = Path(".")
+
+            def uquery(self, expression, attributes):
+                nodes = {
+                    "//:reproducible-programs": {
+                        "buck.type": "sh_test",
+                        "test": "root//:corpus-stamp-check",
+                        "args": ["$(location root//:reproducible-programs-action)"],
+                    },
+                    "//:reproducible-programs-action": {
+                        "buck.type": "_corpus_action",
+                        "harness": "root//:reproducible-programs-harness",
+                        "harness_args": [],
+                        "corpus_env": {},
+                    },
+                    "//:reproducible-programs-harness": {"buck.type": "sh_binary"},
+                    "//:corpus-stamp-check": {"buck.type": "sh_binary"},
+                }
+                return {
+                    label: node
+                    for label, node in nodes.items()
+                    if label in expression
+                }
+
+        inventory = GATE.resolve_inventory(
+            ShellCorpusBuck(), {"//:reproducible-programs"}
+        )
+        self.assertEqual(inventory.listings, {})
+        self.assertIn("//:reproducible-programs", inventory.not_libtest)
+        self.assertIn("sh_binary", inventory.not_libtest["//:reproducible-programs"])
+        self.assertEqual(inventory.unresolved, {})
+
+    def test_a_harness_that_ignores_list_is_not_read_as_an_empty_suite(self):
+        # The defect an adversarial review found: `scripts/test-reproducible-output.sh`
+        # and `scripts/oracle-diff-generated-smoke.sh` do no argument handling,
+        # so `--list` ran the whole suite, exited 0, and printed nothing this
+        # parser matches. Zero identities read as "nothing to compare" while
+        # the gate had just executed a premerge suite a second time.
+        with tempfile.TemporaryDirectory() as directory:
+            harness = Path(directory) / "suite.sh"
+            harness.write_text(
+                "#!/usr/bin/env bash\n"
+                "echo 'running 3 checks'\n"
+                "echo 'ok 1 - reproducible'\n"
+                "exit 0\n"
+            )
+            harness.chmod(0o755)
+            lister = GATE.Lister(Path(directory))
+            listing = GATE.Listing(
+                target="//:suite", binary="//:suite", args=[], env={},
+                namespace_key=CRATE,
+            )
+            identities = lister.identities(listing, {"//:suite": str(harness)})
+        self.assertIsNone(identities)
+        self.assertIn("//:suite", lister.unlistable)
+        self.assertIn("no libtest listing", lister.unlistable["//:suite"])
+
+    def test_a_well_formed_empty_listing_is_not_the_same_thing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            harness = Path(directory) / "empty.sh"
+            harness.write_text("#!/usr/bin/env bash\necho\necho '0 tests, 0 benchmarks'\n")
+            harness.chmod(0o755)
+            lister = GATE.Lister(Path(directory))
+            listing = GATE.Listing(
+                target="//:empty-test", binary="//:empty-test", args=[], env={},
+                namespace_key=CRATE,
+            )
+            identities = lister.identities(listing, {"//:empty-test": str(harness)})
+        self.assertEqual(identities, frozenset())
+        self.assertEqual(lister.unlistable, {})
+
+    def test_a_declared_not_listable_target_is_never_invoked(self):
+        # Probing `//:spec-traceability` costs a second execution of a premerge
+        # suite, which is precisely what this gate exists to stop.
+        target = next(iter(GATE.NOT_LISTABLE))
+        listing = GATE.Listing(
+            target=target, binary="//:harness", args=[], env={}, namespace_key=CRATE
+        )
+        self.assertEqual(GATE.Lister.plans(listing, {"//:harness": "/does/not/exist"}), [])
+        lister = GATE.Lister(Path("."))
+        self.assertIsNone(lister.identities(listing, {"//:harness": "/does/not/exist"}))
+        self.assertEqual(lister.invocations, 0)
+
+    def test_execution_only_env_is_not_materialized(self):
+        # //:cli-staged-programs stages ten rue_program compiles that no
+        # listing consults, and the premerge lane never builds it otherwise.
+        listing = GATE.Listing(
+            target="//:cli-tests-shard-0",
+            binary="//crates/rue-cli-tests:rue-cli-tests",
+            args=[],
+            env={
+                "RUE_CLI_CASES": "$(location //crates/rue-cli-tests:cases)/cases",
+                "RUE_CLI_STAGED_PROGRAMS": "$(location //:cli-staged-programs)",
+            },
+            namespace_key=CRATE,
+        )
+        self.assertEqual(
+            set(GATE.listing_env(listing)), {"RUE_CLI_CASES"}
+        )
+
+    def test_location_macros_expand_to_built_outputs(self):
+        outputs = {"//crates/rue:rue": "/out/rue", "//:std": "/out/std"}
+        self.assertEqual(
+            GATE.expand("$(exe_target root//crates/rue:rue)", outputs), "/out/rue"
+        )
+        self.assertEqual(GATE.expand("$(location //:std)/std", outputs), "/out/std/std")
+
+    def test_an_unbuilt_macro_target_is_an_error_rather_than_a_silent_empty_env(self):
+        # A harness handed an empty path finds no cases and lists nothing,
+        # which would read as "this target duplicates nothing".
+        with self.assertRaises(RuntimeError):
+            GATE.expand("$(location //:missing)", {})
+
+
+class LaneModelTests(unittest.TestCase):
+    """The gate must not silently ignore a lane someone adds to CI."""
+
+    def fake_affected_targets(self, directory: Path, lanes: list[str]) -> Path:
+        script = directory / "affected-targets"
+        script.write_text(
+            "#!/usr/bin/env bash\n"
+            'case "$1" in\n'
+            f'  lanes) printf "%s\\n" {" ".join(lanes)} ;;\n'
+            "  corpus-targets) echo //:cli-tests-shard-0 ;;\n"
+            "  lane-targets) echo //:release-smoke ;;\n"
+            "esac\n"
+        )
+        return script
+
+    class FakeBuck:
+        root = Path(".")
+
+        def uquery(self, expression, attributes):
+            return {"//crates/rue-lexer:rue-lexer-test": {"labels": []}}
+
+    def test_an_unclassified_lane_fails_the_gate(self):
+        with tempfile.TemporaryDirectory() as directory:
+            script = self.fake_affected_targets(
+                Path(directory), ["release", "valgrind", "brand-new-lane"]
+            )
+            with self.assertRaises(RuntimeError) as caught:
+                GATE.lane_membership(self.FakeBuck(), script)
+        self.assertIn("brand-new-lane", str(caught.exception))
+
+    def test_the_known_lanes_are_classified(self):
+        with tempfile.TemporaryDirectory() as directory:
+            script = self.fake_affected_targets(
+                Path(directory), sorted(set(GATE.LANE_PLATFORMS) | GATE.SELECTION_PROXY_LANES)
+            )
+            lanes = GATE.lane_membership(self.FakeBuck(), script)
+        self.assertEqual(set(lanes), set(GATE.LANE_PLATFORMS))
+
+    def test_every_classified_lane_has_a_platform(self):
+        self.assertEqual(
+            set(GATE.LANE_PLATFORMS) & GATE.SELECTION_PROXY_LANES, set()
+        )
+
+    def test_the_determinator_exposes_the_inventories_this_gate_reads(self):
+        for subcommand in ("corpus-targets", "lanes"):
+            result = subprocess.run(
+                ["bash", str(GATE.AFFECTED_TARGETS), subcommand],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(result.stdout.split(), subcommand)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -7,6 +7,7 @@ import argparse
 import importlib.util
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 RESULTS_SCRIPT = Path(__file__).with_name("ci-required-results.py")
@@ -78,6 +79,21 @@ SPEC = importlib.util.spec_from_file_location("ci_required_results", RESULTS_SCR
 RESULTS = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
 SPEC.loader.exec_module(RESULTS)
+
+# RUE-1265: the duplication gate models these three steps as scheduled work, so
+# the filters have to be one fact. Importing them here means a filter added to
+# the workflow without teaching the gate about it fails this validator, rather
+# than quietly running a corpus slice the duplication comparison cannot see.
+DUPLICATION_SCRIPT = Path(__file__).with_name("validate-test-duplication.py")
+_DUP_SPEC = importlib.util.spec_from_file_location(
+    "validate_test_duplication", DUPLICATION_SCRIPT
+)
+DUPLICATION = importlib.util.module_from_spec(_DUP_SPEC)
+assert _DUP_SPEC.loader is not None
+# Registered before execution: the module defines dataclasses, and @dataclass
+# resolves annotations through sys.modules[cls.__module__].
+sys.modules["validate_test_duplication"] = DUPLICATION
+_DUP_SPEC.loader.exec_module(DUPLICATION)
 
 ACTION_ID = r"[A-Za-z_][A-Za-z0-9_-]*"
 JOB_RE = re.compile(rf"^  ({ACTION_ID}):\s*$", re.MULTILINE)
@@ -254,6 +270,11 @@ def validate(
         # may quietly drop. Its sibling staleness gate is pinned below, in the
         # job RUE-1504 moved it to.
         "check-pins",
+        # RUE-1265: the ADR-0069 §2 duplication gate. It is the only check that
+        # compares test contents rather than target lists, so nothing else in
+        # CI can see a target becoming a superset of another; losing the step
+        # restores the blind spot that hid 223s of re-executed work for weeks.
+        "scripts/validate-test-duplication.py",
     ):
         if required not in linux:
             errors.append(f"linux-premerge responsibility missing {required!r}")
@@ -330,9 +351,8 @@ def validate(
         "//crates/rue-runtime:rue-runtime-test",
         "//crates/rue-runtime-abi:rue-runtime-abi-test",
         "scripts/run-native-platform-corpus.sh",
-        "scripts/rue cli abi",
-        "scripts/rue cli cli.linker",
-        "scripts/rue cli cli.fs_file_io",
+    ) + tuple(
+        f"scripts/rue cli {filter_}" for filter_ in DUPLICATION.NATIVE_CLI_FILTERS
     ):
         if required not in native:
             errors.append(f"native-platforms responsibility missing {required!r}")

--- a/scripts/validate-test-duplication.py
+++ b/scripts/validate-test-duplication.py
@@ -1,0 +1,1244 @@
+#!/usr/bin/env python3
+"""Fail when one test is scheduled more than once in a CI run (ADR-0069 §2).
+
+Every other CI gate in this repository compares *target lists*.
+`//:cli-shard-coverage-validation` compares BUCK's shard targets with the
+matrix; `scripts/validate-ci-gate.py` compares the workflow's jobs with the
+platform responsibility matrix; `//test_tiers.bxl:validate` compares tier
+labels with the test graph. None of them compares *test contents*, so a target
+that is a strict superset of another is invisible to all of them:
+`//crates/rue-compiler:scaling-matrix-test` re-ran 813 of `rue-compiler-test`'s
+tests for weeks to gain three, in the same lane, and every gate stayed green
+(RUE-1262). This gate closes that class rather than that instance.
+
+The invariant, from ADR-0069 §2: **no unit of work executes more than once per
+platform per run without a declared reason.** Cross-platform repetition is
+governed by the same ledger, because "the native lanes deliberately do not
+repeat the broad unit suite" is a claim about test contents too, and the same
+`--list` evidence either supports it or does not.
+
+How it works:
+
+1. **Lane membership comes from the live graph, never from YAML.** The premerge
+   lane is `attrfilter(labels, 'rue_test_tier_premerge', ...)` minus the
+   `rue_cli_shard` and `rue_ci_dedicated_lane` sets — the derivation
+   `docs/notes/rue-1250-premerge-critical-path.md` measured and `test.sh`
+   executes. The corpus and gated-lane inventories come from
+   `scripts/affected-targets`, which is the same list CI's determinator already
+   consults, so this gate adds no new hand-maintained row to ADR-0069's ledger.
+2. **Identities come from `--list` on the test binaries.** Cheap and exact: it
+   is how the superset above was found. Rust unit targets, the `sh_test`
+   wrappers that select rows out of one (the scaling matrix), and the
+   `cached_corpus_suite` harnesses all speak the libtest `--list` protocol, and
+   each is listed with the exact args and env its own Buck target carries.
+3. **Allowances are declared here with a reason.** Absence never implies
+   permission, and an allowance that stops matching anything is an error, so
+   the ledger cannot rot into a list of things that used to be true.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_BUCK = ROOT / "buck2"
+AFFECTED_TARGETS = ROOT / "scripts" / "affected-targets"
+
+TIER_PREMERGE = "rue_test_tier_premerge"
+CLI_SHARD_LABEL = "rue_cli_shard"
+DEDICATED_LANE_LABEL = "rue_ci_dedicated_lane"
+
+PREMERGE_QUERY = (
+    "attrfilter(labels, '" + TIER_PREMERGE + "', set(//... toolchains//...))"
+)
+
+# Which platform executes which lane. `linux-premerge` and `platform-corpus`
+# are the two halves of the linux-x64 test load: the premerge tier minus the
+# corpora that own their own job, and those corpora. The rest are the gated
+# lanes RUE-1130 named.
+LANE_PLATFORMS = {
+    "linux-premerge": "linux-x64",
+    "platform-corpus": "linux-x64",
+    "release": "linux-x64",
+    "native-linux-arm64": "linux-arm64",
+    "native-macos-arm64": "macos-arm64",
+}
+
+# Gated lanes that schedule no Buck test target of their own. Their
+# `lane_targets` entries are *selection proxies* — the library and binary a
+# script consumes — not tests, so listing them would invent duplicates that no
+# runner executes. Keeping them named here rather than filtered by rule kind is
+# deliberate: `valgrind` names `//:cli-tests`, which IS a test target, and it
+# runs generated programs under memcheck rather than that corpus.
+SELECTION_PROXY_LANES = {
+    "valgrind",
+    "asan",
+    "compiler-reproducibility",
+    "rue-program-digests",
+}
+
+# The native lanes run three CLI filters as workflow steps rather than as Buck
+# test targets (`scripts/rue cli abi` → `buck2 run //crates/rue-cli-tests:cli --
+# abi`). Everything but the filter strings is derived from the alias's own graph
+# node; `scripts/validate-ci-gate.py` imports these so the workflow and this
+# gate cannot disagree about which filters run.
+NATIVE_CLI_ALIAS = "//crates/rue-cli-tests:cli"
+NATIVE_CLI_FILTERS = ("abi", "cli.linker", "cli.fs_file_io")
+
+
+@dataclass(frozen=True)
+class Allowance:
+    """A duplication this repository has decided to keep, and why.
+
+    An entry declares one of exactly two shapes, and covers only that shape:
+
+    * `per-target` — each named target repeats *by itself* across `platforms`.
+      One entry can carry a roster of targets that repeat for the same written
+      reason, because each of them is an independent one-target fact.
+    * `between-targets` — precisely the named targets overlap on `platforms`.
+      The match is on the exact set.
+
+    Neither shape ever matches by subset. An earlier revision allowed a
+    duplicate set whose targets were a subset of an entry's, which quietly
+    absorbed two real defects: an overlap *between* two members of a
+    `per-target` roster (the RUE-1262 shape, reproduced inside an allowance),
+    and — because CLI shards attribute to the corpus they slice — an overlap
+    between two shards, which reduces to the single owner `//:cli-tests` and
+    slid under the two-target `release-smoke` entry. Both now fail.
+    """
+
+    targets: tuple[str, ...]
+    platforms: tuple[str, ...]
+    reason: str
+    kind: str = "between-targets"
+    # True when the allowance records the current behaviour rather than a
+    # decision. ADR-0069 leaves several of these open, and inventing the ruling
+    # here would be worse than carrying it visibly.
+    provisional: bool = False
+
+    def covers(self, duplicate: "DuplicateSet") -> bool:
+        if duplicate.platforms != self.platforms:
+            return False
+        if self.kind == "per-target":
+            return len(duplicate.targets) == 1 and duplicate.targets[0] in self.targets
+        return set(duplicate.targets) == set(self.targets)
+
+    def unmatched(self, covered: list["DuplicateSet"]) -> list[str]:
+        """What this entry still claims that nothing supports.
+
+        A `between-targets` entry is one indivisible claim about one set, so it
+        is stale as a whole. A roster is N independent claims: seven of eight
+        targets could stop running while the entry stayed "matched" by the
+        eighth, and seven written reasons would keep vouching for work nobody
+        does, so it goes stale per target.
+        """
+        if self.kind != "per-target":
+            return [] if covered else [", ".join(self.targets)]
+        alive = {duplicate.targets[0] for duplicate in covered}
+        return [target for target in self.targets if target not in alive]
+
+
+ALLOWANCES = (
+    Allowance(
+        targets=("//crates/rue-compiler:rue-compiler-test",),
+        platforms=("linux-arm64", "linux-x64", "macos-arm64"),
+        reason=(
+            "The native lanes want this binary's ~27 host-conditional sites and "
+            "pay for its whole unit suite, because platform scope is declared "
+            "per target while it is a property of individual tests. ADR-0069 "
+            "Phase 4 (RUE-1262 scope C) splits the host-conditional tests into "
+            "their own target, following the precedent already set in this crate "
+            "by rue-compiler-public-api-test; the repetition ends there, not by "
+            "dropping coverage here. Until then this is what runs, and "
+            "docs/process/ci.md says so rather than claiming otherwise."
+        ),
+        provisional=True,
+    ),
+    Allowance(
+        kind="per-target",
+        targets=(
+            "//crates/rue-allocator:rue-allocator-test",
+            "//crates/rue-codegen:rue-codegen-test",
+            "//crates/rue-linker:rue-linker-test",
+            "//crates/rue-runtime-abi:rue-runtime-abi-test",
+            "//crates/rue-runtime:rue-runtime-test",
+            "//crates/rue-runtime:runtime-archives-test",
+            "//crates/rue-target:rue-target-test",
+            "//fixtures/rue-program:hello-runs-test",
+        ),
+        platforms=("linux-arm64", "linux-x64", "macos-arm64"),
+        reason=(
+            "The platform responsibility matrix in docs/process/ci.md requires "
+            "exactly this: the native lanes prove the host ABI, object/linker "
+            "path, runtime archive, syscalls, and platform behaviour that "
+            "cross-compilation cannot, and a pass on x86-64 Linux is not "
+            "evidence for AArch64 or Mach-O. The repetition is the coverage. "
+            "Each target here repeats on its own; an overlap BETWEEN any two of "
+            "them is a different fact and is not covered by this entry."
+        ),
+    ),
+    Allowance(
+        targets=("//:cli-tests", "//:release-smoke"),
+        platforms=("linux-x64",),
+        reason=(
+            "Three executions of the same 25 cases on linux-x64: the CLI shards "
+            "run them under //platforms:debug, the `release` job runs "
+            "//:release-smoke under //platforms:release, and //:release-smoke "
+            "carries no `rue_ci_dedicated_lane` label so `test.sh` ALSO runs it "
+            "inside linux-premerge under the debug platform — where the shards "
+            "have already run those cases. The release-configured execution is "
+            "the coverage ADR-0069 calls 'defensible but undecided'; the "
+            "premerge one is a third pass with no configuration of its own, and "
+            "looks like an oversight rather than a decision. Both need the same "
+            "maintainer ruling, so both are declared rather than acted on."
+        ),
+        provisional=True,
+    ),
+    Allowance(
+        targets=("//:cli-tests", "//crates/rue-cli-tests:cli"),
+        platforms=("linux-arm64", "linux-x64", "macos-arm64"),
+        reason=(
+            "The native lanes run `scripts/rue cli abi`, `cli.linker`, and "
+            "`cli.fs_file_io` — the developer entry point, with neither "
+            "RUE_CLI_CASE_TIER nor RUE_PLATFORM_CASE_SELECTION set, so every "
+            "matching case of every tier runs. Those sections contain "
+            "native-execution cases with empty `only_on` lists, which is "
+            "exactly why docs/process/ci.md keeps the explicit filters beside "
+            "the self-enrolling `only_on` selection: a real ABI, linker, or "
+            "filesystem program proves the host syscall and object path, and "
+            "the x86-64 Linux pass in the CLI shards is not evidence for it. "
+            "The repetition is the coverage the responsibility matrix asks for."
+        ),
+    ),
+    Allowance(
+        targets=(
+            "//:cli-tests",
+            "//:release-smoke",
+            "//crates/rue-cli-tests:cli",
+        ),
+        platforms=("linux-arm64", "linux-x64", "macos-arm64"),
+        reason=(
+            "Exactly one case sits in the intersection of the two overlaps "
+            "above: `cli.differential_opt::aggregate_abi_across_opt_levels`. "
+            "libtest filters are substring matches, so the native lanes' `abi` "
+            "filter selects it as well as everything in cases/abi.toml, and it "
+            "is a differential-opt case so //:release-smoke selects it too. "
+            "Nothing new is decided here — it is the two allowances above "
+            "meeting on one case — but it is a distinct target set, and this "
+            "gate does not let one entry vouch for a set it does not name."
+        ),
+        provisional=True,
+    ),
+)
+
+
+# ADR-0069 §2 / RUE-1265. Targets whose harness is a Rust binary — so the gate
+# expects it to answer `--list` — and which do not. An undeclared one is an
+# error, because the alternative is the failure this gate cannot absorb: a
+# binary that stops listing collapses hundreds of tests into one opaque unit
+# and CI prints a clean pass. Each entry states what its opacity hides.
+#
+# Harnesses that are not Rust binaries are not in this ledger and are never
+# probed: a `sh_binary` cannot be libtest, and asking one to `--list` runs its
+# whole suite (see `Listing.listable`).
+NOT_LISTABLE = {
+    "//crates/rue-oracle-diff:oracle-diff-test": (
+        "rue-oracle-diff owns its own argument grammar and exits 1 on --list. "
+        "What this opacity hides is the largest overlap in the repository: this "
+        "target drives every runnable CLI case through the reference "
+        "interpreter and compares it against the compiler's own result, so it "
+        "re-executes the ~1,858-case corpus the CLI shards run in the same lane "
+        "on the same platform. It is a differential rather than a repetition — "
+        "the assertion is agreement between two implementations, which no "
+        "single execution can make — but it is second execution of the same "
+        "compiles, it is far larger than the 25-case release-smoke overlap "
+        "below, and nobody has priced it. Provisional: it needs the same "
+        "maintainer ruling, and making the target listable would let the gate "
+        "score it instead of this note."
+    ),
+    "//crates/rue-oracle-diff:oracle-diff-spec-test": (
+        "The same harness and the same trade against the specification corpus "
+        "//:spec-tests runs, ~2,100 cases, on the same platform in the same "
+        "run. Provisional for the same reason."
+    ),
+    "//:spec-traceability": (
+        "rue-spec's `--traceability` is a reporting mode, not a filter: handed "
+        "`--list` as well it prints the traceability report and exits 0. It "
+        "owns no cases of its own — it reads the same corpus //:spec-tests "
+        "runs and checks paragraph coverage — so the opacity hides no second "
+        "execution of anything. It is skipped rather than probed because "
+        "probing it IS a second execution of a premerge suite."
+    ),
+    "//:frontend-diff-test": (
+        "rue-frontend-diff takes only --refresh-manifest and drives a corpus "
+        "recorded in crates/rue-frontend-diff/src/corpus_manifest.rs. Its "
+        "corpus is that manifest rather than a case inventory shared with "
+        "another target, so the opacity hides no known overlap."
+    ),
+}
+
+
+@dataclass(frozen=True)
+class Scheduled:
+    """One target's test identities, as one lane on one platform runs them."""
+
+    platform: str
+    lane: str
+    target: str
+    # The target a duplicate set is attributed to. CLI shards fold onto the
+    # canonical corpus they slice, so the ledger does not churn every time the
+    # measured weights move a case from one shard to another.
+    owner: str
+    identities: frozenset[str]
+
+
+@dataclass(frozen=True)
+class DuplicateSet:
+    targets: tuple[str, ...]
+    platforms: tuple[str, ...]
+    identities: tuple[str, ...]
+    schedulings: tuple[str, ...]
+    # How many executions each platform pays. `linux-x64 ×2` is the strict
+    # "twice per platform per run" violation; a run of ×1 across three
+    # platforms is cross-platform repetition. Both are in the ledger, and a
+    # reader should not have to count the `scheduled by` line to tell them
+    # apart.
+    per_platform: tuple[tuple[str, int], ...] = ()
+
+    def describe(self, examples: int = 3) -> str:
+        # An identity is `<namespace>\t<test name>`; the namespace exists so two
+        # crates can both own `tests::empty_program`, and a reader does not need
+        # to see it.
+        names = [identity.split("\t", 1)[-1] for identity in self.identities]
+        shown = ", ".join(names[:examples])
+        if len(names) > examples:
+            shown += f", … ({len(names) - examples} more)"
+        spread = ", ".join(f"{platform} ×{count}" for platform, count in self.per_platform)
+        return (
+            f"{len(self.identities)} test(s) scheduled more than once ({spread})"
+            f"\n    owning targets: {', '.join(self.targets)}"
+            f"\n    scheduled by:   {'; '.join(self.schedulings)}"
+            f"\n    tests:          {shown}"
+        )
+
+
+def duplicate_sets(scheduled: list[Scheduled]) -> list[DuplicateSet]:
+    """Group every identity scheduled more than once by who owns it.
+
+    The grouping key is (owning targets, platforms) rather than the individual
+    test, because that is the unit a reader can act on: "these two targets
+    overlap on this platform" is a fact about the graph, while "this test runs
+    twice" is 813 facts about one.
+
+    Attribution folds a CLI shard onto the corpus it slices so a written
+    allowance does not expire when measured weights move a case between shards.
+    That fold must not erase the very thing it is folding, though: when several
+    distinct targets collapse to one owner, the duplication is *inside* the
+    fold group — two shards running the same case — and the key reverts to the
+    real targets. Otherwise a genuine cross-shard overlap would present as the
+    single owner `//:cli-tests` and no report could name what caused it.
+    """
+    where: dict[str, list[Scheduled]] = defaultdict(list)
+    for entry in scheduled:
+        for identity in entry.identities:
+            where[identity].append(entry)
+
+    grouped: dict[tuple, dict] = defaultdict(
+        lambda: {"identities": set(), "schedulings": set(), "spread": {}}
+    )
+    for identity, entries in where.items():
+        if len(entries) < 2:
+            continue
+        owners = {entry.owner for entry in entries}
+        targets = {entry.target for entry in entries}
+        attributed = targets if len(owners) == 1 and len(targets) > 1 else owners
+        key = (
+            tuple(sorted(attributed)),
+            tuple(sorted({entry.platform for entry in entries})),
+        )
+        body = grouped[key]
+        body["identities"].add(identity)
+        per_identity: dict[str, int] = defaultdict(int)
+        for entry in entries:
+            body["schedulings"].add(f"{entry.target} in {entry.lane} ({entry.platform})")
+            per_identity[entry.platform] += 1
+        # The worst single test, not the group's total: three sibling filters
+        # each owning disjoint cases is `×1` on each platform, and reporting it
+        # as `×3` would claim a same-platform violation that does not exist.
+        for platform, count in per_identity.items():
+            body["spread"][platform] = max(body["spread"].get(platform, 0), count)
+
+    return sorted(
+        (
+            DuplicateSet(
+                targets=targets,
+                platforms=platforms,
+                identities=tuple(sorted(body["identities"])),
+                schedulings=tuple(sorted(body["schedulings"])),
+                per_platform=tuple(
+                    (platform, body["spread"][platform]) for platform in platforms
+                ),
+            )
+            for (targets, platforms), body in grouped.items()
+        ),
+        key=lambda duplicate: (duplicate.targets, duplicate.platforms),
+    )
+
+
+def review(
+    duplicates: list[DuplicateSet], allowances: tuple[Allowance, ...] = ALLOWANCES
+) -> list[str]:
+    """Errors for undeclared duplications, and for allowances that rotted.
+
+    Matching is exact in both directions — see `Allowance` for the two shapes
+    and for the two defects that subset matching hid.
+    """
+    errors: list[str] = []
+    covered_by: dict[int, list[DuplicateSet]] = {
+        index: [] for index in range(len(allowances))
+    }
+
+    for duplicate in duplicates:
+        match = next(
+            (
+                index
+                for index, allowance in enumerate(allowances)
+                if allowance.covers(duplicate)
+            ),
+            None,
+        )
+        if match is not None:
+            covered_by[match].append(duplicate)
+            continue
+        errors.append(
+            "undeclared duplication: "
+            + duplicate.describe()
+            + "\n    Either stop scheduling one of them, or add an Allowance to "
+            "scripts/validate-test-duplication.py naming every target involved "
+            "and the reason the second execution earns its cost."
+        )
+
+    for index, allowance in enumerate(allowances):
+        for subject in allowance.unmatched(covered_by[index]):
+            errors.append(
+                f"stale allowance: {subject} on "
+                f"{', '.join(allowance.platforms)} no longer duplicates "
+                "anything. Remove it from the entry; an allowance that matches "
+                "nothing is a claim nobody is checking."
+            )
+
+    return errors
+
+
+# --------------------------------------------------------------------------
+# Buck graph interrogation
+# --------------------------------------------------------------------------
+
+MACRO_RE = re.compile(r"\$\((location|exe|exe_target)\s+([^)]+)\)")
+
+
+def normalize(label: str) -> str:
+    """`root//pkg:name` and `//pkg:name` are the same target."""
+    label = label.strip()
+    if label.startswith("root//"):
+        return label[len("root") :]
+    return label
+
+
+class Buck:
+    def __init__(self, buck: Path, root: Path) -> None:
+        self.buck = buck
+        self.root = root
+
+    def _run(self, args: list[str]) -> str:
+        result = subprocess.run(
+            [str(self.buck), *args],
+            cwd=str(self.root),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"buck2 {' '.join(args)} failed ({result.returncode}):\n{result.stderr}"
+            )
+        return result.stdout
+
+    def uquery(self, expression: str, attributes: str) -> dict[str, dict]:
+        raw = self._run(
+            ["uquery", expression, f"--output-attribute={attributes}", "--json"]
+        )
+        return {normalize(key): value for key, value in json.loads(raw).items()}
+
+    def outputs(self, targets: list[str]) -> dict[str, str]:
+        """Absolute default-output path per target, building what is missing."""
+        if not targets:
+            return {}
+        raw = self._run(["build", "--show-full-json-output", *targets])
+        # `buck2 build` prints progress on stderr and the JSON map on stdout,
+        # but a warning can still precede it; take the JSON object only.
+        start = raw.find("{")
+        parsed = json.loads(raw[start:]) if start >= 0 else {}
+        return {normalize(key): value for key, value in parsed.items()}
+
+
+ATTRIBUTES = "^(buck.type|labels|test|args|env|tests|harness|harness_args|corpus_env|srcs|crate_root)$"
+
+
+@dataclass
+class Listing:
+    """How to enumerate one target's tests, once its inputs are materialized."""
+
+    target: str
+    binary: str  # the Buck target providing the executable
+    args: list[str]
+    env: dict[str, str]
+    namespace_key: str  # targets sharing this share a test-name namespace
+    # Only `rust_test` binaries carry rustc's libtest, which is the only
+    # harness here with an `#[ignore]` concept. The corpus harnesses are
+    # libtest2-mimic `rust_binary`s, so asking them for the ignored set costs a
+    # second full discovery and can only return what the first listing already
+    # returned.
+    has_ignored: bool = False
+
+
+@dataclass
+class Inventory:
+    listings: dict[str, Listing] = field(default_factory=dict)
+    # Targets whose contents cannot be enumerated (a shell gate, a rue_program
+    # scenario). They are still units of work, so each contributes exactly one
+    # opaque identity and duplicates across lanes are still caught.
+    opaque: set[str] = field(default_factory=set)
+    # What each scheduled target expands to. A `test_suite` is not a unit of
+    # work — buck2 runs its members, once each, no matter how many suites reach
+    # them — so the schedule is built from these leaves rather than from the
+    # names the lane happens to mention.
+    units: dict[str, list[str]] = field(default_factory=dict)
+    # Targets that name a Buck target as their harness and whose attributes
+    # could not be read. Falling back to "opaque" here would be the one failure
+    # mode this gate cannot tolerate: a wrapper that lists 850 tests would
+    # silently count as one unit and its duplication would disappear. Loud
+    # instead.
+    unresolved: dict[str, str] = field(default_factory=dict)
+    # Targets the graph says cannot be libtest, with the rule kind that settles
+    # it. Reported, never probed — see the comment at the assignment site.
+    not_libtest: dict[str, str] = field(default_factory=dict)
+    # Targets whose listing was well formed and enumerated nothing.
+    empty: set[str] = field(default_factory=set)
+
+
+def is_target_label(value: object) -> bool:
+    return isinstance(value, str) and value.startswith("root//") and ":" in value
+
+
+def namespace_key(binary: str, node: dict) -> str:
+    """Targets compiling the same sources share a test-name namespace.
+
+    Two crates can both own `tests::empty_program` without that being a
+    duplication, so identities are namespaced. Keying the namespace on the
+    sources rather than on the label is what catches the RUE-1262 shape: a
+    second `rust_test` over the same `srcs` is a different target compiling the
+    same tests, and it must collide. It is also what makes the CLI shards, the
+    release smoke, and the native lanes' `scripts/rue cli` steps comparable —
+    all of them run one binary.
+    """
+    srcs = node.get("srcs")
+    if srcs:
+        fingerprint = json.dumps(
+            {
+                "srcs": sorted(normalize(str(src)) for src in srcs),
+                "crate_root": node.get("crate_root"),
+            },
+            sort_keys=True,
+        )
+        digest = hashlib.sha256(fingerprint.encode()).hexdigest()[:12]
+        return f"srcs:{digest}"
+    return f"target:{binary}"
+
+
+def resolve_inventory(buck: Buck, targets: set[str]) -> Inventory:
+    """Classify each scheduled target into a listable harness or an opaque unit."""
+    inventory = Inventory()
+    pending = set(targets)
+    seen: set[str] = set()
+    attributes: dict[str, dict] = {}
+
+    # test_suite membership is transitive, so resolve in rounds rather than
+    # assuming one level.
+    while pending:
+        batch = sorted(pending - seen)
+        seen |= set(batch)
+        pending = set()
+        # A sub-target (`//crates/rue-rir:rue-rir[doc]`, the compile-fail doc
+        # suite) is not queryable and owns no listable inventory; it is one
+        # opaque unit of work, which is all this gate needs of it.
+        inventory.opaque |= {target for target in batch if "[" in target}
+        batch = [target for target in batch if "[" not in target]
+        if not batch:
+            break
+        attributes.update(buck.uquery(f"set({' '.join(batch)})", ATTRIBUTES))
+        for target in batch:
+            node = attributes.get(target)
+            if node is None:
+                continue
+            if node.get("buck.type") == "test_suite":
+                members = {normalize(item) for item in node.get("tests") or []}
+                pending |= members
+                attributes.setdefault(target, node)["_members"] = sorted(members)
+
+    # A second query for the two things a listable target points at: the binary
+    # a wrapper runs, and the corpus action behind a stamp check. Everything
+    # else a gate names is an input, not a harness.
+    requested: set[str] = set()
+
+    def reference_round() -> bool:
+        referenced: set[str] = set()
+        for _, node in attributes.items():
+            test = node.get("test")
+            if is_target_label(test):
+                referenced.add(normalize(test))
+            harness = node.get("harness")
+            if is_target_label(harness):
+                referenced.add(normalize(harness))
+            for arg in node.get("args") or []:
+                for _, payload in MACRO_RE.findall(arg):
+                    candidate = normalize(payload)
+                    if candidate.startswith("//") and candidate.endswith("-action"):
+                        referenced.add(candidate)
+        referenced = {t for t in referenced if "[" not in t} - set(attributes) - requested
+        if not referenced:
+            return False
+        # Record the request, not the answer: a target the query cannot return
+        # never enters `attributes`, and asking again forever is not a better
+        # outcome than classifying it as unresolved.
+        requested.update(referenced)
+        attributes.update(buck.uquery(f"set({' '.join(sorted(referenced))})", ATTRIBUTES))
+        return True
+
+    # Two rounds: a stamp-check `sh_test` names its `-action`, and only that
+    # action names the harness. Stopping after one round left every corpus
+    # harness unqueried, which reads as "no rule kind" — indistinguishable from
+    # "not a Rust binary" — and namespaced its cases by label instead of by
+    # sources, so the CLI shards and //:release-smoke could not collide.
+    while reference_round():
+        pass
+
+    def namespace_of(binary: str) -> str:
+        return namespace_key(binary, attributes.get(binary, {}))
+
+    def classify(target: str) -> list[str]:
+        """Returns the leaf units `target` schedules, registering each one."""
+        node = attributes.get(target)
+        if node is None:
+            inventory.opaque.add(target)
+            return [target]
+        kind = node.get("buck.type")
+
+        if kind == "test_suite":
+            leaves: list[str] = []
+            for member in node.get("_members", []):
+                leaves.extend(classify(member))
+            return leaves
+
+        if kind == "rust_test":
+            inventory.listings[target] = Listing(
+                target=target,
+                binary=target,
+                args=[],
+                env=dict(node.get("env") or {}),
+                namespace_key=namespace_of(target),
+                has_ignored=True,
+            )
+            return [target]
+
+        if kind == "sh_test":
+            test = node.get("test")
+            args = list(node.get("args") or [])
+            if is_target_label(test):
+                wrapped = normalize(test)
+                wrapped_kind = attributes.get(wrapped, {}).get("buck.type")
+                if wrapped_kind in ("rust_test", "rust_binary"):
+                    # The scaling matrix: one binary, selected rows.
+                    inventory.listings[target] = Listing(
+                        target=target,
+                        binary=wrapped,
+                        args=args,
+                        env=dict(node.get("env") or {}),
+                        namespace_key=namespace_of(wrapped),
+                        has_ignored=wrapped_kind == "rust_test",
+                    )
+                    return [target]
+                action = corpus_action(args)
+                if action and attributes.get(action, {}).get("buck.type") == "_corpus_action":
+                    node_action = attributes[action]
+                    harness = normalize(node_action["harness"])
+                    harness_kind = attributes.get(harness, {}).get("buck.type")
+                    # THE `--list` PROTOCOL IS NOT UNIVERSAL, AND PROBING FOR IT
+                    # IS NOT FREE. `//:reproducible-programs` and
+                    # `//:oracle-diff-generated-smoke` are `sh_binary` harnesses
+                    # over shell scripts that do no argument handling at all:
+                    # handed `--list` they ignore it, run their entire suite to
+                    # completion, exit 0, and print nothing this parser matches.
+                    # The first revision of this gate probed them anyway. It
+                    # bought zero identities for 29s of the 30.6s it spent, and
+                    # — because both are `rue_test_tier_premerge` and the probe
+                    # bypasses `cached_corpus_suite` — it ran two premerge
+                    # suites a second time, uncached, in the step before
+                    # `test.sh` ran them again. A duplication gate causing
+                    # duplication. Only a Rust binary can be libtest, so that is
+                    # the question the graph is asked, before anything executes.
+                    if harness_kind not in ("rust_test", "rust_binary"):
+                        inventory.not_libtest[target] = (
+                            f"harness {harness} is a {harness_kind}; only a Rust "
+                            "binary can carry libtest"
+                        )
+                        inventory.opaque.add(target)
+                        return [target]
+                    inventory.listings[target] = Listing(
+                        target=target,
+                        binary=harness,
+                        args=list(node_action.get("harness_args") or []),
+                        env=dict(node_action.get("corpus_env") or {}),
+                        namespace_key=namespace_of(harness),
+                    )
+                    return [target]
+                if wrapped not in attributes:
+                    inventory.unresolved[target] = (
+                        f"runs {wrapped}, whose attributes the graph query did "
+                        "not return"
+                    )
+        inventory.opaque.add(target)
+        return [target]
+
+    def corpus_action(args: list[str]) -> str | None:
+        for arg in args:
+            for _, payload in MACRO_RE.findall(arg):
+                candidate = normalize(payload)
+                if candidate.endswith("-action"):
+                    return candidate
+        return None
+
+    for target in sorted(targets):
+        inventory.units[target] = classify(target)
+    return inventory
+
+
+# Env keys a harness reads only while *running* a case, never while
+# discovering one. Materializing them would make the gate build artifacts no
+# listing consults.
+#
+# `RUE_CLI_STAGED_PROGRAMS` is the whole reason this exists.
+# `//:cli-staged-programs` stages ten `rue_program` executables, Meridian's
+# among them at 80.7s in ADR-0070's own table, and the premerge lane never
+# builds it: that job builds `//crates/...`, and root corpus targets are
+# deliberately excluded (`ci.yml`, "Build all targets"). The CLI shards that do
+# consume it run in different jobs on different runners, so it would be a cache
+# hit only through BuildBuddy — absent on fork PRs. Discovery does not need it:
+# `crates/rue-cli-tests/src/main.rs:3142` returns immediately when the variable
+# is unset, and `:2032` is the only other read, inside `staged_program()` on the
+# per-case execution path. Dropping it fails closed anyway, because a listing
+# that comes back empty is an error rather than an absent duplication.
+EXECUTION_ONLY_ENV = frozenset({"RUE_CLI_STAGED_PROGRAMS"})
+
+
+def listing_env(listing: "Listing") -> dict[str, str]:
+    return {
+        key: value
+        for key, value in listing.env.items()
+        if key not in EXECUTION_ONLY_ENV
+    }
+
+
+def materialize(buck: Buck, listings: list["Listing"]) -> dict[str, str]:
+    """Build each harness and the `$(location ...)` targets its listing needs."""
+    wanted: set[str] = set()
+    for listing in listings:
+        wanted.add(listing.binary)
+        for value in list(listing_env(listing).values()) + listing.args:
+            for _, payload in MACRO_RE.findall(value):
+                wanted.add(normalize(payload))
+    return buck.outputs(sorted(wanted))
+
+
+def expand(value: str, outputs: dict[str, str]) -> str:
+    def replace(match: re.Match[str]) -> str:
+        target = normalize(match.group(2))
+        path = outputs.get(target)
+        if path is None:
+            raise RuntimeError(f"no built output for {target}")
+        return path
+
+    return MACRO_RE.sub(replace, value)
+
+
+LIST_LINE_RE = re.compile(r"^(?P<name>.+): (?:test|bench(?:mark)?)$")
+# Both harnesses close a listing with a count: rustc's libtest writes
+# "856 tests, 0 benchmarks", libtest2-mimic writes "1858 tests". Its presence is
+# what separates "this binary listed nothing because it owns nothing" from "this
+# binary ignored --list and did something else entirely" — which is not a
+# theoretical distinction: `//:spec-traceability` wraps rue-spec with
+# `--traceability`, and given `--list` it prints the traceability report and
+# exits 0. Scraping that for `NAME: test` finds nothing, and the first revision
+# of this gate read the silence as "no tests to compare" while having just run a
+# premerge suite for the second time in the same job.
+LIST_TRAILER_RE = re.compile(r"^\d+ tests?(?:, \d+ bench(?:mark)?(?:es|s)?)?$")
+
+
+class Lister:
+    """Runs `--list`, once per distinct (binary, args, env), and measures it.
+
+    ADR-0069 accepts this as new required work on the critical path, so the
+    cost is reported rather than assumed. The listings are independent
+    processes, so they run concurrently: the number worth quoting is the wall
+    time a lane pays, not the summed process time.
+    """
+
+    def __init__(self, root: Path, jobs: int | None = None) -> None:
+        self.root = root
+        self.jobs = jobs or min(8, (os.cpu_count() or 2))
+        self.cache: dict[tuple, frozenset[str] | RuntimeError] = {}
+        self.unlistable: dict[str, str] = {}
+        self.lock = threading.Lock()
+        self.timings: list[tuple[float, str]] = []
+        self.process_seconds = 0.0
+        self.wall_seconds = 0.0
+        self.invocations = 0
+
+    @staticmethod
+    def _key(executable: str, args: list[str], env: dict[str, str]) -> tuple:
+        return (executable, tuple(args), tuple(sorted(env.items())))
+
+    def _invoke(self, key: tuple) -> None:
+        executable, args, env_items = key
+        environment = dict(os.environ)
+        environment.update(dict(env_items))
+        started = time.monotonic()
+        result = subprocess.run(
+            [executable, "--list", *args],
+            cwd=str(self.root),
+            capture_output=True,
+            text=True,
+            env=environment,
+            check=False,
+        )
+        elapsed = time.monotonic() - started
+        if result.returncode != 0:
+            value: frozenset[str] | RuntimeError = RuntimeError(
+                f"{executable} --list {' '.join(args)} failed "
+                f"({result.returncode}): {result.stderr.strip().splitlines()[-1] if result.stderr.strip() else 'no output'}"
+            )
+        else:
+            lines = result.stdout.splitlines()
+            if not any(LIST_TRAILER_RE.match(line.strip()) for line in lines):
+                value = RuntimeError(
+                    f"{executable} --list {' '.join(args)} produced no libtest "
+                    "listing (no test-count trailer); the harness ignored --list"
+                )
+            else:
+                value = frozenset(
+                    match.group("name")
+                    for match in (LIST_LINE_RE.match(line) for line in lines)
+                    if match
+                )
+        with self.lock:
+            self.cache[key] = value
+            self.timings.append((elapsed, f"{Path(executable).name} {' '.join(args)}"[:96]))
+            self.process_seconds += elapsed
+            self.invocations += 1
+
+    def prime(self, plans: list[tuple]) -> None:
+        """Run every distinct listing once, in parallel."""
+        pending = []
+        seen: set[tuple] = set()
+        for key in plans:
+            if key in seen or key in self.cache:
+                continue
+            seen.add(key)
+            pending.append(key)
+        if not pending:
+            return
+        started = time.monotonic()
+        with ThreadPoolExecutor(max_workers=self.jobs) as pool:
+            list(pool.map(self._invoke, pending))
+        self.wall_seconds += time.monotonic() - started
+
+    def _list(self, executable: str, args: list[str], env: dict[str, str]) -> frozenset[str]:
+        key = self._key(executable, args, env)
+        if key not in self.cache:
+            self.prime([key])
+        value = self.cache[key]
+        if isinstance(value, RuntimeError):
+            raise value
+        return value
+
+    @staticmethod
+    def plans(listing: Listing, outputs: dict[str, str]) -> list[tuple]:
+        """Every listing invocation `identities` will need, for `prime`."""
+        if listing.target in NOT_LISTABLE:
+            return []
+        executable = outputs[listing.binary]
+        args = [expand(arg, outputs) for arg in listing.args]
+        env = {key: expand(value, outputs) for key, value in listing_env(listing).items()}
+        keys = [Lister._key(executable, args, env)]
+        if listing.has_ignored and "--ignored" not in args:
+            keys.append(Lister._key(executable, [*args, "--ignored"], env))
+        return keys
+
+    def identities(self, listing: Listing, outputs: dict[str, str]) -> frozenset[str] | None:
+        """The tests this target runs, or None when its Rust harness refuses.
+
+        `rue-oracle-diff` and `rue-frontend-diff` are Rust binaries with their
+        own argument grammar; they exit non-zero on `--list` at once, costing
+        nothing. Returning None is not a quiet downgrade — `collect` requires
+        every such target to be declared in `NOT_LISTABLE`, so a binary that
+        *stops* listing fails the gate instead of collapsing its tests into one
+        opaque unit.
+        """
+        if listing.target in NOT_LISTABLE:
+            # Declared, so not probed. `rue-spec --traceability` is the reason
+            # this is a skip rather than a probe-and-tolerate: asking it costs a
+            # second execution of a premerge suite, which is the very thing this
+            # gate exists to prevent.
+            self.unlistable[listing.target] = "declared NOT_LISTABLE; not probed"
+            return None
+        executable = outputs[listing.binary]
+        args = [expand(arg, outputs) for arg in listing.args]
+        env = {key: expand(value, outputs) for key, value in listing_env(listing).items()}
+
+        try:
+            listed = self._list(executable, args, env)
+        except RuntimeError as error:
+            self.unlistable[listing.target] = str(error).splitlines()[-1].strip()
+            return None
+        if listing.has_ignored and "--ignored" not in args:
+            # libtest lists ignored tests too, and an ignored test is not
+            # scheduled work. `--ignored` inverts the selection, which is
+            # exactly how the scaling-matrix canary picks its three rows out of
+            # the shared binary — so subtracting that set leaves what runs.
+            try:
+                listed = listed - self._list(executable, [*args, "--ignored"], env)
+            except RuntimeError:
+                pass
+        return frozenset(f"{listing.namespace_key}\t{name}" for name in listed)
+
+
+# --------------------------------------------------------------------------
+# Lane assembly
+# --------------------------------------------------------------------------
+
+
+def affected_targets(subcommand: str, *args: str, script: Path = AFFECTED_TARGETS) -> list[str]:
+    result = subprocess.run(
+        ["bash", str(script), subcommand, *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"scripts/affected-targets {subcommand} failed: {result.stderr.strip()}"
+        )
+    return [normalize(token) for token in result.stdout.split()]
+
+
+def lane_membership(buck: Buck, script: Path = AFFECTED_TARGETS) -> dict[str, list[str]]:
+    """Which targets each lane schedules, derived rather than transcribed."""
+    premerge = buck.uquery(PREMERGE_QUERY, "^labels$")
+    labels = {target: set(node.get("labels") or []) for target, node in premerge.items()}
+
+    shards = {target for target, tags in labels.items() if CLI_SHARD_LABEL in tags}
+    dedicated = {target for target, tags in labels.items() if DEDICATED_LANE_LABEL in tags}
+
+    lanes = {
+        "linux-premerge": sorted(set(labels) - shards - dedicated),
+        "platform-corpus": sorted(affected_targets("corpus-targets", script=script)),
+        "release": sorted(affected_targets("lane-targets", "release", script=script)),
+    }
+    for lane in ("native-linux-arm64", "native-macos-arm64"):
+        # The manifest-driven corpora appear in the native lanes' selection
+        # entry because an `only_on` case of theirs can be affected, but the
+        # lanes run `scripts/run-native-platform-corpus.sh`'s host-evaluated
+        # `only_on` subset, not the corpus. That subset is a property of the
+        # runner's own host, so a linux-x64 gate cannot enumerate it; the
+        # RUE-1161 platform responsibility gate covers that surface instead.
+        lanes[lane] = sorted(
+            target
+            for target in affected_targets("lane-targets", lane, script=script)
+            if target not in dedicated
+        )
+
+    for lane in ("native-linux-arm64", "native-macos-arm64"):
+        lanes[lane].extend(
+            f"{NATIVE_CLI_ALIAS} {filter_}" for filter_ in NATIVE_CLI_FILTERS
+        )
+
+    known = set(affected_targets("lanes", script=script)) | {"linux-premerge", "platform-corpus"}
+    unclassified = known - set(lanes) - SELECTION_PROXY_LANES
+    if unclassified:
+        raise RuntimeError(
+            "scripts/affected-targets knows lanes this gate does not classify: "
+            + ", ".join(sorted(unclassified))
+            + ". Add it to LANE_PLATFORMS if it schedules Buck test targets, or "
+            "to SELECTION_PROXY_LANES if its targets only represent it for "
+            "selection."
+        )
+    return lanes
+
+
+def owner_of(target: str, shards: set[str]) -> str:
+    """The target a duplicate set is attributed to.
+
+    A CLI shard is a scheduling alternative for `//:cli-tests`, and which shard
+    holds a case is decided by measured weights that move. Attributing to the
+    corpus keeps a written allowance from expiring because a case changed
+    shards. `duplicate_sets` undoes the fold when the duplication is between
+    two members of the fold group, so this cannot hide a cross-shard overlap.
+
+    The three `scripts/rue cli <filter>` workflow steps attribute to the alias
+    they all run, for the same reason: one fact, one entry.
+    """
+    if target in shards:
+        return re.sub(r"-shard-\d+$", "", target)
+    if target.startswith(f"{NATIVE_CLI_ALIAS} "):
+        return NATIVE_CLI_ALIAS
+    return target
+
+
+def workflow_step_listings(buck: Buck) -> dict[str, Listing]:
+    """Listings for the native lanes' three `scripts/rue cli <filter>` steps.
+
+    RUE-1265's first revision modelled only Buck test targets, and these three
+    steps are not one: `scripts/rue cli abi` runs
+    `buck2 run //crates/rue-cli-tests:cli -- abi`. The alias is a real graph
+    node carrying its own env, so everything except the filter string is
+    derived; the filters themselves live in `ci.yml` and
+    `scripts/validate-ci-gate.py` imports `NATIVE_CLI_FILTERS` from here so the
+    two cannot drift.
+
+    It matters because the alias leaves both `RUE_CLI_CASE_TIER` and
+    `RUE_PLATFORM_CASE_SELECTION` unset — every tier, every case, not the
+    `only_on` subset — and `cases/abi.toml` declares no `only_on` at all. Those
+    cases run on linux-x64 in the CLI shards and again on both native lanes,
+    and unlike the host-evaluated native corpus they are fully enumerable from
+    a linux-x64 gate. Omitting them let the invariant overclaim.
+    """
+    node = buck.uquery(f"set({NATIVE_CLI_ALIAS})", "^(buck.type|exe|env)$").get(
+        NATIVE_CLI_ALIAS
+    )
+    if node is None or node.get("buck.type") != "command_alias":
+        raise RuntimeError(
+            f"{NATIVE_CLI_ALIAS} is not a command_alias; the native lanes' "
+            "`scripts/rue cli` steps can no longer be enumerated"
+        )
+    binary = normalize(node["exe"])
+    env = dict(node.get("env") or {})
+    # The same namespace the corpus suites get, because it is the same binary;
+    # otherwise these cases could never collide with the CLI shards' and the
+    # overlap this exists to find would be invisible.
+    harness = buck.uquery(f"set({binary})", ATTRIBUTES).get(binary, {})
+    namespace = namespace_key(binary, harness)
+    return {
+        f"{NATIVE_CLI_ALIAS} {filter_}": Listing(
+            target=f"{NATIVE_CLI_ALIAS} {filter_}",
+            binary=binary,
+            args=[filter_],
+            env=env,
+            namespace_key=namespace,
+        )
+        for filter_ in NATIVE_CLI_FILTERS
+    }
+
+
+def lane_units(members: list[str], expansion: dict[str, list[str]]) -> list[str]:
+    """The leaf targets one lane actually executes, each exactly once.
+
+    A `test_suite` is not a unit of work: buck2 runs its members, and a member
+    named both directly and through a suite still runs once. Counting the name
+    twice would be this gate inventing a duplication no runner performs.
+    """
+    return sorted({unit for member in members for unit in expansion.get(member, [member])})
+
+
+def collect(buck: Buck, script: Path = AFFECTED_TARGETS) -> tuple[list[Scheduled], Lister, Inventory]:
+    lanes = lane_membership(buck, script)
+    # A workflow step is written `<target> <filter>` and is not a Buck target,
+    # so it never reaches the graph queries; `workflow_step_listings` derives it
+    # from the alias instead.
+    scheduled_targets = {
+        target
+        for members in lanes.values()
+        for target in members
+        if " " not in target
+    }
+    inventory = resolve_inventory(buck, scheduled_targets)
+    if inventory.unresolved:
+        raise RuntimeError(
+            "could not resolve what these targets execute, so their contents "
+            "would be invisible rather than compared: "
+            + "; ".join(
+                f"{target} ({reason})"
+                for target, reason in sorted(inventory.unresolved.items())
+            )
+        )
+    inventory.listings.update(workflow_step_listings(buck))
+    outputs = materialize(buck, list(inventory.listings.values()))
+    lister = Lister(buck.root)
+
+    shard_nodes = buck.uquery(
+        f"attrfilter(labels, '{CLI_SHARD_LABEL}', set(//... toolchains//...))", "^labels$"
+    )
+    shards = set(shard_nodes)
+
+    # One parallel pass over every distinct listing, so the cost this gate adds
+    # to the critical path is bounded by the slowest binary rather than by the
+    # sum of all of them.
+    lister.prime(
+        [
+            key
+            for listing in inventory.listings.values()
+            for key in Lister.plans(listing, outputs)
+        ]
+    )
+
+    schedule: list[Scheduled] = []
+    empty: list[str] = []
+    for lane, members in lanes.items():
+        platform = LANE_PLATFORMS[lane]
+        for unit in lane_units(members, inventory.units):
+            listing = inventory.listings.get(unit)
+            identities = lister.identities(listing, outputs) if listing else None
+            if identities is None:
+                identities = frozenset({f"target:{unit}\t<whole target>"})
+            if not identities:
+                # A well-formed listing of zero tests: the binary exists, runs,
+                # and owns nothing to compare (`rue-air-profile-test` is one).
+                # It is still a unit of work, so it counts as one — dropping it
+                # from the schedule, as the first revision did, is how two whole
+                # suites left the comparison without anything saying so.
+                empty.append(unit)
+                identities = frozenset({f"target:{unit}\t<no tests>"})
+            schedule.append(
+                Scheduled(
+                    platform=platform,
+                    lane=lane,
+                    target=unit,
+                    owner=owner_of(unit, shards),
+                    identities=identities,
+                )
+            )
+
+    inventory.empty.update(empty)
+
+    undeclared = sorted(set(lister.unlistable) - set(NOT_LISTABLE))
+    if undeclared:
+        raise RuntimeError(
+            "a Rust harness stopped answering --list, which silently collapses "
+            "every test it owns into one opaque unit: "
+            + "; ".join(f"{target} ({lister.unlistable[target]})" for target in undeclared)
+            + ". Fix the harness, or declare it in NOT_LISTABLE with a reason "
+            "stating what the opacity hides."
+        )
+    recovered = sorted(
+        (set(NOT_LISTABLE) - set(lister.unlistable)) & set(inventory.listings)
+    )
+    if recovered:
+        raise RuntimeError(
+            "these targets are declared NOT_LISTABLE but now enumerate their "
+            "tests; remove the declaration so the gate scores them: "
+            + ", ".join(recovered)
+        )
+    return schedule, lister, inventory
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--buck", type=Path, default=DEFAULT_BUCK)
+    parser.add_argument("--repo-root", type=Path, default=ROOT)
+    parser.add_argument(
+        "--affected-targets",
+        type=Path,
+        default=AFFECTED_TARGETS,
+        help="lane and corpus inventory script (the determinator's own list)",
+    )
+    parser.add_argument(
+        "--report",
+        action="store_true",
+        help="print every lane's identity count even when the gate passes",
+    )
+    args = parser.parse_args()
+
+    buck = Buck(args.buck, args.repo_root)
+    started = time.monotonic()
+    try:
+        schedule, lister, inventory = collect(buck, args.affected_targets)
+    except RuntimeError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    wall = time.monotonic() - started
+
+    duplicates = duplicate_sets(schedule)
+    errors = review(duplicates)
+
+    if args.report:
+        for entry in sorted(schedule, key=lambda item: (item.platform, item.lane, item.target)):
+            print(f"{entry.platform:12} {entry.lane:20} {entry.target} — {len(entry.identities)} test(s)")
+        for target, reason in sorted(inventory.not_libtest.items()):
+            print(f"not libtest: {target} — {reason}")
+        print("slowest listings:")
+        for elapsed, description in sorted(lister.timings, reverse=True)[:5]:
+            print(f"  {elapsed:6.2f}s  {description}")
+
+    # Unconditional, not behind --report. These are the targets whose contents
+    # the comparison cannot see; a reader of a passing CI log has to be able to
+    # tell how much of the graph the verdict actually covers, and the step in
+    # ci.yml does not pass --report.
+    print(
+        f"opaque: {len(inventory.opaque)} unit(s) carry no enumerable inventory "
+        f"({len(inventory.not_libtest)} non-libtest harness, "
+        f"{len(lister.unlistable)} declared NOT_LISTABLE, "
+        f"{len(inventory.empty)} listing zero tests)"
+    )
+    for target in sorted(lister.unlistable):
+        print(f"  not listable: {target} — {NOT_LISTABLE[target].split('.')[0]}.")
+
+    total = sum(len(entry.identities) for entry in schedule)
+    print(
+        f"scheduled {total} test executions across {len(schedule)} target/lane pairs; "
+        f"{lister.invocations} --list invocations cost {lister.wall_seconds:.2f}s wall "
+        f"({lister.process_seconds:.2f}s of process time across {lister.jobs} workers); "
+        f"{wall:.2f}s including graph queries and materialization"
+    )
+
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    allowed = sum(len(entry.identities) for entry in duplicates)
+    print(
+        f"no test executes twice per platform per run: {len(duplicates)} declared "
+        f"duplicate set(s) covering {allowed} test(s), none undeclared"
+    )
+    for entry in ALLOWANCES:
+        if entry.provisional:
+            print(
+                f"note: the allowance for {', '.join(entry.targets)} is provisional "
+                "and awaits a maintainer ruling (ADR-0069 open questions)"
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Phase 3 of ADR-0069 (§2, "Nothing executes twice").

Every CI gate in this repository compares **target lists**. None compares **test contents**, so a target that is a strict superset of another is invisible to all of them. That blind spot hid the largest single cost in CI — `scaling-matrix-test` re-running 813 of `rue-compiler-test`'s tests to gain three — for weeks. RUE-1262 fixed that instance. This is what converts "we fixed this instance" into "this class cannot recur."

## The gate

`scripts/validate-test-duplication.py` resolves each lane's membership from the live graph (never from YAML), maps each target to the binary it actually executes, `--list`s it with its own args and `$(location …)`-resolved env, and fails on any test scheduled more than once per platform per run without a declared allowance. Failures name both owning targets and every lane that scheduled them.

Allowances declare one of two shapes and match **exactly**: `per-target` (a roster, each target repeating on its own) or `between-targets` (an exact set). Neither absorbs an overlap between its own members, and staleness is tracked per target rather than per entry — an 8-target roster cannot sit 7/8 false.

## Cost

**0.30s wall for 73 `--list` invocations**, 0.69s including graph queries and materialization. Slowest single listing is 0.17s.

Four targets are declared `NOT_LISTABLE` and never probed, because probing them *is* the duplication: `//:reproducible-programs` and `//:oracle-diff-generated-smoke` are `sh_binary` wrappers that ignore `--list` and run their whole suite, and `//:spec-traceability` prints a traceability report and exits 0. Listing them cost 16.4s and yielded zero identities — the gate was re-running three premerge suites to learn nothing. A libtest test-count trailer is now required for output to count as a listing at all, so an unlistable harness cannot masquerade as an empty one.

An undeclared Rust harness that refuses `--list` is a hard error. `rue-compiler-test` silently collapsing to one unit would fail the gate rather than pass it.

## What it found

Twelve declared duplicate sets covering 1,933 tests. Eight are the native unit targets repeating per the platform-responsibility matrix. The rest are recorded with written reasons, and four are marked provisional pending a maintainer ruling — printed unconditionally on every passing run, not buried behind a flag:

- `rue-compiler-test` on three platforms (ADR-0069 Phase 4 / RUE-1262 scope C).
- `release-smoke`, which turns out to run **three** times on linux-x64, not two — the third pass is in `linux-premerge` under debug, where the shards already ran those cases, and it carries no configuration of its own.
- One case in the intersection of two allowed overlaps, because libtest filters are substrings.
- The oracle differentials, which re-execute several thousand cases the CLI shards and spec suite already run — the largest overlap in the repo, and currently opaque to the gate because those harnesses cannot be listed.

`docs/process/ci.md` gains a "Where it cannot see" section stating that boundary rather than leaving it implicit, and the `ci.md:46` contradiction with `validate-ci-gate.py:204` is resolved by describing what actually runs and naming Phase 4 as the work that makes the original claim true.

Closes RUE-1265.