### PR TITLE
RUE-1739: Reject empty explicit test filters

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -1609,6 +1609,26 @@ rue_sh_test(
     },
 )
 
+# Every corpus harness must reject an explicit name filter that selects no
+# cases. Keep this as a real subprocess test for all three binaries so a
+# wrapper or harness can’t hide a zero-test pass behind a helper-level check.
+rue_sh_test(
+    name = "zero-filter-harness-tests",
+    test = "scripts/test-zero-filter-harness.sh",
+    env = {
+        "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_SPEC_HARNESS": "$(exe_target //crates/rue-spec:rue-spec)",
+        "RUE_SPEC_CASES": "$(location //crates/rue-spec:cases)/cases",
+        "RUE_UI_HARNESS": "$(exe_target //crates/rue-ui-tests:rue-ui-tests)",
+        "RUE_UI_CASES": "$(location //crates/rue-ui-tests:cases)/cases",
+        "RUE_CLI_HARNESS": "$(exe_target //crates/rue-cli-tests:rue-cli-tests)",
+        "RUE_CLI_CASES": "$(location //crates/rue-cli-tests:cases)/cases",
+        "RUE_EXAMPLES_DIR": "$(location root//:examples)/examples",
+        "RUE_REPO_DIR": "$(location root//:cli-test-fixtures)",
+        "RUE_STD_DIR": "$(location :std)/std",
+    },
+)
+
 # RUE-1118: corpus-action decides whether a corpus suite's result is written to
 # the action cache, so its stamp-only-on-success and absolutization contracts
 # are pinned independently of any corpus actually running.

--- a/crates/rue-spec/README.md
+++ b/crates/rue-spec/README.md
@@ -111,12 +111,14 @@ of being matched against test names (`section.id::case_name`):
 scripts/rue spec 4.2       # every case citing a paragraph in section 4.2
 scripts/rue spec 4.2:5     # only the cases citing paragraph 4.2:5
 scripts/rue spec --spec 4.2:5   # explicit form
-scripts/rue spec arithmetic     # ordinary libtest name filter, unchanged
+scripts/rue spec arithmetic     # ordinary libtest name filter
 ```
 
-A selector that matches no case exits non-zero. A filter that silently selects
-nothing is how a mistyped paragraph ID becomes false evidence that a rule is
-exercised.
+The shared libtest layer rejects an ordinary name filter that selects no cases.
+Spec paragraph selectors that select no cases are rejected by the spec runner's
+own validation as well. An unfiltered spec run that leaves no cases after its
+platform selection remains an error from the spec runner; this shared layer
+does not alter that policy.
 
 ### Platform Responsibility
 

--- a/crates/rue-ui-tests/README.md
+++ b/crates/rue-ui-tests/README.md
@@ -62,8 +62,11 @@ no_warnings = true
 ./buck2 run //crates/rue-ui-tests:rue-ui-tests -- "unused"
 ```
 
+The shared libtest layer rejects an explicit name filter that selects no cases.
+An unfiltered UI run keeps its existing platform-ignore behavior; this shared
+layer only adds the explicit-filter check.
+
 #### When to Add UI Tests vs Spec Tests
 
 - **Spec tests** (`crates/rue-spec/cases/`): Language semantics defined in the specification. These tests have `spec = [...]` references linking to spec paragraphs.
 - **UI tests** (`crates/rue-ui-tests/cases/`): Compiler quality-of-life features not in the spec (warnings, diagnostics, CLI behavior).
-

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -289,6 +289,37 @@ test_rue_cli_examples_survive_case_chdir() {
   rm -rf "$sb"
 }
 
+# RUE-1739: the corpus wrappers must preserve the harness's non-zero result for
+# a typoed explicit name filter. The direct subprocess target separately proves
+# that the real binaries produce this diagnostic before scheduling any case.
+install_zero_filter_buck() {
+  local sb="$1"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "run" ] && [[ "$*" = *rue1739_filter_must_not_match* ]]; then
+  echo "no tests matched the given filter(s): rue1739_filter_must_not_match" >&2
+  exit 101
+fi
+exit 0
+EOF
+  chmod +x "$sb/buck2"
+}
+
+test_rue_corpus_wrappers_reject_zero_filter() {
+  local sb; sb="$(make_rue_sandbox)"
+  install_zero_filter_buck "$sb"
+  local kind rc out
+  for kind in spec ui cli; do
+    rc=0
+    out="$(cd "$sb/work" && "$sb/scripts/rue" "$kind" rue1739_filter_must_not_match 2>&1)" || rc=$?
+    check "scripts/rue $kind: zero-filter run exits non-zero" \
+      "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
+    check "scripts/rue $kind: zero-filter diagnostic is preserved" \
+      "$(grep -q 'no tests matched' <<<"$out" && echo 0 || echo 1)"
+  done
+  rm -rf "$sb"
+}
+
 # crates/clippy-gate.sh is the decision step behind every per-crate
 # <name>-clippy test (RUE-1153): the [clippy.txt] subtarget only captures
 # diagnostics, so this script decides pass/fail. Clean and warning-only files
@@ -1500,6 +1531,7 @@ test_fmt_uses_one_buck_run_and_preserves_paths
 test_rue_exec_resolves_from_caller_cwd
 test_rue_run_resolves_relative_output
 test_rue_cli_examples_survive_case_chdir
+test_rue_corpus_wrappers_reject_zero_filter
 test_clippy_gate_reads_diagnostics_and_fails_closed
 test_rue_named_test_tiers_delegate_to_testsh
 test_rue_quick_delegates_to_quick_testsh

--- a/scripts/test-zero-filter-harness.sh
+++ b/scripts/test-zero-filter-harness.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# End-to-end regression for explicit libtest name filters that select no cases.
+# Each runner must reject the filter before it can report a zero-test pass.
+set -uo pipefail
+
+failures=0
+checks=0
+
+check() {
+  checks=$((checks + 1))
+  if [ "$2" -eq 0 ]; then
+    printf 'ok: %s\n' "$1"
+  else
+    printf 'FAIL: %s\n' "$1" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+run_zero_filter() {
+  name="$1"
+  shift
+  output=''
+  rc=0
+  output="$("$@" rue1739_filter_must_not_match 2>&1)" || rc=$?
+  check "$name rejects an unmatched explicit filter" "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
+  check "$name explains that no tests matched" "$(grep -q 'no tests matched' <<<"$output" && echo 0 || echo 1)"
+}
+
+run_zero_filter spec env \
+  RUE_BINARY="${RUE_BINARY:?RUE_BINARY is required}" \
+  RUE_SPEC_CASES="${RUE_SPEC_CASES:?RUE_SPEC_CASES is required}" \
+  "${RUE_SPEC_HARNESS:?RUE_SPEC_HARNESS is required}"
+run_zero_filter ui env \
+  RUE_BINARY="${RUE_BINARY:?RUE_BINARY is required}" \
+  RUE_UI_CASES="${RUE_UI_CASES:?RUE_UI_CASES is required}" \
+  "${RUE_UI_HARNESS:?RUE_UI_HARNESS is required}"
+run_zero_filter cli env \
+  RUE_BINARY="${RUE_BINARY:?RUE_BINARY is required}" \
+  RUE_CLI_CASES="${RUE_CLI_CASES:?RUE_CLI_CASES is required}" \
+  RUE_EXAMPLES_DIR="${RUE_EXAMPLES_DIR:?RUE_EXAMPLES_DIR is required}" \
+  RUE_REPO_DIR="${RUE_REPO_DIR:?RUE_REPO_DIR is required}" \
+  RUE_STD_DIR="${RUE_STD_DIR:?RUE_STD_DIR is required}" \
+  "${RUE_CLI_HARNESS:?RUE_CLI_HARNESS is required}"
+
+printf '%s\n' '--------------------------------------------------'
+if [ "$failures" -eq 0 ]; then
+  printf 'zero-filter harness tests: all %s checks passed\n' "$checks"
+  exit 0
+fi
+printf 'zero-filter harness tests: %s of %s checks FAILED\n' "$failures" "$checks" >&2
+exit 1

--- a/third-party/reindeer_rules.bzl
+++ b/third-party/reindeer_rules.bzl
@@ -74,6 +74,11 @@ def _libtest2_scheduler_test():
     # remains executable regression coverage rather than an untested patch.
     native.rust_test(
         name = "libtest2-harness-scheduler-test",
+        # This is a Rue-maintained regression target, not an upstream test:
+        # keep its scheduler and filter-policy coverage in the canonical
+        # premerge selection even though the tier validator otherwise excludes
+        # vendored targets from first-party ownership checks.
+        labels = ["rue_test_tier_premerge"],
         srcs = [
             "vendor/libtest2-harness-0.0.3/src/case.rs",
             "vendor/libtest2-harness-0.0.3/src/cli.rs",

--- a/third-party/vendor/libtest2-harness-0.0.3/src/harness.rs
+++ b/third-party/vendor/libtest2-harness-0.0.3/src/harness.rs
@@ -123,6 +123,23 @@ impl Harness<StateParsed> {
             (priority, name)
         });
 
+        // A positive name filter is an assertion about the inventory, not
+        // merely an optimization.  Treat an empty selection as a harness
+        // error so a typo cannot report a passing (zero-test) run.  Leave
+        // unfiltered discovery alone: platform selection, sharding, and
+        // orchestration may intentionally produce an empty inventory.  The
+        // check is after `--skip` filtering, so a filter whose only matches
+        // are skipped is still an empty selection.
+        if !self.state.opts.filters.is_empty() && selected_cases.is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "no tests matched the given filter(s): {}",
+                    self.state.opts.filters.join(", ")
+                ),
+            ));
+        }
+
         self.state.notifier.notify(
             notify::event::DiscoverComplete {
                 elapsed_s: Some(notify::Elapsed(self.state.start.elapsed())),
@@ -759,5 +776,108 @@ mod tests {
         ));
         assert!(remaining_ran.load(Ordering::SeqCst));
         assert!(exclusive_ran.load(Ordering::SeqCst));
+    }
+
+    fn discover_with_args(
+        args: impl IntoIterator<Item = impl Into<std::ffi::OsString>>,
+        cases: Vec<SchedulerCase>,
+    ) -> std::io::Result<Harness<StateDiscovered>> {
+        Harness::new()
+            .with_args(args)?
+            .parse()
+            .expect("test arguments should parse")
+            .discover(cases)
+    }
+
+    fn passing_case(name: &'static str) -> SchedulerCase {
+        SchedulerCase::concurrent(name, |_| Ok(()))
+    }
+
+    #[test]
+    fn empty_unfiltered_discovery_is_still_allowed() {
+        let discovered = discover_with_args(["empty"], vec![]).unwrap();
+        assert!(discovered.run().unwrap());
+    }
+
+    #[test]
+    fn skip_only_empty_selection_is_still_allowed() {
+        let discovered = discover_with_args(
+            ["skip-only", "--skip", "selected"],
+            vec![passing_case("selected")],
+        )
+        .unwrap();
+        assert!(discovered.run().unwrap());
+    }
+
+    #[test]
+    fn a_positive_filter_eliminated_by_skip_is_an_error() {
+        let error = discover_with_args(
+            ["positive-and-skip", "--skip", "selected", "selected"],
+            vec![passing_case("selected")],
+        )
+        .err()
+        .unwrap();
+        assert!(error.to_string().contains("no tests matched"));
+        assert!(error.to_string().contains("selected"));
+    }
+
+    #[test]
+    fn exact_filters_require_the_complete_case_name() {
+        assert!(discover_with_args(
+            ["exact", "--exact", "exact::child"],
+            vec![passing_case("exact::child")],
+        )
+        .unwrap()
+        .run()
+        .unwrap());
+
+        let error = discover_with_args(
+            ["exact-partial", "--exact", "child"],
+            vec![passing_case("exact::child")],
+        )
+        .err()
+        .unwrap();
+        assert!(error.to_string().contains("no tests matched"));
+    }
+
+    #[test]
+    fn multiple_positive_filters_are_or_combined() {
+        assert!(discover_with_args(
+            ["multiple", "missing", "selected"],
+            vec![passing_case("selected")],
+        )
+        .unwrap()
+        .run()
+        .unwrap());
+    }
+
+    #[test]
+    fn list_does_not_turn_an_unmatched_filter_into_a_pass() {
+        let error = discover_with_args(
+            ["list", "--list", "missing"],
+            vec![passing_case("selected")],
+        )
+        .err()
+        .unwrap();
+        assert!(error.to_string().contains("no tests matched"));
+    }
+
+    #[test]
+    fn argfile_filters_are_checked_after_argument_expansion() {
+        let path = std::env::temp_dir().join(format!(
+            "libtest2-harness-filter-{}.args",
+            std::process::id()
+        ));
+        std::fs::write(&path, "missing\n").unwrap();
+        let argfile = format!("@{}", path.display());
+        let error = discover_with_args(
+            ["argfile", argfile.as_str()],
+            vec![passing_case("selected")],
+        )
+        .err()
+        .unwrap();
+        let _ = std::fs::remove_file(path);
+        assert!(error.to_string().contains("no tests matched"));
+        assert!(error.to_string().contains("missing"));
     }
 }


### PR DESCRIPTION
Summary:
- make explicit positive libtest filters that select no cases fail instead of reporting a zero-test pass
- preserve filter-free and skip-only generic harness behavior while pinning exact, multiple-filter, list, skip, and argfile semantics
- add real spec/UI/CLI subprocess and scripts/rue wrapper regressions
- route the Rue-maintained vendored harness tests into the canonical premerge tier

Validation:
- ./buck2 test //third-party:libtest2-harness-scheduler-test (10 passed)
- ./buck2 test //:zero-filter-harness-tests
- ./buck2 test //:wrapper-script-tests
- scripts/rue quick
- scripts/rue premerge (198 passed)
- Python 3.9 and Bash 3.2 baseline validation
- independent adversarial review

Fixes RUE-1739