### PR TITLE
RUE-1574: collect CFG layout/drop prerequisites into sorted vectors

### DIFF
--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -851,9 +851,9 @@ pub(crate) fn import_warnings(
 
 pub(crate) fn collect_type_dependencies(
     ty: &rue_air::SemanticImportType<crate::StableDefinitionKey, crate::ModuleId>,
-    output: &mut std::collections::BTreeSet<crate::TypeInstanceKey>,
+    output: &mut Vec<crate::TypeInstanceKey>,
 ) {
-    output.insert(type_instance_from_semantic(ty));
+    output.push(type_instance_from_semantic(ty));
     // Array representation and CFG indexing depend on the element layout.
     // Pointer and slice representation does not depend on the pointee.
     if let rue_air::SemanticImportType::Array { element, .. } = ty {
@@ -863,14 +863,14 @@ pub(crate) fn collect_type_dependencies(
 
 pub(crate) fn collect_type_and_drop_dependencies(
     ty: &rue_air::SemanticImportType<crate::StableDefinitionKey, crate::ModuleId>,
-    layout_output: &mut std::collections::BTreeSet<crate::TypeInstanceKey>,
-    drop_output: &mut std::collections::BTreeSet<crate::TypeInstanceKey>,
+    layout_output: &mut Vec<crate::TypeInstanceKey>,
+    drop_output: &mut Vec<crate::TypeInstanceKey>,
 ) {
     let instance = type_instance_from_semantic(ty);
-    layout_output.insert(instance.clone());
     if type_may_need_drop_glue(ty) {
-        drop_output.insert(instance);
+        drop_output.push(instance.clone());
     }
+    layout_output.push(instance);
     // Array representation and CFG indexing depend on the element layout.
     // Pointer and slice representation does not depend on the pointee.
     if let rue_air::SemanticImportType::Array { element, .. } = ty {
@@ -1251,13 +1251,23 @@ fn materialize_and_build_cfg(
     let domain_projection_ns = elapsed_ns(domain_projection_started);
 
     let prerequisite_collection_started = std::time::Instant::now();
-    let mut layout_dependencies = std::collections::BTreeSet::new();
-    let mut drop_dependencies = std::collections::BTreeSet::new();
+    // The local type pool is already deduplicated, so per-type tree inserts
+    // buy nothing here: on the maintained workloads every scanned type yields
+    // exactly one unique layout key (the only collisions are array elements,
+    // whose keys the pool also carries). Collect into vectors and normalize
+    // once; the sort matches the ordered-set iteration this replaced, so the
+    // batch request order is unchanged.
+    let mut layout_dependencies: Vec<crate::TypeInstanceKey> = Vec::new();
+    let mut drop_dependencies: Vec<crate::TypeInstanceKey> = Vec::new();
     let mut stable_types_scanned = 0_u64;
     for ty in domains.stable_types() {
         stable_types_scanned = stable_types_scanned.saturating_add(1);
         collect_type_and_drop_dependencies(ty, &mut layout_dependencies, &mut drop_dependencies);
     }
+    layout_dependencies.sort_unstable();
+    layout_dependencies.dedup();
+    drop_dependencies.sort_unstable();
+    drop_dependencies.dedup();
     let layout_prerequisite_requests = layout_dependencies.len() as u64;
     let drop_prerequisite_requests = drop_dependencies.len() as u64;
     context.record_work(rue_query::WorkItem::new(


### PR DESCRIPTION
A work-counter audit found `cfg_prerequisites.layout_requests / stable_types_scanned` is exactly **1.000** on all five maintained workloads: the per-body `BTreeSet`s in CFG prerequisite collection never deduplicate a scanned type. The local type pool is already unique, and the only colliding inserts are array elements whose keys the pool also carries — so every scanned type paid ordered-tree insert cost for nothing.

## What this does

Collects layout and drop-glue prerequisite keys into vectors during the same `stable_types()` walk, then normalizes once with `sort_unstable` + `dedup`. The sort reproduces the ordered-set iteration order exactly, so the adaptive batch request order — and with it every query edge and counter — is unchanged.

Framing this honestly: it is an allocation-shape cleanup (two tree structures → two flat vectors per CFG body), not a claimed wall-time speedup.

## Evidence

Paired debug builds at the same trunk commit: Lattice output SHA-256 and the complete `compiler_work` report are **byte-identical** (`layout_requests` 24,036, `drop_glue_requests` 14,093, all query-runtime counters unchanged — confirming identical request sets and order).

## Testing

- `scripts/rue quick` 30/30; `cfg_query` unit tests 8/8.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JX9YAhH4NCb3nm87AgCZW8)_