### PR TITLE
RUE-1527: repair the timeout-policy gate's error path

### DIFF
--- a/scripts/cli-timeout-policy.py
+++ b/scripts/cli-timeout-policy.py
@@ -235,7 +235,7 @@ def main() -> int:
         )
         print(math.ceil(timeout_ms / 1000))
         return 0
-    except (OSError, ValueError, json.JSONDecodeError, tomllib.TOMLDecodeError) as error:
+    except (OSError, ValueError, json.JSONDecodeError) as error:
         print(f"error: {error}", file=sys.stderr)
         return 2
 

--- a/scripts/generate-site-status.py
+++ b/scripts/generate-site-status.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import argparse
 import json
 import subprocess
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from pathlib import Path
 
 # The sparkline's viewBox, matching the markup in `index.html`.

--- a/scripts/test-cli-timeout-policy.py
+++ b/scripts/test-cli-timeout-policy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import json
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -59,6 +60,30 @@ class TimeoutPolicyTests(unittest.TestCase):
             "minimum_shard_timeout_ms": 5000,
         }
         self.assertEqual(MODULE.derive_timeout_ms(10, 5000, policy), 5000)
+
+    def test_main_reports_a_malformed_policy_and_exits_two(self):
+        # The one test that enters main()'s error path. RUE-1524 left a
+        # stale tomllib name in the except tuple, and because Python only
+        # evaluates that tuple when an exception is raised, every failure
+        # of the gate died as a NameError traceback while the passing path
+        # stayed green. Exercising the path is what pins the contract:
+        # a diagnosable `error:` line and exit 2, not a traceback.
+        with tempfile.TemporaryDirectory() as directory:
+            policy = Path(directory) / "policy.json"
+            policy.write_text("{ not json")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(Path(__file__).with_name("cli-timeout-policy.py")),
+                    "--policy",
+                    str(policy),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 2, result.stderr)
+            self.assertIn("error:", result.stderr)
+            self.assertNotIn("Traceback", result.stderr)
 
     def test_raw_contract_deadlines_are_rejected(self):
         # The gate reads the JSON twin the build derives from the authored

--- a/scripts/validate-shell-bash-baseline.py
+++ b/scripts/validate-shell-bash-baseline.py
@@ -142,6 +142,8 @@ from pathlib import Path
 from typing import NamedTuple
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+# SKIP_DIRECTORIES is re-exported: the tool tests read the prune policy
+# through this module as the gate's own surface.
 from gatelib import SKIP_DIRECTORIES, prune_names
 
 

--- a/scripts/validate-shell-pipefail-pipelines.py
+++ b/scripts/validate-shell-pipefail-pipelines.py
@@ -29,6 +29,8 @@ from pathlib import Path
 from typing import NamedTuple
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+# SKIP_DIRECTORIES is re-exported: the tool tests read the prune policy
+# through this module as the gate's own surface.
 from gatelib import SKIP_DIRECTORIES, prune_names, run_gate
 
 


### PR DESCRIPTION
Fixes RUE-1527. First finding out of the second audit — a live bug the RUE-1524 tranche introduced.

`tomllib.TOMLDecodeError` survived in `main()`'s except tuple after the import was removed. Python evaluates the tuple only when an exception is raised, so the gate's passing path stayed green while every failure path would have died as a `NameError` traceback instead of the intended `error:` line and exit 2. No tool test entered `main()`'s error path, which is why nothing caught it — this PR adds that test (malformed policy → exit 2, diagnosable stderr, no traceback). The baseline gate's curated table keys on imports and structurally cannot see a stale name inside an except tuple; its docstring admits exactly this blind-spot class.

Also from the same lint sweep: the migration's one genuinely unused import (`timezone` in `generate-site-status.py`) is dropped, and the two `SKIP_DIRECTORIES` imports that lint flags as unused are kept and commented as deliberate re-exports — their tool tests read the prune policy through the gate modules, and removing them broke those tests in validation.

Validated with the timeout-policy validation and tool tests, both shell-gate tool-test targets, site-status tool tests, and the Python baseline gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCariNhXQqtLK2bMgcViTr)_