### PR TITLE
RUE-1524: retire the Python 3.11 floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,12 +93,16 @@ jobs:
       - name: Check shell Bash 3.2 baseline
         run: scripts/validate-shell-bash-baseline.py
 
-      # The same failure in the other language: `tomllib` is stdlib only from
-      # 3.11, so //:cli-timeout-policy-validation was green on these runners
-      # (3.12 here, 3.14 on macos-15) and dead on any developer host with an
-      # older interpreter (RUE-1509). This runner cannot reproduce that, so the
-      # check is static: nothing above the documented floor, a version guard on
-      # everything between a stock host's 3.9 and the floor, and AGENTS.md's
+      # The same failure in the other language: the repository floor is a
+      # uniform 3.9 — exactly what a stock Mac's /usr/bin/python3 provides —
+      # while these runners sit comfortably above it (3.12 here, 3.14 on
+      # macos-15). A construct newer than 3.9 therefore stays green in CI and
+      # dies on a stock developer machine, which is what `tomllib` (stdlib
+      # only from 3.11) did to //:cli-timeout-policy-validation (RUE-1509;
+      # RUE-1524 retired the import — the gate now reads a Buck-materialized
+      # JSON twin — and with it the 3.11 floor). This runner cannot reproduce
+      # a stock host, so the check is static: nothing newer than the floor
+      # without a reviewed `# python-baseline-ok` annotation, and AGENTS.md's
       # stated floor matching the gate's.
       #
       # This step is the AUTHORITATIVE run, not a duplicate of the premerge

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,19 +104,20 @@ Rue uses Buck2 through the repository's `./buck2` wrapper, not Cargo:
 
 ## Repository tooling baseline
 
-The repository's Python tooling requires Python 3.11 or newer. Two files
-actually need that today: `scripts/cli-timeout-policy.py` and its tests read
-the CLI execution contracts with `tomllib`, stdlib only from 3.11. Every other
-Python file in the tree runs on 3.9, and the gate below depends on that — 3.9
-is the version it treats as one a file must either run on or explain itself to.
+The repository's Python tooling requires Python 3.9 or newer, uniformly —
+nothing in the tree needs more. The floor was briefly 3.11 because
+`scripts/cli-timeout-policy.py` and its tests read the CLI execution contracts
+with `tomllib`, stdlib only from 3.11 (RUE-1509); since RUE-1524 those
+contracts are consumed as a Buck-materialized JSON twin, derived at build time
+via `//crates/rue-toml2json`, and the floor is a uniform 3.9 again.
 
-A stock Mac is below the floor: macOS ships `/usr/bin/python3` as 3.9.6 and no
-newer interpreter. CI cannot see that gap, because its runners are comfortably
-above the floor — `ubuntu-latest` and `ubuntu-24.04-arm` provide 3.12.3,
-`macos-15` provides 3.14.6. So a premerge-tier target that needs 3.11 stays
-green in CI and fails on a developer machine, which is what
-`//:cli-timeout-policy-validation` did (RUE-1509). Install a 3.11+ interpreter
-and put it earlier on `PATH`.
+A stock Mac now meets the floor: macOS ships `/usr/bin/python3` as 3.9.6, and
+3.9 is chosen precisely so that interpreter is enough — nothing to install.
+The gap CI cannot see runs the other way. Its runners are comfortably above
+the floor — `ubuntu-latest` and `ubuntu-24.04-arm` provide 3.12.3, `macos-15`
+provides 3.14.6 — so a premerge-tier target using a construct newer than 3.9
+stays green in CI and fails on a stock developer machine, which is what
+`//:cli-timeout-policy-validation` did while it needed 3.11 (RUE-1509).
 
 This floor governs the interpreter that runs repository tooling. It is not the
 Python number in `docs/process/build-cache.md`, which records what the pinned
@@ -124,18 +125,13 @@ remote worker image ships for the Buck prelude's rustc wrapper — a different
 interpreter running different code. The remote-execution canary builds; it does
 not run these tests.
 
-A script that needs a construct newer than 3.9 must announce it rather than
-crash on it: guard the first use with `if sys.version_info < (3, 11): raise
-SystemExit(...)`, name the version in the message, and put the `raise`
-unconditionally in that `if`'s own body. An import inside `try:` with an
-`except ImportError` handler has already handled the failure and needs no
-guard. `scripts/validate-python-baseline.py` checks what a static scan can: a
-curated table of version-gated imports, stdlib attributes, builtins, keyword
-arguments and grammar, the presence and shape of those guards, and this
-section's stated floor against the gate's own constant. It is a curated table
-rather than a proof — its docstring lists what it cannot see, including grammar
-with no distinct AST node and every method call. Annotate a reviewed exception
-with `# python-baseline-ok: <reason>`.
+A construct newer than 3.9 fails the gate; the reviewed exception is a
+`# python-baseline-ok: <reason>` annotation on the offending line.
+`scripts/validate-python-baseline.py` checks what a static scan can: a curated
+table of version-gated imports, stdlib attributes, builtins, keyword arguments
+and grammar, and this section's stated floor against the gate's own constant.
+It is a curated table rather than a proof — its docstring lists what it cannot
+see, including grammar with no distinct AST node and every method call.
 
 Shell has the same shape of floor and a stricter one. macOS ships GNU Bash
 3.2.57 as `/bin/bash` and will not ship a GPLv3 one, so a `#!/usr/bin/env bash`

--- a/BUCK
+++ b/BUCK
@@ -877,20 +877,19 @@ rue_sh_test(
     },
 )
 
-# The interpreter-floor gate (RUE-1509). Unlike the Bash baseline's tests, these
-# need no particular interpreter to be INSTALLED to mean something, so premerge
-# is enough. They are not thereby host-independent, and the fixtures are written
-# to keep the difference small and asserted rather than assumed: every fixture is
-# 3.9 syntax, so the scan itself answers identically everywhere, and the two
-# cases that cannot -- what a parse error means, and what the shipped tool does
-# when run -- assert on both sides of the floor. The scan proper is only as
-# strict as the interpreter running it, which is why the authoritative run is
-# ci.yml's `fmt` step, at or above the floor.
+# The interpreter-floor gate (RUE-1509; floor made a uniform 3.9 by RUE-1524).
+# Unlike the Bash baseline's tests, these need no particular interpreter to be
+# INSTALLED to mean something, so premerge is enough. They are not thereby
+# host-independent, and the fixtures are written to keep the difference small
+# and asserted rather than assumed: every fixture is 3.9 syntax, so the scan
+# itself answers identically everywhere, and the one case that cannot -- what
+# a parse error means -- asserts on both sides of the floor. The scan proper is
+# only as strict as the interpreter running it, which is why the authoritative
+# run is ci.yml's `fmt` step, at or above the floor.
 rue_sh_test(
     name = "python-baseline-tool-tests",
     test = "scripts/test-validate-python-baseline.py",
     resources = [
-        "scripts/cli-timeout-policy.py",
         "scripts/validate-python-baseline.py",
     ] + glob(["scripts/gatelib/*.py"]),
     env = {
@@ -1194,12 +1193,30 @@ rue_sh_test(
     },
 )
 
+# JSON twins of TOML-authored policy inputs, so the Python gates run on the
+# repository's 3.9 floor without `tomllib` (RUE-1524). The TOML stays the
+# authored source of truth next to the CLI cases; these artifacts are derived
+# every build and carry no independent content.
+genrule(
+    name = "cli-execution-contracts-json",
+    out = "execution_contracts.json",
+    cmd = "$(exe //crates/rue-toml2json:rue-toml2json) " +
+        "$(location //crates/rue-cli-tests:cases)/cases/execution_contracts.toml > $OUT",
+)
+
+genrule(
+    name = "cli-case-mosaic-json",
+    out = "examples_mosaic.json",
+    cmd = "$(exe //crates/rue-toml2json:rue-toml2json) " +
+        "$(location //crates/rue-cli-tests:cases)/cases/examples_mosaic.toml > $OUT",
+)
+
 rue_sh_test(
     name = "cli-timeout-policy-validation",
     test = "scripts/cli-timeout-policy.py",
     args = [
         "--policy",
-        "$(location //crates/rue-cli-tests:cases)/cases/execution_contracts.toml",
+        "$(location :cli-execution-contracts-json)",
         "--weights",
         "$(location //crates/rue-cli-tests:shard-weights)",
         # RUE-1163: a corpus action gets no test-executor timeout, so the
@@ -1219,7 +1236,8 @@ rue_sh_test(
         glob(["scripts/gatelib/*.py"]),
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
-        "RUE_CLI_CASES": "$(location //crates/rue-cli-tests:cases)/cases",
+        "RUE_CLI_CONTRACTS_JSON": "$(location :cli-execution-contracts-json)",
+        "RUE_CLI_MOSAIC_JSON": "$(location :cli-case-mosaic-json)",
     },
 )
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,11 +31,10 @@ directly if you prefer. macOS also requires Xcode Command Line Tools for linking
 Rue executables.
 
 The repository's own tooling is not hermetic: its gates and test runners are
-Python scripts that use whichever `python3` your `PATH` resolves, and a few of
-them require Python 3.11 or newer. macOS ships `/usr/bin/python3` as 3.9.6, so
-on a stock Mac `scripts/rue premerge` will report that a target needs a newer
-interpreter until you install one and put it earlier on `PATH`. See AGENTS.md,
-"Repository tooling baseline".
+Python scripts that use whichever `python3` your `PATH` resolves, and they
+require Python 3.9 or newer. macOS ships `/usr/bin/python3` as 3.9.6, so a
+stock Mac meets the floor with nothing to install. See AGENTS.md, "Repository
+tooling baseline".
 
 On development machines with several Rue worktrees, unfiltered full suites are
 serialized automatically to avoid oversubscribing the host. Quick and filtered

--- a/crates/rue-toml2json/BUCK
+++ b/crates/rue-toml2json/BUCK
@@ -1,0 +1,14 @@
+load("//crates:defs.bzl", "rue_binary")
+
+# Re-emits a TOML document as JSON. Exists so repository tooling that must
+# run on the Python 3.9 floor can consume TOML-authored policy files through
+# a Buck-materialized JSON artifact instead of importing `tomllib` (3.11+);
+# the CLI execution contracts are the one such file (RUE-1524).
+rue_binary(
+    name = "rue-toml2json",
+    tests = False,
+    deps = [
+        "//third-party:serde_json",
+        "//third-party:toml",
+    ],
+)

--- a/crates/rue-toml2json/src/main.rs
+++ b/crates/rue-toml2json/src/main.rs
@@ -1,0 +1,34 @@
+//! Re-emit a TOML document as JSON on stdout.
+//!
+//! Repository tooling runs on the Python 3.9 floor, where `tomllib` does not
+//! exist. Rather than raise the floor for one file or hand-write a partial
+//! TOML parser, the build materializes a JSON twin of a TOML policy file
+//! with this converter, and the Python side reads that (RUE-1524).
+
+use std::process::ExitCode;
+
+fn run() -> Result<(), String> {
+    let mut args = std::env::args_os().skip(1);
+    let path = match (args.next(), args.next()) {
+        (Some(path), None) => path,
+        _ => return Err("usage: rue-toml2json <file.toml>".to_string()),
+    };
+    let source = std::fs::read_to_string(&path)
+        .map_err(|error| format!("{}: {error}", path.to_string_lossy()))?;
+    let value: toml::Value =
+        toml::from_str(&source).map_err(|error| format!("{}: {error}", path.to_string_lossy()))?;
+    let json = serde_json::to_string_pretty(&value)
+        .map_err(|error| format!("{}: {error}", path.to_string_lossy()))?;
+    println!("{json}");
+    Ok(())
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(message) => {
+            eprintln!("error: {message}");
+            ExitCode::from(2)
+        }
+    }
+}

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -154,13 +154,12 @@ they're recorded here so a future config change doesn't silently regress:
    (Python 3.10 — the prelude's rustc wrapper needs ≥3.9; the default image ships
    3.6), by immutable digest rather than by its moving tag. See
    "Updating the remote worker image" below. This number is the worker image's,
-   for that wrapper, and is not the repository's Python floor — that is 3.11,
+   for that wrapper, and is not the repository's Python floor — that is 3.9,
    in AGENTS.md under "Repository tooling baseline". The two are independent:
    the worker runs Buck actions, and the `remote execution (linux-x64)` job
    builds rather than tests, so repository `scripts/*.py` do not execute there.
-   The worker image *is* below the repository floor, so an explicit
-   `--prefer-remote` **test** run of the two targets that need `tomllib` would
-   meet their version guard on the worker.
+   That the image's 3.10 happens to meet the 3.9 floor is incidental, not
+   load-bearing.
 6. **Linker** (RUE-320): the remote worker needs **`cc`** instead of the absent
    `clang++`. A `remote-execution` constraint is inserted only into the explicit
    full-remote execution configuration. The cache-only configuration omits it

--- a/rust-project.json
+++ b/rust-project.json
@@ -31,15 +31,15 @@
           "name": "rue_target"
         },
         {
-          "crate": 36,
+          "crate": 37,
           "name": "ahash"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "tracing"
         }
       ],
@@ -95,19 +95,19 @@
           "name": "rue_target"
         },
         {
-          "crate": 36,
+          "crate": 37,
           "name": "ahash"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         },
         {
-          "crate": 97,
+          "crate": 98,
           "name": "rayon"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "tracing"
         }
       ],
@@ -158,31 +158,31 @@
           "name": "rue_perf_schema"
         },
         {
-          "crate": 31,
+          "crate": 32,
           "name": "rue_driver"
         },
         {
-          "crate": 72,
+          "crate": 73,
           "name": "libc"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "serde_json"
         },
         {
-          "crate": 107,
+          "crate": 108,
           "name": "sha2"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "tempfile"
         },
         {
-          "crate": 114,
+          "crate": 115,
           "name": "toml"
         }
       ],
@@ -242,7 +242,7 @@
           "name": "rue_span"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         }
       ],
@@ -278,7 +278,7 @@
           "name": "rue_span"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         }
       ],
@@ -314,23 +314,23 @@
           "name": "rue_test_runner"
         },
         {
-          "crate": 76,
+          "crate": 77,
           "name": "libtest2_mimic"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "serde_json"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "tempfile"
         },
         {
-          "crate": 114,
+          "crate": 115,
           "name": "toml"
         }
       ],
@@ -382,19 +382,19 @@
           "name": "rue_target"
         },
         {
-          "crate": 58,
+          "crate": 59,
           "name": "fixedbitset"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "smallvec"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "tracing"
         }
       ],
@@ -470,43 +470,43 @@
           "name": "rue_target"
         },
         {
-          "crate": 36,
+          "crate": 37,
           "name": "ahash"
         },
         {
-          "crate": 39,
+          "crate": 40,
           "name": "annotate_snippets"
         },
         {
-          "crate": 65,
+          "crate": 66,
           "name": "itoa"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         },
         {
-          "crate": 72,
+          "crate": 73,
           "name": "libc"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "serde_json"
         },
         {
-          "crate": 107,
+          "crate": 108,
           "name": "sha2"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "tempfile"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "tracing"
         }
       ],
@@ -534,7 +534,7 @@
           "name": "rue_span"
         },
         {
-          "crate": 112,
+          "crate": 113,
           "name": "thiserror"
         }
       ],
@@ -570,11 +570,11 @@
           "name": "rue_test_runner"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "tempfile"
         }
       ],
@@ -646,15 +646,15 @@
           "name": "rue_test_runner"
         },
         {
-          "crate": 42,
+          "crate": 43,
           "name": "anyhow"
         },
         {
-          "crate": 72,
+          "crate": 73,
           "name": "libc"
         },
         {
-          "crate": 90,
+          "crate": 91,
           "name": "proptest"
         }
       ],
@@ -686,11 +686,11 @@
           "name": "rue_span"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         },
         {
-          "crate": 79,
+          "crate": 80,
           "name": "logos"
         }
       ],
@@ -718,7 +718,7 @@
           "name": "rue_target"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "tracing"
         }
       ],
@@ -758,15 +758,15 @@
           "name": "rue_test_runner"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "tempfile"
         },
         {
-          "crate": 114,
+          "crate": 115,
           "name": "toml"
         }
       ],
@@ -802,7 +802,7 @@
           "name": "rue_compiler"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         }
       ],
@@ -838,15 +838,15 @@
           "name": "rue_span"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "smallvec"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "tracing"
         }
       ],
@@ -870,19 +870,19 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "serde_json"
         },
         {
-          "crate": 107,
+          "crate": 108,
           "name": "sha2"
         },
         {
-          "crate": 114,
+          "crate": 115,
           "name": "toml"
         }
       ],
@@ -906,15 +906,15 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 36,
+          "crate": 37,
           "name": "ahash"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "smallvec"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "tracing"
         }
       ],
@@ -950,11 +950,11 @@
           "name": "rue_span"
         },
         {
-          "crate": 36,
+          "crate": 37,
           "name": "ahash"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         }
       ],
@@ -990,11 +990,11 @@
           "name": "rue_span"
         },
         {
-          "crate": 36,
+          "crate": 37,
           "name": "ahash"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         }
       ],
@@ -1088,11 +1088,11 @@
           "name": "rue_test_runner"
         },
         {
-          "crate": 76,
+          "crate": 77,
           "name": "libtest2_mimic"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "tempfile"
         }
       ],
@@ -1143,19 +1143,19 @@
           "name": "rue_target"
         },
         {
-          "crate": 72,
+          "crate": 73,
           "name": "libc"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "tempfile"
         },
         {
-          "crate": 114,
+          "crate": 115,
           "name": "toml"
         }
       ],
@@ -1163,6 +1163,34 @@
       "source": {
         "include_dirs": [
           "crates/rue-test-runner/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-toml2json",
+      "root_module": "crates/rue-toml2json/src/main.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 106,
+          "name": "serde_json"
+        },
+        {
+          "crate": 115,
+          "name": "toml"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-toml2json/src"
         ],
         "exclude_dirs": []
       },
@@ -1183,7 +1211,7 @@
           "name": "rue_test_runner"
         },
         {
-          "crate": 76,
+          "crate": 77,
           "name": "libtest2_mimic"
         }
       ],
@@ -1246,31 +1274,31 @@
           "name": "rue_target"
         },
         {
-          "crate": 31,
+          "crate": 32,
           "name": "rue_driver"
         },
         {
-          "crate": 72,
+          "crate": 73,
           "name": "libc"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "serde_json"
         },
         {
-          "crate": 107,
+          "crate": 108,
           "name": "sha2"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "tracing"
         },
         {
-          "crate": 122,
+          "crate": 123,
           "name": "tracing_subscriber"
         }
       ],
@@ -1314,27 +1342,27 @@
           "name": "rue_target"
         },
         {
-          "crate": 72,
+          "crate": 73,
           "name": "libc"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "serde_json"
         },
         {
-          "crate": 107,
+          "crate": 108,
           "name": "sha2"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "tracing"
         },
         {
-          "crate": 122,
+          "crate": 123,
           "name": "tracing_subscriber"
         }
       ],
@@ -1358,7 +1386,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 80,
+          "crate": 81,
           "name": "logos_codegen"
         }
       ],
@@ -1382,15 +1410,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 89,
+          "crate": 90,
           "name": "proc_macro2"
         },
         {
-          "crate": 92,
+          "crate": 93,
           "name": "quote"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "syn"
         }
       ],
@@ -1415,15 +1443,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 89,
+          "crate": 90,
           "name": "proc_macro2"
         },
         {
-          "crate": 92,
+          "crate": 93,
           "name": "quote"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "syn"
         }
       ],
@@ -1447,15 +1475,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 89,
+          "crate": 90,
           "name": "proc_macro2"
         },
         {
-          "crate": 92,
+          "crate": 93,
           "name": "quote"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "syn"
         }
       ],
@@ -1479,19 +1507,19 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 48,
+          "crate": 49,
           "name": "cfg_if"
         },
         {
-          "crate": 61,
+          "crate": 62,
           "name": "getrandom"
         },
         {
-          "crate": 85,
+          "crate": 86,
           "name": "once_cell"
         },
         {
-          "crate": 129,
+          "crate": 130,
           "name": "zerocopy"
         }
       ],
@@ -1519,7 +1547,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 82,
+          "crate": 83,
           "name": "memchr"
         }
       ],
@@ -1565,11 +1593,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 41,
+          "crate": 42,
           "name": "anstyle"
         },
         {
-          "crate": 126,
+          "crate": 127,
           "name": "unicode_width"
         }
       ],
@@ -1678,7 +1706,7 @@
       "edition": "2015",
       "deps": [
         {
-          "crate": 45,
+          "crate": 46,
           "name": "bit_vec"
         }
       ],
@@ -1746,7 +1774,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 60,
+          "crate": 61,
           "name": "generic_array"
         }
       ],
@@ -1808,11 +1836,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 51,
+          "crate": 52,
           "name": "crossbeam_epoch"
         },
         {
-          "crate": 52,
+          "crate": 53,
           "name": "crossbeam_utils"
         }
       ],
@@ -1838,7 +1866,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 52,
+          "crate": 53,
           "name": "crossbeam_utils"
         }
       ],
@@ -1885,11 +1913,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 60,
+          "crate": 61,
           "name": "generic_array"
         },
         {
-          "crate": 123,
+          "crate": 124,
           "name": "typenum"
         }
       ],
@@ -1913,27 +1941,27 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 48,
+          "crate": 49,
           "name": "cfg_if"
         },
         {
-          "crate": 52,
+          "crate": 53,
           "name": "crossbeam_utils"
         },
         {
-          "crate": 62,
+          "crate": 63,
           "name": "hashbrown"
         },
         {
-          "crate": 77,
+          "crate": 78,
           "name": "lock_api"
         },
         {
-          "crate": 85,
+          "crate": 86,
           "name": "once_cell"
         },
         {
-          "crate": 86,
+          "crate": 87,
           "name": "parking_lot_core"
         }
       ],
@@ -1958,11 +1986,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 47,
+          "crate": 48,
           "name": "block_buffer"
         },
         {
-          "crate": 53,
+          "crate": 54,
           "name": "crypto_common"
         }
       ],
@@ -2069,7 +2097,7 @@
       "edition": "2015",
       "deps": [
         {
-          "crate": 123,
+          "crate": 124,
           "name": "typenum"
         }
       ],
@@ -2114,11 +2142,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 36,
+          "crate": 37,
           "name": "ahash"
         },
         {
-          "crate": 38,
+          "crate": 39,
           "name": "allocator_api2"
         }
       ],
@@ -2166,11 +2194,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 57,
+          "crate": 58,
           "name": "equivalent"
         },
         {
-          "crate": 63,
+          "crate": 64,
           "name": "hashbrown"
         }
       ],
@@ -2237,11 +2265,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 54,
+          "crate": 55,
           "name": "dashmap"
         },
         {
-          "crate": 62,
+          "crate": 63,
           "name": "hashbrown"
         }
       ],
@@ -2287,11 +2315,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 70,
+          "crate": 71,
           "name": "lexarg_error"
         },
         {
-          "crate": 71,
+          "crate": 72,
           "name": "lexarg_parser"
         }
       ],
@@ -2316,7 +2344,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 71,
+          "crate": 72,
           "name": "lexarg_parser"
         }
       ],
@@ -2382,7 +2410,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 66,
+          "crate": 67,
           "name": "json_write"
         }
       ],
@@ -2408,11 +2436,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 69,
+          "crate": 70,
           "name": "lexarg"
         },
         {
-          "crate": 70,
+          "crate": 71,
           "name": "lexarg_error"
         }
       ],
@@ -2437,27 +2465,27 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 40,
+          "crate": 41,
           "name": "anstream"
         },
         {
-          "crate": 41,
+          "crate": 42,
           "name": "anstyle"
         },
         {
-          "crate": 70,
+          "crate": 71,
           "name": "lexarg_error"
         },
         {
-          "crate": 71,
+          "crate": 72,
           "name": "lexarg_parser"
         },
         {
-          "crate": 73,
+          "crate": 74,
           "name": "libtest_json"
         },
         {
-          "crate": 74,
+          "crate": 75,
           "name": "libtest_lexarg"
         }
       ],
@@ -2484,11 +2512,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 73,
+          "crate": 74,
           "name": "libtest_json"
         },
         {
-          "crate": 75,
+          "crate": 76,
           "name": "libtest2_harness"
         }
       ],
@@ -2515,7 +2543,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 102,
+          "crate": 103,
           "name": "scopeguard"
         }
       ],
@@ -2561,7 +2589,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 32,
+          "crate": 33,
           "name": "logos_derive"
         }
       ],
@@ -2589,31 +2617,31 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 43,
+          "crate": 44,
           "name": "beef"
         },
         {
-          "crate": 59,
+          "crate": 60,
           "name": "fnv"
         },
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lazy_static"
         },
         {
-          "crate": 89,
+          "crate": 90,
           "name": "proc_macro2"
         },
         {
-          "crate": 92,
+          "crate": 93,
           "name": "quote"
         },
         {
-          "crate": 100,
+          "crate": 101,
           "name": "regex_syntax"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "syn"
         }
       ],
@@ -2637,7 +2665,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 99,
+          "crate": 100,
           "name": "regex_automata"
         }
       ],
@@ -2784,7 +2812,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 129,
+          "crate": 130,
           "name": "zerocopy"
         }
       ],
@@ -2810,7 +2838,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 125,
+          "crate": 126,
           "name": "unicode_ident"
         }
       ],
@@ -2836,47 +2864,47 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 44,
+          "crate": 45,
           "name": "bit_set"
         },
         {
-          "crate": 45,
+          "crate": 46,
           "name": "bit_vec"
         },
         {
-          "crate": 46,
+          "crate": 47,
           "name": "bitflags"
         },
         {
-          "crate": 84,
+          "crate": 85,
           "name": "num_traits"
         },
         {
-          "crate": 93,
+          "crate": 94,
           "name": "rand"
         },
         {
-          "crate": 94,
+          "crate": 95,
           "name": "rand_chacha"
         },
         {
-          "crate": 96,
+          "crate": 97,
           "name": "rand_xorshift"
         },
         {
-          "crate": 100,
+          "crate": 101,
           "name": "regex_syntax"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "rusty_fork"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "tempfile"
         },
         {
-          "crate": 124,
+          "crate": 125,
           "name": "unarray"
         }
       ],
@@ -2927,7 +2955,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 89,
+          "crate": 90,
           "name": "proc_macro2"
         }
       ],
@@ -2953,7 +2981,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 95,
+          "crate": 96,
           "name": "rand_core"
         }
       ],
@@ -2980,11 +3008,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 88,
+          "crate": 89,
           "name": "ppv_lite86"
         },
         {
-          "crate": 95,
+          "crate": 96,
           "name": "rand_core"
         }
       ],
@@ -3009,7 +3037,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 61,
+          "crate": 62,
           "name": "getrandom"
         }
       ],
@@ -3035,7 +3063,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 95,
+          "crate": 96,
           "name": "rand_core"
         }
       ],
@@ -3059,11 +3087,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 56,
+          "crate": 57,
           "name": "either"
         },
         {
-          "crate": 98,
+          "crate": 99,
           "name": "rayon_core"
         }
       ],
@@ -3087,11 +3115,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 50,
+          "crate": 51,
           "name": "crossbeam_deque"
         },
         {
-          "crate": 52,
+          "crate": 53,
           "name": "crossbeam_utils"
         }
       ],
@@ -3115,15 +3143,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 37,
+          "crate": 38,
           "name": "aho_corasick"
         },
         {
-          "crate": 82,
+          "crate": 83,
           "name": "memchr"
         },
         {
-          "crate": 100,
+          "crate": 101,
           "name": "regex_syntax"
         }
       ],
@@ -3200,19 +3228,19 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 59,
+          "crate": 60,
           "name": "fnv"
         },
         {
-          "crate": 91,
+          "crate": 92,
           "name": "quick_error"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "tempfile"
         },
         {
-          "crate": 127,
+          "crate": 128,
           "name": "wait_timeout"
         }
       ],
@@ -3257,11 +3285,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 33,
+          "crate": 34,
           "name": "serde_derive"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde_core"
         }
       ],
@@ -3310,19 +3338,19 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 65,
+          "crate": 66,
           "name": "itoa"
         },
         {
-          "crate": 82,
+          "crate": 83,
           "name": "memchr"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde_core"
         },
         {
-          "crate": 130,
+          "crate": 131,
           "name": "zmij"
         }
       ],
@@ -3348,7 +3376,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         }
       ],
@@ -3373,15 +3401,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 48,
+          "crate": 49,
           "name": "cfg_if"
         },
         {
-          "crate": 49,
+          "crate": 50,
           "name": "cpufeatures"
         },
         {
-          "crate": 55,
+          "crate": 56,
           "name": "digest"
         }
       ],
@@ -3405,7 +3433,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lazy_static"
         }
       ],
@@ -3448,15 +3476,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 89,
+          "crate": 90,
           "name": "proc_macro2"
         },
         {
-          "crate": 92,
+          "crate": 93,
           "name": "quote"
         },
         {
-          "crate": 125,
+          "crate": 126,
           "name": "unicode_ident"
         }
       ],
@@ -3510,7 +3538,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 34,
+          "crate": 35,
           "name": "thiserror_impl"
         }
       ],
@@ -3536,7 +3564,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 48,
+          "crate": 49,
           "name": "cfg_if"
         }
       ],
@@ -3560,19 +3588,19 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "serde_spanned"
         },
         {
-          "crate": 115,
+          "crate": 116,
           "name": "toml_datetime"
         },
         {
-          "crate": 116,
+          "crate": 117,
           "name": "toml_edit"
         }
       ],
@@ -3599,7 +3627,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         }
       ],
@@ -3624,27 +3652,27 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 64,
+          "crate": 65,
           "name": "indexmap"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "serde_spanned"
         },
         {
-          "crate": 115,
+          "crate": 116,
           "name": "toml_datetime"
         },
         {
-          "crate": 117,
+          "crate": 118,
           "name": "toml_write"
         },
         {
-          "crate": 128,
+          "crate": 129,
           "name": "winnow"
         }
       ],
@@ -3693,15 +3721,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 35,
+          "crate": 36,
           "name": "tracing_attributes"
         },
         {
-          "crate": 87,
+          "crate": 88,
           "name": "pin_project_lite"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "tracing_core"
         }
       ],
@@ -3729,7 +3757,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 85,
+          "crate": 86,
           "name": "once_cell"
         }
       ],
@@ -3756,15 +3784,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 78,
+          "crate": 79,
           "name": "log"
         },
         {
-          "crate": 85,
+          "crate": 86,
           "name": "once_cell"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "tracing_core"
         }
       ],
@@ -3790,11 +3818,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "tracing_core"
         }
       ],
@@ -3818,55 +3846,55 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 81,
+          "crate": 82,
           "name": "matchers"
         },
         {
-          "crate": 83,
+          "crate": 84,
           "name": "nu_ansi_term"
         },
         {
-          "crate": 85,
+          "crate": 86,
           "name": "once_cell"
         },
         {
-          "crate": 99,
+          "crate": 100,
           "name": "regex_automata"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "serde_json"
         },
         {
-          "crate": 108,
+          "crate": 109,
           "name": "sharded_slab"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "smallvec"
         },
         {
-          "crate": 113,
+          "crate": 114,
           "name": "thread_local"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "tracing"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "tracing_core"
         },
         {
-          "crate": 120,
+          "crate": 121,
           "name": "tracing_log"
         },
         {
-          "crate": 121,
+          "crate": 122,
           "name": "tracing_serde"
         }
       ],

--- a/scripts/cli-timeout-policy.py
+++ b/scripts/cli-timeout-policy.py
@@ -16,23 +16,6 @@ import re
 import sys
 from pathlib import Path
 
-# RUE-1509: `tomllib` is stdlib only from 3.11, and this target carries
-# `rue_test_tier_premerge`, so below the floor the premerge suite died with
-# `ModuleNotFoundError: No module named 'tomllib'` out of a timeout validator --
-# a message naming neither the version nor the remedy. CI never saw it: its
-# runners are 3.12 and newer. The repository floor is 3.11 for this import and
-# nothing else; see AGENTS.md, "Repository tooling baseline".
-if sys.version_info < (3, 11):
-    raise SystemExit(
-        "error: scripts/cli-timeout-policy.py requires Python 3.11 or newer "
-        f"(this interpreter is {platform.python_version()} at {sys.executable}). "
-        "It reads the CLI execution contracts with the stdlib `tomllib` module, "
-        "added in 3.11. Install a 3.11+ interpreter and put it earlier on PATH; "
-        "see AGENTS.md, \"Repository tooling baseline\"."
-    )
-
-import tomllib
-
 PROFILE_NAMES = ("ordinary", "slow", "stress")
 PROFILE_KEYS = {"compile_hang_timeout_ms", "runtime_hang_timeout_ms"}
 POLICY_KEYS = {
@@ -45,7 +28,10 @@ POLICY_KEYS = {
 
 
 def load_policy(path: Path) -> tuple[dict[str, dict[str, int]], dict[str, int]]:
-    data = tomllib.loads(path.read_text())
+    # The contracts are authored as TOML next to the CLI cases; the build
+    # materializes this JSON twin via //crates/rue-toml2json so the gate runs
+    # on the repository's Python 3.9 floor without `tomllib` (RUE-1524).
+    data = json.loads(path.read_text())
     profiles = data.get("timeout_profile")
     policy = data.get("timeout_policy")
     if not isinstance(profiles, dict) or set(profiles) != set(PROFILE_NAMES):
@@ -204,7 +190,10 @@ def main() -> int:
     parser.add_argument(
         "--policy",
         type=Path,
-        default=Path("crates/rue-cli-tests/cases/execution_contracts.toml"),
+        required=True,
+        help="JSON twin of execution_contracts.toml; build "
+        "//:cli-execution-contracts-json or run this gate as "
+        "//:cli-timeout-policy-validation",
     )
     parser.add_argument(
         "--weights", type=Path, default=Path("crates/rue-cli-tests/shard-weights.json")

--- a/scripts/test-cli-timeout-policy.py
+++ b/scripts/test-cli-timeout-policy.py
@@ -1,25 +1,10 @@
 #!/usr/bin/env python3
 import json
 import os
-import platform
 import sys
 import tempfile
 import unittest
 from pathlib import Path
-
-# RUE-1509: the same floor the tool under test carries, stated here too because
-# this file reads the case TOML itself. See AGENTS.md, "Repository tooling
-# baseline".
-if sys.version_info < (3, 11):
-    raise SystemExit(
-        "error: scripts/test-cli-timeout-policy.py requires Python 3.11 or "
-        f"newer (this interpreter is {platform.python_version()} at "
-        f"{sys.executable}). It reads the CLI case TOML with the stdlib "
-        "`tomllib` module, added in 3.11. Install a 3.11+ interpreter and put "
-        "it earlier on PATH; see AGENTS.md, \"Repository tooling baseline\"."
-    )
-
-import tomllib
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from gatelib import load_script
@@ -29,9 +14,11 @@ MODULE = load_script("cli-timeout-policy.py", __file__)
 
 class TimeoutPolicyTests(unittest.TestCase):
     def test_mosaic_section_and_automatic_example_use_slow_profile(self):
-        cases = Path(os.environ["RUE_CLI_CASES"])
-        authority = tomllib.loads((cases / "execution_contracts.toml").read_text())
-        mosaic = tomllib.loads((cases / "examples_mosaic.toml").read_text())
+        # JSON twins materialized by //crates/rue-toml2json genrules (RUE-1524).
+        authority = json.loads(
+            Path(os.environ["RUE_CLI_CONTRACTS_JSON"]).read_text()
+        )
+        mosaic = json.loads(Path(os.environ["RUE_CLI_MOSAIC_JSON"]).read_text())
         automatic = next(
             entry
             for entry in authority["automatic_example"]
@@ -74,29 +61,28 @@ class TimeoutPolicyTests(unittest.TestCase):
         self.assertEqual(MODULE.derive_timeout_ms(10, 5000, policy), 5000)
 
     def test_raw_contract_deadlines_are_rejected(self):
-        text = """
-[timeout_profile.ordinary]
-compile_hang_timeout_ms=1
-runtime_hang_timeout_ms=1
-[timeout_profile.slow]
-compile_hang_timeout_ms=2
-runtime_hang_timeout_ms=2
-[timeout_profile.stress]
-compile_hang_timeout_ms=3
-runtime_hang_timeout_ms=3
-[timeout_policy]
-expected_cost_multiplier_percent=100
-fixed_headroom_ms=1
-minimum_shard_timeout_ms=1
-minimum_monolith_timeout_ms=1
-minimum_slow_suite_timeout_ms=1
-[contract.bad]
-class="ordinary"
-compile_timeout_ms=10
-"""
+        # The gate reads the JSON twin the build derives from the authored
+        # TOML, so the fixture is that JSON shape directly (RUE-1524).
+        data = {
+            "timeout_profile": {
+                "ordinary": {"compile_hang_timeout_ms": 1, "runtime_hang_timeout_ms": 1},
+                "slow": {"compile_hang_timeout_ms": 2, "runtime_hang_timeout_ms": 2},
+                "stress": {"compile_hang_timeout_ms": 3, "runtime_hang_timeout_ms": 3},
+            },
+            "timeout_policy": {
+                "expected_cost_multiplier_percent": 100,
+                "fixed_headroom_ms": 1,
+                "minimum_shard_timeout_ms": 1,
+                "minimum_monolith_timeout_ms": 1,
+                "minimum_slow_suite_timeout_ms": 1,
+            },
+            "contract": {
+                "bad": {"class": "ordinary", "compile_timeout_ms": 10},
+            },
+        }
         with tempfile.TemporaryDirectory() as directory:
-            path = Path(directory) / "policy.toml"
-            path.write_text(text)
+            path = Path(directory) / "policy.json"
+            path.write_text(json.dumps(data))
             with self.assertRaisesRegex(ValueError, "raw deadlines are forbidden"):
                 MODULE.load_policy(path)
 

--- a/scripts/test-validate-python-baseline.py
+++ b/scripts/test-validate-python-baseline.py
@@ -5,20 +5,12 @@ Every fixture here is 3.9 syntax, so the scan means the same thing on every
 interpreter that can run this file. That is deliberate: the one part of the
 policy that is NOT host-independent -- what happens to a file the scanner
 cannot parse -- is asserted on both sides of the floor instead of assumed away.
-
-What needed the most care is that these fail when the thing they describe
-breaks. Asserting the tree is clean passes just as well when the gate has
-stopped looking, so the shipped guard is tested by deleting it from a copy of
-the real file and requiring the finding to come back.
 """
 
 from __future__ import annotations
 
-import re
-import subprocess
 import sys
 import tempfile
-import textwrap
 import unittest
 from pathlib import Path
 
@@ -27,17 +19,6 @@ from gatelib import load_script
 
 SCRIPT = Path(__file__).with_name("validate-python-baseline.py")
 policy = load_script("validate-python-baseline.py", __file__)
-
-TOOL = Path(__file__).with_name("cli-timeout-policy.py")
-
-GUARD = textwrap.dedent(
-    """
-    import sys
-
-    if sys.version_info < (3, 11):
-        raise SystemExit("needs Python 3.11 or newer")
-    """
-)
 
 
 def descriptions(source: str) -> list[str]:
@@ -61,121 +42,35 @@ class ScanTests(unittest.TestCase):
     def test_flags_the_import_that_caused_rue_1509(self) -> None:
         self.assertEqual(descriptions("import tomllib\n"), ["the `tomllib` module"])
 
-    def test_a_guard_above_the_import_settles_it(self) -> None:
-        self.assertEqual(descriptions(GUARD + "import tomllib\n"), [])
-
-    def test_a_guard_below_the_import_does_not(self) -> None:
-        # The program has already died by then, so ordering is the whole point.
-        self.assertEqual(
-            descriptions("import tomllib\n" + GUARD), ["the `tomllib` module"]
-        )
-
-    def test_a_raise_in_the_else_branch_is_not_a_guard(self) -> None:
-        # This one runs the import on 3.10 and reproduces RUE-1509 verbatim, so
-        # accepting it would certify the bug the gate exists to prevent.
-        inverted = (
+    def test_a_version_guard_no_longer_exempts(self) -> None:
+        # RUE-1524 retired the split floor and its guard idiom. A guard above
+        # the import announced a requirement the repository no longer grants,
+        # so it must not silence the finding.
+        guarded = (
             "import sys\n\n"
             "if sys.version_info < (3, 11):\n"
-            "    pass\n"
-            "else:\n"
-            '    raise SystemExit("needs Python 3.11 or newer")\n'
+            '    raise SystemExit("needs Python 3.11 or newer")\n\n'
+            "import tomllib\n"
         )
-        self.assertEqual(
-            descriptions(inverted + "import tomllib\n"), ["the `tomllib` module"]
-        )
+        self.assertEqual(descriptions(guarded), ["the `tomllib` module"])
 
-    def test_a_conditional_raise_is_not_a_guard(self) -> None:
-        # Reachability is the claim; a raise under another condition does not
-        # make it.
-        nested = (
-            "import sys\n\n"
-            "if sys.version_info < (3, 11):\n"
-            "    if False:\n"
-            '        raise SystemExit("needs Python 3.11 or newer")\n'
-        )
-        self.assertEqual(
-            descriptions(nested + "import tomllib\n"), ["the `tomllib` module"]
-        )
-
-    def test_a_guard_that_does_not_name_the_version_does_not_count(self) -> None:
-        silent = (
-            "import sys\n\n"
-            "if sys.version_info < (3, 11):\n"
-            '    raise SystemExit("unsupported")\n'
-        )
-        self.assertEqual(
-            descriptions(silent + "import tomllib\n"), ["the `tomllib` module"]
-        )
-
-    def test_a_version_named_outside_the_raise_does_not_count(self) -> None:
-        # The message the user sees is the one in the raise, not a nearby
-        # string that happens to contain the number.
-        decoy = (
-            "import sys\n\n"
-            "if sys.version_info < (3, 11):\n"
-            '    note = "3.11"\n'
-            '    raise SystemExit("unsupported")\n'
-        )
-        self.assertEqual(
-            descriptions(decoy + "import tomllib\n"), ["the `tomllib` module"]
-        )
-
-    def test_a_guard_that_does_not_exit_does_not_count(self) -> None:
-        warning = (
-            "import sys\n\n"
-            "if sys.version_info < (3, 11):\n"
-            '    print("needs Python 3.11 or newer")\n'
-        )
-        self.assertEqual(
-            descriptions(warning + "import tomllib\n"), ["the `tomllib` module"]
-        )
-
-    def test_a_guard_demanding_too_little_does_not_count(self) -> None:
-        weak = (
-            "import sys\n\n"
-            "if sys.version_info < (3, 10):\n"
-            '    raise SystemExit("needs Python 3.10 or newer")\n'
-        )
-        self.assertEqual(
-            descriptions(weak + "import tomllib\n"), ["the `tomllib` module"]
-        )
-
-    def test_subscripted_version_info_is_the_same_guard(self) -> None:
-        subscripted = (
-            "import sys\n\n"
-            "if sys.version_info[:2] < (3, 11):\n"
-            '    raise SystemExit("needs Python 3.11 or newer")\n'
-        )
-        self.assertEqual(descriptions(subscripted + "import tomllib\n"), [])
-
-    def test_a_handled_import_needs_no_guard(self) -> None:
-        # The vendored-backport idiom. The objection to a bare `import tomllib`
-        # is that it fails unhandled; this one does not, so the rule does not
-        # apply -- and it must not, or the gate would reject the fallback on the
-        # day someone adopts it.
-        for handler in ("ModuleNotFoundError", "ImportError", ""):
-            source = (
-                "try:\n"
-                "    import tomllib\n"
-                f"except {handler}:\n".replace("except :", "except:")
-                + "    import tomli as tomllib\n"
-            )
-            self.assertEqual(descriptions(source), [], handler)
-
-    def test_a_try_that_catches_something_else_is_not_a_handled_import(self) -> None:
+    def test_a_handled_import_is_no_exemption_either(self) -> None:
+        # The vendored-backport idiom would run on 3.9, but since RUE-1524 the
+        # annotation is the one reviewed escape; an unannotated fallback is
+        # still a finding rather than a silent allowance.
         source = (
             "try:\n"
             "    import tomllib\n"
-            "except ValueError:\n"
-            "    tomllib = None\n"
+            "except ImportError:\n"
+            "    import tomli as tomllib\n"
         )
         self.assertEqual(descriptions(source), ["the `tomllib` module"])
 
-    def test_constructs_at_or_below_the_stock_host_are_silent(self) -> None:
+    def test_constructs_at_or_below_the_floor_are_silent(self) -> None:
         for source in ("import graphlib\n", "import zoneinfo\n", "import json\n"):
             self.assertEqual(descriptions(source), [], source)
 
-    def test_flags_the_apis_between_the_stock_host_and_the_floor(self) -> None:
+    def test_flags_constructs_newer_than_the_floor(self) -> None:
         cases = {
             "from datetime import UTC\n": "`datetime.UTC`",
             "from typing import Self\n": "`typing.Self`",
@@ -198,16 +93,14 @@ class ScanTests(unittest.TestCase):
             descriptions("import dataclasses\n@dataclasses.dataclass(slots=True)\nclass C: pass\n"),
         )
 
-    def test_above_the_floor_is_a_finding_a_guard_cannot_answer(self) -> None:
+    def test_a_finding_names_the_floor_and_the_annotation(self) -> None:
         findings, _ = policy.scan("import itertools\nitertools.batched([], 1)\n", "p.py")
         self.assertEqual(len(findings), 1)
-        self.assertTrue(findings[0].above_floor)
-        self.assertIn("above the repository floor", str(findings[0]))
-        self.assertNotIn("sys.version_info", str(findings[0]))
-        guarded, _ = policy.scan(
-            GUARD + "import itertools\nitertools.batched([], 1)\n", "p.py"
-        )
-        self.assertEqual(len(guarded), 1)
+        message = str(findings[0])
+        self.assertIn("above the repository floor of 3.9", message)
+        self.assertIn("python-baseline-ok", message)
+        # The retired guard idiom must not be recommended.
+        self.assertNotIn("sys.version_info", message)
 
     def test_an_alias_does_not_hide_the_construct(self) -> None:
         self.assertIn(
@@ -233,10 +126,11 @@ class ScanTests(unittest.TestCase):
 class UnparseableTests(unittest.TestCase):
     """The one host-dependent behaviour, asserted on whichever side we are on.
 
-    Below the floor a parse error is ambiguous -- `match` needs 3.10, which the
-    floor allows -- so guessing would produce a finding wrong about the version,
-    wrong about the floor, and backwards about the fix. At or above the floor it
-    is unambiguous. Both branches assert, so neither can quietly become a no-op.
+    Below the floor a parse error is ambiguous -- PEP 614 decorator grammar
+    needs 3.9, which the floor allows -- so guessing would produce a finding
+    wrong about the version, wrong about the floor, and backwards about the
+    fix. At or above the floor it is unambiguous. Both branches assert, so
+    neither can quietly become a no-op.
     """
 
     def test_a_parse_error_is_judged_only_from_at_or_above_the_floor(self) -> None:
@@ -249,28 +143,6 @@ class UnparseableTests(unittest.TestCase):
         else:
             self.assertEqual(unscanned, [])
             self.assertEqual(len(findings), 1)
-            self.assertTrue(findings[0].above_floor)
-
-    def test_a_guarded_construct_above_this_host_is_never_a_false_finding(self) -> None:
-        # A correctly guarded `match` is legal at the floor. On 3.9 it does not
-        # parse; the answer must be silence plus a note, never a finding that
-        # tells the author to remove something the floor allows.
-        source = (
-            "import sys\n\n"
-            "if sys.version_info < (3, 10):\n"
-            '    raise SystemExit("needs Python 3.10 or newer")\n\n'
-            "def f(x):\n"
-            "    match x:\n"
-            "        case 1:\n"
-            "            return 2\n"
-            "    return 0\n"
-        )
-        findings, unscanned = policy.scan(source, "p.py")
-        self.assertEqual([str(finding) for finding in findings], [])
-        if policy.SCANNER < (3, 10):
-            self.assertEqual(len(unscanned), 1)
-        else:
-            self.assertEqual(unscanned, [])
 
 
 class DiscoveryTests(unittest.TestCase):
@@ -325,7 +197,7 @@ class DocumentationTests(unittest.TestCase):
             (root / "AGENTS.md").write_text(text, encoding="utf-8")
             return policy.check_docs(root)
 
-    SECTION = policy.FLOOR_SECTION + "\n\nThe tooling requires Python 3.11 or newer.\n"
+    SECTION = policy.FLOOR_SECTION + "\n\nThe tooling requires Python 3.9 or newer.\n"
 
     def test_the_repository_documents_the_floor_this_gate_enforces(self) -> None:
         root = repository_root()
@@ -337,14 +209,14 @@ class DocumentationTests(unittest.TestCase):
         self.assertEqual(self.check(self.SECTION), [])
 
     def test_a_missing_section_is_a_finding(self) -> None:
-        problems = self.check("# Rue\n\nThe tooling requires Python 3.11 or newer.\n")
+        problems = self.check("# Rue\n\nThe tooling requires Python 3.9 or newer.\n")
         self.assertEqual(len(problems), 1)
         self.assertIn("no \"## Repository tooling baseline\" section", problems[0])
 
     def test_the_claim_must_be_inside_the_section(self) -> None:
         # An unrelated sentence elsewhere in a long file is not the floor.
         text = (
-            "# Rue\n\nThe tooling requires Python 3.11 or newer.\n\n"
+            "# Rue\n\nThe tooling requires Python 3.9 or newer.\n\n"
             + policy.FLOOR_SECTION
             + "\n\nSee elsewhere.\n\n## Next\n"
         )
@@ -355,14 +227,16 @@ class DocumentationTests(unittest.TestCase):
     def test_the_claim_must_be_outside_a_code_fence(self) -> None:
         text = (
             policy.FLOOR_SECTION
-            + "\n\n```\nrequires Python 3.11 or newer\n```\n"
+            + "\n\n```\nrequires Python 3.9 or newer\n```\n"
         )
         problems = self.check(text)
         self.assertEqual(len(problems), 1)
         self.assertIn("outside a code fence", problems[0])
 
     def test_a_documented_floor_that_disagrees_is_a_finding(self) -> None:
-        text = policy.FLOOR_SECTION + "\n\nrequires Python 3.9 or newer\n"
+        # 3.11 is exactly the number RUE-1524 retired, so it is the mismatch a
+        # stale document would most plausibly state.
+        text = policy.FLOOR_SECTION + "\n\nrequires Python 3.11 or newer\n"
         problems = self.check(text)
         self.assertEqual(len(problems), 1)
         self.assertIn("Move both together", problems[0])
@@ -390,45 +264,6 @@ class RepositoryTests(unittest.TestCase):
         self.assertEqual([str(note) for note in unscanned], [])
         # A real lower bound: a handful of sandboxed files must not satisfy it.
         self.assertGreater(scanned, 50)
-
-    def test_the_shipped_tool_is_clean_only_because_it_is_guarded(self) -> None:
-        # The bug this whole change answers, pinned by removing its fix: with
-        # the guard deleted, scripts/cli-timeout-policy.py is a bare `import
-        # tomllib` again and the gate must say so.
-        source = TOOL.read_text(encoding="utf-8")
-        findings, unscanned = policy.scan(source, "cli-timeout-policy.py")
-        self.assertEqual([str(finding) for finding in findings], [])
-        self.assertEqual(unscanned, [])
-        stripped = re.sub(
-            r"\nif sys\.version_info < \(3, 11\):\n(?:    .*\n|\n)*?    \)\n",
-            "\n",
-            source,
-        )
-        self.assertNotEqual(stripped, source, "the guard was not found to remove")
-        self.assertEqual(descriptions(stripped), ["the `tomllib` module"])
-
-
-class HostTests(unittest.TestCase):
-    def test_the_tool_reports_the_floor_rather_than_a_missing_module(self) -> None:
-        """Run the real tool and check which failure this host gets.
-
-        Both branches assert something real, so this case cannot quietly become
-        a no-op on either side of the floor -- which is how the RUE-1506
-        mechanism tests first went wrong.
-        """
-        result = subprocess.run(
-            [sys.executable, str(TOOL), "--help"],
-            capture_output=True,
-            text=True,
-        )
-        if sys.version_info < policy.FLOOR:
-            self.assertNotEqual(result.returncode, 0)
-            self.assertNotIn("ModuleNotFoundError", result.stderr)
-            self.assertIn("requires Python 3.11 or newer", result.stderr)
-            self.assertIn("AGENTS.md", result.stderr)
-        else:
-            self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertIn("--policy", result.stdout)
 
 
 if __name__ == "__main__":

--- a/scripts/validate-python-baseline.py
+++ b/scripts/validate-python-baseline.py
@@ -7,49 +7,19 @@ first on PATH. CI's is generous -- `ubuntu-latest` provides 3.12.3 and
 `macos-15` provides 3.14.6 -- and a developer's is not: macOS ships
 `/usr/bin/python3` as 3.9.6. A construct newer than the host interpreter is
 therefore not a portability nicety, it is a traceback before the program does
-any of its work, on a machine CI cannot see.
+any of its work, on a machine CI cannot see. That is how `tomllib`, stdlib
+only from 3.11, killed the premerge suite on every stock Mac while CI stayed
+green (RUE-1509); the Bash analogue is `mapfile` in test.sh (RUE-1506).
 
-That is exactly how it failed. `scripts/cli-timeout-policy.py` imports
-`tomllib`, stdlib only from 3.11, and //:cli-timeout-policy-validation carries
-`rue_test_tier_premerge` -- so the premerge suite died with
-`ModuleNotFoundError: No module named 'tomllib'` on every host below 3.11 while
-CI stayed green, and the message named neither the version nor the remedy
-(RUE-1509). The Bash analogue is `mapfile` in test.sh (RUE-1506); this is the
-same failure in the other language, so it gets the same shape of gate.
-
-Two thresholds, one table:
-
-  FLOOR (3.11)      what the repository requires, documented in AGENTS.md.
-                    Nothing may need MORE than this. A construct above the
-                    floor is a finding with no escape but a portable spelling.
-
-  UNGUARDED (3.9)   what a contributor has WITHOUT installing anything, on the
-                    oldest host that plausibly shows up. A construct between
-                    UNGUARDED and FLOOR is allowed -- that is what the floor
-                    buys -- but the file must announce the requirement instead
-                    of crashing on it.
-
-The guard is one canonical spelling, checked before the construct's first use:
-
-    import sys
-
-    if sys.version_info < (3, 11):
-        raise SystemExit(
-            "error: scripts/x.py requires Python 3.11 or newer (this is ...)"
-        )
-
-    import tomllib
-
-The `raise` must be an unconditional statement in that `if`'s own body. A
-`raise` in the `else`, or nested inside a further condition, is not a guard --
-it is a file that still reaches the import on an old host, which is the
-original bug wearing the fix's clothes. The message must contain the version it
-demands, because naming the requirement is the entire point; a guard that exits
-without saying which version has only moved the mystery.
-
-An import inside `try:` with an `except ImportError`/`ModuleNotFoundError`
-handler is exempt: the whole objection is that the failure is unhandled, and
-that import handles it. That is the shape a vendored fallback takes.
+The floor is a uniform 3.9 -- exactly what a stock Mac provides, so meeting it
+costs a contributor nothing. It was briefly 3.11 for the `tomllib` consumers,
+with version-guard machinery holding everything else to 3.9; RUE-1524 pointed
+those consumers at a Buck-materialized JSON twin of the TOML instead, so no
+file needs more than 3.9 and the guard machinery is retired. A construct newer
+than the floor is simply an error. The only escape is a reviewed
+`# python-baseline-ok: <reason>` annotation -- it has to sit in a real comment,
+and it silences its whole line -- or raising the floor in AGENTS.md and here,
+deliberately.
 
 WHAT IS SCANNED. Every `.py` file, plus every extensionless file carrying a
 python shebang -- `scripts/ci-test-failure-report` is a 126-line program CI runs
@@ -64,23 +34,20 @@ WHAT THIS SCAN CANNOT SEE, stated plainly so the gate is not read as a proof:
     file is reported as unscanned rather than guessed at, and the authoritative
     run is the `fmt` job's CI step, which is at or above the floor.
   - Symmetrically, ABOVE the floor it is too permissive: a scanner on 3.14
-    parses a PEP 701 f-string that 3.11 would reject and calls the file clean.
+    parses a PEP 701 f-string that 3.9 would reject and calls the file clean.
     The Bash gate closes its version of that gap by parsing with a real 3.2 on
     ci.yml's macos-15 leg (RUE-1512). The Python counterpart is
-    `ast.parse(source, feature_version=(3, 11))`, which needs no 3.11 to be
-    installed -- it has existed since 3.8 and runs on whatever interpreter is
-    here. It is deliberately NOT used, and the reason is coverage rather than
-    availability: `feature_version` is documented best-effort, it gates only
-    what CPython's own parser gates by version, and it cannot manufacture
-    grammar the RUNNING interpreter lacks. Measured on 3.10.3: `(3, 9)`
-    correctly rejects a `match` statement, but `except*` (3.11, at the floor
-    and therefore legal) fails at every `feature_version`, because 3.10 cannot
-    parse it at all. So it would reject legal files on old hosts while still
-    missing what has no version gate. Pinning a real 3.11 in CI is the change
-    that would make a sound check possible; until then this is stated rather
-    than approximated. What the gate CAN see without any of that -- version-
-    gated imports, attributes, and grammar with a distinct AST node -- it sees
-    from any host, which is why the table is not redundant either.
+    `ast.parse(source, feature_version=(3, 9))`, which runs on whatever
+    interpreter is here -- it has existed since 3.8. It is deliberately NOT
+    used, and the reason is coverage rather than availability: `feature_version`
+    is documented best-effort, it gates only what CPython's own parser gates by
+    version, and it cannot manufacture grammar the RUNNING interpreter lacks --
+    so it would still pass PEP 701 f-strings and every method call while adding
+    a second, weaker parser's opinion. Parsing with a real 3.9 in CI is the
+    change that would make a sound check possible; until then this is stated
+    rather than approximated. What the gate CAN see without any of that --
+    version-gated imports, attributes, and grammar with a distinct AST node --
+    it sees from any host, which is why the table is not redundant either.
   - Grammar with no distinct AST node is invisible: PEP 701 f-strings (3.12)
     and PEP 696 TypeVar defaults (3.13) parse into the same nodes as their
     older spellings on an interpreter new enough to accept them.
@@ -118,15 +85,13 @@ from gatelib import prune_names
 
 ROOT = Path(__file__).resolve().parent.parent
 
-# What the repository requires. AGENTS.md states this in prose and `check_docs`
-# holds the two copies together, so the gate cannot outlive the documentation
-# that tells a contributor what to install.
-FLOOR = (3, 11)
-
-# What a contributor has before installing anything. macOS ships
-# `/usr/bin/python3` as 3.9.6 and no newer interpreter out of the box, so 3.9
-# is the version a file must either run on or explain itself to.
-UNGUARDED = (3, 9)
+# The one floor: what the repository requires, which is also what a stock
+# Mac's `/usr/bin/python3` (3.9.6) provides. AGENTS.md states this in prose and
+# `check_docs` holds the two copies together, so the gate cannot outlive the
+# documentation that tells a contributor what runs the tooling. RUE-1524
+# retired the short-lived 3.11 floor and the version-guard machinery that a
+# split floor required.
+FLOOR = (3, 9)
 
 SCANNER = (sys.version_info[0], sys.version_info[1])
 
@@ -150,8 +115,7 @@ OTHER_DOCS = ("CONTRIBUTING.md", "README.md", "docs")
 
 # Stdlib modules by the version that introduced them. An import of one of these
 # is the failure that started this: it raises ModuleNotFoundError at import
-# time, before any of the program's own error handling exists -- unless the
-# import is handled, which `handled_imports` accounts for.
+# time, before any of the program's own error handling exists.
 MODULE_SINCE = {
     "graphlib": (3, 9),
     "zoneinfo": (3, 9),
@@ -229,39 +193,28 @@ class Finding(NamedTuple):
     path: str
     line: int
     construct: Construct
-    # A construct above FLOOR has no guard that would make it acceptable; one
-    # between UNGUARDED and FLOOR is merely unannounced. The two need different
-    # sentences, because "add a guard" is wrong advice for the first.
-    above_floor: bool
 
     def __str__(self) -> str:
         needs = version_text(self.construct.since)
-        if self.above_floor:
-            return (
-                f"{self.path}:{self.line}: {self.construct.description} needs "
-                f"Python {needs}, above the repository floor of "
-                f"{version_text(FLOOR)}. Instead, {self.construct.fix} -- or "
-                "raise the floor in AGENTS.md and here, deliberately."
-            )
         return (
             f"{self.path}:{self.line}: {self.construct.description} needs "
-            f"Python {needs}, and a stock host has {version_text(UNGUARDED)}, "
-            f"so this file must announce the requirement rather than crash on "
-            f"it. Add `if sys.version_info < {tuple(self.construct.since)}: "
-            f'raise SystemExit("...{needs}...")` above the first use -- or '
-            "annotate with `# python-baseline-ok: <reason>`."
+            f"Python {needs}, above the repository floor of "
+            f"{version_text(FLOOR)}. Instead, {self.construct.fix} -- annotate "
+            "a reviewed exception with `# python-baseline-ok: <reason>`, or "
+            "raise the floor in AGENTS.md and here, deliberately."
         )
 
 
 class Unscanned(NamedTuple):
     """A file this interpreter could not parse, and could not judge.
 
-    Below the floor, a parse error is ambiguous: `match` needs 3.10, which the
-    floor allows, so a 3.9 host cannot tell a policy violation from a file it is
-    simply too old to read. Guessing would produce a finding that is wrong about
-    the version, wrong about the floor, and backwards about the fix -- the very
-    CI-lenient/developer-strict split this policy exists to close, inverted. So
-    it says what it could not do and leaves the verdict to the CI step.
+    Below the floor, a parse error is ambiguous: PEP 614's relaxed decorator
+    grammar needs 3.9, which the floor allows, so a 3.8 host cannot tell a
+    policy violation from a file it is simply too old to read. Guessing would
+    produce a finding that is wrong about the version, wrong about the floor,
+    and backwards about the fix -- the very CI-lenient/developer-strict split
+    this policy exists to close, inverted. So it says what it could not do and
+    leaves the verdict to the CI step.
     """
 
     path: str
@@ -281,116 +234,6 @@ class Unscanned(NamedTuple):
 
 def version_text(version: tuple[int, int]) -> str:
     return f"{version[0]}.{version[1]}"
-
-
-def guard_versions(tree: ast.Module) -> list[tuple[int, tuple[int, int]]]:
-    """Line and demanded version of each `sys.version_info` guard.
-
-    Only the canonical spelling counts -- a module-level `if sys.version_info <
-    (X, Y)` whose OWN BODY unconditionally raises SystemExit, with the version
-    named in that raise. The strictness is the point: a `raise` in the `else`
-    branch, or nested under another condition, leaves the following import
-    reachable on an old host, so accepting it would certify the exact
-    ModuleNotFoundError this gate exists to prevent.
-    """
-    guards: list[tuple[int, tuple[int, int]]] = []
-    for node in tree.body:
-        if not isinstance(node, ast.If):
-            continue
-        version = compared_version(node.test)
-        if version is None:
-            continue
-        raised = next(
-            (statement for statement in node.body if raises_system_exit(statement)),
-            None,
-        )
-        if raised is None:
-            continue
-        # The message has to name the version, because a guard that exits with
-        # a bare SystemExit has replaced one unexplained failure with another.
-        text = " ".join(
-            value.value
-            for value in ast.walk(raised)
-            if isinstance(value, ast.Constant) and isinstance(value.value, str)
-        )
-        if version_text(version) not in text:
-            continue
-        guards.append((node.lineno, version))
-    return guards
-
-
-def compared_version(test: ast.expr) -> tuple[int, int] | None:
-    """The `(X, Y)` in `sys.version_info < (X, Y)`, or None."""
-    if not isinstance(test, ast.Compare) or len(test.ops) != 1:
-        return None
-    if not isinstance(test.ops[0], ast.Lt):
-        return None
-    subject = test.left
-    # `sys.version_info[:2] < (3, 11)` is the same test, spelled defensively.
-    if isinstance(subject, ast.Subscript):
-        subject = subject.value
-    if not (
-        isinstance(subject, ast.Attribute)
-        and subject.attr == "version_info"
-        and isinstance(subject.value, ast.Name)
-        and subject.value.id == "sys"
-    ):
-        return None
-    bound = test.comparators[0]
-    if not isinstance(bound, ast.Tuple) or len(bound.elts) < 2:
-        return None
-    parts = [
-        element.value
-        for element in bound.elts[:2]
-        if isinstance(element, ast.Constant) and isinstance(element.value, int)
-    ]
-    return (parts[0], parts[1]) if len(parts) == 2 else None
-
-
-def raises_system_exit(statement: ast.stmt) -> bool:
-    """Whether this statement IS an unconditional `raise SystemExit`."""
-    if not isinstance(statement, ast.Raise) or statement.exc is None:
-        return False
-    call = statement.exc
-    if isinstance(call, ast.Call):
-        call = call.func
-    return isinstance(call, ast.Name) and call.id == "SystemExit"
-
-
-def handled_imports(tree: ast.Module) -> set[int]:
-    """`id()` of every import inside a `try` that catches an import failure.
-
-    The objection to a version-gated import is that it fails UNHANDLED, before
-    the program's own error handling exists. A `try: import tomllib / except
-    ModuleNotFoundError: ...` fallback -- the shape a vendored backport takes --
-    has already answered that, so the guard requirement does not apply to it.
-    """
-    exempt: set[int] = set()
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Try):
-            continue
-        if not any(catches_import_error(handler) for handler in node.handlers):
-            continue
-        for statement in node.body:
-            for inner in ast.walk(statement):
-                if isinstance(inner, (ast.Import, ast.ImportFrom)):
-                    exempt.add(id(inner))
-    return exempt
-
-
-def catches_import_error(handler: ast.ExceptHandler) -> bool:
-    if handler.type is None:
-        return True
-    names = (
-        handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type]
-    )
-    for name in names:
-        if isinstance(name, ast.Name) and name.id in (
-            "ImportError",
-            "ModuleNotFoundError",
-        ):
-            return True
-    return False
 
 
 def module_aliases(tree: ast.Module) -> dict[str, str]:
@@ -416,15 +259,12 @@ def constructs(tree: ast.Module) -> list[tuple[int, Construct]]:
     """Every version-gated construct in one parsed module, with its line."""
     found: list[tuple[int, Construct]] = []
     aliases = module_aliases(tree)
-    exempt = handled_imports(tree)
 
     def record(line: int, description: str, since: tuple[int, int], fix: str) -> None:
         found.append((line, Construct(description, since, fix)))
 
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
-            if id(node) in exempt:
-                continue
             for alias in node.names:
                 since = MODULE_SINCE.get(alias.name)
                 if since:
@@ -435,8 +275,6 @@ def constructs(tree: ast.Module) -> list[tuple[int, Construct]]:
                         "read the data with a module that predates the floor",
                     )
         elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
-            if id(node) in exempt:
-                continue
             since = MODULE_SINCE.get(node.module)
             if since:
                 record(
@@ -561,7 +399,8 @@ def scan(source: str, path: str) -> tuple[list[Finding], list[Unscanned]]:
         line = error.lineno or 1
         reason = error.msg
         if SCANNER < FLOOR:
-            # Ambiguous from here: `match` needs 3.10, which the floor allows.
+            # Ambiguous from here: the floor may allow grammar this interpreter
+            # cannot read.
             return [], [Unscanned(path, line, reason)]
         # At or above the floor, unparseable means newer than the floor, or
         # malformed. Either is a finding, and neither claims a version the
@@ -577,32 +416,21 @@ def scan(source: str, path: str) -> tuple[list[Finding], list[Unscanned]]:
                         FLOOR,
                         "use syntax the floor accepts, or fix the file",
                     ),
-                    above_floor=True,
                 )
             ],
             [],
         )
 
     lines = source.splitlines()
-    guards = guard_versions(tree)
     findings: dict[tuple[int, str], Finding] = {}
     for line, construct in constructs(tree):
-        if construct.since <= UNGUARDED:
+        if construct.since <= FLOOR:
             continue
         raw = lines[line - 1] if 0 < line <= len(lines) else ""
         _, comment = split_comment(raw)
         if ALLOW.search(comment):
             continue
-        above_floor = construct.since > FLOOR
-        # A guard cannot excuse a construct the floor does not reach: on a host
-        # AT the floor there is no interpreter for the guard to fall back to.
-        if not above_floor and any(
-            at < line and demanded >= construct.since for at, demanded in guards
-        ):
-            continue
-        findings[(line, construct.description)] = Finding(
-            path, line, construct, above_floor
-        )
+        findings[(line, construct.description)] = Finding(path, line, construct)
     return [findings[key] for key in sorted(findings)], []
 
 
@@ -666,7 +494,7 @@ def strip_fences(text: str) -> str:
     """Blank out fenced code blocks.
 
     A floor quoted inside an example is an example, not a claim, and the
-    section documents the guard's spelling in a fenced block.
+    section may quote spellings in fenced blocks.
     """
     kept = []
     fenced = False


### PR DESCRIPTION
Fixes RUE-1524. Fourth tranche of the RUE-1520 scripts roadmap — the one that retires machinery rather than relocating code. Net −346 lines.

## The pivot

The entire 3.11 interpreter floor existed for one import: `scripts/cli-timeout-policy.py` (and its tests) read the CLI execution contracts with `tomllib`. The contracts stay authored as TOML next to the CLI cases, where the Rust harness reads them natively; a new dependency-light `//crates/rue-toml2json` binary re-emits them (plus the mosaic case the tool tests cross-check) as JSON through genrules, and the Python side reads that. Both `tomllib` imports and their hand-rolled 3.11 guards are gone. The gate now requires `--policy` explicitly — its only real caller is `//:cli-timeout-policy-validation`, which passes the derived artifact. (The audit's premise that `ci-heavy-suite` invokes the tool at runtime turned out to be historical; only BUCK's comments remembered it.)

## What retires with the floor

`validate-python-baseline.py` drops from 806 to 634 lines: the FLOOR/UNGUARDED distinction collapses to a single `FLOOR = (3, 9)`, and the guard-shape recognition machinery (`guard_versions`, `compared_version`, `raises_system_exit`, `handled_imports`, and the exemption plumbing) retires with zero subjects. A construct newer than 3.9 now simply fails the gate; the sole reviewed exception is the `# python-baseline-ok: <reason>` annotation. The `try/except ImportError` code-path exemption goes too — the rewritten AGENTS.md names the annotation as the only escape, and a silent exemption would contradict it — pinned by a new test. The construct tables (3.11 entries included) and the scan-blind-spot inventory are kept in full. The tool tests drop from 435 to 270 lines, replacing nine guard-shape tests with two retirement-pinning ones.

## Docs

AGENTS.md's "Repository tooling baseline" Python half is rewritten around the uniform floor, including the reversal worth stating plainly: a stock Mac's 3.9.6 now **meets** the floor with nothing to install, and the CI visibility gap runs the other way (runners above the floor can green-light constructs a stock machine rejects). CONTRIBUTING.md, the ci.yml gap comment, and build-cache.md follow.

Validated with the python-baseline and timeout-policy targets (validation + tool tests), gatelib tests, the new crate's fmt/clippy gates, the shell baseline, duplication and CI gates, `scripts/rue quick`, and a regenerated `rust-project.json` (133 crates).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCariNhXQqtLK2bMgcViTr)_