### PR TITLE
RUE-1473: skip redundant successful teardown

### DIFF
--- a/crates/rue-cli-tests/cases/successful_fast_exit.toml
+++ b/crates/rue-cli-tests/cases/successful_fast_exit.toml
@@ -1,0 +1,39 @@
+# Successful one-shot native compilation commits all observable output before
+# the driver takes its bounded std::process::exit path (RUE-1473).
+
+[section]
+id = "cli.successful_fast_exit"
+name = "Successful one-shot fast exit"
+description = "Successful native compilation preserves text, benchmark, timing, warnings, and the published executable before exiting 0."
+
+[[case]]
+name = "normal_success_publishes_and_runs"
+files = [{ path = "main.rue", source = "fn main() -> i32 { 0 }\n" }]
+args = ["main.rue", "-o", "prog"]
+compile_stdout_contains = ["Compiled"]
+compile_stderr_not_contains = ["internal compiler error"]
+exit_code = 0
+
+[[case]]
+name = "benchmark_json_is_complete_before_exit"
+files = [{ path = "main.rue", source = "fn main() -> i32 { 0 }\n" }]
+args = ["--benchmark-json", "-j1", "main.rue", "-o", "prog"]
+compile_stdout_contains = [
+  '"schema_version":16',
+  '"phase_accounting":',
+  '"compiler_work":',
+  '"compiler_boundary":',
+  '"emitted_output":',
+]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["internal compiler error"]
+exit_code = 0
+
+[[case]]
+name = "time_passes_and_warnings_survive_exit"
+files = [{ path = "main.rue", source = "fn main() -> i32 {\n    let unused = 42;\n    0\n}\n" }]
+args = ["--time-passes", "main.rue", "-o", "prog"]
+compile_stdout_contains = ["Compiled"]
+compile_stderr_contains = ["Compile", "Lexer", "unused variable"]
+compile_stderr_not_contains = ["internal compiler error"]
+exit_code = 0

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(test)]
@@ -960,6 +961,18 @@ fn print_timing_output(
     }
 }
 
+/// Finish a successful one-shot native compile after every observable
+/// commitment has completed. The compiler host owns only retained query and
+/// source state at this point; publication's temporary guard and all output
+/// reads have already completed. `std::process::exit` preserves the platform
+/// atexit path while avoiding a second full destruction walk of that retained
+/// state. This is deliberately not used for watch, emit, or any failure path.
+fn exit_successful_native_compile() -> ! {
+    let _ = std::io::stdout().flush();
+    let _ = std::io::stderr().flush();
+    std::process::exit(0);
+}
+
 fn compiler_build_profile() -> CompilerBuildProfile {
     #[cfg(rue_release_build)]
     {
@@ -1850,6 +1863,7 @@ fn main() {
                 compiler_boundary.as_ref(),
                 critical_path.as_ref(),
             );
+            exit_successful_native_compile();
         }
         Err(errors) => {
             diagnostics.print_errors(&errors);


### PR DESCRIPTION
## What changed

After a successful one-shot native compile has published its executable, diagnostics, benchmark evidence, and timing output, Rue now explicitly flushes stdout and stderr and exits through `std::process::exit(0)`. Watch mode, emit modes, and every failure path keep their existing cleanup behavior.

CLI coverage verifies normal success output, benchmark JSON, timing output, warnings, exit status, executable publication, and execution.

## Why

Returning normally from `main` recursively destroyed the retained compiler session, source graph, and query graph immediately before the OS reclaimed the process. Six alternating release measurements isolated a median 66.3 ms post-report teardown cost; `std::process::exit` and `_exit` were equivalent, showing that Rust destruction—not platform `atexit` finalization—owned the delay. The chosen path preserves platform `atexit` handlers.

This improves fresh-process wall time after the compiler timing root; it does not claim faster semantic, CFG, or codegen work. RUE-1473 tracks the broader compilation-performance effort.

## Validation

- `scripts/rue cli successful_fast_exit`: 3/3
- `scripts/rue quick`: 30/30
- `scripts/rue premerge`: 194/194
- Six-pair release teardown experiment: median 66.3 ms saved; every paired sample saved more than 51 ms
- Exact artifact SHA-256, size, deterministic benchmark projection, exit status, and temporary-file cleanliness across normal return, `process::exit`, and `_exit` arms