### PR TITLE
RUE-1751: centralize integer semantics

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -14,6 +14,25 @@ fn peer_one_body_authority_cannot_return() {
 }
 
 #[test]
+fn integer_consumers_use_one_representation_independent_kernel() {
+    let semantics = include_str!("integer_semantics.rs");
+    let types = include_str!("types.rs");
+    let comptime = include_str!("sema/comptime_eval.rs");
+
+    assert!(types.contains("pub fn integer_semantics(&self) -> Option<IntegerType>"));
+    assert!(comptime.contains("integer.shift_i128"));
+    assert!(comptime.contains("integer_semantics()"));
+    assert!(!comptime.contains("fn truncate_to_type("));
+    assert!(semantics.contains("pub struct IntegerType"));
+    assert!(semantics.contains("pub fn checked_div_i128"));
+    assert!(semantics.contains("pub fn checked_rem_i128"));
+    assert!(semantics.contains("pub struct CheckedIntegerResult"));
+    assert!(semantics.contains("pub fn checked_add_report_i128"));
+    assert!(semantics.contains("pub fn checked_neg_literal_i128"));
+    assert!(comptime.contains("checked_neg_literal_report_i128"));
+}
+
+#[test]
 fn type_syntax_dependency_admission_indexes_only_the_large_case() {
     let typeck = include_str!("sema/typeck.rs");
 

--- a/crates/rue-air/src/integer_semantics.rs
+++ b/crates/rue-air/src/integer_semantics.rs
@@ -1,0 +1,448 @@
+//! The language-level semantics of Rue's fixed-width integer types.
+//!
+//! This module deliberately knows nothing about [`Type`] or any IR.  It is the
+//! one place where width, signedness, canonical representation, and the
+//! checked/wrapping arithmetic rules are defined.  AIR, CFG folding, and
+//! machine-code planning are adapters over this value-independent kernel.
+
+use std::cmp::Ordering;
+
+/// The raw mathematical result and the result accepted by a fixed-width
+/// integer operation.  `raw` remains available when it is outside the target
+/// type, so diagnostics can explain the value that overflowed; `checked` is
+/// the authoritative typed result consumed by evaluators and adapters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CheckedIntegerResult {
+    raw: Option<i128>,
+    checked: Option<i128>,
+}
+
+impl CheckedIntegerResult {
+    pub const fn raw(self) -> Option<i128> {
+        self.raw
+    }
+
+    pub const fn checked(self) -> Option<i128> {
+        self.checked
+    }
+
+    pub const fn from_raw(raw: Option<i128>) -> Self {
+        Self { raw, checked: raw }
+    }
+}
+
+/// A compact description of one of Rue's eight integer types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct IntegerType {
+    bits: u8,
+    signed: bool,
+}
+
+impl IntegerType {
+    /// Construct an integer description.  Only the language's supported
+    /// widths are accepted.
+    pub const fn new(bits: u8, signed: bool) -> Option<Self> {
+        match bits {
+            8 | 16 | 32 | 64 => Some(Self { bits, signed }),
+            _ => None,
+        }
+    }
+
+    pub const fn bits(self) -> u32 {
+        self.bits as u32
+    }
+
+    pub const fn is_signed(self) -> bool {
+        self.signed
+    }
+
+    pub const fn is_unsigned(self) -> bool {
+        !self.signed
+    }
+
+    pub const fn min_i128(self) -> i128 {
+        if self.signed {
+            -(1_i128 << (self.bits - 1))
+        } else {
+            0
+        }
+    }
+
+    pub const fn max_i128(self) -> i128 {
+        if self.signed {
+            (1_i128 << (self.bits - 1)) - 1
+        } else {
+            (1_i128 << self.bits) - 1
+        }
+    }
+
+    pub const fn mask_u128(self) -> u128 {
+        (1_u128 << self.bits) - 1
+    }
+
+    /// Return whether a mathematical integer is representable in this type.
+    pub fn fits_i128(self, value: i128) -> bool {
+        (self.min_i128()..=self.max_i128()).contains(&value)
+    }
+
+    /// Canonicalize a mathematical integer to the signed/unsigned value
+    /// represented by this type.
+    pub fn canonicalize_i128(self, value: i128) -> i128 {
+        let masked = (value as u128 & self.mask_u128()) as i128;
+        if self.signed && masked >= (1_i128 << (self.bits - 1)) {
+            masked - (1_i128 << self.bits)
+        } else {
+            masked
+        }
+    }
+
+    /// Keep only the low bits of a register image.
+    pub fn mask_u64(self, value: u64) -> u64 {
+        value & self.mask_u128() as u64
+    }
+
+    /// Convert a register image to Rue's canonical 64-bit representation.
+    pub fn canonicalize_u64(self, value: u64) -> u64 {
+        self.canonicalize_i128(value as i128) as u64
+    }
+
+    pub fn sign_extend_u64(self, value: u64) -> u64 {
+        self.canonicalize_u64(value)
+    }
+
+    /// Rue masks shift amounts by the operand width minus one.
+    pub const fn shift_count_mask(self) -> u64 {
+        self.bits as u64 - 1
+    }
+
+    pub fn shift_count_i128(self, value: i128) -> u32 {
+        (value as u128 & u128::from(self.shift_count_mask())) as u32
+    }
+
+    pub fn shift_count_u64(self, value: u64) -> u32 {
+        (value & self.shift_count_mask()) as u32
+    }
+
+    pub fn checked_add_i128(self, lhs: i128, rhs: i128) -> Option<i128> {
+        self.checked_add_report_i128(lhs, rhs).checked()
+    }
+
+    pub fn checked_add_report_i128(self, lhs: i128, rhs: i128) -> CheckedIntegerResult {
+        self.checked_binary_report_i128(lhs, rhs, i128::checked_add)
+    }
+
+    pub fn checked_sub_i128(self, lhs: i128, rhs: i128) -> Option<i128> {
+        self.checked_sub_report_i128(lhs, rhs).checked()
+    }
+
+    pub fn checked_sub_report_i128(self, lhs: i128, rhs: i128) -> CheckedIntegerResult {
+        self.checked_binary_report_i128(lhs, rhs, i128::checked_sub)
+    }
+
+    pub fn checked_mul_i128(self, lhs: i128, rhs: i128) -> Option<i128> {
+        self.checked_mul_report_i128(lhs, rhs).checked()
+    }
+
+    pub fn checked_mul_report_i128(self, lhs: i128, rhs: i128) -> CheckedIntegerResult {
+        self.checked_binary_report_i128(lhs, rhs, i128::checked_mul)
+    }
+
+    pub fn checked_div_i128(self, lhs: i128, rhs: i128) -> Option<i128> {
+        self.checked_div_report_i128(lhs, rhs).checked()
+    }
+
+    pub fn checked_div_report_i128(self, lhs: i128, rhs: i128) -> CheckedIntegerResult {
+        let lhs = self.canonicalize_i128(lhs);
+        let rhs = self.canonicalize_i128(rhs);
+        if self.is_signed() && lhs == self.min_i128() && rhs == -1 {
+            return CheckedIntegerResult::from_raw(None);
+        }
+        self.checked_binary_report_i128(lhs, rhs, i128::checked_div)
+    }
+
+    pub fn checked_rem_i128(self, lhs: i128, rhs: i128) -> Option<i128> {
+        self.checked_rem_report_i128(lhs, rhs).checked()
+    }
+
+    pub fn checked_rem_report_i128(self, lhs: i128, rhs: i128) -> CheckedIntegerResult {
+        let lhs = self.canonicalize_i128(lhs);
+        let rhs = self.canonicalize_i128(rhs);
+        let report = self.checked_binary_report_i128(lhs, rhs, i128::checked_rem);
+        if self.is_signed() && lhs == self.min_i128() && rhs == -1 {
+            CheckedIntegerResult::from_raw(None)
+        } else {
+            report
+        }
+    }
+
+    pub fn checked_neg_i128(self, value: i128) -> Option<i128> {
+        self.checked_neg_report_i128(value).checked()
+    }
+
+    pub fn checked_neg_report_i128(self, value: i128) -> CheckedIntegerResult {
+        let value = self.canonicalize_i128(value);
+        if self.is_unsigned() {
+            let raw = (value == 0).then_some(0);
+            CheckedIntegerResult::from_raw(raw)
+        } else {
+            self.report_raw(value.checked_neg())
+        }
+    }
+
+    /// Negate an integer literal's mathematical magnitude.  Literal syntax
+    /// deliberately keeps the magnitude outside the target type's positive
+    /// range so that `-128` can inhabit `i8`; unlike a runtime value, it must
+    /// not be canonicalized before the checked operation.
+    pub fn checked_neg_literal_i128(self, magnitude: i128) -> Option<i128> {
+        self.checked_neg_literal_report_i128(magnitude).checked()
+    }
+
+    pub fn checked_neg_literal_report_i128(self, magnitude: i128) -> CheckedIntegerResult {
+        if self.is_unsigned() || magnitude < 0 {
+            return CheckedIntegerResult::from_raw(None);
+        }
+        self.report_raw(magnitude.checked_neg())
+    }
+
+    pub fn wrapping_add_i128(self, lhs: i128, rhs: i128) -> i128 {
+        self.canonicalize_i128(lhs.wrapping_add(rhs))
+    }
+
+    pub fn wrapping_sub_i128(self, lhs: i128, rhs: i128) -> i128 {
+        self.canonicalize_i128(lhs.wrapping_sub(rhs))
+    }
+
+    pub fn wrapping_mul_i128(self, lhs: i128, rhs: i128) -> i128 {
+        self.canonicalize_i128(lhs.wrapping_mul(rhs))
+    }
+
+    pub fn shift_i128(self, value: i128, amount: i128, left: bool) -> i128 {
+        let amount = self.shift_count_i128(amount);
+        let value = self.canonicalize_i128(value);
+        let shifted = if left {
+            value.wrapping_shl(amount)
+        } else {
+            value >> amount
+        };
+        self.canonicalize_i128(shifted)
+    }
+
+    pub fn bitnot_i128(self, value: i128) -> i128 {
+        self.canonicalize_i128(!value)
+    }
+
+    pub fn compare_i128(self, lhs: i128, rhs: i128) -> Ordering {
+        self.canonicalize_i128(lhs)
+            .cmp(&self.canonicalize_i128(rhs))
+    }
+
+    pub fn checked_add_u64(self, lhs: u64, rhs: u64) -> Option<u64> {
+        self.map_u64(self.checked_add_i128(self.to_i128(lhs), self.to_i128(rhs))?)
+    }
+
+    pub fn checked_sub_u64(self, lhs: u64, rhs: u64) -> Option<u64> {
+        self.map_u64(self.checked_sub_i128(self.to_i128(lhs), self.to_i128(rhs))?)
+    }
+
+    pub fn checked_mul_u64(self, lhs: u64, rhs: u64) -> Option<u64> {
+        self.map_u64(self.checked_mul_i128(self.to_i128(lhs), self.to_i128(rhs))?)
+    }
+
+    pub fn checked_div_u64(self, lhs: u64, rhs: u64) -> Option<u64> {
+        self.map_u64(self.checked_div_i128(self.to_i128(lhs), self.to_i128(rhs))?)
+    }
+
+    pub fn checked_rem_u64(self, lhs: u64, rhs: u64) -> Option<u64> {
+        self.map_u64(self.checked_rem_i128(self.to_i128(lhs), self.to_i128(rhs))?)
+    }
+
+    pub fn checked_neg_u64(self, value: u64) -> Option<u64> {
+        self.map_u64(self.checked_neg_i128(self.to_i128(value))?)
+    }
+
+    pub fn wrapping_add_u64(self, lhs: u64, rhs: u64) -> u64 {
+        self.canonicalize_u64(lhs.wrapping_add(rhs))
+    }
+
+    pub fn wrapping_sub_u64(self, lhs: u64, rhs: u64) -> u64 {
+        self.canonicalize_u64(lhs.wrapping_sub(rhs))
+    }
+
+    pub fn wrapping_mul_u64(self, lhs: u64, rhs: u64) -> u64 {
+        self.canonicalize_u64(lhs.wrapping_mul(rhs))
+    }
+
+    pub fn shift_u64(self, value: u64, amount: u64, left: bool) -> u64 {
+        self.shift_i128(self.to_i128(value), amount as i128, left) as u64
+    }
+
+    pub fn bitnot_u64(self, value: u64) -> u64 {
+        self.canonicalize_u64(!value)
+    }
+
+    pub fn compare_u64(self, lhs: u64, rhs: u64) -> Ordering {
+        self.to_i128(lhs).cmp(&self.to_i128(rhs))
+    }
+
+    fn checked_binary_report_i128(
+        self,
+        lhs: i128,
+        rhs: i128,
+        op: impl FnOnce(i128, i128) -> Option<i128>,
+    ) -> CheckedIntegerResult {
+        self.report_raw(op(self.canonicalize_i128(lhs), self.canonicalize_i128(rhs)))
+    }
+
+    fn report_raw(self, raw: Option<i128>) -> CheckedIntegerResult {
+        CheckedIntegerResult {
+            raw,
+            checked: raw.filter(|&result| self.fits_i128(result)),
+        }
+    }
+
+    fn to_i128(self, value: u64) -> i128 {
+        if self.signed {
+            self.canonicalize_u64(value) as i64 as i128
+        } else {
+            self.mask_u64(value) as i128
+        }
+    }
+
+    fn map_u64(self, value: i128) -> Option<u64> {
+        self.fits_i128(value)
+            .then_some(self.canonicalize_i128(value) as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IntegerType;
+
+    const ALL: [IntegerType; 8] = [
+        IntegerType::new(8, true).unwrap(),
+        IntegerType::new(16, true).unwrap(),
+        IntegerType::new(32, true).unwrap(),
+        IntegerType::new(64, true).unwrap(),
+        IntegerType::new(8, false).unwrap(),
+        IntegerType::new(16, false).unwrap(),
+        IntegerType::new(32, false).unwrap(),
+        IntegerType::new(64, false).unwrap(),
+    ];
+
+    #[test]
+    fn bounds_and_canonicalization_cover_every_integer_type() {
+        for ty in ALL {
+            let min = ty.min_i128();
+            let max = ty.max_i128();
+            assert!(ty.fits_i128(min));
+            assert!(ty.fits_i128(max));
+            assert!(!ty.fits_i128(min - 1));
+            assert!(!ty.fits_i128(max + 1));
+            assert_eq!(ty.canonicalize_i128(max + 1), min);
+            assert_eq!(ty.canonicalize_i128(min - 1), max);
+        }
+    }
+
+    #[test]
+    fn checked_and_wrapping_boundaries_cover_every_integer_type() {
+        for ty in ALL {
+            let min = ty.min_i128();
+            let max = ty.max_i128();
+            assert_eq!(ty.checked_add_i128(max, 1), None);
+            assert_eq!(ty.checked_sub_i128(min, 1), None);
+            assert_eq!(ty.checked_mul_i128(max, 2), None);
+            assert_eq!(ty.wrapping_add_i128(max, 1), min);
+            assert_eq!(ty.wrapping_sub_i128(min, 1), max);
+            let expected_neg = if ty.is_signed() { None } else { Some(0) };
+            assert_eq!(ty.checked_neg_i128(min), expected_neg);
+            assert_eq!(ty.checked_div_i128(max, 1), Some(max));
+            assert_eq!(ty.checked_rem_i128(max, 1), Some(0));
+            if ty.is_signed() {
+                assert_eq!(ty.checked_div_i128(min, -1), None);
+                assert_eq!(ty.checked_rem_i128(min, -1), None);
+            }
+            assert_eq!(ty.checked_div_i128(0, 0), None);
+            assert_eq!(ty.checked_rem_i128(0, 0), None);
+            assert_eq!(ty.compare_i128(min, max), std::cmp::Ordering::Less);
+            assert_eq!(ty.compare_i128(max, min), std::cmp::Ordering::Greater);
+        }
+    }
+
+    #[test]
+    fn checked_reports_preserve_overflowing_mathematical_results() {
+        let i32 = IntegerType::new(32, true).unwrap();
+        let report = i32.checked_add_report_i128(2_000_000_000, 2_000_000_000);
+        assert_eq!(report.raw(), Some(4_000_000_000));
+        assert_eq!(report.checked(), None);
+
+        for report in [
+            i32.checked_div_report_i128(i32.min_i128(), -1),
+            i32.checked_rem_report_i128(i32.min_i128(), -1),
+        ] {
+            assert_eq!(report.raw(), None);
+            assert_eq!(report.checked(), None);
+        }
+
+        let unrepresentable = i32.report_raw(i128::MAX.checked_add(1));
+        assert_eq!(unrepresentable.raw(), None);
+        assert_eq!(unrepresentable.checked(), None);
+    }
+
+    #[test]
+    fn shifts_and_bitnot_use_width_and_signedness() {
+        for ty in ALL {
+            let max = ty.max_i128();
+            let mask = ty.shift_count_mask();
+            assert_eq!(ty.shift_count_i128(ty.bits() as i128), 0);
+            assert_eq!(ty.shift_count_i128(-1), mask as u32);
+            assert_eq!(ty.shift_i128(1, ty.bits() as i128, true), 1);
+            assert_eq!(
+                ty.shift_i128(1, -1, true),
+                ty.shift_i128(1, mask as i128, true)
+            );
+            let expected_not = if ty.is_signed() { -1 } else { max };
+            assert_eq!(ty.bitnot_i128(0), expected_not);
+            if ty.is_signed() {
+                assert_eq!(ty.shift_i128(-1, 1, false), -1);
+                assert_eq!(ty.checked_neg_i128(max), Some(-max));
+            } else {
+                assert_eq!(ty.shift_i128(max, 1, false), max >> 1);
+                assert_eq!(ty.checked_neg_i128(max), None);
+            }
+        }
+    }
+
+    #[test]
+    fn checked_neg_canonicalizes_noncanonical_operands() {
+        let u8 = IntegerType::new(8, false).unwrap();
+        let i8 = IntegerType::new(8, true).unwrap();
+        assert_eq!(u8.checked_neg_i128(256), Some(0));
+        assert_eq!(i8.checked_neg_i128(128), None);
+    }
+
+    #[test]
+    fn checked_neg_literal_accepts_signed_minimum_magnitudes() {
+        for ty in ALL.iter().copied().filter(|ty| ty.is_signed()) {
+            let minimum = ty.min_i128();
+            let magnitude = -minimum;
+            assert_eq!(ty.checked_neg_literal_i128(magnitude), Some(minimum));
+            assert_eq!(ty.checked_neg_literal_i128(magnitude + 1), None);
+            assert_eq!(ty.checked_neg_i128(minimum), None);
+        }
+    }
+
+    #[test]
+    fn u64_adapters_preserve_canonical_register_images() {
+        for ty in ALL {
+            let max = ty.max_i128() as u64;
+            assert_eq!(ty.canonicalize_u64(max), max);
+            let expected_not = if ty.is_signed() { u64::MAX } else { max };
+            assert_eq!(ty.bitnot_u64(0), expected_not);
+            assert_eq!(ty.shift_u64(1, ty.bits() as u64, true), 1);
+            assert_eq!(ty.shift_count_u64(u64::MAX), ty.shift_count_mask() as u32);
+            assert_eq!(ty.compare_u64(0, max), std::cmp::Ordering::Less);
+            assert_eq!(ty.checked_div_u64(max, 1), Some(max));
+            assert_eq!(ty.checked_rem_u64(max, 1), Some(0));
+        }
+    }
+}

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -18,6 +18,7 @@ pub mod drop_glue_names;
 pub mod ffi_predicates;
 mod inference;
 mod inst;
+pub mod integer_semantics;
 mod intern_pool;
 pub mod layout;
 mod module_registry;
@@ -59,6 +60,7 @@ pub use inst::{
     AirRef, AirSourceOrder, AirStructFields, AirTypeArgs, AirValidationContext, AirValidationError,
     AirValidationErrorKind, MAX_AIR_INSTRUCTIONS_PER_BODY, ValidatedAir,
 };
+pub use integer_semantics::IntegerType;
 pub use intern_pool::{
     EnumData, EnumDefEntry, FrozenTypeInternPool, MAX_COMPOSITE_TYPES, StructData, StructDefEntry,
     TypeData, TypeInternPool, TypeInternPoolStats, TypeValidationError,

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -116,6 +116,7 @@ pub(super) fn validate_comptime_value_for_type_impl(
     Ok(())
 }
 use super::{DeferredOwnershipGate, DeferredOwnershipGateKind};
+use crate::integer_semantics::CheckedIntegerResult;
 use crate::specialize::MAX_SPECIALIZATION_ROUNDS;
 use crate::types::{ArrayLen, StructField, Type, TypeKind};
 
@@ -297,25 +298,8 @@ fn const_pattern_matches(pattern: &rue_rir::RirPatternView<'_>, scrut: ConstValu
 
 /// Check whether `value` is representable in integer type `ty`.
 pub(crate) fn const_int_fits(value: i128, ty: Type) -> bool {
-    match (ty.int_min(), ty.int_max()) {
-        (Some(min), Some(max)) => value >= min && value <= max,
-        _ => false,
-    }
-}
-
-/// Truncate `value` to the width of integer type `ty` (two's complement
-/// wrapping, sign-extended for signed types). Mirrors what the hardware does
-/// for operations defined to truncate (shifts, bitwise NOT on unsigned).
-fn truncate_to_type(value: i128, ty: Type) -> i128 {
-    let width = ty
-        .int_bit_width()
-        .expect("truncate_to_type called with non-integer type");
-    let mask = (1i128 << width) - 1;
-    let mut r = value & mask;
-    if ty.is_signed() && (r & (1i128 << (width - 1))) != 0 {
-        r -= 1i128 << width;
-    }
-    r
+    ty.integer_semantics()
+        .is_some_and(|integer| integer.fits_i128(value))
 }
 
 /// Build the E1200 error for a constant operation that would panic at runtime.
@@ -463,8 +447,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             .filter(Type::is_integer)
     }
 
-    /// Finish an arithmetic operation: range-check `value` against the
-    /// expression's type.
+    /// Finish an arithmetic operation using the kernel's typed result and its
+    /// available raw mathematical result for diagnostics.
     ///
     /// - Typed: out-of-range results are a hard error (the operation would
     ///   panic at runtime, spec 8.1 / 4.14:4).
@@ -472,17 +456,17 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     ///   expression non-evaluable (legacy checked-i64 semantics).
     fn finish_arith(
         &self,
-        value: Option<i128>,
+        result: CheckedIntegerResult,
         ty: Option<Type>,
         op: &str,
         span: Span,
     ) -> CompileResult<Option<ConstValue>> {
         match ty {
-            Some(ty) => match value {
-                Some(v) if const_int_fits(v, ty) => Ok(Some(ConstValue::Integer(v))),
+            Some(ty) => match result.checked() {
+                Some(v) => Ok(Some(ConstValue::Integer(v))),
                 _ => {
                     let ty_name = ty.safe_name_with_pool(Some(self.body_type_pool()));
-                    let detail = match value {
+                    let detail = match result.raw() {
                         Some(v) => format!("the result {} does not fit in {}", v, ty_name),
                         None => format!("the result does not fit in {}", ty_name),
                     };
@@ -496,7 +480,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     ))
                 }
             },
-            None => match value {
+            None => match result.raw() {
                 Some(v) if v >= i128::from(i64::MIN) && v <= i128::from(i64::MAX) => {
                     Ok(Some(ConstValue::Integer(v)))
                 }
@@ -611,18 +595,27 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         ));
                     }
                 }
-                // Negated literals bypass the literal range check so that
-                // `-128` works for i8 (the magnitude alone exceeds i8::MAX).
-                let operand_value =
-                    if let InstData::IntConst(mag) = &self.body_rir_ref().get(*operand).data {
-                        Some(ConstValue::Integer(*mag as i128))
-                    } else {
-                        self.eval_const_expr(*operand, env)?
-                    };
-                match operand_value {
-                    Some(ConstValue::Integer(n)) => self.finish_arith(Some(-n), ty, "-", span),
-                    // Can't negate a boolean, type, or unit
-                    _ => Ok(None),
+                if let InstData::IntConst(magnitude) = &self.body_rir_ref().get(*operand).data {
+                    // The literal path uses mathematical magnitude semantics:
+                    // unlike an ordinary runtime value, `128` must not first
+                    // canonicalize to -128 before becoming `-128`.
+                    let result = ty.and_then(|ty| ty.integer_semantics()).map_or_else(
+                        || CheckedIntegerResult::from_raw((*magnitude as i128).checked_neg()),
+                        |integer| integer.checked_neg_literal_report_i128(*magnitude as i128),
+                    );
+                    self.finish_arith(result, ty, "-", span)
+                } else {
+                    match self.eval_const_expr(*operand, env)? {
+                        Some(ConstValue::Integer(n)) => {
+                            let result = ty.and_then(|ty| ty.integer_semantics()).map_or_else(
+                                || CheckedIntegerResult::from_raw(n.checked_neg()),
+                                |integer| integer.checked_neg_report_i128(n),
+                            );
+                            self.finish_arith(result, ty, "-", span)
+                        }
+                        // Can't negate a boolean, type, or unit
+                        _ => Ok(None),
+                    }
                 }
             }
 
@@ -641,21 +634,33 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     return Ok(None);
                 };
                 let ty = self.const_expr_type(env, inst_ref);
-                self.finish_arith(l.checked_add(r), ty, "+", span)
+                let result = ty.and_then(|ty| ty.integer_semantics()).map_or_else(
+                    || CheckedIntegerResult::from_raw(l.checked_add(r)),
+                    |integer| integer.checked_add_report_i128(l, r),
+                );
+                self.finish_arith(result, ty, "+", span)
             }
             InstData::Sub { lhs, rhs } => {
                 let Some((l, r)) = self.eval_int_operands(*lhs, *rhs, env)? else {
                     return Ok(None);
                 };
                 let ty = self.const_expr_type(env, inst_ref);
-                self.finish_arith(l.checked_sub(r), ty, "-", span)
+                let result = ty.and_then(|ty| ty.integer_semantics()).map_or_else(
+                    || CheckedIntegerResult::from_raw(l.checked_sub(r)),
+                    |integer| integer.checked_sub_report_i128(l, r),
+                );
+                self.finish_arith(result, ty, "-", span)
             }
             InstData::Mul { lhs, rhs } => {
                 let Some((l, r)) = self.eval_int_operands(*lhs, *rhs, env)? else {
                     return Ok(None);
                 };
                 let ty = self.const_expr_type(env, inst_ref);
-                self.finish_arith(l.checked_mul(r), ty, "*", span)
+                let result = ty.and_then(|ty| ty.integer_semantics()).map_or_else(
+                    || CheckedIntegerResult::from_raw(l.checked_mul(r)),
+                    |integer| integer.checked_mul_report_i128(l, r),
+                );
+                self.finish_arith(result, ty, "*", span)
             }
             InstData::Div { lhs, rhs } | InstData::Mod { lhs, rhs } => {
                 let is_div = matches!(&inst.data, InstData::Div { .. });
@@ -675,17 +680,28 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         None => Ok(None),
                     };
                 }
-                // Signed MIN / -1 (and MIN % -1) overflow at runtime, spec 8.1:3.
-                if r == -1 {
-                    match ty {
-                        Some(t) if t.is_signed() && Some(l) == t.int_min() => {
-                            return self.finish_arith(None, ty, op, span);
-                        }
-                        None if l == i128::from(i64::MIN) => return Ok(None),
-                        _ => {}
-                    }
+                // Untyped evaluation retains its historical i64 fallback;
+                // typed MIN / -1 trapping is owned by the kernel report.
+                if r == -1 && ty.is_none() && l == i128::from(i64::MIN) {
+                    return Ok(None);
                 }
-                self.finish_arith(Some(if is_div { l / r } else { l % r }), ty, op, span)
+                let result = ty.and_then(|ty| ty.integer_semantics()).map_or_else(
+                    || {
+                        CheckedIntegerResult::from_raw(if is_div {
+                            l.checked_div(r)
+                        } else {
+                            l.checked_rem(r)
+                        })
+                    },
+                    |integer| {
+                        if is_div {
+                            integer.checked_div_report_i128(l, r)
+                        } else {
+                            integer.checked_rem_report_i128(l, r)
+                        }
+                    },
+                );
+                self.finish_arith(result, ty, op, span)
             }
 
             // Comparison operations
@@ -791,21 +807,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 };
                 match self.const_expr_type(env, inst_ref) {
                     Some(ty) => {
-                        let width = ty
-                            .int_bit_width()
+                        let integer = ty
+                            .integer_semantics()
                             .expect("const_expr_type returned non-integer");
                         // Two's-complement AND masks negative amounts the same
                         // way the hardware masks the count register.
-                        let amt = (r & i128::from(width - 1)) as u32;
-                        let v = if is_shl {
-                            // Wrapping shift + truncation: the low `width`
-                            // bits are exact, which is all that survives.
-                            truncate_to_type(l.wrapping_shl(amt), ty)
-                        } else {
-                            // Value semantics make this arithmetic for signed
-                            // (negative l) and logical for unsigned (l >= 0).
-                            l >> amt
-                        };
+                        let v = integer.shift_i128(l, r, is_shl);
                         Ok(Some(ConstValue::Integer(v)))
                     }
                     None => {
@@ -833,7 +840,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     return Ok(None);
                 };
                 let v = match self.const_expr_type(env, inst_ref) {
-                    Some(ty) => truncate_to_type(!n, ty),
+                    Some(ty) => ty
+                        .integer_semantics()
+                        .expect("bitnot requires an integer type")
+                        .bitnot_i128(n),
                     None => !n,
                 };
                 Ok(Some(ConstValue::Integer(v)))

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -8,6 +8,7 @@
 
 use std::sync::Arc;
 
+use crate::integer_semantics::IntegerType;
 use crate::type_encoding::{self, Composite, Decoded, Primitive};
 
 /// Return the capacity encoded by the canonical synthetic `Str(N)` name.
@@ -968,17 +969,7 @@ impl Type {
     /// For non-integer types, returns `false`.
     #[must_use]
     pub fn literal_fits(&self, value: u64) -> bool {
-        match self.try_kind() {
-            Some(TypeKind::I8) => value <= i8::MAX as u64,
-            Some(TypeKind::I16) => value <= i16::MAX as u64,
-            Some(TypeKind::I32) => value <= i32::MAX as u64,
-            Some(TypeKind::I64) => value <= i64::MAX as u64,
-            Some(TypeKind::U8) => value <= u8::MAX as u64,
-            Some(TypeKind::U16) => value <= u16::MAX as u64,
-            Some(TypeKind::U32) => value <= u32::MAX as u64,
-            Some(TypeKind::U64) => true,
-            _ => false,
-        }
+        self.int_max().is_some_and(|max| i128::from(value) <= max)
     }
 
     /// Get the bit width of this integer type (8, 16, 32, or 64).
@@ -986,13 +977,21 @@ impl Type {
     /// Returns `None` for non-integer types.
     #[must_use]
     pub fn int_bit_width(&self) -> Option<u32> {
-        match self.try_kind()? {
-            TypeKind::I8 | TypeKind::U8 => Some(8),
-            TypeKind::I16 | TypeKind::U16 => Some(16),
-            TypeKind::I32 | TypeKind::U32 => Some(32),
-            TypeKind::I64 | TypeKind::U64 => Some(64),
-            _ => None,
-        }
+        self.integer_semantics().map(IntegerType::bits)
+    }
+
+    /// Return the width and signedness descriptor used by all integer
+    /// semantics consumers.
+    #[must_use]
+    pub fn integer_semantics(&self) -> Option<IntegerType> {
+        let bits = match self.try_kind()? {
+            TypeKind::I8 | TypeKind::U8 => 8,
+            TypeKind::I16 | TypeKind::U16 => 16,
+            TypeKind::I32 | TypeKind::U32 => 32,
+            TypeKind::I64 | TypeKind::U64 => 64,
+            _ => return None,
+        };
+        IntegerType::new(bits, self.is_signed())
     }
 
     /// Get the minimum representable value of this integer type.
@@ -1000,12 +999,7 @@ impl Type {
     /// Returns `None` for non-integer types.
     #[must_use]
     pub fn int_min(&self) -> Option<i128> {
-        let width = self.int_bit_width()?;
-        if self.is_signed() {
-            Some(-(1i128 << (width - 1)))
-        } else {
-            Some(0)
-        }
+        self.integer_semantics().map(IntegerType::min_i128)
     }
 
     /// Get the maximum representable value of this integer type.
@@ -1013,12 +1007,7 @@ impl Type {
     /// Returns `None` for non-integer types.
     #[must_use]
     pub fn int_max(&self) -> Option<i128> {
-        let width = self.int_bit_width()?;
-        if self.is_signed() {
-            Some((1i128 << (width - 1)) - 1)
-        } else {
-            Some((1i128 << width) - 1)
-        }
+        self.integer_semantics().map(IntegerType::max_i128)
     }
 
     /// Check if a u64 value can be negated to fit within the range of this signed integer type.
@@ -1027,13 +1016,11 @@ impl Type {
     /// Returns `true` if the negated value fits, `false` otherwise.
     #[must_use]
     pub fn negated_literal_fits(&self, value: u64) -> bool {
-        match self.try_kind() {
-            Some(TypeKind::I8) => value <= (i8::MIN as i64).unsigned_abs(),
-            Some(TypeKind::I16) => value <= (i16::MIN as i64).unsigned_abs(),
-            Some(TypeKind::I32) => value <= (i32::MIN as i64).unsigned_abs(),
-            Some(TypeKind::I64) => value <= (i64::MIN).unsigned_abs(),
-            _ => false,
-        }
+        self.integer_semantics().is_some_and(|integer| {
+            integer
+                .checked_neg_literal_i128(i128::from(value))
+                .is_some()
+        })
     }
 
     /// Encode this type as a u32 for storage in extra arrays.

--- a/crates/rue-cfg/src/api_inventory.rs
+++ b/crates/rue-cfg/src/api_inventory.rs
@@ -88,3 +88,22 @@ fn cfg_uses_air_synthetic_type_identity_policy() {
         }
     }
 }
+
+#[test]
+fn constant_folding_uses_the_air_integer_semantics_kernel() {
+    let source = include_str!("opt/constfold.rs");
+    assert!(source.contains("integer_semantics()"));
+    assert!(source.contains("compare_u64"));
+    for helper in [
+        "fn type_bits(",
+        "fn is_signed(",
+        "fn sign_extend(",
+        "fn fits_in_signed_type(",
+        "fn fits_in_unsigned_type(",
+    ] {
+        assert!(
+            !source.contains(helper),
+            "const folding regained local helper {helper}"
+        );
+    }
+}

--- a/crates/rue-cfg/src/opt/constfold.rs
+++ b/crates/rue-cfg/src/opt/constfold.rs
@@ -17,8 +17,10 @@
 //! Arithmetic operations that would overflow at runtime are NOT folded.
 //! This ensures the runtime panic behavior is preserved.
 
+use std::cmp::Ordering;
+
 use crate::{Cfg, CfgInstData, CfgValue};
-use rue_air::{EnumId, Type, TypeKind};
+use rue_air::{EnumId, Type};
 
 /// Try to fold a single instruction if it operates on constants.
 /// Returns `true` if the instruction was replaced by a constant.
@@ -54,18 +56,18 @@ pub(super) fn fold_instruction(cfg: &mut Cfg, value: CfgValue) -> bool {
                 })
         }
         CfgInstData::WrappingAdd(lhs, rhs) => fold_binary_arith(cfg, *lhs, *rhs, ty, |a, b| {
-            Some(truncate_to_type(a.wrapping_add(b), ty))
+            Some(ty.integer_semantics()?.wrapping_add_u64(a, b))
         }),
         CfgInstData::WrappingSub(lhs, rhs) => {
             fold_binary_arith(cfg, *lhs, *rhs, ty, |a, b| {
-                Some(truncate_to_type(a.wrapping_sub(b), ty))
+                Some(ty.integer_semantics()?.wrapping_sub_u64(a, b))
             })
             // x wrapping_sub x is always zero and cannot trap.
             .or_else(|| (lhs == rhs).then_some(CfgInstData::Const(0)))
         }
         CfgInstData::WrappingMul(lhs, rhs) => {
             fold_binary_arith(cfg, *lhs, *rhs, ty, |a, b| {
-                Some(truncate_to_type(a.wrapping_mul(b), ty))
+                Some(ty.integer_semantics()?.wrapping_mul_u64(a, b))
             })
             // Wrapping multiplication never traps, so either zero operand
             // annihilates the result even when the other operand is dynamic.
@@ -99,19 +101,27 @@ pub(super) fn fold_instruction(cfg: &mut Cfg, value: CfgValue) -> bool {
         }
         CfgInstData::Lt(lhs, rhs) => {
             let lhs_ty = cfg.get_inst(*lhs).ty;
-            fold_comparison_signed(cfg, *lhs, *rhs, lhs_ty, |a, b| a < b, |a, b| a < b)
+            fold_comparison_ordered(cfg, *lhs, *rhs, lhs_ty, |ordering| {
+                ordering == Ordering::Less
+            })
         }
         CfgInstData::Gt(lhs, rhs) => {
             let lhs_ty = cfg.get_inst(*lhs).ty;
-            fold_comparison_signed(cfg, *lhs, *rhs, lhs_ty, |a, b| a > b, |a, b| a > b)
+            fold_comparison_ordered(cfg, *lhs, *rhs, lhs_ty, |ordering| {
+                ordering == Ordering::Greater
+            })
         }
         CfgInstData::Le(lhs, rhs) => {
             let lhs_ty = cfg.get_inst(*lhs).ty;
-            fold_comparison_signed(cfg, *lhs, *rhs, lhs_ty, |a, b| a <= b, |a, b| a <= b)
+            fold_comparison_ordered(cfg, *lhs, *rhs, lhs_ty, |ordering| {
+                ordering != Ordering::Greater
+            })
         }
         CfgInstData::Ge(lhs, rhs) => {
             let lhs_ty = cfg.get_inst(*lhs).ty;
-            fold_comparison_signed(cfg, *lhs, *rhs, lhs_ty, |a, b| a >= b, |a, b| a >= b)
+            fold_comparison_ordered(cfg, *lhs, *rhs, lhs_ty, |ordering| {
+                ordering != Ordering::Less
+            })
         }
 
         // Bitwise
@@ -138,9 +148,9 @@ pub(super) fn fold_instruction(cfg: &mut Cfg, value: CfgValue) -> bool {
         // `!v` flips all 64 stored bits, but the operation is defined at the
         // operand's width; truncate so the folded constant matches what the
         // runtime computes (RUE-59).
-        CfgInstData::BitNot(operand) => {
-            fold_unary_arith(cfg, *operand, ty, |v| Some(truncate_to_type(!v, ty)))
-        }
+        CfgInstData::BitNot(operand) => fold_unary_arith(cfg, *operand, ty, |v| {
+            Some(ty.integer_semantics()?.bitnot_u64(v))
+        }),
 
         // Everything else is not foldable
         _ => None,
@@ -216,30 +226,24 @@ where
     }
 }
 
-/// Try to fold a comparison that needs signed semantics for signed types.
-fn fold_comparison_signed<Fs, Fu>(
+/// Try to fold an ordered integer comparison through the shared semantics
+/// kernel.  `compare_u64` interprets the same canonical register image as the
+/// language does, including signed narrow values.
+fn fold_comparison_ordered<F>(
     cfg: &Cfg,
     lhs: CfgValue,
     rhs: CfgValue,
     ty: Type,
-    signed_op: Fs,
-    unsigned_op: Fu,
+    op: F,
 ) -> Option<CfgInstData>
 where
-    Fs: FnOnce(i64, i64) -> bool,
-    Fu: FnOnce(u64, u64) -> bool,
+    F: FnOnce(Ordering) -> bool,
 {
     let lhs_val = get_const_int(cfg, lhs)?;
     let rhs_val = get_const_int(cfg, rhs)?;
 
-    let result = if is_signed(ty) {
-        // Sign-extend the values to i64 based on the type
-        let lhs_signed = sign_extend(lhs_val, ty) as i64;
-        let rhs_signed = sign_extend(rhs_val, ty) as i64;
-        signed_op(lhs_signed, rhs_signed)
-    } else {
-        unsigned_op(lhs_val, rhs_val)
-    };
+    let integer = ty.integer_semantics()?;
+    let result = op(integer.compare_u64(lhs_val, rhs_val));
 
     Some(CfgInstData::BoolConst(result))
 }
@@ -255,31 +259,8 @@ fn fold_shift(
     let lhs_val = get_const_int(cfg, lhs)?;
     let rhs_val = get_const_int(cfg, rhs)?;
 
-    // Shift amount must be less than the bit width
-    let bits = type_bits(ty);
-    // A shift amount >= the bit width is masked modulo the width at runtime
-    // (spec 4.3a:10), consistent with dce.rs treating shifts as non-trapping —
-    // it is NOT UB. This fold path assumes rhs < bits (it does not re-narrow the
-    // result for the masked count), so defer the masked case to the backend,
-    // which masks the count correctly.
-    if rhs_val >= bits as u64 {
-        return None;
-    }
-
-    let result = if is_left {
-        lhs_val << rhs_val
-    } else if is_signed(ty) {
-        // Arithmetic right shift for signed types.
-        // Must sign-extend narrow types to i64 before shifting.
-        let signed_val = sign_extend(lhs_val, ty) as i64;
-        (signed_val >> rhs_val) as u64
-    } else {
-        // Logical right shift for unsigned types
-        lhs_val >> rhs_val
-    };
-
-    // Truncate to the type's bit width (canonical representation)
-    let result = truncate_to_type(result, ty);
+    let integer = ty.integer_semantics()?;
+    let result = integer.shift_u64(lhs_val, rhs_val, is_left);
     Some(CfgInstData::Const(result))
 }
 
@@ -336,206 +317,38 @@ fn get_enum_variant(cfg: &Cfg, value: CfgValue) -> Option<(EnumId, u32, u32)> {
     }
 }
 
-/// Check if a type is signed.
-fn is_signed(ty: Type) -> bool {
-    matches!(
-        ty.kind(),
-        TypeKind::I8 | TypeKind::I16 | TypeKind::I32 | TypeKind::I64
-    )
-}
-
-/// Get the bit width of a type.
-fn type_bits(ty: Type) -> u32 {
-    match ty.kind() {
-        TypeKind::I8 | TypeKind::U8 => 8,
-        TypeKind::I16 | TypeKind::U16 => 16,
-        TypeKind::I32 | TypeKind::U32 => 32,
-        TypeKind::I64 | TypeKind::U64 => 64,
-        TypeKind::Bool => 1,
-        _ => 64, // Default for other types
-    }
-}
-
-/// Truncate a value to a type's width, producing the canonical 64-bit
-/// representation: zero-extended for unsigned types, sign-extended for
-/// signed types.
-///
-/// All folds must produce canonical constants. The checked arithmetic
-/// helpers already do (signed results come out of an `i64 as u64` cast,
-/// i.e. sign-extended), and Eq/Ne folding compares raw u64 representations,
-/// so a non-canonical constant — an unmasked `!v`, or a masked-but-not-
-/// extended negative shift result — yields wrong folds and -O0 vs -O1+
-/// divergence (RUE-59).
-fn truncate_to_type(val: u64, ty: Type) -> u64 {
-    let masked = mask_to_type(val, ty);
-    if is_signed(ty) {
-        sign_extend(masked, ty)
-    } else {
-        masked
-    }
-}
-
-/// Mask a value to the bit width of a type.
-fn mask_to_type(val: u64, ty: Type) -> u64 {
-    match ty.kind() {
-        TypeKind::I8 | TypeKind::U8 => val & 0xFF,
-        TypeKind::I16 | TypeKind::U16 => val & 0xFFFF,
-        TypeKind::I32 | TypeKind::U32 => val & 0xFFFF_FFFF,
-        TypeKind::I64 | TypeKind::U64 => val,
-        _ => val,
-    }
-}
-
 // ============================================================================
 // Checked arithmetic (returns None if would overflow)
 // ============================================================================
 
 fn checked_add(a: u64, b: u64, ty: Type) -> Option<u64> {
-    if is_signed(ty) {
-        let (a, b) = sign_extend_operands(a, b, ty);
-        let result = (a as i64).checked_add(b as i64)?;
-        // Check for overflow in the target type
-        if !fits_in_signed_type(result, ty) {
-            return None;
-        }
-        Some(result as u64)
-    } else {
-        let result = a.checked_add(b)?;
-        if !fits_in_unsigned_type(result, ty) {
-            return None;
-        }
-        Some(result)
-    }
+    ty.integer_semantics()?.checked_add_u64(a, b)
 }
 
 fn checked_sub(a: u64, b: u64, ty: Type) -> Option<u64> {
-    if is_signed(ty) {
-        let (a, b) = sign_extend_operands(a, b, ty);
-        let result = (a as i64).checked_sub(b as i64)?;
-        if !fits_in_signed_type(result, ty) {
-            return None;
-        }
-        Some(result as u64)
-    } else {
-        a.checked_sub(b)
-    }
+    ty.integer_semantics()?.checked_sub_u64(a, b)
 }
 
 fn checked_mul(a: u64, b: u64, ty: Type) -> Option<u64> {
-    if is_signed(ty) {
-        let (a, b) = sign_extend_operands(a, b, ty);
-        let result = (a as i64).checked_mul(b as i64)?;
-        if !fits_in_signed_type(result, ty) {
-            return None;
-        }
-        Some(result as u64)
-    } else {
-        let result = a.checked_mul(b)?;
-        if !fits_in_unsigned_type(result, ty) {
-            return None;
-        }
-        Some(result)
-    }
+    ty.integer_semantics()?.checked_mul_u64(a, b)
 }
 
 fn checked_div(a: u64, b: u64, ty: Type) -> Option<u64> {
     if b == 0 {
         return None; // Division by zero - don't fold
     }
-    if is_signed(ty) {
-        let (a, b) = sign_extend_operands(a, b, ty);
-        // MIN / -1 overflows: the quotient -MIN is unrepresentable.
-        // checked_div only catches the i64 case; for narrower types the
-        // quotient (e.g. i32::MIN / -1 = 2^31) is a valid i64 that is merely
-        // out of range, so verify it fits like checked_mul does. Refusing to
-        // fold preserves the mandatory runtime overflow trap (RUE-147).
-        let result = (a as i64).checked_div(b as i64)?;
-        if !fits_in_signed_type(result, ty) {
-            return None;
-        }
-        Some(result as u64)
-    } else {
-        Some(a / b)
-    }
+    ty.integer_semantics()?.checked_div_u64(a, b)
 }
 
 fn checked_mod(a: u64, b: u64, ty: Type) -> Option<u64> {
     if b == 0 {
         return None; // Division by zero - don't fold
     }
-    if is_signed(ty) {
-        let (a, b) = sign_extend_operands(a, b, ty);
-        // MIN % -1 overflows just like MIN / -1 (the implied quotient -MIN is
-        // unrepresentable), even though the remainder itself would be 0.
-        // checked_rem only catches the i64 case, so verify the quotient fits
-        // the target type; refusing to fold preserves the runtime overflow
-        // trap (RUE-147).
-        let quotient = (a as i64).checked_div(b as i64)?;
-        if !fits_in_signed_type(quotient, ty) {
-            return None;
-        }
-        let result = (a as i64).checked_rem(b as i64)?;
-        Some(result as u64)
-    } else {
-        Some(a % b)
-    }
+    ty.integer_semantics()?.checked_rem_u64(a, b)
 }
 
 fn checked_neg(a: u64, ty: Type) -> Option<u64> {
-    if is_signed(ty) {
-        let a = sign_extend(a, ty);
-        let result = (a as i64).checked_neg()?;
-        if !fits_in_signed_type(result, ty) {
-            return None;
-        }
-        Some(result as u64)
-    } else {
-        // Unsigned negation: 0 - a, wrapping
-        // Only 0 doesn't overflow
-        if a == 0 {
-            Some(0)
-        } else {
-            None // Would underflow
-        }
-    }
-}
-
-/// Sign-extend a value based on its type.
-fn sign_extend(val: u64, ty: Type) -> u64 {
-    match ty.kind() {
-        TypeKind::I8 => (val as i8) as i64 as u64,
-        TypeKind::I16 => (val as i16) as i64 as u64,
-        TypeKind::I32 => (val as i32) as i64 as u64,
-        TypeKind::I64 => val,
-        _ => val,
-    }
-}
-
-/// Sign-extend both operands.
-fn sign_extend_operands(a: u64, b: u64, ty: Type) -> (u64, u64) {
-    (sign_extend(a, ty), sign_extend(b, ty))
-}
-
-/// Check if a signed result fits in the target type.
-fn fits_in_signed_type(val: i64, ty: Type) -> bool {
-    match ty.kind() {
-        TypeKind::I8 => val >= i8::MIN as i64 && val <= i8::MAX as i64,
-        TypeKind::I16 => val >= i16::MIN as i64 && val <= i16::MAX as i64,
-        TypeKind::I32 => val >= i32::MIN as i64 && val <= i32::MAX as i64,
-        TypeKind::I64 => true, // i64 can hold any i64
-        _ => true,
-    }
-}
-
-/// Check if an unsigned result fits in the target type.
-fn fits_in_unsigned_type(val: u64, ty: Type) -> bool {
-    match ty.kind() {
-        TypeKind::U8 => val <= u8::MAX as u64,
-        TypeKind::U16 => val <= u16::MAX as u64,
-        TypeKind::U32 => val <= u32::MAX as u64,
-        TypeKind::U64 => true,
-        _ => true,
-    }
+    ty.integer_semantics()?.checked_neg_u64(a)
 }
 
 #[cfg(test)]
@@ -936,6 +749,24 @@ mod tests {
         match &cfg.get_inst(shr).data {
             CfgInstData::Const(val) => {
                 assert_eq!(*val, 0x7F, "Expected 0x7F, got 0x{:X}", val);
+            }
+            other => panic!("Expected Const, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_fold_shift_count_is_masked_at_operand_width() {
+        let mut cfg = make_cfg();
+        let c1 = add_const(&mut cfg, 0x81, Type::U8);
+        let c2 = add_const(&mut cfg, 8, Type::U8);
+        let shr = add_shr(&mut cfg, c1, c2, Type::U8);
+        finalize_cfg(&mut cfg, shr);
+
+        crate::opt::constopt::run(&mut cfg);
+
+        match &cfg.get_inst(shr).data {
+            CfgInstData::Const(value) => {
+                assert_eq!(*value, 0x81, "8 is masked to shift count zero for u8");
             }
             other => panic!("Expected Const, got {:?}", other),
         }

--- a/crates/rue-codegen/src/api_inventory.rs
+++ b/crates/rue-codegen/src/api_inventory.rs
@@ -92,3 +92,14 @@ fn production_codegen_does_not_call_frozen_declaration_test_adapters() {
         }
     }
 }
+
+#[test]
+fn value_planning_uses_the_air_integer_semantics_kernel() {
+    let source = include_str!("value_plan.rs");
+    assert!(source.contains("ty.integer_semantics().map(Into::into)"));
+    assert!(source.contains("IntegerType::new"));
+    assert!(source.contains(".shift_count_mask()"));
+    assert!(!source.contains("TypeKind::I8 | TypeKind::U8 => 8"));
+    assert!(!source.contains("(8, true) => (i8::MIN"));
+    assert!(!source.contains("type_bits(ty) - 1"));
+}

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -11,7 +11,7 @@
 //! architecture cannot quietly invent a different scalar/aggregate policy.
 
 use lasso::Spur;
-use rue_air::{EnumId, RuntimeCallKind, StructId, TypeKind};
+use rue_air::{EnumId, IntegerType, RuntimeCallKind, StructId, TypeKind};
 use rue_cfg::{CfgInstData, CfgValue, Place, PlaceBase, Projection, Type};
 use rue_runtime_abi::RuntimeHelperId;
 
@@ -526,6 +526,15 @@ impl ValueShape {
 pub struct IntegerWidth {
     pub bits: u32,
     pub signed: bool,
+}
+
+impl From<IntegerType> for IntegerWidth {
+    fn from(integer: IntegerType) -> Self {
+        Self {
+            bits: integer.bits(),
+            signed: integer.is_signed(),
+        }
+    }
 }
 
 /// Normalized extension required when an integer value feeds a 64-bit pointer
@@ -2174,17 +2183,7 @@ fn shape(ctx: &CfgLowerContext<'_>, ty: Type) -> ValueShape {
 
 /// Select the language integer width and signedness used by all adapters.
 pub fn integer_width(ty: Type) -> Option<IntegerWidth> {
-    let bits = match ty.kind() {
-        TypeKind::I8 | TypeKind::U8 => 8,
-        TypeKind::I16 | TypeKind::U16 => 16,
-        TypeKind::I32 | TypeKind::U32 => 32,
-        TypeKind::I64 | TypeKind::U64 => 64,
-        _ => return None,
-    };
-    Some(IntegerWidth {
-        bits,
-        signed: ty.is_signed(),
-    })
+    ty.integer_semantics().map(Into::into)
 }
 
 /// Select the width used by a scalar comparison. Booleans and discriminant-only
@@ -2263,13 +2262,9 @@ pub fn type_bits(ty: Type) -> u32 {
 /// The language-level shift-count mask. Hardware details differ by target,
 /// but the language operation has one width-derived count domain.
 pub fn shift_count_mask(ty: Type) -> u64 {
-    match type_bits(ty) {
-        8 => 7,
-        16 => 15,
-        32 => 31,
-        64 => 63,
-        bits => panic!("invalid shift operand width: {bits}"),
-    }
+    ty.integer_semantics()
+        .expect("shift_count_mask called on non-integer type")
+        .shift_count_mask()
 }
 
 /// Return whether an integer type uses the machine's 64-bit value width.
@@ -2291,17 +2286,14 @@ pub fn type_range(ty: Type) -> (i64, i64) {
 
 /// Return the representable range selected by a shared integer-width plan.
 pub fn integer_range(width: IntegerWidth) -> (i64, i64) {
-    match (width.bits, width.signed) {
-        (8, true) => (i8::MIN as i64, i8::MAX as i64),
-        (16, true) => (i16::MIN as i64, i16::MAX as i64),
-        (32, true) => (i32::MIN as i64, i32::MAX as i64),
-        (64, true) => (i64::MIN, i64::MAX),
-        (8, false) => (0, u8::MAX as i64),
-        (16, false) => (0, u16::MAX as i64),
-        (32, false) => (0, u32::MAX as i64),
-        (64, false) => (0, i64::MAX),
-        _ => panic!("invalid integer width: {width:?}"),
-    }
+    let integer = u8::try_from(width.bits)
+        .ok()
+        .and_then(|bits| IntegerType::new(bits, width.signed))
+        .expect("invalid integer width");
+    (
+        integer.min_i128() as i64,
+        integer.max_i128().min(i128::from(i64::MAX)) as i64,
+    )
 }
 
 /// Return the by-reference parameter slots that must be preloaded before the
@@ -2704,6 +2696,15 @@ mod tests {
                 signed: false
             }
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid integer width")]
+    fn integer_range_rejects_widths_that_do_not_fit_the_kernel_descriptor() {
+        integer_range(IntegerWidth {
+            bits: 264,
+            signed: false,
+        });
     }
 
     #[test]

--- a/scripts/validate-type-architecture.py
+++ b/scripts/validate-type-architecture.py
@@ -86,6 +86,7 @@ PUBLIC_TYPE_DECLARATION_ALLOWLIST = {
     ("rue-air", "inference/types.rs", "TypeVarAllocator"): "inference-local allocator",
     ("rue-air", "call_abi.rs", "NativeAbiTypeFacts"): "per-type call-ABI kernel facts, not a type identity",
     ("rue-air", "runtime_call.rs", "RuntimeAirType"): "typed runtime ABI shape classification",
+    ("rue-air", "integer_semantics.rs", "IntegerType"): "fixed-width integer semantics descriptor, not a live type identity",
     ("rue-air", "semantic_import.rs", "SemanticImportType"): "stable semantic import schema",
     ("rue-air", "semantic_import.rs", "SemanticImportTypeFold"): "exhaustive stable schema fold view",
     ("rue-air", "semantic_import.rs", "SemanticImportedType"): "validated imported-type result",


### PR DESCRIPTION
Relates to RUE-1751

## Summary
- add one representation-independent fixed-width integer semantics kernel in rue-air
- migrate AIR comptime arithmetic, CFG constant folding, and shared codegen width/range/shift policy to it
- preserve exact overflow diagnostics through raw-plus-typed operation reports
- add structural guards and boundary coverage across all eight integer types

## Scope
This is the non-conflicting first slice. Durable const evaluation and the inference-time comptime subset remain for coordinated follow-up after the active comptime consolidation work lands.

## Validation
- scripts/rue spec comptime_negative_i8_min
- scripts/rue cli comptime_block_intermediate_overflow_unchanged
- scripts/rue premerge (196 targets passed)