### PR TITLE
Check import demand roots against a set of plan group leaders

### DIFF
--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -19022,15 +19022,26 @@ impl RevisionedQueryDatabase {
                 "import plan does not match its pinned granular input revision",
             ));
         }
-        if roots.occurrences().iter().any(|occurrence| {
-            !plan
+        // Membership is checked through one set built per call. On the ordinary
+        // path roots are exactly the plan's group leaders and the plan grows
+        // with every discovery round, so a nested scan here is quadratic in
+        // plan size over a deep import graph while proving a fact that almost
+        // always holds.
+        {
+            let group_occurrences: HashSet<_> = plan
                 .groups()
                 .iter()
-                .any(|group| group[0].occurrence() == occurrence)
-        }) {
-            return Err(import_input_error(
-                "import demand roots contain an occurrence outside the pinned plan",
-            ));
+                .map(|group| group[0].occurrence())
+                .collect();
+            if roots
+                .occurrences()
+                .iter()
+                .any(|occurrence| !group_occurrences.contains(occurrence))
+            {
+                return Err(import_input_error(
+                    "import demand roots contain an occurrence outside the pinned plan",
+                ));
+            }
         }
         let mut requests = Vec::new();
         let mut fanout = Vec::<Vec<ImportDiscoveryRequest>>::new();
@@ -29347,6 +29358,52 @@ fn main() -> i32 {
         let (program, _) = database.parse_program(runtime_revision, &root, modules);
         let plan = ImportDiscoveryPlan::new(&program.unwrap(), context).unwrap();
         (snapshot, reads, revision, plan)
+    }
+
+    #[test]
+    fn import_frontier_rejects_roots_outside_the_pinned_plan() {
+        let (_, mut assembler, context) =
+            import_fixture(313, "const selected = @import(\"dep\"); fn main() {}");
+        let mut database = RevisionedQueryDatabase::default();
+        let (_, _, revision, plan) = begin_database_plan(&mut database, &mut assembler, context);
+
+        // An occurrence from an unrelated program is definitionally outside the
+        // pinned plan: its specifier and spans exist in no plan group.
+        let (_, mut foreign_assembler, foreign_context) =
+            import_fixture(314, "const other = @import(\"elsewhere\"); fn main() {}");
+        let mut foreign_database = RevisionedQueryDatabase::default();
+        let (_, _, _, foreign_plan) = begin_database_plan(
+            &mut foreign_database,
+            &mut foreign_assembler,
+            foreign_context,
+        );
+        let foreign_occurrence = foreign_plan.demand_roots().occurrences()[0].clone();
+
+        let roots = ImportDemandRoots::new(
+            plan.demand_roots()
+                .occurrences()
+                .iter()
+                .cloned()
+                .chain([foreign_occurrence]),
+        );
+        assert!(
+            database
+                .import_frontier(revision, &plan, ImportDemandMode::Rooted, &roots)
+                .unwrap_err()
+                .to_string()
+                .contains("outside the pinned plan"),
+            "a demand root absent from the pinned plan must be refused"
+        );
+
+        // The exact plan-derived roots remain accepted after the refusal.
+        database
+            .import_frontier(
+                revision,
+                &plan,
+                ImportDemandMode::Rooted,
+                &plan.demand_roots(),
+            )
+            .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## What

`import_frontier` validated each demand root with a nested scan over every plan group (`revisioned_query_database.rs`, previously lines 19025–19034). On the ordinary path the roots are exactly the plan's group leaders (`ImportDemandRoots::whole_plan`), and the plan grows monotonically across discovery rounds, so a deep import graph paid `Σ n_r²` occurrence comparisons over the discovery loop to prove a membership fact that is structurally true there. The guard now builds one `HashSet` of group-leader occurrences per call and probes it — O(roots + groups) per round, same accept/reject behavior.

The reject path had no test; this adds one (`import_frontier_rejects_roots_outside_the_pinned_plan`), constructing a foreign occurrence from an unrelated program and asserting the typed refusal, then confirming the exact plan-derived roots still pass.

## Measurements (release ThinLTO, `-O3 -j1`, x86-64 Linux container)

Same-output paired runs; emitted bytes are unchanged:

- Frozen Lattice workload reproduces its exact executable hash (`b893e76c…85e5`) before and after; compiler-root time is neutral within host noise (Lattice's import depth is ~12, so the guard term is small there).
- A generated 1,024-module import chain (worst-case discovery shape, one module per round) reproduces its exact hash (`802bf2e1…9f4d`) and drops from ~15.0s to ~14.1s fresh-process root time.

## What this deliberately does not fix

The dominant superlinear cost in the deep-chain shape remains: validation certificates are keyed to a single revision (`rue-query`), so every discovery round expires every certificate and re-walks the existing green cone — `validation.certificate_misses` is exactly n² on an n-module chain (4,096 at 64, 65,536 at 256, 1,048,576 at 1,024). Discovery revisions on this path only ever add inputs, so an append-only revision cannot invalidate an existing terminal; letting certificates survive input-append revisions (a durability/watermark notion) would make fresh-build validation O(graph) instead of O(depth × graph). That is a core query-engine design change and should be its own reviewed issue rather than ride along here.

## Validation

- `scripts/rue unit compiler import_frontier_rejects` — passes
- `scripts/rue quick` — 30/30 pass
- `scripts/rue fmt` — clean
- Paired same-output hash checks as above

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTiBg7df72iMgdpAFv5wZs)_