### PR TITLE
RUE-1589: Account only inline scans that run

### DIFF
--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -2492,6 +2492,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             inline_ctor_head_candidates_with_work(self.body_rir_ref(), body, attribution_enabled);
         let mut attribution = ComptimePrecomputeAttribution {
             enabled: attribution_enabled,
+            inline_scan_bodies: u64::from(attribution_enabled),
             inline_scan_pops: scan.pops,
             inline_scan_child_edges: scan.child_edges,
             inline_raw_candidates: scan.raw_candidates,
@@ -2543,6 +2544,7 @@ pub(crate) struct ComptimePrecomputeAttribution {
     pub(crate) alias_type_successes: u64,
     pub(crate) inline_scan_pops: u64,
     pub(crate) inline_scan_child_edges: u64,
+    pub(crate) inline_scan_bodies: u64,
     pub(crate) inline_raw_candidates: u64,
     pub(crate) inline_final_candidates: u64,
     pub(crate) inline_eval_attempts: u64,
@@ -2562,6 +2564,7 @@ impl ComptimePrecomputeAttribution {
         self.alias_type_successes += other.alias_type_successes;
         self.inline_scan_pops += other.inline_scan_pops;
         self.inline_scan_child_edges += other.inline_scan_child_edges;
+        self.inline_scan_bodies += other.inline_scan_bodies;
         self.inline_raw_candidates += other.inline_raw_candidates;
         self.inline_final_candidates += other.inline_final_candidates;
         self.inline_eval_attempts += other.inline_eval_attempts;

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -84,6 +84,7 @@ fn publish_provider_body_breakdown(
         precompute_alias_type_successes = precompute.alias_type_successes,
         precompute_inline_scan_pops = precompute.inline_scan_pops,
         precompute_inline_scan_child_edges = precompute.inline_scan_child_edges,
+        precompute_inline_scan_bodies = precompute.inline_scan_bodies,
         precompute_inline_raw_candidates = precompute.inline_raw_candidates,
         precompute_inline_final_candidates = precompute.inline_final_candidates,
         precompute_inline_eval_attempts = precompute.inline_eval_attempts,

--- a/crates/rue-perf-schema/src/boundary.rs
+++ b/crates/rue-perf-schema/src/boundary.rs
@@ -943,7 +943,8 @@ impl BuildBoundaryEvidence {
             || structure.precompute_inline_scan_pops
                 != structure
                     .precompute_inline_scan_child_edges
-                    .saturating_add(structure.precompute_bodies)
+                    .saturating_add(structure.precompute_inline_scan_bodies)
+            || structure.precompute_inline_scan_bodies > structure.precompute_bodies
             || structure.precompute_inline_final_candidates
                 > structure.precompute_inline_raw_candidates
             || structure.precompute_inline_eval_attempts
@@ -1124,6 +1125,7 @@ mod tests {
                     index_builds: 1,
                     precompute_bodies: 1,
                     precompute_inline_scan_pops: 1,
+                    precompute_inline_scan_bodies: 1,
                     ..crate::SemanticBodyStructureWork::default()
                 },
                 ..CompilerWork::default()
@@ -1406,6 +1408,22 @@ mod tests {
                 .unwrap_err(),
             "compiler provider-analysis attribution is incomplete"
         );
+    }
+
+    #[test]
+    fn current_producer_accepts_census_zero_inline_scan() {
+        let policy = BuildBoundaryPolicy::fresh_source_to_native_v1(WorkerSetting::One);
+        let mut census_zero = evidence();
+        add_success(&mut census_zero.critical_path.semantic_body_input_lowering);
+        add_success(&mut census_zero.critical_path.semantic_provider_analysis);
+        let structure = &mut census_zero.compiler_work.semantic_body_structure;
+        assert_eq!(structure.precompute_bodies, 1);
+        structure.precompute_inline_scan_pops = 0;
+        structure.precompute_inline_scan_child_edges = 0;
+        structure.precompute_inline_scan_bodies = 0;
+        census_zero
+            .validate_current_producer_against(&policy, "x86-64-linux")
+            .unwrap();
     }
 
     #[test]

--- a/crates/rue-perf-schema/src/scaling.rs
+++ b/crates/rue-perf-schema/src/scaling.rs
@@ -263,6 +263,8 @@ pub struct SemanticBodyStructureWork {
     pub precompute_alias_type_successes: u64,
     pub precompute_inline_scan_pops: u64,
     pub precompute_inline_scan_child_edges: u64,
+    #[serde(default)]
+    pub precompute_inline_scan_bodies: u64,
     pub precompute_inline_raw_candidates: u64,
     pub precompute_inline_final_candidates: u64,
     pub precompute_inline_eval_attempts: u64,
@@ -603,6 +605,41 @@ question = "small maintained compiler frontend"
         assert_eq!(
             decoded.semantic_body_structure,
             SemanticBodyStructureWork::default()
+        );
+    }
+
+    #[test]
+    fn older_semantic_body_structure_defaults_inline_scan_bodies() {
+        let mut structure = serde_json::to_value(SemanticBodyStructureWork {
+            precompute_inline_scan_bodies: 7,
+            ..SemanticBodyStructureWork::default()
+        })
+        .unwrap();
+        structure
+            .as_object_mut()
+            .unwrap()
+            .remove("precompute_inline_scan_bodies");
+        let decoded: SemanticBodyStructureWork = serde_json::from_value(structure).unwrap();
+        assert_eq!(decoded.precompute_inline_scan_bodies, 0);
+
+        let mut compiler = serde_json::to_value(CompilerWork {
+            semantic_body_structure: SemanticBodyStructureWork {
+                precompute_inline_scan_bodies: 7,
+                ..SemanticBodyStructureWork::default()
+            },
+            ..CompilerWork::default()
+        })
+        .unwrap();
+        compiler["semantic_body_structure"]
+            .as_object_mut()
+            .unwrap()
+            .remove("precompute_inline_scan_bodies");
+        let decoded: CompilerWork = serde_json::from_value(compiler).unwrap();
+        assert_eq!(
+            decoded
+                .semantic_body_structure
+                .precompute_inline_scan_bodies,
+            0
         );
     }
 

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1387,6 +1387,7 @@ fn benchmark_semantic_body_structure(
         precompute_inline_scan_pops: timing.counter_total("precompute_inline_scan_pops"),
         precompute_inline_scan_child_edges: timing
             .counter_total("precompute_inline_scan_child_edges"),
+        precompute_inline_scan_bodies: timing.counter_total("precompute_inline_scan_bodies"),
         precompute_inline_raw_candidates: timing.counter_total("precompute_inline_raw_candidates"),
         precompute_inline_final_candidates: timing
             .counter_total("precompute_inline_final_candidates"),

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -2825,6 +2825,7 @@ mod phase_accounting_tests {
                 inference_precompute_structural_ns = 80_u64,
                 inference_precompute_eval_provider_ns = 48_u64,
                 precompute_alias_nodes_visited = 7_u64,
+                precompute_inline_scan_bodies = 1_u64,
                 constraint_generation_ns = 256_u64,
                 unification_resolution_ns = 512_u64,
                 air_emission_validation_ns = 1024_u64,
@@ -2852,6 +2853,7 @@ mod phase_accounting_tests {
         }
         assert_eq!(data.counter_total("precompute_bodies"), 1);
         assert_eq!(data.counter_total("precompute_alias_nodes_visited"), 7);
+        assert_eq!(data.counter_total("precompute_inline_scan_bodies"), 1);
     }
 
     #[test]


### PR DESCRIPTION
Fixes RUE-1589

Summary:
- count only bodies whose inline constructor-head reachability scan actually runs
- validate pops as child edges plus scanned bodies, bounded by all precomputed bodies
- keep schema version 1 readable through an additive default and compatibility coverage
- cover the census-zero boundary regression

Validation:
- scripts/rue fmt
- scripts/rue quick
- scripts/rue premerge
- startup benchmark JSON smoke test