### PR TITLE
RUE-1332: ADR-0059 bookkeeping sweep

### DIFF
--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -676,9 +676,9 @@ enum Value {
     /// discriminant-only enum (or C-like enum) stays a bare `Int` tag.
     Aggregate(Vec<Value>),
     /// A raw pointer into the abstract heap (RUE model-gap closure). `None` is
-    /// the null pointer (`@int_to_ptr(0)`, a failed `@alloc`/`@realloc`); `Some`
-    /// names a live cell inside an [`Allocation`]. Heap allocations
-    /// (`@alloc`/`@alloc_bytes`) and address-taken stack places
+    /// the null pointer (`@int_to_ptr` on a zero address, a failed
+    /// `@alloc`/`@realloc`); `Some` names a live cell inside an [`Allocation`].
+    /// Heap allocations (`@alloc`) and address-taken stack places
     /// (`@raw`/`@raw_mut`/`@field_ptr`) share this one provenance-carrying
     /// representation so a pointer read/write, offset, or int round-trip resolves
     /// to the same backing store the source place or allocation owns.
@@ -933,7 +933,7 @@ struct Interp<'a> {
     /// Current call-recursion depth (see [`MAX_DEPTH`]). Incremented on entry to
     /// each `call` and decremented on exit, bounding Rust-stack recursion.
     depth: u32,
-    /// The abstract heap: every `@alloc`/`@alloc_bytes` block and every promoted
+    /// The abstract heap: every `@alloc` block and every promoted
     /// address-taken stack place. Indexed by [`PtrTarget::alloc`]. It lives on
     /// the interpreter (not a frame) so a pointer read across a call boundary
     /// still resolves after the address is passed to a callee.
@@ -3908,7 +3908,7 @@ impl<'a> Interp<'a> {
         })))
     }
 
-    /// `@realloc`/`@realloc_bytes`: grow/shrink an allocation, preserving the
+    /// `@realloc`: grow/shrink an allocation, preserving the
     /// first `min(old, new)` cells and deterministically filling growth. This
     /// model keeps shrink-in-place and move-on-grow behavior; native pointer
     /// identity is deliberately unspecified. Returns null on `new == 0` or allocator failure, leaving the

--- a/docs/designs/0059-byte-oriented-memory-intrinsics.md
+++ b/docs/designs/0059-byte-oriented-memory-intrinsics.md
@@ -1,13 +1,13 @@
 ---
 id: 0059
 title: "Byte-oriented memory intrinsics: unify the two low-level families"
-status: accepted
+status: implemented
 tags: [intrinsics, memory, pointers, allocator, bytes, semantics, stdlib, abi]
 feature-flag: raw_bytes
 created: 2026-07-17
 accepted: 2026-07-17
-implemented:
-spec-sections: []
+implemented: 2026-07-20
+spec-sections: ["4.13:5a", "9.2:7", "9.2:10", "9.2:11", "9.2:12", "9.2:13"]
 superseded-by:
 relates: ["RUE-937", "RUE-879", "RUE-971", "RUE-712", "ADR-0052", "ADR-0005", "ADR-0057"]
 ---
@@ -94,7 +94,7 @@ right intrinsics here" and Zig "is very good at this kind of stuff." Concretely:
   `ArrayBuf` needs), has **no alignment parameter** (`@alloc_bytes` guarantees
   only alignment 1 — flagged as an open question by ADR-0052), and has **no
   null-pointer primitive** (its consumers reach into the *typed* family's
-  `@int_to_ptr(0)` for the null idiom).
+  `@int_to_ptr` for the null idiom).
 - Every std consumer that copies bytes hand-rolls a one-byte-at-a-time `while`
   loop, because there is no bulk-copy primitive in either family.
 
@@ -266,9 +266,19 @@ demonstrated need).
 ```
 
 Kept unchanged. These stay distinct from arithmetic and access (principle 8).
-`@int_to_ptr(0)` remains the null-pointer idiom and `@ptr_to_int(p) == 0` the
-null check — the byte family never had these, and the unified set does not
-strand the consumers that borrow them. Names are chosen so a later strict/exposed
+`@int_to_ptr` on a zero address remains the null-pointer idiom and
+`@ptr_to_int(p) == 0` the null check — the byte family never had these, and the
+unified set does not strand the consumers that borrow them. Spelled out, since
+`@int_to_ptr(0)` as written does not compile twice over — the intrinsic is
+unchecked (E1300 outside a `checked` block) and takes `u64`, which an untyped
+`0` literal is not (E0702):
+
+```rue
+let zero: u64 = 0;
+let null: ptr mut u8 = checked { @int_to_ptr(zero) };
+```
+
+`std/fs.rue` and `std/mem.rue` use exactly this form. Names are chosen so a later strict/exposed
 provenance split does not force a rename of the common path.
 
 ### Reflection substrate — kept, made byte-accurate by RUE-971
@@ -365,15 +375,17 @@ reassessment; this ADR supplies its target shape.
 
 Phases are ordered by the sequencing above. RUE-937 is the tracking issue.
 
-- [ ] **Phase 1: Bulk primitives (now, no RUE-971 dependency)** — RUE-937. Add
+- [x] **Phase 1: Bulk primitives (now, no RUE-971 dependency)** — RUE-937. Add
   `@byte_copy` and `@byte_set` to the `raw_bytes` surface; port
   `StrBuf::copy_packed_bytes`, the `std.fs` marshalling loops, and
   `std.mem.swap` off their per-byte loops; add spec coverage under the existing
-  gate.
-- [ ] **Phase 2: Alignment on the byte allocator (now)** — RUE-960. Add
+  gate. Landed in PR #1750.
+- [x] **Phase 2: Alignment on the byte allocator (now)** — RUE-960. Add
   the `align` parameter to the byte allocator, giving the interim surface the
   `(size, align)` contract; update the runtime operand plan (already
-  `(size, align)`-shaped) and `std` call sites.
+  `(size, align)`-shaped) and `std` call sites. Landed in PR #1752. The interim
+  `_bytes` surface it shaped no longer exists — Phase 3 folded it away — but the
+  `(size, align)` contract it established is the one the unified family carries.
 - [x] **Phase 3: Byte-oriented allocation family (post-/co-RUE-971)** —
   RUE-961. Re-shape `@alloc`/`@realloc`/`@free` to byte + align; fold
   the `_bytes` allocators in; move `ArrayBuf` typed allocation to source-computed
@@ -403,13 +415,15 @@ Phases are ordered by the sequencing above. RUE-937 is the tracking issue.
   `@byte_write` are folded into `@ptr_read`/`@ptr_write` (hard removal, no
   alias window). The `*align(N)` re-evaluation this phase required was made and
   declined; see the fold ruling under "Resolved at acceptance".
-- [ ] **Phase 5: Specification sweep** — RUE-963. Rewrite `4.13:5a` and
-  `9.2:7`,`9.2:10`–`9.2:13`, and remove/fold `9.2:14a`–`9.2:14f`; update
-  traceability.
-- [ ] **Phase 6: Stabilize and de-gate** — RUE-937. Per ADR-0005: remove
-  `preview =` from spec tests, remove the five `require_preview()` sites, remove
-  the `trusted_std_raw_bytes` carve-out and `PreviewFeature::RawBytes`, set this
-  ADR `implemented`.
+- [x] **Phase 5: Specification sweep** — RUE-963. Rewrote `4.13:5a` and
+  `9.2:7`, `9.2:10`–`9.2:13`, and updated traceability. The `9.2:14a`–`9.2:14f`
+  removal this phase was written to perform had already happened: Phase 3
+  restructured that range, and the `14d`/`14e`/`14f` deletion is recorded under
+  the `@byte_read`/`@byte_write` fold ruling below.
+- [x] **Phase 6: Stabilize and de-gate** — RUE-937. Landed in PR #1829, done
+  2026-07-20. Removed `preview =` from spec tests, the `require_preview()`
+  sites, the `trusted_std_raw_bytes` carve-out, and `PreviewFeature::RawBytes`.
+  This ADR's `status` and `implemented:` date follow that landing.
 
 ## Consequences
 
@@ -497,9 +511,10 @@ The proposal's open questions, settled by the 2026-07-17 ratification:
   no alias window, matching the `_bytes` allocator ruling above: `@byte_read` is
   now an unknown intrinsic (E0700). Spec rules `9.2:14d`/`14e`/`14f` are deleted
   and their coverage re-homed onto `9.2:6b`/`9.2:6d`.
-- **Null primitive: keep the `@int_to_ptr(0)` idiom.** A dedicated `@null_ptr`
+- **Null primitive: keep the `@int_to_ptr` idiom.** A dedicated `@null_ptr`
   acquires design questions (typed or untyped result?) better answered by the
-  future provenance work.
+  future provenance work. See the spelled-out form above: it needs a `checked`
+  block and a `u64`-typed zero.
 - **Aligned/unaligned spelling: Rust-style `_unaligned` intrinsics, with a
   Phase 4 checkpoint.** Type-carried `*align(N)` alignment (Zig model) changes
   only the access split — the allocator still passes alignment explicitly even
@@ -509,7 +524,9 @@ The proposal's open questions, settled by the 2026-07-17 ratification:
   Phase 4 explicitly re-evaluates `*align(N)` before implementing the
   intrinsics; a byte-granular `@ptr_offset` variant is likewise deferred to
   demonstrated need (element-scaled at `T = u8` covers byte walking
-  post-RUE-971).
+  post-RUE-971). **Checkpoint answered:** Phase 4 made the re-evaluation and
+  declined `*align(N)`, shipping the `_unaligned` pair. Type-carried alignment
+  remains open as its own design question on RUE-965, not as a debt of this ADR.
 
 ## Future Work
 

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -221,7 +221,7 @@ The table is generated from ADR frontmatter. Run
 | [0056](0056-typed-ir-payload-schemas.md) | Typed IR payload schemas | Implemented | architecture, compiler, ir, performance, validation |
 | [0057](0057-file-io-v0.md) | File IO v0: pure-Rue fs over @syscall with normalized FileError | Accepted | stdlib, io, syscalls, runtime, error-handling, ownership |
 | [0058](0058-canonical-semantic-artifact-algebra.md) | Canonical semantic artifact algebra | Accepted | architecture, compiler, incremental, semantics, validation |
-| [0059](0059-byte-oriented-memory-intrinsics.md) | Byte-oriented memory intrinsics: unify the two low-level families | Accepted | intrinsics, memory, pointers, allocator, bytes, semantics, stdlib, abi |
+| [0059](0059-byte-oriented-memory-intrinsics.md) | Byte-oriented memory intrinsics: unify the two low-level families | Implemented | intrinsics, memory, pointers, allocator, bytes, semantics, stdlib, abi |
 | [0060](0060-network-io-v1.md) | Network IO v1: blocking IPv4 TCP in pure Rue | Accepted | stdlib, io, networking, tcp, syscalls, error-handling, ownership |
 | [0061](0061-supported-compiler-facade.md) | Supported compiler facade and immutable artifact views | Accepted | architecture, compiler, tooling, api, incremental |
 | [0062](0062-place-returning-borrow-accessors.md) | Place-returning borrow accessors: projection reads of owned elements | Accepted | ownership, borrows, collections, accessors, stdlib, formal-semantics |

--- a/std/arraybuf.rue
+++ b/std/arraybuf.rue
@@ -74,9 +74,10 @@
 //     (a projection/yield accessor, Hylo-style) is the RUE-651 follow-up.
 //   * Multi-slot aggregate element types (e.g. a two-field struct) work as long
 //     as they are trivially droppable: every aggregate is laid out
-//     ascending-in-address and `@ptr_read`/`@ptr_write` walk slots upward from
-//     the element base, matching the ascending heap layout (ADR-0040 / RUE-311).
-//     Elements are transferred by copy.
+//     ascending-in-address, matching the ascending heap layout (ADR-0040 /
+//     RUE-311). Elements are transferred by copy. The typed reads and writes
+//     that rest on that layout live in `std/rawbuf.rue`; ADR-0059 folded the
+//     byte family in and this module no longer calls them.
 //
 // The enclosing element type `T` is usable throughout the method bodies below —
 // e.g. to name `option.Option(T)` and bind `let O = option.Option(T)` (RUE-313).


### PR DESCRIPTION
Comments, docs, and the generated ADR index. No code changes; Lattice emits byte-identical output.

## The record said "in progress"; every phase has shipped

RUE-937 (Phases 1 and 6), RUE-960 (2), RUE-961 (3), RUE-968 (3a), RUE-964 (3b), RUE-962 (4), RUE-963 (5) — all Done in Linear, all landed. Phases 1, 2, 5, and 6 are now checked with the PR that landed each, and two get a note rather than a bare tick:

- **Phase 2** shaped the interim `_bytes` allocator surface, which no longer exists — Phase 3 folded it away. What survives is the `(size, align)` contract it established, which the unified family carries.
- **Phase 5** was written to remove `9.2:14a`–`14f`. That had already happened: Phase 3 restructured the range, and the `14d`/`14e`/`14f` deletion is recorded under the `@byte_read`/`@byte_write` fold ruling. So the phase is complete but not in the way its own instructions describe.

Front matter moves to `status: implemented` with `implemented: 2026-07-20`, the date the Phase 6 de-gate (PR #1829) completed, and `spec-sections` carries the paragraphs Phase 5 rewrote. The generated index in `docs/designs/README.md` follows via `validate-adrs.py --write`.

Phase 4's checkbox was already ticked on trunk — that part of the issue is stale.

## The documented null idiom does not compile

The ADR gave `@int_to_ptr(0)` in three places. It fails **twice over**, both verified by execution:

```
error: [E1300]: raw-pointer intrinsic `@int_to_ptr` requires a `checked` block
error: [E0702]: intrinsic '@int_to_ptr' expects u64, found i32
```

The intrinsic is unchecked, so it needs a `checked` block, and it takes `u64`, which an untyped `0` literal is not. The issue reported only the E0702 half; the `checked` requirement has landed since it was filed. The working form is now in the ADR:

```rue
let zero: u64 = 0;
let null: ptr mut u8 = checked { @int_to_ptr(zero) };
```

which is what `std/fs.rue:1255` and `std/mem.rue:25` actually do.

## The `*align(N)` checkpoint is recorded as answered

Phase 4 required a re-evaluation of type-carried `*align(N)` before implementing the access split. It was made and declined, by shipping the `_unaligned` pair. That is now written down next to the ruling that deferred it, with type-carried alignment left open as RUE-965 rather than as an outstanding debt of this ADR.

## Stale comments

- `std/arraybuf.rue` still said `@ptr_read`/`@ptr_write` "walk slots upward" — slot language, and those calls moved to `std/rawbuf.rue` with the fold. The layout fact it rests on is still true, so the comment keeps it and points at the module that does the access.
- Three `rue-oracle` doc comments still named `@alloc_bytes`/`@realloc_bytes`, hard-removed in Phase 3.

## One item deliberately not done

`crates/rue-cli-tests/cases/raw_bytes_degate_readiness.toml` keeps its name. The issue suggested renaming or retiring it, but:

- its header already documents its current role — "retained after the RUE-987 layout flip as a standing behavior-preservation check" — so a reader is not actually misled;
- the case id is load-bearing for `shard-weights.json`, which keys ~6 entries on `cli.raw_bytes_degate_readiness::*`. A rename orphans those, and regenerating them wants real timing data.

The stale name costs less than that churn. Happy to rename it alongside a shard-weight regeneration if you'd rather.

`scripts/validate-adrs.py` and `scripts/validate-doc-links.py` clean, `scripts/rue unit oracle` 104/104, `scripts/rue quick` 30/30.

Fixes RUE-1332

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEt7kDT3SQnCVfGTnb8qP6)_