### PR TITLE
Close the accessor-escape join bypass; fix the inference lookup trio

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -569,18 +569,37 @@ impl<'a> ConstraintGenerator<'a> {
         false
     }
 
-    /// Is this method call the slice `len` of 7.2:17 — `s.len()` on a receiver
-    /// whose type is the synthetic slice struct `[T]`?
+    /// Is this method call a view `len` — `s.len()` on a receiver whose type is
+    /// the synthetic slice struct `[T]` (7.2:17), the `str` string type
+    /// (3.7:45), or a fixed-capacity `Str(N)` (3.7:52)? All three rules give the
+    /// result type as `u64`.
     ///
-    /// Only the slice view qualifies. `str`, `Str(N)`, and StrBuf carry
-    /// source-defined `len` signatures that ordinary method lookup already
-    /// resolves; the slice view has no declared method at all, so its result
-    /// type has to be published here for the call to take part in ordinary
-    /// unification (RUE-1611).
-    fn is_slice_len_call(&self, receiver: StructId, method: Spur, arg_count: usize) -> bool {
+    /// These three share one representation (a `{ptr, len}` view) and one
+    /// method route: sema dispatches every method call on them through
+    /// `analyze_slice_method`, which answers `len()` by reading the `len` word
+    /// as `u64` and rejects everything else as an undefined method. None of
+    /// them has a *declared* `len`, so unless its result type is published
+    /// here the call types as `ERROR`, which unifies with any annotation —
+    /// `let n: i32 = s.len();` then passed inference and reached CFG
+    /// verification as a `u64` value in an `i32` slot (RUE-1611 for `[T]`,
+    /// RUE-1679 for `str`/`Str(N)`).
+    ///
+    /// StrBuf is not in this family: it is a source-defined struct whose
+    /// declared `len` ordinary method lookup already resolves.
+    fn is_view_len_call(&self, receiver: StructId, method: Spur, arg_count: usize) -> bool {
+        let name: &str = &self.type_pool.struct_def(receiver).name;
         arg_count == 0
             && self.interner.resolve(&method) == "len"
-            && crate::types::is_slice_struct_name(&self.type_pool.struct_def(receiver).name)
+            && (crate::types::is_slice_struct_name(name)
+                || crate::types::is_string_view_struct_name(name))
+    }
+
+    /// The string-literal analogue of [`Self::is_view_len_call`]: a zero-arg
+    /// `len` on a receiver whose text type has not been fixed yet. Every text
+    /// type the literal can settle on reports a `u64` byte length, so the
+    /// result is known even though the receiver is not (RUE-1679).
+    fn is_string_literal_len_call(&self, method: Spur, arg_count: usize) -> bool {
+        arg_count == 0 && self.interner.resolve(&method) == "len"
     }
 
     /// Whether an already-known operand is one of Rue's packed string types.
@@ -777,6 +796,18 @@ impl<'a> ConstraintGenerator<'a> {
         }
         self.const_values
             .and_then(|values| values.get(&(file_id, sym)).copied())
+    }
+
+    /// The integer bound to a comptime *value* parameter of the specialization
+    /// currently being analyzed (`comptime n: u64` → `n = 3` for `make(3)`).
+    /// `None` outside a specialization, for a name that is not a comptime value
+    /// parameter, and for a non-integer binding. See the `comptime_values`
+    /// field (RUE-268).
+    fn comptime_value_int(&self, sym: Spur) -> Option<i128> {
+        match self.comptime_values?.get(&sym)? {
+            ConstValue::Integer(n) => Some(*n),
+            _ => None,
+        }
     }
 
     /// Resolve a bare type-alias name in alias-head position against the
@@ -2850,17 +2881,26 @@ impl<'a> ConstraintGenerator<'a> {
 
             // Array-repeat literal `[value; count]` (RUE-235). The array type
             // is `[typeof value; count]`; every slot has the value's type. The
-            // count is a compile-time constant resolved here (literal or a
-            // file-level `const`); an unresolved count (e.g. a `comptime` value
-            // parameter, only known at specialization) yields a fresh variable
-            // and is resolved/diagnosed by sema.
+            // count is a compile-time constant resolved here: a literal, a
+            // comptime value parameter of the specialization being analyzed
+            // (`fn make(comptime n: u64) -> i32 { [0; n][0] }`, spec 7.1:37),
+            // or a file-level `const`. A count that still doesn't resolve
+            // yields a fresh variable and is resolved/diagnosed by sema.
             InstData::ArrayRepeat { value, count } => {
                 let value_info = self.generate(*value, ctx);
                 continues &= value_info.continues;
                 let resolved = match count {
                     RepeatCount::Literal(n) => Some(*n),
+                    // A comptime value parameter captured at the call site
+                    // takes precedence over a file-level `const` of the same
+                    // name, the same precedence array-TYPE lengths use
+                    // (RUE-252). Without the value-parameter half the repeat's
+                    // type stayed an unconstrained variable that decayed to
+                    // `<error>`, and sema reported the array-repeat literal as
+                    // an un-annotatable empty array (E0903, RUE-1681).
                     RepeatCount::Named(sym) => self
-                        .const_value((span.file_id, *sym))
+                        .comptime_value_int(*sym)
+                        .or_else(|| self.const_value((span.file_id, *sym)))
                         .and_then(|v| u64::try_from(v).ok()),
                 };
                 match resolved {
@@ -3054,6 +3094,26 @@ impl<'a> ConstraintGenerator<'a> {
                         span,
                         !arg_diverged && !Self::is_never_concrete(&return_type),
                     );
+                }
+
+                // `len()` on a string literal whose text type is still
+                // contextual. Its result is `u64` whichever type the literal
+                // settles on — `str` (3.7:45) and `Str(N)` (3.7:52) by rule,
+                // StrBuf by its source-defined signature — so publish that
+                // result without pinning the receiver, which keeps its stable
+                // `str` default. The StrBuf-signature
+                // block above answers the same call only when the program
+                // imports StrBuf; without that import the receiver stayed a
+                // bare type variable, the call fell through to a fresh variable
+                // that unified with any annotation, and `let n: i32 =
+                // "hi".len();` reached CFG verification as a `u64` value in an
+                // `i32` slot (RUE-1679, the RUE-1611 class on the string rungs).
+                if self.is_string_literal_candidate(&receiver_info.ty)
+                    && self.is_string_literal_len_call(*method, call_args.len())
+                {
+                    let return_type = InferType::Concrete(Type::U64);
+                    self.record_type(inst_ref, return_type.clone());
+                    return ExprInfo::with_continues(return_type, span, receiver_info.continues);
                 }
 
                 // Resolve the call's result type from the receiver's type.
@@ -3266,8 +3326,9 @@ impl<'a> ConstraintGenerator<'a> {
                             // back to late-registered anonymous-struct
                             // signatures, RUE-164)
                             let method_key = (struct_id, *method);
-                            if self.is_slice_len_call(struct_id, *method, call_args.len()) {
-                                // `len` is the one method a slice `[T]` has
+                            if self.is_view_len_call(struct_id, *method, call_args.len()) {
+                                // `len` is the one method a `{ptr, len}` view —
+                                // a slice `[T]`, a `str`, a `Str(N)` — has
                                 // (7.2:17-18) and sema synthesizes it from the
                                 // view's `len` word, so no signature is
                                 // registered for the synthetic struct. Publish
@@ -3275,7 +3336,8 @@ impl<'a> ConstraintGenerator<'a> {
                                 // call typed as `ERROR`, which unifies with any
                                 // annotation, so `let n: i32 = s.len();` passed
                                 // inference and reached CFG verification as a
-                                // `u64` value in an `i32` binding (RUE-1611).
+                                // `u64` value in an `i32` binding (RUE-1611,
+                                // RUE-1679).
                                 InferType::Concrete(Type::U64)
                             } else if let Some(method_sig) = self.method_sig(&method_key) {
                                 // Generate constraints for arguments
@@ -3855,25 +3917,35 @@ impl<'a> ConstraintGenerator<'a> {
     /// `identity(i32, 42)`) to a concrete type, if it can be determined during
     /// constraint generation.
     ///
-    /// Handles type literals (`i32`, `bool`, ...), named struct/enum types, and
-    /// forwarded type parameters (a reference to `T` inside a specialized generic
-    /// body, resolved via `self.type_subst`). Returns `None` for type values that
-    /// are only known to semantic analysis (e.g. a local variable bound to an
-    /// anonymous struct type) - those are type-checked in sema instead.
+    /// Handles type literals (`i32`, `bool`, ...), named struct/enum types
+    /// (user-declared as well as built-in), and forwarded type parameters (a
+    /// reference to `T` inside a specialized generic body, resolved via
+    /// `self.type_subst`). Returns `None` for type values that are only known
+    /// to semantic analysis (e.g. a local variable bound to an anonymous struct
+    /// type) - those are type-checked in sema instead.
     fn extract_type_argument(&self, arg: InstRef, ctx: &ConstraintContext) -> Option<Type> {
+        let file_id = self.rir.get(arg).span.file_id;
         let resolve_sym = |sym: &Spur| -> Option<Type> {
+            // A forwarded type parameter substitutes to whatever the enclosing
+            // specialization bound it to, of any kind (a primitive, an array,
+            // a nominal type), so this lookup is unfiltered and comes first.
             if let Some(subst) = self.type_subst {
                 if let Some(&ty) = subst.get(sym) {
                     return Some(ty);
                 }
             }
-            if let Some(ty) = self.builtin_struct_type(*sym) {
-                return Some(ty);
-            }
-            if let Some(ty) = self.builtin_enum_type(*sym) {
-                return Some(ty);
-            }
-            None
+            // A directly named struct/enum — `identity(Foo, ..)` — is a type
+            // value exactly like `identity(i32, ..)`. `struct_type_for` /
+            // `enum_type_for` are the same by-file lookups the type-qualified
+            // call path uses (lexical aliases, file-level aliases, the
+            // referencing file's declarations, then builtins), so a nominal
+            // spelling resolves wherever its alias spelling already did.
+            // Consulting only the builtin tables left the argument out of
+            // `type_subst`, so a `-> T` return type could not be substituted
+            // and stayed the literal `type` placeholder — reported as a bogus
+            // "expected Foo, found type" mismatch at the binding (RUE-1680).
+            self.struct_type_for(sym, file_id)
+                .or_else(|| self.enum_type_for(sym, file_id))
         };
 
         match &self.rir.get(arg).data {

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -5607,10 +5607,110 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         Ok(())
     }
 
-    /// Reject the direct escape of an accessor result (ADR-0062): `operand`
-    /// is the RIR expression consumed at an escape-shaped site, and if it was
-    /// expanded as an accessor call, the borrowed place would outlive its
-    /// enclosing full expression there.
+    /// Every accessor result the value of `operand` can be: the accessor call
+    /// itself, or — when `operand` is a *join* — the results its arms
+    /// contribute, in leftmost-first order (ADR-0062, RUE-1678).
+    ///
+    /// A block tail, an `if`/`else` arm, and a `match` arm each materialize
+    /// their value AS the value of the enclosing expression, so an accessor
+    /// result reached through one is still the borrowed place that expression
+    /// consumes: `let b = if c { p.at(i) } else { 0 };` binds exactly the
+    /// second-class place `let b = p.at(i);` binds. Only the accessor CALL is
+    /// registered in `ctx.accessor_call_insts` (a join has no AIR shape of its
+    /// own to peel), so the join relation is decided structurally here, from
+    /// the RIR, and composes through nesting — an `if` inside a `match` arm
+    /// inside a block reports the accessor at the bottom.
+    ///
+    /// Arms contribute independently: a join whose arms call two different
+    /// accessors yields both, and a join with one accessor arm and one
+    /// ordinary arm still yields that one, because the accessor path escapes.
+    fn accessor_results_of(&self, operand: InstRef, ctx: &AnalysisContext) -> Vec<(Spur, Spur)> {
+        // Overwhelmingly common case: the body expanded no accessor at all,
+        // so no join can carry one and nothing needs walking or allocating.
+        if ctx.accessor_call_insts.is_empty() {
+            return Vec::new();
+        }
+        let rir = self.body_rir_ref();
+        let mut found = Vec::new();
+        // Depth-first over a RIR expression tree (acyclic by construction),
+        // children pushed in reverse so arms are visited left to right.
+        let mut pending = vec![operand];
+        while let Some(current) = pending.pop() {
+            if let Some(direct) = ctx.accessor_call_insts.get(&current) {
+                found.push(*direct);
+                continue;
+            }
+            match &rir.get(current).data {
+                InstData::Block { instructions } => {
+                    if let Some(tail) = rir.block_insts(instructions).values().last() {
+                        pending.push(tail);
+                    }
+                }
+                InstData::Branch {
+                    then_block,
+                    else_block,
+                    ..
+                } => {
+                    // An `if` without `else` is unit-typed and carries no
+                    // value, so only the two-armed form can join a result.
+                    if let Some(else_block) = else_block {
+                        pending.push(*else_block);
+                        pending.push(*then_block);
+                    }
+                }
+                InstData::Match { arms, .. } => {
+                    // The arm iterator is not double-ended, so collect the
+                    // bodies before reversing them onto the stack.
+                    let bodies: Vec<InstRef> =
+                        rir.match_arms(arms).iter().map(|(_, body)| body).collect();
+                    pending.extend(bodies.into_iter().rev());
+                }
+                _ => {}
+            }
+        }
+        found
+    }
+
+    /// Does the value of `operand` carry an accessor result out of a join
+    /// (ADR-0062, RUE-1678)? Used by the `if`/`match` arm analyses to decide
+    /// whether an arm's accessor loan outlives the arm's nested-full-expression
+    /// boundary; see [`Self::accessor_results_of`].
+    fn yields_accessor_result(&self, operand: InstRef, ctx: &AnalysisContext) -> bool {
+        !self.accessor_results_of(operand, ctx).is_empty()
+    }
+
+    /// Carry an `if`/`match` arm's accessor loans into the join's enclosing
+    /// full expression, when the arm's value is what the join yields
+    /// (ADR-0062 6.6:10, RUE-1678).
+    ///
+    /// Each arm is analyzed as a nested full expression, so `loans` — taken
+    /// with `nested_expression_loans` just before that boundary closed — has
+    /// already been discarded by the time this runs. For an arm whose value
+    /// is an accessor result the discard is wrong: the loan's extent is the
+    /// full expression the JOIN belongs to, so an exclusive use of the same
+    /// root anywhere in it is still E0259 (`using(if c { g.at(0) } else { 0 },
+    /// inout g)`). Arms are alternatives rather than siblings, so every arm's
+    /// loans are readmitted only after the last arm has been analyzed —
+    /// readmitting earlier would make one arm's loan conflict with the next
+    /// arm's accessor call on the same root.
+    pub(crate) fn readmit_arm_accessor_loans(
+        &self,
+        ctx: &mut AnalysisContext,
+        arm: InstRef,
+        loans: Vec<(Spur, Span, CallLoanKind)>,
+    ) {
+        if loans.is_empty() || !self.yields_accessor_result(arm, ctx) {
+            return;
+        }
+        ctx.readmit_expression_loans(loans);
+    }
+
+    /// Reject the escape of an accessor result (ADR-0062): `operand` is the
+    /// RIR expression consumed at an escape-shaped site, and if its value is
+    /// an accessor result — the call itself, or one carried out of an
+    /// `if`/`match`/block join — the borrowed place would outlive its
+    /// enclosing full expression there. A join over two accessors escapes
+    /// either way, so the diagnostic names the leftmost contributing arm.
     pub(crate) fn reject_accessor_result_escape(
         &self,
         operand: InstRef,
@@ -5618,7 +5718,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         span: Span,
         ctx: &AnalysisContext,
     ) -> CompileResult<()> {
-        let Some((method, root)) = ctx.accessor_call_insts.get(&operand) else {
+        let results = self.accessor_results_of(operand, ctx);
+        let Some((method, root)) = results.first() else {
             return Ok(());
         };
         let method = self.body_interner().resolve(method).to_string();

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -784,6 +784,29 @@ impl AnalysisContext<'_> {
         }
     }
 
+    /// The accessor loans a nested full expression established and still
+    /// holds — the loans of its own tail expression, since every nested
+    /// statement inside it already discarded its own at its boundary.
+    ///
+    /// Read just before [`Self::exit_full_expression`] by an `if`/`match` arm
+    /// whose value flows on as the join's value: that value is an accessor
+    /// result of the ENCLOSING full expression, so its loan keeps the 6.6:10
+    /// extent the arm boundary would otherwise cut short (RUE-1678). The
+    /// caller re-registers the returned loans with
+    /// [`Self::readmit_expression_loans`] after the boundary closes.
+    pub(crate) fn nested_expression_loans(
+        &self,
+        boundary: &FullExpressionBoundary,
+    ) -> Vec<(Spur, Span, CallLoanKind)> {
+        self.expression_loans[boundary.loans..].to_vec()
+    }
+
+    /// Re-register loans harvested by [`Self::nested_expression_loans`] into
+    /// the enclosing full expression (RUE-1678).
+    pub(crate) fn readmit_expression_loans(&mut self, loans: Vec<(Spur, Span, CallLoanKind)>) {
+        self.expression_loans.extend(loans);
+    }
+
     /// Finish a nested full expression, discarding child loans and restoring
     /// the enclosing expression's completed read/use records.
     pub(crate) fn exit_full_expression(&mut self, boundary: FullExpressionBoundary) {

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -206,9 +206,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         ctx.push_scope();
                         let boundary = ctx.enter_full_expression();
                         let result = self.analyze_inst(air, block, ctx);
+                        let loans = ctx.nested_expression_loans(&boundary);
                         ctx.exit_full_expression(boundary);
                         let result = result?;
                         ctx.pop_scope();
+                        // The selected branch IS this `if`'s value, so an
+                        // accessor result it yields keeps its loan for the
+                        // enclosing full expression (RUE-1678), exactly as on
+                        // the ordinary two-armed path below.
+                        self.readmit_arm_accessor_loans(ctx, block, loans);
                         // An `if` without `else` is unit-typed, so its (taken)
                         // then-branch must still be unit (spec 4.6:5).
                         if else_block.is_none()
@@ -257,10 +263,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // Save move state before entering branches.
             let saved_moves = ctx.moved_vars.clone();
 
-            // Analyze then branch with its own scope
+            // Analyze then branch with its own scope. An arm's accessor loan
+            // is harvested before the arm's boundary closes: if the arm's
+            // value is the `if`'s value, that loan belongs to the enclosing
+            // full expression and is readmitted once both arms are analyzed
+            // (ADR-0062 6.6:10, RUE-1678).
             ctx.push_scope();
             let boundary = ctx.enter_full_expression();
             let then_result = self.analyze_inst(air, then_block, ctx);
+            let then_loans = ctx.nested_expression_loans(&boundary);
             ctx.exit_full_expression(boundary);
             let then_result = then_result?;
             let then_type = then_result.ty;
@@ -278,12 +289,20 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ctx.push_scope();
             let boundary = ctx.enter_full_expression();
             let else_result = self.analyze_inst(air, else_b, ctx);
+            let else_loans = ctx.nested_expression_loans(&boundary);
             ctx.exit_full_expression(boundary);
             let else_result = else_result?;
             let else_type = else_result.ty;
             let else_continues = else_result.continues;
             let else_span = self.body_rir_ref().get(else_b).span;
             ctx.pop_scope();
+
+            // Both arms are analyzed, so an arm's accessor loan can no longer
+            // be mistaken for a conflicting sibling of the other arm's
+            // accessor call. Readmit the loans of whichever arms yield the
+            // `if`'s value as an accessor result (RUE-1678).
+            self.readmit_arm_accessor_loans(ctx, then_block, then_loans);
+            self.readmit_arm_accessor_loans(ctx, else_b, else_loans);
 
             // Capture else-branch's move state
             let else_moves = ctx.moved_vars.clone();
@@ -1008,9 +1027,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         ctx.push_scope();
                         let boundary = ctx.enter_full_expression();
                         let result = self.analyze_inst(air, body, ctx);
+                        let loans = ctx.nested_expression_loans(&boundary);
                         ctx.exit_full_expression(boundary);
                         let result = result?;
                         ctx.pop_scope();
+                        // The selected arm IS this `match`'s value, so an
+                        // accessor result it yields keeps its loan for the
+                        // enclosing full expression (RUE-1678).
+                        self.readmit_arm_accessor_loans(ctx, body, loans);
                         return Ok(result);
                     }
                 }
@@ -1105,6 +1129,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // merged after the loop (see merge_arm_moves).
         let moves_before_arms = ctx.moved_vars.clone();
         let mut arm_move_states = Vec::with_capacity(arms.len());
+        // Accessor loans harvested from each arm before its nested
+        // full-expression boundary closed. Arms are alternatives, so these are
+        // readmitted only once every arm has been analyzed (RUE-1678).
+        let mut arm_accessor_loans = Vec::with_capacity(arms.len());
 
         for (pattern, body) in arms.iter() {
             let pattern_span = pattern.span();
@@ -1380,6 +1408,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // Analyze arm body
             let boundary = ctx.enter_full_expression();
             let body_result = self.analyze_inst(air, *body, ctx);
+            arm_accessor_loans.push((*body, ctx.nested_expression_loans(&boundary)));
             ctx.exit_full_expression(boundary);
             let body_result = body_result?;
             let body_type = body_result.ty;
@@ -1492,6 +1521,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             };
 
             air_arms.push((air_pattern, arm_body_ref));
+        }
+
+        // Every arm is analyzed, so an arm's accessor loan can no longer be
+        // mistaken for a conflicting sibling of a later arm's accessor call.
+        // Readmit the loans of whichever arms yield the `match`'s value as an
+        // accessor result (ADR-0062 6.6:10, RUE-1678).
+        for (body, loans) in arm_accessor_loans {
+            self.readmit_arm_accessor_loans(ctx, body, loans);
         }
 
         // Join the arms' move states (union of non-diverging arms;

--- a/crates/rue-cli-tests/cases/array_repeat.toml
+++ b/crates/rue-cli-tests/cases/array_repeat.toml
@@ -78,3 +78,142 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["E0905", "not Copy"]
+
+# --- comptime value-parameter counts (RUE-1681) ------------------------------
+#
+# 7.1:37 admits an in-scope `comptime` value parameter as a repeat count, by
+# the same rules an array-TYPE length uses. Constraint generation resolved only
+# the file-level `const` half, so the repeat's type stayed an unconstrained
+# variable, decayed to the error type, and sema reported the literal as an
+# un-annotatable empty array (E0903) — a legal program rejected. Every case
+# below pins the filled contents on stdout, not just the exit code: an
+# unresolved count used to be a compile failure, but a MIS-resolved one is a
+# silent wrong-length fill.
+
+[[case]]
+name = "repeat_comptime_value_param_count"
+description = "RUE-1681 repro: `[v; n]` with a comptime value-parameter count compiles and fills n slots."
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn make(comptime n: u64) -> i32 {
+    let a = [7; n];
+    @dbg(a[0] + a[1] + a[2]);
+    0
+}
+fn main() -> i32 {
+    make(3)
+}
+""" }]
+stdout = "21\n"
+
+[[case]]
+name = "repeat_comptime_value_param_count_with_annotation"
+description = "The repeat's inferred length agrees with an array-type length named by the same comptime value parameter."
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn make(comptime n: u64) -> i32 {
+    let a: [i32; n] = [0; n];
+    @dbg(a[0] + a[1] + a[2] + 5);
+    0
+}
+fn main() -> i32 {
+    make(3)
+}
+""" }]
+stdout = "5\n"
+
+[[case]]
+name = "repeat_comptime_value_param_count_two_specializations"
+description = "Two specializations of one body get their own counts; each fill has the length of its own instance."
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn total(comptime n: u64, v: i32) -> i32 {
+    let a: [i32; n] = [v; n];
+    let mut acc: i32 = 0;
+    let mut i: u64 = 0;
+    while i < n {
+        acc = acc + a[i];
+        i = i + 1;
+    }
+    acc
+}
+fn main() -> i32 {
+    @dbg(total(2, 10));
+    @dbg(total(5, 3));
+    0
+}
+""" }]
+stdout = "20\n15\n"
+
+[[case]]
+name = "repeat_comptime_value_param_count_nested"
+description = "Both counts of a nested repeat `[[v; n]; m]` resolve against the enclosing comptime value parameters."
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn make(comptime n: u64, comptime m: u64) -> i32 {
+    let grid: [[i32; n]; m] = [[3; n]; m];
+    @dbg(grid[0][0] + grid[1][2]);
+    0
+}
+fn main() -> i32 {
+    make(3, 2)
+}
+""" }]
+stdout = "6\n"
+
+[[case]]
+name = "repeat_comptime_value_param_zero_count_evaluates_value_once"
+description = "A zero comptime value-parameter count still evaluates the repeat value exactly once (spec 7.1:39; the RUE-531 anchoring, reached through a comptime count)."
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn produce() -> i32 {
+    @dbg(42);
+    7
+}
+fn make(comptime n: u64) -> i32 {
+    let a: [i32; n] = [produce(); n];
+    let len: i32 = @intCast(n);
+    @dbg(len);
+    0
+}
+fn main() -> i32 {
+    make(0)
+}
+""" }]
+stdout = "42\n0\n"
+
+[[case]]
+name = "repeat_comptime_value_param_count_shadows_same_named_const"
+description = "A comptime value parameter takes precedence over a file-level const of the same name — the precedence array-type lengths already use (RUE-252). A wrong precedence here fills 9 slots, not 2."
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+const n: usize = 9;
+fn make(comptime n: u64) -> i32 {
+    let a = [1; n];
+    let mut acc: i32 = 0;
+    let mut i: u64 = 0;
+    while i < n {
+        acc = acc + a[i];
+        i = i + 1;
+    }
+    acc
+}
+fn main() -> i32 {
+    @dbg(make(2));
+    0
+}
+""" }]
+stdout = "2\n"
+
+[[case]]
+name = "genuine_empty_array_still_needs_annotation"
+description = "Control: an actually empty, unannotated array literal still gets the E0903 annotation diagnostic — the repeat fix did not weaken it."
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a = [];
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0903", "type annotation required for empty array"]

--- a/crates/rue-cli-tests/cases/borrow_accessors.toml
+++ b/crates/rue-cli-tests/cases/borrow_accessors.toml
@@ -504,3 +504,259 @@ fn main() -> i32 {
 args = ["main.rue", "-O0", "-o", "prog"]
 stdout = "8\n8\n9\n"
 exit_code = 0
+
+# ---------------------------------------------------------------------------
+# Joined accessor results (RUE-1678). Wrapping an accessor call in an `if` or
+# `match` arm, or in a multi-statement block tail, does not turn its borrowed
+# place into a first-class value: the join's value IS the arm's value, so the
+# 6.6:9 escape checks and the 6.6:10 loan extent both see through the join.
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "accessor_result_cannot_be_let_bound_through_if_arm"
+description = "An accessor result reached through an if arm is still an accessor result at a `let` (E0252)."
+files = [{ path = "main.rue", source = """
+struct P {
+    x: i64,
+    fn xr(borrow self) -> borrow i64 { yield self.x; }
+}
+fn main() -> i32 {
+    let p = P { x: 7 };
+    let b = if true { p.xr() } else { 0 };
+    if b == 7 { 0 } else { 1 }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0252", "cannot bind an accessor result with `let`", "`xr`"]
+
+[[case]]
+name = "accessor_result_cannot_be_stored_through_if_arm"
+description = "An accessor result reached through an if arm is still an accessor result at an assignment (E0251)."
+files = [{ path = "main.rue", source = """
+struct P {
+    x: i64,
+    fn xr(borrow self) -> borrow i64 { yield self.x; }
+}
+fn main() -> i32 {
+    let p = P { x: 7 };
+    let mut slot = 0;
+    slot = if true { p.xr() } else { 0 };
+    if slot == 7 { 0 } else { 1 }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0251", "cannot store an accessor result", "`xr`"]
+
+[[case]]
+name = "accessor_result_cannot_be_returned_through_if_arm"
+description = "An accessor result reached through an if arm is still an accessor result at a `return` (E0250)."
+files = [{ path = "main.rue", source = """
+struct P {
+    x: i64,
+    fn xr(borrow self) -> borrow i64 { yield self.x; }
+}
+fn read(borrow p: P, c: bool) -> i64 {
+    return if c { p.xr() } else { 0 };
+}
+fn main() -> i32 {
+    let p = P { x: 1 };
+    if read(borrow p, true) == 1 { 0 } else { 1 }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0250", "cannot return an accessor result", "`xr`"]
+
+[[case]]
+name = "accessor_result_cannot_be_captured_through_if_arm"
+description = "An accessor result reached through an if arm is still an accessor result in a struct literal (E0253)."
+files = [{ path = "main.rue", source = """
+struct P {
+    x: i64,
+    fn xr(borrow self) -> borrow i64 { yield self.x; }
+}
+struct Box { v: i64 }
+fn main() -> i32 {
+    let p = P { x: 1 };
+    let q = Box { v: if true { p.xr() } else { 0 } };
+    if q.v == 1 { 0 } else { 1 }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0253", "cannot capture an accessor result in an aggregate", "`xr`"]
+
+[[case]]
+name = "accessor_result_cannot_escape_through_match_arm"
+description = "A match arm joins an accessor result exactly as an if arm does (E0252)."
+files = [{ path = "main.rue", source = """
+struct P {
+    x: i64,
+    fn xr(borrow self) -> borrow i64 { yield self.x; }
+}
+fn main() -> i32 {
+    let p = P { x: 7 };
+    let n = 1;
+    let b = match n {
+        1 => p.xr(),
+        _ => 0,
+    };
+    if b == 7 { 0 } else { 1 }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0252", "cannot bind an accessor result with `let`", "`xr`"]
+
+[[case]]
+name = "accessor_result_cannot_escape_through_nested_join"
+description = "An if nested inside a match arm still carries the accessor result out to the binding (E0252)."
+files = [{ path = "main.rue", source = """
+struct P {
+    x: i64,
+    fn xr(borrow self) -> borrow i64 { yield self.x; }
+}
+fn main() -> i32 {
+    let p = P { x: 7 };
+    let n = 1;
+    let b = match n {
+        1 => if true { p.xr() } else { 0 },
+        _ => 0,
+    };
+    if b == 7 { 0 } else { 1 }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0252", "cannot bind an accessor result with `let`", "`xr`"]
+
+[[case]]
+name = "accessor_results_in_both_arms_cannot_escape"
+description = "A join whose arms both yield accessor results escapes on either path; the diagnostic names the leftmost."
+files = [{ path = "main.rue", source = """
+struct P {
+    x: i64,
+    y: i64,
+    fn xr(borrow self) -> borrow i64 { yield self.x; }
+    fn yr(borrow self) -> borrow i64 { yield self.y; }
+}
+fn main() -> i32 {
+    let p = P { x: 7, y: 3 };
+    let b = if true { p.xr() } else { p.yr() };
+    if b == 7 { 0 } else { 1 }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0252", "cannot bind an accessor result with `let`", "`xr`"]
+
+[[case]]
+name = "accessor_result_cannot_escape_through_block_tail"
+description = "A multi-statement block's tail carries the accessor result out to the binding (E0252)."
+files = [{ path = "main.rue", source = """
+struct P {
+    x: i64,
+    fn xr(borrow self) -> borrow i64 { yield self.x; }
+}
+fn main() -> i32 {
+    let p = P { x: 1 };
+    let b = {
+        let z = 1;
+        @dbg(z);
+        p.xr()
+    };
+    if b == 1 { 0 } else { 1 }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0252", "cannot bind an accessor result with `let`", "`xr`"]
+
+[[case]]
+name = "accessor_result_through_diverging_arm_reports_once"
+description = "A never-typed sibling arm does not turn the join's single escape into a second return diagnostic."
+files = [{ path = "main.rue", source = """
+struct P {
+    x: i64,
+    fn xr(borrow self) -> borrow i64 { yield self.x; }
+}
+fn read(borrow p: P, c: bool) -> i64 {
+    let b = if c { p.xr() } else { return 0 };
+    b
+}
+fn main() -> i32 {
+    let p = P { x: 1 };
+    if read(borrow p, true) == 1 { 0 } else { 1 }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0252", "cannot bind an accessor result with `let`", "`xr`"]
+compile_stderr_not_contains = ["E0250"]
+
+[[case]]
+name = "joined_accessor_result_conflicts_with_sibling_inout"
+description = "A joined accessor result keeps its loan's full-expression extent, so a sibling `inout` of the same root is E0259."
+files = [{ path = "main.rue", source = """
+struct Grid {
+    cells: [i64; 4],
+    fn at(borrow self, i: u64) -> borrow i64 { yield self.cells[i]; }
+}
+fn using(a: i64, inout g: Grid) -> i64 {
+    g.cells[0] = 9;
+    a
+}
+fn main() -> i32 {
+    let mut g = Grid { cells: [1, 2, 3, 4] };
+    using(if true { g.at(0) } else { 0 }, inout g);
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0259", "as `inout` while an accessor result borrows it"]
+
+[[case]]
+name = "joined_accessor_result_consumed_in_place_is_legal"
+description = "Consuming a joined accessor result by copy-read inside the same full expression stays legal and runs."
+files = [{ path = "main.rue", source = """
+struct P {
+    x: i64,
+    y: i64,
+    fn xr(borrow self) -> borrow i64 { yield self.x; }
+    fn yr(borrow self) -> borrow i64 { yield self.y; }
+}
+fn use1(v: i64) -> i64 { v + 1 }
+fn main() -> i32 {
+    let p = P { x: 7, y: 3 };
+    @dbg(use1(if true { p.xr() } else { 0 }));
+    @dbg(use1(if false { p.xr() } else { p.yr() }));
+    if (if true { p.xr() } else { 0 }) == 7 { 0 } else { 1 }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+stdout = "8\n4\n"
+exit_code = 0
+
+[[case]]
+name = "joined_accessor_result_lowers_on_aarch64"
+description = "A joined accessor result's spliced place lowers on AArch64 without publishing an accessor symbol."
+files = [{ path = "main.rue", source = """
+struct P {
+    x: i64,
+    y: i64,
+    fn xr(borrow self) -> borrow i64 { yield self.x; }
+    fn yr(borrow self) -> borrow i64 { yield self.y; }
+}
+fn use1(v: i64) -> i64 { v + 1 }
+fn main() -> i32 {
+    let p = P { x: 7, y: 3 };
+    if use1(if true { p.xr() } else { p.yr() }) == 8 { 0 } else { 1 }
+}
+""" }]
+args = ["--emit", "asm", "--target", "aarch64-linux", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== Assembly (aarch64-linux) ===", "main:"]
+compile_stdout_not_contains = ["xr:", "yr:"]

--- a/crates/rue-cli-tests/cases/generics.toml
+++ b/crates/rue-cli-tests/cases/generics.toml
@@ -224,3 +224,122 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 42
+
+# =============================================================================
+# A user-declared struct/enum NAME as the comptime type argument (RUE-1680)
+# =============================================================================
+#
+# `identity(Foo, Foo { x: 42 })` was rejected with a bogus
+# "type mismatch: expected Foo, found type". A struct/enum name in argument
+# position parses as a variable reference, and inference resolved such a
+# reference only against the enclosing type substitution and the BUILTIN
+# struct/enum tables — never against the user-declared ones. `T` therefore
+# stayed out of the call's substitution map, a `-> T` return type could not be
+# substituted, and the call's type remained the literal `type` placeholder,
+# which mismatched the binding's annotation.
+#
+# The bug is invisible whenever the return type does not mention `T` — the
+# struct cases above (`one(A, a) -> i32`) passed throughout — so these cases
+# all bind the result to the nominal type.
+
+[[case]]
+name = "generic_struct_name_type_argument"
+description = "RUE-1680 repro: a user struct passed by name as `comptime T: type` with a `-> T` return."
+files = [{ path = "main.rue", source = """
+struct Foo { x: i32 }
+fn identity(comptime T: type, v: T) -> T { v }
+fn main() -> i32 {
+    let f: Foo = identity(Foo, Foo { x: 42 });
+    f.x
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "generic_enum_name_type_argument"
+description = "A user enum name resolves on the same route as a struct name; the payload survives the round trip."
+files = [{ path = "main.rue", source = """
+enum Slot { Empty, Full(i32) }
+fn identity(comptime T: type, v: T) -> T { v }
+fn main() -> i32 {
+    let s: Slot = identity(Slot, Slot.Full(42));
+    match s {
+        Slot.Empty => 0,
+        Slot.Full(v) => v,
+    }
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "generic_struct_name_type_argument_composite_return"
+description = "The composite `-> [T; 2]` return substitutes a user struct passed by name (the RUE-172 shape, which also only worked for primitives)."
+files = [{ path = "main.rue", source = """
+struct Foo { x: i32 }
+fn pair(comptime T: type, a: T, b: T) -> [T; 2] { [a, b] }
+fn main() -> i32 {
+    let p: [Foo; 2] = pair(Foo, Foo { x: 40 }, Foo { x: 2 });
+    p[0].x + p[1].x
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "generic_struct_name_type_argument_forwarded"
+description = "A user-struct type argument forwards through a nested generic call — the RUE-102 relay shape, now reachable with a nominal argument."
+files = [{ path = "main.rue", source = """
+struct Foo { x: i32 }
+fn inner(comptime T: type, v: T) -> T { v }
+fn outer(comptime T: type, v: T) -> T { inner(T, v) }
+fn main() -> i32 {
+    let f: Foo = outer(Foo, Foo { x: 42 });
+    f.x
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "generic_struct_name_type_argument_two_instantiations"
+description = "Two nominal instantiations of one `-> T` generic keep their own layouts; a shared or mis-resolved substitution would read the wrong field."
+files = [{ path = "main.rue", source = """
+struct Pair { x: i32, y: i32 }
+struct Triple { x: i32, y: i32, z: i32 }
+fn echo(comptime T: type, v: T) -> T { v }
+fn main() -> i32 {
+    let p: Pair = echo(Pair, Pair { x: 2, y: 4 });
+    let t: Triple = echo(Triple, Triple { x: 10, y: 30, z: 6 });
+    p.y + t.z + t.x * 3
+}
+""" }]
+exit_code = 40
+
+[[case]]
+name = "generic_type_argument_alias_and_primitive_controls"
+description = "Controls, unchanged by the fix: a let-bound alias (RUE-281) and a primitive literal type name resolve as before, and a local shadowing the type name is still not a type value."
+files = [{ path = "main.rue", source = """
+struct Foo { x: i32 }
+fn identity(comptime T: type, v: T) -> T { v }
+fn main() -> i32 {
+    let P = Foo;
+    let a: Foo = identity(P, Foo { x: 20 });
+    let b: i32 = identity(i32, 22);
+    a.x + b
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "generic_type_argument_runtime_local_shadowing_type_name_rejected"
+description = "Control: a runtime local that shadows a struct name is a value, not a type — the nominal lookup must not fire through a shadowing binding, so the call is still rejected. (The wording is the unsubstituted-`T` mismatch rather than the comptime-argument diagnostic; that is pre-existing and unchanged here.)"
+files = [{ path = "main.rue", source = """
+struct Foo { x: i32 }
+fn identity(comptime T: type, v: T) -> T { v }
+fn main() -> i32 {
+    let Foo = 7;
+    let a: i32 = identity(Foo, 3);
+    a
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206"]
+compile_stderr_not_contains = ["E9000", "internal compiler error"]

--- a/crates/rue-cli-tests/cases/str_type.toml
+++ b/crates/rue-cli-tests/cases/str_type.toml
@@ -453,3 +453,141 @@ fn main() -> i32 {
 args = ["main.rue", "-o", "prog"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 exit_code = 4
+
+# --- `len` result typing on the string rungs (RUE-1679) ----------------------
+#
+# `s.len()` is `u64` (spec 3.7:45 for `str`, 3.7:52 for `Str(N)`). Neither type
+# has a DECLARED `len` — sema answers the call by reading the view's `len` word,
+# the same route a slice `[T]` takes — so until inference published the `u64`
+# result the call typed as the error type, which unifies with any annotation. A
+# mismatched binding then sailed through inference and reached CFG verification
+# as a u64 value in an i32 slot, surfacing as E9000. This is the RUE-1611 class
+# on the string rungs; RUE-1611 fixed `[T]` and deliberately excluded these two
+# on the assumption their `len` signatures resolve, which they do not.
+#
+# Each mismatch case asserts the ABSENCE of the ICE as well as the presence of
+# the ordinary diagnostic: a fix that only changed the wording would still pass
+# a bare `error_contains`.
+
+[[case]]
+name = "str_len_mismatched_annotation_is_e0206"
+description = "RUE-1679 repro: `let n: i32 = s.len();` on a `str` local is E0206 at the binding, not a CFG verification ICE."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s: str = "hello";
+    let n: i32 = s.len();
+    n
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0206", "type mismatch: expected i32, found u64"]
+compile_stderr_not_contains = ["E9000", "internal compiler error", "CFG verification"]
+
+[[case]]
+name = "str_literal_len_mismatched_annotation_is_e0206"
+description = "The same call on a bare literal receiver, whose text type is still contextual when the method is looked up."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let n: i32 = "hello".len();
+    n
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0206", "type mismatch: expected i32, found u64"]
+compile_stderr_not_contains = ["E9000", "internal compiler error", "CFG verification"]
+
+[[case]]
+name = "str_fixed_len_mismatched_annotation_is_e0206"
+description = "A `Str(N)` receiver takes the same route as `str` and is type-checked the same way."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s: Str(16) = "hello";
+    let n: i32 = s.len();
+    n
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0206", "type mismatch: expected i32, found u64"]
+compile_stderr_not_contains = ["E9000", "internal compiler error", "CFG verification"]
+
+[[case]]
+name = "str_field_len_mismatched_annotation_is_e0206"
+description = "A struct-FIELD receiver reaches the call with a concrete `str` type rather than a literal's contextual variable — the other half of the mechanism."
+files = [{ path = "main.rue", source = """
+struct Holder { s: str }
+fn main() -> i32 {
+    let h = Holder { s: "hello" };
+    let n: i32 = h.s.len();
+    n
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0206", "type mismatch: expected i32, found u64"]
+compile_stderr_not_contains = ["E9000", "internal compiler error", "CFG verification"]
+
+[[case]]
+name = "str_param_len_mismatched_annotation_is_e0206"
+description = "A `str` parameter receiver, the third way the receiver's type reaches the call."
+files = [{ path = "main.rue", source = """
+fn take(s: str) -> i32 {
+    let n: i32 = s.len();
+    n
+}
+fn main() -> i32 {
+    take("hello")
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0206", "type mismatch: expected i32, found u64"]
+compile_stderr_not_contains = ["E9000", "internal compiler error", "CFG verification"]
+
+[[case]]
+name = "str_len_u64_annotation_and_intcast_stay_legal"
+description = "Control: the exact `u64` annotation is accepted for `str`, `Str(N)` and a literal, and `@intCast` is how the length reaches a narrower type. Exit code is the summed length, so a wrong published result type would show up as a wrong value, not just a compile failure."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s: str = "hello";
+    let f: Str(16) = "hi";
+    let a: u64 = s.len();
+    let b: u64 = f.len();
+    let c: i32 = @intCast("xyz".len());
+    @intCast(a) + @intCast(b) + c
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 10
+
+[[case]]
+name = "str_unknown_method_is_undefined_method_not_ice"
+description = "Control: `len` is the only method these rungs answer, and every other name is still an ordinary undefined-method diagnostic — publishing `len`'s result did not turn a typo into an ICE."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s: str = "hello";
+    let n = s.bogus();
+    n
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0411", "no method named 'bogus' found for type 'str'"]
+compile_stderr_not_contains = ["E9000", "internal compiler error", "CFG verification"]
+
+[[case]]
+name = "str_len_with_argument_is_undefined_method_not_ice"
+description = "Control: `len` with an argument is not the zero-arg view `len`; it stays an ordinary undefined-method diagnostic."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s: str = "hello";
+    let n: u64 = s.len(1);
+    @intCast(n)
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0411", "no method named 'len' found for type 'str'"]
+compile_stderr_not_contains = ["E9000", "internal compiler error", "CFG verification"]

--- a/crates/rue-spec/cases/arrays/fixed.toml
+++ b/crates/rue-spec/cases/arrays/fixed.toml
@@ -1138,6 +1138,72 @@ fn main() -> i32 {
 """
 exit_code = 20
 
+# 7.1:37 names an in-scope `comptime` value parameter alongside a file-level
+# `const` as a legal repeat count. Constraint generation resolved only the
+# `const` half, so the repeat's type stayed unconstrained and decayed to the
+# error type — reported as the un-annotatable empty-array diagnostic E0903
+# (RUE-1681).
+[[case]]
+name = "array_repeat_comptime_value_param_count"
+spec = ["7.1:37"]
+source = """
+fn make(comptime n: u64) -> i32 {
+    [7; n][0] + [7; n][2]
+}
+fn main() -> i32 {
+    make(3)
+}
+"""
+exit_code = 14
+
+[[case]]
+name = "array_repeat_comptime_value_param_count_matches_annotation"
+spec = ["7.1:37"]
+description = "The repeat's inferred length agrees with an array-TYPE length named by the same comptime value parameter"
+source = """
+fn make(comptime n: u64) -> i32 {
+    let arr: [i32; n] = [0; n];
+    arr[0] + arr[2] + 42
+}
+fn main() -> i32 {
+    make(3)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "array_repeat_comptime_value_param_count_nested"
+spec = ["7.1:37"]
+description = "Both counts of a nested repeat `[[v; n]; m]` resolve against the enclosing comptime value parameters"
+source = """
+fn make(comptime n: u64, comptime m: u64) -> i32 {
+    let grid: [[i32; n]; m] = [[3; n]; m];
+    grid[1][2] + grid[0][0]
+}
+fn main() -> i32 {
+    make(3, 2)
+}
+"""
+exit_code = 6
+
+[[case]]
+name = "array_repeat_comptime_value_param_zero_count_evaluates_value_once"
+spec = ["7.1:37", "7.1:39"]
+description = "A zero comptime value-parameter count still evaluates the repeat value exactly once (the RUE-531 anchoring, now reachable through a comptime count)"
+source = """
+fn produce() -> i32 { @dbg(42); 7 }
+fn make(comptime n: u64) -> i32 {
+    let a: [i32; n] = [produce(); n];
+    @intCast(n)
+}
+fn main() -> i32 {
+    make(0)
+}
+"""
+expected_stdout = """42
+"""
+exit_code = 0
+
 [[case]]
 name = "array_repeat_evaluates_value_once"
 spec = ["7.1:39"]

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -392,6 +392,41 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
+name = "generic_function_type_arg_is_user_struct_name"
+spec = ["4.14:5"]
+description = "A user-declared struct name is a comptime type argument in its own right (`identity(Foo, ..)`), resolving T:=Foo exactly as the primitive and alias spellings do (RUE-1680)"
+source = """
+struct Foo { x: i32 }
+fn identity(comptime T: type, v: T) -> T {
+    v
+}
+fn main() -> i32 {
+    let f: Foo = identity(Foo, Foo { x: 42 });
+    f.x
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "generic_function_type_arg_is_user_enum_name"
+spec = ["4.14:5"]
+description = "A user-declared enum name resolves as a comptime type argument on the same route as a struct name (RUE-1680)"
+source = """
+enum Color { Red, Green }
+fn identity(comptime T: type, v: T) -> T {
+    v
+}
+fn main() -> i32 {
+    let c: Color = identity(Color, Color.Green);
+    match c {
+        Color.Red => 1,
+        Color.Green => 42,
+    }
+}
+"""
+exit_code = 42
+
+[[case]]
 name = "generic_function_with_bool"
 spec = ["4.14:5"]
 description = "Generic identity function specialized for bool"
@@ -1701,6 +1736,37 @@ fn pair(comptime T: type, x: T) -> [T; 2] {
 fn main() -> i32 {
     let p = pair(i32, 21);
     p[0] + p[1]
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "type_param_in_array_return_with_user_struct_arg"
+spec = ["4.14:16"]
+description = "The composite `-> [T; 2]` return substitutes a user-declared struct passed by name, not only a primitive (RUE-1680)"
+source = """
+struct Foo { x: i32 }
+fn pair(comptime T: type, a: T, b: T) -> [T; 2] {
+    [a, b]
+}
+fn main() -> i32 {
+    let p: [Foo; 2] = pair(Foo, Foo { x: 40 }, Foo { x: 2 });
+    p[0].x + p[1].x
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "type_param_forwarded_through_nested_generic_call"
+spec = ["4.14:16"]
+description = "A user-struct type argument forwards through a nested generic call, the shape a forwarded type PARAMETER already had (RUE-102): the inner call's `T` comes from the outer specialization"
+source = """
+struct Foo { x: i32 }
+fn inner(comptime T: type, v: T) -> T { v }
+fn outer(comptime T: type, v: T) -> T { inner(T, v) }
+fn main() -> i32 {
+    let f: Foo = outer(Foo, Foo { x: 42 });
+    f.x
 }
 """
 exit_code = 42

--- a/crates/rue-spec/cases/items/borrow-accessors.toml
+++ b/crates/rue-spec/cases/items/borrow-accessors.toml
@@ -1673,3 +1673,226 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = ["E0259", "accessor"]
+
+# ---------------------------------------------------------------------------
+# A join carries an accessor result (RUE-1678). An `if`/`match` arm and a block
+# tail each yield their value AS the enclosing expression's value, so the
+# escape rule of 6.6:9 and the loan extent of 6.6:10 both apply through them.
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "accessor_result_cannot_be_let_bound_through_if_arm"
+spec = ["6.6:9"]
+description = "Binding an accessor result reached through an if arm still escapes its full expression (E0252)."
+source = """
+struct P {
+    x: i64,
+
+    fn xr(borrow self) -> borrow i64 {
+        yield self.x;
+    }
+}
+fn main() -> i32 {
+    let p = P { x: 1 };
+    let b = if true { p.xr() } else { 0 };
+    if b == 1 { 0 } else { 1 }
+}
+"""
+compile_fail = true
+error_contains = ["E0252", "cannot bind an accessor result with `let`"]
+
+[[case]]
+name = "accessor_result_cannot_be_returned_through_if_arm"
+spec = ["6.6:9"]
+description = "Returning an accessor result reached through an if arm still escapes its full expression (E0250)."
+source = """
+struct P {
+    x: i64,
+
+    fn xr(borrow self) -> borrow i64 {
+        yield self.x;
+    }
+}
+fn read(borrow p: P, c: bool) -> i64 {
+    return if c { p.xr() } else { 0 };
+}
+fn main() -> i32 {
+    let p = P { x: 1 };
+    if read(borrow p, true) == 1 { 0 } else { 1 }
+}
+"""
+compile_fail = true
+error_contains = ["E0250", "cannot return an accessor result"]
+
+[[case]]
+name = "accessor_result_cannot_be_stored_through_if_arm"
+spec = ["6.6:9"]
+description = "Assigning an accessor result reached through an if arm still escapes its full expression (E0251)."
+source = """
+struct P {
+    x: i64,
+
+    fn xr(borrow self) -> borrow i64 {
+        yield self.x;
+    }
+}
+fn main() -> i32 {
+    let p = P { x: 1 };
+    let mut slot = 0;
+    slot = if true { p.xr() } else { 0 };
+    if slot == 1 { 0 } else { 1 }
+}
+"""
+compile_fail = true
+error_contains = ["E0251", "cannot store an accessor result"]
+
+[[case]]
+name = "accessor_result_cannot_be_captured_through_if_arm"
+spec = ["6.6:9"]
+description = "Capturing an accessor result reached through an if arm in an array literal still escapes (E0253)."
+source = """
+struct P {
+    x: i64,
+
+    fn xr(borrow self) -> borrow i64 {
+        yield self.x;
+    }
+}
+fn main() -> i32 {
+    let p = P { x: 1 };
+    let a = [if true { p.xr() } else { 0 }];
+    if a[0] == 1 { 0 } else { 1 }
+}
+"""
+compile_fail = true
+error_contains = ["E0253", "cannot capture an accessor result"]
+
+[[case]]
+name = "accessor_result_cannot_escape_through_match_arm"
+spec = ["6.6:9"]
+description = "A match arm joins an accessor result exactly as an if arm does (E0252)."
+source = """
+struct P {
+    x: i64,
+
+    fn xr(borrow self) -> borrow i64 {
+        yield self.x;
+    }
+}
+fn main() -> i32 {
+    let p = P { x: 1 };
+    let n = 1;
+    let b = match n {
+        1 => p.xr(),
+        _ => 0,
+    };
+    if b == 1 { 0 } else { 1 }
+}
+"""
+compile_fail = true
+error_contains = ["E0252", "cannot bind an accessor result with `let`"]
+
+[[case]]
+name = "accessor_results_in_both_arms_cannot_escape"
+spec = ["6.6:9"]
+description = "A join over two accessor results escapes on either path and names the leftmost arm's accessor (E0252)."
+source = """
+struct P {
+    x: i64,
+    y: i64,
+
+    fn xr(borrow self) -> borrow i64 {
+        yield self.x;
+    }
+
+    fn yr(borrow self) -> borrow i64 {
+        yield self.y;
+    }
+}
+fn main() -> i32 {
+    let p = P { x: 1, y: 2 };
+    let b = if true { p.xr() } else { p.yr() };
+    if b == 1 { 0 } else { 1 }
+}
+"""
+compile_fail = true
+error_contains = ["E0252", "cannot bind an accessor result with `let`", "`xr`"]
+
+[[case]]
+name = "accessor_result_cannot_escape_through_block_tail"
+spec = ["6.6:9"]
+description = "A multi-statement block's tail carries the accessor result out to the binding (E0252)."
+source = """
+struct P {
+    x: i64,
+
+    fn xr(borrow self) -> borrow i64 {
+        yield self.x;
+    }
+}
+fn main() -> i32 {
+    let p = P { x: 1 };
+    let b = {
+        let z = 1;
+        @dbg(z);
+        p.xr()
+    };
+    if b == 1 { 0 } else { 1 }
+}
+"""
+compile_fail = true
+error_contains = ["E0252", "cannot bind an accessor result with `let`"]
+
+[[case]]
+name = "joined_accessor_result_conflicts_with_inout"
+spec = ["6.6:10"]
+description = "A joined accessor result keeps its loan's full-expression extent, so a sibling exclusive use is E0259."
+source = """
+struct Grid {
+    cells: [i64; 4],
+
+    fn at(borrow self, i: u64) -> borrow i64 {
+        yield self.cells[i];
+    }
+}
+fn using(a: i64, b: i64) -> i64 { a + b }
+fn bump(inout g: Grid) -> i64 {
+    g.cells[0] = 9;
+    0
+}
+fn main() -> i32 {
+    let mut g = Grid { cells: [1, 2, 3, 4] };
+    using(if true { g.at(0) } else { 0 }, bump(inout g));
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0259", "while an accessor result borrows it"]
+
+[[case]]
+name = "joined_accessor_result_consumed_in_place_is_legal"
+spec = ["6.6:8", "6.6:9"]
+description = "An accessor result consumed by copy-read within its own full expression is legal through an arm too."
+source = """
+struct P {
+    x: i64,
+    y: i64,
+
+    fn xr(borrow self) -> borrow i64 {
+        yield self.x;
+    }
+
+    fn yr(borrow self) -> borrow i64 {
+        yield self.y;
+    }
+}
+fn use1(v: i64) -> i64 { v + 1 }
+fn main() -> i32 {
+    let p = P { x: 7, y: 3 };
+    let sum = use1(if true { p.xr() } else { 0 }) + use1(if false { p.xr() } else { p.yr() });
+    @dbg(sum);
+    if sum == 12 { 0 } else { 1 }
+}
+"""
+expected_stdout = "12\n"
+exit_code = 0

--- a/crates/rue-spec/cases/types/str-fixed-type.toml
+++ b/crates/rue-spec/cases/types/str-fixed-type.toml
@@ -109,6 +109,37 @@ fn main() -> i32 {
 """
 exit_code = 5
 
+# 3.7:52 — the result type is `u64` and is ordinarily type-checked: annotating
+# the call with another integer type is a type mismatch at the binding. Like
+# `str`, a `Str(N)` has no declared `len`, so until inference published the
+# `u64` result the call typed as the error type, unified with the annotation,
+# and reached CFG verification as a u64 value in an i32 slot (RUE-1679).
+[[case]]
+name = "str_fixed_len_result_is_u64_and_is_type_checked"
+spec = ["3.7:52"]
+compile_fail = true
+error_contains = "expected i32, found u64"
+source = """
+fn main() -> i32 {
+    let s: Str(16) = "hello";
+    let n: i32 = s.len();
+    n
+}
+"""
+
+# 3.7:52 — the control: the exact `u64` annotation of the same call is accepted.
+[[case]]
+name = "str_fixed_len_binds_to_u64"
+spec = ["3.7:52"]
+source = """
+fn main() -> i32 {
+    let s: Str(16) = "hello";
+    let n: u64 = s.len();
+    @intCast(n)
+}
+"""
+exit_code = 5
+
 # 3.7:53 — `s[i]` is the i-th byte as `u8`; packed bytes, not char boundaries.
 [[case]]
 name = "str_fixed_byte_index"

--- a/crates/rue-spec/cases/types/str-type.toml
+++ b/crates/rue-spec/cases/types/str-type.toml
@@ -96,6 +96,55 @@ fn main() -> i32 {
 """
 exit_code = 5
 
+# 3.7:45 — the result type is `u64`, and it takes part in ordinary type
+# checking: an annotation of another integer type is a plain type mismatch at
+# the binding, not a value that flows on unchecked. `str` has no *declared*
+# `len` (the call reads the view's `len` word), so until inference published
+# the `u64` result the call typed as the error type, unified with any
+# annotation, and reached CFG verification as a u64 value in an i32 slot —
+# reported as an internal error (RUE-1679, the RUE-1611 class on `str`).
+[[case]]
+name = "str_len_result_is_u64_and_is_type_checked"
+spec = ["3.7:45"]
+compile_fail = true
+error_contains = "expected i32, found u64"
+source = """
+fn main() -> i32 {
+    let s: str = "hello";
+    let n: i32 = s.len();
+    n
+}
+"""
+
+# 3.7:45 — the same rule holds for a literal receiver, whose text type is still
+# contextual when the method is looked up: `.len()` is `u64` on every text type
+# the literal could settle on.
+[[case]]
+name = "str_literal_len_result_is_u64_and_is_type_checked"
+spec = ["3.7:45"]
+compile_fail = true
+error_contains = "expected i32, found u64"
+source = """
+fn main() -> i32 {
+    let n: i32 = "hello".len();
+    n
+}
+"""
+
+# 3.7:45 — the control: a `u64` binding of the same call is exact, and an
+# explicit conversion is how the length reaches a narrower type.
+[[case]]
+name = "str_len_binds_to_u64_and_converts_explicitly"
+spec = ["3.7:45"]
+source = """
+fn main() -> i32 {
+    let s: str = "hello";
+    let n: u64 = s.len();
+    @intCast(n)
+}
+"""
+exit_code = 5
+
 # 3.7:46 — `s[i]` is the i-th byte as `u8`.
 [[case]]
 name = "str_byte_index"

--- a/docs/spec/src/06-items/06-borrow-accessors.md
+++ b/docs/spec/src/06-items/06-borrow-accessors.md
@@ -96,6 +96,13 @@ loans extend through the enclosing full expression (core calculus
 An accessor result **MUST NOT** escape its full expression: returning it
 (E0250), storing it by assignment (E0251), binding it with a plain `let`
 (E0252), or capturing it in a struct or array literal (E0253) is rejected.
+A join yields whatever its arms yield, so an `if`/`else` arm, a `match` arm,
+and a block's tail expression each pass the property along: when any arm can
+yield an accessor result, the join *is* an accessor result of that arm's root,
+and every rule above applies to it unchanged —
+`let b = if c { v.get_ref(i) } else { 0 };` is the same E0252 as
+`let b = v.get_ref(i);`. Consuming the join within its own full expression
+stays legal, exactly as consuming the call directly does.
 
 {{ rule(id="6.6:10", cat="legality-rule") }}
 
@@ -110,7 +117,9 @@ even though the read syntactically precedes the exclusive access. When the
 accessor result is itself re-borrowed as a `borrow` argument of the same call
 (`use(borrow v.get_ref(i), inout v)`), the conflict is caught by the general
 argument-exclusivity rule and surfaces as its diagnostic (E0430) rather than
-E0259; the program is rejected either way.
+E0259; the program is rejected either way. A loan carried out of a join
+(6.6:9) keeps this extent, so `use(if c { v.get_ref(i) } else { 0 },
+g(inout v))` is rejected on the same footing as the unwrapped call.
 
 {{ rule(id="6.6:11", cat="legality-rule") }}
 


### PR DESCRIPTION
Four fixes from the 2026-08-23 type-inference hunt, developed in isolated worktrees and integrated with hand re-verification of every repro.

## Accessor-result escapes through if/match arms

Wrapping an accessor call in an `if`/`match` arm defeated all four 6.6:9 escape checks (E0250–E0253) **and** the 6.6:10 exclusivity loan — accept-invalid on the stable ADR-0062 surface. Root cause had two halves: the escape check recognized only direct accessor-call refs (a join result missed the map), and each arm's full-expression boundary truncated the result loan at the arm edge, so fixing registration alone would have left E0259 broken. Joins now derive accessor-result status structurally from the RIR (block tails, if arms, match arms; leftmost-first with a zero-alloc fast path), and arms readmit their harvested loans after the last arm — arms are alternatives, so earlier readmission would self-conflict. Twelve bypass shapes now reject with their assigned codes (the worker found five beyond the hunt's seven, including two E0259 exclusivity bypasses); eight direct-form controls are byte-unchanged; legal in-expression consumption through arms (`use1(if c { p.a_ref() } else { 0 })`, 6.1:36) stays legal and is pinned. Two hunt claims were corrected en route: single-statement blocks and fn-tail positions were already rejected via RIR elision.

## The inference lookup trio (all in `inference/generate.rs`, each a lookup stopping one table short of what sema consults)

- **str/Str(N) `.len()` ICE**: the RUE-1611-class publication now covers the string views (`is_view_len_call`, mirroring sema's routing of `[T]`/`str`/`Str(N)` through one method analyzer, plus the still-contextual-literal case), so `let n: i32 = "hello".len();` reports E0206 instead of an E9000 CFG-verification ICE. Non-`len` methods were probed and cleared — sema errors first there, so no silent unify.
- **Direct user type names as `comptime T: type` arguments**: `extract_type_argument` resolves via the by-file struct/enum lookups instead of builtins only, so `identity(Foo, Foo { x: 42 })` works like the aliased spelling the earlier fix covered. Struct, enum, composite-return, and nested-forwarding shapes verified; alias/primitive/shadowing controls unchanged.
- **Array-repeat with comptime count**: `RepeatCount::Named` consults the comptime value-parameter substitution before the file-level const table, so `[0; n]` with `comptime n: u64` compiles per 7.1:37 instead of a bogus E0903; the n=0 evaluation-once pin and the genuine-empty-array diagnostic are intact.

## Validation

- All four bugs reproduced on unmodified trunk first, then verified fixed on the integrated branch by execution; 22 accessor probes and every inference repro/control re-run by hand at integration.
- New coverage: 21 accessor cases (spec + CLI, including an aarch64 asm pin and a no-double-report assertion) and 36 inference cases citing 3.7:45/3.7:52, 4.14:5/4.14:16, 7.1:37/7.1:39.
- No new error codes; no spec prose changes beyond the 6.6 examples.
- Full suite: 231 pass / 0 fail / 0 build failures, exit code captured directly; formatting clean.

Four adjacent findings are filed in the tracker rather than folded in (a disk-guard tooling bug that bit two workers, a derived-value loan residual, a shadowing diagnostic nit, and a dead-code cleanup).

Fixes RUE-1678
Fixes RUE-1679
Fixes RUE-1680
Fixes RUE-1681

---
_Generated by [Claude Code](https://claude.ai/code/session_01JekaZ8oUGSZPXQeodh3sy8)_