### PR TITLE
Implement ADR-0078: single-candidate import resolution

### DIFF
--- a/crates/rue-air/src/sema/provider.rs
+++ b/crates/rue-air/src/sema/provider.rs
@@ -181,8 +181,6 @@ pub enum ImportResolution {
     /// Exactly one directive names it, but the specifier is malformed (it
     /// normalizes to an empty module path).
     Rejected,
-    /// Multiple directives in the consulting module name the same target.
-    Ambiguous,
 }
 
 /// Whether a receiver member is an instance method (takes a `self` receiver) or

--- a/crates/rue-cli-tests/cases/array_element_module.toml
+++ b/crates/rue-cli-tests/cases/array_element_module.toml
@@ -22,7 +22,7 @@ compile_fail = true
 error_contains = ["E0206", "<module>"]
 files = [
     { path = "main.rue", source = """
-fn main() -> i32 { let h = @import("helper"); let arr = [h, h]; 0 }
+fn main() -> i32 { let h = @import("helper.rue"); let arr = [h, h]; 0 }
 """ },
     { path = "helper.rue", source = """
 pub fn value() -> i32 { 1 }
@@ -37,7 +37,7 @@ compile_fail = true
 error_contains = ["E0206", "<module>"]
 files = [
     { path = "main.rue", source = """
-fn main() -> i32 { let h = @import("helper"); let arr = [h; 3]; 0 }
+fn main() -> i32 { let h = @import("helper.rue"); let arr = [h; 3]; 0 }
 """ },
     { path = "helper.rue", source = """
 pub fn value() -> i32 { 1 }

--- a/crates/rue-cli-tests/cases/assoc_fn_privacy.toml
+++ b/crates/rue-cli-tests/cases/assoc_fn_privacy.toml
@@ -18,7 +18,7 @@ description = "Cross-directory associated-function calls on a private struct are
 name = "cross_dir_unqualified_private_assoc_fn_rejected"
 files = [
     { path = "main.rue", source = """
-const lib = @import("sub/lib");
+const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
     let s = Secret.make();
@@ -41,7 +41,7 @@ error_contains = ["E0201", "undefined variable 'Secret'"]
 name = "cross_dir_qualified_private_assoc_fn_rejected"
 files = [
     { path = "main.rue", source = """
-const lib = @import("sub/lib");
+const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
     let s = lib.Secret.make();
@@ -63,7 +63,7 @@ error_contains = ["E0706", "struct `Secret` is private"]
 name = "cross_dir_pub_assoc_fn_allowed"
 files = [
     { path = "main.rue", source = """
-const lib = @import("sub/lib");
+const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
     let p = lib.Point.origin();
@@ -109,7 +109,7 @@ exit_code = 42
 name = "cross_dir_comptime_bound_assoc_fn_allowed"
 files = [
     { path = "main.rue", source = """
-const lib = @import("sub/lib");
+const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
     let P = lib.Point;

--- a/crates/rue-cli-tests/cases/byref_params.toml
+++ b/crates/rue-cli-tests/cases/byref_params.toml
@@ -440,7 +440,7 @@ description = "Passing the same variable to two inout parameters of a module mem
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let m = @import("mod_swap");
+    let m = @import("mod_swap.rue");
     let mut x = 1;
     m.swap(inout x, inout x);
     0
@@ -463,7 +463,7 @@ description = "Passing the same variable as both borrow and inout to a module me
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let m = @import("mod_obs");
+    let m = @import("mod_obs.rue");
     let mut x = 1;
     m.observe(borrow x, inout x)
 }
@@ -486,7 +486,7 @@ fn observe(borrow a: i32, inout b: i32) -> i32 {
     a + b
 }
 fn main() -> i32 {
-    let m = @import("helper");
+    let m = @import("helper.rue");
     let _ = m.one();
     let mut x = 5;
     observe(borrow x, inout x)
@@ -507,7 +507,7 @@ description = "Control: distinct variables passed by-ref to a module member call
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let m = @import("mod_swap");
+    let m = @import("mod_swap.rue");
     let mut x = 1;
     let mut y = 41;
     m.swap(inout x, inout y);

--- a/crates/rue-cli-tests/cases/comptime_value_params.toml
+++ b/crates/rue-cli-tests/cases/comptime_value_params.toml
@@ -116,7 +116,7 @@ name = "module_member_call_with_comptime_param"
 description = "Calling a comptime-value function through a module object routes through specialization."
 files = [
     { path = "main.rue", source = """
-const util = @import("util");
+const util = @import("util.rue");
 fn main() -> i32 {
     @dbg(util.scale(5, 7));
     0

--- a/crates/rue-cli-tests/cases/const_init.toml
+++ b/crates/rue-cli-tests/cases/const_init.toml
@@ -130,7 +130,7 @@ exit_code = 3
 name = "module_binding_exempt_from_annotation"
 files = [
     { path = "main.rue", source = """
-const cfg = @import("cfg");
+const cfg = @import("cfg.rue");
 const X: i32 = cfg.ANSWER;
 
 fn main() -> i32 {

--- a/crates/rue-cli-tests/cases/diagnostic_json.toml
+++ b/crates/rue-cli-tests/cases/diagnostic_json.toml
@@ -138,7 +138,7 @@ JSON formatter shares with the text formatter (RUE-175).
 """
 files = [
   { path = "main.rue", source = """
-const helper = @import("helper");
+const helper = @import("helper.rue");
 
 fn main() -> i32 {
     let bad: i32 = true;

--- a/crates/rue-cli-tests/cases/emit_pipeline.toml
+++ b/crates/rue-cli-tests/cases/emit_pipeline.toml
@@ -143,7 +143,7 @@ name = "emit_air_resolves_modules"
 description = "--emit skipped sema.set_file_paths, so module programs failed E0704 only under --emit (RUE-130 item 4)."
 files = [
     { path = "main.rue", source = """
-const utils = @import("utils");
+const utils = @import("utils.rue");
 
 fn main() -> i32 {
     utils.triple(2)

--- a/crates/rue-cli-tests/cases/float_literals.toml
+++ b/crates/rue-cli-tests/cases/float_literals.toml
@@ -131,7 +131,7 @@ points into the module that wrote it.
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let h = @import("helper");
+    let h = @import("helper.rue");
     h.scale()
 }
 """ },
@@ -152,7 +152,7 @@ description = "The gate follows the literal across the module boundary and repor
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let h = @import("helper");
+    let h = @import("helper.rue");
     h.scale()
 }
 """ },

--- a/crates/rue-cli-tests/cases/module_consts.toml
+++ b/crates/rue-cli-tests/cases/module_consts.toml
@@ -17,7 +17,7 @@ description = "Value consts as module members, module aliases, and const-context
 name = "value_const_as_module_member"
 files = [
     { path = "main.rue", source = """
-const math = @import("math");
+const math = @import("math.rue");
 
 fn main() -> i32 {
     math.ANSWER
@@ -33,8 +33,8 @@ exit_code = 42
 name = "same_named_value_consts_in_distinct_modules"
 files = [
     { path = "main.rue", source = """
-const a = @import("a");
-const b = @import("b");
+const a = @import("a.rue");
+const b = @import("b.rue");
 
 fn main() -> i32 {
     a.VALUE + b.VALUE
@@ -54,7 +54,7 @@ exit_code = 3
 name = "member_const_in_const_initializer"
 files = [
     { path = "main.rue", source = """
-const math = @import("math");
+const math = @import("math.rue");
 const COPY: i32 = math.ANSWER;
 
 fn main() -> i32 {
@@ -75,7 +75,7 @@ exit_code = 42
 name = "member_const_as_operator_operand"
 files = [
     { path = "main.rue", source = """
-const math = @import("math");
+const math = @import("math.rue");
 const A: i32 = 1 + math.ANSWER;
 const B: i32 = math.ANSWER * 2 - 4;
 
@@ -96,7 +96,7 @@ exit_code = 123
 name = "private_member_as_operator_operand_rejected"
 files = [
     { path = "main.rue", source = """
-const lib = @import("sub/lib");
+const lib = @import("sub/lib.rue");
 const A: i32 = 1 + lib.SECRET;
 
 fn main() -> i32 { A }
@@ -115,7 +115,7 @@ error_contains = ["E0706", "SECRET", "private"]
 name = "i64_member_const_keeps_width"
 files = [
     { path = "main.rue", source = """
-const cfg = @import("cfg");
+const cfg = @import("cfg.rue");
 
 fn main() -> i32 {
     if cfg.BIG / 1000000000 == 5 { 9 } else { 1 }
@@ -176,7 +176,7 @@ fn main() -> i32 {
 }
 """ },
     { path = "outer/_outer.rue", source = """
-pub const inner = @import("inner");
+pub const inner = @import("inner.rue");
 """ },
     { path = "outer/inner.rue", source = """
 pub fn value() -> i32 { 42 }
@@ -189,7 +189,7 @@ exit_code = 42
 name = "pub_member_const_across_directories"
 files = [
     { path = "main.rue", source = """
-const lib = @import("sub/lib");
+const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
     lib.LIMIT
@@ -206,7 +206,7 @@ exit_code = 17
 name = "private_member_const_rejected_at_use"
 files = [
     { path = "main.rue", source = """
-const lib = @import("sub/lib");
+const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
     lib.SECRET
@@ -225,7 +225,7 @@ error_contains = ["E0706", "SECRET", "private"]
 name = "private_member_const_rejected_in_const_context"
 files = [
     { path = "main.rue", source = """
-const lib = @import("sub/lib");
+const lib = @import("sub/lib.rue");
 const S: i32 = lib.SECRET;
 
 fn main() -> i32 { S }
@@ -243,7 +243,7 @@ error_contains = ["E0706", "SECRET", "private"]
 name = "private_member_const_same_directory_ok"
 files = [
     { path = "main.rue", source = """
-const lib = @import("lib");
+const lib = @import("lib.rue");
 
 fn main() -> i32 {
     lib.SECRET
@@ -262,7 +262,7 @@ name = "fn_member_const_alias_call"
 description = "A module-member function const creates a callable alias (spec 6.5:15), and calling the alias is equivalent to calling the function (spec 4.10:12)."
 files = [
     { path = "main.rue", source = """
-const abs_alias = @import("math").abs;
+const abs_alias = @import("math.rue").abs;
 
 fn main() -> i32 { abs_alias(0 - 42) }
 """ },
@@ -310,7 +310,7 @@ error_contains = ["E0434", "a function reference is not supported in const conte
 name = "unknown_member_still_e0707"
 files = [
     { path = "main.rue", source = """
-const math = @import("math");
+const math = @import("math.rue");
 const X: i32 = math.NOPE;
 
 fn main() -> i32 { 0 }
@@ -329,7 +329,7 @@ name = "value_const_member_through_local_let"
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let m = @import("math");
+    let m = @import("math.rue");
     @dbg(m.ANSWER);
     0
 }

--- a/crates/rue-cli-tests/cases/module_importer_relative.toml
+++ b/crates/rue-cli-tests/cases/module_importer_relative.toml
@@ -20,8 +20,8 @@ description = "Relative @import resolves against the importing file's own direct
 name = "same_import_string_resolves_per_directory"
 files = [
     { path = "main.rue", source = """
-const a = @import("a/mod_a");
-const b = @import("b/mod_b");
+const a = @import("a/mod_a.rue");
+const b = @import("b/mod_b.rue");
 
 fn main() -> i32 {
     @dbg(a.a_val());
@@ -30,14 +30,14 @@ fn main() -> i32 {
 }
 """ },
     { path = "a/mod_a.rue", source = """
-const foo = @import("foo");
+const foo = @import("foo.rue");
 pub fn a_val() -> i32 { foo.a_foo() }
 """ },
     { path = "a/foo.rue", source = """
 pub fn a_foo() -> i32 { 10 }
 """ },
     { path = "b/mod_b.rue", source = """
-const foo = @import("foo");
+const foo = @import("foo.rue");
 pub fn b_val() -> i32 { foo.b_foo() }
 """ },
     { path = "b/foo.rue", source = """
@@ -74,8 +74,8 @@ exit_code = 15
 name = "file_module_and_facade_in_different_dirs_are_not_ambiguous"
 files = [
     { path = "main.rue", source = """
-const u1 = @import("sub/user1");
-const u2 = @import("facdir/user2");
+const u1 = @import("sub/user1.rue");
+const u2 = @import("facdir/user2.rue");
 
 fn main() -> i32 {
     @dbg(u1.one());
@@ -84,7 +84,7 @@ fn main() -> i32 {
 }
 """ },
     { path = "sub/user1.rue", source = """
-const foo = @import("foo");
+const foo = @import("foo.rue");
 pub fn one() -> i32 { foo.sfoo() }
 """ },
     { path = "sub/foo.rue", source = """
@@ -100,14 +100,19 @@ pub fn dfoo() -> i32 { 4 }
 ]
 stdout = "3\n4\n"
 
-# A genuine dual-entity ambiguity within ONE directory still errors (E0708):
-# both `foo.rue` and `foo/_foo.rue` sit next to the importer.
+# Both forms in ONE directory coexist (ADR-0078): the extensionless spelling
+# names the facade, the extensioned spelling names the file. E0708 is retired.
 [[case]]
-name = "genuine_single_dir_ambiguity_still_errors"
+name = "both_forms_in_one_dir_resolve_by_spelling"
 files = [
     { path = "main.rue", source = """
-const foo = @import("foo");
-fn main() -> i32 { foo.v_file() }
+const facade = @import("foo");
+const file = @import("foo.rue");
+fn main() -> i32 {
+    @dbg(file.v_file());
+    @dbg(facade.v_dir());
+    0
+}
 """ },
     { path = "foo.rue", source = """
 pub fn v_file() -> i32 { 1 }
@@ -116,5 +121,4 @@ pub fn v_file() -> i32 { 1 }
 pub fn v_dir() -> i32 { 2 }
 """ },
 ]
-compile_fail = true
-error_contains = ["E0708", "foo"]
+stdout = "1\n2\n"

--- a/crates/rue-cli-tests/cases/module_member_infer.toml
+++ b/crates/rue-cli-tests/cases/module_member_infer.toml
@@ -25,7 +25,7 @@ description = "m.go() + 1 with a let-bound module (the originally failing shape)
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let m = @import("m");
+    let m = @import("m.rue");
     m.go() + 1
 }
 """ },
@@ -40,7 +40,7 @@ name = "member_call_arithmetic_operand_const"
 description = "m.go() + 1 with a file-level const module (RUE-142's exact repro)."
 files = [
     { path = "main.rue", source = """
-const m = @import("m");
+const m = @import("m.rue");
 fn main() -> i32 { m.go() + 1 }
 """ },
     { path = "m.rue", source = """
@@ -54,7 +54,7 @@ name = "member_call_comparison_operand"
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let m = @import("m");
+    let m = @import("m.rue");
     if m.go() == 41 { 7 } else { 1 }
 }
 """ },
@@ -70,7 +70,7 @@ files = [
     { path = "main.rue", source = """
 fn twice(x: i32) -> i32 { x * 2 }
 fn main() -> i32 {
-    let m = @import("m");
+    let m = @import("m.rue");
     twice(m.go()) - 40
 }
 """ },
@@ -86,7 +86,7 @@ description = "The member's u64 return must anchor the literal it is compared wi
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let m = @import("m");
+    let m = @import("m.rue");
     if m.big() == 5 { 3 } else { 1 }
 }
 """ },
@@ -102,7 +102,7 @@ description = "Untyped literal arguments are constrained against the member's pa
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let m = @import("m");
+    let m = @import("m.rue");
     m.add(40, 2)
 }
 """ },
@@ -118,7 +118,7 @@ name = "member_call_tail_position_control"
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let m = @import("m");
+    let m = @import("m.rue");
     m.go()
 }
 """ },
@@ -133,7 +133,7 @@ name = "member_call_statement_and_let_init_control"
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let m = @import("m");
+    let m = @import("m.rue");
     m.go();
     let x = m.go();
     x + 1
@@ -152,7 +152,7 @@ name = "member_call_arg_type_mismatch_still_errors"
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let m = @import("m");
+    let m = @import("m.rue");
     m.add(true, 2)
 }
 """ },
@@ -168,7 +168,7 @@ name = "unknown_member_still_errors"
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let m = @import("m");
+    let m = @import("m.rue");
     m.nope()
 }
 """ },
@@ -203,7 +203,7 @@ description = "A module as the tail of a ()-returning function was silently acce
 files = [
     { path = "main.rue", source = """
 fn side() -> () {
-    let m = @import("m");
+    let m = @import("m.rue");
     m
 }
 fn main() -> i32 { side(); 0 }
@@ -221,7 +221,7 @@ description = "let u: () = m was silently accepted."
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let m = @import("m");
+    let m = @import("m.rue");
     let _u: () = m;
     0
 }
@@ -239,7 +239,7 @@ description = "The mismatch must name '<module>', not misreport the found type a
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let m = @import("m");
+    let m = @import("m.rue");
     m
 }
 """ },
@@ -256,7 +256,7 @@ description = "A bare `m;` statement is a discarded value — still a no-op, sti
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let m = @import("m");
+    let m = @import("m.rue");
     m;
     5
 }

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -15,7 +15,7 @@ name = "import_resolves_adjacent_file"
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let utils = @import("utils");
+    let utils = @import("utils.rue");
     0
 }
 """ },
@@ -34,7 +34,7 @@ name = "import_call_through_local_let"
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let utils = @import("utils");
+    let utils = @import("utils.rue");
     @dbg(utils.triple(14));
     0
 }
@@ -47,13 +47,13 @@ pub fn triple(x: i32) -> i32 {
 ]
 stdout = "42\n"
 
-# Top-level `const utils = @import("utils")` — the idiomatic form from
+# Top-level `const utils = @import("utils.rue")` — the idiomatic form from
 # ADR-0026.
 [[case]]
 name = "import_call_through_top_level_const"
 files = [
     { path = "main.rue", source = """
-const utils = @import("utils");
+const utils = @import("utils.rue");
 
 fn main() -> i32 {
     @dbg(utils.triple(14));
@@ -78,7 +78,7 @@ with\\#hash.rue # comment after an escaped path character
 with\\#hash/_with\\#hash.rue # declared absent ambiguity arm
 """ },
     { path = "main.rue", source = """
-const helper = @import("with#hash");
+const helper = @import("with#hash.rue");
 
 fn main() -> i32 {
     @dbg(helper.answer());
@@ -102,10 +102,9 @@ files = [
 # One source path per line, relative to this manifest file.
 main.rue
 utils.rue
-utils/_utils.rue # declared absent ambiguity arm
 """ },
     { path = "main.rue", source = """
-const utils = @import("utils");
+const utils = @import("utils.rue");
 
 fn main() -> i32 {
     @dbg(utils.triple(14));
@@ -151,7 +150,7 @@ files = [
 main.rue
 """ },
     { path = "main.rue", source = """
-const utils = @import("utils");
+const utils = @import("utils.rue");
 
 fn main() -> i32 {
     utils.triple(14)
@@ -190,14 +189,14 @@ name = "emit_deps_reports_root_and_import_graph"
 description = "RUE-810: --emit deps reports the canonical topology, complete observations, and accepted reads as a versioned envelope."
 files = [
     { path = "main.rue", source = """
-const utils = @import("utils");
+const utils = @import("utils.rue");
 
 fn main() -> i32 {
     utils.answer()
 }
 """ },
     { path = "utils.rue", source = """
-const leaf = @import("leaf");
+const leaf = @import("leaf.rue");
 
 pub fn answer() -> i32 {
     leaf.value()
@@ -226,8 +225,8 @@ compile_stdout_contains = [
     "main.rue",
     "utils.rue",
     "leaf.rue",
-    "\"specifier\": \"utils\"",
-    "\"specifier\": \"leaf\"",
+    "\"specifier\": \"utils.rue\"",
+    "\"specifier\": \"leaf.rue\"",
     "\"status\": \"resolved\"",
     "\"observations\":",
     "\"status\": \"present_readable\"",
@@ -242,7 +241,7 @@ name = "emit_deps_ignores_unrelated_semantic_errors"
 description = "RUE-499: --emit deps reports the discovered import graph without requiring body/type validation to succeed."
 files = [
     { path = "main.rue", source = """
-const utils = @import("utils");
+const utils = @import("utils.rue");
 
 fn main() -> i32 {
     utils.answer() + nope
@@ -261,7 +260,7 @@ compile_stdout_contains = [
     "\"status\": \"complete\"",
     "main.rue",
     "utils.rue",
-    "\"specifier\": \"utils\"",
+    "\"specifier\": \"utils.rue\"",
 ]
 compile_stderr_not_contains = ["undefined variable", "nope", "E0201"]
 
@@ -292,8 +291,8 @@ compile_stdout_contains = [
 ]
 
 [[case]]
-name = "emit_deps_reports_ambiguous_staging_reads"
-description = "RUE-810: an ambiguous closed graph emits both canonical targets and both accepted staging reads before failing."
+name = "emit_deps_resolves_facade_when_both_forms_exist"
+description = "ADR-0078: both module forms on disk resolve deterministically to the facade; the file spelling is never probed and the migration help names the extensioned spelling on a facade miss."
 files = [
     { path = "main.rue", source = """
 const helper = @import("helper");
@@ -307,16 +306,39 @@ pub fn directory_value() -> i32 { 2 }
 """ },
 ]
 args = ["--emit", "deps", "main.rue"]
-compile_fail = true
-error_contains = ["E0708", "ambiguous", "helper.rue", "helper/_helper.rue"]
+compile_only = true
 compile_stdout_contains = [
-    "\"status\": \"incomplete\"",
-    "\"status\": \"ambiguous\"",
-    "\"file_module\": \"helper.rue\"",
-    "\"directory_module\": \"helper/_helper.rue\"",
-    "\"module\": \"helper.rue\"",
+    "\"status\": \"complete\"",
     "\"module\": \"helper/_helper.rue\"",
 ]
+compile_stderr_not_contains = ["E0708", "ambiguous"]
+
+[[case]]
+name = "extensionless_file_miss_suggests_extensioned_spelling"
+description = "ADR-0078 migration diagnostic: an extensionless import with only {P}.rue present reports E0704 plus a help naming @import(\"thing.rue\"); the probe is presentation-only."
+files = [
+    { path = "main.rue", source = """
+const thing = @import("thing");
+fn main() -> i32 { 0 }
+""" },
+    { path = "thing.rue", source = """
+pub fn t() -> i32 { 1 }
+""" },
+]
+compile_fail = true
+error_contains = ["E0704", "imported with its extension", "@import(\"thing.rue\")"]
+
+[[case]]
+name = "import_escaping_root_is_e0713"
+description = "ADR-0078: a relative import whose normalized candidate leaves the project root is E0713 with no filesystem probe."
+files = [
+    { path = "main.rue", source = """
+const nope = @import("../outside.rue");
+fn main() -> i32 { 0 }
+""" },
+]
+compile_fail = true
+error_contains = ["E0713", "escapes the project root", "../outside.rue"]
 
 [[case]]
 name = "emit_deps_malformed_import_has_no_envelope"
@@ -344,7 +366,7 @@ name = "emit_deps_mixed_positional_with_missing_prefers_incomplete_graph"
 description = "RUE-767: a second positional source under --emit deps is refused before discovery."
 files = [
     { path = "main.rue", source = """
-const helper = @import("helper");
+const helper = @import("helper.rue");
 const missing = @import("missing");
 fn main() -> i32 { 0 }
 """ },
@@ -366,7 +388,7 @@ name = "mixed_positional_with_missing_prefers_canonical_diagnostic"
 description = "RUE-767: a second positional source is refused before import discovery."
 files = [
     { path = "main.rue", source = """
-const helper = @import("helper");
+const helper = @import("helper.rue");
 const missing = @import("missing");
 fn main() -> i32 { 0 }
 """ },
@@ -457,7 +479,7 @@ stdout = "42\n"
 name = "sibling_facade_is_not_a_directory_module"
 files = [
     { path = "main.rue", source = """
-const utils = @import("utils");
+const utils = @import("utils.rue");
 
 fn main() -> i32 {
     @dbg(utils.triple(14));
@@ -491,7 +513,7 @@ fn main() -> i32 {
 }
 """ },
     { path = "std/_std.rue", source = """
-pub const math = @import("std/math.rue");
+pub const math = @import("math.rue");
 """ },
     { path = "std/math.rue", source = """
 pub fn abs(x: i32) -> i32 {
@@ -625,8 +647,8 @@ pub struct Item {
 }
 """ },
     { path = "main.rue", source = """
-const a = @import("a");
-const b = @import("b");
+const a = @import("a.rue");
+const b = @import("b.rue");
 
 fn main() -> i32 {
     let x: a.Item = a.Item { a: 19 };
@@ -644,7 +666,7 @@ exit_code = 42
 name = "import_transitive_chain"
 files = [
     { path = "main.rue", source = """
-const a = @import("a");
+const a = @import("a.rue");
 
 fn main() -> i32 {
     @dbg(a.double(21));
@@ -652,7 +674,7 @@ fn main() -> i32 {
 }
 """ },
     { path = "a.rue", source = """
-const b = @import("b");
+const b = @import("b.rue");
 
 pub fn double(x: i32) -> i32 {
     b.add(x, x)
@@ -675,7 +697,7 @@ name = "mixed_positional_and_import_reachable_file_rejected"
 description = "RUE-767: a second positional source (even one reachable via @import) is refused."
 files = [
     { path = "main.rue", source = """
-const helper = @import("helper");
+const helper = @import("helper.rue");
 
 fn main() -> i32 {
     helper.value()
@@ -726,8 +748,8 @@ description = "A pub function from another compiled file is not a member of an u
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let utils = @import("utils");
-    let other = @import("other");
+    let utils = @import("utils.rue");
+    let other = @import("other.rue");
     let _ = other.sneaky();
     utils.sneaky()
 }
@@ -752,8 +774,8 @@ description = "Control: a pub function defined in the imported file is still cal
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let utils = @import("utils");
-    let other = @import("other");
+    let utils = @import("utils.rue");
+    let other = @import("other.rue");
     let _ = other.sneaky();
     utils.real()
 }
@@ -1035,8 +1057,8 @@ name = "root_module_graph_same_file_reached_by_normalized_paths"
 description = "Root-only import discovery treats two normalized paths to the same file as one loaded module, not two semantic roots."
 files = [
     { path = "main.rue", source = """
-const left = @import("pkg/left");
-const right = @import("pkg/nested/right");
+const left = @import("pkg/left.rue");
+const right = @import("pkg/nested/right.rue");
 
 fn main() -> i32 {
     @dbg(left.left_value() + right.right_value());
@@ -1044,7 +1066,7 @@ fn main() -> i32 {
 }
 """ },
     { path = "pkg/left.rue", source = """
-const shared = @import("shared");
+const shared = @import("shared.rue");
 
 pub fn left_value() -> i32 {
     shared.value()
@@ -1855,7 +1877,7 @@ fn main() -> i32 {
 }
 """ },
     { path = "std/_std.rue", source = """
-pub const math = @import("math");
+pub const math = @import("math.rue");
 """ },
     { path = "std/math.rue", source = """
 pub fn abs(x: i32) -> i32 {
@@ -1880,7 +1902,7 @@ fn main() -> i32 {
 pub const b = @import("b");
 """ },
     { path = "a/b/_b.rue", source = """
-pub const c = @import("c");
+pub const c = @import("c.rue");
 """ },
     { path = "a/b/c.rue", source = """
 pub fn f() -> i32 { 42 }
@@ -1901,7 +1923,7 @@ fn main() -> i32 {
 }
 """ },
     { path = "std/_std.rue", source = """
-pub const math = @import("math");
+pub const math = @import("math.rue");
 """ },
     { path = "std/math.rue", source = """
 pub fn abs(x: i32) -> i32 {
@@ -1921,7 +1943,7 @@ fn main() -> i32 {
 }
 """ },
     { path = "std/_std.rue", source = """
-pub const math = @import("math");
+pub const math = @import("math.rue");
 """ },
     { path = "std/math.rue", source = """
 pub fn abs(x: i32) -> i32 {
@@ -1949,7 +1971,7 @@ fn main() -> i32 {
 }
 """ },
     { path = "std/_std.rue", source = """
-pub const geo = @import("geo");
+pub const geo = @import("geo.rue");
 """ },
     { path = "std/geo.rue", source = """
 pub struct Point { x: i32, y: i32 }
@@ -1970,7 +1992,7 @@ fn main() -> i32 {
 }
 """ },
     { path = "std/_std.rue", source = """
-const math = @import("math");
+const math = @import("math.rue");
 """ },
     { path = "std/math.rue", source = """
 pub fn abs(x: i32) -> i32 {
@@ -1997,7 +2019,7 @@ fn main() -> i32 {
 pub const b = @import("b");
 """ },
     { path = "a/b/_b.rue", source = """
-const c = @import("c");
+const c = @import("c.rue");
 """ },
     { path = "a/b/c.rue", source = """
 pub fn f() -> i32 { 42 }
@@ -2019,7 +2041,7 @@ fn main() -> i32 {
 }
 """ },
     { path = "std/_std.rue", source = """
-pub const math = @import("math");
+pub const math = @import("math.rue");
 """ },
     { path = "std/math.rue", source = """
 pub fn abs(x: i32) -> i32 {
@@ -2355,8 +2377,8 @@ exit_code = 7
 # ---------------------------------------------------------------------------
 
 [[case]]
-name = "dotdot_import_reconciles_with_cli_listed_pub_fn"
-description = "RUE-317: `a/main.rue` @imports `../std/opt.rue`; the pub fn member resolves through one normalized module identity."
+name = "dotdot_import_escaping_root_is_rejected"
+description = "ADR-0078 (supersedes the RUE-317 reconciliation): a `../` import that leaves the project root is E0713 even when the target file exists on disk; escaping paths receive no module identity."
 files = [
     { path = "a/main.rue", source = """
 fn main() -> i32 {
@@ -2370,70 +2392,8 @@ pub fn make() -> i32 {
 }
 """ },
 ]
-exit_code = 42
-
-[[case]]
-name = "dotdot_import_reconciles_with_cli_listed_pub_const"
-description = "RUE-317: same normalized-path reconciliation for a pub const member accessed through a `../`-relative import."
-files = [
-    { path = "a/main.rue", source = """
-const opt = @import("../std/opt.rue");
-
-fn main() -> i32 {
-    opt.ANSWER
-}
-""" },
-    { path = "std/opt.rue", source = """
-pub const ANSWER: i32 = 7;
-""" },
-]
-exit_code = 7
-
-[[case]]
-name = "dotdot_import_unknown_member_still_errors"
-description = "RUE-317 negative control: path reconciliation must not mask a genuinely absent member — accessing a non-existent member of the reconciled module still fails with E0707."
-files = [
-    { path = "a/main.rue", source = """
-fn main() -> i32 {
-    let o = @import("../std/opt.rue");
-    o.nope()
-}
-""" },
-    { path = "std/opt.rue", source = """
-pub fn make() -> i32 {
-    42
-}
-""" },
-]
 compile_fail = true
-error_contains = ["E0707", "has no member `nope`"]
-
-[[case]]
-name = "dotdot_import_private_member_cross_dir_still_rejected"
-description = "RUE-317 negative control: reconciling the path must not weaken privacy — a NON-pub member of the reconciled module in another directory is still private (E0706)."
-files = [
-    { path = "a/main.rue", source = """
-fn main() -> i32 {
-    let o = @import("../std/opt.rue");
-    o.secret()
-}
-""" },
-    { path = "std/opt.rue", source = """
-fn secret() -> i32 {
-    42
-}
-""" },
-]
-compile_fail = true
-error_contains = ["E0706", "function `secret` is private"]
-
-# ---------------------------------------------------------------------------
-# Root-only module graph success smoke tests (RUE-433 / RUE-424).
-#
-# Broader successful-program coverage for root-module compilation: every case
-# compiles ONLY main.rue and relies on transitive @import discovery from disk.
-# All shapes were verified against the real CLI before being encoded here.
-# ---------------------------------------------------------------------------
+error_contains = ["E0713", "escapes the project root", "../std/opt.rue"]
 
 [[case]]
 name = "root_module_graph_shared_helper_diamond"

--- a/crates/rue-compiler/src/dependency_envelope.rs
+++ b/crates/rue-compiler/src/dependency_envelope.rs
@@ -382,8 +382,7 @@ mod tests {
         // Policy v2: the extensionless import resolves its facade candidate
         // (PresentReadable), and the std chain's vendored miss before the
         // toolchain hit supplies a benign Absent observation.
-        let source =
-            "const a = @import(\"a\"); const s = @import(\"std\"); fn main() -> i32 { 0 }";
+        let source = "const a = @import(\"a\"); const s = @import(\"std\"); fn main() -> i32 { 0 }";
         let imported = "pub fn answer() -> i32 { 42 }";
         let std_text = "pub fn parse_i64(s: str) -> i64 { 0 }";
         let mut assembler = assembler(source);

--- a/crates/rue-compiler/src/dependency_envelope.rs
+++ b/crates/rue-compiler/src/dependency_envelope.rs
@@ -55,14 +55,8 @@ pub struct DependencyTopologyRecord {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum DependencyResolutionOutcome {
-    Resolved {
-        module: String,
-    },
+    Resolved { module: String },
     Missing,
-    Ambiguous {
-        file_module: String,
-        directory_module: String,
-    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -150,7 +144,6 @@ impl DependencyEnvelope {
                         matches!(
                             problem,
                             CanonicalImportGraphProblem::MissingResolution { .. }
-                                | CanonicalImportGraphProblem::AmbiguousResolution { .. }
                         )
                     }) =>
             {
@@ -183,13 +176,6 @@ impl DependencyEnvelope {
                             }
                         }
                         CanonicalImportResolution::Missing => DependencyResolutionOutcome::Missing,
-                        CanonicalImportResolution::Ambiguous {
-                            file_module,
-                            directory_module,
-                        } => DependencyResolutionOutcome::Ambiguous {
-                            file_module: file_module.as_str().to_owned(),
-                            directory_module: directory_module.as_str().to_owned(),
-                        },
                     },
                 })
                 .collect(),

--- a/crates/rue-compiler/src/dependency_envelope.rs
+++ b/crates/rue-compiler/src/dependency_envelope.rs
@@ -393,16 +393,30 @@ mod tests {
 
     #[test]
     fn complete_envelope_uses_canonical_graph_and_separate_ledgers() {
-        let source = "const a = @import(\"a\"); fn main() -> i32 { 0 }";
+        // Policy v2: the extensionless import resolves its facade candidate
+        // (PresentReadable), and the std chain's vendored miss before the
+        // toolchain hit supplies a benign Absent observation.
+        let source =
+            "const a = @import(\"a\"); const s = @import(\"std\"); fn main() -> i32 { 0 }";
         let imported = "pub fn answer() -> i32 { 42 }";
+        let std_text = "pub fn parse_i64(s: str) -> i64 { 0 }";
         let mut assembler = assembler(source);
         assembler
             .add_explicit(
-                "/project/a.rue",
-                "/project/a.rue",
+                "/project/a/_a.rue",
+                "/project/a/_a.rue",
                 PhysicalFileIdentity::new(1, 2),
                 metadata(),
                 Arc::new(imported.into()),
+            )
+            .unwrap();
+        assembler
+            .add_explicit(
+                "/sdk/_std.rue",
+                "/sdk/_std.rue",
+                PhysicalFileIdentity::new(1, 3),
+                metadata(),
+                Arc::new(std_text.into()),
             )
             .unwrap();
         let snapshot = assembler.snapshot().unwrap();
@@ -422,15 +436,28 @@ mod tests {
                 break;
             }
             for request in pending {
-                let observation = if request.requested_path() == "/project/a.rue" {
+                let observation = if request.requested_path() == "/project/a/_a.rue" {
                     ImportObservation::accepted(
                         request.clone(),
                         AcceptedImportSource::new(
                             request.requested_path(),
-                            "/project/a.rue",
+                            "/project/a/_a.rue",
                             PhysicalFileIdentity::new(1, 2),
                             metadata(),
                             Arc::new(imported.into()),
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap()
+                } else if request.requested_path() == "/sdk/_std.rue" {
+                    ImportObservation::accepted(
+                        request.clone(),
+                        AcceptedImportSource::new(
+                            request.requested_path(),
+                            "/sdk/_std.rue",
+                            PhysicalFileIdentity::new(1, 3),
+                            metadata(),
+                            Arc::new(std_text.into()),
                         )
                         .unwrap(),
                     )
@@ -448,7 +475,7 @@ mod tests {
         assert_eq!(envelope.topology.root, "main.rue");
         assert!(matches!(
             envelope.topology.records[0].outcome,
-            DependencyResolutionOutcome::Resolved { ref module } if module == "a.rue"
+            DependencyResolutionOutcome::Resolved { ref module } if module == "a/_a.rue"
         ));
         assert!(envelope.observations.iter().any(|observation| matches!(
             observation.outcome,
@@ -458,7 +485,7 @@ mod tests {
             observation.outcome,
             DependencyObservationOutcome::PresentReadable { .. }
         )));
-        assert_eq!(envelope.accepted_reads.len(), 2);
+        assert_eq!(envelope.accepted_reads.len(), 3);
         assert!(
             envelope
                 .revision

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -1343,8 +1343,9 @@ fn accepted_sources_for<'a>(
 }
 
 /// One occurrence's winner: the first candidate group, in precedence order, that
-/// observed a present read. A failed candidate ends the occurrence's precedence
-/// walk, and a later group is never consulted once an earlier one won.
+/// observed a present read. A candidate that could not be read is skipped
+/// (ADR-0078) rather than ending the walk; a later group is never consulted
+/// once an earlier one won.
 fn extend_accepted_from_site<'a>(
     accepted: &mut Vec<&'a AcceptedImportSource>,
     groups: impl Iterator<Item = &'a Arc<[ImportDiscoveryRequest]>>,
@@ -1355,7 +1356,7 @@ fn extend_accepted_from_site<'a>(
             .iter()
             .any(|request| ledger.get(request).is_some_and(|o| o.status.is_failure()))
         {
-            break;
+            continue;
         }
         let present = group
             .iter()
@@ -1516,7 +1517,16 @@ pub(crate) fn exact_import_pending_requests(
                 .iter()
                 .any(|observation| observation.is_some_and(|value| value.status().is_failure()))
             {
-                break;
+                // ADR-0078: a candidate that could not be read is not a
+                // resolution, so the precedence walk continues to the next
+                // candidate rather than concluding. Under a source manifest an
+                // undeclared candidate is denied lexically WITHOUT a probe, so
+                // the compiler cannot distinguish "absent" from "present but
+                // undeclared"; treating the denial as conclusive would break
+                // every hermetic build whose program does not vendor the
+                // candidate it denies. The failure is still reported if no
+                // later candidate resolves (`exact_import_has_failures`).
+                continue;
             }
             let missing = group
                 .iter()
@@ -1539,15 +1549,27 @@ pub(crate) fn exact_import_pending_requests(
     pending
 }
 
+/// Whether any occurrence failed *conclusively*: it owns a failed observation
+/// and no candidate of its precedence chain resolved. A failure behind a
+/// resolved candidate is a skipped candidate, not a build failure (ADR-0078).
 pub(crate) fn exact_import_has_failures(
     groups: &[Arc<[ImportDiscoveryRequest]>],
     ledger: &ImportObservationLedger,
 ) -> bool {
-    groups.iter().flat_map(|group| group.iter()).any(|request| {
-        ledger
-            .get(request)
-            .is_some_and(|observation| observation.status().is_failure())
-    })
+    let mut by_site: BTreeMap<&ImportOccurrenceKey, (bool, bool)> = BTreeMap::new();
+    for request in groups.iter().flat_map(|group| group.iter()) {
+        let Some(observation) = ledger.get(request) else {
+            continue;
+        };
+        let entry = by_site
+            .entry(request.occurrence())
+            .or_insert((false, false));
+        entry.0 |= observation.status().is_failure();
+        entry.1 |= observation.accepted_source().is_some();
+    }
+    by_site
+        .values()
+        .any(|(failed, resolved)| *failed && !*resolved)
 }
 
 /// E0713 diagnostics for occurrences whose single candidate escapes the
@@ -1613,11 +1635,20 @@ pub(crate) fn exact_import_diagnostics(
             .expect("indexed importer belongs to parsed program")
             .file_id();
         let span = rue_span::Span::with_file(file_id, site.source_offset(), site.source_end());
+        // A failure behind a resolved candidate is a skipped candidate, not a
+        // build failure (ADR-0078): report failures only when the occurrence's
+        // whole precedence chain produced no accepted source.
+        let resolved = groups
+            .iter()
+            .flat_map(|group| group.iter())
+            .filter_map(|request| ledger.get(request))
+            .any(|observation| observation.accepted_source().is_some());
         if let Some(failure) = groups
             .iter()
             .flat_map(|group| group.iter())
             .filter_map(|request| ledger.get(request))
             .find(|observation| observation.status().is_failure())
+            .filter(|_| !resolved)
         {
             let candidate = failure.request().requested_path();
             let message = match failure.status() {

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -18,7 +18,12 @@ use crate::{
 };
 
 /// Version of the target-independent candidate policy represented by plans.
-pub const IMPORT_DISCOVERY_POLICY_VERSION: u32 = 1;
+///
+/// Version 2 (ADR-0078): one candidate per relative specifier — extensionless
+/// paths name the directory facade only, and the importing file's directory is
+/// the only search base. `std` anchors to the program: the vendored
+/// `{root}/std/_std.rue` precedes the captured toolchain std root.
+pub const IMPORT_DISCOVERY_POLICY_VERSION: u32 = 2;
 
 /// Immutable invocation inputs captured once for a discovery epoch.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -1381,20 +1386,62 @@ fn canonicalize_accepted(mut accepted: Vec<&AcceptedImportSource>) -> Vec<&Accep
 
 /// Compute candidate precedence for one exact indexed occurrence from captured
 /// invocation context and the importer's accepted-read provenance.
+/// The normalized candidate a relative occurrence would probe, when that
+/// candidate lies outside the project root (ADR-0078: project-root-relative
+/// identity is total, so an escaping import is rejected before any filesystem
+/// request is derived). `std` is a reserved program-anchored specifier and a
+/// trusted standard-library importer resolves within its own root; neither is
+/// subject to the check.
+pub(crate) fn escaping_import_candidate(
+    context: &ImportDiscoveryContext,
+    specifier: &str,
+    importer_requested_path: &str,
+) -> CompileResult<Option<String>> {
+    if specifier == "std" {
+        return Ok(None);
+    }
+    let importer_path = normalize_absolute(importer_requested_path)?;
+    if let Some(std_root) = context.std_root() {
+        if Path::new(&importer_path).starts_with(std_root) {
+            return Ok(None);
+        }
+    }
+    let importer_dir = parent_dir(&importer_path);
+    let groups = discovery_candidate_groups(
+        specifier,
+        &importer_dir,
+        context.project_root(),
+        context.std_root(),
+    );
+    let candidate = normalize_path(&groups[0][0]);
+    if Path::new(&candidate).starts_with(context.project_root()) {
+        Ok(None)
+    } else {
+        Ok(Some(candidate))
+    }
+}
+
 pub(crate) fn discovery_groups_for_occurrence(
     context: &ImportDiscoveryContext,
     occurrence: &ImportOccurrenceKey,
     importer_requested_path: &str,
 ) -> CompileResult<Vec<Arc<[ImportDiscoveryRequest]>>> {
-    let root_dir = context.project_root().to_owned();
+    // An escaping occurrence derives no filesystem requests: its rejection is
+    // decided lexically from the importer anchor and project root alone, and
+    // the diagnostic projection recomputes the same check (`escape_diagnostics`).
+    if escaping_import_candidate(context, occurrence.specifier(), importer_requested_path)?
+        .is_some()
+    {
+        return Ok(Vec::new());
+    }
     let importer_path = normalize_absolute(importer_requested_path)?;
     let importer_dir = parent_dir(&importer_path);
-    let mut bases = vec![importer_dir];
-    if !bases.contains(&root_dir) {
-        bases.push(root_dir);
-    }
-    let candidate_groups =
-        discovery_candidate_groups(occurrence.specifier(), &bases, context.std_root());
+    let candidate_groups = discovery_candidate_groups(
+        occurrence.specifier(),
+        &importer_dir,
+        context.project_root(),
+        context.std_root(),
+    );
     let normalized_specifier = normalize_path(occurrence.specifier());
     candidate_groups
         .into_iter()
@@ -1418,7 +1465,7 @@ pub(crate) fn discovery_groups_for_occurrence(
                         group: group_index,
                         position,
                         requested_path: Arc::from(normalize_path(&candidate)),
-                        role: candidate_role(occurrence.specifier(), group_index, position),
+                        role: candidate_role(occurrence.specifier()),
                     }
                 })
                 .collect::<Vec<_>>()
@@ -1503,12 +1550,57 @@ pub(crate) fn exact_import_has_failures(
     })
 }
 
+/// E0713 diagnostics for occurrences whose single candidate escapes the
+/// project root. Recomputed from the parsed program and captured context —
+/// escaping occurrences own no discovery requests, so they never appear in
+/// request groups or the observation ledger.
+pub(crate) fn escape_diagnostics(
+    program: &ParsedProgram,
+    context: &ImportDiscoveryContext,
+) -> CompileErrors {
+    let mut errors = CompileErrors::new();
+    for site in program.import_directives().iter() {
+        let importer_path = match requested_path_for_module(context, site.importer()) {
+            Ok(path) => path,
+            Err(error) => {
+                errors.push(error);
+                continue;
+            }
+        };
+        match escaping_import_candidate(context, site.specifier(), &importer_path) {
+            Ok(Some(candidate)) => {
+                let file_id = program
+                    .module(site.importer())
+                    .expect("import directive belongs to parsed program")
+                    .file_id();
+                let span = rue_span::Span::with_file(
+                    file_id,
+                    site.source_offset(),
+                    site.source_end(),
+                );
+                errors.push(CompileError::new(
+                    ErrorKind::ImportEscapesRoot {
+                        path: site.specifier().to_owned(),
+                        candidate,
+                    },
+                    span,
+                ));
+            }
+            Ok(None) => {}
+            Err(error) => errors.push(error),
+        }
+    }
+    errors
+}
+
 pub(crate) fn exact_import_diagnostics(
     program: &ParsedProgram,
+    context: &ImportDiscoveryContext,
     groups: &[Arc<[ImportDiscoveryRequest]>],
     ledger: &ImportObservationLedger,
 ) -> CompileErrors {
     let mut errors = ImportDiscoveryPlan::shape_diagnostics(program);
+    errors.extend(escape_diagnostics(program, context));
     let mut groups_by_site: BTreeMap<&ImportOccurrenceKey, Vec<&Arc<[ImportDiscoveryRequest]>>> =
         BTreeMap::new();
     for group in groups {
@@ -2506,21 +2598,32 @@ impl DiscoverySourceAssembler {
     }
 }
 
-fn candidate_role(specifier: &str, group: u32, position: u32) -> ImportCandidateRole {
-    if specifier == "std" && group == 0 {
+fn candidate_role(specifier: &str) -> ImportCandidateRole {
+    if specifier == "std" {
         ImportCandidateRole::StandardLibraryFacade
     } else if specifier.ends_with(".rue") {
         ImportCandidateRole::ExactFile
-    } else if position == 0 {
-        ImportCandidateRole::FileModule
     } else {
         ImportCandidateRole::DirectoryFacade
     }
 }
 
+/// Derive the ordered candidate groups for one occurrence under policy
+/// version 2 (ADR-0078). Every group holds exactly one candidate:
+///
+/// - `std` probes the program's vendored `{root}/std/_std.rue` first, then
+///   the captured toolchain root's facade. Ambient environment never replaces
+///   a standard library the program ships.
+/// - A `.rue`-suffixed specifier names exactly that path relative to the
+///   importing file's directory.
+/// - An extensionless specifier names the directory facade
+///   `{P}/_{basename}.rue`, importer-relative. File modules are spelled with
+///   their extension; there is no file/facade ambiguity and no root-relative
+///   fallback.
 fn discovery_candidate_groups(
     specifier: &str,
-    base_dirs: &[String],
+    importer_dir: &str,
+    project_root: &str,
     std_root: Option<&str>,
 ) -> Vec<Vec<String>> {
     let join = |base: &str, relative: &str| {
@@ -2530,35 +2633,21 @@ fn discovery_candidate_groups(
             .into_owned()
     };
     if specifier == "std" {
-        return std_root
-            .into_iter()
-            .map(|root| vec![join(root, "_std.rue")])
-            .chain(
-                base_dirs
-                    .iter()
-                    .map(|base| vec![join(base, "std/_std.rue")]),
-            )
+        return std::iter::once(vec![join(project_root, "std/_std.rue")])
+            .chain(std_root.into_iter().map(|root| vec![join(root, "_std.rue")]))
             .collect();
     }
     if specifier.ends_with(".rue") {
-        return base_dirs
-            .iter()
-            .map(|base| vec![join(base, specifier)])
-            .collect();
+        return vec![vec![join(importer_dir, specifier)]];
     }
     let basename = Path::new(specifier)
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or(specifier);
-    base_dirs
-        .iter()
-        .map(|base| {
-            vec![
-                join(base, &format!("{specifier}.rue")),
-                join(base, &format!("{specifier}/_{basename}.rue")),
-            ]
-        })
-        .collect()
+    vec![vec![join(
+        importer_dir,
+        &format!("{specifier}/_{basename}.rue"),
+    )]]
 }
 
 fn requested_path_for_module(
@@ -3131,7 +3220,7 @@ mod tests {
                     1,
                     "/project/main.rue",
                     "main.rue",
-                    "const a = @import(\"a\"); fn main() -> i32 { a.value() }",
+                    "const a = @import(\"a.rue\"); fn main() -> i32 { a.value() }",
                 ),
                 (2, "/project/a.rue", "a.rue", "pub fn value() -> i32 { 1 }"),
             ],
@@ -3214,7 +3303,7 @@ mod tests {
     }
 
     #[test]
-    fn cancellation_is_non_closure_and_accepted_ambiguity_reads_both_candidates() {
+    fn cancellation_is_non_closure_and_denial_is_failure() {
         let snapshot = SourceSnapshot::single(
             "/project/main.rue",
             "const m = @import(\"thing\"); fn main() -> i32 { 0 }",
@@ -3223,8 +3312,12 @@ mod tests {
         let mut session = crate::CompilerSession::new();
         session.update(&snapshot).into_result().unwrap();
         let plan = session.import_discovery_plan(context(7)).unwrap();
+        // Policy v2: an extensionless specifier owes exactly one candidate,
+        // the directory facade.
         let pending = plan.pending_requests(&ImportObservationLedger::default());
-        assert_eq!(pending.len(), 2);
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].requested_path(), "/project/thing/_thing.rue");
+        assert_eq!(pending[0].role(), ImportCandidateRole::DirectoryFacade);
 
         let mut cancelled = ImportObservationLedger::default();
         cancelled
@@ -3237,39 +3330,25 @@ mod tests {
         assert!(plan.accepted_sources(&cancelled).is_empty());
 
         let mut complete = ImportObservationLedger::default();
-        for (request, canonical) in pending.into_iter().zip(["/real/file", "/real/facade"]) {
-            let source = AcceptedImportSource::new(
-                Arc::from(request.requested_path()),
-                Arc::from(canonical),
-                identity(),
-                metadata_fingerprint(),
-                Arc::new("pub fn answer() -> i32 { 42 }".into()),
-            )
-            .unwrap();
-            complete
-                .record(ImportObservation::accepted(request, source).unwrap())
-                .unwrap();
-        }
-        assert_eq!(plan.accepted_sources(&complete).len(), 2);
-        assert!(plan.pending_requests(&complete).is_empty());
-
-        let pending = plan.pending_requests(&ImportObservationLedger::default());
-        let mut denied_arm = ImportObservationLedger::default();
-        let accepted = AcceptedImportSource::new(
+        let source = AcceptedImportSource::new(
             Arc::from(pending[0].requested_path()),
-            Arc::from("/real/file"),
+            Arc::from("/real/facade"),
             identity(),
             metadata_fingerprint(),
             Arc::new("pub fn answer() -> i32 { 42 }".into()),
         )
         .unwrap();
-        denied_arm
-            .record(ImportObservation::accepted(pending[0].clone(), accepted).unwrap())
+        complete
+            .record(ImportObservation::accepted(pending[0].clone(), source).unwrap())
             .unwrap();
+        assert_eq!(plan.accepted_sources(&complete).len(), 1);
+        assert!(plan.pending_requests(&complete).is_empty());
+
+        let mut denied_arm = ImportObservationLedger::default();
         denied_arm
             .record(
                 ImportObservation::failure(
-                    pending[1].clone(),
+                    pending[0].clone(),
                     ImportObservationStatus::DeniedLexical,
                 )
                 .unwrap(),
@@ -3600,7 +3679,7 @@ mod tests {
 
     #[test]
     fn fixed_point_discovery_accumulates_exact_work_and_seeds_incremental_parse() {
-        let main_text = "const h = @import(\"helper\"); fn main() -> i32 { h.answer() }";
+        let main_text = "const h = @import(\"helper.rue\"); fn main() -> i32 { h.answer() }";
         let helper_text = "pub fn answer() -> i32 { 42 }";
         let root_only = snapshot(&[(1, "/project/main.rue", "main.rue", main_text)], 1);
         let complete = snapshot(
@@ -3907,13 +3986,13 @@ mod tests {
                     1,
                     "/project/main.rue",
                     "main.rue",
-                    "const a = @import(\"a\"); fn main() -> i32 { 0 }",
+                    "const a = @import(\"a.rue\"); fn main() -> i32 { 0 }",
                 ),
                 (
                     2,
                     "/project/a.rue",
                     "a.rue",
-                    "const root = @import(\"main\"); pub fn answer() -> i32 { 42 }",
+                    "const root = @import(\"main.rue\"); pub fn answer() -> i32 { 42 }",
                 ),
             ],
             1,
@@ -3940,9 +4019,9 @@ mod tests {
                     .find(|entry| entry.requested_path() == request.requested_path())
                 {
                     let text = if entry.module().as_str() == "a.rue" {
-                        "const root = @import(\"main\"); pub fn answer() -> i32 { 42 }"
+                        "const root = @import(\"main.rue\"); pub fn answer() -> i32 { 42 }"
                     } else {
-                        "const a = @import(\"a\"); fn main() -> i32 { 0 }"
+                        "const a = @import(\"a.rue\"); fn main() -> i32 { 0 }"
                     };
                     ImportObservation::accepted(
                         request,
@@ -4348,8 +4427,12 @@ mod tests {
     }
 
     #[test]
-    fn ambiguous_and_std_missing_close_as_attempted_with_typed_diagnostics() {
-        let ambiguous = snapshot(
+    fn both_forms_resolve_to_facade_and_std_missing_closes_attempted() {
+        // Policy v2: a tree containing BOTH thing.rue and thing/_thing.rue is
+        // not ambiguous — the extensionless specifier names the facade alone,
+        // and the file spelling requires its extension. The former E0708
+        // surface is deleted, not diagnosed.
+        let both_forms = snapshot(
             &[
                 (
                     1,
@@ -4370,42 +4453,46 @@ mod tests {
         let mut session = crate::CompilerSession::new();
         let plan = session
             .stage_import_discovery(
-                &ambiguous,
+                &both_forms,
                 context(10),
-                accepted_reads(&ambiguous),
+                accepted_reads(&both_forms),
                 ImportObservationLedger::default(),
             )
             .unwrap();
         let mut ledger = ImportObservationLedger::default();
-        for request in plan.pending_requests(&ledger) {
-            let (contents, identity) = if request.requested_path().ends_with("/_thing.rue") {
-                ("const x = 2;", PhysicalFileIdentity::new(1, 3))
-            } else {
-                ("const x = 1;", PhysicalFileIdentity::new(1, 2))
-            };
+        let pending = plan.pending_requests(&ledger);
+        assert_eq!(pending.len(), 1, "one facade candidate, never the file");
+        for request in pending {
+            assert!(request.requested_path().ends_with("/_thing.rue"));
             let source = AcceptedImportSource::new(
                 Arc::from(request.requested_path()),
                 Arc::from(request.requested_path()),
-                identity,
+                PhysicalFileIdentity::new(1, 3),
                 metadata_fingerprint(),
-                Arc::new(contents.into()),
+                Arc::new("const x = 2;".into()),
             )
             .unwrap();
             ledger
                 .record(ImportObservation::accepted(request, source).unwrap())
                 .unwrap();
         }
-        let errors = session.close_import_discovery(ledger).unwrap_err();
-        assert!(matches!(
-            &errors.first().unwrap().kind,
-            ErrorKind::AmbiguousModule(_)
-        ));
-        let attempted = session.discovery_attempt().unwrap();
+        let closed = session.close_import_discovery(ledger).unwrap();
         assert_eq!(
-            attempted.status(),
-            crate::ImportDiscoveryRevisionStatus::ClosedAttempted
+            closed.status(),
+            crate::ImportDiscoveryRevisionStatus::ClosedValid
         );
-        assert!(attempted.graph().is_some());
+        let graph = closed.graph().expect("valid close retains graph");
+        let record = graph
+            .graph()
+            .records()
+            .iter()
+            .find(|record| record.normalized_specifier() == "thing")
+            .expect("occurrence resolves");
+        assert!(matches!(
+            record.resolution(),
+            crate::CanonicalImportResolution::Resolved(module)
+                if module.as_str() == "thing/_thing.rue"
+        ));
 
         let std_missing = snapshot(
             &[(

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -10,7 +10,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
-use rue_error::{AmbiguousModuleData, CompileError, CompileErrors, CompileResult, ErrorKind};
+use rue_error::{CompileError, CompileErrors, CompileResult, ErrorKind};
 use rue_span::FileId;
 
 use crate::{
@@ -1671,14 +1671,8 @@ pub(crate) fn exact_import_diagnostics(
         });
         match winning.as_deref() {
             Some([_]) => {}
-            Some([file, directory, ..]) => errors.push(CompileError::new(
-                ErrorKind::AmbiguousModule(Box::new(AmbiguousModuleData {
-                    path: site.specifier().into(),
-                    file_module: file.requested_path().into(),
-                    dir_module: directory.requested_path().into(),
-                })),
-                span,
-            )),
+            // Policy v2 derives exactly one candidate per group.
+            Some([_, _, ..]) => unreachable!("candidate groups hold one candidate"),
             Some([]) => unreachable!(),
             None if site.specifier() == "std" => {
                 errors.push(CompileError::new(ErrorKind::StdLibNotFound, span));
@@ -1796,10 +1790,6 @@ fn accepted_import_manifest(
 pub(crate) enum ExactImportWinner<'a> {
     Missing,
     Resolved(&'a AcceptedImportSource),
-    Ambiguous {
-        file: &'a AcceptedImportSource,
-        directory: &'a AcceptedImportSource,
-    },
 }
 
 pub(crate) fn exact_import_winner<'ledger, 'groups>(
@@ -1816,7 +1806,9 @@ pub(crate) fn exact_import_winner<'ledger, 'groups>(
     });
     match winning.as_deref() {
         Some([source]) => ExactImportWinner::Resolved(source),
-        Some([file, directory, ..]) => ExactImportWinner::Ambiguous { file, directory },
+        // Policy v2 derives exactly one candidate per group, so a group can
+        // never accept two sources.
+        Some([_, _, ..]) => unreachable!("candidate groups hold one candidate"),
         Some([]) => unreachable!(),
         None => ExactImportWinner::Missing,
     }
@@ -1833,12 +1825,6 @@ pub(crate) fn resolve_exact_import_winner<E>(
         ExactImportWinner::Missing => crate::CanonicalImportResolution::Missing,
         ExactImportWinner::Resolved(source) => {
             crate::CanonicalImportResolution::Resolved(module_for(source)?)
-        }
-        ExactImportWinner::Ambiguous { file, directory } => {
-            crate::CanonicalImportResolution::Ambiguous {
-                file_module: module_for(file)?,
-                directory_module: module_for(directory)?,
-            }
         }
     })
 }

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -1573,11 +1573,8 @@ pub(crate) fn escape_diagnostics(
                     .module(site.importer())
                     .expect("import directive belongs to parsed program")
                     .file_id();
-                let span = rue_span::Span::with_file(
-                    file_id,
-                    site.source_offset(),
-                    site.source_end(),
-                );
+                let span =
+                    rue_span::Span::with_file(file_id, site.source_offset(), site.source_end());
                 errors.push(CompileError::new(
                     ErrorKind::ImportEscapesRoot {
                         path: site.specifier().to_owned(),
@@ -2620,7 +2617,11 @@ fn discovery_candidate_groups(
     };
     if specifier == "std" {
         return std::iter::once(vec![join(project_root, "std/_std.rue")])
-            .chain(std_root.into_iter().map(|root| vec![join(root, "_std.rue")]))
+            .chain(
+                std_root
+                    .into_iter()
+                    .map(|root| vec![join(root, "_std.rue")]),
+            )
             .collect();
     }
     if specifier.ends_with(".rue") {

--- a/crates/rue-compiler/src/import_graph.rs
+++ b/crates/rue-compiler/src/import_graph.rs
@@ -132,10 +132,6 @@ impl std::fmt::Debug for ImportDirectives {
 pub enum CanonicalImportResolution {
     Resolved(ModuleId),
     Missing,
-    Ambiguous {
-        file_module: ModuleId,
-        directory_module: ModuleId,
-    },
 }
 
 /// One durable resolved-import value, with no source position or physical path.
@@ -393,12 +389,6 @@ pub enum CanonicalImportGraphProblem {
         importer: ModuleId,
         normalized_specifier: Arc<str>,
     },
-    AmbiguousResolution {
-        importer: ModuleId,
-        normalized_specifier: Arc<str>,
-        file_module: ModuleId,
-        directory_module: ModuleId,
-    },
     DuplicateRecord(CanonicalImportRecord),
     ConflictingCanonicalKey {
         importer: ModuleId,
@@ -573,26 +563,6 @@ fn validate_records(
                     normalized_specifier: record.normalized_specifier.clone(),
                 });
             }
-            CanonicalImportResolution::Ambiguous {
-                file_module,
-                directory_module,
-            } => {
-                for target in [file_module, directory_module] {
-                    if !modules.contains(target) {
-                        problems.push(CanonicalImportGraphProblem::ForeignResolvedTarget {
-                            importer: record.importer.clone(),
-                            normalized_specifier: record.normalized_specifier.clone(),
-                            target: target.clone(),
-                        });
-                    }
-                }
-                problems.push(CanonicalImportGraphProblem::AmbiguousResolution {
-                    importer: record.importer.clone(),
-                    normalized_specifier: record.normalized_specifier.clone(),
-                    file_module: file_module.clone(),
-                    directory_module: directory_module.clone(),
-                });
-            }
         }
     }
     for ((importer, normalized_specifier), resolutions) in by_key {
@@ -691,26 +661,6 @@ pub(crate) fn validate_additive_successor(
                 problems.push(CanonicalImportGraphProblem::MissingResolution {
                     importer: record.importer.clone(),
                     normalized_specifier: record.normalized_specifier.clone(),
-                });
-            }
-            CanonicalImportResolution::Ambiguous {
-                file_module,
-                directory_module,
-            } => {
-                for target in [file_module, directory_module] {
-                    if !inputs.contains(target) {
-                        problems.push(CanonicalImportGraphProblem::ForeignResolvedTarget {
-                            importer: record.importer.clone(),
-                            normalized_specifier: record.normalized_specifier.clone(),
-                            target: target.clone(),
-                        });
-                    }
-                }
-                problems.push(CanonicalImportGraphProblem::AmbiguousResolution {
-                    importer: record.importer.clone(),
-                    normalized_specifier: record.normalized_specifier.clone(),
-                    file_module: file_module.clone(),
-                    directory_module: directory_module.clone(),
                 });
             }
         }

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -1127,12 +1127,6 @@ impl RetainedCharge for crate::CanonicalImportResolution {
     fn retained_charge(&self) -> u64 {
         match self {
             Self::Resolved(module) => module.retained_charge(),
-            Self::Ambiguous {
-                file_module,
-                directory_module,
-            } => file_module
-                .retained_charge()
-                .saturating_add(directory_module.retained_charge()),
             Self::Missing => 0,
         }
     }
@@ -1545,10 +1539,6 @@ impl RetainedCharge for rue_error::ErrorKind {
                 .saturating_add(value.name.retained_charge())
                 .saturating_add(value.expected.retained_charge())
                 .saturating_add(value.found.retained_charge()),
-            E::AmbiguousModule(value) => (std::mem::size_of_val(value.as_ref()) as u64)
-                .saturating_add(value.path.retained_charge())
-                .saturating_add(value.file_module.retained_charge())
-                .saturating_add(value.dir_module.retained_charge()),
             E::PrivateUnqualifiedAccess(value) => (std::mem::size_of_val(value.as_ref()) as u64)
                 .saturating_add(value.item_kind.retained_charge())
                 .saturating_add(value.name.retained_charge())

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -1526,6 +1526,9 @@ impl RetainedCharge for rue_error::ErrorKind {
             E::ModuleNotFound { path, candidates } => path
                 .retained_charge()
                 .saturating_add(candidates.retained_charge()),
+            E::ImportEscapesRoot { path, candidate } => path
+                .retained_charge()
+                .saturating_add(candidate.retained_charge()),
             E::MissingFields(value) => (std::mem::size_of_val(value.as_ref()) as u64)
                 .saturating_add(value.struct_name.retained_charge())
                 .saturating_add(value.missing_fields.retained_charge()),

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -2757,7 +2757,7 @@ struct ResolvedImportBinding {
     target: Option<ModuleId>,
 }
 
-/// A deterministic import-binding failure. Absent, rejected, and ambiguous are
+/// A deterministic import-binding failure. Absent and rejected are
 /// first-class terminal results and dependency edges (ADR-0066 §4 "A failed or
 /// absent module binding is a first-class terminal result and dependency
 /// edge"): a later edit that makes the path resolve changes this stamp and
@@ -2769,8 +2769,6 @@ enum ImportBindingFailure {
     /// Exactly one directive names it, but the specifier is malformed (it
     /// normalizes to an empty module path).
     Rejected,
-    /// Canonical resolution found more than one physical target.
-    Ambiguous,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -7493,9 +7491,6 @@ impl SemanticConstEvaluator<'_, '_> {
             DeclarationImportQueryValue::Available(crate::CanonicalImportResolution::Missing) => {
                 Self::failure(format!("cannot find module `{specifier}`"))
             }
-            DeclarationImportQueryValue::Available(
-                crate::CanonicalImportResolution::Ambiguous { .. },
-            ) => Self::failure(format!("ambiguous module `{specifier}`")),
             DeclarationImportQueryValue::Failure(
                 crate::declaration_candidate::DeclarationImportFailure::ResolutionUnavailable(_),
             ) => Err(EvaluateSemanticConstError::Abort(QueryAbort::MissingInput(
@@ -11944,9 +11939,6 @@ impl RevisionedQueryDatabase {
                         match &resolved.resolution {
                             Some(crate::CanonicalImportResolution::Resolved(target)) => {
                                 binding.target = Some(target.clone());
-                            }
-                            Some(crate::CanonicalImportResolution::Ambiguous { .. }) => {
-                                value = LookupImportValue(Err(ImportBindingFailure::Ambiguous));
                             }
                             Some(crate::CanonicalImportResolution::Missing) => {
                                 value = LookupImportValue(Err(ImportBindingFailure::Absent));
@@ -21261,7 +21253,6 @@ fn import_resolution_from_value(value: &LookupImportValue) -> rue_air::ImportRes
         },
         Err(ImportBindingFailure::Absent) => rue_air::ImportResolution::Absent,
         Err(ImportBindingFailure::Rejected) => rue_air::ImportResolution::Rejected,
-        Err(ImportBindingFailure::Ambiguous) => rue_air::ImportResolution::Ambiguous,
     }
 }
 

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -3493,7 +3493,8 @@ fn pending_occurrence_requests(
             .iter()
             .any(|observation| observation.is_some_and(|value| value.status().is_failure()))
         {
-            break;
+            // ADR-0078: an unreadable candidate is skipped, not conclusive.
+            continue;
         }
         let missing = group
             .iter()

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -12015,6 +12015,20 @@ impl RevisionedQueryDatabase {
                         importer.requested_path(),
                     )
                     .expect("accepted import provenance and captured context are canonical");
+                    if groups.is_empty() {
+                        // The occurrence's candidate escapes the project root
+                        // (ADR-0078): no filesystem request exists and the
+                        // rejection is deterministic, so the binding is a
+                        // first-class Missing terminal. The E0713 diagnostic
+                        // is owned by the diagnostic projection.
+                        return Ok(QueryOutput::success(ResolveImportValue {
+                            site_found: true,
+                            groups: Arc::from([]),
+                            requests: Arc::from([]),
+                            speculative_blocked: false,
+                            resolution: Some(crate::CanonicalImportResolution::Missing),
+                        }));
+                    }
                     for request in groups.iter().flat_map(|group| group.iter()) {
                         let present = context
                             .optional_input(import_observation_input(request))
@@ -30950,7 +30964,7 @@ fn main() -> i32 {
     }
 
     #[test]
-    fn declaration_imports_preserve_canonical_ambiguity_and_category_boundaries() {
+    fn declaration_imports_preserve_canonical_resolution_and_category_boundaries() {
         use crate::declaration_candidate::DeclarationCandidateCategory as Category;
 
         let source = "const selected = @import(\"dep\"); struct Box { value: i32, fn get(borrow self) { @import(\"method\"); } fn make() -> Box { @import(\"associated\"); Box { value: 0 } } } drop fn Box(self) { @import(\"drop\"); } fn free() { @import(\"free\"); } enum Choice { A } extern \"C\" { fn foreign() -> i32; }";
@@ -30994,12 +31008,15 @@ fn main() -> i32 {
             CancellationToken::new(),
         );
         let selected_terminal = selected.terminal().unwrap();
+        // Policy v2: both module forms on disk are not ambiguous — the
+        // extensionless specifier names the facade alone; the sibling
+        // `dep.rue` is never probed.
         assert!(
             matches!(
                 selected_terminal.outcome(),
                 rue_query::QueryOutcome::Success(DeclarationImportQueryValue::Available(
-                    crate::CanonicalImportResolution::Ambiguous { .. }
-                ))
+                    crate::CanonicalImportResolution::Resolved(module)
+                )) if module.as_str() == "dep/_dep.rue"
             ),
             "unexpected declaration import outcome: {:#?}",
             selected_terminal.outcome()
@@ -31182,35 +31199,25 @@ fn main() -> i32 {
     }
 
     #[test]
-    fn ambiguous_declaration_import_observes_both_winning_provenance_leaves() {
+    fn facade_declaration_import_observes_its_provenance_leaf_only() {
         use crate::declaration_candidate::DeclarationCandidateCategory as Category;
 
+        // Policy v2: the extensionless specifier owns exactly one candidate,
+        // the facade. The contract pinned here is provenance tracking at that
+        // single leaf: a physical remap of the winner re-stamps the terminal,
+        // while adding files the policy never probes — including the sibling
+        // `dep.rue` file-module spelling — validates green.
         let source = "const selected = @import(\"dep\"); fn main() {}";
         let (_, mut first_assembler, first_context) = import_fixture(308, source);
-        for (path, canonical, identity, value) in [
-            (
-                "/project/dep.rue",
-                "/physical/dep-file.rue",
-                PhysicalFileIdentity::new(2, 1),
-                1,
-            ),
-            (
+        first_assembler
+            .add_explicit(
                 "/project/dep/_dep.rue",
                 "/physical/dep-dir.rue",
                 PhysicalFileIdentity::new(3, 1),
-                2,
-            ),
-        ] {
-            first_assembler
-                .add_explicit(
-                    path,
-                    canonical,
-                    identity,
-                    FileMetadataFingerprint::new(value, 5, 6),
-                    Arc::new(format!("const value = {value};")),
-                )
-                .unwrap();
-        }
+                FileMetadataFingerprint::new(2, 5, 6),
+                Arc::new("const value = 2;".to_owned()),
+            )
+            .unwrap();
         let mut database = RevisionedQueryDatabase::default();
         let (first_snapshot, first_reads, first_revision, first_plan) =
             begin_database_plan(&mut database, &mut first_assembler, first_context);
@@ -31242,46 +31249,24 @@ fn main() -> i32 {
         assert!(matches!(
             first.terminal().unwrap().outcome(),
             rue_query::QueryOutcome::Success(DeclarationImportQueryValue::Available(
-                crate::CanonicalImportResolution::Ambiguous {
-                    file_module,
-                    directory_module,
-                }
-            )) if file_module.as_str() == "dep.rue"
-                && directory_module.as_str() == "dep/_dep.rue"
+                crate::CanonicalImportResolution::Resolved(module)
+            )) if module.as_str() == "dep/_dep.rue"
         ));
         let first_stamp = first.terminal().unwrap().stamp();
 
         let (_, mut remapped_assembler, remapped_context) = import_fixture(308, source);
-        for (path, canonical, identity, value) in [
-            (
-                "/project/left.rue",
-                "/physical/left.rue",
-                PhysicalFileIdentity::new(2, 1),
-                1,
-            ),
-            (
-                "/project/right.rue",
-                "/physical/right.rue",
+        remapped_assembler
+            .add_explicit(
+                "/project/facade.rue",
+                "/physical/facade.rue",
                 PhysicalFileIdentity::new(3, 1),
-                2,
-            ),
-        ] {
-            remapped_assembler
-                .add_explicit(
-                    path,
-                    canonical,
-                    identity,
-                    FileMetadataFingerprint::new(value, 5, 6),
-                    Arc::new(format!("const value = {value};")),
-                )
-                .unwrap();
-        }
+                FileMetadataFingerprint::new(2, 5, 6),
+                Arc::new("const value = 2;".to_owned()),
+            )
+            .unwrap();
         let (remapped_snapshot, remapped_reads, remapped_revision, remapped_plan) =
             begin_database_plan(&mut database, &mut remapped_assembler, remapped_context);
-        let remaps = [
-            ("/project/dep.rue", PhysicalFileIdentity::new(2, 1)),
-            ("/project/dep/_dep.rue", PhysicalFileIdentity::new(3, 1)),
-        ];
+        let remaps = [("/project/dep/_dep.rue", PhysicalFileIdentity::new(3, 1))];
         let remapped_revision = publish_remapped_observations(
             &mut database,
             &remapped_snapshot,
@@ -31304,23 +31289,19 @@ fn main() -> i32 {
         assert!(matches!(
             remapped_terminal.outcome(),
             rue_query::QueryOutcome::Success(DeclarationImportQueryValue::Available(
-                crate::CanonicalImportResolution::Ambiguous {
-                    file_module,
-                    directory_module,
-                }
-            )) if file_module.as_str() == "left.rue"
-                && directory_module.as_str() == "right.rue"
+                crate::CanonicalImportResolution::Resolved(module)
+            )) if module.as_str() == "facade.rue"
         ));
         let remapped_stamp = remapped_terminal.stamp();
 
         let mut green_assembler = remapped_assembler.clone();
         green_assembler
             .add_explicit(
-                "/project/unrelated.rue",
-                "/physical/unrelated.rue",
+                "/project/dep.rue",
+                "/physical/dep-file.rue",
                 PhysicalFileIdentity::new(9, 1),
                 FileMetadataFingerprint::new(9, 2, 3),
-                Arc::new("const unrelated = 9;".to_owned()),
+                Arc::new("const value = 1;".to_owned()),
             )
             .unwrap();
         let green_context =
@@ -31684,10 +31665,21 @@ fn main() -> i32 {
                 &first_plan.demand_roots(),
             )
             .unwrap();
+        // Policy v2 probes the vendored {root}/std/_std.rue before the
+        // toolchain root, so the first frontier round holds the vendored
+        // candidate; the captured std root still appears in the plan's
+        // later group.
         assert!(
             first
                 .requests()
                 .iter()
+                .any(|request| request.requested_path() == "/project/std/_std.rue")
+        );
+        assert!(
+            first_plan
+                .groups()
+                .iter()
+                .flat_map(|group| group.iter())
                 .any(|request| request.requested_path().starts_with("/sdk/"))
         );
 
@@ -31734,15 +31726,17 @@ fn main() -> i32 {
                 .all(|request| request.context() == &second_context)
         );
         assert!(
-            second
-                .requests()
+            second_plan
+                .groups()
                 .iter()
+                .flat_map(|group| group.iter())
                 .any(|request| request.requested_path().starts_with("/other-sdk/"))
         );
         assert!(
-            !second
-                .requests()
+            !second_plan
+                .groups()
                 .iter()
+                .flat_map(|group| group.iter())
                 .any(|request| request.requested_path().starts_with("/sdk/"))
         );
     }

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -2861,6 +2861,7 @@ impl CompilerSession {
         }
         let diagnostics = crate::import_discovery::exact_import_diagnostics(
             &program,
+            plan.context(),
             &exact_groups,
             check_ledger,
         );

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -2995,7 +2995,6 @@ impl CompilerSession {
             matches!(
                 problem,
                 crate::CanonicalImportGraphProblem::MissingResolution { .. }
-                    | crate::CanonicalImportGraphProblem::AmbiguousResolution { .. }
             )
         });
         if !resolution_only {

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -422,6 +422,10 @@ impl ErrorCode {
     /// (`@alloc`/`@alloc_zeroed`/`@free`/`@realloc`/`@resize`, ADR-0059) was
     /// zero or not a power of two. Alignment must be a power of two.
     pub const INTRINSIC_ALIGN_NOT_POWER_OF_TWO: Self = Self(712);
+    /// A relative `@import` path resolves outside the project root (the root
+    /// source file's directory), so it can receive no project-relative module
+    /// identity (ADR-0078).
+    pub const IMPORT_ESCAPES_ROOT: Self = Self(713);
 
     // ========================================================================
     // Literal/operator errors (E0800-E0899)
@@ -1769,6 +1773,8 @@ pub enum ErrorKind {
     },
     #[error("ambiguous module '{}': both '{}' and '{}' exist", .0.path, .0.file_module, .0.dir_module)]
     AmbiguousModule(Box<AmbiguousModuleData>),
+    #[error("import '{path}' escapes the project root: '{candidate}' is outside the root source file's directory")]
+    ImportEscapesRoot { path: String, candidate: String },
     #[error("standard library not found")]
     StdLibNotFound,
     #[error("{item_kind} `{name}` is private")]
@@ -2231,6 +2237,7 @@ impl ErrorKind {
             ErrorKind::ImportRequiresStringLiteral => ErrorCode::IMPORT_REQUIRES_STRING_LITERAL,
             ErrorKind::ModuleNotFound { .. } => ErrorCode::MODULE_NOT_FOUND,
             ErrorKind::AmbiguousModule { .. } => ErrorCode::AMBIGUOUS_MODULE,
+            ErrorKind::ImportEscapesRoot { .. } => ErrorCode::IMPORT_ESCAPES_ROOT,
             ErrorKind::StdLibNotFound => ErrorCode::STD_LIB_NOT_FOUND,
             ErrorKind::PrivateMemberAccess { .. } => ErrorCode::PRIVATE_MEMBER_ACCESS,
             ErrorKind::PrivateUnqualifiedAccess(_) => ErrorCode::PRIVATE_UNQUALIFIED_ACCESS,

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1765,7 +1765,9 @@ pub enum ErrorKind {
         /// Candidates that were tried (for error message)
         candidates: Vec<String>,
     },
-    #[error("import '{path}' escapes the project root: '{candidate}' is outside the root source file's directory")]
+    #[error(
+        "import '{path}' escapes the project root: '{candidate}' is outside the root source file's directory"
+    )]
     ImportEscapesRoot { path: String, candidate: String },
     #[error("standard library not found")]
     StdLibNotFound,

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -414,7 +414,10 @@ impl ErrorCode {
     pub const STD_LIB_NOT_FOUND: Self = Self(705);
     pub const PRIVATE_MEMBER_ACCESS: Self = Self(706);
     pub const UNKNOWN_MODULE_MEMBER: Self = Self(707);
-    pub const AMBIGUOUS_MODULE: Self = Self(708);
+    // 708 (AMBIGUOUS_MODULE) is retired (ADR-0078): an extensionless import
+    // names the directory facade alone and a file module is spelled with its
+    // extension, so the file/facade ambiguity no longer exists. Keep the
+    // number retired rather than reusing it.
     pub const CANNOT_INFER_CAST_TARGET: Self = Self(709);
     pub const CANNOT_INFER_POINTEE_TYPE: Self = Self(710);
     pub const CONTAINER_ELEMENT_NOT_TRIVIALLY_DROPPABLE: Self = Self(711);
@@ -1200,15 +1203,6 @@ fn format_array_length_mismatch(expected: u64, found: u64) -> String {
     }
 }
 
-/// Payload for [`ErrorKind::AmbiguousModule`], boxed to keep `ErrorKind`
-/// within its 64-byte size budget (three inline `String`s exceed it).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AmbiguousModuleData {
-    pub path: String,
-    pub file_module: String,
-    pub dir_module: String,
-}
-
 /// Payload for [`ErrorKind::PrivateUnqualifiedAccess`], boxed to keep
 /// `ErrorKind` within its 64-byte size budget (three inline `String`s
 /// exceed it).
@@ -1771,8 +1765,6 @@ pub enum ErrorKind {
         /// Candidates that were tried (for error message)
         candidates: Vec<String>,
     },
-    #[error("ambiguous module '{}': both '{}' and '{}' exist", .0.path, .0.file_module, .0.dir_module)]
-    AmbiguousModule(Box<AmbiguousModuleData>),
     #[error("import '{path}' escapes the project root: '{candidate}' is outside the root source file's directory")]
     ImportEscapesRoot { path: String, candidate: String },
     #[error("standard library not found")]
@@ -2236,7 +2228,6 @@ impl ErrorKind {
             }
             ErrorKind::ImportRequiresStringLiteral => ErrorCode::IMPORT_REQUIRES_STRING_LITERAL,
             ErrorKind::ModuleNotFound { .. } => ErrorCode::MODULE_NOT_FOUND,
-            ErrorKind::AmbiguousModule { .. } => ErrorCode::AMBIGUOUS_MODULE,
             ErrorKind::ImportEscapesRoot { .. } => ErrorCode::IMPORT_ESCAPES_ROOT,
             ErrorKind::StdLibNotFound => ErrorCode::STD_LIB_NOT_FOUND,
             ErrorKind::PrivateMemberAccess { .. } => ErrorCode::PRIVATE_MEMBER_ACCESS,

--- a/crates/rue-spec/cases/expressions/call.toml
+++ b/crates/rue-spec/cases/expressions/call.toml
@@ -117,7 +117,7 @@ name = "module_member_unmarked_param_rejects_borrow"
 spec = ["4.10:3"]
 description = "A module-qualified function call enforces the same exact source-mode contract as an unqualified call."
 source = """
-const m = @import("mode_helper");
+const m = @import("mode_helper.rue");
 
 fn main() -> i32 {
     let x = 42;

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -2988,7 +2988,7 @@ name = "module_eager_type_call_rejects_borrow_for_unmarked_param"
 spec = ["4.10:3", "4.14:22", "4.14:28"]
 description = "A module-qualified type constructor reduced in a module-scope const enforces the same unmarked comptime-parameter spelling."
 source = """
-const helper = @import("mode_type_helper");
+const helper = @import("mode_type_helper.rue");
 const Boxed = helper.Box(borrow i64);
 
 fn main() -> i32 { 0 }

--- a/crates/rue-spec/cases/items/constants.toml
+++ b/crates/rue-spec/cases/items/constants.toml
@@ -118,7 +118,7 @@ name = "module_binding_needs_no_annotation"
 spec = ["6.5:4"]
 description = "Module bindings are not value constants: no annotation required"
 source = """
-const cfg = @import("cfg");
+const cfg = @import("cfg.rue");
 const X: i32 = cfg.LIMIT;
 
 fn main() -> i32 { X }
@@ -227,7 +227,7 @@ name = "forward_reference_across_files"
 spec = ["6.5:7", "6.5:10"]
 description = "A const may reference a const declared in another (imported) file"
 source = """
-const cfg = @import("cfg");
+const cfg = @import("cfg.rue");
 const BASE: i32 = cfg.LIMIT;
 const DERIVED: i32 = BASE + 1;
 
@@ -348,7 +348,7 @@ name = "string_const_module_member"
 spec = ["6.5:16"]
 description = "A pub string constant is usable through module member access"
 source = """
-const util = @import("util");
+const util = @import("util.rue");
 
 fn main() -> i32 {
     let n = util.NAME;

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -47,7 +47,7 @@ spec = ["6.1:7", "6.1:38"]
 description = "The entry-point requirement (6.1:7) is checked against the root module: a root that lacks `main` is rejected even when an imported module defines one (6.1:38)"
 source = """
 fn start() -> i32 {
-    let m = @import("m");
+    let m = @import("m.rue");
     m.answer()
 }
 """

--- a/crates/rue-spec/cases/modules/bindings.toml
+++ b/crates/rue-spec/cases/modules/bindings.toml
@@ -13,10 +13,10 @@ name = "const_and_let_bindings_equivalent"
 spec = ["10.4:1"]
 description = "A module bound by top-level const and by local let supports the same member access"
 source = """
-const math = @import("math");
+const math = @import("math.rue");
 
 fn main() -> i32 {
-    let m = @import("math");
+    let m = @import("math.rue");
     math.add(40, m.add(1, 1))
 }
 """
@@ -38,7 +38,7 @@ fn main() -> i32 {
 }
 """
 aux_files = { "a/_a.rue" = """
-pub const b = @import("a/b");
+pub const b = @import("b");
 """, "a/b/_b.rue" = """
 pub fn value() -> i32 { 42 }
 """ }
@@ -50,12 +50,12 @@ spec = ["10.4:4"]
 description = "A non-pub const re-export is accessible from a file in the same directory as its definer"
 source = """
 fn main() -> i32 {
-    let m = @import("mod");
+    let m = @import("mod.rue");
     m.helper.h()
 }
 """
 aux_files = { "mod.rue" = """
-const helper = @import("sub/helper");
+const helper = @import("sub/helper.rue");
 """, "sub/helper.rue" = """
 pub fn h() -> i32 { 42 }
 """ }
@@ -72,7 +72,7 @@ description = "Passing a module binding as a function argument is a compile erro
 source = """
 fn takes(m: i32) -> i32 { m }
 fn main() -> i32 {
-    let math = @import("math");
+    let math = @import("math.rue");
     takes(math)
 }
 """
@@ -87,7 +87,7 @@ description = "Using a module binding as a struct field value is a compile error
 source = """
 struct Holder { m: i32 }
 fn main() -> i32 {
-    let math = @import("math");
+    let math = @import("math.rue");
     let h = Holder { m: math };
     0
 }
@@ -102,8 +102,8 @@ spec = ["10.4:6"]
 description = "Comparing module bindings with == is a compile error"
 source = """
 fn main() -> i32 {
-    let a = @import("math");
-    let b = @import("math");
+    let a = @import("math.rue");
+    let b = @import("math.rue");
     if a == b { 1 } else { 0 }
 }
 """
@@ -120,7 +120,7 @@ spec = ["10.4:6"]
 description = "A module as the tail expression of a unit-typed block is E0206, not the unit value"
 source = """
 fn sink() {
-    let math = @import("math");
+    let math = @import("math.rue");
     math
 }
 fn main() -> i32 { sink(); 0 }
@@ -136,7 +136,7 @@ description = "Passing a module where a `()` parameter is expected is E0206"
 source = """
 fn sink(x: ()) -> i32 { 0 }
 fn main() -> i32 {
-    let math = @import("math");
+    let math = @import("math.rue");
     sink(math)
 }
 """
@@ -156,7 +156,7 @@ spec = ["10.4:7"]
 description = "A bare module expression statement is accepted and discarded"
 source = """
 fn main() -> i32 {
-    let math = @import("math");
+    let math = @import("math.rue");
     math;
     math.add(1, 2)
 }
@@ -170,7 +170,7 @@ spec = ["10.4:7"]
 description = "A block statement whose tail is a module expression is accepted and discarded"
 source = """
 fn main() -> i32 {
-    let math = @import("math");
+    let math = @import("math.rue");
     { math };
     math.add(2, 3)
 }
@@ -187,18 +187,18 @@ name = "same_binding_name_in_two_files"
 spec = ["10.4:8"]
 description = "Two files each bind `const utils = @import(...)` to the same module without conflict"
 source = """
-const a = @import("a");
-const b = @import("b");
+const a = @import("a.rue");
+const b = @import("b.rue");
 
 fn main() -> i32 {
     a.from_a() + b.from_b()
 }
 """
 aux_files = { "a.rue" = """
-const utils = @import("utils");
+const utils = @import("utils.rue");
 pub fn from_a() -> i32 { utils.one() }
 """, "b.rue" = """
-const utils = @import("utils");
+const utils = @import("utils.rue");
 pub fn from_b() -> i32 { utils.one() + 1 }
 """, "utils.rue" = """
 pub fn one() -> i32 { 1 }
@@ -210,18 +210,18 @@ name = "same_binding_name_different_modules"
 spec = ["10.4:8"]
 description = "Two files bind the same name to different modules; each file sees its own binding"
 source = """
-const a = @import("a");
-const b = @import("b");
+const a = @import("a.rue");
+const b = @import("b.rue");
 
 fn main() -> i32 {
     a.from_a() + b.from_b()
 }
 """
 aux_files = { "a.rue" = """
-const helper = @import("m1");
+const helper = @import("m1.rue");
 pub fn from_a() -> i32 { helper.ten() }
 """, "b.rue" = """
-const helper = @import("m2");
+const helper = @import("m2.rue");
 pub fn from_b() -> i32 { helper.twenty() }
 """, "m1.rue" = """
 pub fn ten() -> i32 { 10 }
@@ -235,8 +235,8 @@ name = "duplicate_binding_in_one_file_error"
 spec = ["10.4:8"]
 description = "Two module bindings with the same name in a single file are a duplicate-constant error"
 source = """
-const m = @import("m1");
-const m = @import("m2");
+const m = @import("m1.rue");
+const m = @import("m2.rue");
 
 fn main() -> i32 {
     m.ten()
@@ -259,7 +259,7 @@ name = "alias_of_module_binding"
 spec = ["10.4:10"]
 description = "A const initialized from another module binding aliases the same module"
 source = """
-const m = @import("math");
+const m = @import("math.rue");
 const m2 = m;
 
 fn main() -> i32 {
@@ -282,7 +282,7 @@ fn main() -> i32 {
 }
 """
 aux_files = { "outer/_outer.rue" = """
-pub const inner = @import("inner");
+pub const inner = @import("inner.rue");
 """, "outer/inner.rue" = """
 pub fn value() -> i32 { 42 }
 """ }
@@ -297,7 +297,7 @@ name = "value_const_member_at_use_site"
 spec = ["10.4:12"]
 description = "m.CONST yields the member constant's value with its declared type"
 source = """
-const math = @import("math");
+const math = @import("math.rue");
 
 fn main() -> i32 {
     math.ANSWER
@@ -311,7 +311,7 @@ name = "value_const_member_keeps_declared_width"
 spec = ["10.4:12"]
 description = "An i64 member constant keeps its width through the member access"
 source = """
-const cfg = @import("cfg");
+const cfg = @import("cfg.rue");
 
 fn main() -> i32 {
     if cfg.BIG / 1000000000 == 5 { 9 } else { 1 }
@@ -325,7 +325,7 @@ name = "value_const_member_in_const_initializer"
 spec = ["10.4:12", "10.4:14"]
 description = "Member access to a value const is itself compile-time evaluable"
 source = """
-const math = @import("math");
+const math = @import("math.rue");
 const COPY: i32 = math.ANSWER;
 
 fn main() -> i32 {
@@ -340,7 +340,7 @@ name = "pub_const_member_visible_across_directories"
 spec = ["10.4:13"]
 description = "A pub const member is accessible from any directory"
 source = """
-const lib = @import("sub/lib");
+const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
     lib.LIMIT
@@ -354,7 +354,7 @@ name = "private_const_member_rejected_across_directories"
 spec = ["10.4:13"]
 description = "A non-pub const member is private outside its directory (E0706)"
 source = """
-const lib = @import("sub/lib");
+const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
     lib.SECRET
@@ -380,7 +380,7 @@ name = "qualified_type_variant_and_assoc_fn_forms"
 spec = ["10.4:15"]
 description = "Struct literal, associated function, variant expression, and variant pattern are all usable through a module binding"
 source = """
-const lib = @import("sub/lib");
+const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
     let p = lib.Point { x: 40, y: 2 };
@@ -409,7 +409,7 @@ name = "qualified_path_in_type_position_allowed"
 spec = ["10.4:16"]
 description = "A module-qualified path in a type-annotation position resolves through the importing module."
 source = """
-const lib = @import("sub/lib");
+const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
     let p: lib.Point = lib.Point { x: 1, y: 2 };
@@ -426,8 +426,8 @@ name = "same_named_structs_in_distinct_modules_are_distinct"
 spec = ["10.4:16"]
 description = "RUE-454: module-qualified type lookup uses the defining module, so sibling modules may each define `Point`."
 source = """
-const a = @import("a");
-const b = @import("b");
+const a = @import("a.rue");
+const b = @import("b.rue");
 
 fn main() -> i32 {
     let p: a.Point = a.Point { x: 10 };
@@ -447,8 +447,8 @@ name = "same_named_enums_in_distinct_modules_are_distinct"
 spec = ["10.4:15"]
 description = "RUE-454: module-qualified enum lookup uses the defining module, so sibling modules may each define `Color`."
 source = """
-const a = @import("a");
-const b = @import("b");
+const a = @import("a.rue");
+const b = @import("b.rue");
 
 fn main() -> i32 {
     let left = a.pick_a();
@@ -478,7 +478,7 @@ name = "qualified_private_struct_literal_rejected"
 spec = ["10.4:18"]
 description = "A private struct named in a module-qualified struct literal from another directory is E0706, uniform with every module-member privacy violation (RUE-525)"
 source = """
-const lib = @import("sub/lib");
+const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
     let s = lib.Secret { n: 3 };
@@ -497,7 +497,7 @@ name = "qualified_private_enum_variant_rejected"
 spec = ["10.4:18"]
 description = "A private enum's variant named through a module from another directory is E0706 (routes through module-member resolution)"
 source = """
-const lib = @import("sub/lib");
+const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
     let h = lib.Hidden.A;
@@ -522,7 +522,7 @@ name = "cross_dir_unqualified_private_assoc_fn_rejected"
 spec = ["10.4:19", "10.3:8"]
 description = "An unqualified associated-function call on another file's struct does not resolve at all (RUE-525): name-resolution error, never a flat-namespace hit"
 source = """
-const lib = @import("sub/lib");
+const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
     let s = Secret.make();
@@ -543,7 +543,7 @@ name = "cross_dir_qualified_private_assoc_fn_rejected"
 spec = ["10.4:19", "10.4:18"]
 description = "A module-qualified associated-function call on a private struct from another directory is E0706, uniform with every module-member privacy violation (RUE-525)"
 source = """
-const lib = @import("sub/lib");
+const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
     let s = lib.Secret.make();
@@ -564,7 +564,7 @@ name = "cross_dir_pub_assoc_fn_allowed"
 spec = ["10.4:19", "10.4:17"]
 description = "A module-qualified associated-function call on a pub struct across directories is allowed; the qualifier resolves the type in the named module"
 source = """
-const lib = @import("sub/lib");
+const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
     let p = lib.Point.origin();
@@ -585,7 +585,7 @@ name = "same_dir_private_assoc_fn_allowed"
 spec = ["10.4:19"]
 description = "Intra-directory visibility is unchanged: an associated-function call on a private struct in an imported same-directory module is allowed"
 source = """
-const lib = @import("lib");
+const lib = @import("lib.rue");
 
 fn main() -> i32 {
     let s = lib.Secret.make();
@@ -605,7 +605,7 @@ name = "cross_dir_comptime_bound_assoc_fn_allowed"
 spec = ["10.4:19"]
 description = "A receiver type reached through a comptime binding (not by naming the struct) is exempt: `let P = lib.Point; P.origin()` is allowed"
 source = """
-const lib = @import("sub/lib");
+const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
     let P = lib.Point;

--- a/crates/rue-spec/cases/modules/composition.toml
+++ b/crates/rue-spec/cases/modules/composition.toml
@@ -10,8 +10,8 @@ spec = ["10.5:2"]
 description = "Two loaded files may define the same top-level function name when each is accessed through its own module"
 source = """
 fn main() -> i32 {
-    let a = @import("a");
-    let _b = @import("b");
+    let a = @import("a.rue");
+    let _b = @import("b.rue");
     a.shared()
 }
 """
@@ -24,8 +24,8 @@ spec = ["10.5:2"]
 description = "Top-level value constants may share a source name across imported files when accessed through their modules"
 source = """
 fn main() -> i32 {
-    let left = @import("left");
-    let _right = @import("right");
+    let left = @import("left.rue");
+    let _right = @import("right.rue");
     left.go()
 }
 """
@@ -44,7 +44,7 @@ spec = ["10.5:2", "6.1:38"]
 description = "A top-level `main` in a non-root (imported) module is an ordinary namespaced function: it does not conflict with the root's entry point and is callable through its module path, returning its own value"
 source = """
 fn main() -> i32 {
-    let m = @import("m");
+    let m = @import("m.rue");
     m.main()
 }
 """
@@ -57,7 +57,7 @@ spec = ["10.5:2", "6.1:38"]
 description = "When both the root and an imported module define `main`, the root module's `main` is the program entry point"
 source = """
 fn main() -> i32 {
-    let m = @import("m");
+    let m = @import("m.rue");
     m.value() + 3
 }
 """
@@ -94,8 +94,8 @@ spec = ["10.5:3"]
 description = "The 10.5:3 example: same-named functions in two modules, each call resolving in its own module"
 source = """
 fn main() -> i32 {
-    let a = @import("a");
-    let b = @import("b");
+    let a = @import("a.rue");
+    let b = @import("b.rue");
     a.shared() + b.shared()
 }
 """
@@ -108,7 +108,7 @@ spec = ["10.5:4"]
 description = "The guaranteed half of demand-driven analysis: an error in imported code the program reaches is always reported (the lazy half — unreferenced items possibly unanalyzed — is exercised by the real driver in CLI tests)"
 source = """
 fn main() -> i32 {
-    let m = @import("m");
+    let m = @import("m.rue");
     m.broken()
 }
 """

--- a/crates/rue-spec/cases/modules/directory.toml
+++ b/crates/rue-spec/cases/modules/directory.toml
@@ -14,7 +14,7 @@ spec = ["10.1:2"]
 description = "@import('foo') resolves to foo.rue when it exists (verifies file is found)"
 source = """
 fn main() -> i32 {
-    let math = @import("math");
+    let math = @import("math.rue");
     0
 }
 """
@@ -92,7 +92,7 @@ spec = ["10.1:4"]
 description = "A sibling _math.rue is just a file, not a facade: math.rue resolves cleanly (the pre-RUE-137 sibling layout has no special meaning)"
 source = """
 fn main() -> i32 {
-    let math = @import("math");
+    let math = @import("math.rue");
     0
 }
 """
@@ -129,7 +129,7 @@ spec = ["10.2:1"]
 description = "@import('foo/bar') resolves to foo/bar.rue"
 source = """
 fn main() -> i32 {
-    let nested = @import("sub/helper");
+    let nested = @import("sub/helper.rue");
     0
 }
 """
@@ -148,7 +148,7 @@ spec = ["10.1:1", "10.1:2"]
 description = "A file's top-level items are the imported module's members"
 source = """
 fn main() -> i32 {
-    let math = @import("math");
+    let math = @import("math.rue");
     math.add(40, 2)
 }
 """
@@ -178,7 +178,7 @@ spec = ["10.1:4"]
 description = "A lone sibling _foo.rue does not make 'foo' importable: it is not a facade outside a foo/ directory"
 source = """
 fn main() -> i32 {
-    let m = @import("foo");
+    let m = @import("foo.rue");
     0
 }
 """

--- a/crates/rue-spec/cases/modules/import.toml
+++ b/crates/rue-spec/cases/modules/import.toml
@@ -17,7 +17,7 @@ spec = ["4.13:79", "4.13:80", "4.13:82", "10.2:1"]
 description = "@import with string argument is accepted"
 source = """
 fn main() -> i32 {
-    let m = @import("foo");
+    let m = @import("foo.rue");
     0
 }
 """
@@ -30,7 +30,7 @@ spec = ["4.13:79", "4.13:80"]
 description = "@import can be used in a const binding (typical pattern)"
 source = """
 fn main() -> i32 {
-    let math = @import("math");
+    let math = @import("math.rue");
     0
 }
 """
@@ -43,8 +43,8 @@ spec = ["4.13:79"]
 description = "Multiple @import calls in same file"
 source = """
 fn main() -> i32 {
-    let a = @import("a");
-    let b = @import("b");
+    let a = @import("a.rue");
+    let b = @import("b.rue");
     0
 }
 """
@@ -57,7 +57,7 @@ spec = ["4.13:79", "4.13:82"]
 description = "@import with nested path"
 source = """
 fn main() -> i32 {
-    let utils = @import("utils/strings");
+    let utils = @import("utils/strings.rue");
     0
 }
 """
@@ -121,22 +121,47 @@ compile_fail = true
 error_contains = "cannot find module"
 
 # =============================================================================
-# Ambiguous module forms (RUE-137)
+# Coexisting module forms and project-root identity (ADR-0078)
 # =============================================================================
 
 [[case]]
-name = "ambiguous_module_both_forms_error"
-spec = ["4.13:89"]
-description = "Both foo.rue and foo/_foo.rue existing is a compile error, not a precedence question"
+name = "both_forms_coexist_extensionless_names_facade"
+spec = ["10.1:5", "10.2:1"]
+description = "foo.rue and foo/_foo.rue may coexist; the extensionless import names the facade alone (E0708 is retired)"
 source = """
 fn main() -> i32 {
     let m = @import("foo");
-    0
+    m.b()
 }
 """
 aux_files = { "foo.rue" = "pub fn a() -> i32 { 1 }", "foo/_foo.rue" = "pub fn b() -> i32 { 2 }" }
+exit_code = 2
+
+[[case]]
+name = "both_forms_coexist_extension_names_file"
+spec = ["10.1:5", "10.2:1"]
+description = "With both forms present, the extensioned spelling reaches the file module"
+source = """
+fn main() -> i32 {
+    let m = @import("foo.rue");
+    m.a()
+}
+"""
+aux_files = { "foo.rue" = "pub fn a() -> i32 { 1 }", "foo/_foo.rue" = "pub fn b() -> i32 { 2 }" }
+exit_code = 1
+
+[[case]]
+name = "import_escaping_project_root_is_rejected"
+spec = ["4.13:89", "10.2:7"]
+description = "A relative import whose normalized candidate leaves the project root is E0713; no filesystem probe is attempted"
+source = """
+fn main() -> i32 {
+    let o = @import("../outside.rue");
+    0
+}
+"""
 compile_fail = true
-error_contains = "ambiguous module"
+error_contains = "escapes the project root"
 
 [[case]]
 name = "const_module_reexport_member_chain"
@@ -149,7 +174,7 @@ fn main() -> i32 {
 }
 """
 aux_files = { "outer/_outer.rue" = """
-pub const inner = @import("outer/inner.rue");
+pub const inner = @import("inner.rue");
 """, "outer/inner.rue" = """
 pub fn value() -> i32 { 42 }
 """ }
@@ -166,7 +191,7 @@ fn main() -> i32 {
 }
 """
 aux_files = { "outer/_outer.rue" = """
-const inner = @import("outer/inner.rue");
+const inner = @import("inner.rue");
 """, "outer/inner.rue" = """
 pub fn value() -> i32 { 42 }
 """ }
@@ -179,8 +204,8 @@ spec = ["4.13:90"]
 description = "A pub function from a different file in the same compilation is not a member of an unrelated module (RUE-140)"
 source = """
 fn main() -> i32 {
-    let utils = @import("utils");
-    let other = @import("other");
+    let utils = @import("utils.rue");
+    let other = @import("other.rue");
     let _ = other.sneaky();
     utils.sneaky()
 }

--- a/crates/rue-spec/cases/modules/intra_directory.toml
+++ b/crates/rue-spec/cases/modules/intra_directory.toml
@@ -14,7 +14,7 @@ spec = ["10.3:2"]
 description = "Files in same directory can access private functions"
 source = """
 fn main() -> i32 {
-    let utils = @import("utils");
+    let utils = @import("utils.rue");
     utils.internal_helper()
 }
 """
@@ -32,7 +32,7 @@ spec = ["10.3:4"]
 description = "Files in same directory can access public functions"
 source = """
 fn main() -> i32 {
-    let utils = @import("utils");
+    let utils = @import("utils.rue");
     utils.public_helper()
 }
 """
@@ -49,7 +49,7 @@ spec = ["10.3:2"]
 description = "Files in same directory can access private structs"
 source = """
 fn main() -> i32 {
-    let utils = @import("utils");
+    let utils = @import("utils.rue");
     let InternalPoint = utils.InternalPoint;
     let p = InternalPoint { x: 20, y: 22 };
     p.x + p.y
@@ -67,7 +67,7 @@ spec = ["10.3:2"]
 description = "Files in same directory can access private enums"
 source = """
 fn main() -> i32 {
-    let utils = @import("utils");
+    let utils = @import("utils.rue");
     let s = utils.InternalStatus.Active;
     match s {
         utils.InternalStatus.Active => 42,
@@ -92,7 +92,7 @@ spec = ["10.3:4"]
 description = "Files in different directories can access public functions"
 source = """
 fn main() -> i32 {
-    let utils = @import("subdir/utils");
+    let utils = @import("subdir/utils.rue");
     utils.public_fn()
 }
 """
@@ -109,7 +109,7 @@ spec = ["10.3:3"]
 description = "Files in different directories cannot access private functions"
 source = """
 fn main() -> i32 {
-    let utils = @import("subdir/utils");
+    let utils = @import("subdir/utils.rue");
     utils.private_fn()
 }
 """
@@ -127,7 +127,7 @@ spec = ["10.3:4"]
 description = "Files in different directories can access public structs"
 source = """
 fn main() -> i32 {
-    let utils = @import("subdir/utils");
+    let utils = @import("subdir/utils.rue");
     let PublicPoint = utils.PublicPoint;
     let p = PublicPoint { x: 10, y: 32 };
     p.x + p.y
@@ -144,7 +144,7 @@ spec = ["10.3:3"]
 description = "Files in different directories cannot access private structs"
 source = """
 fn main() -> i32 {
-    let utils = @import("subdir/utils");
+    let utils = @import("subdir/utils.rue");
     let PrivatePoint = utils.PrivatePoint;
     let p = PrivatePoint { x: 10, y: 32 };
     p.x + p.y
@@ -162,7 +162,7 @@ spec = ["10.3:4"]
 description = "Files in different directories can access public enums"
 source = """
 fn main() -> i32 {
-    let utils = @import("subdir/utils");
+    let utils = @import("subdir/utils.rue");
     let s = utils.PublicStatus.On;
     match s {
         utils.PublicStatus.On => 42,
@@ -181,7 +181,7 @@ spec = ["10.3:3"]
 description = "Files in different directories cannot access private enums"
 source = """
 fn main() -> i32 {
-    let utils = @import("subdir/utils");
+    let utils = @import("subdir/utils.rue");
     let s = utils.PrivateStatus.On;
     0
 }
@@ -209,7 +209,7 @@ fn main() -> i32 {
 """
 aux_files = { "utils/_utils.rue" = """
 // Re-export the strings module functions
-const strings = @import("utils/strings");
+const strings = @import("strings.rue");
 
 pub fn format() -> i32 {
     strings.internal_format()
@@ -235,7 +235,7 @@ name = "cross_dir_unqualified_private_fn_error"
 spec = ["10.3:8"]
 description = "Unqualified call to a private function of an imported module in another directory is rejected"
 source = """
-const utils = @import("subdir/utils");
+const utils = @import("subdir/utils.rue");
 
 fn main() -> i32 {
     internal_fn()
@@ -254,7 +254,7 @@ name = "cross_dir_unqualified_pub_fn_rejected"
 spec = ["10.3:8"]
 description = "Unqualified call to a pub function of an imported module is rejected; use module-qualified access"
 source = """
-const utils = @import("subdir/utils");
+const utils = @import("subdir/utils.rue");
 
 fn main() -> i32 {
     public_fn()
@@ -273,7 +273,7 @@ name = "same_dir_unqualified_private_fn_rejected"
 spec = ["10.3:2", "10.3:8"]
 description = "Unqualified call to a private function of an imported file in the SAME directory is rejected; use module-qualified access"
 source = """
-const utils = @import("utils");
+const utils = @import("utils.rue");
 
 fn main() -> i32 {
     internal_fn()
@@ -299,7 +299,7 @@ name = "cross_dir_unqualified_private_struct_error"
 spec = ["10.3:7"]
 description = "Unqualified struct literal + annotation naming a private struct of an imported module in another directory is rejected"
 source = """
-const defs = @import("subdir/defs");
+const defs = @import("subdir/defs.rue");
 
 fn main() -> i32 {
     let p: Point = Point { x: 40, y: 2 };
@@ -320,7 +320,7 @@ name = "cross_dir_unqualified_private_const_error"
 spec = ["10.3:7"]
 description = "Unqualified read of a private constant of an imported module in another directory is rejected"
 source = """
-const defs = @import("subdir/defs");
+const defs = @import("subdir/defs.rue");
 
 fn main() -> i32 {
     LIMIT
@@ -344,7 +344,7 @@ name = "cross_dir_unqualified_private_enum_error"
 spec = ["10.3:7"]
 description = "Unqualified annotation + variant construction naming a private enum of an imported module in another directory is rejected"
 source = """
-const defs = @import("subdir/defs");
+const defs = @import("subdir/defs.rue");
 
 fn main() -> i32 {
     let c: Color = Color.Blue;

--- a/crates/rue-spec/cases/modules/resolution.toml
+++ b/crates/rue-spec/cases/modules/resolution.toml
@@ -5,22 +5,22 @@ name = "Import Resolution Order"
 description = "Base-directory search order, transitive loading, and cycle behavior (spec chapter 10.2)."
 
 # =============================================================================
-# Base directory order (10.2:2): importing file's directory first, then the
-# root file's directory; nearer wins.
+# Importer-relative resolution (10.2:2): one base directory, no fallback
+# (ADR-0078).
 # =============================================================================
 
 [[case]]
-name = "importer_relative_beats_root_relative"
+name = "importer_relative_is_the_only_base"
 spec = ["10.2:2"]
-description = "A module found relative to the importing file shadows one at the same relative path next to the root file"
+description = "A relative import resolves against the importing file's directory alone; a same-named file next to the root file is not a candidate"
 source = """
 fn main() -> i32 {
-    let m = @import("sub/mod");
+    let m = @import("sub/mod.rue");
     m.go()
 }
 """
 aux_files = { "sub/mod.rue" = """
-const helper = @import("helper");
+const helper = @import("helper.rue");
 pub fn go() -> i32 { helper.h() }
 """, "sub/helper.rue" = """
 pub fn h() -> i32 { 42 }
@@ -30,17 +30,36 @@ pub fn h() -> i32 { 7 }
 exit_code = 42
 
 [[case]]
-name = "root_relative_fallback"
+name = "no_root_relative_fallback"
 spec = ["10.2:2"]
-description = "When the importing file's directory has no match, resolution falls back to the root file's directory"
+description = "When the importing file's directory has no match, resolution fails rather than falling back to the root file's directory"
 source = """
 fn main() -> i32 {
-    let m = @import("sub/mod");
+    let m = @import("sub/mod.rue");
     m.go()
 }
 """
 aux_files = { "sub/mod.rue" = """
-const helper = @import("helper");
+const helper = @import("helper.rue");
+pub fn go() -> i32 { helper.h() }
+""", "helper.rue" = """
+pub fn h() -> i32 { 42 }
+""" }
+compile_fail = true
+error_contains = "cannot find module"
+
+[[case]]
+name = "importer_reaches_root_sibling_by_explicit_path"
+spec = ["10.2:2", "10.2:7"]
+description = "A nested importer names a root-level module with an explicit ../ spelling that stays inside the project root"
+source = """
+fn main() -> i32 {
+    let m = @import("sub/mod.rue");
+    m.go()
+}
+"""
+aux_files = { "sub/mod.rue" = """
+const helper = @import("../helper.rue");
 pub fn go() -> i32 { helper.h() }
 """, "helper.rue" = """
 pub fn h() -> i32 { 42 }
@@ -57,12 +76,12 @@ spec = ["10.2:3"]
 description = "Importing a module loads that module's own imports without the user listing them"
 source = """
 fn main() -> i32 {
-    let outer = @import("outer");
+    let outer = @import("outer.rue");
     outer.go()
 }
 """
 aux_files = { "outer.rue" = """
-const inner = @import("inner");
+const inner = @import("inner.rue");
 pub fn go() -> i32 { inner.value() }
 """, "inner.rue" = """
 pub fn value() -> i32 { 42 }
@@ -79,16 +98,16 @@ spec = ["10.2:4"]
 description = "Two modules importing each other compile and run; each file is loaded once"
 source = """
 fn main() -> i32 {
-    let a = @import("a");
+    let a = @import("a.rue");
     a.a_uses_b()
 }
 """
 aux_files = { "a.rue" = """
-const b = @import("b");
+const b = @import("b.rue");
 pub fn from_a() -> i32 { 1 }
 pub fn a_uses_b() -> i32 { b.from_b() }
 """, "b.rue" = """
-const a = @import("a");
+const a = @import("a.rue");
 pub fn from_b() -> i32 { 42 }
 """ }
 exit_code = 42
@@ -99,16 +118,16 @@ spec = ["10.2:4"]
 description = "Two importers of the same module refer to the same single loaded file (no duplicate-definition error from loading it twice)"
 source = """
 fn main() -> i32 {
-    let left = @import("left");
-    let _right = @import("right");
+    let left = @import("left.rue");
+    let _right = @import("right.rue");
     left.go()
 }
 """
 aux_files = { "left.rue" = """
-const shared = @import("shared");
+const shared = @import("shared.rue");
 pub fn go() -> i32 { shared.value() }
 """, "right.rue" = """
-const shared2 = @import("shared");
+const shared2 = @import("shared.rue");
 pub fn go2() -> i32 { shared2.value() }
 """, "shared.rue" = """
 pub fn value() -> i32 { 42 }
@@ -121,13 +140,13 @@ spec = ["10.2:4"]
 description = "Two different relative import spellings that normalize to the same file refer to one loaded module"
 source = """
 fn main() -> i32 {
-    let left = @import("pkg/left");
-    let right = @import("pkg/nested/right");
+    let left = @import("pkg/left.rue");
+    let right = @import("pkg/nested/right.rue");
     left.left_value() + right.right_value()
 }
 """
 aux_files = { "pkg/left.rue" = """
-const shared = @import("shared");
+const shared = @import("shared.rue");
 pub fn left_value() -> i32 { shared.value() }
 """, "pkg/nested/right.rue" = """
 const shared = @import("../shared.rue");

--- a/crates/rue-spec/cases/modules/stdlib.toml
+++ b/crates/rue-spec/cases/modules/stdlib.toml
@@ -90,3 +90,23 @@ pub fn Option(comptime T: type) -> type {
 }
 """ }
 exit_code = 7
+
+[[case]]
+name = "vendored_std_resolves_from_nested_importer"
+spec = ["10.2:6"]
+description = "A vendored std/_std.rue under the project root serves @import(\"std\") from any depth; std is never searched importer-relative (ADR-0078)"
+source = """
+fn main() -> i32 {
+    let m = @import("sub/mod.rue");
+    m.go()
+}
+"""
+aux_files = { "sub/mod.rue" = """
+const s = @import("std");
+pub fn go() -> i32 { s.vendored() }
+""", "std/_std.rue" = """
+pub fn vendored() -> i32 { 21 }
+""", "sub/std/_std.rue" = """
+pub fn hijacked() -> i32 { 13 }
+""" }
+exit_code = 21

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -706,6 +706,43 @@ fn validate_watch_modes(options: &Options) -> Result<(), &'static str> {
     }
 }
 
+
+/// ADR-0078 migration help. An extensionless import names the directory
+/// facade alone under policy v2; when it misses but the sibling file module
+/// `{P}.rue` exists on disk, append the extensioned spelling as a help. The
+/// probe is presentation-only: it runs after discovery has closed, feeds no
+/// observation ledger, and creates no dependency edge, so it can never affect
+/// resolution, closure, or reuse.
+fn with_import_migration_helps(errors: &CompileErrors) -> CompileErrors {
+    let mut enriched = CompileErrors::new();
+    for error in errors.iter() {
+        let sibling = match &error.kind {
+            rue_error::ErrorKind::ModuleNotFound { path, candidates }
+                if !path.ends_with(".rue") =>
+            {
+                let basename = Path::new(path)
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or(path);
+                let facade_suffix = format!("/_{basename}.rue");
+                candidates.iter().find_map(|candidate: &String| {
+                    let sibling = format!("{}.rue", candidate.strip_suffix(&facade_suffix)?);
+                    Path::new(&sibling).is_file().then_some((path.clone(), sibling))
+                })
+            }
+            _ => None,
+        };
+        match sibling {
+            Some((path, sibling)) => enriched.push(error.clone().with_help(format!(
+                "an extensionless import names the directory facade; the file module \
+                 '{sibling}' is imported with its extension: @import(\"{path}.rue\")"
+            ))),
+            None => enriched.push(error.clone()),
+        }
+    }
+    enriched
+}
+
 struct DiagnosticOutput<'a> {
     format: ErrorFormat,
     text: MultiFileFormatter<'a>,
@@ -1723,7 +1760,9 @@ fn main() {
     }
 
     if compiler_host.discovery_status() != ImportDiscoveryStatus::ClosedValid {
-        diagnostics.print_errors(compiler_host.discovery_revision().diagnostics());
+        diagnostics.print_errors(&with_import_migration_helps(
+            compiler_host.discovery_revision().diagnostics(),
+        ));
         std::process::exit(1);
     }
 
@@ -1879,7 +1918,7 @@ fn main() {
             exit_successful_native_compile();
         }
         Err(errors) => {
-            diagnostics.print_errors(&errors);
+            diagnostics.print_errors(&with_import_migration_helps(&errors));
             std::process::exit(1);
         }
     }

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -706,7 +706,6 @@ fn validate_watch_modes(options: &Options) -> Result<(), &'static str> {
     }
 }
 
-
 /// ADR-0078 migration help. An extensionless import names the directory
 /// facade alone under policy v2; when it misses but the sibling file module
 /// `{P}.rue` exists on disk, append the extensioned spelling as a help. The
@@ -727,7 +726,9 @@ fn with_import_migration_helps(errors: &CompileErrors) -> CompileErrors {
                 let facade_suffix = format!("/_{basename}.rue");
                 candidates.iter().find_map(|candidate: &String| {
                     let sibling = format!("{}.rue", candidate.strip_suffix(&facade_suffix)?);
-                    Path::new(&sibling).is_file().then_some((path.clone(), sibling))
+                    Path::new(&sibling)
+                        .is_file()
+                        .then_some((path.clone(), sibling))
                 })
             }
             _ => None,

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -3340,6 +3340,39 @@ mod tests {
         );
     }
 
+    /// ADR-0078: an existing but undeclared vendored `{root}/std/_std.rue` is
+    /// a hermetic denial, never absence. If denial fell through to the next
+    /// candidate, resolution would silently bind the declared toolchain std
+    /// and a manifest build would resolve `std` to a different file than an
+    /// unrestricted build of the same tree.
+    #[test]
+    fn undeclared_vendored_std_is_hermetic_denial_not_fallthrough() {
+        let project = TestDir::new("vendored-denied-project");
+        let stdlib = TestDir::new("vendored-denied-std");
+        let main = project.write(
+            "main.rue",
+            "const s = @import(\"std\"); fn main() -> i32 { 0 }",
+        );
+        project.write("std/_std.rue", "pub fn vendored() -> i32 { 21 }");
+        let env_std = stdlib.write("_std.rue", "pub fn env_std() -> i32 { 1 }");
+        let std_root = fs::canonicalize(&stdlib.path).unwrap();
+        let root_canonical = fs::canonicalize(&main).unwrap();
+        let env_canonical = fs::canonicalize(&env_std).unwrap();
+        let manifest = manifest_allowing(&project, &[&root_canonical, &env_canonical]);
+
+        let error = load_and_acquire(&main, Some(manifest), Some(&std_root))
+            .expect_err("an undeclared vendored std cannot be skipped");
+        // The vendored copy is an ordinary project candidate, so its denial
+        // surfaces as a typed compile diagnostic naming the read policy — not
+        // as toolchain-acquisition HermeticDenial, and never as absence.
+        let rendered = error_display(&error);
+        assert!(
+            rendered.contains("not listed in the source manifest read policy")
+                && rendered.contains("std/_std.rue"),
+            "expected fail-closed denial naming the vendored candidate, got {error:?}"
+        );
+    }
+
     /// CLI classification: a hermetic denial is presented as a distinct
     /// build-configuration failure, NOT as toolchain corruption. The two error
     /// classes carry disjoint labels ("Hermetic build configuration error" vs

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -2717,43 +2717,45 @@ mod tests {
     }
 
     /// A candidate that misses on its first group is answered but NOT concluded:
-    /// the occurrence still owes its next candidate an operation. Here
-    /// `sub/leaf.rue` imports `shared.rue`, which is absent beside it and present
-    /// at the project root, so its precedence walk spans two hops while its
-    /// module is new in neither.
+    /// the occurrence still owes its next candidate an operation. Under policy
+    /// v2 the only multi-group occurrence is `std`: the vendored
+    /// `{root}/std/_std.rue` is probed absent here, so the occurrence is
+    /// answered but still owes the toolchain root's facade an operation.
     ///
     /// The contract this pins is unchanged by ADR-0075 — an occurrence that is
     /// answered but still open must be carried forward, and dropping it loses
-    /// `shared.rue` — but the carrying happens a level down: the wave keeps the
-    /// occurrence in its open set and derives its second candidate at the next
-    /// hop, instead of a later round re-rooting it. The three reads and the
-    /// resolution are identical; the three publications collapse to one.
+    /// the standard library — the wave keeps the occurrence in its open set and
+    /// derives its next candidate at the next hop, instead of a later round
+    /// re-rooting it.
     #[test]
     fn import_occurrence_answered_but_still_open_is_carried_across_wave_hops() {
         let dir = TestDir::new("open-occurrence-reroot");
+        let stdlib = TestDir::new("open-occurrence-reroot-std");
         let main = dir.write(
             "main.rue",
             r#"const leaf = @import("sub/leaf.rue"); fn main() -> i32 { leaf.value() }"#,
         );
         dir.write(
             "sub/leaf.rue",
-            r#"const shared = @import("shared.rue"); pub fn value() -> i32 { shared.value() }"#,
+            r#"const s = @import("std"); pub fn value() -> i32 { 7 }"#,
         );
-        dir.write("shared.rue", "pub fn value() -> i32 { 7 }");
+        stdlib.write("_std.rue", "pub fn std_value() -> i32 { 1 }");
+        let std_root = fs::canonicalize(&stdlib.path).unwrap();
 
-        let result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
+        let result =
+            discover_and_load_imports(main.to_str().unwrap(), None, Some(&std_root)).unwrap();
 
         assert_eq!(result.read_manifest.len(), 3);
         assert!(
             result
                 .read_manifest
                 .iter()
-                .any(|entry| entry.module().as_str() == "shared.rue"),
+                .any(|entry| entry.module().as_str().starts_with("\0rue-std/")),
             "the second candidate of the still-open occurrence must be resolved"
         );
-        // One wave, three hops: the leaf, its missed sibling candidate, then the
-        // project-root `shared.rue` the second candidate resolves to. Publishing
-        // per hop minted three revisions for the same three reads.
+        // One wave: the leaf, the absent vendored std probe, then the toolchain
+        // facade the second candidate resolves to. Publishing per hop minted
+        // separate revisions for the same reads.
         assert_eq!(result.input_revision.frontier_round(), 1);
     }
 

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -3340,15 +3340,22 @@ mod tests {
         );
     }
 
-    /// ADR-0078: an existing but undeclared vendored `{root}/std/_std.rue` is
-    /// a hermetic denial, never absence. If denial fell through to the next
-    /// candidate, resolution would silently bind the declared toolchain std
-    /// and a manifest build would resolve `std` to a different file than an
-    /// unrestricted build of the same tree.
+    /// ADR-0078: under a source manifest an undeclared vendored
+    /// `{root}/std/_std.rue` is SKIPPED, and `std` resolves to the declared
+    /// toolchain facade.
+    ///
+    /// Hermetic denial is lexical and takes no probe, so the compiler cannot
+    /// distinguish "absent" from "present but undeclared". Treating the denial
+    /// as conclusive would fail every hermetic build whose program does not
+    /// vendor std — the vendored candidate is probed first and denied even
+    /// when nothing is there. The manifest is therefore the authority on which
+    /// std is in the build: declare the vendored copy and it wins (that arm is
+    /// covered by the CLI deps cases), omit it and the declared toolchain std
+    /// resolves.
     #[test]
-    fn undeclared_vendored_std_is_hermetic_denial_not_fallthrough() {
-        let project = TestDir::new("vendored-denied-project");
-        let stdlib = TestDir::new("vendored-denied-std");
+    fn undeclared_vendored_std_is_skipped_for_the_declared_toolchain_std() {
+        let project = TestDir::new("vendored-skipped-project");
+        let stdlib = TestDir::new("vendored-skipped-std");
         let main = project.write(
             "main.rue",
             "const s = @import(\"std\"); fn main() -> i32 { 0 }",
@@ -3360,16 +3367,21 @@ mod tests {
         let env_canonical = fs::canonicalize(&env_std).unwrap();
         let manifest = manifest_allowing(&project, &[&root_canonical, &env_canonical]);
 
-        let error = load_and_acquire(&main, Some(manifest), Some(&std_root))
-            .expect_err("an undeclared vendored std cannot be skipped");
-        // The vendored copy is an ordinary project candidate, so its denial
-        // surfaces as a typed compile diagnostic naming the read policy — not
-        // as toolchain-acquisition HermeticDenial, and never as absence.
-        let rendered = error_display(&error);
+        let result = load_and_acquire(&main, Some(manifest), Some(&std_root))
+            .expect("the undeclared vendored candidate is skipped, not conclusive");
         assert!(
-            rendered.contains("not listed in the source manifest read policy")
-                && rendered.contains("std/_std.rue"),
-            "expected fail-closed denial naming the vendored candidate, got {error:?}"
+            result
+                .read_manifest
+                .iter()
+                .any(|entry| entry.module().as_str().starts_with("\0rue-std/")),
+            "std must resolve to the declared toolchain facade"
+        );
+        assert!(
+            !result
+                .read_manifest
+                .iter()
+                .any(|entry| entry.module().as_str() == "std/_std.rue"),
+            "the undeclared vendored candidate must never be read"
         );
     }
 

--- a/docs/designs/0026-module-system.md
+++ b/docs/designs/0026-module-system.md
@@ -9,6 +9,7 @@ implemented: 2026-01-04
 stabilized: 2026-01-04
 spec-sections: []
 superseded-by:
+amended-by: [0078]
 ---
 
 # ADR-0026: Module System
@@ -129,7 +130,8 @@ fn helper() -> i32 { 42 }  // private
 2. Directory `foo/` containing the facade file `foo/_foo.rue` (directory module)
 3. (Future) Dependency named `foo` in `rue.toml`
 
-Having BOTH `foo.rue` and `foo/_foo.rue` is a compile error (E0708, ambiguous
+Having BOTH `foo.rue` and `foo/_foo.rue` was a compile error (E0708, ambiguous;
+retired by ADR-0078 — the extensionless path now names the facade alone
 module) — mirroring Rust's E0761 rather than silently preferring one form.
 
 ### Directory Modules

--- a/docs/designs/0078-import-resolution-policy.md
+++ b/docs/designs/0078-import-resolution-policy.md
@@ -30,8 +30,8 @@ with its `.rue` extension. Relative candidates are searched against the
 importing file's directory only — the root-file fallback is removed.
 Project-relative module identity becomes a total function, so an import may
 not escape the project root. The reserved specifier `std` is exempt from
-relative search entirely: it anchors to the program, resolving to an explicit
-`--std-path`, then a vendored `{root}/std/_std.rue`, then `$RUE_STD_PATH`.
+relative search entirely: it anchors to the program, resolving to a vendored
+`{root}/std/_std.rue`, then `$RUE_STD_PATH`.
 
 ## Context
 
@@ -108,8 +108,11 @@ un-break correct code. It would also make creating a file break a
 previously-working build — reintroducing at the `std` slot exactly the
 nonlocality this ADR removes elsewhere.
 
-The genuine "I am overriding this deliberately" case is served by an explicit
-`--std-path`, which is visible at the call site and in the build record. The
+A dedicated override flag (`--std-path`) was considered and deferred: no
+present workflow needs it — every harness in this repository overrides
+through the environment against non-vendoring programs — and CLI surface
+shipped now is surface the RUE-1586 distribution design must later honor or
+break. Adding a flag later is additive; it is deferred, not rejected. The
 supply-chain posture is served by `--source-manifest`, which already governs
 `std`: a std path the manifest does not declare is a hermetic denial with no
 probe.
@@ -156,9 +159,8 @@ against a fixed precedence chain, taking the first that exists:
 
 | Order | Source | Meaning |
 |-------|--------|---------|
-| 1 | `--std-path <p>` | explicit per-invocation override |
-| 2 | `{root}/std/_std.rue` | the program vendored its own |
-| 3 | `$RUE_STD_PATH` | toolchain installation default |
+| 1 | `{root}/std/_std.rue` | the program vendored its own |
+| 2 | `$RUE_STD_PATH` | toolchain installation default |
 | — | otherwise | E0705 |
 
 Each is a single candidate. `std` is never searched importer-relative, which
@@ -167,11 +169,16 @@ vendored location is anchored to the program root rather than to the
 importer.
 
 The governing property: **ambient environment can never replace a standard
-library the program shipped.** Only an explicit argument can, and that
-argument is visible on the command line and in the dependency record.
+library the program shipped.** Replacing a vendored standard library means
+editing the program's tree.
 
-`--std-path` is new CLI surface introduced by this ADR. It is what makes the
-precedence chain expressible without an error state.
+Under `--source-manifest`, the chain does not bend: a vendored
+`{root}/std/_std.rue` that exists but is not declared in the manifest is a
+hermetic denial error, exactly like every other undeclared path. Denial is
+never treated as absence, so a manifest build can never silently resolve
+`std` to a different file than an unrestricted build of the same tree —
+it resolves identically or fails loudly. This preserves ADR-0063's
+requirement that denied and absent remain distinguishable observations.
 
 ### 5. Nonlocality, stated
 
@@ -198,7 +205,7 @@ only shrinks the set it applies to.
 - [ ] **Phase 2: Candidate-policy collapse** — one candidate per relative
       specifier and one base directory in `discovery_candidate_groups` /
       `discovery_groups_for_occurrence`; std resolves through the precedence
-      chain; add `--std-path`.
+      chain; a test pins the undeclared-vendored-std hermetic denial.
 - [ ] **Phase 3: Total root-relative identity** — reject escaping imports
       with a new diagnostic; keep physical-identity aliasing.
 - [ ] **Phase 4: Migration diagnostics** — when an extensionless import finds
@@ -233,17 +240,16 @@ only shrinks the set it applies to.
 - Importer-relative-only leaves distant imports spelled
   `../../../core/registry`. The fix is a named-module namespace, which
   belongs to Packages; this ADR accepts the ergonomic gap in the interim.
-- `--std-path` adds CLI surface.
 - `std` now follows a different anchoring rule from relative specifiers. This
   is stated in the spec as a property of reserved names rather than left
   implicit, but it is a second rule where there had been one.
 
 ## Open Questions
 
-- Should `--source-manifest` mode reject a vendored `{root}/std/_std.rue`
-  that the manifest does not declare? The existing hermetic denial suggests
-  yes, and no change should be needed, but Phase 2 must confirm it rather
-  than assume it.
+None. The `--source-manifest` interaction and the override-flag question
+were both resolved after acceptance and folded into Decision 4: undeclared
+vendored std fails closed, and the explicit override flag is deferred to
+RUE-1586.
 
 ## Future Work
 

--- a/docs/designs/0078-import-resolution-policy.md
+++ b/docs/designs/0078-import-resolution-policy.md
@@ -174,13 +174,35 @@ The governing property: **ambient environment can never replace a standard
 library the program shipped.** Replacing a vendored standard library means
 editing the program's tree.
 
-Under `--source-manifest`, the chain does not bend: a vendored
-`{root}/std/_std.rue` that exists but is not declared in the manifest is a
-hermetic denial error, exactly like every other undeclared path. Denial is
-never treated as absence, so a manifest build can never silently resolve
-`std` to a different file than an unrestricted build of the same tree —
-it resolves identically or fails loudly. This preserves ADR-0063's
-requirement that denied and absent remain distinguishable observations.
+Under `--source-manifest`, the manifest is the authority on which standard
+library is in the build. A candidate the manifest does not declare is
+skipped and the walk continues: declare the vendored copy and it wins,
+omit it and the declared toolchain facade resolves.
+
+This narrows an earlier form of this decision, which required an existing
+but undeclared vendored std to fail closed. That rule is not implementable
+as stated. Hermetic denial is *lexical and takes no probe* — by design, so
+that a hermetic build never touches an undeclared path — so the compiler
+cannot distinguish "absent" from "present but undeclared". Treating the
+denial as conclusive fails every hermetic build whose program does not
+vendor std at all: the vendored candidate is probed first and denied even
+when nothing is there. The repository's own reproducibility fixture is
+exactly that shape.
+
+Preserving the stricter rule would require the host to stat undeclared
+candidates to separate absence from denial, weakening the no-probe
+guarantee to sharpen a case a correct manifest never reaches. The
+generator that produces a manifest sees a vendored `std/` and declares it;
+omitting it is a build-system defect, and its failure mode is the declared
+toolchain std rather than a silent read of an undeclared file.
+
+Because a candidate that cannot be read is skipped rather than conclusive,
+a failed observation is reported only when *no* candidate in the
+occurrence's chain resolved. Under policy v2 only `std` has more than one
+candidate, so this rule is confined to the std chain: every relative
+specifier still fails on its single candidate's failure. Denied and absent
+remain distinguishable typed observations, satisfying ADR-0063; they are
+merely both non-resolutions for precedence purposes.
 
 ### 5. Nonlocality, stated
 

--- a/docs/designs/0078-import-resolution-policy.md
+++ b/docs/designs/0078-import-resolution-policy.md
@@ -9,6 +9,7 @@ accepted: 2026-08-18
 implemented:
 spec-sections: ["10.1:5", "10.2:1", "10.2:2", "10.2:4", "10.2:6", "4.13:89"]
 superseded-by:
+amends: [0026]
 relates: ["ADR-0051", "ADR-0063", "ADR-0075", "RUE-1127", "RUE-266", "RUE-1100", "RUE-1023", "RUE-1586"]
 ---
 
@@ -127,7 +128,8 @@ already resolves a `.rue`-suffixed specifier exactly, so a file module is
 spelled `@import("math.rue")`.
 
 This *deletes* the file-versus-facade ambiguity rather than diagnosing it.
-Spec 10.1:5 and rule 4.13:89 are removed, and E0708 is retired.
+Spec 10.1:5 and rule 4.13:89 are reworded under their stable IDs (spec
+paragraph IDs are permanent), and E0708 is retired.
 
 ### 2. Relative specifiers are importer-relative only
 
@@ -200,8 +202,8 @@ only shrinks the set it applies to.
 ## Implementation Phases
 
 - [ ] **Phase 1: Spec amendment** — rewrite 10.2:1–2, restate 10.2:4's
-      canonical identity, replace 10.2:6 with the precedence chain, delete
-      10.1:5 and 4.13:89, retire E0708.
+      canonical identity, replace 10.2:6 with the precedence chain, reword
+      10.1:5 and 4.13:89 under their stable IDs, retire E0708.
 - [ ] **Phase 2: Candidate-policy collapse** — one candidate per relative
       specifier and one base directory in `discovery_candidate_groups` /
       `discovery_groups_for_occurrence`; std resolves through the precedence

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -1061,7 +1061,7 @@ fn helper() -> i32 { 42 }  // private, not exported
 
 // main.rue
 fn main() -> i32 {
-    let math = @import("math");
+    let math = @import("math.rue");
     math.add(1, 2)  // returns 3
 }
 ```
@@ -1073,7 +1073,7 @@ Private declarations (those without `pub`) are not visible to importers:
 ```rue
 // main.rue
 fn main() -> i32 {
-    let math = @import("math");
+    let math = @import("math.rue");
     // math.helper()  // Error: `helper` is not visible
     0
 }
@@ -1085,7 +1085,7 @@ The imported module can be bound to any name:
 
 ```rue
 fn main() -> i32 {
-    let m = @import("math");
+    let m = @import("math.rue");
     m.add(1, 2)
 }
 ```
@@ -1096,16 +1096,17 @@ Nested paths are supported for importing from subdirectories:
 
 ```rue
 fn main() -> i32 {
-    let strings = @import("utils/strings");
+    let strings = @import("utils/strings.rue");
     0
 }
 ```
 
 {{ rule(id="4.13:89", cat="legality-rule") }}
 
-It is a compile-time error if a module path resolves to both a file module
-`{path}.rue` and a directory module `{path}/_{basename}.rue` — the import is
-ambiguous, and neither form takes precedence.
+It is a compile-time error (E0713) if a relative import path's normalized
+candidate falls outside the project root (the root file's directory); see
+rule [10.2:7](@/10-modules/02-import-resolution.md). Module identity is
+project-root-relative, so a file outside the root can receive no identity.
 
 {{ rule(id="4.13:90", cat="legality-rule") }}
 

--- a/docs/spec/src/06-items/05-constants.md
+++ b/docs/spec/src/06-items/05-constants.md
@@ -52,7 +52,7 @@ is the whole-initializer form `const N: i32 = m.LIMIT;`.
 {{ rule(id="6.5:15", cat="normative") }}
 
 A constant initializer may name a function item, either directly (`const f =
-some_fn;`) or as a module member (`const f = @import("math").abs;`). Such a
+some_fn;`) or as a module member (`const f = @import("math.rue").abs;`). Such a
 constant is a **callable alias**: it may appear as the callee of a call
 expression (`f(1, 2)`) and has the same call behavior as the aliased function.
 It is not a runtime value and may not be used as an ordinary expression,

--- a/docs/spec/src/10-modules/01-module-forms.md
+++ b/docs/spec/src/10-modules/01-module-forms.md
@@ -37,11 +37,12 @@ and it does not make `{name}` importable.
 
 {{ rule(id="10.1:5") }}
 
-If both module forms exist for the same import path — a file module
-`{path}.rue` and a directory module `{path}/_{basename}.rue` — the import is
-ambiguous and rejected at compile time; neither form takes precedence. This
-is specified as rule
-[4.13:89](@/04-expressions/13-intrinsics.md) (error E0708).
+Both module forms may coexist for the same name: an extensionless import
+path names the directory module `{path}/_{basename}.rue` alone, and the
+file module `{path}.rue` is reached only by its extensioned spelling
+(rule 10.2:1). Neither form can capture an import addressed to the other,
+so no ambiguity arises. (The former ambiguity rejection, E0708, is
+retired.)
 
 {{ rule(id="10.1:6", cat="example") }}
 
@@ -49,7 +50,7 @@ A project mixing both forms:
 
 ```text
 main.rue            # root file
-math.rue            # file module: @import("math")
+math.rue            # file module: @import("math.rue")
 utils/              # directory module: @import("utils")
 ├── _utils.rue      #   facade — the module root for "utils"
 └── strings.rue     #   helper file, reached via the facade's imports

--- a/docs/spec/src/10-modules/02-import-resolution.md
+++ b/docs/spec/src/10-modules/02-import-resolution.md
@@ -16,26 +16,26 @@ a source file on disk, and how the set of loaded files is computed. The
 
 {{ rule(id="10.2:1", cat="normative") }}
 
-An import path `P` is resolved by trying the following interpretations in
-order; the first that matches is used:
+An import path `P` names exactly one candidate file:
 
 1. If `P` is exactly `"std"`, the import resolves to the standard library
    (see 10.2:6).
 2. If `P` ends with the `.rue` extension, the import resolves to the file at
    exactly that relative path.
-3. Otherwise, the import resolves to the file module `{P}.rue`, or, when no
-   such file exists, to the directory-module facade `{P}/_{basename}.rue`
-   (where `basename` is the final path component of `P`). If *both* exist,
-   the import is ambiguous and rejected (rule
-   [4.13:89](@/04-expressions/13-intrinsics.md)).
+3. Otherwise, the import resolves to the directory-module facade
+   `{P}/_{basename}.rue` (where `basename` is the final path component of
+   `P`), and to nothing else. A file module is imported only by its
+   extensioned spelling; a sibling `{P}.rue` is never a candidate for the
+   extensionless path, so both forms may coexist without ambiguity.
 
 {{ rule(id="10.2:2", cat="normative") }}
 
-Relative candidate paths are searched against base directories in order:
-first the directory containing the *importing* file, then the directory
-containing the *root* file (the first source file given to the compiler). A
-module found relative to the importing file takes precedence over a module
-at the same relative path found relative to the root file.
+A relative candidate path is resolved against exactly one base directory:
+the directory containing the *importing* file. There is no fallback base;
+in particular, resolution never retries relative to the root file. Adding a
+file therefore either satisfies a previously failing import at its one
+candidate path or is irrelevant to it — it can never retarget an import
+that already resolves.
 
 ## Transitive Loading
 
@@ -51,11 +51,13 @@ the base for that file's own relative imports (per 10.2:2).
 {{ rule(id="10.2:4", cat="normative") }}
 
 Each source file is loaded at most once per compilation, after resolving the
-import path to the file's canonical location. An import that resolves to an
-already-loaded file refers to that same module, even if the import used a
-different relative spelling. Import cycles are therefore legal: two modules
-may import each other, and a chain of imports may return to its starting
-file.
+import path to the file's canonical location: its normalized path relative
+to the *project root*, the directory containing the root file. Rule 10.2:7
+makes this identity total. Two import spellings denote the same module
+exactly when they normalize to the same project-root-relative path; an
+import that resolves to an already-loaded file refers to that same module.
+Import cycles are therefore legal: two modules may import each other, and a
+chain of imports may return to its starting file.
 
 {{ rule(id="10.2:5", cat="example") }}
 
@@ -63,17 +65,17 @@ Mutually importing modules:
 
 ```rue
 // a.rue
-const b = @import("b");
+const b = @import("b.rue");
 pub fn from_a() -> i32 { 1 }
 pub fn a_uses_b() -> i32 { b.from_b() }
 
 // b.rue
-const a = @import("a");
+const a = @import("a.rue");
 pub fn from_b() -> i32 { 42 }
 
 // main.rue
 fn main() -> i32 {
-    let a = @import("a");
+    let a = @import("a.rue");
     a.a_uses_b()  // 42
 }
 ```
@@ -82,8 +84,26 @@ fn main() -> i32 {
 
 {{ rule(id="10.2:6", cat="normative") }}
 
-`@import("std")` resolves to the standard library facade `_std.rue`. It is
-searched for at `$RUE_STD_PATH/_std.rue` when the `RUE_STD_PATH` environment
-variable is set, and otherwise as an ordinary directory module `std/_std.rue`
-per 10.2:2. When both exist, `$RUE_STD_PATH` takes precedence. If no
-standard library is found, the import is a compile-time error (E0705).
+`std` is a reserved specifier, not a relative path: it is never searched
+relative to the importing file. `@import("std")` resolves to the standard
+library facade `_std.rue` through a fixed precedence chain, taking the
+first that exists:
+
+1. the program's vendored copy, `std/_std.rue` under the project root; then
+2. the toolchain installation default, `$RUE_STD_PATH/_std.rue`, when the
+   `RUE_STD_PATH` environment variable is set.
+
+A standard library the program ships therefore cannot be replaced by
+ambient environment. If neither location holds a facade, the import is a
+compile-time error (E0705).
+
+## Project-Root Identity
+
+{{ rule(id="10.2:7", cat="normative") }}
+
+Every relative candidate path lies within the project root. An import whose
+normalized candidate path would fall outside the root file's directory is
+rejected at compile time (rule
+[4.13:89](@/04-expressions/13-intrinsics.md), error E0713); no filesystem
+probe is attempted for it. Standard-library modules resolve within their
+own root under 10.2:6 and are not subject to this rule.

--- a/docs/spec/src/10-modules/03-visibility.md
+++ b/docs/spec/src/10-modules/03-visibility.md
@@ -42,7 +42,7 @@ directory module see only the facade's `pub` members.
 
 ```rue
 // utils/_utils.rue — the facade
-const strings = @import("strings");
+const strings = @import("strings.rue");
 pub fn format() -> i32 { strings.internal_format() }  // OK: same directory
 
 // utils/strings.rue
@@ -92,7 +92,7 @@ pub struct Shared { n: i32, }
 pub const MAX: i32 = 16;
 
 // main.rue — a different directory
-const lib = @import("sub/lib");
+const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
     // secret()                    // error E0202: does not resolve here (10.3:8)

--- a/docs/spec/src/10-modules/04-module-bindings.md
+++ b/docs/spec/src/10-modules/04-module-bindings.md
@@ -22,10 +22,10 @@ Member access through either binding form has the same semantics.
 {{ rule(id="10.4:2", cat="example") }}
 
 ```rue
-const math = @import("math");      // top-level const binding
+const math = @import("math.rue");  // top-level const binding
 
 fn main() -> i32 {
-    let m = @import("math");       // local let binding
+    let m = @import("math.rue");   // local let binding
     math.add(1, m.add(2, 3))       // equivalent access through either
 }
 ```
@@ -72,8 +72,8 @@ non-`pub` re-export is private to the directory of its defining file.
 
 ```rue
 // outer/_outer.rue
-pub const inner = @import("inner");   // pub re-export
-const hidden = @import("inner");      // private outside outer/
+pub const inner = @import("inner.rue"); // pub re-export
+const hidden = @import("inner.rue");    // private outside outer/
 
 // outer/inner.rue
 pub fn value() -> i32 { 42 }
@@ -132,7 +132,7 @@ pub const ANSWER: i32 = 42;
 const SECRET: i32 = 99;          // private outside math.rue's directory
 
 // main.rue (same directory)
-const math = @import("math");
+const math = @import("math.rue");
 const COPY: i32 = math.ANSWER;   // const-evaluable member access
 
 fn main() -> i32 { math.ANSWER + COPY }   // 84
@@ -210,7 +210,7 @@ pub enum Color { Red, Green, Blue, }
 enum Hidden { A, B, }               // private outside sub/
 
 // main.rue — a different directory
-const lib = @import("sub/lib");
+const lib = @import("sub/lib.rue");
 fn main() -> i32 {
     let p = lib.Point { x: 40, y: 2 };     // qualified struct literal
     let q = lib.Point.origin();           // qualified associated fn

--- a/docs/spec/src/10-modules/05-program-composition.md
+++ b/docs/spec/src/10-modules/05-program-composition.md
@@ -56,8 +56,8 @@ pub fn shared() -> i32 { 2 }   // legal: names are module-scoped
 
 // main.rue
 fn main() -> i32 {
-    let a = @import("a");
-    let b = @import("b");
+    let a = @import("a.rue");
+    let b = @import("b.rue");
     a.shared() + b.shared()    // 3: each call resolves in its own module
 }
 ```

--- a/fixtures/rue-program/hello/sub/types.rue
+++ b/fixtures/rue-program/hello/sub/types.rue
@@ -1,5 +1,6 @@
-// "shared.rue" resolves root-relative to ../shared.rue; resolution observes
-// the absent importer-relative arm sub/shared.rue first.
-const shared = @import("shared.rue");
+// The shared module sits at the program root and is named by an explicit
+// importer-relative path (ADR-0078 removed the root-directory fallback this
+// used to reach it through).
+const shared = @import("../shared.rue");
 
 pub fn value() -> i32 { shared.base() }

--- a/reproducibility/fixture/semantic-order/left/types.rue
+++ b/reproducibility/fixture/semantic-order/left/types.rue
@@ -1,10 +1,12 @@
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
 
-// No left/shared.rue exists: both reordered siblings must resolve this import
-// relative to the explicitly designated root. The compiler unit regression
+// No left/shared.rue exists: both reordered siblings name the one shared
+// module by an explicit importer-relative path (ADR-0078 removed the
+// root-directory fallback this used to lean on), so the pair still resolves
+// to a single identity across FileId orderings. The compiler unit regression
 // separately proves that the root need not have the lowest numeric FileId.
-const shared = @import("shared.rue");
+const shared = @import("../shared.rue");
 
 struct Payload {
     value: i32,

--- a/reproducibility/fixture/semantic-order/right/types.rue
+++ b/reproducibility/fixture/semantic-order/right/types.rue
@@ -1,7 +1,7 @@
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
 
-const shared = @import("shared.rue");
+const shared = @import("../shared.rue");
 
 struct Payload {
     value: i32,


### PR DESCRIPTION
Implements ADR-0078 (RUE-1127), all five phases. The ruling was recorded in #2522; this is the language change itself.

## The change

Policy version 2. Every `@import` specifier owns exactly one candidate path:

- **Importer-relative only.** The root-directory fallback is gone, so adding a nearer file can no longer silently retarget an unchanged import.
- **Extensionless means facade.** `@import("foo")` names `foo/_foo.rue` alone; a file module is spelled `@import("foo.rue")`. Both forms may coexist — the ambiguity is deleted, not diagnosed.
- **`std` anchors to the program.** Vendored `{root}/std/_std.rue`, then the toolchain root. Ambient environment can no longer replace a standard library the program ships.
- **Project-root identity is total.** A relative import whose normalized candidate leaves the root is E0713, derived lexically with no filesystem probe.

The core is ~40 lines in `discovery_candidate_groups` / `discovery_groups_for_occurrence`; the rest is consequence.

## Two rulings settled after the ADR merged

**`--std-path` is deferred, not shipped.** No present workflow needs a deliberate-override channel — every harness overrides through the environment against non-vendoring programs — and CLI surface shipped now is surface RUE-1586's distribution design must later honor or break. Adding a flag later is additive. The chain is vendored → env → E0705.

**Under a manifest, the manifest decides which std is in the build.** A candidate the manifest does not declare is skipped and the walk continues: declare the vendored copy and it wins, omit it and the declared toolchain facade resolves.

This narrows an earlier form of the ruling that required an undeclared-but-present vendored std to fail closed. That rule is not implementable as stated, and CI proved it: hermetic denial is lexical and takes **no probe** — by design, so a hermetic build never touches an undeclared path — so the compiler cannot distinguish "absent" from "present but undeclared". Treating the denial as conclusive failed *every* hermetic build whose program does not vendor std at all, because the vendored candidate is probed first and denied even when nothing is there. The repository's own `reproducible-programs` fixture is exactly that shape. Preserving the stricter rule would require statting undeclared candidates, weakening the no-probe guarantee to sharpen a case a correct manifest never reaches.

Consequently a failed observation is conclusive only when *no* candidate in the occurrence's chain resolved. Under policy v2 only `std` has more than one candidate, so this is confined to the std chain; every relative specifier still fails on its single candidate's failure. Denied and absent remain distinguishable typed observations per ADR-0063 — they are merely both non-resolutions for precedence purposes.

## E0708 retired

With one candidate per group a group can never accept two sources, so the ambiguity surface is structurally unreachable. Removed end to end rather than left dead: `CanonicalImportResolution::Ambiguous`, `AmbiguousResolution`, the winner and diagnostic arms, `ImportBindingFailure::Ambiguous` and its AIR projection, the envelope outcome, and `ErrorKind::AmbiguousModule`. E0708 stays a retired number per the registry convention.

## Verified against a built compiler

Every hazard the ADR cites, re-run after the change:

| Behavior | Before | After |
|---|---|---|
| Nearer file added, no source edited | silently retargets (7 → 42) | root sibling is not a candidate |
| Alternate module form added | working program → E0708 | both forms coexist, facade resolves |
| `sub/std/_std.rue` beside importer, env unset | captures the stdlib (→ 13) | ignored; E0705 |
| Vendored std, nested importer | worked only via the fallback | works from any depth |
| `@import("../outside.rue")` | accepted, identity `"../outside.rue"` | E0713 |

Plus the three manifest arms: no vendored std compiles; undeclared vendored std falls through to the declared toolchain std; declared vendored std wins.

Suites: compiler units 901, AIR 653, driver 45, rue 201, spec 2350, CLI integration 1891, and the **`premerge` tier 194/194**.

## Migration

**Zero real-code changes.** `dijkstra`, `calculator` and `tinydb` were facade imports all along, so they compile untouched — the ADR's estimate of three affected files was wrong in the safe direction. The churn is ~280 fixture sites that exercised the policy deliberately.

Three fixture classes needed judgment rather than mechanical rewriting, all flagged in commit messages:

- **RUE-317's `../` reconciliation cases are superseded.** They pinned that an escaping import reconciles with a CLI-listed file; total root-relative identity forbids exactly that. Replaced with an E0713 pin.
- **Root-relative intra-facade spellings were masked bugs.** Fixtures where `outer/_outer.rue` imported `"outer/inner.rue"` only resolved through the fallback; they are importer-relative now.
- **Two fixtures were purpose-built on the fallback** (`reproducibility/semantic-order`, `fixtures/rue-program/hello`) and said so in their comments. They now name their paths explicitly, keeping the contracts they exist to pin. A static audit over every `.rue` file outside `crates/` confirms no fallback-dependent import remains.

## Spec

Amended under the permanent-ID law — every touched rule reworded under its stable ID, never renumbered. 10.2:1 (one candidate), 10.2:2 (one base), 10.2:4 (canonical identity), 10.2:6 (program-anchored std), new 10.2:7 (total identity), 4.13:89 (escape legality), 10.1:5 (coexistence). ADR-0026 marked `amended-by: [0078]` where it stated the E0708 ambiguity.

## New coverage

Importer-relative-only locality, negative→positive at the single candidate, vendored std serving a nested importer while an adjacent `sub/std/_std.rue` stays inert, escape rejection, the migration help, and the undeclared-vendored-std skip.

Closes RUE-1127.