### PR TITLE
Audit and contain ordered symbol-handle uses (ADR-0076 Phase 1)

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -27,6 +27,7 @@ const _: () = assert!(std::mem::size_of::<AirInstData>() <= 32);
 use crate::types::{StructId, Type};
 use crate::{FrozenTypeInternPool, TypeInternPool};
 use lasso::{Key, Spur, ThreadedRodeo};
+use rue_rir::SymbolHandle;
 use rue_span::Span;
 
 #[cfg(any(test, feature = "fuzz-support"))]
@@ -882,8 +883,16 @@ pub(crate) fn encode_const_values(
             }
             crate::sema::ConstValue::Function(value) => {
                 words.push(ConstValueTag::Function.word());
+                // The dense space named here is the body's own symbol table.
+                // The analysis interner is the body RIR's interner
+                // (`require_rir_authority`), and `materialize_candidate_rir`
+                // builds it by interning the packed symbol section in order, so
+                // a handle's ordinal is its index in that section. ADR-0076's
+                // shared revision interner breaks that equality: this word then
+                // needs a body-local remap, exactly like the packed RIR's own
+                // symbol words.
                 words.push(
-                    u32::try_from(value.into_usize())
+                    u32::try_from(value.body_local_ordinal())
                         .map_err(|_| error(AirBuildErrorKind::ResourceLimit))?,
                 );
             }
@@ -1030,9 +1039,9 @@ impl Iterator for ConstValueIterator<'_> {
             ConstValueTag::Type => crate::sema::ConstValue::Type(
                 Type::try_from_u32(payload[0]).expect("validated const type"),
             ),
-            ConstValueTag::Function => crate::sema::ConstValue::Function(
+            ConstValueTag::Function => crate::sema::ConstValue::Function(SymbolHandle::new(
                 Spur::try_from_usize(payload[0] as usize).expect("validated const symbol"),
-            ),
+            )),
         })
     }
 }
@@ -1843,7 +1852,7 @@ impl Air {
                             })?;
                         } else if let crate::sema::ConstValue::Function(symbol) = value {
                             context
-                                .validate_symbol(symbol)
+                                .validate_symbol(symbol.spur())
                                 .map_err(|reason| fail(Some(index), reason))?;
                         }
                     }

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -288,7 +288,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 file: const_info.span.file_id.index(),
                 name: alias_name,
             });
-            name = callee;
+            name = callee.spur();
             resolved_alias = true;
         }
 
@@ -1259,7 +1259,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 .call_facts()
                 .call_value_const(mfile, function_name)
                 .and_then(|info| match info.value {
-                    ConstValue::Function(fkey) => Some((fkey, info.is_pub)),
+                    ConstValue::Function(fkey) => Some((fkey.spur(), info.is_pub)),
                     _ => None,
                 });
             if let Some((fkey, is_pub)) = reexport {

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -1720,7 +1720,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // literal: its content joins the function's local string table
             // and lowers to a `.rodata`-backed `str` value (RUE-957).
             ConstValue::String(content) => {
-                let content = self.body_interner().resolve(&content).to_string();
+                let content = self.body_interner().resolve(&content.spur()).to_string();
                 let anchor = anchor.ok_or_else(|| {
                     CompileError::new(
                         ErrorKind::InternalError(

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -2726,10 +2726,12 @@ where
                     self.const_poisoned.insert(key.clone(), err.clone());
                     return Err(err);
                 };
-                ConstValue::Function(self.interner.get_or_intern(name.as_ref()))
+                ConstValue::Function(self.interner.get_or_intern(name.as_ref()).into())
             }
             V::Unit => ConstValue::Unit,
-            V::String(value) => ConstValue::String(self.interner.get_or_intern(value.as_ref())),
+            V::String(value) => {
+                ConstValue::String(self.interner.get_or_intern(value.as_ref()).into())
+            }
         })
     }
 }
@@ -5981,7 +5983,7 @@ mod tests {
         let ConstValue::Function(symbol) = callable.value else {
             panic!("function-valued const");
         };
-        assert_eq!(pool.resolve_symbol(symbol), "fn2");
+        assert_eq!(pool.resolve_symbol(symbol.spur()), "fn2");
     }
 
     #[test]

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use lasso::Spur;
 use rue_error::CompileWarning;
-use rue_rir::RirParamMode;
+use rue_rir::{RirParamMode, SymbolHandle};
 use rue_span::{FileId, Span};
 
 use crate::inst::{AirPlaceBase, AirProjection};
@@ -1125,7 +1125,13 @@ pub enum ConstValue {
     /// Function-valued constants are currently callable aliases only: they can
     /// be used as the callee of a call expression, but cannot be materialized
     /// as ordinary runtime values.
-    Function(lasso::Spur),
+    ///
+    /// The payload is an equality-only [`SymbolHandle`] rather than a bare
+    /// `Spur` because this value reaches two places that must not depend on a
+    /// handle's numeric value: specialization name mangling, which spells a
+    /// link-time symbol, and the AIR comptime-argument encoder, which writes
+    /// one word per argument (ADR-0076).
+    Function(SymbolHandle),
     /// String value - stores the interned literal content (RUE-957).
     ///
     /// A string constant's use sites materialize it exactly like an inline
@@ -1133,7 +1139,7 @@ pub enum ConstValue {
     /// and lowers to `.rodata`-backed `str` (`{ptr, len}`). String constants
     /// are not usable as comptime arguments (no `comptime s: str` parameters
     /// exist), so specialization serialization rejects them.
-    String(lasso::Spur),
+    String(SymbolHandle),
     /// Unit value - the value of `()`.
     Unit,
 }
@@ -1178,7 +1184,7 @@ impl ConstValue {
     }
 
     /// Try to extract a function reference.
-    pub fn as_function(self) -> Option<lasso::Spur> {
+    pub fn as_function(self) -> Option<SymbolHandle> {
         match self {
             ConstValue::Function(name) => Some(name),
             _ => None,

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -15,6 +15,7 @@ use lasso::{Spur, ThreadedRodeo};
 use rue_error::{CompileError, CompileResult, PreviewFeatures};
 use rue_rir::{
     InstData, InstRef, Rir, RirParam, RirParamMode, RirTypeSyntaxBuilder, RirTypeSyntaxRef,
+    SymbolHandle,
 };
 use rue_span::{FileId, Span};
 use rue_target::Target;
@@ -1822,7 +1823,7 @@ where
             self.register_provider_anonymous_method_endpoints(identity, resolved)?;
         }
         if let Some(function) = function {
-            let source_symbol = info.value.as_function()?;
+            let source_symbol = info.value.as_function()?.spur();
             let alias_symbol =
                 if let Some(module) = self.source.foreign_function_module(&self.key, &function) {
                     self.interner.get_or_intern(&format!(
@@ -1833,7 +1834,7 @@ where
                 } else {
                     source_symbol
                 };
-            info.value = ConstValue::Function(alias_symbol);
+            info.value = ConstValue::Function(alias_symbol.into());
             self.function_alias_keys
                 .borrow_mut()
                 .insert(alias_symbol, function);
@@ -2307,11 +2308,13 @@ where
             ConstValue::Bool(value) => V::Bool(value),
             ConstValue::Type(ty) => V::Type(self.durable_type_from_concrete(ty)?),
             ConstValue::Function(symbol) => {
-                let (_, definition) = self.function_token_for_symbol(symbol)?;
+                let (_, definition) = self.function_token_for_symbol(symbol.spur())?;
                 V::Function(definition)
             }
             ConstValue::Unit => V::Unit,
-            ConstValue::String(symbol) => V::String(Arc::from(self.interner.resolve(&symbol))),
+            ConstValue::String(symbol) => {
+                V::String(Arc::from(self.interner.resolve(&symbol.spur())))
+            }
         })
     }
 
@@ -2340,10 +2343,13 @@ where
             V::Type(ty) => ConstValue::Type(self.materialize_durable_type(ty)?),
             V::Function(definition) => ConstValue::Function(
                 self.interner
-                    .get_or_intern(&self.source.definition_name(definition)?),
+                    .get_or_intern(&self.source.definition_name(definition)?)
+                    .into(),
             ),
             V::Unit => ConstValue::Unit,
-            V::String(value) => ConstValue::String(self.interner.get_or_intern(value.as_ref())),
+            V::String(value) => {
+                ConstValue::String(self.interner.get_or_intern(value.as_ref()).into())
+            }
         })
     }
 
@@ -2810,7 +2816,7 @@ where
             }
             CanonicalArgumentValue::Unit => ConstValue::Unit,
             CanonicalArgumentValue::String(value) => {
-                ConstValue::String(self.interner.get_or_intern(value.as_ref()))
+                ConstValue::String(self.interner.get_or_intern(value.as_ref()).into())
             }
             CanonicalArgumentValue::Function(function) => {
                 let FunctionInstanceKey::Definition(definition) = function.as_ref() else {
@@ -2827,7 +2833,7 @@ where
                 self.function_tokens
                     .borrow_mut()
                     .insert(symbol, (token, definition.clone()));
-                ConstValue::Function(symbol)
+                ConstValue::Function(symbol.into())
             }
         })
     }
@@ -3131,6 +3137,7 @@ where
     fn inference_const_function_alias(&self, key: (FileId, Spur)) -> Option<Spur> {
         self.call_value_const(key.0, key.1)
             .and_then(|info| info.value.as_function())
+            .map(SymbolHandle::spur)
     }
     fn inference_module_binding_type(&self, key: (FileId, Spur)) -> Option<Type> {
         self.call_module_binding(key.0, key.1).map(|info| info.ty)
@@ -3869,10 +3876,10 @@ where
                 CanonicalArgumentValue::Type(Box::new(self.canonical_type_instance(ty)?))
             }
             ConstValue::Function(symbol) => CanonicalArgumentValue::Function(Box::new(
-                FunctionInstanceKey::Definition(self.function_identity(symbol)?),
+                FunctionInstanceKey::Definition(self.function_identity(symbol.spur())?),
             )),
             ConstValue::String(symbol) => {
-                CanonicalArgumentValue::String(self.interner.resolve(&symbol).into())
+                CanonicalArgumentValue::String(self.interner.resolve(&symbol.spur()).into())
             }
             ConstValue::Unit => CanonicalArgumentValue::Unit,
         })

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -1868,17 +1868,18 @@ where
             SemanticImportConstValue::Bool(v) => ConstValue::Bool(*v),
             SemanticImportConstValue::Type(v) => ConstValue::Type(self.import_type_local(v)?),
             SemanticImportConstValue::Function(key) => ConstValue::Function(
-                *self
+                (*self
                     .functions
                     .get(&FunctionInstanceKey::Definition(key.clone()))
-                    .ok_or(SemanticImportFailure::MissingFunction)?,
+                    .ok_or(SemanticImportFailure::MissingFunction)?)
+                .into(),
             ),
             SemanticImportConstValue::Unit => ConstValue::Unit,
             // The epoch owns an isolated interner, so the content round-trips
             // through it for validation; durable const payloads are never
             // installed into a live analyzer (install fails closed on consts).
             SemanticImportConstValue::String(content) => {
-                ConstValue::String(self.interner.get_or_intern(content.as_ref()))
+                ConstValue::String(self.interner.get_or_intern(content.as_ref()).into())
             }
         })
     }
@@ -2018,7 +2019,8 @@ where
             ConstValue::Bool(v) => SemanticImportConstValue::Bool(v),
             ConstValue::Type(v) => SemanticImportConstValue::Type(self.export_type_local(v)?),
             ConstValue::Function(symbol) => {
-                let Some(FunctionInstanceKey::Definition(key)) = self.function_exports.get(&symbol)
+                let Some(FunctionInstanceKey::Definition(key)) =
+                    self.function_exports.get(&symbol.spur())
                 else {
                     return Err(SemanticImportFailure::ForeignLocalValue);
                 };
@@ -2026,7 +2028,7 @@ where
             }
             ConstValue::Unit => SemanticImportConstValue::Unit,
             ConstValue::String(content) => {
-                SemanticImportConstValue::String(Arc::from(self.interner.resolve(&content)))
+                SemanticImportConstValue::String(Arc::from(self.interner.resolve(&content.spur())))
             }
         })
     }

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -31,7 +31,7 @@
 use ahash::{AHashMap, AHashSet};
 use std::collections::hash_map::Entry;
 
-use lasso::{Key, Spur, ThreadedRodeo};
+use lasso::{Spur, ThreadedRodeo};
 use rue_error::{CompileError, CompileResult, CompileWarning, ErrorKind};
 use rue_span::Span;
 
@@ -112,6 +112,7 @@ fn collect_specializations(
                 work.specialization_requests_unique += 1;
                 let base_name = interner.resolve(name);
                 let mangled = mangle_specialized_name(
+                    interner,
                     base_name,
                     &entry.key().type_args,
                     &entry.key().value_args,
@@ -196,11 +197,11 @@ where
                     crate::SemanticImportConstValue::Type(host.export_body_type(*value)?)
                 }
                 ConstValue::Function(value) => {
-                    crate::SemanticImportConstValue::Function(host.function_identity(*value)?)
+                    crate::SemanticImportConstValue::Function(host.function_identity(value.spur())?)
                 }
                 ConstValue::Unit => crate::SemanticImportConstValue::Unit,
                 ConstValue::String(content) => crate::SemanticImportConstValue::String(
-                    std::sync::Arc::from(host.resolve_publication_symbol(content)),
+                    std::sync::Arc::from(host.resolve_publication_symbol(&content.spur())),
                 ),
             })
         })
@@ -349,8 +350,12 @@ where
         ))
     })?;
     let base_name = host.body_interner().resolve(&key.base_name).to_owned();
-    let specialized_name_text =
-        mangle_specialized_name(&base_name, &key.type_args, &key.value_args);
+    let specialized_name_text = mangle_specialized_name(
+        host.body_interner(),
+        &base_name,
+        &key.type_args,
+        &key.value_args,
+    );
     let base_call_info = crate::sema::FunctionCallInfo::from_body(base_info);
     let param_comptime_type = host.comptime_type_param_flags(&base_call_info);
     let base_params = host
@@ -573,7 +578,13 @@ const SPEC_SEP: char = '.';
 /// (RUE-100's lesson: colliding mangles mean duplicate symbols at link time).
 /// The `.` separator is illegal in Rue identifiers, so these names cannot
 /// collide with a user-spellable function name (RUE-41).
+///
+/// The interner is a parameter because a symbol-valued argument contributes its
+/// *text*, never its handle: this name becomes a link-time symbol, and ADR-0076
+/// makes a handle's numeric value scheduling-dependent once one interner is
+/// shared across a revision's bodies.
 pub(crate) fn mangle_specialized_name(
+    interner: &ThreadedRodeo,
     base_name: &str,
     type_args: &[Type],
     value_args: &[ConstValue],
@@ -585,7 +596,7 @@ pub(crate) fn mangle_specialized_name(
     }
     for value in value_args {
         mangled.push(SPEC_SEP);
-        mangled.push_str(&mangle_const_value(value));
+        mangled.push_str(&mangle_const_value(interner, value));
     }
     mangled
 }
@@ -594,18 +605,20 @@ pub(crate) fn mangle_specialized_name(
 ///
 /// Negative integers use an `m` (minus) prefix on the magnitude because `-`
 /// is not a safe symbol character (`-3` -> `vm3`).
-fn mangle_const_value(value: &ConstValue) -> String {
+fn mangle_const_value(interner: &ThreadedRodeo, value: &ConstValue) -> String {
     match value {
         ConstValue::Integer(n) if *n < 0 => format!("vm{}", n.unsigned_abs()),
         ConstValue::Integer(n) => format!("v{}", n),
         ConstValue::Bool(b) => format!("v{}", b),
         ConstValue::Unit => "vunit".to_string(),
         ConstValue::Type(ty) => format!("v{}", mangle_type(*ty)),
-        ConstValue::Function(name) => format!("vfn{}", name.into_usize()),
-        // Comptime parameters have no string type, so strings never appear
-        // in a specialization key (RUE-957). The interner index still gives
-        // a unique, symbol-safe fragment should that ever change.
-        ConstValue::String(content) => format!("vstr{}", content.into_usize()),
+        // Both symbol-valued arms spell the symbol's text. Neither is reachable
+        // today — a callable alias is refused as a comptime argument
+        // (`validate_comptime_value_for_type_impl`) and no comptime parameter
+        // has a string type (RUE-957) — but a mangled fragment carrying an
+        // interner index would be a link-name that depends on intern order.
+        ConstValue::Function(name) => format!("vfn{}", interner.resolve(&name.spur())),
+        ConstValue::String(content) => format!("vstr{}", interner.resolve(&content.spur())),
     }
 }
 

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -523,11 +523,16 @@ impl CfgDomainProjection {
             .iter()
             .map(|(_, stable)| stable)
             .collect::<Vec<_>>();
-        let symbols = self
+        // `symbols` is stored ordered by live interner handle, which is a
+        // private lookup order rather than a semantic one. Render it in stable
+        // symbol order so this snapshot describes the body's durable shape and
+        // not the order its interner happened to issue handles in (ADR-0076).
+        let mut symbols = self
             .symbols
             .iter()
             .map(|(_, stable)| stable)
             .collect::<Vec<_>>();
+        symbols.sort();
         format!(
             "{instruction_kinds:?}|{types:?}|{strings:?}|{:?}|{spans:?}|{symbols:?}",
             self.atoms
@@ -673,6 +678,10 @@ impl CfgDomainProjection {
         Ok((imported, string_map))
     }
 
+    /// The live-handle order this searches is the same one insertion sorts by,
+    /// so the answer is a function of the handle alone and never of the order
+    /// the interner issued handles in — the property ADR-0076 needs from every
+    /// ordered symbol-handle use that survives.
     pub(crate) fn callable_for_symbol(&self, name: Spur) -> Option<crate::FunctionInstanceKey> {
         let position = self
             .symbols

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -500,6 +500,11 @@ struct RawWarningCallHead {
     components: Vec<Spur>,
 }
 
+/// Ordering exists to group equal raw heads for `dedup`, and reaches no
+/// published order: [`project_warning_call_heads`] resolves every component to
+/// its spelling and re-sorts the projection by that text before publishing it.
+/// A component's interner handle therefore decides which raw head is adjacent
+/// to which, never what a consumer observes (ADR-0076).
 impl Ord for RawWarningCallHead {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         let span_key =

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -36651,9 +36651,9 @@ fn main() -> i32 {
             V::Integer(value) => format!("integer:{value}"),
             V::Bool(value) => format!("bool:{value}"),
             V::Type(value) => format!("type:{}", endpoint_display(pool, value)),
-            V::Function(value) => format!("function:{}", resolve_symbol(value)),
+            V::Function(value) => format!("function:{}", resolve_symbol(value.spur())),
             V::Unit => "unit".to_owned(),
-            V::String(value) => format!("string:{}", resolve_symbol(value)),
+            V::String(value) => format!("string:{}", resolve_symbol(value.spur())),
         };
         ConstInfoRender {
             is_pub: info.is_pub,

--- a/crates/rue-rir/src/lib.rs
+++ b/crates/rue-rir/src/lib.rs
@@ -26,6 +26,7 @@ mod anonymous_sites;
 mod api_inventory;
 mod astgen;
 mod inst;
+mod symbol;
 mod type_syntax;
 
 pub use anonymous_sites::{AnonymousTypeSite, AnonymousTypeSiteKind, anonymous_type_sites};
@@ -48,6 +49,7 @@ pub use inst::{
     RirStructMethodsRange, RirStructuralAnchor, RirStructuralPathSegment, RirValidationContext,
     ValidatedRir,
 };
+pub use symbol::SymbolHandle;
 pub use type_syntax::{
     RirTypeSyntaxAppendError, RirTypeSyntaxArena, RirTypeSyntaxBuildError, RirTypeSyntaxBuilder,
     RirTypeSyntaxNode, RirTypeSyntaxRange, RirTypeSyntaxRef, RirTypeSyntaxSymbol,

--- a/crates/rue-rir/src/symbol.rs
+++ b/crates/rue-rir/src/symbol.rs
@@ -1,0 +1,96 @@
+//! The equality-only handle into a body's symbol interner (ADR-0076).
+//!
+//! A [`lasso::Spur`] is an index into whatever interner issued it, assigned in
+//! first-intern order. Today every body owns a private `ThreadedRodeo`, so that
+//! order is a deterministic function of the body's own traversal. ADR-0076
+//! shares one append-only interner across the bodies of a revision, at which
+//! point first-intern order becomes a function of worker scheduling and a
+//! handle's numeric value stops being reproducible.
+//!
+//! [`SymbolHandle`] is the type that states that contract in the type system.
+//! It wraps a `Spur` and deliberately offers less than one:
+//!
+//! - no `Ord`/`PartialOrd`, so it cannot be a sort key, a `BTreeMap`/`BTreeSet`
+//!   key, or an operand of a comparison;
+//! - no `lasso::Key` implementation, so `into_usize()` is not in scope and a
+//!   handle's numeric value cannot silently become a name, a word in a
+//!   published payload, or the seed of a deterministic counter.
+//!
+//! What remains is equality, hashing, and resolution against the interner that
+//! issued the handle. Anything that needs an order takes it from the symbol's
+//! text or from a stable identity (ADR-0074's structural hashes).
+//!
+//! The escape hatch is [`SymbolHandle::body_local_ordinal`], named so that
+//! every remaining value-bearing use is one grep away and each one has to say
+//! which body-local dense space it is speaking about.
+
+use lasso::{Key, Spur};
+
+/// An equality-only handle into one body's symbol interner.
+///
+/// See the module documentation for the ADR-0076 contract this type carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct SymbolHandle(Spur);
+
+impl SymbolHandle {
+    /// Adopt an interner-issued handle.
+    #[must_use]
+    pub const fn new(spur: Spur) -> Self {
+        Self(spur)
+    }
+
+    /// The underlying interner key, for the interner calls that need one
+    /// (`resolve`, `try_resolve`) and for the code that has not migrated yet.
+    #[must_use]
+    pub const fn spur(self) -> Spur {
+        self.0
+    }
+
+    /// This handle's numeric value inside the interner that issued it.
+    ///
+    /// ADR-0076 forbids letting that value reach an emitted artifact, a
+    /// published payload, or a deterministic counter. It is legitimate only
+    /// where the issuing interner is a body-private dense table whose ordinals
+    /// are the encoding — the packed RIR symbol section is the one such space
+    /// in the compiler today — and every caller owes an explanation of which
+    /// dense space it means.
+    #[must_use]
+    pub fn body_local_ordinal(self) -> usize {
+        self.0.into_usize()
+    }
+}
+
+impl From<Spur> for SymbolHandle {
+    fn from(spur: Spur) -> Self {
+        Self::new(spur)
+    }
+}
+
+impl From<SymbolHandle> for Spur {
+    fn from(handle: SymbolHandle) -> Self {
+        handle.spur()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SymbolHandle;
+
+    /// The contract is the *absence* of ordering, which no runtime assertion can
+    /// observe. This test states it as a trait-bound witness instead: a handle
+    /// satisfies the traits equality-only use needs, and the negative half is
+    /// enforced by the compiler at every would-be `sort`/`BTreeMap` site.
+    #[test]
+    fn handle_is_equality_only() {
+        fn assert_equality_only<T: Copy + Eq + std::hash::Hash>() {}
+        assert_equality_only::<SymbolHandle>();
+
+        let interner = lasso::ThreadedRodeo::new();
+        let first = SymbolHandle::new(interner.get_or_intern("alpha"));
+        let second = SymbolHandle::new(interner.get_or_intern("beta"));
+        assert_ne!(first, second);
+        assert_eq!(first, SymbolHandle::new(interner.get_or_intern("alpha")));
+        assert_eq!(interner.resolve(&first.spur()), "alpha");
+    }
+}

--- a/docs/notes/README.md
+++ b/docs/notes/README.md
@@ -10,6 +10,7 @@ real.
 
 | File | Records | Status | Superseded by |
 | --- | --- | --- | --- |
+| [adr-0076-symbol-handle-ordered-use-audit.md](adr-0076-symbol-handle-ordered-use-audit.md) | ADR-0076 Phase 1: the complete inventory of ordered and value-bearing symbol-handle uses, their conversions, and what a revision-shared interner still owes. | current | — |
 | [adr-0071-phase-1-reference-baseline.md](adr-0071-phase-1-reference-baseline.md) | The first complete `fresh_source_to_native_v1` reference measurements closing ADR-0071's measurement phase. | current | — |
 | [adr-0071-horizontal-vertical-ownership-reaudit.md](adr-0071-horizontal-vertical-ownership-reaudit.md) | Current-source whole-pipeline ownership re-audit after the accepted ADR-0071 and RUE-1510 work, with the next measured verticals. | current | — |
 | [adr-0071-phase-2-semantic-cfg-ownership-audit.md](adr-0071-phase-2-semantic-cfg-ownership-audit.md) | Point-in-time Phase 2 audit (2026-08-13) of semantic-to-CFG ownership before the accepted payload-sharing and packed-artifact work. | historical | [adr-0071-horizontal-vertical-ownership-reaudit.md](adr-0071-horizontal-vertical-ownership-reaudit.md) |

--- a/docs/notes/adr-0076-symbol-handle-ordered-use-audit.md
+++ b/docs/notes/adr-0076-symbol-handle-ordered-use-audit.md
@@ -1,0 +1,226 @@
+# ADR-0076 symbol-handle ordered-use audit
+
+Status: implementation audit, 2026-08-17. This is ADR-0076 Phase 1: the
+complete inventory of every place a symbol handle's *order* or *numeric value*
+can influence something deterministic, the classification of each, and what was
+done about it. Phase 2 shares one append-only symbol interner across the bodies
+of a revision, at which point a `Spur`'s value stops being a function of the
+body that minted it and becomes a function of worker scheduling. Everything
+below is what has to be true before that is safe.
+
+The measurement that motivates the sharing is
+[per-body-identity-closure-materialization.md](per-body-identity-closure-materialization.md);
+the contract is [ADR-0076](../designs/0076-shared-revision-symbol-space.md).
+
+## Result
+
+Three findings, in descending order of how much they change the plan.
+
+1. **Nothing in the compiler orders symbol handles through `Ord`.** The whole
+   ordered-use class travels through one explicit conversion,
+   `lasso::Key::into_usize`, which makes the audit finite and greppable rather
+   than a search over every comparison in the tree.
+2. **Exactly one site let a handle's value reach an emitted artifact**, and it
+   was latent rather than live: specialization name mangling spelled a
+   symbol-valued comptime argument as its interner index, and that mangled name
+   is a link-time symbol. Both of its arms are unreachable today, which is why
+   the byte-identity gate below stayed green when they were converted to spell
+   the symbol's text.
+3. **The blocking finding for Phase 2 is not an ordering at all.** A body's
+   symbol handles are today *dense and equal to the packed RIR's symbol
+   ordinals*, by an invariant the compiler asserts. A revision-shared interner
+   breaks that equality by construction, so Phase 2 needs a body-local remap
+   that ADR-0076 does not currently mention. This is stated in full under
+   [What Phase 2 still owes](#what-phase-2-still-owes).
+
+## How the inventory was taken
+
+Four sweeps, because no single one is complete.
+
+**Trait-level ordering, proven by the compiler.** `PartialOrd, Ord` were
+temporarily removed from the vendored `lasso::Spur` derive and `//crates/...`
+was built in full, tests included. It compiled. No code in the workspace orders
+a symbol handle through the `Ord` trait, directly or through a derive: a scan of
+every type that carries a symbol-handle field or payload (84 in the committed
+tree) confirms none of them derives `Ord` or `PartialOrd` either, and no `BTreeMap` or `BTreeSet` in the
+tree is keyed by a symbol handle. The vendored derive was restored afterwards.
+
+**Hash iteration order, already neutralized.** Symbol handles are heavily used
+as `AHashMap`/`AHashSet` keys — `AHashMap<Spur, Type>`, `AHashMap<Spur,
+ConstValue>`, `AHashSet<Spur>` and friends, most of the 1,136 `Spur` mentions in
+the tree. None of these iteration orders can reach output, and that is a
+property the tree already has rather than one this audit established: `ahash` is
+built with `runtime-rng` (`third-party/BUCK`), so its seeds come from
+`getrandom` once per process, and `std`'s `RandomState` is seeded per process
+too. Iteration order of a hash map keyed by anything already varies between
+compiler runs. The executables below are byte-identical across four separate
+compiler processes, so no hash-map iteration order of any key type escapes into
+a deterministic artifact — the whole class is (a) by construction, and sharing
+the interner does not change it.
+
+**Value extraction, enumerated.** Every `Key::into_usize` call site: 88 in the
+tree, 38 of them the AST's `Display`. Each is classified below.
+
+**Byte identity, measured.** The gate at the end of this note.
+
+## Classification
+
+`(a)` equality or membership only — safe under any handle assignment.
+`(b)` ordered — a handle decides a sort, a search, or an iteration order.
+`(c)` value-bearing — a handle's number becomes a name, a stored word, or an
+index into something.
+
+### (a) Equality and membership
+
+Everything not named below, which is the overwhelming majority: every
+`AHashMap`/`AHashSet` keyed by a handle in `sema`, `inference`, `scope`, the
+comptime substitution maps, `KnownSymbols`' pre-interned comparison handles, the
+endpoint overlay's exact-lookup registries, `SpecializationKey`'s `base_name`,
+and the `PartialEq`/`Hash` derives that carry a handle inside a larger key. No
+action; these are exactly what an equality-only handle is for.
+
+### (b) Ordered uses
+
+| Site | What it orders | Classification and action |
+| --- | --- | --- |
+| `crates/rue-compiler/src/durable_cfg.rs:1201` (`CfgDomainProjection::new`) and `:633` (`import_accessor_cfg`) | Sorts `symbols: Vec<(Spur, StableCfgSymbol)>` by `(live.into_usize(), stable)`, then dedups | **Contained.** The order is a private lookup index consumed only by `callable_for_symbol`'s `partition_point` on the same key, so the answer is a function of the queried handle and never of the order handles were issued in. Left in place, with the reason recorded at both ends. Its one escape is fixed below. |
+| `crates/rue-compiler/src/durable_cfg.rs:688` (`callable_for_symbol`) | Binary search by `live.into_usize()` | **Contained**, same argument. A structural test forbids replacing it with a linear scan, so the sorted vector stays. |
+| `crates/rue-compiler/src/durable_cfg.rs:506` (`stable_debug_snapshot`) | Rendered the projection's stable symbols in live-handle order | **Converted.** The snapshot now sorts the projected `StableCfgSymbol`s. Behavior-preserving because the rendered *set* is unchanged and the new order is a total order on durable content; what changes is that the string no longer describes the interner's issue order. This was the only place `symbols`' vector order was observable. |
+| `crates/rue-compiler/src/parsed_modules.rs:508` (`impl Ord for RawWarningCallHead`) | Orders declaration-local warning call heads by their path components' handles, for `sort` + `dedup` | **Contained.** `project_warning_call_heads` resolves every component to its spelling and then re-sorts and re-dedups the projection by that text before publishing it, so the raw order decides only which raw heads are adjacent. Two distinct handles never resolve to the same text within one interner, so both dedups agree on the same set. Left in place with the containment argument recorded at the `impl`. |
+| `crates/rue-air/src/sema/analysis/type_inference.rs:294` | `string_literal_types` gathered from `generated_structs().values()` — a handle-keyed map | **Contained.** The gathered types are `sort_unstable_by_key(Type::as_u32)`-ed and deduped before use, so the map's iteration order is discarded. Pool indices are body-private and ADR-0076 does not share them. |
+| `crates/rue-air/src/sema/provider_body_host.rs:2428` (`anonymous_key_cmp`) | Orders exported anonymous identities | **(a), listed to close it out.** The comparator reads `IssuedAnonymousNominalKey`, whose components are definition tokens and canonical arguments; no handle participates. Its neighbours at `:2488`/`:2504` sort capture lists by resolved `Arc<str>` name, which is already the text ordering this ADR asks for. |
+| `crates/rue-air/src/semantic_import.rs:1172`, `:1355`, `crates/rue-air/src/specialize.rs:310` | Sorts of nominals, callables, and selected specializations | **(a).** All key on durable identities (`NominalInstanceKey`, `FunctionInstanceKey`, `SemanticSpecializationIdentity`), never on a handle. |
+
+### (c) Value-bearing uses
+
+| Site | What the value becomes | Classification and action |
+| --- | --- | --- |
+| `crates/rue-air/src/specialize.rs` `mangle_const_value` | `vfn{index}` / `vstr{index}` fragments of a specialized function's mangled name — which is interned and becomes a **link-time symbol** | **Converted.** Both arms now spell the symbol's text, and `mangle_specialized_name` takes the interner for that purpose. Behavior-preserving because neither arm is reachable: a callable alias is refused as a comptime argument by `validate_comptime_value_for_type_impl`, and no comptime parameter has a string type (RUE-957), which the AIR encoder also asserts. This is the one site where a handle's number could have reached an emitted artifact, and the conversion removes the possibility rather than the (absent) symptom. |
+| `crates/rue-air/src/inst.rs:895` (AIR comptime-argument encoder) | One `u32` word per `ConstValue::Function` argument in the AIR payload | **(c), structural; deferred to Phase 2 with its contract stated in source.** The word is legitimate exactly because the body's interner is dense: it is the body RIR's interner, and `materialize_candidate_rir` builds it by interning the packed symbol section in order. The call now reads `SymbolHandle::body_local_ordinal` and says which dense space it means. A shared interner invalidates the premise; see below. |
+| `crates/rue-rir/src/inst.rs:2749`, `:3582`, `:3607`, `:4435`, `:4574`, `:4577`, `:4584`, `:4636`, `:4677`, `:4830` and `crates/rue-rir/src/inst/packed.rs:606`, `:653`, `:746`, `:801` | The packed RIR symbol section: a handle **is** its ordinal in a dense per-body table, written as a `u32` word and validated against `symbol_count` | **(c), structural; the blocking Phase 2 item.** Not convertible — the encoding is the dense space. See below. |
+| `crates/rue-compiler/src/canonical_lower.rs:386` | Asserts `symbol.into_usize() == ordinal` while rebuilding a body's interner from the packed symbol section | **(c), structural.** This is the invariant the two rows above depend on, stated as a runtime check. It is also the exact assertion a shared interner fails. |
+| `crates/rue-compiler/src/revisioned_query_database.rs:6697`, `:6714`, `:6735`, `:6758`, `:6773`, `:6851` | Indexes a `&[&str]` dense candidate symbol view by handle ordinal | **(c), structural**, and the same dense space: `materialize_semantic_candidate_rir` returns the packed symbol section as a `Vec<&str>` whose positions are the ordinals. Safe as long as the packed space stays body-local. |
+| `crates/rue-compiler/src/canonical_lower.rs:517` | `"candidate AST references foreign symbol ordinal {n}"` | **Contained.** Internal-error prose on a path that has already failed; not a published diagnostic surface. |
+| `crates/rue-parser/src/ast.rs` (38 sites), `crates/rue-lexer/src/lib.rs:333`–`:335`, `crates/rue-air/src/inst.rs:3777`/`:3790`/`:3808`/`:3843`, `crates/rue-cfg/src/inst.rs:3100`/`:3117`/`:3141`, `crates/rue-rir/src/inst.rs:6481`, `crates/rue-codegen/src/cfg_lower.rs:185`/`:199`/`:243` | `sym:{n}` in a `Debug`/`Display` render | **Contained.** Every one is either a `Debug` impl or the no-interner arm of a render whose production caller always supplies an interner — `format_cfg_inst_data_with_interner` is `cfg_lower`'s only caller and passes `Some`. Left as is: they are the diagnostic of last resort for a handle that cannot be resolved, and giving them a text spelling is not possible by definition. |
+| `crates/rue-air/src/inst.rs:351` | `"symbol {n} is outside the interner"` | **Contained**, same reason. |
+| `crates/rue-compiler/src/parsed_modules.rs:44`, `:3450`, `crates/rue-cfg/src/opt/forward.rs:357`/`:474`/`:514`, `crates/rue-air/src/inst.rs:4184`–`:4186`, `crates/rue-cfg/src/inst.rs:3479`–`:3480` | Test scaffolding | **Contained.** Test-only; they construct or assert on handles in a single interner they own. |
+
+## The mechanical guard
+
+`rue_rir::SymbolHandle` is the equality-only wrapper ADR-0076 requires. It wraps
+a `Spur` and deliberately offers less than one: no `Ord`/`PartialOrd`, so it
+cannot be a sort key, a `BTreeMap`/`BTreeSet` key, or an operand of a
+comparison; and no `lasso::Key` implementation, so `into_usize()` is not in
+scope on it. The only way to a handle's number is
+`SymbolHandle::body_local_ordinal`, whose name says what a caller has to be able
+to justify and whose doc comment says it.
+
+The migrated surface is `ConstValue::Function` and `ConstValue::String`, the two
+symbol payloads that carry a handle out of body analysis into the two places
+that must not depend on its value — the specialization mangler and the AIR
+comptime-argument encoder. Both were live hazards; both are now expressed
+through the wrapper, so the mangler *cannot* reach for an index and the encoder
+*must* name the dense space it is speaking about. Everything else in the tree
+still uses bare `Spur`.
+
+That is a deliberate stopping point, not an accident of effort. A full migration
+would touch 1,136 sites across eight crates, and the trait sweep above showed
+what it would buy: nothing, because no site orders a handle through `Ord`. The
+guard that matters against reintroduction is the one on the *value*, and the
+value is what the two migrated payloads carry.
+
+### What is not migrated
+
+- The RIR/packed layer (`rue-rir`), where handles are dense ordinals on purpose.
+  Migrating it would mean spelling `body_local_ordinal` at every encode and
+  decode, which is noise around a contract that is already this note's headline
+  Phase 2 item.
+- The body-analysis maps (`AHashMap<Spur, …>` and friends). They are class (a)
+  and the wrapper adds nothing they do not already have.
+- `rue-parser` and `rue-lexer`, whose interners are per-file parse interners
+  that ADR-0076 does not share.
+
+## What Phase 2 still owes
+
+Flagged for the consensus round: ADR-0076's implementation shape does not
+mention any of this, and Phase 2 cannot land without it.
+
+**The body's interner is a dense table and the compiler depends on it.**
+`materialize_candidate_rir_internal` builds each body's `ThreadedRodeo` by
+interning the packed symbol section in order and *fails the body* unless every
+handle's ordinal equals its index in that section
+(`crates/rue-compiler/src/canonical_lower.rs:386`). The packed RIR encodes every
+symbol as that ordinal in a `u32` word and validates each against
+`symbol_count`; the semantic candidate path hands the same section out as a
+`Vec<&str>` indexed by ordinal; the AIR comptime-argument encoder writes the same
+ordinal. A revision-shared interner assigns a body's symbols sparse handles out
+of a revision-wide space, so the invariant fails on the first body and the
+encodings become meaningless. This is not an ordering that can be converted to
+text — the ordinal *is* the encoding.
+
+The shape of the fix already exists in the tree: `PackedValidatedRir` decodes
+through `remap_symbol: impl FnMut(u32) -> Result<Spur, E>` and `AstGen` takes a
+`normalize_symbol: Fn(Spur) -> Spur`, so a body-local dense table alongside the
+shared interner is a remap away rather than a rewrite. But ADR-0076 currently
+reads as though the shared interner replaces the body's interner one-for-one
+behind `body_symbol_interner()`, and it cannot: a body needs *both* a shared
+equality space and a private dense space, and the ADR should say which artifact
+speaks which.
+
+**`require_rir_authority` holds an `Rc`, not an `Arc`.** ADR-0076 §5 says the
+assertion "becomes `Arc::ptr_eq` against the revision's interner". Today it is
+`std::ptr::eq(rir.rir_interner(), Rc::as_ref(&state_interner))` over
+`Rc<ThreadedRodeo>` (`crates/rue-air/src/sema/body_identity.rs:794`), and the
+interner is `Rc`-held throughout `body_identity.rs` and `provider_body_host.rs`.
+A revision-shared interner has to cross worker threads, so Phase 2 includes an
+`Rc` → `Arc` conversion of that whole ownership chain. It is mechanical, but it
+is not free and the ADR does not budget for it.
+
+**Two dead mangler arms are load-bearing for the byte-identity gate.** The
+specialization mangler's symbol-valued arms are unreachable, which is why
+converting them cost nothing. If a later change makes a callable alias or a
+string a legal comptime argument, the conversion in this note is what keeps the
+resulting link symbol independent of intern order — and the resulting mangled
+names will differ from what the pre-conversion code would have produced. That is
+the intended behavior, not a regression to investigate.
+
+## Byte identity
+
+Release build (`./buck2 build //crates/rue:rue --target-platforms
+//platforms:release`), `RUE_STD_PATH` at the repository `std`, three shapes,
+`-j1` and `-j4`, two runs of each tree.
+
+Emitted executables are byte-identical before and after, on all three shapes at
+both worker counts:
+
+| shape | executable |
+| --- | --- |
+| Lattice (`performance/workloads/lattice/main.rue`) | `45784ce7c7cde992d7ea820912ca1692c05dc7582a367210d017b3765a9a89e7` |
+| Mosaic (`examples/mosaic/main.rue`) | `4cdead1a98e77fce940b5d6f9b693d8decba26b1c666896bcc78d48a1b79f97b` |
+| chain256 (generated, 256 single-call modules) | `32e711f148c77d8dc798b905ae7ea1c80701595527f150540ad781e929a198b6` |
+
+`compiler_work`, `source_metrics`, `emitted_output`, and `compiler_boundary`
+compared field by field:
+
+| shape | fields | `-j1` differences | `-j4` differences | `-j4` fields excluded as scheduling-inherent |
+| --- | ---: | ---: | ---: | ---: |
+| Lattice | 658 | 0 | 0 | 18 |
+| Mosaic | 424 | 0 | 0 | 19 |
+| chain256 | 946 | 0 | 0 | 17 |
+
+At `-j1` every field is reproducible and every field matches. At `-j4` a small
+set of `query_runtime` and `query_engine` scheduling counters (the excluded
+count is empirical, and drifts by a few fields between samples) (`reuses`,
+`demands`, `endorsement_probes`, `joins`, …) varies between repeated runs of the
+*same* tree; those are excluded by comparing two runs of each tree and masking
+any field that already disagrees with itself. No field outside that mask
+differs. The exclusion is a property of the query engine's work-stealing, not of
+this change: the same fields vary run to run on the parent commit.
+
+## Suites
+
+`//crates/rue-air:rue-air-test`, `//crates/rue-rir:rue-rir-test`,
+`//crates/rue-compiler:rue-compiler-test`, `//crates/rue:rue-driver-test`,
+`scripts/rue quick` (30 targets), `scripts/rue ui` (250 cases), and
+`scripts/rue cli` all pass, with `scripts/rue fmt` applied and the clippy gate
+clean.


### PR DESCRIPTION
Phase 1 of ADR-0076 (#2477): make the codebase safe for scheduling-dependent symbol-handle assignment before any interner is shared. Pure refactor — byte identity and every counter unchanged. 15 files, +422/−44.

## The audit (full inventory in `docs/notes/adr-0076-symbol-handle-ordered-use-audit.md`)

The decisive sweep was mechanical: temporarily removing `PartialOrd`/`Ord` from the vendored `Spur` derive and building the whole workspace with tests — **it compiled**, proving nothing orders a symbol handle through `Ord` (84 handle-carrying types scanned; vendor patch reverted, no third-party file touched). Hash-map iteration is already scheduling-varied per process (`runtime-rng` seeds), so that class is closed by construction. The entire remaining surface is 88 explicit `into_usize` sites: 6 ordered (1 converted, 5 contained with in-source justification), 22 value-bearing (2 converted, 20 structural dense-ordinal encodings), the rest debug renders and test scaffolding.

Two real conversions: `mangle_const_value` spelled a symbol-valued comptime argument as its **interner index inside a link-time symbol name** (both arms currently unreachable, which is why bytes were unaffected — but it was a landmine for Phase 2); `CfgDomainProjection::stable_debug_snapshot` rendered symbols in live-handle order and now sorts by durable content.

## The wrapper

`rue_rir::SymbolHandle` — no `Ord`/`PartialOrd`, no `lasso::Key` (so `into_usize` is out of scope), one named escape hatch — migrated onto `ConstValue::Function`/`ConstValue::String`, exactly the payloads that reach the mangler and AIR comptime-argument encoder. Full migration of all 1,136 handle mentions was rejected on the sweep's evidence, not effort: no site orders through `Ord`, so the guard that matters is on the value, where it now is.

## Verification

- Executables byte-identical before/after on Lattice, Mosaic, chain256, at `-j1` **and** `-j4`, two runs per tree; Lattice hash re-verified independently on this branch post-rebase (`b893e76c…85e5`).
- Counters: 658/424/946 fields compared per shape — 0 differences (at `-j4`, the 17–19 known work-stealing counters vary between runs of the *same* tree and were masked after verifying the same variance on the parent commit).
- Suites: rue-air 652 + rue-rir (re-run on this branch), compiler, driver, quick 30 (re-run), UI 250, CLI 1,892/0; fmt + clippy clean; doc-links green.

## Flag for the ADR-0076 consensus round

The audit found the ADR's Phase 2 premise needs amending: **packed RIR asserts each body's symbol handles equal its dense ordinals** (`materialize_candidate_rir_internal`, `canonical_lower.rs:386`), and that ordinal *is* the encoding — a shared sparse interner cannot replace the body interner one-for-one behind `body_symbol_interner()`. Phase 2 needs a dual-space design (shared equality space + body-private dense encoding space, wired through the existing `remap_symbol`/`normalize_symbol` machinery), and the ADR's §5 `Arc::ptr_eq` language needs to account for today's `Rc` ownership chain. An amendment PR follows separately; Phase 2 waits for it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTiBg7df72iMgdpAFv5wZs)_