### PR TITLE
RUE-1729: expose x86 variable-shift dependencies before scheduling

### DIFF
--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -133,7 +133,7 @@
 
 use rue_error::{CompileResult, ice_error};
 
-use super::mir::{LabelId, Reg, SHIFT_COUNT, X86Inst, X86Mir};
+use super::mir::{LabelId, Reg, X86Inst, X86Mir};
 use crate::vreg::BLOCK_LABEL_BASE;
 use crate::{EmittedCode, EmittedInst, EmittedRelocation, format_offset};
 
@@ -484,13 +484,15 @@ impl<'a> Emitter<'a> {
 
     /// Internal implementation of emit.
     fn emit_internal(&mut self) -> CompileResult<()> {
-        // Verify no MovRMIndexed or MovMRIndexed survived into emission.
-        // These are pre-regalloc pseudos whose virtual address bases must have
-        // been lowered by regalloc into MovRM/MovMR with physical bases.
+        // Verify no pre-regalloc pseudos survived into emission. Dynamic Shl
+        // must be canonicalized to ShlRCl while its count is loaded into RCX;
+        // keeping a second emitter-side expansion would bypass scheduling's
+        // explicit RCX dependency model.
         for (i, inst) in self.mir.iter().enumerate() {
             if matches!(
                 inst,
-                X86Inst::MovRMIndexed { .. }
+                X86Inst::Shl { .. }
+                    | X86Inst::MovRMIndexed { .. }
                     | X86Inst::MovMRIndexed { .. }
                     | X86Inst::NarrowLoadIndexed { .. }
                     | X86Inst::NarrowStoreIndexed { .. }
@@ -1297,31 +1299,8 @@ impl<'a> Emitter<'a> {
                     format_offset(adjusted_disp)
                 );
             }
-            X86Inst::Shl { dst, count } => {
-                let dst_reg = dst.as_physical();
-                let cnt = count.as_physical();
-
-                // If count isn't already in the fixed count register, move it.
-                if cnt != SHIFT_COUNT {
-                    // NB: this clobbers rcx, which is exactly what we want.
-                    self.begin_inst();
-                    self.emit_mov_rr(SHIFT_COUNT, cnt);
-                    end_inst!(self, "mov {}, {}", SHIFT_COUNT, cnt);
-                }
-
-                // If dst is the count register, that's a conflict (dst would be
-                // clobbered by the move above or would shift itself by itself).
-                // `mir::RESERVED_REGS` makes that unreachable by keeping the
-                // count register out of allocation entirely (RUE-1146).
-                assert!(
-                    dst_reg != SHIFT_COUNT,
-                    "Shl dst allocated to the shift-count register, but x86 requires \
-         the count in CL; regalloc must never assign it"
-                );
-
-                self.begin_inst();
-                self.emit_shl_cl(dst_reg);
-                end_inst!(self, "shl {}, cl", dst_reg);
+            X86Inst::Shl { .. } => {
+                unreachable!("pre-regalloc Shl rejected before emission")
             }
 
             X86Inst::MovRMIndexed { .. }
@@ -3036,6 +3015,18 @@ mod tests {
             .0
     }
 
+    fn emit_sequence(instructions: &[X86Inst]) -> Vec<u8> {
+        let mut mir = X86Mir::new();
+        for inst in instructions {
+            mir.push(inst.clone());
+        }
+        Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap()
+            .0
+    }
+
     #[test]
     fn test_mov_eax_imm32() {
         let code = emit_single(X86Inst::MovRI32 {
@@ -3559,12 +3550,38 @@ mod tests {
 
     #[test]
     fn test_shl_r14_cl() {
-        let code = emit_single(X86Inst::Shl {
+        let code = emit_single(X86Inst::ShlRCl {
             dst: Operand::Physical(Reg::R14),
-            count: Operand::Physical(Reg::Rcx),
         });
         // shl r14, cl -> 49 D3 E6  (REX.W|B because r/m=r14, opcode D3, modrm E0|6)
         assert_eq!(code, vec![0x49, 0xD3, 0xE6]);
+    }
+
+    #[test]
+    fn test_shift_count_move_then_shl_r8_cl() {
+        let code = emit_sequence(&[
+            X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rcx),
+                src: Operand::Physical(Reg::R11),
+            },
+            X86Inst::ShlRCl {
+                dst: Operand::Physical(Reg::R8),
+            },
+        ]);
+        // mov rcx, r11; shl r8, cl
+        assert_eq!(code, vec![0x4C, 0x89, 0xD9, 0x49, 0xD3, 0xE0]);
+    }
+
+    #[test]
+    fn test_rejects_pre_regalloc_shl() {
+        let mut mir = X86Mir::new();
+        mir.push(X86Inst::Shl {
+            dst: Operand::Physical(Reg::R14),
+            count: Operand::Physical(Reg::Rcx),
+        });
+
+        let result = Emitter::new(&mir, 0, 0, 0, &[], &[]).without_frame().emit();
+        assert!(result.is_err(), "pre-regalloc Shl must not reach emission");
     }
 
     // =========================================================================

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -64,8 +64,9 @@ pub enum Reg {
 /// * **Machine role.** `rsp` is the stack pointer and `rbp` the frame pointer.
 /// * **Fixed instruction operand.** `idiv`/`div`/`mul` read and write the
 ///   `rdx:rax` pair (see `X86Inst::clobbers`), `cdq`/`cqo` write `rdx`, and the
-///   variable-count shifts take their count in `cl`, i.e. `rcx`. The emitter
-///   asserts the shift destination is not `rcx` for exactly this reason.
+///   variable-count shifts take their count in `cl`, i.e. `rcx`. Keeping `rcx`
+///   reserved lets register allocation load the count without destroying the
+///   shift destination.
 /// * **Register-allocation scratch.** [`SCRATCH_VALUE`], [`SCRATCH_SOURCE`],
 ///   [`SCRATCH_ADDR_BASE`], and [`SCRATCH_ADDR_INDEX`] hold reloaded spill
 ///   values and lowered address components while an instruction is rewritten.
@@ -110,9 +111,8 @@ pub(crate) const SCRATCH_ADDR_BASE: Reg = Reg::Rdx;
 pub(crate) const SCRATCH_ADDR_INDEX: Reg = Reg::Rcx;
 
 /// The register a variable-count shift takes its count in: `cl`, the low byte
-/// of `rcx`. This is a fixed machine operand, not a choice — the emitter
-/// asserts that a shift's destination is not this register, and the allocator
-/// therefore cannot hand it out.
+/// of `rcx`. This is a fixed machine operand, not a choice, so the allocator
+/// cannot hand it out.
 pub(crate) const SHIFT_COUNT: Reg = Reg::Rcx;
 
 /// Whether the allocator is forbidden from handing out `reg`.
@@ -578,7 +578,9 @@ pub enum X86Inst {
     /// `lea dst, [base + disp]` - Load effective address.
     Lea { dst: Operand, base: Reg, disp: i32 },
 
-    /// `shl dst, count` - Shift left (multiply by 2^count).
+    /// `shl dst, count` - Pre-register-allocation variable left-shift pseudo.
+    /// Register allocation loads `count` into `cl` and lowers this to
+    /// [`X86Inst::ShlRCl`] before scheduling.
     Shl { dst: Operand, count: Operand },
 
     /// `mov dst, [base]` - Load from memory via a virtual base register.

--- a/crates/rue-codegen/src/x86_64/peephole.rs
+++ b/crates/rue-codegen/src/x86_64/peephole.rs
@@ -479,6 +479,28 @@ mod tests {
     }
 
     #[test]
+    fn runtime_shift_preserves_incoming_flags_for_liveness() {
+        let instructions = vec![
+            X86Inst::CmpRR {
+                src1: Operand::Physical(Reg::Rax),
+                src2: Operand::Physical(Reg::Rbx),
+            },
+            X86Inst::ShlRCl {
+                dst: Operand::Physical(Reg::Rax),
+            },
+            X86Inst::Sete {
+                dst: Operand::Physical(Reg::Rcx),
+            },
+        ];
+
+        // A runtime count of zero leaves FLAGS untouched, so the shift cannot
+        // be considered a killing writer when deciding whether the compare's
+        // FLAGS are live. Both implementations must retain that fact.
+        assert!(!flags_dead_after(&instructions, 0));
+        assert!(!compute_flags_dead(&instructions)[0]);
+    }
+
+    #[test]
     fn test_keep_nonzero_shift() {
         let mut instructions = vec![
             X86Inst::ShlRI {

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -746,9 +746,8 @@ impl RegAlloc {
 
                 match Self::get_allocation(context, dst) {
                     Some(Allocation::Register(reg)) => {
-                        mir.push(X86Inst::Shl {
+                        mir.push(X86Inst::ShlRCl {
                             dst: Operand::Physical(reg),
-                            count: Operand::Physical(SHIFT_COUNT),
                         });
                     }
                     Some(Allocation::Spill(offset)) => {
@@ -757,9 +756,8 @@ impl RegAlloc {
                             base: Reg::Rbp,
                             offset,
                         });
-                        mir.push(X86Inst::Shl {
+                        mir.push(X86Inst::ShlRCl {
                             dst: Operand::Physical(SCRATCH_VALUE),
-                            count: Operand::Physical(SHIFT_COUNT),
                         });
                         mir.push_after(X86Inst::MovMR {
                             base: Reg::Rbp,
@@ -771,10 +769,7 @@ impl RegAlloc {
                         unreachable!("destination cannot be rematerializable")
                     }
                     None => {
-                        mir.push(X86Inst::Shl {
-                            dst,
-                            count: Operand::Physical(SHIFT_COUNT),
-                        });
+                        mir.push(X86Inst::ShlRCl { dst });
                     }
                 }
             }
@@ -1586,6 +1581,59 @@ mod tests {
             }
             _ => panic!("expected MovRI32"),
         }
+    }
+
+    #[test]
+    fn dynamic_shl_with_physical_rcx_count_becomes_shl_rcl_without_move() {
+        let mut mir = X86Mir::new();
+        mir.push(X86Inst::Shl {
+            dst: Operand::Physical(Reg::R8),
+            count: Operand::Physical(Reg::Rcx),
+        });
+
+        let mir = RegAlloc::new(mir, 0).allocate().unwrap();
+
+        assert!(matches!(
+            mir.instructions(),
+            [X86Inst::ShlRCl {
+                dst: Operand::Physical(Reg::R8),
+            }]
+        ));
+    }
+
+    #[test]
+    fn dynamic_shl_moves_allocated_count_to_rcx_before_shl_rcl() {
+        let mut mir = X86Mir::new();
+        let count = mir.alloc_vreg();
+        mir.push(X86Inst::MovRM {
+            dst: Operand::Virtual(count),
+            base: Reg::Rdi,
+            offset: 0,
+        });
+        mir.push(X86Inst::Shl {
+            dst: Operand::Physical(Reg::R8),
+            count: Operand::Virtual(count),
+        });
+
+        let mir = RegAlloc::new(mir, 0).allocate().unwrap();
+        let instructions = mir.instructions();
+
+        assert!(matches!(
+            instructions,
+            [
+                X86Inst::MovRM {
+                    dst: Operand::Physical(count_reg),
+                    ..
+                },
+                X86Inst::MovRR {
+                    dst: Operand::Physical(Reg::Rcx),
+                    src: Operand::Physical(src_reg),
+                },
+                X86Inst::ShlRCl {
+                    dst: Operand::Physical(Reg::R8),
+                }
+            ] if *count_reg == *src_reg && *count_reg != Reg::Rcx
+        ));
     }
 
     #[test]

--- a/crates/rue-codegen/src/x86_64/schedule.rs
+++ b/crates/rue-codegen/src/x86_64/schedule.rs
@@ -621,8 +621,18 @@ pub(super) fn writes_flags(inst: &X86Inst) -> bool {
 pub(super) fn reads_flags(inst: &X86Inst) -> bool {
     matches!(
         inst,
+        // A runtime count of zero preserves FLAGS. Model variable-count
+        // shifts as read/write dependencies so scheduling keeps both the
+        // incoming FLAGS value and the shift's non-zero result ordered.
+        X86Inst::Shl { .. }
+            | X86Inst::ShlRCl { .. }
+            | X86Inst::Shl32RCl { .. }
+            | X86Inst::ShrRCl { .. }
+            | X86Inst::Shr32RCl { .. }
+            | X86Inst::SarRCl { .. }
+            | X86Inst::Sar32RCl { .. }
         // Conditional set
-        X86Inst::Sete { .. }
+            | X86Inst::Sete { .. }
             | X86Inst::Setne { .. }
             | X86Inst::Setl { .. }
             | X86Inst::Setg { .. }
@@ -883,6 +893,55 @@ mod tests {
 
         let nodes = build_dep_graph(&instructions, 0, 2);
         assert!(nodes[1].deps.contains(&0));
+    }
+
+    #[test]
+    fn test_shift_count_move_and_use_stay_ordered() {
+        let instructions = vec![
+            X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rcx),
+                src: Operand::Physical(Reg::R11),
+            },
+            X86Inst::ShlRCl {
+                dst: Operand::Physical(Reg::Rax),
+            },
+        ];
+
+        let nodes = build_dep_graph(&instructions, 0, instructions.len());
+        assert!(
+            nodes[1].deps.contains(&0),
+            "the RCX move must remain before the implicit-CL shift"
+        );
+    }
+
+    #[test]
+    fn test_runtime_shift_reads_and_writes_flags() {
+        let shift = X86Inst::ShlRCl {
+            dst: Operand::Physical(Reg::Rax),
+        };
+        let pre_regalloc_shift = X86Inst::Shl {
+            dst: Operand::Physical(Reg::Rax),
+            count: Operand::Physical(Reg::R11),
+        };
+
+        assert!(reads_flags(&shift));
+        assert!(writes_flags(&shift));
+        assert!(reads_flags(&pre_regalloc_shift));
+        assert!(writes_flags(&pre_regalloc_shift));
+
+        let instructions = vec![
+            X86Inst::CmpRR {
+                src1: Operand::Physical(Reg::Rax),
+                src2: Operand::Physical(Reg::Rbx),
+            },
+            shift,
+            X86Inst::Sete {
+                dst: Operand::Physical(Reg::Rdx),
+            },
+        ];
+        let nodes = build_dep_graph(&instructions, 0, instructions.len());
+        assert!(nodes[1].deps.contains(&0));
+        assert!(nodes[2].deps.contains(&1));
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- canonicalize variable-count x86 shifts into explicit RCX setup plus ShlRCl before scheduling
- reject surviving pre-regalloc Shl pseudos in the emitter
- model runtime-count shifts as both reading and writing FLAGS, preserving count-zero semantics
- add regalloc, scheduler, peephole, encoding, and emitter regression coverage

Validation:
- scripts/rue unit codegen
- scripts/rue quick
- scripts/rue premerge
- scripts/rue test
- focused shift, signed-array-index, and string-mutation CLI suites

Fixes RUE-1729