### PR TITLE
Use faster required-type membership set

### DIFF
--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -1594,7 +1594,7 @@ pub(crate) fn select_materialization_facts(
     };
     selection.callable(identity);
     let mut required_types = Vec::new();
-    let mut seen_required_types = std::collections::HashSet::new();
+    let mut seen_required_types = AHashSet::new();
     let mut require_type = |ty: &crate::durable_semantics::DurableType| {
         if seen_required_types.insert(ty.clone()) {
             required_types.push(ty.clone());


### PR DESCRIPTION
## Summary
- use the compiler-owned AHashSet for required durable-type membership in local CFG materialization
- preserve first-seen required-type order and all semantic facts

## Evidence
- 12 matched fresh-process Lattice -O3 -j1 pairs
- exact compiler work counters and emitted output in every pair
- median total delta: -4.5 ms
- focused materialization tests and full quick tier pass
- dedicated incremental edit matrix completed cleanly for Mosaic and Lattice
- bounded-retention witness reproduces the same pre-existing projection-cone panic on clean trunk