### PR TITLE
RUE-1472: reserve ELF parser capacities

### DIFF
--- a/crates/rue-linker/src/elf.rs
+++ b/crates/rue-linker/src/elf.rs
@@ -990,8 +990,16 @@ impl ObjectFile {
         }
 
         // Parse section headers
-        let mut sections = Vec::new();
-        let mut section_map = HashMap::new();
+        // A truncated table may claim the maximum u16 section count, so cap
+        // reservations by the number of complete headers present in `data`.
+        // Valid tables still reserve their exact declared count.
+        let section_capacity = if e_shentsize >= ELF64_SHDR_SIZE {
+            e_shnum.min(data.len().saturating_sub(e_shoff) / e_shentsize)
+        } else {
+            0
+        };
+        let mut sections = Vec::with_capacity(section_capacity);
+        let mut section_map = HashMap::with_capacity(section_capacity);
         let mut symtab_idx = None;
         let mut strtab_idx = None;
 
@@ -1007,7 +1015,7 @@ impl ObjectFile {
             entsize: u64,
         }
 
-        let mut raw_sections = Vec::new();
+        let mut raw_sections = Vec::with_capacity(section_capacity);
 
         for i in 0..e_shnum {
             let sh_offset = e_shoff + i * e_shentsize;
@@ -1170,6 +1178,13 @@ impl ObjectFile {
                 return Err(ParseError::InvalidSymbol("zero entsize".into()));
             }
             let sym_count = symtab.size / symtab.entsize;
+            // Avoid speculative allocation for an undersized entry width: the
+            // existing per-entry bounds check must reject that malformed table.
+            if symtab.entsize >= ELF64_SYM_SIZE as u64 {
+                if let Ok(capacity) = usize::try_from(sym_count) {
+                    let _ = symbols.try_reserve(capacity);
+                }
+            }
             for i in 0..sym_count {
                 let sym_offset = (i * symtab.entsize) as usize;
                 if sym_offset + ELF64_SYM_SIZE > symtab_data.len() {
@@ -1271,6 +1286,13 @@ impl ObjectFile {
                 continue; // Skip malformed relocation sections
             }
             let rela_count = raw.size / raw.entsize;
+            // As with symbols, malformed undersized entries must reach the
+            // existing bounds check without a large speculative allocation.
+            if raw.entsize >= ELF64_RELA_SIZE as u64 {
+                if let Ok(capacity) = usize::try_from(rela_count) {
+                    let _ = sections[target_section].relocations.try_reserve(capacity);
+                }
+            }
 
             for j in 0..rela_count {
                 let rela_offset = (j * raw.entsize) as usize;
@@ -1977,6 +1999,27 @@ mod tests {
         assert!(matches!(
             ObjectFile::parse(&data),
             Err(ParseError::InvalidSection(_))
+        ));
+    }
+
+    #[test]
+    fn test_large_section_count_short_table_fails_before_reserving_claimed_count() {
+        let mut data = [0u8; ELF64_EHDR_SIZE];
+        data[0..4].copy_from_slice(&ELF_MAGIC);
+        data[EI_CLASS] = ELFCLASS64;
+        data[EI_DATA] = ELFDATA2LSB;
+        data[E_TYPE_OFFSET..E_TYPE_OFFSET + 2].copy_from_slice(&ET_REL.to_le_bytes());
+        data[E_MACHINE_OFFSET..E_MACHINE_OFFSET + 2].copy_from_slice(&EM_X86_64.to_le_bytes());
+        data[E_SHOFF_OFFSET..E_SHOFF_OFFSET + 8]
+            .copy_from_slice(&(ELF64_EHDR_SIZE as u64).to_le_bytes());
+        data[E_SHENTSIZE_OFFSET..E_SHENTSIZE_OFFSET + 2]
+            .copy_from_slice(&(TEST_SHDR_SIZE as u16).to_le_bytes());
+        data[E_SHNUM_OFFSET..E_SHNUM_OFFSET + 2].copy_from_slice(&u16::MAX.to_le_bytes());
+
+        assert!(matches!(
+            ObjectFile::parse(&data),
+            Err(ParseError::InvalidSection(message))
+                if message == "section header out of bounds"
         ));
     }
 


### PR DESCRIPTION
## Summary

- reserve ELF section metadata containers from the validated section-table extent
- reserve symbol and relocation storage only after validating entry sizes and checked counts
- preserve malformed-input behavior, including the oversized section-count diagnostic

## Why this seam

The controlled post-#2466 profile showed allocation/free work dominating leaf samples, with `ObjectFile::parse` the largest specific Rue leaf (10 samples). The ELF parser knew exact metadata counts but grew its section, symbol, and relocation collections from zero. This change uses those already-validated counts without changing archive ownership or linker architecture.

## Performance falsifier

Sixteen alternating fresh-process, one-worker, `-O3` Lattice pairs against exact trunk `b2cd40bff`:

- retired instructions: **-0.0868%** median, MAD 0.0227%, 15/16 wins
- `link_parse_objects`: **-16.8556%**, 15/16 wins
- `link_archive_resolve`: **-16.7473%**, 14/16 wins
- full linker: **-11.8871%**, 13/16 wins
- root wall time: -0.4083%, 12/16 wins
- cycles: -0.2790%, 12/16 wins
- RSS: -0.0792%, 12/16 wins

Four alternating allocation-instrumented pairs:

- allocation calls: -11,130 to -11,537 (-0.1186% to -0.1229%)
- requested bytes: -6,910,172 to -7,267,692 (-0.4356% to -0.4581%)

## Correctness

- executable SHA-256 identical: `b893e76cfabed737b149d0e8c4d8527077dedd17da78418db20a28a7d30885e5`
- canonical `compiler_work`, `source_metrics`, `emitted_output`, and `compiler_boundary` JSON exact
- malformed maximum-section-count regression preserves `InvalidSection("section header out of bounds")`
- `scripts/rue quick`: 30/30
- differential oracle: 4/4
- linker-focused tests and Clippy clean

Linear: RUE-1472
