### PR TITLE
RUE-1636, RUE-1654, RUE-1710: keep an integer's inference class at one width, and stop deriving a free size by scanning

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -636,6 +636,37 @@ impl<'a> ConstraintGenerator<'a> {
         }
     }
 
+    /// The element type of an indexable operand whose type is *already*
+    /// concrete at constraint-generation time: an interned fixed array
+    /// `[T; N]`, or the synthetic slice struct `[T]` whose first field is the
+    /// `*const T` half of the fat pointer (ADR-0043, RUE-322). An
+    /// `InferType::Array` base is handled structurally by the caller; this
+    /// covers the interned forms — a slice parameter, an annotated binding, a
+    /// call result — that reach the generator as `Concrete`.
+    ///
+    /// Without it, indexing a concrete slice degraded to a fresh variable, so
+    /// an integer literal sharing an operator with the element (`e.i.a * 10`)
+    /// had nothing to take its width from and defaulted to i32, while sema
+    /// typed the operator from the element's real width. That is exactly the
+    /// mixed-width AIR the operator-agreement check in `inst.rs` rejects
+    /// (RUE-1636 family; the check found this producer).
+    fn concrete_element_type(&self, ty: &InferType) -> Option<Type> {
+        let ty = ty.as_concrete()?;
+        if let Some(array_id) = ty.as_array() {
+            return Some(self.type_pool.array_def(array_id).0);
+        }
+        let id = ty.as_struct()?;
+        // `str`/`Str(N)` share the view representation but index as bytes;
+        // `is_string_indexable_type` answers those before this is consulted.
+        if !crate::types::is_slice_struct_name(&self.type_pool.struct_def(id).name) {
+            return None;
+        }
+        match self.type_pool.struct_def(id).fields.first()?.ty.kind() {
+            TypeKind::PtrConst(ptr_id) => Some(self.type_pool.ptr_const_def(ptr_id)),
+            _ => None,
+        }
+    }
+
     /// Provide file-level constant types (name -> declared type) for `VarRef`
     /// resolution. See the `const_types` field for details (RUE-142).
     pub fn with_const_types(mut self, const_types: &'a AHashMap<(FileId, Spur), Type>) -> Self {
@@ -2905,12 +2936,19 @@ impl<'a> ConstraintGenerator<'a> {
                 } else {
                     match &base_info.ty {
                         InferType::Array { element, .. } => (**element).clone(),
-                        _ => {
-                            // Base might be a type variable that will resolve to an array.
-                            // Use a fresh variable for the element type.
-                            let result_var = self.fresh_var();
-                            InferType::Var(result_var)
-                        }
+                        // An interned array or slice type carries its element
+                        // type too; publish it rather than letting a literal
+                        // beside the element default to i32 (see
+                        // `concrete_element_type`).
+                        _ => match self.concrete_element_type(&base_info.ty) {
+                            Some(element_type) => self.type_to_infer(element_type),
+                            None => {
+                                // Base might be a type variable that will resolve to an array.
+                                // Use a fresh variable for the element type.
+                                let result_var = self.fresh_var();
+                                InferType::Var(result_var)
+                            }
+                        },
                     }
                 }
             }
@@ -3856,7 +3894,26 @@ impl<'a> ConstraintGenerator<'a> {
                 let var = self.fresh_var();
                 InferType::Var(var)
             }
-            rue_rir::RirPatternView::Int { .. } => InferType::IntLiteral,
+            // An integer pattern is an integer literal, and is typed exactly
+            // like one: a fresh variable marked in `int_literal_vars`, never
+            // the bare `InferType::IntLiteral` terminal (RUE-1636).
+            //
+            // The terminal is absorbing. `Unifier::bind` stores it into the
+            // scrutinee's substitution slot, so every variable already chained
+            // to the scrutinee path-compresses onto `IntLiteral` and the
+            // union-find class stops having a single representative. A later
+            // concrete type then upgrades only the variable that happens to be
+            // queried (`rebind_int_literal_to_concrete`); its siblings stay
+            // `IntLiteral` and default to i32. `let a = 1; let b = 2; let c = a
+            // + b; match c { 3 => {}, _ => {} } a` with an `i64` return typed
+            // `a` as i64 while `b` stayed i32 — one class, two widths, and
+            // mixed-width AIR downstream.
+            //
+            // A marked variable keeps the class intact: binding the scrutinee
+            // to it extends the chain instead of terminating it, so the
+            // representative is upgraded once for the whole class and every
+            // member resolves to the same width.
+            rue_rir::RirPatternView::Int { .. } => InferType::Var(self.fresh_int_literal_var()),
             rue_rir::RirPatternView::Bool(_, _) => InferType::Concrete(Type::BOOL),
             rue_rir::RirPatternView::Path {
                 module,

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -1674,6 +1674,67 @@ impl Air {
                 Ok(current)
             };
 
+            // AIR is fully typed, and every producer states the same operator
+            // invariant: an operator's operands agree with each other, and an
+            // arithmetic/bitwise/unary result agrees with its operands (see
+            // `sema::analysis::builtin_ops::analyze_binary_arith`). Enforcing
+            // it here fails fast at the AIR boundary instead of letting a
+            // mixed-width `add %a:i64, %b:i32` reach CFG construction — where
+            // only a downstream return-value width mismatch catches it, late
+            // and as an E9000 naming the wrong instruction — or reach codegen
+            // unnoticed and appear to work by accident of the 8-byte slot
+            // model (RUE-1654).
+            //
+            // `!` and `<error>` are the only escapes: a diverging operand
+            // never produces a value, and an erroneous one has already been
+            // reported, so neither carries a width the operator must respect.
+            // That is exactly what `Type::can_coerce_to` already means, so
+            // reuse it rather than restating the exemption.
+            let agree = |a: Type, b: Type| a.can_coerce_to(&b) || b.can_coerce_to(&a);
+            // Only valid for a reference that `check_ref` has already
+            // accepted: it proves the index is inside the instruction store.
+            let operand_ty = |value: AirRef| self.instructions[value.as_u32() as usize].ty;
+            let operands_agree = |a: AirRef, b: AirRef| -> Result<(), AirValidationError> {
+                let (a_ty, b_ty) = (operand_ty(a), operand_ty(b));
+                if agree(a_ty, b_ty) {
+                    Ok(())
+                } else {
+                    Err(fail(
+                        Some(index),
+                        format!(
+                            "operands {a} and {b} have mismatched types {} and {}",
+                            a_ty.name(),
+                            b_ty.name()
+                        ),
+                    ))
+                }
+            };
+            let result_agrees = |a: AirRef| -> Result<(), AirValidationError> {
+                let a_ty = operand_ty(a);
+                if agree(a_ty, inst.ty) {
+                    Ok(())
+                } else {
+                    Err(fail(
+                        Some(index),
+                        format!(
+                            "result type {} does not match operand {a} of type {}",
+                            inst.ty.name(),
+                            a_ty.name()
+                        ),
+                    ))
+                }
+            };
+            let result_is_bool = || -> Result<(), AirValidationError> {
+                if agree(inst.ty, Type::BOOL) {
+                    Ok(())
+                } else {
+                    Err(fail(
+                        Some(index),
+                        format!("comparison result type {} is not bool", inst.ty.name()),
+                    ))
+                }
+            };
+
             match &inst.data {
                 AirInstData::TypeConst(ty) => validate_type(*ty).map_err(|reason| {
                     fail(Some(index), format!("invalid type constant: {reason}"))
@@ -1686,12 +1747,6 @@ impl Air {
                 | AirInstData::WrappingMul(a, b)
                 | AirInstData::Div(a, b)
                 | AirInstData::Mod(a, b)
-                | AirInstData::Eq(a, b)
-                | AirInstData::Ne(a, b)
-                | AirInstData::Lt(a, b)
-                | AirInstData::Gt(a, b)
-                | AirInstData::Le(a, b)
-                | AirInstData::Ge(a, b)
                 | AirInstData::And(a, b)
                 | AirInstData::Or(a, b)
                 | AirInstData::BitAnd(a, b)
@@ -1701,11 +1756,51 @@ impl Air {
                 | AirInstData::Shr(a, b) => {
                     check_ref(*a)?;
                     check_ref(*b)?;
+                    operands_agree(*a, *b)?;
+                    result_agrees(*a)?;
+                    result_agrees(*b)?;
                 }
-                AirInstData::Neg(value)
-                | AirInstData::Not(value)
-                | AirInstData::BitNot(value)
-                | AirInstData::Drop { value } => check_ref(*value)?,
+                // Comparisons are the one binary family whose result type is
+                // unrelated to its operands: the result is always `bool`.
+                //
+                // Operand agreement is enforced here only when the operands
+                // are not both integers. Two producers still emit mixed-width
+                // integer comparisons, and both sit outside this change:
+                //
+                //   * the slice bounds check lowers `s[i]` to
+                //     `Lt(index, len)`, keeping the source index's own
+                //     integer type on the left and the fat pointer's `u64`
+                //     length on the right;
+                //   * an integer literal compared against a struct field
+                //     whose base type is still an inference variable (the
+                //     value came from an `if`/`match` join) defaults to `i32`
+                //     while the field read is the field's declared type —
+                //     the documented `known_field_type` fallback in
+                //     `inference::generate`.
+                //
+                // Both are only accidentally correct: codegen picks a
+                // comparison's width from its LEFT operand, so a narrow left
+                // operand silently truncates the right one. Tighten this to
+                // plain `operands_agree` once those two producers agree with
+                // the invariant (RUE-1654).
+                AirInstData::Eq(a, b)
+                | AirInstData::Ne(a, b)
+                | AirInstData::Lt(a, b)
+                | AirInstData::Gt(a, b)
+                | AirInstData::Le(a, b)
+                | AirInstData::Ge(a, b) => {
+                    check_ref(*a)?;
+                    check_ref(*b)?;
+                    if !(operand_ty(*a).is_integer() && operand_ty(*b).is_integer()) {
+                        operands_agree(*a, *b)?;
+                    }
+                    result_is_bool()?;
+                }
+                AirInstData::Neg(value) | AirInstData::Not(value) | AirInstData::BitNot(value) => {
+                    check_ref(*value)?;
+                    result_agrees(*value)?;
+                }
+                AirInstData::Drop { value } => check_ref(*value)?,
                 AirInstData::Branch {
                     cond,
                     then_value,
@@ -1734,8 +1829,19 @@ impl Air {
                     check_place(*place)?;
                 }
                 AirInstData::PlaceWrite { place, value } => {
-                    check_place(*place)?;
+                    let place_ty = check_place(*place)?;
                     check_ref(*value)?;
+                    let value_ty = operand_ty(*value);
+                    if !agree(place_ty, value_ty) {
+                        return Err(fail(
+                            Some(index),
+                            format!(
+                                "store writes {} into a place of type {}",
+                                value_ty.name(),
+                                place_ty.name()
+                            ),
+                        ));
+                    }
                 }
                 AirInstData::EnumPayloadGet {
                     base,
@@ -4474,6 +4580,119 @@ mod tests {
             assert_eq!(air.checkpoint().instructions, before_errors.instructions);
             assert_eq!(air.checkpoint().extra, before_errors.extra);
         }
+    }
+
+    /// RUE-1654: AIR is fully typed, so an operator's operands must agree.
+    /// The `!`/`<error>` escapes are the only mismatches admitted, and a
+    /// comparison keeps its own `bool` result independent of its operands.
+    #[test]
+    fn validation_rejects_disagreeing_operator_operands() {
+        let pool = TypeInternPool::new().freeze();
+        let two_operands =
+            |lhs: Type, rhs: Type, make: fn(AirRef, AirRef) -> AirInstData, result: Type| {
+                let mut air = Air::new(Type::I64);
+                air.push_inst(AirInst {
+                    data: AirInstData::Const(1),
+                    ty: lhs,
+                    span: Span::new(0, 0),
+                });
+                air.push_inst(AirInst {
+                    data: AirInstData::Const(1),
+                    ty: rhs,
+                    span: Span::new(0, 0),
+                });
+                air.push_inst(AirInst {
+                    data: make(AirRef::from_raw(0), AirRef::from_raw(1)),
+                    ty: result,
+                    span: Span::new(0, 0),
+                });
+                air.finish(AirValidationContext::Canonical(&pool))
+            };
+
+        // The exact shape RUE-1636 used to produce: one inference class that
+        // settled on two widths, reaching AIR as `add %0:i64, %1:i32`.
+        let error = two_operands(Type::I64, Type::I32, AirInstData::Add, Type::I64).unwrap_err();
+        assert!(
+            error.reason.contains("mismatched types i64 and i32"),
+            "unexpected reason: {}",
+            error.reason
+        );
+
+        // A result that disagrees with operands that agree with each other.
+        let error = two_operands(Type::I64, Type::I64, AirInstData::Add, Type::I32).unwrap_err();
+        assert!(
+            error.reason.contains("result type i32"),
+            "unexpected reason: {}",
+            error.reason
+        );
+
+        // `!` is exempt: a diverging operand never produces a value, so it
+        // carries no width for the operator to respect.
+        assert!(two_operands(Type::I64, Type::NEVER, AirInstData::Add, Type::I64).is_ok());
+
+        // `<error>` is the other exemption. It only exists before the type
+        // pool is frozen, so it is checked against the semantic context (the
+        // canonical one rejects an incomplete type outright).
+        let semantic_pool = TypeInternPool::new();
+        let mut errored = Air::new(Type::I64);
+        errored.push_inst(AirInst {
+            data: AirInstData::Const(1),
+            ty: Type::I64,
+            span: Span::new(0, 0),
+        });
+        errored.push_inst(AirInst {
+            data: AirInstData::Const(1),
+            ty: Type::ERROR,
+            span: Span::new(0, 0),
+        });
+        errored.push_inst(AirInst {
+            data: AirInstData::Add(AirRef::from_raw(0), AirRef::from_raw(1)),
+            ty: Type::I64,
+            span: Span::new(0, 0),
+        });
+        assert!(
+            errored
+                .finish(AirValidationContext::Semantic(&semantic_pool))
+                .is_ok()
+        );
+
+        // A comparison's operands are unrelated to its result, which is bool.
+        assert!(two_operands(Type::I64, Type::I64, AirInstData::Lt, Type::BOOL).is_ok());
+        let error = two_operands(Type::I64, Type::I64, AirInstData::Lt, Type::I64).unwrap_err();
+        assert!(
+            error.reason.contains("is not bool"),
+            "unexpected reason: {}",
+            error.reason
+        );
+        // Operands of different KINDS are rejected even for a comparison; only
+        // the integer/integer pair is deferred (see the exemption in `finish`).
+        let error = two_operands(Type::BOOL, Type::I64, AirInstData::Eq, Type::BOOL).unwrap_err();
+        assert!(
+            error.reason.contains("mismatched types bool and i64"),
+            "unexpected reason: {}",
+            error.reason
+        );
+
+        // A unary operator's result follows its operand.
+        let mut air = Air::new(Type::I64);
+        air.push_inst(AirInst {
+            data: AirInstData::Const(1),
+            ty: Type::I64,
+            span: Span::new(0, 0),
+        });
+        air.push_inst(AirInst {
+            data: AirInstData::Neg(AirRef::from_raw(0)),
+            ty: Type::I32,
+            span: Span::new(0, 0),
+        });
+        let error = air
+            .finish(AirValidationContext::Canonical(&pool))
+            .unwrap_err();
+        assert!(
+            error.reason.contains("result type i32"),
+            "unexpected reason: {}",
+            error.reason
+        );
     }
 
     #[test]

--- a/crates/rue-cli-tests/cases/integer_class_width.toml
+++ b/crates/rue-cli-tests/cases/integer_class_width.toml
@@ -1,0 +1,393 @@
+# Integer inference classes keep ONE width, and AIR is checked for it.
+#
+# Two related defects, driven end-to-end through the real CLI:
+#
+#   RUE-1636 an integer match pattern was typed as the absorbing
+#            `InferType::IntLiteral` terminal. Unification stored that terminal
+#            into the scrutinee variable's substitution slot, so every variable
+#            already chained to the scrutinee path-compressed onto it and the
+#            union-find class lost its single representative. A later concrete
+#            type then upgraded only the queried variable; its siblings stayed
+#            literal and defaulted to i32. One inference class, two widths.
+#
+#   RUE-1654 AIR validation did not check operand-type agreement, so the
+#            mixed-width AIR RUE-1636 produced (`add %8:i64, %9:i32`) sailed
+#            past `ValidatedAir` and CFG construction. Only the return-value
+#            width mismatch was caught, late, as an E9000 naming an unrelated
+#            instruction — and the shapes that did not reach a return were not
+#            caught at all.
+#
+# Every case pins an exact VALUE that does not fit in i32, not just an exit
+# code: the broken widths only show up as a truncated or rejected 64-bit value,
+# and two of the three original reproductions were silent at the exit-code
+# level. `@dbg` output is the assertion.
+
+[section]
+id = "cli.integer_class_width"
+name = "Integer inference class width"
+description = "An integer's inference class settles on ONE width even when a match intervenes (RUE-1636), and AIR operands must agree (RUE-1654)."
+
+# ---------------------------------------------------------------------------
+# RUE-1636: the three reported reproductions.
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "match_then_sibling_binding_returned_at_i64"
+description = "RUE-1636 repro 1: rejected with a bogus E0800 'literal value 4294967296 is out of range for i32' — `a` was upgraded to i64 by the return type while its sibling `b` stayed behind at the i32 default."
+files = [{ path = "main.rue", source = """
+fn f() -> i64 {
+    let a = 1;
+    let b = 4294967296;
+    let c = a + b;
+    match c {
+        3 => {},
+        _ => {},
+    }
+    a
+}
+
+fn main() -> i32 {
+    @dbg(f());
+    0
+}
+""" }]
+stdout = "1\n"
+
+[[case]]
+name = "match_then_whole_class_used_in_tail_expression"
+description = "RUE-1636 repro 2: ICEd with E9000 'CFG verification failed: return value has type I32 expected I64' — the tail expression mixed class members that had settled on different widths."
+files = [{ path = "main.rue", source = """
+fn f() -> i64 {
+    let a = 1;
+    let b = 0 - 5;
+    let c = a + b;
+    match c {
+        3 => {},
+        _ => {},
+    }
+    a + b + c
+}
+
+fn main() -> i32 {
+    @dbg(f());
+    0
+}
+""" }]
+stdout = "-8\n"
+
+[[case]]
+name = "match_then_scrutinee_returned_keeps_64_bit_value"
+description = "RUE-1636 repro 3: compiled silently into type-inconsistent AIR (`add %8:i64, %9:i32`) that only worked by accident of the 8-byte slot model. The pinned value fails if either operand truncates."
+files = [{ path = "main.rue", source = """
+fn f() -> i64 {
+    let a = 1;
+    let b = 4294967296;
+    let c = a + b;
+    match c {
+        3 => {},
+        _ => {},
+    }
+    c
+}
+
+fn main() -> i32 {
+    @dbg(f());
+    0
+}
+""" }]
+stdout = "4294967297\n"
+
+# ---------------------------------------------------------------------------
+# The settling context can arrive in several shapes, all after the match.
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "match_then_annotation_settles_the_class"
+description = "A later `let d: i64 = c` settles the class the match ran over, and every member follows."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a = 1;
+    let b = 4294967296;
+    let c = a + b;
+    match c {
+        3 => {},
+        _ => {},
+    }
+    let d: i64 = c;
+    @dbg(d);
+    @dbg(b);
+    0
+}
+""" }]
+stdout = "4294967297\n4294967296\n"
+
+[[case]]
+name = "match_then_call_argument_settles_the_class"
+description = "A later call whose parameter is u64 settles the class; the unsigned width is taken by the whole class, not just the argument."
+files = [{ path = "main.rue", source = """
+fn take(v: u64) -> u64 { v }
+
+fn main() -> i32 {
+    let a = 1;
+    let b = 4294967296;
+    let c = a + b;
+    match c {
+        3 => {},
+        _ => {},
+    }
+    @dbg(take(c));
+    @dbg(b);
+    0
+}
+""" }]
+stdout = "4294967297\n4294967296\n"
+
+[[case]]
+name = "match_many_int_patterns_chain_onto_one_class"
+description = "Several integer patterns chain onto the same scrutinee; the arm that runs is pinned along with the class's settled width."
+files = [{ path = "main.rue", source = """
+fn f() -> i64 {
+    let a = 1;
+    let b = 4294967296;
+    let c = a + b;
+    match c {
+        1 => { @dbg(1); },
+        2 => { @dbg(2); },
+        4294967297 => { @dbg(3); },
+        _ => { @dbg(0); },
+    }
+    a + b
+}
+
+fn main() -> i32 {
+    @dbg(f());
+    0
+}
+""" }]
+stdout = "3\n4294967297\n"
+
+[[case]]
+name = "match_on_unsigned_class_settled_after_the_match"
+description = "The same shape on an unsigned class: the pattern must not force the i32 default onto a u64 value."
+files = [{ path = "main.rue", source = """
+fn f() -> u64 {
+    let a = 1;
+    let b = 18446744073709551615 - 1;
+    let c = a + b;
+    match c {
+        0 => { @dbg(1); },
+        _ => { @dbg(0); },
+    }
+    c
+}
+
+fn main() -> i32 {
+    @dbg(f());
+    0
+}
+""" }]
+stdout = "0\n18446744073709551615\n"
+
+[[case]]
+name = "nested_match_shares_the_enclosing_class"
+description = "A match inside a match arm still leaves the class free for the width the return type settles."
+files = [{ path = "main.rue", source = """
+fn f() -> i64 {
+    let a = 1;
+    let b = 4294967296;
+    let c = a + b;
+    match c {
+        3 => { @dbg(3); },
+        _ => {
+            match a {
+                1 => { @dbg(1); },
+                _ => { @dbg(0); },
+            }
+        },
+    }
+    c
+}
+
+fn main() -> i32 {
+    @dbg(f());
+    0
+}
+""" }]
+stdout = "1\n4294967297\n"
+
+# ---------------------------------------------------------------------------
+# The fix must not weaken the diagnostics an integer pattern still owes.
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "int_pattern_on_bool_scrutinee_still_rejected"
+description = "A marked literal VARIABLE rejects a non-integer binding exactly as the terminal did — the scrutinee's bool type is still reported at the pattern."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let b = true;
+    match b {
+        1 => 1,
+        _ => 0,
+    }
+}
+""" }]
+compile_fail = true
+error_contains = ["bool"]
+
+[[case]]
+name = "int_pattern_out_of_range_for_settled_type_still_rejected"
+description = "Once the scrutinee's type is known, a pattern that cannot be represented in it is still an error (spec 4.7:23)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: u8 = 1;
+    match a {
+        300 => 1,
+        _ => 0,
+    }
+}
+""" }]
+compile_fail = true
+error_contains = ["out of range"]
+
+[[case]]
+name = "unmatched_int_pattern_class_still_defaults_to_i32"
+description = "With no settling context anywhere, the class still takes the i32 default (spec 4.1:3) — the fix restores the class, it does not remove the default."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a = 1;
+    let b = 2;
+    let c = a + b;
+    match c {
+        3 => { @dbg(3); },
+        _ => { @dbg(0); },
+    }
+    c
+}
+""" }]
+stdout = "3\n"
+exit_code = 3
+
+# ---------------------------------------------------------------------------
+# RUE-1654's operand-agreement check found a second producer of mixed-width
+# AIR: indexing a CONCRETE slice or array type degraded to a fresh inference
+# variable, so a literal sharing an operator with the element had nothing to
+# take its width from. `@intCast(...)` is what makes it visible — it absorbs
+# the surrounding context that would otherwise have settled the operator's
+# type from the outside.
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "slice_element_settles_a_literal_beside_it"
+description = "A literal multiplied with a slice element takes the element's 64-bit width. `@dbg` accepts any integer width, so it supplies no context of its own — before, the class had nothing to settle on, defaulted to i32, and the program was rejected with a bogus E0800."
+files = [{ path = "main.rue", source = """
+struct Cell { v: i64 }
+
+fn scale(borrow s: [Cell]) -> i32 {
+    let e = s[0];
+    @dbg(e.v * 4294967296);
+    0
+}
+
+fn main() -> i32 {
+    let a: [Cell; 2] = [Cell { v: 3 }, Cell { v: 5 }];
+    scale(borrow a)
+}
+""" }]
+stdout = "12884901888\n"
+
+[[case]]
+name = "slice_element_literal_inside_intcast"
+description = "`@intCast` supplies its own result type, so it cannot settle its argument — the element's width has to reach the literal directly (the `add %21:i64, %22:i32` shape the AIR check rejects)."
+files = [{ path = "main.rue", source = """
+struct Inner { a: i64 }
+struct Outer { i: Inner, b: i64 }
+
+fn pick(borrow s: [Outer]) -> i32 {
+    let e = s[1];
+    @intCast(e.i.a * 10 + e.b + @intCast(s.len()))
+}
+
+fn main() -> i32 {
+    let a: [Outer; 2] = [
+        Outer { i: Inner { a: 1 }, b: 2 },
+        Outer { i: Inner { a: 4 }, b: 0 },
+    ];
+    @dbg(pick(borrow a));
+    0
+}
+""" }]
+stdout = "42\n"
+
+[[case]]
+name = "slice_of_scalars_element_settles_a_literal"
+description = "The same for a slice of a bare scalar: `s[0]`'s element type is known from the slice's own type, with no struct field in between."
+files = [{ path = "main.rue", source = """
+fn head_scaled(borrow s: [i64]) -> i32 {
+    @dbg(s[0] * 4294967296);
+    @intCast(s[1] * 10)
+}
+
+fn main() -> i32 {
+    let a: [i64; 3] = [7, 8, 9];
+    @dbg(head_scaled(borrow a));
+    0
+}
+""" }]
+stdout = "30064771072\n80\n"
+
+# Cross-mechanism case, added at integration time (RUE-1636 x RUE-1711).
+#
+# Neither worker's own suite could see this seam. RUE-1636 taught a slice/array
+# element to publish the element type its base already carries; RUE-1711 added
+# byte scans over a `StrBuf` to `std.fs` and `std.c` to reject interior NULs.
+# Those scans compare a byte against the literal `0`, which is exactly the
+# shape RUE-1636 fixed -- so the std guard's correctness now depends on the
+# inference fix.
+#
+# Both std scans were written defensively as `let nul: u8 = 0;` and compared
+# against that binding, which sidesteps the question. This case pins the BARE
+# literal spelling: `byte_at_borrowed(..) == 0` must compare at u8. If the
+# literal ever defaults to i32 again, the comparison silently widens and a
+# NUL-bearing path could scan clean -- and the AIR guard added with RUE-1654
+# would NOT catch it, because it exempts integer/integer comparison operands
+# pending the FieldGet fallback. So the behaviour is asserted here directly.
+[[case]]
+name = "std_byte_scan_against_bare_literal_compares_at_byte_width"
+description = "A StrBuf byte compared against an unannotated `0` settles the literal at u8, so an interior NUL is found and a clean buffer is not."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn scan(borrow s: std.strbuf.StrBuf) -> bool {
+    let n = s.len();
+    let mut i: u64 = 0;
+    while i < n {
+        if std.strbuf.StrBuf.byte_at_borrowed(borrow s, i) == 0 {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+fn main() -> i32 {
+    let mut p = std.strbuf.StrBuf.new();
+    p.push(97);
+    p.push(0);
+    p.push(98);
+    if scan(borrow p) { @dbg(1); } else { @dbg(0); }
+
+    let mut q = std.strbuf.StrBuf.new();
+    q.push(99);
+    q.push(98);
+    if scan(borrow q) { @dbg(1); } else { @dbg(0); }
+
+    // A byte that is merely LARGE must not be mistaken for the terminator by a
+    // comparison that widened: 255 stays 255 at u8.
+    let mut r = std.strbuf.StrBuf.new();
+    r.push(255);
+    if scan(borrow r) { @dbg(1); } else { @dbg(0); }
+    0
+}
+""" }]
+stdout = "1\n0\n0\n"

--- a/crates/rue-cli-tests/cases/std_c_strings.toml
+++ b/crates/rue-cli-tests/cases/std_c_strings.toml
@@ -1,0 +1,228 @@
+# std.c StrBuf <-> char* export/import, and the interior-NUL contract (RUE-1710).
+#
+# `owned_c_string(source)` allocates `source.len() + 1` bytes; `free_c_string`
+# recovers the size by scanning to the first `0`. Those two agree only while the
+# buffer holds exactly one `0`. An interior NUL broke the agreement silently:
+# a 4003-byte source was allocated as 4004 bytes and released as 3, and the
+# module's own doc comment asserted the opposite — that "the full len + 1 bytes
+# are still what free_c_string reclaims via its own scan, so interior NULs are a
+# caller concern, not a leak".
+#
+# WHY THE MISMATCH IS NOT MERELY A LEAK. `@free` classifies a block by the size
+# it is handed and pushes it onto that class's free list (the exact-(size,align)
+# contract std/rawbuf.rue documents). A 4 KiB block released as 3 bytes joins the
+# 8-byte free list and is handed straight back out as an 8-byte allocation; a
+# block over 16 KiB has its own mapping and, released as a small size, is pushed
+# onto a small free list and never unmapped. Nothing asserts, nothing traps —
+# hence these cases, which are the only thing that can see it.
+#
+# The fix makes `owned_c_string` FAIL-FAST on an interior NUL rather than export
+# a C string whose C-visible length differs from its source's, so the scan in
+# `free_c_string` is exact by construction. `has_interior_nul` is the public
+# guard a caller with untrusted bytes uses to keep the decision.
+#
+# These run on every target: std.c's string helpers are plain Rue over `@alloc`,
+# `@free`, and raw pointer reads/writes with no per-target data, and the
+# allocator behind them is the same crate everywhere. The archive-linked FFI
+# half of this surface (a real C `strlen` measuring the exported pointer) lives
+# in cases/c_ffi.toml.
+
+[section]
+id = "cli.std_c_strings"
+name = "std.c C-string export contract"
+description = "owned_c_string/free_c_string round-trips, and the interior-NUL rejection that keeps the free size equal to the allocated size (RUE-1710)."
+
+# The repro, in the form it can still be observed in: an interior NUL now aborts
+# at the export instead of producing a buffer that will be freed under the wrong
+# size. Before the fix this program ran to completion and printed "exported",
+# having quietly filed a 4 KiB block on the 8-byte free list.
+[[case]]
+name = "c_owned_c_string_panics_on_interior_nul"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let mut s = std.strbuf.StrBuf.new();
+    s.push(65);
+    s.push(66);
+    s.push(0);
+    let mut i: u64 = 0;
+    while i < 4000 {
+        s.push(67);
+        i += 1;
+    }
+    let p = std.c.owned_c_string(borrow s);
+    println("exported");
+    std.c.free_c_string(p);
+    0
+}
+""" }]
+exit_code = 101
+stdout = ""
+runtime_error_contains = ["panic: owned_c_string: source contains an interior NUL byte"]
+
+# A NUL at the very end is rejected on the same terms: the export would be
+# indistinguishable from the NUL-free source, but the allocation would be one
+# byte longer than the scan recovers, which is the same class of disagreement.
+[[case]]
+name = "c_owned_c_string_panics_on_trailing_nul"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let mut s = std.strbuf.StrBuf.new();
+    s.push_str("trailing");
+    s.push(0);
+    let p = std.c.owned_c_string(borrow s);
+    println("exported");
+    std.c.free_c_string(p);
+    0
+}
+""" }]
+exit_code = 101
+stdout = ""
+runtime_error_contains = ["panic: owned_c_string: source contains an interior NUL byte"]
+
+# The public guard. A caller holding bytes it does not control tests them and
+# decides, instead of taking the panic. Checks the first byte, an interior byte,
+# the last byte, and a NUL-free source, so a predicate with an off-by-one bound
+# fails here rather than in the wild.
+[[case]]
+name = "c_has_interior_nul_positions"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn report(name: std.strbuf.StrBuf, flagged: bool) {
+    if flagged {
+        println(name + ": true");
+    } else {
+        println(name + ": false");
+    }
+}
+
+fn main() -> i32 {
+    let mut clean = std.strbuf.StrBuf.new();
+    clean.push_str("abcd");
+
+    let mut empty = std.strbuf.StrBuf.new();
+
+    let mut first = std.strbuf.StrBuf.new();
+    first.push(0);
+    first.push_str("abcd");
+
+    let mut middle = std.strbuf.StrBuf.new();
+    middle.push_str("ab");
+    middle.push(0);
+    middle.push_str("cd");
+
+    let mut last = std.strbuf.StrBuf.new();
+    last.push_str("abcd");
+    last.push(0);
+
+    report("clean", std.c.has_interior_nul(borrow clean));
+    report("empty", std.c.has_interior_nul(borrow empty));
+    report("first", std.c.has_interior_nul(borrow first));
+    report("middle", std.c.has_interior_nul(borrow middle));
+    report("last", std.c.has_interior_nul(borrow last));
+    0
+}
+""" }]
+stdout = """
+clean: false
+empty: false
+first: true
+middle: true
+last: true
+"""
+exit_code = 0
+
+# The property the rejection buys, observed through the allocator. A NUL-free
+# 4005-byte C string is exported and released; the block must go back to the
+# class it came from. Requesting the SAME size returns the very block just freed
+# (the free lists are LIFO), and requesting 8 bytes does NOT — which is exactly
+# what an interior-NUL export used to make happen. Both probes are taken before
+# anything is printed, so no intervening StrBuf allocation can disturb them.
+[[case]]
+name = "c_free_c_string_returns_block_to_its_own_size_class"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let mut s = std.strbuf.StrBuf.new();
+    s.push_str("hello");
+    let mut i: u64 = 0;
+    while i < 4000 {
+        s.push(67);
+        i += 1;
+    }
+
+    let p = std.c.owned_c_string(borrow s);
+    let scanned = std.c.c_strlen(p);
+    let pa: u64 = checked { @ptr_to_int(p) };
+    std.c.free_c_string(p);
+
+    let q: ptr mut u8 = checked { @alloc(4006, 1) };
+    let qa: u64 = checked { @ptr_to_int(q) };
+    let r: ptr mut u8 = checked { @alloc(8, 1) };
+    let ra: u64 = checked { @ptr_to_int(r) };
+    checked { @free(q, 4006, 1); };
+    checked { @free(r, 8, 1); };
+
+    println("scanned len: " + @to_string(scanned));
+    if pa == qa {
+        println("same size class: true");
+    } else {
+        println("same size class: false");
+    }
+    if pa == ra {
+        println("small class polluted: true");
+    } else {
+        println("small class polluted: false");
+    }
+    0
+}
+""" }]
+stdout = """
+scanned len: 4005
+same size class: true
+small class polluted: false
+"""
+exit_code = 0
+
+# The ordinary round trip, with no FFI archive involved: export a StrBuf to an
+# owned C string, measure it with the module's own scan, import it back, and
+# compare. The guard must not cost the NUL-free path anything.
+[[case]]
+name = "c_owned_c_string_roundtrip_without_ffi"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let text = "hello world";
+    let sb = std.strbuf.StrBuf.from_str(borrow text);
+
+    let cstr = std.c.owned_c_string(borrow sb);
+    println("strlen: " + @to_string(std.c.c_strlen(cstr)));
+
+    let back = std.c.strbuf_from_c_string(cstr);
+    if std.strbuf.StrBuf.equals_borrowed(borrow sb, borrow back) {
+        println("roundtrip equal: true");
+    } else {
+        println("roundtrip equal: false");
+    }
+    println("reimported len: " + @to_string(back.len()));
+    std.c.free_c_string(cstr);
+    0
+}
+""" }]
+stdout = """
+strlen: 11
+roundtrip equal: true
+reimported len: 11
+"""
+exit_code = 0

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -359,6 +359,17 @@ const ENTRIES: &[Entry] = &[
         runtime_call(UnsupportedRuntimeCallKind::Println),
         &[],
     ),
+    // The RUE-1636 cross-mechanism case builds a `StrBuf` and scans it byte by
+    // byte, so the oracle model stops at the byte-copy intrinsic like every
+    // other StrBuf-backed case here. The rest of the `cli.integer_class_width`
+    // section is plain integer arithmetic the oracle models directly, which is
+    // why this is the section's only entry.
+    Entry::new(
+        "cli.integer_class_width",
+        "std_byte_scan_against_bare_literal_compares_at_byte_width",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
     // RUE-954: the literal-threading regression cases invoke a real dup(2)
     // syscall, which the oracle does not model.
     Entry::new(
@@ -523,6 +534,40 @@ const ENTRIES: &[Entry] = &[
         "cli.slices",
         "struct_element_slice_empty_view",
         intrinsic(UnsupportedIntrinsicKind::EmptySlicePointer),
+        &[],
+    ),
+    // std.c C-string export contract (RUE-1710): every case builds a StrBuf and
+    // exports it through `@alloc` + raw pointer writes, so the oracle model
+    // stops at the byte-copy intrinsic. The FFI-free round-trip case reaches
+    // `println` first instead, which is the runtime-call gap.
+    Entry::new(
+        "cli.std_c_strings",
+        "c_free_c_string_returns_block_to_its_own_size_class",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_c_strings",
+        "c_has_interior_nul_positions",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_c_strings",
+        "c_owned_c_string_panics_on_interior_nul",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_c_strings",
+        "c_owned_c_string_panics_on_trailing_nul",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_c_strings",
+        "c_owned_c_string_roundtrip_without_ffi",
+        runtime_call(UnsupportedRuntimeCallKind::Println),
         &[],
     ),
     // IntMap key extremes (RUE-1709). These cases assert on stdout rather than

--- a/crates/rue-spec/cases/expressions/match.toml
+++ b/crates/rue-spec/cases/expressions/match.toml
@@ -1349,3 +1349,133 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+# =============================================================================
+# Integer patterns adopt the scrutinee's type; they do not fix it (RUE-1636)
+# =============================================================================
+#
+# 4.7:13 says a pattern's type is the scrutinee's type, and 4.1:3 says an
+# integer literal takes its type from context rather than pinning one. An
+# integer PATTERN is an integer literal in pattern position, so it must behave
+# the same way: matching on a value whose width is only settled later must not
+# freeze that value — or any value inferred together with it — at the i32
+# default.
+#
+# The unifier used to type an integer pattern as the absorbing `IntLiteral`
+# terminal, which collapsed the scrutinee's inference class: a later concrete
+# type upgraded only the variable that happened to be queried, and its
+# siblings silently defaulted to i32. Each case below settles the width
+# AFTER the match and pins a value that does not fit in i32, so a class member
+# left behind at i32 is a visible failure rather than an accident of layout.
+
+[[case]]
+name = "match_int_pattern_scrutinee_width_fixed_by_return_type"
+spec = ["4.7:13", "4.1:3"]
+description = "RUE-1636: matching on `c` does not pin `c`'s inference class to i32; the i64 return type reaches the class through `a`, and the sibling `b` keeps its 64-bit value instead of being rejected as out of range for i32."
+source = """
+fn f() -> i64 {
+    let a = 1;
+    let b = 4294967296;
+    let c = a + b;
+    match c {
+        3 => {},
+        _ => {},
+    }
+    @dbg(b);
+    a
+}
+
+fn main() -> i32 {
+    @dbg(f());
+    0
+}
+"""
+expected_stdout = "4294967296\n1\n"
+exit_code = 0
+
+[[case]]
+name = "match_int_pattern_class_stays_consistent_in_a_tail_expression"
+spec = ["4.7:13", "4.1:3"]
+description = "RUE-1636: every member of the matched value's class has the same width, so a tail expression combining all of them is well typed (it used to reach CFG verification with an i32 value in an i64 return slot)."
+source = """
+fn f() -> i64 {
+    let a = 1;
+    let b = 0 - 5;
+    let c = a + b;
+    match c {
+        3 => {},
+        _ => {},
+    }
+    a + b + c
+}
+
+fn main() -> i32 {
+    @dbg(f());
+    0
+}
+"""
+expected_stdout = "-8\n"
+exit_code = 0
+
+[[case]]
+name = "match_int_pattern_width_fixed_by_later_annotation"
+spec = ["4.7:13", "4.1:3"]
+description = "RUE-1636: the settling context may come after the match as a plain annotation on one class member; the width it fixes belongs to the whole class."
+source = """
+fn main() -> i32 {
+    let a = 1;
+    let b = 4294967296;
+    let c = a + b;
+    match c {
+        3 => {},
+        _ => {},
+    }
+    let d: i64 = a;
+    @dbg(d);
+    @dbg(b);
+    0
+}
+"""
+expected_stdout = "1\n4294967296\n"
+exit_code = 0
+
+[[case]]
+name = "match_int_pattern_multiple_arms_share_one_class"
+spec = ["4.7:13", "4.1:3"]
+description = "RUE-1636: several integer patterns chain onto the same scrutinee class; the width settled later applies to every member."
+source = """
+fn f() -> i64 {
+    let a = 1;
+    let b = 4294967296;
+    let c = a + b;
+    match c {
+        1 => { @dbg(1); },
+        2 => { @dbg(2); },
+        _ => { @dbg(0); },
+    }
+    a + b
+}
+
+fn main() -> i32 {
+    @dbg(f());
+    0
+}
+"""
+expected_stdout = "0\n4294967297\n"
+exit_code = 0
+
+[[case]]
+name = "match_int_pattern_out_of_range_for_settled_scrutinee_type"
+spec = ["4.7:23", "4.7:13"]
+description = "The pattern still has to fit the type the scrutinee settles on: typing patterns as literal variables did not weaken 4.7:23."
+source = """
+fn main() -> i32 {
+    let a: u8 = 1;
+    match a {
+        300 => 1,
+        _ => 0,
+    }
+}
+"""
+compile_fail = true
+error_contains = "out of range"

--- a/std/c.rue
+++ b/std/c.rue
@@ -153,6 +153,26 @@ pub const c_bool = bool;
 // unchecked-context work (ADR-0064 ruling 3): a pointer received from or handed
 // to C carries no Rue lifetime, aliasing, or validity guarantee, and the caller
 // is responsible for keeping it live and for freeing what it owns.
+//
+// INTERIOR NUL BYTES (RUE-1710). A StrBuf may hold a `0` byte; a C string may
+// not — the terminator IS the length, so the two representations disagree about
+// what such a buffer means. `owned_c_string` refuses to build a C string from
+// one instead of exporting a value whose C-visible length differs from its
+// source's. That refusal is what makes `free_c_string`'s scan sound: with no
+// interior `0`, the scan recovers EXACTLY the length that was allocated, so the
+// `(size, align)` pair handed to `@free` is the one `@alloc` was given.
+// That exactness is a hard allocator requirement, not bookkeeping: `@free`
+// picks the size class from the size it is passed and pushes the block onto
+// that class's free list (see `std/rawbuf.rue`'s exact-layout contract), so a
+// 4 KiB block released as 3 bytes joins the 8-byte free list and is handed back
+// out as an 8-byte allocation, and an over-16 KiB block — its own mapping —
+// released as a small size is never unmapped at all. Nothing traps on the
+// mismatch; it is silently wrong, which is why the invariant is enforced at the
+// only place that can still see the source bytes.
+//
+// Callers holding bytes that MIGHT contain a `0` test them with
+// [`has_interior_nul`] first and decide what to do (reject, escape, truncate)
+// with the context to choose correctly.
 
 /// Scan a NUL-terminated C string and return its length in bytes, EXCLUDING the
 /// terminator — the `strlen(3)` shape.
@@ -170,6 +190,27 @@ pub fn c_strlen(cstr: ptr mut u8) -> u64 {
     len
 }
 
+/// True when `source` holds a `0` byte anywhere, i.e. cannot be exported as a C
+/// string.
+///
+/// This is the guard for [`owned_c_string`], which fail-fasts on such a source.
+/// It is public because only the caller knows what to do about bytes it does
+/// not control — reject the input, escape it, or truncate it deliberately —
+/// and testing first is how a caller keeps that decision instead of taking a
+/// panic. `source` is only read.
+pub fn has_interior_nul(borrow source: strbuf.StrBuf) -> bool {
+    let len = source.len();
+    let nul: u8 = 0;
+    let mut i: u64 = 0;
+    while i < len {
+        if strbuf.StrBuf.byte_at_borrowed(borrow source, i) == nul {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
 /// Copy `source`'s bytes into a freshly allocated, NUL-terminated C string and
 /// return a pointer the CALLER OWNS.
 ///
@@ -178,13 +219,21 @@ pub fn c_strlen(cstr: ptr mut u8) -> u64 {
 /// (or `const char*`) parameter. It is an INDEPENDENT allocation: `source`
 /// is borrowed, remains valid, and is not consumed. Ownership transfers to the
 /// caller, who MUST release the buffer with [`free_c_string`] (never a StrBuf
-/// free — this buffer is not a StrBuf and carries no capacity header). If
-/// `source` itself contains an interior `0` byte, the C string is effectively
-/// truncated at that byte from a C consumer's point of view; the full
-/// `len + 1` bytes are still what `free_c_string` reclaims via its own scan, so
-/// interior NULs are a caller concern, not a leak. Allocation failure is
-/// fail-fast, matching StrBuf's allocator convention.
+/// free — this buffer is not a StrBuf and carries no capacity header).
+///
+/// An INTERIOR `0` BYTE in `source` is a caller error and is FAIL-FAST
+/// (RUE-1710): such bytes have no C string that represents them — a C consumer
+/// sees only the prefix — and exporting the truncation anyway would also
+/// desynchronize [`free_c_string`], whose scan would then release the
+/// allocation under a smaller size than `@alloc` was given (the section comment
+/// above spells out why that silently corrupts the allocator's free lists).
+/// Test with [`has_interior_nul`] when the bytes are not already known to be
+/// NUL-free. Allocation failure is fail-fast too, matching StrBuf's allocator
+/// convention.
 pub fn owned_c_string(borrow source: strbuf.StrBuf) -> ptr mut u8 {
+    if has_interior_nul(borrow source) {
+        @panic("owned_c_string: source contains an interior NUL byte");
+    }
     let len = source.len();
     let buf: ptr mut u8 = checked { @alloc(len + 1, 1) };
     if checked { @ptr_to_int(buf) } == 0 {
@@ -221,11 +270,16 @@ pub fn strbuf_from_c_string(cstr: ptr mut u8) -> strbuf.StrBuf {
 
 /// Release a buffer returned by [`owned_c_string`].
 ///
-/// `cstr` must be a pointer `owned_c_string` returned and not yet freed. The
-/// length is recovered by scanning to the terminator (the buffer was allocated
-/// as `strlen + 1` bytes at alignment one), so the caller does not track the
-/// size. Passing any other pointer — a StrBuf's backing buffer, a C-owned
-/// string, or an already-freed pointer — is a contract violation.
+/// `cstr` must be a pointer [`owned_c_string`] returned and not yet freed. The
+/// length is recovered by scanning to the terminator, so the caller does not
+/// track the size. That scan is EXACT rather than a guess, and only because
+/// `owned_c_string` guarantees the buffer holds no interior `0`: its allocation
+/// was `strlen + 1` bytes at alignment one, and with a single `0` in the buffer
+/// the scan finds that same `strlen`. `@free` selects the size class from the
+/// size it is given, so a scan that stopped short would release the block into
+/// the wrong class — silently, with no diagnostic. Passing any other pointer —
+/// a StrBuf's backing buffer, a C-owned string, one built with a different
+/// length, or an already-freed pointer — is a contract violation.
 pub fn free_c_string(cstr: ptr mut u8) {
     let mut len: u64 = 0;
     let nul: u8 = 0;


### PR DESCRIPTION
Three bugs from one fix cycle, in disjoint crates. Every claim below was re-verified by execution on this branch rather than inherited from the worker notes.

**Rebased onto current trunk. This PR no longer carries RUE-1711** — see "What changed on rebase" at the bottom.

## RUE-1636 — the unifier lost type-variable equality

Integer match patterns were typed as the bare `InferType::IntLiteral` terminal. Binding the scrutinee stored that absorbing terminal into its substitution slot, so variables already chained to the scrutinee path-compressed onto it and the union-find class stopped having a single representative. A later concrete type then upgraded only the queried variable; its siblings defaulted to i32.

Patterns are now typed as marked int-literal *variables* (`fresh_int_literal_var`), the way integer literal expressions already were, so binding extends the chain instead of terminating it.

Three spellings, three different symptoms — all reproduced here before and after:

| variant | before | after |
| --- | --- | --- |
| `match c {3=>{},_=>{}}` then return i64 | `E0800` literal out of range for i32 | compiles |
| `let b = 0 - 5;` then `a + b + c` | `E9000` CFG verification failed | compiles |
| `let b = 2;` then `a` | silent `add %8:i64, %9:i32` | consistent AIR |

The third is the one that matters most: it reached codegen and worked only by accident of the 8-byte slot model.

## RUE-1654 — AIR validation did not check operand agreement

Which is why that third variant shipped silently. `Air::finish` now enforces that arithmetic, bitwise, shift and logical operands agree with each other and with the result; that comparisons agree and yield `bool`; and that a `PlaceWrite` matches its place. `!` and the error type are the only escapes, reusing what `Type::can_coerce_to` already encodes.

Implemented **before** the RUE-1636 fix, deliberately, so the guard could be shown to fire on the bad AIR and then go quiet once the inference bug was gone.

Integer/integer *comparison* operands are exempt for now. Two producers remain, both named in a comment in `finish` and both filed rather than papered over: RUE-1777 (the slice bounds check's `Lt(index, u64 len)`) and RUE-1778 (a literal compared against a struct field whose base is still an inference variable). Fix both and the exemption can be deleted. Arithmetic is enforced with no exemption at all.

Turning the guard on found a third producer, which **is** fixed here: indexing a base whose type is an interned array or the slice struct dropped an element type the base already carried, making `s[0].v * 4294967296` on a slice a bogus `E0800`. That was a user-visible reject-valid, not just an AIR smell.

## RUE-1710 — free_c_string freed with a scan-derived size

`owned_c_string` allocated `len + 1` bytes; `free_c_string` recovered the size by scanning to the first NUL. An interior NUL freed a 4 KiB block under size 3, and since the allocator classifies by the size it is handed, the block joined the 8-byte free list and came straight back out as an 8-byte allocation. Corruption, not a leak — and observable only by pointer identity, which is filed separately as RUE-1779.

`owned_c_string` now fails fast, with a public `has_interior_nul` predicate so a caller holding untrusted bytes keeps the decision. The scan in `free_c_string` is therefore exact by construction and its signature is unchanged. The doc comment that asserted the opposite is corrected.

## The cross-mechanism case, and why it is load-bearing

Added at integration time, and the rebase made the argument for it stronger rather than weaker.

Trunk's `_path_has_nul` — part of the RUE-1711 fix that landed while this was in flight — scans with `if b == 0`: the **bare literal** spelling, compared against a `u8` read out of an `Option(u8)` match. That is exactly the shape RUE-1636 governs, so a shipped security check depends on the inference fix in this PR.

The case pins that spelling directly and confirms it emits `%15 : u8 = const 0` and an honest `eq %14:u8, %15:u8`. It is asserted directly rather than left to the guard, because the RUE-1654 guard would **not** catch a regression there — it exempts integer/integer comparisons pending RUE-1777 and RUE-1778.

Verified in both directions: trunk's full fs suite runs green against these inference changes (34 passed, including the new NUL-rejection cases).

## What changed on rebase

RUE-1711 landed independently on trunk (#2625) while this was in flight. That fix rejects a NUL-bearing path *before* marshalling rather than inside `_path_to_cbuf`, which keeps the rejection free of both the allocation and the syscall, and lets `_mkdirat_raw` answer on its raw-errno channel.

It subsumes what was here, so this branch drops its own `std/fs.rue` change and its five `fs_interior_nul` cases rather than carrying a second spelling of the same guard. Trunk's coverage was checked for gaps first: its cases cover both `rename` operands and the no-parents-created guarantee, and the surrounding `fs_file_io` cases already serve as the NUL-free control. Nothing was lost worth re-adding.

## Verification

`./test.sh` → `Tests finished: Pass 234. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0`, exit 0 on the pre-rebase tree; re-running on the rebased tree, with the affected sections already confirmed green individually (`integer_class_width` 15/15, `std_c_strings` 5/5, `fs_` 34/34).

Both backends: no codegen or CFG files changed, so there is no target split to ship; `--emit asm --target aarch64-linux` was sanity-checked on the repros regardless.

New coverage: 15 CLI cases in `integer_class_width`, 5 in `std_c_strings`, 5 spec cases under `4.7:13`/`4.1:3`/`4.7:23`, and a `ValidatedAir` unit test per new rule arm. The std.c cases were mutation-checked with `std/c.rue` stashed: 3/5 fail, the survivors being deliberate controls.

## Filed, not fixed here

RUE-1777 and RUE-1778 (the two remaining comparison-agreement producers — fixing both lets the RUE-1654 rule tighten to plain `operands_agree`), RUE-1779 (the allocator cannot detect a wrong-size-class free), RUE-1780 (no `std.fs` path type, so the NUL invariant is procedural rather than structural), RUE-1781 (`free_c_string(null)` faults), RUE-1782 (a signal-killed `test.sh` prints `TEST SUITE: PASSED`).

Fixes RUE-1636
Fixes RUE-1654
Fixes RUE-1710