### PR TITLE
RUE-1510: unify AIR semantic type policy

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -12,10 +12,9 @@ use crate::Type;
 use crate::intern_pool::TypeInternPool;
 use crate::scope::ScopedContext;
 use crate::sema::ConstValue;
-use crate::types::{
-    ArrayLen, ModuleId, PtrMutability, StructId, TypeKind, parse_array_type_syntax,
-    parse_pointer_type_syntax,
-};
+#[cfg(test)]
+use crate::types::ArrayLen;
+use crate::types::{ModuleId, StructId, TypeKind};
 use lasso::{Spur, ThreadedRodeo};
 use rue_rir::{InstData, InstRef, RepeatCount, Rir, RirTypeSyntaxNode, RirTypeSyntaxRef};
 use rue_span::{FileId, Span};
@@ -494,11 +493,8 @@ impl<'a> ConstraintGenerator<'a> {
             && let Some(id) = t.as_struct()
         {
             let name: &str = &self.type_pool.struct_def(id).name;
-            return name == "str"
-                || (name.starts_with("Str(") && name.ends_with(')'))
-                || (name.starts_with('[')
-                    && name.ends_with(']')
-                    && crate::types::parse_array_type_syntax(name).is_none());
+            return crate::types::is_string_view_struct_name(name)
+                || crate::types::is_slice_struct_name(name);
         }
         false
     }
@@ -623,6 +619,7 @@ impl<'a> ConstraintGenerator<'a> {
     /// against file-level integer constants (`[i32; K]`). Names that don't
     /// resolve here (e.g. a `comptime` value parameter, only known at
     /// specialization) yield `None`; sema resolves and diagnoses them (RUE-16).
+    #[cfg(test)]
     fn resolve_infer_array_length(&self, len: &ArrayLen, file_id: FileId) -> Option<u64> {
         match len {
             ArrayLen::Literal(n) => Some(*n),
@@ -1187,7 +1184,7 @@ impl<'a> ConstraintGenerator<'a> {
                     // applied by the authoritative semantic pass. Eagerly
                     // substituting them here makes inference reject programs
                     // that the semantic annotation/coercion path accepts.
-                    let annotated = self.resolve_type_arena_with_subst(
+                    let annotated = self.infer_type_hint(
                         self.rir.type_syntax(),
                         *type_syntax,
                         None,
@@ -1412,7 +1409,7 @@ impl<'a> ConstraintGenerator<'a> {
                                 // (RUE-172) - substitute T
                                 match func.param_type_syntax.get(i).and_then(|syntax| {
                                     syntax.as_ref().and_then(|syntax| {
-                                        self.resolve_structured_type_with_subst(
+                                        self.infer_structured_type_hint(
                                             syntax,
                                             &type_subst,
                                             &value_subst,
@@ -1446,7 +1443,7 @@ impl<'a> ConstraintGenerator<'a> {
                             == InferType::Concrete(Type::COMPTIME_TYPE)
                         {
                             match func.return_type_syntax.as_ref().and_then(|syntax| {
-                                self.resolve_structured_type_with_subst(
+                                self.infer_structured_type_hint(
                                     syntax,
                                     &type_subst,
                                     &value_subst,
@@ -2803,7 +2800,7 @@ impl<'a> ConstraintGenerator<'a> {
                                         if *declared == InferType::Concrete(Type::COMPTIME_TYPE) {
                                             match func.param_type_syntax.get(i).and_then(|syntax| {
                                                 syntax.as_ref().and_then(|syntax| {
-                                                    self.resolve_structured_type_with_subst(
+                                                    self.infer_structured_type_hint(
                                                         syntax,
                                                         &type_subst,
                                                         &value_subst,
@@ -3414,10 +3411,6 @@ impl<'a> ConstraintGenerator<'a> {
         }
     }
 
-    /// Resolve a type name to an InferType.
-    ///
-    /// Handles primitive types, array syntax `[T; N]`, pointer syntax `ptr mut T` / `ptr const T`,
-    /// and struct/enum types.
     /// Resolve a call argument used as a comptime type value (e.g. the `i32` in
     /// `identity(i32, 42)`) to a concrete type, if it can be determined during
     /// constraint generation.
@@ -3445,7 +3438,7 @@ impl<'a> ConstraintGenerator<'a> {
 
         match &self.rir.get(arg).data {
             InstData::TypeConst { type_name } => {
-                match self.resolve_rir_type(*type_name, self.rir.get(arg).span.file_id) {
+                match self.infer_rir_type_hint(*type_name, self.rir.get(arg).span.file_id) {
                     Some(InferType::Concrete(ty)) => Some(ty),
                     _ => None,
                 }
@@ -3710,32 +3703,34 @@ impl<'a> ConstraintGenerator<'a> {
         if exhaustive { selected } else { None }
     }
 
-    /// Resolve parser-structured body type syntax for best-effort constraint
-    /// generation. Semantic analysis remains authoritative for qualified and
-    /// comptime-constructor types, but ordinary names, arrays, pointers, and
-    /// substitutions no longer round-trip through rendered syntax.
-    fn resolve_rir_type(&self, syntax: RirTypeSyntaxRef, file_id: FileId) -> Option<InferType> {
-        self.resolve_rir_type_with_subst(syntax, self.type_subst, None, file_id)
+    /// Derive a best-effort constraint hint from parser-structured type syntax.
+    ///
+    /// This is deliberately not semantic type resolution: it produces no
+    /// durable type fact or diagnostic, and fact-bearing forms such as qualified
+    /// names and comptime constructors return `None`. The one authoritative
+    /// semantic policy runs later through `resolve_structured_semantic_type_syntax`.
+    fn infer_rir_type_hint(&self, syntax: RirTypeSyntaxRef, file_id: FileId) -> Option<InferType> {
+        self.infer_rir_type_hint_with_substitutions(syntax, self.type_subst, None, file_id)
     }
 
-    fn resolve_rir_type_with_subst(
+    fn infer_rir_type_hint_with_substitutions(
         &self,
         syntax: RirTypeSyntaxRef,
         subst: Option<&HashMap<Spur, Type>>,
         values: Option<&HashMap<Spur, i128>>,
         file_id: FileId,
     ) -> Option<InferType> {
-        self.resolve_type_arena_with_subst(self.rir.type_syntax(), syntax, subst, values, file_id)
+        self.infer_type_hint(self.rir.type_syntax(), syntax, subst, values, file_id)
     }
 
-    fn resolve_structured_type_with_subst(
+    fn infer_structured_type_hint(
         &self,
         syntax: &crate::sema::StructuredTypeSyntax,
         subst: &HashMap<Spur, Type>,
         values: &HashMap<Spur, i128>,
         file_id: FileId,
     ) -> Option<InferType> {
-        self.resolve_type_arena_with_subst(
+        self.infer_type_hint(
             &syntax.arena,
             syntax.root,
             Some(subst),
@@ -3744,7 +3739,7 @@ impl<'a> ConstraintGenerator<'a> {
         )
     }
 
-    fn resolve_type_arena_with_subst(
+    fn infer_type_hint(
         &self,
         arena: &rue_rir::RirTypeSyntaxArena<Spur>,
         syntax: RirTypeSyntaxRef,
@@ -3764,13 +3759,12 @@ impl<'a> ConstraintGenerator<'a> {
                 if let Some(ty) = self.const_type_alias((file_id, name)) {
                     return Some(self.type_to_infer(ty));
                 }
-                self.resolve_type_name(self.interner.resolve(&name), file_id)
+                self.infer_named_type_hint(self.interner.resolve(&name), file_id)
             }
             RirTypeSyntaxNode::Unit => Some(InferType::Concrete(Type::UNIT)),
             RirTypeSyntaxNode::Never => Some(InferType::Concrete(Type::NEVER)),
             RirTypeSyntaxNode::Array { element, length } => {
-                let element =
-                    self.resolve_type_arena_with_subst(arena, *element, subst, values, file_id)?;
+                let element = self.infer_type_hint(arena, *element, subst, values, file_id)?;
                 let length = match arena.node(*length)? {
                     RirTypeSyntaxNode::Integer(value) => u64::try_from(*value).ok()?,
                     RirTypeSyntaxNode::Named(symbol) => {
@@ -3790,7 +3784,7 @@ impl<'a> ConstraintGenerator<'a> {
             RirTypeSyntaxNode::PointerConst { pointee }
             | RirTypeSyntaxNode::PointerMut { pointee } => {
                 let pointee = self
-                    .resolve_type_arena_with_subst(arena, *pointee, subst, values, file_id)?
+                    .infer_type_hint(arena, *pointee, subst, values, file_id)?
                     .as_concrete()?;
                 let ty = match arena.node(syntax)? {
                     RirTypeSyntaxNode::PointerConst { .. } => {
@@ -3813,44 +3807,7 @@ impl<'a> ConstraintGenerator<'a> {
         }
     }
 
-    fn resolve_type_name(&self, name: &str, file_id: FileId) -> Option<InferType> {
-        // Check for array syntax first: [T; N]
-        if let Some((element_type_str, len)) = parse_array_type_syntax(name) {
-            // Recursively resolve the element type
-            let element_ty = self.resolve_type_name(&element_type_str, file_id)?;
-            let length = self.resolve_infer_array_length(&len, file_id)?;
-            return Some(InferType::Array {
-                element: Box::new(element_ty),
-                length,
-            });
-        }
-
-        // Check for pointer syntax: ptr mut T / ptr const T
-        if let Some((pointee_type_str, mutability)) = parse_pointer_type_syntax(name) {
-            // Recursively resolve the pointee type
-            let pointee_infer_ty = self.resolve_type_name(&pointee_type_str, file_id)?;
-
-            // Convert InferType to Type so we can intern the pointer
-            let pointee_ty = match pointee_infer_ty {
-                InferType::Concrete(ty) => ty,
-                // Can't handle non-concrete types in pointer positions during constraint generation
-                _ => return None,
-            };
-
-            // Intern the pointer type
-            let ptr_ty = match mutability {
-                PtrMutability::Mut => {
-                    let ptr_id = self.type_pool.intern_ptr_mut_from_type(pointee_ty);
-                    Type::new_ptr_mut(ptr_id)
-                }
-                PtrMutability::Const => {
-                    let ptr_id = self.type_pool.intern_ptr_const_from_type(pointee_ty);
-                    Type::new_ptr_const(ptr_id)
-                }
-            };
-            return Some(InferType::Concrete(ptr_ty));
-        }
-
+    fn infer_named_type_hint(&self, name: &str, file_id: FileId) -> Option<InferType> {
         // Check primitives (single shared table, RUE-155)
         if let Some(ty) = Type::from_primitive_name(name) {
             return Some(InferType::Concrete(ty));
@@ -4970,11 +4927,11 @@ mod tests {
 
         // Same module: the alias head resolves to its aliased type.
         assert_eq!(
-            cgen.resolve_type_name("MyAlias", file_a),
+            cgen.infer_named_type_hint("MyAlias", file_a),
             Some(InferType::Concrete(Type::I32))
         );
         // Another module: out of scope, does not resolve bare.
-        assert_eq!(cgen.resolve_type_name("MyAlias", file_b), None);
+        assert_eq!(cgen.infer_named_type_hint("MyAlias", file_b), None);
     }
 
     /// Array lengths need an integer value; alias heads need a type. The two
@@ -5008,6 +4965,6 @@ mod tests {
             None
         );
         // An integer const name in alias-head position is not a type alias.
-        assert_eq!(cgen.resolve_type_name("K", file_a), None);
+        assert_eq!(cgen.infer_named_type_hint("K", file_a), None);
     }
 }

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -144,13 +144,13 @@ pub use semantic_type_resolution::{
     SemanticResolvedModule, SemanticTypeConstructorHead, SemanticTypeConstructorParameter,
     SemanticTypeFact, SemanticTypeFactKind, SemanticTypeSyntaxError, SemanticTypeSyntaxFailure,
     SemanticTypeSyntaxProvider, SemanticValueSyntax, SemanticVisibilityDomain,
-    resolve_semantic_comptime_call, resolve_semantic_module_path, resolve_semantic_type_syntax,
-    resolve_structured_semantic_type_syntax, resolve_structured_semantic_type_syntax_with,
+    resolve_semantic_module_path, resolve_structured_semantic_type_syntax,
+    resolve_structured_semantic_type_syntax_with,
 };
 pub use types::{
     ArrayLen, ArrayTypeId, EnumDef, EnumId, LangItem, ModuleDef, ModuleId, PtrConstTypeId,
-    PtrMutTypeId, PtrMutability, StructDef, StructField, StructId, Type, TypeKind,
-    parse_array_type_syntax, parse_pointer_type_syntax, parse_type_call_syntax,
+    PtrMutTypeId, StructDef, StructField, StructId, Type, TypeKind, fixed_string_capacity,
+    is_slice_struct_name, is_string_view_struct_name,
 };
 
 /// Sentinel value used to encode parameter slots in AIR instructions.

--- a/crates/rue-air/src/sema/aggregate_resolution.rs
+++ b/crates/rue-air/src/sema/aggregate_resolution.rs
@@ -1,8 +1,7 @@
 //! Provider-generic aggregate, field, and variant resolution.
 //!
-//! Selection order lives here. [`EpochFacts`] is the generic production adapter
-//! that delegates declaration reads to an [`AggregateFactSource`] supplied by
-//! its host; `Sema` supplies the current declaration-epoch source.
+//! Selection order lives here. Both body-analysis hosts implement the one
+//! [`AggregateFacts`] boundary directly.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -20,23 +19,6 @@ use crate::types::{EnumId, ModuleId, StructId, Type};
 use crate::{SemanticImportNominalKind, SemanticImportType};
 
 pub(crate) trait AggregateFacts {
-    fn value_const(&self, file: FileId, name: Spur) -> Option<ConstInfo>;
-    fn module_binding(&self, file: FileId, name: Spur) -> Option<ConstInfo>;
-    fn struct_in_file(&self, file: FileId, name: Spur) -> Option<StructId>;
-    fn enum_in_file(&self, file: FileId, name: Spur) -> Option<EnumId>;
-    fn builtin_struct(&self, name: Spur) -> Option<StructId>;
-    fn builtin_enum(&self, name: Spur) -> Option<EnumId>;
-    fn module(&self, module: ModuleId) -> AggregateModuleFact;
-    fn file_path(&self, file: FileId) -> Option<&str>;
-    #[allow(dead_code)]
-    fn source_path(&self, span: rue_span::Span) -> Option<&str>;
-    fn visibility_domain(&self, file: FileId) -> crate::SemanticVisibilityDomain {
-        crate::SemanticVisibilityDomain::from_file_path(self.file_path(file))
-    }
-}
-
-/// Raw immutable aggregate-resolution reads supplied by a body-analysis host.
-pub(super) trait AggregateFactSource {
     fn aggregate_value_const(&self, file: FileId, name: Spur) -> Option<ConstInfo>;
     fn aggregate_module_binding(&self, file: FileId, name: Spur) -> Option<ConstInfo>;
     fn aggregate_struct_in_file(&self, file: FileId, name: Spur) -> Option<StructId>;
@@ -70,15 +52,13 @@ impl AggregateModuleFact {
     }
 }
 
-/// Direct epoch reads for the current host. The generic adapter below owns the
-/// read-only abstraction; this impl is only the production source of facts.
-impl<D: DeclarationPhase> AggregateFactSource for Sema<'_, D> {
+impl<D: DeclarationPhase> AggregateFacts for Sema<'_, D> {
     fn aggregate_value_const(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
-        self.value_const(&(file, name)).cloned()
+        self.declarations.value_const(&(file, name)).cloned()
     }
 
     fn aggregate_module_binding(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
-        self.module_binding(&(file, name)).cloned()
+        self.declarations.module_binding(&(file, name)).cloned()
     }
 
     fn aggregate_struct_in_file(&self, file: FileId, name: Spur) -> Option<StructId> {
@@ -115,50 +95,6 @@ impl<D: DeclarationPhase> AggregateFactSource for Sema<'_, D> {
     }
 }
 
-/// Read-only aggregate-resolution adapter used by the canonical body engine.
-pub(crate) struct EpochFacts<'host, H: super::fact_mode::BodyAnalysisReadHost> {
-    host: &'host H,
-}
-
-impl<'host, H: super::fact_mode::BodyAnalysisReadHost> EpochFacts<'host, H> {
-    pub(in crate::sema) fn new(host: &'host H) -> Self {
-        Self { host }
-    }
-}
-
-impl<H: super::fact_mode::BodyAnalysisReadHost> AggregateFacts for EpochFacts<'_, H> {
-    fn value_const(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
-        self.host.aggregate_value_const(file, name)
-    }
-    fn module_binding(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
-        self.host.aggregate_module_binding(file, name)
-    }
-    fn struct_in_file(&self, file: FileId, name: Spur) -> Option<StructId> {
-        self.host.aggregate_struct_in_file(file, name)
-    }
-    fn enum_in_file(&self, file: FileId, name: Spur) -> Option<EnumId> {
-        self.host.aggregate_enum_in_file(file, name)
-    }
-    fn builtin_struct(&self, name: Spur) -> Option<StructId> {
-        self.host.aggregate_builtin_struct(name)
-    }
-    fn builtin_enum(&self, name: Spur) -> Option<EnumId> {
-        self.host.aggregate_builtin_enum(name)
-    }
-    fn module(&self, module: ModuleId) -> AggregateModuleFact {
-        self.host.aggregate_module(module)
-    }
-    fn file_path(&self, file: FileId) -> Option<&str> {
-        self.host.aggregate_file_path(file)
-    }
-    fn source_path(&self, span: rue_span::Span) -> Option<&str> {
-        self.host.aggregate_source_path(span)
-    }
-    fn visibility_domain(&self, file: FileId) -> crate::SemanticVisibilityDomain {
-        self.host.aggregate_visibility_domain(file)
-    }
-}
-
 pub(crate) enum StructLiteralHead {
     Bound(Type),
     Named(StructId),
@@ -188,14 +124,14 @@ pub(crate) fn resolve_enum_type_name<P: AggregateFacts>(
     if let Some(ty) = local_type {
         return ty.as_enum().map(|id| (id, true));
     }
-    if let Some(info) = facts.value_const(file, name)
+    if let Some(info) = facts.aggregate_value_const(file, name)
         && let ConstValue::Type(ty) = info.value
     {
         return ty.as_enum().map(|id| (id, true));
     }
     facts
-        .enum_in_file(file, name)
-        .or_else(|| facts.builtin_enum(name))
+        .aggregate_enum_in_file(file, name)
+        .or_else(|| facts.aggregate_builtin_enum(name))
         .map(|id| (id, false))
 }
 
@@ -208,14 +144,14 @@ pub(crate) fn resolve_struct_type_name<P: AggregateFacts>(
     if let Some(ty) = local_type {
         return ty.as_struct().map(|id| (id, true));
     }
-    if let Some(info) = facts.value_const(file, name)
+    if let Some(info) = facts.aggregate_value_const(file, name)
         && let ConstValue::Type(ty) = info.value
     {
         return ty.as_struct().map(|id| (id, true));
     }
     facts
-        .struct_in_file(file, name)
-        .or_else(|| facts.builtin_struct(name))
+        .aggregate_struct_in_file(file, name)
+        .or_else(|| facts.aggregate_builtin_struct(name))
         .map(|id| (id, false))
 }
 
@@ -228,14 +164,14 @@ pub(crate) fn select_struct_literal_head<P: AggregateFacts>(
     if let Some(ty) = local_type {
         return StructLiteralHead::Bound(ty);
     }
-    if let Some(info) = facts.value_const(file, name)
+    if let Some(info) = facts.aggregate_value_const(file, name)
         && let ConstValue::Type(ty) = info.value
     {
         return StructLiteralHead::Bound(ty);
     }
     facts
-        .struct_in_file(file, name)
-        .or_else(|| facts.builtin_struct(name))
+        .aggregate_struct_in_file(file, name)
+        .or_else(|| facts.aggregate_builtin_struct(name))
         .map_or(StructLiteralHead::Absent, StructLiteralHead::Named)
 }
 
@@ -244,15 +180,15 @@ pub(crate) fn select_module_type_member<P: AggregateFacts>(
     file: FileId,
     name: Spur,
 ) -> ModuleTypeMember {
-    if let Some(id) = facts.struct_in_file(file, name) {
+    if let Some(id) = facts.aggregate_struct_in_file(file, name) {
         return ModuleTypeMember::Struct(id);
     }
-    if let Some(id) = facts.enum_in_file(file, name) {
+    if let Some(id) = facts.aggregate_enum_in_file(file, name) {
         return ModuleTypeMember::Enum(id);
     }
     if let Some(info) = facts
-        .module_binding(file, name)
-        .or_else(|| facts.value_const(file, name))
+        .aggregate_module_binding(file, name)
+        .or_else(|| facts.aggregate_value_const(file, name))
     {
         return ModuleTypeMember::Const(info);
     }
@@ -264,11 +200,11 @@ pub(crate) fn select_qualified_type<P: AggregateFacts>(
     file: FileId,
     name: Spur,
 ) -> QualifiedType {
-    if let Some(id) = facts.enum_in_file(file, name) {
+    if let Some(id) = facts.aggregate_enum_in_file(file, name) {
         return QualifiedType::Enum(id);
     }
     facts
-        .struct_in_file(file, name)
+        .aggregate_struct_in_file(file, name)
         .map_or(QualifiedType::Absent, QualifiedType::Struct)
 }
 
@@ -277,7 +213,7 @@ pub(crate) fn select_qualified_enum<P: AggregateFacts>(
     file: FileId,
     name: Spur,
 ) -> Option<EnumId> {
-    facts.enum_in_file(file, name)
+    facts.aggregate_enum_in_file(file, name)
 }
 
 pub(crate) fn resolve_aggregate_module_ref<P: AggregateFacts>(
@@ -295,14 +231,14 @@ pub(crate) fn resolve_aggregate_module_ref<P: AggregateFacts>(
                 }
             }
             facts
-                .module_binding(root_file, name)
+                .aggregate_module_binding(root_file, name)
                 .and_then(|binding| binding.ty.as_module())
         }
         InstData::FieldGet { base, field } => {
             let parent = resolve_aggregate_module_ref(facts, rir, base, root_file, locals)?;
-            let parent_file = facts.module(parent).file;
+            let parent_file = facts.aggregate_module(parent).file;
             facts
-                .module_binding(parent_file, field)
+                .aggregate_module_binding(parent_file, field)
                 .and_then(|binding| binding.ty.as_module())
         }
         _ => None,
@@ -319,14 +255,14 @@ pub(crate) fn resolve_visibility_module_ref<P: AggregateFacts>(
     let module_ty = match inst.data {
         InstData::VarRef { name, .. } => locals.get(&name).map(|local| local.ty).or_else(|| {
             facts
-                .module_binding(inst.span.file_id, name)
+                .aggregate_module_binding(inst.span.file_id, name)
                 .map(|binding| binding.ty)
         }),
         InstData::FieldGet { base, field } => {
             let parent = resolve_visibility_module_ref(facts, rir, base, locals)?;
-            let parent_file = facts.module(parent).file;
+            let parent_file = facts.aggregate_module(parent).file;
             facts
-                .module_binding(parent_file, field)
+                .aggregate_module_binding(parent_file, field)
                 .map(|binding| binding.ty)
         }
         _ => None,
@@ -343,8 +279,8 @@ pub(crate) fn is_accessible<P: AggregateFacts>(
     if is_public || accessing_file == defining_file {
         return true;
     }
-    let accessing = facts.visibility_domain(accessing_file);
-    let defining = facts.visibility_domain(defining_file);
+    let accessing = facts.aggregate_visibility_domain(accessing_file);
+    let defining = facts.aggregate_visibility_domain(defining_file);
     defining.is_visible_from(&accessing, is_public)
 }
 
@@ -398,9 +334,9 @@ pub enum ProviderStructHead {
     Absent,
 }
 
-/// The aggregate-resolution ProviderFacts driver: answers the family-1D
-/// [`AggregateFacts`] from a body identity pool + a caller-populated overlay,
-/// instead of the epoch `Sema` tables [`EpochFacts`] reads.
+/// Query-backed aggregate fact state: answers [`AggregateFacts`] from a body
+/// identity pool plus a caller-populated overlay, while the epoch host reads
+/// its own tables directly.
 ///
 /// Generic over the pool durable source `S` and the pool's durable nominal key
 /// `K` and module `M` (rue-compiler binds `K = StableDefinitionKey`,
@@ -457,7 +393,7 @@ where
         }
     }
 
-    /// Construct the aggregate facade from the one task-local provider
+    /// Construct the aggregate fact state from the one task-local provider
     /// authority shared with endpoint and call resolution.
     pub fn with_state(state: &super::ProviderBodyAnalysisState<K, M, S>) -> Self {
         Self::with_overlay_identity(state.identity_context())
@@ -546,13 +482,13 @@ where
     /// `structs_by_file_name` lookup under the durable-key bijection.
     pub fn struct_in_file(&self, file: FileId, name: &str) -> Option<Type> {
         let symbol = self.identity.pool().intern_name(name);
-        AggregateFacts::struct_in_file(self, file, symbol).map(Type::new_struct)
+        AggregateFacts::aggregate_struct_in_file(self, file, symbol).map(Type::new_struct)
     }
 
     /// (P) The enum declared as `(file, name)`, as a pool [`Type`].
     pub fn enum_in_file(&self, file: FileId, name: &str) -> Option<Type> {
         let symbol = self.identity.pool().intern_name(name);
-        AggregateFacts::enum_in_file(self, file, symbol).map(Type::new_enum)
+        AggregateFacts::aggregate_enum_in_file(self, file, symbol).map(Type::new_enum)
     }
 
     /// (P) The builtin struct for a bare name (the pool's pre-registered `str`),
@@ -560,14 +496,14 @@ where
     /// (r6 builtin facts).
     pub fn builtin_struct(&self, name: &str) -> Option<Type> {
         let symbol = self.identity.pool().intern_name(name);
-        AggregateFacts::builtin_struct(self, symbol).map(Type::new_struct)
+        AggregateFacts::aggregate_builtin_struct(self, symbol).map(Type::new_struct)
     }
 
     /// (P) The builtin enum for a bare name (one of `BUILTIN_ENUMS`), as a pool
     /// [`Type`].
     pub fn builtin_enum(&self, name: &str) -> Option<Type> {
         let symbol = self.identity.pool().intern_name(name);
-        AggregateFacts::builtin_enum(self, symbol).map(Type::new_enum)
+        AggregateFacts::aggregate_builtin_enum(self, symbol).map(Type::new_enum)
     }
 
     /// Run the provider-generic [`select_module_type_member`] over this driver:
@@ -635,21 +571,21 @@ where
     M: Eq + Hash,
     S: DurableNominalSource<K, M>,
 {
-    fn value_const(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
+    fn aggregate_value_const(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
         self.value_consts
             .borrow()
             .get(&(file.index(), name))
             .cloned()
     }
 
-    fn module_binding(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
+    fn aggregate_module_binding(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
         self.module_bindings
             .borrow()
             .get(&(file.index(), name))
             .cloned()
     }
 
-    fn struct_in_file(&self, file: FileId, name: Spur) -> Option<StructId> {
+    fn aggregate_struct_in_file(&self, file: FileId, name: Spur) -> Option<StructId> {
         let key = self.by_file_name.get(&(file.index(), name)).cloned()?;
         self.identity
             .pool_mut()?
@@ -658,7 +594,7 @@ where
             .as_struct()
     }
 
-    fn enum_in_file(&self, file: FileId, name: Spur) -> Option<EnumId> {
+    fn aggregate_enum_in_file(&self, file: FileId, name: Spur) -> Option<EnumId> {
         let key = self.by_file_name.get(&(file.index(), name)).cloned()?;
         self.identity
             .pool_mut()?
@@ -667,7 +603,7 @@ where
             .as_enum()
     }
 
-    fn builtin_struct(&self, name: Spur) -> Option<StructId> {
+    fn aggregate_builtin_struct(&self, name: Spur) -> Option<StructId> {
         let name = self.identity.pool().resolve_symbol(name).to_owned();
         self.identity
             .pool_mut()?
@@ -679,7 +615,7 @@ where
             .as_struct()
     }
 
-    fn builtin_enum(&self, name: Spur) -> Option<EnumId> {
+    fn aggregate_builtin_enum(&self, name: Spur) -> Option<EnumId> {
         let name = self.identity.pool().resolve_symbol(name).to_owned();
         self.identity
             .pool_mut()?
@@ -691,7 +627,7 @@ where
             .as_enum()
     }
 
-    fn module(&self, module: ModuleId) -> AggregateModuleFact {
+    fn aggregate_module(&self, module: ModuleId) -> AggregateModuleFact {
         let definition = self
             .identity
             .modules()
@@ -704,11 +640,11 @@ where
         }
     }
 
-    fn file_path(&self, file: FileId) -> Option<&str> {
+    fn aggregate_file_path(&self, file: FileId) -> Option<&str> {
         self.file_paths.get(&file).map(String::as_str)
     }
 
-    fn source_path(&self, _span: rue_span::Span) -> Option<&str> {
+    fn aggregate_source_path(&self, _span: rue_span::Span) -> Option<&str> {
         // Deferred to the flip: consumed only by inline `aggregates.rs`
         // diagnostic paths, never by the provider-generic selection logic.
         None

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -12,10 +12,9 @@ use rue_rir::{InstData, InstRef, RirParamMode};
 use rue_span::Span;
 
 use super::aggregate_resolution::{
-    AggregateFacts, ModuleTypeMember, QualifiedType, StructLiteralHead,
-    resolve_aggregate_module_ref, resolve_enum_type_name, resolve_struct_type_name,
-    select_module_type_member, select_qualified_enum, select_qualified_type,
-    select_struct_literal_head,
+    ModuleTypeMember, QualifiedType, StructLiteralHead, resolve_aggregate_module_ref,
+    resolve_enum_type_name, resolve_struct_type_name, select_module_type_member,
+    select_qualified_enum, select_qualified_type, select_struct_literal_head,
 };
 use super::analysis::FirstClassStrSite;
 use super::context::{AnalysisContext, AnalysisResult, ConstValue};
@@ -38,7 +37,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     ) -> Option<(crate::types::EnumId, bool)> {
         let facts = self.aggregate_facts();
         resolve_enum_type_name(
-            &facts,
+            facts,
             ctx.comptime_type_vars.get(&type_name).copied(),
             ctx.current_file_id,
             type_name,
@@ -64,7 +63,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     ) -> Option<(crate::types::StructId, bool)> {
         let facts = self.aggregate_facts();
         resolve_struct_type_name(
-            &facts,
+            facts,
             ctx.comptime_type_vars.get(&type_name).copied(),
             ctx.current_file_id,
             type_name,
@@ -370,7 +369,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             };
             let struct_id = {
                 let facts = self.aggregate_facts();
-                facts.struct_in_file(facts.module(module_id).file, type_name)
+                facts.aggregate_struct_in_file(facts.aggregate_module(module_id).file, type_name)
             }
             .ok_or_compile_error(ErrorKind::UnknownType(type_name_str.to_string()), span)?;
             // Module-qualified visibility is E0706 (RUE-525), uniform with
@@ -391,7 +390,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let head = {
                 let facts = self.aggregate_facts();
                 select_struct_literal_head(
-                    &facts,
+                    facts,
                     ctx.comptime_type_vars.get(&type_name).copied(),
                     span.file_id,
                     type_name,
@@ -628,10 +627,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         // Resolve the module to its canonical request-local file identity, so
         // equivalent path spellings select the same visibility domain.
-        let module_fact = self.aggregate_facts().module(module_id);
+        let module_fact = self.aggregate_facts().aggregate_module(module_id);
         let member = {
             let facts = self.aggregate_facts();
-            select_module_type_member(&facts, module_fact.file, member_name)
+            select_module_type_member(facts, module_fact.file, member_name)
         };
 
         // First, try to find a struct with this name defined by the module's
@@ -870,7 +869,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     ) -> Option<crate::types::ModuleId> {
         let facts = self.aggregate_facts();
         resolve_aggregate_module_ref(
-            &facts,
+            facts,
             self.body_rir_ref(),
             inst_ref,
             span.file_id,
@@ -903,8 +902,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         };
         let selected = {
             let facts = self.aggregate_facts();
-            let file = facts.module(module_id).file;
-            select_qualified_type(&facts, file, type_name)
+            let file = facts.aggregate_module(module_id).file;
+            select_qualified_type(facts, file, type_name)
         };
 
         // Enum member: `module.Enum.Variant(payload)` is tuple-variant
@@ -999,8 +998,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         };
         let Some(enum_id) = ({
             let facts = self.aggregate_facts();
-            let file = facts.module(module_id).file;
-            select_qualified_enum(&facts, file, type_name)
+            let file = facts.aggregate_module(module_id).file;
+            select_qualified_enum(facts, file, type_name)
         }) else {
             // `type_name` is not an enum in this module: this is const/field
             // access through the module, not a variant path. Fall through.

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -202,13 +202,13 @@ fn materialize_argument_value(
         V::Integer(value) => super::ConstValue::Integer(*value),
         V::Bool(value) => super::ConstValue::Bool(*value),
         V::Type(value) => {
-            super::ConstValue::Type(super::body_endpoint::resolve_instance_type(&facts, value)?)
+            super::ConstValue::Type(super::body_endpoint::resolve_instance_type(facts, value)?)
         }
         V::Function(value) => {
             let crate::FunctionInstanceKey::Definition(token) = value.as_ref() else {
                 return Err(crate::SemanticBodyExportFailure::MissingStableIdentity);
             };
-            let symbol = super::body_endpoint::resolve_free_function_symbol(&facts, *token)
+            let symbol = super::body_endpoint::resolve_free_function_symbol(facts, *token)
                 .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)?;
             super::ConstValue::Function(symbol)
         }
@@ -221,7 +221,7 @@ fn materialize_instance_type(
     sema: &BodySema<'_>,
     value: &crate::TypeInstanceKey<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
 ) -> Result<Type, crate::SemanticBodyExportFailure> {
-    super::body_endpoint::resolve_instance_type(&sema.endpoint_facts(), value)
+    super::body_endpoint::resolve_instance_type(sema.endpoint_facts(), value)
 }
 
 fn canonical_composed_identity(
@@ -358,7 +358,7 @@ fn composed_callable_metadata(
                 .ok_or_else(missing)?;
             let info = sema
                 .call_facts()
-                .method_info(struct_id, method)
+                .call_method_info(struct_id, method)
                 .ok_or_else(missing)?;
             Ok((
                 sema.method_symbol(struct_id, member.name.as_ref(), info.has_self),
@@ -428,11 +428,7 @@ pub(crate) fn import_staged_body(
                 name,
                 kind: NK::Struct,
             } => {
-                if let Some(capacity) = name
-                    .strip_prefix("Str(")
-                    .and_then(|name| name.strip_suffix(')'))
-                    .and_then(|capacity| capacity.parse().ok())
-                {
+                if let Some(capacity) = crate::types::fixed_string_capacity(name) {
                     capacities.insert(capacity);
                 }
             }
@@ -812,7 +808,7 @@ pub(crate) fn import_staged_body(
             .ok_or(BF::Semantic(F::MissingFunction))?;
         let info = sema
             .call_facts()
-            .method_info(struct_id, name)
+            .call_method_info(struct_id, name)
             .ok_or(BF::Semantic(F::MissingFunction))?;
         let expected = match identity.kind {
             DK::Method => info.has_self && identity.name.as_ref() != "__drop",
@@ -857,7 +853,7 @@ pub(crate) fn import_staged_body(
                     .ok_or(BF::Semantic(F::MissingFunction))?;
                 let info = sema
                     .call_facts()
-                    .method_info(struct_id, name)
+                    .call_method_info(struct_id, name)
                     .ok_or(BF::Semantic(F::MissingFunction))?;
                 let expected = match member.kind {
                     crate::AnonymousMemberKind::Method => {
@@ -987,7 +983,7 @@ pub(crate) fn imported_body_references(
         let AirInstData::Call { name, .. } = instruction.data else {
             continue;
         };
-        if facts.function_contains(name) {
+        if facts.call_function_contains(name) {
             functions.insert(name);
         }
     }
@@ -1387,7 +1383,7 @@ fn collect_static_function_references(sema: &BodySema<'_>) -> HashSet<Spur> {
     for (_, inst) in sema.rir.iter() {
         if let InstData::Call { name, .. } = &inst.data
             && let Some(function_key) =
-                resolve_static_call_reference(&sema.call_facts(), *name, inst.span.file_id)
+                resolve_static_call_reference(sema.call_facts(), *name, inst.span.file_id)
         {
             referenced.insert(function_key);
         }
@@ -1403,7 +1399,7 @@ fn collect_static_function_references(sema: &BodySema<'_>) -> HashSet<Spur> {
         };
         if let Some(function) = sema
             .call_facts()
-            .resolve_function_name_local(name, FileId::new(event.callable_file))
+            .call_resolve_function_name_local(name, FileId::new(event.callable_file))
         {
             referenced.insert(function);
         }
@@ -1563,7 +1559,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
 
     // Find main() - the reference root for executable body analysis.
     let main_sym = match sema.interner.get("main") {
-        Some(sym) if sema.call_facts().function_contains(sym) => sym,
+        Some(sym) if sema.call_facts().call_function_contains(sym) => sym,
         _ => {
             // No main function found - this is an error
             return Err(CompileErrors::from(CompileError::without_span(
@@ -2192,7 +2188,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                     .interner
                     .get(&type_name_str)
                     .expect("named struct definition must retain its interned source name");
-                let Some(method_ref) = sema.call_facts().named_method_declaration(
+                let Some(method_ref) = sema.call_facts().call_named_method_declaration(
                     struct_def.file_id,
                     owner_name,
                     method_name,

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -3,7 +3,6 @@
 //! This category owns builtin operations within the canonical semantic-analysis
 //! implementation.
 
-use super::super::call_resolution::CallResolutionFacts;
 use super::super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
 use super::*;
 
@@ -100,7 +99,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             span,
         )?;
         let method = self.body_interner().get_or_intern("concat_borrowed");
-        if self.call_facts().method_info(struct_id, method).is_none() {
+        if self
+            .call_facts()
+            .call_method_info(struct_id, method)
+            .is_none()
+        {
             return Err(CompileError::new(
                 ErrorKind::InternalError("canonical StrBuf is missing concat_borrowed".to_string()),
                 span,
@@ -490,7 +493,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             } => {
                 let base_ty = self.peek_place_type(*receiver, ctx)?;
                 let struct_id = base_ty.as_struct()?;
-                let info = self.call_facts().method_info(struct_id, *method)?;
+                let info = self.call_facts().call_method_info(struct_id, *method)?;
                 info.returns_borrow.then_some(info.return_type)
             }
             InstData::FieldGet { base, field } => {

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -9,7 +9,6 @@
 use super::super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
 use super::*;
 use crate::sema::NamedConstDependencyTargetEvent;
-use crate::sema::call_resolution::CallResolutionFacts;
 use crate::sema::info::FunctionCallInfo;
 
 fn module_display_name(path: &str) -> &str {
@@ -236,7 +235,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     .and_then(|ty| ty.as_struct())
                     && self
                         .call_facts()
-                        .method_info(struct_id, *method)
+                        .call_method_info(struct_id, *method)
                         .is_some_and(|info| info.returns_borrow)
                 {
                     return self.analyze_accessor_call_value(
@@ -273,7 +272,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let mut resolved_alias = false;
         let const_info = self
             .call_facts()
-            .resolve_const_info_in_file(name, span.file_id);
+            .call_resolve_const_info_in_file(name, span.file_id);
         if let Some(const_info) = const_info
             && let Some(callee) = const_info.value.as_function()
         {
@@ -296,7 +295,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let local_name = (!resolved_alias)
             .then(|| {
                 self.call_facts()
-                    .resolve_function_name_local(name, span.file_id)
+                    .call_resolve_function_name_local(name, span.file_id)
             })
             .flatten();
         if let Some(local_name) = local_name {
@@ -325,11 +324,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
 
         // Look up the function
-        let source_name = self.call_facts().source_function_name(name);
+        let source_name = self.call_facts().call_source_function_name(name);
         let fn_name_str = self.body_interner().resolve(&source_name).to_string();
         let fn_info = self
             .call_facts()
-            .function_info(name)
+            .call_function_info(name)
             .ok_or_compile_error(ErrorKind::UndefinedFunction(fn_name_str.clone()), span)?;
 
         self.analyze_resolved_function_call(air, name, fn_info, args_range, span, ctx, true)
@@ -356,7 +355,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         ctx: &mut AnalysisContext,
         check_unqualified_visibility: bool,
     ) -> CompileResult<AnalysisResult> {
-        let source_name = self.call_facts().source_function_name(name);
+        let source_name = self.call_facts().call_source_function_name(name);
         let fn_name_str = self.body_interner().resolve(&source_name).to_string();
 
         // Visibility (E0460, RUE-37/RUE-180): an unqualified call must not
@@ -910,7 +909,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 let ty = self.peek_place_type(receiver, ctx)?;
                 let struct_id = ty.as_struct()?;
 
-                let info = self.call_facts().method_info(struct_id, method)?;
+                let info = self.call_facts().call_method_info(struct_id, method)?;
                 matches!(info.self_mode, RirParamMode::Inout | RirParamMode::Borrow).then_some(root)
             })
         };
@@ -1005,7 +1004,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let method_key = (struct_id, method);
         let method_info = self
             .call_facts()
-            .method_info(struct_id, method)
+            .call_method_info(struct_id, method)
             .ok_or_compile_error(
                 ErrorKind::UndefinedMethod {
                     type_name: struct_name_str.clone(),
@@ -1241,11 +1240,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
         let fn_name_str = self.body_interner().resolve(&function_name).to_string();
-        let module_def = self.call_facts().module_def(module_id);
+        let module_def = self.call_facts().call_module_def(module_id);
         let module_file_id = Some(module_def.file_id);
         let mut function_key = module_file_id.and_then(|file_id| {
             self.call_facts()
-                .resolve_function_name_local(function_name, file_id)
+                .call_resolve_function_name_local(function_name, file_id)
         });
 
         // Fallback: a re-exported function member — `pub const f = @import("x").f;`
@@ -1261,7 +1260,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         {
             let reexport = self
                 .call_facts()
-                .value_const(mfile, function_name)
+                .call_value_const(mfile, function_name)
                 .and_then(|info| match info.value {
                     ConstValue::Function(fkey) => Some((fkey, info.is_pub)),
                     _ => None,
@@ -1297,7 +1296,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         })?;
         let fn_info = self
             .call_facts()
-            .function_info(function_key)
+            .call_function_info(function_key)
             .ok_or_compile_error(
                 ErrorKind::UnknownModuleMember {
                     module_name: module_display_name(&module_def.import_path).to_string(),
@@ -1418,7 +1417,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             }
         } else if let Some(info) = self
             .call_facts()
-            .value_const(ctx.current_file_id, type_name)
+            .call_value_const(ctx.current_file_id, type_name)
             && let ConstValue::Type(ty) = info.value
         {
             // Module-level `const C = Counter(i32); C.zero()` (RUE-595): the
@@ -1468,7 +1467,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let method_key = (struct_id, function);
         let method_info = self
             .call_facts()
-            .method_info(struct_id, function)
+            .call_method_info(struct_id, function)
             .ok_or_compile_error(
                 ErrorKind::UndefinedAssocFn {
                     type_name: type_name_str.clone(),

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -5,7 +5,6 @@
 //! them. It extends the canonical [`BodySema`] rather than introducing peer
 //! analysis state.
 
-use super::super::call_resolution::CallResolutionFacts;
 use super::super::context::{LocalVar, VariableMoveState};
 use super::super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
 use super::*;
@@ -484,7 +483,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         || ctx.comptime_value_vars.contains_key(name)
                         || self
                             .call_facts()
-                            .value_const(self.body_rir_ref().get(operand).span.file_id, *name)
+                            .call_value_const(self.body_rir_ref().get(operand).span.file_id, *name)
                             .is_some())
             }
             _ => false,
@@ -501,7 +500,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     && !ctx.has_param(*name)
                     && self
                         .call_facts()
-                        .value_const(self.body_rir_ref().get(operand).span.file_id, *name)
+                        .call_value_const(self.body_rir_ref().get(operand).span.file_id, *name)
                         .is_some_and(|info| matches!(info.value, ConstValue::String(_)))
             }
             _ => false,
@@ -645,7 +644,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let len_method = self.body_interner().get_or_intern("len");
         let Some(ptr_ty) = self
             .call_facts()
-            .method_info(struct_id, ptr_method)
+            .call_method_info(struct_id, ptr_method)
             .map(|m| m.return_type)
         else {
             return Err(CompileError::new(
@@ -657,7 +656,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         };
         let Some(len_ty) = self
             .call_facts()
-            .method_info(struct_id, len_method)
+            .call_method_info(struct_id, len_method)
             .map(|m| m.return_type)
         else {
             return Err(CompileError::new(
@@ -1119,7 +1118,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         else {
             return Ok(None);
         };
-        let Some(info) = self.call_facts().method_info(struct_id, method) else {
+        let Some(info) = self.call_facts().call_method_info(struct_id, method) else {
             return Ok(None);
         };
         if !info.returns_borrow {
@@ -1156,7 +1155,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     ) -> CompileResult<PlaceTrace> {
         let info = self
             .call_facts()
-            .method_info(struct_id, method)
+            .call_method_info(struct_id, method)
             .expect("accessor expansion follows a successful method lookup");
         let method_name_str = self.body_interner().resolve(&method).to_string();
         let call_name = self.method_symbol(struct_id, &method_name_str, true);
@@ -1305,7 +1304,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             } => {
                 let base_ty = self.peek_place_type(*receiver, ctx)?;
                 let base_struct = base_ty.as_struct()?;
-                let info = self.call_facts().method_info(base_struct, *method)?;
+                let info = self.call_facts().call_method_info(base_struct, *method)?;
                 if !info.returns_borrow {
                     return None;
                 }
@@ -1988,7 +1987,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // @import("math")`). Module bindings are per-file scoped (RUE-113),
         // so the lookup is keyed by the reference's own file and takes
         // precedence over file-local value constants.
-        let module_binding = self.call_facts().module_binding(span.file_id, name);
+        let module_binding = self.call_facts().call_module_binding(span.file_id, name);
         if let Some(binding) = module_binding {
             self.record_body_named_dependency(
                 super::super::NamedConstDependencyTargetEvent::ModuleBinding {
@@ -2013,7 +2012,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // never re-analyzed at use sites.
         let const_info = self
             .call_facts()
-            .resolve_const_info_in_file(name, span.file_id);
+            .call_resolve_const_info_in_file(name, span.file_id);
         if let Some(const_info) = const_info {
             // Apply the uniform privacy rule even though ordinary unqualified
             // lookup resolves in the reference file (spec 10.3:1, 10.3:7).
@@ -3249,7 +3248,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ));
         };
         let method = self.body_interner().get_or_intern("byte_at_borrowed");
-        if self.call_facts().method_info(struct_id, method).is_none() {
+        if self
+            .call_facts()
+            .call_method_info(struct_id, method)
+            .is_none()
+        {
             return Err(CompileError::new(
                 ErrorKind::InternalError(
                     "trusted std StrBuf is missing its source `byte_at_borrowed` method"

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -11,6 +11,7 @@ use rue_rir::{InstData, InstRef, RirParamMode};
 use rue_span::{FileId, Span};
 
 use super::RirDeclarationIndexWork;
+use super::body_endpoint::BodyEndpointProvider;
 use super::{ConstValue, Sema, SemaOutput};
 use crate::types::{Type, TypeKind};
 use crate::{StableDefinitionKind, StableDefinitionNamespace};
@@ -655,15 +656,8 @@ impl<'a> DeclarationShells<'a> {
                 {
                     if name.as_ref() == "str" {
                         *needs_str = true;
-                    } else if let Some(capacity) = name
-                        .strip_prefix("Str(")
-                        .and_then(|value| value.strip_suffix(')'))
-                    {
-                        fixed.insert(
-                            capacity
-                                .parse()
-                                .map_err(|_| DeclarationInstallFailure::UnsupportedType)?,
-                        );
+                    } else if let Some(capacity) = crate::types::fixed_string_capacity(name) {
+                        fixed.insert(capacity);
                     }
                 }
                 SemanticExportType::Array { element, .. }
@@ -2266,8 +2260,7 @@ impl<'a> BoundSema<'a> {
     }
 
     /// The request-local [`BodySema`] whose declaration maps this bind
-    /// populated — the exact reference [`super::body_endpoint::EpochFacts`]
-    /// wraps. Test-only: the pool-arc twin-parity tests
+    /// populated. Test-only: the pool-arc twin-parity tests
     /// (`body_identity.rs`) read the epoch's populated `FunctionInfo` /
     /// `MethodInfo` / RIR-index answers through this handle to compare against
     /// the provider-side pool + RIR index.
@@ -2314,14 +2307,13 @@ impl<'a> BoundSema<'a> {
     /// index-independent render / metadata (via [`Self::with_type_pool`]), never
     /// the raw id.
     pub fn epoch_nominal_type(&self, file: FileId, name: Spur) -> Option<crate::types::Type> {
-        use super::body_endpoint::BodyEndpointProvider;
         let facts = self.sema.endpoint_facts();
         facts
-            .struct_by_file_name(file, name)
+            .endpoint_struct_by_file_name(file, name)
             .map(crate::types::Type::new_struct)
             .or_else(|| {
                 facts
-                    .enum_by_file_name(file, name)
+                    .endpoint_enum_by_file_name(file, name)
                     .map(crate::types::Type::new_enum)
             })
     }
@@ -2338,7 +2330,7 @@ impl<'a> BoundSema<'a> {
             .values()
             .find(|endpoint| endpoint.file == file.index())?;
         let facts = self.sema.endpoint_facts();
-        resolve_instance_type(&facts, &crate::TypeInstanceKey::Module(endpoint.token)).ok()
+        resolve_instance_type(facts, &crate::TypeInstanceKey::Module(endpoint.token)).ok()
     }
 
     /// Recover the current request file for an epoch module type. This is the
@@ -2375,10 +2367,9 @@ impl<'a> BoundSema<'a> {
     /// caller compares its index-independent render / metadata via
     /// [`Self::with_type_pool`], never the raw id.
     pub fn epoch_generated_struct_type(&self, name: Spur) -> Option<crate::types::Type> {
-        use super::body_endpoint::BodyEndpointProvider;
         let facts = self.sema.endpoint_facts();
         facts
-            .generated_struct(name)
+            .endpoint_generated_struct(name)
             .map(crate::types::Type::new_struct)
     }
 
@@ -2493,10 +2484,9 @@ impl<'a> BoundSema<'a> {
         type_name: Spur,
         method: Spur,
     ) -> Option<super::info::MethodInfo> {
-        use super::body_endpoint::BodyEndpointProvider;
         let facts = self.sema.endpoint_facts();
-        let struct_id = facts.struct_by_file_name(file, type_name)?;
-        facts.method_info(struct_id, method)
+        let struct_id = facts.endpoint_struct_by_file_name(file, type_name)?;
+        facts.endpoint_method_info(struct_id, method)
     }
 
     /// Return the canonical
@@ -2513,7 +2503,7 @@ impl<'a> BoundSema<'a> {
     ) -> crate::ProviderModuleMember {
         use super::aggregate_resolution::{ModuleTypeMember, select_module_type_member};
         let facts = self.sema.aggregate_facts();
-        match select_module_type_member(&facts, file, name) {
+        match select_module_type_member(facts, file, name) {
             ModuleTypeMember::Struct(id) => {
                 crate::ProviderModuleMember::Struct(crate::types::Type::new_struct(id))
             }
@@ -2531,7 +2521,7 @@ impl<'a> BoundSema<'a> {
     pub fn epoch_qualified_type(&self, file: FileId, name: Spur) -> crate::ProviderQualifiedType {
         use super::aggregate_resolution::{QualifiedType, select_qualified_type};
         let facts = self.sema.aggregate_facts();
-        match select_qualified_type(&facts, file, name) {
+        match select_qualified_type(facts, file, name) {
             QualifiedType::Enum(id) => {
                 crate::ProviderQualifiedType::Enum(crate::types::Type::new_enum(id))
             }
@@ -2548,7 +2538,7 @@ impl<'a> BoundSema<'a> {
     pub fn epoch_struct_literal_head(&self, file: FileId, name: Spur) -> crate::ProviderStructHead {
         use super::aggregate_resolution::{StructLiteralHead, select_struct_literal_head};
         let facts = self.sema.aggregate_facts();
-        match select_struct_literal_head(&facts, None, file, name) {
+        match select_struct_literal_head(facts, None, file, name) {
             StructLiteralHead::Bound(ty) => crate::ProviderStructHead::Bound(ty),
             StructLiteralHead::Named(id) => {
                 crate::ProviderStructHead::Named(crate::types::Type::new_struct(id))
@@ -2570,7 +2560,7 @@ impl<'a> BoundSema<'a> {
     ) -> bool {
         use super::aggregate_resolution::is_accessible;
         let facts = self.sema.aggregate_facts();
-        is_accessible(&facts, accessing_file, defining_file, is_public)
+        is_accessible(facts, accessing_file, defining_file, is_public)
     }
 
     /// Return the canonical physical file path for `file`, so parity checks
@@ -3128,7 +3118,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
             TypeKind::Struct(id) => {
                 let def = self.type_pool.struct_def(id);
                 if let Some(element) = self.slice_element_type(ty)
-                    && def.name.starts_with('[')
+                    && crate::types::is_slice_struct_name(&def.name)
                 {
                     Ok(SemanticExportType::Slice {
                         element: Box::new(self.export_type(element, stack)?),

--- a/crates/rue-air/src/sema/body_endpoint.rs
+++ b/crates/rue-air/src/sema/body_endpoint.rs
@@ -5,12 +5,11 @@
 //! the same fact vocabulary for its non-body responsibilities.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::hash::Hash;
 use std::sync::Arc;
 
 use ahash::AHashMap;
-use lasso::{Spur, ThreadedRodeo};
+use lasso::Spur;
 use rue_rir::InstRef;
 use rue_span::FileId;
 
@@ -35,253 +34,136 @@ use crate::{
 pub(crate) trait BodyEndpointProvider {
     /// Intern a source name to its symbol, or `None` if never interned. Mirrors
     /// `interner.get`.
-    fn name_symbol(&self, name: &str) -> Option<Spur>;
+    fn endpoint_name_symbol(&self, name: &str) -> Option<Spur>;
 
     /// The current stable endpoint for a definition token.
-    fn definition_endpoint(
+    fn endpoint_definition_endpoint(
         &self,
         token: SemanticDefinitionToken,
     ) -> Option<SemanticDefinitionEndpoint>;
 
     /// The current stable endpoint for a module token.
-    fn module_endpoint(&self, token: SemanticModuleToken) -> Option<SemanticModuleEndpoint>;
-
-    /// The internal free-function symbol declared as `(file, name)`.
-    fn function_by_file_name(&self, file: FileId, name: Spur) -> Option<Spur>;
-
-    /// The struct id declared as `(file, name)`.
-    fn struct_by_file_name(&self, file: FileId, name: Spur) -> Option<StructId>;
-
-    /// The enum id declared as `(file, name)`.
-    fn enum_by_file_name(&self, file: FileId, name: Spur) -> Option<EnumId>;
-
-    /// The built-in or compiler-generated struct id for a bare name, preferring
-    /// the built-in table. Mirrors `builtin_structs.or_else(generated_structs)`.
-    fn builtin_or_generated_struct(&self, name: Spur) -> Option<StructId>;
-
-    /// The compiler-generated struct id for a bare name.
-    fn generated_struct(&self, name: Spur) -> Option<StructId>;
-
-    /// The built-in enum id for a bare name.
-    fn builtin_enum(&self, name: Spur) -> Option<EnumId>;
-
-    /// The struct id for an issued anonymous nominal identity.
-    fn anon_struct(&self, identity: &IssuedAnonymousNominalKey) -> Option<StructId>;
-
-    /// The enum id for an issued anonymous nominal identity.
-    fn anon_enum(&self, identity: &IssuedAnonymousNominalKey) -> Option<EnumId>;
-
-    /// The signature/binding info for an internal free-function symbol.
-    fn function_info(&self, name: Spur) -> Option<FunctionInfo>;
-
-    /// The signature/binding info for a `(struct, name)` member.
-    fn method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo>;
-
-    /// The source name a specialized/internal function name derives from.
-    /// Mirrors `Sema::source_function_name` (identity when unmapped).
-    fn source_function_name(&self, name: Spur) -> Spur;
-
-    /// The module id whose definition lives in `file`.
-    fn module_id_for_file(&self, file: u32) -> Option<ModuleId>;
-
-    /// Intern an array type, or `None` on a type-validation failure.
-    fn intern_array(&self, element: Type, len: u64) -> Option<Type>;
-
-    /// Intern a `ptr const` type, or `None` on a type-validation failure.
-    fn intern_ptr_const(&self, pointee: Type) -> Option<Type>;
-
-    /// Intern a `ptr mut` type, or `None` on a type-validation failure.
-    fn intern_ptr_mut(&self, pointee: Type) -> Option<Type>;
-}
-
-/// Endpoint reads supplied by a body-analysis host. Most operations are
-/// immutable table reads. Type interning is host-specific and is not part of
-/// the shared read view.
-pub(super) trait BodyEndpointFactSource {
-    fn endpoint_read_view(&self) -> Option<BodyEndpointReadView<'_>> {
-        None
-    }
-
-    fn endpoint_view(&self) -> BodyEndpointReadView<'_> {
-        self.endpoint_read_view()
-            .expect("body endpoint fact source has no shared read view")
-    }
-
-    fn endpoint_name_symbol(&self, name: &str) -> Option<Spur> {
-        self.endpoint_view().name_symbol(name)
-    }
-    fn endpoint_definition_endpoint(
-        &self,
-        token: SemanticDefinitionToken,
-    ) -> Option<SemanticDefinitionEndpoint> {
-        self.endpoint_view().definition_endpoint(token)
-    }
     fn endpoint_module_endpoint(
         &self,
         token: SemanticModuleToken,
-    ) -> Option<SemanticModuleEndpoint> {
-        self.endpoint_view().module_endpoint(token)
-    }
-    fn endpoint_function_by_file_name(&self, file: FileId, name: Spur) -> Option<Spur> {
-        self.endpoint_view().function_by_file_name(file, name)
-    }
-    fn endpoint_struct_by_file_name(&self, file: FileId, name: Spur) -> Option<StructId> {
-        self.endpoint_view().struct_by_file_name(file, name)
-    }
-    fn endpoint_enum_by_file_name(&self, file: FileId, name: Spur) -> Option<EnumId> {
-        self.endpoint_view().enum_by_file_name(file, name)
-    }
-    fn endpoint_builtin_or_generated_struct(&self, name: Spur) -> Option<StructId> {
-        self.endpoint_view().builtin_or_generated_struct(name)
-    }
-    fn endpoint_generated_struct(&self, name: Spur) -> Option<StructId> {
-        self.endpoint_view().generated_struct(name)
-    }
-    fn endpoint_builtin_enum(&self, name: Spur) -> Option<EnumId> {
-        self.endpoint_view().builtin_enum(name)
-    }
-    fn endpoint_anon_struct(&self, identity: &IssuedAnonymousNominalKey) -> Option<StructId> {
-        self.endpoint_view().anon_struct(identity)
-    }
-    fn endpoint_anon_enum(&self, identity: &IssuedAnonymousNominalKey) -> Option<EnumId> {
-        self.endpoint_view().anon_enum(identity)
-    }
-    fn endpoint_function_info(&self, name: Spur) -> Option<FunctionInfo> {
-        self.endpoint_view().function_info(name)
-    }
-    fn endpoint_method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo> {
-        self.endpoint_view().method_info(struct_id, name)
-    }
-    fn endpoint_source_function_name(&self, name: Spur) -> Spur {
-        self.endpoint_view().source_function_name(name)
-    }
-    fn endpoint_module_id_for_file(&self, file: u32) -> Option<ModuleId> {
-        self.endpoint_view().module_id_for_file(file)
-    }
-    fn endpoint_intern_array(&self, _element: Type, _len: u64) -> Option<Type> {
-        None
-    }
-    fn endpoint_intern_ptr_const(&self, _pointee: Type) -> Option<Type> {
-        None
-    }
-    fn endpoint_intern_ptr_mut(&self, _pointee: Type) -> Option<Type> {
-        None
-    }
+    ) -> Option<SemanticModuleEndpoint>;
+
+    /// The internal free-function symbol declared as `(file, name)`.
+    fn endpoint_function_by_file_name(&self, file: FileId, name: Spur) -> Option<Spur>;
+
+    /// The struct id declared as `(file, name)`.
+    fn endpoint_struct_by_file_name(&self, file: FileId, name: Spur) -> Option<StructId>;
+
+    /// The enum id declared as `(file, name)`.
+    fn endpoint_enum_by_file_name(&self, file: FileId, name: Spur) -> Option<EnumId>;
+
+    /// The built-in or compiler-generated struct id for a bare name, preferring
+    /// the built-in table. Mirrors `builtin_structs.or_else(generated_structs)`.
+    fn endpoint_builtin_or_generated_struct(&self, name: Spur) -> Option<StructId>;
+
+    /// The compiler-generated struct id for a bare name.
+    fn endpoint_generated_struct(&self, name: Spur) -> Option<StructId>;
+
+    /// The built-in enum id for a bare name.
+    fn endpoint_builtin_enum(&self, name: Spur) -> Option<EnumId>;
+
+    /// The struct id for an issued anonymous nominal identity.
+    fn endpoint_anon_struct(&self, identity: &IssuedAnonymousNominalKey) -> Option<StructId>;
+
+    /// The enum id for an issued anonymous nominal identity.
+    fn endpoint_anon_enum(&self, identity: &IssuedAnonymousNominalKey) -> Option<EnumId>;
+
+    /// The signature/binding info for an internal free-function symbol.
+    fn endpoint_function_info(&self, name: Spur) -> Option<FunctionInfo>;
+
+    /// The signature/binding info for a `(struct, name)` member.
+    fn endpoint_method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo>;
+
+    /// The source name a specialized/internal function name derives from.
+    /// Mirrors `Sema::source_function_name` (identity when unmapped).
+    fn endpoint_source_function_name(&self, name: Spur) -> Spur;
+
+    /// The module id whose definition lives in `file`.
+    fn endpoint_module_id_for_file(&self, file: u32) -> Option<ModuleId>;
+
+    /// Intern an array type, or `None` on a type-validation failure.
+    fn endpoint_intern_array(&self, element: Type, len: u64) -> Option<Type>;
+
+    /// Intern a `ptr const` type, or `None` on a type-validation failure.
+    fn endpoint_intern_ptr_const(&self, pointee: Type) -> Option<Type>;
+
+    /// Intern a `ptr mut` type, or `None` on a type-validation failure.
+    fn endpoint_intern_ptr_mut(&self, pointee: Type) -> Option<Type>;
 }
 
-/// Shared read view for declaration-owned endpoint facts.
-pub(super) struct BodyEndpointReadView<'a> {
-    interner: &'a ThreadedRodeo,
-    declarations: &'a super::DeclarationNamespace,
-    stable_definition_endpoints: &'a HashMap<SemanticDefinitionToken, SemanticDefinitionEndpoint>,
-    stable_module_endpoints: &'a HashMap<SemanticModuleToken, SemanticModuleEndpoint>,
-    anonymous_methods: &'a HashMap<(StructId, Spur), MethodInfo>,
-    generated_structs: &'a HashMap<Spur, StructId>,
-    anon_struct_identities: &'a HashMap<IssuedAnonymousNominalKey, StructId>,
-    anon_enum_identities: &'a HashMap<IssuedAnonymousNominalKey, EnumId>,
-    module_registry: &'a crate::module_registry::ModuleRegistry,
-}
-
-impl BodyEndpointReadView<'_> {
-    fn name_symbol(&self, name: &str) -> Option<Spur> {
+impl<D: DeclarationPhase> BodyEndpointProvider for Sema<'_, D> {
+    fn endpoint_name_symbol(&self, name: &str) -> Option<Spur> {
         self.interner.get(name)
     }
 
-    fn definition_endpoint(
+    fn endpoint_definition_endpoint(
         &self,
         token: SemanticDefinitionToken,
     ) -> Option<SemanticDefinitionEndpoint> {
         self.stable_definition_endpoints.get(&token).cloned()
     }
 
-    fn module_endpoint(&self, token: SemanticModuleToken) -> Option<SemanticModuleEndpoint> {
-        self.stable_module_endpoints.get(&token).copied()
+    fn endpoint_module_endpoint(
+        &self,
+        token: SemanticModuleToken,
+    ) -> Option<SemanticModuleEndpoint> {
+        self.stable_module_endpoints.get(&token).cloned()
     }
 
-    fn function_by_file_name(&self, file: FileId, name: Spur) -> Option<Spur> {
-        self.declarations
-            .functions_by_file_name
-            .get(&(file, name))
-            .copied()
+    fn endpoint_function_by_file_name(&self, file: FileId, name: Spur) -> Option<Spur> {
+        self.functions_by_file_name.get(&(file, name)).copied()
     }
 
-    fn struct_by_file_name(&self, file: FileId, name: Spur) -> Option<StructId> {
-        self.declarations
-            .structs_by_file_name
-            .get(&(file, name))
-            .copied()
+    fn endpoint_struct_by_file_name(&self, file: FileId, name: Spur) -> Option<StructId> {
+        self.structs_by_file_name.get(&(file, name)).copied()
     }
 
-    fn enum_by_file_name(&self, file: FileId, name: Spur) -> Option<EnumId> {
-        self.declarations
-            .enums_by_file_name
-            .get(&(file, name))
-            .copied()
+    fn endpoint_enum_by_file_name(&self, file: FileId, name: Spur) -> Option<EnumId> {
+        self.enums_by_file_name.get(&(file, name)).copied()
     }
 
-    fn builtin_or_generated_struct(&self, name: Spur) -> Option<StructId> {
-        self.declarations
-            .builtin_structs
-            .get(&name)
-            .or_else(|| self.generated_structs.get(&name))
-            .copied()
+    fn endpoint_builtin_or_generated_struct(&self, name: Spur) -> Option<StructId> {
+        self.resolve_builtin_struct_name(name)
+            .or_else(|| self.generated_structs.get(&name).copied())
     }
 
-    fn generated_struct(&self, name: Spur) -> Option<StructId> {
+    fn endpoint_generated_struct(&self, name: Spur) -> Option<StructId> {
         self.generated_structs.get(&name).copied()
     }
 
-    fn builtin_enum(&self, name: Spur) -> Option<EnumId> {
-        self.declarations.builtin_enums.get(&name).copied()
+    fn endpoint_builtin_enum(&self, name: Spur) -> Option<EnumId> {
+        self.resolve_builtin_enum_name(name)
     }
 
-    fn anon_struct(&self, identity: &IssuedAnonymousNominalKey) -> Option<StructId> {
+    fn endpoint_anon_struct(&self, identity: &IssuedAnonymousNominalKey) -> Option<StructId> {
         self.anon_struct_identities.get(identity).copied()
     }
 
-    fn anon_enum(&self, identity: &IssuedAnonymousNominalKey) -> Option<EnumId> {
+    fn endpoint_anon_enum(&self, identity: &IssuedAnonymousNominalKey) -> Option<EnumId> {
         self.anon_enum_identities.get(identity).copied()
     }
 
-    fn function_info(&self, name: Spur) -> Option<FunctionInfo> {
-        self.declarations.functions.get(&name).copied()
+    fn endpoint_function_info(&self, name: Spur) -> Option<FunctionInfo> {
+        self.functions.get(&name).copied()
     }
 
-    fn method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo> {
-        self.anonymous_methods
-            .get(&(struct_id, name))
-            .copied()
-            .or_else(|| self.declarations.methods.get(&(struct_id, name)).copied())
+    fn endpoint_method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo> {
+        self.method_info((struct_id, name)).copied()
     }
 
-    fn source_function_name(&self, name: Spur) -> Spur {
-        self.declarations
-            .function_source_names
-            .get(&name)
-            .copied()
-            .unwrap_or(name)
+    fn endpoint_source_function_name(&self, name: Spur) -> Spur {
+        Sema::source_function_name(self, name)
     }
 
-    fn module_id_for_file(&self, file: u32) -> Option<ModuleId> {
+    fn endpoint_module_id_for_file(&self, file: u32) -> Option<ModuleId> {
         (0..self.module_registry.len())
             .map(|index| ModuleId::new(index as u32))
             .find(|id| self.module_registry.get_def(*id).file_id.index() == file)
-    }
-}
-
-impl<D: DeclarationPhase> BodyEndpointFactSource for Sema<'_, D> {
-    fn endpoint_read_view(&self) -> Option<BodyEndpointReadView<'_>> {
-        Some(BodyEndpointReadView {
-            interner: self.interner,
-            declarations: &self.declarations,
-            stable_definition_endpoints: &self.stable_definition_endpoints,
-            stable_module_endpoints: &self.stable_module_endpoints,
-            anonymous_methods: &self.anonymous_methods,
-            generated_structs: &self.generated_structs,
-            anon_struct_identities: &self.anon_struct_identities,
-            anon_enum_identities: &self.anon_enum_identities,
-            module_registry: &self.module_registry,
-        })
     }
 
     fn endpoint_intern_array(&self, element: Type, len: u64) -> Option<Type> {
@@ -297,80 +179,6 @@ impl<D: DeclarationPhase> BodyEndpointFactSource for Sema<'_, D> {
     }
 }
 
-/// Read-only endpoint adapter used by the canonical body engine.
-///
-/// It carries only a host capability; the current epoch-backed host is one
-/// production source, while an owned body state can supply the same reads next.
-pub(crate) struct EpochFacts<'host, H: BodyEndpointFactSource> {
-    host: &'host H,
-}
-
-impl<'host, H: BodyEndpointFactSource> EpochFacts<'host, H> {
-    pub(in crate::sema) fn new(host: &'host H) -> Self {
-        Self { host }
-    }
-}
-
-impl<H: BodyEndpointFactSource> BodyEndpointProvider for EpochFacts<'_, H> {
-    fn name_symbol(&self, name: &str) -> Option<Spur> {
-        self.host.endpoint_name_symbol(name)
-    }
-    fn definition_endpoint(
-        &self,
-        token: SemanticDefinitionToken,
-    ) -> Option<SemanticDefinitionEndpoint> {
-        self.host.endpoint_definition_endpoint(token)
-    }
-    fn module_endpoint(&self, token: SemanticModuleToken) -> Option<SemanticModuleEndpoint> {
-        self.host.endpoint_module_endpoint(token)
-    }
-    fn function_by_file_name(&self, file: FileId, name: Spur) -> Option<Spur> {
-        self.host.endpoint_function_by_file_name(file, name)
-    }
-    fn struct_by_file_name(&self, file: FileId, name: Spur) -> Option<StructId> {
-        self.host.endpoint_struct_by_file_name(file, name)
-    }
-    fn enum_by_file_name(&self, file: FileId, name: Spur) -> Option<EnumId> {
-        self.host.endpoint_enum_by_file_name(file, name)
-    }
-    fn builtin_or_generated_struct(&self, name: Spur) -> Option<StructId> {
-        self.host.endpoint_builtin_or_generated_struct(name)
-    }
-    fn generated_struct(&self, name: Spur) -> Option<StructId> {
-        self.host.endpoint_generated_struct(name)
-    }
-    fn builtin_enum(&self, name: Spur) -> Option<EnumId> {
-        self.host.endpoint_builtin_enum(name)
-    }
-    fn anon_struct(&self, identity: &IssuedAnonymousNominalKey) -> Option<StructId> {
-        self.host.endpoint_anon_struct(identity)
-    }
-    fn anon_enum(&self, identity: &IssuedAnonymousNominalKey) -> Option<EnumId> {
-        self.host.endpoint_anon_enum(identity)
-    }
-    fn function_info(&self, name: Spur) -> Option<FunctionInfo> {
-        self.host.endpoint_function_info(name)
-    }
-    fn method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo> {
-        self.host.endpoint_method_info(struct_id, name)
-    }
-    fn source_function_name(&self, name: Spur) -> Spur {
-        self.host.endpoint_source_function_name(name)
-    }
-    fn module_id_for_file(&self, file: u32) -> Option<ModuleId> {
-        self.host.endpoint_module_id_for_file(file)
-    }
-    fn intern_array(&self, element: Type, len: u64) -> Option<Type> {
-        self.host.endpoint_intern_array(element, len)
-    }
-    fn intern_ptr_const(&self, pointee: Type) -> Option<Type> {
-        self.host.endpoint_intern_ptr_const(pointee)
-    }
-    fn intern_ptr_mut(&self, pointee: Type) -> Option<Type> {
-        self.host.endpoint_intern_ptr_mut(pointee)
-    }
-}
-
 /// Resolve a definition-token function reference to its internal free-function
 /// symbol. The endpoint, name interning, and by-file lookup all fail to the
 /// same `MissingStableIdentity` in the caller, so a single `None` is faithful.
@@ -378,9 +186,9 @@ pub(in crate::sema) fn resolve_free_function_symbol<P: BodyEndpointProvider>(
     facts: &P,
     token: SemanticDefinitionToken,
 ) -> Option<Spur> {
-    let endpoint = facts.definition_endpoint(token)?;
-    let symbol = facts.name_symbol(endpoint.name.as_ref())?;
-    facts.function_by_file_name(FileId::new(endpoint.file), symbol)
+    let endpoint = facts.endpoint_definition_endpoint(token)?;
+    let symbol = facts.endpoint_name_symbol(endpoint.name.as_ref())?;
+    facts.endpoint_function_by_file_name(FileId::new(endpoint.file), symbol)
 }
 
 /// Materialize a canonical type-instance key into a concrete [`Type`]. The
@@ -407,67 +215,85 @@ pub(in crate::sema) fn resolve_instance_type<P: BodyEndpointProvider>(
         T::Never => Type::NEVER,
         T::ComptimeType => Type::COMPTIME_TYPE,
         T::BuiltinNominal { kind, name } => {
-            let symbol = facts.name_symbol(name.as_ref()).ok_or_else(missing)?;
+            let symbol = facts
+                .endpoint_name_symbol(name.as_ref())
+                .ok_or_else(missing)?;
             match kind {
                 AK::Struct => Type::new_struct(
                     facts
-                        .builtin_or_generated_struct(symbol)
+                        .endpoint_builtin_or_generated_struct(symbol)
                         .ok_or_else(missing)?,
                 ),
-                AK::Enum => Type::new_enum(facts.builtin_enum(symbol).ok_or_else(missing)?),
+                AK::Enum => {
+                    Type::new_enum(facts.endpoint_builtin_enum(symbol).ok_or_else(missing)?)
+                }
             }
         }
         T::Nominal(N::Builtin { kind, name }) => {
-            let symbol = facts.name_symbol(name.as_ref()).ok_or_else(missing)?;
+            let symbol = facts
+                .endpoint_name_symbol(name.as_ref())
+                .ok_or_else(missing)?;
             match kind {
                 AK::Struct => Type::new_struct(
                     facts
-                        .builtin_or_generated_struct(symbol)
+                        .endpoint_builtin_or_generated_struct(symbol)
                         .ok_or_else(missing)?,
                 ),
-                AK::Enum => Type::new_enum(facts.builtin_enum(symbol).ok_or_else(missing)?),
+                AK::Enum => {
+                    Type::new_enum(facts.endpoint_builtin_enum(symbol).ok_or_else(missing)?)
+                }
             }
         }
         T::Nominal(N::Named(token)) => {
-            let endpoint = facts.definition_endpoint(*token).ok_or_else(missing)?;
+            let endpoint = facts
+                .endpoint_definition_endpoint(*token)
+                .ok_or_else(missing)?;
             let symbol = facts
-                .name_symbol(endpoint.name.as_ref())
+                .endpoint_name_symbol(endpoint.name.as_ref())
                 .ok_or_else(missing)?;
             match endpoint.kind {
                 StableDefinitionKind::Struct => Type::new_struct(
                     facts
-                        .struct_by_file_name(FileId::new(endpoint.file), symbol)
+                        .endpoint_struct_by_file_name(FileId::new(endpoint.file), symbol)
                         .ok_or_else(missing)?,
                 ),
                 StableDefinitionKind::Enum => Type::new_enum(
                     facts
-                        .enum_by_file_name(FileId::new(endpoint.file), symbol)
+                        .endpoint_enum_by_file_name(FileId::new(endpoint.file), symbol)
                         .ok_or_else(missing)?,
                 ),
                 _ => return Err(missing()),
             }
         }
         T::Nominal(N::Anonymous(identity)) => match identity.kind {
-            AK::Struct => Type::new_struct(facts.anon_struct(identity).ok_or_else(missing)?),
-            AK::Enum => Type::new_enum(facts.anon_enum(identity).ok_or_else(missing)?),
+            AK::Struct => {
+                Type::new_struct(facts.endpoint_anon_struct(identity).ok_or_else(missing)?)
+            }
+            AK::Enum => Type::new_enum(facts.endpoint_anon_enum(identity).ok_or_else(missing)?),
         },
         T::Array { element, len } => facts
-            .intern_array(resolve_instance_type(facts, element)?, *len)
+            .endpoint_intern_array(resolve_instance_type(facts, element)?, *len)
             .ok_or_else(missing)?,
         T::Slice { name, .. } => {
-            let symbol = facts.name_symbol(name.as_ref()).ok_or_else(missing)?;
-            Type::new_struct(facts.generated_struct(symbol).ok_or_else(missing)?)
+            let symbol = facts
+                .endpoint_name_symbol(name.as_ref())
+                .ok_or_else(missing)?;
+            Type::new_struct(
+                facts
+                    .endpoint_generated_struct(symbol)
+                    .ok_or_else(missing)?,
+            )
         }
         T::PtrConst(value) => facts
-            .intern_ptr_const(resolve_instance_type(facts, value)?)
+            .endpoint_intern_ptr_const(resolve_instance_type(facts, value)?)
             .ok_or_else(missing)?,
         T::PtrMut(value) => facts
-            .intern_ptr_mut(resolve_instance_type(facts, value)?)
+            .endpoint_intern_ptr_mut(resolve_instance_type(facts, value)?)
             .ok_or_else(missing)?,
         T::Module(token) => {
-            let endpoint = facts.module_endpoint(*token).ok_or_else(missing)?;
+            let endpoint = facts.endpoint_module_endpoint(*token).ok_or_else(missing)?;
             let id = facts
-                .module_id_for_file(endpoint.file)
+                .endpoint_module_id_for_file(endpoint.file)
                 .ok_or_else(missing)?;
             Type::new_module(id)
         }
@@ -556,9 +382,9 @@ impl<K> Default for EndpointOverlay<K> {
     }
 }
 
-/// The endpoint-resolution ProviderFacts driver: answers the family-1A endpoint
-/// ops from a body identity pool + RIR index + [`BodyFactProvider`], instead of
-/// the epoch `Sema` tables [`EpochFacts`] reads.
+/// Query-backed endpoint fact state. It owns the body identity pool, RIR index,
+/// provider, and request-local overlay; the epoch host reads its own tables
+/// directly.
 ///
 /// Generic over the provider `P`, the pool durable source `S`, and the pool's
 /// durable nominal key `K` and module `M` (rue-compiler binds
@@ -595,7 +421,7 @@ where
         Self::with_identity(provider, identity, rir)
     }
 
-    /// Construct the endpoint facade from the one task-local provider
+    /// Construct the endpoint fact state from the one task-local provider
     /// authority shared with calls, aggregates, and body analysis.
     pub fn with_state(
         provider: &'a P,
@@ -648,7 +474,7 @@ where
     }
 
     /// Register one anonymous method atomically under both lookup preimages in
-    /// the identity context shared with the call facade.
+    /// the identity context shared with call-resolution fact state.
     pub fn register_anonymous_method(
         &self,
         file: FileId,
@@ -974,7 +800,7 @@ where
 
     /// (R) The first free-function RIR declaration for `(source_name, file)`,
     /// answered by [`BodyRirIndex`] over the request-local `Rir` — the exact `InstRef`
-    /// [`EpochFacts::first_free_function`] returns, keyed provider-naturally by
+    /// the epoch host returns, keyed provider-naturally by
     /// the source name string.
     pub fn first_free_function(&self, source_name: &str, file: FileId) -> Option<InstRef> {
         let symbol = self.rir.rir_interner().get(source_name)?;
@@ -999,7 +825,7 @@ where
     }
 
     /// (R) The destructor RIR declaration handle for `(file, type_name)`, the
-    /// exact scan [`EpochFacts::destructor`] performs, answered by
+    /// exact scan the epoch host performs, answered by
     /// [`BodyRirIndex`]. Returns the located declaration `InstRef` (the private
     /// destructor record's public handle); the epoch keys the same record by the
     /// same `(file, type_name)` scan.
@@ -1146,11 +972,11 @@ where
     K: Clone + Eq + Hash,
     M: Clone + Eq + Hash,
 {
-    fn name_symbol(&self, name: &str) -> Option<Spur> {
+    fn endpoint_name_symbol(&self, name: &str) -> Option<Spur> {
         Some(self.identity.pool().intern_name(name))
     }
 
-    fn definition_endpoint(
+    fn endpoint_definition_endpoint(
         &self,
         token: SemanticDefinitionToken,
     ) -> Option<SemanticDefinitionEndpoint> {
@@ -1165,11 +991,14 @@ where
         })
     }
 
-    fn module_endpoint(&self, token: SemanticModuleToken) -> Option<SemanticModuleEndpoint> {
+    fn endpoint_module_endpoint(
+        &self,
+        token: SemanticModuleToken,
+    ) -> Option<SemanticModuleEndpoint> {
         self.overlay.borrow().module_tokens.get(&token).copied()
     }
 
-    fn function_by_file_name(&self, file: FileId, name: Spur) -> Option<Spur> {
+    fn endpoint_function_by_file_name(&self, file: FileId, name: Spur) -> Option<Spur> {
         self.overlay
             .borrow()
             .functions_by_file_name
@@ -1177,7 +1006,7 @@ where
             .map(|(symbol, _)| *symbol)
     }
 
-    fn struct_by_file_name(&self, file: FileId, name: Spur) -> Option<StructId> {
+    fn endpoint_struct_by_file_name(&self, file: FileId, name: Spur) -> Option<StructId> {
         let key = self
             .overlay
             .borrow()
@@ -1191,7 +1020,7 @@ where
             .as_struct()
     }
 
-    fn enum_by_file_name(&self, file: FileId, name: Spur) -> Option<EnumId> {
+    fn endpoint_enum_by_file_name(&self, file: FileId, name: Spur) -> Option<EnumId> {
         let key = self
             .overlay
             .borrow()
@@ -1205,7 +1034,7 @@ where
             .as_enum()
     }
 
-    fn builtin_or_generated_struct(&self, name: Spur) -> Option<StructId> {
+    fn endpoint_builtin_or_generated_struct(&self, name: Spur) -> Option<StructId> {
         let owned = self.identity.pool().resolve_symbol(name).to_owned();
         self.identity
             .pool_mut()?
@@ -1217,10 +1046,10 @@ where
             .and_then(|ty| ty.as_struct())
             // Mirror the epoch's `builtin_structs.or_else(generated_structs)`:
             // a generated slice struct answers here too (RUE-1091 r6a).
-            .or_else(|| self.generated_struct(name))
+            .or_else(|| self.endpoint_generated_struct(name))
     }
 
-    fn generated_struct(&self, name: Spur) -> Option<StructId> {
+    fn endpoint_generated_struct(&self, name: Spur) -> Option<StructId> {
         // The generated slice-struct name, minted and recorded by
         // `register_generated_slice` (RUE-1091 r6a — builtin / slice name
         // facts). A name never seeded fails closed, exactly as the epoch's
@@ -1228,7 +1057,7 @@ where
         self.overlay.borrow().generated_slices.get(&name).copied()
     }
 
-    fn builtin_enum(&self, name: Spur) -> Option<EnumId> {
+    fn endpoint_builtin_enum(&self, name: Spur) -> Option<EnumId> {
         let name = self.identity.pool().resolve_symbol(name).to_owned();
         self.identity
             .pool_mut()?
@@ -1240,7 +1069,7 @@ where
             .as_enum()
     }
 
-    fn anon_struct(&self, identity: &IssuedAnonymousNominalKey) -> Option<StructId> {
+    fn endpoint_anon_struct(&self, identity: &IssuedAnonymousNominalKey) -> Option<StructId> {
         // RUE-1091 r6b: mint the anonymous struct through the pool for a durable
         // key seeded by `register_anonymous_nominal`. An unseeded issued key fails
         // closed (the pool never invents an identity), mirroring the epoch's
@@ -1253,7 +1082,7 @@ where
             .as_struct()
     }
 
-    fn anon_enum(&self, identity: &IssuedAnonymousNominalKey) -> Option<EnumId> {
+    fn endpoint_anon_enum(&self, identity: &IssuedAnonymousNominalKey) -> Option<EnumId> {
         let durable = self.anon_by_issued.borrow().get(identity).cloned()?;
         self.identity
             .pool_mut()?
@@ -1262,7 +1091,7 @@ where
             .as_enum()
     }
 
-    fn function_info(&self, name: Spur) -> Option<FunctionInfo> {
+    fn endpoint_function_info(&self, name: Spur) -> Option<FunctionInfo> {
         let key = self.overlay.borrow().function_keys.get(&name).cloned()?;
         let file = self
             .overlay
@@ -1327,23 +1156,23 @@ where
             .ok()
     }
 
-    fn method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo> {
+    fn endpoint_method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo> {
         // The shared registry preserves Sema's anonymous-before-named order.
         // Named entries are installed from the exact call fact before analysis
         // consumes the endpoint view; both facades then observe one authority.
         self.method_info(struct_id, name)
     }
 
-    fn source_function_name(&self, name: Spur) -> Spur {
+    fn endpoint_source_function_name(&self, name: Spur) -> Spur {
         // Identity: the specialization name map is r5.
         name
     }
 
-    fn module_id_for_file(&self, file: u32) -> Option<ModuleId> {
+    fn endpoint_module_id_for_file(&self, file: u32) -> Option<ModuleId> {
         self.identity.modules().id_for_file(FileId::new(file))
     }
 
-    fn intern_array(&self, element: Type, len: u64) -> Option<Type> {
+    fn endpoint_intern_array(&self, element: Type, len: u64) -> Option<Type> {
         self.identity
             .pool()
             .type_pool()
@@ -1351,7 +1180,7 @@ where
             .ok()
     }
 
-    fn intern_ptr_const(&self, pointee: Type) -> Option<Type> {
+    fn endpoint_intern_ptr_const(&self, pointee: Type) -> Option<Type> {
         self.identity
             .pool()
             .type_pool()
@@ -1359,7 +1188,7 @@ where
             .ok()
     }
 
-    fn intern_ptr_mut(&self, pointee: Type) -> Option<Type> {
+    fn endpoint_intern_ptr_mut(&self, pointee: Type) -> Option<Type> {
         self.identity
             .pool()
             .type_pool()

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -62,7 +62,7 @@
 //!   [`BodyIdentityPool::find_or_create_anon`] (r6b) mints the producer-nominal
 //!   anonymous struct / enum from its durable identity + shape, and
 //!   [`ProviderIdentityContext::register_anonymous_method`] supplies the
-//!   request-local dispatch entry shared by endpoint and call facades. The
+//!   request-local dispatch entry shared by endpoint and call fact state. The
 //!   method body itself remains a local RIR concern; an issued anonymous key
 //!   with no registered durable identity still resolves by lookup only
 //!   ([`BodyIdentityPool::register_issued_anonymous`]);
@@ -563,7 +563,7 @@ where
         }
     }
 
-    /// Return the interner authority shared by all provider facades in this
+    /// Return the interner authority shared by all provider fact state in this
     /// identity context.
     pub fn interner(&self) -> Rc<ThreadedRodeo> {
         Rc::clone(&self.pool.borrow().interner)
@@ -682,7 +682,7 @@ where
 
 /// The rue-air-owned type and parameter authority for one provider body.
 ///
-/// Provider fact facades clone the identity context from this state; they do
+/// Provider fact stores clone the identity context from this state; they do
 /// not create peer pools or interners. `finalize_containment_metadata` seals
 /// the exact prerequisite facts and rebases the authority onto append-only
 /// type/parameter overlays, so lazy body-local materialization remains valid.
@@ -1113,11 +1113,7 @@ where
             S::Never => Type::NEVER,
             S::ComptimeType => Type::COMPTIME_TYPE,
             S::BuiltinNominal { name, kind } => {
-                if let Some(capacity) = name
-                    .strip_prefix("Str(")
-                    .and_then(|name| name.strip_suffix(')'))
-                    .and_then(|capacity| capacity.parse::<u64>().ok())
-                {
+                if let Some(capacity) = crate::types::fixed_string_capacity(name) {
                     if *kind != SemanticImportNominalKind::Struct {
                         return Err(IdentityMintError::BuiltinNominalKindMismatch);
                     }
@@ -2752,8 +2748,8 @@ where
 /// [`RirDeclarationIndex`] is already body-independent — `RirDeclarationIndex::
 /// new(rir)` is built from the shared `Rir` alone, its `InstRef`s locate that
 /// arena, and it already answers `first_free_function` and `destructors`
-/// verbatim (they are the tables [`super::body_endpoint::EpochFacts`] delegates
-/// to). So this index **re-uses it wholesale** for those two ops rather than
+/// verbatim (they are the tables the epoch host consults directly). So this
+/// index **re-uses it wholesale** for those two ops rather than
 /// duplicating the arena walk.
 ///
 /// The one op the production index does not expose as a keyed point lookup is
@@ -2840,7 +2836,7 @@ impl BodyRirBundle {
         )
     }
 
-    /// The one interner authority for this body RIR and its provider facades.
+    /// The one interner authority for this body RIR and its provider fact state.
     pub fn shared_interner(&self) -> Rc<ThreadedRodeo> {
         Rc::clone(&self.rir_interner)
     }
@@ -2997,7 +2993,7 @@ impl BodyRirIndex {
     }
 
     /// The first free-function RIR declaration for `(source, file)`. The exact
-    /// answer [`super::body_endpoint::EpochFacts::first_free_function`] returns.
+    /// answer the epoch host's direct fact implementation returns.
     pub(in crate::sema) fn first_free_function(
         &self,
         source: Spur,
@@ -3009,7 +3005,7 @@ impl BodyRirIndex {
     /// The named-method RIR declaration for a named struct owner, keyed by the
     /// durable-available `(owner_file, owner_type_name, method_name)` preimage of
     /// the epoch's `(StructId, method_name)` key. Equal to
-    /// [`super::body_endpoint::EpochFacts::named_method_declaration`] under the
+    /// the epoch host's direct fact implementation under the
     /// `struct_by_file_name` bijection.
     pub(in crate::sema) fn named_method_declaration(
         &self,
@@ -3035,7 +3031,7 @@ impl BodyRirIndex {
     }
 
     /// The destructor declaration record for `(file, type_name)`. The exact
-    /// scan [`super::body_endpoint::EpochFacts::destructor`] performs.
+    /// scan the epoch host performs.
     pub(in crate::sema) fn destructor(
         &self,
         file: u32,
@@ -6053,7 +6049,7 @@ mod tests {
     // Twin-parity for the endpoint seam ops. Each test builds a real
     // program's `Rir` through the production lex/parse/astgen path, binds its
     // declarations through the epoch, and compares the pool-side `BodyRirIndex`
-    // answers against the epoch's `EpochFacts` over the SAME `Rir` — then the
+    // answers against the epoch host over the SAME `Rir` — then the
     // capstone assembles a complete `FunctionInfo` / `MethodInfo` from the index
     // (2c) + a durable signature (2b, resolving types through 2a) and proves it
     // equals production's populated info struct field-for-field.
@@ -6079,7 +6075,7 @@ mod tests {
 
     /// Bind declarations through the epoch so `functions`, `methods`,
     /// `named_method_declarations`, and the `type_pool` are populated — the
-    /// state the `EpochFacts` twin reads.
+    /// state the epoch-side twin reads.
     fn bind<'a>(
         rir: &'a Rir,
         interner: &'a ThreadedRodeo,
@@ -6235,7 +6231,9 @@ mod tests {
 
         // Production's populated FunctionInfo for `make`.
         let make_src = interner.get("make").unwrap();
-        let internal = facts.function_by_file_name(file, make_src).unwrap();
+        let internal = facts
+            .endpoint_function_by_file_name(file, make_src)
+            .unwrap();
         let prod = facts.function_info(internal).unwrap();
 
         // 2c: the RIR index locates the declaration; fill the request/RIR handle.
@@ -6333,8 +6331,8 @@ mod tests {
 
         let widget = interner.get("Widget").unwrap();
         let bump = interner.get("bump").unwrap();
-        let struct_id = facts.struct_by_file_name(file, widget).unwrap();
-        let prod = facts.method_info(struct_id, bump).unwrap();
+        let struct_id = facts.endpoint_struct_by_file_name(file, widget).unwrap();
+        let prod = facts.endpoint_method_info(struct_id, bump).unwrap();
 
         // 2c: the RIR index locates the method declaration; fill the handle.
         let declaration = index.named_method_declaration(file, widget, bump).unwrap();

--- a/crates/rue-air/src/sema/call_resolution.rs
+++ b/crates/rue-air/src/sema/call_resolution.rs
@@ -38,41 +38,41 @@ use crate::types::{ModuleDef, ModuleId, StructId};
 pub(crate) trait CallResolutionFacts {
     /// The signature/binding info for an internal free-function symbol.
     /// Mirrors `Sema::function_info` (`functions.get`).
-    fn function_info(&self, name: Spur) -> Option<FunctionCallInfo>;
+    fn call_function_info(&self, name: Spur) -> Option<FunctionCallInfo>;
 
     /// Whether an internal free-function symbol is declared. Mirrors
     /// `functions.contains_key`.
-    fn function_contains(&self, name: Spur) -> bool;
+    fn call_function_contains(&self, name: Spur) -> bool;
 
     /// The source name a specialized/internal function name derives from.
     /// Mirrors `Sema::source_function_name` (identity when unmapped).
-    fn source_function_name(&self, name: Spur) -> Spur;
+    fn call_source_function_name(&self, name: Spur) -> Spur;
 
     /// The internal free-function symbol a source name resolves to inside its
     /// own file. Mirrors `Sema::resolve_function_name_local`.
-    fn resolve_function_name_local(&self, name: Spur, file: FileId) -> Option<Spur>;
+    fn call_resolve_function_name_local(&self, name: Spur, file: FileId) -> Option<Spur>;
 
     /// The value-constant info declared as `(file, name)`. Mirrors
     /// `Sema::resolve_const_info_in_file` (a file-scoped `value_const`).
-    fn resolve_const_info_in_file(&self, name: Spur, file: FileId) -> Option<ConstInfo>;
+    fn call_resolve_const_info_in_file(&self, name: Spur, file: FileId) -> Option<ConstInfo>;
 
     /// The value-constant info declared as `(file, name)`. Mirrors
-    /// `value_const`; distinct from [`Self::resolve_const_info_in_file`] only in
+    /// `value_const`; distinct from [`Self::call_resolve_const_info_in_file`] only in
     /// how the key is spelled at the call site.
-    fn value_const(&self, file: FileId, name: Spur) -> Option<ConstInfo>;
+    fn call_value_const(&self, file: FileId, name: Spur) -> Option<ConstInfo>;
 
     /// The module-binding const declared as `(file, name)`. Mirrors
     /// `module_binding`.
-    fn module_binding(&self, file: FileId, name: Spur) -> Option<ConstInfo>;
+    fn call_module_binding(&self, file: FileId, name: Spur) -> Option<ConstInfo>;
 
     /// The method/associated-function info for `(struct, name)`, preferring the
     /// anonymous table then the named table. Mirrors `Sema::method_info`.
-    fn method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodCallInfo>;
+    fn call_method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodCallInfo>;
 
     /// The named-method RIR declaration for the durable-available
     /// `(owner_file, owner_type_name, method_name)` preimage. Mirrors
     /// `structs_by_file_name.get` followed by `named_method_declarations.get`.
-    fn named_method_declaration(
+    fn call_named_method_declaration(
         &self,
         owner_file: FileId,
         owner_type_name: Spur,
@@ -81,33 +81,12 @@ pub(crate) trait CallResolutionFacts {
 
     /// The module definition for a module id. Mirrors
     /// `module_registry.get_def`.
-    fn module_def(&self, module_id: ModuleId) -> ModuleDef;
+    fn call_module_def(&self, module_id: ModuleId) -> ModuleDef;
 }
 
-/// Raw immutable call-resolution reads supplied by a body-analysis host.
-pub(super) trait CallResolutionFactSource {
-    fn call_function_info(&self, name: Spur) -> Option<FunctionCallInfo>;
-    fn call_function_contains(&self, name: Spur) -> bool;
-    fn call_source_function_name(&self, name: Spur) -> Spur;
-    fn call_resolve_function_name_local(&self, name: Spur, file: FileId) -> Option<Spur>;
-    fn call_resolve_const_info_in_file(&self, name: Spur, file: FileId) -> Option<ConstInfo>;
-    fn call_value_const(&self, file: FileId, name: Spur) -> Option<ConstInfo>;
-    fn call_module_binding(&self, file: FileId, name: Spur) -> Option<ConstInfo>;
-    fn call_method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodCallInfo>;
-    fn call_named_method_declaration(
-        &self,
-        file: FileId,
-        ty: Spur,
-        method: Spur,
-    ) -> Option<InstRef>;
-    fn call_module_def(&self, module: ModuleId) -> ModuleDef;
-}
-
-/// Direct epoch reads for the current host. The generic adapter below owns the
-/// read-only abstraction; this impl is only the production source of facts.
-impl<D: DeclarationPhase> CallResolutionFactSource for Sema<'_, D> {
+impl<D: DeclarationPhase> CallResolutionFacts for Sema<'_, D> {
     fn call_function_info(&self, name: Spur) -> Option<FunctionCallInfo> {
-        self.function_info(name)
+        Sema::function_info(self, name)
             .copied()
             .map(FunctionCallInfo::from_body)
     }
@@ -117,27 +96,27 @@ impl<D: DeclarationPhase> CallResolutionFactSource for Sema<'_, D> {
     }
 
     fn call_source_function_name(&self, name: Spur) -> Spur {
-        self.source_function_name(name)
+        Sema::source_function_name(self, name)
     }
 
     fn call_resolve_function_name_local(&self, name: Spur, file: FileId) -> Option<Spur> {
-        self.resolve_function_name_local(name, file)
+        Sema::resolve_function_name_local(self, name, file)
     }
 
     fn call_resolve_const_info_in_file(&self, name: Spur, file: FileId) -> Option<ConstInfo> {
-        self.resolve_const_info_in_file(name, file).cloned()
+        Sema::resolve_const_info_in_file(self, name, file).cloned()
     }
 
     fn call_value_const(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
-        self.value_const(&(file, name)).cloned()
+        self.declarations.value_const(&(file, name)).cloned()
     }
 
     fn call_module_binding(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
-        self.module_binding(&(file, name)).cloned()
+        self.declarations.module_binding(&(file, name)).cloned()
     }
 
     fn call_method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodCallInfo> {
-        self.method_info((struct_id, name))
+        Sema::method_info(self, (struct_id, name))
             .copied()
             .map(MethodCallInfo::from_body)
     }
@@ -161,50 +140,6 @@ impl<D: DeclarationPhase> CallResolutionFactSource for Sema<'_, D> {
     }
 }
 
-/// Read-only call-resolution adapter used by the canonical body engine.
-pub(crate) struct EpochFacts<'host, H: super::fact_mode::BodyAnalysisReadHost> {
-    host: &'host H,
-}
-
-impl<'host, H: super::fact_mode::BodyAnalysisReadHost> EpochFacts<'host, H> {
-    pub(in crate::sema) fn new(host: &'host H) -> Self {
-        Self { host }
-    }
-}
-
-impl<H: super::fact_mode::BodyAnalysisReadHost> CallResolutionFacts for EpochFacts<'_, H> {
-    fn function_info(&self, name: Spur) -> Option<FunctionCallInfo> {
-        self.host.call_function_info(name)
-    }
-    fn function_contains(&self, name: Spur) -> bool {
-        self.host.call_function_contains(name)
-    }
-    fn source_function_name(&self, name: Spur) -> Spur {
-        self.host.call_source_function_name(name)
-    }
-    fn resolve_function_name_local(&self, name: Spur, file: FileId) -> Option<Spur> {
-        self.host.call_resolve_function_name_local(name, file)
-    }
-    fn resolve_const_info_in_file(&self, name: Spur, file: FileId) -> Option<ConstInfo> {
-        self.host.call_resolve_const_info_in_file(name, file)
-    }
-    fn value_const(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
-        self.host.call_value_const(file, name)
-    }
-    fn module_binding(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
-        self.host.call_module_binding(file, name)
-    }
-    fn method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodCallInfo> {
-        self.host.call_method_info(struct_id, name)
-    }
-    fn named_method_declaration(&self, file: FileId, ty: Spur, method: Spur) -> Option<InstRef> {
-        self.host.call_named_method_declaration(file, ty, method)
-    }
-    fn module_def(&self, module_id: ModuleId) -> ModuleDef {
-        self.host.call_module_def(module_id)
-    }
-}
-
 /// Resolve a statically discovered call name to the free-function symbol it
 /// references for reachability. The provider-generic form of the inline
 /// resolution in `collect_static_function_references`, replaying `analyze_call`'s
@@ -220,17 +155,17 @@ pub(in crate::sema) fn resolve_static_call_reference<P: CallResolutionFacts>(
 ) -> Option<Spur> {
     let mut target = name;
     let mut resolved_alias = false;
-    if let Some(const_info) = facts.resolve_const_info_in_file(name, file)
+    if let Some(const_info) = facts.call_resolve_const_info_in_file(name, file)
         && let Some(callee) = const_info.value.as_function()
     {
         target = callee;
         resolved_alias = true;
     }
 
-    if resolved_alias && facts.function_contains(target) {
+    if resolved_alias && facts.call_function_contains(target) {
         Some(target)
     } else {
-        facts.resolve_function_name_local(target, file)
+        facts.call_resolve_function_name_local(target, file)
     }
 }
 
@@ -248,9 +183,9 @@ pub(in crate::sema) fn resolve_static_call_reference<P: CallResolutionFacts>(
 // provider-generic free function above).
 // ---------------------------------------------------------------------------
 
-/// The call-resolution ProviderFacts driver: answers the family-1C facts from a
-/// [`BodyFactProvider`] + the body-scoped identity pool, instead of the epoch
-/// `Sema` tables [`EpochFacts`] reads.
+/// Query-backed call-resolution fact state. It owns the body-scoped identity
+/// pool, request RIR view, and consulted overlays; the epoch host reads its own
+/// tables directly.
 ///
 /// Generic over the provider `P`, the pool durable source `S`, and the pool's
 /// durable nominal/callable key `K` and module `M` (rue-compiler binds
@@ -284,7 +219,7 @@ where
         Self::with_identity(provider, identity, rir)
     }
 
-    /// Construct the call facade from the one task-local provider authority.
+    /// Construct the call fact state from the one task-local provider authority.
     pub fn with_state(
         provider: &'a P,
         state: &super::ProviderBodyAnalysisState<K, M, S>,
@@ -477,7 +412,7 @@ where
     }
 
     /// Install one anonymous method atomically under its compact and
-    /// durable-owner lookup preimages. Endpoint and call facades cloned from
+    /// durable-owner lookup preimages. Endpoint and call fact state cloned from
     /// this context therefore observe the same anonymous-first result.
     pub fn register_anonymous_method(
         &self,

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -127,6 +127,14 @@ mod tests {
     const TYPE_INFERENCE_SOURCE: &str = include_str!("analysis/type_inference.rs");
     const CONTROL_FLOW_SOURCE: &str = include_str!("control_flow.rs");
     const TYPECK_SOURCE: &str = include_str!("typeck.rs");
+    const FACT_MODE_SOURCE: &str = include_str!("fact_mode.rs");
+    const AGGREGATE_RESOLUTION_SOURCE: &str = include_str!("aggregate_resolution.rs");
+    const CALL_RESOLUTION_SOURCE: &str = include_str!("call_resolution.rs");
+    const BODY_ENDPOINT_SOURCE: &str = include_str!("body_endpoint.rs");
+    const PROVIDER_BODY_HOST_SOURCE: &str = include_str!("provider_body_host.rs");
+    const SEMANTIC_TYPE_RESOLUTION_SOURCE: &str = include_str!("../semantic_type_resolution.rs");
+    const TYPES_SOURCE: &str = include_str!("../types.rs");
+    const AIR_LIB_SOURCE: &str = include_str!("../lib.rs");
     const VISIBILITY_SOURCE: &str = include_str!("visibility.rs");
     const BINDING_MANIFEST_SOURCE: &str = include_str!("binding_manifest.rs");
     const CALL_INTRINSIC_PEER_SOURCE: &str = concat!(
@@ -1024,7 +1032,7 @@ mod tests {
     }
 
     #[test]
-    fn type_syntax_evaluator_is_generic_and_has_one_explicit_host() {
+    fn structured_type_syntax_has_one_policy_and_two_fact_hosts() {
         fn item<'source>(source: &'source str, header: &str) -> &'source str {
             let start = source.find(header).expect("item header is present");
             let rest = &source[start..];
@@ -1062,9 +1070,18 @@ mod tests {
             );
         }
         assert_eq!(
-            TYPECK_SOURCE.matches("TypeSyntaxHost for Sema<").count(),
+            TYPECK_SOURCE
+                .matches("impl<'source, D: DeclarationPhase> TypeSyntaxHost for Sema<")
+                .count(),
             1,
-            "only the production epoch implements the type-syntax host"
+            "the epoch implements the shared fact host exactly once"
+        );
+        assert_eq!(
+            PROVIDER_BODY_HOST_SOURCE
+                .matches("impl<P, S, K, M> TypeSyntaxHost for ProviderBodyHost<")
+                .count(),
+            1,
+            "the query-backed body host implements the shared fact host exactly once"
         );
         assert!(TYPECK_SOURCE.contains("pub(super) trait TypeSyntaxHost"));
         assert!(TYPECK_SOURCE.contains("pub(super) struct TypeSyntaxProvider"));
@@ -1098,15 +1115,15 @@ mod tests {
             ),
             item(
                 TYPECK_SOURCE,
-                "impl<H: TypeSyntaxHost> crate::SemanticModulePathProvider<FileId, crate::types::ModuleId, FileId>\n    for DeferredTypeSyntaxProvider",
+                "impl<H: DeferredTypeSyntaxHost>\n    crate::SemanticModulePathProvider<FileId, crate::types::ModuleId, FileId>\n    for DeferredTypeSyntaxProvider",
             ),
             item(
                 TYPECK_SOURCE,
-                "impl<H: TypeSyntaxHost>\n    crate::SemanticTypeSyntaxProvider<\n        FileId,\n        crate::types::ModuleId,\n        FileId,\n        Spur,\n        Spur,\n        DeferredTypeResolution,\n        DeferredValueResolution,\n    > for DeferredTypeSyntaxProvider",
+                "impl<H: DeferredTypeSyntaxHost>\n    crate::SemanticTypeSyntaxProvider<\n        FileId,\n        crate::types::ModuleId,\n        FileId,\n        Spur,\n        Spur,\n        DeferredTypeResolution,\n        DeferredValueResolution,\n    > for DeferredTypeSyntaxProvider",
             ),
             item(
                 TYPECK_SOURCE,
-                "impl<'s, 'c, 'p, H: TypeSyntaxHost> DeferredTypeSyntaxProvider<'s, 'c, 'p, H>",
+                "impl<'s, 'c, 'p, H: DeferredTypeSyntaxHost> DeferredTypeSyntaxProvider<'s, 'c, 'p, H>",
             ),
         ] {
             for forbidden in [
@@ -1119,6 +1136,8 @@ mod tests {
                 "DeferredSemaTypeSyntaxProvider",
                 "type_syntax_deferred_array_length",
                 "type_syntax_deferred_value_argument",
+                ".parse::<",
+                ".trim(",
             ] {
                 assert!(
                     !evaluator.contains(forbidden),
@@ -1129,15 +1148,13 @@ mod tests {
 
         let deferred = item(
             TYPECK_SOURCE,
-            "impl<'s, 'c, 'p, H: TypeSyntaxHost> DeferredTypeSyntaxProvider<'s, 'c, 'p, H>",
+            "impl<'s, 'c, 'p, H: DeferredTypeSyntaxHost> DeferredTypeSyntaxProvider<'s, 'c, 'p, H>",
         );
         for required in [
             "fn deferred_argument_expected(",
             "fn validate_value_position(",
-            "resolve_semantic_comptime_call(",
             "type_syntax_signature_substitutions_are_ready(",
             "type_syntax_resolve_substituted_parameter_type(",
-            "type_syntax_resolve_substituted_return_type(",
             "type_syntax_validate_deferred_value(",
         ] {
             assert!(
@@ -1148,7 +1165,7 @@ mod tests {
 
         for (method, provider) in [
             (
-                "resolve_type_syntax_with_epoch_facts",
+                "resolve_structured_type_syntax_with_epoch_facts",
                 "TypeSyntaxProvider::new",
             ),
             (
@@ -1160,7 +1177,7 @@ mod tests {
                 "TypeSyntaxProvider::new",
             ),
             (
-                "validate_deferred_type_position_with_epoch_facts",
+                "validate_deferred_rir_type",
                 "DeferredTypeSyntaxProvider::new",
             ),
         ] {
@@ -1173,9 +1190,207 @@ mod tests {
         }
         let bare_value = deferred;
         assert!(bare_value.contains("TypeSyntaxProvider::new"));
-        assert!(bare_value.contains("DeferredTypeSyntaxProvider::new"));
         assert!(!TYPECK_SOURCE.contains("SemaTypeSyntaxProvider"));
         assert!(!TYPECK_SOURCE.contains("DeferredSemaTypeSyntaxProvider"));
+        assert_eq!(
+            SEMANTIC_TYPE_RESOLUTION_SOURCE
+                .matches("pub fn resolve_structured_semantic_type_syntax_with<")
+                .count(),
+            1,
+            "all storage hosts share one recursive structured policy"
+        );
+        for forbidden in [
+            "pub fn resolve_semantic_type_syntax",
+            "pub fn resolve_semantic_comptime_call",
+            "SemanticValueSyntax::Rendered",
+            "parse_array_type_syntax(",
+            "parse_pointer_type_syntax(",
+            "parse_type_call_syntax(",
+        ] {
+            assert!(
+                !SEMANTIC_TYPE_RESOLUTION_SOURCE.contains(forbidden),
+                "the canonical resolver has no rendered-string peer: {forbidden}"
+            );
+        }
+        for forbidden in [
+            "parse_array_type_syntax",
+            "parse_pointer_type_syntax",
+            "parse_type_call_syntax",
+        ] {
+            assert!(
+                !TYPES_SOURCE.contains(forbidden),
+                "rue-air must not retain a rendered type-syntax parser: {forbidden}"
+            );
+            assert!(
+                !AIR_LIB_SOURCE.contains(forbidden),
+                "rue-air must not export a rendered type-syntax parser: {forbidden}"
+            );
+            assert!(
+                !GENERATE_SOURCE.contains(forbidden),
+                "inference must consume structured type syntax: {forbidden}"
+            );
+        }
+        let provider_type_facts = item(
+            PROVIDER_BODY_HOST_SOURCE,
+            "impl<P, S, K, M> TypeSyntaxHost for ProviderBodyHost<",
+        );
+        for forbidden in [
+            "fn resolve_rir_type_syntax",
+            "fn resolve_type_name_in_file",
+            "parse_array_type_syntax(",
+            "parse_pointer_type_syntax(",
+            "parse_type_call_syntax(",
+            "RirTypeSyntaxNode::",
+        ] {
+            assert!(
+                !provider_type_facts.contains(forbidden),
+                "the query-backed host supplies facts but owns no peer policy: {forbidden}"
+            );
+        }
+
+        let inference_hint = item(GENERATE_SOURCE, "fn infer_type_hint(");
+        for required in [
+            "RirTypeSyntaxNode::Qualified { .. }",
+            "RirTypeSyntaxNode::TypeCall { .. }",
+            "RirTypeSyntaxNode::ValueCall { .. }",
+            "=> None",
+        ] {
+            assert!(
+                inference_hint.contains(required),
+                "constraint generation must defer fact-bearing syntax to semantic resolution: {required}"
+            );
+        }
+        for forbidden in ["render_type", ".parse::<", "parse_type_syntax"] {
+            assert!(
+                !inference_hint.contains(forbidden),
+                "constraint hints must consume structured syntax without becoming a peer resolver: {forbidden}"
+            );
+        }
+
+        let provider_host = item(
+            PROVIDER_BODY_HOST_SOURCE,
+            "impl<P, S, K, M> OrdinaryBodyAnalysisHost for ProviderBodyHost<",
+        );
+        for required in [
+            "resolve_structured_semantic_type_syntax_with(",
+            "resolve_semantic_module_path(",
+            "resolve_array_length_fact(",
+            "Some(definition.file_id)",
+        ] {
+            assert!(
+                provider_host.contains(required),
+                "the query-backed host lost the shared type policy: {required}"
+            );
+        }
+        for forbidden in [
+            "fn resolve_array_length_in_file(",
+            "for segment in request.segments",
+            "Some(resolved.site)",
+        ] {
+            assert!(
+                !PROVIDER_BODY_HOST_SOURCE.contains(forbidden),
+                "the query-backed host regained handwritten type policy: {forbidden}"
+            );
+        }
+    }
+
+    #[test]
+    fn body_fact_contracts_have_no_forwarding_object_layer() {
+        let fact_sources = concat!(
+            include_str!("fact_mode.rs"),
+            include_str!("aggregate_resolution.rs"),
+            include_str!("call_resolution.rs"),
+            include_str!("body_endpoint.rs"),
+            include_str!("ordinary_engine.rs"),
+            include_str!("mod.rs"),
+            include_str!("provider_body_host.rs"),
+        );
+        for forbidden in [
+            "struct EpochFacts",
+            "AggregateFactSource",
+            "CallResolutionFactSource",
+            "BodyEndpointFactSource",
+            "BodyEndpointReadView",
+            "trait BodyAnalysisHost",
+        ] {
+            assert!(
+                !fact_sources.contains(forbidden),
+                "body analysis must not regain a pass-through fact layer: {forbidden}"
+            );
+        }
+
+        assert_eq!(
+            AGGREGATE_RESOLUTION_SOURCE
+                .matches("AggregateFacts for Sema<'_, D>")
+                .count(),
+            1
+        );
+        assert_eq!(
+            CALL_RESOLUTION_SOURCE
+                .matches("CallResolutionFacts for Sema<'_, D>")
+                .count(),
+            1
+        );
+        assert_eq!(
+            BODY_ENDPOINT_SOURCE
+                .matches("BodyEndpointProvider for Sema<'_, D>")
+                .count(),
+            1
+        );
+        for contract in [
+            "BodyEndpointProvider for ProviderBodyHost<",
+            "CallResolutionFacts for ProviderBodyHost<",
+            "AggregateFactsTrait for ProviderBodyHost<",
+        ] {
+            assert_eq!(
+                PROVIDER_BODY_HOST_SOURCE.matches(contract).count(),
+                1,
+                "the query-backed host implements {contract} directly exactly once"
+            );
+        }
+        assert!(FACT_MODE_SOURCE.contains(
+            "BodyEndpointProvider + CallResolutionFacts + AggregateFacts + InferenceFactSource"
+        ));
+    }
+
+    #[test]
+    fn synthetic_type_names_have_one_identity_policy() {
+        let consumers = [
+            ("inference/generate.rs", GENERATE_SOURCE),
+            ("semantic_import.rs", include_str!("../semantic_import.rs")),
+            ("analysis.rs", ANALYSIS_ROOT_SOURCE),
+            ("binding_manifest.rs", BINDING_MANIFEST_SOURCE),
+            ("body_identity.rs", include_str!("body_identity.rs")),
+            ("ordinary_engine.rs", ORDINARY_ENGINE_SOURCE),
+            (
+                "semantic_body_export.rs",
+                include_str!("semantic_body_export.rs"),
+            ),
+            ("typeck.rs", TYPECK_SOURCE),
+        ];
+        for (name, source) in consumers {
+            for peer in [
+                ".strip_prefix(\"Str(\")",
+                ".starts_with(\"Str(\")",
+                ".starts_with('[')",
+            ] {
+                assert!(
+                    !source.contains(peer),
+                    "{name} regained handwritten synthetic-type identity policy: {peer}"
+                );
+            }
+        }
+        for helper in [
+            "pub fn fixed_string_capacity(",
+            "pub fn is_slice_struct_name(",
+            "pub fn is_string_view_struct_name(",
+        ] {
+            assert_eq!(
+                TYPES_SOURCE.matches(helper).count(),
+                1,
+                "synthetic type identity must have one owner: {helper}"
+            );
+        }
     }
 
     /// Every source-name resolution carries an explicit lexical scope.
@@ -1232,19 +1447,19 @@ mod tests {
             }
         }
 
-        // `TypeRootAuthority` stays a single-field newtype, private to the
-        // type-syntax module, reachable only through `in_file`.
+        // `TypeRootAuthority` stays a single-field request-state newtype owned
+        // by typeck. The two fact hosts may construct it only through `in_file`.
         assert!(
             TYPECK_SOURCE.contains("pub(super) struct TypeRootAuthority {\n    file: FileId,\n}")
         );
         assert!(TYPECK_SOURCE.contains("pub(super) fn in_file(file: FileId) -> Self {"));
         for (file, source) in RESOLVER_SOURCES {
-            if *file == "typeck.rs" {
+            if matches!(*file, "typeck.rs" | "provider_body_host.rs") {
                 continue;
             }
             assert!(
                 !source.contains("TypeRootAuthority"),
-                "{file} names the root authority; it is private to typeck.rs"
+                "{file} names request-state authority outside the two fact hosts"
             );
         }
         for construction in TYPECK_SOURCE.match_indices("TypeRootAuthority::") {

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -15,7 +15,6 @@ use rue_span::Span;
 
 use super::analysis::FirstClassStrSite;
 use super::anon_structs::TrustedTryProducer;
-use super::call_resolution::CallResolutionFacts;
 use super::context::{
     AnalysisContext, AnalysisResult, ConstValue, LocalVar, LoopEdgeStates, union_move_maps,
 };
@@ -2002,7 +2001,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     let is_accessor = ctx
                         .resolved_type_of(*receiver)
                         .and_then(|ty| ty.as_struct())
-                        .and_then(|struct_id| self.call_facts().method_info(struct_id, *method))
+                        .and_then(|struct_id| {
+                            self.call_facts().call_method_info(struct_id, *method)
+                        })
                         .is_some_and(|info| info.returns_borrow);
                     let link = if is_accessor {
                         AccessorMethodLink::Accessor

--- a/crates/rue-air/src/sema/fact_mode.rs
+++ b/crates/rue-air/src/sema/fact_mode.rs
@@ -10,32 +10,12 @@ use std::collections::HashMap;
 use lasso::Spur;
 use rue_span::{FileId, Span};
 
-use super::aggregate_resolution::{
-    AggregateFactSource, AggregateFacts, EpochFacts as EpochAggregateFacts,
-};
-use super::body_endpoint::{
-    BodyEndpointFactSource, BodyEndpointProvider, EpochFacts as EpochEndpointFacts,
-};
-use super::call_resolution::{
-    CallResolutionFactSource, CallResolutionFacts, EpochFacts as EpochCallFacts,
-};
-use super::{ConstValue, DeclarationPhase, HostInferenceFacts, InferenceContext, Sema};
-use crate::inference::LazyInferenceFacts;
+use super::ConstValue;
+use super::aggregate_resolution::AggregateFacts;
+use super::body_endpoint::BodyEndpointProvider;
+use super::call_resolution::CallResolutionFacts;
 use crate::sema::inference_ctx::InferenceFactSource;
-use crate::types::{ArrayLen, ModuleId, Type};
-
-/// Exact input for resolving one type-syntax fragment.
-///
-/// `root_file` is the whole scope of the request: a source name is resolved
-/// against that file's declarations and imports and nothing wider. There is
-/// deliberately no way to ask for a scope-free lookup (RUE-497, RUE-1126).
-pub(crate) struct TypeSyntaxRequest<'a> {
-    pub(crate) syntax: &'a str,
-    pub(crate) root_file: FileId,
-    pub(crate) span: Span,
-    pub(crate) type_substitutions: Option<&'a HashMap<Spur, Type>>,
-    pub(crate) value_substitutions: Option<&'a HashMap<Spur, ConstValue>>,
-}
+use crate::types::{ArrayLen, Type};
 
 /// One exact declaration-owned type fragment in a body-local symbol domain.
 /// Cloning this value only clones the arena's three shared slices; it never
@@ -68,153 +48,23 @@ pub(crate) struct ArrayLengthRequest<'a> {
     pub(crate) value_substitutions: Option<&'a HashMap<Spur, ConstValue>>,
 }
 
-type TypeSyntaxResult = Result<
+pub(crate) type TypeSyntaxResult = Result<
     Type,
     crate::SemanticTypeSyntaxError<std::convert::Infallible, rue_error::CompileError, FileId, Spur>,
 >;
 
-/// The read-only slice of a body-analysis host.
+/// The read-only capabilities required by body analysis.
 ///
-/// The adapters below only need these immutable point-query capabilities. The
-/// mutable receiver/state migration is deliberately outside this extraction.
+/// This marker adds no object or dispatch layer; it groups the contracts both
+/// concrete hosts implement directly.
 pub(crate) trait BodyAnalysisReadHost:
-    BodyEndpointFactSource + CallResolutionFactSource + AggregateFactSource + InferenceFactSource
+    BodyEndpointProvider + CallResolutionFacts + AggregateFacts + InferenceFactSource
 {
 }
 
 impl<T> BodyAnalysisReadHost for T where
-    T: BodyEndpointFactSource
-        + CallResolutionFactSource
-        + AggregateFactSource
-        + InferenceFactSource
+    T: BodyEndpointProvider + CallResolutionFacts + AggregateFacts + InferenceFactSource
 {
-}
-
-/// Host capability consumed by the canonical body-analysis engine.
-///
-/// Associated fact facades return owned or short-lived read-only values; the
-/// mutable operations take a request object so the contract stays independent
-/// of the current analyzer representation.
-pub(crate) trait BodyAnalysisHost: BodyAnalysisReadHost + Sized {
-    type EndpointFacts<'a>: BodyEndpointProvider
-    where
-        Self: 'a;
-    fn endpoint_facts(&self) -> Self::EndpointFacts<'_>;
-
-    type CallFacts<'a>: CallResolutionFacts
-    where
-        Self: 'a;
-    fn call_facts(&self) -> Self::CallFacts<'_>;
-
-    type AggregateFacts<'a>: AggregateFacts
-    where
-        Self: 'a;
-    fn aggregate_facts(&self) -> Self::AggregateFacts<'_>;
-
-    type InferenceFacts<'a>: LazyInferenceFacts
-    where
-        Self: 'a;
-    fn inference_facts<'a>(&'a self, ctx: &'a InferenceContext) -> Self::InferenceFacts<'a>;
-
-    fn resolve_type_syntax(&mut self, request: TypeSyntaxRequest<'_>) -> TypeSyntaxResult;
-    fn resolve_structured_type_syntax(
-        &mut self,
-        request: StructuredTypeSyntaxRequest<'_>,
-    ) -> TypeSyntaxResult;
-    fn resolve_type_module_prefix(
-        &mut self,
-        request: ModulePrefixRequest<'_>,
-    ) -> rue_error::CompileResult<(ModuleId, Option<FileId>, String)>;
-    fn resolve_array_length(
-        &mut self,
-        request: ArrayLengthRequest<'_>,
-    ) -> rue_error::CompileResult<u64>;
-}
-
-/// The canonical epoch host. This is the only location that names the epoch
-/// adapters; the host contract above remains representation-independent.
-impl<'source, D: DeclarationPhase> BodyAnalysisHost for Sema<'source, D> {
-    type EndpointFacts<'a>
-        = EpochEndpointFacts<'a, Self>
-    where
-        Self: 'a;
-
-    fn endpoint_facts(&self) -> Self::EndpointFacts<'_> {
-        EpochEndpointFacts::new(self)
-    }
-
-    type CallFacts<'a>
-        = EpochCallFacts<'a, Self>
-    where
-        Self: 'a;
-
-    fn call_facts(&self) -> Self::CallFacts<'_> {
-        EpochCallFacts::new(self)
-    }
-
-    type AggregateFacts<'a>
-        = EpochAggregateFacts<'a, Self>
-    where
-        Self: 'a;
-
-    fn aggregate_facts(&self) -> Self::AggregateFacts<'_> {
-        EpochAggregateFacts::new(self)
-    }
-
-    type InferenceFacts<'a>
-        = HostInferenceFacts<'a, Self>
-    where
-        Self: 'a;
-
-    fn inference_facts<'a>(&'a self, ctx: &'a InferenceContext) -> Self::InferenceFacts<'a> {
-        HostInferenceFacts::new(ctx, self)
-    }
-
-    fn resolve_type_syntax(&mut self, request: TypeSyntaxRequest<'_>) -> TypeSyntaxResult {
-        self.resolve_type_syntax_with_epoch_facts(
-            request.syntax,
-            request.root_file,
-            request.span,
-            request.type_substitutions,
-            request.value_substitutions,
-        )
-    }
-
-    fn resolve_structured_type_syntax(
-        &mut self,
-        request: StructuredTypeSyntaxRequest<'_>,
-    ) -> TypeSyntaxResult {
-        self.resolve_structured_type_syntax_with_epoch_facts(
-            &request.syntax.arena,
-            request.syntax.root,
-            request.root_file,
-            request.span,
-            request.type_substitutions,
-            request.value_substitutions,
-        )
-    }
-
-    fn resolve_type_module_prefix(
-        &mut self,
-        request: ModulePrefixRequest<'_>,
-    ) -> rue_error::CompileResult<(ModuleId, Option<FileId>, String)> {
-        self.resolve_type_module_prefix_with_epoch_facts(
-            request.root_file,
-            request.segments,
-            request.span,
-        )
-    }
-
-    fn resolve_array_length(
-        &mut self,
-        request: ArrayLengthRequest<'_>,
-    ) -> rue_error::CompileResult<u64> {
-        self.resolve_array_length_with_epoch_facts(
-            request.length,
-            request.span,
-            request.value_substitutions,
-        )
-    }
 }
 
 #[cfg(test)]
@@ -224,13 +74,13 @@ mod tests {
 
     use super::*;
     use crate::inference::{FunctionSig, MethodSig};
-    use crate::sema::PreviewFeatures;
     use crate::sema::aggregate_resolution::AggregateModuleFact;
     use crate::sema::anon_structs::IssuedAnonymousNominalKey;
     use crate::sema::info::{
         ConstInfo, FunctionCallInfo, FunctionInfo, MethodCallInfo, MethodInfo,
     };
-    use crate::types::{EnumId, ModuleDef, StructId};
+    use crate::sema::{HostInferenceFacts, InferenceContext, PreviewFeatures, Sema};
+    use crate::types::{EnumId, ModuleDef, ModuleId, StructId};
     use crate::{
         SemanticDefinitionEndpoint, SemanticDefinitionToken, SemanticModuleEndpoint,
         SemanticModuleToken,
@@ -256,7 +106,7 @@ mod tests {
         path: Box<str>,
     }
 
-    impl BodyEndpointFactSource for OwnedReadHost {
+    impl BodyEndpointProvider for OwnedReadHost {
         fn endpoint_name_symbol(&self, name: &str) -> Option<Spur> {
             (name == self.label.as_ref()).then_some(self.symbol)
         }
@@ -319,7 +169,7 @@ mod tests {
         }
     }
 
-    impl CallResolutionFactSource for OwnedReadHost {
+    impl CallResolutionFacts for OwnedReadHost {
         fn call_function_info(&self, _: Spur) -> Option<FunctionCallInfo> {
             None
         }
@@ -352,7 +202,7 @@ mod tests {
         }
     }
 
-    impl AggregateFactSource for OwnedReadHost {
+    impl AggregateFacts for OwnedReadHost {
         fn aggregate_value_const(&self, _: FileId, _: Spur) -> Option<ConstInfo> {
             None
         }
@@ -434,11 +284,8 @@ mod tests {
     }
 
     #[test]
-    fn owned_read_host_exercises_the_same_adapter_requests_as_sema() {
+    fn owned_read_host_exercises_the_same_fact_contracts_as_sema() {
         use crate::inference::LazyInferenceFacts;
-        use crate::sema::aggregate_resolution::EpochFacts as AggregateFactsView;
-        use crate::sema::body_endpoint::EpochFacts as EndpointFactsView;
-        use crate::sema::call_resolution::EpochFacts as CallFactsView;
 
         let interner = ThreadedRodeo::new();
         let symbol = interner.get_or_intern("body");
@@ -452,29 +299,23 @@ mod tests {
         };
         assert_eq!(owned.ownership.tag(), 1);
 
-        let epoch_endpoint = EndpointFactsView::new(&sema);
-        let owned_endpoint = EndpointFactsView::new(&owned);
         assert_eq!(
-            owned_endpoint.name_symbol("body"),
-            epoch_endpoint.name_symbol("body")
+            owned.endpoint_name_symbol("body"),
+            sema.endpoint_name_symbol("body")
         );
 
-        let epoch_call = CallFactsView::new(&sema);
-        let owned_call = CallFactsView::new(&owned);
         assert_eq!(
-            owned_call.source_function_name(symbol),
-            epoch_call.source_function_name(symbol)
+            owned.call_source_function_name(symbol),
+            sema.call_source_function_name(symbol)
         );
         assert_eq!(
-            owned_call.function_contains(symbol),
-            epoch_call.function_contains(symbol)
+            owned.call_function_contains(symbol),
+            sema.call_function_contains(symbol)
         );
 
-        let epoch_aggregate = AggregateFactsView::new(&sema);
-        let owned_aggregate = AggregateFactsView::new(&owned);
         assert_eq!(
-            owned_aggregate.file_path(FileId::DEFAULT),
-            epoch_aggregate.file_path(FileId::DEFAULT)
+            owned.aggregate_file_path(FileId::DEFAULT),
+            sema.aggregate_file_path(FileId::DEFAULT)
         );
 
         let epoch_context = InferenceContext::new(&sema);

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -73,7 +73,6 @@ pub use binding_manifest::{
 };
 pub use context::ConstValue;
 pub use declaration_index::RirDeclarationIndexWork;
-pub(crate) use fact_mode::BodyAnalysisHost;
 pub(crate) use fact_mode::StructuredTypeSyntax;
 pub(crate) use inference_ctx::HostInferenceFacts;
 pub use inference_ctx::InferenceContext;
@@ -1102,10 +1101,8 @@ impl BodySema<'_> {
 }
 
 impl<D: DeclarationPhase> Sema<'_, D> {
-    pub(in crate::sema) fn aggregate_facts(
-        &self,
-    ) -> <Self as BodyAnalysisHost>::AggregateFacts<'_> {
-        BodyAnalysisHost::aggregate_facts(self)
+    pub(in crate::sema) fn aggregate_facts(&self) -> &Self {
+        self
     }
 
     pub(crate) fn body_owner_token(
@@ -1131,12 +1128,12 @@ impl<D: DeclarationPhase> Sema<'_, D> {
 }
 
 impl BodySema<'_> {
-    pub(in crate::sema) fn endpoint_facts(&self) -> <Self as BodyAnalysisHost>::EndpointFacts<'_> {
-        BodyAnalysisHost::endpoint_facts(self)
+    pub(in crate::sema) fn endpoint_facts(&self) -> &Self {
+        self
     }
 
-    pub(in crate::sema) fn call_facts(&self) -> <Self as BodyAnalysisHost>::CallFacts<'_> {
-        BodyAnalysisHost::call_facts(self)
+    pub(in crate::sema) fn call_facts(&self) -> &Self {
+        self
     }
 }
 

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -1,12 +1,10 @@
-//! Neutral storage and access seams for the canonical ordinary-body engine.
+//! The canonical ordinary-body algorithm over its two concrete storage hosts.
 //!
-//! The existing body implementation is split across many inherent `BodySema`
-//! blocks. This module is the first migration seam: it makes the request-local
-//! RIR, identity-backed fact families, type pool, and exact parameter-point
-//! copies available through capabilities rather than through a `Sema` wrapper
-//! or `Deref`. The current production adapter is `BodySema`; a provider-backed
-//! receiver will implement the same contract only after its evaluator owns
-//! exact facts.
+//! [`OrdinaryBodyAnalysisHost`] names the state the algorithm actually needs;
+//! the epoch `Sema` host and the query-backed provider host implement it
+//! directly. [`OrdinaryBodyEngine`] only gives that one generic algorithm an
+//! inherent-method receiver, which stable Rust cannot define on a trait. It
+//! owns no state, representation conversion, cache, or alternative policy.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -17,21 +15,23 @@ use rue_error::{CompileError, CompileResult, CompileWarning, ErrorKind};
 use rue_rir::{InstRef, Rir, RirParam, RirParamMode, RirTypeSyntaxRef};
 use rue_span::{FileId, Span};
 
-use super::aggregate_resolution::{AggregateFacts, is_accessible as aggregate_is_accessible};
+use super::aggregate_resolution::is_accessible as aggregate_is_accessible;
 use super::analysis::{ElementwiseConsumption, FirstClassStrSite, linear_not_consumed_error};
 use super::anon_structs::{
     IssuedCanonicalArguments, IssuedFunctionInstanceKey, IssuedStableProducerId,
 };
-use super::call_resolution::CallResolutionFacts;
 use super::context::{AnalysisContext, ParamIndex, ParamInfo};
-use super::fact_mode::{BodyAnalysisHost, StructuredTypeSyntax, StructuredTypeSyntaxRequest};
+use super::fact_mode::{
+    ArrayLengthRequest, BodyAnalysisReadHost, ModulePrefixRequest, StructuredTypeSyntax,
+    StructuredTypeSyntaxRequest, TypeSyntaxResult,
+};
 use super::info::{FunctionCallInfo, MethodCallInfo};
 use super::{
     AnalyzedBodyOwnerEvent, AnalyzedFunction, BodyAnalysisWork, ConstInfo, ConstValue,
     DeclarationPhase, DeclarationTypeDependencyKind, DeclarationTypeDependencySourceKind,
     FunctionInfo, InferenceContext, KnownSymbols, MethodInfo, ParamSlotModes, StructId, Type,
 };
-use crate::inference::InferType;
+use crate::inference::{InferType, LazyInferenceFacts};
 use crate::inst::Air;
 use crate::inst::{AirInst, AirInstData};
 use crate::intern_pool::TypeInternPool;
@@ -78,7 +78,21 @@ pub(crate) struct ExpressionAnalysisBreakdown {
 /// covers the body authority, semantic overlays, and exact point facts needed
 /// by the ordinary expression engine. Transaction publication remains outside
 /// this extraction.
-pub(crate) trait OrdinaryBodyAnalysisHost: BodyAnalysisHost {
+pub(crate) trait OrdinaryBodyAnalysisHost: BodyAnalysisReadHost + Sized {
+    type InferenceFacts<'a>: LazyInferenceFacts
+    where
+        Self: 'a;
+    fn inference_facts<'a>(&'a self, ctx: &'a InferenceContext) -> Self::InferenceFacts<'a>;
+    fn resolve_structured_type_syntax(
+        &mut self,
+        request: StructuredTypeSyntaxRequest<'_>,
+    ) -> TypeSyntaxResult;
+    fn resolve_type_module_prefix(
+        &mut self,
+        request: ModulePrefixRequest<'_>,
+    ) -> CompileResult<(ModuleId, Option<FileId>, String)>;
+    fn resolve_array_length(&mut self, request: ArrayLengthRequest<'_>) -> CompileResult<u64>;
+
     fn record_expression_analysis_breakdown(&mut self, _breakdown: ExpressionAnalysisBreakdown) {}
 
     fn body_param_data(&self, range: ParamRange) -> ParamRangeData;
@@ -274,14 +288,10 @@ pub(crate) trait OrdinaryBodyAnalysisHost: BodyAnalysisHost {
     fn deferred_ownership_gates_mut(&mut self) -> &mut Vec<super::DeferredOwnershipGate>;
 }
 
-// Kept as a private source-compatibility alias while the remaining sema
-// adapters migrate to the receiver name. No engine code depends on a storage
-// object or exposes storage escape hatches.
-/// Generic ordinary-body engine facade over neutral body storage.
+/// Inherent-method receiver for the generic ordinary-body algorithm.
 ///
 /// The engine owns no analyzer representation and has no alternate semantic
-/// algorithm. Its accessors are the migration point used by the canonical
-/// ordinary engine as concrete `BodySema` state is moved behind this contract.
+/// algorithm. Both concrete hosts enter the same methods through this receiver.
 pub(crate) struct OrdinaryBodyEngine<'h, H: OrdinaryBodyAnalysisHost> {
     storage: &'h mut H,
 }
@@ -312,7 +322,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         self.storage.active_anonymous_producer()
     }
     pub(crate) fn function_info(&self, name: Spur) -> Option<FunctionCallInfo> {
-        self.storage.function_info(name)
+        OrdinaryBodyAnalysisHost::function_info(self.storage, name)
     }
     pub(crate) fn function_body_info(&self, name: Spur) -> Option<FunctionInfo> {
         self.storage.function_body_info(name)
@@ -324,22 +334,22 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         self.storage.function_identity(symbol)
     }
     pub(crate) fn value_const(&self, key: &(FileId, Spur)) -> Option<ConstInfo> {
-        self.storage.value_const(key.0, key.1)
+        OrdinaryBodyAnalysisHost::value_const(self.storage, key.0, key.1)
     }
     pub(crate) fn source_function_name(&self, name: Spur) -> Spur {
-        self.storage.source_function_name(name)
+        OrdinaryBodyAnalysisHost::source_function_name(self.storage, name)
     }
     pub(crate) fn resolve_function_name_local(&self, name: Spur, file: FileId) -> Option<Spur> {
-        self.storage.resolve_function_name_local(name, file)
+        OrdinaryBodyAnalysisHost::resolve_function_name_local(self.storage, name, file)
     }
     pub(crate) fn module_def(&self, module: ModuleId) -> ModuleDef {
-        self.storage.module_def(module)
+        OrdinaryBodyAnalysisHost::module_def(self.storage, module)
     }
     pub(crate) fn struct_in_file(&self, file: FileId, name: Spur) -> Option<StructId> {
-        self.storage.struct_in_file(file, name)
+        OrdinaryBodyAnalysisHost::struct_in_file(self.storage, file, name)
     }
     pub(crate) fn builtin_struct(&self, name: Spur) -> Option<StructId> {
-        self.storage.builtin_struct(name)
+        OrdinaryBodyAnalysisHost::builtin_struct(self.storage, name)
     }
     pub(crate) fn target(&self) -> Target {
         self.storage.target()
@@ -732,9 +742,21 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         type_substitutions: Option<&HashMap<Spur, Type>>,
         value_substitutions: Option<&HashMap<Spur, ConstValue>>,
     ) -> CompileResult<Type> {
-        let syntax = self.body_interner().resolve(&type_sym).to_owned();
+        let mut builder = rue_rir::RirTypeSyntaxBuilder::default();
+        let root = builder.push_named_type(type_sym).map_err(|failure| {
+            CompileError::new(
+                ErrorKind::InternalError(format!(
+                    "failed to preserve a resolved type-name token: {failure:?}"
+                )),
+                span,
+            )
+        })?;
+        let syntax = StructuredTypeSyntax {
+            arena: builder.finish(),
+            root,
+        };
         self.storage
-            .resolve_type_syntax(super::fact_mode::TypeSyntaxRequest {
+            .resolve_structured_type_syntax(StructuredTypeSyntaxRequest {
                 syntax: &syntax,
                 root_file,
                 span,
@@ -921,7 +943,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         span: Span,
         values: Option<&HashMap<Spur, ConstValue>>,
     ) -> CompileResult<u64> {
-        BodyAnalysisHost::resolve_array_length(
+        OrdinaryBodyAnalysisHost::resolve_array_length(
             self.storage,
             super::fact_mode::ArrayLengthRequest {
                 length,
@@ -936,7 +958,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         segments: &[&str],
         span: Span,
     ) -> CompileResult<(ModuleId, Option<FileId>, String)> {
-        BodyAnalysisHost::resolve_type_module_prefix(
+        OrdinaryBodyAnalysisHost::resolve_type_module_prefix(
             self.storage,
             super::fact_mode::ModulePrefixRequest {
                 root_file,
@@ -951,9 +973,25 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         segments: &[&str],
         span: Span,
     ) -> CompileResult<Type> {
-        let syntax = segments.join(".");
+        let symbols = segments
+            .iter()
+            .map(|segment| self.body_interner().get_or_intern(segment))
+            .collect::<Vec<_>>();
+        let mut builder = rue_rir::RirTypeSyntaxBuilder::default();
+        let root = builder.push_qualified_type(symbols).map_err(|failure| {
+            CompileError::new(
+                ErrorKind::InternalError(format!(
+                    "failed to preserve a qualified type path: {failure:?}"
+                )),
+                span,
+            )
+        })?;
+        let syntax = StructuredTypeSyntax {
+            arena: builder.finish(),
+            root,
+        };
         self.storage
-            .resolve_type_syntax(super::fact_mode::TypeSyntaxRequest {
+            .resolve_structured_type_syntax(StructuredTypeSyntaxRequest {
                 syntax: &syntax,
                 root_file,
                 span,
@@ -969,7 +1007,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             })
     }
     pub(crate) fn module_binding(&self, key: &(FileId, Spur)) -> Option<ConstInfo> {
-        self.call_facts().module_binding(key.0, key.1)
+        self.call_facts().call_module_binding(key.0, key.1)
     }
     pub(crate) fn known_linear_during_binding(&self, ty: Type) -> Option<bool> {
         self.storage.known_linear_during_binding(ty)
@@ -997,9 +1035,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
     ) -> Result<(IssuedStableProducerId, IssuedCanonicalArguments), crate::SemanticBodyExportFailure>
     {
         use crate::SemanticBodyExportFailure as F;
-        let function = self
-            .storage
-            .function_info(name)
+        let function = OrdinaryBodyAnalysisHost::function_info(self.storage, name)
             .ok_or(F::MissingStableIdentity)?;
         let flags = self.storage.comptime_type_param_flags(&function);
         let mut types = Vec::new();
@@ -1258,8 +1294,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
     pub(crate) fn types_equivalent(&self, left: Type, right: Type) -> bool {
         self.storage.types_equivalent(left, right)
     }
-    pub(crate) fn aggregate_facts(&self) -> H::AggregateFacts<'_> {
-        self.storage.aggregate_facts()
+    pub(crate) fn aggregate_facts(&self) -> &H {
+        self.storage
     }
     pub(crate) fn is_accessible(
         &self,
@@ -1268,7 +1304,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         is_pub: bool,
     ) -> bool {
         aggregate_is_accessible(
-            &self.aggregate_facts(),
+            self.aggregate_facts(),
             accessing_file_id,
             target_file_id,
             is_pub,
@@ -1287,7 +1323,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         }
         let defining_file = self
             .aggregate_facts()
-            .file_path(defining_file_id)
+            .aggregate_file_path(defining_file_id)
             .unwrap_or("<unknown>")
             .to_string();
         Err(CompileError::new(
@@ -1304,11 +1340,11 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             "`{name}` is not marked `pub`; private items are only visible within their defining directory"
         )))
     }
-    pub(crate) fn call_facts(&self) -> H::CallFacts<'_> {
-        self.storage.call_facts()
+    pub(crate) fn call_facts(&self) -> &H {
+        self.storage
     }
     pub(crate) fn method_info(&self, key: (StructId, Spur)) -> Option<MethodCallInfo> {
-        self.call_facts().method_info(key.0, key.1)
+        self.call_facts().call_method_info(key.0, key.1)
     }
     pub(crate) fn has_method(&self, key: (StructId, Spur)) -> bool {
         self.method_info(key).is_some()
@@ -1427,11 +1463,9 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             return None;
         };
         let def = self.body_type_pool().struct_def(struct_id);
-        let is_slice = def.name.starts_with('[')
-            && def.name.ends_with(']')
-            && crate::types::parse_array_type_syntax(&def.name).is_none();
-        let is_str_fixed = def.name.starts_with("Str(") && def.name.ends_with(')');
-        if is_slice || &*def.name == "str" || is_str_fixed {
+        if crate::types::is_slice_struct_name(&def.name)
+            || crate::types::is_string_view_struct_name(&def.name)
+        {
             if let crate::types::TypeKind::PtrConst(ptr_id) = def.fields[0].ty.kind() {
                 return Some(self.body_type_pool().ptr_const_def(ptr_id));
             }
@@ -2322,6 +2356,48 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
 }
 
 impl<'a, D: DeclarationPhase> OrdinaryBodyAnalysisHost for super::Sema<'a, D> {
+    type InferenceFacts<'b>
+        = super::HostInferenceFacts<'b, Self>
+    where
+        Self: 'b;
+
+    fn inference_facts<'b>(&'b self, ctx: &'b InferenceContext) -> Self::InferenceFacts<'b> {
+        super::HostInferenceFacts::new(ctx, self)
+    }
+
+    fn resolve_structured_type_syntax(
+        &mut self,
+        request: StructuredTypeSyntaxRequest<'_>,
+    ) -> TypeSyntaxResult {
+        self.resolve_structured_type_syntax_with_epoch_facts(
+            &request.syntax.arena,
+            request.syntax.root,
+            request.root_file,
+            request.span,
+            request.type_substitutions,
+            request.value_substitutions,
+        )
+    }
+
+    fn resolve_type_module_prefix(
+        &mut self,
+        request: ModulePrefixRequest<'_>,
+    ) -> CompileResult<(ModuleId, Option<FileId>, String)> {
+        self.resolve_type_module_prefix_with_epoch_facts(
+            request.root_file,
+            request.segments,
+            request.span,
+        )
+    }
+
+    fn resolve_array_length(&mut self, request: ArrayLengthRequest<'_>) -> CompileResult<u64> {
+        self.resolve_array_length_with_epoch_facts(
+            request.length,
+            request.span,
+            request.value_substitutions,
+        )
+    }
+
     fn body_param_data(&self, range: ParamRange) -> ParamRangeData {
         self.param_arena.copy_range(range)
     }

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -1,7 +1,7 @@
 //! Concrete body-local host for query-backed ordinary body evaluation.
 //!
 //! This receiver owns only body analysis's RIR and compact semantic state. Durable
-//! declaration facts are materialized through the provider facades as they are
+//! declaration facts are materialized through the provider-owned fact state as they are
 //! consulted; no declaration epoch or whole-program `Sema` is reachable here.
 
 use std::cell::{Cell, RefCell};
@@ -20,23 +20,20 @@ use rue_rir::{
 use rue_span::{FileId, Span};
 use rue_target::Target;
 
-use super::aggregate_resolution::{
-    AggregateFactSource, AggregateFacts as AggregateFactsTrait, EpochFacts as AggregateFacts,
-};
-use super::body_endpoint::{
-    BodyEndpointFactSource, BodyEndpointProvider, EpochFacts as EndpointFacts,
-};
-use super::call_resolution::{CallResolutionFactSource, EpochFacts as CallFacts};
-use super::fact_mode::{
-    ArrayLengthRequest, BodyAnalysisHost, ModulePrefixRequest, StructuredTypeSyntaxRequest,
-    TypeSyntaxRequest,
-};
+use super::aggregate_resolution::AggregateFacts as AggregateFactsTrait;
+use super::body_endpoint::BodyEndpointProvider;
+use super::call_resolution::CallResolutionFacts;
+use super::fact_mode::{ArrayLengthRequest, ModulePrefixRequest, StructuredTypeSyntaxRequest};
 use super::inference_ctx::{InferenceFactSource, InferenceGeneratedNominalOverlays};
 use super::info::{FunctionCallInfo, MethodCallInfo};
 use super::ordinary_engine::{
     ExpressionAnalysisBreakdown, OrdinaryBodyAnalysisHost, OrdinaryBodyEngine,
 };
 use super::semantic_body_export::SemanticBodyExportHost;
+use super::typeck::{
+    SemaTypeResolutionContext, TypeRootAuthority, TypeSyntaxHost, TypeSyntaxNamedKind,
+    TypeSyntaxProvider, semantic_type_syntax_compile_error,
+};
 use super::{
     AnalyzedFunction, BodyAnalysisWork, BodyFactProvider, ConstInfo, ConstValue,
     DeclarationTypeDependencyKind, DeclarationTypeDependencySourceKind, FunctionInfo,
@@ -47,7 +44,7 @@ use crate::inference::{FunctionSig, MethodSig};
 use crate::intern_pool::TypeInternPool;
 use crate::types::{ArrayTypeId, EnumId, ModuleDef, ModuleId, StructId, Type, TypeKind};
 use crate::{
-    ArrayLen, BodyRirBundle, CanonicalArgumentValue, DurableAnonymousSource, DurableCallableSource,
+    BodyRirBundle, CanonicalArgumentValue, DurableAnonymousSource, DurableCallableSource,
     DurableConstSource, DurableNominalSource, FunctionInstanceKey, ParamRange, ParamRangeData,
     SemanticDefinitionToken, SemanticModuleToken, TypeInstanceKey,
 };
@@ -1241,24 +1238,6 @@ where
         Some((body, declaration, instruction.span))
     }
 
-    fn is_accessible(
-        &self,
-        accessing_file: FileId,
-        defining_file: FileId,
-        is_public: bool,
-    ) -> bool {
-        if is_public || accessing_file == defining_file {
-            return true;
-        }
-        let domain = |file| {
-            self.source.source_path(file).map_or_else(
-                || AggregateFactsTrait::visibility_domain(&self.aggregate, file),
-                |path| crate::SemanticVisibilityDomain::from_file_path(Some(&path)),
-            )
-        };
-        domain(defining_file).is_visible_from(&domain(accessing_file), is_public)
-    }
-
     fn function_info_for_symbol(&self, symbol: Spur) -> Option<FunctionCallInfo> {
         if let Some(info) = self.function_infos.borrow().get(&symbol).copied() {
             return Some(info);
@@ -1266,7 +1245,7 @@ where
         if symbol == self.function_symbol {
             return self
                 .endpoint
-                .function_info(symbol)
+                .endpoint_function_info(symbol)
                 .map(FunctionCallInfo::from_body);
         }
         let (key, file, name) =
@@ -1818,10 +1797,10 @@ where
         if let Some(id) = self.generated_enums.get(&symbol) {
             return Some(Type::new_enum(*id));
         }
-        if let Some(id) = self.endpoint.builtin_or_generated_struct(symbol) {
+        if let Some(id) = self.endpoint.endpoint_builtin_or_generated_struct(symbol) {
             return Some(Type::new_struct(id));
         }
-        if let Some(id) = self.endpoint.builtin_enum(symbol) {
+        if let Some(id) = self.endpoint.endpoint_builtin_enum(symbol) {
             return Some(Type::new_enum(id));
         }
         let name = self.interner.resolve(&symbol);
@@ -2282,24 +2261,29 @@ where
         })
     }
 
+    fn materialize_durable_type(&mut self, ty: &crate::SemanticImportType<K, M>) -> Option<Type> {
+        self.register_import_nominal_identities(ty).ok()?;
+        let resolved = self
+            .state
+            .identity_context()
+            .pool_mut()?
+            .resolve_provider_type(ty)
+            .ok()?;
+        if let crate::SemanticImportType::AnonymousNominal(identity) = ty {
+            self.install_provider_anonymous_methods(identity, resolved)?;
+        }
+        Some(resolved)
+    }
+
     fn materialize_durable_const_value(
-        &self,
+        &mut self,
         value: &crate::SemanticImportConstValue<K, M>,
     ) -> Option<ConstValue> {
         use crate::SemanticImportConstValue as V;
         Some(match value {
             V::Integer(value) => ConstValue::Integer(*value),
             V::Bool(value) => ConstValue::Bool(*value),
-            V::Type(ty) => {
-                self.register_import_nominal_identities(ty).ok()?;
-                ConstValue::Type(
-                    self.state
-                        .identity_context()
-                        .pool_mut()?
-                        .resolve_provider_type(ty)
-                        .ok()?,
-                )
-            }
+            V::Type(ty) => ConstValue::Type(self.materialize_durable_type(ty)?),
             V::Function(definition) => ConstValue::Function(
                 self.interner
                     .get_or_intern(&self.source.definition_name(definition)?),
@@ -2793,7 +2777,7 @@ where
     }
 }
 
-impl<P, S, K, M> BodyEndpointFactSource for ProviderBodyHost<'_, P, S, K, M>
+impl<P, S, K, M> BodyEndpointProvider for ProviderBodyHost<'_, P, S, K, M>
 where
     P: BodyFactProvider,
     S: DurableNominalSource<K, M>
@@ -2805,19 +2789,19 @@ where
     M: Clone + Eq + Hash + Ord,
 {
     fn endpoint_name_symbol(&self, name: &str) -> Option<Spur> {
-        self.endpoint.name_symbol(name)
+        self.endpoint.endpoint_name_symbol(name)
     }
     fn endpoint_definition_endpoint(
         &self,
         token: SemanticDefinitionToken,
     ) -> Option<crate::SemanticDefinitionEndpoint> {
-        self.endpoint.definition_endpoint(token)
+        self.endpoint.endpoint_definition_endpoint(token)
     }
     fn endpoint_module_endpoint(
         &self,
         token: SemanticModuleToken,
     ) -> Option<crate::SemanticModuleEndpoint> {
-        self.endpoint.module_endpoint(token)
+        self.endpoint.endpoint_module_endpoint(token)
     }
     fn endpoint_function_by_file_name(&self, file: FileId, name: Spur) -> Option<Spur> {
         self.function_for_file_symbol(file, name)
@@ -2829,37 +2813,37 @@ where
         self.nominal_type_for_symbol(file, name)?.as_enum()
     }
     fn endpoint_builtin_or_generated_struct(&self, name: Spur) -> Option<StructId> {
-        self.endpoint.builtin_or_generated_struct(name)
+        self.endpoint.endpoint_builtin_or_generated_struct(name)
     }
     fn endpoint_generated_struct(&self, name: Spur) -> Option<StructId> {
-        self.endpoint.generated_struct(name)
+        self.endpoint.endpoint_generated_struct(name)
     }
     fn endpoint_builtin_enum(&self, name: Spur) -> Option<EnumId> {
-        self.endpoint.builtin_enum(name)
+        self.endpoint.endpoint_builtin_enum(name)
     }
     fn endpoint_anon_struct(
         &self,
         identity: &super::anon_structs::IssuedAnonymousNominalKey,
     ) -> Option<StructId> {
-        self.endpoint.anon_struct(identity)
+        self.endpoint.endpoint_anon_struct(identity)
     }
     fn endpoint_anon_enum(
         &self,
         identity: &super::anon_structs::IssuedAnonymousNominalKey,
     ) -> Option<EnumId> {
-        self.endpoint.anon_enum(identity)
+        self.endpoint.endpoint_anon_enum(identity)
     }
     fn endpoint_function_info(&self, name: Spur) -> Option<FunctionInfo> {
-        self.endpoint.function_info(name)
+        self.endpoint.endpoint_function_info(name)
     }
     fn endpoint_method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo> {
         self.endpoint.method_info(struct_id, name)
     }
     fn endpoint_source_function_name(&self, name: Spur) -> Spur {
-        self.endpoint.source_function_name(name)
+        self.endpoint.endpoint_source_function_name(name)
     }
     fn endpoint_module_id_for_file(&self, file: u32) -> Option<ModuleId> {
-        self.endpoint.module_id_for_file(file)
+        self.endpoint.endpoint_module_id_for_file(file)
     }
     fn endpoint_intern_array(&self, element: Type, len: u64) -> Option<Type> {
         self.type_pool.try_intern_array(element, len).ok()
@@ -2872,7 +2856,7 @@ where
     }
 }
 
-impl<P, S, K, M> CallResolutionFactSource for ProviderBodyHost<'_, P, S, K, M>
+impl<P, S, K, M> CallResolutionFacts for ProviderBodyHost<'_, P, S, K, M>
 where
     P: BodyFactProvider,
     S: DurableNominalSource<K, M>
@@ -2890,7 +2874,7 @@ where
         self.function_info_for_symbol(name).is_some()
     }
     fn call_source_function_name(&self, name: Spur) -> Spur {
-        self.endpoint.source_function_name(name)
+        self.endpoint.endpoint_source_function_name(name)
     }
     fn call_resolve_function_name_local(&self, name: Spur, file: FileId) -> Option<Spur> {
         self.function_for_file_symbol(file, name)
@@ -2926,7 +2910,7 @@ where
     }
 }
 
-impl<P, S, K, M> AggregateFactSource for ProviderBodyHost<'_, P, S, K, M>
+impl<P, S, K, M> AggregateFactsTrait for ProviderBodyHost<'_, P, S, K, M>
 where
     P: BodyFactProvider,
     S: DurableNominalSource<K, M>
@@ -2950,26 +2934,26 @@ where
         self.nominal_type_for_symbol(file, name)?.as_enum()
     }
     fn aggregate_builtin_struct(&self, name: Spur) -> Option<StructId> {
-        AggregateFactsTrait::builtin_struct(&self.aggregate, name)
+        AggregateFactsTrait::aggregate_builtin_struct(&self.aggregate, name)
     }
     fn aggregate_builtin_enum(&self, name: Spur) -> Option<EnumId> {
-        AggregateFactsTrait::builtin_enum(&self.aggregate, name)
+        AggregateFactsTrait::aggregate_builtin_enum(&self.aggregate, name)
     }
     fn aggregate_module(
         &self,
         module: ModuleId,
     ) -> super::aggregate_resolution::AggregateModuleFact {
-        AggregateFactsTrait::module(&self.aggregate, module)
+        AggregateFactsTrait::aggregate_module(&self.aggregate, module)
     }
     fn aggregate_file_path(&self, file: FileId) -> Option<&str> {
-        AggregateFactsTrait::file_path(&self.aggregate, file)
+        AggregateFactsTrait::aggregate_file_path(&self.aggregate, file)
     }
     fn aggregate_source_path(&self, span: Span) -> Option<&str> {
-        AggregateFactsTrait::source_path(&self.aggregate, span)
+        AggregateFactsTrait::aggregate_source_path(&self.aggregate, span)
     }
     fn aggregate_visibility_domain(&self, file: FileId) -> crate::SemanticVisibilityDomain {
         self.source.source_path(file).map_or_else(
-            || AggregateFactsTrait::visibility_domain(&self.aggregate, file),
+            || AggregateFactsTrait::aggregate_visibility_domain(&self.aggregate, file),
             |path| crate::SemanticVisibilityDomain::from_file_path(Some(&path)),
         )
     }
@@ -3075,7 +3059,7 @@ where
     }
     fn inference_builtin_struct_type(&self, name: Spur) -> Option<Type> {
         self.endpoint
-            .builtin_or_generated_struct(name)
+            .endpoint_builtin_or_generated_struct(name)
             .map(Type::new_struct)
     }
     fn inference_struct_type_by_file(&self, key: (FileId, Spur)) -> Option<Type> {
@@ -3083,7 +3067,9 @@ where
             .filter(|ty| ty.as_struct().is_some())
     }
     fn inference_builtin_enum_type(&self, name: Spur) -> Option<Type> {
-        self.endpoint.builtin_enum(name).map(Type::new_enum)
+        self.endpoint
+            .endpoint_builtin_enum(name)
+            .map(Type::new_enum)
     }
     fn inference_enum_type_by_file(&self, key: (FileId, Spur)) -> Option<Type> {
         self.nominal_type_for_symbol(key.0, key.1)
@@ -3122,7 +3108,7 @@ where
     }
 }
 
-impl<P, S, K, M> BodyAnalysisHost for ProviderBodyHost<'_, P, S, K, M>
+impl<P, S, K, M> TypeSyntaxHost for ProviderBodyHost<'_, P, S, K, M>
 where
     P: BodyFactProvider,
     S: DurableNominalSource<K, M>
@@ -3133,200 +3119,365 @@ where
     K: Clone + Eq + Hash + Ord,
     M: Clone + Eq + Hash + Ord,
 {
-    type EndpointFacts<'b>
-        = EndpointFacts<'b, Self>
-    where
-        Self: 'b;
-    fn endpoint_facts(&self) -> Self::EndpointFacts<'_> {
-        EndpointFacts::new(self)
+    fn type_syntax_symbol(&mut self, name: &str) -> Spur {
+        self.interner.get_or_intern(name)
     }
 
-    type CallFacts<'b>
-        = CallFacts<'b, Self>
-    where
-        Self: 'b;
-    fn call_facts(&self) -> Self::CallFacts<'_> {
-        CallFacts::new(self)
+    fn existing_type_syntax_symbol(&self, name: &str) -> Option<Spur> {
+        self.interner.get(name)
     }
 
-    type AggregateFacts<'b>
-        = AggregateFacts<'b, Self>
-    where
-        Self: 'b;
-    fn aggregate_facts(&self) -> Self::AggregateFacts<'_> {
-        AggregateFacts::new(self)
-    }
-
-    type InferenceFacts<'b>
-        = HostInferenceFacts<'b, Self>
-    where
-        Self: 'b;
-    fn inference_facts<'b>(&'b self, ctx: &'b InferenceContext) -> Self::InferenceFacts<'b> {
-        HostInferenceFacts::new(ctx, self)
-    }
-
-    fn resolve_type_syntax(
+    fn type_syntax_module_binding(
         &mut self,
-        request: TypeSyntaxRequest<'_>,
-    ) -> Result<
-        Type,
-        crate::SemanticTypeSyntaxError<std::convert::Infallible, CompileError, FileId, Spur>,
-    > {
-        fn recurse<P, S, K, M>(
-            host: &mut ProviderBodyHost<'_, P, S, K, M>,
-            syntax: &str,
-            root_file: FileId,
-            span: Span,
-            type_substitutions: Option<&HashMap<Spur, Type>>,
-            value_substitutions: Option<&HashMap<Spur, ConstValue>>,
-        ) -> CompileResult<Type>
-        where
-            P: BodyFactProvider,
-            S: DurableNominalSource<K, M>
-                + DurableAnonymousSource<K, M>
-                + DurableCallableSource<K, M>
-                + DurableConstSource<K, M>
-                + DurableBodyLookupSource<K, M>,
-            K: Clone + Eq + Hash + Ord,
-            M: Clone + Eq + Hash + Ord,
-        {
-            if let Some(substitutions) = type_substitutions {
-                let symbol = host.interner.get_or_intern(syntax);
-                if let Some(ty) = substitutions.get(&symbol) {
-                    return Ok(*ty);
-                }
-            }
-            if let Some((callee, arguments)) = crate::types::parse_type_call_syntax(syntax) {
-                return host.resolve_type_constructor_call(
-                    &callee,
-                    &arguments,
-                    syntax,
-                    root_file,
-                    span,
-                    type_substitutions,
-                    value_substitutions,
-                );
-            }
-            if let Some((element, length)) = crate::types::parse_array_type_syntax(syntax) {
-                let element = recurse(
-                    host,
-                    &element,
-                    root_file,
-                    span,
-                    type_substitutions,
-                    value_substitutions,
-                )?;
-                let length = host.resolve_array_length_in_file(
-                    &length,
-                    root_file,
-                    span,
-                    value_substitutions,
-                )?;
-                return host
-                    .type_pool
-                    .try_intern_array(element, length)
-                    .map_err(|failure| {
-                        CompileError::new(
-                            rue_error::ErrorKind::UnknownType(format!("{syntax}: {failure:?}")),
-                            span,
-                        )
-                    });
-            }
-            if let Some((pointee, mutability)) = crate::types::parse_pointer_type_syntax(syntax) {
-                let pointee = recurse(
-                    host,
-                    &pointee,
-                    root_file,
-                    span,
-                    type_substitutions,
-                    value_substitutions,
-                )?;
-                return match mutability {
-                    crate::types::PtrMutability::Const => {
-                        host.type_pool.try_intern_ptr_const(pointee)
-                    }
-                    crate::types::PtrMutability::Mut => host.type_pool.try_intern_ptr_mut(pointee),
-                }
-                .map_err(|failure| {
-                    CompileError::new(
-                        rue_error::ErrorKind::UnknownType(format!("{syntax}: {failure:?}")),
-                        span,
-                    )
-                });
-            }
-            host.resolve_type_name_in_file(syntax, root_file, span)
-        }
-        recurse(
-            self,
-            request.syntax,
-            request.root_file,
-            request.span,
-            request.type_substitutions,
-            request.value_substitutions,
-        )
-        .map_err(crate::SemanticResolutionError::ProviderFailure)
+        authority: TypeRootAuthority,
+        module: Option<ModuleId>,
+        name: Spur,
+    ) -> CompileResult<Option<crate::SemanticModuleBinding<ModuleId, FileId>>> {
+        let file = module
+            .and_then(|module| {
+                self.calls
+                    .module_def(module)
+                    .map(|definition| definition.file_id)
+            })
+            .unwrap_or_else(|| authority.file());
+        let Some(binding) = self.module_binding_for_symbol(file, name) else {
+            return Ok(None);
+        };
+        let Some(target) = binding.ty.as_module() else {
+            return Ok(None);
+        };
+        let defining_file = binding.span.file_id;
+        let defining_path = self
+            .source
+            .source_path(defining_file)
+            .unwrap_or_else(|| Arc::from("<unknown>"));
+        Ok(Some(crate::SemanticModuleBinding {
+            target,
+            site: defining_file,
+            is_public: binding.is_pub,
+            defining_domain: crate::SemanticVisibilityDomain::from_file_path(Some(
+                defining_path.as_ref(),
+            )),
+            defining_file: defining_path,
+        }))
     }
-    fn resolve_structured_type_syntax(
-        &mut self,
-        request: StructuredTypeSyntaxRequest<'_>,
-    ) -> Result<
-        Type,
-        crate::SemanticTypeSyntaxError<std::convert::Infallible, CompileError, FileId, Spur>,
-    > {
-        self.resolve_rir_type_syntax_in_arena(
-            &request.syntax.arena,
-            request.syntax.root,
-            request.root_file,
-            request.span,
-            request.type_substitutions,
-            request.value_substitutions,
-        )
-        .map_err(crate::SemanticResolutionError::ProviderFailure)
+
+    fn type_syntax_module_display_name(&self, module: ModuleId) -> Arc<str> {
+        self.calls
+            .module_def(module)
+            .map(|definition| Arc::from(definition.import_path.as_str()))
+            .unwrap_or_else(|| Arc::from("<unknown module>"))
     }
-    fn resolve_type_module_prefix(
+
+    fn type_syntax_accessing_domain(
+        &self,
+        authority: TypeRootAuthority,
+    ) -> crate::SemanticVisibilityDomain {
+        let path = self.source.source_path(authority.file());
+        crate::SemanticVisibilityDomain::from_file_path(path.as_deref())
+    }
+
+    fn type_syntax_named_type(
         &mut self,
-        request: ModulePrefixRequest<'_>,
-    ) -> CompileResult<(ModuleId, Option<FileId>, String)> {
-        let mut file = request.root_file;
-        let mut module = None;
-        for segment in request.segments {
-            let symbol = self.interner.get_or_intern(segment);
-            let Some(binding) = self.module_binding_for_symbol(file, symbol) else {
-                return Err(CompileError::new(
-                    rue_error::ErrorKind::UnknownType(request.segments.join(".")),
-                    request.span,
-                ));
-            };
-            let Some(id) = binding.ty.as_module() else {
-                return Err(CompileError::new(
-                    rue_error::ErrorKind::UnknownType(request.segments.join(".")),
-                    request.span,
-                ));
-            };
-            let def = self.calls.module_def(id).ok_or_else(|| {
+        authority: TypeRootAuthority,
+        module: Option<ModuleId>,
+        name: Spur,
+        kind: TypeSyntaxNamedKind,
+    ) -> CompileResult<Option<crate::SemanticTypeFact<Type, FileId>>> {
+        let file = module
+            .and_then(|module| {
+                self.calls
+                    .module_def(module)
+                    .map(|definition| definition.file_id)
+            })
+            .unwrap_or_else(|| authority.file());
+        let selected = match kind {
+            TypeSyntaxNamedKind::Struct => self
+                .nominal_type_for_symbol(file, name)
+                .filter(|ty| ty.as_struct().is_some())
+                .map(|ty| {
+                    let metadata = self
+                        .type_pool
+                        .struct_metadata(ty.as_struct().expect("checked struct type"))
+                        .expect("provider struct type has registered metadata");
+                    (ty, metadata.file_id, metadata.is_pub)
+                }),
+            TypeSyntaxNamedKind::Enum => self
+                .nominal_type_for_symbol(file, name)
+                .filter(|ty| ty.as_enum().is_some())
+                .map(|ty| {
+                    let metadata = self
+                        .type_pool
+                        .enum_metadata(ty.as_enum().expect("checked enum type"))
+                        .expect("provider enum type has registered metadata");
+                    (ty, metadata.file_id, metadata.is_pub)
+                }),
+            TypeSyntaxNamedKind::Alias => {
+                self.const_info_for_symbol(file, name)
+                    .and_then(|info| match info.value {
+                        ConstValue::Type(ty) => Some((ty, info.span.file_id, info.is_pub)),
+                        _ => None,
+                    })
+            }
+        };
+        let Some((value, site, is_public)) = selected else {
+            return Ok(None);
+        };
+        let defining_file = self
+            .source
+            .source_path(site)
+            .unwrap_or_else(|| Arc::from("<unknown>"));
+        Ok(Some(crate::SemanticTypeFact {
+            value,
+            site,
+            is_public,
+            defining_domain: crate::SemanticVisibilityDomain::from_file_path(Some(
+                defining_file.as_ref(),
+            )),
+            defining_file,
+        }))
+    }
+
+    fn type_syntax_make_str(&mut self, span: Span) -> CompileResult<Type> {
+        let name = self.interner.get_or_intern("str");
+        self.nominal_type_for_symbol(span.file_id, name)
+            .filter(|ty| ty.as_struct().is_some())
+            .ok_or_else(|| {
+                CompileError::new(rue_error::ErrorKind::UnknownType("str".to_owned()), span)
+            })
+    }
+
+    fn type_syntax_make_array(
+        &mut self,
+        element: Type,
+        length: u64,
+        span: Span,
+    ) -> CompileResult<Type> {
+        self.type_pool
+            .try_intern_array(element, length)
+            .map_err(|failure| {
                 CompileError::new(
-                    rue_error::ErrorKind::UnknownType(request.segments.join(".")),
-                    request.span,
+                    rue_error::ErrorKind::UnknownType(format!("array type: {failure:?}")),
+                    span,
+                )
+            })
+    }
+
+    fn type_syntax_make_ptr_const(&mut self, pointee: Type, span: Span) -> CompileResult<Type> {
+        self.type_pool
+            .try_intern_ptr_const(pointee)
+            .map_err(|failure| {
+                CompileError::new(
+                    rue_error::ErrorKind::UnknownType(format!("pointer type: {failure:?}")),
+                    span,
+                )
+            })
+    }
+
+    fn type_syntax_make_ptr_mut(&mut self, pointee: Type, span: Span) -> CompileResult<Type> {
+        self.type_pool
+            .try_intern_ptr_mut(pointee)
+            .map_err(|failure| {
+                CompileError::new(
+                    rue_error::ErrorKind::UnknownType(format!("pointer type: {failure:?}")),
+                    span,
+                )
+            })
+    }
+
+    fn type_syntax_require_slices(&mut self, span: Span) -> CompileResult<()> {
+        self.require_preview(
+            rue_error::PreviewFeature::Slices,
+            "the slice type `[T]`",
+            span,
+        )
+    }
+
+    fn type_syntax_make_slice(
+        &mut self,
+        syntax: &str,
+        element: Type,
+        span: Span,
+    ) -> CompileResult<Type> {
+        let durable = self.durable_type_from_concrete(element).ok_or_else(|| {
+            CompileError::new(rue_error::ErrorKind::UnknownType(syntax.to_owned()), span)
+        })?;
+        let id = self
+            .endpoint
+            .register_generated_slice(&durable, syntax)
+            .ok_or_else(|| {
+                CompileError::new(rue_error::ErrorKind::UnknownType(syntax.to_owned()), span)
+            })?;
+        Ok(Type::new_struct(id))
+    }
+
+    fn type_syntax_make_fixed_str(&mut self, capacity: u64, span: Span) -> CompileResult<Type> {
+        let id = self
+            .endpoint
+            .register_generated_fixed_string(capacity)
+            .ok_or_else(|| {
+                CompileError::new(
+                    rue_error::ErrorKind::UnknownType(format!("Str({capacity})")),
+                    span,
                 )
             })?;
-            file = def.file_id;
-            module = Some((id, def.file_path));
-        }
-        let (module, path) = module.ok_or_else(|| {
-            CompileError::new(
-                rue_error::ErrorKind::UnknownType(request.segments.join(".")),
-                request.span,
-            )
-        })?;
-        Ok((module, Some(file), path))
+        self.generated_structs
+            .insert(self.interner.get_or_intern(&format!("Str({capacity})")), id);
+        Ok(Type::new_struct(id))
     }
-    fn resolve_array_length(&mut self, request: ArrayLengthRequest<'_>) -> CompileResult<u64> {
-        self.resolve_array_length_in_file(
-            request.length,
-            request.span.file_id,
-            request.span,
-            request.value_substitutions,
-        )
+
+    fn type_syntax_record_builtin_call(&mut self) {}
+
+    fn type_syntax_constructor(
+        &mut self,
+        authority: TypeRootAuthority,
+        module: Option<ModuleId>,
+        name: Spur,
+    ) -> CompileResult<Option<crate::SemanticTypeConstructorHead<Spur, Spur, FileId>>> {
+        let file = module
+            .and_then(|module| {
+                self.calls
+                    .module_def(module)
+                    .map(|definition| definition.file_id)
+            })
+            .unwrap_or_else(|| authority.file());
+        let Some(symbol) = self.function_for_file_symbol(file, name) else {
+            return Ok(None);
+        };
+        let Some((_, definition)) = self.function_token_for_symbol(symbol) else {
+            return Ok(None);
+        };
+        let Some(signature) = DurableCallableSource::function(&self.source, &definition) else {
+            return Ok(None);
+        };
+        let site = self
+            .source
+            .definition_source(&definition)
+            .map_or(file, |locator| locator.file_id);
+        let defining_file = self
+            .source
+            .source_path(site)
+            .unwrap_or_else(|| Arc::from("<unknown>"));
+        let parameters = signature
+            .parameters
+            .iter()
+            .map(|parameter| crate::SemanticTypeConstructorParameter {
+                name: self.interner.get_or_intern(parameter.name.as_ref()),
+                is_comptime: parameter.is_comptime,
+                is_type: matches!(parameter.ty, crate::SemanticImportType::ComptimeType),
+            })
+            .collect::<Vec<_>>();
+        Ok(Some(crate::SemanticTypeConstructorHead {
+            key: symbol,
+            site,
+            parameters: parameters.into(),
+            returns_type: self.callable_returns_type(&signature, signature.type_syntax.as_ref()),
+            is_public: signature.is_public,
+            defining_domain: crate::SemanticVisibilityDomain::from_file_path(Some(
+                defining_file.as_ref(),
+            )),
+            defining_file,
+        }))
+    }
+
+    fn type_syntax_reduce_constructor(
+        &mut self,
+        head: &crate::SemanticTypeConstructorHead<Spur, Spur, FileId>,
+        type_arguments: &[(Spur, Type)],
+        value_arguments: &[(Spur, ConstValue)],
+        span: Span,
+    ) -> CompileResult<Option<ConstValue>> {
+        let Some((_, definition)) = self.function_token_for_symbol(head.key) else {
+            return Ok(None);
+        };
+        let mut durable_types = Vec::with_capacity(type_arguments.len());
+        for &(name, value) in type_arguments {
+            let Some(value) = self.durable_type_from_concrete(value) else {
+                return Ok(None);
+            };
+            durable_types.push((Arc::from(self.interner.resolve(&name)), value));
+        }
+        let mut durable_values = Vec::with_capacity(value_arguments.len());
+        for &(name, value) in value_arguments {
+            let Some(value) = self.durable_value_from_concrete(value) else {
+                return Ok(None);
+            };
+            durable_values.push((Arc::from(self.interner.resolve(&name)), value));
+        }
+        let reduced =
+            match self
+                .source
+                .reduce_comptime_call(&definition, &durable_types, &durable_values)
+            {
+                DurableComptimeCallOutcome::Reduced(reduced) => reduced,
+                DurableComptimeCallOutcome::NotReduced => return Ok(None),
+                DurableComptimeCallOutcome::Diagnostic(diagnostic) => {
+                    return Err(CompileError::new(
+                        diagnostic.kind,
+                        diagnostic.span.unwrap_or(span),
+                    ));
+                }
+            };
+        let value = match reduced.result {
+            crate::SemanticComptimeCallResult::Type(ty) => {
+                crate::SemanticImportConstValue::Type(ty)
+            }
+            crate::SemanticComptimeCallResult::Value(value) => value,
+        };
+        Ok(self.materialize_durable_const_value(&value))
+    }
+
+    fn type_syntax_value_const(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
+        self.const_info_for_symbol(file, name)
+    }
+
+    fn type_syntax_recover_const(
+        &mut self,
+        file: FileId,
+        name: Spur,
+    ) -> CompileResult<Option<ConstValue>> {
+        Ok(self
+            .const_info_for_symbol(file, name)
+            .map(|info| info.value))
+    }
+
+    fn type_syntax_record_named_const_dependency(&mut self, _file: FileId, _name: String) {}
+
+    fn type_syntax_out_of_scope_const_hint(&self, name: Spur, _exclude: FileId) -> String {
+        let mut paths = self
+            .source
+            .out_of_scope_integer_const_paths(&self.key, self.interner.resolve(&name));
+        paths.sort_unstable();
+        paths.dedup();
+        if paths.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "; an integer constant of that name is declared in {} — import that module and bind a file-level `const` (for example `const {}: i32 = <module>.{};`) to use it as an array length here",
+                paths
+                    .iter()
+                    .map(AsRef::as_ref)
+                    .collect::<Vec<&str>>()
+                    .join(", "),
+                self.interner.resolve(&name),
+                self.interner.resolve(&name),
+            )
+        }
+    }
+
+    fn type_syntax_dependencies(
+        &self,
+        _ty: Type,
+    ) -> Vec<(FileId, String, super::DeclarationTypeDependencyTargetKind)> {
+        Vec::new()
+    }
+
+    fn type_syntax_flush_dependency(
+        &mut self,
+        _file: FileId,
+        _name: String,
+        _kind: super::DeclarationTypeDependencyTargetKind,
+    ) {
     }
 }
 
@@ -3356,1224 +3507,6 @@ where
             &self.preview,
         )
     }
-
-    fn resolve_array_length_in_file(
-        &mut self,
-        length: &ArrayLen,
-        root_file: FileId,
-        span: Span,
-        value_substitutions: Option<&HashMap<Spur, ConstValue>>,
-    ) -> CompileResult<u64> {
-        let invalid =
-            |reason| CompileError::new(rue_error::ErrorKind::InvalidArrayLength { reason }, span);
-        let ArrayLen::Named(name) = length else {
-            let ArrayLen::Literal(value) = length else {
-                unreachable!()
-            };
-            return Ok(*value);
-        };
-        if let Some((callee, arguments)) = crate::types::parse_type_call_syntax(name) {
-            if !callee.contains('.')
-                && let Some(definition) = self.source.free_function(&self.key, &callee)
-                && let Some(signature) = DurableCallableSource::function(&self.source, &definition)
-                && (signature.parameters.len() != arguments.len()
-                    || signature
-                        .parameters
-                        .iter()
-                        .any(|parameter| !parameter.is_comptime))
-            {
-                return Err(invalid(format!(
-                    "array length call '{callee}(...)' is not a compile-time constant; its callee must be a value-returning function whose parameters are all `comptime`"
-                )));
-            }
-            let reduced = self
-                .reduce_comptime_constructor_call(
-                    &callee,
-                    &arguments,
-                    name,
-                    root_file,
-                    span,
-                    None,
-                    value_substitutions,
-                )
-                .map_err(|error| match error.kind {
-                    rue_error::ErrorKind::ComptimeArgNotConst { .. } => invalid(format!(
-                        "array length call '{callee}(...)' is not a compile-time constant; its callee must be a value-returning function whose parameters are all `comptime`"
-                    )),
-                    _ => invalid(format!(
-                        "'{callee}' is not a function; array lengths must be an integer literal, a `const`, a `comptime` value parameter, or a call to a comptime function"
-                    )),
-                })?;
-            return match reduced.result {
-                crate::SemanticComptimeCallResult::Value(
-                    crate::SemanticImportConstValue::Integer(value),
-                ) if value >= 0 => u64::try_from(value).map_err(|_| {
-                    invalid(format!(
-                        "array length '{callee}(...)' ({value}) is too large"
-                    ))
-                }),
-                crate::SemanticComptimeCallResult::Value(
-                    crate::SemanticImportConstValue::Integer(value),
-                ) => Err(invalid(format!(
-                    "array length '{callee}(...)' is negative ({value})"
-                ))),
-                _ => Err(invalid(format!(
-                    "array length call '{callee}(...)' did not evaluate to a compile-time integer"
-                ))),
-            };
-        }
-        let symbol = self.interner.get_or_intern(name);
-        let value = value_substitutions
-            .and_then(|values| values.get(&symbol))
-            .copied()
-            .or_else(|| {
-                self.call_value_const(root_file, symbol)
-                    .map(|info| info.value)
-            });
-        match value {
-            Some(ConstValue::Integer(value)) if value >= 0 => u64::try_from(value)
-                .map_err(|_| invalid(format!("array length '{name}' ({value}) is too large"))),
-            Some(ConstValue::Integer(value)) => Err(invalid(format!(
-                "array length '{name}' is negative ({value})"
-            ))),
-            Some(_) => Err(invalid(format!("array length '{name}' is not an integer"))),
-            None => {
-                let mut paths = self
-                    .source
-                    .out_of_scope_integer_const_paths(&self.key, name);
-                paths.sort_unstable();
-                paths.dedup();
-                let hint = if paths.is_empty() {
-                    String::new()
-                } else {
-                    format!(
-                        "; an integer constant of that name is declared in {} — import that module and bind a file-level `const` (for example `const {name}: i32 = <module>.{name};`) to use it as an array length here",
-                        paths
-                            .iter()
-                            .map(AsRef::as_ref)
-                            .collect::<Vec<&str>>()
-                            .join(", ")
-                    )
-                };
-                Err(invalid(format!(
-                    "'{name}' is not a compile-time constant; array lengths must be an integer literal, a `const`, or a `comptime` value parameter{hint}"
-                )))
-            }
-        }
-    }
-
-    fn resolve_rir_type_syntax(
-        &mut self,
-        syntax: RirTypeSyntaxRef,
-        span: Span,
-        type_substitutions: Option<&HashMap<Spur, Type>>,
-        value_substitutions: Option<&HashMap<Spur, ConstValue>>,
-    ) -> CompileResult<Type> {
-        let arena = self.rir.rir().type_syntax().clone();
-        self.resolve_rir_type_syntax_in_arena(
-            &arena,
-            syntax,
-            span.file_id,
-            span,
-            type_substitutions,
-            value_substitutions,
-        )
-    }
-
-    fn resolve_rir_type_syntax_in_arena(
-        &mut self,
-        arena: &rue_rir::RirTypeSyntaxArena<Spur>,
-        syntax: RirTypeSyntaxRef,
-        root_file: FileId,
-        span: Span,
-        type_substitutions: Option<&HashMap<Spur, Type>>,
-        value_substitutions: Option<&HashMap<Spur, ConstValue>>,
-    ) -> CompileResult<Type> {
-        use rue_rir::RirTypeSyntaxNode as N;
-
-        // Successful structured resolution must not reconstruct the spelling it
-        // replaced. Besides being unnecessary, rendering here made a nested
-        // type render each of its subtrees again during recursive resolution.
-        // Keep spelling reconstruction on the diagnostic path only.
-        let Some(node) = arena.node(syntax).cloned() else {
-            return Err(self.rir_type_unknown_error(arena, syntax, span));
-        };
-        match node {
-            N::Named(symbol) => {
-                let Some(symbol) = arena.symbol(symbol).copied() else {
-                    return Err(self.rir_type_unknown_error(arena, syntax, span));
-                };
-                if let Some(ty) = type_substitutions.and_then(|values| values.get(&symbol)) {
-                    return Ok(*ty);
-                }
-                self.resolve_named_type_symbol_in_file(symbol, root_file, span)
-            }
-            N::Qualified { path } => {
-                let Some(words) = arena.words(path) else {
-                    return Err(self.rir_type_unknown_error(arena, syntax, span));
-                };
-                let mut segments = Vec::with_capacity(words.len());
-                for word in words {
-                    let Some(symbol) = arena.symbol(rue_rir::RirTypeSyntaxSymbol::from_u32(*word))
-                    else {
-                        return Err(self.rir_type_unknown_error(arena, syntax, span));
-                    };
-                    segments.push(*symbol);
-                }
-                self.resolve_qualified_rir_type(&segments, root_file)
-                    .ok_or_else(|| self.rir_type_unknown_error(arena, syntax, span))
-            }
-            N::Unit => Ok(Type::UNIT),
-            N::Never => Ok(Type::NEVER),
-            N::Array { element, length } => {
-                let element = self.resolve_rir_type_syntax_in_arena(
-                    arena,
-                    element,
-                    root_file,
-                    span,
-                    type_substitutions,
-                    value_substitutions,
-                )?;
-                let length = self.resolve_rir_array_length(
-                    arena,
-                    length,
-                    root_file,
-                    span,
-                    type_substitutions,
-                    value_substitutions,
-                )?;
-                self.type_pool
-                    .try_intern_array(element, length)
-                    .map_err(|failure| {
-                        CompileError::new(
-                            rue_error::ErrorKind::UnknownType(format!(
-                                "{}: {failure:?}",
-                                self.rir_type_display(arena, syntax)
-                            )),
-                            span,
-                        )
-                    })
-            }
-            N::Slice { element } => {
-                self.require_preview(
-                    rue_error::PreviewFeature::Slices,
-                    "the slice type `[T]`",
-                    span,
-                )?;
-                let element = self.resolve_rir_type_syntax_in_arena(
-                    arena,
-                    element,
-                    root_file,
-                    span,
-                    type_substitutions,
-                    value_substitutions,
-                )?;
-                let durable = self
-                    .durable_type_from_concrete(element)
-                    .ok_or_else(|| self.rir_type_unknown_error(arena, syntax, span))?;
-                let spelling = self.rir_type_display(arena, syntax);
-                let id = self
-                    .endpoint
-                    .register_generated_slice(&durable, &spelling)
-                    .ok_or_else(|| self.rir_type_unknown_error(arena, syntax, span))?;
-                Ok(Type::new_struct(id))
-            }
-            N::PointerConst { pointee } | N::PointerMut { pointee } => {
-                let is_mut = matches!(arena.node(syntax), Some(N::PointerMut { .. }));
-                let pointee = self.resolve_rir_type_syntax_in_arena(
-                    arena,
-                    pointee,
-                    root_file,
-                    span,
-                    type_substitutions,
-                    value_substitutions,
-                )?;
-                if is_mut {
-                    self.type_pool.try_intern_ptr_mut(pointee)
-                } else {
-                    self.type_pool.try_intern_ptr_const(pointee)
-                }
-                .map_err(|failure| {
-                    CompileError::new(
-                        rue_error::ErrorKind::UnknownType(format!(
-                            "{}: {failure:?}",
-                            self.rir_type_display(arena, syntax)
-                        )),
-                        span,
-                    )
-                })
-            }
-            N::TypeCall { path, arguments } => self.resolve_rir_type_constructor_call(
-                arena,
-                syntax,
-                path,
-                arguments,
-                root_file,
-                span,
-                type_substitutions,
-                value_substitutions,
-            ),
-            N::AnonymousStruct { .. }
-            | N::AnonymousEnum { .. }
-            | N::ValueCall { .. }
-            | N::Integer(_) => Err(self.rir_type_unknown_error(arena, syntax, span)),
-        }
-    }
-
-    fn rir_type_display(
-        &self,
-        arena: &rue_rir::RirTypeSyntaxArena<Spur>,
-        syntax: RirTypeSyntaxRef,
-    ) -> String {
-        arena
-            .render_type_with(syntax, |symbol| self.interner.resolve(symbol))
-            .unwrap_or_else(|| "<invalid structured type syntax>".to_owned())
-    }
-
-    fn rir_type_unknown_error(
-        &self,
-        arena: &rue_rir::RirTypeSyntaxArena<Spur>,
-        syntax: RirTypeSyntaxRef,
-        span: Span,
-    ) -> CompileError {
-        CompileError::new(
-            rue_error::ErrorKind::UnknownType(self.rir_type_display(arena, syntax)),
-            span,
-        )
-    }
-
-    fn resolve_qualified_rir_type(&mut self, segments: &[Spur], root_file: FileId) -> Option<Type> {
-        let (leaf, prefix) = segments.split_last()?;
-        let mut file = root_file;
-        for segment in prefix {
-            let binding = self.module_binding_for_symbol(file, *segment)?;
-            let module = binding.ty.as_module()?;
-            file = self.calls.module_def(module)?.file_id;
-        }
-        let ty = self.nominal_type_for_symbol(file, *leaf).or_else(|| {
-            self.const_info_for_symbol(file, *leaf)
-                .and_then(|info| match info.value {
-                    ConstValue::Type(ty) => Some(ty),
-                    _ => None,
-                })
-        });
-        ty
-    }
-
-    fn resolve_type_name_in_file(
-        &mut self,
-        name: &str,
-        root_file: FileId,
-        span: Span,
-    ) -> CompileResult<Type> {
-        if let Some(capacity) = name
-            .strip_prefix("Str(")
-            .and_then(|name| name.strip_suffix(')'))
-            .and_then(|capacity| capacity.parse::<u64>().ok())
-        {
-            let id = self
-                .endpoint
-                .register_generated_fixed_string(capacity)
-                .ok_or_else(|| {
-                    CompileError::new(rue_error::ErrorKind::UnknownType(name.to_owned()), span)
-                })?;
-            self.generated_structs
-                .insert(self.interner.get_or_intern(name), id);
-            return Ok(Type::new_struct(id));
-        }
-        if let Some((callee, arguments)) = crate::types::parse_type_call_syntax(name) {
-            return self.resolve_type_constructor_call(
-                &callee, &arguments, name, root_file, span, None, None,
-            );
-        }
-        if name.contains('.') {
-            let segments = name.split('.').collect::<Vec<_>>();
-            let Some((leaf, prefix)) = segments.split_last() else {
-                unreachable!()
-            };
-            if prefix.is_empty() || segments.iter().any(|segment| segment.is_empty()) {
-                return Err(CompileError::new(
-                    rue_error::ErrorKind::UnknownType(name.to_owned()),
-                    span,
-                ));
-            }
-            let mut file = root_file;
-            for segment in prefix {
-                let symbol = self.interner.get_or_intern(segment);
-                let binding = self
-                    .module_binding_for_symbol(file, symbol)
-                    .ok_or_else(|| {
-                        CompileError::new(rue_error::ErrorKind::UnknownType(name.to_owned()), span)
-                    })?;
-                let module = binding.ty.as_module().ok_or_else(|| {
-                    CompileError::new(rue_error::ErrorKind::UnknownType(name.to_owned()), span)
-                })?;
-                file = self
-                    .calls
-                    .module_def(module)
-                    .ok_or_else(|| {
-                        CompileError::new(rue_error::ErrorKind::UnknownType(name.to_owned()), span)
-                    })?
-                    .file_id;
-            }
-            let leaf = self.interner.get_or_intern(leaf);
-            if let Some(ty) = self.nominal_type_for_symbol(file, leaf) {
-                let (defining_file, is_public, item_kind) = if let Some(id) = ty.as_struct() {
-                    let definition = self.type_pool.struct_def(id);
-                    (definition.file_id, definition.is_pub, "struct")
-                } else if let Some(id) = ty.as_enum() {
-                    let definition = self.type_pool.enum_def(id);
-                    (definition.file_id, definition.is_pub, "enum")
-                } else {
-                    (file, true, "type")
-                };
-                if !self.is_accessible(root_file, defining_file, is_public) {
-                    return Err(CompileError::new(
-                        rue_error::ErrorKind::PrivateMemberAccess {
-                            item_kind: item_kind.to_owned(),
-                            name: self.interner.resolve(&leaf).to_owned(),
-                        },
-                        span,
-                    ));
-                }
-                return Ok(ty);
-            }
-            if let Some(info) = self.const_info_for_symbol(file, leaf)
-                && let ConstValue::Type(ty) = info.value
-            {
-                if !self.is_accessible(root_file, info.span.file_id, info.is_pub) {
-                    return Err(CompileError::new(
-                        rue_error::ErrorKind::PrivateMemberAccess {
-                            item_kind: "const".to_owned(),
-                            name: self.interner.resolve(&leaf).to_owned(),
-                        },
-                        span,
-                    ));
-                }
-                return Ok(ty);
-            }
-            return Err(CompileError::new(
-                rue_error::ErrorKind::UnknownType(name.to_owned()),
-                span,
-            ));
-        }
-        if let Some((element, length)) = crate::types::parse_array_type_syntax(name) {
-            let element = self.resolve_type_name_in_file(&element, root_file, span)?;
-            let length = self.resolve_array_length_in_file(&length, root_file, span, None)?;
-            return self
-                .type_pool
-                .try_intern_array(element, length)
-                .map_err(|failure| {
-                    CompileError::new(
-                        rue_error::ErrorKind::UnknownType(format!("{name}: {failure:?}")),
-                        span,
-                    )
-                });
-        }
-        if let Some((pointee, mutability)) = crate::types::parse_pointer_type_syntax(name) {
-            let pointee = self.resolve_type_name_in_file(&pointee, root_file, span)?;
-            return match mutability {
-                crate::types::PtrMutability::Const => self.type_pool.try_intern_ptr_const(pointee),
-                crate::types::PtrMutability::Mut => self.type_pool.try_intern_ptr_mut(pointee),
-            }
-            .map_err(|failure| {
-                CompileError::new(
-                    rue_error::ErrorKind::UnknownType(format!("{name}: {failure:?}")),
-                    span,
-                )
-            });
-        }
-        if let Some(element) = name
-            .strip_prefix('[')
-            .and_then(|name| name.strip_suffix(']'))
-            .filter(|element| !element.contains(';'))
-        {
-            self.require_preview(
-                rue_error::PreviewFeature::Slices,
-                "the slice type `[T]`",
-                span,
-            )?;
-            let element_type = self.resolve_type_name_in_file(element, root_file, span)?;
-            let durable_element =
-                self.durable_type_from_concrete(element_type)
-                    .ok_or_else(|| {
-                        CompileError::new(rue_error::ErrorKind::UnknownType(name.to_owned()), span)
-                    })?;
-            let id = self
-                .endpoint
-                .register_generated_slice(&durable_element, name)
-                .ok_or_else(|| {
-                    CompileError::new(rue_error::ErrorKind::UnknownType(name.to_owned()), span)
-                })?;
-            return Ok(Type::new_struct(id));
-        }
-        let ty = if name == "unit" {
-            Type::UNIT
-        } else if name == "never" {
-            Type::NEVER
-        } else if let Some(ty) = Type::from_primitive_name(name) {
-            ty
-        } else {
-            let symbol = self.state.identity_context().name_symbol(name);
-            if let Some(ty) = self.nominal_type_for_symbol(root_file, symbol) {
-                ty
-            } else if let Some(info) = self.const_info_for_symbol(root_file, symbol)
-                && let ConstValue::Type(ty) = info.value
-            {
-                ty
-            } else {
-                return Err(CompileError::new(
-                    rue_error::ErrorKind::UnknownType(name.to_owned()),
-                    span,
-                ));
-            }
-        };
-        Ok(ty)
-    }
-
-    /// Resolve a parser-proven simple type name without reconstructing its
-    /// spelling or interning it again. Compound source spellings never reach
-    /// this boundary: arrays, pointers, calls, paths, unit, and never each have
-    /// their own structured RIR node.
-    fn resolve_named_type_symbol_in_file(
-        &mut self,
-        symbol: Spur,
-        root_file: FileId,
-        span: Span,
-    ) -> CompileResult<Type> {
-        if let Some(ty) = Type::from_primitive_name(self.interner.resolve(&symbol)) {
-            return Ok(ty);
-        }
-        if let Some(ty) = self.nominal_type_for_symbol(root_file, symbol) {
-            return Ok(ty);
-        }
-        if let Some(info) = self.const_info_for_symbol(root_file, symbol)
-            && let ConstValue::Type(ty) = info.value
-        {
-            return Ok(ty);
-        }
-        Err(CompileError::new(
-            rue_error::ErrorKind::UnknownType(self.interner.resolve(&symbol).to_owned()),
-            span,
-        ))
-    }
-
-    fn resolve_type_constructor_call(
-        &mut self,
-        callee: &str,
-        arguments: &[String],
-        syntax: &str,
-        root_file: FileId,
-        span: Span,
-        type_substitutions: Option<&HashMap<Spur, Type>>,
-        value_substitutions: Option<&HashMap<Spur, ConstValue>>,
-    ) -> CompileResult<Type> {
-        if callee == "Str" {
-            let [capacity] = arguments else {
-                return Err(CompileError::new(
-                    rue_error::ErrorKind::UnknownType(syntax.to_owned()),
-                    span,
-                ));
-            };
-            let length = capacity
-                .parse::<u64>()
-                .map(ArrayLen::Literal)
-                .unwrap_or_else(|_| ArrayLen::Named(capacity.clone()));
-            let capacity =
-                self.resolve_array_length_in_file(&length, root_file, span, value_substitutions)?;
-            let id = self
-                .endpoint
-                .register_generated_fixed_string(capacity)
-                .ok_or_else(|| {
-                    CompileError::new(rue_error::ErrorKind::UnknownType(syntax.to_owned()), span)
-                })?;
-            self.generated_structs
-                .insert(self.interner.get_or_intern(&format!("Str({capacity})")), id);
-            return Ok(Type::new_struct(id));
-        }
-        let reduced = self.reduce_comptime_constructor_call(
-            callee,
-            arguments,
-            syntax,
-            root_file,
-            span,
-            type_substitutions,
-            value_substitutions,
-        )?;
-        let crate::SemanticComptimeCallResult::Type(ty) = reduced.result else {
-            return Err(CompileError::new(
-                rue_error::ErrorKind::UnknownType(syntax.to_owned()),
-                span,
-            ));
-        };
-        self.register_import_nominal_identities(&ty).map_err(|_| {
-            CompileError::new(rue_error::ErrorKind::UnknownType(syntax.to_owned()), span)
-        })?;
-        let resolved = self
-            .state
-            .identity_context()
-            .pool_mut()
-            .and_then(|mut pool| pool.resolve_provider_type(&ty).ok())
-            .ok_or_else(|| {
-                CompileError::new(rue_error::ErrorKind::UnknownType(syntax.to_owned()), span)
-            })?;
-        if let crate::SemanticImportType::AnonymousNominal(identity) = &ty {
-            self.install_provider_anonymous_methods(identity, resolved)
-                .ok_or_else(|| {
-                    CompileError::new(rue_error::ErrorKind::UnknownType(syntax.to_owned()), span)
-                })?;
-        }
-        Ok(resolved)
-    }
-
-    fn rir_type_path(
-        &self,
-        arena: &rue_rir::RirTypeSyntaxArena<Spur>,
-        path: rue_rir::RirTypeSyntaxRange,
-    ) -> Option<Vec<String>> {
-        arena
-            .words(path)?
-            .iter()
-            .map(|word| {
-                arena
-                    .symbol(rue_rir::RirTypeSyntaxSymbol::from_u32(*word))
-                    .map(|symbol| self.interner.resolve(symbol).to_owned())
-            })
-            .collect()
-    }
-
-    fn rir_type_references(
-        arena: &rue_rir::RirTypeSyntaxArena<Spur>,
-        range: rue_rir::RirTypeSyntaxRange,
-    ) -> Option<Vec<RirTypeSyntaxRef>> {
-        Some(
-            arena
-                .words(range)?
-                .iter()
-                .copied()
-                .map(RirTypeSyntaxRef::from_u32)
-                .collect(),
-        )
-    }
-
-    fn resolve_rir_array_length(
-        &mut self,
-        arena: &rue_rir::RirTypeSyntaxArena<Spur>,
-        syntax: RirTypeSyntaxRef,
-        root_file: FileId,
-        span: Span,
-        type_substitutions: Option<&HashMap<Spur, Type>>,
-        value_substitutions: Option<&HashMap<Spur, ConstValue>>,
-    ) -> CompileResult<u64> {
-        use rue_rir::RirTypeSyntaxNode as N;
-        let Some(node) = arena.node(syntax) else {
-            return Err(self.rir_array_length_error(arena, syntax, span));
-        };
-        let invalid =
-            |reason| CompileError::new(rue_error::ErrorKind::InvalidArrayLength { reason }, span);
-        match node {
-            N::Integer(value) if *value >= 0 => u64::try_from(*value).map_err(|_| {
-                invalid(format!(
-                    "array length '{}' ({value}) is too large",
-                    self.rir_type_display(arena, syntax)
-                ))
-            }),
-            N::Integer(value) => Err(invalid(format!(
-                "array length '{}' is negative ({value})",
-                self.rir_type_display(arena, syntax)
-            ))),
-            N::Named(name) => {
-                let Some(symbol) = arena.symbol(*name).copied() else {
-                    return Err(self.rir_array_length_error(arena, syntax, span));
-                };
-                let name = self.interner.resolve(&symbol).to_owned();
-                let value = value_substitutions
-                    .and_then(|values| values.get(&symbol))
-                    .copied()
-                    .or_else(|| {
-                        self.call_value_const(root_file, symbol)
-                            .map(|info| info.value)
-                    });
-                match value {
-                    Some(ConstValue::Integer(value)) if value >= 0 => {
-                        u64::try_from(value).map_err(|_| {
-                            invalid(format!("array length '{name}' ({value}) is too large"))
-                        })
-                    }
-                    Some(ConstValue::Integer(value)) => Err(invalid(format!(
-                        "array length '{name}' is negative ({value})"
-                    ))),
-                    Some(_) => Err(invalid(format!("array length '{name}' is not an integer"))),
-                    None => {
-                        let mut paths = self
-                            .source
-                            .out_of_scope_integer_const_paths(&self.key, &name);
-                        paths.sort_unstable();
-                        paths.dedup();
-                        let hint = if paths.is_empty() {
-                            String::new()
-                        } else {
-                            format!(
-                                "; an integer constant of that name is declared in {} — import that module and bind a file-level `const` (for example `const {name}: i32 = <module>.{name};`) to use it as an array length here",
-                                paths
-                                    .iter()
-                                    .map(AsRef::as_ref)
-                                    .collect::<Vec<&str>>()
-                                    .join(", ")
-                            )
-                        };
-                        Err(invalid(format!(
-                            "'{name}' is not a compile-time constant; array lengths must be an integer literal, a `const`, or a `comptime` value parameter{hint}"
-                        )))
-                    }
-                }
-            }
-            N::ValueCall { name, arguments } => {
-                let Some(name) = arena.symbol(*name) else {
-                    return Err(self.rir_array_length_error(arena, syntax, span));
-                };
-                let Some(arguments) = Self::rir_type_references(arena, *arguments) else {
-                    return Err(self.rir_array_length_error(arena, syntax, span));
-                };
-                let callee = self.interner.resolve(name).to_owned();
-                if let Some(definition) = self.source.free_function(&self.key, &callee)
-                    && let Some(signature) =
-                        DurableCallableSource::function(&self.source, &definition)
-                    && (signature.parameters.len() != arguments.len()
-                        || signature
-                            .parameters
-                            .iter()
-                            .any(|parameter| !parameter.is_comptime))
-                {
-                    return Err(invalid(format!(
-                        "array length call '{callee}(...)' is not a compile-time constant; its callee must be a value-returning function whose parameters are all `comptime`"
-                    )));
-                }
-                let display = self.rir_type_display(arena, syntax);
-                let reduced = self
-                    .reduce_rir_comptime_constructor_call(
-                        arena,
-                        std::slice::from_ref(&callee),
-                        &arguments,
-                        root_file,
-                        span,
-                        type_substitutions,
-                        value_substitutions,
-                        &display,
-                    )
-                    .map_err(|error| match error.kind {
-                        rue_error::ErrorKind::ComptimeArgNotConst { .. } => invalid(format!(
-                            "array length call '{callee}(...)' is not a compile-time constant; its callee must be a value-returning function whose parameters are all `comptime`"
-                        )),
-                        _ => invalid(format!(
-                            "'{callee}' is not a function; array lengths must be an integer literal, a `const`, a `comptime` value parameter, or a call to a comptime function"
-                        )),
-                    })?;
-                match reduced.result {
-                    crate::SemanticComptimeCallResult::Value(
-                        crate::SemanticImportConstValue::Integer(value),
-                    ) if value >= 0 => u64::try_from(value).map_err(|_| {
-                        invalid(format!(
-                            "array length '{callee}(...)' ({value}) is too large"
-                        ))
-                    }),
-                    crate::SemanticComptimeCallResult::Value(
-                        crate::SemanticImportConstValue::Integer(value),
-                    ) => Err(invalid(format!(
-                        "array length '{callee}(...)' is negative ({value})"
-                    ))),
-                    _ => Err(invalid(format!(
-                        "array length call '{callee}(...)' did not evaluate to a compile-time integer"
-                    ))),
-                }
-            }
-            _ => Err(self.rir_array_length_error(arena, syntax, span)),
-        }
-    }
-
-    fn rir_array_length_error(
-        &self,
-        arena: &rue_rir::RirTypeSyntaxArena<Spur>,
-        syntax: RirTypeSyntaxRef,
-        span: Span,
-    ) -> CompileError {
-        CompileError::new(
-            rue_error::ErrorKind::InvalidArrayLength {
-                reason: arena
-                    .render_type_with(syntax, |symbol| self.interner.resolve(symbol))
-                    .unwrap_or_else(|| "<invalid structured array length>".to_owned()),
-            },
-            span,
-        )
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn resolve_rir_type_constructor_call(
-        &mut self,
-        arena: &rue_rir::RirTypeSyntaxArena<Spur>,
-        syntax: RirTypeSyntaxRef,
-        path: rue_rir::RirTypeSyntaxRange,
-        arguments: rue_rir::RirTypeSyntaxRange,
-        root_file: FileId,
-        span: Span,
-        type_substitutions: Option<&HashMap<Spur, Type>>,
-        value_substitutions: Option<&HashMap<Spur, ConstValue>>,
-    ) -> CompileResult<Type> {
-        let path = self
-            .rir_type_path(arena, path)
-            .ok_or_else(|| self.rir_type_unknown_error(arena, syntax, span))?;
-        let arguments = Self::rir_type_references(arena, arguments)
-            .ok_or_else(|| self.rir_type_unknown_error(arena, syntax, span))?;
-        if path.as_slice() == ["Str"] {
-            let [capacity] = arguments.as_slice() else {
-                return Err(self.rir_type_unknown_error(arena, syntax, span));
-            };
-            let capacity = self.resolve_rir_array_length(
-                arena,
-                *capacity,
-                root_file,
-                span,
-                type_substitutions,
-                value_substitutions,
-            )?;
-            let id = self
-                .endpoint
-                .register_generated_fixed_string(capacity)
-                .ok_or_else(|| self.rir_type_unknown_error(arena, syntax, span))?;
-            self.generated_structs
-                .insert(self.interner.get_or_intern(&format!("Str({capacity})")), id);
-            return Ok(Type::new_struct(id));
-        }
-        let display = self.rir_type_display(arena, syntax);
-        let reduced = self.reduce_rir_comptime_constructor_call(
-            arena,
-            &path,
-            &arguments,
-            root_file,
-            span,
-            type_substitutions,
-            value_substitutions,
-            &display,
-        )?;
-        let crate::SemanticComptimeCallResult::Type(ty) = reduced.result else {
-            return Err(CompileError::new(
-                rue_error::ErrorKind::UnknownType(display.clone()),
-                span,
-            ));
-        };
-        self.register_import_nominal_identities(&ty).map_err(|_| {
-            CompileError::new(rue_error::ErrorKind::UnknownType(display.clone()), span)
-        })?;
-        let resolved = self
-            .state
-            .identity_context()
-            .pool_mut()
-            .and_then(|mut pool| pool.resolve_provider_type(&ty).ok())
-            .ok_or_else(|| {
-                CompileError::new(rue_error::ErrorKind::UnknownType(display.clone()), span)
-            })?;
-        if let crate::SemanticImportType::AnonymousNominal(identity) = &ty {
-            self.install_provider_anonymous_methods(identity, resolved)
-                .ok_or_else(|| {
-                    CompileError::new(rue_error::ErrorKind::UnknownType(display.clone()), span)
-                })?;
-        }
-        Ok(resolved)
-    }
-
-    fn reduce_comptime_constructor_call(
-        &mut self,
-        callee: &str,
-        arguments: &[String],
-        syntax: &str,
-        root_file: FileId,
-        span: Span,
-        type_substitutions: Option<&HashMap<Spur, Type>>,
-        value_substitutions: Option<&HashMap<Spur, ConstValue>>,
-    ) -> CompileResult<crate::DurableReducedComptimeCall<K, M>> {
-        let mut segments = callee.split('.').collect::<Vec<_>>();
-        let Some(name) = segments.pop() else {
-            unreachable!()
-        };
-        let mut file = root_file;
-        for segment in segments {
-            let symbol = self.interner.get_or_intern(segment);
-            let binding = self
-                .module_binding_for_symbol(file, symbol)
-                .ok_or_else(|| {
-                    CompileError::new(rue_error::ErrorKind::UnknownType(syntax.to_owned()), span)
-                })?;
-            let module = binding.ty.as_module().ok_or_else(|| {
-                CompileError::new(rue_error::ErrorKind::UnknownType(syntax.to_owned()), span)
-            })?;
-            file = self
-                .calls
-                .module_def(module)
-                .ok_or_else(|| {
-                    CompileError::new(rue_error::ErrorKind::UnknownType(syntax.to_owned()), span)
-                })?
-                .file_id;
-        }
-        let source_name = self.interner.get_or_intern(name);
-        let symbol = self
-            .function_for_file_symbol(file, source_name)
-            .ok_or_else(|| {
-                CompileError::new(rue_error::ErrorKind::UnknownType(syntax.to_owned()), span)
-            })?;
-        let (_, definition) = self.function_token_for_symbol(symbol).ok_or_else(|| {
-            CompileError::new(rue_error::ErrorKind::UnknownType(syntax.to_owned()), span)
-        })?;
-        let signature =
-            DurableCallableSource::function(&self.source, &definition).ok_or_else(|| {
-                CompileError::new(rue_error::ErrorKind::UnknownType(syntax.to_owned()), span)
-            })?;
-        if let Some(locator) = self.source.definition_source(&definition)
-            && !self.is_accessible(root_file, locator.file_id, signature.is_public)
-        {
-            return Err(
-                CompileError::new(
-                    rue_error::ErrorKind::PrivateUnqualifiedAccess(Box::new(
-                        rue_error::PrivateUnqualifiedAccessData {
-                            item_kind: "function".to_owned(),
-                            name: name.to_owned(),
-                            defining_file: locator.physical_path.to_string(),
-                        },
-                    )),
-                    span,
-                )
-                .with_help(format!(
-                    "`{name}` is not marked `pub`; private items are only visible within their defining directory"
-                )),
-            );
-        }
-        if signature.parameters.len() != arguments.len()
-            || signature
-                .parameters
-                .iter()
-                .any(|parameter| !parameter.is_comptime)
-        {
-            return Err(CompileError::new(
-                rue_error::ErrorKind::UnknownType(syntax.to_owned()),
-                span,
-            ));
-        }
-
-        let mut type_arguments = Vec::new();
-        let mut value_arguments = Vec::new();
-        for (parameter, argument) in signature.parameters.iter().zip(arguments) {
-            if matches!(parameter.ty, crate::SemanticImportType::ComptimeType) {
-                let argument_symbol = self.interner.get_or_intern(argument);
-                let ty = if let Some(ty) =
-                    type_substitutions.and_then(|substitutions| substitutions.get(&argument_symbol))
-                {
-                    *ty
-                } else if let Some((callee, arguments)) =
-                    crate::types::parse_type_call_syntax(argument)
-                {
-                    self.resolve_type_constructor_call(
-                        &callee,
-                        &arguments,
-                        argument,
-                        root_file,
-                        span,
-                        type_substitutions,
-                        value_substitutions,
-                    )?
-                } else {
-                    self.resolve_type_name_in_file(argument, root_file, span)?
-                };
-                let value = self.durable_type_from_concrete(ty).ok_or_else(|| {
-                    CompileError::new(rue_error::ErrorKind::UnknownType(syntax.to_owned()), span)
-                })?;
-                type_arguments.push((parameter.name.clone(), value));
-                continue;
-            }
-            let concrete = if argument == "true" {
-                Some(ConstValue::Bool(true))
-            } else if argument == "false" {
-                Some(ConstValue::Bool(false))
-            } else if let Ok(value) = argument.parse::<i128>() {
-                Some(ConstValue::Integer(value))
-            } else if let Some((callee, arguments)) = crate::types::parse_type_call_syntax(argument)
-            {
-                match self
-                    .reduce_comptime_constructor_call(
-                        &callee,
-                        &arguments,
-                        argument,
-                        root_file,
-                        span,
-                        type_substitutions,
-                        value_substitutions,
-                    )?
-                    .result
-                {
-                    crate::SemanticComptimeCallResult::Value(value) => {
-                        self.materialize_durable_const_value(&value)
-                    }
-                    crate::SemanticComptimeCallResult::Type(_) => None,
-                }
-            } else {
-                let symbol = self.interner.get_or_intern(argument);
-                value_substitutions
-                    .and_then(|substitutions| substitutions.get(&symbol).cloned())
-                    .or_else(|| {
-                        self.const_info_for_symbol(root_file, symbol)
-                            .map(|info| info.value)
-                    })
-            }
-            .ok_or_else(|| {
-                CompileError::new(
-                    rue_error::ErrorKind::ComptimeArgNotConst {
-                        param_name: parameter.name.to_string(),
-                    },
-                    span,
-                )
-            })?;
-            let value = self.durable_value_from_concrete(concrete).ok_or_else(|| {
-                CompileError::new(rue_error::ErrorKind::UnknownType(syntax.to_owned()), span)
-            })?;
-            value_arguments.push((parameter.name.clone(), value));
-        }
-
-        let reduced =
-            match self
-                .source
-                .reduce_comptime_call(&definition, &type_arguments, &value_arguments)
-            {
-                DurableComptimeCallOutcome::Reduced(reduced) => reduced,
-                DurableComptimeCallOutcome::NotReduced => {
-                    return Err(CompileError::new(
-                        rue_error::ErrorKind::UnknownType(syntax.to_owned()),
-                        span,
-                    ));
-                }
-                DurableComptimeCallOutcome::Diagnostic(diagnostic) => {
-                    return Err(CompileError::new(
-                        diagnostic.kind,
-                        diagnostic.span.unwrap_or(span),
-                    ));
-                }
-            };
-        Ok(reduced)
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn reduce_rir_comptime_constructor_call(
-        &mut self,
-        arena: &rue_rir::RirTypeSyntaxArena<Spur>,
-        path: &[String],
-        arguments: &[RirTypeSyntaxRef],
-        root_file: FileId,
-        span: Span,
-        type_substitutions: Option<&HashMap<Spur, Type>>,
-        value_substitutions: Option<&HashMap<Spur, ConstValue>>,
-        display: &str,
-    ) -> CompileResult<crate::DurableReducedComptimeCall<K, M>> {
-        let Some((name, prefix)) = path.split_last() else {
-            return Err(CompileError::new(
-                rue_error::ErrorKind::UnknownType(display.to_owned()),
-                span,
-            ));
-        };
-        let mut file = root_file;
-        for segment in prefix {
-            let symbol = self.interner.get_or_intern(segment);
-            let binding = self
-                .module_binding_for_symbol(file, symbol)
-                .ok_or_else(|| {
-                    CompileError::new(rue_error::ErrorKind::UnknownType(display.to_owned()), span)
-                })?;
-            let module = binding.ty.as_module().ok_or_else(|| {
-                CompileError::new(rue_error::ErrorKind::UnknownType(display.to_owned()), span)
-            })?;
-            file = self
-                .calls
-                .module_def(module)
-                .ok_or_else(|| {
-                    CompileError::new(rue_error::ErrorKind::UnknownType(display.to_owned()), span)
-                })?
-                .file_id;
-        }
-        let source_name = self.interner.get_or_intern(name);
-        let symbol = self
-            .function_for_file_symbol(file, source_name)
-            .ok_or_else(|| {
-                CompileError::new(rue_error::ErrorKind::UnknownType(display.to_owned()), span)
-            })?;
-        let (_, definition) = self.function_token_for_symbol(symbol).ok_or_else(|| {
-            CompileError::new(rue_error::ErrorKind::UnknownType(display.to_owned()), span)
-        })?;
-        let signature =
-            DurableCallableSource::function(&self.source, &definition).ok_or_else(|| {
-                CompileError::new(rue_error::ErrorKind::UnknownType(display.to_owned()), span)
-            })?;
-        if let Some(locator) = self.source.definition_source(&definition)
-            && !self.is_accessible(root_file, locator.file_id, signature.is_public)
-        {
-            return Err(
-                CompileError::new(
-                    rue_error::ErrorKind::PrivateUnqualifiedAccess(Box::new(
-                        rue_error::PrivateUnqualifiedAccessData {
-                            item_kind: "function".to_owned(),
-                            name: name.to_owned(),
-                            defining_file: locator.physical_path.to_string(),
-                        },
-                    )),
-                    span,
-                )
-                .with_help(format!(
-                    "`{name}` is not marked `pub`; private items are only visible within their defining directory"
-                )),
-            );
-        }
-        if signature.parameters.len() != arguments.len()
-            || signature
-                .parameters
-                .iter()
-                .any(|parameter| !parameter.is_comptime)
-        {
-            return Err(CompileError::new(
-                rue_error::ErrorKind::UnknownType(display.to_owned()),
-                span,
-            ));
-        }
-
-        let mut type_arguments = Vec::new();
-        let mut value_arguments = Vec::new();
-        for (parameter, argument) in signature.parameters.iter().zip(arguments) {
-            if matches!(parameter.ty, crate::SemanticImportType::ComptimeType) {
-                let ty = self.resolve_rir_type_syntax_in_arena(
-                    arena,
-                    *argument,
-                    root_file,
-                    span,
-                    type_substitutions,
-                    value_substitutions,
-                )?;
-                let value = self.durable_type_from_concrete(ty).ok_or_else(|| {
-                    CompileError::new(rue_error::ErrorKind::UnknownType(display.to_owned()), span)
-                })?;
-                type_arguments.push((parameter.name.clone(), value));
-                continue;
-            }
-            let concrete = match arena.node(*argument) {
-                Some(rue_rir::RirTypeSyntaxNode::Integer(value)) => {
-                    Some(ConstValue::Integer(*value))
-                }
-                Some(rue_rir::RirTypeSyntaxNode::Named(name)) => {
-                    let symbol = *arena.symbol(*name).ok_or_else(|| {
-                        CompileError::new(
-                            rue_error::ErrorKind::UnknownType(display.to_owned()),
-                            span,
-                        )
-                    })?;
-                    match self.interner.resolve(&symbol) {
-                        "true" => Some(ConstValue::Bool(true)),
-                        "false" => Some(ConstValue::Bool(false)),
-                        _ => value_substitutions
-                            .and_then(|values| values.get(&symbol))
-                            .copied()
-                            .or_else(|| {
-                                self.const_info_for_symbol(root_file, symbol)
-                                    .map(|info| info.value)
-                            }),
-                    }
-                }
-                Some(rue_rir::RirTypeSyntaxNode::ValueCall { name, arguments }) => {
-                    let name = arena.symbol(*name).ok_or_else(|| {
-                        CompileError::new(
-                            rue_error::ErrorKind::UnknownType(display.to_owned()),
-                            span,
-                        )
-                    })?;
-                    let nested = Self::rir_type_references(arena, *arguments).ok_or_else(|| {
-                        CompileError::new(
-                            rue_error::ErrorKind::UnknownType(display.to_owned()),
-                            span,
-                        )
-                    })?;
-                    match self
-                        .reduce_rir_comptime_constructor_call(
-                            arena,
-                            &[self.interner.resolve(name).to_owned()],
-                            &nested,
-                            root_file,
-                            span,
-                            type_substitutions,
-                            value_substitutions,
-                            display,
-                        )?
-                        .result
-                    {
-                        crate::SemanticComptimeCallResult::Value(value) => {
-                            self.materialize_durable_const_value(&value)
-                        }
-                        crate::SemanticComptimeCallResult::Type(_) => None,
-                    }
-                }
-                Some(rue_rir::RirTypeSyntaxNode::TypeCall { path, arguments }) => {
-                    let nested_path = self.rir_type_path(arena, *path).ok_or_else(|| {
-                        CompileError::new(
-                            rue_error::ErrorKind::UnknownType(display.to_owned()),
-                            span,
-                        )
-                    })?;
-                    let nested = Self::rir_type_references(arena, *arguments).ok_or_else(|| {
-                        CompileError::new(
-                            rue_error::ErrorKind::UnknownType(display.to_owned()),
-                            span,
-                        )
-                    })?;
-                    match self
-                        .reduce_rir_comptime_constructor_call(
-                            arena,
-                            &nested_path,
-                            &nested,
-                            root_file,
-                            span,
-                            type_substitutions,
-                            value_substitutions,
-                            display,
-                        )?
-                        .result
-                    {
-                        crate::SemanticComptimeCallResult::Value(value) => {
-                            self.materialize_durable_const_value(&value)
-                        }
-                        crate::SemanticComptimeCallResult::Type(_) => None,
-                    }
-                }
-                _ => None,
-            }
-            .ok_or_else(|| {
-                CompileError::new(
-                    rue_error::ErrorKind::ComptimeArgNotConst {
-                        param_name: parameter.name.to_string(),
-                    },
-                    span,
-                )
-            })?;
-            let value = self.durable_value_from_concrete(concrete).ok_or_else(|| {
-                CompileError::new(rue_error::ErrorKind::UnknownType(display.to_owned()), span)
-            })?;
-            value_arguments.push((parameter.name.clone(), value));
-        }
-        match self
-            .source
-            .reduce_comptime_call(&definition, &type_arguments, &value_arguments)
-        {
-            DurableComptimeCallOutcome::Reduced(reduced) => Ok(reduced),
-            DurableComptimeCallOutcome::NotReduced => Err(CompileError::new(
-                rue_error::ErrorKind::UnknownType(display.to_owned()),
-                span,
-            )),
-            DurableComptimeCallOutcome::Diagnostic(diagnostic) => Err(CompileError::new(
-                diagnostic.kind,
-                diagnostic.span.unwrap_or(span),
-            )),
-        }
-    }
 }
 
 impl<P, S, K, M> OrdinaryBodyAnalysisHost for ProviderBodyHost<'_, P, S, K, M>
@@ -4587,6 +3520,93 @@ where
     K: Clone + Eq + Hash + Ord,
     M: Clone + Eq + Hash + Ord,
 {
+    type InferenceFacts<'b>
+        = HostInferenceFacts<'b, Self>
+    where
+        Self: 'b;
+
+    fn inference_facts<'b>(&'b self, ctx: &'b InferenceContext) -> Self::InferenceFacts<'b> {
+        HostInferenceFacts::new(ctx, self)
+    }
+
+    fn resolve_structured_type_syntax(
+        &mut self,
+        request: StructuredTypeSyntaxRequest<'_>,
+    ) -> Result<
+        Type,
+        crate::SemanticTypeSyntaxError<std::convert::Infallible, CompileError, FileId, Spur>,
+    > {
+        let interner = Rc::clone(&self.interner);
+        let mut provider = TypeSyntaxProvider::new(
+            self,
+            request.span,
+            TypeRootAuthority::in_file(request.root_file),
+            SemaTypeResolutionContext::Type,
+            request.type_substitutions,
+            request.value_substitutions,
+        );
+        let result = crate::resolve_structured_semantic_type_syntax_with(
+            &mut provider,
+            &request.root_file,
+            &request.syntax.arena,
+            request.syntax.root,
+            |symbol| interner.resolve(symbol),
+        );
+        provider.flush_observed_type_dependencies();
+        result
+    }
+
+    fn resolve_type_module_prefix(
+        &mut self,
+        request: ModulePrefixRequest<'_>,
+    ) -> CompileResult<(ModuleId, Option<FileId>, String)> {
+        let mut provider = TypeSyntaxProvider::new(
+            self,
+            request.span,
+            TypeRootAuthority::in_file(request.root_file),
+            SemaTypeResolutionContext::Type,
+            None,
+            None,
+        );
+        let resolved = crate::resolve_semantic_module_path(
+            &mut provider,
+            &request.root_file,
+            request.segments,
+        )
+        .map_err(|failure| {
+            super::typeck::module_path_resolution_compile_error(failure, request.span)
+        })?;
+        provider.flush_observed_type_dependencies();
+        let definition = self.calls.module_def(resolved.module).ok_or_else(|| {
+            CompileError::new(
+                rue_error::ErrorKind::UnknownType(request.segments.join(".")),
+                request.span,
+            )
+        })?;
+        // `resolved.site` is the source file containing the final module
+        // binding. Member lookup must continue from the target module's file;
+        // imports commonly bind a module in a different file.
+        Ok((
+            resolved.module,
+            Some(definition.file_id),
+            definition.file_path,
+        ))
+    }
+
+    fn resolve_array_length(&mut self, request: ArrayLengthRequest<'_>) -> CompileResult<u64> {
+        let mut provider = TypeSyntaxProvider::new(
+            self,
+            request.span,
+            TypeRootAuthority::in_file(request.span.file_id),
+            SemaTypeResolutionContext::Type,
+            None,
+            request.value_substitutions,
+        );
+        let result = provider.resolve_array_length_fact(request.span.file_id, request.length);
+        provider.flush_observed_type_dependencies();
+        result
+    }
+
     fn record_expression_analysis_breakdown(&mut self, breakdown: ExpressionAnalysisBreakdown) {
         self.expression_breakdown = Some(breakdown);
     }
@@ -4848,7 +3868,7 @@ where
         let same_call = |candidate: FunctionCallInfo| candidate.params == function.params;
         let symbol = if self
             .endpoint
-            .function_info(self.function_symbol)
+            .endpoint_function_info(self.function_symbol)
             .is_some_and(same_body)
         {
             Some(self.function_symbol)
@@ -4901,7 +3921,7 @@ where
                 arena: syntax.arena,
             });
         }
-        let local = self.endpoint.function_info(self.function_symbol)?;
+        let local = self.endpoint.endpoint_function_info(self.function_symbol)?;
         if local.params != function.params {
             return None;
         }
@@ -4929,7 +3949,7 @@ where
                 root: syntax.result,
             });
         }
-        let local = self.endpoint.function_info(self.function_symbol)?;
+        let local = self.endpoint.endpoint_function_info(self.function_symbol)?;
         if local.params != function.params {
             return None;
         }
@@ -5062,18 +4082,7 @@ where
         }
         let value = match reduced.result {
             crate::SemanticComptimeCallResult::Type(ty) => {
-                let _ = self.register_import_nominal_identities(&ty);
-                let resolved = self
-                    .state
-                    .identity_context()
-                    .pool_mut()
-                    .and_then(|mut pool| pool.resolve_provider_type(&ty).ok());
-                if let (crate::SemanticImportType::AnonymousNominal(identity), Some(resolved)) =
-                    (&ty, resolved)
-                {
-                    let _ = self.install_provider_anonymous_methods(identity, resolved);
-                }
-                resolved.map(ConstValue::Type)
+                self.materialize_durable_type(&ty).map(ConstValue::Type)
             }
             crate::SemanticComptimeCallResult::Value(value) => {
                 self.materialize_durable_const_value(&value)
@@ -5088,7 +4097,7 @@ where
         format!("m{}-{}", token.issuer(), token.slot())
     }
     fn resolve_body_type(&mut self, syntax: RirTypeSyntaxRef, span: Span) -> CompileResult<Type> {
-        self.resolve_rir_type_syntax(syntax, span, None, None)
+        self.resolve_body_type_with_substitutions(syntax, span, None, None)
     }
     fn resolve_body_type_with_substitutions(
         &mut self,
@@ -5097,7 +4106,22 @@ where
         type_substitutions: Option<&HashMap<Spur, Type>>,
         value_substitutions: Option<&HashMap<Spur, ConstValue>>,
     ) -> CompileResult<Type> {
-        self.resolve_rir_type_syntax(syntax, span, type_substitutions, value_substitutions)
+        let syntax = super::fact_mode::StructuredTypeSyntax {
+            arena: self.rir.rir().type_syntax().clone(),
+            root: syntax,
+        };
+        let interner = Rc::clone(&self.interner);
+        OrdinaryBodyAnalysisHost::resolve_structured_type_syntax(
+            self,
+            StructuredTypeSyntaxRequest {
+                syntax: &syntax,
+                root_file: span.file_id,
+                span,
+                type_substitutions,
+                value_substitutions,
+            },
+        )
+        .map_err(|failure| semantic_type_syntax_compile_error(&interner, failure, span))
     }
     fn replace_active_anonymous_producer(
         &mut self,
@@ -5150,13 +4174,13 @@ where
         self.function_info_for_symbol(name)
     }
     fn function_body_info(&self, name: Spur) -> Option<FunctionInfo> {
-        self.endpoint.function_info(name)
+        self.endpoint.endpoint_function_info(name)
     }
     fn value_const(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
         self.call_value_const(file, name)
     }
     fn source_function_name(&self, name: Spur) -> Spur {
-        self.endpoint.source_function_name(name)
+        self.endpoint.endpoint_source_function_name(name)
     }
     fn resolve_function_name_local(&self, name: Spur, file: FileId) -> Option<Spur> {
         self.function_for_file_symbol(file, name)
@@ -5170,22 +4194,22 @@ where
         self.nominal_type_for_symbol(file, name)?.as_struct()
     }
     fn builtin_struct(&self, name: Spur) -> Option<StructId> {
-        self.endpoint.builtin_or_generated_struct(name)
+        self.endpoint.endpoint_builtin_or_generated_struct(name)
     }
     fn target(&self) -> Target {
         self.target
     }
     fn builtin_arch_id(&self) -> Option<EnumId> {
         self.endpoint
-            .builtin_enum(self.interner.get_or_intern_static("Arch"))
+            .endpoint_builtin_enum(self.interner.get_or_intern_static("Arch"))
     }
     fn builtin_os_id(&self) -> Option<EnumId> {
         self.endpoint
-            .builtin_enum(self.interner.get_or_intern_static("Os"))
+            .endpoint_builtin_enum(self.interner.get_or_intern_static("Os"))
     }
     fn builtin_data_model_id(&self) -> Option<EnumId> {
         self.endpoint
-            .builtin_enum(self.interner.get_or_intern_static("DataModel"))
+            .endpoint_builtin_enum(self.interner.get_or_intern_static("DataModel"))
     }
     fn destructor_span(&self, _struct_id: StructId) -> Option<Span> {
         None
@@ -5389,7 +4413,7 @@ where
         crate::StableDefinitionKind::Function => {
             let info = host
                 .endpoint
-                .function_info(host.function_symbol)
+                .endpoint_function_info(host.function_symbol)
                 .ok_or_else(|| {
                     CompileError::without_span(rue_error::ErrorKind::UndefinedFunction(
                         name.to_owned(),
@@ -6414,7 +5438,7 @@ where
         .rir()
         .get(
             host.endpoint
-                .function_info(host.function_symbol)
+                .endpoint_function_info(host.function_symbol)
                 .ok_or_else(|| {
                     CompileError::without_span(rue_error::ErrorKind::UndefinedFunction(
                         name.to_owned(),

--- a/crates/rue-air/src/sema/semantic_body_export.rs
+++ b/crates/rue-air/src/sema/semantic_body_export.rs
@@ -925,7 +925,7 @@ impl BodySema<'_> {
                     // its identity (ADR-0066).
                     SemanticImportType::AnonymousNominal(identity.clone())
                 } else if let Some(element) = self.slice_element_type(ty)
-                    && def.name.starts_with('[')
+                    && crate::types::is_slice_struct_name(&def.name)
                 {
                     SemanticImportType::Slice {
                         element: Box::new(self.export_body_type(element)?),

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -6,7 +6,7 @@ mod tests {
     use crate::inst::{AirArgMode, AirInstData, AirRef};
     use crate::sema::{Sema, SemaOutput};
     use crate::types::{StructId, Type};
-    use lasso::ThreadedRodeo;
+    use lasso::{Spur, ThreadedRodeo};
     use rue_error::{
         CompileErrors, CompileResult, ErrorKind, MultiErrorResult, PreviewFeature, PreviewFeatures,
     };
@@ -82,60 +82,24 @@ mod tests {
         sema.analyze_all()
     }
 
-    fn gather_two_file_declarations_for_testing(main: &str, dependency: &str) -> Sema<'static> {
-        let dependency_file = FileId::new(1);
-        let (rir, interner) =
-            lower_files(&[(main, FileId::DEFAULT), (dependency, dependency_file)]);
-        let import = rir
-            .iter()
-            .find_map(|(_, inst)| {
-                let InstData::Intrinsic { name, args } = &inst.data else {
-                    return None;
-                };
-                (interner.resolve(name) == "import").then_some((inst.span.start, args))
+    fn structured_type_for_sema(
+        sema: &mut Sema<'_>,
+        syntax: &str,
+    ) -> (rue_rir::RirTypeSyntaxArena<Spur>, rue_rir::RirTypeSyntaxRef) {
+        let source = format!("fn probe(value: {syntax}) {{}}");
+        let (tokens, parser_interner): (_, ThreadedRodeo) = Lexer::new(&source).tokenize().unwrap();
+        let (ast, parser_interner) = Parser::new(tokens, parser_interner).parse().unwrap();
+        let rue_parser::ast::Item::Function(function) = &ast.items[0] else {
+            panic!("type fixture parses as a function");
+        };
+        let mut builder = rue_rir::RirTypeSyntaxBuilder::default();
+        let root = builder
+            .push_parser_type(&function.params[0].ty, |symbol| {
+                sema.interner
+                    .get_or_intern(parser_interner.resolve(&symbol))
             })
-            .expect("two-file test main must import its dependency");
-        let argument = rir
-            .intrinsic_args(import.1)
-            .get(0)
-            .expect("import must have one argument");
-        let InstData::StringConst { content, .. } = rir.get(argument).data else {
-            panic!("import argument must be a string")
-        };
-        let specifier = interner.resolve(&content).to_owned();
-        let view = TestCanonicalImportView {
-            modules: vec![
-                TestModule {
-                    id: "main.rue".to_owned(),
-                    file_id: FileId::DEFAULT,
-                    path: "/main.rue".to_owned(),
-                },
-                TestModule {
-                    id: specifier.clone(),
-                    file_id: dependency_file,
-                    path: "/dep.rue".to_owned(),
-                },
-            ],
-            sites: vec![TestSite {
-                importer: "main.rue".to_owned(),
-                offset: import.0,
-                specifier: specifier.clone(),
-                target: specifier,
-            }],
-        };
-        let rir = Box::leak(Box::new(rir));
-        let interner = Box::leak(Box::new(interner));
-        let mut sema = Sema::new_synthetic(rir, interner, PreviewFeatures::new());
-        sema.set_root_file_id(FileId::DEFAULT);
-        sema.set_file_paths(HashMap::from([
-            (FileId::DEFAULT, "/main.rue".to_owned()),
-            (dependency_file, "/dep.rue".to_owned()),
-        ]));
-        sema.set_canonical_imports(&view).unwrap();
-        sema.inject_builtin_types();
-        sema.register_type_names().unwrap();
-        sema.resolve_declarations().unwrap();
-        sema
+            .unwrap();
+        (builder.finish(), root)
     }
 
     fn compile_to_air_with_authoritative_identity_order(
@@ -3911,31 +3875,19 @@ fn main() -> i32 {
     }
 
     #[test]
-    fn deferred_array_lengths_reject_qualified_value_heads_but_allow_qualified_type_arguments() {
+    fn deferred_array_lengths_resolve_type_arguments_through_the_structured_policy() {
         let span = Span::with_file(FileId::DEFAULT, 0, 0);
-        let mut sema = gather_two_file_declarations_for_testing(
-            "const dep = @import(\"dep.rue\"); fn main() -> i32 { 0 }",
-            "pub fn Width(comptime T: type) -> i32 { 2 }",
-        );
-        let type_param = sema.interner.get_or_intern("T");
-        let error = sema
-            .validate_deferred_type_position_for_testing("[T; dep.Width(T)]", &[type_param], span)
-            .unwrap_err();
-        assert!(matches!(
-            &error.kind,
-            ErrorKind::UnknownType(name) if name == "dep.Width(...)"
-        ));
-
-        let mut sema = gather_two_file_declarations_for_testing(
-            "const dep = @import(\"dep.rue\");
+        let mut sema = gather_declarations_for_testing(
+            "struct Item { value: i32 }
              fn Width(comptime T: type) -> i32 { 2 }
              fn main() -> i32 { 0 }",
-            "pub struct Item { value: i32 }",
         );
         let type_param = sema.interner.get_or_intern("T");
+        let (arena, syntax) = structured_type_for_sema(&mut sema, "[T; Width(Item)]");
         assert_eq!(
-            sema.validate_deferred_type_position_for_testing(
-                "[T; Width(dep.Item)]",
+            sema.validate_deferred_structured_type_for_testing(
+                &arena,
+                syntax,
                 &[type_param],
                 span,
             )
@@ -3962,14 +3914,16 @@ fn main() -> i32 {
     }
 
     #[test]
-    fn array_length_nested_type_argument_preserves_provider_diagnostic() {
+    fn nested_type_constructor_argument_preserves_provider_diagnostic() {
         let mut sema = gather_declarations_for_testing(
-            "fn Width(comptime T: type) -> i32 { 2 }
+            "fn Make(comptime T: type) -> type { T }
              fn main() -> i32 { 0 }",
         );
+        let (arena, syntax) = structured_type_for_sema(&mut sema, "Make([i32])");
         let error = sema
-            .resolve_type_syntax_for_testing(
-                "[i32; Width([i32])]",
+            .resolve_structured_type_syntax_for_testing(
+                &arena,
+                syntax,
                 Span::with_file(FileId::DEFAULT, 0, 0),
             )
             .unwrap_err();
@@ -3985,12 +3939,15 @@ fn main() -> i32 {
     #[test]
     fn array_length_reducer_failure_preserves_provider_diagnostic() {
         let mut sema = gather_declarations_for_testing(
-            "fn Width(comptime T: type) -> i32 { Width(T) }
+            "struct Leaf { value: i32 }
+             fn Width(comptime T: type) -> i32 { Width(T) }
              fn main() -> i32 { 0 }",
         );
+        let (arena, syntax) = structured_type_for_sema(&mut sema, "[i32; Width(Leaf)]");
         let error = sema
-            .resolve_type_syntax_for_testing(
-                "[i32; Width(i32)]",
+            .resolve_structured_type_syntax_for_testing(
+                &arena,
+                syntax,
                 Span::with_file(FileId::DEFAULT, 0, 0),
             )
             .unwrap_err();
@@ -4067,8 +4024,10 @@ fn main() -> i32 {
             "[i32; 4]",
             "Str(4)",
         ] {
+            let (arena, root) = structured_type_for_sema(&mut sema, syntax);
             assert!(
-                sema.resolve_type_syntax_for_testing(syntax, span).is_ok(),
+                sema.resolve_structured_type_syntax_for_testing(&arena, root, span)
+                    .is_ok(),
                 "scoped resolution should reach '{syntax}' from its own file"
             );
         }

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -15,8 +15,6 @@ use lasso::Spur;
 use rue_error::{CompileError, CompileResult, ErrorKind, PreviewFeature};
 use rue_span::{FileId, Span};
 
-#[cfg(test)]
-use super::context::AnalysisContext;
 use super::{DeclarationPhase, Sema};
 
 /// Frame-displacement budget a single object's slots must address: `i32::MAX`
@@ -36,10 +34,7 @@ pub(crate) const MAX_TYPE_SLOTS: u64 = MAX_TYPE_SIZE_BYTES / 8;
 use super::info::FunctionInfo;
 use crate::inference::InferType;
 use crate::sema::ConstValue;
-use crate::types::{
-    ArrayLen, ArrayTypeId, StructId, Type, TypeKind, parse_array_type_syntax,
-    parse_type_call_syntax,
-};
+use crate::types::{ArrayLen, ArrayTypeId, StructId, Type, TypeKind};
 
 const COMPTIME_PARAMETER_INDEX_THRESHOLD: usize = 8;
 
@@ -142,9 +137,14 @@ pub(super) trait TypeSyntaxHost {
         kind: TypeSyntaxNamedKind,
     ) -> CompileResult<Option<crate::SemanticTypeFact<Type, FileId>>>;
     fn type_syntax_make_str(&mut self, span: Span) -> CompileResult<Type>;
-    fn type_syntax_make_array(&mut self, element: Type, length: u64) -> Type;
-    fn type_syntax_make_ptr_const(&mut self, pointee: Type) -> Type;
-    fn type_syntax_make_ptr_mut(&mut self, pointee: Type) -> Type;
+    fn type_syntax_make_array(
+        &mut self,
+        element: Type,
+        length: u64,
+        span: Span,
+    ) -> CompileResult<Type>;
+    fn type_syntax_make_ptr_const(&mut self, pointee: Type, span: Span) -> CompileResult<Type>;
+    fn type_syntax_make_ptr_mut(&mut self, pointee: Type, span: Span) -> CompileResult<Type>;
     fn type_syntax_require_slices(&mut self, span: Span) -> CompileResult<()>;
     fn type_syntax_make_slice(
         &mut self,
@@ -163,8 +163,8 @@ pub(super) trait TypeSyntaxHost {
     fn type_syntax_reduce_constructor(
         &mut self,
         head: &crate::SemanticTypeConstructorHead<Spur, Spur, FileId>,
-        type_arguments: &HashMap<Spur, Type>,
-        value_arguments: &HashMap<Spur, ConstValue>,
+        type_arguments: &[(Spur, Type)],
+        value_arguments: &[(Spur, ConstValue)],
         span: Span,
     ) -> CompileResult<Option<ConstValue>>;
     fn type_syntax_value_const(&self, file: FileId, name: Spur) -> Option<super::info::ConstInfo>;
@@ -185,11 +185,14 @@ pub(super) trait TypeSyntaxHost {
         name: String,
         kind: super::DeclarationTypeDependencyTargetKind,
     );
-    fn type_syntax_failure_compile_error(
-        &self,
-        failure: crate::SemanticTypeSyntaxError<Infallible, CompileError, FileId, Spur>,
-        span: Span,
-    ) -> CompileError;
+}
+
+/// Additional host capabilities used only while validating a declaration type
+/// whose generic substitutions are not available yet. Keeping these off the
+/// ordinary resolver contract lets every body-analysis host share the one
+/// structured resolver without implementing declaration-epoch machinery it
+/// cannot use.
+pub(super) trait DeferredTypeSyntaxHost: TypeSyntaxHost {
     fn type_syntax_comptime_value_failure(
         &self,
         failure: crate::SemanticTypeSyntaxError<Infallible, CompileError, FileId, Spur>,
@@ -216,12 +219,6 @@ pub(super) trait TypeSyntaxHost {
         function: &FunctionInfo,
         index: usize,
         declared_type: Type,
-        type_substitutions: &HashMap<Spur, Type>,
-        value_substitutions: &HashMap<Spur, ConstValue>,
-    ) -> CompileResult<Type>;
-    fn type_syntax_resolve_substituted_return_type(
-        &mut self,
-        function: &FunctionInfo,
         type_substitutions: &HashMap<Spur, Type>,
         value_substitutions: &HashMap<Spur, ConstValue>,
     ) -> CompileResult<Type>;
@@ -535,9 +532,7 @@ impl<H: TypeSyntaxHost>
                 })?;
                 ArrayLen::Literal(value)
             }
-            crate::SemanticValueSyntax::Name(name) | crate::SemanticValueSyntax::Rendered(name) => {
-                ArrayLen::Named(name.to_owned())
-            }
+            crate::SemanticValueSyntax::Name(name) => ArrayLen::Named(name.to_owned()),
         };
         provider_failure(self.resolve_array_length_fact(*scope, &length)).map(Some)
     }
@@ -566,18 +561,19 @@ impl<H: TypeSyntaxHost>
     }
 
     fn array_type(&mut self, element: Type, length: Option<u64>) -> SemaProviderResult<Type> {
-        Ok(self.host.type_syntax_make_array(
+        provider_failure(self.host.type_syntax_make_array(
             element,
             length.expect("concrete type resolution always resolves array lengths"),
+            self.span,
         ))
     }
 
     fn ptr_const_type(&mut self, pointee: Type) -> SemaProviderResult<Type> {
-        Ok(self.host.type_syntax_make_ptr_const(pointee))
+        provider_failure(self.host.type_syntax_make_ptr_const(pointee, self.span))
     }
 
     fn ptr_mut_type(&mut self, pointee: Type) -> SemaProviderResult<Type> {
-        Ok(self.host.type_syntax_make_ptr_mut(pointee))
+        provider_failure(self.host.type_syntax_make_ptr_mut(pointee, self.span))
     }
 
     fn preflight_slice(&mut self, _scope: &FileId, _syntax: &str) -> SemaProviderResult<()> {
@@ -611,8 +607,7 @@ impl<H: TypeSyntaxHost>
                         ))
                     })?
                 }
-                [crate::SemanticValueSyntax::Name(argument)]
-                | [crate::SemanticValueSyntax::Rendered(argument)] => {
+                [crate::SemanticValueSyntax::Name(argument)] => {
                     provider_failure(self.resolve_array_length_fact(
                         *scope,
                         &ArrayLen::Named((*argument).to_owned()),
@@ -674,20 +669,14 @@ impl<H: TypeSyntaxHost>
         if let crate::SemanticValueSyntax::Integer(value) = syntax {
             return Ok(ConstValue::Integer(value));
         }
-        let syntax = match syntax {
-            crate::SemanticValueSyntax::Name(syntax)
-            | crate::SemanticValueSyntax::Rendered(syntax) => syntax,
-            crate::SemanticValueSyntax::Integer(_) => unreachable!(),
-        };
         match self.resolve_value_argument_fact(*scope, constructor, syntax) {
             Ok(value) => Ok(value),
             Err(error) if self.resolution_context == SemaTypeResolutionContext::ArrayLength => {
-                let length = syntax
-                    .parse::<u64>()
-                    .map(ArrayLen::Literal)
-                    .unwrap_or_else(|_| ArrayLen::Named(syntax.to_string()));
+                let crate::SemanticValueSyntax::Name(name) = syntax else {
+                    return provider_failure(Err(error));
+                };
                 provider_failure(
-                    self.resolve_array_length_fact(*scope, &length)
+                    self.resolve_array_length_fact(*scope, &ArrayLen::Named(name.to_owned()))
                         .map(|value| ConstValue::Integer(value as i128)),
                 )
             }
@@ -701,11 +690,9 @@ impl<H: TypeSyntaxHost>
         type_arguments: &[(Spur, Type)],
         value_arguments: &[(Spur, ConstValue)],
     ) -> SemaProviderResult<Option<crate::SemanticComptimeCallResult<Type, ConstValue>>> {
-        let type_arguments = type_arguments.iter().copied().collect::<HashMap<_, _>>();
-        let value_arguments = value_arguments.iter().copied().collect::<HashMap<_, _>>();
         provider_failure(
             self.host
-                .type_syntax_reduce_constructor(head, &type_arguments, &value_arguments, self.span)
+                .type_syntax_reduce_constructor(head, type_arguments, value_arguments, self.span)
                 .map(|result| match (head.returns_type, result) {
                     (_, None) => None,
                     (true, Some(ConstValue::Type(ty))) => {
@@ -753,7 +740,7 @@ impl<'s, 'c, H: TypeSyntaxHost> TypeSyntaxProvider<'s, 'c, H> {
 
     fn resolve_array_length_fact_inner(
         &mut self,
-        scope: FileId,
+        _scope: FileId,
         length: &ArrayLen,
     ) -> CompileResult<u64> {
         let ArrayLen::Named(name) = length else {
@@ -762,13 +749,6 @@ impl<'s, 'c, H: TypeSyntaxHost> TypeSyntaxProvider<'s, 'c, H> {
             };
             return Ok(*value);
         };
-        if let Ok(value) = name.parse::<u64>() {
-            return Ok(value);
-        }
-        if let Some((callee, arguments)) = parse_type_call_syntax(name) {
-            return self.resolve_array_length_call_fact(scope, &callee, &arguments);
-        }
-
         let symbol = self.host.type_syntax_symbol(name);
         let root_file = self.root_authority.file();
         let value = if let Some(value) = self
@@ -804,82 +784,6 @@ impl<'s, 'c, H: TypeSyntaxHost> TypeSyntaxProvider<'s, 'c, H> {
             None => {
                 Err(self.invalid_array_length(format!("array length '{name}' is not an integer")))
             }
-        }
-    }
-
-    fn resolve_array_length_call_fact(
-        &mut self,
-        scope: FileId,
-        callee: &str,
-        arguments: &[String],
-    ) -> CompileResult<u64> {
-        let call = crate::resolve_semantic_comptime_call(
-            self,
-            &scope,
-            callee,
-            arguments,
-            crate::SemanticComptimeCallExpectation::Value,
-        )
-        .map_err(|failure| self.array_length_call_failure(callee, failure))?;
-        match call.result {
-            crate::SemanticComptimeCallResult::Value(ConstValue::Integer(value)) if value >= 0 => {
-                u64::try_from(value).map_err(|_| {
-                    self.invalid_array_length(format!(
-                        "array length '{callee}(...)' ({value}) is too large"
-                    ))
-                })
-            }
-            crate::SemanticComptimeCallResult::Value(ConstValue::Integer(value)) => Err(self
-                .invalid_array_length(format!(
-                    "array length '{callee}(...)' is negative ({value})"
-                ))),
-            crate::SemanticComptimeCallResult::Value(_) => Err(self.invalid_array_length(format!(
-                "array length call '{callee}(...)' did not evaluate to a compile-time integer"
-            ))),
-            crate::SemanticComptimeCallResult::Type(_) => {
-                unreachable!("value call expectation rejects type-returning callees")
-            }
-        }
-    }
-
-    fn array_length_call_failure(
-        &self,
-        callee: &str,
-        failure: crate::SemanticTypeSyntaxError<Infallible, CompileError, FileId, Spur>,
-    ) -> CompileError {
-        use crate::SemanticResolutionError as E;
-        use crate::SemanticTypeSyntaxFailure as F;
-
-        match failure {
-            E::ProviderAbort(error) => match error {},
-            E::ProviderFailure(error) => error,
-            E::Semantic(F::TypeWhereValueExpected { .. }) => self.invalid_array_length(format!(
-                "array length call '{callee}(...)' must return a value, not a type"
-            )),
-            E::Semantic(F::InvalidConstructorArity { .. })
-            | E::Semantic(F::RuntimeConstructorParameter { .. }) => self.invalid_array_length(
-                format!(
-                    "array length call '{callee}(...)' is not a compile-time constant; its callee must be a value-returning function whose parameters are all `comptime`"
-                ),
-            ),
-            E::Semantic(F::ConstructorDidNotReduce { .. }) => self.invalid_array_length(format!(
-                "array length call '{callee}(...)' did not evaluate to a compile-time integer"
-            )),
-            E::ComptimeCallTypeArgument { error, .. } => {
-                self.host.type_syntax_failure_compile_error(*error, self.span)
-            }
-            E::Semantic(F::Path(_))
-            | E::Semantic(F::UnknownType { .. })
-            | E::Semantic(F::UnknownModuleMember { .. })
-            | E::Semantic(F::PrivateItem { .. })
-            | E::Semantic(F::AmbiguousItem { .. })
-            | E::Semantic(F::NotTypeConstructor { .. }) => self.invalid_array_length(format!(
-                "'{callee}' is not a function; array lengths must be an integer literal, a `const`, a `comptime` value parameter, or a call to a comptime function"
-            )),
-            E::Semantic(F::ValueWhereTypeExpected { argument, .. }) => self
-                .invalid_array_length(format!(
-                    "array length call '{callee}(...)' has non-type argument '{argument}' for a `type` parameter"
-                )),
         }
     }
 
@@ -930,12 +834,14 @@ impl<'s, 'c, H: TypeSyntaxHost> TypeSyntaxProvider<'s, 'c, H> {
         &mut self,
         _scope: FileId,
         constructor: &str,
-        syntax: &str,
+        syntax: crate::SemanticValueSyntax<'_>,
     ) -> CompileResult<ConstValue> {
-        let text = syntax.trim();
-        if let Ok(value) = text.parse::<i128>() {
+        let crate::SemanticValueSyntax::Name(text) = syntax else {
+            let crate::SemanticValueSyntax::Integer(value) = syntax else {
+                unreachable!()
+            };
             return Ok(ConstValue::Integer(value));
-        }
+        };
         if text == "true" {
             return Ok(ConstValue::Bool(true));
         }
@@ -983,12 +889,12 @@ pub(super) enum DeferredValueResolution {
     Pending,
 }
 
-pub(super) struct DeferredTypeSyntaxProvider<'s, 'c, 'p, H: TypeSyntaxHost> {
+pub(super) struct DeferredTypeSyntaxProvider<'s, 'c, 'p, H: DeferredTypeSyntaxHost> {
     inner: TypeSyntaxProvider<'s, 'c, H>,
     parameters: &'p DeferredParameterFacts<'c>,
 }
 
-impl<'s, 'c, 'p, H: TypeSyntaxHost> DeferredTypeSyntaxProvider<'s, 'c, 'p, H> {
+impl<'s, 'c, 'p, H: DeferredTypeSyntaxHost> DeferredTypeSyntaxProvider<'s, 'c, 'p, H> {
     pub(super) fn new(
         host: &'s mut H,
         span: Span,
@@ -1087,13 +993,22 @@ impl<'s, 'c, 'p, H: TypeSyntaxHost> DeferredTypeSyntaxProvider<'s, 'c, 'p, H> {
 
     fn validate_value_position(
         &mut self,
-        value_name: &str,
+        syntax: crate::SemanticValueSyntax<'_>,
         expected: Option<Type>,
         contract: Option<(Spur, Spur)>,
         require_integer: bool,
     ) -> CompileResult<Option<ConstValue>> {
-        let value_name = value_name.trim();
-        if let Some(symbol) = self.inner.host.existing_type_syntax_symbol(value_name) {
+        let rendered;
+        let value_name = match syntax {
+            crate::SemanticValueSyntax::Integer(value) => {
+                rendered = value.to_string();
+                rendered.as_str()
+            }
+            crate::SemanticValueSyntax::Name(name) => name,
+        };
+        if let crate::SemanticValueSyntax::Name(value_name) = syntax
+            && let Some(symbol) = self.inner.host.existing_type_syntax_symbol(value_name)
+        {
             if self.parameters.contains_type(symbol) {
                 if expected != Some(Type::COMPTIME_TYPE) && (expected.is_some() || require_integer)
                 {
@@ -1154,106 +1069,12 @@ impl<'s, 'c, 'p, H: TypeSyntaxHost> DeferredTypeSyntaxProvider<'s, 'c, 'p, H> {
             }
         }
 
-        if let Some((call_name, arguments)) = parse_type_call_syntax(value_name) {
-            let call = {
-                let root_file = self.inner.span.file_id;
-                let mut provider = DeferredTypeSyntaxProvider::new(
-                    self.inner.host,
-                    self.inner.span,
-                    self.parameters,
-                );
-                let call = crate::resolve_semantic_comptime_call(
-                    &mut provider,
-                    &root_file,
-                    &call_name,
-                    &arguments,
-                    crate::SemanticComptimeCallExpectation::Value,
-                );
-                provider.flush_observed_type_dependencies();
-                call
-            }
-            .map_err(|failure| {
-                self.inner
-                    .host
-                    .type_syntax_comptime_value_failure(failure, self.inner.span)
-            })?;
-            let function = self.inner.host.type_syntax_function_info(call.head.key);
-            let type_substitutions = call
-                .type_arguments
-                .iter()
-                .filter_map(|(name, value)| match value {
-                    DeferredTypeResolution::Resolved(value) => Some((*name, *value)),
-                    DeferredTypeResolution::Pending => None,
-                })
-                .collect::<HashMap<_, _>>();
-            let value_substitutions = call
-                .value_arguments
-                .iter()
-                .filter_map(|(name, value)| match value {
-                    DeferredValueResolution::Resolved(value) => Some((*name, *value)),
-                    DeferredValueResolution::Pending => None,
-                })
-                .collect::<HashMap<_, _>>();
-            let concrete = match call.result {
-                crate::SemanticComptimeCallResult::Type(DeferredTypeResolution::Resolved(ty)) => {
-                    Some(ConstValue::Type(ty))
-                }
-                crate::SemanticComptimeCallResult::Value(DeferredValueResolution::Resolved(
-                    value,
-                )) => Some(value),
-                crate::SemanticComptimeCallResult::Type(DeferredTypeResolution::Pending)
-                | crate::SemanticComptimeCallResult::Value(DeferredValueResolution::Pending) => {
-                    None
-                }
+        let value = if let crate::SemanticValueSyntax::Integer(value) = syntax {
+            ConstValue::Integer(value)
+        } else {
+            let crate::SemanticValueSyntax::Name(value_name) = syntax else {
+                unreachable!()
             };
-            let found = if call.head.returns_type {
-                Some(Type::COMPTIME_TYPE)
-            } else if function.return_type != Type::COMPTIME_TYPE {
-                Some(function.return_type)
-            } else {
-                let type_params = call
-                    .head
-                    .parameters
-                    .iter()
-                    .filter_map(|parameter| parameter.is_type.then_some(parameter.name))
-                    .collect::<Vec<_>>();
-                let value_params = call
-                    .head
-                    .parameters
-                    .iter()
-                    .filter_map(|parameter| (!parameter.is_type).then_some(parameter.name))
-                    .collect::<Vec<_>>();
-                self.inner
-                    .host
-                    .type_syntax_signature_substitutions_are_ready(
-                        function.return_type_syntax,
-                        &type_params,
-                        &value_params,
-                        &type_substitutions,
-                        &value_substitutions,
-                    )
-                    .then(|| {
-                        self.inner.host.type_syntax_resolve_substituted_return_type(
-                            &function,
-                            &type_substitutions,
-                            &value_substitutions,
-                        )
-                    })
-                    .transpose()?
-            };
-            self.inner.host.type_syntax_validate_deferred_value(
-                concrete,
-                found,
-                expected,
-                contract,
-                require_integer,
-                value_name,
-                self.inner.span,
-            )?;
-            return Ok(concrete);
-        }
-
-        let value = {
             let mut provider = TypeSyntaxProvider::new(
                 self.inner.host,
                 self.inner.span,
@@ -1265,23 +1086,20 @@ impl<'s, 'c, 'p, H: TypeSyntaxHost> DeferredTypeSyntaxProvider<'s, 'c, 'p, H> {
             let value = match provider.resolve_value_argument_fact(
                 provider.span.file_id,
                 "compile-time call",
-                value_name,
+                syntax,
             ) {
                 Ok(value) => Ok(value),
-                Err(_) if require_integer => {
-                    let length = value_name
-                        .parse::<u64>()
-                        .map(ArrayLen::Literal)
-                        .unwrap_or_else(|_| ArrayLen::Named(value_name.to_string()));
-                    provider
-                        .resolve_array_length_fact(provider.span.file_id, &length)
-                        .map(|length| ConstValue::Integer(length as i128))
-                }
+                Err(_) if require_integer => provider
+                    .resolve_array_length_fact(
+                        provider.span.file_id,
+                        &ArrayLen::Named(value_name.to_owned()),
+                    )
+                    .map(|length| ConstValue::Integer(length as i128)),
                 Err(error) => Err(error),
             };
             provider.flush_observed_type_dependencies();
-            value
-        }?;
+            value?
+        };
         self.inner.host.type_syntax_validate_deferred_value(
             Some(value),
             Some(value.get_type()),
@@ -1295,7 +1113,8 @@ impl<'s, 'c, 'p, H: TypeSyntaxHost> DeferredTypeSyntaxProvider<'s, 'c, 'p, H> {
     }
 }
 
-impl<H: TypeSyntaxHost> crate::SemanticModulePathProvider<FileId, crate::types::ModuleId, FileId>
+impl<H: DeferredTypeSyntaxHost>
+    crate::SemanticModulePathProvider<FileId, crate::types::ModuleId, FileId>
     for DeferredTypeSyntaxProvider<'_, '_, '_, H>
 {
     type Abort = Infallible;
@@ -1328,7 +1147,7 @@ impl<H: TypeSyntaxHost> crate::SemanticModulePathProvider<FileId, crate::types::
     }
 }
 
-impl<H: TypeSyntaxHost>
+impl<H: DeferredTypeSyntaxHost>
     crate::SemanticTypeSyntaxProvider<
         FileId,
         crate::types::ModuleId,
@@ -1529,12 +1348,15 @@ impl<H: TypeSyntaxHost>
             });
         };
         let name = match length {
-            crate::SemanticValueSyntax::Name(name) | crate::SemanticValueSyntax::Rendered(name) => {
-                name
-            }
+            crate::SemanticValueSyntax::Name(name) => name,
             crate::SemanticValueSyntax::Integer(_) => unreachable!(),
         };
-        let value = provider_failure(self.validate_value_position(name, None, None, true))?;
+        let value = provider_failure(self.validate_value_position(
+            crate::SemanticValueSyntax::Name(name),
+            None,
+            None,
+            true,
+        ))?;
         match value {
             None => Ok(None),
             Some(ConstValue::Integer(value)) => u64::try_from(value).map(Some).map_err(|_| {
@@ -1673,15 +1495,6 @@ impl<H: TypeSyntaxHost>
             self.inner.host.type_syntax_symbol(constructor),
             head.parameters[parameter_index].name,
         ));
-        let rendered;
-        let syntax = match syntax {
-            crate::SemanticValueSyntax::Integer(value) => {
-                rendered = value.to_string();
-                rendered.as_str()
-            }
-            crate::SemanticValueSyntax::Name(syntax)
-            | crate::SemanticValueSyntax::Rendered(syntax) => syntax,
-        };
         provider_failure(self.validate_value_position(syntax, expected, contract, false)).map(
             |value| match value {
                 Some(value) => DeferredValueResolution::Resolved(value),
@@ -1772,7 +1585,7 @@ fn module_path_compile_error(
     }
 }
 
-fn module_path_resolution_compile_error(
+pub(super) fn module_path_resolution_compile_error(
     failure: crate::SemanticResolutionError<
         Infallible,
         CompileError,
@@ -1826,11 +1639,23 @@ pub(super) fn semantic_type_syntax_compile_error(
         E::ProviderFailure(error) => error,
         E::Semantic(F::Path(failure)) => module_path_compile_error(failure, span),
         E::Semantic(F::UnknownType { syntax }) => {
-            let display = parse_type_call_syntax(&syntax)
-                .map(|(call, _)| format!("{call}(...)"))
-                .unwrap_or_else(|| syntax.to_string());
-            CompileError::new(ErrorKind::UnknownType(display), span)
+            CompileError::new(ErrorKind::UnknownType(syntax.to_string()), span)
         }
+        E::Semantic(F::UnknownConstructor {
+            constructor,
+            expectation: crate::SemanticComptimeCallExpectation::Type,
+        }) => CompileError::new(ErrorKind::UnknownType(format!("{constructor}(...)")), span),
+        E::Semantic(F::UnknownConstructor {
+            constructor,
+            expectation: crate::SemanticComptimeCallExpectation::Value,
+        }) => CompileError::new(
+            ErrorKind::InvalidArrayLength {
+                reason: format!(
+                    "'{constructor}' is not a function; array lengths must be an integer literal, a `const`, a `comptime` value parameter, or a call to a comptime function"
+                ),
+            },
+            span,
+        ),
         E::Semantic(F::UnknownModuleMember { module, member, .. }) => CompileError::new(
             ErrorKind::UnknownModuleMember {
                 module_name: module.to_string(),
@@ -1873,18 +1698,37 @@ pub(super) fn semantic_type_syntax_compile_error(
             constructor,
             expected,
             found,
+            expectation: crate::SemanticComptimeCallExpectation::Type,
             ..
         })
         | E::Semantic(F::RuntimeConstructorParameter {
             constructor,
             expected,
             found,
+            expectation: crate::SemanticComptimeCallExpectation::Type,
             ..
         }) => CompileError::new(
             ErrorKind::ComptimeEvaluationFailed {
                 reason: format!(
                     "type constructor '{}' expects {} comptime type argument(s), but {} were provided",
                     constructor, expected, found
+                ),
+            },
+            span,
+        ),
+        E::Semantic(F::InvalidConstructorArity {
+            constructor,
+            expectation: crate::SemanticComptimeCallExpectation::Value,
+            ..
+        })
+        | E::Semantic(F::RuntimeConstructorParameter {
+            constructor,
+            expectation: crate::SemanticComptimeCallExpectation::Value,
+            ..
+        }) => CompileError::new(
+            ErrorKind::InvalidArrayLength {
+                reason: format!(
+                    "array length call '{constructor}(...)' is not a compile-time constant; its callee must be a value-returning function whose parameters are all `comptime`"
                 ),
             },
             span,
@@ -2059,14 +1903,25 @@ impl<'source, D: DeclarationPhase> TypeSyntaxHost for Sema<'source, D> {
     fn type_syntax_make_str(&mut self, span: Span) -> CompileResult<Type> {
         self.get_or_create_str_struct(span)
     }
-    fn type_syntax_make_array(&mut self, element: Type, length: u64) -> Type {
-        Type::new_array(self.get_or_create_array_type(element, length))
+    fn type_syntax_make_array(
+        &mut self,
+        element: Type,
+        length: u64,
+        _span: Span,
+    ) -> CompileResult<Type> {
+        Ok(Type::new_array(
+            self.get_or_create_array_type(element, length),
+        ))
     }
-    fn type_syntax_make_ptr_const(&mut self, pointee: Type) -> Type {
-        Type::new_ptr_const(self.type_pool.intern_ptr_const_from_type(pointee))
+    fn type_syntax_make_ptr_const(&mut self, pointee: Type, _span: Span) -> CompileResult<Type> {
+        Ok(Type::new_ptr_const(
+            self.type_pool.intern_ptr_const_from_type(pointee),
+        ))
     }
-    fn type_syntax_make_ptr_mut(&mut self, pointee: Type) -> Type {
-        Type::new_ptr_mut(self.type_pool.intern_ptr_mut_from_type(pointee))
+    fn type_syntax_make_ptr_mut(&mut self, pointee: Type, _span: Span) -> CompileResult<Type> {
+        Ok(Type::new_ptr_mut(
+            self.type_pool.intern_ptr_mut_from_type(pointee),
+        ))
     }
     fn type_syntax_require_slices(&mut self, span: Span) -> CompileResult<()> {
         self.require_preview(PreviewFeature::Slices, "the slice type `[T]`", span)
@@ -2157,11 +2012,13 @@ impl<'source, D: DeclarationPhase> TypeSyntaxHost for Sema<'source, D> {
     fn type_syntax_reduce_constructor(
         &mut self,
         head: &crate::SemanticTypeConstructorHead<Spur, Spur, FileId>,
-        type_arguments: &HashMap<Spur, Type>,
-        value_arguments: &HashMap<Spur, ConstValue>,
+        type_arguments: &[(Spur, Type)],
+        value_arguments: &[(Spur, ConstValue)],
         span: Span,
     ) -> CompileResult<Option<ConstValue>> {
-        self.reduce_type_ctor_body(head.key, type_arguments, value_arguments, span)
+        let type_arguments = type_arguments.iter().copied().collect::<HashMap<_, _>>();
+        let value_arguments = value_arguments.iter().copied().collect::<HashMap<_, _>>();
+        self.reduce_type_ctor_body(head.key, &type_arguments, &value_arguments, span)
             .map_err(|error| Self::label_ctor_instantiation_site(error, span))
     }
 
@@ -2251,14 +2108,9 @@ impl<'source, D: DeclarationPhase> TypeSyntaxHost for Sema<'source, D> {
     ) {
         self.record_resolved_declaration_type_target(file, name, kind);
     }
-    fn type_syntax_failure_compile_error(
-        &self,
-        failure: crate::SemanticTypeSyntaxError<Infallible, CompileError, FileId, Spur>,
-        span: Span,
-    ) -> CompileError {
-        self.type_syntax_compile_error(failure, span)
-    }
+}
 
+impl<'source, D: DeclarationPhase> DeferredTypeSyntaxHost for Sema<'source, D> {
     fn type_syntax_comptime_value_failure(
         &self,
         failure: crate::SemanticTypeSyntaxError<Infallible, CompileError, FileId, Spur>,
@@ -2360,15 +2212,6 @@ impl<'source, D: DeclarationPhase> TypeSyntaxHost for Sema<'source, D> {
             type_substitutions,
             value_substitutions,
         )
-    }
-
-    fn type_syntax_resolve_substituted_return_type(
-        &mut self,
-        function: &FunctionInfo,
-        type_substitutions: &HashMap<Spur, Type>,
-        value_substitutions: &HashMap<Spur, ConstValue>,
-    ) -> CompileResult<Type> {
-        self.resolve_substituted_return_type(function, type_substitutions, value_substitutions)
     }
 
     fn type_syntax_type_mentions_type_param(
@@ -2774,8 +2617,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     pub(crate) fn str_fixed_capacity(&self, ty: Type) -> Option<u64> {
         if let TypeKind::Struct(struct_id) = ty.kind() {
             let name = &self.body_type_pool().struct_def(struct_id).name;
-            let digits = name.strip_prefix("Str(")?.strip_suffix(')')?;
-            digits.parse::<u64>().ok()
+            crate::types::fixed_string_capacity(name)
         } else {
             None
         }
@@ -2794,23 +2636,18 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
 impl<'a, D: DeclarationPhase> Sema<'a, D> {
     /// If `ty` is a synthetic slice struct `[T]` (ADR-0043, RUE-322), return its
-    /// element type `T`; otherwise `None`. Detected by the struct name being
-    /// slice syntax (`[..]` that is not a fixed-array `[T; N]`), the same naming
-    /// trick used for anonymous structs.
+    /// element type `T`; otherwise `None`. Fixed arrays have their own
+    /// [`TypeKind::Array`] identity, so any struct with the synthetic bracketed
+    /// name is a slice.
     pub(crate) fn slice_element_type(&self, ty: Type) -> Option<Type> {
         if let TypeKind::Struct(struct_id) = ty.kind() {
             let def = self.type_pool.struct_def(struct_id);
             // A `[T]` slice, or the `str` string type which is `[u8]` + UTF-8
             // (ADR-0043 Phase 3, RUE-324): both are `{ptr: ptr const E, len}`
             // fat pointers, so `.len()` and `s[i]` reuse one path.
-            let is_slice = def.name.starts_with('[')
-                && def.name.ends_with(']')
-                && parse_array_type_syntax(&def.name).is_none();
-            // A fixed-capacity `Str(N)` (ADR-0043 Phase 5, RUE-326) is `[u8; N]`
-            // + UTF-8 and shares the `{ptr, len}` shape, so `.len()` and byte
-            // indexing route through the same slice/str path as `str`.
-            let is_str_fixed = def.name.starts_with("Str(") && def.name.ends_with(')');
-            if is_slice || &*def.name == "str" || is_str_fixed {
+            if crate::types::is_slice_struct_name(&def.name)
+                || crate::types::is_string_view_struct_name(&def.name)
+            {
                 // Field 0 is `ptr const T`; recover T from its pointee.
                 if let TypeKind::PtrConst(ptr_id) = def.fields[0].ty.kind() {
                     return Some(self.type_pool.ptr_const_def(ptr_id));
@@ -2908,75 +2745,66 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     }
 
     #[cfg(test)]
-    fn resolve_type_syntax_in_scope(
+    pub(crate) fn resolve_structured_type_syntax_for_testing(
         &mut self,
-        syntax: &str,
-        root_file: FileId,
+        arena: &rue_rir::RirTypeSyntaxArena<Spur>,
+        syntax: rue_rir::RirTypeSyntaxRef,
         span: Span,
-        context: Option<&AnalysisContext>,
     ) -> CompileResult<Type> {
-        let (type_substitutions, value_substitutions) = context
-            .map(|context| (&context.comptime_type_vars, &context.comptime_value_vars))
-            .unzip();
-        self.resolve_type_syntax_with_substitutions(
+        self.resolve_structured_type_syntax_with_epoch_facts(
+            arena,
             syntax,
-            root_file,
+            span.file_id,
             span,
-            type_substitutions,
-            value_substitutions,
+            None,
+            None,
         )
         .map_err(|failure| self.type_syntax_compile_error(failure, span))
     }
 
     #[cfg(test)]
-    pub(crate) fn resolve_type_syntax_for_testing(
+    pub(crate) fn validate_deferred_structured_type_for_testing(
         &mut self,
-        syntax: &str,
+        arena: &rue_rir::RirTypeSyntaxArena<Spur>,
+        syntax: rue_rir::RirTypeSyntaxRef,
+        type_params: &[Spur],
         span: Span,
-    ) -> CompileResult<Type> {
-        self.resolve_type_syntax_in_scope(syntax, span.file_id, span, None)
-    }
+    ) -> CompileResult<Option<Type>> {
+        fn contains_value_call(
+            arena: &rue_rir::RirTypeSyntaxArena<Spur>,
+            syntax: rue_rir::RirTypeSyntaxRef,
+        ) -> bool {
+            if matches!(
+                arena.node(syntax),
+                Some(rue_rir::RirTypeSyntaxNode::ValueCall { .. })
+            ) {
+                return true;
+            }
+            let mut found = false;
+            arena.visit_child_references(syntax, |child| {
+                found |= contains_value_call(arena, child);
+            }) && found
+        }
 
-    #[cfg(test)]
-    fn resolve_type_syntax_with_substitutions(
-        &mut self,
-        syntax: &str,
-        root_file: FileId,
-        span: Span,
-        type_substitutions: Option<&HashMap<Spur, Type>>,
-        value_substitutions: Option<&HashMap<Spur, ConstValue>>,
-    ) -> Result<Type, crate::SemanticTypeSyntaxError<Infallible, CompileError, FileId, Spur>> {
-        super::BodyAnalysisHost::resolve_type_syntax(
-            self,
-            super::fact_mode::TypeSyntaxRequest {
-                syntax,
-                root_file,
-                span,
-                type_substitutions,
-                value_substitutions,
-            },
-        )
-    }
-
-    pub(crate) fn resolve_type_syntax_with_epoch_facts(
-        &mut self,
-        syntax: &str,
-        root_file: FileId,
-        span: Span,
-        type_substitutions: Option<&HashMap<Spur, Type>>,
-        value_substitutions: Option<&HashMap<Spur, ConstValue>>,
-    ) -> Result<Type, crate::SemanticTypeSyntaxError<Infallible, CompileError, FileId, Spur>> {
-        let mut provider = TypeSyntaxProvider::new(
-            self,
-            span,
-            TypeRootAuthority::in_file(root_file),
-            SemaTypeResolutionContext::Type,
-            type_substitutions,
-            value_substitutions,
+        let parameters = DeferredParameterFacts::new(type_params, &[], &[]);
+        let interner = self.interner;
+        let mut provider = DeferredTypeSyntaxProvider::new(self, span, &parameters);
+        let result = crate::resolve_structured_semantic_type_syntax_with(
+            &mut provider,
+            &span.file_id,
+            arena,
+            syntax,
+            |symbol| interner.resolve(symbol),
         );
-        let result = crate::resolve_semantic_type_syntax(&mut provider, &root_file, syntax);
         provider.flush_observed_type_dependencies();
-        result
+        match result {
+            Ok(DeferredTypeResolution::Resolved(ty)) => Ok(Some(ty)),
+            Ok(DeferredTypeResolution::Pending) => Ok(None),
+            Err(failure) if contains_value_call(arena, syntax) => Err(
+                DeferredTypeSyntaxHost::type_syntax_comptime_value_failure(self, failure, span),
+            ),
+            Err(failure) => Err(self.type_syntax_compile_error(failure, span)),
+        }
     }
 
     fn type_syntax_compile_error(
@@ -3334,9 +3162,9 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         provider.flush_observed_type_dependencies();
         match result {
             Ok(DeferredTypeResolution::Resolved(_) | DeferredTypeResolution::Pending) => Ok(()),
-            Err(failure) if value_call => Err(TypeSyntaxHost::type_syntax_comptime_value_failure(
-                self, failure, span,
-            )),
+            Err(failure) if value_call => Err(
+                DeferredTypeSyntaxHost::type_syntax_comptime_value_failure(self, failure, span),
+            ),
             Err(failure) => Err(semantic_type_syntax_compile_error(interner, failure, span)),
         }
     }
@@ -3396,44 +3224,6 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     /// Validate a source fragment used in type position. The optional result
     /// is the concrete type when the fragment is independent of the enclosing
     /// generic parameters; `None` means specialization must finish it.
-    #[cfg(test)]
-    fn validate_deferred_type_position(
-        &mut self,
-        type_name: String,
-        parameters: &DeferredParameterFacts<'_>,
-        span: Span,
-    ) -> CompileResult<Option<Type>> {
-        self.validate_deferred_type_position_with_epoch_facts(type_name, parameters, span)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn validate_deferred_type_position_with_epoch_facts(
-        &mut self,
-        type_name: String,
-        parameters: &DeferredParameterFacts<'_>,
-        span: Span,
-    ) -> CompileResult<Option<Type>> {
-        let mut provider = DeferredTypeSyntaxProvider::new(self, span, parameters);
-        let result = crate::resolve_semantic_type_syntax(&mut provider, &span.file_id, &type_name);
-        provider.flush_observed_type_dependencies();
-        match result {
-            Ok(DeferredTypeResolution::Resolved(ty)) => Ok(Some(ty)),
-            Ok(DeferredTypeResolution::Pending) => Ok(None),
-            Err(failure) => Err(self.type_syntax_compile_error(failure, span)),
-        }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn validate_deferred_type_position_for_testing(
-        &mut self,
-        type_name: &str,
-        type_params: &[Spur],
-        span: Span,
-    ) -> CompileResult<Option<Type>> {
-        let parameters = DeferredParameterFacts::new(type_params, &[], &[]);
-        self.validate_deferred_type_position(type_name.to_string(), &parameters, span)
-    }
-
     fn deferred_rir_signature_substitutions_are_ready(
         &self,
         syntax: rue_rir::RirTypeSyntaxRef,

--- a/crates/rue-air/src/sema/visibility.rs
+++ b/crates/rue-air/src/sema/visibility.rs
@@ -33,7 +33,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         is_pub: bool,
     ) -> bool {
         let facts = self.aggregate_facts();
-        is_accessible(&facts, accessing_file_id, target_file_id, is_pub)
+        is_accessible(facts, accessing_file_id, target_file_id, is_pub)
     }
 
     /// Check that an *unqualified* reference may reach the item (RUE-37,
@@ -71,7 +71,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         // always known here.
         let defining_file = self
             .aggregate_facts()
-            .file_path(defining_file_id)
+            .aggregate_file_path(defining_file_id)
             .unwrap_or("<unknown>")
             .to_string();
 
@@ -118,8 +118,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let enum_id = module_file_id
             .and_then(|module_id| {
                 let facts = self.aggregate_facts();
-                let file = facts.module(module_id).file;
-                select_qualified_enum(&facts, file, type_name)
+                let file = facts.aggregate_module(module_id).file;
+                select_qualified_enum(facts, file, type_name)
             })
             .ok_or_else(|| {
                 CompileError::new(ErrorKind::UnknownEnumType(type_name_str.to_string()), span)
@@ -149,6 +149,6 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         ctx: &AnalysisContext,
     ) -> Option<crate::types::ModuleId> {
         let facts = self.aggregate_facts();
-        resolve_visibility_module_ref(&facts, self.body_rir_ref(), module_ref, &ctx.locals)
+        resolve_visibility_module_ref(facts, self.body_rir_ref(), module_ref, &ctx.locals)
     }
 }

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -1357,11 +1357,7 @@ where
             };
             name.as_ref() == "str"
                 || rue_builtins::get_builtin_enum(name).is_some()
-                || name
-                    .strip_prefix("Str(")
-                    .and_then(|name| name.strip_suffix(')'))
-                    .and_then(|capacity| capacity.parse::<u64>().ok())
-                    .is_some()
+                || crate::types::fixed_string_capacity(name).is_some()
         }) {
             return Err(SemanticImportFailure::BuiltinNominalShadow);
         }
@@ -1641,12 +1637,7 @@ where
         name: &Arc<str>,
         kind: SemanticImportNominalKind,
     ) -> Result<LocalNominal, SemanticImportFailure> {
-        if name
-            .strip_prefix("Str(")
-            .and_then(|name| name.strip_suffix(')'))
-            .and_then(|capacity| capacity.parse::<u64>().ok())
-            .is_some()
-        {
+        if crate::types::fixed_string_capacity(name).is_some() {
             if kind != SemanticImportNominalKind::Struct {
                 return Err(SemanticImportFailure::BuiltinNominalKindMismatch);
             }
@@ -1933,7 +1924,7 @@ where
             crate::TypeKind::ComptimeType => SemanticImportType::ComptimeType,
             crate::TypeKind::Struct(id) => {
                 let def = self.type_pool.struct_def(id);
-                if def.name.starts_with('[') && def.name.ends_with(']') && !def.name.contains(';') {
+                if crate::types::is_slice_struct_name(&def.name) {
                     let Some(field) = def.fields.first() else {
                         return Err(SemanticImportFailure::ForeignLocalType);
                     };
@@ -1955,13 +1946,7 @@ where
                         name: name.clone(),
                         kind: *kind,
                     }
-                } else if def.is_builtin
-                    && def
-                        .name
-                        .strip_prefix("Str(")
-                        .and_then(|name| name.strip_suffix(')'))
-                        .and_then(|capacity| capacity.parse::<u64>().ok())
-                        .is_some()
+                } else if def.is_builtin && crate::types::fixed_string_capacity(&def.name).is_some()
                 {
                     // `Str(N)` is registered lazily in the exact transaction
                     // pool. Its compiler-builtin bit plus canonical capacity

--- a/crates/rue-air/src/semantic_type_resolution.rs
+++ b/crates/rue-air/src/semantic_type_resolution.rs
@@ -272,28 +272,10 @@ pub struct SemanticResolvedComptimeCall<K, N, A, T, V> {
 pub type SemanticProviderResult<T, E, F> = Result<T, SemanticProviderError<E, F>>;
 
 /// One comptime value argument preserved by structured type syntax.
-///
-/// `Rendered` belongs only to the temporary adapter for legacy RIR type
-/// spellings. Parser-owned declaration artifacts produce `Integer` or `Name`,
-/// so their semantic path never tokenizes or reparses text.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SemanticValueSyntax<'a> {
     Integer(i128),
     Name(&'a str),
-    Rendered(&'a str),
-}
-
-impl<'a> SemanticValueSyntax<'a> {
-    pub fn from_rendered(syntax: &'a str) -> Self {
-        let syntax = syntax.trim();
-        if let Ok(value) = syntax.parse::<i128>() {
-            Self::Integer(value)
-        } else if is_unqualified_name_syntax(syntax) {
-            Self::Name(syntax)
-        } else {
-            Self::Rendered(syntax)
-        }
-    }
 }
 
 pub trait SemanticTypeSyntaxProvider<S, M, A, K, N, T, V>:
@@ -471,6 +453,10 @@ pub enum SemanticTypeSyntaxFailure<A, N> {
     UnknownType {
         syntax: Arc<str>,
     },
+    UnknownConstructor {
+        constructor: Arc<str>,
+        expectation: SemanticComptimeCallExpectation,
+    },
     UnknownModuleMember {
         module: Arc<str>,
         module_site: A,
@@ -499,12 +485,14 @@ pub enum SemanticTypeSyntaxFailure<A, N> {
         site: A,
         expected: usize,
         found: usize,
+        expectation: SemanticComptimeCallExpectation,
     },
     RuntimeConstructorParameter {
         constructor: Arc<str>,
         site: A,
         expected: usize,
         found: usize,
+        expectation: SemanticComptimeCallExpectation,
     },
     ValueWhereTypeExpected {
         constructor: Arc<str>,
@@ -542,24 +530,6 @@ fn visible_type<T, A, N, E, P>(
             },
         ))
     }
-}
-
-fn is_slice_syntax(syntax: &str) -> Option<&str> {
-    (syntax.starts_with('[')
-        && syntax.ends_with(']')
-        && crate::parse_array_type_syntax(syntax).is_none())
-    .then(|| syntax[1..syntax.len() - 1].trim())
-}
-
-fn is_unqualified_name_syntax(syntax: &str) -> bool {
-    if matches!(syntax, "()" | "!") {
-        return true;
-    }
-    let mut characters = syntax.chars();
-    characters
-        .next()
-        .is_some_and(|character| character == '_' || character.is_ascii_alphabetic())
-        && characters.all(|character| character == '_' || character.is_ascii_alphanumeric())
 }
 
 fn select_named_type<S, M, A, K, N, T, V, P>(
@@ -741,8 +711,9 @@ where
         lift_provider(provider.module_constructor(&resolved.module, name))?
     }
     .ok_or_else(|| {
-        E::Semantic(F::UnknownType {
-            syntax: call_display(),
+        E::Semantic(F::UnknownConstructor {
+            constructor: Arc::from(call_segments.join(".")),
+            expectation,
         })
     })?;
     if !head
@@ -774,6 +745,7 @@ where
             site: head.site,
             expected: head.parameters.len(),
             found: argument_count,
+            expectation,
         }));
     }
     let eligible = head
@@ -787,6 +759,7 @@ where
             site: head.site,
             expected: head.parameters.len(),
             found: argument_count,
+            expectation,
         }));
     }
 
@@ -866,53 +839,6 @@ where
     })
 }
 
-pub fn resolve_semantic_comptime_call<S, M, A, K, N, T, V, P>(
-    provider: &mut P,
-    root_scope: &S,
-    call_path: &str,
-    arguments: &[String],
-    expectation: SemanticComptimeCallExpectation,
-) -> Result<
-    SemanticResolvedComptimeCall<K, N, A, T, V>,
-    SemanticTypeSyntaxError<P::Abort, P::Failure, A, N>,
->
-where
-    M: Clone,
-    A: Clone,
-    N: Clone,
-    P: SemanticTypeSyntaxProvider<S, M, A, K, N, T, V>,
-{
-    let segments = call_path.split('.').collect::<Vec<_>>();
-    resolve_semantic_comptime_call_core(
-        provider,
-        root_scope,
-        &segments,
-        arguments.len(),
-        expectation,
-        || Arc::from(format!("{}({})", call_path, arguments.join(", "))),
-        |index| Arc::from(arguments[index].as_str()),
-        |index| arguments[index].trim().parse::<i128>().is_ok(),
-        |provider, parameter_index, is_type, head, type_arguments, value_arguments| {
-            let argument = &arguments[parameter_index];
-            if is_type {
-                resolve_semantic_type_syntax(provider, root_scope, argument)
-                    .map(ResolvedComptimeArgument::Type)
-            } else {
-                lift_provider(provider.resolve_value_argument(
-                    root_scope,
-                    call_path,
-                    head,
-                    parameter_index,
-                    type_arguments,
-                    value_arguments,
-                    SemanticValueSyntax::from_rendered(argument),
-                ))
-                .map(ResolvedComptimeArgument::Value)
-            }
-        },
-    )
-}
-
 fn structured_path<'a, Sym>(
     arena: &'a rue_rir::RirTypeSyntaxArena<Sym>,
     range: rue_rir::RirTypeSyntaxRange,
@@ -952,6 +878,26 @@ fn structured_syntax_display<'a, Sym>(
         .render_type_with(reference, resolve_symbol)
         .map(Arc::from)
         .unwrap_or_else(|| Arc::from("<invalid structured type syntax>"))
+}
+
+fn structured_type_diagnostic_display<'a, Sym>(
+    arena: &'a rue_rir::RirTypeSyntaxArena<Sym>,
+    reference: rue_rir::RirTypeSyntaxRef,
+    resolve_symbol: impl Copy + Fn(&'a Sym) -> &'a str,
+) -> Arc<str> {
+    match arena.node(reference) {
+        Some(rue_rir::RirTypeSyntaxNode::TypeCall { path, .. }) => {
+            let Some(segments) = structured_path(arena, *path, resolve_symbol) else {
+                return Arc::from("<invalid structured type syntax>");
+            };
+            Arc::from(format!("{}(...)", segments.join(".")))
+        }
+        Some(rue_rir::RirTypeSyntaxNode::ValueCall { name, .. }) => arena
+            .symbol(*name)
+            .map(|symbol| Arc::from(format!("{}(...)", resolve_symbol(symbol))))
+            .unwrap_or_else(|| Arc::from("<invalid structured type syntax>")),
+        _ => structured_syntax_display(arena, reference, resolve_symbol),
+    }
 }
 
 fn structured_value_syntax<'a, Sym>(
@@ -995,7 +941,7 @@ where
         &call_segments,
         arguments.len(),
         expectation,
-        || structured_syntax_display(arena, call_reference, resolve_symbol),
+        || structured_type_diagnostic_display(arena, call_reference, resolve_symbol),
         |index| structured_syntax_display(arena, arguments[index], resolve_symbol),
         |index| {
             matches!(
@@ -1071,8 +1017,7 @@ where
 }
 
 /// Resolve one parser-structured type without reconstructing or tokenizing its
-/// source spelling. Namespace selection and comptime-call policy are shared
-/// with [`resolve_semantic_type_syntax`]; only the input adapter differs.
+/// source spelling.
 pub fn resolve_structured_semantic_type_syntax<S, Sym, M, A, K, N, T, V, P>(
     provider: &mut P,
     root_scope: &S,
@@ -1112,7 +1057,7 @@ where
 
     let unknown = || {
         E::Semantic(F::UnknownType {
-            syntax: structured_syntax_display(arena, root, resolve_symbol),
+            syntax: structured_type_diagnostic_display(arena, root, resolve_symbol),
         })
     };
     match arena.node(root).cloned().ok_or_else(unknown)? {
@@ -1235,85 +1180,6 @@ where
         | R::ValueCall { .. }
         | R::Integer(_) => Err(unknown()),
     }
-}
-
-pub fn resolve_semantic_type_syntax<S, M, A, K, N, T, V, P>(
-    provider: &mut P,
-    root_scope: &S,
-    syntax: &str,
-) -> Result<T, SemanticTypeSyntaxError<P::Abort, P::Failure, A, N>>
-where
-    M: Clone,
-    A: Clone,
-    N: Clone,
-    P: SemanticTypeSyntaxProvider<S, M, A, K, N, T, V>,
-{
-    use SemanticResolutionError as E;
-    use SemanticTypeSyntaxFailure as F;
-
-    if is_unqualified_name_syntax(syntax)
-        && let Some(ty) = resolve_unqualified_semantic_type(provider, root_scope, syntax)?
-    {
-        return Ok(ty);
-    }
-
-    if let Some((element, length)) = crate::parse_array_type_syntax(syntax) {
-        let element = resolve_semantic_type_syntax(provider, root_scope, &element)?;
-        let length = match &length {
-            crate::ArrayLen::Literal(value) => SemanticValueSyntax::Integer(i128::from(*value)),
-            crate::ArrayLen::Named(name) => SemanticValueSyntax::from_rendered(name),
-        };
-        let length = lift_provider(provider.resolve_array_length(root_scope, length))?;
-        return lift_provider(provider.array_type(element, length));
-    }
-    if let Some((pointee, mutability)) = crate::parse_pointer_type_syntax(syntax) {
-        let pointee = resolve_semantic_type_syntax(provider, root_scope, &pointee)?;
-        return lift_provider(match mutability {
-            crate::PtrMutability::Const => provider.ptr_const_type(pointee),
-            crate::PtrMutability::Mut => provider.ptr_mut_type(pointee),
-        });
-    }
-
-    if let Some((call_path, arguments)) = crate::types::parse_type_call_syntax(syntax) {
-        let value_arguments = arguments
-            .iter()
-            .map(|argument| SemanticValueSyntax::from_rendered(argument))
-            .collect::<Vec<_>>();
-        if !call_path.contains('.')
-            && let Some(ty) =
-                lift_provider(provider.builtin_type_call(root_scope, &call_path, &value_arguments))?
-        {
-            return Ok(ty);
-        }
-        let SemanticComptimeCallResult::Type(ty) = resolve_semantic_comptime_call(
-            provider,
-            root_scope,
-            &call_path,
-            &arguments,
-            SemanticComptimeCallExpectation::Type,
-        )?
-        .result
-        else {
-            unreachable!("type call expectation accepts only type results")
-        };
-        lift_provider(provider.observe_materialized_type(&ty))?;
-        return Ok(ty);
-    }
-
-    if let Some(element) = is_slice_syntax(syntax) {
-        lift_provider(provider.preflight_slice(root_scope, syntax))?;
-        let element = resolve_semantic_type_syntax(provider, root_scope, element)?;
-        return lift_provider(provider.slice_type(root_scope, syntax, element));
-    }
-
-    if syntax.contains('.') {
-        let segments = syntax.split('.').collect::<Vec<_>>();
-        return resolve_qualified_semantic_type(provider, root_scope, &segments, Arc::from(syntax));
-    }
-
-    Err(E::Semantic(F::UnknownType {
-        syntax: Arc::from(syntax),
-    }))
 }
 
 #[cfg(test)]
@@ -1501,7 +1367,7 @@ mod tests {
             self.call("array_length", scope, &format!("{length:?}"));
             match length {
                 SemanticValueSyntax::Integer(value) => Ok(u64::try_from(value).ok()),
-                SemanticValueSyntax::Name(_) | SemanticValueSyntax::Rendered(_) => {
+                SemanticValueSyntax::Name(_) => {
                     Err(SemanticProviderError::Failure("unknown length"))
                 }
             }
@@ -1594,7 +1460,7 @@ mod tests {
             match syntax {
                 SemanticValueSyntax::Integer(value) => i64::try_from(value)
                     .map_err(|_| SemanticProviderError::Failure("unknown value")),
-                SemanticValueSyntax::Name(syntax) | SemanticValueSyntax::Rendered(syntax) => syntax
+                SemanticValueSyntax::Name(syntax) => syntax
                     .parse()
                     .map_err(|_| SemanticProviderError::Failure("unknown value")),
             }
@@ -1694,6 +1560,17 @@ mod tests {
         (builder.finish(), root)
     }
 
+    fn resolve_type(
+        fixture: &mut Fixture,
+        syntax: &str,
+    ) -> Result<
+        &'static str,
+        SemanticTypeSyntaxError<&'static str, &'static str, &'static str, &'static str>,
+    > {
+        let (arena, root) = structured_type(syntax);
+        resolve_structured_semantic_type_syntax(fixture, &"app/main.rue", &arena, root)
+    }
+
     #[test]
     fn unqualified_nominal_precedes_alias_and_stops_discovery_exactly() {
         let mut fixture = Fixture::default();
@@ -1706,10 +1583,7 @@ mod tests {
             fact("alias", "alias-site", true, "app/aliases.rue"),
         );
 
-        assert_eq!(
-            resolve_semantic_type_syntax(&mut fixture, &"app/main.rue", "Thing"),
-            Ok("struct")
-        );
+        assert_eq!(resolve_type(&mut fixture, "Thing"), Ok("struct"));
         assert_eq!(
             fixture.calls,
             [
@@ -1742,11 +1616,11 @@ mod tests {
         );
 
         assert_eq!(
-            resolve_semantic_type_syntax(&mut fixture, &"app/main.rue", "api.PublicAlias"),
+            resolve_type(&mut fixture, "api.PublicAlias"),
             Ok("public-alias")
         );
         assert!(matches!(
-            resolve_semantic_type_syntax(&mut fixture, &"app/main.rue", "api.PrivateAlias"),
+            resolve_type(&mut fixture, "api.PrivateAlias"),
             Err(SemanticResolutionError::Semantic(
                 SemanticTypeSyntaxFailure::PrivateItem {
                     kind: SemanticTypeFactKind::Constant,
@@ -1755,10 +1629,7 @@ mod tests {
                 }
             ))
         ));
-        assert_eq!(
-            resolve_semantic_type_syntax(&mut fixture, &"app/main.rue", "Local"),
-            Ok("local")
-        );
+        assert_eq!(resolve_type(&mut fixture, "Local"), Ok("local"));
     }
 
     #[test]
@@ -1773,10 +1644,7 @@ mod tests {
             fact("alias", "alias-site", true, "lib/api.rue"),
         );
 
-        assert_eq!(
-            resolve_semantic_type_syntax(&mut fixture, &"app/main.rue", "api.Alias"),
-            Ok("alias")
-        );
+        assert_eq!(resolve_type(&mut fixture, "api.Alias"), Ok("alias"));
         assert_eq!(
             fixture.calls,
             [
@@ -1835,13 +1703,13 @@ mod tests {
                 ("app/main.rue", "Make"),
                 head("make-site", true, true, vec![type_parameter(true)]),
             );
-            resolve_semantic_type_syntax(&mut fixture, &"app/main.rue", syntax).unwrap();
+            resolve_type(&mut fixture, syntax).unwrap();
             assert_eq!(fixture.calls, expected, "unexpected trace for '{syntax}'");
         }
     }
 
     #[test]
-    fn structured_and_legacy_adapters_share_resolution_policy() {
+    fn structured_shapes_share_one_resolution_policy() {
         for syntax in [
             "api.Alias",
             "[i32; 2]",
@@ -1871,10 +1739,6 @@ mod tests {
                 );
                 fixture
             };
-            let mut legacy = configured();
-            let legacy_result =
-                resolve_semantic_type_syntax(&mut legacy, &"app/main.rue", syntax).unwrap();
-
             let (arena, root) = structured_type(syntax);
             let mut structured = configured();
             let structured_result = resolve_structured_semantic_type_syntax(
@@ -1885,13 +1749,13 @@ mod tests {
             )
             .unwrap();
 
-            assert_eq!(structured_result, legacy_result, "result for `{syntax}`");
-            assert_eq!(structured.calls, legacy.calls, "trace for `{syntax}`");
+            assert!(!structured_result.is_empty(), "result for `{syntax}`");
+            assert!(!structured.calls.is_empty(), "work trace for `{syntax}`");
         }
     }
 
     #[test]
-    fn structured_and_legacy_adapters_share_failure_diagnostics_and_work() {
+    fn structured_failures_preserve_diagnostics_and_bounded_work() {
         for syntax in [
             "Missing",
             "api.PrivateAlias",
@@ -1920,10 +1784,6 @@ mod tests {
                 fixture
             };
 
-            let mut legacy = configured();
-            let legacy_result = resolve_semantic_type_syntax(&mut legacy, &"app/main.rue", syntax);
-            assert!(legacy_result.is_err(), "fixture must fail for `{syntax}`");
-
             let (arena, root) = structured_type(syntax);
             let mut structured = configured();
             let structured_result = resolve_structured_semantic_type_syntax(
@@ -1933,11 +1793,11 @@ mod tests {
                 root,
             );
 
-            assert_eq!(
-                structured_result, legacy_result,
-                "diagnostic for `{syntax}`"
+            assert!(
+                structured_result.is_err(),
+                "fixture must fail for `{syntax}`"
             );
-            assert_eq!(structured.calls, legacy.calls, "work trace for `{syntax}`");
+            assert!(!structured.calls.is_empty(), "work trace for `{syntax}`");
         }
     }
 
@@ -1974,68 +1834,39 @@ mod tests {
             ..Fixture::default()
         };
         assert_eq!(
-            resolve_semantic_type_syntax(&mut fixture, &"app/main.rue", "[Unknown]"),
+            resolve_type(&mut fixture, "[Unknown]"),
             Err(SemanticResolutionError::ProviderFailure("preview required"))
         );
         assert_eq!(fixture.calls, ["slice_preflight:app/main.rue:[Unknown]"]);
     }
 
     #[test]
-    fn value_call_head_restriction_does_not_restrict_qualified_type_arguments() {
-        let mut fixture = Fixture {
-            allow_qualified_paths: Some(true),
-            allow_qualified_value_heads: Some(false),
-            ..Fixture::default()
-        };
+    fn value_call_type_argument_uses_the_canonical_type_policy() {
+        let mut fixture = Fixture::default();
         fixture.constructors.insert(
             ("app/main.rue", "Width"),
             head("width-site", true, false, vec![type_parameter(true)]),
         );
-        fixture.bindings.insert(
-            ("app/main.rue", "lib"),
-            binding("lib", "lib-site", true, "app/main.rue"),
-        );
-        fixture.module_structs.insert(
-            ("lib", "Leaf"),
+        fixture.root_structs.insert(
+            ("app/main.rue", "Leaf"),
             fact("leaf", "leaf-site", true, "lib/types.rue"),
         );
 
-        let call = resolve_semantic_comptime_call(
-            &mut fixture,
-            &"app/main.rue",
-            "Width",
-            &["lib.Leaf".to_string()],
-            SemanticComptimeCallExpectation::Value,
-        )
-        .expect("the unqualified value callee may receive a qualified type argument");
-        assert_eq!(call.result, SemanticComptimeCallResult::Value(2));
-        assert!(
-            resolve_semantic_comptime_call(
-                &mut fixture,
-                &"app/main.rue",
-                "lib.Width",
-                &["lib.Leaf".to_string()],
-                SemanticComptimeCallExpectation::Value,
-            )
-            .is_err(),
-            "the value-call head restriction remains independently enforced"
+        assert_eq!(
+            resolve_type(&mut fixture, "[i32; Width(Leaf)]"),
+            Ok("array"),
+            "a value call's type argument uses the same nominal lookup policy"
         );
     }
 
     #[test]
-    fn malformed_leaves_and_disallowed_qualified_paths_issue_no_fact_queries() {
-        for syntax in ["2", "-3", "true?", "@x"] {
-            let mut fixture = Fixture::default();
-            assert!(resolve_semantic_type_syntax(&mut fixture, &"app/main.rue", syntax).is_err());
-            assert!(fixture.calls.is_empty(), "unexpected trace for '{syntax}'");
-        }
-
+    fn disallowed_qualified_paths_issue_no_fact_queries() {
         for syntax in ["api.Type", "api.Make(i32)"] {
             let mut fixture = Fixture {
                 allow_qualified_paths: Some(false),
                 ..Fixture::default()
             };
-            assert!(resolve_semantic_type_syntax(&mut fixture, &"app/main.rue", syntax).is_err());
+            assert!(resolve_type(&mut fixture, syntax).is_err());
             assert!(fixture.calls.is_empty(), "unexpected trace for '{syntax}'");
         }
     }
@@ -2111,8 +1942,8 @@ mod tests {
                 }
             };
 
-            let error = resolve_semantic_type_syntax(&mut fixture, &"app/main.rue", syntax)
-                .expect_err("case must fail semantically");
+            let error =
+                resolve_type(&mut fixture, syntax).expect_err("case must fail semantically");
             match (case, error) {
                 (
                     FailureCase::UnknownRoot,
@@ -2178,10 +2009,7 @@ mod tests {
                 primitive_error: Some(provider_error),
                 ..Fixture::default()
             };
-            assert_eq!(
-                resolve_semantic_type_syntax(&mut fixture, &"app/main.rue", "i32"),
-                Err(expected)
-            );
+            assert_eq!(resolve_type(&mut fixture, "i32"), Err(expected));
             assert_eq!(
                 fixture.calls,
                 ["substitution:app/main.rue:i32", "primitive:-:i32"]

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -10,6 +10,29 @@ use std::sync::Arc;
 
 use crate::type_encoding::{self, Composite, Decoded, Primitive};
 
+/// Return the capacity encoded by the canonical synthetic `Str(N)` name.
+///
+/// Fixed strings are nominal for ABI and identity purposes, so every compiler
+/// phase must recognize their generated spelling identically.
+pub fn fixed_string_capacity(name: &str) -> Option<u64> {
+    let digits = name.strip_prefix("Str(")?.strip_suffix(')')?;
+    if digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    let capacity: u64 = digits.parse().ok()?;
+    (capacity.to_string() == digits).then_some(capacity)
+}
+
+/// Whether `name` is the canonical spelling of a synthetic slice struct.
+pub fn is_slice_struct_name(name: &str) -> bool {
+    name.starts_with('[') && name.ends_with(']') && !name.contains(';')
+}
+
+/// Whether `name` is a two-word string-view nominal (`str` or `Str(N)`).
+pub fn is_string_view_struct_name(name: &str) -> bool {
+    name == "str" || fixed_string_capacity(name).is_some()
+}
+
 /// A unique identifier for a struct definition.
 ///
 /// Values are issued by [`TypeInternPool`](crate::TypeInternPool); their raw
@@ -1076,29 +1099,6 @@ impl std::fmt::Display for Type {
     }
 }
 
-/// Pointer mutability - whether the pointed-to data can be modified.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PtrMutability {
-    /// Immutable pointer (`ptr const T`)
-    Const,
-    /// Mutable pointer (`ptr mut T`)
-    Mut,
-}
-
-/// Parse pointer type syntax "ptr const T" or "ptr mut T" and return (pointee_type_str, mutability).
-///
-/// Returns `None` if the string doesn't match pointer syntax.
-pub fn parse_pointer_type_syntax(type_name: &str) -> Option<(String, PtrMutability)> {
-    let type_name = type_name.trim();
-    if let Some(rest) = type_name.strip_prefix("ptr const ") {
-        Some((rest.trim().to_string(), PtrMutability::Const))
-    } else if let Some(rest) = type_name.strip_prefix("ptr mut ") {
-        Some((rest.trim().to_string(), PtrMutability::Mut))
-    } else {
-        None
-    }
-}
-
 /// The length component of an array type syntax `[T; N]`.
 ///
 /// The length is either a literal (`[i32; 4]`) or a name referring to a
@@ -1113,164 +1113,26 @@ pub enum ArrayLen {
     Named(String),
 }
 
-/// Parse array type syntax "[T; N]" and return (element_type_str, length).
-///
-/// This handles nested arrays correctly by tracking bracket depth.
-/// For example, `[[i32; 3]; 4]` returns `("[i32; 3]", ArrayLen::Literal(4))`.
-///
-/// The length component may be a decimal literal ([`ArrayLen::Literal`]) or a
-/// name ([`ArrayLen::Named`]) referring to a `const` / `comptime` value
-/// parameter; the caller resolves named lengths to a concrete value (RUE-16).
-pub fn parse_array_type_syntax(type_name: &str) -> Option<(String, ArrayLen)> {
-    let type_name = type_name.trim();
-    if !type_name.starts_with('[') || !type_name.ends_with(']') {
-        return None;
-    }
-
-    // Remove the outer brackets
-    let inner = &type_name[1..type_name.len() - 1];
-
-    // Find the semicolon separator - need to handle nested arrays
-    // We look for the last `;` that's at nesting level 0
-    let mut bracket_depth = 0;
-    let mut semi_pos = None;
-    for (i, ch) in inner.char_indices() {
-        match ch {
-            '[' => bracket_depth += 1,
-            ']' => bracket_depth -= 1,
-            ';' if bracket_depth == 0 => semi_pos = Some(i),
-            _ => {}
-        }
-    }
-
-    let semi_pos = semi_pos?;
-    let element_type = inner[..semi_pos].trim().to_string();
-    let length_str = inner[semi_pos + 1..].trim();
-    if length_str.is_empty() {
-        return None;
-    }
-    let length = match length_str.parse::<u64>() {
-        Ok(n) => ArrayLen::Literal(n),
-        // Not a decimal literal: a named length (`const` / `comptime` param).
-        Err(_) => ArrayLen::Named(length_str.to_string()),
-    };
-
-    Some((element_type, length))
-}
-
-/// Parse a type-function application `Name(arg, ...)` and return
-/// `(name, [arg_str, ...])` (RUE-241).
-///
-/// Recognizes the canonical string [`intern_type`] produces for a
-/// `TypeExpr::TypeCall`: an identifier immediately followed by a
-/// parenthesized, comma-separated argument list. Arguments are returned as raw
-/// substrings (the caller resolves each as a type), split only at top-level
-/// commas so nested calls, arrays, and braces are preserved intact
-/// (`Result(Option(i32), i32)` -> `("Result", ["Option(i32)", "i32"])`).
-///
-/// Returns `None` for anything that is not this shape — array (`[T; N]`),
-/// pointer (`ptr const T`), and anonymous type strings (`enum { Ok(i32) }`,
-/// whose prefix before the first `(` is not a bare identifier) all fall
-/// through so their dedicated resolution paths still apply.
-///
-/// [`intern_type`]: (rue_rir astgen)
-pub fn parse_type_call_syntax(type_name: &str) -> Option<(String, Vec<String>)> {
-    let s = type_name.trim();
-    if !s.ends_with(')') {
-        return None;
-    }
-    let open = s.find('(')?;
-    let name = &s[..open];
-    // The callee name must be a bare identifier or a dotted module-qualified
-    // identifier. This excludes anonymous type strings like
-    // `enum { Ok(i32) }`, whose text before the first `(` contains
-    // spaces/braces.
-    let mut name_chars = name.chars();
-    match name_chars.next() {
-        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
-        _ => return None,
-    }
-    if name.ends_with('.') || name.contains("..") {
-        return None;
-    }
-    if !name_chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.') {
-        return None;
-    }
-
-    // Split the argument list at top-level commas, tracking nesting depth so a
-    // comma inside a nested call/array/brace does not split an argument.
-    let inner = &s[open + 1..s.len() - 1];
-    let mut args = Vec::new();
-    let mut depth = 0i32;
-    let mut start = 0usize;
-    for (i, ch) in inner.char_indices() {
-        match ch {
-            '(' | '[' | '{' => depth += 1,
-            ')' | ']' | '}' => depth -= 1,
-            ',' if depth == 0 => {
-                let arg = inner[start..i].trim();
-                if !arg.is_empty() {
-                    args.push(arg.to_string());
-                }
-                start = i + 1;
-            }
-            _ => {}
-        }
-    }
-    let last = inner[start..].trim();
-    if !last.is_empty() {
-        args.push(last.to_string());
-    }
-
-    Some((name.to_string(), args))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_type_call_syntax_basic() {
-        assert_eq!(
-            parse_type_call_syntax("Result(i32, i32)"),
-            Some((
-                "Result".to_string(),
-                vec!["i32".to_string(), "i32".to_string()]
-            ))
-        );
-    }
+    fn synthetic_string_and_slice_names_have_one_canonical_classifier() {
+        assert_eq!(fixed_string_capacity("Str(0)"), Some(0));
+        assert_eq!(fixed_string_capacity("Str(42)"), Some(42));
+        for invalid in [
+            "str", "Str()", "Str(-1)", "Str(+1)", "Str(01)", "Str(1", "Str(1)x",
+        ] {
+            assert_eq!(fixed_string_capacity(invalid), None, "{invalid}");
+        }
 
-    #[test]
-    fn test_parse_type_call_syntax_nested() {
-        assert_eq!(
-            parse_type_call_syntax("Result(Option(i32), i32)"),
-            Some((
-                "Result".to_string(),
-                vec!["Option(i32)".to_string(), "i32".to_string()]
-            ))
-        );
-    }
-
-    #[test]
-    fn test_parse_type_call_syntax_zero_args() {
-        assert_eq!(
-            parse_type_call_syntax("Foo()"),
-            Some(("Foo".to_string(), vec![]))
-        );
-    }
-
-    #[test]
-    fn test_parse_type_call_syntax_rejects_anon_enum() {
-        // Anonymous enum canonical strings contain `(` but their prefix is not
-        // a bare identifier, so they must not be mistaken for a type call.
-        assert_eq!(parse_type_call_syntax("enum { Ok(i32), Err(i32) }"), None);
-    }
-
-    #[test]
-    fn test_parse_type_call_syntax_rejects_plain() {
-        assert_eq!(parse_type_call_syntax("i32"), None);
-        assert_eq!(parse_type_call_syntax("[i32; 4]"), None);
-        assert_eq!(parse_type_call_syntax("ptr const i32"), None);
+        assert!(is_slice_struct_name("[u8]"));
+        assert!(!is_slice_struct_name("[u8; 4]"));
+        assert!(!is_slice_struct_name("u8"));
+        assert!(is_string_view_struct_name("str"));
+        assert!(is_string_view_struct_name("Str(42)"));
+        assert!(!is_string_view_struct_name("Str(042)"));
     }
 
     // ========== Type ID tests ==========

--- a/crates/rue-cfg/src/api_inventory.rs
+++ b/crates/rue-cfg/src/api_inventory.rs
@@ -69,3 +69,22 @@ fn production_cfg_does_not_call_frozen_declaration_test_adapters() {
         );
     }
 }
+
+#[test]
+fn cfg_uses_air_synthetic_type_identity_policy() {
+    for (name, source) in [
+        ("build.rs", include_str!("build.rs")),
+        ("verify.rs", include_str!("verify.rs")),
+    ] {
+        for peer in [
+            ".strip_prefix(\"Str(\")",
+            ".starts_with(\"Str(\")",
+            ".starts_with('[')",
+        ] {
+            assert!(
+                !source.contains(peer),
+                "{name} regained handwritten synthetic-type identity policy: {peer}"
+            );
+        }
+    }
+}

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -464,10 +464,7 @@ impl<'a> CfgBuilder<'a> {
         }
         if let TypeKind::Struct(struct_id) = ty.kind() {
             let name: &str = &self.type_pool.struct_def(struct_id).name;
-            if self.type_pool.is_strbuf(struct_id)
-                || name == "str"
-                || (name.starts_with("Str(") && name.ends_with(')'))
-            {
+            if self.type_pool.is_strbuf(struct_id) || rue_air::is_string_view_struct_name(name) {
                 return Some(R::Text);
             }
         }

--- a/crates/rue-cfg/src/verify.rs
+++ b/crates/rue-cfg/src/verify.rs
@@ -920,11 +920,7 @@ impl<'a> Verifier<'a> {
         ) else {
             return false;
         };
-        let is_fixed_str = source_def
-            .name
-            .strip_prefix("Str(")
-            .and_then(|rest| rest.strip_suffix(')'))
-            .is_some_and(|capacity| capacity.parse::<u64>().is_ok());
+        let is_fixed_str = rue_air::fixed_string_capacity(&source_def.name).is_some();
         is_fixed_str
             && &*result_def.name == "str"
             && source_def.fields.len() == result_def.fields.len()

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -487,6 +487,27 @@ fn semantic_signatures_preserve_parser_type_structure_without_a_text_grammar() {
 }
 
 #[test]
+fn compiler_uses_air_synthetic_type_identity_policy() {
+    for (name, source) in [
+        (
+            "local_semantic_materialization.rs",
+            include_str!("local_semantic_materialization.rs"),
+        ),
+        (
+            "revisioned_query_database.rs",
+            include_str!("revisioned_query_database.rs"),
+        ),
+    ] {
+        for peer in [".strip_prefix(\"Str(\")", ".starts_with(\"Str(\")"] {
+            assert!(
+                !source.contains(peer),
+                "{name} regained handwritten synthetic-type identity policy: {peer}"
+            );
+        }
+    }
+}
+
+#[test]
 fn body_transaction_has_no_complete_declaration_candidate_map() {
     let runtime = include_str!("revisioned_query_database.rs");
     let method = source_between_exact_boundaries(
@@ -2242,7 +2263,6 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
             for evaluator_only in [
                 ".evaluate_declaration_shell(",
                 ".evaluate_raw_declaration_signature(",
-                ".evaluate_raw_declaration_body(",
                 ".declaration_import(",
                 ".declaration_capabilities()",
                 "project_semantic_shell(",
@@ -2268,19 +2288,6 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
         }
         if !matches!(
             *name,
-            "body_query"
-                | "declaration_candidate"
-                | "parsed_modules"
-                | "revisioned_query_database"
-                | "semantic_query_nucleus"
-        ) {
-            assert!(
-                !code_identifiers(source).contains(&"RawDeclarationBody"),
-                "compiler production module {name} escaped the raw-body authority allowlist"
-            );
-        }
-        if !matches!(
-            *name,
             "declaration_candidate"
                 | "parsed_modules"
                 | "revisioned_query_database"
@@ -2301,6 +2308,9 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
             "RawConstSyntax",
             "raw_const_syntax",
             "compiler.raw-const-syntax",
+            "RawDeclarationBody",
+            "raw_declaration_body",
+            "compiler.raw-declaration-body",
         ] {
             assert!(
                 !source.contains(removed),
@@ -2327,19 +2337,6 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
         "the signature query must project the exact borrowed parsed declaration"
     );
     assert!(!runtime.contains("parse_semantic_signature("));
-    assert_eq!(
-        runtime.matches(".evaluate_raw_declaration_body(").count(),
-        1
-    );
-    assert_eq!(
-        parsed.matches("fn evaluate_raw_declaration_body(").count(),
-        1
-    );
-    assert_eq!(
-        runtime.matches("\"compiler.raw-declaration-body\"").count(),
-        1
-    );
-    assert_eq!(parsed.matches("RawDeclarationBodySyntax {").count(), 1);
     assert_eq!(runtime.matches(".declaration_import(").count(), 1);
     assert_eq!(parsed.matches("fn declaration_import(").count(), 1);
     assert_eq!(
@@ -2347,26 +2344,6 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
         1
     );
     assert!(!runtime.contains("Vec::remove"));
-
-    let raw_body_evaluator = runtime
-        .split("let occurrences_for_raw_body")
-        .nth(1)
-        .and_then(|tail| {
-            tail.split("let parse_for_declaration_body_plan_artifacts")
-                .next()
-        })
-        .unwrap();
-    for forbidden in [
-        "module_rirs",
-        "lower_module_rir",
-        "CanonicalMergedProgram",
-        "SemanticView",
-    ] {
-        assert!(
-            !raw_body_evaluator.contains(forbidden),
-            "raw-body syntax evaluator gained a broad compiler dependency: {forbidden}"
-        );
-    }
 
     let toolchain_demand_evaluator = runtime
         .split("let artifacts_for_toolchain_demands")
@@ -2406,7 +2383,7 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
     let shell_terminal = runtime
         .split("enum DeclarationShellQueryValue")
         .nth(1)
-        .and_then(|tail| tail.split("struct RawDeclarationBodyQueryKey").next())
+        .and_then(|tail| tail.split("struct DeclarationBodyPlanQueryKey").next())
         .unwrap();
     for forbidden in [
         "CompileErrors",
@@ -2420,28 +2397,6 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
         assert!(
             !shell_terminal.contains(forbidden),
             "shell terminal regained positioned/live semantic payload: {forbidden}"
-        );
-    }
-    let raw_body_terminal = runtime
-        .split("enum RawDeclarationBodyQueryValue")
-        .nth(1)
-        .and_then(|tail| tail.split("struct DeclarationBodyPlanQueryKey").next())
-        .unwrap();
-    for forbidden in [
-        "CompileErrors",
-        "Span",
-        "FileId",
-        "Spur",
-        "Ast",
-        "InstRef",
-        "Rir",
-        "TypeId",
-        "SemanticDefinitionToken",
-        "SemanticModuleToken",
-    ] {
-        assert!(
-            !raw_body_terminal.contains(forbidden),
-            "raw-body terminal regained positioned/live parser or semantic payload: {forbidden}"
         );
     }
     let declaration_import_terminal = runtime
@@ -2489,20 +2444,6 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
         assert!(
             !lookup_value.contains(forbidden),
             "LookupName terminal regained locator/live payload: {forbidden}"
-        );
-    }
-    let raw_body_payload = module("declaration_candidate")
-        .split("pub(crate) struct RawDeclarationBodySyntax")
-        .nth(1)
-        .and_then(|tail| {
-            tail.split("pub(crate) enum RawDeclarationBodyFailure")
-                .next()
-        })
-        .unwrap();
-    for forbidden in ["Span", "FileId", "Spur", "Ast", "Rir", "InstRef", "TypeId"] {
-        assert!(
-            !raw_body_payload.contains(forbidden),
-            "raw-body payload regained a positioned or live parser/semantic handle: {forbidden}"
         );
     }
     let declaration_import_payload = module("declaration_candidate")

--- a/crates/rue-compiler/src/declaration_candidate.rs
+++ b/crates/rue-compiler/src/declaration_candidate.rs
@@ -82,45 +82,6 @@ pub(crate) enum DeclarationShellFailure {
     ParserCapabilityMismatch(DeclarationCandidateKey),
 }
 
-/// Test-only record of one anonymous type literal in a retired raw fragment.
-///
-/// `fragment_start` / `fragment_end` are byte offsets **relative to the start of
-/// the constant initializer or body block. Production evaluation consumes the
-/// packed candidate artifact and its indexed anchors directly; this type exists
-/// only so deleted-route selection tests can exercise the old fragment shape.
-#[cfg(test)]
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct RawAnonymousSite {
-    pub(crate) fragment_start: u32,
-    pub(crate) fragment_end: u32,
-    pub(crate) kind: rue_rir::AnonymousTypeSiteKind,
-    pub(crate) anchor: rue_rir::RirStructuralAnchor,
-}
-
-/// Test-only parser projection for the retired raw-body query.
-///
-/// Production runtime and comptime evaluation consume the packed candidate
-/// artifact; this exact fragment remains only as a deletion-regression oracle.
-#[cfg(test)]
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct RawDeclarationBodySyntax {
-    pub(crate) body: Arc<str>,
-    /// Anonymous type literals inside `body`, retained only for the
-    /// deleted-route oracle.
-    pub(crate) anonymous_sites: Arc<[RawAnonymousSite]>,
-}
-
-/// Stable, position-free failure retained by the exact raw-body family.
-#[cfg(test)]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum RawDeclarationBodyFailure {
-    OccurrencesUnavailable(DeclarationOccurrenceFailure),
-    Absent(DeclarationCandidateKey),
-    Ambiguous(DeclarationCandidateKey),
-    CategoryMismatch(DeclarationCandidateKey),
-    ParserCapabilityMismatch(DeclarationCandidateKey),
-}
-
 /// Position-independent identity of one valid `@import` occurrence inside an
 /// exact declaration.
 ///

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -950,11 +950,7 @@ pub(crate) fn select_materialization_facts(
             // exact fact request here.
             if name.as_ref() == "str"
                 || rue_builtins::get_builtin_enum(name).is_some()
-                || name
-                    .strip_prefix("Str(")
-                    .and_then(|name| name.strip_suffix(')'))
-                    .and_then(|capacity| capacity.parse::<u64>().ok())
-                    .is_some()
+                || rue_air::fixed_string_capacity(name).is_some()
             {
                 return;
             }

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -28,35 +28,6 @@ use crate::{
     },
 };
 
-#[cfg(test)]
-use crate::declaration_candidate::{RawAnonymousSite, RawDeclarationBodySyntax};
-
-/// Slice the module-relative anonymous type sites that fall inside `fragment`
-/// into locators relative to `fragment`'s start. The frontend anchor rides
-/// along unchanged; the relative offsets let the durable evaluator reconnect
-/// each reparsed literal to it without a module-space lookup (RUE-1089).
-///
-/// A site straddling or preceding the fragment is dropped rather than clamped:
-/// the durable evaluator then fails closed on the corresponding reparsed literal
-/// (a loud missing-locator diagnostic) instead of adopting a truncated locator.
-#[cfg(test)]
-fn fragment_anonymous_sites(
-    sites: &[rue_rir::AnonymousTypeSite],
-    fragment: Span,
-) -> Arc<[RawAnonymousSite]> {
-    sites
-        .iter()
-        .filter(|site| site.span.start >= fragment.start && site.span.end <= fragment.end)
-        .map(|site| RawAnonymousSite {
-            fragment_start: site.span.start - fragment.start,
-            fragment_end: site.span.end - fragment.start,
-            kind: site.kind,
-            anchor: site.anchor.clone(),
-        })
-        .collect::<Vec<_>>()
-        .into()
-}
-
 #[derive(Debug)]
 struct SymbolProvenance;
 
@@ -176,8 +147,6 @@ pub struct ParsedDefinitionIndex {
     declaration_by_key: HashMap<DeclarationCandidateKey, usize>,
     rir_recipes: Arc<[ParsedRirRecipe]>,
     declaration_capabilities: Arc<[DeclarationOccurrenceCapability]>,
-    #[cfg(test)]
-    raw_declaration_body_terminal_materializations: Arc<AtomicUsize>,
     #[cfg(test)]
     declaration_import_locator_materializations: Arc<AtomicUsize>,
     #[cfg(test)]
@@ -376,42 +345,11 @@ impl ParsedDefinitionIndex {
         )
     }
 
-    /// Materialize the retired raw-body oracle for one exact declaration key.
-    /// Production runtime and comptime evaluation consume the packed candidate
-    /// artifact instead.
-    #[cfg(test)]
-    fn materialize_raw_declaration_body(
-        &self,
-        key: &DeclarationCandidateKey,
-        source_text: &str,
-    ) -> Option<RawDeclarationBodySyntax> {
-        let index = self.declaration_by_key.get(key).copied()?;
-        let candidate = self.declarations.get(index)?;
-        if candidate.fact.key != *key {
-            return None;
-        }
-        let body = candidate.raw_body_span?;
-        let syntax = RawDeclarationBodySyntax {
-            body: Arc::from(source_text.get(body.start as usize..body.end as usize)?),
-            anonymous_sites: fragment_anonymous_sites(&candidate.anonymous_sites, body),
-        };
-        #[cfg(test)]
-        self.raw_declaration_body_terminal_materializations
-            .fetch_add(1, Ordering::Relaxed);
-        Some(syntax)
-    }
-
     fn body_source_spans(&self, key: &DeclarationCandidateKey) -> Option<(Span, Span)> {
         let index = self.declaration_by_key.get(key).copied()?;
         let candidate = self.declarations.get(index)?;
         (candidate.fact.key == *key)
             .then_some((candidate.declaration_span, candidate.raw_body_span?))
-    }
-
-    #[cfg(test)]
-    fn raw_declaration_body_terminal_materialization_count(&self) -> usize {
-        self.raw_declaration_body_terminal_materializations
-            .load(Ordering::Relaxed)
     }
 
     fn declaration_import_range(
@@ -776,15 +714,6 @@ impl ParsedModule {
             .saturating_add(invalid_imports)
     }
 
-    #[cfg(test)]
-    pub(crate) fn evaluate_raw_declaration_body(
-        &self,
-        key: &DeclarationCandidateKey,
-    ) -> Option<RawDeclarationBodySyntax> {
-        self.definitions
-            .materialize_raw_declaration_body(key, self.source_text())
-    }
-
     pub(crate) fn body_source_spans(&self, key: &DeclarationCandidateKey) -> Option<(Span, Span)> {
         self.definitions.body_source_spans(key)
     }
@@ -963,12 +892,6 @@ impl ParsedModule {
             }
             _ => None,
         }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn raw_declaration_body_terminal_materialization_count(&self) -> usize {
-        self.definitions
-            .raw_declaration_body_terminal_materialization_count()
     }
 
     pub(crate) fn declaration_import(
@@ -1702,11 +1625,6 @@ fn bind_payload(
         declaration_by_key: payload.definitions.declaration_by_key.clone(),
         rir_recipes: payload.definitions.rir_recipes.clone(),
         declaration_capabilities: payload.definitions.declaration_capabilities.clone(),
-        #[cfg(test)]
-        raw_declaration_body_terminal_materializations: payload
-            .definitions
-            .raw_declaration_body_terminal_materializations
-            .clone(),
         #[cfg(test)]
         declaration_import_locator_materializations: payload
             .definitions
@@ -3108,8 +3026,6 @@ fn build_definition_index(
         declaration_by_key,
         rir_recipes: rir_recipes.into(),
         declaration_capabilities: declaration_capabilities.into(),
-        #[cfg(test)]
-        raw_declaration_body_terminal_materializations: Arc::new(AtomicUsize::new(0)),
         #[cfg(test)]
         declaration_import_locator_materializations: Arc::new(AtomicUsize::new(0)),
         #[cfg(test)]

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -975,33 +975,6 @@ impl RetainedCharge for crate::declaration_candidate::DeclarationShellFailure {
     }
 }
 
-#[cfg(test)]
-impl RetainedCharge for crate::declaration_candidate::RawAnonymousSite {
-    fn retained_charge(&self) -> u64 {
-        0
-    }
-}
-
-#[cfg(test)]
-macro_rules! candidate_failure_charge {
-    ($ty:ty) => {
-        impl RetainedCharge for $ty {
-            fn retained_charge(&self) -> u64 {
-                match self {
-                    Self::OccurrencesUnavailable(value) => value.retained_charge(),
-                    Self::Absent(key)
-                    | Self::Ambiguous(key)
-                    | Self::CategoryMismatch(key)
-                    | Self::ParserCapabilityMismatch(key) => key.retained_charge(),
-                }
-            }
-        }
-    };
-}
-
-#[cfg(test)]
-candidate_failure_charge!(crate::declaration_candidate::RawDeclarationBodyFailure);
-
 impl RetainedCharge for crate::semantic_query_nucleus::ParsedSemanticParameter {
     fn retained_charge(&self) -> u64 {
         0
@@ -1079,15 +1052,6 @@ impl RetainedCharge for rue_air::declaration_validation::AccessorOwnerMethod {
             .retained_charge()
             .saturating_add(self.is_accessor.retained_charge())
             .saturating_add(self.self_call_targets.retained_charge())
-    }
-}
-
-#[cfg(test)]
-impl RetainedCharge for crate::declaration_candidate::RawDeclarationBodySyntax {
-    fn retained_charge(&self) -> u64 {
-        self.body
-            .retained_charge()
-            .saturating_add(self.anonymous_sites.retained_charge())
     }
 }
 

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -404,8 +404,6 @@ pub(crate) struct RevisionedQueryDatabase {
         StableDeclarationClassificationQueryKey,
         StableDeclarationClassificationQueryValue,
     >,
-    #[cfg(test)]
-    raw_declaration_bodies: QueryFamily<RawDeclarationBodyQueryKey, RawDeclarationBodyQueryValue>,
     warning_body_references:
         QueryFamily<crate::body_query::BodyQueryKey, WarningBodyReferencesValue>,
     #[cfg(test)]
@@ -2143,24 +2141,6 @@ pub(crate) enum StableDeclarationClassificationFailure {
     },
 }
 
-#[cfg(test)]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct RawDeclarationBodyQueryKey(crate::declaration_candidate::DeclarationCandidateKey);
-
-#[cfg(test)]
-impl QueryKey for RawDeclarationBodyQueryKey {
-    fn stable_identity(&self) -> String {
-        self.0.stable_identity()
-    }
-}
-
-#[cfg(test)]
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum RawDeclarationBodyQueryValue {
-    Available(crate::declaration_candidate::RawDeclarationBodySyntax),
-    Failure(crate::declaration_candidate::RawDeclarationBodyFailure),
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct DeclarationBodyPlanQueryKey(crate::declaration_candidate::DeclarationCandidateKey);
 
@@ -2800,8 +2780,6 @@ macro_rules! query_value_charge {
     };
 }
 
-#[cfg(test)]
-query_value_charge!(RawDeclarationBodyQueryValue);
 query_value_charge!(WarningCallHeadProjectionValue);
 query_value_charge!(WarningBodyReferencesValue);
 
@@ -4406,8 +4384,7 @@ fn evaluate_type_shape(
         }
         T::BuiltinNominal { kind, name } | T::Nominal(N::Builtin { kind, name })
             if *kind == rue_air::AnonymousNominalKind::Struct
-                && (name.as_ref() == "str"
-                    || (name.starts_with("Str(") && name.ends_with(')'))) =>
+                && rue_air::is_string_view_struct_name(name) =>
         {
             TypeShapeValue::Available(TypeShape::Struct {
                 fields: Arc::from([
@@ -4614,8 +4591,7 @@ fn evaluate_type_facts(
         T::ComptimeType | T::Module(_) | T::GenericParameter(_) => direct(true),
         T::BuiltinNominal { kind, name } | T::Nominal(N::Builtin { kind, name })
             if *kind == rue_air::AnonymousNominalKind::Struct
-                && (name.as_ref() == "str"
-                    || (name.starts_with("Str(") && name.ends_with(')'))) =>
+                && rue_air::is_string_view_struct_name(name) =>
         {
             direct(true)
         }
@@ -9674,8 +9650,7 @@ impl rue_air::SemanticTypeSyntaxProvider<ModuleId, ModuleId, StableDefinitionKey
                     ))
                 })
             }
-            rue_air::SemanticValueSyntax::Name(name)
-            | rue_air::SemanticValueSyntax::Rendered(name) => {
+            rue_air::SemanticValueSyntax::Name(name) => {
                 if let Some(crate::durable_semantics::DurableConstValue::Integer(value)) =
                     self.value_substitutions.get(name)
                 {
@@ -9859,8 +9834,7 @@ impl rue_air::SemanticTypeSyntaxProvider<ModuleId, ModuleId, StableDefinitionKey
         let capacity = match capacity {
             rue_air::SemanticValueSyntax::Integer(capacity) => u64::try_from(*capacity)
                 .map_err(|_| Self::provider_failure_value("Str capacity must be an integer"))?,
-            rue_air::SemanticValueSyntax::Name(capacity)
-            | rue_air::SemanticValueSyntax::Rendered(capacity) => capacity
+            rue_air::SemanticValueSyntax::Name(capacity) => capacity
                 .parse::<u64>()
                 .map_err(|_| Self::provider_failure_value("Str capacity must be an integer"))?,
         };
@@ -9935,8 +9909,7 @@ impl rue_air::SemanticTypeSyntaxProvider<ModuleId, ModuleId, StableDefinitionKey
         use crate::durable_semantics::DurableConstValue as V;
         let syntax = match syntax {
             rue_air::SemanticValueSyntax::Integer(value) => return Ok(V::Integer(value)),
-            rue_air::SemanticValueSyntax::Name(syntax)
-            | rue_air::SemanticValueSyntax::Rendered(syntax) => syntax,
+            rue_air::SemanticValueSyntax::Name(syntax) => syntax,
         };
         if syntax == "true" || syntax == "false" {
             return Ok(V::Bool(syntax == "true"));
@@ -11212,155 +11185,6 @@ impl RevisionedQueryDatabase {
                 },
             )
             .expect("the StableDeclarationClassification family has one canonical name");
-        #[cfg(test)]
-        let occurrences_for_raw_body = declaration_occurrence_indexes.clone();
-        #[cfg(test)]
-        let shells_for_raw_body = declaration_shells.clone();
-        #[cfg(test)]
-        let parse_for_raw_body = parse_modules.clone();
-        #[cfg(test)]
-        let raw_declaration_bodies = runtime
-            .family_with_equality_and_evaluator(
-                "compiler.raw-declaration-body",
-                declaration_memo_retention,
-                |left: &RawDeclarationBodyQueryValue,
-                 right: &RawDeclarationBodyQueryValue| { left == right },
-                move |context, _, key: &RawDeclarationBodyQueryKey| {
-                    use crate::declaration_candidate::{
-                        DeclarationCandidateCategory, DeclarationOccurrenceCapability,
-                        DeclarationShellFailure, RawDeclarationBodyFailure,
-                    };
-
-                    let indexed = context.query_registered(
-                        &occurrences_for_raw_body,
-                        ModuleQueryKey(key.0.module.clone()),
-                    )?;
-                    let rue_query::QueryOutcome::Success(indexed) = indexed.outcome() else {
-                        unreachable!("DeclarationOccurrenceIndex publishes typed values")
-                    };
-                    let value = match indexed {
-                        DeclarationOccurrenceIndexValue::Failure(failure) => {
-                            RawDeclarationBodyQueryValue::Failure(
-                                RawDeclarationBodyFailure::OccurrencesUnavailable(failure.clone()),
-                            )
-                        }
-                        DeclarationOccurrenceIndexValue::Available(index) => {
-                            match index.capabilities.get(&key.0) {
-                                None => RawDeclarationBodyQueryValue::Failure(
-                                    RawDeclarationBodyFailure::Absent(key.0.clone()),
-                                ),
-                                Some(DeclarationOccurrenceCapability::Ambiguous { .. }) => {
-                                    RawDeclarationBodyQueryValue::Failure(
-                                        RawDeclarationBodyFailure::Ambiguous(key.0.clone()),
-                                    )
-                                }
-                                Some(DeclarationOccurrenceCapability::Exact {
-                                    duplicate_multiplicity: 0,
-                                    ..
-                                }) => RawDeclarationBodyQueryValue::Failure(
-                                    RawDeclarationBodyFailure::ParserCapabilityMismatch(
-                                        key.0.clone(),
-                                    ),
-                                ),
-                                Some(DeclarationOccurrenceCapability::Exact { .. }) => {
-                                    let shell = context.query_registered(
-                                        &shells_for_raw_body,
-                                        DeclarationShellQueryKey(key.0.clone()),
-                                    )?;
-                                    let rue_query::QueryOutcome::Success(shell) = shell.outcome()
-                                    else {
-                                        unreachable!("DeclarationShell publishes typed values")
-                                    };
-                                    match shell {
-                                        DeclarationShellQueryValue::Failure(failure) => {
-                                            let failure = match failure {
-                                                DeclarationShellFailure::OccurrencesUnavailable(
-                                                    failure,
-                                                ) => RawDeclarationBodyFailure::OccurrencesUnavailable(
-                                                    failure.clone(),
-                                                ),
-                                                DeclarationShellFailure::Absent(key) => {
-                                                    RawDeclarationBodyFailure::Absent(key.clone())
-                                                }
-                                                DeclarationShellFailure::Ambiguous(key) => {
-                                                    RawDeclarationBodyFailure::Ambiguous(key.clone())
-                                                }
-                                                DeclarationShellFailure::ParserCapabilityMismatch(
-                                                    key,
-                                                ) => RawDeclarationBodyFailure::ParserCapabilityMismatch(
-                                                    key.clone(),
-                                                ),
-                                            };
-                                            RawDeclarationBodyQueryValue::Failure(failure)
-                                        }
-                                        DeclarationShellQueryValue::Available(fact)
-                                            if !matches!(
-                                                fact.key.category,
-                                                DeclarationCandidateCategory::Function
-                                                    | DeclarationCandidateCategory::Method
-                                                    | DeclarationCandidateCategory::AssociatedFunction
-                                                    | DeclarationCandidateCategory::Destructor
-                                            ) =>
-                                        {
-                                            RawDeclarationBodyQueryValue::Failure(
-                                                RawDeclarationBodyFailure::CategoryMismatch(
-                                                    key.0.clone(),
-                                                ),
-                                            )
-                                        }
-                                        DeclarationShellQueryValue::Available(fact)
-                                            if fact.key != key.0 =>
-                                        {
-                                            RawDeclarationBodyQueryValue::Failure(
-                                                RawDeclarationBodyFailure::ParserCapabilityMismatch(
-                                                    key.0.clone(),
-                                                ),
-                                            )
-                                        }
-                                        DeclarationShellQueryValue::Available(_) => {
-                                            let parsed = context.query_registered(
-                                                &parse_for_raw_body,
-                                                ModuleQueryKey(key.0.module.clone()),
-                                            )?;
-                                            let rue_query::QueryOutcome::Success(parsed) =
-                                                parsed.outcome()
-                                            else {
-                                                unreachable!("ParseModule publishes typed values")
-                                            };
-                                            match &parsed.result {
-                                                Err(_) => RawDeclarationBodyQueryValue::Failure(
-                                                    RawDeclarationBodyFailure::OccurrencesUnavailable(
-                                                        crate::declaration_candidate::DeclarationOccurrenceFailure::ParseRejected {
-                                                            module: key.0.module.clone(),
-                                                        },
-                                                    ),
-                                                ),
-                                                Ok(module) => module
-                                                    .evaluate_raw_declaration_body(&key.0)
-                                                    .map_or_else(
-                                                        || RawDeclarationBodyQueryValue::Failure(
-                                                            RawDeclarationBodyFailure::ParserCapabilityMismatch(
-                                                                key.0.clone(),
-                                                            ),
-                                                        ),
-                                                        RawDeclarationBodyQueryValue::Available,
-                                                    ),
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    };
-                    let kind = if matches!(value, RawDeclarationBodyQueryValue::Available(_)) {
-                        QueryTerminalKind::Success
-                    } else {
-                        QueryTerminalKind::Failure
-                    };
-                    Ok(QueryOutput::success(value).with_terminal_kind(kind))
-                },
-            )
-            .expect("the RawDeclarationBody family has one canonical name");
         let parse_for_declaration_body_plan_artifacts = parse_modules.clone();
         let index_for_declaration_body_plan_artifacts = module_indexes.clone();
         #[cfg(test)]
@@ -15662,8 +15486,6 @@ impl RevisionedQueryDatabase {
             declaration_shells,
             #[cfg(test)]
             stable_declaration_classifications: stable_declaration_classifications.clone(),
-            #[cfg(test)]
-            raw_declaration_bodies: raw_declaration_bodies.clone(),
             warning_body_references,
             #[cfg(test)]
             body_inputs,
@@ -22910,9 +22732,8 @@ impl rue_air::BodyFactProvider for CompilerBodyFactProvider<'_> {
 // `enums_by_file_name`, `value_const`, `type_pool`), this impl answers every
 // point query from the exact body-fact provider (`CompilerBodyFactProvider`) and
 // materializes each consulted nominal into the task-owned overlay. The shared
-// `resolve_semantic_type_syntax` logic is unchanged: only the fact source
-// differs, so a differential proves the two impls resolve every type-syntax
-// shape identically.
+// One structured resolver consumes both fact sources, so the differential
+// proves the storage adapters resolve every type-syntax shape identically.
 //
 // Owned type domain: T = `DurableType` (`SemanticImportType`), the pool-free
 // durable type algebra that IS the byte-identity representation the published
@@ -22930,7 +22751,7 @@ impl rue_air::BodyFactProvider for CompilerBodyFactProvider<'_> {
 // (pure durable name facts); `Str(N)` (a generated fixed-capacity struct) →
 // r6b with the generated-struct/anonymous family; anonymous producer nominals
 // (r4) and well-known `Option` (r6b). These operations are production-compiled
-// provider facades; the eventual body evaluator is the only production caller.
+// test fact hosts; production body evaluation uses the direct host contracts.
 // ---------------------------------------------------------------------------
 
 /// A recoverable failure surfaced by [`ProviderTypeFacts`]. Aborts never reach
@@ -23382,8 +23203,7 @@ impl<'p, 'o, 'db>
                     ))
                 })
             }
-            rue_air::SemanticValueSyntax::Name(name)
-            | rue_air::SemanticValueSyntax::Rendered(name) => {
+            rue_air::SemanticValueSyntax::Name(name) => {
                 if let Ok(value) = name.parse::<u64>() {
                     return Ok(Some(value));
                 }
@@ -23552,8 +23372,7 @@ impl<'p, 'o, 'db>
             rue_air::SemanticValueSyntax::Integer(value) => {
                 return Ok(crate::DurableConstValue::Integer(value));
             }
-            rue_air::SemanticValueSyntax::Name(syntax)
-            | rue_air::SemanticValueSyntax::Rendered(syntax) => syntax,
+            rue_air::SemanticValueSyntax::Name(syntax) => syntax,
         };
         SignatureFacts::new(self.provider)
             .value_argument_fact(scope, syntax, type_arguments, value_arguments)
@@ -25445,7 +25264,7 @@ fn main() -> i32 {
     }
 
     #[test]
-    fn rooted_runtime_and_comptime_avoid_raw_body_reconstruction() {
+    fn rooted_runtime_and_comptime_use_candidate_artifacts() {
         use crate::declaration_candidate::DeclarationCandidateCategory as Category;
         use crate::durable_semantics::DurableType;
         use crate::semantic_query_nucleus::{
@@ -25465,17 +25284,6 @@ fn main() -> i32 {
         let module = ModuleId::from_logical_path("main.rue").unwrap();
         let mut database = RevisionedQueryDatabase::default();
         let revision = revision_for(&mut database, &snapshot);
-        let parsed = database.runtime.request_registered(
-            &database.parse_modules,
-            revision,
-            ModuleQueryKey(module.clone()),
-            CancellationToken::new(),
-        );
-        let rue_query::QueryOutcome::Success(parsed) = parsed.terminal().unwrap().outcome() else {
-            panic!("parse terminal succeeds")
-        };
-        let parsed = parsed.result.as_ref().expect("module parses").clone();
-
         database
             .body_closure(
                 revision,
@@ -25487,12 +25295,6 @@ fn main() -> i32 {
                 CancellationToken::new(),
             )
             .expect("representative rooted runtime body closes");
-        assert_eq!(database.raw_declaration_bodies.retention().terminals, 0);
-        assert_eq!(
-            parsed.raw_declaration_body_terminal_materialization_count(),
-            0
-        );
-
         let candidate =
             declaration_candidate(&database, revision, &module, Category::Function, "Make");
         let _ = request_semantic_nucleus_observed(
@@ -25506,11 +25308,6 @@ fn main() -> i32 {
                 type_arguments: Arc::from([(Arc::from("T"), DurableType::I32)]),
                 value_arguments: Arc::from([]),
             }),
-        );
-        assert_eq!(database.raw_declaration_bodies.retention().terminals, 0);
-        assert_eq!(
-            parsed.raw_declaration_body_terminal_materialization_count(),
-            0
         );
     }
 
@@ -25562,7 +25359,6 @@ fn main() -> i32 {
                 .terminals,
             0
         );
-        assert_eq!(database.raw_declaration_bodies.retention().terminals, 0);
     }
 
     #[test]
@@ -28870,269 +28666,6 @@ fn main() -> i32 {
                 crate::semantic_query_nucleus::SemanticNucleusValue::Signature(_)
             )
         ));
-    }
-
-    #[test]
-    fn raw_declaration_body_is_exact_lazy_and_red_green() {
-        fn program(selected_body: &str, unrelated_body: u32) -> String {
-            let mut source = String::new();
-            for index in 0..128 {
-                let body = if index == 64 { unrelated_body } else { index };
-                source.push_str(&format!("fn unrelated{index}() -> i32 {{ {body} }}\n"));
-            }
-            source.push_str(&format!(
-                "fn selected(comptime T: type) -> type // boundary trivia\n{{ {selected_body} }}\n"
-            ));
-            source
-        }
-
-        let first_text = program("struct { value: T }", 64);
-        let unrelated_edit_text = program("struct { value: T }", 999);
-        let selected_edit_text = program("enum { Value(T), Empty }", 999);
-        let first = source_snapshot(&[(1, "/main.rue", "main.rue", &first_text)], 1);
-        let unrelated_edit =
-            source_snapshot(&[(1, "/main.rue", "main.rue", &unrelated_edit_text)], 1);
-        let selected_edit =
-            source_snapshot(&[(1, "/main.rue", "main.rue", &selected_edit_text)], 1);
-        let module = ModuleId::from_logical_path("main.rue").unwrap();
-        let key = crate::declaration_candidate::DeclarationCandidateKey {
-            module: module.clone(),
-            category: crate::declaration_candidate::DeclarationCandidateCategory::Function,
-            name: Arc::from("selected"),
-            owner: None,
-            duplicate_discriminator: 0,
-        };
-        let mut database = RevisionedQueryDatabase::default();
-        let first_revision = database.source_revision(
-            &super::super::session::ExactSourceInput::new(&first),
-            &first,
-        );
-        let parsed = database.runtime.request_registered(
-            &database.parse_modules,
-            first_revision,
-            ModuleQueryKey(module),
-            CancellationToken::new(),
-        );
-        let parsed_module = match parsed.terminal().unwrap().outcome() {
-            rue_query::QueryOutcome::Success(value) => value.result.clone().unwrap(),
-            rue_query::QueryOutcome::Failure(_) => unreachable!(),
-        };
-        assert_eq!(
-            parsed_module.raw_declaration_body_terminal_materialization_count(),
-            0,
-            "indexing must not allocate raw-body terminal text"
-        );
-
-        let first_request = database.runtime.request_registered(
-            &database.raw_declaration_bodies,
-            first_revision,
-            RawDeclarationBodyQueryKey(key.clone()),
-            CancellationToken::new(),
-        );
-        assert_eq!(execution(&first_request), RequestExecution::Computed);
-        assert_eq!(
-            first_request
-                .dependencies()
-                .iter()
-                .map(|dependency| dependency.node.family())
-                .collect::<Vec<_>>(),
-            vec![
-                "compiler.declaration-occurrence-index",
-                "compiler.declaration-shell",
-                "compiler.parse-module",
-            ]
-        );
-        let first_terminal = first_request.terminal().unwrap();
-        let first_stamp = first_terminal.stamp();
-        assert!(matches!(
-            first_terminal.outcome(),
-            rue_query::QueryOutcome::Success(RawDeclarationBodyQueryValue::Available(syntax))
-                if syntax.body.as_ref() == "{ struct { value: T } }"
-        ));
-        assert_eq!(
-            parsed_module.raw_declaration_body_terminal_materialization_count(),
-            1
-        );
-
-        let warm = database.runtime.request_registered(
-            &database.raw_declaration_bodies,
-            first_revision,
-            RawDeclarationBodyQueryKey(key.clone()),
-            CancellationToken::new(),
-        );
-        assert_eq!(execution(&warm), RequestExecution::Reused);
-        assert_eq!(
-            parsed_module.raw_declaration_body_terminal_materialization_count(),
-            1,
-            "warm reuse must not rematerialize body text"
-        );
-
-        let unrelated_revision = database.source_revision(
-            &super::super::session::ExactSourceInput::new(&unrelated_edit),
-            &unrelated_edit,
-        );
-        let unrelated_request = database.runtime.request_registered(
-            &database.raw_declaration_bodies,
-            unrelated_revision,
-            RawDeclarationBodyQueryKey(key.clone()),
-            CancellationToken::new(),
-        );
-        assert_eq!(unrelated_request.terminal().unwrap().stamp(), first_stamp);
-
-        let selected_revision = database.source_revision(
-            &super::super::session::ExactSourceInput::new(&selected_edit),
-            &selected_edit,
-        );
-        let selected_request = database.runtime.request_registered(
-            &database.raw_declaration_bodies,
-            selected_revision,
-            RawDeclarationBodyQueryKey(key),
-            CancellationToken::new(),
-        );
-        let selected_terminal = selected_request.terminal().unwrap();
-        assert_ne!(selected_terminal.stamp(), first_stamp);
-        assert!(matches!(
-            selected_terminal.outcome(),
-            rue_query::QueryOutcome::Success(RawDeclarationBodyQueryValue::Available(syntax))
-                if syntax.body.as_ref() == "{ enum { Value(T), Empty } }"
-        ));
-    }
-
-    #[test]
-    fn raw_declaration_bodies_cover_body_categories_and_boundaries() {
-        use crate::declaration_candidate::DeclarationCandidateCategory as Category;
-
-        let source = source_snapshot(
-            &[(
-                1,
-                "/main.rue",
-                "main.rue",
-                "fn free() -> i32 // excluded one\n{ 1 }\n\
-                 struct Box { value: i32, fn get(borrow self) -> i32 // excluded two\n{ self.value } fn make(value: i32) -> Box { Box { value } } }\n\
-                 drop fn Box(self) // excluded three\n{ let x = self; }\n\
-                 const value = 1; extern \"C\" { fn foreign() -> i32; }",
-            )],
-            1,
-        );
-        let module = ModuleId::from_logical_path("main.rue").unwrap();
-        let owner = crate::declaration_candidate::DeclarationCandidateOwner {
-            category: Category::Struct,
-            name: Arc::from("Box"),
-        };
-        let key = |category, name: &'static str, owner| {
-            crate::declaration_candidate::DeclarationCandidateKey {
-                module: module.clone(),
-                category,
-                name: Arc::from(name),
-                owner,
-                duplicate_discriminator: 0,
-            }
-        };
-        let mut database = RevisionedQueryDatabase::default();
-        let revision = database.source_revision(
-            &super::super::session::ExactSourceInput::new(&source),
-            &source,
-        );
-        for (candidate, expected) in [
-            (key(Category::Function, "free", None), "{ 1 }"),
-            (
-                key(Category::Method, "get", Some(owner.clone())),
-                "{ self.value }",
-            ),
-            (
-                key(Category::AssociatedFunction, "make", Some(owner.clone())),
-                "{ Box { value } }",
-            ),
-            (
-                key(Category::Destructor, "Box", Some(owner)),
-                "{ let x = self; }",
-            ),
-        ] {
-            let requested = database.runtime.request_registered(
-                &database.raw_declaration_bodies,
-                revision,
-                RawDeclarationBodyQueryKey(candidate),
-                CancellationToken::new(),
-            );
-            match requested.terminal().unwrap().outcome() {
-                rue_query::QueryOutcome::Success(RawDeclarationBodyQueryValue::Available(
-                    syntax,
-                )) => assert_eq!(syntax.body.as_ref(), expected),
-                other => panic!("expected raw body {expected:?}, got {other:?}"),
-            }
-        }
-
-        for candidate in [
-            key(Category::Struct, "Box", None),
-            key(Category::ConstCandidate, "value", None),
-            key(Category::ExternFunction, "foreign", None),
-        ] {
-            let requested = database.runtime.request_registered(
-                &database.raw_declaration_bodies,
-                revision,
-                RawDeclarationBodyQueryKey(candidate.clone()),
-                CancellationToken::new(),
-            );
-            assert!(matches!(
-                requested.terminal().unwrap().outcome(),
-                rue_query::QueryOutcome::Success(RawDeclarationBodyQueryValue::Failure(
-                    crate::declaration_candidate::RawDeclarationBodyFailure::CategoryMismatch(
-                        actual
-                    )
-                )) if actual == &candidate
-            ));
-        }
-    }
-
-    #[test]
-    fn raw_declaration_body_duplicate_discriminators_cancel_and_recover() {
-        let source = source_snapshot(
-            &[(
-                1,
-                "/main.rue",
-                "main.rue",
-                "fn duplicate() -> i32 { 11 } fn duplicate() -> i32 { 22 }",
-            )],
-            1,
-        );
-        let module = ModuleId::from_logical_path("main.rue").unwrap();
-        let key = |duplicate_discriminator| crate::declaration_candidate::DeclarationCandidateKey {
-            module: module.clone(),
-            category: crate::declaration_candidate::DeclarationCandidateCategory::Function,
-            name: Arc::from("duplicate"),
-            owner: None,
-            duplicate_discriminator,
-        };
-        let mut database = RevisionedQueryDatabase::default();
-        let revision = database.source_revision(
-            &super::super::session::ExactSourceInput::new(&source),
-            &source,
-        );
-
-        let canceled = CancellationToken::new();
-        canceled.cancel();
-        let aborted = database.runtime.request_registered(
-            &database.raw_declaration_bodies,
-            revision,
-            RawDeclarationBodyQueryKey(key(0)),
-            canceled,
-        );
-        assert_eq!(execution(&aborted), RequestExecution::Aborted);
-        assert!(aborted.terminal().is_none());
-
-        for (discriminator, expected) in [(0, "{ 11 }"), (1, "{ 22 }")] {
-            let requested = database.runtime.request_registered(
-                &database.raw_declaration_bodies,
-                revision,
-                RawDeclarationBodyQueryKey(key(discriminator)),
-                CancellationToken::new(),
-            );
-            assert!(matches!(
-                requested.terminal().unwrap().outcome(),
-                rue_query::QueryOutcome::Success(RawDeclarationBodyQueryValue::Available(syntax))
-                    if syntax.body.as_ref() == expected
-            ));
-        }
     }
 
     #[test]
@@ -33422,6 +32955,19 @@ fn main() -> i32 {
         Option<crate::DurableDeclarationPayload>,
         Vec<rue_query::NodeIdentity>,
     ) {
+        let source = format!("fn probe(value: {syntax}) {{}}");
+        let (tokens, interner) = rue_lexer::Lexer::new(&source).tokenize().unwrap();
+        let (ast, interner) = rue_parser::Parser::new(tokens, interner).parse().unwrap();
+        let rue_parser::ast::Item::Function(function) = &ast.items[0] else {
+            panic!("type fixture parses as a function");
+        };
+        let mut builder = rue_rir::RirTypeSyntaxBuilder::default();
+        let root = builder
+            .push_parser_type(&function.params[0].ty, |symbol| {
+                Arc::<str>::from(interner.resolve(&symbol))
+            })
+            .unwrap();
+        let arena = builder.finish();
         let key = materialized_key.cloned();
         // The probe node is memoized by label, so each resolution needs a
         // distinct label or a repeat would reuse the first probe's terminal and
@@ -33434,15 +32980,19 @@ fn main() -> i32 {
             |provider| {
                 let mut overlay = crate::ProviderMaterialization::default();
                 let mut facts = ProviderTypeFacts::new(provider, &mut overlay);
-                let resolved =
-                    rue_air::resolve_semantic_type_syntax(&mut facts, scope, syntax).ok();
+                let resolved = rue_air::resolve_structured_semantic_type_syntax(
+                    &mut facts, scope, &arena, root,
+                )
+                .ok();
                 // Resolve a second time through the same overlay: resolution is
                 // idempotent and a repeated consultation materializes no second
                 // copy (the overlay's minted-once contract).
                 let count_after_first = overlay.materialized_nominal_count();
                 let mut facts = ProviderTypeFacts::new(provider, &mut overlay);
-                let re_resolved =
-                    rue_air::resolve_semantic_type_syntax(&mut facts, scope, syntax).ok();
+                let re_resolved = rue_air::resolve_structured_semantic_type_syntax(
+                    &mut facts, scope, &arena, root,
+                )
+                .ok();
                 assert_eq!(
                     resolved, re_resolved,
                     "repeat resolution of {syntax} diverged"
@@ -34533,7 +34083,7 @@ fn main() -> i32 {
                 assert_eq!(
                     endpoints
                         .method_info(compact_owner, compact_name)
-                        .expect("the endpoint facade observes the named registration")
+                        .expect("the endpoint facts observe the named registration")
                         .body,
                     named.body,
                     "endpoint method lookup falls back to the shared named entry"
@@ -34554,10 +34104,10 @@ fn main() -> i32 {
                 assert_eq!(
                     endpoints
                         .method_info(compact_owner, compact_name)
-                        .expect("the endpoint facade observes the anonymous registration")
+                        .expect("the endpoint facts observe the anonymous registration")
                         .body,
                     anonymous.body,
-                    "endpoint and call facades agree on anonymous-first precedence"
+                    "endpoint and call facts agree on anonymous-first precedence"
                 );
                 // Double consult: idempotent, the pool re-mints nothing.
                 let second = facts

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -63,7 +63,7 @@
 //! - **Deeply-nested `inout` field writes** (non-zero inner offset).
 
 use lasso::ThreadedRodeo;
-use rue_air::{FrozenTypeInternPool, RuntimeCallKind, Type, TypeKind, parse_array_type_syntax};
+use rue_air::{FrozenTypeInternPool, RuntimeCallKind, Type, TypeKind};
 use rue_cfg::{Cfg, CfgArgMode, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator};
 use rue_compiler::{
     CompileErrors, CompileOptions, CompilerSession, PreviewFeatures, SourceSnapshot,
@@ -1014,7 +1014,7 @@ impl<'a> Interp<'a> {
 
     fn is_str_like_struct(&self, struct_id: rue_air::StructId) -> bool {
         let name: &str = &self.type_pool().struct_def(struct_id).name;
-        name == "str" || (name.starts_with("Str(") && name.ends_with(')'))
+        rue_air::is_string_view_struct_name(name)
     }
 
     fn text_struct_slots(&self, struct_id: rue_air::StructId) -> Option<usize> {
@@ -1286,9 +1286,7 @@ impl<'a> Interp<'a> {
                     return false;
                 };
                 let def = self.type_pool().struct_def(*struct_id);
-                let is_slice = def.name.starts_with('[')
-                    && def.name.ends_with(']')
-                    && parse_array_type_syntax(&def.name).is_none();
+                let is_slice = rue_air::is_slice_struct_name(&def.name);
                 if !is_slice
                     || def.fields.len() != 2
                     || def.fields[0].ty != pointer_ty

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -8,6 +8,21 @@
 use super::*;
 use rue_compiler::PreviewFeature;
 
+#[test]
+fn oracle_uses_air_synthetic_type_identity_policy() {
+    let source = include_str!("lib.rs");
+    for peer in [
+        ".strip_prefix(\"Str(\")",
+        ".starts_with(\"Str(\")",
+        ".starts_with('[')",
+    ] {
+        assert!(
+            !source.contains(peer),
+            "oracle regained handwritten synthetic-type identity policy: {peer}"
+        );
+    }
+}
+
 mod call_contracts;
 mod place_contracts;
 

--- a/crates/rue-rir/src/type_syntax.rs
+++ b/crates/rue-rir/src/type_syntax.rs
@@ -875,6 +875,17 @@ impl<S: Clone + Eq + Hash> RirTypeSyntaxBuilder<S> {
         self.push_node(RirTypeSyntaxNode::Named(symbol))
     }
 
+    /// Construct one qualified type path from already-tokenized symbol
+    /// segments. Expression paths interpreted in type position use this
+    /// directly; no dotted spelling is reconstructed or reparsed.
+    pub fn push_qualified_type(
+        &mut self,
+        segments: impl IntoIterator<Item = S>,
+    ) -> Result<RirTypeSyntaxRef, RirTypeSyntaxBuildError> {
+        let path = self.symbol_path(segments)?;
+        self.push_node(RirTypeSyntaxNode::Qualified { path })
+    }
+
     pub fn push_integer(
         &mut self,
         value: i128,


### PR DESCRIPTION
## Summary

- replace the spelling-based and provider-local recursive AIR type resolvers with one structured semantic policy
- make the ordinary and provider hosts supply facts directly and share module-path and array-length policy
- remove forwarding-only fact/view layers, centralize synthetic type identities, and delete a dead test-only raw-body query family
- add source-inventory and behavioral guards that prevent those peer policies and pass-through layers from returning

The underlying issue was duplicated high-level semantic policy hidden behind different input/storage surfaces. The holistic audit kept boundaries only when they own state or artifact lifetime, perform a real representation change, or enforce a shared invariant.

Relates to RUE-1510.

## Performance

This removes duplicate policy and 2,413 net lines, but it does not remove a hot query or memo node. The one structured traversal still performs the necessary provider fact lookups and visibility checks, and retired a paired median 19.34 million more instructions. Accordingly, the benchmark shows no measurable wall-time speedup.

Six order-balanced release-thin-LTO Lattice pairs used one query worker:

- compiler-root marginal median: 646.398 ms → 644.181 ms (-2.218 ms)
- paired median: -0.387 ms, paired MAD 4.039 ms
- peak RSS marginal median: 372,908,032 → 353,697,792 bytes (-19,210,240 bytes)
- peak RSS paired median: -20,037,632 bytes, paired MAD 4,284,416 bytes
- all six prototype pairs used less peak memory
- query claims, memo nodes, and display-identity bytes were exactly unchanged
- all outputs were exactly 1,662,976 bytes, SHA-256 `45784ce7c7cde992d7ea820912ca1692c05dc7582a367210d017b3765a9a89e7`

The architectural benefit is one policy and fewer maintenance layers; the measured runtime benefit is memory, not wall time.

## Validation

- `scripts/rue quick`: 31 targets, 0 failures
- `scripts/rue premerge`: 159 targets, 0 failures
- focused fixed-array specs: 86/86
- focused comptime-expression specs: 186/186
- reproducible-programs: 1/1
- exact frozen-Lattice native output as reported above
