### PR TITLE
RUE-1783: announce a watch change whoever detects it

### DIFF
--- a/crates/rue-cli-tests/cases/watch.toml
+++ b/crates/rue-cli-tests/cases/watch.toml
@@ -73,3 +73,37 @@ expected_exit_codes = [1, 2]
 [[case.watch.edits]]
 path = "helper.rue"
 symlink_target = "target_b.rue"
+
+# RUE-1783. The watcher can learn that its inputs changed three ways: the
+# in-flight change monitor, the publication guard, or the trailing check once
+# the monitor has stopped. Only the monitor announced itself, and the
+# `change-detected` milestone was emitted solely from `wait_for_change` -- which
+# the loop reaches only when the cycle ends with nothing pending. So an edit
+# landing after the monitor stopped but before the trailing check was acted on
+# correctly (the watcher rebuilt and republished) and never announced, hanging
+# any consumer waiting on the milestone.
+#
+# The window is normally microseconds, which is why this only ever failed on
+# loaded CI runners. `boundary_delay_ms` widens it on purpose so the edit lands
+# inside it every run: without the fix this case times out after 30s with
+# `timed out waiting for watch event "change-detected"`, exactly as CI reported.
+#
+# `compile_delay_ms` is deliberately 0 here -- this case is about the boundary
+# window, not the in-flight one, and leaving the compile fast keeps the edit
+# from being caught by the monitor instead.
+[[case]]
+name = "change_after_monitor_stops_is_still_announced"
+files = [{ path = "main.rue", source = "fn main() -> i32 { 1 }\n" }]
+
+[case.watch]
+kind = "cancel"
+boundary_delay_ms = 400
+expected_exit_codes = [1, 3]
+
+[[case.watch.edits]]
+path = "main.rue"
+source = "fn main() -> i32 { 2 }\n"
+
+[[case.watch.edits]]
+path = "main.rue"
+source = "fn main() -> i32 { 3 }\n"

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -1061,6 +1061,12 @@ struct WatchScenario {
     source_path: Option<String>,
     #[serde(default)]
     compile_delay_ms: Option<u64>,
+    /// Widen the gap between the watcher's change monitor stopping and its
+    /// trailing input check, so an edit can be made to land inside it on
+    /// purpose. That window is where RUE-1783 lived: a change discovered there
+    /// was acted on but never announced on the protocol.
+    #[serde(default)]
+    boundary_delay_ms: Option<u64>,
     edits: Vec<WatchEdit>,
     expected_exit_codes: Vec<i32>,
 }
@@ -2588,6 +2594,9 @@ fn run_watch_case(
         .stderr(Stdio::piped());
     if let Some(delay) = scenario.compile_delay_ms {
         command.env("RUE_WATCH_TEST_COMPILE_DELAY_MS", delay.to_string());
+    }
+    if let Some(delay) = scenario.boundary_delay_ms {
+        command.env("RUE_WATCH_TEST_BOUNDARY_DELAY_MS", delay.to_string());
     }
     configure_process_group(&mut command);
     let mut child = command

--- a/crates/rue/src/watch.rs
+++ b/crates/rue/src/watch.rs
@@ -33,6 +33,7 @@ const FAILED_REOBSERVE_RETRY: Duration = Duration::from_millis(250);
 // synchronization without wall-clock sleeps.
 const TEST_PROTOCOL_ENV: &str = "RUE_WATCH_TEST_PROTOCOL";
 const TEST_COMPILE_DELAY_ENV: &str = "RUE_WATCH_TEST_COMPILE_DELAY_MS";
+const TEST_BOUNDARY_DELAY_ENV: &str = "RUE_WATCH_TEST_BOUNDARY_DELAY_MS";
 
 fn test_event(event: &str) {
     let Some(path) = std::env::var_os(TEST_PROTOCOL_ENV) else {
@@ -47,6 +48,19 @@ fn test_event(event: &str) {
 
 fn test_compile_delay() {
     let Ok(delay) = std::env::var(TEST_COMPILE_DELAY_ENV) else {
+        return;
+    };
+    let Ok(milliseconds) = delay.parse::<u64>() else {
+        return;
+    };
+    thread::sleep(Duration::from_millis(milliseconds.min(5_000)));
+}
+
+// Widen the unobserved gap between the change monitor stopping and the
+// trailing input check. Test-only, like the compile delay above: it exists so
+// an edit can be made to land inside that window on purpose.
+fn test_boundary_delay() {
+    let Ok(delay) = std::env::var(TEST_BOUNDARY_DELAY_ENV) else {
         return;
     };
     let Ok(milliseconds) = delay.parse::<u64>() else {
@@ -250,13 +264,21 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
         }
 
         let monitor_changed = monitor.finish();
+        // The monitor has stopped and nothing observes the inputs again until
+        // the trailing check below. That gap is where RUE-1783 lived, and it is
+        // normally too short to hit deliberately -- so the harness can widen it
+        // to make the race reproducible instead of hoping a loaded runner
+        // supplies it.
+        test_boundary_delay();
         let changed = watch_cycle_changed(
             publication_changed,
             monitor_changed,
             inputs_changed(&inputs),
         );
-        if !changed {
-            wait_for_change(&inputs);
+        match cycle_boundary_action(changed, monitor_changed) {
+            CycleBoundary::Wait => wait_for_change(&inputs),
+            CycleBoundary::Announce => test_event("change-detected"),
+            CycleBoundary::AlreadyAnnounced => {}
         }
         debounce(&inputs);
         needs_reobserve = true;
@@ -326,6 +348,43 @@ fn watch_cycle_changed(
     publication_changed || monitor_changed || observed_changed
 }
 
+/// What the cycle boundary owes the test protocol once the cycle has settled.
+///
+/// `change-detected` is the protocol's single "a newer revision exists"
+/// milestone, but a cycle can learn that three different ways: the in-flight
+/// `ChangeMonitor`, the publication guard, or the trailing `inputs_changed`
+/// observation. Only the monitor announces itself.
+///
+/// That asymmetry was a race (RUE-1783). The milestone was emitted solely from
+/// `wait_for_change`, which the loop reaches only when the cycle ends with no
+/// change pending — so whether it was emitted depended on whether an edit
+/// landed before or after the trailing check. An edit landing *before* it left
+/// the milestone unsent while the watcher went on to rebuild and publish
+/// perfectly correctly, so a harness waiting on the milestone hung against a
+/// watcher that was doing its job. It reproduced on slow runners because a
+/// longer compile widens the window in which the edit can land early.
+///
+/// Announcing here makes the milestone unconditional: every cycle that ends
+/// knowing about a change reports it exactly once, whichever path found it.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CycleBoundary {
+    /// Nothing has changed yet; block until something does. `wait_for_change`
+    /// emits the milestone itself when it returns.
+    Wait,
+    /// A change is already pending and nobody has announced it.
+    Announce,
+    /// The monitor thread announced this change when it cancelled the compile.
+    AlreadyAnnounced,
+}
+
+fn cycle_boundary_action(changed: bool, monitor_changed: bool) -> CycleBoundary {
+    match (changed, monitor_changed) {
+        (false, _) => CycleBoundary::Wait,
+        (true, true) => CycleBoundary::AlreadyAnnounced,
+        (true, false) => CycleBoundary::Announce,
+    }
+}
+
 fn current_fingerprints(inputs: &[WatchInput]) -> Vec<Option<WatchFingerprint>> {
     watch_input_fingerprints(inputs)
 }
@@ -370,6 +429,52 @@ mod tests {
         assert!(watch_cycle_changed(true, false, false));
         assert!(watch_cycle_changed(true, false, true));
         assert!(!watch_cycle_changed(false, false, false));
+    }
+
+    // RUE-1783. The milestone used to be emitted only from `wait_for_change`,
+    // so a cycle that already knew about a change skipped it entirely and a
+    // harness waiting on it hung against a correctly-working watcher.
+    #[test]
+    fn a_settled_cycle_waits_and_lets_wait_for_change_announce() {
+        assert_eq!(
+            cycle_boundary_action(false, false),
+            CycleBoundary::Wait,
+            "with nothing pending the loop must block, not announce"
+        );
+    }
+
+    #[test]
+    fn a_change_found_at_the_boundary_is_announced_exactly_once() {
+        // The trailing `inputs_changed` observation and the publication guard
+        // both reach here with the monitor quiet: nobody has announced yet.
+        assert_eq!(
+            cycle_boundary_action(true, false),
+            CycleBoundary::Announce,
+            "an edit that landed before the trailing check must still be reported"
+        );
+    }
+
+    #[test]
+    fn a_change_the_monitor_already_reported_is_not_announced_twice() {
+        assert_eq!(
+            cycle_boundary_action(true, true),
+            CycleBoundary::AlreadyAnnounced,
+            "the monitor emits the milestone when it cancels; a second is a phantom revision"
+        );
+    }
+
+    // Whichever path detects it, a cycle that ends knowing about a change must
+    // never fall through to `wait_for_change` -- that would block on a change
+    // that has already happened, which is the hang RUE-1783 filed.
+    #[test]
+    fn no_pending_change_is_ever_waited_on() {
+        for monitor_changed in [false, true] {
+            assert_ne!(
+                cycle_boundary_action(true, monitor_changed),
+                CycleBoundary::Wait,
+                "a known change must not send the loop back to sleep"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
A watch cycle can learn its inputs changed three ways: the in-flight `ChangeMonitor`, the publication guard, or the trailing `inputs_changed` observation once the monitor has stopped. **Only the monitor announced itself.**

The `change-detected` protocol milestone was emitted solely from `wait_for_change`, which the loop reaches only when a cycle ends with nothing pending. So whether the milestone was sent depended on *when* an edit landed, not on whether a change occurred.

An edit landing after `monitor.finish()` but before the trailing check is found by that check, so `changed` is true, so `wait_for_change` is skipped and nobody reports it. The watcher then rebuilds and republishes entirely correctly while a consumer waiting on the milestone hangs.

That is exactly what CI hit on an unrelated PR (#2630) — two successful compiles in the log *and* a 30s timeout on `change-detected`:

```
---- cli.watch::change_during_compile_publishes_only_newest_revision ----
timed out waiting for watch event "change-detected" (count 1)
watch process status: Some(ExitStatus(unix_wait_status(9)))
--- watch stdout ---
Watching main.rue for changes
Compiled main.rue -> prog in 296 ms (target: x86-64-linux, linker: internal)
Compiled main.rue -> prog in 312 ms (target: x86-64-linux, linker: internal)
```

## A wrong first diagnosis, and what corrected it

I originally filed RUE-1783 as a timing-tolerance problem: the case injects `compile_delay_ms = 250`, the runner's compiles took 296ms and 312ms, so the window looked too tight. That reading is **wrong**, and it matters because acting on it (raising the constant) would have left the real bug in place.

Widening that window experimentally disproved it — the case still passed with and without any fix, because the `ChangeMonitor` is still alive during the compile and announces the change itself. The gap that actually matters is the one where *nothing is observing at all*: between the monitor stopping and the trailing check.

Moving the injected delay there reproduces CI byte-for-byte, `unix_wait_status(9)` included. The window is normally microseconds wide, which is why this only ever appeared on loaded runners and never locally.

## The fix

`cycle_boundary_action` makes the milestone unconditional: a cycle that ends knowing about a change reports it exactly once, whichever path found it, and stays silent when the monitor already announced — so a cancelled compile does not report two revisions.

Behaviour outside the test protocol is unchanged. This decides *who announces*, not what the watcher does.

## Coverage

The window is now a permanent test-only seam, `boundary_delay_ms`, in the same spirit as the existing `compile_delay_ms` — it widens the gap so an edit lands inside it on every run rather than hoping a loaded runner supplies the race.

The new case `change_after_monitor_stops_is_still_announced` is **deterministic** where the original was load-dependent. Mutation-checked both directions:

| | without fix | with fix |
| --- | --- | --- |
| `change_after_monitor_stops_is_still_announced` | FAILED — 30s timeout, original error | ok |
| `change_during_compile_publishes_only_newest_revision` | ok (needs real load to fail) | ok |

Four unit tests cover the decision directly, including that a known change is never sent back to sleep — the shape of the hang itself.

## Verification

`./test.sh` → `Tests finished: Pass 234. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0`, exit 0.

`scripts/rue cli watch` → 5/5. `scripts/rue fmt` clean.

No codegen or CFG files changed, so there is no per-target split to ship.

## Note

This unblocks #2630, which is red solely on this flake and whose diff touches no watch code. I could not re-run that job to confirm (403, no re-run permission), which is why the fix comes as its own PR rather than a re-run.

Fixes RUE-1783

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJ13kDoVzYrpTZ7ry3rUaA)_