### PR TITLE
RUE-1608: correct match path pattern grammar

### DIFF
--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -2516,7 +2516,7 @@ exit_code = 42
 
 [[case]]
 name = "inline_type_ctor_pattern_head"
-spec = ["4.14:23"]
+spec = ["4.7:2", "4.14:23"]
 description = "A type-constructor call heads a match pattern: match r { Result(i32, i32).Ok(v) => .. } (RUE-596)"
 source = """
 fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
@@ -2549,7 +2549,7 @@ error_contains = "[E0209]"
 
 [[case]]
 name = "inline_type_ctor_module_qualified_pattern_head"
-spec = ["4.14:23"]
+spec = ["4.7:2", "4.14:23"]
 real_std = true
 description = "A module-qualified type-constructor call heads a match pattern: match r { std.result.Result(i32, i32).Ok(v) => .. } (RUE-947)"
 source = """

--- a/crates/rue-spec/cases/expressions/match.toml
+++ b/crates/rue-spec/cases/expressions/match.toml
@@ -2,7 +2,7 @@
 id = "expressions.match"
 spec_chapter = "4.7"
 name = "Match Expressions"
-description = "Match expressions provide multi-way branching on values. Currently supports integer and boolean patterns with wildcard (_)."
+description = "Match expressions provide multi-way branching on values, including literal, wildcard, and enum path patterns with payload bindings."
 
 # =============================================================================
 # Basic Match with Integers
@@ -514,7 +514,7 @@ compile_fail = true
 # bindings inference cannot reduce locally (RUE-954).
 [[case]]
 name = "arm_literal_typed_by_let_annotation"
-spec = ["4.7:12"]
+spec = ["4.7:2", "4.7:12"]
 source = """
 fn Opt(comptime T: type) -> type {
     enum {
@@ -971,13 +971,13 @@ error_contains = "parentheses"
 # A tuple-variant pattern binds the payload; the arity must match (4.7:30).
 [[case]]
 name = "match_payload_binding_extracts"
-spec = ["4.7:30"]
+spec = ["4.7:2", "4.7:30"]
 source = """
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 fn main() -> i32 {
     match Shape.Rect(3, 4) {
         Shape.Circle(r) => r,
-        Shape.Rect(w, h) => w + h,
+        Shape.Rect(w, h,) => w + h,
         Shape.Empty => 0,
     }
 }
@@ -988,7 +988,7 @@ exit_code = 7
 # repeat (`Rect(_, _)`) since it introduces no name (4.7:30, RUE-601).
 [[case]]
 name = "match_payload_wildcard_discard"
-spec = ["4.7:30"]
+spec = ["4.7:2", "4.7:30"]
 source = """
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 fn main() -> i32 {
@@ -1005,7 +1005,7 @@ exit_code = 42
 # the arity rule that rejects `Shape.Rect(w)` above with E0207.
 [[case]]
 name = "match_bare_variant_pattern_is_all_wildcard_form"
-spec = ["4.7:30", "4.7:34"]
+spec = ["4.7:2", "4.7:30", "4.7:34"]
 source = """
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 fn main() -> i32 {

--- a/docs/spec/src/04-expressions/07-match-expressions.md
+++ b/docs/spec/src/04-expressions/07-match-expressions.md
@@ -13,11 +13,25 @@ A match expression provides multi-way branching based on pattern matching.
 {{ rule(id="4.7:2", cat="normative") }}
 
 ```ebnf
-match_expr = "match" expression "{" { match_arm "," } [ match_arm ] "}" ;
+match_expr     = "match" expression "{" [ match_arms ] "}" ;
+match_arms     = match_arm { "," match_arm } [ "," ] ;
 match_arm = pattern "=>" expression ;
-pattern = "_" | [ "-" ] INTEGER | BOOL | enum_variant_pattern ;
-enum_variant_pattern = IDENT "." IDENT ;
+pattern        = "_"
+               | [ "-" ] INTEGER
+               | BOOL
+               | path_pattern ;
+path_pattern   = pattern_head "." IDENT [ "(" pattern_bindings ")" ] ;
+pattern_head   = qualified_ident [ "(" [ call_args ] ")" ] ;
+pattern_bindings = pattern_binding { "," pattern_binding } [ "," ] ;
+pattern_binding = IDENT | "_" ;
 ```
+
+An enum variant is a `path_pattern`: its `pattern_head` may be a qualified
+identifier (such as `module.Enum`) or an inline type-constructor call (such as
+`Result(i32, i32)`), followed by `.` and the variant name. A bare variant
+pattern omits the optional binding list and is the all-wildcard form. An
+explicit binding list contains one or more names or `_` wildcards and may have
+a trailing comma; an empty list such as `Enum.Variant()` is not a pattern.
 
 ## Patterns
 
@@ -227,16 +241,18 @@ fn absurd(n: Never) -> i32 {
 
 {{ rule(id="4.7:30", cat="normative") }}
 
-A tuple-variant pattern binds the variant's payload into fresh names:
+A tuple-variant path pattern binds the variant's payload into fresh names:
 `EnumName.Variant(a, b)` matches a value of that variant and binds `a`, `b`
-to its payload fields in order. A binding position may instead be the wildcard
-`_`, which matches and discards that field without binding it; unlike a name it
-introduces nothing and so may repeat (`Rect(_, _)`). The number of binding
-positions **MUST** equal the variant's payload arity (see spec 6.3), with one
-carve-out: a *bare* variant pattern that supplies no binding list at all —
-`EnumName.Variant` on a variant of arity one or more — **is** the all-wildcard
-form `EnumName.Variant(_, ..., _)` and is therefore exempt from the arity rule
-(4.7:34 says the same value-context consumption applies to it).
+to its payload fields in order. The enum head may be qualified or an inline
+type-constructor head (4.7:2), and the binding list may end in a trailing
+comma, as in `EnumName.Variant(a, b,)`. A binding position may instead be the
+wildcard `_`, which matches and discards that field without binding it; unlike
+a name it introduces nothing and so may repeat (`Rect(_, _)`). The number of
+binding positions **MUST** equal the variant's payload arity (see spec 6.3),
+with one carve-out: a *bare* variant pattern that supplies no binding list at
+all — `EnumName.Variant` on a variant of arity one or more — **is** the
+all-wildcard form `EnumName.Variant(_, ..., _)` and is therefore exempt from
+the arity rule (4.7:34 says the same value-context consumption applies to it).
 
 A discarded field — one covered by `_`, or by the bare form — is bound to a
 fresh *unnameable* binding: it is moved out of the scrutinee like any other


### PR DESCRIPTION
Summary:
- Align rule 4.7:2 path-pattern EBNF with the canonical Appendix A grammar.
- Clarify qualified and constructor heads, payload bindings, wildcards, bare forms, and trailing commas.
- Extend direct spec traceability using existing focused cases.

Testing:
- scripts/rue fmt
- scripts/rue spec 4.7:2
- ./buck2 test //:spec-traceability
- scripts/rue quick
- scripts/rue premerge

Fixes RUE-1608