### PR TITLE
RUE-1696, RUE-1697, RUE-1733, RUE-1734: close ownership and comptime holes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ website/static/performance-data.json
 # under `static/`, because `static/` is inside the recorded fixture identity and
 # a derived file there would move the identity on every build.
 website/source-excerpts.json
+
+# Isolated worktrees created by Claude Code workflow runs (fix cycles, audits).
+# Transient build trees, multi-GB each, and registered as git worktrees.
+.claude/worktrees/

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -2725,32 +2725,49 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 .field_name
                 .map(|s| self.body_interner().resolve(&s).to_string())
                 .unwrap_or_default();
-            let mut err = CompileError::new(
-                ErrorKind::MoveFieldOutOfDestructorType {
-                    struct_name: struct_def.name.to_string(),
-                    field_name: field_name.clone(),
-                },
-                span,
-            )
-            .with_label(format!("field `{field_name}` is moved out here"), span)
-            .with_note(format!(
-                "the destructor for '{}' runs on the whole value when it is dropped: it \
-                 would observe the moved-out field, and the automatic field cleanup after \
-                 the destructor would drop `{field_name}` a second time",
-                struct_def.name
-            ))
-            .with_help(format!(
-                "borrow the field instead (`borrow value.{field_name}`), or move the whole value"
-            ));
-            if let Some(drop_span) = self.destructor_span(struct_id).as_ref() {
-                err = err.with_label(
-                    format!("destructor for '{}' is defined here", struct_def.name),
-                    *drop_span,
-                );
-            }
-            return Err(err);
+            return Err(self.field_move_out_of_destructor_type_error(struct_id, field_name, span));
         }
         Ok(())
+    }
+
+    /// Build the E0456 diagnostic for moving `field_name` out of `struct_id`.
+    ///
+    /// Shared by the named-place walk above and the computed-base fallback in
+    /// `analyze_field_get`, which spills to a temporary and has no
+    /// `PlaceTrace` to walk (RUE-1697). Takes the field name already owned:
+    /// both callers reach this only on the diagnostic path, so the name is
+    /// never allocated for a successful field lookup.
+    fn field_move_out_of_destructor_type_error(
+        &self,
+        struct_id: StructId,
+        field_name: String,
+        span: Span,
+    ) -> CompileError {
+        let struct_def = self.body_type_pool().struct_def(struct_id);
+        let mut err = CompileError::new(
+            ErrorKind::MoveFieldOutOfDestructorType {
+                struct_name: struct_def.name.to_string(),
+                field_name: field_name.clone(),
+            },
+            span,
+        )
+        .with_label(format!("field `{field_name}` is moved out here"), span)
+        .with_note(format!(
+            "the destructor for '{}' runs on the whole value when it is dropped: it \
+             would observe the moved-out field, and the automatic field cleanup after \
+             the destructor would drop `{field_name}` a second time",
+            struct_def.name
+        ))
+        .with_help(format!(
+            "borrow the field instead (`borrow value.{field_name}`), or move the whole value"
+        ));
+        if let Some(drop_span) = self.destructor_span(struct_id).as_ref() {
+            err = err.with_label(
+                format!("destructor for '{}' is defined here", struct_def.name),
+                *drop_span,
+            );
+        }
+        err
     }
 
     /// Analyze a field access.
@@ -3164,6 +3181,20 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         };
 
         let field_type = struct_field.ty;
+
+        // Moving a non-Copy field out of a destructor-typed value is E0456 no
+        // matter how the value was produced. The named-place path above
+        // rejects it via `reject_field_move_out_of_destructor_type`; a
+        // computed base reaches here instead, and the spilled temporary is
+        // dropped whole at scope exit, so its destructor would observe exactly
+        // the moved-out hole that rule exists to prevent (RUE-1697). The
+        // temporary's type is `base_type`, so the check is the same one, just
+        // without a `PlaceTrace` to walk. Copy fields are read, not moved, and
+        // stay legal.
+        if !self.is_type_copy(field_type) && struct_def.destructor.is_some() {
+            let field_name = field_name.to_string();
+            return Err(self.field_move_out_of_destructor_type_error(struct_id, field_name, span));
+        }
 
         // Allocate a temporary slot for the computed struct value
         let num_slots = self.require_layout_slots(base_type, span)?;
@@ -6039,6 +6070,71 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     .map(|root| (root, kind))
             })
             .collect();
+        // A NESTED `inout` loan of a root that an ENCLOSING call already holds
+        // a SHARED (`borrow`) loan of is the nested spelling of
+        // `f(borrow x, inout x)`, which `check_exclusive_access_in` already
+        // rejects as E0430 (law of exclusivity, spec 6.1:36). It is also
+        // unsound rather than merely irregular: a `borrow str`/slice argument
+        // is snapshotted into a `{ptr, len}` view at argument-evaluation time
+        // (`coerce_borrow_str_operand_to_view`), and the shared loan spans the
+        // whole outer call, so a nested `inout` that reallocates the root
+        // leaves the outer argument's view pointing at freed memory — a
+        // use-after-free in safe code (RUE-1696).
+        //
+        // Deliberately limited to shared-outer/exclusive-nested:
+        //
+        // * A nested `borrow` finishes before the outer call is entered, so it
+        //   cannot outlive anything.
+        // * An `inout` outer loan of an ADDRESS-PASSED parameter passes the
+        //   root's address rather than a snapshot, so a nested `inout` writing
+        //   through the same address observes ordinary sequenced mutation. The
+        //   accumulator idiom `add(mul(x, y, inout flags), z, inout flags)`
+        //   depends on it.
+        //
+        //   This exclusion does NOT generalize to every `inout`: a view
+        //   materialized parameter snapshots whatever its loan mode. `inout
+        //   str` is passed as a two-word `{ptr, len}` value (4.10:4), so a
+        //   nested `inout` that frees or reallocates the root dangles it
+        //   exactly as the shared case above — still accepted here, tracked as
+        //   RUE-1766. The property that actually governs is view
+        //   materialization, not shared-vs-exclusive; this rule is keyed on the
+        //   latter and so covers only half the hole.
+        //
+        // Caught in either argument order, because the enclosing frame covers
+        // the whole outer argument list before any of it is analyzed.
+        // `ctx.call_loaned_roots` holds only genuinely enclosing calls here:
+        // this call's own frame is pushed below.
+        for arg in args.clone() {
+            if !arg.is_inout() {
+                continue;
+            }
+            let Some(root) = root_variable_of(self.body_rir_ref(), arg.value)
+                .or_else(|| self.place_root_with_accessors(arg.value, ctx))
+            else {
+                continue;
+            };
+            let shared_outer_loan = ctx
+                .call_loaned_roots
+                .iter()
+                .flatten()
+                .any(|(loaned, kind)| *loaned == root && *kind == CallLoanKind::Borrow);
+            if shared_outer_loan {
+                let variable = self.body_interner().resolve(&root).to_string();
+                return Err(CompileError::new(
+                    ErrorKind::BorrowInoutConflict {
+                        variable: variable.clone(),
+                    },
+                    self.body_rir_ref().get(arg.value).span,
+                )
+                .with_help(format!(
+                    "the enclosing call already passes `{variable}` as `borrow`, and that \
+                     shared loan spans the whole call — a `borrow str`/slice argument is \
+                     snapshotted before the call runs, so mutating `{variable}` here would \
+                     leave it dangling; evaluate the nested call into its own binding before \
+                     the call"
+                )));
+            }
+        }
         // An `inout` loan on a root an accessor result borrows in the same
         // full expression violates exclusivity (ADR-0062, E0259). Checked
         // three times: here at frame construction (loans taken earlier in the

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -117,7 +117,7 @@ pub(super) fn validate_comptime_value_for_type_impl(
 }
 use super::{DeferredOwnershipGate, DeferredOwnershipGateKind};
 use crate::integer_semantics::CheckedIntegerResult;
-use crate::specialize::MAX_SPECIALIZATION_ROUNDS;
+use crate::specialize::MAX_COMPTIME_CALL_DEPTH;
 use crate::types::{ArrayLen, StructField, Type, TypeKind};
 
 fn elapsed_ns(started: Instant) -> u64 {
@@ -2125,7 +2125,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         callee_env.defining_file = Some(fn_file);
         let depth = self.comptime_type_call_depth() + 1;
         self.set_comptime_type_call_depth(depth);
-        if self.comptime_type_call_depth() > MAX_SPECIALIZATION_ROUNDS {
+        if self.comptime_type_call_depth() > MAX_COMPTIME_CALL_DEPTH {
             self.set_comptime_type_call_depth(self.comptime_type_call_depth() - 1);
             return Err(CompileError::new(
                 ErrorKind::ComptimeEvaluationFailed {
@@ -2135,7 +2135,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                          base case, or a generic function recursively instantiating \
                          itself with new types?",
                         self.body_interner().resolve(&name),
-                        MAX_SPECIALIZATION_ROUNDS
+                        MAX_COMPTIME_CALL_DEPTH
                     ),
                 },
                 fn_span,

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -81,6 +81,27 @@ struct SpecializationInfo {
 /// sema work queue.
 pub const MAX_SPECIALIZATION_ROUNDS: usize = 64;
 
+/// Maximum nesting depth of a *comptime call* — one `comptime`-evaluated
+/// application of a function to compile-time arguments, as opposed to a round
+/// of the specialization worklist above.
+///
+/// This is the single budget both comptime evaluators spend: the in-body engine
+/// (`sema::comptime_eval`) and the durable/declaration-time evaluator
+/// (`rue_compiler`'s `SEMANTIC_COMPTIME_MAX_DEPTH`). Sharing it is the point —
+/// a comptime call must be accepted in both positions or rejected in both, and
+/// while the two paths had separate budgets `let x: i64 = count(40)` compiled
+/// while `const X: i64 = count(40)` was rejected as too deep (RUE-1733).
+///
+/// The value is bounded from *above* by the compiler's own stack, not by taste.
+/// Each level of durable comptime recursion costs roughly 150 KiB of stack
+/// (query frames plus the evaluator's), so on the established 8 MiB stack floor
+/// (`rue_query`'s batch-worker stack size) the durable evaluator exhausts the
+/// stack somewhere past depth 53. A budget above that is decorative: the
+/// process dies before the guard can report anything. 48 keeps a margin while
+/// staying far above any plausible hand-written recursion. Raising it requires
+/// first cutting that per-level stack cost.
+pub const MAX_COMPTIME_CALL_DEPTH: usize = 48;
+
 fn collect_specializations(
     air: &Air,
     interner: &ThreadedRodeo,

--- a/crates/rue-cli-tests/cases/comptime_const_position_parity.toml
+++ b/crates/rue-cli-tests/cases/comptime_const_position_parity.toml
@@ -1,0 +1,66 @@
+# Const position must reduce a comptime call exactly like body position
+# (RUE-1733).
+#
+# `const X = f(..)` is reduced by the durable, declaration-time evaluator;
+# `let x = f(..)` in a body is reduced by the in-body engine. They are one
+# language (4.14:3), so a program that mixes both must not be able to tell
+# them apart. The two evaluators spent different comptime call-depth budgets,
+# so a recursion 40 deep compiled in a body and was rejected as too deep in a
+# const initializer.
+#
+# The spec suite pins the semantics; these cases drive the real binary so the
+# reduced constants are checked as bytes on stdout, not just as exit codes.
+
+[section]
+id = "cli.comptime_const_position_parity"
+name = "Comptime const-position parity"
+description = "A comptime call reduced at declaration time accepts the same depths the in-body engine accepts."
+
+# RUE-1733: 40 sits between the two budgets the evaluators used to disagree on
+# (durable stopped at 32, in-body at 64). Both now spend the one shared
+# MAX_COMPTIME_CALL_DEPTH, so the const and the body call reduce alike.
+[[case]]
+name = "recursion_depth_agrees_between_positions"
+files = [{ path = "main.rue", source = """
+fn count(comptime n: i64) -> i64 { comptime { if n == 0 { 0 } else { count(n - 1) + 1 } } }
+
+const X: i64 = count(40);
+
+fn main() -> i32 {
+    let y: i64 = count(40);
+    if X != y { return 1; }
+    @dbg(X);
+    0
+}
+""" }]
+stdout = "40\n"
+exit_code = 0
+
+# The shared budget must still fire -- in BOTH positions -- rather than run the
+# compiler out of stack. A runaway comptime recursion is a clean E1200 wherever
+# it is written.
+[[case]]
+name = "runaway_recursion_rejected_in_body_position"
+files = [{ path = "main.rue", source = """
+fn count(comptime n: i64) -> i64 { comptime { if n == 0 { 0 } else { count(n - 1) + 1 } } }
+fn main() -> i32 {
+    let y: i64 = count(4000);
+    if y != 4000 { return 1; }
+    0
+}
+""" }]
+compile_fail = true
+compile_stderr_contains = ["E1200", "exceeded the maximum nesting depth"]
+
+[[case]]
+name = "runaway_recursion_rejected_in_const_position"
+files = [{ path = "main.rue", source = """
+fn count(comptime n: i64) -> i64 { comptime { if n == 0 { 0 } else { count(n - 1) + 1 } } }
+const X: i64 = count(4000);
+fn main() -> i32 {
+    if X != 4000 { return 1; }
+    0
+}
+""" }]
+compile_fail = true
+compile_stderr_contains = ["E1200", "exceeded the maximum nesting depth"]

--- a/crates/rue-cli-tests/cases/destructor_field_move.toml
+++ b/crates/rue-cli-tests/cases/destructor_field_move.toml
@@ -174,3 +174,77 @@ fn main() -> i32 {
 """ }]
 stdout = "900\n800\n7\n100\n"
 exit_code = 0
+
+[[case]]
+name = "field_move_out_of_computed_destructor_type_rejected"
+description = "RUE-1697: the rule does not depend on how the value was produced. A COMPUTED base (`make().inner`) spills to a temporary that is dropped whole, so the same moved-out hole appears; before the fix this compiled and the destructor printed garbage instead of 9."
+files = [{ path = "main.rue", source = """
+struct Inner { v: i32 }
+struct Outer { inner: Inner, tag: i32 }
+
+drop fn Outer(self) {
+    @dbg(self.tag);
+}
+
+fn make() -> Outer {
+    Outer { inner: Inner { v: 5 }, tag: 9 }
+}
+
+fn main() -> i32 {
+    let y = make().inner;
+    @dbg(y.v);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0456", "cannot move field `inner` out of a value of type 'Outer'", "destructor"]
+
+[[case]]
+name = "copy_field_of_computed_destructor_type_stays_legal"
+description = "Control: a Copy field of a computed destructor-having value is READ, not moved, so it stays legal; the temporary's destructor still runs exactly once, on the whole value."
+files = [{ path = "main.rue", source = """
+struct Inner { v: i32 }
+struct Outer { inner: Inner, tag: i32 }
+
+drop fn Outer(self) {
+    @dbg(self.tag);
+}
+
+fn make() -> Outer {
+    Outer { inner: Inner { v: 5 }, tag: 9 }
+}
+
+fn main() -> i32 {
+    @dbg(make().tag);
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "9\n9\n100\n"
+exit_code = 0
+
+[[case]]
+name = "field_move_out_of_computed_dtor_free_type_stays_legal"
+description = "Control (the RUE-62/RUE-258 shape): moving a non-Copy field out of a computed value whose own type has NO destructor stays legal, and the temporary's field glue does not re-drop the extracted field — `7` prints once from the new owner at scope exit, not twice."
+files = [{ path = "main.rue", source = """
+struct Inner { v: i32 }
+
+drop fn Inner(self) {
+    @dbg(self.v);
+}
+
+struct Plain { inner: Inner, tag: i32 }
+
+fn make_plain() -> Plain {
+    Plain { inner: Inner { v: 7 }, tag: 3 }
+}
+
+fn main() -> i32 {
+    let y = make_plain().inner;
+    @dbg(y.v);
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "7\n100\n7\n"
+exit_code = 0

--- a/crates/rue-cli-tests/cases/nested_loan_str_view.toml
+++ b/crates/rue-cli-tests/cases/nested_loan_str_view.toml
@@ -1,0 +1,177 @@
+# A nested `inout` loan must not run while an outer argument of the SAME call
+# holds a shared (`borrow`) loan of the same root (RUE-1696).
+#
+# `borrow s: str` does not pass an address: the argument is snapshotted into a
+# `{ptr, len}` view over the StrBuf's heap buffer at argument-evaluation time
+# (`coerce_borrow_str_operand_to_view`). The shared loan spans the whole call,
+# so a sibling argument that reallocates the same StrBuf frees the buffer that
+# view points at, and the callee reads freed memory — a use-after-free in
+# safe code. Before the fix `read_first(borrow b, grow(inout b))` compiled and
+# printed 0 (freed memory) instead of 104.
+#
+# The flat spelling `f(borrow b, inout b)` was already E0430; only the nested
+# spelling `f(borrow b, g(inout b))` escaped, because the ordinary-call loan
+# frame was consulted for by-value MOVES only, never for a nested loan.
+#
+# The opposite nesting (an outer `inout` loan with a nested `borrow`, and the
+# accumulator idiom `add(mul(x, y, inout flags), z, inout flags)`) stays legal:
+# an `inout` argument passes the root's address, not a snapshot, so a nested
+# access observes ordinary sequenced mutation.
+
+[section]
+id = "cli.nested_loan_str_view"
+name = "Nested inout under an outer shared loan"
+description = "A nested `inout` of a root the same call already borrows is rejected; the outer argument's str/slice view would dangle (RUE-1696)."
+
+[[case]]
+name = "nested_inout_under_borrow_str_view_rejected"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+description = "RUE-1696 repro: the nested `grow(inout b)` reallocates the buffer that the sibling `borrow b` argument was already snapshotted into a `str` view over."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn read_first(borrow s: str, x: i32) -> u8 { s[0] }
+fn grow(inout s: StrBuf) -> i32 {
+    s.append_str(borrow "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+    0
+}
+fn main() -> i32 {
+    let mut b = StrBuf.from_str(borrow "hello");
+    let byte = read_first(borrow b, grow(inout b));
+    @dbg(byte);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0430", "cannot borrow 'b'", "dangling"]
+
+[[case]]
+name = "nested_inout_under_borrow_str_view_rejected_reversed_order"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+description = "Argument order does not matter: the outer call's shared loan covers the whole argument list before any of it is evaluated."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn read_first(x: i32, borrow s: str) -> u8 { s[0] }
+fn grow(inout s: StrBuf) -> i32 {
+    s.append_str(borrow "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+    0
+}
+fn main() -> i32 {
+    let mut b = StrBuf.from_str(borrow "hello");
+    let byte = read_first(grow(inout b), borrow b);
+    @dbg(byte);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0430", "cannot borrow 'b'"]
+
+[[case]]
+name = "nested_inout_under_borrow_struct_rejected"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+description = "Root-granular, like the other exclusivity rules: the loan is on the root, so a `borrow` of the whole struct conflicts with a nested `inout` of one of its fields."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+struct Holder { buf: StrBuf, n: i32 }
+fn peek(borrow h: Holder, x: i32) -> i32 { h.n }
+fn grow(inout s: StrBuf) -> i32 {
+    s.append_str(borrow "XXXX");
+    0
+}
+fn main() -> i32 {
+    let mut h = Holder { buf: StrBuf.from_str(borrow "hello"), n: 7 };
+    let n = peek(borrow h, grow(inout h.buf));
+    @dbg(n);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0430", "cannot borrow 'h'"]
+
+[[case]]
+name = "no_nested_mutation_reads_live_buffer"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+description = "Control: the same call shape with a nested call that touches no loaned root keeps compiling and reads the live buffer (104 = 'h')."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn read_first(borrow s: str, x: i32) -> u8 { s[0] }
+fn other(x: i32) -> i32 { x }
+fn main() -> i32 {
+    let mut b = StrBuf.from_str(borrow "hello");
+    let byte = read_first(borrow b, other(0));
+    @dbg(byte);
+    0
+}
+""" }]
+stdout = "104\n"
+exit_code = 0
+
+[[case]]
+name = "nested_inout_of_a_different_root_stays_legal"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+description = "Accepted: the nested `inout` loans a DIFFERENT root, so nothing the outer argument snapshotted can be reallocated."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn read_first(borrow s: str, x: i32) -> u8 { s[0] }
+fn grow(inout s: StrBuf) -> i32 {
+    s.append_str(borrow "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+    0
+}
+fn main() -> i32 {
+    let mut b = StrBuf.from_str(borrow "hello");
+    let mut c = StrBuf.from_str(borrow "world");
+    let byte = read_first(borrow b, grow(inout c));
+    @dbg(byte);
+    @dbg(c.len());
+    0
+}
+""" }]
+stdout = "104\n69\n"
+exit_code = 0
+
+[[case]]
+name = "nested_borrow_under_outer_borrow_stays_legal"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+description = "Accepted: a nested `borrow` of the same root ends before the outer call begins and cannot invalidate anything (spec 6.1:36)."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn read_first(borrow s: str, x: i32) -> u8 { s[0] }
+fn peek(borrow s: StrBuf) -> i32 { 0 }
+fn main() -> i32 {
+    let b = StrBuf.from_str(borrow "hello");
+    let byte = read_first(borrow b, peek(borrow b));
+    @dbg(byte);
+    0
+}
+""" }]
+stdout = "104\n"
+exit_code = 0
+
+[[case]]
+name = "nested_inout_under_outer_inout_stays_legal"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+description = "Accepted: an outer `inout` loan passes an address rather than a snapshot, so the nested-inout accumulator idiom keeps working and both writes land."
+files = [{ path = "main.rue", source = """
+fn mul(a: i32, b: i32, inout flags: i32) -> i32 {
+    flags = flags + 1;
+    a * b
+}
+fn add(a: i32, b: i32, inout flags: i32) -> i32 {
+    flags = flags + 10;
+    a + b
+}
+fn main() -> i32 {
+    let mut flags = 0;
+    let total = add(mul(3, 4, inout flags), 5, inout flags);
+    @dbg(total);
+    @dbg(flags);
+    0
+}
+""" }]
+stdout = "17\n11\n"
+exit_code = 0

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -4291,6 +4291,48 @@ fn durable_const_fits_type(
     }
 }
 
+/// Build the E0481 for an array length that is already *fully concrete* and
+/// still cannot be a length.
+///
+/// This must be a domain diagnostic rather than an opaque `Resolution` failure.
+/// A `Resolution` failure means "this provider could not resolve the syntax
+/// yet", which the comptime-call reduction is entitled to treat as
+/// non-evaluable; the caller then reports whatever it makes of an unreduced
+/// call. So `fn Buf(comptime n: i64) -> type { struct { data: [i64; n] } }`
+/// applied as `Buf(-1)` lost its real "array length is negative" error and
+/// surfaced as an unrelated E1200 about storing a type value at runtime
+/// (RUE-1734). Every caller below has a concrete integer in hand — a still
+/// unsubstituted `comptime n` returns `Ok(None)` well before this point — so the
+/// error is a genuine well-formedness failure and must be reported as one.
+///
+/// The wording mirrors `rue_air::sema::typeck`'s local provider so the same
+/// program reports the same text whichever provider resolved the length.
+fn durable_named_array_length_failure(
+    name: &str,
+    value: i128,
+) -> crate::semantic_query_nucleus::SemanticNucleusFailure {
+    let reason = if value < 0 {
+        format!("array length '{name}' is negative ({value})")
+    } else {
+        format!("array length '{name}' ({value}) is too large")
+    };
+    crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+        rue_error::ErrorKind::InvalidArrayLength { reason },
+    )
+}
+
+/// The unnamed counterpart of [`durable_named_array_length_failure`], for a
+/// length that arrived as a literal or an already-evaluated comptime value.
+fn durable_literal_array_length_failure(
+    value: i128,
+) -> crate::semantic_query_nucleus::SemanticNucleusFailure {
+    crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+        rue_error::ErrorKind::InvalidArrayLength {
+            reason: format!("array length must be non-negative, got {value}"),
+        },
+    )
+}
+
 /// Describe integer type `ty` for the canonical width-truncating semantics in
 /// [`rue_air::integer_semantics`], which the in-body comptime engine already
 /// uses — sharing it is what keeps the two evaluators from disagreeing about
@@ -7069,7 +7111,17 @@ thread_local! {
         const { std::cell::Cell::new(0) };
 }
 
-const SEMANTIC_COMPTIME_MAX_DEPTH: usize = 32;
+/// Comptime call-nesting budget for the durable (declaration-time) evaluator.
+///
+/// This is the *same* constant the in-body engine spends at its comptime-call
+/// site (`rue_air::sema::comptime_eval`), deliberately shared rather than
+/// duplicated: a comptime call must be accepted in both positions or rejected
+/// in both. The durable path used to stop at 32 while a body stopped at 64, so
+/// `let x: i64 = count(40)` compiled while `const X: i64 = count(40)` was
+/// rejected with a depth-exceeded E1200 (RUE-1733). See
+/// [`rue_air::specialize::MAX_COMPTIME_CALL_DEPTH`] for why the shared value is
+/// neither of the two old budgets.
+const SEMANTIC_COMPTIME_MAX_DEPTH: usize = rue_air::specialize::MAX_COMPTIME_CALL_DEPTH;
 
 struct SemanticComptimeCallDepthGuard(usize);
 
@@ -10334,20 +10386,21 @@ impl rue_air::SemanticTypeSyntaxProvider<ModuleId, ModuleId, StableDefinitionKey
         crate::semantic_query_nucleus::SemanticNucleusFailure,
     > {
         match length {
-            rue_air::SemanticValueSyntax::Integer(value) => {
-                u64::try_from(value).map(Some).map_err(|_| {
-                    Self::provider_failure_value(format!(
-                        "array length `{value}` is negative or too large"
+            rue_air::SemanticValueSyntax::Integer(value) => u64::try_from(value)
+                .map(Some)
+                .map_err(|_| {
+                    rue_air::SemanticProviderError::Failure(durable_literal_array_length_failure(
+                        value,
                     ))
-                })
-            }
+                }),
             rue_air::SemanticValueSyntax::Name(name) => {
                 if let Some(crate::durable_semantics::DurableConstValue::Integer(value)) =
                     self.value_substitutions.get(name)
                 {
-                    return u64::try_from(*value).map(Some).map_err(|_| {
-                        Self::provider_failure_value(format!(
-                            "array length `{name}` is negative or too large"
+                    let value = *value;
+                    return u64::try_from(value).map(Some).map_err(|_| {
+                        rue_air::SemanticProviderError::Failure(durable_named_array_length_failure(
+                            name, value,
                         ))
                     });
                 }
@@ -10395,8 +10448,8 @@ impl rue_air::SemanticTypeSyntaxProvider<ModuleId, ModuleId, StableDefinitionKey
                     ));
                 };
                 u64::try_from(value).map(Some).map_err(|_| {
-                    Self::provider_failure_value(format!(
-                        "array length `{name}` is negative or too large"
+                    rue_air::SemanticProviderError::Failure(durable_named_array_length_failure(
+                        name, value,
                     ))
                 })
             }
@@ -10415,10 +10468,9 @@ impl rue_air::SemanticTypeSyntaxProvider<ModuleId, ModuleId, StableDefinitionKey
         let crate::durable_semantics::DurableConstValue::Integer(value) = value else {
             return Self::provider_failure("array length is not an integer");
         };
-        u64::try_from(*value).map(Some).map_err(|_| {
-            Self::provider_failure_value(format!(
-                "array length `{value}` is negative or too large"
-            ))
+        let value = *value;
+        u64::try_from(value).map(Some).map_err(|_| {
+            rue_air::SemanticProviderError::Failure(durable_literal_array_length_failure(value))
         })
     }
 

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -1575,6 +1575,35 @@ fn main() -> i32 {
 """
 exit_code = 42
 
+# =============================================================================
+# Const position evaluates identically to body position (RUE-1733)
+# =============================================================================
+# `const X = f(..)` is reduced by the durable, declaration-time evaluator, while
+# `let x = f(..)` inside a body is reduced by the in-body engine. 4.14:3 makes
+# them one language, so the case below asserts the *same* call agrees in both
+# positions. The two engines used to spend different comptime call-depth
+# budgets, so a recursion 40 deep compiled in a body and was rejected as too
+# deep in a const initializer.
+
+[[case]]
+name = "comptime_const_position_recursion_depth_parity"
+spec = ["4.14:3", "4.14:5"]
+description = "A comptime recursion 40 deep is accepted in const position exactly as in body position - RUE-1733"
+# 40 sits between the two budgets the evaluators used to disagree on (the
+# durable path stopped at 32, the in-body engine at 64); both now spend the one
+# shared MAX_COMPTIME_CALL_DEPTH, so this program compiles either way.
+source = """
+fn count(comptime n: i64) -> i64 { comptime { if n == 0 { 0 } else { count(n - 1) + 1 } } }
+const X: i64 = count(40);
+fn main() -> i32 {
+    let y: i64 = count(40);
+    if X != y { return 1; }
+    if X != 40 { return 2; }
+    42
+}
+"""
+exit_code = 42
+
 # 4.14:2 says evaluation follows runtime semantics *exactly*, which binds every
 # position a comptime value is produced in, not just a `comptime { }` block
 # inside a body. A const initializer reduces the same call through a different

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -1043,6 +1043,72 @@ fn main() -> i32 {
 exit_code = 0
 
 [[case]]
+name = "nested_inout_under_outer_borrow_rejected"
+spec = ["6.1:30"]
+description = "The nested spelling of the borrow/inout conflict: a shared loan spans the whole call, so an `inout` loan taken inside another argument overlaps it and is rejected (RUE-1696)"
+real_std = true
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn read_first(borrow s: str, x: i32) -> u8 { s[0] }
+fn grow(inout s: StrBuf) -> i32 {
+    s.append_str(borrow "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+    0
+}
+fn main() -> i32 {
+    let mut b = StrBuf.from_str(borrow "hello");
+    let byte = read_first(borrow b, grow(inout b));
+    if byte == 104 { 0 } else { 1 }
+}
+"""
+compile_fail = true
+error_contains = "cannot borrow 'b'"
+
+[[case]]
+name = "nested_inout_under_outer_borrow_rejected_reversed_order"
+spec = ["6.1:30"]
+description = "Argument order does not matter: the outer call's shared loan covers the whole argument list before any of it is evaluated"
+real_std = true
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn read_first(x: i32, borrow s: str) -> u8 { s[0] }
+fn grow(inout s: StrBuf) -> i32 {
+    s.append_str(borrow "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+    0
+}
+fn main() -> i32 {
+    let mut b = StrBuf.from_str(borrow "hello");
+    let byte = read_first(grow(inout b), borrow b);
+    if byte == 104 { 0 } else { 1 }
+}
+"""
+compile_fail = true
+error_contains = "cannot borrow 'b'"
+
+[[case]]
+name = "nested_inout_of_other_root_under_borrow_ok"
+spec = ["6.1:30"]
+description = "Root-granular: a nested `inout` loan of a DIFFERENT variable does not overlap the outer shared loan and stays legal"
+real_std = true
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn read_first(borrow s: str, x: i32) -> u8 { s[0] }
+fn grow(inout s: StrBuf) -> i32 {
+    s.append_str(borrow "XXXX");
+    0
+}
+fn main() -> i32 {
+    let b = StrBuf.from_str(borrow "hello");
+    let mut c = StrBuf.from_str(borrow "world");
+    let byte = read_first(borrow b, grow(inout c));
+    if byte == 104 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
 name = "borrow_multiple_same_var_ok"
 spec = ["6.1:28"]
 description = "Multiple borrows of the same variable is allowed"

--- a/crates/rue-spec/cases/types/destructors.toml
+++ b/crates/rue-spec/cases/types/destructors.toml
@@ -1101,6 +1101,60 @@ fn main() -> i32 {
 exit_code = 0
 expected_stdout = "7\n800\n7\n"
 
+[[case]]
+name = "field_move_out_of_computed_destructor_type_rejected"
+spec = ["3.9:34"]
+description = "The rule is about the VALUE, not the place: a field move out of a computed destructor-having value (`make().f`) is rejected too — the temporary it spills into is dropped whole (RUE-1697)"
+source = """
+struct Inner { v: i32 }
+
+drop fn Inner(self) {
+    @dbg(self.v);
+}
+
+struct Outer { f: Inner, tag: i32 }
+
+drop fn Outer(self) {
+    @dbg(self.tag);
+}
+
+fn make() -> Outer {
+    Outer { f: Inner { v: 7 }, tag: 9 }
+}
+
+fn main() -> i32 {
+    let y = make().f;
+    y.v
+}
+"""
+compile_fail = true
+error_contains = "cannot move field `f` out of a value of type 'Outer'"
+
+[[case]]
+name = "copy_field_of_computed_destructor_type_stays_legal"
+spec = ["3.9:34"]
+description = "Reading a Copy field of a computed destructor-having value is not a move and stays legal; the temporary still drops exactly once, as a whole value"
+source = """
+struct Inner { v: i32 }
+
+struct Outer { f: Inner, tag: i32 }
+
+drop fn Outer(self) {
+    @dbg(self.tag);
+}
+
+fn make() -> Outer {
+    Outer { f: Inner { v: 7 }, tag: 9 }
+}
+
+fn main() -> i32 {
+    @dbg(make().tag);
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "9\n9\n"
+
 # =============================================================================
 # The `@drop` intrinsic (RUE-187, ADR-0039)
 # =============================================================================

--- a/crates/rue-ui-tests/cases/diagnostics/comptime_ctor_wellformedness.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/comptime_ctor_wellformedness.toml
@@ -1,0 +1,90 @@
+# Well-formedness errors raised inside a `-> type` constructor body must survive
+# the reduction and be reported as themselves (RUE-1734).
+#
+# The durable type-syntax provider used to report an out-of-range array length
+# as an opaque *resolution* failure ("this provider could not resolve the syntax
+# yet"). The comptime-call reduction is entitled to treat a resolution failure
+# as "not reduced", so `Buf(-1)` silently degraded into an unreduced call and
+# the caller reported whatever it made of that -- for `let B = Buf(-1)`, an
+# E1200 about storing a type value in a runtime variable, which never mentions
+# the negative length that actually broke the program. A length that is already
+# fully substituted is a hard well-formedness error, so the provider now raises
+# the same E0481 the ordinary (in-body) type resolver raises, anchored on the
+# instantiation site.
+
+[section]
+id = "diagnostics.comptime_ctor_wellformedness"
+name = "Type-constructor body well-formedness"
+description = "A hard error inside a `-> type` body is reported as itself at the instantiation site."
+
+[[case]]
+name = "negative_array_length_in_ctor_body"
+source = """
+fn Buf(comptime n: i64) -> type { struct { data: [i64; n] } }
+fn main() -> i32 {
+    let B = Buf(0 - 1);
+    let _ = B;
+    0
+}
+"""
+compile_fail = true
+# The real error, with the real length, anchored on `Buf(0 - 1)` at 3:13 --
+# the instantiation site that chose the bad length. Not the E1200 about
+# storing a type value at runtime that this used to report.
+error_contains = [
+  "E0481",
+  "invalid array length",
+  "array length 'n' is negative (-1)",
+  "3:13",
+]
+
+[[case]]
+name = "negative_array_length_through_nested_ctor"
+description = "The error survives one `-> type` body delegating to another, still anchored on the outermost application."
+source = """
+fn Buf(comptime n: i64) -> type { struct { data: [i64; n] } }
+fn Wrap(comptime n: i64) -> type { struct { inner: Buf(n) } }
+fn main() -> i32 {
+    let B = Wrap(0 - 2);
+    let _ = B;
+    0
+}
+"""
+compile_fail = true
+error_contains = [
+  "E0481",
+  "array length 'n' is negative (-2)",
+  "4:13",
+]
+
+[[case]]
+name = "negative_array_length_in_const_position"
+description = "The same body reduced by the durable evaluator in a const initializer reports the same E0481."
+source = """
+fn Buf(comptime n: i64) -> type { struct { data: [i64; n] } }
+const N: i64 = 0 - 3;
+fn main() -> i32 {
+    let B = Buf(N);
+    let _ = B;
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0481", "array length 'n' is negative (-3)"]
+
+# Control: a well-formed length is unaffected. Reclassifying the failure must
+# not turn a legitimately deferred resolution into an error, so the constructor
+# still reduces, the produced type is still usable, and the program still runs.
+[[case]]
+name = "valid_array_length_in_ctor_body_still_reduces"
+source = """
+fn Buf(comptime n: i64) -> type { struct { data: [i64; n] } }
+fn main() -> i32 {
+    let B = Buf(3);
+    let b: B = B { data: [1, 2, 3] };
+    let x: i64 = b.data[1];
+    if x != 2 { return 1; }
+    42
+}
+"""
+exit_code = 42


### PR DESCRIPTION
Four fixes from a fix cycle, integrated onto trunk and merged up to current trunk. Every repro was re-verified by execution on the integration checkout rather than taken from the workers' reports — trunk moved 30 commits under them mid-cycle, and one worker's entire cluster (RUE-1637, RUE-1638, RUE-1639, RUE-1651) turned out to be already fixed upstream and was discarded after confirming the repros no longer reproduce.

## RUE-1696 — `borrow str` view dangled across a nested `inout` realloc

A `borrow s: str` argument sourced from a `StrBuf` is coerced to a by-value `{ptr,len}` view at the moment that argument is evaluated. Arguments evaluate left to right, so a *later* argument could reallocate the same buffer through a nested `inout` call, leaving the callee reading freed memory:

```rue
fn read_first(borrow s: str, x: i32) -> u8 { s[0] }
fn grow(inout s: StrBuf) -> i32 { s.append_str(borrow "XXXX…"); 0 }
let byte = read_first(borrow b, grow(inout b));   // read 0, not 'h'
```

The ordinary-call loan frame was consulted only for by-value moves, never for a nested loan of a root an enclosing argument already held a view over. It now rejects that shape, reusing E0430.

Narrowed to **shared-outer / exclusive-nested**, because a draft that rejected any nested `inout` under any enclosing loan broke the error-accumulator idiom in `examples/harbor` (`add(mul(x, y, inout flags), z, inout flags)`), which is sound.

**This closes only half the hole, and reviewers should know that going in.** The narrowing is keyed on the loan *mode*, but the property that actually governs is whether the outer parameter is **view-materialized**. `inout str` is also passed as a two-word `{ptr,len}` value (4.10:4), so `read_view(inout s: str, nuke(inout b))` still compiles and still reads freed heap — filed as RUE-1766 with a running repro. The in-source rationale comment has been corrected accordingly; it previously asserted a generalization about `inout` that is false for view-materialized parameters.

## RUE-1697 — computed-base field move bypassed the destructor check

`analyze_field_get`'s named-place path rejected moving a non-Copy field out of a destructor-typed value; the computed-base fallback spilled to a temporary and emitted the move with no such check, so the temporary was dropped whole with a moved-out hole. `let y = make().inner;` compiled and its destructor observed uninitialized memory, while `let y = o.inner;` was correctly E0456. Both paths now share one check and one diagnostic.

## RUE-1733 — comptime call-depth budget raised from 32 to 48 in two of three positions

Measured by execution, not asserted:

| position | before | after |
| --- | --- | --- |
| `const X = count(N)` | cap 32 | **cap 48** |
| `let x = comptime { count(N) }` | cap 32 | **cap 48** |
| `let x = count(N)` (body) | cap 64 | cap 64 |

The original complaint — `count(40)` compiling in a body and rejected in a `const` — is fixed. **Full parity is not achieved**: the body path still spends `MAX_SPECIALIZATION_ROUNDS = 64`, so a call at depth 50 still compiles in a body and is rejected in a `const`. No position regressed.

48 rather than 64 because each level of durable comptime recursion costs roughly 150 KiB of stack, so on the 8 MiB worker stack the durable evaluator exhausts the stack past depth ~53 — a larger budget is decorative, since the process dies before the guard can report. That leaves both durable positions under spec 4.14:18's "at least 64 levels" floor (they were under it before this change too, at 32). Closing that needs either cutting the per-level stack cost, raising the worker stack, or amending the floor — a decision, so it is filed separately as RUE-1767 rather than guessed at here.

## RUE-1734 — invalid array length in a `-> type` ctor body

`Buf(-1)` with `struct { data: [i64; n] }` reported an unrelated E1200 about storing type values at runtime. The real error was being classified as an opaque resolution failure and mapped to `NotReduced`; a concrete invalid length now surfaces as E0481 with typeck's wording. (The original diagnosis in the issue pointed at the `AnonStructType` arm and was refuted during the fix — the loss was in `resolve_array_length`.)

## Verification

Run by hand on this tree: RUE-1696 rejected E0430 with its control still printing 104; RUE-1697 rejected E0456; RUE-1734 reports E0481; the depth caps in the table above measured at their boundaries. Full `./test.sh` passed on the pre-merge head (Pass 231, Fail 0), which was additionally green across all 24 CI checks including both native ARM64 legs, asan, valgrind and compiler reproducibility.

After merging current trunk, both sides' repros were re-run together: RUE-1698's `~0u8` yields 255 through trunk's shared kernel, and the sibling's own suites pass here (`cli nested_linear_destructure` 25/25, `spec move` 207/207).

## Not included

RUE-1698 is deliberately **not** part of this PR; the hunks a worker produced for it were removed before review. #2609 has since merged and fixes it by routing the arms through the shared `integer_semantics` kernel, which is the right shape — a second private truncation helper here would have been the duplicate-semantics drift RUE-1754 tracks, and would have conflicted outright.

Follow-ups filed from this work: RUE-1766 (the `inout str` half of the use-after-free), RUE-1767 (the remaining depth-cap split and the `comptime{}` overrun's wrong diagnostic), RUE-1761 (a nested by-ref method receiver bypasses the same frame check), RUE-1762 (spec 6.1:30/6.1:36 still describe the program this PR now rejects).

Fixes: RUE-1696
Fixes: RUE-1697
Fixes: RUE-1733
Fixes: RUE-1734