### PR TITLE
RUE-1530: derive CLI shard deadlines from harness-reported loads

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -1265,14 +1265,34 @@ genrule(
         "$(location //crates/rue-cli-tests:cases)/cases/examples_mosaic.toml > $OUT",
 )
 
+# RUE-1530: the packing authority for CLI shard deadlines. The harness's emit
+# mode performs the same case discovery the //:cli-tests-shard-* targets
+# perform (premerge tier, default all-platform selection) and packs it with
+# the same runtime LPT rule, once per platform modeled in shard-weights.json.
+# scripts/cli-timeout-policy.py applies its policy arithmetic to these
+# reported loads instead of reimplementing the packing; the declared inputs
+# (cases, examples, weights, harness) re-derive the report whenever the
+# corpus population or its measured costs change.
+genrule(
+    name = "cli-shard-loads-json",
+    out = "shard-loads.json",
+    cmd = "env " +
+        "RUE_CLI_EMIT_SHARD_LOADS={} ".format(CLI_TEST_SHARD_COUNT) +
+        "RUE_CLI_CASE_TIER=premerge " +
+        "RUE_CLI_CASES=$(location //crates/rue-cli-tests:cases)/cases " +
+        "RUE_EXAMPLES_DIR=$(location :examples)/examples " +
+        "RUE_CLI_SHARD_WEIGHTS=$(location //crates/rue-cli-tests:shard-weights) " +
+        "$(exe //crates/rue-cli-tests:rue-cli-tests) > $OUT",
+)
+
 rue_sh_test(
     name = "cli-timeout-policy-validation",
     test = "scripts/cli-timeout-policy.py",
     args = [
         "--policy",
         "$(location :cli-execution-contracts-json)",
-        "--weights",
-        "$(location //crates/rue-cli-tests:shard-weights)",
+        "--shard-loads",
+        "$(location :cli-shard-loads-json)",
         # RUE-1163: a corpus action gets no test-executor timeout, so the
         # `timeout_seconds` spelled here is the only bound on a wedged harness.
         # Declaring this file as an input makes the two sources of truth fail

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -96,6 +96,13 @@
 //! - `RUE_PLATFORM_CASE_SELECTION=native`: register every `only_on` case
 //!   applicable to the current host and no target-independent cases. Required
 //!   native CI uses this declarative selection.
+//! - `RUE_CLI_EMIT_SHARD_LOADS=<count>` (with `RUE_CLI_SHARD_WEIGHTS=<path>`):
+//!   instead of running tests, perform the same case discovery, pack it into
+//!   `<count>` shards once per platform modeled in the weights file, print the
+//!   JSON shard-loads report to stdout, and exit. Needs no compiler binary;
+//!   the `//:cli-shard-loads-json` genrule runs it at build time so
+//!   `scripts/cli-timeout-policy.py` consumes reported loads instead of
+//!   reimplementing the packing.
 //! - `differential_opt = true`: compile+run the case once per optimization
 //!   level (`-O0`/`-O1`/`-O2`/`-O3`) and assert identical exit code AND stdout
 //!   across all levels, catching optimizer miscompiles (RUE-236). The runner
@@ -3523,6 +3530,86 @@ fn example_trials(
     trials
 }
 
+/// The case-name inventory the current tier and platform selection register:
+/// declarative corpus cases plus (under `All` selection) automatic examples.
+///
+/// This is the single population rule for shard planning. `main` feeds it to
+/// the runtime [`CliShardPlan`]; [`emit_shard_loads`] feeds the same names to
+/// the per-platform packing report, so a derived shard deadline can never
+/// model a different inventory than the harness runs.
+fn discover_case_names(
+    corpus: &LoadedCorpus,
+    examples: &[DiscoveredExample],
+    automatic_contracts: &HashMap<String, AutomaticExampleMetadata>,
+    case_tier: CliCaseTierSelection,
+    platform_selection: PlatformCaseSelection,
+) -> Vec<String> {
+    let mut discovered_names = corpus
+        .files
+        .iter()
+        .flat_map(|(_, file)| {
+            file.cases
+                .iter()
+                .filter(|case| {
+                    case_tier.includes(file.section.tier)
+                        && platform_selection.includes(&case.only_on)
+                })
+                .map(|case| format!("{}::{}", file.section.id, case.name))
+        })
+        .collect::<Vec<_>>();
+    if platform_selection == PlatformCaseSelection::All {
+        discovered_names.extend(examples.iter().filter_map(|example| {
+            let tier = automatic_contracts
+                .get(&example.relative_path)
+                .map_or(CliCaseTier::Premerge, |metadata| metadata.tier);
+            case_tier
+                .includes(tier)
+                .then(|| example_test_name(&example.relative_path))
+        }));
+    }
+    discovered_names
+}
+
+/// `RUE_CLI_EMIT_SHARD_LOADS=<count>` mode: run the same case discovery the
+/// test path performs, pack it once per platform modeled in
+/// `RUE_CLI_SHARD_WEIGHTS`, and return the JSON report for stdout.
+///
+/// This needs the cases and examples directories but deliberately nothing
+/// else — no compiler binary, no std, no staged programs — so the
+/// `//:cli-shard-loads-json` genrule can run it hermetically at build time.
+fn emit_shard_loads(
+    count: &str,
+    case_tier: CliCaseTierSelection,
+    platform_selection: PlatformCaseSelection,
+) -> Result<String, String> {
+    let shard_count: u64 = count.parse().map_err(|_| {
+        format!("invalid RUE_CLI_EMIT_SHARD_LOADS {count:?} (expected a shard count)")
+    })?;
+    let weights_path = std::env::var_os("RUE_CLI_SHARD_WEIGHTS").ok_or_else(|| {
+        "RUE_CLI_SHARD_WEIGHTS is required when RUE_CLI_EMIT_SHARD_LOADS is set".to_string()
+    })?;
+    let cases_dir = find_dir("RUE_CLI_CASES", CASES_DIR_PATHS, "cases");
+    let corpus = load_cases(&cases_dir);
+    let examples = discover_examples()?;
+    let discovered_example_paths = examples
+        .iter()
+        .map(|example| example.relative_path.clone())
+        .collect::<HashSet<_>>();
+    let automatic_contracts = validate_contract_metadata(&corpus, &discovered_example_paths)
+        .map_err(|error| format!("invalid CLI execution contract metadata: {error}"))?;
+    let names = discover_case_names(
+        &corpus,
+        &examples,
+        &automatic_contracts,
+        case_tier,
+        platform_selection,
+    );
+    let weights = sharding::ShardWeights::load(Path::new(&weights_path))?;
+    let report = sharding::shard_loads_report(shard_count, &names, &weights)?;
+    serde_json::to_string_pretty(&report)
+        .map_err(|error| format!("cannot serialize shard loads: {error}"))
+}
+
 fn main() {
     // An optional `INDEX/COUNT` spec selects one cost-balanced slice of the
     // corpus so CI can fan the work across parallel runners. Unset (the
@@ -3539,6 +3626,20 @@ fn main() {
         eprintln!("error: {error}");
         std::process::exit(2);
     });
+    // Shard-loads emit mode short-circuits before anything that needs a
+    // compiler: the build-time genrule that runs it has no `RUE_BINARY`.
+    if let Ok(count) = std::env::var("RUE_CLI_EMIT_SHARD_LOADS") {
+        match emit_shard_loads(&count, case_tier, platform_selection) {
+            Ok(json) => {
+                println!("{json}");
+                return;
+            }
+            Err(error) => {
+                eprintln!("error: {error}");
+                std::process::exit(2);
+            }
+        }
+    }
     if shard_selector.is_some() && case_tier != CliCaseTierSelection::Premerge {
         eprintln!(
             "error: RUE_CLI_TEST_SHARD requires RUE_CLI_CASE_TIER=premerge \
@@ -3596,29 +3697,13 @@ fn main() {
         }
     }
 
-    let mut discovered_names = corpus
-        .files
-        .iter()
-        .flat_map(|(_, file)| {
-            file.cases
-                .iter()
-                .filter(|case| {
-                    case_tier.includes(file.section.tier)
-                        && platform_selection.includes(&case.only_on)
-                })
-                .map(|case| format!("{}::{}", file.section.id, case.name))
-        })
-        .collect::<Vec<_>>();
-    if platform_selection == PlatformCaseSelection::All {
-        discovered_names.extend(examples.iter().filter_map(|example| {
-            let tier = automatic_contracts
-                .get(&example.relative_path)
-                .map_or(CliCaseTier::Premerge, |metadata| metadata.tier);
-            case_tier
-                .includes(tier)
-                .then(|| example_test_name(&example.relative_path))
-        }));
-    }
+    let discovered_names = discover_case_names(
+        &corpus,
+        &examples,
+        &automatic_contracts,
+        case_tier,
+        platform_selection,
+    );
     let selected_discovered = discovered_names.len();
     let shard = shard_selector.map(|selector| {
         let weights_path = std::env::var_os("RUE_CLI_SHARD_WEIGHTS").unwrap_or_else(|| {
@@ -3780,6 +3865,76 @@ mod tests {
             automatic_examples: file.automatic_example.clone(),
             files: vec![("inline.toml".to_string(), file)],
         }
+    }
+
+    #[test]
+    fn discovered_shard_population_filters_tier_and_platform_and_adds_examples() {
+        // The population rule main() and the shard-loads emit mode share:
+        // tier filtering, `only_on` platform selection, and (under `All`
+        // selection only) the automatic examples.
+        let host = rue_test_runner::get_host_target();
+        let other = KNOWN_TARGETS
+            .iter()
+            .find(|target| **target != host)
+            .expect("more than one known target");
+        let corpus = corpus_from_toml(&format!(
+            r#"
+                [section]
+                id = "cli.demo"
+                name = "demo"
+
+                [[case]]
+                name = "everywhere"
+
+                [[case]]
+                name = "host_scoped"
+                only_on = ["{host}"]
+
+                [[case]]
+                name = "foreign_scoped"
+                only_on = ["{other}"]
+            "#
+        ));
+        let examples = vec![DiscoveredExample {
+            path: PathBuf::from("examples/demo.rue"),
+            relative_path: "demo.rue".to_string(),
+        }];
+        let contracts = HashMap::new();
+
+        let all = discover_case_names(
+            &corpus,
+            &examples,
+            &contracts,
+            CliCaseTierSelection::Premerge,
+            PlatformCaseSelection::All,
+        );
+        assert_eq!(
+            all,
+            vec![
+                "cli.demo::everywhere",
+                "cli.demo::host_scoped",
+                "cli.demo::foreign_scoped",
+                "cli.examples::demo",
+            ]
+        );
+
+        let native = discover_case_names(
+            &corpus,
+            &examples,
+            &contracts,
+            CliCaseTierSelection::Premerge,
+            PlatformCaseSelection::Native,
+        );
+        assert_eq!(native, vec!["cli.demo::host_scoped"]);
+
+        let slow = discover_case_names(
+            &corpus,
+            &examples,
+            &contracts,
+            CliCaseTierSelection::Slow,
+            PlatformCaseSelection::All,
+        );
+        assert!(slow.is_empty(), "premerge inventory excluded: {slow:?}");
     }
 
     #[test]

--- a/crates/rue-cli-tests/src/sharding.rs
+++ b/crates/rue-cli-tests/src/sharding.rs
@@ -1,13 +1,17 @@
 use rue_test_runner::ShardSelector;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 
 const WEIGHTS_VERSION: u64 = 1;
+const SHARD_LOADS_VERSION: u64 = 1;
 
+/// The measured per-case weight file, `shard-weights.json`: a `common`
+/// baseline, per-platform overlays, and a `default_ms` fallback for any
+/// discovered case the file does not name.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct ShardWeights {
+pub struct ShardWeights {
     version: u64,
     default_ms: u64,
     #[serde(default)]
@@ -16,21 +20,8 @@ struct ShardWeights {
     platforms: BTreeMap<String, BTreeMap<String, u64>>,
 }
 
-/// A deterministic, cost-balanced assignment of every discovered CLI case.
-pub struct CliShardPlan {
-    selector: ShardSelector,
-    assignments: HashMap<String, u64>,
-    estimated_load_ms: Vec<u64>,
-    case_counts: Vec<usize>,
-    platform: String,
-}
-
-impl CliShardPlan {
-    pub fn load(
-        selector: ShardSelector,
-        names: impl IntoIterator<Item = String>,
-        path: &Path,
-    ) -> Result<Self, String> {
+impl ShardWeights {
+    pub fn load(path: &Path) -> Result<Self, String> {
         let contents = std::fs::read_to_string(path)
             .map_err(|error| format!("cannot read {}: {error}", path.display()))?;
         let weights: ShardWeights = serde_json::from_str(&contents)
@@ -58,18 +49,65 @@ impl CliShardPlan {
                 ));
             }
         }
+        Ok(weights)
+    }
 
-        let platform = host_platform().to_string();
-        let platform_weights = weights.platforms.get(&platform);
+    /// The platforms this file models with a dedicated overlay — the set the
+    /// shard-loads report covers, matching what the timeout-policy gate checks.
+    pub fn platform_names(&self) -> impl Iterator<Item = &str> {
+        self.platforms.keys().map(String::as_str)
+    }
+
+    /// The expected cost of `name` on `platform`: the platform overlay first,
+    /// then the common baseline, then `default_ms` for an unmeasured case.
+    fn weight_for(&self, platform: &str, name: &str) -> u64 {
+        self.platforms
+            .get(platform)
+            .and_then(|platform| platform.get(name))
+            .or_else(|| self.common.get(name))
+            .copied()
+            .unwrap_or(self.default_ms)
+    }
+}
+
+/// A deterministic, cost-balanced assignment of every discovered CLI case.
+pub struct CliShardPlan {
+    selector: ShardSelector,
+    assignments: HashMap<String, u64>,
+    estimated_load_ms: Vec<u64>,
+    case_counts: Vec<usize>,
+    platform: String,
+}
+
+impl CliShardPlan {
+    pub fn load(
+        selector: ShardSelector,
+        names: impl IntoIterator<Item = String>,
+        path: &Path,
+    ) -> Result<Self, String> {
+        let weights = ShardWeights::load(path)?;
+        Self::for_platform(selector, host_platform(), names, &weights)
+    }
+
+    /// The single population-and-packing rule, parameterized by platform name.
+    ///
+    /// The runtime path calls this through [`CliShardPlan::load`] with the
+    /// detected host; the shard-loads emit mode calls it once per platform the
+    /// weights file models. Keeping one body is the point: every discovered
+    /// name is weighted (overlay, then common, then `default_ms`) and packed
+    /// LPT-style, so a derived deadline can never model a different corpus
+    /// than the one the harness runs.
+    pub fn for_platform(
+        selector: ShardSelector,
+        platform: &str,
+        names: impl IntoIterator<Item = String>,
+        weights: &ShardWeights,
+    ) -> Result<Self, String> {
         let weighted_names = names.into_iter().map(|name| {
-            let weight = platform_weights
-                .and_then(|platform| platform.get(&name))
-                .or_else(|| weights.common.get(&name))
-                .copied()
-                .unwrap_or(weights.default_ms);
+            let weight = weights.weight_for(platform, &name);
             (name, weight)
         });
-        Self::from_weighted_names(selector, &platform, weighted_names)
+        Self::from_weighted_names(selector, platform, weighted_names)
     }
 
     fn from_weighted_names(
@@ -131,6 +169,14 @@ impl CliShardPlan {
         &self.platform
     }
 
+    pub fn estimated_load_ms(&self) -> &[u64] {
+        &self.estimated_load_ms
+    }
+
+    pub fn case_counts(&self) -> &[usize] {
+        &self.case_counts
+    }
+
     fn validate_skew(&self) -> Result<(), String> {
         let total: u128 = self
             .estimated_load_ms
@@ -150,6 +196,62 @@ impl CliShardPlan {
         }
         Ok(())
     }
+}
+
+/// The machine-readable shard-loads report the emit mode prints: for every
+/// platform the weights file models, the per-shard expected costs the runtime
+/// packing would produce there. `scripts/cli-timeout-policy.py` consumes this
+/// (via the `//:cli-shard-loads-json` genrule) instead of re-deriving the
+/// packing, so the packing exists exactly once — here.
+#[derive(Debug, Serialize)]
+pub struct ShardLoadsReport {
+    version: u64,
+    shard_count: u64,
+    platforms: BTreeMap<String, PlatformShardLoads>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PlatformShardLoads {
+    loads_ms: Vec<u64>,
+    case_counts: Vec<usize>,
+    total_cases: usize,
+}
+
+/// Pack `names` into `shard_count` shards once per modeled platform.
+///
+/// Every platform reuses the exact runtime packing ([`CliShardPlan`]),
+/// including its skew validation, so a weights update that would break a CI
+/// platform's shard balance fails here at build time rather than on that
+/// platform's lane.
+pub fn shard_loads_report(
+    shard_count: u64,
+    names: &[String],
+    weights: &ShardWeights,
+) -> Result<ShardLoadsReport, String> {
+    // The packing is index-independent; selector index 0 is arbitrary.
+    let selector = ShardSelector::parse(Some(&format!("0/{shard_count}")))
+        .map_err(|error| format!("invalid shard count {shard_count}: {error}"))?
+        .expect("a spelled-out spec is never the unset case");
+    let mut platforms = BTreeMap::new();
+    for platform in weights.platform_names() {
+        let plan = CliShardPlan::for_platform(selector, platform, names.iter().cloned(), weights)?;
+        platforms.insert(
+            platform.to_string(),
+            PlatformShardLoads {
+                loads_ms: plan.estimated_load_ms().to_vec(),
+                case_counts: plan.case_counts().to_vec(),
+                total_cases: plan.case_counts().iter().sum(),
+            },
+        );
+    }
+    if platforms.is_empty() {
+        return Err("shard weights model no platforms; nothing to report".to_string());
+    }
+    Ok(ShardLoadsReport {
+        version: SHARD_LOADS_VERSION,
+        shard_count,
+        platforms,
+    })
 }
 
 fn host_platform() -> &'static str {
@@ -244,6 +346,77 @@ mod tests {
         .err()
         .unwrap();
         assert!(error.contains("25% skew"));
+    }
+
+    fn weights_from_json(json: &str) -> ShardWeights {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), json).unwrap();
+        ShardWeights::load(file.path()).unwrap()
+    }
+
+    #[test]
+    fn unweighted_names_fall_back_to_default_ms_per_platform() {
+        // The population rule the emit mode must share with the runtime path:
+        // a discovered case absent from the weights file still costs
+        // `default_ms`, and a platform overlay beats the common baseline.
+        let weights = weights_from_json(
+            r#"{
+                "version": 1,
+                "default_ms": 7,
+                "common": {"a": 100},
+                "platforms": {"fast": {"a": 10}, "slow": {}}
+            }"#,
+        );
+        let names = ["a", "unmeasured"].map(str::to_string);
+        let fast =
+            CliShardPlan::for_platform(selector(0, 1), "fast", names.clone(), &weights).unwrap();
+        assert_eq!(fast.estimated_load_ms(), &[17]);
+        let slow = CliShardPlan::for_platform(selector(0, 1), "slow", names, &weights).unwrap();
+        assert_eq!(slow.estimated_load_ms(), &[107]);
+    }
+
+    #[test]
+    fn shard_loads_report_covers_every_modeled_platform() {
+        let weights = weights_from_json(
+            r#"{
+                "version": 1,
+                "default_ms": 10,
+                "common": {"a": 80, "b": 40, "c": 40},
+                "platforms": {"fast": {"a": 40, "b": 40, "c": 40}, "slow": {}}
+            }"#,
+        );
+        let names: Vec<String> = ["a", "b", "c", "d"].map(str::to_string).into();
+        let report = shard_loads_report(2, &names, &weights).unwrap();
+        let value = serde_json::to_value(&report).unwrap();
+        assert_eq!(value["version"], 1);
+        assert_eq!(value["shard_count"], 2);
+        // fast overlay: a=b=c=40, unweighted d=10 -> a:0, b:1, c:0 (load tie,
+        // index breaks it), d:1. slow (common only): a=80, b=c=40, d=10 ->
+        // a:0, b:1, c:1, d:0 (load tie at 80/80, case-count breaks it).
+        assert_eq!(
+            value["platforms"]["fast"]["loads_ms"],
+            serde_json::json!([80, 50])
+        );
+        assert_eq!(
+            value["platforms"]["slow"]["loads_ms"],
+            serde_json::json!([90, 80])
+        );
+        assert_eq!(value["platforms"]["slow"]["total_cases"], 4);
+        assert_eq!(
+            value["platforms"]["fast"]["case_counts"],
+            serde_json::json!([2, 2])
+        );
+    }
+
+    #[test]
+    fn shard_loads_report_rejects_a_zero_shard_count() {
+        let weights = weights_from_json(
+            r#"{"version": 1, "default_ms": 1, "common": {"a": 1}, "platforms": {"p": {}}}"#,
+        );
+        let error = shard_loads_report(0, &["a".to_string()], &weights)
+            .err()
+            .unwrap();
+        assert!(error.contains("invalid shard count"));
     }
 
     #[test]

--- a/scripts/cli-timeout-policy.py
+++ b/scripts/cli-timeout-policy.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python3
 """Validate CLI hang guards and derive whole-suite executor deadlines.
 
+The packing authority is the CLI harness itself: its
+`RUE_CLI_EMIT_SHARD_LOADS` mode performs the real case discovery (tier and
+platform filtering, `default_ms` fallback for unmeasured cases) and packs it
+with the runtime LPT rule, and Buck materializes the per-platform result as
+//:cli-shard-loads-json. This gate applies the declarative policy arithmetic
+(multiplier, headroom, minimums) to those reported loads; it does not model
+the corpus or the packing itself.
+
 The result is correctness plumbing, not a performance threshold. Shard
 deadlines deliberately combine measured expected cost with proportional and
 fixed headroom so a loaded worker does not turn a healthy case into a flake.
@@ -77,24 +85,39 @@ def host_platform() -> str:
     return "other"
 
 
-def shard_loads(path: Path, platform_name: str, count: int) -> list[int]:
+def load_shard_loads(path: Path) -> dict:
+    """The harness-reported per-platform shard loads (//:cli-shard-loads-json)."""
     data = json.loads(path.read_text())
     if data.get("version") != 1:
-        raise ValueError(f"{path}: unsupported weights version")
-    common = data.get("common", {})
-    platform_weights = data.get("platforms", {}).get(platform_name, {})
-    names = set(common) | set(platform_weights)
-    weighted = [(name, platform_weights.get(name, common.get(name))) for name in names]
-    if not weighted or any(type(weight) is not int or weight <= 0 for _, weight in weighted):
-        raise ValueError(f"{path}: weights must be non-empty positive integers")
-    weighted.sort(key=lambda item: (-item[1], item[0]))
-    loads = [0] * count
-    case_counts = [0] * count
-    for _, weight in weighted:
-        index = min(range(count), key=lambda i: (loads[i], case_counts[i], i))
-        loads[index] += weight
-        case_counts[index] += 1
-    return loads
+        raise ValueError(f"{path}: unsupported shard-loads version")
+    shard_count = data.get("shard_count")
+    if type(shard_count) is not int or shard_count <= 0:
+        raise ValueError(f"{path}: shard_count must be a positive integer")
+    platforms = data.get("platforms")
+    if not isinstance(platforms, dict) or not platforms:
+        raise ValueError(f"{path}: platforms must be a non-empty object")
+    for name, entry in platforms.items():
+        loads = entry.get("loads_ms") if isinstance(entry, dict) else None
+        if (
+            not isinstance(loads, list)
+            or len(loads) != shard_count
+            or any(type(load) is not int or load < 0 for load in loads)
+        ):
+            raise ValueError(
+                f"{path}: platforms.{name}.loads_ms must list {shard_count} "
+                "non-negative integer loads"
+            )
+    return data
+
+
+def platform_loads(loads: dict, platform_name: str) -> list[int]:
+    platforms = loads["platforms"]
+    if platform_name not in platforms:
+        raise ValueError(
+            f"shard loads do not model platform {platform_name!r} "
+            f"(modeled: {', '.join(sorted(platforms))})"
+        )
+    return platforms[platform_name]["loads_ms"]
 
 
 def derive_timeout_ms(expected_ms: int, minimum_ms: int, policy: dict[str, int]) -> int:
@@ -105,21 +128,25 @@ def derive_timeout_ms(expected_ms: int, minimum_ms: int, policy: dict[str, int])
 
 
 def timeout_for_target(
-    target: str, weights_path: Path, platform_name: str, policy: dict[str, int]
+    target: str, loads: dict | None, platform_name: str, policy: dict[str, int]
 ) -> tuple[int, int | None]:
     match = re.fullmatch(r"//:cli-tests-shard-(\d+)", target)
     if match:
+        if loads is None:
+            raise ValueError(f"{target} requires --shard-loads")
         index = int(match.group(1))
-        count = 4
+        count = loads["shard_count"]
         if index >= count:
-            raise ValueError(f"invalid CLI shard index {index}")
-        expected = shard_loads(weights_path, platform_name, count)[index]
+            raise ValueError(f"invalid CLI shard index {index} (shard count {count})")
+        expected = platform_loads(loads, platform_name)[index]
         return (
             derive_timeout_ms(expected, policy["minimum_shard_timeout_ms"], policy),
             expected,
         )
     if target == "//:cli-tests":
-        expected = sum(shard_loads(weights_path, platform_name, 1))
+        if loads is None:
+            raise ValueError(f"{target} requires --shard-loads")
+        expected = sum(platform_loads(loads, platform_name))
         return (
             derive_timeout_ms(expected, policy["minimum_monolith_timeout_ms"], policy),
             expected,
@@ -159,22 +186,20 @@ def buck_timeouts(buck_path: Path) -> dict[str, int]:
 
 
 def check_buck_timeouts(
-    buck_path: Path, weights_path: Path, policy: dict[str, int]
+    buck_path: Path, loads: dict, policy: dict[str, int]
 ) -> list[str]:
     """Report action bounds that cut inside the derived correctness deadline.
 
-    Every platform in the weights file is checked, because the BUCK value is one
-    static number while the derived deadline is per-platform: a bound that is
-    generous on the fastest runner and short on the slowest is still a bound
-    that kills healthy runs.
+    Every platform the shard-loads report models is checked, because the BUCK
+    value is one static number while the derived deadline is per-platform: a
+    bound that is generous on the fastest runner and short on the slowest is
+    still a bound that kills healthy runs.
     """
-    platforms = sorted(json.loads(weights_path.read_text()).get("platforms", {}))
+    platforms = sorted(loads["platforms"])
     errors = []
     for target, declared_seconds in buck_timeouts(buck_path).items():
         for platform_name in platforms:
-            required_ms, _ = timeout_for_target(
-                target, weights_path, platform_name, policy
-            )
+            required_ms, _ = timeout_for_target(target, loads, platform_name, policy)
             required_seconds = math.ceil(required_ms / 1000)
             if declared_seconds < required_seconds:
                 errors.append(
@@ -196,7 +221,11 @@ def main() -> int:
         "//:cli-timeout-policy-validation",
     )
     parser.add_argument(
-        "--weights", type=Path, default=Path("crates/rue-cli-tests/shard-weights.json")
+        "--shard-loads",
+        type=Path,
+        help="harness-reported per-platform shard loads; build "
+        "//:cli-shard-loads-json (the harness's RUE_CLI_EMIT_SHARD_LOADS "
+        "mode is the packing authority)",
     )
     parser.add_argument("--platform", default=host_platform())
     parser.add_argument("--target")
@@ -209,9 +238,16 @@ def main() -> int:
     args = parser.parse_args()
     try:
         _, policy = load_policy(args.policy)
+        loads = (
+            load_shard_loads(args.shard_loads)
+            if args.shard_loads is not None
+            else None
+        )
         if args.target is None:
             if args.buck is not None:
-                errors = check_buck_timeouts(args.buck, args.weights, policy)
+                if loads is None:
+                    raise ValueError("--buck requires --shard-loads")
+                errors = check_buck_timeouts(args.buck, loads, policy)
                 if errors:
                     for error in errors:
                         print(f"error: {error}", file=sys.stderr)
@@ -221,7 +257,7 @@ def main() -> int:
             print("CLI timeout policy valid")
             return 0
         timeout_ms, expected_ms = timeout_for_target(
-            args.target, args.weights, args.platform, policy
+            args.target, loads, args.platform, policy
         )
         detail = (
             "fixed slow-suite guard"

--- a/scripts/test-cli-timeout-policy.py
+++ b/scripts/test-cli-timeout-policy.py
@@ -33,25 +33,85 @@ class TimeoutPolicyTests(unittest.TestCase):
             authority["contract"]["heavyweight_long"]["timeout_profile"], "slow"
         )
 
-    def test_shards_use_lpt_expected_cost_plus_headroom(self):
+    def test_shards_consume_reported_loads_plus_headroom(self):
+        # The packing itself lives in the harness (RUE_CLI_EMIT_SHARD_LOADS);
+        # this gate only applies policy arithmetic to the loads it reported.
+        loads = {
+            "version": 1,
+            "shard_count": 4,
+            "platforms": {
+                "macos": {
+                    "loads_ms": [1000, 800, 600, 600],
+                    "case_counts": [1, 1, 1, 1],
+                    "total_cases": 4,
+                }
+            },
+        }
+        policy = {
+            "expected_cost_multiplier_percent": 150,
+            "fixed_headroom_ms": 500,
+            "minimum_shard_timeout_ms": 1,
+            "minimum_monolith_timeout_ms": 1,
+            "minimum_slow_suite_timeout_ms": 9000,
+        }
+        timeout, expected = MODULE.timeout_for_target(
+            "//:cli-tests-shard-0", loads, "macos", policy
+        )
+        self.assertEqual(expected, 1000)
+        self.assertEqual(timeout, 2000)
+        # The monolith's expected cost is the whole reported inventory.
+        timeout, expected = MODULE.timeout_for_target(
+            "//:cli-tests", loads, "macos", policy
+        )
+        self.assertEqual(expected, 3000)
+        self.assertEqual(timeout, 5000)
+
+    def test_unmodeled_platform_and_bad_shard_index_are_rejected(self):
+        loads = {
+            "version": 1,
+            "shard_count": 2,
+            "platforms": {"linux-x64": {"loads_ms": [10, 10]}},
+        }
+        policy = {
+            "expected_cost_multiplier_percent": 100,
+            "fixed_headroom_ms": 0,
+            "minimum_shard_timeout_ms": 1,
+            "minimum_monolith_timeout_ms": 1,
+            "minimum_slow_suite_timeout_ms": 1,
+        }
+        with self.assertRaisesRegex(ValueError, "do not model platform"):
+            MODULE.timeout_for_target("//:cli-tests-shard-0", loads, "macos", policy)
+        with self.assertRaisesRegex(ValueError, "invalid CLI shard index"):
+            MODULE.timeout_for_target(
+                "//:cli-tests-shard-2", loads, "linux-x64", policy
+            )
+        with self.assertRaisesRegex(ValueError, "requires --shard-loads"):
+            MODULE.timeout_for_target("//:cli-tests", None, "linux-x64", policy)
+
+    def test_shard_loads_file_is_validated(self):
         with tempfile.TemporaryDirectory() as directory:
-            weights = Path(directory) / "weights.json"
-            weights.write_text(
-                '{"version":1,"default_ms":1,"common":{"a":1000,"b":800,"c":600},'
-                '"platforms":{"macos":{"c":1000}}}'
-            )
-            policy = {
-                "expected_cost_multiplier_percent": 150,
-                "fixed_headroom_ms": 500,
-                "minimum_shard_timeout_ms": 1,
-                "minimum_monolith_timeout_ms": 1,
-                "minimum_slow_suite_timeout_ms": 9000,
+            path = Path(directory) / "shard-loads.json"
+            good = {
+                "version": 1,
+                "shard_count": 2,
+                "platforms": {"linux-x64": {"loads_ms": [5, 5]}},
             }
-            timeout, expected = MODULE.timeout_for_target(
-                "//:cli-tests-shard-0", weights, "macos", policy
-            )
-            self.assertEqual(expected, 1000)
-            self.assertEqual(timeout, 2000)
+            path.write_text(json.dumps(good))
+            self.assertEqual(MODULE.load_shard_loads(path), good)
+            for mutation, message in [
+                ({"version": 2}, "unsupported shard-loads version"),
+                ({"shard_count": 0}, "shard_count must be a positive integer"),
+                ({"platforms": {}}, "platforms must be a non-empty object"),
+                (
+                    # One load per shard, or the report models a different
+                    # shard topology than the one BUCK declares.
+                    {"platforms": {"linux-x64": {"loads_ms": [5]}}},
+                    "must list 2 non-negative integer loads",
+                ),
+            ]:
+                path.write_text(json.dumps({**good, **mutation}))
+                with self.assertRaisesRegex(ValueError, message):
+                    MODULE.load_shard_loads(path)
 
     def test_minimum_prevents_sparse_weight_underbudget(self):
         policy = {
@@ -123,18 +183,13 @@ class BuckActionBoundTests(unittest.TestCase):
         "minimum_slow_suite_timeout_ms": 3000,
     }
 
+    LOADS = {
+        "version": 1,
+        "shard_count": 2,
+        "platforms": {"linux-x64": {"loads_ms": [1000, 1000]}},
+    }
+
     def fixture(self, directory, cli_seconds):
-        weights = Path(directory) / "shard-weights.json"
-        weights.write_text(
-            json.dumps(
-                {
-                    "version": 1,
-                    "default_ms": 1,
-                    "common": {"a": 1000, "b": 1000},
-                    "platforms": {"linux-x64": {}},
-                }
-            )
-        )
         buck = Path(directory) / "BUCK"
         buck.write_text(
             f"_CLI_TESTS_TIMEOUT_SECONDS = {cli_seconds}\n"
@@ -142,29 +197,29 @@ class BuckActionBoundTests(unittest.TestCase):
             'cached_corpus_suite(\n    name = "cli-tests-slow",\n'
             "    timeout_seconds = 9999,\n)\n"
         )
-        return buck, weights
+        return buck
 
     def test_bound_covering_the_deadline_passes(self):
         with tempfile.TemporaryDirectory() as directory:
-            buck, weights = self.fixture(directory, 9999)
+            buck = self.fixture(directory, 9999)
             self.assertEqual(
-                MODULE.check_buck_timeouts(buck, weights, self.POLICY), []
+                MODULE.check_buck_timeouts(buck, self.LOADS, self.POLICY), []
             )
 
     def test_bound_inside_the_deadline_is_reported(self):
         with tempfile.TemporaryDirectory() as directory:
-            buck, weights = self.fixture(directory, 1)
-            errors = MODULE.check_buck_timeouts(buck, weights, self.POLICY)
+            buck = self.fixture(directory, 1)
+            errors = MODULE.check_buck_timeouts(buck, self.LOADS, self.POLICY)
             self.assertEqual(len(errors), 1, errors)
             self.assertIn("//:cli-tests", errors[0])
             self.assertIn("A healthy run would be killed", errors[0])
 
     def test_missing_bound_is_an_error_not_a_silent_pass(self):
         with tempfile.TemporaryDirectory() as directory:
-            buck, weights = self.fixture(directory, 9999)
+            buck = self.fixture(directory, 9999)
             buck.write_text("# no timeouts here\n")
             with self.assertRaisesRegex(ValueError, "no action timeout found"):
-                MODULE.check_buck_timeouts(buck, weights, self.POLICY)
+                MODULE.check_buck_timeouts(buck, self.LOADS, self.POLICY)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes RUE-1530. The deadline gate stops modeling the shard packing and asks the executor instead, so the packing exists exactly once.

## The bug

`cli-timeout-policy.py` reimplemented the harness's LPT packing to predict shard loads for deadline derivation, and the model's inputs had drifted from the executor's three ways: the Python side iterated only names in the weights file (never reading `default_ms`), ignored tier and `only_on` case filtering, and hardcoded `count = 4` beside BUCK's `CLI_TEST_SHARD_COUNT`. A CLI case added without regenerating weights was scheduled by the runner and invisible to the deadline — the flake mode the tool exists to prevent.

## The fix

The harness gains `RUE_CLI_EMIT_SHARD_LOADS=<count>`: it runs the *same* case discovery as an ordinary run (refactored into a shared `discover_case_names()`, short-circuiting before anything needs a compiler) and packs per platform via a parameterized `CliShardPlan::for_platform` that the runtime path also uses — one population rule, one packing. A `//:cli-shard-loads-json` genrule materializes the report with the shard count formatted from `CLI_TEST_SHARD_COUNT`, and the Python gate shrinks to policy arithmetic (multiplier, headroom, minimums) over reported loads.

## Verification of equivalence and of the bug

Feeding the old Python packing the harness's actual 1,862-case population produces **bit-identical loads** on all three platforms — the algorithm was never the divergence. The population was: the old model carried ~20 stale weighted names per platform (471s of phantom premerge load on linux-arm64, 415s on macos, 162s on linux-x64) while ignoring 168 discovered-but-unmeasured cases (+178s at `default_ms`). Net honest deadlines: arm64 shard 1125s → 1015s, macos 1010s → 921s, linux-x64 pinned at the 900s minimum — all still covered by the BUCK action bounds, so the gate stays green with correct numbers. The weights skew validation now also runs at JSON-build time, failing the build rather than a CI lane.

Validated with the timeout-policy validation and tool tests, the CLI harness's full unit suite plus new emit/discovery tests, fmt/clippy, `scripts/rue quick`, and the python-baseline, duplication, and CI gates.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCariNhXQqtLK2bMgcViTr)_