### PR TITLE
Avoid redundant one-worker query key clones

### DIFF
--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -1554,7 +1554,7 @@ pub(crate) fn evaluate_optimized_cfg(
     let mut implicit_destructor_dependencies_complete =
         record.implicit_destructor_dependencies_complete;
     let accessor_terminals =
-        context.query_registered_adaptive_batch(cfgs, key.accessor_dependencies.iter().cloned())?;
+        context.query_registered_adaptive_batch_refs(cfgs, key.accessor_dependencies.iter())?;
     let mut accessor_cfgs = std::collections::BTreeMap::new();
     for (dependency, terminal) in key.accessor_dependencies.iter().zip(accessor_terminals) {
         let QueryOutcome::Success(value) = terminal.outcome() else {

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -14185,9 +14185,9 @@ impl RevisionedQueryDatabase {
                         "compiler.cfg",
                         "compiler.optimized-cfg",
                     ]);
-                    let terminals = context.query_registered_adaptive_batch(
+                    let terminals = context.query_registered_adaptive_batch_refs(
                         &optimized_cfgs_for_batch,
-                        key.keys.iter().cloned(),
+                        key.keys.iter(),
                     )?;
                     let kind = if terminals
                         .iter()
@@ -14291,9 +14291,9 @@ impl RevisionedQueryDatabase {
                         .endorse_registered_validations_from(&fallbacks)
                         .expect("backend retention roots belong to this query runtime");
                     let _attempts = context.retain_nested_attempts_for(&["compiler.codegen-unit"]);
-                    let terminals = context.query_registered_adaptive_batch(
+                    let terminals = context.query_registered_adaptive_batch_refs(
                         &codegen_units_for_batch,
-                        key.keys.iter().cloned(),
+                        key.keys.iter(),
                     )?;
                     let kind = if terminals
                         .iter()
@@ -14370,9 +14370,9 @@ impl RevisionedQueryDatabase {
                         .expect("backend retention roots belong to this query runtime");
                     let _attempts =
                         context.retain_nested_attempts_for(&["compiler.object-projection"]);
-                    let terminals = context.query_registered_adaptive_batch(
+                    let terminals = context.query_registered_adaptive_batch_refs(
                         &object_projections_for_batch,
-                        key.keys.iter().cloned(),
+                        key.keys.iter(),
                     )?;
                     let kind = if terminals
                         .iter()
@@ -14427,9 +14427,9 @@ impl RevisionedQueryDatabase {
                     let _validated_registered = context
                         .endorse_registered_validations_from(&fallbacks)
                         .expect("backend retention roots belong to this query runtime");
-                    let terminals = context.query_registered_adaptive_batch(
+                    let terminals = context.query_registered_adaptive_batch_refs(
                         &object_projections_for_backend_publication,
-                        key.objects.keys.iter().cloned(),
+                        key.objects.keys.iter(),
                     )?;
                     if terminals.iter().any(|terminal| {
                         matches!(

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -8382,6 +8382,38 @@ impl QueryContext {
         result.into_result()
     }
 
+    fn query_registered_ref<K, V>(
+        &self,
+        family: &QueryFamily<K, V>,
+        key: &K,
+    ) -> Result<Arc<QueryTerminal<V>>, QueryAbort>
+    where
+        K: QueryKey,
+        V: Clone + Send + Sync + 'static,
+    {
+        assert!(
+            family.inner.evaluator.is_some(),
+            "closure-free dependency requests require a registered evaluator"
+        );
+        let request_id = self.task.next_nested_request();
+        let result = if Arc::ptr_eq(&self.task_runtime(), &family.core) {
+            family.query_task_registered(self.task.clone(), key.clone(), request_id)
+        } else {
+            TaskQueryResult::Aborted {
+                abort: QueryAbort::ForeignRuntime,
+                dependencies: Vec::new(),
+                inputs: Vec::new(),
+                work: Vec::new(),
+            }
+        };
+        self.task.record_nested(
+            request_id,
+            move || NodeIdentity::from_key(family.inner.name.clone(), key),
+            &result,
+        );
+        result.into_result()
+    }
+
     /// Requests stable-ordered registered dependencies with concurrency-aware
     /// scheduling.
     ///
@@ -8409,7 +8441,7 @@ impl QueryContext {
         if self.max_concurrency() == 1 {
             return keys
                 .into_iter()
-                .map(|key| self.query_registered(family, key))
+                .map(|key| self.query_registered_ref(family, &key))
                 .collect();
         }
         let keys = keys.into_iter().collect::<Vec<_>>();
@@ -8447,6 +8479,39 @@ impl QueryContext {
                 .collect(),
         });
         self.query_registered_batch_with_claim(family, items, worker_claim)
+    }
+
+    /// Requests stable-ordered registered dependencies from borrowed keys.
+    ///
+    /// This is the one-worker counterpart to [`Self::query_registered_adaptive_batch`]
+    /// for callers whose keys already live in an immutable batch key. It keeps
+    /// the same request accounting and ordered results, but avoids cloning each
+    /// key merely to hand ownership to the adaptive scheduler before the
+    /// scheduler clones it for the actual query.
+    pub fn query_registered_adaptive_batch_refs<'a, K, V, I>(
+        &self,
+        family: &QueryFamily<K, V>,
+        keys: I,
+    ) -> Result<Vec<Arc<QueryTerminal<V>>>, QueryAbort>
+    where
+        K: QueryKey + 'a,
+        V: Clone + Send + Sync + 'static,
+        I: IntoIterator<Item = &'a K>,
+    {
+        assert!(
+            family.inner.evaluator.is_some(),
+            "closure-free dependency requests require a registered evaluator"
+        );
+        if !Arc::ptr_eq(&self.task_runtime(), &family.core) {
+            return Err(QueryAbort::ForeignRuntime);
+        }
+        if self.max_concurrency() == 1 {
+            return keys
+                .into_iter()
+                .map(|key| self.query_registered_ref(family, key))
+                .collect();
+        }
+        self.query_registered_adaptive_batch(family, keys.into_iter().cloned())
     }
 
     /// Requests a stable-ordered batch of dependencies through one registered
@@ -15871,10 +15936,9 @@ mod tests {
                     "adaptive-batch-root",
                     8,
                     move |context, _, _| {
-                        let terminals = context.query_registered_adaptive_batch(
-                            &leaf_for_root,
-                            [Key("aa"), Key("bbb")],
-                        )?;
+                        let keys = [Key("aa"), Key("bbb")];
+                        let terminals = context
+                            .query_registered_adaptive_batch_refs(&leaf_for_root, keys.iter())?;
                         let sum = terminals
                             .iter()
                             .map(|terminal| match terminal.outcome() {


### PR DESCRIPTION
## Summary

Avoid redundant query-key clones in the one-worker adaptive batch path by allowing compiler callers to pass borrowed batch keys. Parallel batches keep the existing scheduler behavior.

## Validation

- Full premerge: 194 passed, 0 failed, 0 timeouts, 0 build or infrastructure failures
- Query unit tests: 182 passed
- Compiler unit tests: 892 passed, 0 failed, 6 ignored
- Pinned x86-64 Linux release benchmark: median 609 ms across five fresh-process runs, versus approximately 692 ms baseline
- Output remains byte-identical: 1,413,120 bytes, SHA256 b893e76cfabed737b149d0e8c4d8527077dedd17da78418db20a28a7d30885e5