### PR TITLE
RUE-1571: stage the wave's eager parse for the canonical parse query

### DIFF
--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -1112,6 +1112,9 @@ pub struct ImportDiscoveryWave {
     /// Accepted sources reduced hop by hop, in the canonical order each hop
     /// offers them to the assembler.
     accepted: Vec<AcceptedImportSource>,
+    /// Each accepted source's eager parse, staged for the published revision's
+    /// canonical parse query so the same bytes are not lexed and parsed twice.
+    staged_parses: Vec<crate::parsed_modules::StagedModuleParse>,
     /// A source that did not parse ends the wave at that hop's boundary, so the
     /// published revision holds exactly what the equivalent round would have and
     /// the canonical staging parse reports the diagnostics.
@@ -1151,6 +1154,7 @@ impl ImportDiscoveryWave {
             batch_fanout: Vec::new(),
             batch_observations: Vec::new(),
             accepted: Vec::new(),
+            staged_parses: Vec::new(),
             sealed: false,
         })
     }
@@ -1223,7 +1227,7 @@ impl ImportDiscoveryWave {
             if !self.known_modules.insert(module.clone()) {
                 continue;
             }
-            let Some(sites) = crate::parsed_modules::parse_unpublished_import_sites(
+            let Some((sites, staged)) = crate::parsed_modules::parse_unpublished_module(
                 &module,
                 source.canonical_path(),
                 source.source(),
@@ -1231,6 +1235,7 @@ impl ImportDiscoveryWave {
                 self.sealed = true;
                 continue;
             };
+            self.staged_parses.push(staged);
             let importer_path = requested_path_for_module(&self.context, &module)?;
             for site in &sites {
                 let occurrence = ImportOccurrenceKey::from_directive(site);
@@ -1290,6 +1295,13 @@ impl ImportDiscoveryWave {
             .into_iter()
             .map(Arc::<[ImportDiscoveryRequest]>::from)
             .collect();
+    }
+
+    /// Take the wave's staged eager parses for the parse-query stage. Called by
+    /// publication so a staged tree becomes consumable exactly when the revision
+    /// carrying its source does.
+    pub(crate) fn take_staged_parses(&mut self) -> Vec<crate::parsed_modules::StagedModuleParse> {
+        std::mem::take(&mut self.staged_parses)
     }
 
     /// The single batch this wave publishes: every hop's operations, fanout, and

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -1419,9 +1419,25 @@ pub(crate) fn parse_source_snapshot_modules(
         .into_owner_result()
 }
 
+#[cfg(test)]
 pub(crate) fn parse_source_snapshot_module(
     snapshot: &SourceSnapshot,
     module: &ModuleId,
+) -> (Result<Arc<ParsedModule>, CompileErrors>, SyntaxWork) {
+    parse_source_snapshot_module_with_stage(snapshot, module, None)
+}
+
+/// The canonical parse entry with an optional staged wave parse (ADR-0075).
+///
+/// A staged parse is consumed only when its exact [`SourceId`] equals the
+/// snapshot's for this module, so it can never substitute for different bytes;
+/// on identity, `build_module_from_staged` skips the lexer and parser but runs
+/// the identical construction tail. Anything else — no stage, a content
+/// mismatch, or an unpublished module — falls through to the fresh parse.
+pub(crate) fn parse_source_snapshot_module_with_stage(
+    snapshot: &SourceSnapshot,
+    module: &ModuleId,
+    staged: Option<StagedModuleParse>,
 ) -> (Result<Arc<ParsedModule>, CompileErrors>, SyntaxWork) {
     let file_id = snapshot.file_id_for_module(module).ok_or_else(|| {
         CompileErrors::from(invalid_input(format!(
@@ -1429,8 +1445,43 @@ pub(crate) fn parse_source_snapshot_module(
         )))
     });
     match file_id {
-        Ok(file_id) => parse_snapshot_file(snapshot, file_id),
+        Ok(file_id) => {
+            if let Some(staged) = staged
+                && snapshot.source_id(file_id) == Some(&staged.source)
+            {
+                return build_module_from_staged(snapshot, file_id, staged);
+            }
+            parse_snapshot_file(snapshot, file_id)
+        }
         Err(errors) => (Err(errors), SyntaxWork::default()),
+    }
+}
+
+/// One wave-parsed module staged for the canonical parse query.
+///
+/// The discovery wave already ran the canonical lexer and parser on this exact
+/// source; the staged value hands that work to `compiler.parse-module` so the
+/// published revision does not lex and parse the same bytes a second time. The
+/// AST and token spans still carry the unpublished placeholder [`FileId`]; the
+/// consumer rebinds them to the snapshot's real file id before building the
+/// module, so no placeholder span survives into a published artifact.
+///
+/// Exact content identity guards consumption: a staged entry is used only when
+/// its [`SourceId`] equals the snapshot's, so a source rewritten between the
+/// wave and a later revision can never smuggle a stale syntax tree in.
+#[derive(Debug)]
+pub(crate) struct StagedModuleParse {
+    module: ModuleId,
+    source: SourceId,
+    ast: Arc<Ast>,
+    interner: ThreadedRodeo,
+    tokens: Arc<[rue_lexer::Token]>,
+    work: SyntaxWork,
+}
+
+impl StagedModuleParse {
+    pub(crate) fn module(&self) -> &ModuleId {
+        &self.module
     }
 }
 
@@ -1441,27 +1492,86 @@ pub(crate) fn parse_source_snapshot_module(
 /// the next hop's candidate policy needs the freshly read module's `@import`
 /// sites before any revision carries it. This runs the same lexer, parser, and
 /// projection collector `parse_snapshot_file` runs — it is the canonical
-/// recognition path invoked eagerly, not a second one — and returns only the
-/// valid directives, in the same AST order [`ParsedModule::imports`] carries.
+/// recognition path invoked eagerly, not a second one — and returns the valid
+/// directives, in the same AST order [`ParsedModule::imports`] carries, together
+/// with the parse itself as a [`StagedModuleParse`] so the published revision's
+/// canonical parse query reuses this work instead of repeating it.
 ///
 /// `None` means the source did not parse. The wave stops extending there and
 /// publishes; the canonical staging parse of the published revision then reports
 /// the diagnostics, exactly as it would have for the hop-granular round that
 /// read the same source.
-pub(crate) fn parse_unpublished_import_sites(
+pub(crate) fn parse_unpublished_module(
     module: &ModuleId,
     physical_path: &str,
-    source: &str,
-) -> Option<Vec<ImportDirective>> {
+    source: &Arc<String>,
+) -> Option<(Vec<ImportDirective>, StagedModuleParse)> {
     // Occurrence keys carry file-relative offsets, so the placeholder file id
-    // below never reaches a published span.
+    // below never reaches a published span; the staged consumer rebinds every
+    // retained span to the snapshot's real file id.
     let outcome = crate::syntax::parse_file(
         crate::queries::SourceView::new(physical_path, source, FileId::new(1)),
         ThreadedRodeo::new(),
     );
     let ast = outcome.result.ok()?;
     let projections = collect_module_projections(&ast, module, &outcome.interner).ok()?;
-    Some(projections.imports.valid)
+    Some((
+        projections.imports.valid,
+        StagedModuleParse {
+            module: module.clone(),
+            source: SourceId::from_shared_text(source.clone()),
+            ast,
+            interner: outcome.interner,
+            tokens: outcome.tokens,
+            work: outcome.work,
+        },
+    ))
+}
+
+/// Build the canonical parsed module from a staged wave parse.
+///
+/// Token and AST spans are rebound from the wave's placeholder file id to the
+/// snapshot's real one, then the exact `build_module` tail runs on the rebound
+/// syntax: the projection collector and definition index observe byte-identical
+/// input to a fresh parse, so the produced module is indistinguishable from one
+/// the skipped lexer/parser invocation would have yielded.
+fn build_module_from_staged(
+    snapshot: &SourceSnapshot,
+    file_id: FileId,
+    staged: StagedModuleParse,
+) -> (Result<Arc<ParsedModule>, CompileErrors>, SyntaxWork) {
+    let StagedModuleParse {
+        ast,
+        interner,
+        tokens,
+        work,
+        ..
+    } = staged;
+    let tokens: Arc<[rue_lexer::Token]> = tokens
+        .iter()
+        .cloned()
+        .map(|mut token| {
+            token.span = Span::with_file(file_id, token.span.start, token.span.end);
+            token
+        })
+        .collect::<Vec<_>>()
+        .into();
+    // The stage normally owns the last reference, so the rebind mutates the
+    // wave's tree in place rather than copying it.
+    let ast = match Arc::try_unwrap(ast) {
+        Ok(mut ast) => {
+            ast.rebind_file_id(file_id);
+            Arc::new(ast)
+        }
+        Err(shared) => {
+            let mut ast = (*shared).clone();
+            ast.rebind_file_id(file_id);
+            Arc::new(ast)
+        }
+    };
+    let result = build_module(snapshot, file_id, ast, interner, work.tokens, tokens)
+        .map_err(CompileErrors::from);
+    (result, work)
 }
 
 pub(crate) fn rebind_parsed_module(
@@ -3738,6 +3848,72 @@ extern "C" { fn getpid() -> i32; }
             error,
             "invalid compiler input: parsed program contains duplicate file ID 7 for modules a.rue and b.rue"
         );
+    }
+
+    #[test]
+    fn staged_wave_parse_is_consumed_only_on_exact_source_identity() {
+        let text = "const helper = @import(\"helper.rue\");\nfn main() -> i32 { 0 }";
+        let snap = snapshot(
+            &[
+                (3, "/main.rue", "main.rue", text),
+                (4, "/helper.rue", "helper.rue", "fn helper() -> i32 { 1 }"),
+            ],
+            3,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let shared = Arc::new(text.to_owned());
+        let (sites, mut staged) = parse_unpublished_module(&module, "/main.rue", &shared).unwrap();
+        assert_eq!(sites.len(), 1);
+        // A sentinel the fresh path cannot produce, proving which path ran.
+        staged.work.lexed_bytes = 424_242;
+
+        let (fresh, fresh_work) = parse_source_snapshot_module(&snap, &module);
+        let fresh = fresh.unwrap();
+        assert_eq!(fresh_work.lexed_bytes, text.len());
+
+        let (hit, hit_work) = parse_source_snapshot_module_with_stage(&snap, &module, Some(staged));
+        let hit = hit.unwrap();
+        assert_eq!(
+            hit_work.lexed_bytes, 424_242,
+            "the staged parse was consumed"
+        );
+
+        // The staged build is indistinguishable from the fresh parse: same
+        // revision, real file id on every retained span, and identical
+        // definition provenance.
+        assert_eq!(hit.revision(), fresh.revision());
+        assert_eq!(hit.file_id(), fresh.file_id());
+        assert_eq!(hit.tokens().len(), fresh.tokens().len());
+        assert!(
+            hit.tokens()
+                .iter()
+                .zip(fresh.tokens())
+                .all(|(staged, fresh)| staged.span == fresh.span),
+            "token spans must be rebound to the snapshot's file id"
+        );
+        assert_eq!(hit.imports().len(), fresh.imports().len());
+        assert_eq!(
+            hit.definitions.candidates.len(),
+            fresh.definitions.candidates.len()
+        );
+        assert!(
+            hit.definitions
+                .candidates
+                .iter()
+                .zip(fresh.definitions.candidates.iter())
+                .all(|(staged, fresh)| staged.name_span == fresh.name_span
+                    && staged.declaration_span == fresh.declaration_span),
+            "definition spans must match the fresh parse exactly"
+        );
+
+        // A stage for different bytes is discarded, never used: the fresh
+        // parse runs and its work shows the snapshot's own byte count.
+        let other = Arc::new("fn main() -> i32 { 1 }".to_owned());
+        let (_, stale) = parse_unpublished_module(&module, "/main.rue", &other).unwrap();
+        let (mismatch, mismatch_work) =
+            parse_source_snapshot_module_with_stage(&snap, &module, Some(stale));
+        assert_eq!(mismatch_work.lexed_bytes, text.len());
+        assert_eq!(mismatch.unwrap().revision(), fresh.revision());
     }
 
     #[test]

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -374,6 +374,9 @@ where
     }
 }
 
+/// Wave-parsed modules awaiting their one canonical parse-query consumption.
+type ParseStage = Arc<Mutex<HashMap<ModuleId, crate::parsed_modules::StagedModuleParse>>>;
+
 #[cfg(test)]
 type DeclarationBodyPlanFailureInjection = Arc<
     Mutex<
@@ -391,6 +394,10 @@ pub(crate) struct RevisionedQueryDatabase {
     source_stamps: VecDeque<(super::session::ExactSourceInput, u64)>,
     import_store: Arc<Mutex<ImportInputStore>>,
     module_store: Arc<Mutex<ModuleInputStore>>,
+    /// Wave-parsed modules staged for `compiler.parse-module` (ADR-0075). Each
+    /// entry is consumed at most once, and only on exact `SourceId` identity,
+    /// so the stage is a work handoff rather than a second parse authority.
+    parse_stage: ParseStage,
     #[cfg(test)]
     test_import_store: Arc<Mutex<TestImportInputStore>>,
     #[cfg(test)]
@@ -11246,6 +11253,8 @@ impl RevisionedQueryDatabase {
         let declaration_body_plan_astgen_evaluations =
             Arc::new(std::sync::atomic::AtomicU64::new(0));
         let parse_store = module_store.clone();
+        let parse_stage: ParseStage = Arc::new(Mutex::new(HashMap::new()));
+        let parse_stage_for_parse_modules = parse_stage.clone();
         let parse_modules = runtime
             .family_with_equality_and_evaluator(
                 "compiler.parse-module",
@@ -11254,8 +11263,20 @@ impl RevisionedQueryDatabase {
                 move |context, _, key: &ModuleQueryKey| {
                     context.input(module_source_input(&key.0))?;
                     let view = module_input_view(&parse_store, context.revision())?;
+                    // Taking the staged wave parse is a pure work handoff: the
+                    // consumer verifies exact SourceId identity against the
+                    // snapshot this query's declared input pinned, so the value
+                    // remains a function of that input alone.
+                    let staged = parse_stage_for_parse_modules
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .remove(&key.0);
                     let (result, work) =
-                        crate::parsed_modules::parse_source_snapshot_module(&view.snapshot, &key.0);
+                        crate::parsed_modules::parse_source_snapshot_module_with_stage(
+                            &view.snapshot,
+                            &key.0,
+                            staged,
+                        );
                     Ok(QueryOutput::success(ParseModuleValue { result, work }))
                 },
             )
@@ -15996,6 +16017,7 @@ impl RevisionedQueryDatabase {
             source_stamps: VecDeque::new(),
             import_store,
             module_store,
+            parse_stage,
             #[cfg(test)]
             test_import_store,
             #[cfg(test)]
@@ -19713,6 +19735,27 @@ impl RevisionedQueryDatabase {
         }
         groups.sort_by(|left, right| left[0].cmp(&right[0]));
         Ok(groups)
+    }
+
+    /// Stage a wave's eager parses for the canonical parse query.
+    ///
+    /// A newer stage for the same module replaces an older unconsumed one, and
+    /// consumption still verifies exact `SourceId` identity, so a stale entry
+    /// can only ever be discarded, never used.
+    pub(crate) fn stage_module_parses(
+        &self,
+        staged: Vec<crate::parsed_modules::StagedModuleParse>,
+    ) {
+        if staged.is_empty() {
+            return;
+        }
+        let mut stage = self
+            .parse_stage
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for parse in staged {
+            stage.insert(parse.module().clone(), parse);
+        }
     }
 
     pub(crate) fn publish_import_batch(

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -1800,10 +1800,11 @@ impl CompilerSession {
     /// the same order.
     pub(crate) fn publish_import_wave(
         &mut self,
-        wave: crate::ImportDiscoveryWave,
+        mut wave: crate::ImportDiscoveryWave,
         snapshot: &SourceSnapshot,
         accepted_reads: crate::AcceptedReadManifest,
     ) -> crate::CompileResult<(crate::ImportInputRevision, crate::ImportDemandFrontier)> {
+        let staged_parses = wave.take_staged_parses();
         let (frontier, observations) = wave.into_batch();
         let revision = self.queries.revisioned.publish_import_batch(
             &frontier,
@@ -1811,6 +1812,9 @@ impl CompilerSession {
             accepted_reads,
             observations,
         )?;
+        // Stage only after the revision carrying these sources exists, so the
+        // parse query can never observe a stage for unpublished content.
+        self.queries.revisioned.stage_module_parses(staged_parses);
         Ok((revision, frontier))
     }
 


### PR DESCRIPTION
A release-compiler work-counter audit on the frozen Lattice reference workload found every source file lexed and parsed twice: `parse_file` runs exactly `2N−1` times for `N` modules on all five maintained ladder workloads (Lattice: 321 invocations for 161 modules). The ADR-0075 discovery wave runs the canonical lexer/parser/projection collector on each freshly read source to learn its `@import` sites, discards the tree, and the published revision's `compiler.parse-module` query parses the same bytes again.

## What this does

- The wave keeps each successful eager parse as a `StagedModuleParse` (AST, interner, tokens, syntax work), keyed by module and carrying the exact content `SourceId`.
- `publish_import_wave` hands the batch to the query database only after the revision carrying those sources exists.
- `compiler.parse-module` consumes a staged entry only on exact `SourceId` identity (digest **and** bytes) with the snapshot's source for that module. On a hit it rebinds token/AST spans from the wave's placeholder `FileId` to the snapshot's real one and runs the unchanged `build_module` tail. A missing stage, content mismatch, or unpublished module falls through to today's fresh parse; a stale entry can only ever be discarded.

No peer scanner or second parse authority is introduced — the wave's parse *is* the canonical recognition path, now invoked once instead of twice. The rebind reuses the same span-remap machinery `bind_payload` already applies when a payload crosses snapshots, and the staged tree is rebound before payload construction so no module retains two ASTs.

## Evidence

Paired debug builds on the same commit, Lattice one worker `-O3`:

| signal | before | after |
| --- | ---: | ---: |
| `parse_file` invocations | 321 | 161 |
| lexer time | 104.8 ms | 47.6 ms |
| `import_parse_staging` | 293.6 ms | 158.9 ms |
| output SHA-256 | `b893e76c…` | identical |
| every other compiler-work counter | — | byte-identical |

## Testing

- New regression test `staged_wave_parse_is_consumed_only_on_exact_source_identity`: proves consumption via a work sentinel, deep-compares the staged-built module against a fresh parse (revision, file id, token spans, definition spans), and proves a stale stage for different bytes is discarded.
- `scripts/rue quick`: 30/30 green; focused `parsed_modules` and `import_discovery` suites green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JX9YAhH4NCb3nm87AgCZW8)_