### PR TITLE
RUE-1640: point struct field diagnostics at value expressions

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -2688,7 +2688,7 @@ impl<'a> ConstraintGenerator<'a> {
                                 self.add_constraint(Constraint::equal(
                                     value_info.ty,
                                     expected,
-                                    span,
+                                    value_info.span,
                                 ));
                             }
                         }
@@ -2826,7 +2826,11 @@ impl<'a> ConstraintGenerator<'a> {
                 if let Some(field_ty) = self.known_field_type(&base_info.ty, *field) {
                     let expected = self.type_to_infer(field_ty);
                     if value_info.continues {
-                        self.add_constraint(Constraint::equal(value_info.ty, expected, span));
+                        self.add_constraint(Constraint::equal(
+                            value_info.ty,
+                            expected,
+                            value_info.span,
+                        ));
                     }
                 }
                 InferType::Concrete(Type::UNIT)

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -509,6 +509,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // Check if this is an integer literal that needs type coercion
             // This handles the case where HM inference couldn't resolve the type
             // (e.g., when the struct comes from a comptime type variable)
+            let field_span = self.body_rir_ref().get(field_value).span;
             let field_inst = self.body_rir_ref().get(field_value);
             let field_result = if let InstData::IntConst(value) = &field_inst.data {
                 // Integer literal - use the expected field type directly, but
@@ -584,7 +585,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                             .ty
                             .safe_name_with_pool(Some(self.body_type_pool())),
                     },
-                    span,
+                    field_span,
                 )
                 .with_label(
                     format!(
@@ -592,7 +593,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         init_name,
                         expected_field_type.safe_name_with_pool(Some(self.body_type_pool()))
                     ),
-                    span,
+                    field_span,
                 ));
             }
 

--- a/crates/rue-air/src/sema/provider_semantics_tests.rs
+++ b/crates/rue-air/src/sema/provider_semantics_tests.rs
@@ -15,6 +15,7 @@ use super::DurableSignatureParameter;
 use super::provider_fixture::{
     FixtureKey, FixtureModule, FixtureType, ProviderFixture, error_source_slice, value_param,
 };
+use crate::SemanticImportNominalKind;
 use crate::inst::{AirInstData, AirRef};
 use crate::types::Type;
 use crate::{SemanticImportConstValue, SemanticImportType, SemanticParameterMode};
@@ -798,6 +799,55 @@ fn provider_body_resolves_struct_field_types_into_the_pool() {
             "the body's type pool must intern {expected}"
         );
     }
+}
+
+#[test]
+fn provider_body_struct_field_mismatch_points_at_the_value() {
+    let mut fixture = ProviderFixture::new();
+    fixture.declare_struct(
+        "Record",
+        vec![
+            ("count", SemanticImportType::I32),
+            (
+                "text",
+                SemanticImportType::BuiltinNominal {
+                    name: Arc::from("str"),
+                    kind: SemanticImportNominalKind::Struct,
+                },
+            ),
+        ],
+        false,
+    );
+    fixture.declare_function(
+        "id",
+        vec![value_param("n", SemanticImportType::I32)],
+        SemanticImportType::I32,
+    );
+    fixture.declare_function("main", Vec::new(), SemanticImportType::I32);
+    let source = "fn main() -> i32 {\n\
+        let x: i32 = 1;\n\
+        let r = Record { count: 0, text: id(x) };\n\
+        0\n\
+    }";
+    let error = fixture
+        .analyze(source, "main")
+        .map(|_| ())
+        .expect_err("the str field rejects an i32 expression");
+
+    assert!(
+        matches!(&error.kind, ErrorKind::TypeMismatch { expected, found }
+            if expected == "str" && found == "i32"),
+        "the diagnostic wording must preserve its expected/found direction: {error:?}"
+    );
+    assert_eq!(error_source_slice(source, &error), "id(x)");
+    let [label] = error.diagnostic().labels.as_slice() else {
+        panic!("the mismatch must carry exactly one field label: {error:?}");
+    };
+    assert_eq!(label.message, "field 'text' expects type str");
+    assert_eq!(
+        &source[label.span.start as usize..label.span.end as usize],
+        "id(x)"
+    );
 }
 
 // Migrated from `tests::test_copy_struct_with_copy_fields`: a `@copy` struct

--- a/crates/rue-cli-tests/cases/diagnostic_json.toml
+++ b/crates/rue-cli-tests/cases/diagnostic_json.toml
@@ -53,6 +53,50 @@ compile_stderr_not_contains = [
 ]
 
 [[case]]
+name = "struct_field_mismatch_uses_value_span"
+description = "RUE-1640: a struct field assignment mismatch points at the RHS expression, including its JSON primary span."
+files = [{ path = "main.rue", source = """
+struct Pair { flag: bool }
+fn give() -> i32 { 1 }
+fn main() -> i32 {
+    let mut p = Pair { flag: true };
+    p.flag = give();
+    0
+}
+""" }]
+args = ["--error-format", "json", "main.rue", "-o", "prog"]
+compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = ["error E0206 main.rue:5:14"]
+error_contains = [
+  '"code":"E0206"',
+  '"message":"type mismatch: expected bool, found i32"',
+  '"start":119',
+  '"end":125',
+  '"primary":true',
+]
+
+[[case]]
+name = "struct_literal_label_uses_value_span"
+description = "RUE-1640: the semantic struct-field mismatch keeps both the primary and explanatory label on the field value."
+files = [{ path = "main.rue", source = """
+struct Record { text: str }
+fn main() -> i32 {
+    let x: i32 = 1;
+    let r = Record { text: x };
+    0
+}
+""" }]
+args = ["--error-format", "json", "main.rue", "-o", "prog"]
+compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = ["error E0206 main.rue:4:28"]
+error_contains = [
+  '"message":"type mismatch: expected str, found i32"',
+  '''"spans":[{"column":28,"end":95,"file":"main.rue","label":null,"line":4,"primary":true,"start":94},{"column":28,"end":95,"file":"main.rue","label":"field 'text' expects type str","line":4,"primary":false,"start":94}]''',
+]
+
+[[case]]
 name = "successful_compile_warning_is_json"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {

--- a/crates/rue-cli-tests/cases/multifile_errors.toml
+++ b/crates/rue-cli-tests/cases/multifile_errors.toml
@@ -195,9 +195,9 @@ compile_stderr_not_contains = ["main.rue:"]
 name = "field_assign_span_in_second_file"
 description = """
 RUE-175: field-assignment shape. The E0206 for assigning a bool to an i64
-field in the imported (non-root) lib.rue must be attributed to lib.rue:4:5,
-never to the root file. (RUE-920 modernized this case from legacy positional
-inputs to @import.)
+field in the imported (non-root) lib.rue must be attributed to the RHS at
+lib.rue:4:11, never to the root file. (RUE-920 modernized this case from legacy
+positional inputs to @import; RUE-1640 narrowed it to the value expression.)
 """
 files = [
     { path = "main.rue", source = """
@@ -218,7 +218,7 @@ pub fn check() -> i32 {
 ]
 args = ["main.rue", "-o", "prog"]
 compile_fail = true
-error_contains = ["E0206", "lib.rue:4:5"]
+error_contains = ["E0206", "lib.rue:4:11"]
 compile_stderr_not_contains = ["main.rue:"]
 
 [[case]]

--- a/crates/rue-ui-tests/cases/diagnostics/error-spans.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/error-spans.toml
@@ -59,3 +59,34 @@ compile_fail = true
 # 3:14), not the whole `for` statement: the desugared @__rue_iter_len intrinsic
 # carries the iterable's span (rue-rir component review, 2026-07-04).
 error_contains = ["3:14", "expected an array or a StrBuf, found i32"]
+
+# Struct field mismatches use the value expression's span, including when the
+# value is a nested expression and the mismatching field is not first. This
+# keeps the primary diagnostic useful instead of pointing at the whole literal
+# (RUE-1640).
+[[case]]
+name = "struct_field_type_mismatch_points_at_value_expression"
+source = """
+struct Pair { left: i32, right: bool }
+fn id(n: i32) -> i32 { n }
+
+fn main() -> i32 {
+    let x: i32 = 1;
+    Pair { left: 1, right: id(x) }
+}
+"""
+compile_fail = true
+error_contains = ["6:28", "expected bool, found i32"]
+
+[[case]]
+name = "struct_field_sema_mismatch_label_points_at_value"
+source = """
+struct Record { text: str }
+fn main() -> i32 {
+    let x: i32 = 1;
+    let r = Record { text: x };
+    0
+}
+"""
+compile_fail = true
+error_contains = ["4:28", "field 'text' expects type str", "expected str, found i32"]


### PR DESCRIPTION
## Summary

- attribute struct-literal type mismatches and field labels to the field value expression
- attribute struct-init and field-assignment inference constraints to their RHS values
- pin unit, UI, text CLI, and JSON CLI diagnostic spans and preserve message direction and label ordering

## Validation

- scripts/rue fmt
- scripts/rue unit air provider_body_struct_field_mismatch_points_at_the_value
- scripts/rue ui diagnostics.error-spans
- scripts/rue cli diagnostic_json
- scripts/rue cli field_assign_span_in_second_file
- scripts/rue quick
- scripts/rue premerge (196 pass, 0 fail)

Fixes RUE-1640