### PR TITLE
RUE-1590: ignore empty performance records in staleness gate

### DIFF
--- a/scripts/test-validate-performance-stall.py
+++ b/scripts/test-validate-performance-stall.py
@@ -3,8 +3,12 @@
 
 from __future__ import annotations
 
+import json
 import sys
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from gatelib import load_script
@@ -13,11 +17,15 @@ stall = load_script("validate-performance-stall.py", __file__)
 
 
 def data(*points: tuple[str, str, str]) -> dict:
-    """Build derived data from (platform, commit, finished_at) triples."""
+    """Build measured derived data from (platform, commit, finished_at) triples."""
     platforms: dict[str, list] = {}
     for platform, commit, finished_at in points:
         platforms.setdefault(platform, []).append(
-            {"commit": commit, "finished_at": finished_at}
+            {
+                "commit": commit,
+                "finished_at": finished_at,
+                "workloads": {"startup": {}},
+            }
         )
     return {
         "platforms": [
@@ -29,6 +37,22 @@ def data(*points: tuple[str, str, str]) -> dict:
 
 def fixed(count: int):
     return lambda _commit: count
+
+
+def run_main(subject: dict) -> tuple[int, str]:
+    """Run the validator's early empty-data path against a temporary file."""
+    with TemporaryDirectory() as directory:
+        path = Path(directory) / "derived.json"
+        path.write_text(json.dumps(subject))
+        original_argv = sys.argv
+        sys.argv = ["validate-performance-stall.py", "--data", str(path)]
+        output = StringIO()
+        try:
+            with redirect_stdout(output), redirect_stderr(output):
+                result = stall.main()
+        finally:
+            sys.argv = original_argv
+        return result, output.getvalue()
 
 
 def test_a_current_series_is_not_stalled() -> None:
@@ -79,6 +103,89 @@ def test_an_empty_dashboard_is_not_a_stall() -> None:
     assert stall.stalled({"platforms": []}, fixed(1000)) == []
 
 
+def test_a_genuinely_empty_dashboard_passes_main() -> None:
+    result, output = run_main({"platforms": []})
+    assert result == 0
+    assert "nothing to stall" in output
+
+
+def test_published_all_empty_points_alarm_instead_of_passing_main() -> None:
+    subject = {
+        "platforms": [
+            {
+                "platform": "x86_64-linux",
+                "epochs": [
+                    {
+                        "epoch": 3,
+                        "points": [
+                            {
+                                "commit": "a" * 40,
+                                "finished_at": "2026-08-08T00:00:00Z",
+                                "workloads": {},
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    assert stall.newest_plotted(subject) == []
+    assert stall.unmeasured_platforms(subject) == [("x86_64-linux", 3, 1)]
+    result, output = run_main(subject)
+    assert result == 1
+    assert "contain no measurements" in output
+    assert "not the honest empty-dashboard state" in output
+
+
+def test_a_healthy_platform_cannot_mask_an_all_empty_platform() -> None:
+    subject = {
+        "platforms": [
+            {
+                "platform": "x86_64-linux",
+                "epochs": [
+                    {
+                        "epoch": 3,
+                        "points": [
+                            {
+                                "commit": "a" * 40,
+                                "finished_at": "2026-08-08T00:00:00Z",
+                                "workloads": {"startup": {}},
+                            }
+                        ],
+                    }
+                ],
+            },
+            {
+                "platform": "aarch64-macos",
+                "epochs": [
+                    {
+                        "epoch": 3,
+                        "points": [
+                            {
+                                "commit": "b" * 40,
+                                "finished_at": "2026-08-08T00:00:00Z",
+                                "workloads": {},
+                            },
+                            {
+                                "commit": "c" * 40,
+                                "finished_at": "2026-08-08T01:00:00Z",
+                                "workloads": {},
+                            },
+                        ],
+                    }
+                ],
+            },
+            {"platform": "aarch64-linux", "epochs": [{"epoch": 3, "points": []}]},
+        ]
+    }
+    assert stall.unmeasured_platforms(subject) == [("aarch64-macos", 3, 2)]
+    result, output = run_main(subject)
+    assert result == 1
+    assert "aarch64-macos" in output
+    assert "x86_64-linux" not in output
+    assert "aarch64-linux" not in output
+
+
 def test_the_newest_point_wins_regardless_of_ordering() -> None:
     subject = {
         "platforms": [
@@ -88,8 +195,16 @@ def test_the_newest_point_wins_regardless_of_ordering() -> None:
                     {
                         "epoch": 2,
                         "points": [
-                            {"commit": "b" * 40, "finished_at": "2026-08-08T05:00:00Z"},
-                            {"commit": "a" * 40, "finished_at": "2026-08-08T01:00:00Z"},
+                            {
+                                "commit": "b" * 40,
+                                "finished_at": "2026-08-08T05:00:00Z",
+                                "workloads": {"startup": {}},
+                            },
+                            {
+                                "commit": "a" * 40,
+                                "finished_at": "2026-08-08T01:00:00Z",
+                                "workloads": {"startup": {}},
+                            },
                         ],
                     }
                 ],
@@ -110,13 +225,21 @@ def test_the_newest_point_spans_epochs() -> None:
                     {
                         "epoch": 2,
                         "points": [
-                            {"commit": "a" * 40, "finished_at": "2026-08-01T00:00:00Z"}
+                            {
+                                "commit": "a" * 40,
+                                "finished_at": "2026-08-01T00:00:00Z",
+                                "workloads": {"startup": {}},
+                            }
                         ],
                     },
                     {
                         "epoch": 3,
                         "points": [
-                            {"commit": "c" * 40, "finished_at": "2026-08-08T00:00:00Z"}
+                            {
+                                "commit": "c" * 40,
+                                "finished_at": "2026-08-08T00:00:00Z",
+                                "workloads": {"startup": {}},
+                            }
                         ],
                     },
                 ],
@@ -124,6 +247,129 @@ def test_the_newest_point_spans_epochs() -> None:
         ]
     }
     assert stall.newest_plotted(subject)[0][1] == "c" * 40
+
+
+def test_empty_points_do_not_advance_the_series_or_reset_grace() -> None:
+    # Failed records advance collection time but have no valid workload. The
+    # older measurement remains the staleness input, including its age.
+    old = "a" * 40
+    failures = ["b" * 40, "c" * 40, "d" * 40]
+    subject = {
+        "platforms": [
+            {
+                "platform": "x86_64-linux",
+                "epochs": [
+                    {
+                        "epoch": 2,
+                        "points": [
+                            {
+                                "commit": old,
+                                "finished_at": "2026-08-08T00:00:00Z",
+                                "workloads": {"startup": {}},
+                            },
+                            {
+                                "commit": failures[0],
+                                "finished_at": "2026-08-08T01:00:00Z",
+                                "workloads": {},
+                            },
+                            {
+                                "commit": failures[1],
+                                "finished_at": "2026-08-08T02:00:00Z",
+                                "workloads": {},
+                            },
+                            {
+                                "commit": failures[2],
+                                "finished_at": "2026-08-08T03:00:00Z",
+                                "workloads": {},
+                            },
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    assert stall.newest_plotted(subject)[0][1] == old
+    assert stall.unmeasured_platforms(subject) == []
+    assert stall.stalled(
+        subject, lambda commit: 6, commit_age=lambda commit: 3 * 60 * 60
+    ) == [("x86_64-linux", old, 6)]
+    assert stall.stalled(subject, lambda commit: 6, commit_age=lambda commit: 60) == []
+
+
+def test_a_partial_point_with_a_workload_remains_current() -> None:
+    # Partial runs have no headline index, but their valid workloads are real
+    # measurements and must retain the prior newest-point behavior.
+    partial = "b" * 40
+    subject = {
+        "platforms": [
+            {
+                "platform": "x86_64-linux",
+                "epochs": [
+                    {
+                        "epoch": 2,
+                        "points": [
+                            {
+                                "commit": "a" * 40,
+                                "finished_at": "2026-08-08T00:00:00Z",
+                                "index": {"latency": 1.0},
+                                "workloads": {"startup": {}},
+                            },
+                            {
+                                "commit": partial,
+                                "finished_at": "2026-08-08T01:00:00Z",
+                                "complete": False,
+                                "index": None,
+                                "workloads": {"startup": {}},
+                            },
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    assert stall.newest_plotted(subject)[0][1] == partial
+
+
+def test_empty_points_in_a_new_epoch_do_not_hide_an_older_measurement() -> None:
+    # This is the validator's cross-epoch behavior when both epochs are in the
+    # derived input: an empty newer epoch is not a live performance series.
+    old = "a" * 40
+    subject = {
+        "platforms": [
+            {
+                "platform": "x86_64-linux",
+                "epochs": [
+                    {
+                        "epoch": 2,
+                        "baseline_commit": "a" * 40,
+                        "points": [
+                            {
+                                "commit": old,
+                                "finished_at": "2026-08-01T00:00:00Z",
+                                "index": {"latency": 1.0},
+                                "workloads": {"startup": {}},
+                            }
+                        ],
+                    },
+                    {
+                        "epoch": 3,
+                        "baseline_commit": None,
+                        "points": [
+                            {
+                                "commit": "b" * 40,
+                                "finished_at": "2026-08-08T00:00:00Z",
+                                "workloads": {},
+                            }
+                        ],
+                    },
+                ],
+            }
+        ]
+    }
+    assert stall.newest_plotted(subject)[0][1] == old
+    assert stall.unmeasured_platforms(subject) == []
+    assert stall.newest_epochs(subject)[0][1]["epoch"] == 2
+    assert stall.unindexed(subject) == []
 
 
 def indexed_epoch(
@@ -146,6 +392,7 @@ def indexed_epoch(
                                 "commit": "a" * 40,
                                 "finished_at": f"2026-08-0{i + 1}T00:00:00Z",
                                 "index": None if value is None else {"latency": value},
+                                "workloads": {"startup": {}},
                             }
                             for i, value in enumerate(indexes)
                         ],
@@ -190,6 +437,7 @@ def test_a_retired_epoch_is_not_held_to_publishing_an_index() -> None:
                                 "commit": "a" * 40,
                                 "finished_at": "2026-08-01T00:00:00Z",
                                 "index": None,
+                                "workloads": {"startup": {}},
                             }
                         ],
                     },
@@ -201,6 +449,7 @@ def test_a_retired_epoch_is_not_held_to_publishing_an_index() -> None:
                                 "commit": "d" * 40,
                                 "finished_at": "2026-08-08T00:00:00Z",
                                 "index": {"latency": 1.0},
+                                "workloads": {"startup": {}},
                             }
                         ],
                     },
@@ -243,6 +492,7 @@ def collecting_epoch(
                                 "complete": complete,
                                 "finished_at": f"2026-08-15T00:{i:02d}:00Z",
                                 "index": None,
+                                "workloads": {"startup": {}},
                             }
                             for i, (commit, complete) in enumerate(points)
                         ],
@@ -271,6 +521,19 @@ def test_the_deadline_is_counted_in_points_not_trunk_commits() -> None:
         collecting_epoch(6, None, [("a" * 40, True)] * 11), max_points=10
     )
     assert late and late[0][4] == 11
+
+
+def test_empty_points_do_not_count_toward_the_unpinned_deadline() -> None:
+    # Collection failures are not complete measurements and cannot satisfy an
+    # epoch's baseline deadline merely by accumulating in its point list.
+    subject = collecting_epoch(
+        6,
+        None,
+        [("a" * 40, True)] + [(chr(98 + i) * 40, True) for i in range(11)],
+    )
+    for point in subject["platforms"][0]["epochs"][0]["points"][1:]:
+        point["workloads"] = {}
+    assert stall.unpinned(subject) == []
 
 
 def test_an_epoch_that_never_pins_its_baseline_is_a_failure() -> None:
@@ -326,6 +589,7 @@ def test_a_retired_unpinned_epoch_does_not_block_the_repository() -> None:
                                 "complete": True,
                                 "finished_at": "2026-08-01T00:00:00Z",
                                 "index": None,
+                                "workloads": {"startup": {}},
                             }
                         ],
                     },
@@ -339,6 +603,7 @@ def test_a_retired_unpinned_epoch_does_not_block_the_repository() -> None:
                                 "complete": True,
                                 "finished_at": "2026-08-08T00:00:00Z",
                                 "index": {"latency": 1.0},
+                                "workloads": {"startup": {}},
                             }
                         ],
                     },

--- a/scripts/validate-performance-stall.py
+++ b/scripts/validate-performance-stall.py
@@ -84,18 +84,58 @@ class HistoryUnavailable(Exception):
     """A measured commit is not present in the checkout's history."""
 
 
-def newest_plotted(data: dict) -> list[tuple[str, str, str]]:
-    """Return (platform, commit, finished_at) for each platform's newest point.
+def is_measurement(point: dict) -> bool:
+    """Whether a derived point contains at least one valid workload.
 
-    Points are ordered by measurement time within an epoch, and epochs are
-    ordered by identifier, so the newest point is the last point of the last
-    epoch that has any.
+    `derive` keeps a point for every accepted run so failures remain visible,
+    but leaves `workloads` empty when no valid sample survived.  Such a point
+    is useful collection-health evidence, not a current performance
+    measurement.  Partial runs still have one or more workload entries and
+    therefore remain measurements for staleness purposes.
+    """
+    return bool(point.get("workloads"))
+
+
+def unmeasured_platforms(data: dict) -> list[tuple[str, int, int]]:
+    """Return (platform, epoch, points) groups for all-unmeasured platforms.
+
+    This deliberately counts points before applying :func:`is_measurement`.
+    The distinction lets the gate tolerate a genuinely empty dashboard while
+    reporting a platform whose data branch contains only accepted records whose
+    samples all failed validation. A platform with at least one measurement
+    is omitted, even if it has newer empty records.
+    """
+    unmeasured = []
+    for platform in data.get("platforms", []):
+        groups = []
+        measured = False
+        for epoch in platform.get("epochs", []):
+            points = epoch.get("points", [])
+            if points:
+                groups.append(
+                    (platform["platform"], epoch.get("epoch"), len(points))
+                )
+                measured = measured or any(is_measurement(point) for point in points)
+        if groups and not measured:
+            unmeasured.extend(groups)
+    return unmeasured
+
+
+def newest_plotted(data: dict) -> list[tuple[str, str, str]]:
+    """Return (platform, commit, finished_at) for each platform's newest
+    measurement.
+
+    Empty points record collection failures but do not advance the published
+    performance series. Partial points are measurements because they retain
+    at least one valid workload and remain eligible here.
     """
     newest = []
     for platform in data.get("platforms", []):
         latest = None
         for epoch in platform.get("epochs", []):
             for point in epoch.get("points", []):
+                if not is_measurement(point):
+                    continue
                 if latest is None or point["finished_at"] > latest["finished_at"]:
                     latest = point
         if latest is not None:
@@ -104,16 +144,19 @@ def newest_plotted(data: dict) -> list[tuple[str, str, str]]:
 
 
 def newest_epochs(data: dict) -> list[tuple[str, dict]]:
-    """Return each platform's live epoch: the one holding its newest point.
+    """Return each platform's live epoch: the one holding its newest measurement.
 
     A retired epoch keeps whatever it published and is not the signal anyone
-    reads, so only the epoch still receiving points is held to publishing one.
+    reads, so only the epoch still receiving measurements is held to publishing
+    one. Empty points do not move a platform into a newer epoch.
     """
     live = []
     for platform in data.get("platforms", []):
         newest = None
         for epoch in platform.get("epochs", []):
             for point in epoch.get("points", []):
+                if not is_measurement(point):
+                    continue
                 if newest is None or point["finished_at"] > newest[0]:
                     newest = (point["finished_at"], epoch)
         if newest is not None:
@@ -135,7 +178,7 @@ def unindexed(data: dict) -> list[tuple[str, int, int]]:
     for platform, epoch in newest_epochs(data):
         if not epoch.get("baseline_commit"):
             continue
-        points = epoch.get("points", [])
+        points = [point for point in epoch.get("points", []) if is_measurement(point)]
         if points and not any(point.get("index") for point in points):
             missing.append((platform, epoch.get("epoch"), len(points)))
     return missing
@@ -170,7 +213,11 @@ def unpinned(
         if epoch.get("baseline_commit"):
             continue
         complete = sorted(
-            (point for point in epoch.get("points", []) if point.get("complete")),
+            (
+                point
+                for point in epoch.get("points", [])
+                if is_measurement(point) and point.get("complete")
+            ),
             key=lambda point: point["finished_at"],
         )
         if not complete:
@@ -317,6 +364,30 @@ def report_unindexed(missing: list[tuple[str, int, int]]) -> str:
     return "\n".join(lines)
 
 
+def report_unmeasured(published: list[tuple[str, int, int]]) -> str:
+    """Explain why published records with no measurements block the gate."""
+    lines = [
+        "The published performance records contain no measurements.",
+        "",
+    ]
+    for platform, epoch, points in published:
+        lines.append(
+            f"  {platform}: epoch {epoch} has {points} published point(s), "
+            "but none has a valid workload measurement"
+        )
+    lines += [
+        "",
+        "Records are present, so this is not the honest empty-dashboard state.",
+        "Every accepted run in the selected data has zero valid workloads, so",
+        "there is no measured commit whose age could make this gate pass.",
+        "",
+        "Check the collection-health failures and restore at least one valid",
+        "workload measurement. Once an older measurement is present, failed",
+        "records do not advance the series and the ordinary grace rule applies.",
+    ]
+    return "\n".join(lines)
+
+
 def report_unpinned(late: list[tuple[str, int, str, str, int]], max_points: int) -> str:
     lines = [
         "A collecting epoch has never pinned its baseline, so no index is published.",
@@ -381,6 +452,11 @@ def main() -> int:
     args = parser.parse_args()
 
     data = json.loads(args.data.read_text())
+
+    unmeasured = unmeasured_platforms(data)
+    if unmeasured:
+        print(report_unmeasured(unmeasured), file=sys.stderr)
+        return 1
 
     plotted = newest_plotted(data)
     if not plotted:


### PR DESCRIPTION
## Summary

- treat a derived point as current only when it contains at least one valid workload measurement
- alarm on all-empty published platform data while preserving the honest empty-dashboard state
- cover advancing empty records, partial records, grace behavior, epoch selection, and mixed-platform failure

## Validation

- `./buck2 test //:performance-stall-validator-tool-tests`
- `scripts/rue quick`
- `scripts/rue premerge`

Fixes RUE-1590