### PR TITLE
RUE-1687: index general-inlining eligibility instead of scanning

### DIFF
--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -1938,11 +1938,26 @@ pub(crate) fn apply_general_inlining(
         );
     }
     let recursive = recursive_scc_nodes(&graph);
+    // Membership and by-key lookup only; `records` keeps its ordered iteration
+    // above, and `recursive` its ordered construction. Both are probed once per
+    // call site below, where a `BTree` probe means walking a recursive identity.
+    let recursive_set: ahash::AHashSet<&crate::FunctionInstanceKey> = recursive.iter().collect();
+    let record_lookup: ahash::AHashMap<&crate::FunctionInstanceKey, _> = records.iter().collect();
+    // `eligible` is asked once per call site, and used to end in a linear scan
+    // of every key in the batch comparing recursive function identities. On
+    // Lattice that is 1,280 keys per question, and it made this pass the
+    // largest source of `FunctionInstanceKey` equality in the whole compile.
+    // The first match wins here exactly as `Iterator::find` did.
+    let mut key_by_function: ahash::AHashMap<&crate::FunctionInstanceKey, &OptimizedCfgQueryKey> =
+        ahash::AHashMap::with_capacity(keys.len());
+    for key in keys.iter() {
+        key_by_function.entry(&key.cfg.function).or_insert(key);
+    }
     let eligible = |function: &crate::FunctionInstanceKey| {
-        let Some(record) = records.get(function) else {
+        let Some(record) = record_lookup.get(function).copied() else {
             return false;
         };
-        if recursive.contains(function)
+        if recursive_set.contains(function)
             || has_calls.get(function).copied().unwrap_or(true)
             || !phase2_size_eligible(record.cfg.value_count())
         {
@@ -1952,9 +1967,8 @@ pub(crate) fn apply_general_inlining(
             return false;
         }
         matches!(
-            &keys
-                .iter()
-                .find(|key| key.cfg.function == *function)
+            &key_by_function
+                .get(function)
                 .map(|key| &key.cfg.semantic_input),
             Some(CfgSemanticInput::Body { input, .. }) if !canonical_body(&input.canonical).is_accessor
         )
@@ -1968,17 +1982,20 @@ pub(crate) fn apply_general_inlining(
         let Some(sites) = callsites.get(function) else {
             continue;
         };
+        // The caller's own record is the same for every site in this
+        // iteration, so it is resolved once rather than per site.
+        let caller_record = record_lookup.get(function).copied();
         let selected = sites
             .iter()
             .filter(|(call, callee)| {
                 eligible(callee)
-                    && records.get(callee).is_some_and(|callee| {
+                    && record_lookup.get(callee).copied().is_some_and(|callee| {
                         // CFG calls carry physical argument values. A
                         // zero-width source parameter can therefore make
                         // the physical count differ; the Phase-2 policy
                         // excludes that ABI shape rather than handing it
                         // to the source-parameter splice primitive.
-                        records.get(function).is_some_and(|caller| {
+                        caller_record.is_some_and(|caller| {
                             caller
                                 .cfg
                                 .get_call_args(&caller.cfg.get_inst(*call).data)


### PR DESCRIPTION
Implements RUE-1687. Follow-up to RUE-1682 (#2580) — profiling the same pass again turned up something worse than a constant factor.

## The linear scan

`eligible` is asked once per call site, and it ended in:

```rust
keys.iter()
    .find(|key| key.cfg.function == *function)
    .map(|key| &key.cfg.semantic_input)
```

A scan of **every optimized-CFG key in the batch** — 1,280 on Lattice — comparing `FunctionInstanceKey` by equality. Those are recursive identities bottoming out in `StableDefinitionKey`, whose comparison ends in a `memcmp` over a module path and a definition name. Per call site.

It made this pass the largest single source of function-identity equality in the compile: **2,314,350 `PartialEq::eq` calls**.

An `AHashMap` from function identity to key replaces it, built once. `Iterator::find` answers with the first match, so the map is filled through `entry().or_insert()` to keep the same one.

**This is O(batch) per call site**, so its cost grows with the square of program size in the worst case. The Lattice number understates what it costs on a larger program.

## Three smaller probes in the same pass

- `records.get(function)` inside the per-site filter is **loop-invariant** — the caller's own record is the same for every site in that iteration. Resolved once before the filter.
- `records.get(callee)` per site, and the same lookup inside `eligible`, go through a by-key hash index.
- `recursive.contains(function)` is a membership test, so it goes to a hash set.

## What deliberately did not change

`records` stays a `BTreeMap` — it is iterated in key order and that order reaches the output. `recursive_scc_nodes` still builds and returns its ordered set; only the membership test against it is hashed. Same reasoning as #2580: the ordered structures whose iteration is observable are left alone.

## Result

| | Retired instructions | |
| --- | ---: | ---: |
| after RUE-1682 | 8,168,738,864 | |
| linear scan replaced by an index | 8,087,642,646 | −0.99% |
| invariant hoisted, probes indexed | **8,048,091,637** | −0.49% |

**−1.47%**, emitted executable byte-identical (`cmp`-verified). Cumulative across the session: **9,486,324,770 → 8,048,091,637, −15.16%.**

## Validation

- `scripts/rue premerge` — 196 pass, 0 fail, 0 build failures
- `scripts/rue fmt` applied
- Emitted Lattice executable byte-identical against the pre-series compiler

---
_Generated by [Claude Code](https://claude.ai/code/session_011sbnn24fuaT6oLix6Sgk7S)_