### PR TITLE
RUE-1633: Remove dead direct materialization adapters

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -90,6 +90,8 @@ fn local_semantic_materialization_is_an_inert_exact_fact_boundary() {
         "rue_air::SemanticImportEpoch::new_local(",
         ".materialize_local_body_with_types(",
         "FunctionInstanceKey::AnonymousMember",
+        "materialize_canonical_body_with_indexes(",
+        "materialize_semantic_body_with_indexes(",
     ] {
         assert!(
             local.contains(required),
@@ -104,6 +106,8 @@ fn local_semantic_materialization_is_an_inert_exact_fact_boundary() {
         "Mutex<",
         "RwLock<",
         "cache:",
+        "materialize_canonical_body(",
+        "materialize_semantic_body(",
     ] {
         assert!(
             !local.contains(forbidden),
@@ -160,8 +164,6 @@ fn cfg_queries_own_local_semantic_materialization_and_terminal_domains() {
     let database = include_str!("revisioned_query_database.rs");
     for required in [
         "CfgSemanticInput::Body",
-        "materialize_canonical_body(",
-        "materialize_semantic_body(",
         "synthesize_canonical_drop_glue(",
         "CfgDomainProjection::from_local_body(",
         "pub(crate) type_pool: rue_air::FrozenTypeInternPool",
@@ -173,6 +175,25 @@ fn cfg_queries_own_local_semantic_materialization_and_terminal_domains() {
         assert!(
             cfg.contains(required),
             "CFG ownership boundary lost: {required}"
+        );
+    }
+    for required in [
+        "crate::local_semantic_materialization::materialize_canonical_body_with_indexes(",
+        "crate::local_semantic_materialization::materialize_semantic_body_with_indexes(",
+    ] {
+        let live_calls = cfg
+            .lines()
+            .filter(|line| line.trim_start().starts_with(required))
+            .count();
+        assert_eq!(
+            live_calls, 1,
+            "CFG query must have exactly one live indexed materialization call: {required}"
+        );
+    }
+    for forbidden in ["materialize_canonical_body(", "materialize_semantic_body("] {
+        assert!(
+            !cfg.contains(forbidden),
+            "CFG query regained a direct materialization adapter call: {forbidden}"
         );
     }
     for forbidden in [

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -1177,9 +1177,9 @@ fn materialize_and_build_cfg(
     context.record_work(rue_query::WorkItem::new("cfg.materialize.attempts", 1));
     let input_preparation_ns = elapsed_ns(input_preparation_started);
     let materialization_started = std::time::Instant::now();
-    // The indexed variants preserve the materialize_canonical_body(...) and
-    // materialize_semantic_body(...) adapters for direct providers while this
-    // hot path reuses the exact fact-side indexes prepared during selection.
+    // Both CFG inputs use the exact fact-side indexes prepared during
+    // selection, keeping canonical-body and drop-glue materialization on one
+    // indexed path.
     let materialized = match &key.semantic_input {
         CfgSemanticInput::Body { input, .. } => {
             crate::local_semantic_materialization::materialize_canonical_body_with_indexes(

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -880,38 +880,6 @@ fn mangle_canonical_value(value: &crate::CanonicalArgumentValue) -> String {
     }
 }
 
-/// Materialize one canonical body from exact query facts.
-///
-/// The declaration and anonymous slices may contain only the facts required by
-/// this body. Missing transitive shapes/callables fail closed in `rue-air`;
-/// this adapter never widens the request by discovering a program universe.
-#[allow(dead_code)]
-pub(crate) fn materialize_canonical_body(
-    canonical: &crate::body_query::CanonicalBody,
-    body_span: rue_span::Span,
-    declarations: &[DurableDeclarationSemantic],
-    anonymous_nominals: &[DurableAnonymousNominal],
-    callable_facts: &[LocalCallableFact],
-    nominal_metadata: &[LocalNominalMetadataFact],
-    modules: &[ModuleId],
-    builtin_facts: &[LocalBuiltinNominalFact],
-    materialization_types: &[crate::durable_semantics::DurableType],
-) -> Result<LocalSemanticMaterialization, LocalMaterializationFailure> {
-    let indexes = LocalMaterializationIndexes::new(declarations, nominal_metadata);
-    materialize_canonical_body_with_indexes(
-        canonical,
-        body_span,
-        declarations,
-        anonymous_nominals,
-        callable_facts,
-        nominal_metadata,
-        modules,
-        builtin_facts,
-        materialization_types,
-        &indexes,
-    )
-}
-
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn materialize_canonical_body_with_indexes(
     canonical: &crate::body_query::CanonicalBody,
@@ -950,35 +918,6 @@ pub(crate) fn materialize_canonical_body_with_indexes(
         builtin_facts,
         materialization_types,
         indexes,
-    )
-}
-
-#[allow(clippy::too_many_arguments, dead_code)]
-pub(crate) fn materialize_semantic_body(
-    identity: FunctionInstanceKey,
-    body: &rue_air::SemanticBody<StableDefinitionKey, ModuleId>,
-    body_span: rue_span::Span,
-    declarations: &[DurableDeclarationSemantic],
-    anonymous_nominals: &[DurableAnonymousNominal],
-    callable_facts: &[LocalCallableFact],
-    nominal_metadata: &[LocalNominalMetadataFact],
-    modules: &[ModuleId],
-    builtin_facts: &[LocalBuiltinNominalFact],
-    materialization_types: &[crate::durable_semantics::DurableType],
-) -> Result<LocalSemanticMaterialization, LocalMaterializationFailure> {
-    let indexes = LocalMaterializationIndexes::new(declarations, nominal_metadata);
-    materialize_semantic_body_with_indexes(
-        identity,
-        body,
-        body_span,
-        declarations,
-        anonymous_nominals,
-        callable_facts,
-        nominal_metadata,
-        modules,
-        builtin_facts,
-        materialization_types,
-        &indexes,
     )
 }
 
@@ -1212,6 +1151,34 @@ pub(crate) fn materialize_semantic_body_with_indexes(
         body_span,
         materialization_types,
     )?)
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn materialize_canonical_body_for_test(
+    canonical: &crate::body_query::CanonicalBody,
+    body_span: rue_span::Span,
+    declarations: &[DurableDeclarationSemantic],
+    anonymous_nominals: &[DurableAnonymousNominal],
+    callable_facts: &[LocalCallableFact],
+    nominal_metadata: &[LocalNominalMetadataFact],
+    modules: &[ModuleId],
+    builtin_facts: &[LocalBuiltinNominalFact],
+    materialization_types: &[crate::durable_semantics::DurableType],
+) -> Result<LocalSemanticMaterialization, LocalMaterializationFailure> {
+    let indexes = LocalMaterializationIndexes::new(declarations, nominal_metadata);
+    materialize_canonical_body_with_indexes(
+        canonical,
+        body_span,
+        declarations,
+        anonymous_nominals,
+        callable_facts,
+        nominal_metadata,
+        modules,
+        builtin_facts,
+        materialization_types,
+        &indexes,
+    )
 }
 
 /// Select the transitive nominal and callable closure needed to materialize one
@@ -1949,7 +1916,7 @@ mod tests {
             },
         };
         assert_eq!(
-            materialize_canonical_body(
+            materialize_canonical_body_for_test(
                 &canonical,
                 rue_span::Span::with_file(rue_span::FileId::new(3), 100, 200),
                 std::slice::from_ref(&declaration),
@@ -1966,7 +1933,7 @@ mod tests {
             .err(),
             Some(LocalMaterializationFailure::MissingNominalMetadata)
         );
-        let output = materialize_canonical_body(
+        let output = materialize_canonical_body_for_test(
             &canonical,
             rue_span::Span::with_file(rue_span::FileId::new(3), 100, 200),
             std::slice::from_ref(&declaration),
@@ -2038,7 +2005,7 @@ mod tests {
                 payload: DurableDeclarationPayload::Destructor,
             },
         ];
-        let error = materialize_canonical_body(
+        let error = materialize_canonical_body_for_test(
             &crate::body_query::CanonicalBody::Ordinary {
                 owner: function.clone(),
                 body: body(),
@@ -2118,7 +2085,7 @@ mod tests {
             .as_ref();
         assert!(destructor_symbol.ends_with(".__drop"));
 
-        materialize_canonical_body(
+        materialize_canonical_body_for_test(
             &crate::body_query::CanonicalBody::Ordinary {
                 owner: function,
                 body: body(),

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -38707,18 +38707,19 @@ fn main() -> i32 {
             identity: instance,
             symbol: Arc::from(live_name.as_str()),
         };
-        let materialized = crate::local_semantic_materialization::materialize_canonical_body(
-            &canonical,
-            body_span,
-            &[],
-            &[],
-            std::slice::from_ref(&callable),
-            &[],
-            std::slice::from_ref(&module),
-            &[],
-            &[],
-        )
-        .expect("durable provider export materializes in a fresh local epoch");
+        let materialized =
+            crate::local_semantic_materialization::materialize_canonical_body_for_test(
+                &canonical,
+                body_span,
+                &[],
+                &[],
+                std::slice::from_ref(&callable),
+                &[],
+                std::slice::from_ref(&module),
+                &[],
+                &[],
+            )
+            .expect("durable provider export materializes in a fresh local epoch");
 
         assert_eq!(materialized.identity, live_identity);
         assert_eq!(materialized.name, live_name);


### PR DESCRIPTION
Summary:
- remove the unused direct canonical and semantic materialization adapters from production
- keep focused coverage through an explicitly test-only canonical helper
- pin the indexed CFG materialization path with precise architecture inventory checks

Validation:
- scripts/rue fmt
- focused compiler materialization and API inventory tests
- scripts/rue quick
- scripts/rue premerge

Fixes RUE-1633