### PR TITLE
RUE-1711: reject fs paths holding a NUL byte instead of truncating them

### DIFF
--- a/crates/rue-cli-tests/cases/fs_file_io.toml
+++ b/crates/rue-cli-tests/cases/fs_file_io.toml
@@ -1,7 +1,8 @@
 # V1 FOLLOW-UPS (ADR-0057 "Future Work"): the cases whose names begin `fs_seek_`,
 # `fs_stat_`/`fs_metadata_`, `fs_rename_`, `fs_remove_`, and `fs_mkdir_` exercise
 # seek/tell, fstat/newfstatat metadata, rename, unlink, and directory
-# create/remove. The `fs_mkdir_` group also covers `create_dir_all` (RUE-995):
+# create/remove. The `fs_interior_nul_` pair covers the path PRECONDITION those
+# entry points share (RUE-1711) rather than any one syscall. The `fs_mkdir_` group also covers `create_dir_all` (RUE-995):
 # nested creation, idempotent re-creation, the separator shapes its byte scan has
 # to collapse, and the EEXIST-but-not-a-directory case.
 # They are UNGATED, like the v0 group, because each one issues a syscall whose
@@ -1012,4 +1013,158 @@ fn main() -> i32 {
 }
 """ }]
 stdout = "1\n2\n"
+exit_code = 0
+
+# RUE-1711: a path holding a NUL byte of its own has no C-string spelling. The
+# terminator `_path_to_cbuf` appends is not the first one the kernel meets, so
+# the syscall reads the PREFIX — `"victim\0decoy"` names `victim`. Before the
+# fix `fs.remove` of that path returned Ok and deleted `victim`: a silent
+# operation on a file the caller never wrote, reachable by any program that
+# builds paths out of untrusted bytes, which is exactly what byte-string paths
+# invite. Every path-taking entry point now answers `InvalidInput`, and it
+# answers before marshalling, so the file the prefix names is untouched.
+#
+# The NUL is pushed as a byte rather than written as `\0`: these sources are
+# TOML basic strings, where `\0` is not a valid escape.
+[[case]]
+name = "fs_interior_nul_path_rejected"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const SB = std.strbuf.StrBuf;
+
+fn plain(s: str) -> SB {
+    let mut out = SB.new();
+    out.append_str(borrow s);
+    out
+}
+
+fn nul_path(a: str, b: str) -> SB {
+    let mut out = SB.new();
+    out.append_str(borrow a);
+    out.push(0);
+    out.append_str(borrow b);
+    out
+}
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let CR = std.result.Result((), FE);
+    let MR = std.result.Result(std.fs.Metadata, FE);
+
+    // The file the truncated path would name.
+    match F.create(borrow plain("victim")) {
+        R.Ok(f) => { match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 61; } }; },
+        R.Err(_e) => { return 62; },
+    };
+
+    // The repro: this removed `victim` before the fix.
+    match std.fs.remove(borrow nul_path("victim", "decoy")) {
+        CR.Ok(_u) => { return 63; },
+        CR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 64; } },
+    };
+    match std.fs.metadata(borrow plain("victim")) {
+        MR.Ok(_m) => {},
+        MR.Err(_e) => { return 65; },
+    };
+
+    // The same answer from every other path-taking entry point.
+    match F.open(borrow nul_path("victim", "decoy")) {
+        R.Ok(_x) => { return 66; },
+        R.Err(e) => match e { FE.InvalidInput => {}, _ => { return 67; } },
+    };
+    match F.create(borrow nul_path("victim", "decoy")) {
+        R.Ok(_x) => { return 68; },
+        R.Err(e) => match e { FE.InvalidInput => {}, _ => { return 69; } },
+    };
+    match F.append(borrow nul_path("victim", "decoy")) {
+        R.Ok(_x) => { return 70; },
+        R.Err(e) => match e { FE.InvalidInput => {}, _ => { return 71; } },
+    };
+    match std.fs.metadata(borrow nul_path("victim", "decoy")) {
+        MR.Ok(_m) => { return 72; },
+        MR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 73; } },
+    };
+    match std.fs.create_dir(borrow nul_path("newdir", "decoy")) {
+        CR.Ok(_u) => { return 74; },
+        CR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 75; } },
+    };
+    match std.fs.remove_dir(borrow nul_path("victim", "decoy")) {
+        CR.Ok(_u) => { return 76; },
+        CR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 77; } },
+    };
+
+    // `rename` reads two paths, so each one is checked; a clean `from` does not
+    // license a `to` the kernel would truncate.
+    match std.fs.rename(borrow nul_path("victim", "decoy"), borrow plain("moved")) {
+        CR.Ok(_u) => { return 78; },
+        CR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 79; } },
+    };
+    match std.fs.rename(borrow plain("victim"), borrow nul_path("moved", "decoy")) {
+        CR.Ok(_u) => { return 80; },
+        CR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 81; } },
+    };
+
+    // Nothing above touched the file the prefix names, and the rejected
+    // renames did not half-happen.
+    match std.fs.metadata(borrow plain("victim")) {
+        MR.Ok(_m) => {},
+        MR.Err(_e) => { return 82; },
+    };
+    match std.fs.metadata(borrow plain("moved")) {
+        MR.Ok(_m) => { return 83; },
+        MR.Err(e) => match e { FE.NotFound => {}, _ => { return 84; } },
+    };
+    0
+}
+""" }]
+exit_code = 0
+
+# RUE-1711, the `create_dir_all` half. Its prefix loop would have marshalled
+# `"nulparent\0x"` for the path `"nulparent\0x/y"`, which the kernel reads as
+# `nulparent` — so the call returned Ok having created a directory under a name
+# the caller never wrote. The check therefore runs AHEAD of that loop: this is
+# the one operation whose "NOT ATOMIC" contract would otherwise let a rejected
+# path leave real directories behind.
+[[case]]
+name = "fs_interior_nul_create_dir_all_creates_nothing"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const SB = std.strbuf.StrBuf;
+
+fn plain(s: str) -> SB {
+    let mut out = SB.new();
+    out.append_str(borrow s);
+    out
+}
+
+fn nul_path(a: str, b: str) -> SB {
+    let mut out = SB.new();
+    out.append_str(borrow a);
+    out.push(0);
+    out.append_str(borrow b);
+    out
+}
+
+fn main() -> i32 {
+    let FE = std.fs.FileError;
+    let CR = std.result.Result((), FE);
+    let MR = std.result.Result(std.fs.Metadata, FE);
+
+    match std.fs.create_dir_all(borrow nul_path("nulparent", "x/y")) {
+        CR.Ok(_u) => { return 61; },
+        CR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 62; } },
+    };
+
+    // Not even the first component: the rejection precedes any mkdirat.
+    match std.fs.metadata(borrow plain("nulparent")) {
+        MR.Ok(_m) => { return 63; },
+        MR.Err(e) => match e { FE.NotFound => {}, _ => { return 64; } },
+    };
+    0
+}
+""" }]
 exit_code = 0

--- a/crates/rue-cli-tests/cases/fs_read_dir.toml
+++ b/crates/rue-cli-tests/cases/fs_read_dir.toml
@@ -727,3 +727,66 @@ tree/up_link symlink
 6
 """
 exit_code = 0
+
+# RUE-1711: both enumeration entry points inherit the path precondition, because
+# both reach the kernel through the same `File._open_with` marshalling that
+# `File.open` uses. `"listed\0decoy"` would otherwise have listed `listed` — a
+# whole directory's contents returned for a path naming something else. `walk`
+# is checked separately from `read_dir` even though it delegates to it, since
+# that delegation is the only reason it is covered at all.
+#
+# The NUL is pushed as a byte rather than written as `\0`: these sources are
+# TOML basic strings, where `\0` is not a valid escape.
+[[case]]
+name = "read_dir_interior_nul_path_rejected"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const SB = std.strbuf.StrBuf;
+
+fn mk(s: str) -> SB {
+    let mut out = SB.new();
+    out.append_str(borrow s);
+    out
+}
+
+fn nul_mk(a: str, b: str) -> SB {
+    let mut out = SB.new();
+    out.append_str(borrow a);
+    out.push(0);
+    out.append_str(borrow b);
+    out
+}
+
+fn main() -> i32 {
+    let FE = std.fs.FileError;
+    let CR = std.result.Result((), FE);
+    let DR = std.result.Result(std.fs.DirEntries, FE);
+
+    // A real directory sitting at the name the truncated path would reach.
+    match std.fs.create_dir(borrow mk("listed")) {
+        CR.Ok(_u) => {},
+        CR.Err(_e) => { return 61; },
+    };
+
+    match std.fs.read_dir(borrow nul_mk("listed", "decoy")) {
+        DR.Ok(_d) => { return 62; },
+        DR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 63; } },
+    };
+
+    match std.fs.walk(borrow nul_mk("listed", "decoy")) {
+        DR.Ok(_d) => { return 64; },
+        DR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 65; } },
+    };
+
+    // The directory itself still lists, so the rejection is about the path and
+    // not about `listed` having become unreadable.
+    match std.fs.read_dir(borrow mk("listed")) {
+        DR.Ok(_d) => { @dbg(0); },
+        DR.Err(_e) => { return 66; },
+    };
+    0
+}
+""" }]
+stdout = "0\n"
+exit_code = 0

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -250,6 +250,24 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
+    // RUE-1711: the interior-NUL cases are debt for the same reason as the rest
+    // of the group and not for the reason they exist — the rejection they assert
+    // happens in Rue, above the syscall, but they still build their paths with
+    // StrBuf, whose bulk byte copy is the unmodeled intrinsic. What they check is
+    // the returned `FileError` and the state of the filesystem afterward, which
+    // is the CLI assertion's job here rather than the oracle's.
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_interior_nul_path_rejected",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_interior_nul_create_dir_all_creates_nothing",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
     // RUE-1481: directory enumeration (`read_dir`/`walk`) reaches the same
     // `@byte_copy` gap as the rest of the std.fs group — every entry's path is
     // pooled through StrBuf, which copies bytes in bulk. Ungated in the case
@@ -305,6 +323,15 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.fs_read_dir",
         "walk_nested_tree_is_depth_first_preorder",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
+    // RUE-1711: same StrBuf byte copy as the enumeration cases above. Unlike the
+    // two symlink cases, this one stages its directory from the program itself,
+    // so it stays a single-source case and does reach a gap to register.
+    Entry::new(
+        "cli.fs_read_dir",
+        "read_dir_interior_nul_path_rejected",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),

--- a/docs/designs/0057-file-io-v0.md
+++ b/docs/designs/0057-file-io-v0.md
@@ -109,6 +109,19 @@ touches `StrBuf`'s private buffer. There is **no `Path`/`PathBuf` abstraction in
 v0** — a byte string is the path. A typed path layer can arrive later without
 changing the syscall boundary.
 
+A byte string can hold a byte a C string cannot carry. A path containing a NUL
+of its own has no C-string spelling at all: the terminator appended here is not
+the first one the kernel meets, so the syscall reads the **prefix** and
+`"victim\0decoy"` names `victim`. Truncating is the dangerous answer, because
+nothing about it is visible to the caller — the operation reports success on a
+file they never named, and a program deriving paths from untrusted bytes (which
+byte-string paths invite) can be steered into it. Every path-taking entry point
+therefore **rejects** such a path as `FileError.InvalidInput`, the answer Rust's
+CString-based `std::fs` gives the same input, and rejects it *before*
+marshalling so the prefix is never touched. `create_dir_all` checks ahead of its
+prefix loop for that reason: it is the one operation whose non-atomic contract
+would otherwise let a rejected path leave real directories behind (RUE-1711).
+
 ### 3. Error model: a normalized `FileError`, never a raw errno
 
 Every fallible operation returns `Result(T, FileError)` (the ADR-0038 library

--- a/std/fs.rue
+++ b/std/fs.rue
@@ -39,7 +39,9 @@
 // `fs_stat_`/`fs_metadata_` CLI cases, which run on aarch64-macos.
 //
 // PATHS are byte-string `StrBuf`s; the syscall boundary copies the bytes into a
-// NUL-terminated buffer and never exposes that terminator to the caller.
+// NUL-terminated buffer and never exposes that terminator to the caller. A path
+// carrying a NUL byte of its own is rejected as `FileError.InvalidInput` there
+// instead of being truncated to its prefix (RUE-1711).
 //
 // ERRORS normalize to `FileError` from per-OS errno tables — a raw errno never
 // escapes. Linux and macOS give the same logical error different integers
@@ -646,8 +648,41 @@ fn _normalize_macos(e: i64) -> FileError {
 // Reads bytes through the public `StrBuf.byte_at` accessor (RUE-712 uses the
 // PR #1714 `byte_at`), so `fs` never touches `StrBuf`'s private buffer.
 // The caller frees the returned buffer with `len + 1`.
+//
+// A path holding a NUL byte of its own has no C-string spelling: the terminator
+// appended here is not the first one the kernel meets, so the syscall reads the
+// PREFIX. `"victim\0decoy"` would name `"victim"` — a silent operation on a
+// different file than the caller asked for, and a program that builds paths
+// from untrusted bytes (which is exactly what byte-string paths invite) can be
+// steered by it. Every entry point below therefore rejects such a path as
+// `FileError.InvalidInput` before marshalling it, the same answer Rust's
+// CString-based `std::fs` gives the same input (RUE-1711).
 // ---------------------------------------------------------------------------
 
+// True if `path` contains byte 0 anywhere, which makes it unrepresentable as a
+// C string. Scans through the public `byte_at` accessor for the same reason
+// `_path_to_cbuf` does. `i < n` keeps the index in range, so the `None` arm is
+// unreachable; it answers "contains a NUL" regardless, leaving the impossible
+// case on the rejecting side rather than passing an unread byte to the kernel.
+fn _path_has_interior_nul(borrow path: strbuf.StrBuf) -> bool {
+    let n = path.len();
+    let O = option.Option(u8);
+    let mut i: u64 = 0;
+    while i < n {
+        let b = match path.byte_at(i) {
+            O.Some(x) => x,
+            O.None => 0,
+        };
+        if b == 0 {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+// Marshal a validated path. The caller has already rejected a path containing
+// byte 0 (see above); this copy would otherwise hand the kernel a truncated one.
 fn _path_to_cbuf(borrow path: strbuf.StrBuf) -> ptr mut u8 {
     let n = path.len();
     let buf: ptr mut u8 = checked { @alloc(n + 1, 1) };
@@ -681,6 +716,9 @@ pub struct File {
     // Shared openat path used by the three constructors.
     fn _open_with(borrow path: strbuf.StrBuf, flags: u64, mode: u64) -> result.Result(File, FileError) {
         let R = result.Result(File, FileError);
+        if _path_has_interior_nul(borrow path) {
+            return R.Err(FileError.InvalidInput);
+        }
         let cbuf = _path_to_cbuf(borrow path);
         let addr: u64 = checked { @ptr_to_int(cbuf) };
         let free_len = path.len() + 1;
@@ -929,6 +967,9 @@ drop fn File(self) {
 // `d_type` would have reported.
 fn _metadata_at(borrow path: strbuf.StrBuf, flags: u64) -> result.Result(Metadata, FileError) {
     let R = result.Result(Metadata, FileError);
+    if _path_has_interior_nul(borrow path) {
+        return R.Err(FileError.InvalidInput);
+    }
     let cbuf = _path_to_cbuf(borrow path);
     let paddr: u64 = checked { @ptr_to_int(cbuf) };
     let free_len = path.len() + 1;
@@ -961,6 +1002,12 @@ pub fn metadata(borrow path: strbuf.StrBuf) -> result.Result(Metadata, FileError
 // existing `to` is atomically replaced (POSIX rename semantics).
 pub fn rename(borrow from: strbuf.StrBuf, borrow to: strbuf.StrBuf) -> result.Result((), FileError) {
     let R = result.Result((), FileError);
+    if _path_has_interior_nul(borrow from) {
+        return R.Err(FileError.InvalidInput);
+    }
+    if _path_has_interior_nul(borrow to) {
+        return R.Err(FileError.InvalidInput);
+    }
     let fbuf = _path_to_cbuf(borrow from);
     let faddr: u64 = checked { @ptr_to_int(fbuf) };
     let flen = from.len() + 1;
@@ -981,6 +1028,9 @@ pub fn rename(borrow from: strbuf.StrBuf, borrow to: strbuf.StrBuf) -> result.Re
 // directory path fails (EISDIR/EPERM -> the normalized error); use `remove_dir`.
 pub fn remove(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
     let R = result.Result((), FileError);
+    if _path_has_interior_nul(borrow path) {
+        return R.Err(FileError.InvalidInput);
+    }
     let cbuf = _path_to_cbuf(borrow path);
     let addr: u64 = checked { @ptr_to_int(cbuf) };
     let free_len = path.len() + 1;
@@ -998,6 +1048,10 @@ pub fn remove(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
 // success, `-errno` on failure. `create_dir` and `create_dir_all` share this so
 // there is one marshalling path; only their errno HANDLING differs (the
 // recursive form has to inspect EEXIST before deciding it is an error).
+//
+// Both reject an interior NUL before calling this, and every path reaching it
+// from `create_dir_all` is a PREFIX of one already checked, so nothing here can
+// be truncated at the syscall.
 fn _mkdirat_raw(borrow path: strbuf.StrBuf) -> i64 {
     let cbuf = _path_to_cbuf(borrow path);
     let addr: u64 = checked { @ptr_to_int(cbuf) };
@@ -1024,6 +1078,9 @@ fn _path_separator() -> u8 {
 // existing path is `Err(FileError.AlreadyExists)`.
 pub fn create_dir(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
     let R = result.Result((), FileError);
+    if _path_has_interior_nul(borrow path) {
+        return R.Err(FileError.InvalidInput);
+    }
     let ret = _mkdirat_raw(borrow path);
     if ret < 0 {
         R.Err(_normalize_errno(0 - ret))
@@ -1082,6 +1139,12 @@ fn _create_dir_idempotent(borrow path: strbuf.StrBuf) -> result.Result((), FileE
 // in place, matching `mkdir -p` and Rust's `fs::create_dir_all`.
 pub fn create_dir_all(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
     let R = result.Result((), FileError);
+    // Ahead of the prefix loop: this call creates nothing at all for a path it
+    // is going to reject, rather than leaving the components before the NUL
+    // behind as the NOT ATOMIC note above would otherwise allow.
+    if _path_has_interior_nul(borrow path) {
+        return R.Err(FileError.InvalidInput);
+    }
     let n = path.len();
     if n == 0 {
         return R.Err(FileError.NotFound);
@@ -1133,6 +1196,9 @@ pub fn create_dir_all(borrow path: strbuf.StrBuf) -> result.Result((), FileError
 // non-empty directory is `Err` (ENOTEMPTY -> `Other`, or the normalized case).
 pub fn remove_dir(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
     let R = result.Result((), FileError);
+    if _path_has_interior_nul(borrow path) {
+        return R.Err(FileError.InvalidInput);
+    }
     let cbuf = _path_to_cbuf(borrow path);
     let addr: u64 = checked { @ptr_to_int(cbuf) };
     let free_len = path.len() + 1;


### PR DESCRIPTION
Fixes RUE-1711.

## The bug

`_path_to_cbuf` copied a `StrBuf` path into a NUL-terminated buffer without looking at the bytes it copied. A path carrying a NUL of its own has no C-string spelling, so the terminator it appends is not the first one the kernel meets and the syscall reads the **prefix**.

Verified on `1d657d4` with the real std, before the change:

| call | result | what actually happened |
| --- | --- | --- |
| `fs.remove("victim\0decoy")` | `Ok(())` | `victim` was deleted |
| `fs.create_dir_all("nulparent\0x/y")` | `Ok(())` | `nulparent` was created |
| `fs.read_dir("listed\0decoy")` | `Ok(entries)` | listed `listed` |

Nothing about any of these is visible to the caller — each reports success against a name the caller never wrote — and a program deriving paths from untrusted bytes, which is what byte-string paths invite, can be steered into it.

## The change

Reject such a path as `FileError.InvalidInput`, the answer Rust's `CString`-based `std::fs` gives the same input. The rule lives in one predicate, `_path_has_interior_nul`, that every path-taking entry point consults *before* marshalling, so the file the prefix names is never touched:

- `File._open_with` — covers `open` / `create` / `append`, and `read_dir` / `walk` reach the kernel through it
- `_metadata_at` — covers `fs.metadata` and the `DT_UNKNOWN` kind fallback
- `rename`, on **both** operands — a clean `from` does not license a `to` the kernel would truncate
- `remove`, `create_dir`, `create_dir_all`, `remove_dir`

`create_dir_all` checks ahead of its prefix loop rather than inside it. It is the one operation whose documented non-atomicity would otherwise let a rejected path leave real directories behind, and before this its loop was exactly what minted `nulparent`.

`_mkdirat_raw` is left unguarded and documented as such: both its callers check first, and every path reaching it from `create_dir_all` is a prefix of one already checked.

## Tests

Three CLI cases, each failing on the prior std with the operation reporting success (exit codes 63, 61, 62 respectively):

- `fs_interior_nul_path_rejected` — the `remove` repro plus every other entry point, asserting the victim file survives and the rejected renames did not half-happen
- `fs_interior_nul_create_dir_all_creates_nothing` — rejection precedes any `mkdirat`, so not even the first component appears
- `read_dir_interior_nul_path_rejected` — `read_dir` and `walk`, and the directory still lists by its real name

The NUL is pushed as a byte rather than written as `\0`: these sources are TOML basic strings, where `\0` is not a valid escape.

`scripts/rue premerge` — 200 passed, 0 failed. `scripts/rue cli fs_` — 35 passed. `//crates/rue-oracle-diff:oracle-diff-test-action` — passes.

## Notes

ADR-0057 §2 gets the decision recorded alongside the existing path-marshalling paragraph it qualifies.

The second commit registers the three new cases in the oracle-diff model-gap inventory. All three build their paths with `StrBuf`, so they reach the same `@byte_copy` gap the rest of the std.fs group already carries, and an unregistered gap is a harness failure rather than silent debt. The debt is incidental to what they test — the rejection they assert happens in Rue, above the syscall.

Scope is `std.fs` only. `std.c`'s `free_c_string` has its own interior-NUL problem, tracked separately as RUE-1710, and is untouched here.