### PR TITLE
Record the lazy display-identity rejection and pin cycle render text

### DIFF
--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -14686,6 +14686,16 @@ mod tests {
             panic!("a body which transitively asks for itself is a true cycle");
         };
         assert_eq!(nodes.len(), 2);
+        // The rendered cycle names every memo node on it, in canonical order.
+        // Any future change to when a memo-node key is formatted has to keep
+        // this text exactly, because consumers match cycle members by name.
+        assert_eq!(
+            nodes
+                .iter()
+                .map(|node| (node.family(), node.key()))
+                .collect::<Vec<_>>(),
+            vec![("ring", "a"), ("ring", "b")]
+        );
         assert_eq!(runtime.metrics().cycles, 1);
     }
 

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1853,6 +1853,40 @@ and executable byte remains identical. This is therefore an asymptotic and
 architectural win with no measured cold-time regression on the maintained
 workload.
 
+Deferring the memo-node display identity itself was then measured and rejected.
+Fixed one-worker cold Lattice materializes 32,912 memo-node identities holding
+7,999,794 formatted key bytes, one per incarnation, and the premise was that
+nothing reads that text unless a diagnostic, cycle render, or abort needs a
+name. A prototype kept the typed key behind a `OnceLock` and formatted on first
+demand, with shared-`Arc` shortcuts in identity equality and ordering and an
+incarnation-first comparison for exact frame identities. It changed no counter
+at all: the runtime still named all 32,912 nodes, because two readers demand
+every node's text on the ordinary path.
+
+Publication is the first. `retained_terminal_charge` counts the formatted key
+length of the published node and of each of its dependency observations, so the
+deterministic retained charge names every node that publishes a terminal and
+every node that is observed. Removing those two terms from the charge does
+leave the emitted executable and all 136 compiler-work counters identical, and
+drops the identity totals to 24,079 materializations and 5,086,634 bytes, but
+the formatted length was carrying real retention back-pressure: the same
+budget then holds a larger retained set, and median peak RSS rises from 295.12
+MB to 299.99 MB across five paired runs whose ranges do not overlap. Trading
+2.91 MB of formatted text for 4.87 MB of additional retained artifacts is a net
+memory regression, so the charge keeps counting presentation bytes.
+
+Frame publication is the second, and it bounds the idea independently. RUE-1381
+publishes each frame's dependency array in canonical family-then-key order, so
+completing a frame compares the display identities of sibling dependencies. Any
+two dependencies inside one family are separated by their key text alone, which
+is what the residual 24,079 materializations above are. Reaching a materially
+smaller number therefore requires changing the published dependency order, and
+that order is also the order validation walks and early-exits on, so it is a
+retention-and-validation policy decision rather than a presentation change. The
+prototype was not retained; `QueryKey::stable_identity` stays documented as
+presentation-only, and the display-identity counters continue to report one
+materialization per memo node.
+
 ## Next actions and decision boundary
 
 ADR-0071 Phase 2 extends this general architecture record with the current

--- a/docs/process/compiler-scaling.md
+++ b/docs/process/compiler-scaling.md
@@ -181,11 +181,18 @@ separate from materialization shows when accounting work repeats over an
 unchanged artifact, even when host timing noise hides its cost.
 
 The display-identity table similarly reports formatted key bytes per token.
-Memo-node identities and abort fallbacks label diagnostics. Structured-wait
-identities are materialized only when a detected wait cycle must be rendered;
-registering an acyclic edge formats no key text. Typed query keys, not display
-strings, remain authoritative for memo lookup. Family names are shared and
-therefore excluded from the byte totals.
+Memo-node identities and abort fallbacks label diagnostics. A memo-node
+identity is formatted when its incarnation is created, and the count therefore
+tracks memo nodes rather than rendered names, because two runtime readers need
+that text for every node anyway: the deterministic retained-terminal charge
+counts its formatted bytes, and a completed frame publishes its dependency
+array in canonical family-then-key order. Deferring it was measured and
+rejected; see the
+[cold-compiler architecture audit](../notes/post-adr-0063-cold-compiler-architecture-audit.md).
+Structured-wait identities are materialized only when a detected wait cycle
+must be rendered; registering an acyclic edge formats no key text. Typed query
+keys, not display strings, remain authoritative for memo lookup. Family names
+are shared and therefore excluded from the byte totals.
 
 The compiled examples are never executed. Runtime tests and heavyweight
 example scenarios remain in their existing suites, so a slow example runtime


### PR DESCRIPTION
Documentation of a measured optimization rejection, plus one pinning test. No runtime behavior change.

The Lattice fresh-build profile shows `display_identities.memo_node_materializations = 32,912` retaining ~8MB of formatted key text, which looked like a pure eager-allocation tax. A full deferred-formatting prototype (typed key + `OnceLock` slot, metrics charged at real materialization) was built and measured: **it removes nothing** — the count stayed at exactly 32,912, because two ordinary-path readers demand every node's text:

1. `retained_terminal_charge` adds `node.key().len()` for every published node and every observed dependency — the formatted length is part of the deterministic retained-charge policy, not just presentation.
2. RUE-1381's canonical published dependency order is family-then-key, so `NodeIdentity::cmp` reads key text on every `Task::pop`.

Isolating the charge terms shows the residual 24,079 materializations belong to the ordering contract, and removing presentation bytes from the retained charge is a net memory regression (median peak RSS 295.1 → 300.0 MB across paired runs, to save 2.9 MB of text) because the charge was carrying real retention back-pressure. The prototype was therefore reverted, matching the audit file's earlier rejection of shared-`Arc` identity fast paths (+3.0 MiB RSS).

Changes:
- `docs/notes/post-adr-0063-cold-compiler-architecture-audit.md`: the rejection recorded in the file's house style, with both readers and the numbers, so the idea isn't re-attempted from scratch.
- `docs/process/compiler-scaling.md`: the display-identity paragraph now explains why the memo-node count tracks nodes rather than rendered names.
- `crates/rue-query/src/lib.rs`: `registered_batch_dependency_cycle_is_reported_exactly` now pins the rendered cycle text, so any future deferral attempt must preserve diagnostic output.

Verification: `rue-query-test` 176/176 (re-run on this branch), `scripts/rue quick` green; agent-side runs also covered `scripts/rue ui` (250) and `rue-driver-test`. Lattice executable hash and all 136 `compiler_work` counters unchanged (docs + test only).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTiBg7df72iMgdpAFv5wZs)_