### PR TITLE
RUE-1472: skip shared query-family comparisons

### DIFF
--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -2319,7 +2319,12 @@ impl PartialOrd for NodeIdentity {
 
 impl Ord for NodeIdentity {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        (self.family(), self.key()).cmp(&(other.family(), other.key()))
+        let family_order = if Arc::ptr_eq(&self.inner.family, &other.inner.family) {
+            std::cmp::Ordering::Equal
+        } else {
+            self.family().cmp(other.family())
+        };
+        family_order.then_with(|| self.key().cmp(other.key()))
     }
 }
 
@@ -11324,6 +11329,36 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
+
+    #[test]
+    fn node_identity_order_matches_lexical_family_key_order() {
+        let shared_family: Arc<str> = Arc::from("family");
+        let shared_a = NodeIdentity::new(shared_family.clone(), Arc::from("a"));
+        let shared_b = NodeIdentity::new(shared_family.clone(), Arc::from("b"));
+        assert!(Arc::ptr_eq(&shared_a.inner.family, &shared_b.inner.family));
+        assert_eq!(
+            shared_a.cmp(&shared_b),
+            ("family", "a").cmp(&("family", "b"))
+        );
+
+        let distinct_family_a: Arc<str> = Arc::from(String::from("same"));
+        let distinct_family_b: Arc<str> = Arc::from(String::from("same"));
+        assert!(!Arc::ptr_eq(&distinct_family_a, &distinct_family_b));
+        let equal_text_a = NodeIdentity::new(distinct_family_a, Arc::from("key"));
+        let equal_text_b = NodeIdentity::new(distinct_family_b, Arc::from("key"));
+        assert_eq!(equal_text_a.cmp(&equal_text_b), std::cmp::Ordering::Equal);
+
+        let alpha = NodeIdentity::new(Arc::from("alpha"), Arc::from("key"));
+        let beta = NodeIdentity::new(Arc::from("beta"), Arc::from("key"));
+        assert_eq!(alpha.cmp(&beta), ("alpha", "key").cmp(&("beta", "key")));
+
+        let key_a = NodeIdentity::new(shared_family.clone(), Arc::from("key-a"));
+        let key_b = NodeIdentity::new(shared_family, Arc::from("key-b"));
+        assert_eq!(
+            key_a.cmp(&key_b),
+            ("family", "key-a").cmp(&("family", "key-b"))
+        );
+    }
 
     #[test]
     fn active_validations_stay_inline_and_detect_cycles() {


### PR DESCRIPTION
## Summary

- preserve exact canonical `(family, key)` dependency ordering
- skip lexical family-byte comparison when two `NodeIdentity` values share the canonical query-family `Arc<str>`
- retain lexical comparison for distinct allocations and the exact key tie-break
- add focused equivalence coverage for shared families, equal-text distinct allocations, distinct families, and key ordering

## Measured rationale

Fresh merged-trunk sampling placed 18 recursive samples in the final `TaskDependencies` unstable sort under `Task::pop`, beside 21 `memcmp` samples. The existing hash-then-canonical-sort architecture was a measured RUE-1381 win and remains intact; this change only removes a redundant comparison within that owner.

Sixteen directly alternating fresh-process `-O3 -j1 --target x86-64-linux` Lattice pairs against `29bad2a82`:

- compiler root: paired median **-0.504%** (639.401 ms vs 639.042 ms separate medians; MAD 1.178%)
- compiler pipeline: paired median **-0.817%**
- instructions: paired median **-0.291%**, MAD 0.064%, improved in **16/16** pairs
- cycles: paired median **-0.537%**
- peak RSS: paired median **+0.209%**

Four allocator-instrumented pairs show no supporting memory-work regression:

- allocation calls: **-166** median (**-0.0017%**)
- requested bytes: **+25.7 KiB** median (**+0.0016%**)

With one shared standard-library path, `compiler_work`, source metrics, compiler boundary, emitted metadata, and every output byte are exact. Emitted SHA-256 remains `b893e76cfabed737b149d0e8c4d8527077dedd17da78418db20a28a7d30885e5`.

## Validation

- `scripts/rue quick` — 30 targets passed
- rue-query suite — 176 passed
- `scripts/rue unit compiler:rue-compiler-differential-oracle-test` — 4 passed
- focused ordering equivalence test

[RUE-1472](https://linear.app/steve-klabnik/issue/RUE-1472/perfmilestone-reach-the-250-ms-compiler-target-and-evaluate-the-150-ms)