### PR TITLE
RUE-1514: prove the deleted signature parse, name the missing counter

### DIFF
--- a/.github/workflows/performance-collect.yml
+++ b/.github/workflows/performance-collect.yml
@@ -194,6 +194,33 @@ jobs:
                  "the reviewed fresh-process non-regression ratchet in performance/manifest.toml."
             exit 1
           fi
+          # RUE-1514. An appendable run that measured no complete workload
+          # publishes no headline point, so the series stops advancing exactly
+          # as it does on exit 3 — but every check reported success. Three
+          # platforms collected nothing for a day behind that green, and the
+          # first signal was the stall gate, which fires days later and fails
+          # every pull request in the repository rather than this job at the
+          # commit that broke it. The runner's own log lines above name the
+          # failing workloads and why each one failed.
+          if [ "$status" -eq 5 ]; then
+            echo "::error::the run is appendable but a workload did not complete validly," \
+                 "so no headline point enters this platform's series at this commit."
+            exit 1
+          fi
+          # Everything else nonzero, including a status no branch above names.
+          # The file records whatever the runner exited with, so without this a
+          # panic (101), a signal death, or an exit code added to the runner
+          # later falls straight through: the step succeeds, the job is green,
+          # and `publish` reports "no records were produced; nothing to publish"
+          # and succeeds too. That is RUE-1514's failure mode reached through a
+          # different door, and the same argument applies to it — a guard
+          # against a silent failure is worth nothing if failing past it is
+          # itself silent.
+          if [ "$status" -ne 0 ]; then
+            echo "::error::the runner exited with unhandled status $status;" \
+                 "no collection happened at this commit."
+            exit 1
+          fi
 
   # Runtime performance of compiled Rue programs (ADR-0072 Phase 1, RUE-1046).
   #
@@ -324,6 +351,14 @@ jobs:
           if [ "$status" -eq 5 ]; then
             echo "::error::the runtime report is appendable but a workload did" \
                  "not complete; the series has a hole at this commit."
+            exit 1
+          fi
+          # The same catch-all the compile-time leg above states its reasons
+          # for: the file holds whatever the runner exited with, and an
+          # unhandled status must not pass for a healthy collection.
+          if [ "$status" -ne 0 ]; then
+            echo "::error::the runtime runner exited with unhandled status" \
+                 "$status; no runtime collection happened at this commit."
             exit 1
           fi
 
@@ -462,6 +497,14 @@ jobs:
           if [ "$status" -eq 5 ]; then
             echo "::error::the runtime report is appendable but a workload did" \
                  "not complete; the series has a hole at this commit."
+            exit 1
+          fi
+          # The same catch-all the compile-time leg above states its reasons
+          # for: the file holds whatever the runner exited with, and an
+          # unhandled status must not pass for a healthy collection.
+          if [ "$status" -ne 0 ]; then
+            echo "::error::the runtime runner exited with unhandled status" \
+                 "$status; no runtime collection happened at this commit."
             exit 1
           fi
 

--- a/crates/rue-bench/src/main.rs
+++ b/crates/rue-bench/src/main.rs
@@ -57,6 +57,19 @@ mod exit {
     /// The run is valid and publishable, but crossed a reviewed performance
     /// ratchet. The raw evidence still belongs in its series.
     pub const REGRESSION: u8 = 4;
+    /// The run is appendable, but a workload did not complete validly.
+    ///
+    /// Distinct from every code above: nothing is wrong with the run object,
+    /// and the evidence belongs in the store. What is wrong is the series,
+    /// which now has a hole where a point should be, and in the all-workloads
+    /// case has no new point at all (RUE-1514).
+    ///
+    /// It exists because ADR-0067 §7's dashboard warning was not enough on its
+    /// own: an incomplete collection exited 0, the workflow went green, and the
+    /// repository-wide stall gate spoke up days later at commits that did not
+    /// cause it. `rue-bench runtime` already answers this question this way;
+    /// the two runners in one binary should not disagree about it.
+    pub const INCOMPLETE: u8 = 5;
 }
 
 struct Options {
@@ -611,13 +624,29 @@ fn run(options: &Options) -> Result<u8, String> {
 
     report(&run, &outcome, &regressions, &options.output);
 
-    Ok(if !outcome.is_appendable() {
+    Ok(collection_exit(&outcome, &regressions))
+}
+
+/// The status a written run object reports to its workflow.
+///
+/// Separate from the run's assembly because it is the whole interface between
+/// a collection and the human who finds out about it: every other signal this
+/// runner produces is a line in a log nobody reads unless something already
+/// told them to.
+///
+/// A regression outranks incompleteness: it is a judgement about the
+/// measurement that did happen, while incompleteness is about the one that did
+/// not, and the ratchet is the louder of the two.
+fn collection_exit(outcome: &ValidationOutcome, regressions: &[ProcessElapsedRegression]) -> u8 {
+    if !outcome.is_appendable() {
         exit::NOT_APPENDABLE
     } else if !regressions.is_empty() {
         exit::REGRESSION
+    } else if !outcome.completeness.publishes_headline() {
+        exit::INCOMPLETE
     } else {
         exit::OK
-    })
+    }
 }
 
 fn report(
@@ -633,6 +662,17 @@ fn report(
 
     for error in &outcome.errors {
         eprintln!("rue-bench: not appendable: {error}");
+    }
+    // Every recorded failure, in the job log rather than only inside the
+    // uploaded run object. A workload that produced no sample records exactly
+    // one of these and nothing else, so this line is the whole explanation of
+    // an empty collection — and reading it should not require downloading an
+    // artifact (RUE-1514).
+    for failure in &run.failures {
+        eprintln!(
+            "rue-bench: {} failure: {failure:?}",
+            failure.workload().unwrap_or("run-level")
+        );
     }
     for sample in &outcome.invalid_samples {
         eprintln!(
@@ -656,6 +696,12 @@ fn report(
                 "rue-bench: partial run; no headline point. Incomplete workloads: {}",
                 missing.join(", ")
             );
+            if run.workloads.is_empty() {
+                eprintln!(
+                    "rue-bench: no workload produced a sample, so this commit adds no point to \
+                     any series"
+                );
+            }
         }
     }
 }
@@ -885,5 +931,39 @@ window = 10
                 missing: vec!["startup".to_string()],
             }
         );
+    }
+
+    #[test]
+    fn an_incomplete_collection_reports_a_status_of_its_own() {
+        // RUE-1514. The run above is appendable and stored, and used to exit 0
+        // for that reason: a fail-closed sample check that was fail-open at the
+        // level of the series it protects. Three platforms published
+        // `workloads: []` for a day with every job green, and what eventually
+        // spoke up was the stall gate — days late, and against every pull
+        // request in the repository rather than this collection.
+        let manifest = Manifest::parse(FIXTURE_MANIFEST).expect("fixture manifest");
+
+        let complete = validate_run(&manifest, &fixture_run());
+        assert_eq!(collection_exit(&complete, &[]), exit::OK);
+
+        let mut empty = fixture_run();
+        empty.workloads.clear();
+        empty.failures.push(FailureRecord::WorkloadCrashed {
+            workload: "startup".to_string(),
+            sample_index: 0,
+            detail: "build-boundary evidence rejected".to_string(),
+        });
+        let outcome = validate_run(&manifest, &empty);
+        assert!(outcome.is_appendable(), "{:?}", outcome.errors);
+        assert_eq!(collection_exit(&outcome, &[]), exit::INCOMPLETE);
+
+        // A run that cannot be stored at all keeps saying so. Both codes fail
+        // the collection job, but they are different facts with different
+        // remedies, and the job's message says which one happened.
+        let mut rejected = fixture_run();
+        rejected.identity.pins.workload_source_hashes.clear();
+        let outcome = validate_run(&manifest, &rejected);
+        assert!(!outcome.is_appendable());
+        assert_eq!(collection_exit(&outcome, &[]), exit::NOT_APPENDABLE);
     }
 }

--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -572,9 +572,9 @@ fn render(report: &ScalingReport) -> String {
     }
 
     out.push_str("\n### Semantic leaf attribution\n\n");
-    out.push_str("Signature parsing is the nested aggregate across every semantic query consumer of an exact signature terminal; declaration nuclei are its primary owner, but specialized and body-input consumers may also contribute. Body input lowering and provider analysis are nested inside body analysis. These leaf intervals are explanatory and must not be added to their enclosing intervals.\n\n");
-    out.push_str("| workload / workers | signature parsing total/max ms | body input lowering total/max ms | provider analysis total/max ms |\n");
-    out.push_str("| --- | ---: | ---: | ---: |\n");
+    out.push_str("Body input lowering and provider analysis are nested inside body analysis. These leaf intervals are explanatory and must not be added to their enclosing intervals. Signature parsing had a column here until RUE-1510 projected signatures from the canonical parsed declaration; there is no signature parse left to time, so the column is gone rather than reporting a structural zero.\n\n");
+    out.push_str("| workload / workers | body input lowering total/max ms | provider analysis total/max ms |\n");
+    out.push_str("| --- | ---: | ---: |\n");
     for observation in &report.workloads {
         let evidence = observation.samples.iter().map(|sample| {
             sample
@@ -589,14 +589,11 @@ fn render(report: &ScalingReport) -> String {
                 summarize(evidence.clone().map(|value| select(&value).max_ns)),
             )
         };
-        let signature = pair(|value| &value.semantic_declaration_signature_parsing);
         let lowering = pair(|value| &value.semantic_body_input_lowering);
         let provider = pair(|value| &value.semantic_provider_analysis);
         out.push_str(&format!(
-            "| {} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} |\n",
+            "| {} | {:.2}/{:.2} | {:.2}/{:.2} |\n",
             observation_label(observation),
-            signature.0.median as f64 / 1_000_000.0,
-            signature.1.median as f64 / 1_000_000.0,
             lowering.0.median as f64 / 1_000_000.0,
             lowering.1.median as f64 / 1_000_000.0,
             provider.0.median as f64 / 1_000_000.0,

--- a/crates/rue-perf-schema/src/boundary.rs
+++ b/crates/rue-perf-schema/src/boundary.rs
@@ -390,6 +390,17 @@ pub struct CompilerCriticalPathEvidence {
     #[serde(default)]
     pub semantic_declaration_nuclei: DurationDistribution,
     /// Exact signature-fragment parsing across semantic query consumers.
+    ///
+    /// Permanently absent from a current producer. RUE-1510 replaced signature
+    /// source reconstruction and parser re-entry with a projection from the
+    /// canonical parsed declaration, so no span opens and this stays at its
+    /// default. Unlike the three deleted body-input intervals below, which are
+    /// still entered once per materialization and report zero nanoseconds, the
+    /// count itself is zero. The field is retained because immutable historical
+    /// records carry real values here and `deny_unknown_fields` would refuse
+    /// them without it, and
+    /// [`BuildBoundaryEvidence::validate_current_producer_against`] now proves
+    /// the deletion instead of the work.
     #[serde(default)]
     pub semantic_declaration_signature_parsing: DurationDistribution,
     /// Inclusive rooted body-closure query and immediate work reduction.
@@ -491,6 +502,99 @@ pub struct CompilerCriticalPathEvidence {
     pub declined_joins: u64,
     pub donated_permits: u64,
 }
+
+/// Semantic critical-path counters a current producer must actually report,
+/// each with the schema field name the rejection names.
+///
+/// A table rather than a chain of `||` so the check can say which entry failed.
+/// Every row is evidence that a phase ran at all; a row is removed only when
+/// the work it timed is deleted from the compiler, and then the deletion itself
+/// becomes the assertion rather than the row simply disappearing.
+type SemanticEvidenceRow = (
+    &'static str,
+    fn(&CompilerCriticalPathEvidence) -> &DurationDistribution,
+);
+
+const REQUIRED_SEMANTIC_EVIDENCE: [SemanticEvidenceRow; 26] = [
+    ("semantic_prerequisite_bodies", |critical| {
+        &critical.semantic_prerequisite_bodies
+    }),
+    ("semantic_declaration_graph", |critical| {
+        &critical.semantic_declaration_graph
+    }),
+    ("semantic_declaration_occurrence_indexes", |critical| {
+        &critical.semantic_declaration_occurrence_indexes
+    }),
+    ("semantic_declaration_nuclei", |critical| {
+        &critical.semantic_declaration_nuclei
+    }),
+    ("semantic_body_closure", |critical| {
+        &critical.semantic_body_closure
+    }),
+    ("semantic_body_graph_projection", |critical| {
+        &critical.semantic_body_graph_projection
+    }),
+    ("semantic_body_input_lowering", |critical| {
+        &critical.semantic_body_input_lowering
+    }),
+    ("semantic_body_input_attributed_total", |critical| {
+        &critical.semantic_body_input_attributed_total
+    }),
+    ("semantic_body_input_assembly_snapshot", |critical| {
+        &critical.semantic_body_input_assembly_snapshot
+    }),
+    ("semantic_body_input_lex_parse", |critical| {
+        &critical.semantic_body_input_lex_parse
+    }),
+    ("semantic_body_input_rir_lower", |critical| {
+        &critical.semantic_body_input_rir_lower
+    }),
+    ("semantic_body_input_span_remap_validation", |critical| {
+        &critical.semantic_body_input_span_remap_validation
+    }),
+    ("semantic_body_input_rir_index", |critical| {
+        &critical.semantic_body_input_rir_index
+    }),
+    ("semantic_provider_analysis", |critical| {
+        &critical.semantic_provider_analysis
+    }),
+    ("semantic_provider_host_setup", |critical| {
+        &critical.semantic_provider_host_setup
+    }),
+    ("semantic_provider_expression_engine", |critical| {
+        &critical.semantic_provider_expression_engine
+    }),
+    ("semantic_expression_setup", |critical| {
+        &critical.semantic_expression_setup
+    }),
+    ("semantic_inference_precompute", |critical| {
+        &critical.semantic_inference_precompute
+    }),
+    ("semantic_inference_precompute_structural", |critical| {
+        &critical.semantic_inference_precompute_structural
+    }),
+    ("semantic_inference_precompute_eval_provider", |critical| {
+        &critical.semantic_inference_precompute_eval_provider
+    }),
+    ("semantic_constraint_generation", |critical| {
+        &critical.semantic_constraint_generation
+    }),
+    ("semantic_unification_resolution", |critical| {
+        &critical.semantic_unification_resolution
+    }),
+    ("semantic_air_emission_validation", |critical| {
+        &critical.semantic_air_emission_validation
+    }),
+    ("semantic_provider_specialization_selection", |critical| {
+        &critical.semantic_provider_specialization_selection
+    }),
+    ("semantic_provider_body_export", |critical| {
+        &critical.semantic_provider_body_export
+    }),
+    ("semantic_provider_result_projection", |critical| {
+        &critical.semantic_provider_result_projection
+    }),
+];
 
 /// Complete evidence attached to one fresh compiler process.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -726,35 +830,37 @@ impl BuildBoundaryEvidence {
     ) -> Result<(), String> {
         self.validate_against(policy, target)?;
         let critical = &self.critical_path;
-        if critical.semantic_prerequisite_bodies.count == 0
-            || critical.semantic_declaration_graph.count == 0
-            || critical.semantic_declaration_occurrence_indexes.count == 0
-            || critical.semantic_declaration_nuclei.count == 0
-            || critical.semantic_declaration_signature_parsing.count == 0
-            || critical.semantic_body_closure.count == 0
-            || critical.semantic_body_graph_projection.count == 0
-            || critical.semantic_body_input_lowering.count == 0
-            || critical.semantic_body_input_attributed_total.count == 0
-            || critical.semantic_body_input_assembly_snapshot.count == 0
-            || critical.semantic_body_input_lex_parse.count == 0
-            || critical.semantic_body_input_rir_lower.count == 0
-            || critical.semantic_body_input_span_remap_validation.count == 0
-            || critical.semantic_body_input_rir_index.count == 0
-            || critical.semantic_provider_analysis.count == 0
-            || critical.semantic_provider_host_setup.count == 0
-            || critical.semantic_provider_expression_engine.count == 0
-            || critical.semantic_expression_setup.count == 0
-            || critical.semantic_inference_precompute.count == 0
-            || critical.semantic_inference_precompute_structural.count == 0
-            || critical.semantic_inference_precompute_eval_provider.count == 0
-            || critical.semantic_constraint_generation.count == 0
-            || critical.semantic_unification_resolution.count == 0
-            || critical.semantic_air_emission_validation.count == 0
-            || critical.semantic_provider_specialization_selection.count == 0
-            || critical.semantic_provider_body_export.count == 0
-            || critical.semantic_provider_result_projection.count == 0
-        {
-            return Err("compiler omitted semantic critical-path evidence".to_string());
+        // Named, not a boolean chain. One message for every counter says only
+        // that some evidence is absent, which is what a maintainer gets from CI
+        // when this fires; diagnosing RUE-1514 from it took reading this
+        // function and bisecting the published data branch to find which of the
+        // conditions had gone false.
+        let omitted = REQUIRED_SEMANTIC_EVIDENCE
+            .iter()
+            .filter(|(_, select)| select(critical).count == 0)
+            .map(|(name, _)| *name)
+            .collect::<Vec<_>>();
+        if !omitted.is_empty() {
+            return Err(format!(
+                "compiler omitted semantic critical-path evidence: {}",
+                omitted.join(", ")
+            ));
+        }
+        // The one counter deleted rather than omitted, held to the opposite
+        // rule. RUE-1510 replaced signature source reconstruction and parser
+        // re-entry with a projection from the canonical parsed declaration, so
+        // a current producer opens no such span. Requiring it to be non-zero
+        // rejected every process from that commit onward; simply dropping the
+        // entry would leave the boundary with nothing to say about a frontend
+        // path this variant no longer describes. Proving the deletion keeps
+        // the evidence fail-closed in the direction that is still falsifiable.
+        if critical.semantic_declaration_signature_parsing.count != 0 {
+            return Err(format!(
+                "semantic_declaration_signature_parsing reported {} invocations; RUE-1510 deleted \
+                 signature parsing, so a fresh_source_to_native_v1 process performing one is \
+                 running a frontend path this boundary variant does not describe",
+                critical.semantic_declaration_signature_parsing.count
+            ));
         }
         let lowering_counts = [
             critical.semantic_body_input_attributed_total.count,
@@ -961,7 +1067,8 @@ mod tests {
                 semantic_declaration_graph: distribution(),
                 semantic_declaration_occurrence_indexes: distribution(),
                 semantic_declaration_nuclei: distribution(),
-                semantic_declaration_signature_parsing: distribution(),
+                // Zero for a current producer: RUE-1510 deleted the span.
+                semantic_declaration_signature_parsing: DurationDistribution::default(),
                 semantic_body_closure: distribution(),
                 semantic_body_graph_projection: distribution(),
                 semantic_body_input_lowering: distribution(),
@@ -1285,6 +1392,72 @@ mod tests {
                 .unwrap_err(),
             "compiler provider-analysis attribution is incomplete"
         );
+    }
+
+    #[test]
+    fn omitted_semantic_evidence_names_the_missing_counters() {
+        // The rejection a maintainer reads out of CI has to point at the field.
+        // RUE-1514 was one message covering 27 conditions: every published run
+        // for a day said "compiler omitted semantic critical-path evidence" and
+        // nothing more, and finding which counter had gone to zero meant
+        // reading this predicate and bisecting the data branch.
+        let policy = BuildBoundaryPolicy::fresh_source_to_native_v1(WorkerSetting::One);
+
+        let mut one_missing = evidence();
+        one_missing.critical_path.semantic_declaration_nuclei = DurationDistribution::default();
+        assert_eq!(
+            one_missing
+                .validate_current_producer_against(&policy, "x86-64-linux")
+                .unwrap_err(),
+            "compiler omitted semantic critical-path evidence: semantic_declaration_nuclei"
+        );
+
+        // Every absent counter is named, not just the first: a producer that
+        // stopped reporting a whole phase should say so in one collection.
+        let mut several_missing = evidence();
+        several_missing.critical_path.semantic_declaration_graph = DurationDistribution::default();
+        several_missing
+            .critical_path
+            .semantic_unification_resolution = DurationDistribution::default();
+        assert_eq!(
+            several_missing
+                .validate_current_producer_against(&policy, "x86-64-linux")
+                .unwrap_err(),
+            "compiler omitted semantic critical-path evidence: semantic_declaration_graph, \
+             semantic_unification_resolution"
+        );
+
+        assert_eq!(REQUIRED_SEMANTIC_EVIDENCE.len(), 26);
+    }
+
+    #[test]
+    fn a_reappearing_signature_parse_fails_closed() {
+        // The inverse rule, and the reason the field is not simply dropped from
+        // the required set. RUE-1510 deleted signature source reconstruction
+        // and parser re-entry, so the current producer reports zero here — the
+        // fixture above. A process that reports one is doing frontend work this
+        // boundary variant does not describe, which is a reviewed schema event
+        // rather than a sample to admit quietly.
+        let policy = BuildBoundaryPolicy::fresh_source_to_native_v1(WorkerSetting::One);
+        evidence()
+            .validate_current_producer_against(&policy, "x86-64-linux")
+            .unwrap();
+
+        let mut reparsed = evidence();
+        reparsed
+            .critical_path
+            .semantic_declaration_signature_parsing = distribution();
+        let error = reparsed
+            .validate_current_producer_against(&policy, "x86-64-linux")
+            .unwrap_err();
+        assert!(
+            error.starts_with("semantic_declaration_signature_parsing reported 1 invocations"),
+            "{error}"
+        );
+
+        // Immutable historical records still carry real values here and must
+        // keep validating; only the current producer is held to the deletion.
+        reparsed.validate_against(&policy, "x86-64-linux").unwrap();
     }
 
     #[test]

--- a/docs/designs/0067-compiler-performance-measurement.md
+++ b/docs/designs/0067-compiler-performance-measurement.md
@@ -319,7 +319,16 @@ discarded. Publication is tiered:
 - a headline point is published only when every suite workload completed
   validly;
 - when the latest run is incomplete, the dashboard shows an explicit
-  collection-health warning naming the failing workloads.
+  collection-health warning naming the failing workloads;
+- an incomplete run also fails its own collection job, with its recorded
+  failures in that job's log. The dashboard warning is where collection health
+  is *read*; it is not what tells anyone to look. A refused run stores nothing
+  and an incomplete one still publishes each workload that completed, but
+  neither advances the headline series, and when no workload completes the two
+  are indistinguishable from outside. Until RUE-1514 the incomplete case did
+  that while every check reported success, leaving the repository-wide stall
+  gate above to notice days later, against pull requests that did not cause
+  it.
 
 Fixed headline membership is preserved without throwing away evidence, and a
 persistently broken workload is visible rather than an unexplained hole.

--- a/docs/process/compiler-scaling.md
+++ b/docs/process/compiler-scaling.md
@@ -73,9 +73,9 @@ independently verified native output digest. The report records:
 - dependency-ready item count, summed queue delay, and maximum queue delay;
 - longest query/dependency ancestry;
 - bounded request-wide declaration-graph, body-closure, and rooted-body-graph
-  projection histograms, with nested declaration-nucleus, exact-signature
-  parsing, semantic-prerequisite, body-input lowering, provider analysis,
-  semantic-analysis, CFG-construction, and CFG-optimization distributions;
+  projection histograms, with nested declaration-nucleus, semantic-prerequisite,
+  body-input lowering, provider analysis, semantic-analysis, CFG-construction,
+  and CFG-optimization distributions;
 - the inclusive reached-toolchain acquisition envelope (which contains the
   rooted semantic attempt), joins, declined joins, and permit donations;
 - output binary size.
@@ -106,12 +106,21 @@ declaration interval; body prerequisite and analysis timings are nested inside
 the closure interval. Nested values explain their owner and are never added to
 the enclosing duration.
 
-The semantic-leaf table further attributes exact signature-fragment parsing
-across its semantic query consumers (primarily declaration nuclei), and exact
-body-fragment lowering plus provider-backed analysis inside body analysis. This
-distinguishes repeated syntax preparation from the semantic engine without
-changing the canonical computation path. Because the signature aggregate may
-have more than one semantic parent, it is explanatory rather than additive.
+The semantic-leaf table further attributes exact body-fragment lowering plus
+provider-backed analysis inside body analysis. This separates the cost of
+materializing a body's request-local input from the semantic engine that then
+runs over it, without changing the canonical computation path. Since the
+canonical-plan cutover that lowering interval contains no syntax preparation:
+assembly/snapshot, lex/parse, and body-local RIR lowering are emitted as
+literal zeros, and what it measures is packed decode, current-span projection,
+temporary base-symbol reconstruction, and validation. Nested values explain
+their owner rather than adding to it.
+
+It attributed exact signature-fragment parsing as well until RUE-1510 projected
+signatures from the canonical parsed declaration. There is no signature parse
+left to time, so the column is gone rather than reporting a structural zero;
+the boundary evidence keeps the field and now proves the deletion, refusing a
+process that performs one.
 
 The provider-detail table then separates host setup, canonical expression
 analysis, specialization selection, durable body export, and final result

--- a/scripts/validate-release-configuration.py
+++ b/scripts/validate-release-configuration.py
@@ -31,6 +31,12 @@ COLLECTION_BOUNDARY_SNIPPETS = (
     'RUE="$(scripts/rue-bin --target-platforms //platforms:release)"',
     "--manifest performance/manifest.toml",
     'if [ "$status" -eq 4 ]',
+    # RUE-1514: the compile-time incomplete-collection branch. Pinned for the
+    # reason the ratchet branch above is — a guard against a silent failure is
+    # worth nothing if deleting it is itself silent — and pinned by the error
+    # text inside the branch rather than by its `-eq 5` test, which the two
+    # pre-existing runtime legs in this same file would satisfy on their own.
+    "no headline point enters this platform",
 )
 SCALING_BOUNDARY_SNIPPETS = (
     "schema_version = 3",


### PR DESCRIPTION
**The compile-time performance series has measured nothing on any platform since 2026-08-15T03:34Z**, with every collection workflow green throughout. This restores it.

## What broke

Every run published since trunk `7571c6f0` carries `workloads: []` and two failures:

```
build-boundary evidence rejected: compiler omitted semantic critical-path evidence
```

`crates/rue-perf-schema/src/boundary.rs` fail-closes unless all 27 semantic critical-path counters are non-zero. `7571c6f0` — RUE-1510, *project signatures from canonical declarations* — deliberately eliminated the `declaration_signature_parsing` pass, so that counter is permanently 0. The compiler change is correct and valuable (−1,597 parser invocations, −2.66% process time, −10.46 MiB RSS); **the predicate is what went stale.**

Measured on a real release compiler across 18 processes, of 38 distribution counters, `semantic_declaration_signature_parsing` is the **only** one at zero, and zero in every process.

## Inverted, not deleted

Deleting the row would leave 26 assertions and silence on the field. Instead a producer reporting **any** signature parse is now rejected by name: the liveness check becomes a deletion check, still fail-closed and still falsifiable. `main.rs` deliberately keeps mapping the pass name onto the field — **that mapping is now the detector**, and removing it would make the new assertion unfalsifiable.

This is a real trade rather than a free win. The old predicate could only be wrong by being over-strict about *missing* evidence; the inverted one can be wrong about *correct code*, if signature parsing is ever legitimately reintroduced. It also no longer proves that signature work happens at all, since `project_semantic_signature` carries no span. Restoring that liveness coverage is RUE-1515.

`validate_against` is untouched, so historical records still validate, and the field stays in the schema because `deny_unknown_fields` would otherwise refuse them.

## Two silent-failure holes closed

**The rejection now names the counter.** One message covered 27 conditions, so CI output said only that *something* was absent — diagnosing this took reading the predicate and bisecting the data branch.

**A collection that measures nothing is no longer green.** The runner rejected the evidence, published `workloads: []`, exited 0, and the workflow passed — a fail-closed check that was fail-open at the series level. Compile-time `rue-bench` now exits 5 (INCOMPLETE), matching what its own runtime mode already does, and the measure leg fails on it.

All three status steps also gained a catch-all: they tested exit 3, 4, and 5 and let everything else through, so a panic (101) or a signal death passed green with "nothing to publish". Verified across 0/3/4/5/6/101/137/255 — only 0 passes now.

`validate-release-configuration.py` pins the new branch by its unique error text rather than `-eq 5`, because two pre-existing runtime legs would have made an exit-code pin vacuous.

## Why the old tests didn't catch it

The pre-fix boundary test suite passes 7/7 against the broken predicate, because its fixture was a synthetic all-non-zero distribution modelling no real producer. The fixture is now `DurationDistribution::default()` — what the real producer actually emits for an absent pass.

Note that nothing on the pull-request path runs a real compile through this validator, which is why RUE-1510 merged green and broke collection only afterwards. Closing that needs a release ThinLTO compiler in premerge, which premerge deliberately does not build — left as a maintainer call.

Closes RUE-1514.