### PR TITLE
Gate discovery certificate misses to linear chain growth

### DIFF
--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -1877,6 +1877,19 @@ impl CompilerSession {
         self.parse_sources_materialized
     }
 
+    /// Cumulative red/green validation certificate misses in the canonical
+    /// query runtime. ADR-0073 makes fresh-build discovery preserve
+    /// certificates across its append-only frontier rounds, so this count
+    /// stays linear in module count on a deep import chain; a return toward
+    /// rounds-times-graph growth is a structural regression.
+    pub(crate) fn validation_certificate_misses(&self) -> u64 {
+        self.queries
+            .revisioned
+            .runtime_retention_metrics()
+            .validation
+            .certificate_misses
+    }
+
     /// See the field docs on `parse_key_entries_compared`.
     pub(crate) fn parse_key_entries_compared(&self) -> u64 {
         self.parse_key_entries_compared

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -200,6 +200,15 @@ pub fn parse_sources_materialized(session: &crate::CompilerSession) -> u64 {
     session.parse_sources_materialized()
 }
 
+/// Cumulative red/green validation certificate misses (ADR-0073). Fresh-build
+/// discovery preserves certificates across append-only frontier rounds, so a
+/// deep import chain keeps this linear in module count; growth toward
+/// rounds-times-graph is a structural regression, gated where discovery-shape
+/// tests already pin per-round linearity.
+pub fn validation_certificate_misses(session: &crate::CompilerSession) -> u64 {
+    session.validation_certificate_misses()
+}
+
 /// Source entries embedded in parse query keys (RUE-1112): an ordinary key
 /// carries every file's exact content identity; a successor key carries only
 /// the published lineage identity plus its appended segment.

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -2067,6 +2067,17 @@ mod tests {
             (MODULES - 1) as u64,
             "each import occurrence must enter the plan exactly once"
         );
+        // ADR-0073: every frontier round publishes an append-only overlay, so
+        // validation certificates survive the whole discovery chain. Without
+        // that, each of the ~MODULES rounds expired every certificate and this
+        // count grew as rounds times graph size — quadratic in chain depth
+        // (961+ at this shape). The bound is deliberately loose against
+        // scheduling variation while remaining far below quadratic growth.
+        assert!(
+            rue_compiler::unstable::validation_certificate_misses(&result.session)
+                <= (MODULES as u64) * 8,
+            "discovery certificate misses must stay linear in module count"
+        );
     }
 
     fn module_source_id(


### PR DESCRIPTION
## What

The premerge structural gate promised in the ADR-0073 follow-ups. The existing deep-import-chain staging test (`import_chain_stages_only_each_new_module_and_import_group`, 32-module chain through the real discovery loop) already pins parse-materialization and plan-group linearity per round; it now also asserts `validation_certificate_misses <= MODULES * 8`.

Calibration: before the ADR-0073 mechanism, each frontier round expired every certificate and this counter grew as rounds × graph size — 961+ at this exact shape, well over the 256 bound. After it, the count is single digits. A regression toward quadratic discovery validation now fails a fast premerge unit test instead of waiting for a wall-clock symptom on the scaling dashboard.

Adds the `CompilerSession` accessor (reading the existing `runtime_retention_metrics()` snapshot) and the matching `unstable::validation_certificate_misses` helper in the established pattern of the other discovery-shape counters.

## Validation

- `rue-driver-test`: 39/39 pass (including the extended chain test)
- `scripts/rue quick`: green
- `scripts/rue fmt`: clean
- No production code paths changed — accessor + test only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTiBg7df72iMgdpAFv5wZs)_