### PR TITLE
RUE-1742: Enforce portable corpus action timeouts

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -98,6 +98,14 @@ sh_binary(
     visibility = ["PUBLIC"],
 )
 
+python_bootstrap_binary(
+    name = "corpus-timeout-runner",
+    main = "scripts/corpus-timeout.py",
+    # This is a declared input of every cacheable corpus action.  Do not
+    # replace it with a timeout binary discovered from the host PATH.
+    visibility = ["PUBLIC"],
+)
+
 sh_binary(
     name = "corpus-stamp-check",
     main = "scripts/corpus-stamp-check",
@@ -1608,6 +1616,7 @@ filegroup(
     name = "corpus-script-inputs",
     srcs = [
         "scripts/corpus-action",
+        "scripts/corpus-timeout.py",
         "scripts/corpus-stamp-check",
     ],
 )

--- a/corpus.bzl
+++ b/corpus.bzl
@@ -143,6 +143,9 @@ def _corpus_action_impl(ctx: AnalysisContext) -> list[Provider]:
             ctx.attrs.wrapper[RunInfo],
             stamp.as_output(),
             ctx.attrs.harness[RunInfo],
+            "--timeout-runner",
+            ctx.attrs.timeout_runner[RunInfo],
+            "--",
             ctx.attrs.harness_args,
         ),
         env = action_env,
@@ -205,6 +208,10 @@ _corpus_action = rule(
         "harness_args": attrs.list(attrs.string(), default = []),
         "repetition": attrs.string(default = ""),
         "timeout_seconds": attrs.option(attrs.int(), default = None),
+        # A cacheable action may not discover a host timeout binary from PATH.
+        # Keep the portable runner in the action graph so it is a declared,
+        # cache-keyed input on every platform.
+        "timeout_runner": attrs.dep(providers = [RunInfo], default = "//:corpus-timeout-runner"),
         "wrapper": attrs.dep(providers = [RunInfo], default = "//:corpus-action"),
     },
 )

--- a/scripts/corpus-action
+++ b/scripts/corpus-action
@@ -8,7 +8,7 @@
 # inputs like any other action, so the merge_group run reuses the result the PR
 # run uploaded rather than re-running the suite.
 #
-# usage: scripts/corpus-action STAMP HARNESS [ARG ...]
+# usage: scripts/corpus-action STAMP HARNESS --timeout-runner RUNNER... -- [ARG ...]
 #
 # Buck expands $(location) and $(exe_target) inside a genrule to paths relative
 # to the action's working directory, which is not the project root. The corpus
@@ -19,14 +19,29 @@
 # because `$(...)` is Buck's own macro syntax.
 set -uo pipefail
 
-if [[ $# -lt 2 ]]; then
-    echo "usage: scripts/corpus-action STAMP HARNESS [ARG ...]" >&2
+if [[ $# -lt 5 || "$3" != "--timeout-runner" ]]; then
+    echo "usage: scripts/corpus-action STAMP HARNESS --timeout-runner RUNNER... -- [ARG ...]" >&2
     exit 2
 fi
 
 stamp="$1"
 harness="$2"
-shift 2
+shift 3
+
+# RunInfo can be a command plus arguments (the Python bootstrap is
+# `python3 <script>`), so parse it as a delimited command rather than assuming
+# that the first token is an executable path. The harness arguments follow the
+# second `--` unchanged.
+timeout_runner_args=()
+while [[ $# -gt 0 && "$1" != "--" ]]; do
+    timeout_runner_args+=("$1")
+    shift
+done
+if [[ $# -eq 0 || ${#timeout_runner_args[@]} -eq 0 ]]; then
+    echo "error: timeout runner command is missing its '--' delimiter" >&2
+    exit 2
+fi
+shift
 
 # Resolve a path without requiring GNU realpath (macOS runners ship BSD tools
 # and no coreutils). A directory resolves directly; anything else resolves
@@ -63,6 +78,13 @@ done
 unset RUE_CORPUS_ABSOLUTIZE
 
 harness="$(absolutize "$harness")" || exit 2
+if [[ ${#timeout_runner_args[@]} -eq 1 ]]; then
+    timeout_runner_args[0]="$(absolutize "${timeout_runner_args[0]}")" || exit 2
+else
+    # The first token is the declared interpreter (`python3`); the bootstrap
+    # script is the second token and is relative to the action's cwd.
+    timeout_runner_args[1]="$(absolutize "${timeout_runner_args[1]}")" || exit 2
+fi
 
 # The per-case budgets in execution_contracts.toml are the honest gates. This
 # outer bound only replaces the test executor's timeout, which a build action
@@ -70,10 +92,49 @@ harness="$(absolutize "$harness")" || exit 2
 # and reports nothing useful.
 timeout_seconds="${RUE_CORPUS_TIMEOUT_SECONDS:-}"
 unset RUE_CORPUS_TIMEOUT_SECONDS
-if [[ -n "$timeout_seconds" ]] && command -v timeout >/dev/null 2>&1; then
-    timeout "$timeout_seconds" "$harness" "$@"
+if [[ -n "$timeout_seconds" ]]; then
+    timeout_marker="$(mktemp "${TMPDIR:-/tmp}/rue-corpus-timeout.XXXXXX")" || {
+        echo "error: cannot create corpus timeout marker" >&2
+        exit 2
+    }
+    cleanup_timeout_marker() {
+        rm -f "$timeout_marker"
+    }
+    trap cleanup_timeout_marker EXIT
+
+    # The wrapper is a separate shell process from the Python runner. Forward
+    # cancellation explicitly so the runner can terminate and reap the entire
+    # harness process group before this action exits.
+    cancel_signal=0
+    runner_pid=""
+    forward_signal() {
+        cancel_signal="$1"
+        if [[ -n "$runner_pid" ]]; then
+            kill "-$1" "$runner_pid" 2>/dev/null || true
+        fi
+    }
+    trap 'forward_signal 2' INT
+    trap 'forward_signal 15' TERM
+    "${timeout_runner_args[@]}" "$timeout_seconds" "$timeout_marker" "$harness" "$@" &
+    runner_pid=$!
+    if [[ "$cancel_signal" -ne 0 ]]; then
+        kill "-$cancel_signal" "$runner_pid" 2>/dev/null || true
+    fi
+    wait "$runner_pid"
     status=$?
-    if [[ "$status" -eq 124 ]]; then
+    if [[ "$cancel_signal" -ne 0 ]]; then
+        # A trapped signal interrupts the first wait. Ignore further
+        # cancellation signals while the second wait reaps the runner; this
+        # keeps a repeated INT/TERM from interrupting cleanup and leaking the
+        # harness process group.
+        trap '' INT TERM
+        wait "$runner_pid"
+        reap_status=$?
+        trap - INT TERM
+        status=$((128 + cancel_signal))
+    fi
+    trap - INT TERM
+    if [[ "$status" -eq 124 && -s "$timeout_marker" ]]; then
         echo "error: corpus harness exceeded ${timeout_seconds}s: $harness $*" >&2
     fi
 else

--- a/scripts/corpus-timeout.py
+++ b/scripts/corpus-timeout.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Run a corpus harness with a portable, process-group timeout.
+
+This is deliberately a small action tool rather than a lookup of ``timeout``
+from PATH.  The Buck target that builds it is an input to every corpus action,
+so changing the timeout implementation invalidates the action cache entry.
+
+Usage:
+    corpus-timeout.py SECONDS TIMEOUT_MARKER COMMAND [ARG ...]
+
+The marker is private wrapper plumbing.  It is created only when the command
+actually exceeds its deadline, which lets the shell wrapper distinguish that
+case from a harness that legitimately exits 124 without changing the command's
+stdout or stderr.
+"""
+
+import math
+import os
+import signal
+import subprocess
+import sys
+import time
+from typing import List, Optional
+
+
+# A wedged harness gets this long to handle TERM before the whole process group
+# is forcibly killed.  Keep the bound short because this is the action's outer
+# deadline, not a harness-level cleanup policy.
+TERM_GRACE_SECONDS = 1.0
+KILL_GRACE_SECONDS = 1.0
+
+
+def usage() -> int:
+    print(
+        "usage: corpus-timeout.py SECONDS TIMEOUT_MARKER COMMAND [ARG ...]",
+        file=sys.stderr,
+    )
+    return 2
+
+
+def parse_seconds(value: str) -> float:
+    try:
+        seconds = float(value)
+    except ValueError as error:
+        raise ValueError("timeout must be a finite number greater than zero") from error
+    if not math.isfinite(seconds) or seconds <= 0:
+        raise ValueError("timeout must be a finite number greater than zero")
+    return seconds
+
+
+def signal_group(process_group: int, signal_number: int) -> bool:
+    """Signal a process group, tolerating a group that already exited."""
+    try:
+        os.killpg(process_group, signal_number)
+    except (PermissionError, ProcessLookupError):
+        return False
+    return True
+
+
+def group_exists(process_group: int) -> bool:
+    """Return whether the process group still has a member."""
+    try:
+        os.killpg(process_group, 0)
+    except (PermissionError, ProcessLookupError):
+        return False
+    return True
+
+
+def terminate_group(process: subprocess.Popen, first_signal: int = signal.SIGTERM) -> None:
+    """Signal the harness group, then KILL it after a bounded grace period."""
+    process_group = process.pid
+    signal_group(process_group, first_signal)
+
+    deadline = time.monotonic() + TERM_GRACE_SECONDS
+    while time.monotonic() < deadline:
+        if not group_exists(process_group):
+            return
+        time.sleep(min(0.05, deadline - time.monotonic()))
+
+    # Do not stop at the leader: a harness can leave descendants running after
+    # it handles TERM, so the forced cleanup always addresses the whole group.
+    signal_group(process_group, signal.SIGKILL)
+    deadline = time.monotonic() + KILL_GRACE_SECONDS
+    while time.monotonic() < deadline and group_exists(process_group):
+        time.sleep(min(0.05, deadline - time.monotonic()))
+
+
+def shell_status(returncode: int) -> int:
+    """Map a signal termination to the status a shell would report."""
+    if returncode < 0:
+        return 128 + (-returncode)
+    return returncode
+
+
+def write_timeout_marker(path: str) -> None:
+    try:
+        with open(path, "w", encoding="ascii") as marker:
+            marker.write("timed out\n")
+    except OSError:
+        # The timeout status remains authoritative even if diagnostic plumbing
+        # cannot be recorded.  The wrapper still emits its generic failure.
+        pass
+
+
+def reap_after_termination(process: subprocess.Popen) -> None:
+    """Reap the leader without allowing cleanup to become unbounded."""
+    try:
+        process.wait(timeout=KILL_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        pass
+
+
+def wait_for_process(
+    process: subprocess.Popen, seconds: float, pending_signal: List[Optional[int]]
+) -> Optional[int]:
+    """Wait in short intervals so wrapper cancellation is handled promptly."""
+    deadline = time.monotonic() + seconds
+    while True:
+        if pending_signal[0] is not None:
+            return None
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            # The deadline is a race boundary. A child that completed at the
+            # same instant must keep its real status and must not be marked as
+            # a timeout or killed.
+            completed = process.poll()
+            if completed is not None:
+                return completed
+            try:
+                return process.wait(timeout=0)
+            except subprocess.TimeoutExpired:
+                return None
+        try:
+            return process.wait(timeout=min(remaining, 0.1))
+        except subprocess.TimeoutExpired:
+            continue
+
+
+def run(seconds: float, marker: str, command: list[str]) -> int:
+    pending_signal: List[Optional[int]] = [None]
+
+    def handle_signal(signum: int, _frame: object) -> None:
+        if pending_signal[0] is None:
+            pending_signal[0] = signum
+
+    old_handlers = {
+        signum: signal.signal(signum, handle_signal)
+        for signum in (signal.SIGINT, signal.SIGTERM)
+    }
+    try:
+        # start_new_session creates a new session and process group on both
+        # supported hosts (stock macOS and Linux).  The group is what makes
+        # timeout cleanup include compiler children and other descendants.
+        process = subprocess.Popen(command, start_new_session=True)
+    except FileNotFoundError:
+        for signum, handler in old_handlers.items():
+            signal.signal(signum, handler)
+        return 127
+    except PermissionError:
+        for signum, handler in old_handlers.items():
+            signal.signal(signum, handler)
+        return 126
+    except OSError as error:
+        print("corpus-timeout: cannot start command: {}".format(error), file=sys.stderr)
+        for signum, handler in old_handlers.items():
+            signal.signal(signum, handler)
+        return 1
+
+    try:
+        result = wait_for_process(process, seconds, pending_signal)
+        if pending_signal[0] is not None:
+            terminate_group(process, pending_signal[0])
+            reap_after_termination(process)
+            return 128 + pending_signal[0]
+        if result is not None:
+            return shell_status(result)
+
+        terminate_group(process)
+        reap_after_termination(process)
+        write_timeout_marker(marker)
+        return 124
+    finally:
+        for signum, handler in old_handlers.items():
+            signal.signal(signum, handler)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 4:
+        return usage()
+    try:
+        seconds = parse_seconds(argv[1])
+    except ValueError as error:
+        print("corpus-timeout: {}".format(error), file=sys.stderr)
+        return 2
+    return run(seconds, argv[2], argv[3:])
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/test-corpus-action.sh
+++ b/scripts/test-corpus-action.sh
@@ -18,6 +18,7 @@ else
     SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 fi
 CORPUS_ACTION="$SCRIPTS_DIR/corpus-action"
+TIMEOUT_RUNNER="$SCRIPTS_DIR/corpus-timeout.py"
 
 failures=0
 tests=0
@@ -35,6 +36,66 @@ sandbox() {
     mktemp -d "${TMPDIR:-/tmp}/rue-corpus-action-test.XXXXXX"
 }
 
+pid_is_running() {
+    local pid state
+    pid="$1"
+    state="$(ps -p "$pid" -o stat= 2>/dev/null | tr -d '[:space:]')"
+    case "$state" in
+        ""|Z*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+wait_pid_gone() {
+    local pid attempts
+    pid="$1"
+    attempts=0
+    while [ "$attempts" -lt 40 ]; do
+        if ! pid_is_running "$pid"; then
+            return 0
+        fi
+        sleep 0.1
+        attempts=$((attempts + 1))
+    done
+    return 1
+}
+
+wait_for_file() {
+    local path attempts
+    path="$1"
+    attempts=0
+    while [ "$attempts" -lt 40 ]; do
+        if [ -s "$path" ]; then
+            return 0
+        fi
+        sleep 0.1
+        attempts=$((attempts + 1))
+    done
+    return 1
+}
+
+cleanup_recorded_processes() {
+    local dir pid
+    dir="$1"
+    for path in "$dir/group.pid" "$dir/child.pid" "$dir/grandchild.pid"; do
+        if [ -s "$path" ]; then
+            pid="$(cat "$path")"
+            kill -KILL "$pid" 2>/dev/null || true
+        fi
+    done
+    if [ -s "$dir/group.pid" ]; then
+        pid="$(cat "$dir/group.pid")"
+        kill -KILL "-$pid" 2>/dev/null || true
+    fi
+}
+
+cleanup_fixture() {
+    local dir
+    dir="$1"
+    cleanup_recorded_processes "$dir"
+    rm -rf "$dir"
+}
+
 # A harness that passes writes a stamp.
 t_success() {
     local dir stamp status
@@ -42,7 +103,7 @@ t_success() {
     printf '#!/usr/bin/env bash\nexit 0\n' >"$dir/harness"
     chmod +x "$dir/harness"
     stamp="$dir/stamp.txt"
-    (cd "$dir" && "$CORPUS_ACTION" "$stamp" ./harness >/dev/null 2>&1)
+    (cd "$dir" && "$CORPUS_ACTION" "$stamp" ./harness --timeout-runner "$TIMEOUT_RUNNER" -- >/dev/null 2>&1)
     status=$?
     check "passing harness exits 0" "0" "$status"
     check "passing harness writes a stamp" "yes" "$([ -s "$stamp" ] && echo yes || echo no)"
@@ -57,7 +118,7 @@ t_failure_writes_no_stamp() {
     printf '#!/usr/bin/env bash\nexit 3\n' >"$dir/harness"
     chmod +x "$dir/harness"
     stamp="$dir/stamp.txt"
-    (cd "$dir" && "$CORPUS_ACTION" "$stamp" ./harness >/dev/null 2>&1)
+    (cd "$dir" && "$CORPUS_ACTION" "$stamp" ./harness --timeout-runner "$TIMEOUT_RUNNER" -- >/dev/null 2>&1)
     status=$?
     check "failing harness propagates its status" "3" "$status"
     check "failing harness writes no stamp" "no" "$([ -e "$stamp" ] && echo yes || echo no)"
@@ -79,7 +140,7 @@ t_absolutize() {
             OBSERVED="$dir/observed" \
                 RUE_TEST_CASES="cases" \
                 RUE_CORPUS_ABSOLUTIZE="RUE_TEST_CASES" \
-                "$CORPUS_ACTION" "$dir/stamp.txt" ./harness >/dev/null 2>&1
+                "$CORPUS_ACTION" "$dir/stamp.txt" ./harness --timeout-runner "$TIMEOUT_RUNNER" -- >/dev/null 2>&1
     )
     status=$?
     observed="$(cat "$dir/observed" 2>/dev/null)"
@@ -104,7 +165,7 @@ t_absolutize_declared_output() {
             OBSERVED="$dir/observed" \
                 RUE_CLI_CASE_TIMINGS="out/case-timings.jsonl" \
                 RUE_CORPUS_ABSOLUTIZE="RUE_CLI_CASE_TIMINGS" \
-                "$CORPUS_ACTION" "$dir/stamp.txt" ./harness >/dev/null 2>&1
+                "$CORPUS_ACTION" "$dir/stamp.txt" ./harness --timeout-runner "$TIMEOUT_RUNNER" -- >/dev/null 2>&1
     )
     status=$?
     observed="$(cat "$dir/observed" 2>/dev/null)"
@@ -127,7 +188,7 @@ t_missing_absolutize_target_fails() {
     (
         cd "$dir" &&
             RUE_CORPUS_ABSOLUTIZE="RUE_NOT_SET_ANYWHERE" \
-                "$CORPUS_ACTION" "$dir/stamp.txt" ./harness >/dev/null 2>&1
+                "$CORPUS_ACTION" "$dir/stamp.txt" ./harness --timeout-runner "$TIMEOUT_RUNNER" -- >/dev/null 2>&1
     )
     status=$?
     check "unset absolutize target fails" "2" "$status"
@@ -146,7 +207,7 @@ t_plumbing_is_hidden() {
             OBSERVED="$dir/observed" \
                 RUE_CORPUS_ABSOLUTIZE="" \
                 RUE_CORPUS_TIMEOUT_SECONDS="60" \
-                "$CORPUS_ACTION" "$dir/stamp.txt" ./harness >/dev/null 2>&1
+                "$CORPUS_ACTION" "$dir/stamp.txt" ./harness --timeout-runner "$TIMEOUT_RUNNER" -- >/dev/null 2>&1
     )
     observed="$(cat "$dir/observed" 2>/dev/null)"
     check "plumbing variables are unset for the harness" "unset|unset" "$observed"
@@ -154,25 +215,122 @@ t_plumbing_is_hidden() {
 }
 
 # A wedged harness is bounded, and a timeout is a failure, so no stamp is
-# written and the timed-out result is never cached.
+# written and the timed-out result is never cached. This invokes the same
+# source helper that the Buck `python_bootstrap_binary` wraps, so the check
+# exercises the macOS path even though GNU timeout is not installed here.
 t_timeout() {
-    local dir status
+    local dir status output started finished elapsed
     dir="$(sandbox)"
-    if ! command -v timeout >/dev/null 2>&1; then
-        echo "skip: no timeout(1) on this host"
-        return
-    fi
-    printf '#!/usr/bin/env bash\nsleep 30\n' >"$dir/harness"
+    printf '#!/usr/bin/env bash\nwhile :; do sleep 1; done\n' >"$dir/harness"
     chmod +x "$dir/harness"
-    (
+    started="$(date +%s)"
+    output="$(
         cd "$dir" &&
             RUE_CORPUS_TIMEOUT_SECONDS=1 \
-                "$CORPUS_ACTION" "$dir/stamp.txt" ./harness >/dev/null 2>&1
-    )
+                "$CORPUS_ACTION" "$dir/stamp.txt" ./harness --timeout-runner "$TIMEOUT_RUNNER" -- 2>&1
+    )"
     status=$?
+    finished="$(date +%s)"
+    elapsed=$((finished - started))
     check "timed-out harness fails" "124" "$status"
     check "timed-out harness writes no stamp" "no" "$([ -e "$dir/stamp.txt" ] && echo yes || echo no)"
+    check "timed-out harness reports the focused diagnostic" \
+        "yes" "$(case "$output" in *"corpus harness exceeded 1s"*) echo yes ;; *) echo no ;; esac)"
+    check "timed-out harness is bounded" "yes" "$([ "$elapsed" -le 5 ] && echo yes || echo no)"
     rm -rf "$dir"
+}
+
+# An ordinary exit 124 is still an ordinary harness result, not a timeout.
+# The private marker keeps the focused timeout diagnostic specific.
+t_exit_124_is_not_timeout() {
+    local dir status output
+    dir="$(sandbox)"
+    printf '#!/usr/bin/env bash\nexit 124\n' >"$dir/harness"
+    chmod +x "$dir/harness"
+    output="$(
+        cd "$dir" &&
+            RUE_CORPUS_TIMEOUT_SECONDS=5 \
+                "$CORPUS_ACTION" "$dir/stamp.txt" ./harness --timeout-runner "$TIMEOUT_RUNNER" -- 2>&1
+    )" || status=$?
+    status="${status:-0}"
+    check "ordinary exit 124 is preserved" "124" "$status"
+    check "ordinary exit 124 has no timeout diagnostic" \
+        "no" "$(case "$output" in *"corpus harness exceeded"*) echo yes ;; *) echo no ;; esac)"
+    check "ordinary exit 124 writes no stamp" "no" "$([ -e "$dir/stamp.txt" ] && echo yes || echo no)"
+    rm -rf "$dir"
+}
+
+# TERM-ignoring descendants must be killed with the harness process group.
+t_timeout_kills_descendants() {
+    local dir status group_pid child_pid grandchild_pid output
+    dir="$(sandbox)"
+    printf '#!/usr/bin/env bash\nprintf "%%s" "$$" > "$GROUP_PID_FILE"\n(\n    ( trap "" TERM; while :; do sleep 1; done ) &\n    printf "%%s" "$!" > "$GRANDCHILD_PID_FILE"\n    trap "" TERM\n    while :; do sleep 1; done\n) &\nprintf "%%s" "$!" > "$CHILD_PID_FILE"\ntrap "" TERM\nwhile :; do sleep 1; done\n' >"$dir/harness"
+    chmod +x "$dir/harness"
+    output="$(
+        cd "$dir" &&
+            GROUP_PID_FILE="$dir/group.pid" CHILD_PID_FILE="$dir/child.pid" \
+                GRANDCHILD_PID_FILE="$dir/grandchild.pid" RUE_CORPUS_TIMEOUT_SECONDS=1 \
+                "$CORPUS_ACTION" "$dir/stamp.txt" ./harness --timeout-runner "$TIMEOUT_RUNNER" -- 2>&1
+    )" || status=$?
+    status="${status:-0}"
+    group_pid="$(cat "$dir/group.pid" 2>/dev/null)"
+    child_pid="$(cat "$dir/child.pid" 2>/dev/null)"
+    grandchild_pid="$(cat "$dir/grandchild.pid" 2>/dev/null)"
+    check "TERM-ignoring harness times out" "124" "$status"
+    check "TERM-ignoring process group is recorded" "yes" "$([ -n "$group_pid" ] && echo yes || echo no)"
+    check "TERM-ignoring child is killed" "yes" \
+        "$([ -n "$child_pid" ] && wait_pid_gone "$child_pid" && echo yes || echo no)"
+    check "TERM-ignoring grandchild is killed" "yes" \
+        "$([ -n "$grandchild_pid" ] && wait_pid_gone "$grandchild_pid" && echo yes || echo no)"
+    check "TERM-ignoring process group is gone" "yes" \
+        "$([ -n "$group_pid" ] && wait_pid_gone "$group_pid" && echo yes || echo no)"
+    check "forced cleanup retains focused diagnostic" \
+        "yes" "$(case "$output" in *"corpus harness exceeded 1s"*) echo yes ;; *) echo no ;; esac)"
+    cleanup_fixture "$dir"
+}
+
+# Signalling only corpus-action must be forwarded to the Python runner. The
+# runner then cleans the entire harness group before the wrapper returns 143.
+t_wrapper_cancellation() {
+    local dir status action_pid group_pid child_pid grandchild_pid output
+    dir="$(sandbox)"
+    printf '#!/usr/bin/env bash\nprintf "%%s" "$$" > "$GROUP_PID_FILE"\n(\n    ( trap "" TERM INT; while :; do sleep 1; done ) &\n    printf "%%s" "$!" > "$GRANDCHILD_PID_FILE"\n    trap "" TERM INT\n    while :; do sleep 1; done\n) &\nprintf "%%s" "$!" > "$CHILD_PID_FILE"\ntrap "" TERM INT\nwhile :; do sleep 1; done\n' >"$dir/harness"
+    chmod +x "$dir/harness"
+    GROUP_PID_FILE="$dir/group.pid" CHILD_PID_FILE="$dir/child.pid" \
+        GRANDCHILD_PID_FILE="$dir/grandchild.pid" RUE_CORPUS_TIMEOUT_SECONDS=30 \
+        "$CORPUS_ACTION" "$dir/stamp.txt" "$dir/harness" --timeout-runner "$TIMEOUT_RUNNER" -- \
+        >"$dir/output" 2>&1 &
+    action_pid=$!
+
+    if ! wait_for_file "$dir/group.pid" || ! wait_for_file "$dir/grandchild.pid"; then
+        check "cancellable harness records its process group" "yes" "no"
+        kill -TERM "$action_pid" 2>/dev/null || true
+        wait "$action_pid" 2>/dev/null || true
+        cleanup_fixture "$dir"
+        return
+    fi
+    kill -TERM "$action_pid" 2>/dev/null || true
+    # The harness ignores TERM, so runner cleanup remains active long enough
+    # for this second signal to exercise the wrapper's signal-immune reap.
+    sleep 0.1
+    kill -TERM "$action_pid" 2>/dev/null || true
+    wait "$action_pid" 2>/dev/null
+    status=$?
+    output="$(cat "$dir/output" 2>/dev/null)"
+    group_pid="$(cat "$dir/group.pid" 2>/dev/null)"
+    child_pid="$(cat "$dir/child.pid" 2>/dev/null)"
+    grandchild_pid="$(cat "$dir/grandchild.pid" 2>/dev/null)"
+    check "repeated wrapper cancellation returns SIGTERM status" "143" "$status"
+    check "wrapper cancellation removes the stamp" "no" "$([ -e "$dir/stamp.txt" ] && echo yes || echo no)"
+    check "wrapper cancellation removes the harness" "yes" \
+        "$([ -n "$group_pid" ] && wait_pid_gone "$group_pid" && echo yes || echo no)"
+    check "wrapper cancellation removes the child" "yes" \
+        "$([ -n "$child_pid" ] && wait_pid_gone "$child_pid" && echo yes || echo no)"
+    check "wrapper cancellation removes the grandchild" "yes" \
+        "$([ -n "$grandchild_pid" ] && wait_pid_gone "$grandchild_pid" && echo yes || echo no)"
+    check "wrapper cancellation has no timeout diagnostic" \
+        "no" "$(case "$output" in *"corpus harness exceeded"*) echo yes ;; *) echo no ;; esac)"
+    cleanup_fixture "$dir"
 }
 
 t_usage() {
@@ -189,6 +347,9 @@ t_absolutize_declared_output
 t_missing_absolutize_target_fails
 t_plumbing_is_hidden
 t_timeout
+t_exit_124_is_not_timeout
+t_timeout_kills_descendants
+t_wrapper_cancellation
 t_usage
 
 if [ "$failures" -ne 0 ]; then


### PR DESCRIPTION
## Summary

- replace host PATH discovery of `timeout` with a declared, cache-keyed Python runner
- terminate and reap the complete harness process group on timeout or action cancellation
- distinguish real timeouts from ordinary exit 124 and cover deadline and repeated-signal races

## Validation

- `scripts/test-corpus-action.sh` (32 checks)
- `./buck2 test //:corpus-action-tests`
- `scripts/rue premerge` (196 targets)
- Python 3.9 and Bash 3.2 baseline validators
- independent adversarial review

Fixes RUE-1742