### PR TITLE
Pre-size anonymous provider endpoint maps

### DIFF
--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -2802,6 +2802,10 @@ where
         if methods.is_empty() {
             return Some(());
         }
+        self.anonymous_function_identities
+            .borrow_mut()
+            .reserve(methods.len());
+        self.anonymous_methods.borrow_mut().reserve(methods.len());
         let owner_name = self.member_callable_owner(struct_id);
         let owner_symbol = self.member_callable_owner_symbol(&owner_name);
         for method in methods {


### PR DESCRIPTION
## Summary
- reserve request-local anonymous callable and method maps before installing a durable method set
- preserve exact identity resolution, method ordering, and emitted artifacts

## Validation
- Buck2 formatter check: passed
- differential oracle: 4 passed, 0 failed
- full compiler suite: 901 passed, 0 failed, 6 ignored
- 48 baseline/candidate output digests matched: bc0a5802ef1b7eda31ad5fbba7d61a17d1b3d97679e84c59de3537c644b4d090

## Benchmark
Fresh-process, one-worker, -O3 Lattice compilation, interleaved against clean merged trunk:
- batch 1: total median 597.71 ms -> 592.25 ms (-5.45 ms), paired median -15.25 ms, 16/24 faster
- batch 2: total median 587.41 ms -> 588.91 ms (+1.50 ms), paired median -0.37 ms, 12/24 faster
- batch 3: total median 680.32 ms -> 648.77 ms (-31.55 ms), paired median -13.69 ms, 17/24 faster

The targeted semantic phases improved consistently across all three batches; output remained byte-identical.