### PR TITLE
RUE-1766: reject nested inout under materialized string views

### DIFF
--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -1232,7 +1232,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 // borrows in the same full expression violates exclusivity
                 // (ADR-0062, E0259).
                 self.reject_accessor_loan_conflict(root, "as an `inout self` receiver", span, ctx)?;
-                Some(vec![(root, CallLoanKind::Inout)])
+                Some(vec![(root, CallLoanKind::Inout, false)])
             }
             (AirArgMode::Borrow, Some(root)) => {
                 self.reject_accessor_shared_loan_conflict(
@@ -1241,7 +1241,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     span,
                     ctx,
                 )?;
-                Some(vec![(root, CallLoanKind::Borrow)])
+                Some(vec![(root, CallLoanKind::Borrow, false)])
             }
             _ => None,
         };

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -1261,7 +1261,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // calls and must conflict.
         let frame_count = ctx.call_loaned_roots.len();
         for (frame_index, frame) in ctx.call_loaned_roots.iter().enumerate() {
-            if frame.iter().any(|(r, kind)| {
+            if frame.iter().any(|(r, kind, _view_materialized)| {
                 *r == root
                     && !(frame_index + 1 == frame_count && *kind == CallLoanKind::Inout)
                     && (*kind == CallLoanKind::Inout || accessor_loan_kind == CallLoanKind::Inout)
@@ -5636,7 +5636,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         ctx: &AnalysisContext,
     ) -> CompileResult<()> {
         for frame in ctx.call_loaned_roots.iter().rev() {
-            if let Some((_, kind)) = frame.iter().find(|(r, _)| *r == root) {
+            if let Some((_, kind, _view_materialized)) = frame.iter().find(|(r, _, _)| *r == root) {
                 let variable = self.body_interner().resolve(&root).to_string();
                 let kw = kind.keyword();
                 return Err(CompileError::new(
@@ -6034,6 +6034,24 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
     }
 
+    /// Whether a by-reference call argument is narrowed into a view value at
+    /// this call boundary. This mirrors the corresponding lowering branches
+    /// below: `borrow str`/slice arguments are view values, while `inout str`
+    /// only narrows a `StrBuf` source. Forwarded `inout str` and direct
+    /// `Str(N)` operands remain address-passed.
+    fn call_arg_view_materialized(
+        &self,
+        arg: &RirCallArg,
+        param_type: Type,
+        source_type: Option<Type>,
+    ) -> bool {
+        (arg.is_borrow()
+            && (self.is_str_struct(param_type) || self.slice_element_type(param_type).is_some()))
+            || (arg.is_inout()
+                && self.is_str_struct(param_type)
+                && source_type.is_some_and(|ty| self.is_strbuf(ty)))
+    }
+
     /// Analyze call arguments, materializing a fat-pointer slice value for any
     /// argument whose parameter is a slice type (ADR-0043, RUE-322).
     ///
@@ -6061,9 +6079,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     {
         // Loan-frame discipline (RUE-523): a by-value move of a root this call
         // passes `inout`/`borrow` conflicts in either argument order.
-        let frame: Vec<(Spur, CallLoanKind)> = args
+        let frame: Vec<(Spur, CallLoanKind, bool)> = args
             .clone()
-            .filter_map(|arg| {
+            .enumerate()
+            .filter_map(|(index, arg)| {
                 let kind = if arg.is_inout() {
                     CallLoanKind::Inout
                 } else if arg.is_borrow() {
@@ -6071,13 +6090,19 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 } else {
                     return None;
                 };
+                let param_type = param_types[index];
+                let view_materialized = self.call_arg_view_materialized(
+                    &arg,
+                    param_type,
+                    ctx.resolved_type_of(arg.value),
+                );
                 root_variable_of(self.body_rir_ref(), arg.value)
                     .or_else(|| {
                         // Both shared and exclusive accessor-call place chains
                         // root their loan at the receiver (ADR-0062/RUE-1016).
                         self.place_root_with_accessors(arg.value, ctx)
                     })
-                    .map(|root| (root, kind))
+                    .map(|root| (root, kind, view_materialized))
             })
             .collect();
         // A NESTED `inout` loan of a root that an ENCLOSING call already holds
@@ -6091,7 +6116,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // leaves the outer argument's view pointing at freed memory — a
         // use-after-free in safe code (RUE-1696).
         //
-        // Deliberately limited to shared-outer/exclusive-nested:
+        // Deliberately limited to shared-or-view-materialized-outer/
+        // exclusive-nested:
         //
         // * A nested `borrow` finishes before the outer call is entered, so it
         //   cannot outlive anything.
@@ -6102,13 +6128,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         //   depends on it.
         //
         //   This exclusion does NOT generalize to every `inout`: a view
-        //   materialized parameter snapshots whatever its loan mode. `inout
-        //   str` is passed as a two-word `{ptr, len}` value (4.10:4), so a
-        //   nested `inout` that frees or reallocates the root dangles it
-        //   exactly as the shared case above — still accepted here, tracked as
-        //   RUE-1766. The property that actually governs is view
-        //   materialization, not shared-vs-exclusive; this rule is keyed on the
-        //   latter and so covers only half the hole.
+        //   materialized parameter snapshots whatever its loan mode. A
+        //   `StrBuf` passed as `inout str` is narrowed to a two-word `{ptr,
+        //   len}` view (4.10:4), so a nested `inout` that frees or reallocates
+        //   the root dangles it exactly as the shared case above. Forwarded
+        //   `inout str` and direct `Str(N)` operands remain address-passed.
         //
         // Caught in either argument order, because the enclosing frame covers
         // the whole outer argument list before any of it is analyzed.
@@ -6123,13 +6147,26 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             else {
                 continue;
             };
-            let shared_outer_loan = ctx
-                .call_loaned_roots
-                .iter()
-                .flatten()
-                .any(|(loaned, kind)| *loaned == root && *kind == CallLoanKind::Borrow);
-            if shared_outer_loan {
+            let conflicting_outer_loan =
+                ctx.call_loaned_roots
+                    .iter()
+                    .flatten()
+                    .find(|(loaned, kind, view_materialized)| {
+                        *loaned == root && (*kind == CallLoanKind::Borrow || *view_materialized)
+                    });
+            if let Some((_, kind, view_materialized)) = conflicting_outer_loan {
                 let variable = self.body_interner().resolve(&root).to_string();
+                let loan_kind = kind.keyword();
+                let reason = if *view_materialized {
+                    "the enclosing call materializes a view snapshot before the call runs, so mutating"
+                } else {
+                    "that shared loan spans the whole call, so mutating"
+                };
+                let consequence = if *view_materialized {
+                    "would leave its view dangling"
+                } else {
+                    "would overlap the shared loan"
+                };
                 return Err(CompileError::new(
                     ErrorKind::BorrowInoutConflict {
                         variable: variable.clone(),
@@ -6137,11 +6174,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     self.body_rir_ref().get(arg.value).span,
                 )
                 .with_help(format!(
-                    "the enclosing call already passes `{variable}` as `borrow`, and that \
-                     shared loan spans the whole call — a `borrow str`/slice argument is \
-                     snapshotted before the call runs, so mutating `{variable}` here would \
-                     leave it dangling; evaluate the nested call into its own binding before \
-                     the call"
+                    "the enclosing call already passes `{variable}` as `{loan_kind}`, and \
+                     {reason} `{variable}` here {consequence}; evaluate the nested call into \
+                     its own binding before the call"
                 )));
             }
         }
@@ -6491,7 +6526,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 // reach the caller's storage, while `len` reads the correct
                 // word. Whole-view rebinding is already rejected
                 // (StrViewReassignment), so the snapshot length stays valid.
-                if self.is_strbuf(arg_result.ty) {
+                if self.call_arg_view_materialized(&arg, param_ty, Some(arg_result.ty)) {
                     let span = self.body_rir_ref().get(arg.value).span;
                     let (view, prefix) =
                         self.strbuf_text_view(air, arg_result.air_ref, arg_result.ty, span, ctx)?;

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -659,8 +659,12 @@ pub(crate) struct AnalysisContext<'a> {
     /// a double free in safe code. Move-record sites consult this via the
     /// engine's `reject_move_of_call_loaned_root` (E0208, spec 6.1, RUE-523).
     /// Completed nested LOANS (`f(inout x, g(borrow x))`) do not conflict:
-    /// the inner loan ends before the outer call begins.
-    pub call_loaned_roots: Vec<Vec<(Spur, CallLoanKind)>>,
+    /// the inner loan ends before the outer call begins. The third field is
+    /// true when the enclosing by-ref argument is materialized as a view
+    /// value (for example `borrow str`, or `StrBuf` narrowed to `inout str`),
+    /// rather than passed by address; nested exclusive access must not
+    /// invalidate such a snapshot.
+    pub call_loaned_roots: Vec<Vec<(Spur, CallLoanKind, bool)>>,
     /// True while re-running a loop's condition/body to validate the loop's
     /// back edge (see [`AnalysisContext::fork_for_loop_recheck`]). The recheck
     /// pass starts from a move state that already includes every move the loop

--- a/crates/rue-cli-tests/cases/nested_loan_str_view.toml
+++ b/crates/rue-cli-tests/cases/nested_loan_str_view.toml
@@ -1,5 +1,6 @@
 # A nested `inout` loan must not run while an outer argument of the SAME call
-# holds a shared (`borrow`) loan of the same root (RUE-1696).
+# holds either a shared (`borrow`) loan or a view-materialized loan of the same
+# root (RUE-1696, RUE-1766).
 #
 # `borrow s: str` does not pass an address: the argument is snapshotted into a
 # `{ptr, len}` view over the StrBuf's heap buffer at argument-evaluation time
@@ -15,13 +16,15 @@
 #
 # The opposite nesting (an outer `inout` loan with a nested `borrow`, and the
 # accumulator idiom `add(mul(x, y, inout flags), z, inout flags)`) stays legal:
-# an `inout` argument passes the root's address, not a snapshot, so a nested
-# access observes ordinary sequenced mutation.
+# an ordinary address-passed `inout` argument passes the root's address, not a
+# snapshot, so a nested access observes ordinary sequenced mutation. An
+# `inout str` sourced from `StrBuf` is different: it is view-materialized and
+# must reject same-root nesting.
 
 [section]
 id = "cli.nested_loan_str_view"
-name = "Nested inout under an outer shared loan"
-description = "A nested `inout` of a root the same call already borrows is rejected; the outer argument's str/slice view would dangle (RUE-1696)."
+name = "Nested inout under an outer shared or view-materialized loan"
+description = "A nested `inout` of a root the same call already borrows or snapshots is rejected; ordinary address-passed `inout` remains legal (RUE-1696, RUE-1766)."
 
 [[case]]
 name = "nested_inout_under_borrow_str_view_rejected"
@@ -66,6 +69,147 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["E0430", "cannot borrow 'b'"]
+
+[[case]]
+name = "nested_inout_under_inout_str_view_dangling_repro_rejected"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+description = "RUE-1766 exact dangling repro: the outer `inout str` view is snapshotted before `nuke` frees and reallocates the same root, so the nested exclusive loan is rejected."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn nuke(inout b: StrBuf) -> i64 {
+    b.free();
+    let mut c = StrBuf.new();
+    c.push_str("ZZZZZ");
+    let mut d = StrBuf.new();
+    d.push_str("YYYYY");
+    @intCast(c.len() + d.len())
+}
+fn read_view(inout s: str, k: i64) -> i64 {
+    let l: i64 = @intCast(s.len());
+    @dbg(l);
+    let b0: i64 = @intCast(s[0]);
+    @dbg(b0);
+    k
+}
+fn main() -> i32 {
+    let mut b = StrBuf.new();
+    b.push_str("hello");
+    let r = read_view(inout b, nuke(inout b));
+    @intCast(r)
+}
+""" }]
+compile_fail = true
+error_contains = ["E0430", "cannot borrow 'b'", "dangling"]
+
+[[case]]
+name = "nested_inout_under_inout_str_view_rejected_reversed_order"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+description = "The `inout str` snapshot conflict is independent of argument evaluation order."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn read_first(x: i32, inout s: str) -> u8 { s[0] }
+fn grow(inout s: StrBuf) -> i32 {
+    s.append_str(borrow "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+    0
+}
+fn main() -> i32 {
+    let mut b = StrBuf.from_str(borrow "hello");
+    let byte = read_first(grow(inout b), inout b);
+    @dbg(byte);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0430", "cannot borrow 'b'", "dangling"]
+
+[[case]]
+name = "nested_inout_under_inout_str_view_different_root_stays_legal"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+description = "An `inout str` view and nested `inout` of distinct roots remain legal."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn read_first(inout s: str, x: i32) -> u8 { s[0] }
+fn grow(inout s: StrBuf) -> i32 {
+    s.append_str(borrow "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+    0
+}
+fn main() -> i32 {
+    let mut b = StrBuf.from_str(borrow "hello");
+    let mut c = StrBuf.from_str(borrow "world");
+    let byte = read_first(inout b, grow(inout c));
+    @dbg(byte);
+    @dbg(c.len());
+    0
+}
+""" }]
+stdout = "104\n69\n"
+exit_code = 0
+
+[[case]]
+name = "nested_inout_under_address_passed_inout_stays_legal"
+description = "An ordinary address-passed `inout` parameter remains legal for sequenced nested accumulator updates."
+files = [{ path = "main.rue", source = """
+fn mul(a: i32, b: i32, inout flags: i32) -> i32 {
+    flags = flags + 1;
+    a * b
+}
+fn add(a: i32, b: i32, inout flags: i32) -> i32 {
+    flags = flags + 10;
+    a + b
+}
+fn main() -> i32 {
+    let mut flags = 0;
+    let total = add(mul(3, 4, inout flags), 5, inout flags);
+    @dbg(total);
+    @dbg(flags);
+    0
+}
+""" }]
+stdout = "17\n11\n"
+exit_code = 0
+
+[[case]]
+name = "nested_inout_under_forwarded_inout_str_stays_legal"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+description = "A forwarded `inout str` parameter is address-passed, so same-root nested `inout` remains legal."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn leaf(inout s: str) -> i32 { @intCast(s.len()) }
+fn read_view(inout s: str, x: i32) -> i32 {
+    @intCast(s.len()) + x
+}
+fn outer(inout s: str) -> i32 {
+    read_view(inout s, leaf(inout s))
+}
+fn main() -> i32 {
+    let mut b = StrBuf.from_str(borrow "hello");
+    @dbg(outer(inout b));
+    0
+}
+""" }]
+stdout = "10\n"
+exit_code = 0
+
+[[case]]
+name = "nested_inout_under_direct_str_n_stays_legal"
+description = "A direct `Str(N)` operand is address-passed, so same-root nested `inout` remains legal."
+files = [{ path = "main.rue", source = """
+fn leaf(inout s: Str(8)) -> i32 { @intCast(s.len()) }
+fn read_view(inout s: str, x: i32) -> i32 {
+    @intCast(s.len()) + x
+}
+fn main() -> i32 {
+    let mut b: Str(8) = "hello";
+    @dbg(read_view(inout b, leaf(inout b)));
+    0
+}
+""" }]
+stdout = "10\n"
+exit_code = 0
 
 [[case]]
 name = "nested_inout_under_borrow_struct_rejected"

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -1109,6 +1109,142 @@ fn main() -> i32 {
 exit_code = 0
 
 [[case]]
+name = "nested_inout_under_outer_inout_str_dangling_repro_rejected"
+spec = ["6.1:30"]
+description = "RUE-1766 exact dangling repro: a view-materialized outer `inout str` argument keeps the root loaned while a nested call frees and reallocates its buffer"
+real_std = true
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn nuke(inout b: StrBuf) -> i64 {
+    b.free();
+    let mut c = StrBuf.new();
+    c.push_str("ZZZZZ");
+    let mut d = StrBuf.new();
+    d.push_str("YYYYY");
+    @intCast(c.len() + d.len())
+}
+fn read_view(inout s: str, k: i64) -> i64 {
+    let l: i64 = @intCast(s.len());
+    @dbg(l);
+    let b0: i64 = @intCast(s[0]);
+    @dbg(b0);
+    k
+}
+fn main() -> i32 {
+    let mut b = StrBuf.new();
+    b.push_str("hello");
+    let r = read_view(inout b, nuke(inout b));
+    @intCast(r)
+}
+"""
+compile_fail = true
+error_contains = "cannot borrow 'b'"
+
+[[case]]
+name = "nested_inout_under_outer_inout_str_rejected_reversed_order"
+spec = ["6.1:30"]
+description = "The view-materialized `inout str` conflict is independent of argument order"
+real_std = true
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn read_first(x: i32, inout s: str) -> u8 { s[0] }
+fn grow(inout s: StrBuf) -> i32 {
+    s.append_str(borrow "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+    0
+}
+fn main() -> i32 {
+    let mut b = StrBuf.from_str(borrow "hello");
+    let byte = read_first(grow(inout b), inout b);
+    if byte == 104 { 0 } else { 1 }
+}
+"""
+compile_fail = true
+error_contains = "cannot borrow 'b'"
+
+[[case]]
+name = "nested_inout_under_outer_inout_str_other_root_ok"
+spec = ["6.1:30"]
+description = "A view-materialized outer `inout str` and a nested `inout` of another root remain legal"
+real_std = true
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn read_first(inout s: str, x: i32) -> u8 { s[0] }
+fn grow(inout s: StrBuf) -> i32 {
+    s.append_str(borrow "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+    0
+}
+fn main() -> i32 {
+    let mut b = StrBuf.from_str(borrow "hello");
+    let mut c = StrBuf.from_str(borrow "world");
+    let byte = read_first(inout b, grow(inout c));
+    if byte == 104 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "nested_inout_under_outer_address_passed_inout_ok"
+spec = ["6.1:30"]
+description = "An ordinary address-passed `inout` parameter remains legal for sequenced nested accumulator updates"
+source = """
+fn mul(a: i32, b: i32, inout flags: i32) -> i32 {
+    flags = flags + 1;
+    a * b
+}
+fn add(a: i32, b: i32, inout flags: i32) -> i32 {
+    flags = flags + 10;
+    a + b
+}
+fn main() -> i32 {
+    let mut flags = 0;
+    let total = add(mul(3, 4, inout flags), 5, inout flags);
+    if total == 17 && flags == 11 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "nested_inout_under_forwarded_inout_str_ok"
+spec = ["6.1:30"]
+description = "A forwarded `inout str` parameter is address-passed, so same-root nested `inout` remains legal"
+real_std = true
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn leaf(inout s: str) -> i32 { @intCast(s.len()) }
+fn read_view(inout s: str, x: i32) -> i32 {
+    @intCast(s.len()) + x
+}
+fn outer(inout s: str) -> i32 {
+    read_view(inout s, leaf(inout s))
+}
+fn main() -> i32 {
+    let mut b = StrBuf.from_str(borrow "hello");
+    if outer(inout b) == 10 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "nested_inout_under_direct_str_n_ok"
+spec = ["6.1:30"]
+description = "A direct `Str(N)` operand is address-passed, so same-root nested `inout` remains legal"
+source = """
+fn leaf(inout s: Str(8)) -> i32 { @intCast(s.len()) }
+fn read_view(inout s: str, x: i32) -> i32 {
+    @intCast(s.len()) + x
+}
+fn main() -> i32 {
+    let mut b: Str(8) = "hello";
+    if read_view(inout b, leaf(inout b)) == 10 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
 name = "borrow_multiple_same_var_ok"
 spec = ["6.1:28"]
 description = "Multiple borrows of the same variable is allowed"


### PR DESCRIPTION
## Summary
- track whether enclosing by-reference arguments materialize snapshots
- reject same-root nested exclusive loans under StrBuf-backed inout str views
- preserve forwarded inout str, direct fixed strings, ordinary inout, and distinct-root sequencing

## Testing
- scripts/rue fmt
- scripts/rue spec items.functions
- scripts/rue cli nested_loan_str_view
- scripts/rue quick
- scripts/rue premerge
- scripts/rue test

Fixes RUE-1766