### PR TITLE
RUE-1609: track completed exclusive uses

### DIFF
--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -107,6 +107,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         param_types: &[Type],
         param_modes: &[RirParamMode],
         validate_semantic_types: bool,
+        call_may_continue: bool,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<CallOperands> {
         let args = self.body_rir_ref().call_args(args_range).to_vec();
@@ -115,6 +116,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             args.iter().copied(),
             param_types,
             param_modes,
+            call_may_continue,
             ctx,
         )?;
         if validate_semantic_types {
@@ -558,11 +560,20 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         // Analyze all arguments. Slice parameters (ADR-0043, RUE-322) coerce a
         // `borrow arr` argument into a by-value fat pointer here.
+        let expression_ledgers_before_call = ctx.checkpoint_expression_ledgers();
         let CallOperands {
             args: air_args,
             temp_scope,
             continues,
-        } = self.analyze_call_operands(air, args_range, &param_types, &param_modes, false, ctx)?;
+        } = self.analyze_call_operands(
+            air,
+            args_range,
+            &param_types,
+            &param_modes,
+            false,
+            !fn_info.return_type.is_never(),
+            ctx,
+        )?;
 
         // Handle generic function calls differently
         if is_generic {
@@ -770,15 +781,19 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             )?;
             let air_ref =
                 self.wrap_value_with_temp_scope(air, air_ref, return_type, span, temp_scope)?;
-            Ok(AnalysisResult::with_continues(
+            let result = AnalysisResult::with_continues(
                 air_ref,
                 return_type,
                 continues && !return_type.is_never(),
-            ))
+            );
+            if !result.continues {
+                ctx.rollback_expression_ledgers(expression_ledgers_before_call);
+            }
+            Ok(result)
         } else {
             // Regular non-generic call
             let return_type = base_return_type;
-            self.emit_call_result(
+            let result = self.emit_call_result(
                 air,
                 name,
                 &air_args,
@@ -786,7 +801,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 return_type,
                 continues && !return_type.is_never(),
                 span,
-            )
+            )?;
+            if !result.continues {
+                ctx.rollback_expression_ledgers(expression_ledgers_before_call);
+            }
+            Ok(result)
         }
     }
 
@@ -934,6 +953,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // Analyze the receiver expression. When it is a by-ref receiver,
         // `byref_arg_root` makes the var-ref / field / index reads borrow the
         // place instead of moving out of it (restored afterwards).
+        let expression_ledgers_before_call = ctx.checkpoint_expression_ledgers();
         let mut receiver_result =
             self.analyze_with_borrow_root(air, receiver, receiver_byref_root, ctx)?;
         let receiver_continues = receiver_result.continues;
@@ -1234,6 +1254,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             &method_param_types,
             &method_param_modes,
             false,
+            receiver_continues && !return_type.is_never(),
             ctx,
         );
         if receiver_frame_pushed {
@@ -1283,6 +1304,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             receiver_continues && args_result.continues && !return_type.is_never(),
             span,
         )?;
+        if call.continues
+            && receiver_mode == AirArgMode::Inout
+            && let Some(root) = self.extract_root_variable(receiver)
+        {
+            self.record_completed_exclusive_use(root, span, ctx);
+        }
+        if !call.continues {
+            ctx.rollback_expression_ledgers(expression_ledgers_before_call);
+        }
         Ok(call)
     }
 
@@ -1412,13 +1442,22 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // materialize their by-value fat-pointer views exactly like direct
         // calls do (RUE-559) — std functions taking `borrow s: str` are called
         // this way.
+        let expression_ledgers_before_call = ctx.checkpoint_expression_ledgers();
         let CallOperands {
             args: air_args,
             temp_scope,
             continues,
-        } = self.analyze_call_operands(air, args_range, &param_types, &param_modes, true, ctx)?;
+        } = self.analyze_call_operands(
+            air,
+            args_range,
+            &param_types,
+            &param_modes,
+            true,
+            !fn_info.return_type.is_never(),
+            ctx,
+        )?;
 
-        self.emit_call_result(
+        let result = self.emit_call_result(
             air,
             function_key,
             &air_args,
@@ -1426,7 +1465,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             fn_info.return_type,
             continues && !fn_info.return_type.is_never(),
             span,
-        )
+        )?;
+        if !result.continues {
+            ctx.rollback_expression_ledgers(expression_ledgers_before_call);
+        }
+        Ok(result)
     }
 
     /// Analyze a type-qualified associated-function call.
@@ -1573,6 +1616,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // path as free and module-member calls. In particular, `borrow str`
         // and `[T]` parameters are physical by-value views even though their
         // source modes remain Borrow (RUE-634).
+        let expression_ledgers_before_call = ctx.checkpoint_expression_ledgers();
         let CallOperands {
             args: air_args,
             temp_scope,
@@ -1583,6 +1627,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             &method_param_types,
             &method_param_modes,
             false,
+            !return_type.is_never(),
             ctx,
         )?;
 
@@ -1594,7 +1639,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let call_name = self.method_symbol(struct_id, &function_name_str, false);
         let call_name_sym = self.body_interner().get_or_intern(&call_name);
 
-        self.emit_call_result(
+        let result = self.emit_call_result(
             air,
             call_name_sym,
             &air_args,
@@ -1602,6 +1647,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return_type,
             continues && !return_type.is_never(),
             span,
-        )
+        )?;
+        if !result.continues {
+            ctx.rollback_expression_ledgers(expression_ledgers_before_call);
+        }
+        Ok(result)
     }
 }

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -1143,7 +1143,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         air: &mut Air,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<Option<PlaceTrace>> {
-        if let Some((place, root, ty, mutable)) = ctx.accessor_place_refs.get(&inst_ref).copied() {
+        if let Some((place, root, ty, mutable, continues)) =
+            ctx.accessor_place_refs.get(&inst_ref).copied()
+        {
             let cached = air.get_place(place);
             return Ok(Some(PlaceTrace {
                 base: cached.base,
@@ -1154,7 +1156,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 is_borrow_param: !mutable,
                 pending_stmts: Vec::new(),
                 via_accessor: true,
-                continues: true,
+                continues,
             }));
         }
         // Peek the receiver type without emitting anything: only proceed when
@@ -1200,6 +1202,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<PlaceTrace> {
+        let expression_ledgers_before_call = ctx.checkpoint_expression_ledgers();
         let info = self
             .call_facts()
             .call_method_info(struct_id, method)
@@ -1273,50 +1276,79 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 span,
             ));
         }
-        // Mutable accessors carry an exclusive loan; shared and exclusive
-        // accessor results conflict on the same root. The existing root loan
-        // list is intentionally expression-scoped and root-granular.
+        // Analyze guard operands before installing the result loan. Under the
+        // accessor-call evaluation rule, no accessor result exists when the
+        // receiver or a guard operand diverges.
         let loan_kind = if info.returns_inout {
             CallLoanKind::Inout
         } else {
             CallLoanKind::Borrow
         };
-        if ctx.expression_loans.iter().any(|(r, _, kind)| {
-            *r == root && (*kind == CallLoanKind::Inout || loan_kind == CallLoanKind::Inout)
-        }) {
-            return Err(CompileError::new(
-                ErrorKind::AccessorLoanConflict {
-                    variable: self.body_interner().resolve(&root).to_string(),
-                    conflict: "for another accessor result",
-                },
-                span,
-            ));
-        }
-        if loan_kind == CallLoanKind::Inout
-            && ctx
-                .expression_shared_reads
-                .iter()
-                .any(|(read_root, _)| *read_root == root)
-        {
-            return Err(CompileError::new(
-                ErrorKind::AccessorLoanConflict {
-                    variable: self.body_interner().resolve(&root).to_string(),
-                    conflict: "for an exclusive accessor result after a shared read",
-                },
-                span,
-            ));
-        }
-        ctx.expression_loans.push((root, span, loan_kind));
-        ctx.accessor_call_insts.insert(inst_ref, (method, root));
-        ctx.referenced_methods.insert((struct_id, method));
-        self.record_body_method_dependency((struct_id, method));
-
         let param_data = self.body_param_data(info.params);
         let param_types = param_data.types().to_vec();
         let param_modes = param_data.modes().to_vec();
         self.validate_call_contract_for_accessor(args_range, &param_types, &param_modes, span)?;
-        let operands =
-            self.analyze_call_operands(air, args_range, &param_types, &param_modes, false, ctx)?;
+        let operands = self.analyze_call_operands(
+            air,
+            args_range,
+            &param_types,
+            &param_modes,
+            false,
+            true,
+            ctx,
+        )?;
+        let accessor_continues = receiver_trace.continues && operands.continues;
+        if !accessor_continues {
+            ctx.rollback_expression_ledgers(expression_ledgers_before_call);
+        }
+        if accessor_continues {
+            // Mutable accessors carry an exclusive loan; shared and exclusive
+            // accessor results conflict on the same root. The root loan list
+            // is intentionally expression-scoped and root-granular.
+            if ctx.expression_loans.iter().any(|(r, _, kind)| {
+                *r == root && (*kind == CallLoanKind::Inout || loan_kind == CallLoanKind::Inout)
+            }) {
+                return Err(CompileError::new(
+                    ErrorKind::AccessorLoanConflict {
+                        variable: self.body_interner().resolve(&root).to_string(),
+                        conflict: "for another accessor result",
+                    },
+                    span,
+                ));
+            }
+            if let Some((_, exclusive_span)) = ctx
+                .expression_exclusive_uses
+                .iter()
+                .find(|(used_root, _)| *used_root == root)
+            {
+                return Err(CompileError::new(
+                    ErrorKind::AccessorLoanConflict {
+                        variable: self.body_interner().resolve(&root).to_string(),
+                        conflict: "for an accessor result after an exclusive use",
+                    },
+                    span,
+                )
+                .with_label("exclusive use here", *exclusive_span));
+            }
+            if loan_kind == CallLoanKind::Inout
+                && ctx
+                    .expression_shared_reads
+                    .iter()
+                    .any(|(read_root, _)| *read_root == root)
+            {
+                return Err(CompileError::new(
+                    ErrorKind::AccessorLoanConflict {
+                        variable: self.body_interner().resolve(&root).to_string(),
+                        conflict: "for an exclusive accessor result after a shared read",
+                    },
+                    span,
+                ));
+            }
+            ctx.expression_loans.push((root, span, loan_kind));
+        }
+        ctx.accessor_call_insts.insert(inst_ref, (method, root));
+        ctx.referenced_methods.insert((struct_id, method));
+        self.record_body_method_dependency((struct_id, method));
         let receiver_place = Self::build_place_ref(air, &receiver_trace)?;
         let receiver_value = air.add_inst(AirInst {
             data: AirInstData::PlaceRead {
@@ -1343,10 +1375,17 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         receiver_trace.via_accessor = true;
         receiver_trace.is_borrow_param = !info.returns_inout;
         receiver_trace.is_root_mutable = info.returns_inout;
+        receiver_trace.continues = accessor_continues;
         let yielded_place = Self::build_place_ref(air, &receiver_trace)?;
         ctx.accessor_place_refs.insert(
             inst_ref,
-            (yielded_place, root, info.return_type, info.returns_inout),
+            (
+                yielded_place,
+                root,
+                info.return_type,
+                info.returns_inout,
+                accessor_continues,
+            ),
         );
         Ok(receiver_trace)
     }
@@ -1395,7 +1434,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             span,
         });
         let value = Self::finish_traced_value(air, &mut trace, value, ty, span)?;
-        Ok(AnalysisResult::new(value, ty))
+        Ok(AnalysisResult::with_continues(value, ty, trace.continues))
     }
 
     /// The syntactic root of a place expression that may pass through
@@ -1898,6 +1937,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                                     .entry(name)
                                     .or_default()
                                     .mark_path_moved(&[], span);
+                                self.record_completed_exclusive_use(name, span, ctx);
                                 moves_out = true;
                             }
                         }
@@ -1999,6 +2039,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     .entry(name)
                     .or_default()
                     .mark_path_moved(&[], span);
+                self.record_completed_exclusive_use(name, span, ctx);
             }
 
             // Mark variable as used
@@ -2367,6 +2408,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     ty: Type::UNIT,
                     span,
                 });
+                if value_result.continues {
+                    self.record_completed_exclusive_use(name, span, ctx);
+                }
                 return Ok(AnalysisResult::with_continues(
                     air_ref,
                     Type::UNIT,
@@ -2445,6 +2489,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ty: Type::UNIT,
             span,
         });
+        if value_result.continues {
+            self.record_completed_exclusive_use(name, span, ctx);
+        }
         Ok(AnalysisResult::with_continues(
             air_ref,
             Type::UNIT,
@@ -2812,6 +2859,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     .entry(trace.root_var)
                     .or_default()
                     .mark_path_moved(&[], span);
+                if trace.continues {
+                    self.record_completed_exclusive_use(trace.root_var, span, ctx);
+                }
                 emit_move_marker = true;
             } else if !self.is_type_copy(field_type) {
                 // For non-linear types, check if accessing a non-Copy field
@@ -2859,6 +2909,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     .entry(trace.root_var)
                     .or_default()
                     .mark_path_moved(&field_path, span);
+                if trace.continues {
+                    self.record_completed_exclusive_use(trace.root_var, span, ctx);
+                }
 
                 // Export statically-trackable partial moves to drop elaboration
                 // so the moved path's drop inside the scope-exit drop is
@@ -2906,7 +2959,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             if trace.via_accessor {
                 ctx.accessor_place_refs.insert(
                     inst_ref,
-                    (place_ref, trace.root_var, field_type, trace.is_root_mutable),
+                    (
+                        place_ref,
+                        trace.root_var,
+                        field_type,
+                        trace.is_root_mutable,
+                        trace.continues,
+                    ),
                 );
             }
             let mut air_ref = air.add_inst(AirInst {
@@ -3210,7 +3269,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             if trace.via_accessor {
                 ctx.accessor_place_refs.insert(
                     inst_ref,
-                    (place_ref, trace.root_var, elem_type, trace.is_root_mutable),
+                    (
+                        place_ref,
+                        trace.root_var,
+                        elem_type,
+                        trace.is_root_mutable,
+                        trace.continues,
+                    ),
                 );
             }
             let mut air_ref = air.add_inst(AirInst {
@@ -3855,10 +3920,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 self.peek_place_type(place, ctx)
                     .ok_or_else(|| CompileError::new(ErrorKind::InvalidAssignmentTarget, span))
             },
-            |(_, _, ty, _)| Ok(ty),
+            |(_, _, ty, _, _)| Ok(ty),
         )?;
         let previous_expected = ctx.expected_type.replace(destination_type);
         let rhs_shared_reads_before = ctx.expression_shared_reads.len();
+        let rhs_exclusive_uses_before = ctx.expression_exclusive_uses.len();
         let value_result = self.analyze_inst(air, value, ctx);
         ctx.expected_type = previous_expected;
         let value_result = value_result?;
@@ -3878,24 +3944,28 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if cached.is_none() {
             ctx.expression_shared_reads
                 .truncate(rhs_shared_reads_before);
+            ctx.expression_exclusive_uses
+                .truncate(rhs_exclusive_uses_before);
         }
-        let (place_ref, root_var, mutable) = if let Some((place_ref, root, _, mutable)) = cached {
-            (place_ref, root, mutable)
-        } else {
-            let trace = self
-                .try_trace_place(place, air, ctx)?
-                .ok_or_else(|| CompileError::new(ErrorKind::InvalidAssignmentTarget, span))?;
-            if !trace.via_accessor || !trace.is_root_mutable {
-                return Err(CompileError::new(ErrorKind::InvalidAssignmentTarget, span));
-            }
-            let root = trace.root_var;
-            self.reject_mutate_iter_borrowed(root, span, ctx)?;
-            (
-                Self::build_place_ref(air, &trace)?,
-                root,
-                trace.is_root_mutable,
-            )
-        };
+        let (place_ref, root_var, mutable, place_continues) =
+            if let Some((place_ref, root, _, mutable, continues)) = cached {
+                (place_ref, root, mutable, continues)
+            } else {
+                let trace = self
+                    .try_trace_place(place, air, ctx)?
+                    .ok_or_else(|| CompileError::new(ErrorKind::InvalidAssignmentTarget, span))?;
+                if !trace.via_accessor || !trace.is_root_mutable {
+                    return Err(CompileError::new(ErrorKind::InvalidAssignmentTarget, span));
+                }
+                let root = trace.root_var;
+                self.reject_mutate_iter_borrowed(root, span, ctx)?;
+                (
+                    Self::build_place_ref(air, &trace)?,
+                    root,
+                    trace.is_root_mutable,
+                    trace.continues,
+                )
+            };
         if !mutable {
             return Err(CompileError::new(ErrorKind::InvalidAssignmentTarget, span));
         }
@@ -3911,10 +3981,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ty: Type::UNIT,
             span,
         });
+        let continues = value_result.continues && place_continues;
+        if continues {
+            self.record_completed_exclusive_use(root_var, span, ctx);
+        }
         Ok(AnalysisResult::with_continues(
             air_ref,
             Type::UNIT,
-            value_result.continues,
+            continues,
         ))
     }
 
@@ -4081,10 +4155,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ty: Type::UNIT,
                 span,
             });
+            let continues = trace.continues && value_result.continues;
+            if continues {
+                self.record_completed_exclusive_use(trace.root_var, span, ctx);
+            }
             return Ok(AnalysisResult::with_continues(
                 air_ref,
                 Type::UNIT,
-                value_result.continues,
+                continues,
             ));
         }
 
@@ -4288,10 +4366,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ty: Type::UNIT,
                 span,
             });
+            let continues = trace.continues && index_result.continues && value_result.continues;
+            if continues {
+                self.record_completed_exclusive_use(trace.root_var, span, ctx);
+            }
             return Ok(AnalysisResult::with_continues(
                 air_ref,
                 Type::UNIT,
-                index_result.continues && value_result.continues,
+                continues,
             ));
         }
 
@@ -4823,6 +4905,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             .entry(trace.root_var)
             .or_default()
             .mark_path_moved(&elem_path, span);
+        if trace.continues {
+            self.record_completed_exclusive_use(trace.root_var, span, ctx);
+        }
         Ok(Some(k))
     }
 
@@ -5128,6 +5213,25 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         Ok(())
     }
 
+    /// Remember an exclusive use after its operation has completed. A
+    /// nested call's live loan frame disappears when that call returns, but
+    /// its exclusive use still conflicts with a later accessor result in the
+    /// enclosing full expression.
+    pub(crate) fn record_completed_exclusive_use(
+        &self,
+        root: Spur,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) {
+        if !ctx
+            .expression_exclusive_uses
+            .iter()
+            .any(|(used_root, _)| *used_root == root)
+        {
+            ctx.expression_exclusive_uses.push((root, span));
+        }
+    }
+
     pub(crate) fn reject_accessor_shared_loan_conflict(
         &self,
         root: Spur,
@@ -5376,6 +5480,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         args: A,
         param_types: &[Type],
         param_modes: &[RirParamMode],
+        call_may_continue: bool,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<CallOperands>
     where
@@ -5452,7 +5557,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // 6.6:16, E0259). Args whose place roots through an accessor chain
         // (`f(inout v.get_mut(i))`) have no plain root variable here and are
         // governed by accessor expansion's own frame check instead.
-        for arg in args {
+        for arg in args.clone() {
             if !arg.is_inout() && !arg.is_borrow() {
                 continue;
             }
@@ -5471,6 +5576,23 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         self.body_rir_ref().get(arg.value).span,
                         ctx,
                     )?;
+                }
+            }
+        }
+        // The exclusive use is complete once this call's argument list has
+        // finished and all same-call accessor checks have succeeded. Retain
+        // it for the enclosing full expression so a later accessor result
+        // still observes the conflict.
+        if result.continues && call_may_continue {
+            for arg in args {
+                if arg.is_inout()
+                    && let Some(root) = self.extract_root_variable(arg.value)
+                {
+                    self.record_completed_exclusive_use(
+                        root,
+                        self.body_rir_ref().get(arg.value).span,
+                        ctx,
+                    );
                 }
             }
         }

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -684,7 +684,7 @@ pub(crate) struct AnalysisContext<'a> {
     /// AIR place handles for accessor calls already materialized in this
     /// expression. Compound assignment reuses the same yielded place rather
     /// than expanding and loaning the accessor a second time.
-    pub accessor_place_refs: AHashMap<InstRef, (crate::inst::AirPlaceRef, Spur, Type, bool)>,
+    pub accessor_place_refs: AHashMap<InstRef, (crate::inst::AirPlaceRef, Spur, Type, bool, bool)>,
     /// Active accessor-result loans for the current full expression
     /// (ADR-0062): each entry is the receiver root, call span, and shared or
     /// exclusive mode of an expanded accessor call. The statement loop
@@ -695,6 +695,10 @@ pub(crate) struct AnalysisContext<'a> {
     /// Ordinary shared reads in the current full expression. An exclusive
     /// accessor result conflicts with these reads in either evaluation order.
     pub expression_shared_reads: Vec<(Spur, Span)>,
+    /// Completed exclusive uses in the current full expression. An accessor
+    /// result conflicts with a prior use of the same root even when that use
+    /// was a nested call whose own loan frame has already ended.
+    pub expression_exclusive_uses: Vec<(Spur, Span)>,
     /// Resolved-type overlays for accessor bodies currently being inlined,
     /// innermost last. `resolved_type_of` consults these before the body's
     /// own `resolved_types`, letting the caller's analysis walk accessor-body
@@ -712,6 +716,59 @@ pub(crate) struct AnalysisContext<'a> {
     /// registry-installed `Option(payload)`. Left `false` everywhere else, where
     /// a contextual enum may validate — but never select — the result identity.
     pub try_operand: bool,
+}
+
+pub(crate) struct FullExpressionBoundary {
+    loans: usize,
+    shared_reads: Vec<(Spur, Span)>,
+    exclusive_uses: Vec<(Spur, Span)>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct ExpressionLedgerCheckpoint {
+    loans: usize,
+    shared_reads: usize,
+    exclusive_uses: usize,
+}
+
+impl AnalysisContext<'_> {
+    /// Snapshot expression-scoped semantic records before a strict operation.
+    /// If that operation does not continue, records created by its operands
+    /// cannot affect later unreachable analysis.
+    pub(crate) fn checkpoint_expression_ledgers(&self) -> ExpressionLedgerCheckpoint {
+        ExpressionLedgerCheckpoint {
+            loans: self.expression_loans.len(),
+            shared_reads: self.expression_shared_reads.len(),
+            exclusive_uses: self.expression_exclusive_uses.len(),
+        }
+    }
+
+    pub(crate) fn rollback_expression_ledgers(&mut self, checkpoint: ExpressionLedgerCheckpoint) {
+        self.expression_loans.truncate(checkpoint.loans);
+        self.expression_shared_reads
+            .truncate(checkpoint.shared_reads);
+        self.expression_exclusive_uses
+            .truncate(checkpoint.exclusive_uses);
+    }
+
+    /// Start a nested full expression. Active loans from the enclosing
+    /// expression remain visible, while completed read/use records are
+    /// isolated until the child finishes.
+    pub(crate) fn enter_full_expression(&mut self) -> FullExpressionBoundary {
+        FullExpressionBoundary {
+            loans: self.expression_loans.len(),
+            shared_reads: std::mem::take(&mut self.expression_shared_reads),
+            exclusive_uses: std::mem::take(&mut self.expression_exclusive_uses),
+        }
+    }
+
+    /// Finish a nested full expression, discarding child loans and restoring
+    /// the enclosing expression's completed read/use records.
+    pub(crate) fn exit_full_expression(&mut self, boundary: FullExpressionBoundary) {
+        self.expression_loans.truncate(boundary.loans);
+        self.expression_shared_reads = boundary.shared_reads;
+        self.expression_exclusive_uses = boundary.exclusive_uses;
+    }
 }
 
 // Import InstRef for use in resolved_types
@@ -941,6 +998,7 @@ impl<'a> AnalysisContext<'a> {
             accessor_place_refs: self.accessor_place_refs.clone(),
             expression_loans: self.expression_loans.clone(),
             expression_shared_reads: self.expression_shared_reads.clone(),
+            expression_exclusive_uses: self.expression_exclusive_uses.clone(),
             inline_resolved_types: self.inline_resolved_types.clone(),
             place_aliases: self.place_aliases.clone(),
             try_operand: false,

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -169,7 +169,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 return match taken_block {
                     Some(block) => {
                         ctx.push_scope();
-                        let result = self.analyze_inst(air, block, ctx)?;
+                        let boundary = ctx.enter_full_expression();
+                        let result = self.analyze_inst(air, block, ctx);
+                        ctx.exit_full_expression(boundary);
+                        let result = result?;
                         ctx.pop_scope();
                         // An `if` without `else` is unit-typed, so its (taken)
                         // then-branch must still be unit (spec 4.6:5).
@@ -209,7 +212,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
 
         // Condition must be bool
-        let cond_result = ctx.with_expected_type(None, |ctx| self.analyze_inst(air, cond, ctx))?;
+        let boundary = ctx.enter_full_expression();
+        let cond_result = ctx.with_expected_type(None, |ctx| self.analyze_inst(air, cond, ctx));
+        ctx.exit_full_expression(boundary);
+        let cond_result = cond_result?;
 
         if let Some(else_b) = else_block {
             // Save move state before entering branches.
@@ -217,7 +223,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
             // Analyze then branch with its own scope
             ctx.push_scope();
-            let then_result = self.analyze_inst(air, then_block, ctx)?;
+            let boundary = ctx.enter_full_expression();
+            let then_result = self.analyze_inst(air, then_block, ctx);
+            ctx.exit_full_expression(boundary);
+            let then_result = then_result?;
             let then_type = then_result.ty;
             let then_continues = then_result.continues;
             let then_span = self.body_rir_ref().get(then_block).span;
@@ -231,7 +240,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
             // Analyze else branch with its own scope
             ctx.push_scope();
-            let else_result = self.analyze_inst(air, else_b, ctx)?;
+            let boundary = ctx.enter_full_expression();
+            let else_result = self.analyze_inst(air, else_b, ctx);
+            ctx.exit_full_expression(boundary);
+            let else_result = else_result?;
             let else_type = else_result.ty;
             let else_continues = else_result.continues;
             let else_span = self.body_rir_ref().get(else_b).span;
@@ -297,7 +309,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let saved_moves = ctx.moved_vars.clone();
 
             ctx.push_scope();
-            let then_result = self.analyze_inst(air, then_block, ctx)?;
+            let boundary = ctx.enter_full_expression();
+            let then_result = self.analyze_inst(air, then_block, ctx);
+            ctx.exit_full_expression(boundary);
+            let then_result = then_result?;
             ctx.pop_scope();
 
             // Check that the then branch has unit type (or Never/Error)
@@ -365,7 +380,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let moves_before_loop = ctx.moved_vars.clone();
 
         // While loop: condition must be bool, result is Unit
-        let cond_result = self.analyze_inst(air, cond, ctx)?;
+        let boundary = ctx.enter_full_expression();
+        let cond_result = self.analyze_inst(air, cond, ctx);
+        ctx.exit_full_expression(boundary);
+        let cond_result = cond_result?;
 
         // Analyze body with its own scope. The loop_break_stack entry makes
         // breaks inside the body target this while loop, not an outer loop;
@@ -373,7 +391,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         ctx.push_scope();
         ctx.loop_depth += 1;
         ctx.loop_break_stack.push(LoopEdgeStates::default());
-        let body_result = self.analyze_inst(air, body, ctx)?;
+        let boundary = ctx.enter_full_expression();
+        let body_result = self.analyze_inst(air, body, ctx);
+        ctx.exit_full_expression(boundary);
+        let body_result = body_result?;
         ctx.loop_depth -= 1;
         // pop_scope replays this scope's RUE-522 restoration onto the
         // break-site snapshots still on the stack, so the record popped
@@ -422,11 +443,17 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             scratch_ctx.moved_vars = backedge_moves;
             let recovered_before = self.body_analysis_recovered_errors_mut().len();
             let result = (|| -> CompileResult<()> {
-                self.analyze_inst(air, cond, &mut scratch_ctx)?;
+                let boundary = scratch_ctx.enter_full_expression();
+                let result = self.analyze_inst(air, cond, &mut scratch_ctx);
+                scratch_ctx.exit_full_expression(boundary);
+                result?;
                 scratch_ctx.push_scope();
                 scratch_ctx.loop_depth += 1;
                 scratch_ctx.loop_break_stack.push(LoopEdgeStates::default());
-                self.analyze_inst(air, body, &mut scratch_ctx)?;
+                let boundary = scratch_ctx.enter_full_expression();
+                let result = self.analyze_inst(air, body, &mut scratch_ctx);
+                scratch_ctx.exit_full_expression(boundary);
+                result?;
                 scratch_ctx.loop_break_stack.pop();
                 scratch_ctx.loop_depth -= 1;
                 scratch_ctx.pop_scope();
@@ -482,7 +509,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if let Some(var) = iter_borrow {
             ctx.iter_borrows.push(var);
         }
-        let body_result = self.analyze_inst(air, body, ctx)?;
+        let boundary = ctx.enter_full_expression();
+        let body_result = self.analyze_inst(air, body, ctx);
+        ctx.exit_full_expression(boundary);
+        let body_result = body_result?;
         if iter_borrow.is_some() {
             ctx.iter_borrows.pop();
         }
@@ -534,7 +564,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             if let Some(var) = iter_borrow {
                 scratch_ctx.iter_borrows.push(var);
             }
+            let boundary = scratch_ctx.enter_full_expression();
             let result = self.analyze_inst(air, body, &mut scratch_ctx);
+            scratch_ctx.exit_full_expression(boundary);
             air.rollback(checkpoint);
             for error in &mut self.body_analysis_recovered_errors_mut()[recovered_before..] {
                 *error = error
@@ -874,7 +906,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     self.warn_unreachable_pruned_arms(arms.iter().cloned(), scrutinee_type, ctx);
                     if let Some(body) = selected {
                         ctx.push_scope();
-                        let result = self.analyze_inst(air, body, ctx)?;
+                        let boundary = ctx.enter_full_expression();
+                        let result = self.analyze_inst(air, body, ctx);
+                        ctx.exit_full_expression(boundary);
+                        let result = result?;
                         ctx.pop_scope();
                         return Ok(result);
                     }
@@ -905,9 +940,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         });
         // Analyze the scrutinee under only the pattern-derived contract. The
         // match expression's own result expectation belongs to its arms.
+        let boundary = ctx.enter_full_expression();
         let scrutinee_result = ctx.with_expected_type(expected_scrutinee, |ctx| {
             self.analyze_inst(air, scrutinee, ctx)
-        })?;
+        });
+        ctx.exit_full_expression(boundary);
+        let scrutinee_result = scrutinee_result?;
         let scrutinee_type = scrutinee_result.ty;
 
         // Validate that we can match on this type (integers, booleans, and enums)
@@ -1239,7 +1277,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             }
 
             // Analyze arm body
-            let body_result = self.analyze_inst(air, *body, ctx)?;
+            let boundary = ctx.enter_full_expression();
+            let body_result = self.analyze_inst(air, *body, ctx);
+            ctx.exit_full_expression(boundary);
+            let body_result = body_result?;
             let body_type = body_result.ty;
 
             // Payload bindings are ordinary locals living in the ARM scope,
@@ -2238,7 +2279,6 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     ) -> CompileResult<AnalysisResult> {
         // Get the instruction refs from extra data
         let inst_refs = self.body_rir_ref().block_insts(instructions).to_vec();
-
         // Push a new scope for this block.
         ctx.push_scope();
 
@@ -2257,23 +2297,19 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let recovery_checkpoint = self
                 .body_analysis_error_recovery()
                 .then(|| (air.checkpoint(), ctx.clone()));
-            // Each non-tail statement is a full expression: accessor-result
-            // loans taken inside it (ADR-0062) end when it does. Loans taken
-            // by an *enclosing* statement (this block nested inside an
-            // expression) stay live across it, so this truncates rather than
-            // clears. The tail expression's loans are part of the enclosing
-            // full expression and survive the block.
-            let expression_loans_before = ctx.expression_loans.len();
-            let expression_shared_reads_before = ctx.expression_shared_reads.len();
+            // Each non-tail statement is a nested full expression. Enclosing
+            // accessor loans remain active through it, but completed reads and
+            // exclusive uses belong to the enclosing expression and must not
+            // enter the child. The tail expression remains part of the
+            // enclosing full expression and therefore needs no boundary.
+            let boundary = (!is_last).then(|| ctx.enter_full_expression());
             let outcome = if is_last {
                 self.analyze_inst(air, inst_ref, ctx)
             } else {
                 ctx.with_expected_type(None, |ctx| self.analyze_inst(air, inst_ref, ctx))
             };
-            if !is_last {
-                ctx.expression_loans.truncate(expression_loans_before);
-                ctx.expression_shared_reads
-                    .truncate(expression_shared_reads_before);
+            if let Some(boundary) = boundary {
+                ctx.exit_full_expression(boundary);
             }
             let result = match outcome {
                 Ok(result) => result,
@@ -2348,7 +2384,6 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // state is restored first so this frame removes dead locals and
         // restores any shadowed outer bindings normally.
         ctx.pop_scope();
-
         // Handle empty blocks - they evaluate to Unit
         let last = match last_result {
             Some(result) => result,

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -2145,6 +2145,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             accessor_place_refs: AHashMap::new(),
             expression_loans: Vec::new(),
             expression_shared_reads: Vec::new(),
+            expression_exclusive_uses: Vec::new(),
             inline_resolved_types: Vec::new(),
             place_aliases: AHashMap::new(),
             try_operand: false,

--- a/crates/rue-spec/cases/items/borrow-accessors.toml
+++ b/crates/rue-spec/cases/items/borrow-accessors.toml
@@ -867,6 +867,32 @@ compile_fail = true
 error_contains = ["E0259", "while an accessor result borrows it"]
 
 [[case]]
+name = "accessor_loan_conflicts_with_completed_nested_inout"
+spec = ["6.6:10", "6.6:16"]
+description = "A completed nested exclusive use still conflicts with a later accessor result in the same full expression (E0259)."
+source = """
+struct P {
+    value: i64,
+
+    fn f(borrow self) -> borrow i64 {
+        yield self.value;
+    }
+}
+fn g(inout p: P) -> i64 {
+    p.value = p.value + 1;
+    0
+}
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let mut p = P { value: 2 };
+    use_two(g(inout p), p.f());
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0259", "accessor result"]
+
+[[case]]
 name = "accessor_loan_conflicts_with_direct_sibling_inout"
 spec = ["6.6:10"]
 description = "A direct `inout` argument of the very call consuming the accessor result is an exclusive use of the borrowed root (E0259, RUE-1593)."
@@ -890,6 +916,451 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = ["E0259", "as `inout` while an accessor result borrows it"]
+
+[[case]]
+name = "completed_nested_inout_does_not_escape_full_expression"
+spec = ["6.6:8", "6.6:10"]
+description = "A completed nested exclusive use does not keep its loan beyond its full expression, so a later accessor call is legal."
+source = """
+struct P {
+    value: i64,
+
+    fn f(borrow self) -> borrow i64 {
+        yield self.value;
+    }
+}
+fn g(inout p: P) -> i64 {
+    p.value = p.value + 1;
+    0
+}
+fn main() -> i32 {
+    let mut p = P { value: 2 };
+    g(inout p);
+    if p.f() == 3 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "completed_nested_inout_condition_does_not_reach_body"
+spec = ["6.6:8", "6.6:10"]
+description = "A condition's completed exclusive use does not leak into the separate full expression of its body."
+source = """
+struct P {
+    value: i64,
+
+    fn f(borrow self) -> borrow i64 { yield self.value; }
+}
+fn g(inout p: P) -> i64 { p.value = p.value + 1; 0 }
+fn main() -> i32 {
+    let mut p = P { value: 2 };
+    if g(inout p) == 0 {
+        if p.f() == 99 { @panic(\"unexpected\"); }
+    }
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "completed_nested_inout_branch_arms_are_separate"
+spec = ["6.6:8", "6.6:10"]
+description = "Completed exclusive uses in sibling branch arms do not leak between their full expressions."
+source = """
+struct P {
+    value: i64,
+
+    fn f(borrow self) -> borrow i64 { yield self.value; }
+}
+fn g(inout p: P) -> i64 { p.value = p.value + 1; 0 }
+fn main() -> i32 {
+    let mut p = P { value: 2 };
+    if true {
+        g(inout p);
+    } else {
+        if p.f() == 99 { @panic(\"unexpected\"); }
+    }
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "completed_nested_inout_loop_condition_does_not_reach_body"
+spec = ["6.6:8", "6.6:10"]
+description = "A while condition's completed exclusive use does not leak into the loop body full expression."
+source = """
+struct P {
+    value: i64,
+
+    fn f(borrow self) -> borrow i64 { yield self.value; }
+}
+fn pred(inout p: P) -> bool { p.value = p.value + 1; false }
+fn main() -> i32 {
+    let mut p = P { value: 2 };
+    while pred(inout p) {
+        if p.f() == 99 { @panic(\"unexpected\"); }
+    }
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "accessor_loan_in_if_arm_does_not_reach_outer_inout"
+spec = ["6.6:8", "6.6:10"]
+description = "An accessor loan in an if arm ends at that arm's full-expression boundary before an outer inout use."
+source = """
+struct P {
+    value: i64,
+
+    fn f(borrow self) -> borrow i64 { yield self.value; }
+}
+fn g(inout p: P) -> i64 { p.value = p.value + 1; 0 }
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let mut p = P { value: 2 };
+    use_two(if true { if p.f() == 2 { 0 } else { 1 } } else { 0 }, g(inout p));
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "shared_read_in_if_arm_does_not_reach_outer_accessor"
+spec = ["6.6:8", "6.6:16"]
+description = "A shared read in an if arm ends at that arm's full-expression boundary before an outer exclusive accessor."
+source = """
+struct V {
+    cells: [i64; 2],
+
+    fn get_mut(inout self, i: u64) -> inout i64 { yield self.cells[i]; }
+}
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let mut v = V { cells: [1, 2] };
+    use_two(if true { v.cells[1] } else { 0 }, v.get_mut(0));
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "enclosing_accessor_loan_conflicts_inside_if_arm"
+spec = ["6.6:16"]
+description = "An active enclosing accessor loan remains visible while an if arm is analyzed."
+source = """
+struct V {
+    cells: [i64; 2],
+
+    fn get_ref(borrow self, i: u64) -> borrow i64 { yield self.cells[i]; }
+    fn get_mut(inout self, i: u64) -> inout i64 { yield self.cells[i]; }
+}
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let mut v = V { cells: [1, 2] };
+    use_two(v.get_ref(0), if true { if v.get_mut(1) == 2 { 0 } else { 1 } } else { 0 });
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0259", "accessor"]
+
+[[case]]
+name = "completed_nested_inout_match_scrutinee_does_not_reach_arm"
+spec = ["6.6:8", "6.6:10"]
+description = "A match scrutinee's completed exclusive use does not leak into an arm full expression."
+source = """
+struct P {
+    value: i64,
+
+    fn f(borrow self) -> borrow i64 { yield self.value; }
+}
+fn g(inout p: P) -> i64 { p.value = p.value + 1; 0 }
+fn main() -> i32 {
+    let mut p = P { value: 2 };
+    match g(inout p) {
+        0 => { if p.f() == 99 { @panic(\"unexpected\"); } },
+        _ => {},
+    }
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "accessor_loan_conflicts_with_projected_nested_inout"
+spec = ["6.6:10", "6.6:16"]
+description = "A completed nested inout of a projection records its canonical root for a later accessor result."
+source = """
+struct P {
+    value: i64,
+
+    fn f(borrow self) -> borrow i64 { yield self.value; }
+}
+fn bump(inout value: i64) -> i64 { value = value + 1; value }
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let mut p = P { value: 2 };
+    use_two(bump(inout p.value), p.f());
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0259", "accessor result"]
+
+[[case]]
+name = "accessor_loan_conflicts_with_projected_inout_self"
+spec = ["6.6:10", "6.6:16"]
+description = "A completed nested inout-self call on a projection records its canonical root for a later accessor result."
+source = """
+struct Inner {
+    value: i64,
+
+    fn bump(inout self) -> i64 { self.value = self.value + 1; self.value }
+}
+struct P {
+    inner: Inner,
+    value: i64,
+
+    fn f(borrow self) -> borrow i64 { yield self.value; }
+}
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let mut p = P { inner: Inner { value: 2 }, value: 3 };
+    use_two(p.inner.bump(), p.f());
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0259", "accessor result"]
+
+[[case]]
+name = "accessor_loan_conflicts_with_completed_move"
+spec = ["6.6:10"]
+description = "A completed nested move remains exclusive for a later accessor result in the same full expression."
+source = """
+linear struct P {
+    value: i64,
+
+    fn f(borrow self) -> borrow i64 { yield self.value; }
+}
+fn take(p: P) -> i64 { p.value }
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let p = P { value: 2 };
+    use_two(take(p), p.f());
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0259", "accessor result"]
+
+[[case]]
+name = "completed_nested_assignment_does_not_escape_discarded_statement"
+spec = ["6.6:8", "6.6:10"]
+description = "An assignment in a discarded nested-block statement does not keep an exclusive use in the enclosing full expression."
+source = """
+struct P {
+    value: i64,
+
+    fn f(borrow self) -> borrow i64 { yield self.value; }
+}
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let mut p = P { value: 2 };
+    use_two({ p.value = 3; 0 }, p.f());
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "completed_nested_inout_does_not_escape_discarded_statement"
+spec = ["6.6:8", "6.6:10"]
+description = "A nested inout in a discarded statement does not keep an exclusive use in the enclosing full expression."
+source = """
+struct P {
+    value: i64,
+
+    fn f(borrow self) -> borrow i64 { yield self.value; }
+}
+fn g(inout p: P) -> i64 { p.value = p.value + 1; 0 }
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let mut p = P { value: 2 };
+    use_two({ g(inout p); 0 }, p.f());
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "completed_nested_inout_tail_reaches_enclosing_expression"
+spec = ["6.6:10", "6.6:16"]
+description = "A nested block tail belongs to the enclosing full expression and conflicts with a later accessor result."
+source = """
+struct P {
+    value: i64,
+
+    fn f(borrow self) -> borrow i64 { yield self.value; }
+}
+fn g(inout p: P) -> i64 { p.value = p.value + 1; 0 }
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let mut p = P { value: 2 };
+    use_two({ 0; g(inout p) }, p.f());
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0259", "accessor result"]
+
+[[case]]
+name = "outer_completed_inout_does_not_enter_discarded_nested_statement"
+spec = ["6.6:8", "6.6:10"]
+description = "An enclosing completed use does not enter a discarded nested-block statement's full expression."
+source = """
+struct P {
+    value: i64,
+
+    fn f(borrow self) -> borrow i64 { yield self.value; }
+}
+fn g(inout p: P) -> i64 { p.value = p.value + 1; 0 }
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let mut p = P { value: 2 };
+    use_two(g(inout p), { p.f(); 0 });
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "diverging_inout_operand_does_not_complete_exclusive_use"
+spec = ["6.6:10"]
+description = "An inout call whose later operand diverges never completes, so it creates no completed-use record."
+source = """
+struct P {
+    value: i64,
+
+    fn f(borrow self) -> borrow i64 { yield self.value; }
+}
+fn g(inout p: P, x: i64) -> i64 { p.value = p.value + x; 0 }
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let mut p = P { value: 2 };
+    use_two(g(inout p, @panic(\"stop\")), p.f());
+    0
+}
+"""
+compile_only = true
+
+[[case]]
+name = "never_returning_inout_call_does_not_complete_exclusive_use"
+spec = ["6.6:10"]
+description = "A never-returning inout call does not complete its exclusive use before unreachable later operands."
+source = """
+struct P {
+    value: i64,
+
+    fn f(borrow self) -> borrow i64 { yield self.value; }
+}
+fn stop(inout p: P) -> ! { p.value = p.value + 1; @panic(\"stop\") }
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let mut p = P { value: 2 };
+    use_two(stop(inout p), p.f());
+    0
+}
+"""
+compile_only = true
+
+[[case]]
+name = "diverging_inout_self_call_does_not_complete_exclusive_use"
+spec = ["6.6:10"]
+description = "An inout-self call with a diverging operand never completes its exclusive use."
+source = """
+struct P {
+    value: i64,
+
+    fn f(borrow self) -> borrow i64 { yield self.value; }
+    fn set(inout self, value: i64) -> i64 { self.value = value; value }
+}
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let mut p = P { value: 2 };
+    use_two(p.set(@panic(\"stop\")), p.f());
+    0
+}
+"""
+compile_only = true
+
+[[case]]
+name = "diverging_projected_inout_self_does_not_complete_exclusive_use"
+spec = ["6.6:10"]
+description = "An inout-self call whose projected receiver diverges never completes its exclusive use."
+source = """
+struct Cell {
+    value: i64,
+
+    fn bump(inout self) -> i64 { self.value = self.value + 1; self.value }
+}
+struct P {
+    cells: [Cell; 1],
+    value: i64,
+
+    fn f(borrow self) -> borrow i64 { yield self.value; }
+}
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let mut p = P { cells: [Cell { value: 1 }], value: 2 };
+    use_two(p.cells[if @panic("stop") { 0 } else { 0 }].bump(), p.f());
+    0
+}
+"""
+compile_only = true
+
+[[case]]
+name = "diverging_call_rolls_back_operand_accessor_loan"
+spec = ["6.6:10"]
+description = "An accessor loan from an operand of a diverging call does not reach later unreachable siblings."
+source = """
+struct P {
+    value: i64,
+
+    fn f(borrow self) -> borrow i64 { yield self.value; }
+}
+fn g(inout p: P) -> i64 { p.value = p.value + 1; 0 }
+fn outer(a: i64, b: i64) -> i64 { a + b }
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let mut p = P { value: 2 };
+    use_two(outer(p.f(), @panic("stop")), g(inout p));
+    0
+}
+"""
+compile_only = true
+
+[[case]]
+name = "diverging_accessor_guard_does_not_create_result_loan"
+spec = ["6.6:10"]
+description = "A diverging accessor guard prevents the result loan and its completed-use conflict from arising."
+source = """
+struct P {
+    value: i64,
+
+    fn f(borrow self, guard: i64) -> borrow i64 { yield self.value; }
+}
+fn g(inout p: P) -> i64 { p.value = p.value + 1; 0 }
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let mut p = P { value: 2 };
+    use_two(g(inout p), p.f(@panic("stop")));
+    0
+}
+"""
+compile_only = true
 
 [[case]]
 name = "accessor_loan_conflicts_with_direct_sibling_inout_reversed"


### PR DESCRIPTION
## Summary

- retain exclusive-use records for the enclosing full expression
- isolate and roll back expression-scoped borrow records at semantic boundaries and divergence
- add focused accessor exclusivity regressions

## Validation

- scripts/rue fmt
- scripts/rue spec borrow-accessors
- scripts/rue quick
- scripts/rue premerge
- scripts/rue test

Fixes RUE-1609