### PR TITLE
RUE-1615: gate loop move checks on reachable back edges

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -146,13 +146,34 @@ pub struct ConstraintContext<'a> {
     pub return_type: Type,
     /// How many loops we're nested inside (for break/continue validation).
     pub loop_depth: u32,
-    /// One entry per enclosing loop (innermost last); set to `true` when a
-    /// `break` targeting that loop is seen. An infinite loop containing a
-    /// break has type `()`; without one it has type `!` (see spec 4.8).
-    pub loop_break_stack: Vec<bool>,
+    /// One entry per enclosing loop (innermost last). The syntactic bit gives
+    /// an infinite loop its spec-mandated type even when its break is in dead
+    /// code; the reachable bit determines whether that break can actually
+    /// leave the loop and continue an enclosing expression (RUE-1615).
+    pub loop_break_stack: Vec<LoopBreakFact>,
     checked_depth: u32,
     /// Scope stack for efficient scope management.
     scope_stack: Vec<Vec<(Spur, Option<LocalVarInfo>)>>,
+}
+
+/// Break facts collected during constraint generation. Type inference still
+/// analyzes unreachable suffixes for diagnostics, so reachability must be
+/// restored separately from the syntactic classification (spec 4.8:21).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LoopBreakFact {
+    pub syntactic: bool,
+    pub reachable: bool,
+}
+
+fn restore_reachable_break_facts(
+    loop_break_stack: &mut [LoopBreakFact],
+    reachable_facts: &[LoopBreakFact],
+) {
+    assert_eq!(reachable_facts.len(), loop_break_stack.len());
+    for (reachable, analyzed) in loop_break_stack.iter_mut().zip(reachable_facts) {
+        reachable.syntactic |= analyzed.syntactic;
+        reachable.reachable = analyzed.reachable;
+    }
 }
 
 impl<'a> ConstraintContext<'a> {
@@ -367,6 +388,23 @@ pub struct ConstraintGenerator<'a> {
 }
 
 impl<'a> ConstraintGenerator<'a> {
+    /// Generate one operand in a left-to-right sequence. Later operands are
+    /// still visited for diagnostics after an earlier operand diverges, but
+    /// their break facts cannot reach the enclosing loop (RUE-1615).
+    fn generate_sequenced_operand(
+        &mut self,
+        inst_ref: InstRef,
+        ctx: &mut ConstraintContext,
+        reachable: bool,
+    ) -> ExprInfo {
+        let reachable_facts = ctx.loop_break_stack.clone();
+        let info = self.generate(inst_ref, ctx);
+        if !reachable {
+            restore_reachable_break_facts(&mut ctx.loop_break_stack, &reachable_facts);
+        }
+        info
+    }
+
     /// Create a new constraint generator.
     pub fn new(
         rir: &'a Rir,
@@ -1127,7 +1165,14 @@ impl<'a> ConstraintGenerator<'a> {
             | InstData::Le { lhs, rhs }
             | InstData::Ge { lhs, rhs } => {
                 let lhs_info = self.generate(*lhs, ctx);
+                let reachable_facts_after_lhs = ctx.loop_break_stack.clone();
                 let rhs_info = self.generate(*rhs, ctx);
+                if !lhs_info.continues {
+                    restore_reachable_break_facts(
+                        &mut ctx.loop_break_stack,
+                        &reachable_facts_after_lhs,
+                    );
+                }
                 continues &= lhs_info.continues && rhs_info.continues;
                 // Operands must have the same type. (Chained comparisons are
                 // rejected at parse time — validate.rs, RUE-528 — so a
@@ -1140,7 +1185,14 @@ impl<'a> ConstraintGenerator<'a> {
             // Logical operators: operands must be bool, result is bool
             InstData::And { lhs, rhs } | InstData::Or { lhs, rhs } => {
                 let lhs_info = self.generate(*lhs, ctx);
+                let reachable_facts_after_lhs = ctx.loop_break_stack.clone();
                 let rhs_info = self.generate(*rhs, ctx);
+                if !lhs_info.continues {
+                    restore_reachable_break_facts(
+                        &mut ctx.loop_break_stack,
+                        &reachable_facts_after_lhs,
+                    );
+                }
                 // Logical operators short-circuit. A diverging RHS does not
                 // eliminate the LHS path that skips it, so only divergence of
                 // the always-evaluated LHS removes normal continuation.
@@ -1375,8 +1427,8 @@ impl<'a> ConstraintGenerator<'a> {
             }
 
             InstData::PlaceSet { place, value } => {
-                let place_info = self.generate(*place, ctx);
                 let value_info = self.generate(*value, ctx);
+                let place_info = self.generate_sequenced_operand(*place, ctx, value_info.continues);
                 continues &= place_info.continues && value_info.continues;
                 if value_info.continues {
                     self.add_constraint(Constraint::equal(place_info.ty, value_info.ty, span));
@@ -1449,7 +1501,8 @@ impl<'a> ConstraintGenerator<'a> {
                     && matches!(self.interner.resolve(name), "print" | "println");
                 let result = if is_print_builtin {
                     for arg in args.iter() {
-                        arg_diverged |= !self.generate(arg.value, ctx).continues;
+                        let info = self.generate_sequenced_operand(arg.value, ctx, !arg_diverged);
+                        arg_diverged |= !info.continues;
                     }
                     InferType::Concrete(Type::UNIT)
                 } else if let Some(func) = function_key.and_then(|key| self.func_sig(key)) {
@@ -1464,7 +1517,8 @@ impl<'a> ConstraintGenerator<'a> {
                         let arg_infos: Vec<ExprInfo> = args
                             .iter()
                             .map(|arg| {
-                                let info = self.generate(arg.value, ctx);
+                                let info =
+                                    self.generate_sequenced_operand(arg.value, ctx, !arg_diverged);
                                 arg_diverged |= !info.continues;
                                 info
                             })
@@ -1599,14 +1653,17 @@ impl<'a> ConstraintGenerator<'a> {
                         // panicking and process what we can.
                         // Still process all arguments to catch type errors within them
                         for arg in args.iter() {
-                            arg_diverged |= !self.generate(arg.value, ctx).continues;
+                            let info =
+                                self.generate_sequenced_operand(arg.value, ctx, !arg_diverged);
+                            arg_diverged |= !info.continues;
                         }
                         // Return the declared return type (error will be caught in sema)
                         func.return_type.clone()
                     } else {
                         // Generate constraints for each argument
                         for (arg, param_ty) in args.iter().zip(func.param_types.iter()) {
-                            let arg_info = self.generate(arg.value, ctx);
+                            let arg_info =
+                                self.generate_sequenced_operand(arg.value, ctx, !arg_diverged);
                             arg_diverged |= !arg_info.continues;
                             // Slice parameters coerce from an array argument
                             // (`borrow arr`); skip strict equality and let sema
@@ -1625,7 +1682,8 @@ impl<'a> ConstraintGenerator<'a> {
                 } else {
                     // Unknown function - still process arguments for constraint generation
                     for arg in args.iter() {
-                        arg_diverged |= !self.generate(arg.value, ctx).continues;
+                        let info = self.generate_sequenced_operand(arg.value, ctx, !arg_diverged);
+                        arg_diverged |= !info.continues;
                     }
                     InferType::Concrete(Type::ERROR)
                 };
@@ -1641,6 +1699,14 @@ impl<'a> ConstraintGenerator<'a> {
             InstData::Intrinsic { name, args } => {
                 let intrinsic_name = self.interner.resolve(name);
                 let args = self.rir.intrinsic_args(args);
+                let mut args_reachable = true;
+                macro_rules! generate_intrinsic_arg {
+                    ($arg:expr) => {{
+                        let info = self.generate_sequenced_operand($arg, ctx, args_reachable);
+                        args_reachable &= info.continues;
+                        info
+                    }};
+                }
 
                 let intrinsic_ty = if intrinsic_name == "intCast"
                     || intrinsic_name == "bitCast"
@@ -1656,7 +1722,7 @@ impl<'a> ConstraintGenerator<'a> {
                     for arg_ref in args.iter() {
                         // Process arguments for constraint generation; the
                         // integer check happens in sema.
-                        let _ = self.generate(*arg_ref, ctx);
+                        let _ = generate_intrinsic_arg!(*arg_ref);
                     }
                     // Return type is inferred from context - create a fresh type variable
                     let result_var = self.fresh_var();
@@ -1673,7 +1739,7 @@ impl<'a> ConstraintGenerator<'a> {
                         // Text-taking intrinsics accept every stable text view.
                         // Leave literals unconstrained so they take the
                         // canonical `str` default when std is not imported.
-                        self.generate(*arg_ref, ctx);
+                        generate_intrinsic_arg!(*arg_ref);
                     }
                     InferType::Concrete(Type::NEVER)
                 } else if intrinsic_name == "assert" {
@@ -1684,7 +1750,7 @@ impl<'a> ConstraintGenerator<'a> {
                     for arg_ref in args.iter() {
                         // As with `@panic`, a literal message keeps the stable
                         // `str` default instead of requiring imported StrBuf.
-                        self.generate(*arg_ref, ctx);
+                        generate_intrinsic_arg!(*arg_ref);
                     }
                     InferType::Concrete(Type::UNIT)
                 } else if intrinsic_name == "read_line" {
@@ -1703,7 +1769,7 @@ impl<'a> ConstraintGenerator<'a> {
                     // literal defaults to i32 like everywhere else. Sema checks
                     // the resolved type is an integer and widens per signedness.
                     for arg_ref in args.iter() {
-                        self.generate(*arg_ref, ctx);
+                        generate_intrinsic_arg!(*arg_ref);
                     }
                     self.string_infer_type()
                 } else if intrinsic_name == "parse_i32"
@@ -1716,7 +1782,7 @@ impl<'a> ConstraintGenerator<'a> {
                     // int type) is resolved from context, so use a fresh
                     // variable and let sema validate the resolved Option shape.
                     for arg_ref in args.iter() {
-                        let info = self.generate(*arg_ref, ctx);
+                        let info = generate_intrinsic_arg!(*arg_ref);
                         if self.is_string_literal_candidate(&info.ty) {
                             self.add_constraint(Constraint::equal(
                                 info.ty,
@@ -1741,7 +1807,7 @@ impl<'a> ConstraintGenerator<'a> {
                     // @arg_len(i) / @env_len(i): a single u64 index, returns u64
                     // (RUE-935).
                     for arg_ref in args.iter() {
-                        let info = self.generate(*arg_ref, ctx);
+                        let info = generate_intrinsic_arg!(*arg_ref);
                         self.add_constraint(Constraint::equal(
                             info.ty,
                             InferType::Concrete(Type::U64),
@@ -1753,7 +1819,7 @@ impl<'a> ConstraintGenerator<'a> {
                     // @arg_ptr(i) / @env_ptr(i): a single u64 index, returns
                     // `ptr mut u8` (RUE-935).
                     for arg_ref in args.iter() {
-                        let info = self.generate(*arg_ref, ctx);
+                        let info = generate_intrinsic_arg!(*arg_ref);
                         self.add_constraint(Constraint::equal(
                             info.ty,
                             InferType::Concrete(Type::U64),
@@ -1775,7 +1841,7 @@ impl<'a> ConstraintGenerator<'a> {
                     let result_var = self.fresh_var();
                     let result_ty = InferType::Var(result_var);
                     for arg_ref in args.iter() {
-                        let info = self.generate(*arg_ref, ctx);
+                        let info = generate_intrinsic_arg!(*arg_ref);
                         self.add_constraint(Constraint::equal(
                             info.ty,
                             result_ty.clone(),
@@ -1794,7 +1860,7 @@ impl<'a> ConstraintGenerator<'a> {
                     // argument keeps sema's targeted E0702 (`u64 for argument
                     // {i}`) instead of a generic unification E0206.
                     for arg_ref in args.iter() {
-                        let info = self.generate(*arg_ref, ctx);
+                        let info = generate_intrinsic_arg!(*arg_ref);
                         if matches!(self.rir.get(*arg_ref).data, InstData::IntConst(_)) {
                             self.add_constraint(Constraint::equal(
                                 info.ty,
@@ -1807,7 +1873,7 @@ impl<'a> ConstraintGenerator<'a> {
                 } else if intrinsic_name == "ptr_to_int" {
                     // @ptr_to_int: takes a pointer, returns u64
                     for arg_ref in args.iter() {
-                        self.generate(*arg_ref, ctx);
+                        generate_intrinsic_arg!(*arg_ref);
                     }
                     InferType::Concrete(Type::U64)
                 } else if intrinsic_name == "ptr_write" || intrinsic_name == "ptr_write_unaligned" {
@@ -1836,7 +1902,7 @@ impl<'a> ConstraintGenerator<'a> {
                     let typed_shape = args.len() == 2;
                     let mut pointee = None;
                     for (index, arg_ref) in args.iter().enumerate() {
-                        let info = self.generate(*arg_ref, ctx);
+                        let info = generate_intrinsic_arg!(*arg_ref);
                         if !typed_shape {
                             continue;
                         }
@@ -1882,7 +1948,7 @@ impl<'a> ConstraintGenerator<'a> {
                     let typed_shape = args.len() == 1;
                     let mut pointee = None;
                     for (index, arg_ref) in args.iter().enumerate() {
-                        let info = self.generate(*arg_ref, ctx);
+                        let info = generate_intrinsic_arg!(*arg_ref);
                         if typed_shape && index == 0 {
                             pointee = self.concrete_pointee_type(&info.ty);
                         }
@@ -1899,7 +1965,7 @@ impl<'a> ConstraintGenerator<'a> {
                     // The return type is the same as the input pointer type.
                     // We create a fresh type variable for proper inference.
                     for arg_ref in args.iter() {
-                        self.generate(*arg_ref, ctx);
+                        generate_intrinsic_arg!(*arg_ref);
                     }
                     let result_var = self.fresh_var();
                     InferType::Var(result_var)
@@ -1908,7 +1974,7 @@ impl<'a> ConstraintGenerator<'a> {
                     // pointer-shaped expression until accessor-yield analysis
                     // turns it into an indirect place.
                     for arg_ref in args.iter() {
-                        self.generate(*arg_ref, ctx);
+                        generate_intrinsic_arg!(*arg_ref);
                     }
                     let result_var = self.fresh_var();
                     InferType::Var(result_var)
@@ -1922,7 +1988,7 @@ impl<'a> ConstraintGenerator<'a> {
                     // so we create a fresh type variable for proper inference
                     // (Sema fixes it to `ptr const T`/`ptr mut T`).
                     for arg_ref in args.iter() {
-                        self.generate(*arg_ref, ctx);
+                        generate_intrinsic_arg!(*arg_ref);
                     }
                     let result_var = self.fresh_var();
                     InferType::Var(result_var)
@@ -1932,7 +1998,7 @@ impl<'a> ConstraintGenerator<'a> {
                     // operands are physical byte counts, so both are u64 and
                     // the result type is fixed rather than context-inferred.
                     for arg_ref in args.iter() {
-                        let info = self.generate(*arg_ref, ctx);
+                        let info = generate_intrinsic_arg!(*arg_ref);
                         self.add_constraint(Constraint::equal(
                             info.ty,
                             InferType::Concrete(Type::U64),
@@ -1950,7 +2016,7 @@ impl<'a> ConstraintGenerator<'a> {
                     let ptr_ty =
                         Type::new_ptr_mut(self.type_pool.intern_ptr_mut_from_type(Type::U8));
                     for (i, arg_ref) in args.iter().enumerate() {
-                        let info = self.generate(*arg_ref, ctx);
+                        let info = generate_intrinsic_arg!(*arg_ref);
                         let expected = if i == 0 { ptr_ty } else { Type::U64 };
                         self.add_constraint(Constraint::equal(
                             info.ty,
@@ -1968,7 +2034,7 @@ impl<'a> ConstraintGenerator<'a> {
                     let ptr_ty =
                         Type::new_ptr_mut(self.type_pool.intern_ptr_mut_from_type(Type::U8));
                     for (i, arg_ref) in args.iter().enumerate() {
-                        let info = self.generate(*arg_ref, ctx);
+                        let info = generate_intrinsic_arg!(*arg_ref);
                         let expected = if i == 0 { ptr_ty } else { Type::U64 };
                         self.add_constraint(Constraint::equal(
                             info.ty,
@@ -1988,7 +2054,7 @@ impl<'a> ConstraintGenerator<'a> {
                     let ptr_ty =
                         Type::new_ptr_mut(self.type_pool.intern_ptr_mut_from_type(Type::U8));
                     for (i, arg_ref) in args.iter().enumerate() {
-                        let info = self.generate(*arg_ref, ctx);
+                        let info = generate_intrinsic_arg!(*arg_ref);
                         let expected = match i {
                             0 => Some(ptr_ty),
                             2 => Some(Type::U64),
@@ -2008,7 +2074,7 @@ impl<'a> ConstraintGenerator<'a> {
                     let ptr_ty =
                         Type::new_ptr_mut(self.type_pool.intern_ptr_mut_from_type(Type::U8));
                     for (i, arg_ref) in args.iter().enumerate() {
-                        let info = self.generate(*arg_ref, ctx);
+                        let info = generate_intrinsic_arg!(*arg_ref);
                         let expected = match i {
                             0 => Some(ptr_ty),
                             1 => Some(Type::U8),
@@ -2027,7 +2093,7 @@ impl<'a> ConstraintGenerator<'a> {
                 } else if intrinsic_name == "int_to_ptr" {
                     // @int_to_ptr: returns a pointer type inferred from context
                     for arg_ref in args.iter() {
-                        self.generate(*arg_ref, ctx);
+                        generate_intrinsic_arg!(*arg_ref);
                     }
                     let result_var = self.fresh_var();
                     InferType::Var(result_var)
@@ -2074,7 +2140,7 @@ impl<'a> ConstraintGenerator<'a> {
                     // call on the binding unresolvable (RUE-142) and let a
                     // bare module expression coerce to `()` silently.
                     for arg_ref in args.iter() {
-                        self.generate(*arg_ref, ctx);
+                        generate_intrinsic_arg!(*arg_ref);
                     }
                     InferType::Concrete(Type::new_module(crate::types::ModuleId::UNRESOLVED))
                 } else if intrinsic_name == "dbg"
@@ -2083,7 +2149,7 @@ impl<'a> ConstraintGenerator<'a> {
                 {
                     // The remaining known intrinsics all return unit.
                     for arg_ref in args.iter() {
-                        self.generate(*arg_ref, ctx);
+                        generate_intrinsic_arg!(*arg_ref);
                     }
                     InferType::Concrete(Type::UNIT)
                 } else {
@@ -2093,16 +2159,14 @@ impl<'a> ConstraintGenerator<'a> {
                     // expected type — the same treatment @cast gets (RUE-319,
                     // here RUE-1281).
                     for arg_ref in args.iter() {
-                        self.generate(*arg_ref, ctx);
+                        generate_intrinsic_arg!(*arg_ref);
                     }
                     InferType::Var(self.fresh_var())
                 };
                 // Every intrinsic evaluates its operands strictly in source
                 // order.  Keep that control fact separate from the intrinsic's
                 // ordinary value type (notably `@assert`, which remains unit).
-                continues &= args
-                    .iter()
-                    .all(|arg_ref| self.expr_continues.get(&*arg_ref).copied().unwrap_or(true));
+                continues &= args_reachable;
                 intrinsic_ty
             }
 
@@ -2157,6 +2221,7 @@ impl<'a> ConstraintGenerator<'a> {
                 self.enter_scope(ctx);
                 let mut last_ty = InferType::Concrete(Type::UNIT);
                 let mut diverged = false;
+                let mut diverged_break_stack: Option<Vec<LoopBreakFact>> = None;
                 let block_insts = self.rir.block_insts(instructions);
                 for block_inst_ref in block_insts.values() {
                     let info = self.generate(block_inst_ref, ctx);
@@ -2171,7 +2236,13 @@ impl<'a> ConstraintGenerator<'a> {
                     if !diverged {
                         diverged = !info.continues;
                         last_ty = info.ty;
+                        if diverged {
+                            diverged_break_stack = Some(ctx.loop_break_stack.clone());
+                        }
                     }
+                }
+                if let Some(reachable_facts) = diverged_break_stack {
+                    restore_reachable_break_facts(&mut ctx.loop_break_stack, &reachable_facts);
                 }
                 self.exit_scope(ctx);
                 if diverged {
@@ -2189,6 +2260,7 @@ impl<'a> ConstraintGenerator<'a> {
                 else_block,
             } => {
                 let cond_info = self.generate(*cond, ctx);
+                let reachable_facts_after_condition = ctx.loop_break_stack.clone();
                 continues &= cond_info.continues;
                 self.add_constraint(Constraint::equal(
                     cond_info.ty,
@@ -2237,7 +2309,7 @@ impl<'a> ConstraintGenerator<'a> {
 
                 let then_info = self.generate(*then_block, ctx);
 
-                if let Some(else_ref) = else_block {
+                let branch_ty = if let Some(else_ref) = else_block {
                     let else_info = self.generate(*else_ref, ctx);
 
                     // Handle Never type coercion:
@@ -2283,12 +2355,20 @@ impl<'a> ConstraintGenerator<'a> {
                     // and retains the condition-false continuation even when
                     // the then branch diverges.
                     InferType::Concrete(Type::UNIT)
+                };
+                if !cond_info.continues {
+                    restore_reachable_break_facts(
+                        &mut ctx.loop_break_stack,
+                        &reachable_facts_after_condition,
+                    );
                 }
+                branch_ty
             }
 
             // While loop
             InstData::Loop { cond, body } => {
                 let cond_info = self.generate(*cond, ctx);
+                let reachable_facts_after_condition = ctx.loop_break_stack.clone();
                 continues &= cond_info.continues;
                 self.add_constraint(Constraint::equal(
                     cond_info.ty,
@@ -2297,10 +2377,16 @@ impl<'a> ConstraintGenerator<'a> {
                 ));
 
                 ctx.loop_depth += 1;
-                ctx.loop_break_stack.push(false);
+                ctx.loop_break_stack.push(LoopBreakFact::default());
                 self.generate(*body, ctx);
                 ctx.loop_break_stack.pop();
                 ctx.loop_depth -= 1;
+                if !cond_info.continues {
+                    restore_reachable_break_facts(
+                        &mut ctx.loop_break_stack,
+                        &reachable_facts_after_condition,
+                    );
+                }
 
                 // Loops produce unit
                 InferType::Concrete(Type::UNIT)
@@ -2309,14 +2395,15 @@ impl<'a> ConstraintGenerator<'a> {
             // Infinite loop
             InstData::InfiniteLoop { body, .. } => {
                 ctx.loop_depth += 1;
-                ctx.loop_break_stack.push(false);
+                ctx.loop_break_stack.push(LoopBreakFact::default());
                 self.generate(*body, ctx);
-                let has_break = ctx.loop_break_stack.pop().unwrap_or(false);
+                let break_fact = ctx.loop_break_stack.pop().unwrap_or_default();
                 ctx.loop_depth -= 1;
 
                 // An infinite loop with a break targeting it exits with unit;
                 // without one it never returns (see spec 4.8:17 / 4.8:21).
-                if has_break {
+                if break_fact.syntactic {
+                    continues = break_fact.reachable;
                     InferType::Concrete(Type::UNIT)
                 } else {
                     continues = false;
@@ -2330,8 +2417,9 @@ impl<'a> ConstraintGenerator<'a> {
                 match value {
                     None => {
                         // Record the break against the innermost enclosing loop.
-                        if let Some(broke) = ctx.loop_break_stack.last_mut() {
-                            *broke = true;
+                        if let Some(break_fact) = ctx.loop_break_stack.last_mut() {
+                            break_fact.syntactic = true;
+                            break_fact.reachable = true;
                         }
                     }
                     Some(v) => {
@@ -2354,6 +2442,7 @@ impl<'a> ConstraintGenerator<'a> {
             // Match expression
             InstData::Match { scrutinee, arms } => {
                 let scrutinee_info = self.generate(*scrutinee, ctx);
+                let reachable_facts_after_scrutinee = ctx.loop_break_stack.clone();
                 let arms = self.rir.match_arms(arms);
 
                 // Comptime-known scrutinee (spec 4.14:19): when the scrutinee
@@ -2372,6 +2461,12 @@ impl<'a> ConstraintGenerator<'a> {
                     self.enter_scope(ctx);
                     let body_info = self.generate(selected, ctx);
                     self.exit_scope(ctx);
+                    if !scrutinee_info.continues {
+                        restore_reachable_break_facts(
+                            &mut ctx.loop_break_stack,
+                            &reachable_facts_after_scrutinee,
+                        );
+                    }
                     self.record_type(inst_ref, body_info.ty.clone());
                     return ExprInfo::with_continues(
                         body_info.ty,
@@ -2473,6 +2568,12 @@ impl<'a> ConstraintGenerator<'a> {
 
                 if non_never_arms.is_empty() {
                     // All arms diverge - result is Never
+                    if !scrutinee_info.continues {
+                        restore_reachable_break_facts(
+                            &mut ctx.loop_break_stack,
+                            &reachable_facts_after_scrutinee,
+                        );
+                    }
                     InferType::Concrete(Type::NEVER)
                 } else {
                     // Create constraints for non-Never arms to have the same type
@@ -2484,6 +2585,12 @@ impl<'a> ConstraintGenerator<'a> {
                             result_ty.clone(),
                             arm_info.span,
                         ));
+                    }
+                    if !scrutinee_info.continues {
+                        restore_reachable_break_facts(
+                            &mut ctx.loop_break_stack,
+                            &reachable_facts_after_scrutinee,
+                        );
                     }
                     result_ty
                 }
@@ -2539,7 +2646,7 @@ impl<'a> ConstraintGenerator<'a> {
                     // (`S { a: 300 }` with a: u8 used to truncate to 44).
                     // (RUE-72)
                     for (field_name, value_ref) in fields.values() {
-                        let value_info = self.generate(value_ref, ctx);
+                        let value_info = self.generate_sequenced_operand(value_ref, ctx, continues);
                         continues &= value_info.continues;
                         if let Some(field_ty) = self.field_type_of(struct_ty, field_name) {
                             let expected = self.type_to_infer(field_ty);
@@ -2563,7 +2670,9 @@ impl<'a> ConstraintGenerator<'a> {
                     // with unresolved variables, which sema then reported as
                     // an internal compiler error (RUE-170).
                     for (_, value_ref) in fields.values() {
-                        continues &= self.generate(value_ref, ctx).continues;
+                        continues &= self
+                            .generate_sequenced_operand(value_ref, ctx, continues)
+                            .continues;
                     }
                     InferType::Concrete(Type::ERROR)
                 }
@@ -2676,8 +2785,8 @@ impl<'a> ConstraintGenerator<'a> {
 
             // Field assignment
             InstData::FieldSet { base, field, value } => {
-                let base_info = self.generate(*base, ctx);
                 let value_info = self.generate(*value, ctx);
+                let base_info = self.generate_sequenced_operand(*base, ctx, value_info.continues);
                 continues &= base_info.continues && value_info.continues;
                 // Constrain the assigned value against the field's declared
                 // type, so a literal RHS is range-checked at the field's width
@@ -2719,10 +2828,11 @@ impl<'a> ConstraintGenerator<'a> {
                     }
                 } else {
                     // Get element type from first element, constrain rest to match
-                    let first_info = self.generate(elements.get(0).unwrap(), ctx);
+                    let first_info =
+                        self.generate_sequenced_operand(elements.get(0).unwrap(), ctx, true);
                     continues &= first_info.continues;
                     for elem_ref in elements.values().skip(1) {
-                        let elem_info = self.generate(elem_ref, ctx);
+                        let elem_info = self.generate_sequenced_operand(elem_ref, ctx, continues);
                         continues &= elem_info.continues;
                         self.add_constraint(Constraint::equal(
                             elem_info.ty,
@@ -2793,14 +2903,18 @@ impl<'a> ConstraintGenerator<'a> {
 
             // Array index assignment
             InstData::IndexSet { base, index, value } => {
-                let base_info = self.generate(*base, ctx);
-                let index_info = self.generate(*index, ctx);
+                let value_info = self.generate(*value, ctx);
+                let base_info = self.generate_sequenced_operand(*base, ctx, value_info.continues);
+                let index_info = self.generate_sequenced_operand(
+                    *index,
+                    ctx,
+                    value_info.continues && base_info.continues,
+                );
                 // Index must be an integer type (signed or unsigned) per spec
                 // 7.1:7. Negative/out-of-range indices trap at runtime via the
                 // bounds check, not at compile time (RUE-81/RUE-87).
                 self.add_constraint(Constraint::is_integer(index_info.ty, index_info.span));
 
-                let value_info = self.generate(*value, ctx);
                 continues &= base_info.continues && index_info.continues && value_info.continues;
 
                 // Constrain value type to match array element type
@@ -2899,6 +3013,7 @@ impl<'a> ConstraintGenerator<'a> {
                 // Generate type for receiver
                 let receiver_info = self.generate(*receiver, ctx);
                 let call_args = self.rir.call_args(args);
+                let mut arg_diverged = !receiver_info.continues;
 
                 // A string literal is otherwise defaulted only after solving,
                 // but method lookup needs a receiver type while constraints
@@ -2924,7 +3039,9 @@ impl<'a> ConstraintGenerator<'a> {
                     let param_types = method_sig.param_types.clone();
                     let return_type = method_sig.return_type.clone();
                     for (arg, param_type) in call_args.iter().zip(param_types.iter()) {
-                        let arg_info = self.generate(arg.value, ctx);
+                        let arg_info =
+                            self.generate_sequenced_operand(arg.value, ctx, !arg_diverged);
+                        arg_diverged |= !arg_info.continues;
                         self.add_constraint(Constraint::equal(
                             arg_info.ty,
                             param_type.clone(),
@@ -2935,9 +3052,7 @@ impl<'a> ConstraintGenerator<'a> {
                     return ExprInfo::with_continues(
                         return_type.clone(),
                         span,
-                        receiver_info.continues
-                            && self.call_args_continue(args)
-                            && !Self::is_never_concrete(&return_type),
+                        !arg_diverged && !Self::is_never_concrete(&return_type),
                     );
                 }
 
@@ -2970,7 +3085,12 @@ impl<'a> ConstraintGenerator<'a> {
                                 // parameter type (same as a direct Call).
                                 for (arg, param_ty) in call_args.iter().zip(func.param_types.iter())
                                 {
-                                    let arg_info = self.generate(arg.value, ctx);
+                                    let arg_info = self.generate_sequenced_operand(
+                                        arg.value,
+                                        ctx,
+                                        !arg_diverged,
+                                    );
+                                    arg_diverged |= !arg_info.continues;
                                     // Slice and `borrow str` parameters coerce
                                     // from a `borrow` argument; skip strict
                                     // equality and let sema materialize the
@@ -2998,7 +3118,15 @@ impl<'a> ConstraintGenerator<'a> {
                                 // constrains, and same-file generic Calls do too).
                                 let arg_infos: Vec<ExprInfo> = call_args
                                     .iter()
-                                    .map(|arg| self.generate(arg.value, ctx))
+                                    .map(|arg| {
+                                        let info = self.generate_sequenced_operand(
+                                            arg.value,
+                                            ctx,
+                                            !arg_diverged,
+                                        );
+                                        arg_diverged |= !info.continues;
+                                        info
+                                    })
                                     .collect();
                                 let mut type_subst: AHashMap<lasso::Spur, Type> = AHashMap::new();
                                 let mut value_subst: AHashMap<lasso::Spur, i128> = AHashMap::new();
@@ -3059,7 +3187,12 @@ impl<'a> ConstraintGenerator<'a> {
                                 // Arity mismatch: just process the arguments;
                                 // sema checks the rest.
                                 for arg in call_args.iter() {
-                                    self.generate(arg.value, ctx);
+                                    let info = self.generate_sequenced_operand(
+                                        arg.value,
+                                        ctx,
+                                        !arg_diverged,
+                                    );
+                                    arg_diverged |= !info.continues;
                                 }
                             }
                             if func.return_type == InferType::Concrete(Type::COMPTIME_TYPE) {
@@ -3072,7 +3205,9 @@ impl<'a> ConstraintGenerator<'a> {
                         } else {
                             // Unknown member - sema reports UndefinedFunction
                             for arg in call_args.iter() {
-                                self.generate(arg.value, ctx);
+                                let info =
+                                    self.generate_sequenced_operand(arg.value, ctx, !arg_diverged);
+                                arg_diverged |= !info.continues;
                             }
                             InferType::Concrete(Type::ERROR)
                         }
@@ -3118,7 +3253,9 @@ impl<'a> ConstraintGenerator<'a> {
                             result
                         } else {
                             for arg in call_args.iter() {
-                                self.generate(arg.value, ctx);
+                                let info =
+                                    self.generate_sequenced_operand(arg.value, ctx, !arg_diverged);
+                                arg_diverged |= !info.continues;
                             }
                             InferType::Var(self.fresh_var())
                         }
@@ -3153,7 +3290,12 @@ impl<'a> ConstraintGenerator<'a> {
                                     // (RUE-634/RUE-636).
                                     let defer_equality =
                                         self.is_slice_struct_type(param_type.clone());
-                                    let arg_info = self.generate(arg.value, ctx);
+                                    let arg_info = self.generate_sequenced_operand(
+                                        arg.value,
+                                        ctx,
+                                        !arg_diverged,
+                                    );
+                                    arg_diverged |= !arg_info.continues;
                                     if !defer_equality {
                                         self.add_constraint(Constraint::equal(
                                             arg_info.ty,
@@ -3167,14 +3309,21 @@ impl<'a> ConstraintGenerator<'a> {
                                 // Method not found - sema will report the error
                                 // Still generate arg types to catch errors in arguments
                                 for arg in call_args.iter() {
-                                    self.generate(arg.value, ctx);
+                                    let info = self.generate_sequenced_operand(
+                                        arg.value,
+                                        ctx,
+                                        !arg_diverged,
+                                    );
+                                    arg_diverged |= !info.continues;
                                 }
                                 InferType::Concrete(Type::ERROR)
                             }
                         } else {
                             // Non-struct receiver - sema will report the error
                             for arg in call_args.iter() {
-                                self.generate(arg.value, ctx);
+                                let info =
+                                    self.generate_sequenced_operand(arg.value, ctx, !arg_diverged);
+                                arg_diverged |= !info.continues;
                             }
                             InferType::Concrete(Type::ERROR)
                         }
@@ -3208,15 +3357,15 @@ impl<'a> ConstraintGenerator<'a> {
                             result
                         } else {
                             for arg in call_args.iter() {
-                                self.generate(arg.value, ctx);
+                                let info =
+                                    self.generate_sequenced_operand(arg.value, ctx, !arg_diverged);
+                                arg_diverged |= !info.continues;
                             }
                             InferType::Var(self.fresh_var())
                         }
                     }
                 };
-                continues &= receiver_info.continues
-                    && self.call_args_continue(args)
-                    && !Self::is_never_concrete(&result_type);
+                continues &= !arg_diverged && !Self::is_never_concrete(&result_type);
 
                 result_type
             }
@@ -3284,7 +3433,11 @@ impl<'a> ConstraintGenerator<'a> {
         ctx: &mut ConstraintContext,
     ) -> InferType {
         let lhs_info = self.generate(lhs, ctx);
+        let reachable_facts_after_lhs = ctx.loop_break_stack.clone();
         let rhs_info = self.generate(rhs, ctx);
+        if !lhs_info.continues {
+            restore_reachable_break_facts(&mut ctx.loop_break_stack, &reachable_facts_after_lhs);
+        }
 
         // A diverging operand (`!`, e.g. `n - match m {}`) makes the whole
         // expression diverge. Never coerces to any type (spec 3.4:3-4), so
@@ -3343,7 +3496,11 @@ impl<'a> ConstraintGenerator<'a> {
         ctx: &mut ConstraintContext,
     ) -> InferType {
         let lhs_info = self.generate(lhs, ctx);
+        let reachable_facts_after_lhs = ctx.loop_break_stack.clone();
         let rhs_info = self.generate(rhs, ctx);
+        if !lhs_info.continues {
+            restore_reachable_break_facts(&mut ctx.loop_break_stack, &reachable_facts_after_lhs);
+        }
         self.expr_continues
             .insert(inst_ref, lhs_info.continues && rhs_info.continues);
 
@@ -3508,8 +3665,10 @@ impl<'a> ConstraintGenerator<'a> {
                 .find_variant(self.interner.resolve(&function))
                 .map(|vidx| def.variant_payload(vidx).to_vec())?;
             let args = self.rir.call_args(args);
+            let mut arg_diverged = false;
             for (i, arg) in args.iter().enumerate() {
-                let arg_info = self.generate(arg.value, ctx);
+                let arg_info = self.generate_sequenced_operand(arg.value, ctx, !arg_diverged);
+                arg_diverged |= !arg_info.continues;
                 if let Some(&pty) = payload.get(i) {
                     // Convert the declared payload type structurally so an array
                     // payload (`[i32; 2]`) unifies with an array-literal argument
@@ -3524,9 +3683,11 @@ impl<'a> ConstraintGenerator<'a> {
         let struct_id = ty.as_struct()?;
         let method_sig = self.method_sig(&(struct_id, function))?;
         let args = self.rir.call_args(args);
+        let mut arg_diverged = false;
         for (arg, param_type) in args.iter().zip(method_sig.param_types.iter()) {
             let defer_equality = self.is_slice_struct_type(param_type.clone());
-            let arg_info = self.generate(arg.value, ctx);
+            let arg_info = self.generate_sequenced_operand(arg.value, ctx, !arg_diverged);
+            arg_diverged |= !arg_info.continues;
             if !defer_equality {
                 self.add_constraint(Constraint::equal(
                     arg_info.ty,

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -131,10 +131,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let mut payload_refs: Vec<AirRef> = Vec::with_capacity(args.len());
         let mut continues = true;
         for (i, arg) in args.iter().enumerate() {
+            let reachable_edges_before_arg = ctx.loop_break_stack.clone();
             let expected = payload_types[i];
             let arg_result = ctx
                 .with_expected_type(Some(expected), |ctx| self.analyze_inst(air, arg.value, ctx))?;
             let actual = arg_result.ty;
+            if !continues {
+                Self::restore_reachable_loop_edges(ctx, &reachable_edges_before_arg);
+            }
             continues &= arg_result.continues;
             if !self.types_compatible(actual, expected) && actual != Type::ERROR {
                 return Err(self.type_mismatch_error(
@@ -497,6 +501,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let mut source_order: Vec<usize> = Vec::with_capacity(field_inits.len());
 
         for &(init_field_name, field_value) in &field_inits {
+            let reachable_edges_before_field = ctx.loop_break_stack.clone();
             let init_name = self.body_interner().resolve(&init_field_name).to_owned();
             let field_idx = field_index_map[init_name.as_str()];
             let expected_field_type = struct_def.fields[field_idx].ty;
@@ -539,6 +544,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 // Not an integer literal - analyze normally
                 self.analyze_inst(air, field_value, ctx)?
             };
+            if !continues {
+                Self::restore_reachable_loop_edges(ctx, &reachable_edges_before_field);
+            }
             continues &= field_result.continues;
 
             // An accessor result is a second-class borrowed place (ADR-0062):
@@ -1194,7 +1202,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let mut air_elems = Vec::with_capacity(elem_refs.len());
         let mut continues = true;
         for elem_ref in elem_refs {
+            let reachable_edges_before_elem = ctx.loop_break_stack.clone();
             let elem_result = self.analyze_inst(air, elem_ref, ctx)?;
+            if !continues {
+                Self::restore_reachable_loop_edges(ctx, &reachable_edges_before_elem);
+            }
             continues &= elem_result.continues;
             // An accessor result cannot be captured as an array element
             // (ADR-0062): the member would store a second-class borrow.

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -300,7 +300,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         F: FnOnce(AirRef, AirRef) -> AirInstData,
     {
         let lhs_result = self.analyze_inst(air, lhs, ctx)?;
+        let reachable_edges_after_lhs = ctx.loop_break_stack.clone();
         let rhs_result = self.analyze_inst(air, rhs, ctx)?;
+        if !lhs_result.continues {
+            Self::restore_reachable_loop_edges(ctx, &reachable_edges_after_lhs);
+        }
 
         if !lhs_result.continues || !rhs_result.continues {
             let air_ref = air.add_inst(AirInst {
@@ -368,19 +372,27 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         );
         let (lhs_result, rhs_result) = if lhs_is_literal {
             let rhs_result = self.analyze_inst_for_projection(air, rhs, ctx)?;
+            let reachable_edges_after_rhs = ctx.loop_break_stack.clone();
             let expected = (self.is_strbuf(rhs_result.ty) || self.is_str_like(rhs_result.ty))
                 .then_some(rhs_result.ty);
             let lhs_result = ctx.with_expected_type(expected, |ctx| {
                 self.analyze_inst_for_projection(air, lhs, ctx)
             })?;
+            if !rhs_result.continues {
+                Self::restore_reachable_loop_edges(ctx, &reachable_edges_after_rhs);
+            }
             (lhs_result, rhs_result)
         } else {
             let lhs_result = self.analyze_inst_for_projection(air, lhs, ctx)?;
+            let reachable_edges_after_lhs = ctx.loop_break_stack.clone();
             let expected = (self.is_strbuf(lhs_result.ty) || self.is_str_like(lhs_result.ty))
                 .then_some(lhs_result.ty);
             let rhs_result = ctx.with_expected_type(expected, |ctx| {
                 self.analyze_inst_for_projection(air, rhs, ctx)
             })?;
+            if !lhs_result.continues {
+                Self::restore_reachable_loop_edges(ctx, &reachable_edges_after_lhs);
+            }
             (lhs_result, rhs_result)
         };
         let lhs_type = lhs_result.ty;

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -842,6 +842,21 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
     // Helper methods for intrinsic analysis (delegated from analyze_intrinsic_impl)
 
+    fn analyze_sequenced_intrinsic_operand(
+        &mut self,
+        air: &mut Air,
+        operand: InstRef,
+        reachable: bool,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        let reachable_edges = ctx.loop_break_stack.clone();
+        let result = self.analyze_inst(air, operand, ctx)?;
+        if !reachable {
+            Self::restore_reachable_loop_edges(ctx, &reachable_edges);
+        }
+        Ok(result)
+    }
+
     pub(super) fn analyze_dbg_intrinsic(
         &mut self,
         air: &mut Air,
@@ -1140,7 +1155,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let mut extra_data = vec![cond_result.air_ref];
         let mut temp_scope = Vec::new();
         if args.len() > 1 {
+            let reachable_edges_before_message = ctx.loop_break_stack.clone();
             let msg_result = self.analyze_inst_for_projection(air, args[1].value, ctx)?;
+            if !cond_result.continues {
+                Self::restore_reachable_loop_edges(ctx, &reachable_edges_before_message);
+            }
             self.validate_abort_message_type(
                 "assert",
                 msg_result.ty,
@@ -1962,8 +1981,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ));
         }
 
-        let lhs = self.analyze_inst(air, args[0].value, ctx)?;
-        let rhs = self.analyze_inst(air, args[1].value, ctx)?;
+        let lhs = self.analyze_sequenced_intrinsic_operand(air, args[0].value, true, ctx)?;
+        let rhs =
+            self.analyze_sequenced_intrinsic_operand(air, args[1].value, lhs.continues, ctx)?;
         let lty = lhs.ty;
         let rty = rhs.ty;
 

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -5,7 +5,7 @@
 //! them. It extends the canonical body-analysis engine rather than
 //! introducing peer analysis state.
 
-use super::super::context::{LocalVar, ParamInfo, VariableMoveState};
+use super::super::context::{FieldPath, LocalVar, ParamInfo, VariableMoveState};
 use super::super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
 use super::*;
 use crate::inst::AirPlaceRef;
@@ -3942,6 +3942,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         ctx.expected_type = previous_expected;
         let value_result = value_result?;
         self.reject_accessor_result_escape(value, AccessorEscapeSite::Store, span, ctx)?;
+        let reachable_edges_after_rhs = ctx.loop_break_stack.clone();
         // A plain assignment's RHS is complete before the LHS place is
         // evaluated. Ordinary shared-read markers are expression-order
         // bookkeeping and can be truncated before the target is traced;
@@ -3967,6 +3968,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 let trace = self
                     .try_trace_place(place, air, ctx)?
                     .ok_or_else(|| CompileError::new(ErrorKind::InvalidAssignmentTarget, span))?;
+                if !value_result.continues {
+                    Self::restore_reachable_loop_edges(ctx, &reachable_edges_after_rhs);
+                }
                 if !trace.via_accessor || !trace.is_root_mutable {
                     return Err(CompileError::new(ErrorKind::InvalidAssignmentTarget, span));
                 }
@@ -4015,8 +4019,18 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // Try to trace the base to a place
-        if let Some(mut trace) = self.try_trace_place(base, air, ctx)? {
+        // Assignment evaluates the RHS before the target (spec 5.2:17-18).
+        // Analyze the value first, then keep any target edges from a dead RHS
+        // out of the enclosing loop's reachable control-flow facts.
+        let value_result = self.analyze_inst(air, value, ctx)?;
+        self.reject_accessor_result_escape(value, AccessorEscapeSite::Store, span, ctx)?;
+        let reachable_edges_after_value = ctx.loop_break_stack.clone();
+        let traced = self.try_trace_place(base, air, ctx)?;
+        if !value_result.continues {
+            Self::restore_reachable_loop_edges(ctx, &reachable_edges_after_value);
+        }
+
+        if let Some(mut trace) = traced {
             // Check if the root variable was fully moved
             if let Some(state) = ctx.moved_vars.get(&trace.root_var) {
                 if let Some(moved_span) = state.full_move {
@@ -4116,11 +4130,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // A write through an element of a partially moved array
             // (`xs[0].f = ...` after an element of `xs` moved out) is
             // rejected (RUE-186, E0480), like a direct element write.
-            self.reject_write_into_partially_moved_array(&trace, ctx, span)?;
-
-            // Analyze the value
-            let value_result = self.analyze_inst(air, value, ctx)?;
-            self.reject_accessor_result_escape(value, AccessorEscapeSite::Store, span, ctx)?;
+            self.reject_write_into_partially_moved_array(&trace, ctx, span, None)?;
 
             // RUE-387: writing a live linear value's field would silently drop
             // the old field value. Legal only when that exact field path was
@@ -4194,8 +4204,28 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // Try to trace the base to a place
-        if let Some(mut trace) = self.try_trace_place(base, air, ctx)? {
+        // Keep the one shape that can reinitialize itself: a direct constant
+        // element read from the same root array.  The RHS is analyzed first,
+        // so its element move is present when the target-side partial-array
+        // guard runs; remember that this exact path was new before the RHS.
+        let rhs_element = self.direct_constant_array_element_path(value);
+        let rhs_element_was_unmoved = rhs_element.as_ref().is_some_and(|(root, path)| {
+            ctx.moved_vars
+                .get(root)
+                .is_none_or(|state| state.is_path_or_descendant_moved(path).is_none())
+        });
+        // Assignment evaluates the RHS before the target and index
+        // (spec 5.2:17-18). Analyze the value first so dead target edges do
+        // not become reachable loop back edges.
+        let value_result = self.analyze_inst(air, value, ctx)?;
+        self.reject_accessor_result_escape(value, AccessorEscapeSite::Store, span, ctx)?;
+        let reachable_edges_after_rhs = ctx.loop_break_stack.clone();
+        let traced = self.try_trace_place(base, air, ctx)?;
+        if !value_result.continues {
+            Self::restore_reachable_loop_edges(ctx, &reachable_edges_after_rhs);
+        }
+
+        if let Some(mut trace) = traced {
             // Check if the root variable was fully moved
             if let Some(state) = ctx.moved_vars.get(&trace.root_var) {
                 if let Some(moved_span) = state.full_move {
@@ -4271,7 +4301,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // Analyze index. Index must be an integer type (signed or
             // unsigned) per spec 7.1:7; negative/out-of-range runtime indices
             // trap at runtime via the bounds check (RUE-81).
+            let reachable_edges_before_index = ctx.loop_break_stack.clone();
             let index_result = self.analyze_inst(air, index, ctx)?;
+            if !(value_result.continues && trace.continues) {
+                Self::restore_reachable_loop_edges(ctx, &reachable_edges_before_index);
+            }
             if !index_result.ty.is_integer() && !index_result.ty.is_error() {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
@@ -4319,11 +4353,22 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
             // Writing into an array with moved-out elements is rejected
             // (RUE-186, E0480): the write can't re-arm per-element ownership.
-            self.reject_write_into_partially_moved_array(&trace, ctx, span)?;
-
-            // Analyze the value
-            let value_result = self.analyze_inst(air, value, ctx)?;
-            self.reject_accessor_result_escape(value, AccessorEscapeSite::Store, span, ctx)?;
+            let reinitialized_path = rhs_element
+                .filter(|(root, path)| {
+                    rhs_element_was_unmoved
+                        && *root == trace.root_var
+                        && path == &trace.field_path()
+                        && ctx.moved_vars.get(root).is_some_and(|state| {
+                            state.partial_moves.iter().any(|(moved, _)| moved == path)
+                        })
+                })
+                .map(|(_, path)| path);
+            self.reject_write_into_partially_moved_array(
+                &trace,
+                ctx,
+                span,
+                reinitialized_path.as_deref(),
+            )?;
 
             // RUE-387: writing a live linear value into an array element would
             // silently drop the old element. Legal only when that exact
@@ -5280,15 +5325,18 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// Reject a write into an array place while one or more of the root
     /// array's elements are moved out (RUE-186, E0480). Re-arming
     /// per-element ownership through an element (or through-element) write
-    /// is not supported — sema-side reinitialization and the runtime drop
-    /// flags would disagree — so the whole array must be reinitialized
-    /// instead. Writes into arrays with no outstanding element moves are
-    /// unaffected.
+    /// is not supported in general — sema-side reinitialization and the
+    /// runtime drop flags would disagree — so the whole array must be
+    /// reinitialized instead. The sole exception is an immediate direct
+    /// same-element self-move, whose exact path is passed as `except_path` and
+    /// re-armed by the caller. Writes into arrays with no outstanding element
+    /// moves are unaffected.
     fn reject_write_into_partially_moved_array(
         &self,
         trace: &PlaceTrace,
         ctx: &AnalysisContext,
         span: Span,
+        except_path: Option<&[Spur]>,
     ) -> CompileResult<()> {
         // The write must go through the root array (position-0 Index
         // projection); element moves only exist for array roots.
@@ -5302,6 +5350,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return Ok(());
         };
         let element_move_span = state.partial_moves.iter().find_map(|(p, s)| {
+            if except_path.is_some_and(|except| p.as_slice() == except) {
+                return None;
+            }
             p.first()
                 .filter(|seg| is_index_segment(self.body_interner(), **seg))
                 .map(|_| *s)
@@ -5315,6 +5366,32 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 .with_label("element moved out here", moved_span)
                 .with_help("reinitialize the whole array instead (`xs = [...]`)"),
         )
+    }
+
+    /// Return the path tracked by a direct constant-index array read, if any.
+    ///
+    /// This intentionally accepts only `array[K]` rooted directly at a
+    /// variable. Nested projections and dynamic indices must remain subject to
+    /// the conservative partial-array write rejection.
+    fn direct_constant_array_element_path(
+        &mut self,
+        inst_ref: InstRef,
+    ) -> Option<(Spur, FieldPath)> {
+        let (base, index) = match &self.body_rir_ref().get(inst_ref).data {
+            InstData::IndexGet { base, index } => (*base, *index),
+            _ => return None,
+        };
+        let root = match &self.body_rir_ref().get(base).data {
+            InstData::VarRef { name, .. } => *name,
+            _ => return None,
+        };
+        let index = self.try_get_const_index(index)?;
+        (index >= 0).then(|| {
+            (
+                root,
+                vec![index_path_segment(self.body_interner(), index as u64)],
+            )
+        })
     }
 
     /// Extract the root variable symbol from an expression, if it refers to a variable.
@@ -5865,6 +5942,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let mut temp_scope: Vec<AirRef> = Vec::new();
         let mut continues = true;
         for (i, arg) in args.enumerate() {
+            let reachable_edges_before_arg = ctx.loop_break_stack.clone();
             // A `str` parameter (ADR-0043 Phase 3, RUE-324) is a first-class
             // 2-word value, not a `borrow`-materialized fat pointer. A string
             // literal argument materializes as a `str` under the expected type;
@@ -5911,6 +5989,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 let arg_result = self.analyze_inst(air, arg.value, ctx);
                 ctx.expected_type = prev_expected;
                 let arg_result = arg_result?;
+                if !continues {
+                    Self::restore_reachable_loop_edges(ctx, &reachable_edges_before_arg);
+                }
                 continues &= arg_result.continues;
                 // `Str(N)` is a nominal fixed-capacity value, not a bare
                 // string view. Contextual literals materialize directly as
@@ -6032,6 +6113,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             }
             ctx.byref_arg_root = prev_byref_root;
             let mut arg_result = arg_result?;
+            if !continues {
+                Self::restore_reachable_loop_edges(ctx, &reachable_edges_before_arg);
+            }
             continues &= arg_result.continues;
             if elaborates_borrow {
                 let span = self.body_rir_ref().get(arg.value).span;

--- a/crates/rue-air/src/sema/analysis/pointers.rs
+++ b/crates/rue-air/src/sema/analysis/pointers.rs
@@ -7,6 +7,21 @@ use super::super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine
 use super::*;
 
 impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
+    fn analyze_sequenced_pointer_operand(
+        &mut self,
+        air: &mut Air,
+        operand: InstRef,
+        reachable: bool,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        let reachable_edges = ctx.loop_break_stack.clone();
+        let result = self.analyze_inst(air, operand, ctx)?;
+        if !reachable {
+            Self::restore_reachable_loop_edges(ctx, &reachable_edges);
+        }
+        Ok(result)
+    }
+
     /// Analyze @ptr_read / @ptr_read_unaligned intrinsic: reads value through
     /// pointer. Signature: `@ptr_read(ptr: ptr const T) -> T`.
     ///
@@ -154,6 +169,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // struct-init field-literal coercion in `analyze_struct_init`; the
         // range check keeps `@ptr_write(p_u8, 300)` an honest E0800.
         let value_inst = self.body_rir_ref().get(args[1].value);
+        let reachable_edges_before_value = ctx.loop_break_stack.clone();
         let value_result = match &value_inst.data {
             InstData::IntConst(value) if pointee_type.is_integer() => {
                 if !pointee_type.literal_fits(*value) {
@@ -176,6 +192,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 self.analyze_inst(air, args[1].value, ctx)
             })?,
         };
+        if !ptr_result.continues {
+            Self::restore_reachable_loop_edges(ctx, &reachable_edges_before_value);
+        }
         let value_type = value_result.ty;
 
         // Check that value type matches pointee type
@@ -225,8 +244,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ));
         }
 
-        let ptr_result = self.analyze_inst(air, args[0].value, ctx)?;
-        let offset_result = self.analyze_inst(air, args[1].value, ctx)?;
+        let ptr_result = self.analyze_sequenced_pointer_operand(air, args[0].value, true, ctx)?;
+        let offset_result =
+            self.analyze_sequenced_pointer_operand(air, args[1].value, ptr_result.continues, ctx)?;
         let ptr_type = ptr_result.ty;
         let offset_type = offset_result.ty;
 
@@ -418,9 +438,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 span,
             ));
         }
-        let size = self.analyze_inst(air, args[0].value, ctx)?;
+        let size = self.analyze_sequenced_pointer_operand(air, args[0].value, true, ctx)?;
         self.require_intrinsic_type(&intrinsic, size.ty, Type::U64, span)?;
-        let align = self.analyze_inst(air, args[1].value, ctx)?;
+        let align =
+            self.analyze_sequenced_pointer_operand(air, args[1].value, size.continues, ctx)?;
         self.require_intrinsic_type(&intrinsic, align.ty, Type::U64, span)?;
         self.require_power_of_two_align(&intrinsic, args[1].value, span, ctx)?;
         let result_ty = Type::new_ptr_mut(self.body_type_pool().intern_ptr_mut_from_type(Type::U8));
@@ -471,11 +492,22 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 span,
             ));
         }
-        let ptr = self.analyze_inst(air, args[0].value, ctx)?;
+        let ptr = self.analyze_sequenced_pointer_operand(air, args[0].value, true, ctx)?;
         self.require_mut_u8_pointer("realloc", ptr.ty, span)?;
-        let old_size = self.analyze_inst(air, args[1].value, ctx)?;
-        let align = self.analyze_inst(air, args[2].value, ctx)?;
-        let new_size = self.analyze_inst(air, args[3].value, ctx)?;
+        let old_size =
+            self.analyze_sequenced_pointer_operand(air, args[1].value, ptr.continues, ctx)?;
+        let align = self.analyze_sequenced_pointer_operand(
+            air,
+            args[2].value,
+            ptr.continues && old_size.continues,
+            ctx,
+        )?;
+        let new_size = self.analyze_sequenced_pointer_operand(
+            air,
+            args[3].value,
+            ptr.continues && old_size.continues && align.continues,
+            ctx,
+        )?;
         self.require_intrinsic_type("realloc", old_size.ty, Type::U64, span)?;
         self.require_intrinsic_type("realloc", align.ty, Type::U64, span)?;
         self.require_intrinsic_type("realloc", new_size.ty, Type::U64, span)?;
@@ -524,11 +556,22 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 span,
             ));
         }
-        let ptr = self.analyze_inst(air, args[0].value, ctx)?;
+        let ptr = self.analyze_sequenced_pointer_operand(air, args[0].value, true, ctx)?;
         self.require_mut_u8_pointer("resize", ptr.ty, span)?;
-        let old_size = self.analyze_inst(air, args[1].value, ctx)?;
-        let align = self.analyze_inst(air, args[2].value, ctx)?;
-        let new_size = self.analyze_inst(air, args[3].value, ctx)?;
+        let old_size =
+            self.analyze_sequenced_pointer_operand(air, args[1].value, ptr.continues, ctx)?;
+        let align = self.analyze_sequenced_pointer_operand(
+            air,
+            args[2].value,
+            ptr.continues && old_size.continues,
+            ctx,
+        )?;
+        let new_size = self.analyze_sequenced_pointer_operand(
+            air,
+            args[3].value,
+            ptr.continues && old_size.continues && align.continues,
+            ctx,
+        )?;
         self.require_intrinsic_type("resize", old_size.ty, Type::U64, span)?;
         self.require_intrinsic_type("resize", align.ty, Type::U64, span)?;
         self.require_intrinsic_type("resize", new_size.ty, Type::U64, span)?;
@@ -573,10 +616,16 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 span,
             ));
         }
-        let ptr = self.analyze_inst(air, args[0].value, ctx)?;
+        let ptr = self.analyze_sequenced_pointer_operand(air, args[0].value, true, ctx)?;
         self.require_mut_u8_pointer("free", ptr.ty, span)?;
-        let size = self.analyze_inst(air, args[1].value, ctx)?;
-        let align = self.analyze_inst(air, args[2].value, ctx)?;
+        let size =
+            self.analyze_sequenced_pointer_operand(air, args[1].value, ptr.continues, ctx)?;
+        let align = self.analyze_sequenced_pointer_operand(
+            air,
+            args[2].value,
+            ptr.continues && size.continues,
+            ctx,
+        )?;
         self.require_intrinsic_type("free", size.ty, Type::U64, span)?;
         self.require_intrinsic_type("free", align.ty, Type::U64, span)?;
         self.require_power_of_two_align("free", args[2].value, span, ctx)?;
@@ -649,11 +698,16 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 span,
             ));
         }
-        let dst = self.analyze_inst(air, args[0].value, ctx)?;
+        let dst = self.analyze_sequenced_pointer_operand(air, args[0].value, true, ctx)?;
         self.require_mut_u8_pointer(&intrinsic, dst.ty, span)?;
-        let src = self.analyze_inst(air, args[1].value, ctx)?;
+        let src = self.analyze_sequenced_pointer_operand(air, args[1].value, dst.continues, ctx)?;
         self.require_u8_pointer(&intrinsic, src.ty, span)?;
-        let size = self.analyze_inst(air, args[2].value, ctx)?;
+        let size = self.analyze_sequenced_pointer_operand(
+            air,
+            args[2].value,
+            dst.continues && src.continues,
+            ctx,
+        )?;
         self.require_intrinsic_type(&intrinsic, size.ty, Type::U64, span)?;
         let overlapping = name == self.known_symbols().byte_move;
         let air_ref = air.add_intrinsic(
@@ -696,11 +750,17 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 span,
             ));
         }
-        let dst = self.analyze_inst(air, args[0].value, ctx)?;
+        let dst = self.analyze_sequenced_pointer_operand(air, args[0].value, true, ctx)?;
         self.require_mut_u8_pointer("byte_set", dst.ty, span)?;
-        let byte = self.analyze_inst(air, args[1].value, ctx)?;
+        let byte =
+            self.analyze_sequenced_pointer_operand(air, args[1].value, dst.continues, ctx)?;
         self.require_intrinsic_type("byte_set", byte.ty, Type::U8, span)?;
-        let size = self.analyze_inst(air, args[2].value, ctx)?;
+        let size = self.analyze_sequenced_pointer_operand(
+            air,
+            args[2].value,
+            dst.continues && byte.continues,
+            ctx,
+        )?;
         self.require_intrinsic_type("byte_set", size.ty, Type::U64, span)?;
         let air_ref = air.add_intrinsic(
             Some(crate::RuntimeCallKind::ByteSet),
@@ -950,7 +1010,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let mut arg_refs = Vec::with_capacity(args.len());
         let mut continues = true;
         for (i, arg) in args.iter().enumerate() {
+            let reachable_edges_before_arg = ctx.loop_break_stack.clone();
             let arg_result = self.analyze_inst(air, arg.value, ctx)?;
+            if !continues {
+                Self::restore_reachable_loop_edges(ctx, &reachable_edges_before_arg);
+            }
             continues &= arg_result.continues;
             let arg_type = arg_result.ty;
 

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -329,7 +329,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         match &inst.data {
             InstData::And { lhs, rhs } => {
                 let lhs_result = self.analyze_inst(air, *lhs, ctx)?;
+                let reachable_edges_after_lhs = ctx.loop_break_stack.clone();
                 let rhs_result = self.analyze_inst(air, *rhs, ctx)?;
+                if !lhs_result.continues {
+                    Self::restore_reachable_loop_edges(ctx, &reachable_edges_after_lhs);
+                }
 
                 if !lhs_result.continues || !rhs_result.continues {
                     let air_ref = air.add_inst(AirInst {
@@ -350,7 +354,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
             InstData::Or { lhs, rhs } => {
                 let lhs_result = self.analyze_inst(air, *lhs, ctx)?;
+                let reachable_edges_after_lhs = ctx.loop_break_stack.clone();
                 let rhs_result = self.analyze_inst(air, *rhs, ctx)?;
+                if !lhs_result.continues {
+                    Self::restore_reachable_loop_edges(ctx, &reachable_edges_after_lhs);
+                }
 
                 if !lhs_result.continues || !rhs_result.continues {
                     let air_ref = air.add_inst(AirInst {

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -27,6 +27,22 @@ use crate::scope::ScopedContext;
 use crate::types::{Type, TypeKind};
 
 impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
+    /// Discard edge snapshots collected while analyzing code after a
+    /// diverging child expression. Keep syntactic `break` classification for
+    /// loop typing, but only retain moves from edges reachable at this
+    /// sequencing boundary (spec 4.8:21; RUE-1615).
+    pub(super) fn restore_reachable_loop_edges(
+        ctx: &mut AnalysisContext,
+        reachable_edges: &[LoopEdgeStates],
+    ) {
+        assert_eq!(reachable_edges.len(), ctx.loop_break_stack.len());
+        let mut restored = reachable_edges.to_vec();
+        for (reachable, analyzed) in restored.iter_mut().zip(&ctx.loop_break_stack) {
+            reachable.broke |= analyzed.broke;
+        }
+        ctx.loop_break_stack = restored;
+    }
+
     /// Analyze a control flow instruction.
     ///
     /// Handles: Branch, Loop, InfiniteLoop, Match, Break, Continue, Ret, Block
@@ -235,6 +251,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let cond_result = ctx.with_expected_type(None, |ctx| self.analyze_inst(air, cond, ctx));
         ctx.exit_full_expression(boundary);
         let cond_result = cond_result?;
+        let reachable_edges_after_condition = ctx.loop_break_stack.clone();
 
         if let Some(else_b) = else_block {
             // Save move state before entering branches.
@@ -270,6 +287,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
             // Capture else-branch's move state
             let else_moves = ctx.moved_vars.clone();
+
+            if !cond_result.continues {
+                Self::restore_reachable_loop_edges(ctx, &reachable_edges_after_condition);
+            }
 
             // Merge move states from both branches.
             ctx.merge_branch_moves(then_moves, else_moves, !then_continues, !else_continues);
@@ -353,6 +374,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // Capture then-branch's move state
             let then_moves = ctx.moved_vars.clone();
 
+            if !cond_result.continues {
+                Self::restore_reachable_loop_edges(ctx, &reachable_edges_after_condition);
+            }
+
             // For if-without-else:
             if !then_result.continues {
                 // Then-branch diverges - code after if only runs if cond was false
@@ -403,6 +428,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let cond_result = self.analyze_inst(air, cond, ctx);
         ctx.exit_full_expression(boundary);
         let cond_result = cond_result?;
+        // The condition-false path exits the while before its body runs.
+        // Keep its ownership state separate from the body's fall-through:
+        // a body that always diverges must not overwrite this zero-iteration
+        // exit with an arbitrary state from one diverging arm.
+        let moves_after_condition = ctx.moved_vars.clone();
+        let reachable_edges_after_condition = ctx.loop_break_stack.clone();
 
         // Analyze body with its own scope. The loop_break_stack entry makes
         // breaks inside the body target this while loop, not an outer loop;
@@ -420,27 +451,43 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // break-site snapshots still on the stack, so the record popped
         // afterwards describes the post-loop scope view.
         ctx.pop_scope();
-        let (break_moves, continue_moves) = ctx
-            .loop_break_stack
-            .pop()
-            .unwrap_or_default()
-            .merged_moves();
+        let edge_record = ctx.loop_break_stack.pop().unwrap_or_default();
+        if !cond_result.continues {
+            Self::restore_reachable_loop_edges(ctx, &reachable_edges_after_condition);
+        }
+        let (break_moves, continue_moves) = edge_record.merged_moves();
         // The back edge carries the fall-through state joined with the
         // continue-site states — a continue re-enters the loop exactly like
         // falling off the body's end — while a break path never re-enters.
         // Keep the joined state for the recheck below (RUE-1293).
-        let mut backedge_moves = ctx.moved_vars.clone();
+        let mut reachable_backedge_moves = body_result.continues.then(|| ctx.moved_vars.clone());
         if let Some(continue_moves) = &continue_moves {
-            backedge_moves = union_move_maps(&backedge_moves, continue_moves);
+            reachable_backedge_moves = Some(match reachable_backedge_moves {
+                Some(fallthrough_moves) => union_move_maps(&fallthrough_moves, continue_moves),
+                None => continue_moves.clone(),
+            });
         }
-        // A while loop's exits are the condition-false fall-through — whose
-        // state on iterations past the first is the back-edge state — AND its
-        // breaks; union in the at-break states so a move on a break path is
-        // marked after the loop too (RUE-1293).
-        ctx.moved_vars = match &break_moves {
-            Some(break_moves) => union_move_maps(&backedge_moves, break_moves),
-            None => backedge_moves.clone(),
-        };
+        // Only a condition that can complete and a body path that reaches
+        // either its fall-through or an explicit continue can return to the
+        // loop head. Break-only paths end at the loop exit and must not make
+        // the back-edge recheck reject a move that runs at most once
+        // (RUE-1615).
+        let backedge_reachable = cond_result.continues && reachable_backedge_moves.is_some();
+        // A while loop's exits are the zero-iteration condition-false path,
+        // later condition-false paths reached from the back edge, and its
+        // breaks. Join only reachable contributors: the post-body state is
+        // not an exit when every body path diverges (RUE-1615), while a move
+        // on a break path remains visible after the loop (RUE-1293).
+        let mut exit_moves = moves_after_condition;
+        if cond_result.continues {
+            if let Some(reachable_backedge_moves) = &reachable_backedge_moves {
+                exit_moves = union_move_maps(&exit_moves, reachable_backedge_moves);
+            }
+            if let Some(break_moves) = &break_moves {
+                exit_moves = union_move_maps(&exit_moves, break_moves);
+            }
+        }
+        ctx.moved_vars = exit_moves;
 
         // A while loop discards its body's result value on every iteration;
         // discarding a value that carries a linear value would implicitly
@@ -452,7 +499,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // state. Any use of a value moved by a previous iteration then errors.
         // The scratch Air and context are discarded - this pass exists only
         // for the checks.
-        if !ctx.in_loop_move_recheck && backedge_moves != moves_before_loop {
+        if backedge_reachable
+            && !ctx.in_loop_move_recheck
+            && reachable_backedge_moves.as_ref() != Some(&moves_before_loop)
+        {
             let checkpoint = air.checkpoint();
             let mut scratch_ctx = ctx.fork_for_loop_recheck();
             // Seed the back-edge recheck with the back-edge state (the
@@ -460,7 +510,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // state: break-path moves never reach the back edge, and seeding
             // them would reject a value legitimately moved only on a path
             // that exits the loop (RUE-1293).
-            scratch_ctx.moved_vars = backedge_moves;
+            scratch_ctx.moved_vars =
+                reachable_backedge_moves.expect("reachable back edge must have a move state");
             let recovered_before = self.body_analysis_recovered_errors_mut().len();
             let result = (|| -> CompileResult<()> {
                 let boundary = scratch_ctx.enter_full_expression();
@@ -551,12 +602,26 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // is unreachable.
         let has_break = edge_record.broke;
         let (break_moves, continue_moves) = edge_record.merged_moves();
+        // `has_break` is syntactic and controls the loop's static type even
+        // for an unreachable break (4.8:21). Only a reachable break snapshot
+        // makes this loop continue to its enclosing context; an inner loop
+        // whose reachable paths all return must not create an outer phantom
+        // back edge (RUE-1615).
+        let has_reachable_break = break_moves.is_some();
         // The back edge carries the fall-through state joined with the
         // continue-site states; keep it for the recheck below (RUE-1293).
-        let mut backedge_moves = ctx.moved_vars.clone();
+        let mut reachable_backedge_moves = body_result.continues.then(|| ctx.moved_vars.clone());
         if let Some(continue_moves) = &continue_moves {
-            backedge_moves = union_move_maps(&backedge_moves, continue_moves);
+            reachable_backedge_moves = Some(match reachable_backedge_moves {
+                Some(fallthrough_moves) => union_move_maps(&fallthrough_moves, continue_moves),
+                None => continue_moves.clone(),
+            });
         }
+        // A break-only body has no path back to the loop head. Its move state
+        // belongs exclusively to the exit join, not to a phantom iteration
+        // (RUE-1615). Explicit continue edges remain real back edges even when
+        // every other body path diverges.
+        let backedge_reachable = reachable_backedge_moves.is_some();
         // An infinite loop's only exits are its breaks, so the union of the
         // at-break states IS the exit ownership state — the back-edge state
         // re-enters the loop and never reaches the code after it (RUE-1293;
@@ -573,15 +638,17 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         self.reject_discarded_linear_value(body_result.ty, body)?;
 
         // Loop back-edge move check (see analyze_while_loop for details).
-        // Note: like Rust, this is conservative - a body that unconditionally
-        // breaks after the move still errors.
-        if !ctx.in_loop_move_recheck && backedge_moves != moves_before_loop {
+        if backedge_reachable
+            && !ctx.in_loop_move_recheck
+            && reachable_backedge_moves.as_ref() != Some(&moves_before_loop)
+        {
             let checkpoint = air.checkpoint();
             let mut scratch_ctx = ctx.fork_for_loop_recheck();
             // Seed with the back-edge state (fall-through joined with the
             // continue states), not the exit state: only the back edge's
             // moves reach the next iteration (RUE-1293).
-            scratch_ctx.moved_vars = backedge_moves;
+            scratch_ctx.moved_vars =
+                reachable_backedge_moves.expect("reachable back edge must have a move state");
             let recovered_before = self.body_analysis_recovered_errors_mut().len();
             scratch_ctx.push_scope();
             scratch_ctx.loop_depth += 1;
@@ -620,7 +687,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ty: loop_ty,
             span,
         });
-        Ok(AnalysisResult::with_continues(air_ref, loop_ty, has_break))
+        Ok(AnalysisResult::with_continues(
+            air_ref,
+            loop_ty,
+            has_reachable_break,
+        ))
     }
 
     /// Validate an integer pattern literal against the scrutinee type and
@@ -976,6 +1047,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         ctx.exit_full_expression(boundary);
         let scrutinee_result = scrutinee_result?;
         let scrutinee_type = scrutinee_result.ty;
+        let reachable_edges_after_scrutinee = ctx.loop_break_stack.clone();
 
         // Validate that we can match on this type (integers, booleans, and enums)
         if !scrutinee_type.is_integer() && scrutinee_type != Type::BOOL && !scrutinee_type.is_enum()
@@ -1426,6 +1498,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // `full_move_on_all_paths` intersects for the linear must-consume
         // check). Matches are exhaustive, so the arms cover every path.
         let continues = result_continues.unwrap_or(true);
+        if !scrutinee_result.continues {
+            Self::restore_reachable_loop_edges(ctx, &reachable_edges_after_scrutinee);
+        }
         ctx.merge_arm_moves(arm_move_states);
 
         // Exhaustiveness checking
@@ -2435,6 +2510,23 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         if let Some(moves) = reachable_moves {
             ctx.moved_vars = moves;
+        }
+        if let Some(reachable_context) = diverged_context.as_ref() {
+            // Dead suffixes are still analyzed for diagnostics, but their
+            // break/continue snapshots cannot reach the enclosing join. Keep
+            // the snapshots from the first reachable divergence while
+            // preserving `broke` from the full analysis: loop typing is
+            // syntactic even when a break occurs only in unreachable code
+            // (4.8:21).
+            assert_eq!(
+                reachable_context.loop_break_stack.len(),
+                ctx.loop_break_stack.len()
+            );
+            let mut reachable_edges = reachable_context.loop_break_stack.clone();
+            for (reachable, analyzed) in reachable_edges.iter_mut().zip(&ctx.loop_break_stack) {
+                reachable.broke |= analyzed.broke;
+            }
+            ctx.loop_break_stack = reachable_edges;
         }
         // Pop scope to remove block-scoped variables. The reachable move
         // state is restored first so this frame removes dead locals and

--- a/crates/rue-cli-tests/cases/loop_moves.toml
+++ b/crates/rue-cli-tests/cases/loop_moves.toml
@@ -6,8 +6,8 @@
 # valid controls that must keep compiling (value defined inside the body,
 # reassignment before the next use, Copy types).
 #
-# Like Rust, the check is conservative: a `loop` body that unconditionally
-# breaks after the move still errors even though no second iteration runs.
+# A move is checked only when a body path can return to the loop head. A body
+# that unconditionally breaks after the move runs at most once and is valid.
 
 [section]
 id = "cli.loop_moves"
@@ -65,8 +65,8 @@ compile_fail = true
 error_contains = ["E0205", "previous iteration of the loop"]
 
 [[case]]
-name = "move_in_infinite_loop_with_break"
-description = "Conservative like Rust: an unconditional break after the move still errors."
+name = "move_in_infinite_loop_with_break_ok"
+description = "An unconditional break makes the move execute at most once, so there is no back-edge conflict."
 files = [{ path = "main.rue", source = """
 struct Data { x: i32 }
 fn consume(d: Data) -> i32 { d.x }
@@ -76,8 +76,317 @@ fn main() -> i32 {
     0
 }
 """ }]
+exit_code = 0
+
+[[case]]
+name = "diverging_intrinsic_argument_does_not_create_phantom_break"
+description = "An intrinsic argument after a diverging argument is unreachable and cannot create a break edge."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn never() -> ! { loop {} }
+fn run() -> bool { true }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    loop {
+        if run() { break; }
+        consume(d);
+        checked { @syscall(never(), { break; 0 }); }
+    }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "diverging_place_rhs_does_not_create_phantom_break"
+description = "A mutable place target after a diverging assignment RHS is unreachable and cannot create a break edge."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+struct P {
+    x: i32,
+    fn at(inout self, i: i32) -> inout i32 { yield self.x; }
+}
+fn never() -> ! { loop {} }
+fn run() -> bool { true }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    let mut p = P { x: 0 };
+    loop {
+        if run() { break; }
+        consume(d);
+        loop { p.at({ break; 0 }) = never(); }
+    }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "diverging_field_rhs_does_not_create_phantom_break"
+description = "A projected field target after a diverging assignment RHS is unreachable and cannot create a break edge."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+struct P {
+    value: i32,
+    fn at(inout self, i: i32) -> inout P { yield self; }
+}
+fn never() -> ! { loop {} }
+fn run() -> bool { true }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    let mut p = P { value: 0 };
+    loop {
+        if run() { break; }
+        consume(d);
+        loop { p.at({ break; 0 }).value = never(); }
+    }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "diverging_alloc_argument_does_not_create_phantom_continue"
+description = "An allocator argument after a diverging argument is unreachable and cannot create a back edge."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn never() -> ! { loop {} }
+fn run() -> bool { true }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    loop {
+        if run() { break; }
+        consume(d);
+        loop { checked { @alloc(never(), { continue; 0 }); } }
+    }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "diverging_place_target_does_not_create_phantom_continue"
+description = "A place target after a diverging assignment RHS is unreachable and cannot create a back edge."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+struct P {
+    x: i32,
+    fn at(inout self, i: i32) -> inout i32 { yield self.x; }
+}
+fn never() -> ! { loop {} }
+fn run() -> bool { true }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    let mut p = P { x: 0 };
+    loop {
+        if run() { break; }
+        consume(d);
+        loop { p.at({ continue; 0 }) = never(); }
+    }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "diverging_assert_argument_does_not_create_phantom_continue"
+description = "An assert message after a diverging condition is unreachable and cannot create a back edge."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn never() -> ! { loop {} }
+fn run() -> bool { true }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    loop {
+        if run() { break; }
+        consume(d);
+        loop { @assert(never(), { continue; "dead" }); }
+    }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "diverging_index_rhs_does_not_create_phantom_break"
+description = "An index target after a diverging assignment RHS is unreachable and cannot create a break edge."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn never() -> ! { loop {} }
+fn run() -> bool { true }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    let mut a = [0];
+    loop {
+        if run() { break; }
+        consume(d);
+        loop { a[if run() { break; } else { 0 }] = never(); }
+    }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "move_in_all_break_arms_ok"
+description = "When every conditional body arm breaks, neither arm reaches a later iteration."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    let choose = 1;
+    loop {
+        if choose == 1 { consume(d); break; }
+        else { consume(d); break; }
+    }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "move_in_nested_all_break_control_flow_ok"
+description = "Nested loops and branches whose paths all break do not create a phantom back edge."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    let choose = 1;
+    loop {
+        while choose == 1 {
+            if choose == 1 { consume(d); break; }
+            else { consume(d); break; }
+        }
+        break;
+    }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "nested_loop_with_only_return_does_not_create_outer_backedge"
+description = "An inner loop with only a reachable return and an unreachable break still diverges to its outer loop."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    loop {
+        consume(d);
+        loop { return 0; break; }
+    }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "move_in_while_condition_and_break_ok"
+description = "A condition move and a body move are each executed once when the body always breaks."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn check(d: Data) -> bool { d.x > 0 }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let condition_data = Data { x: 1 };
+    let body_data = Data { x: 2 };
+    while check(condition_data) { consume(body_data); break; }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "move_into_explicit_continue_errors"
+description = "An explicit continue is a real back edge and retains the previous-iteration rejection."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    loop { consume(d); continue; }
+}
+""" }]
 compile_fail = true
 error_contains = ["E0205", "previous iteration of the loop"]
+
+[[case]]
+name = "unreachable_continue_after_break_is_ignored"
+description = "A continue after an unconditional break is dead and must not create a back edge."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    loop { consume(d); break; continue; }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "while_all_diverging_break_or_return_preserves_owned_exit"
+description = "A return arm that moves is not a post-loop path when the other arm breaks."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn consume(d: Data) -> i32 { d.x }
+fn run() -> bool { false }
+fn leave() -> bool { false }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    while run() {
+        if leave() { consume(d); return 0; }
+        else { break; }
+    }
+    consume(d)
+}
+""" }]
+exit_code = 1
+
+[[case]]
+name = "while_all_diverging_match_preserves_owned_exit"
+description = "A match arm that moves and returns is excluded when the other arm breaks."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn consume(d: Data) -> i32 { d.x }
+fn run() -> bool { false }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    while run() {
+        match run() {
+            true => { consume(d); return 0; },
+            false => { break; }
+        }
+    }
+    consume(d)
+}
+""" }]
+exit_code = 1
+
+[[case]]
+name = "while_zero_iteration_linear_path_is_checked"
+description = "A linear value consumed only when the while body runs is not consumed on the false-condition exit."
+files = [{ path = "main.rue", source = """
+linear struct Token { value: i32 }
+fn consume(t: Token) { @drop(t); }
+fn run() -> bool { false }
+fn main() -> i32 {
+    let t = Token { value: 1 };
+    while run() { consume(t); break; }
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0443", "not consumed on all paths"]
 
 [[case]]
 name = "conditional_move_in_loop"
@@ -172,3 +481,172 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 12
+
+[[case]]
+name = "diverging_if_condition_does_not_create_phantom_continue"
+description = "A continue in an arm whose condition diverges is unreachable and cannot form a back edge."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn never() -> ! { loop {} }
+fn run() -> bool { true }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    loop {
+        if run() { break; }
+        consume(d);
+        if never() { continue; }
+    }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "diverging_match_scrutinee_does_not_create_phantom_continue"
+description = "Continue arms after a diverging match scrutinee are unreachable and cannot form a back edge."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn never() -> ! { loop {} }
+fn run() -> bool { true }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    loop {
+        if run() { break; }
+        consume(d);
+        match (if never() { true } else { false }) {
+            true => { continue; },
+            false => { continue; }
+        }
+    }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "diverging_call_argument_does_not_create_phantom_continue"
+description = "Arguments after a diverging call operand are unreachable and cannot create a back edge."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn never() -> ! { loop {} }
+fn run() -> bool { true }
+fn consume(d: Data) -> i32 { d.x }
+fn add(a: i32, b: i32) -> i32 { a + b }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    loop {
+        if run() { break; }
+        consume(d);
+        add(never(), { continue; 0 });
+    }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "diverging_binary_lhs_does_not_create_phantom_continue"
+description = "An operand after a diverging binary left-hand side is unreachable and cannot create a back edge."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn never() -> ! { loop {} }
+fn run() -> bool { true }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    loop {
+        if run() { break; }
+        consume(d);
+        never() + { continue; 0 };
+    }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "diverging_comparison_lhs_does_not_create_phantom_break"
+description = "A break in a comparison RHS after a diverging LHS is unreachable and cannot make an inner loop fall through."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn never() -> ! { loop {} }
+fn run() -> bool { true }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    loop {
+        if run() { break; }
+        consume(d);
+        loop { never() == { break; 0 }; }
+    }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "diverging_logical_lhs_does_not_create_phantom_break"
+description = "A break in a logical RHS after a diverging LHS is unreachable and cannot make an inner loop fall through."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn never() -> ! { loop {} }
+fn run() -> bool { true }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    loop {
+        if run() { break; }
+        consume(d);
+        loop { never() && { break; true }; }
+    }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "diverging_array_element_does_not_create_phantom_break"
+description = "An array element after a diverging element is unreachable and cannot create a break edge."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn never() -> ! { loop {} }
+fn run() -> bool { true }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    loop {
+        if run() { break; }
+        consume(d);
+        loop { [never(), { break; 0 }]; }
+    }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "diverging_method_argument_does_not_create_phantom_break"
+description = "A method argument after a diverging argument is unreachable and cannot make an inner loop continue."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+struct Ops {
+    n: i32,
+    fn add(borrow self, a: i32, b: i32) -> i32 { self.n + a + b }
+}
+fn never() -> ! { loop {} }
+fn run() -> bool { true }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    let ops = Ops { n: 0 };
+    loop {
+        if run() { break; }
+        consume(d);
+        loop { ops.add(never(), { break; 0 }); }
+    }
+    0
+}
+""" }]
+exit_code = 0

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -2942,3 +2942,50 @@ fn main() -> i32 {
 }
 """
 exit_code = 0
+
+# A break-only body has no path back to the loop head. The move is therefore
+# checked only at the break exit, not as if a second iteration could run
+# (formal core §5.7, (Loop-Break)).
+[[case]]
+name = "break_only_body_move_is_legal"
+spec = ["3.8:5", "3.8:51", "4.8:21"]
+description = "A move before an unconditional break is not a previous-iteration move."
+source = """
+struct P { x: i64 }
+
+fn consume(p: P) -> i64 { p.x }
+
+fn main() -> i32 {
+    let p = P { x: 1 };
+    loop {
+        let _ = consume(p);
+        break;
+    }
+    0
+}
+"""
+exit_code = 0
+
+# A normal fall-through path is a real back edge and retains the repeated-use
+# rejection. This is the negative control for the break-only case above.
+[[case]]
+name = "fallthrough_body_move_is_rejected"
+spec = ["3.8:5", "4.8:1", "4.8:5"]
+description = "A move in a while body that can fall through is rejected on re-entry."
+source = """
+struct P { x: i64 }
+
+fn consume(p: P) -> i64 { p.x }
+
+fn main() -> i32 {
+    let p = P { x: 1 };
+    let mut i = 0;
+    while i < 2 {
+        let _ = consume(p);
+        i = i + 1;
+    }
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0205", "previous iteration of the loop"]

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -1018,15 +1018,13 @@ which exit it.
   drop flag of `3.8:73` are likewise observable: a break arm that moves and a
   break arm that does not produce exactly one drop on each path. So the core
   and the compiler agree on (Loop-Break), and no RUE-1293 divergence remains.
-  What *does* remain, in the opposite direction (observed 2026-08-23; not yet
-  filed): when **every** path through the body breaks, the compiler rejects the
-  move itself with E0205 and the note "value was moved in a previous iteration
-  of the loop", although no back edge exists to carry it there —
-  `loop { eat(t); break; }` is the minimal case. Under (Loop-Break) the
-  back-edge premise constrains only the body's *fall-through* state `Σ_back`,
-  which is `⊥` when every path diverges, so the premise is vacuous and the
-  program is well-formed; this is an over-rejection, not the accepted
-  use-after-move RUE-1293 described.
+  **Compiler agreement (RUE-1615, resolved).** The back-edge check is gated on
+  an actually reachable return to the loop head. When every path through the
+  body breaks, the fall-through state `Σ_back` is `⊥`, so a move in
+  `loop { eat(t); break; }` is checked only against the at-break exit state and
+  is not incorrectly rejected as a move in a previous iteration. Explicit
+  `continue` edges and ordinary fall-through paths remain back edges and retain
+  the recheck required by this rule.
 
 A `never`-typed expression is accepted wherever a value of any type is expected —
 this is the coercion, stated as **subsumption on the bottom type** (`3.4:3/4`):


### PR DESCRIPTION
Fixes RUE-1615

## Summary
- join loop-entry ownership only from reachable fallthrough and continue edges
- preserve break-edge exit ownership and real multi-iteration move errors
- keep syntactic loop typing distinct from reachable outward control flow
- cover ordered operand divergence and update the formal calculus note

## Validation
- scripts/rue cli loop_moves (34 passed)
- scripts/rue spec move-semantics (154 passed)
- scripts/rue quick (31 targets passed)
- scripts/rue premerge (196 targets passed)
- scripts/rue test (231 targets passed)