### PR TITLE
RUE-1525: per-crate structural gates for debug asserts and inventories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,6 @@ jobs:
           echo "Checking formatting across ${#TARGETS[@]} crates..."
           ./buck2 test "${TARGETS[@]}"
 
-      - name: Check production debug assertions
-        run: scripts/validate-debug-assert-policy.py
-
       # The gates themselves must not fail open. `grep -q` behind a pipe under
       # `pipefail` discards the very finding it just made (RUE-1011, RUE-1155).
       - name: Check shell pipefail pipelines

--- a/BUCK
+++ b/BUCK
@@ -1336,13 +1336,13 @@ rue_sh_test(
     test = "scripts/validate-runtime-abi-inventory.py",
     resources = glob(["scripts/gatelib/*.py"]),
     args = [
-        "--source", "rue-air=$(location //crates/rue-air:runtime-abi-inventory-sources)",
-        "--source", "rue-builtins=$(location //crates/rue-builtins:runtime-abi-inventory-sources)",
-        "--source", "rue-cfg=$(location //crates/rue-cfg:runtime-abi-inventory-sources)",
-        "--source", "rue-codegen=$(location //crates/rue-codegen:runtime-abi-inventory-sources)",
-        "--source", "rue-compiler=$(location //crates/rue-compiler:runtime-abi-inventory-sources)",
-        "--source", "rue-linker=$(location //crates/rue-linker:runtime-abi-inventory-sources)",
-        "--source", "rue-oracle=$(location //crates/rue-oracle:runtime-abi-inventory-sources)",
+        "--source", "rue-air=$(location //crates/rue-air:rue-air-sources)",
+        "--source", "rue-builtins=$(location //crates/rue-builtins:rue-builtins-sources)",
+        "--source", "rue-cfg=$(location //crates/rue-cfg:rue-cfg-sources)",
+        "--source", "rue-codegen=$(location //crates/rue-codegen:rue-codegen-sources)",
+        "--source", "rue-compiler=$(location //crates/rue-compiler:rue-compiler-sources)",
+        "--source", "rue-linker=$(location //crates/rue-linker:rue-linker-sources)",
+        "--source", "rue-oracle=$(location //crates/rue-oracle:rue-oracle-sources)",
     ],
 )
 
@@ -1361,11 +1361,11 @@ rue_sh_test(
     test = "scripts/validate-type-architecture.py",
     resources = glob(["scripts/gatelib/*.py"]),
     args = [
-        "--source", "rue-air=$(location //crates/rue-air:type-architecture-inventory-sources)",
-        "--source", "rue-cfg=$(location //crates/rue-cfg:type-architecture-inventory-sources)",
-        "--source", "rue-codegen=$(location //crates/rue-codegen:type-architecture-inventory-sources)",
-        "--source", "rue-compiler=$(location //crates/rue-compiler:type-architecture-inventory-sources)",
-        "--source", "rue-oracle=$(location //crates/rue-oracle:type-architecture-inventory-sources)",
+        "--source", "rue-air=$(location //crates/rue-air:rue-air-sources)",
+        "--source", "rue-cfg=$(location //crates/rue-cfg:rue-cfg-sources)",
+        "--source", "rue-codegen=$(location //crates/rue-codegen:rue-codegen-sources)",
+        "--source", "rue-compiler=$(location //crates/rue-compiler:rue-compiler-sources)",
+        "--source", "rue-oracle=$(location //crates/rue-oracle:rue-oracle-sources)",
     ],
 )
 
@@ -1384,10 +1384,10 @@ rue_sh_test(
     test = "scripts/validate-payload-ownership.py",
     resources = glob(["scripts/gatelib/*.py"]),
     args = [
-        "--source", "rue-rir=$(location //crates/rue-rir:payload-ownership-inventory-sources)",
-        "--source", "rue-air=$(location //crates/rue-air:payload-ownership-inventory-sources)",
-        "--source", "rue-cfg=$(location //crates/rue-cfg:payload-ownership-inventory-sources)",
-        "--source", "rue-codegen=$(location //crates/rue-codegen:payload-ownership-inventory-sources)",
+        "--source", "rue-rir=$(location //crates/rue-rir:rue-rir-sources)",
+        "--source", "rue-air=$(location //crates/rue-air:rue-air-sources)",
+        "--source", "rue-cfg=$(location //crates/rue-cfg:rue-cfg-sources)",
+        "--source", "rue-codegen=$(location //crates/rue-codegen:rue-codegen-sources)",
     ],
 )
 
@@ -1406,8 +1406,8 @@ rue_sh_test(
     test = "scripts/validate-body-analysis-capabilities.py",
     resources = glob(["scripts/gatelib/*.py"]),
     args = [
-        "--source", "rue-air=$(location //crates/rue-air:body-analysis-capability-inventory-sources)",
-        "--source", "rue-compiler=$(location //crates/rue-compiler:body-analysis-capability-inventory-sources)",
+        "--source", "rue-air=$(location //crates/rue-air:rue-air-sources)",
+        "--source", "rue-compiler=$(location //crates/rue-compiler:rue-compiler-sources)",
     ],
 )
 

--- a/BUCK
+++ b/BUCK
@@ -67,6 +67,27 @@ filegroup(
     visibility = ["PUBLIC"],
 )
 
+# The per-crate debug-assertion checks emitted by rue_crate/rue_binary
+# (RUE-1525) address the gate script and its gatelib helpers cross-package
+# through these targets. `mode = "reference"` is load-bearing: the script
+# resolves `from gatelib import ...` relative to its own location, so it must
+# execute in place under scripts/ rather than as an isolated buck-out copy.
+# The gatelib filegroup exists so the emitting macro can declare the helpers
+# as resources — a gatelib edit re-runs every crate's check instead of
+# serving a stale pass.
+export_file(
+    name = "debug-assert-policy-script",
+    src = "scripts/validate-debug-assert-policy.py",
+    mode = "reference",
+    visibility = ["PUBLIC"],
+)
+
+filegroup(
+    name = "gatelib-sources",
+    srcs = glob(["scripts/gatelib/*.py"]),
+    visibility = ["PUBLIC"],
+)
+
 # The two halves of a cached corpus suite: the action wrapper that runs a
 # harness and writes its stamp, and the thin check that asserts the stamp.
 sh_binary(
@@ -128,8 +149,9 @@ sh_binary(
 # ASan harness (RUE-560) has no BUCK file, so no macro emits its gates. Its
 # clippy runs as a dedicated `cargo clippy -D warnings` step in the CI asan
 # job; its format check lives here, where the root package can still name its
-# sources, so the file the old gate DID cover keeps its coverage.
-_ASAN_FMT_SRCS = glob(["crates/rue-runtime-asan/src/**/*.rs"])
+# sources, so the file the old gate DID cover keeps its coverage. The same
+# sources feed its explicit debug-assert check below.
+_ASAN_GATE_SRCS = glob(["crates/rue-runtime-asan/src/**/*.rs"])
 
 rue_sh_test(
     name = "rue-runtime-asan-fmt-check",
@@ -140,8 +162,26 @@ rue_sh_test(
         "--edition",
         "2024",
         "--check",
-    ] + _ASAN_FMT_SRCS,
-    resources = _ASAN_FMT_SRCS + [":rustfmt-config"],
+    ] + _ASAN_GATE_SRCS,
+    resources = _ASAN_GATE_SRCS + [":rustfmt-config"],
+    # Excluded from quick iteration like every per-crate gate, so
+    # `scripts/rue quick` keeps meaning "unit tests only".
+    labels = ["rue_not_quick"],
+)
+
+# The same exception for the per-crate debug-assertion checks (RUE-1525): no
+# BUCK file means no macro emits `rue-runtime-asan-debug-assert-check`, so the
+# root package, which can still name the sources, declares it explicitly.
+rue_sh_test(
+    name = "rue-runtime-asan-debug-assert-check",
+    test = "scripts/validate-debug-assert-policy.py",
+    args = [
+        "--crate",
+        "rue-runtime-asan",
+        "--sources",
+        "crates/rue-runtime-asan/src",
+    ],
+    resources = _ASAN_GATE_SRCS + glob(["scripts/gatelib/*.py"]),
     # Excluded from quick iteration like every per-crate gate, so
     # `scripts/rue quick` keeps meaning "unit tests only".
     labels = ["rue_not_quick"],
@@ -845,6 +885,20 @@ rue_sh_test(
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
     },
+)
+
+# The structural complement of the per-crate debug-assertion checks
+# (RUE-1525): those run only for crates that emit them, so deleting a crate
+# would leave its ledger entries permanently unchecked. This gate fails when
+# any ledger entry names a crate rust-project.json no longer lists.
+rue_sh_test(
+    name = "debug-assert-ledger-check",
+    test = "scripts/validate-debug-assert-policy.py",
+    args = [
+        "--ledger-crates",
+        "rust-project.json",
+    ],
+    resources = ["rust-project.json"] + glob(["scripts/gatelib/*.py"]),
 )
 
 rue_sh_test(

--- a/crates/defs.bzl
+++ b/crates/defs.bzl
@@ -25,6 +25,23 @@ load("//:test_defs.bzl", "rue_test_labels")
 
 _RUSTFMT_CONFIG = "//:rustfmt-config"
 
+def _sources_filegroup(name, srcs):
+    """Emits `<name>-sources`: this crate's compiled sources as a PUBLIC filegroup.
+
+    Structural gates that live outside this package (the root-BUCK inventory
+    validators, RUE-1525) take a crate's sources as a `$(location ...)` input.
+    Emitting the filegroup from the macro every crate already calls replaces
+    the per-gate hand-written `*-inventory-sources` filegroups — one identical
+    `glob(["src/**/*.rs"])` copy per gate per crate — with a single sources
+    target that exists because the crate declares itself, and that new gates
+    can reuse without touching the crate's BUCK file.
+    """
+    native.filegroup(
+        name = name + "-sources",
+        srcs = srcs,
+        visibility = ["PUBLIC"],
+    )
+
 def _fmt_check(name, srcs):
     """Emits `<name>-fmt-check`: rustfmt --check over this crate's own sources.
 
@@ -97,6 +114,7 @@ def rue_crate(
     different srcs), use `tests = False` and write the rust_test by hand.
     """
     srcs = glob(["src/**/*.rs"])
+    _sources_filegroup(name, srcs)
     _fmt_check(name, srcs)
     _clippy_check(name)
     native.rust_library(
@@ -130,6 +148,7 @@ def rue_binary(
     build time).
     """
     srcs = glob(["src/**/*.rs"])
+    _sources_filegroup(name, srcs)
     _fmt_check(name, srcs)
     _clippy_check(name)
     native.rust_binary(

--- a/crates/defs.bzl
+++ b/crates/defs.bzl
@@ -77,6 +77,47 @@ def _fmt_check(name, srcs):
         labels = rue_test_labels("premerge", ["rue_not_quick"]),
     )
 
+_DEBUG_ASSERT_GATE = "//:debug-assert-policy-script"
+_GATELIB = "//:gatelib-sources"
+
+def _debug_assert_check(name, srcs):
+    """Emits `<name>-debug-assert-check`: the reviewed debug-assertion ledger,
+    scoped to this crate's sources.
+
+    Coverage is structural, like `_fmt_check`: a crate is checked because it
+    declares the target, and only that crate's edit re-runs it. The gate
+    script is addressed cross-package through a root `export_file` (mode =
+    "reference", so it executes in place next to scripts/gatelib/); the
+    gatelib filegroup rides along as a resource so a helper change re-runs
+    the check rather than serving a stale pass. The sh_test runs from the
+    project root, so `--sources` is the package-relative src/ directory and
+    `srcs` are declared as resources for the same staleness reason.
+
+    The check is keyed by the crate DIRECTORY name — that is the path the
+    ledger's `crates/<name>/src/...` entries use — so a package defining
+    several macro targets from the same sources (crates/rue: rue-driver, rue,
+    rue-benchmark) emits exactly one check, from the target whose name
+    matches the directory. Orphaned ledger entries for a crate that stopped
+    emitting a check entirely are caught by //:debug-assert-ledger-check.
+    """
+    crate = package_name().split("/")[-1]
+    if name != crate:
+        return
+    native.sh_test(
+        name = name + "-debug-assert-check",
+        test = _DEBUG_ASSERT_GATE,
+        args = [
+            "--crate",
+            crate,
+            "--sources",
+            package_name() + "/src",
+        ],
+        resources = srcs + [_GATELIB],
+        # Premerge tier; excluded from quick iteration so `scripts/rue quick`
+        # keeps meaning "unit tests only" (see quick-test.sh).
+        labels = rue_test_labels("premerge", ["rue_not_quick"]),
+    )
+
 def _clippy_check(name):
     """Emits `<name>-clippy`: fails when this crate's clippy diagnostics contain an error.
 
@@ -117,6 +158,7 @@ def rue_crate(
     _sources_filegroup(name, srcs)
     _fmt_check(name, srcs)
     _clippy_check(name)
+    _debug_assert_check(name, srcs)
     native.rust_library(
         name = name,
         srcs = srcs,
@@ -151,6 +193,7 @@ def rue_binary(
     _sources_filegroup(name, srcs)
     _fmt_check(name, srcs)
     _clippy_check(name)
+    _debug_assert_check(name, srcs)
     native.rust_binary(
         name = name,
         srcs = srcs,

--- a/crates/rue-air/BUCK
+++ b/crates/rue-air/BUCK
@@ -1,29 +1,5 @@
 load("//crates:defs.bzl", "rue_crate")
 
-filegroup(
-    name = "runtime-abi-inventory-sources",
-    srcs = glob(["src/**/*.rs"]),
-    visibility = ["PUBLIC"],
-)
-
-filegroup(
-    name = "type-architecture-inventory-sources",
-    srcs = glob(["src/**/*.rs"]),
-    visibility = ["PUBLIC"],
-)
-
-filegroup(
-    name = "payload-ownership-inventory-sources",
-    srcs = glob(["src/**/*.rs"]),
-    visibility = ["PUBLIC"],
-)
-
-filegroup(
-    name = "body-analysis-capability-inventory-sources",
-    srcs = glob(["src/**/*.rs"]),
-    visibility = ["PUBLIC"],
-)
-
 rue_crate(
     name = "rue-air",
     deps = [

--- a/crates/rue-builtins/BUCK
+++ b/crates/rue-builtins/BUCK
@@ -1,11 +1,5 @@
 load("//crates:defs.bzl", "rue_crate")
 
-filegroup(
-    name = "runtime-abi-inventory-sources",
-    srcs = glob(["src/**/*.rs"]),
-    visibility = ["PUBLIC"],
-)
-
 rue_crate(
     name = "rue-builtins",
     deps = [

--- a/crates/rue-cfg/BUCK
+++ b/crates/rue-cfg/BUCK
@@ -1,23 +1,5 @@
 load("//crates:defs.bzl", "rue_crate")
 
-filegroup(
-    name = "runtime-abi-inventory-sources",
-    srcs = glob(["src/**/*.rs"]),
-    visibility = ["PUBLIC"],
-)
-
-filegroup(
-    name = "type-architecture-inventory-sources",
-    srcs = glob(["src/**/*.rs"]),
-    visibility = ["PUBLIC"],
-)
-
-filegroup(
-    name = "payload-ownership-inventory-sources",
-    srcs = glob(["src/**/*.rs"]),
-    visibility = ["PUBLIC"],
-)
-
 rue_crate(
     name = "rue-cfg",
     deps = [

--- a/crates/rue-codegen/BUCK
+++ b/crates/rue-codegen/BUCK
@@ -1,23 +1,5 @@
 load("//crates:defs.bzl", "rue_crate")
 
-filegroup(
-    name = "runtime-abi-inventory-sources",
-    srcs = glob(["src/**/*.rs"]),
-    visibility = ["PUBLIC"],
-)
-
-filegroup(
-    name = "type-architecture-inventory-sources",
-    srcs = glob(["src/**/*.rs"]),
-    visibility = ["PUBLIC"],
-)
-
-filegroup(
-    name = "payload-ownership-inventory-sources",
-    srcs = glob(["src/**/*.rs"]),
-    visibility = ["PUBLIC"],
-)
-
 rue_crate(
     name = "rue-codegen",
     deps = [

--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -1,24 +1,6 @@
 load("//crates:defs.bzl", "rue_crate")
 load("//:test_defs.bzl", "rue_rust_test", "rue_sh_test")
 
-filegroup(
-    name = "runtime-abi-inventory-sources",
-    srcs = glob(["src/**/*.rs"]),
-    visibility = ["PUBLIC"],
-)
-
-filegroup(
-    name = "type-architecture-inventory-sources",
-    srcs = glob(["src/**/*.rs"]),
-    visibility = ["PUBLIC"],
-)
-
-filegroup(
-    name = "body-analysis-capability-inventory-sources",
-    srcs = glob(["src/**/*.rs"]),
-    visibility = ["PUBLIC"],
-)
-
 # Per-target runtime staticlibs are mapped into src/ so the compiler can embed
 # all supported runtimes and select the matching archive at link time.
 _RUNTIME_MAPPED_SRCS = {

--- a/crates/rue-linker/BUCK
+++ b/crates/rue-linker/BUCK
@@ -1,11 +1,5 @@
 load("//crates:defs.bzl", "rue_crate")
 
-filegroup(
-    name = "runtime-abi-inventory-sources",
-    srcs = glob(["src/**/*.rs"]),
-    visibility = ["PUBLIC"],
-)
-
 rue_crate(
     name = "rue-linker",
     deps = [

--- a/crates/rue-oracle/BUCK
+++ b/crates/rue-oracle/BUCK
@@ -1,17 +1,5 @@
 load("//crates:defs.bzl", "rue_crate")
 
-filegroup(
-    name = "runtime-abi-inventory-sources",
-    srcs = glob(["src/**/*.rs"]),
-    visibility = ["PUBLIC"],
-)
-
-filegroup(
-    name = "type-architecture-inventory-sources",
-    srcs = glob(["src/**/*.rs"]),
-    visibility = ["PUBLIC"],
-)
-
 rue_crate(
     name = "rue-oracle",
     deps = [

--- a/crates/rue-rir/BUCK
+++ b/crates/rue-rir/BUCK
@@ -1,11 +1,5 @@
 load("//crates:defs.bzl", "rue_crate")
 
-filegroup(
-    name = "payload-ownership-inventory-sources",
-    srcs = glob(["src/**/*.rs"]),
-    visibility = ["PUBLIC"],
-)
-
 rue_crate(
     name = "rue-rir",
     deps = [

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -229,12 +229,15 @@ it is a p90 win first and a smaller p50 win. Do not re-derive a saving from an
 assumption that this job is free.
 
 Production `debug_assert*` use is governed by
-`scripts/validate-debug-assert-policy.py`, run by required formatting CI and
-`scripts/rue quick`. Every surviving call has an exact per-file allowance and
-rationale; changing the count requires reviewing the ledger. CFG optimization,
-code generation, and linking have no allowances: an invariant whose violation
-could change emitted code must be an always-on assertion or a real compiler
-diagnostic.
+`scripts/validate-debug-assert-policy.py`. The gate is structural (RUE-1525):
+`rue_crate`/`rue_binary` emit a premerge-tier `<name>-debug-assert-check` per
+crate, scoped to that crate's sources, and `//:debug-assert-ledger-check`
+fails when a ledger entry names a crate `rust-project.json` no longer lists —
+so a deleted crate cannot leave allowances nothing enforces. Every surviving
+call has an exact per-file allowance and rationale; changing the count
+requires reviewing the ledger. CFG optimization, code generation, and linking
+have no allowances: an invariant whose violation could change emitted code
+must be an always-on assertion or a real compiler diagnostic.
 
 ## Test execution tiers
 

--- a/quick-test.sh
+++ b/quick-test.sh
@@ -12,9 +12,6 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
-echo "Checking production debug-assertion policy..."
-scripts/validate-debug-assert-policy.py
-
 echo "Checking Buck test-tier ownership..."
 ./buck2 bxl //test_tiers.bxl:validate
 

--- a/scripts/test-debug-assert-policy.py
+++ b/scripts/test-debug-assert-policy.py
@@ -16,39 +16,48 @@ policy = load_script("validate-debug-assert-policy.py", __file__)
 
 class DebugAssertPolicyTests(unittest.TestCase):
     def validate(
-        self, files: dict[str, str], allowances: dict[str, policy.Allowance]
+        self,
+        crate: str,
+        files: dict[str, str],
+        allowances: dict[str, policy.Allowance],
     ) -> list[str]:
+        """Run the scoped check over a fixture src/ tree for one crate."""
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
+            sources = Path(directory)
             for relative, contents in files.items():
-                path = root / relative
+                path = sources / relative
                 path.parent.mkdir(parents=True, exist_ok=True)
                 path.write_text(contents)
-            return policy.validate(root, allowances)
+            return policy.validate_crate(crate, sources, allowances)
 
     def test_accepts_exact_reviewed_allowance(self) -> None:
-        path = "crates/rue-air/src/lib.rs"
         self.assertEqual(
             self.validate(
-                {path: "fn f() { debug_assert!(true); }\n"},
-                {path: policy.Allowance(1, "redundant test invariant")},
+                "rue-air",
+                {"lib.rs": "fn f() { debug_assert!(true); }\n"},
+                {"crates/rue-air/src/lib.rs": policy.Allowance(1, "redundant test invariant")},
             ),
             [],
         )
 
     def test_rejects_unreviewed_assertion(self) -> None:
         errors = self.validate(
-            {"crates/rue-codegen/src/lib.rs": "debug_assert_eq!(1, 1);\n"}, {}
+            "rue-codegen", {"lib.rs": "debug_assert_eq!(1, 1);\n"}, {}
         )
         self.assertEqual(len(errors), 1)
         self.assertIn("unreviewed", errors[0])
+        self.assertIn("crates/rue-codegen/src/lib.rs", errors[0])
 
     def test_rejects_ledger_drift_in_either_direction(self) -> None:
-        path = "crates/rue-air/src/lib.rs"
-        allowance = {path: policy.Allowance(2, "two redundant checks")}
-        too_few = self.validate({path: "debug_assert!(true);\n"}, allowance)
+        allowance = {
+            "crates/rue-air/src/lib.rs": policy.Allowance(2, "two redundant checks")
+        }
+        too_few = self.validate(
+            "rue-air", {"lib.rs": "debug_assert!(true);\n"}, allowance
+        )
         too_many = self.validate(
-            {path: "debug_assert!(true);\ndebug_assert!(true);\ndebug_assert!(true);\n"},
+            "rue-air",
+            {"lib.rs": "debug_assert!(true);\ndebug_assert!(true);\ndebug_assert!(true);\n"},
             allowance,
         )
         self.assertIn("expects 2, found 1", too_few[0])
@@ -61,9 +70,93 @@ class DebugAssertPolicyTests(unittest.TestCase):
 const TEXT: &str = "debug_assert_ne!(1, 1);";
 const RAW: &str = r#"debug_assert!(false);"#;
 """
+        self.assertEqual(self.validate("rue-codegen", {"lib.rs": source}, {}), [])
+
+    def test_scoping_ignores_other_crates_ledger_entries(self) -> None:
+        # Checking rue-codegen must not fail on rue-air's allowance: that
+        # entry belongs to rue-air's own check.
         self.assertEqual(
-            self.validate({"crates/rue-codegen/src/lib.rs": source}, {}), []
+            self.validate(
+                "rue-codegen",
+                {"lib.rs": "fn f() {}\n"},
+                {"crates/rue-air/src/lib.rs": policy.Allowance(1, "another crate's")},
+            ),
+            [],
         )
+
+    def test_allowance_for_unscanned_file_fails_as_drift(self) -> None:
+        # An in-scope ledger entry whose file the scan cannot reach (deleted,
+        # or outside src/) must fail rather than go silently unchecked.
+        errors = self.validate(
+            "rue-air",
+            {"lib.rs": "fn f() {}\n"},
+            {"crates/rue-air/src/missing.rs": policy.Allowance(1, "stale entry")},
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("expects 1, found 0", errors[0])
+
+    def test_missing_or_empty_sources_directory_fails_closed(self) -> None:
+        missing = policy.validate_crate(
+            "rue-air", Path("/nonexistent/rue-air/src"), {}
+        )
+        self.assertEqual(len(missing), 1)
+        self.assertIn("does not exist", missing[0])
+
+        with tempfile.TemporaryDirectory() as directory:
+            empty = policy.validate_crate("rue-air", Path(directory), {})
+        self.assertEqual(len(empty), 1)
+        self.assertIn("no .rs files", empty[0])
+
+    def project(self, *root_modules: str) -> dict:
+        return {"crates": [{"root_module": module} for module in root_modules]}
+
+    def test_ledger_accepts_entries_for_existing_crates(self) -> None:
+        self.assertEqual(
+            policy.validate_ledger_crates(
+                self.project(
+                    "crates/rue-air/src/lib.rs",
+                    "third-party/vendor/lasso/src/lib.rs",
+                ),
+                {"crates/rue-air/src/lib.rs": policy.Allowance(1, "reviewed")},
+            ),
+            [],
+        )
+
+    def test_ledger_rejects_orphaned_crate_entry(self) -> None:
+        # A deleted crate emits no per-crate check, so its surviving ledger
+        # entries would be enforced by nothing; the ledger mode fails on them.
+        errors = policy.validate_ledger_crates(
+            self.project("crates/rue-air/src/lib.rs"),
+            {"crates/rue-retired/src/lib.rs": policy.Allowance(1, "orphaned")},
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("rue-retired", errors[0])
+        self.assertIn("orphaned", errors[0])
+
+    def test_ledger_rejects_malformed_key_and_empty_project(self) -> None:
+        malformed = policy.validate_ledger_crates(
+            self.project("crates/rue-air/src/lib.rs"),
+            {"scripts/foo.py": policy.Allowance(1, "not a crate path")},
+        )
+        self.assertEqual(len(malformed), 1)
+        self.assertIn("crates/<name>/", malformed[0])
+
+        # Third-party-only (or empty) project data means the first-party
+        # detection is broken, never that the ledger is clean.
+        empty = policy.validate_ledger_crates(
+            self.project("third-party/vendor/lasso/src/lib.rs"),
+            {"crates/rue-air/src/lib.rs": policy.Allowance(1, "reviewed")},
+        )
+        self.assertEqual(len(empty), 1)
+        self.assertIn("no first-party crates", empty[0])
+
+    def test_real_ledger_names_only_first_party_shapes(self) -> None:
+        # The checked-in ledger must keep the crates/<name>/src/... shape the
+        # per-crate checks reconstruct their keys in.
+        for path in policy.ALLOWANCES:
+            parts = path.split("/")
+            self.assertEqual(parts[0], "crates", path)
+            self.assertEqual(parts[2], "src", path)
 
 
 if __name__ == "__main__":

--- a/scripts/validate-debug-assert-policy.py
+++ b/scripts/validate-debug-assert-policy.py
@@ -6,11 +6,20 @@ be the only barrier between malformed compiler state and wrong generated code.
 Every surviving production use is therefore an explicit reviewed exception.
 Changing, adding, or removing one requires updating this ledger with its
 rationale; the lowering, codegen, and linker crates intentionally have none.
+
+The gate runs per crate (RUE-1525): `--crate NAME --sources DIR` scans one
+crate's src/ tree and compares it against this ledger's entries for that
+crate, so each crate's check is a Buck test target emitted by the
+rue_crate/rue_binary macros and re-runs only when that crate changes.
+`--ledger-crates rust-project.json` is the structural complement: it fails
+when a ledger entry names a crate that no longer exists, which the per-crate
+checks cannot see because a deleted crate no longer emits one.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 from pathlib import Path
@@ -20,7 +29,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from gatelib import mask_rust_non_code, run_gate
 
 
-ROOT = Path(__file__).resolve().parent.parent
 DEBUG_ASSERT = re.compile(r"\bdebug_assert(?:_eq|_ne)?!\s*\(")
 
 
@@ -77,13 +85,8 @@ def count_debug_asserts(path: Path) -> int:
     return len(DEBUG_ASSERT.findall(mask_rust_non_code(path.read_text())[0]))
 
 
-def validate(root: Path, allowances: dict[str, Allowance] = ALLOWANCES) -> list[str]:
-    actual = {
-        path.relative_to(root).as_posix(): count_debug_asserts(path)
-        for path in sorted((root / "crates").glob("**/*.rs"))
-    }
-    actual = {path: count for path, count in actual.items() if count}
-
+def compare(actual: dict[str, int], allowances: dict[str, Allowance]) -> list[str]:
+    """The per-file comparison: exact reviewed counts, nothing unreviewed."""
     errors: list[str] = []
     for path in sorted(set(actual) | set(allowances)):
         observed = actual.get(path, 0)
@@ -101,16 +104,114 @@ def validate(root: Path, allowances: dict[str, Allowance] = ALLOWANCES) -> list[
     return errors
 
 
+def validate_crate(
+    crate: str, sources: Path, allowances: dict[str, Allowance] = ALLOWANCES
+) -> list[str]:
+    """Scan one crate's src/ tree against its slice of the ledger.
+
+    `sources` is the crate's src/ directory; each file maps to the ledger key
+    `crates/<crate>/src/<relative>`, matching how the repository-wide walk
+    used to key the same file. The comparison covers every ledger entry under
+    `crates/<crate>/`, so an allowance for a file the scan cannot reach
+    (deleted, or outside src/) fails as drift instead of going silently
+    unchecked.
+    """
+    if not sources.is_dir():
+        return [f"{crate}: sources directory {sources} does not exist"]
+    files = sorted(sources.rglob("*.rs"))
+    if not files:
+        return [
+            f"{crate}: no .rs files under {sources}; "
+            "the check's wiring is broken, this is never a clean crate"
+        ]
+    actual = {
+        f"crates/{crate}/src/{path.relative_to(sources).as_posix()}": count_debug_asserts(path)
+        for path in files
+    }
+    actual = {path: count for path, count in actual.items() if count}
+    prefix = f"crates/{crate}/"
+    scoped = {path: a for path, a in allowances.items() if path.startswith(prefix)}
+    return compare(actual, scoped)
+
+
+def first_party_crates(project: dict) -> set[str]:
+    """Crate directory names rust-project.json knows as first-party.
+
+    First-party entries are the ones whose root_module lives under crates/;
+    third-party and sysroot crates root elsewhere.
+    """
+    names = set()
+    for crate in project.get("crates", []):
+        root_module = crate.get("root_module", "")
+        if root_module.startswith("crates/"):
+            names.add(root_module.split("/")[1])
+    return names
+
+
+def validate_ledger_crates(
+    project: dict, allowances: dict[str, Allowance] = ALLOWANCES
+) -> list[str]:
+    """Fail-closed check that every ledger entry names a crate that exists.
+
+    The per-crate checks only run for crates that emit them, so deleting a
+    crate would otherwise leave its ledger entries permanently unchecked —
+    an allowance nothing enforces. This mode fails on such orphans.
+    """
+    crates = first_party_crates(project)
+    if not crates:
+        return [
+            "rust-project.json lists no first-party crates; "
+            "a broken project description is never a clean ledger"
+        ]
+    errors: list[str] = []
+    for path in sorted(allowances):
+        parts = path.split("/")
+        if len(parts) < 3 or parts[0] != "crates":
+            errors.append(f"{path}: ledger keys must be crates/<name>/... paths")
+        elif parts[1] not in crates:
+            errors.append(
+                f"{path}: ledger names crate '{parts[1]}', which rust-project.json "
+                "does not know; remove the orphaned allowance"
+            )
+    return errors
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("root", nargs="?", type=Path, default=ROOT)
+    parser.add_argument("--crate", help="crate name to check (with --sources)")
+    parser.add_argument(
+        "--sources", type=Path, help="the crate's src/ directory (with --crate)"
+    )
+    parser.add_argument(
+        "--ledger-crates",
+        type=Path,
+        help="rust-project.json; verify every ledger entry names a first-party crate",
+    )
     args = parser.parse_args()
 
-    total = sum(allowance.count for allowance in ALLOWANCES.values())
+    if args.ledger_crates is not None:
+        if args.crate is not None or args.sources is not None:
+            parser.error("--ledger-crates does not combine with --crate/--sources")
+        project = json.loads(args.ledger_crates.read_text())
+        crate_names = sorted({path.split("/")[1] for path in ALLOWANCES})
+        return run_gate(
+            lambda: validate_ledger_crates(project),
+            f"debug-assert ledger valid: {len(ALLOWANCES)} entries across "
+            f"{len(crate_names)} existing crate(s)",
+        )
+
+    if args.crate is None or args.sources is None:
+        parser.error("pass --crate NAME with --sources DIR, or --ledger-crates FILE")
+
+    prefix = f"crates/{args.crate}/"
+    reviewed = sum(
+        allowance.count
+        for path, allowance in ALLOWANCES.items()
+        if path.startswith(prefix)
+    )
     return run_gate(
-        lambda: validate(args.root),
-        "debug-assertion policy valid: "
-        f"{total} reviewed debug-only assertion(s), none in CFG/codegen/linker",
+        lambda: validate_crate(args.crate, args.sources),
+        f"debug-assert policy valid for {args.crate}: {reviewed} reviewed assertion(s)",
     )
 
 


### PR DESCRIPTION
Fixes RUE-1525. Fifth tranche of the RUE-1520 scripts roadmap: two gates move onto the structural per-crate pattern the `-fmt-check`/`-clippy` targets established.

## One sources filegroup per crate

`rue_crate`/`rue_binary` now emit `<name>-sources` (the same `src/**/*.rs` glob, PUBLIC). The four inventory validators' 18 `--source` args repoint at those, and the 18 hand-written, byte-identical filegroups across 8 crate BUCK files are deleted. (The audit estimated 32; the true count was 18 — several crates only ever grew the filegroups the validators actually reference.)

## Per-crate debug-assert checks

`validate-debug-assert-policy.py` loses its repository walk. Each macro call now emits `<name>-debug-assert-check` (premerge tier, `rue_not_quick`, crate srcs as declared resources), scanning only that crate and comparing against its slice of the shared ledger — an in-scope allowance the scan can't reach fails as drift. Two structural complements close the gaps a per-crate split opens: `//:debug-assert-ledger-check` validates every ledger key against `rust-project.json`'s first-party crates (so a deleted crate's orphaned allowances fail instead of going silently unchecked), and an explicit root target covers `rue-runtime-asan`, the one BUCK-less crate. The bare pre-steps in `quick-test.sh` and ci.yml's fmt job retire — the premerge tier carries the checks now, cached and parallel, re-running only for crates that changed.

Notable wiring detail: the gate script is exported with `mode = "reference"` so the cross-package sh_tests execute it in place, where it can import `scripts/gatelib/`.

Tier inventory: 167 → 197 premerge targets (29 emitted checks + the ledger check); quick stays unit-tests-only. Tool tests grew from 4 to 11 (scoped fixtures plus ledger-orphan and fail-closed cases).

Validated with all 29 emitted checks, the ledger check, the four inventory validations and tool tests, `scripts/rue quick`, the python/shell baselines, pipefail, duplication and CI gates, wrapper-script tests, and tier bxl validation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCariNhXQqtLK2bMgcViTr)_