### PR TITLE
RUE-1617: stop cryptographic and eager-format costs in query keys

### DIFF
--- a/crates/rue-compiler/src/bound_definitions.rs
+++ b/crates/rue-compiler/src/bound_definitions.rs
@@ -4,8 +4,6 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
-use sha2::{Digest, Sha256};
-
 use crate::ModuleId;
 
 /// Durable-key name for the canonical semantic namespace taxonomy.
@@ -58,19 +56,17 @@ struct StableDefinitionIdentity {
 #[derive(Clone)]
 pub struct StableDefinitionKey(Arc<StableDefinitionIdentity>);
 
-struct DefinitionIdentityDigester(Sha256);
-
-impl Hasher for DefinitionIdentityDigester {
-    fn finish(&self) -> u64 {
-        let digest = self.0.clone().finalize();
-        u64::from_le_bytes(digest[..8].try_into().expect("SHA-256 prefix length"))
-    }
-
-    fn write(&mut self, bytes: &[u8]) {
-        self.0.update(bytes);
-    }
-}
-
+/// Bucket-selector digest for one issued definition identity.
+///
+/// This is a hash-table accelerator, never a durable or serialized value:
+/// [`StableDefinitionKey`]'s `PartialEq` and `Ord` remain authoritative over
+/// the complete fields, so a collision here costs one extra field comparison
+/// in a bucket and can never conflate distinct keys. That makes a
+/// cryptographic digest unnecessary — issuance previously ran SHA-256 over
+/// every module, name, and owner string, which measured 1.9% of a fresh
+/// Lattice compile purely to select buckets. `StableHasher` is the
+/// repository's fixed-key, byte-order-independent mixer, so the accelerator
+/// stays deterministic across processes at a fraction of the cost.
 fn definition_hash_accelerator(
     module: &ModuleId,
     namespace: StableDefinitionNamespace,
@@ -78,17 +74,14 @@ fn definition_hash_accelerator(
     name: &Arc<str>,
     owner: &Option<StableNamedTypeKey>,
 ) -> [u8; 16] {
-    let mut hasher = DefinitionIdentityDigester(Sha256::new());
-    hasher.write(b"rue.stable-definition-key\0v1\0sha256\0");
+    let mut hasher = rue_query::StableHasher::new();
+    hasher.write(b"rue.stable-definition-key\0v2\0stable-hasher\0");
     module.hash(&mut hasher);
     namespace.hash(&mut hasher);
     kind.hash(&mut hasher);
     name.hash(&mut hasher);
     owner.hash(&mut hasher);
-    let digest = hasher.0.finalize();
-    digest[..16]
-        .try_into()
-        .expect("SHA-256 accelerator prefix length")
+    hasher.finish128().to_u128().to_le_bytes()
 }
 
 impl StableDefinitionKey {

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -7,7 +7,7 @@
 
 use std::hash::{Hash, Hasher};
 use std::num::NonZeroUsize;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use lasso::Key as _;
 use rue_query::{QueryAbort, QueryContext, QueryFamily, QueryKey, QueryOutcome, QueryOutput};
@@ -111,7 +111,9 @@ pub(crate) struct CfgQueryKey {
     pub(crate) configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
     pub(crate) semantic_input: CfgSemanticInput,
     memo_hash: u64,
-    display_identity: Arc<str>,
+    /// Formatted only when something asks what this node is called
+    /// (ADR-0074); ordinary compilation never reads it.
+    display_identity: OnceLock<Arc<str>>,
 }
 
 impl CfgQueryKey {
@@ -123,7 +125,7 @@ impl CfgQueryKey {
         #[cfg(test)]
         CFG_QUERY_KEY_CONSTRUCTIONS.with(|count| count.set(count.get() + 1));
 
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        let mut hasher = rue_query::StableHasher::new();
         // The family index needs a well-distributed in-process partition, not a
         // durable fingerprint of the whole semantic payload. Function and
         // configuration distribute independent CFGs across shards; the small
@@ -135,18 +137,21 @@ impl CfgQueryKey {
         function.hash(&mut hasher);
         configuration.hash(&mut hasher);
         let memo_hash = hasher.finish();
-        let display_identity: Arc<str> = format!(
-            "{function:?};target={:?};preview={:?}",
-            configuration.target, configuration.preview_features
-        )
-        .into();
         Self {
             function,
             configuration,
             semantic_input,
             memo_hash,
-            display_identity,
+            display_identity: OnceLock::new(),
         }
+    }
+
+    fn format_identity(&self) -> String {
+        let function = &self.function;
+        format!(
+            "{function:?};target={:?};preview={:?}",
+            self.configuration.target, self.configuration.preview_features
+        )
     }
 }
 
@@ -168,11 +173,13 @@ impl Hash for CfgQueryKey {
 
 impl QueryKey for CfgQueryKey {
     fn stable_identity(&self) -> String {
-        self.display_identity.to_string()
+        self.format_identity()
     }
 
     fn shared_stable_identity(&self) -> Arc<str> {
-        self.display_identity.clone()
+        self.display_identity
+            .get_or_init(|| self.format_identity().into())
+            .clone()
     }
 
     /// Function and configuration, which is exactly what `memo_hash` and the
@@ -436,7 +443,10 @@ pub(crate) struct OptimizedCfgQueryKey {
     pub(crate) cfg: CfgQueryKey,
     pub(crate) opt_level: rue_cfg::OptLevel,
     pub(crate) accessor_dependencies: Arc<[CfgQueryKey]>,
-    display_identity: Arc<str>,
+    /// Lazy for the same reason as [`CfgQueryKey`]: building it forced the
+    /// inner CFG key's identity too, so every optimized-CFG key formatted a
+    /// recursive function identity that normal compilation never reads.
+    display_identity: OnceLock<Arc<str>>,
 }
 
 impl OptimizedCfgQueryKey {
@@ -445,18 +455,21 @@ impl OptimizedCfgQueryKey {
         opt_level: rue_cfg::OptLevel,
         accessor_dependencies: Arc<[CfgQueryKey]>,
     ) -> Self {
-        let cfg_identity = cfg.shared_stable_identity();
-        let display_identity: Arc<str> = format!(
-            "{cfg_identity};opt={opt_level:?};accessors={}",
-            accessor_dependencies.len()
-        )
-        .into();
         Self {
             cfg,
             opt_level,
             accessor_dependencies,
-            display_identity,
+            display_identity: OnceLock::new(),
         }
+    }
+
+    fn format_identity(&self) -> String {
+        let cfg_identity = self.cfg.shared_stable_identity();
+        let opt_level = self.opt_level;
+        format!(
+            "{cfg_identity};opt={opt_level:?};accessors={}",
+            self.accessor_dependencies.len()
+        )
     }
 }
 
@@ -480,11 +493,13 @@ impl std::hash::Hash for OptimizedCfgQueryKey {
 
 impl QueryKey for OptimizedCfgQueryKey {
     fn stable_identity(&self) -> String {
-        self.display_identity.to_string()
+        self.format_identity()
     }
 
     fn shared_stable_identity(&self) -> Arc<str> {
-        self.display_identity.clone()
+        self.display_identity
+            .get_or_init(|| self.format_identity().into())
+            .clone()
     }
 
     fn stable_hash(&self, hasher: &mut rue_query::StableHasher) {

--- a/crates/rue-compiler/src/codegen_query.rs
+++ b/crates/rue-compiler/src/codegen_query.rs
@@ -8,7 +8,7 @@
 
 use std::{
     hash::{Hash, Hasher},
-    sync::Arc,
+    sync::{Arc, OnceLock},
 };
 
 use rue_query::{QueryAbort, QueryContext, QueryFamily, QueryKey, QueryOutcome, QueryOutput};
@@ -72,7 +72,11 @@ pub(crate) struct CodegenUnitQueryKey {
     #[cfg(test)]
     inject_failure: bool,
     memo_hash: u64,
-    display_identity: Arc<str>,
+    /// Formatted on the first diagnostic, cycle render, or abort that asks
+    /// what this node is *called* (ADR-0074). Ordinary compilation never
+    /// reads it: eagerly formatting `{function:?}` here walked the whole
+    /// recursive function identity and allocated for every constructed key.
+    display_identity: OnceLock<Arc<str>>,
 }
 
 impl CodegenUnitQueryKey {
@@ -94,7 +98,11 @@ impl CodegenUnitQueryKey {
         optimized_cfg_batch: Option<Arc<crate::revisioned_query_database::OptimizedCfgBatchKey>>,
     ) -> Self {
         let function = optimized_cfg.cfg.function.clone();
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        // A memo bucket selector, not an identity: `PartialEq` below compares
+        // the complete fields, so this only has to be fast and deterministic.
+        // `DefaultHasher` is SipHash-1-3, which dominated key construction on
+        // a fresh Lattice compile.
+        let mut hasher = rue_query::StableHasher::new();
         function.hash(&mut hasher);
         target.hash(&mut hasher);
         target.data_model().hash(&mut hasher);
@@ -116,11 +124,6 @@ impl CodegenUnitQueryKey {
         let memo_hash = hasher.finish();
         let data_model = target.data_model();
         let code_model = CodeModel::for_target(target);
-        let display_identity: Arc<str> = format!(
-            "{function:?};target={target:?};data-model={data_model:?};code-model={code_model:?};opt={optimization:?};backend={BACKEND_EPOCH};abi-layout={ABI_LAYOUT_EPOCH};batch={}",
-            optimized_cfg_batch.is_some()
-        )
-        .into();
         Self {
             function,
             target,
@@ -135,8 +138,20 @@ impl CodegenUnitQueryKey {
             #[cfg(test)]
             inject_failure,
             memo_hash,
-            display_identity,
+            display_identity: OnceLock::new(),
         }
+    }
+
+    fn format_identity(&self) -> String {
+        let function = &self.function;
+        let target = self.target;
+        let data_model = self.data_model;
+        let code_model = self.code_model;
+        let optimization = self.optimization;
+        format!(
+            "{function:?};target={target:?};data-model={data_model:?};code-model={code_model:?};opt={optimization:?};backend={BACKEND_EPOCH};abi-layout={ABI_LAYOUT_EPOCH};batch={}",
+            self.optimized_cfg_batch.is_some()
+        )
     }
 }
 
@@ -172,11 +187,13 @@ impl Hash for CodegenUnitQueryKey {
 }
 impl QueryKey for CodegenUnitQueryKey {
     fn stable_identity(&self) -> String {
-        self.display_identity.to_string()
+        self.format_identity()
     }
 
     fn shared_stable_identity(&self) -> Arc<str> {
-        self.display_identity.clone()
+        self.display_identity
+            .get_or_init(|| self.format_identity().into())
+            .clone()
     }
 
     /// The same field set `memo_hash` covers, absorbed structurally.

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -1,4 +1,8 @@
-use std::collections::HashMap;
+// Local, request-scoped maps keyed by dense type/symbol identities. Equality
+// stays authoritative, so the hasher is a bucket selector: `ahash` replaces
+// SipHash here because CFG domain projection rebuilds these maps for every
+// body on the fresh-compile path.
+use ahash::AHashMap as HashMap;
 use std::sync::Arc;
 
 use lasso::{Key, Spur};
@@ -12,7 +16,7 @@ type CanonicalType = SemanticImportType<crate::StableDefinitionKey, crate::Modul
 #[cfg(test)]
 pub(crate) struct CfgTypeAdmissionIndex<'a> {
     pool: &'a rue_air::FrozenTypeInternPool,
-    aggregates: &'a HashMap<Type, crate::TypeInstanceKey>,
+    aggregates: &'a std::collections::HashMap<Type, crate::TypeInstanceKey>,
     live_by_stable: Option<HashMap<CanonicalType, Type>>,
 }
 
@@ -20,7 +24,7 @@ pub(crate) struct CfgTypeAdmissionIndex<'a> {
 impl<'a> CfgTypeAdmissionIndex<'a> {
     pub(crate) fn new(
         pool: &'a rue_air::FrozenTypeInternPool,
-        aggregates: &'a HashMap<Type, crate::TypeInstanceKey>,
+        aggregates: &'a std::collections::HashMap<Type, crate::TypeInstanceKey>,
     ) -> Self {
         Self {
             pool,
@@ -128,7 +132,7 @@ fn live_instruction_kind(data: &AirInstData) -> rue_air::SemanticBodyInstKind {
 fn canonical_type_from_live_cached(
     ty: Type,
     pool: &rue_air::FrozenTypeInternPool,
-    aggregates: &HashMap<Type, crate::TypeInstanceKey>,
+    aggregates: &std::collections::HashMap<Type, crate::TypeInstanceKey>,
     stable_by_live: &mut HashMap<Type, CanonicalType>,
 ) -> Result<CanonicalType, CfgDomainFailure> {
     if let Some(stable) = stable_by_live.get(&ty) {
@@ -239,7 +243,7 @@ fn record_cfg_type(
     types: &mut Vec<(Type, CanonicalType)>,
     ty: Type,
     pool: &rue_air::FrozenTypeInternPool,
-    aggregates: &HashMap<Type, crate::TypeInstanceKey>,
+    aggregates: &std::collections::HashMap<Type, crate::TypeInstanceKey>,
     stable_by_live: &mut HashMap<Type, CanonicalType>,
 ) -> Result<(), CfgDomainFailure> {
     match canonical_type_from_live_cached(ty, pool, aggregates, stable_by_live) {
@@ -562,7 +566,7 @@ impl CfgDomainProjection {
             .types
             .iter()
             .map(|(_, stable)| stable.clone())
-            .collect::<std::collections::HashSet<_>>();
+            .collect::<ahash::AHashSet<_>>();
         for (_, stable) in &old.types {
             if live_primitive(stable).is_some() || !stable_types.insert(stable.clone()) {
                 continue;
@@ -614,11 +618,7 @@ impl CfgDomainProjection {
             old_symbols.entry(*live).or_insert(stable);
         }
         let mut indices = first_string_indices(strings)?;
-        let mut domain_strings = self
-            .strings
-            .iter()
-            .cloned()
-            .collect::<std::collections::HashSet<_>>();
+        let mut domain_strings = self.strings.iter().cloned().collect::<ahash::AHashSet<_>>();
         let mut additions = Vec::new();
         let mut string_map = std::collections::BTreeMap::new();
         for (old_index, stable) in &old.strings {
@@ -1142,10 +1142,7 @@ impl CfgDomainProjection {
             .iter()
             .map(|(current, _)| *current)
             .collect::<Vec<_>>();
-        let mut enqueued = pending
-            .iter()
-            .copied()
-            .collect::<std::collections::HashSet<_>>();
+        let mut enqueued = pending.iter().copied().collect::<ahash::AHashSet<_>>();
         let mut visited = std::collections::HashSet::new();
         let mut incomplete = false;
         while let Some(current) = pending.pop() {
@@ -1362,7 +1359,7 @@ mod tests {
         let old = projection(symbol);
         let mut current = projection(symbol);
         let pool = rue_air::TypeInternPool::new().freeze();
-        let aggregates = HashMap::new();
+        let aggregates = std::collections::HashMap::new();
         let mut admission = CfgTypeAdmissionIndex::new(&pool, &aggregates);
 
         current.admit_stable_types(&old, &mut admission).unwrap();

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -403,7 +403,11 @@ impl<T: Clone + Eq + Hash> SliceInterner<T> {
     /// it as the shared copy. Returns whether the slice was reused.
     fn intern(&mut self, values: Vec<T>) -> (Arc<[T]>, bool) {
         use std::hash::Hasher;
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        // Bucket selector only: the scan below compares slice contents, so a
+        // collision costs one extra comparison rather than sharing a wrong
+        // slice. SipHash over every selected fact slice was measurable on the
+        // fresh-compile materialization path.
+        let mut hasher = rue_query::StableHasher::new();
         values.hash(&mut hasher);
         let bucket = self.buckets.entry(hasher.finish()).or_default();
         if let Some(shared) = bucket

--- a/crates/rue-compiler/src/object_query.rs
+++ b/crates/rue-compiler/src/object_query.rs
@@ -48,7 +48,9 @@ pub(crate) struct ObjectProjectionQueryKey {
     pub(crate) object_format: ObjectFormat,
     pub(crate) abi_layout_epoch: u32,
     pub(crate) object_writer_epoch: u32,
-    display_identity: Arc<str>,
+    /// Lazy (ADR-0074): formatting this forced the codegen key's identity,
+    /// which walks the whole recursive function identity.
+    display_identity: OnceLock<Arc<str>>,
 }
 
 impl ObjectProjectionQueryKey {
@@ -56,19 +58,24 @@ impl ObjectProjectionQueryKey {
         let target = codegen.target;
         let object_format = ObjectFormat::for_target(target);
         let abi_layout_epoch = codegen.abi_layout_epoch;
-        let codegen_identity = codegen.shared_stable_identity();
-        let display_identity: Arc<str> = format!(
-            "object-projection;{codegen_identity};target={target:?};format={object_format:?};abi-layout={abi_layout_epoch};writer={OBJECT_WRITER_EPOCH}"
-        )
-        .into();
         Self {
             abi_layout_epoch,
             codegen,
             target,
             object_format,
             object_writer_epoch: OBJECT_WRITER_EPOCH,
-            display_identity,
+            display_identity: OnceLock::new(),
         }
+    }
+
+    fn format_identity(&self) -> String {
+        let codegen_identity = self.codegen.shared_stable_identity();
+        let target = self.target;
+        let object_format = self.object_format;
+        let abi_layout_epoch = self.abi_layout_epoch;
+        format!(
+            "object-projection;{codegen_identity};target={target:?};format={object_format:?};abi-layout={abi_layout_epoch};writer={OBJECT_WRITER_EPOCH}"
+        )
     }
 }
 
@@ -96,11 +103,13 @@ impl Hash for ObjectProjectionQueryKey {
 
 impl QueryKey for ObjectProjectionQueryKey {
     fn stable_identity(&self) -> String {
-        self.display_identity.to_string()
+        self.format_identity()
     }
 
     fn shared_stable_identity(&self) -> Arc<str> {
-        self.display_identity.clone()
+        self.display_identity
+            .get_or_init(|| self.format_identity().into())
+            .clone()
     }
 
     fn stable_hash(&self, hasher: &mut rue_query::StableHasher) {


### PR DESCRIPTION
Implements RUE-1617.

## What this is

A profile-driven constant-factor pass on the fresh-compile path.

A callgrind run of a fresh `-O3 -j1` Lattice build (9.49G instructions, release build) attributes roughly half of all retired instructions to identity-key hashing, comparison, and the allocation traffic around them, against about 27% doing actual compilation:

| Category | Instructions | Share |
| --- | ---: | ---: |
| real compiler work (cfg/codegen/air/parse) | 2,493,799,931 | 27.3% |
| identity keys: hash/cmp/clone | 1,746,881,845 | 19.1% |
| other/uncategorized | 1,527,746,877 | 16.7% |
| hash tables (hashbrown/sip/btree/dashmap) | 1,460,447,487 | 16.0% |
| allocator (mimalloc) | 780,687,295 | 8.5% |
| memcpy/memcmp | 533,604,405 | 5.8% |
| query runtime bookkeeping | 468,567,434 | 5.1% |
| SHA-256 digests | 119,790,480 | 1.3% |

This change takes the subset of that where a cryptographic or presentation cost was being paid for work that only needed a fast, deterministic bucket selector.

## Changes

**Eager display identities.** ADR-0074 established that a query key's presentation text is formatted on first diagnostic, cycle render, or abort, and `BodyQueryKey` already holds it in a `OnceLock`. Four keys still formatted eagerly in their constructors: `CodegenUnitQueryKey`, `ObjectProjectionQueryKey`, `CfgQueryKey`, and `OptimizedCfgQueryKey`. Each `format!` rendered `{function:?}` — a Debug walk of the whole recursive `FunctionInstanceKey` tree — plus an allocation, for text ordinary compilation never reads. The wrapper keys compounded it: building an object-projection identity forced its codegen key's identity, which walked the function identity again. `CodegenUnitQueryKey::new_with_batch` alone measured 117,311 instructions per call.

**Cryptographic bucket selectors.** `StableDefinitionKey`'s hash accelerator ran SHA-256 over every module, name, and owner string at issuance. It is documented as a bucket selector, recomputed at issuance and never durable or serialized, with `PartialEq` and `Ord` authoritative over the complete fields — so a collision costs one extra comparison in a bucket and can never conflate distinct keys. The per-key memo hashes in `CodegenUnitQueryKey` and `CfgQueryKey`, and the slice-interner bucket in local semantic materialization, likewise used `DefaultHasher` (SipHash-1-3) where typed equality already decides. All four now use the repository's fixed-key `StableHasher`, which stays deterministic across processes and byte orders.

**Per-body maps.** `durable_cfg`'s request-scoped maps, rebuilt for every body during CFG domain projection, now use `ahash` rather than SipHash. Maps that cross the materialization boundary keep their `std` type.

## Result

Same fresh `-O3 -j1` Lattice build:

- **9,486,324,770 → 9,140,648,435 retired instructions (−3.64%)**
- Emitted executable **byte-identical** to the previous compiler's output (`cmp`-verified)
- SipHash fell from 5.80% to 2.91% of the profile; SHA-256 from 1.93% to 1.31%

Wall time on the development host is within run-to-run noise at this magnitude; the instruction count is the deterministic signal. That host is a 4-core container where a fresh Lattice build runs ~2.2–2.4s at `-j1`, so it is not a substitute for the ADR-0071 reference regime — the reference collection remains the authority for any milestone claim.

## On iteration order

Changing a map's hasher changes its iteration order, which would matter if any emitted output depended on it. It cannot: `std::collections::HashMap` seeds `RandomState` per process, so the order of these maps was already arbitrary from run to run, and `compiler reproducibility` is a passing gate on trunk. The byte-identical executable and the green reproducibility check confirm it directly.

## Validation

- `scripts/rue quick` — 31 pass, 0 fail
- `scripts/rue premerge` — 196 pass, 0 fail
- `scripts/rue fmt` applied
- Emitted Lattice executable byte-identical against the pre-change compiler

## What this is not

A constant-factor pass over the measurement layer, not the architectural one. The dominant remaining cost is structural: `FunctionInstanceKey`, `TypeInstanceKey`, and `AnonymousNominalKey` are recursive trees (`Specialization { base: Box<…>, arguments: { types: Arc<[TypeInstanceKey]>, … } }`) re-walked on every hash, compare, and clone. `CodegenUnitQueryKey::stable_hash` still costs **44,455 instructions per call** against roughly 500 for a flat key, and wrapper keys re-walk the same tree (`ObjectProjection → CodegenUnit → FunctionInstanceKey`, and again via `OptimizedCfg → Cfg → FunctionInstanceKey`).

Caching a digest inside those keys is not open: `stable_key_witness` re-runs `stable_hash` with a recording hasher to obtain the structural collision tiebreak, so a cached digest would collapse the witness to its own bytes and defeat the forced-collision test. Interning the identities behind handles — the direction ADR-0074's "shared family handle plus a 128-bit digest" already gestures at — addresses both, and is left to a separate change.