### PR TITLE
RUE-1573: reject runtime-rooted member heads in the alias-precompute filter

### DIFF
--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1468,6 +1468,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 return Ok(None);
             }
         }
+        // The precompute's walk conveys runtime locals through this set rather
+        // than `runtime_locals`; the qualified-constant walk already honors it,
+        // and the same spec 4.14:6 shadowing applies to a qualified call.
+        if let Some(names) = env.runtime_binding_names
+            && names.contains(&recv_name)
+        {
+            return Ok(None);
+        }
         if env.type_subst.contains_key(&recv_name) || env.value_subst.contains_key(&recv_name) {
             return Ok(None);
         }
@@ -2568,9 +2576,18 @@ pub(super) fn initializer_may_evaluate_to_type_with_bindings(
         InstData::AnonStructType { .. }
         | InstData::AnonEnumType { .. }
         | InstData::TypeConst { .. }
-        | InstData::Call { .. }
-        | InstData::MethodCall { .. }
-        | InstData::FieldGet { .. } => true,
+        | InstData::Call { .. } => true,
+        // A dotted head reduces to a type only through a module or type
+        // binding, so its receiver spine must bottom out at a `VarRef` that a
+        // runtime binding does not shadow (spec 4.14:6). A call result, an
+        // index, or a runtime local's member is a genuine runtime value; the
+        // evaluator would return non-evaluable for it, so skip the evaluation.
+        InstData::MethodCall { receiver, .. } => {
+            spine_root_names_unshadowed_binding(rir, *receiver, runtime_bindings)
+        }
+        InstData::FieldGet { .. } => {
+            spine_root_names_unshadowed_binding(rir, inst_ref, runtime_bindings)
+        }
         InstData::VarRef { name, .. } => !runtime_bindings.contains(name),
         InstData::Comptime { expr } => {
             initializer_may_evaluate_to_type_with_bindings(rir, *expr, runtime_bindings)
@@ -2606,6 +2623,25 @@ pub(super) fn initializer_may_evaluate_to_type_with_bindings(
             initializer_may_evaluate_to_type_with_bindings(rir, body, runtime_bindings)
         }),
         _ => false,
+    }
+}
+
+/// Whether a dotted receiver spine could still name a module, type, or
+/// constant binding: it must be a chain of member accesses bottoming out at a
+/// `VarRef` whose name no runtime binding shadows (spec 4.14:6). This mirrors
+/// the reachability requirement of the evaluator's own qualified-call walk,
+/// which rejects every other receiver shape as a runtime call.
+fn spine_root_names_unshadowed_binding(
+    rir: &rue_rir::Rir,
+    mut cursor: InstRef,
+    runtime_bindings: &AHashSet<Spur>,
+) -> bool {
+    loop {
+        match &rir.get(cursor).data {
+            InstData::VarRef { name, .. } => return !runtime_bindings.contains(name),
+            InstData::FieldGet { base, .. } => cursor = *base,
+            _ => return false,
+        }
     }
 }
 

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -165,4 +165,65 @@ mod tests {
             assert_eq!(candidates.get(name), Some(&false), "must skip {name}");
         }
     }
+
+    #[test]
+    fn comptime_type_alias_filter_skips_runtime_rooted_member_heads() {
+        let source = r#"
+            fn main(value: i32) -> i32 {
+                let RuntimeMethod = value.reserve(1);
+                let RuntimeField = value.field;
+                let RuntimeChain = value.a.b;
+                let CallRootedField = make().field;
+                let CallRootedMethod = make().method(1);
+                let ModuleMethod = module.Make(i32);
+                let ModuleChainMethod = std.option.Option(i32);
+                let TypeMethod = SomeType.new();
+                let ModulePath = std.strbuf.StrBuf;
+                0
+            }
+        "#;
+        let (rir, interner) = lower_files(&[(source, FileId::DEFAULT)]);
+        let runtime: AHashSet<lasso::Spur> = [interner.get("value").unwrap()].into_iter().collect();
+        let mut candidates = AHashMap::new();
+        for (_, inst) in rir.iter() {
+            if let InstData::Alloc {
+                name: Some(name),
+                init,
+                ..
+            } = inst.data
+            {
+                candidates.insert(
+                    interner.resolve(&name).to_owned(),
+                    crate::sema::comptime_eval::initializer_may_evaluate_to_type_with_bindings(
+                        &rir, init, &runtime,
+                    ),
+                );
+            }
+        }
+
+        // A member head rooted at a runtime binding, or at anything other than
+        // a dotted name spine, can never reduce to a type: the evaluator's
+        // qualified walk rejects those receivers, so the filter skips the
+        // evaluation outright (spec 4.14:6 shadowing included).
+        for name in [
+            "RuntimeMethod",
+            "RuntimeField",
+            "RuntimeChain",
+            "CallRootedField",
+            "CallRootedMethod",
+        ] {
+            assert_eq!(candidates.get(name), Some(&false), "must skip {name}");
+        }
+        // Unshadowed dotted spines stay eligible: module-qualified type
+        // functions, re-export chains, type-rooted member heads, and module
+        // paths to types all still reach the evaluator.
+        for name in [
+            "ModuleMethod",
+            "ModuleChainMethod",
+            "TypeMethod",
+            "ModulePath",
+        ] {
+            assert_eq!(candidates.get(name), Some(&true), "must retain {name}");
+        }
+    }
 }


### PR DESCRIPTION
The comptime type-alias precompute (RUE-251/RUE-530) runs full comptime evaluations at a 2–5% hit rate: Lattice attempts 1,701 evals for 36 type successes. Shape instrumentation shows the waste is member heads the filter accepts unconditionally — `MethodCall` on runtime values (1,143 failed evals on Lattice: `data.reserve(65536)` and friends), runtime `FieldGet` chains, and call-rooted receivers. Each such eval costs a guaranteed-fruitless provider resolution.

## What this does

`eval_module_qualified_comptime_call` — the only way a `MethodCall`/`FieldGet` head can reduce to a type — already rejects every receiver that is not a dotted `VarRef`/`FieldGet` spine bottoming out at an unshadowed name. The filter (`initializer_may_evaluate_to_type_with_bindings`) now applies that same reachability rule up front: a member head is eligible only when its receiver spine bottoms out at a `VarRef` no runtime binding shadows (spec 4.14:6). Everything the evaluator could reduce still reaches it — module-qualified type functions, re-export chains, type-rooted heads, module paths.

The qualified-call walk also gains the `runtime_binding_names` shadow check its qualified-constant sibling already had. That is consistency hardening for the same spec rule, not a user-visible bug fix: the analysis path re-checks independently, and I could not reproduce a divergence on trunk (a shadowed-module qualified call still gets its E0413).

## Evidence

Paired debug builds, one worker `-O3` — eval attempts fall with **identical** type successes and output hash on every maintained workload:

| workload | evals before → after | type successes |
| --- | ---: | ---: |
| lattice | 1,701 → 776 | 36 → 36 |
| ruelex | 267 → 54 | 12 → 12 |
| gazette | 972 → 571 | 50 → 50 |
| harbor | 1,008 → 641 | 105 → 105 |
| mosaic | 658 → 392 | 49 → 49 |

Provider name lookups drop ~800 on Lattice (50,864 vs 51,637).

## Testing

- New unit test `comptime_type_alias_filter_skips_runtime_rooted_member_heads` covering all five rejected shapes and four retained ones.
- Existing `comptime_type_alias_filter_keeps_every_type_producing_shape` still green (qualified calls/paths retained).
- `scripts/rue quick` 30/30; `scripts/rue spec 4.14` 203/203.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JX9YAhH4NCb3nm87AgCZW8)_