### PR TITLE
RUE-1722: validate shared CLI shard timeout against maximum load

### DIFF
--- a/scripts/cli-timeout-policy.py
+++ b/scripts/cli-timeout-policy.py
@@ -32,6 +32,7 @@ POLICY_KEYS = {
     "minimum_monolith_timeout_ms",
     "minimum_slow_suite_timeout_ms",
 }
+SHARD_FAMILY_TARGET = "//:cli-tests-shard-*"
 
 
 def load_policy(path: Path) -> tuple[dict[str, dict[str, int]], dict[str, int]]:
@@ -143,6 +144,25 @@ def timeout_for_target(
     raise ValueError(f"no CLI timeout policy for target {target}")
 
 
+def timeout_for_shard_family(
+    loads: dict | None, platform_name: str, policy: dict[str, int]
+) -> tuple[int, int]:
+    """Derive the shared action bound for all CLI shards on one platform.
+
+    Buck gives every ``//:cli-tests-shard-*`` action the same timeout, so the
+    family bound must cover the most expensive shard rather than a particular
+    shard index.  Per-shard deadlines remain available through
+    :func:`timeout_for_target` for consumers that need them.
+    """
+    if loads is None:
+        raise ValueError(f"{SHARD_FAMILY_TARGET} requires --shard-loads")
+    expected = max(platform_loads(loads, platform_name))
+    return (
+        derive_timeout_ms(expected, policy["minimum_shard_timeout_ms"], policy),
+        expected,
+    )
+
+
 # RUE-1163: the corpus actions' outer bounds, as spelled in the root BUCK file.
 # A corpus runs as a build action now, which gets no test-executor timeout, so
 # `timeout_seconds` is the only thing that stops a wedged harness — and it must
@@ -151,7 +171,7 @@ def timeout_for_target(
 # bound while the policy allowed 3600s, so a healthy run could be killed.
 BUCK_TIMEOUT_PATTERNS = {
     "//:cli-tests": re.compile(r"^_CLI_TESTS_TIMEOUT_SECONDS = (\d+)$", re.MULTILINE),
-    "//:cli-tests-shard-0": re.compile(
+    SHARD_FAMILY_TARGET: re.compile(
         r"^_CLI_SHARD_TIMEOUT_SECONDS = (\d+)$", re.MULTILINE
     ),
     "//:cli-tests-slow": re.compile(
@@ -161,7 +181,7 @@ BUCK_TIMEOUT_PATTERNS = {
 
 
 def buck_timeouts(buck_path: Path) -> dict[str, int]:
-    """The action bounds the root BUCK file declares, keyed by target."""
+    """The root BUCK action bounds, keyed by target or shared shard family."""
     text = buck_path.read_text()
     found = {}
     for target, pattern in BUCK_TIMEOUT_PATTERNS.items():
@@ -177,22 +197,39 @@ def check_buck_timeouts(
 ) -> list[str]:
     """Report action bounds that cut inside the derived correctness deadline.
 
-    Every platform the shard-loads report models is checked, because the BUCK
-    value is one static number while the derived deadline is per-platform: a
-    bound that is generous on the fastest runner and short on the slowest is
-    still a bound that kills healthy runs.
+    Every modeled platform is checked, because the BUCK value is one static
+    number while the derived deadline is per-platform: a bound that is
+    generous on the fastest runner and short on the slowest is still a bound
+    that kills healthy runs.  The shared shard-family bound is compared with
+    the maximum shard load on each platform; the monolith keeps its true
+    whole-inventory calculation.
     """
     platforms = sorted(loads["platforms"])
     errors = []
     for target, declared_seconds in buck_timeouts(buck_path).items():
         for platform_name in platforms:
-            required_ms, _ = timeout_for_target(target, loads, platform_name, policy)
+            if target == SHARD_FAMILY_TARGET:
+                required_ms, expected_ms = timeout_for_shard_family(
+                    loads, platform_name, policy
+                )
+            else:
+                required_ms, expected_ms = timeout_for_target(
+                    target, loads, platform_name, policy
+                )
             required_seconds = math.ceil(required_ms / 1000)
             if declared_seconds < required_seconds:
+                if target == SHARD_FAMILY_TARGET:
+                    detail = (
+                        f"the shared CLI shard family (maximum shard load "
+                        f"{expected_ms}ms)"
+                    )
+                else:
+                    detail = target
                 errors.append(
-                    f"{target}: BUCK bounds the corpus action at {declared_seconds}s, "
-                    f"inside the {required_seconds}s correctness deadline the policy "
-                    f"derives for {platform_name}. A healthy run would be killed."
+                    f"{target}: BUCK bounds {detail} at {declared_seconds}s, "
+                    f"inside the {required_seconds}s correctness deadline the "
+                    f"policy derives for {platform_name}. A healthy run would "
+                    "be killed."
                 )
     return errors
 

--- a/scripts/test-cli-timeout-policy.py
+++ b/scripts/test-cli-timeout-policy.py
@@ -46,6 +46,26 @@ class TimeoutPolicyTests(unittest.TestCase):
         self.assertEqual(expected, 3000)
         self.assertEqual(timeout, 5000)
 
+    def test_shared_shard_family_uses_maximum_not_shard_zero(self):
+        loads = {
+            "version": 1,
+            "shard_count": 3,
+            "platforms": {"macos": {"loads_ms": [1000, 2000, 500]}},
+        }
+        policy = {
+            "expected_cost_multiplier_percent": 150,
+            "fixed_headroom_ms": 500,
+            "minimum_shard_timeout_ms": 1,
+        }
+        shard_timeout, shard_expected = MODULE.timeout_for_target(
+            "//:cli-tests-shard-0", loads, "macos", policy
+        )
+        family_timeout, family_expected = MODULE.timeout_for_shard_family(
+            loads, "macos", policy
+        )
+        self.assertEqual((shard_timeout, shard_expected), (2000, 1000))
+        self.assertEqual((family_timeout, family_expected), (3500, 2000))
+
     def test_unmodeled_platform_and_bad_shard_index_are_rejected(self):
         loads = {
             "version": 1,
@@ -169,11 +189,11 @@ class BuckActionBoundTests(unittest.TestCase):
         "platforms": {"linux-x64": {"loads_ms": [1000, 1000]}},
     }
 
-    def fixture(self, directory, cli_seconds):
+    def fixture(self, directory, cli_seconds, shard_seconds=9999):
         buck = Path(directory) / "BUCK"
         buck.write_text(
             f"_CLI_TESTS_TIMEOUT_SECONDS = {cli_seconds}\n"
-            "_CLI_SHARD_TIMEOUT_SECONDS = 9999\n"
+            f"_CLI_SHARD_TIMEOUT_SECONDS = {shard_seconds}\n"
             'cached_corpus_suite(\n    name = "cli-tests-slow",\n'
             "    timeout_seconds = 9999,\n)\n"
         )
@@ -193,6 +213,38 @@ class BuckActionBoundTests(unittest.TestCase):
             self.assertEqual(len(errors), 1, errors)
             self.assertIn("//:cli-tests", errors[0])
             self.assertIn("A healthy run would be killed", errors[0])
+
+    def test_shared_shard_bound_checks_the_true_maximum_not_shard_zero(self):
+        loads = {
+            "version": 1,
+            "shard_count": 2,
+            "platforms": {"linux-x64": {"loads_ms": [1000, 3000]}},
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            # Two seconds is above shard 0's one-second derived deadline, but
+            # below the three-second deadline required by the family maximum.
+            buck = self.fixture(directory, 9999, shard_seconds=2)
+            errors = MODULE.check_buck_timeouts(buck, loads, self.POLICY)
+            self.assertEqual(len(errors), 1, errors)
+            self.assertIn(MODULE.SHARD_FAMILY_TARGET, errors[0])
+            self.assertIn("shared CLI shard family", errors[0])
+            self.assertIn("maximum shard load 3000ms", errors[0])
+
+    def test_shared_shard_bound_is_checked_against_each_platform_maximum(self):
+        loads = {
+            "version": 1,
+            "shard_count": 2,
+            "platforms": {
+                "linux-x64": {"loads_ms": [1000, 1000]},
+                "macos": {"loads_ms": [1000, 3000]},
+            },
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            buck = self.fixture(directory, 9999, shard_seconds=2)
+            errors = MODULE.check_buck_timeouts(buck, loads, self.POLICY)
+            self.assertEqual(len(errors), 1, errors)
+            self.assertIn("macos", errors[0])
+            self.assertIn("maximum shard load 3000ms", errors[0])
 
     def test_missing_bound_is_an_error_not_a_silent_pass(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
Summary:
- model the BUCK shard timeout as one shared CLI shard-family bound
- derive that bound from each platform's maximum reported shard load
- cover non-maximal shard zero and platform-specific maxima in tool tests

Validation:
- scripts/rue fmt
- python3 scripts/test-cli-timeout-policy.py
- scripts/validate-python-baseline.py
- ./buck2 test //:cli-timeout-policy-tool-tests //:cli-timeout-policy-validation //:python-baseline-tool-tests
- scripts/rue quick
- scripts/rue premerge

Fixes RUE-1722