### PR TITLE
Integer-bounds intrinsics, literal contextual typing, macOS stack-overflow abort

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -2004,7 +2004,7 @@ impl<'a> ConstraintGenerator<'a> {
                     // sema stays authoritative for both the type and the
                     // diagnostic.
                     "int_max" | "int_min" => self
-                        .resolve_rir_type(*type_arg, span.file_id)
+                        .infer_rir_type_hint(*type_arg, span.file_id)
                         .filter(|ty| matches!(ty, InferType::Concrete(ty) if ty.is_integer()))
                         .unwrap_or_else(|| InferType::Var(self.fresh_var())),
                     // The remaining type intrinsics return i32 (the size or

--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1979,13 +1979,24 @@ impl<'a> ConstraintGenerator<'a> {
                 }
             }
 
-            // Type intrinsic (@size_of, @align_of)
-            InstData::TypeIntrinsic {
-                name: _,
-                type_arg: _,
-            } => {
-                // Type intrinsics return i32 (the size or alignment value)
-                InferType::Concrete(Type::I32)
+            // Type intrinsic (@size_of, @align_of, @int_max, @int_min)
+            InstData::TypeIntrinsic { name, type_arg } => {
+                match self.interner.resolve(name) {
+                    // The integer-bounds intrinsics evaluate to a value of the
+                    // queried type itself (RUE-694): `@int_max(u8): u8`. When
+                    // the type argument doesn't resolve here (a generic `T`
+                    // before substitution) — or resolves to a non-integer,
+                    // which sema rejects as E0702 — leave a fresh variable so
+                    // sema stays authoritative for both the type and the
+                    // diagnostic.
+                    "int_max" | "int_min" => self
+                        .resolve_rir_type(*type_arg, span.file_id)
+                        .filter(|ty| matches!(ty, InferType::Concrete(ty) if ty.is_integer()))
+                        .unwrap_or_else(|| InferType::Var(self.fresh_var())),
+                    // The remaining type intrinsics return i32 (the size or
+                    // alignment value).
+                    _ => InferType::Concrete(Type::I32),
+                }
             }
 
             // Field-offset intrinsic (@offset_of) — the compile-time byte

--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1672,9 +1672,23 @@ impl<'a> ConstraintGenerator<'a> {
                     self.add_constraint(Constraint::is_integer(result_ty.clone(), span));
                     result_ty
                 } else if intrinsic_name == "syscall" {
-                    // @syscall: syscall_num and up to 6 args (all u64), returns i64
+                    // @syscall: syscall_num and up to 6 args (all u64), returns i64.
+                    //
+                    // An integer-literal argument sees the declared u64
+                    // parameter type here (RUE-954), so `@syscall(32, 1)`
+                    // works without pre-binding `let fd: u64 = 1`. Only
+                    // literals are constrained: a wrongly-typed non-literal
+                    // argument keeps sema's targeted E0702 (`u64 for argument
+                    // {i}`) instead of a generic unification E0206.
                     for arg_ref in args.iter() {
-                        self.generate(*arg_ref, ctx);
+                        let info = self.generate(*arg_ref, ctx);
+                        if matches!(self.rir.get(*arg_ref).data, InstData::IntConst(_)) {
+                            self.add_constraint(Constraint::equal(
+                                info.ty,
+                                InferType::Concrete(Type::U64),
+                                info.span,
+                            ));
+                        }
                     }
                     InferType::Concrete(Type::I64)
                 } else if intrinsic_name == "ptr_to_int" {
@@ -2217,6 +2231,7 @@ impl<'a> ConstraintGenerator<'a> {
                     self.enter_scope(ctx);
                     if let rue_rir::RirPatternView::Path {
                         module,
+                        ctor_head,
                         type_name,
                         variant,
                         bindings,
@@ -2225,16 +2240,24 @@ impl<'a> ConstraintGenerator<'a> {
                     } = &pattern
                     {
                         if !bindings.is_empty() {
-                            // NOTE: an inline type-constructor pattern head
-                            // (`Result(i32,i32).Ok(v)`, RUE-596) cannot be
-                            // reduced by the inference engine (it has no comptime
-                            // interpreter), so `enum_type_for` is `None` for it
-                            // and the payload bindings are not pre-typed here.
-                            // Sema's `materialize_match_bindings` resolves them
-                            // authoritatively via `try_evaluate_const`.
-                            let enum_ty = module
-                                .and_then(|module_ref| {
-                                    self.enum_type_for_module(module_ref, type_name)
+                            // An inline type-constructor pattern head
+                            // (`Result(i32,i32).Ok(v)`, RUE-596) has no comptime
+                            // interpreter in the inference engine, but sema
+                            // pre-reduced it in `inline_ctor_head_types`
+                            // (RUE-950/RUE-954) — consult that first so the
+                            // payload bindings are pre-typed and a sibling
+                            // arm's literal sees the join's expectation. Sema's
+                            // `materialize_match_bindings` stays authoritative
+                            // via `try_evaluate_const`.
+                            let enum_ty = ctor_head
+                                .and_then(|head| {
+                                    self.inline_ctor_head_types
+                                        .and_then(|heads| heads.get(&head).copied())
+                                })
+                                .or_else(|| {
+                                    module.and_then(|module_ref| {
+                                        self.enum_type_for_module(module_ref, type_name)
+                                    })
                                 })
                                 .or_else(|| self.enum_type_for(type_name, pat_span.file_id));
                             if let Some(payload) = enum_ty
@@ -3408,10 +3431,24 @@ impl<'a> ConstraintGenerator<'a> {
             rue_rir::RirPatternView::Int { .. } => InferType::IntLiteral,
             rue_rir::RirPatternView::Bool(_, _) => InferType::Concrete(Type::BOOL),
             rue_rir::RirPatternView::Path {
-                module, type_name, ..
+                module,
+                ctor_head,
+                type_name,
+                ..
             } => {
-                let enum_ty = module
-                    .and_then(|module_ref| self.enum_type_for_module(module_ref, type_name))
+                // An inline type-constructor head (`Opt(u8).Some(b)`, RUE-596)
+                // was pre-reduced by sema in `inline_ctor_head_types`; consult
+                // it first so the pattern contributes the real enum type
+                // instead of poisoning the scrutinee with `<error>` (RUE-954).
+                let enum_ty = ctor_head
+                    .and_then(|head| {
+                        self.inline_ctor_head_types
+                            .and_then(|heads| heads.get(&head).copied())
+                    })
+                    .or_else(|| {
+                        module
+                            .and_then(|module_ref| self.enum_type_for_module(module_ref, type_name))
+                    })
                     .or_else(|| self.enum_type_for(type_name, pattern.span().file_id));
                 if let Some(enum_ty) = enum_ty {
                     InferType::Concrete(enum_ty)

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -109,6 +109,44 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return Ok(AnalysisResult::new(air_ref, Type::UNIT));
         }
 
+        // `@int_max(T)` / `@int_min(T)` (RUE-694): the largest/smallest value
+        // representable in integer type `T`, typed as `T` itself — the only
+        // result type that never truncates (`u64::MAX` doesn't fit any signed
+        // type; `i64::MIN` doesn't fit `u64`). The value folds to a `Const`
+        // here like `@size_of`; the u64 payload carries narrow signed minima
+        // sign-extended, matching how negative literals are emitted.
+        if intrinsic_name == "int_max" || intrinsic_name == "int_min" {
+            if ty.is_error() {
+                let air_ref = air.add_inst(AirInst {
+                    data: AirInstData::Const(0),
+                    ty: Type::ERROR,
+                    span,
+                });
+                return Ok(AnalysisResult::new(air_ref, Type::ERROR));
+            }
+            let bound = if intrinsic_name == "int_max" {
+                ty.int_max()
+            } else {
+                ty.int_min()
+            };
+            let Some(bound) = bound else {
+                return Err(CompileError::new(
+                    ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
+                        name: intrinsic_name,
+                        expected: "an integer type".to_string(),
+                        found: self.format_type_name(ty),
+                    })),
+                    span,
+                ));
+            };
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::Const(bound as u64),
+                ty,
+                span,
+            });
+            return Ok(AnalysisResult::new(air_ref, ty));
+        }
+
         // Calculate the value through the checked layout query. Oversized
         // types produce E0906 rather than overflowing or truncating the slot
         // count (RUE-561).

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1373,7 +1373,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // container runs each live element's drop glue before freeing its
             // buffer (RUE-646). It reduces to unit so the surrounding block
             // body still yields the `struct { .. }` tail. `@size_of`/`@align_of`
-            // are not comptime-foldable here and stay non-evaluable.
+            // are not comptime-foldable here and stay non-evaluable (spec
+            // 4.14:29); `@int_max`/`@int_min` depend only on the type identity,
+            // not layout, so they evaluate to their integer bound (RUE-694).
             InstData::TypeIntrinsic { name, type_arg } => {
                 let (name, type_arg) = (*name, *type_arg);
                 let gate = self.body_interner().resolve(&name);
@@ -1384,6 +1386,31 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 // not comptime-foldable here.
                 let is_droppable_gate = gate == "require_droppable";
                 let is_trivial_gate = gate == "require_trivially_droppable";
+                let is_int_bound = gate == "int_max" || gate == "int_min";
+                if is_int_bound {
+                    let is_max = gate == "int_max";
+                    // A still-unresolved type parameter makes the intrinsic
+                    // non-evaluable here; it folds at a concrete instantiation.
+                    let Some(int_ty) = self
+                        .resolve_rir_type_for_comptime_with_subst_and_values_at_span(
+                            type_arg,
+                            env.type_subst,
+                            env.value_subst,
+                            span,
+                        )
+                    else {
+                        return Ok(None);
+                    };
+                    let bound = if is_max {
+                        int_ty.int_max()
+                    } else {
+                        int_ty.int_min()
+                    };
+                    // A non-integer argument is diagnosed by runtime analysis
+                    // (`analyze_type_intrinsic`, E0702); stay non-evaluable
+                    // rather than duplicating the diagnostic.
+                    return Ok(bound.map(ConstValue::Integer));
+                }
                 if !is_droppable_gate && !is_trivial_gate {
                     return Ok(None);
                 }

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -2707,6 +2707,26 @@ fn inline_ctor_head_candidates_with_work(
                     work.raw_candidates += 1;
                 }
             }
+            // An inline type-constructor pattern head (`Opt(u8).Some(b)`,
+            // RUE-596) carries the head instruction on the pattern itself.
+            // Collecting it lets inference pre-type the arm's payload
+            // bindings and the pattern's scrutinee contract, so an arm
+            // literal in a sibling arm sees the enclosing expectation
+            // instead of defaulting to i32 (RUE-954).
+            InstData::Match { ref arms, .. } => {
+                for (pattern, _) in rir.match_arms(arms).iter() {
+                    if let rue_rir::RirPatternView::Path {
+                        ctor_head: Some(head),
+                        ..
+                    } = pattern
+                    {
+                        candidates.push(head);
+                        if attribution_enabled {
+                            work.raw_candidates += 1;
+                        }
+                    }
+                }
+            }
             _ => {}
         }
 

--- a/crates/rue-cli-tests/cases/intrinsic_args.toml
+++ b/crates/rue-cli-tests/cases/intrinsic_args.toml
@@ -114,3 +114,53 @@ fn main() -> i32 {
 ]
 stdout = "0\n"
 exit_code = 0
+
+# ---------------------------------------------------------------------------
+# RUE-954: integer literals in @syscall argument positions see the declared
+# u64 parameter type. Before the fix every literal defaulted to i32 and had
+# to be pre-bound (`let fd: u64 = 1;`) to satisfy E0702.
+# ---------------------------------------------------------------------------
+
+# dup(1) — both the syscall number and the fd are bare literals.
+[[case]]
+name = "syscall_integer_literal_args_typed_u64"
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let r = checked { @syscall(32, 1) };
+    if r >= 0 { 0 } else { 1 }
+}
+""" },
+]
+only_on = ["x86-64-linux"]
+
+# Mixed literal and variable arguments: the literal is typed u64 in place,
+# the variable keeps its own (correct) type.
+[[case]]
+name = "syscall_mixed_literal_and_var_args"
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let n: u64 = 32;
+    let r = checked { @syscall(n, 1) };
+    if r >= 0 { 0 } else { 1 }
+}
+""" },
+]
+only_on = ["x86-64-linux"]
+
+# Control: a wrongly-typed non-literal argument still reports the targeted
+# E0702 (the literal threading must not widen a real i32 variable).
+[[case]]
+name = "syscall_non_literal_wrong_type_still_e0702"
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let fd: i32 = 1;
+    let r = checked { @syscall(32, fd) };
+    0
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0702", "u64 for argument 1", "found i32"]

--- a/crates/rue-cli-tests/cases/match_inference_fixes.toml
+++ b/crates/rue-cli-tests/cases/match_inference_fixes.toml
@@ -168,3 +168,76 @@ fn absurd(n: Never) -> i32 { let y: u8 = 300; let _ = match n {}; 0 }
 fn main() -> i32 { absurd(loop {}) }
 """ }]
 error_contains = ["E0800"]
+
+# ---------------------------------------------------------------------------
+# RUE-954: match arms see the enclosing `let` annotation even when the
+# pattern heads are inline type-constructor calls. Before the fix, the
+# un-reduced head left the payload binding `<error>`-typed, the arm join
+# never saw the annotation, and the sibling arm's literal defaulted to i32
+# (E0206 "expected u8, found i32").
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "inline_ctor_pattern_head_arm_literal_widens"
+description = "RUE-954: `let first: u8 = match x { Opt(u8).Some(b) => b, Opt(u8).None => 0 }` — the None arm's literal is typed u8 by the annotation, not defaulted to i32."
+files = [{ path = "main.rue", source = """
+fn Opt(comptime T: type) -> type {
+    enum {
+        Some(T),
+        None,
+    }
+}
+
+fn main() -> i32 {
+    let x = Opt(u8).Some(116);
+    let first: u8 = match x {
+        Opt(u8).Some(b) => b,
+        Opt(u8).None => 0,
+    };
+    if first == 116 { 0 } else { 1 }
+}
+""" }]
+
+[[case]]
+name = "inline_ctor_pattern_head_wide_payload_runs"
+description = "RUE-954: the widened value flows through the payload binding at runtime — a u64 payload above i32::MAX round-trips through the match."
+files = [{ path = "main.rue", source = """
+fn Opt(comptime T: type) -> type {
+    enum {
+        Some(T),
+        None,
+    }
+}
+
+fn main() -> i32 {
+    let x = Opt(u64).Some(4294967296);
+    let v: u64 = match x {
+        Opt(u64).Some(b) => b,
+        Opt(u64).None => 0,
+    };
+    if v == 4294967296 { 0 } else { 1 }
+}
+""" }]
+
+[[case]]
+name = "inline_ctor_pattern_head_arm_mismatch_still_errors"
+description = "RUE-954 control: genuinely disagreeing arm types under an inline ctor head still report E0206 (the fix threads the expectation, it does not suppress the check)."
+compile_fail = true
+files = [{ path = "main.rue", source = """
+fn Opt(comptime T: type) -> type {
+    enum {
+        Some(T),
+        None,
+    }
+}
+
+fn main() -> i32 {
+    let x = Opt(u8).Some(1);
+    let v = match x {
+        Opt(u8).Some(b) => b,
+        Opt(u8).None => false,
+    };
+    0
+}
+""" }]
+error_contains = ["E0206"]

--- a/crates/rue-cli-tests/cases/stack_overflow.toml
+++ b/crates/rue-cli-tests/cases/stack_overflow.toml
@@ -15,15 +15,15 @@
 # stack overflow: safe Rue has no other way to segfault (bounds-checked, no null
 # derefs, arithmetic traps). See crates/rue-runtime/src/entry.rs.
 #
-# Platform scope (`only_on` the two Linux targets): the handler is implemented
-# for x86-64 Linux and aarch64 Linux. macOS is a documented TODO — Darwin's
-# `sigaction(2)` requires a caller-supplied signal trampoline that cannot be
-# verified on a Linux host, so its `install_stack_overflow_handler` is a no-op
-# there (a macOS stack overflow still exits 139). We use `only_on` rather than
-# `known_bug_on = ["aarch64-macos"]` because a program that dies by signal is a
-# FATAL failure the harness cannot mask with a known_bug marker, so the case is
-# simply not run on macOS. See the macOS stub in
-# crates/rue-runtime/src/aarch64_macos.rs.
+# Platform scope (`only_on` all three targets): the handler is implemented for
+# x86-64 Linux, aarch64 Linux, and aarch64 macOS (RUE-707). The macOS path uses
+# the raw Darwin `sigaction(2)` with a hand-written `sa_tramp` trampoline; the
+# linking of that trampoline reference is verified on any host (the internal
+# linker statically relaxes its GOT_LOAD relocations), while delivery behavior
+# is verified by CI's macOS leg running this very case. If it regresses there,
+# this case fails loudly — a signal-death is a FATAL failure `known_bug` can't
+# absorb, which is why the scope stays `only_on`. See
+# crates/rue-runtime/src/aarch64_macos.rs::install_stack_overflow_handler.
 
 [section]
 id = "cli.stack_overflow"
@@ -37,7 +37,7 @@ description = "Deep recursion aborts with 'stack overflow' + exit 101, not a raw
 [[case]]
 name = "deep_recursion_aborts_cleanly"
 description = "depth(10_000_000) overflows the stack and aborts with 'stack overflow' + exit 101 (not SIGSEGV/139)."
-only_on = ["x86-64-linux", "aarch64-linux"]
+only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
 files = [{ path = "prog.rue", source = """
 fn depth(n: i64) -> i64 { if n == 0 { 0 } else { 1 + depth(n - 1) } }
 fn main() -> i32 { @dbg(depth(10000000)); 0 }

--- a/crates/rue-cli-tests/cases/std_core.toml
+++ b/crates/rue-cli-tests/cases/std_core.toml
@@ -15,7 +15,7 @@ description = "std.cmp, std.math, std.mem, std.tuple, std.fmt exercised end-to-e
 
 [[case]]
 name = "std_core_m1_smoke"
-description = "cmp/math/mem/tuple/fmt all produce correct results (14 checks → exit 42)."
+description = "cmp/math/mem/tuple/fmt all produce correct results (18 checks → exit 42)."
 env = { RUE_STD_PATH = "${REAL_STD}" }
 args = ["main.rue", "-o", "prog"]
 exit_code = 42
@@ -49,13 +49,25 @@ fn main() -> i32 {
     let n97: i64 = 97;
     if std.math.is_prime(i64, n97) { score = score + 1; }
 
-    // std.math (i64 checked_*)
+    // std.math (generic checked_*, RUE-694)
     let O = std.option.Option(i64);
-    let big: i64 = 9223372036854775807;
+    let big: i64 = @int_max(i64);
     let one: i64 = 1;
-    match std.math.checked_add(big, one) { O.Some(v) => {}, O.None => { score = score + 1; } }
+    match std.math.checked_add(i64, big, one) { O.Some(v) => {}, O.None => { score = score + 1; } }
     let six: i64 = 6;
-    match std.math.checked_mul(six, seven) { O.Some(v) => { if v == 42 { score = score + 1; } }, O.None => {} }
+    match std.math.checked_mul(i64, six, seven) { O.Some(v) => { if v == 42 { score = score + 1; } }, O.None => {} }
+    let OU = std.option.Option(u8);
+    let u200: u8 = 200;
+    let u100: u8 = 100;
+    match std.math.checked_add(u8, u200, u100) { OU.Some(v) => {}, OU.None => { score = score + 1; } }
+    match std.math.checked_mul(u8, u200, u100) { OU.Some(v) => {}, OU.None => { score = score + 1; } }
+    let OI8 = std.option.Option(i8);
+    let n100: i8 = -100;
+    let p100: i8 = 100;
+    let minus1: i8 = -1;
+    let i8min: i8 = @int_min(i8);
+    match std.math.checked_sub(i8, n100, p100) { OI8.Some(v) => {}, OI8.None => { score = score + 1; } }
+    match std.math.checked_mul(i8, i8min, minus1) { OI8.Some(v) => {}, OI8.None => { score = score + 1; } }
 
     // std.mem
     let mut x: i64 = 1;
@@ -74,7 +86,7 @@ fn main() -> i32 {
     if std.fmt.to_hex(n255).len() == 2 { score = score + 1; }
     if std.fmt.bool_to_string(true).len() == 4 { score = score + 1; }
 
-    if score == 14 { 42 } else { @intCast(score) }
+    if score == 18 { 42 } else { @intCast(score) }
 }
 """ }]
 

--- a/crates/rue-compiler/src/integration_tests.rs
+++ b/crates/rue-compiler/src/integration_tests.rs
@@ -1278,6 +1278,25 @@ drop fn StrBuf(self) { }
             let src = "fn main() -> i32 { @align_of(i64) }";
             assert!(test_air(src).is_ok());
         }
+
+        #[test]
+        fn int_bounds_intrinsics() {
+            // @int_max(T)/@int_min(T) are typed at T itself (RUE-694), so the
+            // u8 bound flows into a u8 annotation and the i64 bound into i64.
+            let src = "fn main() -> i32 {
+                let a: u8 = @int_max(u8);
+                let b: i64 = @int_min(i64);
+                if a == 255 && b < 0 { 0 } else { 1 }
+            }";
+            assert!(test_air(src).is_ok());
+        }
+
+        #[test]
+        fn int_bounds_reject_non_integer() {
+            // A non-integer type argument is E0702, not a successful fold.
+            let src = "fn main() -> i32 { let x = @int_max(bool); 0 }";
+            assert!(test_air(src).is_err());
+        }
     }
 
     // ========================================================================

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -8040,6 +8040,71 @@ impl SemanticConstEvaluator<'_, '_> {
                     crate::durable_semantics::DurableType::Unit,
                 )))
             }
+            E::TypeIntrinsic { name, type_arg }
+                if matches!(self.symbol(name).as_ref(), "int_max" | "int_min") =>
+            {
+                // `@int_max(T)` / `@int_min(T)` (RUE-694) fold in const context
+                // too: unlike `@size_of`, they depend only on the type identity,
+                // never on layout. The numeric authority stays `Type::int_max`/
+                // `Type::int_min`; this arm only maps the durable scalar back.
+                let is_max = self.symbol(name).as_ref() == "int_max";
+                let ty = resolve_semantic_candidate_type(
+                    self.provider,
+                    &self.declaration.declaration.module,
+                    self.rir,
+                    self.symbols,
+                    *type_arg,
+                )
+                .map_err(|error| match error {
+                    rue_air::SemanticResolutionError::ProviderAbort(abort) => {
+                        EvaluateSemanticConstError::Abort(abort)
+                    }
+                    rue_air::SemanticResolutionError::ProviderFailure(failure) => {
+                        EvaluateSemanticConstError::failure(failure)
+                    }
+                    other => Self::failure_value(format!("{other:?}")),
+                })?;
+                use crate::durable_semantics::DurableType as T;
+                let scalar = match ty {
+                    T::I8 => Some(rue_air::Type::I8),
+                    T::I16 => Some(rue_air::Type::I16),
+                    T::I32 => Some(rue_air::Type::I32),
+                    T::I64 => Some(rue_air::Type::I64),
+                    T::U8 => Some(rue_air::Type::U8),
+                    T::U16 => Some(rue_air::Type::U16),
+                    T::U32 => Some(rue_air::Type::U32),
+                    T::U64 => Some(rue_air::Type::U64),
+                    _ => None,
+                };
+                let bound = scalar.and_then(|scalar| {
+                    if is_max {
+                        scalar.int_max()
+                    } else {
+                        scalar.int_min()
+                    }
+                });
+                let Some(bound) = bound else {
+                    return Err(Self::domain_failure(
+                        crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+                            rue_error::ErrorKind::IntrinsicTypeMismatch(Box::new(
+                                rue_error::IntrinsicTypeMismatchError {
+                                    name: if is_max {
+                                        "int_max".to_string()
+                                    } else {
+                                        "int_min".to_string()
+                                    },
+                                    expected: "an integer type".to_string(),
+                                    found: ty.kind().display_name().to_string(),
+                                },
+                            )),
+                        ),
+                    ));
+                };
+                Ok(EvaluatedSemanticConst::Value(TypedSemanticConst::typed(
+                    V::Integer(bound),
+                    ty,
+                )))
+            }
             E::EnumVariant {
                 module: None,
                 type_name,

--- a/crates/rue-linker/src/constants.rs
+++ b/crates/rue-linker/src/constants.rs
@@ -312,6 +312,10 @@ pub const ARM64_RELOC_BRANCH26: u32 = 2;
 pub const ARM64_RELOC_PAGE21: u32 = 3;
 /// ARM64_RELOC_PAGEOFF12: Page offset
 pub const ARM64_RELOC_PAGEOFF12: u32 = 4;
+/// ARM64_RELOC_GOT_LOAD_PAGE21: ADRP of a GOT entry's page
+pub const ARM64_RELOC_GOT_LOAD_PAGE21: u32 = 5;
+/// ARM64_RELOC_GOT_LOAD_PAGEOFF12: LDR of a GOT entry within its page
+pub const ARM64_RELOC_GOT_LOAD_PAGEOFF12: u32 = 6;
 /// ARM64_RELOC_ADDEND: carries the addend for the *following* relocation
 /// entry (Mach-O ARM64 relocation_info has no addend field of its own)
 pub const ARM64_RELOC_ADDEND: u32 = 10;

--- a/crates/rue-linker/src/elf.rs
+++ b/crates/rue-linker/src/elf.rs
@@ -14,6 +14,8 @@ use crate::constants::{
     // Mach-O constants
     ARM64_RELOC_ADDEND,
     ARM64_RELOC_BRANCH26,
+    ARM64_RELOC_GOT_LOAD_PAGE21,
+    ARM64_RELOC_GOT_LOAD_PAGEOFF12,
     ARM64_RELOC_PAGE21,
     ARM64_RELOC_PAGEOFF12,
     ARM64_RELOC_UNSIGNED,
@@ -318,6 +320,16 @@ pub enum RelocationType {
     Ldst64Lo12,
     /// R_AARCH64_LDST128_ABS_LO12_NC: 128-bit load/store page offset (imm12 << 4).
     Ldst128Lo12,
+    /// ARM64_RELOC_GOT_LOAD_PAGE21 (Mach-O): ADRP of a GOT entry's page.
+    /// This linker produces fully static executables with no GOT, so the load
+    /// is relaxed to direct addressing (the aarch64 analogue of the x86-64
+    /// GotPcRelX relaxation): the ADRP is retargeted at the symbol itself,
+    /// and the paired GOT_LOAD_PAGEOFF12 LDR becomes an ADD (RUE-707).
+    GotLoadAdrpPage21,
+    /// ARM64_RELOC_GOT_LOAD_PAGEOFF12 (Mach-O): LDR of a GOT entry within its
+    /// page, relaxed to an ADD of the symbol's low 12 bits (see
+    /// [`RelocationType::GotLoadAdrpPage21`]).
+    GotLoadPageOff12,
     /// Unknown relocation type.
     Unknown(u32),
 }
@@ -865,6 +877,8 @@ impl ObjectFile {
                     ARM64_RELOC_BRANCH26 => RelocationType::Call26, // Could be Jump26, but works either way
                     ARM64_RELOC_PAGE21 => RelocationType::AdrpPage21,
                     ARM64_RELOC_PAGEOFF12 => RelocationType::AddLo12,
+                    ARM64_RELOC_GOT_LOAD_PAGE21 => RelocationType::GotLoadAdrpPage21,
+                    ARM64_RELOC_GOT_LOAD_PAGEOFF12 => RelocationType::GotLoadPageOff12,
                     _ => RelocationType::Unknown(r_type),
                 };
 

--- a/crates/rue-linker/src/emit.rs
+++ b/crates/rue-linker/src/emit.rs
@@ -356,6 +356,13 @@ impl ObjectBuilder {
                 RelocationType::Ldst32Lo12 => R_AARCH64_LDST32_ABS_LO12_NC,
                 RelocationType::Ldst64Lo12 => R_AARCH64_LDST64_ABS_LO12_NC,
                 RelocationType::Ldst128Lo12 => R_AARCH64_LDST128_ABS_LO12_NC,
+                // The GOT_LOAD pair exists only as parsed Mach-O input
+                // (statically relaxed at apply time, RUE-707); Rue's own
+                // codegen never creates one, so it cannot reach the ELF
+                // object emitter.
+                RelocationType::GotLoadAdrpPage21 | RelocationType::GotLoadPageOff12 => {
+                    unreachable!("Mach-O GOT_LOAD relocations are never emitted by Rue codegen")
+                }
                 RelocationType::Unknown(t) => t,
             };
             let r_info = ((sym_idx as u64) << 32) | (r_type as u64);

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -114,6 +114,8 @@ fn relocation_patch_size(rel_type: RelocationType) -> Result<usize, LinkError> {
         | RelocationType::Call26
         | RelocationType::AdrpPage21
         | RelocationType::AddLo12
+        | RelocationType::GotLoadAdrpPage21
+        | RelocationType::GotLoadPageOff12
         | RelocationType::Ldst8Lo12
         | RelocationType::Ldst16Lo12
         | RelocationType::Ldst32Lo12
@@ -460,10 +462,16 @@ fn apply_relocation(
             inst = (inst & 0xFC000000) | ((offset as u32) & 0x03FFFFFF);
             buf[patch_range.clone()].copy_from_slice(&inst.to_le_bytes());
         }
-        RelocationType::AdrpPage21 => {
+        RelocationType::AdrpPage21 | RelocationType::GotLoadAdrpPage21 => {
             // AArch64 ADRP - loads PC-relative page address (21-bit page offset)
             // S + A gives the effective address; we need the page containing that
             // Result is the page containing (S + A) minus page containing PC
+            //
+            // GotLoadAdrpPage21 is the Mach-O GOT-load form relaxed for static
+            // linking: with no GOT, the ADRP addresses the symbol's own page
+            // directly and the paired GotLoadPageOff12 LDR becomes an ADD, so
+            // the register ends up holding the symbol's address exactly as the
+            // GOT slot would have (RUE-707).
             let effective_addr = (target_addr as i64 + addend) as u64;
             let target_page = effective_addr & !0xFFF;
             let pc_page = pc & !0xFFF;
@@ -568,6 +576,32 @@ fn apply_relocation(
             // Load/store imm12 is in bits 10-21, same field position as ADD.
             inst = (inst & 0xFFC003FF) | (imm << 10);
             buf[patch_range].copy_from_slice(&inst.to_le_bytes());
+        }
+        RelocationType::GotLoadPageOff12 => {
+            // Mach-O ARM64_RELOC_GOT_LOAD_PAGEOFF12, statically relaxed
+            // (RUE-707): the compiler emitted `ldr xN, [xM, #gotoff]` to read
+            // the symbol's address out of its GOT slot. This linker builds no
+            // GOT — every symbol is defined in the final image — so rewrite
+            // the LDR into `add xN, xM, #lo12(S + A)`, producing the symbol's
+            // address directly (the paired GOT_LOAD_PAGE21 ADRP was already
+            // pointed at the symbol's page). The aarch64 analogue of the
+            // x86-64 GotPcRelX mov->lea relaxation.
+            let effective_addr = (target_addr as i64 + addend) as u64;
+            let lo12 = (effective_addr & 0xFFF) as u32;
+            let inst = u32::from_le_bytes(buf[patch_range.clone()].try_into().unwrap());
+            // Only the 64-bit LDR (unsigned immediate) form can address a GOT
+            // slot; anything else means an assumption above is wrong, so fail
+            // loudly rather than emit a corrupt instruction.
+            if inst & 0xFFC0_0000 != 0xF940_0000 {
+                return Err(LinkError::UnsupportedRelocation(format!(
+                    "GOT_LOAD_PAGEOFF12 on non-LDR instruction 0x{inst:08x} for symbol {sym_name}"
+                )));
+            }
+            let rn = (inst >> 5) & 0x1F;
+            let rd = inst & 0x1F;
+            // ADD (immediate, 64-bit): sf=1, imm12 in bits 10-21.
+            let add = 0x9100_0000 | (lo12 << 10) | (rn << 5) | rd;
+            buf[patch_range].copy_from_slice(&add.to_le_bytes());
         }
         RelocationType::Unknown(t) => {
             return Err(LinkError::UnsupportedRelocation(format!(
@@ -5023,6 +5057,141 @@ mod tests {
             add,
             0x91000000 | (lo12 << 10),
             "ADD imm12 must be the unscaled byte offset"
+        );
+    }
+
+    /// RUE-707: the Mach-O GOT_LOAD pair is statically relaxed. The ADRP is
+    /// retargeted at the symbol's own page and the LDR that would have read
+    /// the GOT slot becomes an ADD of the symbol's low 12 bits, so the
+    /// register holds the symbol's address with no GOT in the image. This is
+    /// the pattern rustc emits for `extern_symbol as usize` in the macOS
+    /// runtime (the sa_tramp reference), which PR #1512 shipped unsupported —
+    /// every macOS link failed with "unsupported relocation: unknown type 6".
+    #[test]
+    fn test_macho_got_load_pair_relaxes_to_direct_address() {
+        use crate::macho::{PAGE_SIZE, VM_BASE};
+
+        let text = {
+            let mut s = text_section(
+                "__text",
+                vec![
+                    0x09, 0x00, 0x00, 0x90, // adrp x9, gvar@GOTPAGE
+                    0x29, 0x01, 0x40, 0xF9, // ldr x9, [x9, gvar@GOTPAGEOFF]
+                    0xC0, 0x03, 0x5F, 0xD6, // ret
+                ],
+                vec![
+                    Relocation {
+                        offset: 0,
+                        symbol_index: 1,
+                        rel_type: RelocationType::GotLoadAdrpPage21,
+                        addend: 0,
+                    },
+                    Relocation {
+                        offset: 4,
+                        symbol_index: 1,
+                        rel_type: RelocationType::GotLoadPageOff12,
+                        addend: 0,
+                    },
+                ],
+            );
+            s.align = 4;
+            s
+        };
+        let data = Section {
+            name: "__DATA,__data".into(),
+            data: vec![0u8; 16],
+            size: 16,
+            flags: SectionFlags::ALLOC | SectionFlags::WRITE,
+            relocations: vec![],
+            align: 8,
+        };
+        let obj = make_obj(
+            crate::elf::ElfMachine::Aarch64,
+            vec![text, data],
+            vec![
+                sym("main", Some(0), 0, SymbolBinding::Global),
+                sym("gvar", Some(1), 8, SymbolBinding::Global),
+            ],
+        );
+
+        let mut linker = Linker::new(Target::Aarch64Macos);
+        linker.add_object(obj).unwrap();
+        let macho = linker.link("main").unwrap();
+
+        let code_off = macho_entryoff(&macho) as usize;
+        let segments = macho_segments(&macho);
+        let (_, data_vmaddr, ..) = segments
+            .iter()
+            .find(|(n, ..)| n == "__DATA")
+            .cloned()
+            .expect("__DATA segment");
+        assert_eq!(data_vmaddr % PAGE_SIZE, 0);
+        assert!(data_vmaddr > VM_BASE);
+        let lo12 = ((data_vmaddr + 8) & 0xFFF) as u32;
+        assert_eq!(lo12, 8);
+
+        // The ADRP must still be an ADRP (targeting gvar's page, not a GOT's).
+        let adrp = read_u32_at(&macho, code_off);
+        assert_eq!(
+            adrp & 0x9F00_001F,
+            0x9000_0009,
+            "GOT_LOAD_PAGE21 site must stay an ADRP to x9"
+        );
+        // The LDR must have been rewritten to ADD x9, x9, #lo12(gvar).
+        let add = read_u32_at(&macho, code_off + 4);
+        assert_eq!(
+            add,
+            0x9100_0000 | (lo12 << 10) | (9 << 5) | 9,
+            "GOT_LOAD_PAGEOFF12 LDR must relax to ADD of the symbol's low 12 bits"
+        );
+    }
+
+    /// RUE-707: GOT_LOAD_PAGEOFF12 on anything but the 64-bit LDR
+    /// (unsigned-immediate) form means the relaxation's assumptions are wrong;
+    /// the link must fail loudly rather than emit a corrupt instruction.
+    #[test]
+    fn test_macho_got_load_pageoff12_rejects_non_ldr() {
+        let text = {
+            let mut s = text_section(
+                "__text",
+                vec![
+                    0x29, 0x01, 0x00, 0x91, // add x9, x9, #0 — not an LDR
+                    0xC0, 0x03, 0x5F, 0xD6, // ret
+                ],
+                vec![Relocation {
+                    offset: 0,
+                    symbol_index: 1,
+                    rel_type: RelocationType::GotLoadPageOff12,
+                    addend: 0,
+                }],
+            );
+            s.align = 4;
+            s
+        };
+        let data = Section {
+            name: "__DATA,__data".into(),
+            data: vec![0u8; 16],
+            size: 16,
+            flags: SectionFlags::ALLOC | SectionFlags::WRITE,
+            relocations: vec![],
+            align: 8,
+        };
+        let obj = make_obj(
+            crate::elf::ElfMachine::Aarch64,
+            vec![text, data],
+            vec![
+                sym("main", Some(0), 0, SymbolBinding::Global),
+                sym("gvar", Some(1), 8, SymbolBinding::Global),
+            ],
+        );
+
+        let mut linker = Linker::new(Target::Aarch64Macos);
+        linker.add_object(obj).unwrap();
+        let result = linker.link("main");
+        assert!(
+            matches!(result, Err(LinkError::UnsupportedRelocation(ref s)) if s.contains("non-LDR")),
+            "GOT_LOAD_PAGEOFF12 on a non-LDR must be an UnsupportedRelocation error, got: {:?}",
+            result
         );
     }
 

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -308,6 +308,20 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
+    // RUE-954: the literal-threading regression cases invoke a real dup(2)
+    // syscall, which the oracle does not model.
+    Entry::new(
+        "cli.intrinsic_args",
+        "syscall_integer_literal_args_typed_u64",
+        external(ExternalDependencyKind::SystemCall),
+        &["x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.intrinsic_args",
+        "syscall_mixed_literal_and_var_args",
+        external(ExternalDependencyKind::SystemCall),
+        &["x86-64-linux"],
+    ),
     // RUE-682: only the std.hash cases that route bytes through StrBuf or
     // ArrayBuf(u8) hit the `@byte_copy` gap. The three that hash `str` views
     // directly — including `hash_known_answer_vectors`, which carries the

--- a/crates/rue-parser/src/intrinsics.rs
+++ b/crates/rue-parser/src/intrinsics.rs
@@ -20,11 +20,17 @@
 /// must be lowered as a `TypeIntrinsic` (like `@size_of`), not an expression
 /// call. `require_trivially_droppable` is the analogous by-copy-read gate
 /// (RUE-651).
+///
+/// `int_max`/`int_min` are the integer-bounds intrinsics (RUE-694): they take
+/// an integer type and evaluate to that type's largest/smallest value, typed
+/// as the queried type itself.
 pub const TYPE_INTRINSICS: &[&str] = &[
     "size_of",
     "align_of",
     "require_droppable",
     "require_trivially_droppable",
+    "int_max",
+    "int_min",
 ];
 
 /// The field-offset intrinsic `@offset_of(T, field)` (RUE-301): its first

--- a/crates/rue-parser/src/parser.rs
+++ b/crates/rue-parser/src/parser.rs
@@ -472,6 +472,8 @@ mod tests {
                 "align_of",
                 "require_droppable",
                 "require_trivially_droppable",
+                "int_max",
+                "int_min",
             ] {
                 let source = format!("fn f() -> i32 {{ @{intrinsic}({spelling}) }}");
                 let args = intrinsic_args(&source);
@@ -515,6 +517,8 @@ mod tests {
             "fn f() -> i32 { @size_of(Point { x: 1 }) }",
             "fn f() -> i32 { @align_of(!x) }",
             "fn f() -> i32 { @require_droppable(!true) }",
+            "fn f() -> i32 { @int_max(1 + 2) }",
+            "fn f() -> i32 { @int_min(\"s\") }",
             "fn f() -> i32 { @offset_of(1 + 2, x) }",
         ] {
             let errors = parse_source(source).unwrap_err();

--- a/crates/rue-runtime/src/aarch64_macos.rs
+++ b/crates/rue-runtime/src/aarch64_macos.rs
@@ -402,38 +402,163 @@ pub fn munmap(addr: *mut u8, size: usize) -> i64 {
     if err_flag != 0 { -result } else { result }
 }
 
-/// Install the stack-overflow SIGSEGV handler.
+/// macOS syscall number for sigaction (SYS_sigaction).
+const SYS_SIGACTION: u64 = 46;
+/// macOS syscall number for sigaltstack (SYS_sigaltstack).
+const SYS_SIGALTSTACK: u64 = 53;
+/// Segmentation-fault signal number (same value as Linux).
+const SIGSEGV: u64 = 11;
+/// Run the handler on the alternate signal stack. Darwin's value (0x0001)
+/// differs from Linux's (0x0800_0000).
+const SA_ONSTACK: i32 = 0x0001;
+
+// Darwin's `sigaction(2)` (SYS_sigaction = 46) takes a `struct __sigaction`
+// that, unlike Linux, carries a CALLER-SUPPLIED signal trampoline
+// (`sa_tramp`): on delivery the kernel jumps to `sa_tramp`, not the handler.
+// macOS provides no kernel/vDSO trampoline (libc supplies its own
+// `_sigtramp`), so this freestanding runtime defines one. The kernel's
+// `sendsig` enters it with
+//   x0 = catcher (the registered handler), x1 = infostyle, x2 = sig,
+//   x3 = siginfo*, x4 = ucontext*.
+// Our catcher is `extern "C" fn(i32) -> !` and exits the process, so the
+// trampoline only needs to invoke it with the signal number in `x0`; it never
+// returns, so no `sigreturn` epilogue is required (the same reasoning as the
+// x86-64 Linux restorer, which also never runs because the handler exits).
+core::arch::global_asm!(
+    ".globl _rue_darwin_sigtramp",
+    ".p2align 2",
+    "_rue_darwin_sigtramp:",
+    "mov x9, x0", // x9 = catcher (the real handler)
+    "mov x0, x2", // x0 = sig (the handler's only argument)
+    "blr x9",     // catcher(sig) — never returns (it exits)
+    "brk #0x1",   // trap if control ever returns here
+);
+
+unsafe extern "C" {
+    /// Signal-entry trampoline defined in `global_asm!` above. Address only —
+    /// never called directly from Rust. Referencing it from Rust emits a
+    /// Mach-O GOT_LOAD relocation pair, which the internal linker statically
+    /// relaxes to direct addressing (RUE-707).
+    fn rue_darwin_sigtramp();
+}
+
+/// Darwin `stack_t` layout: `{ void *ss_sp; size_t ss_size; int ss_flags; }`.
+/// Note the field order differs from Linux (size before flags).
+#[repr(C)]
+struct DarwinStackT {
+    ss_sp: *mut u8,
+    ss_size: usize,
+    ss_flags: i32,
+}
+
+/// Darwin `struct __sigaction` — the shape the raw `sigaction` syscall
+/// expects: the handler, then the caller-supplied trampoline, then the mask
+/// and flags (XNU `bsd/sys/signal.h`).
+#[repr(C)]
+struct DarwinSigaction {
+    sa_handler: usize,
+    sa_tramp: usize,
+    sa_mask: u32,
+    sa_flags: i32,
+}
+
+/// Register `nss` as the alternate signal stack (`sigaltstack(2)`).
 ///
-/// # macOS limitation (RUE-707)
+/// # Safety
+/// `nss` must point at a valid `DarwinStackT` describing a live memory region.
+unsafe fn sigaltstack(nss: *const DarwinStackT) -> i64 {
+    let result: i64;
+    let err_flag: u64;
+    // SAFETY: caller guarantees `nss` is valid; the syscall itself follows the
+    // same Darwin convention as every wrapper above (carry flag = error).
+    unsafe {
+        asm!(
+            "svc #0x80",
+            "cset {err}, cs",
+            inlateout("x16") SYS_SIGALTSTACK => _,
+            in("x0") nss,
+            in("x1") 0u64, // oss: NULL
+            lateout("x0") result,
+            err = out(reg) err_flag,
+            out("x17") _,
+        );
+    }
+    if err_flag != 0 { -result } else { result }
+}
+
+/// Install `nsa` as the disposition for signal `sig` (`sigaction(2)`).
 ///
-/// On Linux this maps an alternate signal stack (`sigaltstack`) and installs a
-/// `SIGSEGV` handler (`rt_sigaction`) with `SA_ONSTACK`, turning a stack
-/// overflow into a clean "stack overflow" abort (exit 101) instead of a raw
-/// SIGSEGV (exit 139).
+/// # Safety
+/// `nsa` must point at a valid `DarwinSigaction` whose `sa_tramp` is a valid
+/// signal-entry trampoline.
+unsafe fn sigaction_syscall(sig: u64, nsa: *const DarwinSigaction) -> i64 {
+    let result: i64;
+    let err_flag: u64;
+    // SAFETY: caller guarantees `nsa` is valid; same syscall convention as the
+    // wrappers above.
+    unsafe {
+        asm!(
+            "svc #0x80",
+            "cset {err}, cs",
+            inlateout("x16") SYS_SIGACTION => _,
+            in("x0") sig,
+            in("x1") nsa,
+            in("x2") 0u64, // osa: NULL
+            lateout("x0") result,
+            err = out(reg) err_flag,
+            out("x17") _,
+        );
+    }
+    if err_flag != 0 { -result } else { result }
+}
+
+/// Install the stack-overflow SIGSEGV handler (RUE-645 / RUE-707).
 ///
-/// Darwin's signal ABI requires a platform-specific implementation, so this is
-/// intentionally a no-op:
+/// Maps a 64 KiB alternate signal stack (comfortably above macOS
+/// `MINSIGSTKSZ`), registers it with `sigaltstack`, and installs a `SIGSEGV`
+/// handler via the raw `sigaction` syscall with `SA_ONSTACK` and our own
+/// `sa_tramp`. A stack overflow then aborts cleanly ("stack overflow", exit
+/// 101) instead of a raw SIGSEGV (exit 139), matching the Linux targets.
 ///
-/// - The BSD `sigaction(2)` syscall (SYS_sigaction = 46) takes a
-///   `struct __sigaction` that, unlike Linux, includes a **caller-supplied
-///   signal trampoline** (`sa_tramp`). macOS provides no kernel/vDSO
-///   trampoline; libc passes its own `_sigtramp`, which saves/restores the
-///   full register + FP/SIMD state and finally issues the `sigreturn` syscall.
-///   A freestanding runtime would have to hand-write and correctly align that
-///   trampoline in assembly.
-/// - The `struct __sigaction` / `stack_t` layouts and flag values differ from
-///   Linux and require Apple Silicon validation.
+/// Every step is best-effort: any syscall failure leaves the default
+/// disposition in place, and a wrong trampoline only affects the (rare)
+/// stack-overflow delivery path — never a normal program — so the worst case
+/// is the prior exit-139 behavior.
 ///
-/// Getting the trampoline subtly wrong re-crashes inside signal delivery, so
-/// the runtime leaves the default SIGSEGV disposition in place (exit 139).
-/// The CLI regression test is marked `known_bug_on = ["aarch64-macos"]` and
-/// RUE-707 tracks the missing trampoline and handler.
-///
-/// The `_handler` argument matches the Linux signature so `entry::_main` can
-/// call this unconditionally.
-pub fn install_stack_overflow_handler(_handler: extern "C" fn(i32) -> !) {
-    // Deliberate no-op until the Darwin trampoline contract is implemented
-    // and validated (RUE-707).
+/// The first attempt at this (PR #1512) made every macOS link fail: the
+/// `rue_darwin_sigtramp as usize` reference emits an
+/// `ARM64_RELOC_GOT_LOAD_PAGE21/PAGEOFF12` pair, which the internal linker
+/// did not support at the time. The linker now statically relaxes those
+/// (LDR from the GOT slot -> ADD of the symbol address), so this reference
+/// links; behavioral verification is CI's macOS leg running the
+/// `stack_overflow.toml` CLI case.
+pub fn install_stack_overflow_handler(handler: extern "C" fn(i32) -> !) {
+    const ALT_STACK_SIZE: usize = 64 * 1024;
+
+    let stack = mmap(ALT_STACK_SIZE);
+    if stack.is_null() {
+        return;
+    }
+
+    let ss = DarwinStackT {
+        ss_sp: stack,
+        ss_size: ALT_STACK_SIZE,
+        ss_flags: 0,
+    };
+    // SAFETY: `ss` describes the region just mmap'd, live for the process.
+    if unsafe { sigaltstack(&ss) } < 0 {
+        return;
+    }
+
+    let act = DarwinSigaction {
+        sa_handler: handler as usize,
+        sa_tramp: rue_darwin_sigtramp as usize,
+        sa_mask: 0,
+        sa_flags: SA_ONSTACK,
+    };
+    // SAFETY: `act` is a valid `__sigaction` with a real trampoline; SIGSEGV
+    // is a valid signal number.
+    let _ = unsafe { sigaction_syscall(SIGSEGV, &act) };
 }
 
 /// Exit the process with the given status code.
@@ -600,10 +725,10 @@ mod tests {
 
     #[test]
     fn stack_overflow_handler_is_installable() {
-        // Reference the installer so the unit-test build type-checks it. On
-        // macOS this is a deliberate no-op (RUE-707); taking its
-        // address keeps the signature in sync with the Linux backends without
-        // executing anything.
+        // Reference the installer so the unit-test build type-checks it.
+        // Taking its address keeps the signature in sync with the Linux
+        // backends without executing anything (installing a real SIGSEGV
+        // disposition inside the libtest harness would be hostile).
         let installer: fn(extern "C" fn(i32) -> !) = install_stack_overflow_handler;
         assert!(installer as usize != 0);
     }

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -527,6 +527,125 @@ fn main() -> i32 {
 """
 exit_code = 4
 
+# =============================================================================
+# @int_max / @int_min Intrinsics (RUE-694)
+# =============================================================================
+
+[[case]]
+name = "int_max_int_min_all_widths"
+spec = ["4.13:126", "4.13:127"]
+source = """
+fn main() -> i32 {
+    if @int_max(u8) != 255 { return 1; }
+    if @int_min(u8) != 0 { return 2; }
+    if @int_max(i8) != 127 { return 3; }
+    if @int_min(i8) != -128 { return 4; }
+    if @int_max(u16) != 65535 { return 5; }
+    if @int_max(i16) != 32767 { return 6; }
+    if @int_min(i16) != -32768 { return 7; }
+    if @int_max(u32) != 4294967295 { return 8; }
+    if @int_max(i32) != 2147483647 { return 9; }
+    if @int_min(i32) != -2147483647 - 1 { return 10; }
+    if @int_max(u64) != 18446744073709551615 { return 11; }
+    if @int_min(u64) != 0 { return 12; }
+    if @int_max(i64) != 9223372036854775807 { return 13; }
+    if @int_min(i64) != -9223372036854775807 - 1 { return 14; }
+    0
+}
+"""
+exit_code = 0
+
+# The result is typed at the queried type itself (4.13:128): a u8 bound flows
+# into a u8 parameter without a cast, and the extreme u64/i64 bounds — which
+# fit no other integer type — are usable directly.
+[[case]]
+name = "int_bounds_result_typed_at_queried_type"
+spec = ["4.13:128"]
+source = """
+fn takes_u8(x: u8) -> i32 { if x == 255 { 0 } else { 1 } }
+fn main() -> i32 {
+    takes_u8(@int_max(u8))
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "int_bounds_reject_non_integer_type"
+spec = ["4.13:129"]
+source = """
+fn main() -> i32 {
+    @int_max(bool)
+}
+"""
+compile_fail = true
+error_contains = ["E0702", "an integer type", "bool"]
+
+[[case]]
+name = "int_min_reject_struct_type"
+spec = ["4.13:129"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let x = @int_min(Point);
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0702"]
+
+# The integer-bounds intrinsics are comptime-evaluable (4.13:130): legal in a
+# const initializer and in a comptime argument position, where @size_of is not
+# (4.14:29).
+[[case]]
+name = "int_bounds_const_initializer"
+spec = ["4.13:130"]
+source = """
+const MAX8: u8 = @int_max(u8);
+const MIN64: i64 = @int_min(i64);
+fn main() -> i32 {
+    if MAX8 != 255 { return 1; }
+    if MIN64 != -9223372036854775807 - 1 { return 2; }
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "int_bounds_comptime_argument"
+spec = ["4.13:130"]
+source = """
+fn pick(comptime n: i8) -> i32 {
+    if n == 127 { 0 } else { 1 }
+}
+fn main() -> i32 {
+    pick(@int_max(i8))
+}
+"""
+exit_code = 0
+
+# Generic comptime-typed code composes with the bounds (4.13:132): an overflow
+# predicate over `T` needs no per-type constants (the RUE-694 motivating use).
+[[case]]
+name = "int_bounds_generic_overflow_predicate"
+spec = ["4.13:126", "4.13:128"]
+source = """
+fn would_overflow_add(comptime T: type, a: T, b: T) -> bool {
+    if b > 0 {
+        return a > @int_max(T) - b;
+    }
+    a < @int_min(T) - b
+}
+fn main() -> i32 {
+    if would_overflow_add(u8, 200, 100) == false { return 1; }
+    if would_overflow_add(u8, 100, 100) == true { return 2; }
+    if would_overflow_add(i8, 100, 100) == false { return 3; }
+    if would_overflow_add(i8, -100, -100) == false { return 4; }
+    if would_overflow_add(i64, 1, 1) == true { return 5; }
+    0
+}
+"""
+exit_code = 0
+
 # Each type observes its natural compact alignment (4.13:22): i8 and bool are
 # one byte, i64 is eight, and a struct's alignment is its widest field's (Point
 # is four, from its i32 fields).

--- a/crates/rue-spec/cases/expressions/match.toml
+++ b/crates/rue-spec/cases/expressions/match.toml
@@ -508,6 +508,32 @@ fn main() -> i32 {
 """
 compile_fail = true
 
+# All arms agree at the annotated binding type (4.7:12): an integer-literal
+# arm is typed at the `let` annotation rather than defaulting to i32, even
+# when the pattern heads are inline type-constructor calls whose payload
+# bindings inference cannot reduce locally (RUE-954).
+[[case]]
+name = "arm_literal_typed_by_let_annotation"
+spec = ["4.7:12"]
+source = """
+fn Opt(comptime T: type) -> type {
+    enum {
+        Some(T),
+        None,
+    }
+}
+
+fn main() -> i32 {
+    let x = Opt(u8).Some(116);
+    let first: u8 = match x {
+        Opt(u8).Some(b) => b,
+        Opt(u8).None => 0,
+    };
+    if first == 116 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
 # =============================================================================
 # Pattern Type Must Match Scrutinee
 # =============================================================================

--- a/crates/rue-ui-tests/cases/diagnostics/int_bounds_non_integer.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/int_bounds_non_integer.toml
@@ -1,0 +1,39 @@
+[section]
+id = "diagnostics.int-bounds-non-integer"
+name = "@int_max/@int_min on a non-integer type is E0702 in every context (RUE-694)"
+description = """
+The integer-bounds intrinsics are defined only for integer types (spec
+4.13:129). A non-integer type argument reports E0702 naming the intrinsic, the
+expectation, and the found type — in runtime expression position and in a
+const initializer alike, so the const-context path does not degrade to the
+generic E0434 unsupported-expression diagnostic.
+"""
+
+[[case]]
+name = "int_max_bool_expression_position"
+description = "Runtime expression position names the intrinsic and the found type."
+source = """
+fn main() -> i32 {
+    let x = @int_max(bool);
+    0
+}
+"""
+compile_fail = true
+error_contains = [
+    "E0702",
+    "intrinsic '@int_max' expects an integer type, found bool",
+]
+
+[[case]]
+name = "int_min_bool_const_position"
+description = "A const initializer reports the same E0702, not E0434."
+source = """
+const X: i32 = @int_min(bool);
+
+fn main() -> i32 { X }
+"""
+compile_fail = true
+error_contains = [
+    "E0702",
+    "expects an integer type",
+]

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -53,6 +53,8 @@ Expression intrinsics (usable in any expression position):
 | `@dbg` | Print debug output | 1 expression (int, bool, or string) | `()` |
 | `@size_of` | Get type size in bytes | 1 type | `i32` |
 | `@align_of` | Get type alignment in bytes | 1 type | `i32` |
+| `@int_max` | Largest value of an integer type (§4.13:126) | 1 type (integer) | that integer type |
+| `@int_min` | Smallest value of an integer type (§4.13:126) | 1 type (integer) | that integer type |
 | `@offset_of` | Get a struct field's byte offset | 1 type, 1 field name | `u64` |
 | `@intCast` | Convert between integer types | 1 expression (integer) | inferred integer type |
 | `@bitCast` | Reinterpret an integer's bits at the same width (§4.13:118) | 1 expression (integer) | inferred integer type of the same width |
@@ -270,6 +272,58 @@ fn main() -> i32 {
     @align_of(i32)    // 4 (i32's natural alignment, observed under the compact layout)
 }
 ```
+
+## `@int_max` and `@int_min`
+
+{{ rule(id="4.13:126", cat="normative") }}
+
+The `@int_max` intrinsic returns the largest value representable in an integer
+type, and the `@int_min` intrinsic returns the smallest. The bounds follow the
+two's-complement ranges of §3.1: for an unsigned type of width *w* they are
+`2^w - 1` and `0`; for a signed type they are `2^(w-1) - 1` and `-2^(w-1)`.
+
+{{ rule(id="4.13:127", cat="normative") }}
+
+`@int_max` and `@int_min` each accept exactly one argument, which **MUST** be
+an integer type (§3.1).
+
+{{ rule(id="4.13:128", cat="normative") }}
+
+The result type of `@int_max(T)` and `@int_min(T)` is `T` itself. This is the
+only result type that can represent every bound exactly: `@int_max(u64)`
+exceeds every signed type, and `@int_min(i64)` is below every unsigned type.
+
+{{ rule(id="4.13:129", cat="legality-rule") }}
+
+It is a compile-time error (`E0702`) to apply `@int_max` or `@int_min` to a
+type argument that is not an integer type.
+
+{{ rule(id="4.13:130", cat="normative") }}
+
+The value of `@int_max(T)` and `@int_min(T)` is determined at compile time,
+and — unlike `@size_of` and `@align_of` — the integer-bounds intrinsics are
+**comptime-evaluable** (4.14:29): the bounds depend only on the identity of
+`T`, never on layout, so they may appear in `const` initializers and
+`comptime` argument positions.
+
+{{ rule(id="4.13:131") }}
+
+```rue
+fn main() -> i32 {
+    if @int_max(u8) == 255 && @int_min(i8) == -128 {
+        0
+    } else {
+        1
+    }
+}
+```
+
+{{ rule(id="4.13:132", cat="informative") }}
+
+Because the result is typed at the queried type, the intrinsics compose with
+generic `comptime T` code: overflow predicates such as
+`a > @int_max(T) - b` need no per-type constants, which is the motivating use
+(generic checked/saturating arithmetic, RUE-694).
 
 ## `@offset_of`
 

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -730,16 +730,18 @@ fn main() -> i32 {
 {{ rule(id="4.14:29", cat="legality-rule") }}
 
 The comptime-evaluable set is exactly the least set closed under rules
-4.14:26 through 4.14:28; **no other expression is comptime-evaluable**. In
-particular, the type-introspection intrinsics `@size_of` and `@align_of`
-(§4.13) are *not* comptime-evaluable in the current language: although their
-results are compile-time constants, an implementation is not required to fold
-them into the comptime-evaluable set, and this one does not. Using such an
-expression where comptime evaluation is required is a compile-time error — in a
+4.14:26 through 4.14:28, plus the integer-bounds intrinsics `@int_max` and
+`@int_min` (4.13:130), whose values depend only on the identity of their type
+argument; **no other expression is comptime-evaluable**. In particular, the
+layout-introspection intrinsics `@size_of` and `@align_of` (§4.13) are *not*
+comptime-evaluable in the current language: although their results are
+compile-time constants, an implementation is not required to fold them into
+the comptime-evaluable set, and this one does not. Using such an expression
+where comptime evaluation is required is a compile-time error — in a
 `comptime` argument position (4.14:6) the diagnostic is `E1201`, and in a
 `const` initializer (Chapter 6) it is `E0434`. A future revision may enlarge
-the set; a program that relies on an expression *not* covered by rules
-4.14:26–4.14:28 being comptime-evaluable is non-portable.
+the set; a program that relies on an expression *not* covered by this rule
+being comptime-evaluable is non-portable.
 
 ```rue
 fn dbl(comptime n: i32) -> i32 { n * 2 }

--- a/examples/harbor/accounting.rue
+++ b/examples/harbor/accounting.rue
@@ -23,21 +23,21 @@ fn cast(value: u64, inout overflows: u64) -> i64 {
 }
 
 fn add(a: i64, b: i64, inout overflows: u64) -> i64 {
-    match std.math.checked_add(a, b) {
+    match std.math.checked_add(i64, a, b) {
         OptI64.Some(v) => v,
         OptI64.None => { overflows += 1; if b >= 0 { 9223372036854775807 } else { -9223372036854775807 - 1 } },
     }
 }
 
 fn sub(a: i64, b: i64, inout overflows: u64) -> i64 {
-    match std.math.checked_sub(a, b) {
+    match std.math.checked_sub(i64, a, b) {
         OptI64.Some(v) => v,
         OptI64.None => { overflows += 1; if b < 0 { 9223372036854775807 } else { -9223372036854775807 - 1 } },
     }
 }
 
 fn mul(a: i64, b: i64, inout overflows: u64) -> i64 {
-    match std.math.checked_mul(a, b) {
+    match std.math.checked_mul(i64, a, b) {
         OptI64.Some(v) => v,
         OptI64.None => {
             overflows += 1;

--- a/examples/ruelex/lex.rue
+++ b/examples/ruelex/lex.rue
@@ -220,7 +220,8 @@ pub struct Lexer {
         if word_eq(borrow key, "type") { return "TYPE(type)"; }
 
         if word_eq(borrow key, "size_of") || word_eq(borrow key, "align_of") ||
-            word_eq(borrow key, "require_droppable") || word_eq(borrow key, "require_trivially_droppable") {
+            word_eq(borrow key, "require_droppable") || word_eq(borrow key, "require_trivially_droppable") ||
+            word_eq(borrow key, "int_max") || word_eq(borrow key, "int_min") {
             self.last_aux = 1;
         } else if word_eq(borrow key, "offset_of") {
             self.last_aux = 2;

--- a/std/math.rue
+++ b/std/math.rue
@@ -3,9 +3,9 @@
 // The legacy `abs`/`min`/`max`/`clamp` remain `i32` for backward compatibility;
 // the GENERIC (comptime-`T`) min/max/clamp live in `std.cmp`. The extended
 // functions below are generic over a comptime integer type `T` (verified:
-// `+ - * / % < &` all work on a type parameter). `checked_*` are `i64`-concrete:
-// portable generic overflow checks need an integer-bounds intrinsic
-// (`@int_max(T)`/`@int_min(T)`) that does not exist yet (RUE-694).
+// `+ - * / % < &` all work on a type parameter), including `checked_*`, whose
+// overflow pre-checks use the integer-bounds intrinsics `@int_max(T)`/
+// `@int_min(T)` (RUE-694).
 //
 // NOTE: calling a generic (`comptime T`) helper here from another module with a
 // bare integer literal currently fails to coerce the literal (RUE-693); bind a
@@ -137,83 +137,93 @@ pub fn is_prime(comptime T: type, n: T) -> bool {
     true
 }
 
-// --- i64 checked arithmetic (None on overflow, no trap) ---
+// --- checked arithmetic (None on overflow, no trap) ---
+//
+// Generic over a comptime integer type `T` (RUE-694): the overflow pre-checks
+// are written against `@int_max(T)`/`@int_min(T)`, so signed and unsigned
+// types alike work. The signed-only corners (`MIN / -1`) live behind an
+// `@int_min(T) == 0` signedness test whose signed arm is unreachable for
+// unsigned instantiations and avoids negative literals so it still
+// type-checks at unsigned `T`.
 
-// `i64::MAX` / `i64::MIN` written without overflowing the literal parser.
-fn i64_max() -> i64 {
-    9223372036854775807
-}
-fn i64_min() -> i64 {
-    -9223372036854775807 - 1
-}
-
-// `a + b`, or `None` if it would overflow `i64`.
-pub fn checked_add(a: i64, b: i64) -> option.Option(i64) {
-    let O = option.Option(i64);
+// `a + b`, or `None` if it would overflow `T`.
+pub fn checked_add(comptime T: type, a: T, b: T) -> option.Option(T) {
+    let O = option.Option(T);
     if b > 0 {
-        if a > i64_max() - b {
+        if a > @int_max(T) - b {
             return O.None;
         }
     } else {
-        if a < i64_min() - b {
+        if a < @int_min(T) - b {
             return O.None;
         }
     }
     O.Some(a + b)
 }
 
-// `a - b`, or `None` if it would overflow `i64`.
-pub fn checked_sub(a: i64, b: i64) -> option.Option(i64) {
-    let O = option.Option(i64);
+// `a - b`, or `None` if it would overflow `T`.
+pub fn checked_sub(comptime T: type, a: T, b: T) -> option.Option(T) {
+    let O = option.Option(T);
     if b < 0 {
-        if a > i64_max() + b {
+        if a > @int_max(T) + b {
             return O.None;
         }
     } else {
-        if a < i64_min() + b {
+        if a < @int_min(T) + b {
             return O.None;
         }
     }
     O.Some(a - b)
 }
 
-// `a * b`, or `None` if it would overflow `i64`. Pre-checks via division so the
+// `a * b`, or `None` if it would overflow `T`. Pre-checks via division so the
 // multiply itself never traps.
-pub fn checked_mul(a: i64, b: i64) -> option.Option(i64) {
-    let O = option.Option(i64);
+pub fn checked_mul(comptime T: type, a: T, b: T) -> option.Option(T) {
+    let O = option.Option(T);
     if a == 0 || b == 0 {
         return O.Some(0);
     }
-    // The MIN/-1 corner traps under the division pre-check, so handle it first.
-    if a == -1 {
-        if b == i64_min() {
+    if @int_min(T) == 0 {
+        // Unsigned: a single division pre-check covers every case.
+        if a > @int_max(T) / b {
             return O.None;
         }
         return O.Some(a * b);
     }
-    if b == -1 {
-        if a == i64_min() {
+    // Signed. The MIN/-1 corners trap under the division pre-check, so handle
+    // them first; `minus_one` is computed rather than written as a literal so
+    // this (unreachable-for-unsigned) path type-checks at unsigned `T`.
+    let zero: T = 0;
+    let minus_one: T = zero - 1;
+    if a == minus_one {
+        if b == @int_min(T) {
+            return O.None;
+        }
+        return O.Some(a * b);
+    }
+    if b == minus_one {
+        if a == @int_min(T) {
             return O.None;
         }
         return O.Some(a * b);
     }
     if a > 0 {
         if b > 0 {
-            if a > i64_max() / b {
+            if a > @int_max(T) / b {
                 return O.None;
             }
         } else {
-            if b < i64_min() / a {
+            if b < @int_min(T) / a {
                 return O.None;
             }
         }
     } else {
         if b > 0 {
-            if a < i64_min() / b {
+            if a < @int_min(T) / b {
                 return O.None;
             }
         } else {
-            if a < i64_max() / b {
+            if a < @int_max(T) / b {
                 return O.None;
             }
         }

--- a/std/strings.rue
+++ b/std/strings.rue
@@ -124,9 +124,9 @@ pub fn parse_int(s: StrBuf) -> option.Option(i64) {
             return O.None;
         }
         let dg: i64 = @intCast(byte - 48);
-        match math.checked_mul(acc, ten) {
+        match math.checked_mul(i64, acc, ten) {
             O.Some(m) => {
-                match math.checked_add(m, dg) {
+                match math.checked_add(i64, m, dg) {
                     O.Some(sum) => {
                         acc = sum;
                     },


### PR DESCRIPTION
Three forgotten backlog items.

## `@int_max(T)` / `@int_min(T)` — Fixes RUE-694

A type's representable bounds were previously unobtainable, so generic checked/saturating arithmetic over `comptime T` could not be written (`std.math.checked_*` hard-coded `i64` literals for this reason). This adds the integer-bounds intrinsics to the `@size_of` type-intrinsic family:

- **Result type is `T` itself** — the only choice that never truncates (`@int_max(u64)` fits no signed type, `@int_min(i64)` fits no unsigned type). The value folds to a `Const` at analysis time; narrow signed minima ride the u64 payload sign-extended, matching how negative literals are emitted.
- **Comptime-evaluable**, unlike `@size_of`/`@align_of`: the bounds depend only on the type identity, never layout, so `const MAX: i64 = @int_max(i64);` and comptime argument positions work. Both the body comptime engine and the declaration-time semantic-nucleus evaluator handle them, with `Type::int_max`/`int_min` as the single numeric authority.
- **E0702 on a non-integer type argument** in every context (expression and const positions), reusing the existing diagnostic rather than allocating a new code.
- Spec: new paragraphs 4.13:126–132 plus quick-reference rows; 4.14:29 amended to admit the intrinsics into the comptime-evaluable set. Traceability gate green.
- **`std.math.checked_add/sub/mul` are now generic over `comptime T`** — the payoff the issue promised. Overflow pre-checks are written against the new intrinsics, the hand-rolled `i64_max`/`i64_min` helpers are gone, and the signed `MIN/-1` corners sit behind an `@int_min(T) == 0` signedness test whose signed arm computes minus-one instead of writing a negative literal, so unsigned instantiations type-check. The `std_core` smoke gains u8/i8 overflow coverage.

## Integer-literal contextual typing gaps — Fixes RUE-954

The two remaining unthreaded positions of the RUE-633/RUE-950 family:

1. **Match arms under inline type-constructor pattern heads** ignored the `let` annotation: `let first: u8 = match x { Opt(u8).Some(b) => b, Opt(u8).None => 0 }` failed with E0206 because the head is not reducible inside the inference engine, the payload binding fell to the unknown-name `<error>` fallback, and the sibling arm's literal defaulted to i32. Sema already pre-reduces inline constructor heads (`inline_ctor_head_types`, RUE-950) for expression positions — the candidate scan now also collects pattern `ctor_head`s, and both `pattern_type` and the payload-binding pre-typing consult the map.
2. **`@syscall` argument positions** generated arguments unconstrained, so `@syscall(32, 1)` failed E0702 until each literal was pre-bound as `let fd: u64 = 1`. Literal arguments now see the declared `u64` parameter type; non-literal arguments are left to sema so a wrongly-typed variable keeps the targeted `E0702: u64 for argument {i}` diagnostic instead of degrading to a generic unification E0206.

The new syscall regression cases are registered as `SystemCall` oracle model gaps (the corpus classification audit requires it).

## macOS aarch64 stack-overflow clean abort — Fixes RUE-707

The July attempt (PR #1512) failed for a reason that had nothing to do with signals: referencing the hand-written `sa_tramp` trampoline from Rust emits a Mach-O `GOT_LOAD_PAGE21/PAGEOFF12` relocation pair the internal linker rejected as unknown types, so **every** macOS link died. Reproduced locally on Linux (`link error: unsupported relocation: unknown type 6`), then fixed in two halves:

- **Linker**: statically relax the GOT_LOAD pair. The linker builds fully static images with no GOT, so the ADRP is retargeted at the symbol's own page and the LDR of the GOT slot is rewritten to an ADD of the symbol's low 12 bits — the aarch64 analogue of the existing x86-64 GotPcRelX mov→lea relaxation. A GOT_LOAD_PAGEOFF12 on anything but the 64-bit LDR form fails loudly. This also defuses the same latent landmine in the runtime archive's `compiler_builtins` float tables.
- **Runtime**: install the handler on macOS — 64 KiB alternate stack via `sigaltstack` (SYS 53), SIGSEGV disposition via the raw Darwin `sigaction` (SYS 46) with `SA_ONSTACK` and a hand-written `sa_tramp` (Darwin's kernel jumps to a caller-supplied trampoline, not the handler; ours forwards the signal number and never returns, so no `sigreturn` epilogue is needed). Best-effort throughout: any failure leaves the prior exit-139 behavior.

Cross-linked and disassembled locally: the relaxed pair lands exactly on the trampoline address, and the `__sigaction`/`stack_t` stores match the XNU layouts. **Behavioral verification is this PR's macOS CI leg**, which now runs the `stack_overflow.toml` case on aarch64-macos.

## Validation

- `scripts/rue quick` — 885 passed; full linker suite incl. new GOT_LOAD relaxation unit tests (relax + reject-non-LDR)
- Full spec run incl. traceability gate — 2343 passed (4.7, 4.13, 4.14 cover the new/changed paragraphs)
- `scripts/rue cli match_inference` / `cli intrinsic` / `cli std` / `cli stack_overflow` — new regression + control cases pass
- `scripts/rue ui` — new E0702 diagnostic cases pass
- `//:cli-shard-weights-validation`, oracle-diff corpus audit — green
- Control cases pin that genuinely disagreeing arms and wrong-typed syscall variables still error (E0206 / E0702)