### PR TITLE
Enforce linear must-consume at every exit edge

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -244,9 +244,9 @@ pub(crate) fn linear_not_consumed_error(
         )
         .with_label("consumed here, but not on every path", consumed_span)
         .with_help(
-            "a linear value must be consumed on every path; \
-             consume it in the other branches too (paths that diverge, \
-             e.g. by returning, are exempt)",
+            "a linear value must be consumed on every path; consume it in \
+             the other branches too (a branch that exits early — `return`, \
+             `?`, `break`, `continue` — must consume it before the exit)",
         ),
         None => CompileError::new(
             ErrorKind::LinearValueNotConsumed(name.to_string()),

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -5,11 +5,12 @@
 //! them. It extends the canonical body-analysis engine rather than
 //! introducing peer analysis state.
 
-use super::super::context::{LocalVar, VariableMoveState};
+use super::super::context::{LocalVar, ParamInfo, VariableMoveState};
 use super::super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
 use super::*;
 use crate::inst::AirPlaceRef;
 use crate::scope::ScopedContext;
+use ahash::AHashMap;
 
 /// The position into which a value is being placed when the ADR-0043 two-types
 /// string model (RUE-386) requires a *first-class* `str`: a bare `str`
@@ -4471,50 +4472,204 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let Some(local) = ctx.locals.get(symbol) else {
                 continue;
             };
-
-            // Only check types that require consumption: linear structs
-            // themselves, and non-empty arrays whose elements carry one (an
-            // array of linear values must be consumed — as a whole, or
-            // element-wise via constant-index moves (RUE-186); dropping it
-            // would silently drop every element).
-            if !self.type_requires_consumption(local.ty) {
-                continue;
-            }
-
-            // Consumption must hold on EVERY path (must-consume).
-            // `full_move` alone is may-move (union at branch joins): a value
-            // consumed in only one branch of an if/match still leaks on the
-            // other paths.
             let state = ctx.moved_vars.get(symbol);
-            if state.is_some_and(|s| s.full_move_on_all_paths) {
-                continue;
+            self.check_linear_binding_consumed(*symbol, local, state)?;
+        }
+
+        Ok(())
+    }
+
+    /// The must-consume obligation for one binding against one move state —
+    /// the shared kernel of the scope-exit walk above and the early-exit edge
+    /// walk below ([`Self::check_linear_values_at_exit_edge`]).
+    ///
+    /// Consumption must hold on EVERY path (must-consume): `full_move` alone
+    /// is may-move (union at branch joins), so a value consumed in only one
+    /// branch of an if/match still leaks on the other paths. Only types that
+    /// require consumption are checked: linear structs themselves, and
+    /// non-empty arrays whose elements carry one (an array of linear values
+    /// must be consumed — as a whole, or element-wise via constant-index
+    /// moves (RUE-186); dropping it would silently drop every element).
+    fn check_linear_binding_consumed(
+        &self,
+        symbol: Spur,
+        local: &LocalVar,
+        state: Option<&VariableMoveState>,
+    ) -> CompileResult<()> {
+        if !self.type_requires_consumption(local.ty) {
+            return Ok(());
+        }
+        if state.is_some_and(|s| s.full_move_on_all_paths) {
+            return Ok(());
+        }
+
+        // Element-wise consumption of a linear array (RUE-186, spec
+        // 3.8:71): moving every element out (constant indices) on every
+        // path satisfies the array's must-consume obligation. Partial
+        // element consumption is an error naming the missing elements.
+        match self.check_array_elementwise_consumption(local.ty, state, symbol, local.span)? {
+            ElementwiseConsumption::Complete => return Ok(()),
+            ElementwiseConsumption::NotElementwise => {}
+        }
+
+        // Per-place residue (core §5.6, spec 3.8:60, RUE-1591): consuming
+        // exactly the linear sub-places of an infectious carrier
+        // discharges its obligation, and the non-linear residue is left
+        // for the ordinary scope-exit drop walk.
+        let Some(residue) = self.residual_linear_place(local.ty, state, &mut Vec::new()) else {
+            return Ok(());
+        };
+
+        let name = self.body_interner().resolve(&symbol);
+        let err = linear_not_consumed_error(
+            name,
+            local.span,
+            Self::residue_consumed_on_some_path(state, &residue),
+        );
+        let err = self.note_residual_linear_place(err, symbol, &residue);
+        Err(self.attach_infectious_linear_note(err, local.ty))
+    }
+
+    /// The must-consume obligation for one by-value parameter against one
+    /// move state (spec 3.8:62, RUE-61): the callee owns its pass-by-value
+    /// parameters and drops them at exit unless moved out, so a by-value
+    /// parameter carrying a linear value must be consumed on every path —
+    /// exactly like a linear local. `inout`/`borrow` parameters stay owned by
+    /// the caller and comptime parameters are substituted away, so both are
+    /// exempt here; the destructor exemption for `self` (3.8:62) is the
+    /// caller's to apply, since it is a property of the body, not of the
+    /// parameter.
+    ///
+    /// Shared by the end-of-body check in `analyze_function_internal` (the
+    /// fall-through exit) and the early-exit edge walk below (RUE-1614), so
+    /// both exits enforce one rule with one diagnostic shape.
+    pub(crate) fn check_linear_param_consumed(
+        &self,
+        param: &ParamInfo,
+        state: Option<&VariableMoveState>,
+        span: Span,
+    ) -> CompileResult<()> {
+        if param.mode != RirParamMode::Normal || param.is_comptime {
+            return Ok(());
+        }
+        if !self.type_requires_consumption(param.ty) {
+            return Ok(());
+        }
+        if state.is_some_and(|s| s.full_move_on_all_paths) {
+            return Ok(());
+        }
+        // Element-wise consumption of a linear array parameter (RUE-186)
+        // satisfies the obligation like a whole move.
+        match self.check_array_elementwise_consumption(param.ty, state, param.name, span)? {
+            ElementwiseConsumption::Complete => return Ok(()),
+            ElementwiseConsumption::NotElementwise => {}
+        }
+        // Per-place residue (core §5.6, RUE-1591): a by-value parameter of an
+        // infectious carrier is consumed by consuming its linear sub-places;
+        // the rest is dropped by the ordinary exit walk, exactly as for a
+        // local.
+        let Some(residue) = self.residual_linear_place(param.ty, state, &mut Vec::new()) else {
+            return Ok(());
+        };
+        let name = self.body_interner().resolve(&param.name);
+        let err = linear_not_consumed_error(
+            name,
+            span,
+            Self::residue_consumed_on_some_path(state, &residue),
+        )
+        .with_note(format!(
+            "parameter '{name}' is passed by value, so this function owns it \
+             and must consume it (pass it on, return it, or destructure it)"
+        ));
+        let err = self.note_residual_linear_place(err, param.name, &residue);
+        Err(self.attach_infectious_linear_note(err, param.ty))
+    }
+
+    /// RUE-1614: enforce the linear must-consume obligation at an early-exit
+    /// EDGE — a `return`, the `?` operator's failure path, a `break`, or a
+    /// `continue` — against the move state in force AT that edge.
+    ///
+    /// The scope-exit walk above runs over the state at each block's
+    /// fall-through exit. After a *conditional* early exit the enclosing
+    /// branch joins carry only the non-diverging continuation (diverging arms
+    /// are excluded from the join), so the edge's own state is never observed
+    /// by any scope-exit check — a linear value live only across the edge
+    /// escaped into the exit's unwind drops and was destroyed unconsumed.
+    /// (A *straight-line* early exit is caught without this walk: the
+    /// enclosing block's divergence snapshot re-runs the scope-exit check on
+    /// the state at the divergence.)
+    ///
+    /// The walk visits every binding introduced by the scope frames the edge
+    /// unwinds — `ctx.scope_stack[first_unwound_frame..]` — innermost frame
+    /// first, entries in declaration order within a frame (matching the
+    /// scope-exit walk's report order). Because `locals`/`moved_vars` are
+    /// keyed by NAME (RUE-522), a frame entry's saved shadow value is
+    /// virtually restored as the walk unwinds past it, exactly as `pop_scope`
+    /// would, so shadowed outer bindings are checked with their OWN state,
+    /// and a comptime alias that merely hides a local restores the hidden
+    /// binding for the outer frames' checks.
+    ///
+    /// `function_exit` additionally checks the by-value parameters (spec
+    /// 3.8:62) — a `return` or `?` unwinds them too — unless the body is a
+    /// destructor, whose `self` is disposed of by the drop glue (3.8:62).
+    /// `break`/`continue` pass `false`: bindings outside the loop stay live
+    /// and may still be consumed after it.
+    pub(crate) fn check_linear_values_at_exit_edge(
+        &self,
+        ctx: &AnalysisContext,
+        first_unwound_frame: usize,
+        function_exit: bool,
+    ) -> CompileResult<()> {
+        // The virtually-unwound view: a symbol present here has had its
+        // innermost binding(s) unwound, and maps to the shadowed binding (or
+        // absence) that pop_scope would restore.
+        let mut unwound_locals: AHashMap<Spur, Option<&LocalVar>> = AHashMap::new();
+        let mut unwound_moves: AHashMap<Spur, Option<&VariableMoveState>> = AHashMap::new();
+
+        for frame_idx in (first_unwound_frame..ctx.scope_stack.len()).rev() {
+            let frame = &ctx.scope_stack[frame_idx];
+            // Pushed pairwise with `frame` by `insert_local` and
+            // `bind_comptime_type_var`, so `move_frame[k]` below is the same
+            // binding as `frame[k]` (a desync would index out of bounds).
+            let move_frame = &ctx.moved_scope_stack[frame_idx];
+
+            // Resolve the binding each entry introduced (reverse order, so a
+            // later same-name entry's saved shadow value feeds the earlier
+            // entry), then check in declaration order.
+            let mut resolved: Vec<(Spur, Option<&LocalVar>, Option<&VariableMoveState>)> =
+                Vec::with_capacity(frame.len());
+            for (k, (symbol, old_local)) in frame.iter().enumerate().rev() {
+                let local = match unwound_locals.get(symbol) {
+                    Some(saved) => *saved,
+                    None => ctx.locals.get(symbol),
+                };
+                let state = match unwound_moves.get(symbol) {
+                    Some(saved) => *saved,
+                    None => ctx.moved_vars.get(symbol),
+                };
+                resolved.push((*symbol, local, state));
+                unwound_locals.insert(*symbol, old_local.as_ref());
+                unwound_moves.insert(*symbol, move_frame[k].1.as_ref());
             }
-
-            // Element-wise consumption of a linear array (RUE-186, spec
-            // 3.8:71): moving every element out (constant indices) on every
-            // path satisfies the array's must-consume obligation. Partial
-            // element consumption is an error naming the missing elements.
-            match self.check_array_elementwise_consumption(local.ty, state, *symbol, local.span)? {
-                ElementwiseConsumption::Complete => continue,
-                ElementwiseConsumption::NotElementwise => {}
+            for (symbol, local, state) in resolved.into_iter().rev() {
+                // An entry can name a non-local binding (a comptime type
+                // alias hiding a local pushes one); it introduces no value.
+                let Some(local) = local else { continue };
+                self.check_linear_binding_consumed(symbol, local, state)?;
             }
+        }
 
-            // Per-place residue (core §5.6, spec 3.8:60, RUE-1591): consuming
-            // exactly the linear sub-places of an infectious carrier
-            // discharges its obligation, and the non-linear residue is left
-            // for the ordinary scope-exit drop walk.
-            let Some(residue) = self.residual_linear_place(local.ty, state, &mut Vec::new()) else {
-                continue;
-            };
-
-            let name = self.body_interner().resolve(&*symbol);
-            let err = linear_not_consumed_error(
-                name,
-                local.span,
-                Self::residue_consumed_on_some_path(state, &residue),
-            );
-            let err = self.note_residual_linear_place(err, *symbol, &residue);
-            return Err(self.attach_infectious_linear_note(err, local.ty));
+        if function_exit && !ctx.is_destructor {
+            // The parameter diagnostic points at the body, matching the
+            // end-of-body check's shape (there is no binding span to cite).
+            let body_span = self.body_rir_ref().get(ctx.producer).span;
+            for param in ctx.params {
+                let state = match unwound_moves.get(&param.name) {
+                    Some(saved) => *saved,
+                    None => ctx.moved_vars.get(&param.name),
+                };
+                self.check_linear_param_consumed(param, state, body_span)?;
+            }
         }
 
         Ok(())

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -307,6 +307,14 @@ pub(crate) struct LoopEdgeStates {
     pub break_snaps: Vec<(AHashMap<Spur, VariableMoveState>, usize)>,
     /// One `moved_vars` snapshot per `continue` targeting this loop.
     pub continue_snaps: Vec<(AHashMap<Spur, VariableMoveState>, usize)>,
+    /// Index of the first scope frame a `break`/`continue` targeting this
+    /// loop unwinds — the loop's own scope frame, recorded when the loop
+    /// pushes it. The early-exit edge walk (RUE-1614) enforces the linear
+    /// must-consume obligation over exactly the frames `first_unwound_frame..`
+    /// at each such edge: those scopes end at the edge and their live
+    /// bindings are dropped there, while bindings outside the loop stay live
+    /// and may still be consumed after it.
+    pub first_unwound_frame: usize,
 }
 
 /// Record one snapshot in a per-loop edge list, merging with an existing
@@ -347,6 +355,15 @@ fn merged_edge_moves(
 }
 
 impl LoopEdgeStates {
+    /// A fresh record for a loop whose own (just-pushed) scope frame is
+    /// `first_unwound_frame` (RUE-1614).
+    pub fn entered_at(first_unwound_frame: usize) -> Self {
+        LoopEdgeStates {
+            first_unwound_frame,
+            ..LoopEdgeStates::default()
+        }
+    }
+
     /// Record one break's snapshot.
     pub fn record_break(&mut self, moves: &AHashMap<Spur, VariableMoveState>, depth: usize) {
         self.broke = true;
@@ -716,6 +733,11 @@ pub(crate) struct AnalysisContext<'a> {
     /// registry-installed `Option(payload)`. Left `false` everywhere else, where
     /// a contextual enum may validate — but never select — the result identity.
     pub try_operand: bool,
+    /// True while analyzing a destructor body. A destructor's `self` is
+    /// disposed of by the drop glue after the body runs (spec 3.8:62), so the
+    /// early-exit edge walk (RUE-1614) must skip the by-value parameter
+    /// obligation exactly as the end-of-body parameter check does.
+    pub is_destructor: bool,
 }
 
 pub(crate) struct FullExpressionBoundary {
@@ -1002,6 +1024,7 @@ impl<'a> AnalysisContext<'a> {
             inline_resolved_types: self.inline_resolved_types.clone(),
             place_aliases: self.place_aliases.clone(),
             try_operand: false,
+            is_destructor: self.is_destructor,
         }
     }
 

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -76,6 +76,16 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     return Err(CompileError::new(ErrorKind::BreakWithValue, inst.span));
                 }
 
+                // The break unwinds the scopes between here and the loop:
+                // those scopes end AT this edge and their live bindings are
+                // dropped here (spec 4.8:21), so a linear value they hold
+                // must already be consumed in the state in force at the edge
+                // (RUE-1614). The enclosing joins exclude this diverging arm,
+                // so no scope-exit check ever observes this state.
+                if let Some(record) = ctx.loop_break_stack.last() {
+                    self.check_linear_values_at_exit_edge(ctx, record.first_unwound_frame, false)?;
+                }
+
                 // Record the break against the innermost enclosing loop: it
                 // is now `()`-typed instead of `!` (spec 4.8:17), and the
                 // move state in force HERE is one of the loop's exit states —
@@ -101,6 +111,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 // Validate that we're inside a loop
                 if ctx.loop_depth == 0 {
                     return Err(CompileError::new(ErrorKind::ContinueOutsideLoop, inst.span));
+                }
+
+                // The continue unwinds the scopes between here and the loop
+                // head: this iteration's bindings in those scopes end AT this
+                // edge and are dropped here, so a linear value they hold must
+                // already be consumed in the state in force at the edge
+                // (RUE-1614), exactly as at a break.
+                if let Some(record) = ctx.loop_break_stack.last() {
+                    self.check_linear_values_at_exit_edge(ctx, record.first_unwound_frame, false)?;
                 }
 
                 // The move state in force HERE rides the back edge into the
@@ -390,7 +409,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // the flag itself is unused because a while loop is always `()`.
         ctx.push_scope();
         ctx.loop_depth += 1;
-        ctx.loop_break_stack.push(LoopEdgeStates::default());
+        ctx.loop_break_stack
+            .push(LoopEdgeStates::entered_at(ctx.scope_stack.len() - 1));
         let boundary = ctx.enter_full_expression();
         let body_result = self.analyze_inst(air, body, ctx);
         ctx.exit_full_expression(boundary);
@@ -449,7 +469,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 result?;
                 scratch_ctx.push_scope();
                 scratch_ctx.loop_depth += 1;
-                scratch_ctx.loop_break_stack.push(LoopEdgeStates::default());
+                scratch_ctx
+                    .loop_break_stack
+                    .push(LoopEdgeStates::entered_at(
+                        scratch_ctx.scope_stack.len() - 1,
+                    ));
                 let boundary = scratch_ctx.enter_full_expression();
                 let result = self.analyze_inst(air, body, &mut scratch_ctx);
                 scratch_ctx.exit_full_expression(boundary);
@@ -502,7 +526,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         ctx.push_scope();
         ctx.loop_depth += 1;
-        ctx.loop_break_stack.push(LoopEdgeStates::default());
+        ctx.loop_break_stack
+            .push(LoopEdgeStates::entered_at(ctx.scope_stack.len() - 1));
         // A `for` over a named variable borrows it (shared) for the body's
         // duration (spec 4.8:26, RUE-233): record the borrow so a mutation of
         // the iterated collection inside the body is rejected (E0428).
@@ -560,7 +585,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let recovered_before = self.body_analysis_recovered_errors_mut().len();
             scratch_ctx.push_scope();
             scratch_ctx.loop_depth += 1;
-            scratch_ctx.loop_break_stack.push(LoopEdgeStates::default());
+            scratch_ctx
+                .loop_break_stack
+                .push(LoopEdgeStates::entered_at(
+                    scratch_ctx.scope_stack.len() - 1,
+                ));
             if let Some(var) = iter_borrow {
                 scratch_ctx.iter_borrows.push(var);
             }
@@ -1551,7 +1580,21 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 span,
             )
         };
-        match self.trusted_try_producer(operand_ty) {
+        let trusted_producer = self.trusted_try_producer(operand_ty);
+
+        // The `?` failure arm is an early `return` (4.15): it ends every open
+        // scope, dropping their live bindings and the by-value parameters at
+        // this edge, so a linear value any of them holds must already be
+        // consumed in the state in force HERE, after the operand's own
+        // consumptions (RUE-1614) — exactly as at an explicit `return`. The
+        // check runs only for a genuine try (a trusted Option/Result operand;
+        // a lookalike reports E0504 instead) whose operand actually reaches
+        // this edge.
+        if trusted_producer.is_some() && operand_result.continues {
+            self.check_linear_values_at_exit_edge(ctx, 0, true)?;
+        }
+
+        match trusted_producer {
             Some(TrustedTryProducer::Option) => {
                 let operand_enum_id = operand_ty
                     .as_enum()
@@ -2188,7 +2231,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 span,
             ));
         }
-        let inner_air_ref = if let Some(inner) = inner {
+        let (inner_air_ref, edge_reachable) = if let Some(inner) = inner {
             // Explicit return with value. A `str`-returning function
             // (ADR-0043 Phase 3, RUE-324) supplies `str` as the expected type so
             // a string-literal `return "..."` materializes as a static-backed,
@@ -2244,7 +2287,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     span,
                 ));
             }
-            Some(inner_result.air_ref)
+            (Some(inner_result.air_ref), inner_result.continues)
         } else {
             // `return;` without expression - only valid for unit-returning functions
             if ctx.return_type != Type::UNIT && !ctx.return_type.is_error() {
@@ -2258,8 +2301,21 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     span,
                 ));
             }
-            None
+            (None, true)
         };
+
+        // The return ends every open scope: their live bindings — and the
+        // by-value parameters — are dropped at this edge (spec 4.9:7), so a
+        // linear value any of them holds must already be consumed in the
+        // state in force HERE, after the operand's own consumptions
+        // (RUE-1614). The enclosing joins exclude this diverging arm, so no
+        // scope-exit check ever observes this state; without the edge check a
+        // conditional return leaked the value into the return path's unwind
+        // drops. An operand that itself diverges never reaches this edge, so
+        // its obligation sites report instead (no double-report).
+        if edge_reachable {
+            self.check_linear_values_at_exit_edge(ctx, 0, true)?;
+        }
 
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Ret(inner_air_ref),

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -15,7 +15,7 @@ use rue_rir::{InstRef, Rir, RirParamMode, RirTypeSyntaxRef};
 use rue_span::{FileId, Span};
 
 use super::aggregate_resolution::is_accessible as aggregate_is_accessible;
-use super::analysis::{ElementwiseConsumption, FirstClassStrSite, linear_not_consumed_error};
+use super::analysis::FirstClassStrSite;
 use super::anon_structs::{
     IssuedCanonicalArguments, IssuedFunctionInstanceKey, IssuedStableProducerId,
 };
@@ -2149,6 +2149,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             inline_resolved_types: Vec::new(),
             place_aliases: AHashMap::new(),
             try_operand: false,
+            is_destructor,
         };
 
         // Accessor body shape (ADR-0062 phase 1): the body block must end in
@@ -2191,46 +2192,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         // substituted away; destructors are exempt (see the doc comment).
         if !is_destructor {
             for p in &param_vec {
-                if p.mode != RirParamMode::Normal || p.is_comptime {
-                    continue;
-                }
-                if !self.type_requires_consumption(p.ty) {
-                    continue;
-                }
                 let state = self.moved_state(&ctx, &p.name);
-                if !state.is_some_and(|s| s.full_move_on_all_paths) {
-                    // Element-wise consumption of a linear array parameter
-                    // (RUE-186) satisfies the obligation like a whole move.
-                    match self.check_array_elementwise_consumption(
-                        p.ty,
-                        state,
-                        p.name,
-                        self.body_rir_ref().get(body).span,
-                    )? {
-                        ElementwiseConsumption::Complete => continue,
-                        ElementwiseConsumption::NotElementwise => {}
-                    }
-                    // Per-place residue (core §5.6, RUE-1591): a by-value
-                    // parameter of an infectious carrier is consumed by
-                    // consuming its linear sub-places; the rest is dropped by
-                    // the ordinary exit walk, exactly as for a local.
-                    let Some(residue) = self.residual_linear_place(p.ty, state, &mut Vec::new())
-                    else {
-                        continue;
-                    };
-                    let name = self.body_interner().resolve(&p.name);
-                    let err = linear_not_consumed_error(
-                        name,
-                        self.body_rir_ref().get(body).span,
-                        Self::residue_consumed_on_some_path(state, &residue),
-                    )
-                    .with_note(format!(
-                        "parameter '{name}' is passed by value, so this function owns it \
-                         and must consume it (pass it on, return it, or destructure it)"
-                    ));
-                    let err = self.note_residual_linear_place(err, p.name, &residue);
-                    return Err(self.attach_infectious_linear_note(err, p.ty));
-                }
+                self.check_linear_param_consumed(p, state, self.body_rir_ref().get(body).span)?;
             }
         }
 

--- a/crates/rue-cli-tests/cases/linear_must_consume.toml
+++ b/crates/rue-cli-tests/cases/linear_must_consume.toml
@@ -4,8 +4,11 @@
 # (union) state: a linear value consumed in only ONE branch of an if/match
 # counted as consumed, silently dropping it on the other paths. Consumption
 # is now intersected at branch joins (full_move_on_all_paths), so every
-# non-diverging path must consume the value. Paths that diverge (return)
-# never reach the end of scope and are exempt.
+# non-diverging path must consume the value. A diverging path is exempt from
+# the check at the scope's END, but not from the obligation: an early exit
+# (`return`, `?`, `break`, `continue`) ends the scopes it unwinds AT the
+# edge and drops their live bindings there, so the value must already be
+# consumed in the state in force at the edge (RUE-1614).
 
 [section]
 id = "cli.linear_must_consume"
@@ -82,21 +85,137 @@ fn main() -> i32 {
 """ }]
 exit_code = 7
 
+# RUE-1614: this control previously returned bare `0` on the diverging branch
+# — the return path silently dropped `m` unconsumed. The return path must
+# consume too; consuming IN the return operand discharges the obligation
+# before the edge.
 [[case]]
 name = "linear_consume_then_return_control"
-description = "Control: a diverging branch (early return) never reaches end of scope, so it is exempt."
+description = "Control: an early-return path that consumes the value (here: in the return operand) is legal."
 files = [{ path = "main.rue", source = """
 linear struct MustUse { value: i32 }
 fn consume(m: MustUse) -> i32 { m.value }
 fn main() -> i32 {
     let m = MustUse { value: 5 };
     if false {
-        return 0;
+        return consume(m) - 5;
     }
     consume(m)
 }
 """ }]
 exit_code = 5
+
+# RUE-1614: the conditional-return hole, with the runtime consequence made
+# observable — before the fix this compiled clean and the destructor of the
+# leaked linear's field ran on the return path (a value the program never
+# consumed), printing 7 and exiting 1.
+[[case]]
+name = "linear_conditional_return_leak_rejected"
+description = "A conditional early return with the linear value still live is E0406 (RUE-1614)."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+linear struct L { v: i32, d: D }
+fn main() -> i32 {
+    let l = L { v: 5, d: D { v: 7 } };
+    if l.v > 0 { return 1; }
+    @drop(l);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0406", "'l' must be consumed"]
+
+# RUE-1614 legal counterpart: discharging the obligation on the return path
+# (before the edge) and on the fall-through is legal; the destructor runs
+# exactly once, at the taken path's @drop site.
+[[case]]
+name = "linear_conditional_return_both_paths_consume"
+description = "Consuming before the conditional return and on the fall-through is legal on both paths."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+linear struct L { v: i32, d: D }
+fn main() -> i32 {
+    let l = L { v: 5, d: D { v: 7 } };
+    if l.v > 4 { @drop(l); return 0; }
+    @drop(l);
+    1
+}
+""" }]
+exit_code = 0
+stdout = "7\n"
+
+# RUE-1614 break edge: the break unwinds the loop-body scopes and drops their
+# live bindings at the edge — before the fix the destructor ran once per
+# skipped-consumption exit.
+[[case]]
+name = "linear_conditional_break_leak_rejected"
+description = "A conditional break with a loop-local linear value still live is E0406 (RUE-1614)."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+fn consume(m: MustUse) -> i32 { m.value }
+fn main() -> i32 {
+    let mut i = 0;
+    let mut total = 0;
+    loop {
+        let m = MustUse { value: 1 };
+        if i > 2 { break; }
+        i = i + 1;
+        total = total + consume(m);
+    }
+    total
+}
+""" }]
+compile_fail = true
+error_contains = ["E0406", "'m' must be consumed"]
+
+# RUE-1614 continue edge: a continue unwinds this iteration's loop-body
+# scopes exactly like a break.
+[[case]]
+name = "linear_conditional_continue_leak_rejected"
+description = "A conditional continue with a loop-local linear value still live is E0406 (RUE-1614)."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+fn consume(m: MustUse) -> i32 { m.value }
+fn main() -> i32 {
+    let mut i = 0;
+    let mut total = 0;
+    while i < 3 {
+        let m = MustUse { value: 1 };
+        i = i + 1;
+        if i > 1 { continue; }
+        total = total + consume(m);
+    }
+    total
+}
+""" }]
+compile_fail = true
+error_contains = ["E0406", "'m' must be consumed"]
+
+# RUE-1614 loop-edge control: consuming before the conditional break, and on
+# every other path, is legal; linears bound OUTSIDE the loop stay live across
+# a break edge and are consumed after the loop.
+[[case]]
+name = "linear_break_after_consume_control"
+description = "Control: consuming the loop-local linear before the break (and each fall-through) is legal."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+fn consume(m: MustUse) -> i32 { m.value }
+fn main() -> i32 {
+    let outer = MustUse { value: 3 };
+    let mut i = 0;
+    let mut total = 0;
+    loop {
+        let m = MustUse { value: 1 };
+        total = total + consume(m);
+        if i > 1 { break; }
+        i = i + 1;
+    }
+    total + consume(outer)
+}
+""" }]
+exit_code = 6
 
 [[case]]
 name = "linear_one_branch_in_loop_rejected"

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -424,6 +424,15 @@ const ENTRIES: &[Entry] = &[
         external(ExternalDependencyKind::SystemCall),
         &["aarch64-linux"],
     ),
+    // RUE-1614: the legal consume-before-`?` regression case exercises the
+    // early-return failure edge through @parse_i64, which the oracle does
+    // not model (same debt as the expressions.try entries above).
+    Entry::new(
+        "types.move-semantics",
+        "linear_consumed_before_try_accepted",
+        intrinsic(UnsupportedIntrinsicKind::ParseI64),
+        &[],
+    ),
     Entry::new(
         "types.mutable_strings",
         "string_growth_on_append",

--- a/crates/rue-spec/cases/expressions/match.toml
+++ b/crates/rue-spec/cases/expressions/match.toml
@@ -1154,11 +1154,34 @@ fn main() -> i32 {
 compile_fail = true
 error_contains = ["E0406", "'c.l' still holds a linear value"]
 
-# A diverging arm body is exempt only on paths that actually consume or
-# diverge before scope exit (3.8:51): consuming on the surviving branch and
-# returning on the other is legal from an arm exactly as from a block.
+# A linear payload binding must be consumed on the early-return path too: the
+# return unwinds the arm scope and drops its live bindings there (3.8:51,
+# RUE-1614 — this case previously returned bare `0` and leaked `x` on that
+# path). Consuming before the return discharges the obligation on both
+# branches, from an arm exactly as from a block.
 [[case]]
-name = "match_linear_payload_binding_diverging_branch_is_exempt"
+name = "match_linear_payload_binding_early_return_consumes"
+spec = ["4.7:31", "3.8:51"]
+source = """
+linear struct L { v: i32 }
+enum E { A(L), B }
+fn sink(x: L) -> i32 { x.v }
+fn main() -> i32 {
+    let c = true;
+    let e = E.A(L { v: 37 });
+    match e {
+        E.A(x) => if c { sink(x) + 5 } else { @drop(x); return 0 },
+        E.B => 2,
+    }
+}
+"""
+exit_code = 42
+
+# The RUE-1614 hole in arm position: a conditional return inside an arm with
+# the payload binding still live escaped the arm-scope check (RUE-1603), which
+# only sees the fall-through join.
+[[case]]
+name = "match_linear_payload_binding_conditional_return_leak_rejected"
 spec = ["4.7:31", "3.8:51"]
 source = """
 linear struct L { v: i32 }
@@ -1173,7 +1196,8 @@ fn main() -> i32 {
     }
 }
 """
-exit_code = 42
+compile_fail = true
+error_contains = ["E0406", "'x' must be consumed"]
 
 # `@drop` is the explicit-discard escape hatch for a named linear payload
 # binding, exactly as for any linear local (3.9:37).

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -1152,10 +1152,14 @@ fn main() -> i32 {
 """
 exit_code = 7
 
+# RUE-1614: a `return` ends every open scope and drops its live bindings, so
+# a linear value must be consumed BEFORE the return edge, not merely on the
+# fall-through path. This case previously returned bare `0` on the diverging
+# branch and passed — the return path silently dropped `m` unconsumed.
 [[case]]
-name = "linear_diverging_branch_exempt"
+name = "linear_early_return_path_consumes"
 spec = ["3.8:51"]
-description = "A branch that returns never reaches the end of scope, so it is exempt from consumption"
+description = "An early-return path satisfies must-consume by consuming before (here: in) the return"
 source = """
 linear struct MustUse { value: i32 }
 
@@ -1164,12 +1168,226 @@ fn consume(m: MustUse) -> i32 { m.value }
 fn main() -> i32 {
     let m = MustUse { value: 5 };
     if false {
-        return 0;
+        return consume(m) - 5;
     }
     consume(m)
 }
 """
 exit_code = 5
+
+# The RUE-1614 hole itself: a CONDITIONAL return leaves the enclosing joins
+# carrying only the fall-through continuation, so no scope-exit check ever
+# saw the return edge's state and the value escaped into the return path's
+# unwind drops (its destructor ran on a value never consumed).
+[[case]]
+name = "linear_conditional_return_leak_rejected"
+spec = ["3.8:51", "3.8:32"]
+description = "A conditional early return with the linear value still live is rejected (RUE-1614)"
+source = """
+linear struct MustUse { value: i32 }
+
+fn consume(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    let m = MustUse { value: 5 };
+    if m.value > 0 {
+        return 1;
+    }
+    consume(m)
+}
+"""
+compile_fail = true
+error_contains = ["E0406", "'m' must be consumed"]
+
+# The same edge rule for loop exits: a `break` unwinds the loop-body scopes
+# and drops their live bindings at the edge (4.8:21), so a linear declared in
+# the body must be consumed before a conditional `break` (RUE-1614).
+[[case]]
+name = "linear_conditional_break_leak_rejected"
+spec = ["3.8:51", "4.8:21"]
+description = "A conditional break with a loop-local linear value still live is rejected (RUE-1614)"
+source = """
+linear struct MustUse { value: i32 }
+
+fn consume(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    let mut i = 0;
+    let mut total = 0;
+    loop {
+        let m = MustUse { value: 1 };
+        if i > 2 { break; }
+        i = i + 1;
+        total = total + consume(m);
+    }
+    total
+}
+"""
+compile_fail = true
+error_contains = ["E0406", "'m' must be consumed"]
+
+# ... and for the back edge: a `continue` unwinds this iteration's loop-body
+# scopes exactly like a break (RUE-1614).
+[[case]]
+name = "linear_conditional_continue_leak_rejected"
+spec = ["3.8:51"]
+description = "A conditional continue with a loop-local linear value still live is rejected (RUE-1614)"
+source = """
+linear struct MustUse { value: i32 }
+
+fn consume(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    let mut i = 0;
+    let mut total = 0;
+    while i < 3 {
+        let m = MustUse { value: 1 };
+        i = i + 1;
+        if i > 1 { continue; }
+        total = total + consume(m);
+    }
+    total
+}
+"""
+compile_fail = true
+error_contains = ["E0406", "'m' must be consumed"]
+
+# A break edge only unwinds the loop's own scopes: a linear bound OUTSIDE the
+# loop stays live across the break and may be consumed after it.
+[[case]]
+name = "linear_outer_value_survives_break_edge"
+spec = ["3.8:51"]
+description = "A conditional break does not demand consumption of linears bound outside the loop"
+source = """
+linear struct MustUse { value: i32 }
+
+fn consume(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    let m = MustUse { value: 5 };
+    let mut i = 0;
+    loop {
+        i = i + 1;
+        if i > 2 { break; }
+    }
+    consume(m)
+}
+"""
+exit_code = 5
+
+# The `?` failure path is an implicit early return (4.15:7): it unwinds every
+# open scope, so a linear value live across a `?` leaks on the failure path
+# exactly as across a conditional `return` (RUE-1614).
+[[case]]
+name = "linear_live_across_try_rejected"
+spec = ["3.8:51", "4.15:7"]
+description = "A linear value live across a `?` expression is rejected: the failure path would drop it (RUE-1614)"
+source = """
+const std = @import("std");
+
+linear struct MustUse { value: i64 }
+
+fn consume(m: MustUse) -> i64 { m.value }
+
+fn parse_two(s: str) -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
+    let m = MustUse { value: 5 };
+    let n = @parse_i64(s)?;
+    let v = consume(m);
+    O.Some(n + v)
+}
+
+fn main() -> i32 {
+    let O = std.option.Option(i64);
+    match parse_two("37") {
+        O.Some(n) => @intCast(n),
+        O.None => 1,
+    }
+}
+"""
+real_std = true
+compile_fail = true
+error_contains = ["E0406", "'m' must be consumed"]
+
+# Consuming before the `?` discharges the obligation on both continuations.
+[[case]]
+name = "linear_consumed_before_try_accepted"
+spec = ["3.8:51", "4.15:7"]
+description = "Consuming the linear value before the `?` satisfies must-consume on the failure path too"
+source = """
+const std = @import("std");
+
+linear struct MustUse { value: i64 }
+
+fn consume(m: MustUse) -> i64 { m.value }
+
+fn parse_two(s: str) -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
+    let m = MustUse { value: 5 };
+    let v = consume(m);
+    let n = @parse_i64(s)?;
+    O.Some(n + v)
+}
+
+fn main() -> i32 {
+    let O = std.option.Option(i64);
+    match parse_two("37") {
+        O.Some(n) => @intCast(n),
+        O.None => 1,
+    }
+}
+"""
+real_std = true
+exit_code = 42
+
+# The edge check is keyed on the residual ownership state, like the scope-exit
+# walk (RUE-1591): an infectious carrier whose linear sub-place is still live
+# at a conditional return edge is rejected naming that sub-place.
+[[case]]
+name = "linear_carrier_residue_live_at_return_edge_rejected"
+spec = ["3.8:51", "3.8:60"]
+description = "A carrier whose linear sub-place is unconsumed at a conditional return edge is rejected with the residual-place note (RUE-1614)"
+source = """
+linear struct Token { value: i32 }
+struct Carrier { t: Token, junk: i32 }
+
+fn consume(t: Token) -> i32 { t.value }
+
+fn main() -> i32 {
+    let c = Carrier { t: Token { value: 5 }, junk: 1 };
+    if c.junk > 0 {
+        return 1;
+    }
+    consume(c.t)
+}
+"""
+compile_fail = true
+error_contains = ["E0406", "'c.t' still holds a linear value"]
+
+# A by-value parameter's obligation (3.8:62) holds at a return edge too: the
+# return unwinds the parameter scope and drops it there (RUE-1614).
+[[case]]
+name = "linear_param_live_at_return_edge_rejected"
+spec = ["3.8:51", "3.8:62"]
+description = "A by-value linear parameter unconsumed at a conditional return edge is rejected (RUE-1614)"
+source = """
+linear struct MustUse { value: i32 }
+
+fn consume(m: MustUse) -> i32 { m.value }
+
+fn taker(m: MustUse, early: bool) -> i32 {
+    if early {
+        return 0;
+    }
+    consume(m)
+}
+
+fn main() -> i32 {
+    taker(MustUse { value: 5 }, false)
+}
+"""
+compile_fail = true
+error_contains = ["E0406", "passed by value"]
 
 [[case]]
 name = "linear_one_branch_in_loop_error"

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -507,13 +507,20 @@ Its second clause covers the paths that never reach `Σf`. A body ending in
 `return` has `Σf = ⊥` (§5.7), which discharges nothing: the function's scopes
 end at the `return` instead, so the obligation must hold in the state in force
 *there* — the same "consumed on only some paths" discipline §5.5's join applies
-to branches (`3.8:50`). **Compiler divergence** (observed 2026-08-23 while
-verifying this premise; not yet filed): the compiler checks the obligation
-path-insensitively, so a linear binding consumed on the fall-through path but
-still live across an early `return` is accepted, and its destructor runs on the
-return path — an implicit drop of a value the program never consumed, which is
-what `3.8:32/62/66` forbid. The core states the prose rule; the compiler is the
-artifact in the wrong (RUE-305).
+to branches (`3.8:50`). **Compiler agreement (RUE-1614, resolved).** The
+divergence recorded here — the obligation checked only at fall-through scope
+exits, so a linear binding consumed on the fall-through path but still live
+across a conditional early `return` was accepted, its destructor running on
+the return path (an implicit drop of a value the program never consumed,
+which is what `3.8:32/62/66` forbid) — **no longer reproduces** (re-verified
+2026-08-23, RUE-1614). The compiler now enforces the residual obligation at
+every early-exit edge, against the state in force at the edge after the
+operand's own consumptions: `return` and the `?` failure path check every
+open scope plus the by-value parameters (a destructor's `self` stays exempt,
+`3.8:62`), and `break`/`continue` check exactly the scopes the edge unwinds,
+so a linear bound outside the loop stays consumable after it. The surface
+spec's `3.8:51` — which had stated the diverging-path exemption broadly
+enough to read as an amnesty — now states the same edge rule.
 
 The `borrow` and `inout` restrictions are **callee-polarity** rules: the caller
 may not touch a lent place while the loan is live, while the callee may touch the

--- a/docs/spec/src/03-types/08-move-semantics.md
+++ b/docs/spec/src/03-types/08-move-semantics.md
@@ -183,9 +183,9 @@ linear struct Invalid { value: i32 }  // ERROR: linear types cannot be @copy
 
 A linear value **MUST** be consumed on every control-flow path on which it goes out of scope. It is a compile-time error for a linear value to be consumed in only some branches of a conditional (`if`/`else` or `match`): the paths that do not consume it would drop it implicitly.
 
-{{ rule(id="3.8:51", cat="normative") }}
+{{ rule(id="3.8:51", cat="legality-rule") }}
 
-A control-flow path that diverges (for example, by executing a `return` expression) does not reach the end of the value's scope, and so is exempt from the consumption requirement on that path.
+A control-flow path that diverges before a scope's end never reaches that scope's end, and so is exempt from the consumption check applied *there* on that path (the diverging path contributes nothing to 3.8:50's branch requirement). Divergence is not an amnesty from consumption: an exit that unwinds scopes — a `return` expression (including the implicit return of a `?` expression's failure path, 4.15:7), a `break`, or a `continue` — ends the scopes it exits at the exit itself and drops their live bindings there (4.9:7, 4.8:21), so a linear value held by any scope the exit unwinds — including, for a `return` or `?`, a pass-by-value parameter (3.8:62) — **MUST** already have been consumed in the state in force when the exit executes. It is a compile-time error otherwise, exactly as at the scope's end (3.8:32, 3.8:50): the exit's drops would otherwise destroy the value unconsumed.
 
 {{ rule(id="3.8:52", cat="example") }}
 


### PR DESCRIPTION
Closes the exit-edge hole in the linear-enforcement family, discovered during the core-maintenance verification and sharpened during integration: a **conditional** `return`, `break`, `continue`, or `?` failure arm escaped the must-consume analysis entirely — the diverging arm is excluded from branch joins, so no scope-exit check ever observed the edge state, and the unwind drop glue destroyed live linear values at runtime (destructor observably firing on an unconsumed linear). Straight-line exits were already caught via the divergence-snapshot mechanism, which is exactly why the conditional shapes went unnoticed.

## Fix

A new exit-edge check enforces the residual linear obligation at each edge against the state in force there, after the edge operand's own consumptions (`return sink(l)` and `return l` stay legal). It shares one kernel with the scope-exit walk — E0406/E0443 selection, element-wise array consumption, residual sub-places with their notes — and the by-value-parameter helper with its exemptions (destructor `self`, `inout`/`borrow`, comptime). `break`/`continue` check only the frames the edge actually unwinds, so linears in outer scopes stay consumable after the loop; shadow frames are virtually replayed so shadowed outer bindings are checked with their own state. No new codes.

Spec 3.8:51 **endorsed the bug as written** ("diverging paths are exempt") — rewritten to the edge rule. The core's dated divergence note under (Fn) is resolved. Three corpus cases asserting the unsound behavior are reworked to consume on the exit path, each citing the issue; ~12 new edge-coverage cases plus negative twins are added across spec and CLI suites.

## Validation

- All four edge kinds reproduced on unmodified base with observable destructor output, then verified rejected on this branch by execution; legal discharge patterns (consume on every path, `@drop`, return-of-the-value) verified compiling and running.
- Suites: quick, spec 3.8 (152) / 3.9 / 4.7 / 4.8 / 4.9 / 4.15, cli linear (81), cli drop (126), formatting clean.
- Full suite: 231 pass / 0 fail / 0 build failures, exit code captured directly.

Two adjacent findings are filed in the tracker rather than folded in: the `@panic`-edge consistency question (no runtime unsoundness — panic aborts without drops) and a pre-existing declared-linear destructure drop leak entangled with the open husk ruling.

Fixes RUE-1614

---
_Generated by [Claude Code](https://claude.ai/code/session_01JekaZ8oUGSZPXQeodh3sy8)_