### PR TITLE
RUE-1472: avoid duplicate anonymous endpoint publication

### DIFF
--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -1710,6 +1710,8 @@ where
             .cloned()
             .or_else(|| self.endpoint.durable_anonymous_identity(owner_type))?;
         let issued = self.register_and_issue_anonymous_identity(&identity)?;
+        self.endpoint
+            .register_anonymous_nominal(issued.clone(), identity.clone());
         self.register_provider_anonymous_method_endpoints_with_issued(
             &identity, owner_type, issued,
         )?;
@@ -2665,8 +2667,6 @@ where
         owner_type: Type,
         issued_identity: super::anon_structs::IssuedAnonymousNominalKey,
     ) -> Option<()> {
-        self.endpoint
-            .register_anonymous_nominal(issued_identity.clone(), identity.clone());
         let Some(struct_id) = owner_type.as_struct() else {
             return Some(());
         };


### PR DESCRIPTION
## Rationale

A fresh symbolized Lattice profile at merged trunk `556a271a5` placed 29 recursive samples in import nominal-identity registration. Resolving the hot return addresses showed repeated anonymous method-endpoint installation. The anonymous import path already publishes the endpoint mapping before minting, but the method helper inserted the same issued/durable mapping again.

This change keeps endpoint publication explicit at every caller (including the cold `method_info_for_symbol` recovery path) and removes the helper-owned duplicate. Registration-before-mint, failure ordering, canonical identity ownership, query architecture, and outputs are unchanged. It is deliberately narrower than the previously falsified broad anonymous-import success cache.

## Performance falsifiers

Controlled workload: fresh process, one worker, `-O3`, `--target x86-64-linux`, Lattice, exact trunk compiler baseline. Sixteen alternating pairs:

- instructions: **-0.1405%** paired median, MAD 0.0350%, range -0.3238%..-0.0230%; improved **16/16**
- compiler root: **-0.5454%** paired median, MAD 0.6076%; improved 12/16
- semantic provider analysis: **-0.3222%** paired median; improved 11/16
- cycles: **-0.3198%** paired median; improved 12/16
- RSS: **-0.4406%** paired median; improved 16/16

Four allocation-instrumented pairs:

- allocation count: median **-14,966.5** calls (-0.1573%)
- requested bytes: median **-1,612,132** bytes (-0.1011%)

## Exactness and validation

- emitted output is byte-identical: `b893e76cfabed737b149d0e8c4d8527077dedd17da78418db20a28a7d30885e5`
- `compiler_work`, `source_metrics`, `emitted_output`, and `compiler_boundary` match exactly
- `scripts/rue quick`: Pass 30, Fail 0
- compiler differential/incremental oracle: 4 passed
- focused provider-body suite: 95 passed
- `scripts/rue fmt` and `git diff --check` pass

Tracker: RUE-1472