### PR TITLE
Enforce linear must-consume on match-arm payload bindings

### DIFF
--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -1229,6 +1229,18 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let body_result = self.analyze_inst(air, *body, ctx)?;
             let body_type = body_result.ty;
 
+            // Payload bindings are ordinary locals living in the ARM scope,
+            // not in the body's own block scope, so the block-exit
+            // must-consume check never sees them (RUE-1603). Enforce the
+            // linear obligation here, exactly as `analyze_block` does before
+            // its pop: unconditionally (a diverging body discharges the
+            // obligation only by actually consuming the value on that path),
+            // per arm (this arm's own move state, before it is harvested
+            // below). Unnameable positions (RUE-1592) are registered in no
+            // scope and were already rejected up front when linear (E0486),
+            // so this visits exactly the named bindings.
+            self.check_unconsumed_linear_values(ctx)?;
+
             ctx.pop_scope();
             arm_move_states.push((std::mem::take(&mut ctx.moved_vars), body_type.is_never()));
 

--- a/crates/rue-cli-tests/cases/linear_must_consume.toml
+++ b/crates/rue-cli-tests/cases/linear_must_consume.toml
@@ -419,3 +419,82 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 42
+
+# ---------------------------------------------------------------------------
+# RUE-1603: a NAMED match-arm payload binding is an ordinary local in the ARM
+# scope, so a linear one must be consumed there. The arm scope used to be
+# popped without the block-exit linear leak check, so these leaked silently.
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "linear_match_payload_binding_unconsumed_rejected"
+description = "A named linear payload binding left unconsumed in its arm is a leak (RUE-1603; compiled silently before)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+enum E { A(L), B }
+fn main() -> i32 {
+    let e = E.A(L { v: 5 });
+    match e { E.A(x) => 1, E.B => 2 }
+}
+""" }]
+compile_fail = true
+error_contains = ["E0406", "linear value 'x' must be consumed"]
+
+[[case]]
+name = "linear_match_carrier_payload_binding_names_residual_place"
+description = "A linear-carrying struct payload binding left unconsumed names the residual sub-place (RUE-1603)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+struct D { d: i32 }
+struct C { l: L, d: D }
+enum E2 { A(C), B }
+fn main() -> i32 {
+    let e = E2.A(C { l: L { v: 5 }, d: D { d: 6 } });
+    match e { E2.A(c) => 1, E2.B => 2 }
+}
+""" }]
+compile_fail = true
+error_contains = ["E0406", "'c.l' still holds a linear value"]
+
+[[case]]
+name = "linear_match_payload_binding_one_branch_rejected"
+description = "A payload binding consumed on only one branch of the arm body is E0443, like any linear local (RUE-1603)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+enum E { A(L), B }
+fn sink(x: L) -> i32 { x.v }
+fn main() -> i32 {
+    let c = true;
+    let e = E.A(L { v: 5 });
+    match e { E.A(x) => if c { sink(x) } else { 0 }, E.B => 2 }
+}
+""" }]
+compile_fail = true
+error_contains = ["E0443", "not consumed on all paths"]
+
+[[case]]
+name = "linear_match_payload_binding_drop_hatch_runs"
+description = "Control: @drop discharges a named linear payload binding's obligation and the program runs (RUE-1603)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+enum E { A(L), B }
+fn main() -> i32 {
+    let e = E.A(L { v: 5 });
+    match e { E.A(x) => { @drop(x); 42 }, E.B => 2 }
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "linear_match_payload_binding_consumed_runs"
+description = "Control: consuming the payload binding in the arm body compiles and runs (RUE-1603)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+enum E { A(L), B }
+fn sink(x: L) -> i32 { x.v }
+fn main() -> i32 {
+    let e = E.A(L { v: 40 });
+    match e { E.A(x) => sink(x) + 2, E.B => 2 }
+}
+""" }]
+exit_code = 42

--- a/crates/rue-spec/cases/expressions/match.toml
+++ b/crates/rue-spec/cases/expressions/match.toml
@@ -1072,6 +1072,127 @@ fn main() -> i32 {
 """
 exit_code = 42
 
+# A NAMED payload binding is an ordinary local living in its arm's scope, so
+# a linear one carries the usual must-consume obligation there (4.7:31,
+# 3.8:32). This compiled silently before RUE-1603: the arm scope was popped
+# without the linear leak check that block exit runs.
+[[case]]
+name = "match_named_linear_payload_binding_unconsumed_rejected"
+spec = ["4.7:31", "3.8:32", "3.8:35"]
+source = """
+linear struct L { v: i32 }
+enum E { A(L), B }
+fn main() -> i32 {
+    let e = E.A(L { v: 5 });
+    match e {
+        E.A(x) => 1,
+        E.B => 2,
+    }
+}
+"""
+compile_fail = true
+error_contains = ["E0406", "'x'"]
+
+# Control: consuming the binding in the arm body discharges the obligation.
+[[case]]
+name = "match_named_linear_payload_binding_consumed_is_legal"
+spec = ["4.7:31", "3.8:32"]
+source = """
+linear struct L { v: i32 }
+enum E { A(L), B }
+fn sink(x: L) -> i32 { x.v }
+fn main() -> i32 {
+    let e = E.A(L { v: 5 });
+    match e {
+        E.A(x) => sink(x) + 37,
+        E.B => 2,
+    }
+}
+"""
+exit_code = 42
+
+# The obligation is per-path (3.8:50): a binding consumed in only one branch
+# of the arm body leaks on the other.
+[[case]]
+name = "match_linear_payload_binding_one_branch_consumption_rejected"
+spec = ["4.7:31", "3.8:50", "3.8:52"]
+source = """
+linear struct L { v: i32 }
+enum E { A(L), B }
+fn sink(x: L) -> i32 { x.v }
+fn main() -> i32 {
+    let c = true;
+    let e = E.A(L { v: 5 });
+    match e {
+        E.A(x) => if c { sink(x) } else { 0 },
+        E.B => 2,
+    }
+}
+"""
+compile_fail = true
+error_contains = ["E0443", "not consumed on all paths"]
+
+# An infectious carrier bound from a payload behaves like any carrier local
+# (3.8:58, 3.8:60): the obligation attaches to its linear sub-places, and a
+# leaked sub-place is named at the arm's end.
+[[case]]
+name = "match_linear_carrier_payload_binding_unconsumed_rejected"
+spec = ["4.7:31", "3.8:32", "3.8:58"]
+source = """
+linear struct L { v: i32 }
+struct D { d: i32 }
+struct C { l: L, d: D }
+enum E2 { A(C), B }
+fn main() -> i32 {
+    let e = E2.A(C { l: L { v: 5 }, d: D { d: 6 } });
+    match e {
+        E2.A(c) => 1,
+        E2.B => 2,
+    }
+}
+"""
+compile_fail = true
+error_contains = ["E0406", "'c.l' still holds a linear value"]
+
+# A diverging arm body is exempt only on paths that actually consume or
+# diverge before scope exit (3.8:51): consuming on the surviving branch and
+# returning on the other is legal from an arm exactly as from a block.
+[[case]]
+name = "match_linear_payload_binding_diverging_branch_is_exempt"
+spec = ["4.7:31", "3.8:51"]
+source = """
+linear struct L { v: i32 }
+enum E { A(L), B }
+fn sink(x: L) -> i32 { x.v }
+fn main() -> i32 {
+    let c = true;
+    let e = E.A(L { v: 37 });
+    match e {
+        E.A(x) => if c { sink(x) + 5 } else { return 0 },
+        E.B => 2,
+    }
+}
+"""
+exit_code = 42
+
+# `@drop` is the explicit-discard escape hatch for a named linear payload
+# binding, exactly as for any linear local (3.9:37).
+[[case]]
+name = "match_named_linear_payload_binding_drop_hatch"
+spec = ["4.7:31", "3.9:37"]
+source = """
+linear struct L { v: i32 }
+enum E { A(L), B }
+fn main() -> i32 {
+    let e = E.A(L { v: 5 });
+    match e {
+        E.A(x) => { @drop(x); 42 },
+        E.B => 2,
+    }
+}
+"""
+exit_code = 42
+
 # Bindings move the payload out in value context and are usable in the arm
 # body (4.7:31).
 [[case]]

--- a/docs/spec/src/04-expressions/07-match-expressions.md
+++ b/docs/spec/src/04-expressions/07-match-expressions.md
@@ -254,7 +254,10 @@ Payload bindings inherit the scrutinee's access mode (ADR-0037/ADR-0038). A
 bare `match e` uses the scrutinee in value context: the matched arm's bindings
 **move** the payload out of the enum (or copy it, if the payload type is
 `Copy`). Each binding is in scope for its arm's body and shadows any outer
-binding of the same name.
+binding of the same name. A named payload binding is an ordinary local
+binding: one whose type carries a linear value (3.8:57) is subject to the
+must-consume obligation (3.8:32, 3.8:50) at the end of its arm, exactly as a
+`let` binding is at the end of its block.
 
 {{ rule(id="4.7:32") }}
 


### PR DESCRIPTION
Closes the third hole in the linear-discard family, found during the integration of #2557 and verified pre-existing on trunk: a **named** match-arm binding of a linear payload left unconsumed compiled silently — the linear value was dropped with no diagnostic.

```rue
linear struct L { v: i32 }
enum E { A(L), B }
fn main() -> i32 {
    let e = E.A(L { v: 5 });
    match e { E.A(x) => 1, E.B => 2 }   // compiled silently; now E0406
}
```

## Root cause and fix

`check_unconsumed_linear_values` had a single call site at block exit, but payload bindings live in the **arm's own scope** (pushed in `analyze_match`, popped without the check), so the block-level walk never saw them. The fix is one call at the arm-scope exit, mirroring the block-exit site exactly: unconditional, per arm, on that arm's own move state, before the state is harvested. Everything else comes from the shared machinery unchanged — E0406 naming the binding, E0443 for consumption on only some paths, the residual sub-place note for linear-carrying payloads (`'c.l' still holds a linear value`), and the infection note. No new error codes, no elaboration or drop-scheduling changes. The unnameable `_` positions from the previous PR are registered in no scope and already rejected up front (E0486), so there is no double-report.

Spec 4.7:31 gains one sentence stating that a named payload binding carries the ordinary must-consume obligation at the end of its arm.

## Validation

- Both repros (direct linear payload; linear-carrying struct payload with unconsumed sub-place) reproduced on unmodified trunk first, then verified rejected on this branch by execution.
- Controls verified unchanged: consumed bindings, `@drop` in the arm, a diverging arm that consumes on the return path, `E.A(_)`/bare-form E0486, and `let`-bound enforcement. One-branch consumption yields E0443. Diverging-arm and `_`-prefixed-name behavior matched against the block-level equivalents.
- New coverage: 6 spec cases citing 4.7:31 and the 3.8 obligation paragraphs, 5 CLI cases with exact diagnostics.
- Full suite: 231 pass / 0 fail / 0 timeout, clippy included; formatting clean.

Fixes RUE-1603

---
_Generated by [Claude Code](https://claude.ai/code/session_01JekaZ8oUGSZPXQeodh3sy8)_