### PR TITLE
Scope discovery rounds to the reads and measurements they change

### DIFF
--- a/crates/rue-compiler/src/diagnostic_attempt_store.rs
+++ b/crates/rue-compiler/src/diagnostic_attempt_store.rs
@@ -287,7 +287,7 @@ impl DiagnosticAttemptStore {
             {
                 continue;
             }
-            source_bytes += source.files().map(|file| file.source.len()).sum::<usize>();
+            source_bytes += source.total_source_bytes();
             attempts.push(source);
         }
         DiagnosticRetentionMetrics {

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -1118,9 +1118,7 @@ fn extend_accepted_from_site<'a>(
 
 /// The canonical order and deduplication every accepted-source set is published
 /// in, whichever occurrences it was reduced from.
-fn canonicalize_accepted<'a>(
-    mut accepted: Vec<&'a AcceptedImportSource>,
-) -> Vec<&'a AcceptedImportSource> {
+fn canonicalize_accepted(mut accepted: Vec<&AcceptedImportSource>) -> Vec<&AcceptedImportSource> {
     accepted.sort_by(|left, right| {
         left.requested_path
             .cmp(&right.requested_path)

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -741,6 +741,25 @@ impl ImportDemandFrontier {
             .flat_map(|requests| requests.iter())
             .map(ImportDiscoveryRequest::occurrence)
     }
+
+    /// The occurrences whose ledger answers changed since the previous round's
+    /// reads were assembled: this frontier's own demanded occurrences, plus the
+    /// previous frontier's.
+    ///
+    /// A round assembles from a ledger holding the carried observations plus its
+    /// own batch's answers. The previous round's fanout answers — the extra
+    /// occurrences that shared one host read — only enter the carried ledger when
+    /// that batch is published, so they first become assemblable here; this
+    /// round's own batch supplies the rest. Every occurrence outside the union
+    /// carries the observations it already carried, so its winner cannot change.
+    pub(crate) fn round_read_roots(&self, previous: &ImportDemandFrontier) -> ImportDemandRoots {
+        ImportDemandRoots::new(
+            previous
+                .demanded_occurrences()
+                .chain(self.demanded_occurrences())
+                .cloned(),
+        )
+    }
 }
 
 /// Exact parser-owned import occurrences demanded by canonical query
@@ -1014,6 +1033,43 @@ impl ImportDiscoveryPlan {
     ) -> Vec<&'a AcceptedImportSource> {
         accepted_sources_for(self.groups.delta_segment().iter(), ledger)
     }
+
+    /// The accepted sources of exactly `occurrences`, resolved by the same
+    /// candidate precedence as [`Self::accepted_sources`].
+    ///
+    /// One ordinary discovery round only changes the ledger at the occurrences
+    /// its own and its predecessor round's frontier demanded answers for; every
+    /// other occurrence carries the identical observations it carried when it was
+    /// last assembled, so re-deriving its winner re-proves an already assembled
+    /// conclusion. Reducing exactly the changed occurrences therefore yields the
+    /// same new accepted sources, in the same canonical order, as reducing the
+    /// whole plan — while costing O(changed occurrences · log n) rather than
+    /// O(plan) per round.
+    ///
+    /// Each occurrence's candidate groups are found by binary search: every
+    /// request in a plan carries the plan's own context, so the canonical group
+    /// order sorts by context and then by occurrence, and one occurrence's groups
+    /// are a contiguous range of every stored segment.
+    pub(crate) fn accepted_sources_at<'a>(
+        &'a self,
+        ledger: &'a ImportObservationLedger,
+        occurrences: &ImportDemandRoots,
+    ) -> Vec<&'a AcceptedImportSource> {
+        let mut accepted = Vec::new();
+        let mut candidates: Vec<&Arc<[ImportDiscoveryRequest]>> = Vec::new();
+        for occurrence in occurrences.occurrences() {
+            candidates.clear();
+            self.groups.for_each_matching(
+                |group| (&group[0].context, &group[0].occurrence).cmp(&(&self.context, occurrence)),
+                |group| candidates.push(group),
+            );
+            // Segment-local ranges arrive segment by segment; candidate
+            // precedence is the canonical group order.
+            candidates.sort_by(|left, right| group_order(left, right));
+            extend_accepted_from_site(&mut accepted, candidates.iter().copied(), ledger);
+        }
+        canonicalize_accepted(accepted)
+    }
 }
 
 /// The winning accepted sources across a set of candidate request groups.
@@ -1028,24 +1084,43 @@ fn accepted_sources_for<'a>(
     }
     let mut accepted = Vec::new();
     for groups in by_site.values() {
-        for group in groups {
-            if group
-                .iter()
-                .any(|request| ledger.get(request).is_some_and(|o| o.status.is_failure()))
-            {
-                break;
-            }
-            let present = group
-                .iter()
-                .filter_map(|request| ledger.get(request))
-                .filter_map(ImportObservation::accepted_source)
-                .collect::<Vec<_>>();
-            if !present.is_empty() {
-                accepted.extend(present);
-                break;
-            }
+        extend_accepted_from_site(&mut accepted, groups.iter().copied(), ledger);
+    }
+    canonicalize_accepted(accepted)
+}
+
+/// One occurrence's winner: the first candidate group, in precedence order, that
+/// observed a present read. A failed candidate ends the occurrence's precedence
+/// walk, and a later group is never consulted once an earlier one won.
+fn extend_accepted_from_site<'a>(
+    accepted: &mut Vec<&'a AcceptedImportSource>,
+    groups: impl Iterator<Item = &'a Arc<[ImportDiscoveryRequest]>>,
+    ledger: &'a ImportObservationLedger,
+) {
+    for group in groups {
+        if group
+            .iter()
+            .any(|request| ledger.get(request).is_some_and(|o| o.status.is_failure()))
+        {
+            break;
+        }
+        let present = group
+            .iter()
+            .filter_map(|request| ledger.get(request))
+            .filter_map(ImportObservation::accepted_source)
+            .collect::<Vec<_>>();
+        if !present.is_empty() {
+            accepted.extend(present);
+            break;
         }
     }
+}
+
+/// The canonical order and deduplication every accepted-source set is published
+/// in, whichever occurrences it was reduced from.
+fn canonicalize_accepted<'a>(
+    mut accepted: Vec<&'a AcceptedImportSource>,
+) -> Vec<&'a AcceptedImportSource> {
     accepted.sort_by(|left, right| {
         left.requested_path
             .cmp(&right.requested_path)
@@ -1508,6 +1583,12 @@ pub struct DiscoverySourceAssembler {
     /// Cumulative provenance entries appended by extension manifest builds —
     /// the only per-round manifest work once a lineage's first manifest exists.
     manifest_entries_appended: u64,
+    /// Cumulative accepted sources reduced out of a plan and offered to this
+    /// assembler — the exact per-round read volume. A round that reduces the
+    /// whole plan offers every already assembled leaf again, so this grows as
+    /// rounds times plan; a round that reduces only the occurrences it changed
+    /// keeps it linear in the discovered module count.
+    plan_reads_reduced: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -1739,6 +1820,7 @@ impl DiscoverySourceAssembler {
             appended_since_manifest: Vec::new(),
             manifest_entries_rebuilt: 0,
             manifest_entries_appended: 0,
+            plan_reads_reduced: 0,
         })
     }
 
@@ -1769,8 +1851,40 @@ impl DiscoverySourceAssembler {
                 "discovery plan belongs to a different epoch or captured context",
             ));
         }
+        let reduced = plan.accepted_sources(ledger);
+        self.plan_reads_reduced = self.plan_reads_reduced.saturating_add(reduced.len() as u64);
         let mut added = 0;
-        for source in plan.accepted_sources(ledger) {
+        for source in reduced {
+            added += usize::from(self.add_source(source)?);
+        }
+        Ok(added)
+    }
+
+    /// Add only the accepted reads of the occurrences one ordinary discovery
+    /// round changed. The rest of the plan carries the observations it carried
+    /// when it was last assembled, and assembly is idempotent for an already
+    /// assembled source, so this adds exactly what re-reducing the whole plan
+    /// would add — in the same canonical order, at O(changed occurrences) per
+    /// round instead of O(plan).
+    ///
+    /// `occurrences` is compiler-derived from the frontier values themselves
+    /// (see `ImportDemandFrontier::demanded_occurrences`); the host contributes
+    /// no membership claim of its own.
+    pub fn add_plan_round_reads(
+        &mut self,
+        plan: &ImportDiscoveryPlan,
+        ledger: &ImportObservationLedger,
+        occurrences: &ImportDemandRoots,
+    ) -> CompileResult<usize> {
+        if plan.context != self.context {
+            return Err(invalid_input(
+                "discovery plan belongs to a different epoch or captured context",
+            ));
+        }
+        let reduced = plan.accepted_sources_at(ledger, occurrences);
+        self.plan_reads_reduced = self.plan_reads_reduced.saturating_add(reduced.len() as u64);
+        let mut added = 0;
+        for source in reduced {
             added += usize::from(self.add_source(source)?);
         }
         Ok(added)
@@ -1789,8 +1903,10 @@ impl DiscoverySourceAssembler {
                 "discovery plan belongs to a different epoch or captured context",
             ));
         }
+        let reduced = plan.delta_accepted_sources(ledger);
+        self.plan_reads_reduced = self.plan_reads_reduced.saturating_add(reduced.len() as u64);
         let mut added = 0;
-        for source in plan.delta_accepted_sources(ledger) {
+        for source in reduced {
             added += usize::from(self.add_source(source)?);
         }
         Ok(added)
@@ -2066,6 +2182,14 @@ impl DiscoverySourceAssembler {
     /// Cumulative provenance entries appended by extension manifest builds.
     pub fn manifest_entries_appended(&self) -> u64 {
         self.manifest_entries_appended
+    }
+
+    /// Cumulative accepted sources reduced out of a plan and offered to this
+    /// assembler; see the field docs on `plan_reads_reduced`. This is the exact
+    /// per-round read volume, so a host can prove its rounds stay linear in the
+    /// discovered module count rather than rounds times plan.
+    pub fn plan_reads_reduced(&self) -> u64 {
+        self.plan_reads_reduced
     }
 }
 

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -595,6 +595,9 @@ struct ParsedSyntaxPayload {
 /// Immutable, Arc-shareable parsed syntax and exact local provenance.
 #[derive(Debug)]
 pub struct ParsedModule {
+    /// Memoized retained-artifact charge of this exact module value; see
+    /// [`Self::retained_allocation_charge`].
+    retained_charge: std::sync::OnceLock<u64>,
     revision: ModuleRevision,
     file_id: FileId,
     physical_path: Arc<str>,
@@ -660,7 +663,19 @@ impl ParsedModule {
     /// Charge the complete retained graph, including the immutable parser
     /// payload and the snapshot-local aliases derived from it. Aliased Arcs are
     /// charged once per reachable field rather than deduplicated by address.
+    ///
+    /// A module is immutable, so its charge is computed once per value and
+    /// memoized: the program a discovery round publishes is charged whole on
+    /// every publication and every retention measurement, and re-walking each
+    /// carried module's syntax on each of those is quadratic in the length of an
+    /// import chain. The memo answers with the number the walk produces.
     pub(crate) fn retained_allocation_charge(&self) -> u64 {
+        *self
+            .retained_charge
+            .get_or_init(|| self.walk_retained_allocation_charge())
+    }
+
+    fn walk_retained_allocation_charge(&self) -> u64 {
         let ast_charge = |ast: &Arc<Ast>| ast.retained_charge();
         let tokens_charge = |tokens: &[rue_lexer::Token]| std::mem::size_of_val(tokens) as u64;
         let imports_charge = |imports: &[ImportDirective]| {
@@ -953,6 +968,8 @@ impl ParsedModule {
         };
         function.name.name = foreign;
         Arc::new(Self {
+            // A perturbed module is a distinct value; it charges itself.
+            retained_charge: std::sync::OnceLock::new(),
             revision: self.revision.clone(),
             file_id: self.file_id,
             physical_path: self.physical_path.clone(),
@@ -1655,6 +1672,7 @@ fn bind_payload(
         })
         .collect::<Vec<_>>();
     Arc::new(ParsedModule {
+        retained_charge: std::sync::OnceLock::new(),
         revision,
         file_id,
         physical_path: Arc::from(snapshot.metadata().physical_path(file_id).unwrap()),

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -1163,6 +1163,12 @@ impl RetainedCharge for crate::SourceMetadata {
 
 impl RetainedCharge for crate::SourceSnapshot {
     fn retained_charge(&self) -> u64 {
+        self.memoized_retained_charge(|| self.walk_retained_charge())
+    }
+}
+
+impl crate::SourceSnapshot {
+    fn walk_retained_charge(&self) -> u64 {
         let records = self.metadata().file_ids().fold(0_u64, |charge, file_id| {
             charge
                 .saturating_add(std::mem::size_of::<(

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -671,6 +671,11 @@ pub struct CompilerSession {
     /// Protocol context only while the typed import-closure query is open.
     /// Closed attempts live exclusively in their plan or closure terminal.
     open_discovery: Option<Arc<ImportDiscoveryRevisionArtifact>>,
+    /// The exact snapshot and accepted-read manifest pair whose fail-closed
+    /// agreement this session has already proved, so a stage extending that pair
+    /// re-proves only its own appended entries. Both values are immutable, so
+    /// holding them is what makes the structural-extension proof below sound.
+    validated_accepted_reads: Option<(SourceSnapshot, crate::AcceptedReadManifest)>,
     /// Trusted-toolchain continuation state (RUE-1112). Set only at a
     /// successful import-discovery close and single-use: consumed by a
     /// successful `publish_trusted_toolchain_successor`, and cleared on any new
@@ -2296,6 +2301,47 @@ impl CompilerSession {
         )
     }
 
+    /// Prove the staged snapshot and its accepted-read provenance manifest agree,
+    /// fail-closed, before anything is staged from them.
+    ///
+    /// A stage whose snapshot AND manifest are both direct structural extensions
+    /// of the exact pair this session last proved re-checks only the appended
+    /// entries. The prefix is not assumed unchanged: both values are immutable
+    /// and the extension proof is pointer lineage, so the retained prefix IS the
+    /// pair already checked. Any other stage — a fresh lineage, a rebuilt
+    /// snapshot, a manifest that compacted away its lineage — re-checks the whole
+    /// pair, which is also what a mid-discovery source change lands on, because a
+    /// changed source cannot appear as an extension of an already proved pair.
+    fn validate_staged_accepted_reads(
+        &mut self,
+        snapshot: &SourceSnapshot,
+        accepted_reads: &crate::AcceptedReadManifest,
+    ) -> Result<(), CompileErrors> {
+        let extension = self.validated_accepted_reads.as_ref().and_then(
+            |(previous_snapshot, previous_reads)| {
+                let files = snapshot.direct_appended_file_ids_from(previous_snapshot)?;
+                let entries = accepted_reads
+                    .segments()
+                    .direct_delta_from(previous_reads.segments())?;
+                Some((files, entries, previous_reads))
+            },
+        );
+        match extension {
+            Some((files, entries, previous_reads)) => {
+                validate_appended_accepted_reads(
+                    snapshot,
+                    accepted_reads,
+                    previous_reads,
+                    &files,
+                    entries,
+                )?;
+            }
+            None => validate_accepted_read_manifest(snapshot, accepted_reads)?,
+        }
+        self.validated_accepted_reads = Some((snapshot.clone(), accepted_reads.clone()));
+        Ok(())
+    }
+
     fn stage_import_discovery_inner(
         &mut self,
         snapshot: &SourceSnapshot,
@@ -2335,7 +2381,7 @@ impl CompilerSession {
         // attempts are retained as projections of the canonical frontier.
         self.open_discovery = None;
         let source_revision = snapshot.source_revision().clone();
-        if let Err(errors) = validate_accepted_read_manifest(snapshot, &accepted_reads) {
+        if let Err(errors) = self.validate_staged_accepted_reads(snapshot, &accepted_reads) {
             let diagnostic_snapshot = self.publish_import_diagnostics(
                 snapshot,
                 Some(context.clone()),
@@ -6503,6 +6549,62 @@ fn validate_accepted_read_manifest(
                     "accepted read manifest content does not match logical module {module}"
                 )),
             )));
+        }
+    }
+    Ok(())
+}
+
+/// The appended half of [`validate_accepted_read_manifest`], for a snapshot and
+/// manifest that both directly extend an already validated pair. It proves the
+/// same properties over the appended entries: the manifest covers the snapshot
+/// exactly, names no module twice, and carries each source's exact content
+/// fingerprint. Failure messages match the whole-pair check, because a caller
+/// cannot observe which half proved the disagreement.
+fn validate_appended_accepted_reads(
+    snapshot: &SourceSnapshot,
+    accepted_reads: &crate::AcceptedReadManifest,
+    previous_reads: &crate::AcceptedReadManifest,
+    appended_files: &[crate::FileId],
+    appended_entries: &[crate::AcceptedReadManifestEntry],
+) -> Result<(), CompileErrors> {
+    let reject = |message: String| {
+        Err(CompileErrors::from(CompileError::without_span(
+            ErrorKind::InvalidCompilerInput(message),
+        )))
+    };
+    if accepted_reads.len() != snapshot.len() {
+        return reject("accepted read manifest does not cover the staging source snapshot".into());
+    }
+    if appended_entries.len() != appended_files.len() {
+        // Equal totals over equal prefixes make this unreachable; a pair that
+        // reaches it is not the shape this delta check reasons about, so it is
+        // proved by the whole-pair check rather than diagnosed from here.
+        return validate_accepted_read_manifest(snapshot, accepted_reads);
+    }
+    for entry in appended_entries {
+        if previous_reads.find_module(entry.module()).is_some() {
+            return reject("accepted read manifest contains duplicate logical modules".into());
+        }
+    }
+    for file_id in appended_files {
+        let module = snapshot
+            .module_id(*file_id)
+            .expect("snapshot files have logical module IDs");
+        let Ok(index) = appended_entries.binary_search_by(|entry| entry.module().cmp(module))
+        else {
+            return reject(format!(
+                "accepted read manifest is missing logical module {module}"
+            ));
+        };
+        let source = snapshot
+            .source(*file_id)
+            .expect("snapshot files retain their source text");
+        if appended_entries[index].content_fingerprint()
+            != crate::import_discovery::source_fingerprint(source.source)
+        {
+            return reject(format!(
+                "accepted read manifest content does not match logical module {module}"
+            ));
         }
     }
     Ok(())

--- a/crates/rue-compiler/src/shared_segments.rs
+++ b/crates/rue-compiler/src/shared_segments.rs
@@ -138,6 +138,26 @@ impl<T> SharedSegments<T> {
         None
     }
 
+    /// Every element comparing `Equal` under `f`, by binary search for the equal
+    /// range of each sorted segment — O(segments · log n + matches), with no
+    /// materialization and no whole-sequence scan. `f` must be consistent with
+    /// the canonical order, so each segment's matches are contiguous. Matches are
+    /// yielded segment by segment; a caller needing canonical order across
+    /// segments sorts the (small) result itself.
+    pub(crate) fn for_each_matching<'a>(
+        &'a self,
+        f: impl Fn(&T) -> Ordering,
+        mut visit: impl FnMut(&'a T),
+    ) {
+        for segment in self.segments.iter() {
+            let start = segment.partition_point(|value| f(value) == Ordering::Less);
+            let end = segment.partition_point(|value| f(value) != Ordering::Greater);
+            for value in &segment[start..end] {
+                visit(value);
+            }
+        }
+    }
+
     /// Iterate the logical merged sequence in canonical order without allocating
     /// the merged buffer (a small per-segment cursor vector aside).
     pub(crate) fn iter(&self) -> MergeIter<'_, T> {

--- a/crates/rue-compiler/src/source_snapshot.rs
+++ b/crates/rue-compiler/src/source_snapshot.rs
@@ -30,6 +30,15 @@ pub struct SourceSnapshot {
 
 #[derive(Debug)]
 struct SourceSnapshotData {
+    /// Memoized retained-artifact charge of this exact snapshot value. The
+    /// charge is a pure function of immutable data, so computing it once per
+    /// value yields the identical number every retention pass would recompute.
+    /// Discovery retains one snapshot per frontier round and re-measures the
+    /// retained set every round, so recomputing the whole-snapshot walk on each
+    /// measurement is quadratic in the length of an import chain.
+    retained_charge: std::sync::OnceLock<u64>,
+    /// Memoized total retained source bytes; see [`SourceSnapshot::total_source_bytes`].
+    source_bytes: std::sync::OnceLock<usize>,
     metadata: SourceMetadata,
     /// `Arc`-shared size-tiered record segments, oldest first. Untouched tiers
     /// stay shared; compacted tail tiers copy only record metadata and retain
@@ -188,6 +197,8 @@ impl SourceSnapshot {
 
         Ok(Self {
             data: Arc::new(SourceSnapshotData {
+                retained_charge: std::sync::OnceLock::new(),
+                source_bytes: std::sync::OnceLock::new(),
                 metadata,
                 len: contents.len(),
                 segments: vec![Arc::new(SnapshotSegment::from_records(contents))],
@@ -308,6 +319,8 @@ impl SourceSnapshot {
 
         Ok(Self {
             data: Arc::new(SourceSnapshotData {
+                retained_charge: std::sync::OnceLock::new(),
+                source_bytes: std::sync::OnceLock::new(),
                 metadata,
                 len: contents.len(),
                 segments: vec![Arc::new(SnapshotSegment::from_records(contents))],
@@ -347,6 +360,25 @@ impl SourceSnapshot {
     #[inline]
     pub fn len(&self) -> usize {
         self.data.len
+    }
+
+    /// This snapshot value's retained-artifact charge, computed by `charge` on
+    /// first use and memoized for the life of the value. The snapshot is
+    /// immutable, so the memo and a fresh walk are the same number.
+    pub(crate) fn memoized_retained_charge(&self, charge: impl FnOnce() -> u64) -> u64 {
+        *self.data.retained_charge.get_or_init(charge)
+    }
+
+    /// Total retained source bytes across this snapshot's files, memoized for
+    /// the life of the immutable value. Retention measurement asks every
+    /// retained diagnostic attempt for this number, and discovery re-measures
+    /// once per frontier round.
+    pub(crate) fn total_source_bytes(&self) -> usize {
+        *self.data.source_bytes.get_or_init(|| {
+            (0..self.data.len)
+                .map(|index| self.record_at(index).text.len())
+                .sum()
+        })
     }
 
     /// Whether this snapshot contains no source files.
@@ -559,6 +591,8 @@ impl SourceSnapshot {
         let len = base.data.len + appended_len;
         Ok(SourceSnapshot {
             data: Arc::new(SourceSnapshotData {
+                retained_charge: std::sync::OnceLock::new(),
+                source_bytes: std::sync::OnceLock::new(),
                 metadata,
                 segments,
                 segment_offsets,

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -73,6 +73,19 @@ pub fn plan_round_roots(
     plan.round_roots(previous)
 }
 
+/// The occurrences one ordinary discovery round must assemble reads for: the
+/// occurrences `current` and `previous` demanded host answers for. Every other
+/// occurrence carries the observations it carried when it was last assembled, so
+/// assembling this union adds exactly what re-reducing the whole plan would add.
+/// Both halves come from the compiler-owned frontier values; the host supplies
+/// no membership of its own.
+pub fn plan_round_read_roots(
+    previous: &ImportDemandFrontier,
+    current: &ImportDemandFrontier,
+) -> ImportDemandRoots {
+    current.round_read_roots(previous)
+}
+
 pub fn publish_import_observation_batch(
     session: &mut crate::CompilerSession,
     frontier: &ImportDemandFrontier,

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -12,7 +12,7 @@ use rue_compiler::unstable::{
     RootedParkOutcome, TrustedSuccessorDelta, begin_import_input_request,
     close_import_discovery_successor, close_import_input_request, closed_discovery_continuation,
     discovery_attempt, import_demand_frontier_for_roots, import_observation_ledger,
-    plan_delta_roots, plan_round_roots, publish_import_observation_batch,
+    plan_delta_roots, plan_round_read_roots, plan_round_roots, publish_import_observation_batch,
     publish_trusted_toolchain_successor, rooted_or_toolchain_park,
     stage_import_discovery_successor, stage_import_input_request,
 };
@@ -957,9 +957,24 @@ fn drive_import_discovery_to_close(
         // Assemble only the newly read leaves: a successor adds its delta groups'
         // accepted sources, never re-feeding the predecessor plan through the
         // winner map.
-        let assembled = match &reclose {
-            Some(_) => assembler.add_successor_plan_reads(&plan, &next_ledger),
-            None => assembler.add_plan_reads(&plan, &next_ledger),
+        //
+        // An ordinary round assembles the same way once it has a predecessor
+        // round: only the occurrences this round's batch answered, plus the ones
+        // the previous round's fanout answered as that batch was published, can
+        // have gained a winner since the last assembly. Re-reducing the WHOLE
+        // plan every round instead re-derives every already assembled leaf's
+        // winner and re-offers it to the assembler, which is quadratic in the
+        // depth of an import chain. The first round has no predecessor, so it
+        // reduces the whole plan — for a continuation that is also what admits
+        // the carried generation's already accepted reads.
+        let assembled = match (&reclose, &previous_frontier) {
+            (Some(_), _) => assembler.add_successor_plan_reads(&plan, &next_ledger),
+            (None, None) => assembler.add_plan_reads(&plan, &next_ledger),
+            (None, Some(previous)) => assembler.add_plan_round_reads(
+                &plan,
+                &next_ledger,
+                &plan_round_read_roots(previous, &frontier),
+            ),
         };
         let _ = assembled.map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
         let successor_snapshot = assembler
@@ -2132,6 +2147,16 @@ mod tests {
         assert!(
             import_frontier_roots_requested(&result.session) <= (MODULES as u64) * 4,
             "frontier dispatch must stay linear in chain depth, not rounds times plan"
+        );
+        // The read half of the same property: each round reduces only the
+        // occurrences it and the previous round demanded answers for, so it
+        // offers the assembler about one accepted source per round plus the
+        // first round's whole-plan reduction. Re-reducing the whole plan every
+        // round instead offered every already assembled leaf again — 528 at this
+        // shape, and quadratic in chain depth.
+        assert!(
+            result.assembler.plan_reads_reduced() <= (MODULES as u64) * 2,
+            "per-round read volume must stay linear in chain depth, not rounds times plan"
         );
     }
 


### PR DESCRIPTION
Follow-up to #2457, removing the remaining per-round whole-plan work in import discovery. 9 files, +366/−24. Callgrind-guided: total instructions at n=256 dropped 1,779.7M → 830.6M (discovery share 77% → 52%).

## The three removals

1. **Whole-plan assembly re-reduction** (34.6% of all instructions): each round re-reduced every accepted source in the plan. `ImportDiscoveryPlan::accepted_sources_at(ledger, occurrences)` now reduces only the named occurrences, locating each one's candidate groups by binary search over the plan's shared sorted segments; the winner walk and canonical sort/dedup are shared helpers so the scoped and whole-plan paths use one formula. Ordinary rounds derive the changed-occurrence set from the compiler's own frontier values (previous ∪ current `demanded_occurrences()` — the previous round's fanout is in the union because its answers only reach the carried ledger at publication, the case a naive this-round-only delta would drop). Round 1 of a generation and trusted re-closes are unchanged.
2. **Retained-charge re-walks of immutable values** (~11%): `SourceSnapshot` and `ParsedModule` memoize their charge (and total source bytes) — the values are immutable, so the memo returns exactly what the walk returns.
3. **Whole-manifest staging re-proofs**: `validate_staged_accepted_reads` re-proves only appended entries when both snapshot and manifest are direct structural extensions (pointer-lineage proof) of the exact pair the session last proved; any other shape — fresh lineage, rebuilt snapshot, changed source — falls back to the untouched whole-pair check with identical messages.

## Numbers (release, `-O3 -j1`)

| | n=256 | n=1024 |
|---|---|---|
| `import_read` + `import_parse_staging` + `import_plan_publish` | 234–241ms → 94–155ms | 2,696–2,882ms → **628–787ms** |
| combined 256→1024 scaling | 11–12× → **5.1–6.7×** | |
| whole compile | 514ms → ~400ms | 4,298ms → **~1,800ms** |

Re-verified on this branch after rebasing onto post-ADR-0074 trunk: 1,024-chain root 1,846ms, discovery 1,367ms; Lattice hash `b893e76c…85e5` with `memo_node_materializations` still 0.

## Identity and gates

- Executables sha256-identical before/after on both chains, Lattice, and Mosaic; **all 136 `compiler_work` counters identical** on all four workloads (baseline captured from a stashed pristine build; base-vs-base re-run confirms run-to-run determinism).
- New counter `plan_reads_reduced` (per-round read volume), premerge-bounded at `≤ 2·MODULES` in the 32-module driver test alongside the frontier-roots bound — whole-plan behavior would be 528 at that shape.

## Validation

Agent-side: `scripts/rue quick` 30/30, `rue-driver-test` 40/40, `rue-compiler-test`, `scripts/rue cli` 1,892/0 (re-run on the exact committed tree), `scripts/rue fmt`. Re-run on this branch post-rebase: driver 40/40, compiler 883/883, quick green, plus the release-build hash/counter checks above.

## Measured remainders (documented, not addressed)

`request_parse` projection bookkeeping (15.6× per 4× n, now the largest superlinear term), `CompilerSessionMetrics::synchronize` per-round ledger walk (11.4×), and `DiagnosticAttemptStore::find_exact` (14.8×, small absolute). These are the natural targets after ADR-0075's wave-granularity collapses the round count itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTiBg7df72iMgdpAFv5wZs)_