### PR TITLE
[Linker] Resolve archives with a worklist and index Mach-O externals

### DIFF
--- a/crates/rue-linker/src/emit.rs
+++ b/crates/rue-linker/src/emit.rs
@@ -673,24 +673,35 @@ impl ObjectBuilder {
         }
 
         // External symbol names (for relocations)
-        // All symbols need underscore prefix for macOS
-        let mut extern_symbols: Vec<String> = Vec::new();
+        // All symbols need underscore prefix for macOS.
+        //
+        // Keyed by the *source* name rather than the Mach-O one, the same way
+        // `build_elf` indexes its externals: `add_macho_underscore` prepends
+        // exactly one `_` to every name, so both keys partition the relocations
+        // identically, and keying on the source name means the underscored
+        // string is built once per distinct symbol here instead of again for
+        // every relocation that names it. The map replaces a linear `contains`
+        // per relocation while building the table and a linear `position` per
+        // relocation while emitting them, both quadratic in an object's symbol
+        // count.
         let mut extern_name_offsets: Vec<usize> = Vec::new();
+        let mut extern_symbol_indices: HashMap<&str, usize> = HashMap::new();
         for reloc in &self.relocations {
             // Skip string symbols - they're handled via local symbols
             // String symbols use .rodata.strN format (possibly with @PAGE/@PAGEOFF suffix)
             if reloc.symbol.starts_with(".rodata.str") {
                 continue;
             }
-            // Always add underscore prefix for macOS
-            let macho_sym = crate::util::add_macho_underscore(&reloc.symbol);
-            if !extern_symbols.contains(&macho_sym) {
+            if !extern_symbol_indices.contains_key(reloc.symbol.as_str()) {
+                extern_symbol_indices.insert(reloc.symbol.as_str(), extern_name_offsets.len());
                 extern_name_offsets.push(strtab.len());
+                // Always add underscore prefix for macOS
+                let macho_sym = crate::util::add_macho_underscore(&reloc.symbol);
                 strtab.extend_from_slice(macho_sym.as_bytes());
                 strtab.push(0);
-                extern_symbols.push(macho_sym);
             }
         }
+        let num_extern_symbols = extern_name_offsets.len();
 
         // Symbol table follows text relocations
         let symtab_offset = align_up(
@@ -706,7 +717,7 @@ impl ObjectBuilder {
         // r_symbolnum=0 in relocations as invalid. By putting function first,
         // string symbols start at index 1+.
         let num_local_syms = 0; // No local symbols - all are external
-        let num_extern_syms = 1 + num_string_syms + extern_symbols.len(); // function + non-empty strings + external refs
+        let num_extern_syms = 1 + num_string_syms + num_extern_symbols; // function + non-empty strings + external refs
         let num_syms = num_local_syms + num_extern_syms;
 
         // String table follows symbol table
@@ -821,7 +832,7 @@ impl ObjectBuilder {
         //   - External defined symbols: function + string constants
         //   - Undefined symbols: external references
         let num_extdef = 1 + num_string_syms; // function + string symbols
-        let num_undef = extern_symbols.len();
+        let num_undef = num_extern_symbols;
 
         macho.extend_from_slice(&LC_DYSYMTAB.to_le_bytes()); // cmd
         macho.extend_from_slice(&(MACHO64_DYSYMTAB_CMD_SIZE as u32).to_le_bytes()); // cmdsize
@@ -895,9 +906,10 @@ impl ObjectBuilder {
                     // Function symbol is at index 0
                     (0_u32, true)
                 } else {
-                    // Undefined external symbol
-                    let macho_sym = crate::util::add_macho_underscore(&reloc.symbol);
-                    let sym_idx = extern_symbols.iter().position(|s| s == &macho_sym).unwrap();
+                    // Undefined external symbol. Every non-string relocation
+                    // registered its symbol in the table above, so this lookup
+                    // cannot miss.
+                    let sym_idx = extern_symbol_indices[reloc.symbol.as_str()];
                     // Undefined externals start after function and non-empty string symbols
                     (1 + num_string_syms as u32 + sym_idx as u32, true)
                 }
@@ -996,8 +1008,8 @@ impl ObjectBuilder {
         }
 
         // Symbols N+1..: External symbols (undefined)
-        for (i, _sym) in extern_symbols.iter().enumerate() {
-            macho.extend_from_slice(&(extern_name_offsets[i] as u32).to_le_bytes()); // n_strx
+        for &name_offset in &extern_name_offsets {
+            macho.extend_from_slice(&(name_offset as u32).to_le_bytes()); // n_strx
             macho.push(N_EXT | N_UNDF); // n_type: external, undefined
             macho.push(0); // n_sect: NO_SECT
             macho.extend_from_slice(&0_u16.to_le_bytes()); // n_desc
@@ -1633,6 +1645,71 @@ mod tests {
         assert!(obj_str.contains("_helper"), "should contain _helper");
         assert!(obj_str.contains("_more_data"), "should contain _more_data");
         assert!(obj_str.contains("_exit"), "should contain _exit");
+    }
+
+    /// Every Mach-O relocation must resolve to the symbol it names, whatever
+    /// the order and repetition of the references.
+    ///
+    /// The emitted symbol table is function, then non-empty string constants,
+    /// then undefined externals in first-reference order, and a relocation's
+    /// `r_symbolnum` indexes that table. Round-tripping through the parser
+    /// pins the index map against each case that can shift it: a self-reference
+    /// (index 0), string constants interleaved with externals, repeated
+    /// references to an already-registered external, and a late reference back
+    /// to the first external registered.
+    #[test]
+    fn test_macho_relocation_symbol_resolution_round_trip() {
+        let references = [
+            "puts",
+            ".rodata.str0",
+            "malloc",
+            "puts",
+            "resolver",
+            ".rodata.str1",
+            "free",
+            "malloc",
+            ".rodata.str0",
+            "puts",
+        ];
+
+        let nop = [0x1F, 0x20, 0x03, 0xD5];
+        let mut code = Vec::new();
+        for _ in 0..references.len() {
+            code.extend_from_slice(&nop);
+        }
+
+        let mut builder = ObjectBuilder::new(Target::Aarch64Macos, "resolver")
+            .code(code)
+            .strings(vec!["alpha".to_string(), "beta".to_string()]);
+        for (i, symbol) in references.iter().enumerate() {
+            builder = builder.relocation(CodeRelocation {
+                offset: (i * 4) as u64,
+                symbol: (*symbol).into(),
+                rel_type: if symbol.starts_with(".rodata.str") {
+                    RelocationType::AdrpPage21
+                } else {
+                    RelocationType::Call26
+                },
+                addend: 0,
+            });
+        }
+        let obj = builder.build();
+
+        let parsed = ObjectFile::parse(&obj).expect("emitted Mach-O object parses");
+        let text = parsed.section_map["__TEXT,__text"];
+        let resolved: Vec<&str> = parsed.sections[text]
+            .relocations
+            .iter()
+            .map(|reloc| parsed.symbols[reloc.symbol_index].name.as_str())
+            .collect();
+
+        // Emission prefixes every Mach-O symbol with exactly one underscore and
+        // parsing strips exactly that one back off (RUE-919), so a correctly
+        // indexed relocation round-trips to the name it was emitted for.
+        assert_eq!(
+            resolved, references,
+            "each relocation must name the symbol it was emitted for"
+        );
     }
 
     /// Test multiple string constants with varying sizes.

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -1,6 +1,6 @@
 //! The linker - combines object files and produces an executable.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use rue_target::Target;
 use tracing::info_span;
@@ -224,6 +224,44 @@ fn validate_defined_symbols(obj: &ObjectFile) -> Result<(), LinkError> {
         }
     }
     Ok(())
+}
+
+/// Whether `sym` is a definition that satisfies references to its name.
+///
+/// A definition is section-anchored, globally visible (strong or weak), and
+/// named; anonymous and local symbols never participate in cross-object
+/// resolution. Both `add_object` and archive extraction ask this question, so
+/// they ask it in one place.
+fn provides_definition(sym: &Symbol) -> bool {
+    sym.section_index.is_some()
+        && (sym.binding == SymbolBinding::Global || sym.binding == SymbolBinding::Weak)
+        && !sym.name.is_empty()
+}
+
+/// Whether `sym` is an undefined reference that some definition must satisfy.
+///
+/// The counterpart of [`provides_definition`]: no section, strong global
+/// binding, and named. An undefined *weak* reference does not demand a
+/// definition — it resolves to address 0 (RUE-131 item 9) — so it must not pull
+/// an archive member in.
+fn references_undefined(sym: &Symbol) -> bool {
+    sym.section_index.is_none() && sym.binding == SymbolBinding::Global && !sym.name.is_empty()
+}
+
+/// Queue an undefined symbol name for archive resolution, at most once.
+///
+/// `queued` records every name ever pushed, so a symbol referenced by many
+/// objects is resolved once rather than once per reference; `pending` keeps the
+/// surviving names in insertion order, which is what makes extraction
+/// order-deterministic (see [`Linker::add_archive`]).
+fn enqueue_undefined<'a>(
+    name: &'a str,
+    pending: &mut VecDeque<&'a str>,
+    queued: &mut HashSet<&'a str>,
+) {
+    if queued.insert(name) {
+        pending.push_back(name);
+    }
 }
 
 /// Compose a final symbol address without permitting malformed object metadata
@@ -938,10 +976,7 @@ impl Linker {
 
         // Collect global symbols
         for sym in &obj.symbols {
-            if sym.section_index.is_some()
-                && (sym.binding == SymbolBinding::Global || sym.binding == SymbolBinding::Weak)
-                && !sym.name.is_empty()
-            {
+            if provides_definition(sym) {
                 if let Some((_, existing)) = self.global_symbols.get(&sym.name) {
                     // Two strong definitions collide; weak symbols defer.
                     if existing.binding != SymbolBinding::Weak && sym.binding != SymbolBinding::Weak
@@ -989,92 +1024,80 @@ impl Linker {
     /// This path is object-format neutral, so it governs ELF and Mach-O archive
     /// members identically. Post-extraction weak/strong resolution among the
     /// members actually pulled in is still owned by [`Self::add_object`].
+    ///
+    /// # Resolution shape
+    ///
+    /// The rescan is a worklist rather than a scan of the whole link per round.
+    /// The already-linked objects do not change while members are being
+    /// selected, so their symbol tables are read exactly once; each extracted
+    /// member then contributes its own undefined symbols to the same worklist,
+    /// which is what a rescan round was for. The pipeline links roughly 1,280
+    /// single-function objects, so a per-round walk of every linked symbol table
+    /// was quadratic in the size of the link.
     pub fn add_archive(&mut self, archive: Archive) -> Result<(), LinkError> {
         // Convert to a Vec we can index into
         let archive_objects: Vec<ObjectFile> = archive.objects.into_iter().collect();
 
-        // Map each symbol to every member that defines it, in archive member
-        // order. A last-writer-wins `HashMap::insert` index would instead bind
-        // each symbol to its *last* provider, so selection could extract a later
-        // member over an earlier one and silently change weak/strong resolution
-        // when a user or foreign archive ships multiple providers (RUE-848).
-        // Retaining the ordered provider list keeps selection first-eligible and
-        // independent of hash iteration order.
-        let mut symbol_providers: HashMap<String, Vec<usize>> = HashMap::new();
-        for (obj_idx, obj) in archive_objects.iter().enumerate() {
-            for sym in &obj.symbols {
-                if sym.section_index.is_some()
-                    && (sym.binding == SymbolBinding::Global || sym.binding == SymbolBinding::Weak)
-                    && !sym.name.is_empty()
-                {
-                    symbol_providers
-                        .entry(sym.name.clone())
-                        .or_default()
-                        .push(obj_idx);
-                }
-            }
-        }
-
-        // Also build an index of undefined symbols in each archive object
-        let mut obj_undefined: Vec<Vec<String>> = Vec::with_capacity(archive_objects.len());
-        for obj in &archive_objects {
-            let mut undef = Vec::new();
-            for sym in &obj.symbols {
-                if sym.section_index.is_none()
-                    && sym.binding == SymbolBinding::Global
-                    && !sym.name.is_empty()
-                {
-                    undef.push(sym.name.clone());
-                }
-            }
-            obj_undefined.push(undef);
-        }
-
-        // Track which archive objects we've selected and which symbols are defined
-        let mut selected: Vec<bool> = vec![false; archive_objects.len()];
-        let mut defined_symbols: std::collections::HashSet<String> =
-            self.global_symbols.keys().cloned().collect();
-
-        // Iterate until we reach a fixed point
-        loop {
-            // Collect undefined symbols from currently linked objects and selected archive objects
-            let mut undefined: Vec<String> = Vec::new();
-
-            // Add required symbols (e.g., entry point) that aren't yet defined
-            for sym_name in &self.required_symbols {
-                if !defined_symbols.contains(sym_name) {
-                    undefined.push(sym_name.clone());
+        // Decide which members are needed. Every name below is borrowed from
+        // `self` or from `archive_objects` — both outlive this block — so
+        // resolution copies no symbol names; scoping the borrows here lets the
+        // selected members move into `self` afterwards.
+        let selected: Vec<bool> = {
+            // Map each symbol to every member that defines it, in archive member
+            // order. A last-writer-wins `HashMap::insert` index would instead bind
+            // each symbol to its *last* provider, so selection could extract a later
+            // member over an earlier one and silently change weak/strong resolution
+            // when a user or foreign archive ships multiple providers (RUE-848).
+            // Retaining the ordered provider list keeps selection first-eligible and
+            // independent of hash iteration order.
+            let mut symbol_providers: HashMap<&str, Vec<usize>> = HashMap::new();
+            for (obj_idx, obj) in archive_objects.iter().enumerate() {
+                for sym in &obj.symbols {
+                    if provides_definition(sym) {
+                        symbol_providers.entry(&sym.name).or_default().push(obj_idx);
+                    }
                 }
             }
 
-            // From already-linked objects
+            // Track which archive objects we've selected and which symbols are defined
+            let mut selected: Vec<bool> = vec![false; archive_objects.len()];
+            let mut defined: HashSet<&str> =
+                self.global_symbols.keys().map(String::as_str).collect();
+
+            // The undefined symbols still to resolve, in the order they were
+            // discovered. Deduplicating them is a correctness property and not
+            // only a size one: one symbol referenced by hundreds of objects used
+            // to enter a round's list once per reference, and because
+            // `find(|idx| !selected[idx])` skips the member it just pulled, the
+            // second lookup of an already-satisfied symbol extracted a *second*
+            // provider of it — a duplicate-symbol error, or a silently different
+            // weak/strong resolution. The worklist stays an ordered queue so
+            // extraction remains first-eligible in archive order and independent
+            // of hash iteration order.
+            let mut pending: VecDeque<&str> = VecDeque::new();
+            let mut queued: HashSet<&str> = HashSet::new();
+
+            // Required symbols (e.g. the entry point) are undefined by
+            // definition, followed by every reference the linked objects make.
+            for name in &self.required_symbols {
+                enqueue_undefined(name, &mut pending, &mut queued);
+            }
             for obj in &self.objects {
                 for sym in &obj.symbols {
-                    if sym.section_index.is_none()
-                        && sym.binding == SymbolBinding::Global
-                        && !sym.name.is_empty()
-                        && !defined_symbols.contains(&sym.name)
-                    {
-                        undefined.push(sym.name.clone());
+                    if references_undefined(sym) {
+                        enqueue_undefined(&sym.name, &mut pending, &mut queued);
                     }
                 }
             }
 
-            // From selected archive objects
-            for (idx, selected_flag) in selected.iter().enumerate() {
-                if *selected_flag {
-                    for sym_name in &obj_undefined[idx] {
-                        if !defined_symbols.contains(sym_name) {
-                            undefined.push(sym_name.clone());
-                        }
-                    }
+            while let Some(name) = pending.pop_front() {
+                // A member pulled in for an earlier reference may have defined
+                // this symbol in the meantime; an already-satisfied symbol
+                // extracts nothing (RUE-848).
+                if defined.contains(name) {
+                    continue;
                 }
-            }
-
-            // Try to resolve undefined symbols from the archive
-            let mut added_any = false;
-            for sym_name in undefined {
-                let Some(providers) = symbol_providers.get(&sym_name) else {
+                let Some(providers) = symbol_providers.get(name) else {
                     continue;
                 };
                 // First-eligible extraction: pull the earliest member (in
@@ -1085,24 +1108,22 @@ impl Linker {
                     continue;
                 };
                 selected[obj_idx] = true;
-                added_any = true;
 
-                // Add defined symbols from this object
+                // The member's own definitions satisfy later references, and its
+                // own references join the worklist — the transitive step the
+                // fixed-point rescan used to perform.
                 for sym in &archive_objects[obj_idx].symbols {
-                    if sym.section_index.is_some()
-                        && (sym.binding == SymbolBinding::Global
-                            || sym.binding == SymbolBinding::Weak)
-                        && !sym.name.is_empty()
-                    {
-                        defined_symbols.insert(sym.name.clone());
+                    if provides_definition(sym) {
+                        defined.insert(&sym.name);
+                    }
+                    if references_undefined(sym) {
+                        enqueue_undefined(&sym.name, &mut pending, &mut queued);
                     }
                 }
             }
 
-            if !added_any {
-                break;
-            }
-        }
+            selected
+        };
 
         // Now actually add the selected objects
         for (idx, obj) in archive_objects.into_iter().enumerate() {
@@ -1133,7 +1154,7 @@ impl Linker {
     /// after ad-hoc code signing with `codesign -s - <binary>`.
     fn link_macho(self, entry_point: &str) -> Result<Vec<u8>, LinkError> {
         use crate::constants::{VM_PROT_EXECUTE, VM_PROT_READ};
-        use crate::macho::{MachOBuilder, Section64, Segment64, VM_BASE};
+        use crate::macho::{ImageSizes, MachOBuilder, Section64, Segment64, VM_BASE};
 
         // The Mach-O path splits into the same three phases as `link_elf`.
         let layout_span = info_span!("link_layout").entered();
@@ -1265,10 +1286,11 @@ impl Linker {
         // same single-source-of-truth computation as build_dynamic(). __DATA
         // begins wherever the actual __TEXT layout ends.
         // (RUE-131 items 3 and 8)
-        let mut layout_builder = MachOBuilder::new()
-            .with_code(merged_text.clone(), 0) // only the length matters for layout
-            .with_data(merged_data.clone())
-            .with_bss(bss_size);
+        // Only the extents of the merged image matter here, so the pre-pass is
+        // measured rather than fed: handing the builder `merged_text` and
+        // `merged_data` copied the entire linked image for a computation that
+        // never reads a byte of it.
+        let mut layout_builder = MachOBuilder::new();
         layout_builder.add_segment(Segment64::pagezero());
         let mut text_segment =
             Segment64::new("__TEXT").with_protection(VM_PROT_READ | VM_PROT_EXECUTE);
@@ -1278,7 +1300,14 @@ impl Linker {
         // builder's command sizes identical (compute_dynamic_layout counts it
         // either way).
         layout_builder.add_segment(Segment64::new("__LINKEDIT").with_protection(VM_PROT_READ));
-        let layout = layout_builder.dynamic_layout();
+        let layout = layout_builder.dynamic_layout_for(ImageSizes {
+            code: merged_text.len(),
+            // __TEXT carries the rodata (merged into `merged_text` above), so
+            // the __DATA-side rodata region is empty on this path.
+            rodata: 0,
+            data: merged_data.len(),
+            bss: bss_size,
+        });
 
         let text_file_offset = layout.text_file_offset as u64;
         // Code+rodata are mapped at this virtual address
@@ -3043,6 +3072,135 @@ mod tests {
             linker.global_symbols.contains_key("helper"),
             "the later member providing the transitively undefined symbol is pulled on rescan"
         );
+    }
+
+    /// One symbol referenced by many linked objects must pull exactly one
+    /// provider, however many objects name it.
+    ///
+    /// The undefined list used to gain an entry per *reference* rather than per
+    /// symbol, and first-eligible extraction skips members it has already
+    /// selected — so the second object's reference to `shared` pulled the
+    /// archive's *second* provider of `shared`, colliding with the first. This
+    /// is the shape the pipeline actually links: ~1,280 single-function objects
+    /// calling a small set of shared runtime symbols.
+    #[test]
+    fn test_archive_symbol_referenced_by_many_objects_pulls_one_member() {
+        let mut linker = Linker::new(ELF_TARGET);
+        for i in 0..8 {
+            let caller = format!("caller{i}");
+            linker
+                .add_object(archive_member(
+                    &[(caller.as_str(), SymbolBinding::Global)],
+                    &["shared"],
+                ))
+                .unwrap();
+        }
+
+        let archive = Archive {
+            objects: vec![
+                archive_member(
+                    &[
+                        ("shared", SymbolBinding::Global),
+                        ("marker_a", SymbolBinding::Global),
+                    ],
+                    &[],
+                ),
+                archive_member(
+                    &[
+                        ("shared", SymbolBinding::Global),
+                        ("marker_b", SymbolBinding::Global),
+                    ],
+                    &[],
+                ),
+            ],
+        };
+        linker
+            .add_archive(archive)
+            .expect("repeated references to one symbol must not extract two providers");
+
+        assert!(
+            linker.global_symbols.contains_key("marker_a"),
+            "the first provider satisfies every reference"
+        );
+        assert!(
+            !linker.global_symbols.contains_key("marker_b"),
+            "no reference may extract a second provider of an already-pulled symbol"
+        );
+    }
+
+    /// A reference satisfied by a member pulled in for an *earlier* reference
+    /// extracts nothing, even when the archive holds another provider of it.
+    #[test]
+    fn test_archive_reference_satisfied_by_earlier_extraction_pulls_nothing() {
+        let mut linker = Linker::new(ELF_TARGET);
+        linker
+            .add_object(archive_member(
+                &[("root", SymbolBinding::Global)],
+                &["entry", "shared"],
+            ))
+            .unwrap();
+
+        let archive = Archive {
+            objects: vec![
+                archive_member(
+                    &[
+                        ("entry", SymbolBinding::Global),
+                        ("shared", SymbolBinding::Global),
+                    ],
+                    &[],
+                ),
+                archive_member(
+                    &[
+                        ("shared", SymbolBinding::Global),
+                        ("marker_b", SymbolBinding::Global),
+                    ],
+                    &[],
+                ),
+            ],
+        };
+        linker
+            .add_archive(archive)
+            .expect("an already-satisfied reference must not extract a second provider");
+
+        assert!(
+            linker.global_symbols.contains_key("entry"),
+            "the member satisfying the first reference is pulled"
+        );
+        assert!(
+            !linker.global_symbols.contains_key("marker_b"),
+            "`shared` was defined by that same member, so it pulls nothing"
+        );
+    }
+
+    /// RUE-848: the transitive step still reaches arbitrarily deep, including
+    /// when each provider sits *earlier* in the archive than its user, so the
+    /// chain is only reachable by following each newly pulled member's own
+    /// undefined symbols.
+    #[test]
+    fn test_archive_transitive_chain_walks_backwards() {
+        // Member i defines link{i} and references link{i-1}.
+        let names: Vec<String> = (0..5).map(|i| format!("link{i}")).collect();
+        let objects: Vec<ObjectFile> = (0..5)
+            .map(|i| {
+                let undefs: Vec<&str> = if i == 0 {
+                    Vec::new()
+                } else {
+                    vec![names[i - 1].as_str()]
+                };
+                archive_member(&[(names[i].as_str(), SymbolBinding::Global)], &undefs)
+            })
+            .collect();
+
+        let mut linker = Linker::new(ELF_TARGET);
+        linker.require_symbol("link4");
+        linker.add_archive(Archive { objects }).unwrap();
+
+        for name in &names {
+            assert!(
+                linker.global_symbols.contains_key(name.as_str()),
+                "{name} must be pulled transitively"
+            );
+        }
     }
 
     /// RUE-131 item 9: a relocation against an UNDEFINED weak symbol resolves

--- a/crates/rue-linker/src/macho.rs
+++ b/crates/rue-linker/src/macho.rs
@@ -32,11 +32,31 @@ pub const PAGE_SIZE: u64 = Target::Aarch64Macos.page_size();
 /// Default VM base address for executables.
 pub const VM_BASE: u64 = Target::Aarch64Macos.default_base_addr();
 
+/// The image content sizes a dynamic layout depends on.
+///
+/// `compute_dynamic_layout` reads only the *lengths* of the code, rodata, and
+/// data buffers, never a byte of their contents. Passing the lengths lets the
+/// linker's pre-build layout pass measure the merged image it has already built
+/// instead of handing the builder a second copy of every linked byte
+/// (see [`MachOBuilder::dynamic_layout_for`]).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ImageSizes {
+    /// Bytes of code destined for `__TEXT,__text`.
+    pub(crate) code: usize,
+    /// Bytes of read-only data destined for `__DATA,__const`.
+    pub(crate) rodata: usize,
+    /// Bytes of initialized data destined for `__DATA,__data`.
+    pub(crate) data: usize,
+    /// Size of the zero-filled `__DATA,__bss` region.
+    pub(crate) bss: u64,
+}
+
 /// Computed file/VM layout for a dynamic executable — produced only by
 /// `compute_dynamic_layout` so relocation pre-pass and the actual build can
-/// never disagree. The linker consumes this (via [`MachOBuilder::dynamic_layout`])
-/// to place symbols before the binary is built, including a data segment whose
-/// address follows the actual extent of __TEXT. (RUE-131)
+/// never disagree. The linker consumes this (via
+/// [`MachOBuilder::dynamic_layout_for`]) to place symbols before the binary is
+/// built, including a data segment whose address follows the actual extent of
+/// __TEXT. (RUE-131)
 pub(crate) struct DynamicLayout {
     pub(crate) text_file_offset: usize,
     pub(crate) text_segment_file_size: usize,
@@ -747,13 +767,32 @@ impl MachOBuilder {
     /// including all present __const, __data, and __bss section commands, so
     /// their text and data offsets cannot diverge (RUE-131).
     fn compute_dynamic_layout(&self) -> DynamicLayout {
-        let has_data = !self.rodata.is_empty() || !self.data.is_empty() || self.bss_size > 0;
+        self.dynamic_layout_for(ImageSizes {
+            code: self.code.len(),
+            rodata: self.rodata.len(),
+            data: self.data.len(),
+            bss: self.bss_size,
+        })
+    }
+
+    /// The full pre-build layout (text offset, data segment address, …),
+    /// measured against `sizes` instead of the builder's own buffers.
+    ///
+    /// The linker needs the data segment's virtual address before building, so
+    /// data/bss symbols can be placed and relocations applied against the
+    /// addresses the binary will actually use. Nothing in the computation reads
+    /// image *contents*, only extents, so that pre-pass describes the merged
+    /// image by size rather than copying it into a throwaway builder.
+    /// Load-command sizes still come from the builder's own segments and
+    /// commands, which is what the pre-pass configures.
+    pub(crate) fn dynamic_layout_for(&self, sizes: ImageSizes) -> DynamicLayout {
+        let has_data = sizes.rodata > 0 || sizes.data > 0 || sizes.bss > 0;
 
         // Segment header + up to 3 sections (__const, __data, __bss)
         let data_segment_cmd_size = if has_data {
-            let num_sections = (!self.rodata.is_empty() as usize)
-                + (!self.data.is_empty() as usize)
-                + ((self.bss_size > 0) as usize);
+            let num_sections = ((sizes.rodata > 0) as usize)
+                + ((sizes.data > 0) as usize)
+                + ((sizes.bss > 0) as usize);
             MACHO64_SEGMENT_CMD_SIZE + MACHO64_SECTION_SIZE * num_sections
         } else {
             0
@@ -807,17 +846,16 @@ impl MachOBuilder {
         // declared segment — the data segment then overlapped it in the file
         // and dyld mapped garbage. (RUE-131 item 3)
         let text_segment_file_size =
-            align_up((text_file_offset + self.code.len()) as u64, PAGE_SIZE) as usize;
+            align_up((text_file_offset + sizes.code) as u64, PAGE_SIZE) as usize;
 
         let (data_file_offset, data_vm_addr, data_file_size, data_vm_size) = if has_data {
             // Data segment starts at the next page after __TEXT
             let offset = text_segment_file_size;
             let vm_addr = VM_BASE + offset as u64;
             // File size: rodata + data (not bss)
-            let file_size =
-                align_up(self.rodata.len() as u64, 8) + align_up(self.data.len() as u64, 8);
+            let file_size = align_up(sizes.rodata as u64, 8) + align_up(sizes.data as u64, 8);
             // VM size includes bss
-            let vm_size = align_up(file_size + self.bss_size, PAGE_SIZE);
+            let vm_size = align_up(file_size + sizes.bss, PAGE_SIZE);
             (offset, vm_addr, file_size as usize, vm_size)
         } else {
             (0, 0, 0, 0)
@@ -853,15 +891,6 @@ impl MachOBuilder {
     /// Delegates to the single shared layout computation.
     pub fn calculate_text_file_offset_for_dynamic(&self) -> u64 {
         self.compute_dynamic_layout().text_file_offset as u64
-    }
-
-    /// The full pre-build layout (text offset, data segment address, …).
-    ///
-    /// The linker needs the data segment's virtual address before building so
-    /// data/bss symbols can be placed and relocations applied against the
-    /// addresses the binary will actually use.
-    pub(crate) fn dynamic_layout(&self) -> DynamicLayout {
-        self.compute_dynamic_layout()
     }
 
     /// Build a dynamic executable (using LC_MAIN + dyld).


### PR DESCRIPTION
Three bounded fixes in `crates/rue-linker`. The pipeline links roughly 1,280 single-function objects, so anything the linker repeats per object per pass is quadratic in the size of the link.

## Archive resolution (`linker.rs`, `add_archive`)

The fixed-point loop rebuilt its undefined-symbol list from scratch each round — rescanning **every** linked object's symbol table and pushing one owned `String` per undefined reference, with no deduplication.

The already-linked objects cannot change while archive members are being selected (members are added to `self` only after the loop), so their symbol tables are now read exactly once into a worklist, and each extracted member extends that worklist with its own undefined symbols — the transitive step the rescan existed to perform. Names are borrowed from `self`/the archive rather than cloned, and a `HashSet` dedups the queue while a `VecDeque` keeps insertion order, so extraction stays first-eligible in archive member order and independent of hash iteration order (RUE-848's property).

Deduplication also closes a real extraction hole rather than only shrinking a list. First-eligible selection skips members it has already pulled, so a second reference to a symbol with two providers extracted the *second* provider, which then collided as a duplicate definition. Two of the new tests fail on the old implementation with `DuplicateSymbol("shared")`:

- `test_archive_symbol_referenced_by_many_objects_pulls_one_member` — eight objects referencing one symbol, archive with two providers
- `test_archive_reference_satisfied_by_earlier_extraction_pulls_nothing` — a reference already satisfied by the member pulled in for an earlier reference

`test_archive_transitive_chain_walks_backwards` guards the rewrite itself: a five-deep chain whose providers all sit earlier in the archive than their users, reachable only by following each newly pulled member's own references.

## Mach-O object emission (`emit.rs`, `build_macho`)

External-symbol collection deduplicated with `extern_symbols.contains(...)` (O(S²) per object) and relocation emission resolved each symbol with `.iter().position(...)` (O(S) per relocation). Both now go through the `HashMap` index the ELF path at `emit.rs:229` already carries for exactly this reason.

The map is keyed on the *source* name rather than the underscored one: `add_macho_underscore` prepends exactly one `_` to every name, so both keys partition the relocations identically, and the underscored string is now built once per distinct symbol instead of again for every relocation naming it — the duplicated string building the brief called out. `extern_symbols` itself was only ever read for its length, so only the name offsets are retained.

`test_macho_relocation_symbol_resolution_round_trip` pins the index map end to end: an object whose relocations mix a self-reference (symbol index 0), interleaved string constants, repeated references to an already-registered external, and a late reference back to the first external is emitted, parsed back, and every relocation must name the symbol it was emitted for.

## Mach-O layout pre-pass (`linker.rs`, `link_macho` / `macho.rs`)

The pre-build layout builder received `merged_text.clone()` and `merged_data.clone()` — a copy of the entire linked image — for a computation that, per its own comment, reads only the lengths. `compute_dynamic_layout` now delegates to `dynamic_layout_for(ImageSizes { .. })`, and `link_macho` measures the merged image instead of copying it. Load-command sizes still come from the builder's own segments and commands.

## Verification

- `//crates/rue-linker:rue-linker-test` — 156 pass (152 before, 4 new).
- `scripts/rue quick` — 30 targets pass.
- Clippy and fmt checks for the crate pass; `scripts/rue fmt` applied.
- **Byte-identical output**, `examples/lattice/main.rue` compiled with the compiler built before and after the change:
  - x86-64-linux (ELF): `45784ce7c7cde992d7ea820912ca1692c05dc7582a367210d017b3765a9a89e7` both.
  - aarch64-macos (Mach-O), cross-compiled on Linux: `a29ad940222f28d879c769bc4696cbefcee02f87aa435687446f85a078278bd3` both.
- Timing on the same example (`--time-passes`, medians of three, host is noisy at this scale): `Link_archive_resolve` ~21ms → ~17ms on the ELF path. The rest is within run-to-run variance — the win here is complexity, not a headline number for this workload size.

**macOS is CI-validated.** Everything above ran on Linux; the Mach-O evidence is emitted bytes from a cross-compiled image, not a binary that was signed and executed. Please watch the `macos-15` leg of `native-platforms` (which also carries the baseline-bash half of the shell gate).

No Linear issue tracks this work, so none is cited; the change touches only `crates/rue-linker/`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P4B2t9mNjqWStgqVFFeRSN)_