### PR TITLE
RUE-1649: keep Darwin signal trampoline private

### DIFF
--- a/crates/rue-builtins/src/lib.rs
+++ b/crates/rue-builtins/src/lib.rs
@@ -524,6 +524,7 @@ mod tests {
         assert!(!is_reserved_function_name("memcpy2"));
         assert!(!is_reserved_function_name("my_memcpy"));
         assert!(!is_reserved_function_name("_main_loop"));
+        assert!(!is_reserved_function_name("rue_darwin_sigtramp"));
     }
 
     #[test]

--- a/crates/rue-runtime-abi/src/lib.rs
+++ b/crates/rue-runtime-abi/src/lib.rs
@@ -1791,6 +1791,9 @@ mod tests {
 
     #[test]
     fn reserved_exports_are_separate_and_targeted() {
+        assert_eq!(classify_export("rue_darwin_sigtramp"), None);
+        assert_eq!(ReservedExportId::from_symbol("rue_darwin_sigtramp"), None);
+        assert_eq!(RuntimeHelperId::from_symbol("rue_darwin_sigtramp"), None);
         assert_eq!(ReservedExportId::ALL.len(), RESERVED_EXPORTS.len());
         for (index, id) in ReservedExportId::ALL.iter().copied().enumerate() {
             assert_eq!(id as usize, index);

--- a/crates/rue-runtime/src/aarch64_macos.rs
+++ b/crates/rue-runtime/src/aarch64_macos.rs
@@ -425,6 +425,7 @@ const SA_ONSTACK: i32 = 0x0001;
 // returns, so no `sigreturn` epilogue is required (the same reasoning as the
 // x86-64 Linux restorer, which also never runs because the handler exits).
 core::arch::global_asm!(
+    ".private_extern _rue_darwin_sigtramp",
     ".globl _rue_darwin_sigtramp",
     ".p2align 2",
     "_rue_darwin_sigtramp:",

--- a/crates/rue-runtime/tests/validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/validate_runtime_archives.py
@@ -8,6 +8,12 @@ from pathlib import Path
 
 AR_MAGIC = b"!<arch>\n"
 ELF_MAGIC = b"\x7fELF"
+MACHO_64_LE_MAGIC = b"\xcf\xfa\xed\xfe"
+LC_SYMTAB = 0x2
+N_EXT = 0x01
+N_TYPE = 0x0E
+N_SECT = 0x0E
+N_PEXT = 0x10
 
 
 def archive_members(path: Path):
@@ -70,6 +76,55 @@ def macho_cpu(payload: bytes):
     return struct.unpack_from(byte_order + "I", payload, 4)[0]
 
 
+def macho_symbols(payload: bytes):
+    """Return (name, n_type, n_sect) for symbols in a 64-bit little-endian Mach-O."""
+    if not payload.startswith(MACHO_64_LE_MAGIC):
+        return []
+    if len(payload) < 32:
+        raise AssertionError("truncated 64-bit Mach-O header")
+
+    ncmds, sizeofcmds = struct.unpack_from("<II", payload, 16)
+    commands_end = 32 + sizeofcmds
+    if commands_end > len(payload):
+        raise AssertionError("truncated Mach-O load commands")
+
+    symoff = nsyms = stroff = strsize = None
+    offset = 32
+    for _ in range(ncmds):
+        if offset + 8 > commands_end:
+            raise AssertionError("truncated Mach-O load command")
+        cmd, cmdsize = struct.unpack_from("<II", payload, offset)
+        if cmdsize < 8 or offset + cmdsize > commands_end:
+            raise AssertionError("invalid Mach-O load command size")
+        if cmd == LC_SYMTAB:
+            if cmdsize < 24:
+                raise AssertionError("truncated Mach-O symbol-table command")
+            symoff, nsyms, stroff, strsize = struct.unpack_from(
+                "<IIII", payload, offset + 8
+            )
+        offset += cmdsize
+
+    if symoff is None:
+        raise AssertionError("Mach-O object has no symbol table")
+    symbols_end = symoff + nsyms * 16
+    strings_end = stroff + strsize
+    if symbols_end > len(payload) or strings_end > len(payload):
+        raise AssertionError("truncated Mach-O symbol table")
+
+    symbols = []
+    for index in range(nsyms):
+        entry = symoff + index * 16
+        strx, n_type, n_sect = struct.unpack_from("<IBB", payload, entry)
+        if strx >= strsize:
+            raise AssertionError("Mach-O symbol has invalid string-table index")
+        name_start = stroff + strx
+        name_end = payload.find(b"\0", name_start, strings_end)
+        if name_end < 0:
+            raise AssertionError("unterminated Mach-O symbol name")
+        symbols.append((payload[name_start:name_end].decode("utf-8"), n_type, n_sect))
+    return symbols
+
+
 def validate_archive(path: Path, expected_format: str, expected_machine: int):
     object_count = 0
     for name, payload in archive_members(path):
@@ -95,6 +150,34 @@ def validate_archive(path: Path, expected_format: str, expected_machine: int):
 
     if object_count == 0:
         raise AssertionError(f"{path}: archive contains no recognized object members")
+
+    if expected_format == "macho":
+        trampoline_symbols = []
+        for name, payload in archive_members(path):
+            for symbol, n_type, n_sect in macho_symbols(payload):
+                if symbol == "_rue_darwin_sigtramp":
+                    trampoline_symbols.append((name, n_type, n_sect))
+        if len(trampoline_symbols) != 1:
+            raise AssertionError(
+                f"{path}: expected one _rue_darwin_sigtramp symbol, "
+                f"found {len(trampoline_symbols)}"
+            )
+        member, n_type, n_sect = trampoline_symbols[0]
+        if n_type & N_PEXT == 0:
+            raise AssertionError(
+                f"{path}: member {member!r} trampoline is not private external "
+                f"(n_type={n_type:#x})"
+            )
+        if n_type & N_TYPE != N_SECT or n_sect == 0:
+            raise AssertionError(
+                f"{path}: member {member!r} trampoline is not a defined section "
+                f"symbol (n_type={n_type:#x}, n_sect={n_sect})"
+            )
+        if n_type & N_EXT == 0:
+            raise AssertionError(
+                f"{path}: member {member!r} trampoline is not externally linkable "
+                f"(n_type={n_type:#x})"
+            )
 
 
 def main():


### PR DESCRIPTION
## Summary

- mark the Darwin signal trampoline as a Mach-O private external symbol
- keep the internal trampoline outside the public runtime ABI and source-reserved namespace
- validate the built runtime archive symbol visibility and the manifest/reservation boundary

## Validation

- `scripts/rue quick`
- `scripts/rue fmt`
- `./buck2 test //crates/rue-runtime:runtime-archives-test`
- `./buck2 test //crates/rue-runtime-abi:rue-runtime-abi-test //crates/rue-builtins:rue-builtins-test`
- `scripts/rue cli reserved_names`
- `scripts/rue cli stack_overflow`
- `scripts/rue premerge` (196 passed)

Fixes RUE-1649