### PR TITLE
RUE-1472: avoid physical operand verifier allocations

### DIFF
--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -1364,10 +1364,16 @@ impl RegAllocBackend for Aarch64Backend {
         })
     }
 
-    fn physical_operands(inst: &Self::Inst) -> Vec<Self::Reg> {
-        let mut regs: Vec<_> = super::schedule::regs_read(inst).into();
-        regs.extend(super::schedule::regs_written(inst));
-        regs
+    fn for_each_physical_operand<F>(inst: &Self::Inst, mut visit: F)
+    where
+        F: FnMut(Self::Reg),
+    {
+        for reg in super::schedule::regs_read(inst) {
+            visit(reg);
+        }
+        for reg in super::schedule::regs_written(inst) {
+            visit(reg);
+        }
     }
 
     fn new_mir() -> Self::Mir {
@@ -1430,6 +1436,20 @@ mod tests {
         );
         assert_eq!(file.len(), ALLOCATABLE_REGS.len());
         assert_eq!(file.caller_saved_flattened(), CALLER_SAVED_REGS.to_vec());
+    }
+
+    #[test]
+    fn physical_operand_visitor_preserves_read_then_write_order() {
+        let inst = Aarch64Inst::AddRR {
+            dst: Operand::Physical(Reg::X2),
+            src1: Operand::Physical(Reg::X0),
+            src2: Operand::Physical(Reg::X1),
+        };
+        let mut observed = Vec::new();
+        <Aarch64Backend as RegAllocBackend>::for_each_physical_operand(&inst, |reg| {
+            observed.push(reg);
+        });
+        assert_eq!(observed, [Reg::X0, Reg::X1, Reg::X2]);
     }
 
     #[test]

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -1268,7 +1268,8 @@ pub trait RegAllocBackend {
     /// own register class (RUE-1067).
     fn register_file() -> RegisterFile<'static, Self::Reg>;
 
-    /// Every physical register `inst` names as an operand — read or written.
+    /// Visit every physical register `inst` names as an operand — read or
+    /// written — in the backend's canonical read-then-write order.
     ///
     /// This is the exhaustive per-instruction enumeration each backend's
     /// scheduler already maintains (`regs_read` + `regs_written`), reused here
@@ -1276,7 +1277,9 @@ pub trait RegAllocBackend {
     /// an allocatable register directly. Implicit clobbers are deliberately not
     /// included: a call destroys the caller-saved registers without naming any
     /// of them as an operand, and the allocator models that separately.
-    fn physical_operands(inst: &Self::Inst) -> Vec<Self::Reg>;
+    fn for_each_physical_operand<F>(inst: &Self::Inst, visit: F)
+    where
+        F: FnMut(Self::Reg);
 
     fn new_mir() -> Self::Mir;
     fn take_symbols(mir: &mut Self::Mir) -> Vec<String>;
@@ -1439,7 +1442,7 @@ impl<I> RewriteBuffer<I> {
 fn assert_no_allocatable_physical_operands<B: RegAllocBackend>(mir: &B::Mir) {
     let file = B::register_file();
     for inst in B::instructions(mir) {
-        for reg in B::physical_operands(inst) {
+        B::for_each_physical_operand(inst, |reg| {
             for (_, save) in file.iter() {
                 assert!(
                     !save.caller_saved.contains(&reg) && !save.callee_saved.contains(&reg),
@@ -1447,7 +1450,7 @@ fn assert_no_allocatable_physical_operands<B: RegAllocBackend>(mir: &B::Mir) {
                      allocation may put an unrelated value there"
                 );
             }
-        }
+        });
     }
 }
 

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -1429,10 +1429,16 @@ impl RegAllocBackend for X86Backend {
         })
     }
 
-    fn physical_operands(inst: &Self::Inst) -> Vec<Self::Reg> {
-        let mut regs: Vec<_> = super::schedule::regs_read(inst).into();
-        regs.extend(super::schedule::regs_written(inst));
-        regs
+    fn for_each_physical_operand<F>(inst: &Self::Inst, mut visit: F)
+    where
+        F: FnMut(Self::Reg),
+    {
+        for reg in super::schedule::regs_read(inst) {
+            visit(reg);
+        }
+        for reg in super::schedule::regs_written(inst) {
+            visit(reg);
+        }
     }
 
     fn new_mir() -> Self::Mir {
@@ -1495,6 +1501,19 @@ mod tests {
         );
         assert_eq!(file.len(), ALLOCATABLE_REGS.len());
         assert_eq!(file.caller_saved_flattened(), CALLER_SAVED_REGS.to_vec());
+    }
+
+    #[test]
+    fn physical_operand_visitor_preserves_read_then_write_order() {
+        let inst = X86Inst::AddRR {
+            dst: Operand::Physical(Reg::Rax),
+            src: Operand::Physical(Reg::Rcx),
+        };
+        let mut observed = Vec::new();
+        <X86Backend as RegAllocBackend>::for_each_physical_operand(&inst, |reg| {
+            observed.push(reg);
+        });
+        assert_eq!(observed, [Reg::Rax, Reg::Rcx, Reg::Rax]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep Rue's always-on pre-allocation physical-register verifier
- replace its per-instruction `Vec` materialization with an order-preserving visitor
- preserve read-then-write operand order on x86-64 and AArch64

## Evidence

Temporary exact-trunk instrumentation attributed **49.029 ms** across 1,280 allocator invocations to this verifier. It inspects 246,467 MIR instructions, and the old backend contract converted every instruction's physical operands into a temporary heap vector.

Fresh-process, one-worker, `-O3` Lattice on exact trunk `7f2ce3c7c`, 8 alternating pairs:

- retired instructions: **-0.2813% median**, 8/8 wins, 0.0308% paired MAD
- cycles: **-0.5827% median**, 7/8 wins
- process wall: **-1.3825% median**, 7/8 wins
- RSS: -3.4215% median; peak footprint: -3.6913% median (both bimodal/noisy, 5/8 wins)

This clears the primary retired-instruction falsifier without adding retained state.

## Correctness

- the verifier remains always-on and preserves its early panic text/location
- implicit clobbers remain excluded
- x86-64 and AArch64 visitor-order and malformed-lowering tests pass
- emitted executable SHA-256 remains `b893e76cfabed737b149d0e8c4d8527077dedd17da78418db20a28a7d30885e5`
- stable benchmark JSON sections are exact
- full x86-64 `--emit regalloc` output is byte-exact (SHA-256 `ace50e0a1c2ef7ee2b38d785e61931918b7daebdb56c58bda43f39a71bc2adb4`)
- full AArch64 `--emit asm` output is byte-exact (SHA-256 `cd6007dfe1749437b75548795f4c26ad914072e09baa3024471ca8a9c408bc71`)
- 728 codegen tests and 890 compiler tests passed
- builds, Clippy, formatting, and diff checks passed

Tracker: RUE-1472
