### PR TITLE
RUE-1510: project signatures from canonical declarations

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -306,7 +306,7 @@ fn warning_body_projection_stays_parse_only_and_below_rir_body_analysis() {
     );
     for forbidden in [
         "raw_declaration_bodies",
-        "raw_declaration_signatures",
+        "declaration_signature_projections",
         "body_inputs",
         "body_transactions",
         "module_rirs",
@@ -2087,7 +2087,7 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
         ) {
             assert!(
                 !code_identifiers(source).contains(&"RawDeclarationSignature"),
-                "compiler production module {name} escaped the raw-signature authority allowlist"
+                "compiler production module {name} escaped the signature-projection authority allowlist"
             );
         }
         if !matches!(
@@ -2128,21 +2128,21 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
         runtime
             .matches(".evaluate_raw_declaration_signature(")
             .count(),
-        1
+        0,
+        "the production signature projection must not reconstruct raw syntax"
+    );
+    assert!(!parsed.contains("fn evaluate_raw_declaration_signature("));
+    assert!(!parsed.contains("RawDeclarationSignatureLocator"));
+    assert!(
+        !runtime.contains("compiler.declaration-signature-projection"),
+        "the semantic nucleus must not retain a peer signature-projection family"
     );
     assert_eq!(
-        parsed
-            .matches("fn evaluate_raw_declaration_signature(")
-            .count(),
-        1
+        runtime.matches("project_semantic_signature(").count(),
+        1,
+        "the signature query must project the exact borrowed parsed declaration"
     );
-    assert_eq!(
-        runtime
-            .matches("\"compiler.raw-declaration-signature\"")
-            .count(),
-        1
-    );
-    assert_eq!(parsed.matches("RawDeclarationSignatureSyntax {").count(), 1);
+    assert!(!runtime.contains("parse_semantic_signature("));
     assert_eq!(
         runtime.matches(".evaluate_raw_declaration_body(").count(),
         1
@@ -2241,7 +2241,7 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
     let raw_const_terminal = runtime
         .split("enum RawConstSyntaxQueryValue")
         .nth(1)
-        .and_then(|tail| tail.split("struct RawDeclarationSignatureQueryKey").next())
+        .and_then(|tail| tail.split("struct RawDeclarationBodyQueryKey").next())
         .unwrap();
     for forbidden in [
         "CompileErrors",
@@ -2256,28 +2256,6 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
         assert!(
             !raw_const_terminal.contains(forbidden),
             "raw-constant terminal regained positioned/live parser or semantic payload: {forbidden}"
-        );
-    }
-    let raw_signature_terminal = runtime
-        .split("enum RawDeclarationSignatureQueryValue")
-        .nth(1)
-        .and_then(|tail| tail.split("struct RawDeclarationBodyQueryKey").next())
-        .unwrap();
-    for forbidden in [
-        "CompileErrors",
-        "Span",
-        "FileId",
-        "Spur",
-        "Ast",
-        "InstRef",
-        "Rir",
-        "TypeId",
-        "SemanticDefinitionToken",
-        "SemanticModuleToken",
-    ] {
-        assert!(
-            !raw_signature_terminal.contains(forbidden),
-            "raw-signature terminal regained positioned/live parser or semantic payload: {forbidden}"
         );
     }
     let raw_body_terminal = runtime
@@ -2364,7 +2342,7 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
         .split("pub(crate) struct RawDeclarationSignatureSyntax")
         .nth(1)
         .and_then(|tail| {
-            tail.split("pub(crate) enum RawDeclarationSignatureFailure")
+            tail.split("pub(crate) struct RawDeclarationBodySyntax")
                 .next()
         })
         .unwrap();
@@ -2408,26 +2386,6 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
         assert!(
             !declaration_import_payload.contains(forbidden),
             "declaration-import payload regained a positioned or live parser/semantic handle: {forbidden}"
-        );
-    }
-    let raw_signature_locator = parsed
-        .split("enum RawDeclarationSignatureLocator")
-        .nth(1)
-        .and_then(|tail| {
-            tail.split("pub(crate) struct ParsedDeclarationLocator")
-                .next()
-        })
-        .unwrap();
-    for forbidden in ["Vec<", "Arc<[Span]>", "Box<"] {
-        assert!(
-            !raw_signature_locator.contains(forbidden),
-            "raw-signature parser locator regained per-declaration heap storage: {forbidden}"
-        );
-    }
-    for required in ["Contiguous", "SplitStruct", "Extern"] {
-        assert!(
-            raw_signature_locator.contains(required),
-            "raw-signature parser locator lost bounded inline shape {required}"
         );
     }
     let declaration_import_locator = parsed

--- a/crates/rue-compiler/src/declaration_candidate.rs
+++ b/crates/rue-compiler/src/declaration_candidate.rs
@@ -128,13 +128,15 @@ pub(crate) enum RawConstSyntaxFailure {
     ParserCapabilityMismatch(DeclarationCandidateKey),
 }
 
-/// Parser-validated syntax for one declaration signature, detached from its
-/// source epoch and parser symbol universe.
+/// Parser-validated signature syntax retained only for an anonymous member
+/// produced during comptime evaluation, detached from its source epoch and
+/// parser symbol universe.
 ///
 /// Concatenating `declaration_fragments` reconstructs a body-free declaration
-/// for the exact key. Struct fragments omit every method declaration while
-/// retaining the struct header, directives, fields, and closing brace.
-/// `extern_abi` retains the surrounding ABI literal for an extern member.
+/// for that produced member. Named declarations instead project their exact
+/// canonical parsed nodes directly in `compiler.semantic-nucleus`; this
+/// transport remains only until anonymous members publish the same structured
+/// per-declaration artifact.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct RawDeclarationSignatureSyntax {
     pub(crate) declaration_fragments: Arc<[Arc<str>]>,
@@ -151,7 +153,7 @@ pub(crate) struct RawDeclarationSignatureSyntax {
 pub(crate) struct RawAccessorSignatureSyntax {
     /// The accessor's exact body. Its declaration-shape rules include a
     /// trailing-yield check even when no caller demands body analysis, so this
-    /// one signature query legitimately depends on its own body.
+    /// anonymous-member transport legitimately retains its own body.
     pub(crate) body: Arc<str>,
     /// Every method the accessor's owner declares — its name, whether it is
     /// itself an accessor, and the method names its body calls on its own
@@ -174,16 +176,6 @@ pub(crate) struct RawAccessorSignatureSyntax {
     /// Empty for an accessor with no owning type, or whose owner declares no
     /// other methods.
     pub(crate) owner_methods: Arc<[rue_air::declaration_validation::AccessorOwnerMethod]>,
-}
-
-/// Stable, position-free failure retained by the exact raw-signature family.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum RawDeclarationSignatureFailure {
-    OccurrencesUnavailable(DeclarationOccurrenceFailure),
-    Absent(DeclarationCandidateKey),
-    Ambiguous(DeclarationCandidateKey),
-    CategoryMismatch(DeclarationCandidateKey),
-    ParserCapabilityMismatch(DeclarationCandidateKey),
 }
 
 /// Parser-validated syntax for one body-bearing declaration, detached from its
@@ -292,6 +284,7 @@ pub(crate) struct DeclarationParameterHeader {
     pub(crate) name: Arc<str>,
     pub(crate) mode: DeclarationParameterMode,
     pub(crate) is_comptime: bool,
+    pub(crate) is_type_parameter: bool,
 }
 
 /// Position-free header fact owned by the keyed declaration-shell family.

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -28,7 +28,7 @@ use crate::{
         DeclarationCandidateCategory, DeclarationCandidateKey, DeclarationCandidateOwner,
         DeclarationOccurrenceCapability, DeclarationParameterHeader, DeclarationParameterMode,
         DeclarationShellFact, DeclarationShellFailure, RawAnonymousSite, RawConstSyntax,
-        RawDeclarationBodySyntax, RawDeclarationSignatureSyntax,
+        RawDeclarationBodySyntax,
     },
 };
 
@@ -178,8 +178,6 @@ pub struct ParsedDefinitionIndex {
     declaration_capabilities: Arc<[DeclarationOccurrenceCapability]>,
     #[cfg(test)]
     raw_const_syntax_materializations: Arc<AtomicUsize>,
-    #[cfg(test)]
-    raw_declaration_signature_terminal_materializations: Arc<AtomicUsize>,
     #[cfg(test)]
     raw_declaration_body_terminal_materializations: Arc<AtomicUsize>,
     #[cfg(test)]
@@ -383,70 +381,6 @@ impl ParsedDefinitionIndex {
             .load(Ordering::Relaxed)
     }
 
-    /// Materialize the body-free syntax for exactly one declaration key.
-    /// Locators are indexed with the module, but source fragments are copied
-    /// only after this exact `declaration_by_key` lookup succeeds.
-    fn materialize_raw_declaration_signature(
-        &self,
-        key: &DeclarationCandidateKey,
-        source_text: &str,
-    ) -> Option<RawDeclarationSignatureSyntax> {
-        let index = self.declaration_by_key.get(key).copied()?;
-        let candidate = self.declarations.get(index)?;
-        if candidate.fact.key != *key {
-            return None;
-        }
-        let locator = candidate.raw_signature_locator?;
-        let fragment = |span: Span| {
-            source_text
-                .get(span.start as usize..span.end as usize)
-                .map(Arc::from)
-        };
-        let (declaration_fragments, extern_abi) = match locator {
-            RawDeclarationSignatureLocator::Contiguous { declaration } => {
-                (vec![fragment(declaration)?].into(), None)
-            }
-            RawDeclarationSignatureLocator::SplitStruct {
-                retained_prefix,
-                closing_brace,
-            } => (
-                vec![fragment(retained_prefix)?, fragment(closing_brace)?].into(),
-                None,
-            ),
-            RawDeclarationSignatureLocator::Extern { declaration, abi } => {
-                (vec![fragment(declaration)?].into(), Some(fragment(abi)?))
-            }
-        };
-        // 6.6:7 lets an accessor yield through a nested *accessor* call. For a
-        // link whose receiver is this accessor's own `self`, the callee is one
-        // of the owner's methods, so the deciding fact is the sibling
-        // declaration's parsed `-> borrow` qualifier — retained here, where
-        // the terminal is already materialized from this module's parse, so an
-        // edit to a sibling invalidates this accessor's signature.
-        let accessor = if candidate.is_accessor {
-            Some(Arc::new(
-                crate::declaration_candidate::RawAccessorSignatureSyntax {
-                    body: fragment(candidate.raw_body_span?)?,
-                    owner_methods: key.owner.as_ref().map_or_else(
-                        || Arc::from(Vec::new()),
-                        |owner| self.owner_method_accessor_facts(owner),
-                    ),
-                },
-            ))
-        } else {
-            None
-        };
-        let syntax = RawDeclarationSignatureSyntax {
-            declaration_fragments,
-            extern_abi,
-            accessor,
-        };
-        #[cfg(test)]
-        self.raw_declaration_signature_terminal_materializations
-            .fetch_add(1, Ordering::Relaxed);
-        Some(syntax)
-    }
-
     /// Every method one owner declares in this module — its name, whether it
     /// is itself a `-> borrow` accessor, and its `self`-call targets — in the
     /// normalized form the raw signature terminal retains.
@@ -470,12 +404,6 @@ impl ParsedDefinitionIndex {
                     },
                 ),
         )
-    }
-
-    #[cfg(test)]
-    fn raw_declaration_signature_terminal_materialization_count(&self) -> usize {
-        self.raw_declaration_signature_terminal_materializations
-            .load(Ordering::Relaxed)
     }
 
     /// Materialize the syntax for exactly one body-bearing declaration key.
@@ -566,7 +494,6 @@ pub(crate) struct ParsedDeclarationCandidate {
     ast_locator: ParsedDeclarationAstLocator,
     declaration_span: Span,
     raw_const_syntax_spans: Option<RawConstSyntaxSpans>,
-    raw_signature_locator: Option<RawDeclarationSignatureLocator>,
     raw_body_span: Option<Span>,
     is_accessor: bool,
     /// The method names this declaration's body calls on its own `self`
@@ -632,24 +559,6 @@ pub enum ParsedDeclarationAstRef<'a> {
 struct RawConstSyntaxSpans {
     declared_type: Option<Span>,
     initializer: Span,
-}
-
-/// Parser-private signature locators. These current-epoch spans are also the
-/// only source of future diagnostic projection; they never enter the durable
-/// raw-signature terminal.
-#[derive(Debug, Clone, Copy)]
-enum RawDeclarationSignatureLocator {
-    Contiguous {
-        declaration: Span,
-    },
-    SplitStruct {
-        retained_prefix: Span,
-        closing_brace: Span,
-    },
-    Extern {
-        declaration: Span,
-        abi: Span,
-    },
 }
 
 /// Parser-private range into the module's source-ordered import table for one
@@ -860,20 +769,6 @@ impl ParsedModule {
         self.definitions.raw_const_syntax_materialization_count()
     }
 
-    pub(crate) fn evaluate_raw_declaration_signature(
-        &self,
-        key: &DeclarationCandidateKey,
-    ) -> Option<RawDeclarationSignatureSyntax> {
-        self.definitions
-            .materialize_raw_declaration_signature(key, self.source_text())
-    }
-
-    #[cfg(test)]
-    pub(crate) fn raw_declaration_signature_terminal_materialization_count(&self) -> usize {
-        self.definitions
-            .raw_declaration_signature_terminal_materialization_count()
-    }
-
     pub(crate) fn evaluate_raw_declaration_body(
         &self,
         key: &DeclarationCandidateKey,
@@ -897,6 +792,28 @@ impl ParsedModule {
         let index = self.definitions.declaration_by_key.get(key).copied()?;
         let candidate = self.definitions.declarations.get(index)?;
         (candidate.fact.key == *key).then_some(candidate.anonymous_sites.as_ref())
+    }
+
+    /// Exact parsed sibling facts needed to validate one accessor signature.
+    /// The keyed declaration lookup and owner join are both checked here so a
+    /// signature projection cannot silently borrow a neighboring owner's
+    /// method set after an incremental update.
+    pub(crate) fn declaration_accessor_owner_methods(
+        &self,
+        key: &DeclarationCandidateKey,
+    ) -> Option<Arc<[rue_air::declaration_validation::AccessorOwnerMethod]>> {
+        let index = self.definitions.declaration_by_key.get(key).copied()?;
+        let candidate = self.definitions.declarations.get(index)?;
+        if candidate.fact.key != *key {
+            return None;
+        }
+        if !candidate.is_accessor {
+            return Some(Arc::from([]));
+        }
+        Some(key.owner.as_ref().map_or_else(
+            || Arc::from([]),
+            |owner| self.definitions.owner_method_accessor_facts(owner),
+        ))
     }
 
     /// Resolve an exact declaration key to the borrowed parser node that owns
@@ -1753,28 +1670,6 @@ fn bind_payload(
                         initializer: remap_span(spans.initializer),
                     }
                 }),
-                raw_signature_locator: candidate.raw_signature_locator.map(
-                    |locator| match locator {
-                        RawDeclarationSignatureLocator::Contiguous { declaration } => {
-                            RawDeclarationSignatureLocator::Contiguous {
-                                declaration: remap_span(declaration),
-                            }
-                        }
-                        RawDeclarationSignatureLocator::SplitStruct {
-                            retained_prefix,
-                            closing_brace,
-                        } => RawDeclarationSignatureLocator::SplitStruct {
-                            retained_prefix: remap_span(retained_prefix),
-                            closing_brace: remap_span(closing_brace),
-                        },
-                        RawDeclarationSignatureLocator::Extern { declaration, abi } => {
-                            RawDeclarationSignatureLocator::Extern {
-                                declaration: remap_span(declaration),
-                                abi: remap_span(abi),
-                            }
-                        }
-                    },
-                ),
                 raw_body_span: candidate.raw_body_span.map(remap_span),
                 is_accessor: candidate.is_accessor,
                 self_call_targets: candidate.self_call_targets.clone(),
@@ -1799,11 +1694,6 @@ fn bind_payload(
         raw_const_syntax_materializations: payload
             .definitions
             .raw_const_syntax_materializations
-            .clone(),
-        #[cfg(test)]
-        raw_declaration_signature_terminal_materializations: payload
-            .definitions
-            .raw_declaration_signature_terminal_materializations
             .clone(),
         #[cfg(test)]
         raw_declaration_body_terminal_materializations: payload
@@ -2244,7 +2134,6 @@ fn build_definition_index(
         ParsedDeclarationAstLocator,
         Span,
         Option<RawConstSyntaxSpans>,
-        Option<RawDeclarationSignatureLocator>,
         Option<Span>,
         bool,
         Arc<[Arc<str>]>,
@@ -2285,10 +2174,18 @@ fn build_definition_index(
                 .iter()
                 .map(|param| {
                     let (mode, is_comptime) = candidate_parameter_mode(param.mode);
+                    let is_type_parameter = is_comptime
+                        && match &param.ty {
+                            rue_parser::ast::TypeExpr::Named(name) => {
+                                resolve_name(*name)?.as_ref() == "type"
+                            }
+                            _ => false,
+                        };
                     Ok(DeclarationParameterHeader {
                         name: resolve_name(param.name)?,
                         mode,
                         is_comptime,
+                        is_type_parameter,
                     })
                 })
                 .collect::<CompileResult<Vec<_>>>()
@@ -2357,7 +2254,6 @@ fn build_definition_index(
                         declaration_span,
                         signature_spans: Vec<Span>,
                         raw_const_syntax_spans: Option<RawConstSyntaxSpans>,
-                        raw_signature_locator: Option<RawDeclarationSignatureLocator>,
                         raw_body_span: Option<Span>,
                         anonymous_sites: Arc<[rue_rir::AnonymousTypeSite]>|
          -> CompileResult<()> {
@@ -2368,27 +2264,6 @@ fn build_definition_index(
                 resolver,
                 &signature_spans,
             )?;
-            if let Some(locator) = raw_signature_locator {
-                let (first, second, abi) = match locator {
-                    RawDeclarationSignatureLocator::Contiguous { declaration } => {
-                        (declaration, None, None)
-                    }
-                    RawDeclarationSignatureLocator::SplitStruct {
-                        retained_prefix,
-                        closing_brace,
-                    } => (retained_prefix, Some(closing_brace), None),
-                    RawDeclarationSignatureLocator::Extern { declaration, abi } => {
-                        (declaration, None, Some(abi))
-                    }
-                };
-                validate_span("raw declaration signature", first, file_id, source_text)?;
-                if let Some(span) = second {
-                    validate_span("raw declaration signature", span, file_id, source_text)?;
-                }
-                if let Some(span) = abi {
-                    validate_span("raw extern ABI", span, file_id, source_text)?;
-                }
-            }
             if let Some(body) = raw_body_span {
                 validate_span("raw declaration body", body, file_id, source_text)?;
             }
@@ -2425,7 +2300,6 @@ fn build_definition_index(
                 ast_locator,
                 declaration_span,
                 raw_const_syntax_spans,
-                raw_signature_locator,
                 raw_body_span,
                 is_accessor,
                 method_self_call_targets,
@@ -2453,13 +2327,6 @@ fn build_definition_index(
                 function.span,
                 vec![signature_prefix(function.span, function.body.span())?],
                 None,
-                Some(RawDeclarationSignatureLocator::Contiguous {
-                    declaration: token_bounded_signature_prefix(
-                        function.span,
-                        function.body.span(),
-                        tokens,
-                    )?,
-                }),
                 Some(function.body.span()),
                 rue_rir::anonymous_type_sites(&function.body).into(),
             )?,
@@ -2482,7 +2349,6 @@ fn build_definition_index(
                     structure.span,
                     signature_fragments_excluding_method_bodies(structure)?,
                     None,
-                    Some(struct_signature_locator(structure, tokens)?),
                     None,
                     Arc::from([]),
                 )?;
@@ -2524,13 +2390,6 @@ fn build_definition_index(
                         method.span,
                         vec![signature_prefix(method.span, method.body.span())?],
                         None,
-                        Some(RawDeclarationSignatureLocator::Contiguous {
-                            declaration: token_bounded_signature_prefix(
-                                method.span,
-                                method.body.span(),
-                                tokens,
-                            )?,
-                        }),
                         Some(method.body.span()),
                         rue_rir::anonymous_type_sites(&method.body).into(),
                     )?;
@@ -2553,9 +2412,6 @@ fn build_definition_index(
                 value.span,
                 vec![value.span],
                 None,
-                Some(RawDeclarationSignatureLocator::Contiguous {
-                    declaration: token_bounded_declaration(value.span, tokens)?,
-                }),
                 None,
                 Arc::from([]),
             )?,
@@ -2588,7 +2444,6 @@ fn build_definition_index(
                     vec![signature_prefix(value.span, value.init.span())?],
                     Some(raw_const_syntax_spans),
                     None,
-                    None,
                     rue_rir::anonymous_type_sites(&value.init).into(),
                 )?;
             }
@@ -2612,13 +2467,6 @@ fn build_definition_index(
                 value.span,
                 vec![signature_prefix(value.span, value.body.span())?],
                 None,
-                Some(RawDeclarationSignatureLocator::Contiguous {
-                    declaration: token_bounded_signature_prefix(
-                        value.span,
-                        value.body.span(),
-                        tokens,
-                    )?,
-                }),
                 Some(value.body.span()),
                 rue_rir::anonymous_type_sites(&value.body).into(),
             )?,
@@ -2646,10 +2494,6 @@ fn build_definition_index(
                         function.span,
                         vec![function.span],
                         None,
-                        Some(RawDeclarationSignatureLocator::Extern {
-                            declaration: token_bounded_declaration(function.span, tokens)?,
-                            abi: block.abi_span,
-                        }),
                         None,
                         Arc::from([]),
                     )?;
@@ -2725,7 +2569,6 @@ fn build_definition_index(
                 ast_locator,
                 declaration_span,
                 raw_const_syntax_spans,
-                raw_signature_locator,
                 raw_body_span,
                 is_accessor,
                 self_call_targets,
@@ -2748,7 +2591,6 @@ fn build_definition_index(
                     ast_locator,
                     declaration_span,
                     raw_const_syntax_spans,
-                    raw_signature_locator,
                     raw_body_span,
                     is_accessor,
                     self_call_targets,
@@ -2858,8 +2700,6 @@ fn build_definition_index(
         #[cfg(test)]
         raw_const_syntax_materializations: Arc::new(AtomicUsize::new(0)),
         #[cfg(test)]
-        raw_declaration_signature_terminal_materializations: Arc::new(AtomicUsize::new(0)),
-        #[cfg(test)]
         raw_declaration_body_terminal_materializations: Arc::new(AtomicUsize::new(0)),
         #[cfg(test)]
         declaration_import_locator_materializations: Arc::new(AtomicUsize::new(0)),
@@ -2919,110 +2759,6 @@ fn signature_fragments_excluding_method_bodies(
         structure.span.end,
     ));
     Ok(fragments)
-}
-
-/// Bound a body-bearing declaration at the last signature token. Lexer trivia
-/// before the body belongs to neither the signature nor the body and therefore
-/// must not perturb the durable signature terminal.
-fn token_bounded_signature_prefix(
-    declaration: Span,
-    body: Span,
-    tokens: &[rue_lexer::Token],
-) -> CompileResult<Span> {
-    signature_prefix(declaration, body)?;
-    let signature_end = tokens
-        .iter()
-        .filter(|token| {
-            token.span.file_id == declaration.file_id
-                && token.span.start >= declaration.start
-                && token.span.end <= body.start
-                && !matches!(token.kind, rue_lexer::TokenKind::Eof)
-        })
-        .map(|token| token.span.end)
-        .max()
-        .ok_or_else(|| invalid_input("declaration signature contains no token before its body"))?;
-    if signature_end <= declaration.start {
-        return Err(invalid_input(
-            "declaration signature token boundary is empty",
-        ));
-    }
-    Ok(Span::with_file(
-        declaration.file_id,
-        declaration.start,
-        signature_end,
-    ))
-}
-
-/// Trim a body-free declaration to its first and last tokens.
-fn token_bounded_declaration(
-    declaration: Span,
-    tokens: &[rue_lexer::Token],
-) -> CompileResult<Span> {
-    let mut declaration_tokens = tokens.iter().filter(|token| {
-        token.span.file_id == declaration.file_id
-            && token.span.start >= declaration.start
-            && token.span.end <= declaration.end
-            && !matches!(token.kind, rue_lexer::TokenKind::Eof)
-    });
-    let first = declaration_tokens
-        .next()
-        .ok_or_else(|| invalid_input("declaration contains no tokens"))?;
-    let last = declaration_tokens.next_back().unwrap_or(first);
-    Ok(Span::with_file(
-        declaration.file_id,
-        first.span.start,
-        last.span.end,
-    ))
-}
-
-/// Retain only a struct's header/directives/fields and its closing-brace token.
-/// The two inline spans exclude the delimiter and all trivia before the first
-/// method, all methods, and all trivia after the last method. Omitting a
-/// trailing field comma is valid Rue syntax, so concatenating these fragments
-/// remains a deterministic, reparsable struct declaration.
-fn struct_signature_locator(
-    structure: &rue_parser::ast::StructDecl,
-    tokens: &[rue_lexer::Token],
-) -> CompileResult<RawDeclarationSignatureLocator> {
-    let declaration_tokens = || {
-        tokens.iter().filter(|token| {
-            token.span.file_id == structure.span.file_id
-                && token.span.start >= structure.span.start
-                && token.span.end <= structure.span.end
-                && !matches!(token.kind, rue_lexer::TokenKind::Eof)
-        })
-    };
-    let first = declaration_tokens()
-        .next()
-        .ok_or_else(|| invalid_input("struct declaration contains no tokens"))?;
-    let opening_brace = declaration_tokens()
-        .find(|token| matches!(token.kind, rue_lexer::TokenKind::LBrace))
-        .ok_or_else(|| invalid_input("struct declaration has no opening-brace token"))?;
-    let closing_brace = declaration_tokens()
-        .rev()
-        .find(|token| matches!(token.kind, rue_lexer::TokenKind::RBrace))
-        .ok_or_else(|| invalid_input("struct declaration has no closing-brace token"))?;
-    let retained_end = if let Some(field) = structure.fields.last() {
-        let field_end_is_token_boundary =
-            declaration_tokens().any(|token| token.span.end == field.span.end);
-        if !field_end_is_token_boundary {
-            return Err(invalid_input(
-                "struct field does not end at a token boundary",
-            ));
-        }
-        field.span.end
-    } else {
-        opening_brace.span.end
-    };
-    if first.span.start >= retained_end || retained_end > closing_brace.span.start {
-        return Err(invalid_input(
-            "struct retained signature tokens are not ordered before its closing brace",
-        ));
-    }
-    Ok(RawDeclarationSignatureLocator::SplitStruct {
-        retained_prefix: Span::with_file(structure.span.file_id, first.span.start, retained_end),
-        closing_brace: closing_brace.span,
-    })
 }
 
 fn declaration_signature_fingerprint(

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -1007,7 +1007,6 @@ macro_rules! candidate_failure_charge {
 }
 
 candidate_failure_charge!(crate::declaration_candidate::RawConstSyntaxFailure);
-candidate_failure_charge!(crate::declaration_candidate::RawDeclarationSignatureFailure);
 candidate_failure_charge!(crate::declaration_candidate::RawDeclarationBodyFailure);
 
 impl RetainedCharge for crate::declaration_candidate::RawDeclarationSignatureSyntax {
@@ -1024,6 +1023,46 @@ impl RetainedCharge for crate::declaration_candidate::RawAccessorSignatureSyntax
         self.body
             .retained_charge()
             .saturating_add(self.owner_methods.retained_charge())
+    }
+}
+
+impl RetainedCharge for crate::semantic_query_nucleus::ParsedSemanticParameter {
+    fn retained_charge(&self) -> u64 {
+        0
+    }
+}
+
+zero_charge!(
+    crate::semantic_query_nucleus::ParsedSemanticText,
+    crate::semantic_query_nucleus::ParsedSemanticField,
+    crate::semantic_query_nucleus::ParsedSemanticVariant,
+);
+
+impl RetainedCharge for crate::semantic_query_nucleus::ParsedSemanticSignature {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Callable {
+                text,
+                parameters,
+                accessor_cycle,
+                ..
+            } => text
+                .retained_charge()
+                .saturating_add(parameters.retained_charge())
+                .saturating_add(accessor_cycle.retained_charge()),
+            Self::Struct { text, fields, .. } => text
+                .retained_charge()
+                .saturating_add(fields.retained_charge()),
+            Self::Enum {
+                text,
+                variants,
+                payloads,
+            } => text
+                .retained_charge()
+                .saturating_add(variants.retained_charge())
+                .saturating_add(payloads.retained_charge()),
+            Self::Destructor => 0,
+        }
     }
 }
 

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -405,9 +405,6 @@ pub(crate) struct RevisionedQueryDatabase {
     >,
     #[cfg(test)]
     raw_const_syntax: QueryFamily<RawConstSyntaxQueryKey, RawConstSyntaxQueryValue>,
-    #[allow(dead_code)]
-    raw_declaration_signatures:
-        QueryFamily<RawDeclarationSignatureQueryKey, RawDeclarationSignatureQueryValue>,
     #[cfg(test)]
     raw_declaration_bodies: QueryFamily<RawDeclarationBodyQueryKey, RawDeclarationBodyQueryValue>,
     warning_body_references:
@@ -2108,21 +2105,6 @@ enum RawConstSyntaxQueryValue {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct RawDeclarationSignatureQueryKey(crate::declaration_candidate::DeclarationCandidateKey);
-
-impl QueryKey for RawDeclarationSignatureQueryKey {
-    fn stable_identity(&self) -> String {
-        self.0.stable_identity()
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum RawDeclarationSignatureQueryValue {
-    Available(crate::declaration_candidate::RawDeclarationSignatureSyntax),
-    Failure(crate::declaration_candidate::RawDeclarationSignatureFailure),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct RawDeclarationBodyQueryKey(crate::declaration_candidate::DeclarationCandidateKey);
 
 impl QueryKey for RawDeclarationBodyQueryKey {
@@ -2748,7 +2730,6 @@ macro_rules! query_value_charge {
 }
 
 query_value_charge!(RawConstSyntaxQueryValue);
-query_value_charge!(RawDeclarationSignatureQueryValue);
 query_value_charge!(RawDeclarationBodyQueryValue);
 query_value_charge!(WarningBodySyntaxValue);
 query_value_charge!(WarningBodyReferencesValue);
@@ -5924,14 +5905,11 @@ fn exact_specialized_callable_types(
     context: &rue_query::QueryContext,
     semantic_nucleus: &SemanticNucleusFamily,
     declaration_shells: &QueryFamily<DeclarationShellQueryKey, DeclarationShellQueryValue>,
-    raw_declaration_signatures: &QueryFamily<
-        RawDeclarationSignatureQueryKey,
-        RawDeclarationSignatureQueryValue,
-    >,
     lookup_names: &QueryFamily<LookupNameKey, LookupNameValue>,
     declaration: &crate::declaration_candidate::DeclarationCandidateKey,
     definition: &crate::StableDefinitionKey,
     signature_parameters: &[crate::durable_semantics::DurableSemanticParameter],
+    callable_type_syntax: &rue_air::DurableCallableTypeSyntax,
     arguments: &crate::CanonicalArguments,
     configuration: &crate::semantic_query_nucleus::SemanticQueryConfiguration,
 ) -> Result<
@@ -5998,31 +5976,7 @@ fn exact_specialized_callable_types(
         ))));
     }
 
-    let raw = context.query_registered(
-        raw_declaration_signatures,
-        RawDeclarationSignatureQueryKey(declaration.clone()),
-    )?;
-    let rue_query::QueryOutcome::Success(raw) = raw.outcome() else {
-        unreachable!("RawDeclarationSignature publishes typed values")
-    };
-    let RawDeclarationSignatureQueryValue::Available(raw) = raw else {
-        return Ok(Err(TypeQueryFailure::Unavailable(Arc::from(format!(
-            "specialized callable syntax is unavailable: {raw:?}"
-        )))));
-    };
-    let parsed = match crate::semantic_query_nucleus::parse_semantic_signature(declaration, raw) {
-        Ok(parsed) => parsed,
-        Err(failure) => return Ok(Err(TypeQueryFailure::Invalid(failure))),
-    };
-    let crate::semantic_query_nucleus::ParsedSemanticSignature::Callable {
-        parameters, result, ..
-    } = parsed
-    else {
-        return Ok(Err(TypeQueryFailure::Invalid(Arc::from(
-            "specialized definition is not callable",
-        ))));
-    };
-    if parameters.len() != signature_parameters.len() {
+    if callable_type_syntax.parameters.len() != signature_parameters.len() {
         return Ok(Err(TypeQueryFailure::Invalid(Arc::from(
             "specialized callable syntax disagrees with its semantic signature",
         ))));
@@ -6048,12 +6002,13 @@ fn exact_specialized_callable_types(
             .map_err(semantic_type_query_failure)
     };
     let mut runtime_parameters = Vec::new();
-    for (parameter, _semantic) in parameters
+    for (parameter, _semantic) in callable_type_syntax
+        .parameters
         .iter()
         .zip(signature_parameters)
         .filter(|(_, semantic)| durable_parameter_is_runtime(semantic))
     {
-        match resolve(&parameter.ty) {
+        match resolve(parameter) {
             Ok(ty) => runtime_parameters.push(ty),
             Err(ResolveSemanticSignatureError::Abort(abort)) => return Err(abort),
             Err(ResolveSemanticSignatureError::Failure(failure)) => {
@@ -6063,7 +6018,7 @@ fn exact_specialized_callable_types(
             }
         }
     }
-    let result = match resolve(&result) {
+    let result = match resolve(&callable_type_syntax.result) {
         Ok(result) => result,
         Err(ResolveSemanticSignatureError::Abort(abort)) => return Err(abort),
         Err(ResolveSemanticSignatureError::Failure(failure)) => {
@@ -6079,10 +6034,6 @@ fn query_callable_signature(
     context: &rue_query::QueryContext,
     semantic_nucleus: &SemanticNucleusFamily,
     declaration_shells: &QueryFamily<DeclarationShellQueryKey, DeclarationShellQueryValue>,
-    raw_declaration_signatures: &QueryFamily<
-        RawDeclarationSignatureQueryKey,
-        RawDeclarationSignatureQueryValue,
-    >,
     lookup_names: &QueryFamily<LookupNameKey, LookupNameValue>,
     body_produced_anonymous: &QueryFamily<
         crate::body_query::BodyQueryKey,
@@ -6247,15 +6198,20 @@ fn query_callable_signature(
             }
             let (runtime_types, result) = match callable {
                 crate::FunctionInstanceKey::Specialization { arguments, .. } => {
+                    let Some(callable_type_syntax) = signature.callable_type_syntax.as_ref() else {
+                        return Ok(Err(TypeQueryFailure::Unavailable(Arc::from(
+                            "specialized callable type syntax is unavailable",
+                        ))));
+                    };
                     match exact_specialized_callable_types(
                         context,
                         semantic_nucleus,
                         declaration_shells,
-                        raw_declaration_signatures,
                         lookup_names,
                         declaration,
                         definition,
                         parameters,
+                        callable_type_syntax,
                         arguments,
                         &key.configuration,
                     )? {
@@ -6333,10 +6289,6 @@ fn evaluate_call_abi(
     context: &rue_query::QueryContext,
     semantic_nucleus: &SemanticNucleusFamily,
     declaration_shells: &QueryFamily<DeclarationShellQueryKey, DeclarationShellQueryValue>,
-    raw_declaration_signatures: &QueryFamily<
-        RawDeclarationSignatureQueryKey,
-        RawDeclarationSignatureQueryValue,
-    >,
     lookup_names: &QueryFamily<LookupNameKey, LookupNameValue>,
     body_produced_anonymous: &QueryFamily<
         crate::body_query::BodyQueryKey,
@@ -6354,7 +6306,6 @@ fn evaluate_call_abi(
         context,
         semantic_nucleus,
         declaration_shells,
-        raw_declaration_signatures,
         lookup_names,
         body_produced_anonymous,
         key,
@@ -6982,18 +6933,6 @@ pub(crate) fn durable_value_from_argument(
         V::Unit => D::Unit,
         V::String(value) => D::String(value.clone()),
     })
-}
-
-fn callable_result_type_syntax(
-    declaration: &crate::declaration_candidate::DeclarationCandidateKey,
-    syntax: &crate::declaration_candidate::RawDeclarationSignatureSyntax,
-) -> Option<Arc<str>> {
-    let crate::semantic_query_nucleus::ParsedSemanticSignature::Callable { result, .. } =
-        crate::semantic_query_nucleus::parse_semantic_signature(declaration, syntax).ok()?
-    else {
-        return None;
-    };
-    Some(result)
 }
 
 fn comptime_call_for_anonymous_function(
@@ -11096,13 +11035,14 @@ fn resolve_parsed_semantic_signature(
             is_accessor,
             accessor_body,
             accessor_cycle,
+            ..
         } => {
             if *is_accessor {
-                // 6.6:3-6.6:7 over the reparsed declaration. Which forms are
+                // 6.6:3-6.6:7 over the exact canonical declaration. Which forms are
                 // illegal, in which order, and how each diagnostic reads are
                 // `rue_air::declaration_validation`'s, shared with the RIR
                 // producers (RUE-1232); this seam owns only the lowering of
-                // the reparsed signature into that vocabulary.
+                // the parsed signature projection into that vocabulary.
                 use rue_air::declaration_validation as rules;
                 use rue_air::declaration_validation::{
                     AccessorParameterForm, AccessorReceiverForm,
@@ -11190,9 +11130,9 @@ fn resolve_parsed_semantic_signature(
             }
             let mut generic_index = 0_u32;
             for parameter in parameters.iter() {
-                if parameter.is_comptime && parameter.ty.trim() == "type" {
+                if parameter.is_comptime && parsed.text(parameter.ty).trim() == "type" {
                     provider.substitutions.insert(
-                        parameter.name.clone(),
+                        Arc::from(parsed.text(parameter.name)),
                         crate::durable_semantics::DurableType::GenericParameter(generic_index),
                     );
                     generic_index += 1;
@@ -11203,16 +11143,16 @@ fn resolve_parsed_semantic_signature(
                 .map(|parameter| {
                     let ty = resolve(
                         provider,
-                        &parameter.ty,
+                        parsed.text(parameter.ty),
                         rue_air::DeclarationTypeDependencyKind::Signature,
                     )?;
-                    if parameter.is_comptime && parameter.ty.trim() != "type" {
+                    if parameter.is_comptime && parsed.text(parameter.ty).trim() != "type" {
                         provider
                             .deferred_value_parameters
-                            .insert(parameter.name.clone(), ty.clone());
+                            .insert(Arc::from(parsed.text(parameter.name)), ty.clone());
                     }
                     Ok(DurableSemanticParameter {
-                        name: parameter.name.clone(),
+                        name: Arc::from(parsed.text(parameter.name)),
                         ty,
                         mode: match parameter.mode {
                             crate::declaration_candidate::DeclarationParameterMode::Value => {
@@ -11231,7 +11171,7 @@ fn resolve_parsed_semantic_signature(
                 .collect::<Result<Vec<_>, ResolveSemanticSignatureError>>()?;
             let result = resolve(
                 provider,
-                result,
+                parsed.text(*result),
                 rue_air::DeclarationTypeDependencyKind::Signature,
             )?;
             if contains_slice(&result) {
@@ -11395,6 +11335,7 @@ fn resolve_parsed_semantic_signature(
             is_copy,
             is_linear,
             is_repr_c,
+            ..
         } => {
             if let Some(kind) = rue_air::declaration_validation::linear_copy_struct(
                 provider.dependency_source.name(),
@@ -11405,18 +11346,19 @@ fn resolve_parsed_semantic_signature(
             }
             if let Some(kind) = rue_air::declaration_validation::duplicate_field(
                 provider.dependency_source.name(),
-                fields.iter().map(|(name, _)| name),
+                fields.iter().map(|field| parsed.text(field.name)),
             ) {
                 return Err(diagnostic(kind));
             }
             let fields = fields
                 .iter()
-                .map(|(name, syntax)| {
+                .map(|field| {
+                    let name: Arc<str> = Arc::from(parsed.text(field.name));
                     Ok((
-                        name.clone(),
+                        name,
                         resolve(
                             provider,
-                            syntax,
+                            parsed.text(field.ty),
                             rue_air::DeclarationTypeDependencyKind::Field,
                         )?,
                     ))
@@ -11522,24 +11464,29 @@ fn resolve_parsed_semantic_signature(
                 is_repr_c: *is_repr_c,
             })
         }
-        Input::Enum { variants } => {
+        Input::Enum {
+            variants, payloads, ..
+        } => {
             if let Some(kind) = rue_air::declaration_validation::duplicate_variant(
                 provider.dependency_source.name(),
-                variants.iter().map(|(name, _)| name),
+                variants.iter().map(|variant| parsed.text(variant.name)),
             ) {
                 return Err(diagnostic(kind));
             }
             let variants: Vec<(Arc<str>, Arc<[crate::durable_semantics::DurableType]>)> = variants
                 .iter()
-                .map(|(name, payload)| {
+                .map(|variant| {
+                    let payload = payloads
+                        .get(variant.payload_start as usize..variant.payload_end as usize)
+                        .expect("signature payload ranges are validated when projected");
                     Ok((
-                        name.clone(),
+                        Arc::from(parsed.text(variant.name)),
                         payload
                             .iter()
                             .map(|syntax| {
                                 resolve(
                                     provider,
-                                    syntax,
+                                    parsed.text(*syntax),
                                     rue_air::DeclarationTypeDependencyKind::Payload,
                                 )
                             })
@@ -12178,155 +12125,6 @@ impl RevisionedQueryDatabase {
                 },
             )
             .expect("the RawConstSyntax family has one canonical name");
-        let occurrences_for_raw_signature = declaration_occurrence_indexes.clone();
-        let shells_for_raw_signature = declaration_shells.clone();
-        let parse_for_raw_signature = parse_modules.clone();
-        let raw_declaration_signatures = runtime
-            .family_with_equality_and_evaluator(
-                "compiler.raw-declaration-signature",
-                declaration_memo_retention,
-                |left: &RawDeclarationSignatureQueryValue,
-                 right: &RawDeclarationSignatureQueryValue| { left == right },
-                move |context, _, key: &RawDeclarationSignatureQueryKey| {
-                    use crate::declaration_candidate::{
-                        DeclarationCandidateCategory, DeclarationOccurrenceCapability,
-                        DeclarationShellFailure, RawDeclarationSignatureFailure,
-                    };
-
-                    let indexed = context.query_registered(
-                        &occurrences_for_raw_signature,
-                        ModuleQueryKey(key.0.module.clone()),
-                    )?;
-                    let rue_query::QueryOutcome::Success(indexed) = indexed.outcome() else {
-                        unreachable!("DeclarationOccurrenceIndex publishes typed values")
-                    };
-                    let value = match indexed {
-                        DeclarationOccurrenceIndexValue::Failure(failure) => {
-                            RawDeclarationSignatureQueryValue::Failure(
-                                RawDeclarationSignatureFailure::OccurrencesUnavailable(
-                                    failure.clone(),
-                                ),
-                            )
-                        }
-                        DeclarationOccurrenceIndexValue::Available(index) => {
-                            match index.capabilities.get(&key.0) {
-                                None => RawDeclarationSignatureQueryValue::Failure(
-                                    RawDeclarationSignatureFailure::Absent(key.0.clone()),
-                                ),
-                                Some(DeclarationOccurrenceCapability::Ambiguous { .. }) => {
-                                    RawDeclarationSignatureQueryValue::Failure(
-                                        RawDeclarationSignatureFailure::Ambiguous(key.0.clone()),
-                                    )
-                                }
-                                Some(DeclarationOccurrenceCapability::Exact {
-                                    duplicate_multiplicity: 0,
-                                    ..
-                                }) => RawDeclarationSignatureQueryValue::Failure(
-                                    RawDeclarationSignatureFailure::ParserCapabilityMismatch(
-                                        key.0.clone(),
-                                    ),
-                                ),
-                                Some(DeclarationOccurrenceCapability::Exact { .. }) => {
-                                    let shell = context.query_registered(
-                                        &shells_for_raw_signature,
-                                        DeclarationShellQueryKey(key.0.clone()),
-                                    )?;
-                                    let rue_query::QueryOutcome::Success(shell) = shell.outcome()
-                                    else {
-                                        unreachable!("DeclarationShell publishes typed values")
-                                    };
-                                    match shell {
-                                        DeclarationShellQueryValue::Failure(failure) => {
-                                            let failure = match failure {
-                                                DeclarationShellFailure::OccurrencesUnavailable(
-                                                    failure,
-                                                ) => RawDeclarationSignatureFailure::OccurrencesUnavailable(
-                                                    failure.clone(),
-                                                ),
-                                                DeclarationShellFailure::Absent(key) => {
-                                                    RawDeclarationSignatureFailure::Absent(
-                                                        key.clone(),
-                                                    )
-                                                }
-                                                DeclarationShellFailure::Ambiguous(key) => {
-                                                    RawDeclarationSignatureFailure::Ambiguous(
-                                                        key.clone(),
-                                                    )
-                                                }
-                                                DeclarationShellFailure::ParserCapabilityMismatch(
-                                                    key,
-                                                ) => RawDeclarationSignatureFailure::ParserCapabilityMismatch(
-                                                    key.clone(),
-                                                ),
-                                            };
-                                            RawDeclarationSignatureQueryValue::Failure(failure)
-                                        }
-                                        DeclarationShellQueryValue::Available(fact)
-                                            if fact.key.category
-                                                == DeclarationCandidateCategory::ConstCandidate =>
-                                        {
-                                            RawDeclarationSignatureQueryValue::Failure(
-                                                RawDeclarationSignatureFailure::CategoryMismatch(
-                                                    key.0.clone(),
-                                                ),
-                                            )
-                                        }
-                                        DeclarationShellQueryValue::Available(fact)
-                                            if fact.key != key.0 =>
-                                        {
-                                            RawDeclarationSignatureQueryValue::Failure(
-                                                RawDeclarationSignatureFailure::ParserCapabilityMismatch(
-                                                    key.0.clone(),
-                                                ),
-                                            )
-                                        }
-                                        DeclarationShellQueryValue::Available(_) => {
-                                            let parsed = context.query_registered(
-                                                &parse_for_raw_signature,
-                                                ModuleQueryKey(key.0.module.clone()),
-                                            )?;
-                                            let rue_query::QueryOutcome::Success(parsed) =
-                                                parsed.outcome()
-                                            else {
-                                                unreachable!("ParseModule publishes typed values")
-                                            };
-                                            match &parsed.result {
-                                                Err(_) => RawDeclarationSignatureQueryValue::Failure(
-                                                    RawDeclarationSignatureFailure::OccurrencesUnavailable(
-                                                        crate::declaration_candidate::DeclarationOccurrenceFailure::ParseRejected {
-                                                            module: key.0.module.clone(),
-                                                        },
-                                                    ),
-                                                ),
-                                                Ok(module) => module
-                                                    .evaluate_raw_declaration_signature(&key.0)
-                                                    .map_or_else(
-                                                        || RawDeclarationSignatureQueryValue::Failure(
-                                                            RawDeclarationSignatureFailure::ParserCapabilityMismatch(
-                                                                key.0.clone(),
-                                                            ),
-                                                        ),
-                                                        RawDeclarationSignatureQueryValue::Available,
-                                                    ),
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    };
-                    let kind = if matches!(
-                        value,
-                        RawDeclarationSignatureQueryValue::Available(_)
-                    ) {
-                        QueryTerminalKind::Success
-                    } else {
-                        QueryTerminalKind::Failure
-                    };
-                    Ok(QueryOutput::success(value).with_terminal_kind(kind))
-                },
-            )
-            .expect("the RawDeclarationSignature family has one canonical name");
         let occurrences_for_raw_body = declaration_occurrence_indexes.clone();
         let shells_for_raw_body = declaration_shells.clone();
         let parse_for_raw_body = parse_modules.clone();
@@ -13073,7 +12871,7 @@ impl RevisionedQueryDatabase {
             .expect("the DeclarationImport family has one canonical name");
         let shells_for_semantic_nucleus = declaration_shells.clone();
         let shells_for_produced_anonymous = declaration_shells.clone();
-        let signatures_for_semantic_nucleus = raw_declaration_signatures.clone();
+        let parse_for_semantic_nucleus = parse_modules.clone();
         let consts_for_semantic_nucleus = raw_const_syntax.clone();
         let bodies_for_semantic_nucleus = raw_declaration_bodies.clone();
         let names_for_semantic_nucleus = lookup_names.clone();
@@ -13162,7 +12960,6 @@ impl RevisionedQueryDatabase {
         let body_input_resolver = BodyInputResolver {
             stable_declaration_classifications: stable_declaration_classifications.clone(),
             declaration_shells: declaration_shells.clone(),
-            raw_declaration_signatures: raw_declaration_signatures.clone(),
             declaration_body_plan_artifacts: declaration_body_plan_artifacts.clone(),
             body_source_bases: body_source_bases.clone(),
         };
@@ -13497,7 +13294,6 @@ impl RevisionedQueryDatabase {
             Arc::new(std::sync::OnceLock::<SemanticNucleusFamily>::new());
         let semantic_nucleus_for_produced_anonymous_evaluator =
             semantic_nucleus_for_produced_anonymous.clone();
-        let signatures_for_produced_anonymous = raw_declaration_signatures.clone();
         let body_produced_anonymous = runtime
             .family_with_equality_and_evaluator(
                 "compiler.body-produced-anonymous",
@@ -13625,18 +13421,10 @@ impl RevisionedQueryDatabase {
                     else {
                         return Err(QueryAbort::Canceled);
                     };
-                    let exact_signature = context.query_registered(
-                        &signatures_for_produced_anonymous,
-                        RawDeclarationSignatureQueryKey(declaration.clone()),
-                    )?;
-                    let rue_query::QueryOutcome::Success(
-                        RawDeclarationSignatureQueryValue::Available(exact_signature),
-                    ) = exact_signature.outcome()
-                    else {
-                        return Err(QueryAbort::Canceled);
-                    };
-                    let Some(exact_result) =
-                        callable_result_type_syntax(&declaration, exact_signature)
+                    let Some(exact_result) = signature
+                        .callable_type_syntax
+                        .as_ref()
+                        .map(|syntax| syntax.result.clone())
                     else {
                         return Err(QueryAbort::Canceled);
                     };
@@ -13898,31 +13686,35 @@ impl RevisionedQueryDatabase {
                                         .with_terminal_kind(QueryTerminalKind::Failure));
                                 }
                             }
-                            let raw = context.query_registered(
-                                &signatures_for_semantic_nucleus,
-                                RawDeclarationSignatureQueryKey(query.declaration.clone()),
+                            context.check_canceled()?;
+                            let parsed_module = context.query_registered(
+                                &parse_for_semantic_nucleus,
+                                ModuleQueryKey(query.declaration.module.clone()),
                             )?;
-                            let rue_query::QueryOutcome::Success(raw) = raw.outcome() else {
-                                unreachable!("RawDeclarationSignature publishes typed values")
+                            let rue_query::QueryOutcome::Success(parsed_module) =
+                                parsed_module.outcome()
+                            else {
+                                unreachable!("ParseModule publishes typed values")
                             };
-                            match raw {
-                                RawDeclarationSignatureQueryValue::Failure(failure) => {
-                                    Value::Failure(Failure::Syntax(Arc::from(format!(
-                                        "{failure:?}"
-                                    ))))
-                                }
-                                RawDeclarationSignatureQueryValue::Available(raw) => {
-                                    match crate::semantic_query_nucleus::parse_semantic_signature(
-                                        &query.declaration,
-                                        raw,
-                                    ) {
-                                        Ok(parsed) => {
+                            let parsed = match &parsed_module.result {
+                                Ok(module) => crate::semantic_query_nucleus::project_semantic_signature(
+                                    module,
+                                    &query.declaration,
+                                ),
+                                Err(_) => Err(Arc::from(
+                                    "declaration signature module failed to parse",
+                                )),
+                            };
+                            context.check_canceled()?;
+                            match parsed {
+                                Err(failure) => Value::Failure(Failure::Syntax(failure)),
+                                Ok(parsed) => {
                                             if let crate::semantic_query_nucleus::ParsedSemanticSignature::Callable {
                                                 parameters,
                                                 ..
                                             } = &parsed
                                                 && let Some((kind, ordinal)) = rue_air::declaration_validation::duplicate_parameter_with_ordinal(
-                                                    parameters.iter().map(|parameter| &parameter.name),
+                                                    parameters.iter().map(|parameter| parsed.text(parameter.name)),
                                                 )
                                             {
                                                 return Ok(QueryOutput::success(Value::Failure(
@@ -14033,9 +13825,6 @@ impl RevisionedQueryDatabase {
                                                     Value::Failure(*failure)
                                                 }
                                             }
-                                        }
-                                        Err(failure) => Value::Failure(Failure::Syntax(failure)),
-                                    }
                                 }
                             }
                         }
@@ -15052,7 +14841,6 @@ impl RevisionedQueryDatabase {
             .expect("Layout family is installed once");
         let semantic_nucleus_for_call_abi = semantic_nucleus.clone();
         let declaration_shells_for_call_abi = declaration_shells.clone();
-        let raw_signatures_for_call_abi = raw_declaration_signatures.clone();
         let lookup_names_for_call_abi = lookup_names.clone();
         let produced_anonymous_for_call_abi = body_produced_anonymous.clone();
         let layouts_for_call_abi = layouts.clone();
@@ -15067,7 +14855,6 @@ impl RevisionedQueryDatabase {
                         context,
                         &semantic_nucleus_for_call_abi,
                         &declaration_shells_for_call_abi,
-                        &raw_signatures_for_call_abi,
                         &lookup_names_for_call_abi,
                         &produced_anonymous_for_call_abi,
                         &layouts_for_call_abi,
@@ -16695,7 +16482,6 @@ impl RevisionedQueryDatabase {
                 .set(BodyTransactionEvaluator {
                     parse_modules: parse_modules.clone(),
                     module_source_bases: module_source_bases.clone(),
-                    raw_declaration_signatures: raw_declaration_signatures.clone(),
                     body_input: body_input_resolver,
                     body_source_bases: body_source_bases.clone(),
                     body_toolchain_demands: body_toolchain_demands.clone(),
@@ -16748,7 +16534,6 @@ impl RevisionedQueryDatabase {
             stable_declaration_classifications: stable_declaration_classifications.clone(),
             #[cfg(test)]
             raw_const_syntax,
-            raw_declaration_signatures,
             #[cfg(test)]
             raw_declaration_bodies: raw_declaration_bodies.clone(),
             warning_body_references,
@@ -17651,8 +17436,6 @@ struct BodyInputResolver {
         StableDeclarationClassificationQueryValue,
     >,
     declaration_shells: QueryFamily<DeclarationShellQueryKey, DeclarationShellQueryValue>,
-    raw_declaration_signatures:
-        QueryFamily<RawDeclarationSignatureQueryKey, RawDeclarationSignatureQueryValue>,
     declaration_body_plan_artifacts:
         QueryFamily<DeclarationBodyPlanQueryKey, DeclarationBodyPlanArtifactsValue>,
     body_source_bases:
@@ -17722,40 +17505,16 @@ impl BodyInputResolver {
         {
             return Ok(BodyInputValue::Incomplete(Incomplete::Extern));
         }
-        let signature = match context.query_registered(
-            &self.raw_declaration_signatures,
-            RawDeclarationSignatureQueryKey(candidate.clone()),
-        ) {
-            Ok(value) => value,
-            Err(QueryAbort::MissingInput(_)) => {
-                return Ok(BodyInputValue::Incomplete(Incomplete::MissingPrerequisite(
-                    Arc::from("raw declaration signature"),
-                )));
-            }
-            Err(abort) => return Err(abort),
-        };
-        let rue_query::QueryOutcome::Success(RawDeclarationSignatureQueryValue::Available(
-            signature,
-        )) = signature.outcome()
-        else {
-            return Ok(BodyInputValue::Incomplete(Incomplete::MissingPrerequisite(
-                Arc::from("raw declaration signature"),
-            )));
-        };
         if shell.is_generic && matches!(key.instance, crate::FunctionInstanceKey::Definition(_)) {
             use crate::declaration_candidate::DeclarationCandidateCategory as Category;
-            use crate::semantic_query_nucleus::ParsedSemanticSignature;
 
             let named_runtime_value_body = matches!(
                 candidate.category,
                 Category::Method | Category::AssociatedFunction
-            ) && matches!(
-                crate::semantic_query_nucleus::parse_semantic_signature(&candidate, signature),
-                Ok(ParsedSemanticSignature::Callable { parameters, .. })
-                    if parameters.iter().all(|parameter| {
-                        !parameter.is_comptime || parameter.ty.trim() != "type"
-                    })
-            );
+            ) && shell
+                .parameters
+                .iter()
+                .all(|parameter| !parameter.is_comptime || !parameter.is_type_parameter);
             if !named_runtime_value_body {
                 return Ok(BodyInputValue::Incomplete(Incomplete::Generic));
             }
@@ -17802,8 +17561,6 @@ impl BodyInputResolver {
 struct BodyTransactionEvaluator {
     parse_modules: QueryFamily<ModuleQueryKey, ParseModuleValue>,
     module_source_bases: QueryFamily<ModuleQueryKey, Option<rue_air::DurableBodySourceLocator>>,
-    raw_declaration_signatures:
-        QueryFamily<RawDeclarationSignatureQueryKey, RawDeclarationSignatureQueryValue>,
     body_input: BodyInputResolver,
     body_source_bases:
         QueryFamily<crate::body_query::BodyQueryKey, Option<crate::body_query::BodySourceLocator>>,
@@ -18697,18 +18454,10 @@ impl BodyTransactionEvaluator {
                     else {
                         return Err(QueryAbort::Canceled);
                     };
-                    let exact_signature = context.query_registered(
-                        &self.raw_declaration_signatures,
-                        RawDeclarationSignatureQueryKey(candidate.clone()),
-                    )?;
-                    let rue_query::QueryOutcome::Success(
-                        RawDeclarationSignatureQueryValue::Available(exact_signature),
-                    ) = exact_signature.outcome()
-                    else {
-                        return Err(QueryAbort::Canceled);
-                    };
-                    let Some(exact_result) =
-                        callable_result_type_syntax(&candidate, exact_signature)
+                    let Some(exact_result) = signature
+                        .callable_type_syntax
+                        .as_ref()
+                        .map(|syntax| syntax.result.clone())
                     else {
                         return Err(QueryAbort::Canceled);
                     };
@@ -26611,15 +26360,19 @@ fn main() -> i32 {
         };
         let mut database = RevisionedQueryDatabase::default();
         let revision = revision_for(&mut database, &snapshot);
-        let requested = database.runtime.request_registered(
-            &database.raw_declaration_signatures,
+        let (requested, _) = request_semantic_nucleus_observed(
+            &database,
             revision,
-            RawDeclarationSignatureQueryKey(candidate),
-            CancellationToken::new(),
+            crate::semantic_query_nucleus::SemanticNucleusKey::Signature(
+                crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
+                    declaration: candidate,
+                    configuration: semantic_configuration(),
+                },
+            ),
         );
         assert!(matches!(
-            requested.terminal().unwrap().outcome(),
-            rue_query::QueryOutcome::Success(RawDeclarationSignatureQueryValue::Available(_))
+            requested,
+            crate::semantic_query_nucleus::SemanticNucleusValue::Signature(_)
         ));
         assert_eq!(
             database
@@ -27431,7 +27184,6 @@ fn main() -> i32 {
                         "compiler.lookup-name",
                         "compiler.module-index",
                         "compiler.parse-module",
-                        "compiler.raw-declaration-signature",
                         "compiler.semantic-nucleus",
                     ],
                     7,
@@ -27476,7 +27228,7 @@ fn main() -> i32 {
                     &[
                         "compiler.declaration-shell",
                         "compiler.lookup-name",
-                        "compiler.raw-declaration-signature",
+                        "compiler.parse-module",
                     ],
                     &[
                         "compiler.declaration-occurrence-index",
@@ -27484,7 +27236,6 @@ fn main() -> i32 {
                         "compiler.lookup-name",
                         "compiler.module-index",
                         "compiler.parse-module",
-                        "compiler.raw-declaration-signature",
                         "compiler.semantic-nucleus",
                     ],
                     10,
@@ -27495,7 +27246,7 @@ fn main() -> i32 {
                         &signature_attempt,
                         &[
                             "compiler.declaration-shell",
-                            "compiler.raw-declaration-signature",
+                            "compiler.parse-module",
                             "compiler.semantic-nucleus",
                         ],
                         &[
@@ -27504,7 +27255,6 @@ fn main() -> i32 {
                             "compiler.lookup-name",
                             "compiler.module-index",
                             "compiler.parse-module",
-                            "compiler.raw-declaration-signature",
                             "compiler.semantic-nucleus",
                         ],
                         9,
@@ -27513,15 +27263,11 @@ fn main() -> i32 {
                 _ => assert_direct_semantic_observation(
                     "direct signature",
                     &signature_attempt,
-                    &[
-                        "compiler.declaration-shell",
-                        "compiler.raw-declaration-signature",
-                    ],
+                    &["compiler.declaration-shell", "compiler.parse-module"],
                     &[
                         "compiler.declaration-occurrence-index",
                         "compiler.declaration-shell",
                         "compiler.parse-module",
-                        "compiler.raw-declaration-signature",
                     ],
                     4,
                 ),
@@ -27712,7 +27458,6 @@ fn main() -> i32 {
                 "compiler.declaration-shell",
                 "compiler.parse-module",
                 "compiler.raw-declaration-body",
-                "compiler.raw-declaration-signature",
                 "compiler.semantic-nucleus",
             ],
             7,
@@ -27986,7 +27731,6 @@ fn main() -> i32 {
                     "compiler.parse-module",
                     "compiler.raw-const-syntax",
                     "compiler.raw-declaration-body",
-                    "compiler.raw-declaration-signature",
                     "compiler.semantic-nucleus",
                 ],
                 14,
@@ -28027,7 +27771,6 @@ fn main() -> i32 {
                     "compiler.parse-module",
                     "compiler.raw-const-syntax",
                     "compiler.raw-declaration-body",
-                    "compiler.raw-declaration-signature",
                     "compiler.semantic-nucleus",
                 ],
                 18,
@@ -28130,15 +27873,11 @@ fn main() -> i32 {
                 assert_direct_semantic_observation(
                     "deterministic parameter failure",
                     &keyed_attempt,
-                    &[
-                        "compiler.declaration-shell",
-                        "compiler.raw-declaration-signature",
-                    ],
+                    &["compiler.declaration-shell", "compiler.parse-module"],
                     &[
                         "compiler.declaration-occurrence-index",
                         "compiler.declaration-shell",
                         "compiler.parse-module",
-                        "compiler.raw-declaration-signature",
                     ],
                     4,
                 );
@@ -29633,18 +29372,48 @@ fn main() -> i32 {
         ));
     }
 
-    fn raw_signature_text(
-        syntax: &crate::declaration_candidate::RawDeclarationSignatureSyntax,
-    ) -> String {
-        syntax
-            .declaration_fragments
-            .iter()
-            .map(AsRef::as_ref)
-            .collect::<String>()
+    fn project_signature_for_test(
+        database: &RevisionedQueryDatabase,
+        revision: Revision,
+        key: &crate::declaration_candidate::DeclarationCandidateKey,
+    ) -> crate::semantic_query_nucleus::ParsedSemanticSignature {
+        let parsed = database.runtime.request_registered(
+            &database.parse_modules,
+            revision,
+            ModuleQueryKey(key.module.clone()),
+            CancellationToken::new(),
+        );
+        let rue_query::QueryOutcome::Success(parsed) =
+            parsed.terminal().expect("parse terminal").outcome()
+        else {
+            panic!("parse query publishes typed values")
+        };
+        let module = parsed.result.as_ref().expect("module parses");
+        crate::semantic_query_nucleus::project_semantic_signature(module, key)
+            .expect("exact signature projects")
+    }
+
+    fn request_signature_for_test(
+        database: &RevisionedQueryDatabase,
+        revision: Revision,
+        declaration: crate::declaration_candidate::DeclarationCandidateKey,
+        cancellation: CancellationToken,
+    ) -> QueryRequestAttempt<crate::semantic_query_nucleus::SemanticNucleusValue> {
+        database.runtime.request_registered(
+            &database.semantic_nucleus,
+            revision,
+            crate::semantic_query_nucleus::SemanticNucleusKey::Signature(
+                crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
+                    declaration,
+                    configuration: semantic_configuration(),
+                },
+            ),
+            cancellation,
+        )
     }
 
     #[test]
-    fn raw_declaration_signature_is_exact_lazy_and_red_green() {
+    fn declaration_signature_is_exact_lazy_and_red_green() {
         fn program(selected_type: &str, unrelated_body: u32) -> String {
             let mut source = String::new();
             for index in 0..128 {
@@ -29667,114 +29436,95 @@ fn main() -> i32 {
             source_snapshot(&[(1, "/main.rue", "main.rue", &selected_edit_text)], 1);
         let module = ModuleId::from_logical_path("main.rue").unwrap();
         let key = crate::declaration_candidate::DeclarationCandidateKey {
-            module: module.clone(),
+            module,
             category: crate::declaration_candidate::DeclarationCandidateCategory::Function,
             name: Arc::from("selected"),
             owner: None,
             duplicate_discriminator: 0,
         };
         let mut database = RevisionedQueryDatabase::default();
-        let first_revision = database.source_revision(
-            &super::super::session::ExactSourceInput::new(&first),
-            &first,
-        );
-        let parsed = database.runtime.request_registered(
-            &database.parse_modules,
-            first_revision,
-            ModuleQueryKey(module),
-            CancellationToken::new(),
-        );
-        let parsed_module = match parsed.terminal().unwrap().outcome() {
-            rue_query::QueryOutcome::Success(value) => value.result.clone().unwrap(),
-            rue_query::QueryOutcome::Failure(_) => unreachable!(),
-        };
-        assert_eq!(
-            parsed_module.raw_declaration_signature_terminal_materialization_count(),
-            0,
-            "indexing 129 declarations must allocate no raw-signature terminal fragments"
-        );
 
-        let first_request = database.runtime.request_registered(
-            &database.raw_declaration_signatures,
+        let first_revision = revision_for(&mut database, &first);
+        let first_request = request_signature_for_test(
+            &database,
             first_revision,
-            RawDeclarationSignatureQueryKey(key.clone()),
+            key.clone(),
             CancellationToken::new(),
         );
         assert_eq!(execution(&first_request), RequestExecution::Computed);
-        assert_eq!(
+        assert!(
             first_request
                 .dependencies()
                 .iter()
-                .map(|dependency| dependency.node.family())
-                .collect::<Vec<_>>(),
-            vec![
-                "compiler.declaration-occurrence-index",
-                "compiler.declaration-shell",
-                "compiler.parse-module",
-            ]
+                .any(|dependency| dependency.node.family() == "compiler.parse-module")
         );
-        let first_terminal = first_request.terminal().unwrap();
+        let first_terminal = first_request.terminal().expect("signature terminal");
         let first_stamp = first_terminal.stamp();
-        assert!(matches!(
-            first_terminal.outcome(),
-            rue_query::QueryOutcome::Success(
-                RawDeclarationSignatureQueryValue::Available(syntax)
-            ) if raw_signature_text(syntax).trim_end() == "fn selected(value: i32) -> i32"
-                && syntax.extern_abi.is_none()
-        ));
-        assert_eq!(
-            parsed_module.raw_declaration_signature_terminal_materialization_count(),
-            1,
-            "one exact cold demand must materialize one raw-signature terminal"
-        );
+        let rue_query::QueryOutcome::Success(
+            crate::semantic_query_nucleus::SemanticNucleusValue::Signature(first_signature),
+        ) = first_terminal.outcome()
+        else {
+            panic!("selected signature resolves")
+        };
+        let syntax = first_signature
+            .callable_type_syntax
+            .as_ref()
+            .expect("callable syntax is retained with the resolved signature");
+        assert_eq!(&*syntax.parameters, [Arc::<str>::from("i32")]);
+        assert_eq!(syntax.result.as_ref(), "i32");
 
-        let warm = database.runtime.request_registered(
-            &database.raw_declaration_signatures,
+        let warm = request_signature_for_test(
+            &database,
             first_revision,
-            RawDeclarationSignatureQueryKey(key.clone()),
+            key.clone(),
             CancellationToken::new(),
         );
         assert_eq!(execution(&warm), RequestExecution::Reused);
-        assert_eq!(
-            parsed_module.raw_declaration_signature_terminal_materialization_count(),
-            1,
-            "warm reuse must not rematerialize raw-signature terminal fragments"
-        );
 
-        let unrelated_revision = database.source_revision(
-            &super::super::session::ExactSourceInput::new(&unrelated_edit),
-            &unrelated_edit,
-        );
-        let unrelated_request = database.runtime.request_registered(
-            &database.raw_declaration_signatures,
+        let unrelated_revision = revision_for(&mut database, &unrelated_edit);
+        let unrelated_request = request_signature_for_test(
+            &database,
             unrelated_revision,
-            RawDeclarationSignatureQueryKey(key.clone()),
+            key.clone(),
             CancellationToken::new(),
         );
-        assert_eq!(unrelated_request.terminal().unwrap().stamp(), first_stamp);
+        assert_eq!(
+            unrelated_request
+                .terminal()
+                .expect("signature terminal")
+                .stamp(),
+            first_stamp,
+            "an unrelated body edit must preserve the authoritative signature stamp"
+        );
 
-        let selected_revision = database.source_revision(
-            &super::super::session::ExactSourceInput::new(&selected_edit),
-            &selected_edit,
-        );
-        let selected_request = database.runtime.request_registered(
-            &database.raw_declaration_signatures,
-            selected_revision,
-            RawDeclarationSignatureQueryKey(key),
-            CancellationToken::new(),
-        );
-        let selected_terminal = selected_request.terminal().unwrap();
+        let selected_revision = revision_for(&mut database, &selected_edit);
+        let selected_request =
+            request_signature_for_test(&database, selected_revision, key, CancellationToken::new());
+        let selected_terminal = selected_request.terminal().expect("signature terminal");
         assert_ne!(selected_terminal.stamp(), first_stamp);
-        assert!(matches!(
-            selected_terminal.outcome(),
-            rue_query::QueryOutcome::Success(
-                RawDeclarationSignatureQueryValue::Available(syntax)
-            ) if raw_signature_text(syntax).trim_end() == "fn selected(value: i64) -> i64"
-        ));
+        let rue_query::QueryOutcome::Success(
+            crate::semantic_query_nucleus::SemanticNucleusValue::Signature(selected_signature),
+        ) = selected_terminal.outcome()
+        else {
+            panic!("edited signature resolves")
+        };
+        let syntax = selected_signature
+            .callable_type_syntax
+            .as_ref()
+            .expect("callable syntax is retained");
+        assert_eq!(&*syntax.parameters, [Arc::<str>::from("i64")]);
+        assert_eq!(syntax.result.as_ref(), "i64");
+        assert_eq!(
+            database
+                .declaration_body_plan_astgen_evaluations
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "signature evaluation must not lower a body"
+        );
     }
 
     #[test]
-    fn raw_declaration_signatures_cover_categories_without_struct_method_peers() {
+    fn parsed_signature_projection_covers_every_category_and_exact_duplicate() {
         use crate::declaration_candidate::DeclarationCandidateCategory as Category;
 
         let source = source_snapshot(
@@ -29782,10 +29532,11 @@ fn main() -> i32 {
                 1,
                 "/main.rue",
                 "main.rue",
-                "@copy linear struct Box { value: i32, fn get(borrow self) -> i32 { self.value } @allow(unused_function) fn make(value: i32) -> Box { Box { value } } }\n\
+                "@copy linear struct Box { value: i32, fn get(borrow self) -> i32 { self.value } fn make(value: i32) -> Box { Box { value } } }\n\
                  enum Choice { Empty, Value(i32, u64) }\n\
                  drop fn Box(self) {}\n\
-                 extern \"C\" { fn foreign(value: ptr const u8) -> i32; }",
+                 extern \"C\" { fn foreign(value: ptr const u8) -> i32; }\n\
+                 fn duplicate(value: i32) {} fn duplicate(value: i64) {}",
             )],
             1,
         );
@@ -29794,114 +29545,130 @@ fn main() -> i32 {
             category: Category::Struct,
             name: Arc::from("Box"),
         };
-        let key = |category, name: &'static str, owner| {
+        let key = |category, name: &'static str, owner, duplicate_discriminator| {
             crate::declaration_candidate::DeclarationCandidateKey {
                 module: module.clone(),
                 category,
                 name: Arc::from(name),
                 owner,
-                duplicate_discriminator: 0,
+                duplicate_discriminator,
             }
         };
         let mut database = RevisionedQueryDatabase::default();
-        let revision = database.source_revision(
-            &super::super::session::ExactSourceInput::new(&source),
-            &source,
-        );
-        let request = |key| {
-            database.runtime.request_registered(
-                &database.raw_declaration_signatures,
-                revision,
-                RawDeclarationSignatureQueryKey(key),
-                CancellationToken::new(),
-            )
-        };
+        let revision = revision_for(&mut database, &source);
 
-        let structure = request(key(Category::Struct, "Box", None));
-        let structure_terminal = structure.terminal().unwrap();
-        let structure_stamp = structure_terminal.stamp();
-        let structure = match structure_terminal.outcome() {
-            rue_query::QueryOutcome::Success(RawDeclarationSignatureQueryValue::Available(
-                syntax,
-            )) => syntax,
-            other => panic!("expected struct signature, got {other:?}"),
+        let structure =
+            project_signature_for_test(&database, revision, &key(Category::Struct, "Box", None, 0));
+        let crate::semantic_query_nucleus::ParsedSemanticSignature::Struct {
+            fields,
+            is_copy: true,
+            is_linear: true,
+            is_repr_c: false,
+            ..
+        } = &structure
+        else {
+            panic!("expected compact struct signature, got {structure:?}");
         };
-        let structure_text = raw_signature_text(structure);
-        assert!(structure_text.contains("@copy linear struct Box"));
-        assert!(structure_text.contains("value: i32"));
-        assert!(!structure_text.contains("fn get"));
-        assert!(!structure_text.contains("fn make"));
-        assert!(structure_text.trim_end().ends_with('}'));
-        assert_eq!(structure.declaration_fragments.len(), 2);
+        assert_eq!(fields.len(), 1);
+        assert_eq!(structure.text(fields[0].name), "value");
+        assert_eq!(structure.text(fields[0].ty), "i32");
 
-        for (candidate, expected) in [
+        for (candidate, expected_result, expected_self) in [
             (
-                key(Category::Method, "get", Some(owner.clone())),
-                "fn get(borrow self) -> i32",
+                key(Category::Method, "get", Some(owner.clone()), 0),
+                "i32",
+                true,
             ),
             (
-                key(Category::AssociatedFunction, "make", Some(owner.clone())),
-                "@allow(unused_function) fn make(value: i32) -> Box",
-            ),
-            (
-                key(Category::Enum, "Choice", None),
-                "enum Choice { Empty, Value(i32, u64) }",
-            ),
-            (
-                key(Category::Destructor, "Box", Some(owner)),
-                "drop fn Box(self)",
+                key(Category::AssociatedFunction, "make", Some(owner.clone()), 0),
+                "Box",
+                false,
             ),
         ] {
-            let requested = request(candidate);
+            let signature = project_signature_for_test(&database, revision, &candidate);
             assert!(matches!(
-                requested.terminal().unwrap().outcome(),
-                rue_query::QueryOutcome::Success(
-                    RawDeclarationSignatureQueryValue::Available(syntax)
-                ) if raw_signature_text(syntax).trim_end() == expected
-                    && syntax.extern_abi.is_none()
+                &signature,
+                crate::semantic_query_nucleus::ParsedSemanticSignature::Callable {
+                    result,
+                    has_self,
+                    is_extern: false,
+                    ..
+                } if signature.text(*result) == expected_result && *has_self == expected_self
             ));
         }
 
-        let foreign = request(key(Category::ExternFunction, "foreign", None));
+        let enumeration = project_signature_for_test(
+            &database,
+            revision,
+            &key(Category::Enum, "Choice", None, 0),
+        );
+        let crate::semantic_query_nucleus::ParsedSemanticSignature::Enum {
+            variants, payloads, ..
+        } = &enumeration
+        else {
+            panic!("expected compact enum signature, got {enumeration:?}");
+        };
+        assert_eq!(variants.len(), 2);
+        assert_eq!(enumeration.text(variants[0].name), "Empty");
+        assert_eq!(enumeration.text(variants[1].name), "Value");
+        let payload =
+            &payloads[variants[1].payload_start as usize..variants[1].payload_end as usize];
+        assert_eq!(
+            payload
+                .iter()
+                .map(|value| enumeration.text(*value))
+                .collect::<Vec<_>>(),
+            ["i32", "u64"]
+        );
+
         assert!(matches!(
-            foreign.terminal().unwrap().outcome(),
-            rue_query::QueryOutcome::Success(
-                RawDeclarationSignatureQueryValue::Available(syntax)
-            ) if raw_signature_text(syntax) == "fn foreign(value: ptr const u8) -> i32;"
-                && syntax.extern_abi.as_deref() == Some("\"C\"")
+            project_signature_for_test(
+                &database,
+                revision,
+                &key(Category::Destructor, "Box", Some(owner), 0),
+            ),
+            crate::semantic_query_nucleus::ParsedSemanticSignature::Destructor
+        ));
+        let foreign = project_signature_for_test(
+            &database,
+            revision,
+            &key(Category::ExternFunction, "foreign", None, 0),
+        );
+        assert!(matches!(
+            &foreign,
+            crate::semantic_query_nucleus::ParsedSemanticSignature::Callable {
+                parameters,
+                result,
+                is_extern: true,
+                ..
+            } if parameters.len() == 1
+                && foreign.text(parameters[0].ty) == "ptr const u8"
+                && foreign.text(*result) == "i32"
         ));
 
-        let peer_signature_edit = source_snapshot(
-            &[(
-                1,
-                "/main.rue",
-                "main.rue",
-                "@copy linear struct Box { value: i32, fn get(borrow self) -> u64 { 0 } @allow(unused_function) fn make(value: i32) -> Box { Box { value } } }\n\
-                 enum Choice { Empty, Value(i32, u64) }\n\
-                 drop fn Box(self) {}\n\
-                 extern \"C\" { fn foreign(value: ptr const u8) -> i32; }",
-            )],
-            1,
-        );
-        let peer_revision = database.source_revision(
-            &super::super::session::ExactSourceInput::new(&peer_signature_edit),
-            &peer_signature_edit,
-        );
-        let unchanged_structure = database.runtime.request_registered(
-            &database.raw_declaration_signatures,
-            peer_revision,
-            RawDeclarationSignatureQueryKey(key(Category::Struct, "Box", None)),
-            CancellationToken::new(),
-        );
-        assert_eq!(
-            unchanged_structure.terminal().unwrap().stamp(),
-            structure_stamp,
-            "a peer method signature must not change the struct signature terminal"
-        );
+        for (duplicate_discriminator, expected) in [(0, "i32"), (1, "i64")] {
+            let signature = project_signature_for_test(
+                &database,
+                revision,
+                &key(
+                    Category::Function,
+                    "duplicate",
+                    None,
+                    duplicate_discriminator,
+                ),
+            );
+            assert!(matches!(
+                &signature,
+                crate::semantic_query_nucleus::ParsedSemanticSignature::Callable {
+                    parameters,
+                    ..
+                } if parameters.len() == 1 && signature.text(parameters[0].ty) == expected
+            ));
+        }
     }
 
     #[test]
-    fn raw_declaration_signature_boundaries_exclude_body_and_method_trivia() {
+    fn parsed_signature_projection_excludes_body_peer_and_absolute_trivia() {
         use crate::declaration_candidate::DeclarationCandidateCategory as Category;
 
         let first = source_snapshot(
@@ -29909,267 +29676,143 @@ fn main() -> i32 {
                 1,
                 "/main.rue",
                 "main.rue",
-                "fn free(value: i32) -> i32 // free boundary one\n\
-                     { value }\n\
-                 struct Box { value: i32, // before first method one\n\
-                     fn get(borrow self) -> i32 // method boundary one\n\
-                         { self.value }\n\
-                     // between methods one\n\
-                     fn make(value: i32) -> Box // associated boundary one\n\
-                         { Box { value } }\n\
-                     // after last method one\n\
-                 }\n\
-                 drop fn Box(self) // destructor boundary one\n\
-                     {}",
+                "fn free(value: i32) -> i32 { value }\n\
+                 struct Box { value: i32, fn get(borrow self) -> i32 { self.value } }",
             )],
             1,
         );
-        let trivia_edit = source_snapshot(
+        let relocated = source_snapshot(
             &[(
                 1,
                 "/main.rue",
                 "main.rue",
-                "fn free(value: i32) -> i32         // free boundary two\n\
-\n\
-                 { value }\n\
-                 struct Box { value: i32,             // before first method two\n\
-\n\
-                     fn get(borrow self) -> i32       // method boundary two\n\
-\n\
-                     { self.value }\n\
-                         // between methods two\n\
-                     fn make(value: i32) -> Box       // associated boundary two\n\
-\n\
-                     { Box { value } }\n\
-                         // after last method two\n\
-\n\
-                 }\n\
-                 drop fn Box(self)                    // destructor boundary two\n\
-\n\
-                 {}",
+                "// moved prefix\n\
+                 fn free(value: i32) -> i32 // boundary\n\
+                     { value + 0 }\n\
+                 struct Box { value: i32, fn get(borrow self) -> u64 { 0 } }",
+            )],
+            1,
+        );
+        let signature_edit = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn free(value: i64) -> i32 { 0 }\n\
+                 struct Box { value: i32, fn get(borrow self) -> u64 { 0 } }",
             )],
             1,
         );
         let module = ModuleId::from_logical_path("main.rue").unwrap();
-        let owner = crate::declaration_candidate::DeclarationCandidateOwner {
+        let free = crate::declaration_candidate::DeclarationCandidateKey {
+            module: module.clone(),
+            category: Category::Function,
+            name: Arc::from("free"),
+            owner: None,
+            duplicate_discriminator: 0,
+        };
+        let structure = crate::declaration_candidate::DeclarationCandidateKey {
+            module,
             category: Category::Struct,
             name: Arc::from("Box"),
+            owner: None,
+            duplicate_discriminator: 0,
         };
-        let key = |category, name: &'static str, owner| {
-            crate::declaration_candidate::DeclarationCandidateKey {
-                module: module.clone(),
-                category,
-                name: Arc::from(name),
-                owner,
-                duplicate_discriminator: 0,
-            }
-        };
-        let cases = [
-            (
-                key(Category::Function, "free", None),
-                "fn free(value: i32) -> i32",
-            ),
-            (
-                key(Category::Struct, "Box", None),
-                "struct Box { value: i32}",
-            ),
-            (
-                key(Category::Method, "get", Some(owner.clone())),
-                "fn get(borrow self) -> i32",
-            ),
-            (
-                key(Category::AssociatedFunction, "make", Some(owner.clone())),
-                "fn make(value: i32) -> Box",
-            ),
-            (
-                key(Category::Destructor, "Box", Some(owner)),
-                "drop fn Box(self)",
-            ),
-        ];
         let mut database = RevisionedQueryDatabase::default();
-        let first_revision = database.source_revision(
-            &super::super::session::ExactSourceInput::new(&first),
-            &first,
-        );
-        let mut first_terminals = Vec::new();
-        for (candidate, expected) in &cases {
-            let requested = database.runtime.request_registered(
-                &database.raw_declaration_signatures,
-                first_revision,
-                RawDeclarationSignatureQueryKey(candidate.clone()),
-                CancellationToken::new(),
-            );
-            let terminal = requested.terminal().unwrap();
-            assert!(matches!(
-                terminal.outcome(),
-                rue_query::QueryOutcome::Success(
-                    RawDeclarationSignatureQueryValue::Available(syntax)
-                ) if raw_signature_text(syntax) == *expected
-            ));
-            first_terminals.push((candidate.clone(), terminal.stamp()));
-        }
 
-        let edited_revision = database.source_revision(
-            &super::super::session::ExactSourceInput::new(&trivia_edit),
-            &trivia_edit,
+        let first_revision = revision_for(&mut database, &first);
+        let first_free = project_signature_for_test(&database, first_revision, &free);
+        let first_structure = project_signature_for_test(&database, first_revision, &structure);
+
+        let relocated_revision = revision_for(&mut database, &relocated);
+        assert_eq!(
+            project_signature_for_test(&database, relocated_revision, &free),
+            first_free,
+            "body and absolute-trivia motion must not change a signature"
         );
-        for (candidate, first_stamp) in first_terminals {
-            let requested = database.runtime.request_registered(
-                &database.raw_declaration_signatures,
-                edited_revision,
-                RawDeclarationSignatureQueryKey(candidate),
-                CancellationToken::new(),
-            );
-            assert_eq!(
-                requested.terminal().unwrap().stamp(),
-                first_stamp,
-                "body-boundary and method-adjacent trivia must stay outside the signature terminal"
-            );
-        }
+        assert_eq!(
+            project_signature_for_test(&database, relocated_revision, &structure),
+            first_structure,
+            "a peer method signature must not enter the struct signature"
+        );
+
+        let signature_revision = revision_for(&mut database, &signature_edit);
+        assert_ne!(
+            project_signature_for_test(&database, signature_revision, &free),
+            first_free,
+            "an exact parameter-type edit must change the signature"
+        );
     }
 
     #[test]
-    fn raw_declaration_signature_duplicate_discriminators_are_exact() {
-        let source = source_snapshot(
-            &[(
-                1,
-                "/main.rue",
-                "main.rue",
-                "fn duplicate(value: i32) {} fn duplicate(value: i64) {}",
-            )],
-            1,
-        );
-        let module = ModuleId::from_logical_path("main.rue").unwrap();
-        let mut database = RevisionedQueryDatabase::default();
-        let revision = database.source_revision(
-            &super::super::session::ExactSourceInput::new(&source),
-            &source,
-        );
-        for (duplicate_discriminator, expected) in [
-            (0, "fn duplicate(value: i32)"),
-            (1, "fn duplicate(value: i64)"),
-        ] {
-            let key = crate::declaration_candidate::DeclarationCandidateKey {
-                module: module.clone(),
-                category: crate::declaration_candidate::DeclarationCandidateCategory::Function,
-                name: Arc::from("duplicate"),
-                owner: None,
-                duplicate_discriminator,
-            };
-            let requested = database.runtime.request_registered(
-                &database.raw_declaration_signatures,
-                revision,
-                RawDeclarationSignatureQueryKey(key),
-                CancellationToken::new(),
-            );
-            assert!(matches!(
-                requested.terminal().unwrap().outcome(),
-                rue_query::QueryOutcome::Success(
-                    RawDeclarationSignatureQueryValue::Available(syntax)
-                ) if raw_signature_text(syntax).trim_end() == expected
-            ));
-        }
-    }
-
-    #[test]
-    fn raw_declaration_signature_failures_cancel_and_recover() {
-        use crate::declaration_candidate::{
-            DeclarationCandidateCategory as Category, DeclarationOccurrenceFailure,
-            RawDeclarationSignatureFailure,
-        };
+    fn parsed_accessor_signature_uses_exact_owner_facts() {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Category;
+        use rue_air::declaration_validation::AccessorBodyVerdict;
 
         let source = source_snapshot(
             &[(
                 1,
                 "/main.rue",
                 "main.rue",
-                "const value = 1; fn present() {}",
+                "struct S { field: i32, fn selected(borrow self) -> borrow i32 { yield self.selected(); } }",
             )],
             1,
         );
         let module = ModuleId::from_logical_path("main.rue").unwrap();
-        let key =
-            |category, name: &'static str| crate::declaration_candidate::DeclarationCandidateKey {
-                module: module.clone(),
-                category,
-                name: Arc::from(name),
-                owner: None,
-                duplicate_discriminator: 0,
-            };
+        let key = crate::declaration_candidate::DeclarationCandidateKey {
+            module,
+            category: Category::Method,
+            name: Arc::from("selected"),
+            owner: Some(crate::declaration_candidate::DeclarationCandidateOwner {
+                category: Category::Struct,
+                name: Arc::from("S"),
+            }),
+            duplicate_discriminator: 0,
+        };
         let mut database = RevisionedQueryDatabase::default();
-        let revision = database.source_revision(
-            &super::super::session::ExactSourceInput::new(&source),
-            &source,
-        );
-        let constant = key(Category::ConstCandidate, "value");
-        let absent = key(Category::Function, "absent");
-        for (candidate, expected) in [
-            (
-                constant.clone(),
-                RawDeclarationSignatureFailure::CategoryMismatch(constant),
-            ),
-            (
-                absent.clone(),
-                RawDeclarationSignatureFailure::Absent(absent),
-            ),
-        ] {
-            let requested = database.runtime.request_registered(
-                &database.raw_declaration_signatures,
-                revision,
-                RawDeclarationSignatureQueryKey(candidate),
-                CancellationToken::new(),
-            );
-            assert!(matches!(
-                requested.terminal().unwrap().outcome(),
-                rue_query::QueryOutcome::Success(
-                    RawDeclarationSignatureQueryValue::Failure(actual)
-                ) if actual == &expected
-            ));
-        }
+        let revision = revision_for(&mut database, &source);
+        let signature = project_signature_for_test(&database, revision, &key);
+        assert!(matches!(
+            signature,
+            crate::semantic_query_nucleus::ParsedSemanticSignature::Callable {
+                is_accessor: true,
+                accessor_body: AccessorBodyVerdict::WellFormed,
+                accessor_cycle: Some(name),
+                ..
+            } if name.as_ref() == "selected"
+        ));
+    }
 
-        let present = key(Category::Function, "present");
+    #[test]
+    fn authoritative_signature_cancellation_publishes_nothing_and_retries() {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Category;
+
+        let source = source_snapshot(&[(1, "/main.rue", "main.rue", "fn present() {}")], 1);
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let key = crate::declaration_candidate::DeclarationCandidateKey {
+            module,
+            category: Category::Function,
+            name: Arc::from("present"),
+            owner: None,
+            duplicate_discriminator: 0,
+        };
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = revision_for(&mut database, &source);
+
         let canceled = CancellationToken::new();
         canceled.cancel();
-        let aborted = database.runtime.request_registered(
-            &database.raw_declaration_signatures,
-            revision,
-            RawDeclarationSignatureQueryKey(present.clone()),
-            canceled,
-        );
+        let aborted = request_signature_for_test(&database, revision, key.clone(), canceled);
         assert_eq!(execution(&aborted), RequestExecution::Aborted);
         assert!(aborted.terminal().is_none());
-        let recovered = database.runtime.request_registered(
-            &database.raw_declaration_signatures,
-            revision,
-            RawDeclarationSignatureQueryKey(present),
-            CancellationToken::new(),
-        );
-        assert!(matches!(
-            recovered.terminal().unwrap().outcome(),
-            rue_query::QueryOutcome::Success(RawDeclarationSignatureQueryValue::Available(_))
-        ));
 
-        let rejected = source_snapshot(&[(1, "/main.rue", "main.rue", "fn broken(")], 1);
-        let rejected_revision = database.source_revision(
-            &super::super::session::ExactSourceInput::new(&rejected),
-            &rejected,
-        );
-        let rejected_key = key(Category::Function, "broken");
-        let requested = database.runtime.request_registered(
-            &database.raw_declaration_signatures,
-            rejected_revision,
-            RawDeclarationSignatureQueryKey(rejected_key),
-            CancellationToken::new(),
-        );
+        let recovered =
+            request_signature_for_test(&database, revision, key, CancellationToken::new());
+        assert_eq!(execution(&recovered), RequestExecution::Computed);
         assert!(matches!(
-            requested.terminal().unwrap().outcome(),
+            recovered.terminal().expect("signature terminal").outcome(),
             rue_query::QueryOutcome::Success(
-                RawDeclarationSignatureQueryValue::Failure(
-                    RawDeclarationSignatureFailure::OccurrencesUnavailable(
-                        DeclarationOccurrenceFailure::ParseRejected { module: failed_module }
-                    )
-                )
-            ) if failed_module == &module
+                crate::semantic_query_nucleus::SemanticNucleusValue::Signature(_)
+            )
         ));
     }
 

--- a/crates/rue-compiler/src/semantic_query_nucleus.rs
+++ b/crates/rue-compiler/src/semantic_query_nucleus.rs
@@ -7,6 +7,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
+use lasso::Spur;
 use rue_air::declaration_validation::{
     AccessorBodyVerdict, AccessorExitForm, AccessorYieldRootForm,
 };
@@ -27,17 +28,42 @@ use crate::{
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ParsedSemanticParameter {
-    pub(crate) name: Arc<str>,
+    pub(crate) name: ParsedSemanticText,
     pub(crate) mode: crate::declaration_candidate::DeclarationParameterMode,
     pub(crate) is_comptime: bool,
-    pub(crate) ty: Arc<str>,
+    pub(crate) ty: ParsedSemanticText,
+}
+
+/// One string inside a declaration signature's compact text envelope.
+///
+/// The range is candidate-local and position-independent. It never indexes the
+/// source file: the producer copies only the semantic spellings that consumers
+/// still need until the structured-type tranche removes those spellings too.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ParsedSemanticText {
+    pub(crate) start: u32,
+    pub(crate) end: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ParsedSemanticField {
+    pub(crate) name: ParsedSemanticText,
+    pub(crate) ty: ParsedSemanticText,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ParsedSemanticVariant {
+    pub(crate) name: ParsedSemanticText,
+    pub(crate) payload_start: u32,
+    pub(crate) payload_end: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ParsedSemanticSignature {
     Callable {
+        text: Arc<str>,
         parameters: Arc<[ParsedSemanticParameter]>,
-        result: Arc<str>,
+        result: ParsedSemanticText,
         has_self: bool,
         self_mode: crate::declaration_candidate::DeclarationParameterMode,
         is_unchecked: bool,
@@ -58,18 +84,32 @@ pub(crate) enum ParsedSemanticSignature {
         accessor_cycle: Option<Arc<str>>,
     },
     Struct {
-        fields: Arc<[(Arc<str>, Arc<str>)]>,
+        text: Arc<str>,
+        fields: Arc<[ParsedSemanticField]>,
         is_copy: bool,
         is_linear: bool,
         is_repr_c: bool,
     },
     Enum {
-        variants: Arc<[(Arc<str>, Arc<[Arc<str>]>)]>,
+        text: Arc<str>,
+        variants: Arc<[ParsedSemanticVariant]>,
+        payloads: Arc<[ParsedSemanticText]>,
     },
     Destructor,
 }
 
 impl ParsedSemanticSignature {
+    pub(crate) fn text(&self, value: ParsedSemanticText) -> &str {
+        let text = match self {
+            Self::Callable { text, .. } | Self::Struct { text, .. } | Self::Enum { text, .. } => {
+                text
+            }
+            Self::Destructor => return "",
+        };
+        text.get(value.start as usize..value.end as usize)
+            .expect("signature text ranges are validated when projected")
+    }
+
     pub(crate) fn callable_type_syntax(&self) -> Option<rue_air::DurableCallableTypeSyntax> {
         let Self::Callable {
             parameters, result, ..
@@ -80,66 +120,41 @@ impl ParsedSemanticSignature {
         Some(rue_air::DurableCallableTypeSyntax {
             parameters: parameters
                 .iter()
-                .map(|parameter| parameter.ty.clone())
+                .map(|parameter| Arc::from(self.text(parameter.ty)))
                 .collect(),
-            result: result.clone(),
+            result: Arc::from(self.text(*result)),
         })
     }
 }
 
-/// The body an accessor's signature reparse carries, or the empty stand-in
-/// every ordinary signature reconstructs with.
-fn accessor_body_source(
-    syntax: &crate::declaration_candidate::RawDeclarationSignatureSyntax,
-) -> &str {
-    syntax
-        .accessor
-        .as_ref()
-        .map_or("{}", |accessor| accessor.body.as_ref())
-}
-
-fn signature_source(
-    key: &DeclarationCandidateKey,
-    syntax: &crate::declaration_candidate::RawDeclarationSignatureSyntax,
-) -> String {
-    let fragments = syntax
-        .declaration_fragments
-        .iter()
-        .map(AsRef::as_ref)
-        .collect::<Vec<&str>>();
-    match key.category {
-        // Split struct terminals already retain the entire declaration except
-        // method declarations. Concatenating the retained prefix and closing
-        // brace reconstructs valid field-only syntax; inserting a bare block
-        // here would itself be parsed as a malformed field.
-        Category::Struct => fragments.concat(),
-        Category::Function | Category::Destructor => {
-            format!("{} {}", fragments.concat(), accessor_body_source(syntax))
-        }
-        Category::Method | Category::AssociatedFunction => format!(
-            "struct {} {{ {} {} }}",
-            key.owner
-                .as_ref()
-                .map(|owner| owner.name.as_ref())
-                .unwrap_or("__missing_owner"),
-            fragments.concat(),
-            accessor_body_source(syntax),
-        ),
-        Category::ExternFunction => format!(
-            "extern {} {{ {} }}",
-            syntax.extern_abi.as_deref().unwrap_or("\"C\""),
-            fragments.concat(),
-        ),
-        Category::Enum => fragments.concat(),
-        Category::ConstCandidate => String::new(),
-    }
-}
-
-fn source_fragment(source: &str, span: rue_span::Span) -> Result<Arc<str>, Arc<str>> {
+fn source_fragment(source: &str, span: rue_span::Span) -> Result<&str, Arc<str>> {
     source
         .get(span.start as usize..span.end as usize)
-        .map(Arc::from)
         .ok_or_else(|| Arc::from("semantic signature contains an invalid local span"))
+}
+
+#[derive(Default)]
+struct ParsedSemanticTextBuilder {
+    text: String,
+}
+
+impl ParsedSemanticTextBuilder {
+    fn push(&mut self, value: &str) -> Result<ParsedSemanticText, Arc<str>> {
+        let start = u32::try_from(self.text.len())
+            .map_err(|_| Arc::from("semantic signature text exceeds the supported size"))?;
+        let end = self
+            .text
+            .len()
+            .checked_add(value.len())
+            .and_then(|value| u32::try_from(value).ok())
+            .ok_or_else(|| Arc::from("semantic signature text exceeds the supported size"))?;
+        self.text.push_str(value);
+        Ok(ParsedSemanticText { start, end })
+    }
+
+    fn finish(self) -> Arc<str> {
+        Arc::from(self.text)
+    }
 }
 
 fn parameter_mode(
@@ -154,9 +169,10 @@ fn parameter_mode(
     }
 }
 
-fn parsed_parameters(
+fn parsed_parameters<'a>(
+    text: &mut ParsedSemanticTextBuilder,
     source: &str,
-    interner: &crate::ThreadedRodeo,
+    resolve: impl Copy + Fn(Spur) -> &'a str,
     parameters: &[rue_parser::ast::Param],
 ) -> Result<Arc<[ParsedSemanticParameter]>, Arc<str>> {
     parameters
@@ -164,10 +180,10 @@ fn parsed_parameters(
         .map(|parameter| {
             let (mode, is_comptime) = parameter_mode(parameter.mode);
             Ok(ParsedSemanticParameter {
-                name: Arc::from(interner.resolve(&parameter.name.name)),
+                name: text.push(resolve(parameter.name.name))?,
                 mode,
                 is_comptime,
-                ty: source_fragment(source, parameter.ty.span())?,
+                ty: text.push(source_fragment(source, parameter.ty.span())?)?,
             })
         })
         .collect::<Result<Vec<_>, Arc<str>>>()
@@ -246,9 +262,9 @@ pub(crate) fn ast_self_call_targets(
 /// calls a method of this accessor's owner, so `owner_methods` names it. A
 /// receiver that is anything else — a chained call, a field, an index — has a
 /// type this query does not resolve, and a callee this query must not guess.
-fn accessor_method_link(
+fn accessor_method_link<'a>(
     call: &rue_parser::ast::MethodCallExpr,
-    interner: &crate::ThreadedRodeo,
+    resolve: impl Copy + Fn(Spur) -> &'a str,
     owner_methods: &[rue_air::declaration_validation::AccessorOwnerMethod],
 ) -> rue_air::declaration_validation::AccessorMethodLink {
     use rue_air::declaration_validation::AccessorMethodLink as Link;
@@ -260,7 +276,7 @@ fn accessor_method_link(
     if !matches!(receiver, Expr::SelfExpr(_)) {
         return Link::Unresolved;
     }
-    let name = interner.resolve(&call.method.name);
+    let name = resolve(call.method.name);
     match owner_methods
         .iter()
         .find(|method| method.name.as_ref() == name)
@@ -297,9 +313,9 @@ fn accessor_method_link(
 /// `self.field.m()` — targets a type this query cannot name, so the walk stays
 /// permissive and leaves the rejection to the demanded path, which has the
 /// receiver's type in hand.
-fn accessor_body_shape(
+fn accessor_body_shape<'a>(
     body: &rue_parser::ast::Expr,
-    interner: &crate::ThreadedRodeo,
+    resolve: impl Copy + Fn(Spur) -> &'a str,
     owner_methods: &[rue_air::declaration_validation::AccessorOwnerMethod],
 ) -> AccessorBodyVerdict {
     use rue_parser::ast::Expr;
@@ -313,8 +329,8 @@ fn accessor_body_shape(
     let mut first_exit: Option<(AccessorExitForm, u32)> = None;
     while let Some(expr) = pending.pop() {
         let exit = match expr {
-            // Occurrences are distinguished by span: the reparsed signature
-            // source holds each `yield` exactly once.
+            // Occurrences are distinguished by span: the canonical parsed
+            // body holds each `yield` exactly once.
             Expr::Yield(exit) if exit.span != trailing.span => AccessorExitForm::SecondYield,
             Expr::Return(_) => AccessorExitForm::Return,
             Expr::Try(_) => AccessorExitForm::Try,
@@ -348,7 +364,7 @@ fn accessor_body_shape(
                 continue;
             }
             Expr::MethodCall(call) => {
-                let link = accessor_method_link(call, interner, owner_methods);
+                let link = accessor_method_link(call, resolve, owner_methods);
                 if rue_air::declaration_validation::accessor_method_link_error(link).is_some() {
                     return AccessorBodyVerdict::YieldNotReceiverRooted(
                         AccessorYieldRootForm::PlainMethod,
@@ -357,56 +373,40 @@ fn accessor_body_shape(
                 current = &call.receiver;
                 continue;
             }
-            Expr::Ident(name) => {
-                AccessorYieldRootForm::Named(Arc::from(interner.resolve(&name.name)))
-            }
+            Expr::Ident(name) => AccessorYieldRootForm::Named(Arc::from(resolve(name.name))),
             _ => AccessorYieldRootForm::Value,
         };
         return AccessorBodyVerdict::YieldNotReceiverRooted(root);
     }
 }
 
-/// Reparse one exact body-free syntax terminal into a value-only shape. This
-/// parser owns no name or type resolution policy; every type fragment is later
-/// routed through `rue_air::resolve_semantic_type_syntax`.
-pub(crate) fn parse_semantic_signature(
+/// Project one exact declaration signature from the canonical parsed module.
+///
+/// This borrows parser state only while building the position-independent
+/// value projection. No parser node, parser interner, FileId, or absolute span
+/// enters the returned value; type fragments remain the existing deferred
+/// semantic-type syntax until the structured-type tranche replaces them.
+pub(crate) fn project_semantic_signature(
+    module: &crate::parsed_modules::ParsedModule,
     key: &DeclarationCandidateKey,
-    syntax: &crate::declaration_candidate::RawDeclarationSignatureSyntax,
 ) -> Result<ParsedSemanticSignature, Arc<str>> {
+    use crate::parsed_modules::ParsedDeclarationAstRef;
+
     if key.category == Category::ConstCandidate {
-        return Err(Arc::from("constant candidates have no signature terminal"));
+        return Err(Arc::from(
+            "constant candidates have no signature projection",
+        ));
     }
-    let _signature_parsing_span =
-        tracing::info_span!("declaration_signature_parsing", phase = "semantic_analysis").entered();
-    let source = signature_source(key, syntax);
-    let parsed = crate::syntax::parse_file(
-        crate::SourceView::new("<semantic-signature>", &source, rue_span::FileId::new(0)),
-        crate::ThreadedRodeo::new(),
-    );
-    let ast = parsed
-        .result
-        .map_err(|errors| Arc::from(errors.to_string()))?;
-    let interner = parsed.interner;
-    let item = ast
-        .items
-        .first()
-        .ok_or_else(|| Arc::from("semantic signature parsed no declaration"))?;
-    let unit: Arc<str> = Arc::from("()");
-    let owner_methods = syntax
-        .accessor
-        .as_ref()
-        .map_or::<&[rue_air::declaration_validation::AccessorOwnerMethod], _>(
-        &[],
-        |accessor| &accessor.owner_methods,
-    );
-    let body_shape =
-        |body: &rue_parser::ast::Expr| accessor_body_shape(body, &interner, owner_methods);
-    // 6.6:14 over the retained owner-method facts (RUE-1282): whether this
-    // declaration reaches itself through its siblings' `self`-receiver
-    // accessor calls. Decided here so the accessor's own signature query
-    // rejects the cycle with no call site anywhere in the program.
+    let declaration = module
+        .declaration_ast(key)
+        .ok_or_else(|| Arc::from("semantic signature has no exact parsed declaration"))?;
+    let source = module.source_text();
+    let resolve = |symbol| module.resolve_raw_symbol(symbol);
+    let owner_methods = module
+        .declaration_accessor_owner_methods(key)
+        .ok_or_else(|| Arc::from("semantic signature has no exact accessor facts"))?;
     let accessor_cycle =
-        rue_air::declaration_validation::accessor_self_call_cycle(&key.name, owner_methods)
+        rue_air::declaration_validation::accessor_self_call_cycle(&key.name, &owner_methods)
             .then(|| key.name.clone());
     let callable = |parameters: &[rue_parser::ast::Param],
                     result: Option<&rue_parser::ast::TypeExpr>,
@@ -416,26 +416,37 @@ pub(crate) fn parse_semantic_signature(
                     is_extern,
                     is_c_export,
                     is_accessor,
-                    accessor_body|
+                    body: Option<&rue_parser::ast::Expr>|
      -> Result<ParsedSemanticSignature, Arc<str>> {
+        let mut text = ParsedSemanticTextBuilder::default();
+        let parameters = parsed_parameters(&mut text, source, resolve, parameters)?;
+        let result = text.push(match result {
+            Some(value) => source_fragment(source, value.span())?,
+            None => "()",
+        })?;
         Ok(ParsedSemanticSignature::Callable {
-            parameters: parsed_parameters(&source, &interner, parameters)?,
-            result: result
-                .map(|value| source_fragment(&source, value.span()))
-                .transpose()?
-                .unwrap_or_else(|| unit.clone()),
+            text: text.finish(),
+            parameters,
+            result,
             has_self,
             self_mode,
             is_unchecked,
             is_extern,
             is_c_export,
             is_accessor,
-            accessor_body,
-            accessor_cycle: accessor_cycle.clone(),
+            accessor_body: if is_accessor {
+                body.map_or(AccessorBodyVerdict::MissingTrailingYield, |body| {
+                    accessor_body_shape(body, resolve, &owner_methods)
+                })
+            } else {
+                AccessorBodyVerdict::MissingTrailingYield
+            },
+            accessor_cycle: is_accessor.then(|| accessor_cycle.clone()).flatten(),
         })
     };
-    match (key.category, item) {
-        (Category::Function, rue_parser::ast::Item::Function(function)) => callable(
+
+    match declaration {
+        ParsedDeclarationAstRef::Function(function) => callable(
             &function.params,
             function.return_type.as_ref(),
             false,
@@ -444,102 +455,95 @@ pub(crate) fn parse_semantic_signature(
             false,
             function.export_abi.is_some(),
             function.borrow_return.is_some(),
-            body_shape(&function.body),
+            Some(&function.body),
         ),
-        (Category::ExternFunction, rue_parser::ast::Item::Extern(block)) => {
-            let function = block
-                .fns
-                .first()
-                .ok_or_else(|| Arc::from("semantic extern signature contains no function"))?;
-            callable(
-                &function.params,
-                function.return_type.as_ref(),
-                false,
+        ParsedDeclarationAstRef::ExternFunction { function } => callable(
+            &function.params,
+            function.return_type.as_ref(),
+            false,
+            crate::declaration_candidate::DeclarationParameterMode::Value,
+            false,
+            true,
+            false,
+            false,
+            None,
+        ),
+        ParsedDeclarationAstRef::Method { method, .. } => callable(
+            &method.params,
+            method.return_type.as_ref(),
+            method.receiver.is_some(),
+            method.receiver.as_ref().map_or(
                 crate::declaration_candidate::DeclarationParameterMode::Value,
-                false,
-                true,
-                false,
-                false,
-                AccessorBodyVerdict::MissingTrailingYield,
-            )
-        }
-        (Category::Method | Category::AssociatedFunction, rue_parser::ast::Item::Struct(owner)) => {
-            let method = owner
-                .methods
-                .first()
-                .ok_or_else(|| Arc::from("semantic method signature contains no method"))?;
-            callable(
-                &method.params,
-                method.return_type.as_ref(),
-                method.receiver.is_some(),
-                method.receiver.as_ref().map_or(
-                    crate::declaration_candidate::DeclarationParameterMode::Value,
-                    |receiver| parameter_mode(receiver.mode).0,
-                ),
-                false,
-                false,
-                false,
-                method.borrow_return.is_some(),
-                body_shape(&method.body),
-            )
-        }
-        (Category::Struct, rue_parser::ast::Item::Struct(structure)) => {
+                |receiver| parameter_mode(receiver.mode).0,
+            ),
+            false,
+            false,
+            false,
+            method.borrow_return.is_some(),
+            Some(&method.body),
+        ),
+        ParsedDeclarationAstRef::Struct(structure) => {
+            let mut text = ParsedSemanticTextBuilder::default();
             let fields = structure
                 .fields
                 .iter()
                 .map(|field| {
-                    Ok((
-                        Arc::from(interner.resolve(&field.name.name)),
-                        source_fragment(&source, field.ty.span())?,
-                    ))
+                    Ok(ParsedSemanticField {
+                        name: text.push(resolve(field.name.name))?,
+                        ty: text.push(source_fragment(source, field.ty.span())?)?,
+                    })
                 })
                 .collect::<Result<Vec<_>, Arc<str>>>()?;
-            let copy = interner.get("copy");
-            let is_copy = copy.is_some_and(|copy| {
-                structure
+            Ok(ParsedSemanticSignature::Struct {
+                text: text.finish(),
+                fields: fields.into(),
+                is_copy: structure
                     .directives
                     .iter()
-                    .any(|directive| directive.name.name == copy)
-            });
-            Ok(ParsedSemanticSignature::Struct {
-                fields: fields.into(),
-                is_copy,
+                    .any(|directive| resolve(directive.name.name) == "copy"),
                 is_linear: structure.is_linear,
                 is_repr_c: structure.directives.iter().any(|directive| {
-                    interner.resolve(&directive.name.name) == "repr"
+                    resolve(directive.name.name) == "repr"
                         && directive.args.iter().any(|argument| match argument {
                             rue_parser::ast::DirectiveArg::Ident(argument) => {
-                                interner.resolve(&argument.name) == "c"
+                                resolve(argument.name) == "c"
                             }
                         })
                 }),
             })
         }
-        (Category::Enum, rue_parser::ast::Item::Enum(value)) => {
+        ParsedDeclarationAstRef::Enum(value) => {
+            let mut text = ParsedSemanticTextBuilder::default();
+            let mut payloads = Vec::new();
             let variants = value
                 .variants
                 .iter()
                 .map(|variant| {
-                    Ok((
-                        Arc::from(interner.resolve(&variant.name.name)),
-                        variant
-                            .payload
-                            .iter()
-                            .map(|ty| source_fragment(&source, ty.span()))
-                            .collect::<Result<Vec<_>, Arc<str>>>()?
-                            .into(),
-                    ))
+                    let payload_start = u32::try_from(payloads.len()).map_err(|_| {
+                        Arc::from("semantic signature payload exceeds the supported size")
+                    })?;
+                    for ty in &variant.payload {
+                        payloads.push(text.push(source_fragment(source, ty.span())?)?);
+                    }
+                    let payload_end = u32::try_from(payloads.len()).map_err(|_| {
+                        Arc::from("semantic signature payload exceeds the supported size")
+                    })?;
+                    Ok(ParsedSemanticVariant {
+                        name: text.push(resolve(variant.name.name))?,
+                        payload_start,
+                        payload_end,
+                    })
                 })
                 .collect::<Result<Vec<_>, Arc<str>>>()?;
             Ok(ParsedSemanticSignature::Enum {
+                text: text.finish(),
                 variants: variants.into(),
+                payloads: payloads.into(),
             })
         }
-        (Category::Destructor, rue_parser::ast::Item::DropFn(_)) => {
-            Ok(ParsedSemanticSignature::Destructor)
-        }
-        _ => Err(Arc::from(
-            "semantic signature category does not match reparsed declaration",
+        ParsedDeclarationAstRef::Destructor(_) => Ok(ParsedSemanticSignature::Destructor),
+        ParsedDeclarationAstRef::Const(_) => Err(Arc::from(
+            "constant candidates have no signature projection",
         )),
     }
 }

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -11847,10 +11847,8 @@ fn main() -> i32 {
         assert!(
             dependencies
                 .iter()
-                .filter(|node| node.contains("compiler.raw-declaration-signature"))
-                .all(|node| node.contains(":main:")),
-            "the transient body prerequisite resolver observes only its own raw signature; \
-             callee raw syntax stays behind exact semantic-signature queries: \
+                .all(|node| !node.contains("compiler.declaration-signature-projection")),
+            "body analysis must not regain the deleted peer signature family: \
              transaction={main_transaction:?}; dependencies={dependencies:?}"
         );
         assert!(

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -1928,21 +1928,16 @@ mod tests {
             .iter()
             .find(|pass| pass.name == "optimized_cfg_collection")
             .unwrap();
-        // The session parses the source module once and the registered
-        // declaration-signature terminal parses its exact durable input.
-        // Named BodyInput now projects the canonical module RIR plan and must
-        // never own a parser invocation.
-        assert_eq!(session_parse_file.invocations, 2);
+        // The session parses the source module once. Declaration signatures
+        // project their exact canonical AST nodes, and named body analysis
+        // consumes the canonical candidate plan; neither owns a parser
+        // invocation.
+        assert_eq!(session_parse_file.invocations, 1);
         assert_eq!(session_parse_file.root_invocations, 0);
-        for expected in [
-            ("parse_program", "parse_file"),
-            ("declaration_signature_parsing", "parse_file"),
-        ] {
-            assert!(
-                session_edges.contains(&(expected.0.to_owned(), expected.1.to_owned())),
-                "the demanded reparse is timed beneath its request: {session_edges:?}"
-            );
-        }
+        assert!(session_edges.contains(&("parse_program".to_owned(), "parse_file".to_owned())));
+        assert!(!session_edges.iter().any(|(parent, child)| {
+            parent == "declaration_signature_parsing" || child == "declaration_signature_parsing"
+        }));
         assert!(
             !session_edges.contains(&("body_input_lowering".to_owned(), "parse_file".to_owned()))
         );
@@ -1967,10 +1962,6 @@ mod tests {
         assert!(session_edges.contains(&(
             "body_closure_collection".to_owned(),
             "body_analysis".to_owned()
-        )));
-        assert!(session_edges.contains(&(
-            "declaration_nucleus".to_owned(),
-            "declaration_signature_parsing".to_owned()
         )));
         assert!(
             session_edges.contains(&("body_analysis".to_owned(), "body_input_lowering".to_owned()))
@@ -2093,7 +2084,7 @@ mod tests {
         // leaves beneath the pipeline aggregate.
         assert_eq!(declaration.invocations, 2);
         assert_eq!(declaration.root_invocations, 0);
-        assert_eq!(declaration.leaf_invocations, 1);
+        assert_eq!(declaration.leaf_invocations, 2);
         for phase in [
             Phase::SemanticAnalysis,
             Phase::CfgAndOptimization,

--- a/docs/notes/adr-0071-phase-3-frontend-phase-integrity.md
+++ b/docs/notes/adr-0071-phase-3-frontend-phase-integrity.md
@@ -1,14 +1,14 @@
 # ADR-0071 Phase 3 frontend phase-integrity ledger
 
 This note records the current production frontend re-entry points and the
-replacement contract for Phase 3. Source and tests remain authoritative. Every
-row below is present at trunk revision `2865800c`.
+replacement contract for Phase 3. Source and tests remain authoritative; rows
+marked complete describe paths already removed by the bounded Phase 3 slices.
 
 ## Deletion ledger
 
 | Re-entry | Production owner and consumers | Displaced work | Required deletion proof |
 | --- | --- | --- | --- |
-| Declaration signatures | `parse_semantic_signature` in `semantic_query_nucleus.rs`; called by the semantic-nucleus signature evaluator and transient named-body prerequisite classification | Reconstructs a declaration string, lexes and parses it, then copies parameter, result, field, variant, directive, receiver, and accessor facts back out | Deferred: no production call or definition of `parse_semantic_signature`; signature evaluation consumes the declaration artifact directly |
+| Declaration signatures | `compiler.semantic-nucleus` owns a request-local projection from the exact canonical parsed declaration; specialization typing and call ABI consume its resolved signature, while cheap named-body classification uses parser-indexed shell facts | Deletes body-free source reconstruction, signature lexing/parsing, and the additive retained `compiler.declaration-signature-projection` family | Complete: no production call or definition of `parse_semantic_signature`, no raw-signature parser locator/materializer or peer query family, and a cold signature request performs no body AstGen work |
 | Runtime and specialized bodies | `lower_owned_body_input` in `revisioned_query_database.rs`; called by both the ordinary-definition and free-function-specialization arms of `BodyTransactionEvaluator` | Concatenates retained signature/body text, builds a synthetic snapshot, lexes, parses, lowers with `AstGen`, builds a body RIR index, and remaps synthetic spans for every body transaction and specialization | Both transaction arms consume the same candidate-keyed structured body plan; no production call or definition of `lower_owned_body_input`; specialization count does not increase parsing or AstGen lowering |
 | Anonymous members | `lower_anonymous_member_body_input` in `revisioned_query_database.rs`; called by the anonymous-member arm of `BodyTransactionEvaluator` | Rewrites destructor spelling, wraps the member in a fake named struct, lexes, parses, lowers, indexes, and remaps it | Anonymous-member transactions consume a producer-published structured member plan; no production call or definition of `lower_anonymous_member_body_input` |
 | Comptime bodies | `parse_semantic_body` in `semantic_query_nucleus.rs`; called by the semantic-nucleus comptime-call evaluator | Wraps exact body text in a fake function, lexes and parses it, rediscovers imports, transports anonymous anchors, then evaluates the cloned AST | Comptime evaluation consumes the same declaration artifact as runtime analysis; no production call or definition of `parse_semantic_body` |
@@ -86,9 +86,11 @@ so internal trivia that moves diagnostic endpoints dirties the artifact:
 - ordered declaration-local import sites and accessor facts needed by semantic
   consumers.
 
-Raw signature, body, and constant projections remain independently comparable
-and independently stamped. Existing signature/body/constant query families
-retain their separate stamps and demand edges. The complete declaration plan's
+The semantic-nucleus signature, raw body, and raw constant projections remain
+independently comparable and independently stamped. Signature projection is
+request-local inside the authoritative semantic-nucleus signature evaluator;
+there is no second retained signature family. Raw-body and raw-constant query
+families retain their separate stamps and demand edges. The complete declaration plan's
 structural equality/digest, however, covers every semantically relevant part of
 the declaration: parameters, result, comptime and parameter modes, directives,
 accessor-only state, body structure, and declaration category. Thus a
@@ -97,8 +99,8 @@ the declaration plan and body transaction that depends on it. Sharing
 storage never couples an unchanged raw projection to a sibling edit.
 
 Those projections are also independently demandable and schedulable. One
-schema/storage owner is not one eager computation node: a cold signature query
-does no body AstGen or instruction work; requesting one member does no sibling
+schema/storage owner is not one eager computation node: a cold semantic-nucleus
+signature request does no body AstGen or instruction work; requesting one member does no sibling
 member work; and cancellation, retained charge, and eviction apply to the exact
 projection constructed. Different declaration candidates share no mutable
 arena or lock while their projections run in parallel.
@@ -183,7 +185,7 @@ deleted entry point, plus behavioral coverage proving:
    lookup, while diagnostics relocate through the current locator;
 7. parameter, result, comptime, parameter-mode, directive, and accessor-only
    edits each invalidate the complete declaration plan and body transaction as
-   appropriate while preserving independent raw signature/body/constant
+   appropriate while preserving independent signature/body/constant
    projection stamps;
 8. an equal-length but differently ordered symbol interner fails closed, while
    the plan-owned spelling table recreates an exact local facade when needed;

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1317,13 +1317,13 @@ published compiler-work counter, emitted-output metric, source metric, and
 executable byte remains identical.
 
 RUE-1430 carries exact callable type fragments with the canonical semantic-
-signature projection that already parses them. Body-local materialization
-previously queried the same declaration candidate again and rebuilt a parser
-and interner to recover dependent parameter/result syntax that cannot be
-reconstructed from reduced comptime placeholders. Durable function and method
-facts now transport the canonical fragments directly; raw declaration syntax
-remains an internal dependency of the semantic-signature query instead of a
-peer dependency of every consuming body.
+signature projection. Body-local materialization previously queried the same
+declaration candidate again and rebuilt a parser and interner to recover
+dependent parameter/result syntax that cannot be reconstructed from reduced
+comptime placeholders. Durable function and method facts now transport the
+canonical fragments directly. The semantic-nucleus signature evaluator
+projects those fragments from the exact canonical parsed declaration without
+retaining a raw-signature or peer signature-query terminal.
 
 Cold one-worker Lattice removes 2,738 declaration-identity fact reads, 5,476
 query reuses, and 2,738 redundant signature parser invocations. Sixteen


### PR DESCRIPTION
## Summary

- project each named declaration signature directly from its exact canonical `ParsedModule` node inside `compiler.semantic-nucleus`
- delete body-free source reconstruction, signature lexing/parsing, parser locators, and the additive signature-projection query family
- reuse callable type syntax from the authoritative resolved signature and use parser-indexed shell facts for cold generic body classification
- preserve exact candidate selection, accessor facts, cancellation, red/green signature stamps, and body-independent scheduling

## Why

Named signatures were already present in the canonical parse, but several consumers rebuilt declaration text and invoked the lexer and parser again. This made signature work a peer frontend path and put duplicate parsing directly on the critical path.

The semantic nucleus is now the sole retained signature authority. It borrows the canonical parsed declaration only while constructing a compact request-local projection, then publishes the existing resolved signature value.

## Performance

Six alternating one-worker release pairs compile the frozen Lattice workload to the exact same 1,413,120-byte executable with SHA-256 `b893e76cfabed737b149d0e8c4d8527077dedd17da78418db20a28a7d30885e5`.

- median process time: 680.71 ms → 662.59 ms (-18.11 ms, -2.66%)
- median external peak RSS: 387.58 MB → 376.61 MB (-10.46 MiB, -2.83%)
- parser/lexer invocations: 2,865 → 1,268 (-1,597)
- query claims and memo nodes: -1,468 each

All six paired runs improve both time and RSS.

## Validation

- `scripts/rue fmt`
- signature-focused compiler tests: 23/23
- API inventory: 31/31
- `scripts/rue quick`: 31/31 targets; compiler 873 passed, 6 ignored
- premerge runnable actions: 159 passed, 0 test failures; Buck also selects four Linux-only mimalloc aliases that are incompatible on macOS, identically before source actions in the unchanged baseline and this branch
- exact x86-64 Linux native output parity in all paired measurements
