### PR TITLE
RUE-1639: fix trailing-dot float guidance

### DIFF
--- a/crates/rue-cli-tests/cases/float_literals.toml
+++ b/crates/rue-cli-tests/cases/float_literals.toml
@@ -197,12 +197,32 @@ fn main() -> i32 {
     0
 }
 """ }]
-args = ["--preview", "floats", "main.rue", "-o", "prog"]
+args = ["--error-format", "json", "--preview", "floats", "main.rue", "-o", "prog"]
 compile_fail = true
 error_contains = [
     "E0011",
     "floating-point literal cannot end with `.`: write `5.0` instead of `5.`",
 ]
+json_diagnostics = true
+json_diagnostic_order = ["error E0011 main.rue:2:13"]
+
+[[case]]
+name = "trailing_dot_on_float_is_rejected_with_a_valid_replacement"
+description = "A float base drops only its trailing dot, including exponent spelling; JSON order pins that this is one E0011."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x = 1e9.;
+    0
+}
+""" }]
+args = ["--error-format", "json", "--preview", "floats", "main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = [
+    "E0011",
+    "floating-point literal cannot end with `.`: write `1e9` instead of `1e9.`",
+]
+json_diagnostics = true
+json_diagnostic_order = ["error E0011 main.rue:2:13"]
 
 [[case]]
 name = "empty_exponent_is_rejected"

--- a/crates/rue-parser/src/parser/expressions.rs
+++ b/crates/rue-parser/src/parser/expressions.rs
@@ -283,23 +283,34 @@ impl Parser {
     /// kind the lexer uses for the leading-dot form, because both diagnose one
     /// spelling rule; only the phase that can decide it differs.
     fn reject_trailing_dot_float(&mut self, base: &Expr) -> PResult<()> {
-        let literal_text = match base {
-            Expr::Int(literal) => literal.value.to_string(),
-            Expr::Float(literal) => self.interner.resolve(&literal.value).to_string(),
-            _ => return Ok(()),
-        };
+        if !matches!(base, Expr::Int(_) | Expr::Float(_)) {
+            return Ok(());
+        }
         let dot_span = self.tokens[self.cursor].span;
         let adjacent = base.span().end == dot_span.start;
         let member_follows = matches!(self.nth(1), TokenKind::Ident(_));
         if !adjacent || member_follows {
             return Ok(());
         }
-        let span = base.span().extend_to(dot_span.end);
-        self.record_error(CompileError::new(
-            ErrorKind::MalformedFloatLiteral(format!(
+        let literal_text = match base {
+            Expr::Int(literal) => literal.value.to_string(),
+            Expr::Float(literal) => self.interner.resolve(&literal.value).to_string(),
+            _ => unreachable!("literal kind was checked above"),
+        };
+        let message = match base {
+            Expr::Int(_) => format!(
                 "floating-point literal cannot end with `.`: write `{literal_text}.0` instead \
                  of `{literal_text}.`"
-            )),
+            ),
+            Expr::Float(_) => format!(
+                "floating-point literal cannot end with `.`: write `{literal_text}` instead \
+                 of `{literal_text}.`"
+            ),
+            _ => unreachable!("literal kind was checked above"),
+        };
+        let span = base.span().extend_to(dot_span.end);
+        self.record_error(CompileError::new(
+            ErrorKind::MalformedFloatLiteral(message),
             span,
         ));
         Err(())
@@ -844,10 +855,31 @@ mod tests {
     }
 
     #[test]
+    fn trailing_dot_float_uses_the_float_without_its_final_dot() {
+        for (source, expected) in [
+            (
+                "fn f() { let x = 5.5.; }",
+                "floating-point literal cannot end with `.`: write `5.5` instead of `5.5.`",
+            ),
+            (
+                "fn f() { let x = 1e9.; }",
+                "floating-point literal cannot end with `.`: write `1e9` instead of `1e9.`",
+            ),
+        ] {
+            assert_eq!(
+                parse_errors(source),
+                vec![expected],
+                "unexpected diagnostics for {source}"
+            );
+        }
+    }
+
+    #[test]
     fn trailing_dot_rejection_does_not_disturb_member_access() {
         // A member name after the dot is an ordinary access/method call, on an
         // integer literal as much as on anything else.
         assert!(parses("fn f() { 42.to_string() }"));
+        assert!(parses("fn f() { 5.5.to_string() }"));
         assert!(parses("fn f(p: P) { p.x }"));
         // A space before the dot is not the trailing-dot spelling; it stays an
         // ordinary "expected identifier" diagnostic.
@@ -867,6 +899,12 @@ mod tests {
         assert_eq!(
             errors,
             vec!["floating-point literal cannot end with `.`: write `5.0` instead of `5.`"]
+        );
+
+        let errors = parse_errors("fn f() -> i32 { let x = 5.5.; 1 } fn g() -> i32 { 2 }");
+        assert_eq!(
+            errors,
+            vec!["floating-point literal cannot end with `.`: write `5.5` instead of `5.5.`"]
         );
     }
 }

--- a/crates/rue-ui-tests/cases/diagnostics/float-literals.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/float-literals.toml
@@ -103,6 +103,22 @@ error_contains = [
 ]
 
 [[case]]
+name = "trailing_dot_on_float_names_the_float_without_the_dot"
+description = "A float base such as `5.5` keeps its valid spelling when the parser rejects an extra trailing dot."
+source = """
+fn main() -> i32 {
+    let x = 5.5.;
+    0
+}
+"""
+preview = "floats"
+compile_fail = true
+error_contains = [
+    "E0011",
+    "floating-point literal cannot end with `.`: write `5.5` instead of `5.5.`",
+]
+
+[[case]]
 name = "empty_exponent_names_the_literal"
 description = "`1e` is diagnosed as one malformed literal rather than an integer abutting an identifier."
 source = """


### PR DESCRIPTION
## Summary

- preserve append-`.0` guidance for integer-base trailing dots
- suggest removing the extra dot for float and exponent bases
- defer literal text allocation until the parser knows it will emit E0011
- cover exact messages, diagnostic count, recovery, and legal numeric postfixes

## Validation

- `scripts/rue unit parser trailing_dot`
- `scripts/rue ui float-literals`
- `scripts/rue cli float_literals`
- `scripts/rue quick`
- `scripts/rue fmt`
- `scripts/rue premerge`

Fixes RUE-1639