### PR TITLE
RUE-1683: preserve live worktree rustc scaffolding

### DIFF
--- a/scripts/rue-storage
+++ b/scripts/rue-storage
@@ -14,10 +14,10 @@ usage: scripts/rue-storage status
        scripts/rue-storage reset RUE_ROOT [RUE_ROOT ...]
 
 status inventories every registered Rue worktree and its buck-out size. plan
-asks Buck what stale or untracked output it would remove. clean performs that
-coordinated stale cleanup (default age: 1w) and, below 20% host free space,
-adaptively removes the oldest eligible output while preserving a 12-hour
-minimum TTL. guard is the build preflight: when free space is at or below 10%
+asks Buck what tracked stale output it would remove. clean performs that
+coordinated tracked stale cleanup (default age: 1w) and, below 20% host free
+space, adaptively removes the oldest eligible tracked output while preserving a
+12-hour minimum TTL. guard is the build preflight: when free space is at or below 10%
 of the device AND below the cleanup floor (16 GiB), it runs that cleanup
 across every worktree before allowing more disk-heavy work; a build is
 refused only when free space also sits at or below the hard floor (4 GiB),
@@ -133,6 +133,7 @@ stale_all() {
     local mode="$1" age="$2" root roots failed=0
     local args=(
         clean --stale "$age"
+        --tracked-only
         --adaptive-low-disk-threshold "$adaptive_target_percent"
         --adaptive-min-ttl "$adaptive_min_ttl"
     )

--- a/scripts/test-cleanup-scripts.sh
+++ b/scripts/test-cleanup-scripts.sh
@@ -229,6 +229,8 @@ EOF
     "$([ "$(grep -c -- '--dry-run' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
   check "storage: dry-run includes the adaptive host-free target" \
     "$([ "$(grep -c -- '--adaptive-low-disk-threshold 20' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
+  check "storage: dry-run considers tracked artifacts only" \
+    "$([ "$(grep -c -- '--tracked-only' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
   check "storage: dry-run protects the minimum TTL" \
     "$([ "$(grep -c -- '--adaptive-min-ttl 12h' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
   check "storage: dry-run never performs a full reset" \
@@ -271,6 +273,8 @@ EOF
     "$([ "$(grep -c ':clean --stale 1w' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
   check "storage: pressure guard uses adaptive materializer cleanup" \
     "$([ "$(grep -c -- '--adaptive-low-disk-threshold 20 --adaptive-min-ttl 12h' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
+  check "storage: pressure guard considers tracked artifacts only" \
+    "$([ "$(grep -c -- '--tracked-only' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
 
   : >"$sb/calls.log"
   cat >"$sb/fakebin/df" <<'EOF'
@@ -284,6 +288,66 @@ EOF
   check "storage: healthy guard succeeds without cleanup" "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
   check "storage: healthy guard starts no Buck cleanup" \
     "$(! grep -q ':clean ' "$sb/calls.log" 2>/dev/null && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_guard_preserves_incremental_rustc_scaffolding() {
+  # RUE-1683: adaptive stale cleanup must not remove untracked rustc out-dir
+  # scaffolding from a live sibling worktree. The fake Buck coordinator models
+  # the old behavior by deleting that directory unless --tracked-only is set,
+  # then models a subsequent incremental build that requires it.
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  setup_storage_root "$sb/root-2"
+  mkdir -p "$sb/root-2/buck-out/v2/gen/extras/rue-codegen"
+
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+case "$1" in
+  clean)
+    if [[ "$*" == *"--stale"* && "$*" != *"--tracked-only"* ]]; then
+      rmdir "$PWD/buck-out/v2/gen/extras/rue-codegen" 2>/dev/null || true
+    fi
+    ;;
+  build)
+    [[ -d "$PWD/buck-out/v2/gen/extras/rue-codegen" ]]
+    ;;
+esac
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+if [[ "\$*" == *"worktree list --porcelain"* ]]; then
+  printf 'worktree %s/root-1\n\nworktree %s/root-2\n' "$sb" "$sb"
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$sb/fakebin/git"
+  # Start below the emergency threshold, then recover above the adaptive
+  # target after cleanup. No host-wide disk state is touched.
+  cat >"$sb/fakebin/df" <<EOF
+#!/usr/bin/env bash
+count=0
+[[ -f "$sb/df-count" ]] && count=\$(cat "$sb/df-count")
+printf '%d\n' \$((count + 1)) >"$sb/df-count"
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+if [[ \$count -eq 0 ]]; then
+  printf 'disk 100000 95000 5000 95%% /\n'
+else
+  printf 'disk 100000 75000 25000 75%% /\n'
+fi
+EOF
+  chmod +x "$sb/fakebin/df"
+
+  run_script "$sb" rue-storage guard || rc=$?
+  check "storage: guard preserves a sibling's rustc out-dir scaffolding" \
+    "$([ -d "$sb/root-2/buck-out/v2/gen/extras/rue-codegen" ] && echo 0 || echo 1)"
+  (cd "$sb/root-2" && CALLS="$sb/calls.log" PATH="$sb/fakebin:$PATH" \
+    "$sb/buck2" build --incremental) || rc=1
+  check "storage: subsequent sibling incremental build remains viable" \
+    "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
   rm -rf "$sb"
 }
 
@@ -457,6 +521,7 @@ test_jjtidy_only_deletes_proven_merged
 test_storage_git_failure_is_fail_closed
 test_storage_plans_every_registered_root
 test_storage_guard_is_host_wide_only_under_pressure
+test_storage_guard_preserves_incremental_rustc_scaffolding
 test_storage_guard_blocks_when_pressure_remains_critical
 test_storage_guard_proceeds_between_cleanup_and_hard_floors
 test_storage_guard_survives_cleanup_failure_between_floors


### PR DESCRIPTION
## Summary

- restrict coordinated stale cleanup to Buck-tracked artifacts
- preserve untracked rustc out-dir scaffolding in registered sibling worktrees
- add a hermetic guard regression that proves the next incremental build remains viable

## Validation

- ./buck2 test //:cleanup-script-tests
- scripts/rue quick
- scripts/rue fmt
- scripts/rue premerge

Fixes RUE-1683