### PR TITLE
RUE-1625: make ahash the consistent compiler map hasher

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -18,7 +18,6 @@ use crate::types::{ModuleId, StructId, TypeKind};
 use lasso::{Spur, ThreadedRodeo};
 use rue_rir::{InstData, InstRef, RepeatCount, Rir, RirTypeSyntaxNode, RirTypeSyntaxRef};
 use rue_span::{FileId, Span};
-use std::collections::HashMap;
 
 use ahash::AHashMap;
 use std::rc::Rc;
@@ -110,7 +109,7 @@ pub struct MethodSig {
 ///
 /// Constraint generation consults the thirteen declaration-universe families
 /// purely by key. Rather than eagerly project the whole universe into owned
-/// `HashMap`s before any body is analyzed (the O(universe)-per-body term
+/// `AHashMap`s before any body is analyzed (the O(universe)-per-body term
 /// RUE-1083 removes), the production path implements this trait over the frozen
 /// declaration state and materializes each consulted signature/type on first
 /// lookup. Every method answers exactly the same value the eager projection
@@ -238,9 +237,9 @@ pub struct ConstraintGenerator<'a> {
     /// decides the pool indices those array types receive, and those indices
     /// are later a sort key (`sort_unstable_by_key(Type::as_u32)`). The order
     /// is observable, so the hasher is not a free choice here.
-    expr_types: HashMap<InstRef, InferType>,
+    expr_types: std::collections::HashMap<InstRef, InferType>,
     /// Whether each generated expression reaches its next evaluation point.
-    expr_continues: HashMap<InstRef, bool>,
+    expr_continues: AHashMap<InstRef, bool>,
     /// Function signatures (for call type checking). `None` when the generator
     /// is driven by a lazy provider (`lazy`), which materializes signatures on
     /// demand; unit tests still supply an eager map.
@@ -414,8 +413,8 @@ impl<'a> ConstraintGenerator<'a> {
             interner,
             type_vars: TypeVarAllocator::new(),
             constraints: Vec::with_capacity(rir_capacity),
-            expr_types: HashMap::new(),
-            expr_continues: HashMap::new(),
+            expr_types: std::collections::HashMap::new(),
+            expr_continues: AHashMap::new(),
             functions: Some(functions),
             builtin_structs: Some(builtin_structs),
             structs_by_file_name: None,
@@ -468,8 +467,8 @@ impl<'a> ConstraintGenerator<'a> {
             interner,
             type_vars: TypeVarAllocator::new(),
             constraints: Vec::with_capacity(rir_capacity),
-            expr_types: HashMap::new(),
-            expr_continues: HashMap::new(),
+            expr_types: std::collections::HashMap::new(),
+            expr_continues: AHashMap::new(),
             functions: None,
             builtin_structs: None,
             structs_by_file_name: None,
@@ -957,7 +956,7 @@ impl<'a> ConstraintGenerator<'a> {
     }
 
     /// Get the expression type mapping.
-    pub fn expr_types(&self) -> &HashMap<InstRef, InferType> {
+    pub fn expr_types(&self) -> &std::collections::HashMap<InstRef, InferType> {
         &self.expr_types
     }
 
@@ -973,8 +972,8 @@ impl<'a> ConstraintGenerator<'a> {
         Vec<TypeVarId>,
         Vec<TypeVarId>,
         Type,
-        HashMap<InstRef, InferType>,
-        HashMap<InstRef, bool>,
+        std::collections::HashMap<InstRef, InferType>,
+        AHashMap<InstRef, bool>,
         u32,
     ) {
         (

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -7,7 +7,7 @@
 //! (`provider_body_host`); no whole-program driver lives here.
 
 use super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
-use ahash::{AHashMap, AHashSet};
+use ahash::AHashSet;
 
 use lasso::{Spur, ThreadedRodeo};
 use rue_error::{

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -10,6 +10,7 @@ use super::super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine
 use super::*;
 use crate::sema::NamedConstDependencyTargetEvent;
 use crate::sema::info::FunctionCallInfo;
+use ahash::AHashMap;
 
 fn module_display_name(path: &str) -> &str {
     std::path::Path::new(path)

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -6,6 +6,7 @@
 use super::super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
 use super::*;
 use crate::inference::LazyInferenceFacts;
+use ahash::AHashMap;
 use std::time::Instant;
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -623,7 +623,7 @@ pub(crate) struct AnalysisContext<'a> {
     pub referenced_functions: AHashSet<Spur>,
     /// Methods referenced during analysis of this function.
     /// Each entry is (struct_id, method_name) matching the key format in methods map.
-    pub referenced_methods: AHashSet<(StructId, Spur)>,
+    pub referenced_methods: std::collections::HashSet<(StructId, Spur)>,
     /// While analyzing the value of an `inout`/`borrow` call argument, the ROOT
     /// variable of the place being passed by reference (set by
     /// `analyze_call_args_coerced`; for `f(borrow o.f)` this is `o`). A by-ref argument
@@ -920,7 +920,7 @@ impl<'a> AnalysisContext<'a> {
             comptime_type_vars: self.comptime_type_vars.clone(),
             comptime_value_vars: self.comptime_value_vars.clone(),
             referenced_functions: AHashSet::new(),
-            referenced_methods: AHashSet::new(),
+            referenced_methods: std::collections::HashSet::new(),
             // A by-ref argument's value is a place — a variable or a
             // field/index projection chain (enforced in the call-argument analyzer) —
             // and index subexpressions are analyzed with the root cleared

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -1546,7 +1546,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         Vec<CompileWarning>,
         Vec<String>,
         AHashSet<Spur>,
-        AHashSet<(StructId, Spur)>,
+        std::collections::HashSet<(StructId, Spur)>,
     )> {
         for (_, ty, _, is_comptime) in &param_info {
             reject_runtime_type_value(*ty, *is_comptime, span)?;
@@ -1635,7 +1635,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         Vec<CompileWarning>,
         Vec<String>,
         AHashSet<Spur>,
-        AHashSet<(StructId, Spur)>,
+        std::collections::HashSet<(StructId, Spur)>,
     )> {
         let symbol = self.storage.body_interner().get_or_intern(full_name);
         let identity = crate::FunctionInstanceKey::Definition(
@@ -1691,7 +1691,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         Vec<CompileWarning>,
         Vec<String>,
         AHashSet<Spur>,
-        AHashSet<(StructId, Spur)>,
+        std::collections::HashSet<(StructId, Spur)>,
     )> {
         for (_, ty, _, is_comptime) in &resolved_params {
             reject_runtime_type_value(*ty, *is_comptime, span)?;
@@ -1782,7 +1782,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         Vec<CompileWarning>,
         Vec<String>,
         AHashSet<Spur>,
-        AHashSet<(StructId, Spur)>,
+        std::collections::HashSet<(StructId, Spur)>,
     )> {
         let self_name = self.storage.body_interner().get_or_intern("self");
         let params = [(self_name, struct_type, RirParamMode::Normal, false)];
@@ -1873,7 +1873,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         Vec<String>,
         Vec<crate::LocalAtomRecord<crate::SemanticDefinitionToken, crate::SemanticModuleToken>>,
         AHashSet<Spur>,
-        AHashSet<(StructId, Spur)>,
+        std::collections::HashSet<(StructId, Spur)>,
     )> {
         self.analyze_function_internal(
             infer_ctx,
@@ -1906,7 +1906,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         Vec<String>,
         Vec<crate::LocalAtomRecord<crate::SemanticDefinitionToken, crate::SemanticModuleToken>>,
         AHashSet<Spur>,
-        AHashSet<(StructId, Spur)>,
+        std::collections::HashSet<(StructId, Spur)>,
     )> {
         self.analyze_function_internal(
             infer_ctx,
@@ -1943,7 +1943,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         Vec<String>,
         Vec<crate::LocalAtomRecord<crate::SemanticDefinitionToken, crate::SemanticModuleToken>>,
         AHashSet<Spur>,
-        AHashSet<(StructId, Spur)>,
+        std::collections::HashSet<(StructId, Spur)>,
     )> {
         let expression_setup_started = Instant::now();
         let mut air = Air::new(return_type);
@@ -2133,7 +2133,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             comptime_type_vars,
             comptime_value_vars,
             referenced_functions: AHashSet::new(),
-            referenced_methods: AHashSet::new(),
+            referenced_methods: std::collections::HashSet::new(),
             byref_arg_root: None,
             call_loaned_roots: Vec::new(),
             in_loop_move_recheck: false,

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -384,7 +384,7 @@ pub struct ProviderOrdinaryBody<K, M> {
     pub warnings: Vec<rue_error::CompileWarning>,
     pub strings: Vec<String>,
     pub referenced_functions: AHashSet<Spur>,
-    pub referenced_methods: AHashSet<(StructId, Spur)>,
+    pub referenced_methods: std::collections::HashSet<(StructId, Spur)>,
     pub referenced_definitions: Vec<K>,
     pub referenced_values: Vec<K>,
     pub referenced_specializations:

--- a/crates/rue-air/src/sema/semantic_body_export.rs
+++ b/crates/rue-air/src/sema/semantic_body_export.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ahash::{AHashMap, AHashSet};
+use ahash::AHashMap;
 
 use lasso::Spur;
 use rue_error::CompileWarning;
@@ -60,7 +60,7 @@ pub(crate) fn export_body<H: SemanticBodyExportHost>(
             SemanticSpecializationIdentity<SemanticDefinitionToken, SemanticModuleToken>,
         >,
     >,
-    method_references: &AHashSet<(crate::StructId, Spur)>,
+    method_references: &std::collections::HashSet<(crate::StructId, Spur)>,
 ) -> Result<SemanticBodyExport, F> {
     let warning_anchor = |span: Span| {
         if span.file_id != body_span.file_id

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -325,7 +325,7 @@ pub(crate) struct OneSpecializedBody {
     pub(crate) warnings: Vec<CompileWarning>,
     pub(crate) local_strings: Vec<String>,
     pub(crate) referenced_functions: AHashSet<Spur>,
-    pub(crate) referenced_methods: AHashSet<(StructId, Spur)>,
+    pub(crate) referenced_methods: std::collections::HashSet<(StructId, Spur)>,
     pub(crate) dependencies: Vec<crate::SemanticDefinitionToken>,
     pub(crate) dependency_boundary_complete: bool,
     pub(crate) identity: crate::SemanticSpecializationIdentity<

--- a/crates/rue-cfg/BUCK
+++ b/crates/rue-cfg/BUCK
@@ -6,6 +6,7 @@ rue_crate(
         "//crates/rue-air:rue-air",
         "//crates/rue-error:rue-error",
         "//crates/rue-span:rue-span",
+        "//third-party:ahash",
         "//third-party:lasso",
     ],
 )
@@ -18,6 +19,7 @@ native.rust_library(
         "//crates/rue-air:rue-air",
         "//crates/rue-error:rue-error",
         "//crates/rue-span:rue-span",
+        "//third-party:ahash",
         "//third-party:lasso",
     ],
     rustc_flags = ["--cfg", "feature=\"fuzz-support\""],

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -3,6 +3,7 @@
 //! This module converts the structured control flow in AIR (Branch, Loop)
 //! into explicit basic blocks with terminators.
 
+use ahash::{AHashMap, AHashSet};
 use lasso::{Spur, ThreadedRodeo};
 use rue_air::{
     AirArgMode, AirInstData, AirPattern, AirPlaceBase, AirPlaceRef, AirProjection, AirRef,
@@ -82,7 +83,7 @@ enum MovedSlot {
 /// element is determined by the type at that level.
 type FieldPath = Vec<u32>;
 type MovedPathKey = (MovedSlot, FieldPath);
-type MovedPathMap = std::collections::HashMap<MovedSlot, std::collections::HashSet<FieldPath>>;
+type MovedPathMap = AHashMap<MovedSlot, AHashSet<FieldPath>>;
 
 #[cfg(test)]
 #[derive(Debug, Clone, Default)]
@@ -102,7 +103,7 @@ struct MoveStateStats {
 #[derive(Debug, Clone, Default)]
 struct MoveState {
     /// Slots whose ENTIRE contents were moved out.
-    slots: std::collections::HashSet<MovedSlot>,
+    slots: AHashSet<MovedSlot>,
     /// `(slot, path)` pairs for field paths moved out (on EVERY tracked
     /// path) of a slot that is itself still live. Join: intersection.
     fields: MovedPathMap,
@@ -199,7 +200,7 @@ impl MoveState {
             .is_some_and(|paths| paths.contains(&key.1))
     }
     /// Field paths moved out of `slot` on EVERY tracked path.
-    fn moved_paths_of(&self, slot: MovedSlot) -> std::collections::HashSet<FieldPath> {
+    fn moved_paths_of(&self, slot: MovedSlot) -> AHashSet<FieldPath> {
         #[cfg(test)]
         self.record_slot_path_visits(self.fields.get(&slot).map_or(0, |paths| paths.len()));
         self.fields.get(&slot).cloned().unwrap_or_default()
@@ -207,7 +208,7 @@ impl MoveState {
 
     /// Field paths moved out of `slot` on SOME tracked path (superset of
     /// `moved_paths_of`).
-    fn maybe_moved_paths_of(&self, slot: MovedSlot) -> std::collections::HashSet<FieldPath> {
+    fn maybe_moved_paths_of(&self, slot: MovedSlot) -> AHashSet<FieldPath> {
         #[cfg(test)]
         self.record_slot_path_visits(self.maybe_fields.get(&slot).map_or(0, |paths| paths.len()));
         self.maybe_fields.get(&slot).cloned().unwrap_or_default()
@@ -226,7 +227,7 @@ impl MoveState {
                 let common = paths
                     .intersection(other_paths)
                     .cloned()
-                    .collect::<std::collections::HashSet<_>>();
+                    .collect::<AHashSet<_>>();
                 (!common.is_empty()).then_some((*slot, common))
             })
             .collect();
@@ -285,20 +286,20 @@ pub struct CfgBuilder<'a> {
     /// branch-divergent moves (moved in one arm only), conservative loop
     /// joins, and short-circuit edges drop-exactly-once at RUNTIME even
     /// where the static all-paths analysis must stay conservative.
-    drop_flags: std::collections::HashMap<MovedSlot, u32>,
+    drop_flags: AHashMap<MovedSlot, u32>,
     /// Per-field-path runtime drop flags (RUE-156): like `drop_flags`, but
     /// one flag per `(slot, field path)` with a field-level MarkMoved
     /// anywhere in the function. Armed when the slot is (re)initialized,
     /// cleared at the path's move site; `emit_partial_struct_drop` guards
     /// each possibly-moved field's drop with its flag.
-    field_drop_flags: std::collections::HashMap<MovedPathKey, u32>,
+    field_drop_flags: AHashMap<MovedPathKey, u32>,
     /// Slots with a whole-value MarkMoved anywhere in the AIR (pre-scanned),
     /// i.e. candidates for a drop flag.
-    ever_moved: std::collections::HashSet<MovedSlot>,
+    ever_moved: AHashSet<MovedSlot>,
     /// `(slot, field path)` pairs with a field-level MarkMoved anywhere in
     /// the AIR whose moved type needs drop (pre-scanned), i.e. candidates
     /// for a per-field drop flag.
-    ever_field_moved: std::collections::HashSet<MovedPathKey>,
+    ever_field_moved: AHashSet<MovedPathKey>,
     /// Slots (and struct field paths of any depth, RUE-62/RUE-157) whose
     /// contents have definitely been moved out on every path reaching the
     /// current lowering position. Drop elaboration skips these (the new
@@ -314,11 +315,11 @@ pub struct CfgBuilder<'a> {
     /// moving path skips it at runtime — drop exactly once on every path,
     /// and never a leak.
     moved: MoveState,
-    implicit_named_destructors: std::collections::HashSet<StructId>,
+    implicit_named_destructors: AHashSet<StructId>,
     /// Aggregate types whose destructor dependencies have already been
     /// discovered for this CFG body. Keeps repeated drops linear in the size
     /// of the reachable type graph rather than rewalking the same subgraphs.
-    implicit_destructor_types: std::collections::HashSet<Type>,
+    implicit_destructor_types: AHashSet<Type>,
     anonymous_destructor_dependency_incomplete: bool,
     callable_kind: AnalyzedCallableKind,
 }
@@ -362,7 +363,7 @@ fn derive_source_param_abi(builder: &CfgBuilder<'_>) -> Vec<SourceParamAbi> {
     // Slot -> source type. `param_drops` covers every Normal by-value parameter
     // (including unused ones); `Param` instructions supplement any used
     // parameter whose drop entry was cleared (destructor receivers).
-    let mut ty_at: std::collections::HashMap<u32, Type> = std::collections::HashMap::new();
+    let mut ty_at: AHashMap<u32, Type> = AHashMap::new();
     for &(slot, ty) in air.param_drops() {
         ty_at.entry(slot).or_insert(ty);
     }
@@ -602,13 +603,13 @@ impl<'a> CfgBuilder<'a> {
             allow_unreachable_code,
             errors: Vec::new(),
             scope_stack: vec![Vec::new()], // Start with one scope for the function body
-            drop_flags: std::collections::HashMap::new(),
-            field_drop_flags: std::collections::HashMap::new(),
-            ever_moved: std::collections::HashSet::new(),
-            ever_field_moved: std::collections::HashSet::new(),
+            drop_flags: AHashMap::new(),
+            field_drop_flags: AHashMap::new(),
+            ever_moved: AHashSet::new(),
+            ever_field_moved: AHashSet::new(),
             moved: MoveState::default(),
-            implicit_named_destructors: std::collections::HashSet::new(),
-            implicit_destructor_types: std::collections::HashSet::new(),
+            implicit_named_destructors: AHashSet::new(),
+            implicit_destructor_types: AHashSet::new(),
             anonymous_destructor_dependency_incomplete: false,
             callable_kind,
         };
@@ -2810,7 +2811,7 @@ impl<'a> CfgBuilder<'a> {
             .filter(|(s, _)| *s == key)
             .map(|(_, p)| p.clone())
             .collect();
-        // `ever_field_moved` is a `HashSet`, so its iteration order varies per
+        // `ever_field_moved` is a `AHashSet`, so its iteration order varies per
         // process. `set_field_drop_flag` allocates a hidden local the first time
         // it sees a path, which would make the flag slots — and therefore every
         // frame offset after them — depend on hash order. Sorting pins the
@@ -3199,8 +3200,8 @@ impl<'a> CfgBuilder<'a> {
         ty: Type,
         path: &mut FieldPath,
         projs: &mut Vec<Projection>,
-        definite: &std::collections::HashSet<FieldPath>,
-        maybe: &std::collections::HashSet<FieldPath>,
+        definite: &AHashSet<FieldPath>,
+        maybe: &AHashSet<FieldPath>,
         span: rue_span::Span,
     ) {
         let struct_def = self.type_pool.struct_def(struct_id);
@@ -3360,8 +3361,8 @@ impl<'a> CfgBuilder<'a> {
         array_ty: Type,
         path: &mut FieldPath,
         projs: &mut Vec<Projection>,
-        definite: &std::collections::HashSet<FieldPath>,
-        maybe: &std::collections::HashSet<FieldPath>,
+        definite: &AHashSet<FieldPath>,
+        maybe: &AHashSet<FieldPath>,
         span: rue_span::Span,
     ) {
         let TypeKind::Array(array_id) = array_ty.kind() else {
@@ -3543,7 +3544,6 @@ mod tests {
         SemanticLocalNominal, SemanticLocalNominalShape,
     };
     use rue_span::FileId;
-    use std::collections::HashSet;
     use std::sync::Arc;
 
     #[test]
@@ -3583,13 +3583,13 @@ mod tests {
         let target = MovedSlot::Local(777);
 
         state.stats.slot_path_visits.set(0);
-        assert_eq!(state.moved_paths_of(target), HashSet::from([vec![777]]));
+        assert_eq!(state.moved_paths_of(target), AHashSet::from([vec![777]]));
         assert_eq!(state.stats.slot_path_visits.get(), 1);
 
         state.stats.slot_path_visits.set(0);
         assert_eq!(
             state.maybe_moved_paths_of(target),
-            HashSet::from([vec![777]])
+            AHashSet::from([vec![777]])
         );
         assert_eq!(state.stats.slot_path_visits.get(), 1);
 
@@ -3622,10 +3622,13 @@ mod tests {
         right.mark_path(slot, right_only.clone());
 
         let joined = left.intersect(&right);
-        assert_eq!(joined.moved_paths_of(slot), HashSet::from([shared.clone()]));
+        assert_eq!(
+            joined.moved_paths_of(slot),
+            AHashSet::from([shared.clone()])
+        );
         assert_eq!(
             joined.maybe_moved_paths_of(slot),
-            HashSet::from([shared, left_only, right_only])
+            AHashSet::from([shared, left_only, right_only])
         );
     }
 

--- a/crates/rue-cfg/src/inline.rs
+++ b/crates/rue-cfg/src/inline.rs
@@ -78,8 +78,7 @@
 //! returns produces no continuation edges, leaving the continuation
 //! unreachable — the RUE-347 divergence shape.
 
-use std::collections::HashMap;
-
+use ahash::AHashMap;
 use rue_air::{FrozenTypeInternPool, Type};
 use rue_span::Span;
 
@@ -205,7 +204,7 @@ struct Splice<'a> {
     value_base: u32,
     local_base: u32,
     block_base: u32,
-    redirects: &'a HashMap<u32, ParamRedirect>,
+    redirects: &'a AHashMap<u32, ParamRedirect>,
 }
 
 impl Splice<'_> {
@@ -321,7 +320,7 @@ pub fn inline_call_in_block(
             callee_params: params.len(),
         });
     }
-    let mut redirects: HashMap<u32, ParamRedirect> = HashMap::new();
+    let mut redirects: AHashMap<u32, ParamRedirect> = AHashMap::new();
     // Materialized by-value parameter regions: (base slot, argument, type).
     let mut materialized: Vec<(u32, CfgValue, Type)> = Vec::new();
     for (index, (param, arg)) in params.iter().zip(&call_args).enumerate() {
@@ -1017,12 +1016,11 @@ mod tests {
         ParamSlotModes, SourceParamAbi, StructDef, StructField, StructId, TypeInternPool,
     };
     use rue_span::FileId;
-    use std::collections::HashMap;
 
     /// A hand-built program: each function's drop-elaborated CFG, plus the
     /// shared type pool and interner the splice and its assertions need.
     struct Program {
-        cfgs: HashMap<&'static str, ValidatedCfg>,
+        cfgs: AHashMap<&'static str, ValidatedCfg>,
         type_pool: rue_air::FrozenTypeInternPool,
         interner: ThreadedRodeo,
     }
@@ -1030,7 +1028,7 @@ mod tests {
     impl Program {
         fn new(type_pool: rue_air::FrozenTypeInternPool, interner: ThreadedRodeo) -> Self {
             Self {
-                cfgs: HashMap::new(),
+                cfgs: AHashMap::new(),
                 type_pool,
                 interner,
             }

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -24,6 +24,7 @@ use std::fmt;
 const _: () = assert!(std::mem::size_of::<CfgInst>() <= 48);
 const _: () = assert!(std::mem::size_of::<CfgInstData>() <= 32);
 
+use ahash::AHashSet;
 use lasso::{Key, Spur, ThreadedRodeo};
 use rue_air::{EnumId, ParamSlotModes, StructId, Type};
 use rue_span::Span;
@@ -746,7 +747,7 @@ pub struct Cfg {
     /// `Const` and the constant is dereferenced as an address — the verified
     /// RUE-521 O1+ segfault. By-ref call arguments are the analogous
     /// per-instruction escape, handled directly in constopt's scan.
-    address_taken_slots: std::collections::HashSet<u32>,
+    address_taken_slots: AHashSet<u32>,
     /// Parameter ABI slots whose ADDRESS escapes through an address-taking
     /// intrinsic (`@raw` / `@raw_mut` / `@field_ptr` applied to a parameter),
     /// recorded at construction like `address_taken_slots`. A by-value
@@ -755,7 +756,7 @@ pub struct Cfg {
     /// from the parameter's storage can mutate it (`@ptr_write`), so reads
     /// on either side of such a write are NOT interchangeable. Passes that
     /// treat parameter reads as pure must consult this set.
-    address_taken_params: std::collections::HashSet<u32>,
+    address_taken_params: AHashSet<u32>,
     /// Grouped per-source-parameter ABI descriptors (ADR-0052 phase 5.8,
     /// RUE-1005), derived at construction from the AIR parameter types and the
     /// per-slot by-reference vector. Empty for a directly constructed CFG
@@ -1325,8 +1326,8 @@ impl Cfg {
             num_params,
             fn_name,
             param_modes: param_modes.into(),
-            address_taken_slots: std::collections::HashSet::new(),
-            address_taken_params: std::collections::HashSet::new(),
+            address_taken_slots: AHashSet::new(),
+            address_taken_params: AHashSet::new(),
             source_param_abi: Vec::new(),
             capacity_exceeded: None,
         }

--- a/crates/rue-cfg/src/opt/cse.rs
+++ b/crates/rue-cfg/src/opt/cse.rs
@@ -86,9 +86,8 @@
 //! batched work discipline as [`super::peephole`] and [`super::simplify`],
 //! RUE-794). DCE then removes the now-unused `Const(0)` placeholders.
 
-use std::collections::HashMap;
-
 use crate::{BlockId, Cfg, CfgInstData, CfgValue, Type};
+use ahash::AHashMap;
 
 /// Work counters for one run (RUE-794 convention): a single forward scan of
 /// every block, then one batched use-rewrite. There is no fixpoint loop.
@@ -253,7 +252,7 @@ pub fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
 
     for block_idx in 0..cfg.block_count() {
         let block_id = BlockId::from_raw(block_idx as u32);
-        let mut table: HashMap<VnKey, CfgValue> = HashMap::new();
+        let mut table: AHashMap<VnKey, CfgValue> = AHashMap::new();
 
         for i in 0..cfg.get_block(block_id).insts.len() {
             let value = cfg.get_block(block_id).insts[i];

--- a/crates/rue-cfg/src/opt/forward.rs
+++ b/crates/rue-cfg/src/opt/forward.rs
@@ -75,9 +75,8 @@
 //! sweeps the orphaned loads on its own. They are left as plain `Load`
 //! instructions, not dummied out.
 
-use std::collections::HashSet;
-
 use crate::{BlockId, Cfg, CfgInstData, CfgValue, PlaceBase};
+use ahash::AHashSet;
 
 use super::dce;
 
@@ -124,7 +123,7 @@ pub fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
     // value must stay a place (its address is taken by the callee), so it is
     // never forwarded regardless of rule.
     // ------------------------------------------------------------------
-    let mut byref_arg_values: HashSet<CfgValue> = HashSet::new();
+    let mut byref_arg_values: AHashSet<CfgValue> = AHashSet::new();
     for block in cfg.blocks() {
         for &value in &block.insts {
             if let CfgInstData::Call { args, .. } = &cfg.get_inst(value).data {

--- a/crates/rue-cfg/src/opt/loops.rs
+++ b/crates/rue-cfg/src/opt/loops.rs
@@ -40,8 +40,8 @@
 
 use crate::dominators::DominatorTree;
 use crate::{BlockId, Cfg, CfgEditError, Terminator};
+use ahash::AHashSet;
 use rue_air::FrozenTypeInternPool;
-use std::collections::HashSet;
 
 use super::CfgOptimizationError;
 
@@ -273,7 +273,7 @@ pub(crate) fn loops_with_stats(cfg: &Cfg, dom: &DominatorTree) -> (LoopForest, S
         let mut latches = latch_sets[hi].clone();
         latches.sort_by_key(|b: &BlockId| b.as_u32());
 
-        let mut body: HashSet<BlockId> = HashSet::new();
+        let mut body: AHashSet<BlockId> = AHashSet::new();
         body.insert(header);
         let mut work: Vec<BlockId> = Vec::new();
         for &latch in &latches {

--- a/crates/rue-cfg/src/opt/unroll.rs
+++ b/crates/rue-cfg/src/opt/unroll.rs
@@ -8,8 +8,6 @@
 //! audit for trap, drop, and block-argument ordering. Everything else is
 //! refused without changing the graph.
 
-use std::collections::HashMap;
-
 use super::CfgOptimizationError;
 use super::loops::{NaturalLoop, loops};
 use crate::dominators::DominatorTree;
@@ -17,6 +15,7 @@ use crate::{
     BlockId, Cfg, CfgCallArg, CfgEditError, CfgInst, CfgInstData, CfgValue, PlaceBase, Projection,
     Terminator, Type,
 };
+use ahash::{AHashMap, AHashSet};
 
 /// Shared future code-growth policy (ADR-0049). Inlining can consume this same
 /// representation when its growth budget lands; this pass is the first user.
@@ -308,7 +307,7 @@ fn recognize(cfg: &Cfg, lp: &NaturalLoop) -> Option<Trip> {
                 .map(|(value, _)| *value)
                 .chain(cfg.get_block(*block).insts.iter().copied())
         })
-        .collect::<std::collections::HashSet<_>>();
+        .collect::<AHashSet<_>>();
     let mut external_use = false;
     for block in cfg.block_ids().filter(|block| !lp.contains(*block)) {
         for &value in &cfg.get_block(block).insts {
@@ -335,7 +334,7 @@ fn recognize(cfg: &Cfg, lp: &NaturalLoop) -> Option<Trip> {
     let mut latch_load = None;
     let mut update = None;
     let mut store_count = 0;
-    let mut load_values = std::collections::HashSet::new();
+    let mut load_values = AHashSet::new();
     for &block in &lp.body {
         for &v in &cfg.get_block(block).insts {
             if matches!(cfg.get_inst(v).data, CfgInstData::Load { slot: s } if s == slot) {
@@ -460,7 +459,7 @@ fn checked_trip_count(initial: i128, bound: i128, step: i128, cmp: u8, ty: Type)
     Some(count)
 }
 
-fn map_value(map: &HashMap<CfgValue, CfgValue>, value: CfgValue) -> CfgValue {
+fn map_value(map: &AHashMap<CfgValue, CfgValue>, value: CfgValue) -> CfgValue {
     map.get(&value).copied().unwrap_or(value)
 }
 
@@ -468,7 +467,7 @@ fn remap_data(
     source: &Cfg,
     cfg: &mut Cfg,
     data: &CfgInstData,
-    map: &HashMap<CfgValue, CfgValue>,
+    map: &AHashMap<CfgValue, CfgValue>,
     specialize_slot: Option<(u32, u64)>,
 ) -> Result<CfgInstData, CfgEditError> {
     let m = |v| map_value(map, v);
@@ -684,14 +683,14 @@ fn unroll_one(
         .map(|b| u64::try_from(cfg.get_block(*b).insts.len()).unwrap_or(u64::MAX))
         .try_fold(0u64, |a, b| a.checked_add(b))
         .unwrap_or(u64::MAX);
-    let mut iterations: Vec<HashMap<BlockId, BlockId>> = Vec::new();
+    let mut iterations: Vec<AHashMap<BlockId, BlockId>> = Vec::new();
     let mut all_maps = Vec::new();
     for iteration in 0..trip.count {
-        let block_map: HashMap<_, _> = original_blocks
+        let block_map: AHashMap<_, _> = original_blocks
             .iter()
             .map(|&b| (b, cfg.new_block()))
             .collect();
-        let mut map = HashMap::new();
+        let mut map = AHashMap::new();
         for &b in &original_blocks {
             let params = cfg.get_block(b).params.clone();
             for &(v, ty) in &params {
@@ -736,7 +735,7 @@ fn unroll_one(
                     .map(|(value, _)| *value)
                     .chain(source.get_block(*block).insts.iter().copied())
             })
-            .collect::<std::collections::HashSet<_>>();
+            .collect::<AHashSet<_>>();
         let mut missing_mapping = false;
         for &(v, _) in &insts {
             super::dce::visit_instruction_uses(&source, v, |used| {
@@ -888,8 +887,8 @@ fn remap_term(
     source: &Cfg,
     cfg: &mut Cfg,
     t: &Terminator,
-    map: &HashMap<CfgValue, CfgValue>,
-    blocks: &HashMap<BlockId, BlockId>,
+    map: &AHashMap<CfgValue, CfgValue>,
+    blocks: &AHashMap<BlockId, BlockId>,
 ) -> Result<Terminator, CfgOptimizationError> {
     Ok(match t {
         Terminator::Goto { target, .. } => Terminator::Goto {

--- a/crates/rue-codegen/BUCK
+++ b/crates/rue-codegen/BUCK
@@ -11,6 +11,7 @@ rue_crate(
         "//crates/rue-runtime-abi:rue-runtime-abi",
         "//crates/rue-span:rue-span",
         "//crates/rue-target:rue-target",
+        "//third-party:ahash",
         "//third-party:fixedbitset",
         "//third-party:lasso",
         "//third-party:smallvec",

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -3,8 +3,7 @@
 //! This module converts CFG (explicit control flow graph) to Aarch64Mir
 //! (AArch64 instructions with virtual registers).
 
-use std::collections::HashMap;
-
+use ahash::AHashMap;
 use lasso::ThreadedRodeo;
 use rue_air::FrozenTypeInternPool;
 use rue_cfg::{BlockId, Cfg, CfgValue, Type, ValidatedCfg};
@@ -85,23 +84,23 @@ pub struct CfgLower<'a> {
     target: Target,
     mir: Aarch64Mir,
     /// Maps CFG values to vregs
-    value_map: HashMap<CfgValue, VReg>,
+    value_map: AHashMap<CfgValue, VReg>,
     /// Maps block parameters to vregs (block_id, param_index) -> vreg
-    block_param_vregs: HashMap<(BlockId, u32), VReg>,
+    block_param_vregs: AHashMap<(BlockId, u32), VReg>,
     /// Function name (needed to detect main function)
     fn_name: &'a str,
     /// Maps StructInit CFG values to their field vregs
-    struct_slot_vregs: HashMap<CfgValue, Vec<VReg>>,
+    struct_slot_vregs: AHashMap<CfgValue, Vec<VReg>>,
     /// Maps by-reference parameter indices to their pointer vregs.
     /// For by-ref params, the slot contains a pointer to the caller's memory.
     /// This map stores the vreg holding that pointer so Store can use it.
-    by_ref_param_ptrs: HashMap<u32, VReg>,
+    by_ref_param_ptrs: AHashMap<u32, VReg>,
     /// Maps register-only by-value parameter indices (RUE-1170) to the vreg
     /// their entry copy defined. These vregs are read-only for the rest of
     /// the function — every consumer copies before mutating, the same
     /// invariant that lets CSE key repeated `Param` reads (RUE-914) — so a
     /// single vreg serves every read.
-    param_reg_vregs: HashMap<u32, VReg>,
+    param_reg_vregs: AHashMap<u32, VReg>,
 }
 
 impl crate::call_plan::CallMaterializer for CfgLower<'_> {
@@ -252,7 +251,7 @@ impl<'a> CfgLower<'a> {
     ) -> Self {
         let num_params = cfg.num_params();
 
-        // Pre-calculate capacity hints to reduce HashMap reallocations
+        // Pre-calculate capacity hints to reduce AHashMap reallocations
         let num_values = cfg.value_count();
         let num_blocks = cfg.blocks().len();
         // Estimate ~4 block params per block on average
@@ -268,12 +267,12 @@ impl<'a> CfgLower<'a> {
             symbols,
             target,
             mir: Aarch64Mir::new(),
-            value_map: HashMap::with_capacity(num_values),
-            block_param_vregs: HashMap::with_capacity(estimated_block_params),
+            value_map: AHashMap::with_capacity(num_values),
+            block_param_vregs: AHashMap::with_capacity(estimated_block_params),
             fn_name: cfg.fn_name(),
-            struct_slot_vregs: HashMap::with_capacity(estimated_struct_inits),
-            by_ref_param_ptrs: HashMap::with_capacity(estimated_by_ref_params),
-            param_reg_vregs: HashMap::new(),
+            struct_slot_vregs: AHashMap::with_capacity(estimated_struct_inits),
+            by_ref_param_ptrs: AHashMap::with_capacity(estimated_by_ref_params),
+            param_reg_vregs: AHashMap::new(),
         }
     }
 
@@ -3387,7 +3386,7 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
     fn ctx(&self) -> &crate::cfg_lower::CfgLowerContext<'_> {
         &self.ctx
     }
-    fn slot_cache(&mut self) -> &mut std::collections::HashMap<CfgValue, Vec<VReg>> {
+    fn slot_cache(&mut self) -> &mut AHashMap<CfgValue, Vec<VReg>> {
         &mut self.struct_slot_vregs
     }
     fn alloc_vreg(&mut self) -> VReg {

--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -3,8 +3,6 @@
 //! This module provides AArch64 specific instruction information for liveness analysis.
 //! The actual dataflow algorithm is shared via [`crate::liveness`].
 
-use std::collections::HashMap;
-
 use super::mir::{Aarch64Inst, Aarch64Mir, Operand, Reg, ReturnBehavior};
 use crate::liveness::{
     LivenessAdapter, SuccessorList, VRegList, branch_successor, conditional_successors,
@@ -12,6 +10,7 @@ use crate::liveness::{
 };
 use crate::reg_class::VRegClasses;
 use crate::vreg::LabelId;
+use ahash::AHashMap;
 
 // Re-export shared types from the regalloc module
 pub use crate::regalloc::{InstructionLiveness, LiveRange, LivenessDebugInfo, LoopInfo};
@@ -47,7 +46,7 @@ impl LivenessAdapter for Aarch64LivenessAdapter<'_> {
         &self,
         idx: usize,
         inst: &Self::Inst,
-        label_to_idx: &HashMap<LabelId, usize>,
+        label_to_idx: &AHashMap<LabelId, usize>,
     ) -> SuccessorList {
         get_successors(idx, inst, label_to_idx, self.instructions().len())
     }
@@ -105,7 +104,7 @@ fn get_label(inst: &Aarch64Inst) -> Option<LabelId> {
 fn get_successors(
     idx: usize,
     inst: &Aarch64Inst,
-    label_to_idx: &HashMap<LabelId, usize>,
+    label_to_idx: &AHashMap<LabelId, usize>,
     num_insts: usize,
 ) -> SuccessorList {
     match inst {

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -27,7 +27,7 @@
 //! any realistic function. The separation is handled automatically by the
 //! respective methods.
 
-use std::collections::HashMap;
+use ahash::AHashMap;
 use std::fmt;
 
 pub use rue_runtime_abi::ReturnBehavior;
@@ -1346,7 +1346,7 @@ pub struct Aarch64Mir {
     /// Index for O(1) symbol lookup during interning.
     ///
     /// Maps symbol names to their indices in the `symbols` vector.
-    symbol_index: HashMap<String, u32>,
+    symbol_index: AHashMap<String, u32>,
 }
 
 impl Aarch64Mir {
@@ -1358,7 +1358,7 @@ impl Aarch64Mir {
             vreg_classes: VRegClasses::new(),
             next_label: 0,
             symbols: Vec::new(),
-            symbol_index: HashMap::new(),
+            symbol_index: AHashMap::new(),
         }
     }
 
@@ -1367,7 +1367,7 @@ impl Aarch64Mir {
     /// If the symbol already exists, returns its existing ID.
     /// Otherwise, adds it to the table and returns the new ID.
     pub fn intern_symbol(&mut self, symbol: &str) -> u32 {
-        // O(1) lookup via HashMap
+        // O(1) lookup via AHashMap
         if let Some(&idx) = self.symbol_index.get(symbol) {
             return idx;
         }

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -1415,6 +1415,7 @@ mod tests {
     };
     use crate::reg_class::RegClass;
     use crate::regalloc::{Allocation, RegAllocBackend, RematerializeOp};
+    use ahash::AHashSet;
 
     #[test]
     fn the_register_file_is_general_purpose_only() {
@@ -2294,7 +2295,7 @@ mod tests {
         assert_eq!(num_spills, 5);
 
         // Collect all unique stack offsets used in loads/stores
-        let mut offsets = std::collections::HashSet::new();
+        let mut offsets = AHashSet::new();
         for inst in mir.instructions() {
             match inst {
                 Aarch64Inst::Str {

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -19,8 +19,7 @@
 //! convention decision. Physical-register and stack marshalling, sret
 //! readback, scheduling, and liveness remain architecture-specific.
 
-use std::collections::HashMap;
-
+use ahash::AHashMap;
 use rue_air::Type;
 use rue_air::layout::{PaddingRange, SLOT_BYTES};
 use rue_cfg::CfgValue;
@@ -39,7 +38,7 @@ pub(crate) trait SlotBackend: BoundsCheckBackend {
     fn ctx(&self) -> &CfgLowerContext<'_>;
 
     /// The aggregate slot cache (`struct_slot_vregs`).
-    fn slot_cache(&mut self) -> &mut HashMap<CfgValue, Vec<VReg>>;
+    fn slot_cache(&mut self) -> &mut AHashMap<CfgValue, Vec<VReg>>;
 
     /// Allocate a fresh virtual register.
     fn alloc_vreg(&mut self) -> VReg;

--- a/crates/rue-codegen/src/liveness.rs
+++ b/crates/rue-codegen/src/liveness.rs
@@ -20,10 +20,11 @@
 
 #[cfg(test)]
 use std::cell::Cell;
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use std::iter::Take;
 use std::ops::Deref;
 
+use ahash::{AHashMap, AHashSet};
 use fixedbitset::FixedBitSet;
 
 use crate::index_map::IndexMap;
@@ -174,7 +175,7 @@ pub trait LivenessAdapter {
         &self,
         idx: usize,
         inst: &Self::Inst,
-        label_to_idx: &HashMap<LabelId, usize>,
+        label_to_idx: &AHashMap<LabelId, usize>,
     ) -> SuccessorList;
 
     /// Return virtual registers read by `inst`.
@@ -274,7 +275,7 @@ pub fn fallthrough_successor(idx: usize, num_insts: usize) -> SuccessorList {
 }
 
 /// Successor list for an unconditional branch to `label`.
-pub fn branch_successor(label: LabelId, label_to_idx: &HashMap<LabelId, usize>) -> SuccessorList {
+pub fn branch_successor(label: LabelId, label_to_idx: &AHashMap<LabelId, usize>) -> SuccessorList {
     label_to_idx.get(&label).copied().into_iter().collect()
 }
 
@@ -283,7 +284,7 @@ pub fn branch_successor(label: LabelId, label_to_idx: &HashMap<LabelId, usize>) 
 pub fn conditional_successors(
     idx: usize,
     label: LabelId,
-    label_to_idx: &HashMap<LabelId, usize>,
+    label_to_idx: &AHashMap<LabelId, usize>,
     num_insts: usize,
 ) -> SuccessorList {
     let mut succs = SuccessorList::new();
@@ -329,7 +330,7 @@ pub fn analyze<I, R>(
     vreg_count: u32,
     vreg_classes: VRegClasses,
     get_label: impl Fn(&I) -> Option<LabelId>,
-    get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> SuccessorList,
+    get_successors: impl Fn(usize, &I, &AHashMap<LabelId, usize>) -> SuccessorList,
     get_uses: impl Fn(&I) -> VRegList,
     get_defs: impl Fn(&I) -> VRegList,
     get_clobbers: impl Fn(&I) -> Vec<R>,
@@ -361,7 +362,7 @@ pub fn analyze_with_debug<I, R>(
     vreg_count: u32,
     vreg_classes: VRegClasses,
     get_label: impl Fn(&I) -> Option<LabelId>,
-    get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> SuccessorList,
+    get_successors: impl Fn(usize, &I, &AHashMap<LabelId, usize>) -> SuccessorList,
     get_uses: impl Fn(&I) -> VRegList,
     get_defs: impl Fn(&I) -> VRegList,
     get_clobbers: impl Fn(&I) -> Vec<R>,
@@ -394,7 +395,7 @@ fn analyze_inner<I, R>(
     vreg_count: u32,
     vreg_classes: VRegClasses,
     get_label: impl Fn(&I) -> Option<LabelId>,
-    get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> SuccessorList,
+    get_successors: impl Fn(usize, &I, &AHashMap<LabelId, usize>) -> SuccessorList,
     get_uses: impl Fn(&I) -> VRegList,
     get_defs: impl Fn(&I) -> VRegList,
     get_clobbers: impl Fn(&I) -> Vec<R>,
@@ -481,7 +482,7 @@ where
     );
 
     let debug = collect_debug.then(|| {
-        let bitset_to_hashset = |bs: &FixedBitSet| -> std::collections::HashSet<VReg> {
+        let bitset_to_hashset = |bs: &FixedBitSet| -> AHashSet<VReg> {
             bs.ones().map(|idx| VReg::new(idx as u32)).collect()
         };
         let instruction_liveness = (0..num_insts)
@@ -524,7 +525,7 @@ pub fn analyze_debug<I, R>(
     vreg_count: u32,
     vreg_classes: VRegClasses,
     get_label: impl Fn(&I) -> Option<LabelId>,
-    get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> SuccessorList,
+    get_successors: impl Fn(usize, &I, &AHashMap<LabelId, usize>) -> SuccessorList,
     get_uses: impl Fn(&I) -> VRegList,
     get_defs: impl Fn(&I) -> VRegList,
 ) -> LivenessDebugInfo
@@ -553,8 +554,8 @@ where
 fn build_label_map<I>(
     instructions: &[I],
     get_label: impl Fn(&I) -> Option<LabelId>,
-) -> HashMap<LabelId, usize> {
-    let mut label_to_idx = HashMap::new();
+) -> AHashMap<LabelId, usize> {
+    let mut label_to_idx = AHashMap::new();
     for (idx, inst) in instructions.iter().enumerate() {
         if let Some(label) = get_label(inst) {
             label_to_idx.insert(label, idx);
@@ -566,8 +567,8 @@ fn build_label_map<I>(
 /// Build successor lists for each instruction.
 fn build_successor_lists<I>(
     instructions: &[I],
-    label_to_idx: &HashMap<LabelId, usize>,
-    get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> SuccessorList,
+    label_to_idx: &AHashMap<LabelId, usize>,
+    get_successors: impl Fn(usize, &I, &AHashMap<LabelId, usize>) -> SuccessorList,
 ) -> Vec<SuccessorList> {
     instructions
         .iter()
@@ -950,7 +951,7 @@ where
 pub fn analyze_loops<I>(
     instructions: &[I],
     get_label: impl Fn(&I) -> Option<LabelId>,
-    get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> SuccessorList,
+    get_successors: impl Fn(usize, &I, &AHashMap<LabelId, usize>) -> SuccessorList,
 ) -> LoopInfo {
     let num_insts = instructions.len();
 
@@ -1010,7 +1011,7 @@ mod tests {
     fn test_get_successors(
         idx: usize,
         inst: &TestInst,
-        label_to_idx: &HashMap<LabelId, usize>,
+        label_to_idx: &AHashMap<LabelId, usize>,
         num_insts: usize,
     ) -> SuccessorList {
         match inst {

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -42,9 +42,9 @@
 //!
 //! The [`CostModel`] struct allows these parameters to be configured.
 
-use std::collections::HashSet;
 use std::fmt;
 
+use ahash::AHashSet;
 use rue_error::CompileResult;
 
 use crate::index_map::IndexMap;
@@ -244,9 +244,9 @@ pub struct InstructionLiveness {
     /// Instruction index.
     pub index: usize,
     /// Virtual registers live before this instruction executes.
-    pub live_in: HashSet<VReg>,
+    pub live_in: AHashSet<VReg>,
     /// Virtual registers live after this instruction executes.
-    pub live_out: HashSet<VReg>,
+    pub live_out: AHashSet<VReg>,
     /// Virtual registers defined (written) by this instruction.
     pub defs: Vec<VReg>,
     /// Virtual registers used (read) by this instruction.
@@ -3321,7 +3321,7 @@ mod tests {
         }
 
         // All spill offsets should be unique
-        let unique_offsets: std::collections::HashSet<_> = offsets.iter().copied().collect();
+        let unique_offsets: AHashSet<_> = offsets.iter().copied().collect();
         assert_eq!(
             offsets.len(),
             unique_offsets.len(),
@@ -3373,7 +3373,7 @@ mod tests {
             })
             .collect();
 
-        let unique: std::collections::HashSet<_> = spill_offsets.iter().copied().collect();
+        let unique: AHashSet<_> = spill_offsets.iter().copied().collect();
         assert_eq!(
             spill_offsets.len(),
             unique.len(),

--- a/crates/rue-codegen/src/stack_verify.rs
+++ b/crates/rue-codegen/src/stack_verify.rs
@@ -4,8 +4,7 @@
 //! this module owns the common traversal, stack-depth tracking, and
 //! control-flow join bookkeeping.
 
-use std::collections::HashMap;
-
+use ahash::AHashMap;
 use rue_error::{CompileError, CompileResult};
 
 use crate::vreg::LabelId;
@@ -58,7 +57,7 @@ where
 struct StackVerifier<'a, A: StackVerifyAdapter> {
     adapter: &'a A,
     /// Stack depth at each label (for join point verification).
-    label_depths: HashMap<LabelId, i64>,
+    label_depths: AHashMap<LabelId, i64>,
     /// Current stack depth in bytes relative to the prologue-aligned stack.
     current_depth: i64,
 }
@@ -70,7 +69,7 @@ where
     fn new(adapter: &'a A) -> Self {
         Self {
             adapter,
-            label_depths: HashMap::new(),
+            label_depths: AHashMap::new(),
             current_depth: 0,
         }
     }

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -6,10 +6,10 @@
 //! Struct, enum, array, and pointer definitions are resolved through the
 //! canonical `FrozenTypeInternPool` (ADR-0024).
 
+use ahash::AHashMap;
 use lasso::ThreadedRodeo;
 use rue_air::{ArrayTypeId, EnumId, FrozenTypeInternPool, StructId, TypeKind};
 use rue_cfg::{Cfg, CfgInstData, CfgValue, Type, ValidatedCfg};
-use std::collections::HashMap;
 
 use crate::vreg::VReg;
 
@@ -1203,7 +1203,7 @@ pub(crate) fn ensure_compact_layout_codegen_supported(
 /// * `get_vreg` - Closure to get/allocate a vreg for a given CFG value
 pub fn collect_array_scalar_vregs(
     cfg: &ValidatedCfg,
-    struct_slot_vregs: &HashMap<CfgValue, Vec<VReg>>,
+    struct_slot_vregs: &AHashMap<CfgValue, Vec<VReg>>,
     value: CfgValue,
     get_vreg: &mut impl FnMut(CfgValue) -> VReg,
 ) -> Vec<VReg> {
@@ -1271,7 +1271,7 @@ pub use rue_air::drop_glue_names::array_drop_glue_name;
 /// * `get_vreg` - Closure to get/allocate a vreg for a given CFG value
 pub fn collect_struct_scalar_vregs(
     cfg: &ValidatedCfg,
-    struct_slot_vregs: &HashMap<CfgValue, Vec<VReg>>,
+    struct_slot_vregs: &AHashMap<CfgValue, Vec<VReg>>,
     value: CfgValue,
     get_vreg: &mut impl FnMut(CfgValue) -> VReg,
 ) -> Vec<VReg> {

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -25,8 +25,7 @@
 //! any realistic function. The separation is handled automatically by the
 //! respective methods.
 
-use std::collections::HashMap;
-
+use ahash::AHashMap;
 use lasso::ThreadedRodeo;
 use rue_air::{FrozenTypeInternPool, TypeKind};
 use rue_cfg::{BlockId, Cfg, CfgValue, Type, ValidatedCfg};
@@ -87,9 +86,9 @@ pub struct CfgLower<'a> {
     symbols: crate::MachineSymbolResolver<'a>,
     mir: X86Mir,
     /// Maps CFG values to vregs
-    value_map: HashMap<CfgValue, VReg>,
+    value_map: AHashMap<CfgValue, VReg>,
     /// Maps block parameters to vregs (block_id, param_index) -> vreg
-    block_param_vregs: HashMap<(BlockId, u32), VReg>,
+    block_param_vregs: AHashMap<(BlockId, u32), VReg>,
     /// Next inline label ID for generating unique labels.
     ///
     /// Inline labels (for overflow checks, bounds checks, etc.) use IDs from
@@ -98,17 +97,17 @@ pub struct CfgLower<'a> {
     /// Function name (needed to detect main function)
     fn_name: &'a str,
     /// Maps StructInit CFG values to their field vregs
-    struct_slot_vregs: HashMap<CfgValue, Vec<VReg>>,
+    struct_slot_vregs: AHashMap<CfgValue, Vec<VReg>>,
     /// Maps by-reference parameter indices to their pointer vregs.
     /// For by-ref params, the slot contains a pointer to the caller's memory.
     /// This map stores the vreg holding that pointer so Store can use it.
-    by_ref_param_ptrs: HashMap<u32, VReg>,
+    by_ref_param_ptrs: AHashMap<u32, VReg>,
     /// Maps register-only by-value parameter indices (RUE-1170) to the vreg
     /// their entry copy defined. These vregs are read-only for the rest of
     /// the function — every consumer copies before mutating, the same
     /// invariant that lets CSE key repeated `Param` reads (RUE-914) — so a
     /// single vreg serves every read.
-    param_reg_vregs: HashMap<u32, VReg>,
+    param_reg_vregs: AHashMap<u32, VReg>,
 }
 
 impl crate::call_plan::CallMaterializer for CfgLower<'_> {
@@ -250,7 +249,7 @@ impl<'a> CfgLower<'a> {
     ) -> Self {
         let num_params = cfg.num_params();
 
-        // Pre-calculate capacity hints to reduce HashMap reallocations
+        // Pre-calculate capacity hints to reduce AHashMap reallocations
         let num_values = cfg.value_count();
         let num_blocks = cfg.blocks().len();
         // Estimate ~4 block params per block on average
@@ -265,13 +264,13 @@ impl<'a> CfgLower<'a> {
             interner,
             symbols,
             mir: X86Mir::new(),
-            value_map: HashMap::with_capacity(num_values),
-            block_param_vregs: HashMap::with_capacity(estimated_block_params),
+            value_map: AHashMap::with_capacity(num_values),
+            block_param_vregs: AHashMap::with_capacity(estimated_block_params),
             next_label: 0,
             fn_name: cfg.fn_name(),
-            struct_slot_vregs: HashMap::with_capacity(estimated_struct_inits),
-            by_ref_param_ptrs: HashMap::with_capacity(estimated_by_ref_params),
-            param_reg_vregs: HashMap::new(),
+            struct_slot_vregs: AHashMap::with_capacity(estimated_struct_inits),
+            by_ref_param_ptrs: AHashMap::with_capacity(estimated_by_ref_params),
+            param_reg_vregs: AHashMap::new(),
         }
     }
 
@@ -3154,7 +3153,7 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
     fn ctx(&self) -> &crate::cfg_lower::CfgLowerContext<'_> {
         &self.ctx
     }
-    fn slot_cache(&mut self) -> &mut std::collections::HashMap<CfgValue, Vec<VReg>> {
+    fn slot_cache(&mut self) -> &mut AHashMap<CfgValue, Vec<VReg>> {
         &mut self.struct_slot_vregs
     }
     fn alloc_vreg(&mut self) -> VReg {

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -3,8 +3,6 @@
 //! This module provides x86-64 specific instruction information for liveness analysis.
 //! The actual dataflow algorithm is shared via [`crate::liveness`].
 
-use std::collections::HashMap;
-
 use super::mir::{Operand, Reg, ReturnBehavior, X86Inst, X86Mir};
 use crate::liveness::{
     LivenessAdapter, SuccessorList, VRegList, branch_successor, conditional_successors,
@@ -12,6 +10,7 @@ use crate::liveness::{
 };
 use crate::reg_class::VRegClasses;
 use crate::vreg::LabelId;
+use ahash::AHashMap;
 
 // Re-export shared types from the regalloc module
 pub use crate::regalloc::{InstructionLiveness, LiveRange, LivenessDebugInfo, LoopInfo};
@@ -47,7 +46,7 @@ impl LivenessAdapter for X86LivenessAdapter<'_> {
         &self,
         idx: usize,
         inst: &Self::Inst,
-        label_to_idx: &HashMap<LabelId, usize>,
+        label_to_idx: &AHashMap<LabelId, usize>,
     ) -> SuccessorList {
         get_successors(idx, inst, label_to_idx, self.instructions().len())
     }
@@ -105,7 +104,7 @@ fn get_label(inst: &X86Inst) -> Option<LabelId> {
 fn get_successors(
     idx: usize,
     inst: &X86Inst,
-    label_to_idx: &HashMap<LabelId, usize>,
+    label_to_idx: &AHashMap<LabelId, usize>,
     num_insts: usize,
 ) -> SuccessorList {
     match inst {

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -5,7 +5,7 @@
 //! - Uses virtual registers (unlimited) that are later allocated to physical registers
 //! - Can be emitted to machine code or assembly text
 
-use std::collections::HashMap;
+use ahash::AHashMap;
 use std::fmt;
 
 pub use rue_runtime_abi::ReturnBehavior;
@@ -1028,7 +1028,7 @@ pub struct X86Mir {
     /// Index for O(1) symbol lookup during interning.
     ///
     /// Maps symbol names to their indices in the `symbols` vector.
-    symbol_index: HashMap<String, u32>,
+    symbol_index: AHashMap<String, u32>,
 }
 
 impl X86Mir {
@@ -1040,7 +1040,7 @@ impl X86Mir {
             vreg_classes: VRegClasses::new(),
             next_label: 0,
             symbols: Vec::new(),
-            symbol_index: HashMap::new(),
+            symbol_index: AHashMap::new(),
         }
     }
 
@@ -1049,7 +1049,7 @@ impl X86Mir {
     /// If the symbol already exists, returns its existing ID.
     /// Otherwise, adds it to the table and returns the new ID.
     pub fn intern_symbol(&mut self, symbol: &str) -> u32 {
-        // O(1) lookup via HashMap
+        // O(1) lookup via AHashMap
         if let Some(&idx) = self.symbol_index.get(symbol) {
             return idx;
         }

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -1480,6 +1480,7 @@ mod tests {
     };
     use crate::reg_class::RegClass;
     use crate::regalloc::{Allocation, RegAllocBackend, RematerializeOp};
+    use ahash::AHashSet;
 
     #[test]
     fn the_register_file_is_general_purpose_only() {
@@ -2457,7 +2458,7 @@ mod tests {
         assert_eq!(num_spills, 5);
 
         // Collect all unique stack offsets used in loads/stores
-        let mut offsets = std::collections::HashSet::new();
+        let mut offsets = AHashSet::new();
         for inst in mir.instructions() {
             match inst {
                 X86Inst::MovMR {

--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -119,6 +119,7 @@ rue_rust_test(
         "//crates/rue-cfg:rue-cfg",
         "//crates/rue-span:rue-span",
         "//crates/rue-target:rue-target",
+        "//third-party:ahash",
         "//third-party:sha2",
     ],
 )

--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -305,7 +305,8 @@ use crate::*;
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{HashMap, HashSet};
+    use ahash::{AHashMap, AHashSet};
+
     use std::sync::Arc;
 
     use rue_linker::{CodeRelocation, ObjectBuilder, ObjectFile, RelocationType};
@@ -619,15 +620,15 @@ fn main() -> i32 {
         let strbuf = FileId::new(2);
         let metadata = SourceMetadata::new_with_trusted_standard_library(
             root,
-            HashMap::from([
+            AHashMap::from([
                 (root, "/project/main.rue".to_owned()),
                 (strbuf, "/project/std/strbuf.rue".to_owned()),
             ]),
-            HashMap::from([
+            AHashMap::from([
                 (root, "main.rue".to_owned()),
                 (strbuf, "\0rue-std/strbuf.rue".to_owned()),
             ]),
-            HashSet::from([strbuf]),
+            AHashSet::from([strbuf]),
         )
         .unwrap();
         let source = r#"
@@ -751,7 +752,7 @@ drop fn StrBuf(self) { }
             .iter()
             .filter(|function| function.record.source_name.contains("concat_borrowed"))
             .map(|function| function.record.codegen.defined_symbol.as_ref())
-            .collect::<HashSet<_>>();
+            .collect::<AHashSet<_>>();
         let cleanup_symbols = semantic
             .functions()
             .iter()
@@ -760,7 +761,7 @@ drop fn StrBuf(self) { }
                     || function.record.source_name.starts_with("__rue_drop_")
             })
             .map(|function| function.record.codegen.defined_symbol.as_ref())
-            .collect::<HashSet<_>>();
+            .collect::<AHashSet<_>>();
         let concats: Vec<_> = calls
             .iter()
             .filter(|(_, symbol)| concat_symbols.contains(symbol.as_str()))
@@ -786,17 +787,17 @@ drop fn StrBuf(self) { }
                 .collect();
             let first_cleanup = *cleanups.first().expect("temporary cleanup before println");
             let last_cleanup = *cleanups.last().unwrap();
-            let saved: HashSet<_> = stores
+            let saved: AHashSet<_> = stores
                 .iter()
                 .filter(|(index, _)| *index > *concat_index && *index < first_cleanup)
                 .map(|(_, offset)| *offset)
                 .collect();
-            let restored: HashSet<_> = loads
+            let restored: AHashSet<_> = loads
                 .iter()
                 .filter(|(index, _)| *index > last_cleanup && *index < println_index)
                 .map(|(_, offset)| *offset)
                 .collect();
-            let preserved: HashSet<_> = saved.intersection(&restored).copied().collect();
+            let preserved: AHashSet<_> = saved.intersection(&restored).copied().collect();
             assert_eq!(
                 preserved.len(),
                 3,
@@ -859,7 +860,7 @@ drop fn StrBuf(self) { }
                 .map(|object| object.object.bytes.as_ref())
                 .collect::<Vec<_>>();
 
-            let mut undefined = HashSet::new();
+            let mut undefined = AHashSet::new();
             for bytes in objects {
                 let object = ObjectFile::parse(bytes).unwrap();
                 undefined.extend(

--- a/crates/rue-compiler/src/bound_definitions.rs
+++ b/crates/rue-compiler/src/bound_definitions.rs
@@ -205,7 +205,7 @@ impl Hash for StableDefinitionKey {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use ahash::AHashMap;
     use std::hash::Hasher;
     use std::sync::Arc;
 
@@ -274,7 +274,7 @@ mod tests {
         assert_ne!(first.cmp(&second), std::cmp::Ordering::Equal);
         assert_eq!(first.cmp(&second), second.cmp(&first).reverse());
 
-        let mut colliding = HashMap::new();
+        let mut colliding = AHashMap::new();
         colliding.insert(first, 1);
         colliding.insert(second, 2);
         assert_eq!(colliding.len(), 2);
@@ -284,11 +284,11 @@ mod tests {
         let physical = entries
             .iter()
             .map(|(id, path, _, _)| (FileId::new(*id), (*path).to_owned()))
-            .collect::<HashMap<_, _>>();
+            .collect::<AHashMap<_, _>>();
         let logical = entries
             .iter()
             .map(|(id, _, logical, _)| (FileId::new(*id), (*logical).to_owned()))
-            .collect::<HashMap<_, _>>();
+            .collect::<AHashMap<_, _>>();
         let metadata = SourceMetadata::new(FileId::new(root), physical, logical).unwrap();
         SourceSnapshot::new(
             metadata,

--- a/crates/rue-compiler/src/canonical_lower.rs
+++ b/crates/rue-compiler/src/canonical_lower.rs
@@ -1,11 +1,11 @@
 //! Canonical, provenance-safe lowering from parsed modules to RIR.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::ops::Range;
 use std::sync::Arc;
 use std::time::Instant;
 
+use ahash::AHashMap;
 use lasso::Key;
 use rue_error::{CompileError, ErrorKind};
 use rue_rir::{
@@ -77,7 +77,7 @@ pub(crate) struct CandidateModuleRirOutput {
     work: CanonicalRirWork,
     #[cfg(test)]
     declaration_roots:
-        HashMap<crate::declaration_candidate::DeclarationCandidateKey, ModuleDeclarationRoot>,
+        AHashMap<crate::declaration_candidate::DeclarationCandidateKey, ModuleDeclarationRoot>,
 }
 
 #[cfg(test)]
@@ -939,7 +939,7 @@ fn candidate_root_index(
     symbols: &SemanticSymbolUniverse,
     item_roots: &[rue_rir::AstGenItemRoots],
 ) -> Result<
-    HashMap<crate::declaration_candidate::DeclarationCandidateKey, ModuleDeclarationRoot>,
+    AHashMap<crate::declaration_candidate::DeclarationCandidateKey, ModuleDeclarationRoot>,
     &'static str,
 > {
     use crate::declaration_candidate::DeclarationCandidateCategory as Category;
@@ -1010,7 +1010,7 @@ fn candidate_root_index(
         return Err("AstGen emitted instructions outside every declaration interval");
     }
 
-    let mut index = HashMap::with_capacity(keys.len());
+    let mut index = AHashMap::with_capacity(keys.len());
     for (key, emitted) in keys.into_iter().zip(emitted) {
         let instruction = rir.get(emitted.declaration);
         if instruction.span.file_id != module.file_id() {
@@ -1168,7 +1168,7 @@ fn project_candidate_span(
 
 pub(crate) fn compose_module_rir_from_candidate_artifacts(
     module: std::sync::Arc<crate::parsed_modules::ParsedModule>,
-    artifacts: &HashMap<
+    artifacts: &AHashMap<
         crate::declaration_candidate::DeclarationCandidateKey,
         Arc<DeclarationBodyPlanArtifacts>,
     >,
@@ -1182,7 +1182,7 @@ pub(crate) fn compose_module_rir_from_candidate_artifacts(
     let symbols = SemanticSymbolUniverse::from_modules(std::slice::from_ref(&module));
     let mut editor = RirEditor::new();
     #[cfg(test)]
-    let mut declaration_roots = HashMap::with_capacity(artifacts.len());
+    let mut declaration_roots = AHashMap::with_capacity(artifacts.len());
     let mut work = CanonicalRirWork {
         modules_visited: 1,
         items_visited: module.definitions().rir_recipes().len(),
@@ -1611,7 +1611,6 @@ pub(crate) fn project_candidate_module_rirs_with_work(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
     use std::sync::Arc;
 
     use rue_rir::RirPrinter;
@@ -1696,7 +1695,7 @@ extern "C" { fn getpid() -> i32; }
         let parsed = crate::parsed_modules::parse_source_snapshot_modules(&source).unwrap();
         let module = parsed.modules()[0].clone();
         let old = lower_module_rir_with_work(module.clone()).unwrap();
-        let mut artifacts = HashMap::new();
+        let mut artifacts = AHashMap::new();
         let mut categories = Vec::new();
         for key in module.definitions().declaration_keys_in_source_order() {
             categories.push(key.category);
@@ -1758,7 +1757,7 @@ fn target(inout values: [i32; 4]) -> type {
                 let artifact = lower_parsed_declaration_body_plan(&module, key, || Ok(())).unwrap();
                 (key.clone(), Arc::new(artifact))
             })
-            .collect::<HashMap<_, _>>();
+            .collect::<AHashMap<_, _>>();
         let target_key = artifacts
             .keys()
             .find(|key| key.name.as_ref() == "target")
@@ -1823,11 +1822,11 @@ fn target(inout values: [i32; 4]) -> type {
         let physical = entries
             .iter()
             .map(|(id, path, _, _)| (FileId::new(*id), (*path).to_owned()))
-            .collect::<HashMap<_, _>>();
+            .collect::<AHashMap<_, _>>();
         let logical = entries
             .iter()
             .map(|(id, _, logical, _)| (FileId::new(*id), (*logical).to_owned()))
-            .collect::<HashMap<_, _>>();
+            .collect::<AHashMap<_, _>>();
         let metadata = SourceMetadata::new(FileId::new(root), physical, logical).unwrap();
         SourceSnapshot::new(
             metadata,

--- a/crates/rue-compiler/src/canonical_merge.rs
+++ b/crates/rue-compiler/src/canonical_merge.rs
@@ -1,8 +1,8 @@
 //! Provenance-retaining canonical syntax assembly.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
+use ahash::AHashMap;
 use rue_error::{CompileError, CompileErrors, ErrorKind};
 use rue_span::Span;
 
@@ -179,11 +179,11 @@ fn duplicate_errors<'a>(
 ) -> Vec<CompileError> {
     let mut errors = Vec::new();
     for (physical_path, candidates) in modules {
-        let mut functions = HashMap::<&str, CandidateDef>::new();
-        let mut function_names = HashMap::<&str, CandidateDef>::new();
-        let mut type_names = HashMap::<&str, CandidateDef>::new();
-        let mut structs = HashMap::<&str, CandidateDef>::new();
-        let mut enums = HashMap::<&str, CandidateDef>::new();
+        let mut functions = AHashMap::<&str, CandidateDef>::new();
+        let mut function_names = AHashMap::<&str, CandidateDef>::new();
+        let mut type_names = AHashMap::<&str, CandidateDef>::new();
+        let mut structs = AHashMap::<&str, CandidateDef>::new();
+        let mut enums = AHashMap::<&str, CandidateDef>::new();
         for candidate in candidates {
             let name = candidate.name.as_ref();
             let definition = || CandidateDef {
@@ -284,7 +284,6 @@ fn invalid_input(message: impl Into<String>) -> CompileError {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
 
     use rue_span::FileId;
 
@@ -296,11 +295,11 @@ mod tests {
         let physical = entries
             .iter()
             .map(|(id, path, _, _)| (FileId::new(*id), (*path).to_owned()))
-            .collect::<HashMap<_, _>>();
+            .collect::<AHashMap<_, _>>();
         let logical = entries
             .iter()
             .map(|(id, _, logical, _)| (FileId::new(*id), (*logical).to_owned()))
-            .collect::<HashMap<_, _>>();
+            .collect::<AHashMap<_, _>>();
         let metadata = SourceMetadata::new(FileId::new(root), physical, logical).unwrap();
         SourceSnapshot::new(
             metadata,

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -9,6 +9,7 @@ use std::hash::{Hash, Hasher};
 use std::num::NonZeroUsize;
 use std::sync::{Arc, OnceLock};
 
+use ahash::{AHashMap, AHashSet};
 use lasso::Key as _;
 use rue_query::{QueryAbort, QueryContext, QueryFamily, QueryKey, QueryOutcome, QueryOutput};
 use rue_span::Span;
@@ -1236,7 +1237,7 @@ fn materialize_and_build_cfg(
     }
 
     let domain_projection_started = std::time::Instant::now();
-    let mut callable_by_symbol = std::collections::HashMap::with_capacity(facts.callables.len());
+    let mut callable_by_symbol = AHashMap::with_capacity(facts.callables.len());
     for fact in facts.callables.iter() {
         match callable_by_symbol.entry(fact.symbol.as_ref()) {
             std::collections::hash_map::Entry::Vacant(entry) => {
@@ -1628,7 +1629,7 @@ pub(crate) fn evaluate_optimized_cfg(
     ));
     let mut accessor_calls: std::collections::VecDeque<_> =
         attached_accessor_calls(&current, 0, 0).into();
-    let mut splice_block_redirects = std::collections::HashMap::new();
+    let mut splice_block_redirects = AHashMap::new();
     while let Some((call, call_block)) = accessor_calls.pop_front() {
         let call_block = resolve_splice_block(call_block, &mut splice_block_redirects);
         let rue_cfg::CfgInstData::AccessorCall { name, .. } = current.get_inst(call).data else {
@@ -1690,7 +1691,7 @@ pub(crate) fn evaluate_optimized_cfg(
                 local_atoms
                     .iter()
                     .map(|atom| atom.identity.clone())
-                    .collect::<std::collections::HashSet<_>>()
+                    .collect::<AHashSet<_>>()
             });
             if local_atom_identities.insert(atom.identity.clone()) {
                 local_atoms.push(atom);
@@ -1995,7 +1996,7 @@ pub(crate) fn apply_general_inlining(
         let mut local_atom_identities = local_atoms
             .iter()
             .map(|atom| atom.identity.clone())
-            .collect::<std::collections::HashSet<_>>();
+            .collect::<AHashSet<_>>();
         let mut symbol_mappings = record.codegen.symbol_mappings.as_ref().clone();
         let mut foreign_symbols = record.codegen.foreign_symbols.as_ref().clone();
         let materialization_warnings = record.materialization_warnings.to_vec();
@@ -2313,7 +2314,7 @@ fn attached_accessor_calls(
 
 fn resolve_splice_block(
     original: rue_cfg::BlockId,
-    redirects: &mut std::collections::HashMap<rue_cfg::BlockId, rue_cfg::BlockId>,
+    redirects: &mut AHashMap<rue_cfg::BlockId, rue_cfg::BlockId>,
 ) -> rue_cfg::BlockId {
     let mut current = original;
     while let Some(next) = redirects.get(&current).copied() {

--- a/crates/rue-compiler/src/diagnostic.rs
+++ b/crates/rue-compiler/src/diagnostic.rs
@@ -21,9 +21,9 @@
 //! ```
 
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::io::IsTerminal;
 
+use ahash::AHashMap;
 use annotate_snippets::{Level, Renderer, Snippet};
 use rue_span::offset_to_line_col;
 
@@ -423,7 +423,7 @@ impl<'a> DiagnosticFormatter<'a> {
         }
 
         // Count occurrences of each unused variable name
-        let mut var_name_counts: HashMap<&str, usize> = HashMap::new();
+        let mut var_name_counts: AHashMap<&str, usize> = AHashMap::new();
         for warning in warnings {
             if let Some(name) = warning.kind.unused_variable_name() {
                 *var_name_counts.entry(name).or_insert(0) += 1;
@@ -601,7 +601,7 @@ impl<'a> DiagnosticFormatter<'a> {
 /// ```
 pub struct MultiFileFormatter<'a> {
     /// Mapping from FileId to source information.
-    sources: HashMap<FileId, SourceInfo<'a>>,
+    sources: AHashMap<FileId, SourceInfo<'a>>,
     /// The renderer for formatting diagnostics.
     renderer: Renderer,
 }
@@ -729,7 +729,7 @@ impl<'a> MultiFileFormatter<'a> {
         }
 
         // Count occurrences of each unused variable name
-        let mut var_name_counts: HashMap<&str, usize> = HashMap::new();
+        let mut var_name_counts: AHashMap<&str, usize> = AHashMap::new();
         for warning in warnings {
             if let Some(name) = warning.kind.unused_variable_name() {
                 *var_name_counts.entry(name).or_insert(0) += 1;
@@ -834,7 +834,7 @@ impl<'a> MultiFileFormatter<'a> {
         };
 
         // Collect all file IDs we need to show
-        let mut file_spans: HashMap<FileId, Vec<(Span, Option<&str>, Level)>> = HashMap::new();
+        let mut file_spans: AHashMap<FileId, Vec<(Span, Option<&str>, Level)>> = AHashMap::new();
 
         // Add primary span (promoted label is index 0 when present).
         file_spans.entry(primary_span.file_id).or_default().push((
@@ -1273,7 +1273,7 @@ impl<'a> JsonDiagnosticFormatter<'a> {
 /// ```
 pub struct MultiFileJsonFormatter<'a> {
     /// Mapping from FileId to source information.
-    sources: HashMap<FileId, SourceInfo<'a>>,
+    sources: AHashMap<FileId, SourceInfo<'a>>,
 }
 
 impl<'a> MultiFileJsonFormatter<'a> {

--- a/crates/rue-compiler/src/diagnostic_attempt_store.rs
+++ b/crates/rue-compiler/src/diagnostic_attempt_store.rs
@@ -408,7 +408,7 @@ fn snapshot_matches_source_attempt(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use ahash::AHashMap;
     use std::sync::atomic::{AtomicU64, Ordering};
 
     use rue_span::FileId;
@@ -460,8 +460,8 @@ mod tests {
         SourceSnapshot::new(
             SourceMetadata::new(
                 root,
-                HashMap::from([(root, "/p/main.rue".to_owned())]),
-                HashMap::from([(root, "main.rue".to_owned())]),
+                AHashMap::from([(root, "/p/main.rue".to_owned())]),
+                AHashMap::from([(root, "main.rue".to_owned())]),
             )
             .unwrap(),
             vec![(root, Arc::new(text.to_owned()))],
@@ -564,11 +564,11 @@ mod tests {
         let other = FileId::new(2);
         let metadata = SourceMetadata::new(
             root,
-            HashMap::from([
+            AHashMap::from([
                 (root, "/p/main.rue".to_owned()),
                 (other, "/p/other.rue".to_owned()),
             ]),
-            HashMap::from([
+            AHashMap::from([
                 (root, "main.rue".to_owned()),
                 (other, "other.rue".to_owned()),
             ]),

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -21,6 +21,8 @@
 //! 2. Drops each element in index order (element 0 first, then 1, etc.)
 
 #[cfg(test)]
+use ahash::AHashMap;
+#[cfg(test)]
 use rue_air::{
     AirEditor, AirPattern, AirRef, AirValidationContext, AnalyzedFunction, EnumId,
     FrozenTypeInternPool, ParamSlotModes, StructDef, Type, TypeKind,
@@ -250,7 +252,7 @@ fn plan_type_matches_live(
     planned: &IssuedTypeInstanceKey,
     live: Type,
     type_pool: &FrozenTypeInternPool,
-    types_by_identity: &std::collections::HashMap<IssuedTypeInstanceKey, Type>,
+    types_by_identity: &AHashMap<IssuedTypeInstanceKey, Type>,
 ) -> bool {
     use rue_air::TypeInstanceKey as P;
     match planned {
@@ -295,7 +297,7 @@ fn create_struct_drop_glue_function(
     struct_def: &StructDef,
     struct_id: rue_air::StructId,
     type_pool: &FrozenTypeInternPool,
-    types_by_identity: &std::collections::HashMap<IssuedTypeInstanceKey, Type>,
+    types_by_identity: &AHashMap<IssuedTypeInstanceKey, Type>,
     identity: IssuedTypeInstanceKey,
     facts: &crate::type_queries::DropGlueFacts<
         rue_air::SemanticDefinitionToken,
@@ -439,7 +441,7 @@ fn create_struct_drop_glue_function(
 fn create_array_drop_glue_function(
     array_id: rue_air::ArrayTypeId,
     type_pool: &FrozenTypeInternPool,
-    types_by_identity: &std::collections::HashMap<IssuedTypeInstanceKey, Type>,
+    types_by_identity: &AHashMap<IssuedTypeInstanceKey, Type>,
     identity: IssuedTypeInstanceKey,
     facts: &crate::type_queries::DropGlueFacts<
         rue_air::SemanticDefinitionToken,
@@ -568,7 +570,7 @@ fn create_array_drop_glue_function(
 fn create_enum_drop_glue_function(
     enum_id: EnumId,
     type_pool: &FrozenTypeInternPool,
-    types_by_identity: &std::collections::HashMap<IssuedTypeInstanceKey, Type>,
+    types_by_identity: &AHashMap<IssuedTypeInstanceKey, Type>,
     identity: IssuedTypeInstanceKey,
     facts: &crate::type_queries::DropGlueFacts<
         rue_air::SemanticDefinitionToken,
@@ -815,7 +817,7 @@ mod tests {
     fn insert_test_type(
         ty: Type,
         type_pool: &FrozenTypeInternPool,
-        output: &mut std::collections::HashMap<IssuedTypeInstanceKey, Type>,
+        output: &mut AHashMap<IssuedTypeInstanceKey, Type>,
     ) {
         match ty.kind() {
             TypeKind::Struct(id) => {
@@ -1061,7 +1063,7 @@ mod tests {
         );
         let outer_ty = Type::new_struct(outer_id);
         let type_pool = type_pool.freeze();
-        let mut types_by_identity = std::collections::HashMap::new();
+        let mut types_by_identity = AHashMap::new();
         insert_test_type(outer_ty, &type_pool, &mut types_by_identity);
         let outer_facts = test_facts(crate::type_queries::DropGluePlan::Struct {
             fields: type_pool

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -1,8 +1,4 @@
-// Local, request-scoped maps keyed by dense type/symbol identities. Equality
-// stays authoritative, so the hasher is a bucket selector: `ahash` replaces
-// SipHash here because CFG domain projection rebuilds these maps for every
-// body on the fresh-compile path.
-use ahash::AHashMap as HashMap;
+use ahash::{AHashMap, AHashSet};
 use std::sync::Arc;
 
 use lasso::{Key, Spur};
@@ -17,7 +13,7 @@ type CanonicalType = SemanticImportType<crate::StableDefinitionKey, crate::Modul
 pub(crate) struct CfgTypeAdmissionIndex<'a> {
     pool: &'a rue_air::FrozenTypeInternPool,
     aggregates: &'a std::collections::HashMap<Type, crate::TypeInstanceKey>,
-    live_by_stable: Option<HashMap<CanonicalType, Type>>,
+    live_by_stable: Option<AHashMap<CanonicalType, Type>>,
 }
 
 #[cfg(test)]
@@ -38,8 +34,8 @@ impl<'a> CfgTypeAdmissionIndex<'a> {
         let aggregates = self.aggregates;
         self.live_by_stable
             .get_or_insert_with(|| {
-                let mut live_by_stable = HashMap::with_capacity(pool.len());
-                let mut stable_by_live = HashMap::with_capacity(pool.len());
+                let mut live_by_stable = AHashMap::with_capacity(pool.len());
+                let mut stable_by_live = AHashMap::with_capacity(pool.len());
                 for live in pool.all_types() {
                     if let Ok(stable) =
                         canonical_type_from_live_cached(live, pool, aggregates, &mut stable_by_live)
@@ -54,8 +50,8 @@ impl<'a> CfgTypeAdmissionIndex<'a> {
     }
 }
 
-fn first_string_indices(strings: &[String]) -> Result<HashMap<&str, u32>, CfgDomainFailure> {
-    let mut indices = HashMap::with_capacity(strings.len());
+fn first_string_indices(strings: &[String]) -> Result<AHashMap<&str, u32>, CfgDomainFailure> {
+    let mut indices = AHashMap::with_capacity(strings.len());
     for (index, value) in strings.iter().enumerate() {
         let index = u32::try_from(index).map_err(|_| CfgDomainFailure::Shape)?;
         indices.entry(value.as_str()).or_insert(index);
@@ -133,7 +129,7 @@ fn canonical_type_from_live_cached(
     ty: Type,
     pool: &rue_air::FrozenTypeInternPool,
     aggregates: &std::collections::HashMap<Type, crate::TypeInstanceKey>,
-    stable_by_live: &mut HashMap<Type, CanonicalType>,
+    stable_by_live: &mut AHashMap<Type, CanonicalType>,
 ) -> Result<CanonicalType, CfgDomainFailure> {
     if let Some(stable) = stable_by_live.get(&ty) {
         return Ok(stable.clone());
@@ -244,7 +240,7 @@ fn record_cfg_type(
     ty: Type,
     pool: &rue_air::FrozenTypeInternPool,
     aggregates: &std::collections::HashMap<Type, crate::TypeInstanceKey>,
-    stable_by_live: &mut HashMap<Type, CanonicalType>,
+    stable_by_live: &mut AHashMap<Type, CanonicalType>,
 ) -> Result<(), CfgDomainFailure> {
     match canonical_type_from_live_cached(ty, pool, aggregates, stable_by_live) {
         Ok(stable) => types.push((ty, stable)),
@@ -352,7 +348,7 @@ fn canonical_type_instance(ty: &CanonicalType) -> Option<crate::TypeInstanceKey>
 fn deduplicate_type_mappings(
     mappings: Vec<(Type, CanonicalType)>,
 ) -> Result<Vec<(Type, CanonicalType)>, CfgDomainFailure> {
-    let mut positions: HashMap<Type, usize> = HashMap::with_capacity(mappings.len());
+    let mut positions: AHashMap<Type, usize> = AHashMap::with_capacity(mappings.len());
     let mut unique: Vec<(Type, CanonicalType)> = Vec::with_capacity(mappings.len());
     for (current, stable) in mappings {
         if let Some(&position) = positions.get(&current) {
@@ -444,14 +440,14 @@ pub(crate) struct CfgDomainProjection {
 }
 
 struct CfgTypeDomainIndex<'a> {
-    stable_by_live: HashMap<Type, &'a CanonicalType>,
-    live_by_stable: HashMap<&'a CanonicalType, Type>,
+    stable_by_live: AHashMap<Type, &'a CanonicalType>,
+    live_by_stable: AHashMap<&'a CanonicalType, Type>,
 }
 
 impl<'a> CfgTypeDomainIndex<'a> {
     fn new(old: &'a [(Type, CanonicalType)], current: &'a [(Type, CanonicalType)]) -> Self {
-        let mut stable_by_live = HashMap::with_capacity(old.len());
-        let mut live_by_stable = HashMap::with_capacity(current.len());
+        let mut stable_by_live = AHashMap::with_capacity(old.len());
+        let mut live_by_stable = AHashMap::with_capacity(current.len());
         for (live, stable) in old {
             stable_by_live.entry(*live).or_insert(stable);
         }
@@ -601,7 +597,7 @@ impl CfgDomainProjection {
         for (_, stable) in &old.types {
             type_index.current(stable)?;
         }
-        let mut current_symbols = HashMap::with_capacity(self.symbols.len() + old.symbols.len());
+        let mut current_symbols = AHashMap::with_capacity(self.symbols.len() + old.symbols.len());
         for (live, stable) in &self.symbols {
             current_symbols.entry(stable.clone()).or_insert(*live);
         }
@@ -613,7 +609,7 @@ impl CfgDomainProjection {
             current_symbols.insert(stable.clone(), symbol);
             self.symbols.push((symbol, stable.clone()));
         }
-        let mut old_symbols = HashMap::with_capacity(old.symbols.len());
+        let mut old_symbols = AHashMap::with_capacity(old.symbols.len());
         for (live, stable) in &old.symbols {
             old_symbols.entry(*live).or_insert(stable);
         }
@@ -751,7 +747,7 @@ impl CfgDomainProjection {
                     continue;
                 };
                 let symbols_by_live = symbols_by_live.get_or_insert_with(|| {
-                    let mut index = HashMap::with_capacity(self.symbols.len());
+                    let mut index = AHashMap::with_capacity(self.symbols.len());
                     for (live, stable) in &self.symbols {
                         index.entry(*live).or_insert(stable);
                     }
@@ -964,7 +960,7 @@ impl CfgDomainProjection {
         let type_pool = &materialization.type_pool;
         let interner = &materialization.interner;
         let air = &materialization.air;
-        let mut stable_by_live = HashMap::with_capacity(materialization.materialized_types.len());
+        let mut stable_by_live = AHashMap::with_capacity(materialization.materialized_types.len());
         let mut types = Vec::with_capacity(materialization.materialized_types.len() + 2);
         types.push((Type::I32, CanonicalType::I32));
         types.push((Type::UNIT, CanonicalType::Unit));
@@ -1137,13 +1133,13 @@ impl CfgDomainProjection {
             .iter()
             .enumerate()
             .map(|(position, (current, _))| (*current, position))
-            .collect::<HashMap<_, _>>();
+            .collect::<AHashMap<_, _>>();
         let mut pending = types
             .iter()
             .map(|(current, _)| *current)
             .collect::<Vec<_>>();
         let mut enqueued = pending.iter().copied().collect::<ahash::AHashSet<_>>();
-        let mut visited = std::collections::HashSet::new();
+        let mut visited = AHashSet::new();
         let mut incomplete = false;
         while let Some(current) = pending.pop() {
             if !visited.insert(current) {
@@ -1261,23 +1257,23 @@ impl CfgDomainProjection {
             return Err(CfgDomainFailure::Shape);
         }
         let type_index = CfgTypeDomainIndex::new(&old.types, &new.types);
-        let mut old_symbols = HashMap::with_capacity(old.symbols.len());
-        let mut new_symbols = HashMap::with_capacity(new.symbols.len());
+        let mut old_symbols = AHashMap::with_capacity(old.symbols.len());
+        let mut new_symbols = AHashMap::with_capacity(new.symbols.len());
         for (live, stable) in &old.symbols {
             old_symbols.entry(*live).or_insert(stable);
         }
         for (live, stable) in &new.symbols {
             new_symbols.entry(stable).or_insert(*live);
         }
-        let mut old_strings = HashMap::with_capacity(old.strings.len());
-        let mut new_strings = HashMap::with_capacity(new.strings.len());
+        let mut old_strings = AHashMap::with_capacity(old.strings.len());
+        let mut new_strings = AHashMap::with_capacity(new.strings.len());
         for (index, stable) in &old.strings {
             old_strings.entry(*index).or_insert(stable.as_ref());
         }
         for (index, stable) in &new.strings {
             new_strings.entry(stable.as_ref()).or_insert(*index);
         }
-        let mut old_spans = HashMap::with_capacity(old.spans.len());
+        let mut old_spans = AHashMap::with_capacity(old.spans.len());
         for (span, stable) in &old.spans {
             old_spans.entry(*span).or_insert(*stable);
         }

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -6,10 +6,11 @@
 //! never recognize imports or choose resolution precedence. Plans remain a
 //! whole-graph compatibility projection for diagnostics and closure.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
+use ahash::AHashMap;
 use rue_error::{CompileError, CompileErrors, CompileResult, ErrorKind};
 use rue_span::FileId;
 
@@ -1977,7 +1978,7 @@ pub struct AcceptedReadManifest {
     /// observation, which is a scan of every entry per observation without an
     /// index. Derived state: it never participates in equality, hashing, or
     /// rendering, and clones share it because they are the same value.
-    by_physical_identity: Arc<std::sync::OnceLock<HashMap<PhysicalFileIdentity, IdentitySlot>>>,
+    by_physical_identity: Arc<std::sync::OnceLock<AHashMap<PhysicalFileIdentity, IdentitySlot>>>,
 }
 
 /// Where one physical identity lives in a manifest's segmented entry sequence,
@@ -2113,8 +2114,8 @@ impl AcceptedReadManifest {
     ) -> ManifestIdentityLookup<'_> {
         let mut visited = 0;
         let index = self.by_physical_identity.get_or_init(|| {
-            let mut index: HashMap<PhysicalFileIdentity, IdentitySlot> =
-                HashMap::with_capacity(self.entries.len());
+            let mut index: AHashMap<PhysicalFileIdentity, IdentitySlot> =
+                AHashMap::with_capacity(self.entries.len());
             for (segment, entries) in self.entries.segments().iter().enumerate() {
                 for (position, entry) in entries.iter().enumerate() {
                     visited += 1;
@@ -2796,7 +2797,6 @@ fn invalid_input(message: impl Into<String>) -> CompileError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
 
     fn context(epoch: u64) -> ImportDiscoveryContext {
         ImportDiscoveryContext::new(epoch, "/project", Some("/sdk"), "all").unwrap()
@@ -2845,11 +2845,11 @@ mod tests {
                 entries
                     .iter()
                     .map(|(id, path, _, _)| (FileId::new(*id), (*path).into()))
-                    .collect::<HashMap<_, _>>(),
+                    .collect::<AHashMap<_, _>>(),
                 entries
                     .iter()
                     .map(|(id, _, logical, _)| (FileId::new(*id), (*logical).into()))
-                    .collect::<HashMap<_, _>>(),
+                    .collect::<AHashMap<_, _>>(),
             )
             .unwrap(),
             entries

--- a/crates/rue-compiler/src/integration_tests.rs
+++ b/crates/rue-compiler/src/integration_tests.rs
@@ -13,6 +13,7 @@
 // - Debuggable: Can inspect intermediate IRs in tests
 
 use crate::*;
+use ahash::{AHashMap, AHashSet};
 
 #[cfg(test)]
 mod integration_tests {
@@ -938,22 +939,21 @@ mod integration_tests {
 
         #[test]
         fn text_runtime_shapes_survive_air_durability_and_cfg_lowering() {
-            use std::collections::{HashMap, HashSet};
             use std::sync::Arc;
 
             let root = FileId::new(1);
             let strbuf = FileId::new(2);
             let metadata = SourceMetadata::new_with_trusted_standard_library(
                 root,
-                HashMap::from([
+                AHashMap::from([
                     (root, "/project/main.rue".to_owned()),
                     (strbuf, "/project/std/strbuf.rue".to_owned()),
                 ]),
-                HashMap::from([
+                AHashMap::from([
                     (root, "main.rue".to_owned()),
                     (strbuf, "\0rue-std/strbuf.rue".to_owned()),
                 ]),
-                HashSet::from([strbuf]),
+                AHashSet::from([strbuf]),
             )
             .unwrap();
             let source = r#"

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -8,13 +8,14 @@
 //! immutable and may be retained across later session updates.
 //!
 //! ```
-//! use std::{collections::HashMap, sync::Arc};
+//! use ahash::AHashMap;
+//! use std::sync::Arc;
 //! use rue_compiler::{
 //!     CompileOptions, CompilerSession, FileId, SourceMetadata, SourceSnapshot, compile_snapshot,
 //! };
 //!
 //! let root = FileId::new(7);
-//! let paths = HashMap::from([(root, "src/main.rue".to_owned())]);
+//! let paths = AHashMap::from([(root, "src/main.rue".to_owned())]);
 //! let metadata = SourceMetadata::new(root, paths.clone(), paths)?;
 //! let snapshot = SourceSnapshot::new(
 //!     metadata,

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -11,7 +11,10 @@
 use std::hash::Hash;
 use std::sync::Arc;
 
-use ahash::AHashSet;
+// Request-scoped selection maps keyed by stable identities. Typed equality
+// stays authoritative, so the hasher is only a bucket selector; fact selection
+// rebuilds these for every body on the fresh-compile path.
+use ahash::{AHashMap, AHashSet};
 
 use crate::durable_semantics::{
     DurableAnonymousNominal, DurableAnonymousNominalShape, DurableDeclarationPayload,
@@ -40,14 +43,14 @@ pub(crate) struct LocalFactSelectionIndexWork {
 /// cloned into each exact CFG memo key.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SharedDeclarationFactIndex {
-    declarations: std::collections::HashMap<StableDefinitionKey, usize>,
+    declarations: AHashMap<StableDefinitionKey, usize>,
     destructors: Vec<Option<usize>>,
-    slice_sources: std::collections::HashMap<Arc<str>, crate::TypeInstanceKey>,
+    slice_sources: AHashMap<Arc<str>, crate::TypeInstanceKey>,
 }
 
 impl SharedDeclarationFactIndex {
     pub(crate) fn new(declarations: &[DurableDeclarationSemantic]) -> Self {
-        let mut declaration_index = std::collections::HashMap::with_capacity(declarations.len());
+        let mut declaration_index = AHashMap::with_capacity(declarations.len());
         let mut destructors = vec![None; declarations.len()];
         let named_types = declarations
             .iter()
@@ -62,8 +65,8 @@ impl SharedDeclarationFactIndex {
                     index,
                 )
             })
-            .collect::<std::collections::HashMap<_, _>>();
-        let mut slice_sources = std::collections::HashMap::new();
+            .collect::<AHashMap<_, _>>();
+        let mut slice_sources = AHashMap::new();
         let mut work = LocalFactSelectionIndexWork::default();
         for (index, declaration) in declarations.iter().enumerate() {
             match &declaration.payload {
@@ -132,10 +135,7 @@ impl SharedDeclarationFactIndex {
 pub(crate) struct LocalFactSelectionIndex<'facts> {
     declarations: &'facts [DurableDeclarationSemantic],
     shared: &'facts SharedDeclarationFactIndex,
-    anonymous: std::collections::HashMap<
-        &'facts crate::AnonymousNominalKey,
-        &'facts DurableAnonymousNominal,
-    >,
+    anonymous: AHashMap<&'facts crate::AnonymousNominalKey, &'facts DurableAnonymousNominal>,
 }
 
 impl<'facts> LocalFactSelectionIndex<'facts> {
@@ -145,7 +145,7 @@ impl<'facts> LocalFactSelectionIndex<'facts> {
         anonymous_nominals: &'facts [DurableAnonymousNominal],
     ) -> (Self, LocalFactSelectionIndexWork) {
         let mut work = LocalFactSelectionIndexWork::default();
-        let mut anonymous = std::collections::HashMap::with_capacity(anonymous_nominals.len());
+        let mut anonymous = AHashMap::with_capacity(anonymous_nominals.len());
         for nominal in anonymous_nominals {
             work.anonymous_nominals_scanned += 1;
             anonymous.insert(&nominal.identity, nominal);
@@ -276,7 +276,7 @@ impl RetainedCharge for LocalMaterializationIndexes {
 
 fn collect_slice_sources(
     ty: &crate::durable_semantics::DurableType,
-    output: &mut std::collections::HashMap<Arc<str>, crate::TypeInstanceKey>,
+    output: &mut AHashMap<Arc<str>, crate::TypeInstanceKey>,
     work: &mut LocalFactSelectionIndexWork,
 ) {
     use rue_air::SemanticImportType as T;
@@ -373,7 +373,7 @@ pub(crate) struct LocalMaterializationFactInterner {
     /// Indexes keyed by the identity of the two interned slices they are
     /// derived from. Once those slices are shared, pointer identity is an
     /// exact key: equal content is the same allocation.
-    indexes: std::collections::HashMap<(usize, usize), Arc<LocalMaterializationIndexes>>,
+    indexes: AHashMap<(usize, usize), Arc<LocalMaterializationIndexes>>,
     /// Closures selected, slices newly allocated, and slice requests served
     /// from a slice an earlier selection already built.
     pub(crate) selections: usize,
@@ -387,13 +387,13 @@ pub(crate) struct LocalMaterializationFactInterner {
 /// comparison, so a hash collision costs one comparison rather than sharing
 /// two slices that merely hash alike.
 struct SliceInterner<T> {
-    buckets: std::collections::HashMap<u64, Vec<Arc<[T]>>>,
+    buckets: AHashMap<u64, Vec<Arc<[T]>>>,
 }
 
 impl<T> Default for SliceInterner<T> {
     fn default() -> Self {
         Self {
-            buckets: std::collections::HashMap::new(),
+            buckets: AHashMap::new(),
         }
     }
 }
@@ -501,7 +501,7 @@ impl LocalMaterializationFacts {
     pub(crate) fn union<'a>(facts: impl IntoIterator<Item = &'a Self>) -> Self {
         fn extend_unique<'a, T: Clone + Eq + Hash>(
             destination: &mut Vec<T>,
-            seen: &mut std::collections::HashSet<&'a T>,
+            seen: &mut AHashSet<&'a T>,
             source: &'a [T],
         ) {
             for value in source {
@@ -512,19 +512,19 @@ impl LocalMaterializationFacts {
         }
 
         let mut declarations = Vec::new();
-        let mut seen_declarations = std::collections::HashSet::new();
+        let mut seen_declarations = AHashSet::new();
         let mut anonymous_nominals = Vec::new();
-        let mut seen_anonymous_nominals = std::collections::HashSet::new();
+        let mut seen_anonymous_nominals = AHashSet::new();
         let mut callables = Vec::new();
-        let mut seen_callables = std::collections::HashSet::new();
+        let mut seen_callables = AHashSet::new();
         let mut nominal_metadata = Vec::new();
-        let mut seen_nominal_metadata = std::collections::HashSet::new();
+        let mut seen_nominal_metadata = AHashSet::new();
         let mut modules = Vec::new();
-        let mut seen_modules = std::collections::HashSet::new();
+        let mut seen_modules = AHashSet::new();
         let mut builtin_nominals = Vec::new();
-        let mut seen_builtin_nominals = std::collections::HashSet::new();
+        let mut seen_builtin_nominals = AHashSet::new();
         let mut required_types = Vec::new();
-        let mut seen_required_types = std::collections::HashSet::new();
+        let mut seen_required_types = AHashSet::new();
         for facts in facts {
             extend_unique(
                 &mut declarations,

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -4,11 +4,12 @@
 //! universe, while [`ParsedProgram`] provides the sole parsed-program
 //! representation used by semantic compilation.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use ahash::AHashMap;
 use lasso::Key;
 use lasso::{RodeoResolver, Spur, ThreadedRodeo};
 use rue_error::{CompileError, CompileErrors, CompileResult, ErrorKind};
@@ -144,7 +145,7 @@ impl ParsedDefinitionCandidate {
 pub struct ParsedDefinitionIndex {
     candidates: Arc<[ParsedDefinitionCandidate]>,
     declarations: Arc<[ParsedDeclarationCandidate]>,
-    declaration_by_key: HashMap<DeclarationCandidateKey, usize>,
+    declaration_by_key: AHashMap<DeclarationCandidateKey, usize>,
     rir_recipes: Arc<[ParsedRirRecipe]>,
     declaration_capabilities: Arc<[DeclarationOccurrenceCapability]>,
     #[cfg(test)]
@@ -580,7 +581,7 @@ struct ImportSiteCollector {
 #[derive(Default)]
 struct ParsedModuleProjectionCollector {
     imports: ImportSiteCollector,
-    warning_call_heads: HashMap<ParsedDeclarationAstLocator, Vec<RawWarningCallHead>>,
+    warning_call_heads: AHashMap<ParsedDeclarationAstLocator, Vec<RawWarningCallHead>>,
 }
 
 /// Immutable parsed syntax whose spans and symbols belong to one FileId epoch.
@@ -1855,7 +1856,7 @@ struct ParsedBodyProjectionCollector<'a> {
     module: &'a ModuleId,
     resolver: &'a ThreadedRodeo,
     imports: &'a mut ImportSiteCollector,
-    scopes: Vec<HashMap<Spur, ParsedWarningLexicalBinding>>,
+    scopes: Vec<AHashMap<Spur, ParsedWarningLexicalBinding>>,
     heads: Vec<RawWarningCallHead>,
 }
 
@@ -1968,7 +1969,7 @@ impl<'a> ParsedBodyProjectionCollector<'a> {
         body: &Expr,
         _has_self: bool,
     ) -> CompileResult<()> {
-        self.scopes.push(HashMap::new());
+        self.scopes.push(AHashMap::new());
         let outcome = (|| {
             for parameter in parameters {
                 self.visit_type(&parameter.ty)?;
@@ -2154,7 +2155,7 @@ impl<'a> ParsedBodyProjectionCollector<'a> {
 
     fn visit_block(&mut self, block: &rue_parser::ast::BlockExpr) -> CompileResult<()> {
         use rue_parser::ast::{LetPattern, Statement};
-        self.scopes.push(HashMap::new());
+        self.scopes.push(AHashMap::new());
         let outcome = (|| {
             for statement in &block.statements {
                 match statement {
@@ -2235,7 +2236,7 @@ impl<'a> ParsedBodyProjectionCollector<'a> {
             Expr::Match(value) => {
                 self.visit_expr(&value.scrutinee)?;
                 for arm in &value.arms {
-                    self.scopes.push(HashMap::new());
+                    self.scopes.push(AHashMap::new());
                     let outcome = (|| {
                         if let Pattern::Path(path) = &arm.pattern {
                             if let Some(base) = &path.base {
@@ -2269,7 +2270,7 @@ impl<'a> ParsedBodyProjectionCollector<'a> {
             Expr::Loop(value) => self.visit_block(&value.body)?,
             Expr::For(value) => {
                 self.visit_expr(&value.iterable)?;
-                self.scopes.push(HashMap::new());
+                self.scopes.push(AHashMap::new());
                 let outcome = (|| {
                     if let LetPattern::Ident(ident) = value.binder {
                         self.bind_local(ident)?;
@@ -2508,7 +2509,7 @@ fn project_warning_call_heads(
     import_range: Option<RawDeclarationImportRange>,
     import_sites: &[ImportDirective],
     resolver: &FrozenSymbolResolver,
-    raw_heads: &HashMap<ParsedDeclarationAstLocator, Vec<RawWarningCallHead>>,
+    raw_heads: &AHashMap<ParsedDeclarationAstLocator, Vec<RawWarningCallHead>>,
 ) -> CompileResult<Arc<[ParsedWarningCallHead]>> {
     let owns_warning_body = matches!(
         category,
@@ -2599,7 +2600,7 @@ fn build_definition_index(
     ast: &Ast,
     resolver: &FrozenSymbolResolver,
     import_sites: &[ImportDirective],
-    raw_warning_call_heads: &HashMap<ParsedDeclarationAstLocator, Vec<RawWarningCallHead>>,
+    raw_warning_call_heads: &AHashMap<ParsedDeclarationAstLocator, Vec<RawWarningCallHead>>,
 ) -> CompileResult<ParsedDefinitionIndex> {
     if import_sites.windows(2).any(|sites| {
         (sites[0].source_offset(), sites[0].source_end())
@@ -3090,7 +3091,7 @@ fn build_definition_index(
             },
         )
         .collect::<CompileResult<Vec<_>>>()?;
-    let mut declaration_by_key = HashMap::with_capacity(declarations.len());
+    let mut declaration_by_key = AHashMap::with_capacity(declarations.len());
     let mut declaration_capabilities = Vec::with_capacity(declarations.len());
     for (index, candidate) in declarations.iter().enumerate() {
         let key = candidate.fact.key.clone();
@@ -3109,7 +3110,7 @@ fn build_definition_index(
             });
         }
     }
-    let mut key_by_locator = HashMap::with_capacity(declarations.len());
+    let mut key_by_locator = AHashMap::with_capacity(declarations.len());
     for candidate in &declarations {
         if key_by_locator
             .insert(candidate.ast_locator, candidate.fact.key.clone())
@@ -3287,7 +3288,6 @@ fn invalid_input(message: impl Into<String>) -> CompileError {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
 
     use lasso::Key;
     use rue_error::{PreviewFeature, PreviewFeatures};
@@ -3468,11 +3468,11 @@ extern "C" { fn getpid() -> i32; }
         let physical = entries
             .iter()
             .map(|(id, path, _, _)| (FileId::new(*id), (*path).to_owned()))
-            .collect::<HashMap<_, _>>();
+            .collect::<AHashMap<_, _>>();
         let logical = entries
             .iter()
             .map(|(id, _, logical, _)| (FileId::new(*id), (*logical).to_owned()))
-            .collect::<HashMap<_, _>>();
+            .collect::<AHashMap<_, _>>();
         let metadata = SourceMetadata::new(FileId::new(root), physical, logical).unwrap();
         SourceSnapshot::new(
             metadata,
@@ -3752,8 +3752,8 @@ extern "C" { fn getpid() -> i32; }
     #[test]
     fn one_edit_among_128_modules_parses_exactly_once() {
         fn large(edited: bool) -> SourceSnapshot {
-            let mut physical = HashMap::new();
-            let mut logical = HashMap::new();
+            let mut physical = AHashMap::new();
+            let mut logical = AHashMap::new();
             let mut contents = Vec::new();
             for index in 0..129_u32 {
                 let file_id = FileId::new(index + 1);

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -1,9 +1,9 @@
 use crate::*;
+use ahash::AHashMap;
 use std::sync::Arc;
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
 
     use rue_query::QueryKey;
 
@@ -1047,7 +1047,7 @@ mod tests {
         let metadata = SourceMetadata::from_sources(
             &sources,
             root,
-            HashMap::from([
+            AHashMap::from([
                 (root, "main.rue".to_owned()),
                 (library, "lib.rue".to_owned()),
             ]),
@@ -1937,11 +1937,11 @@ mod tests {
     fn diagnostic_attempt_key_includes_presentation_order() {
         let first = FileId::new(1);
         let second = FileId::new(2);
-        let physical = HashMap::from([
+        let physical = AHashMap::from([
             (first, "/project/first.rue".to_owned()),
             (second, "/project/second.rue".to_owned()),
         ]);
-        let logical = HashMap::from([
+        let logical = AHashMap::from([
             (first, "first.rue".to_owned()),
             (second, "second.rue".to_owned()),
         ]);
@@ -2226,7 +2226,7 @@ mod tests {
     #[test]
     fn documented_snapshot_session_embedding_carries_complete_identity() {
         let root = FileId::new(7);
-        let paths = std::collections::HashMap::from([(root, "src/main.rue".to_owned())]);
+        let paths = AHashMap::from([(root, "src/main.rue".to_owned())]);
         let metadata = SourceMetadata::new(root, paths.clone(), paths).unwrap();
         let snapshot = SourceSnapshot::new(
             metadata,
@@ -2266,8 +2266,7 @@ mod tests {
             SourceView::new("helper.rue", "fn helper() -> i32 { # }", helper),
             SourceView::new("main.rue", "fn main() -> i32 { $ }", root),
         ];
-        let metadata =
-            SourceMetadata::from_sources(&sources, root, std::collections::HashMap::new()).unwrap();
+        let metadata = SourceMetadata::from_sources(&sources, root, AHashMap::new()).unwrap();
         let snapshot = SourceSnapshot::from_sources(&sources, metadata.clone()).unwrap();
 
         let mut session = CompilerSession::new();
@@ -2289,8 +2288,8 @@ mod tests {
         let file_id = FileId::new(3);
         let metadata = SourceMetadata::new(
             file_id,
-            std::collections::HashMap::from([(file_id, "expected.rue".to_string())]),
-            std::collections::HashMap::from([(file_id, "stable.rue".to_string())]),
+            AHashMap::from([(file_id, "expected.rue".to_string())]),
+            AHashMap::from([(file_id, "stable.rue".to_string())]),
         )
         .unwrap();
         let sources = [SourceView::new("actual.rue", "$", file_id)];
@@ -2323,7 +2322,7 @@ mod tests {
         let metadata = SourceMetadata::from_sources(
             &sources,
             root,
-            std::collections::HashMap::from([
+            AHashMap::from([
                 (root, "main.rue".to_string()),
                 (helper, "helper.rue".to_string()),
             ]),
@@ -2388,7 +2387,7 @@ mod tests {
         let metadata = SourceMetadata::from_sources(
             &sources,
             root,
-            std::collections::HashMap::from([
+            AHashMap::from([
                 (root, "main.rue".to_string()),
                 (helper, "helper.rue".to_string()),
             ]),
@@ -2436,7 +2435,7 @@ mod tests {
         let metadata = SourceMetadata::from_sources(
             &sources,
             root,
-            std::collections::HashMap::from([
+            AHashMap::from([
                 (root, "main.rue".to_string()),
                 (helper, "helper.rue".to_string()),
             ]),
@@ -2551,12 +2550,9 @@ mod tests {
                 if reversed {
                     sources.reverse();
                 }
-                let metadata = SourceMetadata::from_sources(
-                    &sources,
-                    sources[0].file_id,
-                    std::collections::HashMap::new(),
-                )
-                .unwrap();
+                let metadata =
+                    SourceMetadata::from_sources(&sources, sources[0].file_id, AHashMap::new())
+                        .unwrap();
                 let snapshot = SourceSnapshot::from_sources(&sources, metadata).unwrap();
                 let options = CompileOptions::default();
                 let canonical_errors = compile_snapshot(&snapshot, &options).unwrap_err();
@@ -2602,7 +2598,7 @@ mod tests {
             let metadata = SourceMetadata::from_sources(
                 &sources,
                 root,
-                std::collections::HashMap::from([
+                AHashMap::from([
                     (root, "main.rue".to_string()),
                     (helper, "helper.rue".to_string()),
                 ]),
@@ -3536,7 +3532,7 @@ mod tests {
             let source_metadata = SourceMetadata::from_sources(
                 &sources,
                 main_id,
-                std::collections::HashMap::from([
+                AHashMap::from([
                     (main_id, "main.rue".to_string()),
                     (left_id, "left.rue".to_string()),
                     (right_id, "right.rue".to_string()),
@@ -3649,7 +3645,7 @@ mod tests {
             let source_metadata = SourceMetadata::from_sources(
                 &sources,
                 FileId::new(1),
-                std::collections::HashMap::from([
+                AHashMap::from([
                     (FileId::new(1), "main.rue".to_string()),
                     (left_id, "left/shared.rue".to_string()),
                     (right_id, "right/shared.rue".to_string()),
@@ -3740,7 +3736,7 @@ mod tests {
         let source_metadata = SourceMetadata::from_sources(
             &sources,
             main_id,
-            std::collections::HashMap::from([
+            AHashMap::from([
                 (main_id, "main.rue".to_string()),
                 (struct_id, "left/clash.rue".to_string()),
                 (enum_id, "right/clash.rue".to_string()),
@@ -3826,12 +3822,8 @@ mod tests {
                 FileId::new(2),
             ),
         ];
-        let metadata = SourceMetadata::from_sources(
-            &sources,
-            FileId::new(1),
-            std::collections::HashMap::new(),
-        )
-        .unwrap();
+        let metadata =
+            SourceMetadata::from_sources(&sources, FileId::new(1), AHashMap::new()).unwrap();
         let snapshot = SourceSnapshot::from_sources(&sources, metadata).unwrap();
         let (_, semantic, _) = test_frontend_snapshot(&snapshot, &CompileOptions::default())
             .expect("frontend should compile");

--- a/crates/rue-compiler/src/producer_nominal_acceptance_tests.rs
+++ b/crates/rue-compiler/src/producer_nominal_acceptance_tests.rs
@@ -17,9 +17,10 @@
 
 use crate::*;
 use std::collections::BTreeSet;
-use std::collections::{HashMap, HashSet};
+
 use std::sync::Arc;
 
+use ahash::{AHashMap, AHashSet};
 use rue_target::Target;
 
 // ===========================================================================
@@ -66,15 +67,15 @@ fn trusted_option_snapshot(root_source: &str) -> SourceSnapshot {
 fn trusted_option_snapshot_with_source(root_source: &str, option_source: &str) -> SourceSnapshot {
     let metadata = SourceMetadata::new_with_trusted_standard_library(
         ROOT_FILE,
-        HashMap::from([
+        AHashMap::from([
             (ROOT_FILE, "/project/main.rue".to_owned()),
             (TRUSTED_OPTION_FILE, "/project/std/option.rue".to_owned()),
         ]),
-        HashMap::from([
+        AHashMap::from([
             (ROOT_FILE, "main.rue".to_owned()),
             (TRUSTED_OPTION_FILE, "\0rue-std/option.rue".to_owned()),
         ]),
-        HashSet::from([TRUSTED_OPTION_FILE]),
+        AHashSet::from([TRUSTED_OPTION_FILE]),
     )
     .expect("trusted-std metadata is valid");
     SourceSnapshot::new(
@@ -1061,8 +1062,7 @@ fn rooted_cfg_at_root_file_id(
     logical_path: &str,
     options: &CompileOptions,
 ) -> RootedCfgOutput {
-    let physical: std::collections::HashMap<FileId, String> =
-        [(file_id, logical_path.to_owned())].into();
+    let physical: AHashMap<FileId, String> = [(file_id, logical_path.to_owned())].into();
     let logical = physical.clone();
     let metadata =
         SourceMetadata::new(file_id, physical, logical).expect("single-file metadata is valid");

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -7,10 +7,11 @@
 //! enters the policy.
 
 use std::borrow::Cow;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::rc::Rc;
 use std::sync::Arc;
 
+use ahash::{AHashMap, AHashSet};
 use rue_parser::ast;
 
 pub(crate) trait RetainedCharge {
@@ -387,7 +388,10 @@ impl<T: RetainedCharge> RetainedCharge for BTreeSet<T> {
     }
 }
 
-impl<K: RetainedCharge, V: RetainedCharge> RetainedCharge for HashMap<K, V> {
+// Generic over the hasher so that a map which swaps `RandomState` for a
+// faster bucket selector still reports its charge. The hasher is not part of
+// what a map retains.
+impl<K: RetainedCharge, V: RetainedCharge, S> RetainedCharge for AHashMap<K, V, S> {
     fn retained_charge(&self) -> u64 {
         let entries = self.len().saturating_mul(std::mem::size_of::<(K, V)>()) as u64;
         self.iter().fold(entries, |charge, (key, value)| {
@@ -398,7 +402,7 @@ impl<K: RetainedCharge, V: RetainedCharge> RetainedCharge for HashMap<K, V> {
     }
 }
 
-impl<T: RetainedCharge> RetainedCharge for HashSet<T> {
+impl<T: RetainedCharge, S> RetainedCharge for AHashSet<T, S> {
     fn retained_charge(&self) -> u64 {
         let entries = self.len().saturating_mul(std::mem::size_of::<T>()) as u64;
         self.iter().fold(entries, |charge, value| {

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -7,7 +7,7 @@
 //! 12 registers each family directly with the runtime; native selection roots
 //! retain the current and last-good terminals.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::rc::Rc;
@@ -375,7 +375,7 @@ where
 }
 
 /// Wave-parsed modules awaiting their one canonical parse-query consumption.
-type ParseStage = Arc<Mutex<HashMap<ModuleId, crate::parsed_modules::StagedModuleParse>>>;
+type ParseStage = Arc<Mutex<AHashMap<ModuleId, crate::parsed_modules::StagedModuleParse>>>;
 
 #[cfg(test)]
 type DeclarationBodyPlanFailureInjection = Arc<
@@ -1412,7 +1412,7 @@ fn backend_retention_fallbacks(
 pub(crate) struct BackendRootCandidate {
     lease: rue_query::RetainedPinSet,
     functions: BTreeSet<crate::FunctionInstanceKey>,
-    cfg_keys: HashSet<crate::cfg_query::CfgQueryKey>,
+    cfg_keys: AHashSet<crate::cfg_query::CfgQueryKey>,
     optimized_cfg_terminals: usize,
     codegen_unit_terminals: usize,
     object_projection_terminals: usize,
@@ -2505,8 +2505,8 @@ struct ModuleInputStore {
     protected_revisions: BTreeSet<Revision>,
     retention_limit: usize,
     next_stamp: u64,
-    stamps: HashMap<ModuleInputLeaf, RetainedValueStamp>,
-    metadata_stamps: HashMap<ModuleMetadataLeaf, RetainedValueStamp>,
+    stamps: AHashMap<ModuleInputLeaf, RetainedValueStamp>,
+    metadata_stamps: AHashMap<ModuleMetadataLeaf, RetainedValueStamp>,
 }
 
 #[cfg(test)]
@@ -2531,8 +2531,8 @@ impl Default for ModuleInputStore {
             protected_revisions: BTreeSet::new(),
             retention_limit: MODULE_INPUT_REVISION_RETENTION,
             next_stamp: 1,
-            stamps: HashMap::new(),
-            metadata_stamps: HashMap::new(),
+            stamps: AHashMap::new(),
+            metadata_stamps: AHashMap::new(),
         }
     }
 }
@@ -3145,10 +3145,10 @@ struct ImportInputStore {
     /// two protected revisions beyond the ordinary recency window.
     protected_revisions: BTreeSet<Revision>,
     next_stamp: u64,
-    context_stamps: HashMap<ImportDiscoveryContext, RetainedValueStamp>,
-    provenance_stamps: HashMap<AcceptedReadManifestEntry, RetainedValueStamp>,
-    observation_stamps: HashMap<ImportObservation, RetainedValueStamp>,
-    topology_stamps: HashMap<AcceptedImportTopologyValue, RetainedValueStamp>,
+    context_stamps: AHashMap<ImportDiscoveryContext, RetainedValueStamp>,
+    provenance_stamps: AHashMap<AcceptedReadManifestEntry, RetainedValueStamp>,
+    observation_stamps: AHashMap<ImportObservation, RetainedValueStamp>,
+    topology_stamps: AHashMap<AcceptedImportTopologyValue, RetainedValueStamp>,
 }
 
 impl Default for ImportInputStore {
@@ -3157,10 +3157,10 @@ impl Default for ImportInputStore {
             revisions: VecDeque::new(),
             protected_revisions: BTreeSet::new(),
             next_stamp: 1,
-            context_stamps: HashMap::new(),
-            provenance_stamps: HashMap::new(),
-            observation_stamps: HashMap::new(),
-            topology_stamps: HashMap::new(),
+            context_stamps: AHashMap::new(),
+            provenance_stamps: AHashMap::new(),
+            observation_stamps: AHashMap::new(),
+            topology_stamps: AHashMap::new(),
         }
     }
 }
@@ -3198,7 +3198,7 @@ fn module_metadata_leaf_for_file(
     }
 }
 
-fn module_metadata_leaves(snapshot: &SourceSnapshot) -> HashMap<ModuleId, ModuleMetadataLeaf> {
+fn module_metadata_leaves(snapshot: &SourceSnapshot) -> AHashMap<ModuleId, ModuleMetadataLeaf> {
     let metadata = snapshot.metadata();
     metadata
         .file_ids()
@@ -3256,7 +3256,7 @@ fn import_input_error(message: impl Into<String>) -> CompileError {
 
 fn exact_value_stamp<T: Clone + Eq + Hash>(
     next_stamp: &mut u64,
-    values: &mut HashMap<T, RetainedValueStamp>,
+    values: &mut AHashMap<T, RetainedValueStamp>,
     value: &T,
 ) -> u64 {
     if let Some(retained) = values.get(value) {
@@ -3299,14 +3299,14 @@ fn lock_import_store(
         .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
-fn retain_stamp_value<T: Eq + Hash>(stamps: &mut HashMap<T, RetainedValueStamp>, value: &T) {
+fn retain_stamp_value<T: Eq + Hash>(stamps: &mut AHashMap<T, RetainedValueStamp>, value: &T) {
     stamps
         .get_mut(value)
         .expect("a published input view retains only values with assigned stamps")
         .retained_views += 1;
 }
 
-fn release_stamp_value<T: Eq + Hash>(stamps: &mut HashMap<T, RetainedValueStamp>, value: &T) {
+fn release_stamp_value<T: Eq + Hash>(stamps: &mut AHashMap<T, RetainedValueStamp>, value: &T) {
     let remove = {
         let retained = stamps
             .get_mut(value)
@@ -3817,7 +3817,7 @@ fn publish_module_inputs_delta(
                 .into_iter()
                 .map(|file_id| module_metadata_leaf_for_file(snapshot, file_id))
                 .map(|leaf| (leaf.module.clone(), leaf))
-                .collect::<HashMap<_, _>>()
+                .collect::<AHashMap<_, _>>()
         })
         .unwrap_or_else(|| module_metadata_leaves(snapshot));
     for source in new_sources {
@@ -11279,7 +11279,7 @@ impl RevisionedQueryDatabase {
         let declaration_body_plan_astgen_evaluations =
             Arc::new(std::sync::atomic::AtomicU64::new(0));
         let parse_store = module_store.clone();
-        let parse_stage: ParseStage = Arc::new(Mutex::new(HashMap::new()));
+        let parse_stage: ParseStage = Arc::new(Mutex::new(AHashMap::new()));
         let parse_stage_for_parse_modules = parse_stage.clone();
         let parse_identity_resolution = identity_resolution.clone();
         let parse_modules = runtime
@@ -17921,11 +17921,11 @@ impl BodyTransactionEvaluator {
                         let definition_tokens = analyzed
                             .definition_tokens
                             .into_iter()
-                            .collect::<std::collections::HashMap<_, _>>();
+                            .collect::<AHashMap<_, _>>();
                         let module_tokens = analyzed
                             .module_tokens
                             .into_iter()
-                            .collect::<std::collections::HashMap<_, _>>();
+                            .collect::<AHashMap<_, _>>();
                         let nested = analyzed
                             .referenced_specializations
                             .iter()
@@ -18254,11 +18254,11 @@ impl BodyTransactionEvaluator {
                         let definition_tokens = analyzed
                             .definition_tokens
                             .into_iter()
-                            .collect::<std::collections::HashMap<_, _>>();
+                            .collect::<AHashMap<_, _>>();
                         let module_tokens = analyzed
                             .module_tokens
                             .into_iter()
-                            .collect::<std::collections::HashMap<_, _>>();
+                            .collect::<AHashMap<_, _>>();
                         let definition = |token: &rue_air::SemanticDefinitionToken| {
                             definition_tokens
                                 .get(token)
@@ -18589,11 +18589,11 @@ impl BodyTransactionEvaluator {
                         let definition_tokens = analyzed
                             .definition_tokens
                             .into_iter()
-                            .collect::<std::collections::HashMap<_, _>>();
+                            .collect::<AHashMap<_, _>>();
                         let module_tokens = analyzed
                             .module_tokens
                             .into_iter()
-                            .collect::<std::collections::HashMap<_, _>>();
+                            .collect::<AHashMap<_, _>>();
                         let definition = |token: &rue_air::SemanticDefinitionToken| {
                             definition_tokens
                                 .get(token)
@@ -20809,7 +20809,7 @@ impl RevisionedQueryDatabase {
                     continue;
                 }
             };
-            let mut artifacts = HashMap::new();
+            let mut artifacts = AHashMap::new();
             let mut failed = false;
             for candidate in parsed.definitions().declaration_keys_in_source_order() {
                 let attempt = self.runtime.request_registered(
@@ -21661,8 +21661,8 @@ pub(crate) struct CompilerBodyDurableSource<'a> {
     provider: &'a CompilerBodyFactProvider<'a>,
     dynamic_anonymous: Rc<std::cell::RefCell<CanonicalAnonymousNominalRegistry>>,
     durable_payloads: Rc<std::cell::RefCell<BodyDurablePayloadCache>>,
-    source_paths: Rc<std::cell::RefCell<HashMap<crate::FileId, Arc<str>>>>,
-    source_locators: Rc<std::cell::RefCell<HashMap<ModuleId, rue_air::DurableBodySourceLocator>>>,
+    source_paths: Rc<std::cell::RefCell<AHashMap<crate::FileId, Arc<str>>>>,
+    source_locators: Rc<std::cell::RefCell<AHashMap<ModuleId, rue_air::DurableBodySourceLocator>>>,
 }
 
 struct ResolvedDeclarationCandidate {
@@ -21677,8 +21677,8 @@ impl<'a> CompilerBodyDurableSource<'a> {
         anonymous: &'a [crate::durable_semantics::DurableAnonymousNominal],
         owner_source: Option<(ModuleId, rue_air::DurableBodySourceLocator)>,
     ) -> Self {
-        let mut source_paths = HashMap::new();
-        let mut source_locators = HashMap::new();
+        let mut source_paths = AHashMap::new();
+        let mut source_locators = AHashMap::new();
         let mut dynamic_anonymous = CanonicalAnonymousNominalRegistry::default();
         dynamic_anonymous.extend(anonymous.iter().cloned());
         if let Some((module, locator)) = owner_source {
@@ -22978,11 +22978,8 @@ fn project_provider_anonymous_shape(
 
 fn project_provider_produced_anonymous_nominals(
     values: &[rue_air::SemanticProducedAnonymousNominal],
-    definitions: &std::collections::HashMap<
-        rue_air::SemanticDefinitionToken,
-        crate::StableDefinitionKey,
-    >,
-    modules: &std::collections::HashMap<rue_air::SemanticModuleToken, ModuleId>,
+    definitions: &AHashMap<rue_air::SemanticDefinitionToken, crate::StableDefinitionKey>,
+    modules: &AHashMap<rue_air::SemanticModuleToken, ModuleId>,
 ) -> Result<
     crate::body_query::BodyProducedAnonymousNominals,
     rue_air::SemanticStableResolutionFailure,
@@ -25065,14 +25062,9 @@ pub(crate) mod test_support {
     /// durable source vocabulary. Reads r2's stable-keyed metadata by key — the
     /// pool consults it on demand (dedup / poison), the O(consumed) shape.
     pub(crate) struct DurableDeclSource {
-        by_key: std::collections::HashMap<
-            StableDefinitionKey,
-            crate::durable_semantics::DurableDeclarationSemantic,
-        >,
-        anon_by_identity: std::collections::HashMap<
-            crate::AnonymousNominalKey,
-            crate::durable_semantics::DurableAnonymousNominal,
-        >,
+        by_key: AHashMap<StableDefinitionKey, crate::durable_semantics::DurableDeclarationSemantic>,
+        anon_by_identity:
+            AHashMap<crate::AnonymousNominalKey, crate::durable_semantics::DurableAnonymousNominal>,
     }
 
     impl DurableDeclSource {
@@ -25081,7 +25073,7 @@ pub(crate) mod test_support {
         ) -> Self {
             Self {
                 by_key: decls.iter().map(|d| (d.key.clone(), d.clone())).collect(),
-                anon_by_identity: std::collections::HashMap::new(),
+                anon_by_identity: AHashMap::new(),
             }
         }
 
@@ -25457,7 +25449,7 @@ mod tests {
         ImportObservation, PhysicalFileIdentity, SourceMetadata,
     };
     use rue_span::FileId;
-    use std::collections::{BTreeSet, HashMap};
+    use std::collections::BTreeSet;
 
     /// ADR-0076 §1/§4: one append-only equality space per revision, shared by
     /// every body of that revision, and retired once the revision leaves the
@@ -26157,11 +26149,11 @@ mod tests {
         let physical = entries
             .iter()
             .map(|(id, path, _, _)| (FileId::new(*id), (*path).to_owned()))
-            .collect::<HashMap<_, _>>();
+            .collect::<AHashMap<_, _>>();
         let logical = entries
             .iter()
             .map(|(id, _, logical, _)| (FileId::new(*id), (*logical).to_owned()))
-            .collect::<HashMap<_, _>>();
+            .collect::<AHashMap<_, _>>();
         let metadata = SourceMetadata::new(FileId::new(root), physical, logical).unwrap();
         SourceSnapshot::new(
             metadata,
@@ -26323,9 +26315,9 @@ mod tests {
         strbuf_source: Option<(FileId, &str)>,
     ) -> SourceSnapshot {
         let root = FileId::new(1);
-        let mut physical = HashMap::from([(root, "/project/main.rue".to_owned())]);
-        let mut logical = HashMap::from([(root, "main.rue".to_owned())]);
-        let mut trusted = std::collections::HashSet::new();
+        let mut physical = AHashMap::from([(root, "/project/main.rue".to_owned())]);
+        let mut logical = AHashMap::from([(root, "main.rue".to_owned())]);
+        let mut trusted = AHashSet::new();
         let mut sources = vec![(root, Arc::new(root_source.to_owned()))];
         if let Some((option, source)) = option_source {
             physical.insert(option, "/sdk/option.rue".to_owned());
@@ -27734,18 +27726,17 @@ fn main() -> i32 {
             ComptimeCallQueryKey, ComptimeCallResultProjection as ResultProjection,
             SemanticNucleusKey as Key, SemanticNucleusValue as V,
         };
-        use std::collections::HashSet;
 
         // The freestanding fallible-intrinsic program plus the trusted Option
         // module the host published on the successor. `main.rue` names a bare
         // `@parse_i64`, which is the reason the demand was emitted upstream.
         let root = FileId::new(1);
         let option = FileId::new(2);
-        let physical = HashMap::from([
+        let physical = AHashMap::from([
             (root, "/project/main.rue".to_owned()),
             (option, "/sdk/option.rue".to_owned()),
         ]);
-        let logical = HashMap::from([
+        let logical = AHashMap::from([
             (root, "main.rue".to_owned()),
             (option, crate::OPTION_MODULE_LOGICAL_PATH.to_owned()),
         ]);
@@ -27753,7 +27744,7 @@ fn main() -> i32 {
             root,
             physical,
             logical,
-            HashSet::from([option]),
+            AHashSet::from([option]),
         )
         .unwrap();
         let source = SourceSnapshot::new(
@@ -32395,8 +32386,8 @@ fn main() -> i32 {
     fn input_stamp_tables_follow_exact_retained_full_and_overlay_views() {
         const GENERATIONS: u64 = IMPORT_INPUT_REVISION_RETENTION as u64 + 32;
         fn assert_exact_values<T: Eq + Hash + std::fmt::Debug>(
-            actual: &HashMap<T, RetainedValueStamp>,
-            expected: &HashMap<T, usize>,
+            actual: &AHashMap<T, RetainedValueStamp>,
+            expected: &AHashMap<T, usize>,
         ) {
             assert_eq!(actual.len(), expected.len());
             for value in expected.keys() {
@@ -32527,10 +32518,10 @@ fn main() -> i32 {
             "the current view must keep its context stamp"
         );
 
-        let mut context_refs = HashMap::new();
-        let mut topology_refs = HashMap::new();
-        let mut provenance_refs = HashMap::new();
-        let mut observation_refs = HashMap::new();
+        let mut context_refs = AHashMap::new();
+        let mut topology_refs = AHashMap::new();
+        let mut provenance_refs = AHashMap::new();
+        let mut observation_refs = AHashMap::new();
         for view in &import_store.revisions {
             *context_refs.entry(view.context.clone()).or_insert(0) += 1;
             *topology_refs
@@ -32554,8 +32545,8 @@ fn main() -> i32 {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         assert_eq!(module_store.revisions.len(), GENERATIONS as usize * 2);
-        let mut module_refs = HashMap::new();
-        let mut metadata_refs = HashMap::new();
+        let mut module_refs = AHashMap::new();
+        let mut metadata_refs = AHashMap::new();
         for view in &module_store.revisions {
             for source in view.snapshot.source_revision().modules() {
                 *module_refs
@@ -37273,7 +37264,6 @@ fn main() -> i32 {
             ComptimeCallResultProjection as ResultProjection, SemanticNucleusKey as Key,
             SemanticNucleusValue as V,
         };
-        use std::collections::HashSet;
 
         // The freestanding fallible-intrinsic program plus the trusted `Option`
         // module published at its trusted logical path. `main` names
@@ -37281,11 +37271,11 @@ fn main() -> i32 {
         // payloads and each maps directly to one exact comptime key.
         let root = FileId::new(1);
         let option = FileId::new(2);
-        let physical = HashMap::from([
+        let physical = AHashMap::from([
             (root, "/project/main.rue".to_owned()),
             (option, "/sdk/option.rue".to_owned()),
         ]);
-        let logical = HashMap::from([
+        let logical = AHashMap::from([
             (root, "main.rue".to_owned()),
             (option, crate::OPTION_MODULE_LOGICAL_PATH.to_owned()),
         ]);
@@ -37293,7 +37283,7 @@ fn main() -> i32 {
             root,
             physical,
             logical,
-            HashSet::from([option]),
+            AHashSet::from([option]),
         )
         .unwrap();
         let snapshot = SourceSnapshot::new(
@@ -38189,17 +38179,17 @@ fn main() -> i32 {
         let unknown_file = FileId::new(4);
         let metadata = SourceMetadata::new_with_trusted_standard_library(
             root_file,
-            HashMap::from([
+            AHashMap::from([
                 (root_file, "/project/main.rue".to_owned()),
                 (leaf_file, "/project/std/leaf.rue".to_owned()),
                 (sibling_file, "/project/helper.rue".to_owned()),
             ]),
-            HashMap::from([
+            AHashMap::from([
                 (root_file, "main.rue".to_owned()),
                 (leaf_file, "\0rue-std/leaf.rue".to_owned()),
                 (sibling_file, "helper.rue".to_owned()),
             ]),
-            std::collections::HashSet::from([leaf_file]),
+            AHashSet::from([leaf_file]),
         )
         .expect("trusted-std metadata is valid");
         let snapshot = SourceSnapshot::new(
@@ -38662,11 +38652,11 @@ fn main() -> i32 {
         let definition_tokens = analyzed
             .definition_tokens
             .into_iter()
-            .collect::<HashMap<_, _>>();
+            .collect::<AHashMap<_, _>>();
         let module_tokens = analyzed
             .module_tokens
             .into_iter()
-            .collect::<HashMap<_, _>>();
+            .collect::<AHashMap<_, _>>();
         let definition = |token: &rue_air::SemanticDefinitionToken| {
             definition_tokens
                 .get(token)

--- a/crates/rue-compiler/src/scaling_harness.rs
+++ b/crates/rue-compiler/src/scaling_harness.rs
@@ -15,8 +15,9 @@ use crate::unstable::{
     import_demand_frontier_for_roots, import_observation_ledger, publish_import_observation_batch,
 };
 use crate::*;
+use ahash::AHashMap;
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet},
     sync::Arc,
 };
 
@@ -84,8 +85,8 @@ fn unrelated_module_snapshot_with_main_and_suffix(
     unrelated_modules: usize,
     suffix: &str,
 ) -> SourceSnapshot {
-    let mut physical = HashMap::new();
-    let mut logical = HashMap::new();
+    let mut physical = AHashMap::new();
+    let mut logical = AHashMap::new();
     let mut contents = Vec::new();
     physical.insert(FileId::DEFAULT, "main.rue".to_owned());
     logical.insert(FileId::DEFAULT, "main.rue".to_owned());

--- a/crates/rue-compiler/src/semantic_symbols.rs
+++ b/crates/rue-compiler/src/semantic_symbols.rs
@@ -5,6 +5,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[cfg(test)]
+use ahash::AHashMap;
+#[cfg(test)]
 use lasso::Spur;
 use lasso::ThreadedRodeo;
 #[cfg(test)]
@@ -199,7 +201,6 @@ fn invalid_input(message: impl Into<String>) -> CompileError {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
 
     use rue_span::FileId;
 
@@ -211,11 +212,11 @@ mod tests {
         let physical = entries
             .iter()
             .map(|(id, path, _, _)| (FileId::new(*id), (*path).to_owned()))
-            .collect::<HashMap<_, _>>();
+            .collect::<AHashMap<_, _>>();
         let logical = entries
             .iter()
             .map(|(id, _, logical, _)| (FileId::new(*id), (*logical).to_owned()))
-            .collect::<HashMap<_, _>>();
+            .collect::<AHashMap<_, _>>();
         let metadata = SourceMetadata::new(FileId::new(root), physical, logical).unwrap();
         SourceSnapshot::new(
             metadata,

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -1,6 +1,7 @@
 //! In-process canonical parse, merge, and RIR query orchestration.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use ahash::{AHashMap, AHashSet};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::sync::{Arc, Mutex};
 
 use crate::{
@@ -3231,7 +3232,7 @@ impl CompilerSession {
 
         // Every predecessor accepted-read entry must appear byte-identical in the
         // successor manifest (altered old provenance rejected).
-        let new_reads: std::collections::HashSet<&crate::AcceptedReadManifestEntry> =
+        let new_reads: AHashSet<&crate::AcceptedReadManifestEntry> =
             accepted_reads.iter().collect();
         for old in state.accepted_reads.iter() {
             if !new_reads.contains(old) {
@@ -5471,8 +5472,8 @@ impl CompilerSession {
         // rendered strings, so it is decorated once per warning rather than
         // twice per comparison. The first module wins a duplicated file id,
         // matching the linear scan this replaces.
-        let mut module_ids: HashMap<rue_span::FileId, &str> =
-            HashMap::with_capacity(graph.modules.len());
+        let mut module_ids: AHashMap<rue_span::FileId, &str> =
+            AHashMap::with_capacity(graph.modules.len());
         for module in graph.modules.iter() {
             module_ids
                 .entry(module.file_id())
@@ -6187,15 +6188,15 @@ fn rooted_unused_function_warnings(
     /// candidates touch one module never indexes the rest.
     struct CandidateModule<'a> {
         module: &'a crate::parsed_modules::ParsedModule,
-        functions: Option<HashMap<rue_span::Span, &'a rue_parser::ast::Function>>,
+        functions: Option<AHashMap<rue_span::Span, &'a rue_parser::ast::Function>>,
     }
 
     // Candidate declarations are keyed by module and located by declaration
     // span, so both lookups are indexed rather than scanned per candidate. The
     // first module and the first item win a duplicated key, matching the linear
     // scans these replace.
-    let mut modules: HashMap<&crate::ModuleId, CandidateModule<'_>> =
-        HashMap::with_capacity(graph.modules.len());
+    let mut modules: AHashMap<&crate::ModuleId, CandidateModule<'_>> =
+        AHashMap::with_capacity(graph.modules.len());
     for module in graph.modules.iter() {
         modules
             .entry(module.module_id())
@@ -6233,7 +6234,7 @@ fn rooted_unused_function_warnings(
         };
         let functions = entry.functions.get_or_insert_with(|| {
             let items = &module.ast().items;
-            let mut spans = HashMap::with_capacity(items.len());
+            let mut spans = AHashMap::with_capacity(items.len());
             for item in items.iter() {
                 if let rue_parser::ast::Item::Function(function) = item {
                     spans.entry(function.span).or_insert(function);
@@ -7077,15 +7078,15 @@ mod tests {
         let option = FileId::new(2);
         let metadata = SourceMetadata::new_with_trusted_standard_library(
             root,
-            HashMap::from([
+            AHashMap::from([
                 (root, "/project/main.rue".to_owned()),
                 (option, "/project/std/option.rue".to_owned()),
             ]),
-            HashMap::from([
+            AHashMap::from([
                 (root, "main.rue".to_owned()),
                 (option, "\0rue-std/option.rue".to_owned()),
             ]),
-            HashSet::from([option]),
+            AHashSet::from([option]),
         )
         .unwrap();
         SourceSnapshot::new(
@@ -7098,10 +7099,8 @@ mod tests {
         .unwrap()
     }
 
-    use std::{
-        collections::{HashMap, HashSet},
-        sync::Arc,
-    };
+    use ahash::{AHashMap, AHashSet};
+    use std::sync::Arc;
 
     use rue_span::FileId;
 
@@ -7227,11 +7226,11 @@ mod tests {
         let physical = entries
             .iter()
             .map(|(id, path, _, _)| (FileId::new(*id), (*path).to_owned()))
-            .collect::<HashMap<_, _>>();
+            .collect::<AHashMap<_, _>>();
         let logical = entries
             .iter()
             .map(|(id, _, logical, _)| (FileId::new(*id), (*logical).to_owned()))
-            .collect::<HashMap<_, _>>();
+            .collect::<AHashMap<_, _>>();
         let metadata = SourceMetadata::new(FileId::new(root), physical, logical).unwrap();
         SourceSnapshot::new(
             metadata,
@@ -11699,7 +11698,7 @@ fn main() -> i32 {
             hash(&second_helper),
             "semantic versions of one function deliberately share the cheap memo partition"
         );
-        let mut exact = std::collections::HashMap::new();
+        let mut exact = AHashMap::new();
         exact.insert(first_helper, "first");
         exact.insert(second_helper, "second");
         assert_eq!(exact.len(), 2, "typed equality resolves the hash collision");

--- a/crates/rue-compiler/src/source_metadata.rs
+++ b/crates/rue-compiler/src/source_metadata.rs
@@ -6,8 +6,7 @@
 //! of the checkout location. Keeping both maps together with an explicit root
 //! makes it impossible for those coupled inputs to drift after construction.
 
-use std::collections::{HashMap, HashSet};
-
+use ahash::{AHashMap, AHashSet};
 use rue_air::normalize_module_path;
 use rue_error::{CompileError, CompileResult, ErrorKind};
 use rue_span::FileId;
@@ -37,13 +36,13 @@ pub struct SourceMetadata {
 #[derive(Debug)]
 struct MetadataSegment {
     sorted_ids: Vec<FileId>,
-    physical_paths: HashMap<FileId, String>,
-    logical_paths: HashMap<FileId, String>,
-    trusted_standard_library_files: HashSet<FileId>,
+    physical_paths: AHashMap<FileId, String>,
+    logical_paths: AHashMap<FileId, String>,
+    trusted_standard_library_files: AHashSet<FileId>,
     /// Normalized path identities, retained so an appended segment can check
     /// cross-segment collisions without re-normalizing predecessor entries.
-    normalized_physical: HashSet<String>,
-    normalized_logical: HashSet<String>,
+    normalized_physical: AHashSet<String>,
+    normalized_logical: AHashSet<String>,
 }
 
 impl Clone for SourceMetadata {
@@ -88,7 +87,7 @@ impl Eq for SourceMetadata {}
 
 impl std::hash::Hash for SourceMetadata {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        // This type owns unordered `HashMap`/`HashSet` fields, so `Hash` cannot
+        // This type owns unordered `AHashMap`/`AHashSet` fields, so `Hash` cannot
         // be derived. Hashing the root plus the deterministic ascending id
         // sequence is consistent with the logical `Eq`: equal metadata
         // necessarily agree on both, and any collision between distinct
@@ -110,8 +109,8 @@ impl SourceMetadata {
     /// materialize both maps so relocation-sensitive defaults remain explicit.
     pub fn new(
         root_file_id: FileId,
-        physical_paths: HashMap<FileId, String>,
-        logical_paths: HashMap<FileId, String>,
+        physical_paths: AHashMap<FileId, String>,
+        logical_paths: AHashMap<FileId, String>,
     ) -> CompileResult<Self> {
         if physical_paths.is_empty() {
             return Err(invalid_input("source metadata contains no files"));
@@ -123,7 +122,7 @@ impl SourceMetadata {
             )));
         }
         let segment =
-            MetadataSegment::validated(physical_paths, logical_paths, HashSet::new(), None)?;
+            MetadataSegment::validated(physical_paths, logical_paths, AHashSet::new(), None)?;
         let len = segment.sorted_ids.len();
         Ok(Self {
             root_file_id,
@@ -135,9 +134,9 @@ impl SourceMetadata {
 
     pub(crate) fn new_with_trusted_standard_library(
         root_file_id: FileId,
-        physical_paths: HashMap<FileId, String>,
-        logical_paths: HashMap<FileId, String>,
-        trusted_standard_library_files: HashSet<FileId>,
+        physical_paths: AHashMap<FileId, String>,
+        logical_paths: AHashMap<FileId, String>,
+        trusted_standard_library_files: AHashSet<FileId>,
     ) -> CompileResult<Self> {
         if physical_paths.is_empty() {
             return Err(invalid_input("source metadata contains no files"));
@@ -175,9 +174,9 @@ impl SourceMetadata {
     /// stay ascending.
     pub(crate) fn extend_with_appended(
         &self,
-        physical_paths: HashMap<FileId, String>,
-        logical_paths: HashMap<FileId, String>,
-        trusted_standard_library_files: HashSet<FileId>,
+        physical_paths: AHashMap<FileId, String>,
+        logical_paths: AHashMap<FileId, String>,
+        trusted_standard_library_files: AHashSet<FileId>,
     ) -> CompileResult<Self> {
         if physical_paths.is_empty() {
             return Err(invalid_input("source metadata extension appends no files"));
@@ -264,13 +263,13 @@ impl SourceMetadata {
     pub(crate) fn from_sources(
         sources: &[SourceView<'_>],
         root_file_id: FileId,
-        logical_path_overrides: HashMap<FileId, String>,
+        logical_path_overrides: AHashMap<FileId, String>,
     ) -> CompileResult<Self> {
         if sources.is_empty() {
             return Err(invalid_input("source metadata contains no files"));
         }
 
-        let mut counts = HashMap::<FileId, usize>::new();
+        let mut counts = AHashMap::<FileId, usize>::new();
         for source in sources {
             *counts.entry(source.file_id).or_default() += 1;
         }
@@ -286,7 +285,7 @@ impl SourceMetadata {
             )));
         }
 
-        let physical_paths: HashMap<_, _> = sources
+        let physical_paths: AHashMap<_, _> = sources
             .iter()
             .map(|source| (source.file_id, source.path.to_owned()))
             .collect();
@@ -413,7 +412,7 @@ impl SourceMetadata {
 
     #[cfg(test)]
     pub(crate) fn validate_sources(&self, sources: &[SourceView<'_>]) -> CompileResult<()> {
-        let mut counts = HashMap::<FileId, usize>::new();
+        let mut counts = AHashMap::<FileId, usize>::new();
         for source in sources {
             *counts.entry(source.file_id).or_default() += 1;
         }
@@ -430,7 +429,7 @@ impl SourceMetadata {
             )));
         }
 
-        let seen: HashSet<_> = counts.keys().copied().collect();
+        let seen: AHashSet<_> = counts.keys().copied().collect();
         let mut unknown_ids: Vec<_> = seen
             .iter()
             .copied()
@@ -523,9 +522,9 @@ impl MetadataSegment {
     /// collision freedom against the shared base's RETAINED normalized
     /// identities (no base entry is re-normalized or re-walked).
     fn validated(
-        physical_paths: HashMap<FileId, String>,
-        logical_paths: HashMap<FileId, String>,
-        trusted_standard_library_files: HashSet<FileId>,
+        physical_paths: AHashMap<FileId, String>,
+        logical_paths: AHashMap<FileId, String>,
+        trusted_standard_library_files: AHashSet<FileId>,
         base: Option<&[std::sync::Arc<MetadataSegment>]>,
     ) -> CompileResult<Self> {
         let mut file_ids: Vec<_> = physical_paths.keys().copied().collect();
@@ -556,7 +555,7 @@ impl MetadataSegment {
             )));
         }
 
-        let logical_paths: HashMap<_, _> = logical_paths
+        let logical_paths: AHashMap<_, _> = logical_paths
             .into_iter()
             .map(|(file_id, path)| (file_id, normalize_module_path(&path)))
             .collect();
@@ -579,11 +578,11 @@ impl MetadataSegment {
             }
         }
 
-        let normalized_physical: HashSet<String> = file_ids
+        let normalized_physical: AHashSet<String> = file_ids
             .iter()
             .map(|file_id| normalize_module_path(&physical_paths[file_id]))
             .collect();
-        let normalized_logical: HashSet<String> = logical_paths.values().cloned().collect();
+        let normalized_logical: AHashSet<String> = logical_paths.values().cloned().collect();
         if let Some(base) = base {
             for segment in base {
                 for path in &normalized_physical {
@@ -617,7 +616,7 @@ impl MetadataSegment {
 fn validate_nonempty_paths(
     kind: &str,
     file_ids: &[FileId],
-    paths: &HashMap<FileId, String>,
+    paths: &AHashMap<FileId, String>,
 ) -> CompileResult<()> {
     for &file_id in file_ids {
         let path = paths.get(&file_id).expect("validated path key");
@@ -634,9 +633,9 @@ fn validate_nonempty_paths(
 fn validate_normalized_collisions(
     kind: &str,
     file_ids: &[FileId],
-    paths: &HashMap<FileId, String>,
+    paths: &AHashMap<FileId, String>,
 ) -> CompileResult<()> {
-    let mut seen = HashMap::<String, FileId>::new();
+    let mut seen = AHashMap::<String, FileId>::new();
     let mut collisions = Vec::new();
     for &file_id in file_ids {
         let normalized = normalize_module_path(paths.get(&file_id).expect("validated path key"));
@@ -684,7 +683,7 @@ mod tests {
         SourceView::new(path, "", FileId::new(file_id))
     }
 
-    fn physical(entries: &[(u32, &str)]) -> HashMap<FileId, String> {
+    fn physical(entries: &[(u32, &str)]) -> AHashMap<FileId, String> {
         entries
             .iter()
             .map(|&(file_id, path)| (FileId::new(file_id), path.to_owned()))
@@ -782,8 +781,8 @@ mod tests {
         assert_eq!(
             error_message(SourceMetadata::new(
                 FileId::new(1),
-                HashMap::new(),
-                HashMap::new()
+                AHashMap::new(),
+                AHashMap::new()
             )),
             "invalid compiler input: source metadata contains no files"
         );
@@ -801,7 +800,7 @@ mod tests {
             error_message(SourceMetadata::from_sources(
                 &sources,
                 FileId::new(2),
-                HashMap::new()
+                AHashMap::new()
             )),
             "invalid compiler input: source files contain duplicate file IDs: 2, 9"
         );

--- a/crates/rue-compiler/src/source_snapshot.rs
+++ b/crates/rue-compiler/src/source_snapshot.rs
@@ -5,9 +5,9 @@
 //! snapshot cheaply share source buffers without duplicating or allowing path
 //! information to drift.
 
-use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use ahash::{AHashMap, AHashSet};
 use rue_error::{CompileError, CompileResult, ErrorKind};
 pub use rue_lexer::MAX_SOURCE_BYTES;
 use rue_span::FileId;
@@ -55,13 +55,13 @@ struct SourceSnapshotData {
 struct SnapshotSegment {
     contents: Vec<SourceRecord>,
     /// Position within THIS segment for each of its file ids.
-    index: HashMap<FileId, usize>,
+    index: AHashMap<FileId, usize>,
     /// Position within THIS segment for each of its module identities. A
     /// snapshot binds each module to exactly one file, so resolving a module to
     /// its file is a per-segment hash lookup instead of a scan of every file.
     /// Where a segment somehow held one module twice, the lowest file id wins,
     /// matching what an ascending scan of the metadata's file ids would find.
-    module_index: HashMap<ModuleId, usize>,
+    module_index: AHashMap<ModuleId, usize>,
     min_file_index: u32,
     max_file_index: u32,
 }
@@ -83,7 +83,7 @@ impl SnapshotSegment {
             .enumerate()
             .map(|(index, record)| (record.file_id, index))
             .collect();
-        let mut module_index = HashMap::with_capacity(contents.len());
+        let mut module_index = AHashMap::with_capacity(contents.len());
         for (position, record) in contents.iter().enumerate() {
             match module_index.entry(record.module_id.clone()) {
                 std::collections::hash_map::Entry::Vacant(slot) => {
@@ -308,7 +308,7 @@ impl SourceSnapshot {
         contents: Vec<(FileId, Arc<String>)>,
     ) -> CompileResult<Self> {
         validate_source_file_count(contents.len())?;
-        let mut counts = HashMap::<FileId, usize>::new();
+        let mut counts = AHashMap::<FileId, usize>::new();
         for (file_id, _) in &contents {
             *counts.entry(*file_id).or_default() += 1;
         }
@@ -325,7 +325,7 @@ impl SourceSnapshot {
             )));
         }
 
-        let seen: HashSet<_> = counts.keys().copied().collect();
+        let seen: AHashSet<_> = counts.keys().copied().collect();
         let mut unknown_ids: Vec<_> = seen
             .iter()
             .copied()
@@ -628,9 +628,9 @@ impl SourceSnapshot {
             return Ok(base.clone());
         }
         validate_source_file_count(base.len().saturating_add(appended.len()))?;
-        let mut physical_paths = HashMap::new();
-        let mut logical_paths = HashMap::new();
-        let mut trusted = HashSet::new();
+        let mut physical_paths = AHashMap::new();
+        let mut logical_paths = AHashMap::new();
+        let mut trusted = AHashSet::new();
         for entry in &appended {
             physical_paths.insert(entry.file_id, entry.physical_path.clone());
             logical_paths.insert(entry.file_id, entry.logical_path.clone());
@@ -806,7 +806,7 @@ mod tests {
     use super::*;
 
     fn metadata(entries: &[(u32, &str)]) -> SourceMetadata {
-        let paths: HashMap<_, _> = entries
+        let paths: AHashMap<_, _> = entries
             .iter()
             .map(|&(file_id, path)| (FileId::new(file_id), path.to_owned()))
             .collect();
@@ -1099,14 +1099,14 @@ mod tests {
     #[test]
     fn revisions_ignore_file_ids_physical_roots_and_input_order() {
         let make = |root_id, helper_id, physical_root: &str, reversed: bool| {
-            let physical = HashMap::from([
+            let physical = AHashMap::from([
                 (FileId::new(root_id), physical_root.to_owned()),
                 (
                     FileId::new(helper_id),
                     format!("{physical_root}/../helper.rue"),
                 ),
             ]);
-            let logical = HashMap::from([
+            let logical = AHashMap::from([
                 (FileId::new(root_id), "app/main.rue".to_owned()),
                 (FileId::new(helper_id), "app/helper.rue".to_owned()),
             ]);
@@ -1141,11 +1141,11 @@ mod tests {
     fn parsed_module_reassembly_preserves_typed_module_origin() {
         let root = FileId::new(7);
         let standard_library = FileId::new(11);
-        let physical = HashMap::from([
+        let physical = AHashMap::from([
             (root, "/project/main.rue".to_owned()),
             (standard_library, "/sdk/strbuf.rue".to_owned()),
         ]);
-        let logical = HashMap::from([
+        let logical = AHashMap::from([
             (root, "app/main.rue".to_owned()),
             (standard_library, "\0rue-std/strbuf.rue".to_owned()),
         ]);
@@ -1153,7 +1153,7 @@ mod tests {
             root,
             physical,
             logical,
-            HashSet::from([standard_library]),
+            AHashSet::from([standard_library]),
         )
         .unwrap();
         let original = SourceSnapshot::new(

--- a/crates/rue-compiler/src/syntax.rs
+++ b/crates/rue-compiler/src/syntax.rs
@@ -91,7 +91,8 @@ pub(crate) fn parse_file(source: SourceView<'_>, interner: ThreadedRodeo) -> Fil
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc};
+    use ahash::AHashMap;
+    use std::sync::Arc;
 
     use rue_error::ErrorKind;
     use rue_span::FileId;
@@ -101,7 +102,7 @@ mod tests {
     use crate::{CompilerSession, Item, SourceMetadata, SourceSnapshot};
 
     fn snapshot(entries: &[(u32, &str, &str)]) -> SourceSnapshot {
-        let physical_paths: HashMap<_, _> = entries
+        let physical_paths: AHashMap<_, _> = entries
             .iter()
             .map(|&(id, path, _)| (FileId::new(id), path.to_owned()))
             .collect();

--- a/crates/rue-compiler/src/test_support.rs
+++ b/crates/rue-compiler/src/test_support.rs
@@ -1,5 +1,6 @@
 use crate::queries::CompileState;
 use crate::*;
+use ahash::AHashMap;
 
 // Test-only projections. Production consumers query CompilerSession artifacts.
 
@@ -185,7 +186,7 @@ pub(crate) fn test_compile_sources(
         .first()
         .map(|source| source.file_id)
         .unwrap_or(FileId::DEFAULT);
-    let metadata = SourceMetadata::from_sources(sources, root, std::collections::HashMap::new())
+    let metadata = SourceMetadata::from_sources(sources, root, AHashMap::new())
         .map_err(CompileErrors::from)?;
     test_compile_sources_with_metadata(sources, &metadata, options)
 }
@@ -474,8 +475,7 @@ fn invalid_fixture(message: &str) -> CompileErrors {
 /// at most once. Production body analysis consumes the durable facts directly.
 #[derive(Default)]
 pub(crate) struct ProviderMaterialization {
-    nominals:
-        std::collections::HashMap<crate::StableDefinitionKey, crate::DurableDeclarationPayload>,
+    nominals: AHashMap<crate::StableDefinitionKey, crate::DurableDeclarationPayload>,
 }
 
 impl ProviderMaterialization {

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -4,6 +4,9 @@
 //! policy. These owned snapshots and opaque session products cannot be
 //! installed into a session or used as query keys.
 
+#[cfg(test)]
+use ahash::AHashMap;
+use ahash::AHashSet;
 use std::fmt::Write as _;
 use std::sync::Arc;
 
@@ -905,7 +908,7 @@ impl crate::CompilerSession {
         let program = self.published_owner().cloned().ok_or_else(|| {
             invalid_input("presentation requires a published source revision".into())
         })?;
-        let mut seen = std::collections::HashSet::with_capacity(request.file_order.len());
+        let mut seen = AHashSet::with_capacity(request.file_order.len());
         for file_id in request.file_order {
             if !seen.insert(*file_id) {
                 return Err(invalid_input(format!(
@@ -1140,21 +1143,19 @@ mod codegen_unit_tests {
     use super::*;
 
     fn trusted_accessor_snapshot(root: &str, module: &str) -> crate::SourceSnapshot {
-        use std::collections::{HashMap, HashSet};
-
         let root_file = crate::FileId::new(1);
         let module_file = crate::FileId::new(2);
         let metadata = crate::SourceMetadata::new_with_trusted_standard_library(
             root_file,
-            HashMap::from([
+            AHashMap::from([
                 (root_file, "/project/main.rue".to_owned()),
                 (module_file, "/project/std/bridge.rue".to_owned()),
             ]),
-            HashMap::from([
+            AHashMap::from([
                 (root_file, "main.rue".to_owned()),
                 (module_file, "\0rue-std/bridge.rue".to_owned()),
             ]),
-            HashSet::from([module_file]),
+            AHashSet::from([module_file]),
         )
         .expect("trusted accessor fixture metadata is valid");
         crate::SourceSnapshot::new(

--- a/crates/rue-compiler/tests/differential_oracle.rs
+++ b/crates/rue-compiler/tests/differential_oracle.rs
@@ -8,7 +8,8 @@
 //! final internal-linker executable bytes. This keeps the oracle on real
 //! production query paths through backend emission and object/link layout.
 
-use std::{collections::HashMap, fmt::Write as _, sync::Arc};
+use ahash::AHashMap;
+use std::{fmt::Write as _, sync::Arc};
 
 use rue_cfg::OptLevel;
 use rue_compiler::unstable::{
@@ -57,11 +58,11 @@ fn snapshot(entries: &[(u32, &str, &str, &str)], root: u32) -> SourceSnapshot {
     let physical = entries
         .iter()
         .map(|(id, path, _, _)| (FileId::new(*id), (*path).to_owned()))
-        .collect::<HashMap<_, _>>();
+        .collect::<AHashMap<_, _>>();
     let logical = entries
         .iter()
         .map(|(id, _, logical, _)| (FileId::new(*id), (*logical).to_owned()))
-        .collect::<HashMap<_, _>>();
+        .collect::<AHashMap<_, _>>();
     let metadata = SourceMetadata::new(FileId::new(root), physical, logical).unwrap();
     SourceSnapshot::new(
         metadata,

--- a/crates/rue-linker/BUCK
+++ b/crates/rue-linker/BUCK
@@ -5,6 +5,7 @@ rue_crate(
     test_platform = "native",
     deps = [
         "//crates/rue-target:rue-target",
+        "//third-party:ahash",
         "//third-party:tracing",
     ],
 )

--- a/crates/rue-linker/src/elf.rs
+++ b/crates/rue-linker/src/elf.rs
@@ -8,8 +8,6 @@
 //! Supports both ELF64 (Linux) and Mach-O 64-bit (macOS) formats.
 //! The format is auto-detected based on magic bytes.
 
-use std::collections::HashMap;
-
 use crate::constants::{
     // Mach-O constants
     ARM64_RELOC_ADDEND,
@@ -82,6 +80,7 @@ use crate::constants::{
     STT_OBJECT,
     STT_SECTION,
 };
+use ahash::AHashMap;
 
 /// Helper to read a u16 from a byte slice at a given offset.
 /// Panics if offset + 2 > slice.len(), so caller must ensure bounds.
@@ -150,7 +149,7 @@ pub struct ObjectFile {
     /// All symbols (both defined and undefined).
     pub symbols: Vec<Symbol>,
     /// Section name to index mapping.
-    pub section_map: HashMap<String, usize>,
+    pub section_map: AHashMap<String, usize>,
     /// The machine architecture this object was compiled for. The linker
     /// validates this against the link target — without it, an "aarch64"
     /// binary could silently embed x86 code (RUE-131 item 10, RUE-36).
@@ -487,7 +486,7 @@ impl ObjectFile {
 
         // Parse load commands to find segments and symbol table
         let mut sections = Vec::new();
-        let mut section_map = HashMap::new();
+        let mut section_map = AHashMap::new();
         let mut symtab_offset = 0usize;
         let mut symtab_count = 0usize;
         let mut strtab_offset = 0usize;
@@ -999,7 +998,7 @@ impl ObjectFile {
             0
         };
         let mut sections = Vec::with_capacity(section_capacity);
-        let mut section_map = HashMap::with_capacity(section_capacity);
+        let mut section_map = AHashMap::with_capacity(section_capacity);
         let mut symtab_idx = None;
         let mut strtab_idx = None;
 

--- a/crates/rue-linker/src/emit.rs
+++ b/crates/rue-linker/src/emit.rs
@@ -2,8 +2,7 @@
 //!
 //! Creates ELF64 relocatable object files from machine code and relocation info.
 
-use std::collections::HashMap;
-
+use ahash::AHashMap;
 use rue_target::Target;
 
 use crate::constants::{
@@ -227,10 +226,10 @@ impl ObjectBuilder {
         }
 
         // Collect external symbols for relocations (excluding string constants)
-        // Use HashMap for O(1) lookup during relocation processing
+        // Use AHashMap for O(1) lookup during relocation processing
         let mut extern_symbols: Vec<String> = Vec::new();
         let mut extern_symbol_offsets: Vec<usize> = Vec::new();
-        let mut extern_symbol_indices: HashMap<String, usize> = HashMap::new();
+        let mut extern_symbol_indices: AHashMap<String, usize> = AHashMap::new();
         for reloc in &self.relocations {
             // Skip string constant symbols - they're local, not external
             if reloc.symbol.starts_with(".rodata.str") {
@@ -333,7 +332,7 @@ impl ObjectBuilder {
                     .unwrap();
                 first_string_sym + string_id
             } else {
-                // External symbol - O(1) lookup via HashMap
+                // External symbol - O(1) lookup via AHashMap
                 extern_symbol_indices[&reloc.symbol] + first_extern_sym
             };
 
@@ -685,7 +684,7 @@ impl ObjectBuilder {
         // relocation while emitting them, both quadratic in an object's symbol
         // count.
         let mut extern_name_offsets: Vec<usize> = Vec::new();
-        let mut extern_symbol_indices: HashMap<&str, usize> = HashMap::new();
+        let mut extern_symbol_indices: AHashMap<&str, usize> = AHashMap::new();
         for reloc in &self.relocations {
             // Skip string symbols - they're handled via local symbols
             // String symbols use .rodata.strN format (possibly with @PAGE/@PAGEOFF suffix)

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -1,7 +1,8 @@
 //! The linker - combines object files and produces an executable.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::VecDeque;
 
+use ahash::{AHashMap, AHashSet};
 use rue_target::Target;
 use tracing::info_span;
 
@@ -257,7 +258,7 @@ fn references_undefined(sym: &Symbol) -> bool {
 fn enqueue_undefined<'a>(
     name: &'a str,
     pending: &mut VecDeque<&'a str>,
-    queued: &mut HashSet<&'a str>,
+    queued: &mut AHashSet<&'a str>,
 ) {
     if queued.insert(name) {
         pending.push_back(name);
@@ -743,8 +744,8 @@ fn collect_section_relocations(
 /// (RUE-131 item 2)
 #[derive(Default)]
 struct SymbolAddresses {
-    globals: HashMap<String, u64>,
-    locals: HashMap<(usize, String), u64>,
+    globals: AHashMap<String, u64>,
+    locals: AHashMap<(usize, String), u64>,
 }
 
 impl SymbolAddresses {
@@ -922,7 +923,7 @@ pub struct Linker {
     /// Page size for alignment.
     page_size: u64,
     /// Symbol table: name -> (object_index, symbol).
-    global_symbols: HashMap<String, (usize, Symbol)>,
+    global_symbols: AHashMap<String, (usize, Symbol)>,
     /// All object files we're linking.
     objects: Vec<ObjectFile>,
     /// Symbols that must be resolved (e.g., entry point).
@@ -938,7 +939,7 @@ impl Linker {
             target,
             base_addr: target.default_base_addr(),
             page_size: target.page_size(),
-            global_symbols: HashMap::new(),
+            global_symbols: AHashMap::new(),
             objects: Vec::new(),
             required_symbols: Vec::new(),
         }
@@ -1044,13 +1045,13 @@ impl Linker {
         // selected members move into `self` afterwards.
         let selected: Vec<bool> = {
             // Map each symbol to every member that defines it, in archive member
-            // order. A last-writer-wins `HashMap::insert` index would instead bind
+            // order. A last-writer-wins `AHashMap::insert` index would instead bind
             // each symbol to its *last* provider, so selection could extract a later
             // member over an earlier one and silently change weak/strong resolution
             // when a user or foreign archive ships multiple providers (RUE-848).
             // Retaining the ordered provider list keeps selection first-eligible and
             // independent of hash iteration order.
-            let mut symbol_providers: HashMap<&str, Vec<usize>> = HashMap::new();
+            let mut symbol_providers: AHashMap<&str, Vec<usize>> = AHashMap::new();
             for (obj_idx, obj) in archive_objects.iter().enumerate() {
                 for sym in &obj.symbols {
                     if provides_definition(sym) {
@@ -1061,7 +1062,7 @@ impl Linker {
 
             // Track which archive objects we've selected and which symbols are defined
             let mut selected: Vec<bool> = vec![false; archive_objects.len()];
-            let mut defined: HashSet<&str> =
+            let mut defined: AHashSet<&str> =
                 self.global_symbols.keys().map(String::as_str).collect();
 
             // The undefined symbols still to resolve, in the order they were
@@ -1075,7 +1076,7 @@ impl Linker {
             // extraction remains first-eligible in archive order and independent
             // of hash iteration order.
             let mut pending: VecDeque<&str> = VecDeque::new();
-            let mut queued: HashSet<&str> = HashSet::new();
+            let mut queued: AHashSet<&str> = AHashSet::new();
 
             // Required symbols (e.g. the entry point) are undefined by
             // definition, followed by every reference the linked objects make.
@@ -1165,7 +1166,7 @@ impl Linker {
         let mut merged_text = Vec::new(); // Code + rodata (goes in __TEXT)
         let mut merged_data = Vec::new(); // Writable data (goes in __DATA)
         let mut bss_size: u64 = 0;
-        let mut section_offsets: HashMap<(usize, usize), u64> = HashMap::new();
+        let mut section_offsets: AHashMap<(usize, usize), u64> = AHashMap::new();
         let mut pending_relocations: Vec<PendingRelocation> = Vec::new();
 
         // Merge code sections (.text* / __text)
@@ -1576,7 +1577,7 @@ impl Linker {
 
         // Track where each section ends up in the merged output
         // Key: (object_index, section_index) -> offset in merged section
-        let mut section_offsets: HashMap<(usize, usize), u64> = HashMap::new();
+        let mut section_offsets: AHashMap<(usize, usize), u64> = AHashMap::new();
 
         // Merge code sections (.text*)
         for (obj_idx, obj) in self.objects.iter().enumerate() {
@@ -2101,7 +2102,7 @@ mod tests {
                 align: 1,
             }],
             symbols,
-            section_map: HashMap::from([(".text".into(), 0)]),
+            section_map: AHashMap::from([(".text".into(), 0)]),
             machine: crate::elf::ElfMachine::X86_64,
             format: ObjectFormat::Elf,
         }
@@ -2546,7 +2547,7 @@ mod tests {
             binding: SymbolBinding::Global,
             sym_type: SymbolType::Func,
         }];
-        let mut section_map = HashMap::new();
+        let mut section_map = AHashMap::new();
         section_map.insert(".text".into(), 0);
         section_map.insert(name.to_string(), 1);
         ObjectFile {
@@ -2796,7 +2797,7 @@ mod tests {
                 binding,
                 sym_type: SymbolType::Func,
             }],
-            section_map: HashMap::from([(".text".into(), 0)]),
+            section_map: AHashMap::from([(".text".into(), 0)]),
             machine: crate::elf::ElfMachine::X86_64,
             format: crate::elf::ObjectFormat::Elf,
         };
@@ -2880,7 +2881,7 @@ mod tests {
                 align: 16,
             }],
             symbols,
-            section_map: HashMap::from([(".text".into(), 0)]),
+            section_map: AHashMap::from([(".text".into(), 0)]),
             machine: crate::elf::ElfMachine::X86_64,
             format: crate::elf::ObjectFormat::Elf,
         }
@@ -3241,7 +3242,7 @@ mod tests {
                     sym_type: SymbolType::None,
                 },
             ],
-            section_map: HashMap::from([(".text".into(), 0)]),
+            section_map: AHashMap::from([(".text".into(), 0)]),
             machine: crate::elf::ElfMachine::X86_64,
             format: crate::elf::ObjectFormat::Elf,
         };
@@ -3606,7 +3607,7 @@ mod tests {
         let obj = ObjectFile {
             sections: vec![text_section],
             symbols: vec![null_symbol, bad_symbol, main_symbol],
-            section_map: HashMap::from([(".text".into(), 0)]),
+            section_map: AHashMap::from([(".text".into(), 0)]),
             machine: crate::elf::ElfMachine::X86_64,
             format: crate::elf::ObjectFormat::Elf,
         };
@@ -3680,7 +3681,7 @@ mod tests {
         let obj = ObjectFile {
             sections: vec![text_section],
             symbols: vec![null_symbol, main_symbol], // Only 2 symbols, but relocation references index 999
-            section_map: HashMap::from([(".text".into(), 0)]),
+            section_map: AHashMap::from([(".text".into(), 0)]),
             machine: crate::elf::ElfMachine::X86_64,
             format: crate::elf::ObjectFormat::Elf,
         };

--- a/crates/rue-parser/BUCK
+++ b/crates/rue-parser/BUCK
@@ -6,6 +6,7 @@ rue_crate(
         "//crates/rue-error:rue-error",
         "//crates/rue-lexer:rue-lexer",
         "//crates/rue-span:rue-span",
+        "//third-party:ahash",
         "//third-party:lasso",
         "//third-party:smallvec",
         "//third-party:tracing",

--- a/crates/rue-parser/src/parser_policy/diagnostics.rs
+++ b/crates/rue-parser/src/parser_policy/diagnostics.rs
@@ -6,10 +6,11 @@
 //! helps, and suggestions are intentionally not part of this parser policy's
 //! exact key.
 
-use std::collections::{HashMap, hash_map::RandomState};
+use std::collections::hash_map::RandomState;
 use std::fmt::{self, Write as _};
 use std::hash::{BuildHasher, Hash, Hasher};
 
+use ahash::AHashMap;
 use rue_error::{CompileError, ErrorKind};
 
 use crate::PARSER_DIAGNOSTIC_BUDGET;
@@ -45,7 +46,7 @@ fn fingerprint(state: &RandomState, error: &CompileError) -> u64 {
 pub(crate) struct ParserDiagnostics {
     retained: Vec<CompileError>,
     fingerprint_state: RandomState,
-    seen: HashMap<u64, Vec<usize>>,
+    seen: AHashMap<u64, Vec<usize>>,
     last_retained: Option<usize>,
     last_unretained: Option<CompileError>,
     summary_span: Option<rue_span::Span>,

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -5331,7 +5331,7 @@ impl QueryRuntime {
             leases: Mutex::new(TaskLeases::default()),
             query_cache: Mutex::new(TaskQueryCache::default()),
             observed_handoffs: Mutex::new(Vec::new()),
-            checked_handoffs: Mutex::new(HashSet::new()),
+            checked_handoffs: Mutex::new(AHashSet::new()),
             #[cfg(test)]
             handoff_validation_visits: AtomicUsize::new(0),
             #[cfg(test)]
@@ -9247,7 +9247,7 @@ struct Task {
     /// Lifecycle identities whose complete dependency DAG has already been
     /// proven live by this rooted task. Every cached identity remains owned by
     /// an observed root lifecycle for the task's lifetime.
-    checked_handoffs: Mutex<HashSet<usize>>,
+    checked_handoffs: Mutex<AHashSet<usize>>,
     #[cfg(test)]
     handoff_validation_visits: AtomicUsize,
     /// Ordered-index probes used by structural amplification tests. One
@@ -10632,7 +10632,7 @@ impl Task {
             leases: Mutex::new(TaskLeases::default()),
             query_cache: Mutex::new(TaskQueryCache::default()),
             observed_handoffs: Mutex::new(Vec::new()),
-            checked_handoffs: Mutex::new(HashSet::new()),
+            checked_handoffs: Mutex::new(AHashSet::new()),
             #[cfg(test)]
             handoff_validation_visits: AtomicUsize::new(0),
             #[cfg(test)]
@@ -11126,7 +11126,7 @@ impl Task {
 
     fn validate_handoff(&self, handoff: &Arc<AttemptHandoffLifecycle>) -> bool {
         let mut checked = lock(&self.checked_handoffs);
-        let mut newly_checked = HashSet::new();
+        let mut newly_checked = AHashSet::new();
         if !self.validate_handoff_once(handoff, &checked, &mut newly_checked) {
             return false;
         }
@@ -11137,8 +11137,8 @@ impl Task {
     fn validate_handoff_once(
         &self,
         lifecycle: &Arc<AttemptHandoffLifecycle>,
-        checked: &HashSet<usize>,
-        newly_checked: &mut HashSet<usize>,
+        checked: &AHashSet<usize>,
+        newly_checked: &mut AHashSet<usize>,
     ) -> bool {
         let identity = Arc::as_ptr(lifecycle) as usize;
         if checked.contains(&identity) || !newly_checked.insert(identity) {
@@ -14962,7 +14962,7 @@ mod tests {
             leases: Mutex::new(TaskLeases::default()),
             query_cache: Mutex::new(TaskQueryCache::default()),
             observed_handoffs: Mutex::new(Vec::new()),
-            checked_handoffs: Mutex::new(HashSet::new()),
+            checked_handoffs: Mutex::new(AHashSet::new()),
             handoff_validation_visits: AtomicUsize::new(0),
             validation_endorsement_index_probes: AtomicUsize::new(0),
         };
@@ -15019,7 +15019,7 @@ mod tests {
             leases: Mutex::new(TaskLeases::default()),
             query_cache: Mutex::new(TaskQueryCache::default()),
             observed_handoffs: Mutex::new(Vec::new()),
-            checked_handoffs: Mutex::new(HashSet::new()),
+            checked_handoffs: Mutex::new(AHashSet::new()),
             handoff_validation_visits: AtomicUsize::new(0),
             validation_endorsement_index_probes: AtomicUsize::new(0),
         };
@@ -15298,7 +15298,7 @@ mod tests {
             leases: Mutex::new(TaskLeases::default()),
             query_cache: Mutex::new(TaskQueryCache::default()),
             observed_handoffs: Mutex::new(Vec::new()),
-            checked_handoffs: Mutex::new(HashSet::new()),
+            checked_handoffs: Mutex::new(AHashSet::new()),
             handoff_validation_visits: AtomicUsize::new(0),
             validation_endorsement_index_probes: AtomicUsize::new(0),
         });

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -6,8 +6,7 @@
 //! session. Whole-program presentation composes these same artifacts rather
 //! than invoking a second module-wide lowering authority.
 
-use std::collections::{HashMap, HashSet};
-
+use ahash::{AHashMap, AHashSet};
 use lasso::{Spur, ThreadedRodeo};
 
 use rue_parser::ast::{ConstDecl, DropFn, ExternBlock, ExternFn};
@@ -78,7 +77,7 @@ pub struct AstGen<'a> {
     /// minting a second, drift-prone anchor from its own `structural_path`; a
     /// missing or kind-mismatched lookup fails closed as an internal error.
     anonymous_anchors:
-        HashMap<rue_span::Span, (crate::AnonymousTypeSiteKind, crate::RirStructuralAnchor)>,
+        AHashMap<rue_span::Span, (crate::AnonymousTypeSiteKind, crate::RirStructuralAnchor)>,
     authoritative_anonymous_anchors: bool,
     /// Nesting depth of semantic producer roots. A transported authoritative
     /// table belongs to the outer exact declaration only; method bodies nested
@@ -163,7 +162,7 @@ impl<'a> AstGen<'a> {
             for_counter: 0,
             compound_counter: 0,
             structural_path: Vec::new(),
-            anonymous_anchors: HashMap::new(),
+            anonymous_anchors: AHashMap::new(),
             authoritative_anonymous_anchors: false,
             producer_root_depth: 0,
             normalize_symbol: Box::new(normalize_symbol),
@@ -192,7 +191,7 @@ impl<'a> AstGen<'a> {
         >,
     ) -> Result<(), crate::RirPayloadBuildError> {
         self.authoritative_anonymous_anchors = true;
-        let mut seen_anchors = HashSet::new();
+        let mut seen_anchors = AHashSet::new();
         for (span, kind, anchor) in anchors {
             if self.anonymous_anchors.contains_key(&span) || !seen_anchors.insert(anchor.clone()) {
                 return Err(crate::RirPayloadBuildError::InvalidBuilderInput {
@@ -3700,9 +3699,9 @@ mod tests {
         }
     }
 
-    fn inst_kind_counts(source: &str) -> std::collections::HashMap<&'static str, usize> {
+    fn inst_kind_counts(source: &str) -> AHashMap<&'static str, usize> {
         let (rir, _) = gen_rir(source);
-        let mut counts = std::collections::HashMap::new();
+        let mut counts = AHashMap::new();
         for (_, instruction) in rir.iter() {
             let kind = match &instruction.data {
                 InstData::Call { .. } => "call",

--- a/crates/rue-rir/src/inst/packed.rs
+++ b/crates/rue-rir/src/inst/packed.rs
@@ -3496,7 +3496,7 @@ mod tests {
             .nodes()
             .iter()
             .map(std::mem::discriminant)
-            .collect::<std::collections::HashSet<_>>();
+            .collect::<ahash::AHashSet<_>>();
         assert_eq!(variants.len(), 13, "fixture must cover every type node");
 
         let packed = pack(&source, &symbols, root);
@@ -4379,7 +4379,7 @@ mod tests {
         let variants = editor
             .iter()
             .map(|(_, instruction)| std::mem::discriminant(&instruction.data))
-            .collect::<std::collections::HashSet<_>>();
+            .collect::<ahash::AHashSet<_>>();
         assert_eq!(variants.len(), 63, "fixture duplicated an InstData variant");
         let payload_stats = editor.payload_storage_stats();
         assert_eq!(RIR_PAYLOAD_FAMILY_NAMES.len(), 17);

--- a/crates/rue/BUCK
+++ b/crates/rue/BUCK
@@ -8,6 +8,7 @@ _DEPS = [
     "//crates/rue-perf-schema:rue-perf-schema",
     "//crates/rue-rir:rue-rir",
     "//crates/rue-target:rue-target",
+    "//third-party:ahash",
     "//third-party:libc",
     "//third-party:serde",
     "//third-party:serde_json",

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::io::Read;
@@ -6,6 +5,7 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
+use ahash::{AHashMap, AHashSet};
 use rue_compiler::unstable::{
     AcceptedImportSource, DiscoverySourceAssembler, ImportDemandFrontier, ImportDemandMode,
     ImportDiscoveryPlan, ImportDiscoveryRequest, ImportDiscoveryWave, ImportInputRevision,
@@ -41,8 +41,8 @@ use rue_compiler::{
 pub(crate) struct SourceManifest {
     path: PathBuf,
     content_hash: u64,
-    allowed: std::collections::HashSet<PathBuf>,
-    declared_paths: std::collections::HashSet<PathBuf>,
+    allowed: AHashSet<PathBuf>,
+    declared_paths: AHashSet<PathBuf>,
 }
 
 impl SourceManifest {
@@ -68,8 +68,8 @@ impl SourceManifest {
             )
         };
 
-        let mut allowed = std::collections::HashSet::new();
-        let mut declared_paths = std::collections::HashSet::new();
+        let mut allowed = AHashSet::new();
+        let mut declared_paths = AHashSet::new();
         for (line_index, raw_line) in content.lines().enumerate() {
             let line_number = line_index + 1;
             let entry = parse_source_manifest_entry(raw_line);
@@ -345,9 +345,9 @@ fn reobserve_accepted_reads(
     snapshot: &SourceSnapshot,
     manifest: &AcceptedReadManifest,
     source_manifest: Option<&SourceManifest>,
-) -> Result<HashMap<String, AcceptedImportSource>, SourceLoadError> {
+) -> Result<AHashMap<String, AcceptedImportSource>, SourceLoadError> {
     let now = SystemTime::now();
-    let mut observed = HashMap::with_capacity(manifest.len());
+    let mut observed = AHashMap::with_capacity(manifest.len());
     for entry in manifest.iter() {
         let cached_source =
             cached_source_for_module(snapshot, entry.module()).ok_or_else(|| {
@@ -396,7 +396,7 @@ fn reobserve_accepted_reads(
 fn execute_import_request(
     request: ImportDiscoveryRequest,
     source_manifest: Option<&SourceManifest>,
-    reobserved_reads: Option<&HashMap<String, AcceptedImportSource>>,
+    reobserved_reads: Option<&AHashMap<String, AcceptedImportSource>>,
 ) -> ImportObservation {
     if let Some(source) = reobserved_reads
         .and_then(|reads| reads.get(request.requested_path()))
@@ -928,7 +928,7 @@ fn run_import_wave(
     plan: &ImportDiscoveryPlan,
     frontier: &ImportDemandFrontier,
     source_manifest: Option<&SourceManifest>,
-    reobserved_reads: Option<&HashMap<String, AcceptedImportSource>>,
+    reobserved_reads: Option<&AHashMap<String, AcceptedImportSource>>,
 ) -> Result<(ImportInputRevision, ImportDemandFrontier), SourceLoadError> {
     for attempt in 0..=WAVE_STAMP_RETRIES {
         let mut wave = begin_import_wave(staging, input_revision, plan, frontier)
@@ -980,7 +980,7 @@ fn drive_import_discovery_to_close(
     staging: &mut CompilerSession,
     context: &ImportDiscoveryContext,
     source_manifest: Option<&SourceManifest>,
-    reobserved_reads: Option<&HashMap<String, AcceptedImportSource>>,
+    reobserved_reads: Option<&AHashMap<String, AcceptedImportSource>>,
     continuation: Option<ImportInputRevision>,
     reclose: Option<ReClose<'_>>,
 ) -> Result<ClosedDiscovery, SourceLoadError> {
@@ -1267,8 +1267,9 @@ pub(crate) fn discover_and_load_imports(
     // duplicate CLI inputs left to detect here; discovery still recognizes
     // `main.rue` and `./main.rue` as the same physical source when one is
     // reached through the other's import graph.
-    let physical_paths: HashMap<_, _> = HashMap::from([(FileId::new(1), root_source.to_string())]);
-    let logical_paths: HashMap<_, _> = HashMap::from([(FileId::new(1), "root".to_string())]);
+    let physical_paths: AHashMap<_, _> =
+        AHashMap::from([(FileId::new(1), root_source.to_string())]);
+    let logical_paths: AHashMap<_, _> = AHashMap::from([(FileId::new(1), "root".to_string())]);
     if let Err(error) = SourceMetadata::new(FileId::new(1), physical_paths, logical_paths) {
         return Err(SourceLoadError::Compiler {
             snapshot: None,

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -92,7 +92,6 @@
 //! ```
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, PoisonError, Weak};
 #[cfg(test)]
@@ -104,6 +103,7 @@ const COMPILER_BUILD_PROFILE: &str = "release_thin_lto";
 #[cfg(not(rue_release_build))]
 const COMPILER_BUILD_PROFILE: &str = "debug";
 
+use ahash::AHashMap;
 use rue_perf_schema::{CompilerWork, DurationDistribution, Phase, PhaseAccounting};
 use serde::Serialize;
 
@@ -128,16 +128,16 @@ pub struct TimingData {
 static NEXT_TIMING_DATA_ID: AtomicU64 = AtomicU64::new(1);
 
 thread_local! {
-    static LOCAL_TIMING: RefCell<HashMap<u64, LocalTiming>> = RefCell::new(HashMap::new());
+    static LOCAL_TIMING: RefCell<AHashMap<u64, LocalTiming>> = RefCell::new(AHashMap::new());
 }
 
 /// The actual timing data storage.
 struct TimingDataInner {
     /// Accumulated measurements per pass name.
     /// Key is the span name (e.g., "lexer", "parser").
-    passes: HashMap<String, PassAggregate>,
+    passes: AHashMap<String, PassAggregate>,
     /// Exact structural counters published by wide timing events.
-    counters: HashMap<String, u64>,
+    counters: AHashMap<String, u64>,
 
     /// Accumulated measurements per driver-phase name.
     ///
@@ -146,7 +146,7 @@ struct TimingDataInner {
     /// machinery but kept out of `passes` and out of `root_duration`, so
     /// `total_ms` keeps meaning "compiler work" and `compile` stays the sole
     /// timing root (RUE-786).
-    driver_phases: HashMap<String, DriverPhaseAggregate>,
+    driver_phases: AHashMap<String, DriverPhaseAggregate>,
 
     /// Timestamped root and phase transitions, merged once per worker. Sorting
     /// this bounded event stream at finalization reconstructs the one global
@@ -222,9 +222,9 @@ enum AccountingTransition {
 /// requested.
 struct LocalTiming {
     target: Weak<Mutex<TimingDataInner>>,
-    passes: HashMap<String, PassAggregate>,
-    counters: HashMap<String, u64>,
-    driver_phases: HashMap<String, DriverPhaseAggregate>,
+    passes: AHashMap<String, PassAggregate>,
+    counters: AHashMap<String, u64>,
+    driver_phases: AHashMap<String, DriverPhaseAggregate>,
     accounting_events: Vec<AccountingEvent>,
     #[cfg(test)]
     synthetic_unattributed: Duration,
@@ -236,9 +236,9 @@ impl LocalTiming {
     fn new(target: Weak<Mutex<TimingDataInner>>) -> Self {
         Self {
             target,
-            passes: HashMap::new(),
-            counters: HashMap::new(),
-            driver_phases: HashMap::new(),
+            passes: AHashMap::new(),
+            counters: AHashMap::new(),
+            driver_phases: AHashMap::new(),
             accounting_events: Vec::new(),
             #[cfg(test)]
             synthetic_unattributed: Duration::ZERO,
@@ -273,7 +273,7 @@ impl Drop for LocalTiming {
     }
 }
 
-fn merge_pass(target: &mut HashMap<String, PassAggregate>, name: String, local: PassAggregate) {
+fn merge_pass(target: &mut AHashMap<String, PassAggregate>, name: String, local: PassAggregate) {
     let aggregate = target.entry(name).or_default();
     aggregate.duration += local.duration;
     aggregate.max_duration = aggregate.max_duration.max(local.max_duration);
@@ -290,7 +290,7 @@ fn merge_pass(target: &mut HashMap<String, PassAggregate>, name: String, local: 
 }
 
 fn merge_driver_phase(
-    target: &mut HashMap<String, DriverPhaseAggregate>,
+    target: &mut AHashMap<String, DriverPhaseAggregate>,
     name: String,
     local: DriverPhaseAggregate,
 ) {
@@ -406,9 +406,9 @@ impl TimingData {
         Self {
             id: NEXT_TIMING_DATA_ID.fetch_add(1, Ordering::Relaxed),
             inner: Arc::new(Mutex::new(TimingDataInner {
-                passes: HashMap::new(),
-                counters: HashMap::new(),
-                driver_phases: HashMap::new(),
+                passes: AHashMap::new(),
+                counters: AHashMap::new(),
+                driver_phases: AHashMap::new(),
                 accounting_events: Vec::new(),
                 #[cfg(test)]
                 synthetic_unattributed: Duration::ZERO,
@@ -1010,13 +1010,13 @@ fn duration_bucket(duration: Duration) -> usize {
     }
 }
 
-fn ordered_aggregates(aggregates: &HashMap<String, PassAggregate>) -> Vec<String> {
+fn ordered_aggregates(aggregates: &AHashMap<String, PassAggregate>) -> Vec<String> {
     let mut names = aggregates.keys().cloned().collect::<Vec<_>>();
     names.sort();
     names
 }
 
-fn ordered_driver_aggregates(aggregates: &HashMap<String, DriverPhaseAggregate>) -> Vec<String> {
+fn ordered_driver_aggregates(aggregates: &AHashMap<String, DriverPhaseAggregate>) -> Vec<String> {
     let mut names = aggregates.keys().cloned().collect::<Vec<_>>();
     names.sort();
     names
@@ -1200,7 +1200,7 @@ struct SemanticProviderBreakdownVisitor {
     constraint_generation_ns: Option<u64>,
     unification_resolution_ns: Option<u64>,
     air_emission_validation_ns: Option<u64>,
-    counters: HashMap<&'static str, u64>,
+    counters: AHashMap<&'static str, u64>,
 }
 
 #[derive(Default)]
@@ -1211,7 +1211,7 @@ struct SemanticBodyLoweringBreakdownVisitor {
     rir_lower_ns: Option<u64>,
     span_remap_validation_ns: Option<u64>,
     body_rir_index_ns: Option<u64>,
-    counters: HashMap<&'static str, u64>,
+    counters: AHashMap<&'static str, u64>,
 }
 
 impl tracing::field::Visit for TimingFlushVisitor {


### PR DESCRIPTION
Implements RUE-1625. Follow-up to RUE-1617 (#2564). Files RUE-1626 for the exceptions.

## Why

#2564 moved four individually-profiled hot spots off SipHash. That left the split between `std::collections::HashMap` and `ahash` decided by which sites had happened to be profiled rather than by any rule, and the remaining default-hasher maps were still SipHash-1-3.

## The rule

A hash map in the compiler is a bucket selector: typed equality decides membership, so its hasher only has to be fast and deterministic. Ordered iteration is `BTreeMap`'s job. `std::collections::HashMap` on its default hasher therefore has no role here.

`rue-query` and `rue-rir` already used the explicit `AHashMap`/`AHashSet` names, so that spelling is adopted everywhere rather than introducing an alias.

## The exceptions

Maps whose hasher is not a free choice are left alone — every one is documented in place:

- **Already a deliberate custom hasher.** `rue-query`'s node registry and retention sets use `BuildHasherDefault<IncarnationHasher>` and `BuildHasherDefault<RetainedIdentityHasher>`, narrower and faster for their key shape than a general-purpose hasher.
- **The packed-RIR decoder's `seen` map**, which pairs a deliberately seeded `RandomState` with `try_reserve` while decoding a length-prefixed input.
- **Five maps pinned by something else.** `canonical_anonymous_types` and `consulted_anonymous_types` in the provider body host, `expr_types` in the constraint generator, and the `aggregate_types` / `method_references` fields that `rue-compiler` and `rue-cfg` read directly. Two are order-dependences reachable from an emitted artifact (a sort key that is not total; pool indices that later become a sort key), one is a `find_map` that answers with an arbitrary member, and two leak their container type into AIR's public surface. **RUE-1626** tracks removing those constraints so these stop being slow because of something else.
- **`BTreeMap`/`BTreeSet`**, ordered on purpose.

## What made this a sweep rather than a rename

`RetainedCharge` was implemented only for the default-hasher `HashMap`/`HashSet`. It is now generic over the hasher parameter, since the hasher is not part of what a map retains.

`ahash` becomes a dependency of `rue`, `rue-cfg`, `rue-codegen`, `rue-linker`, `rue-parser`, and the differential-oracle test target.

## Result

Fresh `-O3 -j1` Lattice build:

| | Retired instructions | vs. previous | vs. pre-RUE-1617 |
| --- | ---: | ---: | ---: |
| before RUE-1617 | 9,486,324,770 | — | — |
| after RUE-1617 (#2564) | 9,140,648,435 | −3.64% | −3.64% |
| **after this change** | **8,919,235,165** | **−2.42%** | **−5.98%** |

The emitted executable is byte-identical to the output from before either change (`cmp`-verified). SipHash no longer appears among the profile's top entries.

Holding the five documented exceptions on the std hasher costs 20.9M instructions — 0.23% of the build. That is the size of what RUE-1626 would reclaim, and it is small enough that respecting the existing comments was clearly the right trade here.

Wall time on the development host — a 4-core container where a fresh Lattice build runs ~2.2s at `-j1` — cannot resolve a change this size, so the instruction count is the signal. The ADR-0071 reference collection remains the authority for any milestone claim.

## On iteration order

Changing a map's hasher changes its iteration order. For the maps that did move this cannot affect output: `RandomState` is seeded per process, so their order was already arbitrary from run to run, and `compiler reproducibility` is a passing gate on trunk. The byte-identical executable confirms it directly. The maps where order *is* reachable are exactly the five left untouched.

## Validation

- `scripts/rue premerge` — 196 pass, 0 fail, 0 build failures
- `scripts/rue fmt` applied
- Emitted Lattice executable byte-identical against the pre-change compiler

## Note for review

The mechanical part is large but uniform. The parts worth a human eye are the exception list above, the `RetainedCharge` signature change, and a handful of places where the import had to be test-gated or moved inside a `mod tests` that imports explicitly rather than via `use super::*`.