### PR TITLE
Hash rue-air's internal lookup tables with ahash

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -18,7 +18,7 @@ fn type_syntax_dependency_admission_indexes_only_the_large_case() {
     let typeck = include_str!("sema/typeck.rs");
 
     assert!(
-        typeck.contains("observed_type_dependency_index: Option<HashSet<ObservedTypeDependency>>")
+        typeck.contains("observed_type_dependency_index: Option<AHashSet<ObservedTypeDependency>>")
     );
     assert!(typeck.contains("const LINEAR_ADMISSION_LIMIT: usize = 8"));
     assert!(typeck.contains("if index.insert(dependency.clone())"));

--- a/crates/rue-air/src/declaration_validation.rs
+++ b/crates/rue-air/src/declaration_validation.rs
@@ -4,7 +4,7 @@
 //! deterministic policy over canonical declaration facts, so the one-shot AIR
 //! adapter and the keyed semantic graph cannot drift on the rule itself.
 
-use std::collections::HashSet;
+use ahash::AHashSet;
 
 use rue_error::ErrorKind;
 
@@ -15,7 +15,7 @@ pub fn duplicate_parameter(names: impl IntoIterator<Item = impl AsRef<str>>) -> 
 pub fn duplicate_parameter_with_ordinal(
     names: impl IntoIterator<Item = impl AsRef<str>>,
 ) -> Option<(ErrorKind, usize)> {
-    let mut seen = HashSet::new();
+    let mut seen = AHashSet::new();
     for (ordinal, name) in names.into_iter().enumerate() {
         let name = name.as_ref();
         if !seen.insert(name.to_owned()) {
@@ -57,7 +57,7 @@ pub fn duplicate_field(
     struct_name: &str,
     fields: impl IntoIterator<Item = impl AsRef<str>>,
 ) -> Option<ErrorKind> {
-    let mut seen = HashSet::new();
+    let mut seen = AHashSet::new();
     for field in fields {
         let field = field.as_ref();
         if !seen.insert(field.to_owned()) {
@@ -74,7 +74,7 @@ pub fn duplicate_variant(
     enum_name: &str,
     variants: impl IntoIterator<Item = impl AsRef<str>>,
 ) -> Option<ErrorKind> {
-    let mut seen = HashSet::new();
+    let mut seen = AHashSet::new();
     for variant in variants {
         let variant = variant.as_ref();
         if !seen.insert(variant.to_owned()) {

--- a/crates/rue-air/src/ffi_predicates.rs
+++ b/crates/rue-air/src/ffi_predicates.rs
@@ -373,7 +373,7 @@ pub fn repr_c_marker_eligible<P: FfiTypePool>(
 mod tests {
     use super::*;
     use crate::{EnumId, PtrConstTypeId, PtrMutTypeId};
-    use std::collections::HashMap;
+    use ahash::AHashMap;
 
     /// A tiny hand-built pool so the predicate algebra can be exercised without
     /// the full type-intern-pool completion protocol. Struct/array IDs are just
@@ -381,8 +381,8 @@ mod tests {
     /// pointer's pointee or read an enum body).
     #[derive(Default)]
     struct MockPool {
-        structs: HashMap<u32, MockStruct>,
-        arrays: HashMap<u32, Type>,
+        structs: AHashMap<u32, MockStruct>,
+        arrays: AHashMap<u32, Type>,
     }
 
     #[derive(Default, Clone)]

--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -19,6 +19,8 @@ use lasso::{Spur, ThreadedRodeo};
 use rue_rir::{InstData, InstRef, RepeatCount, Rir, RirTypeSyntaxNode, RirTypeSyntaxRef};
 use rue_span::{FileId, Span};
 use std::collections::HashMap;
+
+use ahash::AHashMap;
 use std::rc::Rc;
 
 /// Information about a local variable during constraint generation.
@@ -138,9 +140,9 @@ pub(crate) trait LazyInferenceFacts {
 /// Context for constraint generation within a single function.
 pub struct ConstraintContext<'a> {
     /// Local variables in scope.
-    pub locals: HashMap<Spur, LocalVarInfo>,
+    pub locals: AHashMap<Spur, LocalVarInfo>,
     /// Function parameters.
-    pub params: &'a HashMap<Spur, ParamVarInfo>,
+    pub params: &'a AHashMap<Spur, ParamVarInfo>,
     /// Return type of the current function.
     pub return_type: Type,
     /// How many loops we're nested inside (for break/continue validation).
@@ -156,9 +158,9 @@ pub struct ConstraintContext<'a> {
 
 impl<'a> ConstraintContext<'a> {
     /// Create a new context for a function.
-    pub fn new(params: &'a HashMap<Spur, ParamVarInfo>, return_type: Type) -> Self {
+    pub fn new(params: &'a AHashMap<Spur, ParamVarInfo>, return_type: Type) -> Self {
         Self {
-            locals: HashMap::new(),
+            locals: AHashMap::new(),
             params,
             return_type,
             loop_depth: 0,
@@ -172,7 +174,7 @@ impl<'a> ConstraintContext<'a> {
 impl ScopedContext for ConstraintContext<'_> {
     type VarInfo = LocalVarInfo;
 
-    fn locals_mut(&mut self) -> &mut HashMap<Spur, Self::VarInfo> {
+    fn locals_mut(&mut self) -> &mut AHashMap<Spur, Self::VarInfo> {
         &mut self.locals
     }
 
@@ -211,24 +213,31 @@ pub struct ConstraintGenerator<'a> {
     /// Collected constraints.
     constraints: Vec<Constraint>,
     /// Mapping from RIR instruction to its inferred type.
+    ///
+    /// Deliberately the std hasher while the rest of this generator uses
+    /// `AHashMap`: type inference walks this map to pre-create array types
+    /// (`pre_create_array_types_from_infer_type`), so its iteration order
+    /// decides the pool indices those array types receive, and those indices
+    /// are later a sort key (`sort_unstable_by_key(Type::as_u32)`). The order
+    /// is observable, so the hasher is not a free choice here.
     expr_types: HashMap<InstRef, InferType>,
     /// Function signatures (for call type checking). `None` when the generator
     /// is driven by a lazy provider (`lazy`), which materializes signatures on
     /// demand; unit tests still supply an eager map.
-    functions: Option<&'a HashMap<Spur, FunctionSig>>,
+    functions: Option<&'a AHashMap<Spur, FunctionSig>>,
     /// Built-in struct types, which have no defining source file. `None` under
     /// a lazy provider (see `functions`).
-    builtin_structs: Option<&'a HashMap<Spur, Type>>,
+    builtin_structs: Option<&'a AHashMap<Spur, Type>>,
     /// Module-local struct types ((defining file, source name) -> Type::new_struct(id)).
-    structs_by_file_name: Option<&'a HashMap<(FileId, Spur), Type>>,
+    structs_by_file_name: Option<&'a AHashMap<(FileId, Spur), Type>>,
     /// Built-in enum types, which have no defining source file. `None` under a
     /// lazy provider (see `functions`).
-    builtin_enums: Option<&'a HashMap<Spur, Type>>,
+    builtin_enums: Option<&'a AHashMap<Spur, Type>>,
     /// Module-local enum types ((defining file, source name) -> Type::new_enum(id)).
-    enums_by_file_name: Option<&'a HashMap<(FileId, Spur), Type>>,
+    enums_by_file_name: Option<&'a AHashMap<(FileId, Spur), Type>>,
     /// Method signatures: (struct_id, method_name) -> MethodSig. `None` under a
     /// lazy provider (see `functions`).
-    methods: Option<&'a HashMap<(StructId, Spur), MethodSig>>,
+    methods: Option<&'a AHashMap<(StructId, Spur), MethodSig>>,
     /// Demand-population provider (RUE-1091 slice r5b). When present, the
     /// thirteen declaration-universe families are materialized on first consult
     /// through this seam instead of read from eager maps. `None` in unit tests,
@@ -247,34 +256,34 @@ pub struct ConstraintGenerator<'a> {
     strbuf_type: Option<Type>,
     /// Type substitutions for Self and type parameters (used in method bodies).
     /// Maps type names (like "Self") to their concrete types.
-    type_subst: Option<&'a HashMap<Spur, Type>>,
+    type_subst: Option<&'a AHashMap<Spur, Type>>,
     /// File-level constant types (name -> declared type), resolved during
     /// declaration gathering. Consulted by `VarRef` after locals and params so
     /// a const reference infers to its declared type instead of `<error>`
     /// (RUE-142). `None` only in unit tests; production passes the map via
     /// [`Self::with_const_types`].
-    const_types: Option<&'a HashMap<(FileId, Spur), Type>>,
+    const_types: Option<&'a AHashMap<(FileId, Spur), Type>>,
     /// File-level type aliases (`const T = SomeType(...)`) resolved during
     /// declaration gathering. Consulted in type positions.
-    const_type_aliases: Option<&'a HashMap<(FileId, Spur), Type>>,
+    const_type_aliases: Option<&'a AHashMap<(FileId, Spur), Type>>,
     /// Module-binding types (`const utils = @import(...)`): (declaring file,
     /// name) -> module type. Per-file scoped (RUE-113), so `VarRef` consults
     /// this with the reference's own `span.file_id` before `const_types`.
     /// `None` only in unit tests; production passes the map via
     /// [`Self::with_module_binding_types`].
-    module_binding_types: Option<&'a HashMap<(FileId, Spur), Type>>,
+    module_binding_types: Option<&'a AHashMap<(FileId, Spur), Type>>,
     /// Source-level function lookup: (defining file, source name) -> internal
     /// function key. Same-named functions across files get module-qualified
     /// internal keys in `functions`, so module-member calls resolve through
     /// this map first — the bare source name misses for them (RUE-576).
     /// `None` only in unit tests; production passes the map via
     /// [`Self::with_functions_by_file_name`].
-    functions_by_file_name: Option<&'a HashMap<(FileId, Spur), Spur>>,
+    functions_by_file_name: Option<&'a AHashMap<(FileId, Spur), Spur>>,
     /// Module registry file identity for inference-time `module.Type` and
     /// `module.Enum` lookup.
     /// `None` only in unit tests; production passes the map via
     /// [`Self::with_module_file_ids`].
-    module_file_ids: Option<&'a HashMap<crate::types::ModuleId, FileId>>,
+    module_file_ids: Option<&'a AHashMap<crate::types::ModuleId, FileId>>,
     /// Compile-time type aliases bound by `let` in the current function body
     /// (`let P = F();` where `F` returns `type`), pre-resolved by sema before
     /// constraint generation and keyed by each binding's own Alloc
@@ -282,7 +291,7 @@ pub struct ConstraintGenerator<'a> {
     /// alias is brought into scope in [`Self::comptime_alias_types`] and
     /// unwound with its enclosing block (RUE-530). `None` only in unit tests;
     /// production passes the map via [`Self::with_comptime_local_bindings`].
-    comptime_local_bindings: Option<&'a HashMap<InstRef, Type>>,
+    comptime_local_bindings: Option<&'a AHashMap<InstRef, Type>>,
     /// The comptime type aliases currently in scope (name → aliased type),
     /// maintained live during the walk from [`Self::comptime_local_bindings`]
     /// via [`Self::enter_scope`]/[`Self::exit_scope`]. Consulted after
@@ -291,7 +300,7 @@ pub struct ConstraintGenerator<'a> {
     /// concrete paths as named structs (RUE-170), and lexically scoped like
     /// sema's `comptime_type_vars` so sibling-branch aliases don't collide
     /// and an alias doesn't outlive its block (RUE-530).
-    comptime_alias_types: HashMap<Spur, Type>,
+    comptime_alias_types: AHashMap<Spur, Type>,
     /// Per-scope undo frames for `comptime_alias_types`, parallel to the
     /// `ConstraintContext` scope stack (both are pushed/popped only by
     /// [`Self::enter_scope`]/[`Self::exit_scope`]): each frame records the
@@ -308,7 +317,7 @@ pub struct ConstraintGenerator<'a> {
     /// literal defaulted to `i32` and could not satisfy a wider declared type
     /// (RUE-599). `None` only in unit tests; production passes the map via
     /// [`Self::with_inline_ctor_head_types`].
-    inline_ctor_head_types: Option<&'a HashMap<InstRef, Type>>,
+    inline_ctor_head_types: Option<&'a AHashMap<InstRef, Type>>,
     /// Method signatures registered after the shared `InferenceContext` was
     /// built: anonymous-struct methods are registered lazily during comptime
     /// evaluation, so they're absent from `methods`. Consulted when a method
@@ -316,15 +325,15 @@ pub struct ConstraintGenerator<'a> {
     /// its declared return type instead of `<error>` (RUE-164). `None` only
     /// in unit tests; production passes the map via
     /// [`Self::with_extra_method_sigs`].
-    extra_method_sigs: Option<&'a HashMap<(StructId, Spur), MethodSig>>,
+    extra_method_sigs: Option<&'a AHashMap<(StructId, Spur), MethodSig>>,
     /// File-level integer constant values (name -> value), so an array length
     /// naming a `const` (`[i32; K]`) resolves to a concrete length during
     /// constraint generation (RUE-16). `None` only in unit tests; production
     /// passes the map via [`Self::with_const_values`].
-    const_values: Option<&'a HashMap<(FileId, Spur), i128>>,
+    const_values: Option<&'a AHashMap<(FileId, Spur), i128>>,
     /// Function-valued constants: alias name -> callee function name. These
     /// let constraint generation type `alias(...)` as a direct call.
-    const_function_aliases: Option<&'a HashMap<(FileId, Spur), Spur>>,
+    const_function_aliases: Option<&'a AHashMap<(FileId, Spur), Spur>>,
     /// Comptime *value* parameters known for the specialization currently being
     /// analyzed (`comptime n: i32` → `n = 0` for the call `f(0)`). Lets a
     /// `match` on a comptime-known scrutinee prune to its selected arm during
@@ -333,7 +342,7 @@ pub struct ConstraintGenerator<'a> {
     /// cross-constrains every arm and rejects a valid program whose statically
     /// unselected arm has a different type (RUE-268). `None` for ordinary
     /// (non-specialized) functions, where every match is treated as runtime.
-    comptime_values: Option<&'a HashMap<Spur, ConstValue>>,
+    comptime_values: Option<&'a AHashMap<Spur, ConstValue>>,
     /// Type intern pool for creating pointer and array types during constraint generation.
     type_pool: &'a TypeInternPool,
 }
@@ -343,10 +352,10 @@ impl<'a> ConstraintGenerator<'a> {
     pub fn new(
         rir: &'a Rir,
         interner: &'a ThreadedRodeo,
-        functions: &'a HashMap<Spur, FunctionSig>,
-        builtin_structs: &'a HashMap<Spur, Type>,
-        builtin_enums: &'a HashMap<Spur, Type>,
-        methods: &'a HashMap<(StructId, Spur), MethodSig>,
+        functions: &'a AHashMap<Spur, FunctionSig>,
+        builtin_structs: &'a AHashMap<Spur, Type>,
+        builtin_enums: &'a AHashMap<Spur, Type>,
+        methods: &'a AHashMap<(StructId, Spur), MethodSig>,
         type_pool: &'a TypeInternPool,
     ) -> Self {
         Self::with_type_subst(
@@ -370,12 +379,12 @@ impl<'a> ConstraintGenerator<'a> {
     pub fn with_type_subst(
         rir: &'a Rir,
         interner: &'a ThreadedRodeo,
-        functions: &'a HashMap<Spur, FunctionSig>,
-        builtin_structs: &'a HashMap<Spur, Type>,
-        builtin_enums: &'a HashMap<Spur, Type>,
-        methods: &'a HashMap<(StructId, Spur), MethodSig>,
+        functions: &'a AHashMap<Spur, FunctionSig>,
+        builtin_structs: &'a AHashMap<Spur, Type>,
+        builtin_enums: &'a AHashMap<Spur, Type>,
+        methods: &'a AHashMap<(StructId, Spur), MethodSig>,
         type_pool: &'a TypeInternPool,
-        type_subst: Option<&'a HashMap<Spur, Type>>,
+        type_subst: Option<&'a AHashMap<Spur, Type>>,
     ) -> Self {
         let strbuf_type = type_pool.lang_item_type(crate::LangItem::StrBuf);
         let string_literal_default = Type::ERROR;
@@ -403,7 +412,7 @@ impl<'a> ConstraintGenerator<'a> {
             functions_by_file_name: None,
             module_file_ids: None,
             comptime_local_bindings: None,
-            comptime_alias_types: HashMap::new(),
+            comptime_alias_types: AHashMap::new(),
             alias_scope_stack: Vec::new(),
             inline_ctor_head_types: None,
             extra_method_sigs: None,
@@ -426,7 +435,7 @@ impl<'a> ConstraintGenerator<'a> {
         rir: &'a Rir,
         interner: &'a ThreadedRodeo,
         type_pool: &'a TypeInternPool,
-        type_subst: Option<&'a HashMap<Spur, Type>>,
+        type_subst: Option<&'a AHashMap<Spur, Type>>,
         lazy: &'a dyn LazyInferenceFacts,
     ) -> Self {
         let strbuf_type = type_pool.lang_item_type(crate::LangItem::StrBuf);
@@ -455,7 +464,7 @@ impl<'a> ConstraintGenerator<'a> {
             functions_by_file_name: None,
             module_file_ids: None,
             comptime_local_bindings: None,
-            comptime_alias_types: HashMap::new(),
+            comptime_alias_types: AHashMap::new(),
             alias_scope_stack: Vec::new(),
             inline_ctor_head_types: None,
             extra_method_sigs: None,
@@ -535,7 +544,7 @@ impl<'a> ConstraintGenerator<'a> {
 
     /// Provide file-level constant types (name -> declared type) for `VarRef`
     /// resolution. See the `const_types` field for details (RUE-142).
-    pub fn with_const_types(mut self, const_types: &'a HashMap<(FileId, Spur), Type>) -> Self {
+    pub fn with_const_types(mut self, const_types: &'a AHashMap<(FileId, Spur), Type>) -> Self {
         self.const_types = Some(const_types);
         self
     }
@@ -543,7 +552,7 @@ impl<'a> ConstraintGenerator<'a> {
     /// Provide file-level type aliases for type-position resolution.
     pub fn with_const_type_aliases(
         mut self,
-        const_type_aliases: &'a HashMap<(FileId, Spur), Type>,
+        const_type_aliases: &'a AHashMap<(FileId, Spur), Type>,
     ) -> Self {
         self.const_type_aliases = Some(const_type_aliases);
         self
@@ -553,7 +562,7 @@ impl<'a> ConstraintGenerator<'a> {
     /// for `VarRef` resolution. See the `module_binding_types` field (RUE-113).
     pub fn with_module_binding_types(
         mut self,
-        module_binding_types: &'a HashMap<(FileId, Spur), Type>,
+        module_binding_types: &'a AHashMap<(FileId, Spur), Type>,
     ) -> Self {
         self.module_binding_types = Some(module_binding_types);
         self
@@ -563,7 +572,7 @@ impl<'a> ConstraintGenerator<'a> {
     /// for module-member call resolution (RUE-576).
     pub fn with_functions_by_file_name(
         mut self,
-        functions_by_file_name: &'a HashMap<(FileId, Spur), Spur>,
+        functions_by_file_name: &'a AHashMap<(FileId, Spur), Spur>,
     ) -> Self {
         self.functions_by_file_name = Some(functions_by_file_name);
         self
@@ -572,7 +581,7 @@ impl<'a> ConstraintGenerator<'a> {
     /// Provide module registry file identities for `module.Type` lookup.
     pub fn with_module_file_ids(
         mut self,
-        module_file_ids: &'a HashMap<crate::types::ModuleId, FileId>,
+        module_file_ids: &'a AHashMap<crate::types::ModuleId, FileId>,
     ) -> Self {
         self.module_file_ids = Some(module_file_ids);
         self
@@ -584,7 +593,7 @@ impl<'a> ConstraintGenerator<'a> {
     /// RUE-530).
     pub fn with_comptime_local_bindings(
         mut self,
-        comptime_local_bindings: &'a HashMap<InstRef, Type>,
+        comptime_local_bindings: &'a AHashMap<InstRef, Type>,
     ) -> Self {
         self.comptime_local_bindings = Some(comptime_local_bindings);
         self
@@ -595,7 +604,7 @@ impl<'a> ConstraintGenerator<'a> {
     /// (RUE-599).
     pub fn with_inline_ctor_head_types(
         mut self,
-        inline_ctor_head_types: &'a HashMap<InstRef, Type>,
+        inline_ctor_head_types: &'a AHashMap<InstRef, Type>,
     ) -> Self {
         self.inline_ctor_head_types = Some(inline_ctor_head_types);
         self
@@ -606,7 +615,7 @@ impl<'a> ConstraintGenerator<'a> {
     /// (RUE-164).
     pub fn with_extra_method_sigs(
         mut self,
-        extra_method_sigs: &'a HashMap<(StructId, Spur), MethodSig>,
+        extra_method_sigs: &'a AHashMap<(StructId, Spur), MethodSig>,
     ) -> Self {
         self.extra_method_sigs = Some(extra_method_sigs);
         self
@@ -615,7 +624,7 @@ impl<'a> ConstraintGenerator<'a> {
     /// Provide file-level integer constant values (name -> value) so an array
     /// length naming a `const` resolves during constraint generation. See the
     /// `const_values` field (RUE-16).
-    pub fn with_const_values(mut self, const_values: &'a HashMap<(FileId, Spur), i128>) -> Self {
+    pub fn with_const_values(mut self, const_values: &'a AHashMap<(FileId, Spur), i128>) -> Self {
         self.const_values = Some(const_values);
         self
     }
@@ -627,7 +636,7 @@ impl<'a> ConstraintGenerator<'a> {
     /// runtime.
     pub fn with_comptime_values(
         mut self,
-        comptime_values: Option<&'a HashMap<Spur, ConstValue>>,
+        comptime_values: Option<&'a AHashMap<Spur, ConstValue>>,
     ) -> Self {
         self.comptime_values = comptime_values;
         self
@@ -662,7 +671,7 @@ impl<'a> ConstraintGenerator<'a> {
     fn resolve_infer_array_length_with_values(
         &self,
         len: &ArrayLen,
-        values: &HashMap<Spur, i128>,
+        values: &AHashMap<Spur, i128>,
         file_id: FileId,
     ) -> Option<u64> {
         match len {
@@ -1383,14 +1392,12 @@ impl<'a> ConstraintGenerator<'a> {
                             .collect();
 
                         // Build the type substitution map from comptime type arguments
-                        let mut type_subst: std::collections::HashMap<lasso::Spur, Type> =
-                            std::collections::HashMap::new();
+                        let mut type_subst: AHashMap<lasso::Spur, Type> = AHashMap::new();
                         // Comptime VALUE arguments (`comptime N: i32`) captured
                         // as their integer constant, so a return/param type
                         // sized by one — an array length `[i32; N]` — resolves
                         // at this call (RUE-252).
-                        let mut value_subst: std::collections::HashMap<lasso::Spur, i128> =
-                            std::collections::HashMap::new();
+                        let mut value_subst: AHashMap<lasso::Spur, i128> = AHashMap::new();
                         for (i, arg) in args.iter().enumerate() {
                             if i >= func.param_comptime.len()
                                 || !func.param_comptime[i]
@@ -2823,10 +2830,8 @@ impl<'a> ConstraintGenerator<'a> {
                                     .iter()
                                     .map(|arg| self.generate(arg.value, ctx))
                                     .collect();
-                                let mut type_subst: std::collections::HashMap<lasso::Spur, Type> =
-                                    std::collections::HashMap::new();
-                                let mut value_subst: std::collections::HashMap<lasso::Spur, i128> =
-                                    std::collections::HashMap::new();
+                                let mut type_subst: AHashMap<lasso::Spur, Type> = AHashMap::new();
+                                let mut value_subst: AHashMap<lasso::Spur, i128> = AHashMap::new();
                                 for (i, arg) in call_args.iter().enumerate() {
                                     if i >= func.param_comptime.len()
                                         || !func.param_comptime[i]
@@ -3787,8 +3792,8 @@ impl<'a> ConstraintGenerator<'a> {
     fn infer_rir_type_hint_with_substitutions(
         &self,
         syntax: RirTypeSyntaxRef,
-        subst: Option<&HashMap<Spur, Type>>,
-        values: Option<&HashMap<Spur, i128>>,
+        subst: Option<&AHashMap<Spur, Type>>,
+        values: Option<&AHashMap<Spur, i128>>,
         file_id: FileId,
     ) -> Option<InferType> {
         self.infer_type_hint(self.rir.type_syntax(), syntax, subst, values, file_id)
@@ -3797,8 +3802,8 @@ impl<'a> ConstraintGenerator<'a> {
     fn infer_structured_type_hint(
         &self,
         syntax: &crate::sema::StructuredTypeSyntax,
-        subst: &HashMap<Spur, Type>,
-        values: &HashMap<Spur, i128>,
+        subst: &AHashMap<Spur, Type>,
+        values: &AHashMap<Spur, i128>,
         file_id: FileId,
     ) -> Option<InferType> {
         self.infer_type_hint(
@@ -3814,8 +3819,8 @@ impl<'a> ConstraintGenerator<'a> {
         &self,
         arena: &rue_rir::RirTypeSyntaxArena<Spur>,
         syntax: RirTypeSyntaxRef,
-        subst: Option<&HashMap<Spur, Type>>,
-        values: Option<&HashMap<Spur, i128>>,
+        subst: Option<&AHashMap<Spur, Type>>,
+        values: Option<&AHashMap<Spur, i128>>,
         file_id: FileId,
     ) -> Option<InferType> {
         match arena.node(syntax)? {
@@ -3955,10 +3960,10 @@ mod tests {
         );
         assert!(inserted);
 
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
         let cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
         );
@@ -4016,10 +4021,10 @@ mod tests {
     #[test]
     fn test_constraint_generator_int_literal() {
         let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
 
         // Add an integer constant to RIR
         let inst_ref = rir.add_inst(rue_rir::Inst {
@@ -4030,7 +4035,7 @@ mod tests {
         let mut cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
         );
-        let params = HashMap::new();
+        let params = AHashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
         let info = cgen.generate(inst_ref, &mut ctx);
@@ -4046,10 +4051,10 @@ mod tests {
     #[test]
     fn test_constraint_generator_bool_literal() {
         let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
 
         let inst_ref = rir.add_inst(rue_rir::Inst {
             data: InstData::BoolConst(true),
@@ -4059,7 +4064,7 @@ mod tests {
         let mut cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
         );
-        let params = HashMap::new();
+        let params = AHashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::BOOL);
 
         let info = cgen.generate(inst_ref, &mut ctx);
@@ -4079,10 +4084,10 @@ mod tests {
             ("assert", true, Type::UNIT),
         ] {
             let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
-            let functions = HashMap::new();
-            let structs = HashMap::new();
-            let enums = HashMap::new();
-            let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+            let functions = AHashMap::new();
+            let structs = AHashMap::new();
+            let enums = AHashMap::new();
+            let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
 
             // Argument legality belongs to sema; this probe only pins HM's
             // result contract and verifies that an operand is still visited.
@@ -4099,7 +4104,7 @@ mod tests {
             let mut cgen = ConstraintGenerator::new(
                 &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
             );
-            let params = HashMap::new();
+            let params = AHashMap::new();
             let mut ctx = ConstraintContext::new(&params, Type::UNIT);
 
             let info = cgen.generate(intrinsic, &mut ctx);
@@ -4123,10 +4128,10 @@ mod tests {
     #[test]
     fn test_constraint_generator_binary_add() {
         let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
 
         // Create: 1 + 2
         let lhs = rir.add_inst(rue_rir::Inst {
@@ -4145,7 +4150,7 @@ mod tests {
         let mut cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
         );
-        let params = HashMap::new();
+        let params = AHashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
         let info = cgen.generate(add, &mut ctx);
@@ -4164,10 +4169,10 @@ mod tests {
     #[test]
     fn test_constraint_generator_comparison() {
         let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
 
         // Create: 1 < 2
         let lhs = rir.add_inst(rue_rir::Inst {
@@ -4186,7 +4191,7 @@ mod tests {
         let mut cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
         );
-        let params = HashMap::new();
+        let params = AHashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::BOOL);
 
         let info = cgen.generate(lt, &mut ctx);
@@ -4200,10 +4205,10 @@ mod tests {
     #[test]
     fn test_constraint_generator_logical_and() {
         let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
 
         // Create: true && false
         let lhs = rir.add_inst(rue_rir::Inst {
@@ -4222,7 +4227,7 @@ mod tests {
         let mut cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
         );
-        let params = HashMap::new();
+        let params = AHashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::BOOL);
 
         let info = cgen.generate(and, &mut ctx);
@@ -4236,10 +4241,10 @@ mod tests {
     #[test]
     fn test_constraint_generator_negation() {
         let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
 
         // Create: -42
         let operand = rir.add_inst(rue_rir::Inst {
@@ -4254,7 +4259,7 @@ mod tests {
         let mut cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
         );
-        let params = HashMap::new();
+        let params = AHashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
         let info = cgen.generate(neg, &mut ctx);
@@ -4273,10 +4278,10 @@ mod tests {
     #[test]
     fn test_constraint_generator_return() {
         let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
 
         // Create: return 42
         let value = rir.add_inst(rue_rir::Inst {
@@ -4291,7 +4296,7 @@ mod tests {
         let mut cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
         );
-        let params = HashMap::new();
+        let params = AHashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
         let info = cgen.generate(ret, &mut ctx);
@@ -4305,10 +4310,10 @@ mod tests {
     #[test]
     fn test_constraint_generator_if_else() {
         let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
 
         // Create: if true { 1 } else { 2 }
         let cond = rir.add_inst(rue_rir::Inst {
@@ -4335,7 +4340,7 @@ mod tests {
         let mut cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
         );
-        let params = HashMap::new();
+        let params = AHashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
         let info = cgen.generate(branch, &mut ctx);
@@ -4349,10 +4354,10 @@ mod tests {
     #[test]
     fn test_constraint_generator_while_loop() {
         let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
 
         // Create: while true { 0 }
         let cond = rir.add_inst(rue_rir::Inst {
@@ -4371,7 +4376,7 @@ mod tests {
         let mut cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
         );
-        let params = HashMap::new();
+        let params = AHashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::UNIT);
 
         let info = cgen.generate(loop_inst, &mut ctx);
@@ -4384,7 +4389,7 @@ mod tests {
 
     #[test]
     fn test_constraint_context_scope() {
-        let params = HashMap::new();
+        let params = AHashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
         // Use an interner to create a symbol
@@ -4463,10 +4468,10 @@ mod tests {
     #[test]
     fn test_constraint_generator_infinite_loop() {
         let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
 
         // Create: loop { 0 }
         let body = rir.add_inst(rue_rir::Inst {
@@ -4484,7 +4489,7 @@ mod tests {
         let mut cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
         );
-        let params = HashMap::new();
+        let params = AHashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::UNIT);
 
         let info = cgen.generate(loop_inst, &mut ctx);
@@ -4498,10 +4503,10 @@ mod tests {
     #[test]
     fn test_constraint_generator_break_continue() {
         let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
 
         let break_inst = rir.add_inst(rue_rir::Inst {
             data: InstData::Break { value: None },
@@ -4511,7 +4516,7 @@ mod tests {
         let mut cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
         );
-        let params = HashMap::new();
+        let params = AHashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::UNIT);
 
         let info = cgen.generate(break_inst, &mut ctx);
@@ -4524,10 +4529,10 @@ mod tests {
     #[test]
     fn test_constraint_generator_index_get() {
         let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
 
         // Create: arr[0]
         let base = rir.add_inst(rue_rir::Inst {
@@ -4546,7 +4551,7 @@ mod tests {
         let mut cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
         );
-        let params = HashMap::new();
+        let params = AHashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
         let info = cgen.generate(index_get, &mut ctx);
@@ -4564,10 +4569,10 @@ mod tests {
     #[test]
     fn test_constraint_generator_index_set() {
         let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
 
         // Create: arr[0] = 42
         let base = rir.add_inst(rue_rir::Inst {
@@ -4590,7 +4595,7 @@ mod tests {
         let mut cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
         );
-        let params = HashMap::new();
+        let params = AHashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::UNIT);
 
         let info = cgen.generate(index_set, &mut ctx);
@@ -4608,10 +4613,10 @@ mod tests {
     #[test]
     fn test_constraint_generator_empty_block() {
         let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
 
         // Create: { } (empty block)
         let block = rir.add_block(&[], Span::new(0, 2)).unwrap();
@@ -4619,7 +4624,7 @@ mod tests {
         let mut cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
         );
-        let params = HashMap::new();
+        let params = AHashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::UNIT);
 
         let info = cgen.generate(block, &mut ctx);
@@ -4632,10 +4637,10 @@ mod tests {
     #[test]
     fn test_constraint_generator_bitwise_not() {
         let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
 
         // Create: !42 (bitwise NOT)
         let operand = rir.add_inst(rue_rir::Inst {
@@ -4650,7 +4655,7 @@ mod tests {
         let mut cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
         );
-        let params = HashMap::new();
+        let params = AHashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
         let info = cgen.generate(bitnot, &mut ctx);
@@ -4668,10 +4673,10 @@ mod tests {
     #[test]
     fn test_constraint_generator_function_call_arg_count_mismatch() {
         let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
-        let mut functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let mut functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
 
         // Register a function that takes 2 parameters
         let func_name = interner.get_or_intern("foo");
@@ -4685,7 +4690,7 @@ mod tests {
                 InferType::Concrete(Type::BOOL),
             ),
         );
-        let functions_by_file_name = HashMap::from([((FileId::DEFAULT, func_name), func_name)]);
+        let functions_by_file_name = AHashMap::from([((FileId::DEFAULT, func_name), func_name)]);
 
         // Create a call with only 1 argument (mismatch)
         let arg = rir.add_inst(rue_rir::Inst {
@@ -4707,7 +4712,7 @@ mod tests {
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
         )
         .with_functions_by_file_name(&functions_by_file_name);
-        let params = HashMap::new();
+        let params = AHashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::BOOL);
 
         let info = cgen.generate(call, &mut ctx);
@@ -4721,10 +4726,10 @@ mod tests {
     #[test]
     fn test_constraint_generator_unknown_function() {
         let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
-        let functions = HashMap::new(); // Empty - no functions registered
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new(); // Empty - no functions registered
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
 
         // Create a call to an unknown function
         let unknown_func = interner.get_or_intern("unknown");
@@ -4746,7 +4751,7 @@ mod tests {
         let mut cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
         );
-        let params = HashMap::new();
+        let params = AHashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
         let info = cgen.generate(call, &mut ctx);
@@ -4760,10 +4765,10 @@ mod tests {
     #[test]
     fn test_constraint_generator_match_multiple_arms() {
         let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
 
         // Create: match x { 1 => 10, 2 => 20, _ => 30 }
         let scrutinee = rir.add_inst(rue_rir::Inst {
@@ -4811,7 +4816,7 @@ mod tests {
         let mut cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
         );
-        let params = HashMap::new();
+        let params = AHashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
         let info = cgen.generate(match_inst, &mut ctx);
@@ -4850,13 +4855,13 @@ mod tests {
     #[test]
     fn array_length_bare_const_resolves_in_declaring_file_scope() {
         let (rir, interner, type_pool) = cgen_fixture();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
         let file_a = FileId::new(0);
         let k = interner.get_or_intern("K");
-        let mut const_values: HashMap<(FileId, Spur), i128> = HashMap::new();
+        let mut const_values: AHashMap<(FileId, Spur), i128> = AHashMap::new();
         const_values.insert((file_a, k), 4);
 
         let cgen = ConstraintGenerator::new(
@@ -4874,16 +4879,16 @@ mod tests {
     #[test]
     fn array_length_bare_const_out_of_scope_does_not_resolve() {
         let (rir, interner, type_pool) = cgen_fixture();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
         let file_a = FileId::new(0);
         let file_b = FileId::new(1);
         let k = interner.get_or_intern("K");
         // The only `K` lives in file_b; referencing it bare from file_a is out
         // of scope even though `K` is globally unique.
-        let mut const_values: HashMap<(FileId, Spur), i128> = HashMap::new();
+        let mut const_values: AHashMap<(FileId, Spur), i128> = AHashMap::new();
         const_values.insert((file_b, k), 4);
 
         let cgen = ConstraintGenerator::new(
@@ -4905,14 +4910,14 @@ mod tests {
     #[test]
     fn array_length_distant_same_named_const_cannot_perturb_local_resolution() {
         let (rir, interner, type_pool) = cgen_fixture();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
         let file_a = FileId::new(0);
         let file_b = FileId::new(1);
         let n = interner.get_or_intern("N");
-        let mut const_values: HashMap<(FileId, Spur), i128> = HashMap::new();
+        let mut const_values: AHashMap<(FileId, Spur), i128> = AHashMap::new();
         const_values.insert((file_a, n), 3);
         // An unrelated distant const of the same name.
         const_values.insert((file_b, n), 99);
@@ -4940,13 +4945,13 @@ mod tests {
     #[test]
     fn array_length_comptime_value_param_precedes_file_const() {
         let (rir, interner, type_pool) = cgen_fixture();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
         let file_a = FileId::new(0);
         let n = interner.get_or_intern("N");
-        let mut const_values: HashMap<(FileId, Spur), i128> = HashMap::new();
+        let mut const_values: AHashMap<(FileId, Spur), i128> = AHashMap::new();
         const_values.insert((file_a, n), 9);
 
         let cgen = ConstraintGenerator::new(
@@ -4956,7 +4961,7 @@ mod tests {
 
         // With a comptime value binding N=5, the value parameter wins over the
         // file-level const N=9.
-        let mut values: HashMap<Spur, i128> = HashMap::new();
+        let mut values: AHashMap<Spur, i128> = AHashMap::new();
         values.insert(n, 5);
         assert_eq!(
             cgen.resolve_infer_array_length_with_values(
@@ -4967,7 +4972,7 @@ mod tests {
             Some(5)
         );
         // With no value binding, the same-file const supplies the length.
-        let empty: HashMap<Spur, i128> = HashMap::new();
+        let empty: AHashMap<Spur, i128> = AHashMap::new();
         assert_eq!(
             cgen.resolve_infer_array_length_with_values(
                 &ArrayLen::Named("N".to_string()),
@@ -4981,14 +4986,14 @@ mod tests {
     #[test]
     fn alias_head_bare_name_resolves_in_declaring_file_scope_only() {
         let (rir, interner, type_pool) = cgen_fixture();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
         let file_a = FileId::new(0);
         let file_b = FileId::new(1);
         let alias = interner.get_or_intern("MyAlias");
-        let mut const_type_aliases: HashMap<(FileId, Spur), Type> = HashMap::new();
+        let mut const_type_aliases: AHashMap<(FileId, Spur), Type> = AHashMap::new();
         const_type_aliases.insert((file_a, alias), Type::I32);
 
         let cgen = ConstraintGenerator::new(
@@ -5012,16 +5017,16 @@ mod tests {
     #[test]
     fn scoped_lookups_keep_value_and_type_kinds_distinct() {
         let (rir, interner, type_pool) = cgen_fixture();
-        let functions = HashMap::new();
-        let structs = HashMap::new();
-        let enums = HashMap::new();
-        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let functions = AHashMap::new();
+        let structs = AHashMap::new();
+        let enums = AHashMap::new();
+        let methods: AHashMap<(StructId, Spur), MethodSig> = AHashMap::new();
         let file_a = FileId::new(0);
         let value_name = interner.get_or_intern("K");
         let type_name = interner.get_or_intern("T");
-        let mut const_values: HashMap<(FileId, Spur), i128> = HashMap::new();
+        let mut const_values: AHashMap<(FileId, Spur), i128> = AHashMap::new();
         const_values.insert((file_a, value_name), 4);
-        let mut const_type_aliases: HashMap<(FileId, Spur), Type> = HashMap::new();
+        let mut const_type_aliases: AHashMap<(FileId, Spur), Type> = AHashMap::new();
         const_type_aliases.insert((file_a, type_name), Type::I32);
 
         let cgen = ConstraintGenerator::new(

--- a/crates/rue-air/src/inference/unify.rs
+++ b/crates/rue-air/src/inference/unify.rs
@@ -5,6 +5,8 @@
 //! - [`UnificationError`] - Error with span for reporting
 //! - [`Unifier`] - The unification engine
 
+use ahash::AHashSet;
+
 use super::constraint::{Constraint, Substitution};
 use super::types::{InferType, TypeVarId};
 use crate::Type;
@@ -114,11 +116,11 @@ pub struct Unifier {
     /// points at the constraint that introduced the conflict (e.g. the
     /// offending match arm) instead of surfacing later at an unrelated, wider
     /// span like the whole function body (RUE-133).
-    int_literal_vars: std::collections::HashSet<TypeVarId>,
+    int_literal_vars: AHashSet<TypeVarId>,
     /// Variables rooted at string literals, plus variables joined with them.
-    string_literal_vars: std::collections::HashSet<TypeVarId>,
+    string_literal_vars: AHashSet<TypeVarId>,
     /// Concrete string types that may contextualize a literal.
-    string_literal_types: std::collections::HashSet<Type>,
+    string_literal_types: AHashSet<Type>,
 }
 
 impl Default for Unifier {
@@ -132,9 +134,9 @@ impl Unifier {
     pub fn new() -> Self {
         Unifier {
             substitution: Substitution::new(),
-            int_literal_vars: std::collections::HashSet::new(),
-            string_literal_vars: std::collections::HashSet::new(),
-            string_literal_types: std::collections::HashSet::new(),
+            int_literal_vars: AHashSet::new(),
+            string_literal_vars: AHashSet::new(),
+            string_literal_types: AHashSet::new(),
         }
     }
 
@@ -145,9 +147,9 @@ impl Unifier {
     pub fn with_capacity(type_var_count: u32) -> Self {
         Unifier {
             substitution: Substitution::with_capacity(type_var_count as usize),
-            int_literal_vars: std::collections::HashSet::new(),
-            string_literal_vars: std::collections::HashSet::new(),
-            string_literal_types: std::collections::HashSet::new(),
+            int_literal_vars: AHashSet::new(),
+            string_literal_vars: AHashSet::new(),
+            string_literal_types: AHashSet::new(),
         }
     }
 

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -26,7 +26,7 @@
 //! - Read lock for lookups (common case)
 //! - Write lock for insertions (rare, during declaration gathering)
 
-use std::collections::{HashMap, HashSet};
+use ahash::{AHashMap, AHashSet};
 use std::ops::Deref;
 use std::sync::{Arc, LazyLock, PoisonError, RwLock};
 
@@ -196,7 +196,7 @@ enum ValidationMode {
 struct TypeVisitSet {
     inline: [Type; 64],
     len: usize,
-    overflow: Option<HashSet<Type>>,
+    overflow: Option<AHashSet<Type>>,
 }
 
 impl TypeVisitSet {
@@ -220,7 +220,7 @@ impl TypeVisitSet {
             self.len += 1;
             return true;
         }
-        let mut overflow = HashSet::with_capacity(self.len + 1);
+        let mut overflow = AHashSet::with_capacity(self.len + 1);
         overflow.extend(self.inline);
         let inserted = overflow.insert(ty);
         self.overflow = Some(overflow);
@@ -570,22 +570,22 @@ struct TypeInternPoolInner {
 
     /// Base entries this epoch rewrote, keyed by pool index. Empty unless a
     /// mutation reached below `base_len`.
-    overrides: HashMap<usize, TypeData>,
+    overrides: AHashMap<usize, TypeData>,
 
     /// Base containment facts this epoch rewrote, keyed by pool index.
-    override_facts: HashMap<usize, Option<TypeContainmentFacts>>,
+    override_facts: AHashMap<usize, Option<TypeContainmentFacts>>,
 
     /// Composite type data this epoch interned itself, from `base_len` up.
     types: Vec<TypeData>,
 
     /// Structural type deduplication: (element, len) -> canonical array `Type`.
-    array_map: HashMap<(Type, u64), Type>,
+    array_map: AHashMap<(Type, u64), Type>,
 
     /// Structural type deduplication: pointee -> canonical ptr const `Type`.
-    ptr_const_map: HashMap<Type, Type>,
+    ptr_const_map: AHashMap<Type, Type>,
 
     /// Structural type deduplication: pointee -> canonical ptr mut `Type`.
-    ptr_mut_map: HashMap<Type, Type>,
+    ptr_mut_map: AHashMap<Type, Type>,
 
     /// Ownership facts indexed in lockstep with `types` (so also from
     /// `base_len` up). `None` is permitted only while declaration shells or a
@@ -633,24 +633,24 @@ struct TypeInternPoolInner {
     /// provider boundary. A pool that carries the type but not the mark spells
     /// a generated anonymous type as if it were a user nominal and desyncs the
     /// callable symbols joined across that boundary (RUE-1193).
-    anonymous_structs: HashSet<StructId>,
-    anonymous_enums: HashSet<EnumId>,
+    anonymous_structs: AHashSet<StructId>,
+    anonymous_enums: AHashSet<EnumId>,
 
     /// Nominal struct lookup: (defining file, source name) -> canonical `Type`.
-    struct_by_file_name: HashMap<(FileId, Spur), Type>,
+    struct_by_file_name: AHashMap<(FileId, Spur), Type>,
 
     /// Nominal enum lookup: (defining file, source name) -> canonical `Type`.
-    enum_by_file_name: HashMap<(FileId, Spur), Type>,
+    enum_by_file_name: AHashMap<(FileId, Spur), Type>,
 
     /// Relocation-stable logical identity for each defining source file.
-    symbol_paths: Arc<HashMap<FileId, String>>,
+    symbol_paths: Arc<AHashMap<FileId, String>>,
 
     /// Explicit language-item assignments issued by a trusted frontend or
     /// durable semantic import boundary.
-    struct_lang_items: Arc<HashMap<StructId, LangItem>>,
+    struct_lang_items: Arc<AHashMap<StructId, LangItem>>,
 
     /// Reverse index enforcing one canonical nominal for each language item.
-    lang_item_structs: Arc<HashMap<LangItem, StructId>>,
+    lang_item_structs: Arc<AHashMap<LangItem, StructId>>,
 
     /// Structs carrying the `@repr(c)` guarantee marker (ADR-0064 Amendment 1,
     /// RUE-1063). A side map, like `struct_lang_items`, so the marker travels
@@ -658,7 +658,7 @@ struct TypeInternPoolInner {
     /// classifier consult) without widening `StructDef` or its durable form. A
     /// layout no-op today; the guarantee that pins C representation and anchors
     /// FFI-safety.
-    repr_c_structs: Arc<HashSet<StructId>>,
+    repr_c_structs: Arc<AHashSet<StructId>>,
 
     /// Latched once a registration asked for a pool index past the published
     /// 24-bit `Type` payload ceiling (spec Appendix C.6:1,
@@ -804,21 +804,21 @@ impl TypeInternPoolInner {
         Self {
             base: None,
             base_len: 0,
-            overrides: HashMap::new(),
-            override_facts: HashMap::new(),
+            overrides: AHashMap::new(),
+            override_facts: AHashMap::new(),
             types: Vec::new(),
-            array_map: HashMap::new(),
-            ptr_const_map: HashMap::new(),
-            ptr_mut_map: HashMap::new(),
+            array_map: AHashMap::new(),
+            ptr_const_map: AHashMap::new(),
+            ptr_mut_map: AHashMap::new(),
             containment_facts: Vec::new(),
             pending_facts: 0,
             facts_stale: false,
             unsettled_facts: false,
             containment_metrics: TypeContainmentMetrics::default(),
-            anonymous_structs: HashSet::new(),
-            anonymous_enums: HashSet::new(),
-            struct_by_file_name: HashMap::new(),
-            enum_by_file_name: HashMap::new(),
+            anonymous_structs: AHashSet::new(),
+            anonymous_enums: AHashSet::new(),
+            struct_by_file_name: AHashMap::new(),
+            enum_by_file_name: AHashMap::new(),
             symbol_paths: Arc::default(),
             struct_lang_items: Arc::default(),
             lang_item_structs: Arc::default(),
@@ -1046,12 +1046,12 @@ impl TypeInternPoolInner {
         Self {
             base_len: base.entry_count(),
             base: Some(base),
-            overrides: HashMap::new(),
-            override_facts: HashMap::new(),
+            overrides: AHashMap::new(),
+            override_facts: AHashMap::new(),
             types: Vec::new(),
-            array_map: HashMap::new(),
-            ptr_const_map: HashMap::new(),
-            ptr_mut_map: HashMap::new(),
+            array_map: AHashMap::new(),
+            ptr_const_map: AHashMap::new(),
+            ptr_mut_map: AHashMap::new(),
             containment_facts: Vec::new(),
             pending_facts,
             facts_stale,
@@ -1059,10 +1059,10 @@ impl TypeInternPoolInner {
             containment_metrics: TypeContainmentMetrics::default(),
             // Empty locally; `is_anonymous_*` consults the base for entries
             // below `base_len`, matching how `types` is layered.
-            anonymous_structs: HashSet::new(),
-            anonymous_enums: HashSet::new(),
-            struct_by_file_name: HashMap::new(),
-            enum_by_file_name: HashMap::new(),
+            anonymous_structs: AHashSet::new(),
+            anonymous_enums: AHashSet::new(),
+            struct_by_file_name: AHashMap::new(),
+            enum_by_file_name: AHashMap::new(),
             symbol_paths: Arc::clone(&self.symbol_paths),
             struct_lang_items: Arc::clone(&self.struct_lang_items),
             lang_item_structs: Arc::clone(&self.lang_item_structs),
@@ -2566,7 +2566,7 @@ impl TypeInternPool {
     }
 
     /// Set relocation-stable source identities for type-derived symbols.
-    pub(crate) fn set_symbol_paths(&self, symbol_paths: HashMap<FileId, String>) {
+    pub(crate) fn set_symbol_paths(&self, symbol_paths: AHashMap<FileId, String>) {
         self.inner
             .write()
             .unwrap_or_else(PoisonError::into_inner)
@@ -5891,7 +5891,7 @@ mod tests {
         let interner = ThreadedRodeo::default();
         let left_id = FileId::new(42);
         let right_id = FileId::new(7);
-        pool.set_symbol_paths(HashMap::from([
+        pool.set_symbol_paths(AHashMap::from([
             (left_id, "left/shared.rue".to_string()),
             (right_id, "right/shared.rue".to_string()),
         ]));

--- a/crates/rue-air/src/scope.rs
+++ b/crates/rue-air/src/scope.rs
@@ -25,7 +25,7 @@
 //! }
 //! ```
 
-use std::collections::HashMap;
+use ahash::AHashMap;
 
 use lasso::Spur;
 
@@ -46,7 +46,7 @@ pub trait ScopedContext {
     type VarInfo: Clone;
 
     /// Get a mutable reference to the locals map.
-    fn locals_mut(&mut self) -> &mut HashMap<Spur, Self::VarInfo>;
+    fn locals_mut(&mut self) -> &mut AHashMap<Spur, Self::VarInfo>;
 
     /// Get a mutable reference to the scope stack.
     fn scope_stack_mut(&mut self) -> &mut Vec<Vec<(Spur, Option<Self::VarInfo>)>>;
@@ -112,14 +112,14 @@ mod tests {
     /// A minimal implementation of ScopedContext for testing.
     #[derive(Debug)]
     struct TestContext {
-        locals: HashMap<Spur, i32>,
+        locals: AHashMap<Spur, i32>,
         scope_stack: Vec<Vec<(Spur, Option<i32>)>>,
     }
 
     impl TestContext {
         fn new() -> Self {
             Self {
-                locals: HashMap::new(),
+                locals: AHashMap::new(),
                 scope_stack: Vec::new(),
             }
         }
@@ -128,7 +128,7 @@ mod tests {
     impl ScopedContext for TestContext {
         type VarInfo = i32;
 
-        fn locals_mut(&mut self) -> &mut HashMap<Spur, Self::VarInfo> {
+        fn locals_mut(&mut self) -> &mut AHashMap<Spur, Self::VarInfo> {
             &mut self.locals
         }
 

--- a/crates/rue-air/src/sema/aggregate_resolution.rs
+++ b/crates/rue-air/src/sema/aggregate_resolution.rs
@@ -3,8 +3,8 @@
 //! Selection order lives here. Both body-analysis hosts implement the one
 //! [`AggregateFacts`] boundary directly.
 
+use ahash::AHashMap;
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::hash::Hash;
 
 use lasso::Spur;
@@ -178,7 +178,7 @@ pub(crate) fn resolve_aggregate_module_ref<P: AggregateFacts>(
     rir: &Rir,
     inst_ref: InstRef,
     root_file: FileId,
-    locals: &std::collections::HashMap<Spur, LocalVar>,
+    locals: &AHashMap<Spur, LocalVar>,
 ) -> Option<ModuleId> {
     match rir.get(inst_ref).data {
         InstData::VarRef { name, .. } => {
@@ -206,7 +206,7 @@ pub(crate) fn resolve_visibility_module_ref<P: AggregateFacts>(
     facts: &P,
     rir: &Rir,
     inst_ref: InstRef,
-    locals: &std::collections::HashMap<Spur, LocalVar>,
+    locals: &AHashMap<Spur, LocalVar>,
 ) -> Option<ModuleId> {
     let inst = rir.get(inst_ref);
     let module_ty = match inst.data {
@@ -310,15 +310,15 @@ pub struct ProviderAggregateFacts<K, M, S> {
     /// populated on demand as a caller registers a nominal. The `Spur` is the
     /// pool's own interner symbol (the same one the `select_*` wrappers intern
     /// their name argument to), never the shared whole-program interner's.
-    by_file_name: HashMap<(u32, Spur), K>,
+    by_file_name: AHashMap<(u32, Spur), K>,
     /// Request-local file paths (a body-query input, exactly like the RIR — not a
     /// durable fact the pool mints), owned so [`AggregateFacts::file_path`] hands
     /// back a borrowed `&str` without a seam-signature change. A caller registers
     /// the same physical path the epoch's `get_file_path` returns, so
     /// [`is_accessible`]'s visibility-domain computation matches byte-for-byte.
-    file_paths: HashMap<FileId, String>,
-    value_consts: RefCell<HashMap<(u32, Spur), ConstInfo>>,
-    module_bindings: RefCell<HashMap<(u32, Spur), ConstInfo>>,
+    file_paths: AHashMap<FileId, String>,
+    value_consts: RefCell<AHashMap<(u32, Spur), ConstInfo>>,
+    module_bindings: RefCell<AHashMap<(u32, Spur), ConstInfo>>,
 }
 
 impl<K, M, S> ProviderAggregateFacts<K, M, S>
@@ -343,10 +343,10 @@ where
     fn with_overlay_identity(identity: ProviderIdentityContext<K, M, S>) -> Self {
         Self {
             identity,
-            by_file_name: HashMap::new(),
-            file_paths: HashMap::new(),
-            value_consts: RefCell::new(HashMap::new()),
-            module_bindings: RefCell::new(HashMap::new()),
+            by_file_name: AHashMap::new(),
+            file_paths: AHashMap::new(),
+            value_consts: RefCell::new(AHashMap::new()),
+            module_bindings: RefCell::new(AHashMap::new()),
         }
     }
 

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -5,6 +5,8 @@
 //! bounds, move, borrow, and reinitialization semantics to the canonical
 //! `analysis::ownership` API.
 
+use ahash::{AHashMap, AHashSet};
+
 use super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
 use lasso::Spur;
 use rue_error::{CompileError, CompileResult, ErrorKind, MissingFieldsError, OptionExt};
@@ -435,7 +437,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let struct_type = Type::new_struct(struct_id);
 
         // Build a map from field name to struct field index
-        let field_index_map: std::collections::HashMap<&str, usize> = struct_def
+        let field_index_map: AHashMap<&str, usize> = struct_def
             .fields
             .iter()
             .enumerate()
@@ -443,7 +445,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             .collect();
 
         // Check for unknown or duplicate fields
-        let mut seen_fields = std::collections::HashSet::new();
+        let mut seen_fields = AHashSet::new();
         for &(init_field_name, _) in &field_inits {
             let init_name = self.body_interner().resolve(&init_field_name).to_owned();
 

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -7,7 +7,7 @@
 //! (`provider_body_host`); no whole-program driver lives here.
 
 use super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
-use std::collections::{HashMap, HashSet};
+use ahash::{AHashMap, AHashSet};
 
 use lasso::{Spur, ThreadedRodeo};
 use rue_error::{
@@ -304,8 +304,8 @@ where
     A: IntoIterator,
     A::Item: std::ops::Deref<Target = RirCallArg>,
 {
-    let mut inout_vars: HashSet<Spur> = HashSet::new();
-    let mut borrow_vars: HashSet<Spur> = HashSet::new();
+    let mut inout_vars: AHashSet<Spur> = AHashSet::new();
+    let mut borrow_vars: AHashSet<Spur> = AHashSet::new();
 
     for arg in args {
         let arg = &*arg;

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -433,8 +433,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // can accidentally accept it.
         let all_params_comptime = param_comptime.iter().all(|&flag| flag);
         if self.function_returns_type(&fn_info) && (args.is_empty() || all_params_comptime) {
-            let mut type_subst = std::collections::HashMap::new();
-            let mut value_subst = std::collections::HashMap::new();
+            let mut type_subst = AHashMap::new();
+            let mut value_subst = AHashMap::new();
             for (i, is_comptime) in param_comptime.iter().enumerate() {
                 if !*is_comptime {
                     continue;
@@ -565,13 +565,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let mut type_args: Vec<Type> = Vec::new();
             let mut value_args: Vec<ConstValue> = Vec::new();
             let mut runtime_args: Vec<AirCallArg> = Vec::new();
-            let mut type_subst: std::collections::HashMap<Spur, Type> =
-                std::collections::HashMap::new();
+            let mut type_subst: AHashMap<Spur, Type> = AHashMap::new();
             // Comptime VALUE parameters (`comptime N: i32`) map to their
             // captured constant so a runtime param type mentioning one — an
             // array length `arr: [i32; N]` — resolves at this call (RUE-16).
-            let mut value_subst: std::collections::HashMap<Spur, ConstValue> =
-                std::collections::HashMap::new();
+            let mut value_subst: AHashMap<Spur, ConstValue> = AHashMap::new();
 
             for (i, (air_arg, is_comptime)) in
                 air_args.iter().zip(param_comptime.iter()).enumerate()
@@ -717,8 +715,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 // The return type is literally `type`, not a type parameter that was substituted.
                 // Try to evaluate the function body at compile time with type substitutions.
                 // Also build value_subst from comptime VALUE parameters (e.g., comptime N: i32)
-                let mut value_subst: std::collections::HashMap<Spur, ConstValue> =
-                    std::collections::HashMap::new();
+                let mut value_subst: AHashMap<Spur, ConstValue> = AHashMap::new();
                 for (i, is_comptime) in param_comptime.iter().enumerate() {
                     let argument_is_type = air_args.get(i).is_some_and(|argument| {
                         matches!(air.get(argument.value).data, AirInstData::TypeConst(_))

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -40,9 +40,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         return_type: Type,
         params: &[(Spur, Type, RirParamMode, bool)],
         body: InstRef,
-        type_subst: Option<&HashMap<Spur, Type>>,
-        value_subst: Option<&HashMap<Spur, ConstValue>>,
-    ) -> CompileResult<(HashMap<InstRef, Type>, InferenceBreakdown)> {
+        type_subst: Option<&AHashMap<Spur, Type>>,
+        value_subst: Option<&AHashMap<Spur, ConstValue>>,
+    ) -> CompileResult<(AHashMap<InstRef, Type>, InferenceBreakdown)> {
         let precompute_started = Instant::now();
         // Pre-resolve `let`-bound comptime type aliases (`let P = F();` where
         // `F` returns `type`) so inference can see the concrete anonymous
@@ -81,7 +81,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             .map(|(inst_ref, ty)| (*inst_ref, *ty))
             .collect();
         flat_bindings.sort_by_key(|(inst_ref, _)| inst_ref.as_u32());
-        let comptime_local_types: HashMap<Spur, Type> = flat_bindings
+        let comptime_local_types: AHashMap<Spur, Type> = flat_bindings
             .into_iter()
             .filter_map(
                 |(inst_ref, ty)| match self.body_rir_ref().get(inst_ref).data {
@@ -166,7 +166,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
             // Build parameter map for constraint context.
             // Convert Type to InferType so arrays are represented structurally.
-            let mut param_vars: HashMap<Spur, ParamVarInfo> = params
+            let mut param_vars: AHashMap<Spur, ParamVarInfo> = params
                 .iter()
                 .map(|(name, ty, mode, _is_comptime)| {
                     (
@@ -376,7 +376,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // Build the resolved types map, converting InferType to Type.
         // Since we pre-created all array types above, infer_type_to_type only
         // performs lookups (no mutation).
-        let mut resolved_types = HashMap::new();
+        let mut resolved_types = AHashMap::new();
         for (inst_ref, infer_ty) in &expr_types {
             let resolved = unifier.resolve_infer_type(infer_ty);
             let concrete_ty = self.infer_type_to_type(&resolved);

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -74,7 +74,6 @@
 //!   `finalize_containment_metadata` at the same point production freezes.
 
 use std::cell::{Cell, Ref, RefCell, RefMut};
-use std::collections::HashMap;
 use std::hash::Hash;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -474,10 +473,10 @@ pub(in crate::sema) struct BodyIdentityPool<K, M, S> {
 /// handle rather than constructing peer pools.
 #[derive(Default)]
 struct ProviderMethodRegistry {
-    anonymous: HashMap<(StructId, Spur), MethodInfo>,
-    anonymous_by_owner: HashMap<(FileId, Arc<str>, Arc<str>), (StructId, Spur)>,
-    named: HashMap<(StructId, Spur), MethodInfo>,
-    named_by_owner: HashMap<(FileId, Arc<str>, Arc<str>), (StructId, Spur)>,
+    anonymous: AHashMap<(StructId, Spur), MethodInfo>,
+    anonymous_by_owner: AHashMap<(FileId, Arc<str>, Arc<str>), (StructId, Spur)>,
+    named: AHashMap<(StructId, Spur), MethodInfo>,
+    named_by_owner: AHashMap<(FileId, Arc<str>, Arc<str>), (StructId, Spur)>,
 }
 
 impl ProviderMethodRegistry {
@@ -2788,10 +2787,10 @@ pub(in crate::sema) struct BodyRirIndex {
     /// The one additive keyed surface: named-method declarations keyed by the
     /// durable-available `(owner_file, owner_type_name, method_name)` preimage
     /// of the epoch's `(StructId, method_name)` key.
-    named_methods_by_owner: HashMap<(FileId, Spur, Spur), InstRef>,
+    named_methods_by_owner: AHashMap<(FileId, Spur, Spur), InstRef>,
     /// Const declarations keyed by the exact storage preimage used by the
     /// epoch's `const_resolutions`: `(declaring_file, source_name)`.
-    const_declarations: HashMap<(FileId, Spur), InstRef>,
+    const_declarations: AHashMap<(FileId, Spur), InstRef>,
 }
 
 /// One request-local RIR universe shared by every provider fact facade for a
@@ -2942,8 +2941,8 @@ impl BodyRirIndex {
     ) -> (Self, BodyRirIndexAttribution) {
         let declarations = RirDeclarationIndex::new(rir);
         let declaration_index = declarations.work();
-        let mut named_methods_by_owner = HashMap::new();
-        let mut const_declarations = HashMap::new();
+        let mut named_methods_by_owner = AHashMap::new();
+        let mut const_declarations = AHashMap::new();
         let mut attribution = BodyRirIndexAttribution {
             declaration_index,
             ..BodyRirIndexAttribution::default()
@@ -3354,18 +3353,18 @@ mod tests {
     /// A durable nominal + callable source backed by fixed maps, standing in for
     /// r4b's stable-keyed provider.
     struct MapSource {
-        nominals: HashMap<Key, DurableNominal<Key, Module>>,
-        nominal_file_ids: HashMap<Key, FileId>,
-        functions: HashMap<Key, DurableFunction<Key, Module>>,
+        nominals: AHashMap<Key, DurableNominal<Key, Module>>,
+        nominal_file_ids: AHashMap<Key, FileId>,
+        functions: AHashMap<Key, DurableFunction<Key, Module>>,
         function_reads: Rc<Cell<usize>>,
-        methods: HashMap<Key, DurableMethod<Key, Module>>,
-        consts: HashMap<Key, DurableConst<Key, Module>>,
-        anonymous_shapes: HashMap<AnonKey, DurableAnonymousShape<Key, Module>>,
+        methods: AHashMap<Key, DurableMethod<Key, Module>>,
+        consts: AHashMap<Key, DurableConst<Key, Module>>,
+        anonymous_shapes: AHashMap<AnonKey, DurableAnonymousShape<Key, Module>>,
         /// Force a chosen definition relocation for a producer key, so a test can
         /// point two DISTINCT producer keys at one stable-content string (and thus
         /// one digest) and exercise the collision guard without a real 128-bit
         /// hash collision.
-        def_component_overrides: HashMap<Key, String>,
+        def_component_overrides: AHashMap<Key, String>,
     }
 
     impl DurableNominalSource<Key, Module> for MapSource {
@@ -3421,13 +3420,13 @@ mod tests {
     fn source(nominals: impl IntoIterator<Item = (Key, DurableNominal<Key, Module>)>) -> MapSource {
         MapSource {
             nominals: nominals.into_iter().collect(),
-            nominal_file_ids: HashMap::new(),
-            functions: HashMap::new(),
+            nominal_file_ids: AHashMap::new(),
+            functions: AHashMap::new(),
             function_reads: Rc::new(Cell::new(0)),
-            methods: HashMap::new(),
-            consts: HashMap::new(),
-            anonymous_shapes: HashMap::new(),
-            def_component_overrides: HashMap::new(),
+            methods: AHashMap::new(),
+            consts: AHashMap::new(),
+            anonymous_shapes: AHashMap::new(),
+            def_component_overrides: AHashMap::new(),
         }
     }
 
@@ -3447,13 +3446,13 @@ mod tests {
         BodyIdentityPool::new(
             MapSource {
                 nominals: nominals.into_iter().collect(),
-                nominal_file_ids: HashMap::new(),
+                nominal_file_ids: AHashMap::new(),
                 functions: functions.into_iter().collect(),
                 function_reads: Rc::new(Cell::new(0)),
                 methods: methods.into_iter().collect(),
-                consts: HashMap::new(),
-                anonymous_shapes: HashMap::new(),
-                def_component_overrides: HashMap::new(),
+                consts: AHashMap::new(),
+                anonymous_shapes: AHashMap::new(),
+                def_component_overrides: AHashMap::new(),
             },
             Rc::new(ThreadedRodeo::new()),
         )
@@ -3467,13 +3466,13 @@ mod tests {
         BodyIdentityPool::new(
             MapSource {
                 nominals: nominals.into_iter().collect(),
-                nominal_file_ids: HashMap::new(),
+                nominal_file_ids: AHashMap::new(),
                 functions: functions.into_iter().collect(),
                 function_reads: Rc::new(Cell::new(0)),
-                methods: HashMap::new(),
+                methods: AHashMap::new(),
                 consts: consts.into_iter().collect(),
-                anonymous_shapes: HashMap::new(),
-                def_component_overrides: HashMap::new(),
+                anonymous_shapes: AHashMap::new(),
+                def_component_overrides: AHashMap::new(),
             },
             Rc::new(ThreadedRodeo::new()),
         )
@@ -3489,11 +3488,11 @@ mod tests {
         BodyIdentityPool::new(
             MapSource {
                 nominals: nominals.into_iter().collect(),
-                nominal_file_ids: HashMap::new(),
-                functions: HashMap::new(),
+                nominal_file_ids: AHashMap::new(),
+                functions: AHashMap::new(),
                 function_reads: Rc::new(Cell::new(0)),
-                methods: HashMap::new(),
-                consts: HashMap::new(),
+                methods: AHashMap::new(),
+                consts: AHashMap::new(),
                 anonymous_shapes: anonymous_shapes.into_iter().collect(),
                 def_component_overrides: def_component_overrides.into_iter().collect(),
             },
@@ -3788,7 +3787,7 @@ mod tests {
     fn twin_pool(module_path: &str) -> (TypeInternPool, ThreadedRodeo) {
         let pool = TypeInternPool::new();
         let interner = ThreadedRodeo::new();
-        pool.set_symbol_paths(HashMap::from([(TWIN_FILE, module_path.to_owned())]));
+        pool.set_symbol_paths(AHashMap::from([(TWIN_FILE, module_path.to_owned())]));
         (pool, interner)
     }
 
@@ -5335,7 +5334,7 @@ mod tests {
                 ),
             ),
         ]);
-        provider.nominal_file_ids = HashMap::from([(0, FileId::new(41)), (1, FileId::new(41))]);
+        provider.nominal_file_ids = AHashMap::from([(0, FileId::new(41)), (1, FileId::new(41))]);
         let mut pool = BodyIdentityPool::new(provider, Rc::new(ThreadedRodeo::new()));
 
         pool.resolve_provider_type(&DType::Nominal(0)).unwrap();

--- a/crates/rue-air/src/sema/call_resolution.rs
+++ b/crates/rue-air/src/sema/call_resolution.rs
@@ -14,8 +14,8 @@
 //! anonymous-then-named fallback) stays inside that point query, matching the
 //! `body_endpoint` convention.
 
+use ahash::AHashMap;
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::hash::Hash;
 
 use lasso::Spur;
@@ -98,8 +98,8 @@ pub struct ProviderCallFacts<'a, P, S, K, M> {
     provider: &'a P,
     identity: ProviderIdentityContext<K, M, S>,
     rir: BodyRirView<'a>,
-    value_consts: RefCell<HashMap<(u32, Spur), ConstInfo>>,
-    module_bindings: RefCell<HashMap<(u32, Spur), ConstInfo>>,
+    value_consts: RefCell<AHashMap<(u32, Spur), ConstInfo>>,
+    module_bindings: RefCell<AHashMap<(u32, Spur), ConstInfo>>,
 }
 
 impl<'a, P, S, K, M> ProviderCallFacts<'a, P, S, K, M>
@@ -149,8 +149,8 @@ where
             provider,
             identity,
             rir,
-            value_consts: RefCell::new(HashMap::new()),
-            module_bindings: RefCell::new(HashMap::new()),
+            value_consts: RefCell::new(AHashMap::new()),
+            module_bindings: RefCell::new(AHashMap::new()),
         }
     }
 

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -46,7 +46,7 @@
 //!   (`try_evaluate_const` and friends) convert it to `None` and
 //!   defer to the runtime check.
 
-use std::collections::{HashMap, HashSet};
+use ahash::{AHashMap, AHashSet};
 use std::sync::LazyLock;
 use std::time::Instant;
 
@@ -124,11 +124,11 @@ fn elapsed_ns(started: Instant) -> u64 {
 }
 
 /// Empty type substitution map for evaluation contexts without one.
-static EMPTY_TYPE_SUBST: LazyLock<HashMap<Spur, Type>> = LazyLock::new(HashMap::new);
+static EMPTY_TYPE_SUBST: LazyLock<AHashMap<Spur, Type>> = LazyLock::new(AHashMap::new);
 /// Empty value substitution map for evaluation contexts without one.
-static EMPTY_VALUE_SUBST: LazyLock<HashMap<Spur, ConstValue>> = LazyLock::new(HashMap::new);
+static EMPTY_VALUE_SUBST: LazyLock<AHashMap<Spur, ConstValue>> = LazyLock::new(AHashMap::new);
 /// Empty module-member map for evaluation contexts without one.
-static EMPTY_MODULE_MEMBERS: LazyLock<HashMap<InstRef, ConstValue>> = LazyLock::new(HashMap::new);
+static EMPTY_MODULE_MEMBERS: LazyLock<AHashMap<InstRef, ConstValue>> = LazyLock::new(AHashMap::new);
 
 /// The environment a compile-time expression is evaluated in.
 pub(crate) struct ComptimeEnv<'a> {
@@ -139,19 +139,19 @@ pub(crate) struct ComptimeEnv<'a> {
         super::anon_structs::IssuedCanonicalArguments,
     )>,
     /// Comptime type parameters in scope (e.g. `T` -> `i32`).
-    type_subst: &'a HashMap<Spur, Type>,
+    type_subst: &'a AHashMap<Spur, Type>,
     /// Comptime value parameters in scope (e.g. `N` -> `42`).
-    value_subst: &'a HashMap<Spur, ConstValue>,
+    value_subst: &'a AHashMap<Spur, ConstValue>,
     /// Resolved types from HM inference for the function being analyzed.
     /// `None` when evaluating expressions outside a typed function context
     /// (comptime function bodies before specialization, const initializers).
-    resolved_types: Option<&'a HashMap<InstRef, Type>>,
+    resolved_types: Option<&'a AHashMap<InstRef, Type>>,
     /// Runtime locals in scope at the point being evaluated. A runtime local
     /// shadows same-named comptime parameters and file-level constants, so a
     /// reference to it makes the expression non-evaluable — without this,
     /// `let n = x; g(n)` inside a body with `comptime n` in scope would
     /// wrongly evaluate `n` to the parameter's value (spec 4.14:6).
-    runtime_locals: Option<&'a HashMap<Spur, LocalVar>>,
+    runtime_locals: Option<&'a AHashMap<Spur, LocalVar>>,
     /// Runtime parameters in scope. They shadow same-named type values and
     /// constants just like locals; comptime parameters resolve through the
     /// substitution maps before this guard is consulted.
@@ -160,16 +160,16 @@ pub(crate) struct ComptimeEnv<'a> {
     /// type-alias walk. This lightweight lexical view prevents ordinary
     /// parameters and earlier `let` bindings from falling through to global
     /// constant/type lookup before `AnalysisContext` exists.
-    runtime_binding_names: Option<&'a HashSet<Spur>>,
+    runtime_binding_names: Option<&'a AHashSet<Spur>>,
     /// `let` bindings introduced by blocks inside the comptime expression.
-    locals: HashMap<Spur, ConstValue>,
+    locals: AHashMap<Spur, ConstValue>,
     /// Values of module-member accesses (`m.CONST`) appearing in this
     /// expression, pre-resolved from the module's file (with privacy checks)
     /// before evaluation. The engine has no file/collector context of its own,
     /// so a `FieldGet` on a module is only evaluable as a sub-expression
     /// operand (`1 + m.CONST`) by looking its value up here (RUE-267). Keyed by
     /// the `FieldGet` instruction. Empty outside const-initializer evaluation.
-    const_module_members: &'a HashMap<InstRef, ConstValue>,
+    const_module_members: &'a AHashMap<InstRef, ConstValue>,
     /// The file whose code is currently being reduced (RUE-511). A
     /// module-qualified comptime call written in a `-> type` constructor body
     /// (`let O = b.Mk(T)`) names an import (`b`) of *this* file's import graph,
@@ -190,7 +190,7 @@ impl<'a> ComptimeEnv<'a> {
     /// parameter, wherever the anonymous-type arms resolve field, payload,
     /// and method-signature types. Locals are inserted last, so an alias
     /// shadows a same-named enclosing parameter (lexical scoping).
-    fn substs_with_locals(&self) -> (HashMap<Spur, Type>, HashMap<Spur, ConstValue>) {
+    fn substs_with_locals(&self) -> (AHashMap<Spur, Type>, AHashMap<Spur, ConstValue>) {
         let mut type_subst = self.type_subst.clone();
         let mut value_subst = self.value_subst.clone();
         for (name, val) in &self.locals {
@@ -217,7 +217,7 @@ impl<'a> ComptimeEnv<'a> {
             runtime_locals: None,
             runtime_params: None,
             runtime_binding_names: None,
-            locals: HashMap::new(),
+            locals: AHashMap::new(),
             const_module_members: &EMPTY_MODULE_MEMBERS,
             defining_file: None,
         }
@@ -226,8 +226,8 @@ impl<'a> ComptimeEnv<'a> {
     /// An environment with comptime parameter substitutions but no resolved
     /// types (used when evaluating a comptime function body at a call site).
     pub(crate) fn with_subst(
-        type_subst: &'a HashMap<Spur, Type>,
-        value_subst: &'a HashMap<Spur, ConstValue>,
+        type_subst: &'a AHashMap<Spur, Type>,
+        value_subst: &'a AHashMap<Spur, ConstValue>,
     ) -> Self {
         Self {
             producer: None,
@@ -238,7 +238,7 @@ impl<'a> ComptimeEnv<'a> {
             runtime_locals: None,
             runtime_params: None,
             runtime_binding_names: None,
-            locals: HashMap::new(),
+            locals: AHashMap::new(),
             const_module_members: &EMPTY_MODULE_MEMBERS,
             defining_file: None,
         }
@@ -259,7 +259,7 @@ impl<'a> ComptimeEnv<'a> {
             runtime_locals: Some(&ctx.locals),
             runtime_params: Some((ctx.params, ctx.param_index)),
             runtime_binding_names: None,
-            locals: HashMap::new(),
+            locals: AHashMap::new(),
             const_module_members: &EMPTY_MODULE_MEMBERS,
             defining_file: Some(ctx.current_file_id),
         }
@@ -373,8 +373,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     pub(crate) fn try_evaluate_const_with_subst(
         &mut self,
         inst_ref: InstRef,
-        type_subst: &HashMap<Spur, Type>,
-        value_subst: &HashMap<Spur, ConstValue>,
+        type_subst: &AHashMap<Spur, Type>,
+        value_subst: &AHashMap<Spur, ConstValue>,
     ) -> Option<ConstValue> {
         let mut env = ComptimeEnv::with_subst(type_subst, value_subst);
         env.producer = Some(inst_ref);
@@ -1917,8 +1917,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // `WrapA(WrapA(i32))`) and references to enclosing comptime
         // params/aliases both resolve. A non-const argument makes the whole
         // call non-evaluable.
-        let mut callee_types: HashMap<Spur, Type> = HashMap::new();
-        let mut callee_values: HashMap<Spur, ConstValue> = HashMap::new();
+        let mut callee_types: AHashMap<Spur, Type> = AHashMap::new();
+        let mut callee_values: AHashMap<Spur, ConstValue> = AHashMap::new();
         for (i, arg) in args.iter().enumerate() {
             let Some(v) = self.eval_const_expr(arg.value, env)? else {
                 return Ok(None);
@@ -1976,8 +1976,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         &mut self,
         function_name: Spur,
         function: &crate::sema::info::FunctionCallInfo,
-        callee_types: &HashMap<Spur, Type>,
-        callee_values: &HashMap<Spur, ConstValue>,
+        callee_types: &AHashMap<Spur, Type>,
+        callee_values: &AHashMap<Spur, ConstValue>,
         span: Span,
     ) -> CompileResult<()> {
         let params = function.params;
@@ -2063,8 +2063,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     pub(crate) fn reduce_type_ctor_body(
         &mut self,
         name: Spur,
-        callee_types: &HashMap<Spur, Type>,
-        callee_values: &HashMap<Spur, ConstValue>,
+        callee_types: &AHashMap<Spur, Type>,
+        callee_values: &AHashMap<Spur, ConstValue>,
         span: Span,
     ) -> CompileResult<Option<ConstValue>> {
         if let Some(result) =
@@ -2142,8 +2142,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         &mut self,
         ctor: Spur,
         ty: Type,
-        callee_types: &HashMap<Spur, Type>,
-        callee_values: &HashMap<Spur, ConstValue>,
+        callee_types: &AHashMap<Spur, Type>,
+        callee_values: &AHashMap<Spur, ConstValue>,
     ) {
         // Membership in the pool's anonymous registry is the classifier, never
         // the name spelling (RUE-1050): a name-prefix test here silently broke
@@ -2212,19 +2212,19 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     pub(crate) fn precompute_comptime_type_locals(
         &mut self,
         body: InstRef,
-        type_subst: Option<&HashMap<Spur, Type>>,
-        value_subst: Option<&HashMap<Spur, ConstValue>>,
+        type_subst: Option<&AHashMap<Spur, Type>>,
+        value_subst: Option<&AHashMap<Spur, ConstValue>>,
         runtime_params: &[Spur],
         attribution_enabled: bool,
-    ) -> (HashMap<InstRef, Type>, ComptimePrecomputeAttribution) {
+    ) -> (AHashMap<InstRef, Type>, ComptimePrecomputeAttribution) {
         let mut attribution = ComptimePrecomputeAttribution {
             enabled: attribution_enabled,
             ..ComptimePrecomputeAttribution::default()
         };
-        let mut discovered: HashMap<InstRef, Type> = HashMap::new();
-        let mut eval_types: HashMap<Spur, Type> = type_subst.cloned().unwrap_or_default();
-        let eval_values: HashMap<Spur, ConstValue> = value_subst.cloned().unwrap_or_default();
-        let mut runtime_bindings: HashSet<Spur> = runtime_params.iter().copied().collect();
+        let mut discovered: AHashMap<InstRef, Type> = AHashMap::new();
+        let mut eval_types: AHashMap<Spur, Type> = type_subst.cloned().unwrap_or_default();
+        let eval_values: AHashMap<Spur, ConstValue> = value_subst.cloned().unwrap_or_default();
+        let mut runtime_bindings: AHashSet<Spur> = runtime_params.iter().copied().collect();
         let mut root_frame = Vec::new();
         self.walk_comptime_type_locals(
             body,
@@ -2250,10 +2250,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     fn walk_comptime_type_locals(
         &mut self,
         inst_ref: InstRef,
-        discovered: &mut HashMap<InstRef, Type>,
-        eval_types: &mut HashMap<Spur, Type>,
-        eval_values: &HashMap<Spur, ConstValue>,
-        runtime_bindings: &mut HashSet<Spur>,
+        discovered: &mut AHashMap<InstRef, Type>,
+        eval_types: &mut AHashMap<Spur, Type>,
+        eval_values: &AHashMap<Spur, ConstValue>,
+        runtime_bindings: &mut AHashSet<Spur>,
         frame: &mut Vec<(Spur, Option<Type>, bool)>,
         attribution: &mut ComptimePrecomputeAttribution,
     ) {
@@ -2407,9 +2407,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     fn try_eval_type_alias_init(
         &mut self,
         init: InstRef,
-        eval_types: &HashMap<Spur, Type>,
-        eval_values: &HashMap<Spur, ConstValue>,
-        runtime_bindings: &HashSet<Spur>,
+        eval_types: &AHashMap<Spur, Type>,
+        eval_values: &AHashMap<Spur, ConstValue>,
+        runtime_bindings: &AHashSet<Spur>,
     ) -> Option<Type> {
         // `eval_const_expr`'s `Call` arm reduces type-function calls
         // compositionally (including nested/delegating ones), so a single
@@ -2452,11 +2452,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     pub(crate) fn precompute_inline_ctor_head_types(
         &mut self,
         body: InstRef,
-        type_subst: Option<&HashMap<Spur, Type>>,
-        value_subst: Option<&HashMap<Spur, ConstValue>>,
-        comptime_local_types: &HashMap<Spur, Type>,
+        type_subst: Option<&AHashMap<Spur, Type>>,
+        value_subst: Option<&AHashMap<Spur, ConstValue>>,
+        comptime_local_types: &AHashMap<Spur, Type>,
         attribution_enabled: bool,
-    ) -> (HashMap<InstRef, Type>, ComptimePrecomputeAttribution) {
+    ) -> (AHashMap<InstRef, Type>, ComptimePrecomputeAttribution) {
         // A head is the receiver of a `.NAME(..)` path whose receiver is
         // itself a call (`F(args).Ok(x)`, or module-qualified
         // `m.F(args).Ok(x)`, which RIR spells as a nested MethodCall), or a
@@ -2477,10 +2477,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             },
             ..ComptimePrecomputeAttribution::default()
         };
-        let mut eval_types: HashMap<Spur, Type> = type_subst.cloned().unwrap_or_default();
+        let mut eval_types: AHashMap<Spur, Type> = type_subst.cloned().unwrap_or_default();
         eval_types.extend(comptime_local_types);
-        let eval_values: HashMap<Spur, ConstValue> = value_subst.cloned().unwrap_or_default();
-        let mut reduced = HashMap::new();
+        let eval_values: AHashMap<Spur, ConstValue> = value_subst.cloned().unwrap_or_default();
+        let mut reduced = AHashMap::new();
         for head in candidates {
             let started = attribution.enabled.then(Instant::now);
             if attribution.enabled {

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -10,7 +10,7 @@
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use ahash::AHashSet;
 
     /// All InstData variants that exist in the RIR.
     ///
@@ -179,8 +179,8 @@ mod tests {
     ///
     /// Looks for patterns like `InstData::VariantName` and extracts `VariantName`.
     /// Excludes matches that are actually `AirInstData::` (which contains `InstData::` as substring).
-    fn extract_instdata_variants(source: &str) -> HashSet<String> {
-        let mut variants = HashSet::new();
+    fn extract_instdata_variants(source: &str) -> AHashSet<String> {
+        let mut variants = AHashSet::new();
 
         // Simple regex-like extraction using string matching
         // Looking for "InstData::" followed by variant name (alphanumeric)
@@ -682,7 +682,7 @@ mod tests {
         let analysis_variants = extract_instdata_variants(ANALYSIS_SOURCE);
 
         // Get all expected variants
-        let all_variants: HashSet<String> = ALL_INSTDATA_VARIANTS
+        let all_variants: AHashSet<String> = ALL_INSTDATA_VARIANTS
             .iter()
             .map(|s| s.to_string())
             .collect();

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -4,7 +4,7 @@
 //! analysis, including local variable tracking, scope management, and move
 //! state tracking for affine types.
 
-use std::collections::{HashMap, HashSet};
+use ahash::{AHashMap, AHashSet};
 use std::sync::Arc;
 
 use lasso::Spur;
@@ -79,7 +79,7 @@ pub(crate) struct VariableMoveState {
     /// The element-wise linear array consumption check (RUE-186) needs
     /// MUST-move information: an element consumed in only one branch is
     /// still dropped on the other paths.
-    pub partial_moves_on_all_paths: HashSet<FieldPath>,
+    pub partial_moves_on_all_paths: AHashSet<FieldPath>,
 }
 
 impl VariableMoveState {
@@ -272,7 +272,7 @@ impl PartialEq for VariableMoveState {
 /// outer binding's state at the break is exactly the saved entry this
 /// restoration writes back.
 pub(crate) fn restore_scope_moves(
-    moves: &mut HashMap<Spur, VariableMoveState>,
+    moves: &mut AHashMap<Spur, VariableMoveState>,
     frame: &[(Spur, Option<VariableMoveState>)],
 ) {
     for (symbol, old_moves) in frame.iter().rev() {
@@ -304,9 +304,9 @@ pub(crate) struct LoopEdgeStates {
     /// A `break` targeting this loop exists: the loop is `()`-typed.
     pub broke: bool,
     /// One `moved_vars` snapshot per `break` targeting this loop.
-    pub break_snaps: Vec<(HashMap<Spur, VariableMoveState>, usize)>,
+    pub break_snaps: Vec<(AHashMap<Spur, VariableMoveState>, usize)>,
     /// One `moved_vars` snapshot per `continue` targeting this loop.
-    pub continue_snaps: Vec<(HashMap<Spur, VariableMoveState>, usize)>,
+    pub continue_snaps: Vec<(AHashMap<Spur, VariableMoveState>, usize)>,
 }
 
 /// Record one snapshot in a per-loop edge list, merging with an existing
@@ -321,8 +321,8 @@ pub(crate) struct LoopEdgeStates {
 /// the post-loop scope view. Eager same-depth merging keeps each list as
 /// small as the loop's live scope nesting.
 fn record_edge_snapshot(
-    snaps: &mut Vec<(HashMap<Spur, VariableMoveState>, usize)>,
-    moves: &HashMap<Spur, VariableMoveState>,
+    snaps: &mut Vec<(AHashMap<Spur, VariableMoveState>, usize)>,
+    moves: &AHashMap<Spur, VariableMoveState>,
     depth: usize,
 ) {
     if let Some((existing, existing_depth)) = snaps.last_mut()
@@ -336,8 +336,8 @@ fn record_edge_snapshot(
 
 /// Union-merge a drained edge list, or `None` when the edge never fired.
 fn merged_edge_moves(
-    snaps: Vec<(HashMap<Spur, VariableMoveState>, usize)>,
-) -> Option<HashMap<Spur, VariableMoveState>> {
+    snaps: Vec<(AHashMap<Spur, VariableMoveState>, usize)>,
+) -> Option<AHashMap<Spur, VariableMoveState>> {
     let mut snaps = snaps.into_iter();
     let (mut merged, _) = snaps.next()?;
     for (snap, _) in snaps {
@@ -348,13 +348,13 @@ fn merged_edge_moves(
 
 impl LoopEdgeStates {
     /// Record one break's snapshot.
-    pub fn record_break(&mut self, moves: &HashMap<Spur, VariableMoveState>, depth: usize) {
+    pub fn record_break(&mut self, moves: &AHashMap<Spur, VariableMoveState>, depth: usize) {
         self.broke = true;
         record_edge_snapshot(&mut self.break_snaps, moves, depth);
     }
 
     /// Record one continue's snapshot.
-    pub fn record_continue(&mut self, moves: &HashMap<Spur, VariableMoveState>, depth: usize) {
+    pub fn record_continue(&mut self, moves: &AHashMap<Spur, VariableMoveState>, depth: usize) {
         record_edge_snapshot(&mut self.continue_snaps, moves, depth);
     }
 
@@ -364,8 +364,8 @@ impl LoopEdgeStates {
     pub fn merged_moves(
         self,
     ) -> (
-        Option<HashMap<Spur, VariableMoveState>>,
-        Option<HashMap<Spur, VariableMoveState>>,
+        Option<AHashMap<Spur, VariableMoveState>>,
+        Option<AHashMap<Spur, VariableMoveState>>,
     ) {
         (
             merged_edge_moves(self.break_snaps),
@@ -380,11 +380,11 @@ impl LoopEdgeStates {
 /// (no-moves) state, which correctly clears `full_move_on_all_paths`: the
 /// other branch did not move it.
 pub(crate) fn union_move_maps(
-    branch1: &HashMap<Spur, VariableMoveState>,
-    branch2: &HashMap<Spur, VariableMoveState>,
-) -> HashMap<Spur, VariableMoveState> {
+    branch1: &AHashMap<Spur, VariableMoveState>,
+    branch2: &AHashMap<Spur, VariableMoveState>,
+) -> AHashMap<Spur, VariableMoveState> {
     let default = VariableMoveState::default();
-    let mut merged = HashMap::new();
+    let mut merged = AHashMap::new();
     for symbol in branch1.keys().chain(branch2.keys()) {
         if merged.contains_key(symbol) {
             continue;
@@ -432,7 +432,7 @@ pub(crate) struct ParamInfo {
 /// one body-scoped index shared by every analysis pass.
 #[derive(Debug)]
 pub(crate) struct ParamIndex {
-    by_name: Option<HashMap<Spur, usize>>,
+    by_name: Option<AHashMap<Spur, usize>>,
 }
 
 impl ParamIndex {
@@ -440,7 +440,7 @@ impl ParamIndex {
 
     pub(crate) fn new(params: &[ParamInfo]) -> Self {
         let by_name = (params.len() > Self::LINEAR_LOOKUP_LIMIT).then(|| {
-            let mut by_name = HashMap::with_capacity(params.len());
+            let mut by_name = AHashMap::with_capacity(params.len());
             for (index, param) in params.iter().enumerate() {
                 let previous = by_name.insert(param.name, index);
                 assert!(
@@ -528,7 +528,7 @@ pub(crate) struct AnalysisContext<'a> {
     /// File that owns the function body currently being analyzed.
     pub current_file_id: FileId,
     /// Local variables in scope
-    pub locals: HashMap<Spur, LocalVar>,
+    pub locals: AHashMap<Spur, LocalVar>,
     /// Function parameters (immutable reference, shared across the function)
     pub params: &'a [ParamInfo],
     /// Body-scoped parameter-name index shared by every semantic consumer.
@@ -552,7 +552,7 @@ pub(crate) struct AnalysisContext<'a> {
     /// (RUE-1293; formal core §5.7, (Loop-Break)) — see [`LoopEdgeStates`].
     pub loop_break_stack: Vec<LoopEdgeStates>,
     /// Local variables that have been read (for unused variable detection)
-    pub used_locals: HashSet<Spur>,
+    pub used_locals: AHashSet<Spur>,
     /// Return type of the current function (for explicit return validation)
     pub return_type: Type,
     /// Scope stack for efficient scope management.
@@ -582,10 +582,10 @@ pub(crate) struct AnalysisContext<'a> {
     /// Maps RIR instruction refs to their resolved concrete types.
     /// This is populated by running constraint generation and unification
     /// before AIR emission.
-    pub resolved_types: &'a HashMap<InstRef, Type>,
+    pub resolved_types: &'a AHashMap<InstRef, Type>,
     /// Variables that have been moved (for affine type checking).
     /// Maps variable symbol to move state (supports partial/field-level moves).
-    pub moved_vars: HashMap<Spur, VariableMoveState>,
+    pub moved_vars: AHashMap<Spur, VariableMoveState>,
     /// Warnings collected during this function's analysis.
     /// Finalization merges these per-function warnings into the global output.
     pub warnings: Vec<CompileWarning>,
@@ -595,7 +595,7 @@ pub(crate) struct AnalysisContext<'a> {
     pub allow_unused_variables: bool,
     /// Local string table: maps string content to local index (for deduplication within function).
     /// Finalization merges these strings globally after body analysis.
-    pub local_string_table: HashMap<String, u32>,
+    pub local_string_table: AHashMap<String, u32>,
     /// Local string data indexed by local string table index.
     /// After analysis, these are merged into the global string table with ID remapping.
     pub local_strings: Vec<String>,
@@ -606,19 +606,19 @@ pub(crate) struct AnalysisContext<'a> {
     /// When a variable is bound to a comptime type (e.g., `let P = make_point()` where
     /// `make_point() -> type`), this map stores the resolved type so it can be used
     /// as a type annotation (e.g., `let p: P = ...`).
-    pub comptime_type_vars: HashMap<Spur, Type>,
+    pub comptime_type_vars: AHashMap<Spur, Type>,
     /// Comptime value variables: maps variable symbols to their compile-time constant values.
     /// When an anonymous struct method captures comptime parameters from the enclosing function
     /// (e.g., `fn FixedBuffer(comptime N: i32)` creates a struct with methods that reference `N`),
     /// this map stores the captured values so method bodies can resolve them.
-    pub comptime_value_vars: HashMap<Spur, ConstValue>,
+    pub comptime_value_vars: AHashMap<Spur, ConstValue>,
     /// Functions referenced during analysis of this function.
     /// Used for demand-driven semantic analysis (ADR-0045) to track
     /// which functions need to be analyzed. Each entry is a function name symbol.
-    pub referenced_functions: HashSet<Spur>,
+    pub referenced_functions: AHashSet<Spur>,
     /// Methods referenced during analysis of this function.
     /// Each entry is (struct_id, method_name) matching the key format in methods map.
-    pub referenced_methods: HashSet<(StructId, Spur)>,
+    pub referenced_methods: AHashSet<(StructId, Spur)>,
     /// While analyzing the value of an `inout`/`borrow` call argument, the ROOT
     /// variable of the place being passed by reference (set by
     /// `analyze_call_args_coerced`; for `f(borrow o.f)` this is `o`). A by-ref argument
@@ -675,7 +675,7 @@ pub(crate) struct AnalysisContext<'a> {
     /// root. Escape-shape checks (`return`/`let`/store/aggregate capture)
     /// consult this after analyzing an operand to reject binding a borrowed
     /// place beyond its full expression, naming the offending accessor.
-    pub accessor_call_insts: HashMap<InstRef, (Spur, Spur)>,
+    pub accessor_call_insts: AHashMap<InstRef, (Spur, Spur)>,
     /// Active accessor-result loans for the current full expression
     /// (ADR-0062): each entry is the receiver root of an expanded accessor
     /// call, shared mode, together with the call span. The statement loop
@@ -687,11 +687,11 @@ pub(crate) struct AnalysisContext<'a> {
     /// innermost last. `resolved_type_of` consults these before the body's
     /// own `resolved_types`, letting the caller's analysis walk accessor-body
     /// instructions that the caller's inference never visited.
-    pub inline_resolved_types: Vec<Arc<HashMap<InstRef, Type>>>,
+    pub inline_resolved_types: Vec<Arc<AHashMap<InstRef, Type>>>,
     /// Names bound to caller places during accessor inlining (`self` inside
     /// an inlined accessor body). Scoped save/restore is handled by the
     /// expansion itself.
-    pub place_aliases: HashMap<Spur, PlaceAlias>,
+    pub place_aliases: AHashMap<Spur, PlaceAlias>,
     /// True only while analyzing the operand of a `?` expression (RUE-318). The
     /// `?` site cannot supply an `expected_type` for a *bare* fallible intrinsic
     /// (`@read_line()?` / `@parse_i64(s)?`): the enclosing function's `Option(U)`
@@ -708,7 +708,7 @@ use rue_rir::InstRef;
 impl ScopedContext for AnalysisContext<'_> {
     type VarInfo = LocalVar;
 
-    fn locals_mut(&mut self) -> &mut HashMap<Spur, Self::VarInfo> {
+    fn locals_mut(&mut self) -> &mut AHashMap<Spur, Self::VarInfo> {
         &mut self.locals
     }
 
@@ -906,8 +906,8 @@ impl<'a> AnalysisContext<'a> {
             local_atoms: self.local_atoms.clone(),
             comptime_type_vars: self.comptime_type_vars.clone(),
             comptime_value_vars: self.comptime_value_vars.clone(),
-            referenced_functions: HashSet::new(),
-            referenced_methods: HashSet::new(),
+            referenced_functions: AHashSet::new(),
+            referenced_methods: AHashSet::new(),
             // A by-ref argument's value is a place — a variable or a
             // field/index projection chain (enforced in the call-argument analyzer) —
             // and index subexpressions are analyzed with the root cleared
@@ -960,8 +960,8 @@ impl<'a> AnalysisContext<'a> {
     /// - If both diverge, the whole if-else diverges and moves don't matter
     pub fn merge_branch_moves(
         &mut self,
-        then_moves: HashMap<Spur, VariableMoveState>,
-        else_moves: HashMap<Spur, VariableMoveState>,
+        then_moves: AHashMap<Spur, VariableMoveState>,
+        else_moves: AHashMap<Spur, VariableMoveState>,
         then_diverges: bool,
         else_diverges: bool,
     ) {
@@ -1008,7 +1008,7 @@ impl<'a> AnalysisContext<'a> {
     /// Each entry is the `moved_vars` snapshot after analyzing one arm
     /// (starting from the same pre-match state), paired with whether that
     /// arm's body diverges.
-    pub fn merge_arm_moves(&mut self, arm_moves: Vec<(HashMap<Spur, VariableMoveState>, bool)>) {
+    pub fn merge_arm_moves(&mut self, arm_moves: Vec<(AHashMap<Spur, VariableMoveState>, bool)>) {
         let mut live = arm_moves
             .iter()
             .filter(|(_, diverges)| !diverges)
@@ -1635,9 +1635,9 @@ mod tests {
 
         let mut then_state = VariableMoveState::default();
         then_state.mark_path_moved(&[], span);
-        let mut then_moves = HashMap::new();
+        let mut then_moves = AHashMap::new();
         then_moves.insert(var, then_state);
-        let else_moves = HashMap::new();
+        let else_moves = AHashMap::new();
 
         let merged = union_move_maps(&then_moves, &else_moves);
         let state = merged.get(&var).expect("var should be may-moved");

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -5,7 +5,7 @@
 //! control-flow lowering does not introduce a peer analysis context.
 
 use super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
-use std::collections::HashMap;
+use ahash::AHashMap;
 use std::sync::Arc;
 
 use lasso::Spur;
@@ -619,7 +619,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let mut wildcard_span: Option<Span> = None;
         let mut bool_true_span: Option<Span> = None;
         let mut bool_false_span: Option<Span> = None;
-        let mut seen_ints: HashMap<i64, Span> = HashMap::new();
+        let mut seen_ints: AHashMap<i64, Span> = AHashMap::new();
         for (pattern, _) in arms {
             let pattern_span = pattern.span();
 
@@ -935,12 +935,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let mut wildcard_span: Option<Span> = None;
         let mut bool_true_span: Option<Span> = None;
         let mut bool_false_span: Option<Span> = None;
-        let mut seen_ints: HashMap<i64, Span> = HashMap::new();
+        let mut seen_ints: AHashMap<i64, Span> = AHashMap::new();
         // Maps each covered enum-variant index to the span of its first arm, so a
         // second arm matching the same variant can be reported as unreachable
         // (mirroring seen_ints / bool_*_span). The map's len() still drives the
         // exhaustiveness check below, identically to the former HashSet.
-        let mut covered_variants: HashMap<u32, Span> = HashMap::new();
+        let mut covered_variants: AHashMap<u32, Span> = AHashMap::new();
         let mut pattern_enum_id: Option<crate::types::EnumId> = None;
 
         // Analyze each arm (each arm gets its own scope)

--- a/crates/rue-air/src/sema/declaration_index.rs
+++ b/crates/rue-air/src/sema/declaration_index.rs
@@ -5,7 +5,7 @@
 //! only with the exact RIR and interner epoch from which it was built. They are
 //! arena locators, not durable semantic or tooling identities.
 
-use std::collections::{HashMap, HashSet};
+use ahash::{AHashMap, AHashSet};
 
 use lasso::Spur;
 use rue_rir::{InstData, InstRef, Rir};
@@ -68,8 +68,8 @@ pub(super) struct RirShellDeclaration {
 #[derive(Debug)]
 pub(super) struct RirDeclarationIndex {
     free_functions: Vec<InstRef>,
-    free_functions_by_file_name: HashMap<(FileId, Spur), Vec<InstRef>>,
-    free_functions_by_name: HashMap<Spur, Vec<InstRef>>,
+    free_functions_by_file_name: AHashMap<(FileId, Spur), Vec<InstRef>>,
+    free_functions_by_name: AHashMap<Spur, Vec<InstRef>>,
     named_methods: Vec<InstRef>,
     anonymous_methods: Vec<InstRef>,
     destructors: Vec<RirDestructorDeclaration>,
@@ -80,10 +80,10 @@ pub(super) struct RirDeclarationIndex {
 impl RirDeclarationIndex {
     pub(super) fn new(rir: &Rir) -> Self {
         let mut function_candidates = Vec::new();
-        let mut named_method_refs = HashSet::new();
-        let mut named_method_owners = HashMap::new();
-        let mut anonymous_method_refs = HashSet::new();
-        let mut declaration_source_orders = HashMap::new();
+        let mut named_method_refs = AHashSet::new();
+        let mut named_method_owners = AHashMap::new();
+        let mut anonymous_method_refs = AHashSet::new();
+        let mut declaration_source_orders = AHashMap::new();
         let mut destructors = Vec::new();
         let mut const_shell_declarations = Vec::new();
         let mut work = RirDeclarationIndexWork {
@@ -148,8 +148,8 @@ impl RirDeclarationIndex {
         }
 
         let mut free_functions = Vec::new();
-        let mut free_functions_by_file_name = HashMap::<(FileId, Spur), Vec<InstRef>>::new();
-        let mut free_functions_by_name = HashMap::<Spur, Vec<InstRef>>::new();
+        let mut free_functions_by_file_name = AHashMap::<(FileId, Spur), Vec<InstRef>>::new();
+        let mut free_functions_by_name = AHashMap::<Spur, Vec<InstRef>>::new();
         let mut named_methods = Vec::new();
         let mut anonymous_methods = Vec::new();
         let mut shell_declarations = nominal_candidates

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -9,7 +9,7 @@
 //! - Collecting method signatures from impl blocks
 //! - Validating @copy structs
 
-use std::collections::HashSet;
+use ahash::AHashSet;
 use std::sync::Arc;
 
 use rue_error::{CompileError, CompileResult};
@@ -175,7 +175,7 @@ fn accessor_body_verdict(
 /// here is answered about this body alone.
 fn body_instructions(rir: &rue_rir::Rir, body: InstRef) -> Vec<InstRef> {
     let mut pending = vec![body];
-    let mut seen = HashSet::new();
+    let mut seen = AHashSet::new();
     let mut contained = Vec::new();
     let mut children = Vec::new();
     while let Some(current) = pending.pop() {

--- a/crates/rue-air/src/sema/fact_mode.rs
+++ b/crates/rue-air/src/sema/fact_mode.rs
@@ -5,7 +5,7 @@
 //! storage strategy. The provider body host supplies these facts to executable
 //! body analysis.
 
-use std::collections::HashMap;
+use ahash::AHashMap;
 
 use lasso::Spur;
 use rue_span::{FileId, Span};
@@ -30,8 +30,8 @@ pub(crate) struct StructuredTypeSyntaxRequest<'a> {
     pub(crate) syntax: &'a StructuredTypeSyntax,
     pub(crate) root_file: FileId,
     pub(crate) span: Span,
-    pub(crate) type_substitutions: Option<&'a HashMap<Spur, Type>>,
-    pub(crate) value_substitutions: Option<&'a HashMap<Spur, ConstValue>>,
+    pub(crate) type_substitutions: Option<&'a AHashMap<Spur, Type>>,
+    pub(crate) value_substitutions: Option<&'a AHashMap<Spur, ConstValue>>,
 }
 
 /// Exact input for resolving a module-qualified type prefix.
@@ -45,7 +45,7 @@ pub(crate) struct ModulePrefixRequest<'a> {
 pub(crate) struct ArrayLengthRequest<'a> {
     pub(crate) length: &'a ArrayLen,
     pub(crate) span: Span,
-    pub(crate) value_substitutions: Option<&'a HashMap<Spur, ConstValue>>,
+    pub(crate) value_substitutions: Option<&'a AHashMap<Spur, ConstValue>>,
 }
 
 pub(crate) type TypeSyntaxResult = Result<

--- a/crates/rue-air/src/sema/inference_ctx.rs
+++ b/crates/rue-air/src/sema/inference_ctx.rs
@@ -6,8 +6,8 @@
 //! function/struct/enum/method/const family on first lookup instead of eagerly
 //! projecting the whole declaration universe (RUE-1091 slice r5b).
 
+use ahash::AHashMap;
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::rc::Rc;
 
 use lasso::Spur;
@@ -20,9 +20,9 @@ use crate::types::{ModuleId, StructId, Type};
 /// The generated-nominal overlay snapshot consumed by [`InferenceContext`].
 /// It is a construction-time input, not a replay cache for semantic results.
 pub(crate) struct InferenceGeneratedNominalOverlays {
-    pub(crate) builtin_struct_types: HashMap<Spur, Type>,
-    pub(crate) struct_types_by_file: HashMap<(FileId, Spur), Type>,
-    pub(crate) enum_types_by_file: HashMap<(FileId, Spur), Type>,
+    pub(crate) builtin_struct_types: AHashMap<Spur, Type>,
+    pub(crate) struct_types_by_file: AHashMap<(FileId, Spur), Type>,
+    pub(crate) enum_types_by_file: AHashMap<(FileId, Spur), Type>,
 }
 
 /// Immutable declaration reads required by the inference fact facade.
@@ -82,19 +82,19 @@ pub(super) trait InferenceFactSource {
 /// reconciliation (RUE-164) with no behavior change.
 #[derive(Debug, Default)]
 pub struct InferenceContext {
-    func_sigs: RefCell<HashMap<Spur, Rc<FunctionSig>>>,
-    method_sigs: RefCell<HashMap<(StructId, Spur), Rc<MethodSig>>>,
+    func_sigs: RefCell<AHashMap<Spur, Rc<FunctionSig>>>,
+    method_sigs: RefCell<AHashMap<(StructId, Spur), Rc<MethodSig>>>,
     /// Generated builtin struct nominals present when the context was built,
     /// keyed by source name. In the eager projection these *overwrote* the base
     /// builtin table, so they win over `builtin_structs` at lookup.
-    gen_builtin_struct_types: HashMap<Spur, Type>,
+    gen_builtin_struct_types: AHashMap<Spur, Type>,
     /// Generated struct nominals keyed by (defining file, source name). In the
     /// eager projection the base `structs_by_file_name` was inserted first and
     /// these only filled gaps (`or_insert`), so the base wins at lookup.
-    gen_struct_types_by_file: HashMap<(FileId, Spur), Type>,
+    gen_struct_types_by_file: AHashMap<(FileId, Spur), Type>,
     /// Generated enum nominals keyed by (defining file, source name). Base wins,
     /// as for `gen_struct_types_by_file`.
-    gen_enum_types_by_file: HashMap<(FileId, Spur), Type>,
+    gen_enum_types_by_file: AHashMap<(FileId, Spur), Type>,
 }
 
 impl InferenceContext {
@@ -108,8 +108,8 @@ impl InferenceContext {
             enum_types_by_file: gen_enum_types_by_file,
         } = host.inference_generated_nominal_overlays();
         Self {
-            func_sigs: RefCell::new(HashMap::new()),
-            method_sigs: RefCell::new(HashMap::new()),
+            func_sigs: RefCell::new(AHashMap::new()),
+            method_sigs: RefCell::new(AHashMap::new()),
             gen_builtin_struct_types,
             gen_struct_types_by_file,
             gen_enum_types_by_file,

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -5,7 +5,7 @@
 //! inherent-method receiver, which stable Rust cannot define on a trait. It
 //! owns no state, representation conversion, cache, or alternative policy.
 
-use std::collections::{HashMap, HashSet};
+use ahash::{AHashMap, AHashSet};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -108,13 +108,13 @@ pub(crate) trait OrdinaryBodyAnalysisHost: BodyAnalysisReadHost + Sized {
     fn strbuf_type(&self) -> Option<Type>;
     fn is_strbuf(&self, ty: Type) -> bool;
     fn types_equivalent(&self, left: Type, right: Type) -> bool;
-    fn generated_structs(&self) -> &HashMap<Spur, StructId>;
+    fn generated_structs(&self) -> &AHashMap<Spur, StructId>;
 
     fn body_interner(&self) -> &ThreadedRodeo;
     fn body_type_pool(&self) -> &TypeInternPool;
     fn struct_id_for_name(&self, name: Spur) -> Option<StructId>;
-    fn generated_structs_mut(&mut self) -> &mut HashMap<Spur, StructId>;
-    fn generated_enums_mut(&mut self) -> &mut HashMap<Spur, EnumId>;
+    fn generated_structs_mut(&mut self) -> &mut AHashMap<Spur, StructId>;
+    fn generated_enums_mut(&mut self) -> &mut AHashMap<Spur, EnumId>;
     fn anonymous_struct_id(
         &self,
         identity: &super::anon_structs::IssuedAnonymousNominalKey,
@@ -125,10 +125,10 @@ pub(crate) trait OrdinaryBodyAnalysisHost: BodyAnalysisReadHost + Sized {
     ) -> Option<EnumId>;
     fn anonymous_struct_identities_mut(
         &mut self,
-    ) -> &mut HashMap<super::anon_structs::IssuedAnonymousNominalKey, StructId>;
+    ) -> &mut AHashMap<super::anon_structs::IssuedAnonymousNominalKey, StructId>;
     fn anonymous_enum_identities_mut(
         &mut self,
-    ) -> &mut HashMap<super::anon_structs::IssuedAnonymousNominalKey, EnumId>;
+    ) -> &mut AHashMap<super::anon_structs::IssuedAnonymousNominalKey, EnumId>;
     fn anonymous_digest_owner(
         &self,
         digest: u128,
@@ -148,13 +148,14 @@ pub(crate) trait OrdinaryBodyAnalysisHost: BodyAnalysisReadHost + Sized {
         ty: Type,
         identity: super::anon_structs::IssuedAnonymousNominalKey,
     );
-    fn anonymous_struct_methods_mut(&mut self)
-    -> &mut HashMap<StructId, Vec<super::AnonMethodSig>>;
+    fn anonymous_struct_methods_mut(
+        &mut self,
+    ) -> &mut AHashMap<StructId, Vec<super::AnonMethodSig>>;
     fn anonymous_struct_captures_mut(
         &mut self,
-    ) -> &mut HashMap<StructId, HashMap<Spur, ConstValue>>;
-    fn anonymous_struct_ids_mut(&mut self) -> &mut HashSet<StructId>;
-    fn anonymous_enum_ids_mut(&mut self) -> &mut HashSet<EnumId>;
+    ) -> &mut AHashMap<StructId, AHashMap<Spur, ConstValue>>;
+    fn anonymous_struct_ids_mut(&mut self) -> &mut AHashSet<StructId>;
+    fn anonymous_enum_ids_mut(&mut self) -> &mut AHashSet<EnumId>;
     fn canonical_type_instance(
         &self,
         ty: Type,
@@ -193,8 +194,8 @@ pub(crate) trait OrdinaryBodyAnalysisHost: BodyAnalysisReadHost + Sized {
     fn reduce_external_comptime_call(
         &mut self,
         _name: Spur,
-        _callee_types: &HashMap<Spur, Type>,
-        _callee_values: &HashMap<Spur, ConstValue>,
+        _callee_types: &AHashMap<Spur, Type>,
+        _callee_values: &AHashMap<Spur, ConstValue>,
         _span: Span,
     ) -> Option<CompileResult<Option<ConstValue>>> {
         None
@@ -206,8 +207,8 @@ pub(crate) trait OrdinaryBodyAnalysisHost: BodyAnalysisReadHost + Sized {
         &mut self,
         syntax: RirTypeSyntaxRef,
         span: Span,
-        type_substitutions: Option<&HashMap<Spur, Type>>,
-        value_substitutions: Option<&HashMap<Spur, ConstValue>>,
+        type_substitutions: Option<&AHashMap<Spur, Type>>,
+        value_substitutions: Option<&AHashMap<Spur, ConstValue>>,
     ) -> CompileResult<Type>;
     fn replace_active_anonymous_producer(
         &mut self,
@@ -249,9 +250,9 @@ pub(crate) trait OrdinaryBodyAnalysisHost: BodyAnalysisReadHost + Sized {
     fn destructor_span(&self, struct_id: StructId) -> Option<Span>;
     fn infectious_linear_reason(&self, struct_id: StructId) -> Option<(String, String)>;
     fn well_known_option(&self, payload: Type) -> Option<Type>;
-    fn set_anon_struct_type_subst(&mut self, struct_id: StructId, subst: HashMap<Spur, Type>);
-    fn anon_struct_type_subst(&self, struct_id: StructId) -> HashMap<Spur, Type>;
-    fn anon_struct_captured_values(&self, struct_id: StructId) -> HashMap<Spur, ConstValue>;
+    fn set_anon_struct_type_subst(&mut self, struct_id: StructId, subst: AHashMap<Spur, Type>);
+    fn anon_struct_type_subst(&self, struct_id: StructId) -> AHashMap<Spur, Type>;
+    fn anon_struct_captured_values(&self, struct_id: StructId) -> AHashMap<Spur, ConstValue>;
 
     fn body_dependency_observer(&self) -> Option<AnalyzedBodyOwnerEvent>;
     fn record_body_named_dependency(&mut self, target: super::NamedConstDependencyTargetEvent);
@@ -374,7 +375,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
     pub(crate) fn set_anon_struct_type_subst(
         &mut self,
         struct_id: StructId,
-        subst: HashMap<Spur, Type>,
+        subst: AHashMap<Spur, Type>,
     ) {
         self.storage.set_anon_struct_type_subst(struct_id, subst)
     }
@@ -442,8 +443,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
     pub(crate) fn reduce_external_comptime_call(
         &mut self,
         name: Spur,
-        callee_types: &HashMap<Spur, Type>,
-        callee_values: &HashMap<Spur, ConstValue>,
+        callee_types: &AHashMap<Spur, Type>,
+        callee_values: &AHashMap<Spur, ConstValue>,
         span: Span,
     ) -> Option<CompileResult<Option<ConstValue>>> {
         self.storage
@@ -516,8 +517,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
     pub(crate) fn resolve_rir_type_for_comptime_with_subst_and_values_at_span(
         &mut self,
         syntax: RirTypeSyntaxRef,
-        type_subst: &HashMap<Spur, Type>,
-        value_subst: &HashMap<Spur, ConstValue>,
+        type_subst: &AHashMap<Spur, Type>,
+        value_subst: &AHashMap<Spur, ConstValue>,
         span: Span,
     ) -> Option<Type> {
         self.storage
@@ -527,14 +528,14 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
     pub(crate) fn extract_anon_method_sigs(
         &mut self,
         methods: &rue_rir::RirAnonStructMethodsRange,
-        type_subst: &HashMap<Spur, Type>,
-        value_subst: &HashMap<Spur, ConstValue>,
+        type_subst: &AHashMap<Spur, Type>,
+        value_subst: &AHashMap<Spur, ConstValue>,
     ) -> Vec<super::AnonMethodSig> {
         fn resolve<H: OrdinaryBodyAnalysisHost>(
             engine: &mut OrdinaryBodyEngine<'_, H>,
             syntax: RirTypeSyntaxRef,
-            type_subst: &HashMap<Spur, Type>,
-            value_subst: &HashMap<Spur, ConstValue>,
+            type_subst: &AHashMap<Spur, Type>,
+            value_subst: &AHashMap<Spur, ConstValue>,
             span: Span,
         ) -> super::AnonMethodType {
             use super::AnonMethodType as T;
@@ -630,11 +631,11 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         struct_id: StructId,
         struct_type: Type,
         methods: &rue_rir::RirAnonStructMethodsRange,
-        type_subst: &HashMap<Spur, Type>,
-        value_subst: &HashMap<Spur, ConstValue>,
+        type_subst: &AHashMap<Spur, Type>,
+        value_subst: &AHashMap<Spur, ConstValue>,
     ) -> Option<()> {
         let method_refs = self.body_rir_ref().anon_struct_methods(methods).to_vec();
-        let mut seen_methods = HashSet::new();
+        let mut seen_methods = AHashSet::new();
         let mut staged = Vec::with_capacity(method_refs.len());
         for method_ref in method_refs {
             let method_inst = {
@@ -721,8 +722,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         &mut self,
         type_sym: Spur,
         span: Span,
-        type_substitutions: Option<&HashMap<Spur, Type>>,
-        value_substitutions: Option<&HashMap<Spur, ConstValue>>,
+        type_substitutions: Option<&AHashMap<Spur, Type>>,
+        value_substitutions: Option<&AHashMap<Spur, ConstValue>>,
     ) -> CompileResult<Type> {
         self.resolve_type_with_substitutions_in_file(
             type_sym,
@@ -738,8 +739,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         type_sym: Spur,
         root_file: FileId,
         span: Span,
-        type_substitutions: Option<&HashMap<Spur, Type>>,
-        value_substitutions: Option<&HashMap<Spur, ConstValue>>,
+        type_substitutions: Option<&AHashMap<Spur, Type>>,
+        value_substitutions: Option<&AHashMap<Spur, ConstValue>>,
     ) -> CompileResult<Type> {
         let mut builder = rue_rir::RirTypeSyntaxBuilder::default();
         let root = builder.push_named_type(type_sym).map_err(|failure| {
@@ -858,8 +859,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         function: &FunctionCallInfo,
         param_index: usize,
         declared: Type,
-        type_subst: &HashMap<Spur, Type>,
-        value_subst: &HashMap<Spur, ConstValue>,
+        type_subst: &AHashMap<Spur, Type>,
+        value_subst: &AHashMap<Spur, ConstValue>,
         span: Span,
     ) -> CompileResult<Type> {
         if declared != Type::COMPTIME_TYPE {
@@ -900,8 +901,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
     pub(crate) fn resolve_substituted_return_type(
         &mut self,
         function: &FunctionCallInfo,
-        type_subst: &HashMap<Spur, Type>,
-        value_subst: &HashMap<Spur, ConstValue>,
+        type_subst: &AHashMap<Spur, Type>,
+        value_subst: &AHashMap<Spur, ConstValue>,
         span: Span,
     ) -> CompileResult<Type> {
         if function.return_type != Type::COMPTIME_TYPE {
@@ -940,7 +941,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         &mut self,
         length: &crate::types::ArrayLen,
         span: Span,
-        values: Option<&HashMap<Spur, ConstValue>>,
+        values: Option<&AHashMap<Spur, ConstValue>>,
     ) -> CompileResult<u64> {
         OrdinaryBodyAnalysisHost::resolve_array_length(
             self.storage,
@@ -1029,8 +1030,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
     pub(crate) fn canonical_function_producer(
         &self,
         name: Spur,
-        tys: &HashMap<Spur, Type>,
-        vals: &HashMap<Spur, ConstValue>,
+        tys: &AHashMap<Spur, Type>,
+        vals: &AHashMap<Spur, ConstValue>,
     ) -> Result<(IssuedStableProducerId, IssuedCanonicalArguments), crate::SemanticBodyExportFailure>
     {
         use crate::SemanticBodyExportFailure as F;
@@ -1081,7 +1082,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         identity: super::anon_structs::IssuedAnonymousNominalKey,
         fields: &[crate::types::StructField],
         sigs: &[super::AnonMethodSig],
-        captured: &HashMap<Spur, ConstValue>,
+        captured: &AHashMap<Spur, ConstValue>,
     ) -> CompileResult<(Type, bool)> {
         if let Some(id) = self.storage.anonymous_struct_id(&identity) {
             return Ok((Type::new_struct(id), false));
@@ -1272,7 +1273,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
     pub(crate) fn set_comptime_type_call_depth(&mut self, depth: usize) {
         self.storage.set_comptime_type_call_depth(depth)
     }
-    pub(crate) fn generated_structs(&self) -> &HashMap<Spur, StructId> {
+    pub(crate) fn generated_structs(&self) -> &AHashMap<Spur, StructId> {
         self.storage.generated_structs()
     }
     pub(crate) fn body_analysis_work_mut(&mut self) -> &mut BodyAnalysisWork {
@@ -1542,15 +1543,15 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         AnalyzedFunction,
         Vec<CompileWarning>,
         Vec<String>,
-        HashSet<Spur>,
-        HashSet<(StructId, Spur)>,
+        AHashSet<Spur>,
+        AHashSet<(StructId, Spur)>,
     )> {
         for (_, ty, _, is_comptime) in &param_info {
             reject_runtime_type_value(*ty, *is_comptime, span)?;
         }
         let function_symbol = self.storage.body_interner().get_or_intern(fn_name);
         let producer = self
-            .canonical_function_producer(function_symbol, &HashMap::new(), &HashMap::new())
+            .canonical_function_producer(function_symbol, &AHashMap::new(), &AHashMap::new())
             .map_err(|failure| {
                 CompileError::new(
                     ErrorKind::InternalError(format!(
@@ -1630,8 +1631,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         AnalyzedFunction,
         Vec<CompileWarning>,
         Vec<String>,
-        HashSet<Spur>,
-        HashSet<(StructId, Spur)>,
+        AHashSet<Spur>,
+        AHashSet<(StructId, Spur)>,
     )> {
         let symbol = self.storage.body_interner().get_or_intern(full_name);
         let identity = crate::FunctionInstanceKey::Definition(
@@ -1686,8 +1687,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         AnalyzedFunction,
         Vec<CompileWarning>,
         Vec<String>,
-        HashSet<Spur>,
-        HashSet<(StructId, Spur)>,
+        AHashSet<Spur>,
+        AHashSet<(StructId, Spur)>,
     )> {
         for (_, ty, _, is_comptime) in &resolved_params {
             reject_runtime_type_value(*ty, *is_comptime, span)?;
@@ -1777,8 +1778,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         AnalyzedFunction,
         Vec<CompileWarning>,
         Vec<String>,
-        HashSet<Spur>,
-        HashSet<(StructId, Spur)>,
+        AHashSet<Spur>,
+        AHashSet<(StructId, Spur)>,
     )> {
         let self_name = self.storage.body_interner().get_or_intern("self");
         let params = [(self_name, struct_type, RirParamMode::Normal, false)];
@@ -1868,8 +1869,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         Vec<CompileWarning>,
         Vec<String>,
         Vec<crate::LocalAtomRecord<crate::SemanticDefinitionToken, crate::SemanticModuleToken>>,
-        HashSet<Spur>,
-        HashSet<(StructId, Spur)>,
+        AHashSet<Spur>,
+        AHashSet<(StructId, Spur)>,
     )> {
         self.analyze_function_internal(
             infer_ctx,
@@ -1891,8 +1892,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         return_type: Type,
         params: &[(Spur, Type, RirParamMode, bool)],
         body: InstRef,
-        type_subst: &HashMap<Spur, Type>,
-        value_subst: &HashMap<Spur, ConstValue>,
+        type_subst: &AHashMap<Spur, Type>,
+        value_subst: &AHashMap<Spur, ConstValue>,
     ) -> CompileResult<(
         Air,
         u32,
@@ -1901,8 +1902,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         Vec<CompileWarning>,
         Vec<String>,
         Vec<crate::LocalAtomRecord<crate::SemanticDefinitionToken, crate::SemanticModuleToken>>,
-        HashSet<Spur>,
-        HashSet<(StructId, Spur)>,
+        AHashSet<Spur>,
+        AHashSet<(StructId, Spur)>,
     )> {
         self.analyze_function_internal(
             infer_ctx,
@@ -1924,8 +1925,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         return_type: Type,
         params: &[(Spur, Type, RirParamMode, bool)],
         body: InstRef,
-        type_subst: Option<&std::collections::HashMap<Spur, Type>>,
-        value_subst: Option<&std::collections::HashMap<Spur, ConstValue>>,
+        type_subst: Option<&AHashMap<Spur, Type>>,
+        value_subst: Option<&AHashMap<Spur, ConstValue>>,
         is_destructor: bool,
         allow_unused_variable: bool,
         self_is_mut: bool,
@@ -1938,8 +1939,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         Vec<CompileWarning>,
         Vec<String>,
         Vec<crate::LocalAtomRecord<crate::SemanticDefinitionToken, crate::SemanticModuleToken>>,
-        HashSet<Spur>,
-        HashSet<(StructId, Spur)>,
+        AHashSet<Spur>,
+        AHashSet<(StructId, Spur)>,
     )> {
         let expression_setup_started = Instant::now();
         let mut air = Air::new(return_type);
@@ -2079,8 +2080,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         // Create analysis context with resolved types
         // If type_subst is provided, initialize comptime_type_vars with the substitutions
         // so that type parameters can be resolved during struct initialization.
-        let comptime_type_vars = type_subst.map(|s| s.clone()).unwrap_or_else(HashMap::new);
-        let comptime_value_vars = value_subst.map(|s| s.clone()).unwrap_or_else(HashMap::new);
+        let comptime_type_vars = type_subst.map(|s| s.clone()).unwrap_or_else(AHashMap::new);
+        let comptime_value_vars = value_subst.map(|s| s.clone()).unwrap_or_else(AHashMap::new);
         let (canonical_producer, canonical_producer_arguments) =
             self.active_anonymous_producer().cloned().ok_or_else(|| {
                 CompileError::new(
@@ -2106,29 +2107,29 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             canonical_producer_arguments,
             canonical_function_identity,
             current_file_id: self.body_rir_ref().get(body).span.file_id,
-            locals: HashMap::new(),
+            locals: AHashMap::new(),
             params: &param_vec,
             param_index: &param_index,
             next_slot: 0,
             loop_depth: 0,
             checked_depth: 0,
             loop_break_stack: Vec::new(),
-            used_locals: HashSet::new(),
+            used_locals: AHashSet::new(),
             return_type,
             scope_stack: Vec::new(),
             moved_scope_stack: Vec::new(),
             comptime_type_scope_stack: Vec::new(),
             resolved_types: &resolved_types,
-            moved_vars: HashMap::new(),
+            moved_vars: AHashMap::new(),
             warnings: Vec::new(),
             allow_unused_variables: allow_unused_variable,
-            local_string_table: HashMap::new(),
+            local_string_table: AHashMap::new(),
             local_strings: Vec::new(),
             local_atoms: Vec::new(),
             comptime_type_vars,
             comptime_value_vars,
-            referenced_functions: HashSet::new(),
-            referenced_methods: HashSet::new(),
+            referenced_functions: AHashSet::new(),
+            referenced_methods: AHashSet::new(),
             byref_arg_root: None,
             call_loaned_roots: Vec::new(),
             in_loop_move_recheck: false,
@@ -2136,10 +2137,10 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             expected_type: None,
             infer_ctx,
             accessor_trailing_yield: None,
-            accessor_call_insts: HashMap::new(),
+            accessor_call_insts: AHashMap::new(),
             expression_loans: Vec::new(),
             inline_resolved_types: Vec::new(),
-            place_aliases: HashMap::new(),
+            place_aliases: AHashMap::new(),
             try_operand: false,
         };
 

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -5,7 +5,6 @@
 //! consulted; no declaration epoch or whole-program analyzer is reachable here.
 
 use std::cell::{Cell, RefCell};
-use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -356,8 +355,8 @@ pub struct ProviderOrdinaryBody<K, M> {
     pub function: AnalyzedFunction,
     pub warnings: Vec<rue_error::CompileWarning>,
     pub strings: Vec<String>,
-    pub referenced_functions: HashSet<Spur>,
-    pub referenced_methods: HashSet<(StructId, Spur)>,
+    pub referenced_functions: AHashSet<Spur>,
+    pub referenced_methods: AHashSet<(StructId, Spur)>,
     pub referenced_definitions: Vec<K>,
     pub referenced_values: Vec<K>,
     pub referenced_specializations:
@@ -854,26 +853,35 @@ struct ProviderBodyHost<'a, P, S, K, M> {
     modules_by_file: RefCell<AHashMap<FileId, M>>,
     module_tokens: RefCell<AHashMap<ModuleId, (SemanticModuleToken, M)>>,
     next_module_file: Cell<u32>,
-    generated_structs: HashMap<Spur, StructId>,
-    generated_enums: HashMap<Spur, EnumId>,
+    generated_structs: AHashMap<Spur, StructId>,
+    generated_enums: AHashMap<Spur, EnumId>,
     anonymous_methods: RefCell<AHashMap<(StructId, Spur), MethodCallInfo>>,
     /// Anonymous method endpoints whose complete durable signature set has
     /// already been installed in this body request. Provider type resolution
     /// handles recursive nominal shells inside the type pool and does not call
     /// back into endpoint installation, so only successful walks are cached.
     anonymous_method_registrations: RefCell<AHashSet<Type>>,
-    anonymous_struct_ids: HashSet<StructId>,
-    anonymous_enum_ids: HashSet<EnumId>,
-    anon_struct_identities: HashMap<super::anon_structs::IssuedAnonymousNominalKey, StructId>,
-    anon_enum_identities: HashMap<super::anon_structs::IssuedAnonymousNominalKey, EnumId>,
-    anonymous_digest_owners: HashMap<u128, super::anon_structs::IssuedAnonymousNominalKey>,
-    canonical_anonymous_types: HashMap<Type, super::anon_structs::IssuedAnonymousNominalKey>,
+    anonymous_struct_ids: AHashSet<StructId>,
+    anonymous_enum_ids: AHashSet<EnumId>,
+    anon_struct_identities: AHashMap<super::anon_structs::IssuedAnonymousNominalKey, StructId>,
+    anon_enum_identities: AHashMap<super::anon_structs::IssuedAnonymousNominalKey, EnumId>,
+    anonymous_digest_owners: AHashMap<u128, super::anon_structs::IssuedAnonymousNominalKey>,
+    /// Kept on the std hasher, unlike its neighbours: `produced_anonymous_nominals`
+    /// walks this map into the exported nominal payload and sorts that payload by
+    /// identity alone, so two entries sharing an identity would keep whatever
+    /// order the table iterated in. The sort key is not total over the entries,
+    /// which makes the iteration order reachable from an emitted artifact.
+    canonical_anonymous_types:
+        std::collections::HashMap<Type, super::anon_structs::IssuedAnonymousNominalKey>,
+    /// Kept on the std hasher for the same class of reason: `anonymous_struct_id`
+    /// and `anonymous_enum_id` scan this map with `find_map`, which answers with
+    /// an arbitrary member of the matching set rather than a canonical one.
     consulted_anonymous_types:
-        RefCell<HashMap<Type, super::anon_structs::IssuedAnonymousNominalKey>>,
-    durable_anonymous_types: HashMap<Type, crate::AnonymousNominalKey<K, M>>,
-    anon_struct_method_sigs: HashMap<StructId, Vec<super::AnonMethodSig>>,
-    anon_struct_captured_values: HashMap<StructId, HashMap<Spur, ConstValue>>,
-    anon_struct_type_subst: HashMap<StructId, HashMap<Spur, Type>>,
+        RefCell<std::collections::HashMap<Type, super::anon_structs::IssuedAnonymousNominalKey>>,
+    durable_anonymous_types: AHashMap<Type, crate::AnonymousNominalKey<K, M>>,
+    anon_struct_method_sigs: AHashMap<StructId, Vec<super::AnonMethodSig>>,
+    anon_struct_captured_values: AHashMap<StructId, AHashMap<Spur, ConstValue>>,
+    anon_struct_type_subst: AHashMap<StructId, AHashMap<Spur, Type>>,
     active_anonymous_producer: Option<(
         super::anon_structs::IssuedStableProducerId,
         super::anon_structs::IssuedCanonicalArguments,
@@ -883,7 +891,7 @@ struct ProviderBodyHost<'a, P, S, K, M> {
     recovered_errors: Vec<CompileError>,
     comptime_depth: usize,
     deferred_ownership: Vec<super::DeferredOwnershipGate>,
-    ctor_displays: HashMap<Type, String>,
+    ctor_displays: AHashMap<Type, String>,
     current_anonymous_identity:
         Option<FunctionInstanceKey<SemanticDefinitionToken, SemanticModuleToken>>,
 }
@@ -996,28 +1004,28 @@ where
             modules_by_file: RefCell::new(AHashMap::new()),
             module_tokens: RefCell::new(AHashMap::new()),
             next_module_file: Cell::new(u32::MAX),
-            generated_structs: HashMap::new(),
-            generated_enums: HashMap::new(),
+            generated_structs: AHashMap::new(),
+            generated_enums: AHashMap::new(),
             anonymous_methods: RefCell::new(AHashMap::new()),
             anonymous_method_registrations: RefCell::new(AHashSet::new()),
-            anonymous_struct_ids: HashSet::new(),
-            anonymous_enum_ids: HashSet::new(),
-            anon_struct_identities: HashMap::new(),
-            anon_enum_identities: HashMap::new(),
-            anonymous_digest_owners: HashMap::new(),
-            canonical_anonymous_types: HashMap::new(),
-            consulted_anonymous_types: RefCell::new(HashMap::new()),
-            durable_anonymous_types: HashMap::new(),
-            anon_struct_method_sigs: HashMap::new(),
-            anon_struct_captured_values: HashMap::new(),
-            anon_struct_type_subst: HashMap::new(),
+            anonymous_struct_ids: AHashSet::new(),
+            anonymous_enum_ids: AHashSet::new(),
+            anon_struct_identities: AHashMap::new(),
+            anon_enum_identities: AHashMap::new(),
+            anonymous_digest_owners: AHashMap::new(),
+            canonical_anonymous_types: std::collections::HashMap::new(),
+            consulted_anonymous_types: RefCell::new(std::collections::HashMap::new()),
+            durable_anonymous_types: AHashMap::new(),
+            anon_struct_method_sigs: AHashMap::new(),
+            anon_struct_captured_values: AHashMap::new(),
+            anon_struct_type_subst: AHashMap::new(),
             active_anonymous_producer: None,
             body_work: BodyAnalysisWork::default(),
             expression_breakdown: None,
             recovered_errors: Vec::new(),
             comptime_depth: 0,
             deferred_ownership: Vec::new(),
-            ctor_displays: HashMap::new(),
+            ctor_displays: AHashMap::new(),
             current_anonymous_identity: None,
         };
         for identity in &well_known.nominals {
@@ -1930,7 +1938,7 @@ where
                 return Err(crate::SemanticBodyExportFailure::MissingStableIdentity);
             }
         };
-        self.install_anonymous_dependencies(&import, &mut HashSet::new())?;
+        self.install_anonymous_dependencies(&import, &mut AHashSet::new())?;
         let ty = self
             .state
             .identity_context()
@@ -1962,7 +1970,7 @@ where
     fn install_anonymous_dependencies(
         &mut self,
         value: &crate::SemanticImportType<K, M>,
-        visited_named: &mut HashSet<K>,
+        visited_named: &mut AHashSet<K>,
     ) -> Result<(), crate::SemanticBodyExportFailure> {
         use crate::SemanticImportType as T;
         match value {
@@ -2295,7 +2303,7 @@ where
 
     fn produced_anonymous_nominals(
         &self,
-        initial: &HashSet<super::anon_structs::IssuedAnonymousNominalKey>,
+        initial: &AHashSet<super::anon_structs::IssuedAnonymousNominalKey>,
     ) -> Result<Arc<[crate::SemanticProducedAnonymousNominal]>, crate::SemanticBodyExportFailure>
     {
         fn mode(value: RirParamMode) -> crate::SemanticParameterMode {
@@ -2963,8 +2971,8 @@ where
     M: Clone + Eq + Hash + Ord,
 {
     fn inference_generated_nominal_overlays(&self) -> InferenceGeneratedNominalOverlays {
-        let mut builtin_struct_types = HashMap::new();
-        let mut struct_types_by_file = HashMap::new();
+        let mut builtin_struct_types = AHashMap::new();
+        let mut struct_types_by_file = AHashMap::new();
         for (name, id) in &self.generated_structs {
             let def = self.type_pool.struct_def(*id);
             if def.is_builtin {
@@ -2972,7 +2980,7 @@ where
             }
             struct_types_by_file.insert((def.file_id, *name), Type::new_struct(*id));
         }
-        let mut enum_types_by_file = HashMap::new();
+        let mut enum_types_by_file = AHashMap::new();
         for (name, id) in &self.generated_enums {
             let def = self.type_pool.enum_def(*id);
             enum_types_by_file.insert((def.file_id, *name), Type::new_enum(*id));
@@ -3623,7 +3631,7 @@ where
     fn types_equivalent(&self, left: Type, right: Type) -> bool {
         left == right
     }
-    fn generated_structs(&self) -> &HashMap<Spur, StructId> {
+    fn generated_structs(&self) -> &AHashMap<Spur, StructId> {
         &self.generated_structs
     }
     fn body_interner(&self) -> &ThreadedRodeo {
@@ -3645,10 +3653,10 @@ where
                 .and_then(|ty| ty.as_struct())
         })
     }
-    fn generated_structs_mut(&mut self) -> &mut HashMap<Spur, StructId> {
+    fn generated_structs_mut(&mut self) -> &mut AHashMap<Spur, StructId> {
         &mut self.generated_structs
     }
-    fn generated_enums_mut(&mut self) -> &mut HashMap<Spur, EnumId> {
+    fn generated_enums_mut(&mut self) -> &mut AHashMap<Spur, EnumId> {
         &mut self.generated_enums
     }
     fn anonymous_struct_id(
@@ -3691,12 +3699,12 @@ where
     }
     fn anonymous_struct_identities_mut(
         &mut self,
-    ) -> &mut HashMap<super::anon_structs::IssuedAnonymousNominalKey, StructId> {
+    ) -> &mut AHashMap<super::anon_structs::IssuedAnonymousNominalKey, StructId> {
         &mut self.anon_struct_identities
     }
     fn anonymous_enum_identities_mut(
         &mut self,
-    ) -> &mut HashMap<super::anon_structs::IssuedAnonymousNominalKey, EnumId> {
+    ) -> &mut AHashMap<super::anon_structs::IssuedAnonymousNominalKey, EnumId> {
         &mut self.anon_enum_identities
     }
     fn anonymous_digest_owner(
@@ -3728,18 +3736,18 @@ where
     }
     fn anonymous_struct_methods_mut(
         &mut self,
-    ) -> &mut HashMap<StructId, Vec<super::AnonMethodSig>> {
+    ) -> &mut AHashMap<StructId, Vec<super::AnonMethodSig>> {
         &mut self.anon_struct_method_sigs
     }
     fn anonymous_struct_captures_mut(
         &mut self,
-    ) -> &mut HashMap<StructId, HashMap<Spur, ConstValue>> {
+    ) -> &mut AHashMap<StructId, AHashMap<Spur, ConstValue>> {
         &mut self.anon_struct_captured_values
     }
-    fn anonymous_struct_ids_mut(&mut self) -> &mut HashSet<StructId> {
+    fn anonymous_struct_ids_mut(&mut self) -> &mut AHashSet<StructId> {
         &mut self.anonymous_struct_ids
     }
-    fn anonymous_enum_ids_mut(&mut self) -> &mut HashSet<EnumId> {
+    fn anonymous_enum_ids_mut(&mut self) -> &mut AHashSet<EnumId> {
         &mut self.anonymous_enum_ids
     }
     fn canonical_type_instance(
@@ -3946,8 +3954,8 @@ where
     fn reduce_external_comptime_call(
         &mut self,
         name: Spur,
-        callee_types: &HashMap<Spur, Type>,
-        callee_values: &HashMap<Spur, ConstValue>,
+        callee_types: &AHashMap<Spur, Type>,
+        callee_values: &AHashMap<Spur, ConstValue>,
         span: Span,
     ) -> Option<CompileResult<Option<ConstValue>>> {
         let definition = if name == self.function_symbol {
@@ -4078,8 +4086,8 @@ where
         &mut self,
         syntax: RirTypeSyntaxRef,
         span: Span,
-        type_substitutions: Option<&HashMap<Spur, Type>>,
-        value_substitutions: Option<&HashMap<Spur, ConstValue>>,
+        type_substitutions: Option<&AHashMap<Spur, Type>>,
+        value_substitutions: Option<&AHashMap<Spur, ConstValue>>,
     ) -> CompileResult<Type> {
         let syntax = super::fact_mode::StructuredTypeSyntax {
             arena: self.rir.rir().type_syntax().clone(),
@@ -4225,16 +4233,16 @@ where
     fn well_known_option(&self, payload: Type) -> Option<Type> {
         self.endpoint.well_known_option_for_payload(payload)
     }
-    fn set_anon_struct_type_subst(&mut self, struct_id: StructId, subst: HashMap<Spur, Type>) {
+    fn set_anon_struct_type_subst(&mut self, struct_id: StructId, subst: AHashMap<Spur, Type>) {
         self.anon_struct_type_subst.insert(struct_id, subst);
     }
-    fn anon_struct_type_subst(&self, struct_id: StructId) -> HashMap<Spur, Type> {
+    fn anon_struct_type_subst(&self, struct_id: StructId) -> AHashMap<Spur, Type> {
         self.anon_struct_type_subst
             .get(&struct_id)
             .cloned()
             .unwrap_or_default()
     }
-    fn anon_struct_captured_values(&self, struct_id: StructId) -> HashMap<Spur, ConstValue> {
+    fn anon_struct_captured_values(&self, struct_id: StructId) -> AHashMap<Spur, ConstValue> {
         self.anon_struct_captured_values
             .get(&struct_id)
             .cloned()
@@ -4380,7 +4388,7 @@ where
         .canonical_anonymous_types
         .values()
         .cloned()
-        .collect::<HashSet<_>>();
+        .collect::<AHashSet<_>>();
     let infer = InferenceContext::new(&host);
     let host_setup_ns = elapsed_ns(host_setup_started);
     let expression_engine_started = Instant::now();
@@ -4614,7 +4622,7 @@ where
             .zip(referenced_specializations.iter())
             .map(|((symbol, _), instance)| (*symbol, instance.clone())),
     );
-    let selected_calls = selected_calls.into_iter().collect::<HashMap<_, _>>();
+    let selected_calls = selected_calls.into_iter().collect::<AHashMap<_, _>>();
     let specialization_selection_ns = elapsed_ns(specialization_selection_started);
     let body_export_started = Instant::now();
     let export = super::semantic_body_export::export_body(
@@ -4642,7 +4650,7 @@ where
                 .get(symbol)
                 .map(|(_, key)| key.clone())
         })
-        .collect::<HashSet<_>>();
+        .collect::<AHashSet<_>>();
     referenced_definitions.extend(
         referenced_methods
             .iter()
@@ -4716,7 +4724,7 @@ fn anonymous_member_in_producer(
         .get(member.name.as_ref())
         .ok_or("anonymous member name is absent from its producer artifact")?;
     let mut pending = vec![producer_root];
-    let mut visited = HashSet::new();
+    let mut visited = AHashSet::new();
     let mut owner_found = false;
     let mut declaration = None;
     while let Some(reference) = pending.pop() {
@@ -4958,7 +4966,7 @@ where
         .insert(issued_owner.clone(), struct_id);
     host.anonymous_struct_ids.insert(struct_id);
     let type_captures = host.source.anonymous_type_captures(durable_owner);
-    let mut type_subst = HashMap::with_capacity(type_captures.len());
+    let mut type_subst = AHashMap::with_capacity(type_captures.len());
     for (name, durable_type) in type_captures {
         let ty = host
             .state
@@ -4998,7 +5006,7 @@ where
         host.anon_struct_type_subst.insert(struct_id, type_subst);
     }
     let value_captures = host.source.anonymous_value_captures(durable_owner);
-    let mut captured_values = HashMap::with_capacity(value_captures.len());
+    let mut captured_values = AHashMap::with_capacity(value_captures.len());
     for (name, durable_value) in value_captures {
         let value = host
             .materialize_durable_const_value(&durable_value)
@@ -5017,7 +5025,7 @@ where
         .canonical_anonymous_types
         .values()
         .cloned()
-        .collect::<HashSet<_>>();
+        .collect::<AHashSet<_>>();
 
     let (params, body, has_self, self_mode, self_is_mut, span) =
         match &host.rir.rir().get(declaration).data {
@@ -5217,7 +5225,7 @@ where
             .zip(referenced_specializations.iter())
             .map(|((symbol, _), instance)| (*symbol, instance.clone())),
     );
-    let selected_calls = selected_calls.into_iter().collect::<HashMap<_, _>>();
+    let selected_calls = selected_calls.into_iter().collect::<AHashMap<_, _>>();
     let body_span = host.rir.rir().get(body).span;
     let specialization_selection_ns = elapsed_ns(specialization_selection_started);
     let body_export_started = Instant::now();
@@ -5257,7 +5265,7 @@ where
                 .get(symbol)
                 .map(|(_, key)| key.clone())
         })
-        .collect::<HashSet<_>>();
+        .collect::<AHashSet<_>>();
     referenced_definitions.extend(
         referenced_methods
             .iter()
@@ -5366,7 +5374,7 @@ where
         .canonical_anonymous_types
         .values()
         .cloned()
-        .collect::<HashSet<_>>();
+        .collect::<AHashSet<_>>();
     let type_args = arguments
         .types
         .iter()
@@ -5431,7 +5439,7 @@ where
             .zip(referenced_specializations.iter())
             .map(|((symbol, _), instance)| (*symbol, instance.clone())),
     );
-    let selected_calls = selected_calls.into_iter().collect::<HashMap<_, _>>();
+    let selected_calls = selected_calls.into_iter().collect::<AHashMap<_, _>>();
     let specialization_selection_ns = elapsed_ns(specialization_selection_started);
     let body_export_started = Instant::now();
     let body = super::semantic_body_export::export_body(
@@ -5461,7 +5469,7 @@ where
                 .get(symbol)
                 .map(|(_, key)| key.clone())
         })
-        .collect::<HashSet<_>>();
+        .collect::<AHashSet<_>>();
     referenced_definitions.extend(
         specialized
             .referenced_methods

--- a/crates/rue-air/src/sema/provider_fixture.rs
+++ b/crates/rue-air/src/sema/provider_fixture.rs
@@ -22,7 +22,7 @@
 //!   panics; if body analysis ever starts consulting the provider object on
 //!   this path, fixture tests fail loudly instead of silently absorbing it.
 
-use std::collections::HashMap;
+use ahash::AHashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -114,10 +114,10 @@ pub(crate) type FixtureBody = ProviderOrdinaryBody<FixtureKey, FixtureModule>;
 pub(crate) struct FixtureFacts {
     module_path: Arc<str>,
     file: FileId,
-    functions: HashMap<FixtureKey, DurableFunction<FixtureKey, FixtureModule>>,
-    methods: HashMap<FixtureKey, DurableMethod<FixtureKey, FixtureModule>>,
-    nominals: HashMap<FixtureKey, DurableNominal<FixtureKey, FixtureModule>>,
-    consts: HashMap<FixtureKey, DurableConst<FixtureKey, FixtureModule>>,
+    functions: AHashMap<FixtureKey, DurableFunction<FixtureKey, FixtureModule>>,
+    methods: AHashMap<FixtureKey, DurableMethod<FixtureKey, FixtureModule>>,
+    nominals: AHashMap<FixtureKey, DurableNominal<FixtureKey, FixtureModule>>,
+    consts: AHashMap<FixtureKey, DurableConst<FixtureKey, FixtureModule>>,
 }
 
 /// The in-memory durable fact source handed to the production body host. Facts

--- a/crates/rue-air/src/sema/provider_module_registry.rs
+++ b/crates/rue-air/src/sema/provider_module_registry.rs
@@ -1,6 +1,6 @@
 //! Body-local module registry assembled from durable module facts.
 
-use std::collections::HashMap;
+use ahash::AHashMap;
 use std::hash::Hash;
 
 use rue_span::FileId;
@@ -13,16 +13,16 @@ use crate::{ModuleDef, ModuleId};
 /// the current request's file handle are registered alongside it because they
 /// are request-local facts, not properties reconstructible from a compact id.
 pub(in crate::sema) struct ProviderModuleRegistry<M> {
-    by_durable: HashMap<M, ModuleId>,
-    by_file: HashMap<FileId, ModuleId>,
+    by_durable: AHashMap<M, ModuleId>,
+    by_file: AHashMap<FileId, ModuleId>,
     defs: Vec<ModuleDef>,
 }
 
 impl<M> Default for ProviderModuleRegistry<M> {
     fn default() -> Self {
         Self {
-            by_durable: HashMap::new(),
-            by_file: HashMap::new(),
+            by_durable: AHashMap::new(),
+            by_file: AHashMap::new(),
             defs: Vec::new(),
         }
     }

--- a/crates/rue-air/src/sema/semantic_body_export.rs
+++ b/crates/rue-air/src/sema/semantic_body_export.rs
@@ -1,7 +1,6 @@
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::sync::Arc;
+
+use ahash::{AHashMap, AHashSet};
 
 use lasso::Spur;
 use rue_error::CompileWarning;
@@ -56,12 +55,12 @@ pub(crate) fn export_body<H: SemanticBodyExportHost>(
     strings: &[String],
     warnings: &[CompileWarning],
     specialized_calls: Option<
-        &HashMap<
+        &AHashMap<
             Spur,
             SemanticSpecializationIdentity<SemanticDefinitionToken, SemanticModuleToken>,
         >,
     >,
-    method_references: &HashSet<(crate::StructId, Spur)>,
+    method_references: &AHashSet<(crate::StructId, Spur)>,
 ) -> Result<SemanticBodyExport, F> {
     let warning_anchor = |span: Span| {
         if span.file_id != body_span.file_id

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use ahash::AHashMap;
 
     use lasso::ThreadedRodeo;
     use rue_lexer::Lexer;
@@ -126,7 +126,7 @@ mod tests {
             }
         "#;
         let (rir, interner) = lower_files(&[(source, FileId::DEFAULT)]);
-        let mut candidates = HashMap::new();
+        let mut candidates = AHashMap::new();
         for (_, inst) in rir.iter() {
             if let InstData::Alloc {
                 name: Some(name),

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -7,7 +7,7 @@
 //! - Type conversions between AIR types and inference types
 
 use super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
-use std::collections::{HashMap, HashSet};
+use ahash::{AHashMap, AHashSet};
 use std::convert::Infallible;
 
 use lasso::Spur;
@@ -122,12 +122,12 @@ pub(super) struct TypeSyntaxProvider<'host, 'c, H: TypeSyntaxHost> {
     span: Span,
     root_authority: TypeRootAuthority,
     resolution_context: SemaTypeResolutionContext,
-    type_substitutions: Option<&'c HashMap<Spur, Type>>,
-    value_substitutions: Option<&'c HashMap<Spur, ConstValue>>,
+    type_substitutions: Option<&'c AHashMap<Spur, Type>>,
+    value_substitutions: Option<&'c AHashMap<Spur, ConstValue>>,
     // Preserve observation order for the host while using a lazy membership
     // index once a resolution grows beyond the allocation-free small case.
     observed_type_dependencies: Vec<ObservedTypeDependency>,
-    observed_type_dependency_index: Option<HashSet<ObservedTypeDependency>>,
+    observed_type_dependency_index: Option<AHashSet<ObservedTypeDependency>>,
 }
 
 /// The lexical root a type-syntax resolution walks from.
@@ -569,8 +569,8 @@ impl<'s, 'c, H: TypeSyntaxHost> TypeSyntaxProvider<'s, 'c, H> {
         span: Span,
         root_authority: TypeRootAuthority,
         resolution_context: SemaTypeResolutionContext,
-        type_substitutions: Option<&'c HashMap<Spur, Type>>,
-        value_substitutions: Option<&'c HashMap<Spur, ConstValue>>,
+        type_substitutions: Option<&'c AHashMap<Spur, Type>>,
+        value_substitutions: Option<&'c AHashMap<Spur, ConstValue>>,
     ) -> Self {
         Self {
             host,

--- a/crates/rue-air/src/semantic_body.rs
+++ b/crates/rue-air/src/semantic_body.rs
@@ -1146,6 +1146,9 @@ pub struct SemanticImportedBody<K, M> {
     /// session's live `(receiver, method)` keys. Import hosts that resolve
     /// nominals (the staged-body importer) populate this; validation-only
     /// hosts leave it empty because no reachability consumer reads it there.
+    ///
+    /// Kept on the std hasher: `rue-compiler` and `rue-cfg` construct and walk
+    /// this field, so its hasher is part of AIR's public surface.
     pub method_references: std::collections::HashSet<(crate::StructId, lasso::Spur)>,
 }
 

--- a/crates/rue-air/src/semantic_identity.rs
+++ b/crates/rue-air/src/semantic_identity.rs
@@ -494,7 +494,8 @@ stable_definition_kind_schema!(define_stable_definition_kind_schema);
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeSet, HashSet};
+    use ahash::AHashSet;
+    use std::collections::BTreeSet;
 
     use super::*;
 
@@ -552,6 +553,6 @@ mod tests {
             BTreeSet::from([baseline.clone(), same.clone(), moved.clone()]).len(),
             2
         );
-        assert_eq!(HashSet::from([baseline, same, moved]).len(), 2);
+        assert_eq!(AHashSet::from([baseline, same, moved]).len(), 2);
     }
 }

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -5,7 +5,7 @@
 //! an exact semantic request. The importer reconstructs only values that AIR
 //! can represent without borrowing handles from the exporting request.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::hash::Hash;
 use std::sync::Arc;
 
@@ -547,6 +547,9 @@ pub struct SemanticLocalMaterialization<K, M> {
     pub allow_unreachable_code: bool,
     pub type_pool: crate::FrozenTypeInternPool,
     pub interner: Arc<ThreadedRodeo>,
+    /// Kept on the std hasher: `rue-compiler` reads this field directly and
+    /// passes it on by reference, so its hasher is part of AIR's public surface
+    /// rather than an internal choice.
     pub aggregate_types: std::collections::HashMap<crate::Type, TypeInstanceKey<K, M>>,
     /// Exact caller-owned handles explicitly pre-materialized for a mandatory
     /// accessor splice, paired with their stable type identities.
@@ -608,10 +611,10 @@ pub struct SemanticImportEpoch<K: Ord, M: Ord> {
     functions: AHashMap<FunctionInstanceKey<K, M>, Spur>,
     modules: BTreeMap<M, ModuleId>,
     builtins: BTreeMap<(Arc<str>, SemanticImportNominalKind), LocalNominal>,
-    nominal_exports: HashMap<LocalNominal, NominalInstanceKey<K, M>>,
-    function_exports: HashMap<Spur, FunctionInstanceKey<K, M>>,
-    module_exports: HashMap<ModuleId, M>,
-    builtin_exports: HashMap<LocalNominal, (Arc<str>, SemanticImportNominalKind)>,
+    nominal_exports: AHashMap<LocalNominal, NominalInstanceKey<K, M>>,
+    function_exports: AHashMap<Spur, FunctionInstanceKey<K, M>>,
+    module_exports: AHashMap<ModuleId, M>,
+    builtin_exports: AHashMap<LocalNominal, (Arc<str>, SemanticImportNominalKind)>,
     local_completeness: Option<SemanticLocalCompleteness>,
 }
 
@@ -1115,7 +1118,7 @@ where
             && body.strings.len() > 1
             && estimated_scan_comparisons >= LOCAL_ATOM_STRING_INDEX_MIN_COMPARISONS)
             .then(|| {
-                let mut positions = std::collections::HashMap::with_capacity(body.strings.len());
+                let mut positions = AHashMap::with_capacity(body.strings.len());
                 for (index, content) in body.strings.iter().enumerate() {
                     if let Ok(dense_id) = u32::try_from(index) {
                         // Match `position`: malformed duplicate entries resolve
@@ -1324,10 +1327,10 @@ where
             functions,
             modules,
             builtins,
-            nominal_exports: HashMap::new(),
-            function_exports: HashMap::new(),
-            module_exports: HashMap::new(),
-            builtin_exports: HashMap::new(),
+            nominal_exports: AHashMap::new(),
+            function_exports: AHashMap::new(),
+            module_exports: AHashMap::new(),
+            builtin_exports: AHashMap::new(),
             local_completeness: None,
         };
         epoch.rebuild_export_indexes();

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -28,8 +28,7 @@
 //! specialized body. The compiler's query graph owns the cross-body fixed
 //! point and its expansion budget ([`MAX_SPECIALIZATION_ROUNDS`]).
 
-use std::collections::HashMap;
-use std::collections::HashSet;
+use ahash::{AHashMap, AHashSet};
 use std::collections::hash_map::Entry;
 
 use lasso::{Key, Spur, ThreadedRodeo};
@@ -84,7 +83,7 @@ pub const MAX_SPECIALIZATION_ROUNDS: usize = 64;
 fn collect_specializations(
     air: &Air,
     interner: &ThreadedRodeo,
-    specializations: &mut HashMap<SpecializationKey, SpecializationInfo>,
+    specializations: &mut AHashMap<SpecializationKey, SpecializationInfo>,
     pending: &mut Vec<SpecializationKey>,
     work: &mut crate::BodyAnalysisWork,
 ) -> bool {
@@ -133,7 +132,7 @@ fn collect_specializations(
 
 fn rewrite_call_generic(
     air: &mut crate::AirEditor,
-    specializations: &HashMap<SpecializationKey, SpecializationInfo>,
+    specializations: &AHashMap<SpecializationKey, SpecializationInfo>,
     work: &mut crate::BodyAnalysisWork,
 ) {
     let mut rewrites: Vec<(usize, Spur)> = Vec::new();
@@ -230,7 +229,7 @@ pub(crate) fn select_provider_body_specializations<H>(
 where
     H: OrdinaryBodyAnalysisHost + SemanticBodyExportHost,
 {
-    let mut specializations = HashMap::new();
+    let mut specializations = AHashMap::new();
     let mut pending = Vec::new();
     let mut work = crate::BodyAnalysisWork::default();
     if collect_specializations(
@@ -324,8 +323,8 @@ pub(crate) struct OneSpecializedBody {
     pub(crate) function: AnalyzedFunction,
     pub(crate) warnings: Vec<CompileWarning>,
     pub(crate) local_strings: Vec<String>,
-    pub(crate) referenced_functions: HashSet<Spur>,
-    pub(crate) referenced_methods: HashSet<(StructId, Spur)>,
+    pub(crate) referenced_functions: AHashSet<Spur>,
+    pub(crate) referenced_methods: AHashSet<(StructId, Spur)>,
     pub(crate) dependencies: Vec<crate::SemanticDefinitionToken>,
     pub(crate) dependency_boundary_complete: bool,
     pub(crate) identity: crate::SemanticSpecializationIdentity<
@@ -360,8 +359,8 @@ where
         .map(|(name, ty, mode, is_comptime)| (*name, *ty, *mode, *is_comptime))
         .collect::<Vec<_>>();
 
-    let mut type_subst = HashMap::new();
-    let mut value_subst = HashMap::new();
+    let mut type_subst = AHashMap::new();
+    let mut value_subst = AHashMap::new();
     let mut type_arg_idx = 0;
     let mut value_arg_idx = 0;
     for (param_index, (name, _, _, is_comptime)) in base_params.iter().enumerate() {

--- a/crates/rue-air/src/type_properties.rs
+++ b/crates/rue-air/src/type_properties.rs
@@ -4,7 +4,7 @@
 //! validation properties: a well-shaped `Type` can still be foreign to a
 //! pool, out of range, the wrong kind, incomplete, or recovery-only.
 
-use std::collections::HashSet;
+use ahash::AHashSet;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::{Arc, Barrier};
 
@@ -107,7 +107,7 @@ fn encoding_shape_is_exact_and_checked_round_trips_preserve_kind_metadata() {
                 TypeKind::PtrMut(PtrMutTypeId::from_pool_index(payload)),
             ),
         ];
-        let mut raw_values = HashSet::new();
+        let mut raw_values = AHashSet::new();
         for (ty, encoded_kind, decoded_kind) in composites {
             let expected = type_encoding::encode_composite(encoded_kind, payload).unwrap();
             assert_eq!(ty.raw_encoding(), expected);
@@ -270,7 +270,7 @@ fn bounded_composite_graphs_round_trip_through_canonical_pool_storage() {
         frontier = next;
     }
 
-    let mut unique = HashSet::new();
+    let mut unique = AHashSet::new();
     for graph in all {
         let raw = graph.ty.raw_encoding();
         let decoded = Type::try_from_u32(raw).expect("pool-issued encoding must decode");
@@ -330,7 +330,7 @@ fn pool_validation_rejects_wrong_kinds_ranges_and_illegal_children_without_alias
             Type::new_ptr_mut(PtrMutTypeId::from_pool_index(pool_index)),
         ];
         assert_eq!(
-            forged.into_iter().collect::<HashSet<_>>().len(),
+            forged.into_iter().collect::<AHashSet<_>>().len(),
             forged.len()
         );
         for (encoded_kind, ty) in forged.into_iter().enumerate() {


### PR DESCRIPTION
Mechanical hasher sweep in the compiler's hottest crate: **684 `HashMap`/`HashSet` occurrences across 34 files** in `crates/rue-air` move from the default SipHash hasher to `ahash::AHashMap`/`AHashSet` (already a dependency; the sweep matches the direct-import spelling the crate's existing ahash files use). Hashing showed ~4.7% of the flat profile in the earlier hotspot sweep; SipHash's DoS resistance buys nothing for these compiler-internal tables.

**Every site was checked for order sensitivity rather than blind-replaced.** Five collections (14 occurrences) deliberately stay on std, each with the reason recorded at its declaration:

- `ConstraintGenerator::expr_types` — iteration order fixes pool indices that later serve as a sort key (genuinely order-bearing)
- `ProviderBodyHost::canonical_anonymous_types` — feeds a payload sorted by a non-total key; ties retain table order
- `ProviderBodyHost::consulted_anonymous_types` — `find_map` scans answer with an arbitrary matching member
- `SemanticLocalMaterialization::aggregate_types` and `SemanticImportedBody::method_references` — `pub` fields read across crate boundaries

Sites that looked risky but were proven safe are documented in the sweep notes (sorted-before-publication exports, `BTreeSet` landings downstream, entry-only access patterns, counter-assigned ids).

## Verification

- **Byte identity (hard gate): passed.** Lattice `b893e76c…85e5` and mosaic `be93e526…a208` identical before/after on a paired same-worktree comparison, with baseline run-to-run reproducibility confirmed first so the gate is meaningful; re-verified independently on this branch after rebasing onto current trunk. **All 136 `compiler_work` counters identical on both workloads.**
- Suites: `rue-air-test` 651/651 (both in-worktree and re-run on this branch), `rue-driver-test`, `rue-compiler-test`, and `scripts/rue quick` (30 targets) all green; `scripts/rue fmt` applied.
- **Timing: honestly inconclusive on this shared host** — paired medians moved in both directions depending on sweep order (concurrent agent builds, load ~12); pooled over 20 runs semantic moved −0.24%, min-of-10 root −3.0%. The change is justified by the profile share and byte-identity safety, not by a claimed wall-clock number; a clean measurement needs an uncontended host.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTiBg7df72iMgdpAFv5wZs)_