### PR TITLE
RUE-1721: keep filtered tests on the unit tier

### DIFF
--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -450,6 +450,33 @@ test_testsh_cli_examples_survive_case_chdir() {
   rm -rf "$sb"
 }
 
+# A filtered test.sh run keeps the ordinary crate-unit coverage that quick-test
+# uses, but must not pull in the slow/heavy oracle corpora or the opt-in stress
+# ladder. Assert the complete Buck invocation, including its real //crates/...
+# selection, so an exclusions-only change cannot pass while running zero units.
+test_testsh_filtered_unit_selection_matches_quick_policy() {
+  local sb; sb="$(mktemp -d)"
+  cp "$SRC_ROOT/test.sh" "$sb/test.sh"; chmod +x "$sb/test.sh"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$FAKE_CALL_LOG"
+exit 0
+EOF
+  chmod +x "$sb/buck2"
+
+  local rc=0
+  (cd "$sb" && FAKE_CALL_LOG="$sb/calls.log" ./test.sh 'parser::tests::case' \
+    >/dev/null 2>&1) || rc=$?
+  check "test.sh: filtered run succeeds with the fake Buck" \
+    "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
+  check "test.sh: filtered unit step retains the crate-wide selection" \
+    "$([ "$(grep -c '^test //crates/...' "$sb/calls.log" 2>/dev/null)" -eq 1 ] && echo 0 || echo 1)"
+  check "test.sh: filtered unit step matches the canonical quick policy" \
+    "$(grep -Fxq 'test //crates/... --include rue_test_tier_premerge --exclude rue_not_quick --exclude rue_dedicated_suite --always-exclude --ignore-tests-attribute' \
+      "$sb/calls.log" && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
 # ===========================================================================
 # RUE-590 — the sanitizer gives repository examples the bundled std library
 # ===========================================================================
@@ -1477,6 +1504,7 @@ test_clippy_gate_reads_diagnostics_and_fails_closed
 test_rue_named_test_tiers_delegate_to_testsh
 test_rue_quick_delegates_to_quick_testsh
 test_testsh_cli_examples_survive_case_chdir
+test_testsh_filtered_unit_selection_matches_quick_policy
 test_rue_unit_maps_crate_and_forwards_args
 test_rue_unit_zero_match_fails_loud
 test_rue_unit_failing_test_propagates_exit

--- a/test.sh
+++ b/test.sh
@@ -19,7 +19,9 @@ set -euo pipefail
 # silently omitted. (RUE-132, RUE-144)
 #
 # With a pattern argument, the spec/UI/CLI suites are instead run directly
-# with the filter (unit tests still run in full, as before).
+# with the filter. The crate-unit step uses the same premerge-only selection as
+# quick-test.sh, so filtered runs retain ordinary unit coverage without pulling
+# in slow corpora or opt-in stress suites.
 #
 # READING THE RESULT (RUE-579). This script's EXIT CODE is authoritative:
 # `buck2 test` returns non-zero when any target fails and `set -e` propagates
@@ -189,9 +191,17 @@ if [[ $# -eq 0 ]]; then
     ./buck2 test "${test_args[@]}"
 else
     # Unit tests live under //crates/...; the suite sh_tests are at the repo
-    # root, so this scope keeps them out of the unfiltered step below.
+    # root, so this scope keeps them out of the filtered unit step below. Keep
+    # this selector in lockstep with quick-test.sh: the premerge label retains
+    # ordinary crate units while excluding the slow and stress tiers, and the
+    # quick-policy exclusions omit not-quick tooling and dedicated suites.
     echo "Running unit tests..."
-    ./buck2 test //crates/...
+    ./buck2 test //crates/... \
+        --include rue_test_tier_premerge \
+        --exclude rue_not_quick \
+        --exclude rue_dedicated_suite \
+        --always-exclude \
+        --ignore-tests-attribute
 
     # RUE-1163: each harness has a command_alias carrying the corpus's declared
     # inputs, so a filtered run plumbs no environment by hand. The previous


### PR DESCRIPTION
## Summary

- apply the canonical quick crate-unit Buck policy to filtered test.sh runs
- keep ordinary crate unit coverage while excluding slow oracle corpora and opt-in stress targets
- add a hermetic wrapper regression that pins the generated Buck invocation and non-vacuous crate selection

## Validation

- ./buck2 test //:wrapper-script-tests (156 checks)
- scripts/rue quick (31 targets)
- scripts/rue fmt
- scripts/rue premerge (196 targets)
- /bin/bash -n test.sh scripts/test-wrapper-scripts.sh
- git diff --check

Fixes RUE-1721