### PR TITLE
RUE-1746: make yield expressions reachable in Appendix A

### DIFF
--- a/crates/rue-spec/src/traceability.rs
+++ b/crates/rue-spec/src/traceability.rs
@@ -2300,6 +2300,59 @@ block         = "block" ;
     }
 
     #[test]
+    fn grammar_sync_keeps_yield_expr_reachable_and_exact() {
+        let spec_dir = tempfile::tempdir().unwrap();
+        let appendix_dir = spec_dir.path().join("appendices");
+        fs::create_dir(&appendix_dir).unwrap();
+        let source = r#"
+<!-- grammar-sync(id="6.6:2", production="primary", role="source", relation="contains", symbol="yield_expr") -->
+<!-- grammar-sync(id="6.6:2", production="yield_expr", role="source") -->
+```ebnf
+primary    = expression | yield_expr ;
+yield_expr = "yield" expression ;
+```
+"#;
+        let appendix = r#"
+<!-- grammar-sync(id="6.6:2", production="primary", role="appendix", relation="contains", symbol="yield_expr") -->
+<!-- grammar-sync(id="6.6:2", production="yield_expr", role="appendix") -->
+```ebnf
+primary    = expression | yield_expr ;
+yield_expr = "yield" expression ;
+expression = "value" ;
+```
+"#;
+        fs::write(spec_dir.path().join("borrow-accessors.md"), source).unwrap();
+        let appendix_path = appendix_dir.join("A-grammar.md");
+        fs::write(&appendix_path, appendix).unwrap();
+        assert!(validate_grammar_consistency(spec_dir.path()).is_ok());
+
+        fs::write(
+            &appendix_path,
+            appendix.replace(
+                "primary    = expression | yield_expr ;",
+                "primary    = expression ;",
+            ),
+        )
+        .unwrap();
+        let error = validate_grammar_consistency(spec_dir.path()).unwrap_err();
+        assert!(error.contains("contain `yield_expr`"), "{error}");
+
+        fs::write(
+            &appendix_path,
+            appendix.replace(
+                "yield_expr = \"yield\" expression ;",
+                "yield_expr = \"yield\" expression \"drift\" ;",
+            ),
+        )
+        .unwrap();
+        let error = validate_grammar_consistency(spec_dir.path()).unwrap_err();
+        assert!(
+            error.contains("yield_expr") && error.contains("differs"),
+            "{error}"
+        );
+    }
+
+    #[test]
     fn test_parse_spec_comment() {
         // Simple shortcode without category defaults to informative
         let (id, cat) = parse_spec_comment("{{ rule(id=\"3.1:1\") }}")

--- a/docs/spec/src/06-items/06-borrow-accessors.md
+++ b/docs/spec/src/06-items/06-borrow-accessors.md
@@ -20,6 +20,9 @@ exclusive place, and uses `inout self` with an `-> inout T` result.
 
 {{ rule(id="6.6:2", cat="syntax") }}
 
+<!-- grammar-sync(id="6.6:2", production="primary", role="source", relation="contains", symbol="yield_expr") -->
+<!-- grammar-sync(id="6.6:2", production="yield_expr", role="source") -->
+
 ```ebnf
 accessor    = "fn" IDENT "(" accessor_self [ "," params ] ")"
               "->" accessor_result type "{" { statement } yield_expr [ ";" ] "}" ;

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -22,6 +22,8 @@ this appendix governs.
 <!-- grammar-sync(id="9.3:1a", production="extern_fn", role="appendix") -->
 <!-- grammar-sync(id="9.3:1a", production="extern_result", role="appendix") -->
 <!-- grammar-sync(id="9.3:1a", production="extern_export", role="appendix") -->
+<!-- grammar-sync(id="6.6:2", production="primary", role="appendix", relation="contains", symbol="yield_expr") -->
+<!-- grammar-sync(id="6.6:2", production="yield_expr", role="appendix") -->
 
 <!-- grammar-sync(id="2.1:26", production="INTEGER", role="appendix", relation="contains", symbol="byte_literal") -->
 <!-- grammar-sync(id="2.1:26", production="byte_literal", role="appendix") -->
@@ -97,12 +99,10 @@ compound_op    = "+=" | "-=" | "*=" | "/=" | "%="
 expr_stmt      = expression ";"
                | control_flow_expr
                | block_expr ;          (* block-like expressions need no semicolon *)
-yield_expr     = "yield" expression ;  (* the trailing exit of an accessor body
-                                          (ADR-0062); parsed as an
-                                          expression form, valid only as the
-                                          single trailing statement of a
-                                          `-> borrow` or `-> inout` accessor
-                                          body — a legality rule *)
+(* The trailing exit of an accessor body (ADR-0062); parsed as an expression
+   form, valid only as the single trailing statement of a `-> borrow` or
+   `-> inout` accessor body — a legality rule. *)
+yield_expr     = "yield" expression ;
 
 (* Place expressions: a variable — or `self`, inside a method — followed by
    zero or more field/index projections, or an accessor call followed by those
@@ -188,7 +188,8 @@ primary        = INTEGER | STRING | BOOL | "()"
                | comptime_expr
                | checked_expr
                | block_expr
-               | control_flow_expr ;
+               | control_flow_expr
+               | yield_expr ;
 
 (* An identifier optionally followed by call arguments, a struct literal
    body, or a path. *)


### PR DESCRIPTION
## Summary

- admit stable accessor yield expressions through the Appendix A primary production
- preserve the broader parser syntax while §6.6 legality rules constrain valid placement
- add exact synchronization and mutation-sensitive reachability coverage

## Validation

- scripts/rue fmt
- scripts/rue premerge: 200 passed, 0 failed
- independent adversarial review: no blockers

Fixes RUE-1746