### PR TITLE
RUE-1544: verify dominance with the shared dominator tree

### DIFF
--- a/crates/rue-cfg/src/dominators.rs
+++ b/crates/rue-cfg/src/dominators.rs
@@ -10,10 +10,12 @@
 //! This is shared analysis infrastructure, not a pass: consumers recompute it
 //! on demand rather than caching it across mutations. The value-forwarding pass
 //! (RUE-914, `opt/forward.rs`) uses [`DominatorTree::dominates`] to turn sema's
-//! definite-initialization argument into an always-on checked invariant, and
+//! definite-initialization argument into an always-on checked invariant,
 //! natural-loop analysis (RUE-926, `opt/loops.rs`) and LICM (RUE-927,
 //! `opt/licm.rs`, run at `-O3` from `opt/mod.rs`) build the loop forest and its
-//! hoisting decisions on it.
+//! hoisting decisions on it, and the structural verifier (RUE-227,
+//! `verify.rs`) uses it for both reachability and the defined-before-use
+//! dominance check on every operand.
 //!
 //! ## Definitions
 //!
@@ -36,21 +38,32 @@
 //!    order at least one predecessor is always processed before a block is
 //!    visited, so the fixpoint is reached in a handful of sweeps for reducible
 //!    graphs.
+//! 4. Number the finished tree in preorder and record, for each block, the
+//!    largest preorder number in its subtree. `a` dominates `b` exactly when
+//!    `b`'s number lies inside `a`'s interval, so [`DominatorTree::dominates`]
+//!    is two integer comparisons rather than a walk up `b`'s `idom` chain.
 //!
 //! `intersect(a, b)` walks the two fingers up the partial tree, each time
 //! advancing whichever finger has the smaller postorder number (i.e. is deeper,
 //! farther from the entry), until they meet at the common dominator.
 //!
+//! Step 4 is what makes the query cheap enough to call once per operand. The
+//! verifier does exactly that, so an O(depth) chain walk there would be
+//! quadratic again on a deep CFG — the shape RUE-1544 removed from the
+//! verifier's own dominance computation.
+//!
 //! The pipeline consumers are value forwarding's Rule 1 dominance check
-//! (`opt/forward.rs`), natural-loop detection (`opt/loops.rs`), and LICM
-//! (`opt/licm.rs`); the `idom` query itself is exercised only by this module's
-//! tests and carries a targeted allow below.
+//! (`opt/forward.rs`), natural-loop detection (`opt/loops.rs`), LICM
+//! (`opt/licm.rs`), and the structural verifier (`verify.rs`); the `idom` query
+//! itself is exercised only by this module's tests and carries a targeted allow
+//! below.
 
 use crate::{BlockId, Cfg, Terminator};
 
 /// The immediate-dominator tree of a [`Cfg`].
 ///
-/// Query it with [`DominatorTree::idom`] and [`DominatorTree::dominates`].
+/// Query it with [`DominatorTree::idom`], [`DominatorTree::dominates`], and
+/// [`DominatorTree::is_reachable`].
 pub(crate) struct DominatorTree {
     /// Immediate dominator of each block by raw block index.
     ///
@@ -61,7 +74,17 @@ pub(crate) struct DominatorTree {
     idom: Vec<Option<BlockId>>,
     /// Postorder number of each block by raw index; `None` when unreachable.
     /// The entry holds the maximum among reachable blocks.
+    ///
+    /// This is the DFS from the entry over the current terminators, so it is
+    /// also the authority for [`Self::is_reachable`].
     post_num: Vec<Option<u32>>,
+    /// Dominator-tree preorder number of each block by raw index; `None` when
+    /// the block is unreachable and therefore absent from the tree.
+    pre_num: Vec<Option<u32>>,
+    /// Largest preorder number in each block's dominator subtree, so that `a`
+    /// dominates `b` exactly when `pre_num[a] <= pre_num[b] <= subtree_last[a]`.
+    /// Only meaningful where `pre_num` is `Some`.
+    subtree_last: Vec<u32>,
 }
 
 impl DominatorTree {
@@ -150,7 +173,27 @@ impl DominatorTree {
             }
         }
 
-        DominatorTree { idom, post_num }
+        let (pre_num, subtree_last) = preorder_intervals(&idom, entry, n);
+
+        DominatorTree {
+            idom,
+            post_num,
+            pre_num,
+            subtree_last,
+        }
+    }
+
+    /// Whether `block` is reachable from the entry along the current
+    /// terminators.
+    ///
+    /// This is the tree's own DFS, so a consumer that needs both reachability
+    /// and dominance pays for one traversal rather than two.
+    pub(crate) fn is_reachable(&self, block: BlockId) -> bool {
+        self.post_num
+            .get(block.as_u32() as usize)
+            .copied()
+            .flatten()
+            .is_some()
     }
 
     /// The immediate dominator of `block`, or `None` when `block` is the entry
@@ -171,29 +214,76 @@ impl DominatorTree {
     /// Whether `a` dominates `b` (every path from the entry to `b` passes
     /// through `a`). Reflexive: a block dominates itself. An unreachable `b` is
     /// dominated only by itself.
+    ///
+    /// Constant time: `a` dominates `b` iff `b` sits in `a`'s dominator-tree
+    /// subtree, and the preorder intervals make that a containment test.
     pub(crate) fn dominates(&self, a: BlockId, b: BlockId) -> bool {
-        let bi = b.as_u32() as usize;
-        if bi >= self.idom.len() {
-            return a == b;
-        }
-        // Unreachable blocks have no idom entry; only self-dominance holds.
-        if self.post_num[bi].is_none() {
-            return a == b;
-        }
-        // Walk up b's idom chain to the entry. The entry's self-loop terminates
-        // the walk.
-        let mut cur = b;
-        loop {
-            if cur == a {
-                return true;
-            }
-            match self.idom[cur.as_u32() as usize] {
-                Some(d) if d != cur => cur = d,
-                // Reached the entry sentinel (d == cur) without finding `a`.
-                _ => return false,
-            }
+        let (ai, bi) = (a.as_u32() as usize, b.as_u32() as usize);
+        match (
+            self.pre_num.get(ai).copied().flatten(),
+            self.pre_num.get(bi).copied().flatten(),
+        ) {
+            (Some(pre_a), Some(pre_b)) => pre_a <= pre_b && pre_b <= self.subtree_last[ai],
+            // A block outside the tree — unreachable, or an out-of-range id —
+            // dominates nothing but itself and is dominated by nothing else.
+            _ => a == b,
         }
     }
+}
+
+/// Number the dominator tree in preorder and record where each subtree ends.
+///
+/// Returns `(pre_num, subtree_last)`: a block's descendants are exactly the
+/// blocks whose preorder number lies in `pre_num[block] ..= subtree_last[block]`,
+/// which is the standard constant-time ancestor test.
+///
+/// The walk starts at the entry and follows `idom` edges outward, so it numbers
+/// exactly the reachable blocks: the fixpoint above gives every reachable block
+/// an immediate dominator, and leaves unreachable blocks with `None`.
+fn preorder_intervals(
+    idom: &[Option<BlockId>],
+    entry: BlockId,
+    n: usize,
+) -> (Vec<Option<u32>>, Vec<u32>) {
+    // Invert `idom` into child lists. The entry's self-loop sentinel is not an
+    // edge, so it is skipped rather than made a child of itself.
+    let mut children: Vec<Vec<BlockId>> = vec![Vec::new(); n];
+    for (index, parent) in idom.iter().enumerate() {
+        let block = BlockId::from_raw(index as u32);
+        match *parent {
+            Some(parent) if parent != block => children[parent.as_u32() as usize].push(block),
+            _ => {}
+        }
+    }
+
+    let mut pre_num: Vec<Option<u32>> = vec![None; n];
+    let mut subtree_last: Vec<u32> = vec![0; n];
+    if (entry.as_u32() as usize) >= n {
+        return (pre_num, subtree_last);
+    }
+
+    let mut next = 0_u32;
+    pre_num[entry.as_u32() as usize] = Some(next);
+    next += 1;
+    // Stack of (block, next child index to descend into).
+    let mut stack: Vec<(BlockId, usize)> = vec![(entry, 0)];
+    while let Some(&(block, cursor)) = stack.last() {
+        let block_children = &children[block.as_u32() as usize];
+        if cursor < block_children.len() {
+            let child = block_children[cursor];
+            stack.last_mut().unwrap().1 += 1;
+            pre_num[child.as_u32() as usize] = Some(next);
+            next += 1;
+            stack.push((child, 0));
+        } else {
+            stack.pop();
+            // Everything numbered since `block` was pushed is in its subtree,
+            // and `block` itself took a number, so `next` is never zero here.
+            subtree_last[block.as_u32() as usize] = next - 1;
+        }
+    }
+
+    (pre_num, subtree_last)
 }
 
 /// Intersect two nodes of the partial dominator tree, per Cooper–Harvey–Kennedy:
@@ -363,6 +453,164 @@ mod tests {
         // The body is inside the loop; it does not dominate the exit (the
         // header can branch straight to exit without entering the body).
         assert!(!dom.dominates(body, exit));
+    }
+
+    /// Whether `target` is reachable from the entry, optionally with `removed`
+    /// deleted from the graph.
+    fn reaches(cfg: &Cfg, target: BlockId, removed: Option<BlockId>) -> bool {
+        let entry = cfg.entry;
+        if removed == Some(entry) {
+            return false;
+        }
+        let mut seen = vec![false; cfg.block_count()];
+        seen[entry.as_u32() as usize] = true;
+        let mut stack = vec![entry];
+        while let Some(block) = stack.pop() {
+            if block == target {
+                return true;
+            }
+            for successor in successors_of(cfg, block) {
+                if removed == Some(successor) {
+                    continue;
+                }
+                let index = successor.as_u32() as usize;
+                if !seen[index] {
+                    seen[index] = true;
+                    stack.push(successor);
+                }
+            }
+        }
+        false
+    }
+
+    /// Dominance straight from the definition: `b` must stop being reachable
+    /// once `a` is deleted from the graph. This shares no code with the CHK
+    /// fixpoint or the preorder intervals, so it is a real oracle for both.
+    fn dominates_by_definition(cfg: &Cfg, a: BlockId, b: BlockId) -> bool {
+        if !reaches(cfg, b, None) {
+            // An unreachable block is dominated only by itself, which is the
+            // convention `DominatorTree::dominates` documents.
+            return a == b;
+        }
+        a == b || !reaches(cfg, b, Some(a))
+    }
+
+    /// Check every block pair of `cfg` against the definition, plus every
+    /// block's reachability.
+    fn assert_matches_definition(cfg: &Cfg) {
+        let dom = DominatorTree::compute(cfg);
+        for i in 0..cfg.block_count() {
+            let a = BlockId::from_raw(i as u32);
+            assert_eq!(
+                dom.is_reachable(a),
+                reaches(cfg, a, None),
+                "reachability of {a}"
+            );
+            for j in 0..cfg.block_count() {
+                let b = BlockId::from_raw(j as u32);
+                assert_eq!(
+                    dom.dominates(a, b),
+                    dominates_by_definition(cfg, a, b),
+                    "dominates({a}, {b})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_dominance_matches_the_definition_on_reducible_graphs() {
+        // Straight line with a diamond hanging off it, then a loop whose body
+        // has its own branch, then a dead island.
+        let mut cfg = make_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let t = cfg.new_block();
+        let e = cfg.new_block();
+        let header = cfg.new_block();
+        let body = cfg.new_block();
+        let body_alt = cfg.new_block();
+        let exit = cfg.new_block();
+        let island = cfg.new_block();
+
+        let cond = bool_const(&mut cfg, entry);
+        cfg.set_terminator(entry, branch(cond, t, e));
+        cfg.set_terminator(t, goto(header));
+        cfg.set_terminator(e, goto(header));
+        let loop_cond = bool_const(&mut cfg, header);
+        cfg.set_terminator(header, branch(loop_cond, body, exit));
+        let body_cond = bool_const(&mut cfg, body);
+        cfg.set_terminator(body, branch(body_cond, body_alt, header));
+        cfg.set_terminator(body_alt, goto(header));
+        cfg.set_terminator(exit, Terminator::Return { value: None });
+        cfg.set_terminator(island, goto(exit));
+
+        assert_matches_definition(&cfg);
+    }
+
+    #[test]
+    fn test_dominance_matches_the_definition_on_an_irreducible_graph() {
+        // Two loop headers entered from outside, each branching into the other:
+        // no single back edge, so the CHK fixpoint needs more than one sweep.
+        let mut cfg = make_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let left = cfg.new_block();
+        let right = cfg.new_block();
+        let exit = cfg.new_block();
+
+        let cond = bool_const(&mut cfg, entry);
+        cfg.set_terminator(entry, branch(cond, left, right));
+        let left_cond = bool_const(&mut cfg, left);
+        cfg.set_terminator(left, branch(left_cond, right, exit));
+        let right_cond = bool_const(&mut cfg, right);
+        cfg.set_terminator(right, branch(right_cond, left, exit));
+        cfg.set_terminator(exit, Terminator::Return { value: None });
+
+        assert_matches_definition(&cfg);
+    }
+
+    #[test]
+    fn test_dominance_matches_the_definition_on_a_switch_fan_out() {
+        // The verifier's motivating shape (RUE-1544): one Switch over many arm
+        // blocks that all rejoin. Every arm is a child of the switch block, so
+        // the preorder intervals here are all singletons but the join's is not.
+        let mut cfg = make_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let join = cfg.new_block();
+        let arms: Vec<BlockId> = (0..6).map(|_| cfg.new_block()).collect();
+
+        let scrutinee = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(0),
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        let cases = cfg
+            .push_switch_cases(
+                arms.iter()
+                    .enumerate()
+                    .skip(1)
+                    .map(|(index, &arm)| (index as i64, arm))
+                    .collect::<Vec<_>>(),
+            )
+            .expect("switch cases fit");
+        cfg.set_terminator(
+            entry,
+            Terminator::Switch {
+                scrutinee,
+                cases,
+                default: arms[0],
+            },
+        );
+        for &arm in &arms {
+            cfg.set_terminator(arm, goto(join));
+        }
+        cfg.set_terminator(join, Terminator::Return { value: None });
+
+        assert_matches_definition(&cfg);
     }
 
     #[test]

--- a/crates/rue-cfg/src/verify.rs
+++ b/crates/rue-cfg/src/verify.rs
@@ -31,6 +31,7 @@
 //! again after all passes.
 
 use crate::PayloadError;
+use crate::dominators::DominatorTree;
 use crate::inst::{
     BlockId, Cfg, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator, ValidatedCfg,
 };
@@ -301,8 +302,13 @@ struct Verifier<'a> {
     require_complete_attachments: bool,
     skip_unreachable_blocks: bool,
     attachments: Vec<Option<Attachment>>,
-    reachable: Vec<bool>,
-    dominators: Vec<Vec<bool>>,
+    /// Reachability and dominance for the graph under verification.
+    ///
+    /// `None` until [`Verifier::verify`] has cleared the structural checks that
+    /// make terminator decoding safe — the tree walks every terminator, so it
+    /// may only be built once targets are known to be in bounds and payload
+    /// slices are known to be valid.
+    dominators: Option<DominatorTree>,
 }
 
 impl<'a> Verifier<'a> {
@@ -317,8 +323,7 @@ impl<'a> Verifier<'a> {
             require_complete_attachments,
             skip_unreachable_blocks: false,
             attachments: vec![None; cfg.value_count()],
-            reachable: vec![false; cfg.block_count()],
-            dominators: Vec::new(),
+            dominators: None,
         }
     }
 
@@ -338,6 +343,16 @@ impl<'a> Verifier<'a> {
             skip_unreachable_blocks: true,
             ..Self::new(cfg, type_pool, false)
         }
+    }
+
+    /// Reachability and dominance for the graph under verification.
+    ///
+    /// Only reachable from the per-block sweep in [`Self::verify`], which runs
+    /// after the tree is built.
+    fn dominators(&self) -> &DominatorTree {
+        self.dominators
+            .as_ref()
+            .expect("dominator tree is built before the per-block sweep queries it")
     }
 
     fn error(&self, message: impl std::fmt::Display) -> CfgVerificationError {
@@ -365,18 +380,19 @@ impl<'a> Verifier<'a> {
     fn verify(mut self) -> Result<(), CfgVerificationError> {
         self.verify_block_table_and_attachments()?;
         self.verify_targets_and_slices()?;
-        self.compute_reachability();
-        self.compute_dominators();
+        // Every target is in bounds and every payload slice is valid by this
+        // point, so the shared dominator tree can decode the terminators.
+        self.dominators = Some(DominatorTree::compute(self.cfg));
 
         for block in self.cfg.blocks() {
-            let block_index = block.id.as_u32() as usize;
+            let reachable = self.dominators().is_reachable(block.id);
             // Mid-pipeline materialization checks only reason about the live
             // graph: unreachable blocks may legitimately be pre-DCE husks with
             // stale terminators/edge arguments. Every other caller checks them.
-            if self.skip_unreachable_blocks && !self.reachable[block_index] {
+            if self.skip_unreachable_blocks && !reachable {
                 continue;
             }
-            if self.reachable[block_index] && matches!(block.terminator, Terminator::None) {
+            if reachable && matches!(block.terminator, Terminator::None) {
                 return Err(self.error(format_args!(
                     "reachable block {} has no terminator",
                     block.id
@@ -622,92 +638,6 @@ impl<'a> Verifier<'a> {
             )));
         }
         Ok(())
-    }
-
-    fn compute_reachability(&mut self) {
-        let mut stack = vec![self.cfg.entry];
-        while let Some(id) = stack.pop() {
-            let index = id.as_u32() as usize;
-            if self.reachable[index] {
-                continue;
-            }
-            self.reachable[index] = true;
-            self.for_each_successor(id, |successor| stack.push(successor));
-        }
-    }
-
-    fn for_each_successor(&self, block: BlockId, mut f: impl FnMut(BlockId)) {
-        match &self.cfg.get_block(block).terminator {
-            Terminator::Goto { target, .. } => f(*target),
-            Terminator::Branch {
-                then_block,
-                else_block,
-                ..
-            } => {
-                f(*then_block);
-                f(*else_block);
-            }
-            Terminator::Switch { cases, default, .. } => {
-                for &(_, target) in self.cfg.switch_cases(cases) {
-                    f(target);
-                }
-                f(*default);
-            }
-            Terminator::Return { .. } | Terminator::Unreachable | Terminator::None => {}
-        }
-    }
-
-    fn compute_dominators(&mut self) {
-        let count = self.cfg.block_count();
-        let mut predecessors = vec![Vec::new(); count];
-        for block in self.cfg.blocks() {
-            if self.reachable[block.id.as_u32() as usize] {
-                self.for_each_successor(block.id, |successor| {
-                    predecessors[successor.as_u32() as usize].push(block.id)
-                });
-            }
-        }
-        self.dominators = vec![vec![false; count]; count];
-        for block in self.cfg.blocks() {
-            let index = block.id.as_u32() as usize;
-            if !self.reachable[index] {
-                continue;
-            }
-            if block.id == self.cfg.entry {
-                self.dominators[index][index] = true;
-            } else {
-                for candidate in 0..count {
-                    self.dominators[index][candidate] = self.reachable[candidate];
-                }
-            }
-        }
-        loop {
-            let mut changed = false;
-            for block in self.cfg.blocks() {
-                let index = block.id.as_u32() as usize;
-                if !self.reachable[index] || block.id == self.cfg.entry {
-                    continue;
-                }
-                let mut next = vec![true; count];
-                if predecessors[index].is_empty() {
-                    next.fill(false);
-                } else {
-                    for pred in &predecessors[index] {
-                        for (candidate, present) in next.iter_mut().enumerate() {
-                            *present &= self.dominators[pred.as_u32() as usize][candidate];
-                        }
-                    }
-                }
-                next[index] = true;
-                if next != self.dominators[index] {
-                    self.dominators[index] = next;
-                    changed = true;
-                }
-            }
-            if !changed {
-                break;
-            }
-        }
     }
 
     fn verify_inst(
@@ -1230,9 +1160,13 @@ impl<'a> Verifier<'a> {
             | Attachment::Inst {
                 block: def_block, ..
             } => {
-                let use_index = use_block.as_u32() as usize;
-                if self.reachable[use_index]
-                    && !self.dominators[use_index][def_block.as_u32() as usize]
+                // An unreachable use is exempt: no path reaches it, so no
+                // definition can dominate it and nothing it reads can be wrong
+                // at runtime. A reachable use must be dominated by its
+                // definition — including when the definition sits in a block
+                // the entry cannot reach, which never dominates anything.
+                let dominators = self.dominators();
+                if dominators.is_reachable(use_block) && !dominators.dominates(def_block, use_block)
                 {
                     return Err(self.error(format_args!(
                         "{} {} in reachable block {} is defined in block {}, which does not dominate the use",
@@ -1805,6 +1739,73 @@ mod tests {
         );
         cfg.set_terminator(left, Terminator::Return { value: Some(value) });
         cfg.set_terminator(right, Terminator::Return { value: Some(value) });
+        cfg.verify().unwrap();
+    }
+
+    /// A terminator-less reachable entry plus two *unreachable* blocks, where
+    /// the second reads a value defined in the first. Neither orphan dominates
+    /// the other, so this is the shape that separates "unreachable uses are
+    /// exempt" from "unreachable definitions dominate nothing". The caller
+    /// terminates the entry, which is what picks between the two.
+    fn cfg_with_unreachable_cross_block_use() -> (Cfg, CfgValue) {
+        let mut cfg = unit_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+
+        let orphan_def = cfg.new_block();
+        let orphaned = cfg.add_inst_to_block(
+            orphan_def,
+            CfgInst {
+                data: CfgInstData::Const(1),
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(orphan_def, Terminator::Unreachable);
+
+        let orphan_use = cfg.new_block();
+        cfg.set_terminator(
+            orphan_use,
+            Terminator::Return {
+                value: Some(orphaned),
+            },
+        );
+        (cfg, orphaned)
+    }
+
+    #[test]
+    fn verify_exempts_uses_inside_unreachable_blocks() {
+        // No path reaches the use, so no definition can dominate it and there
+        // is nothing to get wrong at run time. The orphans' structural checks
+        // still run, per `verify_checks_slots_in_unreachable_blocks`.
+        let (mut cfg, _) = cfg_with_unreachable_cross_block_use();
+        let entry = cfg.entry;
+        let live = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(0),
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Return { value: Some(live) });
+        cfg.verify().unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "does not dominate the use")]
+    fn verify_rejects_reachable_use_of_unreachable_definition() {
+        // Same graph, except the entry returns the orphan's value. An
+        // unreachable definition dominates nothing, so a reachable use of it
+        // is rejected.
+        let (mut cfg, orphaned) = cfg_with_unreachable_cross_block_use();
+        let entry = cfg.entry;
+        cfg.set_terminator(
+            entry,
+            Terminator::Return {
+                value: Some(orphaned),
+            },
+        );
         cfg.verify().unwrap();
     }
 


### PR DESCRIPTION
Fixes RUE-1544.

## Problem

`crates/rue-cfg/src/verify.rs` computed dominance privately, as a dense `blocks x blocks` `Vec<Vec<bool>>` iterated to a fixpoint, allocating a fresh blocks-sized `Vec` per block per sweep. The matrix alone is ~100MB at 10k blocks.

That ran on **every** `verify()`: at least twice per function (`Cfg::finish` and `Cfg::finish_after_optimization`), plus once per LICM preheader (`opt/loops.rs`) and once per accessor inline splice (`inline.rs`).

The crate already owned a near-linear Cooper–Harvey–Kennedy dominator tree in `crates/rue-cfg/src/dominators.rs` (RUE-914), used by `opt/forward.rs`, `opt/loops.rs`, and `opt/licm.rs`. The verifier's matrix was a second, slower computation of the same relation.

## What changed

* The verifier queries the shared `DominatorTree` instead of building a matrix. Its private reachability DFS and its private successor decoder go with it: the tree's own DFS answers reachability via a new `DominatorTree::is_reachable`, so the verifier makes one traversal where it used to make two plus a fixpoint.
* `DominatorTree::dominates` walked `b`'s idom chain, which is O(depth) — still quadratic across every operand use on a deep CFG. It now numbers the finished tree in preorder, records each subtree's last preorder number, and answers with an interval containment test in constant time. That is a strictly cheaper query for the existing optimizer consumers too.
* The tree is built after `verify_targets_and_slices()`, since it decodes every terminator and may only run once targets are known in bounds and payload slices valid.

Nothing outside `crates/rue-cfg/` is touched.

## Semantics

Unchanged — same accepts, same rejects, same messages, including the unreachable-block conventions the matrix encoded:

* an unreachable **use** is exempt from the dominance check (the matrix guarded the query on the use block's reachability);
* an unreachable **definition** dominates nothing, so a reachable use of one is still rejected with `... does not dominate the use`.

Two new verifier tests pin those two halves against the one graph shape that separates them. The hard-panic contract documented at the top of `verify.rs` (RUE-45) is untouched.

`DominatorTree` also gains an oracle test: over a reducible graph, an irreducible graph, and a switch fan-out, every block pair is checked against the definition of dominance — `b` must stop being reachable once `a` is deleted — which shares no code with the CHK fixpoint or the intervals. Mutating the interval bound by one fails six of the module's seven tests, so the oracle is not vacuous.

## Measurements

Generated single-function probe whose only axis is match-arm count (each arm lowers to one CFG block under a single `Switch`). Release compiler (`//platforms:release`), `-O3`, median of three samples, `phase_accounting.phase_ns.cfg_and_optimization`:

| match arms | before | after | speedup |
| --- | --- | --- | --- |
| 1000 | 14.1 ms | 2.7 ms | 5x |
| 2000 | 50.9 ms | 2.6 ms | 20x |
| 4000 | 199.7 ms | 4.5 ms | 44x |
| 8000 | 850.6 ms | 8.0 ms | 106x |
| 16000 | 3285.4 ms | 13.9 ms | 236x |

Before is 4x per doubling — clean O(blocks²). After is linear. Total compile wall time at 8000 arms falls from 1339 ms to 263 ms, and at 16000 arms from 4641 ms to 515 ms.

The probe generator is scratch tooling and is deliberately not committed; nothing under `performance/` changes, so no suite revision is involved.

## Codegen is unaffected

`examples/lattice/main.rue` at `-O3` compiles to a byte-identical executable before and after:

```
b893e76cfabed737b149d0e8c4d8527077dedd17da78418db20a28a7d30885e5  lattice-before
b893e76cfabed737b149d0e8c4d8527077dedd17da78418db20a28a7d30885e5  lattice-after
```

The 8k- and 16k-arm probe executables are byte-identical too, and both still print the expected `92`.

## Testing

* `scripts/rue unit cfg` — 258 passed, 0 failed.
* `./buck2 test //crates/rue-cfg/...` — unit tests, fmt check, clippy, and the debug-assert policy gate all pass.
* `scripts/rue quick` — 30 targets pass, 0 failures.
* `scripts/rue fmt`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhUhrqAwp3CgP1AR7PDw1H)_