### PR TITLE
RUE-1745: add C FFI declarations to Appendix A

### DIFF
--- a/crates/rue-spec/cases/runtime/foreign-boundary.toml
+++ b/crates/rue-spec/cases/runtime/foreign-boundary.toml
@@ -13,6 +13,26 @@ name = "Foreign-Boundary Semantics"
 description = "Rules governing the target-C foreign boundary: foreign redeclaration agreement and the reserved entry-point symbol."
 
 # =============================================================================
+# ABI legality (9.3:1b)
+# =============================================================================
+
+[[case]]
+name = "foreign_unsupported_abi_is_rejected"
+spec = ["9.3:1b"]
+preview = "c_ffi"
+preview_should_pass = true
+description = "A foreign declaration with an ABI string other than C is rejected"
+source = """
+extern "Rust" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["unsupported extern ABI", "\"C\""]
+
+# =============================================================================
 # Foreign redeclaration (9.3:5, RUE-1218)
 # =============================================================================
 
@@ -46,7 +66,7 @@ error_contains = [
 
 [[case]]
 name = "foreign_redeclaration_that_agrees_is_accepted"
-spec = ["9.3:5"]
+spec = ["9.3:1a", "9.3:5"]
 preview = "c_ffi"
 preview_should_pass = true
 description = "An identical redeclaration of one C symbol is legal, as in C; parameter names are not part of the signature"
@@ -119,7 +139,7 @@ error_contains = [
 
 [[case]]
 name = "c_export_named_main_rejected"
-spec = ["9.3:6"]
+spec = ["9.3:1a", "9.3:6"]
 preview = "c_ffi"
 preview_should_pass = true
 description = "The export direction of the same rule: a `pub extern \"C\" fn` named `main` is rejected (E1106)"

--- a/crates/rue-spec/src/traceability.rs
+++ b/crates/rue-spec/src/traceability.rs
@@ -2184,6 +2184,122 @@ dec_literal = "d" ;
     }
 
     #[test]
+    fn grammar_sync_keeps_c_ffi_items_and_productions_reachable() {
+        let spec_dir = tempfile::tempdir().unwrap();
+        let appendix_dir = spec_dir.path().join("appendices");
+        fs::create_dir(&appendix_dir).unwrap();
+        let source = r#"
+<!-- grammar-sync(id="9.3:1a", production="item", role="source", relation="contains", symbol="extern_block") -->
+<!-- grammar-sync(id="9.3:1a", production="item", role="source", relation="contains", symbol="extern_export") -->
+<!-- grammar-sync(id="9.3:1a", production="extern_block", role="source") -->
+<!-- grammar-sync(id="9.3:1a", production="extern_fn", role="source") -->
+<!-- grammar-sync(id="9.3:1a", production="extern_result", role="source") -->
+<!-- grammar-sync(id="9.3:1a", production="extern_export", role="source") -->
+```ebnf
+item          = function | extern_block | extern_export | struct_def ;
+extern_block  = "extern" STRING "{" { extern_fn } "}" ;
+extern_fn     = "fn" IDENT "(" [ params ] ")" [ extern_result ] ";" ;
+extern_result = "->" type ;
+extern_export = "pub" "extern" STRING [ "unchecked" ] "fn" IDENT "(" [ params ] ")" [ result ] "{" block "}" ;
+```
+"#;
+        let appendix = r#"
+<!-- grammar-sync(id="9.3:1a", production="item", role="appendix", relation="contains", symbol="extern_block") -->
+<!-- grammar-sync(id="9.3:1a", production="item", role="appendix", relation="contains", symbol="extern_export") -->
+<!-- grammar-sync(id="9.3:1a", production="extern_block", role="appendix") -->
+<!-- grammar-sync(id="9.3:1a", production="extern_fn", role="appendix") -->
+<!-- grammar-sync(id="9.3:1a", production="extern_result", role="appendix") -->
+<!-- grammar-sync(id="9.3:1a", production="extern_export", role="appendix") -->
+```ebnf
+item          = function | extern_block | extern_export | struct_def ;
+extern_block  = "extern" STRING "{" { extern_fn } "}" ;
+extern_fn     = "fn" IDENT "(" [ params ] ")" [ extern_result ] ";" ;
+extern_result = "->" type ;
+extern_export = "pub" "extern" STRING [ "unchecked" ] "fn" IDENT "(" [ params ] ")" [ result ] "{" block "}" ;
+function      = "function" ;
+struct_def    = "struct" ;
+STRING        = "string" ;
+IDENT         = "identifier" ;
+params        = "params" ;
+type          = "type" ;
+result        = "result" ;
+block         = "block" ;
+```
+"#;
+        fs::write(spec_dir.path().join("foreign-boundary.md"), source).unwrap();
+        let appendix_path = appendix_dir.join("A-grammar.md");
+        fs::write(&appendix_path, appendix).unwrap();
+        assert!(validate_grammar_consistency(spec_dir.path()).is_ok());
+
+        fs::write(
+            &appendix_path,
+            appendix.replace(
+                "item          = function | extern_block | extern_export | struct_def ;",
+                "item          = function | extern_block | struct_def ;",
+            ),
+        )
+        .unwrap();
+        let error = validate_grammar_consistency(spec_dir.path()).unwrap_err();
+        assert!(error.contains("contain `extern_export`"), "{error}");
+
+        fs::write(
+            &appendix_path,
+            appendix.replace(
+                "extern_block  = \"extern\" STRING \"{\" { extern_fn } \"}\" ;",
+                "extern_block  = \"extern\" STRING \"{\" { extern_fn } \"}\" \"broken\" ;",
+            ),
+        )
+        .unwrap();
+        let error = validate_grammar_consistency(spec_dir.path()).unwrap_err();
+        assert!(
+            error.contains("extern_block") && error.contains("differs"),
+            "{error}"
+        );
+
+        fs::write(
+            &appendix_path,
+            appendix.replace(
+                "extern_fn     = \"fn\" IDENT \"(\" [ params ] \")\" [ extern_result ] \";\" ;",
+                "extern_fn     = \"fn\" IDENT \"(\" [ params ] \")\" [ extern_result ] \"broken\" ;",
+            ),
+        )
+        .unwrap();
+        let error = validate_grammar_consistency(spec_dir.path()).unwrap_err();
+        assert!(
+            error.contains("extern_fn") && error.contains("differs"),
+            "{error}"
+        );
+
+        fs::write(
+            &appendix_path,
+            appendix.replace(
+                "extern_result = \"->\" type ;",
+                "extern_result = \"=>\" type ;",
+            ),
+        )
+        .unwrap();
+        let error = validate_grammar_consistency(spec_dir.path()).unwrap_err();
+        assert!(
+            error.contains("extern_result") && error.contains("differs"),
+            "{error}"
+        );
+
+        fs::write(
+            &appendix_path,
+            appendix.replace(
+                "extern_export = \"pub\" \"extern\" STRING [ \"unchecked\" ] \"fn\" IDENT \"(\" [ params ] \")\" [ result ] \"{\" block \"}\" ;",
+                "extern_export = \"pub\" \"extern\" STRING [ \"unchecked\" ] \"fn\" IDENT \"(\" [ params ] \")\" [ result ] \"{\" block \"}\" \"broken\" ;",
+            ),
+        )
+        .unwrap();
+        let error = validate_grammar_consistency(spec_dir.path()).unwrap_err();
+        assert!(
+            error.contains("extern_export") && error.contains("differs"),
+            "{error}"
+        );
+    }
+
+    #[test]
     fn test_parse_spec_comment() {
         // Simple shortcode without category defaults to informative
         let (id, cat) = parse_spec_comment("{{ rule(id=\"3.1:1\") }}")

--- a/docs/spec/src/09-unchecked-code/03-foreign-boundary.md
+++ b/docs/spec/src/09-unchecked-code/03-foreign-boundary.md
@@ -21,6 +21,35 @@ foreign *call* requires a `checked` block, § 9.1); an *export* body is ordinary
 Rue code. The rules below govern what happens when control, a trap, or ownership
 crosses this boundary.
 
+{{ rule(id="9.3:1a", cat="syntax") }}
+
+The C foreign-boundary declarations have the following syntax. This is a
+syntactic description only: the `c_ffi` preview gate, ABI and FFI-safety
+requirements, checked-call rule, and other legality constraints are specified
+below and are not encoded by this grammar. The ABI position is a `STRING`
+lexical token.
+
+<!-- grammar-sync(id="9.3:1a", production="item", role="source", relation="contains", symbol="extern_block") -->
+<!-- grammar-sync(id="9.3:1a", production="item", role="source", relation="contains", symbol="extern_export") -->
+<!-- grammar-sync(id="9.3:1a", production="extern_block", role="source") -->
+<!-- grammar-sync(id="9.3:1a", production="extern_fn", role="source") -->
+<!-- grammar-sync(id="9.3:1a", production="extern_result", role="source") -->
+<!-- grammar-sync(id="9.3:1a", production="extern_export", role="source") -->
+
+```ebnf
+extern_block  = "extern" STRING "{" { extern_fn } "}" ;
+extern_fn     = "fn" IDENT "(" [ params ] ")" [ extern_result ] ";" ;
+extern_result = "->" type ;
+extern_export = "pub" "extern" STRING [ "unchecked" ] "fn" IDENT
+                "(" [ params ] ")" [ result ] "{" block "}" ;
+```
+
+{{ rule(id="9.3:1b", cat="legality-rule") }}
+
+The ABI `STRING` in a foreign declaration or export **MUST** have the value
+`"C"`. Any other ABI string is unsupported in this version and is rejected at
+compile time.
+
 ## Abort at the boundary
 
 {{ rule(id="9.3:2", cat="dynamic-semantics") }}

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -16,6 +16,13 @@ Rue. The EBNF fragments that appear inline in Chapters 5 and 6 are
 the construct under discussion; where any of them differs from this appendix,
 this appendix governs.
 
+<!-- grammar-sync(id="9.3:1a", production="item", role="appendix", relation="contains", symbol="extern_block") -->
+<!-- grammar-sync(id="9.3:1a", production="item", role="appendix", relation="contains", symbol="extern_export") -->
+<!-- grammar-sync(id="9.3:1a", production="extern_block", role="appendix") -->
+<!-- grammar-sync(id="9.3:1a", production="extern_fn", role="appendix") -->
+<!-- grammar-sync(id="9.3:1a", production="extern_result", role="appendix") -->
+<!-- grammar-sync(id="9.3:1a", production="extern_export", role="appendix") -->
+
 <!-- grammar-sync(id="2.1:26", production="INTEGER", role="appendix", relation="contains", symbol="byte_literal") -->
 <!-- grammar-sync(id="2.1:26", production="byte_literal", role="appendix") -->
 <!-- grammar-sync(id="2.1:26", production="byte_char", role="appendix") -->
@@ -29,7 +36,7 @@ this appendix governs.
 ```ebnf
 (* Program structure *)
 program        = { item } ;
-item           = function | struct_def | enum_def | drop_fn | const_decl ;
+item           = function | extern_block | extern_export | struct_def | enum_def | drop_fn | const_decl ;
 
 (* Directives and intrinsics *)
 directives     = { directive } ;
@@ -51,6 +58,14 @@ params         = param { "," param } [ "," ] ;
 param          = [ param_mode ] IDENT ":" type ;
 param_mode     = "comptime" | "inout" | "borrow" ;
 block          = { statement } [ expression ] ;
+
+(* C foreign boundary declarations. Preview, ABI, and FFI-safety requirements
+   are legality rules rather than grammar. *)
+extern_block   = "extern" STRING "{" { extern_fn } "}" ;
+extern_fn      = "fn" IDENT "(" [ params ] ")" [ extern_result ] ";" ;
+extern_result  = "->" type ;
+extern_export  = "pub" "extern" STRING [ "unchecked" ] "fn" IDENT
+                 "(" [ params ] ")" [ result ] "{" block "}" ;
 
 (* Structs: fields first (comma-separated), then inline methods *)
 struct_def     = directives [ "pub" ] [ "linear" ]


### PR DESCRIPTION
## Summary

- make C FFI imports and exports reachable from the Appendix A item grammar
- separate the syntax rule from the decoded ABI legality rule
- add exact grammar synchronization, mutation, and unsupported-ABI coverage

## Validation

- scripts/rue fmt
- scripts/rue premerge: 200 passed, 0 failed
- focused grammar synchronization test: 1 passed

Fixes RUE-1745