### PR TITLE
Resolve module and physical identities by index rather than by scan

### DIFF
--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -6,7 +6,7 @@
 //! never recognize imports or choose resolution precedence. Plans remain a
 //! whole-graph compatibility projection for diagnostics and closure.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
@@ -1753,17 +1753,19 @@ pub(crate) fn accepted_import_module(
     source: &AcceptedImportSource,
     accepted_reads: &AcceptedReadManifest,
 ) -> CompileResult<ModuleId> {
-    let mut matches = accepted_reads
-        .iter()
-        .filter(|entry| entry.metadata_identity() == source.metadata_identity());
-    let entry = matches.next().ok_or_else(|| {
-        invalid_input("accepted observation is absent from accepted read provenance")
-    })?;
-    if matches.next().is_some() {
-        return Err(invalid_input(
-            "accepted read manifest contains duplicate physical identities",
-        ));
-    }
+    let entry = match accepted_reads.lookup_physical_identity(source.metadata_identity()) {
+        ManifestIdentityLookup::Unique(entry) => entry,
+        ManifestIdentityLookup::Absent => {
+            return Err(invalid_input(
+                "accepted observation is absent from accepted read provenance",
+            ));
+        }
+        ManifestIdentityLookup::Duplicate => {
+            return Err(invalid_input(
+                "accepted read manifest contains duplicate physical identities",
+            ));
+        }
+    };
     validate_accepted_import_source(source, entry)
 }
 
@@ -1849,6 +1851,30 @@ pub struct AcceptedReadManifest {
     /// Lazily materialized merged slice for consumers that need `Arc<[T]>`
     /// (the compiler-owned staging boundary and retained artifacts).
     merged: Arc<std::sync::OnceLock<Arc<[AcceptedReadManifestEntry]>>>,
+    /// Lazily materialized inverse of the entry sequence: host-observed
+    /// physical identity to its entry's segment position. The sequence is
+    /// sorted by module identity, so a physical identity has no binary search;
+    /// authorizing a discovery batch asks this question once per accepted
+    /// observation, which is a scan of every entry per observation without an
+    /// index. Derived state: it never participates in equality, hashing, or
+    /// rendering, and clones share it because they are the same value.
+    by_physical_identity: Arc<std::sync::OnceLock<HashMap<PhysicalFileIdentity, IdentitySlot>>>,
+}
+
+/// Where one physical identity lives in a manifest's segmented entry sequence,
+/// or that the manifest names it more than once.
+#[derive(Debug, Clone, Copy)]
+enum IdentitySlot {
+    Unique { segment: u32, position: u32 },
+    Duplicate,
+}
+
+/// The outcome of resolving one host-observed physical identity against a
+/// manifest.
+pub(crate) enum ManifestIdentityLookup<'a> {
+    Absent,
+    Unique(&'a AcceptedReadManifestEntry),
+    Duplicate,
 }
 
 fn accepted_read_order(
@@ -1894,6 +1920,7 @@ impl AcceptedReadManifest {
                 accepted_read_order,
             ),
             merged: Arc::new(std::sync::OnceLock::new()),
+            by_physical_identity: Arc::new(std::sync::OnceLock::new()),
         }
     }
 
@@ -1907,6 +1934,7 @@ impl AcceptedReadManifest {
         Self {
             entries: crate::shared_segments::SharedSegments::flat(entries, accepted_read_order),
             merged: Arc::new(merged),
+            by_physical_identity: Arc::new(std::sync::OnceLock::new()),
         }
     }
 
@@ -1920,6 +1948,7 @@ impl AcceptedReadManifest {
         Self {
             entries: crate::shared_segments::SharedSegments::extend(&base.entries, appended),
             merged: Arc::new(std::sync::OnceLock::new()),
+            by_physical_identity: Arc::new(std::sync::OnceLock::new()),
         }
     }
 
@@ -1944,6 +1973,41 @@ impl AcceptedReadManifest {
     /// The provenance entry for `module`, by per-segment binary search.
     pub(crate) fn find_module(&self, module: &ModuleId) -> Option<&AcceptedReadManifestEntry> {
         self.entries.find_by(|entry| entry.module.cmp(module))
+    }
+
+    /// The entry a host-observed physical identity names, by one hash lookup
+    /// into the lazily materialized inverse index.
+    ///
+    /// A manifest that names the same physical file twice reports
+    /// [`ManifestIdentityLookup::Duplicate`] rather than picking a winner, so
+    /// the ambiguity still reaches the caller that must reject it.
+    pub(crate) fn lookup_physical_identity(
+        &self,
+        identity: PhysicalFileIdentity,
+    ) -> ManifestIdentityLookup<'_> {
+        let index = self.by_physical_identity.get_or_init(|| {
+            let mut index: HashMap<PhysicalFileIdentity, IdentitySlot> =
+                HashMap::with_capacity(self.entries.len());
+            for (segment, entries) in self.entries.segments().iter().enumerate() {
+                for (position, entry) in entries.iter().enumerate() {
+                    index
+                        .entry(entry.metadata_identity)
+                        .and_modify(|slot| *slot = IdentitySlot::Duplicate)
+                        .or_insert(IdentitySlot::Unique {
+                            segment: segment as u32,
+                            position: position as u32,
+                        });
+                }
+            }
+            index
+        });
+        match index.get(&identity) {
+            None => ManifestIdentityLookup::Absent,
+            Some(IdentitySlot::Duplicate) => ManifestIdentityLookup::Duplicate,
+            Some(IdentitySlot::Unique { segment, position }) => ManifestIdentityLookup::Unique(
+                &self.entries.segments()[*segment as usize][*position as usize],
+            ),
+        }
     }
 
     /// Whether `entry` appears byte-identical in this manifest.
@@ -2677,6 +2741,54 @@ mod tests {
                 content_fingerprint: source_fingerprint(source.source),
             })
             .collect()
+    }
+
+    #[test]
+    fn physical_identity_lookup_matches_a_scan_across_compacted_segments() {
+        let entry = |index: u64, identity: u64| AcceptedReadManifestEntry {
+            module: ModuleId::from_logical_path(format!("module_{index:04}.rue")).unwrap(),
+            requested_path: Arc::from(format!("/project/module_{index:04}.rue").as_str()),
+            canonical_path: Arc::from(format!("/project/module_{index:04}.rue").as_str()),
+            metadata_identity: PhysicalFileIdentity::new(1, identity),
+            metadata_fingerprint: metadata_fingerprint(),
+            content_fingerprint: index,
+        };
+
+        // One-entry additive rounds. The entry count is deliberately not a
+        // power of two, so size-tiered compaction leaves the sequence spread
+        // over several segments rather than one flat tier.
+        const ENTRIES: u64 = 100;
+        let mut manifest = AcceptedReadManifest::from_entries(vec![entry(0, 0)]);
+        for index in 1..ENTRIES {
+            manifest =
+                AcceptedReadManifest::extend_with_appended(&manifest, vec![entry(index, index)]);
+        }
+        assert!(manifest.segments().segments().len() > 1);
+
+        for index in 0..ENTRIES {
+            let identity = PhysicalFileIdentity::new(1, index);
+            let scanned = manifest
+                .iter()
+                .filter(|candidate| candidate.metadata_identity() == identity)
+                .collect::<Vec<_>>();
+            assert_eq!(scanned.len(), 1);
+            match manifest.lookup_physical_identity(identity) {
+                ManifestIdentityLookup::Unique(found) => assert_eq!(found, scanned[0]),
+                _ => panic!("module {index} resolves to exactly one entry"),
+            }
+        }
+        assert!(matches!(
+            manifest.lookup_physical_identity(PhysicalFileIdentity::new(9, 9)),
+            ManifestIdentityLookup::Absent
+        ));
+
+        // Two modules naming one physical file stay an ambiguity the caller
+        // rejects rather than a silently chosen winner.
+        let ambiguous = AcceptedReadManifest::from_entries(vec![entry(0, 7), entry(1, 7)]);
+        assert!(matches!(
+            ambiguous.lookup_physical_identity(PhysicalFileIdentity::new(1, 7)),
+            ManifestIdentityLookup::Duplicate
+        ));
     }
 
     fn indexed_test_request(occurrence_index: u32, position: u32) -> ImportDiscoveryRequest {

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -1423,15 +1423,11 @@ pub(crate) fn parse_source_snapshot_module(
     snapshot: &SourceSnapshot,
     module: &ModuleId,
 ) -> (Result<Arc<ParsedModule>, CompileErrors>, SyntaxWork) {
-    let file_id = snapshot
-        .metadata()
-        .file_ids()
-        .find(|file_id| snapshot.module_id(*file_id) == Some(module))
-        .ok_or_else(|| {
-            CompileErrors::from(invalid_input(format!(
-                "source snapshot contains no module {module}"
-            )))
-        });
+    let file_id = snapshot.file_id_for_module(module).ok_or_else(|| {
+        CompileErrors::from(invalid_input(format!(
+            "source snapshot contains no module {module}"
+        )))
+    });
     match file_id {
         Ok(file_id) => parse_snapshot_file(snapshot, file_id),
         Err(errors) => (Err(errors), SyntaxWork::default()),
@@ -1473,9 +1469,7 @@ pub(crate) fn rebind_parsed_module(
     module: &Arc<ParsedModule>,
 ) -> Arc<ParsedModule> {
     let file_id = snapshot
-        .metadata()
-        .file_ids()
-        .find(|file_id| snapshot.module_id(*file_id) == Some(module.module_id()))
+        .file_id_for_module(module.module_id())
         .expect("parsed module belongs to the projected source snapshot");
     if module.file_id() == file_id
         && module.physical_path()

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -20272,10 +20272,7 @@ impl RevisionedQueryDatabase {
             work.modules_considered += 1;
             work.previous_module_lookups += 1;
             let current_file_id = snapshot
-                .files()
-                .find_map(|source| {
-                    (snapshot.module_id(source.file_id) == Some(&module)).then_some(source.file_id)
-                })
+                .file_id_for_module(&module)
                 .expect("parse demand belongs to the published source revision");
             let attempt = self.runtime.request_registered(
                 &self.parse_modules,

--- a/crates/rue-compiler/src/source_snapshot.rs
+++ b/crates/rue-compiler/src/source_snapshot.rs
@@ -56,6 +56,12 @@ struct SnapshotSegment {
     contents: Vec<SourceRecord>,
     /// Position within THIS segment for each of its file ids.
     index: HashMap<FileId, usize>,
+    /// Position within THIS segment for each of its module identities. A
+    /// snapshot binds each module to exactly one file, so resolving a module to
+    /// its file is a per-segment hash lookup instead of a scan of every file.
+    /// Where a segment somehow held one module twice, the lowest file id wins,
+    /// matching what an ascending scan of the metadata's file ids would find.
+    module_index: HashMap<ModuleId, usize>,
     min_file_index: u32,
     max_file_index: u32,
 }
@@ -77,9 +83,23 @@ impl SnapshotSegment {
             .enumerate()
             .map(|(index, record)| (record.file_id, index))
             .collect();
+        let mut module_index = HashMap::with_capacity(contents.len());
+        for (position, record) in contents.iter().enumerate() {
+            match module_index.entry(record.module_id.clone()) {
+                std::collections::hash_map::Entry::Vacant(slot) => {
+                    slot.insert(position);
+                }
+                std::collections::hash_map::Entry::Occupied(mut slot) => {
+                    if record.file_id.index() < contents[*slot.get()].file_id.index() {
+                        slot.insert(position);
+                    }
+                }
+            }
+        }
         Self {
             contents,
             index,
+            module_index,
             min_file_index,
             max_file_index,
         }
@@ -408,6 +428,25 @@ impl SourceSnapshot {
     /// Canonical logical module identity for a request-local file.
     pub fn module_id(&self, file_id: FileId) -> Option<&ModuleId> {
         self.record(file_id).map(|record| &record.module_id)
+    }
+
+    /// The file this snapshot binds `module` to.
+    ///
+    /// A snapshot's [`SourceRevision`] rejects duplicate module identities, so
+    /// this inverse is a function. Segments hold disjoint ascending file-id
+    /// ranges, so the oldest segment carrying the module also holds its lowest
+    /// file id: the answer is exactly the one an ascending scan of the
+    /// metadata's file ids would find, at O(segments) hash lookups instead of
+    /// O(files) record lookups. Projecting a whole program is one such lookup
+    /// per module, which is where the difference between linear and quadratic
+    /// lives for a deep import chain.
+    pub(crate) fn file_id_for_module(&self, module: &ModuleId) -> Option<FileId> {
+        self.data.segments.iter().find_map(|segment| {
+            segment
+                .module_index
+                .get(module)
+                .map(|&position| segment.contents[position].file_id)
+        })
     }
 
     /// Load-order-independent root and module/content mapping.
@@ -911,6 +950,32 @@ mod tests {
                 .expect("the deepest module is present")
                 .file_id,
             FileId::new(DEPTH)
+        );
+
+        // The per-segment module index answers exactly what an ascending scan
+        // of the metadata's file ids answers, for every module and across every
+        // compacted tier.
+        for (position, file_id) in snapshot.metadata().file_ids().enumerate() {
+            let module = snapshot
+                .module_id(file_id)
+                .expect("every snapshot file has a module identity")
+                .clone();
+            assert_eq!(snapshot.file_id_for_module(&module), Some(file_id));
+            // The scan this replaces is quadratic, so compare against it on a
+            // sample rather than on every module.
+            if position % 64 == 0 {
+                let scanned = snapshot
+                    .metadata()
+                    .file_ids()
+                    .find(|candidate| snapshot.module_id(*candidate) == Some(&module));
+                assert_eq!(snapshot.file_id_for_module(&module), scanned);
+            }
+        }
+        assert_eq!(
+            snapshot.file_id_for_module(
+                &crate::ModuleId::from_logical_path("absent.rue").expect("valid module path")
+            ),
+            None
         );
     }
 


### PR DESCRIPTION
Measurement-first fix of the remaining deep-chain superlinearity. 4 files, +196/−28.

## The re-measurement first (the brief's suspects were stale)

The four sites indicted by the 2026-08-16 instrumentation (`CompilerSessionMetrics::synchronize`, `DiagnosticAttemptStore::find_exact`, `SourceSnapshot::walk_retained_charge`, `request_parse` bookkeeping) are **all linear and negligible on current trunk** — wave-granular discovery collapsed the round count their multipliers depended on (e.g. the snapshot first-charge is now 79k of 2.9G instructions, scaling 3.96× per 4× n). An incremental retained charge remains possible but unjustified; not shipped.

The fresh callgrind profile at n=256 vs n=1024 indicted two genuinely quadratic scans instead, together **27% of the n=1024 build**:

1. **Module → file resolution**: `parse_program`, `rebind_parsed_module`, and `parse_source_snapshot_module` each walked every file in the snapshot per module (2.13M `SourceSnapshot::record` calls, 526k `physical_path` calls at n=1024).
2. **Physical identity → manifest entry**: `accepted_import_module` walked all accepted-read entries per accepted observation (3.15M merge-iterator steps) — the manifest is sorted by module identity, not physical identity.

## The fix

Snapshot segments carry a `module_index` beside the existing file-id index (`SourceSnapshot::file_id_for_module`); `AcceptedReadManifest` materializes an inverse physical-identity index on first use. Both return exactly what the scans returned — segments hold disjoint ascending file-id ranges so the oldest segment carrying a module yields its lowest file id, and duplicated physical identities still report ambiguity rather than picking a winner. Tests pin both scan-equivalences across compacted size tiers.

## Scaling (callgrind Ir, n=256 → n=1024 ratio)

| Site | before | after |
|---|---|---|
| **Total instructions** | 5.10× | **3.97×** (n=1024 total −29.3%) |
| `SourceSnapshot::record` | 15.33× | 3.99× |
| `parse_program` | 15.71× | 3.93× |
| `accepted_import_module` | 15.37× | 4.00× |
| `rebind_parsed_module` | 15.74× | 3.99× |

Wall clock (min-of-9 interleaved on a contended host): `source_loading` −38% at n=1024, `import_parse_staging` −44%, `parse_program` −90%. On this branch after rebase onto the just-merged discovery-witness change: **chain1024 root 656ms / discovery 182ms** (was 14.1s / ~12.5s when this campaign started).

## Gates

- Executables byte-identical at `-j1` and `-j4` on Lattice, Mosaic, chain256, chain1024 (8/8 hashes); Lattice re-verified independently on this branch post-rebase (`b893e76c…85e5`).
- All 136 `compiler_work` counters byte-identical at `-j1` on all four workloads; `-j4` differs only in the known scheduling-variant set, verified identical-variance on the baseline binary.
- Suites: quick 30/30, compiler 898/898 (re-run on this branch post-rebase), rue-query, driver, CLI 1,892/0; fmt + clippy clean.
- Remaining scaling tops out at ~5× for BTreeMap comparisons (n·log n, expected); the one noted outlier for future work is `rue_query::Task::observe_handoff` at 7.2× (0.2% of the build).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTiBg7df72iMgdpAFv5wZs)_