### PR TITLE
RUE-1643: support large AArch64 stack adjustments

### DIFF
--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -81,8 +81,8 @@
 use rue_error::{CompileError, CompileResult, ErrorKind, ice_error};
 
 use super::mir::{
-    Aarch64Inst, Aarch64Mir, BLOCK_LABEL_BASE, Cond, LabelId, Reg, SCRATCH_ADDRESS,
-    narrow_load_mnemonic, narrow_store_mnemonic,
+    Aarch64Inst, Aarch64Mir, BLOCK_LABEL_BASE, Cond, LabelId, MAX_ADD_SUB_IMMEDIATE, Reg,
+    SCRATCH_ADDRESS, narrow_load_mnemonic, narrow_store_mnemonic,
 };
 use crate::{EmittedCode, EmittedInst, EmittedRelocation};
 
@@ -156,10 +156,14 @@ const OPCODE_LDP_POST: u32 = 0xA8C00000;
 // Arithmetic instructions (64-bit)
 /// ADD Xd, Xn, Xm - Add (64-bit, no flags)
 const OPCODE_ADD_X: u32 = 0x8B000000;
+/// ADD Xd, Xn, Xm, UXTX; register 31 names SP in this form.
+const OPCODE_ADD_EXT_X: u32 = 0x8B206000;
 /// ADD Xd, Xn, #imm12 - Add immediate (64-bit)
 const OPCODE_ADD_IMM_X: u32 = 0x91000000;
 /// SUB Xd, Xn, Xm - Subtract (64-bit, no flags)
 const OPCODE_SUB_X: u32 = 0xCB000000;
+/// SUB Xd, Xn, Xm, UXTX; register 31 names SP in this form.
+const OPCODE_SUB_EXT_X: u32 = 0xCB206000;
 /// SUB Xd, Xn, #imm12 - Subtract immediate (64-bit)
 const OPCODE_SUB_IMM_X: u32 = 0xD1000000;
 /// SUBS Xd, Xn, Xm - Subtract and set flags (64-bit)
@@ -1944,6 +1948,26 @@ impl<'a> Emitter<'a> {
         self.emit_u32(inst);
     }
 
+    /// Emit the extended-register form used when an operand is SP.
+    ///
+    /// In the shifted-register encoding, register encoding 31 names XZR;
+    /// the extended-register encoding is the AArch64 form that names SP.
+    fn emit_add_ext_rr(&mut self, rd: Reg, rn: Reg, rm: Reg) {
+        let inst = OPCODE_ADD_EXT_X
+            | (rm.encoding() as u32) << 16
+            | (rn.encoding() as u32) << 5
+            | rd.encoding() as u32;
+        self.emit_u32(inst);
+    }
+
+    fn emit_sub_ext_rr(&mut self, rd: Reg, rn: Reg, rm: Reg) {
+        let inst = OPCODE_SUB_EXT_X
+            | (rm.encoding() as u32) << 16
+            | (rn.encoding() as u32) << 5
+            | rd.encoding() as u32;
+        self.emit_u32(inst);
+    }
+
     fn emit_adds_rr32(&mut self, rd: Reg, rn: Reg, rm: Reg) {
         // ADDS Wd, Wn, Wm - 32-bit add with flags for i32 overflow detection
         let inst = OPCODE_ADDS_W
@@ -1968,11 +1992,22 @@ impl<'a> Emitter<'a> {
         // ADD for the low part. Previously the immediate was masked & 0xFFF,
         // silently truncating — e.g. epilogues of frames >4095 bytes
         // mis-adjusted SP by multiples of 4096. (RUE-129)
-        // Correctness guard (must run in release): an immediate wider than the
-        // 24 bits the two-instruction shifted form can encode would be silently
-        // truncated below, mis-adjusting SP, so plain `assert!` not
-        // `debug_assert!` (RUE-45).
-        assert!(imm < (1 << 24), "ADD immediate exceeds 24 bits: {imm}");
+        // Values above the two-instruction limit are materialized in the
+        // emitter scratch register below; the shared limit is kept named so
+        // peephole cannot synthesize an unencodable MIR immediate.
+        if imm > MAX_ADD_SUB_IMMEDIATE as u32 {
+            assert!(
+                rd != SCRATCH_ADDRESS && rn != SCRATCH_ADDRESS,
+                "large ADD immediate cannot use its scratch register as an operand"
+            );
+            self.emit_mov_imm(SCRATCH_ADDRESS, imm as i64);
+            if rd == Reg::Sp || rn == Reg::Sp {
+                self.emit_add_ext_rr(rd, rn, SCRATCH_ADDRESS);
+            } else {
+                self.emit_add_rr(rd, rn, SCRATCH_ADDRESS, false);
+            }
+            return;
+        }
         if imm > 0xFFF {
             let inst = OPCODE_ADD_IMM_X
                 | (1 << 22)
@@ -2035,11 +2070,26 @@ impl<'a> Emitter<'a> {
         // silently truncating — prologues of frames >4095 bytes UNDER-ALLOCATED
         // by multiples of 4096, so locals overlapped the caller's stack.
         // (RUE-129)
-        // Correctness guard (must run in release): an immediate wider than the
-        // 24 bits the two-instruction shifted form can encode would be silently
-        // truncated below, under-allocating the frame, so plain `assert!` not
-        // `debug_assert!` (RUE-45).
-        assert!(imm < (1 << 24), "SUB immediate exceeds 24 bits: {imm}");
+        // Values above the two-instruction limit are materialized in the
+        // emitter scratch register below; the shared limit is kept named so
+        // peephole cannot synthesize an unencodable MIR immediate.
+        if imm > MAX_ADD_SUB_IMMEDIATE as u32 {
+            assert!(
+                rd != SCRATCH_ADDRESS && rn != SCRATCH_ADDRESS,
+                "large SUB immediate cannot use its scratch register as an operand"
+            );
+            self.emit_mov_imm(SCRATCH_ADDRESS, imm as i64);
+            if rd == Reg::Sp || rn == Reg::Sp {
+                self.emit_sub_ext_rr(rd, rn, SCRATCH_ADDRESS);
+            } else {
+                let inst = OPCODE_SUB_X
+                    | (SCRATCH_ADDRESS.encoding() as u32) << 16
+                    | (rn.encoding() as u32) << 5
+                    | rd.encoding() as u32;
+                self.emit_u32(inst);
+            }
+            return;
+        }
         if imm > 0xFFF {
             let inst = OPCODE_SUB_IMM_X
                 | (1 << 22)
@@ -2734,6 +2784,57 @@ mod tests {
         assert_ne!(hi & (1 << 22), 0, "first SUB must use the LSL #12 form");
         assert_eq!((hi >> 10) & 0xFFF, 0x2, "high chunk should be 2 (=8192)");
         assert_eq!((lo >> 10) & 0xFFF, 9536 - 8192, "low chunk remainder");
+    }
+
+    #[test]
+    fn test_add_sub_imm_boundary_materializes_above_sequence_limit() {
+        let at_limit = emit_single(Aarch64Inst::AddImm {
+            dst: Operand::Physical(Reg::X0),
+            src: Operand::Physical(Reg::X1),
+            imm: MAX_ADD_SUB_IMMEDIATE,
+        });
+        assert_eq!(at_limit.len(), 8, "the inclusive limit uses two immediates");
+
+        let above_limit = emit_single(Aarch64Inst::AddImm {
+            dst: Operand::Physical(Reg::X0),
+            src: Operand::Physical(Reg::X1),
+            imm: MAX_ADD_SUB_IMMEDIATE + 1,
+        });
+        assert_eq!(above_limit.len(), 12, "larger add uses MOV + register add");
+        let add = u32::from_le_bytes(above_limit[8..12].try_into().unwrap());
+        assert_eq!(add & 0xFF000000, OPCODE_ADD_X);
+        assert_eq!((add >> 16) & 0x1F, SCRATCH_ADDRESS.encoding() as u32);
+        assert_eq!((add >> 5) & 0x1F, Reg::X1.encoding() as u32);
+        assert_eq!(add & 0x1F, Reg::X0.encoding() as u32);
+
+        let above_limit_sp_add = emit_single(Aarch64Inst::AddImm {
+            dst: Operand::Physical(Reg::Sp),
+            src: Operand::Physical(Reg::Sp),
+            imm: MAX_ADD_SUB_IMMEDIATE + 1,
+        });
+        let sp_add = u32::from_le_bytes(above_limit_sp_add[8..12].try_into().unwrap());
+        assert_eq!(sp_add & 0xFF200000, OPCODE_ADD_EXT_X & 0xFF200000);
+        assert_eq!((sp_add >> 16) & 0x1F, SCRATCH_ADDRESS.encoding() as u32);
+        assert_eq!((sp_add >> 5) & 0x1F, Reg::Sp.encoding() as u32);
+        assert_eq!(sp_add & 0x1F, Reg::Sp.encoding() as u32);
+        assert_eq!((sp_add >> 13) & 0x7, 3, "extended form must use UXTX");
+
+        let above_limit_sp = emit_single(Aarch64Inst::SubImm {
+            dst: Operand::Physical(Reg::Sp),
+            src: Operand::Physical(Reg::Sp),
+            imm: MAX_ADD_SUB_IMMEDIATE + 1,
+        });
+        assert_eq!(
+            above_limit_sp.len(),
+            12,
+            "larger stack subtract uses MOV + register sub"
+        );
+        let sub = u32::from_le_bytes(above_limit_sp[8..12].try_into().unwrap());
+        assert_eq!(sub & 0xFF200000, OPCODE_SUB_EXT_X & 0xFF200000);
+        assert_eq!((sub >> 16) & 0x1F, SCRATCH_ADDRESS.encoding() as u32);
+        assert_eq!((sub >> 5) & 0x1F, Reg::Sp.encoding() as u32);
+        assert_eq!(sub & 0x1F, Reg::Sp.encoding() as u32);
+        assert_eq!((sub >> 13) & 0x7, 3, "extended form must use UXTX");
     }
 
     #[test]

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -178,6 +178,10 @@ pub(crate) const SCRATCH_SOURCE_C: Reg = Reg::X12;
 /// rewriting, with allocated values already live in registers.
 pub(crate) const SCRATCH_ADDRESS: Reg = Reg::X15;
 
+/// Largest immediate encoded by the two-instruction ADD/SUB immediate form.
+/// Values above this limit are materialized by the emitter.
+pub(crate) const MAX_ADD_SUB_IMMEDIATE: i32 = (1 << 24) - 1;
+
 /// Whether the allocator is forbidden from handing out `reg`.
 pub(crate) const fn is_reserved(reg: Reg) -> bool {
     let mut index = 0;

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -23,6 +23,8 @@ mod verify;
 
 pub use cfg_lower::CfgLower;
 pub use emit::Emitter;
+#[cfg(test)]
+pub(crate) use mir::MAX_ADD_SUB_IMMEDIATE;
 pub use mir::{Aarch64Inst, Aarch64Mir, Cond, Operand, Reg, VReg};
 pub use regalloc::RegAlloc;
 

--- a/crates/rue-codegen/src/aarch64/peephole.rs
+++ b/crates/rue-codegen/src/aarch64/peephole.rs
@@ -14,7 +14,8 @@
 //! - `cmp r, #0` → `tst r, r` (same flags, sometimes faster)
 //!
 //! ## Category 3: Adjacent instruction combining
-//! - `add r, r, #a` + `add r, r, #b` → `add r, r, #(a+b)` (when sum fits in i32)
+//! - `add r, r, #a` + `add r, r, #b` → `add r, r, #(a+b)` (when the sum fits
+//!   the ordinary AArch64 immediate sequence)
 //!
 //! The pass operates in-place on the instruction vector for efficiency.
 //!
@@ -34,7 +35,7 @@
 //! instructions (`add`/`sub`/`mov`/shifts/`eor` without the S suffix), so
 //! they need no flags gate.
 
-use super::mir::{Aarch64Inst, Cond, Operand, Reg};
+use super::mir::{Aarch64Inst, Cond, MAX_ADD_SUB_IMMEDIATE, Operand, Reg};
 use super::schedule::writes_flags;
 
 /// Apply peephole optimizations to the instruction stream.
@@ -169,8 +170,12 @@ fn combine_adjacent(instructions: &mut Vec<Aarch64Inst>) -> usize {
                 && operands_equal(dst2, src2)
                 && operands_equal(dst1, dst2)
             {
-                // Check for overflow when combining immediates
-                if let Some(combined) = imm1.checked_add(*imm2) {
+                // Keep the combined MIR immediate within the ordinary
+                // AArch64 immediate sequence; larger values use emitter
+                // materialization and should not be synthesized here.
+                if let Some(combined) = imm1.checked_add(*imm2).filter(|combined| {
+                    (-MAX_ADD_SUB_IMMEDIATE..=MAX_ADD_SUB_IMMEDIATE).contains(combined)
+                }) {
                     // Replace first instruction with combined add
                     instructions[i] = Aarch64Inst::AddImm {
                         dst: *dst1,
@@ -204,7 +209,10 @@ fn combine_adjacent(instructions: &mut Vec<Aarch64Inst>) -> usize {
                 && operands_equal(dst2, src2)
                 && operands_equal(dst1, dst2)
             {
-                if let Some(combined) = imm1.checked_add(*imm2) {
+                if let Some(combined) = imm1
+                    .checked_add(*imm2)
+                    .filter(|combined| (0..=MAX_ADD_SUB_IMMEDIATE).contains(combined))
+                {
                     instructions[i] = Aarch64Inst::SubImm {
                         dst: *dst1,
                         src: *src1,
@@ -656,6 +664,150 @@ mod tests {
             instructions[0],
             Aarch64Inst::SubImm { imm: 30, .. }
         ));
+    }
+
+    #[test]
+    fn test_combine_adds_at_encoding_limit_but_not_above() {
+        let physical = Operand::Physical(Reg::X0);
+        let mut at_limit = vec![
+            Aarch64Inst::AddImm {
+                dst: physical,
+                src: physical,
+                imm: MAX_ADD_SUB_IMMEDIATE - 1,
+            },
+            Aarch64Inst::AddImm {
+                dst: physical,
+                src: physical,
+                imm: 1,
+            },
+            Aarch64Inst::Ret,
+        ];
+        assert_eq!(optimize(&mut at_limit), 1);
+        assert!(matches!(
+            at_limit[0],
+            Aarch64Inst::AddImm {
+                imm: MAX_ADD_SUB_IMMEDIATE,
+                ..
+            }
+        ));
+
+        let mut above_limit = vec![
+            Aarch64Inst::AddImm {
+                dst: physical,
+                src: physical,
+                imm: MAX_ADD_SUB_IMMEDIATE,
+            },
+            Aarch64Inst::AddImm {
+                dst: physical,
+                src: physical,
+                imm: 1,
+            },
+            Aarch64Inst::Ret,
+        ];
+        assert_eq!(optimize(&mut above_limit), 0);
+        assert_eq!(above_limit.len(), 3);
+    }
+
+    #[test]
+    fn test_combine_adds_signed_limit_but_not_below() {
+        let physical = Operand::Physical(Reg::X0);
+        let mut at_limit = vec![
+            Aarch64Inst::AddImm {
+                dst: physical,
+                src: physical,
+                imm: -MAX_ADD_SUB_IMMEDIATE + 1,
+            },
+            Aarch64Inst::AddImm {
+                dst: physical,
+                src: physical,
+                imm: -1,
+            },
+            Aarch64Inst::Ret,
+        ];
+        assert_eq!(optimize(&mut at_limit), 1);
+        assert!(matches!(
+            at_limit[0],
+            Aarch64Inst::AddImm { imm, .. } if imm == -MAX_ADD_SUB_IMMEDIATE
+        ));
+
+        let mut below_limit = vec![
+            Aarch64Inst::AddImm {
+                dst: physical,
+                src: physical,
+                imm: -MAX_ADD_SUB_IMMEDIATE,
+            },
+            Aarch64Inst::AddImm {
+                dst: physical,
+                src: physical,
+                imm: -1,
+            },
+            Aarch64Inst::Ret,
+        ];
+        assert_eq!(optimize(&mut below_limit), 0);
+        assert_eq!(below_limit.len(), 3);
+    }
+
+    #[test]
+    fn test_combine_subs_at_encoding_limit_but_not_above() {
+        let physical = Operand::Physical(Reg::X0);
+        let mut at_limit = vec![
+            Aarch64Inst::SubImm {
+                dst: physical,
+                src: physical,
+                imm: MAX_ADD_SUB_IMMEDIATE - 1,
+            },
+            Aarch64Inst::SubImm {
+                dst: physical,
+                src: physical,
+                imm: 1,
+            },
+            Aarch64Inst::Ret,
+        ];
+        assert_eq!(optimize(&mut at_limit), 1);
+        assert!(matches!(
+            at_limit[0],
+            Aarch64Inst::SubImm {
+                imm: MAX_ADD_SUB_IMMEDIATE,
+                ..
+            }
+        ));
+
+        let mut above_limit = vec![
+            Aarch64Inst::SubImm {
+                dst: physical,
+                src: physical,
+                imm: MAX_ADD_SUB_IMMEDIATE,
+            },
+            Aarch64Inst::SubImm {
+                dst: physical,
+                src: physical,
+                imm: 1,
+            },
+            Aarch64Inst::Ret,
+        ];
+        assert_eq!(optimize(&mut above_limit), 0);
+        assert_eq!(above_limit.len(), 3);
+    }
+
+    #[test]
+    fn test_combine_subs_rejects_negative_domain() {
+        let physical = Operand::Physical(Reg::X0);
+        let mut instructions = vec![
+            Aarch64Inst::SubImm {
+                dst: physical,
+                src: physical,
+                imm: -1,
+            },
+            Aarch64Inst::SubImm {
+                dst: physical,
+                src: physical,
+                imm: -1,
+            },
+            Aarch64Inst::Ret,
+        ];
+
+        assert_eq!(optimize(&mut instructions), 0);
+        assert_eq!(instructions.len(), 3);
     }
 
     #[test]

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -534,8 +534,12 @@ pub use x86_64::{Operand, Reg, X86Inst, X86Mir};
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aarch64::MAX_ADD_SUB_IMMEDIATE;
     use lasso::ThreadedRodeo;
-    use rue_air::{AirEditor, AirValidationContext, FrozenTypeInternPool, Type, TypeInternPool};
+    use rue_air::{
+        AirEditor, AirValidationContext, FrozenTypeInternPool, Type, TypeInternPool,
+        layout::SLOT_BYTES,
+    };
     use rue_cfg::{CfgBuilder, ValidatedCfg};
     use rue_span::Span;
 
@@ -617,6 +621,19 @@ mod tests {
     }
 
     fn test_cfg() -> (ValidatedCfg, FrozenTypeInternPool, ThreadedRodeo) {
+        test_cfg_with_locals(0)
+    }
+
+    fn test_cfg_with_locals(
+        num_locals: u32,
+    ) -> (ValidatedCfg, FrozenTypeInternPool, ThreadedRodeo) {
+        test_cfg_with_locals_named(num_locals, "main")
+    }
+
+    fn test_cfg_with_locals_named(
+        num_locals: u32,
+        fn_name: &str,
+    ) -> (ValidatedCfg, FrozenTypeInternPool, ThreadedRodeo) {
         let mut air = AirEditor::new(Type::I32);
 
         let const_ref = air.add_const(42, Type::I32, Span::new(0, 2));
@@ -629,9 +646,9 @@ mod tests {
             .expect("test AIR must validate");
         let cfg_output = CfgBuilder::build(
             &air,
+            num_locals,
             0,
-            0,
-            "main",
+            fn_name,
             &type_pool,
             vec![],
             &interner,
@@ -793,6 +810,53 @@ mod tests {
 
         // Should have no strings
         assert!(machine_code.strings.is_empty());
+    }
+
+    #[test]
+    fn large_frame_codegen_emits_on_both_architectures_without_large_fixture_data() {
+        // One slot above the immediate sequence's byte capacity forces the
+        // real frame prologue/epilogue through the large-SP materialization
+        // path. The CFG itself remains a constant return, so this allocates
+        // only compact slot metadata rather than an aggregate-sized AIR body.
+        let num_locals = (MAX_ADD_SUB_IMMEDIATE as u64 / SLOT_BYTES + 1) as u32;
+        let (cfg, type_pool, interner) = test_cfg_with_locals_named(num_locals, "large_frame");
+
+        let x86 = x86_64::generate(&cfg, &type_pool, &[], &interner)
+            .expect("x86-64 large frame generation should succeed");
+        assert!(!x86.code.is_empty());
+
+        let arm = aarch64::generate(
+            &cfg,
+            &type_pool,
+            &[],
+            &interner,
+            rue_target::Target::Aarch64Linux,
+        )
+        .expect("AArch64 large frame generation should succeed");
+        assert!(!arm.code.is_empty());
+
+        let words = arm
+            .code
+            .chunks_exact(4)
+            .map(|bytes| u32::from_le_bytes(bytes.try_into().unwrap()));
+        let words = words.collect::<Vec<_>>();
+        let has_large_sp_adjust = words.iter().copied().any(|word| {
+            (word & 0xFF200000) == 0xCB200000
+                && ((word >> 16) & 0x1F) == 15
+                && ((word >> 5) & 0x1F) == 31
+                && (word & 0x1F) == 31
+                && ((word >> 13) & 0x7) == 3
+        }) && words.iter().copied().any(|word| {
+            (word & 0xFF200000) == 0x8B200000
+                && ((word >> 16) & 0x1F) == 15
+                && ((word >> 5) & 0x1F) == 31
+                && (word & 0x1F) == 31
+                && ((word >> 13) & 0x7) == 3
+        });
+        assert!(
+            has_large_sp_adjust,
+            "AArch64 frame must use UXTX register ADD/SUB through x15: {words:x?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes RUE-1643.

AArch64 now materializes stack adjustments above the two-instruction immediate range through the reserved emitter scratch register and uses the SP-capable UXTX register form. The peephole combiner shares the immediate boundary and respects the signed AddImm and nonnegative SubImm domains.

Coverage pins the exact encoding boundary, peephole boundaries, and large-frame emission on both x86-64 and AArch64 using a compact validated CFG.

Validation:
- scripts/rue fmt
- scripts/rue unit codegen (740 passed)
- scripts/rue quick (31 targets passed)
- scripts/rue premerge (196 passed, 0 failed)