### PR TITLE
RUE-1471: reuse durable anonymous identity digests

### DIFF
--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -246,6 +246,18 @@ pub trait DurableAnonymousSource<K, M> {
         _key: &AnonymousNominalKey<K, M>,
     ) -> Option<DurableAnonymousShape<K, M>>;
 
+    /// Return the durable shape and its canonical presentation digest from one
+    /// source operation. The default composes the two legacy hooks for small
+    /// test sources; compiler-owned sources should override this to perform a
+    /// single durable-record lookup.
+    fn anonymous_shape_and_digest(
+        &self,
+        key: &AnonymousNominalKey<K, M>,
+    ) -> Option<(DurableAnonymousShape<K, M>, u128)> {
+        let shape = self.anonymous_shape(key)?;
+        Some((shape, self.anonymous_identity_digest(key)))
+    }
+
     /// Callable signatures declared by an anonymous struct. Implementations
     /// that only provide shape identity may leave this empty.
     fn anonymous_methods(
@@ -272,6 +284,23 @@ pub trait DurableAnonymousSource<K, M> {
         _key: &AnonymousNominalKey<K, M>,
     ) -> Vec<(Arc<str>, SemanticImportConstValue<K, M>)> {
         Vec::new()
+    }
+
+    /// Return the canonical presentation digest for an anonymous identity.
+    ///
+    /// The default is deliberately the same relocation and hash used by the
+    /// semantic epoch, so small test sources need no extra bookkeeping. A
+    /// compiler-owned source may override this with a digest retained by its
+    /// durable anonymous fact; the structured key remains the semantic
+    /// authority and this value is presentation-only.
+    fn anonymous_identity_digest(&self, key: &AnonymousNominalKey<K, M>) -> u128 {
+        let relocated: AnonymousNominalKey<String, String> = key
+            .try_map_identities::<String, String, std::convert::Infallible>(
+                &|definition| Ok(self.definition_symbol_component(definition)),
+                &|module| Ok(self.module_symbol_component(module)),
+            )
+            .expect("anonymous identity relocation to stable content is infallible");
+        crate::stable_digest::stable_anonymous_identity_digest(&relocated)
     }
 
     /// Relocate a durable definition key to the exact stable-symbol content the
@@ -1619,9 +1648,9 @@ where
             return Err(error.clone());
         }
 
-        let shape = self
+        let (shape, digest) = self
             .source
-            .anonymous_shape(key)
+            .anonymous_shape_and_digest(key)
             .ok_or(IdentityMintError::MissingAnonymousShape)?;
 
         // The presentation digest is a pure function of the producer identity,
@@ -1629,7 +1658,6 @@ where
         // is spelled into the name only; guard a distinct key colliding on it
         // BEFORE reserving or registering, so no colliding entity or symbol is
         // ever published (RUE-1089, Theme 4b).
-        let digest = self.anonymous_identity_digest(key);
         self.guard_anonymous_digest_collision(digest, key)?;
 
         let minted = match shape {
@@ -1879,21 +1907,6 @@ where
             return self.enum_identities.get(&id).cloned();
         }
         None
-    }
-
-    /// The stable presentation digest of an anonymous producer identity: relocate
-    /// every embedded definition / module key to its request-independent stable
-    /// content through the [`DurableAnonymousSource`] adapter, then hash through
-    /// the ONE shared computation the epoch also uses (the ratified single
-    /// digest path, RUE-1089 / RUE-1091).
-    fn anonymous_identity_digest(&self, key: &AnonymousNominalKey<K, M>) -> u128 {
-        let relocated: AnonymousNominalKey<String, String> = key
-            .try_map_identities::<String, String, std::convert::Infallible>(
-                &|definition| Ok(self.source.definition_symbol_component(definition)),
-                &|module| Ok(self.source.module_symbol_component(module)),
-            )
-            .expect("anonymous identity relocation to stable content is infallible");
-        crate::stable_digest::stable_anonymous_identity_digest(&relocated)
     }
 
     /// Fail-closed digest-collision gate. Re-presenting the SAME key is
@@ -4486,6 +4499,7 @@ mod tests {
             )
             .unwrap();
         let digest = crate::stable_digest::stable_anonymous_identity_digest(&relocated);
+        assert_eq!(pool.source.anonymous_identity_digest(&key), digest);
         assert_eq!(
             render(pool.type_pool(), ty),
             format!("__anon_struct_{digest:032x}"),

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -28,6 +28,11 @@ pub struct DurableAnonymousNominal {
     /// The structured identity remains the semantic authority; this cache only
     /// avoids repeatedly rendering and hashing it in body-local type pools.
     source_symbol: Arc<str>,
+    /// Canonical digest retained alongside the source symbol so body-local
+    /// pools can use the exact durable computation without relocating the key.
+    /// This is presentation-only; semantic equality, ordering, and hashing
+    /// intentionally ignore it below.
+    anonymous_digest: u128,
     pub shape: DurableAnonymousNominalShape,
     pub type_captures: Arc<[(Arc<str>, DurableType)]>,
     pub value_captures: Arc<[(Arc<str>, DurableConstValue)]>,
@@ -56,12 +61,17 @@ impl DurableAnonymousNominal {
         type_captures: Arc<[(Arc<str>, DurableType)]>,
         value_captures: Arc<[(Arc<str>, DurableConstValue)]>,
     ) -> Self {
-        let source_symbol = Arc::from(crate::semantic_identity::anonymous_nominal_source_symbol(
-            &identity,
-        ));
+        let anonymous_digest = crate::semantic_identity::anonymous_nominal_digest(&identity);
+        let source_symbol = Arc::from(
+            crate::semantic_identity::anonymous_nominal_source_symbol_from_digest(
+                &identity,
+                anonymous_digest,
+            ),
+        );
         Self {
             identity,
             source_symbol,
+            anonymous_digest,
             shape,
             type_captures,
             value_captures,
@@ -72,6 +82,7 @@ impl DurableAnonymousNominal {
         Self {
             identity: self.identity.clone(),
             source_symbol: self.source_symbol.clone(),
+            anonymous_digest: self.anonymous_digest,
             shape,
             type_captures: self.type_captures.clone(),
             value_captures: self.value_captures.clone(),
@@ -80,6 +91,10 @@ impl DurableAnonymousNominal {
 
     pub(crate) fn source_symbol(&self) -> &Arc<str> {
         &self.source_symbol
+    }
+
+    pub(crate) fn anonymous_identity_digest(&self) -> u128 {
+        self.anonymous_digest
     }
 }
 
@@ -268,5 +283,63 @@ impl RetainedCharge for DurableDeclarationSemantic {
         self.key
             .retained_charge()
             .saturating_add(self.payload.retained_charge())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::Hasher;
+
+    fn identity() -> crate::AnonymousNominalKey {
+        let module = crate::ModuleId::from_logical_path("digest-test.rue").unwrap();
+        let definition = crate::StableDefinitionKey::from_stable_parts(
+            module,
+            crate::StableDefinitionNamespace::Value,
+            crate::StableDefinitionKind::Function,
+            Arc::from("probe"),
+            None,
+        );
+        crate::AnonymousNominalKey {
+            kind: rue_air::AnonymousNominalKind::Struct,
+            producer: crate::StableProducerId::Definition(definition),
+            anchor: rue_rir::RirStructuralAnchor::new(vec![
+                rue_rir::RirStructuralPathSegment::Body,
+                rue_rir::RirStructuralPathSegment::AnonymousType(0),
+            ]),
+            arguments: crate::CanonicalArguments::default(),
+        }
+    }
+
+    #[test]
+    fn cached_digest_matches_canonical_digest_without_changing_semantic_equality() {
+        let identity = identity();
+        let shape = DurableAnonymousNominalShape::Struct {
+            fields: Arc::from([]),
+            methods: Arc::from([]),
+        };
+        let nominal = DurableAnonymousNominal::new(
+            identity.clone(),
+            shape.clone(),
+            Arc::from([]),
+            Arc::from([]),
+        );
+        assert_eq!(
+            nominal.anonymous_identity_digest(),
+            crate::semantic_identity::anonymous_nominal_digest(&identity)
+        );
+
+        // The cache is not a durable semantic fact: even deliberately stale
+        // presentation caches compare and hash exactly like the original.
+        let mut stale = nominal.clone();
+        stale.source_symbol = Arc::from("stale");
+        stale.anonymous_digest = 0;
+        assert_eq!(nominal, stale);
+        let mut nominal_hash = DefaultHasher::new();
+        nominal.hash(&mut nominal_hash);
+        let mut stale_hash = DefaultHasher::new();
+        stale.hash(&mut stale_hash);
+        assert_eq!(nominal_hash.finish(), stale_hash.finish());
     }
 }

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -1745,6 +1745,10 @@ mod tests {
         );
         let expected_symbol = crate::semantic_identity::anonymous_nominal_source_symbol(&identity);
         assert_eq!(nominal.source_symbol().as_ref(), expected_symbol);
+        assert_eq!(
+            nominal.anonymous_identity_digest(),
+            crate::semantic_identity::anonymous_nominal_digest(&identity)
+        );
         let shared = SharedDeclarationFactIndex::new(&[]);
         let (index, _) = LocalFactSelectionIndex::new(&shared, &[], std::slice::from_ref(&nominal));
         let symbols = std::collections::BTreeMap::from([(

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -21833,6 +21833,20 @@ impl rue_air::DurableAnonymousSource<crate::StableDefinitionKey, ModuleId>
             .map(|nominal| project_provider_anonymous_shape(nominal))
     }
 
+    fn anonymous_shape_and_digest(
+        &self,
+        key: &crate::AnonymousNominalKey,
+    ) -> Option<(
+        rue_air::DurableAnonymousShape<crate::StableDefinitionKey, ModuleId>,
+        u128,
+    )> {
+        let nominal = self.anonymous_nominal(key)?;
+        Some((
+            project_provider_anonymous_shape(&nominal),
+            nominal.anonymous_identity_digest(),
+        ))
+    }
+
     fn anonymous_methods(
         &self,
         key: &crate::AnonymousNominalKey,
@@ -24135,6 +24149,20 @@ pub(crate) mod test_support {
             self.anon_by_identity
                 .get(key)
                 .map(|nominal| durable_anonymous_shape(&nominal.shape))
+        }
+
+        fn anonymous_shape_and_digest(
+            &self,
+            key: &crate::AnonymousNominalKey,
+        ) -> Option<(
+            rue_air::DurableAnonymousShape<StableDefinitionKey, ModuleId>,
+            u128,
+        )> {
+            let nominal = self.anon_by_identity.get(key)?;
+            Some((
+                durable_anonymous_shape(&nominal.shape),
+                nominal.anonymous_identity_digest(),
+            ))
         }
 
         fn definition_symbol_component(&self, key: &StableDefinitionKey) -> String {

--- a/crates/rue-compiler/src/semantic_identity.rs
+++ b/crates/rue-compiler/src/semantic_identity.rs
@@ -208,14 +208,38 @@ pub(crate) fn anonymous_nominal_source_symbol_in(
     plan: &AnonymousSymbolPlan,
     identity: &AnonymousNominalKey,
 ) -> String {
+    anonymous_nominal_source_symbol_with_plan_and_digest(
+        plan,
+        identity,
+        anonymous_nominal_digest(identity),
+    )
+}
+
+/// Spell an anonymous nominal when the canonical digest was already retained
+/// by its durable fact. The identity still supplies the kind and collision-plan
+/// lookup; the digest is never recovered from presentation text.
+pub(crate) fn anonymous_nominal_source_symbol_from_digest(
+    identity: &AnonymousNominalKey,
+    digest: u128,
+) -> String {
+    anonymous_nominal_source_symbol_with_plan_and_digest(
+        &AnonymousSymbolPlan::EMPTY,
+        identity,
+        digest,
+    )
+}
+
+fn anonymous_nominal_source_symbol_with_plan_and_digest(
+    plan: &AnonymousSymbolPlan,
+    identity: &AnonymousNominalKey,
+    digest: u128,
+) -> String {
     let kind = match identity.kind {
         AnonymousNominalKind::Struct => "struct",
         AnonymousNominalKind::Enum => "enum",
     };
-    let component = rue_air::stable_digest::stable_anonymous_symbol_component(
-        anonymous_nominal_digest(identity),
-        plan.ordinal(identity),
-    );
+    let component =
+        rue_air::stable_digest::stable_anonymous_symbol_component(digest, plan.ordinal(identity));
     format!("__anon_{kind}_{component}")
 }
 


### PR DESCRIPTION
## What changed

The existing durable anonymous-nominal terminal now retains its canonical presentation digest beside the already-retained source symbol. `BodyIdentityPool` obtains shape and digest from one durable-source operation, so body-local anonymous minting no longer relocates the full producer identity into fresh definition/module strings and hashes it again.

The structured `AnonymousNominalKey` remains the semantic authority. The cached digest is deliberately excluded from durable equality, ordering, and hashing. Canonical-producer collapse, exact symbol spelling, and the pre-publication collision guard are unchanged. Test/fixture sources retain the canonical relocation-and-hash default; compiler sources reuse the durable record.

## Why

A fresh post-RUE-1473 profile on current trunk identified semantic analysis as the largest phase. Cold Lattice registers 4,793 imported anonymous nominals, while the symbolized sample placed allocator/format/hash work in anonymous identity minting among the largest named semantic owners. The durable fact already computed the same canonical spelling, making the repeated body-local computation accidental ownership rather than a new semantic boundary.

The first prototype fetched shape and digest separately. Although it improved clock, it added exactly 3,196 producer-fact reads/query reuses, so that form was rejected. This version fuses both values through one existing durable lookup and restores exact deterministic work.

## Measurement

Exact parent: `ca559416b`.

Across 16 balanced, alternating, fresh-process, release-ThinLTO, Rue `-O3`, `--jobs 1`, x86-64 Linux-target Lattice pairs on macOS:

- compiler root: **-1.3059%** paired median, 0.8459% MAD (**-8.50 ms** median)
- semantic analysis: **-3.5008%**
- provider analysis: **-6.1514%**
- provider expression engine: **-6.9022%**
- CFG/optimization and backend: neutral
- peak RSS: +0.4967% paired median (+1.79 MB), inside local run dispersion

Four System-allocation-accounted pairs remove **194,000–194,188 allocation calls** and **12.90–13.18 MB requested bytes**, so the observed peak movement is not a cumulative allocation regression.

Every pair preserved exact deterministic compiler work, source metrics, output metadata, and executable SHA-256 `b893e76cfabed737b149d0e8c4d8527077dedd17da78418db20a28a7d30885e5`.

The local clock is directional; hosted reference measurement remains the milestone authority.

## Validation

- `scripts/rue fmt`
- `scripts/rue quick` — 30 pass, 0 fail
- `//crates/rue-compiler:rue-compiler-differential-oracle-test` — 4 pass, retained sessions match stepwise fresh sessions, including failure recovery and bounded eviction
- focused AIR digest, durable cache/equality, and local-materialization tests
- 16 balanced fresh one-worker Lattice timing pairs
- 4 allocation-accounting pairs

Tracks RUE-1471.
