### PR TITLE
Count and gate publication cone-retention failures

### DIFF
--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -1272,6 +1272,9 @@ mod tests {
                         retention_enforcements: 1,
                         retention_scan_entries: 4,
                     },
+                    publication: rue_perf_schema::PublicationWork {
+                        cone_retention_failures: 73,
+                    },
                 },
                 samples: vec![sample.clone(), sample],
             }],

--- a/crates/rue-compiler/src/linking.rs
+++ b/crates/rue-compiler/src/linking.rs
@@ -577,6 +577,7 @@ pub(crate) fn link_internal_with_warnings(
         query_runtime: crate::unstable::QueryRuntimeMetrics::default(),
         semantic_reachability: crate::unstable::SemanticReachabilityMetrics::default(),
         provider_observations: crate::unstable::ProviderObservationMetrics::default(),
+        publication: crate::unstable::PublicationMetrics::default(),
     })
 }
 
@@ -682,6 +683,7 @@ pub(crate) fn link_system_with_warnings(
         query_runtime: crate::unstable::QueryRuntimeMetrics::default(),
         semantic_reachability: crate::unstable::SemanticReachabilityMetrics::default(),
         provider_observations: crate::unstable::ProviderObservationMetrics::default(),
+        publication: crate::unstable::PublicationMetrics::default(),
     })
 }
 use std::io::{Read, Write};

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -2342,6 +2342,70 @@ mod tests {
     }
 
     #[test]
+    fn publication_seams_leave_no_lease_reacquisition_cascades() {
+        // RUE-1576 gate: the collection-scope handoffs replace per-node
+        // lease-reacquisition demand cascades with borrowed cone authority.
+        // Every remaining way a handoff can fail to cover a cone is
+        // structural and program-independent, so one full one-worker compile
+        // pinning both counters to zero is a complete regression detector:
+        // a nonzero value here means a seam silently degraded and the
+        // cascades returned. One worker is the exactness regime the scaling
+        // contract already pins for deterministic work; parallel workers
+        // carry a known residual seam in scope inheritance that a separate
+        // issue tracks, so the gate deliberately matches the structural
+        // probes rather than the worker matrix.
+        let root = FileId::new(1);
+        let helper = FileId::new(2);
+        let sources = [
+            SourceView::new(
+                "/checkout/main.rue",
+                "const helper = @import(\"helper.rue\");\n\
+                 struct Pair { left: i32, right: i32 }\n\
+                 fn main() -> i32 {\n\
+                     let pair = Pair { left: helper.answer(), right: 2 };\n\
+                     pair.left + pair.right\n\
+                 }",
+                root,
+            ),
+            SourceView::new(
+                "/checkout/helper.rue",
+                "pub fn answer() -> i32 { 40 }",
+                helper,
+            ),
+        ];
+        let metadata = SourceMetadata::from_sources(
+            &sources,
+            root,
+            std::collections::HashMap::from([
+                (root, "main.rue".to_string()),
+                (helper, "helper.rue".to_string()),
+            ]),
+        )
+        .unwrap();
+        let snapshot = SourceSnapshot::from_sources(&sources, metadata).unwrap();
+        let mut session = CompilerSession::with_query_concurrency(1);
+        let discovery = crate::test_support::TestDiscoveryHost::new(&snapshot)
+            .unwrap()
+            .drive(&mut session)
+            .unwrap();
+        let output = crate::queries::compile_with_session(
+            &mut session,
+            &discovery.snapshot,
+            &CompileOptions::default(),
+        )
+        .unwrap();
+        let metrics = output.unstable_metrics();
+        assert_eq!(
+            metrics.publication.cone_retention_failures, 0,
+            "every publication seam must hand its retained cone forward"
+        );
+        assert_eq!(
+            metrics.query_runtime.validation.proof_reacquisition_misses, 0,
+            "no scope may re-lease a cone its predecessor collection certified"
+        );
+    }
+
+    #[test]
     fn canonical_batch_reports_one_pass_structural_work() {
         let root = FileId::new(7);
         let helper = FileId::new(2);

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -148,6 +148,7 @@ pub struct CompileOutput {
     pub(crate) query_runtime: crate::unstable::QueryRuntimeMetrics,
     pub(crate) semantic_reachability: crate::unstable::SemanticReachabilityMetrics,
     pub(crate) provider_observations: crate::unstable::ProviderObservationMetrics,
+    pub(crate) publication: crate::unstable::PublicationMetrics,
 }
 
 impl CompileOutput {
@@ -160,6 +161,7 @@ impl CompileOutput {
             self.query_runtime,
             self.semantic_reachability,
             self.provider_observations,
+            self.publication,
         )
     }
 }
@@ -326,5 +328,8 @@ pub(crate) fn compile_rooted_with_session(
     output.query_runtime = query_runtime;
     output.semantic_reachability = semantic_reachability;
     output.provider_observations = provider_observations;
+    output.publication = crate::unstable::PublicationMetrics {
+        cone_retention_failures: session.publication_cone_retention_failures(),
+    };
     Ok(output)
 }

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -399,6 +399,10 @@ pub(crate) struct RevisionedQueryDatabase {
     /// after each within one rooted compile.
     cfg_collection_root: Arc<Mutex<PublishedCollectionRoot>>,
     codegen_collection_root: Arc<Mutex<PublishedCollectionRoot>>,
+    /// Times the declaration publication could not retain its projection cone
+    /// and fell back to unassisted validation. Expected zero; nonzero means
+    /// the seam handoff silently degraded and the demand cascades returned.
+    publication_cone_retention_failures: Arc<std::sync::atomic::AtomicU64>,
     /// Wave-parsed modules staged for `compiler.parse-module` (ADR-0075). Each
     /// entry is consumed at most once, and only on exact `SourceId` identity,
     /// so the stage is a work handoff rather than a second parse authority.
@@ -14164,6 +14168,7 @@ impl RevisionedQueryDatabase {
         // artifacts alive until body closure atomically replaces that bridge
         // with the complete rooted body graph. They are initialized here so
         // both publication evaluators share the same handoff authority.
+        let publication_cone_retention_failures = Arc::new(std::sync::atomic::AtomicU64::new(0));
         let declaration_semantics_root =
             Arc::new(Mutex::new(PublishedDeclarationSemanticsRoot::default()));
         let body_closure_root = Arc::new(Mutex::new(PublishedBodyClosureRoot::default()));
@@ -14172,6 +14177,8 @@ impl RevisionedQueryDatabase {
         let orders_for_declaration_projection = declaration_orders.clone();
         let nucleus_for_declaration_projection = semantic_nucleus.clone();
         let shells_for_declaration_projection = declaration_shells.clone();
+        let cone_retention_failures_for_declaration_publication =
+            publication_cone_retention_failures.clone();
         let declaration_semantics_projection = runtime
             .family_with_equality_and_evaluator(
                 "compiler.declaration-semantics-projection",
@@ -14265,13 +14272,25 @@ impl RevisionedQueryDatabase {
                     let mut pending = context
                         .retain_observed_family(&artifacts_for_declaration_publication)
                         .expect("candidate artifacts belong to this query runtime");
-                    // Best-effort: an incompletely observed cone leaves the
-                    // lease exactly as it is today; a complete one lets the
-                    // successor scope skip its per-node lease reacquisition.
-                    if let Ok(cone) = context
+                    // Best-effort: an unretained cone leaves the lease exactly
+                    // as it is today — the successor scope re-leases through
+                    // demand cascades instead of borrowing. That degradation is
+                    // counted (and asserted in debug builds) so it can never
+                    // read as the stronger run: the session gate pins the
+                    // counter and the miss count to zero on maintained
+                    // workloads.
+                    match context
                         .retain_observed_terminal_cone_from(&projection, &validation_fallbacks)
                     {
-                        pending.absorb(cone);
+                        Ok(cone) => pending.absorb(cone),
+                        Err(error) => {
+                            debug_assert!(
+                                false,
+                                "declaration publication could not retain its projection cone: {error:?}"
+                            );
+                            cone_retention_failures_for_declaration_publication
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        }
                     }
                     context.register_attempt_handoff(
                         PublishedDeclarationSemanticsTerminalHandoff {
@@ -16085,6 +16104,7 @@ impl RevisionedQueryDatabase {
             module_store,
             cfg_collection_root,
             codegen_collection_root,
+            publication_cone_retention_failures,
             parse_stage,
             #[cfg(test)]
             test_import_store,
@@ -19832,6 +19852,13 @@ impl RevisionedQueryDatabase {
         }
         groups.sort_by(|left, right| left[0].cmp(&right[0]));
         Ok(groups)
+    }
+
+    /// RUE-1576: how many declaration publications could not retain their
+    /// projection cone this session. Expected zero.
+    pub(crate) fn publication_cone_retention_failures(&self) -> u64 {
+        self.publication_cone_retention_failures
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Stage a wave's eager parses for the canonical parse query.

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -1826,6 +1826,14 @@ impl CompilerSession {
         self.queries.revisioned.import_ledger(revision)
     }
 
+    /// RUE-1576: how many declaration publications could not retain their
+    /// projection cone this session. Expected zero; the pipeline gate pins it.
+    pub(crate) fn publication_cone_retention_failures(&self) -> u64 {
+        self.queries
+            .revisioned
+            .publication_cone_retention_failures()
+    }
+
     /// Stages the current compiler-published import-input revision.
     ///
     /// Snapshot, context, accepted reads, and carried observations are read as

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -2383,6 +2383,15 @@ pub struct OneShotMetrics {
     pub query_runtime: QueryRuntimeMetrics,
     pub semantic_reachability: SemanticReachabilityMetrics,
     pub provider_observations: ProviderObservationMetrics,
+    pub publication: PublicationMetrics,
+}
+
+/// Deterministic publication-seam health for one compiler process (RUE-1576).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PublicationMetrics {
+    /// Times the declaration publication could not retain its projection cone
+    /// and validation fell back to per-node demand cascades. Expected zero.
+    pub cone_retention_failures: u64,
 }
 
 impl OneShotMetrics {
@@ -2392,6 +2401,7 @@ impl OneShotMetrics {
         query_runtime: QueryRuntimeMetrics,
         semantic_reachability: SemanticReachabilityMetrics,
         provider_observations: ProviderObservationMetrics,
+        publication: PublicationMetrics,
     ) -> Self {
         Self {
             files: stats.files,
@@ -2404,6 +2414,7 @@ impl OneShotMetrics {
             query_runtime,
             semantic_reachability,
             provider_observations,
+            publication,
         }
     }
 }

--- a/crates/rue-perf-schema/src/lib.rs
+++ b/crates/rue-perf-schema/src/lib.rs
@@ -98,9 +98,10 @@ pub use runtime::{
 pub use sanity::is_commit;
 pub use scaling::{
     CfgLocalEpochWork, CfgMaterializationWork, CfgPrerequisiteWork, CfgRetainedChargeWork,
-    CompilerWork, QueryRuntimeWork, SCALING_REPORT_SCHEMA_VERSION, ScalingIdentity,
-    ScalingManifest, ScalingObservation, ScalingRegime, ScalingReport, ScalingWorkload,
-    SemanticBodyStructureWork, SemanticProviderWork, SemanticReachabilityWork, WorkloadShape,
+    CompilerWork, PublicationWork, QueryRuntimeWork, SCALING_REPORT_SCHEMA_VERSION,
+    ScalingIdentity, ScalingManifest, ScalingObservation, ScalingRegime, ScalingReport,
+    ScalingWorkload, SemanticBodyStructureWork, SemanticProviderWork, SemanticReachabilityWork,
+    WorkloadShape,
 };
 pub use series::{Metric, SeriesId};
 pub use stats::{

--- a/crates/rue-perf-schema/src/scaling.rs
+++ b/crates/rue-perf-schema/src/scaling.rs
@@ -217,6 +217,22 @@ pub struct CompilerWork {
     pub cfg_local_epoch: CfgLocalEpochWork,
     /// Work performed by the revisioned query runtime.
     pub query_runtime: QueryRuntimeWork,
+    /// Publication-seam health for the proof-lease handoffs (RUE-1576).
+    #[serde(default)]
+    pub publication: PublicationWork,
+}
+
+/// Deterministic publication-seam health for one compiler process.
+///
+/// The collection-scope handoffs replace per-node lease-reacquisition demand
+/// cascades with borrowed cone authority; this group records the times a
+/// handoff could not be produced and validation silently fell back. Expected
+/// zero; the compiler's pipeline gate pins it there on maintained workloads.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PublicationWork {
+    /// Declaration publications that could not retain their projection cone.
+    pub cone_retention_failures: u64,
 }
 
 /// Deterministic structural work behind successful body lowerings and
@@ -560,6 +576,15 @@ question = "small maintained compiler frontend"
     fn rejects_unknown_fields_instead_of_guessing() {
         let error = ScalingManifest::parse(&format!("{VALID}\nsurprise = true\n")).unwrap_err();
         assert!(error.contains("unknown field"), "{error}");
+    }
+
+    #[test]
+    fn older_compiler_work_defaults_publication_seam_health() {
+        let mut encoded = serde_json::to_value(CompilerWork::default()).unwrap();
+        let object = encoded.as_object_mut().unwrap();
+        object.remove("publication");
+        let decoded: CompilerWork = serde_json::from_value(encoded).unwrap();
+        assert_eq!(decoded.publication, PublicationWork::default());
     }
 
     #[test]

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1261,6 +1261,9 @@ fn benchmark_compiler_work(
             strings: metrics.semantic.cfg.local_strings as u64,
             local_atoms: metrics.semantic.cfg.local_atoms as u64,
         },
+        publication: rue_perf_schema::PublicationWork {
+            cone_retention_failures: metrics.publication.cone_retention_failures,
+        },
         query_runtime: rue_perf_schema::QueryRuntimeWork {
             claims: runtime.claims,
             reuses: runtime.reuses,

--- a/scripts/validate-debug-assert-policy.py
+++ b/scripts/validate-debug-assert-policy.py
@@ -59,7 +59,10 @@ ALLOWANCES = {
     "crates/rue-compiler/src/diagnostic_attempt_store.rs": Allowance(2, "redundant diagnostic retention accounting"),
     "crates/rue-compiler/src/parsed_modules.rs": Allowance(1, "redundant source ownership check"),
     "crates/rue-compiler/src/revisioned_query_database.rs": Allowance(
-        2, "redundant memo-retention and pending-scheduler accounting checks"
+        3,
+        "redundant memo-retention, pending-scheduler, and publication"
+        " cone-retention accounting checks; the last is backed by an always-on"
+        " failure counter",
     ),
     "crates/rue-compiler/src/semantic_query_nucleus.rs": Allowance(1, "redundant semantic query category check"),
     "crates/rue-compiler/src/session.rs": Allowance(3, "redundant rooted-session phase and provenance checks"),


### PR DESCRIPTION
Hardening follow-up to #2511 (RUE-1576). The collection-scope seam handoffs are best-effort by design: a publication that cannot retain its projection cone leaves the lease exactly as before, and validation falls back to per-node lease reacquisition through demand cascades. That fallback is correct but silently reintroduces the amplification the seams removed. This PR makes the degradation observable and pinned:

- **Debug assertion**: debug builds assert the declaration publication retained its cone, so any structural regression fails loudly in development and CI debug runs.
- **Failure counter**: all builds count retention failures in a new `publication` group (`cone_retention_failures`), carried from the session through `OneShotMetrics` into the `compiler_work` benchmark schema. The schema field is additive — older reports decode with a zero default (covered by a schema test).
- **Pipeline gate**: a new test compiles a two-module program at one worker and pins both `publication.cone_retention_failures` and `validation.proof_reacquisition_misses` to zero. One worker is the exactness regime the scaling contract already pins for deterministic work; parallel workers carry a known residual scope-inheritance seam that is tracked separately.

Verification: `scripts/rue quick` fully green on top of current trunk (Pass 30, no build failures); rue-compiler, rue-query, rue-perf-schema, and rue-bench test targets pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JX9YAhH4NCb3nm87AgCZW8)_