### PR TITLE
RUE-1749: Revalidate watch inputs at publication

### DIFF
--- a/crates/rue/src/compile.rs
+++ b/crates/rue/src/compile.rs
@@ -1,8 +1,10 @@
 use rue_compiler::unstable::{CancellableCompileOutcome, CompilationCancellation, OneShotMetrics};
 use rue_compiler::{CompileErrors, CompileOptions, CompileWarning};
-use rue_driver::FilesystemCompilerHost;
+use rue_driver::{FilesystemCompilerHost, WatchInput};
 
-use crate::output::{PublicationDestination, PublishRequest, publish_executable};
+use crate::output::{
+    PublicationDestination, PublishRequest, publish_executable, publish_watch_executable,
+};
 
 /// Typed ownership boundary for the compile/link/publish operation.
 pub(crate) struct CompileRequest<'a> {
@@ -16,6 +18,7 @@ pub(crate) struct CancellableCompileRequest<'a> {
     pub(crate) options: CompileOptions,
     pub(crate) destination: PublicationDestination,
     pub(crate) cancellation: CompilationCancellation,
+    pub(crate) watch_inputs: Vec<WatchInput>,
 }
 
 pub(crate) enum CompileCycleOutcome {
@@ -30,6 +33,12 @@ pub(crate) struct LinkedExecutable {
     metrics: OneShotMetrics,
     linked_bytes: Vec<u8>,
     destination: PublicationDestination,
+    observation: PublicationObservation,
+}
+
+enum PublicationObservation {
+    OneShot,
+    Watch(Vec<WatchInput>),
 }
 
 pub(crate) struct PublishedExecutable {
@@ -51,6 +60,7 @@ pub(crate) fn execute(request: CompileRequest<'_>) -> Result<LinkedExecutable, C
         metrics,
         linked_bytes: output.elf,
         destination: request.destination,
+        observation: PublicationObservation::OneShot,
     })
 }
 
@@ -68,6 +78,7 @@ pub(crate) fn execute_cancellable(request: CancellableCompileRequest<'_>) -> Com
                 metrics,
                 linked_bytes: output.elf,
                 destination: request.destination,
+                observation: PublicationObservation::Watch(request.watch_inputs),
             }))
         }
         CancellableCompileOutcome::Errors(errors) => CompileCycleOutcome::Errors(errors),
@@ -78,16 +89,32 @@ pub(crate) fn execute_cancellable(request: CancellableCompileRequest<'_>) -> Com
 impl LinkedExecutable {
     /// Finalize and publish the linked bytes after compiler timing/accounting closes.
     pub(crate) fn publish(self) -> PublicationAttempt {
-        let publication = publish_executable(PublishRequest {
-            destination: self.destination,
-            bytes: &self.linked_bytes,
-            target: self.target,
-        });
-        PublicationAttempt {
-            warnings: self.warnings,
-            result: publication.map(|()| PublishedExecutable {
-                metrics: self.metrics,
+        let LinkedExecutable {
+            target,
+            warnings,
+            metrics,
+            linked_bytes,
+            destination,
+            observation,
+        } = self;
+        let publication = match observation {
+            PublicationObservation::OneShot => publish_executable(PublishRequest {
+                destination,
+                bytes: &linked_bytes,
+                target,
             }),
+            PublicationObservation::Watch(inputs) => publish_watch_executable(
+                PublishRequest {
+                    destination,
+                    bytes: &linked_bytes,
+                    target,
+                },
+                &inputs,
+            ),
+        };
+        PublicationAttempt {
+            warnings,
+            result: publication.map(|()| PublishedExecutable { metrics }),
         }
     }
 }

--- a/crates/rue/src/lib.rs
+++ b/crates/rue/src/lib.rs
@@ -11,4 +11,5 @@ mod source_loader;
 pub use host::{FilesystemCompilerHost, HostOpenRequest};
 pub use source_loader::{
     HermeticDenialError, SourceLoadError, ToolchainIntegrityError, WatchFingerprint, WatchInput,
+    watch_input_fingerprints, watch_inputs_changed, watch_inputs_changed_with_reader,
 };

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -2328,11 +2328,13 @@ mod tests {
                 host.source_snapshot().files().map(|source| source.path),
             )
             .unwrap();
+            let watch_inputs = host.watch_inputs();
             compile::execute_cancellable(compile::CancellableCompileRequest {
                 host,
                 options: options.clone(),
                 destination: publication,
                 cancellation: rue_compiler::unstable::CompilationCancellation::new(),
+                watch_inputs,
             })
         };
 

--- a/crates/rue/src/output.rs
+++ b/crates/rue/src/output.rs
@@ -4,6 +4,7 @@ use std::io::{self, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
+use rue_driver::{WatchInput, watch_inputs_changed};
 use rue_error::{CompileError, ErrorKind};
 use rue_target::Target;
 
@@ -18,12 +19,13 @@ pub(crate) struct PublishRequest<'a> {
 
 pub(crate) struct PublicationDestination {
     path: PathBuf,
-    source_paths: Vec<String>,
+    source_paths: Vec<PathBuf>,
 }
 
 #[derive(Debug)]
 pub(crate) enum PublishError {
     WouldClobberSource,
+    InputsChanged,
     Io {
         operation: &'static str,
         paths: Vec<PathBuf>,
@@ -49,6 +51,7 @@ impl PublishError {
             Self::WouldClobberSource => {
                 "output path is also an input source file; refusing to overwrite it".to_owned()
             }
+            Self::InputsChanged => "an accepted input changed before output publication".to_owned(),
             Self::Io {
                 operation,
                 paths,
@@ -112,9 +115,11 @@ fn output_would_clobber(
 fn validate_destination(destination: &PublicationDestination) -> Result<(), PublishError> {
     let output_key = clobber_key(&destination.path);
     let output_metadata = fs::metadata(&destination.path).ok();
-    if destination.source_paths.iter().any(|source| {
-        output_would_clobber(&output_key, output_metadata.as_ref(), Path::new(source))
-    }) {
+    if destination
+        .source_paths
+        .iter()
+        .any(|source| output_would_clobber(&output_key, output_metadata.as_ref(), source))
+    {
         return Err(PublishError::WouldClobberSource);
     }
     Ok(())
@@ -126,12 +131,31 @@ pub(crate) fn preflight_destination<'a>(
     path: &Path,
     source_paths: impl IntoIterator<Item = &'a str>,
 ) -> Result<PublicationDestination, PublishError> {
+    preflight_destination_paths(path, source_paths.into_iter().map(PathBuf::from))
+}
+
+fn preflight_destination_paths(
+    path: &Path,
+    source_paths: impl IntoIterator<Item = PathBuf>,
+) -> Result<PublicationDestination, PublishError> {
     let destination = PublicationDestination {
         path: path.to_owned(),
-        source_paths: source_paths.into_iter().map(str::to_owned).collect(),
+        source_paths: source_paths.into_iter().collect(),
     };
     validate_destination(&destination)?;
     Ok(destination)
+}
+
+pub(crate) fn preflight_watch_destination(
+    path: &Path,
+    inputs: &[WatchInput],
+) -> Result<PublicationDestination, PublishError> {
+    let source_paths = inputs
+        .iter()
+        .flat_map(|input| [input.requested_path(), input.canonical_path()])
+        .map(Path::to_owned)
+        .collect::<Vec<_>>();
+    preflight_destination_paths(path, source_paths)
 }
 
 struct PendingOutput(PathBuf);
@@ -217,9 +241,32 @@ pub(crate) fn publish_executable(request: PublishRequest<'_>) -> Result<(), Publ
     publish_executable_with_finalizer(request, finalize_executable)
 }
 
+/// Publish a watch candidate only if the accepted source observations still
+/// hold at the final publication boundary.
+pub(crate) fn publish_watch_executable(
+    request: PublishRequest<'_>,
+    inputs: &[WatchInput],
+) -> Result<(), PublishError> {
+    publish_executable_with_finalizer_and_observation(
+        request,
+        Some(inputs),
+        finalize_executable,
+        || {},
+    )
+}
+
 fn publish_executable_with_finalizer(
     request: PublishRequest<'_>,
     finalizer: impl FnOnce(&Path, Target) -> Result<(), PublishError>,
+) -> Result<(), PublishError> {
+    publish_executable_with_finalizer_and_observation(request, None, finalizer, || {})
+}
+
+fn publish_executable_with_finalizer_and_observation(
+    request: PublishRequest<'_>,
+    watch_inputs: Option<&[WatchInput]>,
+    finalizer: impl FnOnce(&Path, Target) -> Result<(), PublishError>,
+    before_rename: impl FnOnce(),
 ) -> Result<(), PublishError> {
     validate_destination(&request.destination)?;
     let destination = &request.destination.path;
@@ -241,6 +288,22 @@ fn publish_executable_with_finalizer(
     drop(file);
 
     finalizer(&pending.0, request.target)?;
+
+    // The hook is used only by deterministic unit tests to mutate an input in
+    // the narrow window this check protects: after finalization/signing and
+    // before the atomic replacement.
+    before_rename();
+    // The destination may have become an alias of an input while the
+    // candidate was being finalized. Check it at the same boundary as the
+    // accepted-input observations, before the atomic replacement.
+    let destination_error = validate_destination(&request.destination).err();
+    let all_inputs_changed = watch_inputs.is_some_and(watch_inputs_changed);
+    if let Some(error) = destination_error {
+        return Err(error);
+    }
+    if all_inputs_changed {
+        return Err(PublishError::InputsChanged);
+    }
 
     replace_destination(&pending.0, destination).map_err(|error| {
         PublishError::io(
@@ -371,6 +434,63 @@ mod tests {
         ));
         assert_eq!(fs::read(&destination).unwrap(), b"old executable");
         assert_eq!(fs::read_dir(&directory).unwrap().count(), 1);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn changed_accepted_input_at_final_boundary_preserves_destination() {
+        let directory = temporary_directory("publish-input-change");
+        let source = directory.join("main.rue");
+        let destination = directory.join("program");
+        fs::write(&source, b"old source").unwrap();
+        fs::write(&destination, b"old executable").unwrap();
+        let publication_destination =
+            preflight_destination(&destination, [source.to_str().unwrap()]).unwrap();
+        let watch_inputs = vec![WatchInput::new(
+            source.clone(),
+            source.clone(),
+            rue_driver::WatchFingerprint::from_bytes(b"old source"),
+        )];
+
+        let result = publish_executable_with_finalizer_and_observation(
+            PublishRequest {
+                destination: publication_destination,
+                bytes: b"new executable",
+                target: Target::X86_64Linux,
+            },
+            Some(&watch_inputs),
+            |temporary, _target| {
+                fs::metadata(temporary).unwrap();
+                Ok(())
+            },
+            || fs::write(&source, b"new source").unwrap(),
+        );
+
+        assert!(matches!(result, Err(PublishError::InputsChanged)));
+        assert_eq!(fs::read(&destination).unwrap(), b"old executable");
+        assert_eq!(fs::read_dir(&directory).unwrap().count(), 2);
+        assert!(fs::read_dir(&directory).unwrap().all(|entry| {
+            !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".program.rue-tmp-")
+        }));
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn watch_preflight_refuses_an_expected_absence_output_collision() {
+        let directory = temporary_directory("watch-absence-clobber");
+        let destination = directory.join("candidate.rue");
+        let inputs = vec![WatchInput::expected_absence(destination.clone())];
+
+        assert!(matches!(
+            preflight_watch_destination(&destination, &inputs),
+            Err(PublishError::WouldClobberSource)
+        ));
+        assert!(!destination.exists());
         fs::remove_dir_all(directory).unwrap();
     }
 

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -109,6 +109,59 @@ impl WatchInput {
     }
 }
 
+/// Report whether any accepted filesystem observation has changed.
+///
+/// Requested aliases, canonical targets, and expected-absence probes are all
+/// part of the observation. Canonical fingerprints are read once for aliased
+/// inputs so polling and publication share the same filesystem semantics.
+pub fn watch_inputs_changed(inputs: &[WatchInput]) -> bool {
+    watch_inputs_changed_with_reader(inputs, WatchFingerprint::read)
+}
+
+pub fn watch_inputs_changed_with_reader<F>(inputs: &[WatchInput], mut read: F) -> bool
+where
+    F: FnMut(&Path) -> Option<WatchFingerprint>,
+{
+    let mut canonical_fingerprints = AHashMap::new();
+    inputs.iter().any(|input| {
+        let requested = input.requested_path();
+        let canonical = input.canonical_path();
+        if input.expected_fingerprint().is_none() {
+            return !matches!(
+                fs::canonicalize(requested),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound
+            );
+        }
+        if requested != canonical && fs::canonicalize(requested).ok().as_deref() != Some(canonical)
+        {
+            return true;
+        }
+
+        let observed = canonical_fingerprints
+            .entry(canonical.to_owned())
+            .or_insert_with(|| read(canonical));
+        *observed != input.expected_fingerprint()
+    })
+}
+
+pub fn watch_input_fingerprints(inputs: &[WatchInput]) -> Vec<Option<WatchFingerprint>> {
+    let mut canonical_fingerprints = AHashMap::new();
+    inputs
+        .iter()
+        .map(|input| {
+            if input.requested_path() != input.canonical_path()
+                && fs::canonicalize(input.requested_path()).ok().as_deref()
+                    != Some(input.canonical_path())
+            {
+                return None;
+            }
+            *canonical_fingerprints
+                .entry(input.canonical_path().to_owned())
+                .or_insert_with(|| WatchFingerprint::read(input.canonical_path()))
+        })
+        .collect()
+}
+
 #[derive(Debug)]
 pub(crate) struct SourceManifest {
     path: PathBuf,

--- a/crates/rue/src/watch.rs
+++ b/crates/rue/src/watch.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+#[cfg(test)]
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -10,7 +10,12 @@ use std::time::{Duration, Instant};
 
 use rue_compiler::unstable::{CompilationCancellation, SourceInfo};
 use rue_compiler::{CompileOptions, LinkerMode};
-use rue_driver::{FilesystemCompilerHost, SourceLoadError, WatchFingerprint, WatchInput};
+#[cfg(test)]
+use rue_driver::watch_inputs_changed_with_reader;
+use rue_driver::{
+    FilesystemCompilerHost, SourceLoadError, WatchFingerprint, WatchInput,
+    watch_input_fingerprints, watch_inputs_changed,
+};
 
 use crate::compile::{CancellableCompileRequest, CompileCycleOutcome, execute_cancellable};
 use crate::output;
@@ -150,9 +155,9 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
             .collect();
         let diagnostics = DiagnosticOutput::new(request.error_format, source_infos);
 
-        let destination = match output::preflight_destination(
+        let destination = match output::preflight_watch_destination(
             Path::new(&request.output_path),
-            source_snapshot.files().map(|source| source.path),
+            &inputs,
         ) {
             Ok(destination) => destination,
             Err(output::PublishError::WouldClobberSource) => {
@@ -183,9 +188,11 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
             options: request.compile_options.clone(),
             destination,
             cancellation,
+            watch_inputs: inputs.clone(),
         });
 
         let changed_before_publication = monitor.changed() || inputs_changed(&inputs);
+        let mut publication_changed = false;
         if changed_before_publication {
             test_event("canceled-before-publication");
             eprintln!(
@@ -213,6 +220,14 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
                             "Error: output path '{}' became an input source; keeping the last successful executable",
                             request.output_path
                         ),
+                        Err(output::PublishError::InputsChanged) => {
+                            publication_changed = true;
+                            test_event("canceled-at-publication");
+                            eprintln!(
+                                "Watch cycle canceled after {} ms; a newer source revision is available",
+                                cycle_started.elapsed().as_millis()
+                            );
+                        }
                         Err(error) => diagnostics.print_error(&error.into_compile_error()),
                     }
                 }
@@ -234,7 +249,12 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
             }
         }
 
-        let changed = monitor.finish() || inputs_changed(&inputs);
+        let monitor_changed = monitor.finish();
+        let changed = watch_cycle_changed(
+            publication_changed,
+            monitor_changed,
+            inputs_changed(&inputs),
+        );
         if !changed {
             wait_for_change(&inputs);
         }
@@ -295,51 +315,27 @@ fn debounce(inputs: &[WatchInput]) {
 }
 
 fn inputs_changed(inputs: &[WatchInput]) -> bool {
-    inputs_changed_with_reader(inputs, WatchFingerprint::read)
+    watch_inputs_changed(inputs)
+}
+
+fn watch_cycle_changed(
+    publication_changed: bool,
+    monitor_changed: bool,
+    observed_changed: bool,
+) -> bool {
+    publication_changed || monitor_changed || observed_changed
 }
 
 fn current_fingerprints(inputs: &[WatchInput]) -> Vec<Option<WatchFingerprint>> {
-    let mut canonical_fingerprints = HashMap::new();
-    inputs
-        .iter()
-        .map(|input| {
-            if input.requested_path() != input.canonical_path()
-                && fs::canonicalize(input.requested_path()).ok().as_deref()
-                    != Some(input.canonical_path())
-            {
-                return None;
-            }
-            *canonical_fingerprints
-                .entry(input.canonical_path().to_owned())
-                .or_insert_with(|| WatchFingerprint::read(input.canonical_path()))
-        })
-        .collect()
+    watch_input_fingerprints(inputs)
 }
 
-fn inputs_changed_with_reader<F>(inputs: &[WatchInput], mut read: F) -> bool
+#[cfg(test)]
+fn inputs_changed_with_reader<F>(inputs: &[WatchInput], read: F) -> bool
 where
     F: FnMut(&Path) -> Option<WatchFingerprint>,
 {
-    let mut canonical_fingerprints = HashMap::new();
-    inputs.iter().any(|input| {
-        let requested = input.requested_path();
-        let canonical = input.canonical_path();
-        if input.expected_fingerprint().is_none() {
-            return !matches!(
-                fs::canonicalize(requested),
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound
-            );
-        }
-        if requested != canonical && fs::canonicalize(requested).ok().as_deref() != Some(canonical)
-        {
-            return true;
-        }
-
-        let observed = canonical_fingerprints
-            .entry(canonical.to_owned())
-            .or_insert_with(|| read(canonical));
-        *observed != input.expected_fingerprint()
-    })
+    watch_inputs_changed_with_reader(inputs, read)
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -368,6 +364,13 @@ impl PollBackoff {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn final_publication_change_latches_reobserve() {
+        assert!(watch_cycle_changed(true, false, false));
+        assert!(watch_cycle_changed(true, false, true));
+        assert!(!watch_cycle_changed(false, false, false));
+    }
 
     #[test]
     fn detects_content_changes_even_when_file_length_is_unchanged() {


### PR DESCRIPTION
## Summary

- carry the exact accepted watch-input observation with each cancellable linked candidate
- revalidate fingerprints, requested/canonical identities, negative probes, and destination clobbering after finalization and immediately before atomic rename
- discard stale candidates while preserving the previous executable and the existing debounce/reobserve retry cycle
- keep one-shot publication unchanged and retain temporary-output cleanup on every rejected path

## Validation

- `scripts/rue fmt`
- `./buck2 test //crates/rue:rue-test` (209 passed)
- `scripts/rue cli watch` (3 passed)
- `scripts/rue quick` (31 targets passed)
- `scripts/rue premerge` (196 targets passed)
- `scripts/rue test` (231 targets passed)

Fixes RUE-1749
