### PR TITLE
Close two linear-ownership soundness holes: carrier partial moves and discarded match payloads

### DIFF
--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -2468,15 +2468,44 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         Ok(())
     }
 
-    /// Reject a field access that consumes (destructures) a linear struct
-    /// when the destructure would implicitly drop a *different* field that
-    /// itself carries a linear value (E0474, spec 3.8:58, RUE-40).
+    /// Whether `struct_id` names a struct **declared** `linear`, as opposed to
+    /// one that is linear only because a field carries a linear value
+    /// (infectious linearity, spec 3.8:58).
+    ///
+    /// The pool's `StructDef::is_linear` is the transitive join, so it cannot
+    /// tell the two apart on its own; [`Self::infectious_linear_reason`] names
+    /// the culprit field exactly when the join — and not the declaration — is
+    /// what made the struct linear, so `is_linear` without such a reason is
+    /// the declared case.
+    ///
+    /// The distinction is load-bearing (RUE-1591): whole-value destructuring
+    /// consumption (3.8:33, 3.8:74 — the obligation belongs to the VALUE
+    /// regardless of what its fields hold) applies to a declared-`linear`
+    /// struct only. An infectious carrier follows the ordinary partial-move
+    /// model of 3.8:22/3.8:28.
+    pub(crate) fn struct_declared_linear(&self, struct_id: StructId) -> bool {
+        self.body_type_pool().struct_def(struct_id).is_linear
+            && self.infectious_linear_reason(struct_id).is_none()
+    }
+
+    /// Reject a field access that consumes (destructures) a **declared**
+    /// `linear` struct when the destructure would implicitly drop a
+    /// *different* field that itself carries a linear value (E0474, spec
+    /// 3.8:60, RUE-40).
     ///
     /// Destructuring consumption (spec 3.8:33) extracts the accessed leaf
     /// field and drops everything else in the value. That implicit drop must
     /// not lose a linear value. Every struct level along the projection
     /// chain is checked: at each level, all fields other than the projected
     /// one are dropped.
+    ///
+    /// Only levels whose struct is declared `linear` destructure this way
+    /// (RUE-1591). A field access on an *infectious* carrier is an ordinary
+    /// partial move: the siblings stay Owned and their residue is dropped by
+    /// the scope-exit walk, so a linear sibling is caught by the residual
+    /// must-consume check ([`Self::residual_linear_place`], core §5.6)
+    /// instead of here — that is what lets `sink(c.inner)` keep a Copy
+    /// sibling readable while `c.tag` alone still fails.
     fn reject_linear_destructure_dropping_linear_field(
         &self,
         trace: &PlaceTrace,
@@ -2488,6 +2517,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 struct_id,
                 field_index,
             } = proj.proj
+                && self.struct_declared_linear(struct_id)
             {
                 let def = self.body_type_pool().struct_def(struct_id);
                 for (i, field) in def.fields.iter().enumerate() {
@@ -2686,14 +2716,26 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 trace.base_type
             };
 
-            let is_linear = parent_type
+            // Whole-value destructuring consumption (3.8:33) is the model for
+            // a struct DECLARED `linear` only: its obligation belongs to the
+            // value itself, whatever its fields hold (3.8:74). A struct that
+            // is linear merely because a field carries a linear value
+            // (infectious linearity, 3.8:58) follows the ORDINARY partial-move
+            // model instead (3.8:22/3.8:28, core §5.6): the accessed field
+            // moves, its siblings stay Owned and readable, and the non-moved
+            // residue is dropped by the scope-exit walk (3.8:60, 3.9:2). The
+            // linear obligation then lives on the linear sub-place and is
+            // discharged by consuming it — see `residual_linear_place`.
+            // Modelling the carrier as a whole-value consumption instead both
+            // leaked the siblings' drop glue and over-rejected Copy sibling
+            // reads (RUE-1591).
+            let is_declared_linear = parent_type
                 .as_struct()
-                .map(|id| self.body_type_pool().struct_def(id).is_linear)
-                .unwrap_or(false);
+                .is_some_and(|id| self.struct_declared_linear(id));
 
             // Move checking using the trace. `move_is_partial` selects the
             // MarkMoved marker's place component: absent for a whole-struct
-            // (linear) move, the accessed place for a field-path move
+            // (declared-linear) move, the accessed place for a field-path move
             // (RUE-62, RUE-157).
             //
             // A use as a by-ref call argument (`f(borrow o.f)`, `f(inout
@@ -2709,7 +2751,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // shared read (spec 4.8:26), so the binder may be read but not
             // moved out, whole-value or field-granular (RUE-259).
             if !is_byref_arg_use
-                && (is_linear || !self.is_type_copy(field_type))
+                && (is_declared_linear || !self.is_type_copy(field_type))
                 && matches!(trace.base, AirPlaceBase::Local(s) if air.is_borrow_slot(s))
             {
                 return Err(CompileError::new(
@@ -2735,8 +2777,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         ));
                     }
                 }
-            } else if is_linear {
-                // For linear types, field access consumes the entire struct
+            } else if is_declared_linear {
+                // For a declared-linear struct, field access destructures and
+                // so consumes the entire struct (3.8:33).
                 self.reject_accessor_place_move(&trace, field_type, span)?;
                 self.reject_linear_destructure_dropping_linear_field(&trace, span)?;
                 self.reject_move_out_of_byref_param(trace.root_var, ctx, span)?;
@@ -4307,12 +4350,143 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ElementwiseConsumption::NotElementwise => {}
             }
 
+            // Per-place residue (core §5.6, spec 3.8:60, RUE-1591): consuming
+            // exactly the linear sub-places of an infectious carrier
+            // discharges its obligation, and the non-linear residue is left
+            // for the ordinary scope-exit drop walk.
+            let Some(residue) = self.residual_linear_place(local.ty, state, &mut Vec::new()) else {
+                continue;
+            };
+
             let name = self.body_interner().resolve(&*symbol);
-            let err = linear_not_consumed_error(name, local.span, state.and_then(|s| s.full_move));
+            let err = linear_not_consumed_error(
+                name,
+                local.span,
+                Self::residue_consumed_on_some_path(state, &residue),
+            );
+            let err = self.note_residual_linear_place(err, *symbol, &residue);
             return Err(self.attach_infectious_linear_note(err, local.ty));
         }
 
         Ok(())
+    }
+
+    /// Core §5.6 `residual-linear(Σ, p, T)`: the path (relative to the root
+    /// variable) of a sub-place of `p: T` that still holds an unconsumed
+    /// linear value under the move state `state`, or `None` when the
+    /// must-consume obligation is fully discharged.
+    ///
+    /// The leak check is keyed on the RESIDUAL ownership state, not on the
+    /// binding's type alone (RUE-1591): after a partial move the obligation
+    /// attaches to whatever linear content is still present, so consuming
+    /// exactly the linear part of an infectious carrier
+    /// (`let c = C { l: token, d: junk }; sink(c.l);`) is legal and the
+    /// non-linear residue (`c.d`, destructor and all) is dropped by the
+    /// ordinary scope-exit walk.
+    ///
+    /// Following the core's clauses:
+    /// - a place moved out on every path holds nothing — `None`;
+    /// - a **declared**-`linear` struct's obligation belongs to the value
+    ///   itself, not its contents (3.8:74), so a live one is always residue.
+    ///   A husk whose linear field was moved out is reached only through the
+    ///   moved-out clause above, which keeps the current husk acceptance
+    ///   (RUE-614, an open maintainer decision) unchanged;
+    /// - a struct otherwise recurses into the fields that carry a linear
+    ///   value;
+    /// - everything else (arrays, enums, scalars) falls back to the type's own
+    ///   obligation, because their sub-places are not tracked per place here.
+    ///   Whole-array element-wise consumption is checked separately by
+    ///   [`Self::check_array_elementwise_consumption`] before this runs.
+    ///
+    /// `path` is scratch space threaded through the recursion; it is restored
+    /// to its entry value before returning.
+    pub(crate) fn residual_linear_place(
+        &self,
+        ty: Type,
+        state: Option<&VariableMoveState>,
+        path: &mut Vec<Spur>,
+    ) -> Option<Vec<Spur>> {
+        if state.is_some_and(|s| Self::place_moved_on_all_paths(s, path)) {
+            return None;
+        }
+        let Some(struct_id) = ty.as_struct() else {
+            return self.type_requires_consumption(ty).then(|| path.clone());
+        };
+        if self.struct_declared_linear(struct_id) {
+            return Some(path.clone());
+        }
+        let def = self.body_type_pool().struct_def(struct_id);
+        for field in def.fields.iter() {
+            if !self.type_carries_linear(field.ty) {
+                continue;
+            }
+            path.push(self.body_interner().get_or_intern(&field.name));
+            let found = self.residual_linear_place(field.ty, state, path);
+            path.pop();
+            if found.is_some() {
+                return found;
+            }
+        }
+        None
+    }
+
+    /// The span at which the residual linear place was consumed on SOME path,
+    /// when it was — that selects the more precise "not consumed on all paths"
+    /// diagnostic (E0443) over the bare "was dropped" one (E0406).
+    ///
+    /// A whole-value move takes precedence: it is the coarser, more likely
+    /// intent. Otherwise the residue's own may-move span is what the author
+    /// needs to see — the branch where they DID consume it (RUE-1591).
+    pub(crate) fn residue_consumed_on_some_path(
+        state: Option<&VariableMoveState>,
+        residue: &[Spur],
+    ) -> Option<Span> {
+        let state = state?;
+        state.full_move.or_else(|| {
+            state
+                .partial_moves
+                .iter()
+                .find(|(p, _)| p == residue)
+                .map(|(_, span)| *span)
+        })
+    }
+
+    /// Whether `path` (or an ancestor prefix of it) was moved out on EVERY
+    /// non-diverging path reaching this point.
+    ///
+    /// Must-move, not may-move: a sub-place consumed in only one branch of an
+    /// `if` is still dropped on the other paths, so it does not discharge a
+    /// linear obligation. A whole-variable move subsumes every path under it
+    /// (`mark_path_moved(&[])` clears the partial sets for exactly that
+    /// reason).
+    fn place_moved_on_all_paths(state: &VariableMoveState, path: &[Spur]) -> bool {
+        if state.full_move_on_all_paths {
+            return true;
+        }
+        (1..=path.len()).any(|len| {
+            state
+                .partial_moves_on_all_paths
+                .contains(&path[..len].to_vec())
+        })
+    }
+
+    /// Name the sub-place that still carries the unconsumed linear value, so a
+    /// partially consumed carrier does not report a bare "consume the whole
+    /// value" diagnostic (RUE-1591). A residue at the root itself adds
+    /// nothing the message does not already say.
+    pub(crate) fn note_residual_linear_place(
+        &self,
+        err: rue_error::CompileError,
+        root_var: Spur,
+        residue: &[Spur],
+    ) -> rue_error::CompileError {
+        if residue.is_empty() {
+            return err;
+        }
+        let place = super::format_move_path(self.body_interner(), root_var, residue);
+        err.with_note(format!(
+            "'{place}' still holds a linear value; consume it (or the whole value)"
+        ))
     }
 
     /// Does dropping a value of this type discard a linear value, i.e. does

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -1197,21 +1197,23 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let mut binding_stmts =
                 self.materialize_match_bindings(air, pattern, scrutinee_result.air_ref, ctx)?;
 
-            // RUE-238: a non-binding arm (a wildcard `_`, a variant matched
-            // without binding its payload, or a variant whose payload
-            // positions are all `_`) still *consumes* the scrutinee — the
-            // match marked it moved (see the `mark_moved` in the emitted AIR) —
-            // but extracts nothing, so its active-variant payload would leak.
-            // Emit a drop of the whole scrutinee value; for an enum this lowers
-            // to the variant-dispatched drop glue (`__rue_drop_E`), which drops
-            // exactly the active variant's payload (a no-op when that variant
-            // carries nothing droppable). Arms that bind ANY payload position
-            // by name must not also drop the scrutinee, or the moved-out
-            // fields would be dropped twice; `binding_stmts.is_empty()` is
-            // precisely that guard. Those arms account for every field
-            // themselves: named positions move into binding locals (dropped
-            // at scope exit), and `_` positions are extracted and dropped in
-            // the binding statements (RUE-1270 — previously they leaked).
+            // RUE-238: an arm that extracts NO payload — a wildcard `_` arm,
+            // or an arm matching a discriminant-only variant — still
+            // *consumes* the scrutinee (the match marked it moved; see the
+            // `mark_moved` in the emitted AIR), so its active-variant payload
+            // would leak. Emit a drop of the whole scrutinee value; for an
+            // enum this lowers to the variant-dispatched drop glue
+            // (`__rue_drop_E`), which drops exactly the active variant's
+            // payload (a no-op when that variant carries nothing droppable).
+            //
+            // An arm on a payload-carrying variant must NOT also drop the
+            // scrutinee, or its moved-out fields would be dropped twice.
+            // `binding_stmts.is_empty()` is precisely that guard: since
+            // RUE-1592 `materialize_match_bindings` moves out EVERY payload
+            // position of such a variant — named, `_`-discarded, or covered by
+            // the bare-path form `E.A` — so those arms are never empty and
+            // account for the whole payload themselves, each field dropped at
+            // the arm's end in reverse declaration order.
             if binding_stmts.is_empty() && scrutinee_type.is_enum() {
                 let drop_ref = air.add_inst(AirInst {
                     data: AirInstData::Drop {
@@ -1733,9 +1735,24 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// the AIR statement refs (StorageLive + Alloc per binding) that must run
     /// before the arm body (RUE-221, ADR-0038).
     ///
-    /// Returns an empty vector for patterns without payload bindings. Assumes
-    /// the pattern has already been validated against the scrutinee type by
-    /// the caller (`analyze_match`); re-resolves the enum for convenience.
+    /// EVERY payload position of a payload-carrying variant is materialized,
+    /// including the ones that bind no source name (RUE-1592, ratified
+    /// 2026-08-22). A `_` position — and every position of the all-wildcard
+    /// *bare* variant pattern `E.A` (spec 4.7:30's bare-path carve-out) —
+    /// becomes a fresh **unnameable** binding, exactly as the formal core's §2
+    /// elaboration note states: it is registered in no scope, so nothing can
+    /// name or consume it, but it owns a real frame slot and is therefore
+    /// dropped by the ordinary §5.6 scope-exit machinery at the ARM'S END,
+    /// interleaved with its named siblings in reverse declaration order.
+    /// A linear such field can never discharge its must-consume obligation,
+    /// so it is rejected here (E0486).
+    ///
+    /// Returns an empty vector only for a pattern that is not a path pattern,
+    /// or for a discriminant-only variant (no payload to materialize) — the
+    /// two cases where the caller's whole-scrutinee drop still applies.
+    /// Assumes the pattern has already been validated against the scrutinee
+    /// type by the caller (`analyze_match`); re-resolves the enum for
+    /// convenience.
     fn materialize_match_bindings(
         &mut self,
         air: &mut Air,
@@ -1754,9 +1771,6 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         else {
             return Ok(Vec::new());
         };
-        if bindings.is_empty() {
-            return Ok(Vec::new());
-        }
         let pattern_span = *span;
 
         let enum_id = self
@@ -1775,10 +1789,17 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             },
             pattern_span,
         )? as u32;
+        let enum_name = def.name.to_string();
         let payload = def.variant_payload(variant_index as usize).to_vec();
 
-        // The number of bindings must equal the variant's payload arity.
-        if bindings.len() != payload.len() {
+        // The bare-path carve-out (spec 4.7:30, RUE-1592): a payload-carrying
+        // variant written with no binding list at all (`E.A`) IS the
+        // all-wildcard form `E.A(_, …, _)`, so it is exempt from the arity
+        // rule rather than being an arity error. Every other pattern must
+        // supply exactly as many binding positions as the variant's arity —
+        // `E.A(x, y)` on an arity-1 variant stays E0207.
+        let bare_path = bindings.is_empty();
+        if !bare_path && bindings.len() != payload.len() {
             return Err(CompileError::new(
                 ErrorKind::WrongArgumentCount {
                     expected: payload.len(),
@@ -1786,6 +1807,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 },
                 pattern_span,
             ));
+        }
+
+        // A discriminant-only variant has nothing to materialize. The caller's
+        // whole-scrutinee drop (the RUE-238 guard) covers such an arm, exactly
+        // as it covers a bare `_` arm.
+        if payload.is_empty() {
+            return Ok(Vec::new());
         }
 
         // Every payload binding must be a fresh name (spec 4.7:30). Reusing an
@@ -1807,53 +1835,55 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             }
         }
 
-        // Whether any payload position is moved out by name. When one is, the
-        // arm's binding statements suppress the whole-scrutinee drop (see the
-        // RUE-238 guard at the call site), so every `_`-discarded sibling must
-        // be dropped HERE — extract-and-drop per field — or its payload leaks
-        // (RUE-1270: for a linear sibling this silently bypassed must-consume).
-        // When every position is `_`, no statement is emitted and the
-        // whole-scrutinee drop covers the entire payload via the enum's
-        // variant-dispatched glue, exactly as before.
-        let any_named = bindings
-            .iter()
-            .any(|name| self.body_interner().resolve(name) != "_");
+        // Every payload position — named, `_`-discarded, or covered by the
+        // bare-path form — is moved out of the scrutinee into its own frame
+        // slot, so the arm's binding statements always suppress the
+        // whole-scrutinee drop (the RUE-238 guard at the call site) and the
+        // payload is accounted for field by field. An enum's drop glue is
+        // exactly "drop the active variant's payload" (6.3:20), so the two
+        // accountings coincide; what differs is *when* and in what order,
+        // which is the RUE-1592 ruling below.
+        let mut stmts: Vec<u32> = Vec::with_capacity(payload.len() * 2);
+        for (i, field_ty) in payload.iter().copied().enumerate() {
+            // The source name at this position, or `None` when the position
+            // binds nothing: an explicit `_` discard (RUE-601), or any
+            // position of the bare-path all-wildcard form `E.A` (RUE-1592).
+            let binding_name = if bare_path {
+                None
+            } else {
+                let name = bindings[i];
+                (self.body_interner().resolve(&name) != "_").then_some(name)
+            };
 
-        let mut stmts: Vec<u32> = Vec::with_capacity(bindings.len() * 2);
-        for (i, binding_name) in bindings.iter().enumerate() {
-            // A `_` payload (RUE-601) discards its field: bind nothing. With
-            // no named sibling, the field is not moved out of the scrutinee
-            // and is dropped together with it — exactly like a
-            // discriminant-only match on a payload-carrying variant. With a
-            // named sibling, the scrutinee's own drop is suppressed, so the
-            // discarded field is read out and dropped in place (4.7:30's
-            // "dropped together with it", 6.3:20's exactly-once), in field
-            // order — matching the glue's order for the all-discarded case.
-            // The enumerate index `i` still tracks the real field position
-            // for the other bindings.
-            if self.body_interner().resolve(binding_name) == "_" {
-                if any_named {
-                    let field_ty = payload[i];
-                    let get_ref = air.add_inst(AirInst {
-                        data: AirInstData::EnumPayloadGet {
-                            base: scrutinee_ref,
-                            enum_id,
-                            variant_index,
-                            field_index: i as u32,
-                        },
-                        ty: field_ty,
-                        span: pattern_span,
-                    });
-                    let drop_ref = air.add_inst(AirInst {
-                        data: AirInstData::Drop { value: get_ref },
-                        ty: Type::UNIT,
-                        span: pattern_span,
-                    });
-                    stmts.push(drop_ref.as_u32());
-                }
-                continue;
+            // A non-binding position is a fresh UNNAMEABLE binding (formal
+            // core §2; RUE-1592, ratified 2026-08-22) — not an eager
+            // extract-and-drop (the pre-RUE-1592 behavior), and not a leak
+            // into the scrutinee's own drop. It owns a slot like any other
+            // binding, so §5.6 drops it at the ARM'S END in reverse
+            // declaration order, interleaved with its named siblings.
+            //
+            // Nothing can name it, so a LINEAR field here could never
+            // discharge its must-consume obligation (3.8:52). Rather than let
+            // the ordinary machinery report an unnameable binding, reject the
+            // position up front with a diagnostic that names the variant and
+            // the position (E0486) and points at the escape hatches.
+            if binding_name.is_none() && self.type_requires_consumption(field_ty) {
+                let position = format!("field {i} of `{enum_name}.{variant_name}`");
+                let err = CompileError::new(
+                    ErrorKind::LinearPayloadDiscarded {
+                        position,
+                        type_name: field_ty.safe_name_with_pool(Some(self.body_type_pool())),
+                    },
+                    pattern_span,
+                )
+                .with_help(if bare_path {
+                    "bind the payload — `Enum.Variant(x, ...)` — and consume each linear field, \
+                     or `@drop` it"
+                } else {
+                    "replace `_` with a name and consume the value, or `@drop` it"
+                });
+                return Err(self.attach_infectious_linear_note(err, field_ty));
             }
-            let field_ty = payload[i];
 
             // Read the payload field out of the scrutinee.
             let get_ref = air.add_inst(AirInst {
@@ -1869,18 +1899,23 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
             // Allocate the binding through the canonical local-storage owner,
             // then register the match arm's source-level name in this scope.
+            // An unnameable binding skips only that registration: it is in no
+            // scope, so no expression can refer to it, while its slot still
+            // participates in scope-exit drop elaboration.
             let (slot, storage_live, alloc) =
                 self.allocate_local_storage(air, get_ref, field_ty, pattern_span, ctx)?;
-            ctx.insert_local(
-                *binding_name,
-                LocalVar {
-                    slot,
-                    ty: field_ty,
-                    is_mut: false,
-                    span: pattern_span,
-                    allow_unused: false,
-                },
-            );
+            if let Some(binding_name) = binding_name {
+                ctx.insert_local(
+                    binding_name,
+                    LocalVar {
+                        slot,
+                        ty: field_ty,
+                        is_mut: false,
+                        span: pattern_span,
+                        allow_unused: false,
+                    },
+                );
+            }
 
             stmts.push(storage_live.as_u32());
             stmts.push(alloc.as_u32());

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -2208,16 +2208,25 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
                         ElementwiseConsumption::Complete => continue,
                         ElementwiseConsumption::NotElementwise => {}
                     }
+                    // Per-place residue (core §5.6, RUE-1591): a by-value
+                    // parameter of an infectious carrier is consumed by
+                    // consuming its linear sub-places; the rest is dropped by
+                    // the ordinary exit walk, exactly as for a local.
+                    let Some(residue) = self.residual_linear_place(p.ty, state, &mut Vec::new())
+                    else {
+                        continue;
+                    };
                     let name = self.body_interner().resolve(&p.name);
                     let err = linear_not_consumed_error(
                         name,
                         self.body_rir_ref().get(body).span,
-                        state.and_then(|s| s.full_move),
+                        Self::residue_consumed_on_some_path(state, &residue),
                     )
                     .with_note(format!(
                         "parameter '{name}' is passed by value, so this function owns it \
                          and must consume it (pass it on, return it, or destructure it)"
                     ));
+                    let err = self.note_residual_linear_place(err, p.name, &residue);
                     return Err(self.attach_infectious_linear_note(err, p.ty));
                 }
             }

--- a/crates/rue-cli-tests/cases/infectious_linear.toml
+++ b/crates/rue-cli-tests/cases/infectious_linear.toml
@@ -4,7 +4,10 @@
 # linear value (a linear struct, an array of them, or a nested container) is
 # itself linear: dropping it implicitly would silently drop the linear field.
 # Destructuring consumption (field access) must not implicitly drop a
-# *different* linear-carrying field (E0474).
+# *different* linear-carrying field (E0474) — but only a struct DECLARED
+# `linear` destructures that way. A carrier that is linear only by infection
+# follows the ordinary partial-move model: the accessed field moves, siblings
+# stay Owned, and the residue drops at scope exit (RUE-1591, spec 3.8:60).
 
 [section]
 id = "cli.infectious_linear"
@@ -60,7 +63,24 @@ error_contains = ["E0406", "linear value 'h' must be consumed"]
 
 [[case]]
 name = "destructure_dropping_linear_field_rejected"
-description = "Accessing a non-linear field destructures the container and would drop the linear field (E0474)."
+description = "Accessing a field of a DECLARED-linear struct destructures it and would drop the linear field (E0474)."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+linear struct Pair { inner: MustUse, tag: i32 }
+fn main() -> i32 {
+    let p = Pair { inner: MustUse { value: 1 }, tag: 2 };
+    p.tag
+}
+""" }]
+compile_fail = true
+error_contains = [
+    "E0474",
+    "would implicitly drop linear field 'inner'",
+]
+
+[[case]]
+name = "carrier_copy_sibling_read_does_not_destructure"
+description = "Reading a Copy sibling of an infectious carrier is not a destructure; the unconsumed linear sub-place is reported at scope exit instead (RUE-1591)."
 files = [{ path = "main.rue", source = """
 linear struct MustUse { value: i32 }
 struct Container { inner: MustUse, tag: i32 }
@@ -71,9 +91,322 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = [
-    "E0474",
-    "would implicitly drop linear field 'inner'",
+    "E0406",
+    "linear value 'c' must be consumed",
+    "'c.inner' still holds a linear value",
 ]
+
+[[case]]
+name = "carrier_copy_sibling_readable_around_linear_move"
+description = "A Copy sibling stays readable both before and after the linear field is consumed (RUE-1591, spec 3.8:22/3.8:28)."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+struct Container { inner: MustUse, tag: i32 }
+fn sink(m: MustUse) -> i32 { m.value }
+fn main() -> i32 {
+    let a = Container { inner: MustUse { value: 10 }, tag: 1 };
+    let before = a.tag;
+    let ra = sink(a.inner) + before;
+    let b = Container { inner: MustUse { value: 20 }, tag: 2 };
+    let rb = sink(b.inner);
+    let after = b.tag;
+    ra + rb + after
+}
+""" }]
+exit_code = 33
+
+[[case]]
+name = "carrier_residue_destructor_runs_at_scope_exit"
+description = "The non-moved residue of an infectious carrier keeps its drop glue: consuming the linear field must not leak the sibling destructor (RUE-1591)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+struct C { l: L, d: D }
+fn sink(l: L) -> i32 { l.v }
+fn main() -> i32 {
+    let c = C { l: L { v: 1 }, d: D { v: 42 } };
+    let r = sink(c.l);
+    @dbg(99);
+    r
+}
+""" }]
+exit_code = 1
+stdout = """99
+42
+"""
+
+[[case]]
+name = "carrier_residue_destructor_order_is_declaration_order"
+description = "Residue destructors run in field declaration order after the linear field is consumed (RUE-1591, spec 3.9:2)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+struct D1 { v: i32 }
+drop fn D1(self) { @dbg(self.v); }
+struct D2 { v: i32 }
+drop fn D2(self) { @dbg(self.v); }
+struct C { a: D1, l: L, b: D2 }
+fn sink(l: L) -> i32 { l.v }
+fn main() -> i32 {
+    let c = C { a: D1 { v: 10 }, l: L { v: 1 }, b: D2 { v: 20 } };
+    let r = sink(c.l);
+    @dbg(99);
+    r
+}
+""" }]
+exit_code = 1
+stdout = """99
+10
+20
+"""
+
+[[case]]
+name = "carrier_residue_destructor_runs_once_under_drop_flags"
+description = "Consuming the linear field on both branches still drops the residue exactly once (RUE-1591 drop flags)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+struct C { l: L, d: D }
+fn sink(l: L) -> i32 { l.v }
+fn pick(n: i32) -> i32 {
+    let c = C { l: L { v: 1 }, d: D { v: 42 } };
+    let r = if n > 0 { sink(c.l) } else { sink(c.l) };
+    @dbg(99);
+    r
+}
+fn main() -> i32 { pick(1) }
+""" }]
+exit_code = 1
+stdout = """99
+42
+"""
+
+[[case]]
+name = "carrier_param_residue_dropped_in_callee"
+description = "A by-value carrier parameter is discharged by consuming its linear sub-place; the residue drops at the callee's exit (RUE-1591, spec 3.8:62)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+struct C { l: L, d: D }
+fn sink(l: L) -> i32 { l.v }
+fn eat(c: C) -> i32 {
+    let r = sink(c.l);
+    @dbg(88);
+    r
+}
+fn main() -> i32 {
+    let c = C { l: L { v: 1 }, d: D { v: 42 } };
+    let r = eat(c);
+    @dbg(99);
+    r
+}
+""" }]
+exit_code = 1
+stdout = """88
+42
+99
+"""
+
+[[case]]
+name = "carrier_nested_linear_subplace_consumed"
+description = "A nested linear sub-place discharges the obligation and leaves the outer residue to drop (RUE-1591, core 5.6)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+struct A { l: L, tag: i32 }
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+struct C { a: A, d: D }
+fn sink(l: L) -> i32 { l.v }
+fn main() -> i32 {
+    let c = C { a: A { l: L { v: 7 }, tag: 3 }, d: D { v: 42 } };
+    let r = sink(c.a.l);
+    let t = c.a.tag;
+    @dbg(99);
+    r + t
+}
+""" }]
+exit_code = 10
+stdout = """99
+42
+"""
+
+[[case]]
+name = "carrier_linear_subplace_unconsumed_still_rejected"
+description = "The must-consume obligation moves to the linear sub-place, it does not disappear (RUE-1591)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+struct D { v: i32 }
+struct C { l: L, d: D }
+fn main() -> i32 {
+    let c = C { l: L { v: 1 }, d: D { v: 42 } };
+    c.d.v
+}
+""" }]
+compile_fail = true
+error_contains = [
+    "E0406",
+    "linear value 'c' must be consumed",
+    "'c.l' still holds a linear value",
+]
+
+[[case]]
+name = "carrier_linear_subplace_consumed_one_branch_rejected"
+description = "A linear sub-place consumed on only one path is E0443, naming the branch that did consume it (RUE-1591)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+struct D { v: i32 }
+struct C { l: L, d: D }
+fn sink(l: L) -> i32 { l.v }
+fn pick(n: i32) -> i32 {
+    let c = C { l: L { v: 1 }, d: D { v: 42 } };
+    if n > 0 { sink(c.l) } else { 0 }
+}
+fn main() -> i32 { pick(1) }
+""" }]
+compile_fail = true
+error_contains = [
+    "E0443",
+    "not consumed on all paths",
+    "'c.l' still holds a linear value",
+]
+
+[[case]]
+name = "carrier_residue_destructor_order_aarch64"
+description = "The residue drop is scheduled by the shared drop elaboration, so aarch64 emits the same ordering; run natively on the aarch64 lane (RUE-1591)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+struct D1 { v: i32 }
+drop fn D1(self) { @dbg(self.v); }
+struct D2 { v: i32 }
+drop fn D2(self) { @dbg(self.v); }
+struct C { a: D1, l: L, b: D2 }
+fn sink(l: L) -> i32 { l.v }
+fn main() -> i32 {
+    let c = C { a: D1 { v: 10 }, l: L { v: 1 }, b: D2 { v: 20 } };
+    let r = sink(c.l);
+    @dbg(99);
+    r
+}
+""" }]
+args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
+executable_target = "aarch64-linux"
+execute_if_native = true
+exit_code = 1
+stdout = """99
+10
+20
+"""
+
+[[case]]
+name = "carrier_residue_destructor_order_at_O2"
+description = "The residue drop and its ordering survive inlining and folding: same digits at -O2 as at -O0 (RUE-1591)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+struct D1 { v: i32 }
+drop fn D1(self) { @dbg(self.v); }
+struct D2 { v: i32 }
+drop fn D2(self) { @dbg(self.v); }
+struct C { a: D1, l: L, b: D2 }
+fn sink(l: L) -> i32 { l.v }
+fn main() -> i32 {
+    let c = C { a: D1 { v: 10 }, l: L { v: 1 }, b: D2 { v: 20 } };
+    let r = sink(c.l);
+    @dbg(99);
+    r
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+exit_code = 1
+stdout = """99
+10
+20
+"""
+
+[[case]]
+name = "carrier_param_residue_dropped_in_callee_at_O2"
+description = "The callee-side residue drop of a carrier parameter is preserved at -O2, inlining included (RUE-1591)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+struct C { l: L, d: D }
+fn sink(l: L) -> i32 { l.v }
+fn eat(c: C) -> i32 {
+    let r = sink(c.l);
+    @dbg(88);
+    r
+}
+fn main() -> i32 {
+    let c = C { l: L { v: 1 }, d: D { v: 42 } };
+    let r = eat(c);
+    @dbg(99);
+    r
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+exit_code = 1
+stdout = """88
+42
+99
+"""
+
+[[case]]
+name = "carrier_residue_destructor_runs_once_under_drop_flags_at_O2"
+description = "Branch-conditional consumption still drops the residue exactly once at -O2 (RUE-1591 drop flags)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+struct C { l: L, d: D }
+fn sink(l: L) -> i32 { l.v }
+fn pick(n: i32) -> i32 {
+    let c = C { l: L { v: 1 }, d: D { v: 42 } };
+    let r = if n > 0 { sink(c.l) } else { sink(c.l) };
+    @dbg(99);
+    r
+}
+fn main() -> i32 { pick(1) }
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+exit_code = 1
+stdout = """99
+42
+"""
+
+[[case]]
+name = "carrier_with_own_destructor_field_move_rejected"
+description = "A carrier that has its own destructor now reaches the destructor-type field-move rejection (E0456) instead of silently skipping its destructor via whole-value consumption (RUE-1591)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+struct C { l: L, n: i32 }
+drop fn C(self) { @dbg(self.n); }
+fn sink(l: L) -> i32 { l.v }
+fn main() -> i32 {
+    let c = C { l: L { v: 1 }, n: 7 };
+    sink(c.l)
+}
+""" }]
+compile_fail = true
+error_contains = [
+    "E0456",
+    "cannot move field `l` out of a value of type 'C', which has a destructor",
+]
+
+[[case]]
+name = "declared_linear_husk_behavior_unchanged"
+description = "A DECLARED-linear struct still destructures whole-value: its husk stays droppable (RUE-614, unchanged by RUE-1591)."
+files = [{ path = "main.rue", source = """
+linear struct Token { v: i32 }
+linear struct H { t: Token, n: i32 }
+fn consume(t: Token) -> i32 { t.v }
+fn main() -> i32 {
+    let h = H { t: Token { v: 5 }, n: 1 };
+    consume(h.t)
+}
+""" }]
+exit_code = 5
 
 [[case]]
 name = "extract_and_consume_linear_field_ok"

--- a/crates/rue-cli-tests/cases/wildcard_payload_binding.toml
+++ b/crates/rue-cli-tests/cases/wildcard_payload_binding.toml
@@ -1,13 +1,28 @@
 # `_` as a tuple-variant payload binding (RUE-601): matches and discards a
 # payload field without binding it. Driven through the real binary, including
-# the drop-semantics guarantee — a discarded non-Copy payload is not moved out
-# of the scrutinee, so its destructor runs exactly once (via the scrutinee's
-# drop), same as a bound-but-unused binding.
+# the drop-semantics guarantee — a discarded non-Copy payload's destructor
+# runs exactly once.
+#
+# RUE-1592 (Steve's ruling, recorded 2026-08-22) settled WHEN and IN WHAT
+# ORDER that drop happens, and what happens for a linear field. A discarded
+# payload position — an explicit `_`, or any position of the *bare* variant
+# pattern `E.A`, which is the all-wildcard form — is a fresh UNNAMEABLE
+# binding governed by the ordinary scope rules:
+#
+#   - AFFINE: it drops at the ARM'S END, interleaved with the arm's named
+#     bindings in reverse declaration order. NOT eagerly before the arm body
+#     (the pre-RUE-1592 behavior), and NOT together with the scrutinee.
+#   - LINEAR: nothing can name it, so its must-consume obligation could never
+#     be discharged — a compile-time error (E0486). Binding it by name and
+#     consuming it (or `@drop`-ing it) is the escape hatch.
+#
+# The ordering cases below pin EXACT stdout at both -O0 and -O2, so a drop
+# that is missed, doubled, or re-scheduled by an optimization is caught.
 
 [section]
 id = "cli.wildcard_payload_binding"
 name = "Wildcard payload binding"
-description = "`Err(_)` / `Rect(_, _)` discard payload fields; a discarded non-Copy field is dropped exactly once (RUE-601)."
+description = "`Err(_)` / `Rect(_, _)` / bare `E.A` discard payload fields as fresh unnameable bindings, dropped once at the arm's end (RUE-601, RUE-1592)."
 
 [[case]]
 name = "discard_partial_and_multiple"
@@ -49,6 +64,270 @@ enum Res { Ok(i32), Err(i32) }
 fn div(a: i32, b: i32) -> Res { if b == 0 { Res.Err(1) } else { Res.Ok(a / b) } }
 fn main() -> i32 {
     match div(84, 2) { Res.Ok(v) => v, Res.Err(_) => -1 }
+}
+""" }]
+exit_code = 42
+
+# ---------------------------------------------------------------------------
+# RUE-1592: arm-end drop timing and reverse-declaration interleaving.
+# ---------------------------------------------------------------------------
+
+# The canonical repro. `E.A(x, _)`: the arm BODY runs first (1), then the arm's
+# bindings drop in reverse declaration order — `_` (position 1, prints 22)
+# before `x` (position 0, prints 11) — and only then does execution continue
+# past the match (2). Before RUE-1592 this printed "22 1 11 2": the discarded
+# sibling was extracted and dropped eagerly, ahead of the arm body.
+[[case]]
+name = "discarded_sibling_drops_at_arm_end_in_reverse_order"
+description = "Arm body first, then `_` and the named sibling drop at the arm's end in reverse declaration order (RUE-1592)."
+files = [{ path = "main.rue", source = """
+struct D1 { v: i32 }
+struct D2 { v: i32 }
+
+drop fn D1(self) { @dbg(self.v); }
+drop fn D2(self) { @dbg(self.v); }
+
+enum E { A(D1, D2) }
+
+fn main() -> i32 {
+    let e = E.A(D1 { v: 11 }, D2 { v: 22 });
+    match e {
+        E.A(x, _) => { @dbg(1); }
+    }
+    @dbg(2);
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+stdout = "1\n22\n11\n2\n"
+exit_code = 0
+
+[[case]]
+name = "discarded_sibling_drops_at_arm_end_in_reverse_order_o2"
+description = "Same drop schedule at -O2: optimization must not re-order, drop, or duplicate the arm-end drops (RUE-1592)."
+files = [{ path = "main.rue", source = """
+struct D1 { v: i32 }
+struct D2 { v: i32 }
+
+drop fn D1(self) { @dbg(self.v); }
+drop fn D2(self) { @dbg(self.v); }
+
+enum E { A(D1, D2) }
+
+fn main() -> i32 {
+    let e = E.A(D1 { v: 11 }, D2 { v: 22 });
+    match e {
+        E.A(x, _) => { @dbg(1); }
+    }
+    @dbg(2);
+    0
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+stdout = "1\n22\n11\n2\n"
+exit_code = 0
+
+# A three-field variant with the bound field in the middle: the discarded
+# positions are NOT hoisted ahead of the body, and all three drops interleave
+# strictly by reverse declaration order (3, 2, 1).
+[[case]]
+name = "three_field_discards_interleave_with_named_binding"
+description = "`E.Trip(_, y, _)`: body first, then fields 2, 1, 0 drop in reverse declaration order (RUE-1592)."
+files = [{ path = "main.rue", source = """
+struct A { v: i32 }
+
+drop fn A(self) { @dbg(self.v); }
+
+enum E { Trip(A, A, A), None }
+
+fn main() -> i32 {
+    let e = E.Trip(A { v: 1 }, A { v: 2 }, A { v: 3 });
+    match e {
+        E.Trip(_, y, _) => { @dbg(100); },
+        E.None => {},
+    }
+    @dbg(200);
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+stdout = "100\n3\n2\n1\n200\n"
+exit_code = 0
+
+# The bare payload-carrying variant pattern is the all-wildcard form: same
+# elaboration, same schedule, and each payload destructor runs EXACTLY once.
+[[case]]
+name = "bare_variant_pattern_drops_payload_once_at_arm_end"
+description = "`E.A =>` on an arity-2 variant: body first, then both fields drop once each in reverse order (RUE-1592 bare-path carve-out)."
+files = [{ path = "main.rue", source = """
+struct Big { v: i32 }
+
+drop fn Big(self) { @dbg(self.v); }
+
+enum E { A(Big, Big), B }
+
+fn main() -> i32 {
+    let e = E.A(Big { v: 41 }, Big { v: 42 });
+    let r = match e {
+        E.A => { @dbg(1); 7 },
+        E.B => 0,
+    };
+    @dbg(99);
+    r - 7
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+stdout = "1\n42\n41\n99\n"
+exit_code = 0
+
+[[case]]
+name = "bare_variant_pattern_drops_payload_once_at_arm_end_o2"
+description = "Same bare-variant drop schedule at -O2 — exactly once per field, no reordering (RUE-1592)."
+files = [{ path = "main.rue", source = """
+struct Big { v: i32 }
+
+drop fn Big(self) { @dbg(self.v); }
+
+enum E { A(Big, Big), B }
+
+fn main() -> i32 {
+    let e = E.A(Big { v: 41 }, Big { v: 42 });
+    let r = match e {
+        E.A => { @dbg(1); 7 },
+        E.B => 0,
+    };
+    @dbg(99);
+    r - 7
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+stdout = "1\n42\n41\n99\n"
+exit_code = 0
+
+# The non-taken arm's payload must not be dropped: the drop schedule is
+# per-arm, and the scrutinee's active variant is the one that runs.
+[[case]]
+name = "only_the_selected_arms_payload_is_dropped"
+description = "A bare-variant arm that is not selected drops nothing; only the active variant's payload runs its glue (RUE-1592, 6.3:20)."
+files = [{ path = "main.rue", source = """
+struct A { v: i32 }
+
+drop fn A(self) { @dbg(self.v); }
+
+enum E { Left(A), Right(A, A) }
+
+fn pick(n: i32) -> E {
+    if n == 0 { E.Left(A { v: 5 }) } else { E.Right(A { v: 6 }, A { v: 7 }) }
+}
+
+fn main() -> i32 {
+    match pick(0) { E.Left => { @dbg(1); }, E.Right(_, _) => { @dbg(2); } }
+    @dbg(50);
+    match pick(1) { E.Left => { @dbg(3); }, E.Right(_, _) => { @dbg(4); } }
+    @dbg(60);
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+stdout = "1\n5\n50\n4\n7\n6\n60\n"
+exit_code = 0
+
+# ---------------------------------------------------------------------------
+# RUE-1592 linearity: a discarded LINEAR payload is a compile-time error.
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "linear_payload_discarded_by_wildcard_is_e0486"
+description = "`E.A(_)` over a linear payload is rejected: the unnameable binding could never be consumed (E0486)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+enum E { A(L), B }
+fn main() -> i32 {
+    let e = E.A(L { v: 5 });
+    match e {
+        E.A(_) => 1,
+        E.B => 2,
+    }
+}
+""" }]
+compile_fail = true
+error_contains = ["E0486"]
+
+[[case]]
+name = "linear_payload_discarded_by_bare_variant_is_e0486"
+description = "The bare form `E.A` over a linear payload is rejected identically — it is the all-wildcard form (E0486)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+enum E { A(L), B }
+fn main() -> i32 {
+    let e = E.A(L { v: 5 });
+    match e {
+        E.A => 1,
+        E.B => 2,
+    }
+}
+""" }]
+compile_fail = true
+error_contains = ["E0486"]
+
+[[case]]
+name = "linear_sibling_discarded_beside_named_binding_is_e0486"
+description = "A linear field discarded by `_` beside a named sibling is rejected; the diagnostic names the variant and the position (E0486)."
+files = [{ path = "main.rue", source = """
+struct A { v: i32 }
+linear struct L { v: i32 }
+enum E { Pair(A, L), None }
+fn main() -> i32 {
+    let e = E.Pair(A { v: 1 }, L { v: 2 });
+    match e {
+        E.Pair(x, _) => x.v,
+        E.None => 0,
+    }
+}
+""" }]
+compile_fail = true
+error_contains = ["E0486", "discarded payload field 1 of `E.Pair`"]
+
+[[case]]
+name = "linear_payload_escape_hatch_bind_and_drop"
+description = "The escape hatch: bind the linear field by name and `@drop` it — legal, and the glue runs exactly once at the `@drop` site."
+files = [{ path = "main.rue", source = """
+struct A { v: i32 }
+linear struct L { v: i32 }
+
+drop fn A(self) { @dbg(self.v); }
+drop fn L(self) { @dbg(self.v); }
+
+enum E { Pair(A, L), None }
+
+fn main() -> i32 {
+    let e = E.Pair(A { v: 1 }, L { v: 2 });
+    let r = match e {
+        E.Pair(x, l) => { @dbg(9); @drop(l); @dbg(10); x.v },
+        E.None => 0,
+    };
+    @dbg(50);
+    r - 1
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+stdout = "9\n2\n10\n1\n50\n"
+exit_code = 0
+
+# Control (RUE-1592 repro 1's control): the same shapes over a NON-linear
+# payload keep compiling and running.
+[[case]]
+name = "non_linear_payload_discard_still_compiles"
+description = "Control: `_` and the bare form over an affine payload stay legal (RUE-1592 must not over-reject)."
+files = [{ path = "main.rue", source = """
+struct P { v: i32 }
+enum E { A(P), B }
+fn main() -> i32 {
+    let e = E.A(P { v: 5 });
+    let a = match e { E.A(_) => 20, E.B => 0 };
+    let f = E.A(P { v: 5 });
+    let b = match f { E.A => 22, E.B => 0 };
+    a + b
 }
 """ }]
 exit_code = 42

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -1467,6 +1467,10 @@ impl RetainedCharge for rue_error::ErrorKind {
                 enum_name: left,
                 variant_name: right,
             }
+            | E::LinearPayloadDiscarded {
+                position: left,
+                type_name: right,
+            }
             | E::BufferNotFirstClassStr {
                 found: left,
                 site: right,

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1348,8 +1348,14 @@ pub enum ErrorKind {
     /// Linear struct cannot be marked @copy
     #[error("linear struct '{0}' cannot be marked @copy")]
     LinearStructCopy(String),
-    /// Field access destructures a linear struct, implicitly dropping another
-    /// field that carries a linear value
+    /// Field access destructures a **declared**-`linear` struct, implicitly
+    /// dropping another field that carries a linear value (spec 3.8:60).
+    ///
+    /// Only a declared-`linear` struct destructures whole-value this way. A
+    /// struct that is linear merely because a field carries a linear value
+    /// (infectious linearity, 3.8:58) takes an ordinary partial move on field
+    /// access, so its siblings survive and an unconsumed linear sub-place is
+    /// reported at scope exit by the must-consume family instead (RUE-1591).
     #[error(
         "accessing field '{accessed}' of linear struct '{struct_name}' would implicitly drop linear field '{dropped}'",
         struct_name = .0.struct_name,

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -280,6 +280,14 @@ impl ErrorCode {
     /// 9.1:12, ADR-0028); taking the "address" of a temporary value would
     /// reinterpret the value's bits as a pointer (RUE-274).
     pub const RAW_REQUIRES_PLACE: Self = Self(485);
+    /// A match-arm payload position that binds nothing — an explicit `_`
+    /// discard, or a position covered by the all-wildcard bare variant
+    /// pattern `E.A` — names a payload field whose type carries a linear
+    /// value (RUE-1592, spec 4.7:30). Such a position is a fresh *unnameable*
+    /// binding (formal core §2 elaboration note), so its must-consume
+    /// obligation (3.8:52) could never be discharged. Bind the field by name
+    /// and consume it — or `@drop` it (E0478's escape hatch, RUE-187).
+    pub const LINEAR_PAYLOAD_DISCARDED: Self = Self(486);
     /// A slice type `[T]` was written in return position (`fn f(...) -> [T]`).
     /// A slice is a *second-class* fat-pointer view (ADR-0037, ADR-0043,
     /// RUE-322): it is valid only in argument position and may not be
@@ -1335,6 +1343,16 @@ pub enum ErrorKind {
     /// body result) carries a linear value, which would be implicitly dropped
     #[error("discarded value of type '{type_name}' carries a linear value and must be consumed")]
     LinearValueDiscarded { type_name: String },
+    /// A match-arm payload position that binds nothing — a `_` discard, or a
+    /// position covered by the all-wildcard bare variant pattern — names a
+    /// payload field whose type carries a linear value (RUE-1592, spec
+    /// 4.7:30). Such a position elaborates to a fresh *unnameable* binding
+    /// (formal core §2), and an unnameable binding can never be consumed, so
+    /// the must-consume obligation of 3.8:52 could never be discharged.
+    #[error(
+        "discarded payload {position} carries a linear value of type '{type_name}' and must be consumed"
+    )]
+    LinearPayloadDiscarded { position: String, type_name: String },
     /// Assignment to a place holding a live linear value (RUE-387): the
     /// overwrite would implicitly drop the old linear value.
     #[error("assignment would overwrite a live linear value of type '{type_name}'")]
@@ -2103,6 +2121,7 @@ impl ErrorKind {
                 ErrorCode::LINEAR_VALUE_NOT_CONSUMED_ON_ALL_PATHS
             }
             ErrorKind::LinearValueDiscarded { .. } => ErrorCode::LINEAR_VALUE_DISCARDED,
+            ErrorKind::LinearPayloadDiscarded { .. } => ErrorCode::LINEAR_PAYLOAD_DISCARDED,
             ErrorKind::LinearValueOverwritten { .. } => ErrorCode::LINEAR_VALUE_OVERWRITTEN,
             ErrorKind::LinearValueOverwrittenThroughInout { .. } => {
                 ErrorCode::LINEAR_VALUE_OVERWRITTEN_THROUGH_INOUT
@@ -3143,7 +3162,8 @@ mod tests {
             ErrorKind::SliceEscapesScope.code(),
             ErrorCode::SLICE_ESCAPES_SCOPE
         );
-        // Codes are contiguous with the not-yet-implemented gate (E0486).
+        // Codes are contiguous with the discarded-linear-payload gate
+        // (E0486, RUE-1592).
         assert_eq!(ErrorCode::SLICE_RETURN_NOT_ALLOWED.0, 487);
         assert_eq!(ErrorCode::SLICE_IN_AGGREGATE_FIELD.0, 488);
         assert_eq!(ErrorCode::SLICE_ESCAPES_SCOPE.0, 489);

--- a/crates/rue-spec/cases/expressions/match.toml
+++ b/crates/rue-spec/cases/expressions/match.toml
@@ -1000,6 +1000,78 @@ fn main() -> i32 {
 """
 exit_code = 42
 
+# The bare-path carve-out (4.7:30, RUE-1592): a payload-carrying variant
+# written with no binding list IS the all-wildcard form, so it is exempt from
+# the arity rule that rejects `Shape.Rect(w)` above with E0207.
+[[case]]
+name = "match_bare_variant_pattern_is_all_wildcard_form"
+spec = ["4.7:30", "4.7:34"]
+source = """
+enum Shape { Circle(i32), Rect(i32, i32), Empty }
+fn main() -> i32 {
+    let a = match Shape.Rect(3, 4) { Shape.Rect => 40, Shape.Circle(r) => r, Shape.Empty => 0 };
+    let b = match Shape.Circle(9)  { Shape.Rect(_, _) => 0, Shape.Circle => 2, Shape.Empty => 0 };
+    a + b
+}
+"""
+exit_code = 42
+
+# A discarded payload field is a fresh unnameable binding, so a LINEAR one can
+# never discharge its must-consume obligation and is rejected (4.7:30, 3.8:50;
+# RUE-1592 ruling of 2026-08-22 — this previously compiled silently).
+[[case]]
+name = "match_payload_wildcard_over_linear_rejected"
+spec = ["4.7:30", "3.8:50"]
+source = """
+linear struct L { v: i32 }
+enum E { A(L), B }
+fn main() -> i32 {
+    let e = E.A(L { v: 5 });
+    match e {
+        E.A(_) => 1,
+        E.B => 2,
+    }
+}
+"""
+compile_fail = true
+error_contains = "[E0486]"
+
+# The bare form is the all-wildcard form, so it is rejected identically
+# (4.7:30 bare-path carve-out, RUE-1592).
+[[case]]
+name = "match_bare_variant_over_linear_payload_rejected"
+spec = ["4.7:30", "3.8:50"]
+source = """
+linear struct L { v: i32 }
+enum E { A(L), B }
+fn main() -> i32 {
+    let e = E.A(L { v: 5 });
+    match e {
+        E.A => 1,
+        E.B => 2,
+    }
+}
+"""
+compile_fail = true
+error_contains = "[E0486]"
+
+# Control: the same shapes over a NON-linear payload keep compiling (4.7:30).
+[[case]]
+name = "match_payload_wildcard_over_affine_payload_is_legal"
+spec = ["4.7:30"]
+source = """
+struct P { v: i32 }
+enum E { A(P), B }
+fn main() -> i32 {
+    let e = E.A(P { v: 5 });
+    let a = match e { E.A(_) => 20, E.B => 0 };
+    let f = E.A(P { v: 5 });
+    let b = match f { E.A => 22, E.B => 0 };
+    a + b
+}
+"""
+exit_code = 42
+
 # Bindings move the payload out in value context and are usable in the arm
 # body (4.7:31).
 [[case]]

--- a/crates/rue-spec/cases/types/destructors.toml
+++ b/crates/rue-spec/cases/types/destructors.toml
@@ -1301,7 +1301,7 @@ expected_stdout = "5\n5\n100\n"
 [[case]]
 name = "partial_payload_bind_drops_discarded_sibling"
 spec = ["4.7:30", "6.3:20"]
-description = "A match arm binding one payload field drops the `_`-discarded sibling exactly once (RUE-1270: it previously leaked)"
+description = "A match arm binding one payload field drops the `_`-discarded sibling exactly once, at the arm's end (RUE-1270 leak; RUE-1592 timing)"
 source = """
 struct A { v: i32 }
 
@@ -1314,7 +1314,7 @@ enum E { Pair(A, A), None }
 fn main() -> i32 {
     let e = E.Pair(A { v: 1 }, A { v: 2 });
     let r = match e {
-        E.Pair(x, _) => x.v,   // discarded sibling (2) drops in the arm, bound x (1) at scope exit
+        E.Pair(x, _) => x.v,   // both fields drop at the arm's end, reverse order: `_` (2), then x (1)
         E.None => 0,
     };
     @dbg(500);
@@ -1324,10 +1324,16 @@ fn main() -> i32 {
 exit_code = 0
 expected_stdout = "2\n1\n500\n"
 
+# RUE-1592 ruling (Steve, 2026-08-22): `_` in payload position is a fresh
+# unnameable binding governed by §5.6 exactly like its named siblings, so a
+# discarded AFFINE field drops at the ARM'S END — interleaved with the named
+# siblings in reverse declaration order — not eagerly before the arm body.
+# This case previously pinned the eager pre-body order ("1\n3\n2\n500\n");
+# the flip is the ruling, not a regression.
 [[case]]
-name = "partial_payload_bind_drops_every_discarded_sibling_in_field_order"
+name = "partial_payload_bind_drops_every_discarded_sibling_in_reverse_order"
 spec = ["4.7:30", "6.3:20"]
-description = "Both `_`-discarded fields of a three-field variant drop, in field order, before the bound field's scope exit (RUE-1270)"
+description = "The `_`-discarded fields of a three-field variant drop at the arm's end, interleaved with the bound field in reverse declaration order (RUE-1592)"
 source = """
 struct A { v: i32 }
 
@@ -1348,12 +1354,18 @@ fn main() -> i32 {
 }
 """
 exit_code = 0
-expected_stdout = "1\n3\n2\n500\n"
+expected_stdout = "3\n2\n1\n500\n"
 
+# RUE-1592 ruling (Steve, 2026-08-22): a LINEAR payload covered by `_` is a
+# COMPILE-TIME ERROR — the unnameable binding it elaborates to can never be
+# consumed, so its must-consume obligation could never be discharged. This
+# case previously asserted that the linear sibling was silently drop-glued
+# (RUE-1270's compiler-side resolution); the ruling overturns that in favor of
+# the formal core's §2 story. `@drop` is the escape hatch (see the case below).
 [[case]]
-name = "partial_payload_bind_linear_sibling_is_dropped_not_leaked"
-spec = ["6.3:19", "6.3:20"]
-description = "A linear sibling discarded by `_` in a partial bind runs its drop glue; the match consumed the enum (RUE-1270: it previously neither dropped nor errored)"
+name = "partial_payload_bind_linear_sibling_is_rejected"
+spec = ["6.3:19", "4.7:30"]
+description = "A linear sibling discarded by `_` in a partial bind is rejected at compile time (E0486, RUE-1592)"
 source = """
 struct A { v: i32 }
 
@@ -1379,13 +1391,49 @@ fn main() -> i32 {
     r - 1
 }
 """
+compile_fail = true
+error_contains = "[E0486]"
+
+[[case]]
+name = "partial_payload_bind_linear_sibling_named_and_dropped"
+spec = ["6.3:19", "4.7:30"]
+description = "The escape hatch for a linear payload field: bind it by name and `@drop` it (RUE-1592)"
+source = """
+struct A { v: i32 }
+
+drop fn A(self) {
+    @dbg(self.v);
+}
+
+linear struct L { v: i32 }
+
+drop fn L(self) {
+    @dbg(self.v);
+}
+
+enum E { Pair(A, L), None }
+
+fn main() -> i32 {
+    let e = E.Pair(A { v: 1 }, L { v: 2 });
+    let r = match e {
+        E.Pair(x, l) => { @drop(l); x.v },
+        E.None => 0,
+    };
+    @dbg(500);
+    r - 1
+}
+"""
 exit_code = 0
 expected_stdout = "2\n1\n500\n"
 
+# RUE-1592 ruling: an all-`_` payload is N fresh unnameable bindings, so the
+# fields drop at the arm's end in REVERSE declaration order — not through the
+# scrutinee's variant-dispatched glue in field order. This case previously
+# pinned that glue order ("1\n2\n500\n").
 [[case]]
-name = "all_discarded_payload_drops_through_enum_glue"
+name = "all_discarded_payload_drops_at_arm_end_in_reverse_order"
 spec = ["4.7:30", "6.3:20"]
-description = "A variant arm discarding every payload field drops the whole active payload via the enum's glue, in field order"
+description = "A variant arm discarding every payload field drops each field at the arm's end, in reverse declaration order (RUE-1592)"
 source = """
 struct A { v: i32 }
 
@@ -1398,7 +1446,7 @@ enum E { Pair(A, A), None }
 fn main() -> i32 {
     let e = E.Pair(A { v: 1 }, A { v: 2 });
     let r = match e {
-        E.Pair(_, _) => 7,
+        E.Pair(_, _) => { @dbg(7); 7 },
         E.None => 0,
     };
     @dbg(500);
@@ -1406,7 +1454,62 @@ fn main() -> i32 {
 }
 """
 exit_code = 0
-expected_stdout = "1\n2\n500\n"
+expected_stdout = "7\n2\n1\n500\n"
+
+# The bare payload-carrying variant pattern `E.Pair` is the all-wildcard form
+# (spec 4.7:30 bare-path carve-out, RUE-1592): identical elaboration, identical
+# drop schedule, and the payload destructor runs EXACTLY once.
+[[case]]
+name = "bare_variant_pattern_drops_payload_at_arm_end"
+spec = ["4.7:30", "4.7:34", "6.3:20"]
+description = "A bare payload-carrying variant pattern is the all-wildcard form: each field drops once, at the arm's end, in reverse declaration order (RUE-1592)"
+source = """
+struct A { v: i32 }
+
+drop fn A(self) {
+    @dbg(self.v);
+}
+
+enum E { Pair(A, A), None }
+
+fn main() -> i32 {
+    let e = E.Pair(A { v: 1 }, A { v: 2 });
+    let r = match e {
+        E.Pair => { @dbg(7); 7 },
+        E.None => 0,
+    };
+    @dbg(500);
+    r - 7
+}
+"""
+exit_code = 0
+expected_stdout = "7\n2\n1\n500\n"
+
+# The bare form is governed by the same linearity rule as an explicit `_`
+# (RUE-1592 ruling (a)): a linear payload it covers is a compile-time error.
+[[case]]
+name = "bare_variant_pattern_over_linear_payload_is_rejected"
+spec = ["6.3:19", "4.7:30"]
+description = "A bare variant pattern covering a linear payload is rejected identically to `_` (E0486, RUE-1592)"
+source = """
+linear struct L { v: i32 }
+
+drop fn L(self) {
+    @dbg(self.v);
+}
+
+enum E { A(L), B }
+
+fn main() -> i32 {
+    let e = E.A(L { v: 5 });
+    match e {
+        E.A => 1,
+        E.B => 2,
+    }
+}
+"""
+compile_fail = true
+error_contains = "[E0486]"
 
 [[case]]
 name = "full_payload_bind_drops_bindings_at_scope_exit"

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -1386,7 +1386,24 @@ exit_code = 42
 [[case]]
 name = "linear_destructure_dropping_linear_field_error"
 spec = ["3.8:60"]
-description = "Field access that would implicitly drop a different linear field is rejected"
+description = "Destructuring a DECLARED-linear struct that would implicitly drop a different linear field is rejected at the access"
+source = """
+linear struct MustUse { value: i32 }
+
+linear struct Pair { inner: MustUse, tag: i32 }
+
+fn main() -> i32 {
+    let p = Pair { inner: MustUse { value: 1 }, tag: 2 };
+    p.tag
+}
+"""
+compile_fail = true
+error_contains = "would implicitly drop linear field 'inner'"
+
+[[case]]
+name = "infectious_carrier_unconsumed_field_reported_at_scope_exit"
+spec = ["3.8:60"]
+description = "Reading a Copy sibling of an infectious carrier does not destructure it; the unconsumed linear sub-place is reported at scope exit (RUE-1591)"
 source = """
 linear struct MustUse { value: i32 }
 
@@ -1398,7 +1415,110 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = "would implicitly drop linear field 'inner'"
+error_contains = "'c.inner' still holds a linear value"
+
+[[case]]
+name = "infectious_carrier_copy_sibling_read_before_move"
+spec = ["3.8:28", "3.8:60"]
+description = "A Copy sibling of an infectious carrier may be read before the linear field is consumed (RUE-1591)"
+source = """
+linear struct MustUse { value: i32 }
+
+struct Container { inner: MustUse, tag: i32 }
+
+fn sink(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    let c = Container { inner: MustUse { value: 40 }, tag: 2 };
+    let t = c.tag;
+    sink(c.inner) + t
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "infectious_carrier_copy_sibling_read_after_move"
+spec = ["3.8:22", "3.8:28"]
+description = "A Copy sibling stays Owned and readable after the linear field is partially moved out (RUE-1591)"
+source = """
+linear struct MustUse { value: i32 }
+
+struct Container { inner: MustUse, tag: i32 }
+
+fn sink(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    let c = Container { inner: MustUse { value: 40 }, tag: 2 };
+    let s = sink(c.inner);
+    let t = c.tag;
+    s + t
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "infectious_carrier_move_sibling_still_usable"
+spec = ["3.8:22", "3.8:60"]
+description = "A move-typed sibling of an infectious carrier remains accessible after the linear field moves out (RUE-1591)"
+source = """
+linear struct MustUse { value: i32 }
+
+struct Payload { n: i32 }
+
+struct Container { inner: MustUse, rest: Payload }
+
+fn sink(m: MustUse) -> i32 { m.value }
+
+fn take(p: Payload) -> i32 { p.n }
+
+fn main() -> i32 {
+    let c = Container { inner: MustUse { value: 40 }, rest: Payload { n: 2 } };
+    sink(c.inner) + take(c.rest)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "infectious_carrier_whole_use_after_partial_move_error"
+spec = ["3.8:26", "3.8:60"]
+description = "An infectious carrier cannot be used as a whole once its linear field moved out (RUE-1591)"
+source = """
+linear struct MustUse { value: i32 }
+
+struct Container { inner: MustUse, tag: i32 }
+
+fn sink(m: MustUse) -> i32 { m.value }
+
+fn eat(c: Container) -> i32 { sink(c.inner) }
+
+fn main() -> i32 {
+    let c = Container { inner: MustUse { value: 1 }, tag: 2 };
+    let r = sink(c.inner);
+    eat(c) + r
+}
+"""
+compile_fail = true
+error_contains = "use of moved value 'c'"
+
+[[case]]
+name = "infectious_carrier_field_consumed_one_branch_error"
+spec = ["3.8:50", "3.8:60"]
+description = "A linear sub-place consumed on only one path leaves a residual obligation (RUE-1591)"
+source = """
+linear struct MustUse { value: i32 }
+
+struct Container { inner: MustUse, tag: i32 }
+
+fn sink(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    let c = Container { inner: MustUse { value: 1 }, tag: 2 };
+    let n = 1;
+    if n > 0 { sink(c.inner) } else { 0 }
+}
+"""
+compile_fail = true
+error_contains = "not consumed on all paths"
 
 [[case]]
 name = "linear_container_consumed_one_branch_error"

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -110,9 +110,17 @@ Notes on what is **absent by design** (lives in elaboration, `02-elaboration.md`
   specified in `02-elaboration.md` rather than treated as transparent sugar;
 - **`_` in payload-binding position** → a fresh, unnameable binding, governed
   by §5.6 exactly like its named siblings (an `Affine` payload it covers drops
-  at the arm's end; a `Linear` one makes the arm ill-formed). RUE-1270 records
-  a compiler divergence in this area (sibling drops skipped by a partial
-  payload binding); the core states the fresh-binding rule;
+  at the arm's end, interleaved with the named siblings in the §5.6
+  reverse-declaration order; a `Linear` one makes the arm ill-formed).
+  The **bare payload-carrying variant pattern** `E.A` — a variant of arity
+  `n ≥ 1` written with no binding list — elaborates to the all-wildcard form
+  `E.A(_, …, _)` and therefore to `n` such fresh unnameable bindings; it is not
+  a separate core form and carries no separate rule. The compiler agrees with
+  this story as of RUE-1592 (ratified 2026-08-22): the earlier divergence
+  RUE-1270 recorded here — sibling drops skipped, then eagerly pre-body dropped,
+  by a partial payload binding, and a linear discarded payload silently
+  drop-glued rather than rejected — is resolved in the core's favor, so no
+  divergence remains in this area;
 - **no-argument `@panic()`** → the message form (§6.12, D-Panic) with the
   fixed message `panic` (verified: the compiler emits the bare word and exits
   101).

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -663,7 +663,10 @@ attaches to whatever linear content is still present. `carries_linear(T)` at
 the binding's type would over-reject the legal idiom of consuming exactly the
 linear part of an infectious carrier (`let h = Holder { t: token, n: 0 };
 consume(h.t);` — `class(Holder) = Linear` by the join, yet prose and compiler
-both let the non-linear residue drop). Precisely:
+both let the non-linear residue drop). The compiler reached this model in
+RUE-1591: it previously treated `consume(h.t)` on an infectious carrier as a
+whole-value destructuring consumption, which both leaked the residue's drop
+glue and over-rejected reads of a Copy sibling. Precisely:
 
 ```
   residual-linear(Σ, p, T) =
@@ -684,8 +687,11 @@ obligation belongs to the value itself, not its contents (`3.8:74` — "must be
 consumed regardless of what its fields hold"; the empty
 `linear struct MustUse` of `3.8:75` is the motivating case), so a husk whose
 linear field was moved out is still ill-formed to drop. The compiler currently
-diverges on exactly that husk case — it keys purely on residual content and
-accepts the drop (RUE-614); the core states the prose rule.
+diverges on exactly that husk case and accepts the drop (RUE-614): it models a
+field access on a declared-`linear` struct as a whole-value destructure, so the
+husk is `MovedOut` before this clause is ever consulted. The core states the
+prose rule. RUE-1591 confined that whole-value destructure to the declared case
+and left this divergence untouched.
 
 Parameters passed `inout`/`borrow`, and a destructor's own `self`, are exempt from
 the must-consume and drop obligations here (`3.8:62`): the caller (resp. the drop

--- a/docs/spec/src/03-types/08-move-semantics.md
+++ b/docs/spec/src/03-types/08-move-semantics.md
@@ -138,7 +138,7 @@ A linear type **MUST** be explicitly consumed. It is a compile-time error for a 
 
 {{ rule(id="3.8:33", cat="normative") }}
 
-Consuming a linear value is the same operation as moving it: any use of a linear value (3.8:76) consumes it. Passing it as a by-value argument (the function becomes the consumer), returning it (the caller becomes responsible for consuming it), and moving a field out of it (a partial move that destructures it, 3.8:22) are all uses, and therefore each consumes the value.
+Consuming a linear value is the same operation as moving it: any use of a linear value (3.8:76) consumes it. Passing it as a by-value argument (the function becomes the consumer) and returning it (the caller becomes responsible for consuming it) are both uses, and therefore each consumes the value. Moving a field out of a value whose struct type is declared `linear` *destructures* it: because the obligation belongs to the value itself and not to its contents (3.8:74), the field access consumes the whole value, and the other fields are dropped with it (subject to 3.8:60). A field access on a struct that is linear only by infection (3.8:58) is not a destructure; it is the ordinary partial move of 3.8:22, and the carrier's obligation is discharged sub-place by sub-place (3.8:60).
 
 {{ rule(id="3.8:34", cat="example") }}
 
@@ -227,7 +227,9 @@ fn main() -> i32 {
 
 {{ rule(id="3.8:60", cat="legality-rule") }}
 
-It is a compile-time error for a field access that consumes a linear value (destructuring, 3.8:33) to implicitly drop a *different* field that carries a linear value. Every struct level along the access path is checked. The access is a partial move of exactly the accessed field (3.8:22): sibling fields remain in place, and the residue — every field other than the accessed one, at each level — is dropped by the ordinary scope-exit walk of the destructured value's binding (3.9:2). A linear sibling in that residue would therefore be implicitly dropped at scope exit, which is what this rule rejects at the access itself.
+It is a compile-time error for a field access that *destructures* a value whose struct type is declared `linear` (3.8:33) to implicitly drop a *different* field that carries a linear value. Every declared-`linear` struct level along the access path is checked: destructuring consumption extracts the accessed field and drops the rest of the value, so a linear sibling in that residue would be silently dropped.
+
+A field access on a struct that is linear only by infection (3.8:58) does **not** destructure it. It is an ordinary partial move of exactly the accessed field (3.8:22): sibling fields remain accessible (3.8:22 for move-typed siblings, 3.8:28 for Copy ones), and the non-moved residue is dropped by the ordinary scope-exit walk of the binding (3.9:2). Such a carrier's must-consume obligation (3.8:32) attaches to its linear *sub-places* rather than to the carrier as a whole: it is discharged by consuming each linear sub-place on every path, and a linear sub-place left unconsumed is reported where it is dropped — at scope exit — not at a sibling's access. Consuming a linear sub-place therefore leaves the siblings, including any destructor they carry, to drop normally.
 
 {{ rule(id="3.8:61", cat="example") }}
 
@@ -240,12 +242,31 @@ fn sink(m: MustUse) -> i32 { m.value }
 
 fn main() -> i32 {
     let c = Container { inner: MustUse { value: 1 }, tag: 2 };
-    c.tag            // ERROR: would implicitly drop linear field 'inner'
+    c.tag            // ERROR: 'c.inner' is never consumed (reported at scope exit)
 }
 
 fn ok() -> i32 {
     let c = Container { inner: MustUse { value: 1 }, tag: 2 };
-    sink(c.inner)    // OK: extracts the linear field; 'tag' (non-linear) is dropped
+    sink(c.inner)    // OK: consumes the linear field; 'tag' (non-linear) is dropped
+}
+
+fn also_ok() -> i32 {
+    let c = Container { inner: MustUse { value: 1 }, tag: 2 };
+    let t = c.tag;   // OK: 'tag' is Copy, so reading it moves nothing (3.8:28)
+    sink(c.inner) + t
+}
+```
+
+The declared-`linear` case is the one this rule rejects at the access itself, because there the access really does drop the siblings:
+
+```rue
+linear struct MustUse { value: i32 }
+
+linear struct Pair { inner: MustUse, tag: i32 }
+
+fn main() -> i32 {
+    let p = Pair { inner: MustUse { value: 1 }, tag: 2 };
+    p.tag            // ERROR: destructuring 'p' would implicitly drop linear field 'inner'
 }
 ```
 

--- a/docs/spec/src/04-expressions/07-match-expressions.md
+++ b/docs/spec/src/04-expressions/07-match-expressions.md
@@ -231,9 +231,22 @@ A tuple-variant pattern binds the variant's payload into fresh names:
 `EnumName.Variant(a, b)` matches a value of that variant and binds `a`, `b`
 to its payload fields in order. A binding position may instead be the wildcard
 `_`, which matches and discards that field without binding it; unlike a name it
-introduces nothing and so may repeat (`Rect(_, _)`). A discarded field is not
-moved out of the scrutinee and is dropped together with it. The number of
-binding positions **MUST** equal the variant's payload arity (see spec 6.3).
+introduces nothing and so may repeat (`Rect(_, _)`). The number of binding
+positions **MUST** equal the variant's payload arity (see spec 6.3), with one
+carve-out: a *bare* variant pattern that supplies no binding list at all —
+`EnumName.Variant` on a variant of arity one or more — **is** the all-wildcard
+form `EnumName.Variant(_, ..., _)` and is therefore exempt from the arity rule
+(4.7:34 says the same value-context consumption applies to it).
+
+A discarded field — one covered by `_`, or by the bare form — is bound to a
+fresh *unnameable* binding: it is moved out of the scrutinee like any other
+payload binding, but no expression can name it. Consequently it is **dropped at
+the end of its arm**, interleaved with the arm's named bindings in the usual
+reverse-declaration order (3.9:4), not before the arm's body and not as part of
+the scrutinee. A discarded field whose type carries a linear value is a
+compile-time error: nothing can name that binding, so its must-consume
+obligation (3.8:50) could never be discharged. Bind such a field by name and
+consume it — `@drop` (3.9:37) is the explicit-discard escape hatch.
 
 {{ rule(id="4.7:31", cat="normative") }}
 
@@ -273,10 +286,11 @@ the match has already used.
 {{ rule(id="4.7:34", cat="legality-rule") }}
 
 A move-type scrutinee is consumed by the match independently of whether the matched
-arm binds a payload. A match whose selected arm binds nothing — a bare variant
-pattern, a wildcard `_`, or a literal pattern — still moves a move-type scrutinee,
-because the scrutinee occurs in value context regardless of the pattern. Using the
-scrutinee after such a match is therefore a use-after-move error (3.8:5).
+arm binds a payload *by name*. A match whose selected arm introduces no name — a
+bare variant pattern (which is the all-wildcard form, 4.7:30), a wildcard `_`, or a
+literal pattern — still moves a move-type scrutinee, because the scrutinee occurs in
+value context regardless of the pattern. Using the scrutinee after such a match is
+therefore a use-after-move error (3.8:5).
 
 {{ rule(id="4.7:35", cat="example") }}
 
@@ -306,7 +320,7 @@ fn use_again(e: E) -> i32 { 0 }
 fn main() -> i32 {
     let e = E.A(Big { value: 7 });   // move type: Big is not Copy
     let r = match e {
-        E.A => 1,                    // binds nothing, yet consumes `e`
+        E.A => 1,                    // introduces no name, yet consumes `e`
         E.B => 2,
     };
     r + use_again(e)                  // ERROR: use of moved value 'e'


### PR DESCRIPTION
Two fixes from the 2026-08-22 spec audit, developed in isolated worktrees and integrated onto current trunk with hand re-verification of every repro at -O0 and -O2 plus cross-mechanism tests at their seam.

## Commit 1: confine destructuring consumption to declared-linear structs

A struct that is linear only by infection (a field carries a linear value) was modeled as whole-value destructuring consumption on any field access. Consequences: consuming the linear field (`sink(c.l)`) **silently skipped the sibling's destructor** (a drop leak in accepted safe code, violating spec 3.8:60 and the core's no-leak theorem), and Copy-sibling reads were over-rejected (E0474 before the move, E0205 after).

The fix keys the destructure on a new `struct_declared_linear` predicate: declared-`linear` structs keep whole-value semantics (3.8:33/3.8:74); infectious carriers take the ordinary partial-move + residue path, with the must-consume obligation tracked per linear sub-place at scope exit (core §5.6 `residual-linear`). The declared-linear husk acceptance is an open maintainer decision and is pinned unchanged by a dedicated test. E0474 is narrowed to its remaining legitimate role; no new error codes. Amends spec 3.8:33/3.8:60/3.8:61 and the core's divergence notes.

## Commit 2: elaborate discarded match payloads as unnameable arm bindings

Per the ruling recorded on the tracker issue (2026-08-22): a payload position that binds no name — `_`, or any position of the bare all-wildcard variant form — is a fresh unnameable binding. It owns a frame slot, registers in no scope, and drops at the **arm's end** interleaved with named siblings in reverse declaration order, replacing the eager pre-body extract-and-drop. A **linear** payload in such a position could never discharge must-consume and is rejected up front with new **E0486**, with named binding or `@drop` as escape hatches; previously it compiled silently. The bare variant form is the all-wildcard case of the arity rule (parenthesized arity mismatches keep E0207). Three destructor-order goldens flipped deliberately under the ruling, each cited in its case comment. Amends spec 4.7:30/4.7:34–36 and retires the core's stale divergence note.

## Validation

- All briefed repros reproduced on unmodified trunk first, then re-verified fixed on the integrated branch by execution, exact stdout and exit codes, at -O0 and -O2; aarch64 checked via `--emit asm` plus a native CLI case.
- Cross-mechanism tests at the seam (linear-carrying structs as match payloads): `_`-discard rejection, arm-bound carrier consuming its linear field with the sibling destructor firing exactly once, mixed carrier + `_` arm ordering.
- New coverage: 25+ CLI cases with exact drop-order assertions (including -O2 and aarch64 variants), 13 spec cases citing the amended paragraphs; traceability at 100%.
- Full suite on the integrated branch: 231 pass / 0 fail / 0 timeout, clippy gates included; formatting clean.

Fixes RUE-1591
Fixes RUE-1592