### PR TITLE
Pre-size constraint storage from body RIR length

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -388,11 +388,12 @@ impl<'a> ConstraintGenerator<'a> {
     ) -> Self {
         let strbuf_type = type_pool.lang_item_type(crate::LangItem::StrBuf);
         let string_literal_default = Type::ERROR;
+        let rir_capacity = rir.len();
         Self {
             rir,
             interner,
             type_vars: TypeVarAllocator::new(),
-            constraints: Vec::new(),
+            constraints: Vec::with_capacity(rir_capacity),
             expr_types: HashMap::new(),
             functions: Some(functions),
             builtin_structs: Some(builtin_structs),
@@ -440,11 +441,12 @@ impl<'a> ConstraintGenerator<'a> {
     ) -> Self {
         let strbuf_type = type_pool.lang_item_type(crate::LangItem::StrBuf);
         let string_literal_default = Type::ERROR;
+        let rir_capacity = rir.len();
         Self {
             rir,
             interner,
             type_vars: TypeVarAllocator::new(),
-            constraints: Vec::new(),
+            constraints: Vec::with_capacity(rir_capacity),
             expr_types: HashMap::new(),
             functions: None,
             builtin_structs: None,


### PR DESCRIPTION
## Summary
- pre-size the order-preserving constraint vector from the body RIR length
- keep the expression-type map unmodified because its iteration order is semantically observable

## Validation
- 26 paired fresh-process Lattice -O3/-j1 runs: 578.865 ms candidate median vs 586.098 ms baseline (-1.23%), 17/26 wins
- compiler work counters identical across all pairs
- emitted output identical across all pairs
- scripts/rue quick
- scripts/rue unit compiler warm
- scripts/rue premerge