### PR TITLE
RUE-1771: implement the v2 evidence encoding, dual reader, and store re-encode

### DIFF
--- a/crates/rue-bench/src/calibrate.rs
+++ b/crates/rue-bench/src/calibrate.rs
@@ -1624,6 +1624,7 @@ mod tests {
                 },
             },
             boundary: None,
+            full_evidence: None,
             workloads: vec![WorkloadObservation {
                 workload: "startup".to_string(),
                 boundary: None,

--- a/crates/rue-bench/src/calibrate.rs
+++ b/crates/rue-bench/src/calibrate.rs
@@ -1587,6 +1587,8 @@ mod tests {
                 compiler_root_ns: latency_ns * u64::from(batch),
             },
             boundary_evidence: Vec::new(),
+            boundary_processes: Vec::new(),
+            boundary_work_processes: Vec::new(),
         }
     }
 
@@ -1621,8 +1623,10 @@ mod tests {
                     architecture: "aarch64".to_string(),
                 },
             },
+            boundary: None,
             workloads: vec![WorkloadObservation {
                 workload: "startup".to_string(),
+                boundary: None,
                 samples: latencies.iter().map(|ns| sample(*ns, batch)).collect(),
             }],
             failures: Vec::new(),

--- a/crates/rue-bench/src/check_baselines.rs
+++ b/crates/rue-bench/src/check_baselines.rs
@@ -145,12 +145,12 @@ fn report(
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
     // The shape `derive`'s own tests use, so the fixture cannot drift from
     // what the manifest parser actually requires.
-    const BASE: &str = r#"
+    pub(crate) const BASE: &str = r#"
 [[suite]]
 revision = 1
 timing_schema_version = 1

--- a/crates/rue-bench/src/derive.rs
+++ b/crates/rue-bench/src/derive.rs
@@ -1735,6 +1735,10 @@ window = 3
                 environment: fingerprint("AMD EPYC 7763"),
             },
             boundary: None,
+            // Direct-constructed stored records carry a placeholder
+            // commitment; validation checks the shape, and only encode_v2
+            // computes the real address.
+            full_evidence: Some("f".repeat(64)),
             workloads: vec![WorkloadObservation {
                 workload: "startup".to_string(),
                 boundary: None,

--- a/crates/rue-bench/src/derive.rs
+++ b/crates/rue-bench/src/derive.rs
@@ -1734,8 +1734,10 @@ window = 3
                 },
                 environment: fingerprint("AMD EPYC 7763"),
             },
+            boundary: None,
             workloads: vec![WorkloadObservation {
                 workload: "startup".to_string(),
+                boundary: None,
                 samples: latencies
                     .iter()
                     .map(|ns| {
@@ -1749,6 +1751,8 @@ window = 3
                             output_binary_bytes: 12_288,
                             phases: accounting(ns * batch),
                             boundary_evidence: Vec::new(),
+                            boundary_processes: Vec::new(),
+                            boundary_work_processes: Vec::new(),
                         }
                     })
                     .collect(),

--- a/crates/rue-bench/src/main.rs
+++ b/crates/rue-bench/src/main.rs
@@ -695,7 +695,11 @@ fn run(options: &Options) -> Result<u8, String> {
     }
     std::fs::write(&options.output, &serialized)
         .map_err(|error| format!("could not write {}: {error}", options.output.display()))?;
-    let full_evidence_path = options.output.with_extension("full-evidence.json");
+    // Deliberately NOT a `.json` sibling: the publish job sweeps every
+    // `*.json` artifact onto the data branch, and under the dual-version
+    // reader the full-evidence form is itself appendable — the one file that
+    // must never reach the store is the one a `.json` spelling would publish.
+    let full_evidence_path = options.output.with_extension("full-evidence");
     std::fs::write(&full_evidence_path, &full_serialized)
         .map_err(|error| format!("could not write {}: {error}", full_evidence_path.display()))?;
 

--- a/crates/rue-bench/src/main.rs
+++ b/crates/rue-bench/src/main.rs
@@ -27,6 +27,7 @@ mod fixture;
 mod incremental;
 mod measure;
 mod pins;
+mod reencode;
 mod runtime;
 mod scaling;
 mod staleness_inputs;
@@ -37,9 +38,9 @@ use std::process::ExitCode;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use rue_perf_schema::{
-    Completeness, FailureRecord, Invocation, Manifest, ProcessElapsedRegression,
-    RUN_SCHEMA_VERSION, ResolvedPins, RunIdentity, RunObject, Sample, ValidationOutcome,
-    WorkloadObservation, process_elapsed_regressions, validate_run,
+    Completeness, FULL_EVIDENCE_SCHEMA_VERSION, FailureRecord, Invocation, Manifest,
+    ProcessElapsedRegression, ResolvedPins, RunIdentity, RunObject, Sample, ValidationOutcome,
+    WorkloadObservation, encode_v2, process_elapsed_regressions, validate_run,
 };
 
 use crate::measure::{SampleOutcome, SampleRequest, measure_sample};
@@ -118,6 +119,14 @@ Subcommands:
                        manifest and index.json. Covers retired epochs, which
                        `staleness-inputs` deliberately keeps out of the derived
                        data. Exits 3 when one does not resolve.
+
+  reencode --data-root <dir> --manifest <path> [--apply]
+                       rewrite every full-evidence (schema v1) record in
+                       <dir>/runs into the v2 witness-plus-digests encoding
+                       under new content addresses, moving index.json and the
+                       manifest pins with them (ADR-0067 Amendment 1). Dry run
+                       by default; --apply writes, then requires every declared
+                       baseline to resolve, exiting 3 when one does not.
 
   check-pins --manifest <path> --compiler <path> [--repo-root <path>]
                        answer whether this tree still matches every collection
@@ -216,6 +225,15 @@ fn main() -> ExitCode {
             Ok(status) => ExitCode::from(status),
             Err(message) => {
                 eprintln!("rue-bench check-baselines: {message}");
+                ExitCode::from(exit::USAGE)
+            }
+        };
+    }
+    if std::env::args().nth(1).as_deref() == Some("reencode") {
+        return match reencode::run() {
+            Ok(status) => ExitCode::from(status),
+            Err(message) => {
+                eprintln!("rue-bench reencode: {message}");
                 ExitCode::from(exit::USAGE)
             }
         };
@@ -604,6 +622,7 @@ fn run(options: &Options) -> Result<u8, String> {
         if !samples.is_empty() {
             observations.push(WorkloadObservation {
                 workload: workload.id.clone(),
+                boundary: None,
                 samples,
             });
         }
@@ -613,8 +632,11 @@ fn run(options: &Options) -> Result<u8, String> {
     // would hash differently from the identical measurement written correctly.
     observations.sort_by(|left, right| left.workload.cmp(&right.workload));
 
+    // Assembled in the full-evidence encoding: every per-process proof is
+    // present for validation's deep checks and for the retained artifact.
+    // Only what reaches the store is written in the digest encoding below.
     let run = RunObject {
-        schema_version: RUN_SCHEMA_VERSION,
+        schema_version: FULL_EVIDENCE_SCHEMA_VERSION,
         identity: RunIdentity {
             suite_revision: epoch.suite_revision,
             epoch: epoch.id,
@@ -633,6 +655,7 @@ fn run(options: &Options) -> Result<u8, String> {
             },
             environment: environment::fingerprint(),
         },
+        boundary: None,
         workloads: observations,
         failures,
     };
@@ -640,10 +663,28 @@ fn run(options: &Options) -> Result<u8, String> {
     let outcome = validate_run(&manifest, &run);
     let regressions = process_elapsed_regressions(&manifest, &run, &outcome);
 
-    // The run object is written whatever the verdict. Evidence of a broken
-    // collection is worth more than a missing file.
-    let serialized = rue_perf_schema::canonical_json(&run)
+    // The stored form replaces per-process evidence with one witness per
+    // workload plus per-process digests (ADR-0071 Amendment 1). Validation ran
+    // over the full form above; the encoded form is validated again so an
+    // encoding defect fails the collection rather than reaching the store.
+    let encoded = encode_v2(&run)
+        .map_err(|error| format!("could not encode the run object for storage: {error}"))?;
+    let encoded_outcome = validate_run(&manifest, &encoded);
+    if encoded_outcome.errors != outcome.errors {
+        return Err(format!(
+            "the encoded run object validates differently from the full one: {:?}",
+            encoded_outcome.errors
+        ));
+    }
+
+    // Both forms are written whatever the verdict. Evidence of a broken
+    // collection is worth more than a missing file. The full-evidence form is
+    // the collection workflow's retained artifact: complete per-process depth
+    // for the artifact retention window, at zero cost to the store.
+    let serialized = rue_perf_schema::canonical_json(&encoded)
         .map_err(|error| format!("could not serialize the run object: {error}"))?;
+    let full_serialized = rue_perf_schema::canonical_json(&run)
+        .map_err(|error| format!("could not serialize the full-evidence form: {error}"))?;
     if let Some(parent) = options
         .output
         .parent()
@@ -654,8 +695,11 @@ fn run(options: &Options) -> Result<u8, String> {
     }
     std::fs::write(&options.output, &serialized)
         .map_err(|error| format!("could not write {}: {error}", options.output.display()))?;
+    let full_evidence_path = options.output.with_extension("full-evidence.json");
+    std::fs::write(&full_evidence_path, &full_serialized)
+        .map_err(|error| format!("could not write {}: {error}", full_evidence_path.display()))?;
 
-    report(&run, &outcome, &regressions, &options.output);
+    report(&encoded, &outcome, &regressions, &options.output);
 
     Ok(collection_exit(&outcome, &regressions))
 }
@@ -828,7 +872,7 @@ window = 10
         phases.phase_ns.insert(Phase::SemanticAnalysis, 10);
 
         RunObject {
-            schema_version: RUN_SCHEMA_VERSION,
+            schema_version: rue_perf_schema::RUN_SCHEMA_VERSION,
             identity: RunIdentity {
                 suite_revision: 1,
                 epoch: 1,
@@ -860,8 +904,10 @@ window = 10
                     architecture: "x86_64".to_string(),
                 },
             },
+            boundary: None,
             workloads: vec![WorkloadObservation {
                 workload: "startup".to_string(),
+                boundary: None,
                 samples: vec![Sample {
                     batch_size: 1,
                     process_elapsed_ns: 20,
@@ -869,6 +915,8 @@ window = 10
                     output_binary_bytes: 1,
                     phases,
                     boundary_evidence: Vec::new(),
+                    boundary_processes: Vec::new(),
+                    boundary_work_processes: Vec::new(),
                 }],
             }],
             failures: Vec::new(),

--- a/crates/rue-bench/src/main.rs
+++ b/crates/rue-bench/src/main.rs
@@ -656,6 +656,7 @@ fn run(options: &Options) -> Result<u8, String> {
             environment: environment::fingerprint(),
         },
         boundary: None,
+        full_evidence: None,
         workloads: observations,
         failures,
     };
@@ -663,26 +664,11 @@ fn run(options: &Options) -> Result<u8, String> {
     let outcome = validate_run(&manifest, &run);
     let regressions = process_elapsed_regressions(&manifest, &run, &outcome);
 
-    // The stored form replaces per-process evidence with one witness per
-    // workload plus per-process digests (ADR-0071 Amendment 1). Validation ran
-    // over the full form above; the encoded form is validated again so an
-    // encoding defect fails the collection rather than reaching the store.
-    let encoded = encode_v2(&run)
-        .map_err(|error| format!("could not encode the run object for storage: {error}"))?;
-    let encoded_outcome = validate_run(&manifest, &encoded);
-    if encoded_outcome.errors != outcome.errors {
-        return Err(format!(
-            "the encoded run object validates differently from the full one: {:?}",
-            encoded_outcome.errors
-        ));
-    }
-
-    // Both forms are written whatever the verdict. Evidence of a broken
-    // collection is worth more than a missing file. The full-evidence form is
-    // the collection workflow's retained artifact: complete per-process depth
-    // for the artifact retention window, at zero cost to the store.
-    let serialized = rue_perf_schema::canonical_json(&encoded)
-        .map_err(|error| format!("could not serialize the run object: {error}"))?;
+    // Evidence is written before anything can abort. A run that validation
+    // refuses is exactly the run whose bytes matter most (RUE-1258), so the
+    // full-evidence form — the collection workflow's retained artifact,
+    // complete per-process depth at zero cost to the store — reaches disk
+    // before the encoding step gets a chance to fail.
     let full_serialized = rue_perf_schema::canonical_json(&run)
         .map_err(|error| format!("could not serialize the full-evidence form: {error}"))?;
     if let Some(parent) = options
@@ -693,8 +679,6 @@ fn run(options: &Options) -> Result<u8, String> {
         std::fs::create_dir_all(parent)
             .map_err(|error| format!("could not create {}: {error}", parent.display()))?;
     }
-    std::fs::write(&options.output, &serialized)
-        .map_err(|error| format!("could not write {}: {error}", options.output.display()))?;
     // Deliberately NOT a `.json` sibling: the publish job sweeps every
     // `*.json` artifact onto the data branch, and under the dual-version
     // reader the full-evidence form is itself appendable — the one file that
@@ -702,6 +686,31 @@ fn run(options: &Options) -> Result<u8, String> {
     let full_evidence_path = options.output.with_extension("full-evidence");
     std::fs::write(&full_evidence_path, &full_serialized)
         .map_err(|error| format!("could not write {}: {error}", full_evidence_path.display()))?;
+
+    // The stored form replaces per-process evidence with one witness per
+    // workload plus per-process digests (ADR-0071 Amendment 1).
+    let encoded = encode_v2(&run)
+        .map_err(|error| format!("could not encode the run object for storage: {error}"))?;
+    let serialized = rue_perf_schema::canonical_json(&encoded)
+        .map_err(|error| format!("could not serialize the run object: {error}"))?;
+    std::fs::write(&options.output, &serialized)
+        .map_err(|error| format!("could not write {}: {error}", options.output.display()))?;
+
+    // The encoded form is validated again so an encoding defect fails the
+    // collection loudly rather than reaching the store unnoticed. The gate is
+    // appendability agreement, not error-list equality: the two encodings
+    // word the same refusal differently (per-process details against
+    // witness-level ones), and a run that validation rejects under both is
+    // ordinary rejected evidence, published and exit-coded exactly as
+    // before. Both files are already on disk either way.
+    let encoded_outcome = validate_run(&manifest, &encoded);
+    if encoded_outcome.is_appendable() != outcome.is_appendable() {
+        return Err(format!(
+            "the encoded run object's appendability disagrees with the full form's: full \
+             {:?}, encoded {:?}",
+            outcome.errors, encoded_outcome.errors
+        ));
+    }
 
     report(&encoded, &outcome, &regressions, &options.output);
 
@@ -909,6 +918,9 @@ window = 10
                 },
             },
             boundary: None,
+            // A placeholder commitment: validation checks the shape, and only
+            // encode_v2 computes the real address.
+            full_evidence: Some("f".repeat(64)),
             workloads: vec![WorkloadObservation {
                 workload: "startup".to_string(),
                 boundary: None,

--- a/crates/rue-bench/src/measure.rs
+++ b/crates/rue-bench/src/measure.rs
@@ -193,6 +193,8 @@ pub fn measure_sample(request: &SampleRequest<'_>) -> SampleOutcome {
         output_binary_bytes: output_binary_bytes.unwrap_or(0),
         phases,
         boundary_evidence,
+        boundary_processes: Vec::new(),
+        boundary_work_processes: Vec::new(),
     }))
 }
 
@@ -214,6 +216,8 @@ pub fn measure_fresh_compile(request: &SampleRequest<'_>) -> Result<FreshCompile
             output_binary_bytes: completed.output_binary_bytes,
             phases: completed.accounting,
             boundary_evidence: completed.boundary_evidence.into_iter().collect(),
+            boundary_processes: Vec::new(),
+            boundary_work_processes: Vec::new(),
         },
         shape: completed.shape,
         target: completed.target,

--- a/crates/rue-bench/src/reencode.rs
+++ b/crates/rue-bench/src/reencode.rs
@@ -278,6 +278,7 @@ mod tests {
                 },
             },
             boundary: None,
+            full_evidence: None,
             workloads: vec![WorkloadObservation {
                 workload: "startup".to_string(),
                 boundary: None,
@@ -350,8 +351,13 @@ mod tests {
         let manifest_file = store.path().join("manifest.toml");
         std::fs::write(&manifest_file, manifest_pinned_to(&old_address)).unwrap();
 
-        let mut encoded = record.clone();
-        encoded.schema_version = RUN_SCHEMA_VERSION;
+        let encoded = encode_v2(&record).unwrap();
+        assert_eq!(encoded.schema_version, RUN_SCHEMA_VERSION);
+        assert_eq!(
+            encoded.full_evidence.as_deref(),
+            Some(old_address.as_str()),
+            "a re-encoded record names its pre-compaction original"
+        );
         let new_address = Stored::minted(encoded).unwrap().address().to_string();
         assert_ne!(old_address, new_address, "the version field is addressed");
 

--- a/crates/rue-bench/src/reencode.rs
+++ b/crates/rue-bench/src/reencode.rs
@@ -1,0 +1,423 @@
+//! Re-encode a store tree from the full-evidence encoding to the stored one.
+//!
+//! The one-time compaction ADR-0067 Amendment 1 Question 2 accepts: every
+//! schema-v1 record in `runs/` is rewritten in the v2 witness-plus-digests
+//! encoding under its own new content address, `index.json` and the manifest's
+//! pinned addresses move with them, and the originals leave the tree. Nothing
+//! here touches git: the operator lands the result as a single ordinary append
+//! commit, with the pre-compaction tip tagged so every original record keeps a
+//! quotable name in history.
+//!
+//! `schema_version` is part of the canonical form, so **every** re-encoded
+//! record moves — evidence-free records included, whose only change is the
+//! version field. The manifest re-pin is therefore not optional, and the run
+//! ends by asking the `check-baselines` question of the rewritten pair: a
+//! wrong baseline address on a retired epoch is exactly the silent failure
+//! this tool must not be able to produce.
+//!
+//! Address rewriting in `index.json` and the manifest is textual: a content
+//! address is a 64-hex string unique to its record, so replacing occurrences
+//! preserves every comment and formatting choice in files this tool does not
+//! own.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use rue_perf_schema::{FULL_EVIDENCE_SCHEMA_VERSION, Manifest, RunObject, Stored, encode_v2};
+
+use crate::check_baselines::unresolved;
+use crate::staleness_inputs::parse_index;
+
+pub fn run() -> Result<u8, String> {
+    let mut data_root: Option<PathBuf> = None;
+    let mut manifest_path: Option<PathBuf> = None;
+    let mut apply = false;
+    let mut args = std::env::args().skip(2);
+    while let Some(flag) = args.next() {
+        let mut value = || {
+            args.next()
+                .ok_or_else(|| format!("{flag} requires a value"))
+        };
+        match flag.as_str() {
+            "--data-root" => data_root = Some(PathBuf::from(value()?)),
+            "--manifest" => manifest_path = Some(PathBuf::from(value()?)),
+            "--apply" => apply = true,
+            other => return Err(format!("unrecognized argument {other:?}")),
+        }
+    }
+    let data_root = data_root.ok_or("reencode requires --data-root <path>")?;
+    let manifest_path = manifest_path.ok_or("reencode requires --manifest <path>")?;
+    report(&data_root, &manifest_path, apply, &mut std::io::stdout())
+}
+
+fn report(
+    data_root: &Path,
+    manifest_path: &Path,
+    apply: bool,
+    out: &mut impl std::io::Write,
+) -> Result<u8, String> {
+    let runs_dir = data_root.join("runs");
+    let mut entries: Vec<PathBuf> = std::fs::read_dir(&runs_dir)
+        .map_err(|error| format!("could not read {}: {error}", runs_dir.display()))?
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<Result<_, _>>()
+        .map_err(|error| format!("could not list {}: {error}", runs_dir.display()))?;
+    entries.retain(|path| {
+        path.extension()
+            .is_some_and(|extension| extension == "json")
+    });
+    entries.sort();
+
+    let mut moves: BTreeMap<String, String> = BTreeMap::new();
+    let mut planned: Vec<(PathBuf, String, String)> = Vec::new();
+    let mut already_encoded = 0usize;
+    let mut bytes_before = 0u64;
+    let mut bytes_after = 0u64;
+
+    for path in &entries {
+        let text = std::fs::read_to_string(path)
+            .map_err(|error| format!("could not read {}: {error}", path.display()))?;
+        let stored = Stored::<RunObject>::read(&text)
+            .map_err(|error| format!("{}: {error}", path.display()))?;
+        bytes_before += text.len() as u64;
+        if stored.record().schema_version != FULL_EVIDENCE_SCHEMA_VERSION {
+            already_encoded += 1;
+            bytes_after += text.len() as u64;
+            continue;
+        }
+        let encoded =
+            encode_v2(stored.record()).map_err(|error| format!("{}: {error}", path.display()))?;
+        let minted =
+            Stored::minted(encoded).map_err(|error| format!("{}: {error}", path.display()))?;
+        let serialized = rue_perf_schema::canonical_json(minted.record())
+            .map_err(|error| format!("{}: {error}", path.display()))?;
+        bytes_after += serialized.len() as u64;
+        moves.insert(stored.address().to_string(), minted.address().to_string());
+        planned.push((path.clone(), minted.address().to_string(), serialized));
+    }
+
+    if apply {
+        for (old_path, new_address, serialized) in &planned {
+            let new_path = runs_dir.join(format!("{new_address}.json"));
+            // The publisher's accident-refusal rule, kept here: differing
+            // bytes under an existing name are an error, identical bytes an
+            // idempotent no-op.
+            match std::fs::read_to_string(&new_path) {
+                Ok(existing) if existing == *serialized => {}
+                Ok(_) => {
+                    return Err(format!(
+                        "{} exists with different bytes",
+                        new_path.display()
+                    ));
+                }
+                Err(_) => {
+                    std::fs::write(&new_path, serialized).map_err(|error| {
+                        format!("could not write {}: {error}", new_path.display())
+                    })?;
+                }
+            }
+            std::fs::remove_file(old_path)
+                .map_err(|error| format!("could not remove {}: {error}", old_path.display()))?;
+        }
+        let index_path = data_root.join("index.json");
+        let index_rewrites = rewrite_addresses(&index_path, &moves)?;
+        let manifest_rewrites = rewrite_addresses(manifest_path, &moves)?;
+        writeln!(
+            out,
+            "rewrote {index_rewrites} address(es) in {} and {manifest_rewrites} in {}",
+            index_path.display(),
+            manifest_path.display()
+        )
+        .map_err(|error| format!("could not write the report: {error}"))?;
+
+        // The acceptance condition, asked of the result: every declared
+        // baseline must resolve against the rewritten index, retired epochs
+        // included.
+        let manifest_text = std::fs::read_to_string(manifest_path)
+            .map_err(|error| format!("could not read {}: {error}", manifest_path.display()))?;
+        let manifest = Manifest::parse(&manifest_text).map_err(|error| error.to_string())?;
+        let index_text = std::fs::read_to_string(&index_path)
+            .map_err(|error| format!("could not read {}: {error}", index_path.display()))?;
+        let index = parse_index(&index_text)?;
+        let missing = unresolved(&manifest, &index);
+        if !missing.is_empty() {
+            for item in &missing {
+                writeln!(
+                    out,
+                    "{} epoch {}: baseline {} does not resolve — {}",
+                    item.platform, item.epoch, item.run, item.detail
+                )
+                .map_err(|error| format!("could not write the report: {error}"))?;
+            }
+            return Ok(crate::exit::NOT_APPENDABLE);
+        }
+    }
+
+    writeln!(
+        out,
+        "{} record(s) re-encoded{}, {} already encoded; {} -> {} bytes",
+        planned.len(),
+        if apply {
+            ""
+        } else {
+            " (dry run; pass --apply to write)"
+        },
+        already_encoded,
+        bytes_before,
+        bytes_after
+    )
+    .map_err(|error| format!("could not write the report: {error}"))?;
+    for (old, new) in &moves {
+        writeln!(out, "{old} {new}")
+            .map_err(|error| format!("could not write the report: {error}"))?;
+    }
+    Ok(crate::exit::OK)
+}
+
+/// Replace every mapped address in a text file, preserving everything else.
+fn rewrite_addresses(path: &Path, moves: &BTreeMap<String, String>) -> Result<usize, String> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|error| format!("could not read {}: {error}", path.display()))?;
+    let mut rewritten = text.clone();
+    let mut count = 0usize;
+    for (old, new) in moves {
+        let occurrences = rewritten.matches(old.as_str()).count();
+        if occurrences > 0 {
+            rewritten = rewritten.replace(old.as_str(), new.as_str());
+            count += occurrences;
+        }
+    }
+    if rewritten != text {
+        std::fs::write(path, &rewritten)
+            .map_err(|error| format!("could not write {}: {error}", path.display()))?;
+    }
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rue_perf_schema::RUN_SCHEMA_VERSION;
+
+    // The derive fixtures build evidence-free protocol-1 records; the
+    // evidence-bearing encode path is covered exhaustively in
+    // rue_perf_schema::encoding. This module tests the orchestration: files
+    // move, the index and manifest follow, the gate runs.
+    fn store_with(records: &[&RunObject]) -> tempfile::TempDir {
+        let directory = tempfile::tempdir().expect("temp dir");
+        std::fs::create_dir(directory.path().join("runs")).expect("runs dir");
+        let mut index_rows = Vec::new();
+        for record in records {
+            let stored = Stored::minted((*record).clone()).expect("addressable");
+            let serialized =
+                rue_perf_schema::canonical_json(stored.record()).expect("serializable");
+            std::fs::write(
+                directory
+                    .path()
+                    .join("runs")
+                    .join(format!("{}.json", stored.address())),
+                serialized,
+            )
+            .expect("write record");
+            index_rows.push(format!(
+                r#"{{"platform":"{}","epoch":{},"finished_at":"{}","run":"{}"}}"#,
+                record.identity.platform,
+                record.identity.epoch,
+                record.identity.finished_at,
+                stored.address()
+            ));
+        }
+        std::fs::write(
+            directory.path().join("index.json"),
+            format!(r#"{{"runs":[{}]}}"#, index_rows.join(",")),
+        )
+        .expect("write index");
+        directory
+    }
+
+    fn fixture_record() -> RunObject {
+        use rue_perf_schema::{
+            EnvironmentFingerprint, Invocation, Phase, PhaseAccounting, ResolvedPins, RunIdentity,
+            Sample, WorkloadObservation,
+        };
+        use std::collections::BTreeMap;
+        let mut phase_ns: BTreeMap<Phase, u64> =
+            Phase::ALL.into_iter().map(|phase| (phase, 0)).collect();
+        phase_ns.insert(Phase::SemanticAnalysis, 1_000_000);
+        RunObject {
+            schema_version: FULL_EVIDENCE_SCHEMA_VERSION,
+            identity: RunIdentity {
+                suite_revision: 1,
+                epoch: 1,
+                platform: "x86_64-linux".to_string(),
+                commit: "a".repeat(40),
+                started_at: "2026-08-20T00:00:00Z".to_string(),
+                finished_at: "2026-08-20T00:01:00Z".to_string(),
+                pins: ResolvedPins {
+                    toolchain_hash: "toolchain".to_string(),
+                    stdlib_hash: "stdlib".to_string(),
+                    workload_source_hashes: BTreeMap::from([(
+                        "startup".to_string(),
+                        "startup-hash".to_string(),
+                    )]),
+                    invocation: Invocation {
+                        target: "x86_64-unknown-linux-gnu".to_string(),
+                        args: Vec::new(),
+                    },
+                },
+                environment: EnvironmentFingerprint {
+                    runner_label: "github-hosted".to_string(),
+                    runner_image: "ubuntu-24.04".to_string(),
+                    runner_image_version: "20260820.1".to_string(),
+                    cpu_model: "AMD EPYC 7763".to_string(),
+                    core_count: 4,
+                    memory_bytes: 16 * 1024 * 1024 * 1024,
+                    kernel_version: "6.8.0".to_string(),
+                    os_version: "Ubuntu 24.04".to_string(),
+                    architecture: "x86_64".to_string(),
+                },
+            },
+            boundary: None,
+            workloads: vec![WorkloadObservation {
+                workload: "startup".to_string(),
+                boundary: None,
+                samples: vec![Sample {
+                    batch_size: 1,
+                    process_elapsed_ns: 2_000_000,
+                    peak_memory_bytes: 32 * 1024 * 1024,
+                    output_binary_bytes: 12_288,
+                    phases: PhaseAccounting {
+                        phase_ns,
+                        mixed_parallel_ns: 0,
+                        unattributed_ns: 0,
+                        compiler_root_ns: 1_000_000,
+                    },
+                    boundary_evidence: Vec::new(),
+                    boundary_processes: Vec::new(),
+                    boundary_work_processes: Vec::new(),
+                }],
+            }],
+            failures: Vec::new(),
+        }
+    }
+
+    fn manifest_pinned_to(address: &str) -> String {
+        format!(
+            "{}\n[epoch.baseline]\ncommit = \"{}\"\nrun = \"{address}\"\n",
+            crate::check_baselines::tests::BASE,
+            "a".repeat(40)
+        )
+    }
+
+    #[test]
+    fn a_dry_run_moves_nothing_and_prints_the_map() {
+        let record = fixture_record();
+        let store = store_with(&[&record]);
+        let old_address = Stored::minted(record.clone())
+            .unwrap()
+            .address()
+            .to_string();
+        let manifest_file = store.path().join("manifest.toml");
+        std::fs::write(&manifest_file, manifest_pinned_to(&old_address)).unwrap();
+
+        let mut output = Vec::new();
+        let code = report(store.path(), &manifest_file, false, &mut output).unwrap();
+        assert_eq!(code, crate::exit::OK);
+        let output = String::from_utf8(output).unwrap();
+        assert!(
+            output.contains("1 record(s) re-encoded (dry run"),
+            "{output}"
+        );
+        assert!(output.contains(&old_address), "{output}");
+        // Nothing moved: the original file is still the only record.
+        assert!(
+            store
+                .path()
+                .join("runs")
+                .join(format!("{old_address}.json"))
+                .exists()
+        );
+    }
+
+    #[test]
+    fn applying_moves_records_and_repins_the_manifest_and_index() {
+        let record = fixture_record();
+        let store = store_with(&[&record]);
+        let old_address = Stored::minted(record.clone())
+            .unwrap()
+            .address()
+            .to_string();
+        let manifest_file = store.path().join("manifest.toml");
+        std::fs::write(&manifest_file, manifest_pinned_to(&old_address)).unwrap();
+
+        let mut encoded = record.clone();
+        encoded.schema_version = RUN_SCHEMA_VERSION;
+        let new_address = Stored::minted(encoded).unwrap().address().to_string();
+        assert_ne!(old_address, new_address, "the version field is addressed");
+
+        let mut output = Vec::new();
+        let code = report(store.path(), &manifest_file, true, &mut output).unwrap();
+        assert_eq!(
+            code,
+            crate::exit::OK,
+            "{}",
+            String::from_utf8(output).unwrap()
+        );
+
+        let runs = store.path().join("runs");
+        assert!(!runs.join(format!("{old_address}.json")).exists());
+        assert!(runs.join(format!("{new_address}.json")).exists());
+        let index = std::fs::read_to_string(store.path().join("index.json")).unwrap();
+        assert!(index.contains(&new_address));
+        assert!(!index.contains(&old_address));
+        let manifest = std::fs::read_to_string(&manifest_file).unwrap();
+        assert!(manifest.contains(&new_address));
+        assert!(!manifest.contains(&old_address));
+    }
+
+    #[test]
+    fn a_second_application_is_an_idempotent_no_op() {
+        let record = fixture_record();
+        let store = store_with(&[&record]);
+        let manifest_file = store.path().join("manifest.toml");
+        let old_address = Stored::minted(record.clone())
+            .unwrap()
+            .address()
+            .to_string();
+        std::fs::write(&manifest_file, manifest_pinned_to(&old_address)).unwrap();
+
+        let mut output = Vec::new();
+        report(store.path(), &manifest_file, true, &mut output).unwrap();
+        let manifest_after_first = std::fs::read_to_string(&manifest_file).unwrap();
+
+        let mut output = Vec::new();
+        let code = report(store.path(), &manifest_file, true, &mut output).unwrap();
+        assert_eq!(code, crate::exit::OK);
+        let output = String::from_utf8(output).unwrap();
+        assert!(
+            output.contains("0 record(s) re-encoded, 1 already encoded"),
+            "{output}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&manifest_file).unwrap(),
+            manifest_after_first
+        );
+    }
+
+    #[test]
+    fn a_baseline_the_rewrite_cannot_reach_fails_the_gate() {
+        // A pin naming an address outside the store: the map cannot move it,
+        // and the closing check-baselines question must fail loudly rather
+        // than let the operator commit a silently broken manifest.
+        let record = fixture_record();
+        let store = store_with(&[&record]);
+        let manifest_file = store.path().join("manifest.toml");
+        std::fs::write(&manifest_file, manifest_pinned_to(&"f".repeat(64))).unwrap();
+
+        let mut output = Vec::new();
+        let code = report(store.path(), &manifest_file, true, &mut output).unwrap();
+        assert_eq!(code, crate::exit::NOT_APPENDABLE);
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("does not resolve"), "{output}");
+    }
+}

--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -1103,6 +1103,8 @@ mod tests {
                 compiler_root_ns: 100,
             },
             boundary_evidence: Vec::new(),
+            boundary_processes: Vec::new(),
+            boundary_work_processes: Vec::new(),
         };
         ScalingReport {
             schema_version: SCALING_REPORT_SCHEMA_VERSION,

--- a/crates/rue-perf-schema/src/boundary.rs
+++ b/crates/rue-perf-schema/src/boundary.rs
@@ -993,7 +993,7 @@ impl BuildBoundaryEvidence {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
     fn distribution() -> DurationDistribution {
@@ -1020,7 +1020,7 @@ mod tests {
         distribution.log2_buckets[6] += 1;
     }
 
-    fn evidence() -> BuildBoundaryEvidence {
+    pub(crate) fn evidence() -> BuildBoundaryEvidence {
         let output_sha256 = "a".repeat(64);
         BuildBoundaryEvidence {
             runner: RunnerBoundaryEvidence {

--- a/crates/rue-perf-schema/src/encoding.rs
+++ b/crates/rue-perf-schema/src/encoding.rs
@@ -334,6 +334,10 @@ pub fn encode_v2(full: &RunObject) -> Result<RunObject, EncodeError> {
 
     let mut encoded = full.clone();
     encoded.schema_version = crate::RUN_SCHEMA_VERSION;
+    // The commitment to what this encoding drops: the full form's own content
+    // address, which is both the retained artifact's name and — for a
+    // re-encoded record — the pre-compaction record's address in history.
+    encoded.full_evidence = Some(crate::canonical::content_address(full)?);
 
     // The run-invariant block comes from the first evidence-bearing process in
     // the record. A record with none stays evidence-free.
@@ -617,6 +621,7 @@ mod tests {
         }
         let mut expected = full.clone();
         expected.schema_version = crate::RUN_SCHEMA_VERSION;
+        expected.full_evidence = Some(crate::canonical::content_address(&full).unwrap());
         assert_eq!(encoded, expected);
     }
 
@@ -646,6 +651,121 @@ mod tests {
             Err(EncodeError::NotFullEvidence {
                 found: crate::RUN_SCHEMA_VERSION
             })
+        );
+    }
+
+    #[test]
+    fn a_named_evidence_type_with_a_missing_field_refuses_to_parse() {
+        // The other half of rule 3: no `serde(default)` may be added either.
+        // A field absent from stored bytes must fail the parse, not fill in.
+        for field in ["output_sha256", "successful_exit", "clock_boundary"] {
+            let mut value = serde_json::to_value(vector_runner()).unwrap();
+            value.as_object_mut().unwrap().remove(field);
+            let parsed: Result<RunnerBoundaryEvidence, _> = serde_json::from_value(value);
+            assert!(parsed.is_err(), "{field} parsed as a default");
+        }
+        for field in ["accepted_inputs", "emitted_output_sha256", "artifact_hits"] {
+            let mut value =
+                serde_json::to_value(crate::boundary::tests::evidence().compiler).unwrap();
+            value.as_object_mut().unwrap().remove(field);
+            let parsed: Result<CompilerBoundaryEvidence, _> = serde_json::from_value(value);
+            assert!(parsed.is_err(), "{field} parsed as a default");
+        }
+    }
+
+    #[test]
+    fn empty_collections_still_serialize_their_keys() {
+        // A `skip_serializing_if` on an empty collection would pass a
+        // non-empty fixture's field-presence test while changing the preimage
+        // of every record whose value is empty. Pin the empty case directly.
+        let mut compiler = crate::boundary::tests::evidence().compiler;
+        compiler.accepted_inputs = Vec::new();
+        compiler.embedded_assets = Vec::new();
+        compiler.configuration.preview_features = Vec::new();
+        let canonical = crate::canonical::canonical_json(&compiler).unwrap();
+        for field in ["accepted_inputs", "embedded_assets", "preview_features"] {
+            assert!(
+                canonical.contains(&format!("\"{field}\":[]")),
+                "{field} omitted when empty: {canonical}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_work_digest_preimage_serializes_every_group() {
+        // `CompilerWork` is the work-digest preimage; rule 3's by-name scope
+        // covers the evidence pair, so this test extends the same guarantee
+        // to the third preimage type. Its `serde(default)` fields are
+        // parse-side tolerance for old records and must still serialize.
+        let canonical = crate::canonical::canonical_json(&CompilerWork::default()).unwrap();
+        for field in [
+            "semantic_provider",
+            "semantic_reachability",
+            "semantic_body_structure",
+            "cfg_materialization",
+            "cfg_prerequisites",
+            "cfg_retained_charge",
+            "cfg_local_epoch",
+            "query_runtime",
+            "publication",
+        ] {
+            assert!(
+                canonical.contains(&format!("\"{field}\":")),
+                "{field} omitted"
+            );
+        }
+    }
+
+    #[test]
+    fn the_identity_preimage_is_the_two_key_object() {
+        let evidence = crate::boundary::tests::evidence();
+        let preimage = IdentityPreimage {
+            runner: &evidence.runner,
+            compiler: &evidence.compiler,
+        };
+        let canonical = crate::canonical::canonical_json(&preimage).unwrap();
+        let expected = format!(
+            "{{\"compiler\":{},\"runner\":{}}}",
+            crate::canonical::canonical_json(&evidence.compiler).unwrap(),
+            crate::canonical::canonical_json(&evidence.runner).unwrap()
+        );
+        assert_eq!(canonical, expected);
+    }
+
+    #[test]
+    fn an_encoded_record_round_trips_through_stored_bytes() {
+        let encoded = encode_v2(&full_run()).unwrap();
+        let serialized = crate::canonical::canonical_json(&encoded).unwrap();
+        let parsed: RunObject = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(parsed, encoded);
+        assert_eq!(
+            crate::canonical::canonical_json(&parsed).unwrap(),
+            serialized
+        );
+    }
+
+    #[test]
+    fn v1_bytes_without_the_new_fields_reserialize_byte_identically() {
+        // A stored v1 record never contained the v2 keys; parsing it must not
+        // materialize them, or every pre-change address would move.
+        let full = full_run();
+        let serialized = crate::canonical::canonical_json(&full).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+        let top = value.as_object().unwrap();
+        assert!(!top.contains_key("boundary"));
+        assert!(!top.contains_key("full_evidence"));
+        let sample = &value["workloads"][0]["samples"][0];
+        let sample = sample.as_object().unwrap();
+        assert!(!sample.contains_key("boundary_processes"));
+        assert!(!sample.contains_key("boundary_work_processes"));
+        let parsed: RunObject = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(
+            crate::canonical::canonical_json(&parsed).unwrap(),
+            serialized
+        );
+        assert_eq!(
+            crate::content_address(&parsed).unwrap(),
+            crate::content_address(&full).unwrap()
         );
     }
 }

--- a/crates/rue-perf-schema/src/encoding.rs
+++ b/crates/rue-perf-schema/src/encoding.rs
@@ -1,0 +1,651 @@
+//! The v2 record encoding: one boundary witness plus per-process digests.
+//!
+//! ADR-0071 Amendment 1 (accepted 2026-08-23) replaces per-process copies of
+//! byte-identical boundary evidence with one complete witness per workload
+//! observation and a pair of SHA-256 digests per process. ADR-0067 Amendment 1
+//! makes `schema_version` the axis that owns this change: encoding shape
+//! dispatches on the record's `schema_version`, while what must be *proven*
+//! keeps dispatching on the suite's `protocol_version`.
+//!
+//! The hoist is a **lossless partition**: every field of a process's
+//! [`RunnerBoundaryEvidence`] and [`CompilerBoundaryEvidence`] lands in exactly
+//! one of the run-level block (invariant across the whole run) or the
+//! workload-level block (invariant across that workload's processes), and a
+//! reader reassembles the complete pair from the two blocks
+//! ([`reassemble_witness`]). The digests commit to the evidence *as measured*:
+//! each process's digest is computed from that process's own original value,
+//! never from the witness, so a process that disagreed with its siblings still
+//! disagrees after encoding — by digest instead of by bytes.
+//!
+//! The digest is `SHA-256(tag || canonical_json(value))` with a fixed ASCII
+//! domain tag ending in a newline. `schema_version` is deliberately outside
+//! every preimage: the process evidence is a property of the process, not of
+//! the record encoding that carries it. If a preimage ever changes, the tag's
+//! trailing `.1` increments and the two schemes are distinguishable by
+//! construction.
+//!
+//! `critical_path` is the one evidence member measured to vary across
+//! processes. One is retained per workload observation — the first process of
+//! the first evidence-bearing sample — and the record states that provenance
+//! in [`WorkloadBoundary::critical_path_source`] rather than relying on the
+//! convention. The same rule and the same `_source` shape carry the
+//! representative `compiler_work` a parallel boundary epoch retains: at one
+//! worker it is a witness every process's digest must match; at any other
+//! worker setting the values are schedule-dependent by design, no per-process
+//! work digest is stored (a digest of unstored bytes that are expected to
+//! differ certifies nothing), and the retained value is a sample, not a
+//! witness.
+
+use serde::{Deserialize, Serialize};
+
+use crate::boundary::{
+    ArtifactHitEvidence, BuildBoundary, BuildBoundaryEvidence, CompilerBoundaryEvidence,
+    CompilerConfigurationEvidence, CompilerCriticalPathEvidence, CompilerInputEvidence,
+    CompilerPipeline, CompilerStage, EmbeddedAssetEvidence, RunnerBoundaryEvidence,
+    RunnerClockBoundary, WorkerSetting,
+};
+use crate::canonical::CanonicalError;
+use crate::run::RunObject;
+use crate::scaling::CompilerWork;
+
+/// Domain tag for the per-process identity digest over `{runner, compiler}`.
+pub const IDENTITY_DIGEST_TAG: &str = "rue.boundary.identity.1\n";
+
+/// Domain tag for the per-process work digest over `compiler_work`.
+pub const WORK_DIGEST_TAG: &str = "rue.boundary.work.1\n";
+
+/// The schema version of the full-evidence encoding.
+///
+/// This is also the encoding the producer builds in memory, validates in
+/// full, and retains as the collection workflow's artifact; only what reaches
+/// the store is written at [`crate::RUN_SCHEMA_VERSION`].
+pub const FULL_EVIDENCE_SCHEMA_VERSION: u32 = 1;
+
+/// Where a retained evidence member came from.
+///
+/// `sample_index` and `process_index` name the entry of the original
+/// full-evidence record that supplied the value. Without this, a retained
+/// member is a number with no stated provenance — which is how a
+/// representative sample gets misread as a witness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceSource {
+    pub sample_index: u32,
+    pub process_index: u32,
+}
+
+/// The run-invariant half of every process's `runner` evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerRunInvariant {
+    pub compiler_binary_sha256: String,
+    pub fresh_state_directory: bool,
+    pub fresh_output_directory: bool,
+    pub daemon_endpoint_supplied: bool,
+    pub retained_session_handle_supplied: bool,
+    pub clock_boundary: RunnerClockBoundary,
+    pub successful_exit: bool,
+    pub native_output_verified: bool,
+}
+
+/// The run-invariant half of every process's `compiler` evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CompilerRunInvariant {
+    pub boundary: BuildBoundary,
+    pub pipeline: CompilerPipeline,
+    pub session_count: u32,
+    pub root_request_count: u32,
+    pub configuration: CompilerConfigurationEvidence,
+    pub completed_stages: Vec<CompilerStage>,
+}
+
+/// Parts of the boundary evidence invariant across the whole run.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RunBoundary {
+    pub runner: RunnerRunInvariant,
+    pub compiler: CompilerRunInvariant,
+}
+
+/// The workload-invariant half of a process's `runner` evidence.
+///
+/// Output identity is four fields, not two; these are the runner's half, and
+/// [`CompilerWorkloadInvariant`] carries the compiler's.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerWorkloadInvariant {
+    pub output_sha256: String,
+    pub output_size_bytes: u64,
+}
+
+/// The workload-invariant half of a process's `compiler` evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CompilerWorkloadInvariant {
+    pub accepted_inputs: Vec<CompilerInputEvidence>,
+    pub embedded_assets: Vec<EmbeddedAssetEvidence>,
+    pub artifact_hits: ArtifactHitEvidence,
+    pub emitted_output_sha256: String,
+    pub emitted_output_size_bytes: u64,
+}
+
+/// Parts of the boundary evidence invariant across one workload's processes,
+/// plus the retained per-workload members.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkloadBoundary {
+    pub runner: RunnerWorkloadInvariant,
+    pub compiler: CompilerWorkloadInvariant,
+    /// The retained deterministic-work value.
+    ///
+    /// At one worker this is a witness: every process's
+    /// `boundary_work_processes` digest must equal [`work_digest`] of this
+    /// value. At any other worker setting it is a representative sample
+    /// carried under the same provenance convention, and no per-process work
+    /// digests are stored.
+    pub compiler_work: CompilerWork,
+    pub compiler_work_source: EvidenceSource,
+    /// The one retained per-commit critical path for this workload.
+    pub critical_path: CompilerCriticalPathEvidence,
+    pub critical_path_source: EvidenceSource,
+}
+
+/// The digest preimage value: the reassembled per-process pair.
+///
+/// Canonical JSON sorts keys, so this serializes as the two-key object
+/// `{"compiler": …, "runner": …}` regardless of field order here.
+#[derive(Serialize)]
+struct IdentityPreimage<'a> {
+    runner: &'a RunnerBoundaryEvidence,
+    compiler: &'a CompilerBoundaryEvidence,
+}
+
+fn tagged_digest<T: Serialize>(tag: &str, value: &T) -> Result<String, CanonicalError> {
+    use sha2::{Digest, Sha256};
+    let canonical = crate::canonical::canonical_json(value)?;
+    let mut hasher = Sha256::new();
+    hasher.update(tag.as_bytes());
+    hasher.update(canonical.as_bytes());
+    Ok(hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect())
+}
+
+/// The per-process identity digest over a `{runner, compiler}` pair.
+pub fn identity_digest(
+    runner: &RunnerBoundaryEvidence,
+    compiler: &CompilerBoundaryEvidence,
+) -> Result<String, CanonicalError> {
+    tagged_digest(IDENTITY_DIGEST_TAG, &IdentityPreimage { runner, compiler })
+}
+
+/// The per-process work digest over a `compiler_work` value.
+pub fn work_digest(work: &CompilerWork) -> Result<String, CanonicalError> {
+    tagged_digest(WORK_DIGEST_TAG, work)
+}
+
+/// Reassemble the complete `{runner, compiler}` pair from the two blocks.
+///
+/// This is the digest preimage a reader recomputes. The partition being
+/// complete and disjoint is what makes the digest independent of *where* a
+/// field was hoisted to; [`encode_v2`] asserts the round-trip against the
+/// original witness so a field landing in neither block, or in both, cannot
+/// pass silently.
+pub fn reassemble_witness(
+    run: &RunBoundary,
+    workload: &WorkloadBoundary,
+) -> (RunnerBoundaryEvidence, CompilerBoundaryEvidence) {
+    let runner = RunnerBoundaryEvidence {
+        compiler_binary_sha256: run.runner.compiler_binary_sha256.clone(),
+        fresh_state_directory: run.runner.fresh_state_directory,
+        fresh_output_directory: run.runner.fresh_output_directory,
+        daemon_endpoint_supplied: run.runner.daemon_endpoint_supplied,
+        retained_session_handle_supplied: run.runner.retained_session_handle_supplied,
+        clock_boundary: run.runner.clock_boundary,
+        successful_exit: run.runner.successful_exit,
+        native_output_verified: run.runner.native_output_verified,
+        output_sha256: workload.runner.output_sha256.clone(),
+        output_size_bytes: workload.runner.output_size_bytes,
+    };
+    let compiler = CompilerBoundaryEvidence {
+        boundary: run.compiler.boundary,
+        pipeline: run.compiler.pipeline,
+        session_count: run.compiler.session_count,
+        root_request_count: run.compiler.root_request_count,
+        configuration: run.compiler.configuration.clone(),
+        completed_stages: run.compiler.completed_stages.clone(),
+        accepted_inputs: workload.compiler.accepted_inputs.clone(),
+        embedded_assets: workload.compiler.embedded_assets.clone(),
+        artifact_hits: workload.compiler.artifact_hits,
+        emitted_output_sha256: workload.compiler.emitted_output_sha256.clone(),
+        emitted_output_size_bytes: workload.compiler.emitted_output_size_bytes,
+    };
+    (runner, compiler)
+}
+
+fn split_run_invariant(evidence: &BuildBoundaryEvidence) -> RunBoundary {
+    RunBoundary {
+        runner: RunnerRunInvariant {
+            compiler_binary_sha256: evidence.runner.compiler_binary_sha256.clone(),
+            fresh_state_directory: evidence.runner.fresh_state_directory,
+            fresh_output_directory: evidence.runner.fresh_output_directory,
+            daemon_endpoint_supplied: evidence.runner.daemon_endpoint_supplied,
+            retained_session_handle_supplied: evidence.runner.retained_session_handle_supplied,
+            clock_boundary: evidence.runner.clock_boundary,
+            successful_exit: evidence.runner.successful_exit,
+            native_output_verified: evidence.runner.native_output_verified,
+        },
+        compiler: CompilerRunInvariant {
+            boundary: evidence.compiler.boundary,
+            pipeline: evidence.compiler.pipeline,
+            session_count: evidence.compiler.session_count,
+            root_request_count: evidence.compiler.root_request_count,
+            configuration: evidence.compiler.configuration.clone(),
+            completed_stages: evidence.compiler.completed_stages.clone(),
+        },
+    }
+}
+
+fn split_workload_invariant(
+    evidence: &BuildBoundaryEvidence,
+    source: EvidenceSource,
+) -> WorkloadBoundary {
+    WorkloadBoundary {
+        runner: RunnerWorkloadInvariant {
+            output_sha256: evidence.runner.output_sha256.clone(),
+            output_size_bytes: evidence.runner.output_size_bytes,
+        },
+        compiler: CompilerWorkloadInvariant {
+            accepted_inputs: evidence.compiler.accepted_inputs.clone(),
+            embedded_assets: evidence.compiler.embedded_assets.clone(),
+            artifact_hits: evidence.compiler.artifact_hits,
+            emitted_output_sha256: evidence.compiler.emitted_output_sha256.clone(),
+            emitted_output_size_bytes: evidence.compiler.emitted_output_size_bytes,
+        },
+        compiler_work: evidence.compiler_work,
+        compiler_work_source: source,
+        critical_path: evidence.critical_path.clone(),
+        critical_path_source: source,
+    }
+}
+
+/// Why a full-evidence record could not be re-encoded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EncodeError {
+    /// The input does not declare the full-evidence schema version.
+    NotFullEvidence { found: u32 },
+    /// The reassembled witness did not equal the original pair.
+    ///
+    /// This is the round-trip guarantee failing: a field landed in neither
+    /// block or in both, and the digests would certify something other than
+    /// the evidence as measured.
+    RoundTrip { workload: String },
+    /// A value could not be canonicalized for digesting.
+    Canonical(CanonicalError),
+}
+
+impl std::fmt::Display for EncodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EncodeError::NotFullEvidence { found } => write!(
+                f,
+                "expected a schema v{FULL_EVIDENCE_SCHEMA_VERSION} full-evidence record, found v{found}"
+            ),
+            EncodeError::RoundTrip { workload } => write!(
+                f,
+                "workload {workload}: reassembled witness differs from the original evidence"
+            ),
+            EncodeError::Canonical(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for EncodeError {}
+
+impl From<CanonicalError> for EncodeError {
+    fn from(error: CanonicalError) -> Self {
+        EncodeError::Canonical(error)
+    }
+}
+
+/// Encode a full-evidence (v1) record into the stored (v2) form.
+///
+/// A record with no boundary evidence anywhere — a protocol-1 suite — changes
+/// only its declared `schema_version`. Everything the encoding drops is
+/// dropped knowingly: per-process `critical_path` histograms for processes
+/// beyond the retained one, replaced by nothing, and per-process
+/// `{runner, compiler}` / `compiler_work` values, replaced by digests a reader
+/// checks against the retained witness.
+///
+/// Digests are computed from each process's own evidence. A record whose
+/// processes disagreed — which validation refuses to append, but the store
+/// keeps as evidence — therefore still disagrees after encoding: the
+/// mismatching process's digest fails the witness comparison exactly where
+/// the original bytes failed the equality check.
+pub fn encode_v2(full: &RunObject) -> Result<RunObject, EncodeError> {
+    if full.schema_version != FULL_EVIDENCE_SCHEMA_VERSION {
+        return Err(EncodeError::NotFullEvidence {
+            found: full.schema_version,
+        });
+    }
+
+    let mut encoded = full.clone();
+    encoded.schema_version = crate::RUN_SCHEMA_VERSION;
+
+    // The run-invariant block comes from the first evidence-bearing process in
+    // the record. A record with none stays evidence-free.
+    let first_evidence = full.workloads.iter().find_map(|observation| {
+        observation
+            .samples
+            .iter()
+            .find_map(|sample| sample.boundary_evidence.first())
+    });
+    let Some(first_evidence) = first_evidence else {
+        return Ok(encoded);
+    };
+    let run_boundary = split_run_invariant(first_evidence);
+
+    for observation in &mut encoded.workloads {
+        // The witness rule: the first process of the first evidence-bearing
+        // sample, with the actual indices recorded as provenance. For a
+        // well-formed record that is samples[0], boundary_evidence[0].
+        let witness = observation
+            .samples
+            .iter()
+            .enumerate()
+            .find_map(|(sample_index, sample)| {
+                sample.boundary_evidence.first().map(|evidence| {
+                    (
+                        EvidenceSource {
+                            sample_index: sample_index as u32,
+                            process_index: 0,
+                        },
+                        evidence.clone(),
+                    )
+                })
+            });
+        let Some((source, witness)) = witness else {
+            // No evidence in this workload: nothing to hoist, nothing to
+            // digest. The reader's protocol checks decide whether that state
+            // was legal, exactly as they did for the original record.
+            continue;
+        };
+
+        let workload_boundary = split_workload_invariant(&witness, source);
+
+        // The round-trip guarantee: the partition is complete and disjoint,
+        // proven by reassembling the witness and requiring exact equality.
+        let (runner, compiler) = reassemble_witness(&run_boundary, &workload_boundary);
+        if runner != witness.runner || compiler != witness.compiler {
+            return Err(EncodeError::RoundTrip {
+                workload: observation.workload.clone(),
+            });
+        }
+
+        // Work digests are stored only where the epoch's whole record is
+        // deterministic per process: one worker. The setting is read from the
+        // evidence itself — validation already requires it to equal the
+        // epoch's declared policy.
+        let one_worker =
+            run_boundary.compiler.configuration.requested_workers == WorkerSetting::One;
+
+        for sample in &mut observation.samples {
+            let mut identity_digests = Vec::with_capacity(sample.boundary_evidence.len());
+            let mut work_digests = Vec::with_capacity(sample.boundary_evidence.len());
+            for evidence in &sample.boundary_evidence {
+                identity_digests.push(identity_digest(&evidence.runner, &evidence.compiler)?);
+                if one_worker {
+                    work_digests.push(work_digest(&evidence.compiler_work)?);
+                }
+            }
+            sample.boundary_processes = identity_digests;
+            sample.boundary_work_processes = work_digests;
+            sample.boundary_evidence = Vec::new();
+        }
+
+        observation.boundary = Some(workload_boundary);
+    }
+
+    encoded.boundary = Some(run_boundary);
+    Ok(encoded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A protocol-2-shaped full-evidence run: the validate fixture with a
+    /// batch of evidence attached to every sample.
+    fn full_run() -> RunObject {
+        let mut run = crate::validate::tests::sample_run();
+        for observation in &mut run.workloads {
+            for sample in &mut observation.samples {
+                let mut evidence = crate::boundary::tests::evidence();
+                evidence.runner.output_size_bytes = sample.output_binary_bytes;
+                evidence.compiler.emitted_output_size_bytes = sample.output_binary_bytes;
+                sample.boundary_evidence = vec![evidence; sample.batch_size as usize];
+            }
+        }
+        run
+    }
+
+    // The worked vector from the supporting note: the mechanism — tag,
+    // canonicalization, hex — pinned to exact bytes checkable with sha256sum.
+    fn vector_runner() -> RunnerBoundaryEvidence {
+        RunnerBoundaryEvidence {
+            compiler_binary_sha256: "a".repeat(64),
+            fresh_state_directory: true,
+            fresh_output_directory: true,
+            daemon_endpoint_supplied: false,
+            retained_session_handle_supplied: false,
+            clock_boundary: RunnerClockBoundary::MonotonicPreSpawnThroughExitAndOutputVerification,
+            successful_exit: true,
+            native_output_verified: true,
+            output_sha256: "b".repeat(64),
+            output_size_bytes: 16384,
+        }
+    }
+
+    #[test]
+    fn the_worked_vector_reproduces_byte_for_byte() {
+        let runner = vector_runner();
+        let canonical = crate::canonical::canonical_json(&runner).unwrap();
+        assert_eq!(
+            canonical.len(),
+            464,
+            "the note pins the preimage at 464 bytes"
+        );
+        assert_eq!(
+            tagged_digest(IDENTITY_DIGEST_TAG, &runner).unwrap(),
+            "2a095434f674a8c7d4096f6c69d45273c1f811a8ac05bd590f82649170a8501e"
+        );
+        assert_eq!(
+            tagged_digest("", &runner).unwrap(),
+            "354de1ad26a990020fb8548f8e29a8b3e5618562fa91e9b256224beb68433675"
+        );
+        assert_eq!(
+            tagged_digest(WORK_DIGEST_TAG, &runner).unwrap(),
+            "b8b977f34591df2d3d8700988c6f0dd0a0a7da1a65e9ac5818bcce75af821155"
+        );
+    }
+
+    #[test]
+    fn the_two_digest_tags_domain_separate_one_value() {
+        // Same construction, different tags, different names — the property
+        // the tag buys. Checked on the vector above for exact bytes; checked
+        // here for the general shape.
+        let work = CompilerWork::default();
+        let under_work_tag = work_digest(&work).unwrap();
+        let under_identity_tag = tagged_digest(IDENTITY_DIGEST_TAG, &work).unwrap();
+        assert_ne!(under_work_tag, under_identity_tag);
+    }
+
+    #[test]
+    fn the_named_evidence_types_serialize_every_field() {
+        // Amendment rule 3: no omission or default rules on
+        // RunnerBoundaryEvidence and CompilerBoundaryEvidence, by name. Every
+        // field is always present in the canonical form, so the preimage can
+        // never depend on what a writer chose to emit.
+        let runner = vector_runner();
+        let canonical = crate::canonical::canonical_json(&runner).unwrap();
+        for field in [
+            "compiler_binary_sha256",
+            "fresh_state_directory",
+            "fresh_output_directory",
+            "daemon_endpoint_supplied",
+            "retained_session_handle_supplied",
+            "clock_boundary",
+            "successful_exit",
+            "native_output_verified",
+            "output_sha256",
+            "output_size_bytes",
+        ] {
+            assert!(
+                canonical.contains(&format!("\"{field}\":")),
+                "{field} omitted"
+            );
+        }
+        let compiler = crate::boundary::tests::evidence().compiler;
+        let canonical = crate::canonical::canonical_json(&compiler).unwrap();
+        for field in [
+            "boundary",
+            "pipeline",
+            "session_count",
+            "root_request_count",
+            "configuration",
+            "completed_stages",
+            "accepted_inputs",
+            "embedded_assets",
+            "artifact_hits",
+            "emitted_output_sha256",
+            "emitted_output_size_bytes",
+        ] {
+            assert!(
+                canonical.contains(&format!("\"{field}\":")),
+                "{field} omitted"
+            );
+        }
+    }
+
+    #[test]
+    fn schema_version_is_outside_every_preimage() {
+        // Re-encoding changes the record's version and nothing about what was
+        // measured, so the digests of a v1 record's evidence and the digests
+        // stored in its v2 form are the same strings.
+        let full = full_run();
+        let encoded = encode_v2(&full).unwrap();
+        let original = full.workloads[0].samples[0].boundary_evidence[0].clone();
+        assert_eq!(
+            encoded.workloads[0].samples[0].boundary_processes[0],
+            identity_digest(&original.runner, &original.compiler).unwrap()
+        );
+    }
+
+    #[test]
+    fn encoding_round_trips_the_witness_exactly() {
+        let full = full_run();
+        let encoded = encode_v2(&full).unwrap();
+        let run = encoded.boundary.as_ref().unwrap();
+        let workload = encoded.workloads[0].boundary.as_ref().unwrap();
+        let (runner, compiler) = reassemble_witness(run, workload);
+        let witness = &full.workloads[0].samples[0].boundary_evidence[0];
+        assert_eq!(runner, witness.runner);
+        assert_eq!(compiler, witness.compiler);
+        assert_eq!(workload.critical_path, witness.critical_path);
+        assert_eq!(workload.compiler_work, witness.compiler_work);
+        assert_eq!(workload.critical_path_source.sample_index, 0);
+        assert_eq!(workload.critical_path_source.process_index, 0);
+    }
+
+    #[test]
+    fn one_worker_records_carry_both_digests_per_process() {
+        let full = full_run();
+        let encoded = encode_v2(&full).unwrap();
+        for observation in &encoded.workloads {
+            for sample in &observation.samples {
+                assert!(sample.boundary_evidence.is_empty());
+                assert_eq!(sample.boundary_processes.len(), sample.batch_size as usize);
+                assert_eq!(
+                    sample.boundary_work_processes.len(),
+                    sample.batch_size as usize
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_parallel_record_stores_no_work_digests() {
+        let mut full = full_run();
+        for observation in &mut full.workloads {
+            for sample in &mut observation.samples {
+                for evidence in &mut sample.boundary_evidence {
+                    evidence.compiler.configuration.requested_workers = WorkerSetting::Automatic;
+                    evidence.compiler.configuration.resolved_workers = 4;
+                }
+            }
+        }
+        let encoded = encode_v2(&full).unwrap();
+        for observation in &encoded.workloads {
+            assert!(observation.boundary.is_some());
+            for sample in &observation.samples {
+                assert_eq!(sample.boundary_processes.len(), sample.batch_size as usize);
+                assert!(sample.boundary_work_processes.is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn an_evidence_free_record_changes_only_its_version() {
+        let mut full = full_run();
+        for observation in &mut full.workloads {
+            for sample in &mut observation.samples {
+                sample.boundary_evidence = Vec::new();
+            }
+        }
+        let encoded = encode_v2(&full).unwrap();
+        assert_eq!(encoded.schema_version, crate::RUN_SCHEMA_VERSION);
+        assert!(encoded.boundary.is_none());
+        for observation in &encoded.workloads {
+            assert!(observation.boundary.is_none());
+            for sample in &observation.samples {
+                assert!(sample.boundary_processes.is_empty());
+                assert!(sample.boundary_work_processes.is_empty());
+            }
+        }
+        let mut expected = full.clone();
+        expected.schema_version = crate::RUN_SCHEMA_VERSION;
+        assert_eq!(encoded, expected);
+    }
+
+    #[test]
+    fn a_disagreeing_process_still_disagrees_after_encoding() {
+        let mut full = full_run();
+        // The startup workload batches 40 processes per sample.
+        let samples = &mut full.workloads[1].samples;
+        let evidence = &mut samples[0].boundary_evidence;
+        assert!(
+            evidence.len() >= 2,
+            "fixture must batch at least two processes"
+        );
+        evidence[1].runner.output_sha256 = "c".repeat(64);
+        let encoded = encode_v2(&full).unwrap();
+        let digests = &encoded.workloads[1].samples[0].boundary_processes;
+        assert_ne!(digests[0], digests[1]);
+        assert_eq!(digests[0], digests[2]);
+    }
+
+    #[test]
+    fn a_record_already_encoded_is_refused() {
+        let full = full_run();
+        let encoded = encode_v2(&full).unwrap();
+        assert_eq!(
+            encode_v2(&encoded),
+            Err(EncodeError::NotFullEvidence {
+                found: crate::RUN_SCHEMA_VERSION
+            })
+        );
+    }
+}

--- a/crates/rue-perf-schema/src/lib.rs
+++ b/crates/rue-perf-schema/src/lib.rs
@@ -44,6 +44,7 @@
 
 mod boundary;
 mod canonical;
+mod encoding;
 mod incremental;
 mod manifest;
 mod run;
@@ -63,6 +64,12 @@ pub use boundary::{
     OptimizationLevel, OutputKind, RunnerBoundaryEvidence, RunnerClockBoundary, WorkerSetting,
 };
 pub use canonical::{CanonicalError, canonical_json, content_address};
+pub use encoding::{
+    CompilerRunInvariant, CompilerWorkloadInvariant, EncodeError, EvidenceSource,
+    FULL_EVIDENCE_SCHEMA_VERSION, IDENTITY_DIGEST_TAG, RunBoundary, RunnerRunInvariant,
+    RunnerWorkloadInvariant, WORK_DIGEST_TAG, WorkloadBoundary, encode_v2, identity_digest,
+    reassemble_witness, work_digest,
+};
 pub use incremental::{
     DisplayIdentityWorkSummary, EDIT_REPORT_SCHEMA_VERSION, EditEndpoints, EditManifest,
     EditManifestError, EditOutcome, EditReport, EditReportIdentity, EditReportRegime, EditRow,
@@ -135,9 +142,13 @@ pub struct DisplayIdentityWork {
     pub abort_fallback_bytes: u64,
 }
 
-/// The schema version of [`RunObject`] as defined by this crate.
+/// The schema version the producer writes (ADR-0067 Amendment 1).
 ///
-/// A run object records the version it was written under. Readers refuse
-/// versions they do not implement rather than guessing: there is no
-/// compatibility path, by design.
-pub const RUN_SCHEMA_VERSION: u32 = 1;
+/// A run object records the version it was written under. Readers implement
+/// every schema version that can still be in the store —
+/// [`FULL_EVIDENCE_SCHEMA_VERSION`] and this one — and refuse only versions
+/// ahead of them. Encoding shape dispatches on the record's
+/// `schema_version`; what must be proven dispatches on the suite's
+/// `protocol_version`. Support for a version may be dropped only once no
+/// record carrying it is reachable by any consumer.
+pub const RUN_SCHEMA_VERSION: u32 = 2;

--- a/crates/rue-perf-schema/src/run.rs
+++ b/crates/rue-perf-schema/src/run.rs
@@ -10,6 +10,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use crate::BuildBoundaryEvidence;
+use crate::encoding::{RunBoundary, WorkloadBoundary};
 
 /// A published wall-clock phase.
 ///
@@ -232,10 +233,30 @@ pub struct Sample {
     pub phases: PhaseAccounting,
     /// One independent runner/compiler proof for each process in this sample.
     ///
-    /// Empty only for historical protocol-v1 suites. Protocol v2 requires
-    /// exactly `batch_size` entries and validates each one against its epoch.
+    /// The full-evidence (schema v1) encoding. Empty for historical
+    /// protocol-v1 suites, and always empty in the stored (schema v2)
+    /// encoding, where each process is committed to by digest instead.
+    /// Protocol v2 under the full-evidence encoding requires exactly
+    /// `batch_size` entries and validates each one against its epoch.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub boundary_evidence: Vec<BuildBoundaryEvidence>,
+    /// Per-process identity digests, schema v2 only.
+    ///
+    /// One entry per process, in spawn order: the tagged SHA-256 of that
+    /// process's reassembled `{runner, compiler}` pair
+    /// ([`crate::identity_digest`]). Protocol v2 requires exactly
+    /// `batch_size` entries, each equal to the digest of the workload's
+    /// retained witness.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub boundary_processes: Vec<String>,
+    /// Per-process deterministic-work digests, schema v2 only.
+    ///
+    /// Present exactly when the epoch's `worker_setting` is `one` — the only
+    /// setting under which `compiler_work` is required to agree across
+    /// processes. A parallel epoch stores none: a digest of unstored bytes
+    /// that are expected to differ certifies nothing.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub boundary_work_processes: Vec<String>,
 }
 
 impl Sample {
@@ -256,6 +277,10 @@ impl Sample {
 pub struct WorkloadObservation {
     /// The workload's logical identifier, as declared by the suite revision.
     pub workload: String,
+    /// Workload-invariant boundary evidence and retained members, schema v2
+    /// only ([`WorkloadBoundary`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub boundary: Option<WorkloadBoundary>,
     /// Raw samples in collection order.
     ///
     /// All samples are stored, including invalid ones. Consumers exclude
@@ -457,6 +482,9 @@ pub struct RunObject {
     pub schema_version: u32,
     /// Identity and configuration of the run.
     pub identity: RunIdentity,
+    /// Run-invariant boundary evidence, schema v2 only ([`RunBoundary`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub boundary: Option<RunBoundary>,
     /// Per-workload raw samples, sorted by workload identifier.
     pub workloads: Vec<WorkloadObservation>,
     /// Structured evidence of everything that failed.
@@ -597,6 +625,8 @@ mod tests {
             output_binary_bytes: 1,
             phases: accounting(100, 100, 0, 0),
             boundary_evidence: Vec::new(),
+            boundary_processes: Vec::new(),
+            boundary_work_processes: Vec::new(),
         };
         assert_eq!(sample.driver_overhead_ns(), Some(50));
     }
@@ -610,6 +640,8 @@ mod tests {
             output_binary_bytes: 1,
             phases: accounting(100, 100, 0, 0),
             boundary_evidence: Vec::new(),
+            boundary_processes: Vec::new(),
+            boundary_work_processes: Vec::new(),
         };
         assert_eq!(sample.driver_overhead_ns(), None);
     }

--- a/crates/rue-perf-schema/src/run.rs
+++ b/crates/rue-perf-schema/src/run.rs
@@ -485,6 +485,17 @@ pub struct RunObject {
     /// Run-invariant boundary evidence, schema v2 only ([`RunBoundary`]).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub boundary: Option<RunBoundary>,
+    /// The content address of this record's full-evidence (schema v1) form,
+    /// schema v2 only.
+    ///
+    /// For a fresh collection this names the workflow's retained
+    /// full-evidence artifact; for a re-encoded record it names the
+    /// pre-compaction original, still reachable in the data branch's history
+    /// under the compaction tag. It is what makes a stored digest of dropped
+    /// evidence more than a producer assertion (ADR-0067 Amendment 1): the
+    /// bytes the encoding drops remain committed to by name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub full_evidence: Option<String>,
     /// Per-workload raw samples, sorted by workload identifier.
     pub workloads: Vec<WorkloadObservation>,
     /// Structured evidence of everything that failed.

--- a/crates/rue-perf-schema/src/stats.rs
+++ b/crates/rue-perf-schema/src/stats.rs
@@ -376,6 +376,8 @@ mod tests {
                 compiler_root_ns: 40_000,
             },
             boundary_evidence: Vec::new(),
+            boundary_processes: Vec::new(),
+            boundary_work_processes: Vec::new(),
         };
         // Latency divides by the batch; the other metrics are per-compilation
         // properties already and must not be.

--- a/crates/rue-perf-schema/src/stored.rs
+++ b/crates/rue-perf-schema/src/stored.rs
@@ -176,8 +176,10 @@ mod tests {
                     architecture: "x86_64".to_string(),
                 },
             },
+            boundary: None,
             workloads: vec![WorkloadObservation {
                 workload: "startup".to_string(),
+                boundary: None,
                 samples: vec![Sample {
                     batch_size: 1,
                     process_elapsed_ns: 2_000_000,
@@ -190,6 +192,8 @@ mod tests {
                         compiler_root_ns: 1_000_000,
                     },
                     boundary_evidence: Vec::new(),
+                    boundary_processes: Vec::new(),
+                    boundary_work_processes: Vec::new(),
                 }],
             }],
             failures: Vec::new(),

--- a/crates/rue-perf-schema/src/stored.rs
+++ b/crates/rue-perf-schema/src/stored.rs
@@ -177,6 +177,7 @@ mod tests {
                 },
             },
             boundary: None,
+            full_evidence: None,
             workloads: vec![WorkloadObservation {
                 workload: "startup".to_string(),
                 boundary: None,

--- a/crates/rue-perf-schema/src/validate.rs
+++ b/crates/rue-perf-schema/src/validate.rs
@@ -27,7 +27,7 @@ use crate::encoding::{
 };
 use crate::manifest::Manifest;
 use crate::run::{FailureRecord, Phase, RunObject, Sample};
-use crate::sanity::{is_commit, is_utc_timestamp, samples_beyond_policy};
+use crate::sanity::{is_commit, is_sha256_digest, is_utc_timestamp, samples_beyond_policy};
 use crate::stats::median;
 
 /// A reason a run may not enter a series at all.
@@ -545,6 +545,15 @@ fn check_boundary_evidence(
     }
     // The full-evidence encoding must not smuggle in v2 shapes: a v1 record
     // carrying digests or blocks is malformed, not partially upgraded.
+    if run.full_evidence.is_some() {
+        if let Some(observation) = run.workloads.first() {
+            errors.push(ValidationError::BoundaryEvidenceMismatch {
+                workload: observation.workload.clone(),
+                sample_index: 0,
+                detail: "a full-evidence record must not name a full-evidence form".to_string(),
+            });
+        }
+    }
     if run.boundary.is_some() {
         if let Some(observation) = run.workloads.first() {
             errors.push(ValidationError::BoundaryEvidenceMismatch {
@@ -681,6 +690,30 @@ fn check_boundary_evidence_encoded(
             detail,
         });
     };
+    // Every stored (v2) record commits to its full-evidence form by content
+    // address, whatever its protocol: the name of the retained artifact for a
+    // fresh collection, of the pre-compaction original for a re-encoded one.
+    match &run.full_evidence {
+        Some(address) if is_sha256_digest(address) => {}
+        Some(address) => {
+            if let Some(observation) = run.workloads.first() {
+                push(
+                    &observation.workload,
+                    0,
+                    format!("full_evidence {address:?} is not a content address"),
+                );
+            }
+        }
+        None => {
+            if let Some(observation) = run.workloads.first() {
+                push(
+                    &observation.workload,
+                    0,
+                    "a stored record must name its full-evidence form".to_string(),
+                );
+            }
+        }
+    }
     match (suite.protocol_version, &epoch.boundary) {
         (1, None) => {
             // A protocol-1 suite carries no evidence under either encoding.
@@ -729,12 +762,17 @@ fn check_boundary_evidence_encoded(
             let one_worker = policy.worker_setting == crate::WorkerSetting::One;
             for observation in &run.workloads {
                 let Some(workload_boundary) = observation.boundary.as_ref() else {
-                    push(
-                        &observation.workload,
-                        0,
-                        "schema v2 protocol-2 record carries no workload boundary block"
-                            .to_string(),
-                    );
+                    // A workload with no samples carried no evidence under
+                    // either encoding; the full path's per-sample loop was
+                    // vacuous over it, and this path must not be stricter.
+                    if !observation.samples.is_empty() {
+                        push(
+                            &observation.workload,
+                            0,
+                            "schema v2 protocol-2 record carries no workload boundary block"
+                                .to_string(),
+                        );
+                    }
                     continue;
                 };
                 let (runner, compiler) = reassemble_witness(run_boundary, workload_boundary);
@@ -799,6 +837,18 @@ fn check_boundary_evidence_encoded(
                                 source.sample_index
                             ),
                         );
+                        continue;
+                    }
+                    let batch = observation.samples[source.sample_index as usize].batch_size;
+                    if source.process_index >= batch {
+                        push(
+                            &observation.workload,
+                            source.sample_index,
+                            format!(
+                                "{member} names process {} of a batch of {batch}",
+                                source.process_index
+                            ),
+                        );
                     }
                 }
                 for (sample_index, sample) in observation.samples.iter().enumerate() {
@@ -843,7 +893,7 @@ fn check_boundary_evidence_encoded(
                             &observation.workload,
                             sample_index,
                             format!(
-                                "process {process}: identity digest disagrees with the workload                                  witness"
+                                "process {process}: identity digest disagrees with the workload witness"
                             ),
                         );
                     }
@@ -867,7 +917,7 @@ fn check_boundary_evidence_encoded(
                                 push(
                                     &observation.workload,
                                     sample_index,
-                                    "one-worker fresh processes reported nondeterministic                                      compiler work"
+                                    "one-worker fresh processes reported nondeterministic compiler work"
                                         .to_string(),
                                 );
                             }
@@ -1303,6 +1353,7 @@ window = 10
                 },
             },
             boundary: None,
+            full_evidence: None,
             workloads: vec![
                 WorkloadObservation {
                     workload: "caldera".to_string(),
@@ -2064,6 +2115,50 @@ window = 10
                 found: RUN_SCHEMA_VERSION + 1,
                 expected: RUN_SCHEMA_VERSION,
             }]
+        );
+    }
+
+    #[test]
+    fn provenance_naming_a_nonexistent_process_is_rejected() {
+        let mut encoded = crate::encode_v2(&boundary_run()).unwrap();
+        encoded.workloads[0]
+            .boundary
+            .as_mut()
+            .unwrap()
+            .critical_path_source
+            .process_index = 999;
+        let outcome = validate_run(&boundary_manifest(), &encoded);
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                ValidationError::BoundaryEvidenceMismatch { detail, .. }
+                    if detail.contains("names process 999 of a batch of 2")
+            )),
+            "unexpected errors: {:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn a_stored_record_must_name_its_full_evidence_form() {
+        let mut encoded = crate::encode_v2(&boundary_run()).unwrap();
+        encoded.full_evidence = None;
+        let outcome = validate_run(&boundary_manifest(), &encoded);
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                ValidationError::BoundaryEvidenceMismatch { detail, .. }
+                    if detail.contains("must name its full-evidence form")
+            )),
+            "unexpected errors: {:?}",
+            outcome.errors
+        );
+        // And the commitment is the input's own address.
+        let full = boundary_run();
+        let encoded = crate::encode_v2(&full).unwrap();
+        assert_eq!(
+            encoded.full_evidence.as_deref(),
+            Some(crate::content_address(&full).unwrap().as_str())
         );
     }
 }

--- a/crates/rue-perf-schema/src/validate.rs
+++ b/crates/rue-perf-schema/src/validate.rs
@@ -22,6 +22,9 @@
 use std::collections::BTreeMap;
 
 use crate::RUN_SCHEMA_VERSION;
+use crate::encoding::{
+    FULL_EVIDENCE_SCHEMA_VERSION, identity_digest, reassemble_witness, work_digest,
+};
 use crate::manifest::Manifest;
 use crate::run::{FailureRecord, Phase, RunObject, Sample};
 use crate::sanity::{is_commit, is_utc_timestamp, samples_beyond_policy};
@@ -30,12 +33,16 @@ use crate::stats::median;
 /// A reason a run may not enter a series at all.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ValidationError {
-    /// The run was written under a schema version this crate does not
-    /// implement. There is no compatibility path, by design.
+    /// The run was written under a schema version ahead of this crate.
+    ///
+    /// Readers implement every version that can still be in the store —
+    /// [`FULL_EVIDENCE_SCHEMA_VERSION`] and [`RUN_SCHEMA_VERSION`] — and
+    /// refuse only versions they do not know. Refusal applies forward,
+    /// never backward.
     UnsupportedSchemaVersion {
         /// The version the run object declares.
         found: u32,
-        /// The version this crate implements.
+        /// The newest version this crate implements.
         expected: u32,
     },
     /// The run names a suite revision the manifest does not declare.
@@ -398,7 +405,9 @@ impl ValidationOutcome {
 pub fn validate_run(manifest: &Manifest, run: &RunObject) -> ValidationOutcome {
     let mut errors = Vec::new();
 
-    if run.schema_version != RUN_SCHEMA_VERSION {
+    if run.schema_version != FULL_EVIDENCE_SCHEMA_VERSION
+        && run.schema_version != RUN_SCHEMA_VERSION
+    {
         // Nothing below can be trusted to mean what it appears to mean, so this
         // is the one failure that stops validation short.
         return ValidationOutcome {
@@ -527,6 +536,43 @@ fn check_boundary_evidence(
     epoch: &crate::manifest::PlatformEpoch,
     errors: &mut Vec<ValidationError>,
 ) {
+    // Encoding shape dispatches on the record's schema version; what must be
+    // proven dispatches on the suite's protocol version. The two cross here
+    // and nowhere else.
+    if run.schema_version == RUN_SCHEMA_VERSION {
+        check_boundary_evidence_encoded(run, suite, epoch, errors);
+        return;
+    }
+    // The full-evidence encoding must not smuggle in v2 shapes: a v1 record
+    // carrying digests or blocks is malformed, not partially upgraded.
+    if run.boundary.is_some() {
+        if let Some(observation) = run.workloads.first() {
+            errors.push(ValidationError::BoundaryEvidenceMismatch {
+                workload: observation.workload.clone(),
+                sample_index: 0,
+                detail: "a full-evidence record must not carry a run boundary block".to_string(),
+            });
+        }
+    }
+    for observation in &run.workloads {
+        if observation.boundary.is_some() {
+            errors.push(ValidationError::BoundaryEvidenceMismatch {
+                workload: observation.workload.clone(),
+                sample_index: 0,
+                detail: "a full-evidence record must not carry a workload boundary block"
+                    .to_string(),
+            });
+        }
+        for (sample_index, sample) in observation.samples.iter().enumerate() {
+            if !sample.boundary_processes.is_empty() || !sample.boundary_work_processes.is_empty() {
+                errors.push(ValidationError::BoundaryEvidenceMismatch {
+                    workload: observation.workload.clone(),
+                    sample_index: sample_index as u32,
+                    detail: "a full-evidence record must not carry per-process digests".to_string(),
+                });
+            }
+        }
+    }
     for observation in &run.workloads {
         let mut expected_output = None;
         let mut expected_work = None;
@@ -609,6 +655,246 @@ fn check_boundary_evidence(
                     sample_index: sample_index as u32,
                     detail,
                 });
+            }
+        }
+    }
+}
+
+/// The stored (schema v2) half of the boundary check: witness plus digests.
+///
+/// Every guarantee the full-evidence path checks per process is re-derived
+/// here from the retained witness and the per-process digests: semantic
+/// validity of the witness against the epoch policy, output-size agreement
+/// per sample, and cross-process identity — a process's digest equal to the
+/// witness digest is the digest-level statement of the byte-equality the
+/// full path asserted.
+fn check_boundary_evidence_encoded(
+    run: &RunObject,
+    suite: &crate::manifest::SuiteRevision,
+    epoch: &crate::manifest::PlatformEpoch,
+    errors: &mut Vec<ValidationError>,
+) {
+    let mut push = |workload: &str, sample_index: u32, detail: String| {
+        errors.push(ValidationError::BoundaryEvidenceMismatch {
+            workload: workload.to_string(),
+            sample_index,
+            detail,
+        });
+    };
+    match (suite.protocol_version, &epoch.boundary) {
+        (1, None) => {
+            // A protocol-1 suite carries no evidence under either encoding.
+            if run.boundary.is_some() {
+                if let Some(observation) = run.workloads.first() {
+                    push(
+                        &observation.workload,
+                        0,
+                        "historical protocol v1 must not carry boundary evidence".to_string(),
+                    );
+                }
+            }
+            for observation in &run.workloads {
+                if observation.boundary.is_some() {
+                    push(
+                        &observation.workload,
+                        0,
+                        "historical protocol v1 must not carry boundary evidence".to_string(),
+                    );
+                }
+                for (sample_index, sample) in observation.samples.iter().enumerate() {
+                    if !sample.boundary_evidence.is_empty()
+                        || !sample.boundary_processes.is_empty()
+                        || !sample.boundary_work_processes.is_empty()
+                    {
+                        push(
+                            &observation.workload,
+                            sample_index as u32,
+                            "historical protocol v1 must not carry boundary evidence".to_string(),
+                        );
+                    }
+                }
+            }
+        }
+        (2, Some(policy)) => {
+            let Some(run_boundary) = run.boundary.as_ref() else {
+                for observation in &run.workloads {
+                    push(
+                        &observation.workload,
+                        0,
+                        "schema v2 protocol-2 record carries no run boundary block".to_string(),
+                    );
+                }
+                return;
+            };
+            let one_worker = policy.worker_setting == crate::WorkerSetting::One;
+            for observation in &run.workloads {
+                let Some(workload_boundary) = observation.boundary.as_ref() else {
+                    push(
+                        &observation.workload,
+                        0,
+                        "schema v2 protocol-2 record carries no workload boundary block"
+                            .to_string(),
+                    );
+                    continue;
+                };
+                let (runner, compiler) = reassemble_witness(run_boundary, workload_boundary);
+                let witness_sample = workload_boundary.critical_path_source.sample_index;
+                let witness_evidence = crate::BuildBoundaryEvidence {
+                    runner,
+                    compiler,
+                    critical_path: workload_boundary.critical_path.clone(),
+                    compiler_work: workload_boundary.compiler_work,
+                };
+                if let Err(detail) = witness_evidence.validate_against(policy, &epoch.target) {
+                    push(
+                        &observation.workload,
+                        witness_sample,
+                        format!("witness: {detail}"),
+                    );
+                }
+                let witness_digest =
+                    match identity_digest(&witness_evidence.runner, &witness_evidence.compiler) {
+                        Ok(digest) => digest,
+                        Err(error) => {
+                            push(
+                                &observation.workload,
+                                witness_sample,
+                                format!("witness cannot be digested: {error}"),
+                            );
+                            continue;
+                        }
+                    };
+                let witness_work_digest = if one_worker {
+                    match work_digest(&workload_boundary.compiler_work) {
+                        Ok(digest) => Some(digest),
+                        Err(error) => {
+                            push(
+                                &observation.workload,
+                                witness_sample,
+                                format!("witness work cannot be digested: {error}"),
+                            );
+                            continue;
+                        }
+                    }
+                } else {
+                    None
+                };
+                let sample_count = observation.samples.len() as u32;
+                for (member, source) in [
+                    (
+                        "critical_path_source",
+                        workload_boundary.critical_path_source,
+                    ),
+                    (
+                        "compiler_work_source",
+                        workload_boundary.compiler_work_source,
+                    ),
+                ] {
+                    if source.sample_index >= sample_count {
+                        push(
+                            &observation.workload,
+                            0,
+                            format!(
+                                "{member} names sample {} of {sample_count}",
+                                source.sample_index
+                            ),
+                        );
+                    }
+                }
+                for (sample_index, sample) in observation.samples.iter().enumerate() {
+                    let sample_index = sample_index as u32;
+                    if !sample.boundary_evidence.is_empty() {
+                        push(
+                            &observation.workload,
+                            sample_index,
+                            "schema v2 record must not carry inline boundary evidence".to_string(),
+                        );
+                        continue;
+                    }
+                    if sample.boundary_processes.len() != sample.batch_size as usize {
+                        push(
+                            &observation.workload,
+                            sample_index,
+                            format!(
+                                "expected {} process proofs, found {}",
+                                sample.batch_size,
+                                sample.boundary_processes.len()
+                            ),
+                        );
+                        continue;
+                    }
+                    if workload_boundary.runner.output_size_bytes != sample.output_binary_bytes {
+                        push(
+                            &observation.workload,
+                            sample_index,
+                            format!(
+                                "proof output size {} disagrees with sample size {}",
+                                workload_boundary.runner.output_size_bytes,
+                                sample.output_binary_bytes
+                            ),
+                        );
+                    }
+                    if let Some(process) = sample
+                        .boundary_processes
+                        .iter()
+                        .position(|digest| digest != &witness_digest)
+                    {
+                        push(
+                            &observation.workload,
+                            sample_index,
+                            format!(
+                                "process {process}: identity digest disagrees with the workload                                  witness"
+                            ),
+                        );
+                    }
+                    match &witness_work_digest {
+                        Some(expected) => {
+                            if sample.boundary_work_processes.len() != sample.batch_size as usize {
+                                push(
+                                    &observation.workload,
+                                    sample_index,
+                                    format!(
+                                        "expected {} work digests, found {}",
+                                        sample.batch_size,
+                                        sample.boundary_work_processes.len()
+                                    ),
+                                );
+                            } else if sample
+                                .boundary_work_processes
+                                .iter()
+                                .any(|digest| digest != expected)
+                            {
+                                push(
+                                    &observation.workload,
+                                    sample_index,
+                                    "one-worker fresh processes reported nondeterministic                                      compiler work"
+                                        .to_string(),
+                                );
+                            }
+                        }
+                        None => {
+                            if !sample.boundary_work_processes.is_empty() {
+                                push(
+                                    &observation.workload,
+                                    sample_index,
+                                    "a parallel-epoch record must not carry work digests"
+                                        .to_string(),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        (protocol, boundary) => {
+            for observation in &run.workloads {
+                push(
+                    &observation.workload,
+                    0,
+                    format!(
+                        "unsupported protocol/boundary pairing: protocol {protocol},                          policy {boundary:?}"
+                    ),
+                );
             }
         }
     }
@@ -974,12 +1260,17 @@ window = 10
             output_binary_bytes: 131_072,
             phases: accounting(root_ns),
             boundary_evidence: Vec::new(),
+            boundary_processes: Vec::new(),
+            boundary_work_processes: Vec::new(),
         }
     }
 
     pub(crate) fn sample_run() -> RunObject {
         RunObject {
-            schema_version: RUN_SCHEMA_VERSION,
+            // The deep per-process checks below exercise the full-evidence
+            // encoding; the stored encoding's checks live in the encoded
+            // tests and in crate::encoding.
+            schema_version: FULL_EVIDENCE_SCHEMA_VERSION,
             identity: RunIdentity {
                 suite_revision: 1,
                 epoch: 1,
@@ -1011,13 +1302,16 @@ window = 10
                     architecture: "x86_64".to_string(),
                 },
             },
+            boundary: None,
             workloads: vec![
                 WorkloadObservation {
                     workload: "caldera".to_string(),
+                    boundary: None,
                     samples: vec![sample(1, 900_000_000), sample(1, 910_000_000)],
                 },
                 WorkloadObservation {
                     workload: "startup".to_string(),
+                    boundary: None,
                     samples: vec![sample(40, 400_000_000), sample(40, 404_000_000)],
                 },
             ],
@@ -1233,6 +1527,7 @@ window = 10
         let mut run = sample_run();
         run.workloads.push(WorkloadObservation {
             workload: "surprise".to_string(),
+            boundary: None,
             samples: vec![sample(1, 5)],
         });
         let outcome = validate_run(&manifest(), &run);
@@ -1570,6 +1865,205 @@ window = 10
             ),
             "{:?}",
             outcome.errors
+        );
+    }
+
+    // ---- The stored (schema v2) encoding, and the dual-version reader ----
+
+    const BOUNDARY_MANIFEST: &str = r#"
+[[suite]]
+revision = 2
+timing_schema_version = 1
+protocol_version = 2
+boundary = "fresh_source_to_native_v1"
+
+[[suite.workloads]]
+id = "startup"
+source = "performance/workloads/startup/main.rue"
+question = "What does a minimal fresh compilation cost end to end?"
+
+[[epoch]]
+id = 3
+collection = true
+platform = "x86_64-linux"
+suite_revision = 2
+target = "x86-64-linux"
+args = ["-O3", "-j1"]
+toolchain_hash = "toolchain-aaa"
+
+[epoch.boundary]
+boundary = "fresh_source_to_native_v1"
+pipeline = "canonical_rooted_query_graph_v1"
+compiler_build_profile = "release_thin_lto"
+optimization = "o3"
+linker = "internal"
+output_kind = "native_executable"
+worker_setting = "one"
+allowed_input_classes = ["workload_source", "trusted_standard_library_source"]
+allowed_embedded_asset_classes = ["bundled_runtime_archive"]
+required_stages = ["source_discovery_and_parsing", "program_construction", "semantic_analysis", "cfg_and_optimization", "backend", "object_generation", "linking", "output_publication"]
+
+[epoch.workload_source_hashes]
+startup = "startup-ddd"
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+[epoch.sampling.startup]
+samples = 2
+batch_size = 2
+
+[epoch.flagging]
+k = 3.0
+window = 10
+"#;
+
+    pub(crate) fn boundary_manifest() -> Manifest {
+        Manifest::parse(BOUNDARY_MANIFEST).expect("fixture boundary manifest is valid")
+    }
+
+    /// A protocol-2 run in the full-evidence encoding, consistent with
+    /// [`boundary_manifest`] and appendable under it.
+    pub(crate) fn boundary_run() -> RunObject {
+        let evidence = crate::boundary::tests::evidence();
+        let mut run = sample_run();
+        run.identity.suite_revision = 2;
+        run.identity.epoch = 3;
+        run.identity.pins.invocation.target = "x86-64-linux".to_string();
+        run.identity.pins.invocation.args = vec!["-O3".to_string(), "-j1".to_string()];
+        run.identity.pins.workload_source_hashes =
+            BTreeMap::from([("startup".to_string(), "startup-ddd".to_string())]);
+        let mut sample = sample(2, 900_000_000);
+        sample.output_binary_bytes = evidence.runner.output_size_bytes;
+        sample.boundary_evidence = vec![evidence.clone(), evidence];
+        run.workloads = vec![WorkloadObservation {
+            workload: "startup".to_string(),
+            boundary: None,
+            samples: vec![sample.clone(), sample],
+        }];
+        run
+    }
+
+    #[test]
+    fn a_full_evidence_protocol_two_run_is_appendable() {
+        let outcome = validate_run(&boundary_manifest(), &boundary_run());
+        assert_eq!(outcome.errors, Vec::new());
+        assert!(outcome.publishes_headline());
+    }
+
+    #[test]
+    fn the_encoded_form_validates_exactly_like_the_full_form() {
+        let full = boundary_run();
+        let encoded = crate::encode_v2(&full).expect("fixture encodes");
+        let full_outcome = validate_run(&boundary_manifest(), &full);
+        let encoded_outcome = validate_run(&boundary_manifest(), &encoded);
+        assert_eq!(encoded_outcome.errors, full_outcome.errors);
+        assert_eq!(encoded_outcome.errors, Vec::new());
+        assert!(encoded_outcome.publishes_headline());
+    }
+
+    #[test]
+    fn a_tampered_process_digest_fails_the_witness_comparison() {
+        let mut encoded = crate::encode_v2(&boundary_run()).unwrap();
+        encoded.workloads[0].samples[1].boundary_processes[1] = "0".repeat(64);
+        let outcome = validate_run(&boundary_manifest(), &encoded);
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                ValidationError::BoundaryEvidenceMismatch { sample_index: 1, detail, .. }
+                    if detail.contains("identity digest disagrees")
+            )),
+            "unexpected errors: {:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn a_stored_record_must_not_carry_inline_evidence() {
+        let full = boundary_run();
+        let mut encoded = crate::encode_v2(&full).unwrap();
+        encoded.workloads[0].samples[0].boundary_evidence =
+            full.workloads[0].samples[0].boundary_evidence.clone();
+        let outcome = validate_run(&boundary_manifest(), &encoded);
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                ValidationError::BoundaryEvidenceMismatch { detail, .. }
+                    if detail.contains("must not carry inline boundary evidence")
+            )),
+            "unexpected errors: {:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn a_one_worker_record_without_work_digests_is_rejected() {
+        let mut encoded = crate::encode_v2(&boundary_run()).unwrap();
+        encoded.workloads[0].samples[0].boundary_work_processes = Vec::new();
+        let outcome = validate_run(&boundary_manifest(), &encoded);
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                ValidationError::BoundaryEvidenceMismatch { detail, .. }
+                    if detail.contains("expected 2 work digests, found 0")
+            )),
+            "unexpected errors: {:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn a_stored_record_missing_its_workload_block_is_rejected() {
+        let mut encoded = crate::encode_v2(&boundary_run()).unwrap();
+        encoded.workloads[0].boundary = None;
+        let outcome = validate_run(&boundary_manifest(), &encoded);
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                ValidationError::BoundaryEvidenceMismatch { detail, .. }
+                    if detail.contains("no workload boundary block")
+            )),
+            "unexpected errors: {:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn a_full_evidence_record_must_not_carry_digests() {
+        let mut full = boundary_run();
+        full.workloads[0].samples[0].boundary_processes = vec!["0".repeat(64); 2];
+        let outcome = validate_run(&boundary_manifest(), &full);
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                ValidationError::BoundaryEvidenceMismatch { detail, .. }
+                    if detail.contains("must not carry per-process digests")
+            )),
+            "unexpected errors: {:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn both_store_versions_read_and_versions_ahead_refuse() {
+        // Readers implement every version still in the store; refusal applies
+        // forward, never backward.
+        let full = boundary_run();
+        assert_eq!(full.schema_version, FULL_EVIDENCE_SCHEMA_VERSION);
+        assert!(validate_run(&boundary_manifest(), &full).is_appendable());
+        let encoded = crate::encode_v2(&full).unwrap();
+        assert_eq!(encoded.schema_version, RUN_SCHEMA_VERSION);
+        assert!(validate_run(&boundary_manifest(), &encoded).is_appendable());
+        let mut ahead = encoded;
+        ahead.schema_version = RUN_SCHEMA_VERSION + 1;
+        let outcome = validate_run(&boundary_manifest(), &ahead);
+        assert_eq!(
+            outcome.errors,
+            vec![ValidationError::UnsupportedSchemaVersion {
+                found: RUN_SCHEMA_VERSION + 1,
+                expected: RUN_SCHEMA_VERSION,
+            }]
         );
     }
 }


### PR DESCRIPTION
Refs RUE-1771. Implements the accepted ADR-0067 Amendment 1 and ADR-0071 Amendment 1 (#2444): the v2 witness-plus-digests run-object encoding, the dual-version reader contract, and the `reencode` tool for the one-time store compaction. #2608's `check-baselines` gate is the closing check of every `reencode --apply`.

## What lands

- **The v2 encoding** (`rue-perf-schema/src/encoding.rs`): run-level and workload-level `boundary` blocks partition each process's `{runner, compiler}` pair losslessly (round-trip asserted at encode time); per-process identity digests `SHA-256("rue.boundary.identity.1\n" || canonical_json({compiler, runner}))`; work digests (`rue.boundary.work.1\n`, over `compiler_work`) exactly where `worker_setting = "one"`; one `critical_path` per observation from the first process of the first evidence-bearing sample, with explicit `_source` provenance carried in the record. The supporting note's worked byte-exact vector is a test, as are the amendment's four digest rules.
- **The dual-version reader**: `RUN_SCHEMA_VERSION = 2` becomes "the version the producer writes"; readers accept both store versions and refuse only versions ahead. Encoding shape dispatches on `schema_version`; proof obligations stay on `protocol_version` — for a v2 protocol-2 record, every cross-process guarantee is re-derived by digest-to-witness comparison, and the witness itself passes the same `validate_against` the full path used. A v1 record carrying v2 shapes, or a v2 record carrying inline evidence, is malformed.
- **The producer** assembles and deep-validates the full-evidence (v1) form, encodes, revalidates the encoded form (error-set equality required — an encoding defect fails collection rather than reaching the store), writes v2 to the store path, and writes the full form alongside as the workflow's retained artifact. The artifact is deliberately not spelled `.json`: the publish job sweeps `incoming/*.json` onto the branch, and under the dual reader the full form is itself appendable.
- **`rue-bench reencode --data-root … --manifest … [--apply]`**: converts every v1 record to v2 under new content addresses, moves `index.json` and the manifest pins textually (comment-preserving), refuses differing bytes under an existing name, is idempotent, and ends by requiring every declared baseline to resolve — retired epochs included — exiting 3 otherwise.

## Acceptance evidence (run against the real store at `44b5d5164`-era tip, 1,619 records, 3,470.7 MiB)

The three re-measurements the amendments deferred to this change:

| Evidence | Result |
| --- | --- |
| Derive-level A/B (RUE-1542-style) | **byte-identical** derived output, original vs re-encoded, after new→old address normalization; 1,619 points, 0 rejected on both sides |
| Fresh serialization of the split-digest encoding | **3,470.7 MiB → 153.2 MiB (4.4%)**; largest record 428.0 KiB (from a 15.9 MiB macOS median) |
| Pack/fetch effect of the append | **~16 MiB** of pack for the complete re-encoded tree (fresh-repo repack), the upper bound on what the append adds to the branch fetch |

Also observed: `reencode --apply` rewrote exactly **10** manifest addresses (nine `[epoch.baseline] run` pins plus the epoch-5 `reference_run`) — the amendment's predicted breakage inventory, exactly; `check-baselines` reports 9/9 against the rewritten pair; full-store `derive` fell from 461s to 24s on the same binary.

## Adversarial review, applied before opening

A subagent review pass ran against the finished implementation; its findings are folded in:

- **Evidence before gates** (the one BROKEN finding): the producer originally cross-checked full-vs-encoded validation *before* writing anything, gated on error-list equality — so any genuinely rejected run (the evidence that matters most, per RUE-1258) aborted with exit 2 and nothing on disk. Now both files are written first, and the gate is appendability agreement: a run rejected under both encodings is ordinary rejected evidence, published and exit-coded exactly as on trunk.
- **The record commits to what it drops**: a new `full_evidence` field carries the content address of the record's full-evidence form — the retained workflow artifact for a fresh collection, the pre-compaction original (reachable under the compaction tag) for a re-encoded record. This is the amendment's "digest in the record", making the artifact arrangement verifiable rather than asserted. Required well-formed on v2, forbidden on v1.
- Provenance `process_index` is bounds-checked; a sample-less workload needs no boundary block (matching the full path's vacuous loop); rule-3 tests now refuse missing fields and pin empty-collection serialization, the `CompilerWork` preimage, and the identity preimage's exact two-key shape; an evidence-bearing v2 record round-trips through stored bytes; and v1 bytes without the new keys re-serialize byte-identically with an unchanged address.

## What follows separately

The one-time compaction itself (operator step, not CI): run `reencode --apply` against a fresh data-branch checkout, tag the pre-compaction tip, land the result as a single append commit, and update the four prose address citations in the ADR-0071 phase notes from the printed map. A crash mid-`--apply` is recovered by starting over from a fresh checkout, not by re-running in place. The staleness job then reads a ~10 MiB live epoch instead of 2.4 GiB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPBpmZU3DpwkumLHNwHsgu
