### PR TITLE
RUE-1595: diagnose unsupported frame array slices

### DIFF
--- a/crates/rue-air/src/call_abi.rs
+++ b/crates/rue-air/src/call_abi.rs
@@ -391,7 +391,7 @@ impl<'a> NativeCallAbi<'a> {
 /// call-ABI transitional rule above and code generation's narrow-access refusal
 /// (RUE-974) consult, so they cannot disagree about which types the compact
 /// layout leaves unchanged.
-pub fn is_slot_identical_layout(type_pool: &FrozenTypeInternPool, ty: Type) -> bool {
+pub fn is_slot_identical_layout<P: crate::FfiTypePool + ?Sized>(type_pool: &P, ty: Type) -> bool {
     match ty.kind() {
         // Eight-byte leaves and the recovery scalar: identical in both models.
         TypeKind::I64
@@ -410,12 +410,11 @@ pub fn is_slot_identical_layout(type_pool: &FrozenTypeInternPool, ty: Type) -> b
         | TypeKind::I32
         | TypeKind::U32 => false,
         TypeKind::Struct(id) => type_pool
-            .struct_def(id)
-            .fields
-            .iter()
-            .all(|field| is_slot_identical_layout(type_pool, field.ty)),
+            .ffi_struct_field_types(id)
+            .into_iter()
+            .all(|field_ty| is_slot_identical_layout(type_pool, field_ty)),
         TypeKind::Array(id) => {
-            let (element, _length) = type_pool.array_def(id);
+            let element = type_pool.ffi_array_element(id);
             is_slot_identical_layout(type_pool, element)
         }
         // Enums narrow their tag (u8/u16/u32 vs an eight-byte slot).

--- a/crates/rue-air/src/ffi_predicates.rs
+++ b/crates/rue-air/src/ffi_predicates.rs
@@ -153,6 +153,14 @@ pub trait FfiTypePool {
     fn ffi_struct_has_destructor(&self, id: StructId) -> bool;
     /// The struct's fields as `(name, type)` in declaration order.
     fn ffi_struct_fields(&self, id: StructId) -> Vec<(String, Type)>;
+    /// The struct's field types in declaration order, without cloning names.
+    /// Shared representation predicates use this narrower projection.
+    fn ffi_struct_field_types(&self, id: StructId) -> Vec<Type> {
+        self.ffi_struct_fields(id)
+            .into_iter()
+            .map(|(_, ty)| ty)
+            .collect()
+    }
     /// The element type of a fixed-size array.
     fn ffi_array_element(&self, id: ArrayTypeId) -> Type;
 }

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -4140,6 +4140,9 @@ impl crate::ffi_predicates::FfiTypePool for TypeInternPool {
             .map(|f| (f.name.clone(), f.ty))
             .collect()
     }
+    fn ffi_struct_field_types(&self, id: StructId) -> Vec<Type> {
+        self.struct_def(id).fields.iter().map(|f| f.ty).collect()
+    }
     fn ffi_array_element(&self, id: ArrayTypeId) -> Type {
         self.array_def(id).0
     }
@@ -4161,6 +4164,9 @@ impl crate::ffi_predicates::FfiTypePool for FrozenTypeInternPool {
             .iter()
             .map(|f| (f.name.clone(), f.ty))
             .collect()
+    }
+    fn ffi_struct_field_types(&self, id: StructId) -> Vec<Type> {
+        self.struct_def(id).fields.iter().map(|f| f.ty).collect()
     }
     fn ffi_array_element(&self, id: ArrayTypeId) -> Type {
         self.array_def(id).0

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -5533,6 +5533,23 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return Err(self.type_mismatch_error(slice_ty, arr_ty, span));
         }
 
+        // A non-slot-width element's compact memory image is not byte-identical
+        // to the full-slot representation used by frame arrays. For narrow
+        // scalars this makes the slice's compact element stride differ from the
+        // frame stride; aggregate elements can also differ in tags, fields, or
+        // padding. Keep the deliberate refusal, but report it at the source-level
+        // coercion boundary rather than letting the synthesized pointer reach the
+        // backend's raw-pointer safety gate (RUE-1595). Empty arrays remain valid:
+        // their null pointer is never dereferenced.
+        if arr_len != 0 && !crate::is_slot_identical_layout(self.body_type_pool(), arr_elem) {
+            return Err(CompileError::new(
+                ErrorKind::SliceFrameArrayNotSupported {
+                    element_type: self.format_type_name(arr_elem),
+                },
+                span,
+            ));
+        }
+
         let zero_ref = air.add_inst(AirInst {
             data: AirInstData::Const(0),
             ty: Type::U64,

--- a/crates/rue-cli-tests/cases/aggregate_layout.toml
+++ b/crates/rue-cli-tests/cases/aggregate_layout.toml
@@ -1239,7 +1239,7 @@ fn main() -> i32 {
 }
 """ }]
 compile_fail = true
-error_contains = ["raw pointer", "frame-resident aggregate"]
+error_contains = ["E9001", "raw pointer", "frame-resident aggregate"]
 
 # --- RUE-1037: heterogeneous enum images via per-variant tag dispatch ---------
 # An enum whose variants' payload layouts DISAGREE (e.g. Ok(struct{i32,i32,i32})

--- a/crates/rue-cli-tests/cases/diagnostic_json.toml
+++ b/crates/rue-cli-tests/cases/diagnostic_json.toml
@@ -68,6 +68,26 @@ compile_stderr_not_contains = [
 ]
 
 [[case]]
+name = "narrow_frame_array_slice_error_has_source_span"
+description = "RUE-1595: whole-array borrowing into a slice reports the stable source-level E0908 diagnostic with the coercion argument's primary span, rather than the backend's spanless E9001."
+files = [{ path = "main.rue", source = """
+fn take(borrow s: [i32]) -> i32 { 0 }
+fn main() -> i32 {
+    let a: [i32; 3] = [1, 2, 3];
+    take(borrow a)
+}
+""" }]
+args = ["--error-format", "json", "main.rue", "-o", "prog"]
+compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = ["error E0908 main.rue:4:17"]
+error_contains = [
+  '"code":"E0908"',
+  '"message":"a frame array with non-slot-width elements cannot yet coerce or borrow as a slice `[T]` (element type `i32`)"',
+  '"primary":true',
+]
+
+[[case]]
 name = "error_batch_order_follows_source_order"
 description = """
 RUE-436: four errors in one file must be published in a single JSON array in

--- a/crates/rue-cli-tests/cases/slices_mvp.toml
+++ b/crates/rue-cli-tests/cases/slices_mvp.toml
@@ -114,12 +114,12 @@ fn main() -> i32 {
 args = ["main.rue", "-o", "prog"]
 exit_code = 6
 
-# A `[u8]` view over a frame array is refused under the compact layout: the
-# slice would stride `@ptr_offset` by the compact element size (1) while the
-# frame stores each `u8` element in an 8-byte slot, so the pointer walk crosses
-# mismatched storage. The refusal is loud (RUE-987 / RUE-1035 M2) and names the
-# frame aggregate. A slot-identical element (see the i64 cases above) is exact;
-# a heap-backed narrow slice awaits compact frames (RUE-975) / a heap slice API.
+# A narrow-element view over a frame array is refused at the source-level
+# coercion boundary: the compact element stride differs from the frame slot
+# stride. The stable diagnostic names the actual restriction and does not leak
+# the backend's raw-pointer implementation. A slot-identical element (see the
+# i64 cases above) is exact; a heap-backed narrow slice awaits compact frames
+# (RUE-975) / a heap slice API.
 [[case]]
 name = "slice_param_narrow_frame_refused"
 files = [{ path = "main.rue", source = """
@@ -139,7 +139,32 @@ fn main() -> i32 {
 """ }]
 args = ["main.rue", "-o", "prog"]
 compile_fail = true
-error_contains = ["raw pointer", "frame-resident aggregate"]
+error_contains = ["E0908", "frame array", "non-slot-width", "coerce or borrow", "u8"]
+compile_stderr_not_contains = ["E9001", "@raw", "@ptr_offset", "@alloc", "heap"]
+
+# The same source-level restriction applies to a four-byte element. Keep this
+# separate from the u8 case so both compact widths remain covered.
+[[case]]
+name = "slice_param_i32_narrow_frame_refused"
+files = [{ path = "main.rue", source = """
+fn sum(borrow s: [i32]) -> i32 {
+    let mut t: i32 = 0;
+    let mut i: u64 = 0;
+    while i < s.len() {
+        t = t + s[i];
+        i = i + 1;
+    }
+    t
+}
+fn main() -> i32 {
+    let a: [i32; 3] = [1, 2, 3];
+    sum(borrow a)
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0908", "frame array", "non-slot-width", "coerce or borrow", "i32"]
+compile_stderr_not_contains = ["E9001", "@raw", "@ptr_offset", "@alloc", "heap"]
 
 # Borrowing a zero-length fixed array still produces a valid zero-length slice:
 # the pointer word is never dereferenced because `len()` is 0. This used to ICE

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -1400,6 +1400,9 @@ impl RetainedCharge for rue_error::ErrorKind {
             | E::ArrayRepeatNonCopy {
                 element_type: value,
             }
+            | E::SliceFrameArrayNotSupported {
+                element_type: value,
+            }
             | E::TypeTooLarge {
                 type_name: value, ..
             }

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -432,6 +432,10 @@ impl ErrorCode {
     pub const ARRAY_REPEAT_NON_COPY: Self = Self(905);
     pub const TYPE_TOO_LARGE: Self = Self(906);
     pub const FUNCTION_FRAME_TOO_LARGE: Self = Self(907);
+    /// A frame array with non-slot-width elements cannot yet be borrowed as a
+    /// slice because slice pointer semantics use the compact element image
+    /// while frames keep a full-slot representation (RUE-1595).
+    pub const SLICE_FRAME_ARRAY_NOT_SUPPORTED: Self = Self(908);
 
     // ------------------------------------------------------------------
     // Bit-reinterpretation errors (E0950-E0959)
@@ -1805,6 +1809,14 @@ pub enum ErrorKind {
          ({max_bytes} bytes)"
     )]
     FunctionFrameTooLarge { max_bytes: u64 },
+    /// A frame-resident array whose element's compact memory image differs from
+    /// its full-slot frame representation cannot yet be coerced to a borrowed
+    /// slice. The source-level coercion is rejected before it synthesizes a
+    /// pointer that would mix those representations (RUE-1595).
+    #[error(
+        "a frame array with non-slot-width elements cannot yet coerce or borrow as a slice `[T]` (element type `{element_type}`)"
+    )]
+    SliceFrameArrayNotSupported { element_type: String },
     /// Assignment into an array (element write, or a write through an element)
     /// while one or more of its elements are moved out (RUE-186). Reinstating
     /// per-element ownership through writes is not supported; the whole array
@@ -2209,6 +2221,9 @@ impl ErrorKind {
             ErrorKind::ArrayRepeatNonCopy { .. } => ErrorCode::ARRAY_REPEAT_NON_COPY,
             ErrorKind::TypeTooLarge { .. } => ErrorCode::TYPE_TOO_LARGE,
             ErrorKind::FunctionFrameTooLarge { .. } => ErrorCode::FUNCTION_FRAME_TOO_LARGE,
+            ErrorKind::SliceFrameArrayNotSupported { .. } => {
+                ErrorCode::SLICE_FRAME_ARRAY_NOT_SUPPORTED
+            }
             ErrorKind::AssignToPartiallyMovedArray { .. } => {
                 ErrorCode::ASSIGN_TO_PARTIALLY_MOVED_ARRAY
             }

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -638,14 +638,16 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
                 @ptr_to_int(p) + s.len()
             }
         }
+        fn route(borrow s: [i32]) -> u64 {
+            slice_len(borrow s) + user_pointer(borrow s)
+        }
         fn offset_probe() -> u64 {
             let a = [1, 2];
             checked { @ptr_to_int(@ptr_offset(@raw(a[0]), 1)) }
         }
         fn main() -> i32 {
             let empty: [i32; 0] = [];
-            let values = [1, 2];
-            @intCast(slice_len(borrow empty) + user_pointer(borrow values) + offset_probe())
+            @intCast(route(borrow empty) + offset_probe())
         }"#;
     let state = query_cfg_state(source).expect("pointer provenance probe must compile");
     let interp = Interp {

--- a/crates/rue-ui-tests/cases/diagnostics/slice_second_class.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/slice_second_class.toml
@@ -15,6 +15,33 @@ diagnostics.
 
 
 [[case]]
+name = "slice_narrow_frame_array_coercion_e0908"
+description = "Borrowing a non-slot-width frame array as a slice is rejected at the source-level coercion boundary with E0908."
+source = """
+fn take(borrow s: [i32]) -> i32 { 0 }
+fn main() -> i32 {
+    let a: [i32; 3] = [1, 2, 3];
+    take(borrow a)
+}
+"""
+compile_fail = true
+error_contains = ["E0908", "frame array", "non-slot-width", "coerce or borrow", "i32"]
+
+[[case]]
+name = "slice_non_slot_identical_enum_frame_array_e0908"
+description = "An equal-stride aggregate element with a non-slot-width tag is rejected at the same source-level coercion boundary rather than leaking backend E9001."
+source = """
+enum E { A(i64), B }
+fn take(borrow s: [E]) -> i32 { 0 }
+fn main() -> i32 {
+    let a: [E; 2] = [E.A(1), E.B];
+    take(borrow a)
+}
+"""
+compile_fail = true
+error_contains = ["E0908", "frame array", "non-slot-width", "coerce or borrow", "E"]
+
+[[case]]
 name = "slice_return_is_second_class_e0487"
 description = "A slice in return position is second-class: E0487 (cannot be returned)."
 source = """


### PR DESCRIPTION
## Summary

- report E0908 at array-to-slice coercion for non-slot-identical frame elements
- preserve slot-identical and zero-length slice behavior and direct raw-pointer backend checks
- cover text and JSON diagnostics

## Testing

- scripts/rue premerge
- focused CLI, UI, JSON, and oracle regressions

Fixes RUE-1595