### PR TITLE
RUE-1473: inline saturated adaptive query batches

### DIFF
--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -7788,11 +7788,11 @@ impl QueryContext {
     /// Requests stable-ordered registered dependencies with concurrency-aware
     /// scheduling.
     ///
-    /// A one-permit runtime cannot execute batch siblings concurrently. In
-    /// that regime this keeps every request in the current task, preserving
-    /// the same dependency observations and result order without allocating
-    /// structured children or donating the sole permit. Wider runtimes use the
-    /// ordinary structured batch so independent evaluators can run in parallel.
+    /// When an enclosing batch has already reserved every nested worker slot,
+    /// this keeps every request in the current task, preserving the same
+    /// dependency observations and result order without allocating structured
+    /// children or donating a permit. Otherwise independent evaluators use the
+    /// ordinary structured batch and can run in parallel.
     pub fn query_registered_adaptive_batch<K, V>(
         &self,
         family: &QueryFamily<K, V>,
@@ -7810,12 +7810,46 @@ impl QueryContext {
             return Err(QueryAbort::ForeignRuntime);
         }
         if self.max_concurrency() == 1 {
-            keys.into_iter()
+            return keys
+                .into_iter()
                 .map(|key| self.query_registered(family, key))
-                .collect()
-        } else {
-            self.query_registered_batch(family, keys)
+                .collect();
         }
+        let keys = keys.into_iter().collect::<Vec<_>>();
+        if keys.len() <= 1 {
+            return keys
+                .into_iter()
+                .map(|key| self.query_registered(family, key))
+                .collect();
+        }
+
+        // Reserve the nested batch worker capacity before constructing any
+        // structured-batch state. An enclosing batch owns all of the
+        // `maximum - 1` worker slots while its children run, so a nested
+        // adaptive request would otherwise allocate wait-graph edges, an
+        // authority, and one child task per item despite having no worker to
+        // execute in parallel. A zero-count claim is a race-safe signal to
+        // preserve the same ordered dependency observations in this task.
+        let worker_claim =
+            BatchWorkerClaim::new(self.task.core.clone(), keys.len().saturating_sub(1));
+        if worker_claim.count == 0 {
+            return keys
+                .into_iter()
+                .map(|key| self.query_registered(family, key))
+                .collect();
+        }
+        let items = Arc::new(RegisteredBatchItems {
+            family: family.inner.name.clone(),
+            items: keys
+                .into_iter()
+                .map(|key| RegisteredBatchItem {
+                    request_id: self.task.next_nested_request(),
+                    key,
+                    ready_at: Instant::now(),
+                })
+                .collect(),
+        });
+        self.query_registered_batch_with_claim(family, items, worker_claim)
     }
 
     /// Requests a stable-ordered batch of dependencies through one registered
@@ -7874,6 +7908,24 @@ impl QueryContext {
         if items.items.is_empty() {
             return Ok(Vec::new());
         }
+        let worker_claim =
+            BatchWorkerClaim::new(self.task.core.clone(), items.items.len().saturating_sub(1));
+        self.query_registered_batch_with_claim(family, items, worker_claim)
+    }
+
+    fn query_registered_batch_with_claim<K, V>(
+        &self,
+        family: &QueryFamily<K, V>,
+        items: Arc<RegisteredBatchItems<K>>,
+        worker_claim: BatchWorkerClaim,
+    ) -> Result<Vec<Arc<QueryTerminal<V>>>, QueryAbort>
+    where
+        K: QueryKey,
+        V: Clone + Send + Sync + 'static,
+    {
+        if items.items.is_empty() {
+            return Ok(Vec::new());
+        }
 
         let wait_labels: Arc<dyn StructuredWaitLabels> = items.clone();
         let structured_waits = StructuredWaitGuard::new(
@@ -7887,8 +7939,6 @@ impl QueryContext {
                 .map(|(index, item)| (TaskId(item.request_id), index)),
         )
         .map_err(QueryAbort::Cycle)?;
-        let worker_claim =
-            BatchWorkerClaim::new(self.task.core.clone(), items.items.len().saturating_sub(1));
         let queue = Arc::new(Mutex::new(VecDeque::from_iter(0..items.items.len())));
         let batch_authority = Arc::new(BatchValidationAuthority::new(
             self.task.core.clone(),
@@ -14760,7 +14810,7 @@ mod tests {
     }
 
     #[test]
-    fn adaptive_registered_batch_stays_inline_only_when_parallelism_is_impossible() {
+    fn adaptive_registered_batch_stays_inline_when_parallelism_is_impossible() {
         fn run(workers: usize) -> (Arc<QueryTerminal<u64>>, RuntimeMetrics) {
             let runtime = QueryRuntime::new(workers);
             publish_empty(&runtime, [revision(1)]);
@@ -14814,6 +14864,102 @@ mod tests {
         assert_eq!(serial_metrics.ready_items, 0);
         assert_eq!(parallel_metrics.donated_permits, 1);
         assert_eq!(parallel_metrics.ready_items, 2);
+    }
+
+    #[test]
+    fn adaptive_registered_batch_stays_inline_when_nested_capacity_is_saturated() {
+        fn run(workers: usize) -> (Arc<QueryTerminal<u64>>, RuntimeMetrics) {
+            let runtime = QueryRuntime::new(workers);
+            publish_empty(&runtime, [revision(1)]);
+            let leaves = runtime
+                .family_with_evaluator::<Key, u64, _>("adaptive-saturated-leaf", 8, |_, _, key| {
+                    Ok(QueryOutput::success(key.0.len() as u64))
+                })
+                .unwrap();
+            let leaves_for_middle = leaves.clone();
+            let middle = runtime
+                .family_with_evaluator::<Key, u64, _>(
+                    "adaptive-saturated-middle",
+                    8,
+                    move |context, _, key| {
+                        let leaf_keys = match key.0 {
+                            "m0" => [Key("m0-aa"), Key("m0-bbb")],
+                            "m1" => [Key("m1-aa"), Key("m1-bbb")],
+                            "m2" => [Key("m2-aa"), Key("m2-bbb")],
+                            "m3" => [Key("m3-aa"), Key("m3-bbb")],
+                            _ => unreachable!("test root only requests known middle keys"),
+                        };
+                        let terminals = context
+                            .query_registered_adaptive_batch(&leaves_for_middle, leaf_keys)?;
+                        let sum = terminals
+                            .iter()
+                            .map(|terminal| match terminal.outcome() {
+                                QueryOutcome::Success(value) => *value,
+                                QueryOutcome::Failure(_) => unreachable!("leaf cannot fail"),
+                            })
+                            .sum();
+                        Ok(QueryOutput::success(sum))
+                    },
+                )
+                .unwrap();
+            let middle_for_root = middle.clone();
+            let root = runtime
+                .family_with_evaluator::<Key, u64, _>(
+                    "adaptive-saturated-root",
+                    8,
+                    move |context, _, _| {
+                        let terminals = context.query_registered_adaptive_batch(
+                            &middle_for_root,
+                            [Key("m0"), Key("m1"), Key("m2"), Key("m3")],
+                        )?;
+                        let sum = terminals
+                            .iter()
+                            .map(|terminal| match terminal.outcome() {
+                                QueryOutcome::Success(value) => *value,
+                                QueryOutcome::Failure(_) => unreachable!("middle cannot fail"),
+                            })
+                            .sum();
+                        Ok(QueryOutput::success(sum))
+                    },
+                )
+                .unwrap();
+            let terminal = runtime
+                .request_registered(&root, revision(1), Key("root"), CancellationToken::new())
+                .into_result()
+                .unwrap();
+            let metrics = runtime.metrics();
+            (terminal, metrics)
+        }
+
+        let (serial, serial_metrics) = run(1);
+        let (saturated, saturated_metrics) = run(4);
+        assert_eq!(serial.outcome(), &QueryOutcome::Success(44));
+        assert_eq!(saturated.outcome(), serial.outcome());
+        let stable_dependencies = |terminal: &QueryTerminal<u64>| {
+            terminal
+                .dependencies()
+                .iter()
+                .map(|dependency| {
+                    (
+                        dependency.node.family().to_owned(),
+                        dependency.node.key().to_owned(),
+                        dependency.stamp,
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            stable_dependencies(&saturated),
+            stable_dependencies(&serial)
+        );
+        assert_eq!(saturated.work(), serial.work());
+        // The outer four-item batch consumes all three nested worker slots.
+        // Its four children are therefore the only structured items; each
+        // child's two leaf requests stay ordered in that child task.
+        assert_eq!(saturated_metrics.donated_permits, 1);
+        assert_eq!(saturated_metrics.ready_items, 4);
+        assert_eq!(serial_metrics.donated_permits, 0);
+        assert_eq!(serial_metrics.ready_items, 0);
     }
 
     #[test]

--- a/docs/notes/adr-0071-horizontal-vertical-ownership-reaudit.md
+++ b/docs/notes/adr-0071-horizontal-vertical-ownership-reaudit.md
@@ -17,7 +17,7 @@ production owner for each of those computations. Presentation requests consume
 the same artifacts instead of selecting peer frontends, semantic engines, CFG
 builders, or backends.
 
-The re-audit found two real appendices and one retention question:
+The re-audit found three real appendices and one suspected retention appendix:
 
 1. CFG preparation imported a stable semantic body into a fresh local AIR/type/
    symbol epoch, then immediately walks the new AIR beside the stable body to
@@ -34,15 +34,25 @@ The re-audit found two real appendices and one retention question:
    thin views.
 3. The optimized `CfgRecord` retains the unoptimized record's AIR and other
    presentation domains even though ordinary codegen consumes CFG/type/codegen
-   domains. This is a plausible memory appendix, but it needs retained-size and
-   eviction evidence before changing the query boundary.
+   domains. Attribution showed that these values are Arc-shared with the
+   dependency cone rather than copied, and retained-edit tests reclaimed the
+   superseded generation. Removing the field would save only an Arc and weaken
+   the exact dependency boundary, so this is not an appendix to remove.
+4. Adaptive layout/drop query batches nested under the already-parallel
+   optimized-CFG batch usually had no worker reservation available, but still
+   built structured child tasks, queues, wait edges, and validation authorities
+   for every exact request. The adaptive API now reserves once and executes in
+   the current task when that reservation is saturated. It preserves every
+   exact query edge while removing scheduling work that cannot create
+   parallelism.
 
-The first two items are completed below without changing the query graph, phase
-ownership, or invalidation. The paired AIR clock and memory result was neutral,
-so it is an ownership and maintenance improvement rather than a claimed
-speedup. The CodegenUnit cleanup likewise has no post-change performance claim
-until the coordinator supplies a measurement. The third is measurement work,
-not yet an authorized representation change.
+The first two ownership items and the adaptive scheduling fix are completed
+below without coarsening the query graph, phase ownership, or invalidation. The
+paired AIR clock and memory result was neutral, so it is an ownership and
+maintenance improvement rather than a claimed speedup. The CodegenUnit cleanup
+is a measured retention improvement. Optimized-CFG attribution rejected the
+suspected representation change, while the nested-batch experiment produced a
+material wall-time and queueing improvement.
 
 ## Current vertical map
 
@@ -54,7 +64,7 @@ not yet an authorized representation change.
 | declaration semantics | `compiler.semantic-nucleus` and exact type/layout/ABI/drop-glue queries | stable definition/type/function keys and immutable fact payloads | Shared payload work is now effective; provider materialization is 97.2% shared on Lattice. |
 | body semantics | `compiler.body-transaction` | immutable stable semantic body plus exact dependency observations | Per-body scheduling is conventional and independently invalidated. No normal source reparse or alternate semantic engine. |
 | local AIR and CFG | `compiler.cfg` | a body-local AIR/type/symbol epoch, `CfgDomainProjection`, validated CFG, warnings, and codegen domains | One owner. AIR is the sole live body representation, and the projection derives from AIR plus its admitted stable identities. |
-| optimized CFG | `compiler.optimized-cfg` | cloned-and-optimized CFG plus Arc-shared local domains | The clone is an immutable-query tradeoff, not a peer optimizer. Retaining AIR through normal backend roots needs measurement. |
+| optimized CFG | `compiler.optimized-cfg` | cloned-and-optimized CFG plus Arc-shared local domains | The clone is an immutable-query tradeoff, not a peer optimizer. Attribution confirms that AIR/domain storage is shared with the exact dependency cone. |
 | target backend | `compiler.codegen-unit` | one per-function target-specific lowering, MIR, liveness, allocation, scheduling, emission, and requested artifacts | One target-selected owner. Shared planning modules make x86-64/AArch64 policy explicit without pretending their MIRs are identical. |
 | object generation | `compiler.object-projection` | serialized object bytes | Canonical query boundary; it projects borrowed `CodegenUnit` sections, ordered atoms, and relocations into transient linker-builder inputs. |
 | linking | `ProgramImagePlan` and the fresh linker | ordered object bytes and export thunks | Deliberately fresh under ADR-0063. The final owned-byte adapter is not a second codegen path. |
@@ -86,8 +96,9 @@ The same review across phases found the following owners:
   parse, semantic, RIR, CFG, codegen, and resource failures. Long candidate
   packing/materialization and body work have bounded checkpoints.
 - **Retention:** query families retain immutable values with explicit charges
-  and bounded history. Publication-time interner rescans are gone. The remaining
-  question is whether optimized CFG roots should retain presentation-only AIR.
+  and bounded history. Publication-time interner rescans are gone. Optimized
+  CFG roots Arc-share their AIR/domain values with the exact dependency cone;
+  they do not retain a second physical body representation.
 
 ## Current measurement
 
@@ -153,7 +164,9 @@ What is unusual in Rue is therefore not parse→RIR→AIR→CFG→MIR. The local
 boundary now follows the conventional shape: AIR is the sole live body
 representation, and CFG derives its relocation domain from AIR without
 consulting a parallel semantic body. The CodegenUnit object-projection
-appendix is also closed; only measured optimized-CFG retention remains open.
+appendix is also closed. Optimized-CFG retention is ordinary Arc sharing, and
+the measured query fanout problem was nested scheduling overhead rather than a
+second semantic computation.
 
 Primary references:
 
@@ -166,9 +179,9 @@ Primary references:
 
 ### Present
 
-- possible presentation-only AIR retention through optimized CFG roots;
-- large but exact layout/drop-glue and query-validation fanout, which needs
-  family-level profiling before it is called duplicate work.
+- large exact layout/drop-glue request fanout remains part of CFG invalidation,
+  but saturated nested requests no longer build child-task machinery that
+  cannot run in parallel.
 
 ### Historical and already removed
 
@@ -241,23 +254,51 @@ its contents. This is therefore a measured retention and ownership win, not a
 wall-time speedup; eliminating the retained aliases does not eliminate the
 linker-owned transient copies or the new fail-closed validation.
 
+### Optimized CFG retains shared domains, not a shadow body
+
+Disposable Lattice attribution measured 58,929,825 logical retained bytes
+across 52,605 unoptimized-CFG pins and 36,379,773 bytes across 1,280 optimized
+CFG pins. The optimized records' component accounting included 3,051,356 AIR
+bytes, 3,056,851 optimized-CFG bytes, 13,269,961 domain bytes, 4,306,650 type-
+pool bytes, 1,838,510 interner bytes, and 8,508,519 codegen-domain bytes. Those
+figures are logical reachability charges, not distinct physical allocations:
+the optimized terminal and its exact unoptimized dependency share the same
+Arcs. A retained-edit witness grew and then reclaimed both families' superseded
+generation (`cfg` 6,117→8,988→6,117; `optimized-cfg`
+5,653→8,430→5,653). Removing the AIR/domain fields would therefore save only
+Arc headers while weakening the terminal's self-contained typed boundary. The
+suspected retention appendix is rejected.
+
+### Saturated adaptive batches stay in the current task
+
+The outer optimized-CFG batch normally reserves all nested worker capacity.
+Inner adaptive layout/drop batches were consequently creating structured child
+tasks and donating permits even though they could not recruit another worker.
+`query_registered_adaptive_batch` now preserves the one-worker streaming path,
+atomically reserves wider-runtime capacity once, and runs stable-order exact
+queries in the current task when the reservation is zero. A nonzero reservation
+still uses the structured parallel path, and public exact-batch semantics are
+unchanged.
+
+Six order-balanced parent/current Lattice pairs at four workers produced the
+exact same 1,662,976-byte executable (`45784ce7…9a89e7`). Complete-root time
+improved by 50.81 ms paired median. Ready items fell from 64,720 to 11,174,
+permit donations from 5,362 to 1,542, summed ready wait by 34.72 seconds, and
+maximum ready wait by 49.45 ms; claims were unchanged. Peak RSS increased by
+about 1.88 MB externally and 1.85 MB in the compiler report. Six one-worker
+control pairs preserved identical work and output and favored the change by
+6.12 ms paired median, within run noise; their ready-item and donation counts
+remained zero. This is a scheduling speedup, not eliminated compiler
+computation: all exact layout/drop queries and their invalidation edges remain.
+
 ## Ranked next work
 
-### 1. Attribute optimized-CFG retention
-
-Measure per-family retained bytes for unoptimized CFG, optimized CFG, AIR,
-types, strings, atoms, and codegen domains on Lattice and retained-edit cases.
-Only then decide whether normal optimized roots can omit AIR while explicit AIR
-presentation retains the unoptimized terminal. A split that weakens dependency
-cones or creates a second CFG record builder is rejected.
-
-### 2. Reprofile graph fanout
-
-After the ownership changes, attribute the 25,141 layout/drop requests and
-283,413 dependency observations by family and critical path. Exact repeated
-query requests are often cheap reuse, not duplicate compiler computation. Act
-only on a measured construction, hashing, or validation owner; do not replace
-the query graph with a global mutable cache.
+The ownership and measured query-scheduling appendices identified by this
+re-audit are closed. Further work should start from a fresh profile rather than
+the rejected optimized-CFG split or aggregation of layout/drop facts. Exact
+repeated requests remain necessary invalidation edges; future changes must
+identify a measured computation, representation, or scheduling owner without a
+global cache or coarser body invalidation.
 
 ## Structural falsifiers
 


### PR DESCRIPTION
## What changed

- reserve nested adaptive-batch worker capacity before constructing structured child state
- execute exact stable-order registered queries in the current task when an enclosing batch has saturated that capacity
- preserve the existing one-worker streaming path and the public structured-batch contract
- record the optimized-CFG retention attribution and paired scheduling measurements in the ownership re-audit

## Why

The outer optimized-CFG batch normally reserves all nested worker slots. Its inner layout and drop-glue batches therefore could not recruit another worker, but still created child tasks, queues, wait edges, validation authorities, and permit-donation traffic for every exact request. This change removes that scheduling work without aggregating or deleting any compiler query or invalidation edge.

## Measured impact

Six order-balanced four-worker Lattice pairs produced the identical 1,662,976-byte executable (`45784ce7…9a89e7`):

- root time: **-50.81 ms** paired median
- ready items: **64,720 → 11,174**
- permit donations: **5,362 → 1,542**
- summed ready wait: **-34.72 s**
- maximum ready wait: **-49.45 ms**
- query claims: unchanged
- peak RSS: **about +1.8 MB**

Six one-worker control pairs preserved identical output and deterministic work, with ready items and donations remaining zero; their -6.12 ms paired median was within run noise.

## Validation

- `scripts/rue unit query`: 170/170
- retained Lattice edit matrix and 1,000-revision retention witness
- `scripts/rue quick`
- `scripts/rue premerge`: 194 targets, 0 failures
- independent adversarial source review

Relates to RUE-1473
