### PR TITLE
RUE-1583: seed registered-batch validation authority with parent proofs

### DIFF
--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -8606,6 +8606,7 @@ impl QueryContext {
             self.task.core.clone(),
             self.task.batch_validation_authority.clone(),
         ));
+        batch_authority.seed_from_task(&self.task);
         // `tracing` dispatch is thread-local. Carry the caller's subscriber into
         // each child so scheduled evaluation keeps compiler timing/log events.
         let tracing_dispatch = tracing::dispatcher::get_default(Clone::clone);
@@ -9388,6 +9389,29 @@ impl BatchValidationAuthority {
             parent,
             state: RwLock::new(BatchValidationAuthorityState::default()),
         }
+    }
+
+    /// Seeds this batch's shared authority with every identity the spawning
+    /// task has already proven. A batch child starts with no task-local
+    /// endorsements, so without the seed every batch begins blind to the
+    /// parent's proofs and each child re-demands ubiquitous shared leaves —
+    /// primitive layouts, standard-library producers — the parent proved
+    /// moments earlier. The seeded identities carry no leases of their own:
+    /// they are backed by the parent task's held leases, which outlive this
+    /// authority because the parent joins every child before its rooted
+    /// request can release them.
+    fn seed_from_task(&self, task: &Task) {
+        let seeded: Vec<(u64, u64, Revision)> = {
+            let scopes = lock(&task.validation_endorsements);
+            let Some(scope) = scopes.first() else {
+                return;
+            };
+            if scope.identities.is_empty() {
+                return;
+            }
+            scope.identities.iter().copied().collect()
+        };
+        write(&self.state).endorsements.extend(seeded);
     }
 
     /// Atomically publishes one completed child's proof and its retention
@@ -17424,6 +17448,84 @@ mod tests {
         assert_eq!(borrowed.memo_hits, 1);
         assert_eq!(borrowed.endorsement_probes, 2);
         assert_eq!(borrowed.endorsement_hits, 1);
+    }
+
+    #[test]
+    fn registered_batch_seeds_parent_proofs_into_its_shared_authority() {
+        let runtime = QueryRuntime::new(1);
+        let first = Revision::new(40, 13);
+        let second = Revision::new(41, 13);
+        let input = InputIdentity::new("source", "batch-seed");
+        runtime
+            .publish_revision(first, [(input.clone(), 1)])
+            .unwrap();
+        runtime
+            .publish_revision(second, [(input.clone(), 1)])
+            .unwrap();
+
+        let input_for_leaf = input.clone();
+        let leaf = runtime
+            .family_with_evaluator::<Key, u64, _>("batch-seed-leaf", 8, move |context, _, _| {
+                context.input(input_for_leaf.clone())?;
+                Ok(QueryOutput::success(1))
+            })
+            .unwrap();
+        let leaf_for_middle = leaf.clone();
+        let middle = runtime
+            .family_with_evaluator::<Key, u64, _>("batch-seed-middle", 8, move |context, _, _| {
+                context.query_registered(&leaf_for_middle, Key("leaf"))?;
+                Ok(QueryOutput::success(2))
+            })
+            .unwrap();
+        let middle_for_top = middle.clone();
+        let top = runtime
+            .family_with_evaluator::<Key, u64, _>("batch-seed-top", 8, move |context, _, _| {
+                context.query_registered(&middle_for_top, Key("middle"))?;
+                Ok(QueryOutput::success(3))
+            })
+            .unwrap();
+
+        runtime
+            .request_registered(&top, first, Key("top"), CancellationToken::new())
+            .into_result()
+            .unwrap();
+        runtime
+            .request_registered(&top, second, Key("top"), CancellationToken::new())
+            .into_result()
+            .unwrap();
+
+        let before = runtime.metrics().validation;
+        let root = runtime.family::<Key, u64>("batch-seed-root", 1).unwrap();
+        let top_for_root = top.clone();
+        runtime
+            .request(
+                &root,
+                second,
+                Key("root"),
+                CancellationToken::new(),
+                move |context| {
+                    let _proof = context.endorse_registered_validations();
+                    // The first batch pays the reacquisition demands and its
+                    // absorbed proofs land in this task's endorsement scope.
+                    context.query_registered_batch(&top_for_root, [Key("top")])?;
+                    // A later batch in the same proof scope starts with those
+                    // proofs seeded into its shared authority, so its children
+                    // borrow them instead of re-demanding the same cone.
+                    context.query_registered_batch(&top_for_root, [Key("top")])?;
+                    Ok(QueryOutput::success(0))
+                },
+            )
+            .into_result()
+            .unwrap();
+
+        let validation = runtime.metrics().validation.saturating_sub(before);
+        assert_validation_work_consistent(validation);
+        assert_eq!(validation.certificate_misses, 0);
+        assert_eq!(
+            validation.proof_reacquisition_misses, 2,
+            "only the first batch re-leases the cone; the second borrows the seed"
+        );
+        assert_eq!(validation.demand_reuses, 2);
     }
 
     #[test]


### PR DESCRIPTION
Fixes RUE-1583.

Attribution (temporary env-gated logging at the miss site, since reverted) showed the parallel-only reacquisition misses concentrate on repeated keys: on Lattice with automatic workers, 67 hot keys — the `U64` layout terminal alone 370 times, `PtrMut(U64)` 219, the std `RawBuf`/`ArrayBuf` anonymous producers 787/578, plus anonymous-nominal and specialization nodes — account for 84% of 6,980 misses. The mechanism: a batch child starts with no task-local endorsements, and each new structured batch's `BatchValidationAuthority` starts empty, so every batch began blind to proofs the parent already held and children re-demanded the same ubiquitous shared leaves once per batch. Serial runs never see this because each item publishes into the parent before the next item starts.

## What this does

`BatchValidationAuthority::seed_from_task` copies the spawning task's outer-scope endorsement identities into the batch's shared authority at construction, and `batch()` calls it right after creating the authority. The seeded identities carry no leases of their own: they are backed by the parent task's held leases, which outlive the authority because the parent joins every child before its rooted request can release anything. No proof semantics change; `retain_observed_terminal_cones_from` stays fail-closed; the snapshot is taken outside the authority's write lock.

## Evidence

Release build, paired against trunk `e52b468` on the same host, `--benchmark-json`:

| workload | workers | misses before | misses after |
| --- | --- | ---: | ---: |
| Caldera | auto | 10,575 | **1,053** |
| Meridian | auto | 7,442 | 3,355 |
| Lattice | auto | 6,821 | 4,666 |
| Lattice / Caldera | `-j1` | 0 | 0 |

All non-`query_runtime` compiler-work counters are byte-identical on Caldera. The win grows with program size because repeated-key misses across successive batches dominate at scale. This container's wall-clock noise exceeds the expected recovery; wall claims should come from the hosted reference regime.

The residue is the first-touch race inside a single batch: concurrently started children validating overlapping cones before any sibling has published. Closing that would need incremental mid-item lease-plus-endorsement publication, which touches the atomicity contract `publish_child` maintains (leases become visible in the same write transaction as the endorsements they back) — left for a separate design discussion, noted on the Linear issue.

## Testing

- New rue-query unit test `registered_batch_seeds_parent_proofs_into_its_shared_authority`: a second batch in the same proof scope adds zero reacquisition misses.
- rue-query suite 183/183; `scripts/rue quick` green (30/30); fmt clean.
- Paired counter/byte-identity verification above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWsiZXjdf6YSuTDg6oJZus)_