### PR TITLE
RUE-1701: suppress SIGPIPE for TcpStream socket writes

### DIFF
--- a/crates/rue-cli-tests/cases/std_net_tcp.toml
+++ b/crates/rue-cli-tests/cases/std_net_tcp.toml
@@ -110,6 +110,167 @@ fn main() -> i32 {
 """ }]
 stdout = "1\n2\n104\n105\n33\n3\n111\n4\n"
 
+# Socket sends use sendto(MSG_NOSIGNAL), so a closed peer reports EPIPE as
+# NetworkError.ConnectionReset instead of terminating the process with SIGPIPE.
+# Each method gets an independent connection and must return the error twice:
+# a raw write can first observe ECONNRESET without a signal, but its next call
+# reaches EPIPE and would kill the process if that method lacked MSG_NOSIGNAL.
+[[case]]
+name = "tcp_write_after_peer_close_is_connection_reset"
+description = "independent bounded write/write_all retries after peer EOF return ConnectionReset rather than SIGPIPE."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+only_on = ["x86-64-linux", "aarch64-linux"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn fail(code: i32) -> i32 {
+    @dbg(code);
+    1
+}
+
+fn main() -> i32 {
+    let RL = std.result.Result(std.net.TcpListener, std.net.NetworkError);
+    let RS = std.result.Result(std.net.TcpStream, std.net.NetworkError);
+    let RA = std.result.Result(std.net.SockAddr, std.net.NetworkError);
+    let RU = std.result.Result(u64, std.net.NetworkError);
+    let RUnit = std.result.Result((), std.net.NetworkError);
+
+    // Keep one live listener and learn its kernel-selected port before connect.
+    let mut listener = match std.net.TcpListener.bind(
+        std.net.SockAddr.v4(std.net.Ipv4Addr.localhost(), 0)
+    ) {
+        RL.Ok(l) => l,
+        RL.Err(e) => { return fail(101); },
+    };
+    let port: u16 = match listener.local_addr() {
+        RA.Ok(a) => a.port,
+        RA.Err(e) => { return fail(102); },
+    };
+    let mut payload = std.arraybuf.ArrayBuf(u8).new();
+    payload.push(170);
+
+    // First connection: successful one-byte write is the positive control for
+    // `write` itself, then two post-close errors prove its EPIPE call is safe.
+    let mut client1 = match std.net.TcpStream.connect(
+        std.net.SockAddr.v4(std.net.Ipv4Addr.localhost(), port)
+    ) {
+        RS.Ok(s) => s,
+        RS.Err(e) => { return fail(103); },
+    };
+    let mut server1 = match listener.accept() {
+        RS.Ok(s) => s,
+        RS.Err(e) => { return fail(104); },
+    };
+    match client1.write(borrow payload) {
+        RU.Ok(n) => { if n == 1 { @dbg(1); } else { return fail(105); } },
+        RU.Err(e) => { return fail(106); },
+    }
+    let mut received = std.arraybuf.ArrayBuf(u8).with_capacity(1);
+    match server1.read(inout received) {
+        RU.Ok(n) => {
+            if n == 1 && received.get_or(0, 0) == 170 {
+                @dbg(2);
+            } else {
+                return fail(107);
+            }
+        },
+        RU.Err(e) => { return fail(108); },
+    }
+
+    // Close the accepted peer cleanly, then require the client to observe EOF
+    // before attempting sends. This removes the FIN/RST timing race from the
+    // write assertions while retaining the connected client descriptor.
+    match server1.shutdown(std.net.Shutdown.Both) {
+        RUnit.Ok(u) => {},
+        RUnit.Err(e) => { return fail(109); },
+    }
+    match server1.close() {
+        RUnit.Ok(u) => {},
+        RUnit.Err(e) => { return fail(110); },
+    }
+    let mut eof1 = std.arraybuf.ArrayBuf(u8).with_capacity(1);
+    match client1.read(inout eof1) {
+        RU.Ok(n) => { if n == 0 { @dbg(3); } else { return fail(111); } },
+        RU.Err(e) => { return fail(112); },
+    }
+
+    // Linux may accept an initial post-FIN send or report ECONNRESET before
+    // EPIPE. Requiring two error returns ensures this method reaches a send
+    // that would raise SIGPIPE without MSG_NOSIGNAL, while remaining bounded.
+    let mut write_resets: u64 = 0;
+    let mut write_attempts: u64 = 0;
+    while write_attempts < 8 {
+        if write_resets == 2 { break; }
+        match client1.write(borrow payload) {
+            RU.Ok(n) => {},
+            RU.Err(e) => {
+                match e {
+                    std.net.NetworkError.ConnectionReset => {
+                        write_resets += 1;
+                    },
+                    _ => { return fail(113); },
+                }
+            },
+        }
+        write_attempts = write_attempts + 1;
+    }
+    if write_resets != 2 { return fail(114); }
+    @dbg(4);
+    match client1.close() { RUnit.Ok(u) => {}, RUnit.Err(e) => { return fail(115); } }
+
+    // Second independent connection gives `write_all` the same proof instead
+    // of relying on `write` to advance the first connection to EPIPE.
+    let mut client2 = match std.net.TcpStream.connect(
+        std.net.SockAddr.v4(std.net.Ipv4Addr.localhost(), port)
+    ) {
+        RS.Ok(s) => s,
+        RS.Err(e) => { return fail(116); },
+    };
+    let mut server2 = match listener.accept() {
+        RS.Ok(s) => s,
+        RS.Err(e) => { return fail(117); },
+    };
+    match server2.shutdown(std.net.Shutdown.Both) {
+        RUnit.Ok(u) => {},
+        RUnit.Err(e) => { return fail(118); },
+    }
+    match server2.close() {
+        RUnit.Ok(u) => {},
+        RUnit.Err(e) => { return fail(119); },
+    }
+    let mut eof2 = std.arraybuf.ArrayBuf(u8).with_capacity(1);
+    match client2.read(inout eof2) {
+        RU.Ok(n) => { if n == 0 { @dbg(5); } else { return fail(120); } },
+        RU.Err(e) => { return fail(121); },
+    }
+
+    let mut write_all_resets: u64 = 0;
+    let mut all_attempts: u64 = 0;
+    while all_attempts < 8 {
+        if write_all_resets == 2 { break; }
+        match client2.write_all(borrow payload) {
+            RUnit.Ok(u) => {},
+            RUnit.Err(e) => {
+                match e {
+                    std.net.NetworkError.ConnectionReset => {
+                        write_all_resets += 1;
+                    },
+                    _ => { return fail(122); },
+                }
+            },
+        }
+        all_attempts = all_attempts + 1;
+    }
+    if write_all_resets != 2 { return fail(123); }
+    @dbg(6);
+    match client2.close() { RUnit.Ok(u) => {}, RUnit.Err(e) => { return fail(124); } }
+    match listener.close() { RUnit.Ok(u) => {}, RUnit.Err(e) => { return fail(125); } }
+    0
+}
+""" }]
+stdout = "1\n2\n3\n4\n5\n6\n"
+
 # Connecting to a just-released ephemeral port is refused, exercising errno
 # normalization (ECONNREFUSED -> ConnectionRefused) through a real syscall.
 [[case]]

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -597,6 +597,12 @@ const ENTRIES: &[Entry] = &[
         &["aarch64-linux", "x86-64-linux"],
     ),
     Entry::new(
+        "cli.std_net_tcp",
+        "tcp_write_after_peer_close_is_connection_reset",
+        external(ExternalDependencyKind::SystemCall),
+        &["aarch64-linux", "x86-64-linux"],
+    ),
+    Entry::new(
         "cli.std_strbuf",
         "mem_swap_exchanges_move_only_strbufs",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),

--- a/docs/designs/0060-network-io-v1.md
+++ b/docs/designs/0060-network-io-v1.md
@@ -9,7 +9,7 @@ accepted: 2026-07-17
 implemented:
 spec-sections: []
 superseded-by:
-relates: ["RUE-713", "RUE-970", "RUE-982", "RUE-983", "RUE-984", "RUE-985", "RUE-986", "ADR-0034", "ADR-0057", "ADR-0059"]
+relates: ["RUE-713", "RUE-970", "RUE-982", "RUE-983", "RUE-984", "RUE-985", "RUE-986", "RUE-1701", "ADR-0034", "ADR-0057", "ADR-0059"]
 ---
 
 # ADR-0060: Network IO v1 — blocking IPv4 TCP in pure Rue
@@ -193,6 +193,9 @@ enum NetworkError {
 This list is an ADR-level contract, not a demand for speculative errno coverage:
 implementation should map useful, stable logical cases and route all remaining
 errors to `Other(i64)`. Raw errno values do not become the public matching API.
+For Linux socket sends, `sendto(2)` uses `MSG_NOSIGNAL` so a broken peer is
+reported to Rue instead of terminating the process with `SIGPIPE`; both
+`ECONNRESET` and `EPIPE` map to `ConnectionReset`.
 `WouldBlock` remains available for unusual kernel/configuration behavior and
 future evolution even though v1 itself creates blocking sockets.
 

--- a/docs/spec/src/08-runtime-behavior/05-signal-termination.md
+++ b/docs/spec/src/08-runtime-behavior/05-signal-termination.md
@@ -49,16 +49,24 @@ system and its shell.
 
 {{ rule(id="8.5:3", cat="informative") }}
 
-A Rue program whose standard output (or any output stream it writes to) is a
-pipe or socket **whose reading end has been closed** is terminated by `SIGPIPE`
-on its next write to that stream, exiting with status `141` (that is,
-`128 + SIGPIPE`, where `SIGPIPE` is `13` on Linux and macOS). This is Rue's
-defined default: it matches the standard Unix behavior for programs in a
-pipeline (such as `rue_program | head`), so a downstream reader that stops
-consuming input promptly and cleanly ends the producer. The runtime's write path
-does **not** intercept this case — the signal is delivered before the failing
+A Rue program whose standard output (or another stream written without
+per-operation signal suppression) is a pipe or socket **whose reading end has
+been closed** is terminated by `SIGPIPE` on its next failing write to that
+stream, exiting with status `141` (that is, `128 + SIGPIPE`, where `SIGPIPE` is
+`13` on Linux and macOS). This is Rue's defined default: it matches the standard
+Unix behavior for programs in a pipeline (such as `rue_program | head`), so a
+downstream reader that stops consuming input promptly and cleanly ends the
+producer. The runtime's standard-output and standard-error write paths do
+**not** intercept this case — the signal is delivered before the failing
 `write` syscall returns, so the write's error result is never observed (see the
 `write_stderr`/`write_stdout` documentation in `rue-runtime`).
+
+Linux `std.net.TcpStream.write` and `write_all` are a socket-scoped exception:
+each send uses `MSG_NOSIGNAL`, so a closed peer returns
+`NetworkError.ConnectionReset` (from `EPIPE` or `ECONNRESET`) instead of
+terminating the process. This per-send flag does not change the process signal
+disposition and therefore does not affect standard output, standard error, or
+raw `@syscall` writes.
 
 {{ rule(id="8.5:4", cat="informative") }}
 
@@ -70,8 +78,9 @@ about to exit regardless.
 
 {{ rule(id="8.5:5") }}
 
-Making the `SIGPIPE` response configurable (an analogue of Rust's
-`-Zon-broken-pipe`, e.g. resetting the disposition so writes observe `EPIPE`
-instead of dying) is a separate, future feature and is intentionally out of
-scope here; the default described above is the only behavior Rue currently
-provides.
+Making the process-wide `SIGPIPE` response configurable (an analogue of Rust's
+`-Zon-broken-pipe`, e.g. resetting the disposition so ordinary writes observe
+`EPIPE` instead of dying) is a separate, future feature and is intentionally out
+of scope here. The default disposition described above remains the only
+process-wide behavior Rue provides; `std.net`'s per-send socket flag does not
+configure or alter it.

--- a/std/net.rue
+++ b/std/net.rue
@@ -152,7 +152,7 @@ pub enum NetworkError {
     AddressInUse,         // EADDRINUSE
     AddressNotAvailable,  // EADDRNOTAVAIL
     ConnectionRefused,    // ECONNREFUSED
-    ConnectionReset,      // ECONNRESET
+    ConnectionReset,      // ECONNRESET, EPIPE (peer closed its receive side)
     ConnectionAborted,    // ECONNABORTED
     NotConnected,         // ENOTCONN
     TimedOut,             // ETIMEDOUT
@@ -240,12 +240,17 @@ fn _sys_net_read() -> u64 {
     }
 }
 
-fn _sys_net_write() -> u64 {
+// Linux `sendto(2)` with MSG_NOSIGNAL is the socket-specific write path. The
+// null destination and zero address length use the already-connected peer;
+// unlike `write(2)`, MSG_NOSIGNAL suppresses SIGPIPE for these sends only.
+fn _sys_net_sendto() -> u64 {
     match @target_arch() {
-        Arch.X86_64 => 1,
-        Arch.Aarch64 => 64,
+        Arch.X86_64 => 44,
+        Arch.Aarch64 => 206,
     }
 }
+
+fn _msg_nosignal() -> u64 { 0x4000 }
 
 fn _sys_net_close() -> u64 {
     match @target_arch() {
@@ -262,7 +267,7 @@ fn _default_backlog() -> u64 { 128 }
 // same on x86-64 and aarch64).
 fn _normalize_net_errno(e: i64) -> NetworkError {
     // EPERM=1 EINTR=4 EBADF=9 EAGAIN=11 EACCES=13 EINVAL=22 EADDRINUSE=98
-    // EADDRNOTAVAIL=99 ECONNABORTED=103 ECONNRESET=104 ENOTCONN=107
+    // EADDRNOTAVAIL=99 ECONNABORTED=103 ECONNRESET=104 EPIPE=32 ENOTCONN=107
     // ETIMEDOUT=110 ECONNREFUSED=111
     if e == 1 {
         NetworkError.PermissionDenied
@@ -275,6 +280,8 @@ fn _normalize_net_errno(e: i64) -> NetworkError {
     } else if e == 111 {
         NetworkError.ConnectionRefused
     } else if e == 104 {
+        NetworkError.ConnectionReset
+    } else if e == 32 {
         NetworkError.ConnectionReset
     } else if e == 103 {
         NetworkError.ConnectionAborted
@@ -400,9 +407,11 @@ pub struct TcpStream {
         R.Ok(n)
     }
 
-    // Send the bytes of `buf` in a single write(2); may send fewer than
-    // `buf.len()` (the count is returned). Use `write_all` for the
-    // whole-buffer guarantee.
+    // Send the bytes of `buf` in a single `sendto(2)` with MSG_NOSIGNAL;
+    // the null destination uses the connected peer and suppresses SIGPIPE
+    // for this socket send. It may send fewer than `buf.len()` (the count is
+    // returned). Use `write_all` for the whole-buffer guarantee. Linux EPIPE
+    // is normalized to ConnectionReset, like ECONNRESET.
     fn write(inout self, borrow buf: arraybuf.ArrayBuf(u8)) -> result.Result(u64, NetworkError) {
         let R = result.Result(u64, NetworkError);
         let n = buf.len();
@@ -420,7 +429,9 @@ pub struct TcpStream {
         }
         let addr: u64 = checked { @ptr_to_int(tmp) };
         let fd_u: u64 = @intCast(self.fd);
-        let ret: i64 = checked { @syscall(_sys_net_write(), fd_u, addr, n) };
+        let ret: i64 = checked {
+            @syscall(_sys_net_sendto(), fd_u, addr, n, _msg_nosignal(), 0, 0)
+        };
         checked { @free(tmp, n, 1); };
         if ret < 0 {
             R.Err(_normalize_net_errno(0 - ret))
@@ -449,7 +460,9 @@ pub struct TcpStream {
         let fd_u: u64 = @intCast(self.fd);
         let mut off: u64 = 0;
         while off < n {
-            let ret: i64 = checked { @syscall(_sys_net_write(), fd_u, base + off, n - off) };
+            let ret: i64 = checked {
+                @syscall(_sys_net_sendto(), fd_u, base + off, n - off, _msg_nosignal(), 0, 0)
+            };
             if ret < 0 {
                 let e = _normalize_net_errno(0 - ret);
                 let retry = match e {


### PR DESCRIPTION
## Summary
- route Linux `TcpStream.write` and `write_all` through `sendto(MSG_NOSIGNAL)` on x86-64 and AArch64
- normalize `EPIPE` to `NetworkError.ConnectionReset` without changing process-wide SIGPIPE behavior
- add bounded independent peer-close regressions for both write methods, including a successful-write control
- clarify the ADR and signal-termination specification for the socket-scoped exception

## Validation
- `scripts/rue fmt`
- `scripts/rue cli std_net_tcp`
- exact regression source cross-compiled for `x86-64-linux` and `aarch64-linux`
- `scripts/rue quick` (31 targets passed)
- `scripts/rue premerge` (196 targets passed)
- separate adversarial review completed with no remaining material findings

Fixes RUE-1701