### PR TITLE
RUE-1510: fuse warning references into parser projections

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -276,32 +276,66 @@ fn source_between_exact_boundaries<'a>(source: &'a str, start: &str, next: &str)
 
 #[test]
 fn warning_body_projection_stays_parse_only_and_below_rir_body_analysis() {
-    let runtime = include_str!("revisioned_query_database.rs");
+    let parsed = include_str!("parsed_modules.rs");
     let projector = source_between_exact_boundaries(
-        runtime,
-        "fn warning_static_call_heads(",
-        "\nstruct WarningStaticCallCollector",
+        parsed,
+        "struct ParsedBodyProjectionCollector<'a>",
+        "\nfn validate_pair(",
     );
     for forbidden in ["lower_module_rir", "OwnedBodyInput", "ModuleRir"] {
         assert!(
             !projector.contains(forbidden),
-            "warning AST projector crossed into RIR/body lowering: {forbidden}"
+            "warning syntax projection crossed into RIR/body lowering: {forbidden}"
         );
     }
     for required in [
-        ".definitions()",
-        ".declaration_locator(candidate)",
-        "module.ast().items",
+        "fn collect_module_projections(",
+        "fn visit_callable(",
+        "fn visit_expr(",
+        "ParsedDeclarationAstLocator::StructMethod",
     ] {
         assert!(
             projector.contains(required),
-            "warning AST projector lost exact parsed-candidate selection: {required}"
+            "parser-owned warning projection lost its canonical syntax edge: {required}"
         );
     }
 
+    let runtime = include_str!("revisioned_query_database.rs");
+    for forbidden in [
+        "compiler.warning-body-syntax",
+        "WarningBodySyntaxQueryKey",
+        "WarningStaticCallCollector",
+        "fn warning_static_call_heads(",
+    ] {
+        assert!(
+            !runtime.contains(forbidden),
+            "warning reachability regained a peer syntax path: {forbidden}"
+        );
+    }
+    let projection_family = source_between_exact_boundaries(
+        runtime,
+        "let parse_for_warning_call_heads = parse_modules.clone();",
+        "        let classifications_for_warning_references =",
+    );
+    for required in [
+        "compiler.warning-call-head-projection",
+        "parse_for_warning_call_heads",
+        ".declaration_warning_call_heads(candidate)",
+    ] {
+        assert!(
+            projection_family.contains(required),
+            "warning call-head terminal lost its thin parser projection: {required}"
+        );
+    }
+    for forbidden in [".ast()", "rue_parser", "AstGen", "lower_module_rir"] {
+        assert!(
+            !projection_family.contains(forbidden),
+            "warning call-head terminal regained syntax/lowering work: {forbidden}"
+        );
+    }
     let evaluator = source_between_exact_boundaries(
         runtime,
-        "let parse_for_warning_syntax = parse_modules.clone();",
+        "let classifications_for_warning_references =",
         "        // Body analysis is a canonical registered evaluator.",
     );
     for forbidden in [
@@ -311,16 +345,16 @@ fn warning_body_projection_stays_parse_only_and_below_rir_body_analysis() {
         "body_transactions",
         "module_rirs",
         "lower_module_rir",
+        ".ast()",
     ] {
         assert!(
             !evaluator.contains(forbidden),
-            "warning query family crossed into RIR/body analysis: {forbidden}"
+            "warning query family crossed into a peer syntax/RIR/body path: {forbidden}"
         );
     }
     for required in [
-        "compiler.warning-body-syntax",
-        "parse_for_warning_syntax",
-        "WarningBodySyntaxQueryKey",
+        "call_heads_for_warning_references",
+        "WarningCallHeadProjectionQueryKey",
         "DeclarationImportQueryKey",
         "CanonicalImportResolution::Resolved",
     ] {
@@ -384,6 +418,25 @@ fn semantic_signatures_preserve_parser_type_structure_without_a_text_grammar() {
     }
 
     let runtime = include_str!("revisioned_query_database.rs");
+    let provider = source_between_exact_boundaries(
+        runtime,
+        "impl rue_air::SemanticTypeSyntaxProvider<",
+        "\nimpl ResolveSemanticSignatureError",
+    );
+    for forbidden in [
+        "parse_type_call_syntax",
+        "resolve_semantic_type_syntax(",
+        "rue_lexer",
+        "rue_parser",
+        ".split(",
+        ".split_once(",
+        ".trim(",
+    ] {
+        assert!(
+            !provider.contains(forbidden),
+            "semantic nucleus provider regained a rendered-type grammar: {forbidden}"
+        );
+    }
     let resolver = source_between_exact_boundaries(
         runtime,
         "fn resolve_parsed_semantic_signature(",
@@ -2474,10 +2527,7 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
     let declaration_import_locator = parsed
         .split("struct RawDeclarationImportRange")
         .nth(1)
-        .and_then(|tail| {
-            tail.split("pub(crate) enum ParsedDeclarationImportFailure")
-                .next()
-        })
+        .and_then(|tail| tail.split("pub(crate) struct ParsedWarningCallHead").next())
         .unwrap();
     for forbidden in ["Vec<", "Arc<", "Box<"] {
         assert!(

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -9,13 +9,10 @@ use std::sync::Arc;
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-#[cfg(test)]
 use lasso::Key;
 use lasso::{RodeoResolver, Spur, ThreadedRodeo};
 use rue_error::{CompileError, CompileErrors, CompileResult, ErrorKind};
-use rue_parser::{
-    AssignTarget, Ast, Expr, IntrinsicArg, Item, Pattern, Statement, TypeExpr, ast::Visibility,
-};
+use rue_parser::{AssignTarget, Ast, Expr, IntrinsicArg, Item, TypeExpr, ast::Visibility};
 use rue_span::{FileId, Span};
 use sha2::{Digest, Sha256};
 
@@ -219,6 +216,26 @@ impl ParsedDefinitionIndex {
                     as u64;
                 charge
                     .saturating_add(declaration.fact.retained_charge())
+                    .saturating_add(declaration.warning_call_heads.iter().fold(
+                        (declaration.warning_call_heads.len()
+                            * std::mem::size_of::<ParsedWarningCallHead>())
+                            as u64,
+                        |charge, head| {
+                            let import = head
+                                .import
+                                .as_ref()
+                                .map_or(0, |import| import.specifier.retained_charge());
+                            head.components.iter().fold(
+                                charge.saturating_add(import).saturating_add(
+                                    (head.components.len() * std::mem::size_of::<Arc<str>>())
+                                        as u64,
+                                ),
+                                |charge, component| {
+                                    charge.saturating_add(component.retained_charge())
+                                },
+                            )
+                        },
+                    ))
                     .saturating_add(
                         declaration
                             .anonymous_sites
@@ -427,6 +444,15 @@ impl ParsedDefinitionIndex {
         })
     }
 
+    pub(crate) fn declaration_warning_call_heads(
+        &self,
+        key: &DeclarationCandidateKey,
+    ) -> Option<&Arc<[ParsedWarningCallHead]>> {
+        let index = self.declaration_by_key.get(key).copied()?;
+        let candidate = self.declarations.get(index)?;
+        (candidate.fact.key == *key).then_some(&candidate.warning_call_heads)
+    }
+
     #[cfg(test)]
     pub fn candidates_named(
         &self,
@@ -456,6 +482,10 @@ pub(crate) struct ParsedDeclarationCandidate {
     /// (RUE-1282).
     self_call_targets: Arc<[Arc<str>]>,
     raw_import_range: Option<RawDeclarationImportRange>,
+    /// Static call/type-constructor heads projected during the canonical
+    /// module syntax walk. Names are already stripped of lexical locals and
+    /// aliases; import references use declaration-local occurrence ordinals.
+    warning_call_heads: Arc<[ParsedWarningCallHead]>,
     /// Value-position anonymous type literals inside this declaration's constant
     /// initializer or body, with module-relative spans and their frontend
     /// anchors. Sliced into fragment-relative sites only by the remaining
@@ -514,6 +544,45 @@ struct RawDeclarationImportRange {
     len: u32,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ParsedWarningCallHead {
+    pub(crate) import: Option<ParsedWarningImport>,
+    pub(crate) components: Arc<[Arc<str>]>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ParsedWarningImport {
+    pub(crate) occurrence: u32,
+    pub(crate) specifier: Arc<str>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RawWarningCallHead {
+    import_span: Option<Span>,
+    components: Vec<Spur>,
+}
+
+impl Ord for RawWarningCallHead {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let span_key =
+            |span: Option<Span>| span.map(|span| (span.file_id.index(), span.start, span.end));
+        span_key(self.import_span)
+            .cmp(&span_key(other.import_span))
+            .then_with(|| {
+                self.components
+                    .iter()
+                    .map(|spur| (*spur).into_usize())
+                    .cmp(other.components.iter().map(|spur| (*spur).into_usize()))
+            })
+    }
+}
+
+impl PartialOrd for RawWarningCallHead {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ParsedDeclarationImportFailure {
     SiteOutOfRange { available: u32 },
@@ -563,6 +632,12 @@ struct ParsedInvalidImportSite {
 struct ImportSiteCollector {
     valid: Vec<ImportDirective>,
     invalid: Vec<ParsedInvalidImportSite>,
+}
+
+#[derive(Default)]
+struct ParsedModuleProjectionCollector {
+    imports: ImportSiteCollector,
+    warning_call_heads: HashMap<ParsedDeclarationAstLocator, Vec<RawWarningCallHead>>,
 }
 
 /// Immutable parsed syntax whose spans and symbols belong to one FileId epoch.
@@ -725,6 +800,13 @@ impl ParsedModule {
         let index = self.definitions.declaration_by_key.get(key).copied()?;
         let candidate = self.definitions.declarations.get(index)?;
         (candidate.fact.key == *key).then_some(candidate.anonymous_sites.as_ref())
+    }
+
+    pub(crate) fn declaration_warning_call_heads(
+        &self,
+        key: &DeclarationCandidateKey,
+    ) -> Option<&Arc<[ParsedWarningCallHead]>> {
+        self.definitions.declaration_warning_call_heads(key)
     }
 
     /// Exact parsed sibling facts needed to validate one accessor signature.
@@ -1465,7 +1547,7 @@ fn build_module(
 ) -> CompileResult<Arc<ParsedModule>> {
     let token = Arc::new(SymbolProvenance);
     let module = snapshot.module_id(file_id).expect("snapshot membership");
-    let import_sites = collect_imports(&ast, module, &interner)?;
+    let projections = collect_module_projections(&ast, module, &interner)?;
     let resolver = Arc::new(interner.into_resolver());
     build_module_with_resolver(
         snapshot,
@@ -1473,7 +1555,7 @@ fn build_module(
         ast,
         resolver,
         token,
-        import_sites,
+        projections,
         token_count,
         tokens,
     )
@@ -1485,7 +1567,7 @@ fn build_module_with_resolver(
     ast: Arc<Ast>,
     resolver: Arc<RodeoResolver<Spur>>,
     token: Arc<SymbolProvenance>,
-    import_sites: ImportSiteCollector,
+    projections: ParsedModuleProjectionCollector,
     token_count: usize,
     tokens: Arc<[rue_lexer::Token]>,
 ) -> CompileResult<Arc<ParsedModule>> {
@@ -1521,7 +1603,8 @@ fn build_module_with_resolver(
         &tokens,
         &provenanced_ast.ast,
         &resolver,
-        &import_sites.valid,
+        &projections.imports.valid,
+        &projections.warning_call_heads,
     )?;
     let payload = Arc::new(ParsedSyntaxPayload {
         source,
@@ -1531,8 +1614,8 @@ fn build_module_with_resolver(
         ast: provenanced_ast,
         resolver,
         definitions,
-        import_sites: import_sites.valid.into(),
-        invalid_import_sites: import_sites.invalid.into(),
+        import_sites: projections.imports.valid.into(),
+        invalid_import_sites: projections.imports.invalid.into(),
     });
     Ok(bind_payload(snapshot, file_id, payload))
 }
@@ -1602,6 +1685,7 @@ fn bind_payload(
                 is_accessor: candidate.is_accessor,
                 self_call_targets: candidate.self_call_targets.clone(),
                 raw_import_range: candidate.raw_import_range,
+                warning_call_heads: candidate.warning_call_heads.clone(),
                 anonymous_sites: candidate
                     .anonymous_sites
                     .iter()
@@ -1665,326 +1749,638 @@ fn bind_payload(
     })
 }
 
-fn collect_imports(
+#[derive(Debug, Clone)]
+struct ParsedWarningStaticPath {
+    import_span: Option<Span>,
+    components: Vec<Spur>,
+}
+
+impl ParsedWarningStaticPath {
+    fn into_head(self) -> Option<RawWarningCallHead> {
+        (!self.components.is_empty()).then_some(RawWarningCallHead {
+            import_span: self.import_span,
+            components: self.components,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+enum ParsedWarningLexicalBinding {
+    Local,
+    StaticAlias(ParsedWarningStaticPath),
+}
+
+/// One parser-owned syntax projection pass. It discovers module imports and
+/// declaration-local warning call heads together, so unused-function warning
+/// reachability never re-enters the AST with a peer scope/name walker.
+struct ParsedBodyProjectionCollector<'a> {
+    module: &'a ModuleId,
+    resolver: &'a ThreadedRodeo,
+    imports: &'a mut ImportSiteCollector,
+    scopes: Vec<HashMap<Spur, ParsedWarningLexicalBinding>>,
+    heads: Vec<RawWarningCallHead>,
+}
+
+impl<'a> ParsedBodyProjectionCollector<'a> {
+    fn new(
+        module: &'a ModuleId,
+        resolver: &'a ThreadedRodeo,
+        imports: &'a mut ImportSiteCollector,
+    ) -> Self {
+        Self {
+            module,
+            resolver,
+            imports,
+            scopes: Vec::new(),
+            heads: Vec::new(),
+        }
+    }
+
+    fn finish(mut self) -> Vec<RawWarningCallHead> {
+        self.heads.sort();
+        self.heads.dedup();
+        self.heads
+    }
+
+    fn symbol(&self, ident: rue_parser::ast::Ident) -> CompileResult<Spur> {
+        self.resolver
+            .try_resolve(&ident.name)
+            .map(|_| ident.name)
+            .ok_or_else(|| invalid_input("AST symbol is absent from the module symbol universe"))
+    }
+
+    fn spelling(&self, ident: rue_parser::ast::Ident) -> CompileResult<&str> {
+        self.resolver
+            .try_resolve(&ident.name)
+            .ok_or_else(|| invalid_input("AST symbol is absent from the module symbol universe"))
+    }
+
+    fn binding(&self, symbol: Spur) -> Option<&ParsedWarningLexicalBinding> {
+        self.scopes
+            .iter()
+            .rev()
+            .find_map(|scope| scope.get(&symbol))
+    }
+
+    fn bind(
+        &mut self,
+        ident: rue_parser::ast::Ident,
+        binding: ParsedWarningLexicalBinding,
+    ) -> CompileResult<()> {
+        let symbol = self.symbol(ident)?;
+        self.scopes
+            .last_mut()
+            .expect("warning projection always has a lexical scope")
+            .insert(symbol, binding);
+        Ok(())
+    }
+
+    fn bind_local(&mut self, ident: rue_parser::ast::Ident) -> CompileResult<()> {
+        self.bind(ident, ParsedWarningLexicalBinding::Local)
+    }
+
+    fn add_path(&mut self, path: ParsedWarningStaticPath) {
+        if let Some(head) = path.into_head() {
+            self.heads.push(head);
+        }
+    }
+
+    fn add_unqualified(&mut self, ident: rue_parser::ast::Ident) -> CompileResult<()> {
+        let symbol = self.symbol(ident)?;
+        match self.binding(symbol).cloned() {
+            Some(ParsedWarningLexicalBinding::Local) => {}
+            Some(ParsedWarningLexicalBinding::StaticAlias(path)) => self.add_path(path),
+            None => self.add_path(ParsedWarningStaticPath {
+                import_span: None,
+                components: vec![symbol],
+            }),
+        }
+        Ok(())
+    }
+
+    fn add_qualified(
+        &mut self,
+        path: impl IntoIterator<Item = rue_parser::ast::Ident>,
+    ) -> CompileResult<()> {
+        let mut symbols = path
+            .into_iter()
+            .map(|ident| self.symbol(ident))
+            .collect::<CompileResult<Vec<_>>>()?;
+        let Some(first) = symbols.first().copied() else {
+            return Ok(());
+        };
+        match self.binding(first).cloned() {
+            Some(ParsedWarningLexicalBinding::Local) => {}
+            Some(ParsedWarningLexicalBinding::StaticAlias(mut alias)) => {
+                alias.components.extend(symbols.drain(1..));
+                self.add_path(alias);
+            }
+            None => self.add_path(ParsedWarningStaticPath {
+                import_span: None,
+                components: symbols,
+            }),
+        }
+        Ok(())
+    }
+
+    fn visit_callable(
+        &mut self,
+        parameters: &[rue_parser::ast::Param],
+        result: Option<&TypeExpr>,
+        body: &Expr,
+        _has_self: bool,
+    ) -> CompileResult<()> {
+        self.scopes.push(HashMap::new());
+        let outcome = (|| {
+            for parameter in parameters {
+                self.visit_type(&parameter.ty)?;
+                self.bind_local(parameter.name)?;
+            }
+            if let Some(result) = result {
+                self.visit_type(result)?;
+            }
+            self.visit_expr(body)
+        })();
+        self.scopes.pop();
+        outcome
+    }
+
+    fn visit_signature(
+        &mut self,
+        parameters: &[rue_parser::ast::Param],
+        result: Option<&TypeExpr>,
+    ) -> CompileResult<()> {
+        for parameter in parameters {
+            self.visit_type(&parameter.ty)?;
+        }
+        if let Some(result) = result {
+            self.visit_type(result)?;
+        }
+        Ok(())
+    }
+
+    fn visit_args(&mut self, args: &[rue_parser::ast::CallArg]) -> CompileResult<()> {
+        for argument in args {
+            self.visit_expr(&argument.expr)?;
+        }
+        Ok(())
+    }
+
+    fn visit_array_length(&mut self, length: &rue_parser::ast::ArrayLength) -> CompileResult<()> {
+        match length {
+            rue_parser::ast::ArrayLength::Literal(_) | rue_parser::ast::ArrayLength::Named(_) => {}
+            rue_parser::ast::ArrayLength::Call { name, args } => {
+                self.add_unqualified(*name)?;
+                for argument in args {
+                    self.visit_array_length(argument)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn visit_type(&mut self, ty: &TypeExpr) -> CompileResult<()> {
+        match ty {
+            TypeExpr::Named(_)
+            | TypeExpr::Qualified { .. }
+            | TypeExpr::Unit(_)
+            | TypeExpr::Never(_)
+            | TypeExpr::StrFixed { .. }
+            | TypeExpr::IntArg { .. } => {}
+            TypeExpr::Array {
+                element, length, ..
+            } => {
+                self.visit_type(element)?;
+                self.visit_array_length(length)?;
+            }
+            TypeExpr::Slice { element, .. } => self.visit_type(element)?,
+            TypeExpr::AnonymousStruct {
+                fields, methods, ..
+            } => {
+                for field in fields {
+                    self.visit_type(&field.ty)?;
+                }
+                for method in methods {
+                    self.visit_callable(
+                        &method.params,
+                        method.return_type.as_ref(),
+                        &method.body,
+                        method.receiver.is_some(),
+                    )?;
+                }
+            }
+            TypeExpr::AnonymousEnum { variants, .. } => {
+                for variant in variants {
+                    for payload in &variant.payload {
+                        self.visit_type(payload)?;
+                    }
+                }
+            }
+            TypeExpr::PointerConst { pointee, .. } | TypeExpr::PointerMut { pointee, .. } => {
+                self.visit_type(pointee)?;
+            }
+            TypeExpr::TypeCall { name, args, .. } => {
+                self.add_unqualified(*name)?;
+                for argument in args {
+                    self.visit_type(argument)?;
+                }
+            }
+            TypeExpr::QualifiedTypeCall { segments, args, .. } => {
+                self.add_qualified(segments.iter().copied())?;
+                for argument in args {
+                    self.visit_type(argument)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn static_path(&self, expr: &Expr) -> CompileResult<Option<ParsedWarningStaticPath>> {
+        match expr {
+            Expr::Ident(ident) => {
+                let symbol = self.symbol(*ident)?;
+                Ok(match self.binding(symbol) {
+                    Some(ParsedWarningLexicalBinding::Local) => None,
+                    Some(ParsedWarningLexicalBinding::StaticAlias(path)) => Some(path.clone()),
+                    None => Some(ParsedWarningStaticPath {
+                        import_span: None,
+                        components: vec![symbol],
+                    }),
+                })
+            }
+            Expr::Field(field) => {
+                let Some(mut path) = self.static_path(&field.base)? else {
+                    return Ok(None);
+                };
+                path.components.push(self.symbol(field.field)?);
+                Ok(Some(path))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn resolved_import_path(&self, expr: &Expr) -> CompileResult<Option<ParsedWarningStaticPath>> {
+        let Expr::IntrinsicCall(import) = expr else {
+            return Ok(None);
+        };
+        if self.spelling(import.name)? != "import" {
+            return Ok(None);
+        }
+        let [IntrinsicArg::Expr(Expr::String(literal))] = import.args.as_slice() else {
+            return Ok(None);
+        };
+        self.resolver.try_resolve(&literal.value).ok_or_else(|| {
+            invalid_input("import literal is absent from the module symbol universe")
+        })?;
+        Ok(Some(ParsedWarningStaticPath {
+            import_span: Some(import.span),
+            components: Vec::new(),
+        }))
+    }
+
+    fn collect_import(&mut self, value: &rue_parser::ast::IntrinsicCallExpr) -> CompileResult<()> {
+        if self.spelling(value.name)? != "import" {
+            return Ok(());
+        }
+        if let [IntrinsicArg::Expr(Expr::String(literal))] = value.args.as_slice() {
+            let specifier = self.resolver.try_resolve(&literal.value).ok_or_else(|| {
+                invalid_input("import literal is absent from the module symbol universe")
+            })?;
+            self.imports.valid.push(ImportDirective::new(
+                self.module.clone(),
+                value.span.start,
+                value.span.end,
+                Arc::from(specifier),
+            ));
+        } else {
+            let (span, shape) = if value.args.len() != 1 {
+                (
+                    value.span,
+                    InvalidImportShape::WrongArity {
+                        actual: u32::try_from(value.args.len()).unwrap_or(u32::MAX),
+                    },
+                )
+            } else {
+                let span = match &value.args[0] {
+                    IntrinsicArg::Expr(expr) => expr.span(),
+                    IntrinsicArg::Type(ty) => ty.span(),
+                };
+                (span, InvalidImportShape::NonStringArgument)
+            };
+            self.imports
+                .invalid
+                .push(ParsedInvalidImportSite { span, shape });
+        }
+        Ok(())
+    }
+
+    fn visit_block(&mut self, block: &rue_parser::ast::BlockExpr) -> CompileResult<()> {
+        use rue_parser::ast::{LetPattern, Statement};
+        self.scopes.push(HashMap::new());
+        let outcome = (|| {
+            for statement in &block.statements {
+                match statement {
+                    Statement::Let(binding) => {
+                        if let Some(ty) = &binding.ty {
+                            self.visit_type(ty)?;
+                        }
+                        self.visit_expr(&binding.init)?;
+                        if let LetPattern::Ident(ident) = binding.pattern {
+                            let alias = (!binding.is_mut)
+                                .then(|| {
+                                    self.resolved_import_path(&binding.init).and_then(|path| {
+                                        path.map_or_else(
+                                            || self.static_path(&binding.init),
+                                            |path| Ok(Some(path)),
+                                        )
+                                    })
+                                })
+                                .transpose()?
+                                .flatten();
+                            self.bind(
+                                ident,
+                                alias.map_or(
+                                    ParsedWarningLexicalBinding::Local,
+                                    ParsedWarningLexicalBinding::StaticAlias,
+                                ),
+                            )?;
+                        }
+                    }
+                    Statement::Assign(assignment) => {
+                        match &assignment.target {
+                            AssignTarget::Var(_) => {}
+                            AssignTarget::Field(field) => self.visit_expr(&field.base)?,
+                            AssignTarget::Index(index) => {
+                                self.visit_expr(&index.base)?;
+                                self.visit_expr(&index.index)?;
+                            }
+                        }
+                        self.visit_expr(&assignment.value)?;
+                    }
+                    Statement::Expr(expr) => self.visit_expr(expr)?,
+                }
+            }
+            self.visit_expr(&block.expr)
+        })();
+        self.scopes.pop();
+        outcome
+    }
+
+    fn visit_expr(&mut self, expr: &Expr) -> CompileResult<()> {
+        use rue_parser::ast::{LetPattern, Pattern};
+        match expr {
+            Expr::Int(_)
+            | Expr::Float(_)
+            | Expr::String(_)
+            | Expr::Bool(_)
+            | Expr::Unit(_)
+            | Expr::Ident(_)
+            | Expr::Continue(_)
+            | Expr::SelfExpr(_)
+            | Expr::Error(_) => {}
+            Expr::TypeLit(value) => self.visit_type(&value.type_expr)?,
+            Expr::Binary(value) => {
+                self.visit_expr(&value.left)?;
+                self.visit_expr(&value.right)?;
+            }
+            Expr::Unary(value) => self.visit_expr(&value.operand)?,
+            Expr::Paren(value) => self.visit_expr(&value.inner)?,
+            Expr::Block(value) => self.visit_block(value)?,
+            Expr::If(value) => {
+                self.visit_expr(&value.cond)?;
+                self.visit_block(&value.then_block)?;
+                if let Some(block) = &value.else_block {
+                    self.visit_block(block)?;
+                }
+            }
+            Expr::Match(value) => {
+                self.visit_expr(&value.scrutinee)?;
+                for arm in &value.arms {
+                    self.scopes.push(HashMap::new());
+                    let outcome = (|| {
+                        if let Pattern::Path(path) = &arm.pattern {
+                            if let Some(base) = &path.base {
+                                self.visit_expr(base)?;
+                            }
+                            if let Some(args) = &path.ctor_args {
+                                if let Some(base) = &path.base {
+                                    if let Some(mut head) = self.static_path(base)? {
+                                        head.components.push(self.symbol(path.type_name)?);
+                                        self.add_path(head);
+                                    }
+                                } else {
+                                    self.add_unqualified(path.type_name)?;
+                                }
+                                self.visit_args(args)?;
+                            }
+                            for binding in &path.bindings {
+                                self.bind_local(*binding)?;
+                            }
+                        }
+                        self.visit_expr(&arm.body)
+                    })();
+                    self.scopes.pop();
+                    outcome?;
+                }
+            }
+            Expr::While(value) => {
+                self.visit_expr(&value.cond)?;
+                self.visit_block(&value.body)?;
+            }
+            Expr::Loop(value) => self.visit_block(&value.body)?,
+            Expr::For(value) => {
+                self.visit_expr(&value.iterable)?;
+                self.scopes.push(HashMap::new());
+                let outcome = (|| {
+                    if let LetPattern::Ident(ident) = value.binder {
+                        self.bind_local(ident)?;
+                    }
+                    self.visit_block(&value.body)
+                })();
+                self.scopes.pop();
+                outcome?;
+            }
+            Expr::Call(value) => {
+                self.add_unqualified(value.name)?;
+                self.visit_args(&value.args)?;
+            }
+            Expr::Break(value) => {
+                if let Some(value) = &value.value {
+                    self.visit_expr(value)?;
+                }
+            }
+            Expr::Return(value) => {
+                if let Some(value) = &value.value {
+                    self.visit_expr(value)?;
+                }
+            }
+            Expr::Yield(value) => self.visit_expr(&value.value)?,
+            Expr::StructLit(value) => {
+                if let Some(base) = &value.base {
+                    self.visit_expr(base)?;
+                }
+                if let Some(args) = &value.ctor_args {
+                    if let Some(base) = &value.base {
+                        if let Some(mut path) = self.static_path(base)? {
+                            path.components.push(self.symbol(value.name)?);
+                            self.add_path(path);
+                        }
+                    } else {
+                        self.add_unqualified(value.name)?;
+                    }
+                    self.visit_args(args)?;
+                }
+                for field in &value.fields {
+                    self.visit_expr(&field.value)?;
+                }
+            }
+            Expr::Field(value) => self.visit_expr(&value.base)?,
+            Expr::MethodCall(value) => {
+                if let Some(mut path) = self.static_path(&value.receiver)? {
+                    path.components.push(self.symbol(value.method)?);
+                    self.add_path(path);
+                }
+                self.visit_expr(&value.receiver)?;
+                self.visit_args(&value.args)?;
+            }
+            Expr::Try(value) => self.visit_expr(&value.operand)?,
+            Expr::IntrinsicCall(value) => {
+                self.collect_import(value)?;
+                for argument in &value.args {
+                    match argument {
+                        IntrinsicArg::Expr(expr) => self.visit_expr(expr)?,
+                        IntrinsicArg::Type(ty) => self.visit_type(ty)?,
+                    }
+                }
+            }
+            Expr::ArrayLit(value) => {
+                for element in &value.elements {
+                    self.visit_expr(element)?;
+                }
+                if let Some(repeat) = &value.repeat {
+                    self.visit_array_length(repeat)?;
+                }
+            }
+            Expr::Index(value) => {
+                self.visit_expr(&value.base)?;
+                self.visit_expr(&value.index)?;
+            }
+            Expr::Path(value) => {
+                if let Some(base) = &value.base {
+                    self.visit_expr(base)?;
+                }
+            }
+            Expr::Comptime(value) => self.visit_expr(&value.expr)?,
+            Expr::Checked(value) => self.visit_expr(&value.expr)?,
+        }
+        Ok(())
+    }
+}
+
+fn collect_module_projections(
     ast: &Ast,
     module: &ModuleId,
     resolver: &ThreadedRodeo,
-) -> CompileResult<ImportSiteCollector> {
-    let mut imports = ImportSiteCollector::default();
-    for item in &ast.items {
+) -> CompileResult<ParsedModuleProjectionCollector> {
+    let mut projections = ParsedModuleProjectionCollector::default();
+    for (item_index, item) in ast.items.iter().enumerate() {
+        let item_index = u32::try_from(item_index)
+            .map_err(|_| invalid_input("parsed item ordinal exceeds u32"))?;
         match item {
             Item::Function(value) => {
-                walk_signature(
+                let mut collector =
+                    ParsedBodyProjectionCollector::new(module, resolver, &mut projections.imports);
+                collector.visit_callable(
                     &value.params,
                     value.return_type.as_ref(),
-                    module,
-                    resolver,
-                    &mut imports,
+                    &value.body,
+                    false,
                 )?;
-                walk_expr(&value.body, module, resolver, &mut imports)?;
+                projections.warning_call_heads.insert(
+                    ParsedDeclarationAstLocator::TopLevel { item: item_index },
+                    collector.finish(),
+                );
             }
             Item::Struct(value) => {
                 for field in &value.fields {
-                    walk_type_expr(&field.ty, module, resolver, &mut imports)?;
+                    let mut collector = ParsedBodyProjectionCollector::new(
+                        module,
+                        resolver,
+                        &mut projections.imports,
+                    );
+                    collector.visit_type(&field.ty)?;
                 }
-                for method in &value.methods {
-                    walk_signature(
+                for (method_index, method) in value.methods.iter().enumerate() {
+                    let method_index = u32::try_from(method_index)
+                        .map_err(|_| invalid_input("parsed method ordinal exceeds u32"))?;
+                    let mut collector = ParsedBodyProjectionCollector::new(
+                        module,
+                        resolver,
+                        &mut projections.imports,
+                    );
+                    collector.visit_callable(
                         &method.params,
                         method.return_type.as_ref(),
-                        module,
-                        resolver,
-                        &mut imports,
+                        &method.body,
+                        method.receiver.is_some(),
                     )?;
-                    walk_expr(&method.body, module, resolver, &mut imports)?;
+                    projections.warning_call_heads.insert(
+                        ParsedDeclarationAstLocator::StructMethod {
+                            item: item_index,
+                            method: method_index,
+                        },
+                        collector.finish(),
+                    );
                 }
             }
-            Item::DropFn(value) => walk_expr(&value.body, module, resolver, &mut imports)?,
+            Item::DropFn(value) => {
+                let mut collector =
+                    ParsedBodyProjectionCollector::new(module, resolver, &mut projections.imports);
+                collector.visit_callable(&[], None, &value.body, true)?;
+                projections.warning_call_heads.insert(
+                    ParsedDeclarationAstLocator::TopLevel { item: item_index },
+                    collector.finish(),
+                );
+            }
             Item::Extern(block) => {
                 for foreign in &block.fns {
-                    walk_signature(
-                        &foreign.params,
-                        foreign.return_type.as_ref(),
+                    let mut collector = ParsedBodyProjectionCollector::new(
                         module,
                         resolver,
-                        &mut imports,
-                    )?;
+                        &mut projections.imports,
+                    );
+                    collector.visit_signature(&foreign.params, foreign.return_type.as_ref())?;
                 }
             }
             Item::Const(value) => {
+                let mut collector =
+                    ParsedBodyProjectionCollector::new(module, resolver, &mut projections.imports);
                 if let Some(ty) = &value.ty {
-                    walk_type_expr(ty, module, resolver, &mut imports)?;
+                    collector.visit_type(ty)?;
                 }
-                walk_expr(&value.init, module, resolver, &mut imports)?;
+                collector.visit_expr(&value.init)?;
             }
             Item::Enum(value) => {
                 for variant in &value.variants {
                     for ty in &variant.payload {
-                        walk_type_expr(ty, module, resolver, &mut imports)?;
+                        let mut collector = ParsedBodyProjectionCollector::new(
+                            module,
+                            resolver,
+                            &mut projections.imports,
+                        );
+                        collector.visit_type(ty)?;
                     }
                 }
             }
             Item::Error(_) => {}
         }
     }
-    imports.valid.sort();
-    imports
+    projections.imports.valid.sort();
+    projections
+        .imports
         .invalid
         .sort_by_key(|site| (site.span.file_id.index(), site.span.start));
-    Ok(imports)
-}
-
-fn walk_signature(
-    params: &[rue_parser::ast::Param],
-    return_type: Option<&TypeExpr>,
-    module: &ModuleId,
-    resolver: &ThreadedRodeo,
-    imports: &mut ImportSiteCollector,
-) -> CompileResult<()> {
-    for param in params {
-        walk_type_expr(&param.ty, module, resolver, imports)?;
-    }
-    if let Some(return_type) = return_type {
-        walk_type_expr(return_type, module, resolver, imports)?;
-    }
-    Ok(())
-}
-
-fn walk_type_expr(
-    ty: &TypeExpr,
-    module: &ModuleId,
-    resolver: &ThreadedRodeo,
-    imports: &mut ImportSiteCollector,
-) -> CompileResult<()> {
-    match ty {
-        TypeExpr::Named(_)
-        | TypeExpr::Qualified { .. }
-        | TypeExpr::Unit(_)
-        | TypeExpr::Never(_)
-        | TypeExpr::StrFixed { .. }
-        | TypeExpr::IntArg { .. } => {}
-        TypeExpr::Array { element, .. } | TypeExpr::Slice { element, .. } => {
-            walk_type_expr(element, module, resolver, imports)?;
-        }
-        TypeExpr::AnonymousStruct {
-            fields, methods, ..
-        } => {
-            for field in fields {
-                walk_type_expr(&field.ty, module, resolver, imports)?;
-            }
-            for method in methods {
-                walk_signature(
-                    &method.params,
-                    method.return_type.as_ref(),
-                    module,
-                    resolver,
-                    imports,
-                )?;
-                walk_expr(&method.body, module, resolver, imports)?;
-            }
-        }
-        TypeExpr::AnonymousEnum { variants, .. } => {
-            for variant in variants {
-                for payload in &variant.payload {
-                    walk_type_expr(payload, module, resolver, imports)?;
-                }
-            }
-        }
-        TypeExpr::PointerConst { pointee, .. } | TypeExpr::PointerMut { pointee, .. } => {
-            walk_type_expr(pointee, module, resolver, imports)?;
-        }
-        TypeExpr::TypeCall { args, .. } | TypeExpr::QualifiedTypeCall { args, .. } => {
-            for arg in args {
-                walk_type_expr(arg, module, resolver, imports)?;
-            }
-        }
-    }
-    Ok(())
-}
-
-fn walk_args(
-    args: &[rue_parser::ast::CallArg],
-    module: &ModuleId,
-    resolver: &ThreadedRodeo,
-    imports: &mut ImportSiteCollector,
-) -> CompileResult<()> {
-    for arg in args {
-        walk_expr(&arg.expr, module, resolver, imports)?;
-    }
-    Ok(())
-}
-
-fn walk_block(
-    block: &rue_parser::ast::BlockExpr,
-    module: &ModuleId,
-    resolver: &ThreadedRodeo,
-    imports: &mut ImportSiteCollector,
-) -> CompileResult<()> {
-    for statement in &block.statements {
-        match statement {
-            Statement::Let(value) => walk_expr(&value.init, module, resolver, imports)?,
-            Statement::Assign(value) => {
-                match &value.target {
-                    AssignTarget::Var(_) => {}
-                    AssignTarget::Field(field) => {
-                        walk_expr(&field.base, module, resolver, imports)?
-                    }
-                    AssignTarget::Index(index) => {
-                        walk_expr(&index.base, module, resolver, imports)?;
-                        walk_expr(&index.index, module, resolver, imports)?;
-                    }
-                }
-                walk_expr(&value.value, module, resolver, imports)?;
-            }
-            Statement::Expr(value) => walk_expr(value, module, resolver, imports)?,
-        }
-    }
-    walk_expr(&block.expr, module, resolver, imports)
-}
-
-fn walk_expr(
-    expr: &Expr,
-    module: &ModuleId,
-    resolver: &ThreadedRodeo,
-    imports: &mut ImportSiteCollector,
-) -> CompileResult<()> {
-    match expr {
-        Expr::Int(_)
-        | Expr::Float(_)
-        | Expr::String(_)
-        | Expr::Bool(_)
-        | Expr::Unit(_)
-        | Expr::Ident(_)
-        | Expr::Continue(_)
-        | Expr::SelfExpr(_)
-        | Expr::Error(_) => {}
-        Expr::TypeLit(value) => {
-            walk_type_expr(&value.type_expr, module, resolver, imports)?;
-        }
-        Expr::Binary(value) => {
-            walk_expr(&value.left, module, resolver, imports)?;
-            walk_expr(&value.right, module, resolver, imports)?;
-        }
-        Expr::Unary(value) => walk_expr(&value.operand, module, resolver, imports)?,
-        Expr::Paren(value) => walk_expr(&value.inner, module, resolver, imports)?,
-        Expr::Block(value) => walk_block(value, module, resolver, imports)?,
-        Expr::If(value) => {
-            walk_expr(&value.cond, module, resolver, imports)?;
-            walk_block(&value.then_block, module, resolver, imports)?;
-            if let Some(block) = &value.else_block {
-                walk_block(block, module, resolver, imports)?;
-            }
-        }
-        Expr::Match(value) => {
-            walk_expr(&value.scrutinee, module, resolver, imports)?;
-            for arm in &value.arms {
-                if let Pattern::Path(path) = &arm.pattern {
-                    if let Some(base) = &path.base {
-                        walk_expr(base, module, resolver, imports)?;
-                    }
-                    if let Some(args) = &path.ctor_args {
-                        walk_args(args, module, resolver, imports)?;
-                    }
-                }
-                walk_expr(&arm.body, module, resolver, imports)?;
-            }
-        }
-        Expr::While(value) => {
-            walk_expr(&value.cond, module, resolver, imports)?;
-            walk_block(&value.body, module, resolver, imports)?;
-        }
-        Expr::Loop(value) => walk_block(&value.body, module, resolver, imports)?,
-        Expr::For(value) => {
-            walk_expr(&value.iterable, module, resolver, imports)?;
-            walk_block(&value.body, module, resolver, imports)?;
-        }
-        Expr::Call(value) => walk_args(&value.args, module, resolver, imports)?,
-        Expr::Break(value) => {
-            if let Some(value) = &value.value {
-                walk_expr(value, module, resolver, imports)?;
-            }
-        }
-        Expr::Return(value) => {
-            if let Some(value) = &value.value {
-                walk_expr(value, module, resolver, imports)?;
-            }
-        }
-        Expr::Yield(value) => walk_expr(&value.value, module, resolver, imports)?,
-        Expr::StructLit(value) => {
-            if let Some(base) = &value.base {
-                walk_expr(base, module, resolver, imports)?;
-            }
-            if let Some(args) = &value.ctor_args {
-                walk_args(args, module, resolver, imports)?;
-            }
-            for field in &value.fields {
-                walk_expr(&field.value, module, resolver, imports)?;
-            }
-        }
-        Expr::Field(value) => walk_expr(&value.base, module, resolver, imports)?,
-        Expr::MethodCall(value) => {
-            walk_expr(&value.receiver, module, resolver, imports)?;
-            walk_args(&value.args, module, resolver, imports)?;
-        }
-        Expr::Try(value) => walk_expr(&value.operand, module, resolver, imports)?,
-        Expr::IntrinsicCall(value) => {
-            let name = resolver.try_resolve(&value.name.name).ok_or_else(|| {
-                invalid_input("intrinsic name is absent from the module symbol universe")
-            })?;
-            if name == "import" {
-                if let [IntrinsicArg::Expr(Expr::String(literal))] = value.args.as_slice() {
-                    let specifier = resolver.try_resolve(&literal.value).ok_or_else(|| {
-                        invalid_input("import literal is absent from the module symbol universe")
-                    })?;
-                    imports.valid.push(ImportDirective::new(
-                        module.clone(),
-                        value.span.start,
-                        value.span.end,
-                        Arc::from(specifier),
-                    ));
-                } else {
-                    let (span, shape) = if value.args.len() != 1 {
-                        (
-                            value.span,
-                            InvalidImportShape::WrongArity {
-                                actual: u32::try_from(value.args.len()).unwrap_or(u32::MAX),
-                            },
-                        )
-                    } else {
-                        let span = match &value.args[0] {
-                            IntrinsicArg::Expr(expr) => expr.span(),
-                            IntrinsicArg::Type(ty) => ty.span(),
-                        };
-                        (span, InvalidImportShape::NonStringArgument)
-                    };
-                    imports
-                        .invalid
-                        .push(ParsedInvalidImportSite { span, shape });
-                }
-            }
-            for arg in &value.args {
-                if let IntrinsicArg::Expr(expr) = arg {
-                    walk_expr(expr, module, resolver, imports)?;
-                }
-            }
-        }
-        Expr::ArrayLit(value) => {
-            for element in &value.elements {
-                walk_expr(element, module, resolver, imports)?;
-            }
-        }
-        Expr::Index(value) => {
-            walk_expr(&value.base, module, resolver, imports)?;
-            walk_expr(&value.index, module, resolver, imports)?;
-        }
-        Expr::Path(value) => {
-            if let Some(base) = &value.base {
-                walk_expr(base, module, resolver, imports)?;
-            }
-        }
-        Expr::Comptime(value) => walk_expr(&value.expr, module, resolver, imports)?,
-        Expr::Checked(value) => walk_expr(&value.expr, module, resolver, imports)?,
-    }
-    Ok(())
+    Ok(projections)
 }
 
 fn validate_pair(
@@ -2026,6 +2422,96 @@ fn declaration_import_range(
     Ok(RawDeclarationImportRange { start, len })
 }
 
+fn project_warning_call_heads(
+    category: DeclarationCandidateCategory,
+    locator: ParsedDeclarationAstLocator,
+    declaration: Span,
+    import_range: Option<RawDeclarationImportRange>,
+    import_sites: &[ImportDirective],
+    resolver: &FrozenSymbolResolver,
+    raw_heads: &HashMap<ParsedDeclarationAstLocator, Vec<RawWarningCallHead>>,
+) -> CompileResult<Arc<[ParsedWarningCallHead]>> {
+    let owns_warning_body = matches!(
+        category,
+        DeclarationCandidateCategory::Function
+            | DeclarationCandidateCategory::Destructor
+            | DeclarationCandidateCategory::Method
+            | DeclarationCandidateCategory::AssociatedFunction
+    );
+    if !owns_warning_body {
+        if raw_heads.contains_key(&locator) {
+            return Err(invalid_input(
+                "bodyless declaration unexpectedly owns warning call heads",
+            ));
+        }
+        return Ok(Arc::from([]));
+    }
+
+    let raw_heads = raw_heads
+        .get(&locator)
+        .ok_or_else(|| invalid_input("body declaration has no warning call-head projection"))?;
+    let import_range = import_range
+        .ok_or_else(|| invalid_input("body declaration has no canonical import range"))?;
+    let start = usize::try_from(import_range.start)
+        .map_err(|_| invalid_input("declaration import start exceeds usize"))?;
+    let end = import_range
+        .start
+        .checked_add(import_range.len)
+        .and_then(|end| usize::try_from(end).ok())
+        .ok_or_else(|| invalid_input("declaration import range exceeds usize"))?;
+    let imports = import_sites
+        .get(start..end)
+        .ok_or_else(|| invalid_input("declaration import range is outside the module table"))?;
+
+    let mut projected = Vec::with_capacity(raw_heads.len());
+    for head in raw_heads.iter() {
+        if head.components.is_empty() {
+            return Err(invalid_input("warning call head has no path components"));
+        }
+        let import = head
+            .import_span
+            .map(|span| {
+                if span.file_id != declaration.file_id
+                    || span.start < declaration.start
+                    || span.end > declaration.end
+                {
+                    return Err(invalid_input(
+                        "warning import alias is outside its declaration",
+                    ));
+                }
+                let occurrence = imports
+                    .binary_search_by_key(&(span.start, span.end), |site| {
+                        (site.source_offset(), site.source_end())
+                    })
+                    .map_err(|_| {
+                        invalid_input("warning import alias has no canonical import site")
+                    })?;
+                let site = &imports[occurrence];
+                Ok(ParsedWarningImport {
+                    occurrence: u32::try_from(occurrence)
+                        .map_err(|_| invalid_input("declaration import occurrence exceeds u32"))?,
+                    specifier: Arc::from(site.specifier()),
+                })
+            })
+            .transpose()?;
+        let components = head
+            .components
+            .iter()
+            .map(|spur| {
+                let symbol = resolver.symbol(*spur)?;
+                Ok(Arc::from(resolver.resolve(&symbol)?))
+            })
+            .collect::<CompileResult<Vec<_>>>()?;
+        projected.push(ParsedWarningCallHead {
+            import,
+            components: components.into(),
+        });
+    }
+    projected.sort();
+    projected.dedup();
+    Ok(projected.into())
+}
+
 fn build_definition_index(
     module: ModuleId,
     file_id: FileId,
@@ -2034,6 +2520,7 @@ fn build_definition_index(
     ast: &Ast,
     resolver: &FrozenSymbolResolver,
     import_sites: &[ImportDirective],
+    raw_warning_call_heads: &HashMap<ParsedDeclarationAstLocator, Vec<RawWarningCallHead>>,
 ) -> CompileResult<ParsedDefinitionIndex> {
     if import_sites.windows(2).any(|sites| {
         (sites[0].source_offset(), sites[0].source_end())
@@ -2053,6 +2540,7 @@ fn build_definition_index(
         bool,
         Arc<[Arc<str>]>,
         Option<RawDeclarationImportRange>,
+        Arc<[ParsedWarningCallHead]>,
         Arc<[rue_rir::AnonymousTypeSite]>,
     )>::new();
     let resolve_name = |ident: rue_parser::Ident| -> CompileResult<Arc<str>> {
@@ -2194,6 +2682,15 @@ fn build_definition_index(
             } else {
                 None
             };
+            let warning_call_heads = project_warning_call_heads(
+                category,
+                ast_locator,
+                declaration_span,
+                raw_import_range,
+                import_sites,
+                resolver,
+                raw_warning_call_heads,
+            )?;
             pending_declarations.push((
                 DeclarationShellFact {
                     key: DeclarationCandidateKey {
@@ -2219,6 +2716,7 @@ fn build_definition_index(
                 is_accessor,
                 method_self_call_targets,
                 raw_import_range,
+                warning_call_heads,
                 anonymous_sites,
             ));
             Ok(())
@@ -2484,6 +2982,7 @@ fn build_definition_index(
                 is_accessor,
                 self_call_targets,
                 raw_import_range,
+                warning_call_heads,
                 anonymous_sites,
             )| {
                 let duplicate = duplicate_counts
@@ -2506,6 +3005,7 @@ fn build_definition_index(
                     is_accessor,
                     self_call_targets,
                     raw_import_range,
+                    warning_call_heads,
                     anonymous_sites,
                 })
             },

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -2281,22 +2281,19 @@ pub(crate) struct WarningStaticCallHead {
     pub(crate) components: Arc<[Arc<str>]>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-struct WarningSyntaxCallHead {
-    import: Option<crate::declaration_candidate::DeclarationImportSiteKey>,
-    components: Arc<[Arc<str>]>,
-}
-
+/// Candidate-local warning syntax projected once by the parser-owned module
+/// walk. This thin terminal exists only to preserve body-local stamps across
+/// sibling edits; it performs no AST traversal of its own.
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum WarningBodySyntaxValue {
-    Available(Arc<[WarningSyntaxCallHead]>),
+enum WarningCallHeadProjectionValue {
+    Available(Arc<[crate::parsed_modules::ParsedWarningCallHead]>),
     Failure(WarningBodyReferencesFailure),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct WarningBodySyntaxQueryKey(crate::declaration_candidate::DeclarationCandidateKey);
+struct WarningCallHeadProjectionQueryKey(crate::declaration_candidate::DeclarationCandidateKey);
 
-impl QueryKey for WarningBodySyntaxQueryKey {
+impl QueryKey for WarningCallHeadProjectionQueryKey {
     fn stable_identity(&self) -> String {
         self.0.stable_identity()
     }
@@ -2811,7 +2808,7 @@ macro_rules! query_value_charge {
 
 #[cfg(test)]
 query_value_charge!(RawDeclarationBodyQueryValue);
-query_value_charge!(WarningBodySyntaxValue);
+query_value_charge!(WarningCallHeadProjectionValue);
 query_value_charge!(WarningBodyReferencesValue);
 
 impl RetainedCharge for DeclarationBodyPlanFailure {
@@ -2845,10 +2842,11 @@ impl RetainedCharge for WarningStaticCallHead {
     }
 }
 
-impl RetainedCharge for WarningSyntaxCallHead {
+impl RetainedCharge for crate::parsed_modules::ParsedWarningCallHead {
     fn retained_charge(&self) -> u64 {
         self.import
-            .retained_charge()
+            .as_ref()
+            .map_or(0, |import| import.specifier.retained_charge())
             .saturating_add(self.components.retained_charge())
     }
 }
@@ -4207,578 +4205,6 @@ fn closure_callable_has_body(
         | Payload::Const { .. }
         | Payload::ModuleBinding { .. } => false,
     }))
-}
-
-/// Project statically resolvable free-function and type-constructor call heads
-/// directly from the canonical parsed module. The exact declaration candidate
-/// selects one parser-owned AST body; no body fragment is reparsed and no RIR,
-/// semantic body analysis, reachability, CFG, or codegen query is entered.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-struct WarningBodySelectionWork {
-    top_level_items_examined: u32,
-    member_items_examined: u32,
-}
-
-fn warning_item_span(item: &rue_parser::ast::Item) -> rue_span::Span {
-    use rue_parser::ast::Item;
-    match item {
-        Item::Function(item) => item.span,
-        Item::Struct(item) => item.span,
-        Item::Enum(item) => item.span,
-        Item::DropFn(item) => item.span,
-        Item::Extern(item) => item.span,
-        Item::Const(item) => item.span,
-        Item::Error(span) => *span,
-    }
-}
-
-/// Find the source-ordered record containing `target` with a bounded binary
-/// search. Parser-owned top-level items and nominal members are non-overlapping,
-/// so the last record beginning no later than the target is the only possible
-/// owner. The exact declaration checks below remain authoritative.
-fn warning_record_containing<'a, T>(
-    records: &'a [T],
-    target: rue_span::Span,
-    mut span: impl FnMut(&T) -> rue_span::Span,
-    examined: &mut u32,
-) -> Option<&'a T> {
-    let mut start = 0;
-    let mut end = records.len();
-    while start < end {
-        let middle = start + (end - start) / 2;
-        *examined = examined.saturating_add(1);
-        if span(&records[middle]).start <= target.start {
-            start = middle + 1;
-        } else {
-            end = middle;
-        }
-    }
-    let record = records.get(start.checked_sub(1)?)?;
-    *examined = examined.saturating_add(1);
-    let record_span = span(record);
-    (record_span.start <= target.start && target.end <= record_span.end).then_some(record)
-}
-
-fn warning_static_call_heads(
-    module: &crate::parsed_modules::ParsedModule,
-    candidate: &crate::declaration_candidate::DeclarationCandidateKey,
-    declaration_imports: &BTreeMap<
-        (u32, u32),
-        crate::declaration_candidate::DeclarationImportSiteKey,
-    >,
-) -> (
-    Result<Arc<[WarningSyntaxCallHead]>, Arc<str>>,
-    WarningBodySelectionWork,
-) {
-    use crate::declaration_candidate::DeclarationCandidateCategory as Category;
-    use rue_parser::ast::Item;
-
-    let mut work = WarningBodySelectionWork::default();
-    let result = (|| {
-        let locator = module
-            .definitions()
-            .declaration_locator(candidate)
-            .ok_or_else(|| {
-                Arc::from("warning call-head projection has no exact declaration locator")
-            })?;
-        let item = warning_record_containing(
-            &module.ast().items,
-            locator.declaration_span,
-            warning_item_span,
-            &mut work.top_level_items_examined,
-        )
-        .ok_or_else(|| Arc::from("warning call-head projection has no containing AST item"))?;
-        let mut collector = WarningStaticCallCollector::new(module, declaration_imports);
-        match (candidate.category, item) {
-            (Category::Function, Item::Function(function))
-                if function.span == locator.declaration_span
-                    && module.resolve_raw_symbol(function.name.name) == candidate.name.as_ref() =>
-            {
-                collector.visit_callable(
-                    &function.params,
-                    function.return_type.as_ref(),
-                    &function.body,
-                    false,
-                );
-            }
-            (Category::Method | Category::AssociatedFunction, Item::Struct(structure)) => {
-                let owner_matches = candidate.owner.as_ref().is_some_and(|owner| {
-                    module.resolve_raw_symbol(structure.name.name) == owner.name.as_ref()
-                });
-                let method = owner_matches
-                    .then(|| {
-                        warning_record_containing(
-                            &structure.methods,
-                            locator.declaration_span,
-                            |method| method.span,
-                            &mut work.member_items_examined,
-                        )
-                    })
-                    .flatten();
-                let Some(method) = method.filter(|method| {
-                    method.span == locator.declaration_span
-                        && module.resolve_raw_symbol(method.name.name) == candidate.name.as_ref()
-                }) else {
-                    return Err(Arc::from(format!(
-                        "warning call-head projection selected no exact member AST body for {}",
-                        candidate.stable_identity()
-                    )));
-                };
-                collector.visit_callable(
-                    &method.params,
-                    method.return_type.as_ref(),
-                    &method.body,
-                    method.receiver.is_some(),
-                );
-            }
-            (Category::Destructor, Item::DropFn(drop_fn))
-                if drop_fn.span == locator.declaration_span
-                    && module.resolve_raw_symbol(drop_fn.type_name.name)
-                        == candidate.name.as_ref() =>
-            {
-                collector.visit_callable(&[], None, &drop_fn.body, true);
-            }
-            _ => {
-                return Err(Arc::from(format!(
-                    "warning call-head projection selected no exact AST body for {}",
-                    candidate.stable_identity()
-                )));
-            }
-        }
-        Ok(collector.heads.into_iter().collect::<Vec<_>>().into())
-    })();
-    (result, work)
-}
-
-#[derive(Debug, Clone)]
-struct WarningStaticPath {
-    import: Option<crate::declaration_candidate::DeclarationImportSiteKey>,
-    components: Vec<Arc<str>>,
-}
-
-impl WarningStaticPath {
-    fn into_head(self) -> Option<WarningSyntaxCallHead> {
-        (!self.components.is_empty()).then(|| WarningSyntaxCallHead {
-            import: self.import,
-            components: self.components.into(),
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
-enum WarningLexicalBinding {
-    Local,
-    StaticAlias(WarningStaticPath),
-}
-
-struct WarningStaticCallCollector<'a> {
-    module: &'a crate::parsed_modules::ParsedModule,
-    declaration_imports:
-        &'a BTreeMap<(u32, u32), crate::declaration_candidate::DeclarationImportSiteKey>,
-    scopes: Vec<BTreeMap<Arc<str>, WarningLexicalBinding>>,
-    heads: BTreeSet<WarningSyntaxCallHead>,
-}
-
-impl<'a> WarningStaticCallCollector<'a> {
-    fn new(
-        module: &'a crate::parsed_modules::ParsedModule,
-        declaration_imports: &'a BTreeMap<
-            (u32, u32),
-            crate::declaration_candidate::DeclarationImportSiteKey,
-        >,
-    ) -> Self {
-        Self {
-            module,
-            declaration_imports,
-            scopes: Vec::new(),
-            heads: BTreeSet::new(),
-        }
-    }
-
-    fn name(&self, ident: rue_parser::ast::Ident) -> Arc<str> {
-        Arc::from(self.module.resolve_raw_symbol(ident.name))
-    }
-
-    fn binding(&self, name: &str) -> Option<&WarningLexicalBinding> {
-        self.scopes.iter().rev().find_map(|scope| scope.get(name))
-    }
-
-    fn bind(&mut self, ident: rue_parser::ast::Ident, binding: WarningLexicalBinding) {
-        let name = self.name(ident);
-        self.scopes
-            .last_mut()
-            .expect("warning projection always has a lexical scope")
-            .insert(name, binding);
-    }
-
-    fn bind_local(&mut self, ident: rue_parser::ast::Ident) {
-        self.bind(ident, WarningLexicalBinding::Local);
-    }
-
-    fn add_path(&mut self, path: WarningStaticPath) {
-        if let Some(head) = path.into_head() {
-            self.heads.insert(head);
-        }
-    }
-
-    fn add_unqualified(&mut self, ident: rue_parser::ast::Ident) {
-        let name = self.name(ident);
-        match self.binding(&name) {
-            Some(WarningLexicalBinding::Local) => {}
-            Some(WarningLexicalBinding::StaticAlias(path)) => self.add_path(path.clone()),
-            None => self.add_path(WarningStaticPath {
-                import: None,
-                components: vec![name],
-            }),
-        }
-    }
-
-    fn add_qualified(&mut self, path: impl IntoIterator<Item = rue_parser::ast::Ident>) {
-        let mut names = path
-            .into_iter()
-            .map(|ident| self.name(ident))
-            .collect::<Vec<_>>();
-        let Some(first) = names.first().cloned() else {
-            return;
-        };
-        match self.binding(&first) {
-            Some(WarningLexicalBinding::Local) => {}
-            Some(WarningLexicalBinding::StaticAlias(alias)) => {
-                let mut alias = alias.clone();
-                alias.components.extend(names.drain(1..));
-                self.add_path(alias);
-            }
-            None => self.add_path(WarningStaticPath {
-                import: None,
-                components: names,
-            }),
-        }
-    }
-
-    fn visit_callable(
-        &mut self,
-        parameters: &[rue_parser::ast::Param],
-        result: Option<&rue_parser::ast::TypeExpr>,
-        body: &rue_parser::ast::Expr,
-        has_self: bool,
-    ) {
-        self.scopes.push(BTreeMap::new());
-        if has_self {
-            self.scopes
-                .last_mut()
-                .expect("scope was just pushed")
-                .insert(Arc::from("self"), WarningLexicalBinding::Local);
-        }
-        for parameter in parameters {
-            self.visit_type(&parameter.ty);
-            self.bind_local(parameter.name);
-        }
-        if let Some(result) = result {
-            self.visit_type(result);
-        }
-        self.visit_expr(body);
-        self.scopes.pop();
-    }
-
-    fn visit_args(&mut self, args: &[rue_parser::ast::CallArg]) {
-        for argument in args {
-            self.visit_expr(&argument.expr);
-        }
-    }
-
-    fn visit_array_length(&mut self, length: &rue_parser::ast::ArrayLength) {
-        match length {
-            rue_parser::ast::ArrayLength::Literal(_) | rue_parser::ast::ArrayLength::Named(_) => {}
-            rue_parser::ast::ArrayLength::Call { name, args } => {
-                self.add_unqualified(*name);
-                for argument in args {
-                    self.visit_array_length(argument);
-                }
-            }
-        }
-    }
-
-    fn visit_type(&mut self, ty: &rue_parser::ast::TypeExpr) {
-        use rue_parser::ast::TypeExpr;
-        match ty {
-            TypeExpr::Named(_)
-            | TypeExpr::Qualified { .. }
-            | TypeExpr::Unit(_)
-            | TypeExpr::Never(_)
-            | TypeExpr::StrFixed { .. }
-            | TypeExpr::IntArg { .. } => {}
-            TypeExpr::Array {
-                element, length, ..
-            } => {
-                self.visit_type(element);
-                self.visit_array_length(length);
-            }
-            TypeExpr::Slice { element, .. } => self.visit_type(element),
-            TypeExpr::AnonymousStruct {
-                fields, methods, ..
-            } => {
-                for field in fields {
-                    self.visit_type(&field.ty);
-                }
-                for method in methods {
-                    self.visit_callable(
-                        &method.params,
-                        method.return_type.as_ref(),
-                        &method.body,
-                        method.receiver.is_some(),
-                    );
-                }
-            }
-            TypeExpr::AnonymousEnum { variants, .. } => {
-                for variant in variants {
-                    for payload in &variant.payload {
-                        self.visit_type(payload);
-                    }
-                }
-            }
-            TypeExpr::PointerConst { pointee, .. } | TypeExpr::PointerMut { pointee, .. } => {
-                self.visit_type(pointee);
-            }
-            TypeExpr::TypeCall { name, args, .. } => {
-                self.add_unqualified(*name);
-                for argument in args {
-                    self.visit_type(argument);
-                }
-            }
-            TypeExpr::QualifiedTypeCall { segments, args, .. } => {
-                self.add_qualified(segments.iter().copied());
-                for argument in args {
-                    self.visit_type(argument);
-                }
-            }
-        }
-    }
-
-    fn static_path(&self, expr: &rue_parser::ast::Expr) -> Option<WarningStaticPath> {
-        use rue_parser::ast::Expr;
-        match expr {
-            Expr::Ident(ident) => {
-                let name = self.name(*ident);
-                match self.binding(&name) {
-                    Some(WarningLexicalBinding::Local) => None,
-                    Some(WarningLexicalBinding::StaticAlias(path)) => Some(path.clone()),
-                    None => Some(WarningStaticPath {
-                        import: None,
-                        components: vec![name],
-                    }),
-                }
-            }
-            Expr::Field(field) => {
-                let mut path = self.static_path(&field.base)?;
-                path.components.push(self.name(field.field));
-                Some(path)
-            }
-            _ => None,
-        }
-    }
-
-    fn resolved_import_path(&self, expr: &rue_parser::ast::Expr) -> Option<WarningStaticPath> {
-        let rue_parser::ast::Expr::IntrinsicCall(import) = expr else {
-            return None;
-        };
-        (self.module.resolve_raw_symbol(import.name.name) == "import")
-            .then(|| {
-                self.declaration_imports
-                    .get(&(import.span.start, import.span.end))
-            })
-            .flatten()
-            .cloned()
-            .map(|import| WarningStaticPath {
-                import: Some(import),
-                components: Vec::new(),
-            })
-    }
-
-    fn visit_block(&mut self, block: &rue_parser::ast::BlockExpr) {
-        use rue_parser::ast::{AssignTarget, LetPattern, Statement};
-        self.scopes.push(BTreeMap::new());
-        for statement in &block.statements {
-            match statement {
-                Statement::Let(binding) => {
-                    if let Some(ty) = &binding.ty {
-                        self.visit_type(ty);
-                    }
-                    self.visit_expr(&binding.init);
-                    if let LetPattern::Ident(ident) = binding.pattern {
-                        let alias = (!binding.is_mut)
-                            .then(|| {
-                                self.resolved_import_path(&binding.init)
-                                    .or_else(|| self.static_path(&binding.init))
-                            })
-                            .flatten();
-                        self.bind(
-                            ident,
-                            alias.map_or(
-                                WarningLexicalBinding::Local,
-                                WarningLexicalBinding::StaticAlias,
-                            ),
-                        );
-                    }
-                }
-                Statement::Assign(assignment) => {
-                    match &assignment.target {
-                        AssignTarget::Var(_) => {}
-                        AssignTarget::Field(field) => self.visit_expr(&field.base),
-                        AssignTarget::Index(index) => {
-                            self.visit_expr(&index.base);
-                            self.visit_expr(&index.index);
-                        }
-                    }
-                    self.visit_expr(&assignment.value);
-                }
-                Statement::Expr(expr) => self.visit_expr(expr),
-            }
-        }
-        self.visit_expr(&block.expr);
-        self.scopes.pop();
-    }
-
-    fn visit_expr(&mut self, expr: &rue_parser::ast::Expr) {
-        use rue_parser::ast::{Expr, IntrinsicArg, LetPattern, Pattern};
-        match expr {
-            Expr::Int(_)
-            | Expr::Float(_)
-            | Expr::String(_)
-            | Expr::Bool(_)
-            | Expr::Unit(_)
-            | Expr::Ident(_)
-            | Expr::Continue(_)
-            | Expr::SelfExpr(_)
-            | Expr::Error(_) => {}
-            Expr::TypeLit(value) => self.visit_type(&value.type_expr),
-            Expr::Binary(value) => {
-                self.visit_expr(&value.left);
-                self.visit_expr(&value.right);
-            }
-            Expr::Unary(value) => self.visit_expr(&value.operand),
-            Expr::Paren(value) => self.visit_expr(&value.inner),
-            Expr::Block(value) => self.visit_block(value),
-            Expr::If(value) => {
-                self.visit_expr(&value.cond);
-                self.visit_block(&value.then_block);
-                if let Some(block) = &value.else_block {
-                    self.visit_block(block);
-                }
-            }
-            Expr::Match(value) => {
-                self.visit_expr(&value.scrutinee);
-                for arm in &value.arms {
-                    self.scopes.push(BTreeMap::new());
-                    if let Pattern::Path(path) = &arm.pattern {
-                        if let Some(base) = &path.base {
-                            self.visit_expr(base);
-                        }
-                        if let Some(args) = &path.ctor_args {
-                            if let Some(base) = &path.base {
-                                if let Some(mut head) = self.static_path(base) {
-                                    head.components.push(self.name(path.type_name));
-                                    self.add_path(head);
-                                }
-                            } else {
-                                self.add_unqualified(path.type_name);
-                            }
-                            self.visit_args(args);
-                        }
-                        for binding in &path.bindings {
-                            self.bind_local(*binding);
-                        }
-                    }
-                    self.visit_expr(&arm.body);
-                    self.scopes.pop();
-                }
-            }
-            Expr::While(value) => {
-                self.visit_expr(&value.cond);
-                self.visit_block(&value.body);
-            }
-            Expr::Loop(value) => self.visit_block(&value.body),
-            Expr::For(value) => {
-                self.visit_expr(&value.iterable);
-                self.scopes.push(BTreeMap::new());
-                if let LetPattern::Ident(ident) = value.binder {
-                    self.bind_local(ident);
-                }
-                self.visit_block(&value.body);
-                self.scopes.pop();
-            }
-            Expr::Call(value) => {
-                self.add_unqualified(value.name);
-                self.visit_args(&value.args);
-            }
-            Expr::Break(value) => {
-                if let Some(value) = &value.value {
-                    self.visit_expr(value);
-                }
-            }
-            Expr::Return(value) => {
-                if let Some(value) = &value.value {
-                    self.visit_expr(value);
-                }
-            }
-            Expr::Yield(value) => self.visit_expr(&value.value),
-            Expr::StructLit(value) => {
-                if let Some(base) = &value.base {
-                    self.visit_expr(base);
-                }
-                if let Some(args) = &value.ctor_args {
-                    if let Some(base) = &value.base {
-                        if let Some(mut path) = self.static_path(base) {
-                            path.components.push(self.name(value.name));
-                            self.add_path(path);
-                        }
-                    } else {
-                        self.add_unqualified(value.name);
-                    }
-                    self.visit_args(args);
-                }
-                for field in &value.fields {
-                    self.visit_expr(&field.value);
-                }
-            }
-            Expr::Field(value) => self.visit_expr(&value.base),
-            Expr::MethodCall(value) => {
-                if let Some(mut path) = self.static_path(&value.receiver) {
-                    path.components.push(self.name(value.method));
-                    self.add_path(path);
-                }
-                self.visit_expr(&value.receiver);
-                self.visit_args(&value.args);
-            }
-            Expr::Try(value) => self.visit_expr(&value.operand),
-            Expr::IntrinsicCall(value) => {
-                for argument in &value.args {
-                    match argument {
-                        IntrinsicArg::Expr(expr) => self.visit_expr(expr),
-                        IntrinsicArg::Type(ty) => self.visit_type(ty),
-                    }
-                }
-            }
-            Expr::ArrayLit(value) => {
-                for element in &value.elements {
-                    self.visit_expr(element);
-                }
-                if let Some(repeat) = &value.repeat {
-                    self.visit_array_length(repeat);
-                }
-            }
-            Expr::Index(value) => {
-                self.visit_expr(&value.base);
-                self.visit_expr(&value.index);
-            }
-            Expr::Path(value) => {
-                if let Some(base) = &value.base {
-                    self.visit_expr(base);
-                }
-            }
-            Expr::Comptime(value) => self.visit_expr(&value.expr),
-            Expr::Checked(value) => self.visit_expr(&value.expr),
-        }
-    }
 }
 
 fn publish_body_plan_materialization_attribution(
@@ -10290,38 +9716,6 @@ impl rue_air::SemanticTypeSyntaxProvider<ModuleId, ModuleId, StableDefinitionKey
                         ),
                     );
                 }
-                if matches!(length, rue_air::SemanticValueSyntax::Rendered(_))
-                    && let Some((call, arguments)) = rue_air::parse_type_call_syntax(name)
-                {
-                    let resolved = rue_air::resolve_semantic_comptime_call(
-                        self,
-                        scope,
-                        &call,
-                        &arguments,
-                        rue_air::SemanticComptimeCallExpectation::Value,
-                    )
-                    .map_err(|error| match semantic_type_query_failure(error) {
-                        ResolveSemanticSignatureError::Abort(abort) => {
-                            rue_air::SemanticProviderError::Abort(abort)
-                        }
-                        ResolveSemanticSignatureError::Failure(failure) => {
-                            rue_air::SemanticProviderError::Failure(*failure)
-                        }
-                    })?;
-                    let rue_air::SemanticComptimeCallResult::Value(
-                        crate::durable_semantics::DurableConstValue::Integer(value),
-                    ) = resolved.result
-                    else {
-                        return Self::provider_failure(format!(
-                            "array length `{name}` is not an integer"
-                        ));
-                    };
-                    return u64::try_from(value).map(Some).map_err(|_| {
-                        Self::provider_failure_value(format!(
-                            "array length `{name}` is negative or too large"
-                        ))
-                    });
-                }
                 let Some(candidate) = self.candidate(scope, name, DefinitionKind::Const)? else {
                     return Self::provider_failure(format!("unknown array length `{name}`"));
                 };
@@ -12679,16 +12073,18 @@ impl RevisionedQueryDatabase {
                 )
                 .expect("the test BodyInput probe family has one canonical name")
         };
-        let parse_for_warning_syntax = parse_modules.clone();
-        let warning_body_syntax = runtime
+        let parse_for_warning_call_heads = parse_modules.clone();
+        let warning_call_head_projections = runtime
             .family_with_equality_and_evaluator(
-                "compiler.warning-body-syntax",
+                "compiler.warning-call-head-projection",
                 declaration_memo_retention,
-                |left: &WarningBodySyntaxValue, right: &WarningBodySyntaxValue| left == right,
-                move |context, _, key: &WarningBodySyntaxQueryKey| {
+                |left: &WarningCallHeadProjectionValue, right: &WarningCallHeadProjectionValue| {
+                    left == right
+                },
+                move |context, _, key: &WarningCallHeadProjectionQueryKey| {
                     let candidate = &key.0;
                     let parsed = context.query_registered(
-                        &parse_for_warning_syntax,
+                        &parse_for_warning_call_heads,
                         ModuleQueryKey(candidate.module.clone()),
                     )?;
                     let rue_query::QueryOutcome::Success(parsed) = parsed.outcome() else {
@@ -12697,62 +12093,29 @@ impl RevisionedQueryDatabase {
                     let module = match &parsed.result {
                         Ok(module) => module,
                         Err(_) => {
-                            return Ok(QueryOutput::success(WarningBodySyntaxValue::Failure(
-                                WarningBodyReferencesFailure::ParseRejected(
-                                    candidate.module.clone(),
+                            return Ok(QueryOutput::success(
+                                WarningCallHeadProjectionValue::Failure(
+                                    WarningBodyReferencesFailure::ParseRejected(
+                                        candidate.module.clone(),
+                                    ),
                                 ),
-                            ))
+                            )
                             .with_terminal_kind(QueryTerminalKind::Failure));
                         }
                     };
-                    let Some(locator) = module.definitions().declaration_locator(candidate) else {
-                        return Ok(QueryOutput::success(WarningBodySyntaxValue::Failure(
-                            WarningBodyReferencesFailure::ParserCapabilityMismatch(
-                                candidate.clone(),
-                            ),
-                        ))
-                        .with_terminal_kind(QueryTerminalKind::Failure));
-                    };
-                    let mut declaration_imports = BTreeMap::new();
-                    for (occurrence, site) in module
-                        .imports()
-                        .iter()
-                        .filter(|site| {
-                            site.source_offset() >= locator.declaration_span.start
-                                && site.source_end() <= locator.declaration_span.end
-                        })
-                        .enumerate()
-                    {
-                        let Ok(occurrence) = u32::try_from(occurrence) else {
-                            return Ok(QueryOutput::success(WarningBodySyntaxValue::Failure(
-                                WarningBodyReferencesFailure::ParserCapabilityMismatch(
-                                    candidate.clone(),
-                                ),
-                            ))
-                            .with_terminal_kind(QueryTerminalKind::Failure));
-                        };
-                        declaration_imports.insert(
-                            (site.source_offset(), site.source_end()),
-                            crate::declaration_candidate::DeclarationImportSiteKey {
-                                declaration: candidate.clone(),
-                                occurrence,
-                                specifier: Arc::from(site.specifier()),
+                    let value = module
+                        .declaration_warning_call_heads(candidate)
+                        .map_or_else(
+                            || {
+                                WarningCallHeadProjectionValue::Failure(
+                                    WarningBodyReferencesFailure::ParserCapabilityMismatch(
+                                        candidate.clone(),
+                                    ),
+                                )
                             },
+                            |heads| WarningCallHeadProjectionValue::Available(heads.clone()),
                         );
-                    }
-                    let (projected, _) =
-                        warning_static_call_heads(module, candidate, &declaration_imports);
-                    let value = projected.map_or_else(
-                        |_| {
-                            WarningBodySyntaxValue::Failure(
-                                WarningBodyReferencesFailure::ParserCapabilityMismatch(
-                                    candidate.clone(),
-                                ),
-                            )
-                        },
-                        WarningBodySyntaxValue::Available,
-                    );
-                    let kind = if matches!(value, WarningBodySyntaxValue::Available(_)) {
+                    let kind = if matches!(value, WarningCallHeadProjectionValue::Available(_)) {
                         QueryTerminalKind::Success
                     } else {
                         QueryTerminalKind::Failure
@@ -12760,10 +12123,10 @@ impl RevisionedQueryDatabase {
                     Ok(QueryOutput::success(value).with_terminal_kind(kind))
                 },
             )
-            .expect("the WarningBodySyntax family has one canonical name");
+            .expect("the WarningCallHeadProjection family has one canonical name");
         let classifications_for_warning_references = stable_declaration_classifications.clone();
         let shells_for_warning_references = declaration_shells.clone();
-        let syntax_for_warning_references = warning_body_syntax.clone();
+        let call_heads_for_warning_references = warning_call_head_projections.clone();
         let imports_for_warning_references = declaration_imports.clone();
         let warning_body_references = runtime
             .family_with_equality_and_evaluator(
@@ -12825,16 +12188,16 @@ impl RevisionedQueryDatabase {
                             Arc::from([]),
                         )));
                     }
-                    let syntax = context.query_registered(
-                        &syntax_for_warning_references,
-                        WarningBodySyntaxQueryKey(candidate.clone()),
+                    let projection = context.query_registered(
+                        &call_heads_for_warning_references,
+                        WarningCallHeadProjectionQueryKey(candidate.clone()),
                     )?;
-                    let rue_query::QueryOutcome::Success(syntax) = syntax.outcome() else {
-                        unreachable!("WarningBodySyntax publishes typed values")
+                    let rue_query::QueryOutcome::Success(projection) = projection.outcome() else {
+                        unreachable!("WarningCallHeadProjection publishes typed values")
                     };
-                    let heads = match syntax {
-                        WarningBodySyntaxValue::Available(heads) => heads,
-                        WarningBodySyntaxValue::Failure(failure) => {
+                    let heads = match projection {
+                        WarningCallHeadProjectionValue::Available(heads) => heads,
+                        WarningCallHeadProjectionValue::Failure(failure) => {
                             return Ok(QueryOutput::success(WarningBodyReferencesValue::Failure(
                                 failure.clone(),
                             ))
@@ -12845,7 +12208,13 @@ impl RevisionedQueryDatabase {
                     for head in heads.iter() {
                         let module = match &head.import {
                             None => None,
-                            Some(import_key) => {
+                            Some(import) => {
+                                let import_key =
+                                    crate::declaration_candidate::DeclarationImportSiteKey {
+                                        declaration: candidate.clone(),
+                                        occurrence: import.occurrence,
+                                        specifier: import.specifier.clone(),
+                                    };
                                 let resolved = context.query_registered(
                                     &imports_for_warning_references,
                                     DeclarationImportQueryKey(import_key.clone()),
@@ -26757,21 +26126,37 @@ fn main() -> i32 {
     }
 
     #[test]
-    fn warning_body_selection_is_logarithmic_and_fail_closed() {
+    fn warning_body_projection_is_candidate_exact_and_fail_closed() {
         use crate::declaration_candidate::DeclarationCandidateCategory as Category;
 
         let mut text = String::new();
         for index in 0..128 {
             text.push_str(&format!("fn unrelated_{index}() -> i32 {{ 0 }}\n"));
         }
-        text.push_str("fn target_free() -> i32 { 0 }\n");
+        text.push_str(
+            "fn target_free() -> i32 {\n\
+                 let local = 0;\n\
+                 target_direct();\n\
+                 local();\n\
+                 let helper = @import(\"helper.rue\");\n\
+                 helper.target_imported()\n\
+             }\n",
+        );
+        text.push_str(
+            "fn target_nested() -> type {\n\
+                 struct { fn hidden() -> i32 { nested_direct() } }\n\
+             }\n",
+        );
+        text.push_str("fn target_type(value: Factory(i32)) -> Result(i32) { value }\n");
         text.push_str("@copy struct Bag { value: i32,\n");
         for index in 0..128 {
             text.push_str(&format!("fn unrelated_member_{index}() -> i32 {{ 0 }}\n"));
         }
-        text.push_str("fn target_associated() -> i32 { 0 }\n");
-        text.push_str("fn target_method(borrow self) -> i32 { self.value }\n}\n");
-        text.push_str("drop fn Bag(self) {}\n");
+        text.push_str("fn target_associated() -> i32 { target_associated_direct() }\n");
+        text.push_str(
+            "fn target_method(borrow self) -> i32 { target_method_direct(); self.value }\n}\n",
+        );
+        text.push_str("drop fn Bag(self) { target_drop_direct(); }\n");
 
         let source = source_snapshot(&[(1, "/main.rue", "main.rue", &text)], 1);
         let module = ModuleId::from_logical_path("main.rue").unwrap();
@@ -26792,35 +26177,58 @@ fn main() -> i32 {
             }) => parsed,
             other => panic!("expected parsed module, got {other:?}"),
         };
-        let empty_imports = std::collections::BTreeMap::new();
-
-        for (category, name, expects_member_search) in [
-            (Category::Function, "target_free", false),
-            (Category::AssociatedFunction, "target_associated", true),
-            (Category::Method, "target_method", true),
-            (Category::Destructor, "Bag", false),
+        for (category, name, expected) in [
+            (
+                Category::Function,
+                "target_free",
+                vec![
+                    (None, vec!["target_direct"]),
+                    (Some("helper.rue"), vec!["target_imported"]),
+                ],
+            ),
+            (
+                Category::AssociatedFunction,
+                "target_associated",
+                vec![(None, vec!["target_associated_direct"])],
+            ),
+            (
+                Category::Method,
+                "target_method",
+                vec![(None, vec!["target_method_direct"])],
+            ),
+            (
+                Category::Destructor,
+                "Bag",
+                vec![(None, vec!["target_drop_direct"])],
+            ),
+            (
+                Category::Function,
+                "target_nested",
+                vec![(None, vec!["nested_direct"])],
+            ),
+            (
+                Category::Function,
+                "target_type",
+                vec![(None, vec!["Factory"]), (None, vec!["Result"])],
+            ),
         ] {
             let candidate = declaration_candidate(&database, revision, &module, category, name);
-            let (projected, work) = warning_static_call_heads(parsed, &candidate, &empty_imports);
-            assert!(
-                projected.is_ok(),
-                "{category:?} selection failed: {projected:?}"
-            );
-            assert!(
-                work.top_level_items_examined <= 10,
-                "{category:?} inspected {} of {} top-level items",
-                work.top_level_items_examined,
-                parsed.ast().items.len()
-            );
-            if expects_member_search {
-                assert!(
-                    work.member_items_examined <= 10,
-                    "{category:?} inspected {} member items",
-                    work.member_items_examined
-                );
-            } else {
-                assert_eq!(work.member_items_examined, 0);
-            }
+            let projected = parsed
+                .declaration_warning_call_heads(&candidate)
+                .unwrap_or_else(|| panic!("{category:?} has no parser-owned warning projection"));
+            let actual = projected
+                .iter()
+                .map(|head| {
+                    (
+                        head.import.as_ref().map(|import| import.specifier.as_ref()),
+                        head.components
+                            .iter()
+                            .map(|component| component.as_ref())
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(actual, expected, "{category:?} projected wrong call heads");
         }
 
         let mut mismatched = declaration_candidate(
@@ -26831,12 +26239,10 @@ fn main() -> i32 {
             "target_free",
         );
         mismatched.name = Arc::from("not-target-free");
-        let (projected, work) = warning_static_call_heads(parsed, &mismatched, &empty_imports);
         assert!(
-            projected.is_err(),
+            parsed.declaration_warning_call_heads(&mismatched).is_none(),
             "a mismatched exact key must fail closed"
         );
-        assert_eq!(work, WarningBodySelectionWork::default());
     }
 
     fn request_semantic_nucleus(

--- a/docs/notes/adr-0071-phase-3-frontend-phase-integrity.md
+++ b/docs/notes/adr-0071-phase-3-frontend-phase-integrity.md
@@ -15,8 +15,8 @@ marked complete describe paths already removed by the bounded Phase 3 slices.
 | Constants | The semantic-nucleus const evaluator directly decodes the exact `compiler.declaration-body-plan-artifacts` terminal into its request-local semantic evaluator | Deletes fake-const source reconstruction, lexing/parsing, duplicate import discovery, cloned AST evaluation, and a second anonymous-anchor transport | Complete: constant evaluation consumes the declaration artifact directly; no production call or definition of `parse_semantic_const`, and the evaluator resolves packed ordinal spellings without reconstructing an interner |
 | Well-known option body scan | `PackedValidatedRir::fallible_intrinsics`; consumed by `compiler.body-toolchain-demands` through `DeclarationBodyPlanArtifacts` | Derives the typed five-kind set during the one canonical packed-RIR traversal; production performs no second lexer pass over retained body text | Complete: the packed header owns the stable typed set and the old lexical scanner remains only as an independent `cfg(test)` oracle |
 | Structured type syntax | Candidate RIR owns one declaration-local `RirTypeSyntaxArena<Spur>` projected directly from parser `TypeExpr`; the canonical packed declaration artifact stores that arena in its versioned type section, and ordinary, specialized, anonymous, constant, comptime, and canonical-RIR consumers decode the same nodes | Deletes `AstGen` compound-type rendering/interning and the RIR-to-sema string grammar for arrays, pointers, calls, qualified paths, anonymous aggregates, and integer/value arguments | Complete for every RIR type operand: instruction and payload schemas carry `RirTypeSyntaxRef`, packed encode/decode is exhaustive and fail-closed, semantic consumers traverse structured nodes, and source inventory forbids a rendered-type adapter at the RIR intake. Simple leaf-name lookup plus diagnostic or `--emit rir` formatting remain presentation policy rather than a semantic transport |
-| Semantic-nucleus type tokenization | `SemanticNucleusTypeProvider` in `crates/rue-compiler/src/revisioned_query_database.rs`, including the handwritten split/decomposition route around lines 10054–10129 and the `parse_type_call_syntax` route beginning around line 10551 | A second handwritten type grammar reconstructs declaration types while binding semantic signatures and constants | The provider consumes the artifact's dense type-syntax nodes; neither the handwritten tokenizer nor a production call to `parse_type_call_syntax` remains in the provider |
-| Warning-only static-call discovery | `warning_static_call_heads` and `WarningStaticCallCollector` in `revisioned_query_database.rs` independently walk canonical AST bodies, implement lexical scopes and static aliases/import paths, and discover value/type call heads for warning reachability | Maintains a peer body-discovery and partial name-resolution path even though it does not reparse text | The canonical candidate/artifact boundary publishes one structured body-reference projection; warning reachability is a thin consumer and the peer collector/scoping resolver is deleted |
+| Semantic-nucleus type tokenization | `SemanticNucleusTypeProvider` consumes the structured type/value nodes projected from the exact parsed declaration and packed candidate artifact | Deletes the last provider-local `parse_type_call_syntax` branch that could reinterpret a rendered array-length value with a second handwritten grammar | Complete: provider inventory forbids the rendered parser, lexer/parser entry points, and split/trim grammars; comptime type/value calls resolve only from typed nodes |
+| Warning-only static-call discovery | The parser-owned module projection collects imports and declaration-local warning call/type heads during one syntax traversal; `compiler.warning-call-head-projection` is an O(1) candidate projection used solely to retain body-local stamps, and `compiler.warning-body-references` resolves its indexed import occurrences | Deletes the independent `warning_static_call_heads` / `WarningStaticCallCollector` AST walk and its peer lexical-scope/name-resolution implementation | Complete: warning queries contain no AST traversal, raw-body request, RIR/AstGen request, or fallback; shadowing, aliases, imports, named methods, nested anonymous methods, type calls, sibling invalidation, and exact failure behavior are covered |
 
 ## Implementation checkpoint: parser-owned signature type syntax
 
@@ -32,12 +32,11 @@ and every parser-legal annotation shape have direct query tests. A source
 inventory fails if either the projection or semantic-signature resolver regains
 a lexer, parser, split/trim grammar, rendered-type adapter, `Span`, or `FileId`.
 
-This checkpoint deliberately does **not** claim the full structured-type row.
-Candidate RIR and the request-local rue-air body adapter still intern rendered
-compound type spellings, and the legacy semantic type resolver remains for those
-body/constant RIR slots. The next structured-type slice extends the same arena
-through candidate RIR and replaces those slots; only then can the old string
-resolver and `parse_type_call_syntax` branch be deleted globally.
+This checkpoint by itself did **not** claim the full structured-type row.
+The later RIR structured-type cutover extends the same arena through candidate
+RIR and replaces the body/constant slots, while the final frontend-integrity
+closure below deletes the remaining provider-local `parse_type_call_syntax`
+branch.
 
 The one-worker frozen Lattice measurement isolates why this slice should improve
 time. The parent rebuilt semantic type structure from compact signature text and
@@ -304,6 +303,61 @@ externally and +221,184 bytes in the compiler report (absolute medians
 movement is reported as measurement noise, not a memory improvement; the
 wall-time claim rests on the repeatable phase-local reductions and the 20/24
 paired root wins.
+
+## Implementation checkpoint: parser-owned warning projection closure
+
+The parser's one module syntax projection now discovers declaration-local
+warning call/type heads while it discovers imports. Lexical locals and static
+aliases use parser-local `Spur` identities during that traversal; only the
+sorted, deduplicated retained heads are converted to owned spellings. Imported
+heads carry the exact declaration-local import occurrence and specifier, so
+`compiler.warning-body-references` continues to resolve imports through the
+canonical declaration-import query rather than performing path resolution
+itself.
+
+A thin candidate-keyed `compiler.warning-call-head-projection` terminal performs
+one O(1) lookup into the parsed definition index. It retains no AST handle and
+does no syntax walk. The terminal is intentionally kept because its exact
+equality preserves body-local warning stamps when a sibling body changes; the
+downstream warning-reference query therefore does not need a broad module stamp
+or a second AST pass. The former `warning_static_call_heads`, candidate span
+search, `WarningStaticCallCollector`, and peer scope/alias resolver are deleted.
+
+The semantic-nucleus provider also no longer interprets a rendered array-length
+value with `parse_type_call_syntax`. Structured comptime calls arrive through
+the declaration/candidate type-syntax arenas; simple names continue through
+ordinary substitution and const lookup. Source inventory forbids the removed
+parser branch and every lexer/parser or split/trim grammar inside that provider.
+
+The expected critical-path improvement is modest: the replacement removes one
+whole declaration-body AST traversal and temporary scope/name allocations, but
+it preserves the small candidate projection terminal required for exact
+invalidation and it adds warning-head collection to the already-required parse
+pass. The rendered-type deletion is a correctness/deletion proof and was not a
+reachable production cost.
+
+The exact-parent gate used one warmup followed by twelve order-balanced
+release-thin-LTO x86-64 pairs with one query worker. Median compiler-root time
+was 664.504 ms for the parent and 664.125 ms for the replacement; the paired
+median was +1.850 ms with a 5.252 ms median absolute deviation, and 5 of 12
+prototype runs were faster. That is recorded as no measurable wall-time change,
+not a speedup. The displaced work is nevertheless observable: all twelve
+prototype runs retired fewer instructions, with a paired median reduction of
+15,800,058, while query claims, memo nodes, and memo display-identity bytes were
+exactly unchanged. Source discovery and parsing increased by a paired median
+1.138 ms because it now owns the projection; the independent later warning AST
+walk and its attribution disappeared.
+
+Peak RSS was allocator-bimodal on this interactive macOS host. External paired
+medians moved +6,914,048 bytes with a 10,002,432-byte paired MAD, and exactly six
+of twelve prototype runs used less memory. A separate counting-allocator run
+showed the replacement made 8,607 fewer allocations and requested 5,085,156
+fewer bytes. The RSS result is therefore recorded as inconclusive/no claimed
+memory improvement rather than as a stable ownership regression. All 24 native
+outputs were 1,662,976 bytes with SHA-256
+`45784ce7c7cde992d7ea820912ca1692c05dc7582a367210d017b3765a9a89e7`.
+Measurement artifacts are in
+`/private/tmp/rue-phase-warning-paired.gsJc0W` on the measuring host.
 
 ## Retained declaration artifact contract
 


### PR DESCRIPTION
## Summary

- collect unused-function warning call and type heads during the parser-owned module projection
- delete the independent warning-only AST and lexical-scope walker
- retain a thin O(1) candidate projection so unrelated sibling edits keep warning, body, CFG, and codegen stamps green
- delete the remaining semantic-nucleus rendered array-length parser branch

## Performance rationale

This removes a duplicate traversal of every reached body and its temporary lexical allocations. The canonical parser traversal now collects the same warning projection, so replacement work remains and the expected wall-time gain is modest. Query claims and nodes are unchanged because the thin candidate terminal preserves exact invalidation.

The frozen Lattice workload has 161 modules, 20,451 source lines, 160,152 tokens, 1,221 functions, and 831,280 source bytes. In 12 order-balanced release-thin-LTO x86-64 pairs with one query worker:

- root median: 664.504 ms baseline to 664.125 ms prototype
- paired root effect: +1.850 ms, MAD 5.252 ms, 5 of 12 prototype runs faster; no measurable wall-time change
- retired instructions: all 12 prototype runs lower, paired median -15.8 million
- allocation work: -8,607 allocations and -5.09 MB requested bytes
- RSS: inconclusive within observed allocator bimodality
- query claims/nodes/display bytes: unchanged

All 24 outputs are byte-identical: 1,662,976 bytes, SHA-256 45784ce7c7cde992d7ea820912ca1692c05dc7582a367210d017b3765a9a89e7.

## Validation

- scripts/rue fmt
- scripts/rue quick: 31/31 targets, compiler 880 passed and 6 ignored
- scripts/rue premerge: 159/159 targets

Relates to RUE-1510. The issue remains open for profile-driven semantic/CFG work and the hosted 500 ms / 256 MiB acceptance gate.