### PR TITLE
Fold nominal count into materialization pass

### DIFF
--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -1006,6 +1006,7 @@ pub(crate) fn materialize_semantic_body_with_indexes(
         return Err(LocalMaterializationFailure::DuplicateNominalMetadata);
     }
     let mut nominals = Vec::new();
+    let mut named_nominal_count = 0;
     for declaration in declarations {
         let (kind, shape) = match &declaration.payload {
             DurableDeclarationPayload::Struct {
@@ -1029,6 +1030,7 @@ pub(crate) fn materialize_semantic_body_with_indexes(
             ),
             _ => continue,
         };
+        named_nominal_count += 1;
         let lang_item = indexes
             .nominal_metadata(&declaration.key)
             .ok_or(LocalMaterializationFailure::MissingNominalMetadata)?;
@@ -1042,15 +1044,6 @@ pub(crate) fn materialize_semantic_body_with_indexes(
             shape,
         });
     }
-    let named_nominal_count = declarations
-        .iter()
-        .filter(|declaration| {
-            matches!(
-                declaration.payload,
-                DurableDeclarationPayload::Struct { .. } | DurableDeclarationPayload::Enum { .. }
-            )
-        })
-        .count();
     if indexes.nominal_metadata.len() != named_nominal_count {
         return Err(LocalMaterializationFailure::ExtraNominalMetadata);
     }


### PR DESCRIPTION
## Summary
- count selected named nominals during the existing materialization declaration pass
- remove the second full declaration scan used only for metadata cardinality validation

## Evidence
- 12 matched fresh-process Lattice -O3 -j1 pairs against the pre-optimization release control
- exact compiler work counters and emitted output in every pair
- median total delta: -4.0 ms versus the pre-#2536 control
- focused local semantic materialization tests pass
- no changes to fact order, metadata validation, or emitted AIR