### PR TITLE
RUE-1634: Back off watch source polling

### DIFF
--- a/crates/rue/src/host.rs
+++ b/crates/rue/src/host.rs
@@ -11,8 +11,8 @@ use rue_compiler::{
 };
 
 use crate::source_loader::{
-    ImportDiscoveryResult, SourceLoadError, SourceLoadRequest, acquire_reached_toolchain_modules,
-    load, reload_from_filesystem,
+    ImportDiscoveryResult, SourceLoadError, SourceLoadRequest, WatchInput,
+    acquire_reached_toolchain_modules, load, reload_from_filesystem,
 };
 
 /// Immutable filesystem configuration captured when a retained host opens.
@@ -69,7 +69,7 @@ impl FilesystemCompilerHost {
 
     /// Exact accepted filesystem closure, plus the policy manifest that can
     /// change which reads are allowed on the next observation.
-    pub fn watch_inputs(&self) -> Vec<(std::path::PathBuf, u64)> {
+    pub fn watch_inputs(&self) -> Vec<WatchInput> {
         self.state.watch_inputs()
     }
 

--- a/crates/rue/src/lib.rs
+++ b/crates/rue/src/lib.rs
@@ -9,4 +9,6 @@ mod host;
 mod source_loader;
 
 pub use host::{FilesystemCompilerHost, HostOpenRequest};
-pub use source_loader::{HermeticDenialError, SourceLoadError, ToolchainIntegrityError};
+pub use source_loader::{
+    HermeticDenialError, SourceLoadError, ToolchainIntegrityError, WatchFingerprint, WatchInput,
+};

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -37,10 +37,70 @@ use rue_compiler::{
     TrustedToolchainModuleDemand,
 };
 
+/// The content fingerprint used by the long-lived filesystem observer.
+///
+/// Keeping the hash policy with the filesystem host means the producer's
+/// accepted-read snapshot and the CLI watcher cannot silently diverge.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct WatchFingerprint(u64);
+
+impl WatchFingerprint {
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        let mut hash = 0xcbf29ce484222325_u64;
+        for byte in bytes {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        Self(hash)
+    }
+
+    pub fn read(path: &Path) -> Option<Self> {
+        fs::read(path).ok().map(|bytes| Self::from_bytes(&bytes))
+    }
+}
+
+/// One accepted filesystem path and its content fingerprint.
+///
+/// `requested_path` is retained separately from `canonical_path`: the watcher
+/// must notice an import alias being deleted or retargeted even though the
+/// canonical file may still exist.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WatchInput {
+    requested_path: PathBuf,
+    canonical_path: PathBuf,
+    fingerprint: WatchFingerprint,
+}
+
+impl WatchInput {
+    pub fn new(
+        requested_path: PathBuf,
+        canonical_path: PathBuf,
+        fingerprint: WatchFingerprint,
+    ) -> Self {
+        Self {
+            requested_path,
+            canonical_path,
+            fingerprint,
+        }
+    }
+
+    pub fn requested_path(&self) -> &Path {
+        &self.requested_path
+    }
+
+    pub fn canonical_path(&self) -> &Path {
+        &self.canonical_path
+    }
+
+    pub fn fingerprint(&self) -> WatchFingerprint {
+        self.fingerprint
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct SourceManifest {
     path: PathBuf,
-    content_hash: u64,
+    content_hash: WatchFingerprint,
     allowed: AHashSet<PathBuf>,
     declared_paths: AHashSet<PathBuf>,
 }
@@ -110,7 +170,7 @@ impl SourceManifest {
 
         Ok(Self {
             path: manifest_path.to_path_buf(),
-            content_hash: watch_content_hash(content.as_bytes()),
+            content_hash: WatchFingerprint::from_bytes(content.as_bytes()),
             allowed,
             declared_paths,
         })
@@ -706,8 +766,8 @@ pub(crate) struct SourceResolutionInputs {
 }
 
 impl ImportDiscoveryResult {
-    pub(crate) fn watch_inputs(&self) -> Vec<(PathBuf, u64)> {
-        let mut paths = Vec::with_capacity(self.read_manifest.len() * 2 + 1);
+    pub(crate) fn watch_inputs(&self) -> Vec<WatchInput> {
+        let mut paths = Vec::with_capacity(self.read_manifest.len() + 1);
         for entry in self.read_manifest.iter() {
             let source = self
                 .source_snapshot
@@ -716,28 +776,28 @@ impl ImportDiscoveryResult {
                     self.source_snapshot.module_id(source.file_id) == Some(entry.module())
                 })
                 .expect("an accepted read has source bytes in the committed snapshot");
-            let hash = watch_content_hash(source.source.as_bytes());
-            paths.push((PathBuf::from(entry.requested_path()), hash));
-            paths.push((PathBuf::from(entry.canonical_path()), hash));
+            let fingerprint = WatchFingerprint::from_bytes(source.source.as_bytes());
+            paths.push(WatchInput::new(
+                PathBuf::from(entry.requested_path()),
+                PathBuf::from(entry.canonical_path()),
+                fingerprint,
+            ));
         }
         if let Some(manifest) = &self.source_manifest {
-            paths.push((manifest.path.clone(), manifest.content_hash));
+            paths.push(WatchInput::new(
+                manifest.path.clone(),
+                manifest.path.clone(),
+                manifest.content_hash,
+            ));
         }
-        paths.sort_by(|left, right| left.0.cmp(&right.0));
-        paths.dedup_by(|left, right| left.0 == right.0);
+        paths.sort_by(|left, right| {
+            left.requested_path()
+                .cmp(right.requested_path())
+                .then_with(|| left.canonical_path().cmp(right.canonical_path()))
+        });
+        paths.dedup();
         paths
     }
-}
-
-pub(crate) fn watch_content_hash(bytes: &[u8]) -> u64 {
-    // A fixed FNV-1a hash keeps the polling watcher deterministic and avoids
-    // retaining another copy of every source buffer in its monitor thread.
-    let mut hash = 0xcbf29ce484222325_u64;
-    for byte in bytes {
-        hash ^= u64::from(*byte);
-        hash = hash.wrapping_mul(0x100000001b3);
-    }
-    hash
 }
 
 /// The closed import-discovery revision produced by

--- a/crates/rue/src/watch.rs
+++ b/crates/rue/src/watch.rs
@@ -1,5 +1,6 @@
+use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
@@ -7,13 +8,14 @@ use std::time::{Duration, Instant};
 
 use rue_compiler::unstable::{CompilationCancellation, SourceInfo};
 use rue_compiler::{CompileOptions, LinkerMode};
-use rue_driver::{FilesystemCompilerHost, SourceLoadError};
+use rue_driver::{FilesystemCompilerHost, SourceLoadError, WatchFingerprint, WatchInput};
 
 use crate::compile::{CancellableCompileRequest, CompileCycleOutcome, execute_cancellable};
 use crate::output;
 use crate::{DiagnosticOutput, ErrorFormat};
 
 const POLL_INTERVAL: Duration = Duration::from_millis(25);
+const MAX_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const QUIET_PERIOD: Duration = Duration::from_millis(75);
 const FAILED_REOBSERVE_RETRY: Duration = Duration::from_millis(250);
 
@@ -32,19 +34,20 @@ struct ChangeMonitor {
 }
 
 impl ChangeMonitor {
-    fn start(inputs: Vec<(PathBuf, u64)>, cancellation: CompilationCancellation) -> Self {
+    fn start(inputs: Vec<WatchInput>, cancellation: CompilationCancellation) -> Self {
         let stop = Arc::new(AtomicBool::new(false));
         let changed = Arc::new(AtomicBool::new(false));
         let thread_stop = stop.clone();
         let thread_changed = changed.clone();
         let thread = thread::spawn(move || {
+            let mut poll = PollBackoff::new();
             while !thread_stop.load(Ordering::Acquire) {
                 if inputs_changed(&inputs) {
                     thread_changed.store(true, Ordering::Release);
                     cancellation.cancel();
                     return;
                 }
-                thread::sleep(POLL_INTERVAL);
+                thread::park_timeout(poll.next_delay());
             }
         });
         Self {
@@ -60,6 +63,9 @@ impl ChangeMonitor {
 
     fn finish(self) -> bool {
         self.stop.store(true, Ordering::Release);
+        // Idle polling backs off, but completing a compile must never wait for
+        // the monitor's current timeout to expire.
+        self.thread.thread().unpark();
         self.thread
             .join()
             .expect("watch change monitor thread panicked");
@@ -222,22 +228,19 @@ fn print_source_load_error(error: SourceLoadError, error_format: ErrorFormat) {
     }
 }
 
-fn wait_for_change(inputs: &[(PathBuf, u64)]) {
+fn wait_for_change(inputs: &[WatchInput]) {
+    let mut poll = PollBackoff::new();
     while !inputs_changed(inputs) {
-        thread::sleep(POLL_INTERVAL);
+        thread::sleep(poll.next_delay());
     }
 }
 
-fn debounce(inputs: &[(PathBuf, u64)]) {
-    let paths = inputs
-        .iter()
-        .map(|(path, _)| path.clone())
-        .collect::<Vec<_>>();
-    let mut previous = current_fingerprints(&paths);
+fn debounce(inputs: &[WatchInput]) {
+    let mut previous = current_fingerprints(inputs);
     let mut quiet_since = Instant::now();
     while quiet_since.elapsed() < QUIET_PERIOD {
         thread::sleep(POLL_INTERVAL);
-        let current = current_fingerprints(&paths);
+        let current = current_fingerprints(inputs);
         if current != previous {
             previous = current;
             quiet_since = Instant::now();
@@ -245,27 +248,69 @@ fn debounce(inputs: &[(PathBuf, u64)]) {
     }
 }
 
-fn inputs_changed(inputs: &[(PathBuf, u64)]) -> bool {
+fn inputs_changed(inputs: &[WatchInput]) -> bool {
+    inputs_changed_with_reader(inputs, WatchFingerprint::read)
+}
+
+fn current_fingerprints(inputs: &[WatchInput]) -> Vec<Option<WatchFingerprint>> {
+    let mut canonical_fingerprints = HashMap::new();
     inputs
         .iter()
-        .any(|(path, expected)| file_hash(path).as_ref() != Some(expected))
+        .map(|input| {
+            if input.requested_path() != input.canonical_path()
+                && fs::canonicalize(input.requested_path()).ok().as_deref()
+                    != Some(input.canonical_path())
+            {
+                return None;
+            }
+            *canonical_fingerprints
+                .entry(input.canonical_path().to_owned())
+                .or_insert_with(|| WatchFingerprint::read(input.canonical_path()))
+        })
+        .collect()
 }
 
-fn current_fingerprints(paths: &[PathBuf]) -> Vec<Option<u64>> {
-    paths.iter().map(|path| file_hash(path)).collect()
+fn inputs_changed_with_reader<F>(inputs: &[WatchInput], mut read: F) -> bool
+where
+    F: FnMut(&Path) -> Option<WatchFingerprint>,
+{
+    let mut canonical_fingerprints = HashMap::new();
+    inputs.iter().any(|input| {
+        let requested = input.requested_path();
+        let canonical = input.canonical_path();
+        if requested != canonical && fs::canonicalize(requested).ok().as_deref() != Some(canonical)
+        {
+            return true;
+        }
+
+        let observed = canonical_fingerprints
+            .entry(canonical.to_owned())
+            .or_insert_with(|| read(canonical));
+        observed.as_ref() != Some(&input.fingerprint())
+    })
 }
 
-fn file_hash(path: &Path) -> Option<u64> {
-    fs::read(path).ok().map(|bytes| content_hash(&bytes))
+#[derive(Clone, Copy, Debug)]
+struct PollBackoff {
+    next: Duration,
 }
 
-fn content_hash(bytes: &[u8]) -> u64 {
-    let mut hash = 0xcbf29ce484222325_u64;
-    for byte in bytes {
-        hash ^= u64::from(*byte);
-        hash = hash.wrapping_mul(0x100000001b3);
+impl PollBackoff {
+    fn new() -> Self {
+        Self {
+            next: POLL_INTERVAL,
+        }
     }
-    hash
+
+    fn next_delay(&mut self) -> Duration {
+        let delay = self.next;
+        self.next = self
+            .next
+            .checked_mul(2)
+            .unwrap_or(MAX_POLL_INTERVAL)
+            .min(MAX_POLL_INTERVAL);
+        delay
+    }
 }
 
 #[cfg(test)]
@@ -283,7 +328,8 @@ mod tests {
                 .as_nanos()
         ));
         fs::write(&path, b"alpha").unwrap();
-        let inputs = vec![(path.clone(), content_hash(b"alpha"))];
+        let fingerprint = WatchFingerprint::from_bytes(b"alpha");
+        let inputs = vec![WatchInput::new(path.clone(), path.clone(), fingerprint)];
         assert!(!inputs_changed(&inputs));
         fs::write(&path, b"bravo").unwrap();
         assert!(inputs_changed(&inputs));
@@ -301,8 +347,78 @@ mod tests {
                 .as_nanos()
         ));
         fs::write(&path, b"source").unwrap();
-        let inputs = vec![(path.clone(), content_hash(b"source"))];
+        let fingerprint = WatchFingerprint::from_bytes(b"source");
+        let inputs = vec![WatchInput::new(path.clone(), path.clone(), fingerprint)];
         fs::remove_file(path).unwrap();
         assert!(inputs_changed(&inputs));
+    }
+
+    #[test]
+    fn backs_off_idle_polls_and_caps_the_delay() {
+        let mut poll = PollBackoff::new();
+        assert_eq!(poll.next_delay(), Duration::from_millis(25));
+        assert_eq!(poll.next_delay(), Duration::from_millis(50));
+        assert_eq!(poll.next_delay(), Duration::from_millis(100));
+        assert_eq!(poll.next_delay(), Duration::from_millis(200));
+        assert_eq!(poll.next_delay(), Duration::from_millis(250));
+        assert_eq!(poll.next_delay(), Duration::from_millis(250));
+    }
+
+    #[test]
+    fn a_new_activity_cycle_restarts_at_low_latency() {
+        let mut idle_cycle = PollBackoff::new();
+        for _ in 0..8 {
+            idle_cycle.next_delay();
+        }
+        assert_eq!(idle_cycle.next_delay(), MAX_POLL_INTERVAL);
+
+        let mut next_cycle = PollBackoff::new();
+        assert_eq!(next_cycle.next_delay(), POLL_INTERVAL);
+    }
+
+    #[test]
+    fn reads_one_physical_path_for_requested_and_canonical_aliases() {
+        let root = std::env::temp_dir().join(format!(
+            "rue-watch-alias-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir(&root).unwrap();
+        let canonical = root.join("source.rue");
+        let requested = root.join("alias.rue");
+        fs::write(&canonical, b"source").unwrap();
+        let canonical = fs::canonicalize(canonical).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&canonical, &requested).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(&canonical, &requested).unwrap();
+
+        let fingerprint = WatchFingerprint::from_bytes(b"source");
+        let inputs = vec![
+            WatchInput::new(requested.clone(), canonical.clone(), fingerprint),
+            WatchInput::new(canonical.clone(), canonical.clone(), fingerprint),
+        ];
+        let mut reads = 0;
+        assert!(!inputs_changed_with_reader(&inputs, |path| {
+            reads += 1;
+            WatchFingerprint::read(path)
+        }));
+        assert_eq!(reads, 1);
+
+        let other = root.join("other.rue");
+        fs::write(&other, b"other").unwrap();
+        fs::remove_file(requested).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&other, root.join("alias.rue")).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(&other, root.join("alias.rue")).unwrap();
+        assert!(inputs_changed(&inputs));
+        fs::remove_file(root.join("alias.rue")).unwrap();
+        fs::remove_file(canonical).unwrap();
+        fs::remove_file(other).unwrap();
+        fs::remove_dir(root).unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- centralize the watch fingerprint policy in the filesystem driver
- collapse requested/canonical aliases to one content read per observation
- back idle polling off from 25 ms to a 250 ms cap while preserving the bounded debounce cadence and prompt monitor shutdown
- add deterministic coverage for backoff/reset, same-length edits, deletion, alias deduplication, and retargeting

## Validation
- `./buck2 test //crates/rue:rue-test //crates/rue:rue-driver-test`
- `scripts/rue quick`
- `scripts/rue fmt`
- `scripts/rue premerge`

Fixes RUE-1634