### PR TITLE
RUE-1533: pin epoch 6's baselines and bound the unpinned state

### DIFF
--- a/performance/manifest.toml
+++ b/performance/manifest.toml
@@ -961,9 +961,13 @@ run = "1404128c40051b386dd7b545c9eb555333004f0774ec99689df1fce296042f18"
 # lattice ratchet and ADR-0071 target carry forward unchanged — the regime
 # they gate is identical here.
 #
-# No [epoch.baseline] yet: a baseline is a complete valid run under this
-# epoch, pinned after the first collection, exactly as epoch 5's was. Until
-# then per-workload observations publish and the headline index waits.
+# Each platform's [epoch.baseline] is its first complete valid run under this
+# epoch, all three from 170c1014 — the commit that declared the epoch, exactly
+# as epoch 5's baselines were pinned at their own declaring commit. Pinned by
+# RUE-1533 rather than with the declaration, because a baseline cannot be named
+# until collection has produced one; the headline index was absent on every
+# platform for the fourteen complete runs, spanning thirty trunk commits, that
+# each of them collected in between (RUE-1533).
 #
 # Measured per-run added cost at declaration time (x86-64 Linux, local):
 # roughly 28 seconds of compile time across the six probes at the sampling
@@ -1042,16 +1046,27 @@ batch_size = 1
 process_elapsed_ns = 250000000
 reference = "ADR-0071"
 
-# No [epoch.process_elapsed_ratchets] yet, and not an oversight: the schema
-# requires a ratchet's reference run to be this epoch's own baseline run, so
-# the ratchet is re-pinned together with the baseline after this epoch's
-# first collection — epoch 5's ratchet (limit 3,022 ms over its 2,887 ms
-# baseline) is the value to re-derive against. The ADR-0071 target above
-# carries forward because it is a property of the product, not of a run.
+# No [epoch.process_elapsed_ratchets] yet. The schema requires a ratchet's
+# reference run to be this epoch's own baseline run, so the ratchet became
+# declarable with the baseline below — but not at epoch 5's derivation. That
+# rule was the baseline median plus k times lattice's calibrated 0.78%
+# relative MAD, which over this epoch's 1,749.77 ms baseline gives a
+# 1,831.66 ms limit, and one of this epoch's own fourteen collected runs
+# already measured 1,823.18 ms. The 0.78% figure is within-session dispersion
+# from a 12-repetition calibration at one commit; run-to-run spread here is
+# roughly ±4%, so the mechanical re-derivation would gate on noise. Re-pinning
+# it needs a calibration decision rather than arithmetic (RUE-1535). The
+# ADR-0071 target above carries forward because it is a property of the
+# product, not of a run.
 
 [epoch.flagging]
 k = 6.0
 window = 5
+
+# The first complete, valid run under this epoch.
+[epoch.baseline]
+commit = "170c10148f1f74ae62330d93cadc9c567e4c93f0"
+run = "e0aecf7e5a506ad4b0044090ab3a4c45d037fc4143b845bcafd69d7424866e07"
 
 [[epoch]]
 id = 6
@@ -1123,6 +1138,11 @@ batch_size = 1
 [epoch.flagging]
 k = 5.0
 window = 3
+
+# The first complete, valid run under this epoch.
+[epoch.baseline]
+commit = "170c10148f1f74ae62330d93cadc9c567e4c93f0"
+run = "fd71cab1b4128891e060deec4e8e4bc312a7bcea4666fde43dd5588d1e01a424"
 
 [[epoch]]
 id = 6
@@ -1199,3 +1219,8 @@ batch_size = 1
 [epoch.flagging]
 k = 4.0
 window = 5
+
+# The first complete, valid run under this epoch.
+[epoch.baseline]
+commit = "170c10148f1f74ae62330d93cadc9c567e4c93f0"
+run = "a4850f73079a73193257fa1418182116f0d4e6453f3b2851284b0f90680ab7d9"

--- a/scripts/test-validate-performance-stall.py
+++ b/scripts/test-validate-performance-stall.py
@@ -202,6 +202,150 @@ def test_a_partial_newest_run_does_not_fail_an_indexed_epoch() -> None:
     assert stall.unindexed(indexed_epoch(5, "b" * 40, [1.0, None])) == []
 
 
+def collecting_epoch(
+    epoch: int,
+    baseline: str | None,
+    points: list[tuple[str, bool]],
+    platform: str = "x86_64-linux",
+) -> dict:
+    """One platform holding one epoch whose points are (commit, complete).
+
+    Points are stamped a minute apart in the order given, so a fixture can hold
+    more of them than a day has hours without the timestamps going out of order.
+    """
+    return {
+        "platforms": [
+            {
+                "platform": platform,
+                "epochs": [
+                    {
+                        "epoch": epoch,
+                        "baseline_commit": baseline,
+                        "points": [
+                            {
+                                "commit": commit,
+                                "run": f"run-of-{commit}",
+                                "complete": complete,
+                                "finished_at": f"2026-08-15T00:{i:02d}:00Z",
+                                "index": None,
+                            }
+                            for i, (commit, complete) in enumerate(points)
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def test_a_new_epoch_is_given_room_to_pin() -> None:
+    # The state is correct while it is young: a baseline is a complete valid run
+    # under the epoch, so it cannot be named before collection produces one.
+    points = [(chr(97 + i) * 40, True) for i in range(stall.DEFAULT_MAX_UNPINNED_POINTS)]
+    assert stall.unpinned(collecting_epoch(6, None, points[:1])) == []
+    assert stall.unpinned(collecting_epoch(6, None, points)) == [], (
+        "the threshold itself still passes"
+    )
+
+
+def test_the_deadline_is_counted_in_points_not_trunk_commits() -> None:
+    # Commits do not arrive one at a time — the RUE-1522 stack put twelve on
+    # trunk in a single merge — so a commit-counted deadline can expire in the
+    # time one pull request takes to land. A stack costs one point.
+    late = stall.unpinned(
+        collecting_epoch(6, None, [("a" * 40, True)] * 11), max_points=10
+    )
+    assert late and late[0][4] == 11
+
+
+def test_an_epoch_that_never_pins_its_baseline_is_a_failure() -> None:
+    # The shape RUE-1533 took: complete runs kept arriving on every platform and
+    # the headline index stayed absent, with nothing red anywhere. Fourteen
+    # complete runs per platform, which is why the deadline has to be inside
+    # that.
+    points = [("a" * 40, True)] + [(chr(98 + i) * 40, True) for i in range(13)]
+    late = stall.unpinned(collecting_epoch(6, None, points))
+    assert late == [("x86_64-linux", 6, "run-of-" + "a" * 40, "a" * 40, 14)]
+    assert stall.DEFAULT_MAX_UNPINNED_POINTS < 14
+
+
+def test_the_run_named_is_the_first_complete_one() -> None:
+    # The one the manifest should pin, and the moment the clock started — not
+    # whichever point happens to be newest, and not a partial run ahead of it.
+    points = [("a" * 40, False)] + [(chr(98 + i) * 40, True) for i in range(11)]
+    late = stall.unpinned(collecting_epoch(6, None, points))
+    assert [(entry[2], entry[3], entry[4]) for entry in late] == [
+        ("run-of-" + "b" * 40, "b" * 40, 11)
+    ]
+
+
+def test_partial_points_never_start_the_deadline() -> None:
+    # A partial run is never a baseline, so an epoch that has only ever
+    # collected partial runs has nothing to pin. That is the commit-count
+    # rule's business, not this one's.
+    subject = collecting_epoch(6, None, [("a" * 40, False)] * 50)
+    assert stall.unpinned(subject) == []
+
+
+def test_an_epoch_with_a_baseline_is_not_held_to_pinning_one() -> None:
+    subject = collecting_epoch(5, "b" * 40, [("a" * 40, True)] * 50)
+    assert stall.unpinned(subject) == []
+
+
+def test_a_retired_unpinned_epoch_does_not_block_the_repository() -> None:
+    # Epoch 4 collected one complete run and was superseded before it was ever
+    # pinned. Only the live epoch is the signal anyone reads, and an epoch that
+    # will never receive another point cannot be brought current.
+    subject = {
+        "platforms": [
+            {
+                "platform": "x86_64-linux",
+                "epochs": [
+                    {
+                        "epoch": 4,
+                        "baseline_commit": None,
+                        "points": [
+                            {
+                                "commit": "a" * 40,
+                                "run": "run-a",
+                                "complete": True,
+                                "finished_at": "2026-08-01T00:00:00Z",
+                                "index": None,
+                            }
+                        ],
+                    },
+                    {
+                        "epoch": 5,
+                        "baseline_commit": "c" * 40,
+                        "points": [
+                            {
+                                "commit": "d" * 40,
+                                "run": "run-d",
+                                "complete": True,
+                                "finished_at": "2026-08-08T00:00:00Z",
+                                "index": {"latency": 1.0},
+                            }
+                        ],
+                    },
+                ],
+            }
+        ]
+    }
+    assert stall.unpinned(subject) == []
+
+
+def test_the_unpinned_report_hands_over_the_block_to_paste() -> None:
+    # There is no bypass, so the remedy has to be actionable by whoever the
+    # gate blocks — including the exact run to pin, which is otherwise only
+    # recoverable by re-deriving the data branch by hand.
+    text = stall.report_unpinned([("x86_64-linux", 6, "run-a", "a" * 40, 9)], 5)
+    assert "not caused by" in text
+    assert "performance/manifest.toml" in text
+    assert "[epoch.baseline]" in text
+    assert 'run = "run-a"' in text
+    assert f'commit = "{"a" * 40}"' in text
+
+
 def test_the_unindexed_report_names_the_pin_to_check() -> None:
     text = stall.report_unindexed([("x86_64-linux", 5, 25)])
     assert "not caused by" in text

--- a/scripts/validate-performance-stall.py
+++ b/scripts/validate-performance-stall.py
@@ -13,13 +13,18 @@ commit count degrades gracefully across quiet weekends while a clock does not.
 Collection legitimately lags trunk by minutes, and a single failed collection
 should not block the repository, so the threshold tolerates both.
 
-Two things can stop, and both are checked here. Points can stop arriving, which
-is what the commit-count rule catches. Points can also keep arriving while the
-headline index they exist to move goes missing — an epoch whose declared
-baseline resolves to nothing publishes a ratio for no workload, so every point
-is plotted and the index is silently absent. That failed openly nowhere: the
-collector succeeded, no run was rejected, and the page simply stopped saying
-whether the compiler is getting slower (RUE-1486).
+Three things can stop, and all three are checked here. Points can stop arriving,
+which is what the commit-count rule catches. Points can also keep arriving while
+the headline index they exist to move goes missing, in two ways that look
+identical on the page and are opposite in the manifest. An epoch whose declared
+baseline resolves to nothing publishes a ratio for no workload (RUE-1486). An
+epoch that never declared one at all publishes no ratio either, and that state
+is legitimate right after the epoch is declared, which is why it survived
+fourteen complete runs on every platform (RUE-1533).
+
+Neither of those failed openly anywhere: the collector succeeded, no run was
+rejected, and the page simply stopped saying whether the compiler is getting
+slower.
 
 The series state comes from `rue-bench derive`, never from a status file stored
 alongside the raw records: ADR-0067 keeps everything derived out of the data
@@ -40,6 +45,27 @@ from pathlib import Path
 # enough that one failed collection, or collection simply lagging a merge, never
 # blocks a pull request.
 DEFAULT_MAX_COMMITS = 5
+
+# Complete runs an epoch may collect before it must have pinned a baseline
+# (RUE-1533). Counted in the epoch's own collected points rather than in trunk
+# commits, which is what every other rule here counts, for two reasons.
+#
+# Trunk commits are the right unit for "collection stopped", where the question
+# is how far the series has fallen behind the tree. They are the wrong unit for
+# "a maintainer has not done something yet", because commits do not arrive one
+# at a time: the RUE-1522 stack put twelve on trunk in a single merge, so a
+# twenty-commit deadline can expire in the time it takes one pull request to
+# land. Points arrive once per collection, so a stack costs one.
+#
+# Points also measure from inside the epoch. A deadline counted from the
+# measured commit to trunk gives an epoch declared while collection is behind
+# no grace at all — its first point arrives already past due, which is exactly
+# the state a stall's remedy creates.
+#
+# Ten is a handful of hours at the current collection cadence, and well inside
+# the fourteen that went uncaught here. A quiet weekend collects nothing and
+# spends none of it.
+DEFAULT_MAX_UNPINNED_POINTS = 10
 
 
 class HistoryUnavailable(Exception):
@@ -87,10 +113,11 @@ def unindexed(data: dict) -> list[tuple[str, int, int]]:
     """Return (platform, epoch, points) for live epochs publishing no index.
 
     An epoch with no baseline yet is the documented state of one that has just
-    been declared, and it publishes no index by design. An epoch that *has* a
-    baseline and still publishes no index is the failure: the baseline names a
-    run nothing resolves to, so no point carries a ratio and the headline index
-    is absent from a series that otherwise looks healthy.
+    been declared, and it publishes no index by design; `unpinned` is what holds
+    that state to a deadline. An epoch that *has* a baseline and still publishes
+    no index is the failure: the baseline names a run nothing resolves to, so no
+    point carries a ratio and the headline index is absent from a series that
+    otherwise looks healthy.
     """
     missing = []
     for platform, epoch in newest_epochs(data):
@@ -100,6 +127,57 @@ def unindexed(data: dict) -> list[tuple[str, int, int]]:
         if points and not any(point.get("index") for point in points):
             missing.append((platform, epoch.get("epoch"), len(points)))
     return missing
+
+
+def unpinned(
+    data: dict,
+    max_points: int = DEFAULT_MAX_UNPINNED_POINTS,
+) -> list[tuple[str, int, str, str, int]]:
+    """Return live epochs that could have pinned a baseline and still have not.
+
+    Declaring an epoch without a baseline is correct — a baseline is a complete
+    valid run *under* that epoch, so it cannot be named until collection has
+    produced one — but the state is meant to end at the first such run. Nothing
+    ended it for epoch 6, which collected fourteen complete runs on every
+    platform while the headline index the page exists to publish stayed absent
+    (RUE-1533).
+
+    The deadline is the epoch's own complete points, for the reasons given at
+    `DEFAULT_MAX_UNPINNED_POINTS`. Complete points only, because a partial run
+    is never a baseline; the run named is the first of them, because that is
+    the one the manifest should pin and the moment the clock started.
+
+    Takes no repository: this rule is decidable from the derived data alone,
+    which also keeps a shallow checkout from turning it into an error.
+
+    Returns (platform, epoch, run, commit, collected), naming the run to pin
+    rather than only the omission.
+    """
+    late = []
+    for platform, epoch in newest_epochs(data):
+        if epoch.get("baseline_commit"):
+            continue
+        complete = sorted(
+            (point for point in epoch.get("points", []) if point.get("complete")),
+            key=lambda point: point["finished_at"],
+        )
+        if not complete:
+            # Collecting, but nothing yet that could serve as a baseline. The
+            # honest state of an epoch declared moments ago, and of one whose
+            # runs are all partial — which the commit-count rule owns.
+            continue
+        if len(complete) > max_points:
+            first = complete[0]
+            late.append(
+                (
+                    platform,
+                    epoch.get("epoch"),
+                    first["run"],
+                    first["commit"],
+                    len(complete),
+                )
+            )
+    return late
 
 
 def stalled(
@@ -201,6 +279,40 @@ def report_unindexed(missing: list[tuple[str, int, int]]) -> str:
     return "\n".join(lines)
 
 
+def report_unpinned(late: list[tuple[str, int, str, str, int]], max_points: int) -> str:
+    lines = [
+        "A collecting epoch has never pinned its baseline, so no index is published.",
+        "",
+    ]
+    for platform, epoch, _run, commit, count in late:
+        lines.append(
+            f"  {platform}: epoch {epoch} has collected {count} complete runs "
+            f"(threshold {max_points}) and could have pinned a baseline since "
+            f"the first of them, at {commit[:12]}"
+        )
+    lines += [
+        "",
+        "This is a repository-wide condition and almost certainly not caused by",
+        "this pull request. An epoch is declared without a baseline on purpose —",
+        "a baseline is a complete valid run under that epoch, so it cannot be",
+        "named until one exists — but that state ends at the first such run, and",
+        "these did not end.",
+        "",
+        "Pin each platform's first complete valid run in performance/manifest.toml,",
+        "in that epoch's block:",
+        "",
+    ]
+    for platform, epoch, run, commit, _count in late:
+        lines += [
+            f"  # {platform}, epoch {epoch}",
+            "  [epoch.baseline]",
+            f'  commit = "{commit}"',
+            f'  run = "{run}"',
+            "",
+        ]
+    return "\n".join(lines)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -216,6 +328,12 @@ def main() -> int:
         help="the branch a stall is measured against (default: origin/trunk)",
     )
     parser.add_argument("--max-commits", type=int, default=DEFAULT_MAX_COMMITS)
+    parser.add_argument(
+        "--max-unpinned-points",
+        type=int,
+        default=DEFAULT_MAX_UNPINNED_POINTS,
+        help="complete runs an epoch may collect before it must pin a baseline",
+    )
     args = parser.parse_args()
 
     data = json.loads(args.data.read_text())
@@ -246,6 +364,11 @@ def main() -> int:
     missing = unindexed(data)
     if missing:
         print(report_unindexed(missing), file=sys.stderr)
+        return 1
+
+    late = unpinned(data, args.max_unpinned_points)
+    if late:
+        print(report_unpinned(late, args.max_unpinned_points), file=sys.stderr)
         return 1
 
     for platform, commit, finished_at in plotted:


### PR DESCRIPTION
The performance dashboard published no headline index on any platform from the
moment epoch 6 began collecting until now. The status line read "No headline
index yet: this epoch has no baseline", and the homepage Field Report dropped
its performance row. Nothing was red: collection succeeded on every trunk
commit, no run was rejected, and every per-workload series kept drawing.

Fixes RUE-1533.

## Why there was no baseline

Two independent causes, one per commit.

RUE-1264 declared epoch 6 and deferred the pin, correctly — a baseline is a
complete valid run *under* the epoch, so it cannot be named until collection
has produced one. Nothing named it afterwards. Each platform then collected
fourteen complete, valid, unrejected runs across thirty trunk commits, none of
which could publish a ratio.

Nothing bounded that state either. `unindexed()` in the staleness gate skips an
epoch with no `baseline_commit`, which is right for a freshly declared one and
is why declaring the next epoch works as a stall remedy — but the exemption had
no expiry, so an epoch that is never pinned looks exactly like one declared five
minutes ago, forever. RUE-1486 closed the neighbouring hole, a baseline naming a
run that resolves to nothing; this is the one beside it.

## What this does

Pins each platform's first complete valid run, all three from `170c1014` — the
commit that declared the epoch, exactly as epoch 5's baselines were pinned at
their own declaring commit. Re-deriving the published records against this
manifest publishes an index on all 42 points, 1.000 at each baseline:

| platform | points | complete | indexed before | indexed after |
| --- | --- | --- | --- | --- |
| x86_64-linux | 14 | 14 | 0 | 14 |
| aarch64-linux | 14 | 14 | 0 | 14 |
| aarch64-macos | 14 | 14 | 0 | 14 |

And fails the gate when a live epoch has collected more complete runs than the
deadline allows without pinning one, printing the `[epoch.baseline]` block to
paste for each platform. The deadline is counted in the epoch's own complete
points rather than trunk commits: commits do not arrive one at a time — the
RUE-1522 stack put twelve on trunk in a single merge — so a commit-counted
deadline can expire in the time one pull request takes to land, and this gate
has no bypass. Points also measure from inside the epoch, so an epoch declared
while collection is behind is not already past due on its first point.

## Verification

* Re-derived `performance-data-v1` at `f87dd50` against this manifest: 1161
  points, 0 rejected, epoch 6 indexed on all three platforms.
* `generate-site-status.py` now emits a performance row (index 0.864 on
  aarch64-linux) where it previously omitted one.
* The gate fails on the pre-fix manifest — naming the same three runs pinned
  here, derived independently — and passes on this one.
* `check-pins` still reports 3 collection epochs matching the tree.
* Gate tests (21 checks), the Python 3.9 baseline gate, and `scripts/rue quick`
  pass.

## Deliberately not here

Epoch 6's `[epoch.process_elapsed_ratchets.lattice]` stays absent, so ADR-0071's
fixed release-quality gate remains unenforced on x86-64 Linux as it has been
since the epoch was declared. It became declarable with the baseline, but epoch
5's derivation rule — baseline median plus k times lattice's calibrated 0.78%
relative MAD — puts the limit at 1,831.66 ms when one of this epoch's own
collected runs already measured 1,823.18 ms. That 0.78% is within-session
dispersion from a single-commit calibration; cross-run spread here is roughly
±4%, so the mechanical re-derivation would gate on noise. Which dispersion a
fixed ratchet should use is a maintainer call, tracked in RUE-1535 with the
numbers, and the manifest comment records why the table is empty.