### PR TITLE
RUE-1740: enforce post-lexer interner limits

### DIFF
--- a/crates/rue-air/src/sema/aggregate_resolution.rs
+++ b/crates/rue-air/src/sema/aggregate_resolution.rs
@@ -364,7 +364,9 @@ where
     /// Callers populate this from durable declaration keys or from an upstream
     /// lookup whose provider edge has already been recorded.
     pub fn register_named_nominal(&mut self, key: K, file: FileId, name: &str) {
-        let symbol = self.identity.pool().intern_name(name);
+        let Ok(symbol) = self.identity.pool().intern_name(name) else {
+            return;
+        };
         self.by_file_name.insert((file.index(), symbol), key);
     }
 
@@ -375,7 +377,9 @@ where
     }
 
     pub fn register_value_const(&self, file: FileId, name: &str, info: ConstInfo) {
-        let name = self.identity.pool().intern_name(name);
+        let Ok(name) = self.identity.pool().intern_name(name) else {
+            return;
+        };
         self.value_consts
             .borrow_mut()
             .insert((file.index(), name), info);
@@ -383,7 +387,9 @@ where
 
     /// Recover an installed value constant with its complete assembled payload.
     pub fn value_const(&self, file: FileId, name: &str) -> Option<ConstInfo> {
-        let name = self.identity.pool().intern_name(name);
+        let Ok(name) = self.identity.pool().intern_name(name) else {
+            return None;
+        };
         self.value_consts
             .borrow()
             .get(&(file.index(), name))
@@ -391,7 +397,9 @@ where
     }
 
     pub fn register_module_binding(&self, file: FileId, name: &str, info: ConstInfo) {
-        let name = self.identity.pool().intern_name(name);
+        let Ok(name) = self.identity.pool().intern_name(name) else {
+            return;
+        };
         self.module_bindings
             .borrow_mut()
             .insert((file.index(), name), info);
@@ -399,7 +407,9 @@ where
 
     /// Recover an installed module binding with its complete assembled payload.
     pub fn module_binding(&self, file: FileId, name: &str) -> Option<ConstInfo> {
-        let name = self.identity.pool().intern_name(name);
+        let Ok(name) = self.identity.pool().intern_name(name) else {
+            return None;
+        };
         self.module_bindings
             .borrow()
             .get(&(file.index(), name))
@@ -438,13 +448,17 @@ where
     /// nominal machinery, as a pool [`Type`]. Equal to the epoch's
     /// `structs_by_file_name` lookup under the durable-key bijection.
     pub fn struct_in_file(&self, file: FileId, name: &str) -> Option<Type> {
-        let symbol = self.identity.pool().intern_name(name);
+        let Ok(symbol) = self.identity.pool().intern_name(name) else {
+            return None;
+        };
         AggregateFacts::aggregate_struct_in_file(self, file, symbol).map(Type::new_struct)
     }
 
     /// (P) The enum declared as `(file, name)`, as a pool [`Type`].
     pub fn enum_in_file(&self, file: FileId, name: &str) -> Option<Type> {
-        let symbol = self.identity.pool().intern_name(name);
+        let Ok(symbol) = self.identity.pool().intern_name(name) else {
+            return None;
+        };
         AggregateFacts::aggregate_enum_in_file(self, file, symbol).map(Type::new_enum)
     }
 
@@ -452,14 +466,18 @@ where
     /// as a pool [`Type`]. Names beyond the pre-registered builtin set fail closed
     /// (r6 builtin facts).
     pub fn builtin_struct(&self, name: &str) -> Option<Type> {
-        let symbol = self.identity.pool().intern_name(name);
+        let Ok(symbol) = self.identity.pool().intern_name(name) else {
+            return None;
+        };
         AggregateFacts::aggregate_builtin_struct(self, symbol).map(Type::new_struct)
     }
 
     /// (P) The builtin enum for a bare name (one of `BUILTIN_ENUMS`), as a pool
     /// [`Type`].
     pub fn builtin_enum(&self, name: &str) -> Option<Type> {
-        let symbol = self.identity.pool().intern_name(name);
+        let Ok(symbol) = self.identity.pool().intern_name(name) else {
+            return None;
+        };
         AggregateFacts::aggregate_builtin_enum(self, symbol).map(Type::new_enum)
     }
 
@@ -467,7 +485,9 @@ where
     /// the r1c struct→enum→const short-circuit, driven from the pool. The const
     /// fall-through consults the installed body-local const overlay.
     pub fn select_module_type_member(&self, file: FileId, name: &str) -> ProviderModuleMember {
-        let symbol = self.identity.pool().intern_name(name);
+        let Ok(symbol) = self.identity.pool().intern_name(name) else {
+            return ProviderModuleMember::Absent;
+        };
         match select_module_type_member(self, file, symbol) {
             ModuleTypeMember::Struct(id) => ProviderModuleMember::Struct(Type::new_struct(id)),
             ModuleTypeMember::Enum(id) => ProviderModuleMember::Enum(Type::new_enum(id)),
@@ -479,7 +499,9 @@ where
     /// Run the provider-generic [`select_qualified_type`] over this driver: the
     /// r1c enum→struct order.
     pub fn select_qualified_type(&self, file: FileId, name: &str) -> ProviderQualifiedType {
-        let symbol = self.identity.pool().intern_name(name);
+        let Ok(symbol) = self.identity.pool().intern_name(name) else {
+            return ProviderQualifiedType::Absent;
+        };
         match select_qualified_type(self, file, symbol) {
             QualifiedType::Enum(id) => ProviderQualifiedType::Enum(Type::new_enum(id)),
             QualifiedType::Struct(id) => ProviderQualifiedType::Struct(Type::new_struct(id)),
@@ -489,7 +511,9 @@ where
 
     /// Run the provider-generic [`select_qualified_enum`] over this driver.
     pub fn select_qualified_enum(&self, file: FileId, name: &str) -> Option<Type> {
-        let symbol = self.identity.pool().intern_name(name);
+        let Ok(symbol) = self.identity.pool().intern_name(name) else {
+            return None;
+        };
         select_qualified_enum(self, file, symbol).map(Type::new_enum)
     }
 
@@ -497,7 +521,9 @@ where
     /// for an unqualified head (`local_type = None`): the const→struct→builtin
     /// order, including an installed const arm.
     pub fn select_struct_literal_head(&self, file: FileId, name: &str) -> ProviderStructHead {
-        let symbol = self.identity.pool().intern_name(name);
+        let Ok(symbol) = self.identity.pool().intern_name(name) else {
+            return ProviderStructHead::Absent;
+        };
         match select_struct_literal_head(self, None, file, symbol) {
             StructLiteralHead::Bound(ty) => ProviderStructHead::Bound(ty),
             StructLiteralHead::Named(id) => ProviderStructHead::Named(Type::new_struct(id)),

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -200,7 +200,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }) else {
             return Ok(None);
         };
-        let method = self.body_interner().get_or_intern("equals_borrowed");
+        let method = self.intern_body_symbol("equals_borrowed")?;
         if self.method_info((struct_id, method)).is_none() {
             return Ok(None);
         }
@@ -210,11 +210,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let (rhs_arg, rhs_scope) =
             self.materialize_borrow_argument(air, rhs.air_ref, rhs.ty, span, ctx)?;
         temp_scope.extend(rhs_scope);
-        let call_name = self.body_interner().get_or_intern(&self.method_symbol(
-            struct_id,
-            "equals_borrowed",
-            false,
-        ));
+        let call_name =
+            self.intern_body_symbol(&self.method_symbol(struct_id, "equals_borrowed", false))?;
         let equal = air.add_call(
             None,
             call_name,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -168,16 +168,6 @@ pub(crate) enum ElementwiseConsumption {
     NotElementwise,
 }
 
-/// Intern the move-path segment for a constant array index (RUE-186).
-///
-/// Element paths reuse the field-path representation: index K becomes the
-/// interned decimal string of K. Identifiers can never be all digits, so
-/// these segments cannot collide with field names (see
-/// [`super::context::FieldPath`]).
-pub(crate) fn index_path_segment(interner: &ThreadedRodeo, index: u64) -> Spur {
-    interner.get_or_intern(index.to_string())
-}
-
 /// True when a move-path segment encodes a constant array index (all-digit
 /// interned string; see [`index_path_segment`]).
 pub(crate) fn is_index_segment(interner: &ThreadedRodeo, seg: Spur) -> bool {

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -98,7 +98,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ErrorKind::InternalError("canonical StrBuf lang item is not a struct".to_string()),
             span,
         )?;
-        let method = self.body_interner().get_or_intern("concat_borrowed");
+        let method = self.intern_body_symbol("concat_borrowed")?;
         if self
             .call_facts()
             .call_method_info(struct_id, method)
@@ -110,12 +110,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ));
         }
         ctx.referenced_methods.insert((struct_id, method));
-        self.record_body_method_dependency((struct_id, method));
-        let call_name = self.body_interner().get_or_intern(&self.method_symbol(
-            struct_id,
-            "concat_borrowed",
-            false,
-        ));
+        self.record_body_method_dependency((struct_id, method))?;
+        let call_name =
+            self.intern_body_symbol(&self.method_symbol(struct_id, "concat_borrowed", false))?;
         let arg_mode = AirArgMode::Borrow;
 
         let (lhs_arg, mut temp_scope) =
@@ -225,7 +222,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let runtime_helper = operation
             .runtime_helper()
             .expect("print builtin must map to a runtime helper");
-        let call_name = self.body_interner().get_or_intern(runtime_helper.symbol);
+        let call_name = self.intern_body_symbol(runtime_helper.symbol)?;
 
         // A StrBuf source reads its `{ptr, len}` prefix through the trusted
         // accessors and passes them as separate scalars (the `*Projected`

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -1080,7 +1080,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             false,
             ctx,
         )?;
-        self.record_body_method_dependency(method_key);
+        self.record_body_method_dependency(method_key)?;
 
         // Clone data needed before mutable borrow
         let return_type = method_info.return_type;
@@ -1294,7 +1294,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // the type name spans files (RUE-571) — must match the definition
         // side, which builds its name through the same helper.
         let call_name = self.method_symbol(struct_id, &method_name_str, true);
-        let call_name_sym = self.body_interner().get_or_intern(&call_name);
+        let call_name_sym = self.intern_body_symbol(&call_name)?;
 
         let call = self.emit_call_result(
             air,
@@ -1608,7 +1608,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             true,
             ctx,
         )?;
-        self.record_body_method_dependency(method_key);
+        self.record_body_method_dependency(method_key)?;
 
         // Clone data needed before mutable borrow
         let return_type = method_info.return_type;
@@ -1638,7 +1638,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // file-qualified name when the type name spans files (RUE-571),
         // matching the definition side.
         let call_name = self.method_symbol(struct_id, &function_name_str, false);
-        let call_name_sym = self.body_interner().get_or_intern(&call_name);
+        let call_name_sym = self.intern_body_symbol(&call_name)?;
 
         let result = self.emit_call_result(
             air,

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -556,7 +556,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             }
             _ => None,
         };
-        let self_symbol = self.body_interner().get_or_intern("self");
+        let self_symbol = self.intern_body_symbol("self")?;
         let mut root = ptr_offset_base;
         let receiver_rooted = loop {
             let Some(current) = root else {
@@ -690,12 +690,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         // String byte view: the bound is the byte length `s.len()`.
         if self.is_strbuf(coll_type) {
-            let source_method = coll_type.as_struct().and_then(|struct_id| {
-                let method = self.body_interner().get_or_intern("len");
+            let source_method = if let Some(struct_id) = coll_type.as_struct() {
+                let method = self.intern_body_symbol("len")?;
                 (self.body_type_pool().struct_lang_item(struct_id) == Some(crate::LangItem::StrBuf)
                     && self.method_info((struct_id, method)).is_some())
                 .then_some((struct_id, method))
-            });
+            } else {
+                None
+            };
             let Some((struct_id, method)) = source_method else {
                 return Err(CompileError::new(
                     ErrorKind::InternalError(
@@ -705,7 +707,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ));
             };
             ctx.referenced_methods.insert((struct_id, method));
-            self.record_body_method_dependency((struct_id, method));
+            self.record_body_method_dependency((struct_id, method))?;
             let (receiver, temp_scope) = self.materialize_borrow_argument(
                 air,
                 coll_result.air_ref,
@@ -713,9 +715,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 span,
                 ctx,
             )?;
-            let call_name = self
-                .body_interner()
-                .get_or_intern(&self.method_symbol(struct_id, "len", true));
+            let call_name = self.intern_body_symbol(&self.method_symbol(struct_id, "len", true))?;
             let call_ref = air.add_call(
                 None,
                 call_name,
@@ -794,9 +794,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             (false, false) => (crate::RuntimeCallKind::StrCharScalar, Type::U32),
             (false, true) => (crate::RuntimeCallKind::StrCharScalarLossy, Type::U32),
         };
-        let call_name = self
-            .body_interner()
-            .get_or_intern(runtime.helper().symbol());
+        let call_name = self.intern_body_symbol(runtime.helper().symbol())?;
         let (ptr, len, temp_scope) =
             self.project_strbuf_text_fields(air, coll_result.air_ref, coll_result.ty, span, ctx)?;
         let call_ref = air.add_call(
@@ -1655,7 +1653,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             .runtime_helper()
             .expect("to_string builtin must map to a runtime helper");
         debug_assert_eq!(runtime_helper.parameters.len(), 2);
-        let call_name = self.body_interner().get_or_intern(runtime_helper.symbol);
+        let call_name = self.intern_body_symbol(runtime_helper.symbol)?;
 
         let air_ref = air.add_call(
             Some(if unsigned {

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -664,8 +664,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // compiler never depends on StrBuf's internal field layout (RUE-1066).
         // Both accessors are `borrow self`, so one materialized borrow of the
         // owner backs both calls.
-        let ptr_method = self.body_interner().get_or_intern("as_ptr");
-        let len_method = self.body_interner().get_or_intern("len");
+        let ptr_method = self.intern_body_symbol("as_ptr")?;
+        let len_method = self.intern_body_symbol("len")?;
         let Some(ptr_ty) = self
             .call_facts()
             .call_method_info(struct_id, ptr_method)
@@ -693,16 +693,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         ctx.referenced_methods.insert((struct_id, ptr_method));
         ctx.referenced_methods.insert((struct_id, len_method));
         {
-            self.record_body_method_dependency((struct_id, ptr_method));
-            self.record_body_method_dependency((struct_id, len_method));
+            self.record_body_method_dependency((struct_id, ptr_method))?;
+            self.record_body_method_dependency((struct_id, len_method))?;
         }
         let (receiver, prefix) = self.materialize_borrow_argument(air, value, ty, span, ctx)?;
-        let ptr_call_name = self
-            .body_interner()
-            .get_or_intern(&self.method_symbol(struct_id, "as_ptr", true));
-        let len_call_name = self
-            .body_interner()
-            .get_or_intern(&self.method_symbol(struct_id, "len", true));
+        let ptr_call_name =
+            self.intern_body_symbol(&self.method_symbol(struct_id, "as_ptr", true))?;
+        let len_call_name = self.intern_body_symbol(&self.method_symbol(struct_id, "len", true))?;
         let ptr_ref = air.add_call(
             None,
             ptr_call_name,
@@ -1110,9 +1107,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         // it (RUE-279); negative/dynamic indices leave it None.
                         let const_index = self.try_get_const_index(*index);
                         let index_segment = match const_index {
-                            Some(k) if k >= 0 => {
-                                Some(super::index_path_segment(self.body_interner(), k as u64))
-                            }
+                            Some(k) if k >= 0 => Some(self.intern_index_path_segment(k as u64)?),
                             _ => None,
                         };
                         trace.projections.push(ProjectionInfo {
@@ -1230,7 +1225,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             .expect("accessor expansion follows a successful method lookup");
         let method_name_str = self.body_interner().resolve(&method).to_string();
         let call_name = self.method_symbol(struct_id, &method_name_str, true);
-        let call_name = self.body_interner().get_or_intern(&call_name);
+        let call_name = self.intern_body_symbol(&call_name)?;
         if self.function_identity(call_name).is_ok_and(|identity| {
             ctx.canonical_function_identity == crate::FunctionInstanceKey::Definition(identity)
         }) {
@@ -1369,7 +1364,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
         ctx.accessor_call_insts.insert(inst_ref, (method, root));
         ctx.referenced_methods.insert((struct_id, method));
-        self.record_body_method_dependency((struct_id, method));
+        self.record_body_method_dependency((struct_id, method))?;
         let receiver_place = Self::build_place_ref(air, &receiver_trace)?;
         let receiver_value = air.add_inst(AirInst {
             data: AirInstData::PlaceRead {
@@ -2422,7 +2417,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 // a linear value would drop the caller's live value implicitly.
                 // An `inout` binding can never be proven moved-out, so this is
                 // always ill-formed (E0494).
-                let discharged = self.place_linear_discharged(param_ty, name, &[], ctx);
+                let discharged = self.place_linear_discharged(param_ty, name, &[], ctx)?;
                 self.check_linear_overwrite(param_ty, discharged, true, span)?;
 
                 // Assignment to a parameter resets its move state
@@ -2489,7 +2484,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // would drop it implicitly. Legal only when the whole variable was
         // proven moved-out on every path (reinit-after-move idiom) — evaluated
         // on the post-RHS move state so `x = f(x)` counts as a discharge.
-        let discharged = self.place_linear_discharged(local_ty, name, &[], ctx);
+        let discharged = self.place_linear_discharged(local_ty, name, &[], ctx)?;
         self.check_linear_overwrite(local_ty, discharged, false, span)?;
         // Two-types model (ADR-0043, RUE-386): reassigning a first-class `str`
         // local must store a first-class `str`, not a buffer or a borrowed view;
@@ -3697,7 +3692,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 span,
             ));
         };
-        let method = self.body_interner().get_or_intern("byte_at_borrowed");
+        let method = self.intern_body_symbol("byte_at_borrowed")?;
         if self
             .call_facts()
             .call_method_info(struct_id, method)
@@ -3712,14 +3707,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ));
         }
         ctx.referenced_methods.insert((struct_id, method));
-        self.record_body_method_dependency((struct_id, method));
+        self.record_body_method_dependency((struct_id, method))?;
         let (receiver, temp_scope) =
             self.materialize_borrow_argument(air, base_result.air_ref, base_result.ty, span, ctx)?;
-        let call_name = self.body_interner().get_or_intern(&self.method_symbol(
-            struct_id,
-            "byte_at_borrowed",
-            false,
-        ));
+        let call_name =
+            self.intern_body_symbol(&self.method_symbol(struct_id, "byte_at_borrowed", false))?;
         let receiver_mode = AirArgMode::Borrow;
         let call_ref = air.add_call(
             None,
@@ -3800,9 +3792,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // value is passed by value; codegen decomposes it into pointer/length
         // argument registers.
         let runtime = crate::RuntimeCallKind::StrByteAt;
-        let call_name = self
-            .body_interner()
-            .get_or_intern(runtime.helper().symbol());
+        let call_name = self.intern_body_symbol(runtime.helper().symbol())?;
         let call_ref = air.add_call(
             Some(runtime),
             call_name,
@@ -4278,7 +4268,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     trace.root_var,
                     &trace.field_path(),
                     ctx,
-                );
+                )?;
             self.check_linear_overwrite(field_type, discharged, false, span)?;
 
             // The write reinitializes its destination: the assigned path
@@ -4344,7 +4334,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // element read from the same root array.  The RHS is analyzed first,
         // so its element move is present when the target-side partial-array
         // guard runs; remember that this exact path was new before the RHS.
-        let rhs_element = self.direct_constant_array_element_path(value);
+        let rhs_element = self.direct_constant_array_element_path(value)?;
         let rhs_element_was_unmoved = rhs_element.as_ref().is_some_and(|(root, path)| {
             ctx.moved_vars
                 .get(root)
@@ -4473,7 +4463,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // its element path segment so field_path nests through it (RUE-279).
             let const_index = self.try_get_const_index(index);
             let index_segment = match const_index {
-                Some(k) if k >= 0 => Some(index_path_segment(self.body_interner(), k as u64)),
+                Some(k) if k >= 0 => Some(self.intern_index_path_segment(k as u64)?),
                 _ => None,
             };
             trace.projections.push(ProjectionInfo {
@@ -4517,7 +4507,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     trace.root_var,
                     &trace.field_path(),
                     ctx,
-                );
+                )?;
             self.check_linear_overwrite(elem_type, discharged, false, span)?;
 
             // The write reinitializes its destination element: the assigned
@@ -4538,7 +4528,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ] = trace.projections.as_slice()
             {
                 if *k >= 0 {
-                    let elem_path = vec![index_path_segment(self.body_interner(), *k as u64)];
+                    let elem_path = vec![self.intern_index_path_segment(*k as u64)?];
                     if let Some(state) = ctx.moved_vars.get_mut(&trace.root_var) {
                         state.mark_path_reinitialized(&elem_path);
                         if state.is_empty() {
@@ -4700,7 +4690,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // element-wise consumption of a root linear array (RUE-186, spec
         // 3.8:71) and of an array field consumed through per-element field
         // moves.
-        let Some(residue) = self.residual_linear_place(local.ty, state, &mut Vec::new()) else {
+        let Some(residue) = self.residual_linear_place(local.ty, state, &mut Vec::new())? else {
             return Ok(());
         };
 
@@ -4757,7 +4747,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // and per-element field consumption of an array anywhere in the
         // parameter's place tree — satisfies the obligation like a whole
         // move.
-        let Some(residue) = self.residual_linear_place(param.ty, state, &mut Vec::new()) else {
+        let Some(residue) = self.residual_linear_place(param.ty, state, &mut Vec::new())? else {
             return Ok(());
         };
         // A root array PARTIALLY consumed element-wise gets the more precise
@@ -4907,32 +4897,32 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         ty: Type,
         state: Option<&VariableMoveState>,
         path: &mut Vec<Spur>,
-    ) -> Option<Vec<Spur>> {
+    ) -> CompileResult<Option<Vec<Spur>>> {
         if state.is_some_and(|s| Self::place_moved_on_all_paths(s, path)) {
-            return None;
+            return Ok(None);
         }
         if let TypeKind::Array(array_id) = ty.kind() {
             return self.residual_linear_array_place(array_id, state, path);
         }
         let Some(struct_id) = ty.as_struct() else {
-            return self.type_requires_consumption(ty).then(|| path.clone());
+            return Ok(self.type_requires_consumption(ty).then(|| path.clone()));
         };
         if self.struct_declared_linear(struct_id) {
-            return Some(path.clone());
+            return Ok(Some(path.clone()));
         }
         let def = self.body_type_pool().struct_def(struct_id);
         for field in def.fields.iter() {
             if !self.type_carries_linear(field.ty) {
                 continue;
             }
-            path.push(self.body_interner().get_or_intern(&field.name));
-            let found = self.residual_linear_place(field.ty, state, path);
+            path.push(self.intern_body_symbol(&field.name)?);
+            let found = self.residual_linear_place(field.ty, state, path)?;
             path.pop();
             if found.is_some() {
-                return found;
+                return Ok(found);
             }
         }
-        None
+        Ok(None)
     }
 
     /// The array clause of [`Self::residual_linear_place`] (RUE-1606): the
@@ -4959,10 +4949,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         array_id: crate::types::ArrayTypeId,
         state: Option<&VariableMoveState>,
         path: &mut Vec<Spur>,
-    ) -> Option<Vec<Spur>> {
+    ) -> CompileResult<Option<Vec<Spur>>> {
         let (elem_ty, len) = self.body_type_pool().array_def(array_id);
         if len == 0 || !self.type_requires_consumption(elem_ty) {
-            return None;
+            return Ok(None);
         }
         let touched_below = state.is_some_and(|s| {
             s.partial_moves
@@ -4970,17 +4960,17 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 .any(|(p, _)| p.len() > path.len() && p[..path.len()] == path[..])
         });
         if !touched_below {
-            return Some(path.clone());
+            return Ok(Some(path.clone()));
         }
         for k in 0..len {
-            path.push(index_path_segment(self.body_interner(), k));
-            let found = self.residual_linear_place(elem_ty, state, path);
+            path.push(self.intern_index_path_segment(k)?);
+            let found = self.residual_linear_place(elem_ty, state, path)?;
             path.pop();
             if found.is_some() {
-                return found;
+                return Ok(found);
             }
         }
-        None
+        Ok(None)
     }
 
     /// The span at which the residual linear place was consumed on SOME path,
@@ -5086,13 +5076,16 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return Ok(ElementwiseConsumption::NotElementwise);
         };
         let (elem_ty, len) = self.body_type_pool().array_def(array_id);
-        let elem_path = |k: u64| vec![index_path_segment(self.body_interner(), k)];
-        let unconsumed: Vec<u64> = (0..len)
-            .filter(|k| {
-                self.residual_linear_place(elem_ty, Some(s), &mut elem_path(*k))
-                    .is_some()
-            })
-            .collect();
+        let mut unconsumed = Vec::new();
+        for k in 0..len {
+            let mut elem_path = vec![self.intern_index_path_segment(k)?];
+            if self
+                .residual_linear_place(elem_ty, Some(s), &mut elem_path)?
+                .is_some()
+            {
+                unconsumed.push(k);
+            }
+        }
         if unconsumed.is_empty() {
             return Ok(ElementwiseConsumption::Complete);
         }
@@ -5107,13 +5100,18 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // An unconsumed element that WAS moved (whole, or below the element)
         // on some path selects the more precise "not consumed on all paths"
         // diagnostic (E0443 over E0406).
-        let some_path_span = unconsumed.iter().find_map(|k| {
-            let target = elem_path(*k);
-            s.partial_moves
+        let mut some_path_span = None;
+        for k in &unconsumed {
+            let target = vec![self.intern_index_path_segment(*k)?];
+            if let Some((_, span)) = s
+                .partial_moves
                 .iter()
                 .find(|(p, _)| p.first() == Some(&target[0]))
-                .map(|(_, span)| *span)
-        });
+            {
+                some_path_span = Some(*span);
+                break;
+            }
+        }
         let list = unconsumed
             .iter()
             .map(|k| format!("[{k}]"))
@@ -5190,21 +5188,25 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         root_var: Spur,
         assigned_path: &[Spur],
         ctx: &AnalysisContext,
-    ) -> bool {
+    ) -> CompileResult<bool> {
         let Some(state) = ctx.moved_vars.get(&root_var) else {
-            return false;
+            return Ok(false);
         };
         // The exact destination place was moved out on every path.
         if assigned_path.is_empty() {
             if state.full_move_on_all_paths {
-                return true;
+                return Ok(true);
             }
         } else if state.partial_moves_on_all_paths.contains(assigned_path) {
-            return true;
+            return Ok(true);
         }
         // A whole linear array consumed element-wise on every path holds no
         // live element to drop.
-        assigned_path.is_empty() && self.array_fully_moved_elementwise(dest_ty, state)
+        if assigned_path.is_empty() {
+            self.array_fully_moved_elementwise(dest_ty, state)
+        } else {
+            Ok(false)
+        }
     }
 
     /// Whether every element of an array was WHOLLY moved out on every path
@@ -5217,16 +5219,22 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// `sink(a[0].p)` element 0 is a live husk that the assignment would
     /// still overwrite, so it does not license reassignment — exactly as a
     /// struct husk does not (`c = ...` stays rejected after `sink(c.l)`).
-    fn array_fully_moved_elementwise(&self, ty: Type, state: &VariableMoveState) -> bool {
+    fn array_fully_moved_elementwise(
+        &self,
+        ty: Type,
+        state: &VariableMoveState,
+    ) -> CompileResult<bool> {
         let TypeKind::Array(array_id) = ty.kind() else {
-            return false;
+            return Ok(false);
         };
         let (_elem, len) = self.body_type_pool().array_def(array_id);
-        (0..len).all(|k| {
-            state
-                .partial_moves_on_all_paths
-                .contains(&vec![index_path_segment(self.body_interner(), k)])
-        })
+        for k in 0..len {
+            let segment = self.intern_index_path_segment(k)?;
+            if !state.partial_moves_on_all_paths.contains(&vec![segment]) {
+                return Ok(false);
+            }
+        }
+        Ok(true)
     }
 
     /// Reject a discarded expression value that carries a linear value
@@ -5315,7 +5323,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // Moving an element out of a borrow/inout parameter would leave the
         // CALLER's array holed, exactly like a whole or field move.
         self.reject_move_out_of_byref_param(trace.root_var, ctx, span)?;
-        let elem_path = vec![index_path_segment(self.body_interner(), k as u64)];
+        let elem_path = vec![self.intern_index_path_segment(k as u64)?];
         if let Some(state) = ctx.moved_vars.get(&trace.root_var) {
             // Whole-element move: reject if the element itself, an ancestor, or
             // any descendant subfield was already moved (`arr[0]` can't be
@@ -5428,7 +5436,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         };
         match first.const_index {
             Some(k) if k >= 0 => {
-                let elem_path = vec![index_path_segment(self.body_interner(), k as u64)];
+                let elem_path = vec![self.intern_index_path_segment(k as u64)?];
                 if let Some(moved_span) = state.is_path_moved(&elem_path) {
                     return Err(use_after_move_path_error(
                         self.body_interner(),
@@ -5512,22 +5520,24 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     fn direct_constant_array_element_path(
         &mut self,
         inst_ref: InstRef,
-    ) -> Option<(Spur, FieldPath)> {
+    ) -> CompileResult<Option<(Spur, FieldPath)>> {
         let (base, index) = match &self.body_rir_ref().get(inst_ref).data {
             InstData::IndexGet { base, index } => (*base, *index),
-            _ => return None,
+            _ => return Ok(None),
         };
         let root = match &self.body_rir_ref().get(base).data {
             InstData::VarRef { name, .. } => *name,
-            _ => return None,
+            _ => return Ok(None),
         };
-        let index = self.try_get_const_index(index)?;
-        (index >= 0).then(|| {
-            (
-                root,
-                vec![index_path_segment(self.body_interner(), index as u64)],
-            )
-        })
+        let Some(index) = self.try_get_const_index(index) else {
+            return Ok(None);
+        };
+        (index >= 0)
+            .then(|| {
+                self.intern_index_path_segment(index as u64)
+                    .map(|segment| (root, vec![segment]))
+            })
+            .transpose()
     }
 
     /// Extract the root variable symbol from an expression, if it refers to a variable.

--- a/crates/rue-air/src/sema/body_endpoint.rs
+++ b/crates/rue-air/src/sema/body_endpoint.rs
@@ -382,7 +382,7 @@ where
         owner: &str,
         method: &str,
         info: MethodInfo,
-    ) -> bool {
+    ) -> Result<bool, lasso::LassoErrorKind> {
         self.identity
             .register_anonymous_method(file, owner, method, info)
     }
@@ -487,13 +487,13 @@ where
         file: u32,
         name: &str,
         kind: StableDefinitionKind,
-    ) -> SemanticDefinitionToken {
-        let symbol = self.identity.pool().intern_name(name);
+    ) -> Option<SemanticDefinitionToken> {
+        let symbol = self.identity.pool().intern_name(name).ok()?;
         let mut overlay = self.overlay.borrow_mut();
         if let Some(token) = overlay.definition_tokens.get(&key) {
             let token = *token;
             overlay.by_file_name.insert((file, symbol), key);
-            return token;
+            return Some(token);
         }
         let slot = overlay.next_slot;
         overlay.next_slot += 1;
@@ -509,15 +509,20 @@ where
         );
         overlay.by_file_name.insert((file, symbol), key.clone());
         overlay.definition_tokens.insert(key, token);
-        token
+        Some(token)
     }
 
     /// Register one free-function endpoint in the body-local token and callable
     /// overlays. The exact durable key supplies signature truth while the local
     /// RIR supplies the declaration/body handles when the endpoint is
     /// consulted.
-    pub fn register_function(&self, key: K, file: FileId, name: &str) -> SemanticDefinitionToken {
-        let symbol = self.identity.pool().intern_name(name);
+    pub fn register_function(
+        &self,
+        key: K,
+        file: FileId,
+        name: &str,
+    ) -> Option<SemanticDefinitionToken> {
+        let symbol = self.identity.pool().intern_name(name).ok()?;
         let mut overlay = self.overlay.borrow_mut();
         if let Some(token) = overlay.definition_tokens.get(&key) {
             let token = *token;
@@ -525,7 +530,7 @@ where
                 .functions_by_file_name
                 .insert((file.index(), symbol), (symbol, key.clone()));
             overlay.function_keys.insert(symbol, key);
-            return token;
+            return Some(token);
         }
         let slot = overlay.next_slot;
         overlay.next_slot += 1;
@@ -544,7 +549,7 @@ where
             .insert((file.index(), symbol), (symbol, key.clone()));
         overlay.function_keys.insert(symbol, key.clone());
         overlay.definition_tokens.insert(key, token);
-        token
+        Some(token)
     }
 
     /// Mint an endpoint token for the exact body owner. Unlike
@@ -557,13 +562,13 @@ where
         name: &str,
         kind: StableDefinitionKind,
         owner: Option<&str>,
-    ) -> SemanticDefinitionToken {
+    ) -> Option<SemanticDefinitionToken> {
         if kind == StableDefinitionKind::Function && owner.is_none() {
             return self.register_function(key, file, name);
         }
         let mut overlay = self.overlay.borrow_mut();
         if let Some(token) = overlay.definition_tokens.get(&key) {
-            return *token;
+            return Some(*token);
         }
         let slot = overlay.next_slot;
         overlay.next_slot += 1;
@@ -578,7 +583,7 @@ where
             },
         );
         overlay.definition_tokens.insert(key, token);
-        token
+        Some(token)
     }
 
     /// Mint (or return) the body-local module token and compact module id for a
@@ -648,7 +653,7 @@ where
     where
         M: Clone,
     {
-        let symbol = self.identity.pool().intern_name(name);
+        let symbol = self.identity.pool().intern_name(name).ok()?;
         let id = self
             .identity
             .pool_mut()?
@@ -669,11 +674,12 @@ where
     /// name in the same generated-nominal overlay used by slice views.
     pub fn register_generated_fixed_string(&self, capacity: u64) -> Option<StructId> {
         let name = format!("Str({capacity})");
-        let symbol = self.identity.pool().intern_name(&name);
+        let symbol = self.identity.pool().intern_name(&name).ok()?;
         let id = self
             .identity
             .pool_mut()?
             .get_or_create_str_fixed(capacity)
+            .ok()?
             .as_struct()?;
         self.overlay
             .borrow_mut()
@@ -871,7 +877,7 @@ where
     M: Clone + Eq + Hash,
 {
     fn endpoint_name_symbol(&self, name: &str) -> Option<Spur> {
-        Some(self.identity.pool().intern_name(name))
+        self.identity.pool().intern_name(name).ok()
     }
 
     fn endpoint_definition_endpoint(

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -346,6 +346,9 @@ pub trait DurableAnonymousSource<K, M> {
 /// closed refusal — the pool never approximates an identity it cannot mint.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in crate::sema) enum IdentityMintError {
+    /// The shared revision symbol space rejected a new spelling. Preserve the
+    /// exact allocator/key-space classification for the compiler boundary.
+    Interner(lasso::LassoErrorKind),
     /// A named nominal key resolves to no durable metadata.
     MissingNominal,
     /// A callable (function / method) key resolves to no durable signature.
@@ -610,13 +613,24 @@ where
     }
 
     fn with_space_mode(source: S, space: SharedSymbolSpace, allow_post_seal_overlay: bool) -> Self {
-        Self {
-            pool: Rc::new(RefCell::new(BodyIdentityPool::new(source, space))),
+        Self::with_space_mode_fallible(source, space, allow_post_seal_overlay)
+            .unwrap_or_else(|error| panic!("private provider identity bootstrap failed: {error:?}"))
+    }
+
+    fn with_space_mode_fallible(
+        source: S,
+        space: SharedSymbolSpace,
+        allow_post_seal_overlay: bool,
+    ) -> Result<Self, IdentityMintError> {
+        Ok(Self {
+            pool: Rc::new(RefCell::new(
+                BodyIdentityPool::try_new(source, space).map_err(IdentityMintError::Interner)?,
+            )),
             modules: Rc::new(RefCell::new(ProviderModuleRegistry::default())),
             methods: Rc::new(RefCell::new(ProviderMethodRegistry::default())),
             frozen: Rc::new(Cell::new(false)),
             allow_post_seal_overlay,
-        }
+        })
     }
 
     /// Return the interner authority shared by all provider fact state in this
@@ -626,7 +640,7 @@ where
     }
 
     /// Intern a provider-facing name in the shared body authority.
-    pub fn name_symbol(&self, name: &str) -> Spur {
+    pub fn name_symbol(&self, name: &str) -> Result<Spur, lasso::LassoErrorKind> {
         self.pool.borrow().intern_name(name)
     }
 
@@ -683,16 +697,16 @@ where
         owner: &str,
         method: &str,
         info: MethodInfo,
-    ) -> bool {
+    ) -> Result<bool, lasso::LassoErrorKind> {
         let Some(owner_id) = info.struct_type.as_struct() else {
-            return false;
+            return Ok(false);
         };
-        let method_symbol = self.pool().intern_name(method);
-        self.methods.borrow_mut().register_anonymous(
+        let method_symbol = self.pool().intern_name(method)?;
+        Ok(self.methods.borrow_mut().register_anonymous(
             (owner_id, method_symbol),
             (file, Arc::from(owner), Arc::from(method)),
             info,
-        )
+        ))
     }
 
     /// Install one named method under both lookup preimages. The registry keeps
@@ -704,16 +718,16 @@ where
         owner: &str,
         method: &str,
         info: MethodInfo,
-    ) -> bool {
+    ) -> Result<bool, lasso::LassoErrorKind> {
         let Some(owner_id) = info.struct_type.as_struct() else {
-            return false;
+            return Ok(false);
         };
-        let method_symbol = self.pool().intern_name(method);
-        self.methods.borrow_mut().register_named(
+        let method_symbol = self.pool().intern_name(method)?;
+        Ok(self.methods.borrow_mut().register_named(
             (owner_id, method_symbol),
             (file, Arc::from(owner), Arc::from(method)),
             info,
-        )
+        ))
     }
 
     pub(in crate::sema) fn method(&self, key: (StructId, Spur)) -> Option<MethodInfo> {
@@ -776,13 +790,21 @@ where
     S: DurableNominalSource<K, M>,
 {
     pub fn new(source: S, space: SharedSymbolSpace) -> Self {
-        let identity = ProviderIdentityContext::with_space_mode(source, space.clone(), true);
+        Self::try_new(source, space).expect("provider identity bootstrap must fit its symbol space")
+    }
+
+    pub(in crate::sema) fn try_new(
+        source: S,
+        space: SharedSymbolSpace,
+    ) -> Result<Self, IdentityMintError> {
+        let identity =
+            ProviderIdentityContext::with_space_mode_fallible(source, space.clone(), true)?;
         let type_pool = identity.type_pool();
-        Self {
+        Ok(Self {
             identity,
             type_pool,
             space,
-        }
+        })
     }
 
     pub fn identity_context(&self) -> ProviderIdentityContext<K, M, S> {
@@ -924,13 +946,16 @@ where
 {
     /// Create an empty pool with the builtin enums and the core `str` identity
     /// pre-registered, mirroring a fresh import epoch.
-    pub(in crate::sema) fn new(source: S, space: SharedSymbolSpace) -> Self {
+    pub(in crate::sema) fn try_new(
+        source: S,
+        space: SharedSymbolSpace,
+    ) -> Result<Self, lasso::LassoErrorKind> {
         let interner = Arc::clone(space.interner());
         let type_pool = Rc::new(TypeInternPool::new());
         let mut builtins = AHashMap::new();
 
         for builtin in rue_builtins::BUILTIN_ENUMS {
-            let symbol = interner.get_or_intern(builtin.name);
+            let symbol = space.try_intern(builtin.name)?;
             let (id, _) = type_pool.register_enum(
                 symbol,
                 EnumDef {
@@ -950,7 +975,7 @@ where
         // The core `str` identity: an ordinary builtin struct paired with a
         // runtime definition. Registered exactly as `SemanticImportedProgram::new`
         // registers it.
-        let str_symbol = interner.get_or_intern("str");
+        let str_symbol = space.try_intern("str")?;
         let ptr_id = type_pool.intern_ptr_const_from_type(Type::U8);
         let (str_id, _) = type_pool.register_struct(
             str_symbol,
@@ -980,7 +1005,7 @@ where
             PoolNominal::Struct(str_id),
         );
 
-        Self {
+        Ok(Self {
             type_pool,
             space,
             interner,
@@ -1007,7 +1032,15 @@ where
             well_known_poisoned: None,
             const_values: AHashMap::new(),
             const_poisoned: AHashMap::new(),
-        }
+        })
+    }
+
+    /// Compatibility constructor for request-local identity contexts. The
+    /// canonical provider path uses [`Self::try_new`] so a revision-shared
+    /// symbol-space failure reaches the compiler boundary as a typed error.
+    #[cfg(test)]
+    pub(in crate::sema) fn new(source: S, space: SharedSymbolSpace) -> Self {
+        Self::try_new(source, space).expect("test identity pool bootstrap must fit")
     }
 
     /// The body-local pool. Downstream reads (`struct_def`, `enum_def`,
@@ -1077,15 +1110,22 @@ where
         self.record_anonymous_identity(key, ty);
     }
 
-    /// Intern a source name into the pool's own interner, returning its
+    /// Intern a source name into the pool's shared interner, returning its
     /// pool-relative [`Spur`]. The provider-driven endpoint driver
     /// ([`super::body_endpoint::ProviderEndpointFacts`]) interns each consulted
     /// name here — the `interner.get_or_intern` analog of the epoch's
     /// `interner.get` — so the symbol it then reverses through
     /// [`Self::resolve_symbol`] and keys the overlay on stays in this pool's own
     /// symbol space, never the shared whole-program interner's.
-    pub(in crate::sema) fn intern_name(&self, name: &str) -> Spur {
-        self.interner.get_or_intern(name)
+    pub(in crate::sema) fn try_intern_name(
+        &self,
+        name: &str,
+    ) -> Result<Spur, lasso::LassoErrorKind> {
+        self.space.try_intern(name)
+    }
+
+    pub(in crate::sema) fn intern_name(&self, name: &str) -> Result<Spur, lasso::LassoErrorKind> {
+        self.try_intern_name(name)
     }
 
     fn record_struct_identity(&mut self, key: K, id: StructId) {
@@ -1146,9 +1186,14 @@ where
     /// to a literal first; that reduction is the caller's job (the type-syntax
     /// resolver), so the pool takes an already-reduced `u64` and never re-derives
     /// a non-literal capacity.
-    pub(in crate::sema) fn get_or_create_str_fixed(&mut self, capacity: u64) -> Type {
+    pub(in crate::sema) fn get_or_create_str_fixed(
+        &mut self,
+        capacity: u64,
+    ) -> Result<Type, IdentityMintError> {
         let name: Arc<str> = Arc::from(format!("Str({capacity})").as_str());
-        let symbol = self.interner.get_or_intern(&name);
+        let symbol = self
+            .intern_name(&name)
+            .map_err(IdentityMintError::Interner)?;
         let ptr_id = self.type_pool.intern_ptr_const_from_type(Type::U8);
         let (id, _) = self.type_pool.register_struct(
             symbol,
@@ -1173,7 +1218,7 @@ where
                 file_id: FileId::DEFAULT,
             },
         );
-        Type::new_struct(id)
+        Ok(Type::new_struct(id))
     }
 
     /// Mint (on first consult) or dedup a concrete [`Type`] for a durable type.
@@ -1204,7 +1249,7 @@ where
                     if *kind != SemanticImportNominalKind::Struct {
                         return Err(IdentityMintError::BuiltinNominalKindMismatch);
                     }
-                    self.get_or_create_str_fixed(capacity)
+                    self.get_or_create_str_fixed(capacity)?
                 } else {
                     match self.builtins.get(&(name.clone(), *kind)).copied() {
                         Some(PoolNominal::Struct(id)) => Type::new_struct(id),
@@ -1253,7 +1298,9 @@ where
                 // exactly as `SemanticImportedProgram::import_type_local`
                 // registers it (ptr + len, builtin, copy).
                 let element = self.resolve(element)?;
-                let symbol = self.interner.get_or_intern(name.as_ref());
+                let symbol = self
+                    .intern_name(name.as_ref())
+                    .map_err(IdentityMintError::Interner)?;
                 let pointer = self.type_pool.intern_ptr_const_from_type(element);
                 let (id, _) = self.type_pool.register_struct(
                     symbol,
@@ -1352,7 +1399,9 @@ where
             .ok_or(IdentityMintError::MissingNominal)?;
         let requested_file = self.source.nominal_file_id(key);
         let file_id = self.file_for_module(&module_path, requested_file)?;
-        let symbol = self.interner.get_or_intern(name.as_ref());
+        let symbol = self
+            .intern_name(name.as_ref())
+            .map_err(IdentityMintError::Interner)?;
         let name = name.clone();
         match body {
             DurableNominalBody::Struct {
@@ -1508,7 +1557,9 @@ where
             .ok_or(IdentityMintError::MissingNominal)?;
 
         let file_id = self.file_for_module(&module_path, None)?;
-        let symbol = self.interner.get_or_intern(name.as_ref());
+        let symbol = self
+            .intern_name(name.as_ref())
+            .map_err(IdentityMintError::Interner)?;
         let name = name.clone();
 
         match body {
@@ -2040,9 +2091,10 @@ where
         // anonymous closure (ADR-0076).
         let (name, symbol) = self
             .space
-            .keyed_symbol_spelling(digest, ANON_NAME_SPELLING, || {
+            .try_keyed_symbol_spelling(digest, ANON_NAME_SPELLING, || {
                 super::anon_structs::anonymous_struct_name(digest)
-            });
+            })
+            .map_err(IdentityMintError::Interner)?;
         let has_destructor = method_names
             .iter()
             .any(|method| method.as_ref() == ANON_DROP_METHOD);
@@ -2132,7 +2184,9 @@ where
 
         let name = super::anon_structs::anonymous_enum_name(digest);
 
-        let symbol = self.interner.get_or_intern(&name);
+        let symbol = self
+            .intern_name(&name)
+            .map_err(IdentityMintError::Interner)?;
         let (id, _) = self.type_pool.register_enum(
             symbol,
             EnumDef {
@@ -2671,7 +2725,10 @@ where
             // Resolve the type first: on failure the arena is untouched (alloc is
             // the final step), so only the callable key is poisoned.
             let ty = self.resolve_callable_type(key, &parameter.ty)?;
-            names.push(self.interner.get_or_intern(parameter.name.as_ref()));
+            names.push(
+                self.intern_name(parameter.name.as_ref())
+                    .map_err(IdentityMintError::Interner)?,
+            );
             types.push(ty);
             modes.push(match parameter.mode {
                 SemanticParameterMode::Value => RirParamMode::Normal,
@@ -2811,12 +2868,18 @@ where
                     self.const_poisoned.insert(key.clone(), err.clone());
                     return Err(err);
                 };
-                ConstValue::Function(self.interner.get_or_intern(name.as_ref()).into())
+                ConstValue::Function(
+                    self.intern_name(name.as_ref())
+                        .map_err(IdentityMintError::Interner)?
+                        .into(),
+                )
             }
             V::Unit => ConstValue::Unit,
-            V::String(value) => {
-                ConstValue::String(self.interner.get_or_intern(value.as_ref()).into())
-            }
+            V::String(value) => ConstValue::String(
+                self.intern_name(value.as_ref())
+                    .map_err(IdentityMintError::Interner)?
+                    .into(),
+            ),
         })
     }
 }
@@ -2961,6 +3024,18 @@ impl BodyRirBundle {
         S: DurableNominalSource<K, M>,
     {
         ProviderBodyAnalysisState::new(source, self.space.clone())
+    }
+
+    pub(in crate::sema) fn try_provider_body_state<K, M, S>(
+        &self,
+        source: S,
+    ) -> Result<ProviderBodyAnalysisState<K, M, S>, IdentityMintError>
+    where
+        K: Clone + Eq + Hash,
+        M: Eq + Hash,
+        S: DurableNominalSource<K, M>,
+    {
+        ProviderBodyAnalysisState::try_new(source, self.space.clone())
     }
 
     pub fn instruction_count(&self) -> usize {
@@ -3230,7 +3305,7 @@ mod tests {
         // RIR-local and provider-created names are the same Spur, not merely
         // strings that were translated between two interner universes.
         let context = state.identity_context();
-        assert_eq!(context.name_symbol("Widget"), widget);
+        assert_eq!(context.name_symbol("Widget").unwrap(), widget);
         assert!(Arc::ptr_eq(&context.interner(), &interner));
         let stable_type_pool = state.type_pool();
         let opposite_order_context = state.identity_context();
@@ -3239,8 +3314,8 @@ mod tests {
             &opposite_order_context.interner()
         ));
         assert_eq!(
-            context.name_symbol("FacadeFirst"),
-            opposite_order_context.name_symbol("FacadeFirst"),
+            context.name_symbol("FacadeFirst").unwrap(),
+            opposite_order_context.name_symbol("FacadeFirst").unwrap(),
             "facade construction order does not fork symbol identity"
         );
 
@@ -3476,7 +3551,7 @@ mod tests {
         assert!(
             state
                 .interner()
-                .resolve(&state.identity_context().name_symbol("Widget"))
+                .resolve(&state.identity_context().name_symbol("Widget").unwrap())
                 == "Widget",
             "a retired space still resolves the handles it issued"
         );
@@ -4661,6 +4736,28 @@ mod tests {
         );
     }
 
+    #[test]
+    fn revision_shared_interner_exhaustion_is_typed_at_anonymous_mint_boundary() {
+        let key = anon_key(AnonymousNominalKind::Struct, 77, 0);
+        let shape = DurableAnonymousShape::Struct {
+            fields: vec![(Arc::from("value"), DType::I32)],
+            struct_method_names: Vec::new(),
+        };
+        let mut durable = source([]);
+        durable.anonymous_shapes.insert(key.clone(), shape);
+        let bootstrap_entries = rue_builtins::BUILTIN_ENUMS.len() + 1; // + core `str`
+        let mut pool = BodyIdentityPool::new(
+            durable,
+            SharedSymbolSpace::with_owner_bound(bootstrap_entries),
+        );
+        assert_eq!(
+            pool.find_or_create_anon(&key),
+            Err(IdentityMintError::Interner(
+                lasso::LassoErrorKind::KeySpaceExhaustion
+            ))
+        );
+    }
+
     /// A field-only anonymous struct mints byte-identically to the epoch's
     /// `find_or_create_anon_struct`: the `__anon_struct_{digest}` name, private,
     /// copyable iff every field is. Dedups by producer key on repeat, and a later
@@ -5273,7 +5370,7 @@ mod tests {
     #[test]
     fn str_fixed_arm_mints_and_dedups() {
         let mut pool = pool([]);
-        let str8 = pool.get_or_create_str_fixed(8);
+        let str8 = pool.get_or_create_str_fixed(8).unwrap();
         let id = str8.as_struct().unwrap();
         let def = pool.type_pool().struct_def(id);
         assert_eq!(&*def.name, "Str(8)");
@@ -5285,8 +5382,12 @@ mod tests {
         assert_eq!(def.fields[1].name, "len");
         assert_eq!(def.fields[1].ty, Type::U64);
         // Same capacity dedups; a different capacity mints a distinct struct.
-        assert_eq!(pool.get_or_create_str_fixed(8), str8, "repeat dedups");
-        let str16 = pool.get_or_create_str_fixed(16);
+        assert_eq!(
+            pool.get_or_create_str_fixed(8).unwrap(),
+            str8,
+            "repeat dedups"
+        );
+        let str16 = pool.get_or_create_str_fixed(16).unwrap();
         assert_ne!(str16, str8);
         assert_eq!(
             &*pool.type_pool().struct_def(str16.as_struct().unwrap()).name,

--- a/crates/rue-air/src/sema/call_resolution.rs
+++ b/crates/rue-air/src/sema/call_resolution.rs
@@ -177,7 +177,7 @@ where
     }
 
     /// Intern a body-local name in the shared provider identity universe.
-    pub fn name_symbol(&self, name: &str) -> Spur {
+    pub fn name_symbol(&self, name: &str) -> Result<Spur, lasso::LassoErrorKind> {
         self.identity.pool().intern_name(name)
     }
 
@@ -185,14 +185,18 @@ where
     /// body-local overlay. The `ConstInfo` type belongs to this driver's shared
     /// identity universe.
     pub fn register_value_const(&self, file: FileId, name: &str, info: ConstInfo) {
-        let name = self.identity.pool().intern_name(name);
+        let Ok(name) = self.identity.pool().intern_name(name) else {
+            return;
+        };
         self.value_consts
             .borrow_mut()
             .insert((file.index(), name), info);
     }
 
     pub fn value_const(&self, file: FileId, name: &str) -> Option<ConstInfo> {
-        let name = self.identity.pool().intern_name(name);
+        let Ok(name) = self.identity.pool().intern_name(name) else {
+            return None;
+        };
         self.value_consts
             .borrow()
             .get(&(file.index(), name))
@@ -200,14 +204,18 @@ where
     }
 
     pub fn register_module_binding(&self, file: FileId, name: &str, info: ConstInfo) {
-        let name = self.identity.pool().intern_name(name);
+        let Ok(name) = self.identity.pool().intern_name(name) else {
+            return;
+        };
         self.module_bindings
             .borrow_mut()
             .insert((file.index(), name), info);
     }
 
     pub fn module_binding(&self, file: FileId, name: &str) -> Option<ConstInfo> {
-        let name = self.identity.pool().intern_name(name);
+        let Ok(name) = self.identity.pool().intern_name(name) else {
+            return None;
+        };
         self.module_bindings
             .borrow()
             .get(&(file.index(), name))
@@ -307,6 +315,7 @@ where
         let info = self.identity.pool_mut()?.resolve_method(key, handle).ok()?;
         self.identity
             .register_named_method(owner_file, owner_type_name, method, info)
+            .ok()?
             .then_some(info)
     }
 
@@ -319,7 +328,7 @@ where
         owner: &str,
         method: &str,
         info: MethodInfo,
-    ) -> bool {
+    ) -> Result<bool, lasso::LassoErrorKind> {
         self.identity
             .register_anonymous_method(file, owner, method, info)
     }

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -2276,7 +2276,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         operand: InstRef,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<()> {
-        let self_sym = self.body_interner().get_or_intern("self");
+        let self_sym = self.intern_body_symbol("self")?;
         let mut current = operand;
         loop {
             let inst = self.body_rir_ref().get(current);

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -248,7 +248,10 @@ fn accessor_yield_root(
     interner: &lasso::ThreadedRodeo,
     operand: InstRef,
 ) -> Option<(AccessorYieldRootForm, Span)> {
-    let self_sym = interner.get_or_intern("self");
+    // Parser primitive setup interns `self` before semantic declaration
+    // validation. This boundary is lookup-only and therefore cannot extend a
+    // compilation-owned symbol domain.
+    let self_sym = interner.get("self").unwrap_or_default();
     let mut current = operand;
     loop {
         let inst = rir.get(current);

--- a/crates/rue-air/src/sema/known_symbols.rs
+++ b/crates/rue-air/src/sema/known_symbols.rs
@@ -25,7 +25,10 @@
 //! }
 //! ```
 
-use lasso::{Spur, ThreadedRodeo};
+use lasso::Spur;
+#[cfg(test)]
+use lasso::ThreadedRodeo;
+use rue_rir::SharedSymbolSpace;
 
 /// Pre-interned symbols for known strings.
 ///
@@ -183,70 +186,89 @@ impl KnownSymbols {
     /// Create a new `KnownSymbols` by interning all known strings.
     ///
     /// This should be called once during semantic-analysis setup.
+    #[cfg(test)]
     pub fn new(interner: &ThreadedRodeo) -> Self {
-        Self {
+        Self::with_intern(|text| {
+            Ok(interner
+                .try_get_or_intern_static(text)
+                .expect("test known-symbol fixture must fit its private interner"))
+        })
+        .expect("test known-symbol fixture must fit its private interner")
+    }
+
+    /// Build the known-symbol table through the revision-owned interner
+    /// policy. Exhaustion is latched by the shared space and reported at the
+    /// provider query boundary; no normal-build mutable override is involved.
+    pub fn new_in_space(space: &SharedSymbolSpace) -> Result<Self, lasso::LassoErrorKind> {
+        Self::with_intern(|text| space.try_intern(text))
+    }
+
+    fn with_intern(
+        mut intern: impl FnMut(&'static str) -> Result<Spur, lasso::LassoErrorKind>,
+    ) -> Result<Self, lasso::LassoErrorKind> {
+        Ok(Self {
             // Intrinsic names
-            dbg: interner.get_or_intern_static("dbg"),
-            drop: interner.get_or_intern_static("drop"),
-            int_cast: interner.get_or_intern_static("intCast"),
-            bit_cast: interner.get_or_intern_static("bitCast"),
-            cast: interner.get_or_intern_static("cast"),
-            panic: interner.get_or_intern_static("panic"),
-            assert: interner.get_or_intern_static("assert"),
-            read_line: interner.get_or_intern_static("read_line"),
-            to_string: interner.get_or_intern_static("to_string"),
-            print: interner.get_or_intern_static("print"),
-            println: interner.get_or_intern_static("println"),
-            parse_i32: interner.get_or_intern_static("parse_i32"),
-            parse_i64: interner.get_or_intern_static("parse_i64"),
-            parse_u32: interner.get_or_intern_static("parse_u32"),
-            parse_u64: interner.get_or_intern_static("parse_u64"),
-            test_preview_gate: interner.get_or_intern_static("test_preview_gate"),
-            import: interner.get_or_intern_static("import"),
-            random_u32: interner.get_or_intern_static("random_u32"),
-            random_u64: interner.get_or_intern_static("random_u64"),
-            arg_count: interner.get_or_intern_static("arg_count"),
-            arg_ptr: interner.get_or_intern_static("arg_ptr"),
-            arg_len: interner.get_or_intern_static("arg_len"),
-            env_count: interner.get_or_intern_static("env_count"),
-            env_ptr: interner.get_or_intern_static("env_ptr"),
-            env_len: interner.get_or_intern_static("env_len"),
-            wrapping_add: interner.get_or_intern_static("wrapping_add"),
-            wrapping_sub: interner.get_or_intern_static("wrapping_sub"),
-            wrapping_mul: interner.get_or_intern_static("wrapping_mul"),
+            dbg: intern("dbg")?,
+            drop: intern("drop")?,
+            int_cast: intern("intCast")?,
+            bit_cast: intern("bitCast")?,
+            cast: intern("cast")?,
+            panic: intern("panic")?,
+            assert: intern("assert")?,
+            read_line: intern("read_line")?,
+            to_string: intern("to_string")?,
+            print: intern("print")?,
+            println: intern("println")?,
+            parse_i32: intern("parse_i32")?,
+            parse_i64: intern("parse_i64")?,
+            parse_u32: intern("parse_u32")?,
+            parse_u64: intern("parse_u64")?,
+            test_preview_gate: intern("test_preview_gate")?,
+            import: intern("import")?,
+            random_u32: intern("random_u32")?,
+            random_u64: intern("random_u64")?,
+            arg_count: intern("arg_count")?,
+            arg_ptr: intern("arg_ptr")?,
+            arg_len: intern("arg_len")?,
+            env_count: intern("env_count")?,
+            env_ptr: intern("env_ptr")?,
+            env_len: intern("env_len")?,
+            wrapping_add: intern("wrapping_add")?,
+            wrapping_sub: intern("wrapping_sub")?,
+            wrapping_mul: intern("wrapping_mul")?,
 
             // Type intrinsics
 
             // Pointer intrinsics
-            ptr_read: interner.get_or_intern_static("ptr_read"),
-            ptr_write: interner.get_or_intern_static("ptr_write"),
-            ptr_read_unaligned: interner.get_or_intern_static("ptr_read_unaligned"),
-            ptr_write_unaligned: interner.get_or_intern_static("ptr_write_unaligned"),
-            ptr_offset: interner.get_or_intern_static("ptr_offset"),
-            ptr_to_int: interner.get_or_intern_static("ptr_to_int"),
-            int_to_ptr: interner.get_or_intern_static("int_to_ptr"),
-            raw: interner.get_or_intern_static("raw"),
-            raw_mut: interner.get_or_intern_static("raw_mut"),
-            field_ptr: interner.get_or_intern_static("field_ptr"),
-            place: interner.get_or_intern_static("place"),
-            syscall: interner.get_or_intern_static("syscall"),
-            alloc: interner.get_or_intern_static("alloc"),
-            free: interner.get_or_intern_static("free"),
-            realloc: interner.get_or_intern_static("realloc"),
-            alloc_zeroed: interner.get_or_intern_static("alloc_zeroed"),
-            resize: interner.get_or_intern_static("resize"),
-            byte_copy: interner.get_or_intern_static("byte_copy"),
-            byte_move: interner.get_or_intern_static("byte_move"),
-            byte_set: interner.get_or_intern_static("byte_set"),
+            ptr_read: intern("ptr_read")?,
+            ptr_write: intern("ptr_write")?,
+            ptr_read_unaligned: intern("ptr_read_unaligned")?,
+            ptr_write_unaligned: intern("ptr_write_unaligned")?,
+            ptr_offset: intern("ptr_offset")?,
+            ptr_to_int: intern("ptr_to_int")?,
+            int_to_ptr: intern("int_to_ptr")?,
+            raw: intern("raw")?,
+            raw_mut: intern("raw_mut")?,
+            field_ptr: intern("field_ptr")?,
+            place: intern("place")?,
+            syscall: intern("syscall")?,
+            alloc: intern("alloc")?,
+            free: intern("free")?,
+            realloc: intern("realloc")?,
+            alloc_zeroed: intern("alloc_zeroed")?,
+            resize: intern("resize")?,
+            byte_copy: intern("byte_copy")?,
+            byte_move: intern("byte_move")?,
+            byte_set: intern("byte_set")?,
 
             // Target platform intrinsics
-            target_arch: interner.get_or_intern_static("target_arch"),
-            target_os: interner.get_or_intern_static("target_os"),
-            target_data_model: interner.get_or_intern_static("target_data_model"),
+            target_arch: intern("target_arch")?,
+            target_os: intern("target_os")?,
+            target_data_model: intern("target_data_model")?,
             // Builtin type names
 
             // Special function names
-        }
+        })
     }
 
     /// Check if a symbol matches any of the parse intrinsics.

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -112,6 +112,14 @@ pub(crate) trait OrdinaryBodyAnalysisHost: BodyAnalysisReadHost + Sized {
     fn generated_structs(&self) -> &AHashMap<Spur, StructId>;
 
     fn body_interner(&self) -> &ThreadedRodeo;
+    /// Fallible form used by every body-derived spelling. Canonical hosts
+    /// route this through their owning revision symbol policy; standalone
+    /// hosts retain their private interner and its exact Lasso classification.
+    fn try_intern_body_symbol(&self, text: impl AsRef<str>) -> Result<Spur, lasso::LassoErrorKind> {
+        self.body_interner()
+            .try_get_or_intern(text)
+            .map_err(|error| error.kind())
+    }
     fn body_type_pool(&self) -> &TypeInternPool;
     fn struct_id_for_name(&self, name: Spur) -> Option<StructId>;
     fn generated_structs_mut(&mut self) -> &mut AHashMap<Spur, StructId>;
@@ -313,6 +321,17 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
     pub(crate) fn body_interner(&self) -> &ThreadedRodeo {
         self.storage.body_interner()
     }
+    pub(crate) fn intern_body_symbol(&self, text: impl AsRef<str>) -> CompileResult<Spur> {
+        self.storage.try_intern_body_symbol(text).map_err(|kind| {
+            CompileError::without_span(rue_error::interner_error_kind(
+                kind,
+                "body symbol interning failed",
+            ))
+        })
+    }
+    pub(crate) fn intern_index_path_segment(&self, index: u64) -> CompileResult<Spur> {
+        self.intern_body_symbol(index.to_string())
+    }
     pub(crate) fn body_type_pool(&self) -> &TypeInternPool {
         self.storage.body_type_pool()
     }
@@ -399,13 +418,17 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
     pub(crate) fn record_body_callable_dependency(&mut self, symbol: Spur) {
         self.storage.record_body_callable_dependency(symbol)
     }
-    pub(crate) fn record_body_method_dependency(&mut self, key: (StructId, Spur)) {
+    pub(crate) fn record_body_method_dependency(
+        &mut self,
+        key: (StructId, Spur),
+    ) -> CompileResult<()> {
         let Some(info) = self.method_info(key) else {
-            return;
+            return Ok(());
         };
         let symbol = self.method_symbol(key.0, self.body_interner().resolve(&key.1), info.has_self);
-        let symbol = self.body_interner().get_or_intern(&symbol);
+        let symbol = self.intern_body_symbol(&symbol)?;
         self.record_body_callable_dependency(symbol);
+        Ok(())
     }
     pub(crate) fn record_specialization_dependency(
         &mut self,
@@ -797,7 +820,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
     }
     pub(crate) fn get_or_create_str_struct(&mut self, _span: Span) -> CompileResult<Type> {
         use crate::types::{StructDef, StructField};
-        let type_sym = self.body_interner().get_or_intern("str");
+        let type_sym = self.intern_body_symbol("str")?;
         if let Some(struct_id) = self.storage.struct_id_for_name(type_sym) {
             return Ok(Type::new_struct(struct_id));
         }
@@ -997,8 +1020,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
     ) -> CompileResult<Type> {
         let symbols = segments
             .iter()
-            .map(|segment| self.body_interner().get_or_intern(segment))
-            .collect::<Vec<_>>();
+            .map(|segment| self.intern_body_symbol(segment))
+            .collect::<CompileResult<Vec<_>>>()?;
         let mut builder = rue_rir::RirTypeSyntaxBuilder::default();
         let root = builder.push_qualified_type(symbols).map_err(|failure| {
             CompileError::new(
@@ -1119,8 +1142,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         self.guard_anonymous_digest_collision(digest, &identity)?;
         let id = self.storage.body_type_pool().reserve_struct_id();
         let name = super::anon_structs::anonymous_struct_name(digest);
-        let name_spur = self.storage.body_interner().get_or_intern(&name);
-        let drop_marker = self.storage.body_interner().get_or_intern("__drop");
+        let name_spur = self.intern_body_symbol(&name)?;
+        let drop_marker = self.intern_body_symbol("__drop")?;
         let has_destructor = sigs.iter().any(|sig| sig.name == drop_marker);
         let is_copy = !has_destructor
             && fields
@@ -1176,7 +1199,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         let digest = self.stable_anonymous_identity_digest(&identity);
         self.guard_anonymous_digest_collision(digest, &identity)?;
         let name = super::anon_structs::anonymous_enum_name(digest);
-        let name_spur = self.storage.body_interner().get_or_intern(&name);
+        let name_spur = self.intern_body_symbol(&name)?;
         let def = crate::types::EnumDef {
             name: Arc::from(name.as_str()),
             variants: names.iter().map(|n| Arc::from(n.as_str())).collect(),
@@ -1556,7 +1579,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         for (_, ty, _, is_comptime) in &param_info {
             reject_runtime_type_value(*ty, *is_comptime, span)?;
         }
-        let function_symbol = self.storage.body_interner().get_or_intern(fn_name);
+        let function_symbol = self.intern_body_symbol(fn_name)?;
         let producer = self
             .canonical_function_producer(function_symbol, &AHashMap::new(), &AHashMap::new())
             .map_err(|failure| {
@@ -1642,7 +1665,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         AHashSet<Spur>,
         std::collections::HashSet<(StructId, Spur)>,
     )> {
-        let symbol = self.storage.body_interner().get_or_intern(full_name);
+        let symbol = self.intern_body_symbol(full_name)?;
         let identity = crate::FunctionInstanceKey::Definition(
             self.storage.function_identity(symbol).map_err(|failure| {
                 CompileError::new(
@@ -1653,7 +1676,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
                 )
             })?,
         );
-        let self_name = self.storage.body_interner().get_or_intern("self");
+        let self_name = self.intern_body_symbol("self")?;
         let mut resolved_params = Vec::with_capacity(params.len() + usize::from(has_self));
         if has_self {
             resolved_params.push((self_name, struct_type, self_mode, false));
@@ -1708,7 +1731,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         let struct_id = struct_type
             .as_struct()
             .expect("method receiver must be a struct");
-        let self_type_name = self.storage.body_interner().get_or_intern("Self");
+        let self_type_name = self.intern_body_symbol("Self")?;
         let mut type_subst = self.storage.anon_struct_type_subst(struct_id);
         type_subst.insert(self_type_name, struct_type);
         let captured_values = self.storage.anon_struct_captured_values(struct_id);
@@ -1786,10 +1809,10 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         AHashSet<Spur>,
         std::collections::HashSet<(StructId, Spur)>,
     )> {
-        let self_name = self.storage.body_interner().get_or_intern("self");
+        let self_name = self.intern_body_symbol("self")?;
         let params = [(self_name, struct_type, RirParamMode::Normal, false)];
         let identity_token = self.storage.function_identity(
-            self.storage.body_interner().get_or_intern(full_name),
+            self.intern_body_symbol(full_name)?,
         ).map_err(|failure| {
             CompileError::new(
                 ErrorKind::InternalError(format!(
@@ -1954,7 +1977,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         // every method body — named or anonymous struct — that actually
         // reaches analysis. By-value `self` (Normal) and destructors are
         // unaffected.
-        let self_sym = self.body_interner().get_or_intern("self");
+        let self_sym = self.intern_body_symbol("self")?;
         if let Some((_, _, mode, _)) = params
             .iter()
             .find(|(name, _, mode, _)| *name == self_sym && *mode != RirParamMode::Normal)

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -12,7 +12,7 @@ use std::time::Instant;
 
 use ahash::{AHashMap, AHashSet};
 use lasso::{Spur, ThreadedRodeo};
-use rue_error::{CompileError, CompileResult, PreviewFeatures};
+use rue_error::{CompileError, CompileResult, ErrorKind, PreviewFeatures};
 use rue_rir::{
     InstData, InstRef, Rir, RirParam, RirParamMode, RirTypeSyntaxBuilder, RirTypeSyntaxRef,
     SymbolHandle,
@@ -96,6 +96,7 @@ fn publish_provider_body_breakdown(
     );
 }
 
+#[cfg(test)]
 fn intern_synthetic_argument_name(interner: &ThreadedRodeo, index: usize) -> Spur {
     let mut bytes = [0_u8; 3 + 20];
     bytes[..3].copy_from_slice(b"arg");
@@ -116,6 +117,29 @@ fn intern_synthetic_argument_name(interner: &ThreadedRodeo, index: usize) -> Spu
     interner.get_or_intern(name)
 }
 
+fn intern_synthetic_argument_name_in_space(
+    space: &rue_rir::SharedSymbolSpace,
+    index: usize,
+) -> Option<Spur> {
+    let mut bytes = [0_u8; 3 + 20];
+    bytes[..3].copy_from_slice(b"arg");
+    let mut value = index;
+    let mut start = bytes.len();
+    loop {
+        start -= 1;
+        bytes[start] = b'0' + (value % 10) as u8;
+        value /= 10;
+        if value == 0 {
+            break;
+        }
+    }
+    let digits = bytes.len() - start;
+    bytes.copy_within(start.., 3);
+    let end = 3 + digits;
+    let name = std::str::from_utf8(&bytes[..end]).expect("synthetic argument name is ASCII");
+    space.try_intern(name).ok()
+}
+
 /// The one spelling of a member callable name, built from an already-rendered
 /// owner component.
 ///
@@ -130,6 +154,19 @@ fn member_callable_name_for_owner(owner: &str, method: &str, has_self: bool) -> 
     name.push_str(separator);
     name.push_str(method);
     name
+}
+
+fn check_shared_interner(
+    space: &rue_rir::SharedSymbolSpace,
+    phase: &'static str,
+) -> CompileResult<()> {
+    if let Some(kind) = space.interner_failure() {
+        return Err(CompileError::without_span(rue_error::interner_error_kind(
+            kind,
+            format!("{phase} shared symbol interner failed: {kind}"),
+        )));
+    }
+    Ok(())
 }
 
 fn append_file_callable_name(mut module_path: String, name: &str) -> String {
@@ -956,6 +993,19 @@ where
     K: Clone + Eq + Hash + Ord,
     M: Clone + Eq + Hash + Ord,
 {
+    fn intern_name(&self, name: impl AsRef<str>) -> Option<Spur> {
+        self.state.symbol_space().try_intern(name).ok()
+    }
+
+    fn intern_name_at(&self, name: impl AsRef<str>, span: Span) -> CompileResult<Spur> {
+        self.state.symbol_space().try_intern(name).map_err(|kind| {
+            CompileError::new(
+                rue_error::interner_error_kind(kind, "provider-generated symbol interning failed"),
+                span,
+            )
+        })
+    }
+
     fn issued_anonymous_identity_for_type(
         &self,
         ty: Type,
@@ -990,27 +1040,43 @@ where
         target: Target,
         preview: PreviewFeatures,
         well_known: &ProviderWellKnownOptionFacts<K, M>,
-    ) -> Option<Self> {
-        let state = bundle.provider_body_state(source.clone());
+    ) -> Result<Option<Self>, super::body_identity::IdentityMintError> {
+        let state = bundle.try_provider_body_state(source.clone())?;
         let rir = bundle.view();
         let endpoint = ProviderEndpointFacts::with_state(provider, &state, rir.clone());
         let calls = ProviderCallFacts::with_state(provider, &state, rir.clone());
         let mut aggregate = ProviderAggregateFacts::with_state(&state);
         if let Some(locator) = source.definition_source(&key) {
             if locator.file_id != file {
-                return None;
+                return Ok(None);
             }
             aggregate.register_file_path(file, &locator.physical_path);
         }
-        let function_token =
-            endpoint.register_body_owner(key.clone(), file, name, owner_kind, owner_name);
-        let function_symbol = state.identity_context().name_symbol(name);
+        let function_token = endpoint
+            .register_body_owner(key.clone(), file, name, owner_kind, owner_name)
+            .ok_or(super::body_identity::IdentityMintError::Interner(
+                state
+                    .symbol_space()
+                    .interner_failure()
+                    .unwrap_or(lasso::LassoErrorKind::FailedAllocation),
+            ))?;
+        let function_symbol = state
+            .symbol_space()
+            .try_intern(name)
+            .map_err(super::body_identity::IdentityMintError::Interner)?;
         let interner = state.interner();
         let type_pool = state.type_pool();
-        let known = KnownSymbols::new(&interner);
-        endpoint
-            .install_well_known_option_types(&well_known.nominals, &well_known.option_by_payload)?;
-        endpoint.finalize_containment_metadata()?;
+        let known = KnownSymbols::new_in_space(state.symbol_space())
+            .map_err(super::body_identity::IdentityMintError::Interner)?;
+        if endpoint
+            .install_well_known_option_types(&well_known.nominals, &well_known.option_by_payload)
+            .is_none()
+        {
+            return Ok(None);
+        }
+        if endpoint.finalize_containment_metadata().is_none() {
+            return Ok(None);
+        }
         let mut host = Self {
             endpoint,
             calls,
@@ -1079,9 +1145,14 @@ where
             current_anonymous_identity: None,
         };
         for identity in &well_known.nominals {
-            host.install_canonical_anonymous_identity(identity)?;
+            if host
+                .install_canonical_anonymous_identity(identity)
+                .is_none()
+            {
+                return Ok(None);
+            }
         }
-        Some(host)
+        Ok(Some(host))
     }
 
     fn push_durable_type_syntax(
@@ -1092,9 +1163,7 @@ where
     ) -> Option<RirTypeSyntaxRef> {
         use crate::SemanticImportType as T;
         let named = |builder: &mut RirTypeSyntaxBuilder<Spur>, name: &str| {
-            builder
-                .push_named_type(self.interner.get_or_intern(name))
-                .ok()
+            builder.push_named_type(self.intern_name(name)?).ok()
         };
         match ty {
             T::I8 => named(builder, "i8"),
@@ -1176,10 +1245,16 @@ where
         syntax: &crate::DurableCallableTypeSyntax,
     ) -> Option<ProviderCallableTypeSyntax> {
         let mut builder = RirTypeSyntaxBuilder::default();
+        for symbol in syntax.syntax.symbols().iter() {
+            self.intern_name(symbol.as_ref())?;
+        }
         let mapped = builder
             .append_remapped(
                 &syntax.syntax,
-                |symbol| self.interner.get_or_intern(symbol.as_ref()),
+                |symbol| {
+                    self.intern_name(symbol.as_ref())
+                        .expect("type-syntax symbols were admitted before remapping")
+                },
                 || Ok::<_, std::convert::Infallible>(()),
             )
             .ok()?;
@@ -1344,7 +1419,7 @@ where
             .resolve_function_call_from(&key, &function, returns_type, file)
             .ok()?;
         self.install_durable_callable_metadata(info, &function, false, exact_type_syntax, file);
-        let token = self.endpoint.register_function(key.clone(), file, &name);
+        let token = self.endpoint.register_function(key.clone(), file, &name)?;
         self.function_infos.borrow_mut().insert(symbol, info);
         self.function_tokens
             .borrow_mut()
@@ -1404,24 +1479,27 @@ where
                 let token = match kind {
                     crate::StableDefinitionKind::Struct | crate::StableDefinitionKind::Enum => self
                         .endpoint
-                        .register_named_nominal(definition.clone(), file.index(), &name, kind),
-                    crate::StableDefinitionKind::Function => {
-                        self.endpoint
-                            .register_function(definition.clone(), file, &name)
-                    }
+                        .register_named_nominal(definition.clone(), file.index(), &name, kind)
+                        .ok_or(())?,
+                    crate::StableDefinitionKind::Function => self
+                        .endpoint
+                        .register_function(definition.clone(), file, &name)
+                        .ok_or(())?,
                     crate::StableDefinitionKind::ValueConst
                     | crate::StableDefinitionKind::ModuleBinding
                     | crate::StableDefinitionKind::Destructor
                     | crate::StableDefinitionKind::Method
                     | crate::StableDefinitionKind::AssociatedFunction => {
                         let owner = self.source.definition_owner_name(definition);
-                        self.endpoint.register_body_owner(
-                            definition.clone(),
-                            file,
-                            &name,
-                            kind,
-                            owner.as_deref(),
-                        )
+                        self.endpoint
+                            .register_body_owner(
+                                definition.clone(),
+                                file,
+                                &name,
+                                kind,
+                                owner.as_deref(),
+                            )
+                            .ok_or(())?
                     }
                 };
                 self.anonymous_definition_tokens
@@ -1472,10 +1550,10 @@ where
         }
         let module = self.modules_by_file.borrow().get(&file)?.clone();
         let name = self.interner.resolve(&source_symbol);
-        let internal = self.interner.get_or_intern(append_file_callable_name(
+        let internal = self.intern_name(append_file_callable_name(
             self.source.module_path(&module),
             name,
-        ));
+        ))?;
         if self.function_infos.borrow().contains_key(&internal) {
             return Some(internal);
         }
@@ -1502,7 +1580,7 @@ where
             .resolve_function_call_from(&key, &function, returns_type, file)
             .ok()?;
         self.install_durable_callable_metadata(info, &function, false, exact_type_syntax, file);
-        let token = self.endpoint.register_function(key.clone(), file, name);
+        let token = self.endpoint.register_function(key.clone(), file, name)?;
         self.function_infos.borrow_mut().insert(internal, info);
         self.function_tokens
             .borrow_mut()
@@ -1634,7 +1712,12 @@ where
         self.type_pool.struct_symbol_name(struct_id)
     }
 
-    fn member_callable_symbol(&self, struct_id: StructId, method: &str, has_self: bool) -> Spur {
+    fn member_callable_symbol(
+        &self,
+        struct_id: StructId,
+        method: &str,
+        has_self: bool,
+    ) -> Option<Spur> {
         self.member_callable_symbol_for_owner(
             &self.member_callable_owner(struct_id),
             method,
@@ -1642,9 +1725,13 @@ where
         )
     }
 
-    fn member_callable_symbol_for_owner(&self, owner: &str, method: &str, has_self: bool) -> Spur {
-        self.interner
-            .get_or_intern(member_callable_name_for_owner(owner, method, has_self))
+    fn member_callable_symbol_for_owner(
+        &self,
+        owner: &str,
+        method: &str,
+        has_self: bool,
+    ) -> Option<Spur> {
+        self.intern_name(member_callable_name_for_owner(owner, method, has_self))
     }
 
     /// The handle for a member callable of an owner whose own spelling the
@@ -1671,16 +1758,16 @@ where
         method_symbol: Spur,
         method: &str,
         has_self: bool,
-    ) -> Spur {
+    ) -> Option<Spur> {
         let Some(owner_symbol) = owner_symbol else {
             return self.member_callable_symbol_for_owner(owner, method, has_self);
         };
-        self.state.symbol_space().derived_symbol(
-            owner_symbol,
-            method_symbol,
-            u8::from(has_self),
-            || member_callable_name_for_owner(owner, method, has_self),
-        )
+        self.state
+            .symbol_space()
+            .try_derived_symbol(owner_symbol, method_symbol, u8::from(has_self), || {
+                member_callable_name_for_owner(owner, method, has_self)
+            })
+            .ok()
     }
 
     /// The handle the shared space already holds for an owner's own spelling,
@@ -1732,7 +1819,7 @@ where
             info.returns_borrow = *returns_borrow;
             info.returns_inout = *returns_inout;
         }
-        let full_symbol = self.member_callable_symbol(struct_id, name, has_self);
+        let full_symbol = self.member_callable_symbol(struct_id, name, has_self)?;
         let token = self.endpoint.register_body_owner(
             key.clone(),
             self.owner_file,
@@ -1743,7 +1830,7 @@ where
                 crate::StableDefinitionKind::AssociatedFunction
             },
             Some(&owner),
-        );
+        )?;
         self.function_tokens
             .borrow_mut()
             .insert(full_symbol, (token, key));
@@ -1809,7 +1896,7 @@ where
         }
         let info = self.named_method_info_for_symbol(struct_id, symbol)?;
         let full_symbol =
-            self.member_callable_symbol(struct_id, self.interner.resolve(&symbol), info.has_self);
+            self.member_callable_symbol(struct_id, self.interner.resolve(&symbol), info.has_self)?;
         self.function_tokens
             .borrow()
             .get(&full_symbol)
@@ -1959,11 +2046,11 @@ where
             let source_symbol = info.value.as_function()?.spur();
             let alias_symbol =
                 if let Some(module) = self.source.foreign_function_module(&self.key, &function) {
-                    self.interner.get_or_intern(&format!(
+                    self.intern_name(format!(
                         "{}${}",
                         self.source.module_path(&module),
                         self.source.definition_name(&function)?
-                    ))
+                    ))?
                 } else {
                     source_symbol
                 };
@@ -2000,7 +2087,7 @@ where
         };
         let token = self
             .endpoint
-            .register_named_nominal(key.clone(), file.index(), name, kind);
+            .register_named_nominal(key.clone(), file.index(), name, kind)?;
         let imported = crate::SemanticImportType::Nominal(key.clone());
         self.register_import_nominal_identities(&imported).ok()?;
         let ty = self
@@ -2033,12 +2120,15 @@ where
                 crate::DurableNominalBody::Struct { .. } => crate::StableDefinitionKind::Struct,
                 crate::DurableNominalBody::Enum { .. } => crate::StableDefinitionKind::Enum,
             };
-            let token = self.endpoint.register_named_nominal(
-                key.clone(),
-                self.owner_file.index(),
-                nominal.name.as_ref(),
-                kind,
-            );
+            let token = self
+                .endpoint
+                .register_named_nominal(
+                    key.clone(),
+                    self.owner_file.index(),
+                    nominal.name.as_ref(),
+                    kind,
+                )
+                .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)?;
             self.nominal_tokens
                 .borrow_mut()
                 .insert(ty, (token, key.clone()));
@@ -2048,9 +2138,10 @@ where
         else {
             return Err(crate::SemanticBodyExportFailure::MissingStableIdentity);
         };
-        let token =
-            self.endpoint
-                .register_named_nominal(key.clone(), self.owner_file.index(), name, kind);
+        let token = self
+            .endpoint
+            .register_named_nominal(key.clone(), self.owner_file.index(), name, kind)
+            .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)?;
         self.nominal_tokens
             .borrow_mut()
             .insert(ty, (token, key.clone()));
@@ -2134,12 +2225,15 @@ where
                 crate::DurableNominalBody::Struct { .. } => crate::StableDefinitionKind::Struct,
                 crate::DurableNominalBody::Enum { .. } => crate::StableDefinitionKind::Enum,
             };
-            let token = self.endpoint.register_named_nominal(
-                key.clone(),
-                self.owner_file.index(),
-                nominal.name.as_ref(),
-                kind,
-            );
+            let token = self
+                .endpoint
+                .register_named_nominal(
+                    key.clone(),
+                    self.owner_file.index(),
+                    nominal.name.as_ref(),
+                    kind,
+                )
+                .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)?;
             self.nominal_tokens
                 .borrow_mut()
                 .insert(ty, (token, key.clone()));
@@ -2244,12 +2338,15 @@ where
                         .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)?
                         .resolve_provider_type(value)
                         .map_err(|_| crate::SemanticBodyExportFailure::MissingStableIdentity)?;
-                    let token = self.endpoint.register_named_nominal(
-                        key.clone(),
-                        self.owner_file.index(),
-                        nominal.name.as_ref(),
-                        kind,
-                    );
+                    let token = self
+                        .endpoint
+                        .register_named_nominal(
+                            key.clone(),
+                            self.owner_file.index(),
+                            nominal.name.as_ref(),
+                            kind,
+                        )
+                        .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)?;
                     registration_token = Some(token);
                     self.import_nominal_registrations
                         .borrow_mut()
@@ -2485,14 +2582,11 @@ where
             V::Bool(value) => ConstValue::Bool(*value),
             V::Type(ty) => ConstValue::Type(self.materialize_durable_type(ty)?),
             V::Function(definition) => ConstValue::Function(
-                self.interner
-                    .get_or_intern(&self.source.definition_name(definition)?)
+                self.intern_name(&self.source.definition_name(definition)?)?
                     .into(),
             ),
             V::Unit => ConstValue::Unit,
-            V::String(value) => {
-                ConstValue::String(self.interner.get_or_intern(value.as_ref()).into())
-            }
+            V::String(value) => ConstValue::String(self.intern_name(value.as_ref())?.into()),
         })
     }
 
@@ -2751,14 +2845,14 @@ where
                 .map(|(ty, _, _)| resolve(ty))
                 .collect::<Option<Vec<_>>>()?;
             let return_type = resolve(&method.result)?;
-            let name = self.interner.get_or_intern(method.name.as_ref());
+            let name = self.intern_name(method.name.as_ref())?;
             let callable = self.member_callable_symbol_for_issued_owner(
                 owner_symbol,
                 &owner_name,
                 name,
                 &method.name,
                 method.has_self,
-            );
+            )?;
             let kind = if method.name.as_ref() == "__drop" {
                 crate::AnonymousMemberKind::Destructor
             } else if method.has_self {
@@ -2784,9 +2878,13 @@ where
             if self.endpoint.method_info(struct_id, name).is_some() {
                 continue;
             }
+            let parameter_names = (0..parameter_types.len())
+                .map(|index| {
+                    intern_synthetic_argument_name_in_space(self.state.symbol_space(), index)
+                })
+                .collect::<Option<Vec<_>>>()?;
             let params = self.state.allocate_params(
-                (0..parameter_types.len())
-                    .map(|index| intern_synthetic_argument_name(&self.interner, index)),
+                parameter_names,
                 parameter_types.iter().copied(),
                 method.parameters.iter().map(|(_, mode, _)| *mode),
                 method.parameters.iter().map(|(_, _, comptime)| *comptime),
@@ -2903,14 +3001,14 @@ where
             .anonymous_definition_module(identity)
             .is_some_and(|module| self.source.module_is_trusted_standard_library(&module));
         for method in methods {
-            let name = self.interner.get_or_intern(method.name.as_ref());
+            let name = self.intern_name(method.name.as_ref())?;
             let callable = self.member_callable_symbol_for_issued_owner(
                 owner_symbol,
                 &owner_name,
                 name,
                 &method.name,
                 method.has_self,
-            );
+            )?;
             let kind = if method.name.as_ref() == "__drop" {
                 crate::AnonymousMemberKind::Destructor
             } else if method.has_self {
@@ -2933,6 +3031,11 @@ where
             if self.endpoint.method_info(struct_id, name).is_some() {
                 continue;
             }
+            let parameter_names = (0..method.parameters.len())
+                .map(|index| {
+                    intern_synthetic_argument_name_in_space(self.state.symbol_space(), index)
+                })
+                .collect::<Option<Vec<_>>>()?;
             self.anonymous_methods.borrow_mut().insert(
                 (struct_id, name),
                 MethodCallInfo {
@@ -2946,8 +3049,7 @@ where
                     returns_borrow: trusted_std_accessor_owner && method.returns_borrow,
                     returns_inout: trusted_std_accessor_owner && method.returns_inout,
                     params: self.state.allocate_params(
-                        (0..method.parameters.len())
-                            .map(|index| intern_synthetic_argument_name(&self.interner, index)),
+                        parameter_names,
                         method
                             .parameters
                             .iter()
@@ -2990,9 +3092,11 @@ where
                 ConstValue::Type(self.materialize_type_instance(ty)?)
             }
             CanonicalArgumentValue::Unit => ConstValue::Unit,
-            CanonicalArgumentValue::String(value) => {
-                ConstValue::String(self.interner.get_or_intern(value.as_ref()).into())
-            }
+            CanonicalArgumentValue::String(value) => ConstValue::String(
+                self.intern_name(value.as_ref())
+                    .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)?
+                    .into(),
+            ),
             CanonicalArgumentValue::Function(function) => {
                 let FunctionInstanceKey::Definition(definition) = function.as_ref() else {
                     return Err(crate::SemanticBodyExportFailure::MissingStableIdentity);
@@ -3001,10 +3105,13 @@ where
                     .source
                     .definition_name(definition)
                     .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)?;
-                let symbol = self.interner.get_or_intern(&name);
-                let token =
-                    self.endpoint
-                        .register_function(definition.clone(), self.owner_file, &name);
+                let symbol = self
+                    .intern_name(&name)
+                    .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)?;
+                let token = self
+                    .endpoint
+                    .register_function(definition.clone(), self.owner_file, &name)
+                    .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)?;
                 self.function_tokens
                     .borrow_mut()
                     .insert(symbol, (token, definition.clone()));
@@ -3351,7 +3458,9 @@ where
     M: Clone + Eq + Hash + Ord,
 {
     fn type_syntax_symbol(&mut self, name: &str) -> Spur {
-        self.interner.get_or_intern(name)
+        self.state.symbol_space().try_intern(name).expect(
+            "type-syntax symbol interning must succeed before this infallible legacy boundary",
+        )
     }
 
     fn type_syntax_module_binding(
@@ -3466,7 +3575,10 @@ where
     }
 
     fn type_syntax_make_str(&mut self, span: Span) -> CompileResult<Type> {
-        let name = self.interner.get_or_intern("str");
+        let name =
+            self.state.symbol_space().try_intern("str").expect(
+                "builtin str interning must succeed before this infallible legacy boundary",
+            );
         self.nominal_type_for_symbol(span.file_id, name)
             .filter(|ty| ty.as_struct().is_some())
             .ok_or_else(|| {
@@ -3540,8 +3652,11 @@ where
                     span,
                 )
             })?;
-        self.generated_structs
-            .insert(self.interner.get_or_intern(&format!("Str({capacity})")), id);
+        let name = self
+            .interner
+            .get(format!("Str({capacity})"))
+            .expect("generated Str name must be admitted before publication");
+        self.generated_structs.insert(name, id);
         Ok(Type::new_struct(id))
     }
 
@@ -3581,7 +3696,10 @@ where
             .parameters
             .iter()
             .map(|parameter| crate::SemanticTypeConstructorParameter {
-                name: self.interner.get_or_intern(parameter.name.as_ref()),
+                name: self
+                    .interner
+                    .get(parameter.name.as_ref())
+                    .expect("signature parameter names must be admitted before analysis"),
                 is_comptime: parameter.is_comptime,
                 is_type: matches!(parameter.ty, crate::SemanticImportType::ComptimeType),
             })
@@ -3871,6 +3989,9 @@ where
     }
     fn body_interner(&self) -> &ThreadedRodeo {
         &self.interner
+    }
+    fn try_intern_body_symbol(&self, text: impl AsRef<str>) -> Result<Spur, lasso::LassoErrorKind> {
+        self.state.symbol_space().try_intern(text)
     }
     fn body_type_pool(&self) -> &TypeInternPool {
         // This accessor is the engine's containment-read boundary. The pool's
@@ -4410,16 +4531,16 @@ where
         self.target
     }
     fn builtin_arch_id(&self) -> Option<EnumId> {
-        self.endpoint
-            .endpoint_builtin_enum(self.interner.get_or_intern_static("Arch"))
+        self.intern_name("Arch")
+            .and_then(|symbol| self.endpoint.endpoint_builtin_enum(symbol))
     }
     fn builtin_os_id(&self) -> Option<EnumId> {
-        self.endpoint
-            .endpoint_builtin_enum(self.interner.get_or_intern_static("Os"))
+        self.intern_name("Os")
+            .and_then(|symbol| self.endpoint.endpoint_builtin_enum(symbol))
     }
     fn builtin_data_model_id(&self) -> Option<EnumId> {
-        self.endpoint
-            .endpoint_builtin_enum(self.interner.get_or_intern_static("DataModel"))
+        self.intern_name("DataModel")
+            .and_then(|symbol| self.endpoint.endpoint_builtin_enum(symbol))
     }
     fn destructor_span(&self, _struct_id: StructId) -> Option<Span> {
         None
@@ -4574,6 +4695,20 @@ where
 }
 
 /// Run the canonical ordinary expression engine over one exact local RIR.
+fn identity_mint_compile_error(error: super::body_identity::IdentityMintError) -> CompileError {
+    match error {
+        super::body_identity::IdentityMintError::Interner(kind) => {
+            CompileError::without_span(rue_error::interner_error_kind(
+                kind,
+                format!("provider semantic interner failed while minting a symbol: {kind}"),
+            ))
+        }
+        other => CompileError::without_span(ErrorKind::InternalError(format!(
+            "provider identity bootstrap failed: {other:?}"
+        ))),
+    }
+}
+
 pub fn analyze_provider_ordinary_body<P, S, K, M>(
     provider: &P,
     source: S,
@@ -4596,349 +4731,377 @@ where
     K: Clone + Eq + Hash + Ord,
     M: Clone + Eq + Hash + Ord,
 {
-    let owner_file = bundle.source_file_id().ok_or_else(|| {
-        CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-            "provider body RIR does not have one source file".into(),
-        ))
-    })?;
-    let host_setup_started = Instant::now();
-    let mut host = ProviderBodyHost::new(
-        provider, source, bundle, key, owner_file, name, owner_kind, owner_name, target, preview,
-        well_known,
-    )
-    .ok_or_else(|| {
-        CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-            "provider body host could not be constructed".into(),
-        ))
-    })?;
-    let initial_anonymous_identities = host
-        .canonical_anonymous_types
-        .values()
-        .cloned()
-        .collect::<AHashSet<_>>();
-    let infer = InferenceContext::new(&host);
-    let host_setup_ns = elapsed_ns(host_setup_started);
-    let expression_engine_started = Instant::now();
-    let (analyzed, body_span) = match owner_kind {
-        crate::StableDefinitionKind::Function => {
-            let info = host
-                .endpoint
-                .endpoint_function_info(host.function_symbol)
-                .ok_or_else(|| {
-                    CompileError::without_span(rue_error::ErrorKind::UndefinedFunction(
-                        name.to_owned(),
-                    ))
-                })?;
-            let declaration = host
-                .endpoint
-                .first_free_function(name, owner_file)
-                .ok_or_else(|| {
-                    CompileError::without_span(rue_error::ErrorKind::UndefinedFunction(
-                        name.to_owned(),
-                    ))
-                })?;
-            host.reject_free_function_accessor(declaration)?;
-            let (return_type, body) = match &host.rir.rir().get(declaration).data {
-                InstData::FnDecl {
-                    return_type, body, ..
-                } => (*return_type, *body),
-                _ => unreachable!("registered provider function points at FnDecl"),
-            };
-            let body_span = host.rir.rir().get(body).span;
-            // The durable call-site signature may normalize body-local types
-            // such as `Str(N)` to their coercion surface. Resolve the exact
-            // declared return spelling for body checking; explicit parameters
-            // retain their exact canonical facts and need no second lookup.
-            let return_type = host.resolve_body_type(return_type, info.span)?;
-            let params = host
-                .state
-                .param_data(info.params)
-                .iter()
-                .map(|(name, ty, mode, comptime)| (*name, *ty, *mode, *comptime))
-                .collect();
-            host.endpoint
-                .finalize_containment_metadata()
-                .ok_or_else(|| {
-                    CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-                        "provider function containment metadata is unavailable".into(),
-                    ))
-                })?;
-            (
-                OrdinaryBodyEngine::new(&mut host).analyze_single_function_resolved(
-                    &infer,
-                    name,
-                    return_type,
-                    params,
-                    body,
-                    info.span,
-                    info.allow_unused_variable,
-                    info.allow_unreachable_code,
-                )?,
-                body_span,
-            )
-        }
-        crate::StableDefinitionKind::Method | crate::StableDefinitionKind::AssociatedFunction => {
-            let owner_name = owner_name.ok_or_else(|| {
-                CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-                    "provider member body has no owner".into(),
-                ))
-            })?;
-            let declaration = host
-                .endpoint
-                .named_method_declaration(owner_file, owner_name, name)
-                .ok_or_else(|| {
-                    CompileError::without_span(rue_error::ErrorKind::UndefinedFunction(
-                        name.to_owned(),
-                    ))
-                })?;
-            let info = host
-                .calls
-                .method_info(&host.key, owner_file, owner_name, name)
-                .ok_or_else(|| {
-                    CompileError::without_span(rue_error::ErrorKind::UndefinedFunction(
-                        name.to_owned(),
-                    ))
-                })?;
-            let (return_type, body) = match &host.rir.rir().get(declaration).data {
-                InstData::FnDecl {
-                    return_type, body, ..
-                } => (*return_type, *body),
-                _ => unreachable!("registered provider member points at FnDecl"),
-            };
-            let body_span = host.rir.rir().get(body).span;
-            let return_type = if matches!(
-                host.rir.rir().type_syntax().node(return_type),
-                Some(rue_rir::RirTypeSyntaxNode::Named(symbol))
-                    if host.rir.rir().type_syntax().symbol(*symbol)
-                        .is_some_and(|symbol| host.interner.resolve(symbol) == "Self")
-            ) {
-                info.struct_type
-            } else {
-                host.resolve_body_type(return_type, info.span)?
-            };
-            let params = host
-                .state
-                .param_data(info.params)
-                .iter()
-                .map(|(name, ty, mode, comptime)| (*name, *ty, *mode, *comptime))
-                .collect();
-            let full_name = host.member_callable_name(
-                info.struct_type
-                    .as_struct()
-                    .expect("named method receiver must be a struct"),
-                name,
-                info.has_self,
-            );
-            let full_symbol = host.interner.get_or_intern(&full_name);
-            let owner_token = host.function_tokens.borrow()[&host.function_symbol].clone();
-            host.function_tokens
-                .borrow_mut()
-                .insert(full_symbol, owner_token);
-            host.endpoint
-                .finalize_containment_metadata()
-                .ok_or_else(|| {
-                    CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-                        "provider method containment metadata is unavailable".into(),
-                    ))
-                })?;
-            (
-                OrdinaryBodyEngine::new(&mut host).analyze_named_method_resolved(
-                    &infer,
-                    &full_name,
-                    return_type,
-                    params,
-                    body,
-                    info.span,
-                    info.struct_type,
-                    info.has_self,
-                    info.self_mode,
-                    info.self_is_mut,
-                    info.returns_borrow,
-                    info.returns_inout,
-                )?,
-                body_span,
-            )
-        }
-        crate::StableDefinitionKind::Destructor => {
-            let owner_name = owner_name.ok_or_else(|| {
-                CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-                    "provider destructor body has no owner".into(),
-                ))
-            })?;
-            let declaration = host
-                .endpoint
-                .destructor(owner_file, owner_name)
-                .ok_or_else(|| {
-                    CompileError::without_span(rue_error::ErrorKind::UndefinedFunction(format!(
-                        "{owner_name}.__drop"
-                    )))
-                })?;
-            let (body, declaration_span) = match &host.rir.rir().get(declaration).data {
-                InstData::DropFnDecl { body, .. } => (*body, host.rir.rir().get(declaration).span),
-                _ => unreachable!("registered provider destructor points at DropFnDecl"),
-            };
-            let body_span = host.rir.rir().get(body).span;
-            let owner_symbol = host.interner.get_or_intern(owner_name);
-            let owner_type = host
-                .nominal_type_for_symbol(owner_file, owner_symbol)
-                .ok_or_else(|| {
-                    CompileError::without_span(rue_error::ErrorKind::UnknownType(
-                        owner_name.to_owned(),
-                    ))
-                })?;
-            let full_name = format!(
-                "{}.__drop",
-                host.type_pool.struct_symbol_name(
-                    owner_type
-                        .as_struct()
-                        .expect("named destructor owner must be a struct")
-                )
-            );
-            let full_symbol = host.interner.get_or_intern(&full_name);
-            let owner_token = host.function_tokens.borrow()[&host.function_symbol].clone();
-            host.function_tokens
-                .borrow_mut()
-                .insert(full_symbol, owner_token);
-            host.endpoint
-                .finalize_containment_metadata()
-                .ok_or_else(|| {
-                    CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-                        "provider destructor containment metadata is unavailable".into(),
-                    ))
-                })?;
-            (
-                OrdinaryBodyEngine::new(&mut host).analyze_named_destructor(
-                    &infer,
-                    &full_name,
-                    body,
-                    declaration_span,
-                    owner_type,
-                )?,
-                body_span,
-            )
-        }
-        _ => {
-            return Err(CompileError::without_span(
-                rue_error::ErrorKind::InvalidCompilerInput(
-                    "provider body request does not own an executable body".into(),
-                ),
-            ));
-        }
-    };
-    let expression_engine_ns = elapsed_ns(expression_engine_started);
-    let expression_breakdown = host
-        .expression_breakdown
-        .expect("provider ordinary body analysis records its expression breakdown");
-    let specialization_selection_started = Instant::now();
-    let (mut function, warnings, strings, referenced_functions, referenced_methods) = analyzed;
-    function.ordinary_owner = Some(host.owner);
-    let (function, selected_calls, mut referenced_specializations) =
-        crate::specialize::select_provider_body_specializations(&mut host, function)?;
-    referenced_specializations.extend(referenced_methods.iter().filter_map(|(owner, method)| {
-        let info = host.method_info_for_symbol(*owner, *method)?;
-        let callable =
-            host.member_callable_symbol(*owner, host.interner.resolve(method), info.has_self);
-        host.anonymous_function_identities
-            .borrow()
-            .get(&callable)
+    let result = (|| -> CompileResult<ProviderOrdinaryBody<K, M>> {
+        let owner_file = bundle.source_file_id().ok_or_else(|| {
+            CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                "provider body RIR does not have one source file".into(),
+            ))
+        })?;
+        let host_setup_started = Instant::now();
+        let mut host = ProviderBodyHost::new(
+            provider, source, bundle, key, owner_file, name, owner_kind, owner_name, target,
+            preview, well_known,
+        )
+        .map_err(identity_mint_compile_error)?
+        .ok_or_else(|| {
+            CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                "provider body host could not be constructed".into(),
+            ))
+        })?;
+        let initial_anonymous_identities = host
+            .canonical_anonymous_types
+            .values()
             .cloned()
-    }));
-    referenced_specializations.extend(host.observed_comptime_producers.borrow().iter().cloned());
-    host.specialized_function_identities.borrow_mut().extend(
-        selected_calls
-            .iter()
-            .zip(referenced_specializations.iter())
-            .map(|((symbol, _), instance)| (*symbol, instance.clone())),
-    );
-    let selected_calls = selected_calls.into_iter().collect::<AHashMap<_, _>>();
-    let specialization_selection_ns = elapsed_ns(specialization_selection_started);
-    let body_export_started = Instant::now();
-    let export = super::semantic_body_export::export_body(
-        &host,
-        host.owner,
-        body_span,
-        &function,
-        &strings,
-        &warnings,
-        Some(&selected_calls),
-        &referenced_methods,
-    )
-    .map_err(|failure| {
-        CompileError::without_span(rue_error::ErrorKind::OutputPublication(format!(
-            "provider body export failed: {failure:?}"
-        )))
-    })?;
-    let body_export_ns = elapsed_ns(body_export_started);
-    let result_projection_started = Instant::now();
-    let mut referenced_definitions = referenced_functions
-        .iter()
-        .filter_map(|symbol| {
-            host.function_tokens
-                .borrow()
-                .get(symbol)
-                .map(|(_, key)| key.clone())
-        })
-        .collect::<AHashSet<_>>();
-    referenced_definitions.extend(
-        referenced_methods
-            .iter()
-            .filter_map(|(owner, method)| host.named_method_definition(*owner, *method)),
-    );
-    let referenced_definitions = referenced_definitions.into_iter().collect();
-    let referenced_values = host
-        .observed_named_definitions
-        .borrow()
-        .iter()
-        .cloned()
-        .collect();
-    let produced_anonymous_nominals = host
-        .produced_anonymous_nominals(&initial_anonymous_identities)
+            .collect::<AHashSet<_>>();
+        let infer = InferenceContext::new(&host);
+        let host_setup_ns = elapsed_ns(host_setup_started);
+        let expression_engine_started = Instant::now();
+        let (analyzed, body_span) = match owner_kind {
+            crate::StableDefinitionKind::Function => {
+                let info = host
+                    .endpoint
+                    .endpoint_function_info(host.function_symbol)
+                    .ok_or_else(|| {
+                        CompileError::without_span(rue_error::ErrorKind::UndefinedFunction(
+                            name.to_owned(),
+                        ))
+                    })?;
+                let declaration = host
+                    .endpoint
+                    .first_free_function(name, owner_file)
+                    .ok_or_else(|| {
+                        CompileError::without_span(rue_error::ErrorKind::UndefinedFunction(
+                            name.to_owned(),
+                        ))
+                    })?;
+                host.reject_free_function_accessor(declaration)?;
+                let (return_type, body) = match &host.rir.rir().get(declaration).data {
+                    InstData::FnDecl {
+                        return_type, body, ..
+                    } => (*return_type, *body),
+                    _ => unreachable!("registered provider function points at FnDecl"),
+                };
+                let body_span = host.rir.rir().get(body).span;
+                // The durable call-site signature may normalize body-local types
+                // such as `Str(N)` to their coercion surface. Resolve the exact
+                // declared return spelling for body checking; explicit parameters
+                // retain their exact canonical facts and need no second lookup.
+                let return_type = host.resolve_body_type(return_type, info.span)?;
+                let params = host
+                    .state
+                    .param_data(info.params)
+                    .iter()
+                    .map(|(name, ty, mode, comptime)| (*name, *ty, *mode, *comptime))
+                    .collect();
+                host.endpoint
+                    .finalize_containment_metadata()
+                    .ok_or_else(|| {
+                        CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                            "provider function containment metadata is unavailable".into(),
+                        ))
+                    })?;
+                (
+                    OrdinaryBodyEngine::new(&mut host).analyze_single_function_resolved(
+                        &infer,
+                        name,
+                        return_type,
+                        params,
+                        body,
+                        info.span,
+                        info.allow_unused_variable,
+                        info.allow_unreachable_code,
+                    )?,
+                    body_span,
+                )
+            }
+            crate::StableDefinitionKind::Method
+            | crate::StableDefinitionKind::AssociatedFunction => {
+                let owner_name = owner_name.ok_or_else(|| {
+                    CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                        "provider member body has no owner".into(),
+                    ))
+                })?;
+                let declaration = host
+                    .endpoint
+                    .named_method_declaration(owner_file, owner_name, name)
+                    .ok_or_else(|| {
+                        CompileError::without_span(rue_error::ErrorKind::UndefinedFunction(
+                            name.to_owned(),
+                        ))
+                    })?;
+                let info = host
+                    .calls
+                    .method_info(&host.key, owner_file, owner_name, name)
+                    .ok_or_else(|| {
+                        CompileError::without_span(rue_error::ErrorKind::UndefinedFunction(
+                            name.to_owned(),
+                        ))
+                    })?;
+                let (return_type, body) = match &host.rir.rir().get(declaration).data {
+                    InstData::FnDecl {
+                        return_type, body, ..
+                    } => (*return_type, *body),
+                    _ => unreachable!("registered provider member points at FnDecl"),
+                };
+                let body_span = host.rir.rir().get(body).span;
+                let return_type = if matches!(
+                    host.rir.rir().type_syntax().node(return_type),
+                    Some(rue_rir::RirTypeSyntaxNode::Named(symbol))
+                        if host.rir.rir().type_syntax().symbol(*symbol)
+                            .is_some_and(|symbol| host.interner.resolve(symbol) == "Self")
+                ) {
+                    info.struct_type
+                } else {
+                    host.resolve_body_type(return_type, info.span)?
+                };
+                let params = host
+                    .state
+                    .param_data(info.params)
+                    .iter()
+                    .map(|(name, ty, mode, comptime)| (*name, *ty, *mode, *comptime))
+                    .collect();
+                let full_name = host.member_callable_name(
+                    info.struct_type
+                        .as_struct()
+                        .expect("named method receiver must be a struct"),
+                    name,
+                    info.has_self,
+                );
+                let full_symbol = host.intern_name_at(&full_name, body_span)?;
+                let owner_token = host.function_tokens.borrow()[&host.function_symbol].clone();
+                host.function_tokens
+                    .borrow_mut()
+                    .insert(full_symbol, owner_token);
+                host.endpoint
+                    .finalize_containment_metadata()
+                    .ok_or_else(|| {
+                        CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                            "provider method containment metadata is unavailable".into(),
+                        ))
+                    })?;
+                (
+                    OrdinaryBodyEngine::new(&mut host).analyze_named_method_resolved(
+                        &infer,
+                        &full_name,
+                        return_type,
+                        params,
+                        body,
+                        info.span,
+                        info.struct_type,
+                        info.has_self,
+                        info.self_mode,
+                        info.self_is_mut,
+                        info.returns_borrow,
+                        info.returns_inout,
+                    )?,
+                    body_span,
+                )
+            }
+            crate::StableDefinitionKind::Destructor => {
+                let owner_name = owner_name.ok_or_else(|| {
+                    CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                        "provider destructor body has no owner".into(),
+                    ))
+                })?;
+                let declaration = host
+                    .endpoint
+                    .destructor(owner_file, owner_name)
+                    .ok_or_else(|| {
+                        CompileError::without_span(rue_error::ErrorKind::UndefinedFunction(
+                            format!("{owner_name}.__drop"),
+                        ))
+                    })?;
+                let (body, declaration_span) = match &host.rir.rir().get(declaration).data {
+                    InstData::DropFnDecl { body, .. } => {
+                        (*body, host.rir.rir().get(declaration).span)
+                    }
+                    _ => unreachable!("registered provider destructor points at DropFnDecl"),
+                };
+                let body_span = host.rir.rir().get(body).span;
+                let owner_symbol = host.intern_name_at(owner_name, body_span)?;
+                let owner_type = host
+                    .nominal_type_for_symbol(owner_file, owner_symbol)
+                    .ok_or_else(|| {
+                        CompileError::without_span(rue_error::ErrorKind::UnknownType(
+                            owner_name.to_owned(),
+                        ))
+                    })?;
+                let full_name = format!(
+                    "{}.__drop",
+                    host.type_pool.struct_symbol_name(
+                        owner_type
+                            .as_struct()
+                            .expect("named destructor owner must be a struct")
+                    )
+                );
+                let full_symbol = host.intern_name_at(&full_name, body_span)?;
+                let owner_token = host.function_tokens.borrow()[&host.function_symbol].clone();
+                host.function_tokens
+                    .borrow_mut()
+                    .insert(full_symbol, owner_token);
+                host.endpoint
+                    .finalize_containment_metadata()
+                    .ok_or_else(|| {
+                        CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                            "provider destructor containment metadata is unavailable".into(),
+                        ))
+                    })?;
+                (
+                    OrdinaryBodyEngine::new(&mut host).analyze_named_destructor(
+                        &infer,
+                        &full_name,
+                        body,
+                        declaration_span,
+                        owner_type,
+                    )?,
+                    body_span,
+                )
+            }
+            _ => {
+                return Err(CompileError::without_span(
+                    rue_error::ErrorKind::InvalidCompilerInput(
+                        "provider body request does not own an executable body".into(),
+                    ),
+                ));
+            }
+        };
+        let expression_engine_ns = elapsed_ns(expression_engine_started);
+        let expression_breakdown = host
+            .expression_breakdown
+            .expect("provider ordinary body analysis records its expression breakdown");
+        let specialization_selection_started = Instant::now();
+        let (mut function, warnings, strings, referenced_functions, referenced_methods) = analyzed;
+        function.ordinary_owner = Some(host.owner);
+        let (function, selected_calls, mut referenced_specializations) =
+            crate::specialize::select_provider_body_specializations(&mut host, function)?;
+        referenced_specializations.extend(referenced_methods.iter().filter_map(
+            |(owner, method)| {
+                let info = host.method_info_for_symbol(*owner, *method)?;
+                let callable = host.member_callable_symbol(
+                    *owner,
+                    host.interner.resolve(method),
+                    info.has_self,
+                )?;
+                host.anonymous_function_identities
+                    .borrow()
+                    .get(&callable)
+                    .cloned()
+            },
+        ));
+        referenced_specializations
+            .extend(host.observed_comptime_producers.borrow().iter().cloned());
+        host.specialized_function_identities.borrow_mut().extend(
+            selected_calls
+                .iter()
+                .zip(referenced_specializations.iter())
+                .map(|((symbol, _), instance)| (*symbol, instance.clone())),
+        );
+        let selected_calls = selected_calls.into_iter().collect::<AHashMap<_, _>>();
+        let specialization_selection_ns = elapsed_ns(specialization_selection_started);
+        let body_export_started = Instant::now();
+        let export = super::semantic_body_export::export_body(
+            &host,
+            host.owner,
+            body_span,
+            &function,
+            &strings,
+            &warnings,
+            Some(&selected_calls),
+            &referenced_methods,
+        )
         .map_err(|failure| {
             CompileError::without_span(rue_error::ErrorKind::OutputPublication(format!(
-                "provider ordinary produced-nominal export failed: {failure:?}"
+                "provider body export failed: {failure:?}"
             )))
         })?;
-    let work = host.provider_body_work.snapshot();
-    let definition_tokens = host
-        .function_tokens
-        .into_inner()
-        .into_values()
-        .chain(host.nominal_tokens.into_inner().into_values())
-        .chain(
-            host.anonymous_definition_tokens
-                .into_inner()
-                .into_iter()
-                .map(|(key, token)| (token, key)),
-        )
-        .collect();
-    let module_tokens = host.module_tokens.into_inner().into_values().collect();
-    let result_projection_ns = elapsed_ns(result_projection_started);
-    publish_provider_body_breakdown(
-        host_setup_ns,
-        expression_engine_ns,
-        specialization_selection_ns,
-        body_export_ns,
-        result_projection_ns,
-        expression_breakdown,
-    );
-    Ok(ProviderOrdinaryBody {
-        owner: host.owner,
-        work,
-        export,
-        function,
-        warnings,
-        strings,
-        referenced_functions,
-        referenced_methods,
-        referenced_definitions,
-        referenced_values,
-        referenced_specializations,
-        produced_anonymous_nominals,
-        type_pool: host.type_pool,
-        interner: host.interner,
-        definition_tokens,
-        module_tokens,
-    })
+        let body_export_ns = elapsed_ns(body_export_started);
+        let result_projection_started = Instant::now();
+        let mut referenced_definitions = referenced_functions
+            .iter()
+            .filter_map(|symbol| {
+                host.function_tokens
+                    .borrow()
+                    .get(symbol)
+                    .map(|(_, key)| key.clone())
+            })
+            .collect::<AHashSet<_>>();
+        referenced_definitions.extend(
+            referenced_methods
+                .iter()
+                .filter_map(|(owner, method)| host.named_method_definition(*owner, *method)),
+        );
+        let referenced_definitions = referenced_definitions.into_iter().collect();
+        let referenced_values = host
+            .observed_named_definitions
+            .borrow()
+            .iter()
+            .cloned()
+            .collect();
+        let produced_anonymous_nominals = host
+            .produced_anonymous_nominals(&initial_anonymous_identities)
+            .map_err(|failure| {
+                CompileError::without_span(rue_error::ErrorKind::OutputPublication(format!(
+                    "provider ordinary produced-nominal export failed: {failure:?}"
+                )))
+            })?;
+        let work = host.provider_body_work.snapshot();
+        let definition_tokens = host
+            .function_tokens
+            .into_inner()
+            .into_values()
+            .chain(host.nominal_tokens.into_inner().into_values())
+            .chain(
+                host.anonymous_definition_tokens
+                    .into_inner()
+                    .into_iter()
+                    .map(|(key, token)| (token, key)),
+            )
+            .collect();
+        let module_tokens = host.module_tokens.into_inner().into_values().collect();
+        let result_projection_ns = elapsed_ns(result_projection_started);
+        publish_provider_body_breakdown(
+            host_setup_ns,
+            expression_engine_ns,
+            specialization_selection_ns,
+            body_export_ns,
+            result_projection_ns,
+            expression_breakdown,
+        );
+        check_shared_interner(bundle.symbol_space(), "ordinary provider analysis")?;
+        Ok(ProviderOrdinaryBody {
+            owner: host.owner,
+            work,
+            export,
+            function,
+            warnings,
+            strings,
+            referenced_functions,
+            referenced_methods,
+            referenced_definitions,
+            referenced_values,
+            referenced_specializations,
+            produced_anonymous_nominals,
+            type_pool: host.type_pool,
+            interner: host.interner,
+            definition_tokens,
+            module_tokens,
+        })
+    })();
+    match (
+        result,
+        check_shared_interner(bundle.symbol_space(), "ordinary provider analysis"),
+    ) {
+        (Err(error), _)
+            if matches!(
+                &error.kind,
+                ErrorKind::CompilerResourceLimit(_) | ErrorKind::CompilerResourceExhaustion(_)
+            ) =>
+        {
+            Err(error)
+        }
+        (_, Err(error)) => Err(error),
+        (result, Ok(())) => result,
+    }
 }
 
 fn anonymous_member_in_producer(
@@ -5088,467 +5251,502 @@ where
     K: Clone + Eq + Hash + Ord,
     M: Clone + Eq + Hash + Ord,
 {
-    let owner_file = bundle.source_file_id().ok_or_else(|| {
-        CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-            "provider anonymous body RIR does not have one source file".into(),
-        ))
-    })?;
-    let TypeInstanceKey::Nominal(crate::NominalInstanceKey::Anonymous(durable_owner)) = owner
-    else {
-        return Err(CompileError::without_span(
-            rue_error::ErrorKind::InvalidCompilerInput(
-                "anonymous member owner is not an anonymous nominal".into(),
-            ),
-        ));
-    };
-    let declaration = {
-        let view = bundle.view();
-        let producer_root = anonymous_producer_root(
-            view.rir(),
-            view.rir_interner(),
-            candidate_root,
-            &source_key,
-            &durable_owner.producer,
+    let result = (|| -> CompileResult<ProviderAnonymousBody<K, M>> {
+        let owner_file = bundle.source_file_id().ok_or_else(|| {
+            CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                "provider anonymous body RIR does not have one source file".into(),
+            ))
+        })?;
+        let TypeInstanceKey::Nominal(crate::NominalInstanceKey::Anonymous(durable_owner)) = owner
+        else {
+            return Err(CompileError::without_span(
+                rue_error::ErrorKind::InvalidCompilerInput(
+                    "anonymous member owner is not an anonymous nominal".into(),
+                ),
+            ));
+        };
+        let declaration = {
+            let view = bundle.view();
+            let producer_root = anonymous_producer_root(
+                view.rir(),
+                view.rir_interner(),
+                candidate_root,
+                &source_key,
+                &durable_owner.producer,
+            )
+            .map_err(|detail| {
+                CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                    detail.into(),
+                ))
+            })?;
+            anonymous_member_in_producer(
+                view.rir(),
+                view.rir_interner(),
+                producer_root,
+                &durable_owner.anchor,
+                member,
+            )
+            .map_err(|detail| {
+                CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                    detail.into(),
+                ))
+            })?
+        };
+        let host_setup_started = Instant::now();
+        let mut host = ProviderBodyHost::new(
+            provider,
+            source,
+            bundle,
+            source_key.clone(),
+            owner_file,
+            member.name.as_ref(),
+            match member.kind {
+                crate::AnonymousMemberKind::Method => crate::StableDefinitionKind::Method,
+                crate::AnonymousMemberKind::AssociatedFunction => {
+                    crate::StableDefinitionKind::AssociatedFunction
+                }
+                crate::AnonymousMemberKind::Destructor => crate::StableDefinitionKind::Destructor,
+            },
+            None,
+            target,
+            preview,
+            well_known,
         )
-        .map_err(|detail| {
-            CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(detail.into()))
-        })?;
-        anonymous_member_in_producer(
-            view.rir(),
-            view.rir_interner(),
-            producer_root,
-            &durable_owner.anchor,
-            member,
-        )
-        .map_err(|detail| {
-            CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(detail.into()))
-        })?
-    };
-    let host_setup_started = Instant::now();
-    let mut host = ProviderBodyHost::new(
-        provider,
-        source,
-        bundle,
-        source_key.clone(),
-        owner_file,
-        member.name.as_ref(),
-        match member.kind {
-            crate::AnonymousMemberKind::Method => crate::StableDefinitionKind::Method,
-            crate::AnonymousMemberKind::AssociatedFunction => {
-                crate::StableDefinitionKind::AssociatedFunction
-            }
-            crate::AnonymousMemberKind::Destructor => crate::StableDefinitionKind::Destructor,
-        },
-        None,
-        target,
-        preview,
-        well_known,
-    )
-    .ok_or_else(|| {
-        CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-            "provider anonymous body host could not be constructed".into(),
-        ))
-    })?;
-    host.current_declaration_override = Some(declaration);
-    let issued_owner = host
-        .register_and_issue_anonymous_identity(durable_owner)
+        .map_err(identity_mint_compile_error)?
         .ok_or_else(|| {
             CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-                "anonymous member owner identities are unavailable".into(),
+                "provider anonymous body host could not be constructed".into(),
             ))
         })?;
-    host.endpoint
-        .register_anonymous_nominal(issued_owner.clone(), (**durable_owner).clone());
-    let owner_type = host
-        .state
-        .identity_context()
-        .pool_mut()
-        .ok_or_else(|| {
-            CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-                "anonymous member owner identity pool is unavailable".into(),
-            ))
-        })?
-        .resolve_provider_type(&crate::SemanticImportType::AnonymousNominal(
-            (**durable_owner).clone(),
-        ))
-        .map_err(|failure| {
-            CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(format!(
-                "anonymous member owner shape is unavailable: {failure:?}"
-            )))
-        })?;
-    host.endpoint
-        .finalize_containment_metadata()
-        .ok_or_else(|| {
-            CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-                "anonymous member owner containment metadata is unavailable".into(),
-            ))
-        })?;
-    let struct_id = owner_type.as_struct().ok_or_else(|| {
-        CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-            "anonymous member owner is not a struct".into(),
-        ))
-    })?;
-    host.canonical_anonymous_types
-        .insert(owner_type, issued_owner.clone());
-    host.anon_struct_identities
-        .insert(issued_owner.clone(), struct_id);
-    host.anonymous_struct_ids.insert(struct_id);
-    let type_captures = host.source.anonymous_type_captures(durable_owner);
-    let mut type_subst = AHashMap::with_capacity(type_captures.len());
-    for (name, durable_type) in type_captures {
-        let ty = host
+        host.current_declaration_override = Some(declaration);
+        let issued_owner = host
+            .register_and_issue_anonymous_identity(durable_owner)
+            .ok_or_else(|| {
+                CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                    "anonymous member owner identities are unavailable".into(),
+                ))
+            })?;
+        host.endpoint
+            .register_anonymous_nominal(issued_owner.clone(), (**durable_owner).clone());
+        let owner_type = host
             .state
             .identity_context()
             .pool_mut()
-            .and_then(|mut pool| pool.resolve_provider_type(&durable_type).ok())
             .ok_or_else(|| {
                 CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-                    "anonymous member type capture cannot be materialized".into(),
+                    "anonymous member owner identity pool is unavailable".into(),
                 ))
+            })?
+            .resolve_provider_type(&crate::SemanticImportType::AnonymousNominal(
+                (**durable_owner).clone(),
+            ))
+            .map_err(|failure| {
+                CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(format!(
+                    "anonymous member owner shape is unavailable: {failure:?}"
+                )))
             })?;
-        let symbol = host
-            .interner
-            .get_or_intern(&ty.safe_name_with_pool(Some(&host.type_pool)));
-        if let Some(id) = ty.as_struct() {
-            host.generated_structs.insert(symbol, id);
-        } else if let Some(id) = ty.as_enum() {
-            host.generated_enums.insert(symbol, id);
-        }
-        if host.endpoint.durable_anonymous_identity(ty).is_some() {
-            host.issued_anonymous_identity_for_type(ty).ok_or_else(|| {
-                CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-                    "anonymous member type capture identity cannot be issued".into(),
-                ))
-            })?;
-        } else if host.endpoint.durable_named_identity(ty).is_some() {
-            host.ensure_named_nominal_identity(ty, host.interner.resolve(&symbol))
-                .map_err(|_| {
-                    CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-                        "anonymous member type capture identity cannot be registered".into(),
-                    ))
-                })?;
-        }
-        type_subst.insert(host.interner.get_or_intern(name.as_ref()), ty);
-    }
-    if !type_subst.is_empty() {
-        host.anon_struct_type_subst.insert(struct_id, type_subst);
-    }
-    let value_captures = host.source.anonymous_value_captures(durable_owner);
-    let mut captured_values = AHashMap::with_capacity(value_captures.len());
-    for (name, durable_value) in value_captures {
-        let value = host
-            .materialize_durable_const_value(&durable_value)
+        host.endpoint
+            .finalize_containment_metadata()
             .ok_or_else(|| {
                 CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-                    "anonymous member value capture cannot be materialized".into(),
+                    "anonymous member owner containment metadata is unavailable".into(),
                 ))
             })?;
-        captured_values.insert(host.interner.get_or_intern(name.as_ref()), value);
-    }
-    if !captured_values.is_empty() {
-        host.anon_struct_captured_values
-            .insert(struct_id, captured_values);
-    }
-    let initial_anonymous_identities = host
-        .canonical_anonymous_types
-        .values()
-        .cloned()
-        .collect::<AHashSet<_>>();
-
-    let (params, body, has_self, self_mode, self_is_mut, returns_borrow, returns_inout, span) =
-        match &host.rir.rir().get(declaration).data {
-            InstData::FnDecl {
-                params,
-                body,
-                has_self,
-                self_mode,
-                self_is_mut,
-                returns_borrow,
-                returns_inout,
-                ..
-            } => (
-                params.clone(),
-                *body,
-                *has_self,
-                *self_mode,
-                *self_is_mut,
-                *returns_borrow,
-                *returns_inout,
-                host.rir.rir().get(declaration).span,
-            ),
-            _ => {
-                return Err(CompileError::without_span(
-                    rue_error::ErrorKind::InvalidCompilerInput(
-                        "anonymous member fragment did not lower to a method".into(),
-                    ),
-                ));
-            }
-        };
-    let expected_kind = if member.name.as_ref() == "__drop" {
-        crate::AnonymousMemberKind::Destructor
-    } else if has_self {
-        crate::AnonymousMemberKind::Method
-    } else {
-        crate::AnonymousMemberKind::AssociatedFunction
-    };
-    if expected_kind != member.kind {
-        return Err(CompileError::without_span(
-            rue_error::ErrorKind::InvalidCompilerInput(
-                "anonymous member kind disagrees with its producer fragment".into(),
-            ),
-        ));
-    }
-    let issued_identity = FunctionInstanceKey::AnonymousMember {
-        owner: Node::new(TypeInstanceKey::Nominal(
-            crate::NominalInstanceKey::Anonymous(Node::new(issued_owner.clone())),
-        )),
-        member: member.clone(),
-    };
-    host.current_anonymous_identity = Some(issued_identity.clone());
-    host.register_provider_anonymous_method_endpoints_with_issued(
-        durable_owner,
-        owner_type,
-        issued_owner,
-    )
-    .ok_or_else(|| {
-        CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-            "anonymous member sibling endpoints are unavailable".into(),
-        ))
-    })?;
-    let full_name = host.member_callable_name(struct_id, &member.name, has_self);
-    let full_symbol = host.interner.get_or_intern(&full_name);
-    host.function_symbol = full_symbol;
-    let owner_token = host
-        .function_tokens
-        .borrow()
-        .values()
-        .next()
-        .cloned()
-        .ok_or_else(|| {
+        let struct_id = owner_type.as_struct().ok_or_else(|| {
             CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-                "anonymous member has no producer token".into(),
+                "anonymous member owner is not a struct".into(),
             ))
         })?;
-    host.function_tokens
-        .borrow_mut()
-        .insert(full_symbol, owner_token);
-
-    let params = host
-        .rir
-        .rir()
-        .params(&params)
-        .values()
-        .collect::<Vec<RirParam>>();
-    let projected = host
-        .source
-        .anonymous_methods(durable_owner)
-        .into_iter()
-        .find(|candidate| candidate.name == member.name)
-        .ok_or_else(|| {
-            CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-                "anonymous member signature is unavailable from its producer".into(),
-            ))
-        })?;
-    if projected.has_self != has_self
-        || projected.self_mode != self_mode
-        || projected.parameters.len() != params.len()
-        || !projected
-            .parameters
-            .iter()
-            .zip(&params)
-            .all(|((_, mode, comptime), parameter)| {
-                *mode == parameter.mode && *comptime == parameter.is_comptime
-            })
-    {
-        return Err(CompileError::without_span(
-            rue_error::ErrorKind::InvalidCompilerInput(
-                "anonymous member signature disagrees with its producer fragment".into(),
-            ),
-        ));
-    }
-    let materialize = |host: &mut ProviderBodyHost<'_, P, S, K, M>,
-                       ty: &crate::DurableAnonymousMethodType<K, M>| {
-        let ty = match ty {
-            crate::DurableAnonymousMethodType::SelfType => owner_type,
-            crate::DurableAnonymousMethodType::Concrete(ty) => host
+        host.canonical_anonymous_types
+            .insert(owner_type, issued_owner.clone());
+        host.anon_struct_identities
+            .insert(issued_owner.clone(), struct_id);
+        host.anonymous_struct_ids.insert(struct_id);
+        let type_captures = host.source.anonymous_type_captures(durable_owner);
+        let mut type_subst = AHashMap::with_capacity(type_captures.len());
+        for (name, durable_type) in type_captures {
+            let ty = host
                 .state
                 .identity_context()
-                .pool_mut()?
-                .resolve_provider_type(ty)
-                .ok()?,
-        };
-        let symbol = host
-            .interner
-            .get_or_intern(&ty.safe_name_with_pool(Some(&host.type_pool)));
-        if host.endpoint.durable_anonymous_identity(ty).is_some() {
-            host.issued_anonymous_identity_for_type(ty)?;
-        } else if host.endpoint.durable_named_identity(ty).is_some() {
-            host.ensure_named_nominal_identity(ty, host.interner.resolve(&symbol))
-                .ok()?;
-        }
-        Some(ty)
-    };
-    let mut resolved_params = params
-        .iter()
-        .zip(&projected.parameters)
-        .map(|(parameter, (projected_type, _, _))| {
-            materialize(&mut host, projected_type)
-                .map(|ty| (parameter.name, ty, parameter.mode, parameter.is_comptime))
+                .pool_mut()
+                .and_then(|mut pool| pool.resolve_provider_type(&durable_type).ok())
                 .ok_or_else(|| {
                     CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-                        "anonymous member parameter type cannot be materialized".into(),
+                        "anonymous member type capture cannot be materialized".into(),
                     ))
-                })
-        })
-        .collect::<CompileResult<Vec<_>>>()?;
-    let return_type = materialize(&mut host, &projected.result).ok_or_else(|| {
-        CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-            "anonymous member result type cannot be materialized".into(),
-        ))
-    })?;
-    let infer = InferenceContext::new(&host);
-    let host_setup_ns = elapsed_ns(host_setup_started);
-    let expression_engine_started = Instant::now();
-    if has_self {
-        resolved_params.insert(
-            0,
-            (
-                host.interner.get_or_intern("self"),
-                owner_type,
-                self_mode,
-                false,
-            ),
-        );
-    }
-    let analyzed = OrdinaryBodyEngine::new(&mut host).analyze_method_with_identity_kind_resolved(
-        &infer,
-        issued_identity.clone(),
-        &full_name,
-        return_type,
-        resolved_params,
-        body,
-        span,
-        owner_type,
-        self_is_mut,
-        member.kind == crate::AnonymousMemberKind::Destructor,
-        returns_borrow || returns_inout,
-    )?;
-    let expression_engine_ns = elapsed_ns(expression_engine_started);
-    let expression_breakdown = host
-        .expression_breakdown
-        .expect("provider anonymous body analysis records its expression breakdown");
-    let specialization_selection_started = Instant::now();
-    let (function, warnings, strings, referenced_functions, referenced_methods) = analyzed;
-    let (function, selected_calls, mut referenced_specializations) =
-        crate::specialize::select_provider_body_specializations(&mut host, function)?;
-    referenced_specializations.extend(referenced_methods.iter().filter_map(|(owner, method)| {
-        let info = host.method_info_for_symbol(*owner, *method)?;
-        let callable =
-            host.member_callable_symbol(*owner, host.interner.resolve(method), info.has_self);
-        host.anonymous_function_identities
-            .borrow()
-            .get(&callable)
+                })?;
+            let symbol = host.intern_name_at(
+                ty.safe_name_with_pool(Some(&host.type_pool)),
+                host.rir.rir().get(declaration).span,
+            )?;
+            if let Some(id) = ty.as_struct() {
+                host.generated_structs.insert(symbol, id);
+            } else if let Some(id) = ty.as_enum() {
+                host.generated_enums.insert(symbol, id);
+            }
+            if host.endpoint.durable_anonymous_identity(ty).is_some() {
+                host.issued_anonymous_identity_for_type(ty).ok_or_else(|| {
+                    CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                        "anonymous member type capture identity cannot be issued".into(),
+                    ))
+                })?;
+            } else if host.endpoint.durable_named_identity(ty).is_some() {
+                host.ensure_named_nominal_identity(ty, host.interner.resolve(&symbol))
+                    .map_err(|_| {
+                        CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                            "anonymous member type capture identity cannot be registered".into(),
+                        ))
+                    })?;
+            }
+            type_subst.insert(
+                host.intern_name_at(name.as_ref(), host.rir.rir().get(declaration).span)?,
+                ty,
+            );
+        }
+        if !type_subst.is_empty() {
+            host.anon_struct_type_subst.insert(struct_id, type_subst);
+        }
+        let value_captures = host.source.anonymous_value_captures(durable_owner);
+        let mut captured_values = AHashMap::with_capacity(value_captures.len());
+        for (name, durable_value) in value_captures {
+            let value = host
+                .materialize_durable_const_value(&durable_value)
+                .ok_or_else(|| {
+                    CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                        "anonymous member value capture cannot be materialized".into(),
+                    ))
+                })?;
+            captured_values.insert(
+                host.intern_name_at(name.as_ref(), host.rir.rir().get(declaration).span)?,
+                value,
+            );
+        }
+        if !captured_values.is_empty() {
+            host.anon_struct_captured_values
+                .insert(struct_id, captured_values);
+        }
+        let initial_anonymous_identities = host
+            .canonical_anonymous_types
+            .values()
             .cloned()
-    }));
-    referenced_specializations.extend(host.observed_comptime_producers.borrow().iter().cloned());
-    host.specialized_function_identities.borrow_mut().extend(
-        selected_calls
+            .collect::<AHashSet<_>>();
+
+        let (params, body, has_self, self_mode, self_is_mut, returns_borrow, returns_inout, span) =
+            match &host.rir.rir().get(declaration).data {
+                InstData::FnDecl {
+                    params,
+                    body,
+                    has_self,
+                    self_mode,
+                    self_is_mut,
+                    returns_borrow,
+                    returns_inout,
+                    ..
+                } => (
+                    params.clone(),
+                    *body,
+                    *has_self,
+                    *self_mode,
+                    *self_is_mut,
+                    *returns_borrow,
+                    *returns_inout,
+                    host.rir.rir().get(declaration).span,
+                ),
+                _ => {
+                    return Err(CompileError::without_span(
+                        rue_error::ErrorKind::InvalidCompilerInput(
+                            "anonymous member fragment did not lower to a method".into(),
+                        ),
+                    ));
+                }
+            };
+        let expected_kind = if member.name.as_ref() == "__drop" {
+            crate::AnonymousMemberKind::Destructor
+        } else if has_self {
+            crate::AnonymousMemberKind::Method
+        } else {
+            crate::AnonymousMemberKind::AssociatedFunction
+        };
+        if expected_kind != member.kind {
+            return Err(CompileError::without_span(
+                rue_error::ErrorKind::InvalidCompilerInput(
+                    "anonymous member kind disagrees with its producer fragment".into(),
+                ),
+            ));
+        }
+        let issued_identity = FunctionInstanceKey::AnonymousMember {
+            owner: Node::new(TypeInstanceKey::Nominal(
+                crate::NominalInstanceKey::Anonymous(Node::new(issued_owner.clone())),
+            )),
+            member: member.clone(),
+        };
+        host.current_anonymous_identity = Some(issued_identity.clone());
+        host.register_provider_anonymous_method_endpoints_with_issued(
+            durable_owner,
+            owner_type,
+            issued_owner,
+        )
+        .ok_or_else(|| {
+            CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                "anonymous member sibling endpoints are unavailable".into(),
+            ))
+        })?;
+        let full_name = host.member_callable_name(struct_id, &member.name, has_self);
+        let full_symbol = host.intern_name_at(&full_name, host.rir.rir().get(declaration).span)?;
+        host.function_symbol = full_symbol;
+        let owner_token = host
+            .function_tokens
+            .borrow()
+            .values()
+            .next()
+            .cloned()
+            .ok_or_else(|| {
+                CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                    "anonymous member has no producer token".into(),
+                ))
+            })?;
+        host.function_tokens
+            .borrow_mut()
+            .insert(full_symbol, owner_token);
+
+        let params = host
+            .rir
+            .rir()
+            .params(&params)
+            .values()
+            .collect::<Vec<RirParam>>();
+        let projected = host
+            .source
+            .anonymous_methods(durable_owner)
+            .into_iter()
+            .find(|candidate| candidate.name == member.name)
+            .ok_or_else(|| {
+                CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                    "anonymous member signature is unavailable from its producer".into(),
+                ))
+            })?;
+        if projected.has_self != has_self
+            || projected.self_mode != self_mode
+            || projected.parameters.len() != params.len()
+            || !projected
+                .parameters
+                .iter()
+                .zip(&params)
+                .all(|((_, mode, comptime), parameter)| {
+                    *mode == parameter.mode && *comptime == parameter.is_comptime
+                })
+        {
+            return Err(CompileError::without_span(
+                rue_error::ErrorKind::InvalidCompilerInput(
+                    "anonymous member signature disagrees with its producer fragment".into(),
+                ),
+            ));
+        }
+        let materialize = |host: &mut ProviderBodyHost<'_, P, S, K, M>,
+                           ty: &crate::DurableAnonymousMethodType<K, M>| {
+            let ty = match ty {
+                crate::DurableAnonymousMethodType::SelfType => owner_type,
+                crate::DurableAnonymousMethodType::Concrete(ty) => host
+                    .state
+                    .identity_context()
+                    .pool_mut()?
+                    .resolve_provider_type(ty)
+                    .ok()?,
+            };
+            let symbol = host.intern_name(ty.safe_name_with_pool(Some(&host.type_pool)))?;
+            if host.endpoint.durable_anonymous_identity(ty).is_some() {
+                host.issued_anonymous_identity_for_type(ty)?;
+            } else if host.endpoint.durable_named_identity(ty).is_some() {
+                host.ensure_named_nominal_identity(ty, host.interner.resolve(&symbol))
+                    .ok()?;
+            }
+            Some(ty)
+        };
+        let mut resolved_params = params
             .iter()
-            .zip(referenced_specializations.iter())
-            .map(|((symbol, _), instance)| (*symbol, instance.clone())),
-    );
-    let selected_calls = selected_calls.into_iter().collect::<AHashMap<_, _>>();
-    let body_span = host.rir.rir().get(body).span;
-    let specialization_selection_ns = elapsed_ns(specialization_selection_started);
-    let body_export_started = Instant::now();
-    let export = super::semantic_body_export::export_body(
-        &host,
-        crate::BodyOwnerToken::new(0, 0),
-        body_span,
-        &function,
-        &strings,
-        &warnings,
-        Some(&selected_calls),
-        &referenced_methods,
-    )
-    .map(|export| crate::SemanticAnonymousBodyExport {
-        identity: issued_identity,
-        body: export.body,
-    })
-    .map_err(|failure| {
-        CompileError::without_span(rue_error::ErrorKind::OutputPublication(format!(
-            "provider anonymous body export failed: {failure:?}"
-        )))
-    })?;
-    let body_export_ns = elapsed_ns(body_export_started);
-    let result_projection_started = Instant::now();
-    let produced_anonymous_nominals = host
-        .produced_anonymous_nominals(&initial_anonymous_identities)
+            .zip(&projected.parameters)
+            .map(|(parameter, (projected_type, _, _))| {
+                materialize(&mut host, projected_type)
+                    .map(|ty| (parameter.name, ty, parameter.mode, parameter.is_comptime))
+                    .ok_or_else(|| {
+                        CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                            "anonymous member parameter type cannot be materialized".into(),
+                        ))
+                    })
+            })
+            .collect::<CompileResult<Vec<_>>>()?;
+        let return_type = materialize(&mut host, &projected.result).ok_or_else(|| {
+            CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                "anonymous member result type cannot be materialized".into(),
+            ))
+        })?;
+        let infer = InferenceContext::new(&host);
+        let host_setup_ns = elapsed_ns(host_setup_started);
+        let expression_engine_started = Instant::now();
+        if has_self {
+            resolved_params.insert(
+                0,
+                (
+                    host.intern_name_at("self", span)?,
+                    owner_type,
+                    self_mode,
+                    false,
+                ),
+            );
+        }
+        let analyzed = OrdinaryBodyEngine::new(&mut host)
+            .analyze_method_with_identity_kind_resolved(
+                &infer,
+                issued_identity.clone(),
+                &full_name,
+                return_type,
+                resolved_params,
+                body,
+                span,
+                owner_type,
+                self_is_mut,
+                member.kind == crate::AnonymousMemberKind::Destructor,
+                returns_borrow || returns_inout,
+            )?;
+        let expression_engine_ns = elapsed_ns(expression_engine_started);
+        let expression_breakdown = host
+            .expression_breakdown
+            .expect("provider anonymous body analysis records its expression breakdown");
+        let specialization_selection_started = Instant::now();
+        let (function, warnings, strings, referenced_functions, referenced_methods) = analyzed;
+        let (function, selected_calls, mut referenced_specializations) =
+            crate::specialize::select_provider_body_specializations(&mut host, function)?;
+        referenced_specializations.extend(referenced_methods.iter().filter_map(
+            |(owner, method)| {
+                let info = host.method_info_for_symbol(*owner, *method)?;
+                let callable = host.member_callable_symbol(
+                    *owner,
+                    host.interner.resolve(method),
+                    info.has_self,
+                )?;
+                host.anonymous_function_identities
+                    .borrow()
+                    .get(&callable)
+                    .cloned()
+            },
+        ));
+        referenced_specializations
+            .extend(host.observed_comptime_producers.borrow().iter().cloned());
+        host.specialized_function_identities.borrow_mut().extend(
+            selected_calls
+                .iter()
+                .zip(referenced_specializations.iter())
+                .map(|((symbol, _), instance)| (*symbol, instance.clone())),
+        );
+        let selected_calls = selected_calls.into_iter().collect::<AHashMap<_, _>>();
+        let body_span = host.rir.rir().get(body).span;
+        let specialization_selection_ns = elapsed_ns(specialization_selection_started);
+        let body_export_started = Instant::now();
+        let export = super::semantic_body_export::export_body(
+            &host,
+            crate::BodyOwnerToken::new(0, 0),
+            body_span,
+            &function,
+            &strings,
+            &warnings,
+            Some(&selected_calls),
+            &referenced_methods,
+        )
+        .map(|export| crate::SemanticAnonymousBodyExport {
+            identity: issued_identity,
+            body: export.body,
+        })
         .map_err(|failure| {
             CompileError::without_span(rue_error::ErrorKind::OutputPublication(format!(
-                "provider anonymous produced-nominal export failed: {failure:?}"
+                "provider anonymous body export failed: {failure:?}"
             )))
         })?;
-    let mut referenced_definitions = referenced_functions
-        .iter()
-        .filter_map(|symbol| {
-            host.function_tokens
-                .borrow()
-                .get(symbol)
-                .map(|(_, key)| key.clone())
-        })
-        .collect::<AHashSet<_>>();
-    referenced_definitions.extend(
-        referenced_methods
+        let body_export_ns = elapsed_ns(body_export_started);
+        let result_projection_started = Instant::now();
+        let produced_anonymous_nominals = host
+            .produced_anonymous_nominals(&initial_anonymous_identities)
+            .map_err(|failure| {
+                CompileError::without_span(rue_error::ErrorKind::OutputPublication(format!(
+                    "provider anonymous produced-nominal export failed: {failure:?}"
+                )))
+            })?;
+        let mut referenced_definitions = referenced_functions
             .iter()
-            .filter_map(|(owner, method)| host.named_method_definition(*owner, *method)),
-    );
-    let referenced_definitions = referenced_definitions.into_iter().collect();
-    let referenced_values = host
-        .observed_named_definitions
-        .borrow()
-        .iter()
-        .cloned()
-        .collect();
-    let work = host.provider_body_work.snapshot();
-    let definition_tokens = host
-        .function_tokens
-        .into_inner()
-        .into_values()
-        .chain(host.nominal_tokens.into_inner().into_values())
-        .chain(
-            host.anonymous_definition_tokens
-                .into_inner()
-                .into_iter()
-                .map(|(key, token)| (token, key)),
-        )
-        .collect();
-    let module_tokens = host.module_tokens.into_inner().into_values().collect();
-    let result_projection_ns = elapsed_ns(result_projection_started);
-    publish_provider_body_breakdown(
-        host_setup_ns,
-        expression_engine_ns,
-        specialization_selection_ns,
-        body_export_ns,
-        result_projection_ns,
-        expression_breakdown,
-    );
-    Ok(ProviderAnonymousBody {
-        work,
-        export,
-        body_span,
-        function,
-        warnings,
-        strings,
-        type_pool: host.type_pool,
-        interner: host.interner,
-        produced_anonymous_nominals,
-        referenced_definitions,
-        referenced_values,
-        referenced_specializations,
-        definition_tokens,
-        module_tokens,
-    })
+            .filter_map(|symbol| {
+                host.function_tokens
+                    .borrow()
+                    .get(symbol)
+                    .map(|(_, key)| key.clone())
+            })
+            .collect::<AHashSet<_>>();
+        referenced_definitions.extend(
+            referenced_methods
+                .iter()
+                .filter_map(|(owner, method)| host.named_method_definition(*owner, *method)),
+        );
+        let referenced_definitions = referenced_definitions.into_iter().collect();
+        let referenced_values = host
+            .observed_named_definitions
+            .borrow()
+            .iter()
+            .cloned()
+            .collect();
+        let work = host.provider_body_work.snapshot();
+        let definition_tokens = host
+            .function_tokens
+            .into_inner()
+            .into_values()
+            .chain(host.nominal_tokens.into_inner().into_values())
+            .chain(
+                host.anonymous_definition_tokens
+                    .into_inner()
+                    .into_iter()
+                    .map(|(key, token)| (token, key)),
+            )
+            .collect();
+        let module_tokens = host.module_tokens.into_inner().into_values().collect();
+        let result_projection_ns = elapsed_ns(result_projection_started);
+        publish_provider_body_breakdown(
+            host_setup_ns,
+            expression_engine_ns,
+            specialization_selection_ns,
+            body_export_ns,
+            result_projection_ns,
+            expression_breakdown,
+        );
+        check_shared_interner(bundle.symbol_space(), "anonymous provider analysis")?;
+        Ok(ProviderAnonymousBody {
+            work,
+            export,
+            body_span,
+            function,
+            warnings,
+            strings,
+            type_pool: host.type_pool,
+            interner: host.interner,
+            produced_anonymous_nominals,
+            referenced_definitions,
+            referenced_values,
+            referenced_specializations,
+            definition_tokens,
+            module_tokens,
+        })
+    })();
+    match (
+        result,
+        check_shared_interner(bundle.symbol_space(), "anonymous provider analysis"),
+    ) {
+        (Err(error), _)
+            if matches!(
+                &error.kind,
+                ErrorKind::CompilerResourceLimit(_) | ErrorKind::CompilerResourceExhaustion(_)
+            ) =>
+        {
+            Err(error)
+        }
+        (_, Err(error)) => Err(error),
+        (result, Ok(())) => result,
+    }
 }
 
 /// Run one exact specialization request through the provider-backed body host.
@@ -5573,197 +5771,219 @@ where
     K: Clone + Eq + Hash + Ord,
     M: Clone + Eq + Hash + Ord,
 {
-    let owner_file = bundle.source_file_id().ok_or_else(|| {
-        CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-            "provider specialized body RIR does not have one source file".into(),
-        ))
-    })?;
-    let host_setup_started = Instant::now();
-    let mut host = ProviderBodyHost::new(
-        provider,
-        source,
-        bundle,
-        base,
-        owner_file,
-        name,
-        crate::StableDefinitionKind::Function,
-        None,
-        target,
-        preview,
-        well_known,
-    )
-    .ok_or_else(|| {
-        CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-            "provider specialization host could not be constructed".into(),
-        ))
-    })?;
-    // A generic free function reaches analysis only through its
-    // specializations, so the 6.6:3/6.6:4 accessor gate runs here as well.
-    if let Some(declaration) = host.endpoint.first_free_function(name, owner_file) {
-        host.reject_free_function_accessor(declaration)?;
-    }
-    let initial_anonymous_identities = host
-        .canonical_anonymous_types
-        .values()
-        .cloned()
-        .collect::<AHashSet<_>>();
-    let type_args = arguments
-        .types
-        .iter()
-        .map(|ty| host.materialize_type_instance(ty))
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|failure| {
-            CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(format!(
-                "provider specialization type argument is unavailable: {failure:?}"
-            )))
-        })?;
-    let value_args = arguments
-        .values
-        .iter()
-        .map(|value| host.materialize_argument_value(value))
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|failure| {
-            CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(format!(
-                "provider specialization value argument is unavailable: {failure:?}"
-            )))
-        })?;
-    let key = crate::specialize::SpecializationKey {
-        base_name: host.function_symbol,
-        type_args,
-        value_args,
-    };
-    host.endpoint
-        .finalize_containment_metadata()
-        .ok_or_else(|| {
+    let result = (|| -> CompileResult<ProviderSpecializedBody<K, M>> {
+        let owner_file = bundle.source_file_id().ok_or_else(|| {
             CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
-                "provider specialization containment metadata is unavailable".into(),
+                "provider specialized body RIR does not have one source file".into(),
             ))
         })?;
-    let infer = InferenceContext::new(&host);
-    let host_setup_ns = elapsed_ns(host_setup_started);
-    let expression_engine_started = Instant::now();
-    let specialized =
-        crate::specialize::analyze_one_specialization_with_host(&mut host, &infer, key)?;
-    let expression_engine_ns = elapsed_ns(expression_engine_started);
-    let expression_breakdown = host
-        .expression_breakdown
-        .expect("provider specialized body analysis records its expression breakdown");
-    let body_span = host
-        .rir
-        .rir()
-        .get(
-            host.endpoint
-                .endpoint_function_info(host.function_symbol)
-                .ok_or_else(|| {
-                    CompileError::without_span(rue_error::ErrorKind::UndefinedFunction(
-                        name.to_owned(),
-                    ))
-                })?
-                .body,
+        let host_setup_started = Instant::now();
+        let mut host = ProviderBodyHost::new(
+            provider,
+            source,
+            bundle,
+            base,
+            owner_file,
+            name,
+            crate::StableDefinitionKind::Function,
+            None,
+            target,
+            preview,
+            well_known,
         )
-        .span;
-    let specialization_selection_started = Instant::now();
-    let (function, selected_calls, referenced_specializations) =
-        crate::specialize::select_provider_body_specializations(&mut host, specialized.function)?;
-    host.specialized_function_identities.borrow_mut().extend(
-        selected_calls
+        .map_err(identity_mint_compile_error)?
+        .ok_or_else(|| {
+            CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                "provider specialization host could not be constructed".into(),
+            ))
+        })?;
+        // A generic free function reaches analysis only through its
+        // specializations, so the 6.6:3/6.6:4 accessor gate runs here as well.
+        if let Some(declaration) = host.endpoint.first_free_function(name, owner_file) {
+            host.reject_free_function_accessor(declaration)?;
+        }
+        let initial_anonymous_identities = host
+            .canonical_anonymous_types
+            .values()
+            .cloned()
+            .collect::<AHashSet<_>>();
+        let type_args = arguments
+            .types
             .iter()
-            .zip(referenced_specializations.iter())
-            .map(|((symbol, _), instance)| (*symbol, instance.clone())),
-    );
-    let selected_calls = selected_calls.into_iter().collect::<AHashMap<_, _>>();
-    let specialization_selection_ns = elapsed_ns(specialization_selection_started);
-    let body_export_started = Instant::now();
-    let body = super::semantic_body_export::export_body(
-        &host,
-        host.owner,
-        body_span,
-        &function,
-        &specialized.local_strings,
-        &specialized.warnings,
-        Some(&selected_calls),
-        &specialized.referenced_methods,
-    )
-    .map_err(|failure| {
-        CompileError::without_span(rue_error::ErrorKind::OutputPublication(format!(
-            "provider specialization export failed: {failure:?}"
-        )))
-    })?
-    .body;
-    let body_export_ns = elapsed_ns(body_export_started);
-    let result_projection_started = Instant::now();
-    let mut referenced_definitions = specialized
-        .referenced_functions
-        .iter()
-        .filter_map(|symbol| {
-            host.function_tokens
-                .borrow()
-                .get(symbol)
-                .map(|(_, key)| key.clone())
-        })
-        .collect::<AHashSet<_>>();
-    referenced_definitions.extend(
-        specialized
-            .referenced_methods
+            .map(|ty| host.materialize_type_instance(ty))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|failure| {
+                CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(format!(
+                    "provider specialization type argument is unavailable: {failure:?}"
+                )))
+            })?;
+        let value_args = arguments
+            .values
             .iter()
-            .filter_map(|(owner, method)| host.named_method_definition(*owner, *method)),
-    );
-    let referenced_definitions = referenced_definitions.into_iter().collect();
-    let referenced_values = host
-        .observed_named_definitions
-        .borrow()
-        .iter()
-        .cloned()
-        .collect();
-    let export = crate::SemanticSpecializedBodyExport {
-        identity: specialized.identity,
-        body,
-        dependencies: specialized.dependencies.into(),
-        dependency_boundary_complete: specialized.dependency_boundary_complete,
-    };
-    let produced_anonymous_nominals = host
-        .produced_anonymous_nominals(&initial_anonymous_identities)
+            .map(|value| host.materialize_argument_value(value))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|failure| {
+                CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(format!(
+                    "provider specialization value argument is unavailable: {failure:?}"
+                )))
+            })?;
+        let key = crate::specialize::SpecializationKey {
+            base_name: host.function_symbol,
+            type_args,
+            value_args,
+        };
+        host.endpoint
+            .finalize_containment_metadata()
+            .ok_or_else(|| {
+                CompileError::without_span(rue_error::ErrorKind::InvalidCompilerInput(
+                    "provider specialization containment metadata is unavailable".into(),
+                ))
+            })?;
+        let infer = InferenceContext::new(&host);
+        let host_setup_ns = elapsed_ns(host_setup_started);
+        let expression_engine_started = Instant::now();
+        let specialized =
+            crate::specialize::analyze_one_specialization_with_host(&mut host, &infer, key)?;
+        let expression_engine_ns = elapsed_ns(expression_engine_started);
+        let expression_breakdown = host
+            .expression_breakdown
+            .expect("provider specialized body analysis records its expression breakdown");
+        let body_span = host
+            .rir
+            .rir()
+            .get(
+                host.endpoint
+                    .endpoint_function_info(host.function_symbol)
+                    .ok_or_else(|| {
+                        CompileError::without_span(rue_error::ErrorKind::UndefinedFunction(
+                            name.to_owned(),
+                        ))
+                    })?
+                    .body,
+            )
+            .span;
+        let specialization_selection_started = Instant::now();
+        let (function, selected_calls, referenced_specializations) =
+            crate::specialize::select_provider_body_specializations(
+                &mut host,
+                specialized.function,
+            )?;
+        host.specialized_function_identities.borrow_mut().extend(
+            selected_calls
+                .iter()
+                .zip(referenced_specializations.iter())
+                .map(|((symbol, _), instance)| (*symbol, instance.clone())),
+        );
+        let selected_calls = selected_calls.into_iter().collect::<AHashMap<_, _>>();
+        let specialization_selection_ns = elapsed_ns(specialization_selection_started);
+        let body_export_started = Instant::now();
+        let body = super::semantic_body_export::export_body(
+            &host,
+            host.owner,
+            body_span,
+            &function,
+            &specialized.local_strings,
+            &specialized.warnings,
+            Some(&selected_calls),
+            &specialized.referenced_methods,
+        )
         .map_err(|failure| {
             CompileError::without_span(rue_error::ErrorKind::OutputPublication(format!(
-                "provider specialization produced-nominal export failed: {failure:?}"
+                "provider specialization export failed: {failure:?}"
             )))
-        })?;
-    let work = host.provider_body_work.snapshot();
-    let definition_tokens = host
-        .function_tokens
-        .into_inner()
-        .into_values()
-        .chain(host.nominal_tokens.into_inner().into_values())
-        .chain(
-            host.anonymous_definition_tokens
-                .into_inner()
-                .into_iter()
-                .map(|(key, token)| (token, key)),
-        )
-        .collect();
-    let module_tokens = host.module_tokens.into_inner().into_values().collect();
-    let result_projection_ns = elapsed_ns(result_projection_started);
-    publish_provider_body_breakdown(
-        host_setup_ns,
-        expression_engine_ns,
-        specialization_selection_ns,
-        body_export_ns,
-        result_projection_ns,
-        expression_breakdown,
-    );
-    Ok(ProviderSpecializedBody {
-        work,
-        export,
-        function,
-        warnings: specialized.warnings,
-        strings: specialized.local_strings,
-        type_pool: host.type_pool,
-        interner: host.interner,
-        produced_anonymous_nominals,
-        referenced_definitions,
-        referenced_values,
-        referenced_specializations,
-        definition_tokens,
-        module_tokens,
-    })
+        })?
+        .body;
+        let body_export_ns = elapsed_ns(body_export_started);
+        let result_projection_started = Instant::now();
+        let mut referenced_definitions = specialized
+            .referenced_functions
+            .iter()
+            .filter_map(|symbol| {
+                host.function_tokens
+                    .borrow()
+                    .get(symbol)
+                    .map(|(_, key)| key.clone())
+            })
+            .collect::<AHashSet<_>>();
+        referenced_definitions.extend(
+            specialized
+                .referenced_methods
+                .iter()
+                .filter_map(|(owner, method)| host.named_method_definition(*owner, *method)),
+        );
+        let referenced_definitions = referenced_definitions.into_iter().collect();
+        let referenced_values = host
+            .observed_named_definitions
+            .borrow()
+            .iter()
+            .cloned()
+            .collect();
+        let export = crate::SemanticSpecializedBodyExport {
+            identity: specialized.identity,
+            body,
+            dependencies: specialized.dependencies.into(),
+            dependency_boundary_complete: specialized.dependency_boundary_complete,
+        };
+        let produced_anonymous_nominals = host
+            .produced_anonymous_nominals(&initial_anonymous_identities)
+            .map_err(|failure| {
+                CompileError::without_span(rue_error::ErrorKind::OutputPublication(format!(
+                    "provider specialization produced-nominal export failed: {failure:?}"
+                )))
+            })?;
+        let work = host.provider_body_work.snapshot();
+        let definition_tokens = host
+            .function_tokens
+            .into_inner()
+            .into_values()
+            .chain(host.nominal_tokens.into_inner().into_values())
+            .chain(
+                host.anonymous_definition_tokens
+                    .into_inner()
+                    .into_iter()
+                    .map(|(key, token)| (token, key)),
+            )
+            .collect();
+        let module_tokens = host.module_tokens.into_inner().into_values().collect();
+        let result_projection_ns = elapsed_ns(result_projection_started);
+        publish_provider_body_breakdown(
+            host_setup_ns,
+            expression_engine_ns,
+            specialization_selection_ns,
+            body_export_ns,
+            result_projection_ns,
+            expression_breakdown,
+        );
+        check_shared_interner(bundle.symbol_space(), "specialized provider analysis")?;
+        Ok(ProviderSpecializedBody {
+            work,
+            export,
+            function,
+            warnings: specialized.warnings,
+            strings: specialized.local_strings,
+            type_pool: host.type_pool,
+            interner: host.interner,
+            produced_anonymous_nominals,
+            referenced_definitions,
+            referenced_values,
+            referenced_specializations,
+            definition_tokens,
+            module_tokens,
+        })
+    })();
+    match (
+        result,
+        check_shared_interner(bundle.symbol_space(), "specialized provider analysis"),
+    ) {
+        (Err(error), _)
+            if matches!(
+                &error.kind,
+                ErrorKind::CompilerResourceLimit(_) | ErrorKind::CompilerResourceExhaustion(_)
+            ) =>
+        {
+            Err(error)
+        }
+        (_, Err(error)) => Err(error),
+        (result, Ok(())) => result,
+    }
 }

--- a/crates/rue-air/src/semantic_body.rs
+++ b/crates/rue-air/src/semantic_body.rs
@@ -1179,7 +1179,7 @@ pub struct SemanticBodyCandidateInstallWork {
     pub strings_installed: usize,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SemanticBodyImportFailure {
     Semantic(super::SemanticImportFailure),
     StableResolution(SemanticStableResolutionFailure),

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -10,7 +10,7 @@ use std::hash::Hash;
 use std::sync::Arc;
 
 use ahash::AHashMap;
-use lasso::{Spur, ThreadedRodeo};
+use lasso::{LassoErrorKind, Spur, ThreadedRodeo};
 use rue_span::FileId;
 
 use crate::Node;
@@ -21,6 +21,7 @@ use crate::{
     SemanticBodyProjection, SemanticImportedBody, StructDef, StructField, StructId, Type,
     TypeInstanceKey, TypeInternPool,
 };
+use rue_rir::SharedSymbolSpace;
 use rue_span::Span;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -356,8 +357,11 @@ impl<K, M> SemanticImportConstValue<K, M> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SemanticImportFailure {
+    /// The body-local symbol domain rejected a new spelling. Preserve the
+    /// lasso classification so the compiler can distinguish E1401 from E1402.
+    Interner(LassoErrorKind),
     DuplicateNominal,
     DuplicateNominalLocalIdentity,
     DuplicateFunction,
@@ -613,7 +617,11 @@ enum LocalNominal {
 /// epoch-branded wrappers, so request-local IDs cannot cross epoch boundaries.
 pub struct SemanticImportEpoch<K: Ord, M: Ord> {
     epoch: Arc<()>,
-    interner: ThreadedRodeo,
+    interner: Arc<ThreadedRodeo>,
+    /// The owner of the local interner. Keeping insertion behind this space
+    /// lets canonical callers inject their request-local bound without a
+    /// mutable or thread-local test override.
+    symbol_space: SharedSymbolSpace,
     type_pool: TypeInternPool,
     module_registry: ModuleRegistry,
     nominals: AHashMap<NominalInstanceKey<K, M>, LocalNominal>,
@@ -719,7 +727,13 @@ where
                 )),
             },
             |_| Err(SemanticBodyImportFailure::UnsupportedGenericCall),
-            |name| interner.get_or_intern(name),
+            |name| {
+                interner.try_get_or_intern(name).map_err(|error| {
+                    SemanticBodyImportFailure::Semantic(SemanticImportFailure::Interner(
+                        error.kind(),
+                    ))
+                })
+            },
         )
     }
 
@@ -738,7 +752,7 @@ where
             (Spur, Vec<Type>, Vec<crate::sema::ConstValue>),
             SemanticBodyImportFailure,
         >,
-        intern: impl Fn(&str) -> Spur,
+        intern: impl Fn(&str) -> Result<Spur, SemanticBodyImportFailure>,
     ) -> Result<SemanticImportedBody<K, M>, SemanticBodyImportFailure> {
         use SemanticBodyImportFailure as F;
         let body_len = body_span
@@ -925,7 +939,7 @@ where
                     let args = call_args(args, current)?;
                     air.add_call(
                         Some(*runtime),
-                        intern(runtime.helper().helper().symbol),
+                        intern(runtime.helper().helper().symbol)?,
                         &args,
                         ty,
                         span,
@@ -948,7 +962,7 @@ where
                     name,
                     args,
                 } => {
-                    let name = intern(name.as_ref());
+                    let name = intern(name.as_ref())?;
                     if args.iter().any(|arg| arg.mode != crate::AirArgMode::Normal) {
                         return Err(F::InvalidParameterModes);
                     }
@@ -1175,20 +1189,36 @@ where
         })
     }
     pub fn new(
+        nominals: Vec<SemanticImportNominal<K>>,
+        function_keys: Vec<(K, Arc<str>)>,
+        module_keys: Vec<M>,
+    ) -> Result<Self, SemanticImportFailure> {
+        Self::new_in_space(
+            nominals,
+            function_keys,
+            module_keys,
+            SharedSymbolSpace::private(),
+        )
+    }
+
+    fn new_in_space(
         mut nominals: Vec<SemanticImportNominal<K>>,
         mut function_keys: Vec<(K, Arc<str>)>,
         mut module_keys: Vec<M>,
+        symbol_space: SharedSymbolSpace,
     ) -> Result<Self, SemanticImportFailure> {
         nominals.sort_by(|a, b| a.key.cmp(&b.key));
         function_keys.sort_by(|a, b| a.0.cmp(&b.0));
         module_keys.sort();
 
-        let interner = ThreadedRodeo::new();
+        let interner = symbol_space.interner().clone();
         let type_pool = TypeInternPool::new();
         let module_registry = ModuleRegistry::new();
         let mut builtins = BTreeMap::new();
         for builtin in rue_builtins::BUILTIN_ENUMS {
-            let symbol = interner.get_or_intern(builtin.name);
+            let symbol = symbol_space
+                .try_intern(builtin.name)
+                .map_err(SemanticImportFailure::Interner)?;
             let (id, _) = type_pool.register_enum(
                 symbol,
                 EnumDef {
@@ -1222,7 +1252,9 @@ where
             if !function_identities.insert(name.clone()) {
                 return Err(SemanticImportFailure::DuplicateFunctionLocalIdentity);
             }
-            let symbol = interner.get_or_intern(name.as_ref());
+            let symbol = symbol_space
+                .try_intern(name.as_ref())
+                .map_err(SemanticImportFailure::Interner)?;
             if functions
                 .insert(FunctionInstanceKey::Definition(key), symbol)
                 .is_some()
@@ -1259,7 +1291,9 @@ where
             }
             let file_id = module_files[&nominal.module_path];
             let name = nominal.name.clone();
-            let symbol = interner.get_or_intern(name.as_ref());
+            let symbol = symbol_space
+                .try_intern(name.as_ref())
+                .map_err(SemanticImportFailure::Interner)?;
             let value = match nominal.kind {
                 SemanticImportNominalKind::Struct => {
                     let (id, _) = type_pool.declare_struct(
@@ -1301,7 +1335,9 @@ where
         // stable core `str` identity. Preserve that order so a fresh epoch's
         // packed nominal IDs match exported AIR exactly. StrBuf is deliberately
         // absent: it is an ordinary source nominal supplied by std.
-        let str_symbol = interner.get_or_intern("str");
+        let str_symbol = symbol_space
+            .try_intern("str")
+            .map_err(SemanticImportFailure::Interner)?;
         let ptr_id = type_pool.intern_ptr_const_from_type(Type::U8);
         let (str_id, _) = type_pool.register_struct(
             str_symbol,
@@ -1333,6 +1369,7 @@ where
         let mut epoch = Self {
             epoch: Arc::new(()),
             interner,
+            symbol_space,
             type_pool,
             module_registry,
             nominals: local,
@@ -1356,9 +1393,27 @@ where
     /// reachable-program universe. Duplicate identities and duplicate local
     /// symbols fail before a body can be imported.
     pub fn new_local(
+        nominals: Vec<SemanticLocalNominal<K, M>>,
+        callables: Vec<SemanticLocalCallable<K, M>>,
+        modules: Vec<M>,
+    ) -> Result<Self, SemanticImportFailure>
+    where
+        K: Eq,
+        M: Clone + Eq,
+    {
+        Self::new_local_in_space(nominals, callables, modules, SharedSymbolSpace::private())
+    }
+
+    /// Construct a body-local epoch using the caller-owned symbol space.
+    ///
+    /// The compiler uses this for request-local CFG materialization so the
+    /// actual AIR insertion path, rather than a post-hoc length check, is
+    /// governed by the same bounded/fallible policy as other canonical names.
+    pub fn new_local_in_space(
         mut nominals: Vec<SemanticLocalNominal<K, M>>,
         mut callables: Vec<SemanticLocalCallable<K, M>>,
         modules: Vec<M>,
+        symbol_space: SharedSymbolSpace,
     ) -> Result<Self, SemanticImportFailure>
     where
         K: Eq,
@@ -1381,7 +1436,7 @@ where
         if modules.windows(2).any(|pair| pair[0] == pair[1]) {
             return Err(SemanticImportFailure::DuplicateModule);
         }
-        let mut epoch = Self::new(Vec::new(), Vec::new(), modules)?;
+        let mut epoch = Self::new_in_space(Vec::new(), Vec::new(), modules, symbol_space)?;
         epoch.functions.reserve(callables.len());
         epoch.nominals.reserve(nominals.len());
 
@@ -1390,7 +1445,10 @@ where
             if !callable_symbols.insert(callable.symbol.clone()) {
                 return Err(SemanticImportFailure::DuplicateCallableLocalIdentity);
             }
-            let symbol = epoch.interner.get_or_intern(callable.symbol.as_ref());
+            let symbol = epoch
+                .symbol_space
+                .try_intern(callable.symbol.as_ref())
+                .map_err(SemanticImportFailure::Interner)?;
             if epoch
                 .functions
                 .insert(callable.key.clone(), symbol)
@@ -1441,7 +1499,10 @@ where
                 return Err(SemanticImportFailure::DuplicateNominalLocalIdentity);
             }
             let file_id = module_files[&nominal.module_path];
-            let symbol = epoch.interner.get_or_intern(nominal.name.as_ref());
+            let symbol = epoch
+                .symbol_space
+                .try_intern(nominal.name.as_ref())
+                .map_err(SemanticImportFailure::Interner)?;
             let local = match nominal.kind {
                 SemanticImportNominalKind::Struct => {
                     let (id, _) = epoch.type_pool.declare_struct(
@@ -1580,7 +1641,11 @@ where
                 )?;
                 Ok((symbol, Vec::new(), Vec::new()))
             },
-            |value| self.interner.get_or_intern(value),
+            |value| {
+                self.symbol_space.try_intern(value).map_err(|kind| {
+                    SemanticBodyImportFailure::Semantic(SemanticImportFailure::Interner(kind))
+                })
+            },
         )?;
         let materialized_types = additional_types
             .iter()
@@ -1627,7 +1692,7 @@ where
             param_modes,
             allow_unreachable_code,
             type_pool: self.type_pool.freeze(),
-            interner: Arc::new(self.interner),
+            interner: self.interner,
             aggregate_types,
             materialized_types,
             strings,
@@ -1658,7 +1723,10 @@ where
             if kind != SemanticImportNominalKind::Struct {
                 return Err(SemanticImportFailure::BuiltinNominalKindMismatch);
             }
-            let symbol = self.interner.get_or_intern(name.as_ref());
+            let symbol = self
+                .symbol_space
+                .try_intern(name.as_ref())
+                .map_err(SemanticImportFailure::Interner)?;
             if let Some(existing) = type_pool.get_struct_by_file_name(FileId::DEFAULT, symbol) {
                 return Ok(LocalNominal::Struct(
                     existing
@@ -1785,7 +1853,10 @@ where
                     .try_intern_ptr_mut(value)
                     .map_err(|_| SemanticImportFailure::InvalidStructuralType)?,
                 F::Slice { element, name } => {
-                    let symbol = self.interner.get_or_intern(name.as_ref());
+                    let symbol = self
+                        .symbol_space
+                        .try_intern(name.as_ref())
+                        .map_err(SemanticImportFailure::Interner)?;
                     let pointer = type_pool.intern_ptr_const_from_type(element);
                     let (id, _) = type_pool.register_struct(
                         symbol,
@@ -1894,9 +1965,12 @@ where
             // The epoch owns an isolated interner, so the content round-trips
             // through it for validation; durable const payloads are never
             // installed into a live analyzer (install fails closed on consts).
-            SemanticImportConstValue::String(content) => {
-                ConstValue::String(self.interner.get_or_intern(content.as_ref()).into())
-            }
+            SemanticImportConstValue::String(content) => ConstValue::String(
+                self.symbol_space
+                    .try_intern(content.as_ref())
+                    .map_err(SemanticImportFailure::Interner)?
+                    .into(),
+            ),
         })
     }
 
@@ -2253,7 +2327,7 @@ where
         &self.type_pool
     }
     pub fn interner(&self) -> &ThreadedRodeo {
-        &self.interner
+        self.interner.as_ref()
     }
     pub fn module_registry(&self) -> &ModuleRegistry {
         &self.module_registry

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -112,10 +112,11 @@ pub const MAX_COMPTIME_CALL_DEPTH: usize = 48;
 fn collect_specializations(
     air: &Air,
     interner: &ThreadedRodeo,
+    intern: impl Fn(&str) -> Result<Spur, lasso::LassoErrorKind>,
     specializations: &mut AHashMap<SpecializationKey, SpecializationInfo>,
     pending: &mut Vec<SpecializationKey>,
     work: &mut crate::BodyAnalysisWork,
-) -> bool {
+) -> CompileResult<bool> {
     let mut has_call_generic = false;
     for inst in air.instructions() {
         work.specialization_air_instructions_scanned += 1;
@@ -146,7 +147,15 @@ fn collect_specializations(
                     &entry.key().type_args,
                     &entry.key().value_args,
                 );
-                let mangled_sym = interner.get_or_intern(&mangled);
+                let mangled_sym = intern(&mangled).map_err(|kind| {
+                    CompileError::new(
+                        rue_error::interner_error_kind(
+                            kind,
+                            format!("specialization symbol interning failed: {kind}"),
+                        ),
+                        inst.span,
+                    )
+                })?;
                 pending.push(entry.key().clone());
                 entry.insert(SpecializationInfo {
                     mangled_name: mangled_sym,
@@ -157,7 +166,7 @@ fn collect_specializations(
             }
         }
     }
-    has_call_generic
+    Ok(has_call_generic)
 }
 
 fn rewrite_call_generic(
@@ -265,10 +274,11 @@ where
     if collect_specializations(
         &function.air,
         host.body_interner(),
+        |text| host.try_intern_body_symbol(text),
         &mut specializations,
         &mut pending,
         &mut work,
-    ) {
+    )? {
         let mut editor = function.air.into_editor();
         rewrite_call_generic(&mut editor, &specializations, &mut work);
         function.air = editor.finish(crate::AirValidationContext::SemanticWithSymbols(

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -87,7 +87,7 @@ fn local_semantic_materialization_is_an_inert_exact_fact_boundary() {
         "pub(crate) fn new(",
         "pub(crate) fn identity(&self) -> &StableDefinitionKey",
         "pub(crate) fn lang_item(&self) -> Option<rue_air::LangItem>",
-        "rue_air::SemanticImportEpoch::new_local(",
+        "rue_air::SemanticImportEpoch::new_local_in_space(",
         ".materialize_local_body_with_types(",
         "FunctionInstanceKey::AnonymousMember",
         "materialize_canonical_body_with_indexes(",
@@ -178,8 +178,8 @@ fn cfg_queries_own_local_semantic_materialization_and_terminal_domains() {
         );
     }
     for required in [
-        "crate::local_semantic_materialization::materialize_canonical_body_with_indexes(",
-        "crate::local_semantic_materialization::materialize_semantic_body_with_indexes(",
+        "crate::local_semantic_materialization::materialize_canonical_body_with_indexes_in_space(",
+        "crate::local_semantic_materialization::materialize_semantic_body_with_indexes_in_space(",
     ] {
         let live_calls = cfg
             .lines()
@@ -296,6 +296,24 @@ fn codegen_queries_consume_only_registered_optimized_cfg_domains() {
             && session.contains("semantic functions only so focused tests can inspect units")
             && !session.contains("_foreign_symbols: &[String]"),
         "collection must retain only the test-only pre-object inspection adapter"
+    );
+}
+
+#[test]
+fn bounded_symbol_space_constructor_is_owner_only() {
+    // rue-rir is a separate crate, so the revision owner cannot use a
+    // crate-private constructor. The constructor is deliberately doc-hidden;
+    // this inventory is the scoped-authority gate that keeps its only normal
+    // build caller inside RevisionSymbolSpace, while the public test seam
+    // remains CompilerSession::with_interner_limit (cfg(test) only).
+    let database = include_str!("revisioned_query_database.rs");
+    let production = database.rsplit_once("#[cfg(test)]").unwrap().0;
+    assert_eq!(
+        production
+            .matches("next_generation_with_owner_bound")
+            .count(),
+        1,
+        "only the revision owner may inject the test bound"
     );
 }
 

--- a/crates/rue-compiler/src/canonical_lower.rs
+++ b/crates/rue-compiler/src/canonical_lower.rs
@@ -17,6 +17,13 @@ use rue_span::FileId;
 use crate::retained_charge::RetainedCharge;
 use crate::{CanonicalMergedProgram, SemanticSymbolUniverse, SourceRevision};
 
+fn interner_resource_error(kind: lasso::LassoErrorKind) -> CompileError {
+    CompileError::without_span(rue_lexer::interner_error_kind(
+        kind,
+        format!("this compilation could not intern another spelling: {kind}"),
+    ))
+}
+
 /// Classify a RIR construction failure for the user.
 ///
 /// Spec C.1:2 makes exceeding a published implementation limit a diagnosable
@@ -429,7 +436,13 @@ impl DeclarationBodyPlan {
                     "body-plan symbol universe did not preserve stable ordinals",
                 )));
             }
-            dense_remap.push(interner.get_or_intern(spelling));
+            let symbol = rue_lexer::try_intern(interner, spelling).map_err(|kind| {
+                BodyPlanMaterializationFailure::Build(RirPayloadBuildError::InternerFailure {
+                    family: "interned strings",
+                    kind,
+                })
+            })?;
+            dense_remap.push(symbol);
         }
         checkpoint().map_err(BodyPlanMaterializationFailure::Query)?;
         let symbol_finished_ns = elapsed();
@@ -538,6 +551,7 @@ fn lower_parsed_declaration_body_plan_internal(
         .ok_or(DeclarationBodyPlanBuildFailure::MissingCandidate)?;
     let symbols = lasso::ThreadedRodeo::new();
     let symbol_failure = RefCell::<Option<Arc<str>>>::new(None);
+    let interner_failure = RefCell::<Option<lasso::LassoErrorKind>>::new(None);
     let aborted = RefCell::new(None);
     let mut cancellation_check = || match checkpoint() {
         Ok(()) => true,
@@ -549,9 +563,20 @@ fn lower_parsed_declaration_body_plan_internal(
         }
     };
     let (editor, declaration, method_owner) = {
+        // AstGen's historical symbol-normalizer callback is infallible.  A
+        // failed insertion therefore needs a control-flow sentinel while the
+        // walk finishes; `interner_failure` is checked immediately after that
+        // walk and before validation or `finish_declaration_body_plan`, so the
+        // sentinel can never key or publish a successful declaration artifact.
         let mut generator = AstGen::with_symbol_normalizer(&symbols, |local| {
             match module.try_resolve_raw_symbol(local) {
-                Some(spelling) => symbols.get_or_intern(spelling),
+                Some(spelling) => match rue_lexer::try_intern(&symbols, spelling) {
+                    Ok(symbol) => symbol,
+                    Err(kind) => {
+                        *interner_failure.borrow_mut() = Some(kind);
+                        lasso::Spur::default()
+                    }
+                },
                 None => {
                     if symbol_failure.borrow().is_none() {
                         *symbol_failure.borrow_mut() = Some(Arc::from(format!(
@@ -559,7 +584,13 @@ fn lower_parsed_declaration_body_plan_internal(
                             local.into_usize()
                         )));
                     }
-                    symbols.get_or_intern("_@rue:invalid-candidate-symbol")
+                    match rue_lexer::try_intern(&symbols, "_@rue:invalid-candidate-symbol") {
+                        Ok(symbol) => symbol,
+                        Err(kind) => {
+                            *interner_failure.borrow_mut() = Some(kind);
+                            lasso::Spur::default()
+                        }
+                    }
                 }
             }
         });
@@ -613,9 +644,13 @@ fn lower_parsed_declaration_body_plan_internal(
                 return Err(DeclarationBodyPlanBuildFailure::Query(abort));
             }
             Err(rue_rir::AstGenFinishError::Payload(error)) => {
-                return Err(DeclarationBodyPlanBuildFailure::Payload(Arc::from(
-                    error.to_string(),
-                )));
+                return Err(
+                    if error.is_resource_limit() || error.is_resource_exhaustion() {
+                        DeclarationBodyPlanBuildFailure::Build(error)
+                    } else {
+                        DeclarationBodyPlanBuildFailure::Payload(Arc::from(error.to_string()))
+                    },
+                );
             }
         };
         (editor, root.declaration, owner)
@@ -626,6 +661,14 @@ fn lower_parsed_declaration_body_plan_internal(
     if let Some(error) = symbol_failure.into_inner() {
         return Err(DeclarationBodyPlanBuildFailure::ForeignSymbol(error));
     }
+    if let Some(kind) = interner_failure.into_inner() {
+        return Err(DeclarationBodyPlanBuildFailure::Build(
+            RirPayloadBuildError::InternerFailure {
+                family: "interned strings",
+                kind,
+            },
+        ));
+    }
     validate_candidate_root(&editor, declaration, candidate, &symbols)?;
     let method_owner = if let Some(owner) = method_owner {
         let owner_name = module
@@ -635,7 +678,12 @@ fn lower_parsed_declaration_body_plan_internal(
                     "method owner name is foreign to the parsed module symbol universe",
                 ))
             })?;
-        let owner_name = symbols.get_or_intern(owner_name);
+        let owner_name = rue_lexer::try_intern(&symbols, owner_name).map_err(|kind| {
+            DeclarationBodyPlanBuildFailure::Build(RirPayloadBuildError::InternerFailure {
+                family: "interned strings",
+                kind,
+            })
+        })?;
         Some(PackedRirMethodOwner {
             declaration,
             name: owner_name,
@@ -1179,7 +1227,13 @@ pub(crate) fn compose_module_rir_from_candidate_artifacts(
             "module source length exceeds RIR span capacity",
         ))
     })?;
-    let symbols = SemanticSymbolUniverse::from_modules(std::slice::from_ref(&module));
+    let symbols =
+        SemanticSymbolUniverse::from_modules(std::slice::from_ref(&module)).map_err(|error| {
+            DeclarationBodyPlanBuildFailure::Build(RirPayloadBuildError::InternerFailure {
+                family: "interned strings",
+                kind: error.0,
+            })
+        })?;
     let mut editor = RirEditor::new();
     #[cfg(test)]
     let mut declaration_roots = AHashMap::with_capacity(artifacts.len());
@@ -1208,7 +1262,14 @@ pub(crate) fn compose_module_rir_from_candidate_artifacts(
             if ordinal & 63 == 0 {
                 checkpoint().map_err(DeclarationBodyPlanBuildFailure::Query)?;
             }
-            local_symbols.push(symbols.interner().get_or_intern(spelling));
+            local_symbols.push(rue_lexer::try_intern(symbols.interner(), spelling).map_err(
+                |kind| {
+                    DeclarationBodyPlanBuildFailure::Build(RirPayloadBuildError::InternerFailure {
+                        family: "interned strings",
+                        kind,
+                    })
+                },
+            )?);
         }
         let mut symbols_translated = 0usize;
         let appended = if let Some(methods) = methods {
@@ -1404,7 +1465,8 @@ fn lower_module_rir_with_work_internal(
     >,
     cancellation_check: Option<&mut dyn FnMut() -> bool>,
 ) -> Result<CandidateModuleRirOutput, (CompileError, CanonicalRirWork)> {
-    let symbols = SemanticSymbolUniverse::from_modules(std::slice::from_ref(&module));
+    let symbols = SemanticSymbolUniverse::from_modules(std::slice::from_ref(&module))
+        .expect("test module symbol universe must fit the published interner bound");
     let view = crate::parsed_modules::ParsedAstView::from_module(module.clone());
     let first_error = RefCell::<Option<CompileError>>::new(None);
     let mut work = CanonicalRirWork {
@@ -1422,9 +1484,8 @@ fn lower_module_rir_with_work_internal(
                         if slot.is_none() {
                             *slot = Some(error);
                         }
-                        symbols
-                            .interner()
-                            .get_or_intern("__rue_invalid_local_symbol")
+                        rue_lexer::try_intern(symbols.interner(), "__rue_invalid_local_symbol")
+                            .expect("test symbol universe must fit the published interner bound")
                     }
                 }
             });
@@ -1518,6 +1579,7 @@ pub(crate) fn project_candidate_module_rirs_with_work(
     merged: &CanonicalMergedProgram,
     modules: &[std::sync::Arc<CandidateModuleRirOutput>],
     query_work: CanonicalRirWork,
+    max_interner_entries: usize,
 ) -> Result<CanonicalRirOutput, (CompileError, CanonicalRirWork)> {
     let ast = merged.ast();
     if modules.len() != ast.modules().len()
@@ -1536,7 +1598,27 @@ pub(crate) fn project_candidate_module_rirs_with_work(
             query_work,
         ));
     }
-    let symbols = SemanticSymbolUniverse::from_modules(ast.modules());
+    let symbols =
+        SemanticSymbolUniverse::from_modules_with_limit(ast.modules(), max_interner_entries)
+            .map_err(|error| (interner_resource_error(error.0), query_work))?;
+    // `append_remapped_with_spans` deliberately exposes an infallible symbol
+    // callback, so consume every module symbol through the bounded interner
+    // before entering that append boundary.  This keeps exhaustion typed and
+    // leaves the callback as a pure lookup over the proven complete map.
+    for lowered in modules {
+        for (_, spelling) in lowered.symbols.interner().iter() {
+            if symbols.interner().get(spelling).is_none()
+                && symbols.interner().len() >= max_interner_entries
+            {
+                return Err((
+                    interner_resource_error(lasso::LassoErrorKind::KeySpaceExhaustion),
+                    query_work,
+                ));
+            }
+            rue_lexer::try_intern(symbols.interner(), spelling)
+                .map_err(|kind| (interner_resource_error(kind), query_work))?;
+        }
+    }
     let mut editor = RirEditor::new();
     let mut module_ranges = Vec::with_capacity(modules.len());
     let mut work = query_work;
@@ -1550,7 +1632,10 @@ pub(crate) fn project_candidate_module_rirs_with_work(
                         .interner()
                         .try_resolve(&local)
                         .expect("validated module RIR symbol belongs to its module universe");
-                    symbols.interner().get_or_intern(text)
+                    symbols
+                        .interner()
+                        .get(text)
+                        .expect("module projection pre-interned every source symbol")
                 },
                 |span| rue_span::Span::with_file(parsed.file_id(), span.start, span.end),
             )
@@ -1649,6 +1734,17 @@ mod tests {
         assert_eq!(
             rir_build_error_kind(
                 "ctx",
+                &RirPayloadBuildError::InternerFailure {
+                    family: "interned strings",
+                    kind: lasso::LassoErrorKind::FailedAllocation,
+                },
+            )
+            .code(),
+            rue_error::ErrorCode::COMPILER_RESOURCE_EXHAUSTION
+        );
+        assert_eq!(
+            rir_build_error_kind(
+                "ctx",
                 &RirPayloadBuildError::InvalidBuilderInput {
                     family: "call args",
                     reason: "bad request",
@@ -1656,6 +1752,29 @@ mod tests {
             )
             .code(),
             rue_error::ErrorCode::INTERNAL_ERROR
+        );
+    }
+
+    #[test]
+    fn canonical_merge_interning_exhaustion_is_a_resource_diagnostic() {
+        // The bound is injected into the session-owned revision symbol space,
+        // so canonical materialization and its worker queries observe it
+        // without process- or thread-local mutation.
+        let snapshot = snapshot(
+            &[
+                (1, "/first.rue", "first.rue", "fn first() {}"),
+                (2, "/second.rue", "second.rue", "fn second() {}"),
+            ],
+            1,
+        );
+        let mut session = crate::CompilerSession::with_interner_limit(20);
+        session.update(&snapshot).into_result().unwrap();
+        let errors = session.canonical_rir().unwrap_err();
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.kind.code() == rue_error::ErrorCode::COMPILER_RESOURCE_LIMIT),
+            "canonical merge must report E1401, got {errors:?}"
         );
     }
 
@@ -2233,8 +2352,13 @@ fn target(inout values: [i32; 4]) -> type {
             items_visited: 1,
             ..CanonicalRirWork::default()
         };
-        let (_, failure_work) =
-            project_candidate_module_rirs_with_work(&merged, &[], query_work).unwrap_err();
+        let (_, failure_work) = project_candidate_module_rirs_with_work(
+            &merged,
+            &[],
+            query_work,
+            rue_lexer::MAX_INTERNED_STRINGS,
+        )
+        .unwrap_err();
         assert_eq!(failure_work, query_work);
     }
 

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -59,11 +59,22 @@ pub(crate) struct CfgBodyInput {
     pub(crate) function: crate::FunctionInstanceKey,
     pub(crate) canonical: Arc<crate::body_query::CanonicalBody>,
     pub(crate) body_span: Span,
+    #[cfg(test)]
+    pub(crate) interner_limit: Option<usize>,
 }
 
 impl PartialEq for CfgBodyInput {
     fn eq(&self, other: &Self) -> bool {
-        self.function == other.function && self.canonical == other.canonical
+        self.function == other.function && self.canonical == other.canonical && {
+            #[cfg(test)]
+            {
+                self.interner_limit == other.interner_limit
+            }
+            #[cfg(not(test))]
+            {
+                true
+            }
+        }
     }
 }
 
@@ -1021,11 +1032,20 @@ fn internal_failure(message: impl Into<String>, body_span: Span) -> CfgValue {
 
 fn interner_copy_capacity_failure(kind: lasso::LassoErrorKind, body_span: Span) -> CfgValue {
     let message = format!("CFG interner isolation failed: {kind}");
-    let kind = if kind.is_failed_alloc() {
-        rue_error::ErrorKind::CompilerResourceExhaustion(message)
-    } else {
-        rue_error::ErrorKind::CompilerResourceLimit(message)
-    };
+    let kind = rue_lexer::interner_error_kind(kind, message);
+    CfgValue::Failure {
+        errors: crate::CompileError::new(kind, body_span).into(),
+        body_span,
+    }
+}
+
+fn interner_resource_failure(
+    kind: lasso::LassoErrorKind,
+    context: impl std::fmt::Display,
+    body_span: Span,
+) -> CfgValue {
+    let message = format!("{context}: {kind}");
+    let kind = rue_lexer::interner_error_kind(kind, message);
     CfgValue::Failure {
         errors: crate::CompileError::new(kind, body_span).into(),
         body_span,
@@ -1180,12 +1200,32 @@ fn materialize_and_build_cfg(
     context.record_work(rue_query::WorkItem::new("cfg.materialize.attempts", 1));
     let input_preparation_ns = elapsed_ns(input_preparation_started);
     let materialization_started = std::time::Instant::now();
+    #[cfg(test)]
+    let local_interner_limit = match &key.semantic_input {
+        CfgSemanticInput::Body { input, .. } => input.interner_limit,
+        CfgSemanticInput::DropGlue { .. } => None,
+    };
+    // The local semantic epoch owns the actual insertion path. Tests inject
+    // their request-local ceiling into that owner so a regression to an
+    // infallible insertion cannot pass by merely checking the final length.
+    let materialization_symbol_space = {
+        #[cfg(test)]
+        {
+            local_interner_limit
+                .map(rue_rir::SharedSymbolSpace::with_owner_bound)
+                .unwrap_or_else(rue_rir::SharedSymbolSpace::private)
+        }
+        #[cfg(not(test))]
+        {
+            rue_rir::SharedSymbolSpace::private()
+        }
+    };
     // Both CFG inputs use the exact fact-side indexes prepared during
     // selection, keeping canonical-body and drop-glue materialization on one
     // indexed path.
     let materialized = match &key.semantic_input {
         CfgSemanticInput::Body { input, .. } => {
-            crate::local_semantic_materialization::materialize_canonical_body_with_indexes(
+            crate::local_semantic_materialization::materialize_canonical_body_with_indexes_in_space(
                 &input.canonical,
                 body_span,
                 &facts.declarations,
@@ -1196,10 +1236,11 @@ fn materialize_and_build_cfg(
                 &builtin_facts,
                 &facts.required_types,
                 &facts.indexes,
+                materialization_symbol_space,
             )
         }
         CfgSemanticInput::DropGlue { owner, .. } => {
-            crate::local_semantic_materialization::materialize_semantic_body_with_indexes(
+            crate::local_semantic_materialization::materialize_semantic_body_with_indexes_in_space(
                 crate::FunctionInstanceKey::DropGlue(Node::new(owner.clone())),
                 body,
                 body_span,
@@ -1211,6 +1252,7 @@ fn materialize_and_build_cfg(
                 &builtin_facts,
                 &facts.required_types,
                 &facts.indexes,
+                materialization_symbol_space,
             )
         }
     };
@@ -1220,6 +1262,28 @@ fn materialize_and_build_cfg(
         Ok(value) => value,
         Err(error) => {
             context.record_work(rue_query::WorkItem::new("cfg.materialize.failures", 1));
+            if let crate::local_semantic_materialization::LocalMaterializationFailure::Import(
+                rue_air::SemanticImportFailure::Interner(kind),
+            ) = &error
+            {
+                return Ok(interner_resource_failure(
+                    *kind,
+                    "request-local CFG symbol domain",
+                    body_span,
+                ));
+            }
+            if let crate::local_semantic_materialization::LocalMaterializationFailure::Body(
+                rue_air::SemanticBodyImportFailure::Semantic(
+                    rue_air::SemanticImportFailure::Interner(kind),
+                ),
+            ) = &error
+            {
+                return Ok(interner_resource_failure(
+                    *kind,
+                    "request-local CFG symbol domain",
+                    body_span,
+                ));
+            }
             return Ok(internal_failure(
                 format!("canonical CFG materialization failed: {error:?}"),
                 body_span,
@@ -1266,6 +1330,13 @@ fn materialize_and_build_cfg(
         }) {
             Ok(value) => value,
             Err(error) => {
+                if let crate::durable_cfg::CfgDomainFailure::Interner(kind) = error {
+                    return Ok(interner_resource_failure(
+                        kind,
+                        "canonical CFG domain interner",
+                        body_span,
+                    ));
+                }
                 return Ok(internal_failure(
                     format!("canonical CFG domain projection failed: {error:?}"),
                     body_span,
@@ -1408,7 +1479,10 @@ fn build_cfg(
         materialized.air.instructions().len() as u64,
     ));
     let builder_started = std::time::Instant::now();
-    let output = rue_cfg::CfgBuilder::build(
+    // Canonical AIR already owns every source symbol. CFG projection must
+    // resolve that body-local domain without extending it; compiler-generated
+    // spellings are admitted by the semantic provider before this boundary.
+    let output = rue_cfg::CfgBuilder::build_with_symbol_resolver(
         &materialized.air,
         materialized.num_locals,
         materialized.num_param_slots,
@@ -1418,6 +1492,7 @@ fn build_cfg(
         &materialized.interner,
         materialized.allow_unreachable_code,
         materialized.callable_kind,
+        |name| materialized.interner.get(name),
     );
     let cfg_builder_ns = elapsed_ns(builder_started);
     let publication_started = std::time::Instant::now();

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -505,6 +505,7 @@ impl RetainedCharge for CfgDomainProjection {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CfgDomainFailure {
+    Interner(lasso::LassoErrorKind),
     Shape,
     Unsupported,
     Missing,
@@ -606,7 +607,9 @@ impl CfgDomainProjection {
             if current_symbols.contains_key(stable) {
                 continue;
             }
-            let symbol = new_interner.get_or_intern(old_interner.resolve(live));
+            let symbol = new_interner
+                .try_get_or_intern(old_interner.resolve(live))
+                .map_err(|error| CfgDomainFailure::Interner(error.kind()))?;
             current_symbols.insert(stable.clone(), symbol);
             self.symbols.push((symbol, stable.clone()));
         }
@@ -1148,7 +1151,9 @@ impl CfgDomainProjection {
                 TypeKind::Struct(id) => {
                     let definition = type_pool.struct_def(id);
                     if let Some(name) = &definition.destructor {
-                        let symbol = interner.get_or_intern(name);
+                        let symbol = interner
+                            .try_get_or_intern(name)
+                            .map_err(|error| CfgDomainFailure::Interner(error.kind()))?;
                         if let Some(callable) = stable_callable(symbol) {
                             symbols.push((symbol, StableCfgSymbol::Callable(callable)));
                         } else if let Some(CanonicalType::AnonymousNominal(owner)) = type_positions

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -882,6 +882,7 @@ fn mangle_canonical_value(value: &crate::CanonicalArgumentValue) -> String {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
 pub(crate) fn materialize_canonical_body_with_indexes(
     canonical: &crate::body_query::CanonicalBody,
     body_span: rue_span::Span,
@@ -893,6 +894,35 @@ pub(crate) fn materialize_canonical_body_with_indexes(
     builtin_facts: &[LocalBuiltinNominalFact],
     materialization_types: &[crate::durable_semantics::DurableType],
     indexes: &LocalMaterializationIndexes,
+) -> Result<LocalSemanticMaterialization, LocalMaterializationFailure> {
+    materialize_canonical_body_with_indexes_in_space(
+        canonical,
+        body_span,
+        declarations,
+        anonymous_nominals,
+        callable_facts,
+        nominal_metadata,
+        modules,
+        builtin_facts,
+        materialization_types,
+        indexes,
+        rue_rir::SharedSymbolSpace::private(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn materialize_canonical_body_with_indexes_in_space(
+    canonical: &crate::body_query::CanonicalBody,
+    body_span: rue_span::Span,
+    declarations: &[DurableDeclarationSemantic],
+    anonymous_nominals: &[DurableAnonymousNominal],
+    callable_facts: &[LocalCallableFact],
+    nominal_metadata: &[LocalNominalMetadataFact],
+    modules: &[ModuleId],
+    builtin_facts: &[LocalBuiltinNominalFact],
+    materialization_types: &[crate::durable_semantics::DurableType],
+    indexes: &LocalMaterializationIndexes,
+    symbol_space: rue_rir::SharedSymbolSpace,
 ) -> Result<LocalSemanticMaterialization, LocalMaterializationFailure> {
     let (identity, body) = match canonical {
         crate::body_query::CanonicalBody::Ordinary { owner, body } => {
@@ -907,7 +937,7 @@ pub(crate) fn materialize_canonical_body_with_indexes(
             body,
         ),
     };
-    materialize_semantic_body_with_indexes(
+    materialize_semantic_body_with_indexes_in_space(
         identity,
         body,
         body_span,
@@ -919,10 +949,12 @@ pub(crate) fn materialize_canonical_body_with_indexes(
         builtin_facts,
         materialization_types,
         indexes,
+        symbol_space,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
 pub(crate) fn materialize_semantic_body_with_indexes(
     identity: FunctionInstanceKey,
     body: &rue_air::SemanticBody<StableDefinitionKey, ModuleId>,
@@ -935,6 +967,37 @@ pub(crate) fn materialize_semantic_body_with_indexes(
     builtin_facts: &[LocalBuiltinNominalFact],
     materialization_types: &[crate::durable_semantics::DurableType],
     indexes: &LocalMaterializationIndexes,
+) -> Result<LocalSemanticMaterialization, LocalMaterializationFailure> {
+    materialize_semantic_body_with_indexes_in_space(
+        identity,
+        body,
+        body_span,
+        declarations,
+        anonymous_nominals,
+        callable_facts,
+        _nominal_metadata,
+        modules,
+        builtin_facts,
+        materialization_types,
+        indexes,
+        rue_rir::SharedSymbolSpace::private(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn materialize_semantic_body_with_indexes_in_space(
+    identity: FunctionInstanceKey,
+    body: &rue_air::SemanticBody<StableDefinitionKey, ModuleId>,
+    body_span: rue_span::Span,
+    declarations: &[DurableDeclarationSemantic],
+    anonymous_nominals: &[DurableAnonymousNominal],
+    callable_facts: &[LocalCallableFact],
+    _nominal_metadata: &[LocalNominalMetadataFact],
+    modules: &[ModuleId],
+    builtin_facts: &[LocalBuiltinNominalFact],
+    materialization_types: &[crate::durable_semantics::DurableType],
+    indexes: &LocalMaterializationIndexes,
+    symbol_space: rue_rir::SharedSymbolSpace,
 ) -> Result<LocalSemanticMaterialization, LocalMaterializationFailure> {
     let callable_kind = if body.is_accessor {
         rue_air::AnalyzedCallableKind::Accessor
@@ -1146,7 +1209,12 @@ pub(crate) fn materialize_semantic_body_with_indexes(
             symbol: fact.symbol.clone(),
         })
         .collect();
-    let epoch = rue_air::SemanticImportEpoch::new_local(nominals, callables, modules.to_vec())?;
+    let epoch = rue_air::SemanticImportEpoch::new_local_in_space(
+        nominals,
+        callables,
+        modules.to_vec(),
+        symbol_space,
+    )?;
     Ok(epoch.materialize_local_body_with_types(
         identity,
         callable_kind,
@@ -1905,6 +1973,59 @@ mod tests {
         owner: Option<(StableDefinitionKind, Arc<str>)>,
     ) -> StableDefinitionKey {
         StableDefinitionKey::for_test(module, kind.namespace(), kind, name, owner)
+    }
+
+    #[test]
+    fn bounded_space_observes_actual_materialization_failure_and_keeps_bound() {
+        let module = ModuleId::from_validated_canonical("main.rue");
+        let function = definition(
+            module.clone(),
+            StableDefinitionKind::Function,
+            "probe",
+            None,
+        );
+        let canonical = crate::body_query::CanonicalBody::Ordinary {
+            owner: function.clone(),
+            body: body(),
+        };
+        let declarations = [];
+        let nominal_metadata = [];
+        let indexes = LocalMaterializationIndexes::new(&declarations, &nominal_metadata);
+        let bounded = rue_rir::SharedSymbolSpace::with_owner_bound(0);
+        let witness = bounded.clone();
+
+        let error = materialize_canonical_body_with_indexes_in_space(
+            &canonical,
+            rue_span::Span::with_file(rue_span::FileId::new(3), 100, 200),
+            &declarations,
+            &[],
+            &[LocalCallableFact {
+                identity: FunctionInstanceKey::Definition(function),
+                symbol: Arc::from("probe"),
+            }],
+            &nominal_metadata,
+            std::slice::from_ref(&module),
+            &[],
+            &[],
+            &indexes,
+            bounded,
+        )
+        .err()
+        .unwrap_or_else(|| {
+            panic!("a zero-entry space must reject the first materialization symbol")
+        });
+
+        assert!(matches!(
+            error,
+            LocalMaterializationFailure::Import(rue_air::SemanticImportFailure::Interner(
+                lasso::LassoErrorKind::KeySpaceExhaustion
+            ))
+        ));
+        assert_eq!(
+            witness.interner_failure(),
+            Some(lasso::LassoErrorKind::KeySpaceExhaustion)
+        );
+        assert_eq!(witness.interner().len(), 0);
     }
 
     #[test]

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -11437,6 +11437,7 @@ impl Default for RevisionedQueryDatabase {
         Self::with_declaration_memo_retention_and_concurrency(
             DECLARATION_QUERY_MEMO_RETENTION,
             crate::query_concurrency(),
+            u32::MAX as usize,
         )
     }
 }
@@ -11447,7 +11448,11 @@ impl RevisionedQueryDatabase {
     /// eviction-lifecycle tests pass a small cap so exceeding it stays cheap.
     #[cfg(test)]
     pub(crate) fn with_declaration_memo_retention(declaration_memo_retention: usize) -> Self {
-        Self::with_declaration_memo_retention_and_concurrency(declaration_memo_retention, 1)
+        Self::with_declaration_memo_retention_and_concurrency(
+            declaration_memo_retention,
+            1,
+            rue_lexer::MAX_INTERNED_STRINGS,
+        )
     }
 
     #[cfg(test)]
@@ -11455,12 +11460,23 @@ impl RevisionedQueryDatabase {
         Self::with_declaration_memo_retention_and_concurrency(
             DECLARATION_QUERY_MEMO_RETENTION,
             query_concurrency,
+            rue_lexer::MAX_INTERNED_STRINGS,
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_interner_limit(max_entries: usize) -> Self {
+        Self::with_declaration_memo_retention_and_concurrency(
+            DECLARATION_QUERY_MEMO_RETENTION,
+            1,
+            max_entries,
         )
     }
 
     fn with_declaration_memo_retention_and_concurrency(
         declaration_memo_retention: usize,
         query_concurrency: usize,
+        max_interner_entries: usize,
     ) -> Self {
         let runtime = CompilerQueryRuntime(QueryRuntime::new(query_concurrency));
         let body_reachability_meter = Arc::new(BodyReachabilityMeter::default());
@@ -16299,7 +16315,7 @@ impl RevisionedQueryDatabase {
                     lookup_root_lease: lookup_root_lease.clone(),
                     runtime: runtime.clone(),
                     shared_durable_payloads: shared_durable_payloads.clone(),
-                    symbol_space: RevisionSymbolSpace::default(),
+                    symbol_space: RevisionSymbolSpace::with_owner_bound(max_interner_entries),
                     #[cfg(test)]
                     inject_body_transaction_failure: inject_body_transaction_failure.clone(),
                     #[cfg(test)]
@@ -17464,15 +17480,30 @@ impl BodyInputResolver {
 /// each other's space and abandon each other's bodies without progressing;
 /// keeping the recent few makes that need more simultaneously live revisions
 /// than the engine pins, while still bounding how many interners are resident.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct RevisionSymbolSpace {
-    generations: rue_rir::SymbolSpaceGenerations,
     live: Mutex<VecDeque<(Revision, rue_rir::SharedSymbolSpace)>>,
+    generations: rue_rir::SymbolSpaceGenerations,
+    max_entries: usize,
+}
+
+impl Default for RevisionSymbolSpace {
+    fn default() -> Self {
+        Self::with_owner_bound(rue_lexer::MAX_INTERNED_STRINGS)
+    }
 }
 
 impl RevisionSymbolSpace {
     /// How many revisions' equality spaces stay live at once.
     const WINDOW: usize = 4;
+
+    fn with_owner_bound(max_entries: usize) -> Self {
+        Self {
+            live: Mutex::new(VecDeque::new()),
+            generations: rue_rir::SymbolSpaceGenerations::default(),
+            max_entries,
+        }
+    }
 
     /// The live generation for `revision`, minting it if this revision has no
     /// live generation yet.
@@ -17484,7 +17515,9 @@ impl RevisionSymbolSpace {
         if let Some((_, space)) = live.iter().find(|(pinned, _)| *pinned == revision) {
             return space.clone();
         }
-        let space = self.generations.next_generation();
+        let space = self
+            .generations
+            .next_generation_with_owner_bound(self.max_entries);
         live.push_back((revision, space.clone()));
         while live.len() > Self::WINDOW {
             if let Some((_, evicted)) = live.pop_front() {
@@ -25740,6 +25773,13 @@ mod tests {
                 },
                 rue_error::ErrorCode::COMPILER_RESOURCE_EXHAUSTION,
             ),
+            (
+                rue_rir::RirPayloadBuildError::InternerFailure {
+                    family: "packed test",
+                    kind: lasso::LassoErrorKind::FailedAllocation,
+                },
+                rue_error::ErrorCode::COMPILER_RESOURCE_EXHAUSTION,
+            ),
         ];
         for (error, expected) in cases {
             let artifact_kind =
@@ -30425,6 +30465,7 @@ fn main() -> i32 {
             &merged,
             &module_rirs,
             query_work,
+            rue_lexer::MAX_INTERNED_STRINGS,
         )
         .unwrap();
         assert_eq!(projected_rir.work().modules_visited, 2);
@@ -36514,7 +36555,7 @@ fn main() -> i32 {
                     .named_method_info(&shift_key, file, "Widget", "shift")
                     .expect("named_method_info resolves");
                 let compact_owner = named.struct_type.as_struct().expect("Widget is a struct");
-                let compact_name = facts.name_symbol("shift");
+                let compact_name = facts.name_symbol("shift").expect("shift is interned");
                 assert_eq!(
                     endpoints
                         .method_info(compact_owner, compact_name)
@@ -36528,7 +36569,9 @@ fn main() -> i32 {
                     ..named
                 };
                 assert!(
-                    facts.register_anonymous_method(file, "Widget", "shift", anonymous),
+                    facts
+                        .register_anonymous_method(file, "Widget", "shift", anonymous)
+                        .expect("shift name is admitted"),
                     "the anonymous method registers atomically under both lookup keys"
                 );
                 let info = facts
@@ -36719,8 +36762,9 @@ fn main() -> i32 {
                     DurableDeclSource::from_declarations(&decls),
                     rue_air::BodyRirView::from_parts(rir_ref, interner),
                 );
-                let token =
-                    facts.register_named_nominal(box_key, file.index(), "Box", Kind::Struct);
+                let token = facts
+                    .register_named_nominal(box_key, file.index(), "Box", Kind::Struct)
+                    .expect("Box name is admitted");
                 let ty = facts
                     .resolve_instance_type(&TypeInstanceKey::<
                         SemanticDefinitionToken,
@@ -36817,12 +36861,15 @@ fn main() -> i32 {
                     rue_air::BodyRirView::from_parts(rir_ref, interner),
                 );
                 let named = |token: DTok| -> T<DTok, MTok> { T::Nominal(N::Named(token)) };
-                let point_token =
-                    facts.register_named_nominal(point_key.clone(), 1, "Point", Kind::Struct);
-                let holder_token =
-                    facts.register_named_nominal(holder_key.clone(), 1, "Holder", Kind::Struct);
-                let color_token =
-                    facts.register_named_nominal(color_key.clone(), 1, "Color", Kind::Enum);
+                let point_token = facts
+                    .register_named_nominal(point_key.clone(), 1, "Point", Kind::Struct)
+                    .expect("Point name is admitted");
+                let holder_token = facts
+                    .register_named_nominal(holder_key.clone(), 1, "Holder", Kind::Struct)
+                    .expect("Holder name is admitted");
+                let color_token = facts
+                    .register_named_nominal(color_key.clone(), 1, "Color", Kind::Enum)
+                    .expect("Color name is admitted");
 
                 let point_ty = facts
                     .resolve_instance_type(&named(point_token))
@@ -37114,12 +37161,9 @@ fn main() -> i32 {
                     adapter,
                     rue_air::BodyRirView::from_parts(rir, interner),
                 );
-                let point_token = facts.register_named_nominal(
-                    point_key.clone(),
-                    file.index(),
-                    "Point",
-                    Kind::Struct,
-                );
+                let point_token = facts
+                    .register_named_nominal(point_key.clone(), file.index(), "Point", Kind::Struct)
+                    .expect("Point name is admitted");
 
                 // Module identity — r4b-3 / the flip (pool-refused arm).
                 let module = facts.resolve_instance_type(&T::Module(MTok::new(0, 0)));
@@ -39859,6 +39903,8 @@ fn main() -> i32 {
                         function,
                         canonical: body.clone(),
                         body_span,
+                        #[cfg(test)]
+                        interner_limit: None,
                     }),
                     materialization: Arc::new(facts),
                 },

--- a/crates/rue-compiler/src/semantic_symbols.rs
+++ b/crates/rue-compiler/src/semantic_symbols.rs
@@ -61,20 +61,34 @@ pub struct SemanticSymbolUniverse {
     unique_semantic_strings: AtomicUsize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SemanticSymbolInternerExhausted(pub(crate) lasso::LassoErrorKind);
+
 impl SemanticSymbolUniverse {
     /// Start a destination universe for one canonical program traversal.
     #[cfg(test)]
     pub(crate) fn new(program: &ParsedProgram) -> Self {
-        let universe = Self::from_modules(program.modules());
+        let universe = Self::from_modules(program.modules())
+            .expect("test semantic universe must fit the published interner bound");
         if let Some(symbols) = program.shared_symbol_strings() {
             for symbol in symbols {
-                universe.interner.get_or_intern(symbol);
+                rue_lexer::try_intern(&universe.interner, symbol)
+                    .expect("test semantic universe must fit the published interner bound");
             }
         }
         universe
     }
 
-    pub(crate) fn from_modules(modules: &[Arc<crate::parsed_modules::ParsedModule>]) -> Self {
+    pub(crate) fn from_modules(
+        modules: &[Arc<crate::parsed_modules::ParsedModule>],
+    ) -> Result<Self, SemanticSymbolInternerExhausted> {
+        Self::from_modules_with_limit(modules, rue_lexer::MAX_INTERNED_STRINGS)
+    }
+
+    pub(crate) fn from_modules_with_limit(
+        modules: &[Arc<crate::parsed_modules::ParsedModule>],
+        max_entries: usize,
+    ) -> Result<Self, SemanticSymbolInternerExhausted> {
         let universe = Self {
             admitted_modules: modules.to_vec().into(),
             interner: Arc::new(ThreadedRodeo::new()),
@@ -93,10 +107,17 @@ impl SemanticSymbolUniverse {
                 .all(|module| module.shares_resolver_with(first))
         {
             for symbol in first.resolver_strings() {
-                universe.interner.get_or_intern(symbol);
+                if universe.interner.get(symbol).is_none() && universe.interner.len() >= max_entries
+                {
+                    return Err(SemanticSymbolInternerExhausted(
+                        lasso::LassoErrorKind::KeySpaceExhaustion,
+                    ));
+                }
+                rue_lexer::try_intern(&universe.interner, symbol)
+                    .map_err(SemanticSymbolInternerExhausted)?;
             }
         }
-        universe
+        Ok(universe)
     }
 
     /// Translate a provenanced local symbol through its owning module view.
@@ -138,7 +159,8 @@ impl SemanticSymbolUniverse {
             self.unique_semantic_strings.fetch_add(1, Ordering::Relaxed);
         }
         Ok(SemanticSymbol {
-            spur: self.interner.get_or_intern(text),
+            spur: rue_lexer::try_intern(&self.interner, text)
+                .expect("test semantic universe must fit the published interner bound"),
             provenance: self.provenance.clone(),
         })
     }

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -666,6 +666,13 @@ impl CompilerSessionUpdate {
 #[derive(Debug, Default)]
 pub struct CompilerSession {
     identity: Arc<()>,
+    /// Test-only injection for the canonical compilation-owned symbol bound.
+    /// Production leaves this unset and uses the published u32 ceiling.
+    #[cfg(test)]
+    interner_limit: Option<usize>,
+    /// Test-only bound for the request-local CFG symbol universe.
+    #[cfg(test)]
+    cfg_interner_limit: Option<usize>,
     /// Test-only differential-oracle perturbation requested through the
     /// unstable test bridge. It corrupts a canonical projection at the next
     /// observation point without reviving a retired selected-result store.
@@ -1473,6 +1480,28 @@ impl CompilerSession {
             crate::revisioned_query_database::RevisionedQueryDatabase::with_query_concurrency(
                 workers,
             );
+        session
+    }
+
+    /// Construct a canonical session with a bounded shared symbol space for
+    /// deterministic resource-limit regression tests. The bound is owned by
+    /// the query database and therefore reaches the worker threads that run
+    /// canonical materialization.
+    #[cfg(test)]
+    pub(crate) fn with_interner_limit(max_entries: usize) -> Self {
+        let mut session = Self::default();
+        session.interner_limit = Some(max_entries);
+        session.queries.revisioned =
+            crate::revisioned_query_database::RevisionedQueryDatabase::with_interner_limit(
+                max_entries,
+            );
+        session
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_cfg_interner_limit(max_entries: usize) -> Self {
+        let mut session = Self::default();
+        session.cfg_interner_limit = Some(max_entries);
         session
     }
 
@@ -4542,7 +4571,17 @@ impl CompilerSession {
                     Ok(modules) => {
                         let projected = {
                             let _span = tracing::info_span!("rir_projection").entered();
-                            project_candidate_module_rirs_with_work(merged, &modules, query_work)
+                            project_candidate_module_rirs_with_work(merged, &modules, query_work, {
+                                #[cfg(test)]
+                                {
+                                    self.interner_limit
+                                        .unwrap_or(rue_lexer::MAX_INTERNED_STRINGS)
+                                }
+                                #[cfg(not(test))]
+                                {
+                                    rue_lexer::MAX_INTERNED_STRINGS
+                                }
+                            })
                         };
                         match projected {
                             Ok(rir) => {
@@ -5188,6 +5227,8 @@ impl CompilerSession {
                         function: closure_body.key.instance.clone(),
                         canonical: body.clone(),
                         body_span,
+                        #[cfg(test)]
+                        interner_limit: self.cfg_interner_limit,
                     }),
                     materialization: Arc::new(materialization),
                 },
@@ -10099,6 +10140,185 @@ mod tests {
         session
             .rooted_cfg(&CompileOptions::default())
             .expect("many shallow specializations must compile");
+    }
+
+    #[test]
+    fn revision_shared_semantic_and_cfg_interning_exhaustion_is_typed() {
+        // Search the owner-controlled bound, rather than relying on a public
+        // thread-local override. The first successful canonical projection
+        // followed by a failing rooted-CFG query proves that the exhaustion
+        // occurs in post-lexer semantic/CFG work.
+        let valid = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn id(comptime T: type, value: T) -> T { value } fn main() -> i32 { id(i32, 42) }",
+            )],
+            1,
+        );
+        let mut observed = None;
+        for limit in 20..256 {
+            let mut session = CompilerSession::with_interner_limit(limit);
+            session.update(&valid).into_result().unwrap();
+            if session.canonical_rir().is_err() {
+                continue;
+            }
+            if let Err(errors) = session.rooted_cfg(&CompileOptions::default()) {
+                let resource_errors = errors
+                    .iter()
+                    .filter(|error| {
+                        error.kind.code() == rue_error::ErrorCode::COMPILER_RESOURCE_LIMIT
+                            || error.kind.code()
+                                == rue_error::ErrorCode::COMPILER_RESOURCE_EXHAUSTION
+                    })
+                    .collect::<Vec<_>>();
+                if resource_errors.len() == 1
+                    && errors.len() == 1
+                    && !errors
+                        .iter()
+                        .any(|error| matches!(error.kind, ErrorKind::InternalError(_)))
+                    && format!("{:?}", resource_errors[0].kind)
+                        .to_ascii_lowercase()
+                        .contains("provider")
+                {
+                    observed = Some(limit);
+                    break;
+                }
+            }
+        }
+        assert!(
+            observed.is_some(),
+            "a successful canonical projection must expose a typed revision-shared semantic/CFG exhaustion"
+        );
+    }
+
+    #[test]
+    fn two_lazy_named_nominals_after_bound_report_one_typed_error() {
+        let valid = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "struct First { second: Second } struct Second { value: i32 } fn main() -> i32 { 0 }",
+            )],
+            1,
+        );
+        let mut observed = false;
+        for limit in 20..256 {
+            let mut session = CompilerSession::with_interner_limit(limit);
+            session.update(&valid).into_result().unwrap();
+            if session.canonical_rir().is_err() {
+                continue;
+            }
+            let Err(errors) = session.rooted_cfg(&CompileOptions::default()) else {
+                continue;
+            };
+            if errors.len() == 1
+                && errors.iter().all(|error| {
+                    matches!(
+                        error.kind,
+                        ErrorKind::CompilerResourceLimit(_)
+                            | ErrorKind::CompilerResourceExhaustion(_)
+                    )
+                })
+                && !errors
+                    .iter()
+                    .any(|error| matches!(error.kind, ErrorKind::InternalError(_)))
+            {
+                observed = true;
+                break;
+            }
+        }
+        assert!(
+            observed,
+            "lazy named nominal materialization must fail once with a typed resource diagnostic"
+        );
+    }
+
+    #[test]
+    fn bounded_request_local_cfg_projection_reports_typed_exhaustion() {
+        let valid = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn main() -> i32 { let value = 42; value }",
+            )],
+            1,
+        );
+        let mut observed = false;
+        for limit in 0..64 {
+            let mut session = CompilerSession::with_cfg_interner_limit(limit);
+            session.update(&valid).into_result().unwrap();
+            if session.canonical_rir().is_err() {
+                continue;
+            }
+            let Err(errors) = session.rooted_cfg(&CompileOptions::default()) else {
+                continue;
+            };
+            if errors.len() == 1
+                && errors.iter().any(|error| {
+                    matches!(error.kind, ErrorKind::CompilerResourceLimit(_))
+                        && format!("{:?}", error.kind).contains("request-local CFG")
+                })
+                && !errors
+                    .iter()
+                    .any(|error| matches!(error.kind, ErrorKind::InternalError(_)))
+            {
+                observed = true;
+                break;
+            }
+        }
+        assert!(
+            observed,
+            "the production CFG query must classify request-local symbol exhaustion"
+        );
+    }
+
+    #[test]
+    fn specialization_symbol_exhaustion_is_typed_at_the_session_boundary() {
+        let mut main = String::from("fn choose(comptime n: i32) -> i32 { n } fn main() -> i32 {\n");
+        for value in 0..32 {
+            main.push_str(&format!("    choose({value}) +\n"));
+        }
+        main.push_str("    0\n}\n");
+        let specialization_call = main.find("choose(0)").expect("generated call") as u32;
+        let specialization_span = rue_span::Span::with_file(
+            FileId::new(1),
+            specialization_call,
+            specialization_call + "choose(0)".len() as u32,
+        );
+        let valid = snapshot(&[(1, "/p/main.rue", "main.rue", main.as_str())], 1);
+        let mut observed = None;
+        for limit in 20..256 {
+            let mut session = CompilerSession::with_interner_limit(limit);
+            session.update(&valid).into_result().unwrap();
+            if session.canonical_rir().is_err() {
+                continue;
+            }
+            let Err(errors) = session.rooted_cfg(&CompileOptions::default()) else {
+                continue;
+            };
+            if errors.len() == 1
+                && !errors
+                    .iter()
+                    .any(|error| matches!(error.kind, ErrorKind::InternalError(_)))
+                && errors.iter().any(|error| {
+                    error.kind.code() == rue_error::ErrorCode::COMPILER_RESOURCE_LIMIT
+                        && format!("{:?}", error.kind)
+                            .contains("specialization symbol interning failed")
+                        && error.span() == Some(specialization_span)
+                })
+            {
+                observed = Some(limit);
+                break;
+            }
+        }
+        assert!(
+            observed.is_some(),
+            "specialization materialization must report the owning symbol-space exhaustion"
+        );
     }
 
     #[test]

--- a/crates/rue-error/BUCK
+++ b/crates/rue-error/BUCK
@@ -4,6 +4,7 @@ rue_crate(
     name = "rue-error",
     deps = [
         "//crates/rue-span:rue-span",
+        "//third-party:lasso",
         "//third-party:thiserror",
     ],
 )

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -33,6 +33,18 @@ use std::collections::HashSet;
 use std::fmt;
 use thiserror::Error;
 
+/// Classify a Lasso interner failure at the compiler diagnostic boundary.
+/// Key-space and configured-memory limits are E1401; an allocator failure is
+/// E1402. Keeping this mapping here prevents phase crates from losing the
+/// allocator's original error kind or duplicating an inverted classifier.
+pub fn interner_error_kind(kind: lasso::LassoErrorKind, message: impl Into<String>) -> ErrorKind {
+    if kind.is_failed_alloc() {
+        ErrorKind::CompilerResourceExhaustion(message.into())
+    } else {
+        ErrorKind::CompilerResourceLimit(message.into())
+    }
+}
+
 // ============================================================================
 // Error Codes
 // ============================================================================

--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -24,14 +24,46 @@ pub const LEXER_DIAGNOSTIC_BUDGET: usize = 100;
 /// is formed, per the graceful-failure policy in spec C.1:2.
 pub const MAX_SOURCE_BYTES: usize = u32::MAX as usize;
 
-/// Maximum number of distinct strings one compilation can intern.
+/// Maximum number of distinct strings in any one compilation-owned symbol
+/// domain.
 ///
 /// Interner handles are `lasso::Spur`, a non-zero `u32`, so the usable keys are
-/// `1..=u32::MAX` (spec Appendix C.5:1, C.6:1). Identifiers and string literals
-/// are the only unbounded, source-driven producers of new interned strings, and
-/// the lexer refuses a file that could carry the shared interner past this
-/// ceiling rather than letting the interner abort (spec C.1:2).
+/// `1..=u32::MAX` (spec Appendix C.5:1, C.6:1). Identifiers, literals, parser
+/// primitives, and compiler-generated spellings ultimately belong to
+/// compilation-owned symbol domains. Lexer/parser staging, canonical semantic
+/// lowering, and revision-shared AIR destinations are separate domains; each
+/// has this per-domain key-space ceiling. Every post-lexer producer must route
+/// new spellings through its owning fallible insertion boundary rather than
+/// letting the interner abort (spec C.1:2).
 pub const MAX_INTERNED_STRINGS: usize = u32::MAX as usize;
+
+/// The one fallible entry point for the compilation-owned symbol interner.
+/// Existing spellings remain readable when the boundary is reached; only a
+/// new spelling consumes capacity.
+pub fn try_intern(
+    interner: &lasso::ThreadedRodeo,
+    text: impl AsRef<str>,
+) -> Result<Spur, lasso::LassoErrorKind> {
+    interner
+        .try_get_or_intern(text)
+        .map_err(|error| error.kind())
+}
+
+/// Preserve Lasso's distinction between a published key-space limit and a
+/// failed allocation when exposing the compiler diagnostic.
+pub fn interner_error_kind(
+    kind: lasso::LassoErrorKind,
+    message: impl Into<String>,
+) -> rue_error::ErrorKind {
+    rue_error::interner_error_kind(kind, message)
+}
+
+/// Stable diagnostic for exhaustion of the compilation-owned symbol interner.
+pub fn interner_exhausted_error() -> rue_error::CompileError {
+    rue_error::CompileError::without_span(rue_error::ErrorKind::CompilerResourceLimit(format!(
+        "this symbol domain exceeded its maximum of {MAX_INTERNED_STRINGS} distinct interned spellings"
+    )))
+}
 
 /// Token kinds in the Rue language.
 ///

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -50,13 +50,13 @@ pub enum LexError {
         escape: char,
     },
     UnterminatedString,
-    /// The string interner ran out of keys. A `Spur` is a non-zero `u32`, so a
-    /// compilation can hold at most [`MAX_INTERNED_STRINGS`] distinct
-    /// identifiers and string literals (spec Appendix C.5:1). `lasso` would
+    /// The string interner failed. A `Spur` is a non-zero `u32`, so one symbol
+    /// domain can hold at most [`MAX_INTERNED_STRINGS`] distinct spellings
+    /// (spec Appendix C.5:1). `lasso` would
     /// abort on the next intern; spec C.1:2 requires a diagnostic naming the
     /// limit instead, so exhaustion is reported through the ordinary lexical
     /// error channel as `E1401`.
-    InternerExhausted,
+    InternerExhausted(lasso::LassoErrorKind),
     /// An uppercase base prefix (`0X`/`0B`/`0O`). Base prefixes are lowercase
     /// (`0x`/`0b`/`0o`, spec 2.1); rejecting the whole literal with a targeted
     /// error is friendlier than Rust's behavior of lexing `0XFF` as `0` plus
@@ -210,7 +210,7 @@ fn process_string_from_quote(lex: &mut logos::Lexer<'_, LogosTokenKind>) -> Resu
     let spur = lex
         .extras
         .try_get_or_intern(&result)
-        .map_err(|_| LexError::InternerExhausted)?;
+        .map_err(|error| LexError::InternerExhausted(error.kind()))?;
     Ok(spur)
 }
 
@@ -312,11 +312,11 @@ fn intern_float_literal(lex: &mut logos::Lexer<'_, LogosTokenKind>) -> Result<Sp
         let digits: String = slice.chars().filter(|c| *c != '_').collect();
         lex.extras
             .try_get_or_intern(&digits)
-            .map_err(|_| LexError::InternerExhausted)
+            .map_err(|error| LexError::InternerExhausted(error.kind()))
     } else {
         lex.extras
             .try_get_or_intern(slice)
-            .map_err(|_| LexError::InternerExhausted)
+            .map_err(|error| LexError::InternerExhausted(error.kind()))
     }
 }
 
@@ -628,7 +628,7 @@ pub enum LogosTokenKind {
         |lex| lex
             .extras
             .try_get_or_intern(lex.slice())
-            .map_err(|_| LexError::InternerExhausted),
+            .map_err(|error| LexError::InternerExhausted(error.kind())),
         priority = 1
     )]
     Ident(Spur),
@@ -946,12 +946,19 @@ impl<'a> LogosLexer<'a> {
                                         span_offset(span.end),
                                     ),
                                 ),
-                                LexError::InternerExhausted => (
-                                    ErrorKind::CompilerResourceLimit(format!(
-                                        "this compilation exceeded the maximum of \
-                                         {MAX_INTERNED_STRINGS} distinct interned identifiers \
-                                         and string literals"
-                                    )),
+                                LexError::InternerExhausted(kind) => (
+                                    crate::interner_error_kind(
+                                        kind,
+                                        match kind {
+                                            lasso::LassoErrorKind::FailedAllocation => {
+                                                "lexer symbol-domain allocation failed while interning a spelling".to_owned()
+                                            }
+                                            _ => format!(
+                                                "this symbol domain exceeded its maximum of \
+                                             {MAX_INTERNED_STRINGS} distinct interned spellings"
+                                            ),
+                                        },
+                                    ),
                                     Span::with_file(
                                         self.file_id,
                                         span_offset(span.start),
@@ -2209,6 +2216,24 @@ mod tests {
         assert!(matches!(tokens[0].kind, TokenKind::Int(0x1e9)));
         assert!(matches!(tokens[1].kind, TokenKind::Int(0b101)));
         assert!(matches!(tokens[2].kind, TokenKind::Int(0o17)));
+    }
+
+    #[test]
+    fn lexer_interner_failure_classification_preserves_allocator_failures() {
+        assert!(matches!(
+            crate::interner_error_kind(
+                lasso::LassoErrorKind::KeySpaceExhaustion,
+                "lexer symbol space"
+            ),
+            ErrorKind::CompilerResourceLimit(_)
+        ));
+        assert!(matches!(
+            crate::interner_error_kind(
+                lasso::LassoErrorKind::FailedAllocation,
+                "lexer symbol space"
+            ),
+            ErrorKind::CompilerResourceExhaustion(_)
+        ));
     }
 
     #[test]

--- a/crates/rue-parser/src/parser.rs
+++ b/crates/rue-parser/src/parser.rs
@@ -20,6 +20,7 @@ pub struct Parser {
     syms: PrimitiveTypeSpurs,
     file_id: FileId,
     errors: diagnostics::ParserDiagnostics,
+    interner_error: Option<lasso::LassoErrorKind>,
 }
 struct PrimitiveTypeSpurs {
     i8: Spur,
@@ -44,27 +45,64 @@ struct PrimitiveTypeSpurs {
 }
 
 impl PrimitiveTypeSpurs {
-    fn new(interner: &mut ThreadedRodeo) -> Self {
+    fn new(
+        interner: &mut ThreadedRodeo,
+        _max_entries: Option<usize>,
+    ) -> Result<Self, lasso::LassoErrorKind> {
+        let intern = |text: &str| {
+            #[cfg(test)]
+            if _max_entries
+                .is_some_and(|limit| interner.len() >= limit && interner.get(text).is_none())
+            {
+                return Err(lasso::LassoErrorKind::KeySpaceExhaustion);
+            }
+            rue_lexer::try_intern(interner, text)
+        };
+        Ok(Self {
+            i8: intern("i8")?,
+            i16: intern("i16")?,
+            i32: intern("i32")?,
+            i64: intern("i64")?,
+            u8: intern("u8")?,
+            u16: intern("u16")?,
+            u32: intern("u32")?,
+            u64: intern("u64")?,
+            bool: intern("bool")?,
+            self_type: intern("Self")?,
+            self_value: intern("self")?,
+            type_kw: intern("type")?,
+            as_kw: intern("as")?,
+            drop_kw: intern("drop")?,
+            drop_marker: intern("__drop")?,
+            allow_directive: intern("allow")?,
+            copy_directive: intern("copy")?,
+            repr_directive: intern("repr")?,
+            underscore: intern("_")?,
+        })
+    }
+
+    fn fallback() -> Self {
+        let symbol = Spur::default();
         Self {
-            i8: interner.get_or_intern("i8"),
-            i16: interner.get_or_intern("i16"),
-            i32: interner.get_or_intern("i32"),
-            i64: interner.get_or_intern("i64"),
-            u8: interner.get_or_intern("u8"),
-            u16: interner.get_or_intern("u16"),
-            u32: interner.get_or_intern("u32"),
-            u64: interner.get_or_intern("u64"),
-            bool: interner.get_or_intern("bool"),
-            self_type: interner.get_or_intern("Self"),
-            self_value: interner.get_or_intern("self"),
-            type_kw: interner.get_or_intern("type"),
-            as_kw: interner.get_or_intern("as"),
-            drop_kw: interner.get_or_intern("drop"),
-            drop_marker: interner.get_or_intern("__drop"),
-            allow_directive: interner.get_or_intern("allow"),
-            copy_directive: interner.get_or_intern("copy"),
-            repr_directive: interner.get_or_intern("repr"),
-            underscore: interner.get_or_intern("_"),
+            i8: symbol,
+            i16: symbol,
+            i32: symbol,
+            i64: symbol,
+            u8: symbol,
+            u16: symbol,
+            u32: symbol,
+            u64: symbol,
+            bool: symbol,
+            self_type: symbol,
+            self_value: symbol,
+            type_kw: symbol,
+            as_kw: symbol,
+            drop_kw: symbol,
+            drop_marker: symbol,
+            allow_directive: symbol,
+            copy_directive: symbol,
+            repr_directive: symbol,
+            underscore: symbol,
         }
     }
 }
@@ -73,9 +111,12 @@ impl Parser {
     /// Create a parser from lexer tokens and their shared symbol interner.
     pub fn new(tokens: Vec<Token>, mut interner: ThreadedRodeo) -> Self {
         let file_id = tokens.first().map(|t| t.span.file_id).unwrap_or_default();
-        let syms = {
+        let (syms, interner_error) = {
             let _span = info_span!("parser_state_setup").entered();
-            PrimitiveTypeSpurs::new(&mut interner)
+            match PrimitiveTypeSpurs::new(&mut interner, None) {
+                Ok(syms) => (syms, None),
+                Err(kind) => (PrimitiveTypeSpurs::fallback(), Some(kind)),
+            }
         };
         Self {
             tokens,
@@ -84,6 +125,30 @@ impl Parser {
             syms,
             file_id,
             errors: diagnostics::ParserDiagnostics::default(),
+            interner_error,
+        }
+    }
+
+    #[cfg(test)]
+    fn new_with_interner_limit_for_test(
+        tokens: Vec<Token>,
+        mut interner: ThreadedRodeo,
+        max_entries: usize,
+    ) -> Self {
+        let file_id = tokens.first().map(|t| t.span.file_id).unwrap_or_default();
+        let (syms, interner_error) = match PrimitiveTypeSpurs::new(&mut interner, Some(max_entries))
+        {
+            Ok(syms) => (syms, None),
+            Err(kind) => (PrimitiveTypeSpurs::fallback(), Some(kind)),
+        };
+        Self {
+            tokens,
+            cursor: 0,
+            interner,
+            syms,
+            file_id,
+            errors: diagnostics::ParserDiagnostics::default(),
+            interner_error,
         }
     }
 
@@ -97,6 +162,15 @@ impl Parser {
     pub fn parse_preserving_interner(
         mut self,
     ) -> Result<(Ast, ThreadedRodeo), (CompileErrors, ThreadedRodeo)> {
+        if let Some(kind) = self.interner_error {
+            return Err((
+                CompileErrors::from(CompileError::without_span(rue_lexer::interner_error_kind(
+                    kind,
+                    "the parser could not intern a required primitive spelling",
+                ))),
+                self.interner,
+            ));
+        }
         let input_token_count = self.tokens.len();
         let parser_token_count = self
             .tokens
@@ -204,6 +278,18 @@ mod tests {
     fn parse_source(source: &str) -> Result<(Ast, ThreadedRodeo), CompileErrors> {
         let (tokens, interner) = Lexer::new(source).tokenize().unwrap();
         Parser::new(tokens, interner).parse()
+    }
+
+    #[test]
+    fn primitive_symbol_key_limit_is_reported_as_a_resource_limit() {
+        let interner = ThreadedRodeo::with_memory_limits(lasso::MemoryLimits::for_memory_usage(1));
+        let errors = Parser::new_with_interner_limit_for_test(Vec::new(), interner, 0)
+            .parse()
+            .unwrap_err();
+        assert!(matches!(
+            errors.first().map(|error| &error.kind),
+            Some(ErrorKind::CompilerResourceLimit(_))
+        ));
     }
 
     #[test]

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -87,6 +87,8 @@ pub struct AstGen<'a> {
     normalize_symbol: Box<dyn Fn(Spur) -> Spur + 'a>,
     cancellation_check: Option<Box<dyn FnMut() -> bool + 'a>>,
     canceled: bool,
+    #[cfg(test)]
+    interner_limit: Option<usize>,
 }
 
 #[derive(Debug)]
@@ -168,7 +170,15 @@ impl<'a> AstGen<'a> {
             normalize_symbol: Box::new(normalize_symbol),
             cancellation_check: None,
             canceled: false,
+            #[cfg(test)]
+            interner_limit: None,
         }
+    }
+
+    #[cfg(test)]
+    fn with_interner_limit_for_test(mut self, max_entries: usize) -> Self {
+        self.interner_limit = Some(max_entries);
+        self
     }
 
     pub fn install_cancellation_check(&mut self, check: impl FnMut() -> bool + 'a) {
@@ -346,6 +356,30 @@ impl<'a> AstGen<'a> {
         (self.normalize_symbol)(symbol)
     }
 
+    /// Intern compiler-generated names through the same bounded symbol space
+    /// as source symbols.  The generator still completes its structural walk
+    /// with a harmless placeholder after exhaustion so the typed failure can
+    /// be returned at `try_finish_editor`, before any RIR is published.
+    fn intern(&mut self, text: impl AsRef<str>) -> Spur {
+        #[cfg(test)]
+        if self.interner_limit.is_some_and(|limit| {
+            self.interner.len() >= limit && self.interner.get(text.as_ref()).is_none()
+        }) {
+            self.record_interner_failure(
+                "interned strings",
+                lasso::LassoErrorKind::KeySpaceExhaustion,
+            );
+            return Spur::default();
+        }
+        match rue_lexer::try_intern(self.interner, text) {
+            Ok(symbol) => symbol,
+            Err(kind) => {
+                self.record_interner_failure("interned strings", kind);
+                Spur::default()
+            }
+        }
+    }
+
     fn with_structural_segment<T>(
         &mut self,
         segment: crate::RirStructuralPathSegment,
@@ -461,6 +495,13 @@ impl<'a> AstGen<'a> {
         if self.payload_error.is_none() {
             self.payload_error =
                 Some(crate::RirPayloadBuildError::InvalidBuilderInput { family, reason });
+        }
+    }
+
+    fn record_interner_failure(&mut self, family: &'static str, kind: lasso::LassoErrorKind) {
+        if self.payload_error.is_none() {
+            self.payload_error =
+                Some(crate::RirPayloadBuildError::InternerFailure { family, kind });
         }
     }
 
@@ -1431,7 +1472,7 @@ impl<'a> AstGen<'a> {
             }
             Expr::SelfExpr(self_expr) => {
                 // `self` in method bodies is just a variable reference to the implicit self parameter
-                let name = self.interner.get_or_intern("self");
+                let name = self.intern("self");
                 self.rir.add_inst(Inst {
                     data: InstData::VarRef { name, anchor: None },
                     span: self_expr.span,
@@ -1752,7 +1793,7 @@ impl<'a> AstGen<'a> {
             self.symbol(id.name)
         } else {
             let init = self.gen_expr_at(crate::RirStructuralPathSegment::Operand(0), coll_expr);
-            let name = self.interner.get_or_intern(format!("@rue:for:coll:{n}"));
+            let name = self.intern(format!("@rue:for:coll:{n}"));
             let alloc = self
                 .rir
                 .add_alloc(&[], Some(name), false, None, init, false, span)
@@ -1762,8 +1803,8 @@ impl<'a> AstGen<'a> {
         };
 
         // let mut __p: u64 = 0;   (position — usize is u64)
-        let p_name = self.interner.get_or_intern(format!("@rue:for:pos:{n}"));
-        let u64_sym = self.interner.get_or_intern("u64");
+        let p_name = self.intern(format!("@rue:for:pos:{n}"));
+        let u64_sym = self.intern("u64");
         let u64_type = self.rir.add_named_type(u64_sym).unwrap_or_else(|error| {
             if self.payload_error.is_none() {
                 self.payload_error = Some(type_syntax_build_error(error));
@@ -1785,7 +1826,7 @@ impl<'a> AstGen<'a> {
         // Sema's not-iterable type error (E0206) anchors on the intrinsic, and
         // it should underline the offending iterable expression.
         let iter_span = coll_expr.span();
-        let len_name = self.interner.get_or_intern(format!("@rue:for:len:{n}"));
+        let len_name = self.intern(format!("@rue:for:len:{n}"));
         let coll_for_len = self.rir.add_inst(Inst {
             data: InstData::VarRef {
                 name: coll_name,
@@ -1859,9 +1900,7 @@ impl<'a> AstGen<'a> {
         // collection still owns and drops it, RUE-259).
         let binder_name: Option<Spur> = match &for_expr.binder {
             LetPattern::Ident(id) => Some(self.symbol(id.name)),
-            LetPattern::Wildcard(_) => {
-                Some(self.interner.get_or_intern(format!("_@rue:for:elem:{n}")))
-            }
+            LetPattern::Wildcard(_) => Some(self.intern(format!("_@rue:for:elem:{n}"))),
         };
         let p_for_get = self.rir.add_inst(Inst {
             data: InstData::VarRef {
@@ -2224,7 +2263,7 @@ impl<'a> AstGen<'a> {
         );
         let n = self.compound_counter;
         self.compound_counter += 1;
-        let name = self.interner.get_or_intern(format!("@rue:place:{n}"));
+        let name = self.intern(format!("@rue:place:{n}"));
         let alloc = self
             .rir
             .add_alloc(&[], Some(name), false, None, init, false, index.span())
@@ -2476,6 +2515,28 @@ mod tests {
         astgen.append_items(&ast.items);
         let rir = astgen.finish();
         (rir, interner)
+    }
+
+    #[test]
+    fn generated_for_name_preserves_interner_failure_kind() {
+        let (tokens, source_interner) = Lexer::new("fn main() { for x in [1] {} }")
+            .tokenize()
+            .unwrap();
+        let (ast, _) = Parser::new(tokens, source_interner).parse().unwrap();
+        let limited = ThreadedRodeo::new();
+        let mut astgen = AstGen::with_symbol_normalizer(&limited, |symbol| symbol)
+            .with_interner_limit_for_test(0);
+        astgen.append_items(&ast.items);
+        let error = astgen
+            .try_finish()
+            .expect_err("generated name must hit the bound");
+        assert!(matches!(
+            error,
+            crate::RirPayloadBuildError::InternerFailure {
+                kind: lasso::LassoErrorKind::KeySpaceExhaustion,
+                ..
+            }
+        ));
     }
 
     fn type_spelling(rir: &Rir, interner: &ThreadedRodeo, reference: RirTypeSyntaxRef) -> String {
@@ -3981,7 +4042,8 @@ mod tests {
         let interner = ThreadedRodeo::new();
         let span = rue_span::Span::new(0, 1);
         let ident = rue_parser::ast::Ident {
-            name: interner.get_or_intern("i32"),
+            name: rue_lexer::try_intern(&interner, "i32")
+                .expect("test AstGen interner must fit the published interner bound"),
             span,
         };
         let array = TypeExpr::Array {

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -37,6 +37,10 @@ pub enum RirPayloadBuildError {
     CapacityFailure {
         family: &'static str,
     },
+    InternerFailure {
+        family: &'static str,
+        kind: lasso::LassoErrorKind,
+    },
     InvalidBuilderInput {
         family: &'static str,
         reason: &'static str,
@@ -49,12 +53,14 @@ impl RirPayloadBuildError {
     /// to pick `E1401` over an internal-error code.
     pub fn is_resource_limit(&self) -> bool {
         matches!(self, Self::ResourceLimitExceeded { .. })
+            || matches!(self, Self::InternerFailure { kind, .. } if !kind.is_failed_alloc())
     }
 
     /// Whether this failure is an allocation failure for an otherwise
     /// representable request (`E1402`), not a limit rejection.
     pub fn is_resource_exhaustion(&self) -> bool {
         matches!(self, Self::CapacityFailure { .. })
+            || matches!(self, Self::InternerFailure { kind, .. } if kind.is_failed_alloc())
     }
 }
 
@@ -70,6 +76,9 @@ impl fmt::Display for RirPayloadBuildError {
             }
             Self::CapacityFailure { family } => {
                 write!(f, "could not reserve storage for RIR {family} payload")
+            }
+            Self::InternerFailure { family, kind } => {
+                write!(f, "could not intern RIR {family} spelling: {kind:?}")
             }
             Self::InvalidBuilderInput { family, reason } => {
                 write!(f, "invalid RIR {family} builder input: {reason}")

--- a/crates/rue-rir/src/symbol.rs
+++ b/crates/rue-rir/src/symbol.rs
@@ -60,7 +60,7 @@
 use ahash::AHashMap;
 use lasso::{Key, Spur, ThreadedRodeo};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, PoisonError, RwLock};
+use std::sync::{Arc, Mutex, PoisonError, RwLock};
 
 /// An equality-only handle into one body's symbol interner.
 ///
@@ -114,6 +114,9 @@ pub struct SharedSymbolSpace {
     generation: u64,
     live: Arc<AtomicBool>,
     spellings: Arc<Spellings>,
+    intern_lock: Arc<Mutex<()>>,
+    interner_failure: Arc<Mutex<Option<lasso::LassoErrorKind>>>,
+    max_entries: usize,
 }
 
 /// How many shards a spelling memo is split across.
@@ -225,6 +228,29 @@ impl SharedSymbolSpace {
             generation: 1,
             live: Arc::new(AtomicBool::new(true)),
             spellings: Arc::new(Spellings::default()),
+            intern_lock: Arc::new(Mutex::new(())),
+            interner_failure: Arc::new(Mutex::new(None)),
+            max_entries: u32::MAX as usize,
+        }
+    }
+
+    /// Construct a space with an explicit symbol bound. Production uses the
+    /// published `u32` key-space ceiling; tests inject a small bound through
+    /// the session-owned space rather than mutating process/thread state.
+    #[doc(hidden)]
+    pub fn with_owner_bound(max_entries: usize) -> Self {
+        Self::with_generation_and_max(1, max_entries)
+    }
+
+    fn with_generation_and_max(generation: u64, max_entries: usize) -> Self {
+        Self {
+            interner: Arc::new(ThreadedRodeo::new()),
+            generation,
+            live: Arc::new(AtomicBool::new(true)),
+            spellings: Arc::new(Spellings::default()),
+            intern_lock: Arc::new(Mutex::new(())),
+            interner_failure: Arc::new(Mutex::new(None)),
+            max_entries,
         }
     }
 
@@ -233,6 +259,56 @@ impl SharedSymbolSpace {
     #[must_use]
     pub fn interner(&self) -> &Arc<ThreadedRodeo> {
         &self.interner
+    }
+
+    /// Fallibly insert a spelling into this generation's shared equality
+    /// space. The lock covers the get/check/insert sequence so the bound is
+    /// deterministic under concurrent provider workers.
+    pub fn try_intern(&self, text: impl AsRef<str>) -> Result<Spur, lasso::LassoErrorKind> {
+        let text = text.as_ref();
+        if let Some(symbol) = self.interner.get(text) {
+            return Ok(symbol);
+        }
+        let _guard = self
+            .intern_lock
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        if let Some(symbol) = self.interner.get(text) {
+            return Ok(symbol);
+        }
+        if self.interner.len() >= self.max_entries {
+            let kind = lasso::LassoErrorKind::KeySpaceExhaustion;
+            let mut failure = self
+                .interner_failure
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            if failure.is_none() {
+                *failure = Some(kind);
+            }
+            return Err(kind);
+        }
+        match self.interner.try_get_or_intern(text) {
+            Ok(symbol) => Ok(symbol),
+            Err(error) => {
+                let kind = error.kind();
+                let mut failure = self
+                    .interner_failure
+                    .lock()
+                    .unwrap_or_else(PoisonError::into_inner);
+                if failure.is_none() {
+                    *failure = Some(kind);
+                }
+                Err(kind)
+            }
+        }
+    }
+
+    /// The first interner failure observed by this generation, if any.
+    pub fn interner_failure(&self) -> Option<lasso::LassoErrorKind> {
+        *self
+            .interner_failure
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
     }
 
     /// The handle for a spelling joined from two spellings this space already
@@ -256,6 +332,7 @@ impl SharedSymbolSpace {
     /// unchanged: it is append-only for the generation's life, it never
     /// outlives it, and a body carrying a retired generation is refused at the
     /// authority check rather than reading a stale association.
+    #[cfg(test)]
     pub fn derived_symbol(
         &self,
         left: Spur,
@@ -263,6 +340,20 @@ impl SharedSymbolSpace {
         variant: u8,
         render: impl FnOnce() -> String,
     ) -> Spur {
+        self.try_derived_symbol(left, right, variant, render)
+            .unwrap_or_default()
+    }
+
+    /// Fallible form of [`Self::derived_symbol`] used by compiler-owned
+    /// materialization. The memo is only published after the interner accepts
+    /// the spelling, so an exhaustion cannot masquerade as a valid handle.
+    pub fn try_derived_symbol(
+        &self,
+        left: Spur,
+        right: Spur,
+        variant: u8,
+        render: impl FnOnce() -> String,
+    ) -> Result<Spur, lasso::LassoErrorKind> {
         let key = DerivedKey {
             left,
             right,
@@ -275,9 +366,20 @@ impl SharedSymbolSpace {
         // taken.
         let shard =
             (left.into_usize() ^ (right.into_usize() << 2)).wrapping_add(usize::from(variant));
-        self.spellings
-            .derived
-            .memoize(shard, key, || self.interner.get_or_intern(render()))
+        if let Some(value) = self.spellings.derived.shards[shard % SPELLING_SHARDS]
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(&key)
+            .copied()
+        {
+            return Ok(value);
+        }
+        let value = self.try_intern(render())?;
+        self.spellings.derived.shards[shard % SPELLING_SHARDS]
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+            .insert(key, value);
+        Ok(value)
     }
 
     /// The spelling for a name that is a total function of a 128-bit identity
@@ -295,21 +397,42 @@ impl SharedSymbolSpace {
     /// stable across the generation's bodies. Everything the memo promises
     /// about interning and retirement is [`Self::derived_symbol`]'s promise,
     /// for the same reasons.
+    #[cfg(test)]
     pub fn keyed_symbol_spelling(
         &self,
         digest: u128,
         variant: u8,
         render: impl FnOnce() -> String,
     ) -> (Arc<str>, Spur) {
-        self.spellings.keyed_symbols.memoize(
-            keyed_shard(digest, variant),
-            (digest, variant),
-            || {
-                let name: Arc<str> = Arc::from(render().as_str());
-                let symbol = self.interner.get_or_intern(&name);
-                (name, symbol)
-            },
-        )
+        self.try_keyed_symbol_spelling(digest, variant, render)
+            .unwrap_or_else(|_| (Arc::from("<interner-exhausted>"), Spur::default()))
+    }
+
+    /// Fallible form of [`Self::keyed_symbol_spelling`].
+    pub fn try_keyed_symbol_spelling(
+        &self,
+        digest: u128,
+        variant: u8,
+        render: impl FnOnce() -> String,
+    ) -> Result<(Arc<str>, Spur), lasso::LassoErrorKind> {
+        let key = (digest, variant);
+        let shard =
+            &self.spellings.keyed_symbols.shards[keyed_shard(digest, variant) % SPELLING_SHARDS];
+        if let Some(value) = shard
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(&key)
+            .cloned()
+        {
+            return Ok(value);
+        }
+        let name: Arc<str> = Arc::from(render().as_str());
+        let symbol = self.try_intern(&name)?;
+        shard
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+            .insert(key, (name.clone(), symbol));
+        Ok((name, symbol))
     }
 
     /// The spelling for a digest-derived name the caller does not intern.
@@ -373,12 +496,18 @@ impl SymbolSpaceGenerations {
     /// Mint a fresh append-only interner as the next generation.
     #[must_use]
     pub fn next_generation(&self) -> SharedSymbolSpace {
-        SharedSymbolSpace {
-            interner: Arc::new(ThreadedRodeo::new()),
-            generation: self.minted.fetch_add(1, Ordering::AcqRel).wrapping_add(1),
-            live: Arc::new(AtomicBool::new(true)),
-            spellings: Arc::new(Spellings::default()),
-        }
+        self.next_generation_with_owner_bound(u32::MAX as usize)
+    }
+
+    /// Mint a fresh generation with an owner-injected bound. The bound is
+    /// normally the published key-space ceiling; tests use this constructor
+    /// through the compiler session so the production path has no mutable
+    /// process or thread state.
+    #[must_use]
+    #[doc(hidden)]
+    pub fn next_generation_with_owner_bound(&self, max_entries: usize) -> SharedSymbolSpace {
+        let generation = self.minted.fetch_add(1, Ordering::AcqRel).wrapping_add(1);
+        SharedSymbolSpace::with_generation_and_max(generation, max_entries)
     }
 }
 
@@ -432,6 +561,26 @@ mod tests {
                 .get_or_intern("__anon_struct_00.member"),
         );
         assert_eq!(space.interner().len(), 1);
+    }
+
+    #[test]
+    fn interner_failure_latch_preserves_the_first_failure_kind() {
+        let space = SharedSymbolSpace::with_owner_bound(0);
+        *space
+            .interner_failure
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            Some(lasso::LassoErrorKind::FailedAllocation);
+
+        assert_eq!(
+            space.try_intern("later-key"),
+            Err(lasso::LassoErrorKind::KeySpaceExhaustion)
+        );
+        assert_eq!(
+            space.interner_failure(),
+            Some(lasso::LassoErrorKind::FailedAllocation),
+            "a later key-space failure must not replace the allocator failure"
+        );
     }
 
     /// Retiring a generation retires every outstanding holder of it at once

--- a/docs/spec/src/appendices/C-implementation-limits.md
+++ b/docs/spec/src/appendices/C-implementation-limits.md
@@ -12,7 +12,7 @@ This appendix documents two different kinds of limit. A **language limit** is pa
 
 {{ rule(id="C.1:2", cat="normative") }}
 
-Exceeding an implementation limit is a diagnosable compile-time failure. An implementation **MUST** reject a translation unit that exceeds one of its implementation limits by reporting a diagnostic that names the exceeded limit, and **MUST NOT** instead wrap or truncate an index, silently discard part of the program, exhaust an internal index space, or terminate abnormally. This is the general policy; the concrete checks listed in this appendix are instances of it.
+Exceeding an implementation limit is a diagnosable compile-time failure. An implementation **MUST** reject a translation unit that exceeds one of its implementation limits by reporting a diagnostic that names the exceeded limit, and **MUST NOT** instead wrap or truncate an index, silently discard part of the program, exhaust an internal index space, or terminate abnormally. If an insertion fails because the allocator cannot provide memory, the implementation **MUST** report allocation exhaustion (E1402); that diagnostic does not claim that a published limit was reached. This is the general policy; the concrete checks listed in this appendix are instances of it.
 
 {{ rule(id="C.1:3") }}
 
@@ -75,9 +75,33 @@ Exceeding it is rejected with diagnostic E0907.
 
 {{ rule(id="C.5:1") }}
 
-There is no separate cap on the length of one identifier: an identifier is a token, so its length is bounded by the source-file limit of C.3:1. The number of *distinct* identifiers and string literals in one compilation is bounded by the string interner, whose handles are non-zero 32-bit keys: at most 4,294,967,295 distinct interned strings.
+There is no separate cap on the length of one identifier: an identifier is a
+token, so its length is bounded by the source-file limit of C.3:1. Each
+compilation-owned symbol domain uses a string interner whose handles are
+non-zero 32-bit keys, so one such domain admits at most 4,294,967,295 distinct
+spellings.
 
-Identifiers and string literals are the only unbounded, source-driven producers of interned strings, and both are interned by the lexer. The lexer interns fallibly: a token whose string cannot be given a key is reported through the ordinary lexical error channel as a resource-limit diagnostic (E1401) naming the limit, so the key space is never exhausted by an abort. Every other interned string is a name the compiler synthesizes for an entity it has already admitted (mangled symbols, anonymous-type names, specialization names), and those entities are themselves bounded by the capacity limits of C.6:1.
+The lexer and parser share one per-file staging interner: the parser consumes
+the interner produced by lexing. Canonical lowering remaps each module's
+vocabulary, parser primitives, and generated RIR spellings into its canonical
+destination. Later semantic analysis uses a separate revision-shared equality
+domain for AIR symbols, including generated member, specialization, and
+anonymous-nominal names. Body-local AIR import and CFG projection may use
+additional request-owned domains. These are distinct index spaces: their counts
+are not added together, and a `Spur` must never cross domains without
+translation. Every reachable insertion in these canonical compilation domains
+is fallible; compatibility-only body fixtures retain a private, unbounded
+interner and are not part of the canonical query path. Key-space exhaustion is
+classified as E1401, while an allocator failure is classified as E1402. The
+per-domain ceilings are published in the C.6 table; E1402 does not claim that a
+ceiling was reached.
+
+The later body-local AIR import and CFG projection tables are also distinct,
+request-owned domains. They are populated only from already admitted canonical
+facts and their insertions are checked at the materialization/projection
+boundary; an interner failure there follows the same E1401/E1402 policy. These
+domains do not extend the revision-shared equality table, and a body-local
+`Spur` is never used as a canonical or revision-shared key.
 
 ## Implementation Capacity Limits
 
@@ -89,7 +113,10 @@ The compiler stores syntax, untyped IR, and typed IR in compact index-based form
 |-----------|-------|------------|--------------|
 | Source bytes in one file | 4,294,967,295 | `u32` span offsets | E1401, before lexing |
 | Source files in one compilation | 4,294,967,295 | `u32` file identifier, `FileId(0)` reserved | E1401, at snapshot assembly |
-| Distinct identifiers and string literals | 4,294,967,295 | non-zero `u32` interner keys | E1401, when a token is interned |
+| Distinct spellings in one per-file lexer/parser staging domain | 4,294,967,295 | non-zero `u32` interner keys | E1401/E1402, during staging |
+| Distinct spellings in one canonical semantic symbol domain | 4,294,967,295 | non-zero `u32` interner keys | E1401/E1402, during canonical remapping |
+| Distinct symbols in one revision-shared AIR equality domain | 4,294,967,295 | non-zero `u32` interner keys | E1401/E1402, at semantic analysis |
+| Distinct symbols in one body-local AIR import or CFG domain | 4,294,967,295 | non-zero `u32` interner keys | E1401/E1402, at materialization/projection |
 | IR instructions in one program | 4,294,967,295 | `u32` instruction reference, `u32::MAX` reserved as the null payload | E1401, at RIR publication |
 | IR payload words in one program | 4,294,967,295 words (16 GiB) | `u32` payload `start`/`extent` into one word store | E1401, at RIR/CFG payload staging |
 | Typed-IR instructions in one function body | 4,294,967,295 | `u32` instruction reference into that body's own array | E1401, at the semantic AIR boundary |


### PR DESCRIPTION
Fixes RUE-1740

Routes compiler-generated and post-lexer symbol insertion through the owning bounded symbol spaces, preserves typed E1401/E1402 failures across semantic and CFG materialization, and documents the per-domain implementation limits.

Validation:
- scripts/rue quick
- scripts/rue premerge
- focused interner exhaustion, provider identity, specialization, and CFG materialization tests