### PR TITLE
RUE-1711: reject NUL-bearing paths instead of operating on the prefix

### DIFF
--- a/crates/rue-cli-tests/cases/fs_file_io.toml
+++ b/crates/rue-cli-tests/cases/fs_file_io.toml
@@ -1013,3 +1013,173 @@ fn main() -> i32 {
 """ }]
 stdout = "1\n2\n"
 exit_code = 0
+
+# RUE-1711: a path holding a NUL byte is `InvalidInput`, not a silent operation
+# on the truncated prefix. `StrBuf` carries its own length so it can hold a NUL,
+# but the NUL-terminated copy handed to the kernel cannot express one — before
+# the check, `remove("victim\0decoy")` marshalled to `"victim"` and returned
+# `Ok` after removing a file the caller never named. That is reachable by any
+# program building paths from untrusted bytes, which byte-string paths invite.
+#
+# The staged `victim` file is what makes this a real assertion rather than a
+# spelling check: the old behavior is not merely "wrong error" but "wrong file
+# gone", so the reopen at the end is the half that would have failed.
+[[case]]
+name = "fs_path_with_nul_does_not_hit_the_truncated_path"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const SB = std.strbuf.StrBuf;
+
+fn mk(s: str) -> SB {
+    let mut out = SB.new();
+    out.append_str(borrow s);
+    out
+}
+
+// "victim" + NUL + "decoy" — a C string built from these bytes is "victim".
+fn victim_nul_decoy() -> SB {
+    let mut out = SB.new();
+    out.append_str(borrow "victim");
+    out.push(0);
+    out.append_str(borrow "decoy");
+    out
+}
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let OR = std.result.Result(F, FE);
+    let CR = std.result.Result((), FE);
+
+    match F.create(borrow mk("victim")) {
+        OR.Ok(f) => { match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 71; } }; },
+        OR.Err(_e) => { return 72; },
+    };
+
+    match std.fs.remove(borrow victim_nul_decoy()) {
+        CR.Ok(_u) => { return 73; },
+        CR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 74; } },
+    };
+
+    // The file the truncated path named is still there.
+    match F.open(borrow mk("victim")) {
+        OR.Ok(f) => { match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 75; } }; },
+        OR.Err(_e) => { return 76; },
+    };
+
+    @dbg(0);
+    0
+}
+""" }]
+stdout = "0\n"
+exit_code = 0
+
+# RUE-1711: the rejection is a property of the module, not of one function, so
+# every path-taking entry point is checked here — including both operands of
+# `rename`, where only one is checked if the guard is written per-call rather
+# than per-operation.
+#
+# The `create_dir_all` tail is the case a check placed at marshalling time alone
+# would not cover: with the NUL in the SECOND component, `deep` is created and
+# only then does the child mkdir see the bad bytes, leaving a directory behind
+# for a request that was never representable. `create_dir_all` is documented as
+# non-atomic on failure, which makes checking it up front the only way to keep
+# the rejection side-effect-free.
+[[case]]
+name = "fs_path_with_nul_rejected_at_every_entry_point"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const SB = std.strbuf.StrBuf;
+
+fn mk(s: str) -> SB {
+    let mut out = SB.new();
+    out.append_str(borrow s);
+    out
+}
+
+fn nul_after(head: str) -> SB {
+    let mut out = SB.new();
+    out.append_str(borrow head);
+    out.push(0);
+    out.append_str(borrow "tail");
+    out
+}
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let OR = std.result.Result(F, FE);
+    let CR = std.result.Result((), FE);
+    let MR = std.result.Result(std.fs.Metadata, FE);
+    let DR = std.result.Result(std.fs.DirEntries, FE);
+
+    match F.open(borrow nul_after("staged")) {
+        OR.Ok(_x) => { return 11; },
+        OR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 12; } },
+    };
+    match F.create(borrow nul_after("staged")) {
+        OR.Ok(_x) => { return 13; },
+        OR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 14; } },
+    };
+    match F.append(borrow nul_after("staged")) {
+        OR.Ok(_x) => { return 15; },
+        OR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 16; } },
+    };
+    match std.fs.metadata(borrow nul_after("staged")) {
+        MR.Ok(_m) => { return 17; },
+        MR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 18; } },
+    };
+    match std.fs.remove(borrow nul_after("staged")) {
+        CR.Ok(_u) => { return 19; },
+        CR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 20; } },
+    };
+
+    // Both rename operands, one at a time.
+    match std.fs.rename(borrow nul_after("staged"), borrow mk("moved")) {
+        CR.Ok(_u) => { return 21; },
+        CR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 22; } },
+    };
+    match std.fs.rename(borrow mk("staged"), borrow nul_after("moved")) {
+        CR.Ok(_u) => { return 23; },
+        CR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 24; } },
+    };
+
+    match std.fs.create_dir(borrow nul_after("dir")) {
+        CR.Ok(_u) => { return 25; },
+        CR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 26; } },
+    };
+    match std.fs.remove_dir(borrow nul_after("dir")) {
+        CR.Ok(_u) => { return 27; },
+        CR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 28; } },
+    };
+    match std.fs.read_dir(borrow nul_after("dir")) {
+        DR.Ok(_d) => { return 29; },
+        DR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 30; } },
+    };
+    match std.fs.walk(borrow nul_after("dir")) {
+        DR.Ok(_d) => { return 31; },
+        DR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 32; } },
+    };
+
+    // NUL in the second component: rejected, and `deep` is not left behind.
+    let mut nested = SB.new();
+    nested.append_str(borrow "deep/inner");
+    nested.push(0);
+    nested.append_str(borrow "tail");
+    match std.fs.create_dir_all(borrow nested) {
+        CR.Ok(_u) => { return 33; },
+        CR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 34; } },
+    };
+    match std.fs.metadata(borrow mk("deep")) {
+        MR.Ok(_m) => { return 35; },
+        MR.Err(e) => match e { FE.NotFound => {}, _ => { return 36; } },
+    };
+
+    @dbg(0);
+    0
+}
+""" }]
+stdout = "0\n"
+exit_code = 0

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -250,6 +250,22 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
+    // RUE-1711: NUL-bearing paths are rejected rather than truncated. Same
+    // substrate and same gap as the rest of the std.fs group — these cases
+    // build their paths through StrBuf, whose bulk byte copy the oracle does
+    // not model. Ungated in the case file, so unscoped here to match.
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_path_with_nul_does_not_hit_the_truncated_path",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_path_with_nul_rejected_at_every_entry_point",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
     // RUE-1481: directory enumeration (`read_dir`/`walk`) reaches the same
     // `@byte_copy` gap as the rest of the std.fs group — every entry's path is
     // pooled through StrBuf, which copies bytes in bulk. Ungated in the case

--- a/docs/designs/0057-file-io-v0.md
+++ b/docs/designs/0057-file-io-v0.md
@@ -109,6 +109,16 @@ touches `StrBuf`'s private buffer. There is **no `Path`/`PathBuf` abstraction in
 v0** — a byte string is the path. A typed path layer can arrive later without
 changing the syscall boundary.
 
+**A path containing a NUL byte is `Err(FileError.InvalidInput)`** (RUE-1711).
+Carrying its own length, a `StrBuf` can hold a NUL that the NUL-terminated copy
+cannot express: the kernel would read `"a\0b"` as `"a"` and operate on a path
+the caller never named — silently, and with `Ok`. Every path-taking entry point
+therefore rejects such a path before marshalling it, which is what Rust's
+`CString`-based `std::fs` does for the same reason. Rejecting up front rather
+than at the copy also keeps the rejection free of side effects: `create_dir_all`
+is deliberately non-atomic on failure, so a NUL in a later component would
+otherwise leave the earlier parents created.
+
 ### 3. Error model: a normalized `FileError`, never a raw errno
 
 Every fallible operation returns `Result(T, FileError)` (the ADR-0038 library
@@ -265,6 +275,9 @@ Implemented under RUE-712 on 2026-07-16:
   read-back round-trip, append semantics, drop-close + reopen, consuming-close +
   double-close safety (all run on every target); open-missing → `NotFound` and
   write-to-read-only → `InvalidInput` (gated `only_on` Linux per §3a).
+- NUL-bearing paths (RUE-1711, same file): the wrong-file removal itself, and
+  the rejection at every path-taking entry point including both `rename`
+  operands and `create_dir_all`'s no-parents-created guarantee.
 
 ## Consequences
 

--- a/std/fs.rue
+++ b/std/fs.rue
@@ -646,7 +646,37 @@ fn _normalize_macos(e: i64) -> FileError {
 // Reads bytes through the public `StrBuf.byte_at` accessor (RUE-712 uses the
 // PR #1714 `byte_at`), so `fs` never touches `StrBuf`'s private buffer.
 // The caller frees the returned buffer with `len + 1`.
+//
+// A `StrBuf` carries its own length and so may hold a NUL byte, but the C
+// convention this copy adopts cannot express one: the kernel stops at the first
+// NUL. Marshalling `"a\0b"` would hand it `"a"`, so an operation aimed at one
+// path would silently hit a different one (RUE-1711). Every entry point
+// therefore rejects a NUL-bearing path with `FileError.InvalidInput` before
+// marshalling it — the same contract Rust's `CString`-based fs states — which
+// is why `_path_to_cbuf` itself may assume the bytes are representable.
 // ---------------------------------------------------------------------------
+
+// True when `path` holds a NUL byte anywhere, making it unrepresentable as a C
+// string. A trailing NUL counts: `_path_to_cbuf` appends its own terminator, so
+// `"a\0"` and `"a"` marshal identically while naming different `StrBuf`s.
+// Checked BEFORE marshalling so a rejected path costs neither the allocation
+// nor the syscall.
+fn _path_has_nul(borrow path: strbuf.StrBuf) -> bool {
+    let O = option.Option(u8);
+    let n = path.len();
+    let mut i: u64 = 0;
+    while i < n {
+        let b = match path.byte_at(i) {
+            O.Some(x) => x,
+            O.None => 0,
+        };
+        if b == 0 {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
 
 fn _path_to_cbuf(borrow path: strbuf.StrBuf) -> ptr mut u8 {
     let n = path.len();
@@ -681,6 +711,9 @@ pub struct File {
     // Shared openat path used by the three constructors.
     fn _open_with(borrow path: strbuf.StrBuf, flags: u64, mode: u64) -> result.Result(File, FileError) {
         let R = result.Result(File, FileError);
+        if _path_has_nul(borrow path) {
+            return R.Err(FileError.InvalidInput);
+        }
         let cbuf = _path_to_cbuf(borrow path);
         let addr: u64 = checked { @ptr_to_int(cbuf) };
         let free_len = path.len() + 1;
@@ -929,6 +962,9 @@ drop fn File(self) {
 // `d_type` would have reported.
 fn _metadata_at(borrow path: strbuf.StrBuf, flags: u64) -> result.Result(Metadata, FileError) {
     let R = result.Result(Metadata, FileError);
+    if _path_has_nul(borrow path) {
+        return R.Err(FileError.InvalidInput);
+    }
     let cbuf = _path_to_cbuf(borrow path);
     let paddr: u64 = checked { @ptr_to_int(cbuf) };
     let free_len = path.len() + 1;
@@ -961,6 +997,9 @@ pub fn metadata(borrow path: strbuf.StrBuf) -> result.Result(Metadata, FileError
 // existing `to` is atomically replaced (POSIX rename semantics).
 pub fn rename(borrow from: strbuf.StrBuf, borrow to: strbuf.StrBuf) -> result.Result((), FileError) {
     let R = result.Result((), FileError);
+    if _path_has_nul(borrow from) || _path_has_nul(borrow to) {
+        return R.Err(FileError.InvalidInput);
+    }
     let fbuf = _path_to_cbuf(borrow from);
     let faddr: u64 = checked { @ptr_to_int(fbuf) };
     let flen = from.len() + 1;
@@ -981,6 +1020,9 @@ pub fn rename(borrow from: strbuf.StrBuf, borrow to: strbuf.StrBuf) -> result.Re
 // directory path fails (EISDIR/EPERM -> the normalized error); use `remove_dir`.
 pub fn remove(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
     let R = result.Result((), FileError);
+    if _path_has_nul(borrow path) {
+        return R.Err(FileError.InvalidInput);
+    }
     let cbuf = _path_to_cbuf(borrow path);
     let addr: u64 = checked { @ptr_to_int(cbuf) };
     let free_len = path.len() + 1;
@@ -999,12 +1041,24 @@ pub fn remove(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
 // there is one marshalling path; only their errno HANDLING differs (the
 // recursive form has to inspect EEXIST before deciding it is an error).
 fn _mkdirat_raw(borrow path: strbuf.StrBuf) -> i64 {
+    if _path_has_nul(borrow path) {
+        return 0 - _errno_einval();
+    }
     let cbuf = _path_to_cbuf(borrow path);
     let addr: u64 = checked { @ptr_to_int(cbuf) };
     let free_len = path.len() + 1;
     let ret: i64 = checked { @syscall(_sys_mkdirat(), _at_fdcwd(), addr, _dir_mode()) };
     checked { @free(cbuf, free_len, 1); };
     ret
+}
+
+// EINVAL as a raw errno, for the one rejection `_mkdirat_raw` makes itself
+// rather than reading back from the kernel. 22 on Linux and macOS alike, and
+// both tables map it to `FileError.InvalidInput`, so a NUL-bearing path reaches
+// `create_dir`/`create_dir_all` as the same error the other entry points return
+// directly.
+fn _errno_einval() -> i64 {
+    22
 }
 
 // EEXIST as a raw errno. Unlike EAGAIN this one AGREES across Linux and macOS
@@ -1082,6 +1136,13 @@ fn _create_dir_idempotent(borrow path: strbuf.StrBuf) -> result.Result((), FileE
 // in place, matching `mkdir -p` and Rust's `fs::create_dir_all`.
 pub fn create_dir_all(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
     let R = result.Result((), FileError);
+    // Checked here as well as in `_mkdirat_raw`, and for the reason this
+    // function is not atomic: a NUL in a LATER component would otherwise be
+    // caught only after the earlier parents had already been created, leaving
+    // directories behind for a request that was never representable.
+    if _path_has_nul(borrow path) {
+        return R.Err(FileError.InvalidInput);
+    }
     let n = path.len();
     if n == 0 {
         return R.Err(FileError.NotFound);
@@ -1133,6 +1194,9 @@ pub fn create_dir_all(borrow path: strbuf.StrBuf) -> result.Result((), FileError
 // non-empty directory is `Err` (ENOTEMPTY -> `Other`, or the normalized case).
 pub fn remove_dir(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
     let R = result.Result((), FileError);
+    if _path_has_nul(borrow path) {
+        return R.Err(FileError.InvalidInput);
+    }
     let cbuf = _path_to_cbuf(borrow path);
     let addr: u64 = checked { @ptr_to_int(cbuf) };
     let free_len = path.len() + 1;


### PR DESCRIPTION
Fixes RUE-1711.

## The bug

`std.fs` paths are `StrBuf`s, which carry their own length and so may hold a NUL byte. The NUL-terminated copy handed to the kernel cannot express one, and `_path_to_cbuf` never checked: `"victim\0decoy"` marshalled to `"victim"`.

Verified on trunk before the fix, with the real compiler against real syscalls:

```
create "victim"
fs.remove("victim\0decoy")  ->  Ok        # and "victim" is gone
File.open("victim")         ->  Err       # the wrong file was unlinked
```

Every path-taking entry point was affected. A program building paths from untrusted bytes — which byte-string paths invite — could be steered onto a different file entirely, with no error to notice.

## The fix

Reject a path holding a NUL with `FileError.InvalidInput`, the contract Rust's `CString`-based `std::fs` states for the same reason.

The check runs at each entry point *before* marshalling rather than inside `_path_to_cbuf`, which keeps a rejected path away from both the allocation and the syscall, and lets `_mkdirat_raw` answer on its raw-errno channel as `-EINVAL` (22 on Linux and macOS alike, and `InvalidInput` in both normalization tables). All seven marshalling sites are covered: `_open_with` (so open/create/append and, through it, `read_dir`/`walk`), `_metadata_at`, both `rename` operands, `remove`, `remove_dir`, and `_mkdirat_raw`.

`create_dir_all` is checked up front as well as through `_mkdirat_raw`. It is deliberately non-atomic on failure, so a NUL in a *later* component would otherwise be caught only after the earlier parents had been created, leaving directories behind for a request that was never representable.

## Tests

Two CLI cases in `crates/rue-cli-tests/cases/fs_file_io.toml`, both confirmed to fail against the pre-fix `std` and pass after:

- `fs_path_with_nul_does_not_hit_the_truncated_path` — the wrong-file removal itself. The staged `victim` must survive; that reopen is the half that fails without the fix, which is what makes this an assertion about behavior rather than about which error code came back.
- `fs_path_with_nul_rejected_at_every_entry_point` — the rejection is a property of the module, not of one function: open/create/append, `metadata`, `remove`, both `rename` operands, `create_dir`, `remove_dir`, `read_dir`, `walk`, and `create_dir_all` with the NUL in the second component, asserting no parent directory is left behind.

The second commit registers both cases in the oracle-diff model-gap inventory: they build their paths through `StrBuf`, reaching the same unmodeled bulk byte copy as the rest of the std.fs group. A local `scripts/rue premerge` does not surface that — it passed 200 tests on the first commit — because the corpus audits run as Buck build actions rather than tier-labeled tests, so only a build of the affected targets forces them.

## Docs

ADR-0057 §2 states the contract and its reasoning, and the implementation-status list records the new coverage. This is the only place in the tree that documents the path model.