### PR TITLE
RUE-1599: propagate diverging statements through blocks

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -190,12 +190,30 @@ pub struct ExprInfo {
     pub ty: InferType,
     /// The span of this expression (for error reporting).
     pub span: Span,
+    /// Whether evaluation reaches its enclosing expression normally.
+    pub continues: bool,
 }
 
 impl ExprInfo {
     /// Create a new expression info.
     pub fn new(ty: InferType, span: Span) -> Self {
-        Self { ty, span }
+        Self {
+            ty,
+            span,
+            continues: true,
+        }
+    }
+
+    pub fn with_continues(ty: InferType, span: Span, continues: bool) -> Self {
+        Self {
+            ty,
+            span,
+            continues,
+        }
+    }
+
+    pub fn diverged(ty: InferType, span: Span) -> Self {
+        Self::with_continues(ty, span, false)
     }
 }
 
@@ -221,6 +239,8 @@ pub struct ConstraintGenerator<'a> {
     /// are later a sort key (`sort_unstable_by_key(Type::as_u32)`). The order
     /// is observable, so the hasher is not a free choice here.
     expr_types: HashMap<InstRef, InferType>,
+    /// Whether each generated expression reaches its next evaluation point.
+    expr_continues: HashMap<InstRef, bool>,
     /// Function signatures (for call type checking). `None` when the generator
     /// is driven by a lazy provider (`lazy`), which materializes signatures on
     /// demand; unit tests still supply an eager map.
@@ -395,6 +415,7 @@ impl<'a> ConstraintGenerator<'a> {
             type_vars: TypeVarAllocator::new(),
             constraints: Vec::with_capacity(rir_capacity),
             expr_types: HashMap::new(),
+            expr_continues: HashMap::new(),
             functions: Some(functions),
             builtin_structs: Some(builtin_structs),
             structs_by_file_name: None,
@@ -448,6 +469,7 @@ impl<'a> ConstraintGenerator<'a> {
             type_vars: TypeVarAllocator::new(),
             constraints: Vec::with_capacity(rir_capacity),
             expr_types: HashMap::new(),
+            expr_continues: HashMap::new(),
             functions: None,
             builtin_structs: None,
             structs_by_file_name: None,
@@ -952,6 +974,7 @@ impl<'a> ConstraintGenerator<'a> {
         Vec<TypeVarId>,
         Type,
         HashMap<InstRef, InferType>,
+        HashMap<InstRef, bool>,
         u32,
     ) {
         (
@@ -960,6 +983,7 @@ impl<'a> ConstraintGenerator<'a> {
             self.string_literal_vars,
             self.string_literal_default,
             self.expr_types,
+            self.expr_continues,
             self.type_vars.count(),
         )
     }
@@ -1018,6 +1042,7 @@ impl<'a> ConstraintGenerator<'a> {
     pub fn generate(&mut self, inst_ref: InstRef, ctx: &mut ConstraintContext) -> ExprInfo {
         let inst = self.rir.get(inst_ref);
         let span = inst.span;
+        let mut continues = true;
 
         let ty = match &inst.data {
             InstData::IntConst(_) => {
@@ -1066,20 +1091,20 @@ impl<'a> ConstraintGenerator<'a> {
             // concatenation (RUE-17 Phase 1, ADR-0035). Split out from the pure
             // arithmetic operators so it doesn't force an `is_integer`
             // constraint on String operands.
-            InstData::Add { lhs, rhs } => self.generate_add(*lhs, *rhs, ctx),
+            InstData::Add { lhs, rhs } => self.generate_add(inst_ref, *lhs, *rhs, ctx),
 
             // Binary arithmetic: both operands must have the same type, result is that type
             InstData::Sub { lhs, rhs }
             | InstData::Mul { lhs, rhs }
             | InstData::Div { lhs, rhs }
-            | InstData::Mod { lhs, rhs } => self.generate_binary_arith(*lhs, *rhs, ctx),
+            | InstData::Mod { lhs, rhs } => self.generate_binary_arith(inst_ref, *lhs, *rhs, ctx),
 
             // Bitwise operations: same as arithmetic
             InstData::BitAnd { lhs, rhs }
             | InstData::BitOr { lhs, rhs }
             | InstData::BitXor { lhs, rhs }
             | InstData::Shl { lhs, rhs }
-            | InstData::Shr { lhs, rhs } => self.generate_binary_arith(*lhs, *rhs, ctx),
+            | InstData::Shr { lhs, rhs } => self.generate_binary_arith(inst_ref, *lhs, *rhs, ctx),
 
             // Comparison operators: operands must match, result is bool
             InstData::Eq { lhs, rhs }
@@ -1090,6 +1115,7 @@ impl<'a> ConstraintGenerator<'a> {
             | InstData::Ge { lhs, rhs } => {
                 let lhs_info = self.generate(*lhs, ctx);
                 let rhs_info = self.generate(*rhs, ctx);
+                continues &= lhs_info.continues && rhs_info.continues;
                 // Operands must have the same type. (Chained comparisons are
                 // rejected at parse time — validate.rs, RUE-528 — so a
                 // comparison LHS reaching here is a legitimately
@@ -1102,6 +1128,10 @@ impl<'a> ConstraintGenerator<'a> {
             InstData::And { lhs, rhs } | InstData::Or { lhs, rhs } => {
                 let lhs_info = self.generate(*lhs, ctx);
                 let rhs_info = self.generate(*rhs, ctx);
+                // Logical operators short-circuit. A diverging RHS does not
+                // eliminate the LHS path that skips it, so only divergence of
+                // the always-evaluated LHS removes normal continuation.
+                continues &= lhs_info.continues;
                 self.add_constraint(Constraint::equal(
                     lhs_info.ty,
                     InferType::Concrete(Type::BOOL),
@@ -1118,6 +1148,7 @@ impl<'a> ConstraintGenerator<'a> {
             // Unary negation: operand must be signed integer
             InstData::Neg { operand } => {
                 let operand_info = self.generate(*operand, ctx);
+                continues &= operand_info.continues;
                 // Result type is the same as operand type
                 let result_ty = operand_info.ty.clone();
                 // Must be a signed integer
@@ -1128,6 +1159,7 @@ impl<'a> ConstraintGenerator<'a> {
             // Logical NOT: operand must be bool
             InstData::Not { operand } => {
                 let operand_info = self.generate(*operand, ctx);
+                continues &= operand_info.continues;
                 self.add_constraint(Constraint::equal(
                     operand_info.ty,
                     InferType::Concrete(Type::BOOL),
@@ -1139,6 +1171,7 @@ impl<'a> ConstraintGenerator<'a> {
             // Bitwise NOT: operand must be integer
             InstData::BitNot { operand } => {
                 let operand_info = self.generate(*operand, ctx);
+                continues &= operand_info.continues;
                 let result_ty = operand_info.ty.clone();
                 // Must be an integer type (signed or unsigned)
                 self.add_constraint(Constraint::is_integer(result_ty.clone(), span));
@@ -1152,6 +1185,7 @@ impl<'a> ConstraintGenerator<'a> {
             // full checking (operand is Option, enclosing fn returns Option).
             InstData::Try { operand } => {
                 let operand_info = self.generate(*operand, ctx);
+                continues &= operand_info.continues;
                 match &operand_info.ty {
                     InferType::Concrete(ty) => ty
                         .as_enum()
@@ -1200,6 +1234,7 @@ impl<'a> ConstraintGenerator<'a> {
                 iter_elem: _,
             } => {
                 let init_info = self.generate(*init, ctx);
+                continues &= init_info.continues;
 
                 let var_ty = if let Some(type_syntax) = type_annotation {
                     // Explicit type annotation - use it and constrain init to
@@ -1285,13 +1320,17 @@ impl<'a> ConstraintGenerator<'a> {
                     }
                 }
 
-                // Alloc produces unit type
+                // Alloc normally produces unit, but an initializer that
+                // cannot reach the binding never reaches that allocation.
+                // Preserve the declared binding type above while exposing
+                // bottom to the enclosing block.
                 InferType::Concrete(Type::UNIT)
             }
 
             // Assignment
             InstData::Assign { name, value } => {
                 let value_info = self.generate(*value, ctx);
+                continues &= value_info.continues;
                 // A local shadows a same-named parameter. Otherwise, constrain
                 // assignment against the declared parameter type too. Every
                 // `inout` whole assignment must be constrained before it can
@@ -1310,7 +1349,10 @@ impl<'a> ConstraintGenerator<'a> {
                     // A `str` target (ADR-0043 Phase 3, RUE-324) accepts a string
                     // literal (HM type `String`) by coercion; skip strict
                     // equality and let sema materialize the `str` on the store.
-                    if !self.is_slice_struct_type(target_ty.clone()) {
+                    if !self.is_slice_struct_type(target_ty.clone())
+                        && value_info.continues
+                        && !Self::is_never_concrete(&value_info.ty)
+                    {
                         // Constrain value to match variable type
                         self.add_constraint(Constraint::equal(value_info.ty, target_ty, span));
                     }
@@ -1322,19 +1364,25 @@ impl<'a> ConstraintGenerator<'a> {
             InstData::PlaceSet { place, value } => {
                 let place_info = self.generate(*place, ctx);
                 let value_info = self.generate(*value, ctx);
-                self.add_constraint(Constraint::equal(place_info.ty, value_info.ty, span));
+                continues &= place_info.continues && value_info.continues;
+                if value_info.continues {
+                    self.add_constraint(Constraint::equal(place_info.ty, value_info.ty, span));
+                }
                 InferType::Concrete(Type::UNIT)
             }
 
             // Return statement
             InstData::Ret(value) => {
+                continues = false;
                 if let Some(val_ref) = value {
                     let value_info = self.generate(*val_ref, ctx);
                     // Constrain return value to match function return type. A
                     // `str` return (ADR-0043 Phase 3, RUE-324) accepts a string
                     // literal (HM type `String`) by coercion; skip strict
                     // equality there and let sema materialize the `str`.
-                    if !self.is_slice_struct_type(InferType::Concrete(ctx.return_type)) {
+                    if value_info.continues
+                        && !self.is_slice_struct_type(InferType::Concrete(ctx.return_type))
+                    {
                         self.add_constraint(Constraint::equal(
                             value_info.ty,
                             InferType::Concrete(ctx.return_type),
@@ -1355,9 +1403,13 @@ impl<'a> ConstraintGenerator<'a> {
 
             // Accessor yield (ADR-0062): the yielded place must have the
             // accessor's declared element type `T` (the function's return
-            // type); the `yield` itself diverges like `return`.
+            // type). Accessor `yield` is represented with the never surface
+            // type, but its standalone accessor CFG preserves the yielded
+            // place as a distinguished reachable operand for call-site
+            // splicing, so it does not carry ordinary return divergence.
             InstData::Yield(value) => {
                 let value_info = self.generate(*value, ctx);
+                continues &= value_info.continues;
                 self.add_constraint(Constraint::equal(
                     value_info.ty,
                     InferType::Concrete(ctx.return_type),
@@ -1372,6 +1424,7 @@ impl<'a> ConstraintGenerator<'a> {
                 let function_key =
                     alias_target.or_else(|| self.function_by_file((span.file_id, *name)));
                 let args = self.rir.call_args(args);
+                let mut arg_diverged = false;
                 // `print(s)` / `println(s)` builtin free functions (RUE-1):
                 // generate the argument and yield unit. Semantic analysis
                 // validates the shared text family (`StrBuf`, `str`, `Str(N)`),
@@ -1381,9 +1434,9 @@ impl<'a> ConstraintGenerator<'a> {
                 // `fn print`/`fn println` (a user definition wins).
                 let is_print_builtin = function_key.is_none()
                     && matches!(self.interner.resolve(name), "print" | "println");
-                if is_print_builtin {
+                let result = if is_print_builtin {
                     for arg in args.iter() {
-                        self.generate(arg.value, ctx);
+                        arg_diverged |= !self.generate(arg.value, ctx).continues;
                     }
                     InferType::Concrete(Type::UNIT)
                 } else if let Some(func) = function_key.and_then(|key| self.func_sig(key)) {
@@ -1397,7 +1450,11 @@ impl<'a> ConstraintGenerator<'a> {
                         // Process all arguments once, collecting their inferred types
                         let arg_infos: Vec<ExprInfo> = args
                             .iter()
-                            .map(|arg| self.generate(arg.value, ctx))
+                            .map(|arg| {
+                                let info = self.generate(arg.value, ctx);
+                                arg_diverged |= !info.continues;
+                                info
+                            })
                             .collect();
 
                         // Build the type substitution map from comptime type arguments
@@ -1529,7 +1586,7 @@ impl<'a> ConstraintGenerator<'a> {
                         // panicking and process what we can.
                         // Still process all arguments to catch type errors within them
                         for arg in args.iter() {
-                            self.generate(arg.value, ctx);
+                            arg_diverged |= !self.generate(arg.value, ctx).continues;
                         }
                         // Return the declared return type (error will be caught in sema)
                         func.return_type.clone()
@@ -1537,6 +1594,7 @@ impl<'a> ConstraintGenerator<'a> {
                         // Generate constraints for each argument
                         for (arg, param_ty) in args.iter().zip(func.param_types.iter()) {
                             let arg_info = self.generate(arg.value, ctx);
+                            arg_diverged |= !arg_info.continues;
                             // Slice parameters coerce from an array argument
                             // (`borrow arr`); skip strict equality and let sema
                             // materialize the fat pointer (ADR-0043, RUE-322).
@@ -1554,9 +1612,15 @@ impl<'a> ConstraintGenerator<'a> {
                 } else {
                     // Unknown function - still process arguments for constraint generation
                     for arg in args.iter() {
-                        self.generate(arg.value, ctx);
+                        arg_diverged |= !self.generate(arg.value, ctx).continues;
                     }
                     InferType::Concrete(Type::ERROR)
+                };
+                if arg_diverged || Self::is_never_concrete(&result) {
+                    continues = false;
+                    result
+                } else {
+                    result
                 }
             }
 
@@ -1565,7 +1629,7 @@ impl<'a> ConstraintGenerator<'a> {
                 let intrinsic_name = self.interner.resolve(name);
                 let args = self.rir.intrinsic_args(args);
 
-                if intrinsic_name == "intCast"
+                let intrinsic_ty = if intrinsic_name == "intCast"
                     || intrinsic_name == "bitCast"
                     || intrinsic_name == "cast"
                 {
@@ -1585,6 +1649,7 @@ impl<'a> ConstraintGenerator<'a> {
                     let result_var = self.fresh_var();
                     InferType::Var(result_var)
                 } else if intrinsic_name == "panic" {
+                    continues = false;
                     // `@panic` diverges: it aborts the process and never returns,
                     // so its expression type is `!` (never), a control-transfer
                     // form that participates in never coercion (spec 3.4:2,
@@ -2018,14 +2083,23 @@ impl<'a> ConstraintGenerator<'a> {
                         self.generate(*arg_ref, ctx);
                     }
                     InferType::Var(self.fresh_var())
-                }
+                };
+                // Every intrinsic evaluates its operands strictly in source
+                // order.  Keep that control fact separate from the intrinsic's
+                // ordinary value type (notably `@assert`, which remains unit).
+                continues &= args
+                    .iter()
+                    .all(|arg_ref| self.expr_continues.get(&*arg_ref).copied().unwrap_or(true));
+                intrinsic_ty
             }
 
             InstData::InternalIntrinsic { intrinsic, args } => {
                 let args = self.rir.internal_intrinsic_args(args);
+                let mut args_continue = true;
                 for arg_ref in args {
-                    self.generate(arg_ref, ctx);
+                    args_continue &= self.generate(arg_ref, ctx).continues;
                 }
+                continues &= args_continue;
                 match intrinsic {
                     // The loop bound and next byte offset are usize (u64).
                     rue_rir::InternalIntrinsic::IterLen
@@ -2069,13 +2143,30 @@ impl<'a> ConstraintGenerator<'a> {
             InstData::Block { instructions } => {
                 self.enter_scope(ctx);
                 let mut last_ty = InferType::Concrete(Type::UNIT);
+                let mut diverged = false;
                 let block_insts = self.rir.block_insts(instructions);
                 for block_inst_ref in block_insts.values() {
                     let info = self.generate(block_inst_ref, ctx);
-                    last_ty = info.ty;
+                    // Keep visiting unreachable instructions so inference can
+                    // report errors in them, but the first genuinely
+                    // diverging instruction makes every later tail
+                    // unreachable. The block therefore has the bottom type,
+                    // rather than the parser's synthetic unit tail. This is
+                    // the HM counterpart of sema's outgoing-state `⊥` and
+                    // lets a semicolon-terminated `@panic`/`return` inhabit
+                    // any surrounding value context.
+                    if !diverged {
+                        diverged = !info.continues;
+                        last_ty = info.ty;
+                    }
                 }
                 self.exit_scope(ctx);
-                last_ty
+                if diverged {
+                    continues = false;
+                    InferType::Concrete(Type::NEVER)
+                } else {
+                    last_ty
+                }
             }
 
             // Branch (if/else)
@@ -2085,6 +2176,7 @@ impl<'a> ConstraintGenerator<'a> {
                 else_block,
             } => {
                 let cond_info = self.generate(*cond, ctx);
+                continues &= cond_info.continues;
                 self.add_constraint(Constraint::equal(
                     cond_info.ty,
                     InferType::Concrete(Type::BOOL),
@@ -2120,7 +2212,14 @@ impl<'a> ConstraintGenerator<'a> {
                         None => InferType::Concrete(Type::UNIT),
                     };
                     self.record_type(inst_ref, result_ty.clone());
-                    return ExprInfo::new(result_ty, span);
+                    return ExprInfo::with_continues(
+                        result_ty,
+                        span,
+                        cond_info.continues
+                            && selected.is_none_or(|block| {
+                                self.expr_continues.get(&block).copied().unwrap_or(true)
+                            }),
+                    );
                 }
 
                 let then_info = self.generate(*then_block, ctx);
@@ -2132,8 +2231,9 @@ impl<'a> ConstraintGenerator<'a> {
                     // - If one branch is Never, the if-else takes the other branch's type
                     // - If both are Never, the result is Never
                     // - Otherwise, both must unify to the same type
-                    let then_is_never = matches!(&then_info.ty, InferType::Concrete(Type::NEVER));
-                    let else_is_never = matches!(&else_info.ty, InferType::Concrete(Type::NEVER));
+                    let then_is_never = !then_info.continues;
+                    let else_is_never = !else_info.continues;
+                    continues &= then_info.continues || else_info.continues;
 
                     match (then_is_never, else_is_never) {
                         (true, true) => {
@@ -2167,7 +2267,8 @@ impl<'a> ConstraintGenerator<'a> {
                     }
                 } else {
                     // No else branch - the if expression has unit type
-                    // (or the then branch type if it's unit-compatible)
+                    // and retains the condition-false continuation even when
+                    // the then branch diverges.
                     InferType::Concrete(Type::UNIT)
                 }
             }
@@ -2175,6 +2276,7 @@ impl<'a> ConstraintGenerator<'a> {
             // While loop
             InstData::Loop { cond, body } => {
                 let cond_info = self.generate(*cond, ctx);
+                continues &= cond_info.continues;
                 self.add_constraint(Constraint::equal(
                     cond_info.ty,
                     InferType::Concrete(Type::BOOL),
@@ -2204,12 +2306,14 @@ impl<'a> ConstraintGenerator<'a> {
                 if has_break {
                     InferType::Concrete(Type::UNIT)
                 } else {
+                    continues = false;
                     InferType::Concrete(Type::NEVER)
                 }
             }
 
             // Break/Continue
             InstData::Break { value } => {
+                continues = false;
                 match value {
                     None => {
                         // Record the break against the innermost enclosing loop.
@@ -2229,7 +2333,10 @@ impl<'a> ConstraintGenerator<'a> {
                 }
                 InferType::Concrete(Type::NEVER)
             }
-            InstData::Continue => InferType::Concrete(Type::NEVER),
+            InstData::Continue => {
+                continues = false;
+                InferType::Concrete(Type::NEVER)
+            }
 
             // Match expression
             InstData::Match { scrutinee, arms } => {
@@ -2253,8 +2360,14 @@ impl<'a> ConstraintGenerator<'a> {
                     let body_info = self.generate(selected, ctx);
                     self.exit_scope(ctx);
                     self.record_type(inst_ref, body_info.ty.clone());
-                    return ExprInfo::new(body_info.ty, span);
+                    return ExprInfo::with_continues(
+                        body_info.ty,
+                        span,
+                        scrutinee_info.continues && body_info.continues,
+                    );
                 }
+
+                continues &= scrutinee_info.continues;
 
                 // Collect arm types, handling Never coercion
                 let mut arm_types: Vec<ExprInfo> = Vec::new();
@@ -2341,10 +2454,9 @@ impl<'a> ConstraintGenerator<'a> {
 
                 // Handle Never type coercion:
                 // Filter out Never arms and use the remaining non-Never types
-                let non_never_arms: Vec<_> = arm_types
-                    .iter()
-                    .filter(|info| !matches!(&info.ty, InferType::Concrete(Type::NEVER)))
-                    .collect();
+                let non_never_arms: Vec<_> =
+                    arm_types.iter().filter(|info| info.continues).collect();
+                continues &= arm_types.iter().any(|info| info.continues);
 
                 if non_never_arms.is_empty() {
                     // All arms diverge - result is Never
@@ -2388,6 +2500,7 @@ impl<'a> ConstraintGenerator<'a> {
                         .filter(|ty| ty.as_struct().is_some())
                 } else if let Some(module_ref) = module {
                     let module_info = self.generate(*module_ref, ctx);
+                    continues &= module_info.continues;
                     let module_id = match module_info.ty {
                         InferType::Concrete(ty) => ty.as_module(),
                         _ => None,
@@ -2414,6 +2527,7 @@ impl<'a> ConstraintGenerator<'a> {
                     // (RUE-72)
                     for (field_name, value_ref) in fields.values() {
                         let value_info = self.generate(value_ref, ctx);
+                        continues &= value_info.continues;
                         if let Some(field_ty) = self.field_type_of(struct_ty, field_name) {
                             let expected = self.type_to_infer(field_ty);
                             // A `str` field (ADR-0043 Phase 3, RUE-324) accepts a
@@ -2436,7 +2550,7 @@ impl<'a> ConstraintGenerator<'a> {
                     // with unresolved variables, which sema then reported as
                     // an internal compiler error (RUE-170).
                     for (_, value_ref) in fields.values() {
-                        self.generate(value_ref, ctx);
+                        continues &= self.generate(value_ref, ctx).continues;
                     }
                     InferType::Concrete(Type::ERROR)
                 }
@@ -2496,6 +2610,7 @@ impl<'a> ConstraintGenerator<'a> {
                 }
 
                 let base_info = self.generate(*base, ctx);
+                continues &= base_info.continues;
                 // When the base's struct type is already concrete, the field's
                 // declared type is known here — yield it so downstream
                 // constraints see the real type instead of a free variable.
@@ -2550,13 +2665,16 @@ impl<'a> ConstraintGenerator<'a> {
             InstData::FieldSet { base, field, value } => {
                 let base_info = self.generate(*base, ctx);
                 let value_info = self.generate(*value, ctx);
+                continues &= base_info.continues && value_info.continues;
                 // Constrain the assigned value against the field's declared
                 // type, so a literal RHS is range-checked at the field's width
                 // instead of wrapping (`s.a = 300` with `a: u8` must be
                 // rejected rather than truncate to 44). (RUE-104)
                 if let Some(field_ty) = self.known_field_type(&base_info.ty, *field) {
                     let expected = self.type_to_infer(field_ty);
-                    self.add_constraint(Constraint::equal(value_info.ty, expected, span));
+                    if value_info.continues {
+                        self.add_constraint(Constraint::equal(value_info.ty, expected, span));
+                    }
                 }
                 InferType::Concrete(Type::UNIT)
             }
@@ -2589,8 +2707,10 @@ impl<'a> ConstraintGenerator<'a> {
                 } else {
                     // Get element type from first element, constrain rest to match
                     let first_info = self.generate(elements.get(0).unwrap(), ctx);
+                    continues &= first_info.continues;
                     for elem_ref in elements.values().skip(1) {
                         let elem_info = self.generate(elem_ref, ctx);
+                        continues &= elem_info.continues;
                         self.add_constraint(Constraint::equal(
                             elem_info.ty,
                             first_info.ty.clone(),
@@ -2613,6 +2733,7 @@ impl<'a> ConstraintGenerator<'a> {
             // and is resolved/diagnosed by sema.
             InstData::ArrayRepeat { value, count } => {
                 let value_info = self.generate(*value, ctx);
+                continues &= value_info.continues;
                 let resolved = match count {
                     RepeatCount::Literal(n) => Some(*n),
                     RepeatCount::Named(sym) => self
@@ -2632,6 +2753,7 @@ impl<'a> ConstraintGenerator<'a> {
             InstData::IndexGet { base, index } => {
                 let base_info = self.generate(*base, ctx);
                 let index_info = self.generate(*index, ctx);
+                continues &= base_info.continues && index_info.continues;
                 // Index must be an integer type (signed or unsigned) per spec
                 // 7.1:7. A negative or out-of-range index is not a type error;
                 // it is caught at runtime by the bounds check (unsigned 64-bit
@@ -2666,14 +2788,17 @@ impl<'a> ConstraintGenerator<'a> {
                 self.add_constraint(Constraint::is_integer(index_info.ty, index_info.span));
 
                 let value_info = self.generate(*value, ctx);
+                continues &= base_info.continues && index_info.continues && value_info.continues;
 
                 // Constrain value type to match array element type
                 if let InferType::Array { element, .. } = &base_info.ty {
-                    self.add_constraint(Constraint::equal(
-                        value_info.ty,
-                        (**element).clone(),
-                        value_info.span,
-                    ));
+                    if value_info.continues {
+                        self.add_constraint(Constraint::equal(
+                            value_info.ty,
+                            (**element).clone(),
+                            value_info.span,
+                        ));
+                    }
                 }
 
                 InferType::Concrete(Type::UNIT)
@@ -2718,7 +2843,11 @@ impl<'a> ConstraintGenerator<'a> {
                     return {
                         let ty = self.generate_type_qualified_call(name, *method, args, span, ctx);
                         self.record_type(inst_ref, ty.clone());
-                        ExprInfo::new(ty, span)
+                        ExprInfo::with_continues(
+                            ty.clone(),
+                            span,
+                            self.call_args_continue(args) && !Self::is_never_concrete(&ty),
+                        )
                     };
                 }
 
@@ -2747,7 +2876,11 @@ impl<'a> ConstraintGenerator<'a> {
                         self.generate_call_on_reduced_type(member_ty, *method, args, span, ctx)
                 {
                     self.record_type(inst_ref, result.clone());
-                    return ExprInfo::new(result, span);
+                    return ExprInfo::with_continues(
+                        result.clone(),
+                        span,
+                        self.call_args_continue(args) && !Self::is_never_concrete(&result),
+                    );
                 }
 
                 // Generate type for receiver
@@ -2786,7 +2919,13 @@ impl<'a> ConstraintGenerator<'a> {
                         ));
                     }
                     self.record_type(inst_ref, return_type.clone());
-                    return ExprInfo::new(return_type, span);
+                    return ExprInfo::with_continues(
+                        return_type.clone(),
+                        span,
+                        receiver_info.continues
+                            && self.call_args_continue(args)
+                            && !Self::is_never_concrete(&return_type),
+                    );
                 }
 
                 // Resolve the call's result type from the receiver's type.
@@ -3051,6 +3190,9 @@ impl<'a> ConstraintGenerator<'a> {
                         }
                     }
                 };
+                continues &= receiver_info.continues
+                    && self.call_args_continue(args)
+                    && !Self::is_never_concrete(&result_type);
 
                 result_type
             }
@@ -3065,6 +3207,7 @@ impl<'a> ConstraintGenerator<'a> {
             InstData::Comptime { expr } => {
                 // Generate constraints for the inner expression
                 let inner_info = self.generate(*expr, ctx);
+                continues &= inner_info.continues;
 
                 // Use a fresh variable so comptime can unify with expected type from context.
                 // The actual evaluation happens in sema where we know the final type.
@@ -3082,6 +3225,7 @@ impl<'a> ConstraintGenerator<'a> {
                     ctx.checked_depth += 1;
                 }
                 let inner_info = self.generate(*expr, ctx);
+                continues &= inner_info.continues;
                 {
                     ctx.checked_depth -= 1;
                 }
@@ -3102,12 +3246,15 @@ impl<'a> ConstraintGenerator<'a> {
 
         // Record the type for this expression
         self.record_type(inst_ref, ty.clone());
-        ExprInfo::new(ty, span)
+        continues &= self.expr_continues.get(&inst_ref).copied().unwrap_or(true);
+        self.expr_continues.insert(inst_ref, continues);
+        ExprInfo::with_continues(ty, span, continues)
     }
 
     /// Generate constraints for a binary arithmetic operation.
     fn generate_binary_arith(
         &mut self,
+        inst_ref: InstRef,
         lhs: InstRef,
         rhs: InstRef,
         ctx: &mut ConstraintContext,
@@ -3121,8 +3268,12 @@ impl<'a> ConstraintGenerator<'a> {
         // integer literal to `!` and then bogusly range-check it against `!`
         // (RUE-270). The result is `!`; the surrounding context coerces it.
         if Self::is_never_concrete(&lhs_info.ty) || Self::is_never_concrete(&rhs_info.ty) {
+            self.expr_continues
+                .insert(inst_ref, lhs_info.continues && rhs_info.continues);
             return InferType::Concrete(Type::NEVER);
         }
+        self.expr_continues
+            .insert(inst_ref, lhs_info.continues && rhs_info.continues);
 
         // Both operands must have the same type
         // Use a fresh type variable for the result
@@ -3162,12 +3313,15 @@ impl<'a> ConstraintGenerator<'a> {
     /// and result share a type that must be an integer.
     fn generate_add(
         &mut self,
+        inst_ref: InstRef,
         lhs: InstRef,
         rhs: InstRef,
         ctx: &mut ConstraintContext,
     ) -> InferType {
         let lhs_info = self.generate(lhs, ctx);
         let rhs_info = self.generate(rhs, ctx);
+        self.expr_continues
+            .insert(inst_ref, lhs_info.continues && rhs_info.continues);
 
         // A diverging operand (`!`, e.g. `1 + match n {}`) makes the whole
         // expression diverge; never coerces to any type (spec 3.4:3-4). Don't
@@ -3240,6 +3394,13 @@ impl<'a> ConstraintGenerator<'a> {
         self.string_literal_default
             .as_struct()
             .is_some_and(|id| &*self.type_pool.struct_def(id).name == "str")
+    }
+
+    fn call_args_continue(&self, args: &rue_rir::RirCallArgsRange) -> bool {
+        self.rir
+            .call_args(args)
+            .iter()
+            .all(|arg| self.expr_continues.get(&arg.value).copied().unwrap_or(true))
     }
 
     /// Generate constraints for a type-qualified call — an associated-function

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -129,11 +129,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // payload type (inference already constrained them; this is the final
         // legality check).
         let mut payload_refs: Vec<AirRef> = Vec::with_capacity(args.len());
+        let mut continues = true;
         for (i, arg) in args.iter().enumerate() {
             let expected = payload_types[i];
             let arg_result = ctx
                 .with_expected_type(Some(expected), |ctx| self.analyze_inst(air, arg.value, ctx))?;
             let actual = arg_result.ty;
+            continues &= arg_result.continues;
             if !self.types_compatible(actual, expected) && actual != Type::ERROR {
                 return Err(self.type_mismatch_error(
                     expected,
@@ -150,7 +152,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let _ = (&variant_name, &enum_name);
 
         let air_ref = air.add_enum_variant(enum_id, variant_index, &payload_refs, ty, span)?;
-        Ok(AnalysisResult::new(air_ref, ty))
+        Ok(AnalysisResult::with_continues(air_ref, ty, continues))
     }
 
     /// Validate the source operand type accepted by structural equality.
@@ -327,12 +329,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // Look up the struct type
         // First check if it's a comptime type variable (e.g., `let Point = make_point(); Point { ... }`)
         let type_name_str = self.body_interner().resolve(&type_name).to_owned();
+        let mut continues = true;
         let struct_id = if let Some(head_ref) = ctor_head {
             // Inline type-constructor struct-literal head `F(args) { ... }`
             // (RUE-596, spec 4.14:23): the head call reduces to a concrete type
             // at comptime; construct as if the type had been bound to a name
             // first (`let P = F(args); P { .. }`).
             let head_result = self.analyze_inst(air, head_ref, ctx)?;
+            continues &= head_result.continues;
             let AirInstData::TypeConst(reduced_ty) = air.get(head_result.air_ref).data else {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
@@ -358,6 +362,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             }
         } else if let Some(module_ref) = module {
             let module_result = self.analyze_inst(air, module_ref, ctx)?;
+            continues &= module_result.continues;
             let Some(module_id) = module_result.ty.as_module() else {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
@@ -534,6 +539,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 // Not an integer literal - analyze normally
                 self.analyze_inst(air, field_value, ctx)?
             };
+            continues &= field_result.continues;
 
             // An accessor result is a second-class borrowed place (ADR-0062):
             // capturing it as an aggregate member would store the borrow.
@@ -600,7 +606,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             struct_type,
             span,
         )?;
-        Ok(AnalysisResult::new(air_ref, struct_type))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            struct_type,
+            continues,
+        ))
     }
 
     /// Analyze module type member access: `module.StructName` or `module.EnumName`.
@@ -1182,8 +1192,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         // Analyze elements
         let mut air_elems = Vec::with_capacity(elem_refs.len());
+        let mut continues = true;
         for elem_ref in elem_refs {
             let elem_result = self.analyze_inst(air, elem_ref, ctx)?;
+            continues &= elem_result.continues;
             // An accessor result cannot be captured as an array element
             // (ADR-0062): the member would store a second-class borrow.
             self.reject_accessor_result_escape(
@@ -1196,7 +1208,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
 
         let air_ref = air.add_array_init(&air_elems, array_type, span)?;
-        Ok(AnalysisResult::new(air_ref, array_type))
+        Ok(AnalysisResult::with_continues(
+            air_ref, array_type, continues,
+        ))
     }
 
     /// Analyze an array-repeat literal `[value; count]` (RUE-235).
@@ -1295,9 +1309,17 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // correctly, marking the array construction unreachable.
         if length == 0 {
             let block_ref = air.add_block(&[value_result.air_ref], air_ref, array_type, span)?;
-            return Ok(AnalysisResult::new(block_ref, array_type));
+            return Ok(AnalysisResult::with_continues(
+                block_ref,
+                array_type,
+                value_result.continues,
+            ));
         }
-        Ok(AnalysisResult::new(air_ref, array_type))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            array_type,
+            value_result.continues,
+        ))
     }
 
     // Enum operations: EnumDecl, EnumVariant

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -141,7 +141,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         )?;
         let air_ref =
             self.wrap_value_with_temp_scope(air, call_ref, string_type, span, temp_scope)?;
-        Ok(AnalysisResult::new(air_ref, string_type))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            string_type,
+            lhs_result.continues && rhs_result.continues,
+        ))
     }
 
     /// Analyze the `print(s)` / `println(s)` builtin free functions (RUE-1).
@@ -272,7 +276,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         )?;
         let air_ref =
             self.wrap_value_with_temp_scope(air, call_ref, Type::UNIT, span, temp_scope)?;
-        Ok(AnalysisResult::new(air_ref, Type::UNIT))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            Type::UNIT,
+            arg_result.continues,
+        ))
     }
 
     /// Analyze a binary arithmetic operator (+, -, *, /, %).
@@ -293,6 +301,19 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     {
         let lhs_result = self.analyze_inst(air, lhs, ctx)?;
         let rhs_result = self.analyze_inst(air, rhs, ctx)?;
+
+        if !lhs_result.continues || !rhs_result.continues {
+            let air_ref = air.add_inst(AirInst {
+                data: make_data(lhs_result.air_ref, rhs_result.air_ref),
+                ty: lhs_result.ty,
+                span,
+            });
+            return Ok(AnalysisResult::with_continues(
+                air_ref,
+                lhs_result.ty,
+                false,
+            ));
+        }
 
         // Verify the type is integer (HM should have enforced this, but check anyway)
         if !lhs_result.ty.is_integer() && !lhs_result.ty.is_error() && !lhs_result.ty.is_never() {
@@ -363,6 +384,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             (lhs_result, rhs_result)
         };
         let lhs_type = lhs_result.ty;
+
+        if !lhs_result.continues || !rhs_result.continues {
+            let air_ref = air.add_inst(AirInst {
+                data: make_data(lhs_result.air_ref, rhs_result.air_ref),
+                ty: Type::BOOL,
+                span,
+            });
+            return Ok(AnalysisResult::with_continues(air_ref, Type::BOOL, false));
+        }
 
         // Propagate Never/Error without additional type errors
         if lhs_type.is_never() || lhs_type.is_error() {

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -145,12 +145,17 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         args: &[AirCallArg],
         temp_scope: Vec<AirRef>,
         return_type: Type,
+        continues: bool,
         span: Span,
     ) -> CompileResult<AnalysisResult> {
         let air_ref = air.add_call(None, name, args, return_type, span)?;
         let air_ref =
             self.wrap_value_with_temp_scope(air, air_ref, return_type, span, temp_scope)?;
-        Ok(AnalysisResult::new(air_ref, return_type))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            return_type,
+            continues,
+        ))
     }
 
     /// Analyze an associated function call.
@@ -556,6 +561,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let CallOperands {
             args: air_args,
             temp_scope,
+            continues,
         } = self.analyze_call_operands(air, args_range, &param_types, &param_modes, false, ctx)?;
 
         // Handle generic function calls differently
@@ -764,11 +770,23 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             )?;
             let air_ref =
                 self.wrap_value_with_temp_scope(air, air_ref, return_type, span, temp_scope)?;
-            Ok(AnalysisResult::new(air_ref, return_type))
+            Ok(AnalysisResult::with_continues(
+                air_ref,
+                return_type,
+                continues && !return_type.is_never(),
+            ))
         } else {
             // Regular non-generic call
             let return_type = base_return_type;
-            self.emit_call_result(air, name, &air_args, temp_scope, return_type, span)
+            self.emit_call_result(
+                air,
+                name,
+                &air_args,
+                temp_scope,
+                return_type,
+                continues && !return_type.is_never(),
+                span,
+            )
         }
     }
 
@@ -918,6 +936,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // place instead of moving out of it (restored afterwards).
         let mut receiver_result =
             self.analyze_with_borrow_root(air, receiver, receiver_byref_root, ctx)?;
+        let receiver_continues = receiver_result.continues;
         let receiver_type = receiver_result.ty;
 
         // Handle module member access: module.function() becomes a direct function call
@@ -1255,9 +1274,16 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let call_name = self.method_symbol(struct_id, &method_name_str, true);
         let call_name_sym = self.body_interner().get_or_intern(&call_name);
 
-        let call =
-            self.emit_call_result(air, call_name_sym, &air_args, temp_scope, return_type, span)?;
-        Ok(AnalysisResult::new(call.air_ref, return_type))
+        let call = self.emit_call_result(
+            air,
+            call_name_sym,
+            &air_args,
+            temp_scope,
+            return_type,
+            receiver_continues && args_result.continues && !return_type.is_never(),
+            span,
+        )?;
+        Ok(call)
     }
 
     /// Analyze a module member call: `module.function(args)` becomes a direct function call.
@@ -1389,6 +1415,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let CallOperands {
             args: air_args,
             temp_scope,
+            continues,
         } = self.analyze_call_operands(air, args_range, &param_types, &param_modes, true, ctx)?;
 
         self.emit_call_result(
@@ -1397,6 +1424,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             &air_args,
             temp_scope,
             fn_info.return_type,
+            continues && !fn_info.return_type.is_never(),
             span,
         )
     }
@@ -1548,6 +1576,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let CallOperands {
             args: air_args,
             temp_scope,
+            continues,
         } = self.analyze_call_operands(
             air,
             args_range,
@@ -1565,6 +1594,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let call_name = self.method_symbol(struct_id, &function_name_str, false);
         let call_name_sym = self.body_interner().get_or_intern(&call_name);
 
-        self.emit_call_result(air, call_name_sym, &air_args, temp_scope, return_type, span)
+        self.emit_call_result(
+            air,
+            call_name_sym,
+            &air_args,
+            temp_scope,
+            return_type,
+            continues && !return_type.is_never(),
+            span,
+        )
     }
 }

--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -72,11 +72,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 | InstData::IndexGet { .. }
                 | InstData::IndexSet { .. }
         );
-        if clears_result_expectation {
-            return ctx
-                .with_expected_type(None, |ctx| self.analyze_inst_dispatch(air, inst_ref, ctx));
+        let mut result = if clears_result_expectation {
+            ctx.with_expected_type(None, |ctx| self.analyze_inst_dispatch(air, inst_ref, ctx))?
+        } else {
+            self.analyze_inst_dispatch(air, inst_ref, ctx)?
+        };
+        if let Some(continues) = ctx.resolved_continues_of(inst_ref) {
+            result.continues = continues;
         }
-        self.analyze_inst_dispatch(air, inst_ref, ctx)
+        Ok(result)
     }
 
     fn analyze_inst_dispatch(

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -1067,7 +1067,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 Type::NEVER,
                 span,
             )?;
-            return Ok(AnalysisResult::new(air_ref, Type::NEVER));
+            return Ok(AnalysisResult::diverged(air_ref, Type::NEVER));
         }
 
         // Panic borrows its message until the runtime call. Give a canonical
@@ -1099,7 +1099,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         )?;
         let air_ref =
             self.wrap_value_with_temp_scope(air, intrinsic_ref, Type::NEVER, span, temp_scope)?;
-        Ok(AnalysisResult::new(air_ref, Type::NEVER))
+        Ok(AnalysisResult::diverged(air_ref, Type::NEVER))
     }
 
     pub(super) fn analyze_assert_intrinsic(

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -95,6 +95,7 @@ pub(crate) struct CallOperands {
     pub(crate) args: Vec<AirCallArg>,
     /// `StorageLive` instructions to prefix onto the call, in operand order.
     pub(crate) temp_scope: Vec<AirRef>,
+    pub(crate) continues: bool,
 }
 
 // Place Building
@@ -155,6 +156,8 @@ pub(crate) struct PlaceTrace {
     /// result may also be written after the receiver and loan checks. Neither
     /// result may be moved out of when it would create an owner alias.
     via_accessor: bool,
+    /// Whether strict projection operands reached their result normally.
+    continues: bool,
 }
 
 #[derive(Clone)]
@@ -940,6 +943,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         is_borrow_param: true,
                         pending_stmts: Vec::new(),
                         via_accessor: true,
+                        continues: true,
                     }));
                 }
 
@@ -957,6 +961,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         is_borrow_param: false,
                         pending_stmts: Vec::new(),
                         via_accessor: false,
+                        continues: true,
                     }));
                 }
 
@@ -975,6 +980,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         is_borrow_param: matches!(param_info.mode, RirParamMode::Borrow),
                         pending_stmts: Vec::new(),
                         via_accessor: false,
+                        continues: true,
                     }));
                 }
 
@@ -1058,6 +1064,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         let index_result = self.analyze_inst(air, *index, ctx);
                         ctx.byref_arg_root = saved_byref_root;
                         let index_result = index_result?;
+                        trace.continues &= index_result.continues;
 
                         // A place trace can be built before the outer read or
                         // write path performs its normal index validation. Do
@@ -1147,6 +1154,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 is_borrow_param: !mutable,
                 pending_stmts: Vec::new(),
                 via_accessor: true,
+                continues: true,
             }));
         }
         // Peek the receiver type without emitting anything: only proceed when
@@ -1675,7 +1683,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // sanctioned way to discard a linear value; `let _` stays an error.
         let Some(name) = name else {
             self.reject_discarded_linear_value(var_type, init)?;
-            return Ok(AnalysisResult::new(init_result.air_ref, Type::UNIT));
+            return Ok(AnalysisResult::with_continues(
+                init_result.air_ref,
+                Type::UNIT,
+                init_result.continues,
+            ));
         };
 
         // Special case: comptime type variables
@@ -1781,7 +1793,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         // Return a block containing both StorageLive and Alloc
         let block_ref = air.add_block(&[storage_live_ref], alloc_ref, Type::UNIT, span)?;
-        Ok(AnalysisResult::new(block_ref, Type::UNIT))
+        Ok(AnalysisResult::with_continues(
+            block_ref,
+            Type::UNIT,
+            init_result.continues,
+        ))
     }
 
     /// Materialize a constant's evaluated value as an AIR instruction.
@@ -2351,7 +2367,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     ty: Type::UNIT,
                     span,
                 });
-                return Ok(AnalysisResult::new(air_ref, Type::UNIT));
+                return Ok(AnalysisResult::with_continues(
+                    air_ref,
+                    Type::UNIT,
+                    value_result.continues,
+                ));
             }
         }
 
@@ -2425,7 +2445,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ty: Type::UNIT,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::UNIT))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            Type::UNIT,
+            value_result.continues,
+        ))
     }
 
     /// Reject a move (full or partial) whose root is a by-ref parameter.
@@ -2916,7 +2940,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             }
             // Accessor guard statements (ADR-0062) run before the read.
             let air_ref = Self::finish_traced_value(air, &mut trace, air_ref, field_type, span)?;
-            return Ok(AnalysisResult::new(air_ref, field_type));
+            return Ok(AnalysisResult::with_continues(
+                air_ref,
+                field_type,
+                trace.continues,
+            ));
         }
 
         // Fallback: base is not a place (e.g., function call result)
@@ -3025,7 +3053,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // A future optimization could add explicit StorageDead at the right point.
         let block_ref =
             air.add_block(&[storage_live_ref, alloc_ref], value_ref, field_type, span)?;
-        Ok(AnalysisResult::new(block_ref, field_type))
+        Ok(AnalysisResult::with_continues(
+            block_ref,
+            field_type,
+            base_result.continues,
+        ))
     }
 
     /// Analyze an array index read.
@@ -3201,7 +3233,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             }
             // Accessor guard statements (ADR-0062) run before the read.
             let air_ref = Self::finish_traced_value(air, &mut trace, air_ref, elem_type, span)?;
-            return Ok(AnalysisResult::new(air_ref, elem_type));
+            return Ok(AnalysisResult::with_continues(
+                air_ref,
+                elem_type,
+                trace.continues,
+            ));
         }
 
         // Fallback: base is not an array place (e.g. function-call result, or
@@ -3379,7 +3415,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // Note: We don't emit StorageDead here. The temporary will be cleaned up by
         // scope-based drop elaboration in the CFG builder.
         let block_ref = air.add_block(&[storage_live_ref, alloc_ref], read_ref, elem_type, span)?;
-        Ok(AnalysisResult::new(block_ref, elem_type))
+        Ok(AnalysisResult::with_continues(
+            block_ref,
+            elem_type,
+            base_result.continues && index_result.continues,
+        ))
     }
 
     /// Analyze a String byte index read: `s[i] -> u8` (RUE-17 Phase 2,
@@ -3488,7 +3528,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         )?;
         let call_ref =
             self.wrap_value_with_temp_scope(air, call_ref, Type::U8, span, temp_scope)?;
-        Ok(AnalysisResult::new(call_ref, Type::U8))
+        Ok(AnalysisResult::with_continues(
+            call_ref,
+            Type::U8,
+            base_result.continues && index_result.continues,
+        ))
     }
 
     /// Analyze a `str` byte index read: `s[i] -> u8` (ADR-0043 Phase 3,
@@ -3564,7 +3608,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             Type::U8,
             span,
         )?;
-        Ok(AnalysisResult::new(call_ref, Type::U8))
+        Ok(AnalysisResult::with_continues(
+            call_ref,
+            Type::U8,
+            base_result.continues && index_result.continues,
+        ))
     }
 
     /// Analyze a slice read-index `s[i]` (ADR-0043, RUE-322).
@@ -3715,7 +3763,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             .chain(std::iter::once(upper_assert_ref))
             .collect();
         let block_ref = air.add_block(&stmt_refs, elem_ref, elem_ty, span)?;
-        Ok(AnalysisResult::new(block_ref, elem_ty))
+        Ok(AnalysisResult::with_continues(
+            block_ref,
+            elem_ty,
+            base_result.continues && index_result.continues,
+        ))
     }
 
     /// Analyze a slice method call (ADR-0043, RUE-322). Only `.len()` is
@@ -3859,7 +3911,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ty: Type::UNIT,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::UNIT))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            Type::UNIT,
+            value_result.continues,
+        ))
     }
 
     /// Analyze a field assignment through the shared place representation.
@@ -4025,7 +4081,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ty: Type::UNIT,
                 span,
             });
-            return Ok(AnalysisResult::new(air_ref, Type::UNIT));
+            return Ok(AnalysisResult::with_continues(
+                air_ref,
+                Type::UNIT,
+                value_result.continues,
+            ));
         }
 
         // Fallback: base is not a place (e.g., function call result)
@@ -4228,7 +4288,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ty: Type::UNIT,
                 span,
             });
-            return Ok(AnalysisResult::new(air_ref, Type::UNIT));
+            return Ok(AnalysisResult::with_continues(
+                air_ref,
+                Type::UNIT,
+                index_result.continues && value_result.continues,
+            ));
         }
 
         // Fallback: base is not a place
@@ -5428,6 +5492,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     {
         let mut air_args = Vec::with_capacity(args.len());
         let mut temp_scope: Vec<AirRef> = Vec::new();
+        let mut continues = true;
         for (i, arg) in args.enumerate() {
             // A `str` parameter (ADR-0043 Phase 3, RUE-324) is a first-class
             // 2-word value, not a `borrow`-materialized fat pointer. A string
@@ -5475,6 +5540,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 let arg_result = self.analyze_inst(air, arg.value, ctx);
                 ctx.expected_type = prev_expected;
                 let arg_result = arg_result?;
+                continues &= arg_result.continues;
                 // `Str(N)` is a nominal fixed-capacity value, not a bare
                 // string view. Contextual literals materialize directly as
                 // the expected capacity above; every other value must retain
@@ -5595,6 +5661,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             }
             ctx.byref_arg_root = prev_byref_root;
             let mut arg_result = arg_result?;
+            continues &= arg_result.continues;
             if elaborates_borrow {
                 let span = self.body_rir_ref().get(arg.value).span;
                 let elaborated = self.elaborate_borrow_operand(
@@ -5682,6 +5749,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         Ok(CallOperands {
             args: air_args,
             temp_scope,
+            continues,
         })
     }
 

--- a/crates/rue-air/src/sema/analysis/pointers.rs
+++ b/crates/rue-air/src/sema/analysis/pointers.rs
@@ -79,7 +79,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         // Create the intrinsic call instruction
         let air_ref = air.add_intrinsic(None, name, &[ptr_result.air_ref], pointee_type, span)?;
-        Ok(AnalysisResult::new(air_ref, pointee_type))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            pointee_type,
+            ptr_result.continues,
+        ))
     }
 
     /// Analyze @ptr_write / @ptr_write_unaligned intrinsic: writes value through
@@ -193,7 +197,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             Type::UNIT,
             span,
         )?;
-        Ok(AnalysisResult::new(air_ref, Type::UNIT))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            Type::UNIT,
+            ptr_result.continues && value_result.continues,
+        ))
     }
 
     /// Analyze @ptr_offset intrinsic: pointer arithmetic.
@@ -254,7 +262,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ptr_type,
             span,
         )?;
-        Ok(AnalysisResult::new(air_ref, ptr_type))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            ptr_type,
+            ptr_result.continues && offset_result.continues,
+        ))
     }
 
     /// Analyze @ptr_to_int intrinsic: converts pointer to u64.
@@ -295,7 +307,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         // Create the intrinsic call instruction (returns u64)
         let air_ref = air.add_intrinsic(None, name, &[ptr_result.air_ref], Type::U64, span)?;
-        Ok(AnalysisResult::new(air_ref, Type::U64))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            Type::U64,
+            ptr_result.continues,
+        ))
     }
 
     /// Analyze @int_to_ptr intrinsic: converts u64 to pointer.
@@ -366,7 +382,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         // Create the intrinsic call instruction
         let air_ref = air.add_intrinsic(None, name, &[addr_result.air_ref], result_type, span)?;
-        Ok(AnalysisResult::new(air_ref, result_type))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            result_type,
+            addr_result.continues,
+        ))
     }
 
     /// Analyze `@alloc(size, align)` and `@alloc_zeroed(size, align)`, the
@@ -423,7 +443,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             result_ty,
             span,
         )?;
-        Ok(AnalysisResult::new(air_ref, result_ty))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            result_ty,
+            size.continues && align.continues,
+        ))
     }
 
     /// Analyze `@realloc(p, old_size, align, new_size) -> ptr mut u8`
@@ -468,7 +492,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ptr.ty,
             span,
         )?;
-        Ok(AnalysisResult::new(air_ref, ptr.ty))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            ptr.ty,
+            ptr.continues && old_size.continues && align.continues && new_size.continues,
+        ))
     }
 
     /// Analyze `@resize(p, old_size, align, new_size) -> bool` (RUE-968), the
@@ -517,7 +545,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             Type::BOOL,
             span,
         )?;
-        Ok(AnalysisResult::new(air_ref, Type::BOOL))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            Type::BOOL,
+            ptr.continues && old_size.continues && align.continues && new_size.continues,
+        ))
     }
 
     /// Analyze `@free(p, size, align)` (ADR-0059 Phase 3, RUE-961). The
@@ -555,7 +587,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             Type::UNIT,
             span,
         )?;
-        Ok(AnalysisResult::new(air_ref, Type::UNIT))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            Type::UNIT,
+            ptr.continues && size.continues && align.continues,
+        ))
     }
 
     /// Reject a comptime-constant allocator `align` argument that is zero or
@@ -631,7 +667,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             Type::UNIT,
             span,
         )?;
-        Ok(AnalysisResult::new(air_ref, Type::UNIT))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            Type::UNIT,
+            dst.continues && src.continues && size.continues,
+        ))
     }
 
     /// Analyze `@byte_set(dst: ptr mut u8, byte: u8, size: u64) -> ()`
@@ -669,7 +709,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             Type::UNIT,
             span,
         )?;
-        Ok(AnalysisResult::new(air_ref, Type::UNIT))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            Type::UNIT,
+            dst.continues && byte.continues && size.continues,
+        ))
     }
 
     fn require_intrinsic_type(
@@ -821,7 +865,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // same way (address of the operand place).
         let name = result_name;
         let air_ref = air.add_intrinsic(None, name, &[arg_result.air_ref], result_type, span)?;
-        Ok(AnalysisResult::new(air_ref, result_type))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            result_type,
+            arg_result.continues,
+        ))
     }
 
     /// Analyze `@field_ptr(s.field)` (RUE-301): a raw `ptr mut F` to a struct
@@ -900,8 +948,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         // Analyze all arguments and verify they are u64
         let mut arg_refs = Vec::with_capacity(args.len());
+        let mut continues = true;
         for (i, arg) in args.iter().enumerate() {
             let arg_result = self.analyze_inst(air, arg.value, ctx)?;
+            continues &= arg_result.continues;
             let arg_type = arg_result.ty;
 
             // All syscall arguments must be u64
@@ -921,7 +971,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         // Create the intrinsic call instruction
         let air_ref = air.add_intrinsic(None, name, &arg_refs, Type::I64, span)?;
-        Ok(AnalysisResult::new(air_ref, Type::I64))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            Type::I64,
+            continues,
+        ))
     }
 
     /// Analyze @target_arch() intrinsic - returns target CPU architecture enum.

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -33,7 +33,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// signatures, struct/enum types, method signatures) converted to InferType format.
     /// This avoids rebuilding these maps for each function, reducing O(n²) to O(n).
     ///
-    /// Returns a map from RIR instruction refs to their resolved concrete types.
+    /// Returns maps from RIR instruction refs to their resolved concrete types
+    /// and normal-continuation facts.
     pub(crate) fn run_type_inference(
         &mut self,
         infer_ctx: &InferenceContext,
@@ -42,7 +43,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         body: InstRef,
         type_subst: Option<&AHashMap<Spur, Type>>,
         value_subst: Option<&AHashMap<Spur, ConstValue>>,
-    ) -> CompileResult<(AHashMap<InstRef, Type>, InferenceBreakdown)> {
+    ) -> CompileResult<(
+        AHashMap<InstRef, Type>,
+        AHashMap<InstRef, bool>,
+        InferenceBreakdown,
+    )> {
         let precompute_started = Instant::now();
         // Pre-resolve `let`-bound comptime type aliases (`let P = F();` where
         // `F` returns `type`) so inference can see the concrete anonymous
@@ -138,6 +143,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             string_literal_vars,
             string_literal_default,
             expr_types,
+            expr_continues,
             type_var_count,
         ) = {
             let facts = self.inference_facts(infer_ctx);
@@ -248,6 +254,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 string_literal_vars,
                 string_literal_default,
                 expr_types,
+                expr_continues,
                 type_var_count,
             ) = cgen.into_parts();
             (
@@ -256,6 +263,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 string_literal_vars,
                 string_literal_default,
                 expr_types,
+                expr_continues,
                 type_var_count,
             )
         };
@@ -386,6 +394,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let unification_resolution_ns = elapsed_ns(unification_resolution_started);
         Ok((
             resolved_types,
+            expr_continues.into_iter().collect(),
             InferenceBreakdown {
                 precompute_ns,
                 precompute_structural_ns,

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -224,6 +224,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
                 let operand_result = self.analyze_inst(air, *operand, ctx)?;
 
+                if !operand_result.continues {
+                    let air_ref = air.add_inst(AirInst {
+                        data: AirInstData::Neg(operand_result.air_ref),
+                        ty,
+                        span: inst.span,
+                    });
+                    return Ok(AnalysisResult::with_continues(air_ref, ty, false));
+                }
+
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::Neg(operand_result.air_ref),
                     ty,
@@ -234,6 +243,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
             InstData::Not { operand } => {
                 let operand_result = self.analyze_inst(air, *operand, ctx)?;
+
+                if !operand_result.continues {
+                    let air_ref = air.add_inst(AirInst {
+                        data: AirInstData::Not(operand_result.air_ref),
+                        ty: Type::BOOL,
+                        span: inst.span,
+                    });
+                    return Ok(AnalysisResult::with_continues(air_ref, Type::BOOL, false));
+                }
 
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::Not(operand_result.air_ref),
@@ -259,6 +277,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 }
 
                 let operand_result = self.analyze_inst(air, *operand, ctx)?;
+
+                if !operand_result.continues {
+                    let air_ref = air.add_inst(AirInst {
+                        data: AirInstData::BitNot(operand_result.air_ref),
+                        ty,
+                        span: inst.span,
+                    });
+                    return Ok(AnalysisResult::with_continues(air_ref, ty, false));
+                }
 
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::BitNot(operand_result.air_ref),
@@ -304,6 +331,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 let lhs_result = self.analyze_inst(air, *lhs, ctx)?;
                 let rhs_result = self.analyze_inst(air, *rhs, ctx)?;
 
+                if !lhs_result.continues || !rhs_result.continues {
+                    let air_ref = air.add_inst(AirInst {
+                        data: AirInstData::And(lhs_result.air_ref, rhs_result.air_ref),
+                        ty: Type::BOOL,
+                        span: inst.span,
+                    });
+                    return Ok(AnalysisResult::with_continues(air_ref, Type::BOOL, false));
+                }
+
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::And(lhs_result.air_ref, rhs_result.air_ref),
                     ty: Type::BOOL,
@@ -315,6 +351,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             InstData::Or { lhs, rhs } => {
                 let lhs_result = self.analyze_inst(air, *lhs, ctx)?;
                 let rhs_result = self.analyze_inst(air, *rhs, ctx)?;
+
+                if !lhs_result.continues || !rhs_result.continues {
+                    let air_ref = air.add_inst(AirInst {
+                        data: AirInstData::Or(lhs_result.air_ref, rhs_result.air_ref),
+                        ty: Type::BOOL,
+                        span: inst.span,
+                    });
+                    return Ok(AnalysisResult::with_continues(air_ref, Type::BOOL, false));
+                }
 
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::Or(lhs_result.air_ref, rhs_result.air_ref),

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -584,6 +584,10 @@ pub(crate) struct AnalysisContext<'a> {
     /// This is populated by running constraint generation and unification
     /// before AIR emission.
     pub resolved_types: &'a AHashMap<InstRef, Type>,
+    /// Canonical normal-continuation facts produced by the same inference walk
+    /// as `resolved_types`. Semantic consumers use these facts rather than
+    /// rediscovering divergence from a construct's surface result type.
+    pub resolved_continues: &'a AHashMap<InstRef, bool>,
     /// Variables that have been moved (for affine type checking).
     /// Maps variable symbol to move state (supports partial/field-level moves).
     pub moved_vars: AHashMap<Spur, VariableMoveState>,
@@ -906,6 +910,7 @@ impl<'a> AnalysisContext<'a> {
             moved_scope_stack: self.moved_scope_stack.clone(),
             comptime_type_scope_stack: self.comptime_type_scope_stack.clone(),
             resolved_types: self.resolved_types,
+            resolved_continues: self.resolved_continues,
             moved_vars: self.moved_vars.clone(),
             warnings: Vec::new(),
             allow_unused_variables: self.allow_unused_variables,
@@ -951,6 +956,13 @@ impl<'a> AnalysisContext<'a> {
             }
         }
         self.resolved_types.get(&inst_ref).copied()
+    }
+
+    /// Return whether inference found a normal outgoing path for an
+    /// instruction. Missing entries occur only for instructions analyzed from
+    /// an inline overlay; their semantic result remains the fallback.
+    pub fn resolved_continues_of(&self, inst_ref: InstRef) -> Option<bool> {
+        self.resolved_continues.get(&inst_ref).copied()
     }
 
     /// Merge move states from two branches.
@@ -1101,6 +1113,10 @@ pub(crate) struct AnalysisResult {
     pub air_ref: AirRef,
     /// The synthesized type of this expression
     pub ty: Type,
+    /// Whether evaluation can reach the next instruction normally. This is
+    /// deliberately independent of `ty`: a call/initializer keeps its
+    /// declared value type even when evaluating an operand diverges.
+    pub continues: bool,
 }
 
 use crate::inst::AirRef;
@@ -1108,7 +1124,25 @@ use crate::inst::AirRef;
 impl AnalysisResult {
     #[must_use]
     pub fn new(air_ref: AirRef, ty: Type) -> Self {
-        Self { air_ref, ty }
+        Self {
+            air_ref,
+            ty,
+            continues: true,
+        }
+    }
+
+    #[must_use]
+    pub fn with_continues(air_ref: AirRef, ty: Type, continues: bool) -> Self {
+        Self {
+            air_ref,
+            ty,
+            continues,
+        }
+    }
+
+    #[must_use]
+    pub fn diverged(air_ref: AirRef, ty: Type) -> Self {
+        Self::with_continues(air_ref, ty, false)
     }
 }
 

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -94,7 +94,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     ty: Type::NEVER,
                     span: inst.span,
                 });
-                Ok(AnalysisResult::new(air_ref, Type::NEVER))
+                Ok(AnalysisResult::diverged(air_ref, Type::NEVER))
             }
 
             InstData::Continue => {
@@ -121,7 +121,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     ty: Type::NEVER,
                     span: inst.span,
                 });
-                Ok(AnalysisResult::new(air_ref, Type::NEVER))
+                Ok(AnalysisResult::diverged(air_ref, Type::NEVER))
             }
 
             InstData::Ret(inner) => {
@@ -219,6 +219,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ctx.push_scope();
             let then_result = self.analyze_inst(air, then_block, ctx)?;
             let then_type = then_result.ty;
+            let then_continues = then_result.continues;
             let then_span = self.body_rir_ref().get(then_block).span;
             ctx.pop_scope();
 
@@ -232,6 +233,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ctx.push_scope();
             let else_result = self.analyze_inst(air, else_b, ctx)?;
             let else_type = else_result.ty;
+            let else_continues = else_result.continues;
             let else_span = self.body_rir_ref().get(else_b).span;
             ctx.pop_scope();
 
@@ -239,19 +241,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let else_moves = ctx.moved_vars.clone();
 
             // Merge move states from both branches.
-            ctx.merge_branch_moves(
-                then_moves,
-                else_moves,
-                then_type.is_never(),
-                else_type.is_never(),
-            );
+            ctx.merge_branch_moves(then_moves, else_moves, !then_continues, !else_continues);
 
             // Compute the unified result type using never type coercion
-            let result_type = match (then_type.is_never(), else_type.is_never()) {
-                (true, true) => Type::NEVER,
-                (true, false) => else_type,
-                (false, true) => then_type,
-                (false, false) => {
+            let result_type = match (then_continues, else_continues) {
+                (false, false) => Type::NEVER,
+                (false, true) => else_type,
+                (true, false) => then_type,
+                (true, true) => {
                     // Neither diverges - types must match exactly
                     if !self.types_equivalent(then_type, else_type)
                         && !then_type.is_error()
@@ -287,7 +284,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ty: result_type,
                 span,
             });
-            Ok(AnalysisResult::new(air_ref, result_type))
+            Ok(AnalysisResult::with_continues(
+                air_ref,
+                result_type,
+                cond_result.continues && (then_result.continues || else_result.continues),
+            ))
         } else {
             // No else branch - result is Unit
             // The then branch must have unit type (spec 4.6:5)
@@ -301,7 +302,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
             // Check that the then branch has unit type (or Never/Error)
             let then_type = then_result.ty;
-            if then_type != Type::UNIT && !then_type.is_never() && !then_type.is_error() {
+            if then_type != Type::UNIT && then_result.continues && !then_type.is_error() {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
                         expected: "()".to_string(),
@@ -319,7 +320,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let then_moves = ctx.moved_vars.clone();
 
             // For if-without-else:
-            if then_type.is_never() {
+            if !then_result.continues {
                 // Then-branch diverges - code after if only runs if cond was false
                 ctx.moved_vars = saved_moves;
             } else {
@@ -341,7 +342,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ty: Type::UNIT,
                 span,
             });
-            Ok(AnalysisResult::new(air_ref, Type::UNIT))
+            Ok(AnalysisResult::with_continues(
+                air_ref,
+                Type::UNIT,
+                cond_result.continues,
+            ))
         }
     }
 
@@ -445,7 +450,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ty: Type::UNIT,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::UNIT))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            Type::UNIT,
+            cond_result.continues,
+        ))
     }
 
     /// Analyze an infinite loop.
@@ -482,6 +491,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // break-site snapshots still on the stack (see analyze_while_loop).
         ctx.pop_scope();
         let edge_record = ctx.loop_break_stack.pop().unwrap_or_default();
+        // Loop classification is purely syntactic (spec 4.8:21): a loop
+        // containing a targeting `break` is unit-typed even when that break
+        // is unreachable.
         let has_break = edge_record.broke;
         let (break_moves, continue_moves) = edge_record.merged_moves();
         // The back edge carries the fall-through state joined with the
@@ -547,7 +559,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ty: loop_ty,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, loop_ty))
+        Ok(AnalysisResult::with_continues(air_ref, loop_ty, has_break))
     }
 
     /// Validate an integer pattern literal against the scrutinee type and
@@ -928,7 +940,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 return Err(CompileError::new(ErrorKind::EmptyMatch, span));
             }
             let air_ref = air.add_match(scrutinee_result.air_ref, &[], Type::NEVER, span)?;
-            return Ok(AnalysisResult::new(air_ref, Type::NEVER));
+            return Ok(AnalysisResult::diverged(air_ref, Type::NEVER));
         }
 
         // Track patterns for exhaustiveness checking and duplicate detection
@@ -946,6 +958,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // Analyze each arm (each arm gets its own scope)
         let mut air_arms = Vec::new();
         let mut result_type: Option<Type> = None;
+        let mut result_continues: Option<bool> = None;
 
         // Move state before any arm runs (after the scrutinee, whose moves
         // happen on every path). Arms are alternatives, not a sequence:
@@ -1242,15 +1255,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             self.check_unconsumed_linear_values(ctx)?;
 
             ctx.pop_scope();
-            arm_move_states.push((std::mem::take(&mut ctx.moved_vars), body_type.is_never()));
+            arm_move_states.push((std::mem::take(&mut ctx.moved_vars), !body_result.continues));
 
             // Update result type (handle Never type coercion)
             result_type = Some(match result_type {
                 None => body_type,
                 Some(prev) => {
-                    if prev.is_never() {
+                    if !result_continues.unwrap_or(true) {
                         body_type
-                    } else if body_type.is_never() {
+                    } else if !body_result.continues {
                         prev
                     } else if !self.types_equivalent(prev, body_type)
                         && !prev.is_error()
@@ -1267,6 +1280,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     }
                 }
             });
+            result_continues = Some(result_continues.unwrap_or(false) || body_result.continues);
 
             // Convert pattern to AIR pattern
             let air_pattern = match &pattern {
@@ -1341,6 +1355,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // Join the arms' move states (union of non-diverging arms;
         // `full_move_on_all_paths` intersects for the linear must-consume
         // check). Matches are exhaustive, so the arms cover every path.
+        let continues = result_continues.unwrap_or(true);
         ctx.merge_arm_moves(arm_move_states);
 
         // Exhaustiveness checking
@@ -1379,7 +1394,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let final_type = result_type.unwrap_or(Type::UNIT);
 
         let air_ref = air.add_match(scrutinee_result.air_ref, &air_arms, final_type, span)?;
-        Ok(AnalysisResult::new(air_ref, final_type))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            final_type,
+            scrutinee_result.continues && continues,
+        ))
     }
 
     /// If `enum_id` names an `Option`-shaped enum — exactly two variants, a
@@ -2206,7 +2225,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ty: Type::NEVER, // Return expressions have Never type
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::NEVER))
+        Ok(AnalysisResult::diverged(air_ref, Type::NEVER))
     }
 
     /// Analyze a block expression.
@@ -2226,6 +2245,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // Process all instructions in the block
         let mut statements = Vec::new();
         let mut last_result: Option<AnalysisResult> = None;
+        let mut diverged = false;
+        let mut diverged_context: Option<AnalysisContext> = None;
         let num_insts = inst_refs.len();
         for (i, inst_ref) in inst_refs.iter().copied().enumerate() {
             let is_last = i == num_insts - 1;
@@ -2274,22 +2295,58 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
             if is_last {
                 last_result = Some(result);
+                if !result.continues && !diverged {
+                    diverged = true;
+                    diverged_context = Some(ctx.clone());
+                }
             } else {
                 // A non-final statement's value is discarded. Discarding a
                 // value that carries a linear value would implicitly drop it
                 // (`make_linear();` — RUE-176), which linearity forbids.
                 self.reject_discarded_linear_value(result.ty, inst_ref)?;
                 statements.push(result.air_ref);
+                // The remaining instructions are still analyzed above so
+                // unreachable-code diagnostics and ordinary semantic errors
+                // remain intact. Once a statement diverges, however, no tail
+                // reaches the block exit: its outgoing ownership state is
+                // bottom and its synthesized block type is Never, even when
+                // the parser supplied a synthetic unit tail.
+                if !result.continues && !diverged {
+                    diverged = true;
+                    diverged_context = Some(ctx.clone());
+                }
             }
         }
 
-        // Check for unconsumed linear values before popping scope
-        self.check_unconsumed_linear_values(ctx)?;
+        // Instructions after a diverging statement are analyzed for
+        // diagnostics, but their moves belong to no reachable path. Restore
+        // the state at the divergence before the block's scope checks and
+        // enclosing joins observe it.
+        // Check live obligations against the snapshot, while retaining the
+        // current context for dead-suffix diagnostics and append-only data.
+        let reachable_moves = diverged_context
+            .as_ref()
+            .map(|reachable| reachable.moved_vars.clone());
+        if let Some(reachable_context) = diverged_context.as_ref() {
+            self.check_unconsumed_linear_values(reachable_context)?;
+            // Keep the current context for diagnostics from declarations in
+            // the unreachable suffix. This is deliberately a second check:
+            // the snapshot proves reachable obligations, while the live
+            // context retains dead-suffix locals and their diagnostics.
+            self.check_unconsumed_linear_values(ctx)?;
+        } else {
+            self.check_unconsumed_linear_values(ctx)?;
+        }
 
         // Check for unused variables before popping scope
         self.check_unused_locals_in_current_scope(ctx);
 
-        // Pop scope to remove block-scoped variables.
+        if let Some(moves) = reachable_moves {
+            ctx.moved_vars = moves;
+        }
+        // Pop scope to remove block-scoped variables. The reachable move
+        // state is restored first so this frame removes dead locals and
+        // restores any shadowed outer bindings normally.
         ctx.pop_scope();
 
         // Handle empty blocks - they evaluate to Unit
@@ -2309,11 +2366,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // Only create a Block instruction if there are statements;
         // otherwise just return the value directly (optimization)
         if statements.is_empty() {
-            Ok(last)
+            Ok(if diverged && last.continues {
+                AnalysisResult::diverged(last.air_ref, Type::NEVER)
+            } else {
+                last
+            })
         } else {
-            let ty = last.ty;
+            let ty = if diverged { Type::NEVER } else { last.ty };
             let air_ref = air.add_block(&statements, last.air_ref, ty, span)?;
-            Ok(AnalysisResult::new(air_ref, ty))
+            Ok(AnalysisResult::with_continues(air_ref, ty, !diverged))
         }
     }
 }

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -2070,7 +2070,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         // for all expressions BEFORE emitting AIR.
         let expression_setup_ns =
             u64::try_from(expression_setup_started.elapsed().as_nanos()).unwrap_or(u64::MAX);
-        let (resolved_types, inference_breakdown) = self.run_type_inference(
+        let (resolved_types, resolved_continues, inference_breakdown) = self.run_type_inference(
             infer_ctx,
             return_type,
             params,
@@ -2123,6 +2123,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             moved_scope_stack: Vec::new(),
             comptime_type_scope_stack: Vec::new(),
             resolved_types: &resolved_types,
+            resolved_continues: &resolved_continues,
             moved_vars: AHashMap::new(),
             warnings: Vec::new(),
             allow_unused_variables: allow_unused_variable,

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -1059,6 +1059,39 @@ compile_fail = true
 error_contains = "not consumed on all paths"
 
 [[case]]
+name = "linear_dead_suffix_after_panic_keeps_scope_state_coherent"
+spec = ["3.4:2", "3.8:32", "3.8:33"]
+description = "Dead-suffix ownership checking does not resurrect or leak a linear declaration"
+source = """
+linear struct MustUse { value: i32 }
+fn consume(m: MustUse) -> i32 { m.value }
+fn main() -> i32 {
+    @panic("dead suffix");
+    let m = MustUse { value: 1 };
+    consume(m);
+}
+"""
+exit_code = 101
+stderr_contains = "panic: dead suffix"
+
+[[case]]
+name = "linear_dead_suffix_before_reachable_typed_tail"
+spec = ["3.4:2", "3.8:32", "3.8:33"]
+description = "A final typed tail remains unreachable without changing linear obligations"
+source = """
+linear struct MustUse { value: i32 }
+fn consume(m: MustUse) -> i32 { m.value }
+fn main() -> i32 {
+    @panic("typed tail");
+    let m = MustUse { value: 1 };
+    consume(m);
+    42
+}
+"""
+exit_code = 101
+stderr_contains = "panic: typed tail"
+
+[[case]]
 name = "linear_consumed_one_match_arm_error"
 spec = ["3.8:50"]
 description = "Linear value consumed in only one match arm is an error"

--- a/crates/rue-spec/cases/types/never.toml
+++ b/crates/rue-spec/cases/types/never.toml
@@ -187,6 +187,147 @@ fn main() -> i32 { test() }
 exit_code = 7
 
 [[case]]
+name = "panic_statement_diverges_has_never_type"
+spec = ["3.4:2", "3.4:6a", "4.13:5b"]
+description = "A semicolon-terminated diverging statement leaves no reachable block tail and gives the block type !"
+source = """
+fn main() -> i32 {
+    @panic("statement");
+}
+"""
+exit_code = 101
+stderr_contains = "panic: statement"
+
+[[case]]
+name = "return_statement_diverges_has_never_type"
+spec = ["3.4:2", "3.4:6a"]
+description = "A semicolon-terminated return leaves no reachable block tail"
+source = """
+fn answer() -> i32 {
+    return 7;
+}
+fn main() -> i32 { answer() }
+"""
+exit_code = 7
+
+[[case]]
+name = "reachable_unit_statement_keeps_reachable_tail"
+spec = ["3.4:6a"]
+description = "An ordinary unit-valued statement does not make the following tail unreachable"
+source = """
+fn touch() {}
+fn main() -> i32 {
+    touch();
+    42
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "short_circuited_panic_keeps_reachable_tail"
+spec = ["3.4:6a", "4.4:5"]
+description = "A panic in a skipped short-circuit operand does not make the logical statement diverge"
+source = """
+fn main() -> i32 {
+    false && @panic("skipped");
+    42
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "nested_panic_statement_diverges_has_never_type"
+spec = ["3.4:2", "3.4:6a", "4.13:5b"]
+description = "A nested block preserves bottom propagation from a diverging statement"
+source = """
+fn main() -> i32 {
+    let value: i32 = {
+        @panic();
+    };
+}
+"""
+exit_code = 101
+stderr_contains = "panic"
+
+[[case]]
+name = "panic_in_let_statement_propagates_bottom"
+spec = ["3.4:2", "3.4:6a", "4.13:5b"]
+description = "A diverging initializer makes its unit-valued let statement non-continuing"
+source = """
+fn main() -> i32 {
+    let value: i32 = @panic("initializer");
+}
+"""
+exit_code = 101
+stderr_contains = "panic: initializer"
+
+[[case]]
+name = "panic_in_call_argument_propagates_bottom"
+spec = ["3.4:2", "3.4:6a", "4.13:5b"]
+description = "A diverging call argument prevents the call statement from reaching its end"
+source = """
+fn sink(value: i32) {}
+fn main() -> i32 {
+    sink(@panic("argument"));
+}
+"""
+exit_code = 101
+stderr_contains = "panic: argument"
+
+[[case]]
+name = "panic_in_pointer_intrinsic_operand_propagates_bottom"
+spec = ["3.4:2", "3.4:6a", "4.13:5b"]
+description = "A diverging strict intrinsic operand prevents the unit-valued statement from continuing"
+source = """
+fn main() -> i32 {
+    checked {
+        @free(@panic("pointer operand"), 0, 1);
+    }
+}
+"""
+exit_code = 101
+stderr_contains = "panic: pointer operand"
+
+[[case]]
+name = "assert_false_remains_unit"
+spec = ["3.4:6a", "4.13:5b"]
+description = "@assert(false) remains unit-typed rather than becoming Never"
+source = """
+fn main() -> i32 {
+    @assert(false);
+}
+"""
+compile_fail = true
+error_contains = ["[E0206]", "expected i32", "found ()"]
+
+[[case]]
+name = "dead_string_reference_after_panic"
+spec = ["3.4:2", "3.4:6a"]
+description = "Unreachable string literals retain their semantic backing after a panic"
+source = """
+fn main() -> i32 {
+    @panic("live");
+    println("dead");
+    0
+}
+"""
+exit_code = 101
+stderr_contains = "panic: live"
+
+[[case]]
+name = "panic_in_assignment_propagates_bottom"
+spec = ["3.4:2", "3.4:6a"]
+description = "A diverging assignment RHS makes the statement non-continuing without changing unit value typing"
+source = """
+fn main() -> i32 {
+    let mut x = 0;
+    x = @panic("assign");
+}
+"""
+exit_code = 101
+stderr_contains = "panic: assign"
+
+[[case]]
 name = "infinite_loop_value_coerces"
 spec = ["3.4:6a"]
 description = "An infinite loop with no reachable break has type ! and coerces into a binding (RUE-299)"

--- a/crates/rue-ui-tests/cases/warnings/unreachable.toml
+++ b/crates/rue-ui-tests/cases/warnings/unreachable.toml
@@ -33,6 +33,18 @@ warning_contains = ["unreachable"]
 expected_warning_count = 1
 
 [[case]]
+name = "unreachable_after_panic_statement"
+source = """
+fn main() -> i32 {
+    @panic("stop");
+    0
+}
+"""
+exit_code = 101
+warning_contains = ["unreachable"]
+expected_warning_count = 1
+
+[[case]]
 name = "no_warning_without_unreachable_code"
 source = """
 fn main() -> i32 {

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -456,11 +456,57 @@ one is always rejected.
 
 ### 5.3 Sequencing, discard, and the linear leak check
 
+Expression evaluation carries an outgoing state `Ω`, whose domain is the live
+ownership state or the distinguished bottom state:
+
 ```
-  Γ ; Σ ; Λ ⊢ e1 ⇒ T1 ⊣ Σ1         carries_linear(T1) = false        -- 3.8:64
+  Ω ::= Σ | ⊥
+```
+
+`Σ` means that evaluation can reach the next expression normally; `⊥` means
+that evaluation has no normal outgoing path. This is separate from the surface
+result type: a call with a diverging argument may retain its declared result
+type while producing `⊥`. The dead-source checker may still visit unreachable
+syntax for diagnostics, but those visits do not derive a reachable `Σ`.
+
+Strict evaluation contexts evaluate their hole before the surrounding
+construct can produce its value. Let `E_strict` range over the operand,
+receiver, argument, initializer, condition, index, and field/value positions of
+assignment, calls, aggregates, projections, strict operators, and intrinsics.
+Short-circuit `&&` and `||` are derived as conditionals (§2.4) and are not
+strict in their right operand. The generic propagation rule is:
+
+```
+  Γ ; Σ ; Λ ⊢ e ⇒ T ⊣ ⊥
+  ─────────────────────────────────────────────── (Strict-Bottom)
+  Γ ; Σ ; Λ ⊢ E_strict[e] ⇒ T_E ⊣ ⊥
+```
+
+`T_E` is the construct's ordinary surface result type (for example `unit` for
+assignment or `Tr` for a call); strict evaluation does not rewrite it to
+`never`. A non-strict context such as a sequence tail is not in `E_strict` and
+uses the explicit bottom rules below. This single rule covers assignment,
+aggregate construction, indexing/field access, call receivers and arguments,
+intrinsic operands, and control-flow conditions without duplicating one bottom
+rule per syntax form.
+
+```
+  Γ ; Σ ; Λ ⊢ e1 ⇒ T1 ⊣ Σ1         T1 ≠ never   carries_linear(T1) = false -- 3.8:64
   Γ ; Σ1 ; Λ ⊢ e2 ⇒ T2 ⊣ Σ2
   ─────────────────────────────────────────────────────────────────── (Seq)
   Γ ; Σ ; Λ ⊢ (e1 ; e2) ⇒ T2 ⊣ Σ2
+
+  Γ ; Σ ; Λ ⊢ e1 ⇒ T1 ⊣ ⊥
+  ─────────────────────────────────────────────────────────────────── (Seq-Bottom)
+  Γ ; Σ ; Λ ⊢ (e1 ; e2) ⇒ never ⊣ ⊥
+
+  Γ ; Σ ; Λ ⊢ e1 ⇒ T1 ⊣ Σ1       Γ, x:T1 ; Σ1[x ↦ Owned] ; Λ ⊢ e2 ⇒ T2 ⊣ Σ2
+  ───────────────────────────────────────────────────────────────────────────── (Let)
+  Γ ; Σ ; Λ ⊢ (let x = e1 ; e2) ⇒ T2 ⊣ Σ2
+
+  Γ ; Σ ; Λ ⊢ e1 ⇒ T1 ⊣ ⊥
+  ─────────────────────────────────────────────────────────────────── (Let-Bottom)
+  Γ ; Σ ; Λ ⊢ (let x = e1 ; e2) ⇒ never ⊣ ⊥
 ```
 
 Discarding a value whose type *carries a linear value* is ill-formed (`3.8:64` —
@@ -474,6 +520,15 @@ Linear` for every type — including enums, whose class is the payload join, and
 zero-length arrays, whose class never reaches Linear.
 `let x = e1 ; e2` is like `Seq` but binds `x` (with `x` Owned in Σ for `e2`) and
 imposes no discard check on `e1`.
+
+`(Seq-Bottom)` and `(Let-Bottom)` are the outgoing-state cases of sequencing:
+once `e1` diverges,
+there is no reachable tail and therefore no `Σ2` to propagate. The surface
+checker may still analyze `e2` to issue unreachable-code diagnostics and report
+ordinary errors in unreachable source, but that analysis does not create a
+reachable ownership path or change the block's `never` type. A semicolon after
+a diverging expression thus has the same result as a tail-position divergence;
+`@assert`, whose analyzed type is `unit`, does not satisfy this rule.
 
 The `@drop(p)` intrinsic is the deliberate, visible discharge of a value's drop
 obligation (`3.9`). For `Affine`/`Linear` operands it consumes the operand, runs
@@ -974,8 +1029,14 @@ and leave Σ unchanged, per §5.4.
       a_i = inout p    (mi = inout):   fully-owned(Σ_{i-1},p), p mutable; Σi = Σ_{i-1};  add (root(p), exclusive) to Λ_call   -- §5.4
   Λ_call is CONSISTENT  (law of exclusivity, §5.4)
   for every (r, _) in Λ_call: fully-owned(Σm,r)       -- loans begin at call entry, after all argument evaluation
+  Tr ≠ never
   ─────────────────────────────────────────────────────────────────────────────── (Call)
   Γ;Σ;Λ ⊢ g ( a1, ..., am ) ⇒ Tr ⊣ Σm
+
+  Γ ⊢ g : (T₁, ..., Tₘ) → Tr       m = |a₁, ..., aₘ|       Tr = never
+  Γ;Σᵢ₋₁;Λᵢ₋₁ ⊢ aᵢ ⇒ Uᵢ ⊣ Σᵢ    (1 ≤ i ≤ m), with Σ₀ = Σ and Λ₀ = Λ
+  ─────────────────────────────────────────────────────────────────────────────── (Call-Bottom)
+  Γ;Σ;Λ ⊢ g ( a1, ..., am ) ⇒ never ⊣ ⊥
 ```
 
 The result type is the callee's return type `Tr` (`4.10:5`); the argument count


### PR DESCRIPTION
## Summary

- propagate canonical normal-continuation facts through inference and semantic block analysis
- preserve unreachable diagnostics, ownership state, and strict versus short-circuit behavior
- align formal outgoing-state sequencing and add traceable specification and UI coverage

## Validation

- scripts/rue fmt
- scripts/rue quick
- scripts/rue premerge
- scripts/rue test

Fixes RUE-1599