### PR TITLE
Propose ADR-0076: shared revision symbol space for body analysis

### DIFF
--- a/docs/designs/0076-shared-revision-symbol-space.md
+++ b/docs/designs/0076-shared-revision-symbol-space.md
@@ -1,0 +1,130 @@
+---
+id: 0076
+title: "Shared revision symbol space for body analysis"
+status: proposal
+tags: [architecture, compiler, performance, query-engine, type-system]
+feature-flag: null
+created: 2026-08-17
+accepted:
+implemented:
+spec-sections: []
+superseded-by:
+relates: ["ADR-0063", "ADR-0071", "ADR-0074", "RUE-1236"]
+---
+
+# ADR-0076: Shared revision symbol space for body analysis
+
+## Status
+
+Proposed, pending review. Follows the measurement note
+`docs/notes/per-body-identity-closure-materialization.md`: of the four
+candidate fixes for per-body identity-closure materialization, sharing the
+symbol interner has roughly five times the headroom of sharing the type
+pool, so it is proposed first. This is an ADR-0063 boundary question — it
+moves a body-private index space into a revision-shared one — which is why
+it needs a stated contract rather than just a byte-identity gate.
+
+## Summary
+
+Every body's semantic analysis today creates a fresh symbol interner
+(`ThreadedRodeo`) alongside its fresh `TypeInternPool`. On a cold Lattice
+build the program's 103-type nominal closure is re-materialized 20,325
+times across 1,263 bodies, and the measured cost is concentrated in the
+leaves of that re-materialization: symbol interning (`try_get_or_intern`,
+213.7M instructions, 2.95% of the build) and the formatting that feeds it,
+with the pool machinery itself at only 0.71%. Interning the same 103
+closure names once per body is pure redundancy: the strings are identical,
+only the `Spur` handles differ.
+
+This ADR shares one append-only symbol interner across all bodies of a
+revision:
+
+1. **Index space and scope.** The shared space is the symbol interner
+   (string → `Spur`), scoped to one revision generation of the semantic
+   engine. Type pools remain body-private exactly as today — this ADR
+   deliberately does not share pool indices, which are sort keys in
+   measured places and whose sharing (candidate A) reaches only 0.71%.
+2. **Handle discipline (the core contract).** `Spur` values under a
+   shared concurrent interner are assigned in first-intern order, which
+   varies with worker scheduling. Therefore: `Spur` is a process-local,
+   equality-only handle. It must never be ordered by, never feed a
+   deterministic counter, never be hashed into published state, and never
+   reach an emitted artifact. Anything needing an order orders by symbol
+   text or by a stable identity (ADR-0074's structural hashes exist for
+   exactly this). The implementation must enforce this mechanically — a
+   wrapper handle type that does not expose `Ord`/`PartialOrd`, with the
+   pre-change audit finding and converting any existing order-bearing use
+   before the sharing lands.
+3. **Byte identity is a hard gate, not a rebaseline.** Because handles
+   are equality-only, emitted output and all deterministic counters remain
+   byte-identical, including across `-j1`/`-j4`. If the implementation
+   cannot achieve that, the ADR's premise failed and the change must not
+   land — there is no counter-rebaseline escape hatch here, unlike
+   ADR-0074/0075 where the artifact itself was redefined.
+4. **Invalidation.** The shared interner is append-only within its
+   revision generation and dropped whole when the generation is
+   superseded. Bodies never observe removal or mutation of an entry. A
+   body analyzed against a superseded generation fails the authority
+   check below and re-runs — fail-closed, never silently reused.
+5. **`require_rir_authority`.** Its pointer-equality assertion (a body's
+   analysis-state interner must be the body RIR's interner) survives with
+   the revision interner as the shared referent: both sides hold the same
+   `Arc`, and the assertion becomes `Arc::ptr_eq` against the revision's
+   interner. A body RIR carrying a superseded generation's interner fails
+   the check, which is the invalidation path in (4) doing its job.
+
+## What this buys
+
+Up to ~213M instructions of redundant interning plus the formatting that
+feeds it — roughly **2.9–3.3% of a cold Lattice build**, concentrated in
+the semantic phase that is 45% of Lattice's wall time. chain-shaped
+programs (closure ≈ 5 types) see approximately nothing, which is the
+expected shape: this is a closure-size-scaled cost.
+
+## Falsifiers
+
+- **Byte identity**: executables and all `compiler_work` counters
+  identical before/after on Lattice, Mosaic, and chain fixtures, at
+  `-j1` and `-j4`, across repeated runs. This is the premise, not a
+  nice-to-have; failure kills the change.
+- **Handle discipline**: the wrapper handle exposes no ordering; a test
+  (or compile-time assertion) proves `Spur`-ordered iteration cannot
+  reach publication. The pre-change audit's findings (every current
+  order-bearing symbol-handle use and its replacement) are listed in the
+  implementation PR.
+- **Authority**: a test hands a body an interner from a superseded
+  generation and asserts `require_rir_authority` refuses it and the body
+  re-runs against the current generation.
+- **Concurrency**: `-j4` stress run with deterministic-output comparison
+  across ≥3 runs (scheduling-varied `Spur` assignment must be invisible).
+- **Retention**: peak RSS on Lattice within ±2% (one interner holding
+  the union of body symbols replaces 1,263 holding overlapping subsets —
+  expected to drop, measured not assumed).
+
+## Rejected alternatives (measured in the note)
+
+- **A. Shared frozen closure pool with copy-on-write overlays**: 0.71%
+  headroom; pool indices are sort keys (`ConstraintGenerator::expr_types`
+  ordering), so it breaks byte-identity by construction.
+- **B. Cross-body memo of minted closures keyed by identity epoch**:
+  refuted — the cached values are pool indices and `Spur`s in another
+  body's index spaces; a memo cannot transplant them.
+- **C. Per-module pre-mint**: strictly dominated by A on Lattice's shape
+  (61 named nominals span all 1,263 bodies).
+- **Caching formatted names without sharing the interner**: removes the
+  formatting but not the insertion, which is the expensive half.
+- **Lazy endpoint installation**: changes work counters by construction;
+  a contract change with unestablished benefit, deferred until this ADR
+  settles the symbol-space question.
+
+## Implementation shape
+
+Phase 1 (audit, own commit): find every ordered or published use of a
+symbol handle; convert each to text or stable-identity ordering; prove
+byte identity unchanged. Phase 2: introduce the equality-only wrapper
+handle and the revision-scoped shared interner behind the existing
+`body_symbol_interner()` accessor; thread the `Arc` through analysis
+state and body RIR; update `require_rir_authority`. Phase 3: falsifier
+tests and the retention measurement. Each phase lands with the full
+byte-identity gate; Phase 1 is independently valuable (it removes latent
+scheduling-sensitivity) even if Phase 2 stalls.

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -238,4 +238,5 @@ The table is generated from ADR frontmatter. Run
 | [0073](0073-validation-certificate-durability.md) | Validation-certificate durability across append-only revisions | Accepted | architecture, compiler, incremental, performance, query-engine |
 | [0074](0074-structural-node-identity.md) | Structural node identity for dependency order and retained charge | Proposal | architecture, compiler, performance, query-engine |
 | [0075](0075-wave-granular-import-discovery.md) | Wave-granular import discovery revisions and cumulative exhaustion witness | Proposal | architecture, compiler, incremental, performance, query-engine |
+| [0076](0076-shared-revision-symbol-space.md) | Shared revision symbol space for body analysis | Proposal | architecture, compiler, performance, query-engine, type-system |
 <!-- ADR-INDEX:END -->


### PR DESCRIPTION
Proposes the contract for the measurement note merged in #2476 (`docs/notes/per-body-identity-closure-materialization.md`): share the symbol interner across a revision's bodies — the measured 2.9–3.3% of a cold Lattice build, five times the headroom of sharing the type pool — while type pools stay body-private.

The contract's load-bearing choices, each answering one of the note's four ADR questions:

1. **Index space and scope**: only the string→handle symbol space becomes shared, scoped to one revision generation; pool indices (measured sort keys) stay body-private.
2. **Handle discipline**: under a shared concurrent interner, handle values are assigned in first-intern order and vary with scheduling — so handles become process-local and equality-only, enforced by a wrapper type without `Ord`, with a pre-change audit converting any order-bearing use to text or ADR-0074 structural-hash ordering.
3. **Byte identity is a hard gate, not a rebaseline**: because handles are equality-only, emitted bytes and all 136 counters must be identical at `-j1` and `-j4`; if the implementation can't achieve that, the premise failed and it must not land — deliberately unlike ADR-0074/0075, where the artifact itself was being redefined.
4. **Invalidation + `require_rir_authority`**: append-only within a generation, dropped whole on supersession; the pointer-equality authority assertion survives as `Arc` identity against the revision's interner, and a body carrying a superseded generation fails it and re-runs — fail-closed.

Falsifiers cover byte identity (the premise), handle discipline, authority refusal, `-j4` scheduling invisibility, and retention (expected to *drop* — one interner holding the union replaces 1,263 holding overlapping subsets — but measured, not assumed). Phase 1 (the ordered-use audit) is independently valuable even if the sharing stalls, since it removes latent scheduling sensitivity.

Same review process as ADR-0074/0075: open for the consensus round — amendments welcome as follow-up PRs (the ADR-0074 collision amendment, #2465, is the model).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTiBg7df72iMgdpAFv5wZs)_