### PR TITLE
RUE-1637: Preserve parser recovery span invariants

### DIFF
--- a/crates/rue-cli-tests/cases/diagnostic_json.toml
+++ b/crates/rue-cli-tests/cases/diagnostic_json.toml
@@ -81,24 +81,45 @@ compile_stderr_not_contains = [
 ]
 
 [[case]]
-name = "parser_recovery_reversed_json_span_is_normalized"
-description = """
-Parser recovery can temporarily produce a reversed primary span. The JSON
-formatter clamps that range while preserving the reachable parser diagnostics;
-this is an end-to-end regression for the published span invariant.
-"""
+name = "parser_recovery_source_span_is_non_reversed"
+description = "Parser recovery emits the offending reserved keyword's source span directly; JSON preserves the source invariant without normalization."
 files = [{ path = "main.rue", source = "fn main() -> i32 { let fn = 2; 0 }" }]
 args = ["--error-format", "json", "main.rue", "-o", "prog"]
 compile_fail = true
 json_diagnostics = true
-json_diagnostic_order = [
-  "error E0100 main.rue:1:24",
-  "error E0100 main.rue:1:24",
-]
+json_diagnostic_order = ["error E0100 main.rue:1:24"]
 error_contains = [
   '"code":"E0100"',
   '"start":23',
-  '"end":23',
+  '"end":25',
+]
+
+[[case]]
+name = "parser_recovery_missing_name_spans_are_exact"
+description = "Malformed item-name recovery reports the missing name and malformed method at their offending tokens, then keeps the JSON order."
+files = [{ path = "main.rue", source = "struct { fn () {} }\nfn main() -> i32 { 0 }" }]
+args = ["--error-format", "json", "main.rue", "-o", "prog"]
+compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = [
+  "error E0100 main.rue:1:8",
+  "error E0100 main.rue:1:10",
+]
+error_contains = ['"code":"E0100"', '"start":7', '"end":8', '"start":9', '"end":11']
+
+[[case]]
+name = "parser_recovery_intrinsic_name_span_is_exact"
+description = "An intrinsic followed by a non-identifier keeps one diagnostic on the offending token with a non-reversed source span."
+files = [{ path = "main.rue", source = "fn main() -> i32 { @1(2); 0 }" }]
+args = ["--error-format", "json", "main.rue", "-o", "prog"]
+compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = ["error E0100 main.rue:1:21"]
+error_contains = [
+  '"code":"E0100"',
+  "\"message\":\"expected identifier or 'drop', found integer\"",
+  '"start":20',
+  '"end":21',
 ]
 
 [[case]]

--- a/crates/rue-parser/src/parser.rs
+++ b/crates/rue-parser/src/parser.rs
@@ -310,6 +310,61 @@ mod tests {
     }
 
     #[test]
+    fn recovery_diagnostics_use_offending_spans_and_continue_without_cascades() {
+        let cases = [
+            // The initial let-pattern error already identifies the reserved
+            // keyword. Item recovery must not add a second error for it.
+            ("fn main() -> i32 { let fn = 2; 0 }", 1, vec![23..25]),
+            ("fn main() -> i32 { let struct = 2; 0 }", 1, vec![23..29]),
+            // The missing struct name is followed by a malformed method; the
+            // later top-level function remains a recovery synchronization
+            // point.
+            (
+                "struct { fn () {} }\nfn main() -> i32 { 0 }",
+                2,
+                vec![7..8, 9..11],
+            ),
+            // `ident_expected` owns the one diagnostic for an intrinsic whose
+            // name is followed by a non-identifier.
+            ("fn main() -> i32 { @1(2); 0 }", 1, vec![20..21]),
+        ];
+
+        for (source, expected_count, expected_ranges) in cases {
+            let errors = parse_source(source).unwrap_err();
+            assert_eq!(errors.len(), expected_count, "{source}: {errors:?}");
+            let ranges = errors
+                .iter()
+                .map(|error| {
+                    let span = error.span().expect("parser diagnostics have spans");
+                    assert!(span.start <= span.end, "{source}: {span:?}");
+                    span.start..span.end
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(ranges, expected_ranges, "{source}: {errors:?}");
+        }
+    }
+
+    #[test]
+    fn all_recovery_diagnostic_spans_are_non_reversed() {
+        for source in [
+            "fn main() -> i32 { let fn = 2; 0 }",
+            "fn main() -> i32 { let struct = 2; 0 }",
+            "struct { fn () {} } fn main() -> i32 { 0 }",
+            "fn main() -> i32 { @1(2); 0 }",
+            "struct S { fn broken( -> i32 { 0 } fn ok() -> i32 { 0 } }",
+        ] {
+            let errors = parse_source(source).unwrap_err();
+            assert!(
+                errors
+                    .iter()
+                    .filter_map(CompileError::span)
+                    .all(|span| span.start <= span.end),
+                "{source}: {errors:?}"
+            );
+        }
+    }
+
+    #[test]
     fn thousands_of_recovery_points_have_a_bounded_diagnostic_result() {
         let mut source = String::new();
         for index in 0..2_000 {

--- a/crates/rue-parser/src/parser/expressions.rs
+++ b/crates/rue-parser/src/parser/expressions.rs
@@ -511,7 +511,7 @@ impl Parser {
         let start = self.start();
         let name = match self.kind() {
             TokenKind::At => {
-                let at = self.bump();
+                self.bump();
                 if self.at(TokenKind::Drop) {
                     let span = self.bump().span;
                     Ident {
@@ -522,14 +522,10 @@ impl Parser {
                     match self.ident_expected("identifier or 'drop'") {
                         Ok(name) => name,
                         Err(()) => {
-                            let previous_end = at.span.start.saturating_sub(5);
-                            self.record_error(CompileError::new(
-                                ErrorKind::UnexpectedToken {
-                                    expected: "identifier".into(),
-                                    found: "'@'".into(),
-                                },
-                                Span::with_file(self.file_id, at.span.start, previous_end),
-                            ));
+                            // `ident_expected` already reports the actual
+                            // offending token. Repeating the failure at `@`
+                            // obscures that location and would violate the
+                            // parser's source-span invariant.
                             return Err(());
                         }
                     }

--- a/crates/rue-parser/src/parser/shared.rs
+++ b/crates/rue-parser/src/parser/shared.rs
@@ -251,17 +251,20 @@ impl Parser {
                     TokenKind::Pub => Some("'unchecked' or 'fn' or 'linear' or 'struct' or …"),
                     _ => None,
                 };
-                if let Some(expected) = expected {
+                // The grammar diagnostic that triggered recovery already
+                // points at the first offending reserved keyword. Do not
+                // retain a second, narrower diagnostic for that same token;
+                // recovery diagnostics are for later malformed item prefixes
+                // encountered while scanning the failed body.
+                if let Some(expected) = expected
+                    && token.span != initial_span
+                {
                     self.record_error(CompileError::new(
                         ErrorKind::UnexpectedToken {
                             expected: expected.into(),
                             found: token.kind.name().to_owned().into(),
                         },
-                        Span::with_file(
-                            self.file_id,
-                            token.span.start,
-                            token.span.start.saturating_sub(1),
-                        ),
+                        token.span,
                     ));
                 }
             }
@@ -299,18 +302,12 @@ impl Parser {
                     break;
                 }
                 let token = self.bump();
-                let previous_end = self
-                    .cursor
-                    .checked_sub(2)
-                    .and_then(|index| self.tokens.get(index))
-                    .map(|token| token.span.end)
-                    .unwrap_or(token.span.start);
                 self.record_error(CompileError::new(
                     ErrorKind::UnexpectedToken {
                         expected: "identifier".into(),
                         found: "'fn'".into(),
                     },
-                    Span::with_file(self.file_id, token.span.start, previous_end),
+                    token.span,
                 ));
                 saw_malformed_function = true;
                 continue;

--- a/crates/rue-ui-tests/cases/diagnostics/parser_recovery.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/parser_recovery.toml
@@ -61,3 +61,65 @@ fn ok() -> i32 { 0 }
 """
 compile_fail = true
 error_contains = ["expected '.', found '=>'", "found '->'"]
+
+# Reserved keywords in a let pattern are diagnosed at the keyword once. The
+# item-level recovery scan must not add a second, narrower diagnostic for the
+# same token.
+[[case]]
+name = "reserved_let_fn_has_one_exact_diagnostic"
+source = "fn main() -> i32 { let fn = 2; 0 }"
+compile_fail = true
+expected_error = """
+error: [E0100]: expected 'mut' or identifier or '_', found 'fn'
+ --> test.rue:1:24
+  |
+1 | fn main() -> i32 { let fn = 2; 0 }
+  |                        ^^
+  |
+"""
+
+[[case]]
+name = "reserved_let_struct_has_one_exact_diagnostic"
+source = "fn main() -> i32 { let struct = 2; 0 }"
+compile_fail = true
+expected_error = """
+error: [E0100]: expected 'mut' or identifier or '_', found 'struct'
+ --> test.rue:1:24
+  |
+1 | fn main() -> i32 { let struct = 2; 0 }
+  |                        ^^^^^^
+  |
+"""
+
+[[case]]
+name = "missing_item_name_and_malformed_method_continue_recovery"
+source = "struct { fn () {} }\nfn main() -> i32 { 0 }"
+compile_fail = true
+expected_error = """
+error: [E0100]: expected identifier, found '{'
+ --> test.rue:1:8
+  |
+1 | struct { fn () {} }
+  |        ^
+  |
+error: [E0100]: expected identifier, found 'fn'
+ --> test.rue:1:10
+  |
+1 | struct { fn () {} }
+  |          ^^
+  |
+error: aborting due to 2 previous errors
+"""
+
+[[case]]
+name = "intrinsic_at_non_identifier_reports_offending_token_once"
+source = "fn main() -> i32 { @1(2); 0 }"
+compile_fail = true
+expected_error = """
+error: [E0100]: expected identifier or 'drop', found integer
+ --> test.rue:1:21
+  |
+1 | fn main() -> i32 { @1(2); 0 }
+  |                     ^
+  |
+"""


### PR DESCRIPTION
## Summary\n\n- use canonical offending-token spans in parser recovery\n- remove duplicate reserved-binding and intrinsic recovery diagnostics\n- pin exact parser, UI, and JSON diagnostic ranges plus continued recovery\n\n## Validation\n\n- scripts/rue unit parser\n- scripts/rue unit compiler parser_budget_is_per_file_and_later_files_are_still_parsed\n- scripts/rue ui parser_recovery\n- scripts/rue cli diagnostic_json\n- scripts/rue spec lexical.keywords\n- scripts/rue quick\n- scripts/rue premerge\n- scripts/rue fmt\n- git diff --check\n\nFixes RUE-1637