### PR TITLE
RUE-1018: stabilize borrow accessors

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -53,7 +53,8 @@ fn accessor_producers_do_not_spell_their_own_declaration_diagnostics() {
             "an accessor producer regained its own copy of a declaration rule: {kind}"
         );
     }
-    // The preview subject is a rule too: 6.6:3 names the same form everywhere.
+    // The declaration subject is a rule too: 6.6:3 names the same form
+    // everywhere.
     assert!(
         !producers.contains("\"a `-> borrow` accessor\""),
         "an accessor producer regained its own 6.6:3 gate subject"

--- a/crates/rue-air/src/declaration_validation.rs
+++ b/crates/rue-air/src/declaration_validation.rs
@@ -120,15 +120,6 @@ pub fn duplicate_destructor(type_name: &str) -> ErrorKind {
 // here exactly once; without that, the two declaration producers drift on
 // wording the way they did before RUE-1232.
 
-/// The preview feature the accessor form is gated behind (6.6:3).
-pub const ACCESSOR_PREVIEW_FEATURE: rue_error::PreviewFeature =
-    rue_error::PreviewFeature::BorrowAccessors;
-
-/// The subject every producer names in the 6.6:3 gate diagnostic. The result
-/// position alone demands the preview, so this is reported before any shape
-/// rule about a form the program cannot yet name.
-pub const ACCESSOR_PREVIEW_SUBJECT: &str = "a place-returning accessor (`-> borrow` or `-> inout`)";
-
 /// What a producer found in the receiver position of a place-returning
 /// declaration (6.6:4). The result qualifier selects the required receiver
 /// mode: shared results pair with `borrow self`, exclusive results with
@@ -242,16 +233,6 @@ pub enum AccessorSignatureViolation {
     /// 6.6:5. `ordinal` indexes the non-receiver parameter list the caller
     /// passed, so a producer holding parameter positions can anchor there.
     Parameter { kind: ErrorKind, ordinal: usize },
-}
-
-/// 6.6:3: the accessor form requires its preview gate. `enabled` is the
-/// caller's answer for [`ACCESSOR_PREVIEW_FEATURE`], since producers carry
-/// their preview set in different shapes.
-pub fn accessor_preview_gate(enabled: bool) -> Option<ErrorKind> {
-    (!enabled).then(|| ErrorKind::PreviewFeatureRequired {
-        feature: ACCESSOR_PREVIEW_FEATURE,
-        what: ACCESSOR_PREVIEW_SUBJECT.to_owned(),
-    })
 }
 
 /// 6.6:4 then 6.6:5 over one accessor declaration's signature. `parameters`

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -1908,11 +1908,6 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        self.require_preview(
-            rue_error::PreviewFeature::BorrowAccessors,
-            "a `yield` accessor exit",
-            span,
-        )?;
         let Some(trailing) = ctx.accessor_trailing_yield else {
             return Err(CompileError::new(ErrorKind::YieldOutsideAccessor, span));
         };

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -23,7 +23,7 @@ use crate::declaration_validation::{
 };
 
 /// The declaration legality of a place-returning accessor (ADR-0062): the
-/// result position requires the `borrow_accessors` preview (6.6:3), the
+/// result position and the `yield` form are legal only for an accessor, the
 /// receiver/result modes pair exactly (6.6:4), every other parameter is a plain by-value
 /// guard input (6.6:5), the body's only exit is its trailing `yield` (6.6:6),
 /// and that `yield` hands out a receiver-rooted place (6.6:7).
@@ -43,15 +43,12 @@ use crate::declaration_validation::{
 /// result qualifier is not encoded in the result type itself, so every
 /// declaration producer must preserve it through its signature facts.
 ///
-/// The preview gate runs first, so an ungated program reports E1100 rather
-/// than a shape error about a form it cannot name yet.
 pub(super) fn check_accessor_declaration_shape(
     rir: &rue_rir::Rir,
     interner: &lasso::ThreadedRodeo,
     declaration: InstRef,
     body: Option<InstRef>,
     has_named_owner: bool,
-    preview_features: &rue_error::PreviewFeatures,
 ) -> CompileResult<()> {
     let inst = rir.get(declaration);
     let InstData::FnDecl {
@@ -69,12 +66,6 @@ pub(super) fn check_accessor_declaration_shape(
         return Ok(());
     }
     let span = inst.span;
-    super::require_preview_feature(
-        preview_features,
-        crate::declaration_validation::ACCESSOR_PREVIEW_FEATURE,
-        crate::declaration_validation::ACCESSOR_PREVIEW_SUBJECT,
-        span,
-    )?;
     // An accessor hands out a projection of its receiver, so the receiver is
     // the first thing that has to exist and have the mode paired with the
     // result. `self` is carried by `has_self`, so the parameter list is

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -126,34 +126,6 @@ pub(crate) struct DeferredOwnershipGate {
     span: Span,
 }
 
-/// Reject a use of an incomplete language feature that the request did not
-/// enable (`docs/designs/0005-preview-features.md`). Declaration rules run
-/// before any body host is available, so the gate is a free function over the
-/// request's feature set.
-pub(crate) fn require_preview_feature(
-    preview_features: &rue_error::PreviewFeatures,
-    feature: rue_error::PreviewFeature,
-    what: &str,
-    span: Span,
-) -> rue_error::CompileResult<()> {
-    if preview_features.contains(&feature) {
-        Ok(())
-    } else {
-        Err(rue_error::CompileError::new(
-            rue_error::ErrorKind::PreviewFeatureRequired {
-                feature,
-                what: what.to_string(),
-            },
-            span,
-        )
-        .with_help(format!(
-            "use `--preview {}` to enable this feature ({})",
-            feature.name(),
-            feature.adr()
-        )))
-    }
-}
-
 #[cfg(test)]
 mod consistency_tests;
 #[cfg(test)]

--- a/crates/rue-air/src/sema/provider_accessor_tests.rs
+++ b/crates/rue-air/src/sema/provider_accessor_tests.rs
@@ -2,7 +2,7 @@
 //! migrated from the retired whole-program `Sema` accessor suite (RUE-1538).
 //!
 //! Production splits the accessor rules across two planes. Declaration
-//! legality — the 6.6:3 preview gate, the 6.6:4/6.6:5 signature shape, the
+//! legality — the 6.6:3 accessor rule, the 6.6:4/6.6:5 signature shape, the
 //! 6.6:6/6.6:7 body shape, and the 6.6:14 `self`-call cycle — is decided at
 //! the declaration query seam in `rue-compiler`
 //! (`revisioned_query_database.rs`, through
@@ -21,16 +21,10 @@
 //! `rue-compiler/src/revisioned_query_database.rs` and the spec suite
 //! `rue-spec/cases/items/borrow-accessors.toml` (6.6:3-6.6:14).
 
-use rue_error::{ErrorKind, PreviewFeature, PreviewFeatures};
+use rue_error::ErrorKind;
 
 use super::provider_fixture::{FixtureKey, MethodShape, ProviderFixture, mode_param, value_param};
 use crate::{AirInstData, SemanticImportType, SemanticParameterMode, StableDefinitionKind};
-
-fn accessor_preview() -> PreviewFeatures {
-    let mut features = PreviewFeatures::new();
-    features.insert(PreviewFeature::BorrowAccessors);
-    features
-}
 
 /// The durable method shape of a phase-1 accessor: `borrow self` receiver
 /// with the accessor flag set.
@@ -59,8 +53,8 @@ fn mutable_accessor_shape() -> MethodShape {
 /// against these facts alone — caller-side accessor analysis establishes the
 /// place/loan contract from the durable signature and never reads the callee
 /// body (RUE-1208).
-fn grid_fixture(preview: PreviewFeatures) -> (ProviderFixture, FixtureKey) {
-    let mut fixture = ProviderFixture::with_preview(preview);
+fn grid_fixture() -> (ProviderFixture, FixtureKey) {
+    let mut fixture = ProviderFixture::new();
     let grid = fixture.declare_struct(
         "Grid",
         vec![(
@@ -82,19 +76,6 @@ fn grid_fixture(preview: PreviewFeatures) -> (ProviderFixture, FixtureKey) {
     (fixture, grid)
 }
 
-/// The accessor's own declaration, for tests that analyze the accessor body
-/// itself (the single declaration the member body plan carries).
-const GRID_ACCESSOR_DECL: &str = r#"struct Grid {
-    cells: [i64; 4],
-
-    fn at(borrow self, i: u64) -> borrow i64 {
-        if i >= 4 {
-            @panic("index out of bounds");
-        }
-        yield self.cells[i];
-    }
-}"#;
-
 fn accessor_call_count(air: &crate::ValidatedAir) -> usize {
     air.iter()
         .filter(|(_, inst)| matches!(inst.data, AirInstData::AccessorCall { .. }))
@@ -103,7 +84,7 @@ fn accessor_call_count(air: &crate::ValidatedAir) -> usize {
 
 #[test]
 fn provider_mutable_accessor_marks_inout_receiver_and_place_result() {
-    let mut fixture = ProviderFixture::with_preview(accessor_preview());
+    let mut fixture = ProviderFixture::new();
     let grid = fixture.declare_struct(
         "Grid",
         vec![(
@@ -158,7 +139,7 @@ fn provider_mutable_accessor_marks_inout_receiver_and_place_result() {
 // instruction exists.
 #[test]
 fn accessor_call_inlines_with_no_call_shape() {
-    let (mut fixture, _) = grid_fixture(accessor_preview());
+    let (mut fixture, _) = grid_fixture();
     fixture.declare_function("main", Vec::new(), SemanticImportType::I32);
     let body = fixture
         .analyze(
@@ -192,7 +173,7 @@ fn accessor_call_inlines_with_no_call_shape() {
 // CFG query to splice.
 #[test]
 fn accessor_calls_remain_marked_for_mandatory_cfg_splicing() {
-    let (mut fixture, _) = grid_fixture(accessor_preview());
+    let (mut fixture, _) = grid_fixture();
     fixture.declare_function("main", Vec::new(), SemanticImportType::I32);
     let body = fixture
         .analyze(
@@ -211,7 +192,7 @@ fn accessor_calls_remain_marked_for_mandatory_cfg_splicing() {
 // (6.6:9).
 #[test]
 fn accessor_result_cannot_be_returned() {
-    let (mut fixture, grid) = grid_fixture(accessor_preview());
+    let (mut fixture, grid) = grid_fixture();
     fixture.declare_function(
         "read",
         vec![mode_param(
@@ -240,7 +221,7 @@ fn accessor_result_cannot_be_returned() {
 // value is an implicit return, so the same escape rule applies.
 #[test]
 fn accessor_result_cannot_be_tail_returned() {
-    let (mut fixture, grid) = grid_fixture(accessor_preview());
+    let (mut fixture, grid) = grid_fixture();
     fixture.declare_function(
         "read",
         vec![mode_param(
@@ -269,7 +250,7 @@ fn accessor_result_cannot_be_tail_returned() {
 // binding would outlive the full-expression loan (6.6:9).
 #[test]
 fn accessor_result_cannot_be_let_bound() {
-    let (mut fixture, _) = grid_fixture(accessor_preview());
+    let (mut fixture, _) = grid_fixture();
     fixture.declare_function("main", Vec::new(), SemanticImportType::I32);
     let error = fixture
         .analyze(
@@ -292,7 +273,7 @@ fn accessor_result_cannot_be_let_bound() {
 // escape site too (6.6:9).
 #[test]
 fn accessor_result_cannot_be_stored() {
-    let (mut fixture, _) = grid_fixture(accessor_preview());
+    let (mut fixture, _) = grid_fixture();
     fixture.declare_function("main", Vec::new(), SemanticImportType::I32);
     let error = fixture
         .analyze(
@@ -317,7 +298,7 @@ fn accessor_result_cannot_be_stored() {
 // (6.6:9).
 #[test]
 fn accessor_result_cannot_be_captured_in_aggregate() {
-    let (mut fixture, _) = grid_fixture(accessor_preview());
+    let (mut fixture, _) = grid_fixture();
     fixture.declare_function("main", Vec::new(), SemanticImportType::I32);
     let error = fixture
         .analyze(
@@ -342,7 +323,7 @@ fn accessor_result_cannot_be_captured_in_aggregate() {
 // exclusive `inout` loan on the same root (6.6:10, ADR-0062 §2).
 #[test]
 fn accessor_loan_conflicts_with_inout_in_same_expression() {
-    let (mut fixture, grid) = grid_fixture(accessor_preview());
+    let (mut fixture, grid) = grid_fixture();
     fixture.declare_function(
         "using",
         vec![
@@ -387,7 +368,7 @@ fn accessor_loan_conflicts_with_inout_in_same_expression() {
 // `uncalled_accessor_body_requires_trailing_yield` (6.6:6).
 #[test]
 fn accessor_body_requires_trailing_yield() {
-    let mut fixture = ProviderFixture::with_preview(accessor_preview());
+    let mut fixture = ProviderFixture::new();
     let p = fixture.declare_struct("P", vec![("x", SemanticImportType::I64)], false);
     fixture.declare_method_with(
         &p,
@@ -422,7 +403,7 @@ fn accessor_body_requires_trailing_yield() {
 // bypassing exit (6.6:6).
 #[test]
 fn accessor_body_rejects_a_second_yield() {
-    let mut fixture = ProviderFixture::with_preview(accessor_preview());
+    let mut fixture = ProviderFixture::new();
     let p = fixture.declare_struct("P", vec![("x", SemanticImportType::I64)], false);
     fixture.declare_method_with(
         &p,
@@ -460,7 +441,7 @@ fn accessor_body_rejects_a_second_yield() {
 // is a non-diverging exit that bypasses the trailing `yield` (6.6:6).
 #[test]
 fn accessor_body_rejects_return() {
-    let mut fixture = ProviderFixture::with_preview(accessor_preview());
+    let mut fixture = ProviderFixture::new();
     let p = fixture.declare_struct("P", vec![("x", SemanticImportType::I64)], false);
     fixture.declare_method_with(
         &p,
@@ -502,7 +483,7 @@ fn accessor_body_rejects_return() {
 // the receiver parameter `self` (6.6:7).
 #[test]
 fn accessor_yield_must_root_at_receiver() {
-    let mut fixture = ProviderFixture::with_preview(accessor_preview());
+    let mut fixture = ProviderFixture::new();
     let p = fixture.declare_struct("P", vec![("x", SemanticImportType::I64)], false);
     fixture.declare_method_with(
         &p,
@@ -540,7 +521,7 @@ fn accessor_yield_must_root_at_receiver() {
 // (6.6:14, E0261) rather than a compiler stack overflow (RUE-1211).
 #[test]
 fn accessor_cannot_yield_a_call_to_itself() {
-    let mut fixture = ProviderFixture::with_preview(accessor_preview());
+    let mut fixture = ProviderFixture::new();
     let p = fixture.declare_struct("P", vec![("x", SemanticImportType::I64)], false);
     fixture.declare_method_with(
         &p,
@@ -575,7 +556,7 @@ fn accessor_cannot_yield_a_call_to_itself() {
 // position (RUE-1211).
 #[test]
 fn accessor_cannot_call_itself_from_a_guard() {
-    let mut fixture = ProviderFixture::with_preview(accessor_preview());
+    let mut fixture = ProviderFixture::new();
     let p = fixture.declare_struct("P", vec![("x", SemanticImportType::I64)], false);
     fixture.declare_method_with(
         &p,
@@ -632,7 +613,7 @@ const MUTUAL_ACCESSORS_DECL: &str = "struct P {
 // transaction — and each retains its one marked call.
 #[test]
 fn mutually_recursive_accessors_retain_marked_calls_for_cfg_cycle_rejection() {
-    let mut fixture = ProviderFixture::with_preview(accessor_preview());
+    let mut fixture = ProviderFixture::new();
     let p = fixture.declare_struct("P", vec![("x", SemanticImportType::I64)], false);
     fixture.declare_method_with(
         &p,
@@ -686,7 +667,7 @@ fn mutually_recursive_accessors_retain_marked_calls_for_cfg_cycle_rejection() {
 // ordinary function body is rejected during that body's analysis (E0256).
 #[test]
 fn yield_outside_accessor_is_rejected() {
-    let mut fixture = ProviderFixture::with_preview(accessor_preview());
+    let mut fixture = ProviderFixture::new();
     fixture.declare_function("main", Vec::new(), SemanticImportType::I32);
     let error = fixture
         .analyze("fn main() -> i32 { yield 1; }", "main")
@@ -704,7 +685,7 @@ fn yield_outside_accessor_is_rejected() {
 // (`reject_free_function_accessor`), so this rejection stays on the seam.
 #[test]
 fn free_function_cannot_be_an_accessor() {
-    let mut fixture = ProviderFixture::with_preview(accessor_preview());
+    let mut fixture = ProviderFixture::new();
     fixture.declare_function(
         "first",
         vec![mode_param(
@@ -738,7 +719,7 @@ fn free_function_cannot_be_an_accessor() {
 // trailing `yield` in the body (6.6:4, RUE-1213).
 #[test]
 fn free_function_accessor_without_yield_is_rejected() {
-    let mut fixture = ProviderFixture::with_preview(accessor_preview());
+    let mut fixture = ProviderFixture::new();
     fixture.declare_function("make", Vec::new(), SemanticImportType::I64);
     let error = fixture
         .analyze(
@@ -761,11 +742,11 @@ fn free_function_accessor_without_yield_is_rejected() {
 
 // Migrated from `tests::plain_free_function_is_not_an_accessor`: only the
 // result-position `borrow` marks an accessor, so an ordinary `-> T` free
-// function keeps compiling with the preview enabled — as does a caller
+// function keeps compiling as a stable function — as does a caller
 // reaching it through its durable signature fact.
 #[test]
 fn plain_free_function_is_not_an_accessor() {
-    let mut fixture = ProviderFixture::with_preview(accessor_preview());
+    let mut fixture = ProviderFixture::new();
     fixture.declare_function("make", Vec::new(), SemanticImportType::I64);
     fixture.declare_function("main", Vec::new(), SemanticImportType::I32);
     fixture
@@ -792,7 +773,7 @@ fn plain_free_function_is_not_an_accessor() {
 // callee's resolved `returns_borrow` fact.
 #[test]
 fn nested_accessor_yield_compiles() {
-    let mut fixture = ProviderFixture::with_preview(accessor_preview());
+    let mut fixture = ProviderFixture::new();
     let p = fixture.declare_struct("P", vec![("x", SemanticImportType::I64)], false);
     fixture.declare_method_with(
         &p,
@@ -831,7 +812,7 @@ fn nested_accessor_yield_compiles() {
 // body-shape rules misfire on the legal form.
 #[test]
 fn legal_accessor_body_compiles() {
-    let mut fixture = ProviderFixture::with_preview(accessor_preview());
+    let mut fixture = ProviderFixture::new();
     let p = fixture.declare_struct("P", vec![("x", SemanticImportType::I64)], false);
     fixture.declare_method_with(
         &p,
@@ -855,61 +836,4 @@ fn legal_accessor_body_compiles() {
         )
         .expect("a legal accessor compiles");
     assert_eq!(body.function.air.return_type(), crate::types::Type::I64);
-}
-
-// Migrated from `tests::accessor_declaration_requires_preview_gate` (and its
-// uncalled twin, which the fixture cannot distinguish): with the gate off,
-// the accessor's demanded body is rejected at its `yield` exit
-// (`require_preview` in `analyze_yield`). The declaration-plane 6.6:3 gate —
-// which fires with no body demanded — is `rules::accessor_preview_gate` at
-// the `rue-compiler` signature query, covered by spec cases
-// `accessor_requires_preview_gate` and `uncalled_accessor_requires_preview_gate`.
-#[test]
-fn accessor_body_requires_preview_gate() {
-    let (fixture, _) = grid_fixture(PreviewFeatures::new());
-    let error = fixture
-        .analyze_member(
-            GRID_ACCESSOR_DECL,
-            "Grid",
-            "at",
-            StableDefinitionKind::Method,
-        )
-        .map(|_| ())
-        .expect_err("the gate is off");
-    assert!(
-        matches!(
-            &error.kind,
-            ErrorKind::PreviewFeatureRequired { feature, .. }
-                if *feature == PreviewFeature::BorrowAccessors
-        ),
-        "unexpected diagnostic: {error:?}"
-    );
-}
-
-// Migrated from `tests::free_function_accessor_without_yield_requires_preview`:
-// 6.6:3 is disjunctive — the `-> borrow` result position alone demands the
-// preview, whether or not the body contains a `yield` (RUE-1213). The
-// provider body path enforces this through the free-function declaration
-// shape check at body entry.
-#[test]
-fn free_function_accessor_without_yield_requires_preview() {
-    let mut fixture = ProviderFixture::new();
-    fixture.declare_function("make", Vec::new(), SemanticImportType::I64);
-    let error = fixture
-        .analyze(
-            "fn make() -> borrow i64 {
-    5
-}",
-            "make",
-        )
-        .map(|_| ())
-        .expect_err("the gate is off");
-    assert!(
-        matches!(
-            &error.kind,
-            ErrorKind::PreviewFeatureRequired { feature, .. }
-                if *feature == PreviewFeature::BorrowAccessors
-        ),
-        "unexpected diagnostic: {error:?}"
-    );
 }

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -3719,7 +3719,6 @@ where
             declaration,
             None,
             false,
-            &self.preview,
         )
     }
 }

--- a/crates/rue-air/src/sema/provider_fixture.rs
+++ b/crates/rue-air/src/sema/provider_fixture.rs
@@ -489,12 +489,6 @@ impl ProviderFixture {
         }
     }
 
-    pub(crate) fn with_preview(preview: PreviewFeatures) -> Self {
-        let mut fixture = Self::new();
-        fixture.preview = preview;
-        fixture
-    }
-
     pub(crate) fn declare_function(
         &mut self,
         name: &str,

--- a/crates/rue-air/src/sema/provider_fixture_tests.rs
+++ b/crates/rue-air/src/sema/provider_fixture_tests.rs
@@ -448,16 +448,11 @@ fn provider_body_constructs_declared_enum_variant() {
     assert_eq!(body.function.air.return_type(), crate::types::Type::I32);
 }
 
-// A legal accessor body analyzed directly under the preview gate: the
-// accessor flag and receiver mode cross as durable method facts.
+// A legal accessor body is analyzed directly from durable method facts.
 #[test]
-fn provider_accessor_body_analyzes_under_preview_gate() {
+fn provider_accessor_body_analyzes_stably() {
     use crate::SemanticParameterMode;
-    use rue_error::PreviewFeature;
-
-    let mut preview = rue_error::PreviewFeatures::new();
-    preview.insert(PreviewFeature::BorrowAccessors);
-    let mut fixture = ProviderFixture::with_preview(preview);
+    let mut fixture = ProviderFixture::new();
     let holder = fixture.declare_struct("Holder", vec![("x", SemanticImportType::I64)], true);
     fixture.declare_method_with(
         &holder,

--- a/crates/rue-cli-tests/cases/borrow_accessors.toml
+++ b/crates/rue-cli-tests/cases/borrow_accessors.toml
@@ -15,7 +15,7 @@ fn main() -> i32 {
     if b.get_ref(0) + 1 == 42 { 0 } else { 1 }
 }
 """ }]
-args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 exit_code = 0
 
@@ -31,7 +31,7 @@ fn main() -> i32 {
     if b.get_ref(0) == 42 { 0 } else { 1 }
 }
 """ }]
-args = ["--preview", "borrow_accessors", "--emit", "asm", "--target", "aarch64-linux", "main.rue"]
+args = ["--emit", "asm", "--target", "aarch64-linux", "main.rue"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 compile_only = true
 compile_stdout_contains = ["=== Assembly (aarch64-linux) ===", "main:"]
@@ -54,7 +54,7 @@ fn main() -> i32 {
     if read_second(borrow b) == 42 { 0 } else { 1 }
 }
 """ }]
-args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 exit_code = 0
 
@@ -70,14 +70,14 @@ fn main() -> i32 {
     if b.get_ref(1) == 1 { 0 } else { 1 }
 }
 """ }]
-args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 exit_code = 101
 runtime_error_contains = ["panic: index out of bounds"]
 
 [[case]]
-name = "trusted_std_accessor_call_requires_preview"
-description = "The trusted declaration exemption does not remove the call-site preview gate."
+name = "trusted_std_accessor_call_is_stable"
+description = "Trusted standard-library accessor calls compile as a stable feature."
 files = [{ path = "main.rue", source = """
 const std = @import("std");
 fn main() -> i32 {
@@ -90,8 +90,20 @@ fn main() -> i32 {
 """ }]
 args = ["main.rue", "-o", "prog"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
+exit_code = 0
+
+[[case]]
+name = "borrow_accessors_preview_name_is_unknown"
+description = "The retired borrow_accessors preview spelling is rejected and the active feature list omits it."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--preview", "borrow_accessors", "-o", "prog"]
 compile_fail = true
-error_contains = ["E1100", "borrow_accessors"]
+error_contains = [
+    "unknown preview feature 'borrow_accessors'",
+    "Available features: test_infra, c_ffi, floats",
+]
 
 [[case]]
 name = "trusted_std_grid_get_ref"
@@ -104,7 +116,7 @@ fn main() -> i32 {
     if g.get_ref(0, 0) + 1 == 42 { 0 } else { 1 }
 }
 """ }]
-args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 exit_code = 0
 
@@ -131,7 +143,7 @@ fn main() -> i32 {
     if root.kids.get_ref(0).kids.get_ref(0).tag == 3 { 0 } else { 1 }
 }
 """ }]
-args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 stdout = "1\n2\n3\n"
 exit_code = 0
@@ -167,7 +179,7 @@ fn main() -> i32 {
     if grid.get_ref(0).get_ref(0) == 42 { 0 } else { 1 }
 }
 """ }]
-args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 exit_code = 0
 
@@ -185,7 +197,7 @@ fn main() -> i32 {
     0
 }
 """ }]
-args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 compile_fail = true
 error_contains = ["E0259", "while an accessor result borrows it"]
@@ -203,7 +215,7 @@ fn main() -> i32 {
     @intCast(first(borrow b))
 }
 """ }]
-args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 compile_fail = true
 error_contains = ["E0250", "cannot return an accessor result"]
@@ -225,7 +237,7 @@ fn main() -> i32 {
     if stack.peek_ref().value == 7 && queue.peek_ref().value == 8 { 0 } else { 1 }
 }
 """ }]
-args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 stdout = "8\n7\n"
 exit_code = 0
@@ -259,7 +271,7 @@ fn main() -> i32 {
     if g.at(0) + g.at(3) == 50 { 0 } else { 1 }
 }
 """ }]
-args = ["--preview", "borrow_accessors", "--emit", "asm", "--target", "aarch64-linux", "main.rue"]
+args = ["--emit", "asm", "--target", "aarch64-linux", "main.rue"]
 compile_only = true
 compile_stdout_contains = ["=== Assembly (aarch64-linux) ===", "main:"]
 compile_stdout_not_contains = [".at:"]
@@ -279,7 +291,7 @@ fn main() -> i32 {
     if v.cells[1] == 42 { 0 } else { 1 }
 }
 """ }]
-args = ["--preview", "borrow_accessors", "main.rue", "-O0", "-o", "prog"]
+args = ["main.rue", "-O0", "-o", "prog"]
 exit_code = 0
 
 [[case]]
@@ -306,7 +318,7 @@ fn main() -> i32 {
     if p.value() == 9 { 0 } else { 1 }
 }
 """ }]
-args = ["--preview", "borrow_accessors", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 stdout = "77\n"
 exit_code = 0
 
@@ -326,14 +338,14 @@ fn main() -> i32 {
     if g.at(0) + g.at(3) == 50 { 0 } else { 1 }
 }
 """ }]
-args = ["--preview", "borrow_accessors", "--emit", "asm", "--target", "x86-64-linux", "main.rue"]
+args = ["--emit", "asm", "--target", "x86-64-linux", "main.rue"]
 compile_only = true
 compile_stdout_contains = ["=== Assembly (x86-64-linux) ===", "main:"]
 compile_stdout_not_contains = [".at:"]
 
 [[case]]
-name = "mutable_accessor_requires_preview"
-description = "The mutable place-returning form remains gated when the preview is disabled."
+name = "mutable_accessor_is_stable"
+description = "The stabilized mutable place-returning form compiles as a stable feature."
 files = [{ path = "main.rue", source = """
 struct P {
     x: i64,
@@ -345,9 +357,8 @@ fn main() -> i32 {
     0
 }
 """ }]
-args = ["main.rue"]
-compile_fail = true
-error_contains = ["E1100", "borrow_accessors"]
+args = ["main.rue", "-o", "prog"]
+exit_code = 0
 
 [[case]]
 name = "mutable_accessor_rejects_live_linear_overwrite"
@@ -365,7 +376,7 @@ fn main() -> i32 {
     0
 }
 """ }]
-args = ["--preview", "borrow_accessors", "main.rue"]
+args = ["main.rue"]
 compile_fail = true
 error_contains = ["E0493", "overwrite a live linear value"]
 
@@ -385,7 +396,7 @@ fn main() -> i32 {
     0
 }
 """ }]
-args = ["--preview", "borrow_accessors", "main.rue", "-O0", "-o", "prog"]
+args = ["main.rue", "-O0", "-o", "prog"]
 stdout = "1\n2\n"
 exit_code = 0
 
@@ -406,7 +417,7 @@ fn main() -> i32 {
     if v.cells[1] == 5 { 0 } else { 1 }
 }
 """ }]
-args = ["--preview", "borrow_accessors", "main.rue", "-O0", "-o", "prog"]
+args = ["main.rue", "-O0", "-o", "prog"]
 stdout = "7\n"
 exit_code = 0
 
@@ -426,7 +437,7 @@ fn main() -> i32 {
     if p.x == 2 && p.y == 2 { 0 } else { 1 }
 }
 """ }]
-args = ["--preview", "borrow_accessors", "main.rue", "-O0", "-o", "prog"]
+args = ["main.rue", "-O0", "-o", "prog"]
 exit_code = 0
 
 [[case]]
@@ -444,7 +455,7 @@ fn main() -> i32 {
     0
 }
 """ }]
-args = ["--preview", "borrow_accessors", "main.rue"]
+args = ["main.rue"]
 compile_fail = true
 error_contains = ["E0259", "another accessor result"]
 
@@ -466,7 +477,7 @@ fn main() -> i32 {
     if p.cell.value == 5 && p.y == 2 { 0 } else { 1 }
 }
 """ }]
-args = ["--preview", "borrow_accessors", "main.rue", "-O0", "-o", "prog"]
+args = ["main.rue", "-O0", "-o", "prog"]
 stdout = "7\n7\n"
 exit_code = 0
 
@@ -490,6 +501,6 @@ fn main() -> i32 {
     if p.a.items[0] == 2 && p.a.items[1] == 5 && p.y == 2 { 0 } else { 1 }
 }
 """ }]
-args = ["--preview", "borrow_accessors", "main.rue", "-O0", "-o", "prog"]
+args = ["main.rue", "-O0", "-o", "prog"]
 stdout = "8\n8\n9\n"
 exit_code = 0

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -142,7 +142,6 @@ fn the_driver_reads_accessor_declaration_rules_from_the_shared_rule_module() {
     );
     for required in [
         "use rue_air::declaration_validation as rules;",
-        "rules::accessor_preview_gate(",
         "rules::accessor_signature_for_mode(",
         "rules::accessor_body_error(",
         "accessor_method_link_error(",

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -641,10 +641,7 @@ mod tests {
              fn main() -> i32 { let p = P { x: 7 }; if p.value() + helper() == 8 { 0 } else { 1 } }",
         )
         .unwrap();
-        let mut options = CompileOptions::default();
-        options
-            .preview_features
-            .insert(rue_error::PreviewFeature::BorrowAccessors);
+        let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session
             .update_for_presentation(&snapshot)
@@ -735,10 +732,7 @@ mod tests {
              fn main() -> i32 { let p = P { x: 7 }; if p.value() == 7 { 0 } else { 1 } }",
         )
         .unwrap();
-        let mut options = CompileOptions::default();
-        options
-            .preview_features
-            .insert(rue_error::PreviewFeature::BorrowAccessors);
+        let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session
             .update_for_presentation(&snapshot)

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -10749,14 +10749,6 @@ fn resolve_parsed_semantic_signature(
                 use rue_air::declaration_validation::{
                     AccessorParameterForm, AccessorReceiverForm,
                 };
-                if let Some(kind) = rules::accessor_preview_gate(
-                    provider
-                        .configuration
-                        .preview_features
-                        .contains(rules::ACCESSOR_PREVIEW_FEATURE),
-                ) {
-                    return Err(diagnostic(kind));
-                }
                 let receiver = if provider.dependency_source.owner().is_none() {
                     AccessorReceiverForm::FreeFunction
                 } else if !*has_self {

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -1168,11 +1168,7 @@ mod codegen_unit_tests {
     }
 
     fn borrow_accessor_options() -> crate::CompileOptions {
-        let mut options = crate::CompileOptions::default();
-        options
-            .preview_features
-            .insert(rue_error::PreviewFeature::BorrowAccessors);
-        options
+        crate::CompileOptions::default()
     }
 
     #[test]
@@ -1392,10 +1388,7 @@ mod codegen_unit_tests {
         };
         let plain = "i64 { self.x }";
         let accessor = "borrow i64 { yield self.x; }";
-        let mut options = crate::CompileOptions::default();
-        options
-            .preview_features
-            .insert(rue_error::PreviewFeature::BorrowAccessors);
+        let options = crate::CompileOptions::default();
 
         let mut session = crate::CompilerSession::new();
         session.update(&source(plain)).into_result().unwrap();
@@ -1435,10 +1428,7 @@ mod codegen_unit_tests {
             )
             .unwrap()
         };
-        let mut options = crate::CompileOptions::default();
-        options
-            .preview_features
-            .insert(rue_error::PreviewFeature::BorrowAccessors);
+        let options = crate::CompileOptions::default();
         let mut session = crate::CompilerSession::new();
 
         session.update(&source(7)).into_result().unwrap();
@@ -1757,10 +1747,7 @@ pub fn Buf(comptime T: type) -> type {{
              fn main() -> i32 { let p = P { x: 3 }; if caller_a(borrow p) + caller_b(borrow p) == 9 { 0 } else { 1 } }",
         )
         .unwrap();
-        let mut options = crate::CompileOptions::default();
-        options
-            .preview_features
-            .insert(rue_error::PreviewFeature::BorrowAccessors);
+        let options = crate::CompileOptions::default();
         let mut session = crate::CompilerSession::new();
         session.update(&snapshot).into_result().unwrap();
         let rooted = session.rooted_cfg(&options).unwrap();

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -660,10 +660,6 @@ pub enum PreviewFeature {
     /// linking (ADR-0064, RUE-1055). Gated until every phase of the guaranteed
     /// target-C boundary is proven on both backends.
     CFfi,
-    /// Place-returning accessors (ADR-0062, RUE-662/RUE-1016): methods with a
-    /// `-> borrow T` or `-> inout T` result whose `yield` body hands out a
-    /// second-class projection of the receiver.
-    BorrowAccessors,
     /// Floating point: `f32`/`f64`, IEEE-754 arithmetic, and `comptime_float`
     /// literals (ADR-0065, RUE-714). Gated until every phase of the M9 rollout
     /// — types and inference, both backends, the dtoa runtime — is complete
@@ -693,7 +689,6 @@ impl PreviewFeature {
         match *self {
             PreviewFeature::TestInfra => "test_infra",
             PreviewFeature::CFfi => "c_ffi",
-            PreviewFeature::BorrowAccessors => "borrow_accessors",
             PreviewFeature::Floats => "floats",
         }
     }
@@ -704,7 +699,6 @@ impl PreviewFeature {
         match *self {
             PreviewFeature::TestInfra => "ADR-0005",
             PreviewFeature::CFfi => "ADR-0064",
-            PreviewFeature::BorrowAccessors => "ADR-0062",
             PreviewFeature::Floats => "ADR-0065",
         }
     }
@@ -714,7 +708,6 @@ impl PreviewFeature {
         &[
             PreviewFeature::TestInfra,
             PreviewFeature::CFfi,
-            PreviewFeature::BorrowAccessors,
             PreviewFeature::Floats,
         ]
     }
@@ -740,7 +733,6 @@ impl std::str::FromStr for PreviewFeature {
         match s {
             "test_infra" => Ok(PreviewFeature::TestInfra),
             "c_ffi" => Ok(PreviewFeature::CFfi),
-            "borrow_accessors" => Ok(PreviewFeature::BorrowAccessors),
             "floats" => Ok(PreviewFeature::Floats),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
@@ -3075,7 +3067,7 @@ mod tests {
     #[test]
     fn test_preview_feature_all_names() {
         let names = PreviewFeature::all_names();
-        assert_eq!(names, "test_infra, c_ffi, borrow_accessors, floats");
+        assert_eq!(names, "test_infra, c_ffi, floats");
     }
 
     #[test]
@@ -3180,8 +3172,8 @@ mod tests {
     fn test_preview_feature_stabilized_are_unknown() {
         // for_loops, method_receivers, enum_payloads, array_repeat,
         // field_init_shorthand, inline_type_ctor_paths, raw_bytes,
-        // aggregate_layout, and slices were stabilized (no longer gated) —
-        // their names must now be rejected.
+        // aggregate_layout, slices, and borrow_accessors were stabilized (no
+        // longer gated) — their names must now be rejected.
         for name in [
             "for_loops",
             "method_receivers",
@@ -3192,6 +3184,7 @@ mod tests {
             "raw_bytes",
             "aggregate_layout",
             "slices",
+            "borrow_accessors",
         ] {
             assert!(
                 name.parse::<PreviewFeature>().is_err(),

--- a/crates/rue-spec/cases/items/borrow-accessors.toml
+++ b/crates/rue-spec/cases/items/borrow-accessors.toml
@@ -1,5 +1,4 @@
-# Borrow accessors (ADR-0062 phases 0-3, RUE-662/RUE-1017), behind the
-# `borrow_accessors` preview.
+# Borrow accessors (ADR-0062 phases 0-4, RUE-662/RUE-1017/RUE-1018).
 #
 # Shared and exclusive accessor calls survive semantic analysis as marked
 # place-producing calls.
@@ -15,9 +14,7 @@ description = "Place-returning shared and exclusive accessors with trailing-yiel
 [[case]]
 name = "accessor_declaration_parses_and_compiles"
 spec = ["6.6:1", "6.6:2"]
-description = "The S2 surface: an ordinary fn with `-> borrow T` and a trailing-yield body is accepted under the preview."
-preview = "borrow_accessors"
-preview_should_pass = true
+description = "The S2 surface: an ordinary fn with `-> borrow T` and a trailing-yield body is accepted."
 source = """
 struct Grid {
     cells: [i64; 4],
@@ -41,8 +38,6 @@ exit_code = 0
 name = "mutable_accessor_assignment_rejects_accessor_rhs"
 spec = ["5.2:14", "6.6:16"]
 description = "A plain assignment retains accessor loans from its RHS while evaluating the target."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -62,8 +57,6 @@ error_contains = ["E0259", "another accessor result"]
 name = "mutable_accessor_projected_field_assignment_order"
 spec = ["5.2:14", "5.2:17", "5.2:18", "6.6:15"]
 description = "A projected exclusive accessor place evaluates a receiver-using RHS first and compounds once."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct Cell { value: i64 }
 struct P {
@@ -85,8 +78,6 @@ exit_code = 0
 name = "nested_accessor_splices_are_repeatable"
 spec = ["6.6:8"]
 description = "Nested accessor calls form a callee-first splice graph and repeated/diamond-shaped uses do not look recursive."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -105,8 +96,6 @@ exit_code = 0
 name = "indirect_accessor_recursion_is_rejected"
 spec = ["6.6:8"]
 description = "An indirect accessor cycle is diagnosed as E0261 before mandatory splicing."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -129,8 +118,6 @@ error_contains = ["E0261", "directly or through other accessors"]
 name = "uncalled_direct_accessor_recursion_is_rejected"
 spec = ["6.6:14"]
 description = "A directly self-recursive accessor is E0261 at its declaration, with no call site."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -149,8 +136,6 @@ error_contains = ["E0261", "an accessor may not invoke itself"]
 name = "uncalled_indirect_accessor_recursion_is_rejected"
 spec = ["6.6:14"]
 description = "A mutual accessor cycle over `self`-receiver calls is E0261 at the declarations, with no call site."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -172,8 +157,6 @@ error_contains = ["E0261", "directly or through other accessors"]
 name = "guard_receiver_accessor_cycle_is_rejected"
 spec = ["6.6:14"]
 description = "An accessor cycle whose re-entrant link runs through a by-value guard receiver is still E0261 when demanded."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -199,8 +182,6 @@ error_contains = ["E0261"]
 name = "projected_receiver_accessor_executes_in_place"
 spec = ["6.6:8"]
 description = "A projected receiver remains a place when its accessor CFG is spliced."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct Inner {
     x: i64,
@@ -218,8 +199,6 @@ exit_code = 0
 name = "callee_only_nominal_relocates_into_caller_domain"
 spec = ["6.6:8"]
 description = "Types used only by an accessor body are rematerialized in the caller domain before splicing."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct Marker { value: i64 }
 struct P {
@@ -238,9 +217,9 @@ fn main() -> i32 {
 exit_code = 0
 
 [[case]]
-name = "accessor_requires_preview_gate"
+name = "accessor_compiles_stably"
 spec = ["6.6:3"]
-description = "Using the accessor form without --preview borrow_accessors is E1100."
+description = "The stabilized accessor form compiles as a stable feature."
 source = """
 struct P {
     x: i64,
@@ -254,30 +233,30 @@ fn main() -> i32 {
     if p.xr() == 1 { 0 } else { 1 }
 }
 """
-compile_fail = true
-error_contains = ["E1100", "borrow_accessors"]
+exit_code = 0
 
 [[case]]
-name = "accessor_result_position_requires_preview_gate"
+name = "uncalled_mutable_accessor_compiles_stably"
 spec = ["6.6:3"]
-description = "The `-> borrow` result position alone is E1100 without the preview, with no `yield` anywhere in the body."
+description = "The stabilized exclusive accessor declaration is accepted even when no call demands its body."
 source = """
-fn make() -> borrow i64 {
-    5
+struct P {
+    x: i64,
+
+    fn xr(inout self) -> inout i64 {
+        yield self.x;
+    }
 }
 fn main() -> i32 {
-    if make() == 5 { 0 } else { 1 }
+    0
 }
 """
-compile_fail = true
-error_contains = ["E1100", "borrow_accessors"]
+exit_code = 0
 
 [[case]]
 name = "accessor_requires_borrow_self"
 spec = ["6.6:4"]
 description = "An `inout self` accessor is rejected: phase 1 accessors are shared projections (E0257)."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -298,8 +277,6 @@ error_contains = ["E0257", "requires a `borrow self` receiver"]
 name = "free_function_accessor_is_rejected"
 spec = ["6.6:4"]
 description = "A `-> borrow` result on a free function is rejected (E0257); the accessor identity is the declared result, not a trailing `yield`."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 fn make() -> borrow i64 {
     5
@@ -315,8 +292,6 @@ error_contains = ["E0257", "this is a free function"]
 name = "generic_free_function_accessor_is_rejected"
 spec = ["6.6:4"]
 description = "A generic free function, which is analyzed only through its specializations, is rejected on the same rule (E0257)."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 fn make(comptime T: type, v: T) -> borrow T {
     v
@@ -332,8 +307,6 @@ error_contains = ["E0257", "this is a free function"]
 name = "accessor_params_are_by_value"
 spec = ["6.6:5"]
 description = "A `borrow`-mode accessor parameter is rejected (E0260)."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -355,8 +328,6 @@ error_contains = ["E0260", "must be by-value"]
 name = "accessor_body_requires_trailing_yield"
 spec = ["6.6:6"]
 description = "An accessor body whose final statement is not a yield is rejected (E0254)."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -377,8 +348,6 @@ error_contains = ["E0254", "single trailing `yield`"]
 name = "yield_outside_accessor_rejected"
 spec = ["6.6:6"]
 description = "A `yield` outside an accessor body is rejected (E0256)."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     yield 1;
@@ -391,8 +360,6 @@ error_contains = ["E0256", "only valid inside the body of a `-> borrow` or `-> i
 name = "accessor_yield_must_root_at_receiver"
 spec = ["6.6:7"]
 description = "Yielding a place not rooted at `self` is rejected (E0255)."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -425,9 +392,9 @@ error_contains = ["E0255", "place rooted at `self`"]
 # ---------------------------------------------------------------------------
 
 [[case]]
-name = "uncalled_accessor_requires_preview_gate"
+name = "uncalled_accessor_compiles_stably"
 spec = ["6.6:3"]
-description = "An accessor nothing calls is still accessor surface: E1100 without the preview."
+description = "An uncalled accessor declaration is accepted after stabilization."
 source = """
 struct P {
     x: i64,
@@ -439,15 +406,12 @@ struct P {
 }
 fn main() -> i32 { 0 }
 """
-compile_fail = true
-error_contains = ["E1100", "borrow_accessors"]
+exit_code = 0
 
 [[case]]
 name = "uncalled_accessor_requires_borrow_self"
 spec = ["6.6:4"]
 description = "The receiver rule holds on a declaration nothing calls (E0257)."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -466,8 +430,6 @@ error_contains = ["E0257", "requires a `borrow self` receiver"]
 name = "uncalled_associated_function_accessor_is_rejected"
 spec = ["6.6:4"]
 description = "An associated function has no receiver to project from, called or not (E0257)."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -486,8 +448,6 @@ error_contains = ["E0257", "an associated function with no receiver"]
 name = "uncalled_accessor_params_are_by_value"
 spec = ["6.6:5"]
 description = "The parameter-mode rule holds on a declaration nothing calls (E0260)."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -506,8 +466,6 @@ error_contains = ["E0260", "must be by-value"]
 name = "uncalled_accessor_body_requires_trailing_yield"
 spec = ["6.6:6"]
 description = "An accessor body with no trailing `yield` is rejected with no call site (E0254)."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -526,8 +484,6 @@ error_contains = ["E0254", "single trailing `yield`"]
 name = "uncalled_accessor_body_rejects_a_second_yield"
 spec = ["6.6:6"]
 description = "A second `yield` bypasses the trailing exit, with no call site (E0254)."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -547,8 +503,6 @@ error_contains = ["E0254", "single trailing `yield`", "a second `yield`"]
 name = "uncalled_accessor_body_rejects_return"
 spec = ["6.6:6"]
 description = "An accessor body may not contain `return`, with no call site (E0254)."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -570,8 +524,6 @@ error_contains = ["E0254", "single trailing `yield`", "a `return`"]
 name = "uncalled_accessor_body_rejects_try"
 spec = ["6.6:6"]
 description = "An accessor body may not contain `?`, with no call site (E0254)."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -591,8 +543,6 @@ error_contains = ["E0254", "single trailing `yield`", "a `?`"]
 name = "uncalled_accessor_yield_must_root_at_receiver"
 spec = ["6.6:7"]
 description = "Yielding a parameter other than the receiver is rejected with no call site (E0255)."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -611,8 +561,6 @@ error_contains = ["E0255", "place rooted at `self`", "`other`"]
 name = "uncalled_accessor_yield_of_a_computed_value_is_rejected"
 spec = ["6.6:7"]
 description = "Yielding a computed value, not a place, is rejected with no call site (E0255)."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -631,8 +579,6 @@ error_contains = ["E0255", "place rooted at `self`", "a value expression"]
 name = "uncalled_nested_accessor_yield_compiles"
 spec = ["6.6:7"]
 description = "Control: a nested accessor call is a legal projection link, so an uncalled accessor chain compiles."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -660,8 +606,6 @@ exit_code = 0
 name = "accessor_yield_through_plain_method_is_rejected"
 spec = ["6.6:7"]
 description = "A projection link through a non-accessor method of the receiver is rejected (E0255) with nothing calling the accessor: whether a `self.m()` link names an accessor is a parsed fact of the owner's other declarations."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -681,8 +625,6 @@ error_contains = ["E0255", "not an accessor projection"]
 name = "called_accessor_yield_through_plain_method_is_rejected"
 spec = ["6.6:7"]
 description = "The same link is rejected from the call site, where the demanded body walk decides every link from the receiver's resolved type."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -702,8 +644,6 @@ error_contains = ["E0255", "not an accessor projection"]
 name = "accessor_yield_through_a_chained_type_s_accessor_compiles"
 spec = ["6.6:7"]
 description = "A link whose receiver is not the accessor's own `self` names a method of another type, which the declaration cannot resolve; it stays permissive there and the demanded path decides it."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct Inner {
     v: i64,
@@ -727,8 +667,6 @@ exit_code = 0
 name = "uncalled_legal_accessor_compiles"
 spec = ["6.6:1", "6.6:2"]
 description = "Control: a well-formed accessor nothing calls compiles, so the unconditional declaration rules reject only ill-formed ones."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -746,8 +684,6 @@ exit_code = 0
 name = "accessor_may_not_call_itself"
 spec = ["6.6:14"]
 description = "A directly self-recursive accessor has no finite inline expansion (E0261)."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -773,8 +709,6 @@ error_contains = ["E0261", "an accessor may not invoke itself"]
 name = "accessor_read_executes_in_place"
 spec = ["6.6:8", "6.6:12"]
 description = "A guarded accessor call reads the projected element in place; guards run at the call site."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct Grid {
     cells: [i64; 4],
@@ -800,8 +734,6 @@ exit_code = 0
 name = "accessor_guard_traps_out_of_bounds"
 spec = ["6.6:12"]
 description = "The accessor's guard panics at the call site for an out-of-bounds index."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct Grid {
     cells: [i64; 4],
@@ -825,8 +757,6 @@ stderr_contains = "panic: index out of bounds"
 name = "accessor_result_cannot_be_returned"
 spec = ["6.6:9"]
 description = "Returning an accessor result escapes its full expression (E0250)."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -850,8 +780,6 @@ error_contains = ["E0250", "cannot return an accessor result"]
 name = "accessor_result_cannot_be_let_bound"
 spec = ["6.6:9"]
 description = "A plain `let` binding of an accessor result escapes its full expression (E0252)."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -873,8 +801,6 @@ error_contains = ["E0252", "cannot bind an accessor result with `let`"]
 name = "accessor_result_cannot_be_stored"
 spec = ["6.6:9"]
 description = "Assigning an accessor result into storage escapes its full expression (E0251)."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -897,8 +823,6 @@ error_contains = ["E0251", "cannot store an accessor result"]
 name = "accessor_result_cannot_be_captured"
 spec = ["6.6:9"]
 description = "Capturing an accessor result in an array literal escapes its full expression (E0253)."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct P {
     x: i64,
@@ -920,8 +844,6 @@ error_contains = ["E0253", "cannot capture an accessor result"]
 name = "accessor_loan_conflicts_with_inout"
 spec = ["6.6:10"]
 description = "An exclusive use of the borrowed root in the same full expression violates exclusivity (E0259)."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct Grid {
     cells: [i64; 4],
@@ -948,8 +870,6 @@ error_contains = ["E0259", "while an accessor result borrows it"]
 name = "accessor_result_drop_glue_read_rejected"
 spec = ["6.6:11"]
 description = "Reading an owning (drop-glue) value out of an accessor result by value is rejected (E0258)."
-preview = "borrow_accessors"
-preview_should_pass = true
 real_std = true
 source = """
 const std = @import("std");
@@ -976,8 +896,6 @@ error_contains = ["E0258"]
 name = "arraybuf_get_ref_projects_drop_glue_element_in_place"
 spec = ["6.6:7", "6.6:8", "6.6:11", "6.6:12"]
 description = "The trusted ArrayBuf bridge yields a receiver-rooted place, so a destructor-bearing element can be projected without copying its owner."
-preview = "borrow_accessors"
-preview_should_pass = true
 real_std = true
 source = """
 const std = @import("std");
@@ -993,9 +911,9 @@ fn main() -> i32 {
 exit_code = 0
 
 [[case]]
-name = "arraybuf_get_ref_call_requires_preview"
+name = "arraybuf_get_ref_call_is_stable"
 spec = ["6.6:3"]
-description = "Trusted standard-library declarations load stably, but calling get_ref without borrow_accessors is E1100."
+description = "Trusted standard-library get_ref calls compile as a stable feature."
 real_std = true
 source = """
 const std = @import("std");
@@ -1006,15 +924,12 @@ fn main() -> i32 {
     if b.get_ref(0) == 1 { 0 } else { 1 }
 }
 """
-compile_fail = true
-error_contains = ["E1100", "borrow_accessors"]
+exit_code = 0
 
 [[case]]
 name = "mutable_accessor_direct_and_projected_assignment"
 spec = ["6.6:15"]
 description = "An exclusive accessor result is a writable place, including projected writes."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct Cell { value: i64 }
 struct V {
@@ -1034,8 +949,6 @@ exit_code = 0
 name = "mutable_accessor_inout_forwarding"
 spec = ["6.6:15"]
 description = "An exclusive accessor result can be forwarded as an inout place."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct V {
     cells: [i64; 2],
@@ -1054,8 +967,6 @@ exit_code = 0
 name = "mutable_accessor_exclusive_conflicts_are_symmetric"
 spec = ["6.6:16"]
 description = "Two exclusive results rooted at one receiver conflict regardless of evaluation order."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct V {
     cells: [i64; 2],
@@ -1075,8 +986,6 @@ error_contains = ["E0426", "same variable"]
 name = "mutable_and_shared_accessor_conflict_mutable_first"
 spec = ["6.6:16"]
 description = "An exclusive accessor conflicts with a shared accessor rooted at the same receiver."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct V {
     cells: [i64; 2],
@@ -1097,8 +1006,6 @@ error_contains = ["E0259", "accessor"]
 name = "mutable_accessor_conflicts_with_ordinary_read_mutable_first"
 spec = ["6.6:16"]
 description = "An exclusive accessor conflicts with an ordinary shared read of the same root."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct V {
     cells: [i64; 2],
@@ -1118,8 +1025,6 @@ error_contains = ["E0259", "shared read"]
 name = "mutable_accessor_conflicts_with_ordinary_read_shared_first"
 spec = ["6.6:16"]
 description = "The ordinary-read-then-exclusive evaluation order is rejected symmetrically."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct V {
     cells: [i64; 2],
@@ -1139,8 +1044,6 @@ error_contains = ["E0259", "shared read"]
 name = "mutable_accessor_projected_read_is_legal"
 spec = ["6.6:15"]
 description = "Reading a projection of an exclusive accessor result remains a read of its yielded place."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct Cell { value: i64 }
 struct V {
@@ -1158,8 +1061,6 @@ exit_code = 0
 name = "mutable_and_shared_accessor_conflict_shared_first"
 spec = ["6.6:16"]
 description = "The shared-then-exclusive evaluation order is rejected symmetrically."
-preview = "borrow_accessors"
-preview_should_pass = true
 source = """
 struct V {
     cells: [i64; 2],

--- a/crates/rue-ui-tests/cases/diagnostics/borrow-accessors.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/borrow-accessors.toml
@@ -21,7 +21,6 @@ fn main() -> i32 {
     @intCast(read(borrow p))
 }
 """
-preview = "borrow_accessors"
 compile_fail = true
 error_contains = ["E0250", "cannot return an accessor result", "`xr`", "`p`"]
 
@@ -40,7 +39,6 @@ struct P {
 }
 fn main() -> i32 { 0 }
 """
-preview = "borrow_accessors"
 compile_fail = true
 error_contains = [
     "E0254",
@@ -62,7 +60,6 @@ struct P {
 }
 fn main() -> i32 { 0 }
 """
-preview = "borrow_accessors"
 compile_fail = true
 error_contains = ["E0255", "place rooted at `self`", "`other`"]
 
@@ -80,7 +77,6 @@ struct P {
 }
 fn main() -> i32 { 0 }
 """
-preview = "borrow_accessors"
 compile_fail = true
 error_contains = ["E0257", "inout self", "-> inout"]
 
@@ -98,7 +94,6 @@ fn main() -> i32 {
     0
 }
 """
-preview = "borrow_accessors"
 compile_fail = true
 error_contains = ["E0203"]
 
@@ -119,7 +114,6 @@ fn main() -> i32 {
     0
 }
 """
-preview = "borrow_accessors"
 compile_fail = true
 error_contains = ["E0250", "cannot return an accessor result"]
 
@@ -137,7 +131,6 @@ fn main() -> i32 {
     0
 }
 """
-preview = "borrow_accessors"
 compile_fail = true
 error_contains = ["E0259", "accessor result"]
 
@@ -155,6 +148,5 @@ struct P {
 }
 fn main() -> i32 { 0 }
 """
-preview = "borrow_accessors"
 compile_fail = true
 error_contains = ["E0254", "second `yield`"]

--- a/docs/designs/0005-preview-features.md
+++ b/docs/designs/0005-preview-features.md
@@ -179,6 +179,7 @@ The following preview features completed this process and are now stable (their
 - `enum_payloads` — see ADR-0038; stabilized 2026-07-03.
 - `string_trio` — see ADR-0043; stabilized by RUE-876 on 2026-07-14.
 - `slices` — see ADR-0043; stabilized by RUE-936 on 2026-08-20.
+- `borrow_accessors` — see ADR-0062; stabilized by RUE-1018 on 2026-08-21.
 
 `test_infra` remains permanently unstable (it exists only to exercise the gating
 mechanism), so the `PreviewFeature` enum is not empty.

--- a/docs/designs/0062-place-returning-borrow-accessors.md
+++ b/docs/designs/0062-place-returning-borrow-accessors.md
@@ -1,13 +1,13 @@
 ---
 id: 0062
 title: "Place-returning borrow accessors: projection reads of owned elements"
-status: accepted
+status: implemented
 tags: [ownership, borrows, collections, accessors, stdlib, formal-semantics]
-feature-flag: borrow_accessors
+feature-flag: (none - feature stabilized)
 created: 2026-07-18
 accepted: 2026-07-18
-implemented:
-spec-sections: []
+implemented: 2026-08-21
+spec-sections: ["6.6"]
 superseded-by:
 relates: ["RUE-662", "RUE-286", "RUE-651", "RUE-646", "RUE-1012", "RUE-1013", "RUE-219", "RUE-390", "ADR-0037", "ADR-0043"]
 ---
@@ -16,7 +16,7 @@ relates: ["RUE-662", "RUE-286", "RUE-651", "RUE-646", "RUE-1012", "RUE-1013", "R
 
 ## Status
 
-Accepted — ratified by Steve on 2026-07-18. Direction and syntax were both
+Implemented — stabilized by RUE-1018 on 2026-08-21. Direction and syntax were both
 decided in the 2026-07-18 design session: build the restricted
 place-returning form now, with the **S2 surface** (`fn` + `-> borrow T` +
 `yield` body — see §"The syntax decision"), conditional on (a) it remaining
@@ -256,7 +256,7 @@ sugar can still be layered on top later without disturbing this choice.)
 
 Tracked in Linear under the RUE-1015 epic:
 
-- [x] **Phase 0: Ratify syntax; spec + grammar + preview gate scaffolding** — RUE-662
+- [x] **Phase 0: Ratify syntax; spec + grammar scaffolding** — RUE-662
 - [x] **Phase 1: Read accessors** (`borrow self` → shared result; parser,
       sema/AIR loan checking, mandatory inlining, formal-core amendment,
       spec coverage) — RUE-662
@@ -266,11 +266,10 @@ Tracked in Linear under the RUE-1015 epic:
       pointing at it; sound grid/stack/queue accessors; the deque and intmap
       exclusions documented until their filler/copy representations change;
       owned-children tree example replacing an arena) — RUE-1017
-- [ ] **Phase 4: preview-gate removal** after dogfooding — RUE-1018
-      (blocked by RUE-1016 and RUE-1017)
+- [x] **Phase 4: preview-gate removal** after dogfooding — RUE-1018
 
-Each phase follows the `docs/designs/0005-preview-features.md` layer
-checklist under the single `borrow-accessors` flag.
+The feature is now part of Rue's stable language surface; no preview flag is
+required.
 
 ## Consequences
 

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -224,7 +224,7 @@ The table is generated from ADR frontmatter. Run
 | [0059](0059-byte-oriented-memory-intrinsics.md) | Byte-oriented memory intrinsics: unify the two low-level families | Implemented | intrinsics, memory, pointers, allocator, bytes, semantics, stdlib, abi |
 | [0060](0060-network-io-v1.md) | Network IO v1: blocking IPv4 TCP in pure Rue | Accepted | stdlib, io, networking, tcp, syscalls, error-handling, ownership |
 | [0061](0061-supported-compiler-facade.md) | Supported compiler facade and immutable artifact views | Accepted | architecture, compiler, tooling, api, incremental |
-| [0062](0062-place-returning-borrow-accessors.md) | Place-returning borrow accessors: projection reads of owned elements | Accepted | ownership, borrows, collections, accessors, stdlib, formal-semantics |
+| [0062](0062-place-returning-borrow-accessors.md) | Place-returning borrow accessors: projection reads of owned elements | Implemented | ownership, borrows, collections, accessors, stdlib, formal-semantics |
 | [0063](0063-parallel-demand-driven-incremental-compilation.md) | Parallel demand-driven incremental compilation | Implemented | architecture, compiler, incremental, parallelism, codegen, linker, performance |
 | [0064](0064-c-ffi.md) | C FFI: a guaranteed target-C boundary for imports and exports | Accepted | ffi, abi, codegen, linker, types, semantics, unsafe, interop |
 | [0065](0065-floating-point.md) | Floating point: f32/f64, IEEE-754 semantics, and register classes | Accepted | types, semantics, codegen, numerics, abi |

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -983,7 +983,7 @@ carries only the moves performed by the by-value arguments. Because the core is
 fully monomorphic (§1), `g` names a single concrete signature: there is no
 overload or generic instantiation to resolve at the call.
 
-**Accessor calls (ADR-0062, preview).** An accessor is a method of the form
+**Accessor calls (ADR-0062).** An accessor is a method of the form
 
 ```
   A.f : fn ( self_mode self : A, x1:T1, ..., xk:Tk ) -> result_mode T { e_guard ; yield p_y }
@@ -2247,7 +2247,7 @@ witness of the dynamic semantics (RUE-50), cited inline in each §6 rule group.
 | §4.1/§5.4 equality borrows its operands | 4.3:3f |
 | §5.5 match / enum elim + intro | 6.3:17, 3.8:33 (destructure), 4.7 (match) |
 | §5.8 leaf/operator/aggregate/call statics | 4.1:2/5/7, 4.2:1/6/14, 4.3:1/2/5/6, 4.3a:3/4, 4.4:2, 3.6:5/6/15/16, 3.5:1/2, 4.10:3/4/5/7, 6.1:36 |
-| §5.8 (Accessor-Call) + accessor body WF (preview, ADR-0062) | 6.6:2–6.6:17 |
+| §5.8 (Accessor-Call) + accessor body WF (ADR-0062) | 6.6:2–6.6:17 |
 | §5.6 enum drop (active payload) | 6.3:20 |
 | §4.3 expression/return value | 4.5:3 (→ value, not just type), 6.1:4/5, 4.9:1/7 |
 | §5.2 assignment / reinit | 3.8:55/56, 3.8:72, 3.8:77 |

--- a/docs/notes/compact-layout-default.md
+++ b/docs/notes/compact-layout-default.md
@@ -70,7 +70,7 @@ their compact and slot layouts coincide, so they are byte-for-byte unaffected.
 
 The preview feature is retired. `--preview aggregate_layout` is now a plain
 unknown-preview error listing the remaining features (`test_infra`, `c_ffi`,
-`borrow_accessors`, `floats`).
+`floats`).
 There is nothing to opt into: the compact layout is simply how Rue lays out
 memory.
 

--- a/docs/spec/src/06-items/06-borrow-accessors.md
+++ b/docs/spec/src/06-items/06-borrow-accessors.md
@@ -6,8 +6,6 @@ template = "spec/page.html"
 
 # Borrow Accessors
 
-{{ preview_feature(feature="borrow_accessors", adr="ADR-0062") }}
-
 {{ rule(id="6.6:1", cat="informative") }}
 
 A *borrow accessor* is a method that hands out a second-class borrow of a
@@ -15,7 +13,7 @@ projection of its receiver: `v.get_ref(i)` produces a borrowed place naming
 element `i` in place — no copy, no move-out — checked by the ordinary
 law-of-exclusivity loan machinery and scoped to the enclosing full expression
 (core calculus `docs/formal/01-core-calculus.md` §5.8, rule `(Accessor-Call)`).
-The same preview also supports mutable accessors: `v.get_mut(i)` produces an
+The same accessor form also supports mutable accessors: `v.get_mut(i)` produces an
 exclusive place, and uses `inout self` with an `-> inout T` result.
 
 ## Declaration
@@ -30,13 +28,11 @@ accessor_result = "borrow" | "inout" ;
 yield_expr  = "yield" expression ;
 ```
 
-{{ rule(id="6.6:3", cat="legality-rule") }}
+{{ rule(id="6.6:3", cat="normative") }}
 
-A `-> borrow` or `-> inout` result position and the `yield` form require the
-`borrow_accessors` preview feature. Without `--preview borrow_accessors`, a
-program using either is rejected at compile time (E1100), per 8.4.
-Stable standard-library loading may analyze its trusted accessor declarations
-without the preview; calling any such accessor remains subject to E1100.
+A `-> borrow` or `-> inout` result position and the `yield` form are stable
+accessor syntax. Programs using either are checked by the declaration and
+call-site legality rules below.
 
 {{ rule(id="6.6:4", cat="legality-rule") }}
 

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -33,8 +33,8 @@ intrinsic_arg  = type | expression ;
 function       = directives [ "pub" ] [ "unchecked" ]
                  "fn" IDENT "(" [ params ] ")" [ result ] "{" block "}" ;
 result         = "->" [ "borrow" | "inout" ] type ; (* marks a place-returning
-                                                        accessor (ADR-0062,
-                                                        preview); result and
+                                                        accessor (ADR-0062);
+                                                        result and
                                                         receiver modes pair —
                                                         a legality rule *)
 params         = param { "," param } [ "," ] ;
@@ -73,7 +73,7 @@ expr_stmt      = expression ";"
                | control_flow_expr
                | block_expr ;          (* block-like expressions need no semicolon *)
 yield_expr     = "yield" expression ;  (* the trailing exit of an accessor body
-                                          (ADR-0062, preview); parsed as an
+                                          (ADR-0062); parsed as an
                                           expression form, valid only as the
                                           single trailing statement of a
                                           `-> borrow` or `-> inout` accessor


### PR DESCRIPTION
## Summary

- stabilize borrow accessors across semantic, compiler, provider, and durable paths
- retire the preview spelling and migrate coverage to stable behavior
- mark ADR-0062 implemented and update specification and traceability

## Testing

- scripts/rue fmt
- scripts/rue quick
- scripts/rue premerge
- scripts/rue test
- focused accessor spec, UI, CLI, and unit suites

Fixes RUE-1018