### PR TITLE
Publish one import-discovery revision per wave, not per hop

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -2034,7 +2034,7 @@ fn unstable_views_do_not_alias_query_engine_records() {
         reexports,
         [
             "pubusecrate::diagnostic::{ColorChoice,DiagnosticFormatter,JsonDiagnostic,JsonDiagnosticFormatter,JsonSpan,JsonSuggestion,MultiFileFormatter,MultiFileJsonFormatter,SourceInfo,};",
-            "pubusecrate::import_discovery::{AcceptedImportSource,DiscoverySourceAssembler,ImportDemandFrontier,ImportDemandMode,ImportDemandRoots,ImportDiscoveryPlan,ImportDiscoveryRequest,ImportInputRevision,ImportObservation,ImportObservationLedger,ImportObservationStatus,};",
+            "pubusecrate::import_discovery::{AcceptedImportSource,DiscoverySourceAssembler,ImportDemandFrontier,ImportDemandMode,ImportDemandRoots,ImportDiscoveryPlan,ImportDiscoveryRequest,ImportDiscoveryWave,ImportInputRevision,ImportObservation,ImportObservationLedger,ImportObservationStatus,};",
             "pubusecrate::session::{ClosedDiscoveryContinuation,RootedCfgOutput,RootedCfgUnit,RootedParkOutcome,TrustedSuccessorDelta,};",
         ],
         "unstable may reexport only reviewed presentation, source-assembly, and host discovery-protocol records"

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -741,24 +741,23 @@ impl ImportDemandFrontier {
             .flat_map(|requests| requests.iter())
             .map(ImportDiscoveryRequest::occurrence)
     }
+}
 
-    /// The occurrences whose ledger answers changed since the previous round's
-    /// reads were assembled: this frontier's own demanded occurrences, plus the
-    /// previous frontier's.
-    ///
-    /// A round assembles from a ledger holding the carried observations plus its
-    /// own batch's answers. The previous round's fanout answers — the extra
-    /// occurrences that shared one host read — only enter the carried ledger when
-    /// that batch is published, so they first become assemblable here; this
-    /// round's own batch supplies the rest. Every occurrence outside the union
-    /// carries the observations it already carried, so its winner cannot change.
-    pub(crate) fn round_read_roots(&self, previous: &ImportDemandFrontier) -> ImportDemandRoots {
-        ImportDemandRoots::new(
-            previous
-                .demanded_occurrences()
-                .chain(self.demanded_occurrences())
-                .cloned(),
-        )
+/// One physical host operation: every candidate request naming the same
+/// operation under the same captured context receives one host answer, which
+/// then fans out to each requesting occurrence.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ImportHostOperationKey {
+    context: ImportDiscoveryContext,
+    requested_path: Arc<str>,
+}
+
+impl ImportHostOperationKey {
+    pub(crate) fn new(request: &ImportDiscoveryRequest) -> Self {
+        Self {
+            context: request.context().clone(),
+            requested_path: Arc::from(request.requested_path()),
+        }
     }
 }
 
@@ -1034,41 +1033,272 @@ impl ImportDiscoveryPlan {
         accepted_sources_for(self.groups.delta_segment().iter(), ledger)
     }
 
-    /// The accepted sources of exactly `occurrences`, resolved by the same
-    /// candidate precedence as [`Self::accepted_sources`].
+    /// The candidate groups of exactly `occurrences`, in candidate-precedence
+    /// order.
     ///
-    /// One ordinary discovery round only changes the ledger at the occurrences
-    /// its own and its predecessor round's frontier demanded answers for; every
-    /// other occurrence carries the identical observations it carried when it was
-    /// last assembled, so re-deriving its winner re-proves an already assembled
-    /// conclusion. Reducing exactly the changed occurrences therefore yields the
-    /// same new accepted sources, in the same canonical order, as reducing the
-    /// whole plan — while costing O(changed occurrences · log n) rather than
-    /// O(plan) per round.
-    ///
-    /// Each occurrence's candidate groups are found by binary search: every
-    /// request in a plan carries the plan's own context, so the canonical group
-    /// order sorts by context and then by occurrence, and one occurrence's groups
-    /// are a contiguous range of every stored segment.
-    pub(crate) fn accepted_sources_at<'a>(
-        &'a self,
-        ledger: &'a ImportObservationLedger,
+    /// A discovery wave continues the precedence walk of the occurrences its
+    /// starting frontier demanded answers for, so it needs those occurrences'
+    /// groups without materializing the merged plan. Each occurrence's groups
+    /// are found by binary search: every request in a plan carries the plan's
+    /// own context, so the canonical group order sorts by context and then by
+    /// occurrence, and one occurrence's groups are a contiguous range of every
+    /// stored segment.
+    pub(crate) fn groups_at(
+        &self,
         occurrences: &ImportDemandRoots,
-    ) -> Vec<&'a AcceptedImportSource> {
-        let mut accepted = Vec::new();
-        let mut candidates: Vec<&Arc<[ImportDiscoveryRequest]>> = Vec::new();
+    ) -> Vec<(ImportOccurrenceKey, Vec<Arc<[ImportDiscoveryRequest]>>)> {
+        let mut found = Vec::with_capacity(occurrences.occurrences().len());
         for occurrence in occurrences.occurrences() {
-            candidates.clear();
+            let mut candidates: Vec<Arc<[ImportDiscoveryRequest]>> = Vec::new();
             self.groups.for_each_matching(
                 |group| (&group[0].context, &group[0].occurrence).cmp(&(&self.context, occurrence)),
-                |group| candidates.push(group),
+                |group| candidates.push(group.clone()),
             );
-            // Segment-local ranges arrive segment by segment; candidate
-            // precedence is the canonical group order.
-            candidates.sort_by(|left, right| group_order(left, right));
-            extend_accepted_from_site(&mut accepted, candidates.iter().copied(), ledger);
+            candidates.sort_by(group_order);
+            found.push((occurrence.clone(), candidates));
         }
-        canonicalize_accepted(accepted)
+        found
+    }
+}
+
+/// One discovery wave: the transitive import closure reachable from a round's
+/// starting frontier, resolved hop by hop and published as ONE input revision
+/// (ADR-0075).
+///
+/// A hop-granular round can only resolve the imports of sources the current
+/// revision already carries, so a depth-n chain costs n revision mints, ledger
+/// appends, batch publications, and validation sweeps. A wave keeps the hop
+/// structure — each hop emits exactly the operations, in exactly the order, the
+/// corresponding round's frontier would have emitted — but resolves the next hop
+/// against its own running ledger instead of a published successor. The reads it
+/// performs, and the order the ledger records them in, are therefore identical
+/// to the sequence of rounds it replaces; only the number of publications
+/// changes.
+///
+/// Candidate policy stays compiler-owned and singular: a hop's next operations
+/// come from [`discovery_groups_for_occurrence`] and
+/// [`exact_import_pending_requests`], the same functions the `ResolveImport`
+/// query evaluates. The wave runs them eagerly because the memoized query cannot
+/// serve sources no revision carries yet.
+#[derive(Debug)]
+pub struct ImportDiscoveryWave {
+    revision: ImportInputRevision,
+    context: ImportDiscoveryContext,
+    /// The wave's running ledger: the revision's carried observations plus every
+    /// answer the wave has recorded, fanned out exactly as publication will.
+    ledger: ImportObservationLedger,
+    /// Occurrences whose candidate-precedence walk is still open, with the
+    /// canonical groups each owns. A concluded occurrence is dropped, so a hop
+    /// costs O(open occurrences), never O(plan).
+    open: BTreeMap<ImportOccurrenceKey, Vec<Arc<[ImportDiscoveryRequest]>>>,
+    /// Modules whose occurrences are already accounted for — the revision's own
+    /// modules plus everything the wave has read.
+    known_modules: BTreeSet<ModuleId>,
+    /// This hop's deduplicated host operations and the occurrence requests each
+    /// one answers.
+    requests: Vec<ImportDiscoveryRequest>,
+    fanout: Vec<Arc<[ImportDiscoveryRequest]>>,
+    /// Every hop's operations and answers in hop order — the single batch this
+    /// wave publishes.
+    batch_requests: Vec<ImportDiscoveryRequest>,
+    batch_fanout: Vec<Arc<[ImportDiscoveryRequest]>>,
+    batch_observations: Vec<ImportObservation>,
+    /// Accepted sources reduced hop by hop, in the canonical order each hop
+    /// offers them to the assembler.
+    accepted: Vec<AcceptedImportSource>,
+    /// A source that did not parse ends the wave at that hop's boundary, so the
+    /// published revision holds exactly what the equivalent round would have and
+    /// the canonical staging parse reports the diagnostics.
+    sealed: bool,
+}
+
+impl ImportDiscoveryWave {
+    /// Begin a wave from a round's starting frontier. `ledger` is the revision's
+    /// carried ledger; `frontier` is the batch the host is about to answer.
+    pub(crate) fn begin(
+        plan: &ImportDiscoveryPlan,
+        frontier: &ImportDemandFrontier,
+        ledger: ImportObservationLedger,
+    ) -> CompileResult<Self> {
+        if frontier.mode != ImportDemandMode::Rooted {
+            return Err(invalid_input(
+                "speculative import work cannot open a discovery wave",
+            ));
+        }
+        let demanded = ImportDemandRoots::new(frontier.demanded_occurrences().cloned());
+        let open = plan.groups_at(&demanded).into_iter().collect();
+        let known_modules = plan
+            .source_revision()
+            .modules()
+            .iter()
+            .map(|revision| revision.module.clone())
+            .collect();
+        Ok(Self {
+            revision: frontier.revision,
+            context: plan.context().clone(),
+            ledger,
+            open,
+            known_modules,
+            requests: frontier.requests.to_vec(),
+            fanout: frontier.fanout.to_vec(),
+            batch_requests: Vec::new(),
+            batch_fanout: Vec::new(),
+            batch_observations: Vec::new(),
+            accepted: Vec::new(),
+            sealed: false,
+        })
+    }
+
+    /// The exact ordered operations the host must answer for this hop.
+    pub fn requests(&self) -> &[ImportDiscoveryRequest] {
+        &self.requests
+    }
+
+    /// Whether the wave has reached its fixed point — the frontier of the
+    /// transitive closure raised no further demand.
+    pub fn is_complete(&self) -> bool {
+        self.requests.is_empty()
+    }
+
+    /// The accepted sources this wave read, in the canonical order they were
+    /// reduced. The host re-verifies their stamps before publication so a
+    /// mid-wave rewrite can never enter a mixed-stamp revision.
+    pub fn accepted_reads(&self) -> &[AcceptedImportSource] {
+        &self.accepted
+    }
+
+    /// Record one hop's answers and derive the next hop.
+    ///
+    /// The answers are checked against this hop's operations exactly as batch
+    /// publication checks them, then fanned out into the running ledger. Sources
+    /// the hop accepted are read for their own `@import` occurrences, whose
+    /// candidate groups join the open set; occurrences whose precedence walk
+    /// concluded leave it.
+    pub(crate) fn extend(&mut self, observations: Vec<ImportObservation>) -> CompileResult<()> {
+        if observations.len() != self.requests.len()
+            || observations
+                .iter()
+                .zip(self.requests.iter())
+                .any(|(observation, request)| observation.request() != request)
+        {
+            return Err(invalid_input(
+                "host import results must exactly preserve the compiler-produced batch order",
+            ));
+        }
+        let hop_requests = std::mem::take(&mut self.requests);
+        let hop_fanout = std::mem::take(&mut self.fanout);
+        let mut answered: BTreeSet<&ImportOccurrenceKey> = BTreeSet::new();
+        for (observation, fanout) in observations.iter().zip(hop_fanout.iter()) {
+            for request in fanout.iter() {
+                answered.insert(request.occurrence());
+                self.ledger
+                    .record(observation.fanout_to(request.clone())?)?;
+            }
+        }
+        // Reduce exactly the occurrences whose ledger answers this hop changed —
+        // the same reduction the round it replaces performs, over the same
+        // occurrences, in the same canonical order.
+        let reduced = {
+            let groups = answered
+                .iter()
+                .filter_map(|occurrence| self.open.get(*occurrence))
+                .flat_map(|groups| groups.iter());
+            accepted_sources_for(groups, &self.ledger)
+                .into_iter()
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+        for source in &reduced {
+            let module = classify_module(
+                &self.context,
+                source.requested_path(),
+                source.canonical_path(),
+            )?;
+            if !self.known_modules.insert(module.clone()) {
+                continue;
+            }
+            let Some(sites) = crate::parsed_modules::parse_unpublished_import_sites(
+                &module,
+                source.canonical_path(),
+                source.source(),
+            ) else {
+                self.sealed = true;
+                continue;
+            };
+            let importer_path = requested_path_for_module(&self.context, &module)?;
+            for site in &sites {
+                let occurrence = ImportOccurrenceKey::from_directive(site);
+                let groups =
+                    discovery_groups_for_occurrence(&self.context, &occurrence, &importer_path)?;
+                self.open.insert(occurrence, groups);
+            }
+        }
+        self.accepted.extend(reduced);
+        self.batch_requests.extend(hop_requests);
+        self.batch_fanout.extend(hop_fanout);
+        self.batch_observations.extend(observations);
+        self.advance_frontier();
+        Ok(())
+    }
+
+    /// Derive the next hop's operations from the open set: each open occurrence's
+    /// pending candidate requests, in occurrence order, deduplicated to one host
+    /// operation with a fanout — the frontier construction, over the wave's own
+    /// running ledger rather than a published revision.
+    fn advance_frontier(&mut self) {
+        let mut requests = Vec::new();
+        let mut fanout = Vec::<Vec<ImportDiscoveryRequest>>::new();
+        let mut operations = BTreeMap::<ImportHostOperationKey, usize>::new();
+        let mut concluded = Vec::new();
+        for (occurrence, groups) in &self.open {
+            let pending = exact_import_pending_requests(groups, &self.ledger);
+            if pending.is_empty() {
+                // The precedence walk is over: the ledger only grows, and no
+                // growth can reopen an occurrence whose candidates are all
+                // decided.
+                concluded.push(occurrence.clone());
+                continue;
+            }
+            for request in pending {
+                let operation = ImportHostOperationKey::new(&request);
+                match operations.get(&operation).copied() {
+                    Some(index) => fanout[index].push(request),
+                    None => {
+                        operations.insert(operation, requests.len());
+                        requests.push(request.clone());
+                        fanout.push(vec![request]);
+                    }
+                }
+            }
+        }
+        for occurrence in concluded {
+            self.open.remove(&occurrence);
+        }
+        if self.sealed {
+            // A hop that read an unparsable source publishes what it has; the
+            // still-open occurrences are re-rooted by the next ordinary round.
+            return;
+        }
+        self.requests = requests;
+        self.fanout = fanout
+            .into_iter()
+            .map(Arc::<[ImportDiscoveryRequest]>::from)
+            .collect();
+    }
+
+    /// The single batch this wave publishes: every hop's operations, fanout, and
+    /// answers, concatenated in hop order.
+    pub(crate) fn into_batch(self) -> (ImportDemandFrontier, Vec<ImportObservation>) {
+        (
+            ImportDemandFrontier {
+                revision: self.revision,
+                mode: ImportDemandMode::Rooted,
+                requests: self.batch_requests.into(),
+                fanout: self.batch_fanout.into_iter().collect::<Vec<_>>().into(),
+                speculative_blocked: false,
+            },
+            self.batch_observations,
+        )
     }
 }
 
@@ -1858,28 +2088,19 @@ impl DiscoverySourceAssembler {
         Ok(added)
     }
 
-    /// Add only the accepted reads of the occurrences one ordinary discovery
-    /// round changed. The rest of the plan carries the observations it carried
-    /// when it was last assembled, and assembly is idempotent for an already
-    /// assembled source, so this adds exactly what re-reducing the whole plan
-    /// would add — in the same canonical order, at O(changed occurrences) per
-    /// round instead of O(plan).
+    /// Add the accepted reads one discovery wave reduced (ADR-0075).
     ///
-    /// `occurrences` is compiler-derived from the frontier values themselves
-    /// (see `ImportDemandFrontier::demanded_occurrences`); the host contributes
-    /// no membership claim of its own.
-    pub fn add_plan_round_reads(
-        &mut self,
-        plan: &ImportDiscoveryPlan,
-        ledger: &ImportObservationLedger,
-        occurrences: &ImportDemandRoots,
-    ) -> CompileResult<usize> {
-        if plan.context != self.context {
+    /// The wave reduced them hop by hop from its own running ledger, in the same
+    /// canonical order and by the same candidate precedence the rounds it
+    /// replaces would have used, so this adds exactly what those rounds' plan
+    /// reductions would have added.
+    pub fn add_wave_reads(&mut self, wave: &ImportDiscoveryWave) -> CompileResult<usize> {
+        if wave.context != self.context {
             return Err(invalid_input(
-                "discovery plan belongs to a different epoch or captured context",
+                "discovery wave belongs to a different epoch or captured context",
             ));
         }
-        let reduced = plan.accepted_sources_at(ledger, occurrences);
+        let reduced = wave.accepted_reads();
         self.plan_reads_reduced = self.plan_reads_reduced.saturating_add(reduced.len() as u64);
         let mut added = 0;
         for source in reduced {

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -120,8 +120,8 @@ pub use import_discovery::{
 pub(crate) use import_discovery::AcceptedImportSource;
 pub(crate) use import_discovery::{
     ImportDemandFrontier, ImportDemandMode, ImportDemandRoots, ImportDiscoveryPlan,
-    ImportDiscoveryRequest, ImportInputRevision, ImportObservation, ImportObservationLedger,
-    ImportObservationStatus,
+    ImportDiscoveryRequest, ImportDiscoveryWave, ImportInputRevision, ImportObservation,
+    ImportObservationLedger, ImportObservationStatus,
 };
 pub use import_graph::{
     CanonicalImportCycle, CanonicalImportGraph, CanonicalImportGraphProblem,

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -1433,6 +1433,36 @@ pub(crate) fn parse_source_snapshot_module(
     }
 }
 
+/// The import occurrences of one source that has been read but not yet
+/// published into an input revision (ADR-0075).
+///
+/// A discovery wave extends past the sources of the revision it started from, so
+/// the next hop's candidate policy needs the freshly read module's `@import`
+/// sites before any revision carries it. This runs the same lexer, parser, and
+/// projection collector `parse_snapshot_file` runs — it is the canonical
+/// recognition path invoked eagerly, not a second one — and returns only the
+/// valid directives, in the same AST order [`ParsedModule::imports`] carries.
+///
+/// `None` means the source did not parse. The wave stops extending there and
+/// publishes; the canonical staging parse of the published revision then reports
+/// the diagnostics, exactly as it would have for the hop-granular round that
+/// read the same source.
+pub(crate) fn parse_unpublished_import_sites(
+    module: &ModuleId,
+    physical_path: &str,
+    source: &str,
+) -> Option<Vec<ImportDirective>> {
+    // Occurrence keys carry file-relative offsets, so the placeholder file id
+    // below never reaches a published span.
+    let outcome = crate::syntax::parse_file(
+        crate::queries::SourceView::new(physical_path, source, FileId::new(1)),
+        ThreadedRodeo::new(),
+    );
+    let ast = outcome.result.ok()?;
+    let projections = collect_module_projections(&ast, module, &outcome.interner).ok()?;
+    Some(projections.imports.valid)
+}
+
 pub(crate) fn rebind_parsed_module(
     snapshot: &SourceSnapshot,
     module: &Arc<ParsedModule>,

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -3012,21 +3012,6 @@ impl RetainedCharge for LookupImportValue {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-struct ImportHostOperationKey {
-    context: ImportDiscoveryContext,
-    requested_path: Arc<str>,
-}
-
-impl ImportHostOperationKey {
-    fn new(request: &ImportDiscoveryRequest) -> Self {
-        Self {
-            context: request.context().clone(),
-            requested_path: Arc::from(request.requested_path()),
-        }
-    }
-}
-
 #[derive(Debug)]
 struct ImportInputView {
     revision: Revision,
@@ -19151,7 +19136,8 @@ impl RevisionedQueryDatabase {
         }
         let mut requests = Vec::new();
         let mut fanout = Vec::<Vec<ImportDiscoveryRequest>>::new();
-        let mut operation_indices = BTreeMap::<ImportHostOperationKey, usize>::new();
+        let mut operation_indices =
+            BTreeMap::<crate::import_discovery::ImportHostOperationKey, usize>::new();
         let mut speculative_blocked = false;
         self.import_frontier_roots_requested = self
             .import_frontier_roots_requested
@@ -19183,7 +19169,7 @@ impl RevisionedQueryDatabase {
             }
             speculative_blocked |= value.speculative_blocked;
             for request in value.requests.iter() {
-                let operation = ImportHostOperationKey::new(request);
+                let operation = crate::import_discovery::ImportHostOperationKey::new(request);
                 if let Some(index) = operation_indices.get(&operation).copied() {
                     fanout[index].push(request.clone());
                 } else {

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -1765,6 +1765,55 @@ impl CompilerSession {
         )
     }
 
+    /// Open a discovery wave over the round's starting frontier (ADR-0075).
+    ///
+    /// The wave resolves the transitive import closure reachable from that
+    /// frontier hop by hop against its own running ledger, then publishes once
+    /// through [`Self::publish_import_wave`].
+    pub(crate) fn begin_import_wave(
+        &mut self,
+        revision: crate::ImportInputRevision,
+        plan: &crate::ImportDiscoveryPlan,
+        frontier: &crate::ImportDemandFrontier,
+    ) -> crate::CompileResult<crate::ImportDiscoveryWave> {
+        if frontier.revision() != revision {
+            return Err(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                "discovery wave frontier belongs to a stale immutable revision".into(),
+            )));
+        }
+        let ledger = self.queries.revisioned.import_ledger(revision)?;
+        crate::ImportDiscoveryWave::begin(plan, frontier, ledger)
+    }
+
+    /// Record one wave hop's answers and derive the next hop's operations.
+    pub(crate) fn extend_import_wave(
+        &mut self,
+        wave: &mut crate::ImportDiscoveryWave,
+        observations: Vec<crate::ImportObservation>,
+    ) -> crate::CompileResult<()> {
+        wave.extend(observations)
+    }
+
+    /// Publish one whole wave as one successor immutable revision. The batch is
+    /// every hop's operations and answers in hop order, so the published ledger
+    /// records exactly the reads the hop-granular rounds would have recorded, in
+    /// the same order.
+    pub(crate) fn publish_import_wave(
+        &mut self,
+        wave: crate::ImportDiscoveryWave,
+        snapshot: &SourceSnapshot,
+        accepted_reads: crate::AcceptedReadManifest,
+    ) -> crate::CompileResult<(crate::ImportInputRevision, crate::ImportDemandFrontier)> {
+        let (frontier, observations) = wave.into_batch();
+        let revision = self.queries.revisioned.publish_import_batch(
+            &frontier,
+            snapshot,
+            accepted_reads,
+            observations,
+        )?;
+        Ok((revision, frontier))
+    }
+
     /// Returns the immutable canonical ledger carried by one input revision.
     pub(crate) fn import_observation_ledger(
         &self,

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -13,8 +13,8 @@ pub use crate::diagnostic::{
 };
 pub use crate::import_discovery::{
     AcceptedImportSource, DiscoverySourceAssembler, ImportDemandFrontier, ImportDemandMode,
-    ImportDemandRoots, ImportDiscoveryPlan, ImportDiscoveryRequest, ImportInputRevision,
-    ImportObservation, ImportObservationLedger, ImportObservationStatus,
+    ImportDemandRoots, ImportDiscoveryPlan, ImportDiscoveryRequest, ImportDiscoveryWave,
+    ImportInputRevision, ImportObservation, ImportObservationLedger, ImportObservationStatus,
 };
 
 /// Begin a fresh external-input observation generation.
@@ -73,17 +73,41 @@ pub fn plan_round_roots(
     plan.round_roots(previous)
 }
 
-/// The occurrences one ordinary discovery round must assemble reads for: the
-/// occurrences `current` and `previous` demanded host answers for. Every other
-/// occurrence carries the observations it carried when it was last assembled, so
-/// assembling this union adds exactly what re-reducing the whole plan would add.
-/// Both halves come from the compiler-owned frontier values; the host supplies
-/// no membership of its own.
-pub fn plan_round_read_roots(
-    previous: &ImportDemandFrontier,
-    current: &ImportDemandFrontier,
-) -> ImportDemandRoots {
-    current.round_read_roots(previous)
+/// Open a discovery wave over one round's starting frontier (ADR-0075).
+///
+/// The wave is the unit of publication: it resolves the transitive import
+/// closure reachable from that frontier hop by hop, emitting each hop's host
+/// operations in the exact order the round it replaces would have emitted them,
+/// and is published once by [`publish_import_wave`].
+pub fn begin_import_wave(
+    session: &mut crate::CompilerSession,
+    revision: ImportInputRevision,
+    plan: &crate::ImportDiscoveryPlan,
+    frontier: &ImportDemandFrontier,
+) -> crate::CompileResult<ImportDiscoveryWave> {
+    session.begin_import_wave(revision, plan, frontier)
+}
+
+/// Record one wave hop's answers and derive the next hop's operations. The host
+/// supplies only results for the exact batch [`ImportDiscoveryWave::requests`]
+/// named, in that order.
+pub fn extend_import_wave(
+    session: &mut crate::CompilerSession,
+    wave: &mut ImportDiscoveryWave,
+    observations: Vec<crate::ImportObservation>,
+) -> crate::CompileResult<()> {
+    session.extend_import_wave(wave, observations)
+}
+
+/// Publish one whole wave as one successor immutable revision, returning that
+/// revision and the batch frontier the next round continues from.
+pub fn publish_import_wave(
+    session: &mut crate::CompilerSession,
+    wave: ImportDiscoveryWave,
+    snapshot: &crate::SourceSnapshot,
+    accepted_reads: crate::AcceptedReadManifest,
+) -> crate::CompileResult<(ImportInputRevision, ImportDemandFrontier)> {
+    session.publish_import_wave(wave, snapshot, accepted_reads)
 }
 
 pub fn publish_import_observation_batch(

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -8,11 +8,12 @@ use std::time::{Duration, SystemTime};
 
 use rue_compiler::unstable::{
     AcceptedImportSource, DiscoverySourceAssembler, ImportDemandFrontier, ImportDemandMode,
-    ImportDiscoveryRequest, ImportInputRevision, ImportObservation, ImportObservationStatus,
-    RootedParkOutcome, TrustedSuccessorDelta, begin_import_input_request,
-    close_import_discovery_successor, close_import_input_request, closed_discovery_continuation,
-    discovery_attempt, import_demand_frontier_for_roots, import_observation_ledger,
-    plan_delta_roots, plan_round_read_roots, plan_round_roots, publish_import_observation_batch,
+    ImportDiscoveryPlan, ImportDiscoveryRequest, ImportDiscoveryWave, ImportInputRevision,
+    ImportObservation, ImportObservationStatus, RootedParkOutcome, TrustedSuccessorDelta,
+    begin_import_input_request, begin_import_wave, close_import_discovery_successor,
+    close_import_input_request, closed_discovery_continuation, discovery_attempt,
+    extend_import_wave, import_demand_frontier_for_roots, import_observation_ledger,
+    plan_delta_roots, plan_round_roots, publish_import_observation_batch, publish_import_wave,
     publish_trusted_toolchain_successor, rooted_or_toolchain_park,
     stage_import_discovery_successor, stage_import_input_request,
 };
@@ -797,6 +798,111 @@ struct ReClose<'a> {
     delta: &'a TrustedSuccessorDelta,
 }
 
+/// How many times one ordinary discovery round may re-run its wave because a
+/// source it read changed before the wave published.
+///
+/// A wave re-run is bounded rather than unlimited: a source being rewritten in a
+/// loop must surface as a fail-closed error instead of spinning discovery
+/// forever. The bound is generous — a real editor save races one wave at most.
+const WAVE_STAMP_RETRIES: u32 = 4;
+
+#[cfg(test)]
+thread_local! {
+    /// Test hook fired between a wave's last read and its stamp verification, so
+    /// a test can rewrite a source inside the exact window the atomicity
+    /// contract covers.
+    static WAVE_PUBLISH_HOOK: std::cell::RefCell<Option<Box<dyn FnMut()>>> =
+        const { std::cell::RefCell::new(None) };
+    /// Waves discarded by that verification and re-run.
+    static WAVE_STAMP_RERUNS: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+fn fire_wave_publish_hook() {
+    WAVE_PUBLISH_HOOK.with(|hook| {
+        if let Some(hook) = hook.borrow_mut().as_mut() {
+            hook();
+        }
+    });
+}
+
+/// Whether every source the wave read still has the exact physical identity and
+/// metadata stamp it was read with.
+///
+/// A wave publishes one revision covering reads taken over its whole closure, so
+/// the window between its first read and its publication is wider than a single
+/// hop's. Verifying the whole batch here, fail-closed, is what makes that window
+/// safe: a revision can never mix a stale read with a fresh one, because a single
+/// disagreement discards the wave and re-runs it.
+fn wave_reads_are_stable(wave: &ImportDiscoveryWave) -> bool {
+    wave.accepted_reads().iter().all(|source| {
+        fs::metadata(Path::new(source.canonical_path())).is_ok_and(|metadata| {
+            physical_file_identity(&metadata) == source.metadata_identity()
+                && file_metadata_fingerprint(&metadata) == source.metadata_fingerprint()
+        })
+    })
+}
+
+/// Resolve one discovery wave to its fixed point and publish it as one revision.
+///
+/// Returns the successor revision and the batch frontier the next round
+/// continues from — the wave's whole fanout, so the next round re-roots exactly
+/// the occurrences the wave demanded answers for.
+#[allow(clippy::too_many_arguments)]
+fn run_import_wave(
+    assembler: &mut DiscoverySourceAssembler,
+    staging: &mut CompilerSession,
+    input_revision: ImportInputRevision,
+    plan: &ImportDiscoveryPlan,
+    frontier: &ImportDemandFrontier,
+    source_manifest: Option<&SourceManifest>,
+    reobserved_reads: Option<&HashMap<String, AcceptedImportSource>>,
+) -> Result<(ImportInputRevision, ImportDemandFrontier), SourceLoadError> {
+    for attempt in 0..=WAVE_STAMP_RETRIES {
+        let mut wave = begin_import_wave(staging, input_revision, plan, frontier)
+            .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+        while !wave.is_complete() {
+            let observations = wave
+                .requests()
+                .iter()
+                .cloned()
+                .map(|request| execute_import_request(request, source_manifest, reobserved_reads))
+                .collect::<Vec<_>>();
+            extend_import_wave(staging, &mut wave, observations)
+                .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+        }
+        #[cfg(test)]
+        fire_wave_publish_hook();
+        if !wave_reads_are_stable(&wave) {
+            #[cfg(test)]
+            WAVE_STAMP_RERUNS.with(|count| count.set(count.get() + 1));
+            if attempt == WAVE_STAMP_RETRIES {
+                return Err(SourceLoadError::Message(format!(
+                    "Error: a source read during import discovery kept changing across {} wave attempts",
+                    WAVE_STAMP_RETRIES + 1
+                )));
+            }
+            // Nothing was assembled or published, so the retry re-reads the same
+            // compiler-produced operations against the settled filesystem.
+            continue;
+        }
+        assembler
+            .add_wave_reads(&wave)
+            .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+        let successor_snapshot = assembler
+            .snapshot()
+            .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+        return publish_import_wave(
+            staging,
+            wave,
+            &successor_snapshot,
+            assembler.accepted_read_manifest(),
+        )
+        .map_err(|error| SourceLoadError::Message(format!("Error: {error}")));
+    }
+    unreachable!("the wave retry loop returns or fails on its last attempt")
+}
+
 fn drive_import_discovery_to_close(
     assembler: &mut DiscoverySourceAssembler,
     staging: &mut CompilerSession,
@@ -931,64 +1037,75 @@ fn drive_import_discovery_to_close(
         }
         let _read_span =
             tracing::info_span!("import_read", phase = "source_discovery_and_parsing").entered();
-        let observations = frontier
-            .requests()
-            .iter()
-            .cloned()
-            .map(|request| execute_import_request(request, source_manifest, reobserved_reads))
-            .collect::<Vec<_>>();
-        // In a trusted-toolchain re-close every frontier request resolves an
-        // `@import` edge owned by an appended leaf or a leaf newly discovered from
-        // it (e.g. strbuf → arraybuf/rawbuf). These edges are toolchain-internal,
-        // so a non-accepted observation there is an environmental failure of THAT
-        // transitive leaf, not a program error — attribute it to the exact failing
-        // module before the outcome is folded into an opaque close diagnostic.
-        if reclose.is_some()
-            && let Some(error) = classify_trusted_transitive_failure(context, &observations)
-        {
-            return Err(error);
-        }
-        let mut next_ledger = ledger;
-        for observation in observations.iter().cloned() {
-            next_ledger
-                .record(observation)
+        match &reclose {
+            // A trusted-toolchain re-close keeps the hop-granular contract: its
+            // frontier is rooted in the successor delta alone, its module set is
+            // fixed by an opaque capability, and its failures are attributed per
+            // leaf before the close folds them (RUE-1112).
+            Some(_) => {
+                let observations = frontier
+                    .requests()
+                    .iter()
+                    .cloned()
+                    .map(|request| {
+                        execute_import_request(request, source_manifest, reobserved_reads)
+                    })
+                    .collect::<Vec<_>>();
+                // In a trusted-toolchain re-close every frontier request resolves
+                // an `@import` edge owned by an appended leaf or a leaf newly
+                // discovered from it (e.g. strbuf → arraybuf/rawbuf). These edges
+                // are toolchain-internal, so a non-accepted observation there is an
+                // environmental failure of THAT transitive leaf, not a program
+                // error — attribute it to the exact failing module before the
+                // outcome is folded into an opaque close diagnostic.
+                if let Some(error) = classify_trusted_transitive_failure(context, &observations) {
+                    return Err(error);
+                }
+                let mut next_ledger = ledger;
+                for observation in observations.iter().cloned() {
+                    next_ledger
+                        .record(observation)
+                        .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+                }
+                // A successor adds its delta groups' accepted sources, never
+                // re-feeding the predecessor plan through the winner map.
+                assembler
+                    .add_successor_plan_reads(&plan, &next_ledger)
+                    .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+                let successor_snapshot = assembler
+                    .snapshot()
+                    .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+                input_revision = publish_import_observation_batch(
+                    staging,
+                    &frontier,
+                    &successor_snapshot,
+                    assembler.accepted_read_manifest(),
+                    observations,
+                )
                 .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+                previous_frontier = Some(frontier);
+            }
+            // An ordinary round resolves its whole wave before publishing
+            // (ADR-0075): the sources this frontier discovers are read, their own
+            // import occurrences are resolved against the wave's running ledger,
+            // and that repeats until the closure raises no further demand. Each hop
+            // emits exactly the operations, in exactly the order, the round it
+            // replaces would have emitted, so the ledger records the same reads in
+            // the same order — only the publication count changes.
+            None => {
+                let (revision, published) = run_import_wave(
+                    assembler,
+                    staging,
+                    input_revision,
+                    &plan,
+                    &frontier,
+                    source_manifest,
+                    reobserved_reads,
+                )?;
+                input_revision = revision;
+                previous_frontier = Some(published);
+            }
         }
-        // Assemble only the newly read leaves: a successor adds its delta groups'
-        // accepted sources, never re-feeding the predecessor plan through the
-        // winner map.
-        //
-        // An ordinary round assembles the same way once it has a predecessor
-        // round: only the occurrences this round's batch answered, plus the ones
-        // the previous round's fanout answered as that batch was published, can
-        // have gained a winner since the last assembly. Re-reducing the WHOLE
-        // plan every round instead re-derives every already assembled leaf's
-        // winner and re-offers it to the assembler, which is quadratic in the
-        // depth of an import chain. The first round has no predecessor, so it
-        // reduces the whole plan — for a continuation that is also what admits
-        // the carried generation's already accepted reads.
-        let assembled = match (&reclose, &previous_frontier) {
-            (Some(_), _) => assembler.add_successor_plan_reads(&plan, &next_ledger),
-            (None, None) => assembler.add_plan_reads(&plan, &next_ledger),
-            (None, Some(previous)) => assembler.add_plan_round_reads(
-                &plan,
-                &next_ledger,
-                &plan_round_read_roots(previous, &frontier),
-            ),
-        };
-        let _ = assembled.map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
-        let successor_snapshot = assembler
-            .snapshot()
-            .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
-        input_revision = publish_import_observation_batch(
-            staging,
-            &frontier,
-            &successor_snapshot,
-            assembler.accepted_read_manifest(),
-            observations,
-        )
-        .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
-        previous_frontier = Some(frontier);
     }
 
     let _close_span = tracing::info_span!("import_discovery_close").entered();
@@ -2068,8 +2185,12 @@ mod tests {
         assert_eq!(wide_result.read_manifest.len(), 25);
     }
 
+    /// ADR-0075: depth costs hops inside one wave, not published revisions. This
+    /// chain is three imports deep and still publishes exactly one discovery
+    /// revision — the wave reads `a`, resolves ITS import in the same round,
+    /// reads `b`, and so on to the fixed point before publishing once.
     #[test]
-    fn import_chain_adds_one_frontier_round_per_depth() {
+    fn import_chain_publishes_one_revision_per_wave_regardless_of_depth() {
         let dir = TestDir::new("depth-frontier");
         let main = dir.write(
             "main.rue",
@@ -2086,7 +2207,7 @@ mod tests {
         dir.write("c.rue", "pub fn value() -> i32 { 3 }");
 
         let result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
-        assert_eq!(result.input_revision.frontier_round(), 3);
+        assert_eq!(result.input_revision.frontier_round(), 1);
         assert_eq!(result.read_manifest.len(), 4);
     }
 
@@ -2112,7 +2233,16 @@ mod tests {
 
         let result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
 
-        assert_eq!(result.input_revision.frontier_round(), (MODULES - 1) as u64);
+        // ADR-0075: the whole chain is ONE wave, so discovery publishes exactly
+        // one input revision no matter how deep it runs. Publishing per import
+        // hop instead cost MODULES-1 revisions here — 31 revision mints, ledger
+        // appends, batch publications, and validation sweeps — and grew with
+        // depth by contract.
+        assert_eq!(
+            result.input_revision.frontier_round(),
+            1,
+            "a chain of any depth publishes one discovery revision per wave"
+        );
         assert_eq!(result.read_manifest.len(), MODULES);
         assert!(
             parse_sources_materialized(&result.session) <= (MODULES + 2) as u64,
@@ -2127,47 +2257,55 @@ mod tests {
             (MODULES - 1) as u64,
             "each import occurrence must enter the plan exactly once"
         );
-        // ADR-0073: every frontier round publishes an append-only overlay, so
-        // validation certificates survive the whole discovery chain. Without
-        // that, each of the ~MODULES rounds expired every certificate and this
-        // count grew as rounds times graph size — quadratic in chain depth
-        // (961+ at this shape). The bound is deliberately loose against
-        // scheduling variation while remaining far below quadratic growth.
+        // ADR-0073: every publication is an append-only overlay, so validation
+        // certificates survive the whole discovery chain. Without that, each of
+        // the ~MODULES hop-granular rounds expired every certificate and this
+        // count grew as rounds times graph size — quadratic in chain depth (961+
+        // at this shape). ADR-0075 leaves one publication to expire anything at
+        // all, so the count is 1 either way; the bound stays loose against
+        // scheduling variation and can only fall as waves remove publications.
         assert!(
             rue_compiler::unstable::validation_certificate_misses(&result.session)
                 <= (MODULES as u64) * 8,
             "discovery certificate misses must stay linear in module count"
         );
-        // Each round roots only in the occurrences the plan just gained plus the
-        // ones the previous round demanded answers for, and the whole plan is
-        // rooted once more to witness closure: roughly two roots per round plus
-        // one final pass. Rooting the whole plan every round instead dispatched
-        // one top-level `ResolveImport` request per occurrence per round — 527 at
-        // this shape, and quadratic in chain depth.
+        // The wave resolves the whole chain against its own running ledger, so
+        // the query frontier is dispatched exactly twice: once for the round's
+        // starting occurrence, and once more for the closing round, which roots
+        // in the wave's fanout (MODULES-1 occurrences) and then owes the whole
+        // plan one closure rooting (MODULES-1 again) — 1 + 31 + 31 = 63 here.
+        // Publishing per hop instead cost 93 at this shape, and rooting the
+        // whole plan every round cost 527 and grew quadratically with depth.
         assert!(
-            import_frontier_roots_requested(&result.session) <= (MODULES as u64) * 4,
+            import_frontier_roots_requested(&result.session) <= (MODULES as u64) * 2,
             "frontier dispatch must stay linear in chain depth, not rounds times plan"
         );
-        // The read half of the same property: each round reduces only the
-        // occurrences it and the previous round demanded answers for, so it
-        // offers the assembler about one accepted source per round plus the
-        // first round's whole-plan reduction. Re-reducing the whole plan every
-        // round instead offered every already assembled leaf again — 528 at this
-        // shape, and quadratic in chain depth.
+        // The read half of the same property: the wave reduces exactly the
+        // occurrences each hop answered, one accepted source apiece, and the
+        // closing round's frontier is empty so it assembles nothing — MODULES-1
+        // reads offered in total. Publishing per hop cost 61 (each round also
+        // re-reduced its predecessor's fanout occurrences), and re-reducing the
+        // whole plan every round offered 528 and grew quadratically with depth.
         assert!(
-            result.assembler.plan_reads_reduced() <= (MODULES as u64) * 2,
+            result.assembler.plan_reads_reduced() <= MODULES as u64,
             "per-round read volume must stay linear in chain depth, not rounds times plan"
         );
     }
 
     /// A candidate that misses on its first group is answered but NOT concluded:
-    /// the occurrence still owes its next candidate a round. Here `sub/leaf.rue`
-    /// imports `shared.rue`, which is absent beside it and present at the project
-    /// root, so its occurrence spans two rounds while its module is new in
-    /// neither. A round that rooted only in the plan's newly staged occurrences
-    /// would drop it.
+    /// the occurrence still owes its next candidate an operation. Here
+    /// `sub/leaf.rue` imports `shared.rue`, which is absent beside it and present
+    /// at the project root, so its precedence walk spans two hops while its
+    /// module is new in neither.
+    ///
+    /// The contract this pins is unchanged by ADR-0075 — an occurrence that is
+    /// answered but still open must be carried forward, and dropping it loses
+    /// `shared.rue` — but the carrying happens a level down: the wave keeps the
+    /// occurrence in its open set and derives its second candidate at the next
+    /// hop, instead of a later round re-rooting it. The three reads and the
+    /// resolution are identical; the three publications collapse to one.
     #[test]
-    fn import_occurrence_answered_but_still_open_is_rerooted_next_round() {
+    fn import_occurrence_answered_but_still_open_is_carried_across_wave_hops() {
         let dir = TestDir::new("open-occurrence-reroot");
         let main = dir.write(
             "main.rue",
@@ -2182,9 +2320,147 @@ mod tests {
         let result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
 
         assert_eq!(result.read_manifest.len(), 3);
-        // Three published batches: the leaf, its missed sibling candidate, then
-        // the project-root `shared.rue` the second candidate resolves to.
-        assert_eq!(result.input_revision.frontier_round(), 3);
+        assert!(
+            result
+                .read_manifest
+                .iter()
+                .any(|entry| entry.module().as_str() == "shared.rue"),
+            "the second candidate of the still-open occurrence must be resolved"
+        );
+        // One wave, three hops: the leaf, its missed sibling candidate, then the
+        // project-root `shared.rue` the second candidate resolves to. Publishing
+        // per hop minted three revisions for the same three reads.
+        assert_eq!(result.input_revision.frontier_round(), 1);
+    }
+
+    /// ADR-0075 stamp atomicity: a wave publishes one revision covering reads
+    /// taken across its whole closure, so a source rewritten after it was read
+    /// and before the wave publishes must be caught as a batch, fail-closed.
+    ///
+    /// The hook fires in exactly that window — after the wave's last hop, before
+    /// its stamp verification — and rewrites a source the wave read on its FIRST
+    /// hop. The wave is discarded and re-run against the settled filesystem, and
+    /// the revision that does publish carries the rewritten bytes with every
+    /// recorded read verifying. No revision can mix a stale read with a fresh
+    /// one, because one disagreement discards the whole wave.
+    #[test]
+    fn a_source_rewritten_mid_wave_forces_a_fail_closed_wave_rerun() {
+        let dir = TestDir::new("wave-stamp-atomicity");
+        let main = dir.write(
+            "main.rue",
+            r#"const a = @import("a.rue"); fn main() -> i32 { a.value() }"#,
+        );
+        dir.write(
+            "a.rue",
+            r#"pub const b = @import("b.rue"); pub fn value() -> i32 { b.value() + 1 }"#,
+        );
+        dir.write("b.rue", "pub fn value() -> i32 { 2 }");
+        let rewritten =
+            r#"pub const b = @import("b.rue"); pub fn value() -> i32 { b.value() + 9 }"#;
+
+        let path = dir.path.join("a.rue");
+        let fired = std::cell::Cell::new(false);
+        WAVE_STAMP_RERUNS.with(|count| count.set(0));
+        WAVE_PUBLISH_HOOK.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move || {
+                if !fired.replace(true) {
+                    fs::write(&path, rewritten).unwrap();
+                }
+            }));
+        });
+        let result = discover_and_load_imports(main.to_str().unwrap(), None, None);
+        WAVE_PUBLISH_HOOK.with(|hook| *hook.borrow_mut() = None);
+        let result = result.expect("a re-run wave closes against the settled filesystem");
+
+        assert_eq!(
+            WAVE_STAMP_RERUNS.with(std::cell::Cell::get),
+            1,
+            "the mid-wave rewrite must discard exactly one wave"
+        );
+        assert_eq!(result.read_manifest.len(), 3);
+        assert!(
+            result
+                .source_snapshot
+                .files()
+                .any(|source| source.source.contains("b.value() + 9")),
+            "the published revision must carry the rewritten source, never the stale read"
+        );
+        for entry in result.read_manifest.iter() {
+            let metadata = fs::metadata(entry.canonical_path()).expect("a published read exists");
+            assert_eq!(
+                physical_file_identity(&metadata),
+                entry.metadata_identity(),
+                "every recorded read of the published revision verifies"
+            );
+            assert_eq!(
+                file_metadata_fingerprint(&metadata),
+                entry.metadata_fingerprint(),
+                "every recorded read of the published revision verifies"
+            );
+        }
+    }
+
+    /// ADR-0075 determinism: the ledger's read order and the revision's contents
+    /// are properties of the compiler's candidate policy, not of how many query
+    /// workers happen to be running. A wave dedupes host operations and derives
+    /// each hop from its own ledger, so both must be identical across worker
+    /// counts and across repeated runs.
+    #[test]
+    fn wave_ledger_order_and_contents_are_independent_of_worker_count() {
+        fn discover(dir: &TestDir, jobs: usize) -> (String, Vec<String>, u64) {
+            rue_compiler::configure_thread_pool(jobs);
+            let result =
+                discover_and_load_imports(dir.path.join("main.rue").to_str().unwrap(), None, None)
+                    .unwrap();
+            let modules = result
+                .source_snapshot
+                .source_revision()
+                .modules()
+                .iter()
+                .map(|revision| revision.module.as_str().to_owned())
+                .collect();
+            (
+                rue_compiler::unstable::import_discovery_observation_ledger_debug(&result.revision),
+                modules,
+                result.input_revision.frontier_round(),
+            )
+        }
+
+        // A shape with real ordering pressure: same-depth siblings, a deeper
+        // chain, and one occurrence whose first candidate misses beside its
+        // importer and is answered at the project root.
+        let dir = TestDir::new("wave-determinism");
+        dir.write(
+            "main.rue",
+            r#"const a = @import("a.rue"); const d = @import("sub/d.rue"); fn main() -> i32 { a.value() + d.value() }"#,
+        );
+        dir.write(
+            "a.rue",
+            r#"pub const b = @import("b.rue"); pub const c = @import("c.rue"); pub fn value() -> i32 { b.value() + c.value() }"#,
+        );
+        dir.write(
+            "b.rue",
+            r#"pub const shared = @import("shared.rue"); pub fn value() -> i32 { shared.value() }"#,
+        );
+        dir.write("c.rue", "pub fn value() -> i32 { 3 }");
+        dir.write(
+            "sub/d.rue",
+            r#"pub const shared = @import("shared.rue"); pub fn value() -> i32 { shared.value() }"#,
+        );
+        dir.write("shared.rue", "pub fn value() -> i32 { 7 }");
+
+        let single = discover(&dir, 1);
+        let repeat = discover(&dir, 1);
+        let parallel = discover(&dir, 4);
+        rue_compiler::configure_thread_pool(0);
+
+        assert_eq!(single, repeat, "discovery must be reproducible run to run");
+        assert_eq!(
+            single, parallel,
+            "ledger read order and revision contents must not depend on worker count"
+        );
+        assert_eq!(single.2, 1, "this closure is one wave");
+        assert_eq!(single.1.len(), 6);
     }
 
     fn module_source_id(
@@ -2317,7 +2593,8 @@ mod tests {
 
         let result =
             discover_and_load_imports(main.to_str().unwrap(), None, Some(&std_root)).unwrap();
-        assert_eq!(result.input_revision.frontier_round(), 2);
+        // `std` and the `math.rue` it re-exports are two hops of one wave.
+        assert_eq!(result.input_revision.frontier_round(), 1);
         assert_eq!(result.read_manifest.len(), 3);
         assert!(
             result
@@ -3180,9 +3457,8 @@ mod tests {
                 .sharing_after
                 .expect("successor close has committed artifacts");
             for (index, name) in artifacts.iter().enumerate() {
-                let (before_ptr, before_delta) = before[index];
+                let (before_ptr, _) = before[index];
                 let (after_ptr, after_delta) = after[index];
-                assert_eq!(before_delta, 0, "the initial close is flat for {name}");
                 assert_eq!(
                     before_ptr, after_ptr,
                     "the successor must retain the predecessor {name} lineage witness"
@@ -3190,14 +3466,33 @@ mod tests {
                 assert!(after_delta > 0, "the successor delta must carry new {name}");
             }
         }
+        let small_before = small_acq.sharing_before.unwrap();
+        let big_before = big_acq.sharing_before.unwrap();
         let small_after = small_acq.sharing_after.unwrap();
         let big_after = big_acq.sharing_after.unwrap();
         for (index, name) in artifacts.iter().enumerate() {
+            // The initial close's own delta IS the project's discovery wave: one
+            // publication carries every module the closure reached, so the
+            // closing stage of a fresh close extends the first round's flat plan
+            // by whatever the wave found (ADR-0075). The small project's root
+            // imports nothing and closes on its first round, so its delta is
+            // empty; the big project's wave carries `a`, `b`, and `c`. That the
+            // predecessor delta tracks project topology this way is what makes
+            // the equal successor deltas below a real independence proof rather
+            // than a comparison of two zeroes.
+            assert_eq!(
+                small_before[index].1, 0,
+                "a close with nothing to discover has no {name} delta"
+            );
             assert_eq!(
                 small_after[index].1, big_after[index].1,
                 "the successor {name} delta size must be independent of the predecessor topology"
             );
         }
+        assert!(
+            big_before.iter().any(|(_, delta)| *delta > 0),
+            "the big project's initial close carries its own discovery wave's delta"
+        );
     }
 
     /// A manifest that denies a newly introduced transitive helper (`arraybuf.rue`,


### PR DESCRIPTION
Implements the wave core of ADR-0075 (#2464): import discovery's unit of publication moves from the import hop to the discovery wave. 8 files, +797/−192.

## Mechanism

When an ordinary round's frontier is non-empty, the new `run_import_wave` opens a compiler-owned wave seeded with the frontier's demanded occurrences and the revision's module set, then iterates hops **inside the wave's running ledger**: host answers the wave's exact ordered operations → answers verified and fanned out → answered occurrences reduced to winners by the canonical precedence walk → winners naming unknown modules are parsed for their own `@import` sites (same lexer/parser/projection collector the snapshot path uses) whose candidate groups join the open set → next hop is the standard frontier construction run over the wave's ledger. Hop *k* therefore emits exactly what round *k* emitted, in the same order — the wave is the round loop with the publication barrier hoisted to the fixpoint. At the fixpoint every read the wave performed is stamp-verified as a batch (fail-closed: a mid-wave source rewrite discards the wave and re-runs it) and published as **one** revision. Parse failures seal the wave at that hop's boundary so diagnostics are unchanged. The trusted re-close path keeps its hop-granular contract untouched.

## Results (agent-measured on a quiet host; re-verified on this branch)

- Discovery revisions: 32-module chain **31 → 1**; Lattice **5 → 1**.
- Chain n=1024: discovery span **903–909ms → 186–201ms** (4.6×); on this branch after rebase, root **754ms / discovery 251ms** (the same workload took 14.1s at the start of this campaign).
- Chain n=256 discovery 83–87ms → 30–33ms; n=64 similarly ~2×.
- Lattice: structurally better (frontier roots −33%, plan reads −43%, one revision) but below wall-clock noise — its discovery is ~5% of compile.

## Identity and falsifiers

- Executables byte-identical before/after AND at `-j1`/`-j4` on Lattice, Mosaic, chains n=64/256/1024; Lattice hash re-verified on this branch (`b893e76c…85e5`).
- **Stamp atomicity**: new test rewrites a source between the wave's last read and verification — exactly one wave discarded, published snapshot carries the new bytes, every recorded read re-verifies.
- **Determinism**: new test pins ledger dump, module order, and revision count identical across `-j1` (twice) and `-j4`.
- **Revision count**: exact `frontier_round() == 1` gate in the 32-module driver test.
- Counter rebaselines, each justified from the wave structure: `import_frontier_roots_requested` 93 → 63 (bound tightened to `≤ 2·MODULES`), `plan_reads_reduced` 61 → 31 (bound tightened to `≤ MODULES`), `certificate_misses` unchanged at 1 (never rises). Parse/module/group counters byte-identical. The answered-but-still-open fixture was rewritten to pin the same contract under wave timing, and one re-close topology test was replaced by the strictly stronger non-zero-delta comparison it previously proxied via two zeroes.

## Suites

Agent-side on the committed tree: quick 30/30, driver 42/42, rue-test 201/201, compiler 883/883, CLI 1,892/0, UI 250/0, fmt clean, both clippy gates green. Re-run on this branch post-rebase: driver 42/42, compiler 883/883, quick green, release hash + chain timings above. (One CLI run taken during concurrent A/B measurement showed child-process-budget timeouts; the isolated rerun on the same commit is 1,892/0.)

## Deliberately not delivered (measured decision)

The **cumulative exhaustion witness** (ADR-0075 item 3) is not implemented: the closing whole-plan re-root still runs, and `publish_trusted_toolchain_successor` still accepts on frontier emptiness. At n=1024 the entire `import_frontier` span is 48ms of a 1,380ms compile and the closing re-root is roughly half of that (~1.8%), while a sound witness needs a verified-witness bit on the frontier, a per-generation coverage record, and a forging hook for the falsifier. The verified 4.6× ships; the witness (and its forged-segment falsifier) remains open under the ADR, whose front matter is left untouched pending that completion.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTiBg7df72iMgdpAFv5wZs)_