### PR TITLE
RUE-1523: single-source the test-tier vocabulary

### DIFF
--- a/scripts/test-validate-tier-ci-selectors.py
+++ b/scripts/test-validate-tier-ci-selectors.py
@@ -63,9 +63,12 @@ def defs_source(tiers: tuple[str, ...]) -> str:
     )
 
 
-def bxl_source(tiers: tuple[str, ...]) -> str:
-    body = "".join(f'    "rue_test_tier_{tier}",\n' for tier in tiers)
-    return f"_TEST_TIER_LABELS = [\n{body}]\n"
+def bxl_source(tiers: tuple[str, ...] = ()) -> str:
+    del tiers  # the vocabulary is loaded, not spelled, since RUE-1523
+    return (
+        'load("//:test_defs.bzl", "RUE_TEST_TIER_LABELS")\n'
+        "_TEST_TIER_LABELS = RUE_TEST_TIER_LABELS\n"
+    )
 
 
 class TierCiSelectorTests(unittest.TestCase):
@@ -187,10 +190,11 @@ class TierCiSelectorTests(unittest.TestCase):
             errors,
         )
 
-    def test_tier_vocabulary_drift_fails(self) -> None:
-        errors = self.validate(bxl=bxl_source(("premerge", "slow")))
+    def test_bxl_dropping_the_vocabulary_load_fails(self) -> None:
+        local_list = '_TEST_TIER_LABELS = [\n    "rue_test_tier_premerge",\n]\n'
+        errors = self.validate(bxl=local_list)
         self.assertEqual(len(errors), 1, errors)
-        self.assertIn("tier vocabulary drift", errors[0])
+        self.assertIn("does not load RUE_TEST_TIER_LABELS", errors[0])
 
     def test_missing_workflow_fails_closed(self) -> None:
         errors = self.validate(omit_release=True)

--- a/scripts/validate-tier-ci-selectors.py
+++ b/scripts/validate-tier-ci-selectors.py
@@ -42,10 +42,15 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from gatelib import job_blocks
 
-BXL_TIER_RE = re.compile(r'^\s*"(rue_test_tier_[a-z]+)",\s*$', re.MULTILINE)
 DEFS_TIER_RE = re.compile(
     r'^TEST_TIER_[A-Z]+ = "(rue_test_tier_[a-z]+)"$', re.MULTILINE
 )
+
+# test_tiers.bxl loads the vocabulary from test_defs.bzl instead of keeping
+# its own copy (RUE-1523), so agreement is structural. This gate pins the
+# load line itself: without it, reverting the bxl to a local list would
+# silently dissolve that guarantee.
+BXL_LOAD_LINE = 'load("//:test_defs.bzl", "RUE_TEST_TIER_LABELS")'
 
 
 @dataclass(frozen=True)
@@ -96,21 +101,17 @@ TIER_SELECTORS: dict[str, tuple[Selector, ...]] = {
 
 
 def declared_tiers(defs_path: Path, bxl_path: Path) -> tuple[set[str], list[str]]:
-    """Returns the agreed tier vocabulary and any disagreement between sources."""
+    """Returns the tier vocabulary and any break in its single-sourcing."""
     defs_tiers = set(DEFS_TIER_RE.findall(defs_path.read_text()))
-    bxl_tiers = set(BXL_TIER_RE.findall(bxl_path.read_text()))
     errors = []
     if not defs_tiers:
         errors.append(f"{defs_path}: no TEST_TIER_* constants found")
-    if not bxl_tiers:
-        errors.append(f"{bxl_path}: no tier labels found")
-    if defs_tiers and bxl_tiers and defs_tiers != bxl_tiers:
+    if BXL_LOAD_LINE not in bxl_path.read_text():
         errors.append(
-            "tier vocabulary drift: "
-            f"{defs_path.name} declares {', '.join(sorted(defs_tiers))}; "
-            f"{bxl_path.name} selects {', '.join(sorted(bxl_tiers))}"
+            f"{bxl_path.name}: does not load RUE_TEST_TIER_LABELS from "
+            f"{defs_path.name}; the selector and the tier macros can drift"
         )
-    return defs_tiers | bxl_tiers, errors
+    return defs_tiers, errors
 
 
 def validate(defs_path: Path, bxl_path: Path, workflows: dict[str, Path]) -> list[str]:

--- a/test_defs.bzl
+++ b/test_defs.bzl
@@ -4,6 +4,15 @@ TEST_TIER_PREMERGE = "rue_test_tier_premerge"
 TEST_TIER_SLOW = "rue_test_tier_slow"
 TEST_TIER_STRESS = "rue_test_tier_stress"
 
+# The one declaration of the tier vocabulary. test_tiers.bxl loads this list
+# instead of keeping its own, so the selector and the macros cannot disagree;
+# scripts/validate-tier-ci-selectors.py reads it from this file only.
+RUE_TEST_TIER_LABELS = [
+    TEST_TIER_PREMERGE,
+    TEST_TIER_SLOW,
+    TEST_TIER_STRESS,
+]
+
 _TEST_TIER_LABELS = {
     "premerge": TEST_TIER_PREMERGE,
     "slow": TEST_TIER_SLOW,

--- a/test_tiers.bxl
+++ b/test_tiers.bxl
@@ -1,10 +1,10 @@
 """Canonical Buck selections and validation for Rue's test execution tiers."""
 
-_TEST_TIER_LABELS = [
-    "rue_test_tier_premerge",
-    "rue_test_tier_slow",
-    "rue_test_tier_stress",
-]
+load("//:test_defs.bzl", "RUE_TEST_TIER_LABELS")
+
+# Loaded from test_defs.bzl so the selector and the tier macros share one
+# vocabulary by construction (RUE-1523).
+_TEST_TIER_LABELS = RUE_TEST_TIER_LABELS
 
 _CLI_SHARD_LABEL = "rue_cli_shard"
 


### PR DESCRIPTION
Fixes RUE-1523. Third tranche of the RUE-1520 scripts roadmap.

`test_defs.bzl` now exports `RUE_TEST_TIER_LABELS` and `test_tiers.bxl` loads it instead of keeping its own copy, so the tier selector and the tier macros share one vocabulary by construction. `validate-tier-ci-selectors.py` reads the vocabulary from `test_defs.bzl` alone and pins the bxl load line itself (so reverting the bxl to a local list fails the gate), replacing the two-file regex cross-check whose drift arm is now structurally unreachable. Tier counts before and after: 165 premerge / 16 slow / 3 stress, unchanged.

## Scope decision: the other regex-to-bxl candidates are declined

The issue proposed emitting graph facts from a bxl for three more gates. On inspection, each declines for a concrete reason:

- **CLI shard set** (`validate-cli-shard-coverage.py`): BUCK already generates the shard targets from `range(CLI_TEST_SHARD_COUNT)`, so the "differently-spelled target reads as absent" drift class does not exist — the count is one constant and the set is exhaustive by construction. The gate's literal-name arm is a fail-closed fallback, not a live path.
- **Dedicated-lane labels and corpus timeouts** (`validate-ci-gate.py`, `cli-timeout-policy.py`): these are single-spelling reads pinned by fixture tests. Consuming bxl-produced facts instead would require moving the gates out of the test graph (a bxl artifact cannot be a test dependency), trading `buck2 test //...` membership and fixture-tested decision logic for marginal robustness — the opposite of the trade this repository has consistently chosen.

Validated with the tier-selector validation and tool tests, gatelib tests, tier bxl validation, the Python baseline gate, and `scripts/rue quick`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCariNhXQqtLK2bMgcViTr)_