### PR TITLE
RUE-1508: resolve provisional test duplication rulings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -856,7 +856,7 @@ jobs:
 
       - name: Run native ABI programs
         if: steps.sel.outputs.run == 'true'
-        run: scripts/ci-timed "${{ matrix.name }} ABI" -- scripts/rue cli abi
+        run: scripts/ci-timed "${{ matrix.name }} ABI" -- scripts/rue cli abi --skip cli.differential_opt::aggregate_abi_across_opt_levels
 
       - name: Run native linker programs
         if: steps.sel.outputs.run == 'true'
@@ -1247,7 +1247,7 @@ jobs:
         run: scripts/ci-timed "release configuration" -- scripts/validate-release-configuration.py
 
       # Builds only the Rue driver and CLI harness under the release platform,
-      # then runs the 24 representative differential-opt cases (96 produced
+      # then runs the 29 representative differential-opt cases (116 produced
       # programs across -O0/-O1/-O2/-O3) through the release-built compiler.
       - name: Run focused release smoke
         if: steps.sel.outputs.run == 'true'

--- a/BUCK
+++ b/BUCK
@@ -532,6 +532,7 @@ cached_corpus_suite(
 # path (RUE-1129).
 cached_corpus_suite(
     name = "release-smoke",
+    labels = ["rue_ci_dedicated_lane"],
     harness = "//crates/rue-cli-tests:rue-cli-tests",
     args = ["--quiet", "differential_opt"],
     env = dict(_CLI_TEST_BASE_ENV.items() + [
@@ -1177,7 +1178,7 @@ rue_sh_test(
         # the workflow wiring, so installer-only edits must invalidate it.
         "scripts/install-valgrind",
         "scripts/run-native-platform-corpus.sh",
-        # RUE-1265: NATIVE_CLI_FILTERS is imported from here, so the two gates
+        # RUE-1265: NATIVE_CLI_INVOCATIONS is imported from here, so the two gates
         # cannot disagree about which `scripts/rue cli` steps the native lanes
         # run.
         "scripts/validate-test-duplication.py",

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -139,13 +139,15 @@ from those corpora: the three explicit `scripts/rue cli` filters below use the
 developer entry point, which sets neither `RUE_CLI_CASE_TIER` nor
 `RUE_PLATFORM_CASE_SELECTION`, so every case matching `abi`, `cli.linker`, or
 `cli.fs_file_io` runs whatever its tier and whether or not it declares
-`only_on`. `cases/abi.toml` declares none, so those cases do run on all three
-platforms. That is the responsibility matrix working as written, and the
-duplication gate scores it as a declared allowance rather than leaving it to
-this paragraph. Backend encoding logic is still tested explicitly for both
-architectures on Linux, while native ARM64 lanes prove the host ABI,
-object/linker path, runtime archive, syscalls, and platform behavior that
-cross-compilation cannot.
+`only_on`. The ABI selection exactly skips
+`cli.differential_opt::aggregate_abi_across_opt_levels`: that one release-smoke
+case was an accidental substring match, while the other 61 ABI-named cases are
+the native responsibility. That is the responsibility matrix working as
+written, and the duplication gate scores it as a declared allowance rather
+than leaving it to this paragraph. Backend encoding logic is still tested
+explicitly for both architectures on Linux, while native ARM64 lanes prove the
+host ABI, object/linker path, runtime archive, syscalls, and platform behavior
+that cross-compilation cannot.
 
 They **do** repeat the broad compiler unit suite, and that is a defect rather
 than the design. This paragraph used to claim otherwise while
@@ -153,13 +155,13 @@ than the design. This paragraph used to claim otherwise while
 into both native lanes; the two statements contradicted each other for weeks
 because nothing compared them (ADR-0069 "What was measured"). What the native
 lanes want is that binary's ~27 host-conditional sites; what they pay for is
-all 850 of its tests, because platform scope is declared per target while it is
-a property of individual tests. ADR-0069 Phase 4 (RUE-1262 scope C) moves the
+all 902 of its tests, because platform scope is declared per target while it is
+a property of individual tests. ADR-0069 Phase 4 (RUE-1266) moves the
 host-conditional tests into their own target — the precedent
 `rue-compiler-public-api-test` already sets in the same crate — and the
 repetition ends there rather than by dropping coverage now. Until then it is a
 declared allowance in the duplication gate below, so the cost stays visible
-and priced.
+and priced until that tracked extraction lands.
 
 The native lanes set `RUE_PLATFORM_CASE_SELECTION=native` through
 `scripts/run-native-platform-corpus.sh`. Both manifest-driven harnesses then
@@ -181,7 +183,7 @@ linux-x64 test lane may use BuildBuddy.
 Required release coverage is intentionally focused (RUE-1129). The
 `release (linux-x64)` job analyzes Buck's configured `rustc_cfg` actions and
 fails unless `//platforms:release` supplies `-Copt-level=3 -Clto=thin` while
-`//platforms:debug` supplies neither. It then runs `//:release-smoke`, the 24
+`//platforms:debug` supplies neither. It then runs `//:release-smoke`, the 29
 representative differential-opt cases, through a release-built Rue compiler.
 It does not build every crate target or run the exhaustive suite.
 
@@ -540,7 +542,7 @@ How it decides:
   answers instead — only a Rust binary can carry libtest — and a Rust harness
   that *does* refuse `--list` must be declared in `NOT_LISTABLE` with a reason
   stating what its opacity hides. An undeclared refusal fails the gate, because
-  the alternative is 850 tests silently collapsing into one opaque unit under a
+  the alternative is 902 tests silently collapsing into one opaque unit under a
   green check.
 - **Allowances are declared with a reason** in the script's `ALLOWANCES`
   ledger. An entry is either `per-target` — a roster of targets that each
@@ -550,16 +552,20 @@ How it decides:
   two-target entry cannot absorb a duplication between two CLI shards.
   Rosters go stale per target, not per entry. Absence never implies permission.
 
-Five duplications are declared today. The native lanes' repetition of the eight
-platform unit targets, and their `scripts/rue cli abi|cli.linker|cli.fs_file_io`
-steps re-running cases the CLI shards run, are both the platform responsibility
-matrix doing its job. Three are provisional and await a maintainer ruling:
-`rue-compiler-test`'s whole suite on three platforms (above); `//:release-smoke`
-running its 25 differential-opt cases three times on linux-x64 — once in the
-shards under `//platforms:debug`, once in the `release` job under
-`//platforms:release`, and once more inside `linux-premerge`, which carries no
-release configuration and looks like an oversight; and the single case that
-falls in the intersection of those two.
+Four duplication families are declared today. The native lanes' repetition of
+the eight platform unit targets, and their
+`scripts/rue cli abi|cli.linker|cli.fs_file_io` steps re-running cases the CLI
+shards run, are both the platform responsibility matrix doing its job. The
+broad `rue-compiler-test` repetition remains a tracked removal owned by
+RUE-1266: its Phase-4 acceptance criteria split
+host-conditional tests into a platform-scoped target that remains in
+linux-premerge and self-enrolls in both ARM64 native lanes, while the broad
+target-independent suite remains only in linux-premerge. The release-smoke
+overlap is deliberately retained only between the debug CLI shards and the
+release-configured release job; `rue_ci_dedicated_lane` prevents a third debug
+execution in linux-premerge. The broad native ABI filter carries an exact skip for
+`cli.differential_opt::aggregate_abi_across_opt_levels`, so all other ABI
+coverage remains and that case cannot return as an accidental substring match.
 
 Cost, measured on a 4-core-class host with the binaries already built: **0.29s
 wall for 73 `--list` invocations**, 1.6s of process time run concurrently. The
@@ -584,18 +590,14 @@ verdict covers. Three groups:
 - **Harnesses that are not libtest.** `//:reproducible-programs`,
   `//:oracle-diff-generated-smoke`, `//:frontend-diff-test`, and
   `//:spec-traceability` each count as one unit.
-- **The oracle differentials**, and this is the largest known gap:
+- **The oracle differentials**, which are intentionally distinct assertions:
   `//crates/rue-oracle-diff:oracle-diff-test` and `:oracle-diff-spec-test` drive
   every runnable CLI and specification case through the reference interpreter
-  and compare it against the compiler, so they re-execute the same ~1,858- and
-  ~2,100-case corpora that the CLI shards and `//:spec-tests` run in the same
-  run on the same platform. That is far larger than the 25-case release-smoke
-  overlap the ledger does score. It is a differential rather than a repetition
-  — the assertion is agreement between two implementations, which no single
-  execution can make — but nobody has priced it, and the gate cannot, because
-  the harness owns its own argument grammar. Making it listable would move it
-  from this list into `ALLOWANCES`, where a written reason would have to stand
-  up. Recorded in `NOT_LISTABLE` as provisional in the meantime.
+  and compare it against the compiler. They may execute overlapping corpus
+  inputs, but the interpreter comparison is the assertion and is not repeated
+  coverage. Their harness-owned runtime eligibility and argument grammar make a
+  `--list` inventory non-authoritative, so they remain explicitly classified in
+  `NOT_LISTABLE` and outside ordinary duplicate accounting.
 
 ## Affected-corpus selection on pull requests (RUE-1119)
 

--- a/scripts/test-validate-ci-gate.py
+++ b/scripts/test-validate-ci-gate.py
@@ -111,6 +111,20 @@ class GateValidatorTests(unittest.TestCase):
         errors = "\n".join(self.validate_text(source, runner))
         self.assertIn("export RUE_PLATFORM_CASE_SELECTION=native", errors)
 
+    def test_native_abi_filter_excludes_only_the_accidental_intersection(self):
+        changed = SOURCE.read_text().replace(
+            "scripts/rue cli abi --skip "
+            "cli.differential_opt::aggregate_abi_across_opt_levels",
+            "scripts/rue cli abi",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn(
+            "scripts/rue cli abi --skip "
+            "cli.differential_opt::aggregate_abi_across_opt_levels",
+            errors,
+        )
+
     def test_unexpected_skip_policy_and_platform_drift_fail(self):
         source = SOURCE.read_text()
         changed = source.replace(
@@ -186,6 +200,28 @@ class GateValidatorTests(unittest.TestCase):
         changed = SOURCE.read_text().replace("            target: //:spec-tests\n", "", 1)
         errors = "\n".join(self.validate_text(changed))
         self.assertIn("//:spec-tests is marked rue_ci_dedicated_lane", errors)
+        self.assertIn("no exactly-one dedicated owner", errors)
+
+    def test_release_smoke_label_is_owned_by_release_job(self):
+        # The label removes release-smoke from linux-premerge; its release job
+        # is therefore the required dedicated owner.
+        changed = SOURCE.read_text().replace(
+            "run: scripts/ci-timed \"release smoke\" -- ./buck2 test //:release-smoke --target-platforms //platforms:release",
+            "run: scripts/ci-timed \"release smoke\" -- ./buck2 test //:other --target-platforms //platforms:release",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("//:release-smoke is marked rue_ci_dedicated_lane", errors)
+        self.assertIn("no exactly-one dedicated owner", errors)
+
+    def test_release_smoke_cannot_be_owned_by_two_dedicated_jobs(self):
+        changed = SOURCE.read_text().replace(
+            "            target: //:spec-tests\n",
+            "            target: //:release-smoke\n            target: //:spec-tests\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("//:release-smoke (owned by platform-corpus, release)", errors)
 
     def test_unlabeled_buck_fails_closed(self):
         buck = ROOT_BUCK.read_text().replace('"rue_ci_dedicated_lane"', '"unused"')

--- a/scripts/test-validate-test-duplication.py
+++ b/scripts/test-validate-test-duplication.py
@@ -258,6 +258,21 @@ class AllowanceTests(unittest.TestCase):
                 tuple(sorted(allowance.platforms)), allowance.platforms, allowance
             )
 
+    def test_native_abi_selection_excludes_only_the_accidental_intersection(self):
+        self.assertEqual(
+            GATE.NATIVE_CLI_INVOCATIONS[0],
+            ("abi", "--skip", GATE.AGGREGATE_ABI_DIFFERENTIAL),
+        )
+
+    def test_aggregate_abi_intersection_cannot_be_absorbed(self):
+        schedule = [
+            scheduled("linux-x64", "platform-corpus", "//:cli-tests", ["abi::aggregate"]),
+            scheduled("linux-x64", "release", "//:release-smoke", ["abi::aggregate"]),
+            scheduled("linux-arm64", "native-linux-arm64", "//crates/rue-cli-tests:cli", ["abi::aggregate"]),
+        ]
+        errors = GATE.review(GATE.duplicate_sets(schedule))
+        self.assertTrue(any("undeclared duplication" in error for error in errors), errors)
+
     def test_every_not_listable_entry_says_what_its_opacity_hides(self):
         # A NOT_LISTABLE entry removes a target from the comparison entirely,
         # which is a larger claim than an allowance makes. The reason has to
@@ -265,6 +280,8 @@ class AllowanceTests(unittest.TestCase):
         for target, reason in GATE.NOT_LISTABLE.items():
             self.assertTrue(target.startswith("//"), target)
             self.assertGreater(len(reason), 120, target)
+        self.assertIn("distinct assertion", GATE.NOT_LISTABLE["//crates/rue-oracle-diff:oracle-diff-test"])
+        self.assertNotIn("provisional", " ".join(GATE.NOT_LISTABLE.values()))
 
 
 class InventoryTests(unittest.TestCase):

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -48,13 +48,30 @@ def dedicated_lane_targets(buck_source: str) -> list[str]:
     return [f"//:{match.group('name')}" for match in DEDICATED_LANE_RE.finditer(buck_source)]
 
 
-def uncovered_dedicated_lanes(buck_source: str, corpus_block: str) -> list[str]:
-    """Labeled corpora that no platform-corpus matrix entry actually runs.
+def _workflow_mentions_target(block: str, target: str) -> bool:
+    """Whether executable workflow text names a dedicated target."""
+    for line in block.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        if re.search(rf"(?<![A-Za-z0-9_.-]){re.escape(target)}(?![A-Za-z0-9_.-])", stripped):
+            return True
+    return False
+
+
+def uncovered_dedicated_lanes(
+    buck_source: str,
+    corpus_block: str,
+    owner_blocks=None,
+) -> list[str]:
+    """Labeled corpora that do not have exactly one dedicated owner.
 
     A corpus carrying the label is skipped by the linux-premerge suite, so if
-    the matrix does not run it — directly or through its shards — it stops being
-    covered at all. That is the RUE-924 false-green shape, reached by way of a
-    label instead of a log line, so it fails the CI contract.
+    the matrix or an explicitly supplied owner job does not run it — directly or
+    through its shards — it stops being covered at all. Conversely, two owners
+    would reintroduce the same work under two lane contracts. Both are the
+    RUE-924 false-green shape, reached by way of a label instead of a log line,
+    so they fail the CI contract.
     """
     matrix_targets = set(re.findall(r"target: (\S+)", corpus_block))
     uncovered = []
@@ -64,8 +81,19 @@ def uncovered_dedicated_lanes(buck_source: str, corpus_block: str) -> list[str]:
             for candidate in matrix_targets
             if candidate.startswith(f"{target}-shard-")
         }
-        if target not in matrix_targets and not sharded:
+        owners = []
+        if target in matrix_targets or sharded:
+            owners.append("platform-corpus")
+        if owner_blocks:
+            owners.extend(
+                owner
+                for owner, block in owner_blocks.items()
+                if _workflow_mentions_target(block, target)
+            )
+        if not owners:
             uncovered.append(target)
+        elif len(owners) > 1:
+            uncovered.append(f"{target} (owned by {', '.join(sorted(owners))})")
     return uncovered
 
 
@@ -399,7 +427,8 @@ def validate(
         "//crates/rue-runtime-abi:rue-runtime-abi-test",
         "scripts/run-native-platform-corpus.sh",
     ) + tuple(
-        f"scripts/rue cli {filter_}" for filter_ in DUPLICATION.NATIVE_CLI_FILTERS
+        "scripts/rue cli " + " ".join(invocation)
+        for invocation in DUPLICATION.NATIVE_CLI_INVOCATIONS
     ):
         if required not in native:
             errors.append(f"native-platforms responsibility missing {required!r}")
@@ -473,10 +502,13 @@ def validate(
                 "no corpus carries rue_ci_dedicated_lane; linux-premerge would "
                 "re-run the corpora that have their own jobs"
             )
-        for target in uncovered_dedicated_lanes(buck_source, corpus):
+        owners = {
+            "release": jobs.get("release", ""),
+        }
+        for target in uncovered_dedicated_lanes(buck_source, corpus, owners):
             errors.append(
                 f"{target} is marked {DEDICATED_LANE_LABEL} (so the premerge "
-                "suite skips it) but no platform-corpus entry runs it"
+                "suite skips it) but has no exactly-one dedicated owner"
             )
 
     for sanitizer in ("valgrind", "asan"):

--- a/scripts/validate-test-duplication.py
+++ b/scripts/validate-test-duplication.py
@@ -89,13 +89,17 @@ SELECTION_PROXY_LANES = {
     "rue-program-digests",
 }
 
-# The native lanes run three CLI filters as workflow steps rather than as Buck
-# test targets (`scripts/rue cli abi` → `buck2 run //crates/rue-cli-tests:cli --
-# abi`). Everything but the filter strings is derived from the alias's own graph
-# node; `scripts/validate-ci-gate.py` imports these so the workflow and this
-# gate cannot disagree about which filters run.
+# The native lanes run three CLI selections as workflow steps rather than as
+# Buck test targets. Everything but their arguments is derived from the
+# alias's own graph node; `scripts/validate-ci-gate.py` imports these so the
+# workflow and this gate cannot disagree about what runs.
 NATIVE_CLI_ALIAS = "//crates/rue-cli-tests:cli"
-NATIVE_CLI_FILTERS = ("abi", "cli.linker", "cli.fs_file_io")
+AGGREGATE_ABI_DIFFERENTIAL = "cli.differential_opt::aggregate_abi_across_opt_levels"
+NATIVE_CLI_INVOCATIONS = (
+    ("abi", "--skip", AGGREGATE_ABI_DIFFERENTIAL),
+    ("cli.linker",),
+    ("cli.fs_file_io",),
+)
 
 
 @dataclass(frozen=True)
@@ -123,11 +127,6 @@ class Allowance:
     platforms: tuple[str, ...]
     reason: str
     kind: str = "between-targets"
-    # True when the allowance records the current behaviour rather than a
-    # decision. ADR-0069 leaves several of these open, and inventing the ruling
-    # here would be worse than carrying it visibly.
-    provisional: bool = False
-
     def covers(self, duplicate: "DuplicateSet") -> bool:
         if duplicate.platforms != self.platforms:
             return False
@@ -158,13 +157,16 @@ ALLOWANCES = (
             "The native lanes want this binary's ~27 host-conditional sites and "
             "pay for its whole unit suite, because platform scope is declared "
             "per target while it is a property of individual tests. ADR-0069 "
-            "Phase 4 (RUE-1262 scope C) splits the host-conditional tests into "
+            "Phase 4 splits the host-conditional tests into "
             "their own target, following the precedent already set in this crate "
-            "by rue-compiler-public-api-test; the repetition ends there, not by "
-            "dropping coverage here. Until then this is what runs, and "
-            "docs/process/ci.md says so rather than claiming otherwise."
+            "by rue-compiler-public-api-test. RUE-1266 owns that Phase-4 "
+            "extraction with exact criteria: split the host-conditional tests "
+            "into a platform-scoped target that remains in linux-premerge and "
+            "self-enrolls in both ARM64 native lanes, while the target-independent "
+            "suite remains only in linux-premerge. Until it "
+            "lands, this allowance keeps the required broad suite running and "
+            "makes the tracked removal visible."
         ),
-        provisional=True,
     ),
     Allowance(
         kind="per-target",
@@ -193,25 +195,22 @@ ALLOWANCES = (
         targets=("//:cli-tests", "//:release-smoke"),
         platforms=("linux-x64",),
         reason=(
-            "Three executions of the same 25 cases on linux-x64: the CLI shards "
-            "run them under //platforms:debug, the `release` job runs "
-            "//:release-smoke under //platforms:release, and //:release-smoke "
-            "carries no `rue_ci_dedicated_lane` label so `test.sh` ALSO runs it "
-            "inside linux-premerge under the debug platform — where the shards "
-            "have already run those cases. The release-configured execution is "
-            "the coverage ADR-0069 calls 'defensible but undecided'; the "
-            "premerge one is a third pass with no configuration of its own, and "
-            "looks like an oversight rather than a decision. Both need the same "
-            "maintainer ruling, so both are declared rather than acted on."
+            "The CLI shards run these cases under //platforms:debug and the "
+            "release job runs //:release-smoke under //platforms:release. The "
+            "release-configured execution is intentionally retained because it "
+            "proves the release optimization configuration; //:release-smoke "
+            "is marked rue_ci_dedicated_lane so linux-premerge no longer runs a "
+            "third debug execution. The exact overlap remains declared because "
+            "debug and release configurations are deliberately distinct."
         ),
-        provisional=True,
     ),
     Allowance(
         targets=("//:cli-tests", "//crates/rue-cli-tests:cli"),
         platforms=("linux-arm64", "linux-x64", "macos-arm64"),
         reason=(
-            "The native lanes run `scripts/rue cli abi`, `cli.linker`, and "
-            "`cli.fs_file_io` — the developer entry point, with neither "
+            "The native lanes run `scripts/rue cli abi` with one exact skip, "
+            "plus `cli.linker` and `cli.fs_file_io` — the developer entry point, "
+            "with neither "
             "RUE_CLI_CASE_TIER nor RUE_PLATFORM_CASE_SELECTION set, so every "
             "matching case of every tier runs. Those sections contain "
             "native-execution cases with empty `only_on` lists, which is "
@@ -221,25 +220,6 @@ ALLOWANCES = (
             "the x86-64 Linux pass in the CLI shards is not evidence for it. "
             "The repetition is the coverage the responsibility matrix asks for."
         ),
-    ),
-    Allowance(
-        targets=(
-            "//:cli-tests",
-            "//:release-smoke",
-            "//crates/rue-cli-tests:cli",
-        ),
-        platforms=("linux-arm64", "linux-x64", "macos-arm64"),
-        reason=(
-            "Exactly one case sits in the intersection of the two overlaps "
-            "above: `cli.differential_opt::aggregate_abi_across_opt_levels`. "
-            "libtest filters are substring matches, so the native lanes' `abi` "
-            "filter selects it as well as everything in cases/abi.toml, and it "
-            "is a differential-opt case so //:release-smoke selects it too. "
-            "Nothing new is decided here — it is the two allowances above "
-            "meeting on one case — but it is a distinct target set, and this "
-            "gate does not let one entry vouch for a set it does not name."
-        ),
-        provisional=True,
     ),
 )
 
@@ -255,23 +235,22 @@ ALLOWANCES = (
 # whole suite (see `Listing.listable`).
 NOT_LISTABLE = {
     "//crates/rue-oracle-diff:oracle-diff-test": (
-        "rue-oracle-diff owns its own argument grammar and exits 1 on --list. "
-        "What this opacity hides is the largest overlap in the repository: this "
-        "target drives every runnable CLI case through the reference "
-        "interpreter and compares it against the compiler's own result, so it "
-        "re-executes the ~1,858-case corpus the CLI shards run in the same lane "
-        "on the same platform. It is a differential rather than a repetition — "
-        "the assertion is agreement between two implementations, which no "
-        "single execution can make — but it is second execution of the same "
-        "compiles, it is far larger than the 25-case release-smoke overlap "
-        "below, and nobody has priced it. Provisional: it needs the same "
-        "maintainer ruling, and making the target listable would let the gate "
-        "score it instead of this note."
+        "distinct-assertion opaque target: rue-oracle-diff owns its own argument "
+        "grammar and exits 1 on --list. It drives every runnable CLI case through "
+        "the reference interpreter and compares that result with the compiler. "
+        "The interpreter differential is a distinct assertion, not repeated "
+        "coverage, so this target is intentionally excluded from ordinary "
+        "duplicate accounting. Its runtime eligibility and corpus selection are "
+        "harness-owned, making a --list inventory non-authoritative; keeping it "
+        "opaque avoids running the corpus merely to classify it."
     ),
     "//crates/rue-oracle-diff:oracle-diff-spec-test": (
-        "The same harness and the same trade against the specification corpus "
-        "//:spec-tests runs, ~2,100 cases, on the same platform in the same "
-        "run. Provisional for the same reason."
+        "distinct-assertion opaque target: the harness drives the specification "
+        "corpus through the reference interpreter and compares compiler behavior. "
+        "That interpreter differential is a distinct assertion, not repeated "
+        "coverage, and therefore is not ordinary duplicate accounting. The "
+        "harness owns runtime eligibility and argument grammar, so --list would "
+        "not provide an authoritative inventory; it remains intentionally opaque."
     ),
     "//:spec-traceability": (
         "rue-spec's `--traceability` is a reporting mode, not a filter: handed "
@@ -528,7 +507,7 @@ class Inventory:
     units: dict[str, list[str]] = field(default_factory=dict)
     # Targets that name a Buck target as their harness and whose attributes
     # could not be read. Falling back to "opaque" here would be the one failure
-    # mode this gate cannot tolerate: a wrapper that lists 850 tests would
+    # mode this gate cannot tolerate: a wrapper that lists 902 tests would
     # silently count as one unit and its duplication would disappear. Loud
     # instead.
     unresolved: dict[str, str] = field(default_factory=dict)
@@ -981,7 +960,8 @@ def lane_membership(buck: Buck, script: Path = AFFECTED_TARGETS) -> dict[str, li
 
     for lane in ("native-linux-arm64", "native-macos-arm64"):
         lanes[lane].extend(
-            f"{NATIVE_CLI_ALIAS} {filter_}" for filter_ in NATIVE_CLI_FILTERS
+            f"{NATIVE_CLI_ALIAS} {' '.join(invocation)}"
+            for invocation in NATIVE_CLI_INVOCATIONS
         )
 
     known = set(affected_targets("lanes", script=script)) | {"linux-premerge", "platform-corpus"}
@@ -1017,14 +997,15 @@ def owner_of(target: str, shards: set[str]) -> str:
 
 
 def workflow_step_listings(buck: Buck) -> dict[str, Listing]:
-    """Listings for the native lanes' three `scripts/rue cli <filter>` steps.
+    """Listings for the native lanes' three `scripts/rue cli` selections.
 
     RUE-1265's first revision modelled only Buck test targets, and these three
-    steps are not one: `scripts/rue cli abi` runs
-    `buck2 run //crates/rue-cli-tests:cli -- abi`. The alias is a real graph
-    node carrying its own env, so everything except the filter string is
-    derived; the filters themselves live in `ci.yml` and
-    `scripts/validate-ci-gate.py` imports `NATIVE_CLI_FILTERS` from here so the
+    steps are not one. The ABI selection runs the historical broad `abi`
+    substring filter but exactly skips the unrelated differential-opt case;
+    that preserves all 61 native ABI assertions instead of narrowing to the 16
+    cases in the `cli.abi` section. The alias is a real graph node carrying its
+    own env, so only these arguments are declared here. They also live in
+    `ci.yml`, and `scripts/validate-ci-gate.py` imports them from here so the
     two cannot drift.
 
     It matters because the alias leaves both `RUE_CLI_CASE_TIER` and
@@ -1050,14 +1031,14 @@ def workflow_step_listings(buck: Buck) -> dict[str, Listing]:
     harness = buck.uquery(f"set({binary})", ATTRIBUTES).get(binary, {})
     namespace = namespace_key(binary, harness)
     return {
-        f"{NATIVE_CLI_ALIAS} {filter_}": Listing(
-            target=f"{NATIVE_CLI_ALIAS} {filter_}",
+        f"{NATIVE_CLI_ALIAS} {' '.join(invocation)}": Listing(
+            target=f"{NATIVE_CLI_ALIAS} {' '.join(invocation)}",
             binary=binary,
-            args=[filter_],
+            args=list(invocation),
             env=env,
             namespace_key=namespace,
         )
-        for filter_ in NATIVE_CLI_FILTERS
+        for invocation in NATIVE_CLI_INVOCATIONS
     }
 
 
@@ -1231,12 +1212,6 @@ def main() -> int:
         f"no test executes twice per platform per run: {len(duplicates)} declared "
         f"duplicate set(s) covering {allowed} test(s), none undeclared"
     )
-    for entry in ALLOWANCES:
-        if entry.provisional:
-            print(
-                f"note: the allowance for {', '.join(entry.targets)} is provisional "
-                "and awaits a maintainer ruling (ADR-0069 open questions)"
-            )
     return 0
 
 


### PR DESCRIPTION
## Summary

- give release-smoke one release-lane owner while retaining debug CLI and release-configuration coverage
- preserve oracle differential execution as a distinct interpreter-comparison assertion outside ordinary duplicate accounting
- remove the aggregate ABI substring intersection without dropping the other 61 native ABI cases
- record RUE-1266 as the tracked Phase-4 removal of broad compiler-suite repetition
- keep dedicated-lane ownership and live listing inventories fail-closed

## Validation

- focused duplication and CI-policy targets
- live test-duplication report: 11 declared sets, none undeclared
- scripts/rue quick
- scripts/rue premerge
- scripts/rue fmt

Fixes RUE-1508