### PR TITLE
RUE-1706: reject absolute and empty @import specifiers

### DIFF
--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -340,6 +340,40 @@ fn main() -> i32 { 0 }
 compile_fail = true
 error_contains = ["E0713", "escapes the project root", "../outside.rue"]
 
+# RUE-1706: `Path::join` DISCARDS its base when the right-hand side is absolute,
+# so an absolute specifier used to become its own candidate — checked only
+# against the project boundary, and accepted whenever it happened to land inside
+# it. These two cases pin the shape rule that now precedes that check. The
+# absolute path here is outside the root, because a CLI case cannot spell its own
+# temp directory; the inside-the-root variant, which is the one that used to
+# COMPILE, is pinned by `non_relative_specifiers_derive_no_discovery_requests` in
+# import_discovery.rs, where a test can choose the paths.
+[[case]]
+name = "absolute_import_specifier_is_e0714"
+description = "RUE-1706: an absolute @import specifier is rejected on its shape, not routed through the project-boundary check."
+files = [
+    { path = "main.rue", source = """
+const h = @import("/etc/hostname.rue");
+fn main() -> i32 { 0 }
+""" },
+]
+compile_fail = true
+error_contains = ["E0714", "relative path", "/etc/hostname.rue"]
+compile_stderr_not_contains = ["E0713", "escapes the project root"]
+
+[[case]]
+name = "empty_import_specifier_is_e0714"
+description = "RUE-1706: an empty @import specifier names nothing; it no longer reports E0713 against a derived '/_.rue' candidate."
+files = [
+    { path = "main.rue", source = """
+const nothing = @import("");
+fn main() -> i32 { 0 }
+""" },
+]
+compile_fail = true
+error_contains = ["E0714", "the specifier is empty"]
+compile_stderr_not_contains = ["E0713", "/_.rue"]
+
 [[case]]
 name = "emit_deps_malformed_import_has_no_envelope"
 description = "RUE-810: malformed import shape has no canonical unresolved topology and emits diagnostics without JSON."

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -1401,6 +1401,12 @@ pub(crate) fn escaping_import_candidate(
     if specifier == "std" {
         return Ok(None);
     }
+    // A specifier that is not a relative path derives no candidate at all, so
+    // there is nothing to place inside or outside the boundary. Reporting it
+    // here as well would give one site two diagnostics for one mistake.
+    if non_relative_specifier(specifier).is_some() {
+        return Ok(None);
+    }
     let importer_path = normalize_absolute(importer_requested_path)?;
     let boundary_root = context
         .std_root()
@@ -1421,11 +1427,78 @@ pub(crate) fn escaping_import_candidate(
     }
 }
 
+/// Why a specifier is not a relative path, and so names no module. Both shapes
+/// are decided from the specifier text alone, before any candidate is derived
+/// (RUE-1706).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NonRelativeSpecifier {
+    /// `@import("")`. It names nothing; `discovery_candidate_groups` would
+    /// spell it as the root-anchored `/_.rue`, an artifact of joining an empty
+    /// basename onto an empty specifier rather than a path any project holds.
+    Empty,
+    /// `@import("/etc/hostname.rue")`, or any other rooted path. `Path::join`
+    /// REPLACES its base when the right-hand side is absolute, so such a
+    /// specifier would become its own candidate, unanchored from the importing
+    /// file — and one that happened to land inside the project root resolved,
+    /// making the program depend on where the tree sits on this machine.
+    Absolute,
+}
+
+/// Classify a specifier that resolution cannot accept. `std` is a reserved
+/// program-anchored specifier (spec 10.2:6), not a path, and is exempt.
+pub(crate) fn non_relative_specifier(specifier: &str) -> Option<NonRelativeSpecifier> {
+    if specifier == "std" {
+        return None;
+    }
+    if specifier.is_empty() {
+        return Some(NonRelativeSpecifier::Empty);
+    }
+    // Deliberately `Path::is_absolute`, the same predicate `Path::join` uses to
+    // decide whether to discard its base: this rejects exactly the specifiers
+    // that would otherwise escape the importer anchor.
+    if Path::new(specifier).is_absolute() {
+        return Some(NonRelativeSpecifier::Absolute);
+    }
+    None
+}
+
+/// E0714 diagnostics for occurrences whose specifier is not a relative path.
+/// Recomputed from the parsed program like `escape_diagnostics`, and for the
+/// same reason: such an occurrence owns no discovery requests, so it appears in
+/// neither the request groups nor the observation ledger.
+pub(crate) fn specifier_diagnostics(program: &ParsedProgram) -> CompileErrors {
+    let mut errors = CompileErrors::new();
+    for site in program.import_directives().iter() {
+        let Some(shape) = non_relative_specifier(site.specifier()) else {
+            continue;
+        };
+        let kind = match shape {
+            NonRelativeSpecifier::Empty => ErrorKind::ImportSpecifierEmpty,
+            NonRelativeSpecifier::Absolute => ErrorKind::ImportSpecifierAbsolute {
+                path: site.specifier().to_owned(),
+            },
+        };
+        let file_id = program
+            .module(site.importer())
+            .expect("import directive belongs to parsed program")
+            .file_id();
+        let span = rue_span::Span::with_file(file_id, site.source_offset(), site.source_end());
+        errors.push(CompileError::new(kind, span));
+    }
+    errors
+}
+
 pub(crate) fn discovery_groups_for_occurrence(
     context: &ImportDiscoveryContext,
     occurrence: &ImportOccurrenceKey,
     importer_requested_path: &str,
 ) -> CompileResult<Vec<Arc<[ImportDiscoveryRequest]>>> {
+    // A specifier that is not a relative path derives no filesystem requests:
+    // like an escaping one, its rejection is decided lexically, and the
+    // diagnostic projection recomputes the same check (`specifier_diagnostics`).
+    if non_relative_specifier(occurrence.specifier()).is_some() {
+        return Ok(Vec::new());
+    }
     // An escaping occurrence derives no filesystem requests: its rejection is
     // decided lexically from the importer anchor and its project or captured
     // standard-library root, and the diagnostic projection recomputes the same
@@ -1619,6 +1692,7 @@ pub(crate) fn exact_import_diagnostics(
     ledger: &ImportObservationLedger,
 ) -> CompileErrors {
     let mut errors = ImportDiscoveryPlan::shape_diagnostics(program);
+    errors.extend(specifier_diagnostics(program));
     errors.extend(escape_diagnostics(program, context));
     let mut groups_by_site: BTreeMap<&ImportOccurrenceKey, Vec<&Arc<[ImportDiscoveryRequest]>>> =
         BTreeMap::new();
@@ -2836,6 +2910,78 @@ mod tests {
                 discovery_groups_for_occurrence(&context, occurrence, importer)
                     .unwrap()
                     .is_empty()
+            );
+        }
+    }
+
+    fn project_occurrence(importer: &str, specifier: &str) -> ImportOccurrenceKey {
+        ImportOccurrenceKey {
+            importer: ModuleId::from_logical_path(importer).unwrap(),
+            source_offset: 0,
+            source_end: specifier.len() as u32,
+            specifier: Arc::from(specifier),
+        }
+    }
+
+    #[test]
+    fn non_relative_specifiers_are_classified_from_their_text() {
+        assert_eq!(
+            non_relative_specifier(""),
+            Some(NonRelativeSpecifier::Empty)
+        );
+        assert_eq!(
+            non_relative_specifier("/etc/hostname.rue"),
+            Some(NonRelativeSpecifier::Absolute)
+        );
+        assert_eq!(
+            non_relative_specifier("/project/helper.rue"),
+            Some(NonRelativeSpecifier::Absolute)
+        );
+        // Relative spellings, including the ones that look unusual, are not
+        // this rule's business: an escaping `..` chain is E0713's.
+        for relative in ["helper.rue", "./helper.rue", "../outside.rue", "nested/mod"] {
+            assert_eq!(non_relative_specifier(relative), None, "{relative}");
+        }
+        // `std` is a reserved program-anchored specifier, not a path.
+        assert_eq!(non_relative_specifier("std"), None);
+    }
+
+    #[test]
+    fn non_relative_specifiers_derive_no_discovery_requests() {
+        let context = context(1);
+        // The absolute specifier here names a file that really is inside the
+        // project root. Before RUE-1706 `Path::join` discarded the importer
+        // anchor, this candidate stayed within the boundary, and the import
+        // RESOLVED — a program that compiled only while its tree sat at this
+        // path on this machine.
+        for specifier in ["", "/project/helper.rue", "/etc/hostname.rue"] {
+            let occurrence = project_occurrence("main.rue", specifier);
+            assert!(
+                discovery_groups_for_occurrence(&context, &occurrence, "/project/main.rue")
+                    .unwrap()
+                    .is_empty(),
+                "{specifier} derived requests"
+            );
+            // One mistake, one diagnostic: the escape check declines these so
+            // they are not also reported as leaving the project root.
+            assert_eq!(
+                escaping_import_candidate(&context, specifier, "/project/main.rue").unwrap(),
+                None,
+                "{specifier} also reported as escaping"
+            );
+        }
+    }
+
+    #[test]
+    fn relative_specifiers_still_derive_discovery_requests() {
+        let context = context(1);
+        for specifier in ["helper.rue", "./helper.rue", "nested/mod"] {
+            let occurrence = project_occurrence("main.rue", specifier);
+            assert!(
+                !discovery_groups_for_occurrence(&context, &occurrence, "/project/main.rue")
+                    .unwrap()
+                    .is_empty(),
+                "{specifier} derived no requests"
             );
         }
     }

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -1537,6 +1537,7 @@ impl RetainedCharge for rue_error::ErrorKind {
             E::ImportEscapesRoot { path, candidate } => path
                 .retained_charge()
                 .saturating_add(candidate.retained_charge()),
+            E::ImportSpecifierAbsolute { path } => path.retained_charge(),
             E::MissingFields(value) => (std::mem::size_of_val(value.as_ref()) as u64)
                 .saturating_add(value.struct_name.retained_charge())
                 .saturating_add(value.missing_fields.retained_charge()),
@@ -1602,6 +1603,7 @@ impl RetainedCharge for rue_error::ErrorKind {
             | E::NonExhaustiveMatch
             | E::EmptyMatch
             | E::ImportRequiresStringLiteral
+            | E::ImportSpecifierEmpty
             | E::StdLibNotFound
             | E::ChainedComparison
             | E::TypeAnnotationRequired

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -421,6 +421,11 @@ impl ErrorCode {
     /// source file's directory), so it can receive no project-relative module
     /// identity (ADR-0078).
     pub const IMPORT_ESCAPES_ROOT: Self = Self(713);
+    /// An `@import` specifier is not a relative path: it is empty, or it is
+    /// absolute. Resolution is defined for relative paths only (spec 10.2:1-2),
+    /// and an absolute specifier would additionally bind the program to one
+    /// machine's layout, which project-root-relative identity exists to avoid.
+    pub const IMPORT_SPECIFIER_NOT_RELATIVE: Self = Self(714);
 
     // ========================================================================
     // Literal/operator errors (E0800-E0899)
@@ -1766,6 +1771,13 @@ pub enum ErrorKind {
         "import '{path}' escapes the project root: '{candidate}' is outside the root source file's directory"
     )]
     ImportEscapesRoot { path: String, candidate: String },
+    #[error("@import requires a relative path, but the specifier is empty")]
+    ImportSpecifierEmpty,
+    #[error(
+        "@import requires a relative path, but '{path}' is absolute; paths resolve \
+         relative to the importing file"
+    )]
+    ImportSpecifierAbsolute { path: String },
     #[error("standard library not found")]
     StdLibNotFound,
     #[error("{item_kind} `{name}` is private")]
@@ -2231,6 +2243,9 @@ impl ErrorKind {
             ErrorKind::ImportRequiresStringLiteral => ErrorCode::IMPORT_REQUIRES_STRING_LITERAL,
             ErrorKind::ModuleNotFound { .. } => ErrorCode::MODULE_NOT_FOUND,
             ErrorKind::ImportEscapesRoot { .. } => ErrorCode::IMPORT_ESCAPES_ROOT,
+            ErrorKind::ImportSpecifierEmpty | ErrorKind::ImportSpecifierAbsolute { .. } => {
+                ErrorCode::IMPORT_SPECIFIER_NOT_RELATIVE
+            }
             ErrorKind::StdLibNotFound => ErrorCode::STD_LIB_NOT_FOUND,
             ErrorKind::PrivateMemberAccess { .. } => ErrorCode::PRIVATE_MEMBER_ACCESS,
             ErrorKind::PrivateUnqualifiedAccess(_) => ErrorCode::PRIVATE_UNQUALIFIED_ACCESS,

--- a/crates/rue-spec/cases/modules/import.toml
+++ b/crates/rue-spec/cases/modules/import.toml
@@ -164,6 +164,45 @@ compile_fail = true
 error_contains = "escapes the project root"
 
 [[case]]
+name = "empty_import_path_is_rejected"
+spec = ["4.13:133", "10.2:8"]
+description = "An empty import path names no candidate and is E0714, not an escape diagnostic about a derived '/_.rue'"
+source = """
+fn main() -> i32 {
+    let nothing = @import("");
+    0
+}
+"""
+compile_fail = true
+error_contains = "requires a relative path"
+
+[[case]]
+name = "absolute_import_path_is_rejected"
+spec = ["4.13:133", "10.2:8"]
+description = "An absolute import path is anchored to a machine rather than to the importing file, and is E0714"
+source = """
+fn main() -> i32 {
+    let h = @import("/etc/hostname.rue");
+    0
+}
+"""
+compile_fail = true
+error_contains = "is absolute"
+
+[[case]]
+name = "relative_import_path_with_leading_dot_still_resolves"
+spec = ["10.2:2", "10.2:8"]
+description = "Rejecting absolute paths does not touch relative ones: an explicit './' prefix resolves against the importing file's directory"
+source = """
+fn main() -> i32 {
+    let m = @import("./foo.rue");
+    m.a()
+}
+"""
+aux_files = { "foo.rue" = "pub fn a() -> i32 { 7 }" }
+exit_code = 7
+
+[[case]]
 name = "const_module_reexport_member_chain"
 spec = ["4.13:81", "10.4:3"]
 description = "A pub const holding a module (ADR-0026 re-export idiom) is accessible as a member; chained access reaches the inner module's functions (RUE-136)"

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -1126,6 +1126,14 @@ candidate falls outside the project root (the root file's directory); see
 rule [10.2:7](@/10-modules/02-import-resolution.md). Module identity is
 project-root-relative, so a file outside the root can receive no identity.
 
+{{ rule(id="4.13:133", cat="legality-rule") }}
+
+It is a compile-time error (E0714) if an import path is empty or absolute;
+see rule [10.2:8](@/10-modules/02-import-resolution.md). `@import` resolves a
+relative path against the importing file's directory, so neither shape names
+a module: the empty path names nothing, and an absolute path is anchored to a
+machine rather than to the importing file.
+
 {{ rule(id="4.13:90", cat="legality-rule") }}
 
 It is a compile-time error to access a member of a module that is not

--- a/docs/spec/src/10-modules/02-import-resolution.md
+++ b/docs/spec/src/10-modules/02-import-resolution.md
@@ -37,6 +37,19 @@ file therefore either satisfies a previously failing import at its one
 candidate path or is irrelevant to it — it can never retarget an import
 that already resolves.
 
+{{ rule(id="10.2:8", cat="normative") }}
+
+An import path is a *relative* path. An empty path names no candidate, and
+an absolute path — one beginning with the root separator `/` — is not
+resolved against the importing file's directory at all, so 10.2:1 and 10.2:2
+give it no meaning. An absolute path would also bind the program to one
+machine's directory layout, which the project-root-relative identity of
+10.2:4 exists to prevent: the same source tree, checked out elsewhere, would
+stop compiling. Either shape is a compile-time error (rule
+[4.13:133](@/04-expressions/13-intrinsics.md), error E0714), decided from the
+path text alone, and no filesystem probe is attempted for it. The reserved
+specifier `"std"` is not a path and is not subject to this rule (10.2:6).
+
 ## Transitive Loading
 
 {{ rule(id="10.2:3", cat="normative") }}


### PR DESCRIPTION
## Summary

- classify absolute and empty `@import` specifiers from the specifier text and report a spanned E0714 at the import site
- derive no filesystem requests for such an occurrence, and stop routing it through the project-boundary check, so one mistake yields one diagnostic
- write down the rule the spec was already assuming, as 10.2:8 and legality rule 4.13:133

## Problem

`discovery_candidate_groups` derives candidates with `Path::join`, which **discards its base** when the right-hand side is absolute. An absolute specifier therefore became its own candidate, unanchored from the importing file, and the only thing between it and resolution was the project-boundary check. Verified on `7c4e2f9`:

| specifier | before | after |
| --- | --- | --- |
| `@import("/abs/path/into/project/helper.rue")` | **compiled and ran** | `E0714` |
| `@import("/etc/hostname.rue")` | `E0713` "escapes the project root" | `E0714` |
| `@import("")` | `E0713` against a `/_.rue` candidate | `E0714` |

The first row is the real damage: the program compiled only while its tree sat at that path on that machine, which is exactly what project-root-relative module identity exists to prevent. The second is fail-closed but the wrong category — the path names no module at all, root or not. The third reports a candidate, `/_.rue`, that is an artifact of the same join against the `{specifier}/_{basename}.rue` template rather than a path any project holds.

Spec 10.2:1-2 defines resolution for relative paths only, so this is drift from the spec, not a gap in it.

## Approach

`non_relative_specifier` classifies the two shapes from the specifier text alone. It uses `Path::is_absolute` deliberately — the same predicate `Path::join` consults when deciding to discard its base, so it rejects exactly the specifiers that would otherwise escape the importer anchor. `"std"` is exempt: it is a reserved program-anchored specifier (10.2:6), not a path.

The check sits beside the escape rule and works the same way, because it is the same kind of rule:

- `discovery_groups_for_occurrence` returns no requests, so nothing reaches the filesystem
- `specifier_diagnostics` recomputes the classification from the parsed program, as `escape_diagnostics` does — a rejected occurrence owns no requests, so it appears in neither the request groups nor the observation ledger
- `escaping_import_candidate` now declines these specifiers, so `@import("")` reports E0714 alone instead of E0714 **and** E0713

## Tests

The absolute path that used to *compile* has to be inside the project root, and a CLI or spec case cannot spell its own temp directory — so that one is pinned by unit tests in `import_discovery.rs`, where the test chooses the paths. `non_relative_specifiers_derive_no_discovery_requests` covers `/project/helper.rue` against a `/project` root, plus the empty and outside-the-root spellings, and asserts the escape check declines all three. `relative_specifiers_still_derive_discovery_requests` is the control.

End-to-end, four spec cases (`4.13:133`, `10.2:8`) and two CLI cases cover the empty and absolute spellings, with `compile_stderr_not_contains` pinning that E0713 and `/_.rue` are gone. A `./foo.rue` case pins that rejecting absolute paths left relative ones alone.

## Validation

- `scripts/rue premerge`: 200 passed, 0 failed
- `//:spec-traceability` (both new normative rules covered), `//crates/rue-oracle-diff:oracle-diff-test` and `:oracle-diff-spec-test` — the lane premerge does not cover; the new CLI cases are `compile_fail`, so ineligible, and need no model-gap entry
- `scripts/rue quick`, `scripts/rue fmt`
- Manually re-ran all three repros against the built compiler, plus `@import("std")` and an ordinary relative import as controls

Fixes RUE-1706


---
_Generated by [Claude Code](https://claude.ai/code/session_01KcQ73d3FmQYaxAUh6Lzi9C)_