### PR TITLE
RUE-1751: migrate durable integer semantics

### DIFF
--- a/crates/rue-air/src/integer_semantics.rs
+++ b/crates/rue-air/src/integer_semantics.rs
@@ -181,12 +181,7 @@ impl IntegerType {
 
     pub fn checked_neg_report_i128(self, value: i128) -> CheckedIntegerResult {
         let value = self.canonicalize_i128(value);
-        if self.is_unsigned() {
-            let raw = (value == 0).then_some(0);
-            CheckedIntegerResult::from_raw(raw)
-        } else {
-            self.report_raw(value.checked_neg())
-        }
+        self.report_raw(value.checked_neg())
     }
 
     /// Negate an integer literal's mathematical magnitude.  Literal syntax
@@ -198,7 +193,7 @@ impl IntegerType {
     }
 
     pub fn checked_neg_literal_report_i128(self, magnitude: i128) -> CheckedIntegerResult {
-        if self.is_unsigned() || magnitude < 0 {
+        if magnitude < 0 {
             return CheckedIntegerResult::from_raw(None);
         }
         self.report_raw(magnitude.checked_neg())
@@ -418,6 +413,13 @@ mod tests {
         let i8 = IntegerType::new(8, true).unwrap();
         assert_eq!(u8.checked_neg_i128(256), Some(0));
         assert_eq!(i8.checked_neg_i128(128), None);
+
+        let unsigned = u8.checked_neg_report_i128(5);
+        assert_eq!(unsigned.raw(), Some(-5));
+        assert_eq!(unsigned.checked(), None);
+        let unsigned_literal = u8.checked_neg_literal_report_i128(5);
+        assert_eq!(unsigned_literal.raw(), Some(-5));
+        assert_eq!(unsigned_literal.checked(), None);
     }
 
     #[test]

--- a/crates/rue-cli-tests/cases/comptime_width_truncation.toml
+++ b/crates/rue-cli-tests/cases/comptime_width_truncation.toml
@@ -560,6 +560,35 @@ compile_fail = true
 error_contains = ["E1200", "remainder by zero", "would panic at runtime"]
 
 [[case]]
+name = "control_min_division_neg_one_still_rejected"
+description = "Division of a signed minimum by -1 overflows at runtime and must remain an E1200 in const position."
+files = [{ path = "main.rue", source = """
+const X: i8 = @int_min(i8) / -1;
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["E1200", "integer overflow", "i8"]
+
+[[case]]
+name = "control_min_remainder_neg_one_still_rejected"
+description = "Remainder of a signed minimum by -1 overflows at runtime and must remain an E1200 in const position."
+files = [{ path = "main.rue", source = """
+const X: i8 = @int_min(i8) % -1;
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["E1200", "integer overflow", "i8"]
+
+[[case]]
+name = "control_min_plus_one_remainder_neg_one_evaluates"
+description = "The signed minimum plus one is a valid dividend case, guarding against over-broad MIN/-1 rejection."
+files = [{ path = "main.rue", source = """
+const X: i8 = (@int_min(i8) + 1) % -1;
+fn main() -> i32 { @intCast(X) }
+""" }]
+exit_code = 0
+
+[[case]]
 name = "control_negate_minimum_still_rejected"
 description = "Negation is not a truncating operation: negating a type's minimum still overflows and is still E1200."
 files = [{ path = "main.rue", source = """

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -2828,6 +2828,83 @@ fn rue_1191_anonymous_digest_collision_authority_is_body_closure_owned() {
 }
 
 #[test]
+fn durable_const_integer_semantics_use_the_shared_kernel() {
+    let source = include_str!("revisioned_query_database.rs");
+    let fits = source
+        .split("fn durable_const_fits_type(")
+        .nth(1)
+        .and_then(|source| source.split("fn durable_int_width(").next())
+        .expect("durable integer fit adapter");
+    let evaluator = source
+        .split("impl SemanticConstEvaluator<'_, '_> {")
+        .nth(1)
+        .and_then(|source| source.split("impl SemanticNucleusTypeProvider<'_>").next())
+        .expect("durable evaluator source");
+    let arithmetic = evaluator
+        .split("fn eval_binary(")
+        .nth(1)
+        .and_then(|source| source.split("fn eval_block(").next())
+        .expect("durable arithmetic evaluator");
+    let unary = evaluator
+        .split("E::Neg { operand } | E::BitNot { operand }")
+        .nth(1)
+        .and_then(|source| source.split("E::Block { instructions }").next())
+        .expect("durable unary evaluator");
+    let arithmetic_policy = format!("{arithmetic}{unary}");
+
+    assert!(fits.contains("integer.fits_i128"));
+    for duplicated_fit in [
+        "i8::try_from",
+        "i16::try_from",
+        "i32::try_from",
+        "i64::try_from",
+        "u8::try_from",
+        "u16::try_from",
+        "u32::try_from",
+        "u64::try_from",
+    ] {
+        assert!(
+            !fits.contains(duplicated_fit),
+            "durable const fit checks regained local integer policy: {duplicated_fit}"
+        );
+    }
+
+    for required in [
+        "durable_int_width",
+        "checked_add_report_i128",
+        "checked_sub_report_i128",
+        "checked_mul_report_i128",
+        "checked_div_report_i128",
+        "checked_rem_report_i128",
+        "checked_neg_report_i128",
+        "checked_neg_literal_report_i128",
+        "compare_i128",
+    ] {
+        assert!(
+            evaluator.contains(required),
+            "durable evaluator missing {required}"
+        );
+    }
+    for forbidden in [
+        ".checked_add(",
+        ".checked_sub(",
+        ".checked_mul(",
+        ".checked_div(",
+        ".checked_rem(",
+        ".checked_neg(",
+        "left < right",
+        "left > right",
+        "left <= right",
+        "left >= right",
+    ] {
+        assert!(
+            !arithmetic_policy.contains(forbidden),
+            "durable evaluator regained local integer policy: {forbidden}"
+        );
+    }
+}
+
+#[test]
 fn import_resolution_remains_discovery_owned() {
     let production = PRODUCTION_MODULES
         .iter()

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -4278,14 +4278,9 @@ fn durable_const_fits_type(
 ) -> bool {
     use crate::durable_semantics::{DurableConstValue as V, DurableType as T};
     match (ty, value) {
-        (T::I8, V::Integer(value)) => i8::try_from(*value).is_ok(),
-        (T::I16, V::Integer(value)) => i16::try_from(*value).is_ok(),
-        (T::I32, V::Integer(value)) => i32::try_from(*value).is_ok(),
-        (T::I64, V::Integer(value)) => i64::try_from(*value).is_ok(),
-        (T::U8, V::Integer(value)) => u8::try_from(*value).is_ok(),
-        (T::U16, V::Integer(value)) => u16::try_from(*value).is_ok(),
-        (T::U32, V::Integer(value)) => u32::try_from(*value).is_ok(),
-        (T::U64, V::Integer(value)) => u64::try_from(*value).is_ok(),
+        (_, V::Integer(value)) => {
+            durable_int_width(ty).is_some_and(|integer| integer.fits_i128(*value))
+        }
         (T::Bool, V::Bool(_)) | (T::Unit, V::Unit) => true,
         (T::ComptimeType, V::Type(_)) => true,
         _ => false,
@@ -7295,6 +7290,28 @@ impl SemanticConstEvaluator<'_, '_> {
         }
     }
 
+    fn checked_integer_result(
+        ty: &crate::durable_semantics::DurableType,
+        result: rue_air::integer_semantics::CheckedIntegerResult,
+        operation: &str,
+    ) -> Result<i128, EvaluateSemanticConstError> {
+        let Some(value) = result.checked() else {
+            let type_name = durable_type_diagnostic_name(ty);
+            let detail = result.raw().map_or_else(
+                || format!("the result does not fit in {type_name}"),
+                |value| {
+                    format!(
+                        "value {value} is out of range for type {type_name}; {value} does not fit in {type_name}"
+                    )
+                },
+            );
+            return Err(Self::comptime_failure_value(format!(
+                "integer overflow evaluating {operation} at type {type_name}: {detail} (this operation would panic at runtime)",
+            )));
+        };
+        Ok(value)
+    }
+
     fn eval_binary(
         &mut self,
         op: SemanticBinaryOp,
@@ -7359,16 +7376,25 @@ impl SemanticConstEvaluator<'_, '_> {
         let operand_ty = self.integer_type(left_ty, right_ty)?;
         Self::require_integer_fits(&operand_ty, left)?;
         Self::require_integer_fits(&operand_ty, right)?;
+        let Some(integer) = durable_int_width(&operand_ty) else {
+            return Self::failure("comptime arithmetic operand is not an integer");
+        };
         let value = match op {
-            O::Add => V::Integer(left.checked_add(right).ok_or_else(|| {
-                Self::comptime_failure_value("integer overflow evaluating addition")
-            })?),
-            O::Sub => V::Integer(left.checked_sub(right).ok_or_else(|| {
-                Self::comptime_failure_value("integer overflow evaluating subtraction")
-            })?),
-            O::Mul => V::Integer(left.checked_mul(right).ok_or_else(|| {
-                Self::comptime_failure_value("integer overflow evaluating multiplication")
-            })?),
+            O::Add => V::Integer(Self::checked_integer_result(
+                &operand_ty,
+                integer.checked_add_report_i128(left, right),
+                "addition",
+            )?),
+            O::Sub => V::Integer(Self::checked_integer_result(
+                &operand_ty,
+                integer.checked_sub_report_i128(left, right),
+                "subtraction",
+            )?),
+            O::Mul => V::Integer(Self::checked_integer_result(
+                &operand_ty,
+                integer.checked_mul_report_i128(left, right),
+                "multiplication",
+            )?),
             O::Div if right == 0 => {
                 return Err(Self::comptime_failure_value(
                     "division by zero (this operation would panic at runtime)",
@@ -7379,18 +7405,22 @@ impl SemanticConstEvaluator<'_, '_> {
                     "remainder by zero (this operation would panic at runtime)",
                 ));
             }
-            O::Div => V::Integer(left.checked_div(right).ok_or_else(|| {
-                Self::comptime_failure_value("integer overflow evaluating division")
-            })?),
-            O::Mod => V::Integer(left.checked_rem(right).ok_or_else(|| {
-                Self::comptime_failure_value("integer overflow evaluating remainder")
-            })?),
-            O::Eq => V::Bool(left == right),
-            O::Ne => V::Bool(left != right),
-            O::Lt => V::Bool(left < right),
-            O::Gt => V::Bool(left > right),
-            O::Le => V::Bool(left <= right),
-            O::Ge => V::Bool(left >= right),
+            O::Div => V::Integer(Self::checked_integer_result(
+                &operand_ty,
+                integer.checked_div_report_i128(left, right),
+                "division",
+            )?),
+            O::Mod => V::Integer(Self::checked_integer_result(
+                &operand_ty,
+                integer.checked_rem_report_i128(left, right),
+                "remainder",
+            )?),
+            O::Eq => V::Bool(integer.compare_i128(left, right) == std::cmp::Ordering::Equal),
+            O::Ne => V::Bool(integer.compare_i128(left, right) != std::cmp::Ordering::Equal),
+            O::Lt => V::Bool(integer.compare_i128(left, right) == std::cmp::Ordering::Less),
+            O::Gt => V::Bool(integer.compare_i128(left, right) == std::cmp::Ordering::Greater),
+            O::Le => V::Bool(integer.compare_i128(left, right) != std::cmp::Ordering::Greater),
+            O::Ge => V::Bool(integer.compare_i128(left, right) != std::cmp::Ordering::Less),
             O::BitAnd => V::Integer(left & right),
             O::BitOr => V::Integer(left | right),
             O::BitXor => V::Integer(left ^ right),
@@ -7405,10 +7435,7 @@ impl SemanticConstEvaluator<'_, '_> {
                 // A non-integer operand type should be unreachable here, but a
                 // diagnosable failure beats an ICE if the type ever resolves to
                 // something unexpected.
-                let Some(width) = durable_int_width(&operand_ty) else {
-                    return Self::failure("comptime shift operand is not an integer");
-                };
-                V::Integer(width.shift_i128(left, right, op == O::Shl))
+                V::Integer(integer.shift_i128(left, right, op == O::Shl))
             }
             O::And | O::Or => unreachable!(),
         };
@@ -7418,9 +7445,6 @@ impl SemanticConstEvaluator<'_, '_> {
             let V::Integer(result) = value else {
                 unreachable!()
             };
-            // Only the trapping arms can land outside the operand type here:
-            // a truncated shift result fits its width by construction.
-            Self::require_integer_fits(&operand_ty, result)?;
             return Ok(EvaluatedSemanticConst::Value(TypedSemanticConst::typed(
                 V::Integer(result),
                 operand_ty,
@@ -8273,11 +8297,15 @@ impl SemanticConstEvaluator<'_, '_> {
                 let (operand_value, ty) = self.int_value(*operand)?;
                 let ty = self.integer_type(ty, None)?;
                 let result = if matches!(&instruction.data, E::Neg { .. }) {
-                    // Negation can overflow (`-@int_min(i8)`), and the runtime
-                    // panics there, so it stays range-checked below.
-                    operand_value.checked_neg().ok_or_else(|| {
-                        Self::comptime_failure_value("integer overflow evaluating negation")
-                    })?
+                    let Some(integer) = durable_int_width(&ty) else {
+                        return Self::failure("comptime negation operand is not an integer");
+                    };
+                    let report = if matches!(&self.rir.get(*operand).data, E::IntConst(_)) {
+                        integer.checked_neg_literal_report_i128(operand_value)
+                    } else {
+                        integer.checked_neg_report_i128(operand_value)
+                    };
+                    Self::checked_integer_result(&ty, report, "negation")?
                 } else {
                     // `~` is closed over the operand width and cannot trap:
                     // `~0u8` is 255, not the i128 -1 this used to compute and
@@ -8290,7 +8318,6 @@ impl SemanticConstEvaluator<'_, '_> {
                         ty,
                     )));
                 };
-                Self::require_integer_fits(&ty, result)?;
                 Ok(EvaluatedSemanticConst::Value(TypedSemanticConst::typed(
                     V::Integer(result),
                     ty,

--- a/crates/rue-spec/cases/items/constants.toml
+++ b/crates/rue-spec/cases/items/constants.toml
@@ -299,6 +299,38 @@ compile_fail = true
 error_contains = ["E1200", "remainder by zero"]
 
 [[case]]
+name = "const_signed_min_division_neg_one_is_compile_error"
+spec = ["6.5:12"]
+description = "A signed minimum divided by -1 overflows like the corresponding runtime operation."
+source = """
+const DIV: i8 = @int_min(i8) / -1;
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E1200", "integer overflow"]
+
+[[case]]
+name = "const_signed_min_remainder_neg_one_is_compile_error"
+spec = ["6.5:12"]
+description = "A signed minimum remainder by -1 overflows like the corresponding runtime operation."
+source = """
+const REM: i8 = @int_min(i8) % -1;
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E1200", "integer overflow"]
+
+[[case]]
+name = "const_signed_min_plus_one_remainder_neg_one_is_valid"
+spec = ["6.5:12"]
+description = "Only the exact signed minimum remainder by -1 overflows; the adjacent value remains valid."
+source = """
+const REM: i8 = (@int_min(i8) + 1) % -1;
+fn main() -> i32 { @intCast(REM) }
+"""
+exit_code = 0
+
+[[case]]
 name = "const_aggregate_initializer_rejected"
 spec = ["6.5:2"]
 description = "A struct literal is not compile-time evaluable, so an aggregate value const is rejected (E0434) (RUE-299)"


### PR DESCRIPTION
Relates to RUE-1751

## Summary

- route durable const add, subtract, multiply, divide, remainder, negation, comparison, and range checks through the shared integer-semantics kernel
- reject signed MIN % -1 in const position, matching body comptime and runtime trap semantics
- preserve width-specific overflow evidence, zero-divisor diagnostics, and negated-literal behavior
- add structural guards against restoring raw integer policy in the durable evaluator

## Scope

This is the second kernel slice after PR #2605 and builds on the durable shift/bitwise-NOT adapter from PR #2609. RUE-1751 remains open for inference-side consolidation under RUE-1750 and final cross-position structural deletion.

## Validation

- scripts/rue premerge — 196 passed, 0 failed, 0 timeouts
- focused durable kernel, CLI, and specification cases passed