### PR TITLE
RUE-1503: derive the static passthrough from the committed tree

### DIFF
--- a/crates/rue-perf-schema/src/runtime.rs
+++ b/crates/rue-perf-schema/src/runtime.rs
@@ -3054,7 +3054,7 @@ samples = 5
         let epoch = manifest
             .collection_epoch("aarch64-linux")
             .expect("aarch64-linux is a row of the v1 platform matrix");
-        assert_eq!(epoch.suite_revision, 4);
+        assert_eq!(epoch.suite_revision, 5);
         assert_eq!(epoch.target, "aarch64-linux");
         assert_eq!(epoch.optimization, OptimizationLevel::O3);
         assert_eq!(epoch.thread_policy, ThreadPolicy::SingleThreaded);
@@ -3082,7 +3082,7 @@ samples = 5
         let epoch = manifest
             .collection_epoch("aarch64-macos")
             .expect("aarch64-macos is the scheduled row of the v1 platform matrix");
-        assert_eq!(epoch.suite_revision, 4);
+        assert_eq!(epoch.suite_revision, 5);
         assert_eq!(epoch.target, "aarch64-macos");
         assert_eq!(epoch.optimization, OptimizationLevel::O3);
         assert_eq!(epoch.thread_policy, ThreadPolicy::SingleThreaded);
@@ -4819,11 +4819,14 @@ records_comparison_identity = true
         // epoch 2's records carry revision 1 and no comparison identity,
         // because neither existed when they were written; epoch 3's carry
         // revision 2 and the identity its peer policy pins; epoch 4's carry
-        // revision 3, the corpus no longer lower-cased. All must be appendable,
-        // and all must publish, or one of these changes would have invalidated
-        // evidence nobody can rewrite.
+        // revision 3, the corpus no longer lower-cased; epoch 5's carry
+        // revision 4, the static passthrough now the committed tree. All must
+        // be appendable, and all must publish, or one of these changes would
+        // have invalidated evidence nobody can rewrite.
         let manifest = RuntimeManifest::parse(CHECKED_IN_MANIFEST).expect("checked-in manifest");
-        for (epoch, suite_revision, preparer_revision) in [(2, 2, 1), (3, 3, 2), (4, 4, 3)] {
+        for (epoch, suite_revision, preparer_revision) in
+            [(2, 2, 1), (3, 3, 2), (4, 4, 3), (5, 5, 4)]
+        {
             let report = shipped_report(epoch, suite_revision, preparer_revision);
             let outcome = validate_runtime_report(&manifest, &report);
             assert_eq!(
@@ -4848,7 +4851,7 @@ records_comparison_identity = true
         // the point someone reads a joined row and cannot say which peer pins
         // it names.
         let manifest = RuntimeManifest::parse(CHECKED_IN_MANIFEST).expect("checked-in manifest");
-        let mut report = shipped_report(4, 4, 3);
+        let mut report = shipped_report(5, 5, 4);
         for observation in &mut report.workloads {
             observation.comparison = None;
         }

--- a/performance/runtime.toml
+++ b/performance/runtime.toml
@@ -437,12 +437,111 @@ description = "the same corpus at ten copies, by deterministic path-prefixed dup
 kind = "semantic_site_pages"
 path = "scripts/gazette-corpus-diff.py"
 
+# ===========================================================================
+# SUITE REVISION 5 (RUE-1503) pins preparer revision 4: the static
+# passthrough is the committed tree.
+#
+# The workloads are revision 4's, and on a clean checkout the measured job is
+# byte-for-byte the same job. What changed is which files the preparer lets
+# into the fixture's static tree — and therefore what an observation RECORDS.
+# `website/build.sh` generates two files into `website/static`
+# (`status.json` and `performance-data.json`); the preparer excluded only the
+# latter, by name, so a machine where the website had ever been built
+# recorded a different `static_digest`, and a different fixture identity,
+# than a clean checkout. Fixture identity is supposed to be a property of the
+# corpus, not of the working tree's build history. Worse than the spurious
+# segment: two of `status.json`'s rows are derived from the performance
+# store, so the benchmark's own published output could flow back into the
+# recorded identity of the workload that produces it — the same loop
+# Decision 3 carves the dashboard pages out of the corpus to prevent.
+#
+# The preparer now excludes everything git ignores under `website/static`,
+# so the registry of "generated, never committed" lives in the `.gitignore`
+# entries that already must exist for build output, instead of in a second
+# hand-maintained list — which is how `status.json` got in.
+#
+# REVISIONS 1 THROUGH 4 STAY DECLARED, and so do the epochs that implement
+# them. Records already in the store name their suite revision and their
+# epoch, and a manifest that forgot either could not validate them.
+# ===========================================================================
+[[suite]]
+revision = 5
+protocol_version = 1
+measured_boundary = "spawn_to_exit_v1"
+
+# Unchanged from revision 4, and untouched by the passthrough change: this
+# workload's fixture is a seeded generator, not the corpus tree.
+[[suite.workloads]]
+id = "wordfreq"
+source = "examples/wordfreq/main.rue"
+question = "How fast does a compiled Rue program tokenize and count words in tens of MiB of text?"
+program_args = ["{fixture}"]
+
+[suite.workloads.fixture]
+kind = "seeded_generator"
+category = "recorded"
+generator = "zipf_ascii_text"
+generator_revision = 1
+seed = 20260813
+bytes = 33554432
+vocabulary_size = 65536
+file_name = "wordfreq-input.txt"
+description = "32 MiB of deterministic ASCII word text with Zipf-distributed word ranks"
+
+[suite.workloads.oracle]
+kind = "golden_stdout"
+path = "performance/fixtures/wordfreq/expected-stdout.txt"
+
+[[suite.workloads]]
+id = "gazette"
+source = "examples/gazette/main.rue"
+question = "How fast does a compiled Rue program build the real rue-lang.dev site, against the production tools that build sites for a living?"
+program_args = ["build", "{fixture}", "-o", "{output}"]
+
+[suite.workloads.fixture]
+kind = "corpus_tree"
+category = "recorded"
+preparer = "scripts/gazette-corpus-diff.py"
+preparer_revision = 4
+scale = 1
+excluded = ["performance.md", "runtime.md"]
+root_name = "gazette-site"
+description = "the live rue-lang.dev content plus the copied specification, as website/build.sh assembles it, minus the two pages whose templates read derived benchmark data"
+
+[suite.workloads.oracle]
+kind = "semantic_site_pages"
+path = "scripts/gazette-corpus-diff.py"
+
+# The 10x rung, unchanged from revision 4 but for the preparer pin. The two
+# honesty notes revision 2 records about this axis — it is a page-count curve,
+# and the specification sidebar collapses on a duplicated page — apply here
+# exactly as they did there.
+[[suite.workloads]]
+id = "gazette_10x"
+source = "examples/gazette/main.rue"
+question = "How does a compiled Rue site build scale with page count, at ten copies of the corpus?"
+program_args = ["build", "{fixture}", "-o", "{output}"]
+
+[suite.workloads.fixture]
+kind = "corpus_tree"
+category = "recorded"
+preparer = "scripts/gazette-corpus-diff.py"
+preparer_revision = 4
+scale = 10
+excluded = ["performance.md", "runtime.md"]
+root_name = "gazette-site-10x"
+description = "the same corpus at ten copies, by deterministic path-prefixed duplication"
+
+[suite.workloads.oracle]
+kind = "semantic_site_pages"
+path = "scripts/gazette-corpus-diff.py"
+
 # The pinned reference regime. Epoch 1 implements suite revision 1, epoch 2
-# revision 2, epoch 3 revision 3, and epoch 4 revision 4; only the last
-# collects. Declaring a new epoch rather than moving an old one to the new
-# revision is what keeps every record already in the store valid: a stored
-# report names the epoch it ran under, and that epoch must go on describing the
-# run it describes.
+# revision 2, epoch 3 revision 3, epoch 4 revision 4, and epoch 5 revision 5;
+# only the last collects. Declaring a new epoch rather than moving an old one
+# to the new revision is what keeps every record already in the store valid: a
+# stored report names the epoch it ran under, and that epoch must go on
+# describing the run it describes.
 #
 # The `local` rows are numbered in one sequence with these but declared at the
 # end of the file, one per target for the revision that collects (RUE-1498).
@@ -1082,7 +1181,8 @@ compiler_args = ["-O3"]
 optimization = "o3"
 thread_policy = "single_threaded"
 hardware_counters = "unavailable_on_hosted_runner"
-collection = true
+# Superseded by epoch 5, which implements suite revision 5.
+collection = false
 
 [epoch.environment]
 runner_label = "github-hosted"
@@ -1132,7 +1232,8 @@ compiler_args = ["-O3"]
 optimization = "o3"
 thread_policy = "single_threaded"
 hardware_counters = "unavailable_on_hosted_runner"
-collection = true
+# Superseded by epoch 5, which implements suite revision 5.
+collection = false
 
 [epoch.environment]
 runner_label = "github-hosted"
@@ -1174,7 +1275,8 @@ compiler_args = ["-O3"]
 optimization = "o3"
 thread_policy = "single_threaded"
 hardware_counters = "unavailable_on_hosted_runner"
-collection = true
+# Superseded by epoch 5, which implements suite revision 5.
+collection = false
 
 [epoch.environment]
 runner_label = "github-hosted"
@@ -1209,7 +1311,163 @@ canary_scale = 10
 records_comparison_identity = true
 
 # ===========================================================================
-# THE LOCAL ROWS, ONE PER TARGET (RUE-1498, extended by RUE-1496).
+# EPOCH 5: suite revision 5, the epoch that collects (RUE-1503).
+#
+# Everything about how these platforms run the workload is epoch 4's — same
+# runners, same sampling policies, same thread parity, same canary, same
+# `records_comparison_identity`. The epoch is new only because the suite
+# revision it implements is new: revision 5 pins preparer revision 4, and an
+# epoch names exactly one revision.
+#
+# THE STORE IS APPEND-ONLY, so epoch 4's records stay valid, keep publishing,
+# and keep joining under the conditions they were collected: preparer
+# revision 3, and a static passthrough that carried whatever gitignored build
+# output the working tree happened to hold. What they must not do is share a
+# segment with revision 5's, and the workload identity's move is what keeps
+# them apart. This is the mechanism that retired epoch 3 in RUE-1496, used
+# again for the same reason.
+#
+# The local rows that reproduce these three are epochs 9, 10, and 11, at the
+# end of the file with the rest of them.
+# ===========================================================================
+
+[[epoch]]
+id = 5
+platform = "x86_64-linux"
+suite_revision = 5
+target = "x86-64-linux"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = true
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+# Unchanged from epoch 4: five samples of each per-push workload, three at 10x.
+# No `[epoch.calibration]` and no `[epoch.flagging]` either — calibration is a
+# property of a workload on a platform and is never inherited, not from the
+# compiler suites and not from this platform's own earlier epoch, so gazette
+# arrives advisory here exactly as it did there.
+[epoch.sampling.wordfreq]
+samples = 5
+
+[epoch.sampling.gazette]
+samples = 5
+
+[epoch.sampling.gazette_10x]
+samples = 3
+
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+# The declaration that makes the comparison identity mandatory here. Every
+# observation of this workload must record which peer ports and which peer
+# versions its peer legs were configured by — including a canary-only one,
+# which measures a single tool and must still say what the others were pinned
+# at, or a bump whose full leg never succeeded leaves no trace in the data.
+records_comparison_identity = true
+
+[epoch.peers.gazette_10x]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 10
+records_comparison_identity = true
+
+[[epoch]]
+id = 5
+platform = "aarch64-linux"
+suite_revision = 5
+target = "aarch64-linux"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = true
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+# The runner is `ubuntu-24.04-arm`; the image it reports is `ubuntu-24.04`,
+# which is how ADR-0067's aarch64-linux epochs already record this regime.
+[epoch.sampling.wordfreq]
+samples = 5
+
+[epoch.sampling.gazette]
+samples = 5
+
+[epoch.sampling.gazette_10x]
+samples = 3
+
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+records_comparison_identity = true
+
+[epoch.peers.gazette_10x]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 10
+records_comparison_identity = true
+
+[[epoch]]
+id = 5
+platform = "aarch64-macos"
+suite_revision = 5
+target = "aarch64-macos"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = true
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "macos-15"
+
+# Nine, as in epoch 4, and for the same reason: this row is off the per-push
+# path, has no calibration of its own, and a larger n per observation makes the
+# dispersion estimate that calibration will be built from converge sooner.
+[epoch.sampling.wordfreq]
+samples = 9
+
+[epoch.sampling.gazette]
+samples = 9
+
+[epoch.sampling.gazette_10x]
+samples = 3
+
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+records_comparison_identity = true
+
+[epoch.peers.gazette_10x]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 10
+records_comparison_identity = true
+
+# ===========================================================================
+# THE LOCAL ROWS, ONE PER TARGET (RUE-1498, extended by RUE-1496 and RUE-1503).
 #
 # `local` is not a platform Rue targets. It is the pseudo-platform a
 # maintainer's own machine runs under, and a local run builds for its epoch's
@@ -1231,22 +1489,26 @@ records_comparison_identity = true
 #     epoch 6   x86-64-linux    suite revision 4
 #     epoch 7   aarch64-macos   suite revision 4
 #     epoch 8   aarch64-linux   suite revision 4
+#     epoch 9   x86-64-linux    suite revision 5
+#     epoch 10  aarch64-macos   suite revision 5
+#     epoch 11  aarch64-linux   suite revision 5
 #
-#     rue-bench runtime --platform local --epoch 7 \
+#     rue-bench runtime --platform local --epoch 10 \
 #       --compiler "$(scripts/rue-bin)" --commit "$(git rev-parse HEAD)" \
 #       --out /tmp/runtime.json --workdir /tmp/runtime-work
 #
 # THE RULE IS "PER TARGET, FOR THE REVISION THAT COLLECTS", not a list of ids,
-# and RUE-1496 is the first change to exercise it. That change advanced the
-# preparer to revision 3 and the suite to revision 4, and
+# and RUE-1496 was the first change to exercise it. Each preparer bump retires
+# the previous revision's local rows along with its reference rows:
 # `crates/rue-bench/src/runtime.rs` refuses fixture preparation when the
 # checked-in preparer's revision differs from the pin its epoch's suite carries
-# — so epochs 4 and 5 above, which pin revision 3, can no longer prepare the
-# gazette workloads at all. They stay declared, because records in the store
-# name them and revision 3 is still readable, and epochs 6 through 8 are what a
-# maintainer runs today. `every_collected_platform_has_a_local_reproduction_epoch`
-# is what turned that from a thing to remember into a build break: it fired on
-# all three collecting rows the moment revision 4 arrived.
+# — so epochs 4 through 8 above, which pin revisions 3 and 4, can no longer
+# prepare the gazette workloads at all. They stay declared, because records in
+# the store name them and those revisions are still readable, and epochs 9
+# through 11 are what a maintainer runs today.
+# `every_collected_platform_has_a_local_reproduction_epoch` is what turns that
+# from a thing to remember into a build break: it fires on all three collecting
+# rows the moment a new revision arrives.
 #
 # Suite revisions 1 through 3 keep only the local epochs they already had.
 # Nothing collects them, and a local path for a contract nothing collects would
@@ -1361,9 +1623,9 @@ canary_scale = 10
 records_comparison_identity = true
 
 # The revision-4 rows (RUE-1496), one per collecting target. Same three
-# targets, same policies, one suite revision later — and they are what a
-# maintainer selects today, because the preparer revision suite 4 pins is the
-# one the checked-in script implements.
+# targets, same policies, one suite revision later. Retired by revision 5 for
+# the same reason revision 3's rows were retired by these: the preparer
+# revision suite 4 pins is no longer the one the checked-in script implements.
 
 # x86-64 Linux at revision 4, the counterpart of epoch 3.
 [[epoch]]
@@ -1453,6 +1715,136 @@ records_comparison_identity = true
 id = 8
 platform = "local"
 suite_revision = 4
+target = "aarch64-linux"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = false
+
+[epoch.environment]
+runner_label = "local"
+runner_image = "local"
+
+[epoch.sampling.wordfreq]
+samples = 2
+
+[epoch.sampling.gazette]
+samples = 2
+
+[epoch.sampling.gazette_10x]
+samples = 2
+
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+records_comparison_identity = true
+
+[epoch.peers.gazette_10x]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 10
+records_comparison_identity = true
+
+# The revision-5 rows (RUE-1503), one per collecting target — what a
+# maintainer selects today, because the preparer revision suite 5 pins is the
+# one the checked-in script implements. As with every earlier extension, they
+# are copied from their revision-4 counterparts and differ from them in
+# `suite_revision` alone.
+
+# x86-64 Linux at revision 5, the counterpart of epoch 6.
+[[epoch]]
+id = 9
+platform = "local"
+suite_revision = 5
+target = "x86-64-linux"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = false
+
+[epoch.environment]
+runner_label = "local"
+runner_image = "local"
+
+[epoch.sampling.wordfreq]
+samples = 2
+
+[epoch.sampling.gazette]
+samples = 2
+
+[epoch.sampling.gazette_10x]
+samples = 2
+
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+records_comparison_identity = true
+
+[epoch.peers.gazette_10x]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 10
+records_comparison_identity = true
+
+# Apple Silicon at revision 5, the counterpart of epoch 7 and the row this
+# project's maintainers actually run.
+[[epoch]]
+id = 10
+platform = "local"
+suite_revision = 5
+target = "aarch64-macos"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = false
+
+[epoch.environment]
+runner_label = "local"
+runner_image = "local"
+
+[epoch.sampling.wordfreq]
+samples = 2
+
+[epoch.sampling.gazette]
+samples = 2
+
+[epoch.sampling.gazette_10x]
+samples = 2
+
+[epoch.peers.gazette]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 1
+records_comparison_identity = true
+
+[epoch.peers.gazette_10x]
+tools = ["zola", "hugo"]
+primary_thread_policy = "pinned_single_thread"
+secondary_thread_policy = "tool_default_parallel"
+canary_tool = "zola"
+canary_scale = 10
+records_comparison_identity = true
+
+# arm64 Linux at revision 5, the counterpart of epoch 8.
+[[epoch]]
+id = 11
+platform = "local"
+suite_revision = 5
 target = "aarch64-linux"
 compiler_args = ["-O3"]
 optimization = "o3"

--- a/scripts/gazette-corpus-diff.py
+++ b/scripts/gazette-corpus-diff.py
@@ -164,7 +164,18 @@ GAZETTE_PORT_REVISION = 2
 # slightly, and the WORKLOAD identity has to move for it. That is the correct
 # outcome rather than a cost: a new comparable segment is exactly what a change
 # to what every tool consumes should open.
-PREPARER_REVISION = 3
+#
+# REVISION 4 (RUE-1503) derives the static passthrough from the committed
+# tree: every file git ignores under `website/static` is excluded from both
+# the copy and the digest. Until now the exclusion was one hardcoded name,
+# and `website/build.sh` generates TWO files there — `status.json` slipped
+# through, so a machine that had ever built the website recorded a different
+# `static_digest` than a clean checkout. The identity is supposed to be a
+# property of the corpus, not of the working tree's build history. Worse, two
+# of `status.json`'s rows are derived from the performance store, which is
+# the same benchmark-feeds-itself loop the `performance-data.json` exclusion
+# and ADR-0072 Decision 3's page carve-outs exist to prevent.
+PREPARER_REVISION = 4
 
 # What gazette itself renders. Inside the workload identity. The peers' roots
 # are `peer_ports.PEER_PORT_ROOTS`, deliberately in the other file.
@@ -250,9 +261,18 @@ def corpus_rules() -> peer_ports.CorpusRules:
 #   beside it in `gazette_peer_ports.py`: both peer configurations lost the same
 #   stale comment, and neither peer's rendering changed. What did change is an
 #   assembly rule, which PREPARER_REVISION records.
+#
+#   RUE-1503. `runtime.html` a fifth time, and the fifth identical conclusion:
+#   an excluded page's template, no port follows. It moved because the
+#   disclosure now says the static passthrough is the committed tree — the
+#   site build derives `status.json` and `performance-data.json` into
+#   `website/static`, and only the latter was excluded, so the recorded
+#   identity depended on whether the website was ever built. No port's bytes
+#   moved. What did change is an assembly rule, which PREPARER_REVISION
+#   records.
 PRODUCTION_TEMPLATE_ROOT = "website/templates"
 PRODUCTION_TEMPLATE_DIGEST = (
-    "be481eb70d83cbd0a5443027f22005ddf476dd375f1b658c9e2635db68350d9c"
+    "12e9ab194652e71ff147598103aed456d63206e2a8ca53d8461aad6b145fff9d"
 )
 
 # Pages Zola emits no rendered body for, so `body` mode has nothing to compare
@@ -1010,6 +1030,56 @@ def duplicate_corpus(content: str, scale: int) -> None:
         shutil.rmtree(original, ignore_errors=True)
 
 
+def static_passthrough_files(static_source: str) -> list[str]:
+    """The static files a fixture carries: the tree minus git-ignored output.
+
+    `website/build.sh` generates derived files INTO `website/static`
+    (`status.json`, `performance-data.json`), so what that directory contains
+    depends on whether the site was ever built in this working tree — and the
+    fixture identity must not (RUE-1503). The registry of "generated, never
+    committed" is the `.gitignore` entries that already have to exist for that
+    output, so the exclusion is derived from git rather than from a second
+    hand-maintained name list here, which is how `status.json` got past the
+    `performance-data.json` entry.
+
+    Refusal was considered and rejected for the ignored class: refusing would
+    make the preparer unrunnable on any machine that ever ran `build.sh`,
+    for files the repository has already declared to be build output. An
+    untracked file that is NOT ignored still rides along, exactly like an
+    uncommitted content edit: the digest moves and the record says so.
+
+    No git, no answer: without the ignore rules there is no way to tell site
+    content from build output, and preparing a fixture whose identity depends
+    on the working tree's build history is the defect this function exists to
+    prevent, so that case refuses rather than degrades.
+    """
+    try:
+        listing = subprocess.run(
+            ["git", "-C", REPO, "ls-files", "--others", "--ignored",
+             "--exclude-standard", "-z", "--", "website/static"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except OSError as error:
+        raise SystemExit(
+            "gazette-corpus-diff: cannot run git to list ignored files under "
+            "website/static (%s); without the ignore rules, site content "
+            "cannot be told apart from generated build output, and a fixture "
+            "identity that depends on whether the website was ever built is "
+            "the defect this check prevents (RUE-1503)" % error)
+    if listing.returncode != 0:
+        raise SystemExit(
+            "gazette-corpus-diff: cannot list git-ignored files under "
+            "website/static (git exited %d: %s); without the ignore rules, "
+            "site content cannot be told apart from generated build output, "
+            "and a fixture identity that depends on whether the website was "
+            "ever built is the defect this check prevents (RUE-1503)"
+            % (listing.returncode, listing.stderr.decode("utf-8", "replace").strip()))
+    prefix = "website/static/"
+    ignored = {entry[len(prefix):] for entry in
+               listing.stdout.decode("utf-8").split("\0")
+               if entry.startswith(prefix)}
+    return [rel for rel in walk_files(static_source) if rel not in ignored]
+
+
 def prepare_fixture(root: str, scale: int) -> dict:
     """Assemble a complete gazette site and record its input identity.
 
@@ -1037,15 +1107,18 @@ def prepare_fixture(root: str, scale: int) -> dict:
     shutil.copy(os.path.join(REPO, "examples", "gazette", "config.toml"),
                 os.path.join(root, "config.toml"))
 
+    # ONE list drives both the digest and the copy, so the fixture cannot
+    # carry a file the recorded identity does not cover — the split where a
+    # hardcoded exclusion in one of two call sites could quietly disagree
+    # with the other.
     static_source = os.path.join(REPO, "website", "static")
-    static_files = [rel for rel in walk_files(static_source)
-                    # Derived at site-build time and never committed; including
-                    # it would make the fixture identity move with every
-                    # collection run rather than with the site.
-                    if rel != "performance-data.json"]
+    static_files = static_passthrough_files(static_source)
     static_digest, static_count, static_bytes = tree_digest(static_source, static_files)
-    shutil.copytree(static_source, os.path.join(root, "static"),
-                    ignore=shutil.ignore_patterns("performance-data.json"))
+    os.makedirs(os.path.join(root, "static"), exist_ok=True)
+    for rel in static_files:
+        dest = os.path.join(root, "static", rel.replace("/", os.sep))
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        shutil.copy2(os.path.join(static_source, rel), dest)
 
     port_digest, port_files, port_bytes = port_identity(GAZETTE_PORT_ROOTS)
 

--- a/website/templates/runtime.html
+++ b/website/templates/runtime.html
@@ -281,6 +281,12 @@
           names were lower-cased here until gazette learned to slugify a content
           path, and all three tools now route them where the live site does,
           from the names the repository actually carries.
+          The static passthrough is the <em>committed</em> static tree: the
+          site build derives two files into it — the home page's status board
+          and the performance dashboard's data — and the preparer excludes
+          everything git ignores there, because the input must not vary with
+          whether the website was ever built, and the benchmark's own published
+          output must never ride back in as its input.
         </p>
         <p>
           <strong>This compares a corpus-specialized Rue program against


### PR DESCRIPTION
Fixes RUE-1503.

## The defect

The corpus preparer copied `website/static` wholesale into the fixture and digested it, excluding exactly one file by name: `performance-data.json`. But `website/build.sh` generates **two** files into that directory, and `status.json` slipped through — so a clean checkout recorded 34 static files while a machine that had ever built the website recorded 35, a different `static_digest`, and therefore a different `fixture_digest`. That is how the RUE-1496 implementer and reviewer reported different corpus file counts (130 vs 131) for the same change.

Worse than the spurious segment: two of `status.json`'s rows are derived from the performance store, so the benchmark's own published output could flow back into the recorded identity of the workload that produces it — the same loop ADR-0072 Decision 3 carves the dashboard pages out of the corpus to prevent, one level down.

## The fix

The preparer now excludes **everything git reports as ignored** under `website/static`, from the digest and the copy alike, with one list driving both so the fixture cannot carry a file the identity does not cover. The registry of "generated, never committed" therefore lives in the `.gitignore` entries that already must exist for build output, instead of in a second hand-maintained list — which is how `status.json` got past the `performance-data.json` entry. This also covers the whole class the issue asks about, `static/spec/` included, not just the named instance.

On the issue's third scope bullet (refuse vs. exclude): refusing **ignored** files was considered and rejected — it would make the preparer unrunnable on any machine that ever ran `build.sh`, for files the repository has already declared to be build output. An untracked file that is *not* ignored still rides along, exactly like an uncommitted content edit: the digest moves and the record says so. With git unavailable there is no way to tell content from build output, so that case refuses loudly rather than degrades.

## Identity consequences

Fixture identity moves (the correct outcome — it was wrong), as its own revision so the segment break means one thing:

- `PREPARER_REVISION` advances to 4; suite revision 5 pins it; epoch 5 collects on each platform while epoch 4 is retired with the store's append-only discipline; local epochs 9–11 join at revision 5 per RUE-1498's rule.
- The runtime page's disclosure now states the static passthrough is the committed tree, which moves the pinned production-template digest; no port follows an excluded page's template, so no port revision advances (fifth entry in the ledger).

## Evidence

- With `status.json`, `performance-data.json`, and a generated `spec/` directory present under `website/static`, `prepare` mode records the **identical** 34-file `static_digest` and `fixture_digest` as a clean checkout, and none of the generated files reach the fixture tree.
- With git unavailable, the preparer refuses with a message naming the reason.
- `rue-perf-schema` (222) and `rue-bench` (151) unit tests pass, including the checked-in manifest assertions and `every_collected_platform_has_a_local_reproduction_epoch`; `scripts/rue quick` passes; python-baseline and formatting clean. Gazette goldens and the spec/CLI suites ride CI, which builds the fixture through this preparer.