### PR TITLE
RUE-1295: Canonicalize anonymous enum symbols

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -2414,7 +2414,7 @@ impl TypeInternPoolInner {
         };
         // See `struct_symbol_name`: unconditional qualification, with the
         // reserved built-in enums and the registry-marked generated anonymous
-        // enums (`__anon_enum_<digest> { … }`) keeping their bare names.
+        // enums (`__anon_enum_<digest>`) keeping their bare names.
         if rue_builtins::is_reserved_enum_name(&data.def.name) || self.is_anonymous_enum(id) {
             return data.def.name.to_string();
         }

--- a/crates/rue-air/src/sema/anon_structs.rs
+++ b/crates/rue-air/src/sema/anon_structs.rs
@@ -53,14 +53,13 @@ pub(crate) fn anonymous_struct_name(digest: u128) -> String {
     format!("__anon_struct_{digest:032x}")
 }
 
-/// The one spelling of the prefix an anonymous enum's name opens with, before
-/// its variants and their rendered payloads.
+/// The one spelling of a generated anonymous enum's name.
 ///
-/// Only the prefix is a function of the digest; the rest of the name renders
-/// the variants through the minting pool, so the whole name is not shareable
-/// the way [`anonymous_struct_name`] is.
-pub(crate) fn anonymous_enum_name_prefix(digest: u128) -> String {
-    format!("__anon_enum_{digest:032x} {{ ")
+/// The digest is the complete source symbol. Variant and payload vocabulary
+/// remains in the enum definition itself rather than in its nominal spelling,
+/// so the epoch and durable producer mints can share this exact helper.
+pub(crate) fn anonymous_enum_name(digest: u128) -> String {
+    format!("__anon_enum_{digest:032x}")
 }
 
 /// The root source definition a producer-nominal key ultimately derives from,

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -2054,9 +2054,9 @@ where
     }
 
     /// Mint the producer-nominal anonymous enum. Byte-mirror of the epoch's
-    /// `find_or_create_anon_enum` naming: `__anon_enum_{digest} { A(T), B }` where
-    /// the payload types render through the same `safe_name_with_pool` the epoch
-    /// spells them with, and the name never decides identity.
+    /// `find_or_create_anon_enum` naming: `__anon_enum_{digest}`. Variant and
+    /// payload vocabulary lives in the definition, and the name never decides
+    /// identity.
     fn mint_anon_enum(
         &mut self,
         key: &AnonymousNominalKey<K, M>,
@@ -2076,25 +2076,7 @@ where
             variant_payloads.push(resolved);
         }
 
-        let mut name = super::anon_structs::anonymous_enum_name_prefix(digest);
-        for (i, vname) in variant_names.iter().enumerate() {
-            if i > 0 {
-                name.push_str(", ");
-            }
-            name.push_str(vname);
-            let payload = &variant_payloads[i];
-            if !payload.is_empty() {
-                name.push('(');
-                for (j, ty) in payload.iter().enumerate() {
-                    if j > 0 {
-                        name.push_str(", ");
-                    }
-                    name.push_str(&ty.safe_name_with_pool(Some(&self.type_pool)));
-                }
-                name.push(')');
-            }
-        }
-        name.push_str(" }");
+        let name = super::anon_structs::anonymous_enum_name(digest);
 
         let symbol = self.interner.get_or_intern(&name);
         let (id, _) = self.type_pool.register_enum(
@@ -4665,11 +4647,10 @@ mod tests {
         );
     }
 
-    /// An anonymous enum mints the `__anon_enum_{digest} { A(i32), B }` name whose
-    /// payloads render through `safe_name_with_pool`, exactly as the epoch spells
-    /// them.
+    /// An anonymous enum mints the bare `__anon_enum_{digest}` source symbol;
+    /// variants and payloads remain in the definition metadata.
     #[test]
-    fn find_or_create_anon_enum_mints_with_payload_names() {
+    fn find_or_create_anon_enum_mints_with_bare_digest_name() {
         let key = anon_key(AnonymousNominalKind::Enum, 5, 0);
         let shape = DurableAnonymousShape::Enum {
             variants: vec![
@@ -4681,11 +4662,7 @@ mod tests {
         let ty = pool.find_or_create_anon(&key).unwrap();
         let def = pool.type_pool().enum_def(ty.as_enum().unwrap());
         assert!(def.name.starts_with("__anon_enum_"));
-        assert!(
-            def.name.ends_with(" { Some(i32), None }"),
-            "enum name renders payloads: {}",
-            def.name
-        );
+        assert_eq!(def.name.len(), "__anon_enum_".len() + 32);
         assert!(!def.is_pub);
         assert_eq!(
             def.variants.iter().map(Arc::as_ref).collect::<Vec<_>>(),
@@ -4905,11 +4882,7 @@ mod tests {
         let minted = pool.find_or_create_anon(&key).unwrap();
         let def = pool.type_pool().enum_def(minted.as_enum().unwrap());
         assert!(def.name.starts_with("__anon_enum_"));
-        assert!(
-            def.name.ends_with(" { Some(i64), None }"),
-            "the trusted enum renders its payloads: {}",
-            def.name
-        );
+        assert_eq!(def.name.len(), "__anon_enum_".len() + 32);
 
         // The export-as-produced ruling: the identity is recorded as
         // well-known, so the provider baseline subtraction exports it as a

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -1153,24 +1153,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         }
         let digest = self.stable_anonymous_identity_digest(&identity);
         self.guard_anonymous_digest_collision(digest, &identity)?;
-        let mut name = super::anon_structs::anonymous_enum_name_prefix(digest);
-        for (index, variant) in names.iter().enumerate() {
-            if index > 0 {
-                name.push_str(", ");
-            }
-            name.push_str(variant);
-            if !payloads[index].is_empty() {
-                name.push('(');
-                for (payload_index, ty) in payloads[index].iter().enumerate() {
-                    if payload_index > 0 {
-                        name.push_str(", ");
-                    }
-                    name.push_str(&ty.safe_name_with_pool(Some(self.storage.body_type_pool())));
-                }
-                name.push(')');
-            }
-        }
-        name.push_str(" }");
+        let name = super::anon_structs::anonymous_enum_name(digest);
         let name_spur = self.storage.body_interner().get_or_intern(&name);
         let def = crate::types::EnumDef {
             name: Arc::from(name.as_str()),

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -37037,8 +37037,8 @@ fn main() -> i32 {
 
     // RUE-1091 r6b: the ENUM analog of the anonymous mint. The pool mints
     // through `mint_anon_enum` from the durable shape, spelling the
-    // `__anon_enum_{digest} { Variant(T), … }` payload-rendering name. The pool
-    // is fed the RAW projected identity (empty-argument specialization wrapper
+    // `__anon_enum_{digest}` bare source symbol. The pool is fed the RAW
+    // projected identity (empty-argument specialization wrapper
     // retained), so the enum path exercises entry canonicalization too.
     #[test]
     fn provider_endpoint_facts_anonymous_enum_mints_from_durable_identity() {
@@ -37084,6 +37084,13 @@ fn main() -> i32 {
         );
         // RAW identity — the wrapper collapse is the pool's entry obligation.
         let durable_identity = projection.anonymous_nominals[0].identity.clone();
+        let durable_source_symbol = projection.anonymous_nominals[0].source_symbol().clone();
+        let durable_drop_glue_symbol =
+            crate::local_semantic_materialization::rooted_callable_symbol(
+                &crate::FunctionInstanceKey::DropGlue(Box::new(crate::TypeInstanceKey::Nominal(
+                    crate::NominalInstanceKey::Anonymous(durable_identity.clone()),
+                ))),
+            );
 
         let rir = &stages.rir;
         let rir_ref = rir.rir();
@@ -37093,6 +37100,8 @@ fn main() -> i32 {
         let adapter = DurableDeclSource::from_declarations(&projection.declarations)
             .with_anonymous_nominals(&projection.anonymous_nominals);
         let identity_for_probe = durable_identity.clone();
+        let expected_source_symbol = durable_source_symbol.clone();
+        let expected_drop_glue_symbol = durable_drop_glue_symbol.clone();
 
         let outcome = database.probe_ready_body_facts(
             revision,
@@ -37137,24 +37146,39 @@ fn main() -> i32 {
                     .expect("the seeded anonymous enum arm resolves");
                 assert_eq!(via_arm, minted, "the arm and direct mint agree");
 
-                facts.with_type_pool(|pool| endpoint_nominal_render(pool, minted))
+                facts.with_type_pool(|pool| {
+                    let render = endpoint_nominal_render(pool, minted);
+                    let frozen = pool.clone().freeze();
+                    let drop_glue = rue_air::drop_glue_names::enum_drop_glue_name(
+                        minted.as_enum().expect("the minted nominal is an enum"),
+                        &frozen,
+                    );
+                    (render, drop_glue)
+                })
             },
         );
-        let pool_render = outcome.result;
+        let (pool_render, pool_drop_glue_symbol) = outcome.result;
 
-        // The full materialization is pinned: the payload-rendering
-        // `__anon_enum_{digest} { … }` name (stable digest over the durable
-        // identity), copyability, visibility, and variant vocabulary.
+        assert_eq!(
+            pool_render.symbol,
+            expected_source_symbol.as_ref(),
+            "the live pool enum symbol must equal the durable source symbol"
+        );
+        assert_eq!(
+            pool_drop_glue_symbol,
+            expected_drop_glue_symbol.as_ref(),
+            "the live enum drop glue must equal the durable DropGlue symbol"
+        );
+
+        // The full materialization is pinned: the bare `__anon_enum_{digest}`
+        // name (stable digest over the durable identity), copyability,
+        // visibility, and variant vocabulary.
         assert!(
             pool_render.display.starts_with("__anon_enum_"),
             "the pool spells the enum digest name: {}",
             pool_render.display
         );
-        assert!(
-            pool_render.display.ends_with(" { Some(i32), None }"),
-            "the pool renders variant payloads into the name: {}",
-            pool_render.display
-        );
+        assert_eq!(pool_render.display.len(), "__anon_enum_".len() + 32);
         assert_eq!(
             pool_render
                 .members
@@ -37178,7 +37202,7 @@ fn main() -> i32 {
     // real `DurableDeclSource` adapter, starting from the declaration-level
     // durable truth (the nucleus `ComptimeCall` terminals the production demand
     // loop roots). The full materializations are pinned: the digest-spelled
-    // `__anon_enum_{digest} { … }` names, copyability, visibility, and variant
+    // `__anon_enum_{digest}` names, copyability, visibility, and variant
     // vocabulary.
     //
     // The export-as-produced ruling: the pool records each installed canonical
@@ -37388,16 +37412,8 @@ fn main() -> i32 {
             assert!(!render.is_pub, "an anonymous nominal is not `pub`");
             assert!(render.is_copy, "an integer-payload Option enum is copyable");
         }
-        assert!(
-            pool_i64_render.display.ends_with(" { Some(i64), None }"),
-            "the i64 registry entry is the Option(i64) enum: {}",
-            pool_i64_render.display
-        );
-        assert!(
-            pool_u32_render.display.ends_with(" { Some(u32), None }"),
-            "the u32 registry entry is the Option(u32) enum: {}",
-            pool_u32_render.display
-        );
+        assert_eq!(pool_i64_render.display.len(), "__anon_enum_".len() + 32);
+        assert_eq!(pool_u32_render.display.len(), "__anon_enum_".len() + 32);
         let mut registry_renders = vec![pool_i64_render, pool_u32_render];
         registry_renders.sort_by(|a, b| a.display.cmp(&b.display));
         assert_eq!(


### PR DESCRIPTION
Fixes RUE-1295.

Summary:
- spell anonymous enums with the bare stable digest in both AIR minting paths
- keep variant metadata and anonymity in their explicit registries
- assert live/durable type and drop-glue symbol agreement

Validation:
- focused anonymous-enum, collision, and registry tests
- scripts/rue quick
- scripts/rue premerge (194 passed)