### PR TITLE
Reuse cached anonymous nominal digests during body closure

### DIFF
--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -15726,28 +15726,34 @@ impl RevisionedQueryDatabase {
                     };
                     let mut anonymous_digest_owners = BTreeMap::new();
                     let mut anonymous_digest_collision = None;
-                    let body_closure_anonymous_digest = |identity: &crate::AnonymousNominalKey| {
-                        #[cfg(test)]
-                        {
-                            let canonical = identity.with_canonical_producer();
-                            if let Some(digest) = anonymous_digest_forcing_for_closure_aggregation
-                                .lock()
-                                .expect("body-closure forced-digest state is not poisoned")
-                                .digests
-                                .get(canonical.as_ref())
-                                .copied()
+                    let body_closure_anonymous_digest =
+                        |nominal: &crate::durable_semantics::DurableAnonymousNominal| {
+                            #[cfg(test)]
                             {
-                                return digest;
+                                let canonical = nominal.identity.with_canonical_producer();
+                                if let Some(digest) =
+                                    anonymous_digest_forcing_for_closure_aggregation
+                                        .lock()
+                                        .expect("body-closure forced-digest state is not poisoned")
+                                        .digests
+                                        .get(canonical.as_ref())
+                                        .copied()
+                                {
+                                    return digest;
+                                }
+                                compiler_anonymous_identity_digest(&nominal.identity)
                             }
-                        }
-                        compiler_anonymous_identity_digest(identity)
-                    };
+                            #[cfg(not(test))]
+                            {
+                                nominal.anonymous_identity_digest()
+                            }
+                        };
                     if let SemanticNucleusProjectionValue::Available(projection) = declarations {
                         for nominal in projection.anonymous_nominals.iter() {
                             register_body_closure_anonymous_digest(
                                 &mut anonymous_digest_owners,
                                 &mut anonymous_digest_collision,
-                                body_closure_anonymous_digest(&nominal.identity),
+                                body_closure_anonymous_digest(nominal),
                                 &nominal.identity,
                             );
                         }
@@ -15796,7 +15802,7 @@ impl RevisionedQueryDatabase {
                                     register_body_closure_anonymous_digest(
                                         &mut anonymous_digest_owners,
                                         &mut anonymous_digest_collision,
-                                        body_closure_anonymous_digest(&nominal.identity),
+                                        body_closure_anonymous_digest(nominal),
                                         &nominal.identity,
                                     );
                                 }
@@ -22463,6 +22469,7 @@ fn provider_definition_symbol_component(key: &crate::StableDefinitionKey) -> Str
 /// domain used by `CompilerBodyDurableSource`, then take the single AIR digest.
 /// Body closure aggregation calls this before any CFG/codegen consumer can
 /// materialize the collected nominal set.
+#[cfg(test)]
 fn compiler_anonymous_identity_digest(identity: &crate::AnonymousNominalKey) -> u128 {
     crate::semantic_identity::anonymous_nominal_digest(identity)
 }


### PR DESCRIPTION
## Summary
- reuse each DurableAnonymousNominal cached identity digest during body-closure aggregation
- keep test-only digest forcing and canonical collision handling unchanged

## Performance evidence
On fresh-process Lattice compilation with -O3 -j1, 40 order-controlled candidate/baseline pairs measured a -2.886 ms median and -2.891 ms mean, with 27/40 candidate wins. The full compiler_work record and executable SHA-256 were identical in every pair.

## Validation
- scripts/rue unit compiler — 901 passed, 0 failed, 6 ignored
- scripts/rue quick — 30 targets passed

Target: continue reducing the current one-worker cold compile path toward 250 ms without changing canonical outputs or work.