### PR TITLE
RUE-1472: skip shared module-path comparisons

### DIFF
--- a/crates/rue-compiler/src/source_identity.rs
+++ b/crates/rue-compiler/src/source_identity.rs
@@ -304,7 +304,7 @@ impl fmt::Display for SourceId {
 }
 
 /// Canonical logical identity of one module.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone)]
 pub struct ModuleId {
     logical_path: Arc<str>,
     origin: ModuleOrigin,
@@ -314,6 +314,40 @@ pub struct ModuleId {
 enum ModuleOrigin {
     Caller,
     StandardLibrary,
+}
+
+impl PartialEq for ModuleId {
+    fn eq(&self, other: &Self) -> bool {
+        (Arc::ptr_eq(&self.logical_path, &other.logical_path)
+            || self.logical_path == other.logical_path)
+            && self.origin == other.origin
+    }
+}
+
+impl Eq for ModuleId {}
+
+impl Hash for ModuleId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.logical_path.hash(state);
+        self.origin.hash(state);
+    }
+}
+
+impl PartialOrd for ModuleId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ModuleId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let path_order = if Arc::ptr_eq(&self.logical_path, &other.logical_path) {
+            Ordering::Equal
+        } else {
+            self.logical_path.cmp(&other.logical_path)
+        };
+        path_order.then_with(|| self.origin.cmp(&other.origin))
+    }
 }
 
 impl ModuleId {
@@ -698,6 +732,12 @@ mod tests {
         value.hash(&mut h);
         h.finish()
     }
+
+    fn module_hash(value: &ModuleId) -> u64 {
+        let mut h = DefaultHasher::new();
+        value.hash(&mut h);
+        h.finish()
+    }
     #[test]
     fn collisions_do_not_equal_or_replace_text() {
         let a = SourceId::from_shared_text_with(Arc::new("a".into()), &Constant);
@@ -728,6 +768,61 @@ mod tests {
         assert_eq!(left, right);
         assert_eq!(left.cmp(&right), Ordering::Equal);
         assert_eq!(hash(&left), hash(&right));
+    }
+
+    #[test]
+    fn module_id_order_skips_shared_path_bytes() {
+        let path: Arc<str> = Arc::from("shared/module.rue");
+        let left = ModuleId {
+            logical_path: path.clone(),
+            origin: ModuleOrigin::Caller,
+        };
+        let right = ModuleId {
+            logical_path: path,
+            origin: ModuleOrigin::Caller,
+        };
+        assert_eq!(left, right);
+        assert_eq!(left.cmp(&right), Ordering::Equal);
+    }
+
+    #[test]
+    fn module_id_order_keeps_equal_text_distinct_paths_equal() {
+        let left = ModuleId {
+            logical_path: Arc::from("same/module.rue"),
+            origin: ModuleOrigin::Caller,
+        };
+        let right = ModuleId {
+            logical_path: Arc::from("same/module.rue"),
+            origin: ModuleOrigin::Caller,
+        };
+        assert!(!Arc::ptr_eq(&left.logical_path, &right.logical_path));
+        assert_eq!(left, right);
+        assert_eq!(left.cmp(&right), Ordering::Equal);
+        assert_eq!(module_hash(&left), module_hash(&right));
+    }
+
+    #[test]
+    fn module_id_order_matches_path_then_origin_tuple() {
+        let earlier = ModuleId {
+            logical_path: Arc::from("a/module.rue"),
+            origin: ModuleOrigin::Caller,
+        };
+        let later = ModuleId {
+            logical_path: Arc::from("b/module.rue"),
+            origin: ModuleOrigin::Caller,
+        };
+        assert!(earlier < later);
+        assert!(later > earlier);
+
+        let caller = ModuleId {
+            logical_path: Arc::from("same/module.rue"),
+            origin: ModuleOrigin::Caller,
+        };
+        let standard = ModuleId {
+            logical_path: Arc::from("same/module.rue"),
+            origin: ModuleOrigin::StandardLibrary,
+        };
+        assert!(caller < standard, "origin remains the tuple tie-break");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- retain Rue's canonical `ModuleId` ordering while short-circuiting logical-path byte comparisons for cloned `Arc` paths
- keep the lexical fallback for distinct allocations and the origin tie-break unchanged
- add focused equality, ordering, and hash-contract coverage

## Measured rationale

Exact trunk baseline: `200a00027`. Lattice, fresh process, `-O3 -j1 --target x86-64-linux`, sixteen balanced alternating pairs:

- retired instructions: **-0.4574% median**, 0.0745% MAD, improved 16/16, range -0.9219% to -0.2906%
- cycles: +0.0662% median, 1.1643% MAD (statistically flat)
- compiler-root wall time: +0.1781% median, 1.7938% MAD (launch-noisy)
- allocations, four pairs: median -93 calls and -21,286 requested bytes

This passes the falsifier on a consistent hardware-independent instruction reduction without allocator growth.

## Correctness

- exact emitted bytes; SHA-256 remains `b893e76cfabed737b149d0e8c4d8527077dedd17da78418db20a28a7d30885e5`
- exact compiler work, source metrics, emitted-output metadata, and compiler boundary
- `scripts/rue quick`: 30/30 targets
- differential incremental oracle: 4/4
- focused `ModuleId` tests and formatting pass
