### PR TITLE
ADR-0080: mark the intra-batch first-touch race closed

### DIFF
--- a/docs/designs/0080-seam-handoff-authority.md
+++ b/docs/designs/0080-seam-handoff-authority.md
@@ -175,8 +175,14 @@ falsifiers below.
   schema, debug assertion, one-worker zero-miss pipeline gate; merged)
 - [x] **Phase 3a: Parent-proof seeding at batch creation** — RUE-1583
   (`BatchValidationAuthority::seed_from_task`; merged)
-- [ ] **Phase 3b: Intra-batch first-touch race** — RUE-1584, under the
-  trust edges ADR-0077 fixes
+- [x] **Phase 3b: Intra-batch first-touch race** — RUE-1584 (per-proof
+  publication into the shared batch authority, authority-held leases as
+  sibling-visible proof, and parent lease seeding across waves; merged).
+  Automatic-worker reacquisition misses fell 97.7% on Lattice, 95.5% on
+  Meridian, 89% on Caldera, with byte-identical executables at every
+  worker count. The residue is simultaneous first probes inside one
+  scheduling quantum, which only exact-identity inheritance
+  (ADR-0077 direction 1) can collapse further.
 - [ ] **Phase 4: Boundary audit** — sweep remaining publication
   boundaries for undocumented re-derivation; each either gains a
   handoff or a seam comment plus counter


### PR DESCRIPTION
Bookkeeping follow-up: RUE-1584 merged as #2529, so ADR-0080's phase 3b is complete.

Checks the box and records what actually closed the gap (per-proof publication into the shared batch authority, authority-held leases as sibling-visible proof, parent lease seeding across waves), the measured outcome (automatic-worker misses −97.7% Lattice / −95.5% Meridian / −89% Caldera, byte-identical executables at every worker count), and what the residue is — simultaneous first probes inside one scheduling quantum, collapsible only by ADR-0077 direction-1 exact-identity inheritance. That last sentence is the point of the edit: without it the leftover misses read as an open instance of this phase rather than as separate ADR-0077 work.

Phase 4 (the boundary audit sweep) remains open.

`scripts/validate-adrs.py` clean; registry valid at 81 records.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JX9YAhH4NCb3nm87AgCZW8)_