### PR TITLE
RUE-1627: derive the codegen key digest once

### DIFF
--- a/crates/rue-compiler/src/codegen_query.rs
+++ b/crates/rue-compiler/src/codegen_query.rs
@@ -72,6 +72,22 @@ pub(crate) struct CodegenUnitQueryKey {
     #[cfg(test)]
     inject_failure: bool,
     memo_hash: u64,
+    /// The ADR-0074 digest of this key's own fields, derived once at
+    /// construction.
+    ///
+    /// `stable_hash` is called several times per unit — by the codegen family
+    /// itself, by `CodegenUnitBatchKey`, and by every `ObjectProjectionQueryKey`
+    /// that wraps this one — and each call used to re-walk the recursive
+    /// `FunctionInstanceKey` beneath it, at roughly 44,000 instructions
+    /// against about 500 for a flat key. Deriving the digest once and
+    /// absorbing those sixteen bytes keeps equal keys equal-digested while
+    /// walking the tree a single time.
+    ///
+    /// This is a deliberately coarse digest in the sense `QueryKey` permits:
+    /// two keys sharing it are separated by typed `Eq`, exactly as the
+    /// retained semantic versions of one function already share
+    /// `CfgQueryKey`'s digest.
+    stable_digest: rue_query::StableKeyHash,
     /// Formatted on the first diagnostic, cycle render, or abort that asks
     /// what this node is *called* (ADR-0074). Ordinary compilation never
     /// reads it: eagerly formatting `{function:?}` here walked the whole
@@ -124,6 +140,24 @@ impl CodegenUnitQueryKey {
         let memo_hash = hasher.finish();
         let data_model = target.data_model();
         let code_model = CodeModel::for_target(target);
+        let mut digest = rue_query::StableHasher::new();
+        function.hash(&mut digest);
+        target.hash(&mut digest);
+        data_model.hash(&mut digest);
+        code_model.hash(&mut digest);
+        std::mem::discriminant(&optimization).hash(&mut digest);
+        BACKEND_EPOCH.hash(&mut digest);
+        ABI_LAYOUT_EPOCH.hash(&mut digest);
+        request.lowering.hash(&mut digest);
+        request.mir.hash(&mut digest);
+        request.liveness.hash(&mut digest);
+        request.regalloc.hash(&mut digest);
+        request.asm.hash(&mut digest);
+        optimized_cfg.stable_hash(&mut digest);
+        optimized_cfg_batch.hash(&mut digest);
+        #[cfg(test)]
+        inject_failure.hash(&mut digest);
+        let stable_digest = digest.finish128();
         Self {
             function,
             target,
@@ -138,6 +172,7 @@ impl CodegenUnitQueryKey {
             #[cfg(test)]
             inject_failure,
             memo_hash,
+            stable_digest,
             display_identity: OnceLock::new(),
         }
     }
@@ -196,24 +231,12 @@ impl QueryKey for CodegenUnitQueryKey {
             .clone()
     }
 
-    /// The same field set `memo_hash` covers, absorbed structurally.
+    /// The digest derived once at construction, over the field set documented
+    /// on `stable_digest`.
     fn stable_hash(&self, hasher: &mut rue_query::StableHasher) {
-        self.function.hash(hasher);
-        self.target.hash(hasher);
-        self.data_model.hash(hasher);
-        self.code_model.hash(hasher);
-        std::mem::discriminant(&self.optimization).hash(hasher);
-        self.backend_epoch.hash(hasher);
-        self.abi_layout_epoch.hash(hasher);
-        self.request.lowering.hash(hasher);
-        self.request.mir.hash(hasher);
-        self.request.liveness.hash(hasher);
-        self.request.regalloc.hash(hasher);
-        self.request.asm.hash(hasher);
-        self.optimized_cfg.stable_hash(hasher);
-        self.optimized_cfg_batch.hash(hasher);
-        #[cfg(test)]
-        self.inject_failure.hash(hasher);
+        let digest = self.stable_digest.to_u128();
+        hasher.write_u64(digest as u64);
+        hasher.write_u64((digest >> 64) as u64);
     }
 }
 


### PR DESCRIPTION
Implements RUE-1627. Third in the series after RUE-1617 (#2564) and RUE-1625 (#2568).

## The finding

`CodegenUnitQueryKey::stable_hash` cost **44,455 instructions per call**, against roughly 500 for every flat query key in the compiler — a ninety-fold gap, and the single largest identifiable item in a fresh `-O3 -j1` Lattice profile.

The digest is structural, so each call re-walked the recursive `FunctionInstanceKey` beneath the key — `Specialization { base: Box<FunctionInstanceKey>, arguments: { types: Arc<[TypeInstanceKey]>, … } }` — down to every leaf.

The walk also happened several times per unit. `stable_hash` ran **6,400 times for 1,280 codegen units**: once for the codegen family itself, once per `CodegenUnitBatchKey`, and once for each of the 3,840 `ObjectProjectionQueryKey`s that wrap a codegen key and re-walked the same tree through it. That wrapper measured 44,620 instructions per call for the same reason.

## The change

The key derives its 128-bit digest once in `new_with_batch`, over exactly the field set `stable_hash` absorbed, and `stable_hash` absorbs those sixteen bytes.

## Why this is sound

This is a deliberately coarse digest in the sense `QueryKey` already documents:

> Equal keys must produce equal digests, so an implementation may absorb a strict subset of the fields `Eq` compares — a deliberately coarse digest costs a cold collision tiebreak, never correctness.

Equal keys still produce equal digests, and typed `Eq` stays authoritative for memo lookup. `CfgQueryKey` already relies on the same latitude — its `stable_hash` deliberately omits `semantic_input`, so "the retained semantic versions of one function deliberately share a digest".

The witness is unaffected in any way that matters. `stable_key_witness` feeds only `NodeIdentity::collision_cmp`, the cold tiebreak reached when two identities of one family share a digest — and keys that share a digest already share a witness today, by the same `CfgQueryKey` precedent.

## Result

Per call, fresh `-O3 -j1` Lattice build:

| | before | after |
| --- | ---: | ---: |
| `CodegenUnitQueryKey::stable_hash` | 44,455 | **91** |
| `ObjectProjectionQueryKey::stable_hash` | 44,620 | **256** |

Across both: 455M instructions down to 1.5M.

End to end: **8,919,235,165 → 8,689,251,726 retired instructions (−2.58%)**, emitted executable byte-identical (`cmp`-verified). Every query key in the compiler now digests in the 91–750 instruction band.

Cumulative across the three changes: **9,486,324,770 → 8,689,251,726, or −8.40%.**

## What this does not do

It leaves the recursive identity trees themselves alone. `Eq`, `Ord`, and `Clone` still walk them, so `StableDefinitionKey::cmp` (2.7% of the profile), `FunctionInstanceKey::cmp` (1.6%), and the surrounding clone and allocation traffic remain proportional to tree depth. RUE-1630 scopes interning those identities behind handles, with the ordering-determinism, `'static`, and session-scope constraints written up.

## Validation

- `scripts/rue premerge` — 196 pass, 0 fail
- `scripts/rue fmt` applied
- Emitted Lattice executable byte-identical against the pre-change compiler