### PR TITLE
Count attempt-handoff observation as a scan-shaped site

### DIFF
--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -2007,6 +2007,24 @@ impl CompilerSession {
             .physical_identity_visits()
     }
 
+    /// Attempt-handoff lifecycles offered to a task's observation scope, and
+    /// the scope positions examined answering them. See
+    /// [`rue_query::RuntimeMetrics::handoff_observations`].
+    pub(crate) fn handoff_observations(&self) -> u64 {
+        self.queries
+            .revisioned
+            .runtime_retention_metrics()
+            .handoff_observations
+    }
+
+    /// See [`Self::handoff_observations`].
+    pub(crate) fn handoff_observation_visits(&self) -> u64 {
+        self.queries
+            .revisioned
+            .runtime_retention_metrics()
+            .handoff_observation_visits
+    }
+
     /// A snapshot of the production provider-op observation counters
     /// (ADR-0066 §4).
     pub(crate) fn provider_observation_metrics(

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -321,6 +321,24 @@ pub fn accepted_read_identity_visits(session: &crate::CompilerSession) -> u64 {
     session.accepted_read_identity_visits()
 }
 
+/// Attempt-handoff lifecycles offered to a task's observation scope ("has this
+/// scope already recorded this lifecycle?"), asked once per handoff a task
+/// observes or inherits from a structured child. Paired with
+/// [`handoff_observation_visits`] exactly as the two pairs above.
+pub fn handoff_observations(session: &crate::CompilerSession) -> u64 {
+    session.handoff_observations()
+}
+
+/// Observation-scope positions examined answering [`handoff_observations`]. An
+/// already committed lifecycle carries no obligation and is answered without
+/// being recorded, so a scope holds only what is still live and the ratio
+/// between these two counters sits at one; a scope that begins accumulating
+/// live lifecycles turns each observation into a walk over the ones before it,
+/// and that ratio is the only thing which moves.
+pub fn handoff_observation_visits(session: &crate::CompilerSession) -> u64 {
+    session.handoff_observation_visits()
+}
+
 /// An owned snapshot of the provider-op observation counters (RUE-1091,
 /// ADR-0066 §4): how many facts of each §4 family the exact body-fact provider
 /// observed. Owned plain data, not a query-engine record. These are live

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -3902,6 +3902,18 @@ pub struct RuntimeMetrics {
     /// Publish-side batching keeps this linear when a live protected closure
     /// grows past its configured soft floor.
     pub retention_scan_entries: u64,
+    /// Attempt-handoff lifecycles offered to a task's observation scope, and
+    /// the scope positions examined answering them.
+    ///
+    /// These are a pair. Recording a lifecycle deduplicates it by pointer
+    /// identity against every lifecycle the same scope already observed, so
+    /// the question count is linear in the work a program dispatches while
+    /// the visit count is what distinguishes a bounded scope from one that
+    /// accumulates. Only their ratio is a scaling property: a scope that
+    /// starts holding live lifecycles turns each observation into a walk over
+    /// the ones before it, and nothing else this runtime publishes moves.
+    pub handoff_observations: u64,
+    pub handoff_observation_visits: u64,
     /// Peak simultaneously executing query bodies.
     pub peak_active_bodies: u64,
     /// Peak tasks simultaneously owning execution permits. Nested query bodies
@@ -3981,6 +3993,8 @@ struct Metrics {
     retention_growth: AtomicU64,
     retention_enforcements: AtomicU64,
     retention_scan_entries: AtomicU64,
+    handoff_observations: AtomicU64,
+    handoff_observation_visits: AtomicU64,
     active_bodies: AtomicU64,
     peak_active_bodies: AtomicU64,
     active_query_workers: AtomicU64,
@@ -4074,6 +4088,8 @@ impl Metrics {
             retention_growth: self.retention_growth.load(Ordering::Relaxed),
             retention_enforcements: self.retention_enforcements.load(Ordering::Relaxed),
             retention_scan_entries: self.retention_scan_entries.load(Ordering::Relaxed),
+            handoff_observations: self.handoff_observations.load(Ordering::Relaxed),
+            handoff_observation_visits: self.handoff_observation_visits.load(Ordering::Relaxed),
             peak_active_bodies: self.peak_active_bodies.load(Ordering::Relaxed),
             peak_query_workers: self.peak_query_workers.load(Ordering::Relaxed),
             active_task_leases: self.active_task_leases.load(Ordering::Relaxed),
@@ -4121,6 +4137,16 @@ impl Metrics {
 
     fn body_left(&self) {
         self.active_bodies.fetch_sub(1, Ordering::AcqRel);
+    }
+
+    /// One handoff-observation question and the scope positions it examined.
+    /// See the field docs on [`RuntimeMetrics::handoff_observations`]; `visits`
+    /// is never zero, so the pair's ratio starts at one and can only be moved
+    /// by a scope that accumulates.
+    fn handoff_observed(&self, visits: u64) {
+        self.handoff_observations.fetch_add(1, Ordering::Relaxed);
+        self.handoff_observation_visits
+            .fetch_add(visits, Ordering::Relaxed);
     }
 
     fn permit_acquired(&self) {
@@ -10005,6 +10031,15 @@ fn commit_handoff(
     }))
 }
 
+/// Positions a linear membership scan examined: everything up to and including
+/// a hit, or the whole list on a miss. Asking at all costs the one question, so
+/// this is never zero — which anchors a visits-per-lookup ratio at one instead
+/// of at zero, where a scope that stopped being consulted would read as an
+/// improvement.
+fn scan_visits(found: Option<usize>, len: usize) -> u64 {
+    found.map_or(len, |index| index + 1).max(1) as u64
+}
+
 fn abort_handoff(
     handoff: &mut dyn QueryAttemptHandoff,
 ) -> Result<(), Box<dyn std::any::Any + Send>> {
@@ -10869,32 +10904,47 @@ impl Task {
         true
     }
 
+    /// Record `handoff` in the innermost live observation scope.
+    ///
+    /// A scope holds only lifecycles that are still live: an already committed
+    /// one carries no obligation and is answered without being recorded. What
+    /// remains is deduplicated by pointer identity, which is a scan over what
+    /// the scope already holds — so this site is counted as a lookup/visit
+    /// pair. See [`RuntimeMetrics::handoff_observations`].
     fn observe_handoff(&self, handoff: Arc<AttemptHandoffLifecycle>) -> bool {
         if Arc::ptr_eq(&handoff, AttemptHandoffLifecycle::shared_committed_ref())
             || handoff.is_committed()
         {
+            self.core.metrics.handoff_observed(1);
             return true;
         }
         if !self.validate_handoff(&handoff) {
+            self.core.metrics.handoff_observed(1);
             return false;
         }
         let mut stack = lock(&self.stack);
         if let Some(frame) = stack.last_mut() {
-            if !frame
+            let recorded = frame
                 .observed_handoffs
                 .iter()
-                .any(|current| Arc::ptr_eq(current, &handoff))
-            {
+                .position(|current| Arc::ptr_eq(current, &handoff));
+            self.core
+                .metrics
+                .handoff_observed(scan_visits(recorded, frame.observed_handoffs.len()));
+            if recorded.is_none() {
                 frame.observed_handoffs.push(handoff);
             }
             return true;
         }
         drop(stack);
         let mut observed = lock(&self.observed_handoffs);
-        if !observed
+        let recorded = observed
             .iter()
-            .any(|current| Arc::ptr_eq(current, &handoff))
-        {
+            .position(|current| Arc::ptr_eq(current, &handoff));
+        self.core
+            .metrics
+            .handoff_observed(scan_visits(recorded, observed.len()));
+        if recorded.is_none() {
             // Keep only the returned root. It owns its dependency lifecycle
             // DAG, which the commit barrier expands once in dependency order.
             observed.push(handoff);

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -20,12 +20,13 @@ use rue_compiler::unstable::{
 #[cfg(test)]
 use rue_compiler::unstable::{
     accepted_read_identity_lookups, accepted_read_identity_visits, committed_successor_sharing,
-    exact_import_groups_dispatched, import_close_records_reduced, import_frontier_roots_requested,
-    import_plan_groups_constructed, import_view_full_leaves_published,
-    import_view_ledger_entries_cloned, import_view_overlay_leaves_published,
-    import_view_read_entries_compared, import_view_source_entries_compared,
-    parse_invalidation_entries_compared, parse_key_entries_compared, parse_modules_dispatched,
-    parse_sources_materialized, snapshot_module_resolution_visits, snapshot_module_resolutions,
+    exact_import_groups_dispatched, handoff_observation_visits, handoff_observations,
+    import_close_records_reduced, import_frontier_roots_requested, import_plan_groups_constructed,
+    import_view_full_leaves_published, import_view_ledger_entries_cloned,
+    import_view_overlay_leaves_published, import_view_read_entries_compared,
+    import_view_source_entries_compared, parse_invalidation_entries_compared,
+    parse_key_entries_compared, parse_modules_dispatched, parse_sources_materialized,
+    snapshot_module_resolution_visits, snapshot_module_resolutions,
 };
 #[cfg(test)]
 use rue_compiler::unstable::{frontend_query_invalidations, rooted_cfg};
@@ -2502,6 +2503,8 @@ mod tests {
         module_resolution_visits: u64,
         identity_lookups: u64,
         identity_visits: u64,
+        handoff_observations: u64,
+        handoff_observation_visits: u64,
         parse_sources_materialized: u64,
         parse_key_entries_compared: u64,
         parse_modules_dispatched: u64,
@@ -2544,6 +2547,8 @@ mod tests {
             module_resolution_visits: snapshot_module_resolution_visits(&result.session),
             identity_lookups: accepted_read_identity_lookups(&result.session),
             identity_visits: accepted_read_identity_visits(&result.session),
+            handoff_observations: handoff_observations(&result.session),
+            handoff_observation_visits: handoff_observation_visits(&result.session),
             parse_sources_materialized: parse_sources_materialized(&result.session),
             parse_key_entries_compared: parse_key_entries_compared(&result.session),
             parse_modules_dispatched: parse_modules_dispatched(&result.session),
@@ -2579,6 +2584,14 @@ mod tests {
     /// `*_lookups` counts the identity questions asked, `*_visits` counts the
     /// positions examined answering them, and their ratio is exactly what an
     /// index-versus-scan regression moves.
+    ///
+    /// The handoff pair extends that shape past discovery into the query
+    /// runtime (RUE-1579). Recording an attempt handoff deduplicates it by
+    /// pointer identity against everything the same observation scope already
+    /// holds, so a scope that starts retaining live lifecycles turns each
+    /// observation into a walk over the ones before it — the same quadratic
+    /// with no dispatch to show for it. That site measured superlinear once
+    /// under callgrind and is linear now; counting it is what keeps it so.
     ///
     /// SIZES. 64 and 256 modules: a 4x span, wide enough that a quadratic term
     /// shows as ~16x against the ~4x asserted here, and cheap enough for the
@@ -2625,6 +2638,14 @@ mod tests {
                 counters.identity_visits >= counters.identity_lookups,
                 "{label} chain: a lookup examines at least one manifest entry"
             );
+            assert!(
+                counters.handoff_observations >= modules as u64,
+                "{label} chain: every module's published work is observed as a handoff"
+            );
+            assert!(
+                counters.handoff_observation_visits >= counters.handoff_observations,
+                "{label} chain: an observation examines at least one scope position"
+            );
         }
 
         let mut violations = Vec::new();
@@ -2648,6 +2669,16 @@ mod tests {
                 "accepted-read identity visits",
                 small.identity_visits,
                 large.identity_visits,
+            ),
+            (
+                "handoff observations",
+                small.handoff_observations,
+                large.handoff_observations,
+            ),
+            (
+                "handoff observation visits",
+                small.handoff_observation_visits,
+                large.handoff_observation_visits,
             ),
             (
                 "parse sources materialized",


### PR DESCRIPTION
Resolves RUE-1579 with an honest verdict plus durable coverage. 4 files, +130/−12.

## The verdict: not reproducible — already linear

The issue's 7.24×-per-4×-modules measurement predates six rue-query merges. Re-measured on current trunk (callgrind, release `-O3 -j1`, chains at n=256/1024/4096): `Task::observe_handoff` scales **3.955× and 3.989× per 4× modules** across a 16× span, at a flat 28.0 Ir/call and 0.07% of the build. Structural reason: the two `Arc::ptr_eq` linear scans (the quadratic-capable part) short-circuit on committed lifecycles — `validate_handoff_once` is reached 7 times total regardless of depth, so the observed-handoff scopes never grow.

## What ships instead: make the scan countable

Per the depth-scaling gate's own rationale (#2510, "make scan-shaped work countable"): new `handoff_observations`/`handoff_observation_visits` runtime counters (the scan rewritten `any` → `position` so its length is countable — semantically identical, +3 Ir/call, total build Ir within layout noise), threaded through the same unstable accessors as the existing meter counters — deliberately NOT added to the published `compiler_work` schema, so its shape is untouched. The pair joins `import_chain_identity_resolution_stays_linear_in_depth` with floor assertions (`observations ≥ modules`, `visits ≥ observations`) and ratio entries under the existing 4×·1.5 bound: measured 3.99×, visits/observation exactly 1.00, deterministic across runs. Only an accumulating handoff scope can move it — which is exactly the regression that would recreate the issue.

## Verification

Executables byte-identical before/after on Lattice, Mosaic, chain256, chain1024 at `-j1` and `-j4` (8/8); Lattice hash re-verified independently on this branch post-rebase (`b893e76c…85e5`). `compiler_work` identical on all four workloads at `-j1` and on both chains at `-j4` (Lattice/Mosaic `-j4` vary only in the documented above-one-worker `query_runtime` set, confirmed by an unchanged-binary self-comparison). Suites: rue-query 182 (re-run on this branch), driver 44/44 including the extended gate (re-run), compiler + public-api, quick 30; fmt/clippy gates clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTiBg7df72iMgdpAFv5wZs)_