### PR TITLE
RUE-1585: Bound Valgrind installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1303,9 +1303,7 @@ jobs:
 
       - name: Install valgrind
         if: steps.sel.outputs.run == 'true'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y valgrind
+        run: scripts/install-valgrind
 
       - name: Build Rue compiler
         if: steps.sel.outputs.run == 'true'

--- a/BUCK
+++ b/BUCK
@@ -1173,6 +1173,9 @@ rue_sh_test(
     ],
     resources = [
         "scripts/ci-required-results.py",
+        # The gate pins the bounded apt timeout/retry/lock policy as well as
+        # the workflow wiring, so installer-only edits must invalidate it.
+        "scripts/install-valgrind",
         "scripts/run-native-platform-corpus.sh",
         # RUE-1265: NATIVE_CLI_FILTERS is imported from here, so the two gates
         # cannot disagree about which `scripts/rue cli` steps the native lanes
@@ -1252,6 +1255,7 @@ rue_sh_test(
         "scripts/ci-required-results.py",
         "scripts/run-native-platform-corpus.sh",
         "scripts/validate-ci-gate.py",
+        "scripts/install-valgrind",
         "scripts/validate-test-duplication.py",
     ] + [":gatelib-sources"],
     env = {
@@ -1259,6 +1263,15 @@ rue_sh_test(
         "RUE_CI_WORKFLOW": "$(location :required-ci-workflows)/.github/workflows/ci.yml",
         "RUE_TEST_RUNNER_SOURCE": "$(location //crates/rue-test-runner:platform-responsibility-source)/src/lib.rs",
         "RUE_ROOT_BUCK": "$(location :root-buck-file)/BUCK",
+    },
+)
+
+rue_sh_test(
+    name = "valgrind-installer-tool-tests",
+    test = "scripts/test-install-valgrind.py",
+    resources = ["scripts/install-valgrind"],
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
     },
 )
 

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -279,6 +279,17 @@ explicit jobs inside the CI aggregate: Valgrind provisions an external runtime
 tool, while ASan requires a pinned nightly Cargo toolchain that Buck does not
 model.
 
+The Valgrind job installs its required runtime through
+`scripts/install-valgrind`, not an inline `apt-get` block. Each of `apt-get
+update` and `apt-get install` has a 10-minute total bound, 30-second HTTP and
+HTTPS acquisition bounds, two apt-native retries, and a 60-second dpkg lock
+wait. GNU `timeout` kills the operation's process group after a 30-second grace
+period; cancellation cleanup also reaches the timeout process itself, so apt
+and dpkg descendants cannot outlive the step. A timeout remains exit 124 and
+other nonzero statuses (including 137) are surfaced unchanged. The CI contract
+validator pins this wiring and policy so a future workflow edit cannot restore
+an unbounded mirror wait or silently change the retry/lock budget.
+
 `./buck2 bxl //test_tiers.bxl:validate` queries Buck's live first-party test
 graph and fails unless every target has exactly one tier. Required formatting
 CI runs that validation, so adding a raw test rule or conflicting tier label
@@ -604,7 +615,8 @@ The selection is **conservative and fail-open** — under-selection silently
 drops coverage (the RUE-924 failure mode), so every uncertain path runs the
 whole corpus. `scripts/affected-targets` forces a full run whenever the diff
 touches an out-of-graph or graph-global input — the `./buck2` pin, `test.sh`,
-any `scripts/ci-*` runner, the selection engine itself, the workflow files, or
+any `scripts/ci-*` runner, the Valgrind installer, the selection engine itself,
+the workflow files, or
 `.buckconfig`/`BUCK`/`*.bzl`/`toolchains`/`platforms`/`prelude`/`rust-toolchain.toml`
 — and it falls back to full on any VCS, provisioning, `buck2`, `btd`, or output
 parsing error.

--- a/scripts/affected-targets
+++ b/scripts/affected-targets
@@ -162,7 +162,7 @@ is_selectable_lane() {
 
 # Out-of-graph (and belt-and-suspenders in-graph) paths that force a full run.
 # Anchored, repo-root-relative, extended-regex alternation.
-FORCE_FULL_REGEX='^crates/rue-runtime-asan/|(^|/)BUCK$|\.bzl$|^\.buckconfig|^\.buckroot$|^\.github/workflows/|^toolchains/|^platforms/|^constraints/|^third-party/|^prelude/|^rust-toolchain\.toml$|^buck2$|^buck2-bin$|^reindeer$|^btd$|^test\.sh$|^scripts/ci-|^scripts/affected-targets$|^scripts/provision-build-cache$|^scripts/with-full-suite-lock$|^scripts/rue$|^scripts/rue-bin$'
+FORCE_FULL_REGEX='^crates/rue-runtime-asan/|(^|/)BUCK$|\.bzl$|^\.buckconfig|^\.buckroot$|^\.github/workflows/|^toolchains/|^platforms/|^constraints/|^third-party/|^prelude/|^rust-toolchain\.toml$|^buck2$|^buck2-bin$|^reindeer$|^btd$|^test\.sh$|^scripts/ci-|^scripts/affected-targets$|^scripts/install-valgrind$|^scripts/provision-build-cache$|^scripts/with-full-suite-lock$|^scripts/rue$|^scripts/rue-bin$'
 
 # buck2 targets invocation BTD's own `targets` wrapper uses (td_util buck::run
 # targets_arguments). Both dumps use the identical command so their unconfigured

--- a/scripts/install-valgrind
+++ b/scripts/install-valgrind
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Install Valgrind for required CI with bounded package-manager operations.
+#
+# Ubuntu's package mirrors have occasionally stopped making progress while apt
+# is downloading an index or package.  apt's per-acquisition timeout and retry
+# policy handles transient failures; GNU timeout supplies the outer bound and
+# process-group cleanup so one wedged operation cannot consume the whole job.
+set -euo pipefail
+
+APT_OPERATION_TIMEOUT_SECONDS=600
+APT_KILL_AFTER_SECONDS=30
+APT_ACQUIRE_TIMEOUT_SECONDS=30
+APT_RETRIES=2
+APT_LOCK_TIMEOUT_SECONDS=60
+
+child_pid=""
+
+terminate_children() {
+    if [[ -n "$child_pid" ]]; then
+        # GNU timeout starts the operation in its own process group.  Killing
+        # that group also reaches sudo and apt/dpkg descendants if the runner
+        # cancels this step while an operation is active.
+        kill -TERM -- "-$child_pid" >/dev/null 2>&1 || true
+        kill -TERM "$child_pid" >/dev/null 2>&1 || true
+        sleep 1
+        kill -KILL -- "-$child_pid" >/dev/null 2>&1 || true
+        kill -KILL "$child_pid" >/dev/null 2>&1 || true
+        child_pid=""
+    fi
+}
+
+on_signal() {
+    terminate_children
+    exit 143
+}
+
+trap terminate_children EXIT
+trap on_signal INT TERM
+
+run_apt() {
+    local operation="$1"
+    shift
+
+    # Do not use an outer retry loop: Acquire::Retries is the one retry policy
+    # for both operations, so a failure cannot multiply its retry budget.
+    timeout \
+        --kill-after="${APT_KILL_AFTER_SECONDS}s" \
+        --signal=TERM \
+        "${APT_OPERATION_TIMEOUT_SECONDS}s" \
+        sudo -n apt-get \
+        -o "DPkg::Lock::Timeout=${APT_LOCK_TIMEOUT_SECONDS}" \
+        -o "Acquire::Retries=${APT_RETRIES}" \
+        -o "Acquire::http::Timeout=${APT_ACQUIRE_TIMEOUT_SECONDS}" \
+        -o "Acquire::https::Timeout=${APT_ACQUIRE_TIMEOUT_SECONDS}" \
+        "$@" &
+    child_pid=$!
+    local status=0
+    wait "$child_pid" || status=$?
+    child_pid=""
+
+    case "$status" in
+        0)
+            return 0
+            ;;
+        124)
+            echo "install-valgrind: apt-get ${operation} timed out after ${APT_OPERATION_TIMEOUT_SECONDS}s" >&2
+            return 124
+            ;;
+        *)
+            echo "install-valgrind: apt-get ${operation} failed (exit ${status})" >&2
+            return "$status"
+            ;;
+    esac
+}
+
+echo "install-valgrind: updating package indexes (bounded to ${APT_OPERATION_TIMEOUT_SECONDS}s)" >&2
+run_apt update update
+
+echo "install-valgrind: installing valgrind (bounded to ${APT_OPERATION_TIMEOUT_SECONDS}s)" >&2
+run_apt install install --no-install-recommends -y valgrind

--- a/scripts/test-affected-targets.sh
+++ b/scripts/test-affected-targets.sh
@@ -78,6 +78,7 @@ expect_full "scripts/ci-corpus-selected"
 expect_full "scripts/affected-targets"
 expect_full "btd"
 expect_full "scripts/provision-build-cache"
+expect_full "scripts/install-valgrind"
 expect_full "scripts/rue"
 expect_full "scripts/rue-bin"
 

--- a/scripts/test-install-valgrind.py
+++ b/scripts/test-install-valgrind.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Exercise the bounded Valgrind installer with fake package commands."""
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("install-valgrind")
+
+
+class InstallerTests(unittest.TestCase):
+    def run_installer(self, apt_status=0, timeout_status=None):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            (fake_bin / "sudo").write_text(
+                "#!/bin/sh\n"
+                "if [ \"$1\" = -n ]; then shift; fi\n"
+                "exec \"$@\"\n"
+            )
+            (fake_bin / "apt-get").write_text(
+                "#!/bin/sh\n"
+                "printf '%s\\n' \"$@\" >>\"$FAKE_APT_ARGS\"\n"
+                f"exit {apt_status}\n"
+            )
+            if timeout_status is None:
+                (fake_bin / "timeout").write_text(
+                    "#!/bin/sh\n"
+                    "printf '%s\\n' \"$@\" >\"$FAKE_TIMEOUT_ARGS\"\n"
+                    "while [ \"$1\" != \"sudo\" ]; do shift; done\n"
+                    "exec \"$@\"\n"
+                )
+            else:
+                (fake_bin / "timeout").write_text(
+                    "#!/bin/sh\n"
+                    f"exit {timeout_status}\n"
+                )
+            for command in fake_bin.iterdir():
+                command.chmod(0o755)
+
+            env = os.environ.copy()
+            env["PATH"] = os.pathsep.join([str(fake_bin), "/usr/bin", "/bin"])
+            env["FAKE_APT_ARGS"] = str(root / "apt-args")
+            env["FAKE_TIMEOUT_ARGS"] = str(root / "timeout-args")
+            result = subprocess.run(
+                [str(SCRIPT)], capture_output=True, text=True, env=env, check=False
+            )
+            apt_args = (
+                (root / "apt-args").read_text().splitlines()
+                if (root / "apt-args").exists()
+                else []
+            )
+            timeout_args = (
+                (root / "timeout-args").read_text().splitlines()
+                if (root / "timeout-args").exists()
+                else []
+            )
+            return result, apt_args, timeout_args
+
+    def test_success_runs_bounded_update_then_install(self):
+        result, apt_args, timeout_args = self.run_installer()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(apt_args.count("update"), 1)
+        self.assertEqual(apt_args.count("install"), 1)
+        self.assertIn("--no-install-recommends", apt_args)
+        self.assertIn("valgrind", apt_args)
+        self.assertIn("DPkg::Lock::Timeout=60", apt_args)
+        self.assertIn("Acquire::Retries=2", apt_args)
+        self.assertIn("Acquire::http::Timeout=30", apt_args)
+        self.assertIn("Acquire::https::Timeout=30", apt_args)
+        self.assertIn('--kill-after=30s', timeout_args)
+        self.assertIn('--signal=TERM', timeout_args)
+        self.assertIn('600s', timeout_args)
+
+    def test_non_timeout_apt_failure_is_preserved(self):
+        result, _, _ = self.run_installer(apt_status=37)
+        self.assertEqual(result.returncode, 37)
+        self.assertIn("apt-get update failed (exit 37)", result.stderr)
+
+    def test_timeout_is_124_and_explained(self):
+        result, _, _ = self.run_installer(timeout_status=124)
+        self.assertEqual(result.returncode, 124)
+        self.assertIn("apt-get update timed out", result.stderr)
+
+    def test_forced_kill_status_is_visible(self):
+        result, _, _ = self.run_installer(timeout_status=137)
+        self.assertEqual(result.returncode, 137)
+        self.assertIn("apt-get update failed (exit 137)", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test-validate-ci-gate.py
+++ b/scripts/test-validate-ci-gate.py
@@ -19,7 +19,9 @@ ROOT_BUCK = Path(os.environ.get("RUE_ROOT_BUCK", MODULE.ROOT_BUCK))
 
 
 class GateValidatorTests(unittest.TestCase):
-    def validate_text(self, text, native_runner=None, test_runner=None, buck=None):
+    def validate_text(
+        self, text, native_runner=None, test_runner=None, buck=None, valgrind_install=None
+    ):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "ci.yml"
             path.write_text(text)
@@ -39,7 +41,15 @@ class GateValidatorTests(unittest.TestCase):
             buck_path.write_text(
                 buck if buck is not None else ROOT_BUCK.read_text()
             )
-            return MODULE.validate(path, runner_path, test_runner_path, buck_path)
+            installer_path = Path(directory) / "install-valgrind"
+            installer_path.write_text(
+                valgrind_install
+                if valgrind_install is not None
+                else MODULE.VALGRIND_INSTALL_SCRIPT.read_text()
+            )
+            return MODULE.validate(
+                path, runner_path, test_runner_path, buck_path, installer_path
+            )
 
     def test_current_workflow_is_valid(self):
         self.assertEqual(
@@ -48,6 +58,30 @@ class GateValidatorTests(unittest.TestCase):
             ),
             [],
         )
+
+    def test_valgrind_cannot_return_to_inline_apt(self):
+        source = SOURCE.read_text().replace(
+            "run: scripts/install-valgrind",
+            "run: |\n          sudo apt-get update\n          sudo apt-get install -y valgrind",
+            1,
+        )
+        errors = "\n".join(self.validate_text(source))
+        self.assertIn("must invoke scripts/install-valgrind", errors)
+        self.assertIn("must not contain an inline unbounded apt-get operation", errors)
+
+    def test_valgrind_policy_drift_fails_contract(self):
+        installer = MODULE.VALGRIND_INSTALL_SCRIPT.read_text().replace(
+            "APT_ACQUIRE_TIMEOUT_SECONDS=30", "APT_ACQUIRE_TIMEOUT_SECONDS=45", 1
+        )
+        errors = "\n".join(self.validate_text(SOURCE.read_text(), valgrind_install=installer))
+        self.assertIn("30-second per-acquisition timeout", errors)
+
+    def test_valgrind_cancellation_cleanup_is_required(self):
+        installer = MODULE.VALGRIND_INSTALL_SCRIPT.read_text().replace(
+            'kill -KILL -- "-$child_pid"', "# cleanup removed", 1
+        )
+        errors = "\n".join(self.validate_text(SOURCE.read_text(), valgrind_install=installer))
+        self.assertIn("forced process-group cleanup", errors)
 
     def test_removing_or_renaming_job_fails_inventory(self):
         source = SOURCE.read_text()

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -17,6 +17,7 @@ TEST_RUNNER_SOURCE = (
     Path(__file__).resolve().parents[1] / "crates/rue-test-runner/src/lib.rs"
 )
 ROOT_BUCK = Path(__file__).resolve().parents[1] / "BUCK"
+VALGRIND_INSTALL_SCRIPT = Path(__file__).with_name("install-valgrind")
 
 # RUE-1161: the platform each entry of the harness's CI_EXECUTED_TARGETS claims
 # a required lane for, and the workflow text that proves that lane exists. The
@@ -171,15 +172,58 @@ def lane_target_drift(workflow: str, script: Path = AFFECTED_TARGETS_SCRIPT) -> 
     ]
 
 
+def valgrind_install_errors(workflow: str, script: str) -> list[str]:
+    """Keep Valgrind installation bounded and on its canonical script path."""
+    block = job_blocks(workflow).get("valgrind", "")
+    errors: list[str] = []
+    if "run: scripts/install-valgrind\n" not in block:
+        errors.append("valgrind must invoke scripts/install-valgrind")
+    if re.search(r"(?:sudo\s+)?apt-get\s+(?:update|install)", block):
+        errors.append("valgrind must not contain an inline unbounded apt-get operation")
+
+    # Keep this exact policy in the CI contract: changing a bound, retry, or
+    # lock option requires changing this reviewable contract and its tests.
+    required = {
+        "APT_OPERATION_TIMEOUT_SECONDS=600": "10-minute apt operation bound",
+        "APT_KILL_AFTER_SECONDS=30": "30-second timeout kill grace period",
+        "APT_ACQUIRE_TIMEOUT_SECONDS=30": "30-second per-acquisition timeout",
+        "APT_RETRIES=2": "two apt-native retries",
+        "APT_LOCK_TIMEOUT_SECONDS=60": "60-second package-manager lock wait",
+        "--kill-after=\"${APT_KILL_AFTER_SECONDS}s\"": "timeout descendant kill bound",
+        "--signal=TERM": "timeout termination signal",
+        '"${APT_OPERATION_TIMEOUT_SECONDS}s"': "timeout operation deadline",
+        "sudo -n apt-get": "non-interactive apt invocation",
+        "DPkg::Lock::Timeout=${APT_LOCK_TIMEOUT_SECONDS}": "explicit apt/dpkg lock wait",
+        "Acquire::Retries=${APT_RETRIES}": "apt-native retry policy",
+        "Acquire::http::Timeout=${APT_ACQUIRE_TIMEOUT_SECONDS}": "HTTP acquisition bound",
+        "Acquire::https::Timeout=${APT_ACQUIRE_TIMEOUT_SECONDS}": "HTTPS acquisition bound",
+        'kill -TERM -- "-$child_pid"': "cancellation process-group cleanup",
+        'kill -TERM "$child_pid"': "timeout process cleanup",
+        'kill -KILL -- "-$child_pid"': "forced process-group cleanup",
+        'kill -KILL "$child_pid"': "forced timeout cleanup",
+        "trap on_signal INT TERM": "cancellation signal handling",
+    }
+    for text, description in required.items():
+        if text not in script:
+            errors.append(f"install-valgrind lost its {description}")
+    return errors
+
+
 def validate(
     ci_path: Path,
     native_runner_path: Path = NATIVE_RUNNER_SCRIPT,
     test_runner_path: Path = TEST_RUNNER_SOURCE,
     buck_path: Path = ROOT_BUCK,
+    valgrind_install_path: Path = VALGRIND_INSTALL_SCRIPT,
 ) -> list[str]:
     workflow = ci_path.read_text()
     native_runner = native_runner_path.read_text()
     errors: list[str] = []
+    try:
+        valgrind_install = valgrind_install_path.read_text()
+    except OSError as error:
+        errors.append(f"Valgrind installer unreadable: {error}")
+        valgrind_install = ""
     try:
         jobs = job_blocks(workflow)
     except ValueError as error:
@@ -441,6 +485,7 @@ def validate(
             errors.append(f"{sanitizer} is no longer consolidated into CI")
     if "inputs.large_program" not in jobs.get("valgrind", ""):
         errors.append("manual Valgrind large_program selection was not preserved")
+    errors.extend(valgrind_install_errors(workflow, valgrind_install))
 
     errors.extend(undeclared_need_outputs(workflow, jobs))
     errors.extend(lane_target_drift(workflow))


### PR DESCRIPTION
## Summary

- replace the unbounded inline Valgrind package install with a canonical bounded installer
- cap each apt operation at 10 minutes, acquisitions at 30 seconds, apt-native retries at two, and lock waits at 60 seconds
- terminate the installer process group on timeout or workflow cancellation while preserving failure status
- enforce the workflow wiring and exact policy through the CI contract, behavioral tests, and affected-target selection

## Evidence

The linked job entered the installer immediately and remained there for 100 minutes until cancellation. A second occurrence retried Azure Ubuntu mirrors, fell back for release metadata, then stopped making progress for six hours while fetching package indexes. Normal installs take 10–22 seconds; one degraded but successful package download took 7m47s, which the 10-minute per-operation bound still accommodates.

## Validation

- focused Buck CI-policy targets (3 passed)
- scripts/rue quick (30 passed)
- scripts/rue premerge (195 passed)
- Bash 3.2 and Python 3.9 baseline validators

Fixes RUE-1585