### PR TITLE
RUE-1472: reuse successor importer paths

### DIFF
--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -881,9 +881,15 @@ impl ImportDiscoveryPlan {
             let Some(module) = program.module(module_id) else {
                 continue;
             };
+            let Some(first_site) = module.imports().first() else {
+                continue;
+            };
+            // Every import site in a parsed module has the same importer. Build
+            // its normalized anchor once instead of repeating the path
+            // normalization for every site in the module.
+            let importer_path = requested_path_for_module(&context, first_site.importer())?;
             for site in module.imports() {
                 let occurrence = ImportOccurrenceKey::from_directive(site);
-                let importer_path = requested_path_for_module(&context, site.importer())?;
                 let built = discovery_groups_for_occurrence(&context, &occurrence, &importer_path)?;
                 constructed += built.len() as u64;
                 delta.extend(built);


### PR DESCRIPTION
## Summary

- normalize each newly appended module importer path once
- reuse that anchor across the module's import directives
- preserve zero-import behavior, canonical group order, diagnostics, and predecessor sharing

## Evidence

On exact trunk `b1df30c0d`, Lattice has 739 import directives across 160 importers. `ImportDiscoveryPlan::extend_successor` repeated the same pure path join/normalization per site, so this removes 579 redundant normalizations (78%) inside the 24.613 ms median `import_plan` owner.

Eight alternating fresh-process, one-worker, `-O3`, x86-64-linux pairs:

- retired instructions: **-0.1060% median**, 8/8 wins, 0.0557% paired MAD
- cycles: -0.2204% median, 5/8 wins (noisy)
- wall: -0.7692% median, 4/8 wins (10 ms timer is too coarse)
- RSS: -0.6340% median, 7/8 wins
- peak memory: -0.6712% median, 7/8 wins

The acceptance signal is deterministic work; wall/cycles are not claimed beyond noise.

## Correctness and incrementality

- 892 compiler tests passed, 6 ignored; import-discovery focused suite passed 32 tests
- compiler Clippy, repository format, and diff checks pass
- warm-session vs stepwise-fresh differential oracle passes
- executable SHA is exact: `b893e76cfabed737b149d0e8c4d8527077dedd17da78418db20a28a7d30885e5`
- AArch64 assembly SHA is exact: `cd6007dfe1749437b75548795f4c26ad914072e09baa3024471ca8a9c408bc71`
- semantic dependency topology matches after removing expected worktree filesystem identities
- all non-timing benchmark facts match byte-for-byte

RUE-1472 remains open above the 250 ms target.