### PR TITLE
RUE-1543: gate on every declared baseline resolving, retired epochs included

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -653,6 +653,16 @@ jobs:
             git reset --quiet
           fi
           echo "reading $(wc -l < "$SELECTED") record(s) from the live epoch"
+          # Baseline resolution is asked here rather than in the derived data,
+          # because the selection above deliberately excludes retired epochs and
+          # a retired epoch's baseline is exactly the one whose loss is silent:
+          # `derive` publishes no index and no ratios while still plotting every
+          # series, and `unindexed()` iterates live epochs only. index.json is
+          # already checked out, so this covers every epoch for one pass over a
+          # file the step is holding anyway.
+          "$BENCH" check-baselines \
+            --manifest performance/manifest.toml \
+            --index "$DATA/index.json"
           DERIVED="$(mktemp)"
           "$BENCH" derive \
             --manifest performance/manifest.toml \

--- a/crates/rue-bench/src/check_baselines.rs
+++ b/crates/rue-bench/src/check_baselines.rs
@@ -1,0 +1,281 @@
+//! Answer "does every declared baseline still name a record that exists?".
+//!
+//! `derive` resolves an epoch's baseline by address among that epoch's own
+//! records (`derive.rs:1316`). A miss is not an error there: the epoch simply
+//! publishes no index and no workload ratios while still plotting every
+//! per-workload series, so the dashboard keeps moving and loses the one number
+//! it exists to publish. `validate-performance-stall.py`'s `unindexed()` gate
+//! reports exactly that — but only for the epoch holding each platform's newest
+//! point.
+//!
+//! That gate cannot be extended to cover a retired epoch by editing it, because
+//! the records are not there to inspect. `staleness-inputs` selects the live
+//! epoch alone before `derive` runs (RUE-1542), so a retired epoch's records
+//! are never materialized into the gate's data root. Selecting every epoch that
+//! declares a baseline would restore the cost RUE-1542 removed: on
+//! 2026-08-18 that is 1,437 of 1,440 records, against the 321 the gate reads
+//! now.
+//!
+//! So the question is asked where it is cheap and total instead. Baseline
+//! resolution needs no derived data and no run object — only the manifest and
+//! `index.json`, which the gate has already checked out to decide what to read.
+//! This covers every epoch, live or retired, at the cost of one pass over an
+//! index the step holds anyway.
+//!
+//! The check is deliberately stricter than "the address exists somewhere". A
+//! baseline must be a record of its own epoch and platform, because that is
+//! what `derive` requires: an address that resolves under a different epoch
+//! resolves to nothing where it is looked up, and would otherwise pass a
+//! whole-store existence test while still publishing no index.
+
+use std::path::{Path, PathBuf};
+
+use rue_perf_schema::Manifest;
+
+use crate::staleness_inputs::{Index, parse_index};
+
+/// One epoch whose declared baseline does not resolve to a record of that epoch.
+#[derive(Debug, PartialEq, Eq)]
+pub struct UnresolvedBaseline {
+    pub platform: String,
+    pub epoch: u32,
+    /// The address the manifest declares.
+    pub run: String,
+    /// Why it did not resolve, in the words the report prints.
+    pub detail: String,
+}
+
+/// Compare every declared baseline against the index.
+///
+/// Pure, so the rule is testable without a checkout or a data branch. Epochs
+/// with no baseline are skipped rather than reported: declaring an epoch before
+/// its first complete run is the documented state, and `unpinned` is what holds
+/// that state to a deadline.
+pub fn unresolved(manifest: &Manifest, index: &Index) -> Vec<UnresolvedBaseline> {
+    let mut missing = Vec::new();
+    for epoch in manifest.epochs() {
+        let Some(baseline) = epoch.baseline.as_ref() else {
+            continue;
+        };
+        let entry = index.runs.iter().find(|entry| entry.run == baseline.run);
+        let detail = match entry {
+            None => Some("no record in index.json carries this address".to_string()),
+            Some(entry) if entry.platform != epoch.platform || entry.epoch != epoch.id => {
+                Some(format!(
+                    "the record is {}'s epoch {}, not {}'s epoch {}",
+                    entry.platform, entry.epoch, epoch.platform, epoch.id
+                ))
+            }
+            Some(_) => None,
+        };
+        if let Some(detail) = detail {
+            missing.push(UnresolvedBaseline {
+                platform: epoch.platform.clone(),
+                epoch: epoch.id,
+                run: baseline.run.clone(),
+                detail,
+            });
+        }
+    }
+    missing
+}
+
+pub fn run() -> Result<u8, String> {
+    let mut manifest_path: Option<PathBuf> = None;
+    let mut index_path: Option<PathBuf> = None;
+    let mut args = std::env::args().skip(2);
+    while let Some(flag) = args.next() {
+        let mut value = || {
+            args.next()
+                .ok_or_else(|| format!("{flag} requires a value"))
+        };
+        match flag.as_str() {
+            "--manifest" => manifest_path = Some(PathBuf::from(value()?)),
+            "--index" => index_path = Some(PathBuf::from(value()?)),
+            other => return Err(format!("unrecognized argument {other:?}")),
+        }
+    }
+    let manifest_path = manifest_path.ok_or("check-baselines requires --manifest <path>")?;
+    let index_path = index_path.ok_or("check-baselines requires --index <path>")?;
+    report(&manifest_path, &index_path, &mut std::io::stdout())
+}
+
+fn report(
+    manifest_path: &Path,
+    index_path: &Path,
+    out: &mut impl std::io::Write,
+) -> Result<u8, String> {
+    let manifest_text = std::fs::read_to_string(manifest_path)
+        .map_err(|error| format!("could not read {}: {error}", manifest_path.display()))?;
+    let manifest = Manifest::parse(&manifest_text).map_err(|error| error.to_string())?;
+
+    // A missing index is a corrupt data branch here, not a first collection:
+    // the caller checked the branch out to reach this point. Tolerating it
+    // would pass the gate in exactly the state it exists to report.
+    let index_text = std::fs::read_to_string(index_path)
+        .map_err(|error| format!("could not read {}: {error}", index_path.display()))?;
+    let index = parse_index(&index_text)?;
+
+    let missing = unresolved(&manifest, &index);
+    let declared = manifest
+        .epochs()
+        .filter(|epoch| epoch.baseline.is_some())
+        .count();
+    if missing.is_empty() {
+        writeln!(out, "{declared} declared baseline(s) resolve")
+            .map_err(|error| format!("could not write the report: {error}"))?;
+        return Ok(crate::exit::OK);
+    }
+    for item in &missing {
+        writeln!(
+            out,
+            "{} epoch {}: baseline {} does not resolve — {}",
+            item.platform, item.epoch, item.run, item.detail
+        )
+        .map_err(|error| format!("could not write the report: {error}"))?;
+    }
+    writeln!(
+        out,
+        "{} of {declared} declared baseline(s) do not resolve; \
+         the epoch publishes no index and no workload ratios",
+        missing.len()
+    )
+    .map_err(|error| format!("could not write the report: {error}"))?;
+    Ok(crate::exit::NOT_APPENDABLE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The shape `derive`'s own tests use, so the fixture cannot drift from
+    // what the manifest parser actually requires.
+    const BASE: &str = r#"
+[[suite]]
+revision = 1
+timing_schema_version = 1
+protocol_version = 1
+
+[[suite.workloads]]
+id = "startup"
+source = "performance/workloads/startup/main.rue"
+question = "What does a minimal fresh compilation cost end to end?"
+
+[[epoch]]
+id = 1
+collection = true
+platform = "x86_64-linux"
+suite_revision = 1
+target = "x86_64-unknown-linux-gnu"
+args = []
+toolchain_hash = "toolchain"
+
+[epoch.workload_source_hashes]
+startup = "startup-hash"
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+[epoch.sampling.startup]
+samples = 3
+batch_size = 1
+
+[epoch.flagging]
+k = 2.0
+window = 3
+"#;
+
+    fn manifest_with(baseline: Option<(&str, &str)>) -> Manifest {
+        let text = match baseline {
+            None => BASE.to_string(),
+            Some((commit, run)) => {
+                format!("{BASE}\n[epoch.baseline]\ncommit = \"{commit}\"\nrun = \"{run}\"\n")
+            }
+        };
+        Manifest::parse(&text).expect("manifest parses")
+    }
+
+    fn index_with(entries: &[(&str, u32, &str)]) -> Index {
+        let runs: Vec<String> = entries
+            .iter()
+            .map(|(platform, epoch, run)| {
+                format!(
+                    r#"{{"platform":"{platform}","epoch":{epoch},"finished_at":"2026-08-18T00:00:00Z","run":"{run}"}}"#
+                )
+            })
+            .collect();
+        parse_index(&format!(r#"{{"runs":[{}]}}"#, runs.join(","))).expect("index parses")
+    }
+
+    #[test]
+    fn a_baseline_present_in_its_own_epoch_resolves() {
+        let manifest = manifest_with(Some(("c0", "abc")));
+        let index = index_with(&[("x86_64-linux", 1, "abc")]);
+        assert_eq!(unresolved(&manifest, &index), Vec::new());
+    }
+
+    #[test]
+    fn an_epoch_without_a_baseline_is_not_reported() {
+        // Declaring an epoch before its first complete run is the documented
+        // state; `unpinned` holds it to a deadline, not this rule.
+        let manifest = manifest_with(None);
+        let index = index_with(&[]);
+        assert_eq!(unresolved(&manifest, &index), Vec::new());
+    }
+
+    #[test]
+    fn a_baseline_naming_no_record_is_reported() {
+        // The compaction's characteristic mistake: the manifest keeps a
+        // pre-compaction address that no longer names anything.
+        let manifest = manifest_with(Some(("c0", "gone")));
+        let index = index_with(&[("x86_64-linux", 1, "abc")]);
+        let missing = unresolved(&manifest, &index);
+        assert_eq!(missing.len(), 1);
+        assert_eq!(missing[0].run, "gone");
+        assert!(
+            missing[0].detail.contains("no record in index.json"),
+            "unexpected detail: {}",
+            missing[0].detail
+        );
+    }
+
+    #[test]
+    fn a_baseline_resolving_under_another_epoch_is_reported() {
+        // Existence somewhere in the store is not resolution: `derive` looks
+        // the address up among its own epoch's records and finds nothing.
+        let manifest = manifest_with(Some(("c0", "abc")));
+        let index = index_with(&[("x86_64-linux", 2, "abc")]);
+        let missing = unresolved(&manifest, &index);
+        assert_eq!(missing.len(), 1);
+        assert!(
+            missing[0].detail.contains("epoch 2"),
+            "unexpected detail: {}",
+            missing[0].detail
+        );
+    }
+
+    #[test]
+    fn a_baseline_resolving_under_another_platform_is_reported() {
+        let manifest = manifest_with(Some(("c0", "abc")));
+        let index = index_with(&[("aarch64-macos", 1, "abc")]);
+        let missing = unresolved(&manifest, &index);
+        assert_eq!(missing.len(), 1);
+        assert!(
+            missing[0].detail.contains("aarch64-macos"),
+            "unexpected detail: {}",
+            missing[0].detail
+        );
+    }
+
+    #[test]
+    fn a_retired_epoch_is_checked_the_same_as_a_live_one() {
+        // The whole point: `collection = false` puts an epoch outside
+        // `unindexed()`'s reach, and inside this one's.
+        let retired = BASE.replace("collection = true", "collection = false");
+        let text = format!("{retired}\n[epoch.baseline]\ncommit = \"c0\"\nrun = \"gone\"\n");
+        let manifest = Manifest::parse(&text).expect("manifest parses");
+        let index = index_with(&[("x86_64-linux", 1, "abc")]);
+        assert_eq!(unresolved(&manifest, &index).len(), 1);
+    }
+}

--- a/crates/rue-bench/src/check_baselines.rs
+++ b/crates/rue-bench/src/check_baselines.rs
@@ -13,8 +13,8 @@
 //! epoch alone before `derive` runs (RUE-1542), so a retired epoch's records
 //! are never materialized into the gate's data root. Selecting every epoch that
 //! declares a baseline would restore the cost RUE-1542 removed: on
-//! 2026-08-18 that is 1,437 of 1,440 records, against the 321 the gate reads
-//! now.
+//! 2026-08-18 that was 1,437 of 1,440 records, against the 321 the gate read
+//! then.
 //!
 //! So the question is asked where it is cheap and total instead. Baseline
 //! resolution needs no derived data and no run object — only the manifest and
@@ -226,8 +226,9 @@ window = 3
 
     #[test]
     fn a_baseline_naming_no_record_is_reported() {
-        // The compaction's characteristic mistake: the manifest keeps a
-        // pre-compaction address that no longer names anything.
+        // A compaction or bulk re-pin's characteristic mistake (RUE-1543):
+        // the manifest keeps a pre-compaction address that no longer names
+        // anything.
         let manifest = manifest_with(Some(("c0", "gone")));
         let index = index_with(&[("x86_64-linux", 1, "abc")]);
         let missing = unresolved(&manifest, &index);
@@ -277,5 +278,67 @@ window = 3
         let manifest = Manifest::parse(&text).expect("manifest parses");
         let index = index_with(&[("x86_64-linux", 1, "abc")]);
         assert_eq!(unresolved(&manifest, &index).len(), 1);
+    }
+
+    #[test]
+    fn the_report_names_the_retired_epoch_and_exits_nonzero() {
+        // The compaction rehearsal, end to end through `report`: a live epoch
+        // whose pin resolves next to a retired epoch whose pin names a
+        // pre-compaction address. The run must exit `NOT_APPENDABLE` naming
+        // exactly the retired epoch — the one `unindexed()` cannot reach.
+        let mut text = format!("{BASE}\n[epoch.baseline]\ncommit = \"c0\"\nrun = \"live\"\n");
+        text.push_str(
+            r#"
+[[epoch]]
+id = 2
+collection = false
+platform = "x86_64-linux"
+suite_revision = 1
+target = "x86_64-unknown-linux-gnu"
+args = []
+toolchain_hash = "toolchain"
+
+[epoch.workload_source_hashes]
+startup = "startup-hash"
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+[epoch.sampling.startup]
+samples = 3
+batch_size = 1
+
+[epoch.flagging]
+k = 2.0
+window = 3
+
+[epoch.baseline]
+commit = "c1"
+run = "pre-compaction"
+"#,
+        );
+        let directory = tempfile::tempdir().expect("temp dir");
+        let manifest_path = directory.path().join("manifest.toml");
+        let index_path = directory.path().join("index.json");
+        std::fs::write(&manifest_path, &text).expect("write manifest");
+        std::fs::write(
+            &index_path,
+            r#"{"runs":[{"platform":"x86_64-linux","epoch":1,"finished_at":"2026-08-18T00:00:00Z","run":"live"}]}"#,
+        )
+        .expect("write index");
+
+        let mut output = Vec::new();
+        let code = report(&manifest_path, &index_path, &mut output).expect("report runs");
+        assert_eq!(code, crate::exit::NOT_APPENDABLE);
+        let output = String::from_utf8(output).expect("report is text");
+        assert!(
+            output.contains("x86_64-linux epoch 2: baseline pre-compaction does not resolve"),
+            "unexpected report: {output}"
+        );
+        assert!(
+            !output.contains("epoch 1:"),
+            "the resolving live pin must not be reported: {output}"
+        );
     }
 }

--- a/crates/rue-bench/src/main.rs
+++ b/crates/rue-bench/src/main.rs
@@ -18,6 +18,7 @@
 //! appendability — over its own manifest and record kind.
 
 mod calibrate;
+mod check_baselines;
 mod check_pins;
 mod derive;
 mod digest;
@@ -111,6 +112,13 @@ Subcommands:
                        point. Lets that gate check out and parse the live epoch
                        instead of the whole append-only history.
 
+  check-baselines --manifest <path> --index <path>
+                       answer whether every declared `[epoch.baseline] run`
+                       still names a record of its own epoch, reading only the
+                       manifest and index.json. Covers retired epochs, which
+                       `staleness-inputs` deliberately keeps out of the derived
+                       data. Exits 3 when one does not resolve.
+
   check-pins --manifest <path> --compiler <path> [--repo-root <path>]
                        answer whether this tree still matches every collection
                        epoch. Exits 3 on drift, which is the change stalling
@@ -199,6 +207,15 @@ fn main() -> ExitCode {
             Ok(()) => ExitCode::from(exit::OK),
             Err(message) => {
                 eprintln!("rue-bench staleness-inputs: {message}");
+                ExitCode::from(exit::USAGE)
+            }
+        };
+    }
+    if std::env::args().nth(1).as_deref() == Some("check-baselines") {
+        return match check_baselines::run() {
+            Ok(status) => ExitCode::from(status),
+            Err(message) => {
+                eprintln!("rue-bench check-baselines: {message}");
                 ExitCode::from(exit::USAGE)
             }
         };

--- a/crates/rue-bench/src/staleness_inputs.rs
+++ b/crates/rue-bench/src/staleness_inputs.rs
@@ -42,19 +42,24 @@ use serde::Deserialize;
 /// Deliberately a subset. This names the fields the selection needs and lets
 /// serde ignore the rest, so a later index field cannot fail the gate.
 #[derive(Debug, Deserialize)]
-struct IndexEntry {
-    platform: String,
-    epoch: u32,
-    finished_at: String,
-    run: String,
+pub(crate) struct IndexEntry {
+    pub(crate) platform: String,
+    pub(crate) epoch: u32,
+    pub(crate) finished_at: String,
+    pub(crate) run: String,
 }
 
 #[derive(Debug, Deserialize)]
-struct Index {
+pub(crate) struct Index {
     /// Compiler runs (ADR-0067). The `runtime` list is deliberately not read:
     /// ADR-0072 Decision 9 keeps the runtime series out of this gate.
     #[serde(default)]
-    runs: Vec<IndexEntry>,
+    pub(crate) runs: Vec<IndexEntry>,
+}
+
+/// Parse `index.json`, naming the file in the error the way both readers want.
+pub(crate) fn parse_index(index_json: &str) -> Result<Index, String> {
+    serde_json::from_str(index_json).map_err(|error| format!("could not parse index.json: {error}"))
 }
 
 /// Return the data-branch paths the staleness gate needs, in a stable order.
@@ -63,8 +68,7 @@ struct Index {
 /// nothing on it is the honest first state of a suite that has not collected,
 /// and the gate reports that as "nothing to stall" rather than failing.
 pub fn select(index_json: &str) -> Result<Vec<String>, String> {
-    let index: Index = serde_json::from_str(index_json)
-        .map_err(|error| format!("could not parse index.json: {error}"))?;
+    let index = parse_index(index_json)?;
 
     // The newest entry per platform, and therefore the epoch to keep. Ties on
     // `finished_at` break on the content address so the choice is a function of

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -488,6 +488,10 @@ def validate(
         # job the run's long pole, and would again: the cost returns silently,
         # as a slow job rather than a failing one (RUE-1542).
         "staleness-inputs",
+        # A retired epoch's baseline is outside the derived data by design, so
+        # the resolution check is a separate responsibility of this job rather
+        # than a rule inside the stall script (RUE-1543).
+        "check-baselines",
     ):
         if required not in staleness:
             errors.append(f"performance-staleness responsibility missing {required!r}")


### PR DESCRIPTION
Refs RUE-1543. Split out of #2444 per the coordination note there: this is the independent integrity safeguard, separated from the ADR amendments so it can land without waiting on any policy ruling.

## The silent failure mode this closes

A wrong baseline address fails silently today — for a *retired* epoch. `derive` publishes no index and no ratios for the affected platform while still plotting every series, and `staleness-inputs` deliberately keeps retired epochs out of the data `derive` reads (RUE-1542), so `unindexed()` can never see the loss. Six of the nine declared baselines sit on retired epochs 2 and 5, squarely in that blind spot.

This exists independent of any compaction decision: a bad edit to `performance/manifest.toml` or a corrupted `index.json` entry hits it today. If #2444's append-based re-encode is later accepted, every address in the store moves and all nine pins get re-pinned — at which point this gate stops being merely useful and becomes the stated acceptance condition. It is deliberately mergeable first.

## Mechanism

`rue-bench check-baselines --manifest … --index …` resolves every baseline declared in the manifest against `index.json` — every epoch, retired included, requiring a record of the baseline's own epoch and platform, which is exactly where `derive` looks it up — and exits 3 naming the epoch on any failure. The CI staleness job runs it against the `index.json` it has already checked out (one pass over a file the step is holding anyway; the selection path stays narrowed per RUE-1542). `validate-ci-gate` pins the responsibility so it cannot be silently dropped from the workflow.

Index-level rather than selection-level on review guidance in #2444: selecting every baseline-bearing epoch into the derive input would restore the cost RUE-1542 removed — on 2026-08-18, 1,437 of 1,440 records against the 321 the gate then read; at `44b5d5164` (2026-08-23), 1,616 of 1,619 against 500.

## Verification

- Seven unit tests over the resolution rule (missing record, wrong epoch, wrong platform, retired epoch, no-baseline state) plus the report path end to end: a simulated compaction — live epoch resolving, retired epoch pinned to a pre-compaction address — exits `NOT_APPENDABLE` (3) naming exactly the retired epoch.
- Against the live store at `44b5d5164` (2026-08-23): 9/9 declared baselines resolve, exit 0.
- Full `rue-bench` suite: 165 passed, 2 ignored, 0 failed; `validate-ci-gate` and its test suite pass with the new responsibility under the RUE-1266 lane structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPBpmZU3DpwkumLHNwHsgu