### PR TITLE
RUE-1472: skip discarded regalloc diagnostics

### DIFF
--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -2286,19 +2286,29 @@ fn scan_intervals<Reg: Copy + Eq + std::hash::Hash>(
         }
     }
 
-    // Build final allocation list
-    let debug_allocations: Vec<(u32, Allocation<Reg>)> = allocation
-        .iter()
-        .enumerate()
-        .filter_map(|(idx, alloc)| alloc.map(|a| (idx as u32, a)))
-        .collect();
+    // Build the final allocation list only for the diagnostic projection.
+    // Normal compilation discards this field, so avoid walking the dense map
+    // and copying every assignment when diagnostics are disabled.
+    let debug_allocations = if collect_debug {
+        allocation
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, alloc)| alloc.map(|a| (idx as u32, a)))
+            .collect()
+    } else {
+        Vec::new()
+    };
 
     let debug_info = RegAllocDebugInfo {
         live_ranges: debug_live_ranges,
         interference: debug_interference,
         allocations: debug_allocations,
         spills: debug_spills,
-        callee_saved_used: used_callee_saved.clone(),
+        callee_saved_used: if collect_debug {
+            used_callee_saved.clone()
+        } else {
+            Vec::new()
+        },
     };
 
     (
@@ -2577,19 +2587,29 @@ fn scan_intervals_with_remat<Reg: Copy + Eq + std::hash::Hash>(
         }
     }
 
-    // Build final allocation list
-    let debug_allocations: Vec<(u32, Allocation<Reg>)> = allocation
-        .iter()
-        .enumerate()
-        .filter_map(|(idx, alloc)| alloc.map(|a| (idx as u32, a)))
-        .collect();
+    // Build the final allocation list only for the diagnostic projection.
+    // Normal compilation discards this field, so avoid walking the dense map
+    // and copying every assignment when diagnostics are disabled.
+    let debug_allocations = if collect_debug {
+        allocation
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, alloc)| alloc.map(|a| (idx as u32, a)))
+            .collect()
+    } else {
+        Vec::new()
+    };
 
     let debug_info = RegAllocDebugInfo {
         live_ranges: debug_live_ranges,
         interference: debug_interference,
         allocations: debug_allocations,
         spills: debug_spills,
-        callee_saved_used: used_callee_saved.clone(),
+        callee_saved_used: if collect_debug {
+            used_callee_saved.clone()
+        } else {
+            Vec::new()
+        },
     };
 
     (


### PR DESCRIPTION
## Summary

- skip projecting the final allocation map into debug diagnostics when register-allocation diagnostics are disabled
- skip cloning the used callee-saved register list on the same production path
- preserve the complete `--emit regalloc` path and all allocation decisions

## Evidence

Fresh-process, one-worker, `-O3` Lattice on exact trunk `7a2bc6734`, 8 alternating pairs:

- retired instructions: **-0.2570% median**, 8/8 wins, 0.0489% paired MAD
- cycles: -0.1717% median (noisy, 4/8 wins)
- process wall: -0.4619% median (noisy, 4/8 wins)
- RSS: -0.2082% median; peak footprint: -0.2847% median (both noisy)

The workload has 1,280 functions and about 248,000 debug allocation-map slot operations on the normal path. These results clear the primary retired-instruction falsifier without a memory regression.

## Correctness

- emitted executable SHA-256 remains `b893e76cfabed737b149d0e8c4d8527077dedd17da78418db20a28a7d30885e5`
- stable benchmark JSON sections are exact
- full Lattice `--emit regalloc` stdout is byte-for-byte exact (SHA-256 `ace50e0a1c2ef7ee2b38d785e61931918b7daebdb56c58bda43f39a71bc2adb4`); stderr remains empty
- 726 codegen tests and 890 compiler tests passed
- compiler build, codegen Clippy, rustfmt, and diff checks passed

Tracker: RUE-1472
