### PR TITLE
RUE-1741: Reject duplicate test identities

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -307,6 +307,23 @@ cached_corpus_suite(
     ],
 )
 
+# RUE-1741: invoke every real test-harness entry point with a filtered,
+# duplicate corpus. The duplicate validator must reject the complete corpus
+# before platform filtering and before libtest2's concurrent scheduler sees a
+# passing case. The CLI fixture also collides with an automatically discovered
+# example, covering both Trial-producing populations.
+rue_sh_test(
+    name = "test-harness-duplicate-names",
+    test = "scripts/test-harness-duplicate-names.sh",
+    env = {
+        "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_CLI_HARNESS": "$(exe_target //crates/rue-cli-tests:rue-cli-tests)",
+        "RUE_SPEC_HARNESS": "$(exe_target //crates/rue-spec:rue-spec)",
+        "RUE_UI_HARNESS": "$(exe_target //crates/rue-ui-tests:rue-ui-tests)",
+    },
+    resources = ["scripts/test-harness-duplicate-names.sh"],
+)
+
 rue_sh_test(
     name = "spec-traceability",
     test = "//crates/rue-spec:rue-spec",

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -179,9 +179,9 @@ use libtest2_mimic::{Harness, RunContext, RunError, Trial};
 use rue_target::{Arch, Target};
 use rue_test_runner::{
     ExpectedFailureOutcome, KNOWN_TARGETS, PlatformCaseSelection, ShardSelector, TestFailure,
-    TestResult, classify_expected_failure, compiler_command, configure_process_group, find_dir,
-    find_rue_binary, ice_message, kill_process_group, run_with_timeout,
-    validate_nonempty_case_corpus,
+    TestNameOrigin, TestResult, classify_expected_failure, compiler_command,
+    configure_process_group, find_dir, find_rue_binary, ice_message, kill_process_group,
+    run_with_timeout, validate_nonempty_case_corpus, validate_unique_test_names,
 };
 use serde::{Deserialize, Serialize};
 
@@ -3815,6 +3815,27 @@ fn discover_examples() -> Result<Vec<DiscoveredExample>, String> {
         .collect())
 }
 
+/// Validate every declarative and automatic CLI identity before any tier,
+/// platform, or shard filtering can construct a trial.
+fn validate_cli_test_names(
+    corpus: &LoadedCorpus,
+    examples: &[DiscoveredExample],
+) -> Result<(), String> {
+    let explicit = corpus.files.iter().flat_map(|(source, file)| {
+        file.cases.iter().map(move |case| TestNameOrigin {
+            name: format!("{}::{}", file.section.id, case.name),
+            source: source.clone(),
+            case: case.name.clone(),
+        })
+    });
+    let automatic = examples.iter().map(|example| TestNameOrigin {
+        name: example_test_name(&example.relative_path),
+        source: example.path.display().to_string(),
+        case: example.relative_path.clone(),
+    });
+    validate_unique_test_names(explicit.chain(automatic))
+}
+
 /// Build one automatic smoke-test trial per discovered example (RUE-48).
 fn example_trials(
     examples: Vec<DiscoveredExample>,
@@ -3929,6 +3950,9 @@ fn emit_shard_loads(
     let cases_dir = find_dir("RUE_CLI_CASES", CASES_DIR_PATHS, "cases");
     let corpus = load_cases(&cases_dir);
     let examples = discover_examples()?;
+    if let Err(error) = validate_cli_test_names(&corpus, &examples) {
+        return Err(format!("invalid CLI test names: {error}"));
+    }
     let discovered_example_paths = examples
         .iter()
         .map(|example| example.relative_path.clone())
@@ -4011,6 +4035,10 @@ fn main() {
         eprintln!("error: {error}");
         std::process::exit(1);
     });
+    if let Err(error) = validate_cli_test_names(&corpus, &examples) {
+        eprintln!("error: invalid CLI test names: {error}");
+        std::process::exit(1);
+    }
     let discovered_example_paths = examples
         .iter()
         .map(|example| example.relative_path.clone())
@@ -4203,6 +4231,31 @@ mod tests {
             automatic_examples: file.automatic_example.clone(),
             files: vec![("inline.toml".to_string(), file)],
         }
+    }
+
+    #[test]
+    fn duplicate_cli_names_are_rejected_before_example_trials_are_built() {
+        let corpus = corpus_from_toml(
+            r#"
+                [section]
+                id = "cli.examples"
+                name = "examples"
+
+                [[case]]
+                name = "demo"
+            "#,
+        );
+        let examples = vec![DiscoveredExample {
+            path: PathBuf::from("examples/demo.rue"),
+            relative_path: "demo.rue".to_string(),
+        }];
+
+        let error = validate_cli_test_names(&corpus, &examples)
+            .expect_err("explicit and automatic duplicate must be rejected");
+        assert!(error.contains("cli.examples::demo"), "{error}");
+        assert!(error.contains("inline.toml"), "{error}");
+        assert!(error.contains("examples/demo.rue"), "{error}");
+        assert!(error.contains("case 'demo'"), "{error}");
     }
 
     #[test]

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -15,7 +15,7 @@ pub const DEFAULT_TIMEOUT_MS: u64 = 10_000;
 /// This matches the convention used by Rust's test harness and the Rue runtime.
 /// When a Rue program encounters a runtime error, it exits with this code.
 pub const RUNTIME_ERROR_EXIT_CODE: i32 = 101;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::io::{Read as IoRead, Write};
 use std::path::{Path, PathBuf};
@@ -1484,6 +1484,69 @@ pub fn expand_test_file(mut test_file: TestFile) -> TestFile {
     test_file
 }
 
+/// The source location of one expanded test identity.
+///
+/// Test harnesses use the identity as the key for libtest2's scheduler. Keep
+/// the source and case name alongside it so duplicate identities can be
+/// reported before any trials are constructed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TestNameOrigin {
+    /// The name passed to libtest2 (for example, `section::case`).
+    pub name: String,
+    /// The test file that declared the case.
+    pub source: String,
+    /// The expanded case name within the source file.
+    pub case: String,
+}
+
+/// Reject duplicate names in a complete, already-expanded test corpus.
+///
+/// This is intentionally shared by all harnesses. Filtering by tier, platform,
+/// selector, or shard must happen only after this check: otherwise a duplicate
+/// can hide in an unselected slice and still corrupt concurrent scheduling when
+/// a later invocation selects it.
+pub fn validate_unique_test_names<I>(origins: I) -> Result<(), String>
+where
+    I: IntoIterator<Item = TestNameOrigin>,
+{
+    let mut by_name: BTreeMap<String, Vec<TestNameOrigin>> = BTreeMap::new();
+    for origin in origins {
+        by_name.entry(origin.name.clone()).or_default().push(origin);
+    }
+
+    let duplicates = by_name
+        .into_iter()
+        .filter(|(_, origins)| origins.len() > 1)
+        .collect::<Vec<_>>();
+    if duplicates.is_empty() {
+        return Ok(());
+    }
+
+    let mut details = Vec::new();
+    for (name, mut origins) in duplicates {
+        origins.sort_by(|left, right| {
+            left.source
+                .cmp(&right.source)
+                .then_with(|| left.case.cmp(&right.case))
+        });
+        let locations = origins
+            .into_iter()
+            .map(|origin| format!("{} (case '{}')", origin.source, origin.case))
+            .collect::<Vec<_>>();
+        details.push(format!(
+            "duplicate test name '{}': {}",
+            name,
+            locations.join("; ")
+        ));
+    }
+
+    Err(format!(
+        "{} duplicate test name(s) found:\n  - {}",
+        details.len(),
+        details.join("\n  - ")
+    ))
+}
+
 /// An error indicating an unknown preview feature name was used in a test.
 #[derive(Debug, Clone)]
 pub struct UnknownPreviewFeatureError {
@@ -1848,6 +1911,7 @@ pub fn discover_files(dir: &Path, ext: &str) -> std::io::Result<Vec<PathBuf>> {
 /// parse, or validation failure instead of silently running a partial corpus.
 pub fn load_test_files(cases_dir: &Path) -> Result<Vec<(String, TestFile)>, String> {
     let mut specs = Vec::new();
+    let mut test_name_origins = Vec::new();
     let mut preview_errors: Vec<UnknownPreviewFeatureError> = Vec::new();
     let mut platform_errors: Vec<UnknownPlatformError> = Vec::new();
     let mut stray_error_assertions: Vec<StrayErrorAssertionError> = Vec::new();
@@ -1899,6 +1963,12 @@ pub fn load_test_files(cases_dir: &Path) -> Result<Vec<(String, TestFile)>, Stri
                 // a declared target a scoped host cannot execute (RUE-1161).
                 platform_responsibility.extend(validate_platform_responsibility(&spec));
 
+                test_name_origins.extend(spec.case.iter().map(|case| TestNameOrigin {
+                    name: format!("{}::{}", spec.section.id, case.name),
+                    source: path.display().to_string(),
+                    case: case.name.clone(),
+                }));
+
                 // Build a relative path from cases_dir to create the identifier
                 // e.g., "expressions/match" for "cases/expressions/match.toml"
                 let relative = path
@@ -1925,6 +1995,8 @@ pub fn load_test_files(cases_dir: &Path) -> Result<Vec<(String, TestFile)>, Stri
             load_errors.join("\n  - ")
         ));
     }
+
+    validate_unique_test_names(test_name_origins)?;
 
     // Report all preview feature errors and fail if any were found
     if !preview_errors.is_empty() {
@@ -3014,6 +3086,92 @@ exit_code = 0
         let error = load_test_files(directory.path()).unwrap_err();
         assert!(error.contains("b-malformed.toml"), "{error}");
         assert!(error.contains("failed to load"), "{error}");
+    }
+
+    #[test]
+    fn duplicate_test_names_are_rejected_with_both_same_file_cases() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::write(
+            directory.path().join("duplicates.toml"),
+            r#"
+[section]
+id = "test.section"
+name = "Test"
+
+[[case]]
+name = "same"
+source = "fn main() -> i32 { 0 }"
+exit_code = 0
+
+[[case]]
+name = "same"
+source = "fn main() -> i32 { 0 }"
+exit_code = 0
+"#,
+        )
+        .unwrap();
+
+        let error = load_test_files(directory.path()).expect_err("duplicate must not load");
+        assert!(
+            error.contains("duplicate test name 'test.section::same'"),
+            "{error}"
+        );
+        assert!(error.contains("duplicates.toml"), "{error}");
+        assert!(error.matches("case 'same'").count() >= 2, "{error}");
+    }
+
+    #[test]
+    fn duplicate_test_names_are_rejected_across_files() {
+        let directory = tempfile::tempdir().unwrap();
+        let file = || {
+            format!(
+                r#"
+[section]
+id = "test.section"
+name = "Test"
+
+[[case]]
+name = "same"
+source = "fn main() -> i32 {{ 0 }}"
+exit_code = 0
+"#
+            )
+        };
+        fs::write(directory.path().join("a.toml"), file()).unwrap();
+        fs::write(directory.path().join("b.toml"), file()).unwrap();
+
+        let error = load_test_files(directory.path()).expect_err("duplicate must not load");
+        assert!(error.contains("a.toml"), "{error}");
+        assert!(error.contains("b.toml"), "{error}");
+        assert!(error.contains("case 'same'"), "{error}");
+    }
+
+    #[test]
+    fn duplicate_test_names_are_rejected_after_parameter_expansion() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::write(
+            directory.path().join("parameterized.toml"),
+            r#"
+[section]
+id = "test.section"
+name = "Test"
+
+[[case]]
+name = "case_{variant}"
+source = "fn main() -> i32 { 0 }"
+exit_code = 0
+params = [
+  { variant = "same" },
+  { variant = "same" },
+]
+"#,
+        )
+        .unwrap();
+
+        let error = load_test_files(directory.path()).expect_err("duplicate must not load");
+        assert!(error.contains("test.section::case_same"), "{error}");
+        assert!(error.contains("parameterized.toml"), "{error}");
+        assert!(error.matches("case 'case_same'").count() >= 2, "{error}");
     }
 
     #[cfg(unix)]

--- a/scripts/test-harness-duplicate-names.sh
+++ b/scripts/test-harness-duplicate-names.sh
@@ -1,0 +1,281 @@
+#!/bin/sh
+set -eu
+
+# Exercise the actual spec, UI, and CLI entry points. The filtered fixtures put
+# a passing case on this host and a failing duplicate on another host, proving
+# validation happens before platform filtering. The all-selected fixtures put
+# both duplicates on this host, proving validation keeps them out of libtest2's
+# concurrent scheduler.
+
+: "${RUE_SPEC_HARNESS:?RUE_SPEC_HARNESS must point to the spec harness}"
+: "${RUE_UI_HARNESS:?RUE_UI_HARNESS must point to the UI harness}"
+: "${RUE_CLI_HARNESS:?RUE_CLI_HARNESS must point to the CLI harness}"
+: "${RUE_BINARY:?RUE_BINARY must point to the Rue compiler}"
+
+host_target() {
+    case "$(uname -s):$(uname -m)" in
+        Linux:x86_64) printf '%s\n' 'x86-64-linux' ;;
+        Linux:aarch64|Linux:arm64) printf '%s\n' 'aarch64-linux' ;;
+        Darwin:x86_64) printf '%s\n' 'x86-64-macos' ;;
+        Darwin:arm64|Darwin:aarch64) printf '%s\n' 'aarch64-macos' ;;
+        *)
+            echo "unsupported host for duplicate-harness regression: $(uname -s) $(uname -m)" >&2
+            exit 1
+            ;;
+    esac
+}
+
+host="$(host_target)"
+case "$host" in
+    x86-64-linux) foreign='aarch64-linux' ;;
+    aarch64-linux) foreign='x86-64-linux' ;;
+    x86-64-macos) foreign='aarch64-linux' ;;
+    aarch64-macos) foreign='x86-64-linux' ;;
+esac
+
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/rue-duplicate-harness.XXXXXX")"
+trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
+mkdir -p "$work_dir/spec" "$work_dir/ui" "$work_dir/cli" \
+    "$work_dir/spec-all" "$work_dir/ui-all" "$work_dir/cli-all" \
+    "$work_dir/examples" "$work_dir/std"
+
+write_shared_case() {
+    directory="$1"
+    cat > "$directory/a.toml" <<EOF
+[section]
+id = "duplicate.section"
+name = "Duplicate"
+
+[[case]]
+name = "same"
+source = "fn main() -> i32 { 0 }"
+exit_code = 0
+only_on = ["$host"]
+EOF
+    cat > "$directory/b.toml" <<EOF
+[section]
+id = "duplicate.section"
+name = "Duplicate"
+
+[[case]]
+name = "same"
+source = "fn main() -> i32 { 0 }"
+exit_code = 1
+only_on = ["$foreign"]
+EOF
+}
+
+write_shared_case "$work_dir/spec"
+write_shared_case "$work_dir/ui"
+
+# These all-selected fixtures deliberately put the failing case first in
+# deterministic source order, followed by a passing case. If the validator is
+# bypassed, libtest2 receives two Trial values with the same key while running
+# with two workers. Its completion map then loses one handle and can print a
+# recorded failure while still exiting zero. The expected path is the
+# validator's exact pre-scheduling boundary, not that false-green outcome.
+write_all_selected_shared_case() {
+    directory="$1"
+    cat > "$directory/a-failing.toml" <<EOF
+[section]
+id = "duplicate.concurrent"
+name = "Concurrent duplicates"
+
+[[case]]
+name = "same"
+source = "fn main() -> i32 { 0 }"
+exit_code = 1
+only_on = ["$host"]
+EOF
+    cat > "$directory/b-passing.toml" <<EOF
+[section]
+id = "duplicate.concurrent"
+name = "Concurrent duplicates"
+
+[[case]]
+name = "same"
+source = "fn main() -> i32 { 0 }"
+exit_code = 0
+only_on = ["$host"]
+EOF
+}
+
+write_all_selected_shared_case "$work_dir/spec-all"
+write_all_selected_shared_case "$work_dir/ui-all"
+
+cat > "$work_dir/cli/a.toml" <<EOF
+[timeout_profile.ordinary]
+compile_hang_timeout_ms = 1000
+runtime_hang_timeout_ms = 1000
+[timeout_profile.slow]
+compile_hang_timeout_ms = 2000
+runtime_hang_timeout_ms = 2000
+[timeout_profile.stress]
+compile_hang_timeout_ms = 3000
+runtime_hang_timeout_ms = 3000
+
+[section]
+id = "cli.examples"
+name = "CLI duplicates"
+
+[[case]]
+name = "demo"
+only_on = ["$host"]
+files = [{ path = "main.rue", source = "fn main() -> i32 { 0 }" }]
+exit_code = 0
+EOF
+cat > "$work_dir/cli/b.toml" <<EOF
+[section]
+id = "cli.examples"
+name = "CLI duplicates"
+
+[[case]]
+name = "demo"
+only_on = ["$foreign"]
+files = [{ path = "main.rue", source = "fn main() -> i32 { 0 }" }]
+exit_code = 1
+EOF
+cat > "$work_dir/examples/demo.rue" <<'EOF'
+fn main() -> i32 { 0 }
+EOF
+
+cat > "$work_dir/cli-all/a-failing.toml" <<EOF
+[timeout_profile.ordinary]
+compile_hang_timeout_ms = 1000
+runtime_hang_timeout_ms = 1000
+[timeout_profile.slow]
+compile_hang_timeout_ms = 2000
+runtime_hang_timeout_ms = 2000
+[timeout_profile.stress]
+compile_hang_timeout_ms = 3000
+runtime_hang_timeout_ms = 3000
+
+[section]
+id = "cli.concurrent"
+name = "CLI concurrent duplicates"
+
+[[case]]
+name = "same"
+only_on = ["$host"]
+files = [{ path = "main.rue", source = "fn main() -> i32 { 0 }" }]
+exit_code = 1
+EOF
+cat > "$work_dir/cli-all/b-passing.toml" <<EOF
+[section]
+id = "cli.concurrent"
+name = "CLI concurrent duplicates"
+
+[[case]]
+name = "same"
+only_on = ["$host"]
+files = [{ path = "main.rue", source = "fn main() -> i32 { 0 }" }]
+exit_code = 0
+EOF
+
+check_rejected() {
+    label="$1"
+    expected_name="$2"
+    expected_a="$3"
+    expected_b="$4"
+    expected_a_case="$5"
+    expected_b_case="$6"
+    expected_extra="$7"
+    expected_extra_case="$8"
+    shift 8
+
+    set +e
+    output="$("$@" 2>&1)"
+    status=$?
+    set -e
+    if [ "$status" -eq 0 ]; then
+        echo "$label unexpectedly passed; duplicate reached the harness" >&2
+        echo "$output" >&2
+        exit 1
+    fi
+    expected_line="  - duplicate test name '$expected_name': $expected_a (case '$expected_a_case'); $expected_b (case '$expected_b_case')"
+    if [ -n "$expected_extra" ]; then
+        expected_line="$expected_line; $expected_extra (case '$expected_extra_case')"
+    fi
+    printf '%s\n' "$output" | grep -F "$expected_line" >/dev/null
+    if printf '%s\n' "$output" | grep -F "running " >/dev/null; then
+        echo "$label entered libtest2 before reporting the duplicate" >&2
+        echo "$output" >&2
+        exit 1
+    fi
+}
+
+check_rejected \
+    spec \
+    'duplicate.section::same' \
+    "$work_dir/spec/a.toml" \
+    "$work_dir/spec/b.toml" \
+    same \
+    same \
+    '' \
+    '' \
+    env RUE_BINARY="$RUE_BINARY" RUE_SPEC_CASES="$work_dir/spec" \
+        RUE_PLATFORM_CASE_SELECTION=native "$RUE_SPEC_HARNESS" --test-threads=2 --quiet
+
+check_rejected \
+    ui \
+    'duplicate.section::same' \
+    "$work_dir/ui/a.toml" \
+    "$work_dir/ui/b.toml" \
+    same \
+    same \
+    '' \
+    '' \
+    env RUE_BINARY="$RUE_BINARY" RUE_UI_CASES="$work_dir/ui" \
+        RUE_PLATFORM_CASE_SELECTION=native "$RUE_UI_HARNESS" --test-threads=2 --quiet
+
+check_rejected \
+    spec-all-selected \
+    'duplicate.concurrent::same' \
+    "$work_dir/spec-all/a-failing.toml" \
+    "$work_dir/spec-all/b-passing.toml" \
+    same \
+    same \
+    '' \
+    '' \
+    env RUE_BINARY="$RUE_BINARY" RUE_SPEC_CASES="$work_dir/spec-all" \
+        RUE_PLATFORM_CASE_SELECTION=native "$RUE_SPEC_HARNESS" --test-threads=2 --quiet
+
+check_rejected \
+    ui-all-selected \
+    'duplicate.concurrent::same' \
+    "$work_dir/ui-all/a-failing.toml" \
+    "$work_dir/ui-all/b-passing.toml" \
+    same \
+    same \
+    '' \
+    '' \
+    env RUE_BINARY="$RUE_BINARY" RUE_UI_CASES="$work_dir/ui-all" \
+        RUE_PLATFORM_CASE_SELECTION=native "$RUE_UI_HARNESS" --test-threads=2 --quiet
+
+check_rejected \
+    cli \
+    'cli.examples::demo' \
+    "$work_dir/cli/a.toml" \
+    "$work_dir/cli/b.toml" \
+    demo \
+    demo \
+    "$work_dir/examples/demo.rue" \
+    demo.rue \
+    env RUE_BINARY="$RUE_BINARY" RUE_CLI_CASES="$work_dir/cli" \
+        RUE_EXAMPLES_DIR="$work_dir/examples" RUE_STD_DIR="$work_dir/std" \
+        RUE_REPO_DIR="$work_dir" RUE_CLI_CASE_TIER=premerge \
+        RUE_PLATFORM_CASE_SELECTION=native "$RUE_CLI_HARNESS" --test-threads=2 --quiet
+
+check_rejected \
+    cli-all-selected \
+    'cli.concurrent::same' \
+    "$work_dir/cli-all/a-failing.toml" \
+    "$work_dir/cli-all/b-passing.toml" \
+    same \
+    same \
+    '' \
+    '' \
+    env RUE_BINARY="$RUE_BINARY" RUE_CLI_CASES="$work_dir/cli-all" \
+        RUE_EXAMPLES_DIR="$work_dir/examples" RUE_STD_DIR="$work_dir/std" \
+        RUE_REPO_DIR="$work_dir" RUE_CLI_CASE_TIER=premerge \
+        RUE_PLATFORM_CASE_SELECTION=native "$RUE_CLI_HARNESS" --test-threads=2 --quiet


### PR DESCRIPTION
Summary:
- validate the complete expanded spec, UI, and CLI test identity sets before filtering, sharding, or scheduling
- include automatic CLI examples and report every colliding origin deterministically
- add real two-thread subprocess regressions for filtered and all-selected duplicate cases

Validation:
- ./buck2 test //:test-harness-duplicate-names
- scripts/rue quick
- scripts/rue premerge (197 passed)
- python3 scripts/validate-shell-bash-baseline.py .
- independent adversarial review

Fixes RUE-1741