### PR TITLE
Pre-size local semantic materialization vectors

### DIFF
--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -1005,7 +1005,8 @@ pub(crate) fn materialize_semantic_body_with_indexes(
     if indexes.has_duplicate_nominal_metadata {
         return Err(LocalMaterializationFailure::DuplicateNominalMetadata);
     }
-    let mut nominals = Vec::new();
+    let mut nominals =
+        Vec::with_capacity(declarations.len() + anonymous_nominals.len() + builtin_facts.len());
     let mut named_nominal_count = 0;
     for declaration in declarations {
         let (kind, shape) = match &declaration.payload {
@@ -1586,7 +1587,9 @@ pub(crate) fn select_materialization_facts(
         seen_opaque_types: AHashSet::new(),
     };
     selection.callable(identity);
-    let mut required_types = Vec::new();
+    let mut required_types = Vec::with_capacity(
+        1 + body.instructions.len() + body.places.len() + body.param_drops.len(),
+    );
     let mut seen_required_types = AHashSet::new();
     let mut require_type = |ty: &crate::durable_semantics::DurableType| {
         if seen_required_types.insert(ty.clone()) {


### PR DESCRIPTION
## Summary

- pre-size local semantic materialization's nominal and required-type vectors from their exact structural inputs
- preserve fact ordering, local identity construction, query keys, and emitted output

## Validation

- `./buck2 test //crates/rue-compiler:rue-compiler-test` — 901 passed, 0 failed, 6 ignored
- `./buck2 test //crates/rue-compiler:rue-compiler-fmt-check`
- `git diff --check`
- exact emitted-output comparison passed
- 24-run interleaved fresh-process Lattice benchmark, `-j1 -O3`: total median 586.322 ms -> 580.670 ms; semantic materialization critical-path median improved in the paired comparison

This is an architecture-preserving allocation reduction. The benchmark comparison was run against merged trunk after PR #2539.
