### PR TITLE
[Perf/CFG] Make required-type deduplication constant-time

### DIFF
--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -1293,8 +1293,9 @@ pub(crate) fn select_materialization_facts(
     };
     selection.callable(identity);
     let mut required_types = Vec::new();
+    let mut seen_required_types = std::collections::HashSet::new();
     let mut require_type = |ty: &crate::durable_semantics::DurableType| {
-        if !required_types.contains(ty) {
+        if seen_required_types.insert(ty.clone()) {
             required_types.push(ty.clone());
         }
     };


### PR DESCRIPTION
## What changed

Use a hash set alongside the first-seen vector when collecting required durable types for local semantic materialization.

## Why

The previous `Vec::contains` membership check rescanned every previously-seen type for each instruction, place, parameter, and dependency. This preserves first-seen ordering while making duplicate detection constant-time.

## Validation

- Full `rue-compiler-test`: 892 passed, 6 ignored