### PR TITLE
RUE-1472: reuse canonical drop symbols

### DIFF
--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -1245,7 +1245,23 @@ fn materialize_and_build_cfg(
     // Every DropGlue terminal observes the exact TypeFacts terminal for the
     // same key. Keep one direct CFG edge to that transitive cone instead of
     // issuing and validating a duplicate top-level TypeFacts request.
-    context.query_registered_adaptive_batch(drop_glues, drop_dependencies)?;
+    let drop_glue_terminals =
+        context.query_registered_adaptive_batch(drop_glues, drop_dependencies.clone())?;
+    let mut drop_glue_symbols = std::collections::BTreeMap::new();
+    let mut destructor_symbols = std::collections::BTreeMap::new();
+    for (query, terminal) in drop_dependencies.iter().zip(drop_glue_terminals) {
+        let QueryOutcome::Success(crate::type_queries::DropGlueValue::Available(facts)) =
+            terminal.outcome()
+        else {
+            continue;
+        };
+        if let Some(symbol) = &facts.machine_symbol {
+            drop_glue_symbols.insert(query.ty.clone(), symbol.clone());
+        }
+        if let Some(symbol) = &facts.destructor_symbol {
+            destructor_symbols.insert(query.ty.clone(), symbol.clone());
+        }
+    }
     let prerequisite_queries_ns = elapsed_ns(prerequisite_queries_started);
     let breakdown = CfgConstructionBreakdown {
         input_preparation_ns,
@@ -1255,7 +1271,16 @@ fn materialize_and_build_cfg(
         prerequisite_collection_ns,
         prerequisite_queries_ns,
     };
-    build_cfg(context, call_abis, key, materialized, domains, breakdown)
+    build_cfg(
+        context,
+        call_abis,
+        key,
+        materialized,
+        domains,
+        drop_glue_symbols,
+        destructor_symbols,
+        breakdown,
+    )
 }
 
 /// The published composite-type ceiling was reached while this body's type
@@ -1285,6 +1310,8 @@ fn build_cfg(
     key: &CfgQueryKey,
     materialized: crate::local_semantic_materialization::LocalSemanticMaterialization,
     domains: crate::durable_cfg::CfgDomainProjection,
+    drop_glue_symbols: std::collections::BTreeMap<crate::TypeInstanceKey, Arc<str>>,
+    destructor_symbols: std::collections::BTreeMap<crate::TypeInstanceKey, Arc<str>>,
     breakdown: CfgConstructionBreakdown,
 ) -> Result<CfgValue, QueryAbort> {
     context.record_work(rue_query::WorkItem::new("cfg.build.attempts", 1));
@@ -1367,6 +1394,8 @@ fn build_cfg(
         &materialized.type_pool,
         &materialized.interner,
         &call_abi_facts,
+        &drop_glue_symbols,
+        &destructor_symbols,
     ) {
         Ok(value) => value,
         Err(error) => {

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -740,6 +740,8 @@ mod tests {
                 len: 3,
                 drop_element: true,
             },
+            machine_symbol: None,
+            destructor_symbol: None,
         };
         let slots = std::collections::BTreeMap::from([(element, 2), (owner.clone(), 6)]);
         let body = synthesize_canonical_drop_glue(&owner, &facts, &slots).unwrap();
@@ -859,6 +861,8 @@ mod tests {
             destructor: None,
             nested: Arc::from([]),
             plan,
+            machine_symbol: None,
+            destructor_symbol: None,
         }
     }
 

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -757,6 +757,8 @@ impl CfgDomainProjection {
             crate::FunctionInstanceKey,
             crate::type_queries::CallAbiFacts,
         >,
+        drop_glue_symbols: &std::collections::BTreeMap<crate::TypeInstanceKey, Arc<str>>,
+        destructor_symbols: &std::collections::BTreeMap<crate::TypeInstanceKey, Arc<str>>,
     ) -> Result<crate::cfg_query::CfgCodegenDomain, CfgDomainFailure> {
         let defined_symbol: Arc<str> = if source_name == "main" {
             Arc::from("main")
@@ -861,10 +863,16 @@ impl CfgDomainProjection {
                                 name: Arc::from("__drop"),
                             },
                         };
-                        let machine =
-                            crate::StableSymbolEncoder::encode(&crate::StableSymbolId::Callable(
-                                crate::StableCallableId::Function(callable),
-                            ));
+                        let machine = destructor_symbols
+                            .get(&owner)
+                            .map(ToString::to_string)
+                            .unwrap_or_else(|| {
+                                crate::StableSymbolEncoder::encode(
+                                    &crate::StableSymbolId::Callable(
+                                        crate::StableCallableId::Function(callable),
+                                    ),
+                                )
+                            });
                         if let Some(previous) =
                             symbol_mappings.insert(source.to_string(), machine.clone())
                             && previous != machine
@@ -887,11 +895,16 @@ impl CfgDomainProjection {
             let Some(drop_glue_source) = drop_glue_source else {
                 continue;
             };
-            let machine = crate::StableSymbolEncoder::encode(&crate::StableSymbolId::Callable(
-                crate::StableCallableId::Function(crate::FunctionInstanceKey::DropGlue(Box::new(
-                    owner,
-                ))),
-            ));
+            let machine = drop_glue_symbols
+                .get(&owner)
+                .map(ToString::to_string)
+                .unwrap_or_else(|| {
+                    crate::StableSymbolEncoder::encode(&crate::StableSymbolId::Callable(
+                        crate::StableCallableId::Function(crate::FunctionInstanceKey::DropGlue(
+                            Box::new(owner.clone()),
+                        )),
+                    ))
+                });
             if let Some(previous) = symbol_mappings.insert(drop_glue_source, machine.clone())
                 && previous != machine
             {

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -5999,6 +5999,20 @@ fn evaluate_drop_glue(
             destructor: facts.destructor.clone(),
             nested: nested.into(),
             plan,
+            machine_symbol: facts.needs_drop.then(|| {
+                Arc::from(crate::StableSymbolEncoder::encode(
+                    &crate::StableSymbolId::Callable(crate::StableCallableId::Function(
+                        crate::FunctionInstanceKey::DropGlue(Box::new(key.ty.clone())),
+                    )),
+                ))
+            }),
+            destructor_symbol: facts.destructor.as_ref().map(|destructor| {
+                Arc::from(crate::StableSymbolEncoder::encode(
+                    &crate::StableSymbolId::Callable(crate::StableCallableId::Function(
+                        destructor.clone(),
+                    )),
+                ))
+            }),
         },
     ))))
 }
@@ -33017,9 +33031,27 @@ fn main() -> i32 {
         let cold = request_drop_glue(&database, first_revision, outer.clone());
         assert_eq!(cold.execution(), RequestExecution::Computed);
         let cold_stamp = cold.terminal().unwrap().stamp();
+        let cold_machine_symbol = match cold.terminal().unwrap().outcome() {
+            rue_query::QueryOutcome::Success(crate::type_queries::DropGlueValue::Available(
+                facts,
+            )) => facts
+                .machine_symbol
+                .clone()
+                .expect("drop glue owns its symbol"),
+            _ => panic!("drop-glue plan did not publish"),
+        };
         let reused = request_drop_glue(&database, first_revision, outer.clone());
         assert_eq!(reused.execution(), RequestExecution::Reused);
         assert_eq!(reused.terminal().unwrap().stamp(), cold_stamp);
+        assert_eq!(
+            match reused.terminal().unwrap().outcome() {
+                rue_query::QueryOutcome::Success(
+                    crate::type_queries::DropGlueValue::Available(facts),
+                ) => facts.machine_symbol.as_deref(),
+                _ => None,
+            },
+            Some(cold_machine_symbol.as_ref())
+        );
 
         let reordered_revision = revision_for(&mut database, &reordered);
         let changed = request_drop_glue(&database, reordered_revision, outer);
@@ -33039,6 +33071,10 @@ fn main() -> i32 {
                 .map(|field| (field.name.as_ref(), field.drop))
                 .collect::<Vec<_>>(),
             [("spacer", false), ("first", true), ("second", true)]
+        );
+        assert_eq!(
+            facts.machine_symbol.as_deref(),
+            Some(cold_machine_symbol.as_ref())
         );
     }
 

--- a/crates/rue-compiler/src/type_queries.rs
+++ b/crates/rue-compiler/src/type_queries.rs
@@ -221,14 +221,32 @@ pub(crate) enum CallAbiValue {
     Failure(TypeQueryFailure),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub(crate) struct DropGlueFacts<D = crate::StableDefinitionKey, M = crate::ModuleId> {
     pub(crate) required: bool,
     pub(crate) synthesize: bool,
     pub(crate) destructor: Option<rue_air::FunctionInstanceKey<D, M>>,
     pub(crate) nested: Arc<[rue_air::TypeInstanceKey<D, M>]>,
     pub(crate) plan: DropGluePlan<D, M>,
+    /// The canonical machine symbol for this owner's synthesized drop glue.
+    /// This is a retained projection, not part of the semantic drop plan.
+    pub(crate) machine_symbol: Option<Arc<str>>,
+    /// The canonical machine symbol for this owner's source destructor, when
+    /// present. This is also a retained projection, not semantic identity.
+    pub(crate) destructor_symbol: Option<Arc<str>>,
 }
+
+impl<D: PartialEq, M: PartialEq> PartialEq for DropGlueFacts<D, M> {
+    fn eq(&self, other: &Self) -> bool {
+        self.required == other.required
+            && self.synthesize == other.synthesize
+            && self.destructor == other.destructor
+            && self.nested == other.nested
+            && self.plan == other.plan
+    }
+}
+
+impl<D: Eq, M: Eq> Eq for DropGlueFacts<D, M> {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum DropGluePlan<D = crate::StableDefinitionKey, M = crate::ModuleId> {
@@ -336,6 +354,8 @@ impl<D, M> DropGlueFacts<D, M> {
                         .into(),
                 },
             },
+            machine_symbol: self.machine_symbol.clone(),
+            destructor_symbol: self.destructor_symbol.clone(),
         })
     }
 }
@@ -453,6 +473,16 @@ impl<D: RetainedCharge, M: RetainedCharge> RetainedCharge for DropGlueFacts<D, M
             .retained_charge()
             .saturating_add(self.nested.retained_charge())
             .saturating_add(self.plan.retained_charge())
+            .saturating_add(
+                self.machine_symbol
+                    .as_ref()
+                    .map_or(0, |symbol| symbol.len() as u64),
+            )
+            .saturating_add(
+                self.destructor_symbol
+                    .as_ref()
+                    .map_or(0, |symbol| symbol.len() as u64),
+            )
     }
 }
 
@@ -566,6 +596,30 @@ mod tests {
     fn native_symbol_is_a_retained_projection_not_abi_semantic_identity() {
         let first = native_facts("__rue_sem_v1_first");
         let second = native_facts("__rue_sem_v1_second");
+        assert_eq!(first, second);
+        assert_ne!(first.retained_charge(), second.retained_charge());
+    }
+
+    #[test]
+    fn drop_symbols_are_retained_projections_not_drop_plan_identity() {
+        let first: DropGlueFacts = DropGlueFacts {
+            required: true,
+            synthesize: true,
+            destructor: None,
+            nested: Arc::from([]),
+            plan: DropGluePlan::None,
+            machine_symbol: Some(Arc::from("__rue_drop_first")),
+            destructor_symbol: Some(Arc::from("__rue_destructor_first")),
+        };
+        let second: DropGlueFacts = DropGlueFacts {
+            required: true,
+            synthesize: true,
+            destructor: None,
+            nested: Arc::from([]),
+            plan: DropGluePlan::None,
+            machine_symbol: Some(Arc::from("__rue_drop_second")),
+            destructor_symbol: Some(Arc::from("__rue_destructor_second")),
+        };
         assert_eq!(first, second);
         assert_ne!(first.retained_charge(), second.retained_charge());
     }


### PR DESCRIPTION
## Summary

- retain canonical synthesized drop-glue and source-destructor machine symbols on the existing `DropGlue` query terminal
- reuse those derived projections while building CFG cleanup aliases
- keep query equality/stamps semantic, preserve encoder fallbacks, and charge retained symbol bytes

## Evidence

The current Lattice trace recorded 9,555 destructor stable-symbol encodes across 24 identity fingerprints and 14,093 drop-glue encodes across 96 identities over 1,280 CFG domains.

Against exact trunk `4bf4ecd35c`, eight alternating fresh-process x86-64-linux `-j1 -O3` Lattice pairs measured:

| Metric | Paired median | MAD | Candidate wins |
| --- | ---: | ---: | ---: |
| retired instructions (primary falsifier) | -0.7801% | 0.0601% | 8/8 |
| cycles | -0.7848% | 1.1093% | 5/8 |
| compiler wall | -1.6193% | 1.4165% | 5/8 |
| process real | -1.6056% | 1.2542% | 5/8 |
| peak footprint | +1.3028% | 2.2280% | 3/8 |

The peak-footprint result is adverse but noisier than its measured effect and is disclosed rather than presented as a win. The retained projection itself is bounded to the already-demanded drop-glue terminals.

All 16 runs emitted exact executable SHA `b893e76cfabed737b149d0e8c4d8527077dedd17da78418db20a28a7d30885e5`. Stable selected JSON (`compiler_work`, source metrics, compiler boundary, output, and stable metadata/schema) was identical in every run with SHA `8bda35052128d3129af194796f590e846ca15067423892cbf5fd046a6fa56120`.

## Correctness and incremental behavior

- derived symbols are excluded from `DropGlueFacts` semantic equality, so query stamps remain owned by the drop plan
- incremental coverage verifies a reused terminal retains the same machine symbol and reordered drop fields publish a new terminal stamp
- incomplete/test inputs retain the existing encoder fallback; defined, foreign, and native-callable behavior is unchanged

## Validation

- focused type-query projection tests (2/2)
- focused drop-glue tests (7/7)
- focused durable-CFG tests (6/6)
- focused call-ABI tests (6/6)
- compiler Clippy
- formatting and `git diff --check`
- broad local compiler, scaling, driver, differential-oracle, and crate test suites passed while the wrapper's final oracle dependency upload continued

Linear: RUE-1472
