### PR TITLE
Render shared-space spellings once per revision

### DIFF
--- a/crates/rue-air/src/sema/anon_structs.rs
+++ b/crates/rue-air/src/sema/anon_structs.rs
@@ -41,6 +41,28 @@ pub(crate) type IssuedCanonicalArguments =
 pub(crate) type IssuedStableProducerId =
     crate::StableProducerId<crate::SemanticDefinitionToken, crate::SemanticModuleToken>;
 
+/// The one spelling of a generated anonymous struct's name.
+///
+/// The name is a total function of the producer digest and nothing else, which
+/// is what lets a whole revision share one rendering of it, and what makes the
+/// pool's anonymity registry rather than the name the authority for whether a
+/// struct is generated (RUE-1050, RUE-1193). Both mints — the producer-nominal
+/// pool and the import epoch it byte-mirrors — spell it here, so the two cannot
+/// drift apart (RUE-1236).
+pub(crate) fn anonymous_struct_name(digest: u128) -> String {
+    format!("__anon_struct_{digest:032x}")
+}
+
+/// The one spelling of the prefix an anonymous enum's name opens with, before
+/// its variants and their rendered payloads.
+///
+/// Only the prefix is a function of the digest; the rest of the name renders
+/// the variants through the minting pool, so the whole name is not shareable
+/// the way [`anonymous_struct_name`] is.
+pub(crate) fn anonymous_enum_name_prefix(digest: u128) -> String {
+    format!("__anon_enum_{digest:032x} {{ ")
+}
+
 /// The root source definition a producer-nominal key ultimately derives from,
 /// unwinding function specializations, anonymous members, and drop glue down to
 /// the owning definition token. `None` for a producer with no source definition

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -375,7 +375,12 @@ enum PoolNominal {
 pub(in crate::sema) struct BodyIdentityPool<K, M, S> {
     type_pool: Rc<TypeInternPool>,
     /// The revision-shared equality space (ADR-0076 §1). Strings are interned
-    /// once per revision generation, not once per body.
+    /// once per revision generation, not once per body, and the generation's
+    /// spelling memos let the names that feed those interner calls be rendered
+    /// once per revision too.
+    space: SharedSymbolSpace,
+    /// The generation's interner, held directly because every mint reaches for
+    /// it.
     interner: Arc<ThreadedRodeo>,
     source: S,
     struct_ids: AHashMap<K, StructId>,
@@ -571,20 +576,12 @@ where
     /// Create the single identity universe for one provider-driven body over
     /// its own private symbol space.
     pub fn new(source: S) -> Self {
-        Self::with_interner_mode(
-            source,
-            Arc::clone(SharedSymbolSpace::private().interner()),
-            false,
-        )
+        Self::with_space_mode(source, SharedSymbolSpace::private(), false)
     }
 
-    fn with_interner_mode(
-        source: S,
-        interner: Arc<ThreadedRodeo>,
-        allow_post_seal_overlay: bool,
-    ) -> Self {
+    fn with_space_mode(source: S, space: SharedSymbolSpace, allow_post_seal_overlay: bool) -> Self {
         Self {
-            pool: Rc::new(RefCell::new(BodyIdentityPool::new(source, interner))),
+            pool: Rc::new(RefCell::new(BodyIdentityPool::new(source, space))),
             modules: Rc::new(RefCell::new(ProviderModuleRegistry::default())),
             methods: Rc::new(RefCell::new(ProviderMethodRegistry::default())),
             frozen: Rc::new(Cell::new(false)),
@@ -742,8 +739,7 @@ where
     S: DurableNominalSource<K, M>,
 {
     pub fn new(source: S, space: SharedSymbolSpace) -> Self {
-        let identity =
-            ProviderIdentityContext::with_interner_mode(source, Arc::clone(space.interner()), true);
+        let identity = ProviderIdentityContext::with_space_mode(source, space.clone(), true);
         let type_pool = identity.type_pool();
         Self {
             identity,
@@ -889,7 +885,8 @@ where
 {
     /// Create an empty pool with the builtin enums and the core `str` identity
     /// pre-registered, mirroring a fresh import epoch.
-    pub(in crate::sema) fn new(source: S, interner: Arc<ThreadedRodeo>) -> Self {
+    pub(in crate::sema) fn new(source: S, space: SharedSymbolSpace) -> Self {
+        let interner = Arc::clone(space.interner());
         let type_pool = Rc::new(TypeInternPool::new());
         let mut builtins = AHashMap::new();
 
@@ -945,6 +942,7 @@ where
 
         Self {
             type_pool,
+            space,
             interner,
             source,
             struct_ids: AHashMap::new(),
@@ -1633,6 +1631,11 @@ where
 /// destructor (RUE-312); mirrored from the epoch's `find_or_create_anon_struct`.
 const ANON_DROP_METHOD: &str = "__drop";
 
+/// Which name derived from an anonymous nominal's digest a generation's
+/// spelling memo holds: the nominal's own, or its destructor's.
+const ANON_NAME_SPELLING: u8 = 0;
+const ANON_DESTRUCTOR_SPELLING: u8 = 1;
+
 impl<K, M, S> BodyIdentityPool<K, M, S>
 where
     K: Clone + Eq + Hash,
@@ -1979,12 +1982,23 @@ where
         fields: &[(Arc<str>, SemanticImportType<K, M>)],
         method_names: &[Arc<str>],
     ) -> Result<Type, IdentityMintError> {
-        let name: Arc<str> = Arc::from(format!("__anon_struct_{digest:032x}").as_str());
-        let symbol = self.interner.get_or_intern(&name);
+        // Both spellings are a total function of the digest, so the generation
+        // renders and interns each once instead of once per body that mints
+        // this nominal — a hundred-fold redundancy on programs with a shared
+        // anonymous closure (ADR-0076).
+        let (name, symbol) = self
+            .space
+            .keyed_symbol_spelling(digest, ANON_NAME_SPELLING, || {
+                super::anon_structs::anonymous_struct_name(digest)
+            });
         let has_destructor = method_names
             .iter()
             .any(|method| method.as_ref() == ANON_DROP_METHOD);
-        let destructor = has_destructor.then(|| Arc::from(format!("{name}.__drop").as_str()));
+        let destructor = has_destructor.then(|| {
+            self.space.keyed_name(digest, ANON_DESTRUCTOR_SPELLING, || {
+                format!("{name}.__drop")
+            })
+        });
 
         // Declare the shell before resolving fields so a field that points back
         // at this nominal resolves the recursive reference to the shell id — the
@@ -2062,7 +2076,7 @@ where
             variant_payloads.push(resolved);
         }
 
-        let mut name = format!("__anon_enum_{digest:032x} {{ ");
+        let mut name = super::anon_structs::anonymous_enum_name_prefix(digest);
         for (i, vname) in variant_names.iter().enumerate() {
             if i > 0 {
                 name.push_str(", ");
@@ -2892,7 +2906,7 @@ impl BodyRirBundle {
         M: Eq + Hash,
         S: DurableNominalSource<K, M>,
     {
-        ProviderIdentityContext::with_interner_mode(source, self.shared_interner(), false)
+        ProviderIdentityContext::with_space_mode(source, self.space.clone(), false)
     }
 
     pub fn provider_body_state<K, M, S>(&self, source: S) -> ProviderBodyAnalysisState<K, M, S>
@@ -3497,7 +3511,7 @@ mod tests {
     fn pool(
         nominals: impl IntoIterator<Item = (Key, DurableNominal<Key, Module>)>,
     ) -> BodyIdentityPool<Key, Module, MapSource> {
-        BodyIdentityPool::new(source(nominals), Arc::new(ThreadedRodeo::new()))
+        BodyIdentityPool::new(source(nominals), SharedSymbolSpace::private())
     }
 
     /// A pool seeded with nominals, functions, and methods for the callable
@@ -3518,7 +3532,7 @@ mod tests {
                 anonymous_shapes: AHashMap::new(),
                 def_component_overrides: AHashMap::new(),
             },
-            Arc::new(ThreadedRodeo::new()),
+            SharedSymbolSpace::private(),
         )
     }
 
@@ -3538,7 +3552,7 @@ mod tests {
                 anonymous_shapes: AHashMap::new(),
                 def_component_overrides: AHashMap::new(),
             },
-            Arc::new(ThreadedRodeo::new()),
+            SharedSymbolSpace::private(),
         )
     }
 
@@ -3560,7 +3574,7 @@ mod tests {
                 anonymous_shapes: anonymous_shapes.into_iter().collect(),
                 def_component_overrides: def_component_overrides.into_iter().collect(),
             },
-            Arc::new(ThreadedRodeo::new()),
+            SharedSymbolSpace::private(),
         )
     }
 
@@ -5349,7 +5363,7 @@ mod tests {
             .step_by(2)
             .map(|key| (key, FileId::new(key + 1)))
             .collect();
-        let mut pool = BodyIdentityPool::new(provider, Arc::new(ThreadedRodeo::new()));
+        let mut pool = BodyIdentityPool::new(provider, SharedSymbolSpace::private());
 
         for key in 0..MODULES {
             let ty = pool.resolve_provider_type(&DType::Nominal(key)).unwrap();
@@ -5399,7 +5413,7 @@ mod tests {
             ),
         ]);
         provider.nominal_file_ids = AHashMap::from([(0, FileId::new(41)), (1, FileId::new(41))]);
-        let mut pool = BodyIdentityPool::new(provider, Arc::new(ThreadedRodeo::new()));
+        let mut pool = BodyIdentityPool::new(provider, SharedSymbolSpace::private());
 
         pool.resolve_provider_type(&DType::Nominal(0)).unwrap();
         assert_eq!(
@@ -5606,7 +5620,7 @@ mod tests {
         supplied_source.functions.insert(0, function.clone());
         supplied_source.function_reads = Rc::clone(&supplied_reads);
         let mut supplied_pool =
-            BodyIdentityPool::new(supplied_source, Arc::new(ThreadedRodeo::new()));
+            BodyIdentityPool::new(supplied_source, SharedSymbolSpace::private());
         let first = supplied_pool
             .resolve_function_call_from(&0, &function, returns_type, file)
             .unwrap();
@@ -5629,7 +5643,7 @@ mod tests {
         ordinary_source.functions.insert(0, function);
         ordinary_source.function_reads = Rc::clone(&ordinary_reads);
         let mut ordinary_pool =
-            BodyIdentityPool::new(ordinary_source, Arc::new(ThreadedRodeo::new()));
+            BodyIdentityPool::new(ordinary_source, SharedSymbolSpace::private());
         let ordinary = ordinary_pool
             .resolve_function_call(&0, returns_type, file)
             .unwrap();
@@ -5676,7 +5690,7 @@ mod tests {
         let mut durable_source = source([]);
         durable_source.functions.insert(0, broken.clone());
         durable_source.function_reads = Rc::clone(&reads);
-        let mut pool = BodyIdentityPool::new(durable_source, Arc::new(ThreadedRodeo::new()));
+        let mut pool = BodyIdentityPool::new(durable_source, SharedSymbolSpace::private());
         let returns_type = false;
         let file = FileId::new(19);
 

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -1090,7 +1090,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         let digest = self.stable_anonymous_identity_digest(&identity);
         self.guard_anonymous_digest_collision(digest, &identity)?;
         let id = self.storage.body_type_pool().reserve_struct_id();
-        let name = format!("__anon_struct_{digest:032x}");
+        let name = super::anon_structs::anonymous_struct_name(digest);
         let name_spur = self.storage.body_interner().get_or_intern(&name);
         let drop_marker = self.storage.body_interner().get_or_intern("__drop");
         let has_destructor = sigs.iter().any(|sig| sig.name == drop_marker);
@@ -1146,7 +1146,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         }
         let digest = self.stable_anonymous_identity_digest(&identity);
         self.guard_anonymous_digest_collision(digest, &identity)?;
-        let mut name = format!("__anon_enum_{digest:032x} {{ ");
+        let mut name = super::anon_structs::anonymous_enum_name_prefix(digest);
         for (index, variant) in names.iter().enumerate() {
             if index > 0 {
                 name.push_str(", ");

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -1620,6 +1620,54 @@ where
             .get_or_intern(member_callable_name_for_owner(owner, method, has_self))
     }
 
+    /// The handle for a member callable of an owner whose own spelling the
+    /// shared space has already issued a handle for.
+    ///
+    /// Sharing the symbol space (ADR-0076) made the interner call a lookup
+    /// rather than an insertion, but a lookup still needs the rendered text, so
+    /// every body that mentions an owner re-rendered and re-hashed the same
+    /// fifty-character member name. The join is a total function of the owner
+    /// spelling, the member spelling, and the separator, so the generation's
+    /// derived-spelling memo holds that association and only the first body to
+    /// spell a member renders it.
+    ///
+    /// `owner_symbol` and `method_symbol` are the handles the space already
+    /// issued for the two components. A caller without an owner handle falls
+    /// back to rendering, which is what
+    /// [`Self::member_callable_symbol_for_owner`] has always done — both arms
+    /// spell through [`member_callable_name_for_owner`], the one renderer
+    /// (RUE-1236).
+    fn member_callable_symbol_for_issued_owner(
+        &self,
+        owner_symbol: Option<Spur>,
+        owner: &str,
+        method_symbol: Spur,
+        method: &str,
+        has_self: bool,
+    ) -> Spur {
+        let Some(owner_symbol) = owner_symbol else {
+            return self.member_callable_symbol_for_owner(owner, method, has_self);
+        };
+        self.state.symbol_space().derived_symbol(
+            owner_symbol,
+            method_symbol,
+            u8::from(has_self),
+            || member_callable_name_for_owner(owner, method, has_self),
+        )
+    }
+
+    /// The handle the shared space already holds for an owner's own spelling,
+    /// which is what keys its members' derived spellings.
+    ///
+    /// This is deliberately a lookup and never an insertion: the retention
+    /// counters are read from the interner's length and byte count, so a
+    /// spelling the unmemoized path never interned must not appear because the
+    /// memo wanted a key. An owner that is not already interned simply takes
+    /// the rendering path.
+    fn member_callable_owner_symbol(&self, owner: &str) -> Option<Spur> {
+        self.interner.get(owner)
+    }
+
     fn named_method_info_for_symbol(
         &self,
         struct_id: StructId,
@@ -2597,6 +2645,7 @@ where
         let mut infos = Vec::with_capacity(methods.len());
         let mut signatures = Vec::with_capacity(methods.len());
         let owner_name = self.member_callable_owner(struct_id);
+        let owner_symbol = self.member_callable_owner_symbol(&owner_name);
         for method in methods {
             let resolve = |ty: &crate::DurableAnonymousMethodType<K, M>| {
                 Some(match ty {
@@ -2616,8 +2665,13 @@ where
                 .collect::<Option<Vec<_>>>()?;
             let return_type = resolve(&method.result)?;
             let name = self.interner.get_or_intern(method.name.as_ref());
-            let callable =
-                self.member_callable_symbol_for_owner(&owner_name, &method.name, method.has_self);
+            let callable = self.member_callable_symbol_for_issued_owner(
+                owner_symbol,
+                &owner_name,
+                name,
+                &method.name,
+                method.has_self,
+            );
             let kind = if method.name.as_ref() == "__drop" {
                 crate::AnonymousMemberKind::Destructor
             } else if method.has_self {
@@ -2745,10 +2799,16 @@ where
             return Some(());
         }
         let owner_name = self.member_callable_owner(struct_id);
+        let owner_symbol = self.member_callable_owner_symbol(&owner_name);
         for method in methods {
             let name = self.interner.get_or_intern(method.name.as_ref());
-            let callable =
-                self.member_callable_symbol_for_owner(&owner_name, &method.name, method.has_self);
+            let callable = self.member_callable_symbol_for_issued_owner(
+                owner_symbol,
+                &owner_name,
+                name,
+                &method.name,
+                method.has_self,
+            );
             let kind = if method.name.as_ref() == "__drop" {
                 crate::AnonymousMemberKind::Destructor
             } else if method.has_self {

--- a/crates/rue-rir/src/symbol.rs
+++ b/crates/rue-rir/src/symbol.rs
@@ -36,10 +36,31 @@
 //!   and body-local; a body decodes them into shared handles through a dense
 //!   remap built once per materialization. The dense space holds that remap
 //!   only — it never re-interns the strings.
+//!
+//! # Spelling memos
+//!
+//! Sharing the equality space turned a per-body insertion into a per-body
+//! lookup, but a lookup still needs the rendered text, so the names that feed
+//! those lookups were still rendered once per body that mentioned them. Two
+//! families of them are a total function of data that does not vary across the
+//! generation's bodies, so the generation memoizes them:
+//!
+//! - a name joined from names the space has already interned — `Owner.method`,
+//!   `Owner::method` — is a function of the two component handles and the
+//!   separator ([`SharedSymbolSpace::derived_symbol`]);
+//! - a generated anonymous nominal's name and its destructor's are a function
+//!   of the nominal's producer digest
+//!   ([`SharedSymbolSpace::keyed_symbol_spelling`],
+//!   [`SharedSymbolSpace::keyed_name`]).
+//!
+//! Only the first body to need a spelling renders it. The memos hold no
+//! authority over how a name is spelled: each caller passes its own renderer,
+//! which stays the one place that form is spelled (RUE-1236).
 
+use ahash::AHashMap;
 use lasso::{Key, Spur, ThreadedRodeo};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, PoisonError, RwLock};
 
 /// An equality-only handle into one body's symbol interner.
 ///
@@ -92,6 +113,96 @@ pub struct SharedSymbolSpace {
     interner: Arc<ThreadedRodeo>,
     generation: u64,
     live: Arc<AtomicBool>,
+    spellings: Arc<Spellings>,
+}
+
+/// How many shards a spelling memo is split across.
+///
+/// Sharded because every body of a revision reads these memos while the writes
+/// are the program's distinct spellings — a few hundred against tens of
+/// thousands of reads on the reference workloads — so one lock word would
+/// bounce between workers for no reason.
+const SPELLING_SHARDS: usize = 16;
+
+/// The two component handles and the join variant a derived spelling is built
+/// from.
+///
+/// The handles are used for equality and hashing only, which is what ADR-0076
+/// §2 leaves a handle: the memo is process-local scratch inside one generation,
+/// never an order, never a published datum, and never an emitted byte.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct DerivedKey {
+    left: Spur,
+    right: Spur,
+    variant: u8,
+}
+
+/// The generation's spelling memos: names joined from interned components, and
+/// names that are a total function of a 128-bit identity digest.
+#[derive(Debug, Default)]
+struct Spellings {
+    derived: Sharded<DerivedKey, Spur>,
+    /// Digest-keyed names the space also holds a handle for.
+    keyed_symbols: Sharded<(u128, u8), (Arc<str>, Spur)>,
+    /// Digest-keyed names that are text only. Kept apart from the interned
+    /// ones so a name the unmemoized path never interned cannot reach the
+    /// interner through a shared entry, which the retention counters read from
+    /// the interner would see.
+    keyed_names: Sharded<(u128, u8), Arc<str>>,
+}
+
+/// A sharded, append-only memo for one generation's spellings.
+#[derive(Debug)]
+struct Sharded<K, V> {
+    shards: [RwLock<AHashMap<K, V>>; SPELLING_SHARDS],
+}
+
+impl<K, V> Sharded<K, V>
+where
+    K: Eq + std::hash::Hash,
+    V: Clone,
+{
+    /// The memoized value for `key`, rendering it with `render` on a miss.
+    ///
+    /// `shard` is the caller's mixing of the key, because what mixes a key well
+    /// depends on the key; it must be a function of `key` alone, or one key
+    /// lands in two shards and the memo silently stops sharing.
+    ///
+    /// `render` runs without the shard lock held, because rendering a spelling
+    /// interns it and the interner takes locks of its own. Two workers can
+    /// therefore both miss and both render; they render the same text, so the
+    /// interner answers both with the same handle and the second write replaces
+    /// an equal entry.
+    fn memoize(&self, shard: usize, key: K, render: impl FnOnce() -> V) -> V {
+        let shard = &self.shards[shard % SPELLING_SHARDS];
+        if let Some(value) = shard
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(&key)
+        {
+            return value.clone();
+        }
+        let value = render();
+        shard
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+            .insert(key, value.clone());
+        value
+    }
+}
+
+/// A digest-keyed memo's shard. The digest is already a hash, so its low bits
+/// choose the lock; the choice is never an order (ADR-0076 §2).
+fn keyed_shard(digest: u128, variant: u8) -> usize {
+    (digest as usize).wrapping_add(usize::from(variant))
+}
+
+impl<K, V> Default for Sharded<K, V> {
+    fn default() -> Self {
+        Self {
+            shards: std::array::from_fn(|_| RwLock::new(AHashMap::new())),
+        }
+    }
 }
 
 impl SharedSymbolSpace {
@@ -113,6 +224,7 @@ impl SharedSymbolSpace {
             interner,
             generation: 1,
             live: Arc::new(AtomicBool::new(true)),
+            spellings: Arc::new(Spellings::default()),
         }
     }
 
@@ -121,6 +233,104 @@ impl SharedSymbolSpace {
     #[must_use]
     pub fn interner(&self) -> &Arc<ThreadedRodeo> {
         &self.interner
+    }
+
+    /// The handle for a spelling joined from two spellings this space already
+    /// issued handles for, rendering it at most once per generation.
+    ///
+    /// `render` is the caller's single spelling authority for the joined form
+    /// (RUE-1236); this method decides how often it runs, never how it spells.
+    /// `variant` distinguishes joins of the same two components that render
+    /// differently — the `.` and `::` member separators.
+    ///
+    /// The memoized association is exactly the one `get_or_intern(render())`
+    /// would produce: within a generation, equal component handles mean equal
+    /// component text, so the rendered text and therefore the issued handle are
+    /// the same for every caller. A miss renders and interns, so the set of
+    /// interned strings — and the retention counters read from it — is what it
+    /// would have been without the memo; a hit only skips re-deriving a string
+    /// the interner already holds. Racing misses render twice and intern the
+    /// same text, which the interner answers with the same handle.
+    ///
+    /// The memo lives inside the generation, so ADR-0076 §4 governs it
+    /// unchanged: it is append-only for the generation's life, it never
+    /// outlives it, and a body carrying a retired generation is refused at the
+    /// authority check rather than reading a stale association.
+    pub fn derived_symbol(
+        &self,
+        left: Spur,
+        right: Spur,
+        variant: u8,
+        render: impl FnOnce() -> String,
+    ) -> Spur {
+        let key = DerivedKey {
+            left,
+            right,
+            variant,
+        };
+        // The handles' ordinals inside the issuing interner are a dense
+        // counter, so mixing the two components spreads consecutive members of
+        // one owner across shards. This is a shard choice, never an order
+        // (ADR-0076 §2): a different assignment changes only which lock is
+        // taken.
+        let shard =
+            (left.into_usize() ^ (right.into_usize() << 2)).wrapping_add(usize::from(variant));
+        self.spellings
+            .derived
+            .memoize(shard, key, || self.interner.get_or_intern(render()))
+    }
+
+    /// The spelling for a name that is a total function of a 128-bit identity
+    /// digest, rendered at most once per generation, with the handle the space
+    /// issued for it.
+    ///
+    /// Generated anonymous nominals are named after their producer digest, so
+    /// every body that mints one re-derives a name it shares with every other
+    /// body that mints the same nominal — a hundred-fold redundancy on the
+    /// reference workloads. `variant` separates names derived from one digest:
+    /// the nominal's own spelling and its destructor's.
+    ///
+    /// `render` is the caller's single spelling authority (RUE-1236) and must
+    /// depend on nothing but the digest, which is what makes the association
+    /// stable across the generation's bodies. Everything the memo promises
+    /// about interning and retirement is [`Self::derived_symbol`]'s promise,
+    /// for the same reasons.
+    pub fn keyed_symbol_spelling(
+        &self,
+        digest: u128,
+        variant: u8,
+        render: impl FnOnce() -> String,
+    ) -> (Arc<str>, Spur) {
+        self.spellings.keyed_symbols.memoize(
+            keyed_shard(digest, variant),
+            (digest, variant),
+            || {
+                let name: Arc<str> = Arc::from(render().as_str());
+                let symbol = self.interner.get_or_intern(&name);
+                (name, symbol)
+            },
+        )
+    }
+
+    /// The spelling for a digest-derived name the caller does not intern.
+    ///
+    /// [`Self::keyed_symbol_spelling`] without the interner call, for a name
+    /// that is only ever text — a generated destructor's name, which travels in
+    /// the nominal's definition rather than as a symbol. Memoizing it must not
+    /// intern it: the retention counters are read from the interner, so a
+    /// spelling the unmemoized path never interned must not appear because the
+    /// memo found it convenient.
+    pub fn keyed_name(
+        &self,
+        digest: u128,
+        variant: u8,
+        render: impl FnOnce() -> String,
+    ) -> Arc<str> {
+        self.spellings
+            .keyed_names
+            .memoize(keyed_shard(digest, variant), (digest, variant), || {
+                Arc::from(render().as_str())
+            })
     }
 
     /// Whether this generation is still current. A retired space fails closed
@@ -167,6 +377,7 @@ impl SymbolSpaceGenerations {
             interner: Arc::new(ThreadedRodeo::new()),
             generation: self.minted.fetch_add(1, Ordering::AcqRel).wrapping_add(1),
             live: Arc::new(AtomicBool::new(true)),
+            spellings: Arc::new(Spellings::default()),
         }
     }
 }
@@ -245,6 +456,105 @@ mod tests {
             holder.interner().len(),
             0,
             "a retired space still resolves the handles it issued"
+        );
+    }
+
+    /// A derived spelling is rendered once per generation and answers with the
+    /// handle `get_or_intern` of the same text would have issued, without
+    /// interning anything the unmemoized path would not have interned.
+    #[test]
+    fn a_derived_spelling_is_rendered_once_per_generation() {
+        let space = SharedSymbolSpace::private();
+        let owner = space.interner().get_or_intern("__anon_struct_00");
+        let member = space.interner().get_or_intern("len");
+        let interned_before = space.interner().len();
+
+        let renders = std::cell::Cell::new(0_usize);
+        let spell = || {
+            renders.set(renders.get() + 1);
+            "__anon_struct_00.len".to_owned()
+        };
+
+        let first = space.derived_symbol(owner, member, 1, spell);
+        let second = space.clone().derived_symbol(owner, member, 1, spell);
+        assert_eq!(first, second);
+        assert_eq!(renders.get(), 1, "the second body reuses the association");
+        assert_eq!(
+            first,
+            space.interner().get_or_intern("__anon_struct_00.len"),
+            "the memo answers with the handle the interner issued"
+        );
+        assert_eq!(
+            space.interner().len(),
+            interned_before + 1,
+            "one spelling was interned, exactly as the unmemoized path would"
+        );
+    }
+
+    /// The join variant is part of the association, so the two member
+    /// separators cannot answer for each other.
+    #[test]
+    fn derived_spellings_separate_the_join_variants() {
+        let space = SharedSymbolSpace::private();
+        let owner = space.interner().get_or_intern("Owner");
+        let member = space.interner().get_or_intern("make");
+        let method = space.derived_symbol(owner, member, 1, || "Owner.make".to_owned());
+        let associated = space.derived_symbol(owner, member, 0, || "Owner::make".to_owned());
+        assert_ne!(method, associated);
+        assert_eq!(space.interner().resolve(&method), "Owner.make");
+        assert_eq!(space.interner().resolve(&associated), "Owner::make");
+    }
+
+    /// A peer generation memoizes independently: an association never crosses
+    /// the generation that minted the handles it is keyed on.
+    #[test]
+    fn derived_spellings_do_not_cross_generations() {
+        let generations = SymbolSpaceGenerations::default();
+        let first = generations.next_generation();
+        let second = generations.next_generation();
+        let owner = first.interner().get_or_intern("Owner");
+        let member = first.interner().get_or_intern("len");
+        first.derived_symbol(owner, member, 1, || "Owner.len".to_owned());
+
+        let peer_owner = second.interner().get_or_intern("Owner");
+        let peer_member = second.interner().get_or_intern("len");
+        let renders = std::cell::Cell::new(0_usize);
+        second.derived_symbol(peer_owner, peer_member, 1, || {
+            renders.set(renders.get() + 1);
+            "Owner.len".to_owned()
+        });
+        assert_eq!(renders.get(), 1, "the peer generation renders for itself");
+        assert_eq!(second.interner().len(), 3);
+    }
+
+    /// A digest-derived name is rendered once per generation, and the interning
+    /// arm interns while the text-only arm does not.
+    #[test]
+    fn keyed_spellings_render_once_and_intern_only_when_asked() {
+        let space = SharedSymbolSpace::private();
+        let digest = 0x0123_4567_89ab_cdef_0123_4567_89ab_cdef_u128;
+        let renders = std::cell::Cell::new(0_usize);
+        let spell = || {
+            renders.set(renders.get() + 1);
+            format!("__anon_struct_{digest:032x}")
+        };
+
+        let (name, symbol) = space.keyed_symbol_spelling(digest, 0, spell);
+        let (again, same) = space.clone().keyed_symbol_spelling(digest, 0, spell);
+        assert_eq!(renders.get(), 1);
+        assert_eq!(name, again);
+        assert_eq!(symbol, same);
+        assert_eq!(space.interner().resolve(&symbol), name.as_ref());
+        assert_eq!(space.interner().len(), 1);
+
+        let destructor = space.keyed_name(digest, 1, || format!("{name}.__drop"));
+        let destructor_again = space.keyed_name(digest, 1, || unreachable!("memoized"));
+        assert_eq!(destructor, destructor_again);
+        assert_eq!(destructor.as_ref(), format!("{name}.__drop"));
+        assert_eq!(
+            space.interner().len(),
+            1,
+            "a text-only spelling never reaches the interner"
         );
     }
 

--- a/docs/designs/0076-shared-revision-symbol-space.md
+++ b/docs/designs/0076-shared-revision-symbol-space.md
@@ -129,6 +129,18 @@ a fixed per-body cost the original closure-size argument did not model —
 so the chain fixture is a control for closure-scaled interning only, not
 a no-op shape for this ADR.
 
+*The formatting term was taken afterwards, by this ADR's own mechanism.*
+A shared space makes a rendered-name-to-handle association stable across
+every body of a revision, so the generation can hold that association
+instead of re-deriving the string per body. `SharedSymbolSpace` gained
+the memos (`derived_symbol` for names joined from interned components,
+`keyed_symbol_spelling` / `keyed_name` for names that are a function of a
+producer digest), governed by §4's retirement semantics like everything
+else in the generation and interning nothing the unmemoized path would
+not have interned. Measured a further −0.90% on Lattice and −0.63% on
+Mosaic with the digests and counters below unchanged; recorded in
+`docs/notes/per-body-identity-closure-materialization.md`.
+
 ## Falsifiers
 
 - **Byte identity**: executables and all `compiler_work` counters
@@ -167,7 +179,9 @@ a no-op shape for this ADR.
 - **C. Per-module pre-mint**: strictly dominated by A on Lattice's shape
   (61 named nominals span all 1,263 bodies).
 - **Caching formatted names without sharing the interner**: removes the
-  formatting but not the insertion, which is the expensive half.
+  formatting but not the insertion, which is the expensive half. Caching
+  them *with* the interner shared is the follow-up recorded under "What
+  this buys", and it reaches both halves.
 - **Lazy endpoint installation**: changes work counters by construction;
   a contract change with unestablished benefit, deferred until this ADR
   settles the symbol-space question.

--- a/docs/notes/per-body-identity-closure-materialization.md
+++ b/docs/notes/per-body-identity-closure-materialization.md
@@ -298,6 +298,58 @@ fields, zero differences). Peak RSS is neutral: a -0.1672 percent paired median
 with 0.2842 percent paired MAD over sixteen balanced Lattice pairs. Compiler
 clock is not reported, for the reason given at the top.
 
+## Implemented: the rendering that fed the lookups
+
+Sharing the symbol space (ADR-0076) turned each body's interner insertion into a
+lookup, but a lookup still needs the rendered string, so the *rendering* was
+still performed once per body. Measured on trunk after ADR-0076, cold Lattice at
+6,771,047,268 instructions:
+
+| site | instructions | share | what it renders |
+| --- | ---: | ---: | --- |
+| `member_callable_name_for_owner` | 13,355,977 | 0.197% | `Owner.method` joins, ~80,300 per build |
+| `format_inner` under `find_or_create_anon` | 19,576,691 | 0.289% | `__anon_struct_<digest>` and its `.__drop` |
+| `try_get_or_intern` from the endpoint installer | 63,715,889 | 0.941% | hashing those rendered strings, 160,404 calls |
+
+Both families are a total function of data that does not vary across the
+bodies of one revision — a member name of the owner and member spellings and
+the separator; an anonymous nominal's name of its producer digest — so the
+generation memoizes the spelling-to-handle association in `SharedSymbolSpace`
+(`derived_symbol`, `keyed_symbol_spelling`, `keyed_name`). Only the first body
+to need a spelling renders it; the rest take a handle-keyed map lookup instead
+of a fifty-character render, hash, and compare. The memos live inside the
+generation, so ADR-0076's retirement semantics govern them unchanged, and they
+never intern a string the unrendered path would not have interned — the
+retention counters are read from the interner's length and byte count.
+
+Cold Lattice `member_callable_name_for_owner` falls to 471,179 instructions,
+`format_inner` to 84,228,020, and `try_get_or_intern` to 197,729,360, against a
+new `derived_symbol` term of 8,983,621. Retired instructions:
+
+| shape | before | after | delta |
+| --- | ---: | ---: | ---: |
+| Lattice | 6,771,047,268 | 6,709,961,467 | -61,085,801 (-0.9022%) |
+| Mosaic | 2,787,590,395 | 2,770,003,393 | -17,587,002 (-0.6309%) |
+| chain256 | 553,664,114 | 554,249,181 | +585,067 (+0.1057%) |
+
+chain256 mints no anonymous nominals and installs no anonymous methods, so it
+consults neither memo; its per-generation construction cost measures 5,194
+instructions there and the rest of its movement is inlining reshuffling in
+untouched code (`SourceMetadata::extend_with_appended` -3.1M against
+`Iterator::eq_by` +1.8M and `physical_path` +1.6M).
+
+Executables are byte-identical on all three shapes at `-j1` and `-j4`
+(Lattice `45784ce7c7cde992d7ea820912ca1692c05dc7582a367210d017b3765a9a89e7`,
+Mosaic `4cdead1a98e77fce940b5d6f9b693d8decba26b1c666896bcc78d48a1b79f97b`,
+chain256 `45f01130cbbae57a2fe22f95e23cb34902a8c28040cc677dce56ba84050c0b1a`), as
+are `compiler_work`, `source_metrics`, `emitted_output`, and
+`compiler_boundary` — 615, 381, and 903 compared fields, zero differences. The
+one exclusion is the `compiler_work.query_runtime` scheduling counters at `-j4`,
+which a baseline-versus-baseline pair of the *same* binary moves by the same
+magnitudes; they are identical at `-j1`. Peak RSS over twelve interleaved pairs:
+Lattice -0.22% (MAD 0.34%), Mosaic -0.03% (MAD 0.13%), chain256 +0.04%
+(MAD 0.06%).
+
 ## What needs an ADR
 
 Candidates A, C, and D all move a body-private index space into a shared one.
@@ -328,7 +380,11 @@ evaluated first, which inverts the ordering the pool-shaped framing suggests.
   target is not worth an implementation.
 - **Caching the formatted member callable name across bodies.** It removes the
   formatting but not the interning, because the body's interner is fresh and the
-  insertion is the expensive half. Subsumed by D.
+  insertion is the expensive half. Subsumed by D — *while the interner was
+  body-private*. D landed as ADR-0076 and made the interner revision-shared,
+  which turned this from subsumed into the remaining half: a shared-space lookup
+  still needs the rendered string, and a rendered-name-to-handle association is
+  now stable across the revision's bodies. Implemented above.
 - **Making anonymous-method endpoint installation lazy.** 76 endpoints are
   installed per body and it is not established how many are used. This changes
   work counters by construction, so it is a contract change, not a bounded


### PR DESCRIPTION
Follow-up to ADR-0076: removes the formatting (and the lookup traffic it feeds) that survived interner sharing. 7 files, +514/−38.

## Measured attribution first

ADR-0076's "What this buys" recorded that sharing converted interner insertions into lookups but a lookup still needs the rendered string. Callgrind on cold Lattice attributed that residue: the `Owner.method` join (13.4M instructions, ~80k calls), anonymous-name `format_inner`/`LowerHex` digest rendering (~30M), and — the larger half the original ~0.4% estimate missed — 63.7M instructions of `try_get_or_intern` calls from the anonymous-endpoint installer that only exist to re-derive an association the revision already made.

## The change

`SharedSymbolSpace` gains generation-scoped spelling memos: `derived_symbol` for names joined from two already-interned components, and `keyed_symbol_spelling`/`keyed_name` for names that are a total function of a producer digest. Callers pass their own renderer, so the memo decides how *often* a form is spelled, never *how* — RUE-1236's one-renderer rule is preserved, and the two byte-mirrored `__anon_struct_{digest:032x}` renderers collapse into one. Consumers: the two anonymous-method installation loops and `mint_anon_struct`.

Two deliberate non-behaviors, because `semantic_strings_retained` and the interner retained charge are read from `interner.len()`/`utf8_bytes()`: owner handles are obtained with `get` (never `get_or_intern`), and text-only destructor names use the non-interning arm — the set of interned strings is provably unchanged. Both memos live inside the generation, so ADR-0076 §4 retirement governs them with no new machinery.

## Results (callgrind, release, `-j1`)

| shape | retired instructions |
|---|---|
| Lattice | **−61.1M (−0.90%)** — member-spelling memo −0.588%, digest memo −0.307% |
| Mosaic | −17.6M (−0.63%) |
| chain256 | +0.11% (consults neither memo; the delta is inlining reshuffle in untouched code, itemized in the report) |

## Gates

- Executables byte-identical on all three shapes at `-j1` and `-j4`; Lattice re-verified independently on this branch post-rebase (`b893e76c…85e5`).
- Counters: 615/381/903 fields compared per shape, zero differences at `-j1`; at `-j4` the known scheduling-variant `query_runtime.*` prefix was excluded after a baseline-vs-baseline pair of the same binary moved the same 19 fields — stated rather than papered over.
- Peak RSS: Lattice −0.22%, Mosaic −0.03%, chain256 +0.04% (12 interleaved pairs) — inside the ±1% gate.
- Suites: rue-rir 128 and rue-air 652 (both re-run on this branch post-rebase), compiler, quick 30 (re-run), UI 250; fmt/clippy/ADR/doc-links validators green. Five new tests cover render-once, variant separation, generation isolation, and the text-never-reaches-the-interner invariant.

## Docs

ADR-0076's "What this buys" and the measurement note's rejected-alternatives entry both claimed the formatting term was untouched/subsumed — true only while the interner was body-private. Both are updated with the measured outcome.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTiBg7df72iMgdpAFv5wZs)_