### PR TITLE
Propose ADR-0074 and ADR-0075: structural identity and wave-granular discovery

### DIFF
--- a/docs/designs/0074-structural-node-identity.md
+++ b/docs/designs/0074-structural-node-identity.md
@@ -1,7 +1,7 @@
 ---
 id: 0074
 title: "Structural node identity for dependency order and retained charge"
-status: proposed
+status: proposal
 tags: [architecture, compiler, performance, query-engine]
 feature-flag: null
 created: 2026-08-17

--- a/docs/designs/0074-structural-node-identity.md
+++ b/docs/designs/0074-structural-node-identity.md
@@ -1,0 +1,139 @@
+---
+id: 0074
+title: "Structural node identity for dependency order and retained charge"
+status: proposed
+tags: [architecture, compiler, performance, query-engine]
+feature-flag: null
+created: 2026-08-17
+accepted:
+implemented:
+spec-sections: []
+superseded-by:
+relates: ["ADR-0063", "ADR-0071", "ADR-0073", "RUE-1381"]
+---
+
+# ADR-0074: Structural node identity for dependency order and retained charge
+
+## Status
+
+Proposed. Approved in principle by Steve Klabnik in session on 2026-08-16
+("yes, let's do all of those"); this document records the contract so the
+implementation has a falsifiable target. This is an internal query-engine
+design with no language-semantics change. It changes the *representation*
+of deterministic artifacts (published dependency order, retained-charge
+values) exactly once, never their determinism.
+
+## Summary
+
+A query node's identity is today the pair of formatted display strings
+`(family, key)` (`NodeIdentity` in `crates/rue-query/src/lib.rs:2228`):
+ordering compares the text (`:2320`), hashing hashes the text (`:2331`),
+the canonical published dependency order is family-then-key-text
+(`into_observations`, `:9321`, per RUE-1381), and the retained-memory
+charge is denominated in the text's byte length
+(`retained_terminal_charge`, `:11196`, charging `key().len()` for the
+published node and again for every observed dependency).
+
+Because presentation is load-bearing for ordering and memory policy, every
+memo-node incarnation must format its display identity eagerly: 32,912
+materializations retaining ~8.0 MB of key text on a fresh Lattice build.
+A full deferred-formatting prototype (2026-08-16, recorded in
+`docs/notes/post-adr-0063-cold-compiler-architecture-audit.md`) removed
+**zero** of them, because the ordinary path reads the text through exactly
+these two contracts; carving presentation bytes out of the retained charge
+alone regressed peak RSS by +4.9 MB to save 2.9 MB of text, because the
+formatted length was carrying real retention back-pressure.
+
+This ADR moves both contracts onto a structural identity so that display
+text becomes genuinely presentation-only, then re-lands the (previously
+falsified) lazy formatting on top:
+
+1. Every `QueryKey` gains a deterministic, content-derived 128-bit
+   **stable key hash**, computed from the typed key's fields with a fixed,
+   keyed-with-a-compile-time-constant hasher — never from the formatted
+   string, and never from addresses, allocation order, or scheduling.
+2. `NodeIdentity` ordering, equality, and hashing become
+   `(family, stable_hash)` with formatted text as a lazily-computed, cold
+   tiebreaker that is only reachable on a 128-bit hash collision between
+   distinct keys of the same family.
+3. The canonical published dependency order (RUE-1381) is redefined as
+   `(family, stable_hash, incarnation)`. The order remains fully
+   deterministic across runs and worker counts; it is one-time different
+   from today's text order.
+4. `retained_terminal_charge` is re-denominated in structural units: the
+   fixed sizes it already counts, plus the actual retained payload sizes,
+   plus a fixed 16-byte identity charge per node/observation in place of
+   `family().len() + key().len()`. The retained-byte budget is
+   recalibrated once so the steady-state retained working set on the
+   ADR-0071 reference workloads is unchanged (measured, not assumed —
+   the falsified prototype proved the charge is real back-pressure).
+5. Memo-node display identities become lazy: formatted on first
+   diagnostic, cycle render, abort, or debug dump that needs a name.
+   `display_identities.memo_node_materializations` then counts actual
+   formatting events; its doc and `docs/process/compiler-scaling.md`
+   already describe the current node-tracking semantics and are updated
+   again to the new meaning.
+
+## What this buys
+
+- ~33k eager string formats and ~8 MB of retained text per fresh Lattice
+  build disappear from the ordinary path (measured 24,079 of them are
+  attributable to the ordering contract alone; the remainder to the
+  retained charge).
+- `NodeIdentity::cmp` and `Hash` become integer comparisons; `Task::pop`
+  and every ordered dependency publication stop touching string bytes.
+- Identity `Arc<str>` pairs shrink to a 16-byte inline hash plus a lazy
+  slot, reducing per-node retained footprint and pointer chasing.
+
+## Falsifiers
+
+The implementation must land with tests that fail if any of these break:
+
+- **Determinism**: two fresh builds of the same inputs publish identical
+  dependency orders and identical retained-charge values, including under
+  different worker counts (`-j1` vs `-j4`) and across process runs (the
+  hash must not be seeded per-process).
+- **Collision safety**: a forced hash collision between two distinct keys
+  (test-only hasher override) still yields a total, deterministic order
+  via the text tiebreaker, and distinct identities never compare equal.
+- **Presentation identity**: diagnostic, cycle-render, and abort text is
+  byte-identical to today's (the pinned cycle-render test from 2026-08-16
+  must pass unchanged); `Debug` formatting still materializes
+  (`session.rs` pins `format!("{:?}", dependency.node)`).
+- **Emitted bytes**: compiled executables are byte-identical on the
+  ADR-0071 reference workloads and the chain fixtures.
+- **Retention neutrality**: median peak RSS on Lattice within ±2% of
+  pre-change after budget recalibration.
+
+## One-time rebaselines (expected, bounded)
+
+- Deterministic `compiler_work` counters whose values encode the current
+  text order (validation visit order, early-exit points) shift once.
+  The falsifier is that they are *identical across runs* after the
+  change, not that they match old values.
+- Any golden artifact embedding the published observation order is
+  regenerated once in the same change.
+
+## Rejected alternatives
+
+- **Ordinal identities assigned at first publication**: deterministic
+  only single-worker; violates the worker-count falsifier.
+- **`runtime_identity: Option<u64>`** (already on `NodeIdentityData`):
+  incarnation-scoped and allocation-ordered; same violation.
+- **Keeping text order, deferring formatting** (the 2026-08-16
+  prototype): measured to remove nothing; recorded in the audit note.
+- **64-bit hash**: collision probability at ~10^5–10^6 keys per family is
+  no longer ignorable across the ecosystem's lifetime; 128-bit keeps the
+  tiebreaker theoretical while the cold path guarantees correctness
+  anyway.
+
+## Implementation shape
+
+`QueryKey` trait gains `fn stable_hash(&self, hasher: &mut StableHasher)`
+alongside `stable_identity()`; the runtime computes the 128-bit digest at
+node mint (cheap: hashes typed fields, no allocation), stores it inline in
+`NodeIdentityData`, and keeps `key: OnceLock<Arc<str>>` for presentation.
+`retained_terminal_charge` swaps the two `len()` terms per the contract
+above; the budget constant is recalibrated in the same commit from
+paired-run RSS measurements. Falsifier tests live next to the existing
+ADR-0073 falsifiers in `rue-query`.

--- a/docs/designs/0075-wave-granular-import-discovery.md
+++ b/docs/designs/0075-wave-granular-import-discovery.md
@@ -1,7 +1,7 @@
 ---
 id: 0075
 title: "Wave-granular import discovery revisions and cumulative exhaustion witness"
-status: proposed
+status: proposal
 tags: [architecture, compiler, incremental, performance, query-engine]
 feature-flag: null
 created: 2026-08-17

--- a/docs/designs/0075-wave-granular-import-discovery.md
+++ b/docs/designs/0075-wave-granular-import-discovery.md
@@ -1,0 +1,158 @@
+---
+id: 0075
+title: "Wave-granular import discovery revisions and cumulative exhaustion witness"
+status: proposed
+tags: [architecture, compiler, incremental, performance, query-engine]
+feature-flag: null
+created: 2026-08-17
+accepted:
+implemented:
+spec-sections: []
+superseded-by:
+relates: ["ADR-0063", "ADR-0071", "ADR-0073", "ADR-0074"]
+---
+
+# ADR-0075: Wave-granular import discovery revisions and cumulative exhaustion witness
+
+## Status
+
+Proposed. Approved in principle by Steve Klabnik in session on 2026-08-16;
+this document records the contract and the invalidation cases so the
+implementation has a falsifiable target. No language-semantics change: the
+final published import plan, resolution results, and emitted bytes are
+byte-identical. What changes is the *granularity* of discovery's revision
+ledger — a deliberate coarsening of the incremental story during
+discovery, spelled out below.
+
+## Summary
+
+Import discovery is semantically one-import-hop deep per round: each round
+resolves the currently-known open imports, batch-publishes the newly
+discovered sources as one immutable input revision, and only then may the
+next layer's imports be resolved against it. A depth-n chain therefore
+takes n rounds *by contract*. The 2026-08-16 work made each round's
+marginal cost small — certificate misses O(1) (ADR-0073), frontier
+dispatch delta-scoped, per-round plan reads delta-scoped — but the round
+*count* itself remains O(depth), and every round still pays fixed
+overheads (revision mint, ledger append, batch publication, validation
+sweep, thread coordination). On the 1,024-module chain those fixed costs
+dominate what remains of the multi-second discovery phase; no per-round
+optimization can remove them because the contract mandates the rounds.
+
+This ADR changes the unit of publication from the import *hop* to the
+discovery *wave*:
+
+1. Within a round, after resolving open imports yields newly discovered
+   sources, the loop reads and parses those sources immediately and
+   resolves *their* imports in the same round, iterating until the
+   frontier yields no new sources. One wave = the transitive closure
+   reachable from the round's starting open set.
+2. The wave then batch-publishes **one** input revision containing every
+   source it discovered, with the ledger recording every read the wave
+   performed, in the same deterministic order the per-hop contract would
+   have recorded them (module-path order within discovery order — the
+   exact order is part of the implementation's falsifier, derived from
+   the current per-round order, not invented).
+3. A depth-n chain thus publishes O(1) discovery revisions instead of n.
+   Rounds still exist (a wave can be followed by another if publication
+   raises new demand); the loop structure, fail-closed frontier guard,
+   and re-close path are unchanged.
+4. The closing whole-plan re-root — one O(plan) dispatch that exists so
+   `publish_trusted_toolchain_successor`'s witness can verify "the whole
+   predecessor plan is exhausted" — is replaced by a **cumulative
+   witness**: the union of dispatched roots provably covers the plan
+   (maintained incrementally as a count/bitmask over plan segments, not
+   recomputed), and the final wave's frontier returned no new demand.
+   The witness remains fail-closed: if the cumulative record cannot
+   prove coverage, the whole-plan re-root runs as today.
+
+## What this buys
+
+- The last O(depth) structural factor in discovery. With per-round costs
+  already delta-scoped, wave-granularity turns a depth-n chain's
+  discovery into O(n) total work with O(1) revision overhead — this is
+  the difference between "deep dependency chains are a pathological
+  shape" and "depth is free."
+- Lattice (import depth ≈ 12) drops ~11 revision publications and their
+  validation sweeps from every fresh build.
+- The closing re-root's O(plan) dispatch disappears in the common case.
+
+## What this costs: invalidation granularity during discovery
+
+Today, a source file that changes *between rounds* is caught at the next
+round's revision publication (stamp mismatch on the recorded read), and
+invalidation re-runs from that round. Under waves:
+
+- **Mid-wave mutation.** A source read early in a wave that changes
+  before the wave publishes is caught at wave publication — every read
+  the wave performed is stamp-verified at publish, batch, fail-closed.
+  The re-run unit is the wave, not the hop. This is strictly coarser
+  re-execution on a strictly narrower race window (discovery of a
+  typical project is tens of milliseconds), and it can never publish a
+  revision that mixes stale and fresh stamps — the falsifier below.
+- **Interruption/resume.** A discovery interrupted mid-wave resumes from
+  the last published revision, re-running the whole wave. Today it
+  resumes from the last hop. Deep-chain cold builds trade at most one
+  wave of redone work (bounded by the plan) for n−1 avoided
+  publications; incremental builds are unaffected because their
+  discovery starts from a full previous plan and typically completes in
+  a single trivial wave.
+- **Downstream consumers of revision identity** (ADR-0073 epochs,
+  certificates) see fewer, larger revisions. ADR-0073's monotonicity
+  proof obligations are per-publication and carry over unchanged — a
+  wave publication is still strictly additive; it is *more* additive at
+  once.
+
+## Falsifiers
+
+- **Plan identity**: final published plan, resolution diagnostics, and
+  emitted executables byte-identical on the ADR-0071 reference workloads,
+  chain fixtures (n = 64/256/1024), and the answered-but-still-open
+  fixture from the 2026-08-16 rooting change.
+- **Stamp atomicity**: a test mutating a source mid-wave (test hook
+  between wave read and wave publish) must observe a fail-closed wave
+  re-run and a published revision whose recorded reads all verify; no
+  mixed-stamp revision can ever be observed.
+- **Revision count**: chain fixtures publish O(1) discovery revisions
+  (premerge-gated exact count per fixture, alongside the existing
+  `certificate_misses` and `import_frontier_roots_requested` gates).
+- **Witness soundness**: a test that forges an uncovered plan segment
+  (test-only) must see the cumulative witness refuse and the whole-plan
+  re-root fire — the fallback stays reachable and correct.
+- **Determinism**: ledger read order and revision contents identical
+  across runs and worker counts.
+
+## One-time rebaselines (expected, bounded)
+
+Deterministic counters that count per-revision events (revisions
+published, validation sweeps, ledger appends, per-round dispatch families)
+shift once to their wave-granular values; the chain premerge gates are
+re-pinned to the new exact counts in the same change. Counters for parse,
+semantic, CFG, codegen, and link work must be byte-identical — waves
+reorder *when* discovery work happens, never *what* work happens.
+
+## Rejected alternatives
+
+- **Speculative parallel resolution across future rounds**: reintroduces
+  scheduling-dependent work sets; violates the determinism falsifier.
+- **Removing rounds entirely** (single implicit wave with streaming
+  publication): erases the fail-closed batch verification point that
+  makes mid-discovery mutation detection deterministic; the wave keeps
+  the barrier, there is just one barrier per closure instead of per hop.
+- **Relaxing the witness without the cumulative record** (trust the
+  frontier's empty answer alone): weaker than today's contract; the
+  cumulative coverage record keeps the witness's meaning intact.
+
+## Implementation shape
+
+The round loop in `crates/rue/src/source_loader.rs` gains an inner
+wave-extension loop between "resolve open imports" and "publish": drain
+the frontier's newly-demanded sources through read + parse + resolve,
+accumulating reads and discovered sources, publishing once at fixpoint.
+The plan-membership guard, `round_roots`, and re-close path are reused
+as-is (a wave is a round whose root set grows during execution). The
+cumulative coverage witness is a per-plan-segment counter maintained by
+the same code that maintains the delta segments today. Falsifier fixtures
+extend the existing 32-module driver test and chain premerge gates.
+Sequencing: implementation starts after the in-flight delta-scoping
+change lands (same files); ADR-0074 is independent (different crate).

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -236,4 +236,6 @@ The table is generated from ADR frontmatter. Run
 | [0071](0071-release-quality-compiler-performance-contract.md) | Release-quality compiler performance contract | Accepted | architecture, compiler, performance, process |
 | [0072](0072-runtime-benchmarking-static-site-generator.md) | Runtime performance benchmarking anchored by a Rue static site generator | Accepted | performance, benchmarking, process, examples, stdlib |
 | [0073](0073-validation-certificate-durability.md) | Validation-certificate durability across append-only revisions | Accepted | architecture, compiler, incremental, performance, query-engine |
+| [0074](0074-structural-node-identity.md) | Structural node identity for dependency order and retained charge | Proposed | architecture, compiler, performance, query-engine |
+| [0075](0075-wave-granular-import-discovery.md) | Wave-granular import discovery revisions and cumulative exhaustion witness | Proposed | architecture, compiler, incremental, performance, query-engine |
 <!-- ADR-INDEX:END -->

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -236,6 +236,6 @@ The table is generated from ADR frontmatter. Run
 | [0071](0071-release-quality-compiler-performance-contract.md) | Release-quality compiler performance contract | Accepted | architecture, compiler, performance, process |
 | [0072](0072-runtime-benchmarking-static-site-generator.md) | Runtime performance benchmarking anchored by a Rue static site generator | Accepted | performance, benchmarking, process, examples, stdlib |
 | [0073](0073-validation-certificate-durability.md) | Validation-certificate durability across append-only revisions | Accepted | architecture, compiler, incremental, performance, query-engine |
-| [0074](0074-structural-node-identity.md) | Structural node identity for dependency order and retained charge | Proposed | architecture, compiler, performance, query-engine |
-| [0075](0075-wave-granular-import-discovery.md) | Wave-granular import discovery revisions and cumulative exhaustion witness | Proposed | architecture, compiler, incremental, performance, query-engine |
+| [0074](0074-structural-node-identity.md) | Structural node identity for dependency order and retained charge | Proposal | architecture, compiler, performance, query-engine |
+| [0075](0075-wave-granular-import-discovery.md) | Wave-granular import discovery revisions and cumulative exhaustion witness | Proposal | architecture, compiler, incremental, performance, query-engine |
 <!-- ADR-INDEX:END -->


### PR DESCRIPTION
Records the two semantics-adjacent contract changes Steve approved for the speed campaign, with falsifiers spelled out before any implementation lands (same discipline as ADR-0073).

**ADR-0074 — Structural node identity.** `NodeIdentity` is today a pair of formatted display strings: ordering, hashing, the RUE-1381 published dependency order, and the retained-memory charge all consume the text, which is why the 2026-08-16 lazy-display prototype removed zero of the 32,912 eager materializations (that measured rejection is recorded in the audit note merged in #2462). The ADR gives every `QueryKey` a content-derived 128-bit stable hash; order/equality/hash become `(family, stable_hash)` with lazily-formatted text as the cold collision tiebreaker; the retained charge is re-denominated in structural units with a one-time budget recalibration; lazy display formatting then actually works. Falsifiers cover cross-run and cross-worker-count determinism, forced-collision totality, byte-identical diagnostics/executables, and RSS neutrality. One-time rebaseline: counters encoding the current text order shift once.

**ADR-0075 — Wave-granular discovery.** A depth-n import chain takes n discovery rounds *by contract* — one hop per revision publication. With per-round costs now delta-scoped (ADR-0073, #2457), the round count itself is the last O(depth) structural factor. The ADR makes a round resolve transitively (read/parse/resolve newly discovered sources within the same round), publishing one revision per wave: O(1) discovery revisions per chain, ~11 publications dropped from every fresh Lattice build. The closing whole-plan re-root is replaced by a cumulative fail-closed exhaustion witness with the re-root as the unprovable-coverage fallback. The invalidation coarsening (mid-wave mutation → wave-granular fail-closed re-run; batch stamp verification at publish) is enumerated with falsifiers, including a mid-wave-mutation test hook requirement and premerge-gated revision counts on the chain fixtures.

Sequencing: ADR-0074 implementation is `rue-query`-local and can start immediately; ADR-0075 implementation starts after the in-flight delta-scoping change lands (same files).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTiBg7df72iMgdpAFv5wZs)_