### PR TITLE
Share one symbol equality space per revision (ADR-0076 Phase 2)

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -318,7 +318,9 @@ fn local_semantic_materialization_owns_complete_cfg_inputs_without_a_peer_cache(
             .expect("provider result declaration");
         assert!(body.contains("pub function: AnalyzedFunction"));
         assert!(body.contains("pub type_pool: Rc<TypeInternPool>"));
-        assert!(body.contains("pub interner: Rc<ThreadedRodeo>"));
+        // The symbol interner is revision-shared and crosses worker threads
+        // (ADR-0076); the type pool stays body-private and `Rc`.
+        assert!(body.contains("pub interner: Arc<ThreadedRodeo>"));
     }
     for forbidden in ["Mutex<", "RwLock<", "QueryFamily<", "cache:", "selected:"] {
         let materialization = import

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -883,16 +883,18 @@ pub(crate) fn encode_const_values(
             }
             crate::sema::ConstValue::Function(value) => {
                 words.push(ConstValueTag::Function.word());
-                // The dense space named here is the body's own symbol table.
-                // The analysis interner is the body RIR's interner
-                // (`require_rir_authority`), and `materialize_candidate_rir`
-                // builds it by interning the packed symbol section in order, so
-                // a handle's ordinal is its index in that section. ADR-0076's
-                // shared revision interner breaks that equality: this word then
-                // needs a body-local remap, exactly like the packed RIR's own
-                // symbol words.
+                // The interner named here is the revision-shared equality space
+                // this body's analysis and its RIR both speak
+                // (`require_rir_authority`, ADR-0076 §1). The word round-trips
+                // inside one body's own AIR payload and nowhere else:
+                // `ConstValueIterator` decodes it back against that same
+                // interner, and the durable export replaces a symbol-valued
+                // const with a definition token or its text rather than with
+                // this number. Under a shared interner the value is assigned in
+                // worker-scheduling order, which is why it may not become
+                // anything a consumer outside this payload reads.
                 words.push(
-                    u32::try_from(value.body_local_ordinal())
+                    u32::try_from(value.issuing_interner_ordinal())
                         .map_err(|_| error(AirBuildErrorKind::ResourceLimit))?,
                 );
             }

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -80,7 +80,7 @@ use std::sync::Arc;
 
 use ahash::AHashMap;
 use lasso::{Spur, ThreadedRodeo};
-use rue_rir::{InstData, InstRef, Rir, RirParamMode, ValidatedRir};
+use rue_rir::{InstData, InstRef, Rir, RirParamMode, SharedSymbolSpace, ValidatedRir};
 use rue_span::{FileId, Span};
 
 use super::ConstValue;
@@ -374,7 +374,9 @@ enum PoolNominal {
 /// order.
 pub(in crate::sema) struct BodyIdentityPool<K, M, S> {
     type_pool: Rc<TypeInternPool>,
-    interner: Rc<ThreadedRodeo>,
+    /// The revision-shared equality space (ADR-0076 §1). Strings are interned
+    /// once per revision generation, not once per body.
+    interner: Arc<ThreadedRodeo>,
     source: S,
     struct_ids: AHashMap<K, StructId>,
     enum_ids: AHashMap<K, EnumId>,
@@ -566,14 +568,19 @@ where
     M: Eq + Hash,
     S: DurableNominalSource<K, M>,
 {
-    /// Create the single identity universe for one provider-driven body.
+    /// Create the single identity universe for one provider-driven body over
+    /// its own private symbol space.
     pub fn new(source: S) -> Self {
-        Self::with_interner_mode(source, Rc::new(ThreadedRodeo::new()), false)
+        Self::with_interner_mode(
+            source,
+            Arc::clone(SharedSymbolSpace::private().interner()),
+            false,
+        )
     }
 
     fn with_interner_mode(
         source: S,
-        interner: Rc<ThreadedRodeo>,
+        interner: Arc<ThreadedRodeo>,
         allow_post_seal_overlay: bool,
     ) -> Self {
         Self {
@@ -587,8 +594,8 @@ where
 
     /// Return the interner authority shared by all provider fact state in this
     /// identity context.
-    pub fn interner(&self) -> Rc<ThreadedRodeo> {
-        Rc::clone(&self.pool.borrow().interner)
+    pub fn interner(&self) -> Arc<ThreadedRodeo> {
+        Arc::clone(&self.pool.borrow().interner)
     }
 
     /// Intern a provider-facing name in the shared body authority.
@@ -713,6 +720,9 @@ pub struct ProviderBodyAnalysisState<K, M, S> {
     /// Stable outer handle; containment sealing rebases its locked inner value
     /// in place so engine-facing references never go stale.
     type_pool: Rc<TypeInternPool>,
+    /// The revision generation whose equality space this state speaks. Held so
+    /// the RIR authority check can refuse a superseded generation (ADR-0076 §5).
+    space: SharedSymbolSpace,
 }
 
 impl<K, M, S> Clone for ProviderBodyAnalysisState<K, M, S> {
@@ -720,6 +730,7 @@ impl<K, M, S> Clone for ProviderBodyAnalysisState<K, M, S> {
         Self {
             identity: self.identity.clone(),
             type_pool: Rc::clone(&self.type_pool),
+            space: self.space.clone(),
         }
     }
 }
@@ -730,12 +741,14 @@ where
     M: Eq + Hash,
     S: DurableNominalSource<K, M>,
 {
-    pub fn new(source: S, interner: Rc<ThreadedRodeo>) -> Self {
-        let identity = ProviderIdentityContext::with_interner_mode(source, interner, true);
+    pub fn new(source: S, space: SharedSymbolSpace) -> Self {
+        let identity =
+            ProviderIdentityContext::with_interner_mode(source, Arc::clone(space.interner()), true);
         let type_pool = identity.type_pool();
         Self {
             identity,
             type_pool,
+            space,
         }
     }
 
@@ -743,8 +756,13 @@ where
         self.identity.clone()
     }
 
-    pub fn interner(&self) -> Rc<ThreadedRodeo> {
+    pub fn interner(&self) -> Arc<ThreadedRodeo> {
         self.identity.interner()
+    }
+
+    /// The revision generation whose shared equality space this state speaks.
+    pub fn symbol_space(&self) -> &SharedSymbolSpace {
+        &self.space
     }
 
     pub fn type_pool(&self) -> Rc<TypeInternPool> {
@@ -791,9 +809,17 @@ where
         self.identity.frozen.get()
     }
 
+    /// Fail-closed check that this state and the body RIR name symbols in the
+    /// same live equality space (ADR-0076 §5).
+    ///
+    /// Under a revision-shared interner the pointer identity is the
+    /// *generation's* identity rather than the body's, so the check also
+    /// refuses a body whose generation has been superseded: its handles are
+    /// still resolvable, but nothing may reuse them against the current
+    /// generation's state.
     pub(in crate::sema) fn require_rir_authority(&self, rir: &BodyRirView<'_>) -> bool {
         let state_interner = self.interner();
-        std::ptr::eq(rir.rir_interner(), Rc::as_ref(&state_interner))
+        self.space.is_live() && std::ptr::eq(rir.rir_interner(), Arc::as_ref(&state_interner))
     }
 }
 
@@ -863,7 +889,7 @@ where
 {
     /// Create an empty pool with the builtin enums and the core `str` identity
     /// pre-registered, mirroring a fresh import epoch.
-    pub(in crate::sema) fn new(source: S, interner: Rc<ThreadedRodeo>) -> Self {
+    pub(in crate::sema) fn new(source: S, interner: Arc<ThreadedRodeo>) -> Self {
         let type_pool = Rc::new(TypeInternPool::new());
         let mut builtins = AHashMap::new();
 
@@ -2803,7 +2829,9 @@ pub(in crate::sema) struct BodyRirIndex {
 #[derive(Debug)]
 pub struct BodyRirBundle {
     rir: ValidatedRir,
-    rir_interner: Rc<ThreadedRodeo>,
+    /// The revision generation this body's symbols were decoded into. The RIR
+    /// and the analysis state it seeds both name symbols here (ADR-0076 §1).
+    space: SharedSymbolSpace,
     rir_index: Arc<BodyRirIndex>,
 }
 
@@ -2820,8 +2848,8 @@ pub struct BodyRirIndexAttribution {
 }
 
 impl BodyRirBundle {
-    pub fn new(rir: ValidatedRir, rir_interner: ThreadedRodeo) -> Self {
-        Self::new_with_index_attribution(rir, rir_interner, false).0
+    pub fn new(rir: ValidatedRir, space: SharedSymbolSpace) -> Self {
+        Self::new_with_index_attribution(rir, space, false).0
     }
 
     /// Construct the canonical bundle while returning bounded index-build
@@ -2829,7 +2857,7 @@ impl BodyRirBundle {
     /// cannot select a peer construction path.
     pub fn new_with_index_attribution(
         rir: ValidatedRir,
-        rir_interner: ThreadedRodeo,
+        space: SharedSymbolSpace,
         attribution_enabled: bool,
     ) -> (Self, BodyRirIndexAttribution) {
         let (rir_index, attribution) =
@@ -2837,7 +2865,7 @@ impl BodyRirBundle {
         (
             Self {
                 rir,
-                rir_interner: Rc::new(rir_interner),
+                space,
                 rir_index: Arc::new(rir_index),
             },
             attribution,
@@ -2845,8 +2873,15 @@ impl BodyRirBundle {
     }
 
     /// The one interner authority for this body RIR and its provider fact state.
-    pub fn shared_interner(&self) -> Rc<ThreadedRodeo> {
-        Rc::clone(&self.rir_interner)
+    pub fn shared_interner(&self) -> Arc<ThreadedRodeo> {
+        Arc::clone(self.space.interner())
+    }
+
+    /// The revision generation this body was materialized against. A caller
+    /// that finds it superseded must re-run the body rather than publish work
+    /// derived from a retired equality space (ADR-0076 §4).
+    pub fn symbol_space(&self) -> &SharedSymbolSpace {
+        &self.space
     }
 
     /// Build a fail-closed compatibility context over this RIR's interner.
@@ -2866,7 +2901,7 @@ impl BodyRirBundle {
         M: Eq + Hash,
         S: DurableNominalSource<K, M>,
     {
-        ProviderBodyAnalysisState::new(source, self.shared_interner())
+        ProviderBodyAnalysisState::new(source, self.space.clone())
     }
 
     pub fn instruction_count(&self) -> usize {
@@ -2887,7 +2922,7 @@ impl BodyRirBundle {
     pub fn view(&self) -> BodyRirView<'_> {
         BodyRirView {
             rir: &self.rir,
-            rir_interner: &self.rir_interner,
+            rir_interner: self.space.interner(),
             index: self.rir_index.clone(),
         }
     }
@@ -3119,18 +3154,19 @@ mod tests {
             (type_pool, params.types().to_vec())
         }
 
-        let interner = Rc::new(ThreadedRodeo::new());
+        let space = SharedSymbolSpace::private();
+        let interner = Arc::clone(space.interner());
         let widget = interner.get_or_intern("Widget");
-        let state = ProviderBodyAnalysisState::new(source([]), Rc::clone(&interner));
+        let state = ProviderBodyAnalysisState::new(source([]), space);
 
         // RIR-local and provider-created names are the same Spur, not merely
         // strings that were translated between two interner universes.
         let context = state.identity_context();
         assert_eq!(context.name_symbol("Widget"), widget);
-        assert!(Rc::ptr_eq(&context.interner(), &interner));
+        assert!(Arc::ptr_eq(&context.interner(), &interner));
         let stable_type_pool = state.type_pool();
         let opposite_order_context = state.identity_context();
-        assert!(Rc::ptr_eq(
+        assert!(Arc::ptr_eq(
             &context.interner(),
             &opposite_order_context.interner()
         ));
@@ -3311,7 +3347,7 @@ mod tests {
             source_lengths: &[],
         };
         let rir = ValidatedRir::finish(editor, &validation).unwrap();
-        let bundle = BodyRirBundle::new(rir, ThreadedRodeo::new());
+        let bundle = BodyRirBundle::new(rir, SharedSymbolSpace::private());
 
         let peer = bundle.provider_identity_context(source([]));
         peer.finalize_containment_metadata().unwrap();
@@ -3328,28 +3364,54 @@ mod tests {
         legacy.finalize_containment_metadata().unwrap();
         assert!(legacy.pool_mut().is_none());
 
-        let interner = Rc::new(ThreadedRodeo::new());
-        let state = ProviderBodyAnalysisState::new(source([]), Rc::clone(&interner));
+        let generations = rue_rir::SymbolSpaceGenerations::default();
+        let space = generations.next_generation();
+        let interner = Arc::clone(space.interner());
+        let state = ProviderBodyAnalysisState::new(source([]), space);
         state.finalize_containment_metadata().unwrap();
         assert!(state.identity_context().pool_mut().is_some());
-        assert!(Rc::ptr_eq(&interner, &state.interner()));
+        assert!(Arc::ptr_eq(&interner, &state.interner()));
         let state_interner = state.interner();
         assert!(std::ptr::eq(
-            Rc::as_ref(&interner),
-            Rc::as_ref(&state_interner)
+            Arc::as_ref(&interner),
+            Arc::as_ref(&state_interner)
         ));
 
         let rir = Rir::default();
-        let matching = BodyRirView::from_parts(&rir, Rc::as_ref(&interner));
+        let matching = BodyRirView::from_parts(&rir, Arc::as_ref(&interner));
         assert_eq!(
             matching.rir_interner() as *const ThreadedRodeo,
-            Rc::as_ref(&interner) as *const ThreadedRodeo
+            Arc::as_ref(&interner) as *const ThreadedRodeo
         );
         assert!(state.require_rir_authority(&matching));
 
         let other_interner = ThreadedRodeo::new();
         let mismatched = BodyRirView::from_parts(&rir, &other_interner);
         assert!(!state.require_rir_authority(&mismatched));
+
+        // ADR-0076 §4/§5: retiring this state's generation makes the authority
+        // check refuse it even though the interner it names is unchanged and
+        // still resolvable. The caller's only correct response is to re-run the
+        // body against the live generation, which is what the fail-closed
+        // contract requires.
+        let successor = generations.next_generation();
+        assert!(
+            state.symbol_space().is_live(),
+            "a peer mint retires nothing"
+        );
+        state.symbol_space().supersede();
+        assert!(!state.symbol_space().is_live());
+        assert!(!state.require_rir_authority(&matching));
+        assert!(
+            state
+                .interner()
+                .resolve(&state.identity_context().name_symbol("Widget"))
+                == "Widget",
+            "a retired space still resolves the handles it issued"
+        );
+        let reran = ProviderBodyAnalysisState::new(source([]), successor.clone());
+        let reran_view = BodyRirView::from_parts(&rir, successor.interner());
+        assert!(reran.require_rir_authority(&reran_view));
     }
 
     /// A durable nominal + callable source backed by fixed maps, standing in for
@@ -3435,7 +3497,7 @@ mod tests {
     fn pool(
         nominals: impl IntoIterator<Item = (Key, DurableNominal<Key, Module>)>,
     ) -> BodyIdentityPool<Key, Module, MapSource> {
-        BodyIdentityPool::new(source(nominals), Rc::new(ThreadedRodeo::new()))
+        BodyIdentityPool::new(source(nominals), Arc::new(ThreadedRodeo::new()))
     }
 
     /// A pool seeded with nominals, functions, and methods for the callable
@@ -3456,7 +3518,7 @@ mod tests {
                 anonymous_shapes: AHashMap::new(),
                 def_component_overrides: AHashMap::new(),
             },
-            Rc::new(ThreadedRodeo::new()),
+            Arc::new(ThreadedRodeo::new()),
         )
     }
 
@@ -3476,7 +3538,7 @@ mod tests {
                 anonymous_shapes: AHashMap::new(),
                 def_component_overrides: AHashMap::new(),
             },
-            Rc::new(ThreadedRodeo::new()),
+            Arc::new(ThreadedRodeo::new()),
         )
     }
 
@@ -3498,7 +3560,7 @@ mod tests {
                 anonymous_shapes: anonymous_shapes.into_iter().collect(),
                 def_component_overrides: def_component_overrides.into_iter().collect(),
             },
-            Rc::new(ThreadedRodeo::new()),
+            Arc::new(ThreadedRodeo::new()),
         )
     }
 
@@ -5287,7 +5349,7 @@ mod tests {
             .step_by(2)
             .map(|key| (key, FileId::new(key + 1)))
             .collect();
-        let mut pool = BodyIdentityPool::new(provider, Rc::new(ThreadedRodeo::new()));
+        let mut pool = BodyIdentityPool::new(provider, Arc::new(ThreadedRodeo::new()));
 
         for key in 0..MODULES {
             let ty = pool.resolve_provider_type(&DType::Nominal(key)).unwrap();
@@ -5337,7 +5399,7 @@ mod tests {
             ),
         ]);
         provider.nominal_file_ids = AHashMap::from([(0, FileId::new(41)), (1, FileId::new(41))]);
-        let mut pool = BodyIdentityPool::new(provider, Rc::new(ThreadedRodeo::new()));
+        let mut pool = BodyIdentityPool::new(provider, Arc::new(ThreadedRodeo::new()));
 
         pool.resolve_provider_type(&DType::Nominal(0)).unwrap();
         assert_eq!(
@@ -5544,7 +5606,7 @@ mod tests {
         supplied_source.functions.insert(0, function.clone());
         supplied_source.function_reads = Rc::clone(&supplied_reads);
         let mut supplied_pool =
-            BodyIdentityPool::new(supplied_source, Rc::new(ThreadedRodeo::new()));
+            BodyIdentityPool::new(supplied_source, Arc::new(ThreadedRodeo::new()));
         let first = supplied_pool
             .resolve_function_call_from(&0, &function, returns_type, file)
             .unwrap();
@@ -5567,7 +5629,7 @@ mod tests {
         ordinary_source.functions.insert(0, function);
         ordinary_source.function_reads = Rc::clone(&ordinary_reads);
         let mut ordinary_pool =
-            BodyIdentityPool::new(ordinary_source, Rc::new(ThreadedRodeo::new()));
+            BodyIdentityPool::new(ordinary_source, Arc::new(ThreadedRodeo::new()));
         let ordinary = ordinary_pool
             .resolve_function_call(&0, returns_type, file)
             .unwrap();
@@ -5614,7 +5676,7 @@ mod tests {
         let mut durable_source = source([]);
         durable_source.functions.insert(0, broken.clone());
         durable_source.function_reads = Rc::clone(&reads);
-        let mut pool = BodyIdentityPool::new(durable_source, Rc::new(ThreadedRodeo::new()));
+        let mut pool = BodyIdentityPool::new(durable_source, Arc::new(ThreadedRodeo::new()));
         let returns_type = false;
         let file = FileId::new(19);
 

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -388,7 +388,7 @@ pub struct ProviderOrdinaryBody<K, M> {
         Vec<FunctionInstanceKey<SemanticDefinitionToken, SemanticModuleToken>>,
     pub produced_anonymous_nominals: Arc<[crate::SemanticProducedAnonymousNominal]>,
     pub type_pool: Rc<TypeInternPool>,
-    pub interner: Rc<ThreadedRodeo>,
+    pub interner: Arc<ThreadedRodeo>,
     pub definition_tokens: Vec<(SemanticDefinitionToken, K)>,
     pub module_tokens: Vec<(SemanticModuleToken, M)>,
 }
@@ -404,7 +404,7 @@ pub struct ProviderSpecializedBody<K, M> {
     pub warnings: Vec<rue_error::CompileWarning>,
     pub strings: Vec<String>,
     pub type_pool: Rc<TypeInternPool>,
-    pub interner: Rc<ThreadedRodeo>,
+    pub interner: Arc<ThreadedRodeo>,
     pub produced_anonymous_nominals: Arc<[crate::SemanticProducedAnonymousNominal]>,
     pub referenced_definitions: Vec<K>,
     pub referenced_values: Vec<K>,
@@ -430,7 +430,7 @@ pub struct ProviderAnonymousBody<K, M> {
     pub warnings: Vec<rue_error::CompileWarning>,
     pub strings: Vec<String>,
     pub type_pool: Rc<TypeInternPool>,
-    pub interner: Rc<ThreadedRodeo>,
+    pub interner: Arc<ThreadedRodeo>,
     pub produced_anonymous_nominals: Arc<[crate::SemanticProducedAnonymousNominal]>,
     pub referenced_definitions: Vec<K>,
     pub referenced_values: Vec<K>,
@@ -828,7 +828,7 @@ struct ProviderBodyHost<'a, P, S, K, M> {
     aggregate: ProviderAggregateFacts<K, M, S>,
     state: ProviderBodyAnalysisState<K, M, S>,
     rir: super::BodyRirView<'a>,
-    interner: Rc<ThreadedRodeo>,
+    interner: Arc<ThreadedRodeo>,
     type_pool: Rc<TypeInternPool>,
     known: KnownSymbols,
     target: Target,
@@ -3574,7 +3574,7 @@ where
         Type,
         crate::SemanticTypeSyntaxError<std::convert::Infallible, CompileError, FileId, Spur>,
     > {
-        let interner = Rc::clone(&self.interner);
+        let interner = Arc::clone(&self.interner);
         let mut provider = TypeSyntaxProvider::new(
             self,
             request.span,
@@ -4148,7 +4148,7 @@ where
             arena: self.rir.rir().type_syntax().clone(),
             root: syntax,
         };
-        let interner = Rc::clone(&self.interner);
+        let interner = Arc::clone(&self.interner);
         OrdinaryBodyAnalysisHost::resolve_structured_type_syntax(
             self,
             StructuredTypeSyntaxRequest {

--- a/crates/rue-air/src/sema/provider_fixture.rs
+++ b/crates/rue-air/src/sema/provider_fixture.rs
@@ -742,7 +742,10 @@ impl ProviderFixture {
             },
         )
         .expect("fixture RIR validates");
-        let bundle = BodyRirBundle::new(rir, interner);
+        let bundle = BodyRirBundle::new(
+            rir,
+            rue_rir::SharedSymbolSpace::adopt(std::sync::Arc::new(interner)),
+        );
         let facts = FixtureFactSource(Rc::new(self.facts.clone()));
         analyze_provider_ordinary_body(
             &UnconsultedFactProvider,

--- a/crates/rue-compiler/src/canonical_lower.rs
+++ b/crates/rue-compiler/src/canonical_lower.rs
@@ -147,12 +147,14 @@ impl DeclarationBodyPlan {
     /// for the subsequent immutable-base/projected-view tranche.
     pub(crate) fn materialize_body_rir_bundle(
         &self,
+        space: &rue_rir::SharedSymbolSpace,
         file_id: FileId,
         declaration_start: u32,
         source_length: u32,
         checkpoint: impl FnMut() -> Result<(), rue_query::QueryAbort>,
     ) -> Result<rue_air::BodyRirBundle, BodyPlanMaterializationFailure> {
         self.materialize_body_rir_bundle_internal(
+            space,
             file_id,
             declaration_start,
             source_length,
@@ -164,6 +166,7 @@ impl DeclarationBodyPlan {
 
     pub(crate) fn materialize_body_rir_bundle_with_attribution(
         &self,
+        space: &rue_rir::SharedSymbolSpace,
         file_id: FileId,
         declaration_start: u32,
         source_length: u32,
@@ -173,6 +176,7 @@ impl DeclarationBodyPlan {
         BodyPlanMaterializationFailure,
     > {
         self.materialize_body_rir_bundle_internal(
+            space,
             file_id,
             declaration_start,
             source_length,
@@ -187,12 +191,14 @@ impl DeclarationBodyPlan {
     /// nested producer/member directly from this same candidate graph.
     pub(crate) fn materialize_body_rir_bundle_with_declaration(
         &self,
+        space: &rue_rir::SharedSymbolSpace,
         file_id: FileId,
         declaration_start: u32,
         source_length: u32,
         checkpoint: impl FnMut() -> Result<(), rue_query::QueryAbort>,
     ) -> Result<(rue_air::BodyRirBundle, InstRef), BodyPlanMaterializationFailure> {
         self.materialize_body_rir_bundle_internal(
+            space,
             file_id,
             declaration_start,
             source_length,
@@ -204,6 +210,7 @@ impl DeclarationBodyPlan {
 
     pub(crate) fn materialize_body_rir_bundle_with_declaration_and_attribution(
         &self,
+        space: &rue_rir::SharedSymbolSpace,
         file_id: FileId,
         declaration_start: u32,
         source_length: u32,
@@ -217,6 +224,7 @@ impl DeclarationBodyPlan {
         BodyPlanMaterializationFailure,
     > {
         self.materialize_body_rir_bundle_internal(
+            space,
             file_id,
             declaration_start,
             source_length,
@@ -228,6 +236,7 @@ impl DeclarationBodyPlan {
 
     fn materialize_body_rir_bundle_internal(
         &self,
+        space: &rue_rir::SharedSymbolSpace,
         file_id: FileId,
         declaration_start: u32,
         source_length: u32,
@@ -241,25 +250,23 @@ impl DeclarationBodyPlan {
         ),
         BodyPlanMaterializationFailure,
     > {
-        let (
-            rir,
-            symbols,
-            declaration,
-            _remap_finished_ns,
-            symbol_finished_ns,
-            validation_finished_ns,
-        ) = self.materialize_candidate_rir_internal(
-            file_id,
-            declaration_start,
-            source_length,
-            true,
-            attribution_enabled,
-            &mut checkpoint,
-        )?;
+        let (rir, declaration, _remap_finished_ns, symbol_finished_ns, validation_finished_ns) =
+            self.materialize_candidate_rir_internal(
+                space,
+                file_id,
+                declaration_start,
+                source_length,
+                true,
+                attribution_enabled,
+                &mut checkpoint,
+            )?;
         let rir_instructions = rir.len() as u64;
         let rir_payload_words = rir.extra_len() as u64;
-        let (bundle, index) =
-            rue_air::BodyRirBundle::new_with_index_attribution(rir, symbols, attribution_enabled);
+        let (bundle, index) = rue_air::BodyRirBundle::new_with_index_attribution(
+            rir,
+            space.clone(),
+            attribution_enabled,
+        );
         checkpoint().map_err(BodyPlanMaterializationFailure::Query)?;
         Ok((
             bundle,
@@ -284,12 +291,14 @@ impl DeclarationBodyPlan {
     #[cfg(test)]
     pub(crate) fn materialize_candidate_rir(
         &self,
+        space: &rue_rir::SharedSymbolSpace,
         file_id: FileId,
         declaration_start: u32,
         source_length: u32,
         mut checkpoint: impl FnMut() -> Result<(), rue_query::QueryAbort>,
-    ) -> Result<(ValidatedRir, lasso::ThreadedRodeo), BodyPlanMaterializationFailure> {
+    ) -> Result<ValidatedRir, BodyPlanMaterializationFailure> {
         self.materialize_candidate_rir_internal(
+            space,
             file_id,
             declaration_start,
             source_length,
@@ -297,7 +306,7 @@ impl DeclarationBodyPlan {
             false,
             &mut checkpoint,
         )
-        .map(|(rir, symbols, _, _, _, _)| (rir, symbols))
+        .map(|(rir, _, _, _, _)| rir)
     }
 
     /// Decode this candidate for declaration-time constant/comptime
@@ -357,18 +366,26 @@ impl DeclarationBodyPlan {
         Ok((rir, symbols, metadata.declaration))
     }
 
+    /// Materialize this body plan's RIR into the revision-shared equality space
+    /// (ADR-0076 §1).
+    ///
+    /// The packed envelope speaks the body-private dense encoding space: a
+    /// symbol *is* its ordinal in the dense spelling section. This builds the
+    /// body's dense remap — ordinal to shared handle, one entry per ordinal,
+    /// interned once per revision rather than once per body — and decodes the
+    /// candidate through it, so the RIR names symbols in the same space its
+    /// analysis state does. The dense space holds only that remap; it does not
+    /// re-intern the section into a private table.
     fn materialize_candidate_rir_internal(
         &self,
+        space: &rue_rir::SharedSymbolSpace,
         file_id: FileId,
         declaration_start: u32,
         source_length: u32,
         include_method_owner: bool,
         attribution_enabled: bool,
         checkpoint: &mut impl FnMut() -> Result<(), rue_query::QueryAbort>,
-    ) -> Result<
-        (ValidatedRir, lasso::ThreadedRodeo, InstRef, u64, u64, u64),
-        BodyPlanMaterializationFailure,
-    > {
+    ) -> Result<(ValidatedRir, InstRef, u64, u64, u64), BodyPlanMaterializationFailure> {
         checkpoint().map_err(BodyPlanMaterializationFailure::Query)?;
         let started = attribution_enabled.then(Instant::now);
         let elapsed = || {
@@ -376,22 +393,35 @@ impl DeclarationBodyPlan {
                 u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX)
             })
         };
-        let symbols = lasso::ThreadedRodeo::new();
+        let interner = space.interner();
         let packed_symbols = self.packed.symbols();
+        let mut dense_remap = Vec::new();
+        dense_remap
+            .try_reserve_exact(packed_symbols.len())
+            .map_err(|_| {
+                BodyPlanMaterializationFailure::Build(RirPayloadBuildError::CapacityFailure {
+                    family: "body-plan dense symbol remap",
+                })
+            })?;
         for (ordinal, spelling) in packed_symbols.enumerate() {
             if ordinal & 63 == 0 {
                 checkpoint().map_err(BodyPlanMaterializationFailure::Query)?;
             }
-            let symbol: lasso::Spur = symbols.get_or_intern(spelling);
-            if symbol.into_usize() != ordinal {
+            // The dense space's own invariant, unchanged in meaning from the
+            // per-body interner it replaces: the remap entry a spelling lands
+            // at *is* the ordinal the packed envelope encodes it as. A shared
+            // handle's numeric value is a revision-wide, scheduling-dependent
+            // datum and deliberately says nothing about this ordinal.
+            if dense_remap.len() != ordinal {
                 return Err(BodyPlanMaterializationFailure::Invalid(Arc::from(
                     "body-plan symbol universe did not preserve stable ordinals",
                 )));
             }
+            dense_remap.push(interner.get_or_intern(spelling));
         }
         checkpoint().map_err(BodyPlanMaterializationFailure::Query)?;
         let symbol_finished_ns = elapsed();
-        let symbol_count = symbols.len();
+        let symbol_count = dense_remap.len();
         let projection = PackedRirProjection {
             symbol_count,
             file_id,
@@ -399,32 +429,32 @@ impl DeclarationBodyPlan {
             source_length,
         };
         let checkpoint_decode = || checkpoint().map_err(BodyPlanMaterializationFailure::Query);
-        let (rir, metadata) = if include_method_owner {
-            self.packed
-                .try_decode_validated_with_method_owner(projection, checkpoint_decode)
-        } else {
-            self.packed
-                .try_decode_validated(projection, checkpoint_decode)
-        }
-        .map_err(|error| match error {
-            rue_rir::PackedRirAppendError::Checkpoint(failure)
-            | rue_rir::PackedRirAppendError::SymbolRemap(failure)
-            | rue_rir::PackedRirAppendError::SpanRemap { error: failure, .. } => failure,
-            rue_rir::PackedRirAppendError::Build(error) => {
-                BodyPlanMaterializationFailure::Build(error)
-            }
-            rue_rir::PackedRirAppendError::Decode(error) => {
-                BodyPlanMaterializationFailure::Invalid(Arc::from(format!(
-                    "private packed body plan is invalid: {error}"
-                )))
-            }
-        })?;
+        let (rir, metadata) = self
+            .packed
+            .try_decode_validated_remapped(
+                projection,
+                include_method_owner,
+                checkpoint_decode,
+                |ordinal| dense_remap.get(ordinal as usize).copied(),
+            )
+            .map_err(|error| match error {
+                rue_rir::PackedRirAppendError::Checkpoint(failure)
+                | rue_rir::PackedRirAppendError::SymbolRemap(failure)
+                | rue_rir::PackedRirAppendError::SpanRemap { error: failure, .. } => failure,
+                rue_rir::PackedRirAppendError::Build(error) => {
+                    BodyPlanMaterializationFailure::Build(error)
+                }
+                rue_rir::PackedRirAppendError::Decode(error) => {
+                    BodyPlanMaterializationFailure::Invalid(Arc::from(format!(
+                        "private packed body plan is invalid: {error}"
+                    )))
+                }
+            })?;
         let remap_finished_ns = elapsed();
         checkpoint().map_err(BodyPlanMaterializationFailure::Query)?;
         let validation_finished_ns = elapsed();
         Ok((
             rir,
-            symbols,
             metadata.declaration,
             remap_finished_ns,
             symbol_finished_ns,
@@ -1734,9 +1764,10 @@ fn target(inout values: [i32; 4]) -> type {
             .unwrap()
             .declaration_span
             .start;
-        let (target_rir, _) = target_artifact
+        let target_rir = target_artifact
             .plan
             .materialize_candidate_rir(
+                &rue_rir::SharedSymbolSpace::private(),
                 module.file_id(),
                 declaration_start,
                 module.source_text().len() as u32,
@@ -1951,6 +1982,76 @@ fn target(inout values: [i32; 4]) -> type {
         );
     }
 
+    /// ADR-0076: two bodies of one revision share the equality space, and the
+    /// space a body is materialized into does not change the program it names.
+    ///
+    /// The second candidate is materialized into a space the first has already
+    /// populated, so its handles are offset out of the dense ordinals the
+    /// packed envelope encodes. Both renders match the private-space render,
+    /// and the shared space holds each spelling once rather than once per body.
+    #[test]
+    fn bodies_of_one_revision_share_one_equality_space() {
+        let source = snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn first() -> i32 { 1 + 2 }\nfn second() -> i32 { 3 + 4 }",
+            )],
+            1,
+        );
+        let module = parse_source_snapshot_modules(&source).unwrap().modules()[0].clone();
+        let source_length = module.source_text().len() as u32;
+        let render = |name: &str, space: &rue_rir::SharedSymbolSpace| {
+            let key = candidate_named(&module, name);
+            let declaration_start = module
+                .definitions()
+                .declaration_locator(&key)
+                .unwrap()
+                .declaration_span
+                .start;
+            let artifacts = lower_parsed_declaration_body_plan(&module, &key, || Ok(())).unwrap();
+            let rir = artifacts
+                .plan
+                .materialize_candidate_rir(
+                    space,
+                    module.file_id(),
+                    declaration_start,
+                    source_length,
+                    || Ok(()),
+                )
+                .unwrap();
+            rue_rir::RirPrinter::new(&rir, space.interner()).to_string()
+        };
+
+        let shared = rue_rir::SharedSymbolSpace::private();
+        let first_shared = render("first", &shared);
+        let interned_after_first = shared.interner().len();
+        let second_shared = render("second", &shared);
+
+        assert_eq!(
+            first_shared,
+            render("first", &rue_rir::SharedSymbolSpace::private())
+        );
+        assert_eq!(
+            second_shared,
+            render("second", &rue_rir::SharedSymbolSpace::private())
+        );
+        assert!(
+            shared.interner().len() < interned_after_first * 2,
+            "the second body reused the first body's interned spellings"
+        );
+        // The dense ordinals the second body's packed envelope encodes are no
+        // longer its handles: the shared space had already issued them.
+        assert!(shared.interner().get("second").is_some());
+        assert!(
+            shared
+                .interner()
+                .get("second")
+                .is_some_and(|symbol| symbol.into_usize() >= interned_after_first)
+        );
+    }
+
     #[test]
     fn body_plan_materialization_reprojects_fails_closed_and_retries() {
         let source = snapshot(
@@ -1970,23 +2071,33 @@ fn target(inout values: [i32; 4]) -> type {
         let source_length = module.source_text().len() as u32;
         let materialized = artifacts
             .plan
-            .materialize_candidate_rir(file_id, declaration_start, source_length, || Ok(()))
-            .unwrap()
-            .0;
+            .materialize_candidate_rir(
+                &rue_rir::SharedSymbolSpace::private(),
+                file_id,
+                declaration_start,
+                source_length,
+                || Ok(()),
+            )
+            .unwrap();
         assert!(
             materialized
                 .iter()
                 .all(|(_, instruction)| instruction.span.file_id == file_id)
         );
         assert!(matches!(
-            artifacts
-                .plan
-                .materialize_body_rir_bundle(file_id, declaration_start, 1, || Ok(()),),
+            artifacts.plan.materialize_body_rir_bundle(
+                &rue_rir::SharedSymbolSpace::private(),
+                file_id,
+                declaration_start,
+                1,
+                || Ok(()),
+            ),
             Err(BodyPlanMaterializationFailure::Invalid(_))
         ));
 
         assert!(matches!(
             artifacts.plan.materialize_body_rir_bundle(
+                &rue_rir::SharedSymbolSpace::private(),
                 file_id,
                 declaration_start,
                 source_length,
@@ -1999,7 +2110,13 @@ fn target(inout values: [i32; 4]) -> type {
         assert!(
             artifacts
                 .plan
-                .materialize_body_rir_bundle(file_id, declaration_start, source_length, || Ok(()),)
+                .materialize_body_rir_bundle(
+                    &rue_rir::SharedSymbolSpace::private(),
+                    file_id,
+                    declaration_start,
+                    source_length,
+                    || Ok(()),
+                )
                 .is_ok()
         );
     }
@@ -2029,9 +2146,10 @@ fn target(inout values: [i32; 4]) -> type {
         assert!(spellings.contains(&"middle"));
         assert!(!spellings.contains(&"first"));
         assert!(!spellings.contains(&"last"));
-        let (materialized, _) = artifacts
+        let materialized = artifacts
             .plan
             .materialize_candidate_rir(
+                &rue_rir::SharedSymbolSpace::private(),
                 module.file_id(),
                 method_span.start,
                 module.source_text().len() as u32,

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -15758,6 +15758,7 @@ impl RevisionedQueryDatabase {
                     provider_observation_meter: provider_observation_meter.clone(),
                     lookup_root_lease: lookup_root_lease.clone(),
                     runtime: runtime.clone(),
+                    symbol_space: RevisionSymbolSpace::default(),
                     #[cfg(test)]
                     inject_body_transaction_failure: inject_body_transaction_failure.clone(),
                     #[cfg(test)]
@@ -16859,6 +16860,51 @@ impl BodyInputResolver {
     }
 }
 
+/// The revision-scoped owner of the shared symbol equality space (ADR-0076).
+///
+/// One append-only interner serves every body of one semantic revision, so a
+/// name in the program's nominal closure is interned once rather than once per
+/// body. A generation is retired when its revision falls out of the window
+/// below; a body still carrying the retired generation fails
+/// `require_rir_authority` and re-runs, so a superseded equality space is never
+/// silently reused.
+///
+/// The window holds more than one revision on purpose. Retiring the previous
+/// generation on every mint would make two concurrently pinned revisions retire
+/// each other's space and abandon each other's bodies without progressing;
+/// keeping the recent few makes that need more simultaneously live revisions
+/// than the engine pins, while still bounding how many interners are resident.
+#[derive(Debug, Default)]
+struct RevisionSymbolSpace {
+    generations: rue_rir::SymbolSpaceGenerations,
+    live: Mutex<VecDeque<(Revision, rue_rir::SharedSymbolSpace)>>,
+}
+
+impl RevisionSymbolSpace {
+    /// How many revisions' equality spaces stay live at once.
+    const WINDOW: usize = 4;
+
+    /// The live generation for `revision`, minting it if this revision has no
+    /// live generation yet.
+    fn generation(&self, revision: Revision) -> rue_rir::SharedSymbolSpace {
+        let mut live = self
+            .live
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some((_, space)) = live.iter().find(|(pinned, _)| *pinned == revision) {
+            return space.clone();
+        }
+        let space = self.generations.next_generation();
+        live.push_back((revision, space.clone()));
+        while live.len() > Self::WINDOW {
+            if let Some((_, evicted)) = live.pop_front() {
+                evicted.supersede();
+            }
+        }
+        space
+    }
+}
+
 struct BodyTransactionEvaluator {
     parse_modules: QueryFamily<ModuleQueryKey, ParseModuleValue>,
     module_source_bases: QueryFamily<ModuleQueryKey, Option<rue_air::DurableBodySourceLocator>>,
@@ -16878,6 +16924,11 @@ struct BodyTransactionEvaluator {
     provider_observation_meter: Arc<ProviderObservationCounters>,
     lookup_root_lease: Arc<Mutex<PublishedRootLookupLease>>,
     runtime: QueryRuntime,
+    /// The ADR-0076 revision-shared symbol space. Every body of one semantic
+    /// revision decodes its RIR into, and analyzes against, one append-only
+    /// interner, so the program's nominal closure is interned once per
+    /// revision instead of once per body.
+    symbol_space: RevisionSymbolSpace,
     #[cfg(test)]
     inject_body_transaction_failure: Arc<std::sync::atomic::AtomicBool>,
     #[cfg(test)]
@@ -17331,11 +17382,13 @@ impl BodyTransactionEvaluator {
                 let _body_input_lowering_span =
                     tracing::info_span!("body_input_lowering", phase = "semantic_analysis")
                         .entered();
+                let symbol_space = self.symbol_space.generation(context.revision());
                 let materialized = if attribution_enabled {
                     input
                         .artifacts
                         .plan
                         .materialize_body_rir_bundle_with_attribution(
+                            &symbol_space,
                             input.source.file_id,
                             input.source.declaration_start,
                             input.source.source_length,
@@ -17347,6 +17400,7 @@ impl BodyTransactionEvaluator {
                         .artifacts
                         .plan
                         .materialize_body_rir_bundle(
+                            &symbol_space,
                             input.source.file_id,
                             input.source.declaration_start,
                             input.source.source_length,
@@ -17386,6 +17440,13 @@ impl BodyTransactionEvaluator {
                     }
                 };
                 drop(_body_input_lowering_span);
+                // ADR-0076 §4: a body materialized against a superseded
+                // equality space is never reused. Abandoning the attempt here
+                // re-runs the body against the live generation, which is the
+                // fail-closed half of `require_rir_authority`.
+                if !bundle.symbol_space().is_live() {
+                    return Err(QueryAbort::Canceled);
+                }
                 let provider = CompilerBodyFactProvider::new(
                     self.compiler_body_provider_queries(
                         context,
@@ -17612,11 +17673,13 @@ impl BodyTransactionEvaluator {
                 let _body_input_lowering_span =
                     tracing::info_span!("body_input_lowering", phase = "semantic_analysis")
                         .entered();
+                let symbol_space = self.symbol_space.generation(context.revision());
                 let materialized = if attribution_enabled {
                     input
                         .artifacts
                         .plan
                         .materialize_body_rir_bundle_with_attribution(
+                            &symbol_space,
                             input.source.file_id,
                             input.source.declaration_start,
                             input.source.source_length,
@@ -17628,6 +17691,7 @@ impl BodyTransactionEvaluator {
                         .artifacts
                         .plan
                         .materialize_body_rir_bundle(
+                            &symbol_space,
                             input.source.file_id,
                             input.source.declaration_start,
                             input.source.source_length,
@@ -17667,6 +17731,13 @@ impl BodyTransactionEvaluator {
                     }
                 };
                 drop(_body_input_lowering_span);
+                // ADR-0076 §4: a body materialized against a superseded
+                // equality space is never reused. Abandoning the attempt here
+                // re-runs the body against the live generation, which is the
+                // fail-closed half of `require_rir_authority`.
+                if !bundle.symbol_space().is_live() {
+                    return Err(QueryAbort::Canceled);
+                }
                 let provider = CompilerBodyFactProvider::new(
                     self.compiler_body_provider_queries(
                         context,
@@ -17980,11 +18051,13 @@ impl BodyTransactionEvaluator {
                 let _body_input_lowering_span =
                     tracing::info_span!("body_input_lowering", phase = "semantic_analysis")
                         .entered();
+                let symbol_space = self.symbol_space.generation(context.revision());
                 let materialized = if attribution_enabled {
                     input
                         .artifacts
                         .plan
                         .materialize_body_rir_bundle_with_declaration_and_attribution(
+                            &symbol_space,
                             input.source.file_id,
                             input.source.declaration_start,
                             input.source.source_length,
@@ -17998,6 +18071,7 @@ impl BodyTransactionEvaluator {
                         .artifacts
                         .plan
                         .materialize_body_rir_bundle_with_declaration(
+                            &symbol_space,
                             input.source.file_id,
                             input.source.declaration_start,
                             input.source.source_length,
@@ -18039,6 +18113,13 @@ impl BodyTransactionEvaluator {
                     }
                 };
                 drop(_body_input_lowering_span);
+                // ADR-0076 §4: a body materialized against a superseded
+                // equality space is never reused. Abandoning the attempt here
+                // re-runs the body against the live generation, which is the
+                // fail-closed half of `require_rir_authority`.
+                if !bundle.symbol_space().is_live() {
+                    return Err(QueryAbort::Canceled);
+                }
                 let provider = CompilerBodyFactProvider::new(
                     self.compiler_body_provider_queries(
                         context,
@@ -24650,6 +24731,41 @@ mod tests {
     };
     use rue_span::FileId;
     use std::collections::{BTreeSet, HashMap};
+
+    /// ADR-0076 §1/§4: one append-only equality space per revision, shared by
+    /// every body of that revision, and retired once the revision leaves the
+    /// live window so a body carrying it fails its authority check.
+    #[test]
+    fn the_revision_symbol_space_is_one_generation_per_revision() {
+        let space = RevisionSymbolSpace::default();
+        let first = Revision::new(1, 0);
+
+        let a = space.generation(first);
+        let b = space.generation(first);
+        assert!(Arc::ptr_eq(a.interner(), b.interner()));
+        a.interner().get_or_intern("__anon_struct_00.member");
+        assert_eq!(b.interner().len(), 1, "the space is shared, not copied");
+
+        // A peer revision gets its own space and does not retire this one, so
+        // two concurrently pinned revisions cannot abandon each other's bodies.
+        let peer = space.generation(Revision::new(2, 0));
+        assert!(!Arc::ptr_eq(a.interner(), peer.interner()));
+        assert!(a.is_live());
+        assert!(peer.is_live());
+        assert_eq!(peer.interner().len(), 0);
+
+        // Falling out of the live window retires it for every holder.
+        for id in 3..=(RevisionSymbolSpace::WINDOW as u64 + 2) {
+            space.generation(Revision::new(id, 0));
+        }
+        assert!(!a.is_live(), "the superseded generation fails closed");
+        assert!(!b.is_live());
+        assert_eq!(
+            a.interner().len(),
+            1,
+            "a retired space still resolves the handles it issued"
+        );
+    }
 
     fn lookup_history_key(name: impl Into<Arc<str>>) -> LookupObservationKey {
         LookupObservationKey::Name(LookupNameKey {
@@ -37515,6 +37631,7 @@ fn main() -> i32 {
             .artifacts
             .plan
             .materialize_body_rir_bundle(
+                &rue_rir::SharedSymbolSpace::private(),
                 input.source.file_id,
                 input.source.declaration_start,
                 input.source.source_length,
@@ -38307,6 +38424,7 @@ fn main() -> i32 {
             .artifacts
             .plan
             .materialize_body_rir_bundle(
+                &rue_rir::SharedSymbolSpace::private(),
                 input.source.file_id,
                 input.source.declaration_start,
                 input.source.source_length,
@@ -38808,16 +38926,18 @@ fn main() -> i32 {
         let first_weak = Arc::downgrade(first_artifact);
         let render = |artifact: &crate::canonical_lower::DeclarationBodyPlanArtifacts| {
             let declaration_start = u32::try_from(text.find("fn f0").unwrap()).unwrap();
-            let (rir, symbols) = artifact
+            let space = rue_rir::SharedSymbolSpace::private();
+            let rir = artifact
                 .plan
                 .materialize_candidate_rir(
+                    &space,
                     rue_span::FileId::new(1),
                     declaration_start,
                     u32::try_from(text.len()).unwrap(),
                     || Ok(()),
                 )
                 .unwrap();
-            rue_rir::RirPrinter::new(&rir, &symbols).to_string()
+            rue_rir::RirPrinter::new(&rir, space.interner()).to_string()
         };
         let first_render = render(first_artifact);
         drop(first_terminal);

--- a/crates/rue-rir/src/inst/packed.rs
+++ b/crates/rue-rir/src/inst/packed.rs
@@ -233,7 +233,7 @@ impl PackedValidatedRir {
         projection: PackedRirProjection,
         checkpoint: impl FnMut() -> Result<(), E>,
     ) -> Result<(ValidatedRir, PackedRirAppendMetadata), PackedRirAppendError<E>> {
-        self.try_decode_validated_internal(projection, false, checkpoint)
+        self.try_decode_validated_internal(projection, false, checkpoint, Self::dense_symbol)
     }
 
     /// Decode one candidate and append its analysis-only named-method owner
@@ -243,7 +243,39 @@ impl PackedValidatedRir {
         projection: PackedRirProjection,
         checkpoint: impl FnMut() -> Result<(), E>,
     ) -> Result<(ValidatedRir, PackedRirAppendMetadata), PackedRirAppendError<E>> {
-        self.try_decode_validated_internal(projection, true, checkpoint)
+        self.try_decode_validated_internal(projection, true, checkpoint, Self::dense_symbol)
+    }
+
+    /// Decode one candidate while translating its dense symbol ordinals into
+    /// another interner's handles.
+    ///
+    /// The packed envelope always speaks the body-private dense encoding space
+    /// (ADR-0076 §1): a symbol *is* its ordinal in this owner's dense spelling
+    /// section. A caller whose analysis state uses the revision-shared equality
+    /// space supplies the body's dense remap here, so the decoded RIR names
+    /// symbols in the same space its analysis does. `remap_symbol` returning
+    /// `None` is an out-of-range ordinal and fails the decode.
+    pub fn try_decode_validated_remapped<E>(
+        &self,
+        projection: PackedRirProjection,
+        include_method_owner: bool,
+        checkpoint: impl FnMut() -> Result<(), E>,
+        remap_symbol: impl FnMut(u32) -> Option<Spur>,
+    ) -> Result<(ValidatedRir, PackedRirAppendMetadata), PackedRirAppendError<E>> {
+        self.try_decode_validated_internal(
+            projection,
+            include_method_owner,
+            checkpoint,
+            remap_symbol,
+        )
+    }
+
+    /// The identity remap: a dense ordinal is its own symbol handle. This is
+    /// the body-private dense encoding space read back as itself, used by the
+    /// declaration-time candidate path whose spelling table is a `&[&str]`
+    /// indexed by the same ordinals.
+    fn dense_symbol(ordinal: u32) -> Option<Spur> {
+        Spur::try_from_usize(ordinal as usize)
     }
 
     fn try_decode_validated_internal<E>(
@@ -251,6 +283,7 @@ impl PackedValidatedRir {
         projection: PackedRirProjection,
         include_method_owner: bool,
         mut checkpoint: impl FnMut() -> Result<(), E>,
+        mut remap_symbol: impl FnMut(u32) -> Option<Spur>,
     ) -> Result<(ValidatedRir, PackedRirAppendMetadata), PackedRirAppendError<E>> {
         enum Checked<E> {
             Callback(E),
@@ -301,7 +334,7 @@ impl PackedValidatedRir {
                 false,
                 || checkpoint().map_err(Checked::Callback),
                 |ordinal| {
-                    Spur::try_from_usize(ordinal as usize).ok_or(Checked::Invalid(
+                    remap_symbol(ordinal).ok_or(Checked::Invalid(
                         PackedRirDecodeError::CountOutOfBounds {
                             family: "projected symbol ordinal",
                         },
@@ -3488,6 +3521,96 @@ mod tests {
         };
         assert_eq!(render(&source), render(&decoded));
         assert_eq!(pack(&decoded, &symbols, root).as_bytes(), packed.as_bytes());
+    }
+
+    /// ADR-0076 dense-space integrity.
+    ///
+    /// The packed envelope always speaks the body-private dense ordinal space.
+    /// Decoding it through a body's dense remap into a *shared* equality space
+    /// — one already carrying unrelated strings, so no handle equals its
+    /// ordinal — produces the same program: the two decodes render identically,
+    /// and the dense decode still repacks to the original bytes. The dense
+    /// space is the encoding; the equality space the body analyzes in is not.
+    #[test]
+    fn a_shared_space_decode_renders_and_repacks_exactly_like_the_dense_one() {
+        let (source, dense_symbols, root) = every_structured_type_owner();
+        let packed = pack(&source, &dense_symbols, root);
+        let projection = PackedRirProjection {
+            symbol_count: packed.symbol_count(),
+            file_id: FileId::DEFAULT,
+            declaration_start: 0,
+            source_length: u32::MAX,
+        };
+
+        let shared: ThreadedRodeo = ThreadedRodeo::new();
+        for occupied in ["@revision", "@peer-body", "@another-body-name"] {
+            shared.get_or_intern(occupied);
+        }
+        let dense_remap = packed
+            .symbols()
+            .map(|spelling| shared.get_or_intern(spelling))
+            .collect::<Vec<_>>();
+        assert_eq!(dense_remap.len(), packed.symbol_count());
+        assert!(
+            dense_remap
+                .iter()
+                .enumerate()
+                .all(|(ordinal, symbol)| symbol.into_usize() != ordinal),
+            "the fixture must exercise handles that are not their own ordinals"
+        );
+
+        let (dense_decoded, dense_metadata) = packed
+            .try_decode_validated(projection, || Ok::<_, ()>(()))
+            .unwrap();
+        let (shared_decoded, shared_metadata) = packed
+            .try_decode_validated_remapped(
+                projection,
+                false,
+                || Ok::<_, ()>(()),
+                |ordinal| dense_remap.get(ordinal as usize).copied(),
+            )
+            .unwrap();
+
+        assert_eq!(dense_metadata.declaration, shared_metadata.declaration);
+        assert_eq!(dense_metadata.declaration, root);
+        assert_eq!(dense_decoded.0.extra, shared_decoded.0.extra);
+        assert_eq!(
+            RirPrinter::new(&dense_decoded, &dense_symbols).to_string(),
+            RirPrinter::new(&shared_decoded, &shared).to_string(),
+            "the equality space a body decodes into does not change the program"
+        );
+        assert_eq!(
+            pack(&dense_decoded, &dense_symbols, root).as_bytes(),
+            packed.as_bytes(),
+            "the dense encoding space round-trips to the same bytes"
+        );
+    }
+
+    /// An ordinal outside the body's dense remap fails the decode closed rather
+    /// than silently naming another body's symbol in the shared space.
+    #[test]
+    fn a_dense_ordinal_outside_the_remap_fails_the_decode() {
+        let (source, dense_symbols, root) = every_structured_type_owner();
+        let packed = pack(&source, &dense_symbols, root);
+        let error = packed
+            .try_decode_validated_remapped(
+                PackedRirProjection {
+                    symbol_count: packed.symbol_count(),
+                    file_id: FileId::DEFAULT,
+                    declaration_start: 0,
+                    source_length: u32::MAX,
+                },
+                false,
+                || Ok::<_, ()>(()),
+                |_| None,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            PackedRirAppendError::Decode(PackedRirDecodeError::CountOutOfBounds {
+                family: "projected symbol ordinal"
+            })
+        ));
     }
 
     #[test]

--- a/crates/rue-rir/src/lib.rs
+++ b/crates/rue-rir/src/lib.rs
@@ -49,7 +49,7 @@ pub use inst::{
     RirStructMethodsRange, RirStructuralAnchor, RirStructuralPathSegment, RirValidationContext,
     ValidatedRir,
 };
-pub use symbol::SymbolHandle;
+pub use symbol::{SharedSymbolSpace, SymbolHandle, SymbolSpaceGenerations};
 pub use type_syntax::{
     RirTypeSyntaxAppendError, RirTypeSyntaxArena, RirTypeSyntaxBuildError, RirTypeSyntaxBuilder,
     RirTypeSyntaxNode, RirTypeSyntaxRange, RirTypeSyntaxRef, RirTypeSyntaxSymbol,

--- a/crates/rue-rir/src/symbol.rs
+++ b/crates/rue-rir/src/symbol.rs
@@ -1,11 +1,11 @@
-//! The equality-only handle into a body's symbol interner (ADR-0076).
+//! The equality-only handle into the shared symbol interner, and the
+//! revision-scoped space that issues it (ADR-0076).
 //!
 //! A [`lasso::Spur`] is an index into whatever interner issued it, assigned in
-//! first-intern order. Today every body owns a private `ThreadedRodeo`, so that
-//! order is a deterministic function of the body's own traversal. ADR-0076
-//! shares one append-only interner across the bodies of a revision, at which
-//! point first-intern order becomes a function of worker scheduling and a
-//! handle's numeric value stops being reproducible.
+//! first-intern order. [`SharedSymbolSpace`] holds one append-only interner per
+//! revision generation of the semantic engine, shared across every body of that
+//! generation, so first-intern order is a function of worker scheduling and a
+//! handle's numeric value is not reproducible between runs.
 //!
 //! [`SymbolHandle`] is the type that states that contract in the type system.
 //! It wraps a `Spur` and deliberately offers less than one:
@@ -20,11 +20,26 @@
 //! issued the handle. Anything that needs an order takes it from the symbol's
 //! text or from a stable identity (ADR-0074's structural hashes).
 //!
-//! The escape hatch is [`SymbolHandle::body_local_ordinal`], named so that
-//! every remaining value-bearing use is one grep away and each one has to say
-//! which body-local dense space it is speaking about.
+//! The escape hatch is [`SymbolHandle::issuing_interner_ordinal`], named so
+//! that every remaining value-bearing use is one grep away and each one has to
+//! say which interner's index space it is speaking about.
+//!
+//! # The two spaces
+//!
+//! ADR-0076 §1 splits what used to be one per-body interner in two:
+//!
+//! - the **shared equality space**, this module's [`SharedSymbolSpace`]. Strings
+//!   are interned once per revision generation; handles are equality-only and
+//!   cross bodies freely within their generation.
+//! - the **body-private dense encoding space**, which is the packed RIR symbol
+//!   section's ordinals. Those ordinals *are* the encoding, so they stay dense
+//!   and body-local; a body decodes them into shared handles through a dense
+//!   remap built once per materialization. The dense space holds that remap
+//!   only — it never re-interns the strings.
 
-use lasso::{Key, Spur};
+use lasso::{Key, Spur, ThreadedRodeo};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 /// An equality-only handle into one body's symbol interner.
 ///
@@ -50,14 +65,109 @@ impl SymbolHandle {
     /// This handle's numeric value inside the interner that issued it.
     ///
     /// ADR-0076 forbids letting that value reach an emitted artifact, a
-    /// published payload, or a deterministic counter. It is legitimate only
-    /// where the issuing interner is a body-private dense table whose ordinals
-    /// are the encoding — the packed RIR symbol section is the one such space
-    /// in the compiler today — and every caller owes an explanation of which
-    /// dense space it means.
+    /// published payload, or a deterministic counter, because under a shared
+    /// revision interner the value is assigned in worker-scheduling order.
+    /// It is legitimate only where the value round-trips inside one artifact
+    /// against the very interner that issued it, and every caller owes an
+    /// explanation of which interner it means.
     #[must_use]
-    pub fn body_local_ordinal(self) -> usize {
+    pub fn issuing_interner_ordinal(self) -> usize {
         self.0.into_usize()
+    }
+}
+
+/// One append-only symbol interner, branded with the revision generation that
+/// minted it (ADR-0076 §1 and §4).
+///
+/// Every body of a generation shares one interner, so a string is interned once
+/// per revision instead of once per body. The space is append-only within its
+/// generation; when the owner retires it with [`Self::supersede`], every clone
+/// reports [`Self::is_live`] as `false` at once, and a body still holding it
+/// fails its RIR authority check rather than being silently reused. The
+/// interner itself stays alive for as long as some holder needs to resolve the
+/// handles it already issued — refusal, not a dangling handle, is the
+/// fail-closed behavior.
+#[derive(Debug, Clone)]
+pub struct SharedSymbolSpace {
+    interner: Arc<ThreadedRodeo>,
+    generation: u64,
+    live: Arc<AtomicBool>,
+}
+
+impl SharedSymbolSpace {
+    /// A space with exactly one generation that nothing else can retire, for
+    /// callers that own a single body: fixtures, tests, and the compatibility
+    /// identity contexts that never cross a revision boundary.
+    #[must_use]
+    pub fn private() -> Self {
+        SymbolSpaceGenerations::default().next_generation()
+    }
+
+    /// Adopt an already-populated interner as a private, single-generation
+    /// space. For harnesses that lex and parse a single body and then analyze
+    /// it against the parse interner; the revision-shared space is minted by
+    /// [`SymbolSpaceGenerations`] instead.
+    #[must_use]
+    pub fn adopt(interner: Arc<ThreadedRodeo>) -> Self {
+        Self {
+            interner,
+            generation: 1,
+            live: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
+    /// The shared interner. Handles resolved through it are valid for every
+    /// body of this generation.
+    #[must_use]
+    pub fn interner(&self) -> &Arc<ThreadedRodeo> {
+        &self.interner
+    }
+
+    /// Whether this generation is still current. A retired space fails closed
+    /// at the authority check.
+    #[must_use]
+    pub fn is_live(&self) -> bool {
+        self.live.load(Ordering::Acquire)
+    }
+
+    /// Retire this generation for every holder of it.
+    ///
+    /// Called by the owner when the revision it belongs to stops being served.
+    /// Retirement is one-way: a generation is never revived, because a body
+    /// that observed it as retired has already been abandoned.
+    pub fn supersede(&self) {
+        self.live.store(false, Ordering::Release);
+    }
+
+    /// The generation ordinal, for diagnostics only. It counts mints within one
+    /// owner; it is never a symbol value and never an emitted datum.
+    #[must_use]
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+}
+
+/// The mint for [`SharedSymbolSpace`] generations.
+///
+/// Minting does not retire anything: an owner serving several revisions at once
+/// keeps a generation per revision and retires each one explicitly when it stops
+/// serving that revision. Retiring on every mint would let two concurrently
+/// pinned revisions retire each other's space and abandon each other's bodies
+/// indefinitely.
+#[derive(Debug, Default)]
+pub struct SymbolSpaceGenerations {
+    minted: AtomicU64,
+}
+
+impl SymbolSpaceGenerations {
+    /// Mint a fresh append-only interner as the next generation.
+    #[must_use]
+    pub fn next_generation(&self) -> SharedSymbolSpace {
+        SharedSymbolSpace {
+            interner: Arc::new(ThreadedRodeo::new()),
+            generation: self.minted.fetch_add(1, Ordering::AcqRel).wrapping_add(1),
+            live: Arc::new(AtomicBool::new(true)),
+        }
     }
 }
 
@@ -75,7 +185,7 @@ impl From<SymbolHandle> for Spur {
 
 #[cfg(test)]
 mod tests {
-    use super::SymbolHandle;
+    use super::{SharedSymbolSpace, SymbolHandle, SymbolSpaceGenerations};
 
     /// The contract is the *absence* of ordering, which no runtime assertion can
     /// observe. This test states it as a trait-bound witness instead: a handle
@@ -92,5 +202,59 @@ mod tests {
         assert_ne!(first, second);
         assert_eq!(first, SymbolHandle::new(interner.get_or_intern("alpha")));
         assert_eq!(interner.resolve(&first.spur()), "alpha");
+    }
+
+    /// The equality space is shared: two bodies of one generation see the same
+    /// handle for the same string, which is the redundancy ADR-0076 removes.
+    #[test]
+    fn one_generation_interns_a_string_once() {
+        let generations = SymbolSpaceGenerations::default();
+        let space = generations.next_generation();
+        let first_body = space.clone();
+        let second_body = space.clone();
+        assert_eq!(
+            first_body
+                .interner()
+                .get_or_intern("__anon_struct_00.member"),
+            second_body
+                .interner()
+                .get_or_intern("__anon_struct_00.member"),
+        );
+        assert_eq!(space.interner().len(), 1);
+    }
+
+    /// Retiring a generation retires every outstanding holder of it at once
+    /// (ADR-0076 §4): the superseded space is not live, so the authority check
+    /// that consults it fails closed. Minting a peer generation does not retire
+    /// anything, so an owner may serve two revisions at once.
+    #[test]
+    fn a_superseded_generation_is_not_live() {
+        let generations = SymbolSpaceGenerations::default();
+        let first = generations.next_generation();
+        let holder = first.clone();
+        let second = generations.next_generation();
+        assert!(first.is_live(), "a peer mint does not retire a generation");
+        assert!(second.is_live());
+        assert_ne!(first.generation(), second.generation());
+
+        first.supersede();
+        assert!(!first.is_live());
+        assert!(!holder.is_live(), "every clone observes the retirement");
+        assert!(second.is_live());
+        assert_eq!(
+            holder.interner().len(),
+            0,
+            "a retired space still resolves the handles it issued"
+        );
+    }
+
+    /// A private space has no owner that could retire it.
+    #[test]
+    fn a_private_space_stays_live() {
+        let space = SharedSymbolSpace::private();
+        assert!(space.is_live());
+        let peer = SharedSymbolSpace::private();
+        assert!(space.is_live());
+        assert!(peer.is_live());
     }
 }

--- a/docs/designs/0076-shared-revision-symbol-space.md
+++ b/docs/designs/0076-shared-revision-symbol-space.md
@@ -78,10 +78,18 @@ revision:
    land — there is no counter-rebaseline escape hatch here, unlike
    ADR-0074/0075 where the artifact itself was redefined.
 4. **Invalidation.** The shared interner is append-only within its
-   revision generation and dropped whole when the generation is
-   superseded. Bodies never observe removal or mutation of an entry. A
-   body analyzed against a superseded generation fails the authority
-   check below and re-runs — fail-closed, never silently reused.
+   revision generation. Bodies never observe removal or mutation of an
+   entry. A body analyzed against a superseded generation fails the
+   authority check below and re-runs — fail-closed, never silently
+   reused. *Amended after Phase 2*: a generation is retired when its
+   revision stops being served, not the instant a successor is minted —
+   retiring on mint would let two concurrently pinned revisions retire
+   each other's spaces and abandon each other's bodies without progress
+   (the implementation keeps a small window of recent generations live
+   and retires on eviction). A retired space's interner remains
+   allocated as long as any holder could still resolve handles it
+   issued: refusal via the authority check, never a dangling handle, is
+   the fail-closed behavior.
 5. **`require_rir_authority`.** Its pointer-equality assertion (a body's
    analysis-state interner must be the body RIR's interner) survives with
    the revision interner as the shared referent: both sides hold the same
@@ -100,11 +108,18 @@ revision:
 
 ## What this buys
 
-Up to ~213M instructions of redundant interning plus the formatting that
-feeds it — roughly **2.9–3.3% of a cold Lattice build**, concentrated in
-the semantic phase that is 45% of Lattice's wall time. chain-shaped
-programs (closure ≈ 5 types) see approximately nothing, which is the
-expected shape: this is a closure-size-scaled cost.
+*As corrected by the Phase 2 measurements.* The reachable term is the
+**insertion half** of interning only: sharing converts insertions into
+lookups, it does not remove calls, and a lookup still needs the rendered
+string, so the formatting that feeds the interner is untouched (it
+remains a separate ~0.4% target per the measurement note). Measured
+Phase 2 result: **−2.84%** of all instructions on a cold Lattice build
+(`try_get_or_intern` inclusive cost 675 → 402 instructions/call at an
+unchanged 597,760 calls), −2.49% on Mosaic. Chain-shaped programs also
+gain (−1.26% on chain256) from the deleted per-body interner lifecycle —
+a fixed per-body cost the original closure-size argument did not model —
+so the chain fixture is a control for closure-scaled interning only, not
+a no-op shape for this ADR.
 
 ## Falsifiers
 
@@ -122,9 +137,12 @@ expected shape: this is a closure-size-scaled cost.
   re-runs against the current generation.
 - **Concurrency**: `-j4` stress run with deterministic-output comparison
   across ≥3 runs (scheduling-varied `Spur` assignment must be invisible).
-- **Retention**: peak RSS on Lattice within ±2% (one interner holding
-  the union of body symbols replaces 1,263 holding overlapping subsets —
-  expected to drop, measured not assumed).
+- **Retention**: peak RSS within ±2% on the reference workloads. *Bound
+  corrected after Phase 2*: the original "expected to drop" prediction
+  was wrong in shape — the per-body interners were transient and freed
+  as bodies completed, never all resident, while the shared space is
+  resident for the whole revision. The honest bound is "does not rise
+  materially"; measured: Lattice +0.17%, Mosaic +1.35%, chain256 +0.01%.
 - **Dense-space integrity** (added with the dual-space amendment): the
   packed-RIR dense-ordinal assertion (`canonical_lower.rs:386`) holds
   unchanged under sharing, and a test proves a body's packed RIR round-

--- a/docs/designs/0076-shared-revision-symbol-space.md
+++ b/docs/designs/0076-shared-revision-symbol-space.md
@@ -157,3 +157,60 @@ state and body RIR; update `require_rir_authority`. Phase 3: falsifier
 tests and the retention measurement. Each phase lands with the full
 byte-identity gate; Phase 1 is independently valuable (it removes latent
 scheduling-sensitivity) even if Phase 2 stalls.
+
+## Phase 2 as implemented
+
+`rue_rir::SharedSymbolSpace` is one append-only `ThreadedRodeo` branded
+with the generation that minted it and carrying a liveness cell every
+clone observes, so retiring a generation refuses every holder of it at
+once. `RevisionSymbolSpace` in the compiler holds one generation per
+semantic revision, and every body of that revision decodes its RIR into,
+and analyzes against, that one interner.
+
+Two deviations from the amended text, both narrowing:
+
+1. **The dense space is a remap, not a second interner.** The body no
+   longer rebuilds a private `ThreadedRodeo` from the packed symbol
+   section. It builds a `Vec<Spur>` from ordinal to shared handle and
+   decodes through `PackedValidatedRir::try_decode_validated_remapped`.
+   The density invariant is unchanged in content — the entry a spelling
+   lands at is the ordinal the envelope encodes it as — and §1's "the
+   dense space holds the body's remap only, not re-interned strings" is
+   what forced this reading.
+2. **The AIR comptime-argument word is not re-densified.** It names the
+   shared handle and round-trips inside one body's own AIR against the
+   interner that issued it; nothing else reads it, and both of its arms
+   remain unreachable. `SymbolHandle::body_local_ordinal` was renamed
+   `issuing_interner_ordinal` because "body-local" stopped being true.
+
+Fail-closed: the body transaction abandons its attempt when the space it
+materialized against is no longer live, which re-runs the body against
+the current generation. `require_rir_authority` is pointer identity
+against that generation's interner *and* its liveness. The owner keeps
+the four most recent revisions' generations live rather than retiring on
+every mint, because two concurrently pinned revisions retiring each
+other's space would abandon each other's bodies without progressing.
+
+Measured, release build, callgrind on the parent commit versus this one:
+Lattice 7,043,253,465 to 6,843,146,953 retired instructions (-200,106,512,
+-2.84%), Mosaic -72,481,991 (-2.49%), chain256 -7,145,295 (-1.26%).
+`try_get_or_intern` is called exactly as often as before — 597,760 times
+on Lattice — but its inclusive cost falls from 403,945,189 to 240,366,124
+instructions, 675 to 402 per call, because sharing converts insertions
+into lookups rather than removing calls. That is the whole realized
+saving; the formatting that feeds the interner is unchanged, because a
+lookup still needs the rendered string. chain256's -1.26% is larger than
+the "approximately nothing" this ADR predicted: it comes from deleting
+the per-body interner construction, population, and drop, a fixed
+per-body cost the closure-size argument did not cover.
+
+Retention did not fall. Peak RSS over twelve interleaved pairs:
+Lattice +0.17% (MAD 0.10%), Mosaic +1.35% (MAD 0.06%), chain256 +0.01%
+(MAD 0.06%). The falsifier's ±2% holds, but its expectation — that one
+union interner would be smaller than 1,263 overlapping ones — was wrong
+in shape: the per-body interners were transient and freed as bodies
+completed, so they were never all resident at once, while the shared one
+is resident for the whole revision. Wall clock is not quoted: twelve
+interleaved pairs give paired medians between -26% and +15% with MADs of
+5-15% on this host, which is the same noise floor the measurement note
+recorded.

--- a/docs/notes/adr-0076-symbol-handle-ordered-use-audit.md
+++ b/docs/notes/adr-0076-symbol-handle-ordered-use-audit.md
@@ -31,7 +31,7 @@ Three findings, in descending order of how much they change the plan.
    ordinals*, by an invariant the compiler asserts. A revision-shared interner
    breaks that equality by construction, so Phase 2 needs a body-local remap
    that ADR-0076 does not currently mention. This is stated in full under
-   [What Phase 2 still owes](#what-phase-2-still-owes).
+   [What Phase 2 still owed, and what it did](#what-phase-2-still-owed-and-what-it-did).
 
 ## How the inventory was taken
 
@@ -96,7 +96,7 @@ action; these are exactly what an equality-only handle is for.
 | Site | What the value becomes | Classification and action |
 | --- | --- | --- |
 | `crates/rue-air/src/specialize.rs` `mangle_const_value` | `vfn{index}` / `vstr{index}` fragments of a specialized function's mangled name — which is interned and becomes a **link-time symbol** | **Converted.** Both arms now spell the symbol's text, and `mangle_specialized_name` takes the interner for that purpose. Behavior-preserving because neither arm is reachable: a callable alias is refused as a comptime argument by `validate_comptime_value_for_type_impl`, and no comptime parameter has a string type (RUE-957), which the AIR encoder also asserts. This is the one site where a handle's number could have reached an emitted artifact, and the conversion removes the possibility rather than the (absent) symptom. |
-| `crates/rue-air/src/inst.rs:895` (AIR comptime-argument encoder) | One `u32` word per `ConstValue::Function` argument in the AIR payload | **(c), structural; deferred to Phase 2 with its contract stated in source.** The word is legitimate exactly because the body's interner is dense: it is the body RIR's interner, and `materialize_candidate_rir` builds it by interning the packed symbol section in order. The call now reads `SymbolHandle::body_local_ordinal` and says which dense space it means. A shared interner invalidates the premise; see below. |
+| `crates/rue-air/src/inst.rs:895` (AIR comptime-argument encoder) | One `u32` word per `ConstValue::Function` argument in the AIR payload | **(c), structural; deferred to Phase 2 with its contract stated in source.** The word is legitimate exactly because the body's interner is dense: it is the body RIR's interner, and `materialize_candidate_rir` builds it by interning the packed symbol section in order. The call now reads `SymbolHandle::issuing_interner_ordinal` and says which interner it means. Phase 2 moved the analysis interner into the revision-shared equality space, so this word is no longer a dense ordinal; it stayed sound because it round-trips inside one body's own AIR against the interner that issued it, and the arm is unreachable. |
 | `crates/rue-rir/src/inst.rs:2749`, `:3582`, `:3607`, `:4435`, `:4574`, `:4577`, `:4584`, `:4636`, `:4677`, `:4830` and `crates/rue-rir/src/inst/packed.rs:606`, `:653`, `:746`, `:801` | The packed RIR symbol section: a handle **is** its ordinal in a dense per-body table, written as a `u32` word and validated against `symbol_count` | **(c), structural; the blocking Phase 2 item.** Not convertible — the encoding is the dense space. See below. |
 | `crates/rue-compiler/src/canonical_lower.rs:386` | Asserts `symbol.into_usize() == ordinal` while rebuilding a body's interner from the packed symbol section | **(c), structural.** This is the invariant the two rows above depend on, stated as a runtime check. It is also the exact assertion a shared interner fails. |
 | `crates/rue-compiler/src/revisioned_query_database.rs:6697`, `:6714`, `:6735`, `:6758`, `:6773`, `:6851` | Indexes a `&[&str]` dense candidate symbol view by handle ordinal | **(c), structural**, and the same dense space: `materialize_semantic_candidate_rir` returns the packed symbol section as a `Vec<&str>` whose positions are the ordinals. Safe as long as the packed space stays body-local. |
@@ -112,8 +112,10 @@ a `Spur` and deliberately offers less than one: no `Ord`/`PartialOrd`, so it
 cannot be a sort key, a `BTreeMap`/`BTreeSet` key, or an operand of a
 comparison; and no `lasso::Key` implementation, so `into_usize()` is not in
 scope on it. The only way to a handle's number is
-`SymbolHandle::body_local_ordinal`, whose name says what a caller has to be able
-to justify and whose doc comment says it.
+`SymbolHandle::issuing_interner_ordinal`, whose name says what a caller has to
+be able to justify and whose doc comment says it. (Phase 1 spelled it
+`body_local_ordinal`; Phase 2 renamed it when the analysis interner stopped
+being body-local.)
 
 The migrated surface is `ConstValue::Function` and `ConstValue::String`, the two
 symbol payloads that carry a handle out of body analysis into the two places
@@ -132,7 +134,7 @@ value is what the two migrated payloads carry.
 ### What is not migrated
 
 - The RIR/packed layer (`rue-rir`), where handles are dense ordinals on purpose.
-  Migrating it would mean spelling `body_local_ordinal` at every encode and
+  Migrating it would mean spelling `issuing_interner_ordinal` at every encode and
   decode, which is noise around a contract that is already this note's headline
   Phase 2 item.
 - The body-analysis maps (`AHashMap<Spur, …>` and friends). They are class (a)
@@ -140,10 +142,35 @@ value is what the two migrated payloads carry.
 - `rue-parser` and `rue-lexer`, whose interners are per-file parse interners
   that ADR-0076 does not share.
 
-## What Phase 2 still owes
+## What Phase 2 still owed, and what it did
 
-Flagged for the consensus round: ADR-0076's implementation shape does not
-mention any of this, and Phase 2 cannot land without it.
+Phase 2 has since landed. Each item below is resolved as described; the
+statements are kept because they are the reasoning the implementation had to
+answer, not a to-do list.
+
+- **The dense table.** Resolved by keeping the packed envelope's dense ordinal
+  space exactly as it was and adding a *body dense remap* — ordinal to shared
+  handle, one `Vec<Spur>` per materialization — consumed by a new
+  `PackedValidatedRir::try_decode_validated_remapped`. The density check moved
+  from "the rebuilt interner issues handle *n* for ordinal *n*" to "the remap
+  entry a spelling lands at is the ordinal the envelope encodes it as", which is
+  the same statement about the same space. The per-body `ThreadedRodeo` rebuild
+  is gone rather than kept alongside the remap: re-interning the section into a
+  private table is exactly the "re-interned strings" ADR-0076 §1 says the dense
+  space must not hold, and keeping it would have spent part of the saving to
+  assert a property the remap already carries.
+- **`Rc` to `Arc`.** Done for the interner ownership chain only
+  (`BodyIdentityPool::interner`, `ProviderIdentityContext::interner`,
+  `ProviderBodyAnalysisState::interner`, `BodyRirBundle`, and the three
+  `Provider*Body` result structs). The body type pool stays `Rc`: ADR-0076 does
+  not share it, and it never crosses a worker thread.
+- **The dead mangler arms** are unchanged and still unreachable.
+
+## What Phase 2 owed (as written before implementation)
+
+Flagged for the consensus round: ADR-0076's implementation shape did not
+mention any of this, and Phase 2 could not land without it. The amendment and
+the implementation both answer it; the section above records how.
 
 **The body's interner is a dense table and the compiler depends on it.**
 `materialize_candidate_rir_internal` builds each body's `ThreadedRodeo` by


### PR DESCRIPTION
Implements Phase 2 of ADR-0076 (#2477, as amended by #2482), plus a second commit truing the ADR against what the implementation measured. 12 files, +757/−148 for the implementation.

## The dual-space wiring

- **Shared equality space**: `RevisionSymbolSpace` hands out one `Arc<ThreadedRodeo>` per semantic revision (small live window, retired on eviction — see below); `BodyRirBundle` and `ProviderBodyAnalysisState` are seeded from the same space, so body-identity interning and RIR symbol resolution share one revision-wide interner instead of 1,263 per-body ones.
- **Body-private dense space**: the packed envelope is untouched on the wire — a symbol *is* its dense ordinal. `materialize_candidate_rir_internal` validates each spelling against the ordinal the envelope encodes (the `canonical_lower.rs:386` invariant survives as the same statement about the same space) and builds a compact `Vec<Spur>` remap into the shared space; `try_decode_validated_remapped` decodes through it. The declaration-time semantic-candidate path keeps its identity remap unchanged.
- **Authority**: the `Rc`→`Arc` conversion budgeted by the amendment; `require_rir_authority` is now liveness + pointer identity over the shared `Arc`, and a body whose generation was retired aborts and re-runs — fail-closed, with a falsifier proving refusal and successful re-run.

Two recorded deviations from the amendment's letter, both argued in the ADR text: the dense space is the remap itself rather than a second interner (keeping one would re-spend the saving to assert a property the remap already carries), and the AIR comptime-argument word names the shared handle (round-trips only within one body's own AIR; both arms remain unreachable).

## Gates (all held — byte identity was the no-escape premise)

- Executables byte-identical before/after on Lattice, Mosaic, chain256 at `-j1` and `-j4` — Lattice/Mosaic digests match the Phase 1 audit exactly; Lattice re-verified independently on this branch post-rebase (`b893e76c…85e5`).
- Counters (658/424/946 fields per shape): `-j1` zero masked, zero differences; `-j4` zero differences under the known work-stealing mask, verified at 8 runs per tree (16 `-j4` runs per shape) after a 2-run comparison produced one spurious under-sampled difference — the mask is confirmed self-varying on the parent commit.
- Falsifiers landed: dense-space integrity (shared-space decode renders identically AND dense decode repacks to original bytes; out-of-remap ordinal fails), one-generation-per-revision, shared-space-across-bodies, superseded-not-live, authority refusal + re-run, intern-once.
- Suites: rue-rir 124, rue-air 652 (both re-run on this branch), compiler 892, driver 42, quick 30 (re-run), UI 250, CLI 1,892; fmt/clippy/ADR/doc-links validators green.

## Measured payoff, honestly attributed

| shape | retired instructions |
|---|---|
| Lattice | **−200.1M (−2.84%)** |
| Mosaic | −72.5M (−2.49%) |
| chain256 | −7.1M (−1.26%) |

`try_get_or_intern` is called exactly as often as before (597,760) — sharing converts insertions into lookups (675 → 402 instructions/call); the formatting that feeds lookups is *not* removed and remains a separate ~0.4% target. chain256's gain comes from the deleted per-body interner lifecycle, a fixed cost the closure-size argument didn't model. Peak RSS: Lattice +0.17%, Mosaic +1.35%, chain256 +0.01% — inside the ±2% gate, with the ADR's "expected to drop" prediction corrected (per-body interners were transient, never all resident). Wall clock unusable on this host (paired MADs 5–15%).

## Second commit: ADR trued against the measurements

Retirement is on eviction from the served-revision window, not on successor mint (retire-on-mint would let two concurrently pinned revisions abandon each other's bodies); the retention falsifier's bound becomes "does not rise materially" with the measured numbers; "What this buys" now states the reachable insertion-half saving and the chain fixture's corrected control role.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTiBg7df72iMgdpAFv5wZs)_