### PR TITLE
RUE-1572: skip the inline ctor-head scan when the arena census is zero

### DIFF
--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -2972,6 +2972,13 @@ impl BodyRirIndex {
         Self::new_with_attribution(rir, false).0
     }
 
+    /// Whole-arena census of inline type-constructor head shapes, taken during
+    /// the declaration-index walk. See
+    /// [`RirDeclarationIndex::inline_ctor_head_candidates`].
+    pub(in crate::sema) fn inline_ctor_head_candidates(&self) -> usize {
+        self.declarations.inline_ctor_head_candidates()
+    }
+
     fn new_with_attribution(
         rir: &Rir,
         attribution_enabled: bool,

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -2461,6 +2461,19 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         comptime_local_types: &AHashMap<Spur, Type>,
         attribution_enabled: bool,
     ) -> (AHashMap<InstRef, Type>, ComptimePrecomputeAttribution) {
+        // The body RIR index walk already censused the whole arena for these
+        // shapes. Zero occurrences anywhere proves the reachability scan below
+        // — whose candidates are a subset of the arena's — would collect
+        // nothing, so the common candidate-free body skips the scan outright.
+        if self.body_inline_ctor_head_candidates() == 0 {
+            return (
+                AHashMap::new(),
+                ComptimePrecomputeAttribution {
+                    enabled: attribution_enabled,
+                    ..ComptimePrecomputeAttribution::default()
+                },
+            );
+        }
         // A head is the receiver of a `.NAME(..)` path whose receiver is
         // itself a call (`F(args).Ok(x)`, or module-qualified
         // `m.F(args).Ok(x)`, which RIR spells as a nested MethodCall), or a

--- a/crates/rue-air/src/sema/declaration_index.rs
+++ b/crates/rue-air/src/sema/declaration_index.rs
@@ -74,6 +74,7 @@ pub(super) struct RirDeclarationIndex {
     anonymous_methods: Vec<InstRef>,
     destructors: Vec<RirDestructorDeclaration>,
     shell_declarations: Vec<RirShellDeclaration>,
+    inline_ctor_head_candidates: usize,
     work: RirDeclarationIndexWork,
 }
 
@@ -90,6 +91,7 @@ impl RirDeclarationIndex {
             build_invocations: 1,
             ..RirDeclarationIndexWork::default()
         };
+        let mut inline_ctor_head_candidates = 0_usize;
 
         // AstGen emits method FnDecls before their enclosing type. Retain all
         // function candidates during this single arena walk, collect owner
@@ -142,6 +144,37 @@ impl RirDeclarationIndex {
                 }
                 InstData::EnumDecl { .. } => {
                     nominal_candidates.push((source_order as u32, inst_ref));
+                }
+                _ => {}
+            }
+            // Whole-arena census of inline type-constructor head shapes
+            // (RUE-596), taken during the walk this index already performs. A
+            // zero census lets the inference precompute skip its per-body
+            // reachability scan outright: the scan's candidates are a subset of
+            // these arena occurrences, so zero here proves zero there.
+            match &inst.data {
+                InstData::MethodCall { receiver, .. } => {
+                    if matches!(
+                        rir.get(*receiver).data,
+                        InstData::Call { .. } | InstData::MethodCall { .. }
+                    ) {
+                        inline_ctor_head_candidates += 1;
+                    }
+                }
+                InstData::StructInit {
+                    ctor_head: Some(_), ..
+                } => {
+                    inline_ctor_head_candidates += 1;
+                }
+                InstData::Match { arms, .. } => {
+                    for (pattern, _) in rir.match_arms(arms).iter() {
+                        if let rue_rir::RirPatternView::Path {
+                            ctor_head: Some(_), ..
+                        } = pattern
+                        {
+                            inline_ctor_head_candidates += 1;
+                        }
+                    }
                 }
                 _ => {}
             }
@@ -208,8 +241,19 @@ impl RirDeclarationIndex {
             anonymous_methods,
             destructors,
             shell_declarations,
+            inline_ctor_head_candidates,
             work,
         }
+    }
+
+    /// Whole-arena count of inline type-constructor head shapes (RUE-596):
+    /// `.NAME(..)` receivers that are themselves calls, struct literals with an
+    /// explicit constructor head, and match patterns carrying one. The
+    /// inference precompute's reachability scan collects a subset of these
+    /// occurrences, so a zero census proves that scan would find nothing.
+    #[inline]
+    pub(super) fn inline_ctor_head_candidates(&self) -> usize {
+        self.inline_ctor_head_candidates
     }
 
     #[inline]

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -215,6 +215,10 @@ pub(crate) trait OrdinaryBodyAnalysisHost: BodyAnalysisReadHost + Sized {
         producer: Option<(IssuedStableProducerId, IssuedCanonicalArguments)>,
     ) -> Option<(IssuedStableProducerId, IssuedCanonicalArguments)>;
     fn body_rir_ref(&self) -> &Rir;
+    /// Whole-arena census of inline type-constructor head shapes (RUE-596),
+    /// taken by the body RIR index build. Zero proves the inference
+    /// precompute's reachability scan would collect no candidates.
+    fn body_inline_ctor_head_candidates(&self) -> usize;
     fn active_anonymous_producer(
         &self,
     ) -> Option<&(IssuedStableProducerId, IssuedCanonicalArguments)>;
@@ -303,6 +307,9 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
 
     pub(crate) fn body_rir_ref(&self) -> &Rir {
         self.storage.body_rir_ref()
+    }
+    pub(crate) fn body_inline_ctor_head_candidates(&self) -> usize {
+        self.storage.body_inline_ctor_head_candidates()
     }
     pub(crate) fn body_interner(&self) -> &ThreadedRodeo {
         self.storage.body_interner()

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -4186,6 +4186,9 @@ where
     fn body_rir_ref(&self) -> &Rir {
         self.rir.rir()
     }
+    fn body_inline_ctor_head_candidates(&self) -> usize {
+        self.rir.rir_index().inline_ctor_head_candidates()
+    }
     fn active_anonymous_producer(
         &self,
     ) -> Option<&(


### PR DESCRIPTION
The inference precompute for inline type-constructor heads (RUE-596) DFS-scans every body's reachable RIR looking for three shapes that almost never occur. Work counters on the maintained ladder: Lattice pops 50,555 worklist nodes for **1** raw candidate and **0** type successes; mosaic and gazette pop ~24k/~25k for **zero** candidates; harbor pops 46,315 for 18.

## What this does

The body RIR declaration index (`RirDeclarationIndex::new`) already visits every arena instruction exactly once per body (`index_rir_instructions_visited / rir_instructions` is exactly 1.000). That existing walk now censuses the same three shapes — method-call receivers that are themselves calls, struct literals with an explicit `ctor_head`, and match patterns carrying one — and stores the count on the index. `precompute_inline_ctor_head_types` returns immediately when the census is zero.

Soundness: the reachability scan's candidates are a subset of the arena's occurrences (the scan only *restricts* by declaration-ownership boundaries), so a zero census proves the scan would collect nothing. A non-zero census runs today's scan unchanged — ownership boundaries, candidate order, and eval behavior are untouched.

## Evidence

Paired debug builds, one worker `-O3`:

| signal | before | after |
| --- | ---: | ---: |
| Lattice `inline_scan_pops` | 50,555 | 139 |
| Harbor `inline_scan_pops` | 46,315 | 609 |
| Harbor raw candidates / evals / type successes | 18 / 18 / 18 | identical |
| output SHA-256 (both workloads) | — | identical |
| all other counter groups | — | identical |

(The remaining 139/609 pops are the bodies that genuinely contain a candidate; they still run the exact scan.)

## Testing

- `scripts/rue quick`: 30/30 green (includes the RUE-596/RUE-599/RUE-954 inline-head regression tests, which exercise the non-zero-census branch).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JX9YAhH4NCb3nm87AgCZW8)_