### PR TITLE
Remove three quadratic costs from the backend

### DIFF
--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -492,8 +492,8 @@ mod tests {
         let info = analyze(&mir);
 
         assert!(info.ranges.is_empty());
-        assert!(info.live_at.is_empty());
         assert!(info.clobbers_at.is_empty());
+        assert_eq!(info.instruction_count(), 0);
     }
 
     #[test]

--- a/crates/rue-codegen/src/liveness.rs
+++ b/crates/rue-codegen/src/liveness.rs
@@ -403,7 +403,6 @@ where
         return (
             LivenessInfo {
                 ranges: IndexMap::new(),
-                live_at: Vec::new(),
                 clobbers_at: Vec::new(),
                 non_returning_at: Vec::new(),
                 vreg_classes,
@@ -480,22 +479,13 @@ where
         }
     });
 
-    // Step 6: Compute live_at for each instruction (union of live_in and live_out)
-    let live_at = match dataflow {
-        DataflowSets::Acyclic { live_in } => {
-            compute_acyclic_live_at(live_in, &successors, vreg_count as usize)
-        }
-        DataflowSets::Cyclic { live_in, live_out } => compute_live_at(live_in, &live_out),
-    };
-
-    // Step 7: Collect clobbers and the never-returning call sites (RUE-1224)
+    // Step 6: Collect clobbers and the never-returning call sites (RUE-1224)
     let clobbers_at: Vec<Vec<R>> = instructions.iter().map(|i| get_clobbers(i)).collect();
     let non_returning_at: Vec<bool> = instructions.iter().map(&get_non_returning).collect();
 
     (
         LivenessInfo {
             ranges,
-            live_at,
             clobbers_at,
             non_returning_at,
             vreg_classes,
@@ -783,32 +773,6 @@ fn build_live_ranges(
     ranges
 }
 
-/// Compute live_at sets (union of live_in and live_out for each instruction).
-fn compute_live_at(mut live_in: Vec<FixedBitSet>, live_out: &[FixedBitSet]) -> Vec<FixedBitSet> {
-    // `live_in` has no consumer after ranges are built. Turn it into the
-    // retained union in place instead of allocating a third full-width table.
-    for (live_at, live_out) in live_in.iter_mut().zip(live_out) {
-        live_at.union_with(live_out);
-    }
-    live_in
-}
-
-fn compute_acyclic_live_at(
-    mut live_in: Vec<FixedBitSet>,
-    successors: &[SuccessorList],
-    vreg_count: usize,
-) -> Vec<FixedBitSet> {
-    let mut live_out = FixedBitSet::with_capacity(vreg_count);
-    for idx in 0..live_in.len() {
-        live_out.clear();
-        for &successor in &successors[idx] {
-            live_out.union_with(&live_in[successor]);
-        }
-        live_in[idx].union_with(&live_out);
-    }
-    live_in
-}
-
 // ============================================================================
 // Loop Detection
 // ============================================================================
@@ -894,52 +858,6 @@ pub fn analyze_loops<I>(
     let successors = build_successor_lists(instructions, &label_to_idx, &get_successors);
 
     compute_loop_info(num_insts, &successors)
-}
-
-// ============================================================================
-// Pressure Analysis
-// ============================================================================
-
-/// Register pressure at each instruction.
-///
-/// This tracks how many virtual registers are live at each program point,
-/// which helps the register allocator make better spill decisions.
-#[derive(Debug, Clone)]
-pub struct PressureInfo {
-    /// Number of live vregs at each instruction index.
-    pub pressure: Vec<u32>,
-    /// Maximum pressure across all instructions.
-    pub max_pressure: u32,
-}
-
-impl PressureInfo {
-    /// Get the pressure at a specific instruction.
-    pub fn at(&self, inst_idx: usize) -> u32 {
-        self.pressure.get(inst_idx).copied().unwrap_or(0)
-    }
-
-    /// Find instructions where pressure exceeds a threshold.
-    pub fn high_pressure_points(&self, threshold: u32) -> Vec<usize> {
-        self.pressure
-            .iter()
-            .enumerate()
-            .filter(|&(_, &p)| p > threshold)
-            .map(|(idx, _)| idx)
-            .collect()
-    }
-}
-
-/// Compute register pressure from live_at sets.
-///
-/// Pressure is simply the count of live vregs at each instruction.
-pub fn compute_pressure(live_at: &[FixedBitSet]) -> PressureInfo {
-    let pressure: Vec<u32> = live_at.iter().map(|bs| bs.count_ones(..) as u32).collect();
-    let max_pressure = pressure.iter().copied().max().unwrap_or(0);
-
-    PressureInfo {
-        pressure,
-        max_pressure,
-    }
 }
 
 #[cfg(test)]
@@ -1136,7 +1054,6 @@ mod tests {
         );
 
         assert!(info.ranges.is_empty());
-        assert!(info.live_at.is_empty());
         assert!(info.clobbers_at.is_empty());
     }
 
@@ -1233,8 +1150,6 @@ mod tests {
         assert_eq!(ones(&live_out[0]), vec![0]);
         assert_eq!(ones(&live_out[1]), vec![0]);
         assert!(live_out[2].is_clear());
-        let live_at = compute_acyclic_live_at(live_in.clone(), &successors, 1);
-        assert!(live_at.iter().all(|set| ones(set) == vec![0]));
         assert_eq!(sweeps, 1, "forward-only control flow is solved exactly");
     }
 
@@ -1354,64 +1269,5 @@ mod tests {
         assert_eq!(loop_info.depth(2), 1, "Loop body");
         assert_eq!(loop_info.depth(3), 1, "Loop back-edge");
         assert_eq!(loop_info.depth(4), 0, "After loop");
-    }
-
-    // ========================================
-    // Pressure analysis tests
-    // ========================================
-
-    #[test]
-    fn test_pressure_simple() {
-        let vreg_count = 3;
-        let mut live_at = vec![
-            FixedBitSet::with_capacity(vreg_count),
-            FixedBitSet::with_capacity(vreg_count),
-            FixedBitSet::with_capacity(vreg_count),
-        ];
-
-        // Instruction 0: 1 vreg live
-        live_at[0].insert(0);
-
-        // Instruction 1: 2 vregs live
-        live_at[1].insert(0);
-        live_at[1].insert(1);
-
-        // Instruction 2: 3 vregs live
-        live_at[2].insert(0);
-        live_at[2].insert(1);
-        live_at[2].insert(2);
-
-        let pressure = compute_pressure(&live_at);
-
-        assert_eq!(pressure.at(0), 1);
-        assert_eq!(pressure.at(1), 2);
-        assert_eq!(pressure.at(2), 3);
-        assert_eq!(pressure.max_pressure, 3);
-    }
-
-    #[test]
-    fn test_high_pressure_points() {
-        let vreg_count = 5;
-        let mut live_at = vec![
-            FixedBitSet::with_capacity(vreg_count),
-            FixedBitSet::with_capacity(vreg_count),
-            FixedBitSet::with_capacity(vreg_count),
-            FixedBitSet::with_capacity(vreg_count),
-        ];
-
-        // Low pressure at 0 and 3
-        live_at[0].insert(0);
-        live_at[3].insert(0);
-
-        // High pressure at 1 and 2
-        for i in 0..5 {
-            live_at[1].insert(i);
-            live_at[2].insert(i);
-        }
-
-        let pressure = compute_pressure(&live_at);
-        let high_points = pressure.high_pressure_points(3);
-
-        assert_eq!(high_points, vec![1, 2]);
     }
 }

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -7,7 +7,7 @@
 //!
 //! The module provides target-independent types for liveness analysis:
 //! - [`LiveRange`]: Represents the instruction range where a vreg's value is needed
-//! - [`LivenessInfo`]: Holds all liveness information (ranges, live_at, clobbers)
+//! - [`LivenessInfo`]: Holds all liveness information (ranges, clobbers)
 //!
 //! Each backend implements its own `analyze()` function that populates these types
 //! based on its specific instruction set and control flow.
@@ -45,7 +45,6 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 
-use fixedbitset::FixedBitSet;
 use rue_error::CompileResult;
 
 use crate::index_map::IndexMap;
@@ -378,10 +377,6 @@ pub struct LivenessInfo<Reg: Copy + Eq + std::hash::Hash> {
     /// Live range for each virtual register (indexed by vreg index).
     /// Uses dense Vec storage since VReg indices are contiguous.
     pub ranges: IndexMap<VReg, Option<LiveRange>>,
-    /// For each instruction, which vregs are live after it executes.
-    /// Uses FixedBitSet for O(n/64) bitwise operations instead of HashSet iteration.
-    /// This is useful for determining which registers are in use at any point.
-    pub live_at: Vec<FixedBitSet>,
     /// For each instruction index, the physical registers clobbered by that instruction.
     /// This is used to prevent allocating vregs to registers that would be clobbered.
     pub clobbers_at: Vec<Vec<Reg>>,
@@ -408,7 +403,6 @@ impl<Reg: Copy + Eq + std::hash::Hash> LivenessInfo<Reg> {
     pub fn new() -> Self {
         Self {
             ranges: IndexMap::new(),
-            live_at: Vec::new(),
             clobbers_at: Vec::new(),
             non_returning_at: Vec::new(),
             vreg_classes: VRegClasses::new(),
@@ -422,7 +416,6 @@ impl<Reg: Copy + Eq + std::hash::Hash> LivenessInfo<Reg> {
         ranges.resize(vreg_count as usize, None);
         Self {
             ranges,
-            live_at: Vec::new(),
             clobbers_at: Vec::new(),
             non_returning_at: Vec::new(),
             vreg_classes: VRegClasses::all_gp(vreg_count),
@@ -435,9 +428,12 @@ impl<Reg: Copy + Eq + std::hash::Hash> LivenessInfo<Reg> {
         self.vreg_classes.class_of(vreg)
     }
 
-    /// Get vregs that are live at a given instruction index.
-    pub fn live_at(&self, inst_idx: usize) -> &FixedBitSet {
-        &self.live_at[inst_idx]
+    /// The number of instructions this analysis covers.
+    ///
+    /// Every per-instruction table is this long; `clobbers_at` is simply the
+    /// one that is always populated.
+    pub fn instruction_count(&self) -> usize {
+        self.clobbers_at.len()
     }
 
     /// Get the live range for a vreg.
@@ -837,6 +833,18 @@ pub fn coalesce<Reg: Copy + Eq + std::hash::Hash>(
     // Union-find structure for tracking coalesced vregs
     let mut parent: HashMap<VReg, VReg> = HashMap::new();
 
+    // Find the representative of a vreg in the union-find
+    fn find(parent: &mut HashMap<VReg, VReg>, vreg: VReg) -> VReg {
+        if let Some(&p) = parent.get(&vreg) {
+            if p != vreg {
+                let root = find(parent, p);
+                parent.insert(vreg, root);
+                return root;
+            }
+        }
+        vreg
+    }
+
     // Process each candidate
     for candidate in candidates {
         let dst = find(&mut parent, candidate.dst);
@@ -893,10 +901,7 @@ pub fn coalesce<Reg: Copy + Eq + std::hash::Hash>(
             parent.insert(dst, src);
             result.coalesce_map.insert(dst, src);
 
-            // Update liveness: assign merged range to src, remove dst.
-            // These are O(1) and later candidates read `range()` to decide
-            // interference, so they stay eager; only the `live_at` rewrite is
-            // deferred (see `apply_merges_to_live_at`).
+            // Update liveness: assign merged range to src, remove dst
             liveness.ranges[src] = Some(merged_range);
             liveness.ranges[dst] = None;
 
@@ -905,72 +910,7 @@ pub fn coalesce<Reg: Copy + Eq + std::hash::Hash>(
         }
     }
 
-    apply_merges_to_live_at(&mut parent, liveness);
-
     result
-}
-
-/// Find the representative of a vreg in the union-find, with path compression.
-fn find(parent: &mut HashMap<VReg, VReg>, vreg: VReg) -> VReg {
-    if let Some(&p) = parent.get(&vreg) {
-        if p != vreg {
-            let root = find(parent, p);
-            parent.insert(vreg, root);
-            return root;
-        }
-    }
-    vreg
-}
-
-/// Rewrite the `live_at` bitsets so every coalesced vreg reads as the
-/// representative its equivalence class settled on.
-///
-/// Substituting eagerly inside the candidate loop — one full sweep of `live_at`
-/// per successful merge — costs O(merges × instructions). Both factors scale
-/// with function size, so a single large straight-line body drove the backend
-/// phase quadratic. One sweep after the loop is equivalent: the eager form
-/// rewrote dst to src at each merge, so a chain a -> b -> c rewrote `a` twice
-/// and left it on the class's final root, which is exactly `find(a)`. Nothing
-/// in the candidate loop reads `live_at`, so deferring the rewrite cannot
-/// change which candidates coalesce.
-fn apply_merges_to_live_at<Reg: Copy + Eq + std::hash::Hash>(
-    parent: &mut HashMap<VReg, VReg>,
-    liveness: &mut LivenessInfo<Reg>,
-) {
-    if parent.is_empty() {
-        return;
-    }
-
-    // Resolve the merged vregs once so the sweep below is an array read per
-    // live bit rather than a union-find walk. Every vreg the merges touched is
-    // a key of `parent`; the rest are their own representatives.
-    let mut root_of: Vec<u32> = (0..liveness.ranges.len() as u32).collect();
-    let merged: Vec<VReg> = parent.keys().copied().collect();
-    for vreg in merged {
-        let idx = vreg.index() as usize;
-        if idx < root_of.len() {
-            root_of[idx] = find(parent, vreg).index();
-        }
-    }
-
-    // A bit cannot be cleared while `ones()` borrows the set, so each set's
-    // moves are collected first. The buffer is reused across sets.
-    let mut moves: Vec<(usize, usize)> = Vec::new();
-    for live_set in &mut liveness.live_at {
-        moves.extend(live_set.ones().filter_map(|idx| {
-            // An index past `root_of` cannot name a merged vreg, so it stays.
-            let root = *root_of.get(idx)? as usize;
-            (root != idx).then_some((idx, root))
-        }));
-
-        let len = live_set.len();
-        for (from, to) in moves.drain(..) {
-            live_set.set(from, false);
-            if to < len {
-                live_set.insert(to);
-            }
-        }
-    }
 }
 
 // ============================================================================
@@ -1768,7 +1708,7 @@ pub fn linear_scan<Reg: Copy + Eq + std::hash::Hash>(
         use_loop_aware_spilling: false,
         ..Default::default()
     };
-    let loop_info = LoopInfo::no_loops(liveness.live_at.len());
+    let loop_info = LoopInfo::no_loops(liveness.instruction_count());
     let (allocation, num_spills, used_callee_saved, _debug_info) = linear_scan_impl(
         vreg_count,
         liveness,
@@ -1854,7 +1794,7 @@ pub fn linear_scan_with_remat<Reg: Copy + Eq + std::hash::Hash>(
         use_loop_aware_spilling: false,
         ..Default::default()
     };
-    let loop_info = LoopInfo::no_loops(liveness.live_at.len());
+    let loop_info = LoopInfo::no_loops(liveness.instruction_count());
     let (allocation, num_spills, used_callee_saved, _debug_info) = linear_scan_impl_with_remat(
         vreg_count,
         liveness,
@@ -1888,7 +1828,7 @@ pub fn linear_scan_with_debug<Reg: Copy + Eq + std::hash::Hash>(
         use_loop_aware_spilling: false,
         ..Default::default()
     };
-    let loop_info = LoopInfo::no_loops(liveness.live_at.len());
+    let loop_info = LoopInfo::no_loops(liveness.instruction_count());
     linear_scan_impl(
         vreg_count,
         liveness,
@@ -2657,15 +2597,13 @@ mod tests {
         // Find max vreg index and max instruction index
         let max_vreg = ranges.iter().map(|(v, _, _)| *v).max().unwrap_or(0);
         let max_inst = ranges.iter().map(|(_, _, e)| *e).max().unwrap_or(0);
-        let vreg_count = (max_vreg + 1) as usize;
 
         let mut info = LivenessInfo::with_vreg_capacity(max_vreg + 1);
         for (vreg_idx, start, end) in ranges {
             info.ranges[VReg::new(vreg_idx)] = Some(LiveRange::new(start, end));
         }
 
-        // Initialize live_at and clobbers_at based on max instruction index
-        info.live_at = vec![FixedBitSet::with_capacity(vreg_count); max_inst + 1];
+        // Initialize clobbers_at based on max instruction index
         info.clobbers_at = vec![Vec::new(); max_inst + 1];
         info
     }
@@ -2769,7 +2707,7 @@ mod tests {
             0,
             false,
             &CostModel::default(),
-            &LoopInfo::no_loops(liveness.live_at.len()),
+            &LoopInfo::no_loops(liveness.instruction_count()),
         );
 
         assert_eq!(num_spills, 0);
@@ -2811,7 +2749,7 @@ mod tests {
             0,
             false,
             &CostModel::default(),
-            &LoopInfo::no_loops(liveness.live_at.len()),
+            &LoopInfo::no_loops(liveness.instruction_count()),
         );
 
         assert_eq!(num_spills, 0, "neither interval had to spill");
@@ -2848,7 +2786,7 @@ mod tests {
             0,
             false,
             &CostModel::default(),
-            &LoopInfo::no_loops(liveness.live_at.len()),
+            &LoopInfo::no_loops(liveness.instruction_count()),
         );
 
         assert_eq!(
@@ -2881,7 +2819,7 @@ mod tests {
             0,
             false,
             &CostModel::default(),
-            &LoopInfo::no_loops(liveness.live_at.len()),
+            &LoopInfo::no_loops(liveness.instruction_count()),
         );
 
         let slot = |vreg: u32| match allocation[VReg::new(vreg)] {
@@ -2971,7 +2909,7 @@ mod tests {
             0,
             false,
             &CostModel::default(),
-            &LoopInfo::no_loops(liveness.live_at.len()),
+            &LoopInfo::no_loops(liveness.instruction_count()),
         );
 
         assert_eq!(num_spills, 0);
@@ -3016,7 +2954,7 @@ mod tests {
             0,
             false,
             &CostModel::default(),
-            &LoopInfo::no_loops(liveness.live_at.len()),
+            &LoopInfo::no_loops(liveness.instruction_count()),
         );
 
         assert_eq!(num_spills, 0);
@@ -3053,7 +2991,7 @@ mod tests {
             0,
             false,
             &CostModel::default(),
-            &LoopInfo::no_loops(liveness.live_at.len()),
+            &LoopInfo::no_loops(liveness.instruction_count()),
         );
 
         assert_eq!(num_spills, 0);
@@ -3100,7 +3038,7 @@ mod tests {
             0,
             false,
             &CostModel::default(),
-            &LoopInfo::no_loops(liveness.live_at.len()),
+            &LoopInfo::no_loops(liveness.instruction_count()),
         );
 
         assert_eq!(num_spills, 0);
@@ -3140,7 +3078,7 @@ mod tests {
             0,
             false,
             &CostModel::default(),
-            &LoopInfo::no_loops(liveness.live_at.len()),
+            &LoopInfo::no_loops(liveness.instruction_count()),
         );
 
         assert_eq!(num_spills, 3);
@@ -3712,64 +3650,6 @@ mod tests {
         assert_eq!(result.representative(VReg::new(0)), VReg::new(0));
         assert_eq!(result.representative(VReg::new(1)), VReg::new(0));
         assert_eq!(result.representative(VReg::new(2)), VReg::new(0));
-    }
-
-    #[test]
-    fn test_coalesce_rewrites_live_at_through_the_whole_chain() {
-        // The `live_at` rewrite is applied once after every candidate has been
-        // decided, so a vreg merged early and merged again later must still
-        // land on its class's final representative — v2 -> v1 -> v0 leaves
-        // every bit reading v0, and no bit for v1 or v2 survives.
-        let mut liveness = make_liveness(vec![(0, 0, 1), (1, 1, 2), (2, 2, 3)]);
-        liveness.live_at[0].insert(0);
-        liveness.live_at[1].insert(1);
-        liveness.live_at[2].insert(2);
-        // A point where both a merged vreg and its representative are live.
-        liveness.live_at[3].insert(0);
-        liveness.live_at[3].insert(2);
-
-        let candidates = vec![
-            CoalesceCandidate {
-                inst_idx: 1,
-                dst: VReg::new(1),
-                src: VReg::new(0),
-            },
-            CoalesceCandidate {
-                inst_idx: 2,
-                dst: VReg::new(2),
-                src: VReg::new(1),
-            },
-        ];
-
-        coalesce(&candidates, &mut liveness);
-
-        for (idx, live_set) in liveness.live_at.iter().enumerate() {
-            assert_eq!(
-                live_set.ones().collect::<Vec<_>>(),
-                vec![0],
-                "live_at[{idx}] should name only the representative v0"
-            );
-        }
-    }
-
-    #[test]
-    fn test_coalesce_leaves_live_at_alone_without_merges() {
-        // No candidate coalesces, so the bitsets must come back untouched.
-        let mut liveness = make_liveness(vec![(0, 0, 3), (1, 1, 4)]);
-        liveness.live_at[1].insert(0);
-        liveness.live_at[1].insert(1);
-
-        // v0 is still live at the move, so the ranges interfere.
-        let candidates = vec![CoalesceCandidate {
-            inst_idx: 3,
-            dst: VReg::new(1),
-            src: VReg::new(0),
-        }];
-
-        let result = coalesce(&candidates, &mut liveness);
-
-        assert_eq!(result.num_eliminated(), 0);
-        assert_eq!(liveness.live_at[1].ones().collect::<Vec<_>>(), vec![0, 1]);
     }
 
     #[test]

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -837,18 +837,6 @@ pub fn coalesce<Reg: Copy + Eq + std::hash::Hash>(
     // Union-find structure for tracking coalesced vregs
     let mut parent: HashMap<VReg, VReg> = HashMap::new();
 
-    // Find the representative of a vreg in the union-find
-    fn find(parent: &mut HashMap<VReg, VReg>, vreg: VReg) -> VReg {
-        if let Some(&p) = parent.get(&vreg) {
-            if p != vreg {
-                let root = find(parent, p);
-                parent.insert(vreg, root);
-                return root;
-            }
-        }
-        vreg
-    }
-
     // Process each candidate
     for candidate in candidates {
         let dst = find(&mut parent, candidate.dst);
@@ -905,28 +893,84 @@ pub fn coalesce<Reg: Copy + Eq + std::hash::Hash>(
             parent.insert(dst, src);
             result.coalesce_map.insert(dst, src);
 
-            // Update liveness: assign merged range to src, remove dst
+            // Update liveness: assign merged range to src, remove dst.
+            // These are O(1) and later candidates read `range()` to decide
+            // interference, so they stay eager; only the `live_at` rewrite is
+            // deferred (see `apply_merges_to_live_at`).
             liveness.ranges[src] = Some(merged_range);
             liveness.ranges[dst] = None;
-
-            // Update live_at bitsets: replace dst with src
-            for live_set in &mut liveness.live_at {
-                let dst_idx = dst.index() as usize;
-                let src_idx = src.index() as usize;
-                if dst_idx < live_set.len() && live_set.contains(dst_idx) {
-                    live_set.set(dst_idx, false);
-                    if src_idx < live_set.len() {
-                        live_set.insert(src_idx);
-                    }
-                }
-            }
 
             // Mark the move for elimination
             result.eliminated_moves.insert(candidate.inst_idx);
         }
     }
 
+    apply_merges_to_live_at(&mut parent, liveness);
+
     result
+}
+
+/// Find the representative of a vreg in the union-find, with path compression.
+fn find(parent: &mut HashMap<VReg, VReg>, vreg: VReg) -> VReg {
+    if let Some(&p) = parent.get(&vreg) {
+        if p != vreg {
+            let root = find(parent, p);
+            parent.insert(vreg, root);
+            return root;
+        }
+    }
+    vreg
+}
+
+/// Rewrite the `live_at` bitsets so every coalesced vreg reads as the
+/// representative its equivalence class settled on.
+///
+/// Substituting eagerly inside the candidate loop — one full sweep of `live_at`
+/// per successful merge — costs O(merges × instructions). Both factors scale
+/// with function size, so a single large straight-line body drove the backend
+/// phase quadratic. One sweep after the loop is equivalent: the eager form
+/// rewrote dst to src at each merge, so a chain a -> b -> c rewrote `a` twice
+/// and left it on the class's final root, which is exactly `find(a)`. Nothing
+/// in the candidate loop reads `live_at`, so deferring the rewrite cannot
+/// change which candidates coalesce.
+fn apply_merges_to_live_at<Reg: Copy + Eq + std::hash::Hash>(
+    parent: &mut HashMap<VReg, VReg>,
+    liveness: &mut LivenessInfo<Reg>,
+) {
+    if parent.is_empty() {
+        return;
+    }
+
+    // Resolve the merged vregs once so the sweep below is an array read per
+    // live bit rather than a union-find walk. Every vreg the merges touched is
+    // a key of `parent`; the rest are their own representatives.
+    let mut root_of: Vec<u32> = (0..liveness.ranges.len() as u32).collect();
+    let merged: Vec<VReg> = parent.keys().copied().collect();
+    for vreg in merged {
+        let idx = vreg.index() as usize;
+        if idx < root_of.len() {
+            root_of[idx] = find(parent, vreg).index();
+        }
+    }
+
+    // A bit cannot be cleared while `ones()` borrows the set, so each set's
+    // moves are collected first. The buffer is reused across sets.
+    let mut moves: Vec<(usize, usize)> = Vec::new();
+    for live_set in &mut liveness.live_at {
+        moves.extend(live_set.ones().filter_map(|idx| {
+            // An index past `root_of` cannot name a merged vreg, so it stays.
+            let root = *root_of.get(idx)? as usize;
+            (root != idx).then_some((idx, root))
+        }));
+
+        let len = live_set.len();
+        for (from, to) in moves.drain(..) {
+            live_set.set(from, false);
+            if to < len {
+                live_set.insert(to);
+            }
+        }
+    }
 }
 
 // ============================================================================
@@ -3668,6 +3712,64 @@ mod tests {
         assert_eq!(result.representative(VReg::new(0)), VReg::new(0));
         assert_eq!(result.representative(VReg::new(1)), VReg::new(0));
         assert_eq!(result.representative(VReg::new(2)), VReg::new(0));
+    }
+
+    #[test]
+    fn test_coalesce_rewrites_live_at_through_the_whole_chain() {
+        // The `live_at` rewrite is applied once after every candidate has been
+        // decided, so a vreg merged early and merged again later must still
+        // land on its class's final representative — v2 -> v1 -> v0 leaves
+        // every bit reading v0, and no bit for v1 or v2 survives.
+        let mut liveness = make_liveness(vec![(0, 0, 1), (1, 1, 2), (2, 2, 3)]);
+        liveness.live_at[0].insert(0);
+        liveness.live_at[1].insert(1);
+        liveness.live_at[2].insert(2);
+        // A point where both a merged vreg and its representative are live.
+        liveness.live_at[3].insert(0);
+        liveness.live_at[3].insert(2);
+
+        let candidates = vec![
+            CoalesceCandidate {
+                inst_idx: 1,
+                dst: VReg::new(1),
+                src: VReg::new(0),
+            },
+            CoalesceCandidate {
+                inst_idx: 2,
+                dst: VReg::new(2),
+                src: VReg::new(1),
+            },
+        ];
+
+        coalesce(&candidates, &mut liveness);
+
+        for (idx, live_set) in liveness.live_at.iter().enumerate() {
+            assert_eq!(
+                live_set.ones().collect::<Vec<_>>(),
+                vec![0],
+                "live_at[{idx}] should name only the representative v0"
+            );
+        }
+    }
+
+    #[test]
+    fn test_coalesce_leaves_live_at_alone_without_merges() {
+        // No candidate coalesces, so the bitsets must come back untouched.
+        let mut liveness = make_liveness(vec![(0, 0, 3), (1, 1, 4)]);
+        liveness.live_at[1].insert(0);
+        liveness.live_at[1].insert(1);
+
+        // v0 is still live at the move, so the ranges interfere.
+        let candidates = vec![CoalesceCandidate {
+            inst_idx: 3,
+            dst: VReg::new(1),
+            src: VReg::new(0),
+        }];
+
+        let result = coalesce(&candidates, &mut liveness);
+
+        assert_eq!(result.num_eliminated(), 0);
+        assert_eq!(liveness.live_at[1].ones().collect::<Vec<_>>(), vec![0, 1]);
     }
 
     #[test]

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -564,8 +564,8 @@ mod tests {
         let info = analyze(&mir);
 
         assert!(info.ranges.is_empty());
-        assert!(info.live_at.is_empty());
         assert!(info.clobbers_at.is_empty());
+        assert_eq!(info.instruction_count(), 0);
     }
 
     #[test]

--- a/crates/rue-codegen/src/x86_64/peephole.rs
+++ b/crates/rue-codegen/src/x86_64/peephole.rs
@@ -63,15 +63,39 @@ pub fn optimize(instructions: &mut Vec<X86Inst>) -> usize {
     // Pass 2: Adjacent instruction combining (add chains)
     changes += combine_adjacent(instructions);
 
-    // Pass 3: Remove identity instructions
-    let mut i = 0;
-    while i < instructions.len() {
-        if is_redundant(&instructions[i]) && removal_preserves_flags(instructions, i) {
-            instructions.remove(i);
-            changes += 1;
-        } else {
-            i += 1;
+    // Pass 3: Remove identity instructions.
+    //
+    // Mark against the pristine vector, then compact once. Deleting in place
+    // with `Vec::remove` shifts the whole tail per removal, and the FLAGS gate
+    // rescanned that tail per candidate, so a long run of redundant
+    // instructions cost O(removals × n) twice over. AArch64's pass 3 already
+    // compacts with `retain`; this matches it while keeping the FLAGS gate,
+    // which AArch64 does not need.
+    //
+    // Marking against the pristine vector is what the in-place loop already
+    // saw. It only ever removed instructions *before* the one it was
+    // examining, so the forward scan behind the gate never observed a removed
+    // instruction — the tail at each decision point was the pristine tail.
+    // Passes 1 and 2 rewrote the stream, so FLAGS-liveness is recomputed here
+    // rather than reusing the pass-1 snapshot.
+    let flags_dead = compute_flags_dead(instructions);
+    let mut doomed = vec![false; instructions.len()];
+    let mut removals = 0;
+    for (i, inst) in instructions.iter().enumerate() {
+        if is_redundant(inst) && removal_preserves_flags(inst, flags_dead[i]) {
+            doomed[i] = true;
+            removals += 1;
         }
+    }
+
+    if removals > 0 {
+        let mut i = 0;
+        instructions.retain(|_| {
+            let keep = !doomed[i];
+            i += 1;
+            keep
+        });
+        changes += removals;
     }
 
     changes
@@ -159,17 +183,20 @@ fn is_shift_by_zero(inst: &X86Inst) -> bool {
     )
 }
 
-/// Check that removing the (redundant) instruction at `idx` does not drop a
-/// FLAGS write that a later reader observes (RUE-152).
+/// Check that removing the (redundant) `inst` does not drop a FLAGS write that
+/// a later reader observes (RUE-152).
 ///
 /// `add r, 0` and `xor r, 0` are register no-ops but still set FLAGS;
-/// shift-by-zero and `mov r, r` touch no flags at all.
-fn removal_preserves_flags(instructions: &[X86Inst], idx: usize) -> bool {
-    let inst = &instructions[idx];
+/// shift-by-zero and `mov r, r` touch no flags at all, so they need no gate.
+///
+/// `flags_dead` must equal `flags_dead_after(instructions, idx)` for the
+/// instruction's own position (precomputed by the caller so a whole pass costs
+/// O(n), not O(n²)).
+fn removal_preserves_flags(inst: &X86Inst, flags_dead: bool) -> bool {
     if !writes_flags(inst) || is_shift_by_zero(inst) {
         return true;
     }
-    flags_dead_after(instructions, idx)
+    flags_dead
 }
 
 /// Transform the instruction at `idx` to a more efficient form.
@@ -978,6 +1005,73 @@ mod tests {
         optimize(&mut instructions);
 
         assert!(matches!(instructions[0], X86Inst::XorRR { .. }));
+    }
+
+    #[test]
+    fn test_redundant_mov_removed_before_flags_reader() {
+        // `mov rax, rax` touches no flags, so removing it cannot disturb the
+        // flags `jz` consumes: it goes even with a reader immediately after.
+        let mut instructions = vec![
+            X86Inst::CmpRI {
+                src: Operand::Physical(Reg::Rbx),
+                imm: 42,
+            },
+            X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rax),
+                src: Operand::Physical(Reg::Rax),
+            },
+            X86Inst::Jz {
+                label: LabelId::new(0),
+            },
+            X86Inst::Ret,
+        ];
+
+        let changes = optimize(&mut instructions);
+
+        assert_eq!(changes, 1);
+        assert_eq!(instructions.len(), 3);
+        assert!(matches!(instructions[0], X86Inst::CmpRI { imm: 42, .. }));
+        assert!(matches!(instructions[1], X86Inst::Jz { .. }));
+        assert!(matches!(instructions[2], X86Inst::Ret));
+    }
+
+    #[test]
+    fn test_removals_gate_each_instruction_at_its_own_position() {
+        // Pass 3 marks against the pristine vector and compacts once, so every
+        // gate decision must still be read at that instruction's own position:
+        // the flags-writing `xor r, 0` in the middle stays because `jz` reads
+        // its flags, while the two flag-free movs around it go, and the
+        // trailing `add r, 0` goes because `ret` leaves its flags dead.
+        let mut instructions = vec![
+            X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rax),
+                src: Operand::Physical(Reg::Rax),
+            },
+            X86Inst::XorRI {
+                dst: Operand::Physical(Reg::Rax),
+                imm: 0,
+            },
+            X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rbx),
+                src: Operand::Physical(Reg::Rbx),
+            },
+            X86Inst::Jz {
+                label: LabelId::new(0),
+            },
+            X86Inst::AddRI {
+                dst: Operand::Physical(Reg::Rax),
+                imm: 0,
+            },
+            X86Inst::Ret,
+        ];
+
+        let changes = optimize(&mut instructions);
+
+        assert_eq!(changes, 3);
+        assert_eq!(instructions.len(), 3);
+        assert!(matches!(instructions[0], X86Inst::XorRI { imm: 0, .. }));
+        assert!(matches!(instructions[1], X86Inst::Jz { .. }));
+        assert!(matches!(instructions[2], X86Inst::Ret));
     }
 
     #[test]


### PR DESCRIPTION
Fixes RUE-1335.

A single large straight-line function compiled with backend-phase time growing
as the square of its statement count. Three things in `rue-codegen` were
responsible. Each commit is independently byte-preserving.

## 1. Register coalescing swept `live_at` per merge (`regalloc.rs`)

`coalesce()` swept **every** `live_at` bitset on each successful merge to
substitute dst with src, so the number of full sweeps tracked the number of move
candidates: O(merges × instructions). Both factors scale with function size.

## 2. x86-64 peephole identity removal (`x86_64/peephole.rs`)

Pass 3 deleted with `Vec::remove` inside a loop, shifting the whole tail per
removal, and the FLAGS gate re-scanned that tail per candidate — O(removals × n)
twice over.

It now marks removals against the pristine vector and compacts once with
`retain`, matching what AArch64's pass 3 already does, with FLAGS-liveness
precomputed in a single backward pass (`compute_flags_dead`, the same technique
pass 1 already uses; recomputed here because passes 1 and 2 rewrite the stream).

Marking against the pristine vector is exactly what the in-place loop saw: it
only ever removed instructions *before* the one it was examining, so the gate's
forward scan never observed a removed instruction, and the tail at each decision
point was the pristine tail.

## 3. The `live_at` bitsets themselves (`liveness.rs`)

Fixing (1) by deferring the sweep left the backend still scaling at ~3.3x per
doubling, and a callgrind diff put the residual in the dense bitsets rather than
in anything that read them. `LivenessInfo::live_at` was a
`Vec<FixedBitSet>` sized instructions × vregs, so building it was quadratic on
its own — and nothing read its contents: the `live_at(idx)` accessor had no
callers, `compute_pressure` was exercised only by its own tests, and the field's
only live use was `.len()` as an instruction count.

So the field is gone, along with the two builders that fed it
(`compute_live_at`, `compute_acyclic_live_at`) and the pressure surface that
consumed it (`PressureInfo`, `compute_pressure` — the dead code RUE-1335 asked
to either wire up or delete). Coalescing loses its `live_at` maintenance
entirely rather than deferring it, which makes commit 1 a deletion. The
instruction count is now `LivenessInfo::instruction_count()`, backed by the
per-instruction `clobbers_at` table. A pressure-aware allocator that wants these
sets back should reintroduce them alongside its own consumer.

## Numbers

Generated single-function probe, `-O3 -j1`, release compiler, backend phase.
Runs are warm and interleaved across the three binaries, best of five — the
first run of any size on this host is several times slower than steady state, so
a naive before-then-after ordering overstates the win.

| statements | before | after 1+2 | after 1+2+3 | total |
| --- | --- | --- | --- | --- |
| 1000 | 120.7 ms | 24.5 ms | 19.2 ms | 6.3x |
| 2000 | 470.3 ms | 83.4 ms | 54.5 ms | 8.6x |
| 4000 | 2891.9 ms | 324.2 ms | 200.2 ms | 14.4x |

## Codegen is unchanged

Compiling with the before and after binaries and comparing executable sha256 —
identical at every stage of the series:

| check | result |
| --- | --- |
| `examples/lattice/main.rue` at -O0 / -O1 / -O2 / -O3 | match |
| probes n=1000 / 2000 / 4000 at -O3 | match |
| lattice + n=2000 on `aarch64-linux` and `aarch64-macos` | match |

The AArch64 checks matter because commit 3 touches the shared `liveness.rs`.

## Tests

- `scripts/rue unit codegen` — 718 passed, covering both backends. Two new
  peephole cases pin the FLAGS gate per instruction position: a redundant
  `mov r, r` is still removed ahead of a flags reader, and a flags-writing
  `xor r, 0` is kept between two removable neighbours. Four tests were deleted
  with the surface they exercised (two pressure tests, one `live_at` union test,
  one empty-info assertion folded into `instruction_count()`).
- `scripts/rue quick` — 30/30.
- `//crates/rue-codegen:rue-codegen-clippy` — pass.

## What is still superlinear

This does not make the backend linear: the probe still scales ~3.5x per doubling
(15.0 / 62.3 / 193.2 / 681.3 ms at n=1000…8000). A callgrind profile of the
final binary puts the residual in `compute_dataflow`, whose `live_in` table has
the same instructions × vregs shape that `live_at` had. The difference is that
`live_in` is load-bearing — `build_live_ranges` reads it — so making it cheap
means changing the liveness representation itself (sparse sets, or deriving
ranges without materializing per-instruction live-in), not deleting it. Tracked
separately as RUE-1545.