### PR TITLE
RUE-1222: make the scheduled cache-free run carry the corpus safeguards

### DIFF
--- a/.github/workflows/correctness-repetitions.yml
+++ b/.github/workflows/correctness-repetitions.yml
@@ -1,3 +1,23 @@
+# Everything here executes the corpora for real, which is the one property that
+# ties its two purposes together (RUE-1159, RUE-1222):
+#
+#   * repetition only detects flakes if each repetition really executes, and
+#   * a corpus is a cacheable build action, so an input it fails to declare is
+#     a false pass rather than an untracked re-run — the cache serves the
+#     previous tree's result for a tree that changed.
+#
+# The second is why the sweep below exists alongside the repeated shards.
+#
+# What makes that hold is the runner, not a flag. Each job starts on a fresh
+# runner with an empty `buck-out`, and no BuildBuddy secret is provisioned here,
+# so there is nothing to serve any of it from. `ci-heavy-suite` also passes
+# `--no-remote-cache`, but that only forecloses a populated remote cache — it
+# does not touch buck2's local DICE state, which is why repeating a target in one
+# workspace needs the separate mechanism `ci-heavy-suite` documents.
+#
+# Nothing here is a required check; it bounds how long a defect can stay
+# invisible, it does not gate a merge. That also means nothing turns red when it
+# fails, so read the run list after changing anything in it.
 name: Correctness repetitions
 
 on:
@@ -9,6 +29,10 @@ on:
         description: Independent executions per shard (failures are never cleared)
         default: "5"
         required: true
+      sweep:
+        description: Also execute every other corpus cache-free (the RUE-1222 safeguard)
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -33,6 +57,11 @@ jobs:
         env:
           RUE_REPETITION_LOG_DIR: ${{ runner.temp }}/repetitions
         run: scripts/ci-repeat-correctness "//:cli-tests-shard-${{ matrix.shard }}" "${{ inputs.repetitions || '5' }}"
+      # Carries the per-repetition logs, the results table, and (RUE-1222) the
+      # `case-timings-N.jsonl` files, which are the freshly measured per-case
+      # costs `scripts/generate-cli-shard-weights.py` wants. A required-CI shard
+      # replays whatever timings the run that populated its cache entry recorded;
+      # these runs execute, so they are the corpus measuring itself again.
       - name: Upload independent-run report
         if: always()
         uses: actions/upload-artifact@v6
@@ -40,6 +69,89 @@ jobs:
           name: correctness-repetitions-linux-x64-shard-${{ matrix.shard }}
           path: ${{ runner.temp }}/repetitions
           if-no-files-found: error
+
+  # RUE-1222: the undeclared-input safeguard.
+  #
+  # Converting the corpora to build actions made the declared input contract
+  # load-bearing: a path a harness reads but the action does not name means the
+  # cache serves the previous tree's stamp for a tree that changed, and the
+  # corpus reports a pass it never ran. PR #2000's first CI run caught the UI
+  # corpus's undeclared `std/` exactly that way. Nothing detects the next one
+  # except a run that actually executes the harness against the current tree.
+  #
+  # The repeated shards above are such a run, but only for the CLI corpus. This
+  # sweep covers the rest, and it takes its inventory from the Buck graph rather
+  # than from a list in this file: `ci-corpus-inventory` queries the
+  # `_corpus_action` rule that `cached_corpus_suite` expands to, so a corpus
+  # converted later is swept without anyone remembering to add it. It fails
+  # closed on an empty or unreadable inventory, and cross-checks the result
+  # against the `rue_heavy_suite` label set, because a sweep that proves nothing
+  # must not report success.
+  #
+  # What the sweep checks is the input DECLARATION, which is a property of the
+  # rule rather than of a configuration: it runs each corpus under
+  # `prelude//platforms:default`, while `ci.yml` runs `//:release-smoke` under
+  # `//platforms:release`. An input the harness reads but the action does not
+  # name is missing in both, so executing either configuration exposes it. What
+  # this does NOT do is exercise the release-configured actions' own cache
+  # entries; nothing here should be read as covering those.
+  corpus-inventory:
+    name: cache-free corpus inventory (linux-x64)
+    if: github.event_name != 'workflow_dispatch' || inputs.sweep
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.inventory.outputs.targets }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: facebook/install-dotslash@v2
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/dotslash
+          key: dotslash-repetitions-linux-x64-${{ hashFiles('buck2') }}
+          restore-keys: dotslash-repetitions-linux-x64-
+      - name: Enumerate every corpus that runs as a build action
+        id: inventory
+        # Both exclusions are the CLI corpus, which `repeat-cli-shards` above
+        # already executes five times over in this same workflow. The shards
+        # declare a strict SUPERSET of `//:cli-tests`' inputs — identical
+        # harness, args, and absolutize list, plus the shard index and the
+        # weights file — and their union is the same case inventory, so there is
+        # no undeclared input `//:cli-tests` could have that the repeated shards
+        # do not already expose. Sweeping it would be one more runner executing
+        # the whole premerge CLI corpus for no incremental guarantee.
+        run: |
+          set -euo pipefail
+          targets="$(scripts/ci-corpus-inventory --json \
+            --exclude '//:cli-tests' --exclude '//:cli-tests-shard-*')"
+          printf 'sweeping: %s\n' "$targets"
+          printf 'targets=%s\n' "$targets" >>"$GITHUB_OUTPUT"
+
+  execute-every-corpus:
+    name: cache-free execution (${{ matrix.target }})
+    needs: corpus-inventory
+    if: github.event_name != 'workflow_dispatch' || inputs.sweep
+    runs-on: ubuntu-latest
+    # Each corpus gets its own runner so a regression stays attributable and
+    # rerunnable, and so the slow-tier CLI suite cannot consume the budget the
+    # rest of the sweep needs. Cache-free means every lane also rebuilds the
+    # compiler; the bound is generous because none of this is on a critical path.
+    timeout-minutes: 300
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.corpus-inventory.outputs.targets) }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: facebook/install-dotslash@v2
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/dotslash
+          key: dotslash-repetitions-linux-x64-${{ hashFiles('buck2') }}
+          restore-keys: dotslash-repetitions-linux-x64-
+      - name: Execute the corpus against the current tree
+        env:
+          RUE_CORPUS_CACHE_FREE: "1"
+        run: scripts/ci-heavy-suite "${{ matrix.target }}"
 
   # RUE-1260. On demand only: this answers a question, it does not stand guard.
   #

--- a/.github/workflows/correctness-repetitions.yml
+++ b/.github/workflows/correctness-repetitions.yml
@@ -119,10 +119,17 @@ jobs:
         # no undeclared input `//:cli-tests` could have that the repeated shards
         # do not already expose. Sweeping it would be one more runner executing
         # the whole premerge CLI corpus for no incremental guarantee.
+        #
+        # The shards are excluded by their `rue_cli_shard` label rather than by
+        # name: that label is what makes the superset argument true, it is the
+        # same one `test.sh` subtracts for the same reason, and it follows
+        # CLI_TEST_SHARD_COUNT without an edit. A name pattern would also have
+        # quietly swallowed any future corpus that happened to be named like a
+        # shard, which is the one way a corpus could leave this sweep silently.
         run: |
           set -euo pipefail
           targets="$(scripts/ci-corpus-inventory --json \
-            --exclude '//:cli-tests' --exclude '//:cli-tests-shard-*')"
+            --exclude '//:cli-tests' --exclude-label rue_cli_shard)"
           printf 'sweeping: %s\n' "$targets"
           printf 'targets=%s\n' "$targets" >>"$GITHUB_OUTPUT"
 

--- a/BUCK
+++ b/BUCK
@@ -519,9 +519,10 @@ CLI_TEST_SHARD_COUNT = 4
         timeout_seconds = _CLI_SHARD_TIMEOUT_SECONDS,
         # RUE-1158 rebalances the shards from measured per-case cost. The
         # measurements are a declared output of the action rather than an
-        # executor --env path, so a cache hit replays the timings that produced
-        # the tree instead of leaving shard-weights.json to refresh only when a
-        # shard actually executes. See cached_corpus_suite's case_timings doc.
+        # executor --env path, so they survive a replayed run instead of
+        # vanishing with it. RUE-1222: what a hit replays is still the run that
+        # wrote the entry, so the weekly cache-free repetitions are where these
+        # are actually re-measured. See cached_corpus_suite's case_timings doc.
         case_timings = True,
     )
     for _shard in range(CLI_TEST_SHARD_COUNT)
@@ -1362,6 +1363,7 @@ filegroup(
     srcs = {
         "crates/clippy-gate.sh": "//crates:clippy-gate",
         "fmt.sh": "fmt.sh",
+        "scripts/ci-corpus-inventory": "scripts/ci-corpus-inventory",
         "scripts/ci-heavy-suite": "scripts/ci-heavy-suite",
         "scripts/cli-timeout-policy.py": "scripts/cli-timeout-policy.py",
         "scripts/ci-timed": "scripts/ci-timed",

--- a/corpus.bzl
+++ b/corpus.bzl
@@ -64,9 +64,11 @@ def cached_corpus_suite(
             inside the action, where a test-executor `--env` never reaches it,
             and a per-run mktemp path would change the action's digest on every
             run and defeat the caching this rule exists for. As an output it is
-            stored with the stamp and materialized on a cache hit, so
-            shard-weights.json keeps refreshing on replayed runs rather than
-            only when a corpus actually executes.
+            stored with the stamp and materialized on a cache hit, so the
+            measurements survive a replayed run instead of vanishing with it.
+            What a hit materializes is still the measurement of whichever run
+            wrote the entry, so FRESH timings come only from a run that
+            executes; RUE-1222's scheduled repetitions are that run.
     """
     for key in absolutize:
         if key not in env:
@@ -80,6 +82,17 @@ def cached_corpus_suite(
         absolutize = absolutize,
         timeout_seconds = timeout_seconds,
         case_timings = case_timings,
+        # RUE-1222. RUE-1159's repetition index used to reach the harness as an
+        # executor `--env`, which RUE-1118 silently broke twice over: the
+        # harness moved inside a build action where an executor env never
+        # arrives, and `buck2 test --env` is not even accepted before `--`, so
+        # every scheduled repetition run failed at argument parsing. Routing it
+        # through a buckconfig fixes both and restores the property the lane
+        # exists for: the value is an action attribute, so each repetition is a
+        # distinct digest that must actually execute. `--no-remote-cache` alone
+        # never did that — it disables the remote cache, while buck2's local
+        # DICE state happily serves repetitions 2..N from repetition 1.
+        repetition = read_root_config("rue", "corpus_repetition", ""),
     )
 
     native.sh_test(
@@ -118,6 +131,12 @@ def _corpus_action_impl(ctx: AnalysisContext) -> list[Provider]:
     action_env["RUE_CORPUS_ABSOLUTIZE"] = " ".join(absolutize)
     if ctx.attrs.timeout_seconds != None:
         action_env["RUE_CORPUS_TIMEOUT_SECONDS"] = str(ctx.attrs.timeout_seconds)
+
+    # RUE-1222: the repetition index, when RUE-1159's scheduled lane sets it.
+    # Injected only when non-empty, so an ordinary run's digest is byte-for-byte
+    # what it was before this existed and no cache entry is invalidated.
+    if ctx.attrs.repetition:
+        action_env["RUE_CORRECTNESS_REPETITION"] = ctx.attrs.repetition
 
     ctx.actions.run(
         cmd_args(
@@ -184,6 +203,7 @@ _corpus_action = rule(
         "corpus_env": attrs.dict(attrs.string(), attrs.arg(), default = {}),
         "harness": attrs.dep(providers = [RunInfo]),
         "harness_args": attrs.list(attrs.string(), default = []),
+        "repetition": attrs.string(default = ""),
         "timeout_seconds": attrs.option(attrs.int(), default = None),
         "wrapper": attrs.dep(providers = [RunInfo], default = "//:corpus-action"),
     },

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -182,10 +182,12 @@ path.
 ## CI
 
 CI reads the key from the `BUILDBUDDY_API_KEY` repo secret (never from a file).
-The cache is provisioned (RUE-1006/RUE-1019) in the `CI` workflow's `clippy`,
-`release`, ordinary platform-test, and macOS corpus jobs, and in the sanitizer
-`valgrind` job, via `scripts/provision-build-cache install && apply` gated on
-secret presence.
+The cache is provisioned (RUE-1006/RUE-1019) via
+`scripts/provision-build-cache install && apply`, gated on secret presence, in
+every `CI` job whose cost is a build — ten of them as of RUE-1504: `clippy`,
+`linux-premerge`, `native-platforms`, `platform-corpus`, `affected-targets`,
+`rue-program-digests`, `remote-execution`, `performance-staleness`, `release`,
+and the sanitizer `valgrind` job.
 
 Availability rules, which the workflow steps must respect:
 
@@ -370,10 +372,170 @@ This matters because the two failure modes look identical in the test output. A
 merge_group run that reports `Pass (0.0s)` on all eighteen corpus jobs while each
 one takes ten minutes is doing no caching at all.
 
-`//:reproducible-programs` and `//:oracle-diff-generated-smoke` remain plain
-`sh_test`s: their harnesses are shell scripts that read repository paths
-directly rather than through declared env inputs, so establishing that contract
-has to come first. Both are off the merge queue's critical path.
+Since RUE-1163 every heavy corpus is converted, including the two shell-script
+harnesses (`//:reproducible-programs`, `//:oracle-diff-generated-smoke`) that
+were held back until they read their repository paths through declared env
+inputs. `scripts/ci-corpus-inventory` reports the current set from the graph:
+
+```bash
+scripts/ci-corpus-inventory            # every cached_corpus_suite, one per line
+```
+
+`scripts/ci-heavy-suite` also names the actions a lane really executed, from the
+invocation's own event log, so the count above has an identity next to it:
+
+```text
+corpus lane: executed action root//:spec-tests-action (cfg#...) (rue_corpus spec-tests)
+corpus lane: every build action was served from cache
+```
+
+### The undeclared-input safeguard (RUE-1222)
+
+Consequence 1 above is the one with no in-band detector. A cache-served corpus
+asserts a stamp; if the harness reads a path the action does not declare, that
+stamp answers for a *different tree* and the suite passes without running. There
+is no signal in the lane: the counters say "cached", the test says `Pass`, and
+the wall time says the cache is working — which is exactly what a correct run
+looks like. The only thing that distinguishes them is a run that actually
+executes the harness against the current tree.
+
+The weekly `correctness-repetitions.yml` workflow is that run:
+
+- `repeat-cli-shards` runs each CLI shard five independent times (RUE-1159);
+- `execute-every-corpus` runs every *other* converted corpus once, one runner
+  each, taking its inventory from `scripts/ci-corpus-inventory` rather than from
+  a list in the workflow. A corpus converted later is swept without an edit; an
+  empty or unreadable inventory fails the job instead of passing vacuously; and
+  the inventory is cross-checked against the `rue_heavy_suite` label set, so a
+  heavy suite that is not a converted corpus fails rather than silently falling
+  out of the sweep.
+
+`//:cli-tests` is deliberately not swept. The four shards declare a strict
+superset of its inputs — same harness, args, and `absolutize`, plus the shard
+index and the weights file — and their union is the same case inventory, so the
+repeated shards already expose anything it could fail to declare.
+
+**What makes these runs execute is the runner, not a flag.** Each job starts with
+an empty `buck-out` and no BuildBuddy secret, so there is nothing to serve it
+from. `ci-heavy-suite` also passes `--no-remote-cache`, but that disables only
+the *remote* cache: buck2's local DICE state and materialized outputs are
+untouched, which is why repeating a target inside one workspace needs the
+separate mechanism below. Do not read the flag as the guarantee.
+
+What the sweep checks is the input *declaration*, which is a property of the rule
+rather than of a configuration. It executes each corpus under
+`prelude//platforms:default`, while `ci.yml` runs `//:release-smoke` under
+`//platforms:release`; an input the harness reads but the action does not name
+is missing in both, so either configuration exposes it. It does not exercise the
+release-configured actions' own cache entries.
+
+This bounds the exposure to one week; it does not remove it. The contract is
+still that every path a harness reads at runtime reaches it through `env`, and
+hence through `$(location ...)`. Nothing on the merge queue's critical path can
+check that for you.
+
+The nightly `release.yml` sweep is not a substitute either. It runs `//...` with
+the cache provisioned, so any corpus in it may legitimately be served rather than
+executed.
+
+Two cautions from RUE-1222, both of which cost this lane real coverage:
+
+- **Nothing turns red when a scheduled workflow fails.** Between RUE-1118 and
+  RUE-1222 every scheduled run died in 18 seconds at argument parsing
+  (`buck2 test --env` is rejected unless it follows `--`) and no one was told.
+  After changing anything here, read the run list.
+- **A repetition only counts if its action digest differs.** See below.
+
+### Keeping the shard weights fresh (RUE-1222)
+
+`shard-weights.json` (RUE-1158) balances the CLI shards from measured per-case
+cost, and consequence 4 above keeps those measurements alive across a cache hit
+by making them a declared output. What a hit replays, though, is the run that
+*wrote* the entry: on a well-cached tree the balance is computed from numbers
+nobody has re-measured.
+
+That staleness degrades two things, not one. The obvious one is how evenly four
+shards finish. The other is a gate: `scripts/cli-timeout-policy.py` derives each
+shard's correctness deadline from the same weights, and
+`//:cli-timeout-policy-validation` fails the build when a suite's
+`timeout_seconds` in `BUCK` no longer covers the derived deadline. Weights are an
+input to a required check, so "they only affect scheduling" is wrong.
+
+The repetitions are where the corpus measures itself again, and each repetition
+really executes because its index makes the action digest differ (below). Each
+writes its own `case-timings-N.jsonl` into the
+`correctness-repetitions-linux-x64-shard-N` artifact.
+
+To refresh the weights, collect the files from **all four shard artifacts** and
+pass every one:
+
+```bash
+scripts/generate-cli-shard-weights.py \
+  --timings linux-x64=shard-0/case-timings-1.jsonl \
+  --timings linux-x64=shard-1/case-timings-1.jsonl   # ... every file, every shard
+```
+
+The tool takes the median per case across all inputs, so several independent
+repetitions are better evidence than one. It **replaces** `platforms.linux-x64`
+with the union of what it is given rather than merging into what is there, and
+each artifact holds only its own shard's cases — so one shard's files alone
+would silently drop the other three shards' weights to the `common` fallback.
+
+### Repeating a corpus so it actually runs (RUE-1222)
+
+RUE-1159's shard repetitions are only evidence if each repetition executes. Two
+mechanisms that look sufficient are not:
+
+- `--no-remote-cache` disables the remote cache, not buck2's local DICE state.
+  Inside one workspace, repetitions 2..N are served from repetition 1's result.
+- An executor `--env` never reaches the harness: since RUE-1118 the harness runs
+  inside a build action, and the test executor's environment is the stamp
+  check's. Worse, `buck2 test --env` is rejected at argument parsing unless it
+  follows `--`, which is what killed every scheduled run for weeks.
+
+The index therefore travels as `-c rue.corpus_repetition=N`, which
+`cached_corpus_suite` folds into the corpus action's environment. That makes each
+repetition a distinct action digest buck2 must execute, and delivers the value to
+the harness as well. It is injected only when non-empty, so an ordinary build's
+digest is unchanged and no cache entry is invalidated. `ci-heavy-suite` passes it
+to **both** its Buck invocations: the timings fetch must name the same
+repetition's action, or it returns another repetition's measurements — or runs
+the whole corpus again to produce them.
+
+### The linux-x64 `local: 1` (RUE-1222, open)
+
+On byte-identical trees the linux-x64 corpus lanes have reported exactly one
+locally executed build action where the arm64 and macOS lanes report none. The
+wall-time cost is negligible, but a standing platform-specific miss nobody can
+name is the kind of thing that stops being one action.
+
+It is **not identified**. The `Commands:` line counts the miss without naming
+it, and the record that would name it is the BuildBuddy invocation view for
+those runs. Three things are worth knowing before anyone repeats the search:
+
+- **The cross-platform comparison is not like-for-like.** Every entry in
+  `ci.yml`'s `platform-corpus` matrix is `ubuntu-latest`, and has been since
+  before the conversion. arm64 and macOS reach the corpora through the
+  `native-platforms` job instead, which runs
+  `scripts/run-native-platform-corpus.sh` — `buck2 run` of the spec and CLI
+  harnesses under `RUE_PLATFORM_CASE_SELECTION=native`. No `cached_corpus_suite`
+  target is built there at all, so "zero local actions on arm64/macOS" is a
+  different action graph reporting zero, not the same graph succeeding where
+  linux-x64 fails.
+- **The corpus action itself is not the candidate.** Its `local_only = True`
+  governs where a *miss* executes, not whether the cache is consulted, and the
+  RUE-1118 measurements show the corpora being served.
+- **The Linux-only branches in the graph today are too new and too broad.**
+  mimalloc's `zig_c_static_archive` and the `_COMPILER_ALLOCATOR_DEPS` link edge
+  both postdate the observation, and both key on `prelude//os:linux` rather than
+  on x86-64, so they would appear on the arm64 lane too.
+
+Rather than guess further, `ci-heavy-suite` now prints the identity of every
+locally executed action after each corpus run (see above). The next merge_group
+run of an already-built tree answers this from the job log alone: read the
+`corpus lane: executed action ...` lines in a linux-x64 corpus job, and the
+target, configuration, and action category of the miss are all there. Until
+that log exists, treat the count as unexplained rather than benign.
 
 ## Updating the remote worker image
 

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -381,6 +381,12 @@ inputs. `scripts/ci-corpus-inventory` reports the current set from the graph:
 scripts/ci-corpus-inventory            # every cached_corpus_suite, one per line
 ```
 
+Exclusions are exact by construction — `--exclude //:cli-tests` names one
+target, `--exclude-label rue_cli_shard` resolves through the graph. There is
+deliberately no pattern form: exclusions are applied after the completeness
+cross-check below, so a wildcard is the one way a corpus could leave the sweep
+with every check still reporting green.
+
 `scripts/ci-heavy-suite` also names the actions a lane really executed, from the
 invocation's own event log, so the count above has an identity next to it:
 

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -439,6 +439,24 @@ after a failure only to gather flake evidence, and exits failed if *any*
 repetition failed; a later pass never masks an earlier failure. Required
 correctness jobs do not automatically retry failed cases.
 
+Every job in that workflow really executes its corpus — each starts on a fresh
+runner with an empty `buck-out` and no cache secret — which is also what makes
+it the undeclared-input safeguard for the corpus build actions (RUE-1222): a
+corpus that reads a path its action does not declare passes against the previous
+tree's result, and only a real execution against the current tree can tell.
+Alongside the repeated shards, `execute-every-corpus` runs each remaining
+converted corpus once, taking its inventory from `scripts/ci-corpus-inventory`
+so a corpus converted later is swept without editing the workflow. The same runs
+are where `crates/rue-cli-tests/shard-weights.json` gets freshly measured
+per-case timings, which feed both shard balance and the derived correctness
+deadline `//:cli-timeout-policy-validation` gates on.
+
+Repetition within one workspace needs more than `--no-remote-cache`, which
+disables only the remote cache: the index rides `-c rue.corpus_repetition=N` so
+each repetition is a distinct action digest. Nothing in this workflow is a
+required check, so a failure here turns nothing red — read the run list after
+changing it. See `docs/process/build-cache.md`.
+
 ## Nothing executes twice (ADR-0069 §2)
 
 **No test the gate can enumerate executes more than once per platform per run

--- a/scripts/ci-corpus-inventory
+++ b/scripts/ci-corpus-inventory
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Enumerate every corpus suite whose run is a cacheable build action (RUE-1118).
+#
+# The inventory comes from the Buck graph, not from a list kept here: every
+# `cached_corpus_suite` expands to one `_corpus_action` rule, so querying that
+# rule kind names exactly the converted corpora and a corpus added later joins
+# the sweep without an edit. That property is the point — the caller (RUE-1222's
+# scheduled cache-free sweep) exists to guarantee that *every* corpus is really
+# executed periodically, and a hand-maintained list is precisely the thing that
+# would quietly stop being every.
+#
+# Fails closed. `scripts/affected-targets` fails open because over-running a
+# corpus is safe and under-running it is what selection is for; here the
+# opposite holds. An inventory that errored or came back empty would turn the
+# sweep green having proved nothing, which is the same false pass the sweep
+# exists to bound.
+set -uo pipefail
+
+json=false
+excludes=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --json)
+            json=true
+            shift
+            ;;
+        --exclude)
+            if [[ $# -lt 2 ]]; then
+                echo "error: --exclude requires a glob" >&2
+                exit 2
+            fi
+            excludes+=("$2")
+            shift 2
+            ;;
+        *)
+            echo "usage: scripts/ci-corpus-inventory [--json] [--exclude GLOB]..." >&2
+            exit 2
+            ;;
+    esac
+done
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root" || exit 1
+
+if ! actions="$(./buck2 uquery "kind('_corpus_action', //...)")"; then
+    echo "error: could not query the corpus inventory from the Buck graph" >&2
+    exit 1
+fi
+
+# Parse and validate the whole inventory before anything is judged against it: a
+# malformed label makes both the cross-check below and the sweep meaningless.
+all_suites=""
+while IFS= read -r action; do
+    [[ -n "$action" ]] || continue
+    # `root//:cli-tests-action` names the action of the `//:cli-tests` suite.
+    suite="${action#root}"
+    if [[ "$suite" != *-action ]]; then
+        echo "error: unexpected corpus action label: $action" >&2
+        exit 1
+    fi
+    suite="${suite%-action}"
+    if [[ ! "$suite" =~ ^//[A-Za-z0-9._/-]*:[A-Za-z0-9._-]+$ ]]; then
+        echo "error: corpus target is not a plain Buck label: $suite" >&2
+        exit 1
+    fi
+    all_suites="$all_suites$suite"$'\n'
+done <<<"$actions"
+
+# Completeness, enforced rather than assumed. The query above says "every target
+# of one rule kind, in the root cell", which is the set of corpora that happen to
+# be converted — not the set that ought to be swept. `rue_heavy_suite` is the
+# label CI and test.sh already use to mean "expensive corpus", so require every
+# heavy suite to be one of these actions. A corpus that regresses to a plain
+# sh_test, or a new heavy suite that never gets converted, then fails this
+# instead of quietly dropping out of the sweep while it still reports success.
+# The converse is deliberately not required: //:release-smoke is a converted
+# corpus that carries no heavy label.
+if ! heavy="$(./buck2 uquery "attrfilter('labels', 'rue_heavy_suite', //...)")"; then
+    echo "error: could not query the heavy-suite set to cross-check the inventory" >&2
+    exit 1
+fi
+missing=""
+while IFS= read -r suite; do
+    [[ -n "$suite" ]] || continue
+    suite="${suite#root}"
+    # Newline-delimited on both sides, so this is an exact label match and not a
+    # prefix that another package's target could satisfy.
+    case $'\n'"$all_suites" in
+        *$'\n'"$suite"$'\n'*) ;;
+        *) missing="$missing $suite" ;;
+    esac
+done <<<"$heavy"
+if [[ -n "$missing" ]]; then
+    echo "error: heavy suite(s) with no corpus action, so the sweep would skip them:$missing" >&2
+    exit 1
+fi
+
+# macOS ships Bash 3.2, where an empty array is "unset" to `set -u`: guard every
+# expansion rather than relying on `${#name[@]}`.
+suites=()
+found=0
+while IFS= read -r suite; do
+    [[ -n "$suite" ]] || continue
+    skip=false
+    for glob in ${excludes[@]+"${excludes[@]}"}; do
+        # shellcheck disable=SC2053  # glob match is the point
+        if [[ "$suite" == $glob ]]; then
+            skip=true
+            break
+        fi
+    done
+    if [[ "$skip" == false ]]; then
+        suites+=("$suite")
+        found=$((found + 1))
+    fi
+done <<<"$all_suites"
+
+if [[ "$found" -eq 0 ]]; then
+    echo "error: the corpus inventory is empty; refusing to report a vacuous sweep" >&2
+    exit 1
+fi
+
+if [[ "$json" == true ]]; then
+    # The label pattern above admits nothing JSON would have to escape, so the
+    # array is assembled directly rather than through a Python dependency.
+    separator='['
+    for suite in "${suites[@]}"; do
+        printf '%s"%s"' "$separator" "$suite"
+        separator=','
+    done
+    printf ']\n'
+else
+    printf '%s\n' "${suites[@]}"
+fi

--- a/scripts/ci-corpus-inventory
+++ b/scripts/ci-corpus-inventory
@@ -18,7 +18,15 @@ set -uo pipefail
 
 json=false
 excludes=()
+exclude_labels=()
 
+# Exclusions are exact, never globs. A glob is the one way a corpus can leave
+# this inventory without an error: it is applied after the completeness
+# cross-check below, so a corpus whose name merely begins with an excluded
+# prefix — a `cli-tests-shard-weights-smoke` against `//:cli-tests-shard-*` —
+# would pass every check here and then silently drop out of the sweep. That is
+# the exact failure this script exists to make impossible, so the prefix
+# spelling is gone: name a target, or name a label the graph resolves.
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --json)
@@ -27,14 +35,30 @@ while [[ $# -gt 0 ]]; do
             ;;
         --exclude)
             if [[ $# -lt 2 ]]; then
-                echo "error: --exclude requires a glob" >&2
+                echo "error: --exclude requires a target label" >&2
+                exit 2
+            fi
+            if [[ ! "$2" =~ ^//[A-Za-z0-9._/-]*:[A-Za-z0-9._-]+$ ]]; then
+                echo "error: --exclude takes an exact target label, not a pattern: $2" >&2
                 exit 2
             fi
             excludes+=("$2")
             shift 2
             ;;
+        --exclude-label)
+            if [[ $# -lt 2 ]]; then
+                echo "error: --exclude-label requires a label" >&2
+                exit 2
+            fi
+            if [[ ! "$2" =~ ^[A-Za-z0-9_-]+$ ]]; then
+                echo "error: --exclude-label takes a plain label: $2" >&2
+                exit 2
+            fi
+            exclude_labels+=("$2")
+            shift 2
+            ;;
         *)
-            echo "usage: scripts/ci-corpus-inventory [--json] [--exclude GLOB]..." >&2
+            echo "usage: scripts/ci-corpus-inventory [--json] [--exclude TARGET].. [--exclude-label LABEL].." >&2
             exit 2
             ;;
     esac
@@ -96,6 +120,23 @@ if [[ -n "$missing" ]]; then
     exit 1
 fi
 
+# Resolve label exclusions through the same graph the inventory came from, so
+# the excluded set tracks the labels rather than a name shape. `rue_cli_shard`
+# is what the four CLI shards actually are, and CLI_TEST_SHARD_COUNT can change
+# without an edit here; nothing else can join the set by being named like one.
+# An empty resolution is not an error — over-sweeping a corpus is safe, and this
+# script's whole failure direction is under-sweeping.
+for label in ${exclude_labels[@]+"${exclude_labels[@]}"}; do
+    if ! labeled="$(./buck2 uquery "attrfilter('labels', '$label', //...)")"; then
+        echo "error: could not query the '$label' set to resolve an exclusion" >&2
+        exit 1
+    fi
+    while IFS= read -r suite; do
+        [[ -n "$suite" ]] || continue
+        excludes+=("${suite#root}")
+    done <<<"$labeled"
+done
+
 # macOS ships Bash 3.2, where an empty array is "unset" to `set -u`: guard every
 # expansion rather than relying on `${#name[@]}`.
 suites=()
@@ -103,9 +144,8 @@ found=0
 while IFS= read -r suite; do
     [[ -n "$suite" ]] || continue
     skip=false
-    for glob in ${excludes[@]+"${excludes[@]}"}; do
-        # shellcheck disable=SC2053  # glob match is the point
-        if [[ "$suite" == $glob ]]; then
+    for excluded in ${excludes[@]+"${excludes[@]}"}; do
+        if [[ "$suite" == "$excluded" ]]; then
             skip=true
             break
         fi

--- a/scripts/ci-heavy-suite
+++ b/scripts/ci-heavy-suite
@@ -104,7 +104,18 @@ elif [[ -r /proc/sys/kernel/random/uuid ]]; then
     buck_trace_id="$(cat /proc/sys/kernel/random/uuid)"
 fi
 
-BUCK_WRAPPER_UUID="$buck_trace_id" ./buck2 test "${test_args[@]}"
+# The report is a diagnostic; the corpus run is the job. So a host with no uuid
+# source must lose the report and nothing else — which means NOT exporting the
+# variable at all, rather than exporting it empty. buck2 parses
+# BUCK_WRAPPER_UUID before it parses a single argument and rejects a set-but-empty
+# value outright (exit 2, `invalid length: found 0`), so the empty-string spelling
+# turns a missing `uuidgen` into a dead corpus lane. Every current CI image has
+# one, but the fallback chain above exists because some Linux hosts do not.
+if [[ -n "$buck_trace_id" ]]; then
+    BUCK_WRAPPER_UUID="$buck_trace_id" ./buck2 test "${test_args[@]}"
+else
+    ./buck2 test "${test_args[@]}"
+fi
 status=$?
 
 # `what-ran` reports one tab-delimited row per command behind a header line that

--- a/scripts/ci-heavy-suite
+++ b/scripts/ci-heavy-suite
@@ -32,28 +32,112 @@ target="$1"
 # against the declarative policy by //:cli-timeout-policy-validation. The
 # per-case budgets in execution_contracts.toml remain the honest gates.
 test_args=("$target")
+# Seeded with the subcommand so the array is never empty: macOS ships Bash 3.2,
+# where expanding an empty array under `set -u` is an unbound-variable error.
+build_args=(build)
 
 # RUE-1158 shard weights. The measurements are a declared output of the corpus
 # action (`:NAME-action[timings]`), not an executor `--env` path, so they are
 # stored in the cache entry alongside the stamp and materialize on a hit too.
 # Copy them to the stable path ci.yml's upload step expects, after the run.
+#
+# RUE-1222: the destination is overridable. A cache hit replays the timings of
+# whichever run wrote the entry, so the only *fresh* measurements come from a
+# cache-free run — and the repetition loop makes several of those per shard.
+# Letting the caller name a per-repetition path keeps all of them instead of
+# having each iteration overwrite the last.
 timings=""
 if [[ "$target" == //:cli-tests-shard-* ]]; then
-    timings="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/rue-cli-case-timings.jsonl"
+    timings="${RUE_CLI_CASE_TIMINGS_DEST:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/rue-cli-case-timings.jsonl}"
 fi
 
-# RUE-1159 repeats a shard to expose flakes, which only works if each repetition
-# actually executes. A cached corpus action would serve repetitions 2..N from the
-# first one's result and report a clean sweep having run the cases once, so a
-# repetition run is explicitly cache-free. This is a scheduled workflow, not the
-# merge-queue critical path, so the lost reuse costs nothing that matters.
-if [[ -n "${RUE_CORRECTNESS_REPETITION:-}" ]]; then
+# A scheduled cache-free run. `--no-remote-cache` is the weaker half of that
+# guarantee than it looks: it disables the REMOTE cache only, while buck2's local
+# DICE state and materialized outputs survive untouched. What actually makes CI's
+# sweep execute is the fresh runner's empty `buck-out` and the absent BuildBuddy
+# secret; the flag only stops a populated remote cache from serving the lane.
+if [[ -n "${RUE_CORRECTNESS_REPETITION:-}" || -n "${RUE_CORPUS_CACHE_FREE:-}" ]]; then
     test_args+=(--no-remote-cache)
-    test_args+=(--env "RUE_CORRECTNESS_REPETITION=$RUE_CORRECTNESS_REPETITION")
+    build_args+=(--no-remote-cache)
 fi
 
-./buck2 test "${test_args[@]}"
+# RUE-1159 repeats a shard to expose flakes, which is only worth anything if each
+# repetition really executes. Within one workspace and one daemon nothing above
+# achieves that — repetitions 2..N are local DICE hits on repetition 1's result,
+# so the lane reported a clean sweep having run the cases once.
+#
+# The index therefore travels as a buckconfig that `cached_corpus_suite` folds
+# into the corpus action's environment (see corpus.bzl). That makes each
+# repetition a distinct action digest, which buck2 must execute, and it delivers
+# the value to the harness as well. It replaces an executor `--env`, which
+# RUE-1118 broke twice over: the harness moved inside a build action where an
+# executor env never arrives, and `buck2 test --env` is rejected at argument
+# parsing unless it follows `--`, so every scheduled run since has died in 18
+# seconds with `unexpected argument '--env' found`.
+#
+# Both invocations must carry it. Without it on the second, the timings fetch
+# would name the *un-nonced* action — a different digest, whose result is either
+# stale or has to be produced by running the whole corpus again.
+if [[ -n "${RUE_CORRECTNESS_REPETITION:-}" ]]; then
+    test_args+=(-c "rue.corpus_repetition=$RUE_CORRECTNESS_REPETITION")
+    build_args+=(-c "rue.corpus_repetition=$RUE_CORRECTNESS_REPETITION")
+fi
+
+# RUE-1222: name the actions this lane actually executed.
+#
+# `Commands: N (cached: C, remote: R, local: L)` counts a miss but cannot say
+# which action it was, and until now the only record that could was the
+# BuildBuddy invocation view. That left a standing unexplained result: on
+# byte-identical trees the linux-x64 corpus lanes report exactly one locally
+# executed action where the arm64 and macOS lanes report none.
+#
+# The report must describe THIS invocation. A bare `buck2 log what-ran` reads the
+# most recent event log in the isolation directory, which is a different command
+# whenever this one wrote no log — exactly the case that matters, since a run
+# that died at argument parsing would otherwise print a reassuring all-clear
+# about a preceding query. Pinning the trace id makes that impossible: no log for
+# this id means no output.
+buck_trace_id=""
+if command -v uuidgen >/dev/null 2>&1; then
+    buck_trace_id="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+elif [[ -r /proc/sys/kernel/random/uuid ]]; then
+    buck_trace_id="$(cat /proc/sys/kernel/random/uuid)"
+fi
+
+BUCK_WRAPPER_UUID="$buck_trace_id" ./buck2 test "${test_args[@]}"
 status=$?
+
+# `what-ran` reports one tab-delimited row per command behind a header line that
+# has none. Only `build` rows are actions; a `test.run` row is a test execution,
+# which never entered the cached/remote/local accounting to begin with.
+if [[ -n "$buck_trace_id" ]] &&
+    executed="$(./buck2 log what-ran --trace-id "$buck_trace_id" \
+        --skip-cache-hits --skip-remote-executions 2>/dev/null |
+        awk -F'\t' '$1 == "build" && NF >= 3 { print $2 }')"; then
+    if [[ -n "$executed" ]]; then
+        # A cold lane — a fork pull_request gets no cache secret — executes the
+        # entire graph, and the question is only ever about the handful a warm
+        # lane misses. Keep the TAIL: rows are in execution order and the corpus
+        # action depends on the whole graph, so it is always last. Capping the
+        # head truncated away the one row anybody reads this for.
+        printf '%s\n' "$executed" | awk '
+            { rows[NR] = $0 }
+            END {
+                start = NR - 25 + 1
+                if (start < 1) {
+                    start = 1
+                } else if (start > 1) {
+                    printf "corpus lane: %d earlier locally executed actions omitted\n", start - 1
+                }
+                for (i = start; i <= NR; i++) {
+                    print "corpus lane: executed action " rows[i]
+                }
+            }'
+    else
+        echo "corpus lane: every build action was served from cache"
+    fi
+fi
+
 if [[ "$status" -ne 0 ]]; then
     exit "$status"
 fi
@@ -62,7 +146,7 @@ if [[ -n "$timings" ]]; then
     # The sh_test only asserts the stamp, so the timings output is not
     # materialized by the test run. Ask for it explicitly; this is a cache
     # lookup on the action that just ran, never a re-execution of the corpus.
-    if produced="$(./buck2 build --show-simple-output "${target}-action[timings]" 2>/dev/null)" \
+    if produced="$(./buck2 "${build_args[@]}" --show-simple-output "${target}-action[timings]" 2>/dev/null)" \
         && [[ -n "$produced" && -f "$produced" ]]; then
         cp "$produced" "$timings"
         timing_cases="$(grep -c '"event":"rue_cli_case_timing"' "$timings" || true)"

--- a/scripts/ci-repeat-correctness
+++ b/scripts/ci-repeat-correctness
@@ -20,7 +20,16 @@ failures=0
 for ((iteration = 1; iteration <= repetitions; iteration++)); do
     log="$log_dir/repetition-$iteration.log"
     echo "correctness repetition $iteration/$repetitions: $target"
-    if RUE_CORRECTNESS_REPETITION="$iteration" scripts/ci-heavy-suite "$target" 2>&1 | tee "$log"; then
+    # RUE-1222: keep each repetition's per-case timings instead of letting them
+    # overwrite one file. These runs are cache-free, so they are the only place
+    # the CLI corpus still measures itself against the current tree; required CI
+    # replays whatever timings the run that populated the cache entry recorded.
+    # Several independent samples per case is also exactly what
+    # generate-cli-shard-weights.py wants — it takes the median across every
+    # --timings input it is given.
+    if RUE_CORRECTNESS_REPETITION="$iteration" \
+        RUE_CLI_CASE_TIMINGS_DEST="$log_dir/case-timings-$iteration.jsonl" \
+        scripts/ci-heavy-suite "$target" 2>&1 | tee "$log"; then
         result=PASS
     else
         result=FAIL
@@ -34,6 +43,19 @@ done
     echo
     echo "\`$target\`: $failures failure(s) across $repetitions independent runs."
     echo "Failures remain failures even if a later repetition passes; inspect the uploaded logs for the case name."
+    echo
+    echo "The uploaded \`case-timings-N.jsonl\` files are freshly measured per-case costs."
+    echo "To refresh \`crates/rue-cli-tests/shard-weights.json\`, collect the files from"
+    echo "**all four shard artifacts** and pass every one as its own \`--timings\`:"
+    echo
+    echo '```'
+    echo "scripts/generate-cli-shard-weights.py \\"
+    echo "  --timings linux-x64=shard-0/case-timings-1.jsonl \\"
+    echo "  --timings linux-x64=shard-1/case-timings-1.jsonl   # ... every file, every shard"
+    echo '```'
+    echo
+    echo "The tool REPLACES \`platforms.linux-x64\` with the union of the inputs it is given,"
+    echo "so one shard's files alone would drop the other three shards' cases."
 } | tee "$log_dir/summary.md"
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     cat "$log_dir/summary.md" >>"$GITHUB_STEP_SUMMARY"

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -893,15 +893,77 @@ if [ "$1" = "bxl" ]; then
   printf 'Rue test tiers valid\n'
   exit 0
 fi
-if [ "$1" = "test" ]; then
-  if [ -n "${FAKE_CALL_LOG:-}" ]; then printf '%s\n' "$*" >>"$FAKE_CALL_LOG"; fi
-  if [ "${FAKE_OMIT:-0}" != 1 ]; then printf 'Pass: root%s (0.1s)\n' "$2"; fi
+# RUE-1222. This fake used to accept ANY argument shape, which is how
+# `buck2 test --env K=V` — rejected by the real binary at argument parsing,
+# before `--` — stayed green here for months while every scheduled repetition
+# run died in 18 seconds. Reproduce buck2's parser well enough that an argument
+# the real binary refuses fails the test suite too.
+subcommand="$1"
+shift
+reject_unknown() {
+  printf "error: unexpected argument '%s' found\n\n  tip: to pass '%s' as a value, use '-- %s'\n" \
+    "$1" "$1" "$1" >&2
+  exit 3
+}
+parse_buck_args() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --) return 0 ;;
+      -c) shift 2 || exit 3; continue ;;
+      --no-remote-cache|--show-simple-output) shift; continue ;;
+      --trace-id|--filter-category) shift 2 || exit 3; continue ;;
+      --skip-cache-hits|--skip-remote-executions) shift; continue ;;
+      -*) reject_unknown "$1" ;;
+      *) shift; continue ;;
+    esac
+  done
+}
+
+# `what-ran` reports one tab-delimited row per command behind a header line with
+# no tabs. Only `build` rows are Buck actions; a `test.run` row is a test
+# execution, which never enters the cached/remote/local accounting at all. The
+# fake serves rows only for the trace id the last `test` invocation recorded,
+# because a bare `what-ran` reads whatever ran last in the isolation directory —
+# the defect that made a failed run print a reassuring all-clear.
+if [ "$subcommand" = "log" ]; then
+  parse_buck_args "$@"
+  requested=""
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "--trace-id" ]; then requested="$2"; fi
+    shift
+  done
+  recorded=""
+  if [ -f "$PWD/fake-last-trace-id" ]; then recorded="$(cat "$PWD/fake-last-trace-id")"; fi
+  if [ -z "$requested" ] || [ "$requested" != "$recorded" ]; then
+    printf 'no event log for that trace id\n' >&2
+    exit 1
+  fi
+  printf 'Showing commands from: buck2 test\n'
+  if [ "${FAKE_LOCAL_ACTIONS:-0}" = 1 ]; then
+    printf 'build\troot//:early (cfg#abc) (rustc early)\tlocal\tenv -C ...\n'
+    printf 'build\troot//:thing (cfg#abc) (rue_corpus thing)\tlocal\tenv -C ...\n'
+    printf 'test.run\tthing\tlocal\tthe stamp check\n'
+  fi
+  exit 0
+fi
+if [ "$subcommand" = "test" ]; then
+  if [ -n "${FAKE_CALL_LOG:-}" ]; then printf 'test %s\n' "$*" >>"$FAKE_CALL_LOG"; fi
+  parse_buck_args "$@"
+  # An invocation that dies before starting writes no event log; `what-ran` then
+  # answers about whatever ran previously in this isolation directory.
+  if [ "${FAKE_NO_EVENT_LOG:-0}" = 1 ]; then
+    rm -f "$PWD/fake-last-trace-id"
+  else
+    printf '%s' "${BUCK_WRAPPER_UUID:-}" >"$PWD/fake-last-trace-id"
+  fi
+  if [ "${FAKE_OMIT:-0}" != 1 ]; then printf 'Pass: root%s (0.1s)\n' "$1"; fi
   exit "${FAKE_EXIT:-0}"
 fi
 # RUE-1118: case timings are a declared output of the corpus action, fetched
 # after the run rather than handed in as an executor --env path.
-if [ "$1" = "build" ]; then
-  if [ -n "${FAKE_CALL_LOG:-}" ]; then printf '%s\n' "$*" >>"$FAKE_CALL_LOG"; fi
+if [ "$subcommand" = "build" ]; then
+  if [ -n "${FAKE_CALL_LOG:-}" ]; then printf 'build %s\n' "$*" >>"$FAKE_CALL_LOG"; fi
+  parse_buck_args "$@"
   if [ "${FAKE_NO_TIMINGS:-0}" = 1 ]; then exit 1; fi
   out="$PWD/fake-case-timings.jsonl"
   printf '%s\n' '{"event":"rue_cli_case_timing","name":"fake","elapsed_s":0.1}' >"$out"
@@ -917,13 +979,21 @@ EOF
   check "ci-heavy-suite: labeled target with a result succeeds" \
     "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
 
-  # RUE-1159 flake detection only means anything if each repetition executes, so
-  # a repetition run must defeat the corpus action's cache.
+  # RUE-1159 flake detection only means anything if each repetition executes.
+  # RUE-1222: `--no-remote-cache` cannot deliver that on its own — it disables
+  # the remote cache while buck2's local DICE state serves repetitions 2..N — so
+  # the index rides a buckconfig that lands in the corpus action's env, making
+  # each repetition a distinct digest buck2 must run. The old executor `--env`
+  # spelling is what the real binary rejects outright, so assert its absence.
   : >"$sb/calls.log"
   rc=0
   (cd "$sb" && RUE_CORRECTNESS_REPETITION=2 FAKE_CALL_LOG="$sb/calls.log" ./ci-heavy-suite //:cli-tests) >/dev/null 2>&1 || rc=$?
   check "ci-heavy-suite: a correctness repetition runs cache-free" \
-    "$([ "$rc" -eq 0 ] && grep -Fq -- '--no-remote-cache' "$sb/calls.log" && grep -Fq 'RUE_CORRECTNESS_REPETITION=2' "$sb/calls.log" && echo 0 || echo 1)"
+    "$([ "$rc" -eq 0 ] && grep -Fq -- '--no-remote-cache' "$sb/calls.log" && echo 0 || echo 1)"
+  check "ci-heavy-suite: the repetition index reaches the action as a buckconfig" \
+    "$(grep -Fq -- '-c rue.corpus_repetition=2' "$sb/calls.log" && echo 0 || echo 1)"
+  check "ci-heavy-suite: no executor --env is passed, which buck2 rejects" \
+    "$(! grep -Fq -- '--env' "$sb/calls.log" && echo 0 || echo 1)"
 
   # RUE-1118/RUE-1163: ci-heavy-suite carries no per-target executor timeouts at
   # all. Every corpus runs as a cacheable build action and the test executor
@@ -1018,6 +1088,179 @@ EOF
   (cd "$sb" && FAKE_EXIT=29 ./ci-heavy-suite //:cli-tests) >/dev/null 2>&1 || rc=$?
   check "ci-heavy-suite: Buck failure exit is preserved" \
     "$([ "$rc" -eq 29 ] && echo 0 || echo 1)"
+
+  # RUE-1222: the scheduled sweep needs the repetition guarantee under its own
+  # name, because it executes a corpus once instead of repeating it. Both buck2
+  # invocations must agree about the cache: the timings fetch reuses the result
+  # the test invocation just computed only if its execution configuration
+  # matches, and a disagreement risks re-running the whole corpus.
+  : >"$sb/calls.log"
+  rc=0
+  (cd "$sb" && RUE_CORPUS_CACHE_FREE=1 FAKE_LABELED_TARGET=//:cli-tests-shard-1 \
+    FAKE_CALL_LOG="$sb/calls.log" RUNNER_TEMP="$timings_dir" \
+    ./ci-heavy-suite //:cli-tests-shard-1) >/dev/null 2>&1 || rc=$?
+  check "ci-heavy-suite: a sweep run executes the corpus cache-free" \
+    "$([ "$rc" -eq 0 ] && grep -Fxq 'test //:cli-tests-shard-1 --no-remote-cache' "$sb/calls.log" && echo 0 || echo 1)"
+  check "ci-heavy-suite: the timings fetch shares the cache-free configuration" \
+    "$(grep -Fq -- 'build --no-remote-cache --show-simple-output' "$sb/calls.log" && echo 0 || echo 1)"
+
+  # The nonce must reach BOTH invocations. Naming the un-nonced action in the
+  # timings fetch would either return another repetition's measurements or make
+  # buck2 run the whole corpus a second time to produce them.
+  : >"$sb/calls.log"
+  rc=0
+  (cd "$sb" && RUE_CORRECTNESS_REPETITION=4 FAKE_LABELED_TARGET=//:cli-tests-shard-1 \
+    FAKE_CALL_LOG="$sb/calls.log" RUNNER_TEMP="$timings_dir" \
+    ./ci-heavy-suite //:cli-tests-shard-1) >/dev/null 2>&1 || rc=$?
+  check "ci-heavy-suite: the timings fetch names the same repetition's action" \
+    "$([ "$rc" -eq 0 ] && [ "$(grep -Fc -- '-c rue.corpus_repetition=4' "$sb/calls.log")" = 2 ] && echo 0 || echo 1)"
+
+  # RUE-1222: a cache hit replays the timings of whichever run wrote the entry,
+  # so a cache-free repetition is the only source of freshly measured cost. Each
+  # repetition must be able to keep its own file instead of overwriting the last.
+  rc=0
+  (cd "$sb" && FAKE_LABELED_TARGET=//:cli-tests-shard-1 \
+    RUNNER_TEMP="$timings_dir" RUE_CLI_CASE_TIMINGS_DEST="$timings_dir/case-timings-3.jsonl" \
+    ./ci-heavy-suite //:cli-tests-shard-1) >/dev/null 2>&1 || rc=$?
+  check "ci-heavy-suite: the timings destination is overridable per repetition" \
+    "$([ "$rc" -eq 0 ] && grep -Fq '"event":"rue_cli_case_timing"' "$timings_dir/case-timings-3.jsonl" && echo 0 || echo 1)"
+
+  # RUE-1222: `Commands: ... local: 1` counts a cache miss without naming it,
+  # which is why the linux-x64 corpus lanes' single non-cache-served action went
+  # unidentified. Report the identity of every locally executed *action*; a
+  # `test.run` row is a test execution and must not be reported as a miss.
+  rc=0
+  out="$(cd "$sb" && FAKE_LOCAL_ACTIONS=1 ./ci-heavy-suite //:cli-tests 2>&1)" || rc=$?
+  check "ci-heavy-suite: a locally executed action is named" \
+    "$([ "$rc" -eq 0 ] && grep -Fq 'corpus lane: executed action root//:thing (cfg#abc) (rue_corpus thing)' <<<"$out" && echo 0 || echo 1)"
+  check "ci-heavy-suite: a test execution is not reported as a cache miss" \
+    "$([ "$(grep -Fc 'corpus lane: executed action' <<<"$out")" = 2 ] && ! grep -Fq 'stamp check' <<<"$out" && echo 0 || echo 1)"
+
+  rc=0
+  out="$(cd "$sb" && ./ci-heavy-suite //:cli-tests 2>&1)" || rc=$?
+  check "ci-heavy-suite: a fully cache-served lane says so" \
+    "$([ "$rc" -eq 0 ] && grep -Fq 'corpus lane: every build action was served from cache' <<<"$out" && echo 0 || echo 1)"
+
+  # RUE-1222 F1/F3 regression guards, both of which the old fake could not see.
+  #
+  # The fake now parses arguments the way buck2 does, so the argument order that
+  # killed every scheduled run since RUE-1118 fails here instead of passing.
+  rc=0
+  out="$(cd "$sb" && ./buck2 test //:cli-tests --env RUE_CORRECTNESS_REPETITION=2 2>&1)" || rc=$?
+  check "fake buck2: rejects --env before -- exactly as the real binary does" \
+    "$([ "$rc" -eq 3 ] && grep -Fq "unexpected argument '--env' found" <<<"$out" && echo 0 || echo 1)"
+
+  # A bare `what-ran` reads whatever ran last in the isolation directory, so a
+  # run that wrote no event log would report a preceding command's actions as
+  # its own — printing an all-clear for a lane that executed nothing. The report
+  # must be pinned to this invocation's trace id.
+  rc=0
+  out="$(cd "$sb" && FAKE_LOCAL_ACTIONS=1 FAKE_NO_EVENT_LOG=1 FAKE_EXIT=3 \
+    ./ci-heavy-suite //:cli-tests 2>&1)" || rc=$?
+  check "ci-heavy-suite: an invocation that logged nothing reports nothing" \
+    "$([ "$rc" -eq 3 ] && ! grep -Fq 'served from cache' <<<"$out" && ! grep -Fq 'executed action' <<<"$out" && echo 0 || echo 1)"
+
+  rm -rf "$sb"
+}
+
+# ===========================================================================
+# RUE-1222 — the corpus inventory that drives the scheduled cache-free sweep.
+#
+# The sweep exists because an undeclared action input is a false pass: the cache
+# serves the previous tree's stamp and the corpus reports success having run
+# nothing. That guarantee is only worth as much as the inventory behind it, so
+# the list comes from the Buck graph and an inventory that cannot be read must
+# fail rather than report a vacuous clean sweep.
+# ===========================================================================
+
+test_ci_corpus_inventory_is_graph_derived_and_fails_closed() {
+  local sb; sb="$(mktemp -d)"
+  mkdir -p "$sb/scripts"
+  cp "$SRC_ROOT/scripts/ci-corpus-inventory" "$sb/scripts/ci-corpus-inventory"
+  chmod +x "$sb/scripts/ci-corpus-inventory"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "uquery" ]; then
+  if [ "${FAKE_QUERY_EXIT:-0}" != 0 ]; then
+    printf 'buck2 exploded\n' >&2
+    exit "$FAKE_QUERY_EXIT"
+  fi
+  # RUE-1222: the inventory cross-checks the corpus-action set against the
+  # rue_heavy_suite label set, so the fake must answer the two queries apart.
+  case "$2" in
+    *rue_heavy_suite*)
+      if [ "${FAKE_HEAVY_QUERY_EXIT:-0}" != 0 ]; then exit "$FAKE_HEAVY_QUERY_EXIT"; fi
+      # An empty graph has no heavy suites either; that case exercises the
+      # vacuous-sweep guard rather than the cross-check.
+      if [ "${FAKE_EMPTY:-0}" = 1 ]; then exit 0; fi
+      printf 'root//:cli-tests\n'
+      printf 'root//:spec-tests\n'
+      if [ "${FAKE_UNCONVERTED_HEAVY:-0}" = 1 ]; then printf 'root//:tutorial-snippet-tests\n'; fi
+      exit 0
+      ;;
+  esac
+  if [ "${FAKE_EMPTY:-0}" = 1 ]; then exit 0; fi
+  if [ "${FAKE_BAD_LABEL:-0}" = 1 ]; then printf 'root//:not-a-corpus\n'; exit 0; fi
+  printf 'root//:cli-tests-action\n'
+  printf 'root//:cli-tests-shard-0-action\n'
+  printf 'root//:cli-tests-shard-1-action\n'
+  printf 'root//:spec-tests-action\n'
+  printf 'root//crates/rue-oracle-diff:oracle-diff-test-action\n'
+  exit 0
+fi
+exit 90
+EOF
+  chmod +x "$sb/buck2"
+
+  local rc=0 out
+  out="$(cd "$sb" && scripts/ci-corpus-inventory 2>&1)" || rc=$?
+  check "ci-corpus-inventory: every corpus action maps back to its suite" \
+    "$([ "$rc" -eq 0 ] && [ "$out" = '//:cli-tests
+//:cli-tests-shard-0
+//:cli-tests-shard-1
+//:spec-tests
+//crates/rue-oracle-diff:oracle-diff-test' ] && echo 0 || echo 1)"
+
+  rc=0
+  out="$(cd "$sb" && scripts/ci-corpus-inventory --json --exclude '//:cli-tests-shard-*' 2>&1)" || rc=$?
+  check "ci-corpus-inventory: --json emits a matrix-ready array with exclusions applied" \
+    "$([ "$rc" -eq 0 ] && [ "$out" = '["//:cli-tests","//:spec-tests","//crates/rue-oracle-diff:oracle-diff-test"]' ] && echo 0 || echo 1)"
+
+  rc=0
+  out="$(cd "$sb" && FAKE_QUERY_EXIT=3 scripts/ci-corpus-inventory 2>&1)" || rc=$?
+  check "ci-corpus-inventory: a failed query fails closed" \
+    "$([ "$rc" -ne 0 ] && grep -Fq 'could not query the corpus inventory' <<<"$out" && echo 0 || echo 1)"
+
+  rc=0
+  out="$(cd "$sb" && FAKE_EMPTY=1 scripts/ci-corpus-inventory 2>&1)" || rc=$?
+  check "ci-corpus-inventory: an empty inventory fails instead of sweeping nothing" \
+    "$([ "$rc" -ne 0 ] && grep -Fq 'refusing to report a vacuous sweep' <<<"$out" && echo 0 || echo 1)"
+
+  rc=0
+  out="$(cd "$sb" && FAKE_EMPTY=1 scripts/ci-corpus-inventory --exclude '//:*' 2>&1)" || rc=$?
+  check "ci-corpus-inventory: excluding everything is an empty inventory too" \
+    "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
+
+  rc=0
+  out="$(cd "$sb" && FAKE_BAD_LABEL=1 scripts/ci-corpus-inventory 2>&1)" || rc=$?
+  check "ci-corpus-inventory: an unrecognized action label is an error, not a silent drop" \
+    "$([ "$rc" -ne 0 ] && grep -Fq 'unexpected corpus action label' <<<"$out" && echo 0 || echo 1)"
+
+  # RUE-1222: "every corpus" has to be enforced, not conventional. A heavy suite
+  # that is not a converted corpus would be absent from the sweep while the
+  # sweep still reported success, which is the failure this whole lane exists to
+  # prevent one level down.
+  rc=0
+  out="$(cd "$sb" && FAKE_UNCONVERTED_HEAVY=1 scripts/ci-corpus-inventory 2>&1)" || rc=$?
+  check "ci-corpus-inventory: a heavy suite with no corpus action fails the inventory" \
+    "$([ "$rc" -ne 0 ] && grep -Fq 'heavy suite(s) with no corpus action' <<<"$out" \
+      && grep -Fq '//:tutorial-snippet-tests' <<<"$out" && echo 0 || echo 1)"
+
+  rc=0
+  out="$(cd "$sb" && FAKE_HEAVY_QUERY_EXIT=4 scripts/ci-corpus-inventory 2>&1)" || rc=$?
+  check "ci-corpus-inventory: an unreadable heavy-suite set fails closed too" \
+    "$([ "$rc" -ne 0 ] && grep -Fq 'cross-check' <<<"$out" && echo 0 || echo 1)"
+
   rm -rf "$sb"
 }
 
@@ -1119,6 +1362,7 @@ test_rue_unit_unknown_crate_errors_cleanly
 test_ci_timed_preserves_status_and_summarizes_actions
 test_cache_probe_counter_validation
 test_ci_heavy_suite_audits_its_target
+test_ci_corpus_inventory_is_graph_derived_and_fails_closed
 test_testsh_delegates_selection_to_buck
 test_sanitizer_defaults_std_path
 test_sanitizer_recursive_discovery_contract

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -885,6 +885,15 @@ EOF
   chmod +x "$sb/scripts/cli-timeout-policy.py"
   cat >"$sb/buck2" <<'EOF'
 #!/usr/bin/env bash
+# The invocation id is read from the environment at startup, before any argument
+# is parsed and for every subcommand. A set-but-empty value is not "absent" — it
+# is a malformed uuid, and the real binary dies on it. Unset is the only way to
+# say "pick one for me". The fake used to accept the empty spelling, which is why
+# a wrapper that exported one could not be caught here.
+if [ -n "${BUCK_WRAPPER_UUID+set}" ] && [ -z "$BUCK_WRAPPER_UUID" ]; then
+  printf 'Error: Parsing buck2 invocation id from env variable BUCK_WRAPPER_UUID\n\nCaused by:\n    invalid length: found 0\n' >&2
+  exit 2
+fi
 if [ "$1" = "uquery" ]; then
   printf 'root%s\n' "${FAKE_LABELED_TARGET:-//:cli-tests}"
   exit 0
@@ -1160,6 +1169,36 @@ EOF
   check "ci-heavy-suite: an invocation that logged nothing reports nothing" \
     "$([ "$rc" -eq 3 ] && ! grep -Fq 'served from cache' <<<"$out" && ! grep -Fq 'executed action' <<<"$out" && echo 0 || echo 1)"
 
+  # The empty invocation id, which the real binary refuses before it parses an
+  # argument. Asserted against the fake directly, the way the `--env` guard above
+  # is: the wrapper test below is only meaningful if this divergence is visible.
+  rc=0
+  out="$(cd "$sb" && BUCK_WRAPPER_UUID="" ./buck2 test //:cli-tests 2>&1)" || rc=$?
+  check "fake buck2: refuses an empty BUCK_WRAPPER_UUID as the real binary does" \
+    "$([ "$rc" -eq 2 ] && grep -Fq 'invalid length: found 0' <<<"$out" && echo 0 || echo 1)"
+
+  # ...so a host with no usable uuid source must lose the report and keep the
+  # run. Exporting the variable empty made that branch fatal instead.
+  #
+  # The shim stands in for both arms of the fallback chain failing: what the code
+  # under test sees either way is an empty trace id, and a shim is the only
+  # spelling of that which reproduces on Linux, where the
+  # /proc/sys/kernel/random/uuid fallback would otherwise succeed.
+  mkdir -p "$sb/nouuid"
+  cat >"$sb/nouuid/uuidgen" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+  chmod +x "$sb/nouuid/uuidgen"
+  : >"$sb/calls.log"
+  rc=0
+  out="$(cd "$sb" && PATH="$sb/nouuid:$PATH" FAKE_CALL_LOG="$sb/calls.log" \
+    ./ci-heavy-suite //:cli-tests 2>&1)" || rc=$?
+  check "ci-heavy-suite: no uuid source costs the what-ran report, not the run" \
+    "$([ "$rc" -eq 0 ] && grep -Fq -- '//:cli-tests' "$sb/calls.log" && echo 0 || echo 1)"
+  check "ci-heavy-suite: and it claims nothing about caching it cannot know" \
+    "$(! grep -Fq 'served from cache' <<<"$out" && ! grep -Fq 'executed action' <<<"$out" && echo 0 || echo 1)"
+
   rm -rf "$sb"
 }
 
@@ -1186,7 +1225,8 @@ if [ "$1" = "uquery" ]; then
     exit "$FAKE_QUERY_EXIT"
   fi
   # RUE-1222: the inventory cross-checks the corpus-action set against the
-  # rue_heavy_suite label set, so the fake must answer the two queries apart.
+  # rue_heavy_suite label set and resolves --exclude-label through the graph as
+  # well, so the fake must answer all three queries apart.
   case "$2" in
     *rue_heavy_suite*)
       if [ "${FAKE_HEAVY_QUERY_EXIT:-0}" != 0 ]; then exit "$FAKE_HEAVY_QUERY_EXIT"; fi
@@ -1198,12 +1238,26 @@ if [ "$1" = "uquery" ]; then
       if [ "${FAKE_UNCONVERTED_HEAVY:-0}" = 1 ]; then printf 'root//:tutorial-snippet-tests\n'; fi
       exit 0
       ;;
+    *rue_cli_shard*)
+      if [ "${FAKE_LABEL_QUERY_EXIT:-0}" != 0 ]; then exit "$FAKE_LABEL_QUERY_EXIT"; fi
+      printf 'root//:cli-tests-shard-0\n'
+      printf 'root//:cli-tests-shard-1\n'
+      exit 0
+      ;;
+    *rue_no_such_label*)
+      exit 0
+      ;;
   esac
   if [ "${FAKE_EMPTY:-0}" = 1 ]; then exit 0; fi
   if [ "${FAKE_BAD_LABEL:-0}" = 1 ]; then printf 'root//:not-a-corpus\n'; exit 0; fi
   printf 'root//:cli-tests-action\n'
   printf 'root//:cli-tests-shard-0-action\n'
   printf 'root//:cli-tests-shard-1-action\n'
+  # A corpus named like a shard but not labeled one. It stands for the way a
+  # prefix exclusion loses a corpus: `//:cli-tests-shard-*` would swallow it
+  # after the completeness cross-check had already passed, so it would leave the
+  # sweep with nothing anywhere reporting an error.
+  printf 'root//:cli-tests-shard-weights-smoke-action\n'
   printf 'root//:spec-tests-action\n'
   printf 'root//crates/rue-oracle-diff:oracle-diff-test-action\n'
   exit 0
@@ -1218,13 +1272,43 @@ EOF
     "$([ "$rc" -eq 0 ] && [ "$out" = '//:cli-tests
 //:cli-tests-shard-0
 //:cli-tests-shard-1
+//:cli-tests-shard-weights-smoke
 //:spec-tests
 //crates/rue-oracle-diff:oracle-diff-test' ] && echo 0 || echo 1)"
 
   rc=0
-  out="$(cd "$sb" && scripts/ci-corpus-inventory --json --exclude '//:cli-tests-shard-*' 2>&1)" || rc=$?
+  out="$(cd "$sb" && scripts/ci-corpus-inventory --json \
+    --exclude '//:cli-tests' --exclude-label rue_cli_shard 2>&1)" || rc=$?
   check "ci-corpus-inventory: --json emits a matrix-ready array with exclusions applied" \
-    "$([ "$rc" -eq 0 ] && [ "$out" = '["//:cli-tests","//:spec-tests","//crates/rue-oracle-diff:oracle-diff-test"]' ] && echo 0 || echo 1)"
+    "$([ "$rc" -eq 0 ] && [ "$out" = '["//:cli-tests-shard-weights-smoke","//:spec-tests","//crates/rue-oracle-diff:oracle-diff-test"]' ] && echo 0 || echo 1)"
+
+  # The finding this replaced a glob to fix. `//:cli-tests-shard-*` matched the
+  # decoy too, and it was applied AFTER the heavy-suite cross-check, so the
+  # corpus left the sweep with every check still green. Resolving the real
+  # shards through their label keeps a look-alike in.
+  check "ci-corpus-inventory: a corpus merely named like a shard stays in the sweep" \
+    "$(grep -Fq 'cli-tests-shard-weights-smoke' <<<"$out" && echo 0 || echo 1)"
+
+  # ...and the spelling that could reintroduce it is refused outright rather
+  # than silently matching one literal target.
+  rc=0
+  out="$(cd "$sb" && scripts/ci-corpus-inventory --exclude '//:cli-tests-shard-*' 2>&1)" || rc=$?
+  check "ci-corpus-inventory: a glob exclusion is rejected, not honored" \
+    "$([ "$rc" -eq 2 ] && grep -Fq 'exact target label' <<<"$out" && echo 0 || echo 1)"
+
+  # A label naming nothing excludes nothing: over-sweeping is safe, and failing
+  # here would make removing a label break an unrelated workflow.
+  rc=0
+  out="$(cd "$sb" && scripts/ci-corpus-inventory --exclude-label rue_no_such_label 2>&1)" || rc=$?
+  check "ci-corpus-inventory: a label that resolves to nothing sweeps everything" \
+    "$([ "$rc" -eq 0 ] && [ "$(wc -l <<<"$out" | tr -d ' ')" = 6 ] && echo 0 || echo 1)"
+
+  # But a label set that cannot be READ is the under-sweeping direction again.
+  rc=0
+  out="$(cd "$sb" && FAKE_LABEL_QUERY_EXIT=5 scripts/ci-corpus-inventory \
+    --exclude-label rue_cli_shard 2>&1)" || rc=$?
+  check "ci-corpus-inventory: an unreadable exclusion label fails closed" \
+    "$([ "$rc" -ne 0 ] && grep -Fq "resolve an exclusion" <<<"$out" && echo 0 || echo 1)"
 
   rc=0
   out="$(cd "$sb" && FAKE_QUERY_EXIT=3 scripts/ci-corpus-inventory 2>&1)" || rc=$?
@@ -1236,10 +1320,18 @@ EOF
   check "ci-corpus-inventory: an empty inventory fails instead of sweeping nothing" \
     "$([ "$rc" -ne 0 ] && grep -Fq 'refusing to report a vacuous sweep' <<<"$out" && echo 0 || echo 1)"
 
+  # Excluding the whole graph one target at a time is still a vacuous sweep, and
+  # has to fail for the same reason an unreadable one does. Spelled out in full
+  # now that there is no wildcard to say it in one argument.
   rc=0
-  out="$(cd "$sb" && FAKE_EMPTY=1 scripts/ci-corpus-inventory --exclude '//:*' 2>&1)" || rc=$?
+  out="$(cd "$sb" && scripts/ci-corpus-inventory \
+    --exclude '//:cli-tests' \
+    --exclude '//:cli-tests-shard-weights-smoke' \
+    --exclude '//:spec-tests' \
+    --exclude '//crates/rue-oracle-diff:oracle-diff-test' \
+    --exclude-label rue_cli_shard 2>&1)" || rc=$?
   check "ci-corpus-inventory: excluding everything is an empty inventory too" \
-    "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
+    "$([ "$rc" -ne 0 ] && grep -Fq 'refusing to report a vacuous sweep' <<<"$out" && echo 0 || echo 1)"
 
   rc=0
   out="$(cd "$sb" && FAKE_BAD_LABEL=1 scripts/ci-corpus-inventory 2>&1)" || rc=$?


### PR DESCRIPTION
Three follow-ups from RUE-1118, which converted the heavy corpora into cacheable build actions.

## The workflow being extended had never once succeeded

`correctness-repetitions.yml`'s only two scheduled runs both died in 18 seconds:

```
failure  Correctness repetitions  31371851477  18s  2026-08-10
failure  Correctness repetitions  30807197495  18s  2026-08-03
error: unexpected argument '--env' found
```

`buck2 test --env` is rejected at argument parsing. But moving it after `--` would only make the command *valid* — the value would land on the stamp-check test process, where nothing reads it. RUE-1118 moved the harness into a build action, so the repetition index has to travel as `-c rue.corpus_repetition=N`, which `cached_corpus_suite` folds into the action's env.

Proven end-to-end against real buck2: `scripts/ci-repeat-correctness //:cli-tests-shard-0 2` → both repetitions pass, with `cli-tests: measured 467 cases` written to `case-timings-1.jsonl` *and* `case-timings-2.jsonl`.

## `--no-remote-cache` never forced execution

It disables the *remote* cache only; buck2's local DICE state and materialized outputs survive, so repetitions 2..N were local hits. The same nonce fixes this by making each repetition a distinct digest. Measured: repetition 1 → `Commands: 31 (local: 31)`, repetition 2 → `Commands: 1 (local: 1)` — the corpus re-executed, the compiler did not. The two timing files differ by content and size, so they are genuinely independent samples rather than one file copied five times.

The claim that cache-freeness "holds by both construction and instruction" is gone from the workflow header, `build-cache.md`, and `ci.md`. Only construction holds — the fresh runner's empty `buck-out` and the absent BuildBuddy secret.

## Sub-tasks

**1. Shard-weight timings** now come from the repetition runs, which are the only ones that measure the corpus against the current tree. Five samples per case instead of one; `generate-cli-shard-weights.py` medians them. The docs now say to collect **all four** shard artifacts and that the tool *replaces* rather than merges a platform's weights — following the old instruction literally would have rewritten `platforms.linux-x64` with one shard's cases.

**2. The linux-x64 `local: 1`** is not fixed, because it could not be identified from source and guessing is worse than instrumenting. The cross-platform comparison behind it was never like-for-like: every `platform-corpus` matrix entry is `ubuntu-latest`, and arm64/macOS reach the corpora through a path that builds no `cached_corpus_suite` at all. `ci-heavy-suite` now prints the identity of every locally executed action, pinned to its own invocation via `--trace-id` — a bare `what-ran` reads the *last* invocation from the isolation directory, which is how a run that exited 3 having executed nothing still printed "every build action was served from cache". Tail-capped, because the `rue_corpus` row is always last and a head cap discarded exactly the row worth reading.

**3. The undeclared-input safeguard** covered 4 of 14 corpora. A new `execute-every-corpus` job sweeps **9** more cache-free, one runner each, with the inventory queried from `kind('_corpus_action', //...)` and cross-checked against the `rue_heavy_suite` label set so a converted-but-unswept corpus fails the inventory rather than passing silently.

Stated precisely: **13 of the 14 corpora execute somewhere in this workflow** — 4 as the repeated shards, 9 in the sweep matrix. `//:cli-tests` executes nowhere, resting entirely on the superset argument (identical harness, args, and absolutize list; the shards' union is the same case inventory), which `//:cli-shard-coverage-validation` machine-checks.

The sweep checks input *declaration*, a property of the rule, so an undeclared input is missing under either configuration. It does not exercise release-configured cache entries, and says so rather than implying "every corpus" means every configuration.

## Test fidelity

The fake `buck2` accepted anything, which is why a permanently broken invocation stayed pinned by a passing assertion. It now parses arguments as the real binary does — exiting 3 on `--env` before `--`, and serving `what-ran` rows only for the recorded trace id. Regression guards added for exactly the defects that hid here. **147 wrapper checks, up from 133.**

## Review round (Fable, at Steve's request)

Both findings fixed in `RUE-1222: make the uuid fallback and the sweep exclusions fail closed`. Each new check fails against the previous code.

**The no-uuid fallback was fatal, not degrading.** buck2 parses `BUCK_WRAPPER_UUID` before it parses an argument and rejects a set-but-empty value (exit 2, `invalid length: found 0`), so a host with neither `uuidgen` nor `/proc/sys/kernel/random/uuid` lost the whole corpus run rather than just the `what-ran` report the guard below it was written to lose. The variable is now exported only when non-empty. The fake accepted the empty value the real binary refuses — the same real/fake gap class this PR set out to close — and now rejects it at startup for every subcommand, distinguishing set-but-empty from unset.

**Sweep exclusions are now exact by construction.** `//:cli-tests-shard-*` was a prefix wildcard applied *after* the completeness cross-check, so a corpus merely named like a shard would pass every check and then silently drop out of the sweep — the one remaining path by which a corpus could leave the inventory without an error. `--exclude` now takes a target label and refuses a pattern; `--exclude-label` resolves through the same graph the inventory came from. The workflow excludes the shards by `rue_cli_shard`, the label that makes the superset argument true and that `test.sh` already subtracts for the same reason, so it follows `CLI_TEST_SHARD_COUNT` without an edit. Verified against the real graph: the label resolves to exactly the four shards and the matrix is the same 9 targets. The inventory fake now carries a shard-shaped decoy, making the drop a live regression rather than a described one.

Rebased on trunk (`adb99c08`); the only conflict was `docs/process/ci.md`, where trunk's ADR-0069 "Nothing executes twice" section and this branch's sweep prose were both inserted after the same paragraph. Kept both, branch text first.

Trunk's new RUE-1507 gate waives this workflow by name as `known_broken="RUE-1222"`. Left in place deliberately: it cannot be removed until a scheduled run actually succeeds, and the gate already self-clears by warning that the waiver has outlived its breakage once one does.

Closes RUE-1222.
