### PR TITLE
Pre-size CFG prerequisite vectors

### DIFF
--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -1257,8 +1257,10 @@ fn materialize_and_build_cfg(
     // whose keys the pool also carries). Collect into vectors and normalize
     // once; the sort matches the ordered-set iteration this replaced, so the
     // batch request order is unchanged.
-    let mut layout_dependencies: Vec<crate::TypeInstanceKey> = Vec::new();
-    let mut drop_dependencies: Vec<crate::TypeInstanceKey> = Vec::new();
+    let stable_type_count = domains.stable_type_count();
+    let mut layout_dependencies: Vec<crate::TypeInstanceKey> =
+        Vec::with_capacity(stable_type_count);
+    let mut drop_dependencies: Vec<crate::TypeInstanceKey> = Vec::with_capacity(stable_type_count);
     let mut stable_types_scanned = 0_u64;
     for ty in domains.stable_types() {
         stable_types_scanned = stable_types_scanned.saturating_add(1);

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -726,6 +726,10 @@ impl CfgDomainProjection {
         self.types.iter().map(|(_, stable)| stable)
     }
 
+    pub(crate) fn stable_type_count(&self) -> usize {
+        self.types.len()
+    }
+
     /// Return the stable callable identities of the source-language calls that
     /// actually survived AIR lowering into this CFG. The durable symbol domain
     /// is deliberately broader: it also closes over compile-time constructors


### PR DESCRIPTION
## Summary

Pre-size the CFG layout and drop-glue prerequisite vectors from the domain's stable-type count before collecting dependencies.

This preserves the existing dependency ordering, sorting, deduplication, query keys, and semantic behavior while avoiding repeated vector growth in every CFG body.

## Validation

- `//crates/rue-compiler:rue-compiler-test`: 901 passed, 0 failed, 6 ignored
- 24-run interleaved fresh-process Lattice benchmark, `-j1 -O3`: total median 551.120 ms -> 546.148 ms; CFG phase median 151.206 ms -> 149.394 ms
- Exact compiled Lattice executable matched byte-for-byte against the baseline
- `git diff --check` passed
