### PR TITLE
ADR-0077: accepted, with two review clarifications

### DIFF
--- a/docs/designs/0077-batch-endorsement-inheritance.md
+++ b/docs/designs/0077-batch-endorsement-inheritance.md
@@ -1,11 +1,11 @@
 ---
 id: 0077
 title: "Endorsement inheritance for batch children"
-status: proposal
+status: accepted
 tags: [architecture, compiler, performance, query-engine, parallelization]
 feature-flag: null
 created: 2026-08-18
-accepted:
+accepted: 2026-08-18
 implemented:
 spec-sections: []
 superseded-by:
@@ -16,7 +16,16 @@ relates: ["ADR-0063", "ADR-0071", "ADR-0073", "RUE-1577"]
 
 ## Status
 
-Proposed, pending review. Follows the measurement note
+Accepted 2026-08-18. Direction 1 was implemented while this record was
+under review: PR #2517 (RUE-1583) seeds each batch's shared authority
+with the spawning task's proved identities at construction
+(`BatchValidationAuthority::seed_from_task`), one point on the
+representation spectrum §"Implementation shape" leaves open, argued on
+exactly the structured-lifetime grounds §1 states. The remaining gap is
+the intra-batch first-touch race (RUE-1584), which lives inside §2's
+sibling-to-sibling direction.
+
+Follows the measurement note
 `docs/notes/compiler-worker-scaling.md` (RUE-1577): the first
 characterization of worker scaling found that adding workers makes
 semantic analysis slower — 0.462× paired at `-j4` on Lattice, dragging
@@ -59,7 +68,14 @@ children under a structured-lifetime argument, in two directions:
    shared `batch_validation_authority`), never by direct mutable sharing
    of another task's live scope. Published authority is already trusted
    cross-task; this direction adds no new trust edge either, only more
-   traffic through an existing one.
+   traffic through an existing one. Publication granularity within this
+   direction is the implementation's choice: publishing per completed
+   item, or per individually proved endorsement, before the proving
+   child itself completes is still publish-on-terminal and adds no new
+   trust edge — provided the atomicity invariant holds (an identity
+   becomes visible in the same write transaction that already retains
+   the lease or fallback backing it) and no task ever observes
+   another's incomplete validation state.
 
 What this ADR does NOT permit: honoring an identity no task in the
 batch's structured lineage proved; endorsements outliving the batch join

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -239,6 +239,6 @@ The table is generated from ADR frontmatter. Run
 | [0074](0074-structural-node-identity.md) | Structural node identity for dependency order and retained charge | Implemented | architecture, compiler, performance, query-engine |
 | [0075](0075-wave-granular-import-discovery.md) | Wave-granular import discovery revisions and cumulative exhaustion witness | Implemented | architecture, compiler, incremental, performance, query-engine |
 | [0076](0076-shared-revision-symbol-space.md) | Shared revision symbol space for body analysis | Implemented | architecture, compiler, performance, query-engine, type-system |
-| [0077](0077-batch-endorsement-inheritance.md) | Endorsement inheritance for batch children | Proposal | architecture, compiler, performance, query-engine, parallelization |
+| [0077](0077-batch-endorsement-inheritance.md) | Endorsement inheritance for batch children | Accepted | architecture, compiler, performance, query-engine, parallelization |
 | [0078](0078-import-resolution-policy.md) | Single-candidate import resolution and program-anchored std | Accepted | language, modules, spec, compiler |
 <!-- ADR-INDEX:END -->


### PR DESCRIPTION
Records the maintainer's acceptance of ADR-0077 (endorsement inheritance for batch children), with the two clarifications from the joint 0077×0078 review:

- **Status**: `accepted` (2026-08-18), noting that direction 1 was implemented during review — PR #2517's `BatchValidationAuthority::seed_from_task` — as one point on the representation spectrum the ADR leaves open, and naming the remaining gap (the intra-batch first-touch race, RUE-1584) as living inside direction 2.
- **Direction 2 granularity**: per-item or per-proof publication before the proving child completes is still publish-on-terminal and adds no new trust edge, provided the lease-before-identity atomicity invariant holds and no task observes another's incomplete validation state. This settles the design question PR #2517 deferred, and is the contract the in-flight RUE-1584 fix is built against.

`scripts/validate-adrs.py --write` run; registry valid; index status updated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JX9YAhH4NCb3nm87AgCZW8)_