### PR TITLE
Batch containment derivation and root discovery rounds in the open set

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -592,10 +592,29 @@ struct TypeInternPoolInner {
     /// metadata mutation await the next canonical containment pass.
     containment_facts: Vec<Option<TypeContainmentFacts>>,
 
-    /// Whether any containment fact may be stale or unavailable. This is the
-    /// O(1) clean-state authority: hot accessors never scan the pool to discover
-    /// whether finalization is needed.
-    containment_dirty: bool,
+    /// Number of entries in this universe whose containment facts are `None`:
+    /// declaration shells, reserved slots, and completions whose incremental
+    /// derivation had an unavailable child. Maintained exactly — `push_entry`
+    /// and `set_facts` track every `None`/`Some` transition, and the full pass
+    /// recomputes it from what remained unavailable — so the O(1) clean-state
+    /// check never scans the pool.
+    pending_facts: usize,
+
+    /// Whether facts that are *present* may be wrong. Set only by
+    /// [`Self::invalidate_containment_metadata`] (destructor mutation after
+    /// facts may already have propagated into ancestors); cleared only by the
+    /// canonical full pass. Unlike `pending_facts`, which fails closed
+    /// per-entry, a stale pool must refuse every derived read globally.
+    facts_stale: bool,
+
+    /// Whether any containment-fact slot changed availability since the last
+    /// full pass. A pass leaves incomplete shells (and, transitively, their
+    /// by-value ancestors) factless on purpose; re-running it before any
+    /// slot turned factless — or factful, which can unblock such an ancestor —
+    /// would recompute the identical result, so the full-pass trigger requires
+    /// this bit alongside `pending_facts > 0`. Reads of the surviving factless
+    /// entries keep failing closed per-entry.
+    unsettled_facts: bool,
     containment_metrics: TypeContainmentMetrics,
 
     /// Structs and enums the compiler generated for anonymous types, recorded
@@ -792,7 +811,9 @@ impl TypeInternPoolInner {
             ptr_const_map: HashMap::new(),
             ptr_mut_map: HashMap::new(),
             containment_facts: Vec::new(),
-            containment_dirty: false,
+            pending_facts: 0,
+            facts_stale: false,
+            unsettled_facts: false,
             containment_metrics: TypeContainmentMetrics::default(),
             anonymous_structs: HashSet::new(),
             anonymous_enums: HashSet::new(),
@@ -866,7 +887,10 @@ impl TypeInternPoolInner {
         let index = self.entry_count();
         self.types.push(entry);
         self.containment_facts.push(facts);
-        self.containment_dirty |= facts.is_none();
+        if facts.is_none() {
+            self.pending_facts += 1;
+            self.unsettled_facts = true;
+        }
         index
     }
 
@@ -885,7 +909,22 @@ impl TypeInternPoolInner {
     }
 
     fn set_facts(&mut self, index: usize, value: Option<TypeContainmentFacts>) {
-        self.containment_dirty |= value.is_none();
+        let previous = self
+            .facts_at(index)
+            .expect("set_facts targets an existing pool entry");
+        match (previous.is_some(), value.is_some()) {
+            (true, false) => self.pending_facts += 1,
+            (false, true) => {
+                self.pending_facts = self
+                    .pending_facts
+                    .checked_sub(1)
+                    .expect("pending containment-fact accounting underflow");
+            }
+            _ => {}
+        }
+        if value.is_none() || previous.is_none() {
+            self.unsettled_facts = true;
+        }
         if index >= self.base_len {
             self.containment_facts[index - self.base_len] = value;
         } else {
@@ -952,7 +991,16 @@ impl TypeInternPoolInner {
         flat.types.extend(self.types.iter().cloned());
         flat.containment_facts
             .extend(self.containment_facts.iter().copied());
-        flat.containment_dirty |= self.containment_dirty;
+        // Flattening already walks every entry, so the pending count is
+        // recomputed exactly instead of merging the two layers' counters
+        // (an override may have completed a base entry counted by the base).
+        flat.pending_facts = flat
+            .containment_facts
+            .iter()
+            .filter(|facts| facts.is_none())
+            .count();
+        flat.facts_stale |= self.facts_stale;
+        flat.unsettled_facts |= self.unsettled_facts;
         flat.containment_metrics.finalize_checks += self.containment_metrics.finalize_checks;
         flat.containment_metrics.nodes += self.containment_metrics.nodes;
         flat.containment_metrics.edges += self.containment_metrics.edges;
@@ -991,7 +1039,9 @@ impl TypeInternPoolInner {
             (Some(_), false) => Arc::new(self.flatten()),
             (None, _) => Arc::new(self.clone()),
         };
-        let containment_dirty = base.containment_dirty;
+        let pending_facts = base.pending_facts;
+        let facts_stale = base.facts_stale;
+        let unsettled_facts = base.unsettled_facts;
         let capacity_exceeded = base.capacity_exceeded;
         Self {
             base_len: base.entry_count(),
@@ -1003,7 +1053,9 @@ impl TypeInternPoolInner {
             ptr_const_map: HashMap::new(),
             ptr_mut_map: HashMap::new(),
             containment_facts: Vec::new(),
-            containment_dirty,
+            pending_facts,
+            facts_stale,
+            unsettled_facts,
             containment_metrics: TypeContainmentMetrics::default(),
             // Empty locally; `is_anonymous_*` consults the base for entries
             // below `base_len`, matching how `types` is layered.
@@ -1176,10 +1228,14 @@ impl TypeInternPoolInner {
         // New complete entries derive their facts incrementally from already
         // finalized children. If every entry is available, no containment edge
         // changed and a repeated endpoint finalization is a true O(1) no-op.
-        // Incomplete shells and destructor mutation clear facts, forcing the
-        // canonical full pass below exactly when graph-wide propagation may be
-        // required.
-        if !self.containment_dirty {
+        // Entries without facts (shells, reserved slots, completions with an
+        // unavailable child) and destructor mutation force the canonical full
+        // pass below exactly when graph-wide propagation may be required.
+        // Factless survivors of the last pass alone do not: the pass already
+        // proved them uncomputable, and nothing turned factless since
+        // (`unsettled_facts`), so re-walking the graph would change nothing.
+        let pass_required = self.facts_stale || (self.pending_facts > 0 && self.unsettled_facts);
+        if !pass_required {
             return Ok(TypeContainmentWork::default());
         }
         let edges = self.containment_edges();
@@ -1331,15 +1387,31 @@ impl TypeInternPoolInner {
                 Arc::make_mut(&mut data.def).metadata_mut().is_linear = true;
             }
         }
+        let mut still_pending = 0usize;
         for (index, value) in facts.into_iter().enumerate() {
-            self.set_facts(index, facts_available[index].then_some(value));
+            let available = facts_available[index];
+            if !available {
+                still_pending += 1;
+            }
+            self.set_facts(index, available.then_some(value));
         }
-        self.containment_dirty = false;
+        // The pass consumed every mutation recorded so far: present facts are
+        // exact again, and the pending count is exactly what the pass could
+        // not compute (incomplete shells and their by-value ancestors).
+        self.pending_facts = still_pending;
+        self.facts_stale = false;
+        self.unsettled_facts = false;
         Ok(work)
     }
 
     fn facts_for_type(&self, ty: Type) -> Option<TypeContainmentFacts> {
-        if self.containment_dirty
+        // A stale pool may hold facts that are present but wrong (a destructor
+        // was attached after they propagated), so it refuses every composite
+        // read until the full pass repairs it. A merely *incomplete* pool does
+        // not: a stored fact is exact the moment it is written — incremental
+        // derivation only consumes children whose own facts are available —
+        // and entries without facts fail closed individually below.
+        if self.facts_stale
             && matches!(
                 ty.kind(),
                 TypeKind::Struct(_) | TypeKind::Enum(_) | TypeKind::Array(_)
@@ -1391,7 +1463,12 @@ impl TypeInternPoolInner {
     }
 
     fn stored_abi_slot_count(&self, ty: Type) -> Option<u32> {
-        if self.containment_dirty
+        // Same refusal shape as `facts_for_type`: a stale pool refuses
+        // globally. An entry's stored width is written together with its
+        // containment facts (by incremental derivation or the full pass), so
+        // fact availability is also the width's per-entry availability marker;
+        // without it the field still holds the meaningless placeholder `0`.
+        if self.facts_stale
             && matches!(
                 ty.kind(),
                 TypeKind::Struct(_) | TypeKind::Enum(_) | TypeKind::Array(_)
@@ -1401,15 +1478,24 @@ impl TypeInternPoolInner {
         }
         match ty.kind() {
             TypeKind::Struct(id) => match self.try_entry(id.pool_index() as usize)? {
-                TypeData::Struct(data) => Some(data.abi_slots),
+                TypeData::Struct(data) => {
+                    self.facts_at(id.pool_index() as usize)??;
+                    Some(data.abi_slots)
+                }
                 _ => None,
             },
             TypeKind::Enum(id) => match self.try_entry(id.pool_index() as usize)? {
-                TypeData::Enum(data) => Some(data.abi_slots),
+                TypeData::Enum(data) => {
+                    self.facts_at(id.pool_index() as usize)??;
+                    Some(data.abi_slots)
+                }
                 _ => None,
             },
             TypeKind::Array(id) => match self.try_entry(id.pool_index() as usize)? {
-                TypeData::Array { abi_slots, .. } => Some(*abi_slots),
+                TypeData::Array { abi_slots, .. } => {
+                    self.facts_at(id.pool_index() as usize)??;
+                    Some(*abi_slots)
+                }
                 _ => None,
             },
             _ => Some(Self::leaf_derived_facts(ty).abi_slots),
@@ -1456,7 +1542,17 @@ impl TypeInternPoolInner {
     }
 
     fn incremental_facts(&self, entry: &TypeData) -> Option<TypeDerivedFacts> {
-        if self.containment_dirty {
+        // Only a stale pool refuses incremental derivation globally: its
+        // present facts may be wrong, and consuming one would launder the
+        // staleness into a fresh entry. Entries *without* facts do not poison
+        // the pool as a whole — every child fact consumed below goes through
+        // `derived_facts_for_type`, which returns `None` for a factless child
+        // (its containment facts and stored width are gated on the same
+        // per-entry availability), so a derivation over unavailable inputs
+        // fails closed here and the entry waits for the canonical full pass.
+        // This is what lets a declare→complete pair settle its own facts even
+        // while the entry being completed is itself still counted pending.
+        if self.facts_stale {
             return None;
         }
         let mut facts = match entry {
@@ -1519,7 +1615,7 @@ impl TypeInternPoolInner {
     }
 
     fn invalidate_containment_metadata(&mut self) {
-        self.containment_dirty = true;
+        self.facts_stale = true;
     }
 
     #[inline]
@@ -2807,10 +2903,10 @@ impl TypeInternPool {
             return;
         }
         let pool_index = struct_id.pool_index() as usize;
-        let entry = inner
-            .try_entry_mut(pool_index)
-            .unwrap_or_else(|| panic!("Invalid declared struct ID: {pool_index}"));
-        match entry {
+        let name = match inner
+            .try_entry(pool_index)
+            .unwrap_or_else(|| panic!("Invalid declared struct ID: {pool_index}"))
+        {
             TypeData::DeclaredStruct(data) => {
                 assert_eq!(
                     data.def.file_id, def.file_id,
@@ -2821,20 +2917,39 @@ impl TypeInternPool {
                     def.name.as_ref(),
                     "completed struct changed textual name"
                 );
-                *entry = TypeData::Struct(StructData {
-                    name: data.name,
-                    abi_slots: 0,
-                    def: Arc::new(StructDefEntry::new(def)),
-                });
+                data.name
             }
             other => panic!(
                 "pool index {} is not a declared struct entry: {:?}",
                 pool_index, other
             ),
+        };
+        // The completing definition carries the declaration's full metadata —
+        // fields, explicit linear marker, and (on paths that know it at
+        // completion time) the destructor symbol — so this is the earliest
+        // point exact facts can derive incrementally from already-available
+        // children, exactly as `complete_struct_registration` does. A child
+        // still awaiting facts (out-of-dependency-order completion) leaves
+        // this entry factless for the canonical full pass, and a destructor
+        // attached later goes through `set_struct_destructor`, which marks
+        // the whole pool stale.
+        let mut entry = TypeData::Struct(StructData {
+            name,
+            abi_slots: 0,
+            def: Arc::new(StructDefEntry::new(def)),
+        });
+        let facts = inner.incremental_facts(&entry);
+        if let Some(facts) = facts {
+            entry.set_abi_slots(facts.abi_slots);
         }
-        // Named declarations are still collecting explicit linear/destructor
-        // metadata. Keep their facts unknown until semantic finalization.
-        inner.set_facts(pool_index, None);
+        if facts.is_some_and(|facts| facts.containment.carries_linear) {
+            let TypeData::Struct(data) = &mut entry else {
+                unreachable!()
+            };
+            Arc::make_mut(&mut data.def).metadata_mut().is_linear = true;
+        }
+        *inner.entry_mut(pool_index) = entry;
+        inner.set_facts(pool_index, facts.map(|facts| facts.containment));
     }
 
     /// Register a new enum (nominal - no deduplication).
@@ -2934,10 +3049,10 @@ impl TypeInternPool {
             return;
         }
         let pool_index = enum_id.pool_index() as usize;
-        let entry = inner
-            .try_entry_mut(pool_index)
-            .unwrap_or_else(|| panic!("Invalid declared enum ID: {pool_index}"));
-        match entry {
+        let name = match inner
+            .try_entry(pool_index)
+            .unwrap_or_else(|| panic!("Invalid declared enum ID: {pool_index}"))
+        {
             TypeData::DeclaredEnum(data) => {
                 assert_eq!(
                     data.def.file_id, def.file_id,
@@ -2948,18 +3063,27 @@ impl TypeInternPool {
                     def.name.as_ref(),
                     "completed enum changed textual name"
                 );
-                *entry = TypeData::Enum(EnumData {
-                    name: data.name,
-                    abi_slots: 0,
-                    def: Arc::new(EnumDefEntry::new(def)),
-                });
+                data.name
             }
             other => panic!(
                 "pool index {} is not a declared enum entry: {:?}",
                 pool_index, other
             ),
+        };
+        // See `complete_declared_struct`: completion is the earliest point
+        // exact facts can derive incrementally; unavailable payload children
+        // leave the entry factless for the canonical full pass.
+        let mut entry = TypeData::Enum(EnumData {
+            name,
+            abi_slots: 0,
+            def: Arc::new(EnumDefEntry::new(def)),
+        });
+        let facts = inner.incremental_facts(&entry);
+        if let Some(facts) = facts {
+            entry.set_abi_slots(facts.abi_slots);
         }
-        inner.set_facts(pool_index, None);
+        *inner.entry_mut(pool_index) = entry;
+        inner.set_facts(pool_index, facts.map(|facts| facts.containment));
     }
 
     /// Intern an array after validating its canonical child in this pool.
@@ -3457,6 +3581,15 @@ impl TypeInternPool {
             .read()
             .unwrap_or_else(PoisonError::into_inner)
             .containment_metrics
+    }
+
+    /// Test-only visibility into the exact count of factless entries.
+    #[cfg(test)]
+    pub(crate) fn pending_containment_facts(&self) -> usize {
+        self.inner
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .pending_facts
     }
 
     pub(crate) fn try_type_carries_linear(&self, ty: Type) -> Option<bool> {
@@ -4554,7 +4687,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_style_declare_complete_batches_one_linear_containment_join() {
+    fn provider_style_declare_complete_batches_settle_without_graph_work() {
         const COUNT: usize = 4_000;
         let declarations = ThreadedRodeo::default();
         let pool = TypeInternPool::new();
@@ -4570,9 +4703,9 @@ mod tests {
             .collect::<Vec<_>>();
 
         // Durable provider materialization declares recursive shells first,
-        // then completes them while unwinding. The first containment-dependent
-        // accessor joins the batch once; subsequent accessors take only the
-        // O(1) clean check.
+        // then completes them while unwinding, so every completion sees its
+        // by-value children already finalized. Each derives its facts
+        // incrementally at completion; no accessor ever pays a graph walk.
         for (index, &id) in ids.iter().enumerate().rev() {
             let name = format!("Imported{index}");
             let fields = ids
@@ -4587,9 +4720,11 @@ mod tests {
             pool.complete_declared_struct(id, struct_def(&name, fields));
         }
 
-        let work = pool.finalize_containment_metadata().unwrap();
-        assert_eq!(work.nodes, COUNT);
-        assert_eq!(work.edges, COUNT - 1);
+        assert_eq!(pool.pending_containment_facts(), 0);
+        assert_eq!(
+            pool.finalize_containment_metadata().unwrap(),
+            TypeContainmentWork::default()
+        );
         assert_eq!(
             pool.finalize_containment_metadata().unwrap(),
             TypeContainmentWork::default()
@@ -4598,10 +4733,190 @@ mod tests {
             pool.containment_metrics(),
             TypeContainmentMetrics {
                 finalize_checks: 2,
-                nodes: COUNT,
-                edges: COUNT - 1,
+                nodes: 0,
+                edges: 0,
+            },
+            "completed declare/complete pairs must not trigger a full pass"
+        );
+        assert!(!pool.type_needs_drop(Type::new_struct(ids[0])));
+    }
+
+    #[test]
+    fn out_of_dependency_order_completion_falls_back_to_the_full_pass() {
+        let declarations = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let (a, _) = pool.declare_struct(
+            declarations.get_or_intern("Outer"),
+            struct_def("Outer", Vec::new()),
+        );
+        let (b, _) = pool.declare_struct(
+            declarations.get_or_intern("Inner"),
+            struct_def("Inner", Vec::new()),
+        );
+        assert_eq!(pool.pending_containment_facts(), 2);
+
+        // Completing the parent while its by-value child is still a factless
+        // shell cannot derive facts incrementally; the parent stays factless
+        // and reads of it fail closed.
+        pool.complete_declared_struct(
+            a,
+            struct_def(
+                "Outer",
+                vec![StructField {
+                    name: "inner".into(),
+                    ty: Type::new_struct(b),
+                }],
+            ),
+        );
+        assert_eq!(pool.pending_containment_facts(), 2);
+        assert_eq!(pool.try_type_needs_drop(Type::new_struct(a)), None);
+
+        let mut inner_def = struct_def("Inner", Vec::new());
+        inner_def.destructor = Some("Inner.__drop".into());
+        pool.complete_declared_struct(b, inner_def);
+        assert_eq!(pool.pending_containment_facts(), 1);
+        assert_eq!(pool.try_type_needs_drop(Type::new_struct(b)), Some(true));
+        assert_eq!(pool.try_type_needs_drop(Type::new_struct(a)), None);
+
+        // The canonical full pass computes the out-of-order parent.
+        let work = pool.finalize_containment_metadata().unwrap();
+        assert_eq!(work.nodes, 2);
+        assert_eq!(work.edges, 1);
+        assert_eq!(pool.pending_containment_facts(), 0);
+        assert!(pool.type_needs_drop(Type::new_struct(a)));
+        assert_eq!(pool.abi_slot_count(Type::new_struct(a)), 0);
+        assert_eq!(
+            pool.finalize_containment_metadata().unwrap(),
+            TypeContainmentWork::default()
+        );
+    }
+
+    #[test]
+    fn destructor_in_completion_matches_late_destructor_metadata() {
+        // The mint paths fold a known destructor into the completing
+        // definition; the frontend attaches it after completion through
+        // `set_struct_destructor`. Both must derive identical facts.
+        fn build(pool: &TypeInternPool, declarations: &ThreadedRodeo, late: bool) -> (Type, Type) {
+            let (owner, _) = pool.declare_struct(
+                declarations.get_or_intern("Owner"),
+                struct_def("Owner", Vec::new()),
+            );
+            let mut def = struct_def(
+                "Owner",
+                vec![StructField {
+                    name: "value".into(),
+                    ty: Type::I64,
+                }],
+            );
+            if !late {
+                def.destructor = Some("Owner.__drop".into());
+            }
+            pool.complete_declared_struct(owner, def);
+            if late {
+                pool.set_struct_destructor(owner, "Owner.__drop".into());
+            }
+            let (wrapper, _) = pool.register_struct(
+                declarations.get_or_intern("Wrapper"),
+                struct_def(
+                    "Wrapper",
+                    vec![StructField {
+                        name: "owner".into(),
+                        ty: Type::new_struct(owner),
+                    }],
+                ),
+            );
+            pool.finalize_containment_metadata().unwrap();
+            (Type::new_struct(owner), Type::new_struct(wrapper))
+        }
+
+        let declarations = ThreadedRodeo::default();
+        let folded_pool = TypeInternPool::new();
+        let late_pool = TypeInternPool::new();
+        let (folded_owner, folded_wrapper) = build(&folded_pool, &declarations, false);
+        let (late_owner, late_wrapper) = build(&late_pool, &declarations, true);
+
+        for (folded, late) in [(folded_owner, late_owner), (folded_wrapper, late_wrapper)] {
+            assert_eq!(
+                folded_pool.type_needs_drop(folded),
+                late_pool.type_needs_drop(late)
+            );
+            assert_eq!(
+                folded_pool.type_carries_linear(folded),
+                late_pool.type_carries_linear(late)
+            );
+            assert_eq!(
+                folded_pool.abi_slot_count(folded),
+                late_pool.abi_slot_count(late)
+            );
+        }
+        let folded_def = folded_pool.struct_def(folded_owner.as_struct().unwrap());
+        let late_def = late_pool.struct_def(late_owner.as_struct().unwrap());
+        assert_eq!(folded_def.destructor, late_def.destructor);
+        assert_eq!(folded_def.is_copy, late_def.is_copy);
+        assert_eq!(folded_def.is_linear, late_def.is_linear);
+        assert!(folded_pool.type_needs_drop(folded_wrapper));
+
+        // The folded path needed no graph walk at all; the late path paid
+        // exactly one full pass for the staleness `set_struct_destructor`
+        // introduced.
+        assert_eq!(
+            folded_pool.containment_metrics(),
+            TypeContainmentMetrics {
+                finalize_checks: 1,
+                nodes: 0,
+                edges: 0,
             }
         );
+        assert_eq!(
+            late_pool.containment_metrics(),
+            TypeContainmentMetrics {
+                finalize_checks: 1,
+                nodes: 2,
+                edges: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn late_destructor_marks_facts_stale_and_updates_ancestors() {
+        let declarations = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let (owner, _) = pool.register_struct(
+            declarations.get_or_intern("Owner"),
+            struct_def("Owner", Vec::new()),
+        );
+        let (wrapper, _) = pool.register_struct(
+            declarations.get_or_intern("Wrapper"),
+            struct_def(
+                "Wrapper",
+                vec![StructField {
+                    name: "owner".into(),
+                    ty: Type::new_struct(owner),
+                }],
+            ),
+        );
+        assert_eq!(
+            pool.finalize_containment_metadata().unwrap(),
+            TypeContainmentWork::default()
+        );
+        assert_eq!(
+            pool.try_type_needs_drop(Type::new_struct(wrapper)),
+            Some(false)
+        );
+
+        // Present facts may now be wrong pool-wide, so reads fail closed even
+        // though no entry is factless, and the next finalization re-walks the
+        // graph to repropagate the destructor into ancestors.
+        pool.set_struct_destructor(owner, "Owner.__drop".into());
+        assert_eq!(pool.pending_containment_facts(), 0);
+        assert_eq!(pool.try_type_needs_drop(Type::new_struct(wrapper)), None);
+        assert_eq!(pool.try_type_needs_drop(Type::new_struct(owner)), None);
+
+        let work = pool.finalize_containment_metadata().unwrap();
+        assert_eq!(work.nodes, 2);
+        assert_eq!(work.edges, 1);
+        assert!(pool.type_needs_drop(Type::new_struct(owner)));
+        assert!(pool.type_needs_drop(Type::new_struct(wrapper)));
     }
 
     #[test]

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -1329,6 +1329,18 @@ where
                         ty,
                     });
                 }
+                // The destructor symbol derives from declaration-time identity
+                // only — name, defining file, builtin and lang-item status —
+                // all fixed by the shell above, so it is spelled before
+                // completion and carried in the completing definition. Folding
+                // it in (instead of `set_struct_destructor` afterwards) keeps
+                // the completion eligible for incremental containment facts
+                // rather than marking the whole pool stale.
+                let destructor = has_destructor.then(|| {
+                    Arc::<str>::from(
+                        format!("{}.__drop", self.type_pool.struct_symbol_name(id)).as_str(),
+                    )
+                });
                 self.type_pool.complete_declared_struct(
                     id,
                     StructDef {
@@ -1336,16 +1348,12 @@ where
                         fields: resolved,
                         is_copy: is_copy && !has_destructor,
                         is_linear,
-                        destructor: None,
+                        destructor,
                         is_builtin,
                         is_pub: is_public,
                         file_id,
                     },
                 );
-                if has_destructor {
-                    let destructor = format!("{}.__drop", self.type_pool.struct_symbol_name(id));
-                    self.type_pool.set_struct_destructor(id, destructor);
-                }
                 Ok(Type::new_struct(id))
             }
             DurableNominalBody::Enum { variants } => {
@@ -1474,6 +1482,15 @@ where
                         ty,
                     });
                 }
+                // See `mint_named_provider`: the destructor symbol is fixed by
+                // declaration-time identity, so it is spelled before completion
+                // and folded into the completing definition to keep the
+                // completion eligible for incremental containment facts.
+                let destructor = has_destructor.then(|| {
+                    Arc::<str>::from(
+                        format!("{}.__drop", self.type_pool.struct_symbol_name(id)).as_str(),
+                    )
+                });
                 self.type_pool.complete_declared_struct(
                     id,
                     StructDef {
@@ -1481,16 +1498,12 @@ where
                         fields: resolved,
                         is_copy: is_copy && !has_destructor,
                         is_linear,
-                        destructor: None,
+                        destructor,
                         is_builtin,
                         is_pub: is_public,
                         file_id,
                     },
                 );
-                if has_destructor {
-                    let destructor = format!("{}.__drop", self.type_pool.struct_symbol_name(id));
-                    self.type_pool.set_struct_destructor(id, destructor);
-                }
                 Ok(Type::new_struct(id))
             }
             DurableNominalBody::Enum { variants } => {
@@ -3933,10 +3946,11 @@ mod tests {
 
     #[test]
     fn containment_freeze_hook_gates_drop_and_linearity_reads() {
-        // Drop/linearity reads answer `None` until the pool-side freeze runs,
-        // then answer the containment
-        // join over the pool's own registrations. Destructor metadata stays out
-        // of the pool's minting scope, so the join sees `destructor: None`.
+        // A completed declare/complete mint derives its containment facts
+        // incrementally, so drop/linearity reads answer exactly as soon as the
+        // pair settles — the pool-side freeze then finds nothing left to walk.
+        // Destructor metadata for this nominal is `None`, and the mint folds
+        // that into the completing definition.
         let mut pool = pool([(
             0,
             named(
@@ -3949,10 +3963,10 @@ mod tests {
         let ty = pool.resolve(&DType::Nominal(0)).unwrap();
         assert_eq!(
             pool.type_needs_drop(ty),
-            None,
-            "un-finalized before the freeze, as production leaves it"
+            Some(false),
+            "a settled mint carries exact facts before the freeze"
         );
-        assert_eq!(pool.type_carries_linear(ty), None);
+        assert_eq!(pool.type_carries_linear(ty), Some(false));
         pool.finalize_containment_metadata()
             .expect("no containment cycle");
         assert_eq!(pool.type_needs_drop(ty), Some(false));

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -723,6 +723,24 @@ impl ImportDemandFrontier {
     pub fn speculative_blocked(&self) -> bool {
         self.speculative_blocked
     }
+
+    /// Every import occurrence whose projection emitted a request into this
+    /// frontier — the whole fanout, not just each host operation's deduplicated
+    /// representative.
+    ///
+    /// Within one request generation these are exactly the occurrences that can
+    /// still demand host input after this batch is answered. An occurrence that
+    /// emitted nothing is conclusive: its candidate observations are all
+    /// recorded, the ledger only grows and rejects conflicting re-observation,
+    /// and a projection over a fully-observed occurrence emits no request. So a
+    /// round that roots in the plan's new occurrences plus these reproduces the
+    /// whole-plan frontier's request set exactly.
+    pub fn demanded_occurrences(&self) -> impl Iterator<Item = &ImportOccurrenceKey> {
+        self.fanout
+            .iter()
+            .flat_map(|requests| requests.iter())
+            .map(ImportDiscoveryRequest::occurrence)
+    }
 }
 
 /// Exact parser-owned import occurrences demanded by canonical query
@@ -895,6 +913,26 @@ impl ImportDiscoveryPlan {
                 .map(|group| group[0].occurrence().clone()),
         )
     }
+
+    /// The demand roots for one ordinary discovery round that continues
+    /// `previous`: the occurrences this round's stage ADDED to the plan, plus
+    /// the occurrences `previous` actually demanded host answers for.
+    ///
+    /// Every other occurrence in the plan was already conclusive when `previous`
+    /// was built and stays conclusive — the ledger only grows within a request
+    /// generation — so rooting in this union emits exactly the request set a
+    /// whole-plan rooting would, in the same canonical order. Both halves are
+    /// compiler-derived: the plan's own delta segment and the frontier's own
+    /// fanout. The host chooses neither.
+    pub(crate) fn round_roots(&self, previous: &ImportDemandFrontier) -> ImportDemandRoots {
+        ImportDemandRoots::new(
+            self.delta_groups()
+                .iter()
+                .map(|group| group[0].occurrence().clone())
+                .chain(previous.demanded_occurrences().cloned()),
+        )
+    }
+
     /// Ordered candidate groups retained by the compiler-owned plan.
     pub fn groups(&self) -> &[Arc<[ImportDiscoveryRequest]>] {
         self.groups.as_slice()

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -540,7 +540,11 @@ pub(crate) struct RevisionedQueryDatabase {
     /// per-round discovery-frontier breadth. The trusted-toolchain re-close roots
     /// only in the newly appended leaves and modules newly discovered from them,
     /// so a predecessor occurrence contributes to this counter exactly once — at
-    /// the initial close — and never again during acquisition.
+    /// the initial close — and never again during acquisition. An ordinary
+    /// acquisition is bounded the same way: after its first round each round
+    /// roots only in the occurrences the plan just gained plus those still open,
+    /// and the whole plan is rooted once more at the end to witness closure, so
+    /// this stays linear in the import graph rather than rounds times graph.
     import_frontier_roots_requested: u64,
     /// Cumulative count of occurrences the close-time exact-import projection has
     /// dispatched a `ResolveImport` query for through [`Self::exact_import_groups`]
@@ -19032,22 +19036,24 @@ impl RevisionedQueryDatabase {
                 "import plan does not match its pinned granular input revision",
             ));
         }
-        // Membership is checked through one set built per call. On the ordinary
-        // path roots are exactly the plan's group leaders and the plan grows
-        // with every discovery round, so a nested scan here is quadratic in
-        // plan size over a deep import graph while proving a fact that almost
-        // always holds.
+        // Membership is proven per root by binary search over the plan's shared,
+        // canonically ordered group segments, so the guard costs O(roots · log
+        // plan) and never materializes the merged plan. Groups are ordered by
+        // their first request, whose leading fields are the plan-wide discovery
+        // context and then the occurrence, so searching on that pair is exact.
+        // The search direction is also the safe one: a comparator disagreeing
+        // with the stored order could only fail to find a group and reject a
+        // legitimate root, never admit one the plan does not contain.
         {
-            let group_occurrences: HashSet<_> = plan
-                .groups()
-                .iter()
-                .map(|group| group[0].occurrence())
-                .collect();
-            if roots
-                .occurrences()
-                .iter()
-                .any(|occurrence| !group_occurrences.contains(occurrence))
-            {
+            let segments = plan.group_segments();
+            if roots.occurrences().iter().any(|occurrence| {
+                !segments.contains_by(|group| {
+                    group[0]
+                        .context()
+                        .cmp(plan.context())
+                        .then_with(|| group[0].occurrence().cmp(occurrence))
+                })
+            }) {
                 return Err(import_input_error(
                     "import demand roots contain an occurrence outside the pinned plan",
                 ));

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -59,6 +59,20 @@ pub fn plan_delta_roots(plan: &crate::ImportDiscoveryPlan) -> ImportDemandRoots 
     plan.delta_roots()
 }
 
+/// The demand roots for one ordinary discovery round continuing `previous`: the
+/// occurrences the plan gained in this round's stage, plus the occurrences
+/// `previous` demanded host answers for. Rooting a round in this union emits the
+/// same requests, in the same canonical order, as rooting it in the whole plan —
+/// every occurrence outside it is already conclusive for the generation. The
+/// host supplies no membership of its own: both halves come from the
+/// compiler-owned plan and frontier values.
+pub fn plan_round_roots(
+    plan: &crate::ImportDiscoveryPlan,
+    previous: &ImportDemandFrontier,
+) -> ImportDemandRoots {
+    plan.round_roots(previous)
+}
+
 pub fn publish_import_observation_batch(
     session: &mut crate::CompilerSession,
     frontier: &ImportDemandFrontier,

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -12,8 +12,9 @@ use rue_compiler::unstable::{
     RootedParkOutcome, TrustedSuccessorDelta, begin_import_input_request,
     close_import_discovery_successor, close_import_input_request, closed_discovery_continuation,
     discovery_attempt, import_demand_frontier_for_roots, import_observation_ledger,
-    plan_delta_roots, publish_import_observation_batch, publish_trusted_toolchain_successor,
-    rooted_or_toolchain_park, stage_import_discovery_successor, stage_import_input_request,
+    plan_delta_roots, plan_round_roots, publish_import_observation_batch,
+    publish_trusted_toolchain_successor, rooted_or_toolchain_park,
+    stage_import_discovery_successor, stage_import_input_request,
 };
 #[cfg(test)]
 use rue_compiler::unstable::{
@@ -766,8 +767,8 @@ struct ClosedDiscovery {
 /// witness.
 ///
 /// `continuation` selects the request generation. `None` begins a fresh
-/// external-input observation generation (the initial close) and roots discovery
-/// in the whole plan. `Some(revision)` is a SAME-GENERATION re-close on a
+/// external-input observation generation (the initial close) and roots its FIRST
+/// round in the whole plan. `Some(revision)` is a SAME-GENERATION re-close on a
 /// strictly-additive successor already published into `revision`: it never begins
 /// a new generation — doing so would defeat the same-generation guarantee the
 /// trusted-toolchain continuation relies on.
@@ -784,6 +785,14 @@ struct ClosedDiscovery {
 /// import occurrences are never re-rooted or re-resolved: the re-close continues
 /// from the verified closed predecessor graph rather than rebuilding it, so
 /// acquisition cost is O(new leaves), not O(existing import topology).
+///
+/// This loop is the owner of "which occurrences are still open", because it is
+/// the only place that knows the ROUND structure: it holds the plan sequence,
+/// the previous round's frontier, and the decision to stop. The compiler owns
+/// both halves of the answer as immutable derived values — the plan's own delta
+/// segment and the frontier's own fanout (`plan_round_roots`) — so the host
+/// contributes no membership claim of its own and the frontier's fail-closed
+/// plan-membership guard still checks every root it is handed.
 struct ReClose<'a> {
     delta: &'a TrustedSuccessorDelta,
 }
@@ -820,6 +829,12 @@ fn drive_import_discovery_to_close(
     };
     let final_plan;
     let witness;
+    // The previous round's frontier, once there is one. It names the exact
+    // occurrences whose host answers arrive this round and which may therefore
+    // demand another candidate; every other occurrence already in the plan was
+    // conclusive when that frontier was built and stays conclusive for the whole
+    // request generation.
+    let mut previous_frontier: Option<ImportDemandFrontier> = None;
     loop {
         // One frontier round: plan and frontier construction (which owns the
         // canonical parse of everything read so far), then the host reads that
@@ -864,20 +879,49 @@ fn drive_import_discovery_to_close(
         // occurrences — those owned by modules added since the predecessor close.
         // These come straight from the plan's delta segment, never by filtering the
         // merged predecessor plan.
-        let roots = match &reclose {
-            Some(_) => plan_delta_roots(&plan),
-            None => plan.demand_roots(),
+        //
+        // An ordinary round roots the same way once it has a predecessor round to
+        // continue: the occurrences this round's stage added to the plan, plus the
+        // ones the previous frontier demanded answers for. Rooting the WHOLE plan
+        // every round instead re-dispatches a top-level `ResolveImport` request per
+        // occurrence per round, which is quadratic in the depth of an import chain
+        // while re-proving conclusions the ledger already fixed. The first round has
+        // no predecessor, so it roots the whole plan.
+        let mut roots = match (&reclose, &previous_frontier) {
+            (Some(_), _) => plan_delta_roots(&plan),
+            (None, None) => plan.demand_roots(),
+            (None, Some(previous)) => plan_round_roots(&plan, previous),
         };
+        // A round rooted in the open set proves only that the open set is
+        // exhausted. The closure witness must mean more: it is what a
+        // trusted-toolchain continuation verifies to accept that the predecessor
+        // closed. So an ordinary discovery owes the whole plan exactly ONE more
+        // rooting, taken when its open set first comes back empty; that whole-plan
+        // frontier is the witness it closes on. A re-close owes nothing: its
+        // predecessor graph is already closed and carried, and re-rooting it is
+        // exactly the O(existing topology) work RUE-1112 removed.
+        let mut closing_reroot_owed = reclose.is_none() && previous_frontier.is_some();
         let frontier = {
             let _span = tracing::info_span!("import_frontier").entered();
-            import_demand_frontier_for_roots(
-                staging,
-                input_revision,
-                &plan,
-                ImportDemandMode::Rooted,
-                &roots,
-            )
-            .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?
+            loop {
+                let frontier = import_demand_frontier_for_roots(
+                    staging,
+                    input_revision,
+                    &plan,
+                    ImportDemandMode::Rooted,
+                    &roots,
+                )
+                .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+                // Requests mean the round is not closing after all, so the debt
+                // stands for a later round. Should the whole-plan rooting disagree
+                // with the open set and produce requests, they are answered like
+                // any other round's rather than dropped.
+                if !frontier.requests().is_empty() || !closing_reroot_owed {
+                    break frontier;
+                }
+                closing_reroot_owed = false;
+                roots = plan.demand_roots();
+            }
         };
         drop(plan_span);
         if frontier.requests().is_empty() {
@@ -929,6 +973,7 @@ fn drive_import_discovery_to_close(
             observations,
         )
         .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+        previous_frontier = Some(frontier);
     }
 
     let _close_span = tracing::info_span!("import_discovery_close").entered();
@@ -2078,6 +2123,43 @@ mod tests {
                 <= (MODULES as u64) * 8,
             "discovery certificate misses must stay linear in module count"
         );
+        // Each round roots only in the occurrences the plan just gained plus the
+        // ones the previous round demanded answers for, and the whole plan is
+        // rooted once more to witness closure: roughly two roots per round plus
+        // one final pass. Rooting the whole plan every round instead dispatched
+        // one top-level `ResolveImport` request per occurrence per round — 527 at
+        // this shape, and quadratic in chain depth.
+        assert!(
+            import_frontier_roots_requested(&result.session) <= (MODULES as u64) * 4,
+            "frontier dispatch must stay linear in chain depth, not rounds times plan"
+        );
+    }
+
+    /// A candidate that misses on its first group is answered but NOT concluded:
+    /// the occurrence still owes its next candidate a round. Here `sub/leaf.rue`
+    /// imports `shared.rue`, which is absent beside it and present at the project
+    /// root, so its occurrence spans two rounds while its module is new in
+    /// neither. A round that rooted only in the plan's newly staged occurrences
+    /// would drop it.
+    #[test]
+    fn import_occurrence_answered_but_still_open_is_rerooted_next_round() {
+        let dir = TestDir::new("open-occurrence-reroot");
+        let main = dir.write(
+            "main.rue",
+            r#"const leaf = @import("sub/leaf.rue"); fn main() -> i32 { leaf.value() }"#,
+        );
+        dir.write(
+            "sub/leaf.rue",
+            r#"const shared = @import("shared.rue"); pub fn value() -> i32 { shared.value() }"#,
+        );
+        dir.write("shared.rue", "pub fn value() -> i32 { 7 }");
+
+        let result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
+
+        assert_eq!(result.read_manifest.len(), 3);
+        // Three published batches: the leaf, its missed sibling candidate, then
+        // the project-root `shared.rue` the second candidate resolves to.
+        assert_eq!(result.input_revision.frontier_round(), 3);
     }
 
     fn module_source_id(


### PR DESCRIPTION
Two independent, individually verified commits from the Lattice speedup campaign; both preserve emitted bytes and deterministic semantic work exactly.

## Commit 1: Derive containment facts incrementally at declaration completion

`body_type_pool()` — the semantic engine's universal type-pool accessor — re-ran the whole-pool containment DFS whenever lazy minting re-dirtied the pool, interleaved with reads on essentially every body. The dirty bit splits into an exact `pending_facts` count plus a `facts_stale` flag (destructor mutation only); `incremental_facts` now refuses only stale pools, completion derives facts incrementally (the mint path folds the destructor into the completing `StructDef` — it was already in scope; the genuinely-late path in `semantic_import` keeps the conservative global invalidation), and an `unsettled` bit prevents a retained shell from forcing a full pass per read forever.

Evidence (agent-measured with a temporary instrumentation build, then re-verified on this branch): full containment passes on Lattice **2,737 → 1,104**, nodes walked **65,056 → 31,771**; executable hash identical (`b893e76c…85e5`); **all 136 `compiler_work` counters identical**; rue-air suite 651/651 including new tests for adjacent completion (zero graph work), out-of-order completion fallback, destructor-fold equivalence against the old two-step, and late-destructor propagation.

## Commit 2: Root ordinary discovery rounds in the open occurrence set

After ADR-0073, the dominant deep-chain cost was the frontier loop dispatching `ResolveImport` for every plan occurrence every round — O(rounds × plan). Ordinary rounds now root `plan delta ∪ previous frontier's demanded occurrences`, with one whole-plan closing re-root before the loop exits; the re-close path is untouched, the frontier's fail-closed plan-membership guard still validates every root (now via binary search over the plan's shared sorted segments), and a new regression test covers the answered-but-not-concluded case that delta-only roots would drop.

Evidence (release, `-O3 -j1`): 1,024-module chain root **10.4s → 5.8s**, discovery phase **9.0s → 4.3s**, `import_frontier` span **3,903ms → 124ms**, `validation.traversals` **565,813 → 43,061** (now 4.0× per 4× n); 32-module driver test pins `import_frontier_roots_requested ≤ 4·MODULES` (was 527, now 93). Hashes identical for both chains and Lattice; on Lattice the only changed counters are the dispatch/validation family this reduces — every parse, semantic, CFG, codegen, and linker counter is unchanged.

## Validation on the combined branch

- `rue-driver-test` 40/40, `rue-compiler-test` 880 pass / 6 ignored, rue-air 651/651, `scripts/rue quick` green; agent-side runs additionally covered `scripts/rue cli` (1,892 pass), differential oracle, and public-api suites
- Combined release build: Lattice `b893e76c…85e5` and 1,024-chain `802bf2e1…9f4d` reproduce exactly
- `scripts/rue fmt` clean

## Known follow-up (measured, not addressed here)

Remaining discovery superlinearity lives in per-round whole-plan work outside the frontier: `import_read` (`add_plan_reads` walking `plan.accepted_sources(ledger)` per round, 213→2,133ms from n=256→1,024), `import_parse_staging` (107→1,122ms), and `import_plan_publish` (32→486ms). Next bounded issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTiBg7df72iMgdpAFv5wZs)_