### PR TITLE
RUE-1522: gatelib — one masker, one walker, one gate skeleton

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -849,6 +849,8 @@ rue_sh_test(
 rue_sh_test(
     name = "debug-assert-policy-tool-tests",
     test = "scripts/test-debug-assert-policy.py",
+    resources = ["scripts/validate-debug-assert-policy.py"] +
+        glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
     },

--- a/BUCK
+++ b/BUCK
@@ -889,7 +889,7 @@ rue_sh_test(
     resources = [
         "scripts/cli-timeout-policy.py",
         "scripts/validate-python-baseline.py",
-    ],
+    ] + glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
     },

--- a/BUCK
+++ b/BUCK
@@ -1367,6 +1367,7 @@ rue_sh_test(
 rue_sh_test(
     name = "body-analysis-capability-inventory-validation",
     test = "scripts/validate-body-analysis-capabilities.py",
+    resources = glob(["scripts/gatelib/*.py"]),
     args = [
         "--source", "rue-air=$(location //crates/rue-air:body-analysis-capability-inventory-sources)",
         "--source", "rue-compiler=$(location //crates/rue-compiler:body-analysis-capability-inventory-sources)",
@@ -1376,7 +1377,8 @@ rue_sh_test(
 rue_sh_test(
     name = "body-analysis-capability-inventory-tool-tests",
     test = "scripts/test-body-analysis-capabilities.py",
-    resources = ["scripts/validate-body-analysis-capabilities.py"],
+    resources = ["scripts/validate-body-analysis-capabilities.py"] +
+        glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
     },

--- a/BUCK
+++ b/BUCK
@@ -859,7 +859,8 @@ rue_sh_test(
 rue_sh_test(
     name = "shell-pipefail-pipeline-tool-tests",
     test = "scripts/test-validate-shell-pipefail-pipelines.py",
-    resources = ["scripts/validate-shell-pipefail-pipelines.py"],
+    resources = ["scripts/validate-shell-pipefail-pipelines.py"] +
+        glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
     },

--- a/BUCK
+++ b/BUCK
@@ -920,6 +920,21 @@ rue_sh_test(
     },
 )
 
+# Shared plumbing for the validate-* gates (RUE-1522): the Rust masker,
+# walker prune policy, workflow job splitter, gate skeleton, and the tool
+# tests' script loader. The masker tests are the single place the
+# lifetime-vs-char-literal contract is pinned.
+rue_sh_test(
+    name = "gatelib-tests",
+    test = "scripts/test-gatelib.py",
+    resources = glob(["scripts/gatelib/*.py"]) + [
+        "scripts/validate-adrs.py",
+    ],
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+    },
+)
+
 # Same drift contract for the Caldera capacity corpus: the committed
 # examples/caldera is generator output, the generator writes in place, and
 # nothing else compares the two (RUE-1521 found a 782-file divergence that

--- a/BUCK
+++ b/BUCK
@@ -1332,6 +1332,7 @@ rue_sh_test(
 rue_sh_test(
     name = "type-architecture-inventory-validation",
     test = "scripts/validate-type-architecture.py",
+    resources = glob(["scripts/gatelib/*.py"]),
     args = [
         "--source", "rue-air=$(location //crates/rue-air:type-architecture-inventory-sources)",
         "--source", "rue-cfg=$(location //crates/rue-cfg:type-architecture-inventory-sources)",
@@ -1344,7 +1345,8 @@ rue_sh_test(
 rue_sh_test(
     name = "type-architecture-inventory-tool-tests",
     test = "scripts/test-type-architecture.py",
-    resources = ["scripts/validate-type-architecture.py"],
+    resources = ["scripts/validate-type-architecture.py"] +
+        glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
     },

--- a/BUCK
+++ b/BUCK
@@ -1028,6 +1028,7 @@ filegroup(
 rue_sh_test(
     name = "tier-ci-selector-validation",
     test = "scripts/validate-tier-ci-selectors.py",
+    resources = glob(["scripts/gatelib/*.py"]),
     args = [
         "--test-defs",
         "$(location :tier-ci-selector-inputs)/test_defs.bzl",
@@ -1043,7 +1044,8 @@ rue_sh_test(
 rue_sh_test(
     name = "tier-ci-selector-tool-tests",
     test = "scripts/test-validate-tier-ci-selectors.py",
-    resources = ["scripts/validate-tier-ci-selectors.py"],
+    resources = ["scripts/validate-tier-ci-selectors.py"] +
+        glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
         "RUE_TIER_VALIDATION_ROOT": "$(location :tier-ci-selector-inputs)",

--- a/BUCK
+++ b/BUCK
@@ -1301,6 +1301,7 @@ rue_sh_test(
 rue_sh_test(
     name = "runtime-abi-inventory-validation",
     test = "scripts/validate-runtime-abi-inventory.py",
+    resources = glob(["scripts/gatelib/*.py"]),
     args = [
         "--source", "rue-air=$(location //crates/rue-air:runtime-abi-inventory-sources)",
         "--source", "rue-builtins=$(location //crates/rue-builtins:runtime-abi-inventory-sources)",
@@ -1315,7 +1316,8 @@ rue_sh_test(
 rue_sh_test(
     name = "runtime-abi-inventory-tool-tests",
     test = "scripts/test-runtime-abi-inventory.py",
-    resources = ["scripts/validate-runtime-abi-inventory.py"],
+    resources = ["scripts/validate-runtime-abi-inventory.py"] +
+        glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
     },

--- a/BUCK
+++ b/BUCK
@@ -840,7 +840,8 @@ rue_sh_test(
 rue_sh_test(
     name = "required-ci-container-pin-tool-tests",
     test = "scripts/test-required-ci-container-pins.py",
-    resources = ["scripts/validate-required-ci-container-pins.py"],
+    resources = ["scripts/validate-required-ci-container-pins.py"] +
+        glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
     },
@@ -900,6 +901,8 @@ rue_sh_test(
 rue_sh_test(
     name = "release-configuration-tool-tests",
     test = "scripts/test-release-configuration.py",
+    resources = ["scripts/validate-release-configuration.py"] +
+        glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
     },
@@ -979,7 +982,8 @@ rue_sh_test(
 rue_sh_test(
     name = "cli-shard-coverage-tool-tests",
     test = "scripts/test-cli-shard-coverage.py",
-    resources = ["scripts/validate-cli-shard-coverage.py"],
+    resources = ["scripts/validate-cli-shard-coverage.py"] +
+        glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
     },
@@ -1001,7 +1005,7 @@ rue_sh_test(
     resources = [
         "scripts/affected-targets",
         "scripts/validate-test-duplication.py",
-    ],
+    ] + glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
     },
@@ -1055,7 +1059,8 @@ rue_sh_test(
 rue_sh_test(
     name = "ci-required-results-tool-tests",
     test = "scripts/test-ci-required-results.py",
-    resources = ["scripts/ci-required-results.py"],
+    resources = ["scripts/ci-required-results.py"] +
+        glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
     },
@@ -1097,7 +1102,7 @@ rue_sh_test(
     test = "scripts/test-validate-performance-stall.py",
     resources = [
         "scripts/validate-performance-stall.py",
-    ],
+    ] + glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
     },
@@ -1113,7 +1118,7 @@ rue_sh_test(
     test = "scripts/test-generate-site-status.py",
     resources = [
         "scripts/generate-site-status.py",
-    ],
+    ] + glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
     },
@@ -1130,7 +1135,7 @@ rue_sh_test(
     test = "scripts/test-extract-source-excerpts.py",
     resources = [
         "scripts/extract-source-excerpts.py",
-    ],
+    ] + glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
     },
@@ -1146,7 +1151,7 @@ rue_sh_test(
     test = "scripts/test-annotate-performance-commits.py",
     resources = [
         "scripts/annotate-performance-commits.py",
-    ],
+    ] + glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
     },
@@ -1182,7 +1187,8 @@ rue_sh_test(
 rue_sh_test(
     name = "cli-shard-weight-tool-tests",
     test = "scripts/test-cli-shard-weights.py",
-    resources = ["scripts/generate-cli-shard-weights.py"],
+    resources = ["scripts/generate-cli-shard-weights.py"] +
+        glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
     },
@@ -1209,7 +1215,8 @@ rue_sh_test(
 rue_sh_test(
     name = "cli-timeout-policy-tool-tests",
     test = "scripts/test-cli-timeout-policy.py",
-    resources = ["scripts/cli-timeout-policy.py"],
+    resources = ["scripts/cli-timeout-policy.py"] +
+        glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
         "RUE_CLI_CASES": "$(location //crates/rue-cli-tests:cases)/cases",
@@ -1259,7 +1266,8 @@ rue_sh_test(
         "PYTHONDONTWRITEBYTECODE": "1",
         "RUE_FUZZ_REPORT_ROOT": "$(location :fuzz-report-test-inputs)",
     },
-    resources = ["scripts/fuzz-report-failure.py"],
+    resources = ["scripts/fuzz-report-failure.py"] +
+        glob(["scripts/gatelib/*.py"]),
 )
 
 # RUE-1507: the health check that notices a scheduled workflow which has never
@@ -1285,7 +1293,8 @@ rue_sh_test(
         "PYTHONDONTWRITEBYTECODE": "1",
         "RUE_SCHEDULED_WORKFLOWS_ROOT": "$(location :scheduled-workflow-test-inputs)",
     },
-    resources = ["scripts/check-scheduled-workflows.py"],
+    resources = ["scripts/check-scheduled-workflows.py"] +
+        glob(["scripts/gatelib/*.py"]),
 )
 
 # RUE-1119: pin the deterministic, coverage-deciding logic of the affected-

--- a/BUCK
+++ b/BUCK
@@ -1083,7 +1083,7 @@ rue_sh_test(
         # cannot disagree about which `scripts/rue cli` steps the native lanes
         # run.
         "scripts/validate-test-duplication.py",
-    ],
+    ] + glob(["scripts/gatelib/*.py"]),
 )
 
 # RUE-1258: the staleness rule, exercised without a repository or a data
@@ -1158,7 +1158,7 @@ rue_sh_test(
         "scripts/run-native-platform-corpus.sh",
         "scripts/validate-ci-gate.py",
         "scripts/validate-test-duplication.py",
-    ],
+    ] + glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
         "RUE_CI_WORKFLOW": "$(location :required-ci-workflows)/.github/workflows/ci.yml",

--- a/BUCK
+++ b/BUCK
@@ -1353,6 +1353,7 @@ rue_sh_test(
 rue_sh_test(
     name = "payload-ownership-inventory-validation",
     test = "scripts/validate-payload-ownership.py",
+    resources = glob(["scripts/gatelib/*.py"]),
     args = [
         "--source", "rue-rir=$(location //crates/rue-rir:payload-ownership-inventory-sources)",
         "--source", "rue-air=$(location //crates/rue-air:payload-ownership-inventory-sources)",
@@ -1364,7 +1365,8 @@ rue_sh_test(
 rue_sh_test(
     name = "payload-ownership-inventory-tool-tests",
     test = "scripts/test-payload-ownership.py",
-    resources = ["scripts/validate-payload-ownership.py"],
+    resources = ["scripts/validate-payload-ownership.py"] +
+        glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
     },

--- a/BUCK
+++ b/BUCK
@@ -868,7 +868,8 @@ rue_sh_test(
 rue_sh_test(
     name = "shell-bash-baseline-tool-tests",
     test = "scripts/test-validate-shell-bash-baseline.py",
-    resources = ["scripts/validate-shell-bash-baseline.py"],
+    resources = ["scripts/validate-shell-bash-baseline.py"] +
+        glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
     },

--- a/scripts/gatelib/__init__.py
+++ b/scripts/gatelib/__init__.py
@@ -1,0 +1,29 @@
+"""Shared plumbing for the scripts/validate-* gates (RUE-1522).
+
+Each gate keeps its own predicate — the curated tables and per-gate logic are
+the product — but the mechanics every gate reimplemented live here exactly
+once: the Rust comment/literal masker, the repository walker with its prune
+policy, the workflow job splitter, the ``--source CRATE=DIR`` parser, the
+gate main skeleton, and the dash-named-script loader the tool tests use.
+
+Runs on Python 3.9 (the repository tooling floor in AGENTS.md).
+"""
+
+from __future__ import annotations
+
+from .discovery import SKIP_DIRECTORIES, prune_names, walk_files
+from .gate import parse_crate_sources, run_gate
+from .loader import load_script
+from .rust import mask_rust_non_code
+from .workflow import job_blocks
+
+__all__ = [
+    "SKIP_DIRECTORIES",
+    "job_blocks",
+    "load_script",
+    "mask_rust_non_code",
+    "parse_crate_sources",
+    "prune_names",
+    "run_gate",
+    "walk_files",
+]

--- a/scripts/gatelib/discovery.py
+++ b/scripts/gatelib/discovery.py
@@ -1,0 +1,56 @@
+"""Repository walking with the shared prune policy.
+
+Two baseline gates carried character-identical ``_prune`` functions and a
+third reimplemented the same policy inline. The policy: skip the build and
+vendor directories below, and skip nested checkouts by their own VCS marker
+rather than by name — the working agreement puts sibling worktrees under
+``.claude/worktrees/``, and reporting a path inside one as though it were a
+path in THIS tree is worse than not scanning it; that copy has its own gate.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Callable, Iterator, List, Optional
+
+SKIP_DIRECTORIES = {
+    ".buckd",
+    ".git",
+    ".jj",
+    "buck-out",
+    "buck2-bin",
+    "node_modules",
+    "target",
+    "third-party",
+}
+
+
+def prune_names(directory: Path, names: List[str]) -> List[str]:
+    """Directory names under ``directory`` to descend into, sorted."""
+    kept = []
+    for name in sorted(names):
+        if name in SKIP_DIRECTORIES:
+            continue
+        path = directory / name
+        if (path / ".git").exists() or (path / ".jj").exists():
+            continue
+        kept.append(name)
+    return kept
+
+
+def walk_files(
+    root: Path,
+    keep: Optional[Callable[[Path], bool]] = None,
+) -> Iterator[Path]:
+    """Every file under ``root`` surviving the prune policy, in sorted order.
+
+    ``keep`` filters files (not directories); omit it to yield everything.
+    """
+    for current, directories, files in os.walk(root):
+        directory = Path(current)
+        directories[:] = prune_names(directory, directories)
+        for name in sorted(files):
+            path = directory / name
+            if keep is None or keep(path):
+                yield path

--- a/scripts/gatelib/gate.py
+++ b/scripts/gatelib/gate.py
@@ -1,0 +1,59 @@
+"""The gate main skeleton and the ``--source CRATE=DIR`` parser.
+
+Every gate is the same program with a different predicate: parse arguments,
+run ``validate``, print each error to stderr with a ``1`` exit, or print a
+one-line summary with a ``0``. ``run_gate`` is that program once. Gates
+with richer interfaces (extra flags, regeneration modes) keep their own
+mains and use the pieces they need.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Callable, Iterable, List, Optional, Sequence, Tuple
+
+
+def run_gate(
+    validate: Callable[[], Sequence[str]],
+    summary: str,
+    failure_heading: Optional[str] = None,
+) -> int:
+    """Run one gate predicate and report in the shared shape.
+
+    ``validate`` returns the error list (empty for a pass). ``summary`` is
+    the single pass line. ``failure_heading``, when given, prints once
+    before the itemized errors.
+    """
+    errors = list(validate())
+    if errors:
+        if failure_heading:
+            print(failure_heading, file=sys.stderr)
+            for error in errors:
+                print(f"  - {error}", file=sys.stderr)
+        else:
+            for error in errors:
+                print(f"error: {error}", file=sys.stderr)
+        return 1
+    print(summary)
+    return 0
+
+
+def parse_crate_sources(
+    items: Iterable[str],
+    allowed: Optional[Iterable[str]] = None,
+) -> List[Tuple[str, Path]]:
+    """Parse repeated ``--source CRATE=DIR`` values.
+
+    Raises ``ValueError`` naming the offending item; gates turn that into
+    their usage exit. ``allowed`` restricts the crate names when the gate
+    owns a fixed inventory.
+    """
+    allowed_set = set(allowed) if allowed is not None else None
+    sources: List[Tuple[str, Path]] = []
+    for item in items:
+        crate, separator, directory = item.partition("=")
+        if not separator or (allowed_set is not None and crate not in allowed_set):
+            raise ValueError(f"invalid --source {item!r}")
+        sources.append((crate, Path(directory)))
+    return sources

--- a/scripts/gatelib/loader.py
+++ b/scripts/gatelib/loader.py
@@ -9,6 +9,7 @@ confusing ``None`` crash.
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 from types import ModuleType
 
@@ -28,5 +29,12 @@ def load_script(name: str, relative_to: str) -> ModuleType:
     if spec is None or spec.loader is None:
         raise ImportError(f"could not build an import spec for {script}")
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    # Registered before execution: `@dataclass` resolves a class's module
+    # through `sys.modules`, and fails outright when it is missing.
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        sys.modules.pop(spec.name, None)
+        raise
     return module

--- a/scripts/gatelib/loader.py
+++ b/scripts/gatelib/loader.py
@@ -1,0 +1,32 @@
+"""Loading a dash-named sibling script as a module, for the tool tests.
+
+The gates are executables with dashes in their names, so 25 test files each
+carried the same five-line ``importlib`` incantation — and 25 copies of the
+``assert`` that is the only thing standing between a typo'd filename and a
+confusing ``None`` crash.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+def load_script(name: str, relative_to: str) -> ModuleType:
+    """Load ``name`` (e.g. ``"validate-payload-ownership.py"``) as a module.
+
+    ``relative_to`` is the caller's ``__file__``; the script is resolved as
+    its sibling, which is where every gate and its test live.
+    """
+    script = Path(relative_to).resolve().with_name(name)
+    if not script.is_file():
+        raise FileNotFoundError(f"no sibling script {name!r} next to {relative_to}")
+    spec = importlib.util.spec_from_file_location(
+        script.stem.replace("-", "_"), script
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"could not build an import spec for {script}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/scripts/gatelib/rust.py
+++ b/scripts/gatelib/rust.py
@@ -1,0 +1,112 @@
+"""The one Rust comment/literal masker every source-scanning gate uses.
+
+Three gates used to carry their own copy, and the copies disagreed about
+Rust lifetimes: one advanced two characters past the quote and misread
+``'a`` in ``<'a, T>``, one required the closing quote by escape-aware
+stepping, and one required it by regex on the same line. This module is the
+union of those behaviors with the disagreement resolved:
+
+- a quote is a character literal only when a closing quote follows on the
+  same line (``CHAR_LITERAL`` below), which is also what keeps a lifetime —
+  ``'a``, ``'static``, ``'_`` — unmasked;
+- multi-character escapes (``'\\u{1F600}'``) and byte literals (``b'x'``)
+  are character literals too, which the escape-stepping copies missed;
+- raw and byte strings (``r".."``, ``br#".."#``), nested block comments,
+  and ordinary strings mask exactly as before.
+
+Masking preserves byte offsets and newlines: every masked byte becomes a
+space, so line/column arithmetic on the masked text matches the original.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List, Tuple
+
+RAW_STRING_START = re.compile(r'(?:br|r)(?P<hashes>#{0,255})"')
+
+# A character literal is a quote around exactly one unit — a single
+# character or a single escape (`\n`, `\x41`, `\u{1F600}`) — with the
+# closing quote immediately after. Anything looser re-creates the bug this
+# module exists to fix: with two lifetimes on one line (`<'a, 'static>`),
+# a "closing quote somewhere on the line" rule reads `'a, '` as a literal
+# and masks real code between the lifetimes.
+CHAR_LITERAL = re.compile(
+    r"b?'(?:\\(?:u\{[0-9a-fA-F_]{1,6}\}|x[0-9a-fA-F]{2}|.)|[^'\\\n])'"
+)
+
+
+def mask_rust_non_code(source: str) -> Tuple[str, List[Tuple[int, int]]]:
+    """Blank comments and literal contents, preserving offsets and newlines.
+
+    Returns the masked text and the ``(start, end)`` spans of the comments,
+    for gates whose exceptions live in comments (``# ...-ok:`` annotations).
+    """
+    masked = list(source)
+    comments: List[Tuple[int, int]] = []
+
+    def hide(start: int, end: int) -> None:
+        for index in range(start, min(end, len(masked))):
+            if masked[index] != "\n":
+                masked[index] = " "
+
+    index = 0
+    while index < len(source):
+        if source.startswith("//", index):
+            end = source.find("\n", index + 2)
+            end = len(source) if end < 0 else end
+            comments.append((index, end))
+            hide(index, end)
+            index = end
+            continue
+
+        if source.startswith("/*", index):
+            start = index
+            depth = 1
+            index += 2
+            while index < len(source) and depth:
+                if source.startswith("/*", index):
+                    depth += 1
+                    index += 2
+                elif source.startswith("*/", index):
+                    depth -= 1
+                    index += 2
+                else:
+                    index += 1
+            comments.append((start, index))
+            hide(start, index)
+            continue
+
+        raw = RAW_STRING_START.match(source, index)
+        if raw:
+            terminator = '"' + raw.group("hashes")
+            end = source.find(terminator, raw.end())
+            end = len(source) if end < 0 else end + len(terminator)
+            hide(index, end)
+            index = end
+            continue
+
+        quote = index + 1 if source.startswith('b"', index) else index
+        if quote < len(source) and source[quote] == '"':
+            end = quote + 1
+            while end < len(source):
+                if source[end] == "\\":
+                    end += 2
+                elif source[end] == '"':
+                    end += 1
+                    break
+                else:
+                    end += 1
+            hide(index, end)
+            index = max(end, index + 1)
+            continue
+
+        literal = CHAR_LITERAL.match(source, index)
+        if literal and source[index] in "b'":
+            hide(literal.start(), literal.end())
+            index = literal.end()
+            continue
+
+        index += 1
+
+    return "".join(masked), comments

--- a/scripts/gatelib/workflow.py
+++ b/scripts/gatelib/workflow.py
@@ -1,0 +1,31 @@
+"""Splitting a GitHub workflow file into its per-job blocks.
+
+Two CI gates carried identical copies of this; the only difference was a
+local variable's name. The split is textual on purpose: these gates assert
+properties of the workflow *source* (indentation-level job keys under the
+top-level ``jobs:`` mapping), and a YAML load would erase the spans they
+report against.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict
+
+ACTION_ID = r"[A-Za-z_][A-Za-z0-9_-]*"
+JOB_RE = re.compile(rf"^  ({ACTION_ID}):\s*$", re.MULTILINE)
+
+
+def job_blocks(workflow: str) -> Dict[str, str]:
+    """Map each job id to its source block, in workflow order."""
+    marker = workflow.find("\njobs:\n")
+    if marker < 0:
+        raise ValueError("workflow has no top-level jobs mapping")
+    body = workflow[marker + len("\njobs:\n") :]
+    matches = list(JOB_RE.finditer(body))
+    return {
+        match.group(1): body[match.start() : matches[index + 1].start()]
+        if index + 1 < len(matches)
+        else body[match.start() :]
+        for index, match in enumerate(matches)
+    }

--- a/scripts/test-annotate-performance-commits.py
+++ b/scripts/test-annotate-performance-commits.py
@@ -3,18 +3,15 @@
 
 from __future__ import annotations
 
-import importlib.util
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
 
-SPEC = importlib.util.spec_from_file_location(
-    "annotate_performance_commits",
-    Path(__file__).resolve().parent / "annotate-performance-commits.py",
-)
-annotate = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(annotate)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
+
+annotate = load_script("annotate-performance-commits.py", __file__)
 
 
 def data(*commits: str) -> dict:

--- a/scripts/test-body-analysis-capabilities.py
+++ b/scripts/test-body-analysis-capabilities.py
@@ -3,19 +3,15 @@
 
 from __future__ import annotations
 
-import importlib.util
 import sys
 import tempfile
 import unittest
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
 
-SCRIPT = Path(__file__).with_name("validate-body-analysis-capabilities.py")
-SPEC = importlib.util.spec_from_file_location("body_analysis_capabilities", SCRIPT)
-assert SPEC is not None and SPEC.loader is not None
-inventory = importlib.util.module_from_spec(SPEC)
-sys.modules[SPEC.name] = inventory
-SPEC.loader.exec_module(inventory)
+inventory = load_script("validate-body-analysis-capabilities.py", __file__)
 
 
 class CapabilityInventoryTests(unittest.TestCase):

--- a/scripts/test-check-scheduled-workflows.py
+++ b/scripts/test-check-scheduled-workflows.py
@@ -15,7 +15,6 @@ the same code CI runs.
 
 from __future__ import annotations
 
-import importlib.util
 import io
 import os
 import sys
@@ -25,16 +24,10 @@ import urllib.error
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-HERE = Path(__file__).resolve().parent
-SPEC = importlib.util.spec_from_file_location(
-    "check_scheduled_workflows", HERE / "check-scheduled-workflows.py"
-)
-assert SPEC and SPEC.loader
-csw = importlib.util.module_from_spec(SPEC)
-# `@dataclass` resolves its own module through `sys.modules`, and fails outright
-# when it is missing (see scripts/test-fuzz-report-failure.py, same idiom).
-sys.modules[SPEC.name] = csw
-SPEC.loader.exec_module(csw)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
+
+csw = load_script("check-scheduled-workflows.py", __file__)
 
 NOW = datetime(2026, 8, 14, 12, 0, tzinfo=timezone.utc)
 DAILY = "0 6 * * *"

--- a/scripts/test-ci-required-results.py
+++ b/scripts/test-ci-required-results.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-import importlib.util
+import sys
 import unittest
 from pathlib import Path
 
-SCRIPT = Path(__file__).with_name("ci-required-results.py")
-SPEC = importlib.util.spec_from_file_location("ci_required_results", SCRIPT)
-MODULE = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(MODULE)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
+
+MODULE = load_script("ci-required-results.py", __file__)
 
 
 def results(value="success"):

--- a/scripts/test-cli-shard-coverage.py
+++ b/scripts/test-cli-shard-coverage.py
@@ -3,16 +3,15 @@
 
 from __future__ import annotations
 
-import importlib.util
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
-SCRIPT = Path(__file__).with_name("validate-cli-shard-coverage.py")
-SPEC = importlib.util.spec_from_file_location("cli_shard_coverage", SCRIPT)
-assert SPEC is not None and SPEC.loader is not None
-coverage = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(coverage)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
+
+coverage = load_script("validate-cli-shard-coverage.py", __file__)
 
 
 def buck(count: int, shard_targets: list[int]) -> str:

--- a/scripts/test-cli-shard-weights.py
+++ b/scripts/test-cli-shard-weights.py
@@ -3,17 +3,16 @@
 
 from __future__ import annotations
 
-import importlib.util
 import json
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
-SCRIPT = Path(__file__).with_name("generate-cli-shard-weights.py")
-SPEC = importlib.util.spec_from_file_location("cli_shard_weights", SCRIPT)
-assert SPEC is not None and SPEC.loader is not None
-weights = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(weights)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
+
+weights = load_script("generate-cli-shard-weights.py", __file__)
 
 
 class CliShardWeightTests(unittest.TestCase):

--- a/scripts/test-cli-timeout-policy.py
+++ b/scripts/test-cli-timeout-policy.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import importlib.util
 import json
 import os
 import platform
@@ -22,10 +21,10 @@ if sys.version_info < (3, 11):
 
 import tomllib
 
-SCRIPT = Path(__file__).with_name("cli-timeout-policy.py")
-SPEC = importlib.util.spec_from_file_location("cli_timeout_policy", SCRIPT)
-MODULE = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(MODULE)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
+
+MODULE = load_script("cli-timeout-policy.py", __file__)
 
 
 class TimeoutPolicyTests(unittest.TestCase):

--- a/scripts/test-debug-assert-policy.py
+++ b/scripts/test-debug-assert-policy.py
@@ -3,17 +3,15 @@
 
 from __future__ import annotations
 
-import importlib.util
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
 
-SCRIPT = Path(__file__).with_name("validate-debug-assert-policy.py")
-SPEC = importlib.util.spec_from_file_location("debug_assert_policy", SCRIPT)
-assert SPEC is not None and SPEC.loader is not None
-policy = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(policy)
+policy = load_script("validate-debug-assert-policy.py", __file__)
 
 
 class DebugAssertPolicyTests(unittest.TestCase):

--- a/scripts/test-extract-source-excerpts.py
+++ b/scripts/test-extract-source-excerpts.py
@@ -13,16 +13,13 @@ against fixtures.
 
 from __future__ import annotations
 
-import importlib.util
 import sys
 from pathlib import Path
 
-SPEC = importlib.util.spec_from_file_location(
-    "extract_source_excerpts",
-    Path(__file__).resolve().parent / "extract-source-excerpts.py",
-)
-ex = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(ex)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
+
+ex = load_script("extract-source-excerpts.py", __file__)
 
 REPO = Path(__file__).resolve().parent.parent
 

--- a/scripts/test-fuzz-report-failure.py
+++ b/scripts/test-fuzz-report-failure.py
@@ -19,7 +19,6 @@ that decide whether a crash is reported once, twice, or not at all:
 
 from __future__ import annotations
 
-import importlib.util
 import os
 import re
 import subprocess
@@ -35,20 +34,10 @@ SCRIPT = SCRIPTS / "fuzz-report-failure.py"
 #: directory; a direct run falls back to the repository checkout.
 ROOT = Path(os.environ.get("RUE_FUZZ_REPORT_ROOT", SCRIPTS.parent))
 
+sys.path.insert(0, str(SCRIPTS))
+from gatelib import load_script
 
-def _load_module():
-    """Import the hyphenated script as a module."""
-    spec = importlib.util.spec_from_file_location("fuzz_report_failure", SCRIPT)
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    # Registered before execution: `dataclasses` resolves a class's module
-    # through `sys.modules`, and fails outright when it is missing.
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return module
-
-
-fr = _load_module()
+fr = load_script("fuzz-report-failure.py", __file__)
 
 
 class MockTransport(fr.Transport):

--- a/scripts/test-gatelib.py
+++ b/scripts/test-gatelib.py
@@ -160,6 +160,14 @@ class GateHelperTests(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             load_script("no-such-script.py", __file__)
 
+    def test_load_script_registers_module_for_dataclasses(self) -> None:
+        # `@dataclass` resolves a class's module through `sys.modules` while
+        # the script executes, so a gate defining one fails to load unless the
+        # loader registers the module first.
+        module = load_script("validate-tier-ci-selectors.py", __file__)
+        self.assertTrue(hasattr(module, "Selector"))
+        self.assertIs(sys.modules["validate_tier_ci_selectors"], module)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test-gatelib.py
+++ b/scripts/test-gatelib.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Tests for the shared gate plumbing (RUE-1522).
+
+The masker tests are the contract three gates used to disagree about: a
+Rust lifetime must survive masking while every literal form is blanked.
+Offset preservation is asserted throughout because every consumer does
+line/column arithmetic on the masked text.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from gatelib import (
+    SKIP_DIRECTORIES,
+    job_blocks,
+    load_script,
+    mask_rust_non_code,
+    parse_crate_sources,
+    prune_names,
+    walk_files,
+)
+
+
+def masked(source: str) -> str:
+    text, _ = mask_rust_non_code(source)
+    return text
+
+
+class MaskerShapeTests(unittest.TestCase):
+    def assert_shape_preserved(self, source: str) -> None:
+        text = masked(source)
+        self.assertEqual(len(text), len(source), "masking changed the length")
+        self.assertEqual(
+            [i for i, c in enumerate(source) if c == "\n"],
+            [i for i, c in enumerate(text) if c == "\n"],
+            "masking moved a newline",
+        )
+
+    def test_line_and_nested_block_comments(self) -> None:
+        source = "let x = 1; // trailing\n/* outer /* inner */ still */ let y = 2;\n"
+        text, comments = mask_rust_non_code(source)
+        self.assertNotIn("trailing", text)
+        self.assertNotIn("inner", text)
+        self.assertIn("let y = 2;", text)
+        self.assertEqual(len(comments), 2)
+        for start, end in comments:
+            self.assertNotIn("let", source[start:end].replace("let y", ""))
+        self.assert_shape_preserved(source)
+
+    def test_string_forms_are_blanked(self) -> None:
+        source = (
+            'a("plain"); b("esc \\" quote"); c(b"bytes");'
+            ' d(r"raw"); e(r#"raw # "hash"#); f(br#"rawbytes"#);\n'
+        )
+        text = masked(source)
+        for content in ["plain", "esc", "bytes", "raw", "hash", "rawbytes"]:
+            self.assertNotIn(content, text)
+        for call in ["a(", "b(", "c(", "d(", "e(", "f("]:
+            self.assertIn(call, text)
+        self.assert_shape_preserved(source)
+
+    def test_char_literals_are_blanked(self) -> None:
+        source = "x('a'); y('\\n'); z('\\''); u('\\u{1F600}'); v(b'x');\n"
+        text = masked(source)
+        self.assertNotIn("a", text.replace("x(", "").replace("(", ""))
+        self.assertNotIn("1F600", text)
+        self.assertNotIn("b'x'", text)
+        self.assert_shape_preserved(source)
+
+    def test_lifetimes_survive_masking(self) -> None:
+        source = (
+            "fn f<'a, 'static, '_>(x: &'a str, m: &'a mut T) -> &'a str {\n"
+            "    struct S<'de> { v: &'de [u8] }\n"
+            "}\n"
+        )
+        text = masked(source)
+        self.assertEqual(text, source, "a lifetime was masked as a literal")
+
+    def test_lifetime_then_char_literal_on_one_line(self) -> None:
+        source = "fn g<'a>(x: &'a str) -> char { 'q' }\n"
+        text = masked(source)
+        self.assertIn("<'a>", text)
+        self.assertIn("&'a str", text)
+        self.assertNotIn("'q'", text)
+        self.assert_shape_preserved(source)
+
+    def test_debug_assert_in_comment_and_string_is_masked(self) -> None:
+        source = (
+            "// debug_assert!(commented)\n"
+            'let s = "debug_assert!(quoted)";\n'
+            "debug_assert!(real);\n"
+        )
+        text = masked(source)
+        self.assertEqual(text.count("debug_assert!"), 1)
+
+
+class DiscoveryTests(unittest.TestCase):
+    def test_prune_skips_named_and_vcs_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as scratch:
+            root = Path(scratch)
+            for name in ["keep", "buck-out", "nested"]:
+                (root / name).mkdir()
+            (root / "nested" / ".git").mkdir()
+            names = ["keep", "buck-out", "nested"]
+            self.assertEqual(prune_names(root, names), ["keep"])
+            self.assertTrue(SKIP_DIRECTORIES.issuperset({"buck-out", ".git"}))
+
+    def test_walk_yields_sorted_kept_files(self) -> None:
+        with tempfile.TemporaryDirectory() as scratch:
+            root = Path(scratch)
+            (root / "keep").mkdir()
+            (root / "target").mkdir()
+            (root / "keep" / "b.py").write_text("")
+            (root / "keep" / "a.py").write_text("")
+            (root / "target" / "skipped.py").write_text("")
+            found = [p.name for p in walk_files(root, lambda p: p.suffix == ".py")]
+            self.assertEqual(found, ["a.py", "b.py"])
+
+
+class WorkflowTests(unittest.TestCase):
+    def test_jobs_split_on_top_level_keys(self) -> None:
+        workflow = (
+            "name: CI\n"
+            "jobs:\n"
+            "  first:\n"
+            "    steps:\n"
+            "      - run: echo one\n"
+            "  second-job:\n"
+            "    steps:\n"
+            "      - run: echo two\n"
+        )
+        blocks = job_blocks(workflow)
+        self.assertEqual(list(blocks), ["first", "second-job"])
+        self.assertIn("echo one", blocks["first"])
+        self.assertNotIn("echo two", blocks["first"])
+
+    def test_missing_jobs_mapping_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            job_blocks("name: CI\n")
+
+
+class GateHelperTests(unittest.TestCase):
+    def test_parse_crate_sources(self) -> None:
+        parsed = parse_crate_sources(["rue-air=/tmp/a"], allowed=["rue-air"])
+        self.assertEqual(parsed, [("rue-air", Path("/tmp/a"))])
+        with self.assertRaises(ValueError):
+            parse_crate_sources(["nonsense"])
+        with self.assertRaises(ValueError):
+            parse_crate_sources(["other=/x"], allowed=["rue-air"])
+
+    def test_load_script_loads_a_gate(self) -> None:
+        module = load_script("validate-adrs.py", __file__)
+        self.assertTrue(hasattr(module, "main"))
+        with self.assertRaises(FileNotFoundError):
+            load_script("no-such-script.py", __file__)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-generate-site-status.py
+++ b/scripts/test-generate-site-status.py
@@ -3,16 +3,13 @@
 
 from __future__ import annotations
 
-import importlib.util
 import sys
 from pathlib import Path
 
-SPEC = importlib.util.spec_from_file_location(
-    "generate_site_status",
-    Path(__file__).resolve().parent / "generate-site-status.py",
-)
-gen = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(gen)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
+
+gen = load_script("generate-site-status.py", __file__)
 
 
 def traceability(covered: int = 798, total: int = 801, **overrides) -> dict:

--- a/scripts/test-payload-ownership.py
+++ b/scripts/test-payload-ownership.py
@@ -3,16 +3,14 @@
 
 from __future__ import annotations
 
-import importlib.util
+import sys
 import tempfile
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
 
-SCRIPT = Path(__file__).with_name("validate-payload-ownership.py")
-SPEC = importlib.util.spec_from_file_location("payload_inventory", SCRIPT)
-assert SPEC is not None and SPEC.loader is not None
-MODULE = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(MODULE)
+MODULE = load_script("validate-payload-ownership.py", __file__)
 
 
 def roots(base: Path) -> list[tuple[str, Path]]:

--- a/scripts/test-release-configuration.py
+++ b/scripts/test-release-configuration.py
@@ -3,17 +3,15 @@
 
 from __future__ import annotations
 
-import importlib.util
 import json
+import sys
 import unittest
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
 
-SCRIPT = Path(__file__).with_name("validate-release-configuration.py")
-SPEC = importlib.util.spec_from_file_location("release_configuration", SCRIPT)
-assert SPEC is not None and SPEC.loader is not None
-release_configuration = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(release_configuration)
+release_configuration = load_script("validate-release-configuration.py", __file__)
 
 
 def payload(platform: str, command: str) -> str:

--- a/scripts/test-required-ci-container-pins.py
+++ b/scripts/test-required-ci-container-pins.py
@@ -3,17 +3,15 @@
 
 from __future__ import annotations
 
-import importlib.util
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
 
-SCRIPT = Path(__file__).with_name("validate-required-ci-container-pins.py")
-SPEC = importlib.util.spec_from_file_location("required_ci_container_pins", SCRIPT)
-assert SPEC is not None and SPEC.loader is not None
-pins = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(pins)
+pins = load_script("validate-required-ci-container-pins.py", __file__)
 
 
 class RequiredCiContainerPinTests(unittest.TestCase):

--- a/scripts/test-runtime-abi-inventory.py
+++ b/scripts/test-runtime-abi-inventory.py
@@ -3,17 +3,15 @@
 
 from __future__ import annotations
 
-import importlib.util
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
 
-SCRIPT = Path(__file__).with_name("validate-runtime-abi-inventory.py")
-SPEC = importlib.util.spec_from_file_location("runtime_abi_inventory", SCRIPT)
-assert SPEC is not None and SPEC.loader is not None
-inventory = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(inventory)
+inventory = load_script("validate-runtime-abi-inventory.py", __file__)
 
 
 class InventoryTests(unittest.TestCase):

--- a/scripts/test-type-architecture.py
+++ b/scripts/test-type-architecture.py
@@ -3,17 +3,15 @@
 
 from __future__ import annotations
 
-import importlib.util
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
 
-SCRIPT = Path(__file__).with_name("validate-type-architecture.py")
-SPEC = importlib.util.spec_from_file_location("type_architecture_inventory", SCRIPT)
-assert SPEC is not None and SPEC.loader is not None
-inventory = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(inventory)
+inventory = load_script("validate-type-architecture.py", __file__)
 
 
 class InventoryTests(unittest.TestCase):

--- a/scripts/test-validate-ci-gate.py
+++ b/scripts/test-validate-ci-gate.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
-import importlib.util
 import os
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
-SCRIPT = Path(__file__).with_name("validate-ci-gate.py")
-SPEC = importlib.util.spec_from_file_location("validate_ci_gate", SCRIPT)
-MODULE = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(MODULE)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
+
+MODULE = load_script("validate-ci-gate.py", __file__)
 SOURCE = Path(os.environ["RUE_CI_WORKFLOW"])
 # Under Buck the crate source is a declared input; a direct run falls back to
 # the checkout path the validator resolves on its own.

--- a/scripts/test-validate-performance-stall.py
+++ b/scripts/test-validate-performance-stall.py
@@ -3,16 +3,13 @@
 
 from __future__ import annotations
 
-import importlib.util
 import sys
 from pathlib import Path
 
-SPEC = importlib.util.spec_from_file_location(
-    "validate_performance_stall",
-    Path(__file__).resolve().parent / "validate-performance-stall.py",
-)
-stall = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(stall)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
+
+stall = load_script("validate-performance-stall.py", __file__)
 
 
 def data(*points: tuple[str, str, str]) -> dict:

--- a/scripts/test-validate-python-baseline.py
+++ b/scripts/test-validate-python-baseline.py
@@ -14,7 +14,6 @@ the real file and requiring the finding to come back.
 
 from __future__ import annotations
 
-import importlib.util
 import re
 import subprocess
 import sys
@@ -23,12 +22,11 @@ import textwrap
 import unittest
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
 
 SCRIPT = Path(__file__).with_name("validate-python-baseline.py")
-SPEC = importlib.util.spec_from_file_location("python_baseline", SCRIPT)
-assert SPEC is not None and SPEC.loader is not None
-policy = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(policy)
+policy = load_script("validate-python-baseline.py", __file__)
 
 TOOL = Path(__file__).with_name("cli-timeout-policy.py")
 

--- a/scripts/test-validate-shell-bash-baseline.py
+++ b/scripts/test-validate-shell-bash-baseline.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import importlib.util
 import os
 import platform
 import subprocess
@@ -15,11 +14,11 @@ import unittest.mock
 from pathlib import Path
 
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
+
 SCRIPT = Path(__file__).with_name("validate-shell-bash-baseline.py")
-SPEC = importlib.util.spec_from_file_location("bash_baseline", SCRIPT)
-assert SPEC is not None and SPEC.loader is not None
-policy = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(policy)
+policy = load_script("validate-shell-bash-baseline.py", __file__)
 
 BASELINE_BASH = "/bin/bash"
 

--- a/scripts/test-validate-shell-pipefail-pipelines.py
+++ b/scripts/test-validate-shell-pipefail-pipelines.py
@@ -3,19 +3,18 @@
 
 from __future__ import annotations
 
-import importlib.util
 import subprocess
+import sys
 import tempfile
 import textwrap
 import unittest
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
 
 SCRIPT = Path(__file__).with_name("validate-shell-pipefail-pipelines.py")
-SPEC = importlib.util.spec_from_file_location("pipefail_pipelines", SCRIPT)
-assert SPEC is not None and SPEC.loader is not None
-policy = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(policy)
+policy = load_script("validate-shell-pipefail-pipelines.py", __file__)
 
 
 class ScanTests(unittest.TestCase):

--- a/scripts/test-validate-test-duplication.py
+++ b/scripts/test-validate-test-duplication.py
@@ -9,19 +9,17 @@ is proven to fail on it rather than asserted to.
 
 from __future__ import annotations
 
-import importlib.util
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
+
 SCRIPT = Path(__file__).with_name("validate-test-duplication.py")
-SPEC = importlib.util.spec_from_file_location("validate_test_duplication", SCRIPT)
-assert SPEC is not None and SPEC.loader is not None
-GATE = importlib.util.module_from_spec(SPEC)
-sys.modules["validate_test_duplication"] = GATE
-SPEC.loader.exec_module(GATE)
+GATE = load_script("validate-test-duplication.py", __file__)
 
 COMPILER = "//crates/rue-compiler:rue-compiler-test"
 SCALING = "//crates/rue-compiler:scaling-matrix-test"

--- a/scripts/test-validate-tier-ci-selectors.py
+++ b/scripts/test-validate-tier-ci-selectors.py
@@ -3,21 +3,16 @@
 
 from __future__ import annotations
 
-import importlib.util
 import os
 import sys
 import tempfile
 import unittest
 from pathlib import Path
 
-SCRIPT = Path(__file__).with_name("validate-tier-ci-selectors.py")
-SPEC = importlib.util.spec_from_file_location("tier_ci_selectors", SCRIPT)
-assert SPEC is not None and SPEC.loader is not None
-selectors = importlib.util.module_from_spec(SPEC)
-# `@dataclass` resolves annotations through `sys.modules[cls.__module__]`, so a
-# file loaded by spec alone must be registered before it executes.
-sys.modules[SPEC.name] = selectors
-SPEC.loader.exec_module(selectors)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import load_script
+
+selectors = load_script("validate-tier-ci-selectors.py", __file__)
 
 TIERS = ("premerge", "slow", "stress")
 

--- a/scripts/validate-body-analysis-capabilities.py
+++ b/scripts/validate-body-analysis-capabilities.py
@@ -15,6 +15,9 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import mask_rust_non_code
+
 
 INVENTORY_FILES = {
     ("rue-air", Path("sema/provider.rs")),
@@ -62,72 +65,6 @@ class Hit:
         )
 
 
-def mask_rust_non_code(source: str) -> str:
-    """Mask comments and literals while preserving offsets and newlines."""
-    masked = list(source)
-
-    def hide(start: int, end: int) -> None:
-        for index in range(start, end):
-            if masked[index] != "\n":
-                masked[index] = " "
-
-    index = 0
-    while index < len(source):
-        if source.startswith("//", index):
-            end = source.find("\n", index + 2)
-            end = len(source) if end < 0 else end
-            hide(index, end)
-            index = end
-            continue
-        if source.startswith("/*", index):
-            depth = 1
-            end = index + 2
-            while end < len(source) and depth:
-                if source.startswith("/*", end):
-                    depth += 1
-                    end += 2
-                elif source.startswith("*/", end):
-                    depth -= 1
-                    end += 2
-                else:
-                    end += 1
-            hide(index, end)
-            index = end
-            continue
-        raw = re.match(r'(?:br|r)(?P<hashes>#{0,255})"', source[index:])
-        if raw:
-            terminator = '"' + raw.group("hashes")
-            end = source.find(terminator, index + raw.end())
-            end = len(source) if end < 0 else end + len(terminator)
-            hide(index, end)
-            index = end
-            continue
-        quote = index + 1 if source.startswith('b"', index) else index
-        if quote < len(source) and source[quote] == '"':
-            end = quote + 1
-            while end < len(source):
-                if source[end] == "\\":
-                    end += 2
-                elif source[end] == '"':
-                    end += 1
-                    break
-                else:
-                    end += 1
-            hide(index, min(end, len(source)))
-            index = end
-            continue
-        if source[index] == "'":
-            end = index + 2
-            if end < len(source) and source[index + 1] == "\\":
-                end += 1
-            if end < len(source) and source[end] == "'":
-                hide(index, end + 1)
-                index = end + 1
-                continue
-        index += 1
-    return "".join(masked)
-
-
 def normalize_relative(path: Path, source_root: Path) -> Path:
     relative = path.relative_to(source_root)
     if relative.parts and relative.parts[0] == "src":
@@ -153,7 +90,7 @@ def classify(sources: list[tuple[str, Path]]) -> list[Hit]:
             hits.append(Hit(crate, relative, 0, "missing required provider source"))
             continue
         source = path.read_text()
-        masked = mask_rust_non_code(source)
+        masked = mask_rust_non_code(source)[0]
         for pattern, label in (
             (TYPE_ACCESS, "whole-program type"),
             (TABLE_ACCESS, "declaration-universe table"),

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -10,6 +10,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import job_blocks
+
 RESULTS_SCRIPT = Path(__file__).with_name("ci-required-results.py")
 NATIVE_RUNNER_SCRIPT = Path(__file__).with_name("run-native-platform-corpus.sh")
 TEST_RUNNER_SOURCE = (
@@ -96,21 +99,6 @@ sys.modules["validate_test_duplication"] = DUPLICATION
 _DUP_SPEC.loader.exec_module(DUPLICATION)
 
 ACTION_ID = r"[A-Za-z_][A-Za-z0-9_-]*"
-JOB_RE = re.compile(rf"^  ({ACTION_ID}):\s*$", re.MULTILINE)
-
-
-def job_blocks(workflow: str) -> dict[str, str]:
-    jobs_marker = workflow.find("\njobs:\n")
-    if jobs_marker < 0:
-        raise ValueError("workflow has no top-level jobs mapping")
-    body = workflow[jobs_marker + len("\njobs:\n") :]
-    matches = list(JOB_RE.finditer(body))
-    return {
-        match.group(1): body[match.start() : matches[index + 1].start()]
-        if index + 1 < len(matches)
-        else body[match.start() :]
-        for index, match in enumerate(matches)
-    }
 
 
 def list_needs(block: str) -> set[str]:

--- a/scripts/validate-debug-assert-policy.py
+++ b/scripts/validate-debug-assert-policy.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import NamedTuple
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from gatelib import mask_rust_non_code
+from gatelib import mask_rust_non_code, run_gate
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -106,18 +106,12 @@ def main() -> int:
     parser.add_argument("root", nargs="?", type=Path, default=ROOT)
     args = parser.parse_args()
 
-    errors = validate(args.root)
-    if errors:
-        for error in errors:
-            print(f"error: {error}", file=sys.stderr)
-        return 1
-
     total = sum(allowance.count for allowance in ALLOWANCES.values())
-    print(
+    return run_gate(
+        lambda: validate(args.root),
         "debug-assertion policy valid: "
-        f"{total} reviewed debug-only assertion(s), none in CFG/codegen/linker"
+        f"{total} reviewed debug-only assertion(s), none in CFG/codegen/linker",
     )
-    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/validate-debug-assert-policy.py
+++ b/scripts/validate-debug-assert-policy.py
@@ -16,11 +16,12 @@ import sys
 from pathlib import Path
 from typing import NamedTuple
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import mask_rust_non_code
+
 
 ROOT = Path(__file__).resolve().parent.parent
 DEBUG_ASSERT = re.compile(r"\bdebug_assert(?:_eq|_ne)?!\s*\(")
-RAW_STRING_START = re.compile(r"(?:br|r)(?P<hashes>#{0,255})\"")
-CHARACTER_LITERAL_START = re.compile(r"'(?:\\.|[^'\\\n])+'")
 
 
 class Allowance(NamedTuple):
@@ -72,137 +73,8 @@ ALLOWANCES = {
 }
 
 
-def strip_non_code(source: str) -> str:
-    """Replace Rust comments and string/character contents with whitespace."""
-
-    result = list(source)
-    index = 0
-    block_depth = 0
-    state = "code"
-    raw_hashes = 0
-
-    def blank(position: int) -> None:
-        if result[position] != "\n":
-            result[position] = " "
-
-    while index < len(source):
-        if state == "line_comment":
-            if source[index] == "\n":
-                state = "code"
-            else:
-                blank(index)
-            index += 1
-            continue
-
-        if state == "block_comment":
-            if source.startswith("/*", index):
-                blank(index)
-                blank(index + 1)
-                block_depth += 1
-                index += 2
-            elif source.startswith("*/", index):
-                blank(index)
-                blank(index + 1)
-                block_depth -= 1
-                index += 2
-                if block_depth == 0:
-                    state = "code"
-            else:
-                blank(index)
-                index += 1
-            continue
-
-        if state == "quoted":
-            if source[index] == "\\":
-                blank(index)
-                if index + 1 < len(source):
-                    blank(index + 1)
-                index += 2
-            else:
-                character = source[index]
-                blank(index)
-                index += 1
-                if character == '"':
-                    state = "code"
-            continue
-
-        if state == "character":
-            if source[index] == "\\":
-                blank(index)
-                if index + 1 < len(source):
-                    blank(index + 1)
-                index += 2
-            else:
-                character = source[index]
-                blank(index)
-                index += 1
-                if character == "'":
-                    state = "code"
-            continue
-
-        if state == "raw":
-            terminator = '"' + ("#" * raw_hashes)
-            if source.startswith(terminator, index):
-                for offset in range(len(terminator)):
-                    blank(index + offset)
-                index += len(terminator)
-                state = "code"
-            else:
-                blank(index)
-                index += 1
-            continue
-
-        if source.startswith("//", index):
-            blank(index)
-            blank(index + 1)
-            index += 2
-            state = "line_comment"
-            continue
-        if source.startswith("/*", index):
-            blank(index)
-            blank(index + 1)
-            index += 2
-            block_depth = 1
-            state = "block_comment"
-            continue
-
-        raw_match = RAW_STRING_START.match(source, index)
-        if raw_match:
-            token = raw_match.group(0)
-            raw_hashes = len(raw_match.group("hashes"))
-            for offset in range(len(token)):
-                blank(index + offset)
-            index += len(token)
-            state = "raw"
-            continue
-
-        if source.startswith('b"', index):
-            blank(index)
-            blank(index + 1)
-            index += 2
-            state = "quoted"
-            continue
-        if source[index] == '"':
-            blank(index)
-            index += 1
-            state = "quoted"
-            continue
-
-        # Treat a quote as a character literal only when it has a closing quote
-        # on this line; this avoids mistaking Rust lifetimes for literals.
-        if source[index] == "'" and CHARACTER_LITERAL_START.match(source, index):
-            blank(index)
-            index += 1
-            state = "character"
-            continue
-
-        index += 1
-
-    return "".join(result)
-
-
 def count_debug_asserts(path: Path) -> int:
-    return len(DEBUG_ASSERT.findall(strip_non_code(path.read_text())))
+    return len(DEBUG_ASSERT.findall(mask_rust_non_code(path.read_text())[0]))
 
 
 def validate(root: Path, allowances: dict[str, Allowance] = ALLOWANCES) -> list[str]:

--- a/scripts/validate-payload-ownership.py
+++ b/scripts/validate-payload-ownership.py
@@ -8,6 +8,9 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import parse_crate_sources
+
 
 OWNER_PATHS = {
     # `inst/packed.rs` is a private submodule of the RIR owner. Its decoder
@@ -153,13 +156,11 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    sources: list[tuple[str, Path]] = []
-    for item in args.source:
-        crate, separator, directory = item.partition("=")
-        if not separator or crate not in OWNER_PATHS:
-            print(f"invalid --source {item!r}", file=sys.stderr)
-            return 2
-        sources.append((crate, Path(directory)))
+    try:
+        sources = parse_crate_sources(args.source, OWNER_PATHS)
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 2
     errors = validate(sources)
     if errors:
         print("typed payload ownership inventory failed:", file=sys.stderr)

--- a/scripts/validate-python-baseline.py
+++ b/scripts/validate-python-baseline.py
@@ -112,6 +112,9 @@ import sys
 from pathlib import Path
 from typing import NamedTuple
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import prune_names
+
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -126,19 +129,6 @@ FLOOR = (3, 11)
 UNGUARDED = (3, 9)
 
 SCANNER = (sys.version_info[0], sys.version_info[1])
-
-# Build outputs and vendored trees are not ours to police, and `buck-out` in
-# particular makes the scan's cost and result depend on whether a build has run.
-SKIP_DIRECTORIES = {
-    ".buckd",
-    ".git",
-    ".jj",
-    "buck-out",
-    "buck2-bin",
-    "node_modules",
-    "target",
-    "third-party",
-}
 
 ALLOW = re.compile(r"#\s*python-baseline-ok:\s*(?P<reason>\S.*?)\s*$")
 
@@ -641,25 +631,6 @@ def split_comment(line: str) -> tuple[str, str]:
     return line, ""
 
 
-def _prune(directory: Path, names: list[str]) -> list[str]:
-    """Directory names to descend into.
-
-    Nested checkouts are pruned by their own VCS marker rather than by name:
-    the working agreement puts sibling worktrees under `.claude/worktrees/`,
-    and reporting a path inside one as though it were a path in THIS tree is
-    worse than not scanning it -- that copy has its own gate.
-    """
-    kept = []
-    for name in sorted(names):
-        if name in SKIP_DIRECTORIES:
-            continue
-        path = directory / name
-        if (path / ".git").exists() or (path / ".jj").exists():
-            continue
-        kept.append(name)
-    return kept
-
-
 def sources(root: Path) -> list[Path]:
     """Every Python file under `root`, by extension or by shebang.
 
@@ -671,7 +642,7 @@ def sources(root: Path) -> list[Path]:
     found: list[Path] = []
     for directory, names, files in os.walk(root):
         here = Path(directory)
-        names[:] = _prune(here, names)
+        names[:] = prune_names(here, names)
         for name in sorted(files):
             path = here / name
             if path.is_symlink() or not path.is_file():

--- a/scripts/validate-runtime-abi-inventory.py
+++ b/scripts/validate-runtime-abi-inventory.py
@@ -13,6 +13,9 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import mask_rust_non_code
+
 
 ROOT = Path(__file__).resolve().parent.parent
 CONSUMER_CRATES = (
@@ -26,7 +29,6 @@ CONSUMER_CRATES = (
 )
 LITERAL = re.compile(r'"(__rue_[A-Za-z0-9_$]*)"')
 TEST_MODULE = re.compile(r"#\[cfg\(test\)\]\s*mod\s+[A-Za-z0-9_]+\s*\{", re.MULTILINE)
-RAW_STRING_START = re.compile(r'(?:br|r)(?P<hashes>#{0,255})"')
 
 # These are namespace or generated-symbol boundaries, not runtime-helper
 # identities. Keep this list about categories rather than individual helpers.
@@ -39,83 +41,6 @@ ALLOWED_PRODUCTION = (
     "__rue_for_",  # internal desugaring temporaries
     "__rue_invalid_local_symbol",  # unreachable canonicalization sentinel
 )
-
-
-def mask_rust_non_code(source: str) -> tuple[str, list[tuple[int, int]]]:
-    """Mask comments and literals while preserving byte offsets and newlines."""
-    masked = list(source)
-    comments: list[tuple[int, int]] = []
-
-    def hide(start: int, end: int) -> None:
-        for index in range(start, end):
-            if masked[index] != "\n":
-                masked[index] = " "
-
-    index = 0
-    while index < len(source):
-        if source.startswith("//", index):
-            end = source.find("\n", index + 2)
-            end = len(source) if end < 0 else end
-            comments.append((index, end))
-            hide(index, end)
-            index = end
-            continue
-        if source.startswith("/*", index):
-            start = index
-            depth = 1
-            index += 2
-            while index < len(source) and depth:
-                if source.startswith("/*", index):
-                    depth += 1
-                    index += 2
-                elif source.startswith("*/", index):
-                    depth -= 1
-                    index += 2
-                else:
-                    index += 1
-            comments.append((start, index))
-            hide(start, index)
-            continue
-
-        raw = RAW_STRING_START.match(source, index)
-        if raw:
-            hashes = raw.group("hashes")
-            terminator = '"' + hashes
-            end = source.find(terminator, raw.end())
-            end = len(source) if end < 0 else end + len(terminator)
-            hide(index, end)
-            index = end
-            continue
-
-        quote_start = index + 1 if source.startswith('b"', index) else index
-        if quote_start < len(source) and source[quote_start] == '"':
-            end = quote_start + 1
-            while end < len(source):
-                if source[end] == "\\":
-                    end += 2
-                elif source[end] == '"':
-                    end += 1
-                    break
-                else:
-                    end += 1
-            hide(index, min(end, len(source)))
-            index = end
-            continue
-
-        # Mask a character literal, but do not mistake a Rust lifetime for one.
-        if source[index] == "'":
-            end = index + 1
-            if end < len(source) and source[end] == "\\":
-                end += 2
-            else:
-                end += 1
-            if end < len(source) and source[end] == "'":
-                end += 1
-                hide(index, end)
-                index = end
-                continue
-        index += 1
-    return "".join(masked), comments
 
 
 def test_module_spans(masked_source: str) -> list[tuple[int, int]]:

--- a/scripts/validate-shell-bash-baseline.py
+++ b/scripts/validate-shell-bash-baseline.py
@@ -141,6 +141,9 @@ import sys
 from pathlib import Path
 from typing import NamedTuple
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import SKIP_DIRECTORIES, prune_names
+
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -158,19 +161,6 @@ BASELINE_MAJOR = 3
 # that IS Bash 3.2, and then parses everything in POSIX mode. Point it at a
 # bash.
 BASELINE_ENV = "RUE_BASELINE_BASH"
-
-# Build outputs and vendored trees are not ours to police, and `buck-out` in
-# particular makes the scan's cost and result depend on whether a build has run.
-SKIP_DIRECTORIES = {
-    ".buckd",
-    ".git",
-    ".jj",
-    "buck-out",
-    "buck2-bin",
-    "node_modules",
-    "target",
-    "third-party",
-}
 
 # `#!/usr/bin/env bash`, `#!/bin/bash`, `#!/usr/bin/env -S bash -eu`.
 BASH_SHEBANG = re.compile(r"^#!\s*\S*(?:\s+-\S+)*\s*(?:\S*/)?bash\b|^#!\S*/bash\b")
@@ -713,25 +703,6 @@ def parse_check(
     return failures, exemptions
 
 
-def _prune(directory: Path, names: list[str]) -> list[str]:
-    """Directory names to descend into.
-
-    Nested checkouts are pruned by their own VCS marker rather than by name:
-    the working agreement puts sibling worktrees under `.claude/worktrees/`,
-    and reporting `.claude/worktrees/rue-1265/test.sh` as though it were a path
-    in THIS tree is worse than not scanning it -- that copy has its own gate.
-    """
-    kept = []
-    for name in sorted(names):
-        if name in SKIP_DIRECTORIES:
-            continue
-        path = directory / name
-        if (path / ".git").exists() or (path / ".jj").exists():
-            continue
-        kept.append(name)
-    return kept
-
-
 class Sources(NamedTuple):
     # Bash-shebang scripts: the construct table's set, and parsed as well.
     bash: list[Path]
@@ -753,7 +724,7 @@ def sources(root: Path) -> Sources:
     workflows: list[Path] = []
     for directory, names, files in os.walk(root):
         here = Path(directory)
-        names[:] = _prune(here, names)
+        names[:] = prune_names(here, names)
         for name in sorted(files):
             path = here / name
             if path.is_symlink() or not path.is_file():

--- a/scripts/validate-shell-pipefail-pipelines.py
+++ b/scripts/validate-shell-pipefail-pipelines.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from typing import NamedTuple
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from gatelib import SKIP_DIRECTORIES, prune_names
+from gatelib import SKIP_DIRECTORIES, prune_names, run_gate
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -190,15 +190,11 @@ def main() -> int:
     parser.add_argument("root", nargs="?", type=Path, default=ROOT)
     args = parser.parse_args()
 
-    findings = validate(args.root)
-    if findings:
-        for finding in findings:
-            print(f"error: {finding}", file=sys.stderr)
-        return 1
-
     scanned = len(shell_scripts(args.root))
-    print(f"pipefail pipeline policy valid: {scanned} shell script(s) scanned")
-    return 0
+    return run_gate(
+        lambda: [str(finding) for finding in validate(args.root)],
+        f"pipefail pipeline policy valid: {scanned} shell script(s) scanned",
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/validate-shell-pipefail-pipelines.py
+++ b/scripts/validate-shell-pipefail-pipelines.py
@@ -28,21 +28,11 @@ import sys
 from pathlib import Path
 from typing import NamedTuple
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import SKIP_DIRECTORIES, prune_names
+
 
 ROOT = Path(__file__).resolve().parent.parent
-
-# Build outputs and vendored trees are not ours to police, and `buck-out` in
-# particular makes the scan's cost and result depend on whether a build has run.
-SKIP_DIRECTORIES = {
-    ".buckd",
-    ".git",
-    ".jj",
-    "buck-out",
-    "buck2-bin",
-    "node_modules",
-    "target",
-    "third-party",
-}
 
 SHEBANG = re.compile(r"^#!.*\b(?:ba|da|k|z)?sh\b")
 
@@ -152,18 +142,7 @@ def shell_scripts(root: Path) -> list[Path]:
     # Prune while walking rather than filtering afterwards: `buck-out` alone
     # holds enough build output to dominate the gate's runtime.
     for directory, names, files in os.walk(root):
-        # Nested checkouts are pruned by their own VCS marker as well as by
-        # name: the working agreement puts sibling worktrees under
-        # `.claude/worktrees/`, and reporting a finding there as though it were
-        # a path in THIS tree is worse than not scanning it -- that copy runs
-        # its own gate (RUE-1506).
-        names[:] = sorted(
-            name
-            for name in names
-            if name not in SKIP_DIRECTORIES
-            and not (Path(directory) / name / ".git").exists()
-            and not (Path(directory) / name / ".jj").exists()
-        )
+        names[:] = prune_names(Path(directory), names)
         for name in sorted(files):
             path = Path(directory) / name
             if path.is_symlink() or not path.is_file():

--- a/scripts/validate-tier-ci-selectors.py
+++ b/scripts/validate-tier-ci-selectors.py
@@ -35,11 +35,13 @@ from __future__ import annotations
 
 import argparse
 import re
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-ACTION_ID = r"[A-Za-z_][A-Za-z0-9_-]*"
-JOB_RE = re.compile(rf"^  ({ACTION_ID}):\s*$", re.MULTILINE)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import job_blocks
+
 BXL_TIER_RE = re.compile(r'^\s*"(rue_test_tier_[a-z]+)",\s*$', re.MULTILINE)
 DEFS_TIER_RE = re.compile(
     r'^TEST_TIER_[A-Z]+ = "(rue_test_tier_[a-z]+)"$', re.MULTILINE
@@ -91,20 +93,6 @@ TIER_SELECTORS: dict[str, tuple[Selector, ...]] = {
         ),
     ),
 }
-
-
-def job_blocks(workflow: str) -> dict[str, str]:
-    marker = workflow.find("\njobs:\n")
-    if marker < 0:
-        raise ValueError("workflow has no top-level jobs mapping")
-    body = workflow[marker + len("\njobs:\n") :]
-    matches = list(JOB_RE.finditer(body))
-    return {
-        match.group(1): body[match.start() : matches[index + 1].start()]
-        if index + 1 < len(matches)
-        else body[match.start() :]
-        for index, match in enumerate(matches)
-    }
 
 
 def declared_tiers(defs_path: Path, bxl_path: Path) -> tuple[set[str], list[str]]:

--- a/scripts/validate-type-architecture.py
+++ b/scripts/validate-type-architecture.py
@@ -8,6 +8,9 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gatelib import parse_crate_sources
+
 
 ROOT = Path(__file__).resolve().parent.parent
 CONSUMER_CRATES = (
@@ -267,12 +270,11 @@ def main() -> int:
     args = parser.parse_args()
 
     root = args.root.resolve()
-    sources = []
-    for item in args.source:
-        crate, separator, path = item.partition("=")
-        if not separator or crate not in CONSUMER_CRATES:
-            parser.error(f"invalid --source {item!r}")
-        sources.append((crate, Path(path).resolve()))
+    try:
+        parsed = parse_crate_sources(args.source, CONSUMER_CRATES)
+    except ValueError as error:
+        parser.error(str(error))
+    sources = [(crate, path.resolve()) for crate, path in parsed]
 
     errors = validate(root, sources or None)
     if errors:


### PR DESCRIPTION
Fixes RUE-1522. Second tranche of the RUE-1520 scripts roadmap: the consolidation of the `validate-*` gates' duplicated plumbing, and the fix for the audit's headline correctness finding.

## The correctness fix

Three gates carried independently written Rust comment/literal maskers that disagreed about lifetimes. `scripts/gatelib/rust.py` is now the one masker, with the contract pinned by tests: **a character literal is a quote around exactly one character or one escape** (`'a'`, `'\n'`, `'\x41'`, `'\u{1F600}'`, `b'x'`), so lifetimes survive masking — including the case that defeats any "closing quote on the same line" heuristic, two lifetimes on one line (`<'a, 'static>`), where the looser rule reads `'a, '` as a literal and masks real code between them. (Writing the replacement reproduced that bug on the first attempt, which is as good an argument for a single pinned implementation as any.)

## The library

`scripts/gatelib/` also carries the shared walker with the prune policy (two character-identical `_prune` copies plus one inline), the workflow `job_blocks` splitter (two identical copies), the `--source CRATE=DIR` parser (three copies), the gate main skeleton, and a `load_script` helper replacing the 5-line `importlib` incantation in the tool tests. Per the audit's recommendation this is **not** a rule DSL — every gate keeps its own predicate and curated tables.

## Migration discipline

Gates migrate **one per commit**, each validated before committing: the gate's findings on the current tree must be unchanged (the debug-assert gate's ledger counts are the sharpest check of this), and its BUCK targets gain the gatelib sources in `resources` so cache keys see library edits. Migrations that would change a gate's findings are reverted and reported, not forced.

Validated per commit with the gate itself, its tool tests, `//:gatelib-tests`, and at tranche boundaries with the Python/shell baseline gates, the duplication gate, and the CI gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCariNhXQqtLK2bMgcViTr)_