### PR TITLE
RUE-1017: adopt borrow accessors in std collections

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1825,6 +1825,15 @@ impl<'a> ConstraintGenerator<'a> {
                     }
                     let result_var = self.fresh_var();
                     InferType::Var(result_var)
+                } else if intrinsic_name == "place" {
+                    // The trusted `@place(ptr)` bridge is represented as a
+                    // pointer-shaped expression until accessor-yield analysis
+                    // turns it into an indirect place.
+                    for arg_ref in args.iter() {
+                        self.generate(*arg_ref, ctx);
+                    }
+                    let result_var = self.fresh_var();
+                    InferType::Var(result_var)
                 } else if intrinsic_name == "raw"
                     || intrinsic_name == "raw_mut"
                     || intrinsic_name == "field_ptr"

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -451,7 +451,9 @@ impl AirPlace {
         if self.projections.is_empty() {
             match self.base {
                 AirPlaceBase::Local(slot) => Some(slot),
-                AirPlaceBase::Param(_) | AirPlaceBase::Accessor(_) => None,
+                AirPlaceBase::Param(_) | AirPlaceBase::Accessor(_) | AirPlaceBase::Indirect(_) => {
+                    None
+                }
             }
         } else {
             None
@@ -464,7 +466,9 @@ impl AirPlace {
         if self.projections.is_empty() {
             match self.base {
                 AirPlaceBase::Param(slot) => Some(slot),
-                AirPlaceBase::Local(_) | AirPlaceBase::Accessor(_) => None,
+                AirPlaceBase::Local(_) | AirPlaceBase::Accessor(_) | AirPlaceBase::Indirect(_) => {
+                    None
+                }
             }
         } else {
             None
@@ -560,6 +564,10 @@ pub enum AirPlaceBase {
     /// second-class place producer, not a value-producing ABI call; CFG
     /// construction preserves it only until the accessor CFG splice.
     Accessor(AirRef),
+    /// Pointee address produced by the trusted std `@place` bridge. The
+    /// address is an ordinary value; after mandatory accessor splicing this
+    /// base is lowered as an ordinary indirect place, never as an accessor ABI.
+    Indirect(AirRef),
 }
 
 /// A projection applied to a place to reach a nested location.
@@ -1598,6 +1606,16 @@ impl Air {
                             format!(
                                 "place {place_ref} accessor base type does not match its producer"
                             ),
+                        ));
+                    }
+                }
+                if let AirPlaceBase::Indirect(pointer) = place.base {
+                    check_ref(pointer)?;
+                    let pointer_ty = self.get(pointer).ty;
+                    if !pointer_ty.is_ptr() {
+                        return Err(fail(
+                            Some(index),
+                            format!("place {place_ref} indirect base is not a pointer"),
                         ));
                     }
                 }
@@ -4005,6 +4023,7 @@ impl Air {
             AirPlaceBase::Local(slot) => write!(f, "${}", slot)?,
             AirPlaceBase::Param(slot) => write!(f, "param%{}", slot)?,
             AirPlaceBase::Accessor(call) => write!(f, "accessor%{}", call.as_u32())?,
+            AirPlaceBase::Indirect(pointer) => write!(f, "*ptr%{}", pointer.as_u32())?,
         }
 
         // Write the projections

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -1082,8 +1082,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 self.place_root_with_accessors(receiver, ctx).is_some();
             let receiver_addressable_probe =
                 if receiver_is_accessor_place || ctx.accessor_call_insts.contains_key(&receiver) {
-                    self.peel_projected_rvalue_scope(air, receiver_result.air_ref)
-                        .0
+                    let (place, prefix) =
+                        self.peel_projected_rvalue_scope(air, receiver_result.air_ref);
+                    if !prefix.is_empty() {
+                        receiver_result = AnalysisResult::new(place, receiver_result.ty);
+                        receiver_temp_scope.extend(prefix);
+                    }
+                    place
                 } else {
                     receiver_result.air_ref
                 };

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -303,6 +303,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 || name == known.raw
                 || name == known.raw_mut
                 || name == known.field_ptr
+                || name == known.place
                 || name == known.alloc
                 || name == known.alloc_zeroed
                 || name == known.free
@@ -474,6 +475,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             self.analyze_addr_of_intrinsic(air, &args, span, ctx, true, raw_mut, "addr_of_mut")
         } else if name == known.field_ptr {
             self.analyze_field_ptr_intrinsic(air, &args, span, ctx)
+        } else if name == known.place {
+            self.analyze_place_intrinsic(air, inst_ref, &args, span, ctx)
         } else if name == known.syscall {
             self.analyze_syscall_intrinsic(air, name, &args, span, ctx)
         } else if name == known.target_arch {
@@ -488,6 +491,107 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 span,
             ))
         }
+    }
+
+    /// Validate the trusted std pointer-to-place bridge. The enclosing yield
+    /// converts this pointer-shaped AIR value into `AirPlaceBase::Indirect`;
+    /// keeping the intrinsic itself value-shaped means it can be spliced and
+    /// materialized with the ordinary pointer lowering path.
+    fn analyze_place_intrinsic(
+        &mut self,
+        air: &mut Air,
+        inst_ref: InstRef,
+        args: &[RirCallArg],
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        let Some(trailing) = ctx.accessor_trailing_yield else {
+            return Err(CompileError::new(
+                ErrorKind::UnknownIntrinsic("place".to_owned()),
+                span,
+            ));
+        };
+        let legal_trailing_bridge = match self.body_rir_ref().get(trailing).data {
+            InstData::Yield(operand) => match self.body_rir_ref().get(operand).data {
+                InstData::Checked { expr } => match self.body_rir_ref().get(expr).data {
+                    InstData::Intrinsic { name, .. } => {
+                        name == self.known_symbols().place && expr == inst_ref
+                    }
+                    _ => false,
+                },
+                _ => false,
+            },
+            _ => false,
+        };
+        if !legal_trailing_bridge
+            || !self.file_module_is_trusted_standard_library(ctx.current_file_id)
+        {
+            return Err(CompileError::new(
+                ErrorKind::UnknownIntrinsic("place".to_owned()),
+                span,
+            ));
+        }
+        if args.len() != 1 {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "place".to_owned(),
+                    expected: 1,
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+        // The bridge is representation-level, but the yielded place must
+        // still be rooted in the accessor receiver. Admit exactly
+        // `@place(@ptr_offset(<self field chain>, ...))`; this keeps the
+        // trusted escape hatch from manufacturing a loan into unrelated
+        // storage while leaving the index expression to the reviewed std
+        // accessor's bounds guard.
+        let ptr_offset_base = match &self.body_rir_ref().get(args[0].value).data {
+            InstData::Intrinsic { name, args } if *name == self.known_symbols().ptr_offset => {
+                let pointer_args = self.body_rir_ref().intrinsic_args(args);
+                (pointer_args.len() == 2)
+                    .then(|| pointer_args.values().next())
+                    .flatten()
+            }
+            _ => None,
+        };
+        let self_symbol = self.body_interner().get_or_intern("self");
+        let mut root = ptr_offset_base;
+        let receiver_rooted = loop {
+            let Some(current) = root else {
+                break false;
+            };
+            match &self.body_rir_ref().get(current).data {
+                InstData::VarRef { name, .. } => break *name == self_symbol,
+                InstData::FieldGet { base, .. } => root = Some(*base),
+                _ => break false,
+            }
+        };
+        if !receiver_rooted {
+            return Err(CompileError::new(
+                crate::declaration_validation::accessor_yield_root_error(
+                    &crate::declaration_validation::AccessorYieldRootForm::Value,
+                ),
+                span,
+            ));
+        }
+        let operand = self.analyze_inst(air, args[0].value, ctx)?;
+        if !operand.ty.is_ptr() && !operand.ty.is_error() {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicTypeMismatch(Box::new(rue_error::IntrinsicTypeMismatchError {
+                    name: "place".to_owned(),
+                    expected: "a raw pointer".to_owned(),
+                    found: operand.ty.name().to_owned(),
+                })),
+                span,
+            ));
+        }
+        // `@place` is a checked-language bridge, not a runtime operation.  The
+        // pointer remains the ordinary value used by the indirect place that
+        // the trailing-yield analysis constructs; emitting an intrinsic here
+        // would incorrectly expose a call-shaped operation to codegen.
+        Ok(AnalysisResult::new(operand.air_ref, operand.ty))
     }
 
     fn analyze_internal_intrinsic_impl(

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -766,7 +766,16 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let AirInstData::PlaceRead { place } = air.get(projected).data else {
             return (original, Vec::new());
         };
-        let AirPlaceBase::Local(owner_slot) = air.get_place(place).base else {
+        let place_base = air.get_place(place).base;
+        // An accessor guards block is also a scope around an addressable place.
+        // A by-ref consumer must receive the tail PlaceRead itself while the
+        // guards stay as prefix statements around that consumer; otherwise CFG
+        // lowering turns the block value into a join value and loses its place
+        // identity before mandatory splicing.
+        if matches!(place_base, AirPlaceBase::Accessor(_)) {
+            return (projected, statements);
+        }
+        let AirPlaceBase::Local(owner_slot) = place_base else {
             return (original, Vec::new());
         };
         let owns_projected_place = statements.windows(2).any(|pair| {
@@ -2798,7 +2807,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         .params
                         .iter()
                         .any(|p| p.name == trace.root_var && p.mode == RirParamMode::Normal),
-                    AirPlaceBase::Accessor(_) => false,
+                    AirPlaceBase::Accessor(_) | AirPlaceBase::Indirect(_) => false,
                 };
                 if is_droppable_param_base {
                     emit_move_marker = true;
@@ -2844,7 +2853,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 let (slot, is_param) = match trace.base {
                     AirPlaceBase::Local(slot) => (slot, false),
                     AirPlaceBase::Param(slot) => (slot, true),
-                    AirPlaceBase::Accessor(_) => {
+                    AirPlaceBase::Accessor(_) | AirPlaceBase::Indirect(_) => {
                         unreachable!("accessor places never receive move markers")
                     }
                 };
@@ -3872,7 +3881,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                             span,
                         ));
                     }
-                    AirPlaceBase::Accessor(_) => {
+                    AirPlaceBase::Accessor(_) | AirPlaceBase::Indirect(_) => {
                         unreachable!("accessor places are classified as borrowed")
                     }
                 }
@@ -4043,7 +4052,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                             span,
                         ));
                     }
-                    AirPlaceBase::Accessor(_) => {
+                    AirPlaceBase::Accessor(_) | AirPlaceBase::Indirect(_) => {
                         unreachable!("accessor places are classified as borrowed")
                     }
                 }
@@ -4603,7 +4612,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 .params
                 .iter()
                 .any(|p| p.name == trace.root_var && p.mode == RirParamMode::Normal),
-            AirPlaceBase::Accessor(_) => false,
+            AirPlaceBase::Accessor(_) | AirPlaceBase::Indirect(_) => false,
         };
         if !droppable_base {
             return Ok(value);
@@ -4611,7 +4620,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let (slot, is_param) = match trace.base {
             AirPlaceBase::Local(slot) => (slot, false),
             AirPlaceBase::Param(slot) => (slot, true),
-            AirPlaceBase::Accessor(_) => {
+            AirPlaceBase::Accessor(_) | AirPlaceBase::Indirect(_) => {
                 unreachable!("accessor places never receive element move markers")
             }
         };
@@ -5373,7 +5382,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ctx.expected_type = previous;
             }
             ctx.byref_arg_root = prev_byref_root;
-            let arg_result = arg_result?;
+            let mut arg_result = arg_result?;
             if elaborates_borrow {
                 let span = self.body_rir_ref().get(arg.value).span;
                 let elaborated = self.elaborate_borrow_operand(
@@ -5398,7 +5407,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 // tail is the place read (ADR-0062); peel it for the address
                 // check, like the `inout str` view materialization below.
                 let addressable_probe = if ctx.accessor_call_insts.contains_key(&arg.value) {
-                    self.peel_projected_rvalue_scope(air, arg_result.air_ref).0
+                    let (place, prefix) = self.peel_projected_rvalue_scope(air, arg_result.air_ref);
+                    if !prefix.is_empty() {
+                        arg_result = AnalysisResult::new(place, arg_result.ty);
+                        temp_scope.extend(prefix);
+                    }
+                    place
                 } else {
                     arg_result.air_ref
                 };

--- a/crates/rue-air/src/sema/body_endpoint.rs
+++ b/crates/rue-air/src/sema/body_endpoint.rs
@@ -79,6 +79,10 @@ pub(crate) trait BodyEndpointProvider {
     /// The module id whose definition lives in `file`.
     fn endpoint_module_id_for_file(&self, file: u32) -> Option<ModuleId>;
 
+    fn endpoint_module_is_trusted_standard_library(&self, module: ModuleId) -> bool;
+
+    fn endpoint_file_is_trusted_standard_library(&self, file: u32) -> bool;
+
     /// Intern an array type, or `None` on a type-validation failure.
     fn endpoint_intern_array(&self, element: Type, len: u64) -> Option<Type>;
 
@@ -1049,6 +1053,16 @@ where
 
     fn endpoint_module_id_for_file(&self, file: u32) -> Option<ModuleId> {
         self.identity.modules().id_for_file(FileId::new(file))
+    }
+
+    fn endpoint_module_is_trusted_standard_library(&self, module: ModuleId) -> bool {
+        let durable = self.identity.modules().durable_for_id(module).cloned();
+        durable.is_some_and(|durable| self.identity.module_is_trusted_standard_library(&durable))
+    }
+
+    fn endpoint_file_is_trusted_standard_library(&self, file: u32) -> bool {
+        self.endpoint_module_id_for_file(file)
+            .is_some_and(|module| self.endpoint_module_is_trusted_standard_library(module))
     }
 
     fn endpoint_intern_array(&self, element: Type, len: u64) -> Option<Type> {

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -155,6 +155,13 @@ pub trait DurableNominalSource<K, M> {
     fn nominal_file_id(&self, _key: &K) -> Option<FileId> {
         None
     }
+
+    /// Whether this durable module is the trusted standard-library namespace.
+    /// The compiler supplies this from its canonical `ModuleId` identity; the
+    /// default keeps fixture sources conservative.
+    fn module_is_trusted_standard_library(&self, _module: &M) -> bool {
+        false
+    }
 }
 
 /// The durable body of an anonymous nominal: its field / variant vocabulary. The
@@ -196,6 +203,8 @@ pub struct DurableAnonymousMethod<K, M> {
     pub name: Arc<str>,
     pub has_self: bool,
     pub self_mode: RirParamMode,
+    pub returns_borrow: bool,
+    pub returns_inout: bool,
     pub parameters: Vec<(DurableAnonymousMethodType<K, M>, RirParamMode, bool)>,
     pub result: DurableAnonymousMethodType<K, M>,
 }
@@ -632,6 +641,13 @@ where
 
     pub(in crate::sema) fn modules(&self) -> Ref<'_, ProviderModuleRegistry<M>> {
         self.modules.borrow()
+    }
+
+    pub(in crate::sema) fn module_is_trusted_standard_library(&self, module: &M) -> bool {
+        self.pool
+            .borrow()
+            .source
+            .module_is_trusted_standard_library(module)
     }
 
     pub(in crate::sema) fn modules_mut(&self) -> RefMut<'_, ProviderModuleRegistry<M>> {

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1770,7 +1770,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// (a destructor, or a field/payload/element that has one) that copy aliases
     /// the element's owned resources: both the copy and the still-live slot run
     /// drop glue at scope exit — a double-free. This gate rejects those reads at
-    /// their call site (E0711); the element must be *moved* out with `pop`/`pop_or`
+    /// their call site (E0711); use `get_ref` to read it in place or *move* it
+    /// out with `pop`/`pop_or`
     /// instead. It is deliberately placed in the `get`/`get_or` method bodies (not
     /// the constructor), so demand-driven analysis (ADR-0045) fires it only when a
     /// program actually calls a by-copy read — storing, pushing, popping, and

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -22,7 +22,7 @@ use crate::declaration_validation::{
     AccessorExitForm, AccessorMethodLink, AccessorYieldRootForm, accessor_method_link_error,
     accessor_yield_root_error,
 };
-use crate::inst::{Air, AirInst, AirInstData, AirPattern, AirRef};
+use crate::inst::{Air, AirInst, AirInstData, AirPattern, AirPlaceBase, AirRef};
 use crate::scope::ScopedContext;
 use crate::types::{Type, TypeKind};
 
@@ -1923,6 +1923,50 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ));
         }
 
+        // Trusted std accessors may yield the checked pointer-to-place bridge.
+        // Analyze the checked expression normally (so checked-depth and all
+        // pointer rules remain authoritative), then retain its pointer value
+        // as an indirect AIR place base. Mandatory accessor splicing embeds
+        // that ordinary place in the caller CFG; no accessor ABI is involved.
+        let bridge = match &self.body_rir_ref().get(operand).data {
+            InstData::Checked { expr } => matches!(
+                &self.body_rir_ref().get(*expr).data,
+                InstData::Intrinsic { name, .. } if *name == self.known_symbols().place
+            ),
+            _ => false,
+        };
+        if bridge {
+            let pointer = self.analyze_inst(air, operand, ctx)?;
+            let pointee = if let Some(id) = pointer.ty.as_ptr_const() {
+                self.body_type_pool().ptr_const_def(id)
+            } else if let Some(id) = pointer.ty.as_ptr_mut() {
+                self.body_type_pool().ptr_mut_def(id)
+            } else {
+                return Err(CompileError::new(
+                    accessor_yield_root_error(&AccessorYieldRootForm::Value),
+                    span,
+                ));
+            };
+            let place = air.make_place(AirPlaceBase::Indirect(pointer.air_ref), pointee, [])?;
+            let read = air.add_inst(crate::AirInst {
+                data: crate::AirInstData::PlaceRead { place },
+                ty: pointee,
+                span,
+            });
+            if !ctx.return_type.is_error() && !self.types_compatible(pointee, ctx.return_type) {
+                return Err(CompileError::new(
+                    ErrorKind::TypeMismatch {
+                        expected: ctx
+                            .return_type
+                            .safe_name_with_pool(Some(self.body_type_pool())),
+                        found: pointee.safe_name_with_pool(Some(self.body_type_pool())),
+                    },
+                    span,
+                ));
+            }
+            return Ok(AnalysisResult::new(read, pointee));
+        }
+
         // The yielded place must be a projection chain rooted at the receiver
         // parameter (E0255). Checked syntactically before the operand is read
         // so a local or temporary is named as such rather than surfacing as a
@@ -1998,12 +2042,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     // it decides every link: an unresolvable callee here is a
                     // plain method as far as 6.6:7 is concerned, since a
                     // legal link has to name an accessor.
-                    let is_accessor = ctx
+                    let resolved_method = ctx
                         .resolved_type_of(*receiver)
                         .and_then(|ty| ty.as_struct())
                         .and_then(|struct_id| {
                             self.call_facts().call_method_info(struct_id, *method)
-                        })
+                        });
+                    let is_accessor = resolved_method
                         .is_some_and(|info| info.returns_borrow || info.returns_inout);
                     let link = if is_accessor {
                         AccessorMethodLink::Accessor

--- a/crates/rue-air/src/sema/info.rs
+++ b/crates/rue-air/src/sema/info.rs
@@ -191,6 +191,10 @@ pub struct AnonMethodSig {
     /// Receiver passing mode. Meaningful when `has_self` is true; associated
     /// functions carry Normal.
     pub self_mode: rue_rir::RirParamMode,
+    /// Whether this signature returns a shared second-class place.
+    pub returns_borrow: bool,
+    /// Whether this signature returns an exclusive second-class place.
+    pub returns_inout: bool,
     /// Parameter type symbols (excluding self parameter)
     pub param_types: Vec<AnonMethodType>,
     /// Explicit parameter passing modes, parallel to `param_types`.

--- a/crates/rue-air/src/sema/known_symbols.rs
+++ b/crates/rue-air/src/sema/known_symbols.rs
@@ -133,6 +133,8 @@ pub struct KnownSymbols {
     /// The `field_ptr` intrinsic symbol - raw `ptr mut` to a struct field place
     /// without forming a reference (RUE-301), the `&raw mut (*p).field` analog.
     pub field_ptr: Spur,
+    /// The trusted checked pointer-to-place bridge used by std accessors.
+    pub place: Spur,
     /// The `syscall` intrinsic symbol - direct OS syscall.
     pub syscall: Spur,
     /// The unified byte-and-alignment allocation family (ADR-0059 Phase 3,
@@ -226,6 +228,7 @@ impl KnownSymbols {
             raw: interner.get_or_intern_static("raw"),
             raw_mut: interner.get_or_intern_static("raw_mut"),
             field_ptr: interner.get_or_intern_static("field_ptr"),
+            place: interner.get_or_intern_static("place"),
             syscall: interner.get_or_intern_static("syscall"),
             alloc: interner.get_or_intern_static("alloc"),
             free: interner.get_or_intern_static("free"),

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -352,6 +352,10 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
     pub(crate) fn module_def(&self, module: ModuleId) -> ModuleDef {
         OrdinaryBodyAnalysisHost::module_def(self.storage, module)
     }
+    pub(crate) fn file_module_is_trusted_standard_library(&self, file: FileId) -> bool {
+        self.storage
+            .endpoint_file_is_trusted_standard_library(file.index())
+    }
     pub(crate) fn struct_in_file(&self, file: FileId, name: Spur) -> Option<StructId> {
         OrdinaryBodyAnalysisHost::struct_in_file(self.storage, file, name)
     }
@@ -578,6 +582,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
                 return_type,
                 has_self,
                 self_mode,
+                returns_borrow,
+                returns_inout,
                 ..
             } = method_inst.data
             {
@@ -592,6 +598,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
                     name,
                     has_self,
                     self_mode,
+                    returns_borrow,
+                    returns_inout,
                     param_types,
                     param_modes,
                     param_comptime,
@@ -668,12 +676,15 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
                 continue;
             };
             let key = (struct_id, method_name);
-            // Accessors are not supported on anonymous structs (ADR-0062
-            // phase 1).
+            // Anonymous accessors remain a user-language restriction. The
+            // trusted std source path is the deliberate exception required by
+            // generic `ArrayBuf(T)`/collection bodies (RUE-1017).
+            let trusted_std_accessor = self
+                .file_module_is_trusted_standard_library(method_inst.span.file_id)
+                && (returns_borrow || returns_inout);
             if !seen_methods.insert(method_name)
                 || self.has_method(key)
-                || returns_borrow
-                || returns_inout
+                || ((returns_borrow || returns_inout) && !trusted_std_accessor)
             {
                 return None;
             }
@@ -720,8 +731,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
                     return_type: return_ty,
                     body,
                     span: method_inst.span,
-                    returns_borrow: false,
-                    returns_inout: false,
+                    returns_borrow: trusted_std_accessor && returns_borrow,
+                    returns_inout: trusted_std_accessor && returns_inout,
                 },
             ));
         }

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -356,6 +356,8 @@ pub struct SemanticProducedAnonymousMethodSignature {
     pub name: Arc<str>,
     pub has_self: bool,
     pub self_mode: crate::SemanticParameterMode,
+    pub returns_borrow: bool,
+    pub returns_inout: bool,
     pub parameters: Arc<
         [(
             SemanticProducedAnonymousMethodType,
@@ -577,6 +579,20 @@ pub enum DurableTryProducer {
 }
 
 pub trait DurableBodyLookupSource<K, M>: Clone {
+    /// Return the defining module for a body owner. The owner itself is not
+    /// necessarily registered as an imported module in the request-local
+    /// endpoint registry.
+    fn definition_module(&self, _definition: &K) -> Option<M> {
+        None
+    }
+
+    fn anonymous_definition_module(
+        &self,
+        _identity: &crate::AnonymousNominalKey<K, M>,
+    ) -> Option<M> {
+        None
+    }
+
     fn free_function(&self, current: &K, name: &str) -> Option<K>;
     fn value_const(&self, current: &K, name: &str) -> Option<K>;
     fn nominal(&self, current: &K, name: &str) -> Option<(K, crate::StableDefinitionKind)>;
@@ -1801,14 +1817,16 @@ where
             .get(&(struct_id, name))
             .copied()
         {
-            return Some(info);
+            return Some(self.recover_trusted_anonymous_accessor(struct_id, name, info));
         }
         if let Some(info) = self
             .endpoint
             .method_info(struct_id, name)
             .map(MethodCallInfo::from_body)
-            .or_else(|| self.named_method_info_for_symbol(struct_id, name))
         {
+            return Some(self.recover_trusted_anonymous_accessor(struct_id, name, info));
+        }
+        if let Some(info) = self.named_method_info_for_symbol(struct_id, name) {
             return Some(info);
         }
         let owner_type = Type::new_struct(struct_id);
@@ -1827,11 +1845,67 @@ where
             .borrow()
             .get(&(struct_id, name))
             .copied()
+            .map(|info| self.recover_trusted_anonymous_accessor(struct_id, name, info))
             .or_else(|| {
                 self.endpoint
                     .method_info(struct_id, name)
                     .map(MethodCallInfo::from_body)
+                    .map(|info| self.recover_trusted_anonymous_accessor(struct_id, name, info))
             })
+    }
+
+    fn recover_trusted_anonymous_accessor(
+        &self,
+        struct_id: StructId,
+        name: Spur,
+        mut info: MethodCallInfo,
+    ) -> MethodCallInfo {
+        if info.returns_borrow || info.returns_inout {
+            return info;
+        }
+        let owner_type = Type::new_struct(struct_id);
+        let durable = self
+            .durable_anonymous_types
+            .get(&owner_type)
+            .cloned()
+            .or_else(|| self.endpoint.durable_anonymous_identity(owner_type));
+        if let Some(durable) = durable {
+            let trusted = self
+                .source
+                .anonymous_definition_module(&durable)
+                .is_some_and(|module| self.source.module_is_trusted_standard_library(&module));
+            if trusted
+                && let Some(method) = self
+                    .source
+                    .anonymous_methods(&durable)
+                    .into_iter()
+                    .find(|method| method.name.as_ref() == self.interner.resolve(&name))
+            {
+                info.returns_borrow = method.returns_borrow;
+                info.returns_inout = method.returns_inout;
+                return info;
+            }
+        }
+        let definition = self.rir_struct_method_decl(struct_id, name);
+        let Some(definition) = definition else {
+            return info;
+        };
+        let trusted = self.endpoint_file_is_trusted_standard_library(
+            self.type_pool.struct_def(struct_id).file_id.index(),
+        );
+        if !trusted {
+            return info;
+        }
+        if let InstData::FnDecl {
+            returns_borrow,
+            returns_inout,
+            ..
+        } = &self.rir.rir().get(definition).data
+        {
+            info.returns_borrow = *returns_borrow;
+            info.returns_inout = *returns_inout;
+        }
+        info
     }
 
     fn const_info_for_symbol(&self, file: FileId, symbol: Spur) -> Option<ConstInfo> {
@@ -2517,6 +2591,8 @@ where
                                     name: Arc::from(self.interner.resolve(&method.name)),
                                     has_self: method.has_self,
                                     self_mode: mode(method.self_mode),
+                                    returns_borrow: method.returns_borrow,
+                                    returns_inout: method.returns_inout,
                                     parameters: method
                                         .param_types
                                         .iter()
@@ -2711,6 +2787,12 @@ where
                 method.parameters.iter().map(|(_, mode, _)| *mode),
                 method.parameters.iter().map(|(_, _, comptime)| *comptime),
             );
+            let returns_borrow = method.returns_borrow;
+            let returns_inout = method.returns_inout;
+            let trusted_std_accessor = self
+                .source
+                .anonymous_definition_module(identity)
+                .is_some_and(|module| self.source.module_is_trusted_standard_library(&module));
             // Consumer analysis needs only the signature. The producer-owned
             // anonymous-member transaction later lowers and analyzes the exact
             // body fragment; these locators are therefore deliberately opaque
@@ -2723,16 +2805,16 @@ where
                     self_mode: method.self_mode,
                     params,
                     return_type,
-                    // Anonymous-struct methods cannot be place-returning
-                    // accessors; declaration validation rejects that mode.
-                    returns_borrow: false,
-                    returns_inout: false,
+                    returns_borrow: trusted_std_accessor && returns_borrow,
+                    returns_inout: trusted_std_accessor && returns_inout,
                 },
             ));
             signatures.push(super::AnonMethodSig {
                 name,
                 has_self: method.has_self,
                 self_mode: method.self_mode,
+                returns_borrow,
+                returns_inout,
                 param_types: parameter_types
                     .into_iter()
                     .map(super::AnonMethodType::Concrete)
@@ -2812,6 +2894,10 @@ where
         self.anonymous_methods.borrow_mut().reserve(methods.len());
         let owner_name = self.member_callable_owner(struct_id);
         let owner_symbol = self.member_callable_owner_symbol(&owner_name);
+        let trusted_std_accessor_owner = self
+            .source
+            .anonymous_definition_module(identity)
+            .is_some_and(|module| self.source.module_is_trusted_standard_library(&module));
         for method in methods {
             let name = self.interner.get_or_intern(method.name.as_ref());
             let callable = self.member_callable_symbol_for_issued_owner(
@@ -2849,10 +2935,12 @@ where
                     struct_type: owner_type,
                     has_self: method.has_self,
                     self_mode: method.self_mode,
-                    // Anonymous-struct methods cannot be place-returning
-                    // accessors; declaration validation rejects that mode.
-                    returns_borrow: false,
-                    returns_inout: false,
+                    // Anonymous accessors remain forbidden for user types.
+                    // The durable std owner identity is the narrow exception,
+                    // and its second-class result mode must survive every
+                    // provider endpoint just like the direct declaration path.
+                    returns_borrow: trusted_std_accessor_owner && method.returns_borrow,
+                    returns_inout: trusted_std_accessor_owner && method.returns_inout,
                     params: self.state.allocate_params(
                         (0..method.parameters.len())
                             .map(|index| intern_synthetic_argument_name(&self.interner, index)),
@@ -2983,6 +3071,20 @@ where
     }
     fn endpoint_module_id_for_file(&self, file: u32) -> Option<ModuleId> {
         self.endpoint.endpoint_module_id_for_file(file)
+    }
+    fn endpoint_module_is_trusted_standard_library(&self, module: ModuleId) -> bool {
+        self.endpoint
+            .endpoint_module_is_trusted_standard_library(module)
+    }
+    fn endpoint_file_is_trusted_standard_library(&self, file: u32) -> bool {
+        if FileId::new(file) == self.owner_file {
+            return self
+                .source
+                .definition_module(&self.key)
+                .is_some_and(|module| self.source.module_is_trusted_standard_library(&module));
+        }
+        self.endpoint_module_id_for_file(file)
+            .is_some_and(|module| self.endpoint_module_is_trusted_standard_library(module))
     }
     fn endpoint_intern_array(&self, element: Type, len: u64) -> Option<Type> {
         self.type_pool.try_intern_array(element, len).ok()
@@ -5161,7 +5263,7 @@ where
         .cloned()
         .collect::<AHashSet<_>>();
 
-    let (params, body, has_self, self_mode, self_is_mut, span) =
+    let (params, body, has_self, self_mode, self_is_mut, returns_borrow, returns_inout, span) =
         match &host.rir.rir().get(declaration).data {
             InstData::FnDecl {
                 params,
@@ -5169,6 +5271,8 @@ where
                 has_self,
                 self_mode,
                 self_is_mut,
+                returns_borrow,
+                returns_inout,
                 ..
             } => (
                 params.clone(),
@@ -5176,6 +5280,8 @@ where
                 *has_self,
                 *self_mode,
                 *self_is_mut,
+                *returns_borrow,
+                *returns_inout,
                 host.rir.rir().get(declaration).span,
             ),
             _ => {
@@ -5333,7 +5439,7 @@ where
         owner_type,
         self_is_mut,
         member.kind == crate::AnonymousMemberKind::Destructor,
-        false,
+        returns_borrow || returns_inout,
     )?;
     let expression_engine_ns = elapsed_ns(expression_engine_started);
     let expression_breakdown = host

--- a/crates/rue-air/src/sema/provider_module_registry.rs
+++ b/crates/rue-air/src/sema/provider_module_registry.rs
@@ -75,4 +75,10 @@ impl<M: Eq + Hash> ProviderModuleRegistry<M> {
     pub(in crate::sema) fn id_for_durable(&self, durable: &M) -> Option<ModuleId> {
         self.by_durable.get(durable).copied()
     }
+
+    pub(in crate::sema) fn durable_for_id(&self, id: ModuleId) -> Option<&M> {
+        self.by_durable
+            .iter()
+            .find_map(|(durable, candidate)| (*candidate == id).then_some(durable))
+    }
 }

--- a/crates/rue-air/src/sema/semantic_body_export.rs
+++ b/crates/rue-air/src/sema/semantic_body_export.rs
@@ -171,6 +171,12 @@ pub(crate) fn export_body<H: SemanticBodyExportHost>(
                 }
                 crate::AirPlaceBase::Accessor(call)
             }
+            crate::AirPlaceBase::Indirect(pointer) => {
+                if pointer.as_u32() as usize >= instruction_count {
+                    return Err(F::InvalidInstructionReference);
+                }
+                crate::AirPlaceBase::Indirect(pointer)
+            }
         };
         places.push(SemanticBodyPlace {
             base,

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -1378,7 +1378,7 @@ impl<'a> CfgBuilder<'a> {
                             // them) — record it so CSE's param keying skips
                             // the slot (RUE-914 hunt finding).
                             PlaceBase::Param(slot) => self.cfg.mark_param_address_taken(slot),
-                            PlaceBase::Accessor(_) => {}
+                            PlaceBase::Accessor(_) | PlaceBase::Indirect(_) => {}
                         },
                         // A bare scalar parameter lowers directly to a Param
                         // value with no backing local; its address escaping
@@ -2209,7 +2209,7 @@ impl<'a> CfgBuilder<'a> {
                     // Accessor places are replaced by the mandatory accessor
                     // CFG splice. Their overwrite drop is elaborated by the
                     // substituted ordinary place when one exists.
-                    AirPlaceBase::Accessor(_) => None,
+                    AirPlaceBase::Accessor(_) | AirPlaceBase::Indirect(_) => None,
                 };
                 if base_key.is_none() && self.type_pool.type_needs_drop(old_ty) {
                     let old_val = self.emit(
@@ -3491,6 +3491,7 @@ impl<'a> CfgBuilder<'a> {
             AirPlaceBase::Local(slot) => PlaceBase::Local(slot),
             AirPlaceBase::Param(slot) => PlaceBase::Param(slot),
             AirPlaceBase::Accessor(call) => PlaceBase::Accessor(self.lower_value(call)?),
+            AirPlaceBase::Indirect(pointer) => PlaceBase::Indirect(self.lower_value(pointer)?),
         };
 
         // Convert projections, lowering any index expressions

--- a/crates/rue-cfg/src/inline.rs
+++ b/crates/rue-cfg/src/inline.rs
@@ -340,9 +340,14 @@ pub fn inline_call_in_block(
                         dst.mark_param_address_taken(slot);
                     }
                 }
-                PlaceBase::Accessor(_) => {
-                    return Err(CfgInlineError::NonPlaceByRefArgument { arg_index: index });
-                }
+                // A nested accessor may be encountered before its producer is
+                // spliced. Preserve that second-class root through this splice;
+                // substituting the producer later composes the final place.
+                PlaceBase::Accessor(_) => {}
+                // Trusted std accessors yield an indirect place. A nested
+                // accessor reborrows that exact storage, so its pointer root
+                // must survive the following mandatory splice.
+                PlaceBase::Indirect(_) => {}
             }
             ParamRedirect::ByRefPlace {
                 base: place.base,
@@ -726,14 +731,14 @@ fn translate_data(
             ParamRedirect::Materialized { slot } => Load { slot },
             ParamRedirect::ByRefPlace {
                 base,
-                base_type: _,
+                base_type,
                 projections,
             } if projections.is_empty() => match base {
                 PlaceBase::Local(slot) => Load { slot },
                 PlaceBase::Param(index) => Param { index },
-                PlaceBase::Accessor(_) => {
-                    unreachable!("accessor roots are rejected at classification")
-                }
+                PlaceBase::Accessor(_) | PlaceBase::Indirect(_) => PlaceRead {
+                    place: dst.make_place(base, base_type, projections)?,
+                },
             },
             ParamRedirect::ByRefPlace {
                 base,
@@ -782,14 +787,15 @@ fn translate_data(
                 ParamRedirect::Materialized { slot } => Store { slot, value },
                 ParamRedirect::ByRefPlace {
                     base,
-                    base_type: _,
+                    base_type,
                     projections,
                 } if projections.is_empty() => match base {
                     PlaceBase::Local(slot) => Store { slot, value },
                     PlaceBase::Param(param_slot) => ParamStore { param_slot, value },
-                    PlaceBase::Accessor(_) => {
-                        unreachable!("accessor roots are rejected at classification")
-                    }
+                    PlaceBase::Accessor(_) | PlaceBase::Indirect(_) => PlaceWrite {
+                        place: dst.make_place(base, base_type, projections)?,
+                        value,
+                    },
                 },
                 ParamRedirect::ByRefPlace {
                     base,
@@ -967,6 +973,11 @@ fn translate_place(
         },
         PlaceBase::Accessor(value) => (
             PlaceBase::Accessor(splice.value(value)),
+            place.base_type,
+            Vec::new(),
+        ),
+        PlaceBase::Indirect(value) => (
+            PlaceBase::Indirect(splice.value(value)),
             place.base_type,
             Vec::new(),
         ),

--- a/crates/rue-cfg/src/inline.rs
+++ b/crates/rue-cfg/src/inline.rs
@@ -565,7 +565,6 @@ fn substitute_accessor_places(
     yielded_value: CfgValue,
 ) -> Result<(), CfgInlineError> {
     let mut replacements = Vec::new();
-    let mut value_replacements = ValueReplacementIndex::new(cfg.value_count());
     for index in 0..cfg.value_count() {
         let value = CfgValue::from_raw(index as u32);
         let place = match &cfg.get_inst(value).data {
@@ -576,12 +575,6 @@ fn substitute_accessor_places(
             }
             _ => continue,
         };
-        if matches!(cfg.get_inst(value).data, CfgInstData::PlaceRead { .. })
-            && cfg.get_place_projections(place).is_empty()
-        {
-            value_replacements.insert(value);
-            continue;
-        }
         let mut projections = cfg.get_place_projections(yielded).to_vec();
         projections.extend_from_slice(cfg.get_place_projections(place));
         let composed = cfg.make_place(yielded.base, yielded.base_type, projections)?;
@@ -594,74 +587,21 @@ fn substitute_accessor_places(
             _ => unreachable!(),
         }
     }
-    if !value_replacements.is_empty() {
-        cfg.rewrite_value_uses(|value| {
-            if value_replacements.contains(value) {
-                yielded_value
-            } else {
-                value
-            }
-        })?;
-        for block_index in 0..cfg.block_count() {
-            let block = BlockId::from_raw(block_index as u32);
-            cfg.get_block_mut(block)
-                .insts
-                .retain(|value| !value_replacements.contains(*value));
-        }
+
+    // The callee's trailing `PlaceRead` is the CFG encoding of `yield place`,
+    // not a dynamic read that survives expansion. Every caller consumer now
+    // names the composed yielded place directly, matching 6.6:12's reduction.
+    // Detaching this structural read is also required for nested accessors:
+    // otherwise its indirect pointer can be lazily materialized in an
+    // earlier-numbered continuation block and then used before definition in
+    // the appended inner guard blocks.
+    for block_index in 0..cfg.block_count() {
+        let block = BlockId::from_raw(block_index as u32);
+        cfg.get_block_mut(block)
+            .insts
+            .retain(|value| *value != yielded_value);
     }
     Ok(())
-}
-
-/// Compact membership index for accessor reads replaced by one yielded value.
-/// `CfgValue` is an arena index, so no hashing or candidate scan is needed.
-struct ValueReplacementIndex {
-    members: Option<Vec<bool>>,
-    value_count: usize,
-    len: usize,
-    #[cfg(test)]
-    membership_probes: std::cell::Cell<u64>,
-}
-
-impl ValueReplacementIndex {
-    fn new(value_count: usize) -> Self {
-        Self {
-            members: None,
-            value_count,
-            len: 0,
-            #[cfg(test)]
-            membership_probes: std::cell::Cell::new(0),
-        }
-    }
-
-    fn insert(&mut self, value: CfgValue) {
-        let members = self
-            .members
-            .get_or_insert_with(|| vec![false; self.value_count]);
-        let member = &mut members[value.as_u32() as usize];
-        if !*member {
-            *member = true;
-            self.len += 1;
-        }
-    }
-
-    fn contains(&self, value: CfgValue) -> bool {
-        #[cfg(test)]
-        self.membership_probes.set(self.membership_probes.get() + 1);
-        self.members
-            .as_ref()
-            .and_then(|members| members.get(value.as_u32() as usize))
-            .copied()
-            .unwrap_or(false)
-    }
-
-    fn is_empty(&self) -> bool {
-        self.len == 0
-    }
-
-    #[cfg(test)]
-    fn membership_probes(&self) -> u64 {
-        self.membership_probes.get()
-    }
 }
 
 /// The callee's per-source-parameter grouping: the recorded ABI descriptors
@@ -1302,24 +1242,7 @@ mod tests {
     }
 
     #[test]
-    fn accessor_replacement_membership_is_one_probe_per_value() {
-        let value_count = 4_096usize;
-        let mut replacements = ValueReplacementIndex::new(value_count);
-        for index in (0..384u32).step_by(3) {
-            replacements.insert(CfgValue::from_raw(index));
-        }
-
-        for index in 0..value_count {
-            assert_eq!(
-                replacements.contains(CfgValue::from_raw(index as u32)),
-                index < 384 && index % 3 == 0
-            );
-        }
-        assert_eq!(replacements.membership_probes(), value_count as u64);
-    }
-
-    #[test]
-    fn many_accessor_reads_are_rewritten_and_detached_together() {
+    fn many_accessor_reads_are_composed_and_structural_yield_is_detached() {
         let mut cfg = Cfg::new(Type::I64, 1, 0, "caller".to_string(), Vec::<bool>::new());
         let entry = cfg.new_block();
         cfg.entry = entry;
@@ -1369,12 +1292,16 @@ mod tests {
         let yielded = Place::local(0, Type::I64);
         substitute_accessor_places(&mut cfg, call, &yielded, yielded_value).unwrap();
 
-        for user in users {
+        for (read, user) in reads.iter().copied().zip(users) {
             assert!(matches!(
                 cfg.get_inst(user).data,
                 CfgInstData::Add(left, right)
-                    if left == yielded_value && right == yielded_value
+                    if left == read && right == read
             ));
+            let CfgInstData::PlaceRead { place } = &cfg.get_inst(read).data else {
+                panic!("accessor consumer must remain a place read");
+            };
+            assert_eq!(place.base, PlaceBase::Local(0));
         }
         let attached = cfg
             .get_block(entry)
@@ -1382,7 +1309,8 @@ mod tests {
             .iter()
             .copied()
             .collect::<Vec<_>>();
-        assert!(reads.iter().all(|read| !attached.contains(read)));
+        assert!(reads.iter().all(|read| attached.contains(read)));
+        assert!(!attached.contains(&yielded_value));
     }
 
     fn count_matching(cfg: &Cfg, predicate: impl Fn(&CfgInstData) -> bool) -> usize {

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -115,7 +115,7 @@ impl Place {
         if self.projections.is_empty() {
             match self.base {
                 PlaceBase::Local(slot) => Some(slot),
-                PlaceBase::Param(_) | PlaceBase::Accessor(_) => None,
+                PlaceBase::Param(_) | PlaceBase::Accessor(_) | PlaceBase::Indirect(_) => None,
             }
         } else {
             None
@@ -128,7 +128,7 @@ impl Place {
         if self.projections.is_empty() {
             match self.base {
                 PlaceBase::Param(slot) => Some(slot),
-                PlaceBase::Local(_) | PlaceBase::Accessor(_) => None,
+                PlaceBase::Local(_) | PlaceBase::Accessor(_) | PlaceBase::Indirect(_) => None,
             }
         } else {
             None
@@ -258,6 +258,7 @@ impl fmt::Display for Place {
             PlaceBase::Local(slot) => write!(f, "${}", slot)?,
             PlaceBase::Param(slot) => write!(f, "%{}", slot)?,
             PlaceBase::Accessor(value) => write!(f, "accessor%{}", value.as_u32())?,
+            PlaceBase::Indirect(pointer) => write!(f, "*ptr%{}", pointer.as_u32())?,
         }
         if !self.projections.is_empty() {
             write!(f, "[{} projections]", self.projections.extent())?;
@@ -276,6 +277,8 @@ pub enum PlaceBase {
     /// Mandatory-inline accessor call whose place result has not yet been
     /// substituted by the inter-procedural CFG splice.
     Accessor(CfgValue),
+    /// Indirect pointee address produced by the trusted std `@place` bridge.
+    Indirect(CfgValue),
 }
 
 /// A projection applied to a place to reach a nested location.
@@ -2155,6 +2158,7 @@ impl Cfg {
                 (value.as_u32() as usize) < self.values.len()
                     && matches!(self.get_inst(value).data, CfgInstData::AccessorCall { .. })
             }
+            PlaceBase::Indirect(value) => (value.as_u32() as usize) < self.values.len(),
         };
         if !base_valid {
             return Err(Self::invalid_edit(operation, "place base is out of bounds"));
@@ -2698,8 +2702,11 @@ impl Cfg {
                 | IntCast { value: v, .. }
                 | Drop { value: v } => *v = map(*v),
                 PlaceRead { place } => {
-                    if let PlaceBase::Accessor(value) = &mut place.base {
-                        *value = map(*value);
+                    match &mut place.base {
+                        PlaceBase::Accessor(value) | PlaceBase::Indirect(value) => {
+                            *value = map(*value)
+                        }
+                        PlaceBase::Local(_) | PlaceBase::Param(_) => {}
                     }
                     place.projections = payload::push_projections(
                         &mut self.projections,
@@ -2722,8 +2729,9 @@ impl Cfg {
                 }
                 PlaceWrite { place, value } => {
                     *value = map(*value);
-                    if let PlaceBase::Accessor(base) = &mut place.base {
-                        *base = map(*base);
+                    match &mut place.base {
+                        PlaceBase::Accessor(base) | PlaceBase::Indirect(base) => *base = map(*base),
+                        PlaceBase::Local(_) | PlaceBase::Param(_) => {}
                     }
                     place.projections = payload::push_projections(
                         &mut self.projections,
@@ -3276,6 +3284,9 @@ impl Cfg {
             }
             PlaceBase::Accessor(value) => {
                 let _ = write!(out, "accessor%{}", value.as_u32());
+            }
+            PlaceBase::Indirect(value) => {
+                let _ = write!(out, "*ptr%{}", value.as_u32());
             }
         }
         for proj in self.get_place_projections(place) {

--- a/crates/rue-cfg/src/opt/dce.rs
+++ b/crates/rue-cfg/src/opt/dce.rs
@@ -286,7 +286,9 @@ pub(super) fn visit_instruction_uses(cfg: &Cfg, value: CfgValue, mut f: impl FnM
 
         // Place operations
         CfgInstData::PlaceRead { place } => {
-            if let crate::PlaceBase::Accessor(value) = place.base {
+            if let crate::PlaceBase::Accessor(value) | crate::PlaceBase::Indirect(value) =
+                place.base
+            {
                 f(value);
             }
             // Visit any index values used in projections
@@ -298,7 +300,9 @@ pub(super) fn visit_instruction_uses(cfg: &Cfg, value: CfgValue, mut f: impl FnM
         }
         CfgInstData::PlaceWrite { place, value } => {
             f(*value);
-            if let crate::PlaceBase::Accessor(value) = place.base {
+            if let crate::PlaceBase::Accessor(value) | crate::PlaceBase::Indirect(value) =
+                place.base
+            {
                 f(value);
             }
             // Visit any index values used in projections

--- a/crates/rue-cfg/src/opt/forward.rs
+++ b/crates/rue-cfg/src/opt/forward.rs
@@ -285,7 +285,7 @@ pub fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
                                 // A parameter base writes through a parameter,
                                 // not a local slot: nothing to kill.
                                 PlaceBase::Param(_) => {}
-                                PlaceBase::Accessor(_) => {
+                                PlaceBase::Accessor(_) | PlaceBase::Indirect(_) => {
                                     clear_all = true;
                                 }
                             },

--- a/crates/rue-cfg/src/opt/unroll.rs
+++ b/crates/rue-cfg/src/opt/unroll.rs
@@ -526,6 +526,7 @@ fn remap_data(
         CfgInstData::PlaceRead { place } => {
             let base = match place.base {
                 PlaceBase::Accessor(v) => PlaceBase::Accessor(m(v)),
+                PlaceBase::Indirect(v) => PlaceBase::Indirect(m(v)),
                 b => b,
             };
             let ps = source
@@ -552,6 +553,7 @@ fn remap_data(
         CfgInstData::PlaceWrite { place, value } => {
             let base = match place.base {
                 PlaceBase::Accessor(v) => PlaceBase::Accessor(m(v)),
+                PlaceBase::Indirect(v) => PlaceBase::Indirect(m(v)),
                 b => b,
             };
             let ps = source

--- a/crates/rue-cfg/src/verify.rs
+++ b/crates/rue-cfg/src/verify.rs
@@ -279,7 +279,7 @@ impl Cfg {
     /// Collect the `CfgValue` operands hiding inside a place's `Index`
     /// projections.
     fn collect_place_operands(&self, place: &crate::inst::Place, out: &mut Vec<CfgValue>) {
-        if let PlaceBase::Accessor(value) = place.base {
+        if let PlaceBase::Accessor(value) | PlaceBase::Indirect(value) = place.base {
             out.push(value);
         }
         for proj in self.get_place_projections(place) {
@@ -884,6 +884,14 @@ impl<'a> Verifier<'a> {
                     )));
                 }
             }
+            PlaceBase::Indirect(pointer) => {
+                let inst = self.cfg.get_inst(pointer);
+                if !inst.ty.is_ptr() {
+                    return Err(self.error(format!(
+                        "{block}: {value} has an invalid indirect place pointer"
+                    )));
+                }
+            }
         }
         let projections = self.cfg.get_place_projections(place);
         if let Some(pool) = self.type_pool {
@@ -1224,8 +1232,11 @@ impl<'a> Verifier<'a> {
                 f(*value, "stored value")
             }
             CfgInstData::PlaceRead { place } => {
-                if let PlaceBase::Accessor(producer) = place.base {
-                    f(producer, "accessor place producer");
+                match place.base {
+                    PlaceBase::Accessor(producer) | PlaceBase::Indirect(producer) => {
+                        f(producer, "place base producer")
+                    }
+                    PlaceBase::Local(_) | PlaceBase::Param(_) => {}
                 }
                 for projection in self.cfg.get_place_projections(place) {
                     if let Projection::Index { index, .. } = projection {
@@ -1234,8 +1245,11 @@ impl<'a> Verifier<'a> {
                 }
             }
             CfgInstData::PlaceWrite { place, value } => {
-                if let PlaceBase::Accessor(producer) = place.base {
-                    f(producer, "accessor place producer");
+                match place.base {
+                    PlaceBase::Accessor(producer) | PlaceBase::Indirect(producer) => {
+                        f(producer, "place base producer")
+                    }
+                    PlaceBase::Local(_) | PlaceBase::Param(_) => {}
                 }
                 for projection in self.cfg.get_place_projections(place) {
                     if let Projection::Index { index, .. } = projection {

--- a/crates/rue-cli-tests/cases/arraybuf_library.toml
+++ b/crates/rue-cli-tests/cases/arraybuf_library.toml
@@ -775,16 +775,17 @@ exit_code = 243
 # StrBuf that aliased its owned heap buffer; both the copy and the still-live
 # slot ran drop glue at scope exit — a double-free that segfaulted in safe code
 # (verified: this program exited 139 before the fix). The reader now gates on its
-# element type and directs the caller to `pop` (which moves the element out,
-# leaving one owner). Storing/pushing/popping a StrBuf element stays legal — the
+# element type and directs the caller to `get_ref` for an in-place read or `pop`
+# to move the element out, leaving one owner. Storing/pushing/popping a StrBuf
+# element stays legal — the
 # `arraybuf_strbuf_elements` case above (which uses `pop`) still runs.
 [[case]]
 name = "arraybuf_get_on_drop_glue_element_rejected"
-description = "A by-copy `get` of a drop-glue element (StrBuf) is rejected with E0711 and pointed at `pop`, instead of a double-free segfault (RUE-651)."
+description = "A by-copy `get` of a drop-glue element (StrBuf) is rejected with E0711 and pointed at `get_ref` or `pop`, instead of a double-free segfault (RUE-651/RUE-1017)."
 env = { RUE_STD_PATH = "${REAL_STD}" }
 args = ["main.rue", "-o", "prog"]
 compile_fail = true
-error_contains = ["E0711", "by copy", "move it out with `pop`"]
+error_contains = ["E0711", "by copy", "use `get_ref` for an in-place read", "move it out with `pop`/`pop_or`"]
 files = [{ path = "main.rue", source = """
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;

--- a/crates/rue-cli-tests/cases/borrow_accessors.toml
+++ b/crates/rue-cli-tests/cases/borrow_accessors.toml
@@ -164,11 +164,15 @@ fn main() -> i32 {
     let mut rows = Rows.new();
     rows.push(row);
     let grid = Grid { rows: rows };
-    if grid.get_ref(0).get_ref(0) == 42 { 0 } else { 1 }
+    @dbg(1017);
+    let matches = grid.get_ref(0).get_ref(0) == 42;
+    @dbg(1018);
+    if matches { 0 } else { 1 }
 }
 """ }]
 args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "1017\n1018\n"
 exit_code = 0
 
 [[case]]

--- a/crates/rue-cli-tests/cases/borrow_accessors.toml
+++ b/crates/rue-cli-tests/cases/borrow_accessors.toml
@@ -164,17 +164,11 @@ fn main() -> i32 {
     let mut rows = Rows.new();
     rows.push(row);
     let grid = Grid { rows: rows };
-    @dbg(1017);
-    @dbg(grid.rows.get_ref(0).values.len());
-    @dbg(grid.get_ref(0).values.len());
-    let matches = grid.get_ref(0).get_ref(0) == 42;
-    @dbg(1018);
-    if matches { 0 } else { 1 }
+    if grid.get_ref(0).get_ref(0) == 42 { 0 } else { 1 }
 }
 """ }]
 args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
-stdout = "1017\n1\n1\n1018\n"
 exit_code = 0
 
 [[case]]

--- a/crates/rue-cli-tests/cases/borrow_accessors.toml
+++ b/crates/rue-cli-tests/cases/borrow_accessors.toml
@@ -165,6 +165,7 @@ fn main() -> i32 {
     rows.push(row);
     let grid = Grid { rows: rows };
     @dbg(1017);
+    @dbg(grid.rows.get_ref(0).values.len());
     @dbg(grid.get_ref(0).values.len());
     let matches = grid.get_ref(0).get_ref(0) == 42;
     @dbg(1018);
@@ -173,7 +174,7 @@ fn main() -> i32 {
 """ }]
 args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
-stdout = "1017\n1\n1018\n"
+stdout = "1017\n1\n1\n1018\n"
 exit_code = 0
 
 [[case]]

--- a/crates/rue-cli-tests/cases/borrow_accessors.toml
+++ b/crates/rue-cli-tests/cases/borrow_accessors.toml
@@ -165,6 +165,7 @@ fn main() -> i32 {
     rows.push(row);
     let grid = Grid { rows: rows };
     @dbg(1017);
+    @dbg(grid.get_ref(0).values.len());
     let matches = grid.get_ref(0).get_ref(0) == 42;
     @dbg(1018);
     if matches { 0 } else { 1 }
@@ -172,7 +173,7 @@ fn main() -> i32 {
 """ }]
 args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
-stdout = "1017\n1018\n"
+stdout = "1017\n1\n1018\n"
 exit_code = 0
 
 [[case]]

--- a/crates/rue-cli-tests/cases/borrow_accessors.toml
+++ b/crates/rue-cli-tests/cases/borrow_accessors.toml
@@ -4,6 +4,246 @@ name = "Borrow accessor CFG splicing"
 description = "Marked place-returning accessor calls are mandatorily spliced before both backends."
 
 [[case]]
+name = "trusted_std_arraybuf_get_ref_splices_indirect_place"
+description = "The trusted ArrayBuf bridge reads the live cell through an ordinary indirect place."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+fn main() -> i32 {
+    let B = std.arraybuf.ArrayBuf(i64);
+    let mut b = B.new();
+    b.push(41);
+    if b.get_ref(0) + 1 == 42 { 0 } else { 1 }
+}
+""" }]
+args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+exit_code = 0
+
+[[case]]
+name = "trusted_std_arraybuf_get_ref_aarch64"
+description = "The indirect ArrayBuf place lowers on AArch64 without publishing a get_ref symbol."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+fn main() -> i32 {
+    let B = std.arraybuf.ArrayBuf(i64);
+    let mut b = B.new();
+    b.push(42);
+    if b.get_ref(0) == 42 { 0 } else { 1 }
+}
+""" }]
+args = ["--preview", "borrow_accessors", "--emit", "asm", "--target", "aarch64-linux", "main.rue"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+compile_only = true
+compile_stdout_contains = ["=== Assembly (aarch64-linux) ===", "main:"]
+compile_stdout_not_contains = ["get_ref:"]
+
+[[case]]
+name = "trusted_std_get_ref_in_provider_helper"
+description = "A helper body retains the durable accessor mode and lowers an indirect place rooted in a borrow parameter."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const B = std.arraybuf.ArrayBuf(i64);
+fn read_second(borrow b: B) -> i64 {
+    let value = b.get_ref(1) + 1;
+    value
+}
+fn main() -> i32 {
+    let mut b = B.new();
+    b.push(1);
+    b.push(41);
+    if read_second(borrow b) == 42 { 0 } else { 1 }
+}
+""" }]
+args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+exit_code = 0
+
+[[case]]
+name = "trusted_std_arraybuf_get_ref_bounds_guard"
+description = "ArrayBuf.get_ref runs its source-defined bounds guard before forming the indirect place."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+fn main() -> i32 {
+    let B = std.arraybuf.ArrayBuf(i64);
+    let mut b = B.new();
+    b.push(1);
+    if b.get_ref(1) == 1 { 0 } else { 1 }
+}
+""" }]
+args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+exit_code = 101
+runtime_error_contains = ["panic: index out of bounds"]
+
+[[case]]
+name = "trusted_std_accessor_call_requires_preview"
+description = "The trusted declaration exemption does not remove the call-site preview gate."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+fn main() -> i32 {
+    let B = std.arraybuf.ArrayBuf(i64);
+    let mut b = B.new();
+    b.push(1);
+    b.get_ref(0);
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+compile_fail = true
+error_contains = ["E1100", "borrow_accessors"]
+
+[[case]]
+name = "trusted_std_grid_get_ref"
+description = "The real-std Grid2D accessor reads a flattened cell through the trusted place bridge."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+fn main() -> i32 {
+    let G = std.grid.Grid2D(i64);
+    let mut g = G.new(1, 1, 41);
+    if g.get_ref(0, 0) + 1 == 42 { 0 } else { 1 }
+}
+""" }]
+args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+exit_code = 0
+
+[[case]]
+name = "owned_children_tree_get_ref_drop_glue"
+description = "Unlike examples/ruelex's POD ArrayBuf(Node) arena with u64 child IDs, an owned-children Node tree traverses nested ArrayBuf(Node) storage through get_ref and drops every node exactly once."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+struct Node {
+    tag: i64,
+    kids: std.arraybuf.ArrayBuf(Node),
+}
+drop fn Node(self) { @dbg(self.tag); }
+fn main() -> i32 {
+    let B = std.arraybuf.ArrayBuf(Node);
+    let mut root = Node { tag: 1, kids: B.new() };
+    let mut child = Node { tag: 2, kids: B.new() };
+    let grandchild = Node { tag: 3, kids: B.new() };
+    child.kids.push(grandchild);
+    root.kids.push(child);
+    // This is the core shape the ruelex arena cannot currently express:
+    // child edges own Nodes directly, yet traversal borrows through both
+    // ArrayBuf levels without copying either owner.
+    if root.kids.get_ref(0).kids.get_ref(0).tag == 3 { 0 } else { 1 }
+}
+""" }]
+args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "1\n2\n3\n"
+exit_code = 0
+
+[[case]]
+name = "nested_grid_row_and_arraybuf_accessors"
+description = "A receiver-rooted grid row accessor composes with ArrayBuf.get_ref as grid.get_ref(i).get_ref(j)."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+struct Row {
+    values: std.arraybuf.ArrayBuf(i64),
+
+    fn get_ref(borrow self, i: u64) -> borrow i64 {
+        yield self.values.get_ref(i);
+    }
+}
+struct Grid {
+    rows: std.arraybuf.ArrayBuf(Row),
+
+    fn get_ref(borrow self, i: u64) -> borrow Row {
+        yield self.rows.get_ref(i);
+    }
+}
+fn main() -> i32 {
+    let Values = std.arraybuf.ArrayBuf(i64);
+    let Rows = std.arraybuf.ArrayBuf(Row);
+    let mut values = Values.new();
+    values.push(42);
+    let row = Row { values: values };
+    let mut rows = Rows.new();
+    rows.push(row);
+    let grid = Grid { rows: rows };
+    if grid.get_ref(0).get_ref(0) == 42 { 0 } else { 1 }
+}
+""" }]
+args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+exit_code = 0
+
+[[case]]
+name = "trusted_std_get_ref_conflicts_with_inout"
+description = "A live ArrayBuf.get_ref loan conflicts with an inout use of the same buffer in the enclosing expression."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+fn use_two(a: i64, b: ()) -> i64 { a }
+fn main() -> i32 {
+    let B = std.arraybuf.ArrayBuf(i64);
+    let mut b = B.new();
+    b.push(1);
+    use_two(b.get_ref(0), b.push(2));
+    0
+}
+""" }]
+args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+compile_fail = true
+error_contains = ["E0259", "while an accessor result borrows it"]
+
+[[case]]
+name = "trusted_std_get_ref_cannot_escape"
+description = "The standard-library accessor retains the ordinary expression-scoped lifetime rule."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const B = std.arraybuf.ArrayBuf(i64);
+fn first(borrow b: B) -> i64 { return b.get_ref(0); }
+fn main() -> i32 {
+    let mut b = B.new();
+    b.push(1);
+    @intCast(first(borrow b))
+}
+""" }]
+args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+compile_fail = true
+error_contains = ["E0250", "cannot return an accessor result"]
+
+[[case]]
+name = "trusted_std_stack_and_queue_peek_ref"
+description = "Stack and Queue peeks reuse ArrayBuf.get_ref and read destructor-bearing elements without copying them."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+struct D { value: i64 }
+drop fn D(self) { @dbg(self.value); }
+fn main() -> i32 {
+    let S = std.stack.Stack(D);
+    let Q = std.queue.Queue(D);
+    let mut stack = S.new();
+    stack.push(D { value: 7 });
+    let mut queue = Q.new();
+    queue.enqueue(D { value: 8 });
+    if stack.peek_ref().value == 7 && queue.peek_ref().value == 8 { 0 } else { 1 }
+}
+""" }]
+args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "8\n7\n"
+exit_code = 0
+
+[[case]]
+name = "place_bridge_rejected_in_user_code"
+description = "The trusted pointer-to-place bridge is not a user-visible intrinsic."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    checked { @place(1) };
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0700", "place"]
+
+[[case]]
 name = "guarded_splice_aarch64"
 files = [{ path = "main.rue", source = """
 struct Grid {

--- a/crates/rue-codegen/src/param_storage.rs
+++ b/crates/rue-codegen/src/param_storage.rs
@@ -307,6 +307,11 @@ fn scan_param_references(cfg: &Cfg, type_pool: &FrozenTypeInternPool) -> ParamRe
                         PlaceBase::Accessor(_) => {
                             panic!("mandatory-inline accessor place reached codegen")
                         }
+                        // The pointer producer is an ordinary SSA value. Any
+                        // parameter storage it depends on is recorded by that
+                        // producer's own operands; the indirect base itself
+                        // names no parameter slot or home region.
+                        PlaceBase::Indirect(_) => {}
                     }
                 }
                 CfgInstData::Alloc { slot, .. }

--- a/crates/rue-codegen/src/place_lower.rs
+++ b/crates/rue-codegen/src/place_lower.rs
@@ -205,6 +205,20 @@ fn resolved_access<B: PlaceLowerBackend + ?Sized>(
                 dynamic_offset,
             )
         }
+        crate::value_plan::PlaceBasePlan::Pointer(ptr) => {
+            let byte_offset = offsets.static_slot_offset as i32 * allocation::SLOT_BYTES as i32;
+            if let Some(dynamic) = dynamic_offset {
+                let addr = b.alloc_vreg();
+                b.emit_reg_move(addr, ptr);
+                if byte_offset != 0 {
+                    b.emit_addr_add_imm(addr, byte_offset);
+                }
+                b.emit_addr_add(addr, dynamic);
+                ProjectedAccess::PointerAddr(addr)
+            } else {
+                ProjectedAccess::PointerOffset { ptr, byte_offset }
+            }
+        }
     }
 }
 
@@ -263,6 +277,7 @@ pub(crate) fn lower_place_read_plan<B: PlaceLowerBackend>(
                 slot,
                 by_ref: false,
             } => b.emit_load_slot(dst, b.ctx().param_frame_slot(slot)),
+            crate::value_plan::PlaceBasePlan::Pointer(ptr) => b.emit_load_ptr_base(dst, ptr),
         }
         return;
     }
@@ -296,6 +311,9 @@ pub(crate) fn lower_place_write_plan<B: PlaceLowerBackend>(
                 slot,
                 by_ref: false,
             } => agg_slots::store_slots(b, vals, b.ctx().param_frame_slot(slot)),
+            crate::value_plan::PlaceBasePlan::Pointer(ptr) => {
+                agg_slots::store_slots_through_ptr(b, vals, ptr, 0)
+            }
         }
         return;
     }
@@ -356,6 +374,16 @@ fn lower_place_addr_plan_with_bounds<B: PlaceLowerBackend + ?Sized>(
                 dst,
                 projected_low_slot(base_slot, root_count, offsets.static_slot_offset),
             );
+            if let Some(dynamic) = dynamic {
+                b.emit_addr_add(dst, dynamic);
+            }
+        }
+        crate::value_plan::PlaceBasePlan::Pointer(ptr) => {
+            b.emit_reg_move(dst, ptr);
+            let byte_offset = offsets.static_slot_offset as i32 * allocation::SLOT_BYTES as i32;
+            if byte_offset != 0 {
+                b.emit_addr_add_imm(dst, byte_offset);
+            }
             if let Some(dynamic) = dynamic {
                 b.emit_addr_add(dst, dynamic);
             }
@@ -481,7 +509,9 @@ mod tests {
         let seed = match base {
             PlaceBase::Local(slot) => Place::local(slot, base_type),
             PlaceBase::Param(slot) => Place::param(slot, base_type),
-            PlaceBase::Accessor(_) => unreachable!("accessor places are spliced before lowering"),
+            PlaceBase::Accessor(_) | PlaceBase::Indirect(_) => {
+                unreachable!("non-materialized places are spliced before lowering")
+            }
         };
         let instruction = value(
             cfg,

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -422,7 +422,12 @@ pub enum ByRefAddressPlan {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PlaceBasePlan {
     Local(u32),
-    Param { slot: u32, by_ref: bool },
+    Param {
+        slot: u32,
+        by_ref: bool,
+    },
+    /// An address value produced by the trusted std pointer-to-place bridge.
+    Pointer(VReg),
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProjectionPlan {
@@ -754,6 +759,11 @@ fn place_plan<A: ValueLowerAdapter>(
             by_ref: ctx.cfg.is_param_by_ref(slot),
         },
         PlaceBase::Accessor(_) => panic!("mandatory-inline accessor place reached codegen"),
+        PlaceBase::Indirect(pointer) => PlaceBasePlan::Pointer(
+            adapter
+                .materialize_value(pointer, ValuePlan::for_value(ctx, pointer))
+                .primary,
+        ),
     };
     let projections = ctx
         .cfg

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -154,6 +154,8 @@ pub struct DurableAnonymousMethodSignature {
     pub name: Arc<str>,
     pub has_self: bool,
     pub self_mode: DurableParameterMode,
+    pub returns_borrow: bool,
+    pub returns_inout: bool,
     pub parameters: Arc<[(DurableAnonymousMethodType, DurableParameterMode, bool)]>,
     pub result: DurableAnonymousMethodType,
     /// Whether the producer declared a body for this member. The body itself

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -7961,6 +7961,8 @@ impl SemanticConstEvaluator<'_, '_> {
                             return_type,
                             has_self,
                             self_mode,
+                            returns_borrow,
+                            returns_inout,
                             ..
                         } = &method.data
                         else {
@@ -8011,6 +8013,8 @@ impl SemanticConstEvaluator<'_, '_> {
                             name: Arc::from(semantic_candidate_spelling(symbols, name)),
                             has_self: *has_self,
                             self_mode: mode(*self_mode),
+                            returns_borrow: *returns_borrow,
+                            returns_inout: *returns_inout,
                             parameters: parameters.into(),
                             result,
                             has_body: true,
@@ -21825,6 +21829,32 @@ fn unique_named_member_candidate<D>(
 impl rue_air::DurableBodyLookupSource<crate::StableDefinitionKey, ModuleId>
     for CompilerBodyDurableSource<'_>
 {
+    fn definition_module(&self, definition: &crate::StableDefinitionKey) -> Option<ModuleId> {
+        Some(definition.module().clone())
+    }
+
+    fn anonymous_definition_module(
+        &self,
+        identity: &rue_air::AnonymousNominalKey<crate::StableDefinitionKey, ModuleId>,
+    ) -> Option<ModuleId> {
+        fn function_module(
+            function: &rue_air::FunctionInstanceKey<crate::StableDefinitionKey, ModuleId>,
+        ) -> Option<ModuleId> {
+            match function {
+                rue_air::FunctionInstanceKey::Definition(definition) => {
+                    Some(definition.module().clone())
+                }
+                rue_air::FunctionInstanceKey::Specialization { base, .. } => function_module(base),
+                rue_air::FunctionInstanceKey::AnonymousMember { .. }
+                | rue_air::FunctionInstanceKey::DropGlue(_) => None,
+            }
+        }
+        match &identity.producer {
+            rue_air::StableProducerId::Definition(definition) => Some(definition.module().clone()),
+            rue_air::StableProducerId::Function(function) => function_module(function),
+        }
+    }
+
     fn free_function(
         &self,
         current: &crate::StableDefinitionKey,
@@ -22442,6 +22472,10 @@ impl rue_air::DurableConstSource<crate::StableDefinitionKey, ModuleId>
 impl rue_air::DurableNominalSource<crate::StableDefinitionKey, ModuleId>
     for CompilerBodyDurableSource<'_>
 {
+    fn module_is_trusted_standard_library(&self, module: &ModuleId) -> bool {
+        module.is_trusted_standard_library()
+    }
+
     fn nominal_file_id(&self, key: &crate::StableDefinitionKey) -> Option<crate::FileId> {
         rue_air::DurableBodyLookupSource::module_source(self, key.module())
             .map(|source| source.file_id)
@@ -22871,6 +22905,8 @@ fn project_provider_anonymous_methods(
             name: method.name.clone(),
             has_self: method.has_self,
             self_mode: mode(method.self_mode),
+            returns_borrow: method.returns_borrow,
+            returns_inout: method.returns_inout,
             parameters: method
                 .parameters
                 .iter()
@@ -22987,6 +23023,8 @@ fn project_provider_produced_anonymous_nominals(
                                     name: method.name.clone(),
                                     has_self: method.has_self,
                                     self_mode: mode(method.self_mode),
+                                    returns_borrow: method.returns_borrow,
+                                    returns_inout: method.returns_inout,
                                     parameters: method
                                         .parameters
                                         .iter()
@@ -25110,6 +25148,10 @@ pub(crate) mod test_support {
     }
 
     impl rue_air::DurableNominalSource<StableDefinitionKey, ModuleId> for DurableDeclSource {
+        fn module_is_trusted_standard_library(&self, module: &ModuleId) -> bool {
+            module.is_trusted_standard_library()
+        }
+
         fn nominal(
             &self,
             key: &StableDefinitionKey,
@@ -30457,6 +30499,8 @@ fn main() -> i32 {
                     name: Arc::from("method"),
                     has_self: false,
                     self_mode: crate::durable_semantics::DurableParameterMode::Value,
+                    returns_borrow: false,
+                    returns_inout: false,
                     parameters: Arc::from([]),
                     result: crate::durable_semantics::DurableAnonymousMethodType::Concrete(
                         rue_air::SemanticImportType::I32,

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -1139,6 +1139,42 @@ impl crate::CompilerSession {
 mod codegen_unit_tests {
     use super::*;
 
+    fn trusted_accessor_snapshot(root: &str, module: &str) -> crate::SourceSnapshot {
+        use std::collections::{HashMap, HashSet};
+
+        let root_file = crate::FileId::new(1);
+        let module_file = crate::FileId::new(2);
+        let metadata = crate::SourceMetadata::new_with_trusted_standard_library(
+            root_file,
+            HashMap::from([
+                (root_file, "/project/main.rue".to_owned()),
+                (module_file, "/project/std/bridge.rue".to_owned()),
+            ]),
+            HashMap::from([
+                (root_file, "main.rue".to_owned()),
+                (module_file, "\0rue-std/bridge.rue".to_owned()),
+            ]),
+            HashSet::from([module_file]),
+        )
+        .expect("trusted accessor fixture metadata is valid");
+        crate::SourceSnapshot::new(
+            metadata,
+            vec![
+                (root_file, Arc::new(root.to_owned())),
+                (module_file, Arc::new(module.to_owned())),
+            ],
+        )
+        .expect("trusted accessor fixture snapshot is valid")
+    }
+
+    fn borrow_accessor_options() -> crate::CompileOptions {
+        let mut options = crate::CompileOptions::default();
+        options
+            .preview_features
+            .insert(rue_error::PreviewFeature::BorrowAccessors);
+        options
+    }
+
     #[test]
     fn codegen_presentation_is_available_before_and_after_normal_codegen() {
         let snapshot = crate::SourceSnapshot::single("main.rue", "fn main() -> i32 { 7 }").unwrap();
@@ -1493,6 +1529,217 @@ mod codegen_unit_tests {
                 (
                     &product.unit.defined_symbol,
                     product.unit.text_atom().unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(warm, fresh);
+    }
+
+    #[test]
+    fn trusted_place_bridge_is_confined_to_the_exact_receiver_rooted_form() {
+        let root = r#"
+const bridge = @import("std/bridge.rue");
+
+fn main() -> i32 {
+    let value: i64 = 7;
+    let pointer: ptr const i64 = checked { @raw(value) };
+    let P = bridge.Buf(i64);
+    let p = P { buf: pointer, value };
+    @intCast(p.get_ref(pointer))
+}
+"#;
+        let module = |body: &str| {
+            format!(
+                r#"
+pub fn Buf(comptime T: type) -> type {{
+    struct {{
+        buf: ptr const T,
+        value: T,
+
+        fn get_ref(borrow self, other: ptr const T) -> borrow T {{
+            {body}
+        }}
+    }}
+}}
+"#
+            )
+        };
+        let options = borrow_accessor_options();
+        let compile = |body: &str| {
+            let snapshot = trusted_accessor_snapshot(root, &module(body));
+            let mut session = crate::CompilerSession::new();
+            crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
+            session.rooted_cfg(&options)
+        };
+
+        compile("yield checked { @place(@ptr_offset(self.buf, 0)) };")
+            .expect("the exact trusted receiver-rooted bridge is accepted");
+
+        let errors = compile("yield checked { @place(@ptr_offset(other, 0)) };").unwrap_err();
+        assert!(
+            errors.iter().any(|error| matches!(
+                &error.kind,
+                rue_error::ErrorKind::AccessorYieldNotReceiverRooted { .. }
+            )),
+            "{errors:?}"
+        );
+
+        for body in [
+            "yield @place(@ptr_offset(self.buf, 0));",
+            "let ignored = checked { @place(@ptr_offset(self.buf, 0)) }; yield self.value;",
+        ] {
+            let errors = compile(body).unwrap_err();
+            assert!(
+                errors.iter().any(|error| matches!(
+                    &error.kind,
+                    rue_error::ErrorKind::UnknownIntrinsic(name) if name == "place"
+                ) || matches!(
+                    &error.kind,
+                    rue_error::ErrorKind::AccessorYieldNotReceiverRooted { .. }
+                )),
+                "{errors:?}"
+            );
+        }
+
+        let errors = compile("yield checked { @place() };").unwrap_err();
+        assert!(
+            errors.iter().any(|error| matches!(
+                &error.kind,
+                rue_error::ErrorKind::IntrinsicWrongArgCount { name, expected: 1, found: 0 }
+                    if name == "place"
+            )),
+            "{errors:?}"
+        );
+
+        let errors = compile("yield checked { @place(@ptr_offset(self.value, 0)) };").unwrap_err();
+        assert!(
+            errors.iter().any(|error| matches!(
+                &error.kind,
+                rue_error::ErrorKind::IntrinsicTypeMismatch(mismatch)
+                    if mismatch.name == "ptr_offset"
+            )),
+            "{errors:?}"
+        );
+    }
+
+    #[test]
+    fn trusted_anonymous_accessor_edit_recomputes_only_its_caller_without_an_abi_unit() {
+        let root = r#"
+const bridge = @import("std/bridge.rue");
+
+fn helper() -> i32 { 1 }
+
+fn main() -> i32 {
+    let value: i64 = 7;
+    let pointer: ptr const i64 = checked { @raw(value) };
+    let B = bridge.Buf(i64);
+    let b = B { buf: pointer };
+    @intCast(b.get_ref(0)) + helper()
+}
+"#;
+        let module = |guard: u64| {
+            format!(
+                r#"
+pub fn Buf(comptime T: type) -> type {{
+    struct {{
+        buf: ptr const T,
+
+        fn get_ref(borrow self, i: u64) -> borrow T {{
+            if i == {guard} {{ @panic("index out of bounds"); }}
+            yield checked {{ @place(@ptr_offset(self.buf, i)) }};
+        }}
+    }}
+}}
+"#
+            )
+        };
+        let options = borrow_accessor_options();
+        let source = |guard| trusted_accessor_snapshot(root, &module(guard));
+        let mut session = crate::CompilerSession::new();
+
+        let cold_source = source(11);
+        crate::publish_test_snapshot(&mut session, &cold_source).unwrap();
+        let cold_semantic = session.rooted_cfg(&options).unwrap();
+        let cold = session
+            .codegen_units(
+                &cold_semantic,
+                &options,
+                rue_codegen::BackendArtifactRequest::default(),
+            )
+            .unwrap();
+        assert_eq!(
+            cold.len(),
+            2,
+            "trusted accessors have no out-of-line ABI unit"
+        );
+        assert!(
+            cold.iter()
+                .all(|unit| !unit.unit.defined_symbol.contains("get_ref"))
+        );
+        let cold_helper_key = cold_semantic
+            .cfgs
+            .iter()
+            .find(|unit| crate::cfg_query::accessor_source_name(&unit.function) == "helper")
+            .unwrap()
+            .optimized_cfg_key
+            .clone();
+
+        let warm_source = source(12);
+        crate::publish_test_snapshot(&mut session, &warm_source).unwrap();
+        let warm_semantic = session.rooted_cfg(&options).unwrap();
+        let warm_helper_key = &warm_semantic
+            .cfgs
+            .iter()
+            .find(|unit| crate::cfg_query::accessor_source_name(&unit.function) == "helper")
+            .unwrap()
+            .optimized_cfg_key;
+        assert_eq!(cold_helper_key, *warm_helper_key);
+        let execution = |name: &str| {
+            session
+                .rooted_cfg_executions()
+                .iter()
+                .find_map(|(identity, execution)| {
+                    matches!(identity, crate::FunctionInstanceKey::Definition(definition) if definition.name() == name)
+                        .then_some(*execution)
+                })
+                .unwrap()
+        };
+        assert_eq!(execution("main"), rue_query::RequestExecution::Computed);
+        assert_eq!(execution("helper"), rue_query::RequestExecution::Reused);
+
+        let warm = session
+            .codegen_units(
+                &warm_semantic,
+                &options,
+                rue_codegen::BackendArtifactRequest::default(),
+            )
+            .unwrap();
+        let mut fresh = crate::CompilerSession::new();
+        let fresh_source = source(12);
+        crate::publish_test_snapshot(&mut fresh, &fresh_source).unwrap();
+        let fresh_semantic = fresh.rooted_cfg(&options).unwrap();
+        let fresh = fresh
+            .codegen_units(
+                &fresh_semantic,
+                &options,
+                rue_codegen::BackendArtifactRequest::default(),
+            )
+            .unwrap();
+        let warm = warm
+            .iter()
+            .map(|product| {
+                (
+                    product.unit.defined_symbol.clone(),
+                    product.unit.text_atom().unwrap().to_vec(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let fresh = fresh
+            .iter()
+            .map(|product| {
+                (
+                    product.unit.defined_symbol.clone(),
+                    product.unit.text_atom().unwrap().to_vec(),
                 )
             })
             .collect::<Vec<_>>();

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1501,11 +1501,12 @@ pub enum ErrorKind {
     /// field/payload that has one). Copying such an element by `@ptr_read` leaves
     /// the copy and the still-live slot both pointing at the same owned buffer, so
     /// both run drop glue at scope exit: a double-free (RUE-651). The read is
-    /// rejected; the element must be *moved* out with `pop`/`pop_or` instead (one
-    /// owner) until borrow-returning reads exist. Mirrors Swift's rule that a
-    /// non-copyable element cannot use a by-value `get` subscript.
+    /// rejected; use the borrow-returning `get_ref` accessor for an in-place
+    /// read, or move the element out with `pop`/`pop_or` instead (one owner).
+    /// Mirrors Swift's rule that a non-copyable element cannot use a by-value
+    /// `get` subscript.
     #[error(
-        "cannot read an element of type `{ty}` by copy: it owns resources (has drop glue), so a by-copy read would alias the owned value and double-free it at scope exit — move it out with `pop`/`pop_or` instead (RUE-651)"
+        "cannot read an element of type `{ty}` by copy: it owns resources (has drop glue), so a by-copy read would alias the owned value and double-free it at scope exit — use `get_ref` for an in-place read, or move it out with `pop`/`pop_or` (RUE-651)"
     )]
     ContainerElementNotTriviallyDroppable { ty: String },
     /// Inout argument is not an lvalue (variable, field, or array element)

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -1392,6 +1392,7 @@ impl<'a> Interp<'a> {
                 };
                 (slot, cfg.num_params(), width, Some(slot))
             }
+            PlaceBase::Indirect(_) => return None,
             PlaceBase::Accessor(_) => return Some(ContractViolationKind::UnsplicedAccessor),
         };
         let out_of_bounds = if width == 0 {
@@ -2794,6 +2795,12 @@ impl<'a> Interp<'a> {
                                                 "accessor place reached call writeback",
                                             ));
                                         }
+                                        PlaceBase::Indirect(_) => {
+                                            return Err(unsupported(
+                                                unsupported_intrinsic_kind("ptr_write"),
+                                                "indirect place reached simple call writeback",
+                                            ));
+                                        }
                                     };
                                     self.place_write(cfg, frame, &place, val)?;
                                 }
@@ -3176,12 +3183,23 @@ impl<'a> Interp<'a> {
                 UnsupportedKind::ContractViolation(ContractViolationKind::UnsplicedAccessor),
                 "accessor place reached oracle storage",
             )),
+            PlaceBase::Indirect(_) => Err(unsupported(
+                unsupported_intrinsic_kind("ptr_read"),
+                "indirect place requires evaluated pointer storage",
+            )),
         }
     }
 
     fn place_read(&mut self, cfg: &'a Cfg, frame: &mut Frame, place: &Place) -> Step<Value> {
         let (base, path) = self.resolve_path(cfg, frame, place)?;
-        let mut cur = self.base_value_of(frame, base)?;
+        let mut cur = match base {
+            PlaceBase::Indirect(pointer) => {
+                let pointer = self.eval(cfg, frame, pointer)?;
+                let target = self.expect_ptr(pointer, unsupported_intrinsic_kind("ptr_read"))?;
+                self.ptr_cell_read(&target, unsupported_intrinsic_kind("ptr_read"))?
+            }
+            _ => self.base_value_of(frame, base)?,
+        };
         for (idx, _projection) in path {
             cur = match cur {
                 Value::Aggregate(mut v) if idx < v.len() => v.swap_remove(idx),
@@ -3213,6 +3231,37 @@ impl<'a> Interp<'a> {
         val: Value,
     ) -> Step<()> {
         let (base, path) = self.resolve_path(cfg, frame, place)?;
+        if let PlaceBase::Indirect(pointer) = base {
+            let pointer = self.eval(cfg, frame, pointer)?;
+            let target = self.expect_ptr(pointer, unsupported_intrinsic_kind("ptr_write"))?;
+            if path.is_empty() {
+                return self
+                    .ptr_cell_write(&target, val, unsupported_intrinsic_kind("ptr_write"))
+                    .map_err(Flow::from);
+            }
+            let mut root = self.ptr_cell_read(&target, unsupported_intrinsic_kind("ptr_write"))?;
+            let mut cur = &mut root;
+            for (idx, _) in &path {
+                cur = match cur {
+                    Value::Aggregate(values) if *idx < values.len() => &mut values[*idx],
+                    Value::Aggregate(_) => {
+                        return Err(Flow::Panic(Panic::runtime(TrapKind::IndexOutOfBounds)));
+                    }
+                    _ => {
+                        return Err(unsupported(
+                            UnsupportedKind::ContractViolation(
+                                ContractViolationKind::NonAggregateProjectionWrite,
+                            ),
+                            "projection of non-aggregate indirect place",
+                        ));
+                    }
+                };
+            }
+            *cur = val;
+            return self
+                .ptr_cell_write(&target, root, unsupported_intrinsic_kind("ptr_write"))
+                .map_err(Flow::from);
+        }
         // Select the storage root. A promoted (address-taken) base writes through
         // its heap allocation so the mutation is observed by both a later direct
         // read and any live pointer. Otherwise write frame storage directly;
@@ -3240,6 +3289,7 @@ impl<'a> Interp<'a> {
                         "accessor place reached oracle write",
                     ));
                 }
+                PlaceBase::Indirect(_) => unreachable!("indirect places return above"),
             };
             if slot >= store.len() {
                 store.resize(slot + 1, None);
@@ -4075,9 +4125,14 @@ fn modeled_pointer_intrinsic(kind: UnsupportedIntrinsicKind) -> bool {
 /// Stable map key for a promoted place base within a frame.
 fn promotion_key(base: PlaceBase) -> u64 {
     match base {
-        PlaceBase::Local(slot) => (slot as u64) << 1,
-        PlaceBase::Param(slot) => ((slot as u64) << 1) | 1,
-        PlaceBase::Accessor(value) => ((value.as_u32() as u64) << 2) | 3,
+        // Every payload is u32, so two high tag bits give the four base kinds
+        // disjoint key spaces. In particular, an indirect value must never
+        // alias an odd local's promoted allocation before the oracle reports
+        // the unsupported address-of-indirect shape.
+        PlaceBase::Local(slot) => slot as u64,
+        PlaceBase::Param(slot) => (1u64 << 32) | slot as u64,
+        PlaceBase::Accessor(value) => (2u64 << 32) | value.as_u32() as u64,
+        PlaceBase::Indirect(value) => (3u64 << 32) | value.as_u32() as u64,
     }
 }
 

--- a/crates/rue-spec/cases/items/borrow-accessors.toml
+++ b/crates/rue-spec/cases/items/borrow-accessors.toml
@@ -1,4 +1,4 @@
-# Borrow accessors (ADR-0062 phases 0-2, RUE-662), behind the
+# Borrow accessors (ADR-0062 phases 0-3, RUE-662/RUE-1017), behind the
 # `borrow_accessors` preview.
 #
 # Shared and exclusive accessor calls survive semantic analysis as marked
@@ -10,7 +10,7 @@
 id = "items.borrow-accessors"
 spec_chapter = "6.6"
 name = "Borrow Accessors"
-description = "Place-returning shared and exclusive accessors with trailing-yield bodies (ADR-0062 phases 0-2)."
+description = "Place-returning shared and exclusive accessors with trailing-yield bodies and trusted standard-library collection adoption (ADR-0062 phases 0-3)."
 
 [[case]]
 name = "accessor_declaration_parses_and_compiles"
@@ -971,6 +971,43 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = ["E0258"]
+
+[[case]]
+name = "arraybuf_get_ref_projects_drop_glue_element_in_place"
+spec = ["6.6:7", "6.6:8", "6.6:11", "6.6:12"]
+description = "The trusted ArrayBuf bridge yields a receiver-rooted place, so a destructor-bearing element can be projected without copying its owner."
+preview = "borrow_accessors"
+preview_should_pass = true
+real_std = true
+source = """
+const std = @import("std");
+struct D { value: i64 }
+drop fn D(self) {}
+fn main() -> i32 {
+    let B = std.arraybuf.ArrayBuf(D);
+    let mut b = B.new();
+    b.push(D { value: 42 });
+    if b.get_ref(0).value == 42 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "arraybuf_get_ref_call_requires_preview"
+spec = ["6.6:3"]
+description = "Trusted standard-library declarations load stably, but calling get_ref without borrow_accessors is E1100."
+real_std = true
+source = """
+const std = @import("std");
+fn main() -> i32 {
+    let B = std.arraybuf.ArrayBuf(i64);
+    let mut b = B.new();
+    b.push(1);
+    if b.get_ref(0) == 1 { 0 } else { 1 }
+}
+"""
+compile_fail = true
+error_contains = ["E1100", "borrow_accessors"]
 
 [[case]]
 name = "mutable_accessor_direct_and_projected_assignment"

--- a/crates/rue-ui-tests/cases/diagnostics/trivially_droppable_gate.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/trivially_droppable_gate.toml
@@ -6,7 +6,8 @@ An owning container's by-copy read (`ArrayBuf(T)::get`/`get_or`, RUE-651) copies
 the element out with `@ptr_read` while the stored slot stays live. For a `T` with
 drop glue that copy would alias the element's owned resources — both the copy and
 the slot run drop glue at scope exit, a double-free. `@require_trivially_droppable(T)`
-in the reader's body rejects those reads (E0711), directing the caller to `pop`
+in the reader's body rejects those reads (E0711), directing the caller to `get_ref`
+for an in-place read or `pop`
 (which moves the element, leaving one owner). Because the gate lives in the method
 body, demand-driven analysis (ADR-0045) fires it only when a by-copy read is
 actually called — storing/pushing/popping/dropping a drop-glue element stays legal
@@ -17,7 +18,7 @@ tested independent of the std `ArrayBuf` source.
 
 [[case]]
 name = "e0711_drop_glue_element_read_rejected"
-description = "Calling a by-copy read whose element type has drop glue is rejected with E0711 and pointed at `pop`."
+description = "Calling a by-copy read whose element type has drop glue is rejected with E0711 and pointed at `get_ref` or `pop`."
 source = """
 struct D { v: i32 }
 drop fn D(self) {}
@@ -41,7 +42,7 @@ compile_fail = true
 error_contains = [
     "E0711",
     "cannot read an element of type `D` by copy",
-    "move it out with `pop`",
+    "use `get_ref` for an in-place read, or move it out with `pop`/`pop_or`",
 ]
 
 [[case]]

--- a/docs/designs/0062-place-returning-borrow-accessors.md
+++ b/docs/designs/0062-place-returning-borrow-accessors.md
@@ -262,9 +262,10 @@ Tracked in Linear under the RUE-1015 epic:
       spec coverage) — RUE-662
 - [x] **Phase 2: Mutable accessors** (`inout self` → exclusive result;
       assignment through the result) — RUE-1016
-- [ ] **Phase 3: std adoption** (`ArrayBuf.get_ref` + E0711 diagnostic
-      pointing at it; grid/deque/intmap accessors; owned-children tree
-      example replacing an arena) — RUE-1017 (blocked by RUE-662)
+- [x] **Phase 3: std adoption** (`ArrayBuf.get_ref` + E0711 diagnostic
+      pointing at it; sound grid/stack/queue accessors; the deque and intmap
+      exclusions documented until their filler/copy representations change;
+      owned-children tree example replacing an arena) — RUE-1017
 - [ ] **Phase 4: preview-gate removal** after dogfooding — RUE-1018
       (blocked by RUE-1016 and RUE-1017)
 

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -1042,9 +1042,9 @@ handle-uniqueness quantify over it unchanged.
 Dynamically an accessor call is not a `(D-Call)`: the call reduces **by the
 accessor's inlined body** — the guards run in the caller (and may trap, §6.12)
 and the redex is then replaced by the projected place itself, `(ℓ, π·π_y)` for
-a user accessor over §6.9's by-ref place plumbing (a library accessor over the
-allocation store would yield `view⟨A | o, k⟩`, §6.13.2 — deferred to the std
-phase, RUE-1017). No call frame is pushed and no calling convention for
+a user accessor over §6.9's by-ref place plumbing, or `view⟨A | o, 1⟩` for the
+trusted `ArrayBuf(T).get_ref` bridge (§6.13.3). No call frame is pushed and no
+calling convention for
 "returning a place" exists; that absence is the RUE-1012 forward-compatibility
 contract.
 
@@ -1912,6 +1912,10 @@ byte-oriented allocation family takes (ADR-0059 Phase 3):
     i < len   →  Some(H(A).i)                               -- a COPY; the cell is untouched
     i ≥ len   →  None
 
+  get_ref(borrow self, i):      -- checked source-defined read accessor (RUE-1017)
+    i < len   →  view⟨A | i, 1⟩                             -- a §5.4-governed loaned place
+    i ≥ len   →  ↯bounds                                      -- guard traps before yield
+
   set(inout self, i, x):
     i ≥ len   →  ⟨⟩                                         -- out of bounds: ignored (the source's contract)
     i < len:     drop(H, H(A).i);  H[A.i ↦ x]   →  ⟨⟩       -- old element dropped first (RUE-646): no leak
@@ -1948,8 +1952,10 @@ citation:
   a second owner of that element's own buffer — in the model, two values
   holding the same inner `buf⟨A⟩`, violating (O1) and double-freeing at drop.
   The equation makes the aliasing visible. The borrow-returning read that
-  would lift the gate (`get_ref`, RUE-662) must produce a §5.4-governed loan,
-  not a value.
+  would lift the gate (`get_ref`, RUE-1017) must produce a §5.4-governed loan,
+  not a value. Its trusted source body is `yield checked {
+  @place(@ptr_offset(...)) };`; `@place` is not a general user intrinsic and
+  the checked bridge is accepted only in this receiver-rooted accessor context.
 - **Growth is identity death** (§6.13.1's `realloc`): a view into the old
   buffer held by an enclosing call would now be stuck — but §5.4's exclusivity
   already rejects that shape (`v[0..2] == g(inout v)`): the `inout` loan

--- a/docs/spec/src/06-items/06-borrow-accessors.md
+++ b/docs/spec/src/06-items/06-borrow-accessors.md
@@ -35,14 +35,18 @@ yield_expr  = "yield" expression ;
 A `-> borrow` or `-> inout` result position and the `yield` form require the
 `borrow_accessors` preview feature. Without `--preview borrow_accessors`, a
 program using either is rejected at compile time (E1100), per 8.4.
+Stable standard-library loading may analyze its trusted accessor declarations
+without the preview; calling any such accessor remains subject to E1100.
 
 {{ rule(id="6.6:4", cat="legality-rule") }}
 
 An accessor **MUST** pair its result and receiver modes exactly: `borrow self`
 with `-> borrow T`, or `inout self` with `-> inout T`. A result on a free
-function, an associated function, a by-value or `mut self` method, or a method
-of an anonymous struct type is rejected (E0257); a mismatched pair reports the
-required pairing.
+function, an associated function, or a by-value or `mut self` method is rejected
+(E0257); user-defined anonymous-struct accessors are also rejected. The
+trusted standard-library anonymous collection path is the narrow exception
+needed by `ArrayBuf(T)` and remains subject to the declaration and call-site
+gates below. A mismatched pair reports the required pairing.
 
 {{ rule(id="6.6:5", cat="legality-rule") }}
 
@@ -67,6 +71,16 @@ parameter: `self`, or a projection chain from `self` through fields, indices,
 or nested accessor calls (E0255). Yielding a local, a parameter other than the
 receiver, or a computed value would hand out a place that dies with the
 accessor's guards.
+
+The trusted standard-library `ArrayBuf(T).get_ref` accessor is the narrow
+representation-level exception. It may use the checked pointer-to-place bridge
+`yield checked { @place(@ptr_offset(...)) };` after its bounds guard. This
+bridge is recognized only for a trusted standard-library accessor whose pointer
+base is a field chain rooted at `self`; user code may not use `@place` to
+manufacture an arbitrary accessor result. Other owning collections compose
+this canonical accessor rather than duplicate the privileged bridge. Its
+defining equation is `i < len -> view⟨A | i, 1⟩` and `i >= len -> bounds trap`
+(ADR-0062, RUE-1017).
 
 ## Calls
 

--- a/examples/ruelex/ast.rue
+++ b/examples/ruelex/ast.rue
@@ -63,6 +63,7 @@ pub const DROP_FN: u64 = 51;
 pub const CONST_DECL: u64 = 52;
 pub const ANON_ENUM_TYPE: u64 = 53;
 pub const SLICE_TYPE: u64 = 54;
+pub const YIELD: u64 = 55;
 
 pub struct Node {
     kind: u64,
@@ -153,6 +154,7 @@ pub struct Arena {
         else if kind == BREAK { "break" }
         else if kind == CONTINUE { "continue" }
         else if kind == RETURN { "return" }
+        else if kind == YIELD { "yield" }
         else if kind == LET { "let" }
         else if kind == ASSIGN { "assign" }
         else if kind == EXPR_STMT { "expr-stmt" }
@@ -267,7 +269,7 @@ pub struct Arena {
             let statement = self.at(link.b);
             let expr = self.at(statement.a);
             if link.kind == LIST && statement.kind == EXPR_STMT &&
-                (expr.kind == BREAK || expr.kind == CONTINUE || expr.kind == RETURN || expr.kind == LOOP) {
+                (expr.kind == BREAK || expr.kind == CONTINUE || expr.kind == RETURN || expr.kind == YIELD || expr.kind == LOOP) {
                 out.push_str(" ");
                 self.dump_shape_node(link.a, inout out);
                 out.push_str(" ");

--- a/examples/ruelex/lex.rue
+++ b/examples/ruelex/lex.rue
@@ -189,6 +189,7 @@ pub struct Lexer {
         if word_eq(borrow key, "in") { return "IN"; }
         if word_eq(borrow key, "match") { return "MATCH"; }
         if word_eq(borrow key, "return") { return "RETURN"; }
+        if word_eq(borrow key, "yield") { return "YIELD"; }
         if word_eq(borrow key, "break") { return "BREAK"; }
         if word_eq(borrow key, "comptime") { return "COMPTIME"; }
         if word_eq(borrow key, "continue") { return "CONTINUE"; }

--- a/examples/ruelex/parse.rue
+++ b/examples/ruelex/parse.rue
@@ -190,6 +190,8 @@ pub struct Parser {
             self.add(ast.CONTINUE, 0, x.start, x.end, 0, 0, 0)
         } else if t.kind == token.RETURN {
             self.parse_return()
+        } else if t.kind == token.YIELD {
+            self.parse_yield()
         } else if t.kind == token.AT {
             self.parse_intrinsic()
         } else if t.kind == token.MINUS || t.kind == token.BANG || t.kind == token.TILDE {
@@ -485,7 +487,7 @@ pub struct Parser {
         kind == token.COMPTIME || kind == token.CHECKED || kind == token.IF ||
         kind == token.MATCH || kind == token.WHILE || kind == token.LOOP ||
         kind == token.FOR || kind == token.BREAK || kind == token.CONTINUE ||
-        kind == token.RETURN || kind == token.AT || kind == token.MINUS ||
+        kind == token.RETURN || kind == token.YIELD || kind == token.AT || kind == token.MINUS ||
         kind == token.BANG || kind == token.TILDE || kind == token.STRUCT || kind == token.ENUM || Self.is_primitive(kind)
     }
 
@@ -501,6 +503,12 @@ pub struct Parser {
         let value = if Self.expression_starts(self.kind()) && !self.at(token.RBRACE) && !self.at(token.COMMA) { self.parse_expr(0, true) } else { 0 };
         let end = if value == 0 { self.previous().end } else { self.arena.at(value).end };
         self.add(ast.RETURN, 0, start, end, value, 0, 0)
+    }
+
+    fn parse_yield(inout self) -> u64 {
+        let start = self.bump().start;
+        let value = self.parse_expr(0, true);
+        self.add(ast.YIELD, 0, start, self.arena.at(value).end, value, 0, 0)
     }
 
     fn parse_block(inout self) -> u64 {
@@ -543,7 +551,7 @@ pub struct Parser {
 
     fn can_omit_semi(kind: u64) -> bool {
         kind == ast.BLOCK || kind == ast.IF || kind == ast.MATCH || kind == ast.WHILE ||
-        kind == ast.LOOP || kind == ast.FOR || kind == ast.BREAK || kind == ast.CONTINUE || kind == ast.RETURN
+        kind == ast.LOOP || kind == ast.FOR || kind == ast.BREAK || kind == ast.CONTINUE || kind == ast.RETURN || kind == ast.YIELD
     }
 
     // Directives and intrinsics share the same `@ IDENT (...)` prefix. Scan
@@ -716,7 +724,12 @@ pub struct Parser {
         let start = self.expect(token.FN).start;
         let name = self.expect(token.IDENT);
         let params = self.parse_params(method);
-        let ret = if self.eat(token.ARROW) { self.parse_type() } else { 0 };
+        let ret = if self.eat(token.ARROW) {
+            // The structural oracle intentionally erases the accessor result
+            // mode, but it must still consume it before parsing the type.
+            let _ = if self.at(token.BORROW) || self.at(token.INOUT) { self.bump().kind } else { 0 };
+            self.parse_type()
+        } else { 0 };
         let body = self.parse_block();
         let kind = if method { ast.METHOD } else { ast.FUNCTION };
         self.add_meta(kind, name.value, flags, start, self.arena.at(body).end, directives, params, ret, body)

--- a/examples/ruelex/token.rue
+++ b/examples/ruelex/token.rue
@@ -12,6 +12,7 @@ pub const ERROR: u64 = 1;
 pub const IDENT: u64 = 2;
 pub const INT: u64 = 3;
 pub const STRING: u64 = 4;
+pub const YIELD: u64 = 5;
 
 pub const BORROW: u64 = 10;
 pub const FN: u64 = 11;
@@ -141,6 +142,7 @@ pub fn kind_from_name(borrow name: StrBuf) -> u64 {
     if eq(borrow name, "IN") { return IN; }
     if eq(borrow name, "MATCH") { return MATCH; }
     if eq(borrow name, "RETURN") { return RETURN; }
+    if eq(borrow name, "YIELD") { return YIELD; }
     if eq(borrow name, "BREAK") { return BREAK; }
     if eq(borrow name, "COMPTIME") { return COMPTIME; }
     if eq(borrow name, "CONTINUE") { return CONTINUE; }

--- a/std/arraybuf.rue
+++ b/std/arraybuf.rue
@@ -59,7 +59,8 @@
 //     drop, not discharge, its elements. Lifting that to true linear-element
 //     ownership needs container/element multiplicity propagation (a future ADR).
 //
-//     READING A NON-COPY ELEMENT — use `pop`, not `get` (RUE-651). `pop`/`pop_or`
+//     READING A NON-COPY ELEMENT — use `get_ref` for in-place reading, or `pop`
+//     to move it out (RUE-1017). `pop`/`pop_or`
 //     MOVE the element out (they retire the slot, so there is exactly one owner)
 //     and are sound for any `T`. `get`/`get_or` return the element *by copy*
 //     (`@ptr_read`): for a trivially-droppable `T` that is fine, but for a `T`
@@ -67,11 +68,12 @@
 //     copy and the still-live slot would run drop glue, a double-free. `get`/
 //     `get_or` therefore GATE on their element type: calling either with a
 //     drop-glue `T` is a compile error (E0711, via `@require_trivially_droppable`
-//     in their bodies) that directs you to `pop`. This is exactly Swift's rule
+//     in their bodies) that directs you to `get_ref` for a read, or `pop` to move
+//     it out. This is exactly Swift's rule
 //     that a non-copyable element cannot use a by-value `get` subscript. Storing,
 //     pushing, popping, and dropping a drop-glue element stay legal (RUE-646) —
 //     only the by-copy *read* is gated. Lifting that to borrow-returning reads
-//     (a projection/yield accessor, Hylo-style) is the RUE-651 follow-up.
+//     (a projection/yield accessor, Hylo-style) is now `get_ref` (RUE-1017).
 //   * Multi-slot aggregate element types (e.g. a two-field struct) work as long
 //     as they are trivially droppable: every aggregate is laid out
 //     ascending-in-address, matching the ascending heap layout (ADR-0040 /
@@ -150,15 +152,15 @@ pub fn ArrayBuf(comptime T: type) -> type {
         // is in scope here, so the method can pass it to `option.Option(T)`
         // (RUE-313). COPY-ELEMENT-ONLY: for a non-Copy `T` the copy aliases the
         // element's owned buffer (double-free — RUE-651); read owned elements
-        // with `pop`.
+        // in place with `get_ref`, or move them out with `pop`.
         fn get(borrow self, i: u64) -> option.Option(T) {
             // By-copy reads are sound only for a trivially-droppable `T`
             // (RUE-651): reading a drop-glue element out by `@ptr_read` while the
             // slot stays live would alias its owned buffer and double-free at
             // scope exit. This gate fires only when a program actually calls
             // `get` (demand-driven analysis, ADR-0045); storing/pushing/popping a
-            // drop-glue element stays legal (RUE-646). Read owned elements out
-            // with `pop`, which moves the element (one owner).
+            // drop-glue element stays legal (RUE-646). Read it in place with
+            // `get_ref`, or use `pop` to move it out (one owner).
             @require_trivially_droppable(T);
             let O = option.Option(T);
             if i < self.len {
@@ -171,17 +173,30 @@ pub fn ArrayBuf(comptime T: type) -> type {
         // Element `i` by copy, or `default` when `i` is out of bounds. An
         // ergonomic default-based read for callers that don't want to match on
         // `Option`. COPY-ELEMENT-ONLY: aliases an owned element's buffer for a
-        // non-Copy `T` (double-free — RUE-651); read owned elements with `pop`.
+        // non-Copy `T` (double-free — RUE-651); read owned elements in place
+        // with `get_ref`, or move them out with `pop_or`.
         fn get_or(borrow self, i: u64, default: T) -> T {
             // Trivially-droppable `T` only, same reason as `get` (RUE-651): a
             // by-copy read of a drop-glue element would alias its owned buffer
-            // (double-free). Read owned elements out with `pop_or` instead.
+            // (double-free). Read them in place with `get_ref`, or move them
+            // out with `pop_or` instead.
             @require_trivially_droppable(T);
             if i < self.len {
                 self.core.read_at(i)
             } else {
                 default
             }
+        }
+
+        // Borrow the live cell in place. Unlike `get`, this never copies an
+        // owning element, so it is valid for drop-glue `T`. The checked
+        // pointer-to-place bridge is trusted only in this std accessor body;
+        // the guard makes the yielded cell lie within the initialized prefix.
+        fn get_ref(borrow self, i: u64) -> borrow T {
+            if i >= self.len {
+                @panic("index out of bounds");
+            }
+            yield checked { @place(@ptr_offset(self.core.buf, i)) };
         }
 
         // --- mutation ---

--- a/std/deque.rue
+++ b/std/deque.rue
@@ -5,6 +5,12 @@
 // unused ring slots (Rue has no generic zero-init, same convention as IntMap);
 // it is never read as a live value (the `count` guards that).
 //
+// Deque intentionally has no `front_ref`/`back_ref` yet (RUE-1017): growth
+// rebuilds the ring by copying from a filler-populated buffer. The current
+// representation therefore admits only trivially-droppable elements; a sound
+// owning-element accessor first needs the ring growth path to move initialized
+// slots without duplicating ownership. Keep that work in RUE-687.
+//
 //     const std = @import("std");
 //     let D = std.deque.Deque(i64);
 //     let mut d = D.new(0);

--- a/std/grid.rue
+++ b/std/grid.rue
@@ -55,6 +55,16 @@ pub fn Grid2D(comptime T: type) -> type {
             }
         }
 
+        // Borrow cell `(r, c)` in place. The flattening guard is checked before
+        // delegating to the canonical ArrayBuf accessor, so an invalid
+        // coordinate traps and a valid result remains rooted in this grid.
+        fn get_ref(borrow self, r: u64, c: u64) -> borrow T {
+            if r >= self.rows || c >= self.cols {
+                @panic("index out of bounds");
+            }
+            yield self.cells.get_ref(r * self.cols + c);
+        }
+
         // Set cell `(r, c)` to `x`. Out-of-bounds indices are ignored.
         fn set(inout self, r: u64, c: u64, x: T) {
             if r < self.rows && c < self.cols {

--- a/std/intmap.rue
+++ b/std/intmap.rue
@@ -7,6 +7,13 @@
 // has no generic zero-init); it is never read as a real value — the per-slot
 // state guards that.
 //
+// IntMap intentionally has no `get_ref` yet (RUE-1017): values live in a
+// filler-populated parallel array and rehashing copies occupied entries into a
+// fresh table. The current representation therefore admits only
+// trivially-droppable values; sound owning-value access first needs rehashing
+// to move initialized slots without duplicating ownership. Track that
+// representation change with RUE-679/RUE-687 before adding one.
+//
 //     const std = @import("std");
 //     let M = std.intmap.IntMap(i64);
 //     let mut m = M.new(0);

--- a/std/queue.rue
+++ b/std/queue.rue
@@ -66,5 +66,15 @@ pub fn Queue(comptime T: type) -> type {
                 self.buf.get(self.head)
             }
         }
+
+        // Borrow the front live element in place, trapping when the queue is
+        // empty. The head cursor is part of the guard and the nested accessor
+        // keeps the loan rooted in this queue's backing buffer.
+        fn peek_ref(borrow self) -> borrow T {
+            if self.head >= self.buf.len() {
+                @panic("queue is empty");
+            }
+            yield self.buf.get_ref(self.head);
+        }
     }
 }

--- a/std/stack.rue
+++ b/std/stack.rue
@@ -53,6 +53,16 @@ pub fn Stack(comptime T: type) -> type {
             }
         }
 
+        // Borrow the top element in place, trapping when the stack is empty.
+        // This remains sound for drop-glue `T` because no owning copy is made.
+        fn peek_ref(borrow self) -> borrow T {
+            let n = self.buf.len();
+            if n == 0 {
+                @panic("stack is empty");
+            }
+            yield self.buf.get_ref(n - 1);
+        }
+
         // Drop all elements, keeping capacity.
         fn clear(inout self) {
             self.buf.clear();


### PR DESCRIPTION
## Summary

- add the preview-gated `ArrayBuf.get_ref` accessor and compose sound `Grid2D`, `Stack`, and `Queue` read accessors
- preserve E0711 for by-copy reads of drop-glue elements while directing users to `get_ref` or `pop`
- add the trusted receiver-rooted pointer-place bridge with mandatory accessor splicing and no runtime ABI unit
- document why the current `Deque` and `IntMap` representations remain out of scope

## Evidence

- maintain an executable owned-children `Node` tree traversal that replaces the recorded arena-only core shape
- cover nested reads, accessor/inout conflicts, lifetime escape, drop-glue elements, provider/durable invalidation, and x86-64/AArch64 lowering

## Validation

- `scripts/rue fmt`
- `scripts/rue quick`
- focused borrow-accessor CLI, spec, UI, compiler, oracle, and clippy checks
- premerge tier, with its sole clippy finding fixed and the affected gate rerun successfully

Fixes RUE-1017

Relates to RUE-286
