### PR TITLE
RUE-1472: reuse native callable machine symbols

### DIFF
--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -784,9 +784,17 @@ impl CfgDomainProjection {
                     } else if source == "main" {
                         source.clone()
                     } else {
-                        crate::StableSymbolEncoder::encode(&crate::StableSymbolId::Callable(
-                            crate::StableCallableId::Function(callable.clone()),
-                        ))
+                        call_abis
+                            .get(callable)
+                            .and_then(|facts| facts.native_symbol.as_ref())
+                            .map(ToString::to_string)
+                            .unwrap_or_else(|| {
+                                crate::StableSymbolEncoder::encode(
+                                    &crate::StableSymbolId::Callable(
+                                        crate::StableCallableId::Function(callable.clone()),
+                                    ),
+                                )
+                            })
                     };
                     (machine, foreign)
                 }
@@ -805,9 +813,17 @@ impl CfgDomainProjection {
                     } else if source == "main" {
                         source.clone()
                     } else {
-                        crate::StableSymbolEncoder::encode(&crate::StableSymbolId::Callable(
-                            crate::StableCallableId::Function(callable),
-                        ))
+                        call_abis
+                            .get(&callable)
+                            .and_then(|facts| facts.native_symbol.as_ref())
+                            .map(ToString::to_string)
+                            .unwrap_or_else(|| {
+                                crate::StableSymbolEncoder::encode(
+                                    &crate::StableSymbolId::Callable(
+                                        crate::StableCallableId::Function(callable),
+                                    ),
+                                )
+                            })
                     };
                     (machine, foreign)
                 }

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -5855,6 +5855,13 @@ fn evaluate_call_abi(
             convention,
             return_class,
             arguments: arguments.into(),
+            native_symbol: matches!(convention, CallAbiConvention::Native).then(|| {
+                Arc::from(crate::StableSymbolEncoder::encode(
+                    &crate::StableSymbolId::Callable(crate::StableCallableId::Function(
+                        key.callable.clone(),
+                    )),
+                ))
+            }),
         },
     )))
 }
@@ -32089,6 +32096,7 @@ fn main() -> i32 {
         for target in [crate::Target::X86_64Linux, crate::Target::Aarch64Linux] {
             let native = request_call_abi(&database, revision, native.clone(), target);
             assert_eq!(native.convention, C::Native);
+            assert!(native.native_symbol.is_some());
             assert_eq!(
                 native.return_class,
                 if target == crate::Target::X86_64Linux {
@@ -32107,6 +32115,7 @@ fn main() -> i32 {
                     rue_air::TargetCAbiFlavor::Aapcs64
                 })
             );
+            assert!(foreign.native_symbol.is_none());
             assert_eq!(
                 foreign.return_class,
                 R::Scalar {

--- a/crates/rue-compiler/src/type_queries.rs
+++ b/crates/rue-compiler/src/type_queries.rs
@@ -137,12 +137,25 @@ impl QueryKey for CallAbiQueryKey {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub(crate) struct CallAbiFacts {
     pub(crate) convention: CallAbiConvention,
     pub(crate) return_class: CallAbiReturnClass,
     pub(crate) arguments: Arc<[CallAbiArgument]>,
+    /// The stable native machine symbol is derived once by the ABI terminal.
+    /// It is a retained projection, not part of the ABI facts' semantic value.
+    pub(crate) native_symbol: Option<Arc<str>>,
 }
+
+impl PartialEq for CallAbiFacts {
+    fn eq(&self, other: &Self) -> bool {
+        self.convention == other.convention
+            && self.return_class == other.return_class
+            && self.arguments == other.arguments
+    }
+}
+
+impl Eq for CallAbiFacts {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CallAbiConvention {
@@ -417,7 +430,11 @@ impl RetainedCharge for CallAbiArgument {
 
 impl RetainedCharge for CallAbiFacts {
     fn retained_charge(&self) -> u64 {
-        self.arguments.retained_charge()
+        self.arguments.retained_charge().saturating_add(
+            self.native_symbol
+                .as_ref()
+                .map_or(0, |symbol| symbol.len() as u64),
+        )
     }
 }
 
@@ -529,5 +546,27 @@ pub(crate) fn align_to(value: u64, alignment: u64) -> u64 {
         value
     } else {
         value.saturating_add(alignment - 1) / alignment * alignment
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn native_facts(symbol: &str) -> CallAbiFacts {
+        CallAbiFacts {
+            convention: CallAbiConvention::Native,
+            return_class: CallAbiReturnClass::ZeroSized,
+            arguments: Arc::from([]),
+            native_symbol: Some(Arc::from(symbol)),
+        }
+    }
+
+    #[test]
+    fn native_symbol_is_a_retained_projection_not_abi_semantic_identity() {
+        let first = native_facts("__rue_sem_v1_first");
+        let second = native_facts("__rue_sem_v1_second");
+        assert_eq!(first, second);
+        assert_ne!(first.retained_charge(), second.retained_charge());
     }
 }


### PR DESCRIPTION
## Summary

- compute each native callable machine symbol once in its existing call-ABI terminal
- carry it as a retained projection excluded from ABI semantic equality
- reuse it in CFG codegen-domain mappings while preserving foreign names and canonical fallback encoding

## Evidence

A fresh-process one-worker -O3 Lattice trace on trunk found 39,022 native stable-symbol encodes across 1,280 CFG domains but only 1,316 distinct identity fingerprints. Native callees accounted for 14,095 encodes and 1,220 distinct identities. This change removes 4,533 production callee encodes; broader destructor/drop-glue aliases remain a separate seam.

After rebasing onto exact trunk b800e12f36f9070490ccd54f23b0d4f177afb90b, eight alternating /usr/bin/time -lp pairs measured:

- retired instructions: -0.0975% paired median, MAD 0.0202%, 8/8 wins
- total time: -0.1679% paired median, 5/8 wins
- peak footprint: -0.1895% paired median, noisy/non-regressive
- cycles: +0.0657% paired median, noisy
- CFG wall subspans: slightly unfavorable/noisy despite the unanimous instruction win

The predeclared primary falsifier was retired instructions. Exact baseline/candidate executable and emitted output SHA matched: b893e76cfabed737b149d0e8c4d8527077dedd17da78418db20a28a7d30885e5. Compiler work, source metrics, compiler boundary, and stable JSON fields also matched.

## Correctness

- focused type-query test: 1/1
- focused call-ABI tests: 6/6
- focused durable-CFG tests: 6/6
- scripts/rue quick: 30/30 before rebase; focused suites rerun after rebase
- compiler Clippy passed
- formatting and diff checks passed

The cached symbol is derived entirely from the call-ABI query key. Manual PartialEq/Eq intentionally excludes it so incremental ABI semantic identity and stamps remain unchanged; retained-charge accounting includes its bytes.