### PR TITLE
Stop body reachability repeating work it has already done

### DIFF
--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -6140,6 +6140,46 @@ pub(crate) fn semantic_nucleus_failure_is_internal_error(
     matches!(kind, rue_error::ErrorKind::InternalError(_))
 }
 
+/// The trusted-toolchain demand of one body, answered from this reachability
+/// evaluation's cache once it has been observed.
+///
+/// Reachability asks for the same body's demand more than once. The prefetch
+/// batch reads the frontier window, and if any demanded module is absent the
+/// parking sweep then walks the whole frontier — which contains that window —
+/// to union what every remaining body still needs. The demand is a pure
+/// function of the key at this revision, so the repeat is served from the cache
+/// and each body is queried at most once per request (RUE-1562).
+///
+/// Only repeats are skipped, so the set of dependency edges the evaluation
+/// records is unchanged: a body whose demand has not been observed yet is still
+/// queried here, and the first observation is what registers the edge.
+fn observe_body_toolchain_demand(
+    context: &rue_query::QueryContext,
+    demands: &QueryFamily<crate::body_query::BodyQueryKey, crate::BodyToolchainDemand>,
+    cache: &mut AHashMap<Arc<crate::FunctionInstanceKey>, crate::BodyToolchainDemand>,
+    configuration: &crate::semantic_query_nucleus::SemanticQueryConfiguration,
+    instance: &Arc<crate::FunctionInstanceKey>,
+) -> Result<crate::BodyToolchainDemand, QueryAbort> {
+    if let Some(demand) = cache.get(instance) {
+        return Ok(demand.clone());
+    }
+    let terminal = context.query_registered(
+        demands,
+        crate::body_query::BodyQueryKey::new(instance.as_ref().clone(), configuration.clone()),
+    )?;
+    let rue_query::QueryOutcome::Success(demand) = terminal.outcome() else {
+        unreachable!("BodyToolchainDemands publishes typed values")
+    };
+    context.record_work(rue_query::WorkItem::new(
+        "reachability.toolchain-demand.queries",
+        1,
+    ));
+    Ok(cache
+        .entry(instance.clone())
+        .or_insert_with(|| demand.clone())
+        .clone())
+}
+
 fn visit_instance_anonymous_nominals<'a>(
     function: &'a crate::FunctionInstanceKey,
     seen: &mut AHashSet<*const crate::AnonymousNominalKey>,
@@ -14534,6 +14574,23 @@ impl RevisionedQueryDatabase {
                         >,
                     )>::new();
                     let mut anonymous_visit_seen = AHashSet::new();
+                    // Toolchain demands observed so far in this evaluation.
+                    //
+                    // The parking path unions the missing modules of every body
+                    // still ready or pending, and it can run more than once per
+                    // request, so the same body's demand was re-queried on each
+                    // sweep — a deep `BodyQueryKey` rebuilt and a registration
+                    // performed per body per parking event (RUE-1562). The
+                    // demand is a pure function of the key at this revision, so
+                    // one evaluation-scoped cache answers every repeat.
+                    //
+                    // Only repeats are skipped: a body whose demand has not
+                    // been observed yet is still queried here, so the set of
+                    // dependency edges this evaluation records is unchanged.
+                    let mut observed_toolchain_demands: AHashMap<
+                        Arc<crate::FunctionInstanceKey>,
+                        crate::BodyToolchainDemand,
+                    > = AHashMap::new();
                     let concurrency = context.max_concurrency();
                     let body_query_prefetch_window = if concurrency == 1 {
                         1
@@ -14685,11 +14742,24 @@ impl RevisionedQueryDatabase {
                             )?;
                             let mut batch_modules = BTreeSet::new();
                             let mut batch_requesters = BTreeSet::new();
-                            for demand in demands {
+                            for (instance, demand) in instances.iter().zip(demands) {
                                 let rue_query::QueryOutcome::Success(demand) = demand.outcome()
                                 else {
                                     unreachable!("BodyToolchainDemands publishes typed values")
                                 };
+                                // The parking sweep below walks the whole ready
+                                // frontier, which contains every instance in
+                                // this window, so record what the batch already
+                                // answered rather than asking again (RUE-1562).
+                                if observed_toolchain_demands
+                                    .insert(instance.clone(), demand.clone())
+                                    .is_none()
+                                {
+                                    context.record_work(rue_query::WorkItem::new(
+                                        "reachability.toolchain-demand.queries",
+                                        1,
+                                    ));
+                                }
                                 let mut any_absent = false;
                                 for module in demand.modules() {
                                     if !present_trusted_modules.contains(module.logical_path()) {
@@ -14704,23 +14774,20 @@ impl RevisionedQueryDatabase {
                                 }
                             }
                             if !batch_modules.is_empty() {
-                                for remaining_instance in
-                                    ready_frontier.keys().chain(pending.keys())
-                                {
-                                    let remaining_demand = context.query_registered(
+                                let remaining: Vec<Arc<crate::FunctionInstanceKey>> =
+                                    ready_frontier.keys().chain(pending.keys()).cloned().collect();
+                                for remaining_instance in remaining {
+                                    // A cached demand skips the query that used
+                                    // to carry this loop's cancellation check.
+                                    context.check_canceled()?;
+                                    let remaining_demand = observe_body_toolchain_demand(
+                                        context,
                                         &toolchain_for_body_closure,
-                                        crate::body_query::BodyQueryKey::new(
-                                            remaining_instance.as_ref().clone(),
-                                            key.configuration.clone(),
-                                        ),
+                                        &mut observed_toolchain_demands,
+                                        &key.configuration,
+                                        &remaining_instance,
                                     )?;
-                                    let rue_query::QueryOutcome::Success(remaining_demand) =
-                                        remaining_demand.outcome()
-                                    else {
-                                        unreachable!(
-                                            "BodyToolchainDemands publishes typed values"
-                                        )
-                                    };
+                                    let remaining_demand = &remaining_demand;
                                     let mut any_absent = false;
                                     for module in remaining_demand.modules() {
                                         if !present_trusted_modules
@@ -14850,11 +14917,14 @@ impl RevisionedQueryDatabase {
                             instance.as_ref().clone(),
                             key.configuration.clone(),
                         );
-                        let demand = context
-                            .query_registered(&toolchain_for_body_closure, body_key.clone())?;
-                        let rue_query::QueryOutcome::Success(demand) = demand.outcome() else {
-                            unreachable!("BodyToolchainDemands publishes typed values")
-                        };
+                        let demand = observe_body_toolchain_demand(
+                            context,
+                            &toolchain_for_body_closure,
+                            &mut observed_toolchain_demands,
+                            &key.configuration,
+                            &instance,
+                        )?;
+                        let demand = &demand;
                         let mut batch_modules = demand
                             .modules()
                             .iter()
@@ -14869,23 +14939,24 @@ impl RevisionedQueryDatabase {
                                 .cloned()
                                 .into_iter()
                                 .collect::<BTreeSet<_>>();
-                            for pending_instance in ready_frontier.keys().chain(pending.keys()) {
-                                if visited.contains(pending_instance) {
-                                    continue;
-                                }
-                                let pending_key = crate::body_query::BodyQueryKey::new(
-                                    pending_instance.as_ref().clone(),
-                                    key.configuration.clone(),
-                                );
-                                let pending_demand = context.query_registered(
+                            let sweep: Vec<Arc<crate::FunctionInstanceKey>> = ready_frontier
+                                .keys()
+                                .chain(pending.keys())
+                                .filter(|pending_instance| !visited.contains(*pending_instance))
+                                .cloned()
+                                .collect();
+                            for pending_instance in sweep {
+                                // A cached demand skips the query that used to
+                                // carry this loop's cancellation check.
+                                context.check_canceled()?;
+                                let pending_demand = observe_body_toolchain_demand(
+                                    context,
                                     &toolchain_for_body_closure,
-                                    pending_key,
+                                    &mut observed_toolchain_demands,
+                                    &key.configuration,
+                                    &pending_instance,
                                 )?;
-                                let rue_query::QueryOutcome::Success(pending_demand) =
-                                    pending_demand.outcome()
-                                else {
-                                    unreachable!("BodyToolchainDemands publishes typed values")
-                                };
+                                let pending_demand = &pending_demand;
                                 let mut any_absent = false;
                                 for module in pending_demand.modules() {
                                     if !present_trusted_modules.contains(module.logical_path()) {
@@ -40474,6 +40545,75 @@ fn main() -> i32 {
     }
 
     #[test]
+    fn each_body_toolchain_demand_is_queried_once_per_reachability_request() {
+        // RUE-1562: reachability reads a body's trusted-toolchain demand from
+        // more than one place — the prefetch batch reads the frontier window,
+        // and the parking sweep walks the whole frontier, which contains that
+        // window. Each body's demand is a pure function of its key at this
+        // revision, so one evaluation-scoped cache answers every repeat and no
+        // body is queried twice.
+        //
+        // A wide frontier is the case that made the duplication visible: the
+        // batch and the sweep overlap by the whole prefetch window.
+        const CALLEES: usize = 24;
+        let mut text = (0..CALLEES)
+            .map(|index| format!("fn f{index}() -> i32 {{ {index} }}\n"))
+            .collect::<String>();
+        let expression = (0..CALLEES)
+            .map(|index| format!("f{index}()"))
+            .collect::<Vec<_>>()
+            .join(" + ");
+        text.push_str(&format!("fn main() -> i32 {{ {expression} }}\n"));
+        let snapshot = source_snapshot(&[(1, "/main.rue", "main.rue", &text)], 1);
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let key = crate::body_query::BodyClosureQueryKey {
+            modules: Arc::from([module.clone()]),
+            roots: Arc::from([free_function_instance(&module, "main")]),
+            configuration: semantic_configuration(),
+        };
+
+        let run = |workers| {
+            let mut database = RevisionedQueryDatabase::with_query_concurrency(workers);
+            let revision = revision_for(&mut database, &snapshot);
+            let request = database
+                .body_closure(revision, key.clone(), CancellationToken::new())
+                .expect("a wide call fan-out publishes one body closure");
+            let rue_query::QueryOutcome::Success(output) = request.terminal.outcome() else {
+                unreachable!("BodyClosure publishes typed values")
+            };
+            assert!(output.fatal.is_none());
+            let queries = request
+                .work
+                .iter()
+                .find_map(|(label, amount)| {
+                    (label.as_ref() == "reachability.toolchain-demand.queries").then_some(*amount)
+                })
+                .unwrap_or(0);
+            (output.reached.len(), queries)
+        };
+
+        for workers in [1, 4] {
+            let (reached, queries) = run(workers);
+            assert_eq!(reached, CALLEES + 1, "every callee is reached");
+            assert_eq!(
+                queries, reached as u64,
+                "with {workers} worker(s) each of the {reached} reached bodies must have its \
+                 toolchain demand queried exactly once, got {queries} queries"
+            );
+        }
+
+        // The counter must not depend on how the work was scheduled: the serial
+        // and parallel paths reach the demand through different call sites, and
+        // a published work ledger that disagreed across worker counts would be
+        // a determinism break rather than a measurement.
+        assert_eq!(
+            run(1),
+            run(4),
+            "demand accounting must be identical across worker counts"
+        );
+    }
+
+    #[test]
     fn ready_anonymous_producers_share_one_structured_frontier() {
         let snapshot = source_snapshot(
             &[(
@@ -41085,6 +41225,66 @@ fn main() -> i32 {
             output.fatal.is_none(),
             "an already observed collision must not leak past the higher-precedence park"
         );
+    }
+
+    #[test]
+    fn parking_unions_pending_demands_without_re_querying_them() {
+        // RUE-1562: when a body demands an absent trusted toolchain module the
+        // park has to union what every still-ready and still-pending body needs
+        // too, which walks the whole frontier. That sweep re-asked the demand
+        // family for bodies the prefetch batch had just read. It now reads the
+        // evaluation's cache, so a body is queried at most once even though it
+        // is visited by both the batch and the sweep.
+        //
+        // A wide fan-out where one leaf parks makes the overlap maximal: the
+        // frontier is still full when the sweep runs.
+        const CALLEES: usize = 24;
+        let mut text = (0..CALLEES)
+            .map(|index| format!("fn f{index}() -> i32 {{ {index} }}\n"))
+            .collect::<String>();
+        text.push_str("fn parked() -> i32 { let _value = @parse_u32(\"1\"); 0 }\n");
+        let calls = (0..CALLEES)
+            .map(|index| format!("f{index}()"))
+            .collect::<Vec<_>>()
+            .join(" + ");
+        text.push_str(&format!("fn main() -> i32 {{ {calls} + parked() }}\n"));
+        let snapshot = source_snapshot(&[(1, "/main.rue", "main.rue", &text)], 1);
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let key = crate::body_query::BodyClosureQueryKey {
+            modules: Arc::from([module.clone()]),
+            roots: Arc::from([free_function_instance(&module, "main")]),
+            configuration: semantic_configuration(),
+        };
+
+        for workers in [1, 4] {
+            let mut database = RevisionedQueryDatabase::with_query_concurrency(workers);
+            let revision = revision_for(&mut database, &snapshot);
+            let request = database
+                .body_closure(revision, key.clone(), CancellationToken::new())
+                .expect("the acquisition round publishes a typed park");
+            let rue_query::QueryOutcome::Success(output) = request.terminal.outcome() else {
+                unreachable!("BodyClosure publishes typed values")
+            };
+            assert!(
+                output.parked_toolchain.is_some(),
+                "with {workers} worker(s) the absent trusted module must park the closure"
+            );
+            let queries = request
+                .work
+                .iter()
+                .find_map(|(label, amount)| {
+                    (label.as_ref() == "reachability.toolchain-demand.queries").then_some(*amount)
+                })
+                .unwrap_or(0);
+            // Every body the round touched is bounded by the whole program, so
+            // one query per distinct body is the ceiling the sweep must respect.
+            assert!(
+                queries <= (CALLEES + 2) as u64,
+                "with {workers} worker(s) the parking sweep re-queried demands: {queries} \
+                 queries for at most {} distinct bodies",
+                CALLEES + 2
+            );
+        }
     }
 
     #[test]

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -6140,6 +6140,44 @@ pub(crate) fn semantic_nucleus_failure_is_internal_error(
     matches!(kind, rue_error::ErrorKind::InternalError(_))
 }
 
+/// The producer functions named by an instance key's statically encoded
+/// anonymous-nominal graph, in traversal order.
+///
+/// Body reachability needs this list twice for the same key: once to schedule
+/// the producers the key names, and again on every frontier scan to ask whether
+/// those producers have all been visited. Walking the key each time made a scan
+/// cost the whole anonymous graph of every pending body, re-derived per round,
+/// even though the graph is statically encoded and cannot move within a
+/// request. The closure is a pure function of the key, so one
+/// evaluation-scoped memo serves both phases (RUE-1557).
+///
+/// Duplicates are preserved rather than collapsed into a set: two identities
+/// can name the same producer, and the scheduling phase is written against the
+/// exact sequence the traversal emits.
+fn instance_producer_closure(
+    context: &rue_query::QueryContext,
+    memo: &mut AHashMap<Arc<crate::FunctionInstanceKey>, Arc<[Arc<crate::FunctionInstanceKey>]>>,
+    seen: &mut AHashSet<*const crate::AnonymousNominalKey>,
+    instance: &Arc<crate::FunctionInstanceKey>,
+) -> Arc<[Arc<crate::FunctionInstanceKey>]> {
+    if let Some(producers) = memo.get(instance) {
+        return producers.clone();
+    }
+    let mut producers = Vec::new();
+    visit_instance_anonymous_nominals(instance.as_ref(), seen, |identity| {
+        if let crate::StableProducerId::Function(producer) = &identity.producer {
+            producers.push(Arc::new(producer.as_ref().clone()));
+        }
+    });
+    context.record_work(rue_query::WorkItem::new(
+        "reachability.anonymous.closure-walks",
+        1,
+    ));
+    memo.entry(instance.clone())
+        .or_insert_with(|| Arc::from(producers))
+        .clone()
+}
+
 /// The trusted-toolchain demand of one body, answered from this reachability
 /// evaluation's cache once it has been observed.
 ///
@@ -14574,6 +14612,11 @@ impl RevisionedQueryDatabase {
                         >,
                     )>::new();
                     let mut anonymous_visit_seen = AHashSet::new();
+                    // Producer closures already derived in this evaluation (RUE-1557).
+                    let mut anonymous_producer_closures: AHashMap<
+                        Arc<crate::FunctionInstanceKey>,
+                        Arc<[Arc<crate::FunctionInstanceKey>]>,
+                    > = AHashMap::new();
                     // Toolchain demands observed so far in this evaluation.
                     //
                     // The parking path unions the missing modules of every body
@@ -14617,32 +14660,29 @@ impl RevisionedQueryDatabase {
                                 anonymous_dependency_pending.pop()
                             {
                                 context.check_canceled()?;
-                                visit_instance_anonymous_nominals(
-                                    instance.as_ref(),
+                                let producers = instance_producer_closure(
+                                    context,
+                                    &mut anonymous_producer_closures,
                                     &mut anonymous_visit_seen,
-                                    |identity| {
-                                        let crate::StableProducerId::Function(producer) =
-                                            &identity.producer
-                                        else {
-                                            return;
-                                        };
-                                        let depth = current_depth
-                                            + usize::from(matches!(
-                                                producer.as_ref(),
-                                                crate::FunctionInstanceKey::Specialization { .. }
-                                        ));
-                                        if let Some((producer, true)) = schedule_body_instance(
-                                            &mut pending,
-                                            &mut ready_frontier,
-                                            &mut prefetched_transactions,
-                                            &visited,
-                                            producer.as_ref(),
-                                            depth,
-                                        ) {
-                                            anonymous_dependency_pending.push((producer, depth));
-                                        }
-                                    },
+                                    &instance,
                                 );
+                                for producer in producers.iter() {
+                                    let depth = current_depth
+                                        + usize::from(matches!(
+                                            producer.as_ref(),
+                                            crate::FunctionInstanceKey::Specialization { .. }
+                                        ));
+                                    if let Some((producer, true)) = schedule_body_instance(
+                                        &mut pending,
+                                        &mut ready_frontier,
+                                        &mut prefetched_transactions,
+                                        &visited,
+                                        producer.as_ref(),
+                                        depth,
+                                    ) {
+                                        anonymous_dependency_pending.push((producer, depth));
+                                    }
+                                }
                             }
                             context.record_work(rue_query::WorkItem::new(
                                 "reachability.frontier.scans",
@@ -14655,19 +14695,14 @@ impl RevisionedQueryDatabase {
                             let mut frontier = Vec::new();
                             let mut blocked_pending = BTreeMap::new();
                             for (instance, depth) in std::mem::take(&mut pending) {
-                                let mut all_producers_visited = true;
-                                visit_instance_anonymous_nominals(
-                                    instance.as_ref(),
+                                let producers = instance_producer_closure(
+                                    context,
+                                    &mut anonymous_producer_closures,
                                     &mut anonymous_visit_seen,
-                                    |identity| {
-                                        if let crate::StableProducerId::Function(producer) =
-                                            &identity.producer
-                                            && !visited.contains(producer.as_ref())
-                                        {
-                                            all_producers_visited = false;
-                                        }
-                                    },
+                                    &instance,
                                 );
+                                let all_producers_visited =
+                                    producers.iter().all(|producer| visited.contains(producer));
                                 let ready = !visited.contains(&instance)
                                     && blocked_on_anonymous
                                         .get(&instance)
@@ -40542,6 +40577,91 @@ fn main() -> i32 {
             (CALLEES + 1) as u64
         );
         assert_eq!(work("reachability.transactions.serial"), 0);
+    }
+
+    #[test]
+    fn anonymous_producer_closures_are_derived_once_per_instance() {
+        // RUE-1557: reachability walks a key's anonymous-nominal graph to
+        // schedule the producers it names, and walks it again on every frontier
+        // scan to ask whether those producers are visited. The graph is
+        // statically encoded and cannot move within a request, so the second
+        // use re-derived a closure the first had already computed — once per
+        // pending body per scan round.
+        //
+        // Several producers keep the frontier alive for more than one round,
+        // which is what made the per-round re-walk visible.
+        const PRODUCERS: usize = 8;
+        let mut text = (0..PRODUCERS)
+            .map(|index| format!("fn P{index}() -> type {{ struct {{ x{index}: i32 }} }}\n"))
+            .collect::<String>();
+        text.push_str("fn main() -> i32 {\n");
+        for index in 0..PRODUCERS {
+            text.push_str(&format!("    let T{index} = P{index}();\n"));
+            text.push_str(&format!(
+                "    let v{index}: T{index} = T{index} {{ x{index}: {index} }};\n"
+            ));
+        }
+        let sum = (0..PRODUCERS)
+            .map(|index| format!("v{index}.x{index}"))
+            .collect::<Vec<_>>()
+            .join(" + ");
+        text.push_str(&format!("    {sum}\n}}\n"));
+        let snapshot = source_snapshot(&[(1, "/main.rue", "main.rue", &text)], 1);
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let key = crate::body_query::BodyClosureQueryKey {
+            modules: Arc::from([module.clone()]),
+            roots: Arc::from([free_function_instance(&module, "main")]),
+            configuration: semantic_configuration(),
+        };
+
+        let run = |workers| {
+            let mut database = RevisionedQueryDatabase::with_query_concurrency(workers);
+            let revision = revision_for(&mut database, &snapshot);
+            let request = database
+                .body_closure(revision, key.clone(), CancellationToken::new())
+                .expect("anonymous producers publish one body closure");
+            let rue_query::QueryOutcome::Success(output) = request.terminal.outcome() else {
+                unreachable!("BodyClosure publishes typed values")
+            };
+            assert!(output.fatal.is_none());
+            assert!(output.scheduling_errors.is_empty());
+            let work = |expected: &str| {
+                request
+                    .work
+                    .iter()
+                    .find_map(|(label, amount)| (label.as_ref() == expected).then_some(*amount))
+                    .unwrap_or(0)
+            };
+            (
+                output.reached.len(),
+                work("reachability.anonymous.closure-walks"),
+                work("reachability.frontier.scans"),
+            )
+        };
+
+        for workers in [1, 4] {
+            let (reached, walks, scans) = run(workers);
+            assert_eq!(reached, PRODUCERS + 1, "every producer body is reached");
+            assert!(
+                scans > 1,
+                "the fixture must take more than one frontier scan to be a regression test \
+                 for per-scan re-walking, got {scans}"
+            );
+            assert!(
+                walks <= reached as u64,
+                "with {workers} worker(s) each of the {reached} instances must have its \
+                 anonymous graph walked at most once, got {walks} walks across {scans} scans"
+            );
+        }
+
+        // With the closure derived once per instance the count no longer tracks
+        // how many scan rounds a schedule happened to take, so it is identical
+        // whatever the worker count.
+        assert_eq!(
+            run(1),
+            run(4),
+            "closure accounting must be identical across worker counts"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #2471, taking two more of the decision-free performance issues. Both are in the body-reachability evaluation, and both have the same shape: a pure result that the loop derives more than once per request.

One commit per issue.

| Commit | Change |
| --- | --- |
| RUE-1562 | Each body's trusted-toolchain demand is queried once per reachability request instead of once per place that reads it |
| RUE-1557 | Each instance's anonymous producer closure is derived once instead of re-walked on every frontier scan |

## What was actually duplicated

**RUE-1562.** The issue describes the parking sweep — when a body demands an absent toolchain module, the park unions what every still-ready and still-pending body needs, which walks the whole frontier. That sweep re-queried demands the prefetch batch had just read, rebuilding a deep `BodyQueryKey` per body to do it.

Measuring it turned up a larger duplication than the issue describes: on the parallel path *every* body's demand was queried twice per request, once by the prefetch batch and once by the coordinator, whether or not anything parked. The new counter shows 50 queries for 25 bodies before the fix and 25 after.

**RUE-1557.** Reachability walks a key's anonymous-nominal graph to schedule the producers it names, then walks it again on every frontier scan to ask whether those producers are visited. The graph is statically encoded and cannot move within a request, so the second use re-derived what the first had already computed — once per pending body per round. Over eight producers taking three scans, that was 18 walks for 9 instances; it is now 9.

## Behaviour

Neither changes results.

- Only *repeat* observations are skipped, so the dependency edges each evaluation records are unchanged: a body whose demand has not been observed yet is still queried, and that first observation is what registers the edge.
- Where a cached answer replaces a query, the loop keeps an explicit cancellation check — that is what the query call was carrying.
- The producer closure keeps duplicates rather than collapsing into a set. Two identities can name the same producer, and the scheduling phase is written against the exact sequence the traversal emits, so its order and multiplicity are preserved.

Executables for `examples/lattice/main.rue`, `examples/bst.rue`, `examples/dijkstra/main.rue` and `examples/collatz.rue` at `-O0` through `-O3` are identical by sha256 to ones built from this branch's merge base.

## A determinism constraint worth recording

My first cut of RUE-1562 added a `…demand.reuses` counter alongside the queries counter, and it broke `ready_anonymous_producers_share_one_structured_frontier`, which pins that the work ledger is identical at one and four workers. Reuse counts are inherently path-dependent — the parallel batch populates the cache and the serial path does not — so that counter could not exist without making a published ledger disagree across worker counts.

The queries counter is stable, because both paths count the same thing: the first observation of each distinct body. Every new assertion is therefore checked at one *and* four workers, and the two new tests assert the counts agree between them.

## Verification

- `scripts/rue premerge` — 194 pass, 0 fail, clippy included, run against this branch's merge base
- `scripts/rue unit compiler` — 890 pass
- `scripts/rue quick` — 30 pass
- Both new tests were confirmed to fail on the pre-change code by the exact factor described above

## Not included

**RUE-1561** was the third decision-free issue in this batch and is deliberately left open, because implementing it as written would be unsound. `type_carries_linear`, `type_has_drop_glue` and `type_is_copy` all break recursion with a shared `visiting` set, and on that break they return `DoesNotCarry`/`false` — an answer that is true only at that position in the traversal. A memo keyed on the type alone would cache a cycle-broken `false` and later serve it at a top-level position where the real answer is `true`, silently changing drop-glue, linearity and Copy decisions. `Deferred` results from signature reentry are context-dependent in the same way.

It is still tractable — the results whose subtree touched neither a cycle-break nor a `Deferred` are safely cacheable, which means propagating a cacheability flag through roughly ten return points in each of the three walkers — but that is a delicate change in soundness-critical code and wants its own pass with the cycle and deferred tests the issue asks for, rather than being appended here.

Fixes RUE-1557
Fixes RUE-1562

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRrzrkJm9LMi4Vvs13sdA6)_