### PR TITLE
[Perf/CFG] Reuse declaration and metadata indexes during local materialization

### DIFF
--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -1112,9 +1112,12 @@ fn materialize_and_build_cfg(
     context.record_work(rue_query::WorkItem::new("cfg.materialize.attempts", 1));
     let input_preparation_ns = elapsed_ns(input_preparation_started);
     let materialization_started = std::time::Instant::now();
+    // The indexed variants preserve the materialize_canonical_body(...) and
+    // materialize_semantic_body(...) adapters for direct providers while this
+    // hot path reuses the exact fact-side indexes prepared during selection.
     let materialized = match &key.semantic_input {
         CfgSemanticInput::Body { input, .. } => {
-            crate::local_semantic_materialization::materialize_canonical_body(
+            crate::local_semantic_materialization::materialize_canonical_body_with_indexes(
                 &input.canonical,
                 body_span,
                 &facts.declarations,
@@ -1124,10 +1127,11 @@ fn materialize_and_build_cfg(
                 &facts.modules,
                 &builtin_facts,
                 &facts.required_types,
+                &facts.indexes,
             )
         }
         CfgSemanticInput::DropGlue { owner, .. } => {
-            crate::local_semantic_materialization::materialize_semantic_body(
+            crate::local_semantic_materialization::materialize_semantic_body_with_indexes(
                 crate::FunctionInstanceKey::DropGlue(Box::new(owner.clone())),
                 body,
                 body_span,
@@ -1138,6 +1142,7 @@ fn materialize_and_build_cfg(
                 &facts.modules,
                 &builtin_facts,
                 &facts.required_types,
+                &facts.indexes,
             )
         }
     };

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -727,6 +727,7 @@ fn mangle_canonical_value(value: &crate::CanonicalArgumentValue) -> String {
 /// The declaration and anonymous slices may contain only the facts required by
 /// this body. Missing transitive shapes/callables fail closed in `rue-air`;
 /// this adapter never widens the request by discovering a program universe.
+#[allow(dead_code)]
 pub(crate) fn materialize_canonical_body(
     canonical: &crate::body_query::CanonicalBody,
     body_span: rue_span::Span,
@@ -1525,7 +1526,6 @@ pub(crate) fn select_materialization_facts(
         .selected_declarations
         .into_values()
         .collect::<Vec<_>>();
-    let nominal_metadata = nominal_metadata;
     Ok(LocalMaterializationFacts {
         indexes: Arc::new(LocalMaterializationIndexes::new(
             &declarations,

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -179,6 +179,99 @@ impl RetainedCharge for SharedDeclarationFactIndex {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct LocalMaterializationIndexes {
+    destructors:
+        std::collections::BTreeMap<(ModuleId, StableDefinitionKind, Arc<str>), FunctionInstanceKey>,
+    nominal_metadata: std::collections::BTreeMap<StableDefinitionKey, Option<rue_air::LangItem>>,
+    has_ambiguous_named_destructor: bool,
+    has_duplicate_nominal_metadata: bool,
+}
+
+impl LocalMaterializationIndexes {
+    pub(crate) fn new(
+        declarations: &[DurableDeclarationSemantic],
+        nominal_metadata: &[LocalNominalMetadataFact],
+    ) -> Self {
+        let mut indexes = Self::default();
+        for candidate in declarations {
+            if !matches!(candidate.payload, DurableDeclarationPayload::Destructor) {
+                continue;
+            }
+            let Some(owner) = candidate.key.owner() else {
+                continue;
+            };
+            if indexes
+                .destructors
+                .insert(
+                    (
+                        owner.module().clone(),
+                        owner.kind(),
+                        Arc::<str>::from(owner.name()),
+                    ),
+                    FunctionInstanceKey::Definition(candidate.key.clone()),
+                )
+                .is_some()
+            {
+                indexes.has_ambiguous_named_destructor = true;
+            }
+        }
+        for fact in nominal_metadata {
+            if indexes
+                .nominal_metadata
+                .insert(fact.identity().clone(), fact.lang_item())
+                .is_some()
+            {
+                indexes.has_duplicate_nominal_metadata = true;
+            }
+        }
+        indexes
+    }
+
+    fn destructor(&self, owner: &StableDefinitionKey) -> Option<FunctionInstanceKey> {
+        self.destructors
+            .get(&(
+                owner.module().clone(),
+                owner.kind(),
+                Arc::<str>::from(owner.name()),
+            ))
+            .cloned()
+    }
+
+    fn nominal_metadata(
+        &self,
+        identity: &StableDefinitionKey,
+    ) -> Option<Option<rue_air::LangItem>> {
+        self.nominal_metadata.get(identity).copied()
+    }
+}
+
+impl RetainedCharge for LocalMaterializationIndexes {
+    fn retained_charge(&self) -> u64 {
+        self.destructors
+            .values()
+            .map(RetainedCharge::retained_charge)
+            .sum::<u64>()
+            .saturating_add(
+                (self.destructors.len()
+                    * std::mem::size_of::<(
+                        (ModuleId, StableDefinitionKind, Arc<str>),
+                        FunctionInstanceKey,
+                    )>()) as u64,
+            )
+            .saturating_add(
+                self.nominal_metadata
+                    .keys()
+                    .map(RetainedCharge::retained_charge)
+                    .sum::<u64>(),
+            )
+            .saturating_add(
+                (self.nominal_metadata.len() * std::mem::size_of::<Option<rue_air::LangItem>>())
+                    as u64,
+            )
+    }
+}
+
 fn collect_slice_sources(
     ty: &crate::durable_semantics::DurableType,
     output: &mut std::collections::HashMap<Arc<str>, crate::TypeInstanceKey>,
@@ -243,6 +336,7 @@ pub(crate) struct LocalMaterializationFacts {
     /// Exact stable types that must exist in this local epoch even when they
     /// originate in an accessor body that will be mandatorily spliced here.
     pub(crate) required_types: Arc<[crate::durable_semantics::DurableType]>,
+    pub(crate) indexes: Arc<LocalMaterializationIndexes>,
 }
 
 impl LocalMaterializationFacts {
@@ -302,11 +396,17 @@ impl LocalMaterializationFacts {
                 &facts.required_types,
             );
         }
+        let declarations: Arc<[DurableDeclarationSemantic]> = declarations.into();
+        let nominal_metadata: Arc<[LocalNominalMetadataFact]> = nominal_metadata.into();
         Self {
-            declarations: declarations.into(),
+            indexes: Arc::new(LocalMaterializationIndexes::new(
+                &declarations,
+                &nominal_metadata,
+            )),
+            declarations,
             anonymous_nominals: anonymous_nominals.into(),
             callables: callables.into(),
-            nominal_metadata: nominal_metadata.into(),
+            nominal_metadata,
             modules: modules.into(),
             builtin_nominals: builtin_nominals.into(),
             required_types: required_types.into(),
@@ -359,6 +459,7 @@ impl RetainedCharge for LocalMaterializationFacts {
             .saturating_add(self.modules.retained_charge())
             .saturating_add(self.builtin_nominals.retained_charge())
             .saturating_add(self.required_types.retained_charge())
+            .saturating_add(self.indexes.retained_charge())
     }
 }
 
@@ -637,6 +738,34 @@ pub(crate) fn materialize_canonical_body(
     builtin_facts: &[LocalBuiltinNominalFact],
     materialization_types: &[crate::durable_semantics::DurableType],
 ) -> Result<LocalSemanticMaterialization, LocalMaterializationFailure> {
+    let indexes = LocalMaterializationIndexes::new(declarations, nominal_metadata);
+    materialize_canonical_body_with_indexes(
+        canonical,
+        body_span,
+        declarations,
+        anonymous_nominals,
+        callable_facts,
+        nominal_metadata,
+        modules,
+        builtin_facts,
+        materialization_types,
+        &indexes,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn materialize_canonical_body_with_indexes(
+    canonical: &crate::body_query::CanonicalBody,
+    body_span: rue_span::Span,
+    declarations: &[DurableDeclarationSemantic],
+    anonymous_nominals: &[DurableAnonymousNominal],
+    callable_facts: &[LocalCallableFact],
+    nominal_metadata: &[LocalNominalMetadataFact],
+    modules: &[ModuleId],
+    builtin_facts: &[LocalBuiltinNominalFact],
+    materialization_types: &[crate::durable_semantics::DurableType],
+    indexes: &LocalMaterializationIndexes,
+) -> Result<LocalSemanticMaterialization, LocalMaterializationFailure> {
     let (identity, body) = match canonical {
         crate::body_query::CanonicalBody::Ordinary { owner, body } => {
             (FunctionInstanceKey::Definition(owner.clone()), body)
@@ -650,7 +779,7 @@ pub(crate) fn materialize_canonical_body(
             body,
         ),
     };
-    materialize_semantic_body(
+    materialize_semantic_body_with_indexes(
         identity,
         body,
         body_span,
@@ -661,10 +790,11 @@ pub(crate) fn materialize_canonical_body(
         modules,
         builtin_facts,
         materialization_types,
+        indexes,
     )
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, dead_code)]
 pub(crate) fn materialize_semantic_body(
     identity: FunctionInstanceKey,
     body: &rue_air::SemanticBody<StableDefinitionKey, ModuleId>,
@@ -677,52 +807,48 @@ pub(crate) fn materialize_semantic_body(
     builtin_facts: &[LocalBuiltinNominalFact],
     materialization_types: &[crate::durable_semantics::DurableType],
 ) -> Result<LocalSemanticMaterialization, LocalMaterializationFailure> {
+    let indexes = LocalMaterializationIndexes::new(declarations, nominal_metadata);
+    materialize_semantic_body_with_indexes(
+        identity,
+        body,
+        body_span,
+        declarations,
+        anonymous_nominals,
+        callable_facts,
+        nominal_metadata,
+        modules,
+        builtin_facts,
+        materialization_types,
+        &indexes,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn materialize_semantic_body_with_indexes(
+    identity: FunctionInstanceKey,
+    body: &rue_air::SemanticBody<StableDefinitionKey, ModuleId>,
+    body_span: rue_span::Span,
+    declarations: &[DurableDeclarationSemantic],
+    anonymous_nominals: &[DurableAnonymousNominal],
+    callable_facts: &[LocalCallableFact],
+    _nominal_metadata: &[LocalNominalMetadataFact],
+    modules: &[ModuleId],
+    builtin_facts: &[LocalBuiltinNominalFact],
+    materialization_types: &[crate::durable_semantics::DurableType],
+    indexes: &LocalMaterializationIndexes,
+) -> Result<LocalSemanticMaterialization, LocalMaterializationFailure> {
     let callable_kind = if body.is_accessor {
         rue_air::AnalyzedCallableKind::Accessor
     } else {
         callable_kind_for_identity(&identity)
     };
 
-    let mut destructors = std::collections::BTreeMap::new();
-    for candidate in declarations {
-        if !matches!(candidate.payload, DurableDeclarationPayload::Destructor) {
-            continue;
-        }
-        let Some(owner) = candidate.key.owner() else {
-            continue;
-        };
-        let owner = (
-            owner.module().clone(),
-            owner.kind(),
-            Arc::<str>::from(owner.name()),
-        );
-        if destructors
-            .insert(
-                owner,
-                FunctionInstanceKey::Definition(candidate.key.clone()),
-            )
-            .is_some()
-        {
-            return Err(LocalMaterializationFailure::AmbiguousNamedDestructor);
-        }
+    if indexes.has_ambiguous_named_destructor {
+        return Err(LocalMaterializationFailure::AmbiguousNamedDestructor);
     }
-    let destructor_for = |owner: &StableDefinitionKey| {
-        destructors
-            .get(&(
-                owner.module().clone(),
-                owner.kind(),
-                Arc::<str>::from(owner.name()),
-            ))
-            .cloned()
-    };
-    let mut metadata = std::collections::BTreeMap::new();
-    for fact in nominal_metadata {
-        if metadata
-            .insert(fact.identity().clone(), fact.lang_item())
-            .is_some()
-        {
-            return Err(LocalMaterializationFailure::DuplicateNominalMetadata);
-        }
+    let destructor_for = |owner: &StableDefinitionKey| indexes.destructor(owner);
+    if indexes.has_duplicate_nominal_metadata {
+        return Err(LocalMaterializationFailure::DuplicateNominalMetadata);
     }
     let mut nominals = Vec::new();
     for declaration in declarations {
@@ -748,8 +874,8 @@ pub(crate) fn materialize_semantic_body(
             ),
             _ => continue,
         };
-        let lang_item = metadata
-            .remove(&declaration.key)
+        let lang_item = indexes
+            .nominal_metadata(&declaration.key)
             .ok_or(LocalMaterializationFailure::MissingNominalMetadata)?;
         nominals.push(rue_air::SemanticLocalNominal {
             key: rue_air::NominalInstanceKey::Named(declaration.key.clone()),
@@ -761,7 +887,16 @@ pub(crate) fn materialize_semantic_body(
             shape,
         });
     }
-    if !metadata.is_empty() {
+    let named_nominal_count = declarations
+        .iter()
+        .filter(|declaration| {
+            matches!(
+                declaration.payload,
+                DurableDeclarationPayload::Struct { .. } | DurableDeclarationPayload::Enum { .. }
+            )
+        })
+        .count();
+    if indexes.nominal_metadata.len() != named_nominal_count {
         return Err(LocalMaterializationFailure::ExtraNominalMetadata);
     }
     nominals.extend(anonymous_nominals.iter().map(|nominal| {
@@ -1386,12 +1521,17 @@ pub(crate) fn select_materialization_facts(
             LocalNominalMetadataFact::new(declaration.key.clone(), lang_item)
         })
         .collect::<Vec<_>>();
+    let declarations = selection
+        .selected_declarations
+        .into_values()
+        .collect::<Vec<_>>();
+    let nominal_metadata = nominal_metadata;
     Ok(LocalMaterializationFacts {
-        declarations: selection
-            .selected_declarations
-            .into_values()
-            .collect::<Vec<_>>()
-            .into(),
+        indexes: Arc::new(LocalMaterializationIndexes::new(
+            &declarations,
+            &nominal_metadata,
+        )),
+        declarations: declarations.into(),
         anonymous_nominals: selection
             .selected_anonymous
             .into_values()
@@ -1452,6 +1592,7 @@ mod tests {
             modules: modules.into(),
             builtin_nominals: Arc::new([]),
             required_types: Arc::new([]),
+            indexes: Arc::new(LocalMaterializationIndexes::default()),
         }
     }
 

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -38679,6 +38679,9 @@ fn main() -> i32 {
                 modules: Arc::from([owner.module().clone()]),
                 builtin_nominals: Arc::from([]),
                 required_types: Arc::from([]),
+                indexes: Arc::new(
+                    crate::local_semantic_materialization::LocalMaterializationIndexes::default(),
+                ),
             };
             let body_span = rue_span::Span::with_file(
                 input.source.file_id,


### PR DESCRIPTION
## What changed

Prepare exact local destructor and nominal-metadata indexes with the selected materialization facts and reuse them during CFG materialization.

## Why

Local materialization rebuilt these lookup maps by scanning the selected facts for every body. The indexed hot path preserves duplicate, missing, and extra-fact validation while avoiding that repeated map construction. Direct providers retain the existing wrapper APIs.

## Validation

- Full `rue-compiler-test`: 892 passed, 6 ignored