### PR TITLE
Cache classified name resolutions

### DIFF
--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -21362,7 +21362,7 @@ struct SemanticNucleusCacheEntry {
 
 struct LookupNameCacheEntry {
     key: LookupNameKey,
-    terminal: Arc<rue_query::QueryTerminal<LookupNameValue>>,
+    resolution: rue_air::NameResolution,
 }
 
 // The maintained cold scaling curve selects 16 slots. Larger capacities remove
@@ -22955,10 +22955,7 @@ impl<'a> CompilerBodyFactProvider<'a> {
             #[cfg(test)]
             self.lookup_name_cache_hits
                 .set(self.lookup_name_cache_hits.get() + 1);
-            return match entry.terminal.outcome() {
-                rue_query::QueryOutcome::Success(value) => name_resolution_from_value(value),
-                _ => rue_air::NameResolution::IndexUnavailable,
-            };
+            return entry.resolution.clone();
         }
         let key = LookupNameKey {
             module: module.clone(),
@@ -22983,8 +22980,10 @@ impl<'a> CompilerBodyFactProvider<'a> {
                     rue_query::QueryOutcome::Success(value) => name_resolution_from_value(value),
                     _ => rue_air::NameResolution::IndexUnavailable,
                 };
-                self.lookup_name_cache.borrow_mut()[cache_slot] =
-                    Some(LookupNameCacheEntry { key, terminal });
+                self.lookup_name_cache.borrow_mut()[cache_slot] = Some(LookupNameCacheEntry {
+                    key,
+                    resolution: resolution.clone(),
+                });
                 resolution
             }
             Err(abort) => {


### PR DESCRIPTION
## What changed

Cache the already-classified `rue_air::NameResolution` in the task-local name lookup cache.

## Why

On cache hits, the compiler was repeatedly rebuilding candidate vectors and reclassifying the same resolution. The cache now returns the immutable classification directly while preserving the existing observed query terminal and lease behavior.

## Measured impact

Across 52 alternating fresh-process `-j1 -O3` Lattice compilations against merged trunk:

- Paired median: **-0.884 ms**
- Paired mean: **-3.079 ms**
- Candidate won **31/52** pairs
- Output SHA-256 and `compiler_work` metrics were identical

## Validation

- `scripts/rue unit compiler`: 901 passed, 0 failed, 6 ignored
- `scripts/rue quick`: 30 passed, 0 failed
- `scripts/rue premerge`: 194 passed, 0 failed