### PR TITLE
Reject direct sibling by-ref use of an accessor-borrowed root (6.6:10)

### DIFF
--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -1221,6 +1221,28 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ctx.call_loaned_roots.pop();
         }
         let args_result = args_result?;
+        // Re-check the receiver after the argument list is analyzed
+        // (RUE-1593): an accessor expanded among this call's own arguments
+        // (`p.bump_with(p.f())`) registered its loan only during argument
+        // analysis, after the pre-frame receiver check above. The by-ref
+        // receiver access spans the same full expression as that loan, so it
+        // is rejected in either evaluation order (spec 6.6:10, 6.6:16,
+        // E0259). A receiver reached through an accessor result has already
+        // been checked against its own loan above.
+        match (receiver_mode, receiver_var) {
+            (AirArgMode::Inout, Some(root)) => {
+                self.reject_accessor_loan_conflict(root, "as an `inout self` receiver", span, ctx)?;
+            }
+            (AirArgMode::Borrow, Some(root)) => {
+                self.reject_accessor_shared_loan_conflict(
+                    root,
+                    "as a `borrow self` receiver",
+                    span,
+                    ctx,
+                )?;
+            }
+            _ => {}
+        }
         air_args.extend(args_result.args);
         // The receiver's materialized owner is entered first: it is created
         // before any explicit operand, so its scope must be the outer one.

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -5339,9 +5339,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             })
             .collect();
         // An `inout` loan on a root an accessor result borrows in the same
-        // full expression violates exclusivity (ADR-0062, E0259). Checked at
-        // frame construction (loans taken by earlier sibling arguments) and
-        // again by accessor expansion itself (the reverse nesting order).
+        // full expression violates exclusivity (ADR-0062, E0259). Checked
+        // three times: here at frame construction (loans taken earlier in the
+        // enclosing expression, e.g. by an already-analyzed sibling of an
+        // outer call), by accessor expansion's frame check (an accessor
+        // expanded under an outer call's live by-ref frame), and again after
+        // this argument list is analyzed (loans registered by THIS call's own
+        // accessor arguments — the direct sibling forms, RUE-1593).
         for arg in args.clone() {
             if !arg.is_inout() && !arg.is_borrow() {
                 continue;
@@ -5368,11 +5372,45 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if pushed {
             ctx.call_loaned_roots.push(frame);
         }
-        let result = self.analyze_call_args_coerced_inner(air, args, param_types, param_modes, ctx);
+        let result =
+            self.analyze_call_args_coerced_inner(air, args.clone(), param_types, param_modes, ctx);
         if pushed {
             ctx.call_loaned_roots.pop();
         }
-        result
+        let result = result?;
+        // Re-check after the argument list is analyzed (RUE-1593): an accessor
+        // expanded among THIS call's own arguments registered its loan in
+        // `ctx.expression_loans` only during the inner analysis, after the
+        // pre-frame check above ran. A direct sibling by-ref use of the same
+        // root — `use(v.get_ref(i), inout v)` or `use(inout v, v.get_ref(i))` —
+        // is an exclusive use of the borrowed root within the same full
+        // expression and is rejected in either argument order (spec 6.6:10,
+        // 6.6:16, E0259). Args whose place roots through an accessor chain
+        // (`f(inout v.get_mut(i))`) have no plain root variable here and are
+        // governed by accessor expansion's own frame check instead.
+        for arg in args {
+            if !arg.is_inout() && !arg.is_borrow() {
+                continue;
+            }
+            if let Some(root) = root_variable_of(self.body_rir_ref(), arg.value) {
+                if arg.is_inout() {
+                    self.reject_accessor_loan_conflict(
+                        root,
+                        "as `inout`",
+                        self.body_rir_ref().get(arg.value).span,
+                        ctx,
+                    )?;
+                } else {
+                    self.reject_accessor_shared_loan_conflict(
+                        root,
+                        "as `borrow`",
+                        self.body_rir_ref().get(arg.value).span,
+                        ctx,
+                    )?;
+                }
+            }
+        }
+        Ok(result)
     }
 
     /// The argument loop behind [`Self::analyze_call_args_coerced`], factored

--- a/crates/rue-spec/cases/items/borrow-accessors.toml
+++ b/crates/rue-spec/cases/items/borrow-accessors.toml
@@ -867,6 +867,132 @@ compile_fail = true
 error_contains = ["E0259", "while an accessor result borrows it"]
 
 [[case]]
+name = "accessor_loan_conflicts_with_direct_sibling_inout"
+spec = ["6.6:10"]
+description = "A direct `inout` argument of the very call consuming the accessor result is an exclusive use of the borrowed root (E0259, RUE-1593)."
+source = """
+struct Grid {
+    cells: [i64; 4],
+
+    fn at(borrow self, i: u64) -> borrow i64 {
+        yield self.cells[i];
+    }
+}
+fn using(a: i64, inout g: Grid) -> i64 {
+    g.cells[0] = 9;
+    a
+}
+fn main() -> i32 {
+    let mut g = Grid { cells: [1, 2, 3, 4] };
+    using(g.at(0), inout g);
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0259", "as `inout` while an accessor result borrows it"]
+
+[[case]]
+name = "accessor_loan_conflicts_with_direct_sibling_inout_reversed"
+spec = ["6.6:10", "6.6:16"]
+description = "The direct sibling `inout` conflict is rejected in the reverse argument order too (E0259, RUE-1593)."
+source = """
+struct Grid {
+    cells: [i64; 4],
+
+    fn at(borrow self, i: u64) -> borrow i64 {
+        yield self.cells[i];
+    }
+}
+fn using(inout g: Grid, a: i64) -> i64 {
+    g.cells[0] = 9;
+    a
+}
+fn main() -> i32 {
+    let mut g = Grid { cells: [1, 2, 3, 4] };
+    using(inout g, g.at(0));
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0259", "as `inout` while an accessor result borrows it"]
+
+[[case]]
+name = "mutable_accessor_loan_conflicts_with_direct_sibling_inout"
+spec = ["6.6:10", "6.6:16"]
+description = "An exclusive accessor result also conflicts with a direct sibling `inout` of its root (E0259, RUE-1593)."
+source = """
+struct Grid {
+    cells: [i64; 4],
+
+    fn at_mut(inout self, i: u64) -> inout i64 {
+        yield self.cells[i];
+    }
+}
+fn using(a: i64, inout g: Grid) -> i64 {
+    g.cells[0] = 9;
+    a
+}
+fn main() -> i32 {
+    let mut g = Grid { cells: [1, 2, 3, 4] };
+    using(g.at_mut(0), inout g);
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0259", "as `inout` while an accessor result borrows it"]
+
+[[case]]
+name = "accessor_loan_conflicts_with_direct_inout_self_receiver"
+spec = ["6.6:10"]
+description = "An `inout self` receiver of the very call consuming the accessor result is an exclusive use of the borrowed root (E0259, RUE-1593)."
+source = """
+struct Grid {
+    cells: [i64; 4],
+
+    fn at(borrow self, i: u64) -> borrow i64 {
+        yield self.cells[i];
+    }
+
+    fn store(inout self, v: i64) -> i64 {
+        self.cells[0] = v;
+        v
+    }
+}
+fn main() -> i32 {
+    let mut g = Grid { cells: [1, 2, 3, 4] };
+    g.store(g.at(1));
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0259", "as an `inout self` receiver while an accessor result borrows it"]
+
+[[case]]
+name = "accessor_read_before_inout_call_is_legal"
+spec = ["6.6:8", "6.6:10"]
+description = "The accessor loan ends with its full expression: reading the result in a prior statement, then calling with `inout`, is legal (RUE-1593)."
+source = """
+struct Cell { value: i64 }
+struct Grid {
+    cells: [Cell; 2],
+
+    fn at(borrow self, i: u64) -> borrow Cell {
+        yield self.cells[i];
+    }
+}
+fn using(a: i64, inout g: Grid) -> i64 {
+    g.cells[0].value = 9;
+    a
+}
+fn main() -> i32 {
+    let mut g = Grid { cells: [Cell { value: 1 }, Cell { value: 2 }] };
+    let first = g.at(0).value;
+    if using(first, inout g) == 1 && g.cells[0].value == 9 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
 name = "accessor_result_drop_glue_read_rejected"
 spec = ["6.6:11"]
 description = "Reading an owning (drop-glue) value out of an accessor result by value is rejected (E0258)."

--- a/docs/spec/src/06-items/06-borrow-accessors.md
+++ b/docs/spec/src/06-items/06-borrow-accessors.md
@@ -106,7 +106,11 @@ an exclusive use conflicts with every active accessor loan. An
 exclusive use of the borrowed root — passing it `inout`, an `inout self`
 receiver access, assigning to it, or moving it — anywhere within the same full
 expression is rejected (E0259). `use(v.get_ref(i), g(inout v))` is ill-formed
-even though the read syntactically precedes the exclusive access.
+even though the read syntactically precedes the exclusive access. When the
+accessor result is itself re-borrowed as a `borrow` argument of the same call
+(`use(borrow v.get_ref(i), inout v)`), the conflict is caught by the general
+argument-exclusivity rule and surfaces as its diagnostic (E0430) rather than
+E0259; the program is rejected either way.
 
 {{ rule(id="6.6:11", cat="legality-rule") }}
 


### PR DESCRIPTION
Closes the accessor-exclusivity gap found by the 2026-08-22 spec audit on the freshly-stabilized accessor surface: spec 6.6:10 rejects any exclusive use of an accessor-borrowed root within the same full expression (E0259, "in either evaluation order" per 6.6:16), but the compiler accepted the **direct sibling** form — an `inout` argument of the very call consuming the accessor result:

```rue
use2(p.f(), inout p)      // compiled on trunk; now E0259 — both argument orders
p.bump_with(p.f())        // inout-self receiver form; now E0259
```

## Root cause and fix

The E0259 check runs at frame construction, **before** the argument list is analyzed — but a sibling accessor argument registers its expression-scoped loan only **during** argument analysis. The intended second line of defense (accessor expansion's frame check) deliberately exempts the innermost by-ref frame so `f(inout v.get_mut(i))` doesn't conflict with its own enclosing use — and that exemption also swallowed a plain sibling `inout p`. The fix re-runs the same per-argument accessor-loan checks **after** the argument list is analyzed, when this call's own loans are visible, and mirrors the post-check for a method call's by-ref receiver. Accessor-rooted by-ref arguments have no plain root at that point and are skipped, preserving the exemption's legitimate case. Analysis-only; the exact existing E0259 diagnostic texts; no new error codes.

Spec 6.6:10 gains a note that the shared re-borrow variant (`use(borrow v.get_ref(i), inout v)`) surfaces as the general argument-exclusivity diagnostic (E0430) — rejected either way, attribution now stated.

## Validation

- Both direct argument orders, the std `ArrayBuf.get_ref` variant, and the receiver form reproduced as accepted on unmodified trunk, then verified rejected with E0259 on this branch by execution.
- Controls byte-identical: nested form E0259, `inout`-self method sibling E0259, exclusive-result variant E0426, shared variant E0430.
- Legal patterns verified unchanged: `use1(p.f())`, `set(inout v.get_mut(i))`, and the split-statement form.
- New coverage: 5 spec cases on 6.6:10/6.6:16 including a legal control; no std or corpus fallout.
- Full suite: 231 pass / 0 fail / 0 timeout, clippy included; formatting clean.

One adjacent shape (`use_two(g(inout p), p.f())` — a completed nested exclusive use before the accessor loan) remains accepted; it needs an expression-scoped record of completed uses and is tracked separately in the tracker as a follow-up.

Fixes RUE-1593

---
_Generated by [Claude Code](https://claude.ai/code/session_01JekaZ8oUGSZPXQeodh3sy8)_