### PR TITLE
RUE-1515: cover signature projection, and charge the RIR-index clock

### DIFF
--- a/crates/rue-compiler/src/canonical_lower.rs
+++ b/crates/rue-compiler/src/canonical_lower.rs
@@ -262,11 +262,23 @@ impl DeclarationBodyPlan {
             )?;
         let rir_instructions = rir.len() as u64;
         let rir_payload_words = rir.extra_len() as u64;
-        let (bundle, index) = rue_air::BodyRirBundle::new_with_index_attribution(
+        // `BodyRirIndexAttribution::duration_ns` documents itself as charged by
+        // the compiler-owned contiguous lowering clock, and until RUE-1515
+        // nothing charged it: the field was summed into
+        // `semantic_body_input_attributed_total` and published as
+        // `body_rir_index_ns` while always reading zero, so published phase
+        // attribution understated the index build by exactly its own cost. The
+        // clock lives here rather than in `rue-air` because the doc says the
+        // compiler owns it, and because this is the only construction site.
+        let index_started = attribution_enabled.then(std::time::Instant::now);
+        let (bundle, mut index) = rue_air::BodyRirBundle::new_with_index_attribution(
             rir,
             space.clone(),
             attribution_enabled,
         );
+        index.duration_ns = index_started.map_or(0, |started| {
+            u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX)
+        });
         checkpoint().map_err(BodyPlanMaterializationFailure::Query)?;
         Ok((
             bundle,

--- a/crates/rue-compiler/src/semantic_query_nucleus.rs
+++ b/crates/rue-compiler/src/semantic_query_nucleus.rs
@@ -359,6 +359,18 @@ pub(crate) fn project_semantic_signature(
 ) -> Result<ParsedSemanticSignature, Arc<str>> {
     use crate::parsed_modules::ParsedDeclarationAstRef;
 
+    // RUE-1510 deleted `declaration_signature_parsing` and replaced it with
+    // this projection, and RUE-1514 held the boundary to the deletion by
+    // rejecting any producer that reports a signature parse. That proves no
+    // parsing happens and says nothing about whether projection happens, so a
+    // regression that removed or short-circuited projection entirely would
+    // pass. This span is the positive half: RUE-1515 requires it non-zero.
+    let _projection_span = tracing::info_span!(
+        "declaration_signature_projection",
+        phase = "semantic_analysis"
+    )
+    .entered();
+
     if key.category == Category::ConstCandidate {
         return Err(Arc::from(
             "constant candidates have no signature projection",

--- a/crates/rue-perf-schema/src/boundary.rs
+++ b/crates/rue-perf-schema/src/boundary.rs
@@ -403,6 +403,15 @@ pub struct CompilerCriticalPathEvidence {
     /// the deletion instead of the work.
     #[serde(default)]
     pub semantic_declaration_signature_parsing: DurationDistribution,
+    /// Exact signature projection from the canonical parsed declaration.
+    ///
+    /// The positive half of the pair above. RUE-1514 proved the deletion of
+    /// signature parsing, which constrains what must *not* happen; a producer
+    /// that removed or short-circuited projection entirely satisfied that and
+    /// published nothing here. RUE-1515 requires this non-zero so the boundary
+    /// covers the path that replaced parsing, not only the path it deleted.
+    #[serde(default)]
+    pub semantic_declaration_signature_projection: DurationDistribution,
     /// Inclusive rooted body-closure query and immediate work reduction.
     #[serde(default)]
     pub semantic_body_closure: DurationDistribution,
@@ -515,7 +524,7 @@ type SemanticEvidenceRow = (
     fn(&CompilerCriticalPathEvidence) -> &DurationDistribution,
 );
 
-const REQUIRED_SEMANTIC_EVIDENCE: [SemanticEvidenceRow; 26] = [
+const REQUIRED_SEMANTIC_EVIDENCE: [SemanticEvidenceRow; 27] = [
     ("semantic_prerequisite_bodies", |critical| {
         &critical.semantic_prerequisite_bodies
     }),
@@ -554,6 +563,9 @@ const REQUIRED_SEMANTIC_EVIDENCE: [SemanticEvidenceRow; 26] = [
     }),
     ("semantic_body_input_rir_index", |critical| {
         &critical.semantic_body_input_rir_index
+    }),
+    ("semantic_declaration_signature_projection", |critical| {
+        &critical.semantic_declaration_signature_projection
     }),
     ("semantic_provider_analysis", |critical| {
         &critical.semantic_provider_analysis
@@ -1069,6 +1081,7 @@ mod tests {
                 semantic_declaration_nuclei: distribution(),
                 // Zero for a current producer: RUE-1510 deleted the span.
                 semantic_declaration_signature_parsing: DurationDistribution::default(),
+                semantic_declaration_signature_projection: distribution(),
                 semantic_body_closure: distribution(),
                 semantic_body_graph_projection: distribution(),
                 semantic_body_input_lowering: distribution(),
@@ -1145,6 +1158,7 @@ mod tests {
             "semantic_declaration_occurrence_indexes",
             "semantic_declaration_nuclei",
             "semantic_declaration_signature_parsing",
+            "semantic_declaration_signature_projection",
             "semantic_body_closure",
             "semantic_body_graph_projection",
             "semantic_body_input_lowering",
@@ -1427,7 +1441,29 @@ mod tests {
              semantic_unification_resolution"
         );
 
-        assert_eq!(REQUIRED_SEMANTIC_EVIDENCE.len(), 26);
+        assert_eq!(REQUIRED_SEMANTIC_EVIDENCE.len(), 27);
+    }
+
+    #[test]
+    fn a_vanished_signature_projection_fails_closed() {
+        // The positive half of the pair below. RUE-1514 proved only that
+        // signature *parsing* is gone; a producer that removed or
+        // short-circuited signature *projection* satisfied that and published
+        // nothing at all for the path that replaced parsing. Under the old
+        // predicate the analogous regression was caught, which is how
+        // RUE-1510's change surfaced in the first place.
+        let policy = BuildBoundaryPolicy::fresh_source_to_native_v1(WorkerSetting::One);
+        let mut vanished = evidence();
+        vanished
+            .critical_path
+            .semantic_declaration_signature_projection = DurationDistribution::default();
+        assert_eq!(
+            vanished
+                .validate_current_producer_against(&policy, "x86-64-linux")
+                .unwrap_err(),
+            "compiler omitted semantic critical-path evidence: \
+             semantic_declaration_signature_projection"
+        );
     }
 
     #[test]

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1084,6 +1084,8 @@ fn compiler_critical_path_evidence(
         semantic_declaration_nuclei: timing.pass_duration_distribution("declaration_nucleus"),
         semantic_declaration_signature_parsing: timing
             .pass_duration_distribution("declaration_signature_parsing"),
+        semantic_declaration_signature_projection: timing
+            .pass_duration_distribution("declaration_signature_projection"),
         semantic_body_closure: timing.pass_duration_distribution("body_closure_collection"),
         semantic_body_graph_projection: timing.pass_duration_distribution("body_graph_projection"),
         semantic_body_input_lowering: timing.pass_duration_distribution("body_input_lowering"),

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -1942,6 +1942,12 @@ mod tests {
         assert!(!session_edges.iter().any(|(parent, child)| {
             parent == "declaration_signature_parsing" || child == "declaration_signature_parsing"
         }));
+        // And the path that replaced it is present. Asserting only the absence
+        // above lets a producer that projects nothing at all pass (RUE-1515).
+        assert!(session_edges.contains(&(
+            "declaration_nucleus".to_owned(),
+            "declaration_signature_projection".to_owned()
+        )));
         assert!(
             !session_edges.contains(&("body_input_lowering".to_owned(), "parse_file".to_owned()))
         );
@@ -2084,11 +2090,16 @@ mod tests {
             .unwrap();
         // The rooted plan requests the declaration once while selecting the
         // entry point and once through the reached-body closure. The query
-        // database reuses the value; both requests remain visible timing
-        // leaves beneath the pipeline aggregate.
+        // database reuses the value; both requests remain visible beneath the
+        // pipeline aggregate.
+        //
+        // Only the second is a leaf. The first evaluates the signature and
+        // opens `declaration_signature_projection` inside itself (RUE-1515);
+        // the second reuses that value and nests nothing, so it stays a leaf.
+        // A regression that stopped projecting would put this back at 2.
         assert_eq!(declaration.invocations, 2);
         assert_eq!(declaration.root_invocations, 0);
-        assert_eq!(declaration.leaf_invocations, 2);
+        assert_eq!(declaration.leaf_invocations, 1);
         for phase in [
             Phase::SemanticAnalysis,
             Phase::CfgAndOptimization,


### PR DESCRIPTION
Both defects from the RUE-1514 review, confirmed against a release compiler on `examples/lattice/main.rue`.

## 1. Signature projection had no counter

RUE-1510 deleted `declaration_signature_parsing` and replaced it with `project_semantic_signature`. RUE-1514 kept the boundary fail-closed by **inverting** the row — rejecting any producer that reports a signature parse.

That proves no signature *parsing* happens and says nothing about whether *projection* happens. A regression that removed or short-circuited projection entirely would pass. Under the old predicate the analogous regression **was** caught — that catch is how RUE-1510's change surfaced at all.

`project_semantic_signature` now opens a `declaration_signature_projection` span, published as `semantic_declaration_signature_projection` and added to `REQUIRED_SEMANTIC_EVIDENCE` (26 → 27 rows). RUE-1514's inverted parsing check stays as belt-and-braces, exactly as the issue scoped it.

Live on Lattice, so the row is real rather than aspirational:

```
semantic_declaration_signature_projection.count     1466
semantic_declaration_signature_projection.total_ns  47,596,605
```

### Knock-on: `declaration_nucleus` loses a leaf

`declaration_nucleus` is requested twice — once selecting the entry point, once through the reached-body closure — and both were timing leaves. The first now nests this span; the second reuses the query value and still nests nothing. So `leaf_invocations` goes 2 → 1, and the timing test pins that shape plus the new `declaration_nucleus -> declaration_signature_projection` edge. A producer that stops projecting fails on the edge as well as on the boundary.

## 2. The RIR-index clock was documented but never charged

`BodyRirIndexAttribution::duration_ns` documented itself as "charged by the compiler-owned contiguous lowering clock", was summed into `semantic_body_input_attributed_total`, was published as `body_rir_index_ns` — and was written nowhere. The only construction was `BodyRirIndexAttribution { declaration_index, ..default() }`.

The boundary's sum invariant could not catch it because both sides omitted the same term.

The clock is now charged around the one construction site, in `canonical_lower.rs` rather than inside `rue-air`, because that is where the doc says ownership lives and where the sibling `span_remap_validation_ns` clock already runs.

**This changes published phase attribution.** On Lattice, over 1,263 materializations:

| counter | before | after |
| -- | -- | -- |
| `semantic_body_input_rir_index.total_ns` | 0 | 34,114,242 |
| `semantic_body_input_attributed_total.total_ns` | 294,310,214 | 328,424,456 |

An **11.6%** increase in attributed body-input time that was previously invisible. The sum invariant holds exactly: `294,310,214 + 34,114,242 = 328,424,456`.

`--time-passes` on the same workload moves from `Semantic_body_input_rir_index: 0.0ms` to `38.7ms`, with `Semantic_body_input_attributed_total` rising from 323.8 ms to 362.5 ms.

## Tests

- New `a_vanished_signature_projection_fails_closed` in `boundary.rs`, sitting next to the existing `a_reappearing_signature_parse_fails_closed` so the pair reads as one rule with two directions.
- `real_compiler_phase_spans_preserve_leaf_boundaries` updated for the new leaf count, with the positive edge assertion added next to the existing absence assertion.
- `omitted_semantic_evidence_names_the_missing_counters` row count 26 → 27.

`scripts/rue unit perf-schema` 223/223, `scripts/rue unit compiler` 892/892, `//crates/rue:rue-test` 201/201, `scripts/rue quick` 30/30.

## Note for reviewers

Because this moves a published number, the first run collected after merge will show a step in `semantic_body_input_attributed_total`. That step is the measurement becoming honest, not a regression — worth an annotation on the performance dashboard if the series is being read across this commit.

Fixes RUE-1515

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEt7kDT3SQnCVfGTnb8qP6)_