### PR TITLE
Fix fuzz-discovered compiler crashes

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -499,6 +499,25 @@ impl<'a> ConstraintGenerator<'a> {
         false
     }
 
+    /// Whether an already-known operand is one of Rue's packed string types.
+    /// String indexing is lowered by semantic analysis to a byte read, so its
+    /// result is always `u8`, unlike an array index whose element type comes
+    /// from the array itself. String literals are admitted here too: their
+    /// contextual type is finalized later, but indexing one has the same
+    /// result type regardless of whether it becomes `str` or `StrBuf`.
+    fn is_string_indexable_type(&self, ty: &InferType) -> bool {
+        if self.is_string_concrete(ty) || self.is_string_literal_candidate(ty) {
+            return true;
+        }
+        let InferType::Concrete(t) = ty else {
+            return false;
+        };
+        let Some(id) = t.as_struct() else {
+            return false;
+        };
+        crate::types::is_string_view_struct_name(&self.type_pool.struct_def(id).name)
+    }
+
     /// The pointee of a pointer operand whose type is *already* concrete at
     /// constraint-generation time — an annotated binding, a parameter, a
     /// pointer-returning intrinsic with a fixed result type. Returns `None` for
@@ -2597,13 +2616,17 @@ impl<'a> ConstraintGenerator<'a> {
                 // Extract element type from array type.
                 // If base is InferType::Array, we can get the element type directly.
                 // Otherwise, we need a fresh variable that will be resolved later.
-                match &base_info.ty {
-                    InferType::Array { element, .. } => (**element).clone(),
-                    _ => {
-                        // Base might be a type variable that will resolve to an array.
-                        // Use a fresh variable for the element type.
-                        let result_var = self.fresh_var();
-                        InferType::Var(result_var)
+                if self.is_string_indexable_type(&base_info.ty) {
+                    InferType::Concrete(Type::U8)
+                } else {
+                    match &base_info.ty {
+                        InferType::Array { element, .. } => (**element).clone(),
+                        _ => {
+                            // Base might be a type variable that will resolve to an array.
+                            // Use a fresh variable for the element type.
+                            let result_var = self.fresh_var();
+                            InferType::Var(result_var)
+                        }
                     }
                 }
             }

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -1119,8 +1119,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             }
         }
 
-        // Get the array type from HM inference
-        let array_type = Self::get_resolved_type(ctx, inst_ref, span, "array literal")?;
+        // Get the array type from HM inference. An unresolved element
+        // variable can survive recovery around a malformed or partially
+        // specialized comptime construction; report the same actionable
+        // annotation diagnostic used for an unconstrained empty array rather
+        // than turning the missing map entry into an internal compiler error.
+        let Some(array_type) = ctx.resolved_type_of(inst_ref) else {
+            return Err(CompileError::new(ErrorKind::TypeAnnotationRequired, span));
+        };
 
         // If an element expression is itself ill-typed, HM inference collapses
         // the whole array to `<error>` rather than a real `[T; N]` (see

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -1050,6 +1050,23 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         ctx.byref_arg_root = saved_byref_root;
                         let index_result = index_result?;
 
+                        // A place trace can be built before the outer read or
+                        // write path performs its normal index validation. Do
+                        // the same AIR-level check here so generic analysis
+                        // cannot record a `type`-valued projection and defer
+                        // the failure to whole-body AIR validation.
+                        let index_type = air.get(index_result.air_ref).ty;
+                        if !index_type.is_integer() {
+                            return Err(CompileError::new(
+                                ErrorKind::TypeMismatch {
+                                    expected: "integer type".to_string(),
+                                    found: index_type
+                                        .safe_name_with_pool(Some(self.body_type_pool())),
+                                },
+                                self.body_rir_ref().get(*index).span,
+                            ));
+                        }
+
                         // Add this projection (no field name for indices).
                         // A non-negative constant index also gets its interned
                         // element path segment so field_path can nest through
@@ -3114,6 +3131,21 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ));
             }
         };
+
+        // Type inference normally enforces this constraint, but generic bodies
+        // can reach authoritative semantic analysis before a comptime type
+        // parameter has been substituted. Reject that value here as well so a
+        // `type`-typed AIR operand cannot reach an index projection.
+        let index_type = air.get(index_result.air_ref).ty;
+        if !index_type.is_integer() {
+            return Err(CompileError::new(
+                ErrorKind::TypeMismatch {
+                    expected: "integer type".to_string(),
+                    found: index_type.safe_name_with_pool(Some(self.body_type_pool())),
+                },
+                self.body_rir_ref().get(index).span,
+            ));
+        }
 
         // Check for constant out-of-bounds index (at the index's resolved
         // operand types, so an overflowing index expression is a compile-time

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -671,13 +671,16 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // 7.1:7. A negative or out-of-range runtime index is not a type
             // error; it traps at runtime via the bounds check (RUE-81).
             let index_result = self.analyze_inst(air, *index, ctx)?;
-            if !index_result.ty.is_integer() && !index_result.ty.is_error() {
+            // Use the AIR instruction's type as the final guard. During
+            // generic analysis the lightweight result can be `ERROR` while
+            // the emitted value still carries a concrete non-integer type;
+            // allowing that value into a projection produces invalid AIR.
+            let index_type = air.get(index_result.air_ref).ty;
+            if !index_type.is_integer() {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
                         expected: "integer type".to_string(),
-                        found: index_result
-                            .ty
-                            .safe_name_with_pool(Some(self.body_type_pool())),
+                        found: index_type.safe_name_with_pool(Some(self.body_type_pool())),
                     },
                     self.body_rir_ref().get(*index).span,
                 ));

--- a/crates/rue-spec/cases/arrays/fixed.toml
+++ b/crates/rue-spec/cases/arrays/fixed.toml
@@ -150,6 +150,38 @@ fn main() -> i32 {
 """
 compile_fail = true
 
+[[case]]
+name = "generic_index_type_error_is_diagnostic"
+spec = ["7.1:7"]
+description = "A comptime type parameter cannot be used as an array index; generic analysis must report a type error before building AIR."
+source = """
+fn f(comptime T: type, x: T) -> i32 {
+    let y: [T; 2] = [x, x];
+    y[T] + y[1]
+}
+fn main() -> i32 { f(i32, 5) }
+"""
+compile_fail = true
+error_contains = ["E0206", "integer type", "type"]
+
+[[case]]
+name = "unresolved_generic_array_literal_is_diagnostic"
+spec = ["7.1:7"]
+description = "An unresolved array literal in a malformed generic construction reports the annotation diagnostic instead of an internal compiler error."
+source = """
+const K: i32 = 3;
+fn Matrix(comptime T: type, comptime N: i32) -> type { struct { row: [T; N] } }
+fn sum(m: Matrix(i32, K)) -> i32 {
+    m.row[0] + m.row[1] + m.row[2]
+}
+fn main() -> i32 {
+    let M = Matrix(i32, K);
+    sum(M { row: [40, 1, 1] }) { row: [T; N] }
+}
+"""
+compile_fail = true
+error_contains = ["E0903"]
+
 # =============================================================================
 # Compile-Time Bounds Checking
 # =============================================================================

--- a/crates/rue-spec/cases/types/strings.toml
+++ b/crates/rue-spec/cases/types/strings.toml
@@ -826,6 +826,21 @@ fn main() -> i32 {
 runtime_error = "index out of bounds"
 
 [[case]]
+name = "string_index_return_type_mismatch_is_diagnostic"
+spec = ["3.7:15", "3.7:16"]
+description = "A string byte index has type u8, so returning it as i8 is a normal type error rather than a CFG ICE."
+source = """
+fn first(s: str) -> i8 {
+    s[0]
+}
+fn main() -> i32 {
+    @intCast(first("hello"))
+}
+"""
+compile_fail = true
+error_contains = ["E0206", "expected i8", "found u8"]
+
+[[case]]
 name = "string_substring_len"
 spec = ["3.7:19"]
 real_std = true


### PR DESCRIPTION
## Summary

- Fix string indexing inference so `str[0]` is typed as `u8`, producing a normal type mismatch instead of a CFG verification ICE.
- Reject non-integer generic array indices before they can become invalid AIR projections.
- Recover unresolved generic array literals with a diagnostic instead of an internal compiler error.
- Add regression cases for the three fuzz-discovered reproducers from issue #2085.

## Root cause

Several frontend recovery paths allowed unresolved or incorrectly typed operands to reach AIR validation. String indexing also used the generic array-element inference path even though semantic analysis lowers it to a byte read.

## Validation

- Full spec suite: 2,343 passed, 18 ignored.
- `payload_schemas` fuzz target: 6 corpus entries, 0 crashes.
- `sema` fuzz target: 6 corpus entries, 0 crashes.
- AIR and spec formatting checks pass.
- `git diff --check` passes.

Closes #2085
