### PR TITLE
RUE-1612: route slice bounds checks through bounds trap

### DIFF
--- a/crates/rue-air/src/runtime_call.rs
+++ b/crates/rue-air/src/runtime_call.rs
@@ -124,6 +124,10 @@ pub enum RuntimeCallKind {
     PanicNoMessage,
     AssertFailed,
     AssertWithMessage,
+    /// Typed identity for compiler-inserted slice bounds traps. This shares
+    /// the `assert` intrinsic's conditional shape while selecting the
+    /// dedicated `__rue_bounds_check` runtime helper in codegen.
+    BoundsCheck,
     ReadLine,
     ParseI32,
     ParseI64,
@@ -287,7 +291,7 @@ const BYTE_SET: &[RuntimeOperandOrigin] = &[
 ];
 
 impl RuntimeCallKind {
-    pub const ALL: [Self; 40] = [
+    pub const ALL: [Self; 41] = [
         Self::StrByteAt,
         Self::StrCharScalar,
         Self::StrCharNext,
@@ -307,6 +311,7 @@ impl RuntimeCallKind {
         Self::PanicNoMessage,
         Self::AssertFailed,
         Self::AssertWithMessage,
+        Self::BoundsCheck,
         Self::ReadLine,
         Self::ParseI32,
         Self::ParseI64,
@@ -349,6 +354,7 @@ impl RuntimeCallKind {
             Self::PanicNoMessage => RuntimeHelperId::PanicNoMessage,
             Self::AssertFailed => RuntimeHelperId::AssertFailed,
             Self::AssertWithMessage => RuntimeHelperId::Panic,
+            Self::BoundsCheck => RuntimeHelperId::BoundsCheck,
             Self::ReadLine => RuntimeHelperId::ReadLine,
             Self::ParseI32 => RuntimeHelperId::ParseI32,
             Self::ParseI64 => RuntimeHelperId::ParseI64,
@@ -395,6 +401,7 @@ impl RuntimeCallKind {
             Self::DebugBool => BOOL_SCALAR,
             Self::PanicNoMessage
             | Self::AssertFailed
+            | Self::BoundsCheck
             | Self::RandomU32
             | Self::RandomU64
             | Self::ArgCount
@@ -412,7 +419,7 @@ impl RuntimeCallKind {
 
     pub const fn activation(self) -> RuntimeCallActivation {
         match self {
-            Self::AssertFailed | Self::AssertWithMessage => {
+            Self::AssertFailed | Self::AssertWithMessage | Self::BoundsCheck => {
                 RuntimeCallActivation::WhenArgumentIsFalse(0)
             }
             _ => RuntimeCallActivation::Always,
@@ -662,6 +669,14 @@ mod tests {
         assert_eq!(
             RuntimeCallKind::Panic.activation(),
             RuntimeCallActivation::Always
+        );
+        assert_eq!(
+            RuntimeCallKind::BoundsCheck.helper(),
+            RuntimeHelperId::BoundsCheck
+        );
+        assert_eq!(
+            RuntimeCallKind::BoundsCheck.activation(),
+            RuntimeCallActivation::WhenArgumentIsFalse(0)
         );
     }
 

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -3685,14 +3685,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// The slice `base_result` is the synthetic 2-word fat-pointer struct
     /// `{ptr: ptr const T, len: u64}`. The read desugars to, in order:
     ///
-    /// 1. a runtime bounds check `@assert(i < len)` — traps with exit 101 (the
-    ///    same discipline as array indexing) when the index is out of range;
+    /// 1. a typed compiler bounds check — traps with exit 101 through the
+    ///    dedicated bounds runtime helper (the same path as array indexing)
+    ///    when the index is out of range;
     /// 2. `@ptr_read(@ptr_offset(ptr, i))` — `@ptr_offset` scales by
     ///    `size_of(T)`, so this reads the i-th element.
     ///
-    /// Everything is built from existing intrinsics, so no new codegen (or
-    /// backend-specific work) is required; the fat pointer flows through the
-    /// same struct/field/pointer paths the manual `{ptr,len}` form already uses.
+    /// The check uses the existing conditional trap lowering and the fat
+    /// pointer flows through the same struct/field/pointer paths the manual
+    /// `{ptr,len}` form already uses, so both backends share one implementation.
     #[allow(clippy::too_many_arguments)]
     pub(super) fn analyze_slice_index_get(
         &mut self,
@@ -3765,12 +3766,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ctx,
         )?;
 
-        // Runtime bounds check: `@assert(index >= 0); @assert(index < len)`
-        // traps (exit 101) when the index is out of range. Unsigned indices only
-        // need the upper-bound check; signed indices also need the lower-bound
-        // check so `s[-1]` cannot pass the signed `index < len` comparison and
-        // read before the backing array.
-        let lower_assert_ref = if index_result.ty.is_signed() {
+        // Runtime bounds check: the condition is kept in AIR as a side-effect
+        // intrinsic, but its typed runtime identity is BoundsCheck rather than
+        // source-level @assert. Codegen lowers that identity through the shared
+        // conditional-trap machinery to the same dedicated bounds helper used
+        // by fixed-array indexing. Unsigned indices only need the upper-bound
+        // check; signed indices also need the lower-bound check so `s[-1]`
+        // cannot read before the backing array.
+        let lower_check_ref = if index_result.ty.is_signed() {
             let zero_ref = air.add_inst(AirInst {
                 data: AirInstData::Const(0),
                 ty: index_result.ty,
@@ -3782,7 +3785,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 span,
             });
             Some(air.add_intrinsic(
-                Some(crate::RuntimeCallKind::AssertFailed),
+                Some(crate::RuntimeCallKind::BoundsCheck),
                 self.known_symbols().assert,
                 &[lower_bound_ref],
                 Type::UNIT,
@@ -3796,8 +3799,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ty: Type::BOOL,
             span,
         });
-        let upper_assert_ref = air.add_intrinsic(
-            Some(crate::RuntimeCallKind::AssertFailed),
+        let upper_check_ref = air.add_intrinsic(
+            Some(crate::RuntimeCallKind::BoundsCheck),
             self.known_symbols().assert,
             &[upper_bound_ref],
             Type::UNIT,
@@ -3823,9 +3826,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // Demand-driven lowering only pulls the returned value's dependencies,
         // so the bounds-check assertion (a pure side effect) must be an explicit
         // statement of the block that yields the element.
-        let stmt_refs: Vec<AirRef> = lower_assert_ref
+        let stmt_refs: Vec<AirRef> = lower_check_ref
             .into_iter()
-            .chain(std::iter::once(upper_assert_ref))
+            .chain(std::iter::once(upper_check_ref))
             .collect();
         let block_ref = air.add_block(&stmt_refs, elem_ref, elem_ty, span)?;
         Ok(AnalysisResult::with_continues(

--- a/crates/rue-cli-tests/cases/slices_mvp.toml
+++ b/crates/rue-cli-tests/cases/slices_mvp.toml
@@ -71,6 +71,7 @@ fn main() -> i32 {
 """ }]
 args = ["main.rue", "-o", "prog"]
 exit_code = 101
+runtime_error_contains = ["index out of bounds"]
 
 # Signed negative indices must trap too. Slice indexing should match array
 # bounds semantics: any index below zero is out of bounds, not a huge pointer
@@ -88,6 +89,7 @@ fn main() -> i32 {
 """ }]
 args = ["main.rue", "-o", "prog"]
 exit_code = 101
+runtime_error_contains = ["index out of bounds"]
 
 # A constant read-index resolves the element position (discriminating value: the
 # middle element 5 catches an off-by-one or wrong-stride lowering).

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -11,7 +11,7 @@
 //! architecture cannot quietly invent a different scalar/aggregate policy.
 
 use lasso::Spur;
-use rue_air::{EnumId, StructId, TypeKind};
+use rue_air::{EnumId, RuntimeCallKind, StructId, TypeKind};
 use rue_cfg::{CfgInstData, CfgValue, Place, PlaceBase, Projection, Type};
 use rue_runtime_abi::RuntimeHelperId;
 
@@ -1623,9 +1623,18 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     primary: arg.primary,
                     slots: arg.slots.clone(),
                 });
+                let call = if *runtime == Some(RuntimeCallKind::BoundsCheck) {
+                    // Slice indexing carries a typed compiler trap identity on
+                    // the existing conditional `assert` shape. Preserve that
+                    // identity through CFG lowering so it reaches the shared
+                    // bounds helper used by fixed-array projections.
+                    crate::runtime_call_plan::RuntimeCallPlan::no_args(RuntimeHelperId::BoundsCheck)
+                } else {
+                    trap_runtime_call(message.as_ref())
+                };
                 let result = adapter.emit_trap(TrapPlan::Assert {
                     condition: values[0].primary,
-                    call: trap_runtime_call(message.as_ref()),
+                    call,
                 });
                 cache_result(adapter, value, result);
                 Some(ValueKind::Intrinsic)
@@ -2372,7 +2381,9 @@ mod tests {
         comparison_integer_width, integer_range, type_bits, type_range,
     };
     use lasso::ThreadedRodeo;
-    use rue_air::{EnumDef, LangItem, ParamSlotModes, StructDef, StructField, TypeInternPool};
+    use rue_air::{
+        EnumDef, LangItem, ParamSlotModes, RuntimeCallKind, StructDef, StructField, TypeInternPool,
+    };
     use rue_cfg::{Cfg, CfgInst, CfgInstData, CfgValue, Place, Type};
     use rue_runtime_abi::RuntimeHelperId;
     use rue_span::{FileId, Span};
@@ -3279,6 +3290,43 @@ mod tests {
             RuntimeHelperId::Panic
         );
         assert_eq!(super::trap_runtime_call(Some(&message)).args().len(), 2);
+    }
+
+    #[test]
+    fn compiler_bounds_trap_uses_shared_helper_on_both_targets() {
+        let interner = ThreadedRodeo::new();
+        let assert_name = interner.get_or_intern("assert");
+        let mut cfg = Cfg::new(Type::UNIT, 0, 0, "slice_bounds_trap".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let condition = cfg.append_inst(entry, inst(CfgInstData::BoolConst(false), Type::BOOL));
+        cfg.append_intrinsic(
+            entry,
+            Some(RuntimeCallKind::BoundsCheck),
+            assert_name,
+            [condition],
+            Type::UNIT,
+            Span::new(0, 0),
+        )
+        .expect("bounds trap intrinsic should append");
+        cfg.set_return(entry, None);
+
+        let pool = TypeInternPool::new().freeze();
+        let x86 = X86CfgLower::new_unchecked(&cfg, &pool, &interner)
+            .lower()
+            .expect("x86 compiler bounds trap should lower");
+        assert!(x86.instructions().iter().any(|instruction| {
+            matches!(instruction, X86Inst::CallRel { symbol_id, .. }
+                if x86.get_symbol(*symbol_id) == "__rue_bounds_check")
+        }));
+
+        let arm = Aarch64CfgLower::new_unchecked(&cfg, &pool, &interner, Target::Aarch64Linux)
+            .lower()
+            .expect("AArch64 compiler bounds trap should lower");
+        assert!(arm.instructions().iter().any(|instruction| {
+            matches!(instruction, Aarch64Inst::Bl { symbol_id, .. }
+                if arm.get_symbol(*symbol_id) == "__rue_bounds_check")
+        }));
     }
 
     #[test]

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -50,7 +50,8 @@
 //! is valid and reports every one as a generator-contract failure.
 //!
 //! - **All other CFG intrinsics.** The `Intrinsic` arm models `@dbg`, `@panic`,
-//!   and `@assert`; every other intrinsic that is allowed to survive to the CFG
+//!   `@assert`, and compiler-inserted slice bounds checks; every other intrinsic
+//!   that is allowed to survive to the CFG
 //!   is a typed model gap: the
 //!   non-deterministic `@read_line`, `@random_u32`/`@random_u64`, `@syscall`;
 //!   the heap intrinsics `@alloc`/`@free`/`@realloc`; the raw-pointer intrinsics
@@ -1740,6 +1741,47 @@ impl<'a> Interp<'a> {
         }
     }
 
+    /// Validate and execute the compiler-inserted bounds check carried by the
+    /// existing `assert` intrinsic shape. Its typed runtime identity is what
+    /// distinguishes a slice check from source-level `@assert` when the oracle
+    /// assigns a trap category.
+    fn eval_bounds_check_intrinsic(
+        &mut self,
+        cfg: &'a Cfg,
+        frame: &mut Frame,
+        name: &str,
+        args: &[CfgValue],
+        result_ty: Type,
+    ) -> Step<Value> {
+        if name != "assert" || result_ty != Type::UNIT || args.len() != 1 {
+            return Err(unsupported(
+                UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
+                "compiler bounds-check intrinsic signature",
+            ));
+        }
+        if cfg.get_inst(args[0]).ty != Type::BOOL {
+            return Err(unsupported(
+                UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
+                "compiler bounds-check intrinsic condition",
+            ));
+        }
+        let values = self.eval_all(cfg, frame, args)?;
+        let [Value::Bool(condition)] = values.as_slice() else {
+            return Err(unsupported(
+                UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
+                "compiler bounds-check intrinsic runtime condition",
+            ));
+        };
+        if *condition {
+            Ok(Value::Unit)
+        } else {
+            self.abort_with_stderr(
+                TrapKind::IndexOutOfBounds,
+                &[b"error: index out of bounds\n"],
+            )
+        }
+    }
+
     fn write_dbg(&mut self, val: &Value, ty: Type) -> Step<()> {
         let remaining = self.stdout_cap.saturating_sub(self.stdout_bytes);
 
@@ -2814,10 +2856,14 @@ impl<'a> Interp<'a> {
                 }
             }
 
-            CfgInstData::Intrinsic { name, .. } => {
+            CfgInstData::Intrinsic { runtime, name, .. } => {
                 let iname = self.interner().resolve(name).to_string();
                 let args = cfg.get_intrinsic_args(&inst.data).to_vec();
-                if let Some(intrinsic) = self.preflight_abort_intrinsic(cfg, &iname, &args, ty)? {
+                if *runtime == Some(RuntimeCallKind::BoundsCheck) {
+                    self.eval_bounds_check_intrinsic(cfg, frame, &iname, &args, ty)?
+                } else if let Some(intrinsic) =
+                    self.preflight_abort_intrinsic(cfg, &iname, &args, ty)?
+                {
                     self.eval_abort_intrinsic(cfg, frame, intrinsic, &args)?
                 } else if iname == "bitCast" {
                     // `@bitCast` is fully modeled, not a gap: a same-width

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -745,6 +745,37 @@ fn array_out_of_bounds_traps() {
 }
 
 #[test]
+fn slice_bounds_check_uses_index_trap_category_without_changing_assertions() {
+    let slice_oob = r#"
+        fn get(borrow s: [i64], i: u64) -> i32 { @intCast(s[i]) }
+        fn main() -> i32 {
+            let a: [i64; 3] = [10, 20, 30];
+            get(borrow a, 5)
+        }
+    "#;
+    let out = run(slice_oob);
+    assert_eq!(out.exit_code, 101);
+    assert_eq!(out.stderr, "error: index out of bounds\n");
+    assert_eq!(out.panic, Some(TrapKind::IndexOutOfBounds));
+
+    let slice_negative = r#"
+        fn get(borrow s: [i64], i: i32) -> i32 { @intCast(s[i]) }
+        fn main() -> i32 {
+            let a: [i64; 3] = [10, 20, 30];
+            get(borrow a, -1)
+        }
+    "#;
+    let out = run(slice_negative);
+    assert_eq!(out.exit_code, 101);
+    assert_eq!(out.stderr, "error: index out of bounds\n");
+    assert_eq!(out.panic, Some(TrapKind::IndexOutOfBounds));
+
+    let assertion = run("fn main() -> i32 { @assert(false); 0 }");
+    assert_eq!(assertion.stderr, "assertion failed\n");
+    assert_eq!(assertion.panic, Some(TrapKind::AssertionFailure));
+}
+
+#[test]
 fn struct_field_mutation() {
     let src = "struct P { x: i32, y: i32 }
     fn main() -> i32 {

--- a/crates/rue-spec/cases/arrays/slices.toml
+++ b/crates/rue-spec/cases/arrays/slices.toml
@@ -693,6 +693,7 @@ fn main() -> i32 {
 }
 """
 exit_code = 101
+runtime_error = "index out of bounds"
 
 # The trap fires before the element is read: an index one past the end is out
 # of range even though the storage beyond it is the caller's own frame.
@@ -710,6 +711,7 @@ fn main() -> i32 {
 }
 """
 exit_code = 101
+runtime_error = "index out of bounds"
 
 # A negative index is out of range, not a backwards offset.
 [[case]]
@@ -725,6 +727,7 @@ fn main() -> i32 {
 }
 """
 exit_code = 101
+runtime_error = "index out of bounds"
 
 # The bounds check does not depend on the element type: a struct-element view
 # traps on an out-of-range index exactly as a scalar-element one does.


### PR DESCRIPTION
## Summary

- route compiler-inserted slice bounds checks through the dedicated bounds trap helper
- preserve source-assert behavior while teaching the oracle the typed bounds-check identity
- cover positive and signed-negative slice failures plus both backend lowerers

## Testing

- scripts/rue cli slices
- scripts/rue spec 7.2:22
- scripts/rue unit codegen compiler_bounds_trap_uses_shared_helper_on_both_targets
- scripts/rue unit air every_runtime_call_plan_matches_the_manifest
- scripts/rue fmt
- scripts/rue quick
- scripts/rue premerge
- scripts/rue slow
- scripts/rue test

Fixes RUE-1612