### PR TITLE
Gate deep-chain identity resolution on countable work

### DIFF
--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -1764,8 +1764,9 @@ fn module_for_accepted_source(
 pub(crate) fn accepted_import_module(
     source: &AcceptedImportSource,
     accepted_reads: &AcceptedReadManifest,
+    meter: &crate::source_snapshot::IdentityResolutionMeter,
 ) -> CompileResult<ModuleId> {
-    let entry = match accepted_reads.lookup_physical_identity(source.metadata_identity()) {
+    let entry = match accepted_reads.lookup_physical_identity(source.metadata_identity(), meter) {
         ManifestIdentityLookup::Unique(entry) => entry,
         ManifestIdentityLookup::Absent => {
             return Err(invalid_input(
@@ -1993,15 +1994,24 @@ impl AcceptedReadManifest {
     /// A manifest that names the same physical file twice reports
     /// [`ManifestIdentityLookup::Duplicate`] rather than picking a winner, so
     /// the ambiguity still reaches the caller that must reject it.
+    ///
+    /// `meter` records the lookup and every manifest entry examined to answer
+    /// it, including the entries walked once to materialize the index. Charging
+    /// the materialization to its triggering lookup keeps the counter an honest
+    /// total: a manifest that is rebuilt and re-indexed once per module would
+    /// show the same quadratic entry count the scan showed.
     pub(crate) fn lookup_physical_identity(
         &self,
         identity: PhysicalFileIdentity,
+        meter: &crate::source_snapshot::IdentityResolutionMeter,
     ) -> ManifestIdentityLookup<'_> {
+        let mut visited = 0;
         let index = self.by_physical_identity.get_or_init(|| {
             let mut index: HashMap<PhysicalFileIdentity, IdentitySlot> =
                 HashMap::with_capacity(self.entries.len());
             for (segment, entries) in self.entries.segments().iter().enumerate() {
                 for (position, entry) in entries.iter().enumerate() {
+                    visited += 1;
                     index
                         .entry(entry.metadata_identity)
                         .and_modify(|slot| *slot = IdentitySlot::Duplicate)
@@ -2013,6 +2023,8 @@ impl AcceptedReadManifest {
             }
             index
         });
+        // The hash probe itself reads at most the one entry it names.
+        meter.record_physical_identity_lookup(visited + 1);
         match index.get(&identity) {
             None => ManifestIdentityLookup::Absent,
             Some(IdentitySlot::Duplicate) => ManifestIdentityLookup::Duplicate,
@@ -2777,6 +2789,7 @@ mod tests {
         }
         assert!(manifest.segments().segments().len() > 1);
 
+        let meter = crate::source_snapshot::IdentityResolutionMeter::default();
         for index in 0..ENTRIES {
             let identity = PhysicalFileIdentity::new(1, index);
             let scanned = manifest
@@ -2784,21 +2797,30 @@ mod tests {
                 .filter(|candidate| candidate.metadata_identity() == identity)
                 .collect::<Vec<_>>();
             assert_eq!(scanned.len(), 1);
-            match manifest.lookup_physical_identity(identity) {
+            match manifest.lookup_physical_identity(identity, &meter) {
                 ManifestIdentityLookup::Unique(found) => assert_eq!(found, scanned[0]),
                 _ => panic!("module {index} resolves to exactly one entry"),
             }
         }
         assert!(matches!(
-            manifest.lookup_physical_identity(PhysicalFileIdentity::new(9, 9)),
+            manifest.lookup_physical_identity(PhysicalFileIdentity::new(9, 9), &meter),
             ManifestIdentityLookup::Absent
         ));
+        // The index is materialized once for this manifest value and shared by
+        // every later lookup, so the whole run costs one pass over the entries
+        // plus one entry per lookup — not one pass per lookup, which is what
+        // the scan cost and what `visits` would show if the index were rebuilt.
+        assert_eq!(meter.physical_identity_lookups(), ENTRIES + 1);
+        assert_eq!(
+            meter.physical_identity_visits(),
+            ENTRIES + meter.physical_identity_lookups()
+        );
 
         // Two modules naming one physical file stay an ambiguity the caller
         // rejects rather than a silently chosen winner.
         let ambiguous = AcceptedReadManifest::from_entries(vec![entry(0, 7), entry(1, 7)]);
         assert!(matches!(
-            ambiguous.lookup_physical_identity(PhysicalFileIdentity::new(1, 7)),
+            ambiguous.lookup_physical_identity(PhysicalFileIdentity::new(1, 7), &meter),
             ManifestIdentityLookup::Duplicate
         ));
     }

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -1423,8 +1423,9 @@ pub(crate) fn parse_source_snapshot_modules(
 pub(crate) fn parse_source_snapshot_module(
     snapshot: &SourceSnapshot,
     module: &ModuleId,
+    meter: &crate::source_snapshot::IdentityResolutionMeter,
 ) -> (Result<Arc<ParsedModule>, CompileErrors>, SyntaxWork) {
-    parse_source_snapshot_module_with_stage(snapshot, module, None)
+    parse_source_snapshot_module_with_stage(snapshot, module, None, meter)
 }
 
 /// The canonical parse entry with an optional staged wave parse (ADR-0075).
@@ -1438,8 +1439,9 @@ pub(crate) fn parse_source_snapshot_module_with_stage(
     snapshot: &SourceSnapshot,
     module: &ModuleId,
     staged: Option<StagedModuleParse>,
+    meter: &crate::source_snapshot::IdentityResolutionMeter,
 ) -> (Result<Arc<ParsedModule>, CompileErrors>, SyntaxWork) {
-    let file_id = snapshot.file_id_for_module(module).ok_or_else(|| {
+    let file_id = snapshot.file_id_for_module(module, meter).ok_or_else(|| {
         CompileErrors::from(invalid_input(format!(
             "source snapshot contains no module {module}"
         )))
@@ -1577,9 +1579,10 @@ fn build_module_from_staged(
 pub(crate) fn rebind_parsed_module(
     snapshot: &SourceSnapshot,
     module: &Arc<ParsedModule>,
+    meter: &crate::source_snapshot::IdentityResolutionMeter,
 ) -> Arc<ParsedModule> {
     let file_id = snapshot
-        .file_id_for_module(module.module_id())
+        .file_id_for_module(module.module_id(), meter)
         .expect("parsed module belongs to the projected source snapshot");
     if module.file_id() == file_id
         && module.physical_path()
@@ -3415,7 +3418,11 @@ extern "C" { fn getpid() -> i32; }
         }
 
         let moved = snapshot(&[(9, "/main.rue", "main.rue", source)], 9);
-        let moved = rebind_parsed_module(&moved, module);
+        let moved = rebind_parsed_module(
+            &moved,
+            module,
+            &crate::source_snapshot::IdentityResolutionMeter::default(),
+        );
         for key in keys {
             let span = match moved.declaration_ast(&key).unwrap() {
                 ParsedDeclarationAstRef::Function(value) => value.span,
@@ -3867,11 +3874,13 @@ extern "C" { fn getpid() -> i32; }
         // A sentinel the fresh path cannot produce, proving which path ran.
         staged.work.lexed_bytes = 424_242;
 
-        let (fresh, fresh_work) = parse_source_snapshot_module(&snap, &module);
+        let meter = crate::source_snapshot::IdentityResolutionMeter::default();
+        let (fresh, fresh_work) = parse_source_snapshot_module(&snap, &module, &meter);
         let fresh = fresh.unwrap();
         assert_eq!(fresh_work.lexed_bytes, text.len());
 
-        let (hit, hit_work) = parse_source_snapshot_module_with_stage(&snap, &module, Some(staged));
+        let (hit, hit_work) =
+            parse_source_snapshot_module_with_stage(&snap, &module, Some(staged), &meter);
         let hit = hit.unwrap();
         assert_eq!(
             hit_work.lexed_bytes, 424_242,
@@ -3910,8 +3919,12 @@ extern "C" { fn getpid() -> i32; }
         // parse runs and its work shows the snapshot's own byte count.
         let other = Arc::new("fn main() -> i32 { 1 }".to_owned());
         let (_, stale) = parse_unpublished_module(&module, "/main.rue", &other).unwrap();
-        let (mismatch, mismatch_work) =
-            parse_source_snapshot_module_with_stage(&snap, &module, Some(stale));
+        let (mismatch, mismatch_work) = parse_source_snapshot_module_with_stage(
+            &snap,
+            &module,
+            Some(stale),
+            &crate::source_snapshot::IdentityResolutionMeter::default(),
+        );
         assert_eq!(mismatch_work.lexed_bytes, text.len());
         assert_eq!(mismatch.unwrap().revision(), fresh.revision());
     }
@@ -3945,7 +3958,11 @@ extern "C" { fn getpid() -> i32; }
             .unwrap()
             .clone();
         let main_id = ModuleId::from_logical_path("main.rue").unwrap();
-        let (new_main, work) = parse_source_snapshot_module(&edited, &main_id);
+        let (new_main, work) = parse_source_snapshot_module(
+            &edited,
+            &main_id,
+            &crate::source_snapshot::IdentityResolutionMeter::default(),
+        );
         let new_main = new_main.unwrap();
         assert_eq!(work.lexer_invocations, 1);
         assert_eq!(work.parser_invocations, 1);

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -583,6 +583,14 @@ pub(crate) struct RevisionedQueryDatabase {
     /// structural-authority path never increments this, so the acquisition
     /// profile can require it zero.
     import_view_read_entries_compared: std::sync::atomic::AtomicU64,
+    /// Module-identity and physical-identity resolution work. Both
+    /// questions are asked once per module by the parse projection and by
+    /// discovery authorization, so answering either by a scan is quadratic in
+    /// the depth of an import chain while dispatching nothing that any other
+    /// counter can see. Shared by `Arc` because the parse-module and
+    /// resolve-import evaluators are `&self`-free closures installed at
+    /// construction.
+    identity_resolution: Arc<crate::source_snapshot::IdentityResolutionMeter>,
     /// The module revisions appended by overlay publications since the last
     /// committed close (RUE-1112): the session-owned recorded-additions lineage.
     /// The successor stage/close derive their module delta from THIS record —
@@ -3405,6 +3413,7 @@ fn release_orphaned_import_stamp_leases(
 fn accepted_import_topology<'a>(
     observations: impl IntoIterator<Item = &'a ImportObservation>,
     accepted_reads: &AcceptedReadManifest,
+    meter: &crate::source_snapshot::IdentityResolutionMeter,
 ) -> CompileResult<Arc<[AcceptedImportTopologyFact]>> {
     let mut topology = observations
         .into_iter()
@@ -3412,7 +3421,7 @@ fn accepted_import_topology<'a>(
             let request = observation.request();
             let outcome = if let Some(source) = observation.accepted_source() {
                 AcceptedImportTopologyOutcome::Resolved(
-                    crate::import_discovery::accepted_import_module(source, accepted_reads)?,
+                    crate::import_discovery::accepted_import_module(source, accepted_reads, meter)?,
                 )
             } else {
                 use crate::ImportObservationStatus as S;
@@ -11240,6 +11249,8 @@ impl RevisionedQueryDatabase {
     ) -> Self {
         let runtime = CompilerQueryRuntime(QueryRuntime::new(query_concurrency));
         let body_reachability_meter = Arc::new(BodyReachabilityMeter::default());
+        let identity_resolution =
+            Arc::new(crate::source_snapshot::IdentityResolutionMeter::default());
         let module_store = Arc::new(Mutex::new(ModuleInputStore::default()));
         #[cfg(test)]
         let test_import_store = Arc::new(Mutex::new(TestImportInputStore {
@@ -11255,6 +11266,7 @@ impl RevisionedQueryDatabase {
         let parse_store = module_store.clone();
         let parse_stage: ParseStage = Arc::new(Mutex::new(HashMap::new()));
         let parse_stage_for_parse_modules = parse_stage.clone();
+        let parse_identity_resolution = identity_resolution.clone();
         let parse_modules = runtime
             .family_with_equality_and_evaluator(
                 "compiler.parse-module",
@@ -11276,6 +11288,7 @@ impl RevisionedQueryDatabase {
                             &view.snapshot,
                             &key.0,
                             staged,
+                            &parse_identity_resolution,
                         );
                     Ok(QueryOutput::success(ParseModuleValue { result, work }))
                 },
@@ -11924,6 +11937,7 @@ impl RevisionedQueryDatabase {
         let import_store = Arc::new(Mutex::new(ImportInputStore::default()));
         let evaluator_store = import_store.clone();
         let index_for_import_resolution = module_indexes.clone();
+        let resolve_identity_resolution = identity_resolution.clone();
         let resolve_imports = runtime
             .family_with_evaluator(
                 "compiler.resolve-import",
@@ -12014,6 +12028,7 @@ impl RevisionedQueryDatabase {
                                     crate::import_discovery::accepted_import_module(
                                         source,
                                         &view.accepted_reads,
+                                        &resolve_identity_resolution,
                                     )
                                     .map_err(|_| ProvenanceLookupFailure::Invalid)
                                 },
@@ -16091,6 +16106,7 @@ impl RevisionedQueryDatabase {
             import_view_ledger_entries_cloned: std::sync::atomic::AtomicU64::new(0),
             import_view_source_entries_compared: std::sync::atomic::AtomicU64::new(0),
             import_view_read_entries_compared: std::sync::atomic::AtomicU64::new(0),
+            identity_resolution,
             lineage_additions: Vec::new(),
             provider_observation_meter,
             lookup_root_lease,
@@ -19681,6 +19697,12 @@ impl RevisionedQueryDatabase {
             .load(std::sync::atomic::Ordering::Relaxed)
     }
 
+    /// The module-identity and physical-identity resolution counters.
+    /// See [`crate::source_snapshot::IdentityResolutionMeter`].
+    pub(crate) fn identity_resolution(&self) -> &crate::source_snapshot::IdentityResolutionMeter {
+        &self.identity_resolution
+    }
+
     /// The module revisions appended by overlay publications since the last
     /// committed close — the recorded-additions lineage (RUE-1112).
     pub(crate) fn lineage_additions(&self) -> &[ModuleRevision] {
@@ -19955,6 +19977,7 @@ impl RevisionedQueryDatabase {
         let accepted_topology = AcceptedImportTopologyValue::Full(accepted_import_topology(
             ledger.iter(),
             &accepted_reads,
+            &self.identity_resolution,
         )?);
         // RUE-1137/RUE-1202: the runtime revision's compatibility slot carries
         // one shared observation namespace for both ordinary updates and
@@ -20161,7 +20184,11 @@ impl RevisionedQueryDatabase {
                 .iter()
                 .filter_map(|observation| observation.accepted_source())
                 .map(|source| {
-                    crate::import_discovery::accepted_import_module(source, &accepted_reads)
+                    crate::import_discovery::accepted_import_module(
+                        source,
+                        &accepted_reads,
+                        &self.identity_resolution,
+                    )
                 })
                 .collect::<Result<_, _>>()?,
             OverlayJustification::TrustedLeaves(added) => {
@@ -20207,7 +20234,13 @@ impl RevisionedQueryDatabase {
             }
         }
         let added_topology = (!new_observations.is_empty())
-            .then(|| accepted_import_topology(&new_observations, &accepted_reads))
+            .then(|| {
+                accepted_import_topology(
+                    &new_observations,
+                    &accepted_reads,
+                    &self.identity_resolution,
+                )
+            })
             .transpose()?;
         let accepted_topology = added_topology.as_ref().map_or_else(
             || parent_view.accepted_topology.clone(),
@@ -20442,7 +20475,11 @@ impl RevisionedQueryDatabase {
             }
             match &value.result {
                 Ok(module) => {
-                    let projected = crate::parsed_modules::rebind_parsed_module(&snapshot, module);
+                    let projected = crate::parsed_modules::rebind_parsed_module(
+                        &snapshot,
+                        module,
+                        &self.identity_resolution,
+                    );
                     if !computed {
                         if Arc::ptr_eq(&projected, module) {
                             work.modules_reused += 1;
@@ -20500,7 +20537,7 @@ impl RevisionedQueryDatabase {
             work.modules_considered += 1;
             work.previous_module_lookups += 1;
             let current_file_id = snapshot
-                .file_id_for_module(&module)
+                .file_id_for_module(&module, &self.identity_resolution)
                 .expect("parse demand belongs to the published source revision");
             let attempt = self.runtime.request_registered(
                 &self.parse_modules,
@@ -20528,7 +20565,11 @@ impl RevisionedQueryDatabase {
             }
             match &value.result {
                 Ok(module) => {
-                    let projected = crate::parsed_modules::rebind_parsed_module(&snapshot, module);
+                    let projected = crate::parsed_modules::rebind_parsed_module(
+                        &snapshot,
+                        module,
+                        &self.identity_resolution,
+                    );
                     if !computed {
                         if Arc::ptr_eq(&projected, module) {
                             work.modules_reused += 1;
@@ -20599,7 +20640,11 @@ impl RevisionedQueryDatabase {
                 unreachable!("ParseModule publishes typed values")
             };
             let parsed = match &parsed_value.result {
-                Ok(parsed) => crate::parsed_modules::rebind_parsed_module(&snapshot, parsed),
+                Ok(parsed) => crate::parsed_modules::rebind_parsed_module(
+                    &snapshot,
+                    parsed,
+                    &self.identity_resolution,
+                ),
                 Err(module_errors) => {
                     errors.extend(module_errors.clone());
                     continue;

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -1963,6 +1963,42 @@ impl CompilerSession {
         self.parse_invalidation_entries_compared
     }
 
+    /// Module-identity resolutions asked of the published source snapshots, and
+    /// the snapshot positions examined to answer them. See
+    /// [`crate::source_snapshot::IdentityResolutionMeter`].
+    pub(crate) fn snapshot_module_resolutions(&self) -> u64 {
+        self.queries
+            .revisioned
+            .identity_resolution()
+            .module_resolutions()
+    }
+
+    /// See [`Self::snapshot_module_resolutions`].
+    pub(crate) fn snapshot_module_resolution_visits(&self) -> u64 {
+        self.queries
+            .revisioned
+            .identity_resolution()
+            .module_resolution_visits()
+    }
+
+    /// Physical-identity lookups asked of the accepted-read manifests, and the
+    /// manifest entries examined to answer them. See
+    /// [`crate::source_snapshot::IdentityResolutionMeter`].
+    pub(crate) fn accepted_read_identity_lookups(&self) -> u64 {
+        self.queries
+            .revisioned
+            .identity_resolution()
+            .physical_identity_lookups()
+    }
+
+    /// See [`Self::accepted_read_identity_lookups`].
+    pub(crate) fn accepted_read_identity_visits(&self) -> u64 {
+        self.queries
+            .revisioned
+            .identity_resolution()
+            .physical_identity_visits()
+    }
+
     /// A snapshot of the production provider-op observation counters
     /// (ADR-0066 §4).
     pub(crate) fn provider_observation_metrics(

--- a/crates/rue-compiler/src/source_snapshot.rs
+++ b/crates/rue-compiler/src/source_snapshot.rs
@@ -125,6 +125,74 @@ struct SourceRecord {
     text: Arc<String>,
 }
 
+/// Deterministic work counters for the two identity questions a build asks once
+/// per module: "which file in this snapshot is bound to this module?" and
+/// "which accepted-read entry names this physical file?".
+///
+/// Both questions used to be answered by scanning the whole set, so each cost
+/// one pass over a set that grows with the program — quadratic in the depth of
+/// an import chain, and invisible to every counter the compiler published,
+/// because a scan dispatches nothing. These counters make the *examinations*
+/// countable, not just the dispatches: a question is one `*_lookups`, and each
+/// position examined while answering it is one `*_visits`. An index-answered
+/// question examines a bounded number of positions; a scan-answered one
+/// examines the whole set, so `visits / lookups` is the shape under test.
+///
+/// Determinism: every field counts work actually performed on the canonical
+/// query path, exactly like `parse_sources_materialized` and
+/// `plan_reads_reduced`. At `-j1` a fresh build of fixed sources performs a
+/// fixed sequence of query executions, so every field is reproducible. The
+/// counters are pure observation — they take part in no key, hash, equality,
+/// or rendered artifact, so no emitted byte depends on them.
+#[derive(Debug, Default)]
+pub(crate) struct IdentityResolutionMeter {
+    module_resolutions: std::sync::atomic::AtomicU64,
+    module_resolution_visits: std::sync::atomic::AtomicU64,
+    physical_identity_lookups: std::sync::atomic::AtomicU64,
+    physical_identity_visits: std::sync::atomic::AtomicU64,
+}
+
+impl IdentityResolutionMeter {
+    /// One module-identity resolution against a snapshot, examining `visited`
+    /// snapshot positions (segment probes plus the record the answer reads).
+    pub(crate) fn record_module_resolution(&self, visited: u64) {
+        self.module_resolutions
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.module_resolution_visits
+            .fetch_add(visited, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// One physical-identity lookup against an accepted-read manifest,
+    /// examining `visited` manifest entries (including any entry examined while
+    /// materializing the inverse index that answers it).
+    pub(crate) fn record_physical_identity_lookup(&self, visited: u64) {
+        self.physical_identity_lookups
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.physical_identity_visits
+            .fetch_add(visited, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub(crate) fn module_resolutions(&self) -> u64 {
+        self.module_resolutions
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub(crate) fn module_resolution_visits(&self) -> u64 {
+        self.module_resolution_visits
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub(crate) fn physical_identity_lookups(&self) -> u64 {
+        self.physical_identity_lookups
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub(crate) fn physical_identity_visits(&self) -> u64 {
+        self.physical_identity_visits
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
 impl SourceSnapshot {
     /// Build a validated one-module snapshot for in-memory tools and tests.
     pub fn single(path: impl Into<String>, source: impl Into<String>) -> CompileResult<Self> {
@@ -440,13 +508,26 @@ impl SourceSnapshot {
     /// O(files) record lookups. Projecting a whole program is one such lookup
     /// per module, which is where the difference between linear and quadratic
     /// lives for a deep import chain.
-    pub(crate) fn file_id_for_module(&self, module: &ModuleId) -> Option<FileId> {
-        self.data.segments.iter().find_map(|segment| {
-            segment
-                .module_index
-                .get(module)
-                .map(|&position| segment.contents[position].file_id)
-        })
+    ///
+    /// `meter` records the resolution and the snapshot positions it examined,
+    /// so the difference above is a counter a test can read rather than an
+    /// instruction count only a profiler can see.
+    pub(crate) fn file_id_for_module(
+        &self,
+        module: &ModuleId,
+        meter: &IdentityResolutionMeter,
+    ) -> Option<FileId> {
+        let mut visited = 0;
+        let found = self.data.segments.iter().find_map(|segment| {
+            // One hash probe per segment, then one record read for the hit.
+            visited += 1;
+            segment.module_index.get(module).map(|&position| {
+                visited += 1;
+                segment.contents[position].file_id
+            })
+        });
+        meter.record_module_resolution(visited);
+        found
     }
 
     /// Load-order-independent root and module/content mapping.
@@ -955,12 +1036,13 @@ mod tests {
         // The per-segment module index answers exactly what an ascending scan
         // of the metadata's file ids answers, for every module and across every
         // compacted tier.
+        let meter = IdentityResolutionMeter::default();
         for (position, file_id) in snapshot.metadata().file_ids().enumerate() {
             let module = snapshot
                 .module_id(file_id)
                 .expect("every snapshot file has a module identity")
                 .clone();
-            assert_eq!(snapshot.file_id_for_module(&module), Some(file_id));
+            assert_eq!(snapshot.file_id_for_module(&module, &meter), Some(file_id));
             // The scan this replaces is quadratic, so compare against it on a
             // sample rather than on every module.
             if position % 64 == 0 {
@@ -968,14 +1050,27 @@ mod tests {
                     .metadata()
                     .file_ids()
                     .find(|candidate| snapshot.module_id(*candidate) == Some(&module));
-                assert_eq!(snapshot.file_id_for_module(&module), scanned);
+                assert_eq!(snapshot.file_id_for_module(&module, &meter), scanned);
             }
         }
         assert_eq!(
             snapshot.file_id_for_module(
-                &crate::ModuleId::from_logical_path("absent.rue").expect("valid module path")
+                &crate::ModuleId::from_logical_path("absent.rue").expect("valid module path"),
+                &meter
             ),
             None
+        );
+        // Every resolution above examined a bounded number of positions: at
+        // most one probe per segment plus the one record the answer reads.
+        // The scan this replaces examined the whole snapshot each time, which
+        // at this depth is two orders of magnitude more per resolution.
+        let bound = (crate::shared_segments::MAX_SIZE_TIERED_SEGMENTS as u64 + 1)
+            * meter.module_resolutions();
+        assert!(
+            meter.module_resolution_visits() <= bound,
+            "{} visits for {} resolutions exceeds the per-segment bound {bound}",
+            meter.module_resolution_visits(),
+            meter.module_resolutions()
         );
     }
 

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -281,6 +281,46 @@ pub fn parse_invalidation_entries_compared(session: &crate::CompilerSession) -> 
     session.parse_invalidation_entries_compared()
 }
 
+/// Module-identity resolutions performed against published source snapshots
+/// ("which file is this module bound to?"), asked once per module by
+/// the parse projection and once more per module it rebinds.
+///
+/// This counter and [`snapshot_module_resolution_visits`] exist as a pair. The
+/// question count is linear in the program by construction; the *visit* count
+/// is what distinguishes an index from a scan, and only the ratio between them
+/// is a scaling property. A scan answered each question by walking the whole
+/// snapshot, so the visits grew as modules squared while nothing this compiler
+/// dispatched — parses, plan groups, frontier roots, certificate misses —
+/// changed at all.
+pub fn snapshot_module_resolutions(session: &crate::CompilerSession) -> u64 {
+    session.snapshot_module_resolutions()
+}
+
+/// Snapshot positions examined answering [`snapshot_module_resolutions`]: one
+/// probe per snapshot segment, plus the one record the answer reads. Segment
+/// count is bounded, so this stays linear in the program; growth toward
+/// resolutions-times-modules is the scan regression.
+pub fn snapshot_module_resolution_visits(session: &crate::CompilerSession) -> u64 {
+    session.snapshot_module_resolution_visits()
+}
+
+/// Physical-identity lookups performed against accepted-read manifests
+/// ("which manifest entry names this physical file?"), asked once per
+/// accepted import observation while authorizing a discovery batch. Paired with
+/// [`accepted_read_identity_visits`] exactly as the module pair above.
+pub fn accepted_read_identity_lookups(session: &crate::CompilerSession) -> u64 {
+    session.accepted_read_identity_lookups()
+}
+
+/// Accepted-read manifest entries examined answering
+/// [`accepted_read_identity_lookups`]. A manifest materializes its
+/// inverse physical-identity index once and shares it with every clone, so the
+/// whole build pays one pass per manifest value plus one entry per lookup;
+/// answering by scan instead cost one pass per lookup.
+pub fn accepted_read_identity_visits(session: &crate::CompilerSession) -> u64 {
+    session.accepted_read_identity_visits()
+}
+
 /// An owned snapshot of the provider-op observation counters (RUE-1091,
 /// ADR-0066 §4): how many facts of each §4 family the exact body-fact provider
 /// observed. Owned plain data, not a query-engine record. These are live

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -19,12 +19,13 @@ use rue_compiler::unstable::{
 };
 #[cfg(test)]
 use rue_compiler::unstable::{
-    committed_successor_sharing, exact_import_groups_dispatched, import_close_records_reduced,
-    import_frontier_roots_requested, import_plan_groups_constructed,
-    import_view_full_leaves_published, import_view_ledger_entries_cloned,
-    import_view_overlay_leaves_published, import_view_read_entries_compared,
-    import_view_source_entries_compared, parse_invalidation_entries_compared,
-    parse_key_entries_compared, parse_modules_dispatched, parse_sources_materialized,
+    accepted_read_identity_lookups, accepted_read_identity_visits, committed_successor_sharing,
+    exact_import_groups_dispatched, import_close_records_reduced, import_frontier_roots_requested,
+    import_plan_groups_constructed, import_view_full_leaves_published,
+    import_view_ledger_entries_cloned, import_view_overlay_leaves_published,
+    import_view_read_entries_compared, import_view_source_entries_compared,
+    parse_invalidation_entries_compared, parse_key_entries_compared, parse_modules_dispatched,
+    parse_sources_materialized, snapshot_module_resolution_visits, snapshot_module_resolutions,
 };
 #[cfg(test)]
 use rue_compiler::unstable::{frontend_query_invalidations, rooted_cfg};
@@ -2487,6 +2488,231 @@ mod tests {
         assert!(
             result.assembler.plan_reads_reduced() <= MODULES as u64,
             "per-round read volume must stay linear in chain depth, not rounds times plan"
+        );
+    }
+
+    /// Deterministic per-size counters for the generated import chain below.
+    ///
+    /// Every field is a work counter published by the compiler, never a clock:
+    /// at `-j1` a fresh build of a fixed chain performs a fixed sequence of
+    /// query executions, so each field is exactly reproducible.
+    #[derive(Clone, Copy)]
+    struct ChainScalingCounters {
+        module_resolutions: u64,
+        module_resolution_visits: u64,
+        identity_lookups: u64,
+        identity_visits: u64,
+        parse_sources_materialized: u64,
+        parse_key_entries_compared: u64,
+        parse_modules_dispatched: u64,
+        parse_invalidation_entries_compared: u64,
+        plan_groups: u64,
+        frontier_roots: u64,
+        plan_reads_reduced: u64,
+        close_records_reduced: u64,
+        overlay_leaves_published: u64,
+        ledger_entries_cloned: u64,
+    }
+
+    /// Compile a generated `modules`-deep import chain and read its counters.
+    ///
+    /// The chain is written programmatically rather than checked in: a fixture
+    /// this size exists only to be scaled, and two committed copies of it would
+    /// drift from each other and from the shape this gate describes.
+    fn chain_scaling_counters(modules: usize) -> ChainScalingCounters {
+        let dir = TestDir::new(&format!("chain-scaling-{modules}"));
+        let main = dir.write(
+            "main.rue",
+            r#"const next = @import("m1.rue"); fn main() -> i32 { 0 }"#,
+        );
+        for index in 1..modules {
+            let source = if index + 1 == modules {
+                format!("pub fn value{index}() -> i32 {{ {index} }}")
+            } else {
+                format!(
+                    "pub const next = @import(\"m{}.rue\"); pub fn value{index}() -> i32 {{ {index} }}",
+                    index + 1
+                )
+            };
+            dir.write(&format!("m{index}.rue"), &source);
+        }
+
+        let result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
+        assert_eq!(result.read_manifest.len(), modules);
+        ChainScalingCounters {
+            module_resolutions: snapshot_module_resolutions(&result.session),
+            module_resolution_visits: snapshot_module_resolution_visits(&result.session),
+            identity_lookups: accepted_read_identity_lookups(&result.session),
+            identity_visits: accepted_read_identity_visits(&result.session),
+            parse_sources_materialized: parse_sources_materialized(&result.session),
+            parse_key_entries_compared: parse_key_entries_compared(&result.session),
+            parse_modules_dispatched: parse_modules_dispatched(&result.session),
+            parse_invalidation_entries_compared: parse_invalidation_entries_compared(
+                &result.session,
+            ),
+            plan_groups: import_plan_groups_constructed(&result.session),
+            frontier_roots: import_frontier_roots_requested(&result.session),
+            plan_reads_reduced: result.assembler.plan_reads_reduced(),
+            close_records_reduced: import_close_records_reduced(&result.session),
+            overlay_leaves_published: import_view_overlay_leaves_published(&result.session),
+            ledger_entries_cloned: import_view_ledger_entries_cloned(&result.session),
+        }
+    }
+
+    /// Deep-chain scaling gate: no counter below may grow faster than the
+    /// module count does, with headroom.
+    ///
+    /// WHY THIS EXISTS. The chain test above pins *dispatch* counts — frontier
+    /// roots, plan groups, reduced reads, certificate misses — and those bounds
+    /// caught the discovery-round regressions they were written for. They
+    /// cannot see a regression that dispatches nothing. Two such regressions
+    /// shipped and lived: projecting a parsed program resolved each module to
+    /// its file by scanning every file in the snapshot, and authorizing a
+    /// discovery batch resolved each accepted observation to its manifest entry
+    /// by scanning every accepted read. Each is one scan per module over a set
+    /// that grows with the program, so each is quadratic in chain depth — and
+    /// every counter this compiler published was unchanged by them, at 32
+    /// modules and at 1024. They were found by running callgrind over 256- and
+    /// 1024-module chains and reading a 15x instruction ratio for 4x the
+    /// modules. CI cannot run callgrind and wall clock on a shared host is far
+    /// too noisy to gate, so the answer is to make scan-shaped work countable:
+    /// `*_lookups` counts the identity questions asked, `*_visits` counts the
+    /// positions examined answering them, and their ratio is exactly what an
+    /// index-versus-scan regression moves.
+    ///
+    /// SIZES. 64 and 256 modules: a 4x span, wide enough that a quadratic term
+    /// shows as ~16x against the ~4x asserted here, and cheap enough for the
+    /// premerge tier — the two compiles together run in well under a second.
+    ///
+    /// HEADROOM. The bound is the size ratio times 1.5. Nothing here is
+    /// expected to beat linear, but several of these counters carry an honest
+    /// n-log-n term: the snapshot and the accepted-read manifest are
+    /// size-tiered segment sequences whose segment count grows with log n, and
+    /// discovery's ordered `BTreeMap`/`BTreeSet` bookkeeping costs log n per
+    /// element. Across this span that factor is log2(256)/log2(64) = 1.33, so
+    /// 1.5 admits n-log-n with margin while leaving a quadratic term — which
+    /// needs 4.0 — nowhere to hide.
+    #[test]
+    fn import_chain_identity_resolution_stays_linear_in_depth() {
+        const SMALL: usize = 64;
+        const LARGE: usize = 256;
+        const SIZE_RATIO: f64 = (LARGE / SMALL) as f64;
+        /// See HEADROOM above: admits an n-log-n term, excludes a quadratic one.
+        const HEADROOM: f64 = 1.5;
+
+        let small = chain_scaling_counters(SMALL);
+        let large = chain_scaling_counters(LARGE);
+
+        // A counter that stopped being incremented would make every ratio below
+        // pass for free, so require the two new counters to have observed at
+        // least one question per module before reading their growth.
+        for (label, counters, modules) in
+            [("64-module", &small, SMALL), ("256-module", &large, LARGE)]
+        {
+            assert!(
+                counters.module_resolutions >= modules as u64,
+                "{label} chain: every module is resolved to its file at least once"
+            );
+            assert!(
+                counters.module_resolution_visits >= counters.module_resolutions,
+                "{label} chain: a resolution examines at least one snapshot position"
+            );
+            assert!(
+                counters.identity_lookups >= modules as u64 - 1,
+                "{label} chain: every accepted import observation is authorized"
+            );
+            assert!(
+                counters.identity_visits >= counters.identity_lookups,
+                "{label} chain: a lookup examines at least one manifest entry"
+            );
+        }
+
+        let mut violations = Vec::new();
+        for (label, small_value, large_value) in [
+            (
+                "snapshot module resolutions",
+                small.module_resolutions,
+                large.module_resolutions,
+            ),
+            (
+                "snapshot module resolution visits",
+                small.module_resolution_visits,
+                large.module_resolution_visits,
+            ),
+            (
+                "accepted-read identity lookups",
+                small.identity_lookups,
+                large.identity_lookups,
+            ),
+            (
+                "accepted-read identity visits",
+                small.identity_visits,
+                large.identity_visits,
+            ),
+            (
+                "parse sources materialized",
+                small.parse_sources_materialized,
+                large.parse_sources_materialized,
+            ),
+            (
+                "parse key entries compared",
+                small.parse_key_entries_compared,
+                large.parse_key_entries_compared,
+            ),
+            (
+                "parse modules dispatched",
+                small.parse_modules_dispatched,
+                large.parse_modules_dispatched,
+            ),
+            (
+                "parse invalidation entries compared",
+                small.parse_invalidation_entries_compared,
+                large.parse_invalidation_entries_compared,
+            ),
+            ("import plan groups", small.plan_groups, large.plan_groups),
+            (
+                "import frontier roots",
+                small.frontier_roots,
+                large.frontier_roots,
+            ),
+            (
+                "plan reads reduced",
+                small.plan_reads_reduced,
+                large.plan_reads_reduced,
+            ),
+            (
+                "close records reduced",
+                small.close_records_reduced,
+                large.close_records_reduced,
+            ),
+            (
+                "overlay leaves published",
+                small.overlay_leaves_published,
+                large.overlay_leaves_published,
+            ),
+            (
+                "ledger entries cloned",
+                small.ledger_entries_cloned,
+                large.ledger_entries_cloned,
+            ),
+        ] {
+            let ratio = large_value as f64 / small_value.max(1) as f64;
+            if ratio > SIZE_RATIO * HEADROOM {
+                // Report every violating counter rather than only the first: a
+                // regression usually moves several at once, and which ones move
+                // together is what names the site.
+                violations.push(format!(
+                    "{label}: {small_value} at {SMALL} modules grew to {large_value} at \
+                     {LARGE} ({ratio:.2}x for {SIZE_RATIO}x the modules)"
+                ));
+            }
+        }
+        assert!(
+            violations.is_empty(),
+            "deep-chain work must stay linear in module count; the bound is {:.2}x \
+             ({SIZE_RATIO}x the modules times {HEADROOM} headroom):\n  {}",
+            SIZE_RATIO * HEADROOM,
+            violations.join("\n  ")
         );
     }
 


### PR DESCRIPTION
Closes the depth-scaling blind spot this week's work exposed: the quadratic scans fixed in #2508 had no counter signature — pure instruction bloat, invisible at n=32, only measurable under callgrind, which CI cannot run. This makes that class of regression countable and gates it. 7 files, +517/−36.

## Counters

New `IdentityResolutionMeter` on `RevisionedQueryDatabase` (following the `provider_observation_meter` precedent), counting the exact work the fixed scans performed: `snapshot_module_resolutions`/`_visits` at `SourceSnapshot::file_id_for_module` and `accepted_read_identity_lookups`/`_visits` at `AcceptedReadManifest::lookup_physical_identity` — with one-pass index materialization deliberately charged to its triggering lookup, so the counter can't be defeated by moving a scan into a per-module index rebuild. Deterministic by construction (monotone sums over canonical-path work, order-independent; verified identical over 5 runs); they take part in no key, hash, or artifact.

## The gate

`import_chain_identity_resolution_stays_linear_in_depth` in the driver premerge test, beside the existing chain-depth counter bounds whose blind spot it closes. In-test-generated chains at 64 and 256 modules (~0.5s total, full driver suite 1.75s); bound is size-ratio × 1.5 = 6.0× — headroom justified against segment-tier and BTreeMap log-n factors (1.33 across this span), leaving quadratic (needs 4.0× extra) nowhere to hide. **Sixteen counters ratio-checked**: the 4 new ones plus 10 existing linear-expected counters that were never ratio-gated, with liveness assertions so a ratio can't pass by a counter going dead.

## Falsifier evidence — the gate catches the real bug

With #2508's two fixes literally reverted (conflict resolution taken to the pre-fix scan bodies, not synthetic loops): the gate trips at **15.81× and 16.19×** — while **all 43 pre-existing driver tests stay green**, which is the direct measurement of the blind spot. Current tree: 3.99× and 4.04×, 44/44 pass. The revert was discarded and is not in this commit.

## Verification

Executables byte-identical at trunk vs this branch on Lattice (`b893e76c…85e5`, re-verified post-rebase), Mosaic, and both chains; existing `compiler_work` counters identical (new ones additive only). Integration note: rebased across #2510-era trunk (RUE-1571 staged wave parse) — the meter now threads through `parse_source_snapshot_module_with_stage`, verified by the full suite re-run. Suites on this branch: driver 44/44 (including the new gate), compiler 900/900, quick 30/30, fmt/clippy clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTiBg7df72iMgdpAFv5wZs)_