### PR TITLE
RUE-1507: block only on the durable signal, warn on the rest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1317,9 +1317,10 @@ jobs:
       # eleven days unnoticed. The check belongs *here*, on the pull-request
       # path, precisely because the thing being diagnosed is that unattended
       # signals are not read — reporting it on another timer would inherit the
-      # bug. It asks only whether each scheduled workflow has ever succeeded and
-      # has succeeded recently, so an ordinary red night is not a repository
-      # event, and a workflow that has quietly stopped working is.
+      # bug. Exactly one condition fails this step: a workflow that has run at
+      # least twice on its schedule and never once succeeded. Staleness, a
+      # disabled workflow, and any API trouble warn and pass, because a false
+      # positive here blocks every merge in the repository.
       - name: Check scheduled workflows are still succeeding
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1288,6 +1288,12 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     name: CI contract
+    # `actions: read` is for the scheduled-workflow health check below. The
+    # block is explicit because declaring one narrows the whole job: checkout
+    # needs `contents: read` named alongside it.
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v6
       - name: Validate aggregate gate and platform responsibilities
@@ -1304,6 +1310,20 @@ jobs:
           --test-tiers-bxl test_tiers.bxl
           --workflow .github/workflows/ci.yml
           --workflow .github/workflows/release.yml
+
+      # RUE-1507. A `schedule:` workflow has no audience: no pull request waits
+      # on it and its result is a row in a tab nobody opens, which is how
+      # `correctness-repetitions.yml` failed every scheduled run it ever had for
+      # eleven days unnoticed. The check belongs *here*, on the pull-request
+      # path, precisely because the thing being diagnosed is that unattended
+      # signals are not read — reporting it on another timer would inherit the
+      # bug. It asks only whether each scheduled workflow has ever succeeded and
+      # has succeeded recently, so an ordinary red night is not a repository
+      # event, and a workflow that has quietly stopped working is.
+      - name: Check scheduled workflows are still succeeding
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: scripts/check-scheduled-workflows.py --repo "$GITHUB_REPOSITORY"
 
   # The only stable branch-protection context. Matrix children may be reshaped
   # without changing this displayed name. The evaluator rejects missing,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,19 @@ jobs:
           --ignore-tests-attribute
           --target-platforms //platforms:release
 
+      # A scheduled lane needs this more than a pull-request lane does, not
+      # less. Nobody is watching when it goes red, so the first person to look
+      # arrives days later — by which time the Actions job log has been
+      # truncated to a tail or aged out entirely, and the run that found the
+      # regression can no longer say what failed (RUE-1268, RUE-1507).
+      - name: Upload failing-suite output
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-suite-failure-logs
+          path: ${{ runner.temp }}/rue-ci-failed-logs
+          if-no-files-found: ignore
+
   # Caldera and Meridian are real compile-and-run coverage, not required-CI
   # success stubs. Each application compiles as one cached rue_program build
   # action (ADR-0070 / RUE-1405); the per-program `-slow` suite fans out to
@@ -133,3 +146,13 @@ jobs:
           scripts/ci-timed "${{ matrix.program }} stress" --
           ./buck2 test "//:large-example-${{ matrix.program }}-stress"
           --target-platforms //platforms:release
+
+      # See the release job's rationale. Named per program so a scheduled run
+      # that loses one of the two stays attributable.
+      - name: Upload failing-program output
+        if: failure() && steps.select.outputs.run == 'true'
+        uses: actions/upload-artifact@v6
+        with:
+          name: large-program-${{ matrix.program }}-failure-logs
+          path: ${{ runner.temp }}/rue-ci-failed-logs
+          if-no-files-found: ignore

--- a/BUCK
+++ b/BUCK
@@ -1187,7 +1187,9 @@ rue_sh_test(
 # otherwise report a clean audit of nothing.
 filegroup(
     name = "scheduled-workflow-test-inputs",
-    srcs = glob([".github/workflows/*.yml"]),
+    # Matches the script's own `*.y*ml` discovery. A narrower glob here would
+    # leave a `.yaml` workflow live in CI but invisible to these tests.
+    srcs = glob([".github/workflows/*.yml", ".github/workflows/*.yaml"]),
 )
 
 rue_sh_test(

--- a/BUCK
+++ b/BUCK
@@ -1176,6 +1176,30 @@ rue_sh_test(
     resources = ["scripts/fuzz-report-failure.py"],
 )
 
+# RUE-1507: the health check that notices a scheduled workflow which has never
+# succeeded. It runs in required CI, so both of its ways of being wrong are
+# expensive — a false red blocks every pull request, and a false green restores
+# the silence that let a weekly safeguard fail for its entire existence. The
+# run-history API cannot be reached from a test, so the classifier is driven
+# through its injected transport with a mock. The real workflow directory is an
+# input as well: discovery is by `schedule:` trigger rather than a list, so a
+# parser that stops recognizing how the workflows are actually written would
+# otherwise report a clean audit of nothing.
+filegroup(
+    name = "scheduled-workflow-test-inputs",
+    srcs = glob([".github/workflows/*.yml"]),
+)
+
+rue_sh_test(
+    name = "scheduled-workflow-tool-tests",
+    test = "scripts/test-check-scheduled-workflows.py",
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "RUE_SCHEDULED_WORKFLOWS_ROOT": "$(location :scheduled-workflow-test-inputs)",
+    },
+    resources = ["scripts/check-scheduled-workflows.py"],
+)
+
 # RUE-1119: pin the deterministic, coverage-deciding logic of the affected-
 # corpus selection — the out-of-graph force-full matcher in
 # scripts/affected-targets and the fail-open gate in scripts/ci-corpus-selected.

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -50,46 +50,78 @@ problem being solved is that unattended signals are not read, so reporting on
 another unattended timer would inherit the bug. Required CI is the one signal
 in this repository that provably reaches a human.
 
-It discovers scheduled workflows from the tree by their `schedule:` trigger
-rather than from a list, so a workflow added later is covered without anyone
-remembering to register it, and asks two questions per workflow:
+### What blocks, and what only warns
 
-- **Has it ever succeeded?** An entire history of failures means nothing it
-  claims to protect was ever protected — stronger and cheaper evidence than any
-  single red run.
-- **Has it succeeded recently?** Within a generous multiple of its own cron
-  period (default four), so an ordinary red night is not a repository-wide
-  event while a workflow that has quietly stopped working is.
+Exactly one condition fails the build: **a workflow that has run on its
+schedule at least twice and has never once succeeded.** That signal is durable
+(no flaky run produces it), unambiguous (nothing it protects was ever
+protected), and self-clearing (one green run ends it permanently). It is the
+RUE-1507 shape precisely.
 
-Both properties are durable: a healthy workflow trips neither, however flaky an
-individual run is. Two cases run history cannot see get their own answers — a
-workflow GitHub has **disabled** stops producing runs entirely (its last one
-may well be green), and a workflow a branch **adds** has no history at all and
-passes with a note until its cron has had a chance to fire.
+Everything else warns and exits 0, because this gate runs on every pull request
+in the repository — a false positive here blocks *all* work, which is worse
+than the bug being defended against. That covers staleness, a workflow GitHub
+has disabled, a schedule that has not yet fired, an unreachable or rate-limited
+API, and any response the classifier cannot make sense of. The repository's
+established posture for an unavailable capability is to say so and continue
+(see the BuildBuddy provisioning steps in `ci.yml`), not to halt every merge.
+
+Staleness is advisory for a concrete reason. It is a heuristic over cron
+cadence, and GitHub's scheduler jitter, queue delay, and a workflow's own
+designed red runs all move it. A `0 6 * * *` cron in this repository starts
+anywhere between 06:36 and 07:14 UTC; runs take 10–25 minutes; and a run enters
+the `status=success` filter only when it *completes*. An earlier revision of
+this gate used a four-period budget read from run creation time, which on real
+`release.yml` history came within thirteen minutes of blocking the repository.
+
+The structural checks below *do* block, because they are deterministic
+questions about the tree with no external state that could make them
+spuriously true.
+
+### Declared policies
 
 A workflow that is genuinely broken with a fix already tracked is declared in
-that script's `POLICIES`, which is the workflow-level form of the repository's
-`known_bug = "RUE-NN"` xfail markers, and expires the same way: once the
-workflow is healthy again the waiver fails as stale and must be deleted, so an
-exemption written for one breakage cannot silently cover the next.
+that script's `POLICIES` with the issue that owns it, which is the
+workflow-level form of the repository's `known_bug = "RUE-NN"` xfail markers.
+The declaration is checked for shape: it must name a real `RUE-NN` issue and
+carry a reason, and it must match a workflow that still exists.
 
-The check is pinned by `scripts/validate-ci-gate.py`, so deleting the step
-fails required CI rather than quietly restoring the original silence, and its
-classification logic is pinned against a mock transport by
+When the workflow becomes healthy the waiver is reported as no longer needed
+and should be deleted, but that report does **not** block — a workflow turning
+green is good news, and good news arriving on a cron nobody chose must not stop
+every merge until someone edits a file.
+
+`fuzz.yml` has its staleness assessment disabled outright rather than widened.
+It is red by design whenever it finds a crash and already files each one into
+Linear (RUE-802, `scripts/fuzz-report-failure.py`). Its full retained history —
+226 scheduled runs from 2026-01-01, measured 2026-08-14 — is 67.7% failures,
+with a longest failing streak of 74 runs and a longest gap between successes of
+75 days. No threshold separates that from a fuzzer that has stopped working, so
+this does not pretend one does.
+
+### Keeping the gate honest
+
+The step and its `actions: read` scope are both pinned by
+`scripts/validate-ci-gate.py` as executable lines rather than substrings, so
+neither can be deleted — nor satisfied by a comment mentioning them — without
+failing required CI. Discovery is by `schedule:` trigger rather than a list, so
+a workflow added later is covered automatically; a workflow whose triggers the
+parser cannot read is *reported* rather than skipped, since silently auditing
+nothing is the same failure at per-workflow granularity. The classifier, the
+API client, and the transport's error handling are pinned against mocks by
 `//:scheduled-workflow-tool-tests`.
+
+### Failure-log artifacts
 
 Scheduled lanes that run commands through `scripts/ci-timed` must also upload
 the preserved `rue-ci-failed-logs` artifact on failure. They need it more than
 pull-request lanes do, not less: nobody is watching when a weekly job goes red,
 so the first person to look arrives days later, by which time the Actions job
-log has been truncated to a tail or aged out entirely. That rule is enforced
-structurally, and only for workflows that actually use `ci-timed` — elsewhere
-the artifact would always be empty, and an empty artifact that looks like
-coverage is the same class of problem.
-
-`fuzz.yml` is exempt from the staleness window because it is red by design
-whenever it finds a crash, and already reports each one into Linear
-(RUE-802, `scripts/fuzz-report-failure.py`).
+log has been truncated to a tail or aged out entirely. The rule applies only to
+workflows that actually use `ci-timed` — elsewhere the artifact would always be
+empty, and an empty artifact that looks like coverage is the same class of
+problem. It is a whole-file check with comments stripped: it proves the upload
+exists, not that every `ci-timed` job has its own.
 
 ## Platform responsibility matrix
 

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -34,6 +34,63 @@ dependencies, always runs, and itself feeds `CI success`. Removing or renaming
 a job without updating every reviewed contract edge therefore fails closed
 instead of silently shrinking coverage.
 
+## Scheduled workflows and their failure signal (RUE-1507)
+
+Workflows on a `schedule:` trigger have no audience. No pull request waits on
+one, nothing is blocked when one goes red, and the result is a row in a tab
+nobody opens. `correctness-repetitions.yml` failed on *every* scheduled run it
+ever had — each dead in 18 seconds on an argument the invoked script does not
+accept — and that went unnoticed for eleven days. A safeguard that fails
+silently is worth less than no safeguard, because its absence would be noticed
+while its presence is assumed.
+
+`scripts/check-scheduled-workflows.py` runs in the `CI contract` job on every
+pull request. It is deliberately **not** itself a scheduled workflow: the
+problem being solved is that unattended signals are not read, so reporting on
+another unattended timer would inherit the bug. Required CI is the one signal
+in this repository that provably reaches a human.
+
+It discovers scheduled workflows from the tree by their `schedule:` trigger
+rather than from a list, so a workflow added later is covered without anyone
+remembering to register it, and asks two questions per workflow:
+
+- **Has it ever succeeded?** An entire history of failures means nothing it
+  claims to protect was ever protected — stronger and cheaper evidence than any
+  single red run.
+- **Has it succeeded recently?** Within a generous multiple of its own cron
+  period (default four), so an ordinary red night is not a repository-wide
+  event while a workflow that has quietly stopped working is.
+
+Both properties are durable: a healthy workflow trips neither, however flaky an
+individual run is. Two cases run history cannot see get their own answers — a
+workflow GitHub has **disabled** stops producing runs entirely (its last one
+may well be green), and a workflow a branch **adds** has no history at all and
+passes with a note until its cron has had a chance to fire.
+
+A workflow that is genuinely broken with a fix already tracked is declared in
+that script's `POLICIES`, which is the workflow-level form of the repository's
+`known_bug = "RUE-NN"` xfail markers, and expires the same way: once the
+workflow is healthy again the waiver fails as stale and must be deleted, so an
+exemption written for one breakage cannot silently cover the next.
+
+The check is pinned by `scripts/validate-ci-gate.py`, so deleting the step
+fails required CI rather than quietly restoring the original silence, and its
+classification logic is pinned against a mock transport by
+`//:scheduled-workflow-tool-tests`.
+
+Scheduled lanes that run commands through `scripts/ci-timed` must also upload
+the preserved `rue-ci-failed-logs` artifact on failure. They need it more than
+pull-request lanes do, not less: nobody is watching when a weekly job goes red,
+so the first person to look arrives days later, by which time the Actions job
+log has been truncated to a tail or aged out entirely. That rule is enforced
+structurally, and only for workflows that actually use `ci-timed` — elsewhere
+the artifact would always be empty, and an empty artifact that looks like
+coverage is the same class of problem.
+
+`fuzz.yml` is exempt from the staleness window because it is red by design
+whenever it finds a crash, and already reports each one into Linear
+(RUE-802, `scripts/fuzz-report-failure.py`).
+
 ## Platform responsibility matrix
 
 | Owner | Required responsibility |

--- a/scripts/check-scheduled-workflows.py
+++ b/scripts/check-scheduled-workflows.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Prove every scheduled workflow is still doing the job it was added to do.
+"""Notice when a scheduled workflow has never once done its job.
 
 A workflow on a `schedule:` trigger has no audience. Nobody opens a pull
 request against it, no merge waits on it, and its result is a row in a tab
@@ -10,34 +10,29 @@ The bug itself is small. What makes it worth a gate is that the workflow was
 believed: a safeguard that fails silently is worth less than no safeguard,
 because its absence is not noticed while its presence is assumed.
 
-This checks the two properties of a scheduled workflow that stay quiet when it
-is healthy and cannot stay quiet when it is not:
+This runs in required CI, on the pull-request path, because that is the one
+signal in this repository that provably reaches a human — reporting it on
+another unattended timer would inherit the very bug being fixed.
 
-**It has succeeded at least once.** A workflow whose entire history is failures
-never worked, so nothing it claims to protect has ever been protected. That is
-strictly stronger evidence than one red run, and it is the exact signature of
-the RUE-1507 bug.
+**Exactly one condition blocks a merge**: a workflow that has run on its
+schedule at least twice and has never once succeeded. That signal is durable
+(no flaky run produces it), unambiguous (nothing it protects was ever
+protected), and self-clearing (one green run ends it forever). It is the
+RUE-1507 shape precisely.
 
-**It has succeeded recently.** "Recently" is a generous multiple of the
-workflow's own cron period, so an ordinary red night is not a repository-wide
-event, while a workflow that has quietly stopped working is one.
+Everything else warns and exits 0. This gate runs on every pull request in the
+repository, so a false positive here blocks *all* work — strictly worse than
+the bug it is defending against. Staleness in particular is a heuristic built
+on cron cadence, and GitHub's scheduler jitter, queue delays, and a workflow's
+own designed red runs all move it; `fuzz.yml` is red on 67.7% of its 226
+retained scheduled runs, with a 75-day gap between successes, entirely by
+design. A heuristic like that may inform a human. It may not block one.
 
-Both are durable: a workflow that is fine never trips either, no matter how
-flaky an individual run is. That is what makes it safe to run this where it
-will actually be read — required CI on every pull request — rather than on
-another unattended timer. The mechanism this file exists to fix cannot be the
-mechanism that reports on it.
-
-Two failure modes get their own answers because a general one would be wrong:
-
-* A workflow GitHub has **disabled** never fires again. It has no failing run
-  to notice, so run history alone cannot see it. The workflow's `state` can.
-  (GitHub disables scheduled workflows in repositories with no activity for 60
-  days, and a disabled workflow reports nothing forever.)
-* A workflow this branch **adds** has no history and is not registered at all.
-  Failing the pull request that introduces a scheduled workflow would be a gate
-  that punishes its own adoption, so an unregistered or just-created workflow
-  passes with a note until its cron has had a chance to fire.
+The same asymmetry governs failure: an API that will not answer, a response
+that cannot be parsed, or any condition this script cannot classify is
+reported and passes. The repository's established posture for an unavailable
+capability is to say so and continue (see the BuildBuddy provisioning steps in
+`ci.yml`), not to halt every merge.
 
 Usage:
     scripts/check-scheduled-workflows.py --repo OWNER/NAME   # structure + history
@@ -51,6 +46,7 @@ import json
 import os
 import re
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -62,53 +58,62 @@ GITHUB_API_URL = "https://api.github.com"
 
 WORKFLOWS_DIR = Path(__file__).resolve().parents[1] / ".github/workflows"
 
+#: A workflow must have failed at least this many scheduled runs, with no
+#: success, before the "never succeeded" verdict blocks a merge. One failed run
+#: is a red run; two-for-two with nothing green is a workflow that has never
+#: worked. `correctness-repetitions.yml` reached this on its second Monday.
+MIN_RUNS_FOR_NEVER_SUCCEEDED = 2
+
 #: Multiple of a workflow's own cron period allowed to pass with no successful
-#: run before it is called stale. Four is deliberately loose: this gate blocks
-#: pull requests, so it must answer "has this stopped working?" and never "did
-#: last night go badly?".
-DEFAULT_STALE_PERIODS = 4
+#: run before it is *reported* stale. Advisory only. Six rather than four
+#: because a daily cron at four tolerates only three consecutive red runs, and
+#: `release.yml` produced a three-run streak within the last three weeks.
+DEFAULT_STALE_PERIODS = 6
+
+#: Floor under any staleness budget. A sub-daily cron would otherwise get a
+#: budget of hours, so one morning's outage would read as a dead workflow.
+MIN_STALE_BUDGET_HOURS = 72.0
+
+#: Issue reference required of every `known_broken` declaration. Rue tracks work
+#: in Linear as `RUE-NN`; a waiver pointing at nothing is a waiver nobody can
+#: follow up.
+ISSUE_RE = re.compile(r"^RUE-\d+$")
 
 
 @dataclass(frozen=True)
 class Policy:
     """A declared deviation from the default rules, and why it exists.
 
-    `known_broken` is the workflow equivalent of the repository's
-    `known_bug = "RUE-NN"` xfail markers: it records a real failure against the
-    issue that will fix it instead of hiding it. It expires the same way those
-    markers do — a waived workflow that has become healthy fails this check as
-    a stale waiver, so the declaration cannot outlive the breakage and quietly
-    keep a future regression silent.
+    `stale_periods = None` disables the staleness report entirely, for a
+    workflow whose red runs are designed behavior rather than evidence.
     """
 
-    stale_periods: int = DEFAULT_STALE_PERIODS
+    stale_periods: int | None = DEFAULT_STALE_PERIODS
     known_broken: str = ""
     note: str = ""
 
 
 POLICIES: dict[str, Policy] = {
-    # RUE-1507's original finding, fixed by RUE-1222. Both scheduled runs it
-    # has ever had failed in 18s with `error: unexpected argument '--env'
-    # found`, so it has never once done the work it was added for. The waiver
-    # exists so this gate does not block the very pull request that repairs it;
-    # when RUE-1222 lands and the next Monday run goes green, this entry starts
-    # failing as stale and must be deleted.
+    # RUE-1507's original finding, fixed by RUE-1222. Both scheduled runs it has
+    # ever had failed in 18s with `error: unexpected argument '--env' found`, so
+    # it has never once done the work it was added for. This is the one waiver
+    # that suppresses a *blocking* verdict, which is why it names the issue that
+    # removes it.
     "correctness-repetitions.yml": Policy(
         known_broken="RUE-1222",
         note="never succeeded; `--env` argument bug fixed by RUE-1222",
     ),
-    # Nightly fuzzing is red *by design* whenever it finds a crash, and it
-    # already reports each one into the Rue Linear team (RUE-802,
-    # scripts/fuzz-report-failure.py), so its red nights reach a human without
-    # this gate's help. Blocking every pull request because the fuzzer did its
-    # job would be strictly harmful. Measured over the 100 scheduled runs
-    # ending 2026-08-14: 46 failures, a longest run of 13 consecutive failing
-    # nights, and a longest gap between successes of 14 days. Thirty days
-    # leaves that ordinary behavior alone while still catching a fuzzer that
-    # has stopped working outright.
+    # Nightly fuzzing is red *by design* whenever it finds a crash, and already
+    # reports each one into the Rue Linear team (RUE-802,
+    # scripts/fuzz-report-failure.py). Its full retained history — 226 scheduled
+    # runs from 2026-01-01, measured 2026-08-14 — is 67.7% failures, with a
+    # longest failing streak of 74 runs and a longest gap between successes of
+    # 75 days. No staleness threshold separates that from a fuzzer that has
+    # stopped working, so this does not pretend one does. Whether the fuzzer is
+    # healthy is answered by the crashes it files, not by the color of the job.
     "fuzz.yml": Policy(
-        stale_periods=30,
-        note="red on any crash found; per-crash reporting is RUE-802's job",
+        stale_periods=None,
+        note="red on any crash found; 67.7% of 226 runs, 75-day success gaps",
     ),
 }
 
@@ -117,12 +122,20 @@ POLICIES: dict[str, Policy] = {
 # Workflow discovery
 # --------------------------------------------------------------------------
 
-#: `on:` through the next top-level key. Workflows are discovered from the tree
-#: rather than from a list in this file, so a scheduled workflow added later is
-#: covered without anyone remembering to register it here — the omission this
-#: gate exists to prevent is precisely the kind nobody remembers.
-ON_BLOCK_RE = re.compile(r"^on:\s*\n(?P<body>(?:[ \t].*\n|\n)*)", re.MULTILINE)
-CRON_RE = re.compile(r"^\s+-\s+cron:\s*['\"]?(?P<expr>[^'\"#\n]+?)['\"]?\s*(?:#.*)?$")
+#: The `on:` key through the next top-level key. Tolerates the quoted `"on":`
+#: form (YAML 1.1 reads a bare `on` as boolean true, so some repositories quote
+#: it), and any trailing content or comment on the key's own line.
+ON_BLOCK_RE = re.compile(
+    r"^[\"']?on[\"']?:(?P<inline>[^\n]*)\n(?P<body>(?:[ \t].*\n|[ \t]*\n)*)",
+    re.MULTILINE,
+)
+
+#: A cron value in either block style (`- cron: '0 0 * * *'`) or flow style
+#: (`schedule: [{cron: '0 0 * * *'}]`), quoted or bare. Matching the value
+#: rather than the surrounding structure is what makes both styles work.
+CRON_VALUE_RE = re.compile(
+    r"""cron:\s*(?:"(?P<dq>[^"]+)"|'(?P<sq>[^']+)'|(?P<bare>[^\n,\]}#]+))"""
+)
 
 
 @dataclass(frozen=True)
@@ -144,128 +157,120 @@ class Scheduled:
         return POLICIES.get(self.name, Policy())
 
 
+@dataclass
+class Discovery:
+    """What the tree scan found, and what it could not read.
+
+    The warnings matter as much as the findings. A workflow whose triggers this
+    parser cannot read is absent from the audit entirely, which is the
+    "inspects nothing, reports success" failure at per-workflow granularity —
+    so it is reported rather than skipped.
+    """
+
+    scheduled: list[Scheduled] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+def strip_comments(text: str) -> str:
+    """Remove YAML comments so prose cannot satisfy a structural check.
+
+    Deliberately simple: a `#` inside a quoted string would be stripped too.
+    Nothing this reads (cron expressions, step keys, artifact paths) contains
+    one, and the conservative direction is to see less, not more.
+    """
+    out = []
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        out.append(re.sub(r"\s+#.*$", "", line))
+    return "\n".join(out) + "\n"
+
+
 def cron_period_hours(expr: str) -> float:
     """How often a 5-field cron expression fires, in hours.
 
-    Only the coarse magnitude matters — this feeds a staleness window measured
-    in multiples of it — so the answer errs toward the longer period, which
-    makes the window wider and the gate quieter rather than noisier.
+    Only the coarse magnitude matters — this feeds an advisory staleness window
+    — so the answer errs toward the *longer* period, which widens the window
+    and makes the report quieter rather than noisier. The calendar fields are
+    therefore tested from the rarest constraint inward: a month restriction
+    fires yearly however permissive the day and hour fields look.
     """
     fields = expr.split()
     if len(fields) != 5:
-        # Not something to guess at. Treat it as weekly, the most forgiving of
-        # the cadences actually in use.
-        return 168.0
-    _minute, hour, dom, month, dow = fields
-    if dow != "*" or month != "*":
-        return 168.0
+        # Not something to guess at, so assume the rarest cadence in use.
+        return 8760.0
+    minute, hour, dom, month, dow = fields
+    if month != "*":
+        return 8760.0
     if dom != "*":
         return 720.0
+    if dow != "*":
+        return 168.0
     step = re.fullmatch(r"\*/(\d+)", hour)
     if step:
         return max(1.0, float(step.group(1)))
     if hour != "*":
         return 24.0
+    step = re.fullmatch(r"\*/(\d+)", minute)
+    if step:
+        return max(1.0, float(step.group(1)) / 60.0)
     return 1.0
 
 
-def schedule_expressions(source: str) -> tuple[str, ...]:
-    """Cron expressions in this workflow's `on:` trigger block.
+def on_block(source: str) -> str | None:
+    """The text of a workflow's trigger block, comments removed.
 
-    Scoped to the `on:` block rather than the whole file so the word
-    `schedule:` in a comment, a job name, or a `run:` heredoc cannot invent a
-    trigger that does not exist.
+    Scoped to `on:` so the word `schedule` in a job name, a comment, or a
+    `run:` heredoc cannot invent a trigger that does not exist.
     """
-    match = ON_BLOCK_RE.search(source)
+    match = ON_BLOCK_RE.search(strip_comments(source))
     if not match:
+        return None
+    return match.group("inline") + "\n" + match.group("body")
+
+
+def schedule_expressions(source: str) -> tuple[str, ...]:
+    """Cron expressions in this workflow's trigger block."""
+    block = on_block(source)
+    if block is None:
         return ()
-    crons: list[str] = []
-    in_schedule = False
-    for line in match.group("body").splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        indent = len(line) - len(line.lstrip())
-        if re.fullmatch(r"schedule:", stripped):
-            in_schedule = True
-            schedule_indent = indent
-            continue
-        if in_schedule:
-            if indent <= schedule_indent and not stripped.startswith("-"):
-                in_schedule = False
-            else:
-                cron = CRON_RE.match(line)
-                if cron:
-                    crons.append(cron.group("expr").strip())
+    crons = []
+    for match in CRON_VALUE_RE.finditer(block):
+        value = match.group("dq") or match.group("sq") or match.group("bare") or ""
+        value = value.strip()
+        if value:
+            crons.append(value)
     return tuple(crons)
 
 
-def discover(workflows_dir: Path) -> list[Scheduled]:
-    """Every workflow in the tree carrying a `schedule:` trigger."""
-    found = []
+def discover(workflows_dir: Path) -> Discovery:
+    """Every workflow in the tree carrying a `schedule:` trigger.
+
+    Discovery is by trigger rather than from a list in this file, so a
+    scheduled workflow added later is covered without anyone remembering to
+    register it — the omission this gate exists to prevent is precisely the
+    kind nobody remembers.
+    """
+    result = Discovery()
     for path in sorted(workflows_dir.glob("*.y*ml")):
         source = path.read_text()
+        block = on_block(source)
+        if block is None:
+            result.warnings.append(
+                f"{path.name}: no `on:` trigger block could be read, so this file "
+                "was not audited. The parser, not the workflow, is likely wrong."
+            )
+            continue
         crons = schedule_expressions(source)
         if crons:
-            found.append(Scheduled(path.name, path, crons, source))
-    return found
-
-
-# --------------------------------------------------------------------------
-# Structural checks (no network)
-# --------------------------------------------------------------------------
-
-#: The directory `scripts/ci-timed` copies a failing command's complete output
-#: into, and the artifact path the `ci.yml` lanes upload from.
-FAILURE_LOG_DIR = "rue-ci-failed-logs"
-
-
-def structural_problems(scheduled: list[Scheduled]) -> list[str]:
-    """Structure that must hold for a scheduled failure to stay debuggable.
-
-    A weekly job's console log ages out of retention, and the Actions job-log
-    API serves only a truncated tail even before it does, so a failure nobody
-    looked at for a fortnight is undiagnosable from the run page alone
-    (RUE-1268). `scripts/ci-timed` already preserves the full output of a
-    failing command; a workflow that uses it and then does not upload what it
-    preserved is throwing the evidence away at the last step. Requiring the
-    upload only of workflows that actually run through `ci-timed` keeps the
-    rule honest: elsewhere the artifact would always be empty, and an empty
-    artifact that looks like coverage is the shape of problem this file exists
-    to catch.
-    """
-    problems = []
-    for workflow in scheduled:
-        if "scripts/ci-timed" not in workflow.source:
-            continue
-        if FAILURE_LOG_DIR not in workflow.source:
-            problems.append(
-                f"{workflow.name}: runs commands through scripts/ci-timed but never "
-                f"uploads {FAILURE_LOG_DIR}; a scheduled failure stops being "
-                "debuggable as soon as the job log ages out. Add the "
-                "`if: failure()` upload-artifact step used by the ci.yml lanes."
+            result.scheduled.append(Scheduled(path.name, path, crons, source))
+        elif "schedule" in block:
+            result.warnings.append(
+                f"{path.name}: its `on:` block mentions `schedule` but no cron "
+                "expression could be read from it, so it was not audited."
             )
-
-    return problems
-
-
-def orphaned_policies(scheduled: list[Scheduled]) -> list[str]:
-    """Declared policies naming a workflow that no longer exists.
-
-    Asked of the complete discovered set, never of a subset: this is a question
-    about the repository, not about one workflow. An entry matching nothing
-    exempts nothing, so it is harmless in itself — but it is evidence that the
-    declarations have stopped being re-read, which is how a waiver written for
-    one breakage ends up covering the next.
-    """
-    known = {workflow.name for workflow in scheduled}
-    return [
-        f"POLICIES declares {name!r}, which is not a scheduled workflow in "
-        f"{WORKFLOWS_DIR.name}/. Remove the entry: it no longer exempts anything, "
-        "and its presence hides that the declarations were never re-examined."
-        for name in sorted(POLICIES)
-        if name not in known
-    ]
+    return result
 
 
 # --------------------------------------------------------------------------
@@ -274,7 +279,7 @@ def orphaned_policies(scheduled: list[Scheduled]) -> list[str]:
 
 
 class TransportError(RuntimeError):
-    """A request could not be completed. Always surfaced; never swallowed."""
+    """A request could not be completed. Reported, never fatal."""
 
 
 class Transport:
@@ -285,13 +290,46 @@ class Transport:
 
 
 class UrllibTransport(Transport):
-    """The real transport: stdlib only, so the script has no dependencies."""
+    """The real transport: stdlib only, so the script has no dependencies.
 
-    def __init__(self, token: str = "", timeout: float = 30.0) -> None:
+    Retries the statuses that mean "ask again" — rate limiting and server
+    faults — honoring `Retry-After` when GitHub sends one. This job issues its
+    queries on every pull request and every merge-group commit against a token
+    bucket shared with the rest of CI, so a transient 429 must not be the
+    script's final answer.
+    """
+
+    RETRY_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+    def __init__(
+        self,
+        token: str = "",
+        timeout: float = 30.0,
+        attempts: int = 3,
+        sleep=time.sleep,
+    ) -> None:
         self.token = token
         self.timeout = timeout
+        self.attempts = attempts
+        self.sleep = sleep
 
     def get(self, url: str) -> dict:
+        last: TransportError | None = None
+        for attempt in range(self.attempts):
+            try:
+                return self._get_once(url)
+            except NotRegistered:
+                raise
+            except TransportError as error:
+                last = error
+                if not getattr(error, "retryable", False):
+                    raise
+                if attempt + 1 < self.attempts:
+                    self.sleep(min(getattr(error, "retry_after", 0.0) or 2.0**attempt, 30.0))
+        assert last is not None
+        raise last
+
+    def _get_once(self, url: str) -> dict:
         request = urllib.request.Request(url, method="GET")
         request.add_header("Accept", "application/vnd.github+json")
         request.add_header("X-GitHub-Api-Version", "2022-11-28")
@@ -304,9 +342,16 @@ class UrllibTransport(Transport):
             if error.code == 404:
                 raise NotRegistered(url)
             detail = error.read().decode(errors="replace")[:300]
-            raise TransportError(f"GET {url} -> HTTP {error.code}: {detail}")
+            failure = TransportError(f"GET {url} -> HTTP {error.code}: {detail}")
+            if error.code in self.RETRY_STATUSES:
+                failure.retryable = True  # type: ignore[attr-defined]
+                header = (error.headers or {}).get("Retry-After")
+                failure.retry_after = float(header) if header else 0.0  # type: ignore[attr-defined]
+            raise failure
         except urllib.error.URLError as error:
-            raise TransportError(f"GET {url} -> {error.reason}")
+            failure = TransportError(f"GET {url} -> {error.reason}")
+            failure.retryable = True  # type: ignore[attr-defined]
+            raise failure
         try:
             return json.loads(body)
         except json.JSONDecodeError:
@@ -322,10 +367,14 @@ class History:
     """What GitHub knows about one workflow's scheduled runs."""
 
     state: str
-    created_at: datetime
     scheduled_runs: int
     successful_runs: int
     last_success: datetime | None
+
+
+def plural(count: int, noun: str) -> str:
+    """`1 run` / `2 runs`. Output is read by people; agreement is not optional."""
+    return f"{count} {noun}" if count == 1 else f"{count} {noun}s"
 
 
 def parse_time(value: str) -> datetime:
@@ -338,11 +387,42 @@ def parse_time(value: str) -> datetime:
 
 
 class Client:
-    """Reads the Actions API. Two counts and a state per workflow, nothing more."""
+    """Reads the Actions API.
+
+    Deliberately frugal. Workflow states arrive in one listing rather than one
+    request each, and the second runs query is issued only when the first shows
+    no successes, so an all-green repository costs one request per workflow
+    plus one.
+    """
 
     def __init__(self, transport: Transport, repo: str) -> None:
         self.transport = transport
         self.repo = repo
+        self._states: dict[str, str] | None = None
+        self._states_error: TransportError | None = None
+
+    def states(self) -> dict[str, str]:
+        """Every registered workflow's state, keyed by file name.
+
+        A failure is remembered, not retried. The caller asks once per
+        workflow, so without this a single outage would re-issue the listing
+        (and its retries) seven times over.
+        """
+        if self._states_error is not None:
+            raise self._states_error
+        if self._states is None:
+            try:
+                data = self.transport.get(
+                    f"{GITHUB_API_URL}/repos/{self.repo}/actions/workflows?per_page=100"
+                )
+            except TransportError as error:
+                self._states_error = error
+                raise
+            self._states = {
+                Path(entry.get("path", "")).name: entry.get("state", "unknown")
+                for entry in data.get("workflows", [])
+            }
+        return self._states
 
     def _runs(self, name: str, **params: str) -> dict:
         query = urllib.parse.urlencode({"event": "schedule", "per_page": "1", **params})
@@ -351,18 +431,35 @@ class Client:
         )
 
     def history(self, name: str) -> History:
-        meta = self.transport.get(
-            f"{GITHUB_API_URL}/repos/{self.repo}/actions/workflows/{name}"
-        )
-        all_runs = self._runs(name)
+        states = self.states()
+        if name not in states:
+            raise NotRegistered(name)
         successes = self._runs(name, status="success")
+        successful = int(successes.get("total_count", 0))
         runs = successes.get("workflow_runs") or []
+
+        last_success = None
+        if runs:
+            # A run enters the `status=success` filter when it *finishes*, so
+            # `updated_at` is when the success actually existed. `created_at`
+            # can be tens of minutes earlier, which on a daily cadence is the
+            # difference between inside and outside a budget.
+            entry = runs[0]
+            stamp = entry.get("updated_at") or entry.get("created_at")
+            if stamp:
+                last_success = parse_time(stamp)
+
+        # Only needed to tell "never fired" from "fired and never succeeded",
+        # which matters only when there are no successes at all.
+        scheduled = successful
+        if successful == 0:
+            scheduled = int(self._runs(name).get("total_count", 0))
+
         return History(
-            state=meta.get("state", "unknown"),
-            created_at=parse_time(meta["created_at"]),
-            scheduled_runs=int(all_runs.get("total_count", 0)),
-            successful_runs=int(successes.get("total_count", 0)),
-            last_success=parse_time(runs[0]["created_at"]) if runs else None,
+            state=states[name],
+            scheduled_runs=scheduled,
+            successful_runs=successful,
+            last_success=last_success,
         )
 
 
@@ -371,7 +468,8 @@ class Client:
 # --------------------------------------------------------------------------
 
 OK = "ok"
-FAIL = "fail"
+WARN = "warn"
+BLOCK = "block"
 
 
 @dataclass
@@ -379,21 +477,17 @@ class Finding:
     """One workflow's verdict, with the evidence it was reached from."""
 
     workflow: str
-    status: str
+    severity: str
     summary: str
     detail: str = ""
 
     @property
-    def failed(self) -> bool:
-        return self.status == FAIL
+    def blocks(self) -> bool:
+        return self.severity == BLOCK
 
 
 def classify(workflow: Scheduled, history: History | None, now: datetime) -> Finding:
-    """Judge one workflow against the two durable properties.
-
-    `history` of None means GitHub has never registered the workflow, which is
-    what a pull request adding one looks like.
-    """
+    """Judge one workflow. Only a never-succeeded verdict may block a merge."""
     policy = workflow.policy
     name = workflow.name
 
@@ -405,86 +499,176 @@ def classify(workflow: Scheduled, history: History | None, now: datetime) -> Fin
         )
 
     if history.state != "active":
-        # No amount of run history can see this: a disabled workflow simply
-        # stops producing runs, and its last one may well have been green.
+        # Run history cannot see this: a disabled workflow stops producing runs
+        # and its last one may well have been green. It is reported rather than
+        # blocking because a workflow disabled on purpose, for an afternoon, is
+        # indistinguishable here from one GitHub retired for inactivity.
         return Finding(
             name,
-            FAIL,
-            f"disabled by GitHub (state: {history.state})",
-            "It will never fire again until it is re-enabled. `disabled_inactivity` "
-            "means 60 days passed with no repository activity; re-enable it from the "
-            "Actions tab or with `gh workflow enable`.",
+            WARN,
+            f"disabled by GitHub (state: {history.state}) and will never fire again",
+            "`disabled_inactivity` means 60 days passed with no repository "
+            "activity. Re-enable it from the Actions tab or with `gh workflow "
+            "enable` if it is still wanted.",
         )
 
-    period = workflow.period_hours
-    age_hours = (now - history.created_at).total_seconds() / 3600.0
-
     if history.scheduled_runs == 0:
-        # Distinguish "too new to have fired" from "should have fired and did
-        # not" — the second is a real finding and the first is not.
-        if age_hours < 2 * period:
-            return Finding(
-                name, OK, "registered recently; its cron has not fired yet"
-            )
+        # Never fired. This is also exactly how a pull request that *adds* a
+        # schedule to an already-registered workflow file looks, so it reports
+        # rather than blocking: the API cannot say when the schedule was added,
+        # only when the file was first registered.
         return Finding(
             name,
-            FAIL,
-            f"registered {age_hours / 24:.0f} days ago and has never run on its "
-            "schedule",
-            f"cron {' / '.join(workflow.crons)} should have fired by now. The "
-            "workflow exists but is producing nothing.",
+            WARN,
+            "has never run on its schedule",
+            f"cron {' / '.join(workflow.crons)}. Expected for a schedule added "
+            "in this branch; if it has been on trunk for longer than that, the "
+            "workflow exists and is producing nothing.",
         )
 
     if history.successful_runs == 0:
-        finding = Finding(
-            name,
-            FAIL,
-            f"has never succeeded in {history.scheduled_runs} scheduled run(s)",
-            "Every run it has ever had failed, so whatever it was added to protect "
-            "has never once been protected. This is RUE-1507's shape: the workflow "
-            "is believed while doing nothing.",
-        )
-    else:
-        assert history.last_success is not None
-        stale_after = policy.stale_periods * period
-        idle_hours = (now - history.last_success).total_seconds() / 3600.0
-        if idle_hours > stale_after:
+        if history.scheduled_runs < MIN_RUNS_FOR_NEVER_SUCCEEDED:
             finding = Finding(
                 name,
-                FAIL,
-                f"last succeeded {idle_hours / 24:.1f} days ago, over its "
-                f"{stale_after / 24:.1f}-day budget",
+                WARN,
+                f"its only scheduled run failed ({history.scheduled_runs} run so far)",
+                "One red run is not yet evidence the workflow has never worked.",
+            )
+        else:
+            finding = Finding(
+                name,
+                BLOCK,
+                f"has never succeeded in {history.scheduled_runs} scheduled runs",
+                "Every run it has ever had failed, so whatever it was added to "
+                "protect has never once been protected. This is RUE-1507's shape: "
+                "the workflow is believed while doing nothing.",
+            )
+    elif policy.stale_periods is None or history.last_success is None:
+        finding = Finding(
+            name,
+            OK,
+            f"{plural(history.successful_runs, 'successful scheduled run')}; "
+            "staleness not assessed",
+        )
+    else:
+        budget = max(
+            policy.stale_periods * workflow.period_hours, MIN_STALE_BUDGET_HOURS
+        )
+        idle = (now - history.last_success).total_seconds() / 3600.0
+        if idle > budget:
+            finding = Finding(
+                name,
+                WARN,
+                f"last succeeded {idle / 24:.1f} days ago, past its "
+                f"{budget / 24:.1f}-day advisory window",
                 f"cron {' / '.join(workflow.crons)} has fired repeatedly since "
-                "without a single green run. Treat it as broken, not unlucky.",
+                "without a green run. Worth a look; not proof of breakage.",
             )
         else:
             finding = Finding(
                 name,
                 OK,
-                f"last succeeded {idle_hours / 24:.1f} days ago "
-                f"({history.successful_runs} successful scheduled run(s))",
+                f"last succeeded {idle / 24:.1f} days ago "
+                f"({plural(history.successful_runs, 'successful scheduled run')})",
             )
 
     if policy.known_broken:
-        if finding.failed:
+        if finding.severity == BLOCK:
             return Finding(
                 name,
                 OK,
                 f"known broken, tracked by {policy.known_broken}: {finding.summary}",
             )
-        # The waiver has outlived the breakage. Left in place it would keep
-        # this workflow exempt forever, so the next regression would be as
-        # silent as the one the waiver was written for.
-        return Finding(
-            name,
-            FAIL,
-            f"waiver for {policy.known_broken} is stale: the workflow is healthy "
-            f"again ({finding.summary})",
-            f"Delete the {name!r} entry from POLICIES in "
-            f"{Path(__file__).name}. A waiver that outlives its breakage silently "
-            "exempts every future one.",
-        )
+        if finding.severity == OK:
+            # The waiver has outlived the breakage. Reported, not blocking: a
+            # workflow turning green is good news, and good news arriving on a
+            # cron nobody chose must not stop every merge in the repository
+            # until someone edits this file.
+            return Finding(
+                name,
+                WARN,
+                f"waiver for {policy.known_broken} is no longer needed: the "
+                f"workflow is healthy again ({finding.summary})",
+                f"Delete the {name!r} entry from POLICIES in "
+                f"{Path(__file__).name}. A waiver that outlives its breakage "
+                "would silently exempt the next one.",
+            )
     return finding
+
+
+# --------------------------------------------------------------------------
+# Structural checks
+# --------------------------------------------------------------------------
+
+#: The directory `scripts/ci-timed` copies a failing command's output into, and
+#: the artifact path the `ci.yml` lanes upload from.
+FAILURE_LOG_DIR = "rue-ci-failed-logs"
+
+
+def structural_problems(scheduled: list[Scheduled]) -> list[str]:
+    """Structure that must hold for a scheduled failure to stay debuggable.
+
+    A weekly job's console log ages out of retention, and the Actions job-log
+    API serves only a truncated tail even before it does, so a failure nobody
+    looked at for a fortnight is undiagnosable from the run page alone
+    (RUE-1268). `scripts/ci-timed` already preserves the full output of a
+    failing command; a workflow that uses it and then does not upload what it
+    preserved is discarding the evidence at the last step.
+
+    The check is a whole-file one: it proves the workflow uploads the preserved
+    directory on failure somewhere, not that every `ci-timed` job has its own
+    upload. Pairing them per job needs a real YAML parse, which is not
+    available here. Comments are stripped first, so prose mentioning the
+    directory cannot satisfy it — that much would otherwise be exactly the
+    false-green shape this file exists to catch.
+    """
+    problems = []
+    for workflow in scheduled:
+        source = strip_comments(workflow.source)
+        if "scripts/ci-timed" not in source:
+            continue
+        if FAILURE_LOG_DIR not in source or "if: failure()" not in source:
+            problems.append(
+                f"{workflow.name}: runs commands through scripts/ci-timed but has no "
+                f"`if: failure()` step uploading {FAILURE_LOG_DIR}; a scheduled "
+                "failure stops being debuggable as soon as the job log ages out. "
+                "Add the upload-artifact step used by the ci.yml lanes."
+            )
+    return problems
+
+
+def policy_problems(scheduled: list[Scheduled]) -> list[str]:
+    """Declared policies that name nothing, or that explain nothing.
+
+    Asked of the complete discovered set, never a subset: this is a question
+    about the repository. These block because they are deterministic facts
+    about the tree, with no external state that could make them spuriously
+    true.
+    """
+    known = {workflow.name for workflow in scheduled}
+    problems = []
+    for name in sorted(POLICIES):
+        policy = POLICIES[name]
+        if name not in known:
+            problems.append(
+                f"POLICIES declares {name!r}, which is not a scheduled workflow in "
+                f"{WORKFLOWS_DIR.name}/. Remove the entry: it no longer exempts "
+                "anything, and its presence hides that the declarations were never "
+                "re-examined."
+            )
+            continue
+        if policy.known_broken and not ISSUE_RE.match(policy.known_broken):
+            problems.append(
+                f"POLICIES[{name!r}].known_broken is {policy.known_broken!r}, which "
+                "is not a RUE-NN issue. A waiver suppresses a blocking verdict, so "
+                "it must name the issue that removes it."
+            )
+        if not policy.note.strip():
+            problems.append(
+                f"POLICIES[{name!r}] carries no note. A declaration without a "
+                "stated reason cannot be re-examined by the next reader."
+            )
+    return problems
 
 
 # --------------------------------------------------------------------------
@@ -495,11 +679,12 @@ def classify(workflow: Scheduled, history: History | None, now: datetime) -> Fin
 @dataclass
 class Report:
     findings: list[Finding] = field(default_factory=list)
-    structural: list[str] = field(default_factory=list)
+    problems: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
 
     @property
-    def failed(self) -> bool:
-        return bool(self.structural) or any(f.failed for f in self.findings)
+    def blocked(self) -> bool:
+        return bool(self.problems) or any(f.blocks for f in self.findings)
 
 
 def check(
@@ -510,7 +695,7 @@ def check(
     """Run the structural checks, and the history checks when given a client."""
     now = now or datetime.now(timezone.utc)
     report = Report(
-        structural=structural_problems(scheduled) + orphaned_policies(scheduled)
+        problems=structural_problems(scheduled) + policy_problems(scheduled)
     )
     if client is None:
         return report
@@ -519,7 +704,19 @@ def check(
             history: History | None = client.history(workflow.name)
         except NotRegistered:
             history = None
-        report.findings.append(classify(workflow, history, now))
+        except TransportError as error:
+            # One unreadable workflow must not decide the repository's fate.
+            report.warnings.append(f"{workflow.name}: run history unavailable: {error}")
+            continue
+        try:
+            report.findings.append(classify(workflow, history, now))
+        except Exception as error:  # noqa: BLE001 - deliberately total
+            # A shape the classifier does not expect is a bug in this file, and
+            # a bug in this file must not block every merge in the repository.
+            report.warnings.append(
+                f"{workflow.name}: could not be classified ({error!r}); "
+                "treating as unknown rather than failing the build."
+            )
     return report
 
 
@@ -547,12 +744,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
 
-    scheduled = discover(args.workflows)
+    discovered = discover(args.workflows)
+    scheduled = discovered.scheduled
     if not scheduled:
-        # The repository has scheduled workflows. Finding none means the
-        # discovery broke, and a gate that inspects an empty list reports
-        # success having checked nothing — the exact failure it is here to
-        # prevent, one level up.
+        # The repository has scheduled workflows. Finding none means discovery
+        # broke, and a gate that inspects an empty list and reports success is
+        # the same bug one level up. This one is deterministic and offline, so
+        # it is safe to block on.
         print(
             f"error: no scheduled workflows found in {args.workflows}; "
             "the discovery is broken, not the tree",
@@ -565,47 +763,57 @@ def main(argv: list[str] | None = None) -> int:
     if not args.offline:
         if not args.repo:
             print(
-                "error: --repo (or $GITHUB_REPOSITORY) is required without --offline",
+                "warning: no --repo and no $GITHUB_REPOSITORY; checking structure "
+                "only. Run history was not read.",
                 file=sys.stderr,
             )
-            return 2
-        token = os.environ.get("GITHUB_TOKEN", "").strip()
-        if not token:
-            print(
-                "warning: GITHUB_TOKEN is unset; using unauthenticated API quota",
-                file=sys.stderr,
-            )
-        client = Client(UrllibTransport(token), args.repo)
+        else:
+            token = os.environ.get("GITHUB_TOKEN", "").strip()
+            if not token:
+                print(
+                    "warning: GITHUB_TOKEN is unset; using unauthenticated API quota",
+                    file=sys.stderr,
+                )
+            client = Client(UrllibTransport(token), args.repo)
 
-    try:
-        report = check(scheduled, client)
-    except TransportError as error:
-        print(f"error: {error}", file=sys.stderr)
-        return 1
+    # `check` absorbs every per-workflow transport and classification failure
+    # into warnings, so there is no error path here to catch: an unavailable
+    # API produces a warned, passing report rather than an exception.
+    report = check(scheduled, client)
+    report.warnings = discovered.warnings + report.warnings
 
     for finding in sorted(report.findings, key=lambda f: f.workflow):
-        mark = "FAIL" if finding.failed else "ok  "
+        mark = {BLOCK: "FAIL", WARN: "warn", OK: "ok  "}[finding.severity]
         print(f"{mark} {finding.workflow}: {finding.summary}")
-        if finding.failed and finding.detail:
+        if finding.severity != OK and finding.detail:
             print(f"       {finding.detail}")
-    for problem in report.structural:
+    for problem in report.problems:
         print(f"FAIL {problem}")
+    for warning in report.warnings:
+        print(f"warn {warning}")
 
-    if report.failed:
+    if report.blocked:
         print(
-            "\nA scheduled workflow is not doing its job. Fix it, or — if a tracked "
-            "issue already owns the fix — declare it in POLICIES with that issue.",
+            "\nA scheduled workflow has never once succeeded, or the audit itself is "
+            "misdeclared. Fix it, or — if a tracked issue already owns the fix — "
+            "declare it in POLICIES with that issue.",
             file=sys.stderr,
         )
         return 1
-    # Say which question was actually answered. A structural pass reported as
-    # if it were a clean bill of health is the same overclaim this gate exists
-    # to catch.
+
+    # Say exactly what was established, and nothing more. A partial audit
+    # reported as a clean bill of health is the overclaim this file condemns.
+    checked = len(report.findings)
+    waived = sum(1 for f in POLICIES.values() if f.known_broken)
+    warned = sum(1 for f in report.findings if f.severity == WARN)
     if client is None:
-        print(f"\nStructure only: {len(scheduled)} workflow(s) checked, no run "
-              "history read (--offline).")
+        print(f"\nStructure only: {len(scheduled)} workflow(s), no run history read.")
     else:
-        print("\nEvery scheduled workflow has succeeded, and succeeded recently.")
+        print(
+            f"\nNo scheduled workflow has failed every run: {checked} audited, "
+            f"{warned} with warnings, {waived} waived, "
+            f"{len(scheduled) - checked} not reached."
+        )
     return 0
 
 

--- a/scripts/check-scheduled-workflows.py
+++ b/scripts/check-scheduled-workflows.py
@@ -1,0 +1,613 @@
+#!/usr/bin/env python3
+"""Prove every scheduled workflow is still doing the job it was added to do.
+
+A workflow on a `schedule:` trigger has no audience. Nobody opens a pull
+request against it, no merge waits on it, and its result is a row in a tab
+nobody visits. `correctness-repetitions.yml` failed on *every* scheduled run it
+ever had — two for two, each dead in 18 seconds on an argument the invoked
+script does not accept — and that went unnoticed for eleven days (RUE-1507).
+The bug itself is small. What makes it worth a gate is that the workflow was
+believed: a safeguard that fails silently is worth less than no safeguard,
+because its absence is not noticed while its presence is assumed.
+
+This checks the two properties of a scheduled workflow that stay quiet when it
+is healthy and cannot stay quiet when it is not:
+
+**It has succeeded at least once.** A workflow whose entire history is failures
+never worked, so nothing it claims to protect has ever been protected. That is
+strictly stronger evidence than one red run, and it is the exact signature of
+the RUE-1507 bug.
+
+**It has succeeded recently.** "Recently" is a generous multiple of the
+workflow's own cron period, so an ordinary red night is not a repository-wide
+event, while a workflow that has quietly stopped working is one.
+
+Both are durable: a workflow that is fine never trips either, no matter how
+flaky an individual run is. That is what makes it safe to run this where it
+will actually be read — required CI on every pull request — rather than on
+another unattended timer. The mechanism this file exists to fix cannot be the
+mechanism that reports on it.
+
+Two failure modes get their own answers because a general one would be wrong:
+
+* A workflow GitHub has **disabled** never fires again. It has no failing run
+  to notice, so run history alone cannot see it. The workflow's `state` can.
+  (GitHub disables scheduled workflows in repositories with no activity for 60
+  days, and a disabled workflow reports nothing forever.)
+* A workflow this branch **adds** has no history and is not registered at all.
+  Failing the pull request that introduces a scheduled workflow would be a gate
+  that punishes its own adoption, so an unregistered or just-created workflow
+  passes with a note until its cron has had a chance to fire.
+
+Usage:
+    scripts/check-scheduled-workflows.py --repo OWNER/NAME   # structure + history
+    scripts/check-scheduled-workflows.py --offline           # structure only
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+GITHUB_API_URL = "https://api.github.com"
+
+WORKFLOWS_DIR = Path(__file__).resolve().parents[1] / ".github/workflows"
+
+#: Multiple of a workflow's own cron period allowed to pass with no successful
+#: run before it is called stale. Four is deliberately loose: this gate blocks
+#: pull requests, so it must answer "has this stopped working?" and never "did
+#: last night go badly?".
+DEFAULT_STALE_PERIODS = 4
+
+
+@dataclass(frozen=True)
+class Policy:
+    """A declared deviation from the default rules, and why it exists.
+
+    `known_broken` is the workflow equivalent of the repository's
+    `known_bug = "RUE-NN"` xfail markers: it records a real failure against the
+    issue that will fix it instead of hiding it. It expires the same way those
+    markers do — a waived workflow that has become healthy fails this check as
+    a stale waiver, so the declaration cannot outlive the breakage and quietly
+    keep a future regression silent.
+    """
+
+    stale_periods: int = DEFAULT_STALE_PERIODS
+    known_broken: str = ""
+    note: str = ""
+
+
+POLICIES: dict[str, Policy] = {
+    # RUE-1507's original finding, fixed by RUE-1222. Both scheduled runs it
+    # has ever had failed in 18s with `error: unexpected argument '--env'
+    # found`, so it has never once done the work it was added for. The waiver
+    # exists so this gate does not block the very pull request that repairs it;
+    # when RUE-1222 lands and the next Monday run goes green, this entry starts
+    # failing as stale and must be deleted.
+    "correctness-repetitions.yml": Policy(
+        known_broken="RUE-1222",
+        note="never succeeded; `--env` argument bug fixed by RUE-1222",
+    ),
+    # Nightly fuzzing is red *by design* whenever it finds a crash, and it
+    # already reports each one into the Rue Linear team (RUE-802,
+    # scripts/fuzz-report-failure.py), so its red nights reach a human without
+    # this gate's help. Blocking every pull request because the fuzzer did its
+    # job would be strictly harmful. Measured over the 100 scheduled runs
+    # ending 2026-08-14: 46 failures, a longest run of 13 consecutive failing
+    # nights, and a longest gap between successes of 14 days. Thirty days
+    # leaves that ordinary behavior alone while still catching a fuzzer that
+    # has stopped working outright.
+    "fuzz.yml": Policy(
+        stale_periods=30,
+        note="red on any crash found; per-crash reporting is RUE-802's job",
+    ),
+}
+
+
+# --------------------------------------------------------------------------
+# Workflow discovery
+# --------------------------------------------------------------------------
+
+#: `on:` through the next top-level key. Workflows are discovered from the tree
+#: rather than from a list in this file, so a scheduled workflow added later is
+#: covered without anyone remembering to register it here — the omission this
+#: gate exists to prevent is precisely the kind nobody remembers.
+ON_BLOCK_RE = re.compile(r"^on:\s*\n(?P<body>(?:[ \t].*\n|\n)*)", re.MULTILINE)
+CRON_RE = re.compile(r"^\s+-\s+cron:\s*['\"]?(?P<expr>[^'\"#\n]+?)['\"]?\s*(?:#.*)?$")
+
+
+@dataclass(frozen=True)
+class Scheduled:
+    """A workflow file that GitHub will run on a timer."""
+
+    name: str
+    path: Path
+    crons: tuple[str, ...]
+    source: str
+
+    @property
+    def period_hours(self) -> float:
+        """The shortest interval between two fires of this workflow."""
+        return min(cron_period_hours(expr) for expr in self.crons)
+
+    @property
+    def policy(self) -> Policy:
+        return POLICIES.get(self.name, Policy())
+
+
+def cron_period_hours(expr: str) -> float:
+    """How often a 5-field cron expression fires, in hours.
+
+    Only the coarse magnitude matters — this feeds a staleness window measured
+    in multiples of it — so the answer errs toward the longer period, which
+    makes the window wider and the gate quieter rather than noisier.
+    """
+    fields = expr.split()
+    if len(fields) != 5:
+        # Not something to guess at. Treat it as weekly, the most forgiving of
+        # the cadences actually in use.
+        return 168.0
+    _minute, hour, dom, month, dow = fields
+    if dow != "*" or month != "*":
+        return 168.0
+    if dom != "*":
+        return 720.0
+    step = re.fullmatch(r"\*/(\d+)", hour)
+    if step:
+        return max(1.0, float(step.group(1)))
+    if hour != "*":
+        return 24.0
+    return 1.0
+
+
+def schedule_expressions(source: str) -> tuple[str, ...]:
+    """Cron expressions in this workflow's `on:` trigger block.
+
+    Scoped to the `on:` block rather than the whole file so the word
+    `schedule:` in a comment, a job name, or a `run:` heredoc cannot invent a
+    trigger that does not exist.
+    """
+    match = ON_BLOCK_RE.search(source)
+    if not match:
+        return ()
+    crons: list[str] = []
+    in_schedule = False
+    for line in match.group("body").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        if re.fullmatch(r"schedule:", stripped):
+            in_schedule = True
+            schedule_indent = indent
+            continue
+        if in_schedule:
+            if indent <= schedule_indent and not stripped.startswith("-"):
+                in_schedule = False
+            else:
+                cron = CRON_RE.match(line)
+                if cron:
+                    crons.append(cron.group("expr").strip())
+    return tuple(crons)
+
+
+def discover(workflows_dir: Path) -> list[Scheduled]:
+    """Every workflow in the tree carrying a `schedule:` trigger."""
+    found = []
+    for path in sorted(workflows_dir.glob("*.y*ml")):
+        source = path.read_text()
+        crons = schedule_expressions(source)
+        if crons:
+            found.append(Scheduled(path.name, path, crons, source))
+    return found
+
+
+# --------------------------------------------------------------------------
+# Structural checks (no network)
+# --------------------------------------------------------------------------
+
+#: The directory `scripts/ci-timed` copies a failing command's complete output
+#: into, and the artifact path the `ci.yml` lanes upload from.
+FAILURE_LOG_DIR = "rue-ci-failed-logs"
+
+
+def structural_problems(scheduled: list[Scheduled]) -> list[str]:
+    """Structure that must hold for a scheduled failure to stay debuggable.
+
+    A weekly job's console log ages out of retention, and the Actions job-log
+    API serves only a truncated tail even before it does, so a failure nobody
+    looked at for a fortnight is undiagnosable from the run page alone
+    (RUE-1268). `scripts/ci-timed` already preserves the full output of a
+    failing command; a workflow that uses it and then does not upload what it
+    preserved is throwing the evidence away at the last step. Requiring the
+    upload only of workflows that actually run through `ci-timed` keeps the
+    rule honest: elsewhere the artifact would always be empty, and an empty
+    artifact that looks like coverage is the shape of problem this file exists
+    to catch.
+    """
+    problems = []
+    for workflow in scheduled:
+        if "scripts/ci-timed" not in workflow.source:
+            continue
+        if FAILURE_LOG_DIR not in workflow.source:
+            problems.append(
+                f"{workflow.name}: runs commands through scripts/ci-timed but never "
+                f"uploads {FAILURE_LOG_DIR}; a scheduled failure stops being "
+                "debuggable as soon as the job log ages out. Add the "
+                "`if: failure()` upload-artifact step used by the ci.yml lanes."
+            )
+
+    return problems
+
+
+def orphaned_policies(scheduled: list[Scheduled]) -> list[str]:
+    """Declared policies naming a workflow that no longer exists.
+
+    Asked of the complete discovered set, never of a subset: this is a question
+    about the repository, not about one workflow. An entry matching nothing
+    exempts nothing, so it is harmless in itself — but it is evidence that the
+    declarations have stopped being re-read, which is how a waiver written for
+    one breakage ends up covering the next.
+    """
+    known = {workflow.name for workflow in scheduled}
+    return [
+        f"POLICIES declares {name!r}, which is not a scheduled workflow in "
+        f"{WORKFLOWS_DIR.name}/. Remove the entry: it no longer exempts anything, "
+        "and its presence hides that the declarations were never re-examined."
+        for name in sorted(POLICIES)
+        if name not in known
+    ]
+
+
+# --------------------------------------------------------------------------
+# Run history
+# --------------------------------------------------------------------------
+
+
+class TransportError(RuntimeError):
+    """A request could not be completed. Always surfaced; never swallowed."""
+
+
+class Transport:
+    """Minimal injectable HTTP seam, so tests run the real client code."""
+
+    def get(self, url: str) -> dict:
+        raise NotImplementedError
+
+
+class UrllibTransport(Transport):
+    """The real transport: stdlib only, so the script has no dependencies."""
+
+    def __init__(self, token: str = "", timeout: float = 30.0) -> None:
+        self.token = token
+        self.timeout = timeout
+
+    def get(self, url: str) -> dict:
+        request = urllib.request.Request(url, method="GET")
+        request.add_header("Accept", "application/vnd.github+json")
+        request.add_header("X-GitHub-Api-Version", "2022-11-28")
+        if self.token:
+            request.add_header("Authorization", f"Bearer {self.token}")
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                body = response.read().decode(errors="replace")
+        except urllib.error.HTTPError as error:
+            if error.code == 404:
+                raise NotRegistered(url)
+            detail = error.read().decode(errors="replace")[:300]
+            raise TransportError(f"GET {url} -> HTTP {error.code}: {detail}")
+        except urllib.error.URLError as error:
+            raise TransportError(f"GET {url} -> {error.reason}")
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError:
+            raise TransportError(f"GET {url} -> non-JSON response: {body[:200]}")
+
+
+class NotRegistered(TransportError):
+    """GitHub does not know this workflow: it is not on the default branch yet."""
+
+
+@dataclass
+class History:
+    """What GitHub knows about one workflow's scheduled runs."""
+
+    state: str
+    created_at: datetime
+    scheduled_runs: int
+    successful_runs: int
+    last_success: datetime | None
+
+
+def parse_time(value: str) -> datetime:
+    """Parse a GitHub timestamp as an aware UTC datetime.
+
+    GitHub answers with both `...Z` and `...-05:00` forms depending on the
+    endpoint; `fromisoformat` before Python 3.11 rejects the former.
+    """
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+class Client:
+    """Reads the Actions API. Two counts and a state per workflow, nothing more."""
+
+    def __init__(self, transport: Transport, repo: str) -> None:
+        self.transport = transport
+        self.repo = repo
+
+    def _runs(self, name: str, **params: str) -> dict:
+        query = urllib.parse.urlencode({"event": "schedule", "per_page": "1", **params})
+        return self.transport.get(
+            f"{GITHUB_API_URL}/repos/{self.repo}/actions/workflows/{name}/runs?{query}"
+        )
+
+    def history(self, name: str) -> History:
+        meta = self.transport.get(
+            f"{GITHUB_API_URL}/repos/{self.repo}/actions/workflows/{name}"
+        )
+        all_runs = self._runs(name)
+        successes = self._runs(name, status="success")
+        runs = successes.get("workflow_runs") or []
+        return History(
+            state=meta.get("state", "unknown"),
+            created_at=parse_time(meta["created_at"]),
+            scheduled_runs=int(all_runs.get("total_count", 0)),
+            successful_runs=int(successes.get("total_count", 0)),
+            last_success=parse_time(runs[0]["created_at"]) if runs else None,
+        )
+
+
+# --------------------------------------------------------------------------
+# Classification
+# --------------------------------------------------------------------------
+
+OK = "ok"
+FAIL = "fail"
+
+
+@dataclass
+class Finding:
+    """One workflow's verdict, with the evidence it was reached from."""
+
+    workflow: str
+    status: str
+    summary: str
+    detail: str = ""
+
+    @property
+    def failed(self) -> bool:
+        return self.status == FAIL
+
+
+def classify(workflow: Scheduled, history: History | None, now: datetime) -> Finding:
+    """Judge one workflow against the two durable properties.
+
+    `history` of None means GitHub has never registered the workflow, which is
+    what a pull request adding one looks like.
+    """
+    policy = workflow.policy
+    name = workflow.name
+
+    if history is None:
+        return Finding(
+            name,
+            OK,
+            "not yet registered with GitHub; will be checked once it reaches trunk",
+        )
+
+    if history.state != "active":
+        # No amount of run history can see this: a disabled workflow simply
+        # stops producing runs, and its last one may well have been green.
+        return Finding(
+            name,
+            FAIL,
+            f"disabled by GitHub (state: {history.state})",
+            "It will never fire again until it is re-enabled. `disabled_inactivity` "
+            "means 60 days passed with no repository activity; re-enable it from the "
+            "Actions tab or with `gh workflow enable`.",
+        )
+
+    period = workflow.period_hours
+    age_hours = (now - history.created_at).total_seconds() / 3600.0
+
+    if history.scheduled_runs == 0:
+        # Distinguish "too new to have fired" from "should have fired and did
+        # not" — the second is a real finding and the first is not.
+        if age_hours < 2 * period:
+            return Finding(
+                name, OK, "registered recently; its cron has not fired yet"
+            )
+        return Finding(
+            name,
+            FAIL,
+            f"registered {age_hours / 24:.0f} days ago and has never run on its "
+            "schedule",
+            f"cron {' / '.join(workflow.crons)} should have fired by now. The "
+            "workflow exists but is producing nothing.",
+        )
+
+    if history.successful_runs == 0:
+        finding = Finding(
+            name,
+            FAIL,
+            f"has never succeeded in {history.scheduled_runs} scheduled run(s)",
+            "Every run it has ever had failed, so whatever it was added to protect "
+            "has never once been protected. This is RUE-1507's shape: the workflow "
+            "is believed while doing nothing.",
+        )
+    else:
+        assert history.last_success is not None
+        stale_after = policy.stale_periods * period
+        idle_hours = (now - history.last_success).total_seconds() / 3600.0
+        if idle_hours > stale_after:
+            finding = Finding(
+                name,
+                FAIL,
+                f"last succeeded {idle_hours / 24:.1f} days ago, over its "
+                f"{stale_after / 24:.1f}-day budget",
+                f"cron {' / '.join(workflow.crons)} has fired repeatedly since "
+                "without a single green run. Treat it as broken, not unlucky.",
+            )
+        else:
+            finding = Finding(
+                name,
+                OK,
+                f"last succeeded {idle_hours / 24:.1f} days ago "
+                f"({history.successful_runs} successful scheduled run(s))",
+            )
+
+    if policy.known_broken:
+        if finding.failed:
+            return Finding(
+                name,
+                OK,
+                f"known broken, tracked by {policy.known_broken}: {finding.summary}",
+            )
+        # The waiver has outlived the breakage. Left in place it would keep
+        # this workflow exempt forever, so the next regression would be as
+        # silent as the one the waiver was written for.
+        return Finding(
+            name,
+            FAIL,
+            f"waiver for {policy.known_broken} is stale: the workflow is healthy "
+            f"again ({finding.summary})",
+            f"Delete the {name!r} entry from POLICIES in "
+            f"{Path(__file__).name}. A waiver that outlives its breakage silently "
+            "exempts every future one.",
+        )
+    return finding
+
+
+# --------------------------------------------------------------------------
+# Driver
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Report:
+    findings: list[Finding] = field(default_factory=list)
+    structural: list[str] = field(default_factory=list)
+
+    @property
+    def failed(self) -> bool:
+        return bool(self.structural) or any(f.failed for f in self.findings)
+
+
+def check(
+    scheduled: list[Scheduled],
+    client: Client | None,
+    now: datetime | None = None,
+) -> Report:
+    """Run the structural checks, and the history checks when given a client."""
+    now = now or datetime.now(timezone.utc)
+    report = Report(
+        structural=structural_problems(scheduled) + orphaned_policies(scheduled)
+    )
+    if client is None:
+        return report
+    for workflow in scheduled:
+        try:
+            history: History | None = client.history(workflow.name)
+        except NotRegistered:
+            history = None
+        report.findings.append(classify(workflow, history, now))
+    return report
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", ""),
+        help="OWNER/NAME to read run history from (default: $GITHUB_REPOSITORY)",
+    )
+    parser.add_argument(
+        "--workflows",
+        type=Path,
+        default=WORKFLOWS_DIR,
+        help="directory of workflow files to audit",
+    )
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="run only the structural checks, which need no network",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    scheduled = discover(args.workflows)
+    if not scheduled:
+        # The repository has scheduled workflows. Finding none means the
+        # discovery broke, and a gate that inspects an empty list reports
+        # success having checked nothing — the exact failure it is here to
+        # prevent, one level up.
+        print(
+            f"error: no scheduled workflows found in {args.workflows}; "
+            "the discovery is broken, not the tree",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"auditing {len(scheduled)} scheduled workflow(s) in {args.workflows}")
+
+    client = None
+    if not args.offline:
+        if not args.repo:
+            print(
+                "error: --repo (or $GITHUB_REPOSITORY) is required without --offline",
+                file=sys.stderr,
+            )
+            return 2
+        token = os.environ.get("GITHUB_TOKEN", "").strip()
+        if not token:
+            print(
+                "warning: GITHUB_TOKEN is unset; using unauthenticated API quota",
+                file=sys.stderr,
+            )
+        client = Client(UrllibTransport(token), args.repo)
+
+    try:
+        report = check(scheduled, client)
+    except TransportError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    for finding in sorted(report.findings, key=lambda f: f.workflow):
+        mark = "FAIL" if finding.failed else "ok  "
+        print(f"{mark} {finding.workflow}: {finding.summary}")
+        if finding.failed and finding.detail:
+            print(f"       {finding.detail}")
+    for problem in report.structural:
+        print(f"FAIL {problem}")
+
+    if report.failed:
+        print(
+            "\nA scheduled workflow is not doing its job. Fix it, or — if a tracked "
+            "issue already owns the fix — declare it in POLICIES with that issue.",
+            file=sys.stderr,
+        )
+        return 1
+    # Say which question was actually answered. A structural pass reported as
+    # if it were a clean bill of health is the same overclaim this gate exists
+    # to catch.
+    if client is None:
+        print(f"\nStructure only: {len(scheduled)} workflow(s) checked, no run "
+              "history read (--offline).")
+    else:
+        print("\nEvery scheduled workflow has succeeded, and succeeded recently.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-check-scheduled-workflows.py
+++ b/scripts/test-check-scheduled-workflows.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Pin the classification logic of scripts/check-scheduled-workflows.py.
+
+The gate this exercises blocks pull requests, so both of its ways of being
+wrong are expensive: a false red stops everyone's work, and a false green
+restores exactly the silence RUE-1507 was filed about. The cases below are
+chosen for those two edges rather than for coverage — what a workflow that has
+never succeeded does, what an ordinary red night does *not* do, and what
+happens when a waiver outlives the breakage it was written for.
+
+Run directly; no network and no credentials. The API is replaced at the
+`Transport` seam, so the client, the classifier, and the driver under test are
+the same code CI runs.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location(
+    "check_scheduled_workflows", HERE / "check-scheduled-workflows.py"
+)
+assert SPEC and SPEC.loader
+csw = importlib.util.module_from_spec(SPEC)
+# `@dataclass` resolves its own module through `sys.modules`, and fails outright
+# when it is missing (see scripts/test-fuzz-report-failure.py, same idiom).
+sys.modules[SPEC.name] = csw
+SPEC.loader.exec_module(csw)
+
+NOW = datetime(2026, 8, 14, 12, 0, tzinfo=timezone.utc)
+DAILY = "0 6 * * *"
+WEEKLY = "17 7 * * 1"
+
+
+def workflow(name: str, cron: str = WEEKLY, source: str = "") -> csw.Scheduled:
+    return csw.Scheduled(name, Path(name), (cron,), source)
+
+
+def history(
+    *,
+    state: str = "active",
+    created_days_ago: float = 90.0,
+    scheduled_runs: int = 10,
+    successful_runs: int = 10,
+    success_days_ago: float | None = 1.0,
+) -> csw.History:
+    return csw.History(
+        state=state,
+        created_at=NOW - timedelta(days=created_days_ago),
+        scheduled_runs=scheduled_runs,
+        successful_runs=successful_runs,
+        last_success=(
+            None if success_days_ago is None else NOW - timedelta(days=success_days_ago)
+        ),
+    )
+
+
+class CronPeriodTests(unittest.TestCase):
+    def test_cadences_in_use(self):
+        self.assertEqual(csw.cron_period_hours("0 0 * * *"), 24.0)
+        self.assertEqual(csw.cron_period_hours("17 7 * * 1"), 168.0)
+        self.assertEqual(csw.cron_period_hours("*/6 * * * *"), 1.0)
+        self.assertEqual(csw.cron_period_hours("0 */6 * * *"), 6.0)
+
+    def test_unparseable_cron_widens_the_window(self):
+        """An expression we cannot read must make the gate quieter, not louder."""
+        self.assertEqual(csw.cron_period_hours("nonsense"), 168.0)
+
+
+class DiscoveryTests(unittest.TestCase):
+    def test_schedule_outside_the_on_block_is_not_a_trigger(self):
+        source = (
+            "name: X\n"
+            "on:\n"
+            "  workflow_dispatch:\n"
+            "\n"
+            "# schedule: this is prose about scheduling\n"
+            "jobs:\n"
+            "  a:\n"
+            "    steps:\n"
+            "      - run: echo '- cron: 0 0 * * *'\n"
+        )
+        self.assertEqual(csw.schedule_expressions(source), ())
+
+    def test_cron_is_read_from_the_on_block(self):
+        source = (
+            "name: X\n"
+            "on:\n"
+            "  push:\n"
+            "    branches: [trunk]\n"
+            "  # a comment between triggers\n"
+            "  schedule:\n"
+            "    - cron: '0 5 * * 1'  # trailing comment\n"
+            "    - cron: \"23 6 * * *\"\n"
+            "  workflow_dispatch:\n"
+            "\n"
+            "jobs: {}\n"
+        )
+        self.assertEqual(csw.schedule_expressions(source), ("0 5 * * 1", "23 6 * * *"))
+
+    def test_the_real_tree_has_scheduled_workflows(self):
+        """Discovery over the actual repository, not a fixture.
+
+        `main` refuses an empty result, but only this proves the parser still
+        matches the workflows as they are really written.
+        """
+        root = os.environ.get("RUE_SCHEDULED_WORKFLOWS_ROOT")
+        directory = (
+            Path(root) / ".github/workflows" if root else csw.WORKFLOWS_DIR
+        )
+        found = csw.discover(directory)
+        self.assertGreaterEqual(len(found), 5, f"discovered only {found}")
+        for entry in found:
+            self.assertTrue(entry.crons, f"{entry.name} discovered with no cron")
+
+
+class NeverSucceededTests(unittest.TestCase):
+    def test_all_failures_is_a_failure(self):
+        finding = csw.classify(
+            workflow("w.yml"),
+            history(successful_runs=0, success_days_ago=None),
+            NOW,
+        )
+        self.assertTrue(finding.failed)
+        self.assertIn("never succeeded", finding.summary)
+
+    def test_one_red_run_after_a_recent_success_is_not_a_failure(self):
+        """Durable on purpose: an ordinary red night is not this gate's business."""
+        finding = csw.classify(workflow("w.yml"), history(success_days_ago=3.0), NOW)
+        self.assertFalse(finding.failed)
+
+
+class StalenessTests(unittest.TestCase):
+    def test_success_inside_the_budget_passes(self):
+        # Weekly, default 4 periods = 28 days.
+        finding = csw.classify(workflow("w.yml"), history(success_days_ago=27.0), NOW)
+        self.assertFalse(finding.failed)
+
+    def test_success_outside_the_budget_fails(self):
+        finding = csw.classify(workflow("w.yml"), history(success_days_ago=29.0), NOW)
+        self.assertTrue(finding.failed)
+        self.assertIn("budget", finding.summary)
+
+    def test_a_declared_policy_widens_the_budget(self):
+        """fuzz.yml's real shape: red by design, and reported by its own path."""
+        csw.POLICIES["stub-fuzz.yml"] = csw.Policy(stale_periods=30)
+        try:
+            entry = workflow("stub-fuzz.yml", cron=DAILY)
+            self.assertFalse(
+                csw.classify(entry, history(success_days_ago=14.0), NOW).failed
+            )
+            self.assertTrue(
+                csw.classify(entry, history(success_days_ago=31.0), NOW).failed
+            )
+        finally:
+            del csw.POLICIES["stub-fuzz.yml"]
+
+
+class DisabledAndUnregisteredTests(unittest.TestCase):
+    def test_disabled_workflow_fails_despite_a_green_history(self):
+        """The case run history cannot see: it stops producing runs, last one green."""
+        finding = csw.classify(
+            workflow("w.yml"),
+            history(state="disabled_inactivity", success_days_ago=0.5),
+            NOW,
+        )
+        self.assertTrue(finding.failed)
+        self.assertIn("disabled", finding.summary)
+
+    def test_unregistered_workflow_passes(self):
+        """A pull request that adds a scheduled workflow must not fail on it."""
+        self.assertFalse(csw.classify(workflow("new.yml"), None, NOW).failed)
+
+    def test_freshly_registered_workflow_passes_before_its_cron_fires(self):
+        finding = csw.classify(
+            workflow("new.yml"),
+            history(created_days_ago=3.0, scheduled_runs=0, successful_runs=0,
+                    success_days_ago=None),
+            NOW,
+        )
+        self.assertFalse(finding.failed)
+
+    def test_registered_long_ago_and_never_fired_fails(self):
+        finding = csw.classify(
+            workflow("w.yml"),
+            history(created_days_ago=60.0, scheduled_runs=0, successful_runs=0,
+                    success_days_ago=None),
+            NOW,
+        )
+        self.assertTrue(finding.failed)
+        self.assertIn("never run on its schedule", finding.summary)
+
+
+class WaiverTests(unittest.TestCase):
+    def test_waiver_suppresses_a_real_failure(self):
+        csw.POLICIES["stub.yml"] = csw.Policy(known_broken="RUE-1222")
+        try:
+            finding = csw.classify(
+                workflow("stub.yml"),
+                history(successful_runs=0, success_days_ago=None),
+                NOW,
+            )
+            self.assertFalse(finding.failed)
+            self.assertIn("RUE-1222", finding.summary)
+        finally:
+            del csw.POLICIES["stub.yml"]
+
+    def test_waiver_that_outlived_its_breakage_fails(self):
+        """Otherwise the exemption silently covers the *next* regression too."""
+        csw.POLICIES["stub.yml"] = csw.Policy(known_broken="RUE-1222")
+        try:
+            finding = csw.classify(
+                workflow("stub.yml"), history(success_days_ago=1.0), NOW
+            )
+            self.assertTrue(finding.failed)
+            self.assertIn("stale", finding.summary)
+        finally:
+            del csw.POLICIES["stub.yml"]
+
+    def test_declared_policies_name_real_workflows(self):
+        """A POLICIES key that matches nothing exempts nothing and hides its own rot."""
+        root = os.environ.get("RUE_SCHEDULED_WORKFLOWS_ROOT")
+        directory = Path(root) / ".github/workflows" if root else csw.WORKFLOWS_DIR
+        self.assertEqual(csw.orphaned_policies(csw.discover(directory)), [])
+
+    def test_an_orphaned_policy_is_reported(self):
+        csw.POLICIES["gone.yml"] = csw.Policy(known_broken="RUE-1")
+        try:
+            # Every real POLICIES key is absent from this one-element list too,
+            # so assert the entry under test is named rather than counting.
+            problems = csw.orphaned_policies([workflow("still-here.yml")])
+            self.assertTrue(any("gone.yml" in problem for problem in problems))
+        finally:
+            del csw.POLICIES["gone.yml"]
+        self.assertFalse(
+            any("gone.yml" in p for p in csw.orphaned_policies([workflow("x.yml")])),
+            "the orphan must disappear once the declaration is removed",
+        )
+
+
+class StructuralTests(unittest.TestCase):
+    def test_ci_timed_without_an_upload_is_a_finding(self):
+        entry = workflow(
+            "w.yml", source="run: scripts/ci-timed 'x' -- ./buck2 test //...\n"
+        )
+        problems = csw.structural_problems([entry])
+        self.assertEqual(len(problems), 1)
+        self.assertIn("rue-ci-failed-logs", problems[0])
+
+    def test_ci_timed_with_an_upload_is_clean(self):
+        entry = workflow(
+            "w.yml",
+            source=(
+                "run: scripts/ci-timed 'x' -- ./buck2 test //...\n"
+                "path: ${{ runner.temp }}/rue-ci-failed-logs\n"
+            ),
+        )
+        self.assertEqual(csw.structural_problems([entry]), [])
+
+    def test_a_workflow_that_never_uses_ci_timed_is_not_asked_for_the_artifact(self):
+        """An always-empty artifact that looks like coverage is the bug, not the fix."""
+        entry = workflow("w.yml", source="run: ./buck2 build //...\n")
+        self.assertEqual(csw.structural_problems([entry]), [])
+
+
+class ClientTests(unittest.TestCase):
+    """The API reading itself, against a mock, so the query shape stays pinned."""
+
+    class MockTransport(csw.Transport):
+        def __init__(self, responses: dict):
+            self.responses = responses
+            self.urls: list[str] = []
+
+        def get(self, url: str):
+            self.urls.append(url)
+            for needle, response in self.responses.items():
+                if needle in url:
+                    if isinstance(response, Exception):
+                        raise response
+                    return response
+            raise AssertionError(f"unexpected URL {url}")
+
+    def test_history_reads_state_counts_and_latest_success(self):
+        transport = self.MockTransport(
+            {
+                "status=success": {
+                    "total_count": 73,
+                    "workflow_runs": [{"created_at": "2026-08-14T02:14:05Z"}],
+                },
+                "runs?": {"total_count": 100, "workflow_runs": []},
+                "workflows/fuzz.yml": {
+                    "state": "active",
+                    "created_at": "2025-12-31T16:23:09.000-06:00",
+                },
+            }
+        )
+        result = csw.Client(transport, "rue-language/rue").history("fuzz.yml")
+        self.assertEqual(result.state, "active")
+        self.assertEqual(result.successful_runs, 73)
+        self.assertEqual(result.scheduled_runs, 100)
+        self.assertEqual(result.last_success.year, 2026)
+        # Every run query must be scoped to the schedule trigger: a workflow
+        # kept green by manual dispatch is exactly the false pass being hunted.
+        for url in transport.urls:
+            if "/runs?" in url:
+                self.assertIn("event=schedule", url)
+
+    def test_unregistered_workflow_surfaces_as_not_registered(self):
+        transport = self.MockTransport({"workflows/new.yml": csw.NotRegistered("u")})
+        with self.assertRaises(csw.NotRegistered):
+            csw.Client(transport, "r/r").history("new.yml")
+
+    def test_check_treats_not_registered_as_a_pass(self):
+        transport = self.MockTransport({"workflows/": csw.NotRegistered("u")})
+        report = csw.check(
+            [workflow("new.yml")], csw.Client(transport, "r/r"), now=NOW
+        )
+        # Scoped to the history verdict: `check` also runs the repository-wide
+        # policy audit, which is not meaningful against a one-element list.
+        self.assertEqual(len(report.findings), 1)
+        self.assertFalse(report.findings[0].failed)
+
+    def test_offset_timestamps_parse(self):
+        """GitHub answers with both `Z` and `-05:00`; 3.10 rejects the former raw."""
+        self.assertEqual(csw.parse_time("2026-08-14T02:14:05Z").hour, 2)
+        self.assertEqual(csw.parse_time("2025-12-31T16:23:09.000-06:00").day, 31)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test-check-scheduled-workflows.py
+++ b/scripts/test-check-scheduled-workflows.py
@@ -1,24 +1,27 @@
 #!/usr/bin/env python3
 """Pin the classification logic of scripts/check-scheduled-workflows.py.
 
-The gate this exercises blocks pull requests, so both of its ways of being
-wrong are expensive: a false red stops everyone's work, and a false green
-restores exactly the silence RUE-1507 was filed about. The cases below are
-chosen for those two edges rather than for coverage — what a workflow that has
-never succeeded does, what an ordinary red night does *not* do, and what
-happens when a waiver outlives the breakage it was written for.
+The gate under test runs on every pull request, so its two ways of being wrong
+are not symmetric. A false green restores the silence RUE-1507 was filed about.
+A false *red* blocks every merge in the repository — worse than the bug being
+fixed. The cases below are chosen around that asymmetry: what blocks, what
+merely warns, and above all what must never block.
 
 Run directly; no network and no credentials. The API is replaced at the
-`Transport` seam, so the client, the classifier, and the driver under test are
+`Transport` seam, and the transport's own error handling is driven through a
+fake `urlopen`, so the client, the classifier, and the driver under test are
 the same code CI runs.
 """
 
 from __future__ import annotations
 
 import importlib.util
+import io
 import os
 import sys
+import tempfile
 import unittest
+import urllib.error
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -38,6 +41,11 @@ DAILY = "0 6 * * *"
 WEEKLY = "17 7 * * 1"
 
 
+def workflows_dir() -> Path:
+    root = os.environ.get("RUE_SCHEDULED_WORKFLOWS_ROOT")
+    return Path(root) / ".github/workflows" if root else csw.WORKFLOWS_DIR
+
+
 def workflow(name: str, cron: str = WEEKLY, source: str = "") -> csw.Scheduled:
     return csw.Scheduled(name, Path(name), (cron,), source)
 
@@ -45,14 +53,12 @@ def workflow(name: str, cron: str = WEEKLY, source: str = "") -> csw.Scheduled:
 def history(
     *,
     state: str = "active",
-    created_days_ago: float = 90.0,
     scheduled_runs: int = 10,
     successful_runs: int = 10,
     success_days_ago: float | None = 1.0,
 ) -> csw.History:
     return csw.History(
         state=state,
-        created_at=NOW - timedelta(days=created_days_ago),
         scheduled_runs=scheduled_runs,
         successful_runs=successful_runs,
         last_success=(
@@ -61,16 +67,117 @@ def history(
     )
 
 
+class BlockingIsNarrowTests(unittest.TestCase):
+    """Exactly one condition may block a merge. These pin its edges."""
+
+    def test_never_succeeded_blocks(self):
+        finding = csw.classify(
+            workflow("w.yml"),
+            history(scheduled_runs=2, successful_runs=0, success_days_ago=None),
+            NOW,
+        )
+        self.assertEqual(finding.severity, csw.BLOCK)
+        self.assertIn("never succeeded", finding.summary)
+
+    def test_a_single_failed_run_only_warns(self):
+        """One red run is a red run; two-for-two is a workflow that never worked."""
+        finding = csw.classify(
+            workflow("w.yml"),
+            history(scheduled_runs=1, successful_runs=0, success_days_ago=None),
+            NOW,
+        )
+        self.assertEqual(finding.severity, csw.WARN)
+
+    def test_staleness_never_blocks(self):
+        """Heuristic. It may inform a human; it may not stop every merge."""
+        finding = csw.classify(
+            workflow("w.yml", cron=DAILY), history(success_days_ago=400.0), NOW
+        )
+        self.assertEqual(finding.severity, csw.WARN)
+
+    def test_disabled_never_blocks(self):
+        finding = csw.classify(
+            workflow("w.yml"), history(state="disabled_inactivity"), NOW
+        )
+        self.assertEqual(finding.severity, csw.WARN)
+
+    def test_never_fired_never_blocks(self):
+        """This is also how adding a schedule to an existing file looks."""
+        finding = csw.classify(
+            workflow("w.yml"),
+            history(scheduled_runs=0, successful_runs=0, success_days_ago=None),
+            NOW,
+        )
+        self.assertEqual(finding.severity, csw.WARN)
+
+    def test_unregistered_workflow_passes(self):
+        self.assertEqual(csw.classify(workflow("new.yml"), None, NOW).severity, csw.OK)
+
+
+class RegressionTests(unittest.TestCase):
+    """The specific false positives an adversarial review found. Each blocked
+    the whole repository on real history before these were fixed."""
+
+    def test_release_yml_august_cluster_does_not_block(self):
+        """Real timings: last success completed 07-31T08:45:04Z, next 08-04T08:47:20Z."""
+        last = datetime(2026, 7, 31, 8, 45, 4, tzinfo=timezone.utc)
+        now = datetime(2026, 8, 4, 8, 47, 20, tzinfo=timezone.utc)
+        entry = workflow("release.yml", cron=DAILY)
+        finding = csw.classify(
+            entry,
+            csw.History("active", 30, 12, last),
+            now,
+        )
+        self.assertNotEqual(finding.severity, csw.BLOCK)
+
+    def test_adding_a_schedule_to_an_existing_workflow_does_not_block(self):
+        """RUE-1488's actual change: a cron added to an already-registered file."""
+        finding = csw.classify(
+            workflow("performance-collect.yml", cron=DAILY),
+            history(scheduled_runs=0, successful_runs=0, success_days_ago=None),
+            NOW,
+        )
+        self.assertNotEqual(finding.severity, csw.BLOCK)
+
+    def test_fuzz_full_history_does_not_block(self):
+        """226 retained runs, 67.7% red, 75-day gaps between successes."""
+        finding = csw.classify(
+            workflow("fuzz.yml", cron="0 0 * * *"),
+            history(scheduled_runs=226, successful_runs=73, success_days_ago=75.0),
+            NOW,
+        )
+        self.assertEqual(finding.severity, csw.OK)
+        self.assertIn("staleness not assessed", finding.summary)
+
+    def test_waiver_expiry_does_not_block(self):
+        """When RUE-1222 lands, the green run must not stop every merge."""
+        finding = csw.classify(
+            workflow("correctness-repetitions.yml"), history(success_days_ago=1.0), NOW
+        )
+        self.assertEqual(finding.severity, csw.WARN)
+        self.assertIn("no longer needed", finding.summary)
+
+
 class CronPeriodTests(unittest.TestCase):
     def test_cadences_in_use(self):
         self.assertEqual(csw.cron_period_hours("0 0 * * *"), 24.0)
         self.assertEqual(csw.cron_period_hours("17 7 * * 1"), 168.0)
-        self.assertEqual(csw.cron_period_hours("*/6 * * * *"), 1.0)
         self.assertEqual(csw.cron_period_hours("0 */6 * * *"), 6.0)
 
+    def test_calendar_constraints_are_read_rarest_first(self):
+        """A month restriction fires yearly however permissive dow looks."""
+        self.assertEqual(csw.cron_period_hours("0 0 1 1 *"), 8760.0)
+        self.assertEqual(csw.cron_period_hours("0 0 1 */3 *"), 8760.0)
+        self.assertEqual(csw.cron_period_hours("0 0 1 * *"), 720.0)
+
     def test_unparseable_cron_widens_the_window(self):
-        """An expression we cannot read must make the gate quieter, not louder."""
-        self.assertEqual(csw.cron_period_hours("nonsense"), 168.0)
+        self.assertEqual(csw.cron_period_hours("nonsense"), 8760.0)
+
+    def test_subdaily_cron_gets_the_budget_floor(self):
+        """Four periods of a 15-minute cron is an hour; an outage is not death."""
+        entry = workflow("w.yml", cron="*/15 * * * *")
+        finding = csw.classify(entry, history(success_days_ago=2.0), NOW)
+        self.assertEqual(finding.severity, csw.OK)
 
 
 class DiscoveryTests(unittest.TestCase):
@@ -80,7 +187,6 @@ class DiscoveryTests(unittest.TestCase):
             "on:\n"
             "  workflow_dispatch:\n"
             "\n"
-            "# schedule: this is prose about scheduling\n"
             "jobs:\n"
             "  a:\n"
             "    steps:\n"
@@ -88,7 +194,11 @@ class DiscoveryTests(unittest.TestCase):
         )
         self.assertEqual(csw.schedule_expressions(source), ())
 
-    def test_cron_is_read_from_the_on_block(self):
+    def test_a_commented_out_cron_is_not_a_trigger(self):
+        source = "on:\n  schedule:\n    # - cron: '0 0 * * *'\n  push:\n\njobs: {}\n"
+        self.assertEqual(csw.schedule_expressions(source), ())
+
+    def test_block_style_with_comments_and_quotes(self):
         source = (
             "name: X\n"
             "on:\n"
@@ -97,151 +207,96 @@ class DiscoveryTests(unittest.TestCase):
             "  # a comment between triggers\n"
             "  schedule:\n"
             "    - cron: '0 5 * * 1'  # trailing comment\n"
-            "    - cron: \"23 6 * * *\"\n"
+            '    - cron: "23 6 * * *"\n'
             "  workflow_dispatch:\n"
-            "\n"
-            "jobs: {}\n"
+            "\njobs: {}\n"
         )
         self.assertEqual(csw.schedule_expressions(source), ("0 5 * * 1", "23 6 * * *"))
 
-    def test_the_real_tree_has_scheduled_workflows(self):
-        """Discovery over the actual repository, not a fixture.
+    def test_quoted_on_key_is_read(self):
+        """YAML 1.1 reads a bare `on` as boolean true, so some repos quote it."""
+        source = '"on":\n  schedule:\n    - cron: "0 0 * * *"\n\njobs: {}\n'
+        self.assertEqual(csw.schedule_expressions(source), ("0 0 * * *",))
 
-        `main` refuses an empty result, but only this proves the parser still
-        matches the workflows as they are really written.
-        """
-        root = os.environ.get("RUE_SCHEDULED_WORKFLOWS_ROOT")
-        directory = (
-            Path(root) / ".github/workflows" if root else csw.WORKFLOWS_DIR
-        )
-        found = csw.discover(directory)
-        self.assertGreaterEqual(len(found), 5, f"discovered only {found}")
-        for entry in found:
+    def test_trailing_comment_on_the_on_key(self):
+        source = "on:  # triggers\n  schedule:\n    - cron: '0 0 * * *'\n\njobs: {}\n"
+        self.assertEqual(csw.schedule_expressions(source), ("0 0 * * *",))
+
+    def test_flow_style_schedule_is_read(self):
+        source = "on:\n  schedule: [{cron: '0 3 * * *'}]\n\njobs: {}\n"
+        self.assertEqual(csw.schedule_expressions(source), ("0 3 * * *",))
+
+    def test_bare_unquoted_cron_is_read(self):
+        source = "on:\n  schedule:\n    - cron: 0 0 * * *\n\njobs: {}\n"
+        self.assertEqual(csw.schedule_expressions(source), ("0 0 * * *",))
+
+    def test_unreadable_schedule_is_warned_about_not_skipped(self):
+        """A workflow the parser cannot read must not vanish from the audit."""
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            (directory / "weird.yml").write_text(
+                "on:\n  schedule:\n    - cronx: '0 0 * * *'\n\njobs: {}\n"
+            )
+            (directory / "real.yml").write_text(
+                "on:\n  schedule:\n    - cron: '0 0 * * *'\n\njobs: {}\n"
+            )
+            result = csw.discover(directory)
+            self.assertEqual([w.name for w in result.scheduled], ["real.yml"])
+            self.assertTrue(any("weird.yml" in w for w in result.warnings))
+
+    def test_the_real_tree_has_scheduled_workflows(self):
+        result = csw.discover(workflows_dir())
+        self.assertGreaterEqual(len(result.scheduled), 5, f"got {result.scheduled}")
+        for entry in result.scheduled:
             self.assertTrue(entry.crons, f"{entry.name} discovered with no cron")
 
-
-class NeverSucceededTests(unittest.TestCase):
-    def test_all_failures_is_a_failure(self):
-        finding = csw.classify(
-            workflow("w.yml"),
-            history(successful_runs=0, success_days_ago=None),
-            NOW,
-        )
-        self.assertTrue(finding.failed)
-        self.assertIn("never succeeded", finding.summary)
-
-    def test_one_red_run_after_a_recent_success_is_not_a_failure(self):
-        """Durable on purpose: an ordinary red night is not this gate's business."""
-        finding = csw.classify(workflow("w.yml"), history(success_days_ago=3.0), NOW)
-        self.assertFalse(finding.failed)
-
-
-class StalenessTests(unittest.TestCase):
-    def test_success_inside_the_budget_passes(self):
-        # Weekly, default 4 periods = 28 days.
-        finding = csw.classify(workflow("w.yml"), history(success_days_ago=27.0), NOW)
-        self.assertFalse(finding.failed)
-
-    def test_success_outside_the_budget_fails(self):
-        finding = csw.classify(workflow("w.yml"), history(success_days_ago=29.0), NOW)
-        self.assertTrue(finding.failed)
-        self.assertIn("budget", finding.summary)
-
-    def test_a_declared_policy_widens_the_budget(self):
-        """fuzz.yml's real shape: red by design, and reported by its own path."""
-        csw.POLICIES["stub-fuzz.yml"] = csw.Policy(stale_periods=30)
-        try:
-            entry = workflow("stub-fuzz.yml", cron=DAILY)
-            self.assertFalse(
-                csw.classify(entry, history(success_days_ago=14.0), NOW).failed
-            )
-            self.assertTrue(
-                csw.classify(entry, history(success_days_ago=31.0), NOW).failed
-            )
-        finally:
-            del csw.POLICIES["stub-fuzz.yml"]
-
-
-class DisabledAndUnregisteredTests(unittest.TestCase):
-    def test_disabled_workflow_fails_despite_a_green_history(self):
-        """The case run history cannot see: it stops producing runs, last one green."""
-        finding = csw.classify(
-            workflow("w.yml"),
-            history(state="disabled_inactivity", success_days_ago=0.5),
-            NOW,
-        )
-        self.assertTrue(finding.failed)
-        self.assertIn("disabled", finding.summary)
-
-    def test_unregistered_workflow_passes(self):
-        """A pull request that adds a scheduled workflow must not fail on it."""
-        self.assertFalse(csw.classify(workflow("new.yml"), None, NOW).failed)
-
-    def test_freshly_registered_workflow_passes_before_its_cron_fires(self):
-        finding = csw.classify(
-            workflow("new.yml"),
-            history(created_days_ago=3.0, scheduled_runs=0, successful_runs=0,
-                    success_days_ago=None),
-            NOW,
-        )
-        self.assertFalse(finding.failed)
-
-    def test_registered_long_ago_and_never_fired_fails(self):
-        finding = csw.classify(
-            workflow("w.yml"),
-            history(created_days_ago=60.0, scheduled_runs=0, successful_runs=0,
-                    success_days_ago=None),
-            NOW,
-        )
-        self.assertTrue(finding.failed)
-        self.assertIn("never run on its schedule", finding.summary)
+    def test_the_real_tree_has_no_unreadable_triggers(self):
+        self.assertEqual(csw.discover(workflows_dir()).warnings, [])
 
 
 class WaiverTests(unittest.TestCase):
-    def test_waiver_suppresses_a_real_failure(self):
-        csw.POLICIES["stub.yml"] = csw.Policy(known_broken="RUE-1222")
+    def test_waiver_suppresses_a_blocking_verdict(self):
+        csw.POLICIES["stub.yml"] = csw.Policy(known_broken="RUE-1222", note="x")
         try:
             finding = csw.classify(
                 workflow("stub.yml"),
-                history(successful_runs=0, success_days_ago=None),
+                history(scheduled_runs=5, successful_runs=0, success_days_ago=None),
                 NOW,
             )
-            self.assertFalse(finding.failed)
+            self.assertEqual(finding.severity, csw.OK)
             self.assertIn("RUE-1222", finding.summary)
         finally:
             del csw.POLICIES["stub.yml"]
 
-    def test_waiver_that_outlived_its_breakage_fails(self):
-        """Otherwise the exemption silently covers the *next* regression too."""
-        csw.POLICIES["stub.yml"] = csw.Policy(known_broken="RUE-1222")
+    def test_a_malformed_issue_reference_is_a_problem(self):
+        csw.POLICIES["stub.yml"] = csw.Policy(known_broken="x", note="y")
         try:
-            finding = csw.classify(
-                workflow("stub.yml"), history(success_days_ago=1.0), NOW
-            )
-            self.assertTrue(finding.failed)
-            self.assertIn("stale", finding.summary)
+            problems = csw.policy_problems([workflow("stub.yml")])
+            self.assertTrue(any("not a RUE-NN issue" in p for p in problems))
         finally:
             del csw.POLICIES["stub.yml"]
 
-    def test_declared_policies_name_real_workflows(self):
-        """A POLICIES key that matches nothing exempts nothing and hides its own rot."""
-        root = os.environ.get("RUE_SCHEDULED_WORKFLOWS_ROOT")
-        directory = Path(root) / ".github/workflows" if root else csw.WORKFLOWS_DIR
-        self.assertEqual(csw.orphaned_policies(csw.discover(directory)), [])
+    def test_a_waiver_without_a_reason_is_a_problem(self):
+        csw.POLICIES["stub.yml"] = csw.Policy(known_broken="RUE-1", note="  ")
+        try:
+            problems = csw.policy_problems([workflow("stub.yml")])
+            self.assertTrue(any("no note" in p for p in problems))
+        finally:
+            del csw.POLICIES["stub.yml"]
 
     def test_an_orphaned_policy_is_reported(self):
-        csw.POLICIES["gone.yml"] = csw.Policy(known_broken="RUE-1")
+        csw.POLICIES["gone.yml"] = csw.Policy(known_broken="RUE-1", note="x")
         try:
-            # Every real POLICIES key is absent from this one-element list too,
-            # so assert the entry under test is named rather than counting.
-            problems = csw.orphaned_policies([workflow("still-here.yml")])
-            self.assertTrue(any("gone.yml" in problem for problem in problems))
+            problems = csw.policy_problems([workflow("still-here.yml")])
+            self.assertTrue(any("gone.yml" in p for p in problems))
         finally:
             del csw.POLICIES["gone.yml"]
         self.assertFalse(
-            any("gone.yml" in p for p in csw.orphaned_policies([workflow("x.yml")])),
-            "the orphan must disappear once the declaration is removed",
+            any("gone.yml" in p for p in csw.policy_problems([workflow("x.yml")]))
         )
+
+    def test_the_shipped_policies_are_well_formed(self):
+        self.assertEqual(csw.policy_problems(csw.discover(workflows_dir()).scheduled), [])
 
 
 class StructuralTests(unittest.TestCase):
@@ -251,85 +306,279 @@ class StructuralTests(unittest.TestCase):
         )
         problems = csw.structural_problems([entry])
         self.assertEqual(len(problems), 1)
-        self.assertIn("rue-ci-failed-logs", problems[0])
+        self.assertIn(csw.FAILURE_LOG_DIR, problems[0])
 
-    def test_ci_timed_with_an_upload_is_clean(self):
+    def test_ci_timed_with_a_failure_upload_is_clean(self):
         entry = workflow(
             "w.yml",
             source=(
                 "run: scripts/ci-timed 'x' -- ./buck2 test //...\n"
+                "if: failure()\n"
                 "path: ${{ runner.temp }}/rue-ci-failed-logs\n"
             ),
         )
         self.assertEqual(csw.structural_problems([entry]), [])
 
+    def test_a_comment_cannot_satisfy_the_artifact_rule(self):
+        """Prose mentioning the directory is the false-green shape being hunted."""
+        entry = workflow(
+            "w.yml",
+            source=(
+                "run: scripts/ci-timed 'x' -- ./buck2 test //...\n"
+                "# we should upload rue-ci-failed-logs on if: failure() someday\n"
+            ),
+        )
+        self.assertEqual(len(csw.structural_problems([entry])), 1)
+
     def test_a_workflow_that_never_uses_ci_timed_is_not_asked_for_the_artifact(self):
-        """An always-empty artifact that looks like coverage is the bug, not the fix."""
         entry = workflow("w.yml", source="run: ./buck2 build //...\n")
         self.assertEqual(csw.structural_problems([entry]), [])
 
+    def test_the_real_tree_is_structurally_clean(self):
+        self.assertEqual(
+            csw.structural_problems(csw.discover(workflows_dir()).scheduled), []
+        )
+
+
+class MockTransport(csw.Transport):
+    def __init__(self, responses: dict):
+        self.responses = responses
+        self.urls: list[str] = []
+
+    def get(self, url: str):
+        self.urls.append(url)
+        for needle, response in self.responses.items():
+            if needle in url:
+                if isinstance(response, Exception):
+                    raise response
+                return response
+        raise AssertionError(f"unexpected URL {url}")
+
+
+LISTING = {
+    "workflows": [
+        {"path": ".github/workflows/fuzz.yml", "state": "active"},
+        {"path": ".github/workflows/release.yml", "state": "disabled_inactivity"},
+    ]
+}
+
 
 class ClientTests(unittest.TestCase):
-    """The API reading itself, against a mock, so the query shape stays pinned."""
-
-    class MockTransport(csw.Transport):
-        def __init__(self, responses: dict):
-            self.responses = responses
-            self.urls: list[str] = []
-
-        def get(self, url: str):
-            self.urls.append(url)
-            for needle, response in self.responses.items():
-                if needle in url:
-                    if isinstance(response, Exception):
-                        raise response
-                    return response
-            raise AssertionError(f"unexpected URL {url}")
-
-    def test_history_reads_state_counts_and_latest_success(self):
-        transport = self.MockTransport(
+    def test_history_uses_completion_time_for_the_last_success(self):
+        """A run enters the success filter when it finishes, not when it starts."""
+        transport = MockTransport(
             {
+                "actions/workflows?": LISTING,
                 "status=success": {
-                    "total_count": 73,
-                    "workflow_runs": [{"created_at": "2026-08-14T02:14:05Z"}],
-                },
-                "runs?": {"total_count": 100, "workflow_runs": []},
-                "workflows/fuzz.yml": {
-                    "state": "active",
-                    "created_at": "2025-12-31T16:23:09.000-06:00",
+                    "total_count": 12,
+                    "workflow_runs": [
+                        {
+                            "created_at": "2026-08-04T08:23:04Z",
+                            "updated_at": "2026-08-04T08:47:20Z",
+                        }
+                    ],
                 },
             }
         )
-        result = csw.Client(transport, "rue-language/rue").history("fuzz.yml")
-        self.assertEqual(result.state, "active")
-        self.assertEqual(result.successful_runs, 73)
-        self.assertEqual(result.scheduled_runs, 100)
-        self.assertEqual(result.last_success.year, 2026)
-        # Every run query must be scoped to the schedule trigger: a workflow
-        # kept green by manual dispatch is exactly the false pass being hunted.
+        result = csw.Client(transport, "r/r").history("fuzz.yml")
+        self.assertEqual(result.last_success, csw.parse_time("2026-08-04T08:47:20Z"))
+
+    def test_run_queries_are_scoped_to_the_schedule_trigger(self):
+        """A workflow kept green by manual dispatch is the false pass being hunted."""
+        transport = MockTransport(
+            {"actions/workflows?": LISTING, "status=success": {"total_count": 5,
+             "workflow_runs": [{"updated_at": "2026-08-13T00:00:00Z"}]}}
+        )
+        csw.Client(transport, "r/r").history("fuzz.yml")
         for url in transport.urls:
             if "/runs?" in url:
                 self.assertIn("event=schedule", url)
 
-    def test_unregistered_workflow_surfaces_as_not_registered(self):
-        transport = self.MockTransport({"workflows/new.yml": csw.NotRegistered("u")})
-        with self.assertRaises(csw.NotRegistered):
-            csw.Client(transport, "r/r").history("new.yml")
+    def test_the_second_query_is_skipped_when_successes_exist(self):
+        """Budget matters: this runs on every PR against a shared token bucket."""
+        transport = MockTransport(
+            {"actions/workflows?": LISTING, "status=success": {"total_count": 5,
+             "workflow_runs": [{"updated_at": "2026-08-13T00:00:00Z"}]}}
+        )
+        csw.Client(transport, "r/r").history("fuzz.yml")
+        self.assertEqual(sum(1 for u in transport.urls if "/runs?" in u), 1)
 
-    def test_check_treats_not_registered_as_a_pass(self):
-        transport = self.MockTransport({"workflows/": csw.NotRegistered("u")})
+    def test_state_listing_is_fetched_once_for_all_workflows(self):
+        transport = MockTransport(
+            {"actions/workflows?": LISTING, "status=success": {"total_count": 1,
+             "workflow_runs": [{"updated_at": "2026-08-13T00:00:00Z"}]}}
+        )
+        client = csw.Client(transport, "r/r")
+        client.history("fuzz.yml")
+        client.history("release.yml")
+        self.assertEqual(sum(1 for u in transport.urls if "actions/workflows?" in u), 1)
+
+    def test_disabled_state_comes_from_the_listing(self):
+        transport = MockTransport(
+            {"actions/workflows?": LISTING, "status=success": {"total_count": 1,
+             "workflow_runs": [{"updated_at": "2026-08-13T00:00:00Z"}]}}
+        )
+        self.assertEqual(
+            csw.Client(transport, "r/r").history("release.yml").state,
+            "disabled_inactivity",
+        )
+
+    def test_a_workflow_absent_from_the_listing_is_not_registered(self):
+        transport = MockTransport({"actions/workflows?": LISTING})
+        with self.assertRaises(csw.NotRegistered):
+            csw.Client(transport, "r/r").history("brand-new.yml")
+
+    def test_a_truncated_success_payload_does_not_raise(self):
+        """A partial page must not become an AssertionError on every PR."""
+        transport = MockTransport(
+            {
+                "actions/workflows?": LISTING,
+                "status=success": {"total_count": 4, "workflow_runs": []},
+            }
+        )
+        result = csw.Client(transport, "r/r").history("fuzz.yml")
+        self.assertIsNone(result.last_success)
+        self.assertEqual(
+            csw.classify(workflow("fuzz.yml"), result, NOW).severity, csw.OK
+        )
+
+    def test_offset_timestamps_parse(self):
+        self.assertEqual(csw.parse_time("2026-08-14T02:14:05Z").hour, 2)
+        self.assertEqual(csw.parse_time("2025-12-31T16:23:09.000-06:00").day, 31)
+
+
+class FailOpenTests(unittest.TestCase):
+    """Nothing about the API's availability may block a merge."""
+
+    def test_a_failing_history_query_warns_and_passes(self):
+        transport = MockTransport(
+            {"actions/workflows?": LISTING,
+             "status=success": csw.TransportError("HTTP 403")}
+        )
         report = csw.check(
-            [workflow("new.yml")], csw.Client(transport, "r/r"), now=NOW
+            [workflow("fuzz.yml")], csw.Client(transport, "r/r"), now=NOW
         )
         # Scoped to the history verdict: `check` also runs the repository-wide
         # policy audit, which is not meaningful against a one-element list.
-        self.assertEqual(len(report.findings), 1)
-        self.assertFalse(report.findings[0].failed)
+        self.assertFalse(any(f.blocks for f in report.findings))
+        self.assertTrue(any("unavailable" in w for w in report.warnings))
 
-    def test_offset_timestamps_parse(self):
-        """GitHub answers with both `Z` and `-05:00`; 3.10 rejects the former raw."""
-        self.assertEqual(csw.parse_time("2026-08-14T02:14:05Z").hour, 2)
-        self.assertEqual(csw.parse_time("2025-12-31T16:23:09.000-06:00").day, 31)
+    def test_an_unclassifiable_workflow_warns_and_passes(self):
+        class Boom(csw.Client):
+            def history(self, name):
+                return "not a History"
+
+        report = csw.check([workflow("w.yml")], Boom(MockTransport({}), "r/r"), now=NOW)
+        self.assertFalse(any(f.blocks for f in report.findings))
+        self.assertTrue(any("could not be classified" in w for w in report.warnings))
+
+    def test_a_failing_listing_is_requested_once_not_once_per_workflow(self):
+        """An outage must not multiply into one retry storm per workflow."""
+        transport = MockTransport({"actions/workflows?": csw.TransportError("HTTP 500")})
+        client = csw.Client(transport, "r/r")
+        report = csw.check(
+            [workflow("a.yml"), workflow("b.yml"), workflow("c.yml")], client, now=NOW
+        )
+        self.assertFalse(any(f.blocks for f in report.findings))
+        self.assertEqual(len(transport.urls), 1)
+        self.assertEqual(len(report.warnings), 3)
+
+    def test_main_exits_zero_when_the_api_is_unreachable(self):
+        """End to end through `main`, with the network guaranteed to fail."""
+        argv = ["--repo", "r/r", "--workflows", str(workflows_dir())]
+
+        def opener(*a, **k):
+            raise urllib.error.URLError("no network")
+
+        real = csw.urllib.request.urlopen
+        csw.urllib.request.urlopen = opener
+        try:
+            self.assertEqual(csw.main(argv), 0)
+        finally:
+            csw.urllib.request.urlopen = real
+
+
+class UrllibTransportTests(unittest.TestCase):
+    """The real transport's error handling, which is where fail-open lives."""
+
+    def _transport(self, opener, **kwargs):
+        transport = csw.UrllibTransport(token="t", sleep=lambda _: None, **kwargs)
+        csw.urllib.request.urlopen = opener
+        return transport
+
+    def setUp(self):
+        self._real = csw.urllib.request.urlopen
+
+    def tearDown(self):
+        csw.urllib.request.urlopen = self._real
+
+    @staticmethod
+    def _http_error(code, headers=None):
+        return urllib.error.HTTPError(
+            "u", code, "err", headers or {}, io.BytesIO(b"body")
+        )
+
+    def test_404_becomes_not_registered(self):
+        transport = self._transport(lambda *a, **k: (_ for _ in ()).throw(
+            self._http_error(404)))
+        with self.assertRaises(csw.NotRegistered):
+            transport.get("https://x/y")
+
+    def test_403_is_not_retried(self):
+        calls = []
+
+        def opener(*a, **k):
+            calls.append(1)
+            raise self._http_error(403)
+
+        transport = self._transport(opener)
+        with self.assertRaises(csw.TransportError):
+            transport.get("https://x/y")
+        self.assertEqual(len(calls), 1)
+
+    def test_429_is_retried_then_surfaces(self):
+        calls = []
+
+        def opener(*a, **k):
+            calls.append(1)
+            raise self._http_error(429, {"Retry-After": "0"})
+
+        transport = self._transport(opener, attempts=3)
+        with self.assertRaises(csw.TransportError):
+            transport.get("https://x/y")
+        self.assertEqual(len(calls), 3)
+
+    def test_500_retry_can_succeed(self):
+        calls = []
+
+        class Response(io.BytesIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        def opener(*a, **k):
+            calls.append(1)
+            if len(calls) == 1:
+                raise self._http_error(500)
+            return Response(b'{"total_count": 1}')
+
+        transport = self._transport(opener, attempts=3)
+        self.assertEqual(transport.get("https://x/y"), {"total_count": 1})
+        self.assertEqual(len(calls), 2)
+
+    def test_non_json_body_is_a_transport_error(self):
+        class Response(io.BytesIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        transport = self._transport(lambda *a, **k: Response(b"<html>"))
+        with self.assertRaises(csw.TransportError):
+            transport.get("https://x/y")
 
 
 if __name__ == "__main__":

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -251,6 +251,22 @@ def validate(
         errors.append("ci-contract no longer runs the structural validator")
     if "scripts/validate-tier-ci-selectors.py" not in contract:
         errors.append("ci-contract no longer proves every test tier is CI-selected")
+    # RUE-1507: the scheduled-workflow health check is the only thing that reads
+    # unattended run history on a path a human actually looks at. Dropping the
+    # step would restore the original silence without changing a single
+    # scheduled workflow, so its presence is part of the CI contract. The
+    # `actions: read` scope is pinned with it: without that, the step fails
+    # closed on every run rather than reporting.
+    if "scripts/check-scheduled-workflows.py" not in contract:
+        errors.append(
+            "ci-contract no longer checks that scheduled workflows still succeed; "
+            "without it a weekly safeguard can fail every run unnoticed (RUE-1507)"
+        )
+    elif "actions: read" not in contract:
+        errors.append(
+            "ci-contract runs the scheduled-workflow check without `actions: read`; "
+            "the run-history query needs that scope"
+        )
 
     remote = jobs.get("remote-execution", "")
     if "    if: github.event_name == 'merge_group'\n" not in remote:

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -262,7 +262,15 @@ def validate(
             "ci-contract no longer checks that scheduled workflows still succeed; "
             "without it a weekly safeguard can fail every run unnoticed (RUE-1507)"
         )
-    elif "actions: read" not in contract:
+    elif not any(
+        line.strip() == "actions: read"
+        for line in contract.splitlines()
+        if not line.lstrip().startswith("#")
+    ):
+        # Matched as an executable line, not a substring: the comment above the
+        # permissions block explains the scope and so contains its own name.
+        # A substring test would be satisfied by that prose alone, leaving the
+        # scope deletable and the next run dead on an opaque 403.
         errors.append(
             "ci-contract runs the scheduled-workflow check without `actions: read`; "
             "the run-history query needs that scope"


### PR DESCRIPTION
`correctness-repetitions.yml` failed every scheduled run it ever had, for eleven days, and nothing surfaced it. An agent restructuring that workflow's YAML never noticed it had never worked. That matters now because RUE-1222 makes it the home of the ADR-0070/RUE-1118 undeclared-input safeguard — and a safeguard that fails silently is worth less than none, because it is believed.

## The audit

Enumerated from the tree, which turned up `cache-probe.yml` (the Actions API also still lists a `test-runner.yml` that no longer exists — evidence for tree-based discovery over the API's inventory).

| Workflow | Scheduled runs | Verdict |
| --- | --- | --- |
| `correctness-repetitions.yml` | 2 | **never succeeded** |
| `fuzz.yml` | 226 | 67.7% red — **by design**, it goes red on any crash found |
| `release.yml` | 21 | 12 pass / 9 fail, self-resolved, nobody alerted |
| `cache-probe.yml`, `performance-*` | 1–2 each | green |

Nothing else is silently broken.

## The check

`scripts/check-scheduled-workflows.py`, run in `CI contract` on every pull request — deliberately not on a cron, because an unattended signal inherits the exact bug being fixed. Required CI is the one signal that provably reaches a human, and this needs no new secret and no new service.

**Exactly one condition fails the build: a workflow that has run on its schedule at least twice and has never once succeeded.** That is the durable signal — it cannot be produced by flakiness, jitter, or an unlucky week. Everything else warns and exits 0.

That posture is deliberate, and it is what the first draft of this change got wrong. A heuristic health check that fails closed blocks *every PR in the repository* on a false positive, which is worse than the bug it fixes. Concretely, the first draft would have:

- blocked the queue for 11 minutes on 2026-08-04, because `release.yml` had three ordinary red nights and success was read from run creation rather than completion;
- blocked RUE-1488, which added a `cron:` to an already-registered workflow file;
- blocked every PR on any 403, 429, or 500 from the Actions API, with no retry — 21 calls per run against a 1,000/hr shared quota.

Now: staleness warns, unreadable triggers warn, transport errors warn per workflow, and any classification exception warns. Transient statuses retry with backoff honoring `Retry-After`. A failed listing is cached as failed rather than re-requested per workflow, which turned one outage into seven retry storms. Requests dropped from 21 to 9.

`fuzz.yml`'s staleness is **not assessed** rather than given a generous threshold: its full history shows a 75-day gap between successes and a 74-run failing streak, so no window distinguishes a working fuzzer from a dead one. The output says so instead of implying a check ran.

`correctness-repetitions.yml` carries a waiver naming RUE-1222. Waivers must match `RUE-\d+` and carry a non-empty note.

## How it proves it still works

Runs on every PR, so a break is immediately visible. `validate-ci-gate.py` pins both the step and its `actions: read` scope, matching executable lines with comments stripped — the first draft's pin was satisfied by the prose comment above the permissions block, so the scope could be dropped silently. Discovery refuses an empty result. A workflow whose triggers cannot be parsed is warned about, not skipped. 51 tests, including the transport layer that findings in the first draft lived in.

`release.yml` gains failure-log artifacts, applied only to workflows that run through `scripts/ci-timed` — elsewhere the artifact would always be empty, which is this same bug one level down.

## Flagged, not fixed

`release.yml` sets `cancel-in-progress: true`, so a `workflow_dispatch` cancels an in-flight scheduled run; the cancelled run uploads no artifact and counts toward total runs but not successes. The narrow fix is `cancel-in-progress: ${{ github.event_name != 'schedule' }}`, but that changes release scheduling semantics beyond this issue.

Closes RUE-1507.