### PR TITLE
RUE-1598: correct spec diagnostic mappings

### DIFF
--- a/crates/rue-spec/cases/items/general.toml
+++ b/crates/rue-spec/cases/items/general.toml
@@ -42,7 +42,7 @@ struct Point { y: i32 }
 fn main() -> i32 { 0 }
 """
 compile_fail = true
-error_contains = "duplicate type"
+error_contains = ["E0405", "duplicate type"]
 
 [[case]]
 name = "duplicate_enum_definitions"
@@ -54,7 +54,7 @@ enum Color { Blue, Yellow }
 fn main() -> i32 { 0 }
 """
 compile_fail = true
-error_contains = "duplicate type"
+error_contains = ["E0405", "duplicate type"]
 
 [[case]]
 name = "struct_and_enum_same_name"
@@ -66,7 +66,7 @@ enum Point { Up, Down }
 fn main() -> i32 { 0 }
 """
 compile_fail = true
-error_contains = "duplicate type"
+error_contains = ["E0405", "duplicate type"]
 
 # =============================================================================
 # Valid Type Names

--- a/crates/rue-spec/cases/modules/composition.toml
+++ b/crates/rue-spec/cases/modules/composition.toml
@@ -89,6 +89,54 @@ compile_fail = true
 error_contains = "E0436"
 
 [[case]]
+name = "same_file_duplicate_constant_error"
+spec = ["10.5:1"]
+description = "Two top-level const declarations with one name in ONE file produce E0418"
+source = """
+const LIMIT: i32 = 1;
+const LIMIT: i32 = 2;
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0418", "duplicate constant"]
+
+[[case]]
+name = "same_file_duplicate_type_error"
+spec = ["10.5:1"]
+description = "Two top-level type declarations with one name in ONE file produce E0405"
+source = """
+struct Point { x: i32 }
+struct Point { y: i32 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0405", "duplicate type"]
+
+[[case]]
+name = "same_file_type_function_collision_error"
+spec = ["10.5:1"]
+description = "A type and a function sharing one name in ONE file collide across kinds (E0436)"
+source = """
+struct Point { x: i32 }
+fn Point() -> i32 { 2 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0436", "Point"]
+
+[[case]]
+name = "same_file_type_constant_collision_error"
+spec = ["10.5:1"]
+description = "A type and a constant sharing one name in ONE file collide across categories (E0436)"
+source = """
+enum Color { Red, Green }
+const Color: i32 = 1;
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0436", "Color"]
+
+[[case]]
 name = "same_named_functions_qualified_calls_sum"
 spec = ["10.5:3"]
 description = "The 10.5:3 example: same-named functions in two modules, each call resolving in its own module"

--- a/docs/spec/src/02-lexical-structure/04-keywords.md
+++ b/docs/spec/src/02-lexical-structure/04-keywords.md
@@ -39,7 +39,7 @@ The following words are keywords and cannot be used as identifiers:
 | `false` | Boolean literal |
 | `struct` | Struct definition |
 | `enum` | Enum definition |
-| `impl` | Impl block |
+| `impl` | Reserved syntax; Rue has no impl-block construct (6.0:1a) |
 | `self` | Self parameter in methods |
 | `drop` | Destructor declaration |
 | `pub` | Public visibility modifier |

--- a/docs/spec/src/03-types/09-destructors.md
+++ b/docs/spec/src/03-types/09-destructors.md
@@ -179,7 +179,7 @@ drop fn TypeName(self) {
 
 {{ rule(id="3.9:25", cat="normative") }}
 
-A user-defined destructor for a *named* struct type **MUST** be declared at the top level, outside of any `impl` block. It **MUST** take exactly one parameter named `self` and return nothing (implicit unit type). (A destructor for an *anonymous* struct type is declared inside the struct body instead; see 3.9:41.)
+A user-defined destructor for a *named* struct type **MUST** be declared as a top-level declaration. Methods and associated functions are declared inline in struct bodies (6.4), not as separate top-level declarations. The destructor **MUST** take exactly one parameter named `self` and return nothing (implicit unit type). (A destructor for an *anonymous* struct type is declared inside the struct body instead; see 3.9:41.)
 
 {{ rule(id="3.9:26", cat="legality-rule") }}
 
@@ -208,7 +208,7 @@ drop fn FileHandle(self) {
 
 {{ rule(id="3.9:30", cat="informative") }}
 
-The `drop fn` syntax was chosen because it clearly indicates the purpose of the function while being distinct from regular functions and methods. The destructor is not part of any impl block because it has special calling semantics: it is invoked automatically by the compiler when values go out of scope.
+The `drop fn` syntax was chosen because it clearly indicates the purpose of the function while being distinct from regular functions and methods. The destructor is a top-level declaration rather than an inline struct-body method or associated function because it has special calling semantics: it is invoked automatically by the compiler when values go out of scope.
 
 {{ rule(id="3.9:31", cat="legality-rule") }}
 

--- a/docs/spec/src/06-items/_index.md
+++ b/docs/spec/src/06-items/_index.md
@@ -42,7 +42,7 @@ implementations under a type the way an `impl` block does in other languages.
 
 {{ rule(id="6.0:2", cat="legality-rule") }}
 
-User-defined type names (structs and enums) **MUST** be unique within their defining module (source file). Defining multiple types with the same name in one file produces a compile-time error (E0436; this is the per-file check of 10.5:1). Distinct modules **MAY** each define a type with the same name (10.5:2); declarations in other modules do not participate in this check and do not constrain the names a module may define.
+User-defined type names (structs and enums) **MUST** be unique within their defining module (source file). Defining multiple types with the same name in one file produces a compile-time error (E0405; this is the per-file check of 10.5:1). Distinct modules **MAY** each define a type with the same name (10.5:2); declarations in other modules do not participate in this check and do not constrain the names a module may define.
 
 {{ rule(id="6.0:3", cat="legality-rule") }}
 

--- a/docs/spec/src/10-modules/05-program-composition.md
+++ b/docs/spec/src/10-modules/05-program-composition.md
@@ -29,10 +29,14 @@ diagnostic that points at `@import` and `--source-manifest`.
 {{ rule(id="10.5:1", cat="legality-rule") }}
 
 It is a compile-time error for one source file to define two top-level
-items with the same name, whether of the same kind (duplicate definition,
-E0436) or of different kinds (a `const` and a `fn` sharing a name, also
-E0436). This check is per-file: it never considers items in other loaded
-files.
+declarations with the same name among user-defined types (structs and enums),
+constants, and functions. Within one declaration category, any pair of
+user-defined type declarations (including a struct/enum pair) produces E0405,
+a const/const collision produces E0418, and a fn/fn collision produces E0436.
+A collision across those three declaration categories produces E0436. This
+check is per-file: it never considers items in other loaded files. Other
+constructs with distinct duplicate diagnostics, such as user-defined
+destructors (3.9:26), retain their own rules.
 
 {{ rule(id="10.5:2", cat="normative") }}
 

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -284,8 +284,8 @@ Notes:
   statements require `;`. Control-flow expressions (`if`, `match`, `while`,
   `loop`, `for`, `break`, `continue`, `return`) and bare blocks may appear as
   statements without a trailing semicolon.
-- There are no `impl` blocks: methods are declared inline inside the
-  `struct` body, after the fields.
+- There is no `impl`-block construct (`impl` remains reserved syntax; 2.4:2):
+  methods are declared inline inside the `struct` body, after the fields.
 - **Method receivers** may carry a mode: `inout self` (mutating receiver) or
   `borrow self` (read-only receiver); a bare `self` is by-value. This mirrors
   the `inout`/`borrow` parameter modes; `comptime self` is not permitted.


### PR DESCRIPTION
## Summary
- align normative duplicate-definition codes with compiler declaration categories
- clarify that impl is reserved while Rue has no impl-block construct
- describe named destructors as top-level declarations and inline struct members accurately
- add focused E0405, E0418, and E0436 spec traceability

## Validation
- scripts/rue fmt
- scripts/rue quick
- scripts/rue premerge
- spec traceability target
- focused 2.4, 3.9, 6.0, and 10.5 spec cases
- focused impl UI and reserved-keyword/duplicate-name CLI cases

Fixes RUE-1598