### PR TITLE
Pre-size AIR instruction storage from imported body length

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -2459,6 +2459,10 @@ impl Air {
         }
     }
 
+    pub(crate) fn reserve_instructions(&mut self, additional: usize) {
+        self.instructions.reserve(additional);
+    }
+
     /// Record a local slot as a non-owning borrow binding (see `borrow_slots`).
     pub(crate) fn add_borrow_slot(&mut self, slot: u32) {
         if !self.borrow_slots.contains(&slot) {

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -772,6 +772,7 @@ where
         let return_type = import_type(&body.return_type)?;
         let mut air = Air::new(return_type);
         let inst_len = body.instructions.len();
+        air.reserve_instructions(inst_len);
         let place_len = body.places.len();
         let check_ref = |r: u32, current: usize| -> Result<AirRef, F> {
             let index = r as usize;


### PR DESCRIPTION
## Summary
- reserve each imported AIR body's instruction arena from the validated semantic instruction count
- preserve AIR contents, validation, ordering, and output behavior

## Evidence
- Lattice `-O3 -j1`, fresh-process paired benchmark, 26 runs
- baseline median: 591.579 ms
- candidate median: 583.843 ms
- paired median: -5.897 ms
- wins/losses: 16/10
- compiler-work counters: identical
- emitted output SHA-256: identical (`b893e76cfabed737b149d0e8c4d8527077dedd17da78418db20a28a7d30885e5`)

## Validation
- `scripts/rue unit air` — 653 passed
- `scripts/rue quick` — 30 targets passed
- `scripts/rue premerge` — 194 checks passed