### PR TITLE
RUE-1510: reuse producer artifacts for anonymous bodies

### DIFF
--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -1484,8 +1484,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
     /// Provider-backed body analysis mints those facts while selecting the
     /// current callable. Re-resolving the explicit parameter spellings would
     /// duplicate nominal registration and type construction without adding a
-    /// distinct correctness check; the body input already depends on the exact
-    /// raw signature terminal. The caller still resolves the declared return
+    /// distinct correctness check; the body query already depends on the exact
+    /// canonical parsed signature projection. The caller still resolves the declared return
     /// spelling because a call-site signature may expose a coercion-normalized
     /// type instead of the exact type checked inside the body.
     #[allow(clippy::too_many_arguments)]

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -395,6 +395,12 @@ pub struct ProviderSpecializedBody<K, M> {
 pub struct ProviderAnonymousBody<K, M> {
     pub work: ProviderBodyWork,
     pub export: crate::SemanticAnonymousBodyExport,
+    /// Exact current-source span of the selected anonymous member body.
+    ///
+    /// The compiler converts this to the producer body's relative coordinate
+    /// before retaining the transaction; no absolute source coordinate crosses
+    /// the query boundary.
+    pub body_span: rue_span::Span,
     /// Exact body-local AIR and its issuing domains; retained for the canonical
     /// local-materialization boundary rather than discarded after export.
     pub function: AnalyzedFunction,
@@ -803,6 +809,12 @@ struct ProviderBodyHost<'a, P, S, K, M> {
     owner_kind: crate::StableDefinitionKind,
     owner_file: FileId,
     owner_name: Option<Arc<str>>,
+    /// Exact declaration selected inside a producer candidate for an
+    /// anonymous-member transaction. Named bodies continue to resolve through
+    /// the request-local declaration index; anonymous members have no named
+    /// source owner and therefore carry their already-validated `InstRef`
+    /// directly.
+    current_declaration_override: Option<InstRef>,
     source: S,
     key: K,
     // Request-local exact-lookup registries. Their iteration order is never a
@@ -953,6 +965,7 @@ where
             owner_kind,
             owner_file: file,
             owner_name: owner_name.map(Arc::from),
+            current_declaration_override: None,
             source,
             key: key.clone(),
             function_infos: RefCell::new(AHashMap::new()),
@@ -1125,19 +1138,23 @@ where
     }
 
     fn current_callable_locator(&self) -> Option<(InstRef, InstRef, Span)> {
-        let name = self.interner.resolve(&self.owner_source_symbol);
-        let declaration = match self.owner_kind {
-            crate::StableDefinitionKind::Function => {
-                self.endpoint.first_free_function(name, self.owner_file)?
+        let declaration = if let Some(declaration) = self.current_declaration_override {
+            declaration
+        } else {
+            let name = self.interner.resolve(&self.owner_source_symbol);
+            match self.owner_kind {
+                crate::StableDefinitionKind::Function => {
+                    self.endpoint.first_free_function(name, self.owner_file)?
+                }
+                crate::StableDefinitionKind::Method
+                | crate::StableDefinitionKind::AssociatedFunction => self
+                    .endpoint
+                    .named_method_declaration(self.owner_file, self.owner_name.as_deref()?, name)?,
+                crate::StableDefinitionKind::Destructor => self
+                    .endpoint
+                    .destructor(self.owner_file, self.owner_name.as_deref()?)?,
+                _ => return None,
             }
-            crate::StableDefinitionKind::Method
-            | crate::StableDefinitionKind::AssociatedFunction => self
-                .endpoint
-                .named_method_declaration(self.owner_file, self.owner_name.as_deref()?, name)?,
-            crate::StableDefinitionKind::Destructor => self
-                .endpoint
-                .destructor(self.owner_file, self.owner_name.as_deref()?)?,
-            _ => return None,
         };
         let instruction = self.rir.rir().get(declaration);
         let body = match instruction.data {
@@ -4889,13 +4906,136 @@ where
     })
 }
 
-/// Run one exact anonymous-member request from the producer-owned member
-/// fragment. The supplied RIR bundle contains only a synthetic owner and this
-/// member; the durable anonymous key remains the sole owner authority.
+fn anonymous_member_in_producer(
+    rir: &rue_rir::Rir,
+    interner: &ThreadedRodeo,
+    producer_root: InstRef,
+    owner_anchor: &rue_rir::RirStructuralAnchor,
+    member: &crate::AnonymousMemberKey,
+) -> Result<InstRef, &'static str> {
+    let member_symbol = interner
+        .get(member.name.as_ref())
+        .ok_or("anonymous member name is absent from its producer artifact")?;
+    let mut pending = vec![producer_root];
+    let mut visited = HashSet::new();
+    let mut owner_found = false;
+    let mut declaration = None;
+    while let Some(reference) = pending.pop() {
+        if !visited.insert(reference) {
+            continue;
+        }
+        let instruction = rir.get(reference);
+        if let InstData::AnonStructType {
+            anchor, methods, ..
+        } = &instruction.data
+        {
+            // Anonymous method bodies are independent semantic producers. A
+            // nested producer can legitimately reuse the same relative anchor,
+            // so never cross method edges while locating an owner in this root.
+            if anchor != owner_anchor {
+                continue;
+            }
+            if owner_found {
+                return Err("anonymous owner anchor is duplicated in its producer artifact");
+            }
+            owner_found = true;
+            for method_ref in rir.anon_struct_methods(methods) {
+                let InstData::FnDecl { name, has_self, .. } = &rir.get(method_ref).data else {
+                    return Err("anonymous owner method edge does not reference a function");
+                };
+                let kind = if interner.resolve(name) == "__drop" {
+                    crate::AnonymousMemberKind::Destructor
+                } else if *has_self {
+                    crate::AnonymousMemberKind::Method
+                } else {
+                    crate::AnonymousMemberKind::AssociatedFunction
+                };
+                if *name == member_symbol
+                    && kind == member.kind
+                    && declaration.replace(method_ref).is_some()
+                {
+                    return Err("anonymous member is duplicated in its producer artifact");
+                }
+            }
+            continue;
+        }
+        rir.child_instructions(reference, &mut pending);
+    }
+    if !owner_found {
+        return Err("anonymous owner anchor is absent from its producer artifact");
+    }
+    declaration.ok_or("anonymous member is absent from its producer artifact")
+}
+
+fn anonymous_producer_root<K, M>(
+    rir: &rue_rir::Rir,
+    interner: &ThreadedRodeo,
+    candidate_root: InstRef,
+    source_key: &K,
+    producer: &crate::StableProducerId<K, M>,
+) -> Result<InstRef, &'static str>
+where
+    K: Eq,
+{
+    match producer {
+        crate::StableProducerId::Definition(key) if key == source_key => Ok(candidate_root),
+        crate::StableProducerId::Definition(_) => {
+            Err("anonymous producer definition disagrees with its candidate artifact")
+        }
+        crate::StableProducerId::Function(function) => {
+            anonymous_function_producer_root(rir, interner, candidate_root, source_key, function)
+        }
+    }
+}
+
+fn anonymous_function_producer_root<K, M>(
+    rir: &rue_rir::Rir,
+    interner: &ThreadedRodeo,
+    candidate_root: InstRef,
+    source_key: &K,
+    function: &crate::FunctionInstanceKey<K, M>,
+) -> Result<InstRef, &'static str>
+where
+    K: Eq,
+{
+    match function {
+        crate::FunctionInstanceKey::Definition(key) if key == source_key => Ok(candidate_root),
+        crate::FunctionInstanceKey::Definition(_) => {
+            Err("anonymous function producer disagrees with its candidate artifact")
+        }
+        crate::FunctionInstanceKey::Specialization { base, .. } => {
+            anonymous_function_producer_root(rir, interner, candidate_root, source_key, base)
+        }
+        crate::FunctionInstanceKey::AnonymousMember { owner, member } => {
+            let crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Anonymous(owner)) =
+                owner.as_ref()
+            else {
+                return Err("nested anonymous producer has a non-anonymous owner");
+            };
+            let producer_root = anonymous_producer_root(
+                rir,
+                interner,
+                candidate_root,
+                source_key,
+                &owner.producer,
+            )?;
+            anonymous_member_in_producer(rir, interner, producer_root, &owner.anchor, member)
+        }
+        crate::FunctionInstanceKey::DropGlue(_) => {
+            Err("drop glue cannot produce an anonymous member body")
+        }
+    }
+}
+
+/// Run one exact anonymous-member request from the canonical artifact of the
+/// named declaration that ultimately produced its owner. Producer boundaries,
+/// structural anchors, and exact member identity select the nested declaration
+/// without source assembly, parsing, AstGen, or a fake named owner.
 pub fn analyze_provider_anonymous_body<P, S, K, M>(
     provider: &P,
     source: S,
     bundle: &BodyRirBundle,
+    candidate_root: InstRef,
     source_key: K,
     owner: &TypeInstanceKey<K, M>,
     member: &crate::AnonymousMemberKey,
@@ -4913,35 +5053,9 @@ where
     K: Clone + Eq + Hash + Ord,
     M: Clone + Eq + Hash + Ord,
 {
-    const SYNTHETIC_OWNER: &str = "AnonymousBodyOwner";
     let owner_file = bundle.source_file_id().ok_or_else(|| {
         CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
             "provider anonymous body RIR does not have one source file".into(),
-        ))
-    })?;
-    let host_setup_started = Instant::now();
-    let mut host = ProviderBodyHost::new(
-        provider,
-        source,
-        bundle,
-        source_key,
-        owner_file,
-        member.name.as_ref(),
-        match member.kind {
-            crate::AnonymousMemberKind::Method => crate::StableDefinitionKind::Method,
-            crate::AnonymousMemberKind::AssociatedFunction => {
-                crate::StableDefinitionKind::AssociatedFunction
-            }
-            crate::AnonymousMemberKind::Destructor => crate::StableDefinitionKind::Destructor,
-        },
-        Some(SYNTHETIC_OWNER),
-        target,
-        preview,
-        well_known,
-    )
-    .ok_or_else(|| {
-        CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-            "provider anonymous body host could not be constructed".into(),
         ))
     })?;
     let TypeInstanceKey::Nominal(crate::NominalInstanceKey::Anonymous(durable_owner)) = owner
@@ -4952,6 +5066,55 @@ where
             ),
         ));
     };
+    let declaration = {
+        let view = bundle.view();
+        let producer_root = anonymous_producer_root(
+            view.rir(),
+            view.rir_interner(),
+            candidate_root,
+            &source_key,
+            &durable_owner.producer,
+        )
+        .map_err(|detail| {
+            CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(detail.into()))
+        })?;
+        anonymous_member_in_producer(
+            view.rir(),
+            view.rir_interner(),
+            producer_root,
+            &durable_owner.anchor,
+            member,
+        )
+        .map_err(|detail| {
+            CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(detail.into()))
+        })?
+    };
+    let host_setup_started = Instant::now();
+    let mut host = ProviderBodyHost::new(
+        provider,
+        source,
+        bundle,
+        source_key.clone(),
+        owner_file,
+        member.name.as_ref(),
+        match member.kind {
+            crate::AnonymousMemberKind::Method => crate::StableDefinitionKind::Method,
+            crate::AnonymousMemberKind::AssociatedFunction => {
+                crate::StableDefinitionKind::AssociatedFunction
+            }
+            crate::AnonymousMemberKind::Destructor => crate::StableDefinitionKind::Destructor,
+        },
+        None,
+        target,
+        preview,
+        well_known,
+    )
+    .ok_or_else(|| {
+        CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+            "provider anonymous body host could not be constructed".into(),
+        ))
+    })?;
+    host.current_declaration_override = Some(declaration);
     let issued_owner = host
         .register_and_issue_anonymous_identity(durable_owner)
         .ok_or_else(|| {
@@ -5057,14 +5220,6 @@ where
         .cloned()
         .collect::<HashSet<_>>();
 
-    let declaration = host
-        .endpoint
-        .named_method_declaration(owner_file, SYNTHETIC_OWNER, member.name.as_ref())
-        .ok_or_else(|| {
-            CompileError::without_span(rue_error::ErrorKind::UndefinedFunction(
-                member.name.to_string(),
-            ))
-        })?;
     let (params, body, has_self, self_mode, self_is_mut, span) =
         match &host.rir.rir().get(declaration).data {
             InstData::FnDecl {
@@ -5345,6 +5500,7 @@ where
     Ok(ProviderAnonymousBody {
         work,
         export,
+        body_span,
         function,
         warnings,
         strings,

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -393,6 +393,53 @@ fn body_transaction_has_no_complete_declaration_candidate_map() {
 }
 
 #[test]
+fn anonymous_body_transaction_has_one_candidate_artifact_path_and_no_frontend_reentry() {
+    let runtime = include_str!("revisioned_query_database.rs");
+    let transaction = source_between_exact_boundaries(
+        runtime,
+        "struct BodyTransactionEvaluator {",
+        "\nimpl RevisionedQueryDatabase {",
+    );
+    for required in [
+        "resolve_producer_artifact",
+        "materialize_body_rir_bundle_with_declaration",
+        "analyze_provider_anonymous_body",
+    ] {
+        assert!(
+            transaction.contains(required),
+            "anonymous transaction lost its canonical candidate path: {required}",
+        );
+    }
+    for forbidden in [
+        "lower_anonymous_member_body_input",
+        "AnonymousMemberLowering",
+        "parse_source_snapshot_module",
+        "SourceSnapshot",
+        "AstGen",
+        "lower_parsed_declaration_body_plan_with_anonymous_anchors",
+    ] {
+        assert!(
+            !transaction.contains(forbidden),
+            "anonymous transaction regained a frontend/rematerialization path: {forbidden}",
+        );
+    }
+
+    let production = runtime.split("\n#[cfg(test)]\nmod tests {").next().unwrap();
+    for removed in [
+        "lower_anonymous_member_body_input",
+        "AnonymousMemberLowering",
+        "DurableAnonymousMemberBodySyntax",
+        "RawDeclarationSignatureSyntax",
+        "RawAccessorSignatureSyntax",
+    ] {
+        assert!(
+            !production.contains(removed),
+            "deleted anonymous/signature carrier returned to production: {removed}",
+        );
+    }
+}
+
+#[test]
 fn well_known_option_resolution_stays_per_body_exact_and_fail_closed() {
     let runtime = include_str!("revisioned_query_database.rs");
     let method = source_between_exact_boundaries(
@@ -2336,20 +2383,6 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
         assert!(
             !raw_const_payload.contains(forbidden),
             "raw-constant payload regained a positioned or live parser handle: {forbidden}"
-        );
-    }
-    let raw_signature_payload = module("declaration_candidate")
-        .split("pub(crate) struct RawDeclarationSignatureSyntax")
-        .nth(1)
-        .and_then(|tail| {
-            tail.split("pub(crate) struct RawDeclarationBodySyntax")
-                .next()
-        })
-        .unwrap();
-    for forbidden in ["Span", "FileId", "Spur", "Ast", "Rir", "InstRef", "TypeId"] {
-        assert!(
-            !raw_signature_payload.contains(forbidden),
-            "raw-signature payload regained a positioned or live parser/semantic handle: {forbidden}"
         );
     }
     let raw_body_payload = module("declaration_candidate")

--- a/crates/rue-compiler/src/canonical_lower.rs
+++ b/crates/rue-compiler/src/canonical_lower.rs
@@ -160,7 +160,7 @@ impl DeclarationBodyPlan {
             false,
             checkpoint,
         )
-        .map(|(bundle, _)| bundle)
+        .map(|(bundle, _, _)| bundle)
     }
 
     pub(crate) fn materialize_body_rir_bundle_with_attribution(
@@ -180,6 +180,51 @@ impl DeclarationBodyPlan {
             true,
             checkpoint,
         )
+        .map(|(bundle, attribution, _)| (bundle, attribution))
+    }
+
+    /// Materialize the producer candidate and retain its exact decoded
+    /// declaration root. Anonymous-member analysis uses that root to select a
+    /// nested producer/member directly from this same candidate graph.
+    pub(crate) fn materialize_body_rir_bundle_with_declaration(
+        &self,
+        file_id: FileId,
+        declaration_start: u32,
+        source_length: u32,
+        checkpoint: impl FnMut() -> Result<(), rue_query::QueryAbort>,
+    ) -> Result<(rue_air::BodyRirBundle, InstRef), BodyPlanMaterializationFailure> {
+        self.materialize_body_rir_bundle_internal(
+            file_id,
+            declaration_start,
+            source_length,
+            false,
+            checkpoint,
+        )
+        .map(|(bundle, _, declaration)| (bundle, declaration))
+    }
+
+    pub(crate) fn materialize_body_rir_bundle_with_declaration_and_attribution(
+        &self,
+        file_id: FileId,
+        declaration_start: u32,
+        source_length: u32,
+        checkpoint: impl FnMut() -> Result<(), rue_query::QueryAbort>,
+    ) -> Result<
+        (
+            rue_air::BodyRirBundle,
+            InstRef,
+            BodyPlanMaterializationAttribution,
+        ),
+        BodyPlanMaterializationFailure,
+    > {
+        self.materialize_body_rir_bundle_internal(
+            file_id,
+            declaration_start,
+            source_length,
+            true,
+            checkpoint,
+        )
+        .map(|(bundle, attribution, declaration)| (bundle, declaration, attribution))
     }
 
     fn materialize_body_rir_bundle_internal(
@@ -190,11 +235,21 @@ impl DeclarationBodyPlan {
         attribution_enabled: bool,
         mut checkpoint: impl FnMut() -> Result<(), rue_query::QueryAbort>,
     ) -> Result<
-        (rue_air::BodyRirBundle, BodyPlanMaterializationAttribution),
+        (
+            rue_air::BodyRirBundle,
+            BodyPlanMaterializationAttribution,
+            InstRef,
+        ),
         BodyPlanMaterializationFailure,
     > {
-        let (rir, symbols, _remap_finished_ns, symbol_finished_ns, validation_finished_ns) = self
-            .materialize_candidate_rir_internal(
+        let (
+            rir,
+            symbols,
+            declaration,
+            _remap_finished_ns,
+            symbol_finished_ns,
+            validation_finished_ns,
+        ) = self.materialize_candidate_rir_internal(
             file_id,
             declaration_start,
             source_length,
@@ -223,6 +278,7 @@ impl DeclarationBodyPlan {
                 rir_instructions,
                 rir_payload_words,
             },
+            declaration,
         ))
     }
 
@@ -242,7 +298,7 @@ impl DeclarationBodyPlan {
             false,
             &mut checkpoint,
         )
-        .map(|(rir, symbols, _, _, _)| (rir, symbols))
+        .map(|(rir, symbols, _, _, _, _)| (rir, symbols))
     }
 
     fn materialize_candidate_rir_internal(
@@ -253,8 +309,10 @@ impl DeclarationBodyPlan {
         include_method_owner: bool,
         attribution_enabled: bool,
         checkpoint: &mut impl FnMut() -> Result<(), rue_query::QueryAbort>,
-    ) -> Result<(ValidatedRir, lasso::ThreadedRodeo, u64, u64, u64), BodyPlanMaterializationFailure>
-    {
+    ) -> Result<
+        (ValidatedRir, lasso::ThreadedRodeo, InstRef, u64, u64, u64),
+        BodyPlanMaterializationFailure,
+    > {
         checkpoint().map_err(BodyPlanMaterializationFailure::Query)?;
         let started = attribution_enabled.then(Instant::now);
         let elapsed = || {
@@ -358,6 +416,7 @@ impl DeclarationBodyPlan {
         Ok((
             rir,
             symbols,
+            appended.metadata.declaration,
             remap_finished_ns,
             symbol_finished_ns,
             validation_finished_ns,
@@ -413,47 +472,13 @@ pub(crate) fn lower_parsed_declaration_body_plan(
     let anchors = module
         .declaration_anonymous_sites(candidate)
         .ok_or(DeclarationBodyPlanBuildFailure::MissingCandidate)?;
-    lower_parsed_declaration_body_plan_internal(
-        module,
-        candidate,
-        CandidateAnonymousAnchors::Indexed(anchors),
-        checkpoint,
-    )
-}
-
-pub(crate) fn lower_parsed_declaration_body_plan_with_anonymous_anchors(
-    module: &crate::parsed_modules::ParsedModule,
-    candidate: &crate::declaration_candidate::DeclarationCandidateKey,
-    anchors: &[(
-        rue_span::Span,
-        rue_rir::AnonymousTypeSiteKind,
-        rue_rir::RirStructuralAnchor,
-    )],
-    checkpoint: impl FnMut() -> Result<(), rue_query::QueryAbort>,
-) -> Result<DeclarationBodyPlanArtifacts, DeclarationBodyPlanBuildFailure> {
-    lower_parsed_declaration_body_plan_internal(
-        module,
-        candidate,
-        CandidateAnonymousAnchors::Explicit(anchors),
-        checkpoint,
-    )
-}
-
-enum CandidateAnonymousAnchors<'a> {
-    Indexed(&'a [rue_rir::AnonymousTypeSite]),
-    Explicit(
-        &'a [(
-            rue_span::Span,
-            rue_rir::AnonymousTypeSiteKind,
-            rue_rir::RirStructuralAnchor,
-        )],
-    ),
+    lower_parsed_declaration_body_plan_internal(module, candidate, anchors, checkpoint)
 }
 
 fn lower_parsed_declaration_body_plan_internal(
     module: &crate::parsed_modules::ParsedModule,
     candidate: &crate::declaration_candidate::DeclarationCandidateKey,
-    authoritative_anchors: CandidateAnonymousAnchors<'_>,
+    authoritative_anchors: &[rue_rir::AnonymousTypeSite],
     mut checkpoint: impl FnMut() -> Result<(), rue_query::QueryAbort>,
 ) -> Result<DeclarationBodyPlanArtifacts, DeclarationBodyPlanBuildFailure> {
     checkpoint().map_err(DeclarationBodyPlanBuildFailure::Query)?;
@@ -488,18 +513,15 @@ fn lower_parsed_declaration_body_plan_internal(
             }
         });
         generator.install_cancellation_check(&mut cancellation_check);
-        match authoritative_anchors {
-            CandidateAnonymousAnchors::Indexed(anchors) => generator
-                .install_authoritative_anonymous_anchors(
-                    anchors
-                        .iter()
-                        .map(|site| (site.span, site.kind, site.anchor.clone())),
-                ),
-            CandidateAnonymousAnchors::Explicit(anchors) => {
-                generator.install_authoritative_anonymous_anchors(anchors.iter().cloned())
-            }
-        }
-        .map_err(|error| DeclarationBodyPlanBuildFailure::Payload(Arc::from(error.to_string())))?;
+        generator
+            .install_authoritative_anonymous_anchors(
+                authoritative_anchors
+                    .iter()
+                    .map(|site| (site.span, site.kind, site.anchor.clone())),
+            )
+            .map_err(|error| {
+                DeclarationBodyPlanBuildFailure::Payload(Arc::from(error.to_string()))
+            })?;
         let (producer, owner) = match ast {
             crate::parsed_modules::ParsedDeclarationAstRef::Function(value) => {
                 (rue_rir::AstGenCandidate::Function(value), None)
@@ -733,20 +755,6 @@ fn finish_declaration_body_plan(
     })
 }
 
-#[derive(Debug, Clone, Copy, Default)]
-pub(crate) struct RemappedBodyRirAttribution {
-    pub(crate) span_remap_validation_ns: u64,
-    pub(crate) index: rue_air::BodyRirIndexAttribution,
-    pub(crate) rir_instructions: u64,
-    pub(crate) rir_payload_words: u64,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct BodyRirAttributionClock {
-    pub(crate) started: Instant,
-    pub(crate) rir_lower_finished_ns: u64,
-}
-
 impl CandidateModuleRirOutput {
     pub(crate) fn revision(&self) -> &crate::ModuleRevision {
         &self.revision
@@ -754,70 +762,6 @@ impl CandidateModuleRirOutput {
 
     pub(crate) fn work(&self) -> CanonicalRirWork {
         self.work
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn into_remapped_body_rir_bundle(
-        self,
-        file_id: FileId,
-        source_length: u32,
-        remap_span: impl FnMut(rue_span::Span) -> rue_span::Span,
-    ) -> Result<rue_air::BodyRirBundle, String> {
-        self.into_remapped_body_rir_bundle_with_attribution(
-            file_id,
-            source_length,
-            remap_span,
-            None,
-        )
-        .map(|(bundle, _)| bundle)
-    }
-
-    pub(crate) fn into_remapped_body_rir_bundle_with_attribution(
-        self,
-        file_id: FileId,
-        source_length: u32,
-        remap_span: impl FnMut(rue_span::Span) -> rue_span::Span,
-        attribution_clock: Option<BodyRirAttributionClock>,
-    ) -> Result<(rue_air::BodyRirBundle, RemappedBodyRirAttribution), String> {
-        let rir_instructions = self.rir.len() as u64;
-        let rir_payload_words = self.rir.extra_len() as u64;
-        let mut editor = RirEditor::new();
-        editor
-            .append_remapped_with_spans(&self.rir, std::convert::identity, remap_span)
-            .map_err(|error| error.to_string())?;
-        let source_lengths = [(file_id, source_length)];
-        let validation = RirValidationContext {
-            symbol_count: self.symbols.interner().len(),
-            source_lengths: &source_lengths,
-        };
-        let rir = ValidatedRir::finish(editor, &validation).map_err(|error| error.to_string())?;
-        let remap_finished_ns = attribution_clock
-            .map(|clock| u64::try_from(clock.started.elapsed().as_nanos()).unwrap_or(u64::MAX));
-        let (bundle, mut index) = rue_air::BodyRirBundle::new_with_index_attribution(
-            rir,
-            Arc::try_unwrap(self.symbols.into_interner())
-                .expect("module RIR owns its semantic symbol interner"),
-            attribution_clock.is_some(),
-        );
-        let span_remap_validation_ns = attribution_clock
-            .zip(remap_finished_ns)
-            .map_or(0, |(clock, finished)| {
-                finished.saturating_sub(clock.rir_lower_finished_ns)
-            });
-        if let (Some(clock), Some(remap_finished_ns)) = (attribution_clock, remap_finished_ns) {
-            let index_finished_ns =
-                u64::try_from(clock.started.elapsed().as_nanos()).unwrap_or(u64::MAX);
-            index.duration_ns = index_finished_ns.saturating_sub(remap_finished_ns);
-        }
-        Ok((
-            bundle,
-            RemappedBodyRirAttribution {
-                span_remap_validation_ns,
-                index,
-                rir_instructions,
-                rir_payload_words,
-            },
-        ))
     }
 }
 
@@ -1827,7 +1771,7 @@ fn target(inout values: [i32; 4]) -> type {
             lower_parsed_declaration_body_plan_internal(
                 &module,
                 target_key,
-                CandidateAnonymousAnchors::Indexed(&corrupted_index),
+                &corrupted_index,
                 || Ok(()),
             ),
             Err(DeclarationBodyPlanBuildFailure::Payload(_))

--- a/crates/rue-compiler/src/declaration_candidate.rs
+++ b/crates/rue-compiler/src/declaration_candidate.rs
@@ -128,56 +128,6 @@ pub(crate) enum RawConstSyntaxFailure {
     ParserCapabilityMismatch(DeclarationCandidateKey),
 }
 
-/// Parser-validated signature syntax retained only for an anonymous member
-/// produced during comptime evaluation, detached from its source epoch and
-/// parser symbol universe.
-///
-/// Concatenating `declaration_fragments` reconstructs a body-free declaration
-/// for that produced member. Named declarations instead project their exact
-/// canonical parsed nodes directly in `compiler.semantic-nucleus`; this
-/// transport remains only until anonymous members publish the same structured
-/// per-declaration artifact.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct RawDeclarationSignatureSyntax {
-    pub(crate) declaration_fragments: Arc<[Arc<str>]>,
-    pub(crate) extern_abi: Option<Arc<str>>,
-    /// Present only for a `-> borrow` accessor: the extra syntax its
-    /// declaration rules read (spec 6.6:6, 6.6:7). `None` keeps every ordinary
-    /// signature body-agnostic.
-    pub(crate) accessor: Option<Arc<RawAccessorSignatureSyntax>>,
-}
-
-/// The syntax an accessor declaration's own legality rules read beyond its
-/// signature (spec 6.6:6, 6.6:7).
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct RawAccessorSignatureSyntax {
-    /// The accessor's exact body. Its declaration-shape rules include a
-    /// trailing-yield check even when no caller demands body analysis, so this
-    /// anonymous-member transport legitimately retains its own body.
-    pub(crate) body: Arc<str>,
-    /// Every method the accessor's owner declares — its name, whether it is
-    /// itself an accessor, and the method names its body calls on its own
-    /// `self` receiver — sorted by name and with ambiguous duplicate names
-    /// dropped.
-    ///
-    /// 6.6:7 admits a method-call link in the yielded chain only when the
-    /// callee is an accessor, and 6.6:14 rejects a cycle of accessor
-    /// expansions (RUE-1282). For a link whose receiver is the accessor's own
-    /// `self`, the callee is a method of this owner, and both deciding facts —
-    /// the sibling's `-> borrow` qualifier and its own `self`-call targets —
-    /// are *parsed* facts of the sibling declaration: no signature or body of
-    /// that sibling is demanded, so there is no query cycle between mutually
-    /// recursive accessors. Retaining the facts here is what records the
-    /// dependency: this terminal is materialized from the module's parse, so
-    /// editing a sibling method's `-> borrow` qualifier or `self`-call set
-    /// changes this value and re-runs every consumer of this accessor's
-    /// signature.
-    ///
-    /// Empty for an accessor with no owning type, or whose owner declares no
-    /// other methods.
-    pub(crate) owner_methods: Arc<[rue_air::declaration_validation::AccessorOwnerMethod]>,
-}
-
 /// Parser-validated syntax for one body-bearing declaration, detached from its
 /// source epoch and parser symbol universe.
 ///

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -154,22 +154,11 @@ pub struct DurableAnonymousMethodSignature {
     pub self_mode: DurableParameterMode,
     pub parameters: Arc<[(DurableAnonymousMethodType, DurableParameterMode, bool)]>,
     pub result: DurableAnonymousMethodType,
-    /// Exact producer-owned syntax for this member body. Declaration-only
-    /// projections may omit it, but a body transaction must refuse to analyze
-    /// the member unless the producer's `body-produced-anonymous` projection
-    /// supplied this fragment.
-    pub body: Option<DurableAnonymousMemberBodySyntax>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DurableAnonymousMemberBodySyntax {
-    /// Exact byte offsets relative to the producer's retained body or constant
-    /// initializer. They are presentation locators, not anonymous identity.
-    pub declaration_start: u32,
-    pub body_start: u32,
-    pub body_end: u32,
-    pub signature: crate::declaration_candidate::RawDeclarationSignatureSyntax,
-    pub body: crate::declaration_candidate::RawDeclarationBodySyntax,
+    /// Whether the producer declared a body for this member. The body itself
+    /// stays in the producer's canonical candidate artifact; anonymous-member
+    /// transactions select that exact nested declaration by owner anchor,
+    /// member name, and member kind instead of retaining or reparsing text.
+    pub has_body: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -252,15 +241,6 @@ impl RetainedCharge for DurableAnonymousMethodSignature {
             .retained_charge()
             .saturating_add(self.parameters.retained_charge())
             .saturating_add(self.result.retained_charge())
-            .saturating_add(self.body.retained_charge())
-    }
-}
-
-impl RetainedCharge for DurableAnonymousMemberBodySyntax {
-    fn retained_charge(&self) -> u64 {
-        self.signature
-            .retained_charge()
-            .saturating_add(self.body.retained_charge())
     }
 }
 

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -383,7 +383,7 @@ impl ParsedDefinitionIndex {
 
     /// Every method one owner declares in this module — its name, whether it
     /// is itself a `-> borrow` accessor, and its `self`-call targets — in the
-    /// normalized form the raw signature terminal retains.
+    /// normalized form the canonical parsed signature projection consumes.
     fn owner_method_accessor_facts(
         &self,
         owner: &crate::declaration_candidate::DeclarationCandidateOwner,

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -1009,23 +1009,6 @@ macro_rules! candidate_failure_charge {
 candidate_failure_charge!(crate::declaration_candidate::RawConstSyntaxFailure);
 candidate_failure_charge!(crate::declaration_candidate::RawDeclarationBodyFailure);
 
-impl RetainedCharge for crate::declaration_candidate::RawDeclarationSignatureSyntax {
-    fn retained_charge(&self) -> u64 {
-        self.declaration_fragments
-            .retained_charge()
-            .saturating_add(self.extern_abi.retained_charge())
-            .saturating_add(self.accessor.retained_charge())
-    }
-}
-
-impl RetainedCharge for crate::declaration_candidate::RawAccessorSignatureSyntax {
-    fn retained_charge(&self) -> u64 {
-        self.body
-            .retained_charge()
-            .saturating_add(self.owner_methods.retained_charge())
-    }
-}
-
 impl RetainedCharge for crate::semantic_query_nucleus::ParsedSemanticParameter {
     fn retained_charge(&self) -> u64 {
         0

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -4027,6 +4027,37 @@ pub(crate) fn function_definition_key(
     }
 }
 
+fn producer_body_source_definition_key(
+    producer: &crate::StableProducerId,
+) -> Option<&StableDefinitionKey> {
+    match producer {
+        crate::StableProducerId::Definition(key) => Some(key),
+        crate::StableProducerId::Function(function) => {
+            function_body_source_definition_key(function)
+        }
+    }
+}
+
+fn function_body_source_definition_key(
+    function: &crate::FunctionInstanceKey,
+) -> Option<&StableDefinitionKey> {
+    match function {
+        crate::FunctionInstanceKey::Definition(key) => Some(key),
+        crate::FunctionInstanceKey::Specialization { base, .. } => {
+            function_body_source_definition_key(base)
+        }
+        crate::FunctionInstanceKey::AnonymousMember { owner, .. } => {
+            let crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Anonymous(owner)) =
+                owner.as_ref()
+            else {
+                return None;
+            };
+            producer_body_source_definition_key(&owner.producer)
+        }
+        crate::FunctionInstanceKey::DropGlue(_) => None,
+    }
+}
+
 fn body_source_definition_key(
     function: &crate::FunctionInstanceKey,
 ) -> Option<&StableDefinitionKey> {
@@ -4036,12 +4067,9 @@ fn body_source_definition_key(
         else {
             return None;
         };
-        return match &owner.producer {
-            crate::StableProducerId::Definition(key) => Some(key),
-            crate::StableProducerId::Function(function) => function_definition_key(function),
-        };
+        return producer_body_source_definition_key(&owner.producer);
     }
-    function_definition_key(function)
+    function_body_source_definition_key(function)
 }
 
 fn closure_callable_has_body(
@@ -4673,52 +4701,6 @@ impl<'a> WarningStaticCallCollector<'a> {
     }
 }
 
-#[derive(Debug)]
-struct AnonymousMemberLowering {
-    bundle: rue_air::BodyRirBundle,
-}
-
-#[derive(Debug, Clone, Copy, Default)]
-struct AnonymousMemberLoweringAttribution {
-    assembly_snapshot_ns: u64,
-    lex_parse_ns: u64,
-    rir_lower_ns: u64,
-    span_remap_validation_ns: u64,
-    index: rue_air::BodyRirIndexAttribution,
-    source_bytes: u64,
-    declaration_fragments: u64,
-    rir_instructions: u64,
-    rir_payload_words: u64,
-}
-
-fn elapsed_ns(started: std::time::Instant) -> u64 {
-    u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX)
-}
-
-fn publish_anonymous_member_lowering_attribution(attribution: AnonymousMemberLoweringAttribution) {
-    let attributed_total_ns = attribution
-        .assembly_snapshot_ns
-        .saturating_add(attribution.lex_parse_ns)
-        .saturating_add(attribution.rir_lower_ns)
-        .saturating_add(attribution.span_remap_validation_ns)
-        .saturating_add(attribution.index.duration_ns);
-    tracing::event!(
-        name: "semantic_anonymous_member_lowering_breakdown",
-        target: "rue::timing",
-        tracing::Level::INFO,
-        attributed_total_ns,
-        assembly_snapshot_ns = attribution.assembly_snapshot_ns,
-        lex_parse_ns = attribution.lex_parse_ns,
-        rir_lower_ns = attribution.rir_lower_ns,
-        span_remap_validation_ns = attribution.span_remap_validation_ns,
-        body_rir_index_ns = attribution.index.duration_ns,
-        source_bytes = attribution.source_bytes,
-        declaration_fragments = attribution.declaration_fragments,
-        rir_instructions = attribution.rir_instructions,
-        rir_payload_words = attribution.rir_payload_words,
-    );
-}
-
 fn publish_body_plan_materialization_attribution(
     attribution: crate::canonical_lower::BodyPlanMaterializationAttribution,
 ) {
@@ -4748,196 +4730,6 @@ fn publish_body_plan_materialization_attribution(
         index_named_methods_indexed = attribution.index.named_methods_indexed,
         index_const_declarations_indexed = attribution.index.const_declarations_indexed,
     );
-}
-
-fn lower_anonymous_member_body_input(
-    input: &crate::durable_semantics::DurableAnonymousMemberBodySyntax,
-    member: &crate::AnonymousMemberKey,
-    source_locator: &rue_air::DurableBodySourceLocator,
-    producer_fragment_start: u32,
-) -> Result<AnonymousMemberLowering, Arc<str>> {
-    let _body_input_lowering_span =
-        tracing::info_span!("body_input_lowering", phase = "semantic_analysis").entered();
-    let attribution_started = tracing::enabled!(
-        target: "rue::timing",
-        tracing::Level::INFO
-    )
-    .then(std::time::Instant::now);
-    // Anonymous members are lowered from the exact fragment published by their
-    // producer. The synthetic named owner exists only to give the standalone
-    // parser the grammar context the member declaration requires; it carries
-    // no semantic identity and never crosses this request.
-    const OWNER: &str = "AnonymousBodyOwner";
-    let mut declaration = input
-        .signature
-        .declaration_fragments
-        .iter()
-        .map(AsRef::as_ref)
-        .collect::<Vec<&str>>()
-        .concat();
-    let mut destructor_expansion = None;
-    if member.kind == crate::AnonymousMemberKind::Destructor {
-        // Named structs spell destructors as a separate declaration, while an
-        // anonymous type spells one inline. The fragment parser only needs a
-        // method-shaped carrier; the durable member key remains the authority
-        // that selects destructor analysis below.
-        let offset = declaration
-            .find("drop fn")
-            .ok_or_else(|| Arc::from("anonymous destructor signature has no `drop fn` marker"))?;
-        declaration.replace_range(offset..offset + "drop fn".len(), "fn __drop");
-        destructor_expansion = Some((offset as u32, 2u32));
-    }
-    let prefix = format!("struct {OWNER} {{");
-    let mut source = prefix.clone();
-    source.push_str(&declaration);
-    source.push_str(input.body.body.as_ref());
-    source.push('}');
-    let source_bytes = source.len() as u64;
-
-    let snapshot = crate::SourceSnapshot::single("<rue-anonymous-body-input>", source)
-        .map_err(|errors| Arc::from(errors.to_string()))?;
-    let module_id = snapshot
-        .module_id(crate::FileId::DEFAULT)
-        .cloned()
-        .ok_or_else(|| Arc::from("anonymous body snapshot has no synthetic module"))?;
-    let assembly_finished_ns = attribution_started.map(elapsed_ns);
-    let (parsed, _) = crate::parsed_modules::parse_source_snapshot_module(&snapshot, &module_id);
-    let module = parsed.map_err(|errors| Arc::from(errors.to_string()))?;
-    if module.ast().items.len() != 1
-        || !module
-            .ast()
-            .items
-            .first()
-            .is_some_and(|item| matches!(item, rue_parser::ast::Item::Struct(_)))
-    {
-        return Err(Arc::from(
-            "anonymous member input did not lower to exactly one synthetic owner",
-        ));
-    }
-    let parse_finished_ns = attribution_started.map(elapsed_ns);
-    let signature_len = prefix.len() + declaration.len();
-    let body_len = input.body.body.len();
-    let anchors = input
-        .body
-        .anonymous_sites
-        .iter()
-        .map(|site| {
-            let start = signature_len
-                .checked_add(site.fragment_start as usize)
-                .and_then(|offset| u32::try_from(offset).ok())
-                .ok_or_else(|| Arc::from("anonymous member anchor start exceeds local source"))?;
-            let end = signature_len
-                .checked_add(site.fragment_end as usize)
-                .and_then(|offset| u32::try_from(offset).ok())
-                .ok_or_else(|| Arc::from("anonymous member anchor end exceeds local source"))?;
-            if site.fragment_start >= site.fragment_end || site.fragment_end as usize > body_len {
-                return Err(Arc::from(
-                    "anonymous member anchor locator is outside its exact body syntax",
-                ));
-            }
-            Ok((
-                rue_span::Span::new(start, end),
-                site.kind,
-                site.anchor.clone(),
-            ))
-        })
-        .collect::<Result<Vec<_>, Arc<str>>>()?;
-    let artifacts = module
-        .definitions()
-        .declaration_keys_in_source_order()
-        .map(|key| {
-            let artifact = if matches!(
-                key.category,
-                crate::declaration_candidate::DeclarationCandidateCategory::Method
-                    | crate::declaration_candidate::DeclarationCandidateCategory::AssociatedFunction
-            ) {
-                crate::canonical_lower::lower_parsed_declaration_body_plan_with_anonymous_anchors(
-                    &module,
-                    key,
-                    &anchors,
-                    || Ok(()),
-                )
-            } else {
-                crate::canonical_lower::lower_parsed_declaration_body_plan(&module, key, || Ok(()))
-            }
-            .map_err(|error| Arc::from(format!("{error:?}")))?;
-            Ok((key.clone(), Arc::new(artifact)))
-        })
-        .collect::<Result<HashMap<_, _>, Arc<str>>>()?;
-    let rir = crate::canonical_lower::compose_module_rir_from_candidate_artifacts(
-        module.clone(),
-        &artifacts,
-        || Ok(()),
-    )
-    .map_err(|error| Arc::from(format!("{error:?}")))?;
-    let rir_finished_ns = attribution_started.map(elapsed_ns);
-    let source_length = source_locator.source_length;
-    let local_prefix = u32::try_from(prefix.len())
-        .map_err(|_| Arc::from("anonymous owner prefix exceeds span capacity"))?;
-    let local_body_start = u32::try_from(signature_len)
-        .map_err(|_| Arc::from("anonymous member signature exceeds span capacity"))?;
-    let remap_signature_offset = |offset: u32| match destructor_expansion {
-        Some((expansion_at, expansion)) if offset > expansion_at => {
-            offset.saturating_sub(expansion)
-        }
-        _ => offset,
-    };
-    let remap_offset = |offset: u32| {
-        if offset >= local_body_start {
-            producer_fragment_start
-                .saturating_add(input.body_start)
-                .saturating_add(offset - local_body_start)
-                .min(producer_fragment_start.saturating_add(input.body_end))
-                .min(source_length)
-        } else if offset >= local_prefix {
-            producer_fragment_start
-                .saturating_add(input.declaration_start)
-                .saturating_add(remap_signature_offset(offset - local_prefix))
-                .min(producer_fragment_start.saturating_add(input.body_start))
-                .min(source_length)
-        } else {
-            producer_fragment_start
-                .saturating_add(input.declaration_start)
-                .min(source_length)
-        }
-    };
-    let (bundle, remap) = rir
-        .into_remapped_body_rir_bundle_with_attribution(
-            source_locator.file_id,
-            source_length,
-            |span| {
-                rue_span::Span::with_file(
-                    source_locator.file_id,
-                    remap_offset(span.start),
-                    remap_offset(span.end),
-                )
-            },
-            attribution_started
-                .zip(rir_finished_ns)
-                .map(|(started, rir_lower_finished_ns)| {
-                    crate::canonical_lower::BodyRirAttributionClock {
-                        started,
-                        rir_lower_finished_ns,
-                    }
-                }),
-        )
-        .map_err(Arc::from)?;
-    if let (Some(assembly_finished_ns), Some(parse_finished_ns), Some(rir_finished_ns)) =
-        (assembly_finished_ns, parse_finished_ns, rir_finished_ns)
-    {
-        publish_anonymous_member_lowering_attribution(AnonymousMemberLoweringAttribution {
-            assembly_snapshot_ns: assembly_finished_ns,
-            lex_parse_ns: parse_finished_ns.saturating_sub(assembly_finished_ns),
-            rir_lower_ns: rir_finished_ns.saturating_sub(parse_finished_ns),
-            span_remap_validation_ns: remap.span_remap_validation_ns,
-            index: remap.index,
-            source_bytes,
-            declaration_fragments: input.signature.declaration_fragments.len() as u64,
-            rir_instructions: remap.rir_instructions,
-            rir_payload_words: remap.rir_payload_words,
-        });
-    }
-    Ok(AnonymousMemberLowering { bundle })
 }
 
 fn declaration_candidate_for_stable_key(
@@ -8318,20 +8110,6 @@ impl SemanticConstEvaluator<'_, '_> {
                         crate::durable_semantics::DurableParameterMode::Inout
                     }
                 };
-                // 6.6:7's accessor-link and 6.6:14 cycle-edge facts for this
-                // anonymous owner's own methods, exactly as a named owner's
-                // members retain them.
-                let owner_methods =
-                    crate::semantic_query_nucleus::owner_method_accessor_facts(methods.iter().map(
-                        |method| rue_air::declaration_validation::AccessorOwnerMethod {
-                            name: Arc::from(self.interner.resolve(&method.name.name)),
-                            is_accessor: method.borrow_return.is_some(),
-                            self_call_targets: crate::semantic_query_nucleus::ast_self_call_targets(
-                                &method.body,
-                                self.interner,
-                            ),
-                        },
-                    ));
                 let methods = methods
                     .iter()
                     .map(|method| {
@@ -8375,69 +8153,6 @@ impl SemanticConstEvaluator<'_, '_> {
                                 },
                             ));
                         }
-                        let body_span = method.body.span();
-                        let declaration_start = method
-                            .span
-                            .start
-                            .checked_sub(self.producer_fragment_start)
-                            .ok_or_else(|| {
-                                Self::failure_value(
-                                    "anonymous member precedes its producer fragment",
-                                )
-                            })?;
-                        let member_body_start = body_span
-                            .start
-                            .checked_sub(self.producer_fragment_start)
-                            .ok_or_else(|| {
-                                Self::failure_value(
-                                    "anonymous member body precedes its producer fragment",
-                                )
-                            })?;
-                        let member_body_end = body_span
-                            .end
-                            .checked_sub(self.producer_fragment_start)
-                            .ok_or_else(|| {
-                                Self::failure_value(
-                                    "anonymous member body precedes its producer fragment",
-                                )
-                            })?;
-                        let signature = self
-                            .source
-                            .get(method.span.start as usize..body_span.start as usize)
-                            .ok_or_else(|| {
-                                Self::failure_value(
-                                    "anonymous member signature span is invalid",
-                                )
-                            })?;
-                        let body = self
-                            .source
-                            .get(body_span.start as usize..body_span.end as usize)
-                            .ok_or_else(|| {
-                                Self::failure_value("anonymous member body span is invalid")
-                            })?;
-                        let anonymous_sites = rue_rir::anonymous_type_sites(&method.body)
-                            .into_iter()
-                            .map(|site| {
-                                let fragment_start =
-                                    site.span.start.checked_sub(body_span.start).ok_or_else(|| {
-                                        Self::failure_value(
-                                            "anonymous member nested site precedes its body",
-                                        )
-                                    })?;
-                                let fragment_end =
-                                    site.span.end.checked_sub(body_span.start).ok_or_else(|| {
-                                        Self::failure_value(
-                                            "anonymous member nested site precedes its body",
-                                        )
-                                    })?;
-                                Ok(crate::declaration_candidate::RawAnonymousSite {
-                                    fragment_start,
-                                    fragment_end,
-                                    kind: site.kind,
-                                    anchor: site.anchor,
-                                })
-                            })
-                            .collect::<Result<Vec<_>, EvaluateSemanticConstError>>()?;
                         let parameters = method
                             .params
                             .iter()
@@ -8464,29 +8179,7 @@ impl SemanticConstEvaluator<'_, '_> {
                             ),
                             parameters: parameters.into(),
                             result,
-                            body: Some(
-                                crate::durable_semantics::DurableAnonymousMemberBodySyntax {
-                                    declaration_start,
-                                    body_start: member_body_start,
-                                    body_end: member_body_end,
-                                    signature:
-                                        crate::declaration_candidate::RawDeclarationSignatureSyntax {
-                                            declaration_fragments: Arc::from([Arc::from(signature)]),
-                                            extern_abi: None,
-                                            accessor: method.borrow_return.is_some().then(|| {
-                                                Arc::new(crate::declaration_candidate::RawAccessorSignatureSyntax {
-                                                    body: Arc::from(body),
-                                                    owner_methods: owner_methods.clone(),
-                                                })
-                                            }),
-                                        },
-                                    body:
-                                        crate::declaration_candidate::RawDeclarationBodySyntax {
-                                            body: Arc::from(body),
-                                            anonymous_sites: anonymous_sites.into(),
-                                        },
-                                },
-                            ),
+                            has_body: true,
                         })
                     })
                     .collect::<Result<Vec<_>, EvaluateSemanticConstError>>()?;
@@ -16483,7 +16176,6 @@ impl RevisionedQueryDatabase {
                     parse_modules: parse_modules.clone(),
                     module_source_bases: module_source_bases.clone(),
                     body_input: body_input_resolver,
-                    body_source_bases: body_source_bases.clone(),
                     body_toolchain_demands: body_toolchain_demands.clone(),
                     body_produced_anonymous: body_produced_anonymous.clone(),
                     semantic_nucleus: semantic_nucleus.clone(),
@@ -17443,30 +17135,34 @@ struct BodyInputResolver {
 }
 
 impl BodyInputResolver {
-    fn resolve(
+    fn select(
         &self,
         context: &rue_query::QueryContext,
         key: &crate::body_query::BodyQueryKey,
-    ) -> Result<crate::body_query::BodyInputValue, QueryAbort> {
-        use crate::body_query::{BodyInputIncomplete as Incomplete, BodyInputValue};
+    ) -> Result<
+        Result<
+            (
+                StableDefinitionKey,
+                crate::declaration_candidate::DeclarationCandidateKey,
+            ),
+            crate::body_query::BodyInputIncomplete,
+        >,
+        QueryAbort,
+    > {
+        use crate::body_query::BodyInputIncomplete as Incomplete;
 
         let Some(definition) = body_source_definition_key(&key.instance).cloned() else {
-            return Ok(BodyInputValue::Incomplete(Incomplete::UnsupportedInstance));
+            return Ok(Err(Incomplete::UnsupportedInstance));
         };
-        if !definition.kind().owns_body() {
-            return Ok(BodyInputValue::Incomplete(Incomplete::UnsupportedKind(
-                definition.kind(),
-            )));
-        }
         let classification = match context.query_registered(
             &self.stable_declaration_classifications,
             StableDeclarationClassificationQueryKey(definition.clone()),
         ) {
             Ok(value) => value,
             Err(QueryAbort::MissingInput(_)) => {
-                return Ok(BodyInputValue::Incomplete(Incomplete::MissingPrerequisite(
-                    Arc::from("stable declaration classification"),
-                )));
+                return Ok(Err(Incomplete::MissingPrerequisite(Arc::from(
+                    "stable declaration classification",
+                ))));
             }
             Err(abort) => return Err(abort),
         };
@@ -17475,11 +17171,91 @@ impl BodyInputResolver {
                 StableDeclarationClassificationQueryValue::Selected(candidate),
             ) => candidate.clone(),
             _ => {
+                return Ok(Err(Incomplete::MissingPrerequisite(Arc::from(
+                    "stable declaration candidate",
+                ))));
+            }
+        };
+        Ok(Ok((definition, candidate)))
+    }
+
+    fn resolve_selected_artifact(
+        &self,
+        context: &rue_query::QueryContext,
+        key: &crate::body_query::BodyQueryKey,
+        definition: StableDefinitionKey,
+        candidate: crate::declaration_candidate::DeclarationCandidateKey,
+    ) -> Result<crate::body_query::BodyInputValue, QueryAbort> {
+        use crate::body_query::{BodyInputIncomplete as Incomplete, BodyInputValue};
+
+        let artifacts = match context.query_registered(
+            &self.declaration_body_plan_artifacts,
+            DeclarationBodyPlanQueryKey(candidate),
+        ) {
+            Ok(value) => value,
+            Err(QueryAbort::MissingInput(_)) => {
                 return Ok(BodyInputValue::Incomplete(Incomplete::MissingPrerequisite(
-                    Arc::from("stable declaration candidate"),
+                    Arc::from("declaration body plan"),
+                )));
+            }
+            Err(abort) => return Err(abort),
+        };
+        let rue_query::QueryOutcome::Success(artifacts) = artifacts.outcome() else {
+            unreachable!("DeclarationBodyPlanArtifacts publishes typed values")
+        };
+        let artifacts = match artifacts {
+            DeclarationBodyPlanArtifactsValue::Available(artifacts) => artifacts,
+            DeclarationBodyPlanArtifactsValue::Failure(failure) => {
+                return Ok(BodyInputValue::Incomplete(Incomplete::BodyPlanFailure(
+                    failure.clone(),
                 )));
             }
         };
+        let locator = context.query_registered(&self.body_source_bases, key.clone())?;
+        let rue_query::QueryOutcome::Success(Some(locator)) = locator.outcome() else {
+            return Ok(BodyInputValue::Incomplete(Incomplete::MissingPrerequisite(
+                Arc::from("body source basis"),
+            )));
+        };
+        Ok(BodyInputValue::Available(
+            crate::body_query::OwnedBodyInput {
+                owner: definition,
+                source: locator.clone(),
+                artifacts: artifacts.clone(),
+            },
+        ))
+    }
+
+    fn resolve_producer_artifact(
+        &self,
+        context: &rue_query::QueryContext,
+        key: &crate::body_query::BodyQueryKey,
+    ) -> Result<crate::body_query::BodyInputValue, QueryAbort> {
+        let (definition, candidate) = match self.select(context, key)? {
+            Ok(selected) => selected,
+            Err(incomplete) => {
+                return Ok(crate::body_query::BodyInputValue::Incomplete(incomplete));
+            }
+        };
+        self.resolve_selected_artifact(context, key, definition, candidate)
+    }
+
+    fn resolve(
+        &self,
+        context: &rue_query::QueryContext,
+        key: &crate::body_query::BodyQueryKey,
+    ) -> Result<crate::body_query::BodyInputValue, QueryAbort> {
+        use crate::body_query::{BodyInputIncomplete as Incomplete, BodyInputValue};
+
+        let (definition, candidate) = match self.select(context, key)? {
+            Ok(selected) => selected,
+            Err(incomplete) => return Ok(BodyInputValue::Incomplete(incomplete)),
+        };
+        if !definition.kind().owns_body() {
+            return Ok(BodyInputValue::Incomplete(Incomplete::UnsupportedKind(
+                definition.kind(),
+            )));
+        }
         let shell = match context.query_registered(
             &self.declaration_shells,
             DeclarationShellQueryKey(candidate.clone()),
@@ -17519,42 +17295,7 @@ impl BodyInputResolver {
                 return Ok(BodyInputValue::Incomplete(Incomplete::Generic));
             }
         }
-        let artifacts = match context.query_registered(
-            &self.declaration_body_plan_artifacts,
-            DeclarationBodyPlanQueryKey(candidate),
-        ) {
-            Ok(value) => value,
-            Err(QueryAbort::MissingInput(_)) => {
-                return Ok(BodyInputValue::Incomplete(Incomplete::MissingPrerequisite(
-                    Arc::from("declaration body plan"),
-                )));
-            }
-            Err(abort) => return Err(abort),
-        };
-        let rue_query::QueryOutcome::Success(artifacts) = artifacts.outcome() else {
-            unreachable!("DeclarationBodyPlanArtifacts publishes typed values")
-        };
-        let artifacts = match artifacts {
-            DeclarationBodyPlanArtifactsValue::Available(artifacts) => artifacts,
-            DeclarationBodyPlanArtifactsValue::Failure(failure) => {
-                return Ok(BodyInputValue::Incomplete(Incomplete::BodyPlanFailure(
-                    failure.clone(),
-                )));
-            }
-        };
-        let locator = context.query_registered(&self.body_source_bases, key.clone())?;
-        let rue_query::QueryOutcome::Success(Some(locator)) = locator.outcome() else {
-            return Ok(BodyInputValue::Incomplete(Incomplete::MissingPrerequisite(
-                Arc::from("body source basis"),
-            )));
-        };
-        Ok(BodyInputValue::Available(
-            crate::body_query::OwnedBodyInput {
-                owner: definition,
-                source: locator.clone(),
-                artifacts: artifacts.clone(),
-            },
-        ))
+        self.resolve_selected_artifact(context, key, definition, candidate)
     }
 }
 
@@ -17562,8 +17303,6 @@ struct BodyTransactionEvaluator {
     parse_modules: QueryFamily<ModuleQueryKey, ParseModuleValue>,
     module_source_bases: QueryFamily<ModuleQueryKey, Option<rue_air::DurableBodySourceLocator>>,
     body_input: BodyInputResolver,
-    body_source_bases:
-        QueryFamily<crate::body_query::BodyQueryKey, Option<crate::body_query::BodySourceLocator>>,
     body_toolchain_demands:
         QueryFamily<crate::body_query::BodyQueryKey, crate::BodyToolchainDemand>,
     body_produced_anonymous:
@@ -18614,16 +18353,28 @@ impl BodyTransactionEvaluator {
                     owner_identity,
                 )) = owner.as_ref()
                 else {
-                    return Err(QueryAbort::Canceled);
+                    return Ok(QueryOutput::success(Self::lowering_failure(
+                        &definition,
+                        "anonymous member has a non-anonymous owner",
+                    ))
+                    .with_terminal_kind(QueryTerminalKind::Failure));
                 };
                 let Some(owner_fact) = selected_anonymous.get(owner_identity) else {
-                    return Err(QueryAbort::Canceled);
+                    return Ok(QueryOutput::success(Self::lowering_failure(
+                        &definition,
+                        "anonymous member owner fact is unavailable",
+                    ))
+                    .with_terminal_kind(QueryTerminalKind::Failure));
                 };
                 let crate::durable_semantics::DurableAnonymousNominalShape::Struct {
                     methods, ..
                 } = &owner_fact.shape
                 else {
-                    return Err(QueryAbort::Canceled);
+                    return Ok(QueryOutput::success(Self::lowering_failure(
+                        &definition,
+                        "anonymous enum cannot own a callable member",
+                    ))
+                    .with_terminal_kind(QueryTerminalKind::Failure));
                 };
                 let Some(method) = methods.iter().find(|candidate| {
                     let kind = if candidate.name.as_ref() == "__drop" {
@@ -18635,21 +18386,103 @@ impl BodyTransactionEvaluator {
                     };
                     candidate.name == member.name && kind == member.kind
                 }) else {
-                    return Err(QueryAbort::Canceled);
-                };
-                let Some(member_input) = &method.body else {
-                    return Err(QueryAbort::Canceled);
-                };
-                let source_basis =
-                    context.query_registered(&self.body_source_bases, key.clone())?;
-                let rue_query::QueryOutcome::Success(Some(source_basis)) = source_basis.outcome()
-                else {
                     return Ok(QueryOutput::success(Self::lowering_failure(
                         &definition,
-                        "anonymous member producer has no real source basis",
+                        "anonymous member identity is absent from its producer facts",
                     ))
                     .with_terminal_kind(QueryTerminalKind::Failure));
                 };
+                if !method.has_body {
+                    return Ok(QueryOutput::success(Self::lowering_failure(
+                        &definition,
+                        "anonymous member producer facts do not admit a body",
+                    ))
+                    .with_terminal_kind(QueryTerminalKind::Failure));
+                }
+                let input = self.body_input.resolve_producer_artifact(context, key)?;
+                let input = match input {
+                    crate::body_query::BodyInputValue::Available(input) => input,
+                    crate::body_query::BodyInputValue::Incomplete(
+                        crate::body_query::BodyInputIncomplete::BodyPlanFailure(failure),
+                    ) => {
+                        return Ok(QueryOutput::success(Self::body_plan_failure(
+                            &definition,
+                            &failure,
+                        ))
+                        .with_terminal_kind(QueryTerminalKind::Failure));
+                    }
+                    crate::body_query::BodyInputValue::Incomplete(incomplete) => {
+                        return Ok(QueryOutput::success(Self::lowering_failure(
+                            &definition,
+                            format!("anonymous producer artifact is unavailable: {incomplete:?}"),
+                        ))
+                        .with_terminal_kind(QueryTerminalKind::Failure));
+                    }
+                };
+                let attribution_enabled =
+                    tracing::enabled!(target: "rue::timing", tracing::Level::INFO);
+                let _body_input_lowering_span =
+                    tracing::info_span!("body_input_lowering", phase = "semantic_analysis")
+                        .entered();
+                let materialized = if attribution_enabled {
+                    input
+                        .artifacts
+                        .plan
+                        .materialize_body_rir_bundle_with_declaration_and_attribution(
+                            input.source.file_id,
+                            input.source.declaration_start,
+                            input.source.source_length,
+                            || self.materialization_checkpoint(context),
+                        )
+                        .map(|(bundle, declaration, attribution)| {
+                            (bundle, declaration, Some(attribution))
+                        })
+                } else {
+                    input
+                        .artifacts
+                        .plan
+                        .materialize_body_rir_bundle_with_declaration(
+                            input.source.file_id,
+                            input.source.declaration_start,
+                            input.source.source_length,
+                            || self.materialization_checkpoint(context),
+                        )
+                        .map(|(bundle, declaration)| (bundle, declaration, None))
+                };
+                let (bundle, candidate_root) = match materialized {
+                    Ok((bundle, declaration, attribution))
+                        if input.artifacts.plan.instruction_count() > 0 =>
+                    {
+                        if let Some(attribution) = attribution {
+                            publish_body_plan_materialization_attribution(attribution);
+                        }
+                        (bundle, declaration)
+                    }
+                    Ok(_) => {
+                        return Ok(QueryOutput::success(Self::lowering_failure(
+                            &definition,
+                            "anonymous producer artifact contains no local instructions",
+                        ))
+                        .with_terminal_kind(QueryTerminalKind::Failure));
+                    }
+                    Err(crate::canonical_lower::BodyPlanMaterializationFailure::Query(abort)) => {
+                        return Err(abort);
+                    }
+                    Err(crate::canonical_lower::BodyPlanMaterializationFailure::Build(error)) => {
+                        return Ok(QueryOutput::success(Self::lowering_build_failure(&error))
+                            .with_terminal_kind(QueryTerminalKind::Failure));
+                    }
+                    Err(crate::canonical_lower::BodyPlanMaterializationFailure::Invalid(
+                        failure,
+                    )) => {
+                        return Ok(QueryOutput::success(Self::lowering_failure(
+                            &definition,
+                            failure,
+                        ))
+                        .with_terminal_kind(QueryTerminalKind::Failure));
+                    }
+                };
+                drop(_body_input_lowering_span);
                 let provider = CompilerBodyFactProvider::new(
                     self.compiler_body_provider_queries(
                         context,
@@ -18661,25 +18494,9 @@ impl BodyTransactionEvaluator {
                     .with_producer_transport_failure(producer_transport_failure.clone()),
                 );
                 let source_locator = rue_air::DurableBodySourceLocator {
-                    file_id: source_basis.file_id,
-                    physical_path: source_basis.physical_path.clone(),
-                    source_length: source_basis.source_length,
-                };
-                let producer_fragment_start = source_basis.body_start;
-                let lowering = match lower_anonymous_member_body_input(
-                    member_input,
-                    member,
-                    &source_locator,
-                    producer_fragment_start,
-                ) {
-                    Ok(lowering) => lowering,
-                    Err(detail) => {
-                        return Ok(QueryOutput::success(Self::lowering_failure(
-                            &definition,
-                            detail,
-                        ))
-                        .with_terminal_kind(QueryTerminalKind::Failure));
-                    }
+                    file_id: input.source.file_id,
+                    physical_path: input.source.physical_path.clone(),
+                    source_length: input.source.source_length,
                 };
                 let source = CompilerBodyDurableSource::with_anonymous(
                     &provider,
@@ -18702,7 +18519,8 @@ impl BodyTransactionEvaluator {
                     rue_air::analyze_provider_anonymous_body(
                         &provider,
                         source,
-                        &lowering.bundle,
+                        &bundle,
+                        candidate_root,
                         definition.clone(),
                         owner.as_ref(),
                         member,
@@ -18723,6 +18541,20 @@ impl BodyTransactionEvaluator {
                     Ok(analyzed) => {
                         self.provider_observation_meter
                             .accrue_provider_body_work(analyzed.work);
+                        let body_anchor = analyzed
+                            .body_span
+                            .start
+                            .checked_sub(input.source.body_start)
+                            .zip(analyzed.body_span.end.checked_sub(input.source.body_start))
+                            .filter(|(start, end)| {
+                                analyzed.body_span.file_id == input.source.file_id
+                                    && start <= end
+                                    && analyzed.body_span.end <= input.source.body_end
+                            })
+                            .map(|(start, end)| crate::body_query::BodyRelativeRange {
+                                start,
+                                end,
+                            });
                         let definition_tokens = analyzed
                             .definition_tokens
                             .into_iter()
@@ -18765,7 +18597,7 @@ impl BodyTransactionEvaluator {
                                 Ok(body),
                                 Ok(nested),
                                 Ok(produced_anonymous_nominals),
-                            ) if identity == key.instance => {
+                            ) if identity == key.instance && body_anchor.is_some() => {
                                 let mut references = analyzed
                                     .referenced_definitions
                                     .into_iter()
@@ -18790,10 +18622,9 @@ impl BodyTransactionEvaluator {
                                 crate::body_query::BodyTransaction::Success {
                                     body: Arc::new(crate::body_query::CanonicalBody::Anonymous {
                                         identity,
-                                        body_anchor: crate::body_query::BodyRelativeRange {
-                                            start: member_input.body_start,
-                                            end: member_input.body_end,
-                                        },
+                                        body_anchor: body_anchor.expect(
+                                            "successful anonymous body projection has an anchor",
+                                        ),
                                         body,
                                     }),
                                     references: crate::body_query::BodyReferences(
@@ -18822,7 +18653,7 @@ impl BodyTransactionEvaluator {
                             },
                         }
                     }
-                    Err(error) => body_failure_with_source(error, source_basis),
+                    Err(error) => body_failure_with_source(error, &input.source),
                 }
             } else {
                 crate::body_query::BodyTransaction::DeterministicFailure {
@@ -22926,7 +22757,7 @@ fn project_provider_produced_anonymous_nominals(
                                         .collect::<Result<Vec<_>, _>>()?
                                         .into(),
                                     result: method_type(&method.result)?,
-                                    body: None,
+                                    has_body: true,
                                 })
                             })
                             .collect::<Result<Vec<_>, _>>()?
@@ -25754,10 +25585,10 @@ mod tests {
             "production provider construction must obtain its view from BodyRirBundle::view"
         );
         let lower = include_str!("canonical_lower.rs");
-        assert!(lower.contains("BodyRirBundle::new"));
+        assert!(lower.contains("BodyRirBundle::new_with_index_attribution"));
         assert!(
-            lower.contains("into_remapped_body_rir_bundle"),
-            "the production lowerer owns the request-local bundle"
+            lower.contains("materialize_body_rir_bundle_with_declaration"),
+            "the packed candidate materializer owns the request-local bundle"
         );
     }
 
@@ -30595,7 +30426,7 @@ fn main() -> i32 {
                     result: crate::durable_semantics::DurableAnonymousMethodType::Concrete(
                         rue_air::SemanticImportType::I32,
                     ),
-                    body: None,
+                    has_body: false,
                 }]),
             },
             Arc::from([]),
@@ -39513,83 +39344,858 @@ fn main() -> i32 {
     }
 
     #[test]
-    fn anonymous_member_body_anchors_are_producer_fragment_relative() {
+    fn anonymous_member_reuses_its_candidate_artifact_and_current_source_basis() {
         let first_text = "// unrelated leading source\nfn Box() -> type {\n    struct { fn get(self) -> i32 { 7 } }\n}";
         let shifted_text = "// another position-only line\n// unrelated leading source\nfn Box() -> type {\n    struct { fn get(self) -> i32 { 7 } }\n}";
-        let source = |text| source_snapshot(&[(1, "/main.rue", "main.rue", text)], 1);
+        let source =
+            |file_id, text| source_snapshot(&[(file_id, "/main.rue", "main.rue", text)], file_id);
         let module = ModuleId::from_logical_path("main.rue").unwrap();
         let producer = crate::FunctionInstanceKey::Specialization {
             base: Box::new(free_function_instance(&module, "Box")),
             arguments: crate::CanonicalArguments::default(),
         };
-        let key = crate::body_query::BodyQueryKey::new(producer, semantic_configuration());
-        let member_syntax =
+        let producer_key =
+            crate::body_query::BodyQueryKey::new(producer.clone(), semantic_configuration());
+        let member_key =
             |terminal: &rue_query::QueryTerminal<crate::body_query::ProducedAnonymous>| {
                 let rue_query::QueryOutcome::Success(
                     crate::body_query::ProducedAnonymous::Produced(produced),
                 ) = terminal.outcome()
                 else {
-                    panic!("anonymous producer did not publish its member syntax")
+                    panic!("anonymous producer did not publish its member facts")
                 };
-                produced
+                let owner = produced
                     .0
                     .iter()
-                    .find_map(|nominal| {
+                    .find(|nominal| {
                         let crate::durable_semantics::DurableAnonymousNominalShape::Struct {
                             methods,
                             ..
                         } = &nominal.shape
                         else {
-                            return None;
+                            return false;
                         };
                         methods
                             .iter()
-                            .find(|method| method.name.as_ref() == "get")?
-                            .body
-                            .clone()
+                            .any(|method| method.name.as_ref() == "get" && method.has_body)
                     })
-                    .expect("producer publishes the anonymous get body")
+                    .expect("producer publishes a body-bearing anonymous get method");
+                crate::body_query::BodyQueryKey::new(
+                    crate::FunctionInstanceKey::AnonymousMember {
+                        owner: Box::new(crate::TypeInstanceKey::Nominal(
+                            crate::NominalInstanceKey::Anonymous(owner.identity.clone()),
+                        )),
+                        member: crate::AnonymousMemberKey {
+                            kind: crate::AnonymousMemberKind::Method,
+                            name: Arc::from("get"),
+                        },
+                    },
+                    semantic_configuration(),
+                )
             };
 
         let mut database = RevisionedQueryDatabase::default();
-        let first_source = source(first_text);
+        let first_source = source(1, first_text);
         let first_revision = revision_for(&mut database, &first_source);
-        let first = database.runtime.request_registered(
+        let first_produced = database.runtime.request_registered(
             &database.body_produced_anonymous,
             first_revision,
-            key.clone(),
+            producer_key.clone(),
             CancellationToken::new(),
         );
-        let first_terminal = first.terminal().unwrap();
-        let first_syntax = member_syntax(first_terminal);
-        let producer_fragment_start = first_text.find("{\n    struct").unwrap();
-        let declaration_start = first_text.find("fn get").unwrap() - producer_fragment_start;
-        let body_start = first_text.find("{ 7 }").unwrap() - producer_fragment_start;
-        assert_eq!(
-            first_syntax.declaration_start,
-            u32::try_from(declaration_start).unwrap(),
+        let first_member = member_key(first_produced.terminal().unwrap());
+        let first_candidate = declaration_candidate(
+            &database,
+            first_revision,
+            &module,
+            crate::declaration_candidate::DeclarationCandidateCategory::Function,
+            "Box",
         );
-        assert_eq!(first_syntax.body_start, u32::try_from(body_start).unwrap());
+        let first_artifact = database.runtime.request_registered(
+            &database.declaration_body_plan_artifacts,
+            first_revision,
+            DeclarationBodyPlanQueryKey(first_candidate),
+            CancellationToken::new(),
+        );
+        let first_artifact_stamp = first_artifact.terminal().unwrap().stamp();
+        let astgen_before_member = database
+            .declaration_body_plan_astgen_evaluations
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let first_transaction = database
+            .body_transaction(
+                first_revision,
+                first_member.clone(),
+                CancellationToken::new(),
+            )
+            .expect("anonymous get transaction succeeds from its producer artifact");
         assert_eq!(
-            first_syntax.body_end,
-            u32::try_from(body_start + "{ 7 }".len()).unwrap(),
+            database
+                .declaration_body_plan_astgen_evaluations
+                .load(std::sync::atomic::Ordering::Relaxed),
+            astgen_before_member,
+            "the anonymous member must reuse its producer candidate AstGen result",
+        );
+        assert!(first_transaction.dependencies().iter().any(|dependency| {
+            dependency.node.family() == "compiler.declaration-body-plan-artifacts"
+                && dependency.stamp == first_artifact_stamp
+        }));
+        let rue_query::QueryOutcome::Success(crate::body_query::BodyTransaction::Success {
+            body,
+            ..
+        }) = first_transaction.outcome()
+        else {
+            panic!("anonymous get transaction did not publish a body")
+        };
+        let crate::body_query::CanonicalBody::Anonymous {
+            body_anchor: first_anchor,
+            ..
+        } = body.as_ref()
+        else {
+            panic!("anonymous get transaction published the wrong body kind")
+        };
+        let first_locator = database
+            .body_source_basis_projection(
+                first_revision,
+                first_member.clone(),
+                CancellationToken::new(),
+            )
+            .unwrap();
+        let rue_query::QueryOutcome::Success(Some(first_locator)) = first_locator.outcome() else {
+            panic!("anonymous member has its producer's current source basis")
+        };
+        assert_eq!(
+            first_locator.body_start + first_anchor.start,
+            u32::try_from(first_text.find("7 }").unwrap()).unwrap(),
+        );
+        assert_eq!(
+            first_locator.body_start + first_anchor.end,
+            u32::try_from(first_text.find("7 }").unwrap() + "7".len()).unwrap(),
         );
 
-        let shifted_source = source(shifted_text);
+        let shifted_source = source(7, shifted_text);
         let shifted_revision = revision_for(&mut database, &shifted_source);
-        let shifted = database.runtime.request_registered(
+        let shifted_produced = database.runtime.request_registered(
             &database.body_produced_anonymous,
             shifted_revision,
-            key,
+            producer_key,
             CancellationToken::new(),
         );
-        let shifted_terminal = shifted.terminal().unwrap();
-        assert_eq!(
-            shifted_terminal.stamp(),
-            first_terminal.stamp(),
-            "moving the producer in its module must not restamp its member syntax",
+        let shifted_member = member_key(shifted_produced.terminal().unwrap());
+        assert_eq!(shifted_member, first_member);
+        let shifted_candidate = declaration_candidate(
+            &database,
+            shifted_revision,
+            &module,
+            crate::declaration_candidate::DeclarationCandidateCategory::Function,
+            "Box",
         );
-        assert_eq!(member_syntax(shifted_terminal), first_syntax);
+        let shifted_artifact = database.runtime.request_registered(
+            &database.declaration_body_plan_artifacts,
+            shifted_revision,
+            DeclarationBodyPlanQueryKey(shifted_candidate),
+            CancellationToken::new(),
+        );
+        assert_eq!(
+            shifted_artifact.terminal().unwrap().stamp(),
+            first_artifact_stamp,
+            "moving the producer must not restamp its candidate artifact",
+        );
+        let astgen_before_shifted_member = database
+            .declaration_body_plan_astgen_evaluations
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let shifted_transaction = database
+            .body_transaction(
+                shifted_revision,
+                shifted_member.clone(),
+                CancellationToken::new(),
+            )
+            .expect("shifted anonymous get transaction succeeds");
+        assert_eq!(
+            database
+                .declaration_body_plan_astgen_evaluations
+                .load(std::sync::atomic::Ordering::Relaxed),
+            astgen_before_shifted_member,
+        );
+        assert_eq!(shifted_transaction.stamp(), first_transaction.stamp());
+        let rue_query::QueryOutcome::Success(crate::body_query::BodyTransaction::Success {
+            body,
+            ..
+        }) = shifted_transaction.outcome()
+        else {
+            panic!("shifted anonymous get transaction did not publish a body")
+        };
+        let crate::body_query::CanonicalBody::Anonymous {
+            body_anchor: shifted_anchor,
+            ..
+        } = body.as_ref()
+        else {
+            panic!("shifted anonymous get transaction published the wrong body kind")
+        };
+        assert_eq!(shifted_anchor, first_anchor);
+        let shifted_locator = database
+            .body_source_basis_projection(
+                shifted_revision,
+                shifted_member,
+                CancellationToken::new(),
+            )
+            .unwrap();
+        let rue_query::QueryOutcome::Success(Some(shifted_locator)) = shifted_locator.outcome()
+        else {
+            panic!("shifted anonymous member has its current producer basis")
+        };
+        assert_eq!(shifted_locator.file_id, FileId::new(7));
+        assert_eq!(
+            shifted_locator.body_start + shifted_anchor.start,
+            u32::try_from(shifted_text.find("7 }").unwrap()).unwrap(),
+        );
+        assert_eq!(
+            shifted_locator.body_start + shifted_anchor.end,
+            u32::try_from(shifted_text.find("7 }").unwrap() + "7".len()).unwrap(),
+        );
+    }
+
+    #[test]
+    fn anonymous_member_diagnostics_relocate_and_internal_trivia_invalidates() {
+        let text = |prefix: &str, trivia: &str| {
+            format!(
+                "{prefix}fn Box() -> type {{\n    struct {{ fn get(self) -> i32 {{ {trivia}missing }} }}\n}}"
+            )
+        };
+        let source = |text: &str| source_snapshot(&[(1, "/main.rue", "main.rue", text)], 1);
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let producer = crate::FunctionInstanceKey::Specialization {
+            base: Box::new(free_function_instance(&module, "Box")),
+            arguments: crate::CanonicalArguments::default(),
+        };
+        let member_key =
+            |terminal: &rue_query::QueryTerminal<crate::body_query::ProducedAnonymous>| {
+                let rue_query::QueryOutcome::Success(
+                    crate::body_query::ProducedAnonymous::Produced(produced),
+                ) = terminal.outcome()
+                else {
+                    panic!("Box did not publish get's owner")
+                };
+                let owner = produced
+                    .0
+                    .iter()
+                    .find(|nominal| {
+                        matches!(
+                            &nominal.shape,
+                            crate::durable_semantics::DurableAnonymousNominalShape::Struct {
+                                methods,
+                                ..
+                            } if methods.iter().any(|method| method.name.as_ref() == "get")
+                        )
+                    })
+                    .unwrap();
+                crate::body_query::BodyQueryKey::new(
+                    crate::FunctionInstanceKey::AnonymousMember {
+                        owner: Box::new(crate::TypeInstanceKey::Nominal(
+                            crate::NominalInstanceKey::Anonymous(owner.identity.clone()),
+                        )),
+                        member: crate::AnonymousMemberKey {
+                            kind: crate::AnonymousMemberKind::Method,
+                            name: Arc::from("get"),
+                        },
+                    },
+                    semantic_configuration(),
+                )
+            };
+        let request = |database: &RevisionedQueryDatabase,
+                       revision,
+                       producer_key: crate::body_query::BodyQueryKey| {
+            let produced = database.runtime.request_registered(
+                &database.body_produced_anonymous,
+                revision,
+                producer_key,
+                CancellationToken::new(),
+            );
+            let member = member_key(produced.terminal().unwrap());
+            let transaction = database
+                .body_transaction(revision, member.clone(), CancellationToken::new())
+                .expect("anonymous diagnostic publishes deterministically");
+            let locator = database
+                .body_source_basis_projection(revision, member, CancellationToken::new())
+                .unwrap();
+            (transaction, locator)
+        };
+
+        let mut database = RevisionedQueryDatabase::default();
+        let first_text = text("", "");
+        let first_source = source(&first_text);
+        let first_revision = revision_for(&mut database, &first_source);
+        let first_candidate = declaration_candidate(
+            &database,
+            first_revision,
+            &module,
+            crate::declaration_candidate::DeclarationCandidateCategory::Function,
+            "Box",
+        );
+        let first_artifact = database.runtime.request_registered(
+            &database.declaration_body_plan_artifacts,
+            first_revision,
+            DeclarationBodyPlanQueryKey(first_candidate),
+            CancellationToken::new(),
+        );
+        let (first_transaction, _) = request(
+            &database,
+            first_revision,
+            crate::body_query::BodyQueryKey::new(producer.clone(), semantic_configuration()),
+        );
+
+        let shifted_text = text("// position-only prefix\n", "");
+        let shifted_source = source(&shifted_text);
+        let shifted_revision = revision_for(&mut database, &shifted_source);
+        let shifted_candidate = declaration_candidate(
+            &database,
+            shifted_revision,
+            &module,
+            crate::declaration_candidate::DeclarationCandidateCategory::Function,
+            "Box",
+        );
+        let shifted_artifact = database.runtime.request_registered(
+            &database.declaration_body_plan_artifacts,
+            shifted_revision,
+            DeclarationBodyPlanQueryKey(shifted_candidate),
+            CancellationToken::new(),
+        );
+        let (shifted_transaction, shifted_locator) = request(
+            &database,
+            shifted_revision,
+            crate::body_query::BodyQueryKey::new(producer.clone(), semantic_configuration()),
+        );
+        assert_eq!(
+            shifted_artifact.terminal().unwrap().stamp(),
+            first_artifact.terminal().unwrap().stamp(),
+        );
+        assert_eq!(shifted_transaction.stamp(), first_transaction.stamp());
+        let rue_query::QueryOutcome::Success(Some(shifted_locator)) = shifted_locator.outcome()
+        else {
+            panic!("shifted anonymous diagnostic has a current source basis")
+        };
+        let rue_query::QueryOutcome::Success(transaction) = shifted_transaction.outcome() else {
+            panic!("shifted anonymous diagnostic has a typed transaction")
+        };
+        let projected = project_transaction_diagnostics(transaction.clone(), Some(shifted_locator));
+        let crate::body_query::BodyTransaction::DeterministicFailure { errors, .. } = projected
+        else {
+            panic!("undefined anonymous name remains a deterministic failure")
+        };
+        let shifted_missing = u32::try_from(shifted_text.find("missing").unwrap()).unwrap();
+        assert!(errors.iter().any(|error| {
+            error.span().is_some_and(|span| {
+                span.file_id == shifted_locator.file_id
+                    && span.start <= shifted_missing
+                    && shifted_missing < span.end
+            })
+        }));
+
+        let internal_text = text("// position-only prefix\n", "       ");
+        let internal_source = source(&internal_text);
+        let internal_revision = revision_for(&mut database, &internal_source);
+        let internal_candidate = declaration_candidate(
+            &database,
+            internal_revision,
+            &module,
+            crate::declaration_candidate::DeclarationCandidateCategory::Function,
+            "Box",
+        );
+        let internal_artifact = database.runtime.request_registered(
+            &database.declaration_body_plan_artifacts,
+            internal_revision,
+            DeclarationBodyPlanQueryKey(internal_candidate),
+            CancellationToken::new(),
+        );
+        let (internal_transaction, internal_locator) = request(
+            &database,
+            internal_revision,
+            crate::body_query::BodyQueryKey::new(producer, semantic_configuration()),
+        );
+        assert_ne!(
+            internal_artifact.terminal().unwrap().stamp(),
+            shifted_artifact.terminal().unwrap().stamp(),
+        );
+        assert_ne!(internal_transaction.stamp(), shifted_transaction.stamp());
+        let rue_query::QueryOutcome::Success(Some(internal_locator)) = internal_locator.outcome()
+        else {
+            panic!("internally shifted anonymous diagnostic has a current source basis")
+        };
+        let rue_query::QueryOutcome::Success(transaction) = internal_transaction.outcome() else {
+            panic!("internally shifted anonymous diagnostic has a typed transaction")
+        };
+        let projected =
+            project_transaction_diagnostics(transaction.clone(), Some(internal_locator));
+        let crate::body_query::BodyTransaction::DeterministicFailure { errors, .. } = projected
+        else {
+            panic!("internally shifted undefined name remains deterministic")
+        };
+        let internal_missing = u32::try_from(internal_text.find("missing").unwrap()).unwrap();
+        assert!(errors.iter().any(|error| {
+            error.span().is_some_and(|span| {
+                span.file_id == internal_locator.file_id
+                    && span.start <= internal_missing
+                    && internal_missing < span.end
+            })
+        }));
+    }
+
+    #[test]
+    fn nested_anonymous_members_share_the_ultimate_candidate_artifact() {
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn Outer() -> type {\n\
+                     struct {\n\
+                         fn make(self) -> type {\n\
+                             struct { fn value(self) -> i32 { 11 } }\n\
+                         }\n\
+                     }\n\
+                 }",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let producer = crate::FunctionInstanceKey::Specialization {
+            base: Box::new(free_function_instance(&module, "Outer")),
+            arguments: crate::CanonicalArguments::default(),
+        };
+        let member_key =
+            |terminal: &rue_query::QueryTerminal<crate::body_query::ProducedAnonymous>,
+             name: &str| {
+                let rue_query::QueryOutcome::Success(
+                    crate::body_query::ProducedAnonymous::Produced(produced),
+                ) = terminal.outcome()
+                else {
+                    panic!("anonymous producer did not publish {name}")
+                };
+                let owner = produced
+                    .0
+                    .iter()
+                    .find(|nominal| {
+                        let crate::durable_semantics::DurableAnonymousNominalShape::Struct {
+                            methods,
+                            ..
+                        } = &nominal.shape
+                        else {
+                            return false;
+                        };
+                        methods
+                            .iter()
+                            .any(|method| method.name.as_ref() == name && method.has_body)
+                    })
+                    .unwrap_or_else(|| panic!("anonymous producer has no body-bearing {name}"));
+                crate::body_query::BodyQueryKey::new(
+                    crate::FunctionInstanceKey::AnonymousMember {
+                        owner: Box::new(crate::TypeInstanceKey::Nominal(
+                            crate::NominalInstanceKey::Anonymous(owner.identity.clone()),
+                        )),
+                        member: crate::AnonymousMemberKey {
+                            kind: crate::AnonymousMemberKind::Method,
+                            name: Arc::from(name),
+                        },
+                    },
+                    semantic_configuration(),
+                )
+            };
+
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = revision_for(&mut database, &source);
+        let outer = database.runtime.request_registered(
+            &database.body_produced_anonymous,
+            revision,
+            crate::body_query::BodyQueryKey::new(producer, semantic_configuration()),
+            CancellationToken::new(),
+        );
+        let make = member_key(outer.terminal().unwrap(), "make");
+        let after_outer = database
+            .declaration_body_plan_astgen_evaluations
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            after_outer, 0,
+            "discovering Outer does not demand a runtime body artifact",
+        );
+
+        let inner = database.runtime.request_registered(
+            &database.body_produced_anonymous,
+            revision,
+            make.clone(),
+            CancellationToken::new(),
+        );
+        let value = member_key(inner.terminal().unwrap(), "value");
+        let after_make = database
+            .declaration_body_plan_astgen_evaluations
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(after_make, 1, "make demands Outer's candidate exactly once");
+        let value_transaction = database
+            .body_transaction(revision, value, CancellationToken::new())
+            .expect("nested value transaction succeeds");
+        assert!(matches!(
+            value_transaction.outcome(),
+            rue_query::QueryOutcome::Success(crate::body_query::BodyTransaction::Success { .. })
+        ));
+        assert_eq!(
+            database
+                .declaration_body_plan_astgen_evaluations
+                .load(std::sync::atomic::Ordering::Relaxed),
+            after_make,
+            "make and value must both select nested declarations from Outer",
+        );
+
+        let make_transaction = database
+            .body_transaction(revision, make, CancellationToken::new())
+            .expect("make transaction remains retained");
+        let artifact_dependency = |transaction: &rue_query::QueryTerminal<_>| {
+            transaction
+                .dependencies()
+                .iter()
+                .find(|dependency| {
+                    dependency.node.family() == "compiler.declaration-body-plan-artifacts"
+                })
+                .map(|dependency| (dependency.incarnation, dependency.stamp))
+                .expect("anonymous transaction directly observes its producer artifact")
+        };
+        assert_eq!(
+            artifact_dependency(&make_transaction),
+            artifact_dependency(&value_transaction),
+        );
+    }
+
+    #[test]
+    fn const_produced_anonymous_member_uses_the_const_candidate_artifact() {
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "const T: type = struct {\n\
+                     value: i32,\n\
+                     fn get(self) -> i32 { self.value }\n\
+                 };\n\
+                 fn main() -> i32 {\n\
+                     let value: T = T { value: 5 };\n\
+                     value.get()\n\
+                 }",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let configuration = semantic_configuration();
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = revision_for(&mut database, &source);
+        let closure = database
+            .body_closure(
+                revision,
+                crate::body_query::BodyClosureQueryKey {
+                    modules: Arc::from([module.clone()]),
+                    roots: Arc::from([free_function_instance(&module, "main")]),
+                    configuration: configuration.clone(),
+                },
+                CancellationToken::new(),
+            )
+            .expect("const-produced anonymous member closure succeeds");
+        let rue_query::QueryOutcome::Success(output) = closure.terminal.outcome() else {
+            panic!("const-produced closure publishes a typed value")
+        };
+        let get = output
+            .reached
+            .iter()
+            .find(|instance| {
+                matches!(
+                    instance,
+                    crate::FunctionInstanceKey::AnonymousMember { member, .. }
+                        if member.name.as_ref() == "get"
+                )
+            })
+            .cloned()
+            .expect("main reaches T.get");
+        let transaction = database
+            .body_transaction(
+                revision,
+                crate::body_query::BodyQueryKey::new(get, configuration),
+                CancellationToken::new(),
+            )
+            .expect("T.get transaction remains retained");
+        assert!(matches!(
+            transaction.outcome(),
+            rue_query::QueryOutcome::Success(crate::body_query::BodyTransaction::Success { .. })
+        ));
+
+        let candidate = declaration_candidate(
+            &database,
+            revision,
+            &module,
+            crate::declaration_candidate::DeclarationCandidateCategory::ConstCandidate,
+            "T",
+        );
+        let artifact = database.runtime.request_registered(
+            &database.declaration_body_plan_artifacts,
+            revision,
+            DeclarationBodyPlanQueryKey(candidate),
+            CancellationToken::new(),
+        );
+        let artifact_stamp = artifact.terminal().unwrap().stamp();
+        assert!(transaction.dependencies().iter().any(|dependency| {
+            dependency.node.family() == "compiler.declaration-body-plan-artifacts"
+                && dependency.stamp == artifact_stamp
+        }));
+        assert_eq!(
+            database
+                .declaration_body_plan_astgen_evaluations
+                .load(std::sync::atomic::Ordering::Relaxed),
+            2,
+            "main and const T each lower once; T.get adds no AstGen work",
+        );
+    }
+
+    #[test]
+    fn anonymous_member_preserves_its_producer_artifact_failure() {
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn Box() -> type { struct { fn get(self) -> i32 { 7 } } }",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let producer = crate::FunctionInstanceKey::Specialization {
+            base: Box::new(free_function_instance(&module, "Box")),
+            arguments: crate::CanonicalArguments::default(),
+        };
+        let crate::FunctionInstanceKey::Definition(definition) =
+            free_function_instance(&module, "Box")
+        else {
+            unreachable!()
+        };
+        let errors = crate::CompileErrors::from(crate::CompileError::without_span(
+            rue_error::ErrorKind::InvalidCompilerInput(
+                "injected anonymous producer artifact failure".into(),
+            ),
+        ));
+        let mut database = RevisionedQueryDatabase::default();
+        database.inject_declaration_body_plan_failure_for_test(&definition, errors.clone());
+        let revision = revision_for(&mut database, &source);
+        let produced = database.runtime.request_registered(
+            &database.body_produced_anonymous,
+            revision,
+            crate::body_query::BodyQueryKey::new(producer, semantic_configuration()),
+            CancellationToken::new(),
+        );
+        let terminal = produced.terminal().unwrap();
+        let rue_query::QueryOutcome::Success(crate::body_query::ProducedAnonymous::Produced(
+            produced,
+        )) = terminal.outcome()
+        else {
+            panic!("Box publishes its anonymous type before runtime body analysis")
+        };
+        let owner = produced
+            .0
+            .iter()
+            .find(|nominal| {
+                matches!(
+                    &nominal.shape,
+                    crate::durable_semantics::DurableAnonymousNominalShape::Struct {
+                        methods,
+                        ..
+                    } if methods.iter().any(|method| method.name.as_ref() == "get")
+                )
+            })
+            .expect("Box publishes get's owner");
+        let get = crate::body_query::BodyQueryKey::new(
+            crate::FunctionInstanceKey::AnonymousMember {
+                owner: Box::new(crate::TypeInstanceKey::Nominal(
+                    crate::NominalInstanceKey::Anonymous(owner.identity.clone()),
+                )),
+                member: crate::AnonymousMemberKey {
+                    kind: crate::AnonymousMemberKind::Method,
+                    name: Arc::from("get"),
+                },
+            },
+            semantic_configuration(),
+        );
+        let transaction = database
+            .body_transaction(revision, get, CancellationToken::new())
+            .expect("artifact failure publishes a deterministic anonymous transaction");
+        let rue_query::QueryOutcome::Success(
+            crate::body_query::BodyTransaction::DeterministicFailure {
+                errors: published, ..
+            },
+        ) = transaction.outcome()
+        else {
+            panic!("anonymous artifact failure was downgraded or canceled")
+        };
+        assert_eq!(published, &errors);
+    }
+
+    #[test]
+    fn anonymous_member_kind_mismatch_is_deterministic_not_cancellation() {
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn Box() -> type { struct { fn get(self) -> i32 { 7 } } }",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let producer = crate::FunctionInstanceKey::Specialization {
+            base: Box::new(free_function_instance(&module, "Box")),
+            arguments: crate::CanonicalArguments::default(),
+        };
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = revision_for(&mut database, &source);
+        let produced = database.runtime.request_registered(
+            &database.body_produced_anonymous,
+            revision,
+            crate::body_query::BodyQueryKey::new(producer, semantic_configuration()),
+            CancellationToken::new(),
+        );
+        let rue_query::QueryOutcome::Success(crate::body_query::ProducedAnonymous::Produced(
+            produced,
+        )) = produced.terminal().unwrap().outcome()
+        else {
+            panic!("Box publishes get's owner")
+        };
+        let owner = produced
+            .0
+            .first()
+            .expect("Box publishes one anonymous struct");
+        let mismatched = crate::body_query::BodyQueryKey::new(
+            crate::FunctionInstanceKey::AnonymousMember {
+                owner: Box::new(crate::TypeInstanceKey::Nominal(
+                    crate::NominalInstanceKey::Anonymous(owner.identity.clone()),
+                )),
+                member: crate::AnonymousMemberKey {
+                    kind: crate::AnonymousMemberKind::AssociatedFunction,
+                    name: Arc::from("get"),
+                },
+            },
+            semantic_configuration(),
+        );
+        let attempt = database.runtime.request_registered(
+            &database.body_transactions,
+            revision,
+            mismatched.clone(),
+            CancellationToken::new(),
+        );
+        assert!(attempt.abort().is_none());
+        let terminal = attempt
+            .terminal()
+            .expect("mismatched anonymous member publishes a stable failure");
+        assert!(matches!(
+            terminal.outcome(),
+            rue_query::QueryOutcome::Success(
+                crate::body_query::BodyTransaction::DeterministicFailure { .. }
+            )
+        ));
+        assert!(
+            database
+                .body_transactions
+                .contains_retained_key(&mismatched)
+        );
+    }
+
+    #[test]
+    fn anonymous_member_materialization_cancellation_publishes_nothing_and_retries() {
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn Box() -> type {\n\
+                     struct { fn get(self) -> i32 { let x = 7; x } }\n\
+                 }",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let producer = crate::FunctionInstanceKey::Specialization {
+            base: Box::new(free_function_instance(&module, "Box")),
+            arguments: crate::CanonicalArguments::default(),
+        };
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = revision_for(&mut database, &source);
+        let produced = database.runtime.request_registered(
+            &database.body_produced_anonymous,
+            revision,
+            crate::body_query::BodyQueryKey::new(producer, semantic_configuration()),
+            CancellationToken::new(),
+        );
+        let terminal = produced.terminal().unwrap();
+        let rue_query::QueryOutcome::Success(crate::body_query::ProducedAnonymous::Produced(
+            produced,
+        )) = terminal.outcome()
+        else {
+            panic!("Box publishes its anonymous get owner")
+        };
+        let owner = produced
+            .0
+            .iter()
+            .find(|nominal| {
+                matches!(
+                    &nominal.shape,
+                    crate::durable_semantics::DurableAnonymousNominalShape::Struct {
+                        methods,
+                        ..
+                    } if methods.iter().any(|method| method.name.as_ref() == "get")
+                )
+            })
+            .unwrap();
+        let get = crate::body_query::BodyQueryKey::new(
+            crate::FunctionInstanceKey::AnonymousMember {
+                owner: Box::new(crate::TypeInstanceKey::Nominal(
+                    crate::NominalInstanceKey::Anonymous(owner.identity.clone()),
+                )),
+                member: crate::AnonymousMemberKey {
+                    kind: crate::AnonymousMemberKind::Method,
+                    name: Arc::from("get"),
+                },
+            },
+            semantic_configuration(),
+        );
+        let candidate = declaration_candidate(
+            &database,
+            revision,
+            &module,
+            crate::declaration_candidate::DeclarationCandidateCategory::Function,
+            "Box",
+        );
+        database
+            .runtime
+            .request_registered(
+                &database.declaration_body_plan_artifacts,
+                revision,
+                DeclarationBodyPlanQueryKey(candidate),
+                CancellationToken::new(),
+            )
+            .into_result()
+            .expect("producer artifact is warm before transaction materialization");
+
+        {
+            let _injection = database.cancel_body_materialization_after_checkpoints_for_test(1);
+            let attempt = database.runtime.request_registered(
+                &database.body_transactions,
+                revision,
+                get.clone(),
+                CancellationToken::new(),
+            );
+            assert!(matches!(attempt.abort(), Some(QueryAbort::Canceled)));
+            assert!(attempt.terminal().is_none());
+            assert!(!database.body_transactions.contains_retained_key(&get));
+        }
+
+        let retry = database
+            .body_transaction(revision, get.clone(), CancellationToken::new())
+            .expect("uncanceled anonymous-member retry completes");
+        assert!(matches!(
+            retry.outcome(),
+            rue_query::QueryOutcome::Success(crate::body_query::BodyTransaction::Success { .. })
+        ));
+        assert!(database.body_transactions.contains_retained_key(&get));
     }
 
     #[test]
@@ -39659,7 +40265,7 @@ fn main() -> i32 {
                 1,
                 "/main.rue",
                 "main.rue",
-                "fn selected(comptime T: type) -> T { 7 }\n",
+                "fn selected(comptime T: type) -> T { 7 }\nstruct NotABody {}\n",
             )],
             1,
         );

--- a/crates/rue-compiler/src/semantic_query_nucleus.rs
+++ b/crates/rue-compiler/src/semantic_query_nucleus.rs
@@ -204,9 +204,9 @@ fn trailing_yield(body: &rue_parser::ast::Expr) -> Option<&rue_parser::ast::Yiel
     }
 }
 
-/// Normalize one owner's method facts into the form
-/// [`crate::declaration_candidate::RawAccessorSignatureSyntax`] retains:
-/// sorted by name, with every ambiguously duplicated name dropped.
+/// Normalize one owner's parsed method facts for canonical accessor
+/// declaration validation: sorted by name, with every ambiguously duplicated
+/// name dropped.
 ///
 /// A duplicate method is its own diagnostic, and 6.6:7 stays permissive
 /// wherever it cannot *prove* a callee is a plain method, so a name that two
@@ -226,33 +226,6 @@ pub(crate) fn owner_method_accessor_facts(
     facts.dedup_by(|left, right| left.name == right.name);
     facts.retain(|fact| !duplicated.contains(&fact.name));
     Arc::from(facts)
-}
-
-/// The method names one body calls on its own `self` receiver, normalized
-/// (sorted, deduplicated) — the 6.6:14 cycle-edge fact (RUE-1282), for a
-/// producer holding the parsed AST and its interner.
-pub(crate) fn ast_self_call_targets(
-    body: &rue_parser::ast::Expr,
-    interner: &crate::ThreadedRodeo,
-) -> Arc<[Arc<str>]> {
-    use rue_parser::ast::Expr;
-    let mut walk = vec![body];
-    let mut targets: Vec<Arc<str>> = Vec::new();
-    while let Some(expr) = walk.pop() {
-        if let Expr::MethodCall(call) = expr {
-            let mut receiver = &*call.receiver;
-            while let Expr::Paren(paren) = receiver {
-                receiver = &paren.inner;
-            }
-            if matches!(receiver, Expr::SelfExpr(_)) {
-                targets.push(Arc::from(interner.resolve(&call.method.name)));
-            }
-        }
-        expr.child_exprs(&mut walk);
-    }
-    targets.sort();
-    targets.dedup();
-    Arc::from(targets)
 }
 
 /// What one method-call link in a yielded projection chain is, as far as the

--- a/crates/rue-compiler/src/semantic_symbols.rs
+++ b/crates/rue-compiler/src/semantic_symbols.rs
@@ -60,10 +60,6 @@ pub struct SemanticSymbolUniverse {
 }
 
 impl SemanticSymbolUniverse {
-    pub(crate) fn into_interner(self) -> Arc<ThreadedRodeo> {
-        self.interner
-    }
-
     /// Start a destination universe for one canonical program traversal.
     #[cfg(test)]
     pub(crate) fn new(program: &ParsedProgram) -> Self {

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -11167,6 +11167,91 @@ fn main() -> i32 {
     }
 
     #[test]
+    fn sibling_only_edit_reuses_anonymous_member_transaction_cfg_and_codegen() {
+        let program = |sibling: &str| {
+            let text = format!(
+                "fn sibling() -> i32 {{ {sibling} }}\n\
+                 const T: type = struct {{\n\
+                     value: i32,\n\
+                     fn get(self) -> i32 {{ self.value }}\n\
+                 }};\n\
+                 fn main() -> i32 {{\n\
+                     let value: T = T {{ value: 5 }};\n\
+                     value.get()\n\
+                 }}"
+            );
+            snapshot(&[(1, "/p/main.rue", "main.rue", text.as_str())], 1)
+        };
+        let options = CompileOptions::default();
+        let configuration = crate::semantic_query_nucleus::SemanticQueryConfiguration {
+            target: options.target,
+            preview_features: StablePreviewFeatures::new(&options.preview_features),
+        };
+        let observe = |session: &mut CompilerSession| {
+            let semantic = session.rooted_cfg(&options).unwrap();
+            let get = semantic
+                .functions()
+                .iter()
+                .find_map(|function| {
+                    matches!(
+                        &function.function,
+                        crate::FunctionInstanceKey::AnonymousMember { member, .. }
+                            if member.name.as_ref() == "get"
+                    )
+                    .then(|| function.function.clone())
+                })
+                .expect("main reaches the anonymous T.get member");
+            let cfg_execution = session
+                .rooted_cfg_executions()
+                .iter()
+                .find_map(|(function, execution)| (function == &get).then_some(*execution))
+                .expect("rooted CFG records T.get's optimized-CFG request");
+            let transaction_stamp = retained_body_transaction(
+                session,
+                &crate::body_query::BodyQueryKey::new(get.clone(), configuration.clone()),
+            )
+            .0;
+            let units = session
+                .codegen_units(
+                    &semantic,
+                    &options,
+                    rue_codegen::BackendArtifactRequest::default(),
+                )
+                .unwrap();
+            let unit = units
+                .iter()
+                .find_map(|unit| (unit.function == get).then(|| unit.unit.clone()))
+                .expect("T.get publishes a codegen unit");
+            let codegen_execution = session
+                .codegen_executions()
+                .iter()
+                .find_map(|(function, execution)| (function == &get).then_some(*execution))
+                .expect("codegen records T.get's request");
+            (
+                get,
+                transaction_stamp,
+                cfg_execution,
+                codegen_execution,
+                unit,
+            )
+        };
+
+        let mut session = CompilerSession::new();
+        session.update(&program("1")).into_result().unwrap();
+        let first = observe(&mut session);
+        assert_eq!(first.2, rue_query::RequestExecution::Computed);
+        assert_eq!(first.3, rue_query::RequestExecution::Computed);
+
+        session.update(&program("123456")).into_result().unwrap();
+        let second = observe(&mut session);
+        assert_eq!(second.0, first.0);
+        assert_eq!(second.1, first.1);
+        assert_eq!(second.2, rue_query::RequestExecution::Reused);
+        assert_eq!(second.3, rue_query::RequestExecution::Reused);
+        assert!(Arc::ptr_eq(&first.4, &second.4));
+    }
+
+    #[test]
     fn cfg_keys_are_constructed_once_and_typed_equality_resolves_memo_hash_collisions() {
         fn hash(key: &crate::cfg_query::CfgQueryKey) -> u64 {
             let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -11232,11 +11317,25 @@ fn main() -> i32 {
     }
 
     #[test]
-    fn owned_codegen_domains_preserve_legacy_backend_bytes_on_both_architectures() {
+    fn owned_codegen_domains_preserve_named_and_anonymous_bytes_on_both_architectures() {
         let source = SourceSnapshot::single(
             "main.rue",
             "fn add(left: i32, right: i32) -> i32 { left + right }\n\
-             fn main() -> i32 { let message = \"owned\"; @dbg(message); add(20, 22) }",
+             fn Box() -> type {\n\
+                 struct {\n\
+                     value: i32,\n\
+                     fn make(value: i32) -> Self { Self { value: value } }\n\
+                     fn get(borrow self) -> i32 { self.value }\n\
+                     drop fn(self) {}\n\
+                 }\n\
+             }\n\
+             fn main() -> i32 {\n\
+                 let message = \"owned\";\n\
+                 @dbg(message);\n\
+                 let B = Box();\n\
+                 let boxed = B.make(add(20, 22));\n\
+                 boxed.get()\n\
+             }",
         )
         .unwrap();
         for target in [Target::X86_64Linux, Target::Aarch64Linux] {

--- a/docs/notes/adr-0071-phase-3-frontend-phase-integrity.md
+++ b/docs/notes/adr-0071-phase-3-frontend-phase-integrity.md
@@ -9,8 +9,8 @@ marked complete describe paths already removed by the bounded Phase 3 slices.
 | Re-entry | Production owner and consumers | Displaced work | Required deletion proof |
 | --- | --- | --- | --- |
 | Declaration signatures | `compiler.semantic-nucleus` owns a request-local projection from the exact canonical parsed declaration; specialization typing and call ABI consume its resolved signature, while cheap named-body classification uses parser-indexed shell facts | Deletes body-free source reconstruction, signature lexing/parsing, and the additive retained `compiler.declaration-signature-projection` family | Complete: no production call or definition of `parse_semantic_signature`, no raw-signature parser locator/materializer or peer query family, and a cold signature request performs no body AstGen work |
-| Runtime and specialized bodies | `lower_owned_body_input` in `revisioned_query_database.rs`; called by both the ordinary-definition and free-function-specialization arms of `BodyTransactionEvaluator` | Concatenates retained signature/body text, builds a synthetic snapshot, lexes, parses, lowers with `AstGen`, builds a body RIR index, and remaps synthetic spans for every body transaction and specialization | Both transaction arms consume the same candidate-keyed structured body plan; no production call or definition of `lower_owned_body_input`; specialization count does not increase parsing or AstGen lowering |
-| Anonymous members | `lower_anonymous_member_body_input` in `revisioned_query_database.rs`; called by the anonymous-member arm of `BodyTransactionEvaluator` | Rewrites destructor spelling, wraps the member in a fake named struct, lexes, parses, lowers, indexes, and remaps it | Anonymous-member transactions consume a producer-published structured member plan; no production call or definition of `lower_anonymous_member_body_input` |
+| Runtime and specialized bodies | `compiler.declaration-body-plan-artifacts` owns one packed candidate artifact; the ordinary-definition and free-function-specialization arms of `BodyTransactionEvaluator` consume it through the transient resolver | Deletes concatenated signature/body text, synthetic snapshots, body-local lex/parse/AstGen, synthetic span remapping, and specialization-multiplied frontend work | Complete: both transaction arms consume the same candidate-keyed structured body plan; no production call or definition of `lower_owned_body_input`; specialization count does not increase parsing or AstGen lowering |
+| Anonymous members | `compiler.declaration-body-plan-artifacts` owns the ultimate named/constant producer candidate; the anonymous-member arm recursively selects the exact nested declaration by producer chain, indexed owner anchor, name, and member kind | Deletes destructor spelling rewrites, fake named owners, synthetic source assembly, lex/parse/AstGen, and the second RIR remap/index path | Complete: no production call or definition of `lower_anonymous_member_body_input` or its explicit-anchor lowering seam; nested and constant-produced members directly observe the producer candidate artifact, and member demand adds no candidate AstGen work |
 | Comptime bodies | `parse_semantic_body` in `semantic_query_nucleus.rs`; called by the semantic-nucleus comptime-call evaluator | Wraps exact body text in a fake function, lexes and parses it, rediscovers imports, transports anonymous anchors, then evaluates the cloned AST | Comptime evaluation consumes the same declaration artifact as runtime analysis; no production call or definition of `parse_semantic_body` |
 | Constants | `parse_semantic_const` in `semantic_query_nucleus.rs`; called by the semantic-nucleus const evaluator | Reconstructs a fake const declaration, lexes and parses it, rediscovers imports, transports anonymous anchors, then evaluates the cloned AST | Constant evaluation consumes the declaration artifact directly; no production call or definition of `parse_semantic_const` |
 | Well-known option body scan | `PackedValidatedRir::fallible_intrinsics`; consumed by `compiler.body-toolchain-demands` through `DeclarationBodyPlanArtifacts` | Derives the typed five-kind set during the one canonical packed-RIR traversal; production performs no second lexer pass over retained body text | Complete: the packed header owns the stable typed set and the old lexical scanner remains only as an independent `cfg(test)` oracle |
@@ -43,10 +43,10 @@ publishes plan-materialization, base-symbol, instruction/payload, and index work
 separately. The next slice is the immutable-base/projected rue-air view that
 removes those remaining per-transaction remap, validation, index, and interner
 rebuilds. Candidate-local construction is independently demandable for indexed
-named declarations, but anonymous members retain their separately listed
-synthetic reparse route until their producer-published structured member plan
-lands. Accordingly this checkpoint still does **not** claim complete frontend
-phase integrity or acceptance items 3 and 12.
+named declarations, and anonymous members now reuse the ultimate producer
+candidate as described below. This checkpoint still does **not** claim complete
+frontend phase integrity or acceptance items 3 and 12 because the request-local
+AIR adapter and candidate-granularity sibling construction remain.
 
 The candidate producer still observes the module parse terminal. A sibling-only
 module revision therefore reevaluates AstGen once for each reached candidate,
@@ -55,6 +55,70 @@ equal; transactions, CFGs, and codegen remain green. Work is not
 multiplied by consumers or specializations, but eliminating this remaining
 producer reevaluation requires a finer parser-owned candidate input stamp and
 is deferred and measured separately.
+
+## Implementation checkpoint: anonymous-member frontend cutover
+
+Anonymous method, associated-function, and destructor transactions no longer
+retain or reconstruct method source. The producer's durable anonymous shape
+retains only the member signature plus a body-availability bit. At execution,
+the transaction requests the packed artifact of the named function, method, or
+constant that ultimately owns the producer chain, decodes that artifact once,
+and recursively locates the exact member declaration. Each hop is identified
+by its indexed structural owner anchor and exact member name/kind; method edges
+are never rediscovered by source position or a name-only scan.
+
+The selected declaration is passed directly to the existing provider-backed
+semantic analyzer. Its current RIR body span is converted to the producer
+body's relative coordinate before the transaction is retained, so a prefix or
+sibling relocation keeps the artifact and transaction stamps green while
+warning and diagnostic presentation uses the latest `FileId` and absolute
+origin. Internal member trivia remains part of the candidate-relative span
+basis and correctly dirties the artifact and transaction.
+
+The displaced route and its support code are deleted: no fake struct owner,
+synthetic `SourceSnapshot`, anonymous lexer/parser/AstGen, explicit anonymous
+anchor override, module-RIR rematerialization helper, or raw anonymous member
+body carrier remains in production. A nested member producer and a member of a
+constant-produced anonymous type both resolve back to the same ultimate
+candidate artifact. Materialization cancellation publishes no terminal and an
+uncanceled retry succeeds; malformed member kind and producer artifact failure
+publish deterministic typed failures rather than cancellation.
+
+This slice removes frontend work from the anonymous-member critical path but
+does not yet remove the one request-local packed decode, current-span
+projection, symbol reconstruction, RIR validation, and index build performed
+for each anonymous transaction. Those costs remain visible under the same AIR
+view deferral as ordinary and specialized bodies.
+
+### Isolated performance evidence
+
+The expected time effect is direct: each reached anonymous runtime member used
+to assemble a synthetic source snapshot and repeat lexing, parsing, AstGen, span
+remapping, validation, and index construction. The replacement selects the
+member from its already-demanded producer artifact. It still decodes the
+producer artifact for the request-local AIR adapter, but it removes the second
+frontend traversal from the one-worker critical path rather than merely moving
+retained ownership.
+
+On the frozen Lattice workload, a release thin-LTO x86-64 compiler was measured
+against its exact parent in six alternating one-worker pairs after one warmup
+per binary. All twelve native outputs were 1,413,120 bytes with SHA-256
+`b893e76cfabed737b149d0e8c4d8527077dedd17da78418db20a28a7d30885e5`.
+The absolute median compiler-root time fell from 746.141 ms to 673.888 ms
+(-72.253 ms, -9.68%); every paired prototype run was faster and the paired
+median delta was -43.513 ms. Median external peak RSS fell from 387,817,472 to
+374,939,648 bytes (-12,877,824 bytes, -12.28 MiB), while the benchmark's
+internal peak fell from 387,555,328 to 374,718,464 bytes. The paired median
+external RSS delta was -13,484,032 bytes.
+
+The phase counters support the intended cause. Median attributed body-input
+work fell from 32.486 ms to 10.980 ms: synthetic assembly (4.239 ms), lex/parse
+(16.700 ms), and body-local RIR lowering (9.395 ms) all fell to zero, leaving
+only the packed decode/current-coordinate projection. Query claims and memo
+nodes each fell by 2,731. The request-local decoded instruction count rose
+because an anonymous transaction now decodes its ultimate producer fragment;
+that remaining work is the explicitly deferred borrowed/projected AIR-view
+slice rather than a hidden frontend fallback.
 
 ## Retained declaration artifact contract
 
@@ -67,11 +131,13 @@ and safe to retain across source revisions. Equality is exact packed-byte
 equality and intentionally includes the candidate-relative diagnostic basis,
 so internal trivia that moves diagnostic endpoints dirties the artifact:
 
-- a canonical typed-logical packed RIR for exactly the selected declaration
-  body. Arena allocation order, orphan payload words, and replacement holes do
-  not enter durable identity. Constant initializers and anonymous member bodies use independently
-  demandable/retained subplans under the same schema; requesting one never
-  eagerly constructs its siblings;
+- a canonical typed-logical packed RIR for exactly the selected top-level or
+  named-member declaration candidate. Arena allocation order, orphan payload
+  words, and replacement holes do not enter durable identity. Constant
+  initializers use their own candidate artifacts; anonymous member bodies are
+  nested declarations selected from the artifact of their ultimate producer.
+  A member request never invokes a second AstGen pass, although candidate-local
+  construction still includes every nested declaration owned by that candidate;
 - an artifact-owned dense string table. RIR symbol indexes refer only to this
   table, never to a parser `Spur` or parser resolver;
 - dense structured type-syntax nodes referenced by declarations and


### PR DESCRIPTION
## What changed

Anonymous method, associated-function, and destructor transactions now consume the packed declaration artifact of their ultimate named or constant producer. The transaction recursively selects the exact nested declaration using the producer chain, indexed structural owner anchor, member name, and member kind.

This deletes the production anonymous-body fallback that reconstructed fake owners and source snapshots, then repeated lexing, parsing, AstGen, span remapping, validation, and indexing. Nested anonymous producers and constant-produced anonymous types use the same canonical artifact path, with typed failure and cancellation behavior preserved.

## Why this should be faster

Every reached anonymous runtime member previously repeated frontend work on the one-worker critical path. Reusing the already-demanded producer artifact removes that duplicate parse/lower path; the remaining request-local packed decode and AIR index construction stay explicitly measured for a later projected-view tranche.

Six alternating frozen-Lattice pairs against the exact parent confirm the expected effect:

- median compiler-root time: 746.141 ms → 673.888 ms (-72.253 ms, -9.68%);
- every prototype pair was faster; paired median delta -43.513 ms;
- median external peak RSS: 387,817,472 → 374,939,648 bytes (-12.28 MiB);
- query claims and memo nodes each fell by 2,731;
- all twelve outputs remained byte-identical: 1,413,120 bytes, SHA-256 `b893e76cfabed737b149d0e8c4d8527077dedd17da78418db20a28a7d30885e5`.

Median attributed body-input work fell from 32.486 ms to 10.980 ms. Synthetic assembly, lex/parse, and body-local RIR lowering all fell to zero; the remaining time is packed decode/current-coordinate projection.

## Validation

- `scripts/rue quick`: 31/31 targets; compiler 881 passed, 6 ignored
- focused anonymous artifact reuse, nested/constant producer, FileId relocation, internal-trivia invalidation, deterministic failure, and cancellation/retry tests
- sibling edit keeps the anonymous transaction, CFG, optimized CFG, and codegen stamps green
- x86-64 and AArch64 named/anonymous native output parity
- macOS `scripts/rue premerge`: all 159 selected prototype tests pass; the tier reports the same four pre-existing third-party mimalloc compatibility build failures as the exact parent

RUE-1510 remains open for the comptime-body, constant, structured type-syntax, and final hosted performance milestones.
