### PR TITLE
RUE-1685: diagnose runtime type-argument shadows

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -3973,13 +3973,15 @@ impl<'a> ConstraintGenerator<'a> {
                 }
                 // A local or parameter shadows any same-named struct/enum. A
                 // local *not* bound to a comptime type value (a runtime value)
-                // has no concrete type here, so don't resolve it — a runtime
-                // value passed to a `comptime T: type` param is still rejected
-                // in sema. Forwarded type parameters (`T` inside a specialized
-                // generic body) are not in scope as runtime params/locals and
-                // resolve via `self.type_subst` above.
+                // has no concrete type here. Preserve that error through
+                // dependent substitutions so inference does not manufacture a
+                // downstream mismatch; sema reports the canonical comptime
+                // known-value diagnostic at the argument itself.
+                // Forwarded type parameters (`T` inside a specialized generic
+                // body) are not in scope as runtime params/locals and resolve
+                // via `self.type_subst` above.
                 if ctx.locals.contains_key(name) || ctx.params.contains_key(name) {
-                    return None;
+                    return Some(Type::ERROR);
                 }
                 resolve_sym(name)
             }

--- a/crates/rue-cli-tests/cases/comptime_alias_infer.toml
+++ b/crates/rue-cli-tests/cases/comptime_alias_infer.toml
@@ -218,7 +218,7 @@ exit_code = 42
 
 [[case]]
 name = "runtime_value_to_comptime_type_param_still_rejected"
-description = "Control for RUE-281: a runtime value passed where a `comptime T: type` argument is expected is still rejected (the fix only resolves comptime type aliases, not runtime values)."
+description = "A plain runtime value passed where a `comptime T: type` argument is expected gets the canonical E1201 diagnostic."
 files = [{ path = "main.rue", source = """
 fn identity(comptime T: type, x: T) -> T { x }
 fn main() -> i32 {
@@ -227,4 +227,52 @@ fn main() -> i32 {
 }
 """ }]
 compile_fail = true
-error_contains = ["E0206"]
+error_contains = ["E1201", "parameter 'T'"]
+compile_stderr_not_contains = ["E0206"]
+
+# Runtime bindings that shadow type spellings must stay on sema's canonical
+# comptime-known-value diagnostic rather than producing an inference mismatch
+# (RUE-1685). The struct shadowing control lives with the nominal generic cases
+# in `generics.toml`; these cover the enum, builtin, and parameter shapes.
+
+[[case]]
+name = "runtime_local_shadowing_enum_type_rejected"
+description = "A runtime local shadows an enum name in a comptime type argument and is diagnosed as an unknown compile-time value."
+files = [{ path = "main.rue", source = """
+enum Choice { No, Yes }
+fn identity(comptime T: type, x: T) -> T { x }
+fn main() -> i32 {
+    let Choice: i32 = 3;
+    identity(Choice, 42)
+}
+""" }]
+compile_fail = true
+error_contains = ["E1201", "parameter 'T'"]
+compile_stderr_not_contains = ["E0206"]
+
+[[case]]
+name = "runtime_local_shadowing_builtin_type_rejected"
+description = "A runtime local shadows the builtin `str` type name in a comptime type argument and is diagnosed as an unknown compile-time value."
+files = [{ path = "main.rue", source = """
+fn identity(comptime T: type, x: T) -> T { x }
+fn main() -> i32 {
+    let str: i32 = 3;
+    identity(str, 42)
+}
+""" }]
+compile_fail = true
+error_contains = ["E1201", "parameter 'T'"]
+compile_stderr_not_contains = ["E0206"]
+
+[[case]]
+name = "runtime_parameter_shadowing_type_rejected"
+description = "A runtime parameter shadows a struct name in a comptime type argument and is diagnosed at the generic parameter."
+files = [{ path = "main.rue", source = """
+struct Foo { value: i32 }
+fn identity(comptime T: type, x: T) -> T { x }
+fn use(Foo: i32) -> i32 { identity(Foo, 42) }
+fn main() -> i32 { use(3) }
+""" }]
+compile_fail = true
+error_contains = ["E1201", "parameter 'T'"]
+compile_stderr_not_contains = ["E0206"]

--- a/crates/rue-cli-tests/cases/generics.toml
+++ b/crates/rue-cli-tests/cases/generics.toml
@@ -330,7 +330,7 @@ exit_code = 42
 
 [[case]]
 name = "generic_type_argument_runtime_local_shadowing_type_name_rejected"
-description = "Control: a runtime local that shadows a struct name is a value, not a type — the nominal lookup must not fire through a shadowing binding, so the call is still rejected. (The wording is the unsubstituted-`T` mismatch rather than the comptime-argument diagnostic; that is pre-existing and unchanged here.)"
+description = "A runtime local that shadows a struct name is a value, not a type — the nominal lookup must not fire through a shadowing binding, so the call gets the canonical E1201 comptime-value diagnostic."
 files = [{ path = "main.rue", source = """
 struct Foo { x: i32 }
 fn identity(comptime T: type, v: T) -> T { v }
@@ -341,5 +341,5 @@ fn main() -> i32 {
 }
 """ }]
 compile_fail = true
-error_contains = ["E0206"]
-compile_stderr_not_contains = ["E9000", "internal compiler error"]
+error_contains = ["E1201", "parameter 'T'"]
+compile_stderr_not_contains = ["E0206", "E9000", "internal compiler error"]


### PR DESCRIPTION
Summary:
- preserve an error sentinel when runtime locals or parameters are used as comptime type arguments
- leave semantic analysis responsible for the canonical E1201 diagnostic
- cover struct, enum, builtin, parameter, plain-runtime-value, alias, nominal, and forwarded-generic cases

Testing:
- scripts/rue fmt
- scripts/rue cli comptime_alias_infer
- scripts/rue cli generics
- scripts/rue spec 4.14
- scripts/rue ui diagnostics
- scripts/rue quick
- scripts/rue premerge

Fixes RUE-1685