### PR TITLE
Five decision-free performance fixes across CFG, codegen, and the query database

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -2810,6 +2810,13 @@ impl<'a> CfgBuilder<'a> {
                 f
             }
         };
+        self.store_field_drop_flag(flag_slot, live, span);
+    }
+
+    /// Write `live` into an already-resolved per-field drop-flag slot. Split
+    /// out so the update path can emit from the slot its own lookup found,
+    /// instead of re-deriving it from the path a second time.
+    fn store_field_drop_flag(&mut self, flag_slot: u32, live: bool, span: rue_span::Span) {
         let val = self.emit(
             CfgInstData::Const(if live { 1 } else { 0 }),
             Type::I32,
@@ -2827,7 +2834,9 @@ impl<'a> CfgBuilder<'a> {
 
     /// Update an EXISTING per-field drop flag; no-op when the path has none
     /// (its type needs no drop). The flag is allocated and armed at the
-    /// slot's initialization site, which always precedes the move.
+    /// slot's initialization site, which always precedes the move, so this
+    /// path never reaches `set_field_drop_flag`'s allocating branch: one
+    /// owned path and one hash answer the whole question.
     fn update_field_drop_flag(
         &mut self,
         key: MovedSlot,
@@ -2835,9 +2844,10 @@ impl<'a> CfgBuilder<'a> {
         live: bool,
         span: rue_span::Span,
     ) {
-        if self.field_drop_flags.contains_key(&(key, path.to_vec())) {
-            self.set_field_drop_flag(key, path.to_vec(), live, span);
-        }
+        let Some(flag_slot) = self.field_drop_flags.get(&(key, path.to_vec())).copied() else {
+            return;
+        };
+        self.store_field_drop_flag(flag_slot, live, span);
     }
 
     /// The path (declaration/element indices, outermost first) named by a
@@ -5353,6 +5363,119 @@ mod tests {
             ),
             "the drop covers the whole re-initialized struct, not one field"
         );
+    }
+
+    /// Stores into hidden drop-flag slots: the temp locals `set_field_drop_flag`
+    /// allocates past the body's declared locals, paired with the constant
+    /// written into them.
+    fn drop_flag_stores(cfg: &Cfg, declared_locals: u32) -> Vec<(u32, u64)> {
+        cfg.blocks()
+            .iter()
+            .flat_map(|block| block.insts.iter())
+            .filter_map(|value| match cfg.get_inst(*value).data {
+                CfgInstData::Store { slot, value } if slot >= declared_locals => {
+                    match cfg.get_inst(value).data {
+                        CfgInstData::Const(constant) => Some((slot, constant)),
+                        _ => None,
+                    }
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn repeated_field_moves_update_one_flag_slot_per_path() {
+        // RUE-1560: `update_field_drop_flag` used to hash and materialize the
+        // path once to ask whether a flag existed and again to write it. It
+        // now resolves the slot once and stores through it, which must not
+        // change what is emitted: the same single flag slot, written in the
+        // same order, with the same drop elaboration around it.
+        //
+        // `let h = H { a: sb(8), b: sb(8) };
+        //  eat(h.a); h.a = sb(4); eat(h.a); h.a = sb(2); 0`
+        //
+        // Each `eat(h.a)` clears the field's flag and each reassignment re-arms
+        // it, so the update path runs four times against a flag that already
+        // exists — the branch that must never allocate a second slot.
+        use SemanticBodyInstData as D;
+        let mut f = BodyFixture::new(SemanticImportType::I32);
+        let (binding, first_eat, place_a) = partial_field_move_prefix(&mut f);
+        let declared_locals = f.num_locals;
+
+        let mut statements = vec![binding, first_eat];
+        for (capacity, reads_again) in [(4u64, true), (2u64, false)] {
+            let cap = f.inst(D::Const(capacity), SemanticImportType::U64);
+            let fresh = f.call_inst("StrBuf.with_capacity", &[cap], nominal_ty("StrBuf"));
+            statements.push(f.inst(
+                D::PlaceWrite {
+                    place: place_a,
+                    value: fresh,
+                },
+                SemanticImportType::Unit,
+            ));
+            if reads_again {
+                let read = f.inst(D::PlaceRead { place: place_a }, nominal_ty("StrBuf"));
+                let moved = f.inst(
+                    D::MarkMoved {
+                        value: read,
+                        slot: 0,
+                        is_param: false,
+                        place: Some(place_a),
+                    },
+                    nominal_ty("StrBuf"),
+                );
+                statements.push(f.call_inst("eat", &[moved], SemanticImportType::I32));
+            }
+        }
+
+        let zero = f.inst(D::Const(0), SemanticImportType::I32);
+        let tail = f.inst(
+            D::Block {
+                statements: statements.into(),
+                value: zero,
+            },
+            SemanticImportType::I32,
+        );
+        f.inst(D::Ret(Some(tail)), SemanticImportType::I32);
+        let cfg = f.build_cfg();
+
+        let stores = drop_flag_stores(&cfg, declared_locals);
+        let slots: std::collections::BTreeSet<u32> = stores.iter().map(|(slot, _)| *slot).collect();
+        assert_eq!(
+            slots.len(),
+            1,
+            "field a's path owns exactly one flag slot however often it is \
+             moved and re-initialized, got stores into {slots:?}"
+        );
+
+        // Armed once at the struct's initialization, then cleared and re-armed
+        // by each move and each reassignment, in source order.
+        let written: Vec<u64> = stores.iter().map(|(_, constant)| *constant).collect();
+        assert_eq!(
+            written,
+            vec![1, 0, 1, 0, 1],
+            "the flag must be armed at initialization and then alternate with \
+             each move and reassignment"
+        );
+
+        // The trailing reassignment leaves the struct whole, so exit is back on
+        // the whole-struct path: one drop covering both fields.
+        let dropped: Vec<_> = cfg
+            .blocks()
+            .iter()
+            .flat_map(|block| block.insts.iter())
+            .filter_map(|value| match cfg.get_inst(*value).data {
+                CfgInstData::Drop { value } => Some(value),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(dropped.len(), 1, "exactly one whole-struct drop at exit");
+        assert!(
+            matches!(cfg.get_inst(dropped[0]).data, CfgInstData::Load { slot: 0 }),
+            "the re-initialized struct drops whole, not field-granularly"
+        );
+        assert_all_blocks_terminated(&cfg);
     }
 
     #[test]

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -653,7 +653,12 @@ impl<'a> CfgBuilder<'a> {
 
         // Owned by-value params are "initialized" at entry: arm their drop
         // flags here so a flag is live before any move site is reached.
-        for &(abi_slot, ty) in &builder.air.param_drops().to_vec() {
+        //
+        // Index instead of snapshotting the slice: the body needs `&mut
+        // builder`, so the `param_drops()` borrow cannot be held across it.
+        // Re-borrowing per step reads the same AIR without copying it.
+        for index in 0..builder.air.param_drops().len() {
+            let (abi_slot, ty) = builder.air.param_drops()[index];
             let key = MovedSlot::Param(abi_slot);
             if builder.ever_moved.contains(&key) && builder.type_needs_drop(ty) {
                 builder.set_drop_flag(key, true, rue_span::Span::default());
@@ -2872,7 +2877,11 @@ impl<'a> CfgBuilder<'a> {
         // Drop owned parameters (unless their value was moved out on every
         // path reaching this exit). The list is empty for destructors and
         // drop-glue functions, which must not re-drop their own parameter.
-        for &(abi_slot, ty) in self.air.param_drops().to_vec().iter().rev() {
+        //
+        // Reverse index rather than a reversed copy: the body needs `&mut
+        // self`, so the `param_drops()` borrow cannot span it.
+        for index in (0..self.air.param_drops().len()).rev() {
+            let (abi_slot, ty) = self.air.param_drops()[index];
             let key = MovedSlot::Param(abi_slot);
             if self.moved.is_slot_moved(key) {
                 continue;
@@ -4800,6 +4809,172 @@ mod tests {
         air.add_ret(Some(zero), Type::I32, span);
         air.set_param_drops(vec![(0, strbuf_ty)]);
         build_editor_cfg(air, 0, 1, "f", &type_pool, vec![false], interner)
+    }
+
+    /// The AIR for `fn wide(a: StrBuf, .., z: StrBuf) -> i32 { 0 }`: many
+    /// pass-by-value droppable parameters, none of them touched, so the whole
+    /// parameter-drop schedule runs at the single exit (RUE-1559).
+    fn wide_owned_param_cfg(interner: &ThreadedRodeo, param_count: u32) -> Cfg {
+        let type_pool = rue_air::TypeInternPool::new();
+        let strbuf_id = register_fixture_struct(
+            &type_pool,
+            interner,
+            "StrBuf",
+            vec![rue_air::StructField {
+                name: "cap".into(),
+                ty: Type::U64,
+            }],
+            Some("StrBuf.__drop"),
+        );
+        let strbuf_ty = Type::new_struct(strbuf_id);
+        let type_pool = type_pool.freeze();
+        let span = rue_span::Span::new(0, 1);
+        let mut air = AirEditor::new(Type::I32);
+        let zero = air.add_const(0, Type::I32, span);
+        air.add_ret(Some(zero), Type::I32, span);
+        air.set_param_drops((0..param_count).map(|slot| (slot, strbuf_ty)).collect());
+        build_editor_cfg(
+            air,
+            0,
+            param_count,
+            "wide",
+            &type_pool,
+            vec![false; param_count as usize],
+            interner,
+        )
+    }
+
+    /// The parameter slots dropped at exit, in the order the CFG drops them.
+    fn dropped_param_order(cfg: &Cfg) -> Vec<u32> {
+        cfg.blocks()
+            .iter()
+            .flat_map(|block| block.insts.iter())
+            .filter_map(|value| match cfg.get_inst(*value).data {
+                CfgInstData::Drop { value } => match cfg.get_inst(value).data {
+                    CfgInstData::Param { index } => Some(index),
+                    _ => None,
+                },
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn wide_parameter_drop_schedule_keeps_reverse_order_without_snapshotting_it() {
+        // RUE-1559: the entry arming pass and the exit cleanup pass both read
+        // `Air::param_drops()` while holding `&mut` on the builder, which used
+        // to be resolved by copying the slice. Iterating by index instead must
+        // leave the schedule itself untouched: every owned parameter is still
+        // dropped exactly once, in reverse declaration order.
+        const PARAM_COUNT: u32 = 64;
+        let interner = ThreadedRodeo::default();
+        let cfg = wide_owned_param_cfg(&interner, PARAM_COUNT);
+
+        let dropped = dropped_param_order(&cfg);
+        assert_eq!(
+            dropped.len(),
+            PARAM_COUNT as usize,
+            "every owned parameter is dropped exactly once at the single exit"
+        );
+        let expected: Vec<u32> = (0..PARAM_COUNT).rev().collect();
+        assert_eq!(
+            dropped, expected,
+            "owned parameters must be cleaned up in reverse declaration order"
+        );
+        assert_all_blocks_terminated(&cfg);
+    }
+
+    #[test]
+    fn walking_the_parameter_drop_schedule_allocates_nothing() {
+        // RUE-1559: the entry-arming and exit-cleanup passes each copied the
+        // schedule into a fresh Vec to satisfy borrowck, so a function with a
+        // non-empty schedule paid allocations a function without one did not.
+        // `to_vec()` on an empty slice does not allocate, which makes an
+        // otherwise identical unscheduled build the control.
+        //
+        // The parameters are `i32`, which needs no cleanup, so a populated
+        // schedule is walked but emits nothing: the two builds produce the
+        // same CFG and differ only in whether the walk had entries to visit.
+        // The AIR — the schedule included — is prepared outside the
+        // measurement, because building a schedule is a cost of having one
+        // rather than of walking it, and only the walk is under test.
+        const PARAM_COUNT: u32 = 128;
+
+        let prepared = |scheduled: bool| {
+            let type_pool = rue_air::TypeInternPool::new().freeze();
+            let span = rue_span::Span::new(0, 1);
+            let mut air = AirEditor::new(Type::I32);
+            let zero = air.add_const(0, Type::I32, span);
+            air.add_ret(Some(zero), Type::I32, span);
+            if scheduled {
+                air.set_param_drops((0..PARAM_COUNT).map(|slot| (slot, Type::I32)).collect());
+            }
+            let air = air
+                .finish(AirValidationContext::Canonical(&type_pool))
+                .expect("test AIR must validate");
+            (air, type_pool, ThreadedRodeo::default())
+        };
+
+        let build = |air: &ValidatedAir, type_pool: &FrozenTypeInternPool, interner| {
+            CfgBuilder::build(
+                air,
+                0,
+                PARAM_COUNT,
+                "scalars",
+                type_pool,
+                vec![false; PARAM_COUNT as usize],
+                interner,
+                false,
+                AnalyzedCallableKind::Ordinary,
+            )
+            .cfg
+            .unwrap()
+            .into_editor()
+        };
+
+        let (scheduled_air, scheduled_pool, scheduled_interner) = prepared(true);
+        let (unscheduled_air, unscheduled_pool, unscheduled_interner) = prepared(false);
+
+        let (scheduled, scheduled_allocations) =
+            crate::allocation_test_support::allocations_during(|| {
+                build(&scheduled_air, &scheduled_pool, &scheduled_interner)
+            });
+        let (unscheduled, unscheduled_allocations) =
+            crate::allocation_test_support::allocations_during(|| {
+                build(&unscheduled_air, &unscheduled_pool, &unscheduled_interner)
+            });
+
+        // The control is only a control if the two builds emit the same CFG.
+        assert_eq!(count_drops(&scheduled), 0, "i32 parameters need no cleanup");
+        assert_eq!(count_drops(&unscheduled), 0);
+        assert_eq!(
+            scheduled.blocks().len(),
+            unscheduled.blocks().len(),
+            "the schedule must not change the emitted block structure"
+        );
+        assert_eq!(
+            scheduled.num_locals(),
+            unscheduled.num_locals(),
+            "a schedule over non-droppable parameters must allocate no flag slots"
+        );
+
+        // One schedule-dependent allocator remains, and it is not the walk:
+        // `derive_source_param_abi` seeds a `HashMap` from `param_drops`, so a
+        // longer schedule costs that map's doubling growth — logarithmic in the
+        // entry count. The two removed copies were a flat constant on top of
+        // that (one at entry, one per exit, here a single exit), so bounding
+        // the difference by the doubling growth alone rejects them at every
+        // width while tolerating a smarter descriptor build.
+        let doubling_growth = PARAM_COUNT.ilog2() + 1;
+        let difference = scheduled_allocations.saturating_sub(unscheduled_allocations);
+        assert!(
+            difference <= doubling_growth as usize,
+            "building a {PARAM_COUNT}-entry parameter-drop schedule allocated \
+             {scheduled_allocations} times against {unscheduled_allocations} for an empty \
+             one, a difference of {difference} over a {doubling_growth}-allocation budget \
+             for the source-param ABI map's growth; walking the schedule is copying it \
+             rather than iterating it"
+        );
     }
 
     #[test]

--- a/crates/rue-codegen/src/liveness.rs
+++ b/crates/rue-codegen/src/liveness.rs
@@ -810,8 +810,15 @@ fn build_live_ranges(
 /// # Algorithm
 ///
 /// 1. Identify back-edges by finding successors[i] where successor <= i
-/// 2. For each back-edge (from -> to), mark all instructions in [to, from] as in a loop
-/// 3. Handle nested loops by tracking depth (incremented for each enclosing loop)
+/// 2. Record each back-edge (from -> to) as an interval `[to, from]` in a
+///    difference array: `+1` at `to`, `-1` just past `from`
+/// 3. Prefix-sum the difference array, so each instruction's depth is the
+///    number of enclosing loop intervals covering it
+///
+/// Accumulating intervals rather than marking each range instruction by
+/// instruction keeps this linear in instructions plus back-edges; the marking
+/// form was back-edges times instructions, which dominated the pass on large
+/// bodies with many back-edges.
 ///
 /// # Arguments
 ///
@@ -829,33 +836,35 @@ where
         return LoopInfo::no_loops(0);
     }
 
-    // Find all back-edges: edges where we jump to an earlier or same instruction
+    // Find all back-edges: edges where we jump to an earlier or same instruction.
     // A back-edge from instruction `from` to instruction `to` (where to <= from)
-    // indicates a loop from `to` to `from`
-    let mut loop_ranges: Vec<(usize, usize)> = Vec::new();
+    // indicates a loop from `to` to `from`, inclusive at both ends. Each one is
+    // recorded as a delta pair rather than painted across its range, so the cost
+    // is one entry per back-edge instead of one per covered instruction. The
+    // ranges need no sorting: interval sums do not depend on their order.
+    let mut deltas = vec![0i64; num_insts + 1];
 
     for (from, succs) in successors.iter().enumerate() {
         for &to in succs.as_ref() {
             if to <= from {
-                // This is a back-edge: we're jumping backwards
-                // The loop spans from `to` (loop header) to `from` (back-edge source)
-                loop_ranges.push((to, from));
+                deltas[to] += 1;
+                deltas[from + 1] -= 1;
             }
         }
     }
 
-    // Sort loop ranges by start point for consistent processing
-    loop_ranges.sort_by_key(|(start, _)| *start);
-
-    // Compute loop depth for each instruction
-    // Each loop range [start, end] increments the depth of all instructions in that range
-    let mut depths = vec![0u32; num_insts];
-
-    for (loop_start, loop_end) in &loop_ranges {
-        for idx in *loop_start..=*loop_end {
-            depths[idx] = depths[idx].saturating_add(1);
-        }
-    }
+    // An instruction's depth is the number of loop ranges covering it, which one
+    // prefix sum over the deltas yields. Accumulate wide and saturate on the way
+    // out, matching the per-range `saturating_add` this replaced for counts
+    // beyond what a `u32` holds.
+    let mut enclosing = 0i64;
+    let depths = deltas[..num_insts]
+        .iter()
+        .map(|delta| {
+            enclosing += delta;
+            u32::try_from(enclosing).unwrap_or(u32::MAX)
+        })
+        .collect();
 
     LoopInfo::from_depths(depths)
 }
@@ -1351,5 +1360,183 @@ mod tests {
         assert_eq!(loop_info.depth(2), 1, "Loop body");
         assert_eq!(loop_info.depth(3), 1, "Loop back-edge");
         assert_eq!(loop_info.depth(4), 0, "After loop");
+    }
+
+    // ========================================
+    // RUE-1558: interval accumulation
+    // ========================================
+
+    /// The marking form `compute_loop_info` replaced: paint every instruction
+    /// covered by every back-edge range. Retained as the differential oracle,
+    /// because RUE-1558 is an implementation optimization and the depth vector
+    /// it produces must not move.
+    fn marked_loop_depths<S: AsRef<[usize]>>(num_insts: usize, successors: &[S]) -> Vec<u32> {
+        let mut depths = vec![0u32; num_insts];
+        for (from, succs) in successors.iter().enumerate() {
+            for &to in succs.as_ref() {
+                if to <= from {
+                    for depth in depths.iter_mut().take(from + 1).skip(to) {
+                        *depth = depth.saturating_add(1);
+                    }
+                }
+            }
+        }
+        depths
+    }
+
+    fn assert_matches_marking_reference(num_insts: usize, successors: &[Vec<usize>], case: &str) {
+        let expected = marked_loop_depths(num_insts, successors);
+        let actual = compute_loop_info(num_insts, successors);
+        for (index, depth) in expected.iter().enumerate() {
+            assert_eq!(
+                actual.depth(index),
+                *depth,
+                "{case}: depth diverged from the marking reference at instruction {index}"
+            );
+        }
+        assert_eq!(
+            actual.max_depth_in_range(0, num_insts.saturating_sub(1)),
+            expected.iter().copied().max().unwrap_or(0),
+            "{case}: cached max depth diverged from the marking reference"
+        );
+    }
+
+    #[test]
+    fn interval_accumulation_matches_marking_on_nested_and_overlapping_loops() {
+        // Triply nested: 1..8 encloses 2..7 encloses 3..6.
+        assert_matches_marking_reference(
+            9,
+            &[
+                vec![1],
+                vec![2],
+                vec![3],
+                vec![4],
+                vec![5],
+                vec![6],
+                vec![3],
+                vec![2],
+                vec![1],
+            ],
+            "triply nested",
+        );
+
+        // Overlapping but not nested: 0..5 and 3..7 share only 3..5. The
+        // marking form and the interval form must agree that the shared
+        // stretch is depth 2 and each tail is depth 1.
+        assert_matches_marking_reference(
+            8,
+            &[
+                vec![1],
+                vec![2],
+                vec![3],
+                vec![4],
+                vec![0],
+                vec![6],
+                vec![7],
+                vec![3],
+            ],
+            "overlapping",
+        );
+
+        // Self-loop: `to == from` is a back-edge covering exactly one
+        // instruction, the inclusive-at-both-ends boundary case.
+        assert_matches_marking_reference(3, &[vec![1], vec![1], vec![]], "self loop");
+
+        // Two back-edges landing on the same header, and a range covering the
+        // whole function.
+        assert_matches_marking_reference(
+            6,
+            &[vec![1], vec![2], vec![1], vec![4], vec![1], vec![0]],
+            "shared header",
+        );
+
+        // No back-edges at all: every depth stays zero.
+        assert_matches_marking_reference(4, &[vec![1], vec![2], vec![3], vec![]], "straight line");
+    }
+
+    #[test]
+    fn interval_accumulation_matches_marking_on_randomized_graphs() {
+        // A fixed-seed xorshift, so a failure reproduces exactly rather than
+        // depending on the run.
+        let mut state = 0x2545_F491_4F6C_DD1Du64;
+        let mut next = move || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state
+        };
+
+        for case in 0..200 {
+            let num_insts = 1 + (next() % 64) as usize;
+            let successors: Vec<Vec<usize>> = (0..num_insts)
+                .map(|from| {
+                    // Up to three successors per instruction, each anywhere in
+                    // range, so back-edges, forward edges and self-loops all
+                    // appear at every density.
+                    (0..next() % 4)
+                        .map(|_| (next() as usize) % num_insts)
+                        .chain(if from + 1 < num_insts {
+                            Some(from + 1)
+                        } else {
+                            None
+                        })
+                        .collect()
+                })
+                .collect();
+            assert_matches_marking_reference(
+                num_insts,
+                &successors,
+                &format!("randomized case {case} ({num_insts} instructions)"),
+            );
+        }
+    }
+
+    #[test]
+    fn many_overlapping_back_edges_stay_linear_in_instructions() {
+        // Every instruction in the second half carries a back-edge to the
+        // matching instruction in the first half, so the ranges overlap
+        // heavily and the marking form would touch ~n^2/4 cells. The interval
+        // form pays one delta pair per back-edge; this case exists so a
+        // reintroduced painting loop shows up as a stalled test rather than a
+        // silent slowdown.
+        const NUM_INSTS: usize = 20_000;
+        let half = NUM_INSTS / 2;
+        let successors: Vec<Vec<usize>> = (0..NUM_INSTS)
+            .map(|index| {
+                if index >= half {
+                    vec![index + 1, index - half]
+                } else {
+                    vec![index + 1]
+                }
+            })
+            .collect();
+
+        let info = compute_loop_info(NUM_INSTS, &successors);
+
+        // Instruction i is covered by every back-edge range [j - half, j] with
+        // j >= half and j - half <= i <= j, i.e. by j in [max(half, i), i +
+        // half], clamped to the instructions that have back-edges.
+        for index in [0, 1, half - 1, half, half + 1, NUM_INSTS - 1] {
+            let lowest = half.max(index);
+            let highest = (index + half).min(NUM_INSTS - 1);
+            let expected = u32::try_from(highest.saturating_sub(lowest) + 1).unwrap();
+            assert_eq!(
+                info.depth(index),
+                expected,
+                "instruction {index} sits inside {expected} overlapping loop ranges"
+            );
+        }
+    }
+
+    #[test]
+    fn back_edge_ranges_are_inclusive_at_both_ends() {
+        // 2 -> 1 covers exactly instructions 1 and 2: the header it lands on
+        // and the instruction the edge leaves from. An off-by-one in the
+        // difference array would drop one end or bleed into instruction 3.
+        let info = compute_loop_info(4, &[vec![1], vec![2], vec![1, 3], vec![]]);
+        assert_eq!(info.depth(0), 0, "before the header");
+        assert_eq!(info.depth(1), 1, "the header is inside its own loop");
+        assert_eq!(info.depth(2), 1, "the back-edge source is inside the loop");
+        assert_eq!(info.depth(3), 0, "the exit is outside the loop");
     }
 }

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -5876,10 +5876,6 @@ fn evaluate_call_abi(
 
 fn evaluate_drop_glue(
     context: &rue_query::QueryContext,
-    type_shapes: &QueryFamily<
-        crate::type_queries::TypeQueryKey,
-        crate::type_queries::TypeShapeValue,
-    >,
     type_facts: &QueryFamily<
         crate::type_queries::TypeQueryKey,
         crate::type_queries::TypeFactsValue,
@@ -5898,14 +5894,14 @@ fn evaluate_drop_glue(
                 .with_terminal_kind(QueryTerminalKind::Failure));
         }
     };
-    let shape_terminal = context.query_registered(type_shapes, key.clone())?;
-    let shape = match type_shape_from_terminal(&shape_terminal) {
-        Ok(shape) => shape,
-        Err(failure) => {
-            return Ok(QueryOutput::success(DropGlueValue::Failure(failure))
-                .with_terminal_kind(QueryTerminalKind::Failure));
-        }
-    };
+    // `evaluate_type_facts` queries `compiler.type-shape` for this same key and
+    // stamps the answer onto every `Available` value it publishes, so the facts
+    // already carry the canonical shape. Asking the shape family again would
+    // repeat a lookup per drop-glue request for a value in hand, and it cannot
+    // disagree: facts that resolved at all resolved through that shape, and the
+    // dependency this drops is still observed transitively through the facts
+    // edge, so invalidation reaches here unchanged.
+    let shape = &facts.shape;
     let children = match shape {
         TypeShape::Array { element, len } if *len != 0 => vec![element.clone()],
         TypeShape::Array { .. } => Vec::new(),
@@ -14028,7 +14024,6 @@ impl RevisionedQueryDatabase {
                 },
             )
             .expect("the CallAbi family has one canonical name");
-        let type_shapes_for_drop_glue = type_shapes.clone();
         let type_facts_for_drop_glue = type_facts.clone();
         let drop_glues = runtime
             .family_with_equality_and_evaluator(
@@ -14037,12 +14032,7 @@ impl RevisionedQueryDatabase {
                 |left: &crate::type_queries::DropGlueValue,
                  right: &crate::type_queries::DropGlueValue| left == right,
                 move |context, _, key: &crate::type_queries::TypeQueryKey| {
-                    evaluate_drop_glue(
-                        context,
-                        &type_shapes_for_drop_glue,
-                        &type_facts_for_drop_glue,
-                        key,
-                    )
+                    evaluate_drop_glue(context, &type_facts_for_drop_glue, key)
                 },
             )
             .expect("the DropGlue family has one canonical name");
@@ -33123,6 +33113,93 @@ fn main() -> i32 {
             },
             CancellationToken::new(),
         )
+    }
+
+    #[test]
+    fn drop_glue_reads_the_shape_carried_by_type_facts_instead_of_requesting_it() {
+        // RUE-1556: `TypeFacts` already carries the canonical `TypeShape` for
+        // its own key — `evaluate_type_facts` stamps the shape it queried onto
+        // every value it publishes — so drop glue asking the shape family again
+        // was a second lookup for a value already in hand. The saved dependency
+        // is still observed transitively through type-facts, so invalidation is
+        // unchanged; only the direct edge is gone.
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "struct Child { value: i64 }\n\
+                 drop fn Child(self) {}\n\
+                 struct Outer { first: Child, spacer: i64, second: Child }",
+            )],
+            1,
+        );
+        let outer = named_type_instance(&module, "Outer", crate::StableDefinitionKind::Struct);
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = revision_for(&mut database, &source);
+
+        let attempt = request_drop_glue(&database, revision, outer.clone());
+        assert_eq!(attempt.execution(), RequestExecution::Computed);
+        let dependencies = attempt.terminal().unwrap().dependencies();
+
+        let families: Vec<&str> = dependencies
+            .iter()
+            .map(|observation| observation.node.family())
+            .collect();
+        assert!(
+            families.contains(&"compiler.type-facts"),
+            "drop glue still depends on the facts it reads the shape from, got {families:?}"
+        );
+        assert!(
+            !families.contains(&"compiler.type-shape"),
+            "one drop-glue request must not perform a shape-family lookup of its \
+             own; the shape travels with the facts. Observed families: {families:?}"
+        );
+
+        // The control for that negative: type-facts does observe the shape
+        // family for this same key, so a shape edge is something these
+        // dependency lists demonstrably show when one exists.
+        let facts_attempt = database.runtime.request_registered(
+            &database.type_facts,
+            revision,
+            crate::type_queries::TypeQueryKey {
+                ty: outer,
+                configuration: semantic_configuration(),
+            },
+            CancellationToken::new(),
+        );
+        let facts_families: Vec<&str> = facts_attempt
+            .terminal()
+            .unwrap()
+            .dependencies()
+            .iter()
+            .map(|observation| observation.node.family())
+            .collect();
+        assert!(
+            facts_families.contains(&"compiler.type-shape"),
+            "type-facts is where the shape is queried and stamped onto the value, \
+             got {facts_families:?}"
+        );
+
+        // The plan itself is derived from that shape, so a correct read shows up
+        // as the same field-granular ownership decisions the shape describes.
+        let rue_query::QueryOutcome::Success(crate::type_queries::DropGlueValue::Available(facts)) =
+            attempt.terminal().unwrap().outcome()
+        else {
+            panic!("drop-glue plan did not publish");
+        };
+        let crate::type_queries::DropGluePlan::Struct { fields } = &facts.plan else {
+            panic!("outer must have a struct plan");
+        };
+        assert_eq!(
+            fields
+                .iter()
+                .map(|field| (field.name.as_ref(), field.drop))
+                .collect::<Vec<_>>(),
+            [("first", true), ("spacer", false), ("second", true)],
+            "the plan must still name every field in shape order"
+        );
     }
 
     #[test]

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -13,7 +13,7 @@ use std::ops::Deref;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
-use ahash::{AHashMap, RandomState};
+use ahash::{AHashMap, AHashSet, RandomState};
 use lasso::Key;
 
 #[derive(Debug, Default)]
@@ -6140,12 +6140,12 @@ pub(crate) fn semantic_nucleus_failure_is_internal_error(
 
 fn visit_instance_anonymous_nominals<'a>(
     function: &'a crate::FunctionInstanceKey,
-    seen: &mut Vec<*const crate::AnonymousNominalKey>,
+    seen: &mut AHashSet<*const crate::AnonymousNominalKey>,
     mut visit: impl FnMut(&'a crate::AnonymousNominalKey),
 ) {
     fn arguments<'a, F: FnMut(&'a crate::AnonymousNominalKey)>(
         arguments: &'a crate::CanonicalArguments,
-        seen: &mut Vec<*const crate::AnonymousNominalKey>,
+        seen: &mut AHashSet<*const crate::AnonymousNominalKey>,
         visit: &mut F,
     ) {
         for ty in arguments.types.iter() {
@@ -6164,19 +6164,20 @@ fn visit_instance_anonymous_nominals<'a>(
 
     fn anonymous<'a, F: FnMut(&'a crate::AnonymousNominalKey)>(
         identity: &'a crate::AnonymousNominalKey,
-        seen: &mut Vec<*const crate::AnonymousNominalKey>,
+        seen: &mut AHashSet<*const crate::AnonymousNominalKey>,
         visit: &mut F,
     ) {
         // Canonical argument slices are shared through `Arc`, so one instance
         // key can reach the same nested identity through several paths. Track
         // those shared objects by address: structural equality is unnecessary
-        // for traversal, and a reusable flat scratch buffer avoids one tree
-        // allocation per visited anonymous identity.
+        // for traversal, and a reusable hashed scratch set avoids one tree
+        // allocation per visited anonymous identity while answering the repeat
+        // check in constant time, so a wide or deeply nested key does not turn
+        // the traversal quadratic in the identities it reaches.
         let identity_pointer = std::ptr::from_ref(identity);
-        if seen.contains(&identity_pointer) {
+        if !seen.insert(identity_pointer) {
             return;
         }
-        seen.push(identity_pointer);
         visit(identity);
         if let crate::StableProducerId::Function(function) = &identity.producer {
             instance_function(function, seen, visit);
@@ -6186,7 +6187,7 @@ fn visit_instance_anonymous_nominals<'a>(
 
     fn instance_type<'a, F: FnMut(&'a crate::AnonymousNominalKey)>(
         ty: &'a crate::TypeInstanceKey,
-        seen: &mut Vec<*const crate::AnonymousNominalKey>,
+        seen: &mut AHashSet<*const crate::AnonymousNominalKey>,
         visit: &mut F,
     ) {
         match ty {
@@ -6203,7 +6204,7 @@ fn visit_instance_anonymous_nominals<'a>(
 
     fn instance_function<'a, F: FnMut(&'a crate::AnonymousNominalKey)>(
         function: &'a crate::FunctionInstanceKey,
-        seen: &mut Vec<*const crate::AnonymousNominalKey>,
+        seen: &mut AHashSet<*const crate::AnonymousNominalKey>,
         visit: &mut F,
     ) {
         match function {
@@ -6228,7 +6229,7 @@ pub(crate) fn collect_instance_anonymous_nominals(
     function: &crate::FunctionInstanceKey,
 ) -> BTreeSet<crate::AnonymousNominalKey> {
     let mut output = BTreeSet::new();
-    let mut seen = Vec::new();
+    let mut seen = AHashSet::new();
     visit_instance_anonymous_nominals(function, &mut seen, |identity| {
         output.insert(identity.clone());
     });
@@ -14536,7 +14537,7 @@ impl RevisionedQueryDatabase {
                             >,
                         >,
                     )>::new();
-                    let mut anonymous_visit_seen = Vec::new();
+                    let mut anonymous_visit_seen = AHashSet::new();
                     let concurrency = context.max_concurrency();
                     let body_query_prefetch_window = if concurrency == 1 {
                         1
@@ -25241,6 +25242,128 @@ mod tests {
             Arc::from(name),
             None,
         ))
+    }
+
+    #[test]
+    fn anonymous_nominal_traversal_visits_each_shared_identity_exactly_once() {
+        // RUE-1555: canonical argument slices are shared through `Arc`, so one
+        // instance key reaches the same nested identity through many paths and
+        // the visited set is consulted far more often than it grows. It used
+        // to be a `Vec` scanned linearly, which made the traversal quadratic
+        // in the identities a key reaches; membership is now constant-time.
+        //
+        // What must not change is the traversal: every reachable identity
+        // produced exactly once, by pointer identity rather than structural
+        // equality, with the scratch buffer reused across calls.
+        const LEAVES: u32 = 256;
+        const SHARERS: u32 = 64;
+
+        let module = ModuleId::from_logical_path("anon.rue").unwrap();
+        let definition = |name: &str| {
+            crate::StableDefinitionKey::from_stable_parts(
+                module.clone(),
+                crate::StableDefinitionNamespace::Type,
+                crate::StableDefinitionKind::Struct,
+                Arc::from(name),
+                None,
+            )
+        };
+        let leaf = |ordinal: u32| crate::AnonymousNominalKey {
+            kind: crate::semantic_identity::AnonymousNominalKind::Struct,
+            producer: crate::StableProducerId::Definition(definition("make")),
+            anchor: crate::semantic_identity::StructuralAnchor::new(vec![
+                crate::semantic_identity::StructuralPathSegment::AnonymousType(ordinal),
+            ]),
+            arguments: crate::CanonicalArguments::default(),
+        };
+
+        // One slice, cloned into every specialization below, so each of the
+        // SHARERS levels re-walks the very same LEAVES addresses. That is the
+        // adversarial shape: LEAVES * SHARERS visit attempts against a visited
+        // set that only ever holds LEAVES entries.
+        let shared: Arc<[crate::TypeInstanceKey]> = (0..LEAVES)
+            .map(|ordinal| {
+                crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Anonymous(leaf(ordinal)))
+            })
+            .collect::<Vec<_>>()
+            .into();
+        let wide = |base: crate::FunctionInstanceKey| crate::FunctionInstanceKey::Specialization {
+            base: Box::new(base),
+            arguments: crate::CanonicalArguments {
+                types: shared.clone(),
+                values: Arc::new([]),
+            },
+        };
+
+        let mut key = free_function_instance(&module, "root");
+        for _ in 0..SHARERS {
+            key = wide(key);
+        }
+        // Deep nesting on top of the fan-out: an identity whose producer is
+        // itself a specialization carrying the same slice, so the whole leaf
+        // set is reachable a second time through a different kind of edge.
+        let nested = crate::AnonymousNominalKey {
+            kind: crate::semantic_identity::AnonymousNominalKind::Struct,
+            producer: crate::StableProducerId::Function(Box::new(wide(free_function_instance(
+                &module, "nested",
+            )))),
+            anchor: crate::semantic_identity::StructuralAnchor::new(vec![
+                crate::semantic_identity::StructuralPathSegment::AnonymousType(LEAVES),
+            ]),
+            arguments: crate::CanonicalArguments {
+                types: shared.clone(),
+                values: Arc::new([]),
+            },
+        };
+        let key = crate::FunctionInstanceKey::Specialization {
+            base: Box::new(key),
+            arguments: crate::CanonicalArguments {
+                types: Arc::from([crate::TypeInstanceKey::Nominal(
+                    crate::NominalInstanceKey::Anonymous(nested.clone()),
+                )]),
+                values: Arc::new([]),
+            },
+        };
+
+        let mut scratch = AHashSet::new();
+        let mut visited = Vec::new();
+        visit_instance_anonymous_nominals(&key, &mut scratch, |identity| {
+            visited.push(identity.clone());
+        });
+
+        assert_eq!(
+            visited.len(),
+            LEAVES as usize + 1,
+            "every leaf plus the nested identity is produced exactly once, \
+             however many paths reach it"
+        );
+        let distinct: BTreeSet<crate::AnonymousNominalKey> = visited.iter().cloned().collect();
+        assert_eq!(
+            distinct.len(),
+            visited.len(),
+            "a repeat visit must be suppressed, not merely deduplicated later"
+        );
+        assert!(
+            distinct.contains(&nested),
+            "the identity reached through a Function producer is still visited"
+        );
+        assert_eq!(
+            collect_instance_anonymous_nominals(&key),
+            distinct,
+            "the collecting wrapper agrees with the raw traversal"
+        );
+
+        // Scratch reuse: the buffer is cleared at entry, so a second traversal
+        // through the same one produces the same result rather than a
+        // truncated one.
+        let mut reused = Vec::new();
+        visit_instance_anonymous_nominals(&key, &mut scratch, |identity| {
+            reused.push(identity.clone());
+        });
+        assert_eq!(
+            reused, visited,
+            "the scratch set must be cleared and reused between traversals"
+        );
     }
 
     fn trusted_option_body_snapshot(root_source: &str, option_source: &str) -> SourceSnapshot {


### PR DESCRIPTION
Implements the recently filed performance issues that carry no open design question — the batch labelled `task`/`Improvement` rather than `needs-decision`. Each names a concrete target and an acceptance test, so none of them needed a maintainer call before implementation.

One commit per issue.

| Commit | Change | Crate |
| --- | --- | --- |
| RUE-1558 | `compute_loop_info` accumulates back-edge intervals instead of painting every covered instruction | `rue-codegen` |
| RUE-1559 | The parameter-drop schedule is indexed rather than copied into a fresh `Vec` at entry and at each exit | `rue-cfg` |
| RUE-1560 | `update_field_drop_flag` resolves its slot with one hashed lookup instead of three | `rue-cfg` |
| RUE-1555 | Anonymous-nominal traversal answers repeat visits from a hash set instead of `Vec::contains` | `rue-compiler` |
| RUE-1556 | Drop glue reads the shape `TypeFacts` already carries instead of querying the shape family again | `rue-compiler` |

The line numbers cited in the issues had drifted since the audit; every target was relocated by symbol and confirmed present before changing it.

## Behaviour

All five are implementation changes with no intended observable effect. Two of them are load-bearing enough to say why:

- **RUE-1558** keeps the conservative loop definition and the exact inclusive `[start, end]` depth results. Depth is accumulated in a wider counter and saturated on the way out, which matches the per-range `saturating_add` it replaces for counts a `u32` cannot hold.
- **RUE-1556** removes a direct query edge. It cannot change results, because `evaluate_type_facts` queries `compiler.type-shape` for the same key and stamps that answer onto every `Available` value it publishes — so facts that resolved at all resolved through that shape, which also makes the removed shape-failure branch unreachable rather than merely unused. The dependency is still observed transitively through the type-facts edge, so invalidation reaches drop glue unchanged.

## Verification

Emitted bytes were checked directly rather than argued: `examples/lattice/main.rue`, `examples/bst.rue`, `examples/dijkstra/main.rue` and `examples/collatz.rue` were compiled at `-O0` through `-O3` with a compiler built from this branch and with one built from `trunk`. All 16 executables are identical by sha256.

- `scripts/rue premerge` — 194 pass, 0 fail, clippy included
- `scripts/rue quick` — 30 pass
- `scripts/rue unit cfg` 261, `unit codegen` 726, `unit compiler` 885 — all pass
- Each commit was built and its crate suite run before committing, so the history bisects

## Tests

Each issue asked for specific coverage:

- **RUE-1558** keeps the old marking algorithm in the test module as a differential oracle and compares against it over nested, overlapping, self-looping and shared-header graphs, 200 fixed-seed randomized graphs, and a 20,000-instruction case where half the instructions carry overlapping back-edges.
- **RUE-1559** pins the reverse declaration order of 64 owned parameters, and measures allocations against an otherwise identical build with an empty schedule — an exact control, since `to_vec()` on an empty slice does not allocate. Confirmed to fail on the pre-change code, by exactly the two copies removed.
- **RUE-1560** moves and re-initializes a struct field repeatedly and pins that the path keeps exactly one flag slot, written in source order.
- **RUE-1555** builds an adversarial key — 256 distinct identities behind one shared argument slice referenced by 64 nested specializations, plus an identity reached through a `Function` producer — and pins that each is produced exactly once and that a reused scratch buffer yields the same result.
- **RUE-1556** asserts the drop-glue request's observed dependency families include type-facts and not type-shape, with the type-facts request as a control showing a shape edge is something these lists do surface.

## Not included

`RUE-1545`, `RUE-1546` and `RUE-1548`–`RUE-1554` were filed alongside these and are left alone: RUE-1545 states in its own body that it needs a maintainer call on which representation replaces the dense liveness table, RUE-1546 implements ADR-0075 while that ADR is still `status: proposal` with an empty `accepted:` field, and the rest carry `needs-decision`. RUE-1547 has no open question but is a substantially larger change with its own acceptance criteria, so it is not bundled here.

Fixes RUE-1555
Fixes RUE-1556
Fixes RUE-1558
Fixes RUE-1559
Fixes RUE-1560

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRrzrkJm9LMi4Vvs13sdA6)_