### PR TITLE
RUE-1682: stop probing recursive identity keys per call instruction

### DIFF
--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -1864,20 +1864,38 @@ pub(crate) fn apply_general_inlining(
         records.insert(key.cfg.function.clone(), record.clone());
     }
 
+    // Membership in the batch is asked once per call instruction across every
+    // function, and again for every edge when the call graph is built.
+    // `records` is a `BTreeMap` whose keys are recursive function identities,
+    // so each probe walks a tree O(log n) times. A hash set answers the same
+    // question once per probe; `records` keeps its ordered iteration, which
+    // call-site selection depends on.
+    let record_keys: ahash::AHashSet<crate::FunctionInstanceKey> =
+        records.keys().cloned().collect();
+
     // Keep every edge, including duplicate edges. The multiplicity is useful
     // for deterministic call-site selection and makes the graph description
     // honest even though SCC detection only needs its distinct neighbors.
-    let mut edges = std::collections::BTreeMap::<
-        crate::FunctionInstanceKey,
-        Vec<crate::FunctionInstanceKey>,
-    >::new();
-    let mut callsites = std::collections::BTreeMap::<
+    // These three are only ever inserted into and looked up by key; nothing
+    // iterates them, so their ordering is not observable and they do not need
+    // to pay a recursive-identity comparison per probe. `records` and `graph`
+    // stay ordered, because iteration order there does reach the output
+    // through call-site selection and SCC detection.
+    let mut edges: ahash::AHashMap<crate::FunctionInstanceKey, Vec<crate::FunctionInstanceKey>> =
+        ahash::AHashMap::new();
+    let mut callsites: ahash::AHashMap<
         crate::FunctionInstanceKey,
         Vec<(rue_cfg::CfgValue, crate::FunctionInstanceKey)>,
-    >::new();
-    let mut has_calls = std::collections::BTreeMap::new();
+    > = ahash::AHashMap::new();
+    let mut has_calls: ahash::AHashMap<crate::FunctionInstanceKey, bool> = ahash::AHashMap::new();
     for (function, record) in &records {
         let mut calls = Vec::new();
+        // Every edge found in this iteration belongs to `function`, so the
+        // callees accumulate locally and land in `edges` once. Going through
+        // `edges.entry(function.clone())` per call instruction cost a
+        // `BTreeMap` probe over a recursive identity plus a deep key clone,
+        // for each of them.
+        let mut function_edges: Vec<crate::FunctionInstanceKey> = Vec::new();
         let mut any_call = false;
         for block in record.cfg.blocks() {
             for &value in &block.insts {
@@ -1893,14 +1911,14 @@ pub(crate) fn apply_general_inlining(
                 let Some(callee) = record.domains.callable_for_symbol(name) else {
                     continue;
                 };
-                edges
-                    .entry(function.clone())
-                    .or_default()
-                    .push(callee.clone());
-                if records.contains_key(&callee) {
+                function_edges.push(callee.clone());
+                if record_keys.contains(&callee) {
                     calls.push((value, callee));
                 }
             }
+        }
+        if !function_edges.is_empty() {
+            edges.insert(function.clone(), function_edges);
         }
         has_calls.insert(function.clone(), any_call);
         callsites.insert(function.clone(), calls);
@@ -1914,7 +1932,7 @@ pub(crate) fn apply_general_inlining(
                 .get(function)
                 .into_iter()
                 .flatten()
-                .filter(|callee| records.contains_key(*callee))
+                .filter(|callee| record_keys.contains(*callee))
                 .cloned()
                 .collect::<Vec<_>>(),
         );


### PR DESCRIPTION
Implements RUE-1682.

## The finding

`StableDefinitionKey::cmp` is **4,833,135 calls and 2.9%** of a fresh `-O3 -j1` Lattice build. Tracing it up: it is mostly recursive descent from `FunctionInstanceKey::cmp` (4,345,963 calls), and the single largest root caller of *that* is `apply_general_inlining` — **1,163,640 comparisons for 148M instructions**.

The pass builds its call graph in `BTreeMap`s keyed by `FunctionInstanceKey`. Those keys are recursive identities bottoming out in `StableDefinitionKey`, whose `Ord` compares a module path and a definition name as strings — so every probe walks a tree and ends in a `memcmp`.

## Three changes

**Membership probes.** `records.contains_key(&callee)` ran once per call instruction across every function, and again per edge while building the graph. Both ask only whether a callee is in the batch, so both now go to a hash set built once from `records.keys()`.

**Edge accumulation.** `edges.entry(function.clone()).or_default().push(callee)` ran per call instruction — a `BTreeMap` probe plus a deep key clone each time — even though every edge found in one iteration of that loop belongs to the same function. The callees now accumulate in a local `Vec` and land in `edges` once.

**Map keying.** `edges`, `callsites`, and `has_calls` are only inserted into and looked up by key; nothing iterates them, so their ordering is not observable.

## What deliberately did not change

`records` and `graph` stay `BTreeMap`. Their iteration order *does* reach the output — through deterministic call-site selection and through `recursive_scc_nodes` — and this is exactly the hazard class RUE-1626 tracks, so I left them alone rather than assume.

## Result

| | Retired instructions | |
| --- | ---: | ---: |
| before | 8,319,004,980 | |
| membership hash set | 8,260,626,608 | −0.70% |
| edge accumulation hoisted | 8,228,346,514 | −0.39% |
| three maps rekeyed | **8,168,738,864** | −0.72% |

**−1.81%**, emitted executable byte-identical (`cmp`-verified). Cumulative across the session: **9,486,324,770 → 8,168,738,864, −13.89%.**

## Relationship to RUE-1630

RUE-1630 proposes fixing the same underlying cost at the representation — interning the module path and definition name to `u32` symbols so `Ord` compares integers. This removes the probes in the hottest consumer instead, and does not depend on that work.

## Validation

- `scripts/rue premerge` — 196 pass, 0 fail, 0 build failures
- `scripts/rue fmt` applied
- Emitted Lattice executable byte-identical against the pre-series compiler

---
_Generated by [Claude Code](https://claude.ai/code/session_011sbnn24fuaT6oLix6Sgk7S)_