### PR TITLE
RUE-930: add free-function inlining driver

### DIFF
--- a/crates/rue-cli-tests/cases/differential_opt.toml
+++ b/crates/rue-cli-tests/cases/differential_opt.toml
@@ -1023,3 +1023,48 @@ fn main() -> i32 {
 """ }]
 stdout = ""
 exit_code = 1
+
+# ADR-0049 Phase 2: ordinary small free functions are inlined only at O2/O3.
+# Keep two call sites so the batch driver exercises deterministic multiplicity
+# and continuation wiring while the callee remains present for codegen.
+[[case]]
+name = "free_function_inlining_multiple_sites_across_opt_levels"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+fn add_one(x: i32) -> i32 { x + 1 }
+
+fn main() -> i32 {
+    let a = add_one(4);
+    let b = add_one(a);
+    @dbg(a);
+    @dbg(b);
+    b
+}
+""" }]
+stdout = "5\n6\n"
+exit_code = 6
+
+# A caller-domain nominal with a destructor is observable across the inline
+# boundary. The copied drop must stay inside the callee's inlined lifetime and
+# print before the caller's next statement at every optimization level.
+[[case]]
+name = "free_function_inlining_preserves_drop_order_across_opt_levels"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+struct Token {
+    value: i32,
+}
+drop fn Token(self) { @dbg(self.value); }
+
+fn consume(token: Token) -> i32 {
+    token.value + 1
+}
+
+fn main() -> i32 {
+    let result = consume(Token { value: 7 });
+    @dbg(result);
+    result
+}
+""" }]
+stdout = "7\n8\n"
+exit_code = 8

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -529,6 +529,11 @@ pub(crate) struct CfgRecord {
     pub(crate) warnings: Arc<[rue_error::CompileWarning]>,
     pub(crate) implicit_destructor_targets: Arc<[crate::TypeInstanceKey]>,
     pub(crate) implicit_destructor_dependencies_complete: bool,
+    /// General interprocedural inlining changes the caller's CFG in a
+    /// whole-program batch. Such a record is a backend result, not a durable
+    /// function-local CFG and must not be admitted to the durable retention
+    /// cone (ADR-0049 Phase 2).
+    pub(crate) durable_reuse_allowed: bool,
 }
 
 #[cfg(test)]
@@ -1513,6 +1518,7 @@ fn build_cfg(
             .into(),
         implicit_destructor_dependencies_complete: materialized.completeness.is_complete()
             && !output.anonymous_destructor_dependency_incomplete,
+        durable_reuse_allowed: true,
     }));
     let cfg_publication_ns = elapsed_ns(publication_started);
     tracing::event!(
@@ -1763,6 +1769,7 @@ pub(crate) fn evaluate_optimized_cfg(
                 .collect::<Vec<_>>()
                 .into(),
             implicit_destructor_dependencies_complete,
+            durable_reuse_allowed: record.durable_reuse_allowed,
         },
     ))
 }
@@ -1805,8 +1812,417 @@ fn optimize_cfg_without_accessors(
             implicit_destructor_targets: record.implicit_destructor_targets.clone(),
             implicit_destructor_dependencies_complete: record
                 .implicit_destructor_dependencies_complete,
+            durable_reuse_allowed: record.durable_reuse_allowed,
         },
     )
+}
+
+/// Apply ADR-0049 Phase 2 to one optimized-CFG batch. The batch is the only
+/// place where the complete reached set is available, so call discovery is
+/// deliberately performed over the actual CFG instruction arenas here. This
+/// keeps the semantic dependency graph out of the inlining decision and gives
+/// callers a single deterministic whole-set result for both backends.
+pub(crate) fn apply_general_inlining(
+    context: &QueryContext,
+    keys: &[OptimizedCfgQueryKey],
+    values: &[CfgValue],
+) -> Result<
+    (
+        Vec<CfgValue>,
+        std::collections::BTreeSet<crate::FunctionInstanceKey>,
+    ),
+    QueryAbort,
+> {
+    if keys.first().is_none_or(|key| {
+        key.opt_level == rue_cfg::OptLevel::O0 || key.opt_level == rue_cfg::OptLevel::O1
+    }) {
+        return Ok((values.to_vec(), std::collections::BTreeSet::new()));
+    }
+    context.check_canceled()?;
+
+    let mut records = std::collections::BTreeMap::new();
+    for (key, value) in keys.iter().zip(values) {
+        let CfgValue::Available(record) = value else {
+            return Ok((values.to_vec(), std::collections::BTreeSet::new()));
+        };
+        records.insert(key.cfg.function.clone(), record.clone());
+    }
+
+    // Keep every edge, including duplicate edges. The multiplicity is useful
+    // for deterministic call-site selection and makes the graph description
+    // honest even though SCC detection only needs its distinct neighbors.
+    let mut edges = std::collections::BTreeMap::<
+        crate::FunctionInstanceKey,
+        Vec<crate::FunctionInstanceKey>,
+    >::new();
+    let mut callsites = std::collections::BTreeMap::<
+        crate::FunctionInstanceKey,
+        Vec<(rue_cfg::CfgValue, crate::FunctionInstanceKey)>,
+    >::new();
+    let mut has_calls = std::collections::BTreeMap::new();
+    for (function, record) in &records {
+        let mut calls = Vec::new();
+        let mut any_call = false;
+        for block in record.cfg.blocks() {
+            for &value in &block.insts {
+                let rue_cfg::CfgInstData::Call { runtime, name, .. } =
+                    record.cfg.get_inst(value).data
+                else {
+                    continue;
+                };
+                any_call = true;
+                if runtime.is_some() {
+                    continue;
+                }
+                let Some(callee) = record.domains.callable_for_symbol(name) else {
+                    continue;
+                };
+                edges
+                    .entry(function.clone())
+                    .or_default()
+                    .push(callee.clone());
+                if records.contains_key(&callee) {
+                    calls.push((value, callee));
+                }
+            }
+        }
+        has_calls.insert(function.clone(), any_call);
+        callsites.insert(function.clone(), calls);
+    }
+
+    let mut graph = std::collections::BTreeMap::new();
+    for function in records.keys() {
+        graph.insert(
+            function.clone(),
+            edges
+                .get(function)
+                .into_iter()
+                .flatten()
+                .filter(|callee| records.contains_key(*callee))
+                .cloned()
+                .collect::<Vec<_>>(),
+        );
+    }
+    let recursive = recursive_scc_nodes(&graph);
+    let eligible = |function: &crate::FunctionInstanceKey| {
+        let Some(record) = records.get(function) else {
+            return false;
+        };
+        if recursive.contains(function)
+            || has_calls.get(function).copied().unwrap_or(true)
+            || !phase2_size_eligible(record.cfg.value_count())
+        {
+            return false;
+        }
+        if !is_true_free_function(function) {
+            return false;
+        }
+        matches!(
+            &keys
+                .iter()
+                .find(|key| key.cfg.function == *function)
+                .map(|key| &key.cfg.semantic_input),
+            Some(CfgSemanticInput::Body { input, .. }) if !canonical_body(&input.canonical).is_accessor
+        )
+    };
+
+    let mut output = values.to_vec();
+    let mut changed = std::collections::BTreeSet::new();
+    for (index, key) in keys.iter().enumerate() {
+        context.check_canceled()?;
+        let function = &key.cfg.function;
+        let Some(sites) = callsites.get(function) else {
+            continue;
+        };
+        let selected = sites
+            .iter()
+            .filter(|(call, callee)| {
+                eligible(callee)
+                    && records.get(callee).is_some_and(|callee| {
+                        // CFG calls carry physical argument values. A
+                        // zero-width source parameter can therefore make
+                        // the physical count differ; the Phase-2 policy
+                        // excludes that ABI shape rather than handing it
+                        // to the source-parameter splice primitive.
+                        records.get(function).is_some_and(|caller| {
+                            caller
+                                .cfg
+                                .get_call_args(&caller.cfg.get_inst(*call).data)
+                                .len()
+                                == callee.cfg.source_param_abi().len()
+                        })
+                    })
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        if selected.is_empty() {
+            continue;
+        }
+        let CfgValue::Available(record) = &output[index] else {
+            continue;
+        };
+        let mut domains = record.domains.clone();
+        let mut strings = record.strings.to_vec();
+        let interner = match copy_interner_preserving_ordinals(&record.interner, || {
+            context.check_canceled()
+        }) {
+            Ok(interner) => Arc::new(interner),
+            Err(CfgInternerCopyFailure::Checkpoint(abort)) => return Err(abort),
+            Err(error) => {
+                output[index] = internal_failure(
+                    format!("general inlining interner isolation failed: {error}"),
+                    record.body_span,
+                );
+                continue;
+            }
+        };
+        let mut local_atoms = record.local_atoms.to_vec();
+        let mut local_atom_identities = local_atoms
+            .iter()
+            .map(|atom| atom.identity.clone())
+            .collect::<std::collections::HashSet<_>>();
+        let mut symbol_mappings = record.codegen.symbol_mappings.as_ref().clone();
+        let mut foreign_symbols = record.codegen.foreign_symbols.as_ref().clone();
+        let materialization_warnings = record.materialization_warnings.to_vec();
+        let warnings = record.warnings.to_vec();
+        let mut implicit_destructor_targets = record
+            .implicit_destructor_targets
+            .iter()
+            .cloned()
+            .collect::<std::collections::BTreeSet<_>>();
+        let mut implicit_destructor_dependencies_complete =
+            record.implicit_destructor_dependencies_complete;
+        let mut current = record.cfg.clone();
+        let mut spliced = false;
+        let mut failed = None;
+        for (call, callee_function) in selected {
+            let Some(callee) = records.get(&callee_function) else {
+                continue;
+            };
+            let (callee_cfg, string_map) = match domains.import_accessor_cfg(
+                &callee.domains,
+                &callee.cfg,
+                &callee.interner,
+                &interner,
+                &mut strings,
+                callee.body_span,
+            ) {
+                Ok(value) => value,
+                Err(crate::durable_cfg::CfgDomainFailure::MissingStableType(_)) => {
+                    // A body-local type domain that is not present in the
+                    // caller cannot be imported without widening the caller's
+                    // immutable type pool. It is outside conservative Phase 2.
+                    continue;
+                }
+                Err(error) => {
+                    failed = Some(format!(
+                        "general inline CFG domain import failed: {error:?}"
+                    ));
+                    break;
+                }
+            };
+            let callee_cfg = match callee_cfg.finish_after_optimization(&record.type_pool) {
+                Ok(cfg) => cfg,
+                Err(error) => {
+                    failed = Some(format!(
+                        "imported general inline CFG failed verification: {error}"
+                    ));
+                    break;
+                }
+            };
+            for atom in callee.local_atoms.iter() {
+                let Some(dense_id) = string_map.get(&atom.dense_id).copied() else {
+                    failed = Some("general inline local atom has no imported string id".to_owned());
+                    break;
+                };
+                let mut atom = atom.clone();
+                atom.dense_id = dense_id;
+                if local_atom_identities.insert(atom.identity.clone()) {
+                    local_atoms.push(atom);
+                }
+            }
+            if failed.is_some() {
+                break;
+            }
+            symbol_mappings.extend(
+                callee
+                    .codegen
+                    .symbol_mappings
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone())),
+            );
+            foreign_symbols.extend(callee.codegen.foreign_symbols.iter().cloned());
+            implicit_destructor_targets.extend(callee.implicit_destructor_targets.iter().cloned());
+            implicit_destructor_dependencies_complete &=
+                callee.implicit_destructor_dependencies_complete;
+            let call_block = current
+                .blocks()
+                .iter()
+                .find(|block| block.insts.contains(&call))
+                .map(|block| block.id)
+                .ok_or_else(|| format!("general inline call site {call} is detached"));
+            let call_block = match call_block {
+                Ok(block) => block,
+                Err(error) => {
+                    failed = Some(error);
+                    break;
+                }
+            };
+            current = match rue_cfg::inline_call_in_block(
+                &current,
+                call,
+                call_block,
+                &callee_cfg,
+                &record.type_pool,
+            ) {
+                Ok(cfg) => cfg,
+                Err(error) => {
+                    failed = Some(format!("general inline splice failed: {error}"));
+                    break;
+                }
+            };
+            spliced = true;
+            context.record_work(rue_query::WorkItem::new("cfg.general-inline-splices", 1));
+        }
+        if let Some(error) = failed {
+            output[index] = internal_failure(error, record.body_span);
+            continue;
+        }
+        if !spliced {
+            continue;
+        }
+        let current = match rue_cfg::opt::optimize(current, key.opt_level, &record.type_pool) {
+            Ok(cfg) => cfg,
+            Err(error) => {
+                output[index] = internal_failure(
+                    format!("general inline reoptimization failed: {error:?}"),
+                    record.body_span,
+                );
+                continue;
+            }
+        };
+        let interner_retained_charge = frozen_interner_retained_charge(&interner);
+        output[index] = CfgValue::Available(Arc::new(CfgRecord {
+            air: record.air.clone(),
+            source_name: record.source_name.clone(),
+            num_locals: record.num_locals,
+            num_param_slots: record.num_param_slots,
+            cfg: current,
+            domains,
+            type_pool: record.type_pool.clone(),
+            interner,
+            interner_retained_charge,
+            strings: strings.into(),
+            local_atoms: local_atoms.into(),
+            local_aggregate_type_aliases: record.local_aggregate_type_aliases,
+            local_materialized_type_handles: record.local_materialized_type_handles,
+            codegen: Arc::new(CfgCodegenDomain {
+                defined_symbol: record.codegen.defined_symbol.clone(),
+                symbol_mappings: Arc::new(symbol_mappings),
+                foreign_symbols: Arc::new(foreign_symbols),
+            }),
+            materialization_warnings: materialization_warnings.into(),
+            body_span: record.body_span,
+            warnings: warnings.into(),
+            implicit_destructor_targets: implicit_destructor_targets
+                .into_iter()
+                .collect::<Vec<_>>()
+                .into(),
+            implicit_destructor_dependencies_complete,
+            durable_reuse_allowed: false,
+        }));
+        changed.insert(function.clone());
+    }
+    Ok((output, changed))
+}
+
+const PHASE2_VALUE_CAP: usize = 32;
+
+fn phase2_size_eligible(value_count: usize) -> bool {
+    value_count <= PHASE2_VALUE_CAP
+}
+
+fn is_true_free_function(function: &crate::FunctionInstanceKey) -> bool {
+    let definition = match function {
+        crate::FunctionInstanceKey::Definition(definition) => definition,
+        crate::FunctionInstanceKey::Specialization { base, .. } => {
+            let crate::FunctionInstanceKey::Definition(definition) = base.as_ref() else {
+                return false;
+            };
+            definition
+        }
+        crate::FunctionInstanceKey::AnonymousMember { .. }
+        | crate::FunctionInstanceKey::DropGlue(_) => return false,
+    };
+    definition.kind() == crate::StableDefinitionKind::Function
+}
+
+/// Return every node in a cyclic strongly-connected component. Duplicate
+/// edges are accepted because call-site multiplicity is a separate property;
+/// SCC membership only depends on reachability.
+fn recursive_scc_nodes<K: Clone + Ord>(
+    graph: &std::collections::BTreeMap<K, Vec<K>>,
+) -> std::collections::BTreeSet<K> {
+    let mut reverse = graph
+        .keys()
+        .cloned()
+        .map(|node| (node, Vec::new()))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    for (caller, callees) in graph {
+        for callee in callees {
+            reverse
+                .get_mut(callee)
+                .expect("graph nodes are complete")
+                .push(caller.clone());
+        }
+    }
+    let mut visited = std::collections::BTreeSet::new();
+    let mut order = Vec::with_capacity(graph.len());
+    for start in graph.keys() {
+        if !visited.insert(start.clone()) {
+            continue;
+        }
+        // A frame retains the next edge index, so siblings are not marked
+        // visited until their predecessor has been fully explored.
+        let mut stack = vec![(start.clone(), 0usize)];
+        while let Some((node, next_index)) = stack.last_mut() {
+            let next = graph.get(node).and_then(|edges| edges.get(*next_index));
+            let Some(next) = next else {
+                let (node, _) = stack.pop().expect("DFS frame exists");
+                order.push(node);
+                continue;
+            };
+            *next_index += 1;
+            if visited.insert(next.clone()) {
+                stack.push((next.clone(), 0));
+            }
+        }
+    }
+    visited.clear();
+    let mut recursive = std::collections::BTreeSet::new();
+    for start in order.into_iter().rev() {
+        if !visited.insert(start.clone()) {
+            continue;
+        }
+        let mut component = Vec::new();
+        let mut stack = vec![start.clone()];
+        while let Some(node) = stack.pop() {
+            component.push(node.clone());
+            for next in reverse.get(&node).into_iter().flatten().rev() {
+                if visited.insert(next.clone()) {
+                    stack.push(next.clone());
+                }
+            }
+        }
+        let cyclic = component.len() > 1
+            || graph
+                .get(&start)
+                .is_some_and(|callees| callees.iter().any(|callee| callee == &start));
+        if cyclic {
+            recursive.extend(component);
+        }
+    }
+    recursive
 }
 
 fn finish_cfg_optimization(
@@ -2061,6 +2477,51 @@ mod accessor_graph_tests {
             validate_accessor_dag(&missing, |node| missing.contains_key(node), &mut work),
             Err(AccessorDagFailure::Cycle(0))
         ));
+    }
+
+    #[test]
+    fn general_inline_scc_detection_handles_cycles_diamonds_and_duplicates() {
+        let cases = [
+            (
+                std::collections::BTreeMap::from([(0, vec![0])]),
+                [0].as_slice(),
+            ),
+            (
+                std::collections::BTreeMap::from([(0, vec![1]), (1, vec![0])]),
+                &[0, 1][..],
+            ),
+            (
+                std::collections::BTreeMap::from([(0, vec![1, 2]), (1, vec![2]), (2, Vec::new())]),
+                &[][..],
+            ),
+            (
+                std::collections::BTreeMap::from([
+                    (0, Vec::new()),
+                    (1, Vec::new()),
+                    (2, Vec::new()),
+                ]),
+                &[][..],
+            ),
+            (
+                std::collections::BTreeMap::from([(0, vec![1, 1]), (1, vec![0])]),
+                &[0, 1][..],
+            ),
+        ];
+        for (graph, expected) in cases {
+            assert_eq!(
+                recursive_scc_nodes(&graph),
+                expected
+                    .iter()
+                    .copied()
+                    .collect::<std::collections::BTreeSet<_>>()
+            );
+        }
+    }
+
+    #[test]
+    fn phase2_policy_keeps_the_32_value_boundary_exact() {
+        assert!(phase2_size_eligible(PHASE2_VALUE_CAP));
+        assert!(!phase2_size_eligible(PHASE2_VALUE_CAP + 1));
     }
 
     #[test]

--- a/crates/rue-compiler/src/codegen_query.rs
+++ b/crates/rue-compiler/src/codegen_query.rs
@@ -61,6 +61,11 @@ pub(crate) struct CodegenUnitQueryKey {
     /// used by lowering. It is excluded from `stable_identity`, but remains in
     /// memo equality so a different function body/configuration cannot alias.
     pub(crate) optimized_cfg: crate::cfg_query::OptimizedCfgQueryKey,
+    /// Rooted compilations carry the exact optimized-CFG batch that performed
+    /// Phase-2 general inlining. Codegen consumes that batch value so it never
+    /// re-queries the uninlined per-function terminal.
+    pub(crate) optimized_cfg_batch:
+        Option<Arc<crate::revisioned_query_database::OptimizedCfgBatchKey>>,
     /// Request-local transport for the deterministic test failure injection.
     /// Registered batch children run on worker threads, so thread-local test
     /// state is captured into the exact key at the host boundary.
@@ -71,11 +76,22 @@ pub(crate) struct CodegenUnitQueryKey {
 }
 
 impl CodegenUnitQueryKey {
+    #[cfg(test)]
     pub(crate) fn new(
         optimized_cfg: crate::cfg_query::OptimizedCfgQueryKey,
         target: rue_target::Target,
         request: rue_codegen::BackendArtifactRequest,
         optimization: rue_cfg::OptLevel,
+    ) -> Self {
+        Self::new_with_batch(optimized_cfg, target, request, optimization, None)
+    }
+
+    pub(crate) fn new_with_batch(
+        optimized_cfg: crate::cfg_query::OptimizedCfgQueryKey,
+        target: rue_target::Target,
+        request: rue_codegen::BackendArtifactRequest,
+        optimization: rue_cfg::OptLevel,
+        optimized_cfg_batch: Option<Arc<crate::revisioned_query_database::OptimizedCfgBatchKey>>,
     ) -> Self {
         let function = optimized_cfg.cfg.function.clone();
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -92,6 +108,7 @@ impl CodegenUnitQueryKey {
         request.regalloc.hash(&mut hasher);
         request.asm.hash(&mut hasher);
         optimized_cfg.hash(&mut hasher);
+        optimized_cfg_batch.hash(&mut hasher);
         #[cfg(test)]
         let inject_failure = INJECT_CODEGEN_FAILURE.with(Cell::get);
         #[cfg(test)]
@@ -100,7 +117,8 @@ impl CodegenUnitQueryKey {
         let data_model = target.data_model();
         let code_model = CodeModel::for_target(target);
         let display_identity: Arc<str> = format!(
-            "{function:?};target={target:?};data-model={data_model:?};code-model={code_model:?};opt={optimization:?};backend={BACKEND_EPOCH};abi-layout={ABI_LAYOUT_EPOCH}"
+            "{function:?};target={target:?};data-model={data_model:?};code-model={code_model:?};opt={optimization:?};backend={BACKEND_EPOCH};abi-layout={ABI_LAYOUT_EPOCH};batch={}",
+            optimized_cfg_batch.is_some()
         )
         .into();
         Self {
@@ -113,6 +131,7 @@ impl CodegenUnitQueryKey {
             abi_layout_epoch: ABI_LAYOUT_EPOCH,
             request,
             optimized_cfg,
+            optimized_cfg_batch,
             #[cfg(test)]
             inject_failure,
             memo_hash,
@@ -132,6 +151,7 @@ impl PartialEq for CodegenUnitQueryKey {
             && self.abi_layout_epoch == other.abi_layout_epoch
             && self.request == other.request
             && self.optimized_cfg == other.optimized_cfg
+            && self.optimized_cfg_batch == other.optimized_cfg_batch
             && {
                 #[cfg(test)]
                 {
@@ -174,6 +194,7 @@ impl QueryKey for CodegenUnitQueryKey {
         self.request.regalloc.hash(hasher);
         self.request.asm.hash(hasher);
         self.optimized_cfg.stable_hash(hasher);
+        self.optimized_cfg_batch.hash(hasher);
         #[cfg(test)]
         self.inject_failure.hash(hasher);
     }
@@ -394,19 +415,44 @@ pub(crate) fn evaluate_codegen_unit(
         crate::cfg_query::OptimizedCfgQueryKey,
         crate::cfg_query::CfgValue,
     >,
+    optimized_cfg_batches: &QueryFamily<
+        crate::revisioned_query_database::OptimizedCfgBatchKey,
+        crate::revisioned_query_database::OptimizedCfgBatchOutput,
+    >,
     key: &CodegenUnitQueryKey,
 ) -> Result<QueryOutput<CodegenUnitValue>, QueryAbort> {
     context.check_canceled()?;
     context.record_work(rue_query::WorkItem::new("codegen.unit.attempts", 1));
-    let _nested = context.retain_nested_attempts_for(&["compiler.optimized-cfg"]);
-    let optimized = context.query_registered(optimized_cfgs, key.optimized_cfg.clone())?;
+    let _nested = context
+        .retain_nested_attempts_for(&["compiler.optimized-cfg", "compiler.optimized-cfg-batch"]);
+    let optimized = if let Some(batch) = &key.optimized_cfg_batch {
+        let batch = context.query_registered(optimized_cfg_batches, (**batch).clone())?;
+        let rue_query::QueryOutcome::Success(batch) = batch.outcome() else {
+            unreachable!("optimized CFG batch publishes typed values")
+        };
+        let index = key
+            .optimized_cfg_batch
+            .as_ref()
+            .and_then(|batch_key| {
+                batch_key
+                    .keys
+                    .iter()
+                    .position(|candidate| candidate == &key.optimized_cfg)
+            })
+            .expect("codegen optimized-CFG key belongs to its batch");
+        let value = batch.values[index].clone();
+        value
+    } else {
+        let terminal = context.query_registered(optimized_cfgs, key.optimized_cfg.clone())?;
+        let QueryOutcome::Success(value) = terminal.outcome() else {
+            unreachable!("OptimizedCfg publishes typed values")
+        };
+        value.clone()
+    };
     context.record_work(rue_query::WorkItem::new(
         "codegen.dependencies.optimized-cfg",
         1,
     ));
-    let QueryOutcome::Success(optimized) = optimized.outcome() else {
-        unreachable!("OptimizedCfg publishes typed values");
-    };
     if let crate::cfg_query::CfgValue::Failure { errors, .. } = optimized {
         return Ok(codegen_failure(errors.clone()));
     }

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -60,6 +60,7 @@ mod tests {
 
         let optimized_batch = crate::revisioned_query_database::OptimizedCfgBatchKey {
             keys: Arc::from([optimized.clone()]),
+            generation: 0,
         };
         let codegen_batch = crate::revisioned_query_database::CodegenUnitBatchKey {
             keys: Arc::from([codegen.clone()]),
@@ -70,7 +71,7 @@ mod tests {
         assert_eq!(
             optimized_batch.stable_identity(),
             format!(
-                "optimized-cfg-batch;units=1\u{1e}{}",
+                "optimized-cfg-batch;units=1\u{1e}{};generation=0",
                 optimized.shared_stable_identity()
             )
         );
@@ -2731,6 +2732,256 @@ mod tests {
             is_elf || is_macho,
             "should produce valid ELF or Mach-O binary"
         );
+    }
+
+    #[test]
+    fn phase2_free_function_inlining_is_structural_and_request_local() {
+        let snapshot = SourceSnapshot::single(
+            "<phase2-inline-structure>",
+            "fn add_one(x: i32) -> i32 { x + 1 } fn main() -> i32 { add_one(4) + add_one(5) }",
+        )
+        .unwrap();
+        let call_count = |output: &RootedCfgOutput, name: &str| {
+            output
+                .cfgs
+                .iter()
+                .find(|unit| unit.record.codegen.defined_symbol.ends_with(name))
+                .map(|unit| {
+                    unit.record
+                        .cfg
+                        .blocks()
+                        .iter()
+                        .flat_map(|block| block.insts.iter())
+                        .filter(|value| {
+                            matches!(
+                                unit.record.cfg.get_inst(**value).data,
+                                rue_cfg::CfgInstData::Call { .. }
+                            )
+                        })
+                        .count()
+                })
+                .unwrap_or_default()
+        };
+        let mut session = CompilerSession::new();
+        session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+
+        for opt_level in [rue_cfg::OptLevel::O0, rue_cfg::OptLevel::O1] {
+            let options = CompileOptions {
+                opt_level,
+                ..CompileOptions::default()
+            };
+            let output = session.rooted_cfg(&options).unwrap();
+            assert_eq!(call_count(&output, "main"), 2);
+            assert!(
+                output
+                    .cfgs
+                    .iter()
+                    .all(|unit| unit.record.durable_reuse_allowed)
+            );
+        }
+
+        for opt_level in [rue_cfg::OptLevel::O2, rue_cfg::OptLevel::O3] {
+            let options = CompileOptions {
+                opt_level,
+                ..CompileOptions::default()
+            };
+            let output = session.rooted_cfg(&options).unwrap();
+            assert_eq!(call_count(&output, "main"), 0);
+            assert!(
+                output
+                    .cfgs
+                    .iter()
+                    .find(|unit| unit.record.codegen.defined_symbol.ends_with("main"))
+                    .is_some_and(|unit| !unit.record.durable_reuse_allowed)
+            );
+            assert!(output.cfgs.iter().any(|unit| matches!(
+                &unit.function,
+                FunctionInstanceKey::Definition(definition) if definition.name() == "add_one"
+            )));
+            let first_generation = output.optimized_cfg_batch.generation;
+            let second = session.rooted_cfg(&options).unwrap();
+            assert_ne!(first_generation, second.optimized_cfg_batch.generation);
+            assert_eq!(call_count(&second, "main"), 0);
+            assert!(session
+                .rooted_cfg_executions()
+                .iter()
+                .any(|(function, execution)| matches!(function, FunctionInstanceKey::Definition(definition) if definition.name() == "add_one")
+                    && matches!(execution, rue_query::RequestExecution::Reused | rue_query::RequestExecution::Joined)));
+        }
+    }
+
+    #[test]
+    fn phase2_excludes_methods_from_general_inlining() {
+        let snapshot = SourceSnapshot::single(
+            "<phase2-method-exclusion>",
+            "struct Counter { value: i32, fn next(self) -> i32 { self.value + 1 } } fn main() -> i32 { Counter { value: 4 }.next() }",
+        )
+        .unwrap();
+        let mut session = CompilerSession::new();
+        session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+        let output = session
+            .rooted_cfg(&CompileOptions {
+                opt_level: rue_cfg::OptLevel::O2,
+                ..CompileOptions::default()
+            })
+            .unwrap();
+        let main = output
+            .cfgs
+            .iter()
+            .find(|unit| unit.record.codegen.defined_symbol.ends_with("main"))
+            .unwrap();
+        assert!(main.record.durable_reuse_allowed);
+        assert!(
+            main.record
+                .cfg
+                .blocks()
+                .iter()
+                .flat_map(|block| block.insts.iter())
+                .any(|value| {
+                    matches!(
+                        main.record.cfg.get_inst(*value).data,
+                        rue_cfg::CfgInstData::Call { .. }
+                    )
+                })
+        );
+    }
+
+    #[test]
+    fn phase2_single_call_token_destructor_is_actually_inlined() {
+        let snapshot = SourceSnapshot::single(
+            "<phase2-token-inline>",
+            "struct Token { value: i32 } drop fn Token(self) { @dbg(self.value); } fn consume(token: Token) -> i32 { token.value + 1 } fn main() -> i32 { consume(Token { value: 7 }) }",
+        )
+        .unwrap();
+        let mut session = CompilerSession::new();
+        session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+        let call_count = |output: &RootedCfgOutput| {
+            let record = &output
+                .cfgs
+                .iter()
+                .find(|unit| {
+                    matches!(&unit.function, FunctionInstanceKey::Definition(definition) if definition.name() == "main")
+                })
+                .unwrap()
+                .record;
+            record
+                .cfg
+                .blocks()
+                .iter()
+                .flat_map(|block| block.insts.iter())
+                .filter(|value| {
+                    matches!(
+                        record.cfg.get_inst(**value).data,
+                        rue_cfg::CfgInstData::Call { .. }
+                    )
+                })
+                .count()
+        };
+        let o0 = session
+            .rooted_cfg(&CompileOptions {
+                opt_level: rue_cfg::OptLevel::O0,
+                ..CompileOptions::default()
+            })
+            .unwrap();
+        assert_eq!(call_count(&o0), 1);
+        assert!(o0.cfgs.iter().find(|unit| matches!(&unit.function, FunctionInstanceKey::Definition(definition) if definition.name() == "main")).unwrap().record.durable_reuse_allowed);
+        let o2 = session
+            .rooted_cfg(&CompileOptions {
+                opt_level: rue_cfg::OptLevel::O2,
+                ..CompileOptions::default()
+            })
+            .unwrap();
+        assert_eq!(call_count(&o2), 0);
+        assert!(!o2.cfgs.iter().find(|unit| matches!(&unit.function, FunctionInstanceKey::Definition(definition) if definition.name() == "main")).unwrap().record.durable_reuse_allowed);
+        assert!(o2.cfgs.iter().any(|unit| matches!(
+            &unit.function,
+            FunctionInstanceKey::Definition(definition) if definition.name() == "consume"
+        )));
+    }
+
+    #[test]
+    fn phase2_codegen_consumes_the_exact_inlined_batch_on_both_backends() {
+        let snapshot = SourceSnapshot::single(
+            "<phase2-inline-codegen>",
+            "fn add_one(x: i32) -> i32 { x + 1 } fn main() -> i32 { add_one(4) }",
+        )
+        .unwrap();
+
+        for target in [Target::X86_64Linux, Target::Aarch64Linux] {
+            let options = CompileOptions {
+                target,
+                opt_level: rue_cfg::OptLevel::O2,
+                ..CompileOptions::default()
+            };
+            let mut session = CompilerSession::new();
+            session
+                .update_for_presentation(&snapshot)
+                .into_result()
+                .unwrap();
+
+            let first = session
+                .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+                .unwrap();
+            let main_cfg = first
+                .cfgs
+                .iter()
+                .find(|unit| matches!(&unit.function, FunctionInstanceKey::Definition(definition) if definition.name() == "main"))
+                .unwrap();
+            assert!(!main_cfg.record.durable_reuse_allowed);
+            assert!(
+                main_cfg
+                    .record
+                    .cfg
+                    .blocks()
+                    .iter()
+                    .flat_map(|block| block.insts.iter())
+                    .all(|value| !matches!(
+                        main_cfg.record.cfg.get_inst(*value).data,
+                        rue_cfg::CfgInstData::Call { .. }
+                    ))
+            );
+            let main_unit = first
+                .units
+                .iter()
+                .find(|unit| matches!(&unit.function, FunctionInstanceKey::Definition(definition) if definition.name() == "main"))
+                .unwrap();
+            let callee_unit = first
+                .units
+                .iter()
+                .find(|unit| matches!(&unit.function, FunctionInstanceKey::Definition(definition) if definition.name() == "add_one"))
+                .unwrap();
+            assert!(
+                main_unit
+                    .unit
+                    .relocations
+                    .iter()
+                    .all(|relocation| relocation.symbol != callee_unit.unit.defined_symbol),
+                "the {target} caller must not retain a relocation to its inlined callee: {:?}",
+                main_unit.unit.relocations
+            );
+
+            session
+                .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+                .unwrap();
+            let executions = session.codegen_executions();
+            assert!(executions.iter().any(|(function, execution)| {
+                matches!(function, FunctionInstanceKey::Definition(definition) if definition.name() == "main")
+                    && *execution == rue_query::RequestExecution::Computed
+            }), "{target}: {executions:?}");
+            assert!(executions.iter().any(|(function, execution)| {
+                matches!(function, FunctionInstanceKey::Definition(definition) if definition.name() == "add_one")
+                    && matches!(execution, rue_query::RequestExecution::Reused | rue_query::RequestExecution::Joined)
+            }), "{target}: {executions:?}");
+        }
     }
 
     #[test]

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -629,6 +629,7 @@ pub(crate) struct RevisionedQueryDatabase {
     backend_root: Arc<Mutex<PublishedBackendRoot>>,
     backend_root_publication_gate: BackendRootPublicationGate,
     next_backend_root_epoch: std::sync::atomic::AtomicU64,
+    next_optimized_cfg_batch_generation: std::sync::atomic::AtomicU64,
     /// Session-scoped injection shared with structured body-query children.
     /// Keeping it on the database avoids both thread-local scheduler escapes
     /// and cross-test interference between independent compiler sessions.
@@ -1420,6 +1421,10 @@ pub(crate) struct BackendRootCandidate {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct OptimizedCfgBatchKey {
     pub(crate) keys: Arc<[crate::cfg_query::OptimizedCfgQueryKey]>,
+    /// O2/O3 batches are request-local because their values may contain
+    /// rewritten callers. Child CFG terminals remain reusable; this token
+    /// prevents a rewritten whole-program result crossing request boundaries.
+    pub(crate) generation: u64,
 }
 
 impl QueryKey for OptimizedCfgBatchKey {
@@ -1429,6 +1434,7 @@ impl QueryKey for OptimizedCfgBatchKey {
             identity.push('\u{1e}');
             identity.push_str(&key.shared_stable_identity());
         }
+        identity.push_str(&format!(";generation={}", self.generation));
         identity
     }
 
@@ -1437,12 +1443,19 @@ impl QueryKey for OptimizedCfgBatchKey {
         for key in self.keys.iter() {
             key.stable_hash(hasher);
         }
+        self.generation.hash(hasher);
     }
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct OptimizedCfgBatchOutput {
     pub(crate) values: Arc<[crate::cfg_query::CfgValue]>,
+    /// Functions whose batch result was changed by general inlining. Their
+    /// function-local CFG children are intentionally omitted from durable
+    /// backend retention for Phase 2. The active request may still transport
+    /// and pin these records for codegen; the request-local batch generation
+    /// ensures no successor can reuse that whole-program result.
+    pub(crate) non_reusable_functions: Arc<[crate::FunctionInstanceKey]>,
     /// Exact child leases acquired while the rooted batch evaluator still owns
     /// every request lease. The memoized root encapsulates these pins so
     /// retaining it also retains the scheduled children through publication.
@@ -14459,6 +14472,7 @@ impl RevisionedQueryDatabase {
                             .iter()
                             .zip(right.values.iter())
                             .all(|(left, right)| crate::cfg_query::cfg_value_equal(left, right))
+                        && left.non_reusable_functions == right.non_reusable_functions
                 },
                 move |context, _, key: &OptimizedCfgBatchKey| {
                     let fallbacks = backend_retention_fallbacks(
@@ -14479,21 +14493,6 @@ impl RevisionedQueryDatabase {
                         &optimized_cfgs_for_batch,
                         key.keys.iter(),
                     )?;
-                    let kind = if terminals
-                        .iter()
-                        .all(|terminal| terminal.kind() == QueryTerminalKind::Success)
-                    {
-                        QueryTerminalKind::Success
-                    } else {
-                        QueryTerminalKind::Failure
-                    };
-                    let retained_children = Arc::new(
-                        context
-                            .retain_observed_terminal_cones_from(&terminals, &fallbacks)
-                            .expect(
-                                "the registered optimized-CFG batch observes every selected child cone",
-                            ),
-                    );
                     let values = terminals
                         .iter()
                         .map(|terminal| {
@@ -14502,10 +14501,29 @@ impl RevisionedQueryDatabase {
                             };
                             value.clone()
                         })
-                        .collect::<Vec<_>>()
-                        .into();
+                        .collect::<Vec<_>>();
+                    let (values, non_reusable_functions) =
+                        crate::cfg_query::apply_general_inlining(context, key.keys.as_ref(), &values)?;
+                    let kind = if values.iter().all(|value| matches!(value, crate::cfg_query::CfgValue::Available(_))) {
+                        QueryTerminalKind::Success
+                    } else {
+                        QueryTerminalKind::Failure
+                    };
+                    let retained_terminals = terminals
+                        .iter()
+                        .zip(values.iter())
+                        .filter(|(_, value)| matches!(value, crate::cfg_query::CfgValue::Available(record) if record.durable_reuse_allowed))
+                        .map(|(terminal, _)| terminal.clone())
+                        .collect::<Vec<_>>();
+                    let retained_children = Arc::new(
+                        context
+                            .retain_observed_terminal_cones_from(&retained_terminals, &fallbacks)
+                            .expect("general inlining batch observes every retained child cone"),
+                    );
+                    let values = values.into();
                     Ok(QueryOutput::success(OptimizedCfgBatchOutput {
                         values,
+                        non_reusable_functions: non_reusable_functions.into_iter().collect::<Vec<_>>().into(),
                         _retained_children: retained_children,
                     })
                     .with_terminal_kind(kind))
@@ -14513,6 +14531,7 @@ impl RevisionedQueryDatabase {
             )
             .expect("the OptimizedCfgBatch family has one canonical name");
         let optimized_cfgs_for_codegen = optimized_cfgs.clone();
+        let optimized_cfg_batches_for_codegen = optimized_cfg_batches.clone();
         #[cfg(test)]
         let codegen_evaluator_gate = Arc::new(Mutex::new(None::<Arc<TestCodegenEvaluatorGate>>));
         #[cfg(test)]
@@ -14548,6 +14567,7 @@ impl RevisionedQueryDatabase {
                     crate::codegen_query::evaluate_codegen_unit(
                         context,
                         &optimized_cfgs_for_codegen,
+                        &optimized_cfg_batches_for_codegen,
                         key,
                     )
                 },
@@ -16195,6 +16215,7 @@ impl RevisionedQueryDatabase {
             backend_root,
             backend_root_publication_gate: BackendRootPublicationGate::default(),
             next_backend_root_epoch: std::sync::atomic::AtomicU64::new(1),
+            next_optimized_cfg_batch_generation: std::sync::atomic::AtomicU64::new(1),
             #[cfg(test)]
             inject_body_transaction_failure,
             #[cfg(test)]
@@ -16613,7 +16634,16 @@ impl RevisionedQueryDatabase {
         OptimizedCfgBatchKey,
         QueryRequestAttempt<OptimizedCfgBatchOutput>,
     ) {
-        let key = OptimizedCfgBatchKey { keys };
+        let generation = if keys
+            .iter()
+            .any(|key| matches!(key.opt_level, rue_cfg::OptLevel::O2 | rue_cfg::OptLevel::O3))
+        {
+            self.next_optimized_cfg_batch_generation
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        } else {
+            0
+        };
+        let key = OptimizedCfgBatchKey { keys, generation };
         let attempt = self.runtime.request_registered(
             &self.optimized_cfg_batches,
             revision,
@@ -16735,7 +16765,18 @@ impl RevisionedQueryDatabase {
             .pin_terminal(terminal)
             .expect("optimized-CFG batch result belongs to the registered family");
         candidate.lease.lease(pin);
-        for optimized in key.keys.iter() {
+        let non_reusable = match terminal.outcome() {
+            rue_query::QueryOutcome::Success(output) => output
+                .non_reusable_functions
+                .iter()
+                .collect::<std::collections::BTreeSet<_>>(),
+            rue_query::QueryOutcome::Failure(_) => std::collections::BTreeSet::new(),
+        };
+        for optimized in key
+            .keys
+            .iter()
+            .filter(|optimized| !non_reusable.contains(&optimized.cfg.function))
+        {
             for cfg_key in
                 std::iter::once(&optimized.cfg).chain(optimized.accessor_dependencies.iter())
             {

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -861,6 +861,7 @@ impl std::fmt::Debug for RootedCfgUnit {
 pub struct RootedCfgOutput {
     graph: RootedBodyGraph,
     pub(crate) cfgs: Vec<RootedCfgUnit>,
+    pub(crate) optimized_cfg_batch: crate::revisioned_query_database::OptimizedCfgBatchKey,
     pub(crate) warnings: Vec<CompileWarning>,
     pub(crate) work: crate::CanonicalSemanticWork,
     backend_work: BackendQueryWork,
@@ -5523,6 +5524,7 @@ impl CompilerSession {
         Ok(RootedCfgOutput {
             graph,
             cfgs,
+            optimized_cfg_batch: cfg_batch_key,
             warnings,
             work,
             backend_work,
@@ -5594,6 +5596,7 @@ impl CompilerSession {
         let RootedCfgOutput {
             graph,
             cfgs,
+            optimized_cfg_batch,
             warnings,
             work,
             backend_work: cfg_work,
@@ -5603,11 +5606,13 @@ impl CompilerSession {
         let codegen_keys = cfgs
             .iter()
             .map(|cfg| {
-                crate::codegen_query::CodegenUnitQueryKey::new(
+                crate::codegen_query::CodegenUnitQueryKey::new_with_batch(
                     cfg.optimized_cfg_key.clone(),
                     options.target,
                     request,
                     options.opt_level,
+                    (!cfg.record.durable_reuse_allowed)
+                        .then(|| std::sync::Arc::new(optimized_cfg_batch.clone())),
                 )
             })
             .collect::<Vec<_>>()


### PR DESCRIPTION
Summary:
- add conservative leaf free-function inlining to optimized CFG batches at O2 and O3
- discover call multiplicity and recursion from CFG Call instructions, retain callees, and keep changed callers out of durable reuse
- feed exact inlined batches to both backends and add structural plus O0/O2/O3 differential coverage, including observable drop order

Validation:
- scripts/rue fmt
- scripts/rue quick
- scripts/rue cli differential_opt
- scripts/rue premerge
- scripts/rue test

Closes RUE-930