### PR TITLE
RUE-1613: clarify mixed-kind duplicate diagnostics

### DIFF
--- a/crates/rue-air/src/declaration_validation.rs
+++ b/crates/rue-air/src/declaration_validation.rs
@@ -48,8 +48,8 @@ pub fn const_cross_kind_collision(
     is_value_const: bool,
     has_non_const_declaration: bool,
 ) -> Option<ErrorKind> {
-    (is_value_const && has_non_const_declaration).then(|| ErrorKind::DuplicateFunctionDefinition {
-        function_name: name.to_owned(),
+    (is_value_const && has_non_const_declaration).then(|| ErrorKind::DuplicateMixedKindDefinition {
+        name: name.to_owned(),
     })
 }
 

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -2123,7 +2123,7 @@ fn main() -> i32 {
 """ },
 ]
 compile_fail = true
-error_contains = ["E0436", "Thing"]
+error_contains = ["E0436", "Thing", "different kind"]
 
 # fn + struct with one name in DIFFERENT files: module-scoped, legal
 # (RUE-572); the call resolves to main.rue's own fn. RUE-767 modernized this
@@ -2172,7 +2172,7 @@ fn main() -> i32 {
 """ },
 ]
 compile_fail = true
-error_contains = ["E0436", "Color"]
+error_contains = ["E0436", "Color", "different kind"]
 
 # Regression: fn + fn duplicate still E0436 (the check that already existed).
 [[case]]

--- a/crates/rue-compiler/src/canonical_merge.rs
+++ b/crates/rue-compiler/src/canonical_merge.rs
@@ -205,13 +205,13 @@ fn duplicate_errors<'a>(
                         functions.insert(name, definition());
                     }
                     if let Some(first) = type_names.get(name) {
-                        errors.push(function_conflict(candidate.declaration_span, name, first));
+                        errors.push(mixed_kind_conflict(candidate.declaration_span, name, first));
                     }
                     function_names.entry(name).or_insert_with(definition);
                 }
                 DefinitionKind::Struct => {
                     if let Some(first) = function_names.get(name) {
-                        errors.push(function_conflict(candidate.declaration_span, name, first));
+                        errors.push(mixed_kind_conflict(candidate.declaration_span, name, first));
                     } else if let Some(first) = structs.get(name) {
                         errors.push(type_conflict(
                             candidate.declaration_span,
@@ -233,7 +233,7 @@ fn duplicate_errors<'a>(
                 }
                 DefinitionKind::Enum => {
                     if let Some(first) = function_names.get(name) {
-                        errors.push(function_conflict(candidate.declaration_span, name, first));
+                        errors.push(mixed_kind_conflict(candidate.declaration_span, name, first));
                     } else if let Some(first) = enums.get(name) {
                         errors.push(type_conflict(
                             candidate.declaration_span,
@@ -264,6 +264,19 @@ fn function_conflict(span: Span, name: &str, first: &CandidateDef) -> CompileErr
     CompileError::new(
         ErrorKind::DuplicateFunctionDefinition {
             function_name: name.to_owned(),
+        },
+        span,
+    )
+    .with_label(
+        format!("first defined in {}", first.physical_path),
+        first.span,
+    )
+}
+
+fn mixed_kind_conflict(span: Span, name: &str, first: &CandidateDef) -> CompileError {
+    CompileError::new(
+        ErrorKind::DuplicateMixedKindDefinition {
+            name: name.to_owned(),
         },
         span,
     )
@@ -343,7 +356,7 @@ mod tests {
         ));
         assert!(matches!(
             &errors[1].kind,
-            ErrorKind::DuplicateFunctionDefinition { function_name } if function_name == "clash"
+            ErrorKind::DuplicateMixedKindDefinition { name } if name == "clash"
         ));
         assert!(matches!(
             &errors[2].kind,

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -1198,7 +1198,7 @@ mod tests {
         ));
         assert!(matches!(
             errors.as_slice()[1].kind,
-            ErrorKind::DuplicateFunctionDefinition { ref function_name } if function_name == "clash"
+            ErrorKind::DuplicateMixedKindDefinition { ref name } if name == "clash"
         ));
     }
 

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -1359,6 +1359,7 @@ impl RetainedCharge for rue_error::ErrorKind {
             | E::DuplicateFunctionDefinition {
                 function_name: value,
             }
+            | E::DuplicateMixedKindDefinition { name: value }
             | E::LinearValueDiscarded { type_name: value }
             | E::LinearValueOverwritten { type_name: value }
             | E::LinearValueOverwrittenThroughInout { type_name: value }

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -19295,8 +19295,8 @@ impl RevisionedQueryDatabase {
                             type_names.get(&name).map(|first| {
                                 (
                                     first,
-                                    rue_error::ErrorKind::DuplicateFunctionDefinition {
-                                        function_name: name.to_string(),
+                                    rue_error::ErrorKind::DuplicateMixedKindDefinition {
+                                        name: name.to_string(),
                                     },
                                 )
                             })
@@ -19306,8 +19306,8 @@ impl RevisionedQueryDatabase {
                         if let Some(first) = function_names.get(&name) {
                             Some((
                                 first,
-                                rue_error::ErrorKind::DuplicateFunctionDefinition {
-                                    function_name: name.to_string(),
+                                rue_error::ErrorKind::DuplicateMixedKindDefinition {
+                                    name: name.to_string(),
                                 },
                             ))
                         } else if let Some(first) = structs.get(&name) {
@@ -19332,8 +19332,8 @@ impl RevisionedQueryDatabase {
                         if let Some(first) = function_names.get(&name) {
                             Some((
                                 first,
-                                rue_error::ErrorKind::DuplicateFunctionDefinition {
-                                    function_name: name.to_string(),
+                                rue_error::ErrorKind::DuplicateMixedKindDefinition {
+                                    name: name.to_string(),
                                 },
                             ))
                         } else if let Some(first) = enums.get(&name) {
@@ -28485,7 +28485,7 @@ fn main() -> i32 {
                     matches!(
                         value,
                         Value::Failure(Failure::Diagnostic(
-                            rue_error::ErrorKind::DuplicateFunctionDefinition { .. }
+                            rue_error::ErrorKind::DuplicateMixedKindDefinition { .. }
                         ))
                     )
                 },

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1333,6 +1333,9 @@ pub enum ErrorKind {
     /// Duplicate function definition
     #[error("duplicate function definition: `{function_name}` is already defined")]
     DuplicateFunctionDefinition { function_name: String },
+    /// Definitions with the same name but different kinds cannot coexist.
+    #[error("duplicate definition: `{name}` conflicts with an existing item of a different kind")]
+    DuplicateMixedKindDefinition { name: String },
     /// Linear value was not consumed before going out of scope
     #[error("linear value '{0}' must be consumed but was dropped")]
     LinearValueNotConsumed(String),
@@ -2113,7 +2116,8 @@ impl ErrorKind {
             ErrorKind::ReservedTypeName { .. } => ErrorCode::RESERVED_TYPE_NAME,
             ErrorKind::ReservedFunctionName { .. } => ErrorCode::RESERVED_FUNCTION_NAME,
             ErrorKind::DuplicateTypeDefinition { .. } => ErrorCode::DUPLICATE_TYPE_DEFINITION,
-            ErrorKind::DuplicateFunctionDefinition { .. } => {
+            ErrorKind::DuplicateFunctionDefinition { .. }
+            | ErrorKind::DuplicateMixedKindDefinition { .. } => {
                 ErrorCode::DUPLICATE_FUNCTION_DEFINITION
             }
             ErrorKind::LinearValueNotConsumed(_) => ErrorCode::LINEAR_VALUE_NOT_CONSUMED,
@@ -2604,10 +2608,11 @@ mod tests {
         );
     }
 
-    /// `ErrorKind::code()` must be injective: no two ErrorKind variants may
-    /// map to the same ErrorCode constant, and every constant must be used by
-    /// exactly one variant (a constant nobody maps to is dead, and usually a
-    /// sign that a variant was repointed at someone else's code).
+    /// `ErrorKind::code()` must cover the declared ErrorCode constants without
+    /// accidental aliases. Intentional aliases (such as the two E0436
+    /// duplicate-definition variants) share one match arm, and every constant
+    /// must be used (a constant nobody maps to is dead, and usually a sign that
+    /// a variant was repointed at someone else's code).
     ///
     /// `test_error_codes_are_unique` (above) guards constant *values*; this
     /// test guards the variant -> constant *mapping*. It scans the body of

--- a/crates/rue-spec/cases/modules/composition.toml
+++ b/crates/rue-spec/cases/modules/composition.toml
@@ -86,7 +86,7 @@ fn X() -> i32 { 2 }
 fn main() -> i32 { 0 }
 """
 compile_fail = true
-error_contains = "E0436"
+error_contains = ["E0436", "different kind"]
 
 [[case]]
 name = "same_file_duplicate_constant_error"
@@ -122,7 +122,7 @@ fn Point() -> i32 { 2 }
 fn main() -> i32 { 0 }
 """
 compile_fail = true
-error_contains = ["E0436", "Point"]
+error_contains = ["E0436", "Point", "different kind"]
 
 [[case]]
 name = "same_file_type_constant_collision_error"
@@ -134,7 +134,31 @@ const Color: i32 = 1;
 fn main() -> i32 { 0 }
 """
 compile_fail = true
-error_contains = ["E0436", "Color"]
+error_contains = ["E0436", "Color", "different kind"]
+
+[[case]]
+name = "same_file_struct_constant_collision_error"
+spec = ["10.5:1"]
+description = "A struct and a constant sharing one name use the kind-neutral E0436 diagnostic"
+source = """
+struct Thing { value: i32 }
+const Thing: i32 = 1;
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0436", "Thing", "different kind"]
+
+[[case]]
+name = "same_file_constant_struct_collision_error"
+spec = ["10.5:1"]
+description = "A constant and a struct sharing one name use the kind-neutral E0436 diagnostic"
+source = """
+const Thing: i32 = 1;
+struct Thing { value: i32 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0436", "Thing", "different kind"]
 
 [[case]]
 name = "same_named_functions_qualified_calls_sum"


### PR DESCRIPTION
## Summary
- give mixed-kind top-level name collisions a kind-neutral E0436 message
- retain explicit duplicate-function wording for fn/fn and the existing code partition
- add declaration-order and nearby regression coverage

## Testing
- scripts/rue fmt
- scripts/rue quick
- focused spec and CLI cases
- scripts/rue premerge

Fixes RUE-1613