### PR TITLE
RUE-1765: prove a batch of inline splices once, not once per splice

### DIFF
--- a/crates/rue-cfg/src/inline.rs
+++ b/crates/rue-cfg/src/inline.rs
@@ -270,7 +270,39 @@ pub fn inline_call_in_block(
     callee: &ValidatedCfg,
     type_pool: &FrozenTypeInternPool,
 ) -> Result<ValidatedCfg, CfgInlineError> {
-    let mut dst: Cfg = (**caller).clone();
+    splice_call_in_block(caller, call, call_block, callee, type_pool)?
+        .finish_after_optimization(type_pool)
+        .map_err(CfgInlineError::Verification)
+}
+
+/// Splice one call without minting the proof that the result is well formed.
+///
+/// [`inline_call_in_block`] is this plus a verification, and a driver inlining
+/// one call site wants exactly that. A driver inlining a *sequence* of call
+/// sites into one caller does not: `ValidatedCfg` can only be minted by
+/// verifying, so threading it through the loop re-proves the whole caller after
+/// every splice, over a caller that each splice has made bigger. On a fresh
+/// Lattice compile that was 2,112 verifications for 760 spliced functions,
+/// 150,324,778 instructions -- 2.3% of the compile spent re-proving what the
+/// previous splice already proved, before the pipeline's own
+/// `finish_after_optimization` proved it once more.
+///
+/// So a batch driver splices through this and verifies once at the end. The
+/// invariant that matters is unchanged: no CFG reaches a consumer without a
+/// full verification, because `optimize` still demands a `ValidatedCfg` and
+/// mints its own. What is given up is attribution -- a malformed splice is
+/// reported against the batch rather than against the splice that caused it,
+/// and a later splice reads a graph an earlier one may have broken. Every edit
+/// on that path is fallible and returns a typed error, so that surfaces as a
+/// rejected batch rather than as a corrupt artifact.
+pub fn splice_call_in_block(
+    caller: &Cfg,
+    call: CfgValue,
+    call_block: BlockId,
+    callee: &Cfg,
+    type_pool: &FrozenTypeInternPool,
+) -> Result<Cfg, CfgInlineError> {
+    let mut dst: Cfg = caller.clone();
 
     // -- Locate and validate the call site. ---------------------------------
     if call.as_u32() as usize >= dst.value_count() {
@@ -553,8 +585,7 @@ pub fn inline_call_in_block(
         substitute_accessor_places(&mut dst, call, &yielded_place, yielded_value)?;
     }
 
-    dst.finish_after_optimization(type_pool)
-        .map_err(CfgInlineError::Verification)
+    Ok(dst)
 }
 
 fn substitute_accessor_places(

--- a/crates/rue-cfg/src/lib.rs
+++ b/crates/rue-cfg/src/lib.rs
@@ -29,7 +29,7 @@ mod verify;
 use rue_error::{CompileError, CompileWarning};
 
 pub use build::CfgBuilder;
-pub use inline::{CfgInlineError, inline_call, inline_call_in_block};
+pub use inline::{CfgInlineError, inline_call, inline_call_in_block, splice_call_in_block};
 pub use inst::{
     BasicBlock, BlockId, Cfg, CfgArgMode, CfgCallArg, CfgDisplay, CfgEditError,
     CfgEditTransactionError, CfgEditor, CfgInst, CfgInstData, CfgPayloadStorageStats,

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -2067,7 +2067,15 @@ pub(crate) fn apply_general_inlining(
             .collect::<std::collections::BTreeSet<_>>();
         let mut implicit_destructor_dependencies_complete =
             record.implicit_destructor_dependencies_complete;
-        let mut current = record.cfg.clone();
+        // Splices run against a plain `Cfg` and the batch is verified once,
+        // below. `ValidatedCfg` can only be minted by verifying, so threading
+        // it through this loop re-proved the whole caller after every splice,
+        // over a caller each splice had just made bigger: 2,112 verifications
+        // for 760 spliced functions, 150,324,778 instructions on a fresh
+        // Lattice compile. Nothing read those proofs -- `optimize` below
+        // demands a `ValidatedCfg` and mints its own, so the graph that
+        // reaches a consumer is verified exactly as strictly as before.
+        let mut current: rue_cfg::Cfg = (*record.cfg).clone();
         let mut spliced = false;
         let mut failed = None;
         for (call, callee_function) in selected {
@@ -2143,7 +2151,7 @@ pub(crate) fn apply_general_inlining(
                     break;
                 }
             };
-            current = match rue_cfg::inline_call_in_block(
+            current = match rue_cfg::splice_call_in_block(
                 &current,
                 call,
                 call_block,
@@ -2166,6 +2174,17 @@ pub(crate) fn apply_general_inlining(
         if !spliced {
             continue;
         }
+        // The whole batch is proved here, once.
+        let current = match current.finish_after_optimization(&record.type_pool) {
+            Ok(cfg) => cfg,
+            Err(error) => {
+                output[index] = internal_failure(
+                    format!("general inline batch failed verification: {error}"),
+                    record.body_span,
+                );
+                continue;
+            }
+        };
         let current = match rue_cfg::opt::optimize(current, key.opt_level, &record.type_pool) {
             Ok(cfg) => cfg,
             Err(error) => {


### PR DESCRIPTION
**6,625,659,967 → 6,504,016,198 retired instructions, −1.84%**, on a fresh `-O3 -j1` Lattice build against trunk at `293a5178`. The emitted Lattice executable is byte-identical, and identical across three separate `-j4` compiles.

## What was happening

Profiling after #2585 put `Verifier::verify` at the top of the list: **306,536,979 instructions inclusive, 4.5%**, over **9,555 calls** — about 5.8 verifications per function. I first wrote that up as a question about how much confidence the pipeline wants to buy. That was the wrong framing. Attributing the calls shows most of them are not a choice anyone made:

| calls | Ir | site |
| ---: | ---: | --- |
| 2,112 | 150,324,778 | `apply_general_inlining` → `inline_call_in_block` → `finish_after_optimization` |
| 1,251 | 56,295,284 | `licm::run` → `ensure_preheader` |
| 1,660 | 34,703,150 | `build_cfg` — once per function |
| 1,660 | 32,167,000 | `evaluate_optimized_cfg` → `optimize_with_stats` — once per function |
| 760 | 25,096,107 | `apply_general_inlining` → `optimize_with_stats` — once per spliced function |
| 2,112 | 7,824,083 | `apply_general_inlining` → callee `finish_after_optimization` |

The first row is the problem. `ValidatedCfg(Cfg)` is a typestate — the only way to get one is to verify — and `inline_call_in_block` takes `&ValidatedCfg` and returns `ValidatedCfg`. So the splice loop

```rust
current = inline_call_in_block(&current, call, call_block, &callee_cfg, &record.type_pool)?;
```

re-proves the *entire caller* after every splice, over a caller that each splice has just made bigger. 2,112 splices across 760 spliced functions, at ~71,000 instructions each.

Nothing reads those proofs. `optimize` runs immediately afterwards, demands a `ValidatedCfg` of its own, and mints it by verifying again.

## The change

`splice_call_in_block` performs the splice without minting the proof. The loop runs against a plain `Cfg` and the batch is verified once at the end, so the graph that reaches a consumer is verified exactly as strictly as before — same verifier, same post-optimization contract, still in release. `inline_call_in_block` keeps its signature and its verification, because a driver splicing a single call site does want the proof immediately.

## What it costs

Attribution. A malformed splice is now reported against the batch rather than against the splice that caused it, and a later splice reads a graph an earlier one may have broken. Every edit on that path is fallible and returns a typed error rather than panicking, so a broken intermediate surfaces as a rejected batch, not as a corrupt artifact. The invariant RUE-45 cares about is untouched: the guard still runs in release, before publication.

## What I left alone

LICM's per-preheader `verify_materialization_with_type_pool` — 1,251 calls, 56,295,284 instructions, 0.85%. That one *is* deliberate: `ensure_preheader` already works on a `&mut Cfg` and asks for the scoped verifier explicitly, with a comment explaining which pre-DCE debris it tolerates and why it is checked at the point of materialization rather than left to the pipeline's final strict pass. Nothing forces it; someone chose it. Whether it earns its cost is a real question and a separate one.

RUE-1765 also records two other routes for the remaining verifier cost — collapsing repeat verifications of an unchanged graph, and widening the `abi_slot_cache` beyond a single verification (33.4M today; its own doc records 406M uncached) — both of which need decisions rather than refactors.

## Validation

- `scripts/rue premerge` — 197 pass, 0 fail, 0 build failures
- Emitted Lattice executable byte-identical to trunk's, and identical across three separate `-j4` compiles

---
_Generated by [Claude Code](https://claude.ai/code/session_011sbnn24fuaT6oLix6Sgk7S)_