### PR TITLE
Discharge array fields consumed element-wise in the residual walk

### DIFF
--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -2395,7 +2395,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 // a linear value would drop the caller's live value implicitly.
                 // An `inout` binding can never be proven moved-out, so this is
                 // always ill-formed (E0494).
-                let discharged = self.place_linear_discharged(param_ty, name, &[], span, ctx);
+                let discharged = self.place_linear_discharged(param_ty, name, &[], ctx);
                 self.check_linear_overwrite(param_ty, discharged, true, span)?;
 
                 // Assignment to a parameter resets its move state
@@ -2462,7 +2462,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // would drop it implicitly. Legal only when the whole variable was
         // proven moved-out on every path (reinit-after-move idiom) — evaluated
         // on the post-RHS move state so `x = f(x)` counts as a discharge.
-        let discharged = self.place_linear_discharged(local_ty, name, &[], span, ctx);
+        let discharged = self.place_linear_discharged(local_ty, name, &[], ctx);
         self.check_linear_overwrite(local_ty, discharged, false, span)?;
         // Two-types model (ADR-0043, RUE-386): reassigning a first-class `str`
         // local must store a first-class `str`, not a buffer or a borrowed view;
@@ -4131,7 +4131,6 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     field_type,
                     trace.root_var,
                     &trace.field_path(),
-                    span,
                     ctx,
                 );
             self.check_linear_overwrite(field_type, discharged, false, span)?;
@@ -4336,7 +4335,6 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     elem_type,
                     trace.root_var,
                     &trace.field_path(),
-                    span,
                     ctx,
                 );
             self.check_linear_overwrite(elem_type, discharged, false, span)?;
@@ -4497,8 +4495,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// branch of an if/match still leaks on the other paths. Only types that
     /// require consumption are checked: linear structs themselves, and
     /// non-empty arrays whose elements carry one (an array of linear values
-    /// must be consumed — as a whole, or element-wise via constant-index
-    /// moves (RUE-186); dropping it would silently drop every element).
+    /// must be consumed — as a whole, element-wise via constant-index moves
+    /// (RUE-186), or per element through its linear sub-places (RUE-1606);
+    /// dropping it would silently drop every element).
     fn check_linear_binding_consumed(
         &self,
         symbol: Spur,
@@ -4512,22 +4511,24 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return Ok(());
         }
 
-        // Element-wise consumption of a linear array (RUE-186, spec
-        // 3.8:71): moving every element out (constant indices) on every
-        // path satisfies the array's must-consume obligation. Partial
-        // element consumption is an error naming the missing elements.
+        // Per-place residue (core §5.6, spec 3.8:60, RUE-1591): consuming
+        // exactly the linear sub-places of an infectious carrier
+        // discharges its obligation, and the non-linear residue is left
+        // for the ordinary scope-exit drop walk. The walk recurses into
+        // array elements (RUE-1606), so it also accepts complete
+        // element-wise consumption of a root linear array (RUE-186, spec
+        // 3.8:71) and of an array field consumed through per-element field
+        // moves.
+        let Some(residue) = self.residual_linear_place(local.ty, state, &mut Vec::new()) else {
+            return Ok(());
+        };
+
+        // A root array PARTIALLY consumed element-wise gets the more
+        // precise diagnostic naming the missing elements (RUE-186).
         match self.check_array_elementwise_consumption(local.ty, state, symbol, local.span)? {
             ElementwiseConsumption::Complete => return Ok(()),
             ElementwiseConsumption::NotElementwise => {}
         }
-
-        // Per-place residue (core §5.6, spec 3.8:60, RUE-1591): consuming
-        // exactly the linear sub-places of an infectious carrier
-        // discharges its obligation, and the non-linear residue is left
-        // for the ordinary scope-exit drop walk.
-        let Some(residue) = self.residual_linear_place(local.ty, state, &mut Vec::new()) else {
-            return Ok(());
-        };
 
         let name = self.body_interner().resolve(&symbol);
         let err = linear_not_consumed_error(
@@ -4567,19 +4568,23 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if state.is_some_and(|s| s.full_move_on_all_paths) {
             return Ok(());
         }
-        // Element-wise consumption of a linear array parameter (RUE-186)
-        // satisfies the obligation like a whole move.
+        // Per-place residue (core §5.6, RUE-1591): a by-value parameter of an
+        // infectious carrier is consumed by consuming its linear sub-places;
+        // the rest is dropped by the ordinary exit walk, exactly as for a
+        // local. The walk recurses into array elements (RUE-1606), so
+        // element-wise consumption of a linear array parameter (RUE-186) —
+        // and per-element field consumption of an array anywhere in the
+        // parameter's place tree — satisfies the obligation like a whole
+        // move.
+        let Some(residue) = self.residual_linear_place(param.ty, state, &mut Vec::new()) else {
+            return Ok(());
+        };
+        // A root array PARTIALLY consumed element-wise gets the more precise
+        // diagnostic naming the missing elements (RUE-186).
         match self.check_array_elementwise_consumption(param.ty, state, param.name, span)? {
             ElementwiseConsumption::Complete => return Ok(()),
             ElementwiseConsumption::NotElementwise => {}
         }
-        // Per-place residue (core §5.6, RUE-1591): a by-value parameter of an
-        // infectious carrier is consumed by consuming its linear sub-places;
-        // the rest is dropped by the ordinary exit walk, exactly as for a
-        // local.
-        let Some(residue) = self.residual_linear_place(param.ty, state, &mut Vec::new()) else {
-            return Ok(());
-        };
         let name = self.body_interner().resolve(&param.name);
         let err = linear_not_consumed_error(
             name,
@@ -4706,10 +4711,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     ///   (RUE-614, an open maintainer decision) unchanged;
     /// - a struct otherwise recurses into the fields that carry a linear
     ///   value;
-    /// - everything else (arrays, enums, scalars) falls back to the type's own
+    /// - an array recurses into its elements once any move was recorded
+    ///   under this place (see [`Self::residual_linear_array_place`]), so
+    ///   consuming the linear content of every element — element-wise for a
+    ///   root array (3.8:71), or through per-element field moves for an
+    ///   array anywhere in the place tree (RUE-1606) — discharges it;
+    /// - everything else (enums, scalars) falls back to the type's own
     ///   obligation, because their sub-places are not tracked per place here.
-    ///   Whole-array element-wise consumption is checked separately by
-    ///   [`Self::check_array_elementwise_consumption`] before this runs.
     ///
     /// `path` is scratch space threaded through the recursion; it is restored
     /// to its entry value before returning.
@@ -4721,6 +4729,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     ) -> Option<Vec<Spur>> {
         if state.is_some_and(|s| Self::place_moved_on_all_paths(s, path)) {
             return None;
+        }
+        if let TypeKind::Array(array_id) = ty.kind() {
+            return self.residual_linear_array_place(array_id, state, path);
         }
         let Some(struct_id) = ty.as_struct() else {
             return self.type_requires_consumption(ty).then(|| path.clone());
@@ -4735,6 +4746,54 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             }
             path.push(self.body_interner().get_or_intern(&field.name));
             let found = self.residual_linear_place(field.ty, state, path);
+            path.pop();
+            if found.is_some() {
+                return found;
+            }
+        }
+        None
+    }
+
+    /// The array clause of [`Self::residual_linear_place`] (RUE-1606): the
+    /// residual obligation of an array-typed place, per element.
+    ///
+    /// An array's linear content can be consumed below the whole-array
+    /// granularity: element-wise constant-index moves for a root array
+    /// (3.8:68/3.8:71), and — for an array ANYWHERE in the place tree whose
+    /// elements are infectious carriers — per-element field moves
+    /// (`h.arr[0].p`; the field-move path model names constant-index
+    /// elements, RUE-279). Recursing into each element at its own path lets
+    /// both discharge the array exactly like a struct field's consumption
+    /// discharges the struct (core §5.6).
+    ///
+    /// When NO move was recorded strictly under this place, no element
+    /// content was ever consumed, so the whole array is the residue — this
+    /// keeps the untouched-array diagnostic (and the walk's cost) independent
+    /// of the array length. Declared-`linear` elements are never dischargeable
+    /// below whole-element granularity (their obligation is the value itself,
+    /// 3.8:74, and an element of a non-root array cannot be moved out at all,
+    /// 3.8:68), so for them the recursion reports the first live element.
+    fn residual_linear_array_place(
+        &self,
+        array_id: crate::types::ArrayTypeId,
+        state: Option<&VariableMoveState>,
+        path: &mut Vec<Spur>,
+    ) -> Option<Vec<Spur>> {
+        let (elem_ty, len) = self.body_type_pool().array_def(array_id);
+        if len == 0 || !self.type_requires_consumption(elem_ty) {
+            return None;
+        }
+        let touched_below = state.is_some_and(|s| {
+            s.partial_moves
+                .iter()
+                .any(|(p, _)| p.len() > path.len() && p[..path.len()] == path[..])
+        });
+        if !touched_below {
+            return Some(path.clone());
+        }
+        for k in 0..len {
+            path.push(index_path_segment(self.body_interner(), k));
+            let found = self.residual_linear_place(elem_ty, state, path);
             path.pop();
             if found.is_some() {
                 return found;
@@ -4822,12 +4881,16 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     }
 
     /// Shared element-wise consumption check for linear arrays (RUE-186):
-    /// returns `Complete` when every element of the array was moved out on
-    /// every path (the must-consume obligation is satisfied), an `Err`
-    /// naming the missing elements when the array was only PARTIALLY
-    /// consumed element-wise, and `NotElementwise` when no element was ever
-    /// consumed (or the type is not an array) — the caller then reports its
-    /// usual whole-value diagnostic.
+    /// returns `Complete` when every element's linear content was consumed
+    /// on every path — a whole-element move (constant index, 3.8:68), or
+    /// consumption of all of the element's linear sub-places (RUE-1606, the
+    /// per-place residual model of core §5.6) — an `Err` naming the missing
+    /// elements when the array was only PARTIALLY consumed element-wise, and
+    /// `NotElementwise` when no element was ever touched (or the type is not
+    /// an array) — the caller then reports its usual whole-value diagnostic.
+    ///
+    /// The reinit-after-overwrite proof is deliberately NOT this check: see
+    /// [`Self::array_fully_moved_elementwise`].
     pub(crate) fn check_array_elementwise_consumption(
         &self,
         ty: Type,
@@ -4841,10 +4904,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let Some(s) = state else {
             return Ok(ElementwiseConsumption::NotElementwise);
         };
-        let (_elem, len) = self.body_type_pool().array_def(array_id);
+        let (elem_ty, len) = self.body_type_pool().array_def(array_id);
         let elem_path = |k: u64| vec![index_path_segment(self.body_interner(), k)];
         let unconsumed: Vec<u64> = (0..len)
-            .filter(|k| !s.partial_moves_on_all_paths.contains(&elem_path(*k)))
+            .filter(|k| {
+                self.residual_linear_place(elem_ty, Some(s), &mut elem_path(*k))
+                    .is_some()
+            })
             .collect();
         if unconsumed.is_empty() {
             return Ok(ElementwiseConsumption::Complete);
@@ -4857,14 +4923,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return Ok(ElementwiseConsumption::NotElementwise);
         }
         let name = self.body_interner().resolve(&symbol);
-        // An unconsumed element that WAS moved on some path selects the
-        // more precise "not consumed on all paths" diagnostic (E0443 over
-        // E0406).
+        // An unconsumed element that WAS moved (whole, or below the element)
+        // on some path selects the more precise "not consumed on all paths"
+        // diagnostic (E0443 over E0406).
         let some_path_span = unconsumed.iter().find_map(|k| {
             let target = elem_path(*k);
             s.partial_moves
                 .iter()
-                .find(|(p, _)| *p == target)
+                .find(|(p, _)| p.first() == Some(&target[0]))
                 .map(|(_, span)| *span)
         });
         let list = unconsumed
@@ -4942,7 +5008,6 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         dest_ty: Type,
         root_var: Spur,
         assigned_path: &[Spur],
-        span: Span,
         ctx: &AnalysisContext,
     ) -> bool {
         let Some(state) = ctx.moved_vars.get(&root_var) else {
@@ -4957,13 +5022,30 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return true;
         }
         // A whole linear array consumed element-wise on every path holds no
-        // live element to drop. Reuse the must-consume element check; `Err`
-        // (partial consumption) and `NotElementwise` are both "not discharged".
-        assigned_path.is_empty()
-            && matches!(
-                self.check_array_elementwise_consumption(dest_ty, Some(state), root_var, span),
-                Ok(ElementwiseConsumption::Complete)
-            )
+        // live element to drop.
+        assigned_path.is_empty() && self.array_fully_moved_elementwise(dest_ty, state)
+    }
+
+    /// Whether every element of an array was WHOLLY moved out on every path
+    /// (constant-index element moves, 3.8:68) — the reinit-after-move proof
+    /// for a whole-array overwrite (3.8:77).
+    ///
+    /// This is deliberately stricter than the must-consume discharge
+    /// ([`Self::check_array_elementwise_consumption`], which since RUE-1606
+    /// also accepts consumption of an element's linear SUB-places): after
+    /// `sink(a[0].p)` element 0 is a live husk that the assignment would
+    /// still overwrite, so it does not license reassignment — exactly as a
+    /// struct husk does not (`c = ...` stays rejected after `sink(c.l)`).
+    fn array_fully_moved_elementwise(&self, ty: Type, state: &VariableMoveState) -> bool {
+        let TypeKind::Array(array_id) = ty.kind() else {
+            return false;
+        };
+        let (_elem, len) = self.body_type_pool().array_def(array_id);
+        (0..len).all(|k| {
+            state
+                .partial_moves_on_all_paths
+                .contains(&vec![index_path_segment(self.body_interner(), k)])
+        })
     }
 
     /// Reject a discarded expression value that carries a linear value

--- a/crates/rue-cli-tests/cases/infectious_linear.toml
+++ b/crates/rue-cli-tests/cases/infectious_linear.toml
@@ -137,6 +137,51 @@ stdout = """99
 """
 
 [[case]]
+name = "array_field_elementwise_subplace_discharge_runs_residue_destructors"
+description = "Consuming each element's linear field discharges an array FIELD's obligation (RUE-1606); every element's residue destructor still runs exactly once, in ascending index order."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+struct C { l: L, d: D }
+struct H { arr: [C; 2] }
+fn sink(l: L) -> i32 { l.v }
+fn main() -> i32 {
+    let h = H { arr: [C { l: L { v: 1 }, d: D { v: 41 } }, C { l: L { v: 2 }, d: D { v: 42 } }] };
+    let r = sink(h.arr[0].l) + sink(h.arr[1].l);
+    @dbg(99);
+    r
+}
+""" }]
+exit_code = 3
+stdout = """99
+41
+42
+"""
+
+[[case]]
+name = "root_array_elementwise_subplace_discharge_runs_residue_destructors"
+description = "A root array of carriers discharged through per-element sub-place moves (RUE-1606) drops each element's residue exactly once at scope exit."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+struct C { l: L, d: D }
+fn sink(l: L) -> i32 { l.v }
+fn main() -> i32 {
+    let xs = [C { l: L { v: 1 }, d: D { v: 41 } }, C { l: L { v: 2 }, d: D { v: 42 } }];
+    let r = sink(xs[0].l) + sink(xs[1].l);
+    @dbg(99);
+    r
+}
+""" }]
+exit_code = 3
+stdout = """99
+41
+42
+"""
+
+[[case]]
 name = "carrier_residue_destructor_order_is_declaration_order"
 description = "Residue destructors run in field declaration order after the linear field is consumed (RUE-1591, spec 3.9:2)."
 files = [{ path = "main.rue", source = """

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -2228,6 +2228,185 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
+name = "linear_array_elementwise_via_subplaces"
+spec = ["3.8:71", "3.8:60"]
+description = "Consuming every element's linear sub-place discharges a root array of carrier structs"
+source = """
+linear struct MustUse { value: i32 }
+struct Carrier { m: MustUse }
+
+fn consume(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    let xs = [Carrier { m: MustUse { value: 40 } }, Carrier { m: MustUse { value: 2 } }];
+    consume(xs[0].m) + consume(xs[1].m)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "linear_array_partial_subplace_rejected"
+spec = ["3.8:71", "3.8:60"]
+description = "Discharging only one element's sub-place names the elements still unconsumed"
+source = """
+linear struct MustUse { value: i32 }
+struct Carrier { m: MustUse }
+
+fn consume(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    let xs = [Carrier { m: MustUse { value: 1 } }, Carrier { m: MustUse { value: 2 } }];
+    consume(xs[0].m)
+}
+"""
+compile_fail = true
+error_contains = ["must be consumed", "element(s) [1]"]
+
+[[case]]
+name = "nested_array_field_subplace_consumption"
+spec = ["3.8:71", "3.8:60"]
+description = "Per-element sub-place consumption discharges an array reached through a field projection"
+source = """
+linear struct MustUse { value: i32 }
+struct Carrier { m: MustUse }
+struct Holder { arr: [Carrier; 2] }
+
+fn consume(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    let h = Holder { arr: [Carrier { m: MustUse { value: 40 } }, Carrier { m: MustUse { value: 2 } }] };
+    consume(h.arr[0].m) + consume(h.arr[1].m)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "nested_array_field_partial_subplace_rejected"
+spec = ["3.8:71", "3.8:60"]
+description = "A partially discharged array field names the sub-place still holding a linear value"
+source = """
+linear struct MustUse { value: i32 }
+struct Carrier { m: MustUse }
+struct Holder { arr: [Carrier; 2] }
+
+fn consume(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    let h = Holder { arr: [Carrier { m: MustUse { value: 1 } }, Carrier { m: MustUse { value: 2 } }] };
+    consume(h.arr[0].m)
+}
+"""
+compile_fail = true
+error_contains = ["must be consumed", "'h.arr[1].m' still holds a linear value"]
+
+[[case]]
+name = "nested_array_field_one_branch_rejected"
+spec = ["3.8:71", "3.8:60"]
+description = "An array field's elements consumed on only some paths do not satisfy the obligation"
+source = """
+linear struct MustUse { value: i32 }
+struct Carrier { m: MustUse }
+struct Holder { arr: [Carrier; 2] }
+
+fn consume(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    let h = Holder { arr: [Carrier { m: MustUse { value: 1 } }, Carrier { m: MustUse { value: 2 } }] };
+    let a = consume(h.arr[0].m);
+    if a == 1 {
+        a + consume(h.arr[1].m)
+    } else {
+        a
+    }
+}
+"""
+compile_fail = true
+error_contains = ["not consumed on all paths", "'h.arr[1].m' still holds a linear value"]
+
+[[case]]
+name = "nested_array_field_param_subplace_consumption"
+spec = ["3.8:71", "3.8:62"]
+description = "A by-value parameter's array field can be discharged per element through sub-place moves"
+source = """
+linear struct MustUse { value: i32 }
+struct Carrier { m: MustUse }
+struct Holder { arr: [Carrier; 2] }
+
+fn consume(m: MustUse) -> i32 { m.value }
+fn consume_all(h: Holder) -> i32 { consume(h.arr[0].m) + consume(h.arr[1].m) }
+
+fn main() -> i32 {
+    consume_all(Holder { arr: [Carrier { m: MustUse { value: 40 } }, Carrier { m: MustUse { value: 2 } }] })
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "nested_array_field_subplace_consumption_before_return"
+spec = ["3.8:71", "3.8:60"]
+description = "Sub-place discharge of an array field is honored at an early-exit edge"
+source = """
+linear struct MustUse { value: i32 }
+struct Carrier { m: MustUse }
+struct Holder { arr: [Carrier; 2] }
+
+fn consume(m: MustUse) -> i32 { m.value }
+
+fn pick(h: Holder, flag: bool) -> i32 {
+    if flag {
+        return consume(h.arr[0].m) + consume(h.arr[1].m);
+    }
+    consume(h.arr[1].m) - consume(h.arr[0].m)
+}
+
+fn main() -> i32 {
+    pick(Holder { arr: [Carrier { m: MustUse { value: 40 } }, Carrier { m: MustUse { value: 2 } }] }, true)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "doubly_nested_array_field_subplace_consumption"
+spec = ["3.8:71", "3.8:60"]
+description = "Sub-place discharge recurses through nested array shapes reached through a field"
+source = """
+linear struct MustUse { value: i32 }
+struct Carrier { m: MustUse }
+struct Grid { g: [[Carrier; 2]; 2] }
+
+fn consume(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    let x = Grid { g: [
+        [Carrier { m: MustUse { value: 20 } }, Carrier { m: MustUse { value: 20 } }],
+        [Carrier { m: MustUse { value: 1 } }, Carrier { m: MustUse { value: 1 } }],
+    ] };
+    consume(x.g[0][0].m) + consume(x.g[0][1].m) + consume(x.g[1][0].m) + consume(x.g[1][1].m)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "linear_array_subplace_discharge_no_reassign"
+spec = ["3.8:77", "3.8:71"]
+description = "Sub-place discharge leaves live element husks, so whole-array reassignment stays rejected"
+source = """
+linear struct MustUse { value: i32 }
+struct Carrier { m: MustUse }
+
+fn consume(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    let mut xs = [Carrier { m: MustUse { value: 1 } }, Carrier { m: MustUse { value: 2 } }];
+    let a = consume(xs[0].m) + consume(xs[1].m);
+    xs = [Carrier { m: MustUse { value: 3 } }, Carrier { m: MustUse { value: 4 } }];
+    a
+}
+"""
+compile_fail = true
+error_contains = "assignment would overwrite a live linear value"
+
+[[case]]
 name = "zero_length_linear_array_vacuously_consumed"
 spec = ["3.8:74"]
 description = "A zero-length array of a linear type holds no linear values; dropping it is fine"

--- a/docs/spec/src/03-types/08-move-semantics.md
+++ b/docs/spec/src/03-types/08-move-semantics.md
@@ -547,7 +547,7 @@ While one or more elements of an array are moved out, it is a compile-time error
 
 {{ rule(id="3.8:71", cat="normative") }}
 
-An array whose elements carry linear values may be consumed element-wise: its must-consume obligation is satisfied when every element has been moved out on every non-diverging path. Moving out only some elements, or moving an element on only some paths, is a compile-time error naming the elements that are not consumed.
+An array whose elements carry linear values may be consumed element-wise: its must-consume obligation is satisfied when every element has been consumed on every non-diverging path — moved out as a whole (a constant-index move, 3.8:68), or, for an element whose type is a carrier struct linear only by infection (3.8:58), by consuming each of the element's linear sub-places (3.8:60). The sub-place route applies to an array anywhere in a place tree: the elements of an array reached through a field projection cannot be moved out as wholes (3.8:68), but consuming their linear sub-places (for example `h.arr[0].p` and `h.arr[1].p`) still discharges the array field's obligation. Consuming only some elements, or an element on only some paths, is a compile-time error naming the elements — or the sub-place — left unconsumed.
 
 {{ rule(id="3.8:72", cat="legality-rule") }}
 

--- a/docs/spec/src/07-arrays/01-fixed-arrays.md
+++ b/docs/spec/src/07-arrays/01-fixed-arrays.md
@@ -416,9 +416,12 @@ element owned — and therefore droppable — again (3.8:72).
 {{ rule(id="7.1:47", cat="normative") }}
 
 An array whose element type carries a must-consume (linear) value satisfies its
-consumption obligation when every element has been moved out on every non-diverging
-path. Moving out only some elements, or moving an element on only some paths, is a
-compile-time error naming the elements that remain unconsumed (3.8:71).
+consumption obligation when every element has been consumed on every non-diverging
+path — moved out as a whole, or (for a carrier-struct element) by consuming each of
+the element's linear sub-places, which is the only element-wise route for an array
+reached through a field projection (3.8:71). Consuming only some elements, or an
+element on only some paths, is a compile-time error naming what remains unconsumed
+(3.8:71).
 
 {{ rule(id="7.1:48", cat="dynamic-semantics") }}
 


### PR DESCRIPTION
Closes the residual-walk conservatism follow-up, with the issue's literal claim half-refuted by evidence and the real reachable gap fixed.

**Refuted half:** whole-element moves of a nested array field (`sink(h.arr[0])`) are rejected at the move site with E0904 by design — spec 3.8:68's root-index rule, enforced at `record_element_move_out`. No move state at that path can exist, so the issue's proposed "consult element move tracking at the field's path" would have been dead machinery for that shape. Left as-is.

**Fixed half:** per-element **field** moves through arrays of infectious carriers (`sink(h.arr[0].p) + sink(h.arr[1].p)`) compiled the moves but still rejected E0406 at scope exit, because the residual walk treated the array field by its whole obligation — and root arrays had the same gap for sub-element moves. The walk now recurses into array elements at their own paths (with a whole-array fast path keeping cost length-independent), the element-wise consumption check counts an element discharged when its per-place residual is empty, partial-consumption messages name only truly undischarged elements (`'h.arr[1].p' still holds a linear value`), and all three must-consume kernels (scope exit, by-value params, exit edges) share the behavior. Overwrite proof deliberately stays strict: array-husk reassignment remains E0493 via a dedicated fully-moved check, matching the struct-husk rule.

## Validation

- Probes verified by execution on unmodified base first, then on the integrated branch: full element-wise field consumption compiles and runs; partial consumption rejects with the element-naming residue note; E0904 on projected whole-element moves unchanged; E0443 one-branch variants; doubly nested arrays; runtime residue destructors exactly once in ascending order.
- Spec 3.8:71 and 7.1:47 extended with 9 citing spec cases plus 2 CLI runtime cases.
- Suites: quick, spec 3.8 (161), spec 7.1 (93), cli linear (83), cli infectious_linear (23), formatting clean.
- Full suite: 231 pass / 0 fail / 0 build failures, exit code captured directly.

One suspected soundness gap discovered during verification (a Copy read through a declared-linear element of a nested array field marks the whole root moved, erasing sibling elements' obligations) is filed in the tracker rather than folded in — it is pre-existing and unchanged by this fix.

Fixes RUE-1606

---
_Generated by [Claude Code](https://claude.ai/code/session_01JekaZ8oUGSZPXQeodh3sy8)_