### PR TITLE
RUE-1518: delete the unconsumed stable-facade capabilities

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -1359,21 +1359,14 @@ fn session_method_metadata(
     let class = if owner == "CompilerSessionUpdate" {
         match symbol {
             "result" | "into_result" | "diagnostics" => "artifact-result",
-            "downstream_invalidated" => "session-status",
             _ => panic!("unclassified stable CompilerSessionUpdate method: {symbol}"),
         }
     } else {
         match symbol {
             "new" | "update" => "session-operation",
-            "published"
-            | "committed_import_graph"
-            | "import_diagnostics"
-            | "rir"
-            | "semantic"
-            | "executable" => "artifact-query",
-            "latest_diagnostics"
-            | "latest_successful_diagnostics"
-            | "last_good_semantic_diagnostics" => "diagnostic-query",
+            "published" | "committed_import_graph" | "import_diagnostics" | "rir" | "semantic" => {
+                "artifact-query"
+            }
             _ => panic!("unclassified stable CompilerSession method: {symbol}"),
         }
     };

--- a/crates/rue-compiler/src/diagnostic_attempt_store.rs
+++ b/crates/rue-compiler/src/diagnostic_attempt_store.rs
@@ -208,11 +208,18 @@ impl DiagnosticAttemptStore {
         self.selected(self.latest)
     }
 
-    pub fn latest_successful(&self) -> Option<&Arc<FrontendDiagnosticSnapshot>> {
+    /// Test observer for the latest-successful selector. The selector itself
+    /// stays production state: it protects its entry from eviction.
+    #[cfg(test)]
+    pub(crate) fn latest_successful(&self) -> Option<&Arc<FrontendDiagnosticSnapshot>> {
         self.selected(self.latest_successful)
     }
 
-    pub fn last_good_semantic(&self) -> Option<&Arc<FrontendDiagnosticSnapshot>> {
+    /// Test observer for the last-good-semantic selector. Syntax or semantic
+    /// failures never replace this baseline, and the selector protects its
+    /// entry from eviction.
+    #[cfg(test)]
+    pub(crate) fn last_good_semantic(&self) -> Option<&Arc<FrontendDiagnosticSnapshot>> {
         self.selected(self.last_good_semantic)
     }
 

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -10,7 +10,7 @@
 //! ```
 //! use std::{collections::HashMap, sync::Arc};
 //! use rue_compiler::{
-//!     CompileOptions, CompilerSession, FileId, SourceMetadata, SourceSnapshot,
+//!     CompileOptions, CompilerSession, FileId, SourceMetadata, SourceSnapshot, compile_snapshot,
 //! };
 //!
 //! let root = FileId::new(7);
@@ -21,14 +21,15 @@
 //!     vec![(root, Arc::new("fn main() -> i32 { 0 }".to_owned()))],
 //! )?;
 //! let mut session = CompilerSession::new();
-//! session.update(&snapshot).into_result()?;
-//! let executable = session.executable(&CompileOptions::default())?;
+//! let syntax = session.update(&snapshot).into_result()?;
+//! assert!(syntax.modules().next().is_some());
+//! let executable = compile_snapshot(&snapshot, &CompileOptions::default())?;
 //! assert!(!executable.elf.is_empty());
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!
-//! Callers that only need a final executable may use [`compile_snapshot`], the
-//! sole one-shot adapter. Filesystem discovery remains the caller's job.
+//! Callers that need a final executable use [`compile_snapshot`], the sole
+//! one-shot stable adapter. Filesystem discovery remains the caller's job.
 //! Stable additions are reviewed against the semantic facade inventory. Debug
 //! presentation, instrumentation, and in-tree driver adapters live under
 //! [`unstable`] and carry no compatibility promise.

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -1413,7 +1413,7 @@ mod tests {
             .unwrap()
             .drive(&mut fresh)
             .unwrap();
-        let oracle = fresh.executable(&options).unwrap();
+        let oracle = fresh.executable_in_compile_scope(&options).unwrap();
         assert_eq!(retained.elf, oracle.elf);
         assert_eq!(retained.warnings, oracle.warnings);
     }

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -188,7 +188,8 @@ pub fn compile_snapshot(
 impl CompilerSession {
     /// Run the fresh backend tail for the exact published snapshot used by the
     /// cold-versus-reused differential oracle, including direct no-discovery
-    /// sessions. Production filesystem callers use [`Self::executable`].
+    /// sessions. Production callers reach the same tail through
+    /// [`compile_snapshot`] or the driver's compile-scope adapter.
     pub(crate) fn oracle_executable(
         &mut self,
         snapshot: &SourceSnapshot,
@@ -197,26 +198,12 @@ impl CompilerSession {
         compile_with_session(self, snapshot, options)
     }
 
-    /// Produce an executable from this session's closed-valid discovery revision.
-    pub fn executable(&mut self, options: &CompileOptions) -> MultiErrorResult<CompileOutput> {
-        let snapshot = self.committed_snapshot_for_executable()?;
-        let total_source_bytes: usize = snapshot.files().map(|source| source.source.len()).sum();
-        let _span = info_span!(
-            "compile",
-            target = %options.target,
-            file_count = snapshot.len(),
-            source_bytes = total_source_bytes
-        )
-        .entered();
-        compile_with_session(self, &snapshot, options)
-    }
-
     /// Produce an executable while the caller's canonical `compile` span is
     /// entered.
     ///
     /// The filesystem driver uses this after import discovery so the exact
     /// discovery parse and the later query pipeline share one timing root.
-    /// Other callers should use [`Self::executable`], which owns that root.
+    /// One-shot callers use [`compile_snapshot`], which owns that root.
     pub(crate) fn executable_in_compile_scope(
         &mut self,
         options: &CompileOptions,

--- a/crates/rue-compiler/src/scaling_harness.rs
+++ b/crates/rue-compiler/src/scaling_harness.rs
@@ -508,8 +508,8 @@ fn assert_warm_fresh_parity(
                 "{label}: ordered semantic warnings diverged"
             );
             assert_eq!(
-                format!("{:?}", warm_session.latest_diagnostics()),
-                format!("{:?}", fresh_session.latest_diagnostics()),
+                format!("{:?}", warm_session.latest_diagnostics_for_test()),
+                format!("{:?}", fresh_session.latest_diagnostics_for_test()),
                 "{label}: ordered diagnostic snapshots diverged"
             );
 
@@ -546,8 +546,8 @@ fn assert_warm_fresh_parity(
                 "{label}: warm/fresh failure diagnostics diverged"
             );
             assert_eq!(
-                format!("{:?}", warm_session.latest_diagnostics()),
-                format!("{:?}", fresh_session.latest_diagnostics()),
+                format!("{:?}", warm_session.latest_diagnostics_for_test()),
+                format!("{:?}", fresh_session.latest_diagnostics_for_test()),
                 "{label}: ordered failure diagnostic snapshots diverged"
             );
             // A failed rooted body/CFG query may stop before unchanged helper

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -648,9 +648,6 @@ impl CompilerSessionUpdate {
     pub(crate) fn invalidation(&self) -> &ParseInvalidationSummary {
         &self.invalidation
     }
-    pub fn downstream_invalidated(&self) -> bool {
-        self.downstream_invalidated
-    }
     pub fn diagnostics(&self) -> &Arc<FrontendDiagnosticSnapshot> {
         &self.diagnostics
     }
@@ -3112,21 +3109,11 @@ impl CompilerSession {
         self.queries.revisioned.module_source_stamp_for_test(source)
     }
     /// Diagnostic snapshot from the most recently attempted query, whether it
-    /// succeeded or failed.
-    pub fn latest_diagnostics(&self) -> Option<&Arc<FrontendDiagnosticSnapshot>> {
+    /// succeeded or failed. In-tree warm/fresh parity oracles compare this
+    /// retained selection; it is not part of the stable facade.
+    #[cfg(test)]
+    pub(crate) fn latest_diagnostics_for_test(&self) -> Option<&Arc<FrontendDiagnosticSnapshot>> {
         self.diagnostics.latest()
-    }
-    /// Most recently queried diagnostic snapshot with no errors.
-    pub fn latest_successful_diagnostics(&self) -> Option<&Arc<FrontendDiagnosticSnapshot>> {
-        self.diagnostics.latest_successful()
-    }
-    /// Most recent successful semantic diagnostic snapshot.
-    ///
-    /// Syntax or semantic failures never replace this last-good semantic
-    /// baseline. A caller may clone the returned `Arc` to pin it independently
-    /// of later session eviction.
-    pub fn last_good_semantic_diagnostics(&self) -> Option<&Arc<FrontendDiagnosticSnapshot>> {
-        self.diagnostics.last_good_semantic()
     }
 
     /// Look up the currently selected, or otherwise most recently indexed,
@@ -9166,7 +9153,8 @@ mod tests {
             format!("{:?}", fresh.warnings())
         );
         let diagnostics = session
-            .latest_diagnostics()
+            .diagnostics
+            .latest()
             .expect("semantic query publishes diagnostics");
         assert!(diagnostics.is_success());
         assert_eq!(
@@ -9209,8 +9197,8 @@ mod tests {
     }
 
     fn assert_diagnostic_parity(actual: &CompilerSession, fresh: &CompilerSession) {
-        let actual = actual.latest_diagnostics().unwrap();
-        let fresh = fresh.latest_diagnostics().unwrap();
+        let actual = actual.diagnostics.latest().unwrap();
+        let fresh = fresh.diagnostics.latest().unwrap();
         assert_eq!(
             format!("{:?}", actual.stage()),
             format!("{:?}", fresh.stage())
@@ -9223,6 +9211,85 @@ mod tests {
             format!("{:?}", actual.warnings()),
             format!("{:?}", fresh.warnings())
         );
+    }
+
+    #[test]
+    fn semantic_failure_preserves_the_last_good_semantic_diagnostic_baseline() {
+        let good = snapshot(
+            &[(1, "/p/main.rue", "main.rue", "fn main() -> i32 { 0 }")],
+            1,
+        );
+        let broken = snapshot(
+            &[(1, "/p/main.rue", "main.rue", "fn main() -> i32 { missing }")],
+            1,
+        );
+        let recovered = snapshot(
+            &[(1, "/p/main.rue", "main.rue", "fn main() -> i32 { 1 }")],
+            1,
+        );
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        session.update(&good).into_result().unwrap();
+        session.rooted_cfg(&options).unwrap();
+        let baseline = session
+            .diagnostics
+            .last_good_semantic()
+            .cloned()
+            .expect("successful semantic query publishes a last-good baseline");
+        assert!(baseline.is_success());
+
+        session.update(&broken).into_result().unwrap();
+        session.rooted_cfg(&options).unwrap_err();
+        let retained = session
+            .diagnostics
+            .last_good_semantic()
+            .cloned()
+            .expect("semantic failure retains the last-good baseline");
+        assert!(
+            Arc::ptr_eq(&retained, &baseline),
+            "a semantic failure must never replace the last-good semantic baseline"
+        );
+
+        session.update(&recovered).into_result().unwrap();
+        session.rooted_cfg(&options).unwrap();
+        let updated = session
+            .diagnostics
+            .last_good_semantic()
+            .cloned()
+            .expect("recovery publishes a new last-good baseline");
+        assert!(updated.is_success());
+        assert!(
+            !Arc::ptr_eq(&updated, &baseline),
+            "recovery must advance the last-good semantic baseline"
+        );
+    }
+
+    #[test]
+    fn injected_diagnostic_oracle_fault_diverges_from_a_fresh_session() {
+        let source = snapshot(
+            &[(1, "/p/main.rue", "main.rue", "fn main() -> i32 { 0 }")],
+            1,
+        );
+        let options = CompileOptions::default();
+        let mut warm = CompilerSession::new();
+        warm.update(&source).into_result().unwrap();
+        warm.rooted_cfg(&options).unwrap();
+        let mut fresh = CompilerSession::new();
+        fresh.update(&source).into_result().unwrap();
+        fresh.rooted_cfg(&options).unwrap();
+        assert_diagnostic_parity(&warm, &fresh);
+
+        assert!(
+            warm.inject_stale_query_for_oracle(
+                crate::unstable::DifferentialOracleFault::Diagnostic
+            )
+        );
+        let corrupted = warm.diagnostics.latest().unwrap();
+        assert!(
+            !corrupted.is_success(),
+            "the injected fault selects a distinct failing canonical attempt"
+        );
+        assert!(fresh.diagnostics.latest().unwrap().is_success());
     }
 
     #[test]
@@ -9484,23 +9551,23 @@ mod tests {
         session.canonical_rir().unwrap();
 
         let root = session.update(&root_only);
-        assert!(root.downstream_invalidated());
+        assert!(root.downstream_invalidated);
         assert_eq!(root.work().modules_reused, 2);
         root.into_result().unwrap();
         session.canonical_rir().unwrap();
         let moved = session.update(&relocated);
-        assert!(moved.downstream_invalidated());
+        assert!(moved.downstream_invalidated);
         assert_eq!(moved.work().modules_rebound, 2);
         moved.into_result().unwrap();
         session.canonical_rir().unwrap();
         let ids = session.update(&reassigned);
-        assert!(ids.downstream_invalidated());
+        assert!(ids.downstream_invalidated);
         assert_eq!(ids.work().modules_reparsed, 0);
         assert_eq!(ids.work().modules_rebound, 2);
         ids.into_result().unwrap();
         session.canonical_rir().unwrap();
         let rename = session.update(&renamed);
-        assert!(rename.downstream_invalidated());
+        assert!(rename.downstream_invalidated);
         assert_eq!(rename.invalidation().added.len(), 1);
         assert_eq!(rename.invalidation().removed.len(), 1);
         // ParseModule is keyed by stable logical module identity. A logical

--- a/crates/rue-compiler/src/supported_api_inventory.rs
+++ b/crates/rue-compiler/src/supported_api_inventory.rs
@@ -6,19 +6,14 @@
 //! source-size budget or adding another forbidden-name exception.
 
 pub(crate) const APPROVED: &str = r#"stable|CompilerSession|artifact-query|embedders|committed_import_graph|pub fn committed_import_graph(&self)->Result<Arc<CanonicalImportGraphOutput>,CompileErrors>
-stable|CompilerSession|artifact-query|embedders|executable|pub fn executable(&mut self,options:&CompileOptions)->MultiErrorResult<CompileOutput>
 stable|CompilerSession|artifact-query|embedders|import_diagnostics|pub fn import_diagnostics(&mut self)->Result<Arc<FrontendDiagnosticSnapshot>,CompileErrors>
 stable|CompilerSession|artifact-query|embedders|published|pub fn published(&self)->Option<crate::SyntaxView>
 stable|CompilerSession|artifact-query|embedders|rir|pub fn rir(&mut self)->Result<Arc<crate::RirView>,CompileErrors>
-stable|CompilerSession|diagnostic-query|embedders|last_good_semantic_diagnostics|pub fn last_good_semantic_diagnostics(&self)->Option<&Arc<FrontendDiagnosticSnapshot>>
-stable|CompilerSession|diagnostic-query|embedders|latest_diagnostics|pub fn latest_diagnostics(&self)->Option<&Arc<FrontendDiagnosticSnapshot>>
-stable|CompilerSession|diagnostic-query|embedders|latest_successful_diagnostics|pub fn latest_successful_diagnostics(&self)->Option<&Arc<FrontendDiagnosticSnapshot>>
 stable|CompilerSession|session-operation|embedders|new|pub fn new()->Self
 stable|CompilerSession|session-operation|embedders|update|pub fn update(&mut self,snapshot:&SourceSnapshot)->CompilerSessionUpdate
 stable|CompilerSessionUpdate|artifact-result|embedders|diagnostics|pub fn diagnostics(&self)->&Arc<FrontendDiagnosticSnapshot>
 stable|CompilerSessionUpdate|artifact-result|embedders|into_result|pub fn into_result(self)->Result<crate::SyntaxView,CompileErrors>
 stable|CompilerSessionUpdate|artifact-result|embedders|result|pub fn result(&self)->Result<crate::SyntaxView,&CompileErrors>
-stable|CompilerSessionUpdate|session-status|embedders|downstream_invalidated|pub fn downstream_invalidated(&self)->bool
 stable|artifact_views|artifact-view|embedders+tooling|ImportDiscoveryStatus|pub use artifact_views::ImportDiscoveryStatus
 stable|artifact_views|artifact-view|embedders+tooling|ImportDiscoveryView|pub use artifact_views::ImportDiscoveryView
 stable|artifact_views|artifact-view|embedders+tooling|RirInstructionView|pub use artifact_views::RirInstructionView

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -499,7 +499,7 @@ pub fn import_discovery_observation_ledger_debug(view: &crate::ImportDiscoveryVi
 }
 
 /// Run the fresh backend tail used by the cold-versus-reused differential
-/// oracle. Stable callers use `CompilerSession::executable`.
+/// oracle. Stable callers use `compile_snapshot`.
 pub fn oracle_executable(
     session: &mut crate::CompilerSession,
     snapshot: &crate::SourceSnapshot,
@@ -509,8 +509,8 @@ pub fn oracle_executable(
 }
 
 /// Produce an executable inside a compile span owned by the filesystem
-/// driver. Stable callers use `CompilerSession::executable`, which owns its
-/// tracing root.
+/// driver. Stable callers use `compile_snapshot`, which owns its tracing
+/// root.
 pub fn executable_in_compile_scope(
     session: &mut crate::CompilerSession,
     options: &crate::CompileOptions,

--- a/crates/rue-compiler/tests/differential_oracle.rs
+++ b/crates/rue-compiler/tests/differential_oracle.rs
@@ -20,9 +20,8 @@ use rue_compiler::unstable::{
     publish_import_observation_batch, rooted_cfg, stage_import_input_request,
 };
 use rue_compiler::{
-    CompileOptions, CompilerSession, FileMetadataFingerprint, FrontendDiagnosticSnapshot,
-    ImportDiscoveryContext, PhysicalFileIdentity, PreviewFeature, PreviewFeatures, SourceMetadata,
-    SourceSnapshot,
+    CompileOptions, CompilerSession, FileMetadataFingerprint, ImportDiscoveryContext,
+    PhysicalFileIdentity, PreviewFeature, PreviewFeatures, SourceMetadata, SourceSnapshot,
 };
 use rue_span::FileId;
 use rue_target::Target;
@@ -45,7 +44,6 @@ struct DiscoveryInput {
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct Observation {
     update: String,
-    diagnostics: String,
     syntax: String,
     rir: String,
     semantic: String,
@@ -116,20 +114,6 @@ fn import_step(name: &'static str, epoch: u64, value: i32) -> Step {
             accepted_reads: assembler.accepted_read_manifest(),
         }),
     }
-}
-
-fn normalize_diagnostics(snapshot: Option<&Arc<FrontendDiagnosticSnapshot>>) -> String {
-    snapshot.map_or_else(
-        || "none".to_owned(),
-        |diagnostics| {
-            format!(
-                "stage={:?};errors={:?};warnings={:?}",
-                diagnostics.stage(),
-                diagnostics.errors(),
-                diagnostics.warnings()
-            )
-        },
-    )
 }
 
 fn close_discovery(session: &mut CompilerSession, step: &Step) -> String {
@@ -342,13 +326,6 @@ fn observe_with_fault(
             format!("source={:?}", step.snapshot.source_revision()),
         ),
     };
-    if fault == Some(DifferentialOracleFault::Diagnostic) {
-        assert!(inject_stale_query_for_oracle(
-            session,
-            DifferentialOracleFault::Diagnostic
-        ));
-    }
-    let diagnostics = normalize_diagnostics(session.latest_diagnostics());
     if fault == Some(DifferentialOracleFault::Import) {
         assert!(inject_stale_query_for_oracle(
             session,
@@ -358,7 +335,6 @@ fn observe_with_fault(
     }
     Observation {
         update,
-        diagnostics,
         syntax,
         rir,
         semantic,
@@ -376,7 +352,6 @@ fn observe(session: &mut CompilerSession, step: &Step) -> Observation {
 fn differing_fields(left: &Observation, right: &Observation) -> Vec<&'static str> {
     [
         (left.update != right.update, "update"),
-        (left.diagnostics != right.diagnostics, "diagnostics"),
         (left.syntax != right.syntax, "syntax"),
         (left.rir != right.rir, "rir"),
         (left.semantic != right.semantic, "semantic"),
@@ -401,9 +376,7 @@ fn first_mismatch(
     fault: Option<DifferentialOracleFault>,
 ) -> Option<(usize, String)> {
     let mut reused = CompilerSession::new();
-    let mut last_good = None;
     for (index, step) in steps.iter().enumerate() {
-        let before_failure = last_good.clone();
         let injected = (index + 1 == steps.len() && index > 0)
             .then_some(fault)
             .flatten();
@@ -419,25 +392,6 @@ fn first_mismatch(
             )
             .unwrap();
             return Some((index, difference));
-        }
-
-        let current = reused.last_good_semantic_diagnostics().cloned();
-        if warm.semantic.starts_with("error:") {
-            assert_eq!(
-                current.as_ref().map(|value| format!("{:?}", value.stage())),
-                before_failure
-                    .as_ref()
-                    .map(|value: &Arc<FrontendDiagnosticSnapshot>| format!("{:?}", value.stage())),
-                "{} replaced last-good diagnostics on failure",
-                step.name
-            );
-        } else {
-            assert!(
-                current.is_some(),
-                "{} did not publish last-good diagnostics",
-                step.name
-            );
-            last_good = current;
         }
     }
     None
@@ -717,18 +671,13 @@ fn failure_recovery_and_bounded_eviction_match_fresh_sessions() {
 }
 
 #[test]
-fn fault_injection_proves_semantic_diagnostic_and_import_cache_detection() {
+fn fault_injection_proves_semantic_and_import_cache_detection() {
     let corpus = corpus();
     for (steps, fault, affected) in [
         (
             &corpus[1..3],
             DifferentialOracleFault::Semantic,
             "affected fields: semantic, emitted-assembly-hash, executable-hash, stable-identities",
-        ),
-        (
-            &corpus[9..11],
-            DifferentialOracleFault::Diagnostic,
-            "affected fields: diagnostics",
         ),
         (
             &corpus[corpus.len() - 2..],

--- a/crates/rue-compiler/tests/public_api.rs
+++ b/crates/rue-compiler/tests/public_api.rs
@@ -23,13 +23,13 @@ fn curated_facade_compiles_for_an_external_consumer() {
     let snapshot = SourceSnapshot::single("main.rue", "fn main() -> i32 { 0 }").unwrap();
     let mut session = CompilerSession::new();
     let update: CompilerSessionUpdate = session.update(&snapshot);
+    let diagnostics: Arc<FrontendDiagnosticSnapshot> = update.diagnostics().clone();
     update.into_result().unwrap();
 
     let syntax = session.published().unwrap();
     let rir: Arc<RirView> = session.rir().unwrap();
     let rooted = rooted_cfg(&mut session, &CompileOptions::default()).unwrap();
     let work: MetricsSnapshot = session.unstable_metrics();
-    let diagnostics: Option<&Arc<FrontendDiagnosticSnapshot>> = session.latest_diagnostics();
     let views: Vec<SourceView<'_>> = snapshot.files().collect();
     assert_eq!(views[0].file_id, FileId::DEFAULT);
     assert!(!rir.is_empty());
@@ -66,8 +66,8 @@ fn curated_facade_compiles_for_an_external_consumer() {
         "FN"
     );
     assert_eq!(work.updates(), 1);
-    assert!(diagnostics.is_some());
-    assert_eq!(diagnostics.unwrap().stage(), DiagnosticStage::Semantic);
+    assert!(diagnostics.is_success());
+    assert_eq!(diagnostics.stage(), DiagnosticStage::Syntax);
     for debug in [format!("{rir:?}")] {
         assert!(!debug.contains("CanonicalRirOutput"));
         assert!(!debug.contains("CanonicalSemanticOutput"));

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1579,9 +1579,10 @@ fn main() {
     // discovery epoch. Every compiler plan and identity decision receives this
     // immutable value; no discovery iteration rereads the environment.
     // One root spans the disjoint intervals that perform canonical compiler
-    // work. RUE-890 made discovery's exact parse publishable, so leaving this
-    // boundary inside `CompilerSession::executable` would incorrectly report
-    // the discovery parse as a second timing root.
+    // work. RUE-890 made discovery's exact parse publishable, so a
+    // compiler-owned `compile` span (as `compile_snapshot` opens) would
+    // incorrectly report the discovery parse as a second timing root; the
+    // driver owns the root and compiles through the compile-scope adapter.
     let compile_span = tracing::info_span!("compile", target = %options.target);
     let captured_std_root = env::var_os("RUE_STD_PATH").map(PathBuf::from);
     #[cfg(rue_benchmark_allocations)]

--- a/docs/designs/0053-typed-compiler-query-state.md
+++ b/docs/designs/0053-typed-compiler-query-state.md
@@ -442,6 +442,10 @@ RUE-813 through RUE-818. `CompilerSession::executable` and
    executable request,
    returning its success or failure directly without session memoization.
 
+Post-decision note (RUE-1518): `CompilerSession::executable` was later deleted
+from the stable facade (no production caller). The adapter contract above is
+carried by `compile_snapshot` and the crate-private compile-scope adapters.
+
 `LinkInputDescriptor::from_compile_options` is the canonical stable description
 of the request's source/resolution/target/features/optimization/linker option
 identity (`CodegenInputDescriptor` plus `StableLinkerInput`). The current

--- a/docs/designs/0061-supported-compiler-facade.md
+++ b/docs/designs/0061-supported-compiler-facade.md
@@ -305,6 +305,16 @@ unstable metrics or become private. Public methods on every type classified
 “move internal” cease to be reachable through the stable facade with their
 owner; they are not individually compatibility commitments.
 
+Post-decision note (RUE-1518): three capabilities in the tables above were
+later deleted from the stable facade because no production caller existed:
+`CompilerSession::executable` (a Keep row above; `compile_snapshot` is the
+sole stable one-shot executable entry, and the CLI keeps the unstable
+compile-scope adapters), the retained-diagnostics queries `latest_diagnostics`,
+`latest_successful_diagnostics`, and `last_good_semantic_diagnostics` (a
+View-wrap row above; the retention selectors remain session-internal and are
+observed by in-tree parity tests only), and
+`CompilerSessionUpdate::downstream_invalidated`.
+
 ### 6. Compatibility and version policy
 
 The follow-ups are an intentional pre-1.0 narrowing, but removals are still


### PR DESCRIPTION
Fixes RUE-1518.

Removes the three stable `CompilerSession` surfaces the RUE-1479 audit flagged as having no production caller, per the maintainer ruling on the issue.

## `CompilerSession::executable`

Deleted. `compile_snapshot()` is the sole one-shot stable adapter, and the lib.rs embedder example is rewritten around it (session `update` + syntax query for the incremental shape, `compile_snapshot` for the executable). The CLI keeps reaching executables through the unstable compile-scope variants; their shared `committed_snapshot_for_executable` helper stays live (called from `executable_in_compile_scope` and the cancellable variant, both on the CLI path). The one test caller migrated to `executable_in_compile_scope` because it genuinely exercises session-retained behavior through `TestDiscoveryHost`.

## The retained-diagnostics query set

`latest_diagnostics`, `latest_successful_diagnostics`, `last_good_semantic_diagnostics` deleted from the stable facade. The retention machinery is untouched, with call-site evidence for each boundary: the `latest` selector keeps production readers (the `import_diagnostics` invalidation check and two publication-metrics sites), and the successful/last-good selector fields still drive eviction protection in `DiagnosticAttemptStore::evict`. Their getters became `#[cfg(test)]` observers rather than deletions because store unit tests still assert selector independence.

Parity coverage moved rather than died: the warm/fresh diagnostic-parity assertions now go through a test-only accessor (scaling harness) and direct field access (session internal tests), and two new internal tests carry what the external differential oracle used to assert (last-good baseline preservation across a failed semantic pass; Diagnostic fault-injection divergence).

One consequence worth naming: the external differential oracle loses its retained-diagnostics observation dimension — with no supported accessor there is nothing external to observe. `unstable::DifferentialOracleFault::Diagnostic` and its injection arm remain (unstable-surface changes were out of scope) with the internal test as their only consumer; restoring the external dimension would need an unstable accessor, a separate decision if ever wanted.

## `CompilerSessionUpdate::downstream_invalidated`

Deleted. The field stays — it is read by the hand-written `Debug` impl and computed meaningfully at all three construction sites — and the root-relocation invalidation test asserts it directly.

## Enforcement and docs

Both inventory layers drop the five entries (`supported_api_inventory.rs` pins and the `api_inventory.rs` classifier arms, including the whole now-empty `diagnostic-query` class), so reintroducing any of these panics as unclassified, consistent with the RUE-1479 pattern. ADR-0061 and ADR-0053 carry short post-decision notes; historical tables untouched.

## Validation

- `scripts/rue fmt` clean (re-run after final edit)
- `./buck2 build //crates/rue-compiler:rue-compiler //crates/rue:rue`
- `scripts/rue unit compiler`: 883 passed, 0 failed, 6 ignored (`api_inventory` filter: 34 passed)
- public-api (6 passed), clippy, differential-oracle targets: all pass
- `scripts/rue quick`: 31/31 targets

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2TjBADys9Zidjs6zA9zFf)_