### PR TITLE
RUE-1645, RUE-1647: reject malformed objects instead of panicking, and stop dropping relocations into unknown ALLOC sections

### DIFF
--- a/crates/rue-linker/src/constants.rs
+++ b/crates/rue-linker/src/constants.rs
@@ -281,6 +281,8 @@ pub const S_ATTR_PURE_INSTRUCTIONS: u32 = 0x80000000;
 pub const S_ATTR_SOME_INSTRUCTIONS: u32 = 0x00000400;
 /// S_ZEROFILL: Section is zero-filled on demand (BSS)
 pub const S_ZEROFILL: u32 = 0x1;
+/// S_ATTR_DEBUG: Section carries debug info and is not part of the loaded image
+pub const S_ATTR_DEBUG: u32 = 0x02000000;
 
 // Mach-O platform constants
 

--- a/crates/rue-linker/src/elf.rs
+++ b/crates/rue-linker/src/elf.rs
@@ -40,6 +40,7 @@ use crate::constants::{
     MACHO64_RELOC_SIZE,
     MACHO64_SECTION_SIZE,
     MACHO64_SEGMENT_CMD_SIZE,
+    MACHO64_SYMTAB_CMD_SIZE,
     MH_MAGIC_64,
     MH_OBJECT,
     N_ABS,
@@ -562,14 +563,28 @@ impl ObjectFile {
                         // flags: u32 at offset 64
                         let flags = read_u32(data, sect_offset + 64);
 
-                        // Determine section flags
+                        // Determine section flags.
+                        //
+                        // ALLOC means "part of the loaded image". Mach-O has no
+                        // per-section ALLOC bit, so it is derived: everything is
+                        // loaded except debug sections, which carry S_ATTR_DEBUG
+                        // and live in the __DWARF segment. The distinction is
+                        // load-bearing — the linker refuses to silently drop a
+                        // relocation into an ALLOC section it cannot place, and
+                        // marking DWARF as ALLOC would turn that safety net into
+                        // spurious link failures (RUE-1647).
                         let mut section_flags = SectionFlags::empty();
-                        section_flags |= SectionFlags::ALLOC;
-                        // S_ATTR_PURE_INSTRUCTIONS = 0x80000000
-                        if flags & 0x80000000 != 0 {
+                        if flags & crate::constants::S_ATTR_DEBUG == 0 && segname != "__DWARF" {
+                            section_flags |= SectionFlags::ALLOC;
+                        }
+                        if flags & crate::constants::S_ATTR_PURE_INSTRUCTIONS != 0 {
                             section_flags |= SectionFlags::EXEC;
                         }
-                        // Check segment name for writability
+                        // Writability is a property of the segment. __DATA is
+                        // writable for the life of the process; __DATA_CONST is
+                        // not (it is read-only once fixups are applied, and this
+                        // linker applies them all statically), so it must not
+                        // pick up WRITE from a prefix match here.
                         if segname == "__DATA" {
                             section_flags |= SectionFlags::WRITE;
                         }
@@ -613,6 +628,18 @@ impl ObjectFile {
                     // nsyms: u32 at offset 12
                     // stroff: u32 at offset 16
                     // strsize: u32 at offset 20
+                    //
+                    // The loop only established that `cmd_offset + cmdsize` is
+                    // inside the file, so a command declaring a short cmdsize
+                    // would let these four reads run past the buffer and panic.
+                    // A malformed object must be an Err, never a panic
+                    // (RUE-1645).
+                    if cmdsize < MACHO64_SYMTAB_CMD_SIZE {
+                        return Err(ParseError::InvalidSymbol(format!(
+                            "LC_SYMTAB load command declares cmdsize {cmdsize}, \
+                             but the command is {MACHO64_SYMTAB_CMD_SIZE} bytes"
+                        )));
+                    }
                     symtab_offset = read_u32(data, cmd_offset + 8) as usize;
                     symtab_count = read_u32(data, cmd_offset + 12) as usize;
                     strtab_offset = read_u32(data, cmd_offset + 16) as usize;
@@ -1069,8 +1096,17 @@ impl ObjectFile {
         }
         let shstrtab_data = &data[shstrtab.offset as usize..shstrtab_end as usize];
 
-        // Helper to read null-terminated string
+        // Helper to read null-terminated string.
+        //
+        // `offset` is a file-controlled u32 (a symbol's `st_name` or a section's
+        // `sh_name`), so it must be checked against the table before slicing:
+        // Rust panics on a range whose START is past the slice, and a malformed
+        // object must produce an Err, not a panic (RUE-1645). An offset exactly
+        // at the end is the empty name and stays valid.
         let read_string = |strtab: &[u8], offset: usize| -> Result<String, ParseError> {
+            if offset > strtab.len() {
+                return Err(ParseError::InvalidStringTable);
+            }
             let start = offset;
             let mut end = start;
             while end < strtab.len() && strtab[end] != 0 {
@@ -1150,6 +1186,17 @@ impl ObjectFile {
         let mut symbols = Vec::new();
 
         if let (Some(symtab_i), Some(strtab_i)) = (symtab_idx, strtab_idx) {
+            // `strtab_i` is the `.symtab` header's `sh_link` field verbatim, so
+            // a malformed object can name a section index the file does not
+            // have. Reject it instead of indexing `raw_sections` and panicking
+            // (RUE-1645).
+            if strtab_i >= raw_sections.len() {
+                return Err(ParseError::InvalidSymbol(format!(
+                    "symbol table sh_link {} is out of bounds (have {} sections)",
+                    strtab_i,
+                    raw_sections.len()
+                )));
+            }
             let symtab = &raw_sections[symtab_i];
             let strtab = &raw_sections[strtab_i];
 
@@ -2341,6 +2388,123 @@ mod tests {
             matches!(&result, Err(ParseError::InvalidSymbol(msg)) if msg.contains("section index")),
             "Expected InvalidSymbol error about section index, got: {:?}",
             result
+        );
+    }
+
+    /// File offset of section header `index` in an ELF object, for the
+    /// malformed-input tests below that corrupt one field of a valid object.
+    fn shdr_offset(data: &[u8], index: usize) -> usize {
+        let e_shoff =
+            u64::from_le_bytes(data[E_SHOFF_OFFSET..E_SHOFF_OFFSET + 8].try_into().unwrap())
+                as usize;
+        let e_shentsize = u16::from_le_bytes(
+            data[E_SHENTSIZE_OFFSET..E_SHENTSIZE_OFFSET + 2]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        e_shoff + index * e_shentsize
+    }
+
+    /// Index of the first section header whose `sh_type` equals `sh_type`.
+    fn find_section_header(data: &[u8], sh_type: u32) -> usize {
+        let e_shnum =
+            u16::from_le_bytes(data[E_SHNUM_OFFSET..E_SHNUM_OFFSET + 2].try_into().unwrap())
+                as usize;
+        (0..e_shnum)
+            .find(|&i| {
+                let base = shdr_offset(data, i);
+                u32::from_le_bytes(data[base + 4..base + 8].try_into().unwrap()) == sh_type
+            })
+            .expect("section header of the requested type")
+    }
+
+    fn elf_object_bytes() -> Vec<u8> {
+        crate::emit::ObjectBuilder::new(rue_target::Target::X86_64Linux, "main")
+            .code(vec![0xC3])
+            .build()
+    }
+
+    /// A `.symtab` whose `sh_link` names a section index the file does not have
+    /// must be rejected, not indexed into. The parser took `sh_link` straight
+    /// from the header and later used it as `&raw_sections[strtab_i]`
+    /// (RUE-1645).
+    #[test]
+    fn malformed_symtab_sh_link_out_of_range_is_rejected() {
+        let mut data = elf_object_bytes();
+        let symtab = shdr_offset(&data, find_section_header(&data, SHT_SYMTAB));
+        // sh_link is a u32 at offset 40 of the section header.
+        data[symtab + 40..symtab + 44].copy_from_slice(&0xFFFF_u32.to_le_bytes());
+
+        let result = ObjectFile::parse(&data);
+        assert!(
+            matches!(&result, Err(ParseError::InvalidSymbol(msg)) if msg.contains("sh_link")),
+            "expected InvalidSymbol about sh_link, got: {result:?}"
+        );
+    }
+
+    /// A symbol whose `st_name` points past the end of its string table must be
+    /// rejected: the name reader sliced `strtab[start..end]`, and Rust panics on
+    /// an out-of-range range start (RUE-1645).
+    #[test]
+    fn malformed_symbol_name_offset_past_strtab_is_rejected() {
+        let mut data = elf_object_bytes();
+        let symtab_header = shdr_offset(&data, find_section_header(&data, SHT_SYMTAB));
+        let symtab_offset = u64::from_le_bytes(
+            data[symtab_header + 24..symtab_header + 32]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        // Entry 0 is the reserved null symbol; corrupt entry 1's st_name.
+        let sym = symtab_offset + ELF64_SYM_SIZE;
+        data[sym..sym + 4].copy_from_slice(&0x00FF_FFFF_u32.to_le_bytes());
+
+        let result = ObjectFile::parse(&data);
+        assert!(
+            matches!(&result, Err(ParseError::InvalidStringTable)),
+            "expected InvalidStringTable, got: {result:?}"
+        );
+    }
+
+    /// The same out-of-range slice start is reachable through a section's
+    /// `sh_name` offset into `.shstrtab` (RUE-1645).
+    #[test]
+    fn malformed_section_name_offset_past_shstrtab_is_rejected() {
+        let mut data = elf_object_bytes();
+        let text = shdr_offset(
+            &data,
+            find_section_header(&data, crate::constants::SHT_PROGBITS),
+        );
+        data[text..text + 4].copy_from_slice(&0x00FF_FFFF_u32.to_le_bytes());
+
+        let result = ObjectFile::parse(&data);
+        assert!(
+            matches!(&result, Err(ParseError::InvalidStringTable)),
+            "expected InvalidStringTable, got: {result:?}"
+        );
+    }
+
+    /// An `LC_SYMTAB` load command declaring a `cmdsize` smaller than the
+    /// `symtab_command` struct must be rejected. Only `cmd_offset + cmdsize <=
+    /// data.len()` was checked, so a final 8-byte command let the four u32
+    /// field reads run past the buffer (RUE-1645).
+    #[test]
+    fn malformed_macho_symtab_command_too_small_is_rejected() {
+        let mut data = vec![0u8; MACHO64_HEADER_SIZE + 8];
+        data[0..4].copy_from_slice(&MH_MAGIC_64.to_le_bytes());
+        data[4..8].copy_from_slice(&crate::constants::CPU_TYPE_ARM64.to_le_bytes());
+        data[12..16].copy_from_slice(&MH_OBJECT.to_le_bytes());
+        data[16..20].copy_from_slice(&1_u32.to_le_bytes()); // ncmds
+        data[20..24].copy_from_slice(&8_u32.to_le_bytes()); // sizeofcmds
+        // The single load command: LC_SYMTAB with a truncated cmdsize.
+        data[MACHO64_HEADER_SIZE..MACHO64_HEADER_SIZE + 4]
+            .copy_from_slice(&LC_SYMTAB.to_le_bytes());
+        data[MACHO64_HEADER_SIZE + 4..MACHO64_HEADER_SIZE + 8]
+            .copy_from_slice(&8_u32.to_le_bytes());
+
+        let result = ObjectFile::parse(&data);
+        assert!(
+            matches!(&result, Err(ParseError::InvalidSymbol(msg)) if msg.contains("LC_SYMTAB")),
+            "expected InvalidSymbol about LC_SYMTAB, got: {result:?}"
         );
     }
 }

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -12,7 +12,7 @@ use crate::constants::{
     PF_R, PF_W, PF_X, PT_LOAD,
 };
 use crate::elf::Section;
-use crate::elf::{ObjectFile, RelocationType, Symbol, SymbolBinding};
+use crate::elf::{ObjectFile, RelocationType, SectionFlags, Symbol, SymbolBinding};
 use crate::util::align_up;
 
 /// Which merged output buffer a relocation's patch site lives in.
@@ -42,7 +42,9 @@ enum SectionKind {
     Rodata,
     /// Writable initialized data (`.data*` / `__DATA,__data` / `__data*`).
     Data,
-    /// Zero-initialized data (`.bss*` / `__DATA,__bss` / `__bss*`).
+    /// Zero-initialized data (`.bss*` / `__DATA,__bss` / `__bss*`, plus Mach-O
+    /// `__DATA,__common`, the S_ZEROFILL section holding tentative definitions
+    /// such as compiler-rt's `___aarch64_have_lse_atomics`).
     Bss,
     /// Anything else (debug info, notes, etc.) — not merged into a segment.
     Other,
@@ -53,6 +55,15 @@ enum SectionKind {
 /// section-classification authority; every merge/base-address decision routes
 /// through it so the classes cannot drift out of sync (RUE-336).
 ///
+/// A section this list does not recognize becomes [`SectionKind::Other`] and is
+/// not placed. That is correct for debug and note sections and wrong for
+/// anything the loader maps, so an unrecognized ALLOC section is caught rather
+/// than dropped: see [`collect_section_relocations`] (RUE-1647). Stock
+/// clang/rustc read-only output — `__DATA_CONST,*` and `__TEXT,__literal4/8/16`
+/// — is named here for that reason. `__DATA_CONST` is read-only once fixups are
+/// applied and this linker applies all of them statically, so it is rodata, not
+/// data.
+///
 /// The prefix sets are mutually exclusive, so the check order is immaterial.
 fn classify_section(name: &str) -> SectionKind {
     if name.starts_with(".text") || name == "__TEXT,__text" || name.starts_with("__text") {
@@ -62,13 +73,21 @@ fn classify_section(name: &str) -> SectionKind {
         || name == "__TEXT,__const"
         || name == "__TEXT,__cstring"
         || name == "__TEXT,__rodata"
+        || name.starts_with("__DATA_CONST,")
+        || name.starts_with("__TEXT,__literal")
+        || name.starts_with("__literal")
         || name.starts_with("__const")
         || name.starts_with(".cstring")
     {
         SectionKind::Rodata
     } else if name.starts_with(".data") || name == "__DATA,__data" || name.starts_with("__data") {
         SectionKind::Data
-    } else if name.starts_with(".bss") || name == "__DATA,__bss" || name.starts_with("__bss") {
+    } else if name.starts_with(".bss")
+        || name == "__DATA,__bss"
+        || name.starts_with("__bss")
+        || name == "__DATA,__common"
+        || name.starts_with("__common")
+    {
         SectionKind::Bss
     } else {
         SectionKind::Other
@@ -700,16 +719,31 @@ fn collect_section_relocations(
             continue;
         }
 
-        // We link text, rodata, data, and bss; skip relocations whose
-        // TARGET symbol lives in a section we don't link (e.g. debug).
+        // We link text, rodata, data, and bss. A relocation whose TARGET
+        // symbol lives in a section we don't link splits into two cases that
+        // used to share one silent `continue`:
+        //
+        // * Non-ALLOC (debug info, notes): the section is never loaded and no
+        //   running instruction can observe the patch site, so skipping is
+        //   correct — and required, since objects routinely carry them.
+        // * ALLOC: the section IS part of the loaded image, but this linker
+        //   places neither it nor its symbols. Skipping left the patch site in
+        //   `.text`/`.rodata`/`.data` holding placeholder bytes and reported a
+        //   successful link — a silent miscompile that only shows up as a wrong
+        //   pointer at runtime (RUE-1647). Fail the link instead; the fix for
+        //   such a section is to name it in `classify_section`, the way
+        //   `__DATA_CONST,*` and `__TEXT,__literal*` now are.
         if let Some(sec_idx) = sym.section_index {
             if sec_idx < obj.sections.len() {
                 let target_sec = &obj.sections[sec_idx];
-                if !is_text_section(&target_sec.name)
-                    && !is_rodata_section(&target_sec.name)
-                    && !is_data_section(&target_sec.name)
-                    && !is_bss_section(&target_sec.name)
-                {
+                if classify_section(&target_sec.name) == SectionKind::Other {
+                    if target_sec.flags.contains(SectionFlags::ALLOC) {
+                        return Err(LinkError::UnsupportedRelocation(format!(
+                            "{:?} against '{}': the target symbol is defined in allocatable \
+                             section '{}', which this linker does not place",
+                            reloc.rel_type, sym.name, target_sec.name
+                        )));
+                    }
                     continue;
                 }
             }
@@ -5639,5 +5673,285 @@ mod tests {
             has_g,
             "archive member defining g must be linked (pulled in by f)"
         );
+    }
+
+    /// Hand-build an object whose `.text` takes the address of a symbol defined
+    /// in `section` — the shape RUE-1647 is about: the patch site is in a
+    /// section we do link, the target is in one we may not.
+    fn object_referencing_section(
+        machine: crate::elf::ElfMachine,
+        text_name: &str,
+        section: Section,
+    ) -> ObjectFile {
+        let abs64 = match machine {
+            crate::elf::ElfMachine::X86_64 => RelocationType::Abs64,
+            crate::elf::ElfMachine::Aarch64 => RelocationType::Aarch64Abs64,
+        };
+        let text = text_section(
+            text_name,
+            vec![0u8; 16],
+            vec![Relocation {
+                offset: 8,
+                symbol_index: 1,
+                rel_type: abs64,
+                addend: 0,
+            }],
+        );
+        make_obj(
+            machine,
+            vec![text, section],
+            vec![
+                sym("main", Some(0), 0, SymbolBinding::Global),
+                sym("target", Some(1), 0, SymbolBinding::Global),
+            ],
+        )
+    }
+
+    /// RUE-1647: a relocation whose target symbol lives in an ALLOCATABLE
+    /// section this linker does not place must be a hard error. It was silently
+    /// skipped — the same `continue` that skips debug sections — leaving the
+    /// patch site in `.text` holding its placeholder bytes while the link
+    /// reported success.
+    #[test]
+    fn relocation_into_unhandled_allocatable_section_is_rejected() {
+        let obj = object_referencing_section(
+            crate::elf::ElfMachine::X86_64,
+            ".text",
+            Section {
+                name: ".init_array".into(),
+                data: vec![0u8; 8],
+                size: 8,
+                flags: SectionFlags::ALLOC | SectionFlags::WRITE,
+                relocations: Vec::new(),
+                align: 8,
+            },
+        );
+        let mut linker = Linker::new(ELF_TARGET);
+        linker.add_object(obj).unwrap();
+        let error = linker
+            .link("main")
+            .expect_err("dropping an allocatable section's relocation is a silent miscompile");
+        assert!(
+            matches!(&error, LinkError::UnsupportedRelocation(msg)
+                if msg.contains("target") && msg.contains(".init_array")),
+            "expected a diagnosable error naming the section, got: {error}"
+        );
+    }
+
+    /// The silent skip stays for genuinely non-allocatable sections: debug and
+    /// note sections are never loaded, so a reference into one cannot corrupt a
+    /// running program (RUE-1647).
+    #[test]
+    fn relocation_into_non_allocatable_section_is_still_skipped() {
+        let obj = object_referencing_section(
+            crate::elf::ElfMachine::X86_64,
+            ".text",
+            Section {
+                name: ".debug_info".into(),
+                data: vec![0u8; 8],
+                size: 8,
+                flags: SectionFlags::empty(),
+                relocations: Vec::new(),
+                align: 1,
+            },
+        );
+        let mut linker = Linker::new(ELF_TARGET);
+        linker.add_object(obj).unwrap();
+        let elf = linker
+            .link("main")
+            .expect("debug references must not fail a link");
+        let (_, text_off, _) = parse_program_headers(&elf)
+            .into_iter()
+            .find(|(f, ..)| *f == (PF_R | PF_X))
+            .expect("R+X segment");
+        assert_eq!(
+            read_u64_at(&elf, text_off as usize + 8),
+            0,
+            "a skipped debug relocation leaves its placeholder"
+        );
+    }
+
+    /// RUE-1647: `__DATA_CONST,__const` and `__TEXT,__literal*` are ordinary
+    /// read-only data that stock clang/rustc emit. They fell through to
+    /// `Other`, so the linker placed neither the section nor its symbols and
+    /// dropped every reference to them.
+    #[test]
+    fn macho_data_const_and_literal_sections_are_linked() {
+        for name in [
+            "__DATA_CONST,__const",
+            "__TEXT,__literal4",
+            "__TEXT,__literal8",
+            "__TEXT,__literal16",
+        ] {
+            let marker = [0xEFu8, 0xBE, 0xAD, 0xDE, 0x0D, 0xF0, 0xED, 0xFE];
+            let obj = object_referencing_section(
+                crate::elf::ElfMachine::Aarch64,
+                "__TEXT,__text",
+                Section {
+                    name: name.into(),
+                    data: marker.to_vec(),
+                    size: marker.len() as u64,
+                    flags: SectionFlags::ALLOC,
+                    relocations: Vec::new(),
+                    align: 8,
+                },
+            );
+            let mut linker = Linker::new(Target::Aarch64Macos);
+            linker.add_object(obj).unwrap();
+            let macho = linker
+                .link("main")
+                .unwrap_or_else(|e| panic!("{name} must link: {e}"));
+
+            let (_, text_vmaddr, text_fileoff, _) = macho_segments(&macho)
+                .into_iter()
+                .find(|(n, ..)| n == "__TEXT")
+                .expect("__TEXT segment");
+            let code_off = macho_entryoff(&macho) as usize;
+            let slot = read_u64_at(&macho, code_off + 8);
+            assert!(
+                slot >= text_vmaddr,
+                "{name}: reference must be patched with a real address, got {slot:#x}"
+            );
+            let file_off = (slot - text_vmaddr + text_fileoff) as usize;
+            assert_eq!(
+                &macho[file_off..file_off + marker.len()],
+                &marker,
+                "{name}: the reference must point at the section's own bytes"
+            );
+        }
+    }
+
+    /// Build the two objects the bss-alignment tests link (RUE-1646).
+    ///
+    /// Object 0 holds `main`, a 17-byte `.data` whose two pointer slots take
+    /// the address of each bss symbol, and an 8-aligned bss section; object 1
+    /// holds a 16-aligned bss section. The odd `.data` size is the point: the
+    /// merged bss base used to be the unrounded end of merged `.data`, so every
+    /// bss symbol inherited that odd offset.
+    fn bss_alignment_objects(
+        machine: crate::elf::ElfMachine,
+        text_name: &str,
+        data_name: &str,
+        bss_name: &str,
+    ) -> (ObjectFile, ObjectFile) {
+        let abs64 = match machine {
+            crate::elf::ElfMachine::X86_64 => RelocationType::Abs64,
+            crate::elf::ElfMachine::Aarch64 => RelocationType::Aarch64Abs64,
+        };
+        let data = Section {
+            name: data_name.into(),
+            data: vec![0u8; 17],
+            size: 17,
+            flags: SectionFlags::ALLOC | SectionFlags::WRITE,
+            relocations: vec![
+                Relocation {
+                    offset: 1,
+                    symbol_index: 1, // bss_align8
+                    rel_type: abs64,
+                    addend: 0,
+                },
+                Relocation {
+                    offset: 9,
+                    symbol_index: 2, // bss_align16 (defined in object 1)
+                    rel_type: abs64,
+                    addend: 0,
+                },
+            ],
+            align: 1,
+        };
+        let bss8 = Section {
+            name: bss_name.into(),
+            data: Vec::new(),
+            size: 4,
+            flags: SectionFlags::ALLOC | SectionFlags::WRITE,
+            relocations: Vec::new(),
+            align: 8,
+        };
+        let obj0 = make_obj(
+            machine,
+            vec![
+                text_section(text_name, vec![0u8; 4], Vec::new()),
+                data,
+                bss8,
+            ],
+            vec![
+                sym("main", Some(0), 0, SymbolBinding::Global),
+                sym("bss_align8", Some(2), 0, SymbolBinding::Global),
+                sym("bss_align16", None, 0, SymbolBinding::Global),
+            ],
+        );
+
+        let bss16 = Section {
+            name: bss_name.into(),
+            data: Vec::new(),
+            size: 8,
+            flags: SectionFlags::ALLOC | SectionFlags::WRITE,
+            relocations: Vec::new(),
+            align: 16,
+        };
+        let obj1 = make_obj(
+            machine,
+            vec![bss16],
+            vec![sym("bss_align16", Some(0), 0, SymbolBinding::Global)],
+        );
+        (obj0, obj1)
+    }
+
+    /// RUE-1646 (ELF): the merged bss base must honor the alignment its bss
+    /// sections declare. It was `data_vaddr + merged_data.len()` with no
+    /// rounding, so an odd-sized `.data` misaligned every bss symbol — the
+    /// runtime's own `AtomicU64` statics included.
+    #[test]
+    fn bss_base_honors_section_alignment_elf() {
+        let (obj0, obj1) =
+            bss_alignment_objects(crate::elf::ElfMachine::X86_64, ".text", ".data", ".bss");
+        let mut linker = Linker::new(ELF_TARGET);
+        linker.add_object(obj0).unwrap();
+        linker.add_object(obj1).unwrap();
+        let elf = linker.link("main").unwrap();
+
+        let (_, data_off, data_vaddr) = parse_program_headers(&elf)
+            .into_iter()
+            .find(|(f, ..)| *f == (PF_R | PF_W))
+            .expect("RW data segment");
+
+        let addr8 = read_u64_at(&elf, data_off as usize + 1);
+        let addr16 = read_u64_at(&elf, data_off as usize + 9);
+        assert!(
+            addr8 > data_vaddr && addr16 > addr8,
+            "bss symbols must land after the merged data ({addr8:#x}, {addr16:#x})"
+        );
+        assert_eq!(addr8 % 8, 0, "8-aligned bss symbol at {addr8:#x}");
+        assert_eq!(addr16 % 16, 0, "16-aligned bss symbol at {addr16:#x}");
+    }
+
+    /// RUE-1646 (Mach-O): same bug, where the bss base was rounded only to a
+    /// hardcoded 8 regardless of what the bss sections asked for.
+    #[test]
+    fn bss_base_honors_section_alignment_macho() {
+        let (obj0, obj1) = bss_alignment_objects(
+            crate::elf::ElfMachine::Aarch64,
+            "__TEXT,__text",
+            "__DATA,__data",
+            "__DATA,__bss",
+        );
+        let mut linker = Linker::new(Target::Aarch64Macos);
+        linker.add_object(obj0).unwrap();
+        linker.add_object(obj1).unwrap();
+        let macho = linker.link("main").unwrap();
+
+        let (_, data_vmaddr, data_fileoff, _) = macho_segments(&macho)
+            .into_iter()
+            .find(|(n, ..)| n == "__DATA")
+            .expect("__DATA segment");
+
+        let addr8 = read_u64_at(&macho, data_fileoff as usize + 1);
+        let addr16 = read_u64_at(&macho, data_fileoff as usize + 9);
+        assert!(
+            addr8 > data_vmaddr && addr16 > addr8,
+            "bss symbols must land after the merged data ({addr8:#x}, {addr16:#x})"
+        );
+        assert_eq!(addr8 % 8, 0, "8-aligned bss symbol at {addr8:#x}");
+        assert_eq!(addr16 % 16, 0, "16-aligned bss symbol at {addr16:#x}");
     }
 }


### PR DESCRIPTION
Two linker bugs from fix cycle 18. Both reproduced before being fixed, and re-verified by execution at integration time.

**Scope note:** this PR originally also carried RUE-1766. That fix landed independently on trunk (`299e893`) while this was queued, which is what dequeued this PR with `MERGE_CONFLICT` — all four conflicting files were the RUE-1766 half. This branch has been rebuilt on current trunk carrying **only** the linker work, which is still unique to it.

## RUE-1647 — relocations into unrecognized ALLOC sections were silently dropped

`collect_section_relocations` skipped any relocation whose target symbol lived in a section classifying as `SectionKind::Other`. That is correct for debug sections and wrong for allocatable ones the name list does not recognize: the patch site kept its placeholder bytes and **the link succeeded**, producing a binary with a wrong pointer in it and no diagnostic anywhere.

Dropping a relocation into an ALLOC section is now a hard `LinkError`. The silent skip is kept only for genuinely non-alloc debug and note sections, and `__DATA_CONST,*`, `__TEXT,__literal*` and S_ZEROFILL `__DATA,__common` are classified rather than falling through. Mach-O parsing also stops marking DWARF as ALLOC.

**This was not hypothetical.** Walking every member of all three shipped runtime archives found the darwin runtime **already carrying 73 `__text` → `__literal16` relocations that are being dropped today** — latent only because floats are not typed yet. Both ELF runtimes were clean. All three are clean after the change.

Confirmed by construction first: an ELF link with a `.text` reference into `.init_array` succeeded with an all-zero patch site, and Mach-O `__DATA_CONST,__const` patched to `0x0`.

Because a hard error can break links that currently succeed, the real link paths were exercised on both targets rather than reasoned about — x86-64-linux (compiled *and* ran), aarch64-linux, aarch64-macos, plus `--emit asm`.

## RUE-1645 — the object parser panicked where its contract says it returns ParseError

Three paths panicked on malformed input while the surrounding code returns `Err(ParseError)`, which many tests assert:

- an unvalidated `sh_link` from the `.symtab` header indexing the section table,
- a file-controlled `u32` string-table offset slicing out of range,
- `LC_SYMTAB` fields read after checking only `cmd_offset + cmdsize`, so a final load command with `cmdsize = 8` read past the buffer.

All three fired as described before the fix. They now return `InvalidSymbol` / `InvalidStringTable`, with four malformed-input tests in the existing `test_symbol_section_index_out_of_bounds` style.

## Verification

Linker unit tests 167/167. `scripts/rue fmt` clean. Full `./test.sh` re-run on this reduced branch.

The earlier full-suite run of this work (when it still carried RUE-1766) was green at `Tests finished: Pass 234. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0`, and that version passed CI 24/24 including all four CLI shards and both native targets.

## Not fixed here

RUE-1646 also landed on trunk independently (`5df2960`) during this cycle; the worker's parallel implementation and its now-unused `merged_bss_alignment` helper were dropped in favour of trunk's.

Three linker follow-ups remain from the worker's analysis: unreferenced ALLOC sections are still dropped, ELF `SHN_COMMON` is unhandled, and `align_up` is applied to raw file alignment.

Fixes RUE-1645
Fixes RUE-1647