### PR TITLE
RUE-1747: Reobserve retargeted watch inputs

### DIFF
--- a/crates/rue-cli-tests/cases/watch.toml
+++ b/crates/rue-cli-tests/cases/watch.toml
@@ -50,3 +50,26 @@ delete = true
 [[case.watch.edits]]
 path = "helper.rue"
 source = "pub fn answer() -> i32 { 2 }\n"
+
+[[case]]
+name = "retargeted_import_symlink_rebuilds_and_publishes_new_output"
+only_on = [
+    "x86-64-linux",
+    "aarch64-linux",
+    "x86-64-macos",
+    "aarch64-macos",
+]
+files = [
+    { path = "main.rue", source = "const helper = @import(\"helper.rue\");\nfn main() -> i32 { helper.answer() }\n" },
+    { path = "target_a.rue", source = "pub fn answer() -> i32 { 1 }\n" },
+    { path = "target_b.rue", source = "pub fn answer() -> i32 { 2 }\n" },
+]
+symlinks = [{ link = "helper.rue", target = "target_a.rue" }]
+
+[case.watch]
+kind = "symlink_retarget"
+expected_exit_codes = [1, 2]
+
+[[case.watch.edits]]
+path = "helper.rue"
+symlink_target = "target_b.rue"

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -1071,6 +1071,7 @@ enum WatchScenarioKind {
     Edit,
     Cancel,
     Delete,
+    SymlinkRetarget,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1081,6 +1082,8 @@ struct WatchEdit {
     source: Option<String>,
     #[serde(default)]
     delete: bool,
+    #[serde(default)]
+    symlink_target: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -2432,15 +2435,33 @@ fn wait_for_watch_event(
     ))
 }
 
+#[cfg(unix)]
+fn replace_watch_symlink(path: &Path, target: &str) -> Result<(), String> {
+    std::fs::remove_file(path)
+        .map_err(|error| format!("failed to replace watch symlink: {error}"))?;
+    std::os::unix::fs::symlink(target, path)
+        .map_err(|error| format!("failed to retarget watch symlink: {error}"))
+}
+
+#[cfg(not(unix))]
+fn replace_watch_symlink(_path: &Path, _target: &str) -> Result<(), String> {
+    Err("watch symlink retarget is only supported on Unix".into())
+}
+
 fn write_watch_edit(dir: &Path, edit: &WatchEdit) -> Result<(), String> {
     let path = dir.join(&edit.path);
-    match (edit.delete, &edit.source) {
-        (true, None) => std::fs::remove_file(&path)
+    match (
+        edit.delete,
+        edit.source.as_deref(),
+        edit.symlink_target.as_deref(),
+    ) {
+        (true, None, None) => std::fs::remove_file(&path)
             .map_err(|error| format!("failed to delete watch fixture {}: {error}", edit.path)),
-        (false, Some(source)) => std::fs::write(&path, source)
+        (false, Some(source), None) => std::fs::write(&path, source)
             .map_err(|error| format!("failed to update watch fixture {}: {error}", edit.path)),
+        (false, None, Some(target)) => replace_watch_symlink(&path, target),
         _ => Err(format!(
-            "watch edit {} must specify exactly one of delete or source",
+            "watch edit {} must specify exactly one of delete, source, or symlink_target",
             edit.path
         )),
     }
@@ -2499,6 +2520,11 @@ fn run_watch_case(
     if scenario.kind == WatchScenarioKind::Delete && scenario.edits.len() != 2 {
         return Err(TestFailure::assertion(
             "delete watch scenario requires delete and restore edits",
+        ));
+    }
+    if scenario.kind == WatchScenarioKind::SymlinkRetarget && scenario.edits.len() != 1 {
+        return Err(TestFailure::assertion(
+            "symlink-retarget watch scenario requires exactly one edit",
         ));
     }
 
@@ -2643,6 +2669,9 @@ fn run_watch_case(
                         "watch acquired toolchain modules before reobserve completed".into(),
                     );
                 }
+            }
+            WatchScenarioKind::SymlinkRetarget => {
+                wait_for_watch_event(&mut child, &protocol, "published", 2, deadline)?;
             }
         }
         assert_watch_program(contract, &program, scenario.expected_exit_codes[1])

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -440,25 +440,24 @@ fn cached_source_for_module(
 
 fn accepted_source_from_read(
     entry: &rue_compiler::AcceptedReadManifestEntry,
+    canonical_path: &Path,
     read: StableRead,
-    cached_source: Arc<String>,
+    cached_source: Option<Arc<String>>,
 ) -> Result<AcceptedImportSource, SourceLoadError> {
     let observed = AcceptedImportSource::new(
         Arc::from(entry.requested_path()),
-        Arc::from(entry.canonical_path()),
+        Arc::from(canonical_path.to_string_lossy().into_owned()),
         read.identity,
         read.fingerprint,
         Arc::new(read.source),
     )
     .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
-    let source = if observed.content_fingerprint() == entry.content_fingerprint() {
-        cached_source
-    } else {
-        observed.source().clone()
-    };
+    let source = cached_source
+        .filter(|_| observed.content_fingerprint() == entry.content_fingerprint())
+        .unwrap_or_else(|| observed.source().clone());
     AcceptedImportSource::new(
         Arc::from(entry.requested_path()),
-        Arc::from(entry.canonical_path()),
+        Arc::from(canonical_path.to_string_lossy().into_owned()),
         read.identity,
         read.fingerprint,
         source,
@@ -481,37 +480,55 @@ fn reobserve_accepted_reads(
                     entry.module()
                 ))
             })?;
-        let path = Path::new(entry.canonical_path());
-        if source_manifest.is_some_and(|policy| {
-            !policy.declares_path_without_probe(Path::new(entry.requested_path()))
-                || !policy.allows_canonical(path)
-        }) {
+        let requested_path = Path::new(entry.requested_path());
+        if source_manifest.is_some_and(|policy| !policy.declares_path_without_probe(requested_path))
+        {
             continue;
         }
-        let metadata = match fs::metadata(path) {
+        // The requested spelling is the watchable authority. Re-resolve it on
+        // every retained observation so replacing an imported/root symlink
+        // cannot keep feeding the old canonical file into the next graph.
+        let canonical_path = match fs::canonicalize(requested_path) {
+            Ok(path) => path,
+            Err(_) => continue,
+        };
+        if source_manifest.is_some_and(|policy| !policy.allows_canonical(&canonical_path)) {
+            continue;
+        }
+        if !canonical_path.is_file() {
+            continue;
+        }
+        let canonical_unchanged = canonical_path == Path::new(entry.canonical_path());
+        let metadata = match fs::metadata(&canonical_path) {
             Ok(metadata) => metadata,
             Err(_) => continue,
         };
-        let accepted = if metadata_requires_content_hash(
-            entry.metadata_identity(),
-            entry.metadata_fingerprint(),
-            &metadata,
-            now,
-        ) {
-            let read = match stable_read_to_string(path) {
-                Ok(read) => read,
-                Err(_) => continue,
-            };
-            accepted_source_from_read(entry, read, cached_source)?
-        } else {
+        let accepted = if canonical_unchanged
+            && !metadata_requires_content_hash(
+                entry.metadata_identity(),
+                entry.metadata_fingerprint(),
+                &metadata,
+                now,
+            ) {
             AcceptedImportSource::new(
                 Arc::from(entry.requested_path()),
-                Arc::from(entry.canonical_path()),
+                Arc::from(canonical_path.to_string_lossy().into_owned()),
                 entry.metadata_identity(),
                 entry.metadata_fingerprint(),
                 cached_source,
             )
             .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?
+        } else {
+            let read = match stable_read_to_string(&canonical_path) {
+                Ok(read) => read,
+                Err(_) => continue,
+            };
+            accepted_source_from_read(
+                entry,
+                &canonical_path,
+                read,
+                canonical_unchanged.then_some(cached_source.clone()),
+            )?
         };
         observed.insert(entry.requested_path().to_owned(), accepted);
     }
@@ -3009,6 +3026,197 @@ mod tests {
             }
             Err(other) => panic!("policy change escaped typed diagnostics: {other:?}"),
             Ok(()) => panic!("policy change reused a now-denied read"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn retained_import_symlink_retarget_adopts_new_canonical_source() {
+        let dir = TestDir::new("retained-import-symlink");
+        let main = dir.write(
+            "main.rue",
+            r#"const leaf = @import("alias.rue"); fn main() -> i32 { leaf.value() }"#,
+        );
+        let first = dir.write("first.rue", "pub fn value() -> i32 { 1 }");
+        let second = dir.write("second.rue", "pub fn value() -> i32 { 2 }");
+        let alias = dir.path.join("alias.rue");
+        std::os::unix::fs::symlink(&first, &alias).unwrap();
+
+        let mut result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
+        let first_canonical = fs::canonicalize(&first).unwrap();
+        assert!(result.read_manifest.iter().any(|entry| {
+            entry.requested_path() == alias.to_string_lossy()
+                && entry.canonical_path() == first_canonical.to_string_lossy()
+        }));
+
+        fs::remove_file(&alias).unwrap();
+        std::os::unix::fs::symlink(&second, &alias).unwrap();
+        reload_from_filesystem(&mut result).unwrap();
+
+        let second_canonical = fs::canonicalize(&second).unwrap();
+        let leaf = result
+            .source_snapshot
+            .files()
+            .find(|source| source.source.contains("value() -> i32 { 2 }"))
+            .expect("the retargeted module bytes are published");
+        assert_eq!(
+            result
+                .source_snapshot
+                .module_id(leaf.file_id)
+                .expect("retargeted module keeps its logical identity")
+                .as_str(),
+            "alias.rue"
+        );
+        assert!(result.read_manifest.iter().any(|entry| {
+            entry.requested_path() == alias.to_string_lossy()
+                && entry.canonical_path() == second_canonical.to_string_lossy()
+        }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn retained_unchanged_import_symlink_preserves_source_identity() {
+        let dir = TestDir::new("retained-unchanged-import-symlink");
+        let main = dir.write(
+            "main.rue",
+            r#"const leaf = @import("alias.rue"); fn main() -> i32 { leaf.value() }"#,
+        );
+        let target = dir.write("target.rue", "pub fn value() -> i32 { 1 }");
+        let alias = dir.path.join("alias.rue");
+        std::os::unix::fs::symlink(&target, &alias).unwrap();
+
+        let mut result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
+        let source_id = module_source_id(&result, "alias.rue");
+        let canonical = fs::canonicalize(&target).unwrap();
+
+        reload_from_filesystem(&mut result).unwrap();
+
+        assert_eq!(module_source_id(&result, "alias.rue"), source_id);
+        assert!(
+            result
+                .source_snapshot
+                .files()
+                .any(|source| { source.source.contains("pub fn value() -> i32 { 1 }") })
+        );
+        assert!(result.read_manifest.iter().any(|entry| {
+            entry.requested_path() == alias.to_string_lossy()
+                && entry.canonical_path() == canonical.to_string_lossy()
+        }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn retained_root_symlink_retarget_adopts_new_canonical_source() {
+        let dir = TestDir::new("retained-root-symlink");
+        let first = dir.write("first.rue", "fn main() -> i32 { 1 }");
+        let second = dir.write("second.rue", "fn main() -> i32 { 2 }");
+        let alias = dir.path.join("main.rue");
+        std::os::unix::fs::symlink(&first, &alias).unwrap();
+
+        let mut result = discover_and_load_imports(alias.to_str().unwrap(), None, None).unwrap();
+        fs::remove_file(&alias).unwrap();
+        std::os::unix::fs::symlink(&second, &alias).unwrap();
+        reload_from_filesystem(&mut result).unwrap();
+
+        let second_canonical = fs::canonicalize(&second).unwrap();
+        assert!(
+            result
+                .source_snapshot
+                .files()
+                .any(|source| { source.source.contains("fn main() -> i32 { 2 }") })
+        );
+        assert!(result.read_manifest.iter().any(|entry| {
+            entry.requested_path() == alias.to_string_lossy()
+                && entry.canonical_path() == second_canonical.to_string_lossy()
+        }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn retained_broken_import_symlink_fails_closed_then_recovers() {
+        let dir = TestDir::new("retained-broken-symlink");
+        let main = dir.write(
+            "main.rue",
+            r#"const leaf = @import("alias.rue"); fn main() -> i32 { leaf.value() }"#,
+        );
+        let target = dir.write("target.rue", "pub fn value() -> i32 { 1 }");
+        let replacement = dir.write("replacement.rue", "pub fn value() -> i32 { 2 }");
+        let alias = dir.path.join("alias.rue");
+        std::os::unix::fs::symlink(&target, &alias).unwrap();
+        let mut result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
+
+        // Leave the requested alias in place but make its target disappear:
+        // retained observation must not silently reuse the old canonical read.
+        fs::remove_file(&target).unwrap();
+        reload_from_filesystem(&mut result).unwrap();
+        assert_eq!(
+            result.revision.status(),
+            ImportDiscoveryStatus::ClosedAttempted
+        );
+        assert!(
+            result
+                .revision
+                .diagnostics()
+                .to_string()
+                .contains("alias.rue")
+        );
+
+        fs::remove_file(&alias).unwrap();
+        std::os::unix::fs::symlink(&replacement, &alias).unwrap();
+        reload_from_filesystem(&mut result).unwrap();
+        assert!(
+            result
+                .source_snapshot
+                .files()
+                .any(|source| { source.source.contains("value() -> i32 { 2 }") })
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn retained_import_symlink_retarget_respects_manifest_revocation() {
+        let dir = TestDir::new("retained-manifest-symlink-revocation");
+        let main = dir.write(
+            "main.rue",
+            r#"const leaf = @import("alias.rue"); fn main() -> i32 { leaf.value() }"#,
+        );
+        let first = dir.write("first.rue", "pub fn value() -> i32 { 1 }");
+        let second = dir.write("second.rue", "pub fn value() -> i32 { 2 }");
+        let alias = dir.path.join("alias.rue");
+        std::os::unix::fs::symlink(&first, &alias).unwrap();
+        let manifest_path = dir.write(
+            "sources.manifest",
+            "main.rue\nalias.rue\nfirst.rue\nsecond.rue\n",
+        );
+        let manifest = SourceManifest::load(manifest_path.to_str().unwrap()).unwrap();
+        let mut result =
+            discover_and_load_imports(main.to_str().unwrap(), Some(manifest), None).unwrap();
+
+        // The alias remains the requested spelling, but the next manifest
+        // revision no longer grants that spelling. This must take the normal
+        // typed lexical-denial path instead of reusing the accepted first read.
+        fs::remove_file(&alias).unwrap();
+        std::os::unix::fs::symlink(&second, &alias).unwrap();
+        fs::write(&manifest_path, "main.rue\nfirst.rue\nsecond.rue\n").unwrap();
+
+        match reload_from_filesystem(&mut result) {
+            Err(SourceLoadError::Compiler {
+                snapshot: Some(snapshot),
+                errors,
+            }) => {
+                let diagnostics = errors.to_string();
+                assert!(diagnostics.contains("source manifest"), "{diagnostics}");
+                assert!(diagnostics.contains("alias.rue"), "{diagnostics}");
+                assert!(
+                    snapshot
+                        .source_revision()
+                        .modules()
+                        .iter()
+                        .all(|module| module.module.as_str() != "alias.rue")
+                );
+            }
+            Err(other) => panic!("manifest revocation escaped typed diagnostics: {other:?}"),
+            Ok(()) => panic!("manifest revocation reused a now-denied read"),
         }
     }
 


### PR DESCRIPTION
Summary:
- re-resolve every retained accepted requested path before reuse
- force fresh canonical identity, metadata, and bytes after symlink retargets while preserving unchanged-input fast paths
- cover imported and root aliases, unchanged aliases, dangling-link recovery, manifest revocation, and real watch publication after retarget

Validation:
- scripts/rue fmt
- ./buck2 test //crates/rue:rue-driver-test
- scripts/rue cli watch
- scripts/rue cli modules
- scripts/rue quick
- scripts/rue premerge (200 passed)
- scripts/rue test (234 passed)
- independent adversarial filesystem-identity review

Fixes RUE-1747