### PR TITLE
RUE-1016: implement mutable accessors

### DIFF
--- a/crates/rue-air/src/declaration_validation.rs
+++ b/crates/rue-air/src/declaration_validation.rs
@@ -127,17 +127,12 @@ pub const ACCESSOR_PREVIEW_FEATURE: rue_error::PreviewFeature =
 /// The subject every producer names in the 6.6:3 gate diagnostic. The result
 /// position alone demands the preview, so this is reported before any shape
 /// rule about a form the program cannot yet name.
-pub const ACCESSOR_PREVIEW_SUBJECT: &str = "a `-> borrow` accessor";
+pub const ACCESSOR_PREVIEW_SUBJECT: &str = "a place-returning accessor (`-> borrow` or `-> inout`)";
 
-/// The note that points an `inout self` accessor at the phase that will admit
-/// it (6.6:4).
-pub const ACCESSOR_INOUT_SELF_NOTE: &str =
-    "mutable accessors (`inout self` -> exclusive result) are a later phase (RUE-1016)";
-
-/// What a producer found in the receiver position of a `-> borrow`
-/// declaration (6.6:4). Only [`AccessorReceiverForm::BorrowSelf`] is legal in
-/// ADR-0062 phase 1: an accessor hands out a shared projection of its
-/// receiver, so the receiver has to exist and be a shared borrow.
+/// What a producer found in the receiver position of a place-returning
+/// declaration (6.6:4). The result qualifier selects the required receiver
+/// mode: shared results pair with `borrow self`, exclusive results with
+/// `inout self`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AccessorReceiverForm {
     /// `borrow self`.
@@ -265,7 +260,18 @@ pub fn accessor_signature(
     receiver: AccessorReceiverForm,
     parameters: impl IntoIterator<Item = AccessorParameterForm>,
 ) -> Option<AccessorSignatureViolation> {
-    if let Some((kind, note)) = accessor_receiver_error(receiver) {
+    accessor_signature_for_mode(receiver, false, parameters)
+}
+
+/// Phase-aware accessor signature validation. Mutable accessors use the same
+/// receiver/argument pairing as an ordinary `inout` access: `-> inout T`
+/// requires `inout self`, while `-> borrow T` requires `borrow self`.
+pub fn accessor_signature_for_mode(
+    receiver: AccessorReceiverForm,
+    result_inout: bool,
+    parameters: impl IntoIterator<Item = AccessorParameterForm>,
+) -> Option<AccessorSignatureViolation> {
+    if let Some((kind, note)) = accessor_receiver_error_for_mode(receiver, result_inout) {
         return Some(AccessorSignatureViolation::Receiver { kind, note });
     }
     for (ordinal, parameter) in parameters.into_iter().enumerate() {
@@ -280,20 +286,34 @@ pub fn accessor_signature(
 pub fn accessor_receiver_error(
     receiver: AccessorReceiverForm,
 ) -> Option<(ErrorKind, Option<&'static str>)> {
+    accessor_receiver_error_for_mode(receiver, false)
+}
+
+pub fn accessor_receiver_error_for_mode(
+    receiver: AccessorReceiverForm,
+    result_inout: bool,
+) -> Option<(ErrorKind, Option<&'static str>)> {
     let (found, note) = match receiver {
-        AccessorReceiverForm::BorrowSelf => return None,
-        AccessorReceiverForm::InoutSelf => {
-            ("an `inout self` receiver", Some(ACCESSOR_INOUT_SELF_NOTE))
-        }
+        AccessorReceiverForm::BorrowSelf if !result_inout => return None,
+        AccessorReceiverForm::InoutSelf if result_inout => return None,
+        AccessorReceiverForm::BorrowSelf => ("a `borrow self` receiver", None),
+        AccessorReceiverForm::InoutSelf => ("an `inout self` receiver", None),
         AccessorReceiverForm::ValueSelf => ("a by-value `self` receiver", None),
         AccessorReceiverForm::FreeFunction => ("a free function", None),
         AccessorReceiverForm::AssociatedFunction => {
             ("an associated function with no receiver", None)
         }
     };
+    let (result, required) = if result_inout {
+        ("`-> inout`", "`inout self`")
+    } else {
+        ("`-> borrow`", "`borrow self`")
+    };
     Some((
         ErrorKind::AccessorRequiresBorrowSelf {
-            found: found.to_owned(),
+            found: format!(
+                "a {result} accessor requires a {required} receiver, but this is {found}"
+            ),
         },
         note,
     ))

--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1319,6 +1319,13 @@ impl<'a> ConstraintGenerator<'a> {
                 InferType::Concrete(Type::UNIT)
             }
 
+            InstData::PlaceSet { place, value } => {
+                let place_info = self.generate(*place, ctx);
+                let value_info = self.generate(*value, ctx);
+                self.add_constraint(Constraint::equal(place_info.ty, value_info.ty, span));
+                InferType::Concrete(Type::UNIT)
+            }
+
             // Return statement
             InstData::Ret(value) => {
                 if let Some(val_ref) = value {

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -309,12 +309,11 @@ where
 
     for arg in args {
         let arg = &*arg;
-        // A `-> borrow T` accessor call is a place for `borrow` arguments
-        // (ADR-0062): it roots at its receiver's root and joins the shared
-        // set. `inout` accessor results stay rejected as non-lvalues (the
-        // exclusive form is the RUE-1016 phase).
+        // An accessor call is a place for both `borrow` and `inout` arguments
+        // (ADR-0062/RUE-1016): it roots at its receiver's root and joins the
+        // corresponding exclusivity set.
         let maybe_var_symbol = root_variable_of(rir, arg.value).or_else(|| {
-            arg.is_borrow()
+            (arg.is_borrow() || arg.is_inout())
                 .then(|| resolve_borrow_root(arg.value))
                 .flatten()
         });

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -486,7 +486,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 }
                 ctx.param(*name).map(|param| param.ty)
             }
-            // A `-> borrow T` accessor call is a place of its element type
+            // A `-> borrow T` or `-> inout T` accessor call is a place of its element type
             // (ADR-0062); any other method call is not a place.
             InstData::MethodCall {
                 receiver, method, ..
@@ -494,7 +494,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 let base_ty = self.peek_place_type(*receiver, ctx)?;
                 let struct_id = base_ty.as_struct()?;
                 let info = self.call_facts().call_method_info(struct_id, *method)?;
-                info.returns_borrow.then_some(info.return_type)
+                (info.returns_borrow || info.returns_inout).then_some(info.return_type)
             }
             InstData::FieldGet { base, field } => {
                 let base_ty = self.peek_place_type(*base, ctx)?;

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -236,7 +236,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     && self
                         .call_facts()
                         .call_method_info(struct_id, *method)
-                        .is_some_and(|info| info.returns_borrow)
+                        .is_some_and(|info| info.returns_borrow || info.returns_inout)
                 {
                     return self.analyze_accessor_call_value(
                         air, inst_ref, *receiver, struct_id, *method, args, inst.span, ctx,
@@ -1078,12 +1078,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // An inlined accessor receiver arrives as a guards block whose
             // tail is the place read (ADR-0062); peel it for the address
             // check, exactly like the `inout str` view materialization.
-            let receiver_addressable_probe = if ctx.accessor_call_insts.contains_key(&receiver) {
-                self.peel_projected_rvalue_scope(air, receiver_result.air_ref)
-                    .0
-            } else {
-                receiver_result.air_ref
-            };
+            let receiver_is_accessor_place =
+                self.place_root_with_accessors(receiver, ctx).is_some();
+            let receiver_addressable_probe =
+                if receiver_is_accessor_place || ctx.accessor_call_insts.contains_key(&receiver) {
+                    self.peel_projected_rvalue_scope(air, receiver_result.air_ref)
+                        .0
+                } else {
+                    receiver_result.air_ref
+                };
             self.require_addressable_read(
                 air,
                 receiver_addressable_probe,
@@ -1092,6 +1095,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             )?;
 
             if receiver_var.is_none()
+                && !receiver_is_accessor_place
                 && (receiver_mode == AirArgMode::Inout || !receiver_is_source_strbuf)
             {
                 return Err(CompileError::new(
@@ -1185,7 +1189,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 self.reject_accessor_loan_conflict(root, "as an `inout self` receiver", span, ctx)?;
                 Some(vec![(root, CallLoanKind::Inout)])
             }
-            (AirArgMode::Borrow, Some(root)) => Some(vec![(root, CallLoanKind::Borrow)]),
+            (AirArgMode::Borrow, Some(root)) => {
+                self.reject_accessor_shared_loan_conflict(
+                    root,
+                    "as a `borrow self` receiver",
+                    span,
+                    ctx,
+                )?;
+                Some(vec![(root, CallLoanKind::Borrow)])
+            }
             _ => None,
         };
         let receiver_frame_pushed = receiver_frame.is_some();

--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -204,6 +204,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             InstData::Alloc { .. } | InstData::VarRef { .. } | InstData::Assign { .. } => {
                 self.analyze_variable_ops(air, inst_ref, ctx)
             }
+            InstData::PlaceSet { place, value } => {
+                self.analyze_place_set(air, *place, *value, inst.span, ctx)
+            }
 
             // Struct operations
             InstData::StructDecl { .. }

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -150,10 +150,10 @@ pub(crate) struct PlaceTrace {
     /// read: every consumer that turns the trace into a value wraps these
     /// around it as a block prefix (see `finish_traced_value`).
     pending_stmts: Vec<AirRef>,
-    /// Whether the trace passed through a `-> borrow T` accessor call. Such
-    /// a place is a second-class shared borrow: it may be read, projected,
-    /// re-borrowed, and compared, but never written through or moved out of
-    /// (write paths reject with E0428, drop-glue value reads with E0258).
+    /// Whether the trace passed through a place-returning accessor call. A
+    /// shared result may be read/projected but not written; an exclusive
+    /// result may also be written after the receiver and loan checks. Neither
+    /// result may be moved out of when it would create an owner alias.
     via_accessor: bool,
 }
 
@@ -1127,6 +1127,19 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         air: &mut Air,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<Option<PlaceTrace>> {
+        if let Some((place, root, ty, mutable)) = ctx.accessor_place_refs.get(&inst_ref).copied() {
+            let cached = air.get_place(place);
+            return Ok(Some(PlaceTrace {
+                base: cached.base,
+                base_type: ty,
+                projections: Vec::new(),
+                root_var: root,
+                is_root_mutable: mutable,
+                is_borrow_param: !mutable,
+                pending_stmts: Vec::new(),
+                via_accessor: true,
+            }));
+        }
         // Peek the receiver type without emitting anything: only proceed when
         // the method is a registered accessor.
         let Some(struct_id) = self
@@ -1138,7 +1151,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let Some(info) = self.call_facts().call_method_info(struct_id, method) else {
             return Ok(None);
         };
-        if !info.returns_borrow {
+        if !info.returns_borrow && !info.returns_inout {
             return Ok(None);
         }
         let span = self.body_rir_ref().get(inst_ref).span;
@@ -1148,14 +1161,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         .map(Some)
     }
 
-    /// Lower a `-> borrow T` accessor call to a marked place-producing call.
+    /// Lower a place-returning accessor call to a marked place-producing call.
     ///
     /// Semantic analysis establishes only the call-site loan and escape
     /// contract. The callee body remains an exact CFG-query dependency and is
     /// mandatorily spliced before code generation; no calling convention for
     /// returning a place exists. Statically this is the
     /// (Accessor-Call) rule: the receiver must be a place; the result is a
-    /// second-class borrowed place whose loan `(root(receiver), shared)`
+    /// second-class place whose shared or exclusive loan on the receiver root
     /// spans the enclosing full expression (registered in
     /// `ctx.expression_loans`).
     #[allow(clippy::too_many_arguments)]
@@ -1201,15 +1214,26 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             trace?.ok_or_else(|| CompileError::new(ErrorKind::BorrowNonLvalue, receiver_span))?
         };
         let root = receiver_trace.root_var;
-        for frame in &ctx.call_loaned_roots {
-            if frame
-                .iter()
-                .any(|(r, kind)| *r == root && *kind == CallLoanKind::Inout)
-            {
+        let accessor_loan_kind = if info.returns_inout {
+            CallLoanKind::Inout
+        } else {
+            CallLoanKind::Borrow
+        };
+        // The innermost frame is the argument list currently being lowered.
+        // Its own `inout` entry is the accessor's enclosing exclusive access,
+        // not a second loan; outer frames still represent genuinely nested
+        // calls and must conflict.
+        let frame_count = ctx.call_loaned_roots.len();
+        for (frame_index, frame) in ctx.call_loaned_roots.iter().enumerate() {
+            if frame.iter().any(|(r, kind)| {
+                *r == root
+                    && !(frame_index + 1 == frame_count && *kind == CallLoanKind::Inout)
+                    && (*kind == CallLoanKind::Inout || accessor_loan_kind == CallLoanKind::Inout)
+            }) {
                 return Err(CompileError::new(
                     ErrorKind::AccessorLoanConflict {
                         variable: self.body_interner().resolve(&root).to_string(),
-                        conflict: "while it is passed `inout`",
+                        conflict: "as an accessor receiver",
                     },
                     span,
                 ));
@@ -1219,7 +1243,53 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if receiver_ty.as_struct() != Some(struct_id) {
             return Err(self.type_mismatch_error(Type::new_struct(struct_id), receiver_ty, span));
         }
-        ctx.expression_loans.push((root, span));
+        if info.returns_inout && !receiver_trace.is_root_mutable {
+            let root_name = self.body_interner().resolve(&root).to_string();
+            return Err(CompileError::new(
+                if receiver_trace.is_borrow_param {
+                    ErrorKind::MutateBorrowedValue {
+                        variable: root_name,
+                    }
+                } else {
+                    ErrorKind::AssignToImmutable(root_name)
+                },
+                span,
+            ));
+        }
+        // Mutable accessors carry an exclusive loan; shared and exclusive
+        // accessor results conflict on the same root. The existing root loan
+        // list is intentionally expression-scoped and root-granular.
+        let loan_kind = if info.returns_inout {
+            CallLoanKind::Inout
+        } else {
+            CallLoanKind::Borrow
+        };
+        if ctx.expression_loans.iter().any(|(r, _, kind)| {
+            *r == root && (*kind == CallLoanKind::Inout || loan_kind == CallLoanKind::Inout)
+        }) {
+            return Err(CompileError::new(
+                ErrorKind::AccessorLoanConflict {
+                    variable: self.body_interner().resolve(&root).to_string(),
+                    conflict: "for another accessor result",
+                },
+                span,
+            ));
+        }
+        if loan_kind == CallLoanKind::Inout
+            && ctx
+                .expression_shared_reads
+                .iter()
+                .any(|(read_root, _)| *read_root == root)
+        {
+            return Err(CompileError::new(
+                ErrorKind::AccessorLoanConflict {
+                    variable: self.body_interner().resolve(&root).to_string(),
+                    conflict: "for an exclusive accessor result after a shared read",
+                },
+                span,
+            ));
+        }
+        ctx.expression_loans.push((root, span, loan_kind));
         ctx.accessor_call_insts.insert(inst_ref, (method, root));
         ctx.referenced_methods.insert((struct_id, method));
         self.record_body_method_dependency((struct_id, method));
@@ -1241,7 +1311,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let mut call_args = Vec::with_capacity(operands.args.len() + 1);
         call_args.push(AirCallArg {
             value: receiver_value,
-            mode: AirArgMode::Borrow,
+            mode: if info.returns_inout {
+                AirArgMode::Inout
+            } else {
+                AirArgMode::Borrow
+            },
         });
         call_args.extend(operands.args);
         let call = air.add_accessor_call(call_name, &call_args, info.return_type, span)?;
@@ -1250,14 +1324,19 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         receiver_trace.projections.clear();
         receiver_trace.pending_stmts.extend(operands.temp_scope);
         receiver_trace.via_accessor = true;
-        receiver_trace.is_borrow_param = true;
-        receiver_trace.is_root_mutable = false;
+        receiver_trace.is_borrow_param = !info.returns_inout;
+        receiver_trace.is_root_mutable = info.returns_inout;
+        let yielded_place = Self::build_place_ref(air, &receiver_trace)?;
+        ctx.accessor_place_refs.insert(
+            inst_ref,
+            (yielded_place, root, info.return_type, info.returns_inout),
+        );
         Ok(receiver_trace)
     }
 
-    /// Analyze a `-> borrow T` accessor call in value position (ADR-0062):
+    /// Analyze a place-returning accessor call in value position (ADR-0062):
     /// expand it to guards plus the yielded place, then read the place. The
-    /// read is a shared-borrow read, so a drop-glue element may only flow to
+    /// result remains a borrowed place, so a drop-glue element may only flow to
     /// a by-ref consumer (a `borrow` argument or by-ref receiver, which take
     /// the place's address); reading it out by value would mint an aliasing
     /// owner (E0258) — exactly the RUE-651 double-free the E0711 gate closes.
@@ -1322,7 +1401,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 let base_ty = self.peek_place_type(*receiver, ctx)?;
                 let base_struct = base_ty.as_struct()?;
                 let info = self.call_facts().call_method_info(base_struct, *method)?;
-                if !info.returns_borrow {
+                if !info.returns_borrow && !info.returns_inout {
                     return None;
                 }
                 self.place_root_with_accessors(*receiver, ctx)
@@ -1750,6 +1829,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         resolved_ty: Option<Type>,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
+        // An ordinary value read is a shared use of the root. It cannot
+        // overlap an exclusive accessor result in the same full expression.
+        if ctx.byref_arg_root != Some(name) {
+            self.reject_accessor_shared_loan_conflict(name, "by a shared read", span, ctx)?;
+            ctx.expression_shared_reads.push((name, span));
+        }
         // Check if it's a parameter — but a `let` that shadows the parameter
         // rebinds the name to a new local, and that local wins for all later
         // reads (spec 5.1:10, RUE-278). A same-named local can only exist by
@@ -2555,6 +2640,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         // Try to trace this expression to a place (lvalue)
         if let Some(mut trace) = self.try_trace_place(inst_ref, air, ctx)? {
+            if !trace.via_accessor && ctx.byref_arg_root != Some(trace.root_var) {
+                self.reject_accessor_shared_loan_conflict(
+                    trace.root_var,
+                    "by a shared read",
+                    span,
+                    ctx,
+                )?;
+                ctx.expression_shared_reads.push((trace.root_var, span));
+            }
             let field_type = trace.result_type();
 
             // Check if the root variable was fully moved (applies regardless of field type)
@@ -2733,6 +2827,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
             // Emit PlaceRead instruction
             let place_ref = Self::build_place_ref(air, &trace)?;
+            if trace.via_accessor {
+                ctx.accessor_place_refs.insert(
+                    inst_ref,
+                    (place_ref, trace.root_var, field_type, trace.is_root_mutable),
+                );
+            }
             let mut air_ref = air.add_inst(AirInst {
                 data: AirInstData::PlaceRead { place: place_ref },
                 ty: field_type,
@@ -2895,6 +2995,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         // Try to trace this expression to a place (lvalue)
         if let Some(mut trace) = self.try_trace_place(inst_ref, air, ctx)? {
+            if !trace.via_accessor && ctx.byref_arg_root != Some(trace.root_var) {
+                self.reject_accessor_shared_loan_conflict(
+                    trace.root_var,
+                    "by a shared read",
+                    span,
+                    ctx,
+                )?;
+                ctx.expression_shared_reads.push((trace.root_var, span));
+            }
             let elem_type = trace.result_type();
 
             // Reading through an index expression whose base place has been
@@ -3014,6 +3123,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
             // Emit PlaceRead instruction
             let place_ref = Self::build_place_ref(air, &trace)?;
+            if trace.via_accessor {
+                ctx.accessor_place_refs.insert(
+                    inst_ref,
+                    (place_ref, trace.root_var, elem_type, trace.is_root_mutable),
+                );
+            }
             let mut air_ref = air.add_inst(AirInst {
                 data: AirInstData::PlaceRead { place: place_ref },
                 ty: elem_type,
@@ -3618,6 +3733,84 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     }
 
     /// Analyze a field assignment through the shared place representation.
+    pub(crate) fn analyze_place_set(
+        &mut self,
+        air: &mut Air,
+        place: InstRef,
+        value: InstRef,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        // Assignment evaluates the RHS before the target (spec 5.2:17-18).
+        // Peek only at the target type for contextual RHS analysis; tracing
+        // an accessor target is deferred until after the RHS so its loan
+        // cannot reject an otherwise valid RHS use of the receiver.
+        let cached_before_rhs = ctx.accessor_place_refs.get(&place).copied();
+        let destination_type = cached_before_rhs.map_or_else(
+            || {
+                self.peek_place_type(place, ctx)
+                    .ok_or_else(|| CompileError::new(ErrorKind::InvalidAssignmentTarget, span))
+            },
+            |(_, _, ty, _)| Ok(ty),
+        )?;
+        let previous_expected = ctx.expected_type.replace(destination_type);
+        let rhs_shared_reads_before = ctx.expression_shared_reads.len();
+        let value_result = self.analyze_inst(air, value, ctx);
+        ctx.expected_type = previous_expected;
+        let value_result = value_result?;
+        self.reject_accessor_result_escape(value, AccessorEscapeSite::Store, span, ctx)?;
+        // A plain assignment's RHS is complete before the LHS place is
+        // evaluated. Ordinary shared-read markers are expression-order
+        // bookkeeping and can be truncated before the target is traced;
+        // accessor loans, however, span the entire assignment expression and
+        // must remain live so two accessor results on one root conflict.
+        // Compound assignment analyzes the same target instruction as the
+        // RHS's read (the compound value is `target op rhs`). That read may
+        // populate the accessor-place cache only while analyzing the RHS, so
+        // refresh it before deciding whether the target has already been
+        // evaluated. A plain assignment's separately generated RHS cannot
+        // populate the target's instruction entry.
+        let cached = cached_before_rhs.or_else(|| ctx.accessor_place_refs.get(&place).copied());
+        if cached.is_none() {
+            ctx.expression_shared_reads
+                .truncate(rhs_shared_reads_before);
+        }
+        let (place_ref, root_var, mutable) = if let Some((place_ref, root, _, mutable)) = cached {
+            (place_ref, root, mutable)
+        } else {
+            let trace = self
+                .try_trace_place(place, air, ctx)?
+                .ok_or_else(|| CompileError::new(ErrorKind::InvalidAssignmentTarget, span))?;
+            if !trace.via_accessor || !trace.is_root_mutable {
+                return Err(CompileError::new(ErrorKind::InvalidAssignmentTarget, span));
+            }
+            let root = trace.root_var;
+            self.reject_mutate_iter_borrowed(root, span, ctx)?;
+            (
+                Self::build_place_ref(air, &trace)?,
+                root,
+                trace.is_root_mutable,
+            )
+        };
+        if !mutable {
+            return Err(CompileError::new(ErrorKind::InvalidAssignmentTarget, span));
+        }
+        if cached.is_some() {
+            self.reject_mutate_iter_borrowed(root_var, span, ctx)?;
+        }
+        self.check_linear_overwrite(destination_type, false, false, span)?;
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::PlaceWrite {
+                place: place_ref,
+                value: value_result.air_ref,
+            },
+            ty: Type::UNIT,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, Type::UNIT))
+    }
+
+    /// Analyze a field assignment through the shared place representation.
     pub(crate) fn analyze_field_set(
         &mut self,
         air: &mut Air,
@@ -3647,10 +3840,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // RUE-233) — E0428, like an explicit `borrow` parameter.
             self.reject_mutate_iter_borrowed(trace.root_var, span, ctx)?;
 
-            // Writing to a root an accessor result borrows in the same full
-            // expression is an exclusive use inside a shared loan's extent
-            // (ADR-0062, E0259).
-            self.reject_accessor_loan_conflict(trace.root_var, "by assignment", span, ctx)?;
+            // A write must not overlap an incompatible accessor-result loan
+            // on the same root (ADR-0062, E0259). A write through this trace's
+            // own exclusive accessor place is the operation that loan permits.
+            if !trace.is_root_mutable || !trace.via_accessor {
+                self.reject_accessor_loan_conflict(trace.root_var, "by assignment", span, ctx)?;
+            }
 
             // Check mutability
             let root_name = self.body_interner().resolve(&trace.root_var).to_string();
@@ -3817,10 +4012,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // RUE-233) — E0428, like an explicit `borrow` parameter.
             self.reject_mutate_iter_borrowed(trace.root_var, span, ctx)?;
 
-            // Writing to a root an accessor result borrows in the same full
-            // expression is an exclusive use inside a shared loan's extent
-            // (ADR-0062, E0259).
-            self.reject_accessor_loan_conflict(trace.root_var, "by assignment", span, ctx)?;
+            // A write must not overlap an incompatible accessor-result loan
+            // on the same root (ADR-0062, E0259). A write through this trace's
+            // own exclusive accessor place is the operation that loan permits.
+            if !trace.is_root_mutable || !trace.via_accessor {
+                self.reject_accessor_loan_conflict(trace.root_var, "by assignment", span, ctx)?;
+            }
 
             // Check mutability
             let root_name = self.body_interner().resolve(&trace.root_var).to_string();
@@ -3985,6 +4182,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // Fallback: base is not a place
         Err(CompileError::new(ErrorKind::InvalidAssignmentTarget, span))
     }
+
     /// Check if directives contain @allow for a specific warning name.
     pub(crate) fn has_allow_directive<'r>(
         &self,
@@ -4657,11 +4855,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         self.reject_accessor_loan_conflict(root, "by value (move)", span, ctx)
     }
 
-    /// Reject an exclusive use — `inout`, mutation, or move — of a root that
-    /// an accessor result borrows within the same full expression (ADR-0062,
-    /// E0259). The accessor loan is shared and extends to the end of the
-    /// enclosing full expression, so any exclusive access within that extent
-    /// violates the law of exclusivity.
+    /// Reject an exclusive use — `inout`, mutation, or move — of a root with
+    /// an active accessor-result loan in the same full expression (ADR-0062,
+    /// E0259). Shared and exclusive accessor loans both exclude another
+    /// exclusive access for their full extent.
     pub(crate) fn reject_accessor_loan_conflict(
         &self,
         root: Spur,
@@ -4669,7 +4866,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         span: Span,
         ctx: &AnalysisContext,
     ) -> CompileResult<()> {
-        if let Some((_, loan_span)) = ctx.expression_loans.iter().find(|(r, _)| *r == root) {
+        if let Some((_, loan_span, _kind)) =
+            ctx.expression_loans.iter().find(|(r, _, _)| *r == root)
+        {
             return Err(CompileError::new(
                 ErrorKind::AccessorLoanConflict {
                     variable: self.body_interner().resolve(&root).to_string(),
@@ -4682,10 +4881,38 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         Ok(())
     }
 
+    pub(crate) fn reject_accessor_shared_loan_conflict(
+        &self,
+        root: Spur,
+        conflict: &'static str,
+        span: Span,
+        ctx: &AnalysisContext,
+    ) -> CompileResult<()> {
+        if let Some((_, loan_span, _kind)) = ctx
+            .expression_loans
+            .iter()
+            .find(|(r, _, kind)| *r == root && *kind == CallLoanKind::Inout)
+        {
+            return Err(CompileError::new(
+                ErrorKind::AccessorLoanConflict {
+                    variable: self.body_interner().resolve(&root).to_string(),
+                    conflict,
+                },
+                span,
+            )
+            .with_label(
+                "exclusive accessor result borrows the value here",
+                *loan_span,
+            ));
+        }
+        Ok(())
+    }
+
     /// Reject a by-value move of a non-trivially-droppable value out of a
     /// place reached through an accessor result (ADR-0062, E0258): the
-    /// result is a shared borrow, not an owner, so moving an owning value
-    /// out of it would mint an aliasing second owner.
+    /// result is a borrowed place, not an owner, so moving an owning value
+    /// out of it would mint an aliasing second owner. Exclusive writes remain
+    /// legal after receiver mutability and loan checks.
     pub(super) fn reject_accessor_place_move(
         &self,
         trace: &PlaceTrace,
@@ -4921,12 +5148,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 };
                 root_variable_of(self.body_rir_ref(), arg.value)
                     .or_else(|| {
-                        // Accessor-call place chains join the shared set
-                        // (ADR-0062); exclusive accessor results do not exist
-                        // in this phase.
-                        (kind == CallLoanKind::Borrow)
-                            .then(|| self.place_root_with_accessors(arg.value, ctx))
-                            .flatten()
+                        // Both shared and exclusive accessor-call place chains
+                        // root their loan at the receiver (ADR-0062/RUE-1016).
+                        self.place_root_with_accessors(arg.value, ctx)
                     })
                     .map(|root| (root, kind))
             })
@@ -4936,16 +5160,25 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // frame construction (loans taken by earlier sibling arguments) and
         // again by accessor expansion itself (the reverse nesting order).
         for arg in args.clone() {
-            if !arg.is_inout() {
+            if !arg.is_inout() && !arg.is_borrow() {
                 continue;
             }
             if let Some(root) = root_variable_of(self.body_rir_ref(), arg.value) {
-                self.reject_accessor_loan_conflict(
-                    root,
-                    "as `inout`",
-                    self.body_rir_ref().get(arg.value).span,
-                    ctx,
-                )?;
+                if arg.is_inout() {
+                    self.reject_accessor_loan_conflict(
+                        root,
+                        "as `inout`",
+                        self.body_rir_ref().get(arg.value).span,
+                        ctx,
+                    )?;
+                } else {
+                    self.reject_accessor_shared_loan_conflict(
+                        root,
+                        "as `borrow`",
+                        self.body_rir_ref().get(arg.value).span,
+                        ctx,
+                    )?;
+                }
             }
         }
         let pushed = !frame.is_empty();
@@ -5093,7 +5326,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     Some(root) => root,
                     None => match self
                         .place_root_with_accessors(arg.value, ctx)
-                        .filter(|_| arg.is_borrow())
+                        .filter(|_| arg.is_borrow() || arg.is_inout())
                     {
                         Some(root) => root,
                         None => {

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -847,6 +847,7 @@ struct MethodSignature {
     params: ParamRange,
     return_type: Type,
     returns_borrow: bool,
+    returns_inout: bool,
 }
 
 fn anonymous_nominal_keys_canonically_equal<K: Eq, M: Eq>(
@@ -2270,6 +2271,8 @@ pub struct DurableMethod<K, M> {
     pub has_self: bool,
     pub self_mode: SemanticParameterMode,
     pub is_accessor: bool,
+    pub returns_borrow: bool,
+    pub returns_inout: bool,
 }
 
 /// The durable callable vocabulary the pool consults to mint callable
@@ -2332,6 +2335,7 @@ pub(in crate::sema) struct MethodIdentityHandle {
     /// Whether the declaration is a `-> borrow T` accessor (ADR-0062);
     /// carried from the RIR `FnDecl` like `self_is_mut`.
     pub returns_borrow: bool,
+    pub returns_inout: bool,
 }
 
 impl<K, M, S> BodyIdentityPool<K, M, S>
@@ -2431,6 +2435,7 @@ where
             body: handle.body,
             span: handle.span,
             returns_borrow: handle.returns_borrow,
+            returns_inout: handle.returns_inout,
         })
     }
 
@@ -2446,6 +2451,7 @@ where
             params: signature.params,
             return_type: signature.return_type,
             returns_borrow: signature.returns_borrow,
+            returns_inout: signature.returns_inout,
         })
     }
 
@@ -2523,7 +2529,9 @@ where
             type_syntax: _,
             has_self,
             self_mode,
-            is_accessor,
+            is_accessor: _,
+            returns_borrow,
+            returns_inout,
         } = self
             .source
             .method(key)
@@ -2543,7 +2551,8 @@ where
             },
             params,
             return_type,
-            returns_borrow: is_accessor,
+            returns_borrow,
+            returns_inout,
         };
         self.method_sigs.insert(key.clone(), signature);
         Ok(signature)
@@ -3122,6 +3131,7 @@ mod tests {
             body: InstRef::from_raw(body),
             span: Span::with_file(owner.0, 1, 2),
             returns_borrow: false,
+            returns_inout: false,
         };
         let named = info(10);
         let anonymous = info(11);
@@ -3657,6 +3667,8 @@ mod tests {
             has_self,
             self_mode,
             is_accessor: false,
+            returns_borrow: false,
+            returns_inout: false,
         }
     }
 
@@ -3686,6 +3698,7 @@ mod tests {
             span: Span::with_file(FileId::new(3), 1, 4),
             self_is_mut: true,
             returns_borrow: false,
+            returns_inout: false,
         }
     }
 
@@ -6211,6 +6224,7 @@ mod tests {
             body,
             self_is_mut,
             returns_borrow,
+            returns_inout,
             ..
         } = &inst.data
         else {
@@ -6221,6 +6235,7 @@ mod tests {
             span: inst.span,
             self_is_mut: *self_is_mut,
             returns_borrow: *returns_borrow,
+            returns_inout: *returns_inout,
         }
     }
 

--- a/crates/rue-air/src/sema/call_resolution.rs
+++ b/crates/rue-air/src/sema/call_resolution.rs
@@ -407,6 +407,7 @@ where
             body,
             self_is_mut,
             returns_borrow,
+            returns_inout,
             ..
         } = &inst.data
         else {
@@ -417,6 +418,7 @@ where
             span: inst.span,
             self_is_mut: *self_is_mut,
             returns_borrow: *returns_borrow,
+            returns_inout: *returns_inout,
         })
     }
 

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -495,7 +495,8 @@ pub(crate) struct AliasProjection {
 
 /// A name bound to a caller place during accessor inlining (ADR-0062).
 ///
-/// While a `-> borrow T` accessor call is expanded at its call site, the
+/// While a place-returning accessor call (`-> borrow T` or `-> inout T`) is
+/// expanded at its call site, the
 /// accessor body's `self` resolves to the *caller's* receiver place: the
 /// place tracer substitutes this alias where the body says `self`, so
 /// `self.f` composes to `<receiver place>.f` rooted at the caller's own
@@ -665,7 +666,7 @@ pub(crate) struct AnalysisContext<'a> {
     /// call expansion (ADR-0062) can run type inference for the accessor's
     /// body on demand before splicing it into the caller.
     pub infer_ctx: &'a super::inference_ctx::InferenceContext,
-    /// When analyzing a `-> borrow T` accessor body, the body block's single
+    /// When analyzing a place-returning accessor body, the body block's single
     /// trailing `yield` instruction — the only `yield` the body may contain.
     /// `None` outside accessor bodies; a `yield` analyzed while this is
     /// `None` is E0256, and one that is not this exact instruction is E0254.
@@ -676,13 +677,20 @@ pub(crate) struct AnalysisContext<'a> {
     /// consult this after analyzing an operand to reject binding a borrowed
     /// place beyond its full expression, naming the offending accessor.
     pub accessor_call_insts: AHashMap<InstRef, (Spur, Spur)>,
+    /// AIR place handles for accessor calls already materialized in this
+    /// expression. Compound assignment reuses the same yielded place rather
+    /// than expanding and loaning the accessor a second time.
+    pub accessor_place_refs: AHashMap<InstRef, (crate::inst::AirPlaceRef, Spur, Type, bool)>,
     /// Active accessor-result loans for the current full expression
-    /// (ADR-0062): each entry is the receiver root of an expanded accessor
-    /// call, shared mode, together with the call span. The statement loop
+    /// (ADR-0062): each entry is the receiver root, call span, and shared or
+    /// exclusive mode of an expanded accessor call. The statement loop
     /// truncates this to its pre-statement length after every statement, so
     /// an entry's extent is exactly the enclosing full expression. An
-    /// exclusive use of a listed root within that extent is E0259.
-    pub expression_loans: Vec<(Spur, Span)>,
+    /// incompatible use of a listed root within that extent is E0259.
+    pub expression_loans: Vec<(Spur, Span, CallLoanKind)>,
+    /// Ordinary shared reads in the current full expression. An exclusive
+    /// accessor result conflicts with these reads in either evaluation order.
+    pub expression_shared_reads: Vec<(Spur, Span)>,
     /// Resolved-type overlays for accessor bodies currently being inlined,
     /// innermost last. `resolved_type_of` consults these before the body's
     /// own `resolved_types`, letting the caller's analysis walk accessor-body
@@ -925,7 +933,9 @@ impl<'a> AnalysisContext<'a> {
             infer_ctx: self.infer_ctx,
             accessor_trailing_yield: self.accessor_trailing_yield,
             accessor_call_insts: self.accessor_call_insts.clone(),
+            accessor_place_refs: self.accessor_place_refs.clone(),
             expression_loans: self.expression_loans.clone(),
+            expression_shared_reads: self.expression_shared_reads.clone(),
             inline_resolved_types: self.inline_resolved_types.clone(),
             place_aliases: self.place_aliases.clone(),
             try_operand: false,

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -1890,7 +1890,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     }
 
     /// Analyze a return statement.
-    /// Analyze a `yield` — the exit form of a `-> borrow T` accessor body
+    /// Analyze a `yield` — the exit form of a place-returning accessor body
     /// (ADR-0062). Outside an accessor body it is E0256; inside one, only the
     /// body's single trailing `yield` is legal (E0254 otherwise). The
     /// trailing `yield` of an *inlined* accessor body never reaches this
@@ -2004,7 +2004,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         .and_then(|struct_id| {
                             self.call_facts().call_method_info(struct_id, *method)
                         })
-                        .is_some_and(|info| info.returns_borrow);
+                        .is_some_and(|info| info.returns_borrow || info.returns_inout);
                     let link = if is_accessor {
                         AccessorMethodLink::Accessor
                     } else {
@@ -2156,6 +2156,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // clears. The tail expression's loans are part of the enclosing
             // full expression and survive the block.
             let expression_loans_before = ctx.expression_loans.len();
+            let expression_shared_reads_before = ctx.expression_shared_reads.len();
             let outcome = if is_last {
                 self.analyze_inst(air, inst_ref, ctx)
             } else {
@@ -2163,6 +2164,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             };
             if !is_last {
                 ctx.expression_loans.truncate(expression_loans_before);
+                ctx.expression_shared_reads
+                    .truncate(expression_shared_reads_before);
             }
             let result = match outcome {
                 Ok(result) => result,

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -22,9 +22,9 @@ use crate::declaration_validation::{
     AccessorYieldRootForm,
 };
 
-/// The declaration legality of a `-> borrow T` accessor (ADR-0062): the result
-/// position requires the `borrow_accessors` preview (6.6:3), the receiver is a
-/// shared `borrow self` (6.6:4), every other parameter is a plain by-value
+/// The declaration legality of a place-returning accessor (ADR-0062): the
+/// result position requires the `borrow_accessors` preview (6.6:3), the
+/// receiver/result modes pair exactly (6.6:4), every other parameter is a plain by-value
 /// guard input (6.6:5), the body's only exit is its trailing `yield` (6.6:6),
 /// and that `yield` hands out a receiver-rooted place (6.6:7).
 ///
@@ -39,9 +39,9 @@ use crate::declaration_validation::{
 /// method-call link in the yielded chain names an accessor — is documented on
 /// [`accessor_yield_root`] and stays with the demanded path.
 ///
-/// The declaring `FnDecl` is the only carrier of `returns_borrow`: the durable
-/// signature records the result type's source spelling, which never contains
-/// the result-position `borrow` qualifier.
+/// The RIR declaration and durable signature both carry the result mode. The
+/// result qualifier is not encoded in the result type itself, so every
+/// declaration producer must preserve it through its signature facts.
 ///
 /// The preview gate runs first, so an ungated program reports E1100 rather
 /// than a shape error about a form it cannot name yet.
@@ -58,12 +58,16 @@ pub(super) fn check_accessor_declaration_shape(
         params,
         has_self,
         self_mode,
-        returns_borrow: true,
+        returns_borrow,
+        returns_inout,
         ..
     } = &inst.data
     else {
         return Ok(());
     };
+    if !*returns_borrow && !*returns_inout {
+        return Ok(());
+    }
     let span = inst.span;
     super::require_preview_feature(
         preview_features,
@@ -72,9 +76,9 @@ pub(super) fn check_accessor_declaration_shape(
         span,
     )?;
     // An accessor hands out a projection of its receiver, so the receiver is
-    // the first thing that has to exist and be a shared borrow. `self` is
-    // carried by `has_self`, so the parameter list is exactly the guard
-    // inputs.
+    // the first thing that has to exist and have the mode paired with the
+    // result. `self` is carried by `has_self`, so the parameter list is
+    // exactly the guard inputs.
     let receiver = if !has_named_owner {
         AccessorReceiverForm::FreeFunction
     } else if !*has_self {
@@ -87,8 +91,9 @@ pub(super) fn check_accessor_declaration_shape(
         }
     };
     let params = rir.params(params);
-    if let Some(violation) = crate::declaration_validation::accessor_signature(
+    if let Some(violation) = crate::declaration_validation::accessor_signature_for_mode(
         receiver,
+        *returns_inout,
         params
             .iter()
             .map(|param| accessor_parameter_form(param.mode, param.is_comptime)),

--- a/crates/rue-air/src/sema/info.rs
+++ b/crates/rue-air/src/sema/info.rs
@@ -96,10 +96,11 @@ pub struct MethodInfo {
     pub body: rue_rir::InstRef,
     /// Span of the method declaration
     pub span: Span,
-    /// Whether the result position is `-> borrow T` (ADR-0062): the method
-    /// is a place-returning accessor whose calls inline to guards plus the
-    /// yielded receiver projection. `return_type` holds the element type `T`.
+    /// Whether the result position is `-> borrow T` (ADR-0062) or `-> inout T`
+    /// (RUE-1016): the method is a place-returning accessor whose calls inline
+    /// to guards plus the yielded receiver projection. `return_type` holds T.
     pub returns_borrow: bool,
+    pub returns_inout: bool,
 }
 
 /// Signature-only callable metadata consumed at a call site. Imported
@@ -144,6 +145,7 @@ pub(crate) struct MethodCallInfo {
     /// calls do not dispatch as ordinary calls: they inline the accessor
     /// body at the call site via the dedicated accessor-body fact.
     pub returns_borrow: bool,
+    pub returns_inout: bool,
 }
 
 impl MethodCallInfo {
@@ -155,6 +157,7 @@ impl MethodCallInfo {
             params: info.params,
             return_type: info.return_type,
             returns_borrow: info.returns_borrow,
+            returns_inout: info.returns_inout,
         }
     }
 }

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -661,6 +661,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
                 self_mode,
                 self_is_mut,
                 returns_borrow,
+                returns_inout,
                 ..
             } = method_inst.data
             else {
@@ -669,7 +670,11 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             let key = (struct_id, method_name);
             // Accessors are not supported on anonymous structs (ADR-0062
             // phase 1).
-            if !seen_methods.insert(method_name) || self.has_method(key) || returns_borrow {
+            if !seen_methods.insert(method_name)
+                || self.has_method(key)
+                || returns_borrow
+                || returns_inout
+            {
                 return None;
             }
             let parameters = self.body_rir_ref().params(&params).to_vec();
@@ -716,6 +721,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
                     body,
                     span: method_inst.span,
                     returns_borrow: false,
+                    returns_inout: false,
                 },
             ));
         }
@@ -1612,6 +1618,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         self_mode: RirParamMode,
         self_is_mut: bool,
         returns_borrow: bool,
+        returns_inout: bool,
     ) -> CompileResult<(
         AnalyzedFunction,
         Vec<CompileWarning>,
@@ -1647,7 +1654,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             struct_type,
             self_is_mut,
             false,
-            returns_borrow,
+            returns_borrow || returns_inout,
         )
     }
 
@@ -2123,7 +2130,9 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             infer_ctx,
             accessor_trailing_yield: None,
             accessor_call_insts: AHashMap::new(),
+            accessor_place_refs: AHashMap::new(),
             expression_loans: Vec::new(),
+            expression_shared_reads: Vec::new(),
             inline_resolved_types: Vec::new(),
             place_aliases: AHashMap::new(),
             try_operand: false,

--- a/crates/rue-air/src/sema/provider_accessor_tests.rs
+++ b/crates/rue-air/src/sema/provider_accessor_tests.rs
@@ -39,6 +39,18 @@ fn accessor_shape() -> MethodShape {
         has_self: true,
         self_mode: SemanticParameterMode::Borrow,
         is_accessor: true,
+        returns_borrow: true,
+        returns_inout: false,
+    }
+}
+
+fn mutable_accessor_shape() -> MethodShape {
+    MethodShape {
+        has_self: true,
+        self_mode: SemanticParameterMode::Inout,
+        is_accessor: true,
+        returns_borrow: false,
+        returns_inout: true,
     }
 }
 
@@ -87,6 +99,56 @@ fn accessor_call_count(air: &crate::ValidatedAir) -> usize {
     air.iter()
         .filter(|(_, inst)| matches!(inst.data, AirInstData::AccessorCall { .. }))
         .count()
+}
+
+#[test]
+fn provider_mutable_accessor_marks_inout_receiver_and_place_result() {
+    let mut fixture = ProviderFixture::with_preview(accessor_preview());
+    let grid = fixture.declare_struct(
+        "Grid",
+        vec![(
+            "cells",
+            SemanticImportType::Array {
+                element: Box::new(SemanticImportType::I64),
+                len: 2,
+            },
+        )],
+        false,
+    );
+    fixture.declare_method_with(
+        &grid,
+        "at_mut",
+        vec![value_param("i", SemanticImportType::U64)],
+        SemanticImportType::I64,
+        mutable_accessor_shape(),
+    );
+    fixture.declare_function(
+        "set",
+        vec![mode_param(
+            "x",
+            SemanticImportType::I64,
+            SemanticParameterMode::Inout,
+        )],
+        SemanticImportType::Unit,
+    );
+    fixture.declare_function("main", Vec::new(), SemanticImportType::I32);
+    let body = fixture
+        .analyze(
+            "fn main() -> i32 {
+    let mut g = Grid { cells: [1, 2] };
+    set(inout g.at_mut(1));
+    0
+}",
+            "main",
+        )
+        .expect("provider mutable accessor compiles");
+    assert_eq!(accessor_call_count(&body.function.air), 1);
+    assert!(
+        body.function
+            .air
+            .iter()
+            .any(|(_, inst)| matches!(inst.data, AirInstData::PlaceRead { .. }))
+    );
 }
 
 // Migrated from `tests::accessor_call_inlines_with_no_call_shape`: a call
@@ -664,7 +726,8 @@ fn free_function_cannot_be_an_accessor() {
     assert!(
         matches!(
             &error.kind,
-            ErrorKind::AccessorRequiresBorrowSelf { found } if found == "a free function"
+            ErrorKind::AccessorRequiresBorrowSelf { found, .. }
+                if found.contains("a free function")
         ),
         "unexpected diagnostic: {error:?}"
     );
@@ -689,7 +752,8 @@ fn free_function_accessor_without_yield_is_rejected() {
     assert!(
         matches!(
             &error.kind,
-            ErrorKind::AccessorRequiresBorrowSelf { found } if found == "a free function"
+            ErrorKind::AccessorRequiresBorrowSelf { found, .. }
+                if found.contains("a free function")
         ),
         "unexpected diagnostic: {error:?}"
     );

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -1696,17 +1696,19 @@ where
         let owner = self.source.definition_name(&receiver_key)?;
         let name = self.interner.resolve(&symbol);
         let (key, has_self) = self.source.named_member(&receiver_key, &owner, name)?;
-        // The signature-only durable subset cannot carry the `-> borrow T`
-        // accessor flag (ADR-0062); recover it from the owning struct's
-        // request-local RIR declaration when that declaration is present.
-        // (Provider body requests currently prune type declarations from
-        // their RIR, so this recovery only fires on hosts whose request
-        // carries the owner — see the RUE-662 provider-path limitation.)
+        // Durable method signatures carry the exact accessor result mode.
+        // Request-local RIR remains authoritative when the owner declaration
+        // is present, preserving parity for bodies materialized from a slice.
         let mut info = self.calls.method_signature_info(&key)?;
         if let Some(method_ref) = self.rir_struct_method_decl(struct_id, symbol)
-            && let InstData::FnDecl { returns_borrow, .. } = &self.rir.rir().get(method_ref).data
+            && let InstData::FnDecl {
+                returns_borrow,
+                returns_inout,
+                ..
+            } = &self.rir.rir().get(method_ref).data
         {
             info.returns_borrow = *returns_borrow;
+            info.returns_inout = *returns_inout;
         }
         let full_symbol = self.member_callable_symbol(struct_id, name, has_self);
         let token = self.endpoint.register_body_owner(
@@ -2721,9 +2723,10 @@ where
                     self_mode: method.self_mode,
                     params,
                     return_type,
-                    // Anonymous-struct methods cannot be accessors (ADR-0062
-                    // phase 1 rejects them at declaration).
+                    // Anonymous-struct methods cannot be place-returning
+                    // accessors; declaration validation rejects that mode.
                     returns_borrow: false,
+                    returns_inout: false,
                 },
             ));
             signatures.push(super::AnonMethodSig {
@@ -2846,9 +2849,10 @@ where
                     struct_type: owner_type,
                     has_self: method.has_self,
                     self_mode: method.self_mode,
-                    // Anonymous-struct methods cannot be accessors (ADR-0062
-                    // phase 1 rejects them at declaration).
+                    // Anonymous-struct methods cannot be place-returning
+                    // accessors; declaration validation rejects that mode.
                     returns_borrow: false,
+                    returns_inout: false,
                     params: self.state.allocate_params(
                         (0..method.parameters.len())
                             .map(|index| intern_synthetic_argument_name(&self.interner, index)),
@@ -4656,6 +4660,7 @@ where
                     info.self_mode,
                     info.self_is_mut,
                     info.returns_borrow,
+                    info.returns_inout,
                 )?,
                 body_span,
             )

--- a/crates/rue-air/src/sema/provider_fixture.rs
+++ b/crates/rue-air/src/sema/provider_fixture.rs
@@ -438,6 +438,8 @@ pub(crate) struct MethodShape {
     pub(crate) has_self: bool,
     pub(crate) self_mode: SemanticParameterMode,
     pub(crate) is_accessor: bool,
+    pub(crate) returns_borrow: bool,
+    pub(crate) returns_inout: bool,
 }
 
 impl Default for MethodShape {
@@ -446,6 +448,8 @@ impl Default for MethodShape {
             has_self: true,
             self_mode: SemanticParameterMode::Value,
             is_accessor: false,
+            returns_borrow: false,
+            returns_inout: false,
         }
     }
 }
@@ -613,6 +617,8 @@ impl ProviderFixture {
                 has_self: shape.has_self,
                 self_mode: shape.self_mode,
                 is_accessor: shape.is_accessor,
+                returns_borrow: shape.returns_borrow,
+                returns_inout: shape.returns_inout,
             },
         );
         key

--- a/crates/rue-air/src/sema/provider_fixture_tests.rs
+++ b/crates/rue-air/src/sema/provider_fixture_tests.rs
@@ -468,6 +468,8 @@ fn provider_accessor_body_analyzes_under_preview_gate() {
             has_self: true,
             self_mode: SemanticParameterMode::Borrow,
             is_accessor: true,
+            returns_borrow: true,
+            returns_inout: false,
         },
     );
     let body = fixture

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -2188,16 +2188,44 @@ impl<'a> CfgBuilder<'a> {
                 // (RUE-62) holds nothing to drop.
                 let air_place = self.air.get_place(*place);
                 let val_ty = self.air.get(*value).ty;
+                let mut old_ty = air_place.base_type;
+                for projection in self.air.get_place_projections(air_place) {
+                    old_ty = match projection {
+                        AirProjection::Field {
+                            struct_id,
+                            field_index,
+                        } => self.type_pool.struct_def(*struct_id).fields[*field_index as usize].ty,
+                        AirProjection::Index { array_type, .. } => {
+                            let (element, _) = self.type_pool.array_def(
+                                array_type.as_array().expect("index projection array type"),
+                            );
+                            element
+                        }
+                    };
+                }
                 let base_key = match air_place.base {
-                    AirPlaceBase::Local(slot) => MovedSlot::Local(slot),
-                    AirPlaceBase::Param(slot) => MovedSlot::Param(slot),
-                    AirPlaceBase::Accessor(_) => {
-                        unreachable!("semantic analysis rejects accessor-place writes")
-                    }
+                    AirPlaceBase::Local(slot) => Some(MovedSlot::Local(slot)),
+                    AirPlaceBase::Param(slot) => Some(MovedSlot::Param(slot)),
+                    // Accessor places are replaced by the mandatory accessor
+                    // CFG splice. Their overwrite drop is elaborated by the
+                    // substituted ordinary place when one exists.
+                    AirPlaceBase::Accessor(_) => None,
                 };
+                if base_key.is_none() && self.type_pool.type_needs_drop(old_ty) {
+                    let old_val = self.emit(
+                        CfgInstData::PlaceRead {
+                            place: cfg_place.duplicate_with_owner(),
+                        },
+                        old_ty,
+                        span,
+                    );
+                    self.emit(CfgInstData::Drop { value: old_val }, Type::UNIT, span);
+                }
                 if air_place.projection_count() == 0 {
-                    self.emit_overwrite_drop(base_key, val_ty, span);
-                } else {
+                    if let Some(base_key) = base_key {
+                        self.emit_overwrite_drop(base_key, val_ty, span);
+                    }
+                } else if let Some(base_key) = base_key {
                     // A single top-level field OR constant-index element write:
                     // skip the old-value drop when that path was definitely
                     // moved out, and guard it with the path's runtime drop flag
@@ -2263,7 +2291,9 @@ impl<'a> CfgBuilder<'a> {
                 } else if let Some(slot) = air_place.as_param() {
                     self.moved.clear_slot(MovedSlot::Param(slot));
                     self.update_drop_flag(MovedSlot::Param(slot), true, span);
-                } else if air_place.projection_count() == 1 {
+                } else if air_place.projection_count() == 1
+                    && let Some(base_key) = base_key
+                {
                     match self.air.get_place_projections(air_place) {
                         [AirProjection::Field { field_index, .. }] => {
                             self.moved.clear_field(base_key, *field_index);

--- a/crates/rue-cfg/src/inline.rs
+++ b/crates/rue-cfg/src/inline.rs
@@ -240,8 +240,10 @@ impl Splice<'_> {
 /// post-optimization contract. Existing caller values keep their indices, and
 /// callee arena value `v` is appended at `caller.value_count() + v`. Drivers
 /// may use that stable offset to discover work introduced by the splice. The
-/// continuation is appended at `caller.block_count()`, followed by callee block
-/// `b` at `caller.block_count() + 1 + b`.
+/// copied callee blocks are appended before the continuation. Keeping the
+/// defining callee blocks before the continuation is significant: lazy backend
+/// materialization of a projected place's index must occur in a dominating
+/// block before a by-reference consumer in the continuation.
 pub fn inline_call(
     caller: &ValidatedCfg,
     call: CfgValue,
@@ -381,11 +383,11 @@ pub fn inline_call_in_block(
     }
 
     // -- Copy the callee arena with uniform shifts. -------------------------
-    let continuation = dst.new_block();
     let block_base = dst.block_count() as u32;
     for _ in 0..callee.block_count() {
         dst.new_block();
     }
+    let continuation = dst.new_block();
     let splice = Splice {
         value_base: dst.value_count() as u32,
         local_base,
@@ -2368,6 +2370,25 @@ mod tests {
         assert!(
             matches!(entry.terminator, Terminator::Goto { .. }),
             "the split call block jumps into the spliced body"
+        );
+        let callee_entry = match &entry.terminator {
+            Terminator::Goto { target, .. } => *target,
+            _ => unreachable!(),
+        };
+        let continuation = inlined
+            .blocks()
+            .iter()
+            .find(|block| {
+                block
+                    .insts
+                    .iter()
+                    .any(|&value| matches!(inlined.get_inst(value).data, CfgInstData::Add(..)))
+            })
+            .expect("the continuation contains the moved post-call computation")
+            .id;
+        assert!(
+            callee_entry.as_u32() < continuation.as_u32(),
+            "spliced callee definitions must precede the continuation so projected-place index dependencies dominate by-ref consumers"
         );
         assert!(
             entry

--- a/crates/rue-cli-tests/cases/borrow_accessors.toml
+++ b/crates/rue-cli-tests/cases/borrow_accessors.toml
@@ -25,6 +25,24 @@ compile_stdout_contains = ["=== Assembly (aarch64-linux) ===", "main:"]
 compile_stdout_not_contains = [".at:"]
 
 [[case]]
+name = "mutable_accessor_inout_forwarding_runtime"
+description = "The real executable path forwards a dynamic-index mutable accessor place at O0."
+files = [{ path = "main.rue", source = """
+struct V {
+    cells: [i64; 2],
+    fn get_mut(inout self, i: u64) -> inout i64 { yield self.cells[i]; }
+}
+fn set(inout x: i64) { x = 42; }
+fn main() -> i32 {
+    let mut v = V { cells: [1, 2] };
+    set(inout v.get_mut(1));
+    if v.cells[1] == 42 { 0 } else { 1 }
+}
+""" }]
+args = ["--preview", "borrow_accessors", "main.rue", "-O0", "-o", "prog"]
+exit_code = 0
+
+[[case]]
 name = "accessor_local_destructor_is_linked_and_runs"
 description = "A destructor required only by a spliced accessor body remains in the caller's codegen dependency closure."
 files = [{ path = "main.rue", source = """
@@ -72,3 +90,166 @@ args = ["--preview", "borrow_accessors", "--emit", "asm", "--target", "x86-64-li
 compile_only = true
 compile_stdout_contains = ["=== Assembly (x86-64-linux) ===", "main:"]
 compile_stdout_not_contains = [".at:"]
+
+[[case]]
+name = "mutable_accessor_requires_preview"
+description = "The mutable place-returning form remains gated when the preview is disabled."
+files = [{ path = "main.rue", source = """
+struct P {
+    x: i64,
+    fn get_mut(inout self) -> inout i64 { yield self.x; }
+}
+fn main() -> i32 {
+    let mut p = P { x: 1 };
+    p.get_mut() = 2;
+    0
+}
+""" }]
+args = ["main.rue"]
+compile_fail = true
+error_contains = ["E1100", "borrow_accessors"]
+
+[[case]]
+name = "mutable_accessor_rejects_live_linear_overwrite"
+description = "Writing a live linear value through an exclusive accessor retains the ordinary overwrite diagnostic."
+files = [{ path = "main.rue", source = """
+linear struct L { value: i32 }
+struct P {
+    x: L,
+    fn get_mut(inout self) -> inout L { yield self.x; }
+}
+fn main() -> i32 {
+    let mut p = P { x: L { value: 1 } };
+    p.get_mut() = L { value: 2 };
+    @drop(p.x);
+    0
+}
+""" }]
+args = ["--preview", "borrow_accessors", "main.rue"]
+compile_fail = true
+error_contains = ["E0493", "overwrite a live linear value"]
+
+[[case]]
+name = "mutable_accessor_overwrite_drops_old_then_new"
+description = "An accessor overwrite drops the old droppable value before storing the RHS, then drops the new value at scope exit."
+files = [{ path = "main.rue", source = """
+struct D { value: i32 }
+drop fn D(self) { @dbg(self.value); }
+struct P {
+    x: D,
+    fn get_mut(inout self) -> inout D { yield self.x; }
+}
+fn main() -> i32 {
+    let mut p = P { x: D { value: 1 } };
+    p.get_mut() = D { value: 2 };
+    0
+}
+""" }]
+args = ["--preview", "borrow_accessors", "main.rue", "-O0", "-o", "prog"]
+stdout = "1\n2\n"
+exit_code = 0
+
+[[case]]
+name = "mutable_accessor_compound_assignment_runtime"
+description = "Compound assignment through a mutable accessor evaluates the target once and stores the updated value."
+files = [{ path = "main.rue", source = """
+struct V {
+    cells: [i64; 2],
+    fn get_mut(inout self, i: u64) -> inout i64 {
+        @dbg(7);
+        yield self.cells[i];
+    }
+}
+fn main() -> i32 {
+    let mut v = V { cells: [1, 2] };
+    v.get_mut(1) += 3;
+    if v.cells[1] == 5 { 0 } else { 1 }
+}
+""" }]
+args = ["--preview", "borrow_accessors", "main.rue", "-O0", "-o", "prog"]
+stdout = "7\n"
+exit_code = 0
+
+[[case]]
+name = "mutable_accessor_assignment_rhs_first"
+description = "A plain accessor assignment evaluates a receiver-using RHS before taking the exclusive target loan."
+files = [{ path = "main.rue", source = """
+struct P {
+    x: i64,
+    y: i64,
+    fn xr(inout self) -> inout i64 { yield self.x; }
+}
+fn bump(inout value: i64) -> i64 { value = value + 1; value }
+fn main() -> i32 {
+    let mut p = P { x: 1, y: 1 };
+    p.xr() = bump(inout p.y);
+    if p.x == 2 && p.y == 2 { 0 } else { 1 }
+}
+""" }]
+args = ["--preview", "borrow_accessors", "main.rue", "-O0", "-o", "prog"]
+exit_code = 0
+
+[[case]]
+name = "mutable_accessor_assignment_rejects_rhs_accessor_conflicts"
+description = "Accessor loans in a plain assignment RHS remain live while the accessor target is evaluated."
+files = [{ path = "main.rue", source = """
+struct P {
+    x: i64,
+    fn xr(inout self) -> inout i64 { yield self.x; }
+    fn rr(borrow self) -> borrow i64 { yield self.x; }
+}
+fn main() -> i32 {
+    let mut p = P { x: 1 };
+    p.xr() = p.xr() + 1;
+    0
+}
+""" }]
+args = ["--preview", "borrow_accessors", "main.rue"]
+compile_fail = true
+error_contains = ["E0259", "another accessor result"]
+
+[[case]]
+name = "mutable_accessor_projected_field_rhs_first_and_compound_once"
+description = "Projected accessor assignments evaluate RHS first and compound targets exactly once."
+files = [{ path = "main.rue", source = """
+struct Cell { value: i64 }
+struct P {
+    cell: Cell,
+    y: i64,
+    fn cell_mut(inout self) -> inout Cell { @dbg(7); yield self.cell; }
+}
+fn bump(inout x: i64) -> i64 { x = x + 1; x }
+fn main() -> i32 {
+    let mut p = P { cell: Cell { value: 1 }, y: 1 };
+    p.cell_mut().value = bump(inout p.y);
+    p.cell_mut().value += 3;
+    if p.cell.value == 5 && p.y == 2 { 0 } else { 1 }
+}
+""" }]
+args = ["--preview", "borrow_accessors", "main.rue", "-O0", "-o", "prog"]
+stdout = "7\n7\n"
+exit_code = 0
+
+[[case]]
+name = "mutable_accessor_projected_index_rhs_first_and_compound_once"
+description = "Index projections above an accessor use RHS-first assignment and one compound accessor evaluation."
+files = [{ path = "main.rue", source = """
+struct A { items: [i64; 2] }
+struct P {
+    a: A,
+    y: i64,
+    fn arr_mut(inout self) -> inout A { @dbg(8); yield self.a; }
+}
+fn bump(inout x: i64) -> i64 { x = x + 1; x }
+fn tap(inout x: u64) -> u64 { @dbg(9); x }
+fn main() -> i32 {
+    let mut p = P { a: A { items: [1, 2] }, y: 1 };
+    p.arr_mut().items[0] = bump(inout p.y);
+    let mut i: u64 = 1;
+    p.arr_mut().items[tap(inout i)] += 3;
+    if p.a.items[0] == 2 && p.a.items[1] == 5 && p.y == 2 { 0 } else { 1 }
+}
+""" }]
+args = ["--preview", "borrow_accessors", "main.rue", "-O0", "-o", "prog"]
+stdout = "8\n8\n9\n"
+exit_code = 0

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -143,7 +143,7 @@ fn the_driver_reads_accessor_declaration_rules_from_the_shared_rule_module() {
     for required in [
         "use rue_air::declaration_validation as rules;",
         "rules::accessor_preview_gate(",
-        "rules::accessor_signature(",
+        "rules::accessor_signature_for_mode(",
         "rules::accessor_body_error(",
         "accessor_method_link_error(",
     ] {

--- a/crates/rue-compiler/src/artifact_views.rs
+++ b/crates/rue-compiler/src/artifact_views.rs
@@ -1131,6 +1131,7 @@ fn statement_record(
                         expr_record(owner, &index.index),
                     ],
                 ),
+                rue_parser::AssignTarget::Method(expr) => expr_record(owner, expr),
             };
             syntax_record(
                 "assignment",
@@ -1632,6 +1633,7 @@ fn rir_kind(data: &rue_rir::InstData) -> &'static str {
         Alloc { .. } => "allocate",
         VarRef { .. } => "variable_reference",
         Assign { .. } => "assignment",
+        PlaceSet { .. } => "place_assignment",
         StructDecl { .. } => "struct_declaration",
         StructInit { .. } => "struct_initializer",
         FieldGet { .. } => "field_read",
@@ -1727,6 +1729,10 @@ fn rir_operands(rir: &rue_rir::Rir, data: &rue_rir::InstData) -> Vec<RirOperandR
         FnDecl { body, .. } | DropFnDecl { body, .. } => push("body", *body),
         ConstDecl { init, .. } | Alloc { init, .. } => push("initializer", *init),
         Assign { value, .. } => push("value", *value),
+        PlaceSet { place, value } => {
+            push("place", *place);
+            push("value", *value);
+        }
         Call { args, .. } => {
             for argument in rir.call_args(args) {
                 push("argument", argument.value);

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -1701,8 +1701,12 @@ pub(crate) fn evaluate_optimized_cfg(
         implicit_destructor_dependencies_complete &=
             callee.implicit_destructor_dependencies_complete;
         let callee_value_base = current.value_count() as u32;
-        let continuation = rue_cfg::BlockId::from_raw(current.block_count() as u32);
-        let callee_block_base = continuation.as_u32() + 1;
+        // `inline_call_in_block` appends copied callee blocks before its
+        // continuation so projected-place definitions dominate continuation
+        // consumers during lazy backend materialization.
+        let callee_block_base = current.block_count() as u32;
+        let continuation =
+            rue_cfg::BlockId::from_raw(callee_block_base + callee_cfg.block_count() as u32);
         let introduced_calls =
             attached_accessor_calls(&callee_cfg, callee_value_base, callee_block_base);
         current = match rue_cfg::inline_call_in_block(

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -2192,6 +2192,7 @@ impl<'a> ParsedBodyProjectionCollector<'a> {
                                 self.visit_expr(&index.base)?;
                                 self.visit_expr(&index.index)?;
                             }
+                            AssignTarget::Method(expr) => self.visit_expr(expr)?,
                         }
                         self.visit_expr(&assignment.value)?;
                     }
@@ -2813,7 +2814,7 @@ fn build_definition_index(
                 is_generic(&function.params)?,
                 function.is_unchecked,
                 false,
-                function.borrow_return.is_some(),
+                function.place_return.is_some(),
                 Arc::from([]),
                 function.span,
                 vec![signature_prefix(function.span, function.body.span())?],
@@ -2876,7 +2877,7 @@ fn build_definition_index(
                         is_generic(&method.params)?,
                         false,
                         false,
-                        method.borrow_return.is_some(),
+                        method.place_return.is_some(),
                         self_call_targets(&method.body)?,
                         method.span,
                         vec![signature_prefix(method.span, method.body.span())?],

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -130,6 +130,7 @@ fn statement_charge(statement: &ast::Statement) -> u64 {
                 ast::AssignTarget::Field(field) => boxed_charge(&field.base, expr_charge),
                 ast::AssignTarget::Index(index) => boxed_charge(&index.base, expr_charge)
                     .saturating_add(boxed_charge(&index.index, expr_charge)),
+                ast::AssignTarget::Method(expr) => expr_charge(expr),
             };
             target.saturating_add(boxed_charge(&statement.value, expr_charge))
         }
@@ -1346,6 +1347,8 @@ impl RetainedCharge for rue_error::ErrorKind {
             | E::InternalError(value)
             | E::InternalCodegenError(value) => value.retained_charge(),
 
+            E::AccessorRequiresBorrowSelf { found } => found.retained_charge(),
+
             E::InvalidArrayLength { reason: value }
             | E::DuplicatePatternBinding { name: value }
             | E::ReservedTypeName { type_name: value }
@@ -1376,7 +1379,6 @@ impl RetainedCharge for rue_error::ErrorKind {
             | E::MoveOutOfInout { variable: value }
             | E::AccessorYieldNotReceiverRooted { found: value }
             | E::AccessorBodyOtherExit { found: value }
-            | E::AccessorRequiresBorrowSelf { found: value }
             | E::AccessorResultMoved { ty: value }
             | E::AccessorLoanConflict {
                 variable: value, ..

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -10730,6 +10730,7 @@ fn resolve_parsed_semantic_signature(
             is_extern,
             is_c_export,
             is_accessor,
+            accessor_result_mode,
             accessor_body,
             accessor_cycle,
             ..
@@ -10769,8 +10770,10 @@ fn resolve_parsed_semantic_signature(
                         }
                     }
                 };
-                if let Some(violation) = rules::accessor_signature(
+                if let Some(violation) = rules::accessor_signature_for_mode(
                     receiver,
+                    *accessor_result_mode
+                        == crate::declaration_candidate::DeclarationParameterMode::Inout,
                     parameters.iter().map(|parameter| {
                         if parameter.is_comptime {
                             return AccessorParameterForm::Comptime;
@@ -11024,6 +11027,11 @@ fn resolve_parsed_semantic_signature(
                     crate::declaration_candidate::DeclarationParameterMode::Inout => M::Inout,
                 },
                 is_accessor: *is_accessor,
+                accessor_result_mode: match accessor_result_mode {
+                    crate::declaration_candidate::DeclarationParameterMode::Value => M::Value,
+                    crate::declaration_candidate::DeclarationParameterMode::Borrow => M::Borrow,
+                    crate::declaration_candidate::DeclarationParameterMode::Inout => M::Inout,
+                },
                 is_unchecked: *is_unchecked,
                 is_extern: *is_extern,
                 is_c_export: *is_c_export,
@@ -22668,6 +22676,7 @@ impl rue_air::DurableCallableSource<crate::StableDefinitionKey, ModuleId>
             has_self,
             self_mode,
             is_accessor,
+            accessor_result_mode,
             ..
         } = signature.signature
         else {
@@ -22688,6 +22697,10 @@ impl rue_air::DurableCallableSource<crate::StableDefinitionKey, ModuleId>
             has_self,
             self_mode,
             is_accessor,
+            returns_borrow: accessor_result_mode
+                == crate::durable_semantics::DurableParameterMode::Borrow,
+            returns_inout: accessor_result_mode
+                == crate::durable_semantics::DurableParameterMode::Inout,
         })
     }
 
@@ -25222,6 +25235,8 @@ pub(crate) mod test_support {
                 has_self: *has_self,
                 self_mode: *self_mode,
                 is_accessor: false,
+                returns_borrow: false,
+                returns_inout: false,
             })
         }
     }
@@ -27378,6 +27393,7 @@ fn main() -> i32 {
                         is_unchecked,
                         is_extern,
                         is_c_export,
+                        ..
                     } = signature
                     else {
                         panic!("free must project a callable signature: {signature:?}")

--- a/crates/rue-compiler/src/semantic_query_nucleus.rs
+++ b/crates/rue-compiler/src/semantic_query_nucleus.rs
@@ -59,6 +59,11 @@ pub(crate) enum ParsedSemanticSignature {
         is_extern: bool,
         is_c_export: bool,
         is_accessor: bool,
+        /// The declared accessor result qualifier. `Value` means no
+        /// place-returning qualifier; it is retained even for invalid
+        /// declarations so all signature producers validate the written
+        /// receiver/result pairing rather than inferring one from the other.
+        accessor_result_mode: crate::declaration_candidate::DeclarationParameterMode,
         /// What the accessor body's own syntax decides about spec 6.6:6 and
         /// 6.6:7, in the producer-neutral vocabulary every accessor producer
         /// shares (RUE-1232). Meaningful only when `is_accessor`; an ordinary
@@ -394,6 +399,7 @@ pub(crate) fn project_semantic_signature(
                     is_extern,
                     is_c_export,
                     is_accessor,
+                    accessor_result_mode,
                     body: Option<&rue_parser::ast::Expr>|
      -> Result<ParsedSemanticSignature, Arc<str>> {
         let mut syntax = rue_rir::RirTypeSyntaxBuilder::default();
@@ -414,6 +420,7 @@ pub(crate) fn project_semantic_signature(
             is_extern,
             is_c_export,
             is_accessor,
+            accessor_result_mode,
             accessor_body: if is_accessor {
                 body.map_or(AccessorBodyVerdict::MissingTrailingYield, |body| {
                     accessor_body_shape(body, resolve, &owner_methods)
@@ -434,7 +441,14 @@ pub(crate) fn project_semantic_signature(
             function.is_unchecked,
             false,
             function.export_abi.is_some(),
-            function.borrow_return.is_some(),
+            function.place_return.is_some(),
+            if function.place_return.is_some_and(|mode| mode.is_inout()) {
+                crate::declaration_candidate::DeclarationParameterMode::Inout
+            } else if function.place_return.is_some_and(|mode| mode.is_borrow()) {
+                crate::declaration_candidate::DeclarationParameterMode::Borrow
+            } else {
+                crate::declaration_candidate::DeclarationParameterMode::Value
+            },
             Some(&function.body),
         ),
         ParsedDeclarationAstRef::ExternFunction { function } => callable(
@@ -446,6 +460,7 @@ pub(crate) fn project_semantic_signature(
             true,
             false,
             false,
+            crate::declaration_candidate::DeclarationParameterMode::Value,
             None,
         ),
         ParsedDeclarationAstRef::Method { method, .. } => callable(
@@ -459,7 +474,14 @@ pub(crate) fn project_semantic_signature(
             false,
             false,
             false,
-            method.borrow_return.is_some(),
+            method.place_return.is_some(),
+            if method.place_return.is_some_and(|mode| mode.is_inout()) {
+                crate::declaration_candidate::DeclarationParameterMode::Inout
+            } else if method.place_return.is_some_and(|mode| mode.is_borrow()) {
+                crate::declaration_candidate::DeclarationParameterMode::Borrow
+            } else {
+                crate::declaration_candidate::DeclarationParameterMode::Value
+            },
             Some(&method.body),
         ),
         ParsedDeclarationAstRef::Struct(structure) => {
@@ -817,6 +839,7 @@ pub(crate) enum DeclarationSignatureProjection {
         has_self: bool,
         self_mode: crate::durable_semantics::DurableParameterMode,
         is_accessor: bool,
+        accessor_result_mode: crate::durable_semantics::DurableParameterMode,
         is_unchecked: bool,
         is_extern: bool,
         is_c_export: bool,
@@ -1077,6 +1100,7 @@ impl DeclarationSemanticValue {
                 has_self,
                 self_mode,
                 is_accessor: _,
+                accessor_result_mode: _,
                 is_unchecked,
                 is_extern: _,
                 is_c_export: _,

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -170,11 +170,8 @@ impl ErrorCode {
     /// A `yield` expression appears outside the body of a `-> borrow T`
     /// accessor. `yield` is the accessor body's exit form (ADR-0062).
     pub const YIELD_OUTSIDE_ACCESSOR: Self = Self(256);
-    /// A `-> borrow T` result on a declaration that is not a `borrow self`
-    /// method: a free function, an associated function, or a method with a
-    /// by-value or `mut self` receiver. Phase 1 accessors are read-only
-    /// projections of a shared receiver borrow (ADR-0062); `inout self`
-    /// accessors are the phase-2 follow-up (RUE-1016).
+    /// An accessor result and receiver use different modes: `-> borrow T`
+    /// requires `borrow self`, while `-> inout T` requires `inout self`.
     pub const ACCESSOR_REQUIRES_BORROW_SELF: Self = Self(257);
     /// A value with drop glue was read out of an accessor result by value.
     /// The result is a borrowed place, not an owner (ADR-0062); copying a
@@ -182,10 +179,9 @@ impl ErrorCode {
     /// same double-free the E0711 gate closes (RUE-651). Only trivially
     /// droppable element values may be read out by value.
     pub const ACCESSOR_RESULT_MOVED: Self = Self(258);
-    /// A root was used exclusively (`inout`, mutation, or move) in the same
-    /// full expression in which an accessor result borrows it. The accessor
-    /// result's shared loan spans the enclosing full expression (ADR-0062),
-    /// so the exclusive use violates the law of exclusivity.
+    /// A root was used incompatibly in the same full expression as an
+    /// accessor result: an exclusive result conflicts with any other loan,
+    /// while a shared result conflicts with an exclusive use (ADR-0062).
     pub const ACCESSOR_LOAN_CONFLICT: Self = Self(259);
     /// An accessor declares a parameter mode other than by-value (`borrow`,
     /// `inout`, or `comptime` on a non-receiver parameter). Phase 1 accessor
@@ -664,10 +660,9 @@ pub enum PreviewFeature {
     /// linking (ADR-0064, RUE-1055). Gated until every phase of the guaranteed
     /// target-C boundary is proven on both backends.
     CFfi,
-    /// Place-returning borrow accessors (ADR-0062, RUE-662): methods with a
-    /// `-> borrow T` result whose `yield`-body hands out a second-class borrow
-    /// of a projection of the receiver. Gated until mutable accessors and std
-    /// adoption complete the rollout (RUE-1015).
+    /// Place-returning accessors (ADR-0062, RUE-662/RUE-1016): methods with a
+    /// `-> borrow T` or `-> inout T` result whose `yield` body hands out a
+    /// second-class projection of the receiver.
     BorrowAccessors,
     /// Floating point: `f32`/`f64`, IEEE-754 arithmetic, and `comptime_float`
     /// literals (ADR-0065, RUE-714). Gated until every phase of the M9 rollout
@@ -1596,11 +1591,10 @@ pub enum ErrorKind {
     #[error("an accessor must yield a place rooted at `self`, not {found}")]
     AccessorYieldNotReceiverRooted { found: String },
     /// A `yield` expression outside an accessor body.
-    #[error("`yield` is only valid inside the body of a `-> borrow` accessor")]
+    #[error("`yield` is only valid inside the body of a `-> borrow` or `-> inout` accessor")]
     YieldOutsideAccessor,
-    /// A `-> borrow T` result on a declaration that is not a `borrow self`
-    /// method.
-    #[error("a `-> borrow` accessor requires a `borrow self` receiver, but this is {found}")]
+    /// An accessor result and receiver use different reference modes.
+    #[error("accessor receiver/result modes do not match: {found}")]
     AccessorRequiresBorrowSelf { found: String },
     /// A drop-glue value read out of an accessor result by value.
     #[error(

--- a/crates/rue-frontend-diff/src/main.rs
+++ b/crates/rue-frontend-diff/src/main.rs
@@ -822,6 +822,7 @@ impl Shapes<'_> {
                     AssignTarget::Var(_) => self.ident(),
                     AssignTarget::Field(e) => self.expr(&Expr::Field(e.clone())),
                     AssignTarget::Index(e) => self.expr(&Expr::Index(e.clone())),
+                    AssignTarget::Method(e) => self.expr(e),
                 },
                 self.expr(&v.value),
                 "_".into(),

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -223,14 +223,29 @@ pub struct Method {
     pub params: Vec<Param>,
     /// Return type (None means implicit unit `()`)
     pub return_type: Option<TypeExpr>,
-    /// When the result position is `-> borrow T`, the span of the `borrow`
-    /// keyword: the method is a place-returning accessor (ADR-0062) whose
-    /// body yields a second-class borrow of a receiver projection.
-    pub borrow_return: Option<Span>,
+    /// The optional place-returning qualifier and its keyword span.
+    pub place_return: Option<PlaceReturn>,
     /// Method body
     pub body: Expr,
     /// Span covering the entire method
     pub span: Span,
+}
+
+/// A place-returning function result qualifier (ADR-0062).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlaceReturn {
+    Borrow(Span),
+    Inout(Span),
+}
+
+impl PlaceReturn {
+    pub fn is_borrow(self) -> bool {
+        matches!(self, Self::Borrow(_))
+    }
+
+    pub fn is_inout(self) -> bool {
+        matches!(self, Self::Inout(_))
+    }
 }
 
 /// A self parameter in a method.
@@ -278,11 +293,9 @@ pub struct Function {
     pub params: Vec<Param>,
     /// Return type (None means implicit unit `()`)
     pub return_type: Option<TypeExpr>,
-    /// When the result position is `-> borrow T`, the span of the `borrow`
-    /// keyword (ADR-0062). Always rejected in sema for free functions —
-    /// accessors require a `borrow self` receiver — but parsed here so the
-    /// diagnostic can be semantic rather than a parse error.
-    pub borrow_return: Option<Span>,
+    /// The optional place-returning qualifier and its keyword span. Free
+    /// functions retain the syntax so sema can diagnose the missing receiver.
+    pub place_return: Option<PlaceReturn>,
     /// Function body
     pub body: Expr,
     /// The C ABI string when this function is a `pub extern "C" fn` export
@@ -1230,6 +1243,8 @@ pub enum AssignTarget {
     Field(FieldExpr),
     /// Index assignment (e.g., `arr[0] = 5`)
     Index(IndexExpr),
+    /// Direct assignment to a place-returning accessor result.
+    Method(Box<Expr>),
 }
 
 /// A while loop expression.
@@ -1400,6 +1415,7 @@ impl Expr {
                             AssignTarget::Index(index) => {
                                 out.extend([index.base.as_ref(), index.index.as_ref()])
                             }
+                            AssignTarget::Method(expr) => out.push(expr),
                         }
                         out.push(&assignment.value);
                     }
@@ -1916,6 +1932,7 @@ fn rebind_statement(statement: &mut Statement, file_id: FileId) {
                     rebind_expr(&mut index.index, file_id);
                     rebind_span(&mut index.span, file_id);
                 }
+                AssignTarget::Method(expr) => rebind_expr(expr, file_id),
             }
             rebind_expr(&mut assignment.value, file_id);
             rebind_span(&mut assignment.span, file_id);
@@ -2371,6 +2388,10 @@ fn fmt_stmt(f: &mut fmt::Formatter<'_>, stmt: &Statement, level: usize) -> fmt::
                     indent(f, level + 1)?;
                     writeln!(f, "Index:")?;
                     fmt_expr(f, &index.index, level + 2)?;
+                }
+                AssignTarget::Method(expr) => {
+                    writeln!(f, "Assign {}method", op)?;
+                    fmt_expr(f, expr, level + 1)?;
                 }
             }
             fmt_expr(f, &assign.value, level + 1)

--- a/crates/rue-parser/src/parser/declarations.rs
+++ b/crates/rue-parser/src/parser/declarations.rs
@@ -121,7 +121,7 @@ impl Parser {
         self.expect(TokenKind::Fn)?;
         let name = self.ident()?;
         let params = self.params()?;
-        let (return_type, borrow_return) = self.return_type_with_borrow()?;
+        let (return_type, place_return) = self.return_type_with_place_mode()?;
         let body = Expr::Block(self.block()?);
         Ok(Function {
             directives,
@@ -130,26 +130,30 @@ impl Parser {
             name,
             params,
             return_type,
-            borrow_return,
+            place_return,
             body,
             export_abi,
             span: self.span_from(start),
         })
     }
 
-    /// Parse an optional `-> [borrow] type` result position. A leading
-    /// `borrow` marks a place-returning accessor (ADR-0062); the keyword's
-    /// span is carried so semantic analysis can gate and diagnose the form.
-    pub(super) fn return_type_with_borrow(&mut self) -> PResult<(Option<TypeExpr>, Option<Span>)> {
+    /// Parse an optional `-> [borrow|inout] type` result position. The
+    /// qualifier and its span are retained so semantic analysis can gate and
+    /// diagnose place-returning accessors (ADR-0062).
+    pub(super) fn return_type_with_place_mode(
+        &mut self,
+    ) -> PResult<(Option<TypeExpr>, Option<PlaceReturn>)> {
         if !self.eat(TokenKind::Arrow) {
             return Ok((None, None));
         }
-        let borrow_return = if self.at(TokenKind::Borrow) {
-            Some(self.bump().span)
+        let place_return = if self.at(TokenKind::Borrow) {
+            Some(PlaceReturn::Borrow(self.bump().span))
+        } else if self.at(TokenKind::Inout) {
+            Some(PlaceReturn::Inout(self.bump().span))
         } else {
             None
         };
-        Ok((Some(self.ty()?), borrow_return))
+        Ok((Some(self.ty()?), place_return))
     }
 
     /// Parse a foreign-declaration block: `extern "C" { fn name(...) -> T; }`.

--- a/crates/rue-parser/src/parser/statements.rs
+++ b/crates/rue-parser/src/parser/statements.rs
@@ -530,10 +530,14 @@ impl Parser {
 }
 
 fn expr_to_target(expr: Expr, self_value: Spur) -> Option<AssignTarget> {
+    if contains_method_call(&expr) {
+        return Some(AssignTarget::Method(Box::new(expr)));
+    }
     match expr {
         Expr::Ident(id) => Some(AssignTarget::Var(id)),
         Expr::Field(field) => Some(AssignTarget::Field(field)),
         Expr::Index(index) => Some(AssignTarget::Index(index)),
+        Expr::MethodCall(call) => Some(AssignTarget::Method(Box::new(Expr::MethodCall(call)))),
         // `self = value` targets the receiver binding; sema enforces that
         // only a `mut self` (or shadowing `let mut`) receiver is assignable.
         Expr::SelfExpr(se) => Some(AssignTarget::Var(Ident {
@@ -541,6 +545,16 @@ fn expr_to_target(expr: Expr, self_value: Spur) -> Option<AssignTarget> {
             span: se.span,
         })),
         _ => None,
+    }
+}
+
+fn contains_method_call(expr: &Expr) -> bool {
+    match expr {
+        Expr::MethodCall(_) => true,
+        Expr::Field(field) => contains_method_call(&field.base),
+        Expr::Index(index) => contains_method_call(&index.base),
+        Expr::Paren(paren) => contains_method_call(&paren.inner),
+        _ => false,
     }
 }
 fn is_control_flow(expr: &Expr) -> bool {

--- a/crates/rue-parser/src/parser/types.rs
+++ b/crates/rue-parser/src/parser/types.rs
@@ -289,7 +289,7 @@ impl Parser {
             }
         }
         self.expect(TokenKind::RParen)?;
-        let (return_type, borrow_return) = self.return_type_with_borrow()?;
+        let (return_type, place_return) = self.return_type_with_place_mode()?;
         let body = Expr::Block(self.block()?);
         Ok(Method {
             directives,
@@ -297,7 +297,7 @@ impl Parser {
             receiver,
             params,
             return_type,
-            borrow_return,
+            place_return,
             body,
             span: self.span_from(start),
         })
@@ -325,7 +325,7 @@ impl Parser {
             }),
             params: Vec::new(),
             return_type: None,
-            borrow_return: None,
+            place_return: None,
             body,
             span,
         })

--- a/crates/rue-rir/src/anonymous_sites.rs
+++ b/crates/rue-rir/src/anonymous_sites.rs
@@ -119,6 +119,9 @@ impl SiteWalker {
                         self.at(Seg::Operand(1), |this| this.walk_expr(&index.base));
                         self.at(Seg::Operand(2), |this| this.walk_expr(&index.index));
                     }
+                    AssignTarget::Method(expr) => {
+                        self.at(Seg::Operand(1), |this| this.walk_expr(expr));
+                    }
                 }
             }
             // A bare expression statement is lowered by `gen_expr` with no extra

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -748,7 +748,7 @@ impl<'a> AstGen<'a> {
         // Methods cannot be marked unchecked (that's a function-level modifier).
         let decl = self
             .rir
-            .add_fn_decl(
+            .add_fn_decl_with_return_modes(
                 &directives,
                 false,
                 false,
@@ -762,7 +762,8 @@ impl<'a> AstGen<'a> {
                 has_self,
                 self_mode,
                 self_is_mut,
-                method.borrow_return.is_some(),
+                method.place_return.is_some_and(|mode| mode.is_borrow()),
+                method.place_return.is_some_and(|mode| mode.is_inout()),
                 method.span,
             )
             .record_failure(&mut self.payload_error);
@@ -857,7 +858,7 @@ impl<'a> AstGen<'a> {
         // Regular functions don't have a self receiver
         let decl = self
             .rir
-            .add_fn_decl(
+            .add_fn_decl_with_return_modes(
                 &directives,
                 func.visibility == Visibility::Public,
                 func.is_unchecked,
@@ -871,7 +872,8 @@ impl<'a> AstGen<'a> {
                 false,
                 RirParamMode::Normal,
                 false,
-                func.borrow_return.is_some(),
+                func.place_return.is_some_and(|mode| mode.is_borrow()),
+                func.place_return.is_some_and(|mode| mode.is_inout()),
                 func.span,
             )
             .record_failure(&mut self.payload_error);
@@ -2064,6 +2066,14 @@ impl<'a> AstGen<'a> {
                             span: assign.span,
                         })
                     }
+                    AssignTarget::Method(expr) => {
+                        let base =
+                            self.gen_expr_at(crate::RirStructuralPathSegment::Operand(1), expr);
+                        self.rir.add_inst(Inst {
+                            data: InstData::PlaceSet { place: base, value },
+                            span: assign.span,
+                        })
+                    }
                 }
             }
             Statement::Expr(expr) => {
@@ -2147,6 +2157,10 @@ impl<'a> AstGen<'a> {
                 });
                 CompoundPlace::Projected { root, steps }
             }
+            AssignTarget::Method(expr) => CompoundPlace::Accessor(self.gen_expr_at(
+                crate::RirStructuralPathSegment::Operand(COMPOUND_ROOT_SEGMENT),
+                expr,
+            )),
         }
     }
 
@@ -2240,6 +2254,7 @@ impl<'a> AstGen<'a> {
                     let base = this.gen_place_root(root);
                     this.gen_place_projections(base, steps)
                 }
+                CompoundPlace::Accessor(place) => *place,
             },
         )
     }
@@ -2282,6 +2297,13 @@ impl<'a> AstGen<'a> {
                 );
                 self.rir.add_inst(Inst { data, span })
             }
+            CompoundPlace::Accessor(place) => self.rir.add_inst(Inst {
+                data: InstData::PlaceSet {
+                    place: *place,
+                    value,
+                },
+                span,
+            }),
         }
     }
 
@@ -2366,6 +2388,9 @@ enum CompoundPlace<'t> {
         root: CompoundRoot<'t>,
         steps: Vec<CompoundStep<'t>>,
     },
+    /// An accessor result is already a yielded place; evaluate it once and
+    /// reuse that value for the read and the typed place write.
+    Accessor(InstRef),
 }
 
 /// The base a projected place bottoms out in.

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -1395,6 +1395,44 @@ impl RirEditor {
         returns_borrow: bool,
         span: Span,
     ) -> Result<InstRef, RirPayloadBuildError> {
+        self.add_fn_decl_with_return_modes(
+            directives,
+            is_pub,
+            is_unchecked,
+            is_extern,
+            is_c_export,
+            name,
+            params,
+            return_type,
+            body,
+            has_self,
+            self_mode,
+            self_is_mut,
+            returns_borrow,
+            false,
+            span,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_fn_decl_with_return_modes(
+        &mut self,
+        directives: &[RirDirective],
+        is_pub: bool,
+        is_unchecked: bool,
+        is_extern: bool,
+        is_c_export: bool,
+        name: Spur,
+        params: &[RirParam],
+        return_type: RirTypeSyntaxRef,
+        body: InstRef,
+        has_self: bool,
+        self_mode: RirParamMode,
+        self_is_mut: bool,
+        returns_borrow: bool,
+        returns_inout: bool,
+        span: Span,
+    ) -> Result<InstRef, RirPayloadBuildError> {
         self.atomic(|rir| {
             let directives = rir.add_directives(directives)?;
             let params = rir.add_params(params)?;
@@ -1413,6 +1451,7 @@ impl RirEditor {
                     self_mode,
                     self_is_mut,
                     returns_borrow,
+                    returns_inout,
                 },
                 span,
             }))
@@ -2102,6 +2141,7 @@ impl RirEditor {
                         self_mode,
                         self_is_mut,
                         returns_borrow,
+                        returns_inout,
                     } => {
                         let directives = source
                             .directives(directives)
@@ -2134,7 +2174,7 @@ impl RirEditor {
                                 })
                             })
                             .collect::<Result<Vec<_>, RirSpanRemapError<E>>>()?;
-                        self.add_fn_decl(
+                        self.add_fn_decl_with_return_modes(
                             &directives,
                             *is_pub,
                             *is_unchecked,
@@ -2148,6 +2188,7 @@ impl RirEditor {
                             *self_mode,
                             *self_is_mut,
                             *returns_borrow,
+                            *returns_inout,
                             span,
                         )?
                     }
@@ -2270,6 +2311,12 @@ impl RirEditor {
                     InstData::Assign { name, value } => {
                         self.add_inst(payload_free(InstData::Assign {
                             name: symbol(*name),
+                            value: remap_ref(*value),
+                        }))
+                    }
+                    InstData::PlaceSet { place, value } => {
+                        self.add_inst(payload_free(InstData::PlaceSet {
+                            place: remap_ref(*place),
                             value: remap_ref(*value),
                         }))
                     }
@@ -3813,6 +3860,10 @@ impl Rir {
                     symbols!(*name);
                     refs!(*value);
                 }
+                InstData::PlaceSet { place, value } => {
+                    refs!(*place);
+                    refs!(*value);
+                }
                 InstData::StructDecl {
                     directives,
                     name,
@@ -4048,6 +4099,7 @@ impl Rir {
             }
             InstData::Block { instructions } => out.extend(self.block_insts(instructions).values()),
             InstData::Assign { value, .. } => out.push(*value),
+            InstData::PlaceSet { place, value } => out.extend([*place, *value]),
             InstData::StructDecl { methods, .. } => {
                 out.extend(self.struct_methods(methods).values())
             }
@@ -5372,6 +5424,8 @@ pub enum InstData {
         /// second-class borrow of a receiver projection. `return_type` holds
         /// the borrowed element type `T`.
         returns_borrow: bool,
+        /// Whether the result position is `-> inout T` (ADR-0062 phase 2).
+        returns_inout: bool,
     },
 
     /// Constant declaration
@@ -5491,6 +5545,11 @@ pub enum InstData {
         /// Value to store
         value: InstRef,
     },
+
+    /// Assignment to an expression that produces a place (currently a
+    /// mutable accessor result). Kept distinct from field/index assignment so
+    /// source field names cannot collide with compiler-generated syntax.
+    PlaceSet { place: InstRef, value: InstRef },
 
     // Struct operations
     /// Struct type declaration
@@ -6129,6 +6188,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     self_mode,
                     self_is_mut,
                     returns_borrow,
+                    returns_inout,
                 } => {
                     let pub_str = if *is_c_export {
                         "pub extern \"C\" "
@@ -6176,7 +6236,13 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         })
                         .collect();
                     let directives_str = self.format_directives(directives);
-                    let borrow_str = if *returns_borrow { "borrow " } else { "" };
+                    let borrow_str = if *returns_borrow {
+                        "borrow "
+                    } else if *returns_inout {
+                        "inout "
+                    } else {
+                        ""
+                    };
                     writeln!(
                         out,
                         "{}{}{}fn {}({}{}) -> {}{} {{",
@@ -6307,6 +6373,15 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         out,
                         "assign {} = {}",
                         self.interner.resolve(&*name),
+                        self.display_ref(*value)
+                    )
+                    .unwrap();
+                }
+                InstData::PlaceSet { place, value } => {
+                    writeln!(
+                        out,
+                        "place_set {} = {}",
+                        self.display_ref(*place),
                         self.display_ref(*value)
                     )
                     .unwrap();
@@ -8619,6 +8694,7 @@ mod typed_payload_tests {
                 self_mode: RirParamMode::Normal,
                 self_is_mut: false,
                 returns_borrow: false,
+                returns_inout: false,
             },
         );
 

--- a/crates/rue-rir/src/inst/packed.rs
+++ b/crates/rue-rir/src/inst/packed.rs
@@ -18,7 +18,7 @@ use crate::{RirTypeSyntaxNode, RirTypeSyntaxRange, RirTypeSyntaxSymbol};
 use super::*;
 
 const MAGIC: &[u8; 4] = b"RIRP";
-const VERSION: u8 = 3;
+const VERSION: u8 = 4;
 const HEADER_LEN: usize = 64;
 
 /// One fallible source intrinsic whose result requires a trusted `Option`
@@ -1407,6 +1407,7 @@ impl<E, C: FnMut() -> Result<(), E>, P: FnMut(RirSpanSlot, Span) -> Result<(u32,
                 self_mode,
                 self_is_mut,
                 returns_borrow,
+                returns_inout,
             } => {
                 self.byte(33)?;
                 self.directives(rir, instruction, directives, |ordinal| {
@@ -1419,7 +1420,8 @@ impl<E, C: FnMut() -> Result<(), E>, P: FnMut(RirSpanSlot, Span) -> Result<(u32,
                         | ((*is_c_export as u8) << 3)
                         | ((*has_self as u8) << 4)
                         | ((*self_is_mut as u8) << 5)
-                        | ((*returns_borrow as u8) << 6),
+                        | ((*returns_borrow as u8) << 6)
+                        | ((*returns_inout as u8) << 7),
                 )?;
                 self.symbol(*name)?;
                 let params = rir.params(params);
@@ -1524,6 +1526,11 @@ impl<E, C: FnMut() -> Result<(), E>, P: FnMut(RirSpanSlot, Span) -> Result<(u32,
             InstData::Assign { name, value } => {
                 self.byte(45)?;
                 self.symbol(*name)?;
+                self.reference(*value)?;
+            }
+            InstData::PlaceSet { place, value } => {
+                self.byte(63)?;
+                self.reference(*place)?;
                 self.reference(*value)?;
             }
             InstData::StructDecl {
@@ -2807,13 +2814,6 @@ impl<
                     RirSpanField::FunctionDirective { directive }
                 })?;
                 let flags = reader.byte()?;
-                if flags & !0x7f != 0 {
-                    return Err(PackedRirDecodeError::InvalidTag {
-                        family: "function flags",
-                        tag: flags,
-                    }
-                    .into());
-                }
                 let name = self.symbol(reader)?;
                 let count = Self::count(reader, "parameters", 4)?;
                 let mut params = Vec::new();
@@ -2844,7 +2844,7 @@ impl<
                 let return_type = self.type_reference(reader)?;
                 let body = self.reference(reader)?;
                 let self_mode = decode_param_mode(reader.byte()?)?;
-                self.destination.add_fn_decl(
+                self.destination.add_fn_decl_with_return_modes(
                     &directives,
                     flags & 1 != 0,
                     flags & 2 != 0,
@@ -2858,8 +2858,14 @@ impl<
                     self_mode,
                     flags & 32 != 0,
                     flags & 64 != 0,
+                    flags & 128 != 0,
                     span,
                 )?
+            }
+            63 => {
+                let place = self.reference(reader)?;
+                let value = self.reference(reader)?;
+                add!(InstData::PlaceSet { place, value })
             }
             34 => {
                 let directives = self.directives(reader, basis, |directive| {

--- a/crates/rue-rir/src/type_syntax.rs
+++ b/crates/rue-rir/src/type_syntax.rs
@@ -569,10 +569,10 @@ impl<S> RirTypeSyntaxArena<S> {
                                 "anonymous receiver mode is invalid",
                             ));
                         }
-                        if header[2] > 1 {
+                        if header[2] > 2 {
                             return Err(invalid(
                                 Some(owner_ref),
-                                "anonymous borrow-return flag is invalid",
+                                "anonymous accessor result mode is invalid",
                             ));
                         }
                         position += 4;
@@ -766,7 +766,19 @@ impl<S: Clone + Eq + Hash> RirTypeSyntaxBuilder<S> {
                         .as_ref()
                         .map_or(u32::MAX, |receiver| stable_param_mode(receiver.mode));
                     method_words.push(receiver);
-                    method_words.push(u32::from(method.borrow_return.is_some()));
+                    // Anonymous methods use the existing result-mode header
+                    // word: 0 = by-value, 1 = borrow, 2 = inout. Keeping the
+                    // mode in the type-syntax carrier makes invalid anonymous
+                    // mutable accessors visible to the same declaration seam.
+                    method_words.push(
+                        if method.place_return.is_some_and(|mode| mode.is_borrow()) {
+                            1
+                        } else if method.place_return.is_some_and(|mode| mode.is_inout()) {
+                            2
+                        } else {
+                            0
+                        },
+                    );
                     method_words.push(
                         u32::try_from(method.params.len())
                             .map_err(|_| RirTypeSyntaxBuildError::TooMuchPayload)?,

--- a/crates/rue-spec/cases/items/borrow-accessors.toml
+++ b/crates/rue-spec/cases/items/borrow-accessors.toml
@@ -1,7 +1,8 @@
-# Borrow accessors (ADR-0062 phases 0-1, RUE-662), behind the
+# Borrow accessors (ADR-0062 phases 0-2, RUE-662), behind the
 # `borrow_accessors` preview.
 #
-# Accessor calls survive semantic analysis as marked place-producing calls.
+# Shared and exclusive accessor calls survive semantic analysis as marked
+# place-producing calls.
 # The optimized-CFG query observes the exact accessor CFG dependencies and
 # mandatorily splices their guards and yielded place before code generation.
 
@@ -9,7 +10,7 @@
 id = "items.borrow-accessors"
 spec_chapter = "6.6"
 name = "Borrow Accessors"
-description = "Place-returning read accessors: `fn (borrow self, ...) -> borrow T` with a trailing-yield body (ADR-0062)."
+description = "Place-returning shared and exclusive accessors with trailing-yield bodies (ADR-0062 phases 0-2)."
 
 [[case]]
 name = "accessor_declaration_parses_and_compiles"
@@ -32,6 +33,50 @@ struct Grid {
 fn main() -> i32 {
     let g = Grid { cells: [1, 2, 3, 4] };
     if g.cells[0] == 1 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "mutable_accessor_assignment_rejects_accessor_rhs"
+spec = ["5.2:14", "6.6:16"]
+description = "A plain assignment retains accessor loans from its RHS while evaluating the target."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct P {
+    x: i64,
+    fn xr(inout self) -> inout i64 { yield self.x; }
+    fn rr(borrow self) -> borrow i64 { yield self.x; }
+}
+fn main() -> i32 {
+    let mut p = P { x: 1 };
+    p.xr() = p.rr() + 1;
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0259", "another accessor result"]
+
+[[case]]
+name = "mutable_accessor_projected_field_assignment_order"
+spec = ["5.2:14", "5.2:17", "5.2:18", "6.6:15"]
+description = "A projected exclusive accessor place evaluates a receiver-using RHS first and compounds once."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct Cell { value: i64 }
+struct P {
+    cell: Cell,
+    y: i64,
+    fn cell_mut(inout self) -> inout Cell { yield self.cell; }
+}
+fn bump(inout x: i64) -> i64 { x = x + 1; x }
+fn main() -> i32 {
+    let mut p = P { cell: Cell { value: 1 }, y: 1 };
+    p.cell_mut().value = bump(inout p.y);
+    p.cell_mut().value += 3;
+    if p.cell.value == 5 && p.y == 2 { 0 } else { 1 }
 }
 """
 exit_code = 0
@@ -247,7 +292,7 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = ["E0257", "requires a `borrow self` receiver", "mutable accessors"]
+error_contains = ["E0257", "requires a `borrow self` receiver"]
 
 [[case]]
 name = "free_function_accessor_is_rejected"
@@ -340,7 +385,7 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = ["E0256", "only valid inside the body of a `-> borrow` accessor"]
+error_contains = ["E0256", "only valid inside the body of a `-> borrow` or `-> inout` accessor"]
 
 [[case]]
 name = "accessor_yield_must_root_at_receiver"
@@ -415,7 +460,7 @@ struct P {
 fn main() -> i32 { 0 }
 """
 compile_fail = true
-error_contains = ["E0257", "requires a `borrow self` receiver", "mutable accessors"]
+error_contains = ["E0257", "requires a `borrow self` receiver"]
 
 [[case]]
 name = "uncalled_associated_function_accessor_is_rejected"
@@ -926,3 +971,170 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = ["E0258"]
+
+[[case]]
+name = "mutable_accessor_direct_and_projected_assignment"
+spec = ["6.6:15"]
+description = "An exclusive accessor result is a writable place, including projected writes."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct Cell { value: i64 }
+struct V {
+    cells: [Cell; 2],
+    fn get_mut(inout self, i: u64) -> inout Cell { yield self.cells[i]; }
+}
+fn main() -> i32 {
+    let mut v = V { cells: [Cell { value: 1 }, Cell { value: 2 }] };
+    v.get_mut(0) = Cell { value: 7 };
+    v.get_mut(1).value = 8;
+    if v.cells[0].value == 7 && v.cells[1].value == 8 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "mutable_accessor_inout_forwarding"
+spec = ["6.6:15"]
+description = "An exclusive accessor result can be forwarded as an inout place."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct V {
+    cells: [i64; 2],
+    fn get_mut(inout self, i: u64) -> inout i64 { yield self.cells[i]; }
+}
+fn set(inout x: i64) { x = 9; }
+fn main() -> i32 {
+    let mut v = V { cells: [1, 2] };
+    set(inout v.get_mut(1));
+    if v.cells[1] == 9 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "mutable_accessor_exclusive_conflicts_are_symmetric"
+spec = ["6.6:16"]
+description = "Two exclusive results rooted at one receiver conflict regardless of evaluation order."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct V {
+    cells: [i64; 2],
+    fn get_mut(inout self, i: u64) -> inout i64 { yield self.cells[i]; }
+}
+fn use_two(inout a: i64, inout b: i64) { a = b; }
+fn main() -> i32 {
+    let mut v = V { cells: [1, 2] };
+    use_two(inout v.get_mut(0), inout v.get_mut(1));
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0426", "same variable"]
+
+[[case]]
+name = "mutable_and_shared_accessor_conflict_mutable_first"
+spec = ["6.6:16"]
+description = "An exclusive accessor conflicts with a shared accessor rooted at the same receiver."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct V {
+    cells: [i64; 2],
+    fn get_ref(borrow self, i: u64) -> borrow i64 { yield self.cells[i]; }
+    fn get_mut(inout self, i: u64) -> inout i64 { yield self.cells[i]; }
+}
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let mut v = V { cells: [1, 2] };
+    use_two(v.get_mut(0), v.get_ref(1));
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0259", "accessor"]
+
+[[case]]
+name = "mutable_accessor_conflicts_with_ordinary_read_mutable_first"
+spec = ["6.6:16"]
+description = "An exclusive accessor conflicts with an ordinary shared read of the same root."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct V {
+    cells: [i64; 2],
+    fn get_mut(inout self, i: u64) -> inout i64 { yield self.cells[i]; }
+}
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let mut v = V { cells: [1, 2] };
+    use_two(v.get_mut(0), v.cells[1]);
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0259", "shared read"]
+
+[[case]]
+name = "mutable_accessor_conflicts_with_ordinary_read_shared_first"
+spec = ["6.6:16"]
+description = "The ordinary-read-then-exclusive evaluation order is rejected symmetrically."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct V {
+    cells: [i64; 2],
+    fn get_mut(inout self, i: u64) -> inout i64 { yield self.cells[i]; }
+}
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let mut v = V { cells: [1, 2] };
+    use_two(v.cells[1], v.get_mut(0));
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0259", "shared read"]
+
+[[case]]
+name = "mutable_accessor_projected_read_is_legal"
+spec = ["6.6:15"]
+description = "Reading a projection of an exclusive accessor result remains a read of its yielded place."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct Cell { value: i64 }
+struct V {
+    cells: [Cell; 1],
+    fn get_mut(inout self, i: u64) -> inout Cell { yield self.cells[i]; }
+}
+fn main() -> i32 {
+    let mut v = V { cells: [Cell { value: 7 }] };
+    if v.get_mut(0).value == 7 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "mutable_and_shared_accessor_conflict_shared_first"
+spec = ["6.6:16"]
+description = "The shared-then-exclusive evaluation order is rejected symmetrically."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct V {
+    cells: [i64; 2],
+    fn get_ref(borrow self, i: u64) -> borrow i64 { yield self.cells[i]; }
+    fn get_mut(inout self, i: u64) -> inout i64 { yield self.cells[i]; }
+}
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let mut v = V { cells: [1, 2] };
+    use_two(v.get_ref(0), v.get_mut(1));
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0259", "accessor"]

--- a/crates/rue-ui-tests/cases/diagnostics/borrow-accessors.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/borrow-accessors.toml
@@ -65,3 +65,96 @@ fn main() -> i32 { 0 }
 preview = "borrow_accessors"
 compile_fail = true
 error_contains = ["E0255", "place rooted at `self`", "`other`"]
+
+[[case]]
+name = "mutable_accessor_requires_exact_receiver_pair"
+description = "Mutable accessor diagnostics identify the required inout self/result pairing."
+source = """
+struct P {
+    x: i64,
+
+    @allow(unused_function)
+    fn xr(borrow self) -> inout i64 {
+        yield self.x;
+    }
+}
+fn main() -> i32 { 0 }
+"""
+preview = "borrow_accessors"
+compile_fail = true
+error_contains = ["E0257", "inout self", "-> inout"]
+
+[[case]]
+name = "mutable_accessor_rejects_immutable_receiver"
+description = "An exclusive accessor cannot be called through an immutable binding."
+source = """
+struct P {
+    x: i64,
+    fn xr(inout self) -> inout i64 { yield self.x; }
+}
+fn main() -> i32 {
+    let p = P { x: 1 };
+    p.xr() = 2;
+    0
+}
+"""
+preview = "borrow_accessors"
+compile_fail = true
+error_contains = ["E0203"]
+
+[[case]]
+name = "mutable_accessor_result_cannot_escape"
+description = "An exclusive accessor result remains expression-scoped and cannot be returned."
+source = """
+struct P {
+    x: i64,
+    fn xr(inout self) -> inout i64 { yield self.x; }
+}
+fn read(inout p: P) -> i64 {
+    return p.xr();
+}
+fn main() -> i32 {
+    let mut p = P { x: 1 };
+    read(inout p);
+    0
+}
+"""
+preview = "borrow_accessors"
+compile_fail = true
+error_contains = ["E0250", "cannot return an accessor result"]
+
+[[case]]
+name = "mutable_accessor_double_value_use_conflicts"
+description = "Two exclusive accessor results rooted at one receiver conflict in ordinary value position."
+source = """
+struct V {
+    cells: [i64; 2],
+    fn get_mut(inout self, i: u64) -> inout i64 { yield self.cells[i]; }
+}
+fn main() -> i32 {
+    let mut v = V { cells: [1, 2] };
+    let _ = v.get_mut(0) + v.get_mut(1);
+    0
+}
+"""
+preview = "borrow_accessors"
+compile_fail = true
+error_contains = ["E0259", "accessor result"]
+
+[[case]]
+name = "mutable_accessor_invalid_body"
+description = "An exclusive accessor body must yield exactly one place rooted at self."
+source = """
+struct P {
+    x: i64,
+    fn xr(inout self) -> inout i64 {
+        self.x = 2;
+        yield self.x;
+        yield self.x;
+    }
+}
+fn main() -> i32 { 0 }
+"""
+preview = "borrow_accessors"
+compile_fail = true
+error_contains = ["E0254", "second `yield`"]

--- a/docs/designs/0062-place-returning-borrow-accessors.md
+++ b/docs/designs/0062-place-returning-borrow-accessors.md
@@ -95,7 +95,7 @@ projection of its borrowed receiver. Phase 1 is read-only:
 
 ```rue
 // Phase 1 (shared):    receiver borrow self  →  shared result borrow
-// Phase 2 (exclusive): receiver inout  self  →  exclusive result borrow
+// Phase 2 (exclusive): receiver inout self  →  exclusive result inout
 fn get_ref(borrow self, i: u64) -> borrow T { … }
 ```
 
@@ -256,12 +256,12 @@ sugar can still be layered on top later without disturbing this choice.)
 
 Tracked in Linear under the RUE-1015 epic:
 
-- [ ] **Phase 0: Ratify syntax; spec + grammar + preview gate scaffolding** — RUE-662
-- [ ] **Phase 1: Read accessors** (`borrow self` → shared result; parser,
+- [x] **Phase 0: Ratify syntax; spec + grammar + preview gate scaffolding** — RUE-662
+- [x] **Phase 1: Read accessors** (`borrow self` → shared result; parser,
       sema/AIR loan checking, mandatory inlining, formal-core amendment,
       spec coverage) — RUE-662
-- [ ] **Phase 2: Mutable accessors** (`inout self` → exclusive result;
-      assignment through the result) — RUE-1016 (blocked by RUE-662)
+- [x] **Phase 2: Mutable accessors** (`inout self` → exclusive result;
+      assignment through the result) — RUE-1016
 - [ ] **Phase 3: std adoption** (`ArrayBuf.get_ref` + E0711 diagnostic
       pointing at it; grid/deque/intmap accessors; owned-children tree
       example replacing an arena) — RUE-1017 (blocked by RUE-662)

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -983,29 +983,31 @@ carries only the moves performed by the by-value arguments. Because the core is
 fully monomorphic (§1), `g` names a single concrete signature: there is no
 overload or generic instantiation to resolve at the call.
 
-**Accessor calls (ADR-0062, preview).** A *read accessor* is a method of the
-form
+**Accessor calls (ADR-0062, preview).** An accessor is a method of the form
 
 ```
-  A.f : fn ( borrow self : A, x1:T1, ..., xk:Tk ) -> borrow T { e_guard ; yield p_y }
+  A.f : fn ( self_mode self : A, x1:T1, ..., xk:Tk ) -> result_mode T { e_guard ; yield p_y }
 ```
 
 whose body is well-formed iff every non-diverging exit is the single trailing
 `yield` of a place `p_y` rooted at the receiver parameter — a projection chain
 `self.f…[e]…` (possibly through a nested accessor call), whose guards `e_guard`
 either diverge (trap, `@panic`) or fall through, with an empty post-`yield`
-continuation. Value parameters are by-value (prose `6.6:4`–`6.6:7`). A call
-produces a **borrowed place**, not a value:
+continuation. Value parameters are by-value (prose `6.6:4`–`6.6:7`). The
+receiver and result modes pair exactly (`borrow`/`borrow` or `inout`/`inout`),
+and an `inout` result requires a mutable addressable receiver. A call produces
+a mode-bearing place, not a value:
 
 ```
   Γ;Σ;Λ ⊢ receiver place p ⇒ A     fully-owned(Σ, p)
   for each i, threading Σ left-to-right (Σ0 = Σ):
       Γ;Σ_{i-1};Λ ⊢ e_i ⇒ Ti ⊣ Σi                       -- by-value guard inputs, §4.2
-  A.f is a well-formed read accessor with element type T
-  add (root(p), shared) to Λ_expr    -- extent: the enclosing FULL EXPRESSION, not the call
+  A.f is a well-formed accessor with element type T
+  mode(result_mode) = shared if result_mode = borrow, exclusive if result_mode = inout
+  add (root(p), mode(result_mode)) to Λ_expr    -- extent: the enclosing FULL EXPRESSION
   Λ_expr ∪ Λ_call of every call in that extent is CONSISTENT   (law of exclusivity, §5.4)
   ─────────────────────────────────────────────────────────────────────── (Accessor-Call)
-  Γ;Σ;Λ ⊢ p.f(e1, ..., ek) ⇒ borrowed-place T ⊣ Σk
+  Γ;Σ;Λ ⊢ p.f(e1, ..., ek) ⇒ place(mode(result_mode), T) ⊣ Σk
 ```
 
 The **full expression** of an occurrence (RUE-1279 — the loan extent above,
@@ -1045,6 +1047,16 @@ allocation store would yield `view⟨A | o, k⟩`, §6.13.2 — deferred to the 
 phase, RUE-1017). No call frame is pushed and no calling convention for
 "returning a place" exists; that absence is the RUE-1012 forward-compatibility
 contract.
+
+For an exclusive result, assignment through the yielded place is a place write:
+the right-hand side is evaluated first, then the destination's old value is
+dropped, then the new value is stored. The ordinary linear-overwrite premise
+therefore applies to the yielded destination; a live linear value cannot be
+silently overwritten unless reinitialization is proven. Shared results may
+coexist, while an exclusive result conflicts with every shared or exclusive
+loan on the same root in either evaluation order. This phase remains
+root-granular and excludes coroutine bodies, `Option(inout T)`, and
+path-granular disjointness.
 
 ---
 
@@ -2229,7 +2241,7 @@ witness of the dynamic semantics (RUE-50), cited inline in each §6 rule group.
 | §4.1/§5.4 equality borrows its operands | 4.3:3f |
 | §5.5 match / enum elim + intro | 6.3:17, 3.8:33 (destructure), 4.7 (match) |
 | §5.8 leaf/operator/aggregate/call statics | 4.1:2/5/7, 4.2:1/6/14, 4.3:1/2/5/6, 4.3a:3/4, 4.4:2, 3.6:5/6/15/16, 3.5:1/2, 4.10:3/4/5/7, 6.1:36 |
-| §5.8 (Accessor-Call) + accessor body WF (preview, ADR-0062) | 6.6:2–6.6:12 |
+| §5.8 (Accessor-Call) + accessor body WF (preview, ADR-0062) | 6.6:2–6.6:17 |
 | §5.6 enum drop (active payload) | 6.3:20 |
 | §4.3 expression/return value | 4.5:3 (→ value, not just type), 6.1:4/5, 4.9:1/7 |
 | §5.2 assignment / reinit | 3.8:55/56, 3.8:72, 3.8:77 |

--- a/docs/spec/src/02-lexical-structure/04-keywords.md
+++ b/docs/spec/src/02-lexical-structure/04-keywords.md
@@ -48,7 +48,7 @@ The following words are keywords and cannot be used as identifiers:
 | `unchecked` | Unchecked function modifier |
 | `ptr` | Pointer type constructor (`ptr const T` / `ptr mut T`) |
 | `extern` | Foreign declaration block (`extern "C" { … }`, ADR-0064) |
-| `yield` | Accessor body exit (`-> borrow T` accessors, ADR-0062) |
+| `yield` | Accessor body exit (`-> borrow T`/`-> inout T` accessors, ADR-0062) |
 
 ## Type Names
 

--- a/docs/spec/src/05-statements/02-assignment.md
+++ b/docs/spec/src/05-statements/02-assignment.md
@@ -14,15 +14,22 @@ An assignment statement evaluates its right-hand side to a value and stores that
 
 ```ebnf
 assign_stmt   = assign_target "=" expression ";" ;
-assign_target = IDENT { "." IDENT | "[" expression "]" }
-              | "self" ( "." IDENT | "[" expression "]" ) { "." IDENT | "[" expression "]" } ;
+assign_target = place_expr ;
+place_expr   = ( IDENT | "self" ) { place_postfix } ;
+place_postfix = "." IDENT | "[" expression "]"
+              | "." IDENT "(" [ call_args ] ")" ;
 ```
 
 The assignment target is a *place*: a variable (or, inside a method, `self`)
 followed by any number of field (`.f`) and index (`[e]`) projections, freely
-mixed. All of `x`, `p.f`, `arr[i]`, `arr[i].f`, `p.arr[i]`, `a.b.c`, and
-`o.items[i].arr[j]` are valid targets. (Appendix A's `place_expr` is the
-normative statement of this production; see that appendix.)
+mixed. An exclusive place-returning accessor call may serve as a place root,
+so `v.get_mut(i)`, `v.get_mut(i).field`, and `v.get_mut(i)[j]` are also valid
+targets; nested method-call links are allowed when each resolves to an
+exclusive accessor. Ordinary value-returning or shared method calls are not
+assignment places and remain a semantic error. All of `x`, `p.f`, `arr[i]`,
+`arr[i].f`, `p.arr[i]`, `a.b.c`, and `o.items[i].arr[j]` are valid targets.
+(Appendix A's `place_expr` is the normative statement of this production; see
+that appendix.)
 
 ## Evaluation Order
 

--- a/docs/spec/src/06-items/06-borrow-accessors.md
+++ b/docs/spec/src/06-items/06-borrow-accessors.md
@@ -15,31 +15,34 @@ projection of its receiver: `v.get_ref(i)` produces a borrowed place naming
 element `i` in place — no copy, no move-out — checked by the ordinary
 law-of-exclusivity loan machinery and scoped to the enclosing full expression
 (core calculus `docs/formal/01-core-calculus.md` §5.8, rule `(Accessor-Call)`).
-This is the ADR-0062 read-accessor form; mutable accessors (`inout self` →
-exclusive result) are a later phase.
+The same preview also supports mutable accessors: `v.get_mut(i)` produces an
+exclusive place, and uses `inout self` with an `-> inout T` result.
 
 ## Declaration
 
 {{ rule(id="6.6:2", cat="syntax") }}
 
 ```ebnf
-accessor    = "fn" IDENT "(" "borrow" "self" [ "," params ] ")"
-              "->" "borrow" type "{" { statement } yield_expr [ ";" ] "}" ;
+accessor    = "fn" IDENT "(" accessor_self [ "," params ] ")"
+              "->" accessor_result type "{" { statement } yield_expr [ ";" ] "}" ;
+accessor_self   = "borrow" "self" | "inout" "self" ;
+accessor_result = "borrow" | "inout" ;
 yield_expr  = "yield" expression ;
 ```
 
 {{ rule(id="6.6:3", cat="legality-rule") }}
 
-A `-> borrow` result position and the `yield` form require the
+A `-> borrow` or `-> inout` result position and the `yield` form require the
 `borrow_accessors` preview feature. Without `--preview borrow_accessors`, a
 program using either is rejected at compile time (E1100), per 8.4.
 
 {{ rule(id="6.6:4", cat="legality-rule") }}
 
-An accessor **MUST** declare a `borrow self` receiver. A `-> borrow` result on
-a free function, an associated function, a by-value or `mut self` method, an
-`inout self` method, or a method of an anonymous struct type is rejected
-(E0257).
+An accessor **MUST** pair its result and receiver modes exactly: `borrow self`
+with `-> borrow T`, or `inout self` with `-> inout T`. A result on a free
+function, an associated function, a by-value or `mut self` method, or a method
+of an anonymous struct type is rejected (E0257); a mismatched pair reports the
+required pairing.
 
 {{ rule(id="6.6:5", cat="legality-rule") }}
 
@@ -70,12 +73,13 @@ accessor's guards.
 {{ rule(id="6.6:8", cat="normative") }}
 
 A call to an accessor requires its receiver to be a place, exactly as passing
-it as a `borrow` argument does (6.4:27), and evaluates its arguments by value.
-The result is a *borrowed place*, not a first-class value: a shared loan on
-the receiver's root variable whose extent is the enclosing full expression
-(core calculus `docs/formal/01-core-calculus.md` §5.8, rule
-`(Accessor-Call)`). Within that extent the result may be read, projected
-further (`v.get_ref(i).name`), passed as a `borrow` argument, or compared.
+it as a `borrow` or `inout` argument does (6.4:27), and evaluates its
+arguments by value. A `-> borrow` result is a *borrowed place*, not a
+first-class value: a shared loan on the receiver's root variable. A `-> inout`
+result is an exclusive place and requires the receiver to be mutable, with
+the same addressability and mutability rules as an `inout` argument. Both
+loans extend through the enclosing full expression (core calculus
+`docs/formal/01-core-calculus.md` §5.8, rule `(Accessor-Call)`).
 
 {{ rule(id="6.6:9", cat="legality-rule") }}
 
@@ -85,7 +89,10 @@ An accessor result **MUST NOT** escape its full expression: returning it
 
 {{ rule(id="6.6:10", cat="legality-rule") }}
 
-The law of exclusivity extends over the accessor loan's whole extent: an
+The law of exclusivity extends over the accessor loan's whole extent: shared
+accessor results may coexist with one another, while an exclusive accessor
+result conflicts with every shared or exclusive access to the same root, and
+an exclusive use conflicts with every active accessor loan. An
 exclusive use of the borrowed root — passing it `inout`, an `inout self`
 receiver access, assigning to it, or moving it — anywhere within the same full
 expression is rejected (E0259). `use(v.get_ref(i), g(inout v))` is ill-formed
@@ -129,3 +136,27 @@ legality rules of this chapter. A re-entrant call reached through any other
 receiver (a by-value guard of the owner's own type) is rejected when a call
 site demands the body's analysis and expansion. The rejection names the
 recursive accessor either way.
+
+{{ rule(id="6.6:15", cat="normative") }}
+
+An exclusive accessor result is expression-scoped and may be used as a place:
+`v.get_mut(i) = value`, projected assignment such as
+`v.get_mut(i).field = value`, and `set(inout v.get_mut(i))` are valid when the
+receiver is mutable. The right-hand side is evaluated first; when the yielded
+destination owns a droppable value, its old value is dropped before the new
+value is stored. Ordinary linear overwrite checks apply to the yielded place;
+an overwrite of a live linear value is rejected unless reinitialization is
+provable.
+
+{{ rule(id="6.6:16", cat="legality-rule") }}
+
+An accessor result **MUST NOT** escape its expression-scoped loan. It cannot be
+returned, captured in an aggregate, or assigned as a value. A mutable accessor
+cannot be called through an immutable or shared-borrowed receiver, and two
+mutable results (or a mutable result and a shared result) rooted at the same
+receiver are rejected in either evaluation order.
+
+{{ rule(id="6.6:17", cat="informative") }}
+
+Accessor exclusivity is root-granular in this phase. Path-granular disjointness,
+coroutine accessor bodies, and `Option(inout T)` results are outside scope.

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -32,10 +32,11 @@ intrinsic_arg  = type | expression ;
 (* Functions *)
 function       = directives [ "pub" ] [ "unchecked" ]
                  "fn" IDENT "(" [ params ] ")" [ result ] "{" block "}" ;
-result         = "->" [ "borrow" ] type ;   (* "borrow" marks a place-returning
-                                               accessor (ADR-0062, preview);
-                                               legal only on `borrow self`
-                                               methods — a legality rule *)
+result         = "->" [ "borrow" | "inout" ] type ; (* marks a place-returning
+                                                        accessor (ADR-0062,
+                                                        preview); result and
+                                                        receiver modes pair —
+                                                        a legality rule *)
 params         = param { "," param } [ "," ] ;
 param          = [ param_mode ] IDENT ":" type ;
 param_mode     = "comptime" | "inout" | "borrow" ;
@@ -75,13 +76,17 @@ yield_expr     = "yield" expression ;  (* the trailing exit of an accessor body
                                           (ADR-0062, preview); parsed as an
                                           expression form, valid only as the
                                           single trailing statement of a
-                                          `-> borrow` accessor body — a
-                                          legality rule *)
+                                          `-> borrow` or `-> inout` accessor
+                                          body — a legality rule *)
 
 (* Place expressions: a variable — or `self`, inside a method — followed by
-   zero or more field/index projections. Used as assignment targets. Assigning
-   to a bare `self` is legal only for a `mut self` receiver (a legality rule). *)
-place_expr     = ( IDENT | "self" ) { "." IDENT | "[" expression "]" } ;
+   zero or more field/index projections, or an accessor call followed by those
+   projections. Ordinary method calls are rejected semantically as targets.
+   Assigning to a bare `self` is legal only for a `mut self` receiver
+   (a legality rule). *)
+place_expr     = ( IDENT | "self" ) { place_postfix } ;
+place_postfix  = "." IDENT | "[" expression "]"
+               | "." IDENT "(" [ call_args ] ")" ;
 
 (* Types *)
 type           = "i8" | "i16" | "i32" | "i64"


### PR DESCRIPTION
## Summary
- add `inout self -> inout T` place-returning accessors under the existing preview gate
- enforce expression-scoped root exclusivity and writable/inout result use with exact-once assignment
- complete durable-provider parity, formal/spec documentation, and spec/UI/CLI coverage

## Validation
- `scripts/rue quick`
- `scripts/rue test`
- `scripts/rue premerge`
- `scripts/rue spec 6.6`
- `scripts/rue ui borrow-accessors`
- `scripts/rue cli borrow_accessors`

Fixes RUE-1016