### PR TITLE
Extract one pure call-ABI classification kernel shared by the live and stable planes

### DIFF
--- a/crates/rue-air/src/call_abi.rs
+++ b/crates/rue-air/src/call_abi.rs
@@ -18,6 +18,19 @@
 //! ABI (RUE-742 / RUE-745, SysV / AAPCS) will add further variants to this
 //! authority rather than embedding a peer FFI calculator inside a backend.
 //!
+//! ## Two planes, one policy kernel
+//!
+//! Two walkers consume this module because their lifetimes differ: the live
+//! classifiers here walk the request-scoped [`FrozenTypeInternPool`], while the
+//! stable query plane (`compiler.call-abi` in `rue-compiler`) walks its own
+//! revision-stable type keys and canonical layout values and must not hold a
+//! live pool. Both project per-type facts and then consult the same pure
+//! kernel — [`NativeAbiTypeFacts`] for the native decision tree,
+//! [`TargetCCallAbi`] plus [`CAbiScalarKind`] for the target-C thresholds and
+//! extensions, [`native_return_register_budget`] and
+//! [`TargetCAbiFlavor::for_arch`] for the per-target numbers — so the
+//! classification policy itself has exactly one production home.
+//!
 //! ## Memory-first transitional rule (ADR-0052 ratified ruling 9)
 //!
 //! The preserved slot call convention stays in force unchanged while memory
@@ -32,6 +45,115 @@
 //! historical register classification byte-for-byte.
 
 use crate::{FrozenTypeInternPool, Type, TypeKind};
+use rue_target::Arch;
+
+/// The native return-register budget for a target architecture: how many
+/// flattened eight-byte slots an aggregate return may occupy before it must
+/// cross through caller storage (sret). This is the single policy home of the
+/// per-target number; each backend's physical return-register roster is pinned
+/// against it by that backend's tests, and the stable query plane consults it
+/// directly instead of restating the numbers.
+pub const fn native_return_register_budget(arch: Arch) -> u32 {
+    match arch {
+        Arch::X86_64 => 6,
+        Arch::Aarch64 => 8,
+    }
+}
+
+/// Target-independent facts about one value type at a native call boundary:
+/// the pure classification kernel both planes share.
+///
+/// The live classifier ([`NativeCallAbi`]) projects these facts from the
+/// [`FrozenTypeInternPool`]; the stable query plane projects them from its
+/// canonical layout value and stable type keys. The projections differ by
+/// representation, but the decision tree — zero-sized omission, the `StrBuf`
+/// sret rule, the return-register budget, and the compact memory-first
+/// indirectness rule — lives only here, so the two planes cannot drift.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NativeAbiTypeFacts {
+    /// Flattened eight-byte ABI slot count (0 for a zero-sized type).
+    pub abi_slots: u32,
+    /// Whether the plane's own aggregate predicate holds for the type. The
+    /// planes project this differently on purpose: the live classifier keeps a
+    /// discriminant-only enum scalar, while the stable projection reports it as
+    /// its one register slot. Both crossings are physically identical; each
+    /// plane's projection is preserved by feeding its own predicate in.
+    pub aggregate: bool,
+    /// Whether the type is the canonical trusted standard-library `StrBuf`,
+    /// which always returns through sret.
+    pub strbuf: bool,
+    /// Whether the compact physical layout is byte-for-byte identical to the
+    /// flattened slot representation (see [`is_slot_identical_layout`]).
+    pub slot_identical: bool,
+}
+
+impl NativeAbiTypeFacts {
+    /// Classify a by-value return: zero-sized returns nothing; `StrBuf`, an
+    /// aggregate over the return-register budget, and a multi-slot aggregate
+    /// the compact layout cannot express slot-identically use sret; any other
+    /// aggregate returns in registers; everything else is a scalar.
+    pub const fn classify_return(self, ret_reg_budget: u32) -> ReturnClass {
+        if self.abi_slots == 0 {
+            return ReturnClass::ZeroSized;
+        }
+        if self.strbuf
+            || (self.aggregate && self.abi_slots > ret_reg_budget)
+            || self.crosses_indirectly_under_compact()
+        {
+            return ReturnClass::Indirect {
+                slot_count: self.abi_slots,
+            };
+        }
+        if self.aggregate {
+            ReturnClass::Registers {
+                slot_count: self.abi_slots,
+            }
+        } else {
+            ReturnClass::Scalar
+        }
+    }
+
+    /// Classify one argument: a by-reference `inout` / `borrow` is one pointer
+    /// slot; a by-value argument is omitted when zero-sized, forced indirect
+    /// when the compact layout cannot express it slot-identically, and passed
+    /// directly across its flattened slots otherwise.
+    pub const fn classify_arg(self, convention: ArgConvention) -> ArgClass {
+        match convention {
+            ArgConvention::ByReference => ArgClass::Indirect,
+            ArgConvention::ByValue => {
+                if self.abi_slots == 0 {
+                    ArgClass::Omitted
+                } else if self.crosses_indirectly_under_compact() {
+                    ArgClass::Indirect
+                } else {
+                    ArgClass::Direct {
+                        slot_count: self.abi_slots,
+                    }
+                }
+            }
+        }
+    }
+
+    /// Physical parameter-slot width of one argument (ADR-0052
+    /// representation 2): one pointer slot by reference, the flattened slot
+    /// count by value. Deliberately independent of the compact transitional
+    /// classification — see [`NativeCallAbi::arg_slot_width`].
+    pub const fn arg_slot_width(self, convention: ArgConvention) -> u32 {
+        match convention {
+            ArgConvention::ByReference => 1,
+            ArgConvention::ByValue => self.abi_slots,
+        }
+    }
+
+    /// The memory-first rule (ADR-0052 ruling 9): a multi-slot aggregate whose
+    /// compact representation is not slot-identical cannot cross the preserved
+    /// register convention and must go indirect — *unless it occupies exactly
+    /// one ABI slot* (RUE-1035), where one register transports the compact
+    /// image losslessly and the one-slot path stays byte-for-byte correct.
+    const fn crosses_indirectly_under_compact(self) -> bool {
+        self.abi_slots > 1 && self.aggregate && !self.slot_identical
+    }
+}
 
 /// Which calling convention governs a boundary.
 ///
@@ -182,6 +304,22 @@ impl<'a> NativeCallAbi<'a> {
         CallAbi::Native
     }
 
+    /// Project the kernel facts for `ty` from the live type pool. This is the
+    /// live plane's representation-specific walk; the classification decision
+    /// itself lives on [`NativeAbiTypeFacts`].
+    fn facts(&self, ty: Type) -> NativeAbiTypeFacts {
+        let abi_slots = self.type_pool.abi_slot_count(ty);
+        NativeAbiTypeFacts {
+            abi_slots,
+            aggregate: self.is_multislot_aggregate(ty, abi_slots),
+            strbuf: matches!(
+                ty.kind(),
+                TypeKind::Struct(struct_id) if self.type_pool.is_strbuf(struct_id)
+            ),
+            slot_identical: is_slot_identical_layout(self.type_pool, ty),
+        }
+    }
+
     /// Classify how a by-value return of `ty` crosses the boundary.
     ///
     /// Reproduces the historical decision exactly: zero-sized returns nothing;
@@ -190,20 +328,7 @@ impl<'a> NativeCallAbi<'a> {
     /// registers; everything else is a scalar. Under the compact layout a
     /// non-slot-identical aggregate is forced indirect (memory-first rule).
     pub fn classify_return(&self, ty: Type) -> ReturnClass {
-        let slot_count = self.type_pool.abi_slot_count(ty);
-        if slot_count == 0 {
-            return ReturnClass::ZeroSized;
-        }
-        if self.return_uses_sret(ty, slot_count)
-            || self.crosses_indirectly_under_compact(ty, slot_count)
-        {
-            return ReturnClass::Indirect { slot_count };
-        }
-        if self.is_multislot_aggregate(ty, slot_count) {
-            ReturnClass::Registers { slot_count }
-        } else {
-            ReturnClass::Scalar
-        }
+        self.facts(ty).classify_return(self.ret_reg_budget)
     }
 
     /// Whether a by-value return of `ty` uses the sret convention. Thin
@@ -221,21 +346,10 @@ impl<'a> NativeCallAbi<'a> {
     /// identical aggregate is forced indirect (memory-first rule).
     pub fn classify_arg(&self, ty: Type, convention: ArgConvention) -> ArgClass {
         match convention {
+            // The kernel's by-reference rule is convention-only, so the facts
+            // projection (a pool walk) is skipped for it.
             ArgConvention::ByReference => ArgClass::Indirect,
-            ArgConvention::ByValue => {
-                let slot_count = self.type_pool.abi_slot_count(ty);
-                if slot_count == 0 {
-                    ArgClass::Omitted
-                } else if self.crosses_indirectly_under_compact(ty, slot_count) {
-                    // Memory-first transitional rule: the preserved slot
-                    // convention cannot pass this compact aggregate by value.
-                    // Code generation refuses it loudly until the indirect
-                    // marshaling lands; the authority still records the intent.
-                    ArgClass::Indirect
-                } else {
-                    ArgClass::Direct { slot_count }
-                }
-            }
+            ArgConvention::ByValue => self.facts(ty).classify_arg(ArgConvention::ByValue),
         }
     }
 
@@ -255,48 +369,14 @@ impl<'a> NativeCallAbi<'a> {
         }
     }
 
-    /// The historical `type_uses_sret_return` predicate: strbuf, or a
-    /// struct/array/payload-enum whose slot count exceeds the budget
-    /// (oversized enums route through the same slot-count policy per RUE-946;
-    /// discriminant-only enums are single-slot and stay scalar).
-    fn return_uses_sret(&self, ty: Type, slot_count: u32) -> bool {
-        match ty.kind() {
-            TypeKind::Struct(struct_id) => {
-                self.type_pool.is_strbuf(struct_id) || slot_count > self.ret_reg_budget
-            }
-            TypeKind::Array(_) | TypeKind::Enum(_) => slot_count > self.ret_reg_budget,
-            _ => false,
-        }
-    }
-
-    /// Whether `ty` needs a complete aggregate slot representation rather than a
-    /// single primary vreg. Discriminant-only enums stay scalar.
+    /// The live plane's aggregate predicate: whether `ty` needs a complete
+    /// aggregate slot representation rather than a single primary vreg.
+    /// Discriminant-only enums stay scalar (oversized enums route through the
+    /// same slot-count policy per RUE-946). This is a facts *projection*; the
+    /// decisions consuming it live on [`NativeAbiTypeFacts`].
     fn is_multislot_aggregate(&self, ty: Type, slot_count: u32) -> bool {
         matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_))
             || (ty.is_enum() && slot_count > 1)
-    }
-
-    /// The memory-first rule (ADR-0052 ruling 9): a multi-slot aggregate whose
-    /// compact representation is not slot-identical cannot cross the preserved
-    /// register convention and must go indirect (by-reference / sret) — *unless
-    /// it occupies exactly one ABI slot* (RUE-1035). Slot-identical aggregates
-    /// keep the historical register decision.
-    ///
-    /// A single-slot aggregate carries its whole value in one eight-byte slot: a
-    /// narrow leaf lives in that slot's low bytes under both the compact image
-    /// and the slot-based frame, so one register transports it losslessly and the
-    /// callee's one-slot decomposition view is identical either way. Forcing such
-    /// a value indirect gained nothing and drove the not-yet-correct single-slot
-    /// indirect marshalling (garbage by-value args, RUE-1035 M1); classifying it
-    /// Direct instead routes it through the proven one-slot path — byte-for-byte
-    /// the same classification the slot model produces for it, on both backends
-    /// and in the oracle. Returns stay consistent: a single-slot aggregate return
-    /// is `Registers { slot_count: 1 }` (never sret), so no caller-side image
-    /// read-back is implied.
-    fn crosses_indirectly_under_compact(&self, ty: Type, slot_count: u32) -> bool {
-        slot_count > 1
-            && self.is_multislot_aggregate(ty, slot_count)
-            && !is_slot_identical_layout(self.type_pool, ty)
     }
 }
 
@@ -359,6 +439,61 @@ pub enum TargetCAbiFlavor {
     SysVAmd64,
     /// The ARM 64-bit Procedure Call Standard (AArch64 Linux/macOS).
     Aapcs64,
+}
+
+impl TargetCAbiFlavor {
+    /// The psABI flavor a target architecture's C boundary follows. The single
+    /// home of the architecture-to-flavor mapping, consulted by the export
+    /// thunk, the import call lowering, and the stable query plane.
+    pub const fn for_arch(arch: Arch) -> Self {
+        match arch {
+            Arch::X86_64 => Self::SysVAmd64,
+            Arch::Aarch64 => Self::Aapcs64,
+        }
+    }
+}
+
+/// Width-and-signedness class of a target-C-passable scalar: the one fact the
+/// extension policy needs. Each plane projects its own type representation
+/// onto this class, so the sign/zero/`_Bool` extension table itself
+/// ([`Self::extension`]) has exactly one home.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CAbiScalarKind {
+    /// 8-bit signed integer.
+    I8,
+    /// 16-bit signed integer.
+    I16,
+    /// 32-bit signed integer.
+    I32,
+    /// 8-bit unsigned integer.
+    U8,
+    /// 16-bit unsigned integer.
+    U16,
+    /// 32-bit unsigned integer.
+    U32,
+    /// The 1-byte C `_Bool` whose byte is 0/1 by contract.
+    Bool,
+    /// A value that already fills its 64-bit register: `i64`/`u64`, pointers,
+    /// and the recovery scalar.
+    RegisterWidth,
+}
+
+impl CAbiScalarKind {
+    /// The canonical 64-bit extension for this scalar at a target-C boundary.
+    /// Both psABIs agree on the operation; signed narrows sign-extend from
+    /// their declared width, unsigned narrows zero-extend, `_Bool`
+    /// zero-extends from its low byte, and register-width values need nothing.
+    pub const fn extension(self) -> ScalarAbiExtension {
+        match self {
+            Self::I8 => ScalarAbiExtension::Signed { from_bits: 8 },
+            Self::I16 => ScalarAbiExtension::Signed { from_bits: 16 },
+            Self::I32 => ScalarAbiExtension::Signed { from_bits: 32 },
+            Self::U8 | Self::Bool => ScalarAbiExtension::Unsigned { from_bits: 8 },
+            Self::U16 => ScalarAbiExtension::Unsigned { from_bits: 16 },
+            Self::U32 => ScalarAbiExtension::Unsigned { from_bits: 32 },
+            Self::RegisterWidth => ScalarAbiExtension::None,
+        }
+    }
 }
 
 /// How a narrow scalar is extended to fill its 64-bit integer register at a
@@ -580,9 +715,26 @@ impl TargetCCallAbi {
         16
     }
 
-    /// Number of eightbytes a `size`-byte aggregate occupies (ceil(size / 8)).
+    /// Number of eightbytes a `size`-byte aggregate occupies (ceil(size / 8)),
+    /// saturating at `u32::MAX` like every byte-count projection here; sema
+    /// rejects layouts anywhere near that bound before they reach a boundary.
     const fn eightbytes(size: u64) -> u32 {
-        ((size + 7) / 8) as u32
+        let eightbytes = size.div_ceil(8);
+        if eightbytes > u32::MAX as u64 {
+            u32::MAX
+        } else {
+            eightbytes as u32
+        }
+    }
+
+    /// Saturating byte-count projection for the u32 fields of the memory
+    /// classes.
+    const fn saturate_u32(value: u64) -> u32 {
+        if value > u32::MAX as u64 {
+            u32::MAX
+        } else {
+            value as u32
+        }
     }
 
     /// Classify how a C-classifiable aggregate of `size` bytes at `align`
@@ -601,8 +753,8 @@ impl TargetCCallAbi {
                 eightbytes: Self::eightbytes(size),
             };
         }
-        let size = size as u32;
-        let align = align as u32;
+        let size = Self::saturate_u32(size);
+        let align = Self::saturate_u32(align);
         match self.flavor {
             TargetCAbiFlavor::SysVAmd64 => AggregateArgClass::ByValueStack { size, align },
             TargetCAbiFlavor::Aapcs64 => AggregateArgClass::ByReferenceCopy { size, align },
@@ -624,8 +776,8 @@ impl TargetCCallAbi {
             }
         } else {
             AggregateReturnClass::Indirect {
-                size: size as u32,
-                align: align as u32,
+                size: Self::saturate_u32(size),
+                align: Self::saturate_u32(align),
             }
         }
     }
@@ -656,30 +808,30 @@ impl TargetCCallAbi {
         Self::canonical_extension(ty)
     }
 
-    /// The canonical 64-bit extension for a supported target-C scalar. Shared by
-    /// both directions; both psABIs agree on the operation.
+    /// The live plane's projection of a supported target-C scalar onto its
+    /// width-and-signedness class; the extension operation itself lives on
+    /// [`CAbiScalarKind::extension`], shared with the stable query plane.
     fn canonical_extension(ty: Type) -> ScalarAbiExtension {
-        match ty.kind() {
-            TypeKind::I8 => ScalarAbiExtension::Signed { from_bits: 8 },
-            TypeKind::I16 => ScalarAbiExtension::Signed { from_bits: 16 },
-            TypeKind::I32 => ScalarAbiExtension::Signed { from_bits: 32 },
-            TypeKind::U8 => ScalarAbiExtension::Unsigned { from_bits: 8 },
-            TypeKind::U16 => ScalarAbiExtension::Unsigned { from_bits: 16 },
-            TypeKind::U32 => ScalarAbiExtension::Unsigned { from_bits: 32 },
-            // The 1-byte `_Bool` with the 0/1 contract: zero-extend its byte.
-            TypeKind::Bool => ScalarAbiExtension::Unsigned { from_bits: 8 },
-            // Register-width scalars and pointers already fill the register.
+        let kind = match ty.kind() {
+            TypeKind::I8 => CAbiScalarKind::I8,
+            TypeKind::I16 => CAbiScalarKind::I16,
+            TypeKind::I32 => CAbiScalarKind::I32,
+            TypeKind::U8 => CAbiScalarKind::U8,
+            TypeKind::U16 => CAbiScalarKind::U16,
+            TypeKind::U32 => CAbiScalarKind::U32,
+            TypeKind::Bool => CAbiScalarKind::Bool,
             TypeKind::I64
             | TypeKind::U64
             | TypeKind::PtrConst(_)
             | TypeKind::PtrMut(_)
-            | TypeKind::Error => ScalarAbiExtension::None,
+            | TypeKind::Error => CAbiScalarKind::RegisterWidth,
             other => panic!(
                 "TargetCCallAbi scalar classification called on non-scalar type {other:?}; \
                  aggregates (P3) and unsupported types are gated by c_passable_by_value \
                  before lowering"
             ),
-        }
+        };
+        kind.extension()
     }
 }
 
@@ -859,6 +1011,178 @@ mod tests {
         assert!(!aapcs.sret_pointer_echoed_in_result_register());
         assert_eq!(sysv.max_aggregate_register_bytes(), 16);
         assert_eq!(aapcs.max_aggregate_register_bytes(), 16);
+    }
+
+    #[test]
+    fn per_arch_budget_and_flavor_have_one_home() {
+        assert_eq!(native_return_register_budget(Arch::X86_64), 6);
+        assert_eq!(native_return_register_budget(Arch::Aarch64), 8);
+        assert_eq!(
+            TargetCAbiFlavor::for_arch(Arch::X86_64),
+            TargetCAbiFlavor::SysVAmd64
+        );
+        assert_eq!(
+            TargetCAbiFlavor::for_arch(Arch::Aarch64),
+            TargetCAbiFlavor::Aapcs64
+        );
+    }
+
+    #[test]
+    fn native_facts_kernel_decision_table() {
+        let scalar = NativeAbiTypeFacts {
+            abi_slots: 1,
+            aggregate: false,
+            strbuf: false,
+            slot_identical: true,
+        };
+        let aggregate = |abi_slots: u32, slot_identical: bool| NativeAbiTypeFacts {
+            abi_slots,
+            aggregate: true,
+            strbuf: false,
+            slot_identical,
+        };
+        for budget in [6u32, 8] {
+            // Zero-sized values vanish in both positions.
+            let zero = NativeAbiTypeFacts {
+                abi_slots: 0,
+                aggregate: true,
+                strbuf: false,
+                slot_identical: true,
+            };
+            assert_eq!(zero.classify_return(budget), ReturnClass::ZeroSized);
+            assert_eq!(zero.classify_arg(ArgConvention::ByValue), ArgClass::Omitted);
+
+            assert_eq!(scalar.classify_return(budget), ReturnClass::Scalar);
+            assert_eq!(
+                scalar.classify_arg(ArgConvention::ByValue),
+                ArgClass::Direct { slot_count: 1 }
+            );
+            // By-reference is one pointer slot regardless of the facts.
+            assert_eq!(
+                aggregate(budget + 1, true).classify_arg(ArgConvention::ByReference),
+                ArgClass::Indirect
+            );
+            assert_eq!(
+                aggregate(budget + 1, true).arg_slot_width(ArgConvention::ByReference),
+                1
+            );
+
+            // The return-register budget boundary: budget - 1 and budget fit,
+            // budget + 1 goes through sret. Arguments ignore the budget.
+            assert_eq!(
+                aggregate(budget - 1, true).classify_return(budget),
+                ReturnClass::Registers {
+                    slot_count: budget - 1
+                }
+            );
+            assert_eq!(
+                aggregate(budget, true).classify_return(budget),
+                ReturnClass::Registers { slot_count: budget }
+            );
+            assert_eq!(
+                aggregate(budget + 1, true).classify_return(budget),
+                ReturnClass::Indirect {
+                    slot_count: budget + 1
+                }
+            );
+            assert_eq!(
+                aggregate(budget + 1, true).classify_arg(ArgConvention::ByValue),
+                ArgClass::Direct {
+                    slot_count: budget + 1
+                }
+            );
+
+            // The compact memory-first rule: a multi-slot non-slot-identical
+            // aggregate goes indirect in both positions; a single-slot one
+            // stays direct (RUE-1035).
+            assert_eq!(
+                aggregate(2, false).classify_return(budget),
+                ReturnClass::Indirect { slot_count: 2 }
+            );
+            assert_eq!(
+                aggregate(2, false).classify_arg(ArgConvention::ByValue),
+                ArgClass::Indirect
+            );
+            assert_eq!(
+                aggregate(1, false).classify_return(budget),
+                ReturnClass::Registers { slot_count: 1 }
+            );
+            assert_eq!(
+                aggregate(1, false).classify_arg(ArgConvention::ByValue),
+                ArgClass::Direct { slot_count: 1 }
+            );
+
+            // Canonical StrBuf always returns through sret, even under budget.
+            let strbuf = NativeAbiTypeFacts {
+                abi_slots: 3,
+                aggregate: true,
+                strbuf: true,
+                slot_identical: true,
+            };
+            assert_eq!(
+                strbuf.classify_return(budget),
+                ReturnClass::Indirect { slot_count: 3 }
+            );
+            assert_eq!(
+                strbuf.classify_arg(ArgConvention::ByValue),
+                ArgClass::Direct { slot_count: 3 }
+            );
+        }
+    }
+
+    #[test]
+    fn c_scalar_kind_extension_table_is_the_shared_authority() {
+        use CAbiScalarKind as K;
+        assert_eq!(
+            K::I8.extension(),
+            ScalarAbiExtension::Signed { from_bits: 8 }
+        );
+        assert_eq!(
+            K::I16.extension(),
+            ScalarAbiExtension::Signed { from_bits: 16 }
+        );
+        assert_eq!(
+            K::I32.extension(),
+            ScalarAbiExtension::Signed { from_bits: 32 }
+        );
+        assert_eq!(
+            K::U8.extension(),
+            ScalarAbiExtension::Unsigned { from_bits: 8 }
+        );
+        assert_eq!(
+            K::U16.extension(),
+            ScalarAbiExtension::Unsigned { from_bits: 16 }
+        );
+        assert_eq!(
+            K::U32.extension(),
+            ScalarAbiExtension::Unsigned { from_bits: 32 }
+        );
+        // The 1-byte `_Bool` 0/1 contract zero-extends from its byte.
+        assert_eq!(
+            K::Bool.extension(),
+            ScalarAbiExtension::Unsigned { from_bits: 8 }
+        );
+        assert!(K::RegisterWidth.extension().is_noop());
+    }
+
+    #[test]
+    fn oversized_aggregate_byte_counts_saturate() {
+        let sysv = TargetCCallAbi::sysv_amd64();
+        let huge = u64::from(u32::MAX) + 9;
+        assert_eq!(
+            sysv.classify_aggregate_arg(huge, 8),
+            AggregateArgClass::ByValueStack {
+                size: u32::MAX,
+                align: 8
+            }
+        );
+        assert_eq!(
+            sysv.classify_aggregate_return(huge, 8),
+            AggregateReturnClass::Indirect {
+                size: u32::MAX,
+                align: 8
+            }
+        );
     }
 
     #[test]

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -39,8 +39,9 @@ mod type_properties;
 mod types;
 
 pub use call_abi::{
-    AggregateArgClass, AggregateReturnClass, ArgClass, ArgConvention, CallAbi, NativeCallAbi,
-    ReturnClass, ScalarAbiExtension, TargetCAbiFlavor, TargetCCallAbi, is_slot_identical_layout,
+    AggregateArgClass, AggregateReturnClass, ArgClass, ArgConvention, CAbiScalarKind, CallAbi,
+    NativeAbiTypeFacts, NativeCallAbi, ReturnClass, ScalarAbiExtension, TargetCAbiFlavor,
+    TargetCCallAbi, is_slot_identical_layout, native_return_register_budget,
 };
 pub use canonical_imports::CanonicalImportView;
 pub use ffi_predicates::{

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -3771,6 +3771,16 @@ mod tests {
     use rue_parser::Parser;
     use rue_rir::AstGen;
 
+    #[test]
+    fn physical_return_register_roster_matches_the_abi_kernel_budget() {
+        assert_eq!(
+            RET_REGS.len() as u32,
+            rue_air::native_return_register_budget(rue_target::Arch::Aarch64),
+            "the backend's return-register roster and the classification \
+             kernel's budget must agree"
+        );
+    }
+
     fn lower_function_to_mir(source: &str, function_name: &str) -> Aarch64Mir {
         lower_function_to_mir_with_preview(source, function_name, PreviewFeatures::new())
     }

--- a/crates/rue-codegen/src/export_thunk.rs
+++ b/crates/rue-codegen/src/export_thunk.rs
@@ -71,10 +71,7 @@ pub fn generate_export_thunk(
 /// boundary consult the same authority (`TargetCCallAbi`), so the export thunk
 /// and the import call agree on every scalar extension.
 fn flavor_for(target: Target) -> TargetCAbiFlavor {
-    match target.arch() {
-        Arch::X86_64 => TargetCAbiFlavor::SysVAmd64,
-        Arch::Aarch64 => TargetCAbiFlavor::Aapcs64,
-    }
+    TargetCAbiFlavor::for_arch(target.arch())
 }
 
 /// The extension each argument register needs, in register order. Shared by both

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -3554,6 +3554,16 @@ mod tests {
     use rue_parser::Parser;
     use rue_rir::AstGen;
 
+    #[test]
+    fn physical_return_register_roster_matches_the_abi_kernel_budget() {
+        assert_eq!(
+            RET_REGS.len() as u32,
+            rue_air::native_return_register_budget(rue_target::Arch::X86_64),
+            "the backend's return-register roster and the classification \
+             kernel's budget must agree"
+        );
+    }
+
     fn lower_to_mir(source: &str) -> X86Mir {
         lower_to_mir_with_preview(source, PreviewFeatures::new())
     }

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -32087,6 +32087,654 @@ fn main() -> i32 {
         }
     }
 
+    /// One stable argument classification against the live classifier's answer
+    /// for the same type under the same convention.
+    fn assert_native_arg_parity(
+        stable: &crate::type_queries::CallAbiArgument,
+        live_class: rue_air::ArgClass,
+        live_width: u32,
+        context: &str,
+    ) {
+        use crate::type_queries::CallAbiArgumentClass as A;
+        assert_eq!(
+            stable.value_slots, live_width,
+            "value-slot width parity for {context}"
+        );
+        match (stable.class, live_class) {
+            (A::Omitted, rue_air::ArgClass::Omitted) => {}
+            (A::NativeDirect { slots }, rue_air::ArgClass::Direct { slot_count }) => {
+                assert_eq!(slots, slot_count, "direct slot parity for {context}");
+            }
+            (A::NativeIndirect, rue_air::ArgClass::Indirect) => {}
+            (A::Reference, rue_air::ArgClass::Indirect) => {}
+            (stable, live) => {
+                panic!(
+                    "argument classification parity mismatch for {context}: {stable:?} != {live:?}"
+                )
+            }
+        }
+    }
+
+    /// One stable return classification against the live classifier's answer.
+    fn assert_native_return_parity(
+        stable: crate::type_queries::CallAbiReturnClass,
+        live: rue_air::ReturnClass,
+        context: &str,
+    ) {
+        use crate::type_queries::CallAbiReturnClass as R;
+        match (stable, live) {
+            (R::ZeroSized, rue_air::ReturnClass::ZeroSized) => {}
+            (
+                R::Scalar {
+                    extension: rue_air::ScalarAbiExtension::None,
+                },
+                rue_air::ReturnClass::Scalar,
+            ) => {}
+            (R::NativeRegisters { slots }, rue_air::ReturnClass::Registers { slot_count }) => {
+                assert_eq!(slots, slot_count, "register slot parity for {context}");
+            }
+            (R::NativeIndirect { slots }, rue_air::ReturnClass::Indirect { slot_count }) => {
+                assert_eq!(slots, slot_count, "indirect slot parity for {context}");
+            }
+            (stable, live) => {
+                panic!(
+                    "return classification parity mismatch for {context}: {stable:?} != {live:?}"
+                )
+            }
+        }
+    }
+
+    #[test]
+    fn call_abi_native_classification_matches_the_live_classifier_on_both_targets() {
+        use lasso::ThreadedRodeo;
+        use rue_air::{
+            ArgConvention, EnumDef, NativeCallAbi, StructDef, StructField, Type, TypeInternPool,
+        };
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "struct Empty {}\n\
+                 struct Wide { a: u64, b: u64 }\n\
+                 struct Narrow { a: u32, b: u32 }\n\
+                 struct OneNarrow { a: u32 }\n\
+                 struct Nested { inner: Wide, tail: [u64; 2] }\n\
+                 struct NestedNarrow { inner: Narrow, tail: u64 }\n\
+                 enum Flag { A, B }\n\
+                 enum Choice { Small(u8, u64), Wide(u32, u16, u64) }\n\
+                 fn scalars(a: i32, b: u32, c: bool, d: i64) -> i64 { d }\n\
+                 fn zero(e: Empty) -> Empty { e }\n\
+                 fn refs(inout a: i64, borrow b: Wide) {}\n\
+                 fn five(v: [u64; 5]) -> [u64; 5] { v }\n\
+                 fn six(v: [u64; 6]) -> [u64; 6] { v }\n\
+                 fn seven(v: [u64; 7]) -> [u64; 7] { v }\n\
+                 fn eight(v: [u64; 8]) -> [u64; 8] { v }\n\
+                 fn nine(v: [u64; 9]) -> [u64; 9] { v }\n\
+                 fn wide(v: Wide) -> Wide { v }\n\
+                 fn narrow(v: Narrow) -> Narrow { v }\n\
+                 fn one_narrow(v: OneNarrow) -> OneNarrow { v }\n\
+                 fn nested(v: Nested) -> Nested { v }\n\
+                 fn nested_narrow(v: NestedNarrow) -> NestedNarrow { v }\n\
+                 fn flag(v: Flag) -> Flag { v }\n\
+                 fn choice(v: Choice) -> Choice { v }",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+
+        // Mirror the source types into a live pool so the stable query can be
+        // compared against the live classifier's answer for the same shapes.
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::new();
+        let struct_def = |name: &str, fields: Vec<(&str, Type)>| StructDef {
+            name: name.into(),
+            fields: fields
+                .into_iter()
+                .map(|(name, ty)| StructField {
+                    name: name.into(),
+                    ty,
+                })
+                .collect(),
+            is_copy: false,
+            is_linear: false,
+            destructor: None,
+            is_builtin: false,
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
+        };
+        let register = |name: &str, fields: Vec<(&str, Type)>| {
+            Type::new_struct(
+                pool.register_struct(interner.get_or_intern(name), struct_def(name, fields))
+                    .0,
+            )
+        };
+        let empty = register("Empty", vec![]);
+        let wide = register("Wide", vec![("a", Type::U64), ("b", Type::U64)]);
+        let narrow = register("Narrow", vec![("a", Type::U32), ("b", Type::U32)]);
+        let one_narrow = register("OneNarrow", vec![("a", Type::U32)]);
+        let tail = Type::new_array(pool.intern_array_from_type(Type::U64, 2));
+        let nested = register("Nested", vec![("inner", wide), ("tail", tail)]);
+        let nested_narrow = register("NestedNarrow", vec![("inner", narrow), ("tail", Type::U64)]);
+        let flag = Type::new_enum(
+            pool.register_enum(
+                interner.get_or_intern("Flag"),
+                EnumDef {
+                    name: "Flag".into(),
+                    variants: Arc::from(["A".into(), "B".into()]),
+                    variant_payloads: vec![vec![], vec![]],
+                    is_pub: false,
+                    file_id: rue_span::FileId::DEFAULT,
+                },
+            )
+            .0,
+        );
+        let choice = Type::new_enum(
+            pool.register_enum(
+                interner.get_or_intern("Choice"),
+                EnumDef {
+                    name: "Choice".into(),
+                    variants: Arc::from(["Small".into(), "Wide".into()]),
+                    variant_payloads: vec![
+                        vec![Type::U8, Type::U64],
+                        vec![Type::U32, Type::U16, Type::U64],
+                    ],
+                    is_pub: false,
+                    file_id: rue_span::FileId::DEFAULT,
+                },
+            )
+            .0,
+        );
+        let arrays: Vec<Type> = (5u64..=9)
+            .map(|len| Type::new_array(pool.intern_array_from_type(Type::U64, len)))
+            .collect();
+        let pool = pool.freeze();
+
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = revision_for(&mut database, &source);
+        for (target, budget) in [
+            (crate::Target::X86_64Linux, 6u32),
+            (crate::Target::Aarch64Linux, 8u32),
+        ] {
+            let live = NativeCallAbi::new(&pool, budget);
+            let by_value = ArgConvention::ByValue;
+            let cases: Vec<(&str, Vec<(ArgConvention, Type)>, Type)> = vec![
+                (
+                    "scalars",
+                    vec![
+                        (by_value, Type::I32),
+                        (by_value, Type::U32),
+                        (by_value, Type::BOOL),
+                        (by_value, Type::I64),
+                    ],
+                    Type::I64,
+                ),
+                ("zero", vec![(by_value, empty)], empty),
+                (
+                    "refs",
+                    vec![
+                        (ArgConvention::ByReference, Type::I64),
+                        (ArgConvention::ByReference, wide),
+                    ],
+                    Type::UNIT,
+                ),
+                ("five", vec![(by_value, arrays[0])], arrays[0]),
+                ("six", vec![(by_value, arrays[1])], arrays[1]),
+                ("seven", vec![(by_value, arrays[2])], arrays[2]),
+                ("eight", vec![(by_value, arrays[3])], arrays[3]),
+                ("nine", vec![(by_value, arrays[4])], arrays[4]),
+                ("wide", vec![(by_value, wide)], wide),
+                ("narrow", vec![(by_value, narrow)], narrow),
+                ("one_narrow", vec![(by_value, one_narrow)], one_narrow),
+                ("nested", vec![(by_value, nested)], nested),
+                (
+                    "nested_narrow",
+                    vec![(by_value, nested_narrow)],
+                    nested_narrow,
+                ),
+                ("choice", vec![(by_value, choice)], choice),
+            ];
+            for (name, params, result) in &cases {
+                let facts = request_call_abi(
+                    &database,
+                    revision,
+                    free_function_instance(&module, name),
+                    target,
+                );
+                assert_eq!(
+                    facts.convention,
+                    crate::type_queries::CallAbiConvention::Native,
+                    "{name} is a native callable"
+                );
+                assert_eq!(facts.arguments.len(), params.len(), "arity of {name}");
+                for (argument, (convention, ty)) in facts.arguments.iter().zip(params) {
+                    assert_native_arg_parity(
+                        argument,
+                        live.classify_arg(*ty, *convention),
+                        live.arg_slot_width(*ty, *convention),
+                        &format!("{name} on {target:?}"),
+                    );
+                }
+                assert_native_return_parity(
+                    facts.return_class,
+                    live.classify_return(*result),
+                    &format!("{name} return on {target:?}"),
+                );
+            }
+
+            // The discriminant-only enum is the one deliberate projection
+            // divergence between the planes: the live classifier reports its
+            // single tag slot as `Scalar`, while the stable projection keeps
+            // reporting the aggregate as one register slot. The physical
+            // crossing is identical (one register); this pin keeps the
+            // divergence visible instead of letting it drift silently.
+            let flag_facts = request_call_abi(
+                &database,
+                revision,
+                free_function_instance(&module, "flag"),
+                target,
+            );
+            assert_eq!(
+                live.classify_return(flag),
+                rue_air::ReturnClass::Scalar,
+                "live plane reports a discriminant-only enum return as a scalar"
+            );
+            assert_eq!(
+                flag_facts.return_class,
+                crate::type_queries::CallAbiReturnClass::NativeRegisters { slots: 1 },
+                "stable plane projects a discriminant-only enum return as one register slot"
+            );
+            assert_native_arg_parity(
+                &flag_facts.arguments[0],
+                live.classify_arg(flag, ArgConvention::ByValue),
+                live.arg_slot_width(flag, ArgConvention::ByValue),
+                &format!("flag argument on {target:?}"),
+            );
+
+            // Pin the classification outcomes themselves, not only the
+            // cross-plane agreement: zero-sized values vanish, a slot-identical
+            // aggregate stays direct, a multi-slot narrow-leaf aggregate is
+            // forced indirect by the compact memory-first rule, and a
+            // single-slot narrow aggregate stays direct (RUE-1035).
+            use crate::type_queries::{CallAbiArgumentClass as A, CallAbiReturnClass as R};
+            let request = |name: &str| {
+                request_call_abi(
+                    &database,
+                    revision,
+                    free_function_instance(&module, name),
+                    target,
+                )
+            };
+            let zero = request("zero");
+            assert!(matches!(zero.arguments[0].class, A::Omitted));
+            assert_eq!(zero.return_class, R::ZeroSized);
+            let wide_facts = request("wide");
+            assert!(matches!(
+                wide_facts.arguments[0].class,
+                A::NativeDirect { slots: 2 }
+            ));
+            assert_eq!(wide_facts.return_class, R::NativeRegisters { slots: 2 });
+            let narrow_facts = request("narrow");
+            assert!(matches!(narrow_facts.arguments[0].class, A::NativeIndirect));
+            assert_eq!(narrow_facts.return_class, R::NativeIndirect { slots: 2 });
+            let one_narrow_facts = request("one_narrow");
+            assert!(matches!(
+                one_narrow_facts.arguments[0].class,
+                A::NativeDirect { slots: 1 }
+            ));
+            assert_eq!(
+                one_narrow_facts.return_class,
+                R::NativeRegisters { slots: 1 }
+            );
+            let nested_narrow_facts = request("nested_narrow");
+            assert!(matches!(
+                nested_narrow_facts.arguments[0].class,
+                A::NativeIndirect
+            ));
+            let refs_facts = request("refs");
+            assert!(matches!(refs_facts.arguments[0].class, A::Reference));
+            assert!(matches!(refs_facts.arguments[1].class, A::Reference));
+
+            // Pin the return-register budget boundary explicitly: budget - 1
+            // and budget fit in registers, budget + 1 goes indirect.
+            let boundary = |name: &str| request(name).return_class;
+            match target {
+                crate::Target::X86_64Linux => {
+                    assert_eq!(boundary("five"), R::NativeRegisters { slots: 5 });
+                    assert_eq!(boundary("six"), R::NativeRegisters { slots: 6 });
+                    assert_eq!(boundary("seven"), R::NativeIndirect { slots: 7 });
+                }
+                _ => {
+                    assert_eq!(boundary("seven"), R::NativeRegisters { slots: 7 });
+                    assert_eq!(boundary("eight"), R::NativeRegisters { slots: 8 });
+                    assert_eq!(boundary("nine"), R::NativeIndirect { slots: 9 });
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn call_abi_target_c_classification_matches_the_live_classifier_on_both_targets() {
+        use lasso::ThreadedRodeo;
+        use rue_air::{StructDef, StructField, TargetCCallAbi, Type, TypeInternPool};
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "@repr(c)\n\
+                 struct CInner { a: i32, b: i32 }\n\
+                 @repr(c)\n\
+                 struct CTwelve { a: i32, b: i32, c: i32 }\n\
+                 @repr(c)\n\
+                 struct CNested { inner: CInner, tail: i64 }\n\
+                 @repr(c)\n\
+                 struct CLarge { a: i64, b: i64, c: i64 }\n\
+                 extern \"C\" {\n\
+                     fn c_signed(a: i8, b: i16, c: i32, d: i64) -> i16;\n\
+                     fn c_unsigned(a: u8, b: u16, c: u32, d: u64, e: bool) -> u16;\n\
+                     fn c_pointers(p: ptr const u8, q: ptr mut u8) -> ptr mut u8;\n\
+                     fn c_eight(v: CInner) -> CInner;\n\
+                     fn c_twelve(v: CTwelve) -> CTwelve;\n\
+                     fn c_sixteen(v: CNested) -> CNested;\n\
+                     fn c_large(v: CLarge) -> CLarge;\n\
+                 }",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::new();
+        let register = |name: &str, fields: Vec<(&str, Type)>| {
+            Type::new_struct(
+                pool.register_struct(
+                    interner.get_or_intern(name),
+                    StructDef {
+                        name: name.into(),
+                        fields: fields
+                            .into_iter()
+                            .map(|(name, ty)| StructField {
+                                name: name.into(),
+                                ty,
+                            })
+                            .collect(),
+                        is_copy: false,
+                        is_linear: false,
+                        destructor: None,
+                        is_builtin: false,
+                        is_pub: false,
+                        file_id: rue_span::FileId::DEFAULT,
+                    },
+                )
+                .0,
+            )
+        };
+        let c_inner = register("CInner", vec![("a", Type::I32), ("b", Type::I32)]);
+        let c_twelve = register(
+            "CTwelve",
+            vec![("a", Type::I32), ("b", Type::I32), ("c", Type::I32)],
+        );
+        let c_nested = register("CNested", vec![("inner", c_inner), ("tail", Type::I64)]);
+        let c_large = register(
+            "CLarge",
+            vec![("a", Type::I64), ("b", Type::I64), ("c", Type::I64)],
+        );
+        let ptr_const_u8 = Type::new_ptr_const(pool.intern_ptr_const_from_type(Type::U8));
+        let ptr_mut_u8 = Type::new_ptr_mut(pool.intern_ptr_mut_from_type(Type::U8));
+        let pool = pool.freeze();
+
+        let assert_scalar_args = |facts: &crate::type_queries::CallAbiFacts,
+                                  abi: &TargetCCallAbi,
+                                  live_params: &[Type],
+                                  live_result: Type,
+                                  name: &str| {
+            use crate::type_queries::{CallAbiArgumentClass as A, CallAbiReturnClass as R};
+            assert_eq!(facts.arguments.len(), live_params.len(), "arity of {name}");
+            for (argument, live_ty) in facts.arguments.iter().zip(live_params) {
+                let A::CScalar { extension } = argument.class else {
+                    panic!("{name} argument is a target-C scalar: {:?}", argument.class);
+                };
+                assert_eq!(
+                    extension,
+                    abi.scalar_arg_extension(*live_ty),
+                    "argument extension parity for {name}"
+                );
+            }
+            let R::Scalar { extension } = facts.return_class else {
+                panic!(
+                    "{name} return is a target-C scalar: {:?}",
+                    facts.return_class
+                );
+            };
+            assert_eq!(
+                extension,
+                abi.scalar_return_extension(live_result),
+                "return extension parity for {name}"
+            );
+        };
+        let assert_aggregate = |facts: &crate::type_queries::CallAbiFacts,
+                                abi: &TargetCCallAbi,
+                                live_ty: Type,
+                                name: &str| {
+            use crate::type_queries::{CallAbiArgumentClass as A, CallAbiReturnClass as R};
+            let layout = pool.layout(live_ty);
+            match (
+                facts.arguments[0].class,
+                abi.classify_aggregate_arg(layout.size, layout.alignment),
+            ) {
+                (
+                    A::CIntegerRegisters { eightbytes },
+                    rue_air::AggregateArgClass::IntegerRegisters {
+                        eightbytes: live_eightbytes,
+                    },
+                ) => assert_eq!(eightbytes, live_eightbytes, "eightbyte parity for {name}"),
+                (
+                    A::CByValueStack { size, alignment },
+                    rue_air::AggregateArgClass::ByValueStack {
+                        size: live_size,
+                        align: live_align,
+                    },
+                ) => assert_eq!(
+                    (size, alignment),
+                    (live_size, live_align),
+                    "byval parity for {name}"
+                ),
+                (
+                    A::CByReferenceCopy { size, alignment },
+                    rue_air::AggregateArgClass::ByReferenceCopy {
+                        size: live_size,
+                        align: live_align,
+                    },
+                ) => assert_eq!(
+                    (size, alignment),
+                    (live_size, live_align),
+                    "reference-copy parity for {name}"
+                ),
+                (stable, live) => {
+                    panic!("aggregate argument parity mismatch for {name}: {stable:?} != {live:?}")
+                }
+            }
+            match (
+                facts.return_class,
+                abi.classify_aggregate_return(layout.size, layout.alignment),
+            ) {
+                (
+                    R::CIntegerRegisters { eightbytes },
+                    rue_air::AggregateReturnClass::IntegerRegisters {
+                        eightbytes: live_eightbytes,
+                    },
+                ) => assert_eq!(
+                    eightbytes, live_eightbytes,
+                    "return eightbyte parity for {name}"
+                ),
+                (
+                    R::CIndirect { size, alignment },
+                    rue_air::AggregateReturnClass::Indirect {
+                        size: live_size,
+                        align: live_align,
+                    },
+                ) => assert_eq!(
+                    (size, alignment),
+                    (live_size, live_align),
+                    "sret parity for {name}"
+                ),
+                (stable, live) => {
+                    panic!("aggregate return parity mismatch for {name}: {stable:?} != {live:?}")
+                }
+            }
+        };
+
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = revision_for(&mut database, &source);
+        for target in [crate::Target::X86_64Linux, crate::Target::Aarch64Linux] {
+            let flavor = if target == crate::Target::X86_64Linux {
+                rue_air::TargetCAbiFlavor::SysVAmd64
+            } else {
+                rue_air::TargetCAbiFlavor::Aapcs64
+            };
+            let abi = TargetCCallAbi::new(flavor);
+            let request = |name: &str| {
+                request_call_abi(
+                    &database,
+                    revision,
+                    free_function_instance(&module, name),
+                    target,
+                )
+            };
+
+            let signed = request("c_signed");
+            assert_eq!(
+                signed.convention,
+                crate::type_queries::CallAbiConvention::TargetC(flavor)
+            );
+            assert_scalar_args(
+                &signed,
+                &abi,
+                &[Type::I8, Type::I16, Type::I32, Type::I64],
+                Type::I16,
+                "c_signed",
+            );
+            assert_scalar_args(
+                &request("c_unsigned"),
+                &abi,
+                &[Type::U8, Type::U16, Type::U32, Type::U64, Type::BOOL],
+                Type::U16,
+                "c_unsigned",
+            );
+            assert_scalar_args(
+                &request("c_pointers"),
+                &abi,
+                &[ptr_const_u8, ptr_mut_u8],
+                ptr_mut_u8,
+                "c_pointers",
+            );
+
+            // Aggregates at 8, 12, 16, and 24 bytes: one eightbyte, rounding
+            // up to two, exactly two, and past the 16-byte register limit
+            // where the psABIs diverge (SysV byval stack, AAPCS64 reference
+            // to a caller copy; sret for returns on both).
+            assert_aggregate(&request("c_eight"), &abi, c_inner, "c_eight");
+            assert_aggregate(&request("c_twelve"), &abi, c_twelve, "c_twelve");
+            assert_aggregate(&request("c_sixteen"), &abi, c_nested, "c_sixteen");
+            assert_aggregate(&request("c_large"), &abi, c_large, "c_large");
+        }
+    }
+
+    #[test]
+    fn call_abi_strbuf_return_uses_sret_on_both_planes() {
+        use lasso::ThreadedRodeo;
+        use rue_air::{ArgConvention, NativeCallAbi, StructDef, StructField, Type, TypeInternPool};
+        let snapshot = trusted_body_snapshot(
+            "fn main() -> i32 { 0 }",
+            None,
+            Some((
+                FileId::new(3),
+                "pub struct StrBuf { buf: ptr mut u8, cap: u64, len: u64 }\n\
+                 pub fn echo(v: StrBuf) -> StrBuf { v }",
+            )),
+        );
+        let strbuf_module =
+            ModuleId::from_trusted_standard_library_path(crate::STRBUF_MODULE_LOGICAL_PATH)
+                .expect("the strbuf module path is inside the standard-library namespace");
+
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::new();
+        let ptr_mut_u8 = Type::new_ptr_mut(pool.intern_ptr_mut_from_type(Type::U8));
+        let (strbuf_id, _) = pool.register_struct(
+            interner.get_or_intern("StrBuf"),
+            StructDef {
+                name: "StrBuf".into(),
+                fields: vec![
+                    StructField {
+                        name: "buf".into(),
+                        ty: ptr_mut_u8,
+                    },
+                    StructField {
+                        name: "cap".into(),
+                        ty: Type::U64,
+                    },
+                    StructField {
+                        name: "len".into(),
+                        ty: Type::U64,
+                    },
+                ],
+                is_copy: false,
+                is_linear: false,
+                destructor: None,
+                is_builtin: false,
+                is_pub: true,
+                file_id: rue_span::FileId::DEFAULT,
+            },
+        );
+        pool.set_struct_lang_item(strbuf_id, rue_air::LangItem::StrBuf);
+        let strbuf = Type::new_struct(strbuf_id);
+        let pool = pool.freeze();
+
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&snapshot),
+            &snapshot,
+        );
+        for (target, budget) in [
+            (crate::Target::X86_64Linux, 6u32),
+            (crate::Target::Aarch64Linux, 8u32),
+        ] {
+            let live = NativeCallAbi::new(&pool, budget);
+            // The canonical StrBuf always returns through sret even though its
+            // three slots fit the return-register budget, and its slot-identical
+            // layout keeps by-value arguments direct.
+            assert_eq!(
+                live.classify_return(strbuf),
+                rue_air::ReturnClass::Indirect { slot_count: 3 }
+            );
+            assert_eq!(
+                live.classify_arg(strbuf, ArgConvention::ByValue),
+                rue_air::ArgClass::Direct { slot_count: 3 }
+            );
+            let facts = request_call_abi(
+                &database,
+                revision,
+                free_function_instance(&strbuf_module, "echo"),
+                target,
+            );
+            assert_eq!(
+                facts.convention,
+                crate::type_queries::CallAbiConvention::Native
+            );
+            assert_eq!(
+                facts.return_class,
+                crate::type_queries::CallAbiReturnClass::NativeIndirect { slots: 3 }
+            );
+            assert_native_arg_parity(
+                &facts.arguments[0],
+                live.classify_arg(strbuf, ArgConvention::ByValue),
+                live.arg_slot_width(strbuf, ArgConvention::ByValue),
+                &format!("StrBuf echo argument on {target:?}"),
+            );
+        }
+    }
+
     #[test]
     fn anonymous_producer_preserves_a_deterministic_body_diagnostic_as_a_typed_failure() {
         let source = source_snapshot(

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -5545,16 +5545,41 @@ fn stable_type_is_strbuf(ty: &crate::TypeInstanceKey) -> bool {
     )
 }
 
+/// The stable plane's projection of a scalar type key onto its target-C
+/// width-and-signedness class; the extension operation itself lives on
+/// [`rue_air::CAbiScalarKind::extension`], shared with the live classifier.
 fn c_scalar_extension(ty: &crate::TypeInstanceKey) -> rue_air::ScalarAbiExtension {
     use crate::TypeInstanceKey as T;
-    match ty {
-        T::I8 => rue_air::ScalarAbiExtension::Signed { from_bits: 8 },
-        T::I16 => rue_air::ScalarAbiExtension::Signed { from_bits: 16 },
-        T::I32 => rue_air::ScalarAbiExtension::Signed { from_bits: 32 },
-        T::U8 | T::Bool => rue_air::ScalarAbiExtension::Unsigned { from_bits: 8 },
-        T::U16 => rue_air::ScalarAbiExtension::Unsigned { from_bits: 16 },
-        T::U32 => rue_air::ScalarAbiExtension::Unsigned { from_bits: 32 },
-        _ => rue_air::ScalarAbiExtension::None,
+    use rue_air::CAbiScalarKind as K;
+    let kind = match ty {
+        T::I8 => K::I8,
+        T::I16 => K::I16,
+        T::I32 => K::I32,
+        T::U8 => K::U8,
+        T::Bool => K::Bool,
+        T::U16 => K::U16,
+        T::U32 => K::U32,
+        // Register-width scalars (i64/u64, pointers) and every remaining key
+        // this projection can see need no extension.
+        _ => K::RegisterWidth,
+    };
+    kind.extension()
+}
+
+/// The stable plane's projection of one type onto the shared native
+/// classification kernel: the canonical layout supplies the slot count and
+/// slot-identity, the stable type keys supply the aggregate and `StrBuf`
+/// predicates. The decision tree itself lives on
+/// [`rue_air::NativeAbiTypeFacts`].
+fn stable_native_abi_facts(
+    layout: &crate::type_queries::CanonicalLayout,
+    ty: &crate::TypeInstanceKey,
+) -> rue_air::NativeAbiTypeFacts {
+    rue_air::NativeAbiTypeFacts {
+        abi_slots: layout.abi_slots,
+        aggregate: stable_type_is_aggregate(ty),
+        strbuf: stable_type_is_strbuf(ty),
+        slot_identical: layout.slot_identical,
     }
 }
 
@@ -5589,14 +5614,10 @@ fn evaluate_call_abi(
                 .with_terminal_kind(QueryTerminalKind::Failure));
         }
     };
-    let target_c_flavor = match key.configuration.target {
-        crate::Target::X86_64Linux => rue_air::TargetCAbiFlavor::SysVAmd64,
-        crate::Target::Aarch64Linux | crate::Target::Aarch64Macos => {
-            rue_air::TargetCAbiFlavor::Aapcs64
-        }
-    };
     let convention = if signature.target_c {
-        CallAbiConvention::TargetC(target_c_flavor)
+        CallAbiConvention::TargetC(rue_air::TargetCAbiFlavor::for_arch(
+            key.configuration.target.arch(),
+        ))
     } else {
         CallAbiConvention::Native
     };
@@ -5624,39 +5645,43 @@ fn evaluate_call_abi(
                     .with_terminal_kind(QueryTerminalKind::Failure));
             }
         };
-        let aggregate = stable_type_is_aggregate(ty);
         let class = match convention {
             CallAbiConvention::Native => {
-                if layout.abi_slots == 0 {
-                    A::Omitted
-                } else if aggregate && layout.abi_slots > 1 && !layout.slot_identical {
-                    A::NativeIndirect
-                } else {
-                    A::NativeDirect {
-                        slots: layout.abi_slots,
+                match stable_native_abi_facts(layout, ty)
+                    .classify_arg(rue_air::ArgConvention::ByValue)
+                {
+                    rue_air::ArgClass::Omitted => A::Omitted,
+                    rue_air::ArgClass::Direct { slot_count } => {
+                        A::NativeDirect { slots: slot_count }
                     }
+                    rue_air::ArgClass::Indirect => A::NativeIndirect,
                 }
             }
             CallAbiConvention::TargetC(flavor) => {
                 if layout.size == 0 {
                     A::Omitted
-                } else if !aggregate {
+                } else if !stable_type_is_aggregate(ty) {
                     A::CScalar {
                         extension: c_scalar_extension(ty),
                     }
-                } else if layout.size <= 16 {
-                    A::CIntegerRegisters {
-                        eightbytes: u32::try_from((layout.size + 7) / 8).unwrap_or(u32::MAX),
-                    }
                 } else {
-                    let size = u32::try_from(layout.size).unwrap_or(u32::MAX);
-                    let alignment = u32::try_from(layout.alignment).unwrap_or(u32::MAX);
-                    match flavor {
-                        rue_air::TargetCAbiFlavor::SysVAmd64 => {
-                            A::CByValueStack { size, alignment }
+                    match rue_air::TargetCCallAbi::new(flavor)
+                        .classify_aggregate_arg(layout.size, layout.alignment)
+                    {
+                        rue_air::AggregateArgClass::IntegerRegisters { eightbytes } => {
+                            A::CIntegerRegisters { eightbytes }
                         }
-                        rue_air::TargetCAbiFlavor::Aapcs64 => {
-                            A::CByReferenceCopy { size, alignment }
+                        rue_air::AggregateArgClass::ByValueStack { size, align } => {
+                            A::CByValueStack {
+                                size,
+                                alignment: align,
+                            }
+                        }
+                        rue_air::AggregateArgClass::ByReferenceCopy { size, align } => {
+                            A::CByReferenceCopy {
+                                size,
+                                alignment: align,
+                            }
                         }
                     }
                 }
@@ -5682,47 +5707,41 @@ fn evaluate_call_abi(
                 .with_terminal_kind(QueryTerminalKind::Failure));
         }
     };
-    let aggregate = stable_type_is_aggregate(&signature.result);
-    let return_class = if return_layout.abi_slots == 0 {
-        R::ZeroSized
-    } else {
-        match convention {
-            CallAbiConvention::Native => {
-                let budget = match key.configuration.target {
-                    crate::Target::X86_64Linux => 6,
-                    crate::Target::Aarch64Linux | crate::Target::Aarch64Macos => 8,
-                };
-                if stable_type_is_strbuf(&signature.result)
-                    || (aggregate && return_layout.abi_slots > budget)
-                    || (aggregate && return_layout.abi_slots > 1 && !return_layout.slot_identical)
-                {
-                    R::NativeIndirect {
-                        slots: return_layout.abi_slots,
-                    }
-                } else if aggregate {
-                    R::NativeRegisters {
-                        slots: return_layout.abi_slots,
-                    }
-                } else {
-                    R::Scalar {
-                        extension: rue_air::ScalarAbiExtension::None,
-                    }
+    let return_class = match convention {
+        CallAbiConvention::Native => {
+            let budget = rue_air::native_return_register_budget(key.configuration.target.arch());
+            match stable_native_abi_facts(return_layout, &signature.result).classify_return(budget)
+            {
+                rue_air::ReturnClass::ZeroSized => R::ZeroSized,
+                rue_air::ReturnClass::Scalar => R::Scalar {
+                    extension: rue_air::ScalarAbiExtension::None,
+                },
+                rue_air::ReturnClass::Registers { slot_count } => {
+                    R::NativeRegisters { slots: slot_count }
+                }
+                rue_air::ReturnClass::Indirect { slot_count } => {
+                    R::NativeIndirect { slots: slot_count }
                 }
             }
-            CallAbiConvention::TargetC(_) => {
-                if !aggregate {
-                    R::Scalar {
-                        extension: c_scalar_extension(&signature.result),
+        }
+        CallAbiConvention::TargetC(flavor) => {
+            if return_layout.abi_slots == 0 {
+                R::ZeroSized
+            } else if !stable_type_is_aggregate(&signature.result) {
+                R::Scalar {
+                    extension: c_scalar_extension(&signature.result),
+                }
+            } else {
+                match rue_air::TargetCCallAbi::new(flavor)
+                    .classify_aggregate_return(return_layout.size, return_layout.alignment)
+                {
+                    rue_air::AggregateReturnClass::IntegerRegisters { eightbytes } => {
+                        R::CIntegerRegisters { eightbytes }
                     }
-                } else if return_layout.size <= 16 {
-                    R::CIntegerRegisters {
-                        eightbytes: u32::try_from((return_layout.size + 7) / 8).unwrap_or(u32::MAX),
-                    }
-                } else {
-                    R::CIndirect {
-                        size: u32::try_from(return_layout.size).unwrap_or(u32::MAX),
-                        alignment: u32::try_from(return_layout.alignment).unwrap_or(u32::MAX),
-                    }
+                    rue_air::AggregateReturnClass::Indirect { size, align } => R::CIndirect {
+                        size,
+                        alignment: align,
+                    },
                 }
             }
         }

--- a/scripts/validate-type-architecture.py
+++ b/scripts/validate-type-architecture.py
@@ -84,6 +84,7 @@ PUBLIC_TYPE_DECLARATION_ALLOWLIST = {
     ("rue-air", "inference/types.rs", "TypeVarId"): "inference-local variable identity",
     ("rue-air", "inference/types.rs", "InferType"): "inference-only term representation",
     ("rue-air", "inference/types.rs", "TypeVarAllocator"): "inference-local allocator",
+    ("rue-air", "call_abi.rs", "NativeAbiTypeFacts"): "per-type call-ABI kernel facts, not a type identity",
     ("rue-air", "runtime_call.rs", "RuntimeAirType"): "typed runtime ABI shape classification",
     ("rue-air", "semantic_import.rs", "SemanticImportType"): "stable semantic import schema",
     ("rue-air", "semantic_import.rs", "SemanticImportTypeFold"): "exhaustive stable schema fold view",


### PR DESCRIPTION
## What

The stable `compiler.call-abi` query (`evaluate_call_abi` in `rue-compiler/src/revisioned_query_database.rs`) independently restated the whole call-ABI classification policy that `rue-air`'s live classifiers (`NativeCallAbi`, `TargetCCallAbi`) already own: the 6/8 native return-register budgets, zero-sized behavior, aggregate register-vs-sret selection, the compact-layout memory-first indirectness rule, `StrBuf` sret, the 16-byte/eightbyte target-C thresholds, the SysV byval-stack vs AAPCS64 reference-copy split, the architecture-to-flavor mapping, and the narrow-scalar extension table. **That duplicated ABI policy is removed.**

`rue-air` now exposes a small pure classification kernel next to the live classifiers:

- `NativeAbiTypeFacts` carries per-type facts (slot count, aggregate and StrBuf predicates, slot-identity) and owns the native decision tree for returns and arguments;
- `native_return_register_budget(Arch)` is the single policy home of the per-target return-register numbers, pinned against each backend's physical `RET_REGS` roster by new backend tests;
- `TargetCAbiFlavor::for_arch` is the single architecture-to-flavor mapping, now also consumed by the export thunk;
- `CAbiScalarKind::extension` is the single sign/zero/`_Bool` extension table; both planes project their own type representation onto it.

**One live and one stable walker remain because their lifetimes differ**: the live classifier walks the request-scoped `FrozenTypeInternPool`, while the stable query plane walks revision-stable type keys and canonical layout values and must never hold a live pool. Both walks are now thin fact projections and result mappings; the decisions live only in the kernel. Typed failures, diagnostics, and the query's dependency edges are unchanged (the by-reference early-out that avoids a layout dependency edge is preserved).

Two behavior notes, both pinned by tests:

- A discriminant-only enum return stays `Scalar` in the live plane and one register slot in the stable projection — a pre-existing projection divergence over a physically identical crossing, preserved deliberately and pinned explicitly.
- The target-C byte-count projections now saturate at `u32::MAX` uniformly (the stable plane already saturated; the live plane previously truncated) — unobservable for any layout sema accepts.

## Why

**This is a correctness and maintenance change**: two independently maintained encodings of the same ABI policy can silently drift, and there was no parity coverage between them. **The expected compile-time effect is neutral**, and **no wall-time improvement is claimed without measurement.**

## How it was verified

The first commit adds parity tests *before* any behavior change, comparing the stable query against the live classifiers on both x86-64 and AArch64 for: zero-sized arguments and returns; scalar signed/unsigned extensions; by-reference (`inout`/`borrow`) parameters; native aggregate returns at return budget −1, budget, and budget +1; slot-identical and non-slot-identical compact aggregates; single-slot narrow aggregates; canonical `StrBuf`; target-C aggregates at 8, 12, 16, and >16 bytes (SysV stack-by-value vs AAPCS64 reference-copy); sret placement/echo facts; and nested aggregates and enums. They passed against the unchanged code, then unchanged against the kernel extraction.

Local runs: compiler call-ABI unit tests 6/6, `rue-air` 744/744, `rue-codegen` 718/718 (including the new roster-vs-budget pins), `scripts/rue quick` (884 compiler unit tests, 30 targets), `scripts/rue cli abi` 62/62, `scripts/rue cli c_ffi` 46/46, `scripts/rue fmt`, and `scripts/rue premerge`.