### PR TITLE
RUE-1707, RUE-1708, RUE-1709: fix std traps at argument extremes

### DIFF
--- a/crates/rue-cli-tests/cases/std_collections.toml
+++ b/crates/rue-cli-tests/cases/std_collections.toml
@@ -155,3 +155,226 @@ fn main() -> i32 {
     42
 }
 """ }]
+
+# ── IntMap key extremes (RUE-1709) ──────────────────────────────────────────
+#
+# IntMap is documented to take any `i64` key, but until now every case above
+# used small NON-NEGATIVE keys — the suite had no negative-key coverage at all.
+# That left two things unpinned:
+#
+#   1. `_slot` hashed a negative key by its MAGNITUDE, `@intCast(0 - k)`, and
+#      `0 - i64::MIN` overflows. `@int_min(i64)` was a single-value landmine:
+#      an ordinary -5 key worked, so nothing looked wrong until exactly that
+#      key showed up. The hash now reinterprets the key's two's-complement bit
+#      pattern, which has no such hole.
+#   2. `_grow_to` carried a SECOND, inline copy of that same hash. A fix
+#      applied to `_slot` alone would place keys by the new hash and re-place
+#      them by the old one on the next growth — every lookup after a growth
+#      silently wrong. The hash now lives in one module-level `_hash`, and the
+#      growth case below is what would catch it diverging again.
+
+# Insert / lookup / overwrite / remove / re-insert, all at i64::MIN, which
+# previously trapped with "integer overflow" on the very first insert.
+#
+# NOT `differential_opt`, and deliberately so: this case's own shape trips a
+# SEPARATE, PRE-EXISTING optimizer bug that has nothing to do with the key. On
+# trunk's unmodified `std/intmap.rue`, at -O2 and -O3 only,
+#
+#     let mut m = M.new(0);
+#     m.insert(42, 7);
+#     println("contains=" + std.fmt.bool_to_string(m.contains(42)));
+#     match m.get(99) { O.Some(v) => ..., O.None => ... }   // takes Some(0)!
+#
+# reads a `None` returned by `IntMap.get` as `Some(filler)`. It needs no
+# negative key, no i64::MIN and no growth — an ordinary key 42 reproduces it —
+# and it disappears if the `bool_to_string(<call>)` concatenation before the
+# lookup is removed. Marking this case `differential_opt` would report that
+# optimizer bug as a std-library regression at the wrong address, so the
+# opt-level sweep is left off HERE and carried by the two cases below, whose
+# assertions do not sit downstream of that shape. See the meta note filed with
+# RUE-1709 for the standalone repro.
+[[case]]
+name = "intmap_key_i64_min_full_lifecycle"
+description = "i64::MIN works as an ordinary key through insert, get, contains, overwrite, remove and re-insert (RUE-1709)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 0
+stdout = """len=1
+get=7
+contains=true
+len_after_overwrite=1
+get2=99
+remove=true
+len_after_remove=0
+contains_after=false
+remove_again=false
+get3=none
+reinsert=5
+is_empty=false
+"""
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let M = std.intmap.IntMap(i64);
+    let O = std.option.Option(i64);
+    let mut m = M.new(0);
+    let mn: i64 = @int_min(i64);
+
+    m.insert(mn, 7);
+    println("len=" + @to_string(m.len()));
+    match m.get(mn) { O.Some(v) => { println("get=" + @to_string(v)); }, O.None => { println("get=none"); } }
+    println("contains=" + std.fmt.bool_to_string(m.contains(mn)));
+
+    m.insert(mn, 99);
+    println("len_after_overwrite=" + @to_string(m.len()));
+    match m.get(mn) { O.Some(v) => { println("get2=" + @to_string(v)); }, O.None => { println("get2=none"); } }
+
+    println("remove=" + std.fmt.bool_to_string(m.remove(mn)));
+    println("len_after_remove=" + @to_string(m.len()));
+    println("contains_after=" + std.fmt.bool_to_string(m.contains(mn)));
+    println("remove_again=" + std.fmt.bool_to_string(m.remove(mn)));
+    match m.get(mn) { O.Some(v) => { println("get3=" + @to_string(v)); }, O.None => { println("get3=none"); } }
+
+    // Re-inserting over the tombstone the removal left behind.
+    m.insert(mn, 5);
+    match m.get(mn) { O.Some(v) => { println("reinsert=" + @to_string(v)); }, O.None => { println("reinsert=none"); } }
+    println("is_empty=" + std.fmt.bool_to_string(m.is_empty()));
+    0
+}
+""" }]
+
+# Negative, zero, positive, MIN and MAX in one table, each mapped to a distinct
+# value so an aliasing hash shows up as a wrong value rather than a miss. The
+# three misses at the end matter too: a magnitude hash folds `k` and `-k` onto
+# the same slot, so near-neighbours of the extremes are exactly where a bad
+# fold would produce a false hit.
+[[case]]
+name = "intmap_negative_zero_positive_and_extreme_keys"
+description = "A mixed table of negative, zero, positive, i64::MIN and i64::MAX keys resolves each to its own value."
+differential_opt = true
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 0
+stdout = """len=7
+values=1234567
+miss_mx-1=false
+miss_neg2=false
+miss_1=false
+"""
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let M = std.intmap.IntMap(i64);
+    let O = std.option.Option(i64);
+    let mut m = M.new(0);
+
+    let mn: i64 = @int_min(i64);
+    let mx: i64 = @int_max(i64);
+    let mnp1: i64 = mn + 1;
+    let neg5: i64 = 0 - 5;
+    let neg1: i64 = 0 - 1;
+
+    m.insert(mn, 1);
+    m.insert(mnp1, 2);
+    m.insert(neg5, 3);
+    m.insert(neg1, 4);
+    m.insert(0, 5);
+    m.insert(5, 6);
+    m.insert(mx, 7);
+
+    println("len=" + @to_string(m.len()));
+    let mut out = StrBuf.new();
+    match m.get(mn) { O.Some(v) => { out = out + @to_string(v); }, O.None => { out = out + "?"; } }
+    match m.get(mnp1) { O.Some(v) => { out = out + @to_string(v); }, O.None => { out = out + "?"; } }
+    match m.get(neg5) { O.Some(v) => { out = out + @to_string(v); }, O.None => { out = out + "?"; } }
+    match m.get(neg1) { O.Some(v) => { out = out + @to_string(v); }, O.None => { out = out + "?"; } }
+    match m.get(0) { O.Some(v) => { out = out + @to_string(v); }, O.None => { out = out + "?"; } }
+    match m.get(5) { O.Some(v) => { out = out + @to_string(v); }, O.None => { out = out + "?"; } }
+    match m.get(mx) { O.Some(v) => { out = out + @to_string(v); }, O.None => { out = out + "?"; } }
+    println("values=" + out);
+
+    let mxm1: i64 = mx - 1;
+    println("miss_mx-1=" + std.fmt.bool_to_string(m.contains(mxm1)));
+    println("miss_neg2=" + std.fmt.bool_to_string(m.contains(0 - 2)));
+    println("miss_1=" + std.fmt.bool_to_string(m.contains(1)));
+    0
+}
+""" }]
+
+# THE one-copy detector. 403 entries against a starting capacity of 8 force
+# repeated `_grow_to` calls, and half the keys are negative, so a `_grow_to`
+# whose hash disagrees with `_slot` re-places them into slots `get` will never
+# probe. Verified by hand: reverting `_grow_to` alone to the old magnitude hash
+# drops `roundtrip` from 400 to 225, so this case fails loudly on divergence
+# rather than merely on the MIN key.
+[[case]]
+name = "intmap_extreme_keys_survive_growth"
+description = "i64::MIN/MIN+1/MAX and 400 mixed-sign keys all still resolve after repeated rehashing (RUE-1709)."
+differential_opt = true
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 0
+stdout = """len=403
+extremes=111 222 333
+roundtrip=400
+remove_min=true
+contains_min=false
+min+1_still=222
+"""
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let M = std.intmap.IntMap(i64);
+    let O = std.option.Option(i64);
+    let mut m = M.new(0);
+
+    let mn: i64 = @int_min(i64);
+    let mx: i64 = @int_max(i64);
+    let mnp1: i64 = mn + 1;
+
+    // Seeded BEFORE the bulk load so they are carried through every growth.
+    m.insert(mn, 111);
+    m.insert(mnp1, 222);
+    m.insert(mx, 333);
+
+    // Cap starts at 8; 400 more keys, half of them negative, force repeated
+    // _grow_to calls, each re-placing every live entry.
+    let mut i: i64 = 1;
+    while i <= 200 {
+        m.insert(0 - i * 1000, i);
+        m.insert(i * 1000, 0 - i);
+        i += 1;
+    }
+    println("len=" + @to_string(m.len()));
+
+    let mut out = StrBuf.new();
+    match m.get(mn) { O.Some(v) => { out = out + @to_string(v); }, O.None => { out = out + "?"; } }
+    out = out + " ";
+    match m.get(mnp1) { O.Some(v) => { out = out + @to_string(v); }, O.None => { out = out + "?"; } }
+    out = out + " ";
+    match m.get(mx) { O.Some(v) => { out = out + @to_string(v); }, O.None => { out = out + "?"; } }
+    println("extremes=" + out);
+
+    let mut ok: i64 = 0;
+    let mut j: i64 = 1;
+    while j <= 200 {
+        match m.get(0 - j * 1000) { O.Some(v) => { if v == j { ok += 1; } }, O.None => {} }
+        match m.get(j * 1000) { O.Some(v) => { if v == 0 - j { ok += 1; } }, O.None => {} }
+        j += 1;
+    }
+    println("roundtrip=" + @to_string(ok));
+
+    // Removal probes with the same hash, so it must find MIN in the grown
+    // table too — and must not disturb its neighbour.
+    println("remove_min=" + std.fmt.bool_to_string(m.remove(mn)));
+    println("contains_min=" + std.fmt.bool_to_string(m.contains(mn)));
+    match m.get(mnp1) { O.Some(v) => { println("min+1_still=" + @to_string(v)); }, O.None => { println("min+1_still=none"); } }
+    0
+}
+""" }]

--- a/crates/rue-cli-tests/cases/std_core.toml
+++ b/crates/rue-cli-tests/cases/std_core.toml
@@ -105,3 +105,319 @@ fn main() -> i32 {
     @intCast(std.cmp.min(i64, 3, 7))
 }
 """ }]
+
+# ── std.math at the type extremes (RUE-1708) ────────────────────────────────
+#
+# The M1 smoke case above exercises gcd/isqrt/is_prime on comfortable mid-range
+# values, which is exactly where these helpers were already correct. All three
+# bugs lived at the ends of the type, where a mid-range sweep structurally
+# cannot reach — hence this separate block:
+#
+#   is_prime  `i * i <= n` overflowed before the loop could exit for a prime
+#             near `@int_max(T)`: `is_prime(i32, 2147483647)` — a Mersenne
+#             prime — TRAPPED instead of answering `true`. The bound is now
+#             `i <= n / i`, the same overflow-free comparison `isqrt` uses,
+#             which fixes every width at once, so widths are checked here.
+#   gcd       `if a < 0 { -a }` trapped for a `T::MIN` operand even when the
+#             answer fit perfectly well: `gcd(i64::MIN, 2)` is 2. Euclid now
+#             runs on the signed values and normalises the sign at the end.
+#   lcm       inherited the same negation. `|lcm(T::MIN, x)|` is a multiple of
+#             `2^(bits-1)` for every non-zero `x` and so is never
+#             representable, making that one a diagnosable panic rather than a
+#             rescued value.
+
+# Every width up to 32 bits, at and just below its maximum. A prime AT the max
+# is the shape that trapped; its composite neighbour pins that the new bound
+# did not simply make everything look prime.
+#
+# 64-bit maxima are deliberately absent: trial division on a prime near
+# `@int_max(i64)` runs ~3e9 iterations before `i` passes `isqrt(n)`, which is a
+# minutes-long case, not a test. The rewritten bound is width-independent, and
+# the six widths below (three of them wider than the `i32` repro) exercise it.
+[[case]]
+name = "math_is_prime_at_type_maxima"
+description = "is_prime answers correctly for primes at/near @int_max of i8/u8/i16/u16/i32/u32 (RUE-1708)."
+differential_opt = true
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 0
+stdout = """i8 127 true
+i8 126 false
+u8 251 true
+u8 255 false
+i16 32749 true
+i16 32767 false
+u16 65521 true
+u16 65535 false
+i32 2147483647 true
+i32 2147483646 false
+u32 4294967291 true
+u32 4294967295 false
+"""
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    // i8: 127 == @int_max(i8) is prime; 126 is not.
+    let a: i8 = @int_max(i8);
+    let b: i8 = 126;
+    println("i8 " + @to_string(a) + " " + std.fmt.bool_to_string(std.math.is_prime(i8, a)));
+    println("i8 " + @to_string(b) + " " + std.fmt.bool_to_string(std.math.is_prime(i8, b)));
+
+    // u8: 251 is the largest u8 prime; 255 == @int_max(u8) is 3*5*17.
+    let c: u8 = 251;
+    let d: u8 = @int_max(u8);
+    println("u8 " + @to_string(c) + " " + std.fmt.bool_to_string(std.math.is_prime(u8, c)));
+    println("u8 " + @to_string(d) + " " + std.fmt.bool_to_string(std.math.is_prime(u8, d)));
+
+    // i16: 32749 is the largest i16 prime; 32767 == @int_max(i16) is 7*31*151.
+    let e: i16 = 32749;
+    let f: i16 = @int_max(i16);
+    println("i16 " + @to_string(e) + " " + std.fmt.bool_to_string(std.math.is_prime(i16, e)));
+    println("i16 " + @to_string(f) + " " + std.fmt.bool_to_string(std.math.is_prime(i16, f)));
+
+    // u16: 65521 is the largest u16 prime; 65535 == @int_max(u16) is composite.
+    let g: u16 = 65521;
+    let h: u16 = @int_max(u16);
+    println("u16 " + @to_string(g) + " " + std.fmt.bool_to_string(std.math.is_prime(u16, g)));
+    println("u16 " + @to_string(h) + " " + std.fmt.bool_to_string(std.math.is_prime(u16, h)));
+
+    // i32: @int_max(i32) == 2^31-1 IS prime (Mersenne) — the original repro.
+    let i: i32 = @int_max(i32);
+    let j: i32 = 2147483646;
+    println("i32 " + @to_string(i) + " " + std.fmt.bool_to_string(std.math.is_prime(i32, i)));
+    println("i32 " + @to_string(j) + " " + std.fmt.bool_to_string(std.math.is_prime(i32, j)));
+
+    // u32: 4294967291 == 2^32-5 is the largest u32 prime.
+    let k: u32 = 4294967291;
+    let l: u32 = @int_max(u32);
+    println("u32 " + @to_string(k) + " " + std.fmt.bool_to_string(std.math.is_prime(u32, k)));
+    println("u32 " + @to_string(l) + " " + std.fmt.bool_to_string(std.math.is_prime(u32, l)));
+    0
+}
+""" }]
+
+# The small end and the negatives, so the rewritten bound is pinned across the
+# whole domain rather than only at the top.
+[[case]]
+name = "math_is_prime_small_and_negative"
+description = "is_prime rejects everything below 2 (i64::MIN included) and classifies 0..9 correctly."
+differential_opt = true
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 0
+stdout = "ffttftftff\nMIN false\n"
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    // n = 0..9 -> f f t t f t f t f f
+    let mut out = StrBuf.new();
+    let mut n: i64 = 0;
+    while n < 10 {
+        if std.math.is_prime(i64, n) { out = out + "t"; } else { out = out + "f"; }
+        n += 1;
+    }
+    println(out);
+    // A negative, and specifically i64::MIN: the `n < 2` guard must reject it
+    // before the new `n / i` bound is ever evaluated.
+    let mn: i64 = @int_min(i64);
+    println("MIN " + std.fmt.bool_to_string(std.math.is_prime(i64, mn)));
+    0
+}
+""" }]
+
+# gcd with a T::MIN operand. Every answer here is representable, so every one
+# of these previously-trapping calls must now simply produce it.
+[[case]]
+name = "math_gcd_at_type_min"
+description = "gcd(T::MIN, x) returns the true gcd instead of trapping on the negation (RUE-1708)."
+differential_opt = true
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 0
+stdout = """gcd(MIN,2)=2
+gcd(2,MIN)=2
+gcd(MIN,6)=2
+gcd(MIN,1)=1
+gcd(MIN,-1)=1
+gcd(MIN,MAX)=1
+gcd(MIN,2^62)=4611686018427387904
+gcd(MIN,MIN+1)=1
+gcd(i8,MIN,2)=2
+gcd(i8,MIN,12)=4
+gcd(i32,MIN,-6)=2
+"""
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let mn: i64 = @int_min(i64);
+    let mx: i64 = @int_max(i64);
+    let one: i64 = 1;
+    let two: i64 = 2;
+    let six: i64 = 6;
+    let p62: i64 = 4611686018427387904;
+    println("gcd(MIN,2)=" + @to_string(std.math.gcd(i64, mn, two)));
+    println("gcd(2,MIN)=" + @to_string(std.math.gcd(i64, two, mn)));
+    println("gcd(MIN,6)=" + @to_string(std.math.gcd(i64, mn, six)));
+    // Magnitude-1 operands are answered before Euclid runs, because the
+    // remainder `T::MIN % -1` traps on its own (the quotient overflows).
+    println("gcd(MIN,1)=" + @to_string(std.math.gcd(i64, mn, one)));
+    println("gcd(MIN,-1)=" + @to_string(std.math.gcd(i64, mn, 0 - one)));
+    println("gcd(MIN,MAX)=" + @to_string(std.math.gcd(i64, mn, mx)));
+    // The largest representable answer involving MIN: gcd(2^63, 2^62).
+    println("gcd(MIN,2^62)=" + @to_string(std.math.gcd(i64, mn, p62)));
+    println("gcd(MIN,MIN+1)=" + @to_string(std.math.gcd(i64, mn, mn + 1)));
+
+    // The same hole existed at every signed width, so check narrower ones too.
+    let i8mn: i8 = @int_min(i8);
+    let i8a: i8 = 2;
+    let i8b: i8 = 12;
+    println("gcd(i8,MIN,2)=" + @to_string(std.math.gcd(i8, i8mn, i8a)));
+    println("gcd(i8,MIN,12)=" + @to_string(std.math.gcd(i8, i8mn, i8b)));
+    let i32mn: i32 = @int_min(i32);
+    let i32b: i32 = 0 - 6;
+    println("gcd(i32,MIN,-6)=" + @to_string(std.math.gcd(i32, i32mn, i32b)));
+    0
+}
+""" }]
+
+# The ordinary domain — every sign combination, both zero cases, and unsigned
+# instantiations — so the sign-at-the-end rewrite is pinned against everything
+# the old body handled, not just the corner it broke on.
+[[case]]
+name = "math_gcd_signs_zero_and_unsigned"
+description = "gcd stays non-negative for every sign combination, gcd(0,0)==0, and unsigned T instantiates at all."
+differential_opt = true
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 0
+stdout = """12 12 12 12
+0 36 36
+1 1 1
+25 50 3
+"""
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let a: i64 = 48;
+    let b: i64 = 36;
+    let z: i64 = 0;
+    let one: i64 = 1;
+    println(@to_string(std.math.gcd(i64, a, b)) + " "
+        + @to_string(std.math.gcd(i64, 0 - a, b)) + " "
+        + @to_string(std.math.gcd(i64, a, 0 - b)) + " "
+        + @to_string(std.math.gcd(i64, 0 - a, 0 - b)));
+    println(@to_string(std.math.gcd(i64, z, z)) + " "
+        + @to_string(std.math.gcd(i64, z, b)) + " "
+        + @to_string(std.math.gcd(i64, b, z)));
+    let p17: i64 = 17;
+    let p13: i64 = 13;
+    println(@to_string(std.math.gcd(i64, p17, p13)) + " "
+        + @to_string(std.math.gcd(i64, one, b)) + " "
+        + @to_string(std.math.gcd(i64, 0 - one, b)));
+
+    // UNSIGNED instantiations. The pre-RUE-1708 body reached for unary `-`,
+    // which E0801 rejects outright on an unsigned type, so `gcd` did not even
+    // COMPILE at unsigned `T` — despite its doc claiming to work for any `T`.
+    // The rewrite spells the negation `zero - x`, so these now build and run.
+    let s8: i8 = 0 - 100;
+    let t8: i8 = 75;
+    let u8a: u8 = 200;
+    let u8b: u8 = 150;
+    let u64a: u64 = @int_max(u64);
+    let u64b: u64 = 3;
+    println(@to_string(std.math.gcd(i8, s8, t8)) + " "
+        + @to_string(std.math.gcd(u8, u8a, u8b)) + " "
+        + @to_string(std.math.gcd(u64, u64a, u64b)));
+    0
+}
+""" }]
+
+# The gcd inputs whose true answer is |T::MIN| == 2^(bits-1) and so genuinely
+# does not fit in T. These stay failures, but honest ones: the panic names the
+# reason instead of reporting a bare "integer overflow" from a negation.
+[[case]]
+name = "math_gcd_unrepresentable_result_panics"
+description = "gcd(MIN, 0) panics naming the unrepresentable |T::MIN|, after a representable MIN call succeeds."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 101
+stdout = "2\n"
+runtime_error_contains = ["panic: gcd: |T::MIN| is not representable in T"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let mn: i64 = @int_min(i64);
+    let two: i64 = 2;
+    let z: i64 = 0;
+    // Representable first, so the panic below is provably about the MIN/0
+    // pairing and not about MIN appearing as an operand at all.
+    println(@to_string(std.math.gcd(i64, mn, two)));
+    println(@to_string(std.math.gcd(i64, mn, z)));
+    0
+}
+""" }]
+
+[[case]]
+name = "math_gcd_min_with_min_panics"
+description = "gcd(MIN, MIN) == 2^(bits-1) does not fit in T and panics rather than overflowing."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 101
+stdout = ""
+runtime_error_contains = ["panic: gcd: |T::MIN| is not representable in T"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let mn: i64 = @int_min(i64);
+    println(@to_string(std.math.gcd(i64, mn, mn)));
+    0
+}
+""" }]
+
+# lcm: the zero short-circuit still wins (even against MIN), and a non-zero MIN
+# operand is rejected with a message instead of trapping in the negation.
+[[case]]
+name = "math_lcm_zero_and_type_min"
+description = "lcm(0, MIN) and lcm(MIN, 0) are 0; a non-zero MIN operand panics as unrepresentable."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 101
+stdout = """12 12 12
+0 0 0 0
+"""
+runtime_error_contains = ["panic: lcm: a T::MIN operand has no representable lcm"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let four: i64 = 4;
+    let six: i64 = 6;
+    let z: i64 = 0;
+    let mn: i64 = @int_min(i64);
+    let two: i64 = 2;
+    println(@to_string(std.math.lcm(i64, four, six)) + " "
+        + @to_string(std.math.lcm(i64, 0 - four, six)) + " "
+        + @to_string(std.math.lcm(i64, four, 0 - six)));
+    // `lcm(0, _) == 0` holds even when the other operand is MIN: the zero
+    // short-circuit runs before the MIN check.
+    println(@to_string(std.math.lcm(i64, z, six)) + " "
+        + @to_string(std.math.lcm(i64, six, z)) + " "
+        + @to_string(std.math.lcm(i64, z, mn)) + " "
+        + @to_string(std.math.lcm(i64, mn, z)));
+    println(@to_string(std.math.lcm(i64, mn, two)));
+    0
+}
+""" }]

--- a/crates/rue-cli-tests/cases/std_fmt_radix.toml
+++ b/crates/rue-cli-tests/cases/std_fmt_radix.toml
@@ -1,0 +1,266 @@
+# std.fmt.to_radix — the base contract, exercised DIRECTLY (RUE-1707).
+#
+# Until now `to_radix` was only reached through `to_hex` smoke checks
+# (std_core.toml, std_m3.toml), which pin base 16 and nothing else: the
+# documented "base 2..=16" contract had no coverage at either edge and none at
+# all outside it. That gap let three different misuses ship, each failing in its
+# own unhelpful way and none of them naming the base as the problem:
+#
+#   base 1   `m /= 1` never decreased `m`      -> INFINITE LOOP (no output ever)
+#   base 0   `m % 0`                           -> "division by zero" trap
+#   base 17+ digit 16 indexed a 16-byte table  -> "index out of bounds" trap,
+#                                                 but ONLY for values that
+#                                                 actually produce a digit > 15
+#
+# That last one is the dangerous one: `to_radix(255, 17)` produced no digit
+# above 15 and so returned a plausible, WRONG `"f0"` with exit 0. A partial
+# success that depends on the data is worse than any trap, so the out-of-range
+# bases below cover both a trapping value and a silently-succeeding one.
+#
+# `to_radix` now @panics on an out-of-contract base. These are runtime-visible
+# (stdout, exit code, stderr), so they are pinned exactly here rather than being
+# folded into a scoring case.
+
+[section]
+id = "cli.std_fmt_radix"
+name = "std.fmt.to_radix base contract"
+description = "Every in-contract base 2..=16 renders known output; every out-of-contract base panics."
+
+# ── in contract: 2..=16 ──────────────────────────────────────────────────────
+
+# One program, all fifteen legal bases, against a value whose digits exercise
+# the full 0-15 digit table (255 is `ff` in hex, `11111111` in binary).
+[[case]]
+name = "to_radix_all_bases_2_through_16"
+description = "255 rendered in every base 2..=16; exact digits pinned for all fifteen."
+differential_opt = true
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 0
+stdout = """2 11111111
+3 100110
+4 3333
+5 2010
+6 1103
+7 513
+8 377
+9 313
+10 255
+11 212
+12 193
+13 168
+14 143
+15 120
+16 ff
+"""
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let n: u64 = 255;
+    let mut base: u64 = 2;
+    while base <= 16 {
+        println(@to_string(base) + " " + std.fmt.to_radix(n, base));
+        base += 1;
+    }
+    0
+}
+""" }]
+
+# The `n == 0` early return predates the guard and must still short-circuit at
+# every legal base — and it must NOT short-circuit past the base check.
+[[case]]
+name = "to_radix_zero_at_every_legal_base"
+description = "to_radix(0, base) is \"0\" for every base 2..=16."
+differential_opt = true
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 0
+stdout = "000000000000000\n"
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let z: u64 = 0;
+    let mut out = StrBuf.new();
+    let mut base: u64 = 2;
+    while base <= 16 {
+        out = out + std.fmt.to_radix(z, base);
+        base += 1;
+    }
+    println(out);
+    0
+}
+""" }]
+
+# u64::MAX at both edges of the contract: the longest string base 2 can make
+# (64 digits) and the shortest base 16 can, with no digit lost or duplicated.
+[[case]]
+name = "to_radix_u64_max_at_contract_edges"
+description = "u64::MAX in base 2 (64 ones) and base 16 (16 f's); to_hex/to_binary agree."
+differential_opt = true
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 0
+stdout = """1111111111111111111111111111111111111111111111111111111111111111
+ffffffffffffffff
+1111111111111111111111111111111111111111111111111111111111111111
+ffffffffffffffff
+"""
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let n: u64 = @int_max(u64);
+    let b2: u64 = 2;
+    let b16: u64 = 16;
+    println(std.fmt.to_radix(n, b2));
+    println(std.fmt.to_radix(n, b16));
+    // The wrappers must route to exactly the same digits.
+    println(std.fmt.to_binary(n));
+    println(std.fmt.to_hex(n));
+    0
+}
+""" }]
+
+# ── out of contract: 0, 1, 17, and far above ─────────────────────────────────
+
+# base 1: the INFINITE LOOP. A hung test is invisible in a suite (it looks like
+# a slow machine, not a failure), so the value of this case is that it now
+# terminates at all — with a diagnosable message instead of never.
+[[case]]
+name = "to_radix_base_1_panics_instead_of_hanging"
+description = "to_radix(5, 1) panics; before the guard `m /= 1` looped forever."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 101
+stdout = ""
+runtime_error_contains = ["panic: to_radix: base must be 2..=16"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let n: u64 = 5;
+    let base: u64 = 1;
+    println(std.fmt.to_radix(n, base));
+    0
+}
+""" }]
+
+# base 0: previously "division by zero" from `m % 0` — a true statement about
+# the arithmetic that says nothing about the caller's actual mistake.
+[[case]]
+name = "to_radix_base_0_panics_not_divide_by_zero"
+description = "to_radix(5, 0) names the base contract, not the `m % 0` it used to trap on."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 101
+stdout = ""
+runtime_error_contains = ["panic: to_radix: base must be 2..=16"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let n: u64 = 5;
+    let base: u64 = 0;
+    println(std.fmt.to_radix(n, base));
+    0
+}
+""" }]
+
+# base 17 with a value that DOES overflow the digit table (16 in base 17 is the
+# single digit 16): previously "index out of bounds".
+[[case]]
+name = "to_radix_base_17_trapping_value_panics"
+description = "to_radix(16, 17) panics on the base rather than indexing past the digit table."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 101
+stdout = ""
+runtime_error_contains = ["panic: to_radix: base must be 2..=16"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let n: u64 = 16;
+    let base: u64 = 17;
+    println(std.fmt.to_radix(n, base));
+    0
+}
+""" }]
+
+# base 17 with a value that does NOT overflow the digit table: 255 = 15*17 + 0,
+# so every digit stayed under 16 and the old code returned a confident "f0" and
+# exited 0. This is the case that makes the guard worth having — a wrong answer
+# nobody would think to check.
+[[case]]
+name = "to_radix_base_17_silently_wrong_value_now_panics"
+description = "to_radix(255, 17) used to print \"f0\" and exit 0; the data-dependent partial success is now rejected."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 101
+stdout = ""
+runtime_error_contains = ["panic: to_radix: base must be 2..=16"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let n: u64 = 255;
+    let base: u64 = 17;
+    println(std.fmt.to_radix(n, base));
+    0
+}
+""" }]
+
+# A base well outside the contract but still a plausible typo.
+[[case]]
+name = "to_radix_base_1000_panics"
+description = "A base of 1000 panics on the contract before any digit is indexed."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 101
+stdout = "before\n"
+runtime_error_contains = ["panic: to_radix: base must be 2..=16"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let n: u64 = 255;
+    let base: u64 = 1000;
+    // Pinning this line proves the panic comes from the call and not from
+    // something earlier in start-up.
+    println("before");
+    println(std.fmt.to_radix(n, base));
+    0
+}
+""" }]
+
+# u64::MAX as the base: `m % base == m`, so the very first digit would have
+# indexed the 16-byte table at 255.
+[[case]]
+name = "to_radix_base_u64_max_panics"
+description = "A base of u64::MAX panics on the contract rather than indexing the digit table at 255."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 101
+stdout = ""
+runtime_error_contains = ["panic: to_radix: base must be 2..=16"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let n: u64 = 255;
+    let base: u64 = @int_max(u64);
+    println(std.fmt.to_radix(n, base));
+    0
+}
+""" }]

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -474,6 +474,28 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::EmptySlicePointer),
         &[],
     ),
+    // IntMap key extremes (RUE-1709). These cases assert on stdout rather than
+    // an exit code, because a hash that mishandles `i64::MIN` or that diverges
+    // between `_slot` and `_grow_to` produces a WRONG VALUE, not a trap — so
+    // `println` is the first thing the oracle model cannot follow in each.
+    Entry::new(
+        "cli.std_collections",
+        "intmap_extreme_keys_survive_growth",
+        runtime_call(UnsupportedRuntimeCallKind::Println),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_collections",
+        "intmap_key_i64_min_full_lifecycle",
+        runtime_call(UnsupportedRuntimeCallKind::Println),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_collections",
+        "intmap_negative_zero_positive_and_extreme_keys",
+        runtime_call(UnsupportedRuntimeCallKind::Println),
+        &[],
+    ),
     Entry::new(
         "cli.std_core",
         "std_core_m1_smoke",
@@ -483,6 +505,47 @@ const ENTRIES: &[Entry] = &[
         // ADR-0059 Phase 4 (RUE-962) the per-byte step is `@ptr_read` over a
         // `ptr u8` rather than the removed `@byte_read`.
         intrinsic(UnsupportedIntrinsicKind::PointerRead),
+        &[],
+    ),
+    // std.math at the type extremes (RUE-1708). Each case reports per-width
+    // answers on stdout, since the bugs produced traps and wrong booleans
+    // rather than distinguishable exit codes. `math_is_prime_small_and_negative`
+    // registers ByteCopy instead of Println because it accumulates its answer
+    // into a `StrBuf` before printing, so the copy is reached first.
+    Entry::new(
+        "cli.std_core",
+        "math_gcd_at_type_min",
+        runtime_call(UnsupportedRuntimeCallKind::Println),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_core",
+        "math_gcd_signs_zero_and_unsigned",
+        runtime_call(UnsupportedRuntimeCallKind::Println),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_core",
+        "math_gcd_unrepresentable_result_panics",
+        runtime_call(UnsupportedRuntimeCallKind::Println),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_core",
+        "math_is_prime_at_type_maxima",
+        runtime_call(UnsupportedRuntimeCallKind::Println),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_core",
+        "math_is_prime_small_and_negative",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_core",
+        "math_lcm_zero_and_type_min",
+        runtime_call(UnsupportedRuntimeCallKind::Println),
         &[],
     ),
     // std.env (RUE-935): argv/envp are captured process state, so the oracle
@@ -528,6 +591,37 @@ const ENTRIES: &[Entry] = &[
         "cli.std_exit",
         "std_exit_terminates_with_status",
         external(ExternalDependencyKind::SystemCall),
+        &[],
+    ),
+    // std.fmt.to_radix's base contract (RUE-1707). The three in-contract cases
+    // render digits to stdout, which the oracle model cannot follow past the
+    // `StrBuf` copy or the `println`. `to_radix_base_1000_panics` joins them
+    // because it deliberately prints a line BEFORE the guard fires; the other
+    // out-of-contract cases (base 0/1/17/u64::MAX) produce no stdout at all and
+    // assert only the `@panic` trap, which is a harness observation rather than
+    // oracle debt, so they are absent here by design.
+    Entry::new(
+        "cli.std_fmt_radix",
+        "to_radix_all_bases_2_through_16",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_fmt_radix",
+        "to_radix_base_1000_panics",
+        runtime_call(UnsupportedRuntimeCallKind::Println),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_fmt_radix",
+        "to_radix_u64_max_at_contract_edges",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_fmt_radix",
+        "to_radix_zero_at_every_legal_base",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(

--- a/std/fmt.rue
+++ b/std/fmt.rue
@@ -24,7 +24,20 @@ pub fn bool_to_string(b: bool) -> StrBuf {
 }
 
 // Unsigned value in an arbitrary base 2..=16, lowercase, no prefix.
+//
+// The base is CHECKED (RUE-1707): it is a contract, not a hint, and an
+// out-of-range base @panics instead of misbehaving. Unguarded, every kind of
+// misuse failed differently and none of them named the real mistake:
+//   * `base == 1` never decreased `m` (`m /= 1`) — an INFINITE LOOP;
+//   * `base == 0` trapped on `m % 0` with "division by zero";
+//   * `base >= 17` indexed past the 16-entry `digits` table, but only once a
+//     digit above 15 actually came up, so `to_radix(16, 17)` trapped with
+//     "index out of bounds" while `to_radix(255, 17)` silently returned a
+//     WRONG "f0" — a data-dependent partial success, the worst of the three.
 pub fn to_radix(n: u64, base: u64) -> StrBuf {
+    if base < 2 || base > 16 {
+        @panic("to_radix: base must be 2..=16");
+    }
     if n == 0 {
         return "0";
     }

--- a/std/intmap.rue
+++ b/std/intmap.rue
@@ -34,6 +34,44 @@ fn _TOMBSTONE() -> u8 {
     2
 }
 
+// Raw two's-complement bit pattern of an `i64` key, as a `u64`.
+//
+// `@intCast` PANICS on a negative source (the value is not representable in
+// u64), so a negative key has to be rebuilt with non-trapping arithmetic. The
+// old code used the magnitude, `@intCast(0 - k)` — which OVERFLOWS at
+// `i64::MIN`, whose negation does not fit in i64, making the single value
+// `@int_min(i64)` an unusable key on a map documented to take any `i64`
+// (RUE-1709). Reinterpreting the bits instead has no such hole.
+//
+// For k < 0: 2^64 - |k| == ~(|k| - 1), and |k| - 1 is spelled `0 - (k + 1)`
+// rather than `(0 - k) - 1` — `k + 1` is in range even at `i64::MIN`, so the
+// subtraction never overflows and the result @intCasts cleanly. `~` is a
+// bitwise op and never traps. (Same shape as `fs._i64_bits`, which rebuilds a
+// seek offset; that one still negates first and so keeps the MIN hole.)
+fn _key_bits(k: i64) -> u64 {
+    if k >= 0 {
+        @intCast(k)
+    } else {
+        let mag_minus_1: u64 = @intCast(0 - (k + 1));
+        ~mag_minus_1
+    }
+}
+
+// Non-negative hash of a key, BEFORE folding into a table. Uses only xorshifts
+// (a multiply would overflow-trap without wrapping arithmetic, RUE-647).
+//
+// This lives in ONE place on purpose. `_slot` and `_grow_to` both need it, and
+// while `_grow_to` carried its own inline copy the two could silently diverge —
+// a hash fix applied to `_slot` alone would place keys by the new hash and then
+// re-place them by the old one on growth, corrupting every lookup afterwards.
+fn _hash(k: i64) -> u64 {
+    let mut h: u64 = _key_bits(k);
+    h ^= (h >> 33);
+    h ^= (h >> 17);
+    h ^= (h >> 29);
+    h
+}
+
 pub fn IntMap(comptime V: type) -> type {
     let Keys = arraybuf.ArrayBuf(i64);
     let Vals = arraybuf.ArrayBuf(V);
@@ -69,18 +107,9 @@ pub fn IntMap(comptime V: type) -> type {
             self.count == 0
         }
 
-        // Non-negative hash of `k` folded into `[0, cap)`. Uses only xorshifts
-        // (a multiply would overflow-trap without wrapping arithmetic, RUE-647).
+        // The module-level `_hash` folded into `[0, cap)`.
         fn _slot(borrow self, k: i64) -> u64 {
-            let mut h: u64 = if k < 0 {
-                @intCast(0 - k)
-            } else {
-                @intCast(k)
-            };
-            h ^= (h >> 33);
-            h ^= (h >> 17);
-            h ^= (h >> 29);
-            h % self.cap
+            _hash(k) % self.cap
         }
 
         // Re-hash into a table of `new_cap` slots.
@@ -105,16 +134,11 @@ pub fn IntMap(comptime V: type) -> type {
                 if self.states.get_or(j, _EMPTY()) == _OCCUPIED() {
                     let k = self.keys.get_or(j, 0);
                     let v = self.vals.get_or(j, self.filler);
-                    // insert into the new arrays by linear probing
-                    let mut h: u64 = if k < 0 {
-                        @intCast(0 - k)
-                    } else {
-                        @intCast(k)
-                    };
-                    h ^= (h >> 33);
-                    h ^= (h >> 17);
-                    h ^= (h >> 29);
-                    let mut idx = h % new_cap;
+                    // Insert into the new arrays by linear probing. `_slot`
+                    // cannot serve here — it folds by `self.cap`, which is
+                    // still the OLD capacity — so fold the shared `_hash` by
+                    // `new_cap` directly rather than re-deriving the hash.
+                    let mut idx = _hash(k) % new_cap;
                     while ns.get_or(idx, _EMPTY()) == _OCCUPIED() {
                         idx = (idx + 1) % new_cap;
                     }

--- a/std/math.rue
+++ b/std/math.rue
@@ -55,28 +55,75 @@ pub fn sign(comptime T: type, x: T) -> T {
 }
 
 // Greatest common divisor (Euclid). The result is non-negative for signed `T`;
-// `gcd(0, 0) == 0`. Absolute value is inlined so the helper works for any `T`.
+// `gcd(0, 0) == 0`.
+//
+// Euclid runs on the SIGNED values and the sign is normalised only at the end
+// (RUE-1708). Taking `|a|`/`|b|` up front — the old shape — trapped for a
+// `T::MIN` operand, whose negation is not representable, even when the answer
+// plainly was: `gcd(i64::MIN, 2) == 2`. Rue's `%` truncates toward zero, so
+// the remainder's magnitude still strictly decreases whatever the signs are
+// and the loop terminates exactly as before.
+//
+// PANICS only when the true gcd is `|T::MIN| == 2^(bits-1)`, which no signed
+// `T` can hold: that is `gcd(MIN, 0)`, `gcd(0, MIN)` and `gcd(MIN, MIN)`.
 pub fn gcd(comptime T: type, a: T, b: T) -> T {
-    let mut x = if a < 0 { -a } else { a };
-    let mut y = if b < 0 { -b } else { b };
+    if @int_min(T) != 0 {
+        // Signed `T`. The remainder `T::MIN % -1` traps (its quotient
+        // overflows), so answer the magnitude-1 operands up front; their gcd
+        // with anything is 1. That is the only pairing the loop below could
+        // hit with `T::MIN` as the dividend. `minus_one` is computed rather
+        // than written as a literal so this whole (unsigned-unreachable) block
+        // still type-checks at unsigned `T`, exactly as in `checked_mul`.
+        let zero: T = 0;
+        let minus_one: T = zero - 1;
+        if a == 1 || b == 1 || a == minus_one || b == minus_one {
+            return 1;
+        }
+    }
+    let mut x = a;
+    let mut y = b;
     while y != 0 {
         let t = y;
         y = x % y;
         x = t;
     }
+    if x < 0 {
+        if x == @int_min(T) {
+            @panic("gcd: |T::MIN| is not representable in T");
+        }
+        // `0 - x`, not `-x`: unary `-` is rejected outright on an unsigned
+        // type (E0801) even in a branch that unsigned `T` can never reach, so
+        // writing it that way would break every unsigned instantiation at
+        // COMPILE time — as the pre-RUE-1708 body silently did, despite the
+        // doc's claim to work for any `T`.
+        let zero: T = 0;
+        return zero - x;
+    }
     x
 }
 
-// Least common multiple. `lcm(0, _) == 0`. SIGNED `T`.
+// Least common multiple. `lcm(0, _) == 0`. SIGNED `T`. Traps on overflow.
+//
+// PANICS for a non-zero `T::MIN` operand (RUE-1708): `|lcm(T::MIN, x)|` is
+// `2^(bits-1)` times an odd factor for every non-zero `x`, so it is never
+// representable — unlike `gcd`, there is nothing to rescue here. Rejecting
+// `T::MIN` up front is also what makes the closing negation safe: for the
+// product to land exactly on `T::MIN`, one operand's magnitude would have to
+// be `2^(bits-1)` itself.
 pub fn lcm(comptime T: type, a: T, b: T) -> T {
     if a == 0 {
-        0
-    } else if b == 0 {
-        0
-    } else {
-        let m = a / gcd(T, a, b) * b;
-        if m < 0 { -m } else { m }
+        return 0;
     }
+    if b == 0 {
+        return 0;
+    }
+    if a == @int_min(T) || b == @int_min(T) {
+        // Unreachable for unsigned `T`: there `@int_min(T)` is 0, already
+        // handled above.
+        @panic("lcm: a T::MIN operand has no representable lcm");
+    }
+    let m = a / gcd(T, a, b) * b;
+    if m < 0 { -m } else { m }
 }
 
 // Integer exponentiation by squaring: `base ** exp`. Traps on overflow.
@@ -123,12 +170,19 @@ pub fn is_pow_of_two(comptime T: type, n: T) -> bool {
 }
 
 // Trial-division primality test.
+//
+// The loop bound is `i <= n / i`, NOT `i * i <= n`: for a prime near
+// `@int_max(T)` the loop only exits once `i` passes `isqrt(n)`, and there the
+// square overflows and traps before the comparison can end it — `is_prime(i32,
+// 2147483647)` trapped instead of returning `true` (RUE-1708). Dividing is the
+// same overflow-free trick `isqrt` above uses, and it fixes every `T` at once.
+// `i >= 2` throughout, so the division never divides by zero.
 pub fn is_prime(comptime T: type, n: T) -> bool {
     if n < 2 {
         return false;
     }
     let mut i: T = 2;
-    while i * i <= n {
+    while i <= n / i {
         if n % i == 0 {
             return false;
         }


### PR DESCRIPTION
Three std entry points failed on values their signatures accept. All three were reproduced on an unmodified checkout first, and every fix was re-verified by hand on the integrated tree.

## RUE-1707 — `to_radix` did not validate its base

`std/fmt.rue` documented "base 2..=16" and enforced nothing:

| call | before | now |
|---|---|---|
| `to_radix(5, 1)` | **infinite loop** (`m /= 1` never decreases `m`) | `panic: to_radix: base must be 2..=16` |
| `to_radix(5, 0)` | division-by-zero trap | same guard panic |
| `to_radix(16, 17)` | index-out-of-bounds trap | same guard panic |
| `to_radix(255, 17)` | silently printed `"f0"` | same guard panic |

The last row is the worst of them: bases ≥ 17 only misbehave when a digit exceeds 15, so misuse was data-dependent and could pass unnoticed. An entry guard turns a hang, two unrelated traps and a silent wrong answer into one diagnosable message. `to_radix(255, 16)` still prints `ff`.

## RUE-1708 — overflow traps at type extremes in `std/math.rue`

`is_prime`'s bound `i * i <= n` overflowed for a prime near the type maximum: the loop only exits once `i` passes `isqrt(n)`, and the square traps before the comparison can end it. `is_prime(i32, 2147483647)` trapped instead of returning `true`. The bound is now `i <= n / i` — the same overflow-free form `isqrt` already uses — which fixes every `T` at once; `i >= 2` throughout, so it never divides by zero.

`gcd` took `|a|` and `|b|` up front, trapping for a `T::MIN` operand even when the answer was representable (`gcd(i64::MIN, 2) == 2`). Euclid now runs on the signed values with the sign normalised at the end. Rue's `%` truncates toward zero, so remainder magnitude still strictly decreases and termination is unchanged. Magnitude-1 operands are answered up front because `T::MIN % -1` traps on quotient overflow, and that is the only pairing the loop could reach with `T::MIN` as dividend. `gcd` now panics only when the true gcd is `|T::MIN|`, which no signed `T` can hold.

That rewrite also fixes `gcd` at **unsigned** `T`, where it never compiled at all. Unary `-` is rejected outright on an unsigned type (E0801) even in a branch unsigned `T` can never reach, so the old body failed to compile for every unsigned instantiation while its doc promised any `T`. Verified against pristine trunk `std/`:

```
error: [E0801]: cannot apply unary operator `-` to type 'u64'
  --> std/math.rue:60:28
```

The negations are spelled `0 - x` for that reason.

`lcm` rejects a non-zero `T::MIN` operand up front: `|lcm(T::MIN, x)|` is `2^(bits-1)` times an odd factor for every non-zero `x` and is never representable. That check is also what makes the closing negation safe.

## RUE-1709 — `IntMap` trapped on key `i64::MIN`

`_slot` hashed negative keys as `@intCast(0 - k)`, which overflows at `i64::MIN` and made that single value unusable as a key on a map documented to take any `i64`. `_key_bits` reinterprets the two's-complement bit pattern instead, spelling `|k| - 1` as `0 - (k + 1)` so every intermediate stays in range.

The hash itself moves into one module-level `_hash`. `_grow_to` carried an **inline copy**, and while it did, a hash fix applied to `_slot` alone would place keys by the new hash and re-place them by the old one on growth, corrupting every later lookup. The extraction is part of the fix, not tidying — worker verification deliberately tested the detector by reverting `_grow_to` alone and watching the growth roundtrip drop from 400 to 225.

## Verified by hand on this tree

```
to_radix(5,1)            -> panic: to_radix: base must be 2..=16, exit 101   (was: hang)
to_radix(5,0) / (255,17) -> same guard panic                                  (was: trap / silent "f0")
to_radix(255,16)         -> ff                                                (control)
is_prime(i32, 2147483647)-> true                                              (was: overflow trap)
gcd(i64, i64::MIN, 2)    -> 2                                                 (was: overflow trap)
gcd(u64, 48, 18)         -> 6                                                 (was: E0801, did not compile)
MIN key + 64 inserts forcing growth -> min_after_growth=7, len=66             (was: trap)
```

Suites: `cli std_fmt_radix` 9/9, `cli std_collections` 5/5, `cli std_core` 9/9, `scripts/rue fmt` clean. Full `./test.sh` result is posted below once it completes; this PR stays a draft until then.

## One deliberate omission

`intmap_key_i64_min_full_lifecycle` is left **without** `differential_opt`, with an in-file comment explaining why, because of a pre-existing **-O2/-O3 miscompile** filed as RUE-1758: an `Option` `None` returned from a struct method is read as `Some(filler)` when a runtime-conditional `StrBuf` concat precedes the match. It reproduces on pristine trunk `std/` with an ordinary key 42 — no `i64::MIN`, no growth — so marking the case would report an optimizer bug as a std-library regression at the wrong address. The other two new IntMap cases do carry `differential_opt` and pass at all four levels.

Also registers 13 oracle model-gap entries that the fail-closed CLI corpus audit required.

Fixes: RUE-1707
Fixes: RUE-1708
Fixes: RUE-1709

---
_Generated by [Claude Code](https://claude.ai/code/session_01JekaZ8oUGSZPXQeodh3sy8)_