### PR TITLE
RUE-1509: name the Python floor instead of dying on tomllib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,22 @@ jobs:
       - name: Check shell Bash 3.2 baseline
         run: scripts/validate-shell-bash-baseline.py
 
+      # The same failure in the other language: `tomllib` is stdlib only from
+      # 3.11, so //:cli-timeout-policy-validation was green on these runners
+      # (3.12 here, 3.14 on macos-15) and dead on any developer host with an
+      # older interpreter (RUE-1509). This runner cannot reproduce that, so the
+      # check is static: nothing above the documented floor, a version guard on
+      # everything between a stock host's 3.9 and the floor, and AGENTS.md's
+      # stated floor matching the gate's.
+      #
+      # This step is the AUTHORITATIVE run, not a duplicate of the premerge
+      # target. A static scan is only as strict as the interpreter performing
+      # it: a host below the floor cannot tell syntax above the floor from
+      # syntax the floor allows, so it reports such a file as unscanned. This
+      # runner's 3.12.3 is above the floor, so nothing is left unjudged here.
+      - name: Check Python interpreter baseline
+        run: scripts/validate-python-baseline.py
+
       - name: Validate Buck test-tier ownership
         run: ./buck2 bxl //test_tiers.bxl:validate
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,41 @@ Rue uses Buck2 through the repository's `./buck2` wrapper, not Cargo:
 ./buck2 run //crates/rue:rue -- --emit <stage> src.rue
 ```
 
+## Repository tooling baseline
+
+The repository's Python tooling requires Python 3.11 or newer. Two files
+actually need that today: `scripts/cli-timeout-policy.py` and its tests read
+the CLI execution contracts with `tomllib`, stdlib only from 3.11. Every other
+Python file in the tree runs on 3.9, and the gate below depends on that — 3.9
+is the version it treats as one a file must either run on or explain itself to.
+
+A stock Mac is below the floor: macOS ships `/usr/bin/python3` as 3.9.6 and no
+newer interpreter. CI cannot see that gap, because its runners are comfortably
+above the floor — `ubuntu-latest` and `ubuntu-24.04-arm` provide 3.12.3,
+`macos-15` provides 3.14.6. So a premerge-tier target that needs 3.11 stays
+green in CI and fails on a developer machine, which is what
+`//:cli-timeout-policy-validation` did (RUE-1509). Install a 3.11+ interpreter
+and put it earlier on `PATH`.
+
+This floor governs the interpreter that runs repository tooling. It is not the
+Python number in `docs/process/build-cache.md`, which records what the pinned
+remote worker image ships for the Buck prelude's rustc wrapper — a different
+interpreter running different code. The remote-execution canary builds; it does
+not run these tests.
+
+A script that needs a construct newer than 3.9 must announce it rather than
+crash on it: guard the first use with `if sys.version_info < (3, 11): raise
+SystemExit(...)`, name the version in the message, and put the `raise`
+unconditionally in that `if`'s own body. An import inside `try:` with an
+`except ImportError` handler has already handled the failure and needs no
+guard. `scripts/validate-python-baseline.py` checks what a static scan can: a
+curated table of version-gated imports, stdlib attributes, builtins, keyword
+arguments and grammar, the presence and shape of those guards, and this
+section's stated floor against the gate's own constant. It is a curated table
+rather than a proof — its docstring lists what it cannot see, including grammar
+with no distinct AST node and every method call. Annotate a reviewed exception
+with `# python-baseline-ok: <reason>`.
+
 ## Compiler architecture
 
 The canonical flow is:

--- a/BUCK
+++ b/BUCK
@@ -862,6 +862,27 @@ rue_sh_test(
     },
 )
 
+# The interpreter-floor gate (RUE-1509). Unlike the Bash baseline's tests, these
+# need no particular interpreter to be INSTALLED to mean something, so premerge
+# is enough. They are not thereby host-independent, and the fixtures are written
+# to keep the difference small and asserted rather than assumed: every fixture is
+# 3.9 syntax, so the scan itself answers identically everywhere, and the two
+# cases that cannot -- what a parse error means, and what the shipped tool does
+# when run -- assert on both sides of the floor. The scan proper is only as
+# strict as the interpreter running it, which is why the authoritative run is
+# ci.yml's `fmt` step, at or above the floor.
+rue_sh_test(
+    name = "python-baseline-tool-tests",
+    test = "scripts/test-validate-python-baseline.py",
+    resources = [
+        "scripts/cli-timeout-policy.py",
+        "scripts/validate-python-baseline.py",
+    ],
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+    },
+)
+
 rue_sh_test(
     name = "release-configuration-tool-tests",
     test = "scripts/test-release-configuration.py",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,13 @@ just forwards to `./buck2 build //crates/rue:rue`, so you can drive Buck2
 directly if you prefer. macOS also requires Xcode Command Line Tools for linking
 Rue executables.
 
+The repository's own tooling is not hermetic: its gates and test runners are
+Python scripts that use whichever `python3` your `PATH` resolves, and a few of
+them require Python 3.11 or newer. macOS ships `/usr/bin/python3` as 3.9.6, so
+on a stock Mac `scripts/rue premerge` will report that a target needs a newer
+interpreter until you install one and put it earlier on `PATH`. See AGENTS.md,
+"Repository tooling baseline".
+
 On development machines with several Rue worktrees, unfiltered full suites are
 serialized automatically to avoid oversubscribing the host. Quick and filtered
 checks remain concurrent. Maintainers can opt into the shared action cache as

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -154,7 +154,14 @@ they're recorded here so a future config change doesn't silently regress:
 5. **Container** (`platforms/remote_cache.bzl`): pinned to `rbe-ubuntu22-04`
    (Python 3.10 — the prelude's rustc wrapper needs ≥3.9; the default image ships
    3.6), by immutable digest rather than by its moving tag. See
-   "Updating the remote worker image" below.
+   "Updating the remote worker image" below. This number is the worker image's,
+   for that wrapper, and is not the repository's Python floor — that is 3.11,
+   in AGENTS.md under "Repository tooling baseline". The two are independent:
+   the worker runs Buck actions, and the `remote execution (linux-x64)` job
+   builds rather than tests, so repository `scripts/*.py` do not execute there.
+   The worker image *is* below the repository floor, so an explicit
+   `--prefer-remote` **test** run of the two targets that need `tomllib` would
+   meet their version guard on the worker.
 6. **Linker** (RUE-320): the remote worker needs **`cc`** instead of the absent
    `clang++`. A `remote-execution` constraint is inserted only into the explicit
    full-remote execution configuration. The cache-only configuration omits it

--- a/scripts/cli-timeout-policy.py
+++ b/scripts/cli-timeout-policy.py
@@ -14,8 +14,24 @@ import math
 import platform
 import re
 import sys
-import tomllib
 from pathlib import Path
+
+# RUE-1509: `tomllib` is stdlib only from 3.11, and this target carries
+# `rue_test_tier_premerge`, so below the floor the premerge suite died with
+# `ModuleNotFoundError: No module named 'tomllib'` out of a timeout validator --
+# a message naming neither the version nor the remedy. CI never saw it: its
+# runners are 3.12 and newer. The repository floor is 3.11 for this import and
+# nothing else; see AGENTS.md, "Repository tooling baseline".
+if sys.version_info < (3, 11):
+    raise SystemExit(
+        "error: scripts/cli-timeout-policy.py requires Python 3.11 or newer "
+        f"(this interpreter is {platform.python_version()} at {sys.executable}). "
+        "It reads the CLI execution contracts with the stdlib `tomllib` module, "
+        "added in 3.11. Install a 3.11+ interpreter and put it earlier on PATH; "
+        "see AGENTS.md, \"Repository tooling baseline\"."
+    )
+
+import tomllib
 
 PROFILE_NAMES = ("ordinary", "slow", "stress")
 PROFILE_KEYS = {"compile_hang_timeout_ms", "runtime_hang_timeout_ms"}

--- a/scripts/test-cli-timeout-policy.py
+++ b/scripts/test-cli-timeout-policy.py
@@ -2,10 +2,25 @@
 import importlib.util
 import json
 import os
+import platform
+import sys
 import tempfile
-import tomllib
 import unittest
 from pathlib import Path
+
+# RUE-1509: the same floor the tool under test carries, stated here too because
+# this file reads the case TOML itself. See AGENTS.md, "Repository tooling
+# baseline".
+if sys.version_info < (3, 11):
+    raise SystemExit(
+        "error: scripts/test-cli-timeout-policy.py requires Python 3.11 or "
+        f"newer (this interpreter is {platform.python_version()} at "
+        f"{sys.executable}). It reads the CLI case TOML with the stdlib "
+        "`tomllib` module, added in 3.11. Install a 3.11+ interpreter and put "
+        "it earlier on PATH; see AGENTS.md, \"Repository tooling baseline\"."
+    )
+
+import tomllib
 
 SCRIPT = Path(__file__).with_name("cli-timeout-policy.py")
 SPEC = importlib.util.spec_from_file_location("cli_timeout_policy", SCRIPT)

--- a/scripts/test-validate-python-baseline.py
+++ b/scripts/test-validate-python-baseline.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""Focused tests for the Python interpreter-floor policy.
+
+Every fixture here is 3.9 syntax, so the scan means the same thing on every
+interpreter that can run this file. That is deliberate: the one part of the
+policy that is NOT host-independent -- what happens to a file the scanner
+cannot parse -- is asserted on both sides of the floor instead of assumed away.
+
+What needed the most care is that these fail when the thing they describe
+breaks. Asserting the tree is clean passes just as well when the gate has
+stopped looking, so the shipped guard is tested by deleting it from a copy of
+the real file and requiring the finding to come back.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("validate-python-baseline.py")
+SPEC = importlib.util.spec_from_file_location("python_baseline", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+policy = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(policy)
+
+TOOL = Path(__file__).with_name("cli-timeout-policy.py")
+
+GUARD = textwrap.dedent(
+    """
+    import sys
+
+    if sys.version_info < (3, 11):
+        raise SystemExit("needs Python 3.11 or newer")
+    """
+)
+
+
+def descriptions(source: str) -> list[str]:
+    findings, _ = policy.scan(source, "probe.py")
+    return [finding.construct.description for finding in findings]
+
+
+def repository_root() -> Path | None:
+    """The checkout, or None when this runs from a Buck sandbox.
+
+    Under Buck the target materializes only its declared inputs, so a
+    whole-tree scan would find nothing and pass vacuously -- the exact
+    fail-open this policy exists to prevent. The authoritative scan is the
+    `fmt` job's CI step.
+    """
+    root = SCRIPT.resolve().parent.parent
+    return root if (root / "AGENTS.md").exists() else None
+
+
+class ScanTests(unittest.TestCase):
+    def test_flags_the_import_that_caused_rue_1509(self) -> None:
+        self.assertEqual(descriptions("import tomllib\n"), ["the `tomllib` module"])
+
+    def test_a_guard_above_the_import_settles_it(self) -> None:
+        self.assertEqual(descriptions(GUARD + "import tomllib\n"), [])
+
+    def test_a_guard_below_the_import_does_not(self) -> None:
+        # The program has already died by then, so ordering is the whole point.
+        self.assertEqual(
+            descriptions("import tomllib\n" + GUARD), ["the `tomllib` module"]
+        )
+
+    def test_a_raise_in_the_else_branch_is_not_a_guard(self) -> None:
+        # This one runs the import on 3.10 and reproduces RUE-1509 verbatim, so
+        # accepting it would certify the bug the gate exists to prevent.
+        inverted = (
+            "import sys\n\n"
+            "if sys.version_info < (3, 11):\n"
+            "    pass\n"
+            "else:\n"
+            '    raise SystemExit("needs Python 3.11 or newer")\n'
+        )
+        self.assertEqual(
+            descriptions(inverted + "import tomllib\n"), ["the `tomllib` module"]
+        )
+
+    def test_a_conditional_raise_is_not_a_guard(self) -> None:
+        # Reachability is the claim; a raise under another condition does not
+        # make it.
+        nested = (
+            "import sys\n\n"
+            "if sys.version_info < (3, 11):\n"
+            "    if False:\n"
+            '        raise SystemExit("needs Python 3.11 or newer")\n'
+        )
+        self.assertEqual(
+            descriptions(nested + "import tomllib\n"), ["the `tomllib` module"]
+        )
+
+    def test_a_guard_that_does_not_name_the_version_does_not_count(self) -> None:
+        silent = (
+            "import sys\n\n"
+            "if sys.version_info < (3, 11):\n"
+            '    raise SystemExit("unsupported")\n'
+        )
+        self.assertEqual(
+            descriptions(silent + "import tomllib\n"), ["the `tomllib` module"]
+        )
+
+    def test_a_version_named_outside_the_raise_does_not_count(self) -> None:
+        # The message the user sees is the one in the raise, not a nearby
+        # string that happens to contain the number.
+        decoy = (
+            "import sys\n\n"
+            "if sys.version_info < (3, 11):\n"
+            '    note = "3.11"\n'
+            '    raise SystemExit("unsupported")\n'
+        )
+        self.assertEqual(
+            descriptions(decoy + "import tomllib\n"), ["the `tomllib` module"]
+        )
+
+    def test_a_guard_that_does_not_exit_does_not_count(self) -> None:
+        warning = (
+            "import sys\n\n"
+            "if sys.version_info < (3, 11):\n"
+            '    print("needs Python 3.11 or newer")\n'
+        )
+        self.assertEqual(
+            descriptions(warning + "import tomllib\n"), ["the `tomllib` module"]
+        )
+
+    def test_a_guard_demanding_too_little_does_not_count(self) -> None:
+        weak = (
+            "import sys\n\n"
+            "if sys.version_info < (3, 10):\n"
+            '    raise SystemExit("needs Python 3.10 or newer")\n'
+        )
+        self.assertEqual(
+            descriptions(weak + "import tomllib\n"), ["the `tomllib` module"]
+        )
+
+    def test_subscripted_version_info_is_the_same_guard(self) -> None:
+        subscripted = (
+            "import sys\n\n"
+            "if sys.version_info[:2] < (3, 11):\n"
+            '    raise SystemExit("needs Python 3.11 or newer")\n'
+        )
+        self.assertEqual(descriptions(subscripted + "import tomllib\n"), [])
+
+    def test_a_handled_import_needs_no_guard(self) -> None:
+        # The vendored-backport idiom. The objection to a bare `import tomllib`
+        # is that it fails unhandled; this one does not, so the rule does not
+        # apply -- and it must not, or the gate would reject the fallback on the
+        # day someone adopts it.
+        for handler in ("ModuleNotFoundError", "ImportError", ""):
+            source = (
+                "try:\n"
+                "    import tomllib\n"
+                f"except {handler}:\n".replace("except :", "except:")
+                + "    import tomli as tomllib\n"
+            )
+            self.assertEqual(descriptions(source), [], handler)
+
+    def test_a_try_that_catches_something_else_is_not_a_handled_import(self) -> None:
+        source = (
+            "try:\n"
+            "    import tomllib\n"
+            "except ValueError:\n"
+            "    tomllib = None\n"
+        )
+        self.assertEqual(descriptions(source), ["the `tomllib` module"])
+
+    def test_constructs_at_or_below_the_stock_host_are_silent(self) -> None:
+        for source in ("import graphlib\n", "import zoneinfo\n", "import json\n"):
+            self.assertEqual(descriptions(source), [], source)
+
+    def test_flags_the_apis_between_the_stock_host_and_the_floor(self) -> None:
+        cases = {
+            "from datetime import UTC\n": "`datetime.UTC`",
+            "from typing import Self\n": "`typing.Self`",
+            "from enum import StrEnum\n": "`enum.StrEnum`",
+            "import itertools\nitertools.pairwise([])\n": "`itertools.pairwise`",
+            "import hashlib\nhashlib.file_digest(f, 'sha256')\n": "`hashlib.file_digest`",
+            "zip(a, b, strict=True)\n": "the `zip(strict=...)` argument",
+            "raise ExceptionGroup('x', [])\n": "the `ExceptionGroup` builtin",
+        }
+        for source, description in cases.items():
+            self.assertIn(description, descriptions(source), source)
+
+    def test_a_method_named_zip_is_not_the_builtin(self) -> None:
+        # `zip` must be a bare name; anything.zip(...) is somebody else's API.
+        self.assertEqual(descriptions("archive.zip(a, strict=True)\n"), [])
+        # `dataclass` is as legitimate spelled through its module, so that one
+        # is still found.
+        self.assertIn(
+            "the `dataclass(slots=...)` argument",
+            descriptions("import dataclasses\n@dataclasses.dataclass(slots=True)\nclass C: pass\n"),
+        )
+
+    def test_above_the_floor_is_a_finding_a_guard_cannot_answer(self) -> None:
+        findings, _ = policy.scan("import itertools\nitertools.batched([], 1)\n", "p.py")
+        self.assertEqual(len(findings), 1)
+        self.assertTrue(findings[0].above_floor)
+        self.assertIn("above the repository floor", str(findings[0]))
+        self.assertNotIn("sys.version_info", str(findings[0]))
+        guarded, _ = policy.scan(
+            GUARD + "import itertools\nitertools.batched([], 1)\n", "p.py"
+        )
+        self.assertEqual(len(guarded), 1)
+
+    def test_an_alias_does_not_hide_the_construct(self) -> None:
+        self.assertIn(
+            "`itertools.batched`",
+            descriptions("import itertools as it\nit.batched([], 1)\n"),
+        )
+
+    def test_an_unrelated_attribute_of_the_same_name_is_not_a_finding(self) -> None:
+        self.assertEqual(descriptions("import shutil\nshutil.batched\n"), [])
+
+    def test_the_annotation_silences_its_line(self) -> None:
+        self.assertEqual(
+            descriptions("import tomllib  # python-baseline-ok: reviewed\n"), []
+        )
+
+    def test_the_annotation_has_to_be_a_comment(self) -> None:
+        self.assertEqual(
+            descriptions('QUOTED = "# python-baseline-ok: no"\nimport tomllib\n'),
+            ["the `tomllib` module"],
+        )
+
+
+class UnparseableTests(unittest.TestCase):
+    """The one host-dependent behaviour, asserted on whichever side we are on.
+
+    Below the floor a parse error is ambiguous -- `match` needs 3.10, which the
+    floor allows -- so guessing would produce a finding wrong about the version,
+    wrong about the floor, and backwards about the fix. At or above the floor it
+    is unambiguous. Both branches assert, so neither can quietly become a no-op.
+    """
+
+    def test_a_parse_error_is_judged_only_from_at_or_above_the_floor(self) -> None:
+        findings, unscanned = policy.scan("def f(:\n", "p.py")
+        if policy.SCANNER < policy.FLOOR:
+            self.assertEqual(findings, [])
+            self.assertEqual(len(unscanned), 1)
+            self.assertIn("not scanned", str(unscanned[0]))
+            self.assertIn("authoritative", str(unscanned[0]))
+        else:
+            self.assertEqual(unscanned, [])
+            self.assertEqual(len(findings), 1)
+            self.assertTrue(findings[0].above_floor)
+
+    def test_a_guarded_construct_above_this_host_is_never_a_false_finding(self) -> None:
+        # A correctly guarded `match` is legal at the floor. On 3.9 it does not
+        # parse; the answer must be silence plus a note, never a finding that
+        # tells the author to remove something the floor allows.
+        source = (
+            "import sys\n\n"
+            "if sys.version_info < (3, 10):\n"
+            '    raise SystemExit("needs Python 3.10 or newer")\n\n'
+            "def f(x):\n"
+            "    match x:\n"
+            "        case 1:\n"
+            "            return 2\n"
+            "    return 0\n"
+        )
+        findings, unscanned = policy.scan(source, "p.py")
+        self.assertEqual([str(finding) for finding in findings], [])
+        if policy.SCANNER < (3, 10):
+            self.assertEqual(len(unscanned), 1)
+        else:
+            self.assertEqual(unscanned, [])
+
+
+class DiscoveryTests(unittest.TestCase):
+    def discover(self, files: dict[str, str]) -> list[str]:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            for relative, body in files.items():
+                path = root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(body, encoding="utf-8")
+            return [
+                path.relative_to(root).as_posix() for path in policy.sources(root)
+            ]
+
+    def test_an_extensionless_python_program_is_scanned(self) -> None:
+        # scripts/ci-test-failure-report is exactly this, and ci.yml runs it
+        # twice. The shebang decides the interpreter; the filename does not.
+        self.assertEqual(
+            self.discover({"scripts/report": "#!/usr/bin/env python3\nimport json\n"}),
+            ["scripts/report"],
+        )
+
+    def test_an_extensionless_shell_program_is_not(self) -> None:
+        self.assertEqual(
+            self.discover({"scripts/run": "#!/usr/bin/env bash\necho hi\n"}), []
+        )
+
+    def test_the_repository_discovers_its_extensionless_program(self) -> None:
+        root = repository_root()
+        if root is None:
+            self.skipTest("not a repository checkout; scan runs as a CI step")
+        found = {path.relative_to(root).as_posix() for path in policy.sources(root)}
+        self.assertIn("scripts/ci-test-failure-report", found)
+
+    def test_vendored_and_build_trees_are_skipped(self) -> None:
+        self.assertEqual(
+            self.discover(
+                {
+                    "third-party/vendor/x.py": "import tomllib\n",
+                    "buck-out/y.py": "import tomllib\n",
+                    "keep.py": "import json\n",
+                }
+            ),
+            ["keep.py"],
+        )
+
+
+class DocumentationTests(unittest.TestCase):
+    def check(self, text: str) -> list[str]:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            (root / "AGENTS.md").write_text(text, encoding="utf-8")
+            return policy.check_docs(root)
+
+    SECTION = policy.FLOOR_SECTION + "\n\nThe tooling requires Python 3.11 or newer.\n"
+
+    def test_the_repository_documents_the_floor_this_gate_enforces(self) -> None:
+        root = repository_root()
+        if root is None:
+            self.skipTest("not a repository checkout; scan runs as a CI step")
+        self.assertEqual(policy.check_docs(root), [])
+
+    def test_a_well_formed_section_satisfies_it(self) -> None:
+        self.assertEqual(self.check(self.SECTION), [])
+
+    def test_a_missing_section_is_a_finding(self) -> None:
+        problems = self.check("# Rue\n\nThe tooling requires Python 3.11 or newer.\n")
+        self.assertEqual(len(problems), 1)
+        self.assertIn("no \"## Repository tooling baseline\" section", problems[0])
+
+    def test_the_claim_must_be_inside_the_section(self) -> None:
+        # An unrelated sentence elsewhere in a long file is not the floor.
+        text = (
+            "# Rue\n\nThe tooling requires Python 3.11 or newer.\n\n"
+            + policy.FLOOR_SECTION
+            + "\n\nSee elsewhere.\n\n## Next\n"
+        )
+        problems = self.check(text)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("no documented Python floor", problems[0])
+
+    def test_the_claim_must_be_outside_a_code_fence(self) -> None:
+        text = (
+            policy.FLOOR_SECTION
+            + "\n\n```\nrequires Python 3.11 or newer\n```\n"
+        )
+        problems = self.check(text)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("outside a code fence", problems[0])
+
+    def test_a_documented_floor_that_disagrees_is_a_finding(self) -> None:
+        text = policy.FLOOR_SECTION + "\n\nrequires Python 3.9 or newer\n"
+        problems = self.check(text)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("Move both together", problems[0])
+
+    def test_a_second_document_stating_a_different_floor_is_a_finding(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            (root / "AGENTS.md").write_text(self.SECTION, encoding="utf-8")
+            (root / "CONTRIBUTING.md").write_text(
+                "requires Python 3.13 or newer\n", encoding="utf-8"
+            )
+            problems = policy.check_docs(root)
+            self.assertEqual(len(problems), 1)
+            self.assertIn("One floor, one place", problems[0])
+
+
+class RepositoryTests(unittest.TestCase):
+    def test_the_tree_is_clean(self) -> None:
+        root = repository_root()
+        if root is None:
+            self.skipTest("not a repository checkout; scan runs as a CI step")
+        findings, unscanned, documentation, scanned = policy.validate(root)
+        self.assertEqual([str(finding) for finding in findings], [])
+        self.assertEqual(documentation, [])
+        self.assertEqual([str(note) for note in unscanned], [])
+        # A real lower bound: a handful of sandboxed files must not satisfy it.
+        self.assertGreater(scanned, 50)
+
+    def test_the_shipped_tool_is_clean_only_because_it_is_guarded(self) -> None:
+        # The bug this whole change answers, pinned by removing its fix: with
+        # the guard deleted, scripts/cli-timeout-policy.py is a bare `import
+        # tomllib` again and the gate must say so.
+        source = TOOL.read_text(encoding="utf-8")
+        findings, unscanned = policy.scan(source, "cli-timeout-policy.py")
+        self.assertEqual([str(finding) for finding in findings], [])
+        self.assertEqual(unscanned, [])
+        stripped = re.sub(
+            r"\nif sys\.version_info < \(3, 11\):\n(?:    .*\n|\n)*?    \)\n",
+            "\n",
+            source,
+        )
+        self.assertNotEqual(stripped, source, "the guard was not found to remove")
+        self.assertEqual(descriptions(stripped), ["the `tomllib` module"])
+
+
+class HostTests(unittest.TestCase):
+    def test_the_tool_reports_the_floor_rather_than_a_missing_module(self) -> None:
+        """Run the real tool and check which failure this host gets.
+
+        Both branches assert something real, so this case cannot quietly become
+        a no-op on either side of the floor -- which is how the RUE-1506
+        mechanism tests first went wrong.
+        """
+        result = subprocess.run(
+            [sys.executable, str(TOOL), "--help"],
+            capture_output=True,
+            text=True,
+        )
+        if sys.version_info < policy.FLOOR:
+            self.assertNotEqual(result.returncode, 0)
+            self.assertNotIn("ModuleNotFoundError", result.stderr)
+            self.assertIn("requires Python 3.11 or newer", result.stderr)
+            self.assertIn("AGENTS.md", result.stderr)
+        else:
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("--policy", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-python-baseline.py
+++ b/scripts/validate-python-baseline.py
@@ -1,0 +1,817 @@
+#!/usr/bin/env python3
+"""Hold repository Python to the interpreter floor AGENTS.md documents.
+
+Every gate, generator, and test runner under `scripts/` is a standalone
+`#!/usr/bin/env python3` program, so the interpreter is whatever the host puts
+first on PATH. CI's is generous -- `ubuntu-latest` provides 3.12.3 and
+`macos-15` provides 3.14.6 -- and a developer's is not: macOS ships
+`/usr/bin/python3` as 3.9.6. A construct newer than the host interpreter is
+therefore not a portability nicety, it is a traceback before the program does
+any of its work, on a machine CI cannot see.
+
+That is exactly how it failed. `scripts/cli-timeout-policy.py` imports
+`tomllib`, stdlib only from 3.11, and //:cli-timeout-policy-validation carries
+`rue_test_tier_premerge` -- so the premerge suite died with
+`ModuleNotFoundError: No module named 'tomllib'` on every host below 3.11 while
+CI stayed green, and the message named neither the version nor the remedy
+(RUE-1509). The Bash analogue is `mapfile` in test.sh (RUE-1506); this is the
+same failure in the other language, so it gets the same shape of gate.
+
+Two thresholds, one table:
+
+  FLOOR (3.11)      what the repository requires, documented in AGENTS.md.
+                    Nothing may need MORE than this. A construct above the
+                    floor is a finding with no escape but a portable spelling.
+
+  UNGUARDED (3.9)   what a contributor has WITHOUT installing anything, on the
+                    oldest host that plausibly shows up. A construct between
+                    UNGUARDED and FLOOR is allowed -- that is what the floor
+                    buys -- but the file must announce the requirement instead
+                    of crashing on it.
+
+The guard is one canonical spelling, checked before the construct's first use:
+
+    import sys
+
+    if sys.version_info < (3, 11):
+        raise SystemExit(
+            "error: scripts/x.py requires Python 3.11 or newer (this is ...)"
+        )
+
+    import tomllib
+
+The `raise` must be an unconditional statement in that `if`'s own body. A
+`raise` in the `else`, or nested inside a further condition, is not a guard --
+it is a file that still reaches the import on an old host, which is the
+original bug wearing the fix's clothes. The message must contain the version it
+demands, because naming the requirement is the entire point; a guard that exits
+without saying which version has only moved the mystery.
+
+An import inside `try:` with an `except ImportError`/`ModuleNotFoundError`
+handler is exempt: the whole objection is that the failure is unhandled, and
+that import handles it. That is the shape a vendored fallback takes.
+
+WHAT IS SCANNED. Every `.py` file, plus every extensionless file carrying a
+python shebang -- `scripts/ci-test-failure-report` is a 126-line program CI runs
+twice, and the interpreter is chosen by its shebang, not by its name. Vendored
+and build directories and nested checkouts are excluded.
+
+WHAT THIS SCAN CANNOT SEE, stated plainly so the gate is not read as a proof:
+
+  - It is only as strict as the interpreter running it. Syntax newer than the
+    scanning interpreter is a parse error, and BELOW the floor a parse error
+    cannot be told apart from syntax the floor legitimately allows -- so such a
+    file is reported as unscanned rather than guessed at, and the authoritative
+    run is the `fmt` job's CI step, which is at or above the floor.
+  - Grammar with no distinct AST node is invisible: PEP 701 f-strings (3.12)
+    and PEP 696 TypeVar defaults (3.13) parse into the same nodes as their
+    older spellings on an interpreter new enough to accept them.
+  - The API table covers module attributes and imports, not method calls.
+    `Path.walk()`, `Exception.add_note()`, `int.bit_count()`,
+    `glob(root_dir=...)` and their kind need a type to resolve the receiver,
+    which this scanner deliberately does not have -- a name-based rule would
+    fire on every method that happened to share the name.
+  - `importlib.import_module("tomllib")` and `__import__` evade it, as any
+    static scan of a dynamic import must.
+  - An annotation silences its whole line, so a construct inside a multi-line
+    call is annotated at the line the scanner reports, not at the argument.
+
+The table is curated, not exhaustive: only constructs whose introducing version
+is unambiguous. A rule that had to hedge would be answered with an annotation
+rather than a fix, which teaches reviewers to ignore the gate.
+
+Annotate a reviewed exception with `# python-baseline-ok: <reason>`. It has to
+sit in a real comment and it silences its whole line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import re
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# What the repository requires. AGENTS.md states this in prose and `check_docs`
+# holds the two copies together, so the gate cannot outlive the documentation
+# that tells a contributor what to install.
+FLOOR = (3, 11)
+
+# What a contributor has before installing anything. macOS ships
+# `/usr/bin/python3` as 3.9.6 and no newer interpreter out of the box, so 3.9
+# is the version a file must either run on or explain itself to.
+UNGUARDED = (3, 9)
+
+SCANNER = (sys.version_info[0], sys.version_info[1])
+
+# Build outputs and vendored trees are not ours to police, and `buck-out` in
+# particular makes the scan's cost and result depend on whether a build has run.
+SKIP_DIRECTORIES = {
+    ".buckd",
+    ".git",
+    ".jj",
+    "buck-out",
+    "buck2-bin",
+    "node_modules",
+    "target",
+    "third-party",
+}
+
+ALLOW = re.compile(r"#\s*python-baseline-ok:\s*(?P<reason>\S.*?)\s*$")
+
+# `#!/usr/bin/env python3`, `#!/usr/bin/python3`, `#!/usr/bin/env -S python3 -u`.
+PYTHON_SHEBANG = re.compile(r"^#!\s*\S*(?:\s+-\S+)*\s*(?:\S*/)?python[\d.]*\b")
+
+# The AGENTS.md section that owns the floor, and the sentence within it. Anchored
+# to the section so an unrelated line elsewhere in a long file cannot satisfy the
+# check by accident.
+FLOOR_SECTION = "## Repository tooling baseline"
+DOCUMENTED_FLOOR = re.compile(r"requires? Python (\d+)\.(\d+) or newer")
+
+# Other documents are checked for a CONFLICTING copy of the same sentence.
+# `docs/process/build-cache.md` states a different Python number on purpose --
+# the remote worker image's, for the Buck prelude's rustc wrapper -- and says so;
+# it does not use this sentence, and must not start to.
+OTHER_DOCS = ("CONTRIBUTING.md", "README.md", "docs")
+
+
+# Stdlib modules by the version that introduced them. An import of one of these
+# is the failure that started this: it raises ModuleNotFoundError at import
+# time, before any of the program's own error handling exists -- unless the
+# import is handled, which `handled_imports` accounts for.
+MODULE_SINCE = {
+    "graphlib": (3, 9),
+    "zoneinfo": (3, 9),
+    "tomllib": (3, 11),
+    "wsgiref.types": (3, 11),
+    "dbm.sqlite3": (3, 13),
+    "annotationlib": (3, 14),
+    "compression": (3, 14),
+    "concurrent.interpreters": (3, 14),
+}
+
+# Names within an existing module, which fail later and less clearly than a
+# missing module: an AttributeError somewhere down a call path.
+API_SINCE = {
+    ("dataclasses", "KW_ONLY"): (3, 10),
+    ("itertools", "pairwise"): (3, 10),
+    ("typing", "ParamSpec"): (3, 10),
+    ("typing", "TypeAlias"): (3, 10),
+    ("typing", "TypeGuard"): (3, 10),
+    ("asyncio", "TaskGroup"): (3, 11),
+    ("asyncio", "timeout"): (3, 11),
+    ("contextlib", "chdir"): (3, 11),
+    ("datetime", "UTC"): (3, 11),
+    ("enum", "StrEnum"): (3, 11),
+    ("hashlib", "file_digest"): (3, 11),
+    ("math", "cbrt"): (3, 11),
+    ("math", "exp2"): (3, 11),
+    ("operator", "call"): (3, 11),
+    ("typing", "LiteralString"): (3, 11),
+    ("typing", "Never"): (3, 11),
+    ("typing", "NotRequired"): (3, 11),
+    ("typing", "Required"): (3, 11),
+    ("typing", "Self"): (3, 11),
+    ("typing", "assert_never"): (3, 11),
+    ("typing", "assert_type"): (3, 11),
+    ("itertools", "batched"): (3, 12),
+    ("random", "binomialvariate"): (3, 12),
+    ("sys", "monitoring"): (3, 12),
+    ("typing", "override"): (3, 12),
+    ("base64", "z85encode"): (3, 13),
+    ("copy", "replace"): (3, 13),
+    ("os", "process_cpu_count"): (3, 13),
+    ("typing", "ReadOnly"): (3, 13),
+    ("typing", "TypeIs"): (3, 13),
+    ("warnings", "deprecated"): (3, 13),
+}
+
+# Builtins. Only the unambiguous ones: a rule keyed on a bare lowercase name
+# would fire on any local variable that happened to share it.
+BUILTIN_SINCE = {
+    "ExceptionGroup": (3, 11),
+    "BaseExceptionGroup": (3, 11),
+}
+
+# Keyword arguments added to a call that has existed forever. `zip(strict=True)`
+# on 3.9 is a TypeError at the call site, which reads like a bug in the caller.
+# The flag says whether the callee must be a bare name: `zip` must, because
+# `anything.zip(a, strict=True)` is somebody else's method, while `dataclass`
+# is as legitimate spelled `dataclasses.dataclass`.
+KEYWORD_SINCE = {
+    ("zip", "strict"): ((3, 10), True),
+    ("dataclass", "slots"): ((3, 10), False),
+    ("dataclass", "kw_only"): ((3, 10), False),
+    ("dataclass", "match_args"): ((3, 10), False),
+}
+
+
+class Construct(NamedTuple):
+    description: str
+    since: tuple[int, int]
+    fix: str
+
+
+class Finding(NamedTuple):
+    path: str
+    line: int
+    construct: Construct
+    # A construct above FLOOR has no guard that would make it acceptable; one
+    # between UNGUARDED and FLOOR is merely unannounced. The two need different
+    # sentences, because "add a guard" is wrong advice for the first.
+    above_floor: bool
+
+    def __str__(self) -> str:
+        needs = version_text(self.construct.since)
+        if self.above_floor:
+            return (
+                f"{self.path}:{self.line}: {self.construct.description} needs "
+                f"Python {needs}, above the repository floor of "
+                f"{version_text(FLOOR)}. Instead, {self.construct.fix} -- or "
+                "raise the floor in AGENTS.md and here, deliberately."
+            )
+        return (
+            f"{self.path}:{self.line}: {self.construct.description} needs "
+            f"Python {needs}, and a stock host has {version_text(UNGUARDED)}, "
+            f"so this file must announce the requirement rather than crash on "
+            f"it. Add `if sys.version_info < {tuple(self.construct.since)}: "
+            f'raise SystemExit("...{needs}...")` above the first use -- or '
+            "annotate with `# python-baseline-ok: <reason>`."
+        )
+
+
+class Unscanned(NamedTuple):
+    """A file this interpreter could not parse, and could not judge.
+
+    Below the floor, a parse error is ambiguous: `match` needs 3.10, which the
+    floor allows, so a 3.9 host cannot tell a policy violation from a file it is
+    simply too old to read. Guessing would produce a finding that is wrong about
+    the version, wrong about the floor, and backwards about the fix -- the very
+    CI-lenient/developer-strict split this policy exists to close, inverted. So
+    it says what it could not do and leaves the verdict to the CI step.
+    """
+
+    path: str
+    line: int
+    reason: str
+
+    def __str__(self) -> str:
+        return (
+            f"{self.path}:{self.line}: not scanned -- Python "
+            f"{version_text(SCANNER)} cannot parse it ({self.reason}), and this "
+            f"host is below the floor of {version_text(FLOOR)}, so a parse error "
+            "here does not distinguish a violation from syntax the floor allows. "
+            "The `fmt` job's CI step runs at or above the floor and is "
+            "authoritative."
+        )
+
+
+def version_text(version: tuple[int, int]) -> str:
+    return f"{version[0]}.{version[1]}"
+
+
+def guard_versions(tree: ast.Module) -> list[tuple[int, tuple[int, int]]]:
+    """Line and demanded version of each `sys.version_info` guard.
+
+    Only the canonical spelling counts -- a module-level `if sys.version_info <
+    (X, Y)` whose OWN BODY unconditionally raises SystemExit, with the version
+    named in that raise. The strictness is the point: a `raise` in the `else`
+    branch, or nested under another condition, leaves the following import
+    reachable on an old host, so accepting it would certify the exact
+    ModuleNotFoundError this gate exists to prevent.
+    """
+    guards: list[tuple[int, tuple[int, int]]] = []
+    for node in tree.body:
+        if not isinstance(node, ast.If):
+            continue
+        version = compared_version(node.test)
+        if version is None:
+            continue
+        raised = next(
+            (statement for statement in node.body if raises_system_exit(statement)),
+            None,
+        )
+        if raised is None:
+            continue
+        # The message has to name the version, because a guard that exits with
+        # a bare SystemExit has replaced one unexplained failure with another.
+        text = " ".join(
+            value.value
+            for value in ast.walk(raised)
+            if isinstance(value, ast.Constant) and isinstance(value.value, str)
+        )
+        if version_text(version) not in text:
+            continue
+        guards.append((node.lineno, version))
+    return guards
+
+
+def compared_version(test: ast.expr) -> tuple[int, int] | None:
+    """The `(X, Y)` in `sys.version_info < (X, Y)`, or None."""
+    if not isinstance(test, ast.Compare) or len(test.ops) != 1:
+        return None
+    if not isinstance(test.ops[0], ast.Lt):
+        return None
+    subject = test.left
+    # `sys.version_info[:2] < (3, 11)` is the same test, spelled defensively.
+    if isinstance(subject, ast.Subscript):
+        subject = subject.value
+    if not (
+        isinstance(subject, ast.Attribute)
+        and subject.attr == "version_info"
+        and isinstance(subject.value, ast.Name)
+        and subject.value.id == "sys"
+    ):
+        return None
+    bound = test.comparators[0]
+    if not isinstance(bound, ast.Tuple) or len(bound.elts) < 2:
+        return None
+    parts = [
+        element.value
+        for element in bound.elts[:2]
+        if isinstance(element, ast.Constant) and isinstance(element.value, int)
+    ]
+    return (parts[0], parts[1]) if len(parts) == 2 else None
+
+
+def raises_system_exit(statement: ast.stmt) -> bool:
+    """Whether this statement IS an unconditional `raise SystemExit`."""
+    if not isinstance(statement, ast.Raise) or statement.exc is None:
+        return False
+    call = statement.exc
+    if isinstance(call, ast.Call):
+        call = call.func
+    return isinstance(call, ast.Name) and call.id == "SystemExit"
+
+
+def handled_imports(tree: ast.Module) -> set[int]:
+    """`id()` of every import inside a `try` that catches an import failure.
+
+    The objection to a version-gated import is that it fails UNHANDLED, before
+    the program's own error handling exists. A `try: import tomllib / except
+    ModuleNotFoundError: ...` fallback -- the shape a vendored backport takes --
+    has already answered that, so the guard requirement does not apply to it.
+    """
+    exempt: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Try):
+            continue
+        if not any(catches_import_error(handler) for handler in node.handlers):
+            continue
+        for statement in node.body:
+            for inner in ast.walk(statement):
+                if isinstance(inner, (ast.Import, ast.ImportFrom)):
+                    exempt.add(id(inner))
+    return exempt
+
+
+def catches_import_error(handler: ast.ExceptHandler) -> bool:
+    if handler.type is None:
+        return True
+    names = (
+        handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type]
+    )
+    for name in names:
+        if isinstance(name, ast.Name) and name.id in (
+            "ImportError",
+            "ModuleNotFoundError",
+        ):
+            return True
+    return False
+
+
+def module_aliases(tree: ast.Module) -> dict[str, str]:
+    """Local name -> module it refers to, for `import x` and `import x as y`.
+
+    `import os.path` binds `os`, not `os.path`, so the binding name and the
+    module it resolves to are not the same string and cannot be conflated.
+    """
+    aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Import):
+            continue
+        for alias in node.names:
+            if alias.asname:
+                aliases[alias.asname] = alias.name
+            else:
+                top = alias.name.split(".")[0]
+                aliases[top] = top
+    return aliases
+
+
+def constructs(tree: ast.Module) -> list[tuple[int, Construct]]:
+    """Every version-gated construct in one parsed module, with its line."""
+    found: list[tuple[int, Construct]] = []
+    aliases = module_aliases(tree)
+    exempt = handled_imports(tree)
+
+    def record(line: int, description: str, since: tuple[int, int], fix: str) -> None:
+        found.append((line, Construct(description, since, fix)))
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if id(node) in exempt:
+                continue
+            for alias in node.names:
+                since = MODULE_SINCE.get(alias.name)
+                if since:
+                    record(
+                        node.lineno,
+                        f"the `{alias.name}` module",
+                        since,
+                        "read the data with a module that predates the floor",
+                    )
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            if id(node) in exempt:
+                continue
+            since = MODULE_SINCE.get(node.module)
+            if since:
+                record(
+                    node.lineno,
+                    f"the `{node.module}` module",
+                    since,
+                    "import a module that predates the floor",
+                )
+            for alias in node.names:
+                dotted = f"{node.module}.{alias.name}"
+                since = MODULE_SINCE.get(dotted)
+                if since:
+                    record(
+                        node.lineno,
+                        f"the `{dotted}` module",
+                        since,
+                        "import a module that predates the floor",
+                    )
+                since = API_SINCE.get((node.module, alias.name))
+                if since:
+                    record(
+                        node.lineno,
+                        f"`{dotted}`",
+                        since,
+                        "use the spelling available at the floor",
+                    )
+        elif isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+            module = aliases.get(node.value.id)
+            since = API_SINCE.get((module, node.attr)) if module else None
+            if since:
+                record(
+                    node.lineno,
+                    f"`{module}.{node.attr}`",
+                    since,
+                    "use the spelling available at the floor",
+                )
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+            since = BUILTIN_SINCE.get(node.id)
+            if since:
+                record(
+                    node.lineno,
+                    f"the `{node.id}` builtin",
+                    since,
+                    "raise and catch an ordinary exception",
+                )
+        elif isinstance(node, ast.Call):
+            bare = isinstance(node.func, ast.Name)
+            if bare:
+                name = node.func.id
+            elif isinstance(node.func, ast.Attribute):
+                name = node.func.attr
+            else:
+                name = None
+            for keyword in node.keywords:
+                rule = KEYWORD_SINCE.get((name, keyword.arg)) if name else None
+                if rule is None:
+                    continue
+                since, bare_only = rule
+                if bare_only and not bare:
+                    continue
+                record(
+                    node.lineno,
+                    f"the `{name}({keyword.arg}=...)` argument",
+                    since,
+                    "drop the argument and do the work explicitly",
+                )
+
+    found.extend(syntax_constructs(tree))
+    return found
+
+
+def syntax_constructs(tree: ast.Module) -> list[tuple[int, Construct]]:
+    """Grammar that a newer interpreter added.
+
+    The node classes are fetched with `getattr` because they do not exist on
+    every interpreter this scanner must itself run on: `ast.Match` arrived in
+    3.10 and `ast.TypeAlias` in 3.12, so naming them directly would make the
+    gate crash on exactly the old hosts it exists to protect.
+    """
+    rules = (
+        (getattr(ast, "Match", ()), "a `match` statement", (3, 10), "use `if`/`elif`"),
+        (
+            getattr(ast, "TryStar", ()),
+            "an `except*` group",
+            (3, 11),
+            "catch the exceptions individually",
+        ),
+        (
+            getattr(ast, "TypeAlias", ()),
+            "a PEP 695 `type` alias",
+            (3, 12),
+            "assign the alias as an ordinary name",
+        ),
+    )
+    found: list[tuple[int, Construct]] = []
+    for node in ast.walk(tree):
+        for node_type, description, since, fix in rules:
+            if node_type and isinstance(node, node_type):
+                found.append((node.lineno, Construct(description, since, fix)))
+        # PEP 695 parameter lists on a def or class. The attribute is absent
+        # before 3.12, where such a file would not have parsed in the first
+        # place.
+        if getattr(node, "type_params", None):
+            found.append(
+                (
+                    node.lineno,
+                    Construct(
+                        "PEP 695 type parameters",
+                        (3, 12),
+                        "declare a module-level `TypeVar`",
+                    ),
+                )
+            )
+    return found
+
+
+def scan(source: str, path: str) -> tuple[list[Finding], list[Unscanned]]:
+    """Findings in one Python file, and whether it could be judged at all."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as error:
+        line = error.lineno or 1
+        reason = error.msg
+        if SCANNER < FLOOR:
+            # Ambiguous from here: `match` needs 3.10, which the floor allows.
+            return [], [Unscanned(path, line, reason)]
+        # At or above the floor, unparseable means newer than the floor, or
+        # malformed. Either is a finding, and neither claims a version the
+        # scanner cannot know.
+        return (
+            [
+                Finding(
+                    path,
+                    line,
+                    Construct(
+                        f"syntax Python {version_text(SCANNER)} cannot parse "
+                        f"({reason})",
+                        FLOOR,
+                        "use syntax the floor accepts, or fix the file",
+                    ),
+                    above_floor=True,
+                )
+            ],
+            [],
+        )
+
+    lines = source.splitlines()
+    guards = guard_versions(tree)
+    findings: dict[tuple[int, str], Finding] = {}
+    for line, construct in constructs(tree):
+        if construct.since <= UNGUARDED:
+            continue
+        raw = lines[line - 1] if 0 < line <= len(lines) else ""
+        _, comment = split_comment(raw)
+        if ALLOW.search(comment):
+            continue
+        above_floor = construct.since > FLOOR
+        # A guard cannot excuse a construct the floor does not reach: on a host
+        # AT the floor there is no interpreter for the guard to fall back to.
+        if not above_floor and any(
+            at < line and demanded >= construct.since for at, demanded in guards
+        ):
+            continue
+        findings[(line, construct.description)] = Finding(
+            path, line, construct, above_floor
+        )
+    return [findings[key] for key in sorted(findings)], []
+
+
+def split_comment(line: str) -> tuple[str, str]:
+    """Split a source line into code and its trailing comment.
+
+    A `#` inside a string literal does not open a comment, so an annotation is
+    only an annotation outside quotes -- otherwise any file quoting this
+    policy's own prose would silence itself.
+    """
+    quote = ""
+    index = 0
+    while index < len(line):
+        character = line[index]
+        if quote:
+            if character == "\\":
+                index += 2
+                continue
+            if character == quote:
+                quote = ""
+        elif character in "'\"":
+            quote = character
+        elif character == "#":
+            return line[:index], line[index:]
+        index += 1
+    return line, ""
+
+
+def _prune(directory: Path, names: list[str]) -> list[str]:
+    """Directory names to descend into.
+
+    Nested checkouts are pruned by their own VCS marker rather than by name:
+    the working agreement puts sibling worktrees under `.claude/worktrees/`,
+    and reporting a path inside one as though it were a path in THIS tree is
+    worse than not scanning it -- that copy has its own gate.
+    """
+    kept = []
+    for name in sorted(names):
+        if name in SKIP_DIRECTORIES:
+            continue
+        path = directory / name
+        if (path / ".git").exists() or (path / ".jj").exists():
+            continue
+        kept.append(name)
+    return kept
+
+
+def sources(root: Path) -> list[Path]:
+    """Every Python file under `root`, by extension or by shebang.
+
+    The shebang half is not decoration. `scripts/ci-test-failure-report` has no
+    suffix and is run twice by ci.yml, and the shebang is what decides which
+    interpreter reads it -- the same reason the Bash baseline policy discovers
+    its scripts that way. A name is not a contract; `#!` is.
+    """
+    found: list[Path] = []
+    for directory, names, files in os.walk(root):
+        here = Path(directory)
+        names[:] = _prune(here, names)
+        for name in sorted(files):
+            path = here / name
+            if path.is_symlink() or not path.is_file():
+                continue
+            if path.suffix == ".py":
+                found.append(path)
+                continue
+            if path.suffix:
+                continue
+            try:
+                with path.open("r", encoding="utf-8", errors="strict") as handle:
+                    first = handle.readline()
+            except (OSError, UnicodeDecodeError):
+                continue
+            if PYTHON_SHEBANG.match(first):
+                found.append(path)
+    return sorted(found)
+
+
+def strip_fences(text: str) -> str:
+    """Blank out fenced code blocks.
+
+    A floor quoted inside an example is an example, not a claim, and the
+    section documents the guard's spelling in a fenced block.
+    """
+    kept = []
+    fenced = False
+    for line in text.splitlines():
+        if line.lstrip().startswith("```"):
+            fenced = not fenced
+            kept.append("")
+            continue
+        kept.append("" if fenced else line)
+    return "\n".join(kept)
+
+
+def floor_section(text: str) -> str | None:
+    """The body of AGENTS.md's tooling-baseline section, or None."""
+    lines = text.splitlines()
+    try:
+        start = lines.index(FLOOR_SECTION)
+    except ValueError:
+        return None
+    for offset, line in enumerate(lines[start + 1 :], start=start + 1):
+        if line.startswith("## "):
+            return "\n".join(lines[start + 1 : offset])
+    return "\n".join(lines[start + 1 :])
+
+
+def check_docs(root: Path) -> list[str]:
+    """Hold the documented floor and this gate's FLOOR together.
+
+    A floor nobody wrote down cannot be acted on, and a floor the gate no longer
+    agrees with is worse than none: the contributor installs one version and the
+    gate demands another. The claim is anchored to its own section and read
+    outside code fences, so an unrelated sentence or a quoted example cannot
+    satisfy it. Other documents are checked for a conflicting copy -- the
+    failure mode is not an absent floor but two of them.
+    """
+    agents = root / "AGENTS.md"
+    try:
+        text = agents.read_text(encoding="utf-8")
+    except OSError:
+        return [f"{agents}: unreadable, so the documented Python floor cannot be read"]
+
+    section = floor_section(text)
+    if section is None:
+        return [
+            f'AGENTS.md: no "{FLOOR_SECTION}" section. The floor must live in '
+            "one named place a contributor can be sent to."
+        ]
+    match = DOCUMENTED_FLOOR.search(strip_fences(section))
+    if not match:
+        return [
+            f'AGENTS.md, "{FLOOR_SECTION}": no documented Python floor. It must '
+            f'state "requires Python {version_text(FLOOR)} or newer" outside a '
+            "code fence, so a contributor hitting this gate knows what to install."
+        ]
+    documented = (int(match.group(1)), int(match.group(2)))
+    problems = []
+    if documented != FLOOR:
+        problems.append(
+            f"AGENTS.md documents a Python floor of {version_text(documented)} "
+            f"but this gate enforces {version_text(FLOOR)}. Move both together."
+        )
+    problems.extend(conflicting_docs(root, documented))
+    return problems
+
+
+def conflicting_docs(root: Path, documented: tuple[int, int]) -> list[str]:
+    """Any other document stating a different floor with the same sentence."""
+    candidates: list[Path] = []
+    for name in OTHER_DOCS:
+        path = root / name
+        if path.is_dir():
+            candidates.extend(sorted(path.rglob("*.md")))
+        elif path.is_file():
+            candidates.append(path)
+    problems = []
+    for path in candidates:
+        try:
+            body = strip_fences(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError):
+            continue
+        for match in DOCUMENTED_FLOOR.finditer(body):
+            stated = (int(match.group(1)), int(match.group(2)))
+            if stated != documented:
+                problems.append(
+                    f"{path.relative_to(root).as_posix()}: states a Python floor "
+                    f"of {version_text(stated)}, but AGENTS.md documents "
+                    f"{version_text(documented)}. One floor, one place."
+                )
+    return problems
+
+
+def validate(root: Path) -> tuple[list[Finding], list[Unscanned], list[str], int]:
+    findings: list[Finding] = []
+    unscanned: list[Unscanned] = []
+    files = sources(root)
+    for path in files:
+        relative = path.relative_to(root).as_posix()
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        file_findings, file_unscanned = scan(source, relative)
+        findings.extend(file_findings)
+        unscanned.extend(file_unscanned)
+    return findings, unscanned, check_docs(root), len(files)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", nargs="?", type=Path, default=ROOT)
+    args = parser.parse_args()
+
+    findings, unscanned, documentation, scanned = validate(args.root)
+    for note in unscanned:
+        print(f"note: {note}", file=sys.stderr)
+    for problem in documentation:
+        print(f"error: {problem}", file=sys.stderr)
+    for finding in findings:
+        print(f"error: {finding}", file=sys.stderr)
+    if findings or documentation:
+        return 1
+
+    summary = (
+        f"python baseline policy valid: {scanned} file(s) scanned against "
+        f"Python {version_text(FLOOR)}"
+    )
+    if unscanned:
+        summary += (
+            f"; {len(unscanned)} unparseable here and left to the CI step, which "
+            f"runs at or above the floor (this is Python {version_text(SCANNER)})"
+        )
+    print(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
`//:cli-timeout-policy-validation` carries `rue_test_tier_premerge` and died on every host below Python 3.11:

```
$ ./buck2 test //:cli-timeout-policy-validation
✗ Fail: root//:cli-timeout-policy-validation
ModuleNotFoundError: No module named 'tomllib'
```

`scripts/cli-timeout-policy.py` imports `tomllib`, stdlib only from 3.11. CI never saw it — `ubuntu-latest` provides 3.12.3 and `macos-15` provides 3.14.6 — while macOS ships `/usr/bin/python3` as 3.9.6. No Python floor was documented anywhere, so a contributor got a bare `ModuleNotFoundError` from an unrelated-looking validator.

This is the Python instance of RUE-1506's Bash `mapfile` bug, landed earlier today: a premerge-tier target green in CI and broken on developer machines because the runner image happens to satisfy an undeclared requirement.

## Why document the floor rather than remove the dependency

Measured, not assumed. `tomllib` is the **only** construct above Python 3.9 anywhere in the repository's 63 Python files; next highest is `str.removeprefix` (3.9). So dropping it really would have removed the constraint entirely.

But the tool parses `crates/rue-cli-tests/cases/`, and that corpus uses the full TOML surface: multi-line basic strings in 213 of 218 files, arrays in 214, inline tables in 84, with escaped quotes inside array elements. A reader for that is not a restricted dialect — it is a second TOML implementation, weaker than stdlib, adjudicating test deadlines.

So the floor is documented in `AGENTS.md` and `CONTRIBUTING.md`, and the two affected scripts announce the requirement instead of crashing:

```
error: scripts/cli-timeout-policy.py requires Python 3.11 or newer (this interpreter is
3.10.3 at /Users/…/3.10.3/bin/python3). It reads the CLI execution contracts with the
stdlib `tomllib` module, added in 3.11. Install a 3.11+ interpreter and put it earlier on
PATH; see AGENTS.md, "Repository tooling baseline".
```

## The guard

`scripts/validate-python-baseline.py`, modeled on the Bash baseline gate RUE-1506 landed, with two thresholds over one curated table: **FLOOR (3.11)**, nothing may exceed it; **UNGUARDED (3.9)**, what a stock Mac ships, so anything between must announce itself.

Discovery is by **shebang**, not by extension — `scripts/ci-test-failure-report` is a `#!/usr/bin/env python3` program invoked twice in CI, and the interpreter is a shebang property rather than a filename one.

A guard must be an unconditional `raise SystemExit` in the `if`'s **own body**. An earlier draft accepted `if sys.version_info < (3, 11): pass / else: raise …`, which reproduces the original `ModuleNotFoundError` verbatim while passing the gate built to prevent it.

Imports inside a `try:` with an `ImportError`/`ModuleNotFoundError` handler are exempt, so the gate does not penalise the `try: import tomllib / except: import tomli` idiom — which is the alternative left open below, and a gate should not argue for its own conclusion.

Below the floor a parse failure is a `note:`, not a finding, because a 3.9 host cannot distinguish a violation from syntax the floor allows; the `fmt` job's step runs above the floor and is authoritative. The docstring carries a "what this scan cannot see" section — PEP 701 f-strings, PEP 696 defaults, method calls, dynamic imports — because a curated table is not a proof, and `AGENTS.md` says so rather than overclaiming.

`docs/process/build-cache.md` already recorded a Python number (the RE container pinned to a 3.10 image); it now states which question that answers and cross-references the floor. The RE topology was checked rather than asserted: that job runs only `buck2 build` on two targets, never `test`, so repo tooling does not execute on the worker in CI.

## Still a maintainer call

Vendoring `tomli` — the backport that became `tomllib` — would remove the floor entirely via a handled import. It is declined here because the repository currently has **zero Python dependencies**, all 63 scripts pure stdlib, and vendoring Python into a reindeer-managed Rust `third-party/vendor` is new infrastructure with a provenance question. Worth knowing that 3.9 is already EOL and 3.10 reaches EOL in October 2026.

Closes RUE-1509.