### PR TITLE
RUE-1542: read the live epoch, not the whole performance store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -632,8 +632,27 @@ jobs:
           git fetch --no-tags origin trunk
           git fetch --no-tags origin performance-data-v1
           DATA="$(mktemp -d)"
-          git --work-tree="$DATA" checkout origin/performance-data-v1 -- .
+          # Read the live epoch, not the whole store. performance-data-v1 is
+          # append-only and now grows by hundreds of megabytes a day, while
+          # every rule this gate applies is a property of the epoch holding each
+          # platform's newest point — so materializing and parsing the rest was
+          # work proportional to the project's whole history, asked on every
+          # pull request, about its present (RUE-1542).
+          #
+          # index.json carries each record's platform, epoch, and finish time,
+          # so the selection never opens a run object to decide whether to read
+          # it. A missing index.json here is a corrupt branch rather than a
+          # first collection — the fetch above already required the branch to
+          # exist — so this is deliberately not tolerant.
+          git --work-tree="$DATA" checkout origin/performance-data-v1 -- index.json
           git reset --quiet
+          SELECTED="$(mktemp)"
+          "$BENCH" staleness-inputs --index "$DATA/index.json" > "$SELECTED"
+          if [ -s "$SELECTED" ]; then
+            xargs git --work-tree="$DATA" checkout origin/performance-data-v1 -- < "$SELECTED"
+            git reset --quiet
+          fi
+          echo "reading $(wc -l < "$SELECTED") record(s) from the live epoch"
           DERIVED="$(mktemp)"
           "$BENCH" derive \
             --manifest performance/manifest.toml \

--- a/crates/rue-bench/src/main.rs
+++ b/crates/rue-bench/src/main.rs
@@ -28,6 +28,7 @@ mod measure;
 mod pins;
 mod runtime;
 mod scaling;
+mod staleness_inputs;
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -103,6 +104,12 @@ Subcommands:
                        performance-data-v1 checkout; writes derived JSON.
                        --runtime-manifest additionally derives the ADR-0072
                        runtime record kind from the same store.
+
+  staleness-inputs --index <path>
+                       print the data-branch paths the staleness gate reads:
+                       every record of the epoch holding each platform's newest
+                       point. Lets that gate check out and parse the live epoch
+                       instead of the whole append-only history.
 
   check-pins --manifest <path> --compiler <path> [--repo-root <path>]
                        answer whether this tree still matches every collection
@@ -184,6 +191,15 @@ fn main() -> ExitCode {
             Err(message) => {
                 eprintln!("rue-bench runtime: {message}");
                 ExitCode::from(runtime::exit::USAGE)
+            }
+        };
+    }
+    if std::env::args().nth(1).as_deref() == Some("staleness-inputs") {
+        return match staleness_inputs::run() {
+            Ok(()) => ExitCode::from(exit::OK),
+            Err(message) => {
+                eprintln!("rue-bench staleness-inputs: {message}");
+                ExitCode::from(exit::USAGE)
             }
         };
     }

--- a/crates/rue-bench/src/staleness_inputs.rs
+++ b/crates/rue-bench/src/staleness_inputs.rs
@@ -1,0 +1,242 @@
+//! Name the records the staleness gate reads, so it can stop reading the rest.
+//!
+//! `performance-data-v1` is append-only and unbounded — 1.5 GB across 1,188
+//! records on 2026-08-16, growing by roughly 300 MB every day since protocol v2
+//! began retaining per-sample boundary evidence. The staleness gate
+//! materialized and parsed all of it on every pull request, which is work
+//! proportional to the whole history of the project for a question about its
+//! present (RUE-1542).
+//!
+//! The gate reads far less than that. Every rule it applies —
+//! `newest_plotted`, `unindexed`, `unpinned` — is a property of the epoch
+//! holding each platform's newest point, and nothing else. Older epochs are
+//! retired: they keep whatever they published, cannot receive another point,
+//! and cannot become stale.
+//!
+//! So the selection is exactly that: per platform, the epoch its newest point
+//! belongs to, and every record in it. Two properties matter and are tested.
+//!
+//! It is the epoch of the platform's newest point rather than the manifest's
+//! collecting epoch. Those are usually the same, and when they are not, the
+//! difference is a platform whose collection has stopped — the one case the
+//! gate exists to catch. Selecting by manifest would drop such a platform out
+//! of the derived data entirely, and a platform with no points at all is not
+//! stalled by `newest_plotted`'s reckoning: it is absent, which reads as fine.
+//!
+//! And the baseline comes along for free. A ratio is measured against the
+//! epoch's own baseline run, which is a record of that epoch, so selecting the
+//! epoch selects whatever the manifest pins — no separate lookup, and no way
+//! for the gate to lose an index it would otherwise have published.
+//!
+//! The rule reads `index.json`, which already carries each record's platform,
+//! epoch, commit, and finish time. That is what makes this cheap: the
+//! selection never opens a run object to decide whether to read it.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// One `index.json` entry, as `scripts/publish-performance-runs.py` writes it.
+///
+/// Deliberately a subset. This names the fields the selection needs and lets
+/// serde ignore the rest, so a later index field cannot fail the gate.
+#[derive(Debug, Deserialize)]
+struct IndexEntry {
+    platform: String,
+    epoch: u32,
+    finished_at: String,
+    run: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Index {
+    /// Compiler runs (ADR-0067). The `runtime` list is deliberately not read:
+    /// ADR-0072 Decision 9 keeps the runtime series out of this gate.
+    #[serde(default)]
+    runs: Vec<IndexEntry>,
+}
+
+/// Return the data-branch paths the staleness gate needs, in a stable order.
+///
+/// An empty index yields no paths rather than an error: a data branch with
+/// nothing on it is the honest first state of a suite that has not collected,
+/// and the gate reports that as "nothing to stall" rather than failing.
+pub fn select(index_json: &str) -> Result<Vec<String>, String> {
+    let index: Index = serde_json::from_str(index_json)
+        .map_err(|error| format!("could not parse index.json: {error}"))?;
+
+    // The newest entry per platform, and therefore the epoch to keep. Ties on
+    // `finished_at` break on the content address so the choice is a function of
+    // the data rather than of directory order — two runs finishing inside the
+    // same second is ordinary on a fast platform.
+    let mut newest: BTreeMap<&str, &IndexEntry> = BTreeMap::new();
+    for entry in &index.runs {
+        newest
+            .entry(entry.platform.as_str())
+            .and_modify(|current| {
+                if (&entry.finished_at, &entry.run) > (&current.finished_at, &current.run) {
+                    *current = entry;
+                }
+            })
+            .or_insert(entry);
+    }
+
+    let mut paths: Vec<String> = index
+        .runs
+        .iter()
+        .filter(|entry| {
+            newest
+                .get(entry.platform.as_str())
+                .is_some_and(|live| live.epoch == entry.epoch)
+        })
+        .map(|entry| format!("runs/{}.json", entry.run))
+        .collect();
+    paths.sort();
+    paths.dedup();
+    Ok(paths)
+}
+
+pub fn run() -> Result<(), String> {
+    let mut index_path: Option<PathBuf> = None;
+    let mut args = std::env::args().skip(2);
+    while let Some(flag) = args.next() {
+        let mut value = || {
+            args.next()
+                .ok_or_else(|| format!("{flag} requires a value"))
+        };
+        match flag.as_str() {
+            "--index" => index_path = Some(PathBuf::from(value()?)),
+            other => return Err(format!("unrecognized argument {other:?}")),
+        }
+    }
+    let index_path = index_path.ok_or("staleness-inputs requires --index <path>")?;
+    print(&index_path, &mut std::io::stdout())
+}
+
+fn print(index_path: &Path, out: &mut impl std::io::Write) -> Result<(), String> {
+    // A missing index is the empty branch, not a failure: `git checkout` of a
+    // path that does not exist would have failed before reaching here, so this
+    // is the first-collection case rather than a lost file.
+    let text = match std::fs::read_to_string(index_path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(format!("could not read {}: {error}", index_path.display()));
+        }
+    };
+    for path in select(&text)? {
+        writeln!(out, "{path}")
+            .map_err(|error| format!("could not write the selection: {error}"))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn index(entries: &[(&str, u32, &str, &str)]) -> String {
+        let runs: Vec<String> = entries
+            .iter()
+            .map(|(platform, epoch, finished_at, run)| {
+                format!(
+                    "{{\"commit\":\"{}\",\"epoch\":{epoch},\"finished_at\":\"{finished_at}\",\
+                     \"platform\":\"{platform}\",\"run\":\"{run}\",\"suite_revision\":4}}",
+                    "a".repeat(40)
+                )
+            })
+            .collect();
+        format!(
+            "{{\"runs\":[{}],\"runtime\":[],\"schema_version\":2}}",
+            runs.join(",")
+        )
+    }
+
+    #[test]
+    fn only_the_epoch_holding_the_newest_point_is_selected() {
+        let text = index(&[
+            ("x86_64-linux", 5, "2026-08-14T00:00:00Z", "old"),
+            ("x86_64-linux", 6, "2026-08-15T00:00:00Z", "new"),
+            ("x86_64-linux", 6, "2026-08-15T01:00:00Z", "newer"),
+        ]);
+        assert_eq!(
+            select(&text).unwrap(),
+            vec!["runs/new.json".to_string(), "runs/newer.json".to_string()]
+        );
+    }
+
+    #[test]
+    fn every_platform_keeps_its_own_live_epoch() {
+        // Platforms advance independently: one may already be collecting a new
+        // epoch while another is still on the previous one.
+        let text = index(&[
+            ("x86_64-linux", 6, "2026-08-15T00:00:00Z", "x6"),
+            ("aarch64-macos", 5, "2026-08-15T00:00:00Z", "m5"),
+            ("aarch64-macos", 4, "2026-08-01T00:00:00Z", "m4"),
+        ]);
+        assert_eq!(
+            select(&text).unwrap(),
+            vec!["runs/m5.json".to_string(), "runs/x6.json".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_platform_whose_collection_stopped_keeps_the_epoch_it_stopped_in() {
+        // The case that makes this "newest point" rather than "collecting
+        // epoch": x86 has moved on, macOS stopped in epoch 5. Selecting by the
+        // manifest's collecting epoch would drop macOS entirely, and a platform
+        // with no points is not stalled — it is invisible.
+        let text = index(&[
+            ("x86_64-linux", 6, "2026-08-15T00:00:00Z", "x6"),
+            ("aarch64-macos", 5, "2026-07-01T00:00:00Z", "m5"),
+        ]);
+        assert_eq!(
+            select(&text).unwrap(),
+            vec!["runs/m5.json".to_string(), "runs/x6.json".to_string()]
+        );
+    }
+
+    #[test]
+    fn ties_on_the_finish_time_are_broken_by_the_address() {
+        // Two runs finishing in the same second must not make the selection
+        // depend on index order; both are in the same epoch here, so the
+        // selection is the same either way, and that is the point.
+        let text = index(&[
+            ("x86_64-linux", 6, "2026-08-15T00:00:00Z", "b"),
+            ("x86_64-linux", 6, "2026-08-15T00:00:00Z", "a"),
+            ("x86_64-linux", 5, "2026-08-14T00:00:00Z", "old"),
+        ]);
+        assert_eq!(
+            select(&text).unwrap(),
+            vec!["runs/a.json".to_string(), "runs/b.json".to_string()]
+        );
+    }
+
+    #[test]
+    fn an_empty_branch_selects_nothing() {
+        assert!(
+            select("{\"runs\":[],\"runtime\":[],\"schema_version\":2}")
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn an_index_field_this_does_not_know_is_not_an_error() {
+        // The index is written by a script that may gain fields. A gate that
+        // failed on one would turn an additive change into a repository-wide
+        // outage.
+        let text = "{\"runs\":[{\"commit\":\"c\",\"epoch\":6,\"finished_at\":\"2026-08-15T00:00:00Z\",\
+                    \"platform\":\"x86_64-linux\",\"run\":\"r\",\"suite_revision\":4,\"future\":1}],\
+                    \"schema_version\":99}";
+        assert_eq!(select(text).unwrap(), vec!["runs/r.json".to_string()]);
+    }
+
+    #[test]
+    fn a_missing_index_is_the_empty_branch() {
+        let mut out = Vec::new();
+        print(Path::new("/nonexistent/index.json"), &mut out).expect("not an error");
+        assert!(out.is_empty());
+    }
+}

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -228,6 +228,33 @@ overlap rather than from the work getting cheaper — median run wall time ~308s
 it is a p90 win first and a smaller p50 win. Do not re-derive a saving from an
 assumption that this job is free.
 
+**The job then grew to 350–400s, and the reason was not the gate** (RUE-1542).
+A step-level breakdown of a 338s run: 6s to build `rue-bench` (a 100% remote
+cache hit), 0.6s to fetch both branches, and ~330s to materialize and parse
+`performance-data-v1`. The store is append-only and was 1.5 GB across 1,188
+records on 2026-08-16, growing ~300 MB a day since protocol-v2 boundary
+evidence began collecting on 2026-08-13 — before that it grew ~2.5 MB a day.
+The gate's own rules are milliseconds.
+
+So the gate now reads the live epoch instead of the whole store.
+`rue-bench staleness-inputs` names each platform's newest-point epoch from
+`index.json` — which carries every record's platform, epoch, and finish time,
+so the selection never opens a run object — and the step checks out only those
+paths. `derive` is unchanged and still derives whatever the data root holds.
+Deriving the 69-record selection and the full 1,188-record branch produces
+byte-identical gate reports, on the passing case and on the failing one; local
+derive time was 197s against the whole branch and 57s against the selection.
+The CI contract pins `staleness-inputs` into the job, because this cost returns
+as a slow job rather than a failing one and would otherwise be re-added by
+anyone restoring the obvious `checkout -- .`.
+
+**This bought a constant, not a trend.** The live epoch grows at the same
+~300 MB a day — epoch 6 went from 42 records and 267 MB to 69 records and
+419 MB in a day — so the selection is worth less each day it is not paired with
+smaller records. The per-sample `boundary_evidence` that drives the growth is
+~37.9 KB, or 990 KB for one `startup` workload, and shrinking it is tracked
+separately.
+
 Production `debug_assert*` use is governed by
 `scripts/validate-debug-assert-policy.py`. The gate is structural (RUE-1525):
 `rue_crate`/`rue_binary` emit a premerge-tier `<name>-debug-assert-check` per

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -308,6 +308,11 @@ def validate(
         # The gate counts trunk commits back to the newest measured one, which
         # a depth-1 checkout cannot reach (RUE-1258).
         "fetch-depth: 0",
+        # The store is append-only and unbounded, while the question is about
+        # the live epoch alone. Checking out and parsing all of it made this
+        # job the run's long pole, and would again: the cost returns silently,
+        # as a slow job rather than a failing one (RUE-1542).
+        "staleness-inputs",
     ):
         if required not in staleness:
             errors.append(f"performance-staleness responsibility missing {required!r}")


### PR DESCRIPTION
`performance staleness (linux-x64)` is the long pole on most CI runs at 350-400s,
well past the ~185-195s `docs/process/ci.md` recorded for it. Almost none of that
is the gate.

Fixes RUE-1542.

## Where the time goes

Step-level breakdown of the 338s gate step in run 31927413480:

| phase | time |
| --- | --- |
| `rue-bench` build | 6s (100% remote cache hit) |
| `git fetch` trunk + performance-data-v1 | 0.6s |
| materialize + parse the data branch | **~330s** |

`performance-data-v1` is append-only and was **1.5 GB across 1,188 records** on
2026-08-16, growing **~300 MB/day** since protocol-v2 boundary evidence began
collecting on 08-13 — before that, ~2.5 MB/day. The gate's own rules run in
milliseconds.

## What this changes

Every rule the gate applies — `newest_plotted`, `unindexed`, `unpinned` — is a
property of the epoch holding each platform's newest point. Retired epochs keep
what they published, cannot receive another point, and cannot go stale, so
parsing the other 1,119 records answered nothing.

`rue-bench staleness-inputs --index index.json` names the live epoch's records.
`index.json` already carries each record's platform, epoch, and finish time, so
the selection never opens a run object to decide whether to read it. The CI step
checks out `index.json`, then only the selected paths. `derive` is untouched and
still derives whatever the data root holds.

Selection is the epoch of each platform's *newest point*, deliberately not the
manifest's *collecting* epoch. Those differ exactly when a platform has stopped
collecting — the case this gate exists to catch — and selecting by manifest
would drop that platform out of the derived data, where a platform with no
points is not stalled by `newest_plotted`'s reckoning, it is absent, which reads
as fine. There is a test for that shape.

## Verification

Derived both ways — full 1,188-record branch and 69-record selection — against
the current manifest and against the pre-RUE-1533 manifest that leaves epoch 6
unpinned:

| case | full branch | selection |
| --- | --- | --- |
| current manifest | passes, 3 platforms current | **byte-identical** |
| epoch 6 unpinned | fails, names all 3 platforms and the runs to pin | **byte-identical** |

Local derive time: 197s over the whole branch, 57s over the selection. The
checkout it replaces goes from 1.5 GB to 419 MB and completes in 0.6s. The
workflow's exact shell sequence was run locally against `performance-data-v1`.

The CI contract now pins `staleness-inputs` into the job: this cost returns as a
slow job rather than a failing one, so nothing else would notice a future edit
restoring the obvious `checkout -- .`.

## Scope

This buys a constant, not a trend. The live epoch grows at the same ~300 MB/day —
epoch 6 went from 42 records / 267 MB to 69 records / 419 MB in one day — so the
selection is worth less each day it is not paired with smaller records. The
per-sample `boundary_evidence` driving that growth (~37.9 KB per sample, 990 KB
for one `startup` workload) is under separate investigation.