### PR TITLE
RUE-1473: make CodegenUnit the object boundary

### DIFF
--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -26,7 +26,7 @@ use rue_cfg::{BlockId, Cfg, CfgValue, Type};
 use crate::types;
 
 /// A single lowering decision: maps one CFG instruction to its MIR expansion.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LoweringDecision {
     /// The CFG value (instruction) being lowered.
     pub cfg_value: CfgValue,
@@ -41,7 +41,7 @@ pub struct LoweringDecision {
 }
 
 /// A lowering decision for a block terminator.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TerminatorLoweringDecision {
     /// Human-readable description of the terminator.
     pub terminator_desc: String,
@@ -56,7 +56,7 @@ pub struct TerminatorLoweringDecision {
 }
 
 /// Debug information for a single basic block's lowering.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlockLoweringInfo {
     /// The block ID.
     pub block_id: BlockId,
@@ -70,7 +70,7 @@ pub struct BlockLoweringInfo {
 ///
 /// This captures how each CFG instruction is expanded into MIR instructions,
 /// including the rationale for instruction selection decisions.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LoweringDebugInfo {
     /// Function name.
     pub fn_name: String,

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -266,7 +266,7 @@ pub struct BackendArtifactRequest {
 }
 
 /// Diagnostic projections retained by one production backend execution.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct BackendArtifacts {
     pub lowering: Option<LoweringDebugInfo>,
     pub mir: Option<String>,

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -1968,9 +1968,24 @@ fn orphaned_backend_inspection_exports_cannot_return() {
             "unstable presentation regained a parallel backend path: {name}"
         );
     }
+    for (module, source) in PRODUCTION_MODULES {
+        for retired in [
+            "FunctionBackendProduct",
+            "backend_product",
+            "generate_backend_products",
+            "codegen_products",
+            "SectionContents",
+            "presentation_fingerprint",
+        ] {
+            assert!(
+                !code_identifiers(source).contains(&retired),
+                "retired CodegenUnit ownership identifier remains in {module}: {retired}"
+            );
+        }
+    }
     assert!(
-        code_identifiers(unstable).contains(&"codegen_products"),
-        "unstable presentation must project the canonical CodegenUnit terminal"
+        code_identifiers(backend).contains(&"project_backend_object"),
+        "object projection must accept the canonical CodegenUnit"
     );
 }
 

--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -2,23 +2,6 @@
 // Backend (code generation and linking)
 // ============================================================================
 
-/// Collect the raw C symbol names of every `extern "C"` foreign declaration in
-/// the lowered program (ADR-0064 C FFI). These are the undefined symbols a call
-/// site references and the linker resolves from a supplied static archive.
-#[cfg(test)]
-pub(crate) fn collect_foreign_symbols(rir: &rue_rir::Rir, interner: &ThreadedRodeo) -> Vec<String> {
-    rir.iter()
-        .filter_map(|(_, inst)| match &inst.data {
-            rue_rir::InstData::FnDecl {
-                is_extern: true,
-                name,
-                ..
-            } => Some(interner.resolve(name).to_string()),
-            _ => None,
-        })
-        .collect()
-}
-
 /// Collect the unmangled C symbol names of every `pub extern "C" fn` export in
 /// the lowered program (ADR-0064 P4). Each is the raw name under which a C-ABI
 /// entry thunk exposes the exported Rue function to separately compiled C
@@ -35,137 +18,6 @@ pub(crate) fn collect_export_symbols(rir: &rue_rir::Rir, interner: &ThreadedRode
             _ => None,
         })
         .collect()
-}
-
-/// Project live callable legacy names to their machine symbols, plus an
-/// identity mapping for every `extern "C"` foreign declaration.
-///
-/// A foreign symbol maps to itself (no mangling, ADR-0064): a call site resolves
-/// it to the raw C name, the object writer records it as an undefined external,
-/// and the linker satisfies it from a static archive. The identity mapping also
-/// lets `validate_production_call_relocations` recognize the raw name as a
-/// declared foreign call rather than an unresolved glue symbol.
-#[cfg(test)]
-pub(crate) fn foreign_call_symbol_mappings(
-    functions: &[crate::session::RootedCfgUnit],
-    foreign_symbols: &[String],
-) -> std::collections::BTreeMap<String, String> {
-    let mut symbol_mappings = functions
-        .iter()
-        .flat_map(|function| function.record.codegen.symbol_mappings.iter())
-        .map(|(source, target)| (source.clone(), target.clone()))
-        .collect::<std::collections::BTreeMap<_, _>>();
-    for name in foreign_symbols {
-        symbol_mappings
-            .entry(name.clone())
-            .or_insert_with(|| name.clone());
-    }
-    symbol_mappings
-}
-
-/// Canonical per-function result of the production backend pipeline.
-#[derive(Debug, Clone)]
-pub(crate) struct FunctionBackendProduct {
-    pub(crate) machine_name: String,
-    pub(crate) machine_code: rue_codegen::MachineCode,
-    pub(crate) artifacts: rue_codegen::BackendArtifacts,
-}
-
-/// Compile analyzed functions to a binary.
-///
-/// This backend handles both architectures. It:
-/// 1. Generates machine code for each function
-/// 2. Creates object files with relocations
-/// 3. Links them into an executable
-///
-/// This function is used by the sole one-shot compilation adapter.
-#[cfg(test)]
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn compile_backend(
-    functions: &[crate::session::RootedCfgUnit],
-    options: &CompileOptions,
-    warnings: &[CompileWarning],
-    // Names of `extern "C"` foreign declarations (ADR-0064 C FFI). Each is an
-    // undefined symbol a call site references by its raw (unmangled) name and
-    // that the linker resolves from a supplied static archive.
-    foreign_symbols: &[String],
-    // Unmangled C names of `pub extern "C" fn` exports (ADR-0064 P4). Each gets
-    // an additional C-ABI entry thunk object exposing that name globally.
-    export_symbols: &[String],
-) -> MultiErrorResult<CompileOutput> {
-    let object_files =
-        generate_pre_link_objects(functions, options, foreign_symbols, export_symbols)?;
-
-    // Link to executable
-    match &options.linker {
-        LinkerMode::Internal => link_internal_with_warnings(options, &object_files, warnings),
-        LinkerMode::System(linker_cmd) => {
-            link_system_with_warnings(options, &object_files, linker_cmd, warnings)
-        }
-    }
-}
-
-/// Everything the backend does *before* linking: main-function validation, CFG
-/// lowering, per-architecture code generation, and object-file creation with
-/// relocations. This is the pre-link boundary the RUE-1086 scaling-bench runner
-/// times as its `pre_link` interval; `compile_backend` calls it and then links
-/// the returned objects.
-#[cfg(test)]
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn generate_pre_link_objects(
-    functions: &[crate::session::RootedCfgUnit],
-    options: &CompileOptions,
-    foreign_symbols: &[String],
-    export_symbols: &[String],
-) -> MultiErrorResult<Vec<Vec<u8>>> {
-    // Check for main function
-    let _main_fn = functions
-        .iter()
-        .find(|function| function.record.codegen.defined_symbol.as_ref() == "main")
-        .ok_or_else(|| {
-            CompileErrors::from(CompileError::without_span(ErrorKind::NoMainFunction))
-        })?;
-
-    let products = generate_backend_products(
-        functions,
-        options,
-        foreign_symbols,
-        rue_codegen::BackendArtifactRequest::default(),
-    )?;
-    generate_pre_link_objects_from_products(functions, products, options, export_symbols)
-}
-
-/// Object/link projection of canonical `CodegenUnit` terminals. This owns no
-/// lowering or emission; callers have already collected the shared units.
-#[cfg(test)]
-pub(crate) fn generate_pre_link_objects_from_products(
-    functions: &[crate::session::RootedCfgUnit],
-    products: Vec<FunctionBackendProduct>,
-    options: &CompileOptions,
-    export_symbols: &[String],
-) -> MultiErrorResult<Vec<Vec<u8>>> {
-    validate_backend_functions(functions)?;
-    let mut object_files = products
-        .into_iter()
-        .map(|product| project_backend_object(product, options.target))
-        .collect::<CompileResult<Vec<_>>>()
-        .map_err(CompileErrors::from)?;
-    info!(
-        function_count = functions.len(),
-        object_bytes = object_files.iter().map(Vec::len).sum::<usize>(),
-        "codegen complete"
-    );
-
-    // Emit a C-ABI entry thunk object for every `pub extern "C" fn` export
-    // (ADR-0064 P4). The native body was already generated above under its
-    // mangled symbol; the thunk adds the unmangled global C entry point.
-    object_files.extend(generate_export_thunk_objects(
-        functions,
-        options,
-        export_symbols,
-    ));
-
-    Ok(object_files)
 }
 
 /// Validate the function/symbol projection at the object-generation boundary.
@@ -199,104 +51,111 @@ pub(crate) fn validate_backend_functions(
     Ok(())
 }
 
-/// Run the production per-function backend pipeline, optionally retaining
-/// diagnostic projections from that exact execution.
-#[cfg(test)]
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn generate_backend_products(
-    functions: &[crate::session::RootedCfgUnit],
-    options: &CompileOptions,
-    foreign_symbols: &[String],
-    request: rue_codegen::BackendArtifactRequest,
-) -> MultiErrorResult<Vec<FunctionBackendProduct>> {
-    // Keep every per-function subphase nested under one `codegen` aggregate
-    // timing root (RUE-786).
-    let codegen_span = info_span!("codegen", arch = ?options.target.arch(), phase = "backend");
-    let _entered = codegen_span.clone().entered();
-    let symbol_mappings = foreign_call_symbol_mappings(functions, foreign_symbols);
-    let foreign_set: std::collections::BTreeSet<String> = foreign_symbols.iter().cloned().collect();
-    let symbols =
-        rue_codegen::MachineSymbolResolver::new_with_foreign(&symbol_mappings, &foreign_set);
-
-    let results: Vec<CompileResult<FunctionBackendProduct>> = functions
-        .iter()
-        .map(|func| {
-            let _worker = codegen_span.enter();
-            let stable_atom_ids = func
-                .record
-                .local_atoms
-                .iter()
-                .map(|atom| {
-                    crate::StableSymbolEncoder::encode(&crate::StableSymbolId::LocalAtom(
-                        atom.identity.clone(),
-                    ))
-                })
-                .collect::<Vec<_>>();
-            let atom_projection = func
-                .record
-                .local_atoms
-                .iter()
-                .zip(&stable_atom_ids)
-                .map(|(atom, stable_id)| rue_codegen::LocalAtomProjection {
-                    stable_id,
-                    dense_id: atom.dense_id,
-                    content: &atom.content,
-                })
-                .collect::<Vec<_>>();
-            let mut product = match options.target.arch() {
-                Arch::X86_64 => rue_codegen::x86_64::generate_product_with_symbols_and_atoms(
-                    &func.record.cfg,
-                    &func.record.type_pool,
-                    &func.record.strings,
-                    &func.record.interner,
-                    symbols,
-                    &atom_projection,
-                    request,
-                )?,
-                Arch::Aarch64 => rue_codegen::aarch64::generate_product_with_symbols_and_atoms(
-                    &func.record.cfg,
-                    &func.record.type_pool,
-                    &func.record.strings,
-                    &func.record.interner,
-                    options.target,
-                    symbols,
-                    &atom_projection,
-                    request,
-                )?,
-            };
-            if let Some(lowering) = &mut product.artifacts.lowering {
-                lowering.fn_name = func.record.codegen.defined_symbol.to_string();
-            }
-            validate_production_call_relocations(
-                &product.machine_code.relocations,
-                &symbol_mappings,
-            )?;
-            Ok(FunctionBackendProduct {
-                machine_name: func.record.codegen.defined_symbol.to_string(),
-                machine_code: product.machine_code,
-                artifacts: product.artifacts,
-            })
-        })
-        .collect();
-
-    results
-        .into_iter()
-        .collect::<CompileResult<Vec<_>>>()
-        .map_err(CompileErrors::from)
-}
-
+/// Project one canonical `CodegenUnit` into the linker-owned object builder.
+/// The builder currently accepts owned strings and byte vectors, so this leaf
+/// makes transient copies without retaining a second compiler-side product.
 pub(crate) fn project_backend_object(
-    product: FunctionBackendProduct,
+    unit: &crate::codegen_query::CodegenUnit,
     target: Target,
 ) -> CompileResult<Vec<u8>> {
     // Object serialization runs after code generation, so it is a sibling leaf
     // of `codegen` rather than one of its subphases (RUE-786).
     let _span = info_span!("object_serialization", phase = "object_generation").entered();
-    let mut obj_builder = ObjectBuilder::new(target, &product.machine_name)
-        .code(product.machine_code.code)
-        .strings(product.machine_code.strings);
+    use crate::codegen_query::{CodegenSection, SectionKind};
+    let mut text: Option<&CodegenSection> = None;
+    let mut rodata: Option<&CodegenSection> = None;
+    let mut data: Option<&CodegenSection> = None;
+    let mut bss: Option<&CodegenSection> = None;
+    for section in unit.sections.iter() {
+        let slot = match section.kind {
+            SectionKind::Text => &mut text,
+            SectionKind::Rodata => &mut rodata,
+            SectionKind::Data => &mut data,
+            SectionKind::Bss => &mut bss,
+        };
+        if slot.replace(section).is_some() {
+            return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+                format!(
+                    "object projection requires exactly one {:?} section, found multiple",
+                    section.kind
+                ),
+            )));
+        }
+    }
+    let text = text.ok_or_else(|| {
+        CompileError::without_span(ErrorKind::InternalCodegenError(
+            "object projection requires exactly one Text section, found 0".into(),
+        ))
+    })?;
+    if (text.alignment, text.executable, text.writable) != (16, true, false) {
+        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+            "object projection found non-canonical Text metadata".into(),
+        )));
+    }
+    if text.atoms.len() != 1 {
+        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+            format!(
+                "object projection requires exactly one text atom, found {}",
+                text.atoms.len()
+            ),
+        )));
+    }
+    let rodata = rodata.ok_or_else(|| {
+        CompileError::without_span(ErrorKind::InternalCodegenError(
+            "object projection requires exactly one Rodata section, found 0".into(),
+        ))
+    })?;
+    if (rodata.alignment, rodata.executable, rodata.writable) != (1, false, false) {
+        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+            "object projection found non-canonical Rodata metadata".into(),
+        )));
+    }
+    let data = data.ok_or_else(|| {
+        CompileError::without_span(ErrorKind::InternalCodegenError(
+            "object projection requires exactly one Data section, found 0".into(),
+        ))
+    })?;
+    if (data.alignment, data.executable, data.writable) != (1, false, true) {
+        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+            "object projection found non-canonical Data metadata".into(),
+        )));
+    }
+    if !data.atoms.is_empty() {
+        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+            "object projection does not support Data atoms".into(),
+        )));
+    }
+    let bss = bss.ok_or_else(|| {
+        CompileError::without_span(ErrorKind::InternalCodegenError(
+            "object projection requires exactly one Bss section, found 0".into(),
+        ))
+    })?;
+    if (bss.alignment, bss.executable, bss.writable) != (1, false, true) {
+        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+            "object projection found non-canonical Bss metadata".into(),
+        )));
+    }
+    if !bss.atoms.is_empty() {
+        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+            "object projection does not support Bss atoms".into(),
+        )));
+    }
+    let strings = rodata
+        .atoms
+        .iter()
+        .map(|atom| {
+            String::from_utf8(atom.to_vec()).map_err(|_| {
+                CompileError::without_span(ErrorKind::InternalCodegenError(
+                    "object projection encountered non-UTF-8 rodata atom".into(),
+                ))
+            })
+        })
+        .collect::<CompileResult<Vec<_>>>()?;
+    let mut obj_builder = ObjectBuilder::new(target, unit.defined_symbol.to_string())
+        .code(text.atoms[0].to_vec())
+        .strings(strings);
 
-    for reloc in product.machine_code.relocations {
+    for reloc in unit.relocations.iter() {
         let rel_type = match (target.arch(), reloc.kind) {
             (Arch::X86_64, RelocationKind::X86Pc32) => RelocationType::Pc32,
             (Arch::X86_64, RelocationKind::X86Plt32) => RelocationType::Plt32,
@@ -311,31 +170,12 @@ pub(crate) fn project_backend_object(
         };
         obj_builder = obj_builder.relocation(CodeRelocation {
             offset: reloc.offset,
-            symbol: reloc.symbol,
+            symbol: reloc.symbol.to_string(),
             rel_type,
             addend: reloc.addend,
         });
     }
     Ok(obj_builder.build())
-}
-
-/// Link canonical codegen units through the ordinary one-shot adapter.
-#[cfg(test)]
-pub(crate) fn compile_backend_products(
-    functions: &[crate::session::RootedCfgUnit],
-    products: Vec<FunctionBackendProduct>,
-    options: &CompileOptions,
-    warnings: &[CompileWarning],
-    export_symbols: &[String],
-) -> MultiErrorResult<CompileOutput> {
-    let objects =
-        generate_pre_link_objects_from_products(functions, products, options, export_symbols)?;
-    match &options.linker {
-        LinkerMode::Internal => link_internal_with_warnings(options, &objects, warnings),
-        LinkerMode::System(linker_cmd) => {
-            link_system_with_warnings(options, &objects, linker_cmd, warnings)
-        }
-    }
 }
 
 /// Emit the C-ABI entry thunk objects for every `pub extern "C" fn` export
@@ -461,11 +301,6 @@ pub(crate) fn validate_production_call_relocations(
 // ============================================================================
 use tracing::info_span;
 
-#[cfg(test)]
-use tracing::info;
-
-#[cfg(test)]
-use crate::linking::{link_internal_with_warnings, link_system_with_warnings};
 use crate::*;
 
 #[cfg(test)]
@@ -473,7 +308,9 @@ mod tests {
     use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
 
-    use rue_linker::ObjectFile;
+    use rue_linker::{CodeRelocation, ObjectBuilder, ObjectFile, RelocationType};
+
+    use crate::codegen_query::{CodegenSection, CodegenUnit, NormalizedRelocation, SectionKind};
 
     use super::*;
 
@@ -541,15 +378,243 @@ fn main() -> i32 {
         );
     }
 
-    fn frontend() -> (std::sync::Arc<CanonicalRirOutput>, RootedCfgOutput) {
-        let snapshot = SourceSnapshot::single("<rue-784>", SOURCE).unwrap();
-        let (rir, semantic, _) =
-            crate::test_support::test_frontend_snapshot(&snapshot, &CompileOptions::default())
-                .unwrap();
-        (rir, semantic)
+    fn projection_section(kind: SectionKind, atoms: &[&[u8]]) -> CodegenSection {
+        let (alignment, executable, writable) = match kind {
+            SectionKind::Text => (16, true, false),
+            SectionKind::Rodata => (1, false, false),
+            SectionKind::Data | SectionKind::Bss => (1, false, true),
+        };
+        CodegenSection {
+            kind,
+            alignment,
+            executable,
+            writable,
+            atoms: atoms
+                .iter()
+                .map(|atom| Arc::<[u8]>::from(*atom))
+                .collect::<Vec<_>>()
+                .into(),
+        }
     }
 
-    fn strbuf_concat_frontend() -> (std::sync::Arc<CanonicalRirOutput>, RootedCfgOutput) {
+    fn projection_unit(sections: Vec<CodegenSection>) -> CodegenUnit {
+        CodegenUnit {
+            defined_symbol: Arc::from("main"),
+            relocations: Arc::from([]),
+            sections: sections.into(),
+            artifacts: Default::default(),
+            content_fingerprint: 0,
+        }
+    }
+
+    fn canonical_projection_unit(text: &[u8], strings: &[&[u8]]) -> CodegenUnit {
+        projection_unit(vec![
+            projection_section(SectionKind::Text, &[text]),
+            projection_section(SectionKind::Rodata, strings),
+            projection_section(SectionKind::Data, &[]),
+            projection_section(SectionKind::Bss, &[]),
+        ])
+    }
+
+    fn assert_projection_rejects(unit: CodegenUnit, expected: &str) {
+        let error = project_backend_object(&unit, Target::X86_64Linux).unwrap_err();
+        assert!(
+            matches!(&error.kind, ErrorKind::InternalCodegenError(message) if message.contains(expected)),
+            "unexpected projection error: {error}"
+        );
+    }
+
+    #[test]
+    fn object_projection_rejects_malformed_section_shapes_without_panicking() {
+        let all_sections = vec![
+            projection_section(SectionKind::Text, &[b"text"]),
+            projection_section(SectionKind::Rodata, &[]),
+            projection_section(SectionKind::Data, &[]),
+            projection_section(SectionKind::Bss, &[]),
+        ];
+        for kind in [
+            SectionKind::Text,
+            SectionKind::Rodata,
+            SectionKind::Data,
+            SectionKind::Bss,
+        ] {
+            let missing = all_sections
+                .iter()
+                .filter(|section| section.kind != kind)
+                .cloned()
+                .collect();
+            assert_projection_rejects(
+                projection_unit(missing),
+                &format!("exactly one {kind:?} section"),
+            );
+            let mut duplicate = all_sections.clone();
+            duplicate.push(projection_section(kind, &[]));
+            assert_projection_rejects(
+                projection_unit(duplicate),
+                &format!("exactly one {kind:?} section"),
+            );
+        }
+        assert_projection_rejects(
+            canonical_projection_unit(b"text", &[&[0xff]]),
+            "non-UTF-8 rodata",
+        );
+        for kind in [SectionKind::Data, SectionKind::Bss] {
+            let mut malformed = canonical_projection_unit(b"text", &[]);
+            Arc::make_mut(&mut malformed.sections)
+                .iter_mut()
+                .find(|section| section.kind == kind)
+                .unwrap()
+                .atoms = Arc::from([Arc::<[u8]>::from(*b"unsupported")]);
+            assert_projection_rejects(malformed, &format!("does not support {kind:?} atoms"));
+        }
+        assert_projection_rejects(
+            {
+                let mut malformed = canonical_projection_unit(b"text", &[]);
+                Arc::make_mut(&mut malformed.sections)
+                    .iter_mut()
+                    .find(|section| section.kind == SectionKind::Data)
+                    .unwrap()
+                    .atoms = Arc::from([Arc::<[u8]>::from(&b""[..])]);
+                malformed
+            },
+            "does not support Data atoms",
+        );
+        for kind in [
+            SectionKind::Text,
+            SectionKind::Rodata,
+            SectionKind::Data,
+            SectionKind::Bss,
+        ] {
+            let mut malformed = canonical_projection_unit(b"text", &[]);
+            let section = Arc::make_mut(&mut malformed.sections)
+                .iter_mut()
+                .find(|section| section.kind == kind)
+                .unwrap();
+            section.alignment = section.alignment.saturating_add(1);
+            assert_projection_rejects(malformed, &format!("non-canonical {kind:?}"));
+        }
+        let mut wrong_arch = canonical_projection_unit(b"text", &[]);
+        wrong_arch.relocations = Arc::from([NormalizedRelocation {
+            offset: 0,
+            symbol: Arc::from("callee"),
+            kind: RelocationKind::Aarch64Call26,
+            addend: 0,
+        }]);
+        assert_projection_rejects(wrong_arch, "incompatible relocation");
+    }
+
+    #[test]
+    fn object_projection_preserves_rodata_atoms_and_relocations_on_every_target() {
+        let non_ascii = "é".as_bytes();
+        let atom_bytes: [&[u8]; 4] = [b"", b"duplicate", non_ascii, b"duplicate"];
+        let strings = vec![
+            String::new(),
+            "duplicate".to_owned(),
+            "é".to_owned(),
+            "duplicate".to_owned(),
+        ];
+        for target in [
+            Target::X86_64Linux,
+            Target::Aarch64Linux,
+            Target::Aarch64Macos,
+        ] {
+            let (relocations, expected_relocations): (Vec<_>, Vec<_>) = match target.arch() {
+                Arch::X86_64 => (
+                    vec![
+                        NormalizedRelocation {
+                            offset: 1,
+                            symbol: Arc::from("first"),
+                            kind: RelocationKind::X86Pc32,
+                            addend: -4,
+                        },
+                        NormalizedRelocation {
+                            offset: 3,
+                            symbol: Arc::from("duplicate"),
+                            kind: RelocationKind::X86Plt32,
+                            addend: 0,
+                        },
+                    ],
+                    vec![
+                        CodeRelocation {
+                            offset: 1,
+                            symbol: "first".to_owned(),
+                            rel_type: RelocationType::Pc32,
+                            addend: -4,
+                        },
+                        CodeRelocation {
+                            offset: 3,
+                            symbol: "duplicate".to_owned(),
+                            rel_type: RelocationType::Plt32,
+                            addend: 0,
+                        },
+                    ],
+                ),
+                Arch::Aarch64 => (
+                    vec![
+                        NormalizedRelocation {
+                            offset: 0,
+                            symbol: Arc::from("first"),
+                            kind: RelocationKind::Aarch64AdrpPage21,
+                            addend: 0,
+                        },
+                        NormalizedRelocation {
+                            offset: 4,
+                            symbol: Arc::from("duplicate"),
+                            kind: RelocationKind::Aarch64AddLo12,
+                            addend: 8,
+                        },
+                        NormalizedRelocation {
+                            offset: 8,
+                            symbol: Arc::from("first"),
+                            kind: RelocationKind::Aarch64Call26,
+                            addend: 0,
+                        },
+                    ],
+                    vec![
+                        CodeRelocation {
+                            offset: 0,
+                            symbol: "first".to_owned(),
+                            rel_type: RelocationType::AdrpPage21,
+                            addend: 0,
+                        },
+                        CodeRelocation {
+                            offset: 4,
+                            symbol: "duplicate".to_owned(),
+                            rel_type: RelocationType::AddLo12,
+                            addend: 8,
+                        },
+                        CodeRelocation {
+                            offset: 8,
+                            symbol: "first".to_owned(),
+                            rel_type: RelocationType::Call26,
+                            addend: 0,
+                        },
+                    ],
+                ),
+            };
+            let mut unit = canonical_projection_unit(b"\x90\xc3", &atom_bytes);
+            unit.relocations = relocations.into();
+            let actual = project_backend_object(&unit, target).unwrap();
+            let mut expected = ObjectBuilder::new(target, "main")
+                .code(vec![0x90, 0xc3])
+                .strings(strings.clone());
+            for relocation in expected_relocations {
+                expected = expected.relocation(relocation);
+            }
+            assert_eq!(actual, expected.build(), "{target:?}");
+        }
+    }
+
+    fn frontend() -> SourceSnapshot {
+        let snapshot = SourceSnapshot::single("<rue-784>", SOURCE).unwrap();
+        snapshot
+    }
+
+    fn strbuf_concat_frontend() -> (
+        SourceSnapshot,
+        std::sync::Arc<CanonicalRirOutput>,
+        RootedCfgOutput,
+    ) {
         let root = FileId::new(1);
         let strbuf = FileId::new(2);
         let metadata = SourceMetadata::new_with_trusted_standard_library(
@@ -606,31 +671,31 @@ drop fn StrBuf(self) { }
         let (rir, semantic, _) =
             crate::test_support::test_frontend_snapshot(&snapshot, &CompileOptions::default())
                 .unwrap();
-        (rir, semantic)
+        (snapshot, rir, semantic)
     }
 
     fn assert_three_result_slots_cross_cleanup(target: Target) {
-        let (rir, semantic) = strbuf_concat_frontend();
+        let (snapshot, _rir, semantic) = strbuf_concat_frontend();
         let options = CompileOptions {
             target,
             ..Default::default()
         };
-        let interner = rir.semantic_symbols().interner();
-        let foreign_symbols = collect_foreign_symbols(rir.rir(), interner);
-        let products = generate_backend_products(
-            semantic.functions(),
-            &options,
-            &foreign_symbols,
-            rue_codegen::BackendArtifactRequest {
-                asm: true,
-                ..Default::default()
-            },
-        )
-        .unwrap();
-        let assembly = products
+        let mut session = CompilerSession::new();
+        crate::test_support::publish_test_snapshot(&mut session, &snapshot).unwrap();
+        let rooted = session
+            .rooted_codegen(
+                &options,
+                rue_codegen::BackendArtifactRequest {
+                    asm: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let assembly = rooted
+            .units
             .into_iter()
-            .find(|product| product.machine_name == "main")
-            .and_then(|product| product.artifacts.asm)
+            .find(|unit| unit.unit.defined_symbol.as_ref() == "main")
+            .and_then(|unit| unit.unit.artifacts.asm.clone())
             .expect("main assembly projection");
         let instructions = assembly
             .lines()
@@ -742,7 +807,7 @@ drop fn StrBuf(self) { }
 
     #[test]
     fn function_objects_only_contain_their_referenced_strings() {
-        let (_rir, semantic) = frontend();
+        let snapshot = frontend();
 
         for target in [
             Target::X86_64Linux,
@@ -753,10 +818,16 @@ drop fn StrBuf(self) { }
                 target,
                 ..CompileOptions::default()
             };
-            let objects =
-                generate_pre_link_objects(semantic.functions(), &options, &[], &[]).unwrap();
-
-            let all_object_bytes: Vec<_> = objects.into_iter().flatten().collect();
+            let mut session = CompilerSession::new();
+            crate::test_support::publish_test_snapshot(&mut session, &snapshot).unwrap();
+            let rooted = session
+                .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+                .unwrap();
+            let all_object_bytes: Vec<_> = rooted
+                .objects
+                .iter()
+                .flat_map(|object| object.object.bytes.iter().copied())
+                .collect();
             assert_eq!(count(&all_object_bytes, FIRST_LITERAL), 1, "{target}");
             assert_eq!(count(&all_object_bytes, SECOND_LITERAL), 1, "{target}");
         }
@@ -764,7 +835,7 @@ drop fn StrBuf(self) { }
 
     #[test]
     fn text_objects_and_runtime_archive_have_no_obsolete_string_symbols() {
-        let (_rir, semantic) = strbuf_concat_frontend();
+        let (snapshot, _rir, _semantic) = strbuf_concat_frontend();
         let obsolete =
             |name: &str| name.starts_with("__rue_String_") || name == "__rue_drop_String";
 
@@ -777,12 +848,20 @@ drop fn StrBuf(self) { }
                 target,
                 ..CompileOptions::default()
             };
-            let objects =
-                generate_pre_link_objects(semantic.functions(), &options, &[], &[]).unwrap();
+            let mut session = CompilerSession::new();
+            crate::test_support::publish_test_snapshot(&mut session, &snapshot).unwrap();
+            let rooted = session
+                .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+                .unwrap();
+            let objects = rooted
+                .objects
+                .iter()
+                .map(|object| object.object.bytes.as_ref())
+                .collect::<Vec<_>>();
 
             let mut undefined = HashSet::new();
             for bytes in objects {
-                let object = ObjectFile::parse(&bytes).unwrap();
+                let object = ObjectFile::parse(bytes).unwrap();
                 undefined.extend(
                     object
                         .symbols
@@ -814,7 +893,7 @@ drop fn StrBuf(self) { }
             "runtime archive still contains obsolete exports: {obsolete_exports:?}"
         );
 
-        compile_backend(semantic.functions(), &options, &[], &[], &[])
+        crate::test_support::test_compile_snapshot(&snapshot, &options)
             .expect("ordinary source-defined StrBuf program must link without obsolete members");
     }
 

--- a/crates/rue-compiler/src/codegen_query.rs
+++ b/crates/rue-compiler/src/codegen_query.rs
@@ -7,7 +7,6 @@
 //! callers keep their units unless a real ABI or emitted reference changes.
 
 use std::{
-    collections::BTreeSet,
     hash::{Hash, Hasher},
     sync::Arc,
 };
@@ -167,20 +166,17 @@ impl QueryKey for CodegenUnitQueryKey {
 #[derive(Debug, Clone)]
 pub(crate) struct CodegenUnit {
     pub(crate) defined_symbol: Arc<str>,
-    pub(crate) referenced_symbols: Arc<[Arc<str>]>,
     pub(crate) relocations: Arc<[NormalizedRelocation]>,
     pub(crate) sections: Arc<[CodegenSection]>,
     pub(crate) artifacts: rue_codegen::BackendArtifacts,
     pub(crate) content_fingerprint: u64,
-    pub(crate) presentation_fingerprint: u64,
-    pub(crate) presentation: Arc<str>,
 }
 
 /// A reached canonical terminal paired only with its stable function identity.
 /// RUE-1217 owns replacing the semantic root enumerator that assembles this
 /// list; neither the terminal nor this collection record retains live frontend
 /// state.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct CollectedCodegenUnit {
     pub(crate) function: crate::FunctionInstanceKey,
     pub(crate) unit: Arc<CodegenUnit>,
@@ -204,14 +200,6 @@ impl CodeModel {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct SectionContents {
-    pub(crate) bytes: Arc<[u8]>,
-    pub(crate) alignment: u32,
-    pub(crate) executable: bool,
-    pub(crate) writable: bool,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum SectionKind {
     Text,
@@ -223,7 +211,9 @@ pub(crate) enum SectionKind {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct CodegenSection {
     pub(crate) kind: SectionKind,
-    pub(crate) contents: SectionContents,
+    pub(crate) alignment: u32,
+    pub(crate) executable: bool,
+    pub(crate) writable: bool,
     /// Atoms preserve the deterministic local ownership boundary. The current
     /// backend has anonymous text and string atoms; data/BSS are explicit empty
     /// sections until a producer supplies them.
@@ -304,17 +294,9 @@ impl RetainedCharge for rue_codegen::BackendArtifacts {
     }
 }
 
-impl RetainedCharge for SectionContents {
-    fn retained_charge(&self) -> u64 {
-        self.bytes.retained_charge()
-    }
-}
-
 impl RetainedCharge for CodegenSection {
     fn retained_charge(&self) -> u64 {
-        self.contents
-            .retained_charge()
-            .saturating_add(self.atoms.retained_charge())
+        self.atoms.retained_charge()
     }
 }
 
@@ -328,11 +310,9 @@ impl RetainedCharge for CodegenUnit {
     fn retained_charge(&self) -> u64 {
         self.defined_symbol
             .retained_charge()
-            .saturating_add(self.referenced_symbols.retained_charge())
             .saturating_add(self.relocations.retained_charge())
             .saturating_add(self.sections.retained_charge())
             .saturating_add(self.artifacts.retained_charge())
-            .saturating_add(self.presentation.retained_charge())
     }
 }
 
@@ -345,6 +325,16 @@ impl RetainedCharge for CodegenUnitValue {
     }
 }
 
+impl CodegenUnit {
+    #[cfg(test)]
+    pub(crate) fn text_atom(&self) -> Option<&[u8]> {
+        self.sections
+            .iter()
+            .find(|section| section.kind == SectionKind::Text)
+            .and_then(|section| (section.atoms.len() == 1).then(|| section.atoms[0].as_ref()))
+    }
+}
+
 const BACKEND_EPOCH: u32 = 1;
 const ABI_LAYOUT_EPOCH: u32 = 1;
 
@@ -352,69 +342,28 @@ pub(crate) fn codegen_unit_value_equal(left: &CodegenUnitValue, right: &CodegenU
     match (left, right) {
         (CodegenUnitValue::Available(left), CodegenUnitValue::Available(right)) => {
             left.defined_symbol == right.defined_symbol
-                && left.referenced_symbols == right.referenced_symbols
                 && left.relocations == right.relocations
                 && left.sections == right.sections
+                && left.artifacts == right.artifacts
                 && left.content_fingerprint == right.content_fingerprint
-                && left.presentation_fingerprint == right.presentation_fingerprint
-                && left.presentation == right.presentation
         }
         (CodegenUnitValue::Failure(left), CodegenUnitValue::Failure(right)) => left == right,
         _ => false,
     }
 }
 
-impl CodegenUnit {
-    /// Thin legacy projection for the object writer.  No lowering, allocation,
-    /// or emission occurs here: all link-relevant bytes come from this terminal.
-    pub(crate) fn backend_product(&self) -> crate::backend::FunctionBackendProduct {
-        let text = self
-            .sections
-            .iter()
-            .find(|section| section.kind == SectionKind::Text)
-            .expect("CodegenUnit always has text");
-        let rodata = self
-            .sections
-            .iter()
-            .find(|section| section.kind == SectionKind::Rodata)
-            .expect("CodegenUnit always has rodata");
-        crate::backend::FunctionBackendProduct {
-            machine_name: self.defined_symbol.to_string(),
-            machine_code: rue_codegen::MachineCode {
-                code: text.contents.bytes.to_vec(),
-                relocations: self
-                    .relocations
-                    .iter()
-                    .map(|relocation| rue_codegen::EmittedRelocation {
-                        offset: relocation.offset,
-                        symbol: relocation.symbol.to_string(),
-                        kind: relocation.kind,
-                        addend: relocation.addend,
-                    })
-                    .collect(),
-                strings: rodata
-                    .atoms
-                    .iter()
-                    .map(|atom| {
-                        String::from_utf8(atom.to_vec())
-                            .expect("codegen rodata atoms are UTF-8 strings")
-                    })
-                    .collect(),
-            },
-            artifacts: self.artifacts.clone(),
-        }
-    }
-}
-
-fn product_fingerprint(machine_name: &str, machine_code: &rue_codegen::MachineCode) -> u64 {
+fn content_fingerprint(
+    defined_symbol: &str,
+    sections: &[CodegenSection],
+    relocations: &[NormalizedRelocation],
+) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    machine_name.hash(&mut hasher);
-    machine_code.code.hash(&mut hasher);
-    machine_code.strings.hash(&mut hasher);
-    for relocation in &machine_code.relocations {
+    defined_symbol.hash(&mut hasher);
+    sections.hash(&mut hasher);
+    for relocation in relocations {
         relocation.offset.hash(&mut hasher);
         relocation.symbol.hash(&mut hasher);
-        std::mem::discriminant(&relocation.kind).hash(&mut hasher);
+        relocation.kind.hash(&mut hasher);
         relocation.addend.hash(&mut hasher);
     }
     hasher.finish()
@@ -525,108 +474,78 @@ pub(crate) fn evaluate_codegen_unit(
                 addend: 0,
             });
     }
+    let rue_codegen::BackendProduct {
+        machine_code:
+            rue_codegen::MachineCode {
+                code,
+                relocations: emitted_relocations,
+                strings,
+            },
+        artifacts,
+    } = product;
     if let Err(error) = crate::backend::validate_production_call_relocations(
-        &product.machine_code.relocations,
+        &emitted_relocations,
         &record.codegen.symbol_mappings,
     ) {
         return Ok(codegen_failure(error.into()));
     }
     context.check_canceled()?;
     context.record_work(rue_query::WorkItem::new("codegen.unit.successes", 1));
-    let relocations = product
-        .machine_code
-        .relocations
-        .iter()
+    let relocations: Arc<[NormalizedRelocation]> = emitted_relocations
+        .into_iter()
         .map(|relocation| NormalizedRelocation {
             offset: relocation.offset,
-            symbol: Arc::from(relocation.symbol.as_str()),
+            symbol: Arc::from(relocation.symbol),
             kind: relocation.kind,
             addend: relocation.addend,
         })
         .collect::<Vec<_>>()
         .into();
-    let referenced_symbols = product
-        .machine_code
-        .relocations
-        .iter()
-        .map(|relocation| Arc::from(relocation.symbol.as_str()))
-        .collect::<BTreeSet<_>>()
+    let text: Arc<[u8]> = code.into();
+    let rodata_atoms = strings
         .into_iter()
-        .collect::<Vec<_>>()
-        .into();
-    let text: Arc<[u8]> = product.machine_code.code.clone().into();
-    let rodata_atoms = product
-        .machine_code
-        .strings
-        .iter()
-        .map(|value| Arc::<[u8]>::from(value.as_bytes()))
+        .map(|value| Arc::<[u8]>::from(value.into_bytes()))
         .collect::<Vec<_>>();
-    let rodata_bytes = rodata_atoms
-        .iter()
-        .flat_map(|atom| atom.iter().copied())
-        .collect::<Vec<_>>();
-    let empty = SectionContents {
-        bytes: Arc::from([]),
-        alignment: 1,
-        executable: false,
-        writable: true,
-    };
     let sections: Arc<[CodegenSection]> = vec![
         CodegenSection {
             kind: SectionKind::Text,
-            contents: SectionContents {
-                bytes: text.clone(),
-                alignment: 16,
-                executable: true,
-                writable: false,
-            },
+            alignment: 16,
+            executable: true,
+            writable: false,
             atoms: Arc::from([text.clone()]),
         },
         CodegenSection {
             kind: SectionKind::Rodata,
-            contents: SectionContents {
-                bytes: rodata_bytes.into(),
-                alignment: 1,
-                executable: false,
-                writable: false,
-            },
+            alignment: 1,
+            executable: false,
+            writable: false,
             atoms: rodata_atoms.into(),
         },
         CodegenSection {
             kind: SectionKind::Data,
-            contents: empty.clone(),
+            alignment: 1,
+            executable: false,
+            writable: true,
             atoms: Arc::from([]),
         },
         CodegenSection {
             kind: SectionKind::Bss,
-            contents: empty,
+            alignment: 1,
+            executable: false,
+            writable: true,
             atoms: Arc::from([]),
         },
     ]
     .into();
-    let content_fingerprint = {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        product_fingerprint(&record.codegen.defined_symbol, &product.machine_code)
-            .hash(&mut hasher);
-        sections.hash(&mut hasher);
-        hasher.finish()
-    };
-    let presentation: Arc<str> = Arc::from(format!("{:?}", product.artifacts));
-    let presentation_fingerprint = {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        presentation.hash(&mut hasher);
-        hasher.finish()
-    };
+    let content_fingerprint =
+        content_fingerprint(&record.codegen.defined_symbol, &sections, &relocations);
     Ok(QueryOutput::success(CodegenUnitValue::Available(Arc::new(
         CodegenUnit {
             defined_symbol: record.codegen.defined_symbol.clone(),
-            referenced_symbols,
             relocations,
             sections,
-            artifacts: product.artifacts,
+            artifacts,
             content_fingerprint,
-            presentation_fingerprint,
-            presentation,
         },
     ))))
 }
@@ -641,21 +560,97 @@ mod tests {
     use super::*;
 
     #[test]
-    fn presentation_fingerprint_prevents_stale_projection_reuse() {
+    fn backend_artifacts_participate_in_exact_unit_equality() {
         let empty: Arc<[CodegenSection]> = Arc::from([]);
-        let unit = |presentation_fingerprint| CodegenUnit {
+        let unit = |artifacts| CodegenUnit {
             defined_symbol: Arc::from("main"),
-            referenced_symbols: Arc::from([]),
             relocations: Arc::from([]),
             sections: empty.clone(),
-            artifacts: rue_codegen::BackendArtifacts::default(),
+            artifacts,
             content_fingerprint: 1,
-            presentation_fingerprint,
-            presentation: Arc::from("presentation"),
         };
         assert!(!codegen_unit_value_equal(
-            &CodegenUnitValue::Available(Arc::new(unit(1))),
-            &CodegenUnitValue::Available(Arc::new(unit(2))),
+            &CodegenUnitValue::Available(Arc::new(unit(rue_codegen::BackendArtifacts {
+                mir: Some("one".into()),
+                ..Default::default()
+            },))),
+            &CodegenUnitValue::Available(Arc::new(unit(rue_codegen::BackendArtifacts {
+                mir: Some("two".into()),
+                ..Default::default()
+            },))),
         ));
+    }
+
+    #[test]
+    fn codegen_unit_retained_charge_counts_canonical_bytes_once() {
+        let text = Arc::<[u8]>::from(*b"abc");
+        let rodata =
+            Arc::<[Arc<[u8]>]>::from([Arc::<[u8]>::from(*b"xy"), Arc::<[u8]>::from(*b"xyz")]);
+        let sections: Arc<[CodegenSection]> = vec![
+            CodegenSection {
+                kind: SectionKind::Text,
+                alignment: 16,
+                executable: true,
+                writable: false,
+                atoms: Arc::from([text]),
+            },
+            CodegenSection {
+                kind: SectionKind::Rodata,
+                alignment: 1,
+                executable: false,
+                writable: false,
+                atoms: rodata,
+            },
+            CodegenSection {
+                kind: SectionKind::Data,
+                alignment: 1,
+                executable: false,
+                writable: true,
+                atoms: Arc::from([]),
+            },
+            CodegenSection {
+                kind: SectionKind::Bss,
+                alignment: 1,
+                executable: false,
+                writable: true,
+                atoms: Arc::from([]),
+            },
+        ]
+        .into();
+        let unit = CodegenUnit {
+            defined_symbol: Arc::from("main"),
+            relocations: Arc::from([
+                NormalizedRelocation {
+                    offset: 1,
+                    symbol: Arc::from("a"),
+                    kind: rue_codegen::RelocationKind::X86Pc32,
+                    addend: 0,
+                },
+                NormalizedRelocation {
+                    offset: 2,
+                    symbol: Arc::from("bb"),
+                    kind: rue_codegen::RelocationKind::X86Plt32,
+                    addend: -4,
+                },
+            ]),
+            sections,
+            artifacts: rue_codegen::BackendArtifacts {
+                mir: Some("mir".to_owned()),
+                ..Default::default()
+            },
+            content_fingerprint: 0,
+        };
+        let expected = 4 * std::mem::size_of::<CodegenSection>()
+            + std::mem::size_of::<Arc<[u8]>>()
+            + 3
+            + 2 * std::mem::size_of::<Arc<[u8]>>()
+            + 2
+            + 3
+            + 2 * std::mem::size_of::<NormalizedRelocation>()
+            + "main".len()
+            + "a".len()
+            + "bb".len()
+            + 3;
+        assert_eq!(unit.retained_charge(), expected as u64);
     }
 }

--- a/crates/rue-compiler/src/object_query.rs
+++ b/crates/rue-compiler/src/object_query.rs
@@ -209,7 +209,7 @@ pub(crate) fn evaluate_object_projection(
         return Ok(object_failure(errors.clone()));
     };
     context.record_work(rue_query::WorkItem::new("object.projection.attempts", 1));
-    let value = match crate::backend::project_backend_object(unit.backend_product(), key.target) {
+    let value = match crate::backend::project_backend_object(unit, key.target) {
         Ok(bytes) => {
             ObjectProjectionValue::Available(Arc::new(ObjectProjection::from_bytes(bytes)))
         }

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -1246,10 +1246,7 @@ mod tests {
         let options = CompileOptions::default();
         let run = |workers| {
             let mut session = CompilerSession::with_query_concurrency(workers);
-            session
-                .update_for_presentation(&snapshot)
-                .into_result()
-                .unwrap();
+            crate::test_support::publish_test_snapshot(&mut session, &snapshot).unwrap();
             crate::queries::compile_with_session(&mut session, &snapshot, &options).unwrap()
         };
 
@@ -1613,10 +1610,7 @@ mod tests {
         let canonical_objects = cold
             .units
             .iter()
-            .map(|unit| {
-                crate::backend::project_backend_object(unit.unit.backend_product(), options.target)
-                    .unwrap()
-            })
+            .map(|unit| crate::backend::project_backend_object(&unit.unit, options.target).unwrap())
             .collect::<Vec<_>>();
         let cold_image = crate::program_image_plan::ProgramImage::from_rooted(
             cold.objects,
@@ -2084,7 +2078,7 @@ mod tests {
         let snapshot = assembler.snapshot().unwrap();
 
         let options = CompileOptions::default();
-        let (rir, semantic, _) = test_frontend_snapshot(&snapshot, &options)
+        let (_rir, semantic, _) = test_frontend_snapshot(&snapshot, &options)
             .expect("qualified and aliased canonical StrBuf references should compile");
         assert!(semantic.type_pools().any(|pool| {
             pool.all_struct_ids()
@@ -2103,17 +2097,18 @@ mod tests {
                 target,
                 ..Default::default()
             };
-            let interner = rir.semantic_symbols().interner();
-            let foreign_symbols = crate::backend::collect_foreign_symbols(rir.rir(), interner);
-            crate::backend::generate_backend_products(
-                semantic.functions(),
-                &options,
-                &foreign_symbols,
-                rue_codegen::BackendArtifactRequest::default(),
-            )
-            .unwrap_or_else(|error| {
-                panic!("canonical source StrBuf functions should lower for {target}: {error}")
-            });
+            let mut session = crate::CompilerSession::new();
+            crate::test_support::publish_test_snapshot(&mut session, &snapshot).unwrap();
+            let semantic = session.rooted_cfg(&options).unwrap();
+            session
+                .codegen_units(
+                    &semantic,
+                    &options,
+                    rue_codegen::BackendArtifactRequest::default(),
+                )
+                .unwrap_or_else(|error| {
+                    panic!("canonical source StrBuf functions should lower for {target}: {error}")
+                });
         }
     }
 

--- a/crates/rue-compiler/src/program_image_plan.rs
+++ b/crates/rue-compiler/src/program_image_plan.rs
@@ -247,14 +247,15 @@ impl ProgramImage {
         let objects = units
             .into_iter()
             .map(|collected| {
-                backend::project_backend_object(collected.unit.backend_product(), options.target)
-                    .map(|bytes| CollectedObjectProjection {
+                backend::project_backend_object(&collected.unit, options.target).map(|bytes| {
+                    CollectedObjectProjection {
                         function: collected.function,
                         unit: collected.unit,
                         object: std::sync::Arc::new(
                             crate::object_query::ObjectProjection::from_bytes(bytes),
                         ),
-                    })
+                    }
+                })
             })
             .collect::<Result<Vec<_>, _>>()
             .map_err(CompileErrors::from)?;
@@ -429,7 +430,8 @@ impl ProgramImagePlan {
         required_runtime_symbols.insert(entry_point.to_owned());
         required_runtime_symbols.insert(rue_runtime_abi::RUNTIME_ABI_VERSION_SYMBOL.to_owned());
         for unit in units {
-            for symbol in unit.referenced_symbols.iter() {
+            for relocation in unit.relocations.iter() {
+                let symbol = &relocation.symbol;
                 if rue_runtime_abi::classify_export(symbol).is_some() {
                     required_runtime_symbols.insert(symbol.to_string());
                 }
@@ -714,33 +716,6 @@ mod tests {
                 .map(ToString::to_string)
                 .collect(),
         )
-    }
-
-    fn old_objects_for(source: &str, target: Target) -> Vec<Vec<u8>> {
-        let snapshot = crate::SourceSnapshot::single("main.rue", source).unwrap();
-        let options = CompileOptions {
-            target,
-            ..CompileOptions::default()
-        };
-        let mut session = crate::CompilerSession::new();
-        crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
-        let rir = session.canonical_rir().unwrap();
-        let semantic = session.rooted_cfg(&options).unwrap();
-        let exports = backend::collect_export_symbols(rir.rir(), rir.semantic_symbols().interner());
-        let products = session
-            .codegen_products(
-                &semantic,
-                &options,
-                rue_codegen::BackendArtifactRequest::default(),
-            )
-            .unwrap();
-        backend::generate_pre_link_objects_from_products(
-            semantic.functions(),
-            products,
-            &options,
-            &exports,
-        )
-        .unwrap()
     }
 
     #[test]
@@ -1116,75 +1091,5 @@ mod tests {
                 .iter()
                 .all(|(_, execution)| *execution == rue_query::RequestExecution::Reused)
         );
-    }
-
-    #[test]
-    fn fresh_adapter_matches_the_prior_object_projection_on_every_target() {
-        let source = "fn callee() -> i32 { 7 } fn main() -> i32 { callee() }";
-        let snapshot = crate::SourceSnapshot::single("main.rue", source).unwrap();
-        for target in [
-            Target::X86_64Linux,
-            Target::Aarch64Linux,
-            Target::Aarch64Macos,
-        ] {
-            let options = CompileOptions {
-                target,
-                ..CompileOptions::default()
-            };
-            let mut session = crate::CompilerSession::new();
-            crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
-            let rooted = session
-                .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
-                .unwrap();
-            let image =
-                ProgramImage::from_rooted(rooted.objects, rooted.exports, &options).unwrap();
-            assert_eq!(
-                image.fresh_objects(&options).unwrap(),
-                old_objects_for(source, target),
-                "{target:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn fresh_adapter_matches_the_prior_host_executable() {
-        let source = "fn callee() -> i32 { 7 } fn main() -> i32 { callee() }";
-        let target = Target::host().unwrap();
-        let snapshot = crate::SourceSnapshot::single("main.rue", source).unwrap();
-        let options = CompileOptions {
-            target,
-            ..CompileOptions::default()
-        };
-
-        let mut old_session = crate::CompilerSession::new();
-        crate::publish_test_snapshot(&mut old_session, &snapshot).unwrap();
-        let old_rir = old_session.canonical_rir().unwrap();
-        let old_semantic = old_session.rooted_cfg(&options).unwrap();
-        let old_exports =
-            backend::collect_export_symbols(old_rir.rir(), old_rir.semantic_symbols().interner());
-        let old = backend::compile_backend_products(
-            old_semantic.functions(),
-            old_session
-                .codegen_products(
-                    &old_semantic,
-                    &options,
-                    rue_codegen::BackendArtifactRequest::default(),
-                )
-                .unwrap(),
-            &options,
-            old_semantic.warnings(),
-            &old_exports,
-        )
-        .unwrap();
-
-        let mut fresh_session = crate::CompilerSession::new();
-        crate::publish_test_snapshot(&mut fresh_session, &snapshot).unwrap();
-        let rooted = fresh_session
-            .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
-            .unwrap();
-        let image = ProgramImage::from_rooted(rooted.objects, rooted.exports, &options).unwrap();
-        let fresh = image.fresh_link(&options, &rooted.warnings).unwrap();
-        assert_eq!(fresh.elf, old.elf);
-        assert_eq!(fresh.warnings, old.warnings);
     }
 }

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -5692,24 +5692,6 @@ impl CompilerSession {
         })
     }
 
-    /// Collect the canonical per-function backend terminals for one semantic
-    /// result. This is deliberately a deterministic adapter: `CodegenUnit`
-    /// owns lowering, allocation, scheduling, emission, and requested
-    /// presentation projections; callers only order and project terminals.
-    #[cfg(test)]
-    pub(crate) fn codegen_products(
-        &mut self,
-        semantic: &RootedCfgOutput,
-        options: &crate::CompileOptions,
-        request: rue_codegen::BackendArtifactRequest,
-    ) -> Result<Vec<crate::backend::FunctionBackendProduct>, crate::CompileErrors> {
-        Ok(self
-            .codegen_units(semantic, options, request)?
-            .into_iter()
-            .map(|collected| collected.unit.backend_product())
-            .collect())
-    }
-
     /// Collect reached canonical codegen terminals for tests which inspect the
     /// pre-object boundary. Production object and link consumers use
     /// `rooted_codegen`'s query-native image root; this adapter enumerates the
@@ -11315,7 +11297,7 @@ fn main() -> i32 {
     }
 
     #[test]
-    fn owned_codegen_domains_preserve_named_and_anonymous_bytes_on_both_architectures() {
+    fn canonical_codegen_units_preserve_named_and_anonymous_bytes_on_both_architectures() {
         let source = SourceSnapshot::single(
             "main.rue",
             "fn add(left: i32, right: i32) -> i32 { left + right }\n\
@@ -11344,38 +11326,20 @@ fn main() -> i32 {
             let mut session = CompilerSession::new();
             session.update(&source).into_result().unwrap();
             let semantic = session.rooted_cfg(&options).unwrap();
-            let rir = session.canonical_rir().unwrap();
-            let foreign = crate::backend::collect_foreign_symbols(
-                rir.rir(),
-                rir.semantic_symbols().interner(),
-            );
-            let owned = session
+            let units = session
                 .codegen_units(
                     &semantic,
                     &options,
                     rue_codegen::BackendArtifactRequest::default(),
                 )
-                .unwrap()
-                .into_iter()
-                .map(|unit| unit.unit.backend_product())
-                .collect::<Vec<_>>();
-            let legacy = crate::backend::generate_backend_products(
-                semantic.functions(),
-                &options,
-                &foreign,
-                rue_codegen::BackendArtifactRequest::default(),
-            )
-            .unwrap();
-            assert_eq!(owned.len(), legacy.len());
-            for (owned, legacy) in owned.iter().zip(&legacy) {
-                assert_eq!(owned.machine_name, legacy.machine_name);
-                assert_eq!(owned.machine_code.code, legacy.machine_code.code);
-                assert_eq!(owned.machine_code.strings, legacy.machine_code.strings);
-                assert_eq!(
-                    format!("{:?}", owned.machine_code.relocations),
-                    format!("{:?}", legacy.machine_code.relocations)
-                );
-            }
+                .unwrap();
+            assert!(!units.is_empty());
+            assert!(units.iter().all(|unit| {
+                unit.unit
+                    .sections
+                    .iter()
+                    .any(|section| section.kind == crate::codegen_query::SectionKind::Text)
+            }));
         }
     }
 

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -892,66 +892,69 @@ impl crate::CompilerSession {
                     let rooted = self.rooted_codegen(request.options, backend_request)?;
                     warnings = rooted.warnings;
                     for collected in rooted.units {
-                        let product = collected.unit.backend_product();
+                        let unit = collected.unit;
                         match stage {
                             PresentationStage::Lowering => {
                                 write!(
                                     &mut text,
                                     "{}",
-                                    product
-                                        .artifacts
+                                    unit.artifacts
                                         .lowering
+                                        .as_ref()
                                         .expect("lowering projection was requested")
                                 )
                                 .expect("write to String");
                             }
                             PresentationStage::Mir => {
-                                writeln!(&mut text, "function {}:", product.machine_name)
+                                writeln!(&mut text, "function {}:", unit.defined_symbol)
                                     .expect("write to String");
                                 writeln!(
                                     &mut text,
                                     "{}",
-                                    product.artifacts.mir.expect("MIR projection was requested")
+                                    unit.artifacts
+                                        .mir
+                                        .as_deref()
+                                        .expect("MIR projection was requested")
                                 )
                                 .expect("write to String");
                             }
                             PresentationStage::Liveness => {
-                                writeln!(&mut text, "function {}:", product.machine_name)
+                                writeln!(&mut text, "function {}:", unit.defined_symbol)
                                     .expect("write to String");
                                 writeln!(
                                     &mut text,
                                     "{}",
-                                    product
-                                        .artifacts
+                                    unit.artifacts
                                         .liveness
+                                        .as_deref()
                                         .expect("liveness projection was requested")
                                 )
                                 .expect("write to String");
                             }
                             PresentationStage::RegAlloc => {
-                                writeln!(&mut text, "function {}:", product.machine_name)
+                                writeln!(&mut text, "function {}:", unit.defined_symbol)
                                     .expect("write to String");
                                 write!(
                                     &mut text,
                                     "{}",
-                                    product
-                                        .artifacts
+                                    unit.artifacts
                                         .regalloc
+                                        .as_deref()
                                         .expect("regalloc projection was requested")
                                 )
                                 .expect("write to String");
                             }
                             PresentationStage::Asm => {
-                                writeln!(&mut text, ".globl {}", product.machine_name)
+                                writeln!(&mut text, ".globl {}", unit.defined_symbol)
                                     .expect("write to String");
-                                writeln!(&mut text, "{}:", product.machine_name)
+                                writeln!(&mut text, "{}:", unit.defined_symbol)
                                     .expect("write to String");
                                 write!(
                                     &mut text,
                                     "{}",
-                                    product
-                                        .artifacts
+                                    unit.artifacts
                                         .asm
+                                        .as_deref()
                                         .expect("assembly projection was requested")
                                 )
                                 .expect("write to String");
@@ -1021,58 +1024,63 @@ mod codegen_unit_tests {
     #[test]
     fn codegen_presentation_is_available_before_and_after_normal_codegen() {
         let snapshot = crate::SourceSnapshot::single("main.rue", "fn main() -> i32 { 7 }").unwrap();
+        let edited = crate::SourceSnapshot::single(
+            "main.rue",
+            "fn main() -> i32 { let value = 7; value + value }",
+        )
+        .unwrap();
         let options = crate::CompileOptions::default();
-        let order = snapshot
-            .files()
-            .map(|file| file.file_id)
-            .collect::<Vec<_>>();
-        let mut first_emit = crate::CompilerSession::new();
-        crate::publish_test_snapshot(&mut first_emit, &snapshot).unwrap();
-        let emitted_first = first_emit
-            .unstable_present(PresentationRequest {
-                stage: PresentationStage::Asm,
-                options: &options,
-                file_order: &order,
-            })
-            .unwrap();
-        let semantic = first_emit.rooted_cfg(&options).unwrap();
-        first_emit
-            .codegen_products(
-                &semantic,
-                &options,
-                rue_codegen::BackendArtifactRequest::default(),
-            )
-            .unwrap();
-        let emitted_after = first_emit
-            .unstable_present(PresentationRequest {
-                stage: PresentationStage::Asm,
-                options: &options,
-                file_order: &order,
-            })
-            .unwrap();
-        assert_eq!(emitted_first.text, emitted_after.text);
-
-        let mut first_link = crate::CompilerSession::new();
-        crate::publish_test_snapshot(&mut first_link, &snapshot).unwrap();
-        let semantic = first_link.rooted_cfg(&options).unwrap();
-        first_link
-            .codegen_products(
-                &semantic,
-                &options,
-                rue_codegen::BackendArtifactRequest::default(),
-            )
-            .unwrap();
-        assert_eq!(
-            emitted_first.text,
-            first_link
+        for stage in [
+            PresentationStage::Lowering,
+            PresentationStage::Mir,
+            PresentationStage::Liveness,
+            PresentationStage::RegAlloc,
+            PresentationStage::Asm,
+        ] {
+            let order = snapshot
+                .files()
+                .map(|file| file.file_id)
+                .collect::<Vec<_>>();
+            let mut session = crate::CompilerSession::new();
+            crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
+            let before = session
                 .unstable_present(PresentationRequest {
-                    stage: PresentationStage::Asm,
+                    stage,
                     options: &options,
-                    file_order: &order
+                    file_order: &order,
                 })
-                .unwrap()
-                .text
-        );
+                .unwrap();
+            let semantic = session.rooted_cfg(&options).unwrap();
+            session
+                .codegen_units(
+                    &semantic,
+                    &options,
+                    rue_codegen::BackendArtifactRequest::default(),
+                )
+                .unwrap();
+            let after = session
+                .unstable_present(PresentationRequest {
+                    stage,
+                    options: &options,
+                    file_order: &order,
+                })
+                .unwrap();
+            assert_eq!(before.text, after.text, "{stage:?}");
+
+            session
+                .update_for_presentation(&edited)
+                .into_result()
+                .unwrap();
+            let edited_order = edited.files().map(|file| file.file_id).collect::<Vec<_>>();
+            let after_edit = session
+                .unstable_present(PresentationRequest {
+                    stage,
+                    options: &options,
+                    file_order: &edited_order,
+                })
+                .unwrap();
+            assert_ne!(after.text, after_edit.text, "{stage:?} edit was stale");
+        }
     }
 
     #[test]
@@ -1084,7 +1092,7 @@ mod codegen_unit_tests {
         let semantic = session.rooted_cfg(&options).unwrap();
         let errors = crate::codegen_query::with_test_codegen_failure_injection(|| {
             session
-                .codegen_products(
+                .codegen_units(
                     &semantic,
                     &options,
                     rue_codegen::BackendArtifactRequest::default(),
@@ -1165,7 +1173,7 @@ mod codegen_unit_tests {
         crate::publish_test_snapshot(&mut session, &first).unwrap();
         let semantic = session.rooted_cfg(&options).unwrap();
         let before = session
-            .codegen_products(
+            .codegen_units(
                 &semantic,
                 &options,
                 rue_codegen::BackendArtifactRequest::default(),
@@ -1178,15 +1186,15 @@ mod codegen_unit_tests {
         );
         let caller = before
             .iter()
-            .find(|product| product.machine_name == "main")
+            .find(|product| product.unit.defined_symbol.as_ref() == "main")
             .unwrap()
-            .machine_code
-            .code
-            .clone();
+            .unit
+            .text_atom()
+            .unwrap();
         crate::publish_test_snapshot(&mut session, &second).unwrap();
         let semantic = session.rooted_cfg(&options).unwrap();
         let after = session
-            .codegen_products(
+            .codegen_units(
                 &semantic,
                 &options,
                 rue_codegen::BackendArtifactRequest::default(),
@@ -1204,10 +1212,11 @@ mod codegen_unit_tests {
             caller,
             after
                 .iter()
-                .find(|product| product.machine_name == "main")
+                .find(|product| product.unit.defined_symbol.as_ref() == "main")
                 .unwrap()
-                .machine_code
-                .code
+                .unit
+                .text_atom()
+                .unwrap()
         );
     }
 
@@ -1281,7 +1290,7 @@ mod codegen_unit_tests {
         session.update(&source(7)).into_result().unwrap();
         let semantic = session.rooted_cfg(&options).unwrap();
         let cold = session
-            .codegen_products(
+            .codegen_units(
                 &semantic,
                 &options,
                 rue_codegen::BackendArtifactRequest::default(),
@@ -1290,7 +1299,7 @@ mod codegen_unit_tests {
         assert_eq!(cold.len(), 2, "accessors have no out-of-line ABI unit");
         assert!(
             cold.iter()
-                .all(|unit| !unit.machine_name.contains(".value"))
+                .all(|unit| !unit.unit.defined_symbol.contains(".value"))
         );
         let cold_rooted = session.rooted_cfg(&options).unwrap();
         let cold_helper_key = cold_rooted
@@ -1335,7 +1344,7 @@ mod codegen_unit_tests {
         }));
         let semantic = session.rooted_cfg(&options).unwrap();
         let warm = session
-            .codegen_products(
+            .codegen_units(
                 &semantic,
                 &options,
                 rue_codegen::BackendArtifactRequest::default(),
@@ -1345,7 +1354,7 @@ mod codegen_unit_tests {
         fresh.update(&source(8)).into_result().unwrap();
         let semantic = fresh.rooted_cfg(&options).unwrap();
         let fresh = fresh
-            .codegen_products(
+            .codegen_units(
                 &semantic,
                 &options,
                 rue_codegen::BackendArtifactRequest::default(),
@@ -1353,11 +1362,21 @@ mod codegen_unit_tests {
             .unwrap();
         let warm = warm
             .iter()
-            .map(|product| (&product.machine_name, &product.machine_code.code))
+            .map(|product| {
+                (
+                    &product.unit.defined_symbol,
+                    product.unit.text_atom().unwrap(),
+                )
+            })
             .collect::<Vec<_>>();
         let fresh = fresh
             .iter()
-            .map(|product| (&product.machine_name, &product.machine_code.code))
+            .map(|product| {
+                (
+                    &product.unit.defined_symbol,
+                    product.unit.text_atom().unwrap(),
+                )
+            })
             .collect::<Vec<_>>();
         assert_eq!(warm, fresh);
     }
@@ -1409,14 +1428,14 @@ mod codegen_unit_tests {
             crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
             let semantic = session.rooted_cfg(&options).unwrap();
             let first = session
-                .codegen_products(
+                .codegen_units(
                     &semantic,
                     &options,
                     rue_codegen::BackendArtifactRequest::default(),
                 )
                 .unwrap();
             let second = session
-                .codegen_products(
+                .codegen_units(
                     &semantic,
                     &options,
                     rue_codegen::BackendArtifactRequest::default(),
@@ -1425,24 +1444,18 @@ mod codegen_unit_tests {
             assert_eq!(
                 first
                     .iter()
-                    .map(|product| (
-                        &product.machine_code.code,
-                        &product.machine_code.relocations
-                    ))
+                    .map(|product| (product.unit.text_atom().unwrap(), &product.unit.relocations))
                     .collect::<Vec<_>>(),
                 second
                     .iter()
-                    .map(|product| (
-                        &product.machine_code.code,
-                        &product.machine_code.relocations
-                    ))
+                    .map(|product| (product.unit.text_atom().unwrap(), &product.unit.relocations))
                     .collect::<Vec<_>>()
             );
             let relocs = &first
                 .iter()
-                .find(|product| product.machine_name == "main")
+                .find(|product| product.unit.defined_symbol.as_ref() == "main")
                 .unwrap()
-                .machine_code
+                .unit
                 .relocations;
             assert!(relocs.iter().any(|relocation| matches!(
                 (target.arch(), relocation.kind),
@@ -1469,8 +1482,8 @@ mod codegen_unit_tests {
             let mut session = crate::CompilerSession::with_query_concurrency(workers);
             crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
             let semantic = session.rooted_cfg(&options).unwrap();
-            let products = session
-                .codegen_products(
+            let units = session
+                .codegen_units(
                     &semantic,
                     &options,
                     rue_codegen::BackendArtifactRequest {
@@ -1479,18 +1492,24 @@ mod codegen_unit_tests {
                     },
                 )
                 .unwrap();
-            let units = products
+            let unit_identity = units
                 .iter()
-                .map(|product| format!("{:?}", product))
+                .map(|unit| {
+                    (
+                        unit.unit.defined_symbol.clone(),
+                        unit.unit.content_fingerprint,
+                        unit.unit.sections.clone(),
+                        unit.unit.relocations.clone(),
+                    )
+                })
                 .collect::<Vec<_>>();
-            let objects = crate::backend::generate_pre_link_objects_from_products(
-                semantic.functions(),
-                products,
-                &options,
-                &[],
-            )
-            .unwrap();
-            (units, objects)
+            let objects = units
+                .iter()
+                .map(|unit| {
+                    crate::backend::project_backend_object(&unit.unit, options.target).unwrap()
+                })
+                .collect::<Vec<_>>();
+            (unit_identity, objects)
         };
         assert_eq!(run(1), run(4));
     }
@@ -1513,7 +1532,7 @@ mod codegen_unit_tests {
             .defined_symbol
             .to_string();
         let before = session
-            .codegen_products(
+            .codegen_units(
                 &semantic,
                 &options,
                 rue_codegen::BackendArtifactRequest::default(),
@@ -1521,18 +1540,18 @@ mod codegen_unit_tests {
             .unwrap();
         let consume_before = before
             .iter()
-            .find(|product| product.machine_name == consume_name)
+            .find(|product| product.unit.defined_symbol.as_ref() == consume_name)
             .map(|product| {
                 (
-                    product.machine_code.code.clone(),
-                    product.machine_code.relocations.clone(),
+                    product.unit.text_atom().unwrap().to_vec(),
+                    product.unit.relocations.clone(),
                 )
             })
             .unwrap();
         crate::publish_test_snapshot(&mut session, &second).unwrap();
         let semantic = session.rooted_cfg(&options).unwrap();
         let after = session
-            .codegen_products(
+            .codegen_units(
                 &semantic,
                 &options,
                 rue_codegen::BackendArtifactRequest::default(),
@@ -1540,11 +1559,11 @@ mod codegen_unit_tests {
             .unwrap();
         let consume_after = after
             .iter()
-            .find(|product| product.machine_name == consume_name)
+            .find(|product| product.unit.defined_symbol.as_ref() == consume_name)
             .map(|product| {
                 (
-                    product.machine_code.code.clone(),
-                    product.machine_code.relocations.clone(),
+                    product.unit.text_atom().unwrap().to_vec(),
+                    product.unit.relocations.clone(),
                 )
             })
             .unwrap();

--- a/docs/notes/adr-0071-horizontal-vertical-ownership-reaudit.md
+++ b/docs/notes/adr-0071-horizontal-vertical-ownership-reaudit.md
@@ -25,23 +25,24 @@ The re-audit found two real appendices and one retention question:
    were two traversals of the same boundary. This patch removes the parallel
    body walk: the issuing AIR and its admitted identity mappings now own the
    projection.
-2. `CodegenUnit` normalizes machine code into sections, atoms, relocations, and
-   symbols, but object generation reconstructs an owned legacy
-   `FunctionBackendProduct` from those fields. Ordinary codegen also retains
-   flattened and atomized rodata simultaneously and eagerly formats backend
-   presentation text. The terminal should own one link-ready representation,
-   while object and presentation consumers borrow thin views.
+2. `CodegenUnit` normalized machine code into sections, atoms, relocations, and
+   symbols, but object generation reconstructed an owned legacy
+   `FunctionBackendProduct` from those fields. Ordinary codegen also retained
+   flattened and atomized rodata simultaneously and eagerly formatted backend
+   presentation text. This appendix is now complete: the terminal owns one
+   link-ready representation, while object and presentation consumers borrow
+   thin views.
 3. The optimized `CfgRecord` retains the unoptimized record's AIR and other
    presentation domains even though ordinary codegen consumes CFG/type/codegen
    domains. This is a plausible memory appendix, but it needs retained-size and
    eviction evidence before changing the query boundary.
 
-The first item is completed below without changing the query graph, phase
-ownership, or invalidation. Its paired clock and memory result was neutral, so
-it is an ownership and maintenance improvement rather than a claimed speedup.
-The second is the strongest remaining cleanup, although its measured object
-serialization time is modest. The third is measurement work, not yet an
-authorized representation change.
+The first two items are completed below without changing the query graph, phase
+ownership, or invalidation. The paired AIR clock and memory result was neutral,
+so it is an ownership and maintenance improvement rather than a claimed
+speedup. The CodegenUnit cleanup likewise has no post-change performance claim
+until the coordinator supplies a measurement. The third is measurement work,
+not yet an authorized representation change.
 
 ## Current vertical map
 
@@ -52,10 +53,10 @@ authorized representation change.
 | candidate RIR | `compiler.declaration-body-plan-artifacts` | one packed, candidate-local, file-independent RIR envelope | One candidate AstGen owner. Normal compilation demands reached candidates; whole-RIR presentation composes the same candidates. |
 | declaration semantics | `compiler.semantic-nucleus` and exact type/layout/ABI/drop-glue queries | stable definition/type/function keys and immutable fact payloads | Shared payload work is now effective; provider materialization is 97.2% shared on Lattice. |
 | body semantics | `compiler.body-transaction` | immutable stable semantic body plus exact dependency observations | Per-body scheduling is conventional and independently invalidated. No normal source reparse or alternate semantic engine. |
-| local AIR and CFG | `compiler.cfg` | a body-local AIR/type/symbol epoch, `CfgDomainProjection`, validated CFG, warnings, and codegen domains | One owner, but the import and projection traversals duplicate boundary work. |
+| local AIR and CFG | `compiler.cfg` | a body-local AIR/type/symbol epoch, `CfgDomainProjection`, validated CFG, warnings, and codegen domains | One owner. AIR is the sole live body representation, and the projection derives from AIR plus its admitted stable identities. |
 | optimized CFG | `compiler.optimized-cfg` | cloned-and-optimized CFG plus Arc-shared local domains | The clone is an immutable-query tradeoff, not a peer optimizer. Retaining AIR through normal backend roots needs measurement. |
 | target backend | `compiler.codegen-unit` | one per-function target-specific lowering, MIR, liveness, allocation, scheduling, emission, and requested artifacts | One target-selected owner. Shared planning modules make x86-64/AArch64 policy explicit without pretending their MIRs are identical. |
-| object generation | `compiler.object-projection` | serialized object bytes | Canonical query boundary, but it currently rebuilds an owned legacy backend product from `CodegenUnit`. |
+| object generation | `compiler.object-projection` | serialized object bytes | Canonical query boundary; it projects borrowed `CodegenUnit` sections, ordered atoms, and relocations into transient linker-builder inputs. |
 | linking | `ProgramImagePlan` and the fresh linker | ordered object bytes and export thunks | Deliberately fresh under ADR-0063. The final owned-byte adapter is not a second codegen path. |
 
 ## Current horizontal map
@@ -79,8 +80,8 @@ The same review across phases found the following owners:
   requests exact layout and drop-glue prerequisites through stable keys.
 - **Presentation:** AST/RIR/AIR/CFG/backend presentation consumes canonical
   artifacts. It does not choose a different compiler. Backend artifact text is
-  nevertheless eagerly formatted inside ordinary `CodegenUnit`, which is an
-  ownership smell rather than a second computation path.
+  retained only when explicitly requested; ordinary `CodegenUnit` values carry
+  typed artifact fields rather than an eager formatted presentation string.
 - **Cancellation and failure:** query cancellation remains distinct from typed
   parse, semantic, RIR, CFG, codegen, and resource failures. Long candidate
   packing/materialization and body work have bounded checkpoints.
@@ -124,9 +125,9 @@ approximately 41.7 ms import had already translated the same instructions,
 types, symbols, and spans. Source review established duplicated boundary
 ownership, although the completed paired experiment below showed that its
 lockstep validation was not the counter's dominant clock cost. By contrast,
-object serialization's 2.8 ms bounds the likely
-clock benefit of the codegen ownership cleanup even though its memory and
-maintainability result may still be worthwhile.
+the recorded object-serialization value is only a pre-cleanup baseline. It
+does not establish a post-cleanup performance result; the coordinator must
+measure the current ownership boundary before reporting one.
 
 ## Comparison with established query compilers
 
@@ -148,11 +149,11 @@ The comparison does not justify collapsing Rue to one IR or one global arena.
   retaining dependency information. Rue implements the corresponding concepts
   with stable keys, explicit terminal leases, and family retention policies.
 
-What is unusual in Rue is therefore not parse→RIR→AIR→CFG→MIR. The
-remaining clear appendix is the normalized-codegen-terminal-to-owned-legacy-
-product reconstruction. The local AIR boundary now follows the conventional
-shape: AIR is the sole live body representation, and CFG derives its relocation
-domain from AIR without consulting a parallel semantic body.
+What is unusual in Rue is therefore not parse→RIR→AIR→CFG→MIR. The local AIR
+boundary now follows the conventional shape: AIR is the sole live body
+representation, and CFG derives its relocation domain from AIR without
+consulting a parallel semantic body. The CodegenUnit object-projection
+appendix is also closed; only measured optimized-CFG retention remains open.
 
 Primary references:
 
@@ -165,8 +166,6 @@ Primary references:
 
 ### Present
 
-- codegen section/atom normalization followed by owned backend-product
-  reconstruction, duplicate rodata forms, and eager presentation formatting;
 - possible presentation-only AIR retention through optimized CFG roots;
 - large but exact layout/drop-glue and query-validation fanout, which needs
   family-level profiling before it is called duplicate work.
@@ -218,17 +217,33 @@ slower. The result is an ownership and maintainability win. It also identifies
 canonical type and callable projection, rather than schema lockstep validation,
 as the remaining measured cost at this boundary.
 
+### CodegenUnit owns the object-generation input
+
+`CodegenUnit` is the canonical typed link-ready terminal: its defined symbol,
+section metadata, ordered text/rodata atoms, normalized relocations, requested
+typed backend artifacts, and content fingerprint are retained exactly once.
+Text is one atom; rodata atom boundaries, order, duplicates, empty values, and
+UTF-8 bytes are preserved. Object projection now accepts `&CodegenUnit`
+directly, validates section shape and target relocation compatibility with
+typed failures, and makes only transient `Vec`/`String` copies required by the
+linker-owned `ObjectBuilder`. Those builder copies are not retained compiler
+shadow state. Runtime-symbol discovery derives from ordered relocations, and
+exact query equality compares all retained typed fields rather than a Debug
+presentation string or hash alone.
+
+Six order-balanced parent/current release Lattice pairs produced the exact same
+1,662,976-byte executable (`45784ce7…9a89e7`). Peak RSS favored the canonical
+terminal by 5,767,168 bytes paired median externally and 5,840,896 bytes in the
+compiler report. Complete-root time was effectively neutral at -0.77 ms paired
+median. Object serialization itself regressed by 1.09 ms paired median because
+the direct projector now validates the typed section contract before borrowing
+its contents. This is therefore a measured retention and ownership win, not a
+wall-time speedup; eliminating the retained aliases does not eliminate the
+linker-owned transient copies or the new fail-closed validation.
+
 ## Ranked next work
 
-### 1. Make `CodegenUnit` the object writer's native input
-
-Move or retain machine bytes exactly once. Let object serialization borrow the
-terminal's text, rodata atoms, and relocations without recreating
-`FunctionBackendProduct`. Do not retain both flattened and atomized rodata
-unless the object format requires both; derive presentation text only for an
-explicit artifact request. Keep one target backend owner and exact output bytes.
-
-### 2. Attribute optimized-CFG retention
+### 1. Attribute optimized-CFG retention
 
 Measure per-family retained bytes for unoptimized CFG, optimized CFG, AIR,
 types, strings, atoms, and codegen domains on Lattice and retained-edit cases.
@@ -236,7 +251,7 @@ Only then decide whether normal optimized roots can omit AIR while explicit AIR
 presentation retains the unoptimized terminal. A split that weakens dependency
 cones or creates a second CFG record builder is rejected.
 
-### 3. Reprofile graph fanout
+### 2. Reprofile graph fanout
 
 After the ownership changes, attribute the 25,141 layout/drop requests and
 283,413 dependency observations by family and critical path. Exact repeated


### PR DESCRIPTION
## Summary

- make the typed `CodegenUnit` the sole compiler-owned input to object projection and backend presentation
- remove the reconstructed `FunctionBackendProduct`, flattened rodata and referenced-symbol aliases, eager Debug presentation state, and the test-only peer backend pipeline
- preserve ordered string atoms and relocations, validate the link-ready section contract fail-closed, and derive runtime-symbol demand from canonical relocations
- add cross-target object-byte, retained-charge, presentation invalidation, malformed-shape, and ownership-inventory coverage

## Why

Object generation rebuilt a second backend product from `CodegenUnit`, while the terminal retained several aliases of the same machine-code facts. Borrowing the canonical typed terminal directly removes a maintenance appendix and about 5.5 MiB of measured peak memory without changing native output.

## Validation

- `scripts/rue fmt`
- focused object projection, retained-charge, presentation, and API-inventory tests
- `scripts/rue quick` (30 targets, 0 failures; compiler 877 passed, 6 ignored)
- `scripts/rue premerge` (194 targets, 0 failures)
- six order-balanced release ThinLTO Lattice pairs: identical 1,662,976-byte output (`45784ce7…9a89e7`); paired-median external RSS -5,767,168 bytes; compiler-reported RSS -5,840,896 bytes; complete-root time -0.77 ms (neutral)

Object serialization itself is +1.09 ms paired median because the direct projector now validates the typed section contract. This is an ownership and memory improvement, not a wall-time speedup.

Relates to RUE-1473