### PR TITLE
RUE-1479, RUE-1501: unstable-only import-discovery facade; one commit predicate

### DIFF
--- a/crates/rue-bench/src/incremental.rs
+++ b/crates/rue-bench/src/incremental.rs
@@ -21,7 +21,7 @@ use rue_perf_schema::{
     ExpectedEditOutcome, FailureStage, OptimizationSetting, OracleComparison, OutcomeIdentity,
     OutcomeKind, PhaseWork, RetainedGauges, RetentionSequence, RetentionStep, RetentionStepOutcome,
     SourceShape, StructuralWork, TransformationIdentity, ValidationWork as ReportValidationWork,
-    WorkerMode, canonical_json, derive_edit_report, render_edit_report_markdown,
+    WorkerMode, canonical_json, derive_edit_report, is_commit, render_edit_report_markdown,
     validate_edit_report,
 };
 use serde::Deserialize;
@@ -626,7 +626,7 @@ fn parse_args() -> Result<IncrementalOptions, String> {
         }
     }
     let commit = commit.ok_or("incremental requires --commit <revision>")?;
-    if commit.len() != 40 || !commit.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+    if !is_commit(&commit) {
         return Err("incremental commit must be a 40-character hexadecimal hash".into());
     }
     let repo_root = repo_root.unwrap_or_else(|| PathBuf::from("."));

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -1175,12 +1175,6 @@ fn root_export_metadata(owner: &str, symbol: &str) -> (&'static str, &'static st
             _ => panic!("unclassified dependency facade export: {symbol}"),
         },
         "import_discovery" => match symbol {
-            "AcceptedImportSource"
-            | "ImportDiscoveryPlan"
-            | "ImportDiscoveryRequest"
-            | "ImportObservation"
-            | "ImportObservationLedger"
-            | "ImportObservationStatus" => ("compatibility-boundary", "legacy-embedders"),
             "AcceptedReadManifest"
             | "AcceptedReadManifestEntry"
             | "FileMetadataFingerprint"
@@ -1188,6 +1182,10 @@ fn root_export_metadata(owner: &str, symbol: &str) -> (&'static str, &'static st
             | "ImportDiscoveryContext"
             | "ImportOccurrenceKey"
             | "PhysicalFileIdentity" => ("dependency-artifact", "source-loaders+embedders"),
+            // The host discovery-protocol records (AcceptedImportSource,
+            // ImportDiscoveryPlan/Request, ImportObservation*) live under
+            // `unstable` with the protocol functions that consume them. Any
+            // return to the stable root is unclassified and fails here.
             _ => panic!("unclassified import-discovery facade export: {symbol}"),
         },
         "import_graph" => match symbol {
@@ -1314,13 +1312,9 @@ fn session_method_metadata(
     } else {
         match symbol {
             "new" | "update" => "session-operation",
-            "import_discovery_plan" | "stage_import_discovery" | "close_import_discovery" => {
-                return ("stable", "compatibility-boundary", "legacy-embedders");
-            }
             "published"
             | "committed_import_graph"
             | "import_diagnostics"
-            | "import_graph"
             | "rir"
             | "semantic"
             | "executable" => "artifact-query",
@@ -1574,6 +1568,22 @@ fn semantic_api_inventory_matches_every_root_export_and_session_signature() {
          classify the owner, stability, category, and approved consumer in \
          supported_api_inventory.rs\n\nactual inventory:\n{actual}"
     );
+}
+
+#[test]
+fn stable_facade_carries_no_compatibility_boundary_classifications() {
+    // RUE-1479 removed the import-discovery compatibility facade. The
+    // classifiers no longer produce these classes, so any reintroduction —
+    // through a classifier arm or an approved-inventory line — fails here.
+    let actual = render_semantic_api_inventory(include_str!("lib.rs"), PRODUCTION_MODULES);
+    for inventory in [actual.as_str(), crate::supported_api_inventory::APPROVED] {
+        for forbidden in ["compatibility-boundary", "legacy-embedders"] {
+            assert!(
+                !inventory.contains(forbidden),
+                "a stable compatibility classification returned to the facade inventory: {forbidden}"
+            );
+        }
+    }
 }
 
 #[test]
@@ -1903,10 +1913,10 @@ fn unstable_views_do_not_alias_query_engine_records() {
         reexports,
         [
             "pubusecrate::diagnostic::{ColorChoice,DiagnosticFormatter,JsonDiagnostic,JsonDiagnosticFormatter,JsonSpan,JsonSuggestion,MultiFileFormatter,MultiFileJsonFormatter,SourceInfo,};",
-            "pubusecrate::import_discovery::{DiscoverySourceAssembler,ImportDemandFrontier,ImportDemandMode,ImportDemandRoots,ImportInputRevision,};",
+            "pubusecrate::import_discovery::{AcceptedImportSource,DiscoverySourceAssembler,ImportDemandFrontier,ImportDemandMode,ImportDemandRoots,ImportDiscoveryPlan,ImportDiscoveryRequest,ImportInputRevision,ImportObservation,ImportObservationLedger,ImportObservationStatus,};",
             "pubusecrate::session::{ClosedDiscoveryContinuation,RootedCfgOutput,RootedCfgUnit,RootedParkOutcome,TrustedSuccessorDelta,};",
         ],
-        "unstable may reexport only reviewed presentation, source-assembly, and Phase-2 demand helpers"
+        "unstable may reexport only reviewed presentation, source-assembly, and host discovery-protocol records"
     );
 
     let facade = include_str!("lib.rs");

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -2778,12 +2778,6 @@ mod tests {
                 .expect("closed-valid revision retains graph"),
             &session.committed_import_graph().unwrap()
         ));
-        assert!(Arc::ptr_eq(
-            committed
-                .graph()
-                .expect("closed-valid revision retains graph"),
-            &session.import_graph(Some("/sdk")).unwrap()
-        ));
         let last_good = session
             .last_good_discovery()
             .unwrap()

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -110,13 +110,17 @@ pub use dependency_envelope::{
 pub(crate) use diagnostic_attempt_store::FrontendDiagnosticIdentity;
 pub use diagnostic_attempt_store::{DiagnosticStage, FrontendDiagnosticSnapshot};
 pub use import_discovery::{
-    AcceptedImportSource, AcceptedReadManifest, AcceptedReadManifestEntry, FileMetadataFingerprint,
-    ImportCandidateRole, ImportDiscoveryContext, ImportDiscoveryPlan, ImportDiscoveryRequest,
-    ImportObservation, ImportObservationLedger, ImportObservationStatus, ImportOccurrenceKey,
-    PhysicalFileIdentity,
+    AcceptedReadManifest, AcceptedReadManifestEntry, FileMetadataFingerprint, ImportCandidateRole,
+    ImportDiscoveryContext, ImportOccurrenceKey, PhysicalFileIdentity,
 };
+// Host discovery-protocol records are published through `unstable` only; the
+// crate-local paths keep the session and its tests on one spelling.
+#[cfg(test)]
+pub(crate) use import_discovery::AcceptedImportSource;
 pub(crate) use import_discovery::{
-    ImportDemandFrontier, ImportDemandMode, ImportDemandRoots, ImportInputRevision,
+    ImportDemandFrontier, ImportDemandMode, ImportDemandRoots, ImportDiscoveryPlan,
+    ImportDiscoveryRequest, ImportInputRevision, ImportObservation, ImportObservationLedger,
+    ImportObservationStatus,
 };
 pub use import_graph::{
     CanonicalImportCycle, CanonicalImportGraph, CanonicalImportGraphProblem,

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -153,9 +153,6 @@ trait SessionQueryMetricsFamily {
     fn projection(work: &mut CompilerSessionWork) -> &mut FrontendQueryWork;
 }
 
-#[derive(Debug)]
-struct ImportsMetricsQuery;
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct AttemptId(pub(crate) u64);
 
@@ -235,7 +232,7 @@ fn project_lifecycle(work: &mut FrontendQueryWork, attempt: &dyn AttemptView) {
     work.calls += 1;
     match attempt.execution() {
         QueryAttemptExecution::Computed => work.executions += 1,
-        QueryAttemptExecution::Reused | QueryAttemptExecution::Adopted => work.reuses += 1,
+        QueryAttemptExecution::Reused => work.reuses += 1,
         QueryAttemptExecution::Rejected => {}
     }
 }
@@ -1402,7 +1399,6 @@ macro_rules! session_query_metrics_family {
     };
 }
 
-session_query_metrics_family!(ImportsMetricsQuery, "imports", imports);
 session_query_metrics_family!(
     ImportDiagnosticQuery,
     "import-diagnostics",
@@ -1646,8 +1642,7 @@ impl CompilerSession {
         payload: Box<dyn std::any::Any + Send>,
     ) -> ! {
         match guard.family {
-            "import-diagnostics" | "merge" | "rir" | "semantic" | "definitions" | "imports"
-            | "parse" => {}
+            "import-diagnostics" | "merge" | "rir" | "semantic" | "definitions" | "parse" => {}
             family => unreachable!("unknown query guard family {family}"),
         }
         self.metrics.synchronize();
@@ -4084,89 +4079,6 @@ impl CompilerSession {
                 diagnostics,
             },
         }
-    }
-
-    /// Return the graph adopted by import discovery.
-    ///
-    /// Import-free direct sessions synthesize the uniquely valid empty graph;
-    /// import-bearing sessions never reconstruct resolution from loaded paths.
-    pub fn import_graph(
-        &mut self,
-        std_dir: Option<&str>,
-    ) -> Result<Arc<CanonicalImportGraphOutput>, CompileErrors> {
-        let mut guard = self.metrics.begin::<ImportsMetricsQuery>();
-        let mut execution = QueryAttemptExecution::Rejected;
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            self.import_graph_attempt(std_dir, &mut guard, &mut execution)
-        }));
-        let result = match result {
-            Ok(result) => result,
-            Err(payload) => self.resume_canceled_query(&mut guard, payload),
-        };
-        if execution == QueryAttemptExecution::Reused {
-            execution = QueryAttemptExecution::Adopted;
-        }
-        guard.finish(execution, None, &result, QueryStructuralWork::None);
-        self.metrics.synchronize();
-        result
-    }
-
-    fn import_graph_attempt(
-        &mut self,
-        std_dir: Option<&str>,
-        guard: &mut QueryComputationGuard,
-        execution: &mut QueryAttemptExecution,
-    ) -> Result<Arc<CanonicalImportGraphOutput>, CompileErrors> {
-        self.require_closed_discovery()?;
-        if let Some(committed) = self.committed_import_discovery_artifact() {
-            let graph = committed
-                .graph()
-                .expect("closed-valid discovery revisions retain their canonical graph");
-            if graph.input().std_dir.as_deref() != std_dir {
-                return Err(CompileErrors::from(CompileError::without_span(
-                    ErrorKind::InvalidCompilerInput(
-                        "the requested standard-library context differs from the committed import discovery revision"
-                            .into(),
-                    ),
-                )));
-            }
-            *execution = QueryAttemptExecution::Reused;
-            return Ok(graph.clone());
-        }
-        let parsed = self.published.clone().ok_or_else(no_published_program)?;
-        if !parsed.import_directives().is_empty() {
-            return Err(CompileErrors::from(CompileError::without_span(
-                ErrorKind::InvalidCompilerInput(
-                    "import-bearing revisions require a committed discovery graph".into(),
-                ),
-            )));
-        }
-        let resolution = ModuleResolutionInputs::new(
-            parsed.root().clone(),
-            parsed
-                .modules()
-                .iter()
-                .map(|module| crate::ModuleResolutionInput {
-                    module: module.module_id().clone(),
-                    physical_path: Arc::from(module.physical_path()),
-                })
-                .collect(),
-        )
-        .expect("published parsed modules have validated resolution inputs");
-        let input = ImportGraphInputDescriptor {
-            sources: parsed.source_revision().clone(),
-            resolution,
-            std_dir: std_dir.map(Arc::from),
-        };
-        *execution = QueryAttemptExecution::Computed;
-        guard.started();
-        let graph = crate::import_graph::import_free_canonical_graph(parsed.as_ref())?;
-        let validation = validate_canonical_import_graph(&graph, &input.resolution);
-        Ok(Arc::new(CanonicalImportGraphOutput {
-            input,
-            graph,
-            validation,
-        }))
     }
 
     pub(crate) fn merge(&mut self) -> Result<Arc<CanonicalMergedProgram>, CompileErrors> {
@@ -9847,13 +9759,12 @@ fn main() -> i32 { 0 }
         );
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        let error = session.import_graph(None).unwrap_err();
+        let error = session.committed_import_graph().unwrap_err();
         assert!(
             error
                 .to_string()
-                .contains("require a committed discovery graph")
+                .contains("no closed-valid import discovery revision is committed")
         );
-        assert_eq!(session.work().imports.executions, 0);
     }
 
     #[test]
@@ -9872,8 +9783,7 @@ fn main() -> i32 { 0 }
         );
         let mut session = CompilerSession::new();
         publish_with_test_imports(&mut session, &source);
-        assert!(session.import_graph(None).is_ok());
-        assert_eq!(session.work().imports.executions, 0);
+        assert!(session.committed_import_graph().is_ok());
     }
 
     #[test]
@@ -9881,8 +9791,11 @@ fn main() -> i32 { 0 }
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<CanonicalImportGraphOutput>();
         let mut session = CompilerSession::new();
-        session.update(&base()).into_result().unwrap();
-        let graph = session.import_graph(None).unwrap();
+        crate::test_support::TestDiscoveryHost::new(&base())
+            .unwrap()
+            .drive(&mut session)
+            .unwrap();
+        let graph = session.committed_import_graph().unwrap();
         assert!(graph.graph().records().is_empty());
         std::thread::spawn(move || assert!(graph.validation().is_valid()))
             .join()

--- a/crates/rue-compiler/src/supported_api_inventory.rs
+++ b/crates/rue-compiler/src/supported_api_inventory.rs
@@ -8,7 +8,6 @@
 pub(crate) const APPROVED: &str = r#"stable|CompilerSession|artifact-query|embedders|committed_import_graph|pub fn committed_import_graph(&self)->Result<Arc<CanonicalImportGraphOutput>,CompileErrors>
 stable|CompilerSession|artifact-query|embedders|executable|pub fn executable(&mut self,options:&CompileOptions)->MultiErrorResult<CompileOutput>
 stable|CompilerSession|artifact-query|embedders|import_diagnostics|pub fn import_diagnostics(&mut self)->Result<Arc<FrontendDiagnosticSnapshot>,CompileErrors>
-stable|CompilerSession|artifact-query|embedders|import_graph|pub fn import_graph(&mut self,std_dir:Option<&str>,)->Result<Arc<CanonicalImportGraphOutput>,CompileErrors>
 stable|CompilerSession|artifact-query|embedders|published|pub fn published(&self)->Option<crate::SyntaxView>
 stable|CompilerSession|artifact-query|embedders|rir|pub fn rir(&mut self)->Result<Arc<crate::RirView>,CompileErrors>
 stable|CompilerSession|diagnostic-query|embedders|last_good_semantic_diagnostics|pub fn last_good_semantic_diagnostics(&self)->Option<&Arc<FrontendDiagnosticSnapshot>>
@@ -38,12 +37,6 @@ stable|dependency_envelope|dependency-artifact|source-loaders+embedders|Dependen
 stable|dependency_envelope|dependency-artifact|source-loaders+embedders|DependencyTopologyRecord|pub use dependency_envelope::DependencyTopologyRecord
 stable|diagnostic_attempt_store|diagnostic|cli+embedders|DiagnosticStage|pub use diagnostic_attempt_store::DiagnosticStage
 stable|diagnostic_attempt_store|diagnostic|cli+embedders|FrontendDiagnosticSnapshot|pub use diagnostic_attempt_store::FrontendDiagnosticSnapshot
-stable|import_discovery|compatibility-boundary|legacy-embedders|AcceptedImportSource|pub use import_discovery::AcceptedImportSource
-stable|import_discovery|compatibility-boundary|legacy-embedders|ImportDiscoveryPlan|pub use import_discovery::ImportDiscoveryPlan
-stable|import_discovery|compatibility-boundary|legacy-embedders|ImportDiscoveryRequest|pub use import_discovery::ImportDiscoveryRequest
-stable|import_discovery|compatibility-boundary|legacy-embedders|ImportObservation|pub use import_discovery::ImportObservation
-stable|import_discovery|compatibility-boundary|legacy-embedders|ImportObservationLedger|pub use import_discovery::ImportObservationLedger
-stable|import_discovery|compatibility-boundary|legacy-embedders|ImportObservationStatus|pub use import_discovery::ImportObservationStatus
 stable|import_discovery|dependency-artifact|source-loaders+embedders|AcceptedReadManifest|pub use import_discovery::AcceptedReadManifest
 stable|import_discovery|dependency-artifact|source-loaders+embedders|AcceptedReadManifestEntry|pub use import_discovery::AcceptedReadManifestEntry
 stable|import_discovery|dependency-artifact|source-loaders+embedders|FileMetadataFingerprint|pub use import_discovery::FileMetadataFingerprint

--- a/crates/rue-compiler/src/typed_query_store.rs
+++ b/crates/rue-compiler/src/typed_query_store.rs
@@ -37,7 +37,6 @@ pub(crate) trait TypedQueryFamily: std::fmt::Debug + Send + Sync {
 pub(crate) enum AttemptExecution {
     Computed,
     Reused,
-    Adopted,
     Rejected,
 }
 

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -12,8 +12,9 @@ pub use crate::diagnostic::{
     JsonSuggestion, MultiFileFormatter, MultiFileJsonFormatter, SourceInfo,
 };
 pub use crate::import_discovery::{
-    DiscoverySourceAssembler, ImportDemandFrontier, ImportDemandMode, ImportDemandRoots,
-    ImportInputRevision,
+    AcceptedImportSource, DiscoverySourceAssembler, ImportDemandFrontier, ImportDemandMode,
+    ImportDemandRoots, ImportDiscoveryPlan, ImportDiscoveryRequest, ImportInputRevision,
+    ImportObservation, ImportObservationLedger, ImportObservationStatus,
 };
 
 /// Begin a fresh external-input observation generation.

--- a/crates/rue-compiler/tests/differential_oracle.rs
+++ b/crates/rue-compiler/tests/differential_oracle.rs
@@ -12,17 +12,17 @@ use std::{collections::HashMap, fmt::Write as _, sync::Arc};
 
 use rue_cfg::OptLevel;
 use rue_compiler::unstable::{
-    DifferentialOracleFault, DiscoverySourceAssembler, ImportDemandMode, PresentationRequest,
-    PresentationStage, begin_import_input_request, close_import_input_request, discovery_attempt,
-    import_demand_frontier_for_roots, import_discovery_accepted_reads_debug,
-    import_discovery_graph_input_debug, import_discovery_observation_ledger_debug,
-    inject_stale_query_for_oracle, oracle_executable, publish_import_observation_batch, rooted_cfg,
-    stage_import_input_request,
+    AcceptedImportSource, DifferentialOracleFault, DiscoverySourceAssembler, ImportDemandMode,
+    ImportObservation, PresentationRequest, PresentationStage, begin_import_input_request,
+    close_import_input_request, discovery_attempt, import_demand_frontier_for_roots,
+    import_discovery_accepted_reads_debug, import_discovery_graph_input_debug,
+    import_discovery_observation_ledger_debug, inject_stale_query_for_oracle, oracle_executable,
+    publish_import_observation_batch, rooted_cfg, stage_import_input_request,
 };
 use rue_compiler::{
-    AcceptedImportSource, CompileOptions, CompilerSession, FileMetadataFingerprint,
-    FrontendDiagnosticSnapshot, ImportDiscoveryContext, ImportObservation, PhysicalFileIdentity,
-    PreviewFeature, PreviewFeatures, SourceMetadata, SourceSnapshot,
+    CompileOptions, CompilerSession, FileMetadataFingerprint, FrontendDiagnosticSnapshot,
+    ImportDiscoveryContext, PhysicalFileIdentity, PreviewFeature, PreviewFeatures, SourceMetadata,
+    SourceSnapshot,
 };
 use rue_span::FileId;
 use rue_target::Target;

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -48,13 +48,12 @@ mod model_gaps;
 mod trap;
 
 use rue_compiler::unstable::{
-    DiscoverySourceAssembler, ImportDemandMode, begin_import_input_request,
-    close_import_input_request, import_demand_frontier_for_roots, import_observation_ledger,
-    publish_import_observation_batch, stage_import_input_request,
+    AcceptedImportSource, DiscoverySourceAssembler, ImportDemandMode, ImportObservation,
+    begin_import_input_request, close_import_input_request, import_demand_frontier_for_roots,
+    import_observation_ledger, publish_import_observation_batch, stage_import_input_request,
 };
 use rue_compiler::{
-    AcceptedImportSource, CompilerSession, FileMetadataFingerprint, ImportDiscoveryContext,
-    ImportObservation, PhysicalFileIdentity,
+    CompilerSession, FileMetadataFingerprint, ImportDiscoveryContext, PhysicalFileIdentity,
 };
 use rue_error::{PreviewFeature, PreviewFeatures};
 use rue_oracle::{

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -1159,13 +1159,12 @@ fn query_cfg_state_with_trusted_std(
     std_modules: &[(u32, &str, &str)],
 ) -> Result<CompileState, CompileErrors> {
     use rue_compiler::unstable::{
-        DiscoverySourceAssembler, ImportDemandMode, begin_import_input_request,
-        close_import_input_request, import_demand_frontier_for_roots, import_observation_ledger,
-        publish_import_observation_batch, stage_import_input_request,
+        AcceptedImportSource, DiscoverySourceAssembler, ImportDemandMode, ImportObservation,
+        begin_import_input_request, close_import_input_request, import_demand_frontier_for_roots,
+        import_observation_ledger, publish_import_observation_batch, stage_import_input_request,
     };
     use rue_compiler::{
-        AcceptedImportSource, CompilerSession, FileMetadataFingerprint, ImportDiscoveryContext,
-        ImportObservation, PhysicalFileIdentity,
+        CompilerSession, FileMetadataFingerprint, ImportDiscoveryContext, PhysicalFileIdentity,
     };
     use std::sync::Arc;
 

--- a/crates/rue-perf-schema/src/lib.rs
+++ b/crates/rue-perf-schema/src/lib.rs
@@ -95,6 +95,7 @@ pub use runtime::{
     RuntimeValidationOutcome, RuntimeWorkload, ThreadPolicy, runtime_sample_value, summarize,
     validate_runtime_report,
 };
+pub use sanity::is_commit;
 pub use scaling::{
     CfgLocalEpochWork, CfgMaterializationWork, CfgPrerequisiteWork, CfgRetainedChargeWork,
     CompilerWork, QueryRuntimeWork, SCALING_REPORT_SCHEMA_VERSION, ScalingIdentity,

--- a/crates/rue-perf-schema/src/validate.rs
+++ b/crates/rue-perf-schema/src/validate.rs
@@ -24,7 +24,7 @@ use std::collections::BTreeMap;
 use crate::RUN_SCHEMA_VERSION;
 use crate::manifest::Manifest;
 use crate::run::{FailureRecord, Phase, RunObject, Sample};
-use crate::sanity::{is_utc_timestamp, samples_beyond_policy};
+use crate::sanity::{is_commit, is_utc_timestamp, samples_beyond_policy};
 use crate::stats::median;
 
 /// A reason a run may not enter a series at all.
@@ -616,7 +616,7 @@ fn check_boundary_evidence(
 
 fn check_identity_shape(run: &RunObject, errors: &mut Vec<ValidationError>) {
     let commit = &run.identity.commit;
-    if commit.len() != 40 || !commit.chars().all(|c| c.is_ascii_hexdigit()) {
+    if !is_commit(commit) {
         errors.push(ValidationError::MalformedCommit {
             value: commit.clone(),
         });

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -7,7 +7,8 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use rue_compiler::unstable::{
-    DiscoverySourceAssembler, ImportDemandFrontier, ImportDemandMode, ImportInputRevision,
+    AcceptedImportSource, DiscoverySourceAssembler, ImportDemandFrontier, ImportDemandMode,
+    ImportDiscoveryRequest, ImportInputRevision, ImportObservation, ImportObservationStatus,
     RootedParkOutcome, TrustedSuccessorDelta, begin_import_input_request,
     close_import_discovery_successor, close_import_input_request, closed_discovery_continuation,
     discovery_attempt, import_demand_frontier_for_roots, import_observation_ledger,
@@ -26,10 +27,9 @@ use rue_compiler::unstable::{
 #[cfg(test)]
 use rue_compiler::unstable::{frontend_query_invalidations, rooted_cfg};
 use rue_compiler::{
-    AcceptedImportSource, AcceptedReadManifest, CompileErrors, CompileOptions, CompilerSession,
-    DependencyEnvelope, FileId, FileMetadataFingerprint, ImportDiscoveryContext,
-    ImportDiscoveryRequest, ImportDiscoveryStatus, ImportDiscoveryView, ImportObservation,
-    ImportObservationStatus, PhysicalFileIdentity, SourceMetadata, SourceSnapshot,
+    AcceptedReadManifest, CompileErrors, CompileOptions, CompilerSession, DependencyEnvelope,
+    FileId, FileMetadataFingerprint, ImportDiscoveryContext, ImportDiscoveryStatus,
+    ImportDiscoveryView, PhysicalFileIdentity, SourceMetadata, SourceSnapshot,
     TrustedToolchainModuleDemand,
 };
 

--- a/docs/designs/0061-supported-compiler-facade.md
+++ b/docs/designs/0061-supported-compiler-facade.md
@@ -229,6 +229,14 @@ of the supported API.
 | Move internal/direct owner | `DiscoverySourceAssembler` | Source aggregation belongs to the post-RUE-861 loader, not the compiler facade. |
 | Remove | `IMPORT_DISCOVERY_POLICY_VERSION` | Query policy version participates internally in request keys; it is not a host compatibility knob. |
 
+Post-decision note (RUE-1479): the six host-protocol observation records above
+(`AcceptedImportSource`, `ImportDiscoveryPlan`, `ImportDiscoveryRequest`,
+`ImportObservation`, `ImportObservationLedger`, `ImportObservationStatus`) were
+later moved off the stable root and are re-exported only from
+`rue_compiler::unstable`, next to the begin/frontier/publish/close protocol
+that consumes them. The dependency-artifact records in the Keep rows are
+unchanged.
+
 #### Stable immutable artifacts and diagnostics
 
 | Disposition | Exact current exports | Final class / reason |


### PR DESCRIPTION
Two independent cleanups, one commit each.

## Move the import-discovery facade to the unstable host protocol

Fixes RUE-1479.

The six host-protocol observation records (`AcceptedImportSource`, `ImportDiscoveryPlan`, `ImportDiscoveryRequest`, `ImportObservation`, `ImportObservationLedger`, `ImportObservationStatus`) leave the stable `rue_compiler` root and are re-exported only from `rue_compiler::unstable`, next to the begin/frontier/publish/close protocol that consumes them. The filesystem host (`crates/rue/src/source_loader.rs`), oracle tooling, and tests import them from there; the canonical discovery protocol itself is unchanged. The seven dependency-artifact records (`AcceptedReadManifest*`, `FileMetadataFingerprint`, `ImportDiscoveryContext`, `PhysicalFileIdentity`, …) stay stable.

`CompilerSession::import_graph(std_dir)` is deleted after a call-site audit found zero production consumers (CLI, host, oracles, and bench all use the committed-discovery protocol). Its four test callers now assert through `committed_import_graph()` / the canonical `TestDiscoveryHost` drive; the writer-less imports metrics query is removed with it (the gauge field stays until rue-bench's reader moves — flagged below).

Inventory enforcement: no entry remains classified `compatibility-boundary|legacy-embedders`; a facade export reintroduced on the stable root now panics as unclassified instead of being silently re-blessed; and a new structural test (`stable_facade_carries_no_compatibility_boundary_classifications`) rejects the classification returning through either inventory layer. ADR-0061's disposition table carries a post-decision note recording the move.

Bounded audit findings that need a design call rather than deletion (not acted on here): `CompilerSession::executable` is the documented stable embedder entry but has no production caller (the CLI uses the unstable compile-scope variants); the retained-diagnostics query set (`latest_diagnostics`, `latest_successful_diagnostics`, `last_good_semantic_diagnostics`) and `CompilerSessionUpdate::downstream_invalidated` are integration-test-only capabilities today.

## Collapse the commit-revision predicate onto `sanity::is_commit`

Fixes RUE-1501.

All three copies agreed — `len() == 40` plus `is_ascii_hexdigit`, either case — so this changes no behaviour; it removes the setup for the divergence the SHA-256 digest predicate already demonstrated (RUE-1489). `validate.rs` takes the crate-internal path; rue-bench reaches the same predicate through a new `is_commit` root re-export, so the CLI's `--commit` gate and the store's identity check can no longer drift apart.

## Validation

- `scripts/rue fmt` clean
- `scripts/rue unit compiler`: 881 passed, 0 failed, 6 ignored (includes the new inventory-rejection test; `api_inventory` filter: 34 passed)
- differential-oracle, public-api, rue-oracle, rue-oracle-diff, clippy (rue-compiler, rue), rue-test: all pass
- `scripts/rue unit perf-schema`: 222 passed; `scripts/rue unit bench`: 151 passed
- `scripts/rue quick`: 31/31 targets