### PR TITLE
RUE-1512: parse every shell script, not just the constructs we can name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,16 @@ jobs:
       # from here. It also covers the `run:` steps of jobs that can land on a
       # macOS runner; the `mapfile` this job itself uses above is NOT one of
       # them, and is correct, because this job only ever runs on ubuntu-latest.
+      #
+      # This is the AUTHORITATIVE run of the construct table. The gate's other
+      # half runs `bash -n` over every script, which catches what no table can
+      # name: RUE-1511 shipped an unbalanced quote inside a multi-line command
+      # substitution, and the table reported that file clean because a syntax
+      # error is not a construct. Every bash rejects that, so this runner's 5.x
+      # catches it here on every pull request — but `;;&`, `;&`, and `coproc`
+      # are a syntax error only on 3.2, so the step says it ran above the
+      # baseline and leaves that part to the macos-15 leg of native-platforms,
+      # which passes --require-baseline-bash (RUE-1512).
       - name: Check shell Bash 3.2 baseline
         run: scripts/validate-shell-bash-baseline.py
 
@@ -663,6 +673,46 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # RUE-1512. The `fmt` job already runs this gate, but on Bash 5, which
+      # parses `;;&`, `;&`, and `coproc` happily — all three are a syntax error
+      # on the 3.2 every Mac and every macos-* runner uses, so a script
+      # carrying one dies there and passes there. This runner's /bin/bash IS
+      # that 3.2 and is the only one in CI that is, so the parse check is
+      # authoritative here. `--require-baseline-bash` refuses to report a pass
+      # on anything else: if this image's /bin/bash ever ages into 5.x the step
+      # fails instead of silently becoming a duplicate of the Linux run, which
+      # is the RUE-1506 lesson — a check that cannot fail where it runs is
+      # worse than no check, because it is believed.
+      #
+      # Deliberately above the lane-selection gate: it needs only the checkout
+      # and Python, takes about a second, and a pull request touching shell
+      # alone is precisely the one this lane might deselect.
+      - name: Parse every bash script with the stock macOS Bash 3.2
+        if: runner.os == 'macOS'
+        run: scripts/validate-shell-bash-baseline.py --require-baseline-bash
+
+      # RUE-1506's demonstrations — `mapfile` exiting 127, `"${empty[@]}"`
+      # unbound under `set -u`, `read` assigning nothing when it fails — plus
+      # RUE-1512's `;;&` parse case. All of them skip without a 3.2, so this
+      # leg is the only place they prove anything.
+      #
+      # They used to run below as `./buck2 test //:shell-bash-baseline-tool-
+      # tests`, which forced them under the lane-selection gate, because buck2
+      # is only installed there. That reproduced the very bug RUE-1506 was
+      # about: `lane_targets native-macos-arm64` does not list that target and
+      # FORCE_FULL_REGEX does not cover `scripts/validate-*.py`, so a pull
+      # request changing ONLY the Bash 3.2 policy and its tests deselects this
+      # lane and skips the step — leaving the target to linux-premerge, where
+      # bash is 5.x and every one of these skips. Run directly instead: the
+      # tests need Python and a /bin/bash, not buck2, so they need no gate.
+      # The target keeps its premerge tier and still runs on Linux, where the
+      # host-independent cases do the work.
+      - name: Demonstrate the Bash 3.2 baseline on the stock macOS Bash
+        if: runner.os == 'macOS'
+        run: python3 scripts/test-validate-shell-bash-baseline.py
+        env:
+          PYTHONDONTWRITEBYTECODE: "1"
+
       # RUE-1130: consult the determinator before any heavy setup. On a
       # selective pull_request run where nothing this lane executes is affected,
       # the heavy steps are skipped and the check still reports success, so no
@@ -776,18 +826,6 @@ jobs:
             done <<< "$narrowed"
           fi
           scripts/ci-timed "$LANE_NAME native units" -- ./buck2 test "${targets[@]}"
-
-      # RUE-1506. The Bash 3.2 baseline policy's demonstrations — `mapfile`
-      # exiting 127, `"${empty[@]}"` unbound under `set -u`, `read` assigning
-      # nothing when it fails — need a 3.2 to demonstrate anything, and this is
-      # the only lane whose /bin/bash is one. Everywhere else they skip, so
-      # premerge alone would leave them a test that cannot fail. Unnarrowed:
-      # the policy scans the whole tree, so any diff can invalidate it.
-      - name: Demonstrate the Bash 3.2 baseline on the stock macOS Bash
-        if: steps.sel.outputs.run == 'true' && runner.os == 'macOS'
-        run: scripts/ci-timed "$LANE_NAME bash baseline" -- ./buck2 test //:shell-bash-baseline-tool-tests
-        env:
-          LANE_NAME: ${{ matrix.name }}
 
       - name: Run every declaratively platform-scoped spec and CLI case
         if: steps.sel.outputs.run == 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,36 @@ rather than a proof — its docstring lists what it cannot see, including gramma
 with no distinct AST node and every method call. Annotate a reviewed exception
 with `# python-baseline-ok: <reason>`.
 
+Shell has the same shape of floor and a stricter one. macOS ships GNU Bash
+3.2.57 as `/bin/bash` and will not ship a GPLv3 one, so a `#!/usr/bin/env bash`
+script has to run on 3.2 — on a stock Mac and on a `macos-*` runner that is the
+interpreter it gets. `scripts/validate-shell-bash-baseline.py` holds two checks
+to that floor, and neither covers the other. A curated construct table names
+Bash 4+ spellings, which is what catches a script that parses on 3.2 and then
+misbehaves: `mapfile` exiting 127 (RUE-1506), `${v:1:-1}` silently answering
+empty. A `bash -n` pass parses every discovered shell script — `#!/bin/sh` and
+bare `.sh` included, since a syntax error is one in any shell — and that is
+what catches a file which does not parse at all: RUE-1511 shipped an unbalanced
+double quote inside a multi-line command substitution, and the table called it
+clean because a syntax error is not a construct (RUE-1512).
+
+The two halves need different interpreters and get them in different places.
+An unbalanced quote is a syntax error on every bash, so the Linux `fmt` job's
+run catches that class on every pull request. `;;&`, `;&`, and `coproc` are a
+syntax error only on 3.2, so that half is authoritative on the `macos-15` leg
+of `native-platforms`, which runs the gate with `--require-baseline-bash` and
+fails if its `/bin/bash` is not a 3.x. Every run says which interpreter parsed
+and whether that was the baseline, so a weaker run cannot read as a stronger
+one, and an empty discovery set fails rather than passing as a clean tree.
+
+Annotate a reviewed table exception with `# bash-baseline-ok: <reason>`. The
+parse check has its own, `# bash-parse-ok: <reason>`, which is file-level
+because a parse failure names where the parser gave up rather than where the
+mistake is. It exists for one real case: `bash -n` parses without executing, so
+it never runs a `shopt`, and a file enabling `extglob` and then using `@(a|b)`
+runs correctly on 3.2.57 while `bash -n` on that same interpreter rejects it.
+A genuine syntax error is fixed, not annotated.
+
 ## Compiler architecture
 
 The canonical flow is:

--- a/scripts/affected-targets
+++ b/scripts/affected-targets
@@ -341,12 +341,20 @@ deferred_corpus_actions() {
         echo "affected-targets: could not query crate-scoped corpus actions" >&2
         return 1
     fi
-    # The query lives in its own variable rather than inline. Bash 3.2 — what
-    # macOS ships as /bin/bash, and this script runs on developer machines —
-    # cannot parse a `$(...)` whose body spans a line continuation and contains
-    # a quoted argument with parentheses; it dies with "unexpected EOF while
-    # looking for matching `\"'" several lines later, naming an innocent line.
-    # RUE-1506 and RUE-1509 are the same class caught in other files.
+    # The query lives in its own variable rather than inline, because the
+    # inline spelling ran several lines and lost its closing `"`: the `)`
+    # ending the command substitution was followed by `; then` instead of `)"`,
+    # so the quote opened before `$(` never closed and bash read to end of file
+    # looking for it — "unexpected EOF while looking for matching `\"'",
+    # reported several lines later at an innocent line.
+    #
+    # Correcting the note left here when that was repaired: this is not a Bash
+    # 3.2 limit. A `$(...)` whose body spans a line continuation and contains a
+    # quoted argument with parentheses parses on 3.2.57 and on 5.2.15 alike;
+    # the missing quote was the whole defect, and every bash rejects it. Hence
+    # RUE-1512 — `scripts/validate-shell-bash-baseline.py` now runs `bash -n`
+    # over every script, because its construct table could not see this: a
+    # syntax error is not a construct to name.
     query="attrfilter(labels, rue_test_tier_premerge, //crates/...)"
     query="$query except (attrfilter(labels, rue_ci_dedicated_lane, //crates/...)"
     query="$query + attrfilter(labels, rue_cli_shard, //crates/...))"

--- a/scripts/test-validate-shell-bash-baseline.py
+++ b/scripts/test-validate-shell-bash-baseline.py
@@ -4,11 +4,14 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import platform
 import subprocess
+import sys
 import tempfile
 import textwrap
 import unittest
+import unittest.mock
 from pathlib import Path
 
 
@@ -19,6 +22,44 @@ policy = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(policy)
 
 BASELINE_BASH = "/bin/bash"
+
+# The RUE-1511 break, as it shipped: the `"` opened after `covered=` is never
+# closed, because the `)` ending the command substitution is followed by
+# `; then` instead of `)"`. Every bash rejects it -- verified on 3.2.57 and
+# 5.2.15 -- and the construct table says nothing, because an unbalanced quote
+# is not a construct. That is the whole case for the parse check (RUE-1512).
+UNBALANCED_QUOTE = textwrap.dedent(
+    r"""
+    buck2=./buck2
+    if ! covered="$("$buck2" uquery \
+        "attrfilter(labels, a, //crates/...) except (attrfilter(labels, b, //crates/...))" \
+        2>/dev/null); then
+        exit 1
+    fi
+    printf '%s\n' "$covered"
+    """
+)
+
+# The same command, correctly quoted (`)"` before `; then`). Bash 3.2 parses
+# this, which is worth asserting: the comment left at the repaired site claims
+# 3.2 cannot parse a `$(...)` spanning a line continuation with a quoted
+# parenthesised argument, and it can.
+BALANCED_QUOTE = textwrap.dedent(
+    r"""
+    buck2=./buck2
+    if ! covered="$("$buck2" uquery \
+        "attrfilter(labels, a, //crates/...) except (attrfilter(labels, b, //crates/...))" \
+        2>/dev/null)"; then
+        exit 1
+    fi
+    printf '%s\n' "$covered"
+    """
+)
+
+# A syntax error on Bash 3.2 and valid on Bash 4+, so `bash -n` only rejects it
+# when a real 3.2 runs it. This is what a Linux runner's 5.x cannot see, and
+# why the macos-15 leg passes --require-baseline-bash.
+BASELINE_ONLY_SYNTAX = "case $x in a) run ;;& b) run ;; esac\n"
 
 
 def baseline_bash_version() -> int | None:
@@ -161,6 +202,15 @@ class ScanTests(unittest.TestCase):
             ["the `mapfile`/`readarray` builtin"],
         )
 
+    def test_the_table_cannot_see_a_syntax_error(self) -> None:
+        # The gap the parse check exists to close, asserted rather than
+        # described: this file is dead on every bash and the table says
+        # nothing, because there is no construct in it to name. `ParseTests`
+        # below catches the same source. Do not "fix" this by adding a rule --
+        # the class is unbounded, which is exactly why the second check is a
+        # parser and not a longer table.
+        self.assertEqual(self.scan(UNBALANCED_QUOTE), [])
+
 
 class WorkflowTests(unittest.TestCase):
     """`run:` steps are held to the baseline on macOS runners only."""
@@ -240,9 +290,12 @@ class DiscoveryTests(unittest.TestCase):
                 path = root / relative
                 path.parent.mkdir(parents=True, exist_ok=True)
                 path.write_text(contents)
-            scripts, workflows = policy.sources(root)
-            found = [p.relative_to(root).as_posix() for p in scripts + workflows]
-            findings = [str(f) for f in policy.validate(root)[0]]
+            discovered = policy.sources(root)
+            found = [
+                p.relative_to(root).as_posix()
+                for p in discovered.bash + discovered.workflows
+            ]
+            findings = [str(f) for f in policy.validate(root).findings]
         return found, findings
 
     BAD = "#!/usr/bin/env bash\nmapfile -t a <f\n"
@@ -280,7 +333,8 @@ class DiscoveryTests(unittest.TestCase):
                 self.assertEqual(found, ["tool"])
 
     def test_ignores_non_bash_interpreters(self) -> None:
-        # A `sh` script has a POSIX problem, not a Bash-version one.
+        # A `sh` script has a POSIX problem, not a Bash-version one, so the
+        # TABLE skips it.
         found, _ = self.discover(
             {
                 "posix.sh": "#!/bin/sh\nmapfile -t a <f\n",
@@ -289,6 +343,26 @@ class DiscoveryTests(unittest.TestCase):
         )
         self.assertEqual(found, [])
 
+    def test_the_parse_set_takes_every_shell_script(self) -> None:
+        # ...but the parse check does not skip it: an unbalanced quote in a
+        # `#!/bin/sh` script is the same RUE-1511 bug, and before this the
+        # repository's one such file was parsed by nothing at all. A bare
+        # `.sh` with no shebang counts too, matching the pipefail gate's set
+        # so the two cover the same files.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "bashy.sh").write_text("#!/usr/bin/env bash\ntrue\n")
+            (root / "posix.sh").write_text("#!/bin/sh\ntrue\n")
+            (root / "bare.sh").write_text("true\n")
+            (root / "tool.py").write_text("#!/usr/bin/env python3\n")
+            discovered = policy.sources(root)
+            self.assertEqual([p.name for p in discovered.bash], ["bashy.sh"])
+            self.assertEqual([p.name for p in discovered.shell], ["bare.sh", "posix.sh"])
+            self.assertEqual(
+                [p.name for p in discovered.parseable],
+                ["bare.sh", "bashy.sh", "posix.sh"],
+            )
+
     def test_workflows_are_scanned_as_workflows(self) -> None:
         found, _ = self.discover(
             {".github/workflows/ci.yml": "jobs:\n  a:\n    runs-on: ubuntu-latest\n"}
@@ -296,17 +370,366 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(found, [".github/workflows/ci.yml"])
 
 
+class InterpreterTests(unittest.TestCase):
+    """Which bash the parse check picks, and what it admits about it.
+
+    A Bash 5 is a usable but weaker parser here, so the question is not whether
+    to accept one -- CI's Linux runners have nothing else -- but whether a run
+    on one can be mistaken for a run at the baseline. It must not be: `;;&` is
+    a syntax error on 3.2 and legal on 5, so a 5.x reporting a clean parse has
+    proved strictly less than it appears to. That is the RUE-1506 shape.
+    """
+
+    def stub(self, directory: str, body: str) -> Path:
+        """A fake `bash` answering the version probe however we like.
+
+        A real Bash 5 is what CI's Linux runners have and this host does not,
+        so the cases that matter most are the ones no macOS test could
+        otherwise reach.
+        """
+        path = Path(directory) / "stub-bash"
+        path.write_text("#!/bin/sh\n" + body)
+        path.chmod(0o755)
+        return path
+
+    def resolve(self, body: str):
+        with tempfile.TemporaryDirectory() as directory:
+            stub = self.stub(directory, body)
+            with unittest.mock.patch.dict(
+                os.environ, {policy.BASELINE_ENV: str(stub)}
+            ):
+                return policy.parse_interpreter()
+
+    def test_a_bash_5_is_usable_but_not_at_the_baseline(self) -> None:
+        found = self.resolve('echo "5 5.2.37(1)-release"\n')
+        self.assertIsNotNone(found)
+        self.assertFalse(found.at_baseline)
+
+    def test_a_bash_4_is_usable_but_not_at_the_baseline(self) -> None:
+        found = self.resolve('echo "4 4.4.20(1)-release"\n')
+        self.assertIsNotNone(found)
+        self.assertFalse(found.at_baseline)
+
+    def test_a_bash_3_is_at_the_baseline_and_reports_its_version(self) -> None:
+        found = self.resolve('echo "3 3.2.57(1)-release"\n')
+        self.assertIsNotNone(found)
+        self.assertTrue(found.at_baseline)
+        self.assertEqual(found.version, "3.2.57(1)-release")
+
+    def test_a_non_bash_interpreter_is_not_usable(self) -> None:
+        # `BASH_VERSINFO` is unset, so the probe answers with neither field.
+        self.assertIsNone(self.resolve("echo\n"))
+
+    def test_an_interpreter_that_fails_the_probe_is_not_usable(self) -> None:
+        self.assertIsNone(self.resolve('echo "3 3.2.57(1)-release"\nexit 3\n'))
+
+    def test_a_missing_interpreter_is_not_usable(self) -> None:
+        with unittest.mock.patch.dict(
+            os.environ, {policy.BASELINE_ENV: "/nonexistent/bash"}
+        ):
+            self.assertIsNone(policy.parse_interpreter())
+
+    def test_the_override_is_not_advisory(self) -> None:
+        # A fallback here would let a broken override be silently replaced by
+        # whatever bash the host happens to have, which is the same "believed
+        # because it passed" failure in miniature.
+        with unittest.mock.patch.dict(
+            os.environ, {policy.BASELINE_ENV: "/nonexistent/bash"}
+        ):
+            self.assertIsNone(policy.parse_interpreter())
+        self.assertIsNotNone(policy.probe(BASELINE_BASH))
+
+
+class ParseTests(unittest.TestCase):
+    """`bash -n`, on whatever bash this host has.
+
+    The cases split by which interpreter can see them, and the split is the
+    design: what every bash rejects is checked on every host, and what only
+    3.2 rejects is checked where a 3.2 exists.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.interpreter = policy.parse_interpreter()
+        if cls.interpreter is None:
+            raise unittest.SkipTest("no bash on this host, so `bash -n` cannot run")
+
+    def failures(self, body: str, name: str = "probe.sh") -> list[policy.ParseFailure]:
+        failures, _ = self.check(body, name)
+        return failures
+
+    def check(self, body: str, name: str = "probe.sh"):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            script = root / name
+            script.write_text(
+                "#!/usr/bin/env bash\nset -euo pipefail\n" + textwrap.dedent(body)
+            )
+            return policy.parse_check([script], root, self.interpreter)
+
+    def test_the_rue_1511_break_fails_to_parse(self) -> None:
+        # The decisive case. The construct table calls this file clean; here it
+        # is caught, without any rule describing it, on any bash.
+        failures = self.failures(UNBALANCED_QUOTE)
+        self.assertEqual([failure.path for failure in failures], ["probe.sh"])
+        self.assertIn("unexpected EOF", failures[0].detail)
+
+    def test_the_message_warns_that_the_named_line_is_not_the_mistake(self) -> None:
+        # Bash names where the parser gave up, which here is the end of the
+        # file. A contributor sent to that line finds nothing wrong with it.
+        message = str(self.failures(UNBALANCED_QUOTE)[0])
+        self.assertIn("PARSER gave up", message)
+        self.assertIn("unbalanced quote", message)
+
+    def test_the_same_command_correctly_quoted_parses(self) -> None:
+        # The repair, and the correction to the diagnosis recorded with it: a
+        # `$(...)` spanning a line continuation with a quoted parenthesised
+        # argument is fine everywhere, including Bash 3.2. The missing `"` was
+        # the whole defect.
+        self.assertEqual(self.failures(BALANCED_QUOTE), [])
+
+    def test_a_bash_4_builtin_is_not_a_parse_failure(self) -> None:
+        # Why the table is not retired: `mapfile` parses perfectly on 3.2 and
+        # then exits 127 at run time, and `${v:1:-1}` parses and answers
+        # wrongly. Neither is visible to a parser; only the table sees them.
+        self.assertEqual(self.failures('mapfile -t a <"$f"\n'), [])
+        self.assertEqual(self.failures("v=${w:1:-1}\n"), [])
+
+    def test_syntax_only_bash_3_2_rejects_needs_a_bash_3_2(self) -> None:
+        # Why the macos-15 leg exists. `;;&` is on the construct table too, so
+        # nothing escapes -- but the parse check's own answer here depends on
+        # the interpreter, and that dependence is the reason a Linux run must
+        # not be reported as a baseline run.
+        failures = self.failures(BASELINE_ONLY_SYNTAX)
+        if self.interpreter.at_baseline:
+            self.assertEqual(len(failures), 1)
+        else:
+            self.assertEqual(failures, [])
+
+    def test_the_portable_spellings_parse(self) -> None:
+        self.assertEqual(
+            self.failures(
+                """
+                targets=()
+                while :; do
+                    target=""
+                    IFS= read -r target || [[ -n "$target" ]] || break
+                    targets+=("$target")
+                done <"$file"
+                covered="$(list "a (b) c" 2>/dev/null)"
+                cat <<'EOF'
+                literal $( text
+                EOF
+                echo "${targets[$((${#targets[@]} - 1))]}" "$covered"
+                """
+            ),
+            [],
+        )
+
+    def test_a_runtime_shopt_makes_bash_n_over_catch(self) -> None:
+        # The check's one wrong answer, and the reason an escape exists.
+        # `bash -n` parses without executing, so it never runs the `shopt`
+        # that makes `@(a|b)` legal -- while the file itself RUNS correctly on
+        # the same interpreter, asserted below so this cannot rot into a claim
+        # about a file that was broken all along.
+        body = 'shopt -s extglob\ncase "$x" in @(abc|def)) echo yes ;; esac\n'
+        self.assertEqual(len(self.failures(body)), 1)
+        with tempfile.TemporaryDirectory() as directory:
+            script = Path(directory) / "extglob.sh"
+            script.write_text("#!/usr/bin/env bash\nx=abc\n" + body)
+            ran = subprocess.run(
+                [self.interpreter.path, str(script)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(ran.returncode, 0, ran.stderr)
+        self.assertEqual(ran.stdout.strip(), "yes")
+
+    def test_the_annotation_exempts_the_file(self) -> None:
+        failures, exemptions = self.check(
+            "# bash-parse-ok: extglob is enabled at run time\n"
+            'shopt -s extglob\ncase "$x" in @(abc|def)) echo yes ;; esac\n'
+        )
+        self.assertEqual(failures, [])
+        self.assertEqual([e.reason for e in exemptions], ["extglob is enabled at run time"])
+
+    def test_the_annotation_must_be_a_real_comment(self) -> None:
+        # Inside a string it is text, exactly as `# bash-baseline-ok:` is.
+        failures, exemptions = self.check(
+            'X="# bash-parse-ok: fake"\n'
+            'shopt -s extglob\ncase "$x" in @(abc|def)) echo yes ;; esac\n'
+        )
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(exemptions, [])
+
+    def test_a_leading_dash_filename_is_not_read_as_options(self) -> None:
+        # Without `--`, bash consumes `-weird.sh` as flags and the usage dump
+        # is reported as that file's syntax error.
+        self.assertEqual(self.failures("true\n", name="-weird.sh"), [])
+        failures = self.failures(UNBALANCED_QUOTE, name="-weird.sh")
+        self.assertEqual(len(failures), 1)
+        self.assertNotIn("invalid option", failures[0].detail)
+
+    def test_the_summary_names_the_interpreter_and_its_tier(self) -> None:
+        # The positive half of the visibility contract: a run that DID parse
+        # says which interpreter did it and whether that was the baseline, so
+        # "53 scanned" can never be mistaken for "53 parsed at 3.2".
+        with tempfile.TemporaryDirectory() as directory:
+            (Path(directory) / "probe.sh").write_text("#!/usr/bin/env bash\ntrue\n")
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), directory],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("1 script(s) parsed by", result.stdout)
+        self.assertIn(self.interpreter.version, result.stdout)
+        expected = "at the baseline" if self.interpreter.at_baseline else "above the"
+        self.assertIn(expected, result.stdout)
+
+
+class ShortfallTests(unittest.TestCase):
+    """What a run says when it could not reach the baseline, and how loudly.
+
+    Not a detail. Every host but a Mac is in one of these two states, so this
+    IS the check's behaviour almost everywhere it runs. It proceeds rather than
+    refusing, because a Bash 5 still catches the RUE-1511 class -- but it never
+    proceeds silently, and on the one runner that is supposed to have a 3.2 the
+    CI step passes `--require-baseline-bash`, so an interpreter that moved or
+    aged into 5.x fails the build instead of downgrading the check unnoticed.
+    """
+
+    def run_gate(self, bash: str, *flags: str) -> subprocess.CompletedProcess[str]:
+        """The shipped tool, against a one-script tree, on a chosen bash.
+
+        A subprocess rather than a call into `main`, because the contract under
+        test is the exit status and the two streams a CI step actually sees.
+        """
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "probe.sh").write_text("#!/usr/bin/env bash\ntrue\n")
+            interpreter = root / ("absent-bash" if bash == "absent" else "stub-bash")
+            if bash != "absent":
+                interpreter.write_text(f'#!/bin/sh\necho "{bash}"\n')
+                interpreter.chmod(0o755)
+            environ = dict(os.environ)
+            environ[policy.BASELINE_ENV] = str(interpreter)
+            return subprocess.run(
+                [sys.executable, str(SCRIPT), directory, *flags],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=environ,
+            )
+
+    def test_no_bash_notes_what_went_unparsed(self) -> None:
+        result = self.run_gate("absent")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("note: no bash at", result.stderr)
+        self.assertIn("1 script(s) NOT parsed", result.stdout)
+
+    def test_no_bash_fails_under_require_baseline_bash(self) -> None:
+        result = self.run_gate("absent", "--require-baseline-bash")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("error: no bash at", result.stderr)
+
+    def test_a_bash_5_parses_but_says_it_is_above_the_baseline(self) -> None:
+        # The Linux CI case. The run is real and worth having -- it catches
+        # everything RUE-1511 was -- but the summary must not let it read as a
+        # baseline run, and the note names what it could not see.
+        result = self.run_gate("5 5.2.15(1)-release")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("note: the parse check ran on Bash 5.2.15", result.stderr)
+        self.assertIn(";;&", result.stderr)
+        self.assertIn("above the baseline", result.stdout)
+
+    def test_a_bash_5_fails_under_require_baseline_bash(self) -> None:
+        # The point of the flag: on macos-15 an above-baseline bash is not a
+        # weaker pass, it is a broken assumption about the runner.
+        result = self.run_gate("5 5.2.15(1)-release", "--require-baseline-bash")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("error: the parse check ran on Bash 5.2.15", result.stderr)
+
+    def test_a_bash_3_reports_no_shortfall_and_satisfies_the_flag(self) -> None:
+        result = self.run_gate("3 3.2.57(1)-release", "--require-baseline-bash")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("at the baseline", result.stdout)
+        self.assertEqual(result.stderr, "")
+
+    def test_an_empty_discovery_set_fails_even_with_the_flag(self) -> None:
+        # The one state where every other signal is green and nothing has been
+        # proven: the interpreter is at the baseline, the flag is satisfied,
+        # and no file was checked. ci.yml makes the same call for the fmt
+        # job's target query sixteen lines above this gate's step (RUE-1152).
+        with tempfile.TemporaryDirectory() as directory:
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), directory, "--require-baseline-bash"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("error: no shell scripts found", result.stderr)
+        self.assertNotIn("policy valid", result.stdout)
+
+    def test_the_library_entry_point_keeps_no_such_floor(self) -> None:
+        # The floor belongs to the tool, not to `validate()`: the discovery
+        # tests scan deliberately empty trees.
+        with tempfile.TemporaryDirectory() as directory:
+            report = policy.validate(Path(directory))
+        self.assertEqual(report.scripts, 0)
+        self.assertEqual(report.findings, [])
+
+    def test_the_construct_table_still_runs_without_an_interpreter(self) -> None:
+        # The halves are independent: a host with no bash at all still gets
+        # every table finding, which is what makes the `fmt` job authoritative
+        # for that half.
+        with tempfile.TemporaryDirectory() as directory:
+            (Path(directory) / "probe.sh").write_text(
+                "#!/usr/bin/env bash\nmapfile -t a <f\n"
+            )
+            environ = dict(os.environ)
+            environ[policy.BASELINE_ENV] = str(Path(directory) / "absent-bash")
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), directory],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=environ,
+            )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("`mapfile`/`readarray` builtin", result.stderr)
+
+
 class RepositoryTests(unittest.TestCase):
-    def test_repository_is_clean(self) -> None:
-        # Under Buck this test runs from a sandbox holding only the validator,
-        # where a whole-tree scan would find nothing and pass vacuously -- the
-        # exact shape of fail-open this policy exists to prevent. Skip loudly
-        # instead; the authoritative scan is the `fmt` job's CI step.
+    def checkout(self) -> Path:
+        # These DO run under Buck, despite the sandbox holding only the
+        # validator: `SCRIPT.resolve()` follows the sandbox symlink back out
+        # to the real file, so `parent.parent` is the checkout and the
+        # whole-tree scan is genuine. The guard is for a copy of this file
+        # somewhere without a tree around it, where a scan would find nothing
+        # and pass vacuously -- the fail-open this policy exists to prevent.
         root = SCRIPT.resolve().parent.parent
         if not (root / "AGENTS.md").exists():
-            self.skipTest("not a repository checkout; scan runs as a CI step")
-        findings, _ = policy.validate(root)
-        self.assertEqual([str(finding) for finding in findings], [])
+            self.skipTest("not a repository checkout; the scan runs as a CI step")
+        return root
+
+    def test_repository_is_clean(self) -> None:
+        self.assertEqual(
+            [str(finding) for finding in policy.validate(self.checkout()).findings], []
+        )
+
+    def test_repository_parses(self) -> None:
+        root = self.checkout()
+        interpreter = policy.parse_interpreter()
+        if interpreter is None:
+            self.skipTest("no bash on this host")
+        report = policy.validate(root, interpreter)
+        self.assertEqual([str(failure) for failure in report.failures], [])
+        # A parse check over nothing would pass just as quietly.
+        self.assertGreater(report.scripts, 0)
 
 
 class MechanismTests(unittest.TestCase):
@@ -381,11 +804,19 @@ class MechanismTests(unittest.TestCase):
 
 class HostTests(unittest.TestCase):
     def test_a_mac_always_has_the_baseline_interpreter(self) -> None:
-        # Guards the skip above: on a macOS host the demonstrations MUST run,
-        # so a silently-skipping suite cannot become the normal state there.
+        # Guards both skips above: on a macOS host the demonstrations and the
+        # parse check MUST run, so a silently-skipping suite cannot become the
+        # normal state there -- which is the state ci.yml's macos-15 leg
+        # depends on, and enforces from its side with --require-baseline-bash.
         if platform.system() != "Darwin":
             self.skipTest("not macOS")
         self.assertEqual(baseline_bash_version(), 3)
+        with unittest.mock.patch.dict(os.environ):
+            os.environ.pop(policy.BASELINE_ENV, None)
+            interpreter = policy.parse_interpreter()
+        self.assertIsNotNone(interpreter)
+        self.assertEqual(interpreter.path, BASELINE_BASH)
+        self.assertTrue(interpreter.at_baseline, interpreter.version)
 
 
 if __name__ == "__main__":

--- a/scripts/validate-python-baseline.py
+++ b/scripts/validate-python-baseline.py
@@ -63,6 +63,24 @@ WHAT THIS SCAN CANNOT SEE, stated plainly so the gate is not read as a proof:
     cannot be told apart from syntax the floor legitimately allows -- so such a
     file is reported as unscanned rather than guessed at, and the authoritative
     run is the `fmt` job's CI step, which is at or above the floor.
+  - Symmetrically, ABOVE the floor it is too permissive: a scanner on 3.14
+    parses a PEP 701 f-string that 3.11 would reject and calls the file clean.
+    The Bash gate closes its version of that gap by parsing with a real 3.2 on
+    ci.yml's macos-15 leg (RUE-1512). The Python counterpart is
+    `ast.parse(source, feature_version=(3, 11))`, which needs no 3.11 to be
+    installed -- it has existed since 3.8 and runs on whatever interpreter is
+    here. It is deliberately NOT used, and the reason is coverage rather than
+    availability: `feature_version` is documented best-effort, it gates only
+    what CPython's own parser gates by version, and it cannot manufacture
+    grammar the RUNNING interpreter lacks. Measured on 3.10.3: `(3, 9)`
+    correctly rejects a `match` statement, but `except*` (3.11, at the floor
+    and therefore legal) fails at every `feature_version`, because 3.10 cannot
+    parse it at all. So it would reject legal files on old hosts while still
+    missing what has no version gate. Pinning a real 3.11 in CI is the change
+    that would make a sound check possible; until then this is stated rather
+    than approximated. What the gate CAN see without any of that -- version-
+    gated imports, attributes, and grammar with a distinct AST node -- it sees
+    from any host, which is why the table is not redundant either.
   - Grammar with no distinct AST node is invisible: PEP 701 f-strings (3.12)
     and PEP 696 TypeVar defaults (3.13) parse into the same nodes as their
     older spellings on an interpreter new enough to accept them.

--- a/scripts/validate-shell-bash-baseline.py
+++ b/scripts/validate-shell-bash-baseline.py
@@ -42,6 +42,92 @@ job may use the builtin sixteen lines above the step that runs this gate. A
 Annotate a reviewed exception with `# bash-baseline-ok: <reason>`. It has to
 sit in a real comment -- inside a string it is text, not an annotation -- and
 it silences its whole line.
+
+TWO CHECKS (RUE-1512), and neither implies the other's coverage.
+
+The table above names constructs. That is its strength -- it can say which
+version introduced a thing and how to spell it on 3.2 -- and it is also its
+ceiling: it cannot flag a file that does not PARSE, because a syntax error is
+not a construct and there is nothing to point at. RUE-1511 shipped one into a
+branch, in this shape:
+
+    if ! covered="$("$buck2" uquery \\
+        "attrfilter(labels, a, //crates/...) except (attrfilter(...))" \\
+        2>/dev/null); then
+
+The closing `"` that should follow the `)` is missing, so the double quote
+opened after `covered=` never closes. Bash reads to end of file looking for it
+and reports:
+
+    line 9: unexpected EOF while looking for matching `"'
+    line 12: syntax error: unexpected end of file
+
+Neither line is the mistake -- they are where the PARSER gave up, several lines
+past it and usually at the end of the file, which is why the error reads as a
+puzzle. Nothing on the table is used, so the gate answered `bash baseline
+policy valid: 53 file(s) scanned` and the break was found by running the suite
+by hand.
+
+So the second check is `bash -n`: parse the script, execute nothing. It needs
+no name for what it finds, which is exactly the class the table cannot
+enumerate. It does not replace the table either -- `mapfile` and `${v:1:-1}`
+parse perfectly on 3.2 and then exit 127 or answer wrongly -- so a file can be
+flawlessly parseable and still dead on a Mac. Run both.
+
+WHICH BASH, and why it matters more than it looks. Measured, not assumed:
+
+  both 3.2 and 5.2 reject   an unbalanced quote, an unterminated `if`, an
+                            unclosed heredoc -- the RUE-1511 class. ANY bash
+                            catches these, so this half runs wherever a bash
+                            exists, including Linux CI.
+  only 3.2 rejects          `;;&`, `;&`, `coproc`. Bash 5 parses all three
+                            happily, so a `bash -n` on Linux is genuinely
+                            weaker and must not be reported as though it were
+                            not.
+  neither rejects           `mapfile`, `declare -A`, `declare -g`, `${v^^}` --
+                            syntax on every version, wrong behaviour or a
+                            runtime error on 3.2. The table's territory, not
+                            the parser's.
+  both reject WRONGLY       `@(a|b)` after a runtime `shopt -s extglob`. See
+                            the annotation below; this is the one direction in
+                            which the parse check over-catches.
+
+Note what this does NOT say: the RUE-1511 construct is not a Bash 4 feature and
+3.2 is not what broke on it. The comment left at the repaired site said 3.2
+"cannot parse a `$(...)` whose body spans a line continuation and contains a
+quoted argument with parentheses"; it can, and so can 5.2, once the quote is
+balanced. The bug was ordinary, which is the point -- an ordinary syntax error
+is invisible to a table of exotic constructs.
+
+So the parse check runs with the strictest bash the host has, prefers a 3.2
+when one exists, and says which it used. On ci.yml's macos-15 leg -- the only
+runner whose /bin/bash IS a 3.2 -- it runs with `--require-baseline-bash`, so a
+bash that moved or aged into 5.x fails the build instead of quietly downgrading
+the check. A check that cannot fail where it runs is worse than no check,
+because it is believed (RUE-1506).
+
+The parse check has its own annotation, `# bash-parse-ok: <reason>`, and it is
+file-level because a parse failure has no line worth attaching to. It exists
+for one real case: `bash -n` parses without executing, so it never runs a
+`shopt`, and
+
+    shopt -s extglob
+    case "$x" in @(abc|def)) echo yes ;; esac
+
+RUNS correctly on 3.2.57 and is rejected by `bash -n` on that same 3.2.57.
+There the file is right and the check is wrong. Keep the bar there: a genuine
+syntax error must be fixed, not annotated, and the reason is reviewed here the
+way `# bash-baseline-ok:` is. Every exemption is printed and counted, because
+the annotation stops checking the whole file.
+
+Workflow `run:` steps get the table only. A step's text is not final Bash: the
+runner substitutes its `${{ }}` expressions first, and a block scalar's uniform
+indentation is not part of the script (an indented heredoc terminator would
+read as an unterminated heredoc). Parsing one as written can therefore differ
+from what the runner parses in both directions, and a gate with false positives
+is a gate that gets switched off. `actionlint` shellchecks those blocks in its
+own job. Extending the parse check there needs the reconstruction done
+properly, and is a separate decision.
 """
 
 from __future__ import annotations
@@ -49,12 +135,29 @@ from __future__ import annotations
 import argparse
 import os
 import re
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 from typing import NamedTuple
 
 
 ROOT = Path(__file__).resolve().parent.parent
+
+# The interpreter this policy is written against. macOS has shipped GNU Bash
+# 3.2.57 as `/bin/bash` since 2007 and will not ship a GPLv3 one, so the floor
+# is a concrete binary at a concrete path rather than a version to hunt for.
+BASELINE_BASH = "/bin/bash"
+BASELINE_MAJOR = 3
+
+# Names the one interpreter the parse check may use -- a hand-built 3.2 on a
+# Linux host, or a deliberately wrong one in a test. When it is set, nothing
+# else is tried: a fallback would make the override advisory, and an override
+# that can be silently ignored is worse than none. It is checked for version,
+# not for sanity: pointing it at macOS's /bin/sh passes the 3.x test, because
+# that IS Bash 3.2, and then parses everything in POSIX mode. Point it at a
+# bash.
+BASELINE_ENV = "RUE_BASELINE_BASH"
 
 # Build outputs and vendored trees are not ours to police, and `buck-out` in
 # particular makes the scan's cost and result depend on whether a build has run.
@@ -72,7 +175,19 @@ SKIP_DIRECTORIES = {
 # `#!/usr/bin/env bash`, `#!/bin/bash`, `#!/usr/bin/env -S bash -eu`.
 BASH_SHEBANG = re.compile(r"^#!\s*\S*(?:\s+-\S+)*\s*(?:\S*/)?bash\b|^#!\S*/bash\b")
 
+# Any shell. Only the PARSE check uses this: a `#!/bin/sh` script has a POSIX
+# problem rather than a Bash-version one, so the construct table rightly
+# ignores it -- but an unbalanced quote in it is the same syntax error, and
+# reaches trunk green if nothing parses the file. Deliberately the pipefail
+# gate's spelling, so the two gates cover the same set of files.
+SHELL_SHEBANG = re.compile(r"^#!.*\b(?:ba|da|k|z)?sh\b")
+
 ALLOW = re.compile(r"#\s*bash-baseline-ok:\s*(?P<reason>\S.*?)\s*$")
+
+# The parse check's own escape, and it needs a separate one: a parse failure
+# has no reliable line to annotate, since bash reports where it gave up rather
+# than where the mistake is. This is file-level and silences the whole file.
+PARSE_ALLOW = re.compile(r"#\s*bash-parse-ok:\s*(?P<reason>\S.*?)\s*$")
 
 # A parameter name, including the positional and special parameters: `${1^^}`
 # and `${@Q}` are as unavailable on 3.2 as `${name^^}` is.
@@ -422,6 +537,182 @@ def scan_workflow(source: str, path: str) -> list[Finding]:
     return findings
 
 
+class Interpreter(NamedTuple):
+    path: str
+    version: str
+    major: int
+
+    @property
+    def at_baseline(self) -> bool:
+        """Whether this interpreter can reject what only Bash 3.2 rejects.
+
+        A Bash 5 accepts `;;&`, `;&`, and `coproc`, so it is a real but weaker
+        parser for this policy. The distinction is carried in the type rather
+        than recomputed at each use, because every message that reports a clean
+        parse has to say which of the two it was.
+        """
+        return self.major == BASELINE_MAJOR
+
+
+def probe(candidate: str) -> Interpreter | None:
+    """Identify `candidate` as a bash, by asking it rather than by its path."""
+    try:
+        result = subprocess.run(
+            [candidate, "-c", 'echo "${BASH_VERSINFO[0]:-} ${BASH_VERSION:-}"'],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    fields = result.stdout.split()
+    # A non-bash interpreter leaves both variables unset, or answers with
+    # something that is not a version at all.
+    if len(fields) != 2 or not fields[0].isdigit():
+        return None
+    return Interpreter(candidate, fields[1], int(fields[0]))
+
+
+def parse_interpreter() -> Interpreter | None:
+    """A 3.2 if this host has one, else the first other bash it finds.
+
+    Preferring rather than requiring, because the two tiers catch different
+    things and the weaker one is worth having. An unbalanced quote -- the
+    RUE-1511 break -- is a syntax error on every bash, so a Linux runner's 5.x
+    catches it on every pull request; `;;&` is a syntax error only on 3.2, so
+    that half waits for the macos-15 leg. Requiring 3.2 outright would trade
+    the first for nothing, and reporting a 5.x as though it were the baseline
+    would claim the second without having it.
+    """
+    override = os.environ.get(BASELINE_ENV)
+    if override:
+        return probe(override)
+    candidates = [BASELINE_BASH]
+    on_path = shutil.which("bash")
+    if on_path and on_path not in candidates:
+        candidates.append(on_path)
+    # `/bin/bash` first, because that is the one macOS pins at 3.2 while a
+    # developer's PATH may well put a Homebrew 5.x ahead of it -- and this
+    # check wants the stricter parser, not the newer one.
+    fallback = None
+    for candidate in candidates:
+        interpreter = probe(candidate)
+        if interpreter is None:
+            continue
+        if interpreter.at_baseline:
+            return interpreter
+        fallback = fallback or interpreter
+    return fallback
+
+
+class ParseFailure(NamedTuple):
+    path: str
+    version: str
+    detail: str
+
+    def __str__(self) -> str:
+        return (
+            f"{self.path}: Bash {self.version} cannot parse this file -- "
+            f"{self.detail}. The line named is where the PARSER gave up, not "
+            "necessarily the mistake: look upward from it for an unbalanced "
+            "quote or bracket, an unclosed heredoc, or a missing `fi`/`done`. "
+            "If the file is correct and this is `bash -n` refusing syntax that "
+            "a runtime `shopt -s extglob` would enable -- it parses without "
+            "executing, so it never sees the `shopt` -- annotate the file with "
+            "`# bash-parse-ok: <reason>`"
+        )
+
+
+class ParseExemption(NamedTuple):
+    path: str
+    reason: str
+
+    def __str__(self) -> str:
+        return f"{self.path}: not parsed (# bash-parse-ok: {self.reason})"
+
+
+def parse_annotation(source: str) -> str | None:
+    """The reviewed reason this file is exempt from `bash -n`, if any.
+
+    File-level rather than per-line, because a parse failure has no trustworthy
+    line to attach to. It has to sit in a real comment, so a file quoting this
+    policy's own prose does not exempt itself.
+    """
+    for raw in source.splitlines():
+        _, comment = split_code(raw)
+        match = PARSE_ALLOW.search(comment)
+        if match:
+            return match.group("reason")
+    return None
+
+
+def parse_check(
+    scripts: list[Path], root: Path, interpreter: Interpreter
+) -> tuple[list[ParseFailure], list[ParseExemption]]:
+    """Parse each script with `interpreter`, executing nothing.
+
+    `bash -n` reads the file, builds the parse tree, and stops, so this costs a
+    process spawn per script and cannot run any of their side effects. That
+    matters here: these scripts drive builds, and a gate that ran them would be
+    a gate nobody could afford to run on every commit.
+
+    Not executing is also this check's one real blind spot in reverse. `shopt`
+    takes effect when it RUNS, so a file that enables `extglob` and then uses
+    `@(a|b)` executes correctly on 3.2 and is rejected by `bash -n` on the same
+    interpreter. That file is right and the check is wrong, which is what
+    `# bash-parse-ok:` is for.
+    """
+    failures: list[ParseFailure] = []
+    exemptions: list[ParseExemption] = []
+    for path in scripts:
+        relative = path.relative_to(root).as_posix()
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        reason = parse_annotation(source)
+        if reason is not None:
+            exemptions.append(ParseExemption(relative, reason))
+            continue
+        try:
+            result = subprocess.run(
+                # `--` because a repository-root file named `-x.sh` would
+                # otherwise be read as options, and the usage dump reported as
+                # that file's syntax error.
+                [interpreter.path, "-n", "--", relative],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                check=False,
+                # Parsing is linear and these are small files, so a hang means
+                # something pathological. Fail it rather than sit until the CI
+                # job's own timeout, where the cause is far less obvious.
+                timeout=60,
+            )
+        except subprocess.TimeoutExpired:
+            failures.append(
+                ParseFailure(relative, interpreter.version, "`bash -n` timed out")
+            )
+            continue
+        if result.returncode == 0:
+            continue
+        # Bash prefixes every diagnostic with the script name it was given.
+        # Repeating it in a message that already opens with the path is noise.
+        lines = []
+        for line in result.stderr.splitlines():
+            line = line.strip()
+            if line.startswith(f"{relative}: "):
+                line = line[len(relative) + 2 :]
+            if line:
+                lines.append(line)
+        detail = "; ".join(lines) or f"`bash -n` exited {result.returncode}"
+        failures.append(ParseFailure(relative, interpreter.version, detail))
+    return failures, exemptions
+
+
 def _prune(directory: Path, names: list[str]) -> list[str]:
     """Directory names to descend into.
 
@@ -441,9 +732,24 @@ def _prune(directory: Path, names: list[str]) -> list[str]:
     return kept
 
 
-def sources(root: Path) -> tuple[list[Path], list[Path]]:
-    """Every bash script and workflow file under `root`."""
+class Sources(NamedTuple):
+    # Bash-shebang scripts: the construct table's set, and parsed as well.
+    bash: list[Path]
+    # Other shell scripts -- a `#!/bin/sh` shebang, or a bare `.sh`. The table
+    # skips these on purpose (a POSIX policy is not a Bash-version policy), but
+    # a syntax error in one is the same bug, so the parse check takes them.
+    shell: list[Path]
+    workflows: list[Path]
+
+    @property
+    def parseable(self) -> list[Path]:
+        return sorted(self.bash + self.shell)
+
+
+def sources(root: Path) -> Sources:
+    """Every shell script and workflow file under `root`."""
     scripts: list[Path] = []
+    shell: list[Path] = []
     workflows: list[Path] = []
     for directory, names, files in os.walk(root):
         here = Path(directory)
@@ -464,38 +770,146 @@ def sources(root: Path) -> tuple[list[Path], list[Path]]:
                     first = handle.readline()
             except (OSError, UnicodeDecodeError):
                 continue
-            # Unlike the pipefail policy, the shebang is the whole question: it
-            # decides which bash runs the file, so a `.sh` without one is not
-            # this gate's business.
+            # For the TABLE the shebang is the whole question: it decides which
+            # bash runs the file, so a `.sh` without one is not that policy's
+            # business. The parse check has no such dependence -- a syntax
+            # error is one in any shell -- so it takes the wider set.
             if BASH_SHEBANG.match(first):
                 scripts.append(path)
-    return sorted(scripts), sorted(workflows)
+            elif path.suffix == ".sh" or SHELL_SHEBANG.match(first):
+                shell.append(path)
+    return Sources(sorted(scripts), sorted(shell), sorted(workflows))
 
 
-def validate(root: Path) -> tuple[list[Finding], int]:
+class Report(NamedTuple):
+    findings: list[Finding]
+    failures: list[ParseFailure]
+    exemptions: list[ParseExemption]
+    # Files the table scanned: bash scripts plus macOS-capable workflows.
+    scanned: int
+    # Scripts the parse check is responsible for, parsed or not. Reported even
+    # when it did not run, because "44 unparsed" is the honest summary of a
+    # host with no bash and "53 scanned" would read like full coverage.
+    scripts: int
+
+
+def validate(root: Path, interpreter: Interpreter | None = None) -> Report:
+    """Both checks over one discovery pass.
+
+    Discovery is shared deliberately: the parse check's claim is that it covers
+    at least the files the table does, so a second, subtly different walk would
+    be a way for a script to fall between them.
+    """
     findings: list[Finding] = []
-    scripts, workflows = sources(root)
-    for path in scripts:
+    found = sources(root)
+    for path in found.bash:
         relative = path.relative_to(root).as_posix()
         findings.extend(scan(path.read_text(encoding="utf-8"), relative))
-    for path in workflows:
+    for path in found.workflows:
         relative = path.relative_to(root).as_posix()
         findings.extend(scan_workflow(path.read_text(encoding="utf-8"), relative))
-    return findings, len(scripts) + len(workflows)
+    parseable = found.parseable
+    failures, exemptions = (
+        parse_check(parseable, root, interpreter) if interpreter else ([], [])
+    )
+    return Report(
+        findings,
+        failures,
+        exemptions,
+        len(found.bash) + len(found.workflows),
+        len(parseable),
+    )
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("root", nargs="?", type=Path, default=ROOT)
+    parser.add_argument(
+        "--require-baseline-bash",
+        action="store_true",
+        help=(
+            f"fail unless the parse check ran on a Bash {BASELINE_MAJOR}.x, "
+            "rather than accepting a newer one or none at all. Pass it "
+            "wherever the host is supposed to have one -- ci.yml's macos-15 "
+            "leg -- so an interpreter that moved or aged into 5.x fails the "
+            "build instead of quietly downgrading the check."
+        ),
+    )
     args = parser.parse_args()
 
-    findings, scanned = validate(args.root)
-    if findings:
-        for finding in findings:
-            print(f"error: {finding}", file=sys.stderr)
+    interpreter = parse_interpreter()
+    report = validate(args.root, interpreter)
+
+    for finding in report.findings:
+        print(f"error: {finding}", file=sys.stderr)
+    for failure in report.failures:
+        print(f"error: {failure}", file=sys.stderr)
+    # An exemption is a reviewed decision, so it passes -- but it is never
+    # silent, because the whole file stops being checked.
+    for exemption in report.exemptions:
+        print(f"note: {exemption}", file=sys.stderr)
+    failed = bool(report.findings or report.failures)
+
+    # An empty discovery set is a broken walk, never a clean tree: the gate
+    # would report "0 file(s) scanned" and pass, which is the fail-open both
+    # halves exist to prevent, and `--require-baseline-bash` would certify the
+    # interpreter while certifying no coverage at all. ci.yml makes the same
+    # call sixteen lines above this gate's own step, for the same reason
+    # (RUE-1152). The library entry point `validate()` has no such floor, so a
+    # test may still scan a deliberately empty tree.
+    if report.scripts == 0:
+        print(
+            f"error: no shell scripts found under {args.root}. This gate is "
+            "run against a repository checkout, where that is a broken "
+            "discovery walk rather than a clean tree -- check the root "
+            "argument and SKIP_DIRECTORIES.",
+            file=sys.stderr,
+        )
+        failed = True
+
+    # The parse check's strength varies by host, so every run states which of
+    # the three it got. Silence would let "policy valid" mean any of them.
+    if interpreter is None:
+        looked = os.environ.get(BASELINE_ENV) or BASELINE_BASH
+        shortfall = (
+            f"no bash at {looked}, so {report.scripts} script(s) went "
+            "unparsed. The construct table names constructs and cannot see a "
+            "file that simply does not parse (RUE-1511)"
+        )
+    elif not interpreter.at_baseline:
+        shortfall = (
+            f"the parse check ran on Bash {interpreter.version}, above the "
+            "3.2 baseline. It catches what every bash rejects "
+            "-- unbalanced quotes, unterminated blocks -- but `;;&`, `;&`, and "
+            "`coproc` parse here and are a syntax error on macOS, so that half "
+            "belongs to ci.yml's macos-15 leg"
+        )
+    else:
+        shortfall = ""
+
+    if shortfall:
+        if args.require_baseline_bash:
+            print(f"error: {shortfall}", file=sys.stderr)
+            failed = True
+        else:
+            print(f"note: {shortfall}", file=sys.stderr)
+
+    if failed:
         return 1
 
-    print(f"bash baseline policy valid: {scanned} file(s) scanned")
+    summary = f"bash baseline policy valid: {report.scanned} file(s) scanned"
+    if interpreter is None:
+        summary += f"; {report.scripts} script(s) NOT parsed -- no bash here"
+    else:
+        where = "at the baseline" if interpreter.at_baseline else "above the baseline"
+        parsed = report.scripts - len(report.exemptions)
+        summary += (
+            f", {parsed} script(s) parsed by {interpreter.path} "
+            f"(Bash {interpreter.version}, {where})"
+        )
+        if report.exemptions:
+            summary += f", {len(report.exemptions)} annotated bash-parse-ok"
+    print(summary)
     return 0
 
 


### PR DESCRIPTION
`scripts/validate-shell-bash-baseline.py` (RUE-1506) flags Bash 4+ **constructs** from a curated table. A table only catches what someone thought to name.

## A correction, because it changed the design

This was filed claiming the motivating construct was "valid Bash 4+ that Bash 3.2 cannot parse." **That was wrong.** The line was missing its closing `"` — `covered="$(` opens a quote and `2>/dev/null); then` closes the command substitution without closing it — so *every* bash rejects it, 5.2.15 included. Restoring `)"` makes it parse on 3.2.

The class is therefore version-independent syntax errors **plus** genuinely 3.2-only constructs, which is a bigger gap than the issue described — and it means the parse check earns its place on Linux, not only on macOS. The same false diagnosis is corrected in `scripts/affected-targets`, where it shipped with RUE-1511.

| | Bash 3.2.57 | Bash 5.2.15 |
| --- | --- | --- |
| unbalanced quote, unclosed `$(`, unterminated `if` | reject | **reject** |
| `;;&`, `;&`, `coproc` | reject | accept |
| `mapfile`, `declare -A`, `${v^^}`, `declare -g` | accept | accept |
| runtime-`shopt` extglob | **reject wrongly** | reject wrongly |

Row 1 is what `fmt` now catches on every PR. Row 2 is what the macOS lane is for. Row 3 stays the construct table's job. Row 4 is why there is an escape hatch.

## What it does

`bash -n` over the same discovery walk, using the strictest bash the host has. `--require-baseline-bash` fails unless a 3.x did the parsing, so the macOS lane cannot quietly degrade to proving nothing. Every shortfall — no bash, a 5.x, a bad `RUE_BASELINE_BASH` — is an `error:` naming it, and an empty discovery set now fails rather than reporting `0 file(s) scanned` in green (the RUE-1152 shape, already fixed once in this workflow).

`bash -n` parses without executing, so it never sees a runtime `shopt -s extglob` and rejects a file that runs correctly on the baseline. `# bash-parse-ok: <reason>` exempts a file, and each exemption prints a `note:` and is counted, since it stops checking the whole file. A genuine syntax error is still fixed, not annotated. The test asserts an annotated fixture *runs* correctly on 3.2, so the escape cannot rot into a claim about a file that was broken all along.

The parse set is bash + `#!/bin/sh` + bare `.sh` — the pipefail gate's set, 44 scripts — because any shell's syntax error is a syntax error. The shebang-only rule stays for the construct table, where it decides which bash runs the file.

## Where it runs

Both macOS steps moved **above** the lane-selection gate. A PR touching only the shell policy does not select `native-macos-arm64`, so the only lane with a 3.2 was skipping the mechanism demonstrations — RUE-1506's own bug, reproduced. The demonstrations need Python and a `/bin/bash`, not buck2, so they run as `python3 scripts/test-validate-shell-bash-baseline.py`; ungating the old `buck2 test` step would have broken it, because `Install dotslash` is itself gated.

## Python analogue: declined, for the right reason

An earlier draft said a floor-version check "would never execute anywhere it could fail." That was wrong — `ast.parse(feature_version=…)` runs on any interpreter and the gate already imports `ast`. The real argument is coverage: on 3.10.3, `feature_version=(3, 9)` correctly rejects `match`, but `except*` fails at *every* `feature_version` because the running parser lacks the grammar. It would reject legal files on old hosts while missing what has no version gate.

Measured cost: 0.345s for the whole gate, 0.104s for the parse of 44 scripts.

Closes RUE-1512.