### PR TITLE
RUE-1711: reject fs paths holding an interior NUL byte

### DIFF
--- a/crates/rue-cli-tests/cases/fs_file_io.toml
+++ b/crates/rue-cli-tests/cases/fs_file_io.toml
@@ -1013,3 +1013,131 @@ fn main() -> i32 {
 """ }]
 stdout = "1\n2\n"
 exit_code = 0
+
+# INTERIOR NUL (RUE-1711). Paths are byte-string `StrBuf`s, and the kernel reads
+# the marshalled buffer as a C string — so a path holding byte 0 anywhere would
+# name only the bytes before it. This case is the behavioral one: `remove` on
+# "victim.dat" + 0 + "totally_different_file" must NOT unlink `victim.dat`. It is
+# a real regression test, not a shape assertion — before the check it exited 1,
+# having removed a file the caller never named.
+[[case]]
+name = "fs_nul_path_does_not_remove_the_truncated_prefix"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let CR = std.result.Result((), FE);
+
+    let mut victim = std.strbuf.StrBuf.new();
+    victim.push_str("victim.dat");
+
+    let created = match F.create(borrow victim) { R.Ok(x) => x, R.Err(_e) => { return 71; } };
+    let mut c = created;
+    match c.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 72; } };
+
+    // "victim.dat" then byte 0 then more bytes. Marshalled without a check, the
+    // kernel reads the C string as "victim.dat" and this unlinks the victim.
+    let mut sneaky = std.strbuf.StrBuf.new();
+    sneaky.push_str("victim.dat");
+    sneaky.push(0);
+    sneaky.push_str("totally_different_file");
+
+    match std.fs.remove(borrow sneaky) {
+        CR.Ok(_u) => { return 1; },
+        CR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 2; } },
+    };
+
+    // the file the truncated path named is still there
+    let opened = match F.open(borrow victim) { R.Ok(x) => x, R.Err(_e) => { return 3; } };
+    let mut h = opened;
+    match h.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 4; } };
+    0
+}
+""" }]
+exit_code = 0
+
+# The same rejection across EVERY path-taking entry point, plus the three things
+# a "reject it" fix can still get wrong: a rejected call must leave the truncated
+# prefix untouched, `create_dir_all` must not create the parents that precede the
+# offending component, and a TRAILING NUL — whose C-string form is a perfectly
+# valid path — must be rejected rather than quietly accepted. NUL-free paths are
+# re-checked at the end so the guard cannot pass by rejecting everything.
+[[case]]
+name = "fs_nul_path_rejected_by_every_entry_point"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+// "<prefix>" then byte 0 then "shadow": a path whose C-string form is just
+// "<prefix>", so an unchecked marshal silently operates on the prefix.
+fn nul_path(borrow prefix: str) -> std.strbuf.StrBuf {
+    let mut out = std.strbuf.StrBuf.new();
+    out.append_str(borrow prefix);
+    out.push(0);
+    out.append_str(borrow "shadow");
+    out
+}
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let CR = std.result.Result((), FE);
+    let MR = std.result.Result(std.fs.Metadata, FE);
+
+    let p = nul_path(borrow "victim.dat");
+
+    // every path-taking entry point reports InvalidInput
+    match F.open(borrow p) { R.Ok(_x) => { return 10; }, R.Err(e) => match e { FE.InvalidInput => {}, _ => { return 11; } } };
+    match F.create(borrow p) { R.Ok(_x) => { return 12; }, R.Err(e) => match e { FE.InvalidInput => {}, _ => { return 13; } } };
+    match F.append(borrow p) { R.Ok(_x) => { return 14; }, R.Err(e) => match e { FE.InvalidInput => {}, _ => { return 15; } } };
+    match std.fs.metadata(borrow p) { MR.Ok(_x) => { return 16; }, MR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 17; } } };
+    match std.fs.remove(borrow p) { CR.Ok(_u) => { return 18; }, CR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 19; } } };
+    match std.fs.create_dir(borrow p) { CR.Ok(_u) => { return 20; }, CR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 21; } } };
+    match std.fs.create_dir_all(borrow p) { CR.Ok(_u) => { return 22; }, CR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 23; } } };
+    match std.fs.remove_dir(borrow p) { CR.Ok(_u) => { return 24; }, CR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 25; } } };
+
+    // rename rejects a NUL in EITHER operand
+    let mut clean = std.strbuf.StrBuf.new();
+    clean.push_str("clean.dat");
+    match std.fs.rename(borrow p, borrow clean) { CR.Ok(_u) => { return 26; }, CR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 27; } } };
+    match std.fs.rename(borrow clean, borrow p) { CR.Ok(_u) => { return 28; }, CR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 29; } } };
+
+    // a rejected call creates nothing under the truncated prefix
+    let mut prefix = std.strbuf.StrBuf.new();
+    prefix.push_str("victim.dat");
+    match std.fs.metadata(borrow prefix) { MR.Ok(_x) => { return 30; }, MR.Err(e) => match e { FE.NotFound => {}, _ => { return 31; } } };
+
+    // create_dir_all creates no parent when a LATER component holds the NUL
+    let mut nested = std.strbuf.StrBuf.new();
+    nested.push_str("parent/child");
+    nested.push(0);
+    nested.push_str("shadow");
+    match std.fs.create_dir_all(borrow nested) { CR.Ok(_u) => { return 32; }, CR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 33; } } };
+    let mut parent = std.strbuf.StrBuf.new();
+    parent.push_str("parent");
+    match std.fs.metadata(borrow parent) { MR.Ok(_x) => { return 34; }, MR.Err(e) => match e { FE.NotFound => {}, _ => { return 35; } } };
+
+    // a TRAILING NUL is rejected too, though its C-string form is a valid path
+    let mut trailing = std.strbuf.StrBuf.new();
+    trailing.push_str("trailing.dat");
+    trailing.push(0);
+    match F.create(borrow trailing) { R.Ok(_x) => { return 36; }, R.Err(e) => match e { FE.InvalidInput => {}, _ => { return 37; } } };
+    let mut bare = std.strbuf.StrBuf.new();
+    bare.push_str("trailing.dat");
+    match std.fs.metadata(borrow bare) { MR.Ok(_x) => { return 38; }, MR.Err(e) => match e { FE.NotFound => {}, _ => { return 39; } } };
+
+    // NUL-free paths are unaffected
+    let made = match F.create(borrow clean) { R.Ok(x) => x, R.Err(_e) => { return 40; } };
+    let mut h = made;
+    match h.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 41; } };
+    match std.fs.metadata(borrow clean) { MR.Ok(_x) => {}, MR.Err(_e) => { return 42; } };
+    match std.fs.remove(borrow clean) { CR.Ok(_u) => {}, CR.Err(_e) => { return 43; } };
+    0
+}
+""" }]
+exit_code = 0

--- a/crates/rue-cli-tests/cases/fs_read_dir.toml
+++ b/crates/rue-cli-tests/cases/fs_read_dir.toml
@@ -727,3 +727,54 @@ tree/up_link symlink
 6
 """
 exit_code = 0
+
+# INTERIOR NUL (RUE-1711). Enumeration marshals its path the same way the file
+# entry points do, so it inherits the same truncation: "tree" + 0 + "shadow"
+# would have listed the real `tree` directory under a path naming something else.
+# Both `read_dir` and `walk` report `InvalidInput`, and the directory still lists
+# normally through a clean path.
+[[case]]
+name = "read_dir_and_walk_reject_nul_path"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const std = @import("std");
+
+fn mk(borrow s: str) -> std.strbuf.StrBuf {
+    let mut out = std.strbuf.StrBuf.new();
+    out.append_str(borrow s);
+    out
+}
+
+fn main() -> i32 {
+    let FE = std.fs.FileError;
+    let DR = std.result.Result(std.fs.DirEntries, FE);
+
+    // "tree" then byte 0 then "shadow": the C-string form is the real directory
+    // "tree", so an unchecked marshal would list it under a path that names
+    // something else.
+    let mut sneaky = std.strbuf.StrBuf.new();
+    sneaky.push_str("tree");
+    sneaky.push(0);
+    sneaky.push_str("shadow");
+
+    match std.fs.read_dir(borrow sneaky) {
+        DR.Ok(_d) => { return 1; },
+        DR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 2; } },
+    };
+    match std.fs.walk(borrow sneaky) {
+        DR.Ok(_d) => { return 3; },
+        DR.Err(e) => match e { FE.InvalidInput => {}, _ => { return 4; } },
+    };
+
+    // the directory itself still lists normally
+    let listing = match std.fs.read_dir(borrow mk(borrow "tree")) { DR.Ok(d) => d, DR.Err(_e) => { return 5; } };
+    if listing.len() != 1 { return 6; }
+    let tree = match std.fs.walk(borrow mk(borrow "tree")) { DR.Ok(d) => d, DR.Err(_e) => { return 7; } };
+    if tree.len() != 1 { return 8; }
+    0
+}
+""" },
+    { path = "tree/a.md", source = "" },
+]
+exit_code = 0

--- a/docs/designs/0057-file-io-v0.md
+++ b/docs/designs/0057-file-io-v0.md
@@ -9,7 +9,7 @@ accepted: 2026-07-16
 implemented: 2026-07-16
 spec-sections: []
 superseded-by:
-relates: ["RUE-712", "RUE-713", "RUE-935", "RUE-940", "ADR-0034", "ADR-0038"]
+relates: ["RUE-712", "RUE-713", "RUE-935", "RUE-940", "RUE-1711", "ADR-0034", "ADR-0038"]
 ---
 
 # ADR-0057: File IO v0 — pure-Rue fs over `@syscall`, normalized `FileError`
@@ -109,6 +109,25 @@ touches `StrBuf`'s private buffer. There is **no `Path`/`PathBuf` abstraction in
 v0** — a byte string is the path. A typed path layer can arrive later without
 changing the syscall boundary.
 
+#### 2a. Interior NUL bytes are rejected, not truncated (RUE-1711)
+
+"Arbitrary bytes" has one exception, and appending the terminator is what forces
+it: the kernel reads the marshalled buffer as a **C string**, so it stops at the
+first byte 0 and everything after it is dropped. Left unchecked, `"victim\0x"`
+is an operation on `victim` — the call succeeds, reports nothing unusual, and
+lands on a path the caller never wrote. Byte-string paths invite exactly the
+program that hits this: one assembling a path from bytes it does not control.
+
+So a path holding byte 0 **anywhere** is rejected with
+`FileError.InvalidInput` before it is marshalled, which is what a `CString`-based
+fs reports for the same input. A trailing NUL is rejected on the same rule even
+though its C-string form is a valid path: the buffer the kernel would read is not
+the byte string the caller passed, and the caller has an unambiguous way to spell
+that path already. The check sits at the marshalling **call sites** rather than
+inside the copy itself, because the copy returns a bare pointer with no way to
+spell a failure. `create_dir_all` checks the whole path once up front, so a
+rejected path creates none of the parents that precede the offending component.
+
 ### 3. Error model: a normalized `FileError`, never a raw errno
 
 Every fallible operation returns `Result(T, FileError)` (the ADR-0038 library
@@ -121,7 +140,7 @@ enum FileError {
     AlreadyExists,      // EEXIST
     Interrupted,        // EINTR — retryable; surfaced, not hidden
     WouldBlock,         // EAGAIN / EWOULDBLOCK
-    InvalidInput,       // EINVAL, EBADF
+    InvalidInput,       // EINVAL, EBADF; also a path holding byte 0 (see 2a)
     Other(i64),         // the raw errno, for everything not yet named
 }
 ```

--- a/std/fs.rue
+++ b/std/fs.rue
@@ -70,7 +70,7 @@ pub enum FileError {
     AlreadyExists,      // EEXIST
     Interrupted,        // EINTR
     WouldBlock,         // EAGAIN / EWOULDBLOCK
-    InvalidInput,       // EINVAL, EBADF
+    InvalidInput,       // EINVAL, EBADF; also a path holding byte 0 (RUE-1711)
     Other(i64),         // any other raw errno
 }
 
@@ -646,7 +646,36 @@ fn _normalize_macos(e: i64) -> FileError {
 // Reads bytes through the public `StrBuf.byte_at` accessor (RUE-712 uses the
 // PR #1714 `byte_at`), so `fs` never touches `StrBuf`'s private buffer.
 // The caller frees the returned buffer with `len + 1`.
+//
+// A path holding byte 0 anywhere is REJECTED before it is marshalled (RUE-1711).
+// The kernel stops at the first NUL, so `"victim\0ignored"` would name `victim`:
+// the operation would silently land on a DIFFERENT path than the one passed, and
+// paths here are byte strings a program may well assemble from input it does not
+// control. Every marshalling site checks `_path_has_nul` first and reports
+// `FileError.InvalidInput`, the same answer a `CString`-based fs gives. The check
+// is at the marshalling sites rather than inside `_path_to_cbuf` because that
+// function returns a bare pointer with no way to spell the failure.
 // ---------------------------------------------------------------------------
+
+// True when `path` holds byte 0 at any index — the bytes past it would be
+// dropped by the kernel's C-string read.
+fn _path_has_nul(borrow path: strbuf.StrBuf) -> bool {
+    let n = path.len();
+    let O = option.Option(u8);
+    let mut i: u64 = 0;
+    while i < n {
+        match path.byte_at(i) {
+            O.Some(b) => {
+                if b == 0 {
+                    return true;
+                }
+            },
+            O.None => {},
+        }
+        i += 1;
+    }
+    false
+}
 
 fn _path_to_cbuf(borrow path: strbuf.StrBuf) -> ptr mut u8 {
     let n = path.len();
@@ -681,6 +710,9 @@ pub struct File {
     // Shared openat path used by the three constructors.
     fn _open_with(borrow path: strbuf.StrBuf, flags: u64, mode: u64) -> result.Result(File, FileError) {
         let R = result.Result(File, FileError);
+        if _path_has_nul(borrow path) {
+            return R.Err(FileError.InvalidInput);
+        }
         let cbuf = _path_to_cbuf(borrow path);
         let addr: u64 = checked { @ptr_to_int(cbuf) };
         let free_len = path.len() + 1;
@@ -929,6 +961,9 @@ drop fn File(self) {
 // `d_type` would have reported.
 fn _metadata_at(borrow path: strbuf.StrBuf, flags: u64) -> result.Result(Metadata, FileError) {
     let R = result.Result(Metadata, FileError);
+    if _path_has_nul(borrow path) {
+        return R.Err(FileError.InvalidInput);
+    }
     let cbuf = _path_to_cbuf(borrow path);
     let paddr: u64 = checked { @ptr_to_int(cbuf) };
     let free_len = path.len() + 1;
@@ -961,6 +996,9 @@ pub fn metadata(borrow path: strbuf.StrBuf) -> result.Result(Metadata, FileError
 // existing `to` is atomically replaced (POSIX rename semantics).
 pub fn rename(borrow from: strbuf.StrBuf, borrow to: strbuf.StrBuf) -> result.Result((), FileError) {
     let R = result.Result((), FileError);
+    if _path_has_nul(borrow from) || _path_has_nul(borrow to) {
+        return R.Err(FileError.InvalidInput);
+    }
     let fbuf = _path_to_cbuf(borrow from);
     let faddr: u64 = checked { @ptr_to_int(fbuf) };
     let flen = from.len() + 1;
@@ -981,6 +1019,9 @@ pub fn rename(borrow from: strbuf.StrBuf, borrow to: strbuf.StrBuf) -> result.Re
 // directory path fails (EISDIR/EPERM -> the normalized error); use `remove_dir`.
 pub fn remove(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
     let R = result.Result((), FileError);
+    if _path_has_nul(borrow path) {
+        return R.Err(FileError.InvalidInput);
+    }
     let cbuf = _path_to_cbuf(borrow path);
     let addr: u64 = checked { @ptr_to_int(cbuf) };
     let free_len = path.len() + 1;
@@ -999,6 +1040,9 @@ pub fn remove(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
 // there is one marshalling path; only their errno HANDLING differs (the
 // recursive form has to inspect EEXIST before deciding it is an error).
 fn _mkdirat_raw(borrow path: strbuf.StrBuf) -> i64 {
+    if _path_has_nul(borrow path) {
+        return 0 - _errno_einval();
+    }
     let cbuf = _path_to_cbuf(borrow path);
     let addr: u64 = checked { @ptr_to_int(cbuf) };
     let free_len = path.len() + 1;
@@ -1012,6 +1056,15 @@ fn _mkdirat_raw(borrow path: strbuf.StrBuf) -> i64 {
 // which both map 17 to `FileError.AlreadyExists`.
 fn _errno_eexist() -> i64 {
     17
+}
+
+// EINVAL as a raw errno, for the raw-result `_mkdirat_raw` to report a path
+// rejected before the syscall. Like EEXIST it agrees across Linux and macOS
+// (both 22), and both tables map 22 to `FileError.InvalidInput` — so the caller
+// that normalizes this gets the same error the `Result`-returning entry points
+// return directly.
+fn _errno_einval() -> i64 {
+    22
 }
 
 // The path separator byte, `/` (ASCII 47). POSIX on every supported target.
@@ -1086,6 +1139,12 @@ pub fn create_dir_all(borrow path: strbuf.StrBuf) -> result.Result((), FileError
     if n == 0 {
         return R.Err(FileError.NotFound);
     }
+    // Whole-path check up front: `_mkdirat_raw` would reject the offending
+    // component anyway, but only after the prefixes before it were created, and
+    // this call creates nothing for a path it cannot use.
+    if _path_has_nul(borrow path) {
+        return R.Err(FileError.InvalidInput);
+    }
     let O = option.Option(u8);
     let sep = _path_separator();
 
@@ -1133,6 +1192,9 @@ pub fn create_dir_all(borrow path: strbuf.StrBuf) -> result.Result((), FileError
 // non-empty directory is `Err` (ENOTEMPTY -> `Other`, or the normalized case).
 pub fn remove_dir(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
     let R = result.Result((), FileError);
+    if _path_has_nul(borrow path) {
+        return R.Err(FileError.InvalidInput);
+    }
     let cbuf = _path_to_cbuf(borrow path);
     let addr: u64 = checked { @ptr_to_int(cbuf) };
     let free_len = path.len() + 1;


### PR DESCRIPTION
## Summary

- reject byte 0 anywhere in an `std.fs` path with `FileError.InvalidInput`, before the path is marshalled
- check at the marshalling call sites, so every path-taking entry point is covered — open/create/append, metadata, rename (either operand), remove, create_dir, create_dir_all, remove_dir, read_dir, walk
- record the path-contract refinement as ADR-0057 section 2a

## Problem

`_path_to_cbuf` copies a `StrBuf` into a NUL-appended buffer and hands the kernel that pointer, which reads it as a C string — so a path holding byte 0 named only the bytes before it. The operation succeeded, reported nothing unusual, and landed on a path the caller never wrote:

```rue
// victim.dat exists
fs.remove(borrow sneaky)   // "victim.dat" + 0 + "totally_different_file"
// -> Ok(()), and victim.dat is gone
```

Byte-string paths invite exactly the program that hits this: one assembling a path from bytes it does not control.

## Approach

The check is at the marshalling call sites rather than inside `_path_to_cbuf`, because that function returns a bare pointer with no way to spell a failure. `_mkdirat_raw` reports it on its raw errno channel as `-EINVAL`; 22 agrees across Linux and macOS and both tables already normalize it to `InvalidInput`, so its callers get the same error the `Result`-returning entry points return directly.

Two cases a "just reject it" fix can still get wrong, both covered:

- **A trailing NUL is rejected too**, though its C-string form is a valid path — the buffer the kernel reads is not the byte string that was passed, and the caller can spell that path unambiguously already.
- **`create_dir_all` checks the whole path once up front**, so a rejected path creates none of the parents preceding the offending component, rather than creating them and failing at the bad one.

## Validation

- `scripts/rue premerge`: 200 passed, 0 failed
- `scripts/rue cli nul`: 7 passed (the 3 new cases plus the existing NUL-named ones)
- `scripts/rue fmt`, `buck2 test //:adr-registry-validation`
- The three new CLI cases each **fail against the pre-fix std**, verified by reverting `std/fs.rue` and re-running: the behavioral case exits 1 having removed the victim file, and the two coverage cases report the truncated call's own error instead of `InvalidInput`.

Fixes RUE-1711


---
_Generated by [Claude Code](https://claude.ai/code/session_01KcQ73d3FmQYaxAUh6Lzi9C)_