### PR TITLE
RUE-1473: attribute only actual toolchain acquisition

### DIFF
--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -2124,6 +2124,51 @@ mod tests {
     }
 
     #[test]
+    fn toolchain_acquisition_timing_excludes_the_semantic_probe() {
+        let project = TestDir::new("toolchain-timing-project");
+        let stdlib = TestDir::new("toolchain-timing-std");
+        let plain = project.write("plain.rue", "fn main() -> i32 { 0 }");
+        let fallible = project.write(
+            "fallible.rue",
+            "fn main() -> i32 { let _ = @parse_i64(\"1\"); 0 }",
+        );
+        stdlib.write(
+            "option.rue",
+            "pub fn Option(comptime T: type) -> type { enum { Some(T), None } }",
+        );
+        let std_root = fs::canonicalize(&stdlib.path).unwrap();
+
+        let measure = |root: &Path| {
+            let data = timing::TimingData::new();
+            let subscriber =
+                tracing_subscriber::registry().with(timing::TimingLayer::new(data.clone()));
+            tracing::subscriber::with_default(subscriber, || {
+                let mut host = FilesystemCompilerHost::open(HostOpenRequest {
+                    root_source: root.to_string_lossy().as_ref(),
+                    source_manifest_path: None,
+                    std_root: Some(&std_root),
+                })
+                .unwrap();
+                host.acquire_reached_toolchain_modules(&CompileOptions::default())
+                    .unwrap();
+            });
+            data.pass_duration_distribution("toolchain_acquisition")
+                .count
+        };
+
+        assert_eq!(
+            measure(&plain),
+            0,
+            "a semantic readiness probe with no park is not acquisition work"
+        );
+        assert_eq!(
+            measure(&fallible),
+            1,
+            "one parked trusted-module acquisition owns one timing span"
+        );
+    }
+
+    #[test]
     fn discovery_parse_and_pipeline_share_the_cli_compile_root() {
         let dir = TestDir::new("timed-discovery-root");
         let main = dir.write(

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -1189,7 +1189,6 @@ pub(crate) fn acquire_reached_toolchain_modules(
     if result.revision.status() != ImportDiscoveryStatus::ClosedValid {
         return Ok(());
     }
-    let _span = tracing::info_span!("toolchain_acquisition").entered();
     for _ in 0..MAX_TOOLCHAIN_ACQUISITION_ROUNDS {
         match rooted_or_toolchain_park(&mut result.session, options) {
             // Analysis satisfied every reached-body demand (or there were none).
@@ -1207,6 +1206,11 @@ pub(crate) fn acquire_reached_toolchain_modules(
             // revision. Satisfy exactly the parked demands, publish one successor,
             // and re-close so semantic can retry on it.
             RootedParkOutcome::Parked(park) => {
+                // Attribute only the host work which satisfies the park. The
+                // semantic request above already owns its own phase spans; wrapping
+                // the whole fixed-point loop here would misreport that cached
+                // semantic work as toolchain acquisition.
+                let _span = tracing::info_span!("toolchain_acquisition").entered();
                 for demand in park.demands() {
                     satisfy_toolchain_module_demand(
                         &mut result.assembler,

--- a/docs/notes/adr-0071-phase-2-semantic-cfg-ownership-audit.md
+++ b/docs/notes/adr-0071-phase-2-semantic-cfg-ownership-audit.md
@@ -47,15 +47,17 @@ Rue `-O3`, x86_64 Linux run
 Lattice's median process time was 2,887.26 ms and compiler-root time was
 2,716.88 ms. The fixed scaling run used the same compiler commit and boundary.
 
-The scaling report's `toolchain_acquisition_ns` is an inclusive tracing span
-around `FilesystemCompilerHost::acquire_reached_toolchain_modules` in
-`crates/rue/src/source_loader.rs`. That operation calls
+The historical scaling report's `toolchain_acquisition_ns` was an inclusive
+tracing span around `FilesystemCompilerHost::acquire_reached_toolchain_modules`
+in `crates/rue/src/source_loader.rs`. That operation calls
 `rooted_or_toolchain_park`, so on the ordinary no-park path its 1,280.70 ms
-one-worker / 1,136.40 ms automatic-worker duration contains the semantic root
-attempt. It is not a separate 1.2-second filesystem or standard-library phase,
-must not be added to semantic time, and does not establish toolchain I/O as a
-bottleneck. The exclusive phase partition remains the authority for phase
-budgeting. The inclusive envelope proves only how long the host's park-aware
+one-worker / 1,136.40 ms automatic-worker duration contained the semantic root
+attempt. It was not a separate 1.2-second filesystem or standard-library phase
+and did not establish toolchain I/O as a bottleneck. The span now begins only
+after a semantic attempt parks and measures the host acquisition/re-close work;
+an ordinary no-park semantic probe contributes zero. Historical reports must
+still use the exclusive phase partition for phase budgeting. The old envelope
+proved only how long the host's park-aware
 operation remains active.
 
 The deterministic one-worker Lattice evidence used below is:


### PR DESCRIPTION
## What changed

- start `toolchain_acquisition` timing only after semantic analysis actually parks for a trusted module
- keep semantic readiness probes under their existing semantic phase spans
- add a regression proving no-park compilation records zero acquisitions while one real park records one
- correct the architecture audit note so historical inclusive measurements are not interpreted as toolchain I/O

## Why

The old span wrapped the entire park-aware loop, including the first rooted semantic analysis attempt. On Lattice this made roughly 298 ms of semantic work look like toolchain acquisition, which could send performance work toward filesystem/import code that was not responsible for the time. The metric now measures only host acquisition and re-close work.

This is an observability correction, not a compiler speed claim.

RUE-1473 remains the broader performance effort; this patch does not complete it.

## Validation

- focused timing regression: 1 passed
- `scripts/rue quick`: 30 targets passed
- `scripts/rue premerge`: 194 targets passed
