### PR TITLE
RUE-1635, RUE-1677: stop re-hashing the batch key and re-counting ABI slots

### DIFF
--- a/crates/rue-cfg/src/verify.rs
+++ b/crates/rue-cfg/src/verify.rs
@@ -309,6 +309,15 @@ struct Verifier<'a> {
     /// may only be built once targets are known to be in bounds and payload
     /// slices are known to be valid.
     dominators: Option<DominatorTree>,
+    /// Memo for [`Verifier::abi_slot_count`], which is a pure function of the
+    /// type against this verifier's fixed pool: `block`, `value`, and `role`
+    /// only name the site in an error message.
+    ///
+    /// The count recurses through struct fields, array elements, and enum
+    /// payloads, and the same types recur constantly across a function's
+    /// slots. Uncached, a fresh Lattice build called it about two million
+    /// times for 406M instructions, 4.8% of the whole compile.
+    abi_slot_cache: std::cell::RefCell<ahash::AHashMap<Type, u32>>,
 }
 
 impl<'a> Verifier<'a> {
@@ -324,6 +333,7 @@ impl<'a> Verifier<'a> {
             skip_unreachable_blocks: false,
             attachments: vec![None; cfg.value_count()],
             dominators: None,
+            abi_slot_cache: std::cell::RefCell::new(ahash::AHashMap::new()),
         }
     }
 
@@ -766,6 +776,10 @@ impl<'a> Verifier<'a> {
         value: CfgValue,
         role: &str,
     ) -> Result<u32, CfgVerificationError> {
+        let cached = self.abi_slot_cache.borrow().get(&ty).copied();
+        if let Some(width) = cached {
+            return Ok(width);
+        }
         let width = match ty.kind() {
             TypeKind::I8
             | TypeKind::I16
@@ -832,6 +846,7 @@ impl<'a> Verifier<'a> {
                 1u32.saturating_add(payload_width)
             }
         };
+        self.abi_slot_cache.borrow_mut().insert(ty, width);
         Ok(width)
     }
 

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -58,10 +58,10 @@ mod tests {
             assert!(key, "owned and shared query display identities must agree");
         }
 
-        let optimized_batch = crate::revisioned_query_database::OptimizedCfgBatchKey {
-            keys: Arc::from([optimized.clone()]),
-            generation: 0,
-        };
+        let optimized_batch = crate::revisioned_query_database::OptimizedCfgBatchKey::new(
+            Arc::from([optimized.clone()]),
+            0,
+        );
         let codegen_batch = crate::revisioned_query_database::CodegenUnitBatchKey {
             keys: Arc::from([codegen.clone()]),
         };

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -1418,13 +1418,62 @@ pub(crate) struct BackendRootCandidate {
     object_projection_terminals: usize,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone)]
 pub(crate) struct OptimizedCfgBatchKey {
     pub(crate) keys: Arc<[crate::cfg_query::OptimizedCfgQueryKey]>,
     /// O2/O3 batches are request-local because their values may contain
     /// rewritten callers. Child CFG terminals remain reusable; this token
     /// prevents a rewritten whole-program result crossing request boundaries.
     pub(crate) generation: u64,
+    /// Digest and memo bucket derived once at construction.
+    ///
+    /// This key names every optimized-CFG unit in the batch, so it is
+    /// whole-program sized: on Lattice it absorbs up to 30,744 bytes. Every
+    /// `CodegenUnitQueryKey` carries a shared handle to one of these, and a
+    /// derived `Hash` made each of the 1,280 codegen keys re-walk the entire
+    /// list — 11.7 MB of hashing per fresh build, 98.4% of everything the
+    /// codegen key absorbed. Deriving both values once here makes hashing the
+    /// batch constant-time for every holder.
+    digest: rue_query::StableKeyHash,
+    memo_hash: u64,
+}
+
+impl OptimizedCfgBatchKey {
+    pub(crate) fn new(
+        keys: Arc<[crate::cfg_query::OptimizedCfgQueryKey]>,
+        generation: u64,
+    ) -> Self {
+        let mut hasher = rue_query::StableHasher::new();
+        hasher.write_usize(keys.len());
+        for key in keys.iter() {
+            key.stable_hash(&mut hasher);
+        }
+        generation.hash(&mut hasher);
+        let digest = hasher.finish128();
+        let memo_hash = hasher.finish();
+        Self {
+            keys,
+            generation,
+            digest,
+            memo_hash,
+        }
+    }
+}
+
+impl PartialEq for OptimizedCfgBatchKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.generation == other.generation
+            && (Arc::ptr_eq(&self.keys, &other.keys) || self.keys == other.keys)
+    }
+}
+
+impl Eq for OptimizedCfgBatchKey {}
+
+impl Hash for OptimizedCfgBatchKey {
+    /// A memo bucket selector; `PartialEq` above stays authoritative.
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.memo_hash.hash(state);
+    }
 }
 
 impl QueryKey for OptimizedCfgBatchKey {
@@ -1438,12 +1487,12 @@ impl QueryKey for OptimizedCfgBatchKey {
         identity
     }
 
+    /// The digest derived once in [`Self::new`], over the same field set this
+    /// used to absorb per call.
     fn stable_hash(&self, hasher: &mut rue_query::StableHasher) {
-        hasher.write_usize(self.keys.len());
-        for key in self.keys.iter() {
-            key.stable_hash(hasher);
-        }
-        self.generation.hash(hasher);
+        let digest = self.digest.to_u128();
+        hasher.write_u64(digest as u64);
+        hasher.write_u64((digest >> 64) as u64);
     }
 }
 
@@ -16643,7 +16692,7 @@ impl RevisionedQueryDatabase {
         } else {
             0
         };
-        let key = OptimizedCfgBatchKey { keys, generation };
+        let key = OptimizedCfgBatchKey::new(keys, generation);
         let attempt = self.runtime.request_registered(
             &self.optimized_cfg_batches,
             revision,


### PR DESCRIPTION
Two independent memoizations, one commit each. Both `cmp`-verified byte-identical.

| | Retired instructions | |
| --- | ---: | ---: |
| trunk before | 8,693,426,827 | |
| RUE-1635 — batch key digest | 8,448,072,684 | −2.82% |
| RUE-1677 — verifier ABI slot memo | **8,319,991,532** | −1.52% |

Cumulative with the three already merged: **9,486,324,770 → 8,319,991,532, −12.29%.**

---

## RUE-1635 — the optimized-CFG batch key was re-hashed whole-program by every codegen key

`OptimizedCfgBatchKey` names *every* optimized-CFG unit in a batch. It derived `Hash`, and `CodegenUnitQueryKey` carries an `Option<Arc<OptimizedCfgBatchKey>>` — so each of the 1,280 codegen keys re-walked the entire batch list, once for its memo hash and once for its digest, even though all of them share one `Arc` to the same batch.

I probed every codegen key constructed during a fresh build, recording the byte stream each component absorbs:

| Component | Median | Max | Total over 1,280 keys |
| --- | ---: | ---: | ---: |
| `function` | 24 | 472 | 68,700 |
| `optimized_cfg` | 56 | 504 | 109,660 |
| `request` | 5 | 5 | 6,400 |
| **`optimized_cfg_batch`** | 8 | **30,744** | **11,689,920** |

**98.4%** of everything the codegen key absorbed. The batch key now derives its digest and memo hash once in a constructor; `PartialEq` stays authoritative over the full key list with an `Arc::ptr_eq` shortcut. It is constructed in exactly one place.

### This corrects RUE-1627's diagnosis

#2570 attributed this cost to walking deep recursive `FunctionInstanceKey` trees. **That was wrong** — those trees total 68,700 bytes across the whole build. The change itself was still correct and its 2.58% was real, because it cut the batch walks per key from five to one; this removes the remaining walks. RUE-1627 and RUE-1630 have both been corrected in Linear.

---

## RUE-1677 — the verifier recomputed `abi_slot_count` for every slot

`Verifier::abi_slot_count` is a pure function of the type against the verifier's fixed pool (`block`, `value`, `role` only name the site in an error message), but nothing memoized it. It recurses through struct fields, array elements, and enum payloads, and `check_local_slot` calls it once per slot — **2,334,232 calls** on a fresh build.

**The verifier is not weakened.** Per RUE-45 it deliberately uses `assert!`/`panic!` rather than `debug_assert!` so the guard fires in release builds, turning malformed AIR→CFG output into a localized compiler-bug report instead of a miscompile. This only stops it recomputing the same answer.

The memo is scoped to one verifier instance, so it inherits that verifier's pool and cannot serve an answer computed against a different one. The early `Ok(0)` returns for a missing pool bypass it.

- calls: 2,334,232 → 756,496 (−67%)
- cost: 431,770,173 → 80,392,677 instructions (−81%)

---

## Validation

- `scripts/rue premerge` — 196 pass, 0 fail, 0 build failures
- `scripts/rue fmt` applied
- Emitted Lattice executable byte-identical against the pre-series compiler

## Measurement note

An initial reading put the verifier at 4.8% of the build. That summed callgrind's *inclusive* call costs across a recursive function and so double-counted the recursion; the honest self-cost figure is about 2.6%, which is consistent with the 1.52% end-to-end result. Wall time on this four-core host cannot resolve changes this size, so every figure above is retired instructions.