### PR TITLE
Use hash lookup for canonical anonymous nominals

### DIFF
--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -21422,8 +21422,10 @@ const LOOKUP_NAME_CACHE_HASHER: RandomState = RandomState::with_seeds(4, 5, 6, 7
 
 #[derive(Default)]
 struct CanonicalAnonymousNominalRegistry {
+    // This registry is queried only by canonical identity; its entries are
+    // never iterated, so map order cannot affect the durable projection.
     by_identity:
-        BTreeMap<crate::AnonymousNominalKey, Rc<crate::durable_semantics::DurableAnonymousNominal>>,
+        AHashMap<crate::AnonymousNominalKey, Rc<crate::durable_semantics::DurableAnonymousNominal>>,
 }
 
 impl CanonicalAnonymousNominalRegistry {
@@ -21434,10 +21436,10 @@ impl CanonicalAnonymousNominalRegistry {
         for nominal in nominals {
             let identity = nominal.identity.with_canonical_producer().into_owned();
             match self.by_identity.entry(identity) {
-                std::collections::btree_map::Entry::Vacant(entry) => {
+                std::collections::hash_map::Entry::Vacant(entry) => {
                     entry.insert(Rc::new(nominal));
                 }
-                std::collections::btree_map::Entry::Occupied(mut entry) => {
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
                     // A declaration projection may carry only the anonymous
                     // shape while a later producer-body fact carries methods.
                     // Never replace that richer authority with a thin repeat;


### PR DESCRIPTION
## Summary

- use a hash lookup for the canonical-anonymous nominal registry
- preserve canonical identity keys, richer-shape replacement, and exact durable projections; the registry is lookup-only and never iterated

## Validation

- `./buck2 test //crates/rue-compiler:rue-compiler-test` — 901 passed, 0 failed, 6 ignored
- `./buck2 test //crates/rue-compiler:rue-compiler-differential-oracle-test` — 4 passed, 0 failed
- `./buck2 test //crates/rue-compiler:rue-compiler-fmt-check`
- `git diff --check`
- exact emitted-output comparison passed
- two independent 24-run interleaved fresh-process Lattice comparisons, `-j1 -O3`: paired total median deltas of -9.93 ms and -11.52 ms; 17/24 and 15/24 candidate runs faster

The baseline was the merged trunk containing PR #2540. Both binaries produced the same emitted-output SHA-256.
