### PR TITLE
RUE-1353: frame-layout follow-ups from the RUE-768 integration

### DIFF
--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -2843,11 +2843,49 @@ impl Cfg {
         Ok(())
     }
 
+    /// The predecessors of one block, in block order.
+    ///
+    /// [`Self::compute_predecessors`] builds a row per block; a caller that
+    /// reads a single row pays that whole table — an allocation per block —
+    /// to look at one of them. This walks the same terminators and collects
+    /// only the row asked for.
+    ///
+    /// Like the table, this is computed on demand rather than cached, so it
+    /// is always in sync with the current terminators.
+    pub fn predecessors_of(&self, block: BlockId) -> Vec<BlockId> {
+        let mut preds = Vec::new();
+        for candidate in &self.blocks {
+            let reaches = match &candidate.terminator {
+                Terminator::Goto { target, .. } => *target == block,
+                Terminator::Branch {
+                    then_block,
+                    else_block,
+                    ..
+                } => *then_block == block || *else_block == block,
+                Terminator::Switch { cases, default, .. } => {
+                    *default == block
+                        || self
+                            .switch_cases(cases)
+                            .iter()
+                            .any(|(_, target)| *target == block)
+                }
+                Terminator::Return { .. } | Terminator::Unreachable | Terminator::None => false,
+            };
+            if reaches {
+                preds.push(candidate.id);
+            }
+        }
+        preds
+    }
+
     /// Compute predecessor lists for all blocks, indexed by block id.
     ///
     /// Predecessors are computed on demand from the current terminators
     /// (rather than cached on each block) so the result is always in sync
     /// with the CFG, even after optimization passes rewrite terminators.
+    ///
+    /// Reach for [`Self::predecessors_of`] when only one block's row is
+    /// wanted.
     pub fn compute_predecessors(&self) -> Vec<Vec<BlockId>> {
         let mut preds: Vec<Vec<BlockId>> = vec![Vec::new(); self.blocks.len()];
 

--- a/crates/rue-cfg/src/opt/loops.rs
+++ b/crates/rue-cfg/src/opt/loops.rs
@@ -468,10 +468,13 @@ fn ensure_preheader_in(
 
     // Partition the header's predecessors: a pred inside the body is a latch
     // (a back edge, kept targeting the header); a pred outside is a loop entry.
-    let preds = cfg.compute_predecessors();
-    let outside: Vec<BlockId> = preds[header.as_u32() as usize]
-        .iter()
-        .copied()
+    //
+    // Only the header's row is read, and this runs once per loop, so building
+    // the whole predecessor table here allocated a vector per block per loop
+    // to look at one of them.
+    let outside: Vec<BlockId> = cfg
+        .predecessors_of(header)
+        .into_iter()
         .filter(|p| !lp.contains(*p))
         .collect();
 

--- a/crates/rue-codegen/src/codegen_pipeline.rs
+++ b/crates/rue-codegen/src/codegen_pipeline.rs
@@ -76,6 +76,9 @@ pub(crate) struct PreparedMir<M, R> {
     /// Per-parameter storage decision shared by lowering, emission, and the
     /// stack-frame reporter (RUE-1170).
     pub(crate) param_storage: crate::param_storage::ParamStoragePlan,
+    /// Per-local frame-cell decision (RUE-768), carried for the same reason:
+    /// the stack-frame reporter names which CFG locals share a cell.
+    pub(crate) local_storage: crate::local_storage::LocalSlotPlan,
     /// Validated final layout consumed by emission and presentation paths.
     pub(crate) frame_layout: FrameLayout,
 }
@@ -271,6 +274,7 @@ where
             used_callee_saved,
             param_homing,
             param_storage,
+            local_storage,
             frame_layout,
         },
         artifacts,

--- a/crates/rue-codegen/src/local_storage.rs
+++ b/crates/rue-codegen/src/local_storage.rs
@@ -220,6 +220,26 @@ impl LocalSlotPlan {
         self.frame_local_slots < self.map.len() as u32
     }
 
+    /// The CFG local slots assigned to each emitted frame local cell, indexed
+    /// by frame slot and in CFG order within a cell.
+    ///
+    /// This is the plan read backwards. `--emit stackframe` reports the frame
+    /// as emitted, where a merged cell is indistinguishable from an unmerged
+    /// one; the whole point of RUE-768 is that two locals can land on one
+    /// cell, and a report that cannot say so cannot be used to review the
+    /// decision or pin it against regression.
+    pub(crate) fn cfg_slots_by_frame_slot(&self) -> Vec<Vec<u32>> {
+        let mut owners = vec![Vec::new(); self.frame_local_slots as usize];
+        for (cfg_slot, &frame_slot) in self.map.iter().enumerate() {
+            // A ZST local can sit one past the local area and is not mapped;
+            // it owns no cell, so it names none here either.
+            if let Some(cell) = owners.get_mut(frame_slot as usize) {
+                cell.push(cfg_slot as u32);
+            }
+        }
+        owners
+    }
+
     fn try_plan(
         cfg: &Cfg,
         type_pool: &FrozenTypeInternPool,
@@ -331,7 +351,7 @@ fn collect_slot_references(
     interner: &ThreadedRodeo,
 ) -> Option<SlotReferences> {
     let num_locals = cfg.num_locals();
-    let span_of = |ty: Type| crate::types::type_slot_count(type_pool, ty).max(1);
+    let span_of = |ty: Type| crate::types::type_slot_span(type_pool, ty);
     let mut per_value = vec![None; cfg.value_count()];
     let escaping = address_escaping_operands(cfg, interner);
 
@@ -722,6 +742,36 @@ fn verify_sharing(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn the_frame_cell_map_inverts_the_plan_and_skips_unmapped_zst_slots() {
+        // The identity plan gives every local its own cell, so every cell has
+        // exactly one owner and the report reads as it always did.
+        let identity = LocalSlotPlan::identity(3);
+        assert_eq!(
+            identity.cfg_slots_by_frame_slot(),
+            vec![vec![0], vec![1], vec![2]]
+        );
+
+        // A merged plan: CFG locals 0 and 2 share cell 0, local 1 keeps cell 1.
+        // Owners come back in CFG order within a cell, which is what makes the
+        // rendered name stable across runs.
+        let merged = LocalSlotPlan {
+            map: vec![0, 1, 0],
+            frame_local_slots: 2,
+        };
+        assert_eq!(merged.cfg_slots_by_frame_slot(), vec![vec![0, 2], vec![1]]);
+        assert!(merged.shares_any_slot());
+
+        // A ZST local may be rooted one past the local area and is not mapped
+        // to a cell. It must not be attributed to a cell it does not occupy,
+        // and must not index out of bounds.
+        let with_zst = LocalSlotPlan {
+            map: vec![0, 1],
+            frame_local_slots: 1,
+        };
+        assert_eq!(with_zst.cfg_slots_by_frame_slot(), vec![vec![0]]);
+    }
+
     use super::*;
 
     fn entity(base: u32, span: u32) -> SlotEntity {

--- a/crates/rue-codegen/src/param_storage.rs
+++ b/crates/rue-codegen/src/param_storage.rs
@@ -241,13 +241,13 @@ fn scan_param_references(cfg: &Cfg, type_pool: &FrozenTypeInternPool) -> ParamRe
         (slot >= num_locals && slot < num_locals + num_params as u32).then(|| slot - num_locals)
     };
     let mark_span = |v: &mut Vec<bool>, index: u32, span: u32| {
-        for offset in 0..span.max(1) {
+        for offset in 0..span {
             if let Some(flag) = v.get_mut((index + offset) as usize) {
                 *flag = true;
             }
         }
     };
-    let span_of = |ty: rue_cfg::Type| crate::types::type_slot_count(type_pool, ty);
+    let span_of = |ty: rue_cfg::Type| crate::types::type_slot_span(type_pool, ty);
 
     for block in cfg.blocks() {
         for &value in &block.insts {

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -282,6 +282,28 @@ pub fn generate_stack_frame_info(
     }
 }
 
+/// The `--emit stackframe` name for one emitted frame local cell.
+///
+/// A cell holding one local reads as that local. A cell RUE-768 merged reads
+/// as its first local plus the others sharing it, because a report that shows
+/// only "local" cannot distinguish a merged frame from an unmerged one — and
+/// distinguishing them is the entire observable effect of slot sharing.
+fn local_slot_name(owners: &[u32]) -> Option<String> {
+    // The kind already renders as `local`, so this names the CFG slots alone.
+    match owners {
+        [] => None,
+        [only] => Some(format!("${only}")),
+        [first, shared @ ..] => {
+            let shared = shared
+                .iter()
+                .map(|slot| format!("${slot}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            Some(format!("${first} shared with {shared}"))
+        }
+    }
+}
+
 /// Generate stack frame info for x86-64.
 fn generate_x86_64_stack_frame(
     cfg: &ValidatedCfg,
@@ -334,9 +356,12 @@ fn generate_x86_64_stack_frame(
     }
 
     // Add local variables
+    let local_owners = prepared.local_storage.cfg_slots_by_frame_slot();
     for i in 0..num_locals {
         slots.push(StackSlot {
-            name: None, // We don't have variable names from CFG yet
+            name: local_owners
+                .get(i as usize)
+                .and_then(|owners| local_slot_name(owners)),
             offset: frame.slot_offset(i),
             size: frame.slot_size(i) as usize,
             ty: "i64".to_string(), // Generic - we don't track types at CFG level
@@ -519,9 +544,12 @@ fn generate_aarch64_stack_frame(
     }
 
     // Add local variables
+    let local_owners = prepared.local_storage.cfg_slots_by_frame_slot();
     for i in 0..num_locals {
         slots.push(StackSlot {
-            name: None,
+            name: local_owners
+                .get(i as usize)
+                .and_then(|owners| local_slot_name(owners)),
             offset: slot_offset(i),
             size: frame.slot_size(i) as usize,
             ty: "i64".to_string(),
@@ -779,6 +807,23 @@ mod tests {
             rue_air::AnalyzedCallableKind::Ordinary,
         );
         (cfg_output.cfg.unwrap(), type_pool, interner)
+    }
+
+    #[test]
+    fn a_merged_local_cell_names_every_slot_sharing_it() {
+        // RUE-768 lets two locals with disjoint storage windows overlay one
+        // cell. Before this the report showed both frames identically, so the
+        // sharing decision could not be reviewed or pinned from it.
+        assert_eq!(local_slot_name(&[]), None, "an unowned cell has no name");
+        assert_eq!(local_slot_name(&[0]), Some("$0".to_string()));
+        assert_eq!(
+            local_slot_name(&[1, 5]),
+            Some("$1 shared with $5".to_string())
+        );
+        assert_eq!(
+            local_slot_name(&[2, 6, 9]),
+            Some("$2 shared with $6, $9".to_string())
+        );
     }
 
     #[test]

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -67,6 +67,24 @@ pub fn type_slot_count(type_pool: &FrozenTypeInternPool, ty: Type) -> u32 {
     type_pool.abi_slot_count(ty)
 }
 
+/// The number of frame slot positions `ty` occupies, clamped to at least one.
+///
+/// [`type_slot_count`] answers zero for a zero-sized type, which is the right
+/// answer for "how many cells hold this value". Frame bookkeeping asks a
+/// different question: which slot positions does a reference to this local
+/// *cover*. A ZST still sits at one addressable position, and a span of zero
+/// makes it invisible to the overlap and interference scans — a reference no
+/// scan can see is one that cannot be proved to conflict, which is how a ZST
+/// slot silently drops out of frame reasoning.
+///
+/// Both the local slot-reference scan (RUE-768) and the parameter home scan
+/// (RUE-1170) independently grew a `.max(1)` for exactly this, in different
+/// places and with the reason recorded in neither. This is that convention,
+/// named once.
+pub fn type_slot_span(type_pool: &FrozenTypeInternPool, ty: Type) -> u32 {
+    type_slot_count(type_pool, ty).max(1)
+}
+
 /// Whether `ty` needs a complete aggregate slot representation rather than a
 /// single primary vreg. Discriminant-only enums remain scalar values.
 pub fn is_multislot_aggregate(type_pool: &FrozenTypeInternPool, ty: Type) -> bool {


### PR DESCRIPTION
Three items the RUE-768 frame-slot-reuse worker left behind. Two are done as asked; the third is deliberately narrower than the issue proposed, with the measurement below.

## 1. `--emit stackframe` could not distinguish shared cells

RUE-768's entire observable effect is that two locals with disjoint storage windows overlay one frame cell — and the reporter printed a merged frame identically to an unmerged one. The decision could not be reviewed from the report, or pinned against regression.

`LocalSlotPlan::cfg_slots_by_frame_slot` exposes the assignment read backwards — one owner list per emitted cell — and both backends' reporters name a cell by the CFG slots sharing it:

```
  [rbp -40] : local '$0' (i64, 8 bytes)
  [rbp -48] : local '$1 shared with $5' (i64, 8 bytes)
  [rbp -56] : local '$2 shared with $6' (i64, 8 bytes)
```

(Two four-element arrays in sibling scopes; before, all five lines read `local '?'`.)

A ZST local rooted one past the local area is mapped to no cell and is attributed to none — the map skips it rather than indexing out of bounds.

## 2. The ZST slot-span clamp was a convention with no name

Frame bookkeeping asks which slot positions a reference **covers**, not how many cells hold the value. A ZST still sits at one addressable position, and a span of zero makes it invisible to the overlap and interference scans — a reference no scan can see cannot be proved to conflict, which is how a ZST slot silently drops out of frame reasoning.

The local scan (RUE-768) and the parameter scan (RUE-1170) each independently grew a `.max(1)` for exactly this, in different places, with the reason recorded in neither. `types::type_slot_span` is that convention named once, with the reason attached. Both call it, and `param_storage`'s `mark_span` no longer re-clamps what its callers already clamped — every one of its 17 call sites now passes either a clamped span or a literal `1`.

## 3. One predecessor row cost a whole table — but no cache

`ensure_preheader_in` reads the header's predecessors and nothing else, and runs once per loop, so it built a vector per block per loop to look at one of them. `Cfg::predecessors_of` walks the same terminators and collects only the row asked for.

**I did not add the cached predecessor view on `Cfg` that the issue proposed.** Measured on Lattice, `compute_predecessors` runs **5,500+ times over 45,731 blocks** — roughly 8 blocks per call. The table is small; the cost is the allocation, not the scan.

A cache would have to be invalidated by every terminator rewrite, and the existing doc comment says predecessors are recomputed precisely so they stay in sync "even after optimization passes rewrite terminators." A stale predecessor list feeds wrong dominators and wrong optimization — a miscompilation class, in exchange for ~5,500 small allocations. That trade wants a maintainer's call, not an unattended one, so this takes only the part that is unambiguously free. Happy to do the cache as a follow-up if you want it.

The other four call sites (`dominators`, `loops_with_stats`, `local_storage`, and the CFG display) genuinely read the whole table and are unchanged.

## Risk

Emitted executables byte-identical: Lattice `b893e76c…`, the call-heavy probe `699519b7…`, both matching trunk. Items 2 and 3 are behavior-preserving by construction; item 1 touches presentation only.

## Tests

- `a_merged_local_cell_names_every_slot_sharing_it` — the naming, including the unowned-cell and three-way-share cases.
- `the_frame_cell_map_inverts_the_plan_and_skips_unmapped_zst_slots` — identity plan, a merged plan (owners in CFG order, which is what makes the rendered name stable), and an unmapped ZST slot.

`scripts/rue unit codegen` 733/733, `scripts/rue unit cfg` 261/261, `scripts/rue quick` 30/30, `scripts/rue ui` 250/250, `scripts/rue cli` 1892/1892.

Fixes RUE-1353

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEt7kDT3SQnCVfGTnb8qP6)_