### PR TITLE
Refresh the Caldera compiler scaling snapshot

### DIFF
--- a/examples/caldera/SCALING.md
+++ b/examples/caldera/SCALING.md
@@ -1,24 +1,33 @@
 # Caldera compiler scaling snapshot
 
-These single-run measurements use the same compiler revision
-(`54a2eac5`), host, default `-O0` pipeline, a warm compiler binary, the
-internal linker, and `--benchmark-json`. They are a checked-in snapshot,
-not a statistically stable performance gate; RUE-1038 tracks retained
-multi-run scaling history.
+These measurements use the same compiler revision (`bcfccc3aa94`), host, and
+regime: a release-built compiler (`--target-platforms //platforms:release`),
+the default `-O0` pipeline, a warm compiler binary, the internal linker, and
+`--benchmark-json`. Each number is the median of three runs on one Linux
+x86-64 host. They are a checked-in snapshot, not a statistically stable
+performance gate; RUE-1038 tracks retained multi-run scaling history.
 
-| Program | Application Rue lines | Compiler graph lines | Files | Tokens | Compile | Peak memory | Executable |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| Lattice | 13,030 | 18,839 | 160 | 155,687 | 2.91s | 239.5MB | 1.74MB |
-| Meridian | 35,863 | 41,672 | 294 | 403,784 | 13.12s | 1.12GB | 4.54MB |
-| Caldera | 104,926 | 110,633 | 827 | 1,209,040 | 80.29s | 2.10GB | 10.27MB |
+| Program | Application Rue lines | Compiler graph lines | Files | Tokens | Functions | Compile | Peak memory | Executable |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Lattice | 13,030 | 20,462 | 161 | 160,221 | 1,221 | 3.54s | 321.7MB | 1.66MB |
+| Meridian | 35,885 | 43,295 | 295 | 405,440 | 3,074 | 8.75s | 933.7MB | 4.78MB |
+| Caldera | 104,945 | 112,258 | 828 | 1,200,390 | 8,569 | 20.81s | 2.05GB | 11.46MB |
 
-Caldera is 2.65 times Meridian's full source graph but takes 6.12 times
-as long to compile. Semantic analysis grows from 7.52s to 56.12s (7.46
-times), while code generation grows from 1.29s to 4.25s (3.30 times).
-Against Lattice, Caldera's graph is 5.87 times larger but total compile
-time is 27.57 times larger and semantic analysis is 40.32 times larger.
+Scaling is now essentially linear. Caldera's full source graph is 2.59 times
+Meridian's and compiles in 2.38 times the wall clock; it is 5.49 times
+Lattice's graph and compiles in 5.88 times the wall clock. Compile time per
+function is flat across the range (2.90ms, 2.85ms, and 2.43ms), and the
+deterministic per-function compiler-work counters stay within roughly 0.8 to
+1.3 times Lattice's rates across the semantic-provider, CFG, and
+query-runtime families. The distinctly nonlinear semantic scaling reported by
+the previous snapshot (80.29s for Caldera at revision `54a2eac5`) is no
+longer present.
 
-The current 100K result therefore succeeds as a capacity experiment but
-exposes distinctly nonlinear semantic scaling. Peak memory remains below
-2.2GB on this host, and the compiled selftest runs in roughly 0.06s, so
-compilation—not Caldera runtime—is the operative bottleneck.
+The remaining cost is an absolute constant factor rather than a scaling
+curve. On Caldera the query runtime performs roughly 33.5 million validation
+probe, visit, lease, and demand operations to support 213 thousand computed
+queries in a fresh single-revision process, and body-local symbol interners
+retain 12.5MB across 336 thousand entries for a program whose distinct
+identifier text is about 61KB. Peak memory remains above 2GB, and the
+compiled selftest runs in well under a second, so compilation — not Caldera
+runtime — remains the operative bottleneck.

--- a/scripts/generate-caldera.py
+++ b/scripts/generate-caldera.py
@@ -3315,28 +3315,37 @@ def emit_support() -> None:
     write("SCALING.md", r'''
         # Caldera compiler scaling snapshot
 
-        These single-run measurements use the same compiler revision
-        (`54a2eac5`), host, default `-O0` pipeline, a warm compiler binary, the
-        internal linker, and `--benchmark-json`. They are a checked-in snapshot,
-        not a statistically stable performance gate; RUE-1038 tracks retained
-        multi-run scaling history.
+        These measurements use the same compiler revision (`bcfccc3aa94`), host, and
+        regime: a release-built compiler (`--target-platforms //platforms:release`),
+        the default `-O0` pipeline, a warm compiler binary, the internal linker, and
+        `--benchmark-json`. Each number is the median of three runs on one Linux
+        x86-64 host. They are a checked-in snapshot, not a statistically stable
+        performance gate; RUE-1038 tracks retained multi-run scaling history.
 
-        | Program | Application Rue lines | Compiler graph lines | Files | Tokens | Compile | Peak memory | Executable |
-        | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-        | Lattice | 13,030 | 18,839 | 160 | 155,687 | 2.91s | 239.5MB | 1.74MB |
-        | Meridian | 35,863 | 41,672 | 294 | 403,784 | 13.12s | 1.12GB | 4.54MB |
-        | Caldera | 104,926 | 110,633 | 827 | 1,209,040 | 80.29s | 2.10GB | 10.27MB |
+        | Program | Application Rue lines | Compiler graph lines | Files | Tokens | Functions | Compile | Peak memory | Executable |
+        | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+        | Lattice | 13,030 | 20,462 | 161 | 160,221 | 1,221 | 3.54s | 321.7MB | 1.66MB |
+        | Meridian | 35,885 | 43,295 | 295 | 405,440 | 3,074 | 8.75s | 933.7MB | 4.78MB |
+        | Caldera | 104,945 | 112,258 | 828 | 1,200,390 | 8,569 | 20.81s | 2.05GB | 11.46MB |
 
-        Caldera is 2.65 times Meridian's full source graph but takes 6.12 times
-        as long to compile. Semantic analysis grows from 7.52s to 56.12s (7.46
-        times), while code generation grows from 1.29s to 4.25s (3.30 times).
-        Against Lattice, Caldera's graph is 5.87 times larger but total compile
-        time is 27.57 times larger and semantic analysis is 40.32 times larger.
+        Scaling is now essentially linear. Caldera's full source graph is 2.59 times
+        Meridian's and compiles in 2.38 times the wall clock; it is 5.49 times
+        Lattice's graph and compiles in 5.88 times the wall clock. Compile time per
+        function is flat across the range (2.90ms, 2.85ms, and 2.43ms), and the
+        deterministic per-function compiler-work counters stay within roughly 0.8 to
+        1.3 times Lattice's rates across the semantic-provider, CFG, and
+        query-runtime families. The distinctly nonlinear semantic scaling reported by
+        the previous snapshot (80.29s for Caldera at revision `54a2eac5`) is no
+        longer present.
 
-        The current 100K result therefore succeeds as a capacity experiment but
-        exposes distinctly nonlinear semantic scaling. Peak memory remains below
-        2.2GB on this host, and the compiled selftest runs in roughly 0.06s, so
-        compilation—not Caldera runtime—is the operative bottleneck.
+        The remaining cost is an absolute constant factor rather than a scaling
+        curve. On Caldera the query runtime performs roughly 33.5 million validation
+        probe, visit, lease, and demand operations to support 213 thousand computed
+        queries in a fresh single-revision process, and body-local symbol interners
+        retain 12.5MB across 336 thousand entries for a program whose distinct
+        identifier text is about 61KB. Peak memory remains above 2GB, and the
+        compiled selftest runs in well under a second, so compilation — not Caldera
+        runtime — remains the operative bottleneck.
     ''')
 
 


### PR DESCRIPTION
Re-measures the checked-in Caldera scaling snapshot at revision `bcfccc3aa94` with a release-built compiler (median of three `--benchmark-json` runs per workload on one Linux x86-64 host) and rewrites the analysis to match what the numbers now show.

What changed since the `54a2eac5` snapshot:

- Caldera compiles in 20.81s (was 80.29s), Meridian in 8.75s, Lattice in 3.54s. Compile time per function is flat across the 7x function-count range (2.90ms / 2.85ms / 2.43ms), and the deterministic per-function compiler-work counters stay within roughly 0.8-1.3x of Lattice's rates. The previous snapshot's "distinctly nonlinear semantic scaling" conclusion no longer holds, so the doc now says so instead.
- The table gains a Functions column and current graph dimensions, peak memory, and executable sizes.
- The analysis records where the remaining cost actually sits: an absolute constant factor, with two measured examples (33.5M query-runtime validation operations supporting 213K computed queries in a fresh single-revision process, and 12.5MB retained across body-local interners for ~61KB of distinct identifier text).

Doc-only change; no compiler behavior is affected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWsiZXjdf6YSuTDg6oJZus)_