### PR TITLE
RUE-1472: skip runtime alias probes

### DIFF
--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -2301,7 +2301,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 }
                 let (name, init) = (*name, *init);
                 if let Some(name) = name {
-                    let alias = if initializer_may_evaluate_to_type(self.body_rir_ref(), init) {
+                    let alias = if initializer_may_evaluate_to_type_with_bindings(
+                        self.body_rir_ref(),
+                        init,
+                        runtime_bindings,
+                    ) {
                         let started = attribution.enabled.then(Instant::now);
                         if attribution.enabled {
                             attribution.alias_filter_accepts += 1;
@@ -2551,35 +2555,37 @@ struct InlineCtorScanWork {
     raw_candidates: u64,
 }
 
-/// Whether the comptime evaluator can possibly return a type value for an
-/// initializer's outer RIR shape.
-///
-/// This is deliberately a one-sided filter. Calls, names, member paths, and
-/// every composition form remain candidates because their result can depend
-/// on exact semantic facts or on a selected control-flow arm. Shapes rejected
-/// here are evaluator arms whose result is always a runtime value, unit, or
-/// `None`; skipping them avoids entering semantic/provider resolution for an
-/// initializer which cannot populate the inference-time type-alias map. The
-/// speculative caller deliberately discards evaluator errors with
-/// `.ok().flatten()`; ordinary analysis still owns every published diagnostic.
-pub(super) fn initializer_may_evaluate_to_type(rir: &rue_rir::Rir, inst_ref: InstRef) -> bool {
+/// This one-sided shape filter excludes names already known to be runtime
+/// bindings in the current lexical scope. Such a name
+/// cannot evaluate to a type, while an unresolved/file-level name must remain
+/// a candidate because the evaluator may resolve it through semantic facts.
+pub(super) fn initializer_may_evaluate_to_type_with_bindings(
+    rir: &rue_rir::Rir,
+    inst_ref: InstRef,
+    runtime_bindings: &AHashSet<Spur>,
+) -> bool {
     match &rir.get(inst_ref).data {
         InstData::AnonStructType { .. }
         | InstData::AnonEnumType { .. }
         | InstData::TypeConst { .. }
-        | InstData::VarRef { .. }
         | InstData::Call { .. }
         | InstData::MethodCall { .. }
         | InstData::FieldGet { .. } => true,
-        InstData::Comptime { expr } => initializer_may_evaluate_to_type(rir, *expr),
-        InstData::ArrayRepeat { value, .. } => initializer_may_evaluate_to_type(rir, *value),
+        InstData::VarRef { name, .. } => !runtime_bindings.contains(name),
+        InstData::Comptime { expr } => {
+            initializer_may_evaluate_to_type_with_bindings(rir, *expr, runtime_bindings)
+        }
+        InstData::ArrayRepeat { value, .. } => {
+            initializer_may_evaluate_to_type_with_bindings(rir, *value, runtime_bindings)
+        }
         InstData::Block { instructions } => {
             let count = rir.block_inst_count(instructions);
             count != 0
-                && initializer_may_evaluate_to_type(
+                && initializer_may_evaluate_to_type_with_bindings(
                     rir,
                     rir.block_inst(instructions, count - 1)
                         .expect("the tail index came from this block payload"),
+                    runtime_bindings,
                 )
         }
         InstData::Branch {
@@ -2587,14 +2593,18 @@ pub(super) fn initializer_may_evaluate_to_type(rir: &rue_rir::Rir, inst_ref: Ins
             else_block,
             ..
         } => {
-            initializer_may_evaluate_to_type(rir, *then_block)
-                || else_block
-                    .is_some_and(|else_block| initializer_may_evaluate_to_type(rir, else_block))
+            initializer_may_evaluate_to_type_with_bindings(rir, *then_block, runtime_bindings)
+                || else_block.is_some_and(|else_block| {
+                    initializer_may_evaluate_to_type_with_bindings(
+                        rir,
+                        else_block,
+                        runtime_bindings,
+                    )
+                })
         }
-        InstData::Match { arms, .. } => rir
-            .match_arms(arms)
-            .iter()
-            .any(|(_, body)| initializer_may_evaluate_to_type(rir, body)),
+        InstData::Match { arms, .. } => rir.match_arms(arms).iter().any(|(_, body)| {
+            initializer_may_evaluate_to_type_with_bindings(rir, body, runtime_bindings)
+        }),
         _ => false,
     }
 }

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use ahash::AHashMap;
+    use ahash::{AHashMap, AHashSet};
 
     use lasso::ThreadedRodeo;
     use rue_lexer::Lexer;
@@ -136,7 +136,11 @@ mod tests {
             {
                 candidates.insert(
                     interner.resolve(&name).to_owned(),
-                    crate::sema::comptime_eval::initializer_may_evaluate_to_type(&rir, init),
+                    crate::sema::comptime_eval::initializer_may_evaluate_to_type_with_bindings(
+                        &rir,
+                        init,
+                        &AHashSet::new(),
+                    ),
                 );
             }
         }


### PR DESCRIPTION
## Summary

- recognize `VarRef`s already proven to be lexical runtime bindings during comptime alias precompute
- skip speculative evaluator/provider work only for those exact bindings
- keep unresolved and file-level names as candidates, preserving the canonical evaluator and diagnostics path

## Evidence

The existing filter traversed 11,626 alias nodes and examined 2,757 allocations. It accepted 1,717 speculative evaluator attempts even though the exact lexical `runtime_bindings` set already proved 16 of those references could not produce a comptime type.

Against exact compiler trunk `c95f57e3e`, eight alternating fresh-process x86-64-linux `-j1 -O3` Lattice pairs measured:

| Metric | Paired median | MAD | Candidate wins |
| --- | ---: | ---: | ---: |
| retired instructions (primary falsifier) | -0.0433% | 0.0216% | 7/8 |
| cycles | -0.4124% | 0.1634% | 7/8 |
| compiler wall | -0.6025% | 1.0677% | 5/8 |
| process real | -0.6988% | 1.0454% | 5/8 |
| maximum RSS | -0.0849% | 2.0168% | 4/8 |
| peak footprint | -0.2716% | 2.3504% | 4/8 |

Memory results are directionally favorable but far noisier than their effects and are not presented as evidence.

All 16 runs emitted exact executable SHA `b893e76cfabed737b149d0e8c4d8527077dedd17da78418db20a28a7d30885e5`. Stable source metrics, compiler boundary, emitted output, metadata, schema, and timing-model JSON was exact with SHA `016106b3e3c2f763f98c1bf59d86cd6585304d0b4295364ce9d4939a5b7daa82`.

Deterministic compiler work changed only as intended:

- alias evaluator attempts: 1,717 -> 1,701
- filter accepts: 1,717 -> 1,701
- filter skips: 1,019 -> 1,035

Traversal counts, type successes, and all other work counters remained exact.

## Validation

- full `rue-air` unit target: 652 tests
- AIR build and Clippy
- focused alias-filter and runtime-parameter false-alias diagnostics
- formatting and `git diff --check`

The branch is rebased onto latest trunk `822ce9069`; the intervening change is documentation-only, so the measured compiler tree is unchanged.

Linear: RUE-1472
