### PR TITLE
Record implemented status for ADR-0073 through ADR-0076

### DIFF
--- a/docs/designs/0073-validation-certificate-durability.md
+++ b/docs/designs/0073-validation-certificate-durability.md
@@ -1,12 +1,12 @@
 ---
 id: 0073
 title: "Validation-certificate durability across append-only revisions"
-status: accepted
+status: implemented
 tags: [architecture, compiler, incremental, performance, query-engine]
 feature-flag: null
 created: 2026-08-16
 accepted: 2026-08-16
-implemented:
+implemented: 2026-08-16
 spec-sections: []
 superseded-by:
 relates: ["ADR-0051", "ADR-0063", "ADR-0067", "ADR-0071", "RUE-1112", "RUE-1473"]
@@ -17,9 +17,13 @@ relates: ["ADR-0051", "ADR-0063", "ADR-0067", "ADR-0071", "RUE-1112", "RUE-1473"
 ## Status
 
 Accepted by Steve Klabnik on 2026-08-16 after external design review recorded
-on PR #2449. This is an internal query-engine design with no language-semantics
-change. It changes only the cost of red/green validation, never what
-invalidates what; that boundary is a falsifier, not an aspiration.
+on PR #2449. Implemented the same day: epoch machinery, directional
+certificate gate, and publication-class routing merged via PR #2453, with
+the falsifier suite and the chain scaling gate; the certificate-miss gate
+followed in PR #2455. This is an internal query-engine design with no
+language-semantics change. It changes only the cost of red/green
+validation, never what invalidates what; that boundary is a falsifier, not
+an aspiration.
 
 ## Summary
 

--- a/docs/designs/0074-structural-node-identity.md
+++ b/docs/designs/0074-structural-node-identity.md
@@ -1,12 +1,12 @@
 ---
 id: 0074
 title: "Structural node identity for dependency order and retained charge"
-status: proposal
+status: implemented
 tags: [architecture, compiler, performance, query-engine]
 feature-flag: null
 created: 2026-08-17
-accepted:
-implemented:
+accepted: 2026-08-16
+implemented: 2026-08-17
 spec-sections: []
 superseded-by:
 relates: ["ADR-0063", "ADR-0071", "ADR-0073", "RUE-1381"]
@@ -16,9 +16,13 @@ relates: ["ADR-0063", "ADR-0071", "ADR-0073", "RUE-1381"]
 
 ## Status
 
-Proposed. Approved in principle by Steve Klabnik in session on 2026-08-16
-("yes, let's do all of those"); this document records the contract so the
-implementation has a falsifiable target. This is an internal query-engine
+Approved by Steve Klabnik in session on 2026-08-16; proposed via PR #2464
+and amended for collision safety on external review via PR #2465 (the
+text-tiebreaker fallback was unsound because display text may collide for
+unequal keys). Implemented 2026-08-17 via PR #2468 with the full falsifier
+suite: 32,912 eager display materializations dropped to zero on a fresh
+Lattice build with all other deterministic counters unchanged and emitted
+bytes identical. This is an internal query-engine
 design with no language-semantics change. It changes the *representation*
 of deterministic artifacts (published dependency order, retained-charge
 values) exactly once, never their determinism.

--- a/docs/designs/0075-wave-granular-import-discovery.md
+++ b/docs/designs/0075-wave-granular-import-discovery.md
@@ -1,11 +1,11 @@
 ---
 id: 0075
 title: "Wave-granular import discovery revisions and cumulative exhaustion witness"
-status: proposal
+status: accepted
 tags: [architecture, compiler, incremental, performance, query-engine]
 feature-flag: null
 created: 2026-08-17
-accepted:
+accepted: 2026-08-16
 implemented:
 spec-sections: []
 superseded-by:
@@ -16,9 +16,15 @@ relates: ["ADR-0063", "ADR-0071", "ADR-0073", "ADR-0074"]
 
 ## Status
 
-Proposed. Approved in principle by Steve Klabnik in session on 2026-08-16;
-this document records the contract and the invalidation cases so the
-implementation has a falsifiable target. No language-semantics change: the
+Approved by Steve Klabnik in session on 2026-08-16 and proposed via PR
+#2464. The wave core (items 1-3) was implemented 2026-08-17 via PR #2472:
+one revision per discovery wave, batch stamp verification, and the
+falsifier suite, with discovery revisions on a depth-n chain collapsing
+from n to 1. Item 4 — the cumulative exhaustion witness replacing the
+closing whole-plan re-root — is deliberately not yet implemented: the
+re-root measured at roughly 1.8% of a deep-chain compile, so the verified
+wave win shipped without it. The ADR remains accepted rather than
+implemented until that item lands or is formally dropped. No language-semantics change: the
 final published import plan, resolution results, and emitted bytes are
 byte-identical. What changes is the *granularity* of discovery's revision
 ledger — a deliberate coarsening of the incremental story during

--- a/docs/designs/0076-shared-revision-symbol-space.md
+++ b/docs/designs/0076-shared-revision-symbol-space.md
@@ -1,12 +1,12 @@
 ---
 id: 0076
 title: "Shared revision symbol space for body analysis"
-status: proposal
+status: implemented
 tags: [architecture, compiler, performance, query-engine, type-system]
 feature-flag: null
 created: 2026-08-17
-accepted:
-implemented:
+accepted: 2026-08-17
+implemented: 2026-08-17
 spec-sections: []
 superseded-by:
 relates: ["ADR-0063", "ADR-0071", "ADR-0074", "RUE-1236"]
@@ -16,7 +16,15 @@ relates: ["ADR-0063", "ADR-0071", "ADR-0074", "RUE-1236"]
 
 ## Status
 
-Proposed, pending review. Follows the measurement note
+Proposed via PR #2477 and implemented 2026-08-17: Phase 1 (the
+ordered-use audit and equality-only handle wrapper) via PR #2481, whose
+findings forced the dual symbol-space amendment in PR #2482, and Phase 2
+(the revision-shared equality space with body-private dense remaps) via
+PR #2483, measured at -2.84% of all instructions on a cold Lattice build
+with emitted bytes and every deterministic counter unchanged. The ADR was
+twice corrected by its own implementation evidence (dual spaces; the
+retention bound), recorded in the amended sections below. Follows the
+measurement note
 `docs/notes/per-body-identity-closure-materialization.md`: of the four
 candidate fixes for per-body identity-closure materialization, sharing the
 symbol interner has roughly five times the headroom of sharing the type

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -235,8 +235,8 @@ The table is generated from ADR frontmatter. Run
 | [0070](0070-rue-program-build-actions.md) | Rue program compilation as declared Buck actions | Accepted | build, ci, testing, tooling |
 | [0071](0071-release-quality-compiler-performance-contract.md) | Release-quality compiler performance contract | Accepted | architecture, compiler, performance, process |
 | [0072](0072-runtime-benchmarking-static-site-generator.md) | Runtime performance benchmarking anchored by a Rue static site generator | Accepted | performance, benchmarking, process, examples, stdlib |
-| [0073](0073-validation-certificate-durability.md) | Validation-certificate durability across append-only revisions | Accepted | architecture, compiler, incremental, performance, query-engine |
-| [0074](0074-structural-node-identity.md) | Structural node identity for dependency order and retained charge | Proposal | architecture, compiler, performance, query-engine |
-| [0075](0075-wave-granular-import-discovery.md) | Wave-granular import discovery revisions and cumulative exhaustion witness | Proposal | architecture, compiler, incremental, performance, query-engine |
-| [0076](0076-shared-revision-symbol-space.md) | Shared revision symbol space for body analysis | Proposal | architecture, compiler, performance, query-engine, type-system |
+| [0073](0073-validation-certificate-durability.md) | Validation-certificate durability across append-only revisions | Implemented | architecture, compiler, incremental, performance, query-engine |
+| [0074](0074-structural-node-identity.md) | Structural node identity for dependency order and retained charge | Implemented | architecture, compiler, performance, query-engine |
+| [0075](0075-wave-granular-import-discovery.md) | Wave-granular import discovery revisions and cumulative exhaustion witness | Accepted | architecture, compiler, incremental, performance, query-engine |
+| [0076](0076-shared-revision-symbol-space.md) | Shared revision symbol space for body analysis | Implemented | architecture, compiler, performance, query-engine, type-system |
 <!-- ADR-INDEX:END -->


### PR DESCRIPTION
Status housekeeping for the four speed-campaign ADRs, per Steve's ruling that implemented designs should say so.

- **ADR-0073** → `implemented` (2026-08-16): epoch machinery, directional certificate gate, and publication-class routing (#2453), certificate-miss gate (#2455).
- **ADR-0074** → `implemented` (2026-08-17): structural node identity (#2468), with the #2465 collision amendment recorded in the Status history.
- **ADR-0075** → `accepted` only, deliberately: the wave core shipped (#2472), but item 4 — the cumulative exhaustion witness — is still open (measured at ~1.8% of a deep-chain compile when deferred), and the Status section says so rather than overclaiming.
- **ADR-0076** → `implemented` (2026-08-17): Phase 1 audit (#2481), dual-space amendment (#2482), Phase 2 shared space (#2483), with the twice-corrected-by-evidence history recorded.

Each Status section now carries the ratification/implementation record in the ADR-0063 style instead of draft language. `scripts/validate-adrs.py --write` regenerated the index; registry valid at 77 records.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTiBg7df72iMgdpAFv5wZs)_