### PR TITLE
RUE-1788: subtract each corpus action together with its test target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ scripts/rue build                    # build the compiler and print its path
 scripts/rue exec prog.rue            # compile and run a quick program
 RUE="$(scripts/rue-bin)"; "$RUE" main.rue -o out
 scripts/rue quick                    # fast unit suite
-scripts/rue premerge                 # canonical required-CI tier
+scripts/rue premerge                 # canonical premerge test tier
 scripts/rue slow                     # canonical scheduled slow tier
 scripts/rue stress                   # canonical opt-in stress tier
 scripts/rue all                      # canonical union of all tiers
@@ -226,6 +226,17 @@ Use proportionate validation:
    architecture-specific suites.
 3. Run the broad/full suite once when the change is cross-cutting or high-risk.
    CI is the final full-platform authority.
+
+`scripts/rue premerge` is a tier, not a preview of required CI. It selects on
+`rue_test_tier_premerge`, so a required lane whose target sits in another tier
+is outside what it can report — the oracle-diff corpora are `tier = "slow"`
+while `test (linux-x64-oracle-diff*)` gates the merge queue. Adding a CLI or
+spec case is the common way to land in that gap: a case reaching a construct
+the oracle does not model is a harness failure until its gap is registered in
+`crates/rue-oracle-diff/src/model_gaps/`, and the audit prints the exact entry
+to add. Run `./buck2 test //crates/rue-oracle-diff:oracle-diff-test` when a
+change adds or edits corpus cases; it reproduces that failure in about two
+minutes (RUE-1711 cost a CI round for want of it).
 
 The generated-oracle smoke target has a fixed two-second child-process budget
 and can time out under heavy parallel load on the local macOS host. If failures

--- a/scripts/affected-targets
+++ b/scripts/affected-targets
@@ -45,7 +45,8 @@
 #   build-scope        Print the targets a `//crates/...` lane may build, with
 #                      or without an impacted list. Narrowing must stay inside
 #                      the lane's own scope, and neither spelling of that scope
-#                      may name a corpus action (RUE-1511).
+#                      may name a corpus action (RUE-1511) or the test target
+#                      that depends on one (RUE-1788).
 #
 # Deliberately NOT `set -e`: a full run is the safe fallback, so failures are
 # handled explicitly and converted into "full", never into a hard error that
@@ -339,9 +340,23 @@ normalize_cell() {
 # `NAME-action` for the test `NAME`, so that mapping is the rule's own
 # construction rather than an inference about the graph.
 #
+# EACH DEFERRAL IS A PAIR, and RUE-1788 is what naming only half of it costs.
+# The `sh_test` the macro emits alongside the action carries
+# `args = ["$(location :NAME-action)"]`, so `NAME` depends on `NAME-action`:
+# subtracting the action while leaving its test target in scope builds the
+# action anyway, through the edge, and runs the corpus exactly as before. That
+# is what `premerge (linux-x64)` did from RUE-1511 until RUE-1788 — the two
+# oracle-diff corpora were subtracted by name and rebuilt by dependency, and
+# both this script's tests and the acceptance check asserted only that no
+# `-action` label appeared in the output, which stayed true throughout.
+#
+# So both halves are emitted. `cquery rdeps` confirms the test target is the
+# action's only dependent, which is what makes the pair the whole closure and
+# not merely the part of it this file happens to know how to name.
+#
 # Fails non-zero when Buck cannot answer, and the caller then builds the corpus
 # actions exactly as it did before.
-deferred_corpus_actions() {
+deferred_corpus_targets() {
     local buck2 actions covered action test_target query
     buck2="$(buck2_bin)"
 
@@ -384,7 +399,9 @@ deferred_corpus_actions() {
         [[ -n "$action" ]] || continue
         test_target="${action%-action}"
         if grep -Fxq "$test_target" <<<"$covered"; then
-            printf '%s\n' "$action"
+            # The test target too: it depends on the action, so subtracting the
+            # action alone leaves the build reaching it through that edge.
+            printf '%s\n' "$action" "$test_target"
         else
             echo "affected-targets: ${action} runs a corpus no required lane owns;" \
                  "keeping it in the build scope" >&2
@@ -396,10 +413,14 @@ deferred_corpus_actions() {
 # The targets a *pattern* lane may build, for lanes whose scope is
 # `//crates/...` rather than a fixed list. With an impacted list it is the
 # narrowed subset; without one it is the whole pattern. Both are the same scope
-# minus the same corpus actions, because both lose independently: fixing only
-# the narrowed spelling leaves the common case — a compiler change, which
-# impacts more than NARROW_LIMIT targets and so is never narrowed — building
-# the corpora exactly as before.
+# minus the same deferred corpus targets, because both lose independently:
+# fixing only the narrowed spelling leaves the common case — a compiler change,
+# which impacts more than NARROW_LIMIT targets and so is never narrowed —
+# building the corpora exactly as before.
+#
+# Both spellings subtract a set that `deferred_corpus_targets` returns whole,
+# each action paired with the test target that depends on it, so neither can
+# reach an action through an edge the other blocks (RUE-1788).
 #
 # RUE-1130 handed the raw impacted closure to `buck2 build` in linux-premerge.
 # That closure spans the whole graph, so narrowing WIDENED the step: it re-ran
@@ -411,7 +432,7 @@ deferred_corpus_actions() {
 build_scope() {
     local file="${1:-}"
     local deferred kept buck2 expr scope
-    deferred="$(deferred_corpus_actions)" || deferred=""
+    deferred="$(deferred_corpus_targets)" || deferred=""
 
     if [[ -z "$file" ]]; then
         # The unnarrowed scope. `buck2 build` accepts patterns and target

--- a/scripts/test-affected-targets.sh
+++ b/scripts/test-affected-targets.sh
@@ -285,6 +285,14 @@ mkdir -p "$scope_root/bin"
 cat >"$scope_root/bin/fake-buck" <<'FAKEBUCK'
 #!/usr/bin/env bash
 # Answers the three queries build_scope() makes, and nothing else.
+#
+# The `//crates/...` universe carries each corpus suite as the PAIR
+# `cached_corpus_suite` really emits — the `sh_test` and the `-action` it
+# depends on — and this stub honours the `except set(...)` the caller builds.
+# Returning a universe with no corpus targets in it, and ignoring the
+# subtraction, is what let RUE-1788 sit here undetected: the unnarrowed case
+# could assert only that no `-action` label appeared, which was true of the
+# stub's answer no matter what the script subtracted.
 case "$2" in
   "kind('_corpus_action', //crates/...)")
     printf '%s\n' \
@@ -298,9 +306,31 @@ case "$2" in
       root//crates/rue-oracle-diff:oracle-diff-test \
       root//crates/rue-oracle-diff:oracle-diff-spec-test ;;
   //crates/...*)
-    printf '%s\n' \
-      root//crates/rue-compiler:rue-compiler \
-      root//crates/rue-span:rue-span-test ;;
+    fake_universe="root//crates/rue-compiler:rue-compiler
+root//crates/rue-span:rue-span-test
+root//crates/rue-oracle-diff:oracle-diff-test
+root//crates/rue-oracle-diff:oracle-diff-test-action
+root//crates/rue-oracle-diff:oracle-diff-spec-test
+root//crates/rue-oracle-diff:oracle-diff-spec-test-action
+root//crates/rue-newthing:newthing-test
+root//crates/rue-newthing:newthing-test-action"
+    fake_excluded=" "
+    case "$2" in
+      *"except set("*)
+        fake_rest="${2#*except set(}"
+        fake_excluded=" ${fake_rest%)} " ;;
+    esac
+    printf '%s\n' "$fake_universe" | while IFS= read -r fake_target; do
+      [ -n "$fake_target" ] || continue
+      # The caller subtracts normalized (`//`) labels; the graph answers with
+      # `root//`. Match either spelling so the stub cannot pass by accident.
+      fake_short="${fake_target#root}"
+      case "$fake_excluded" in
+        *" $fake_target "*) continue ;;
+        *" $fake_short "*) continue ;;
+      esac
+      printf '%s\n' "$fake_target"
+    done ;;
   *) echo "fake-buck: unexpected query: $2" >&2; exit 1 ;;
 esac
 FAKEBUCK
@@ -333,11 +363,12 @@ printf '%s\n' \
   //:spec-tests-action \
   //:cli-tests-shard-2-action \
   //crates/rue-oracle-diff:oracle-diff-test-action \
+  //crates/rue-oracle-diff:oracle-diff-test \
   >"$narrow_root/mixed"
 TESTS=$((TESTS + 1))
 if [ "$(RUE_AFFECTED_BUCK2="$scope_root/bin/fake-buck" "${AFFECTED[@]}" build-scope "$narrow_root/mixed" | tr '\n' ' ')" \
      = "//crates/rue-compiler:rue-compiler //crates/rue-codegen:rue-codegen-test " ]; then
-  pass "narrow: build-scope keeps the crate scope and drops every corpus action"
+  pass "narrow: build-scope keeps the crate scope and drops every corpus target"
 else
   fail "narrow: build-scope did not restore the //crates/... scope"
 fi
@@ -352,25 +383,58 @@ fi
 # common case — a compiler change impacts more than NARROW_LIMIT targets, so it
 # is never narrowed. Both must drop the same actions, or fixing one leaves
 # premerge building the corpora exactly as before.
+#
+# Asserted as an EXACT scope rather than as "no `-action` label appears".
+# RUE-1788 was invisible to the weaker form: the subtraction named the two
+# oracle-diff actions, the build reached them anyway through the `sh_test` that
+# carries `$(location :NAME-action)`, and no `-action` label was ever printed
+# while that happened. What the step must not contain is anything that BUILDS a
+# deferred corpus, which for this rule means the pair, so the pair is what the
+# expectation spells out.
 TESTS=$((TESTS + 1))
-unnarrowed="$(RUE_AFFECTED_BUCK2="$scope_root/bin/fake-buck" "${AFFECTED[@]}" build-scope 2>/dev/null)"
-if [ -n "$unnarrowed" ] && ! grep -q -- '-action$' <<<"$unnarrowed"; then
-  pass "narrow: build-scope with no list expands the pattern without any corpus action"
+unnarrowed="$(RUE_AFFECTED_BUCK2="$scope_root/bin/fake-buck" "${AFFECTED[@]}" build-scope 2>/dev/null | tr '\n' ' ')"
+if [ "$unnarrowed" = "//crates/rue-compiler:rue-compiler //crates/rue-span:rue-span-test //crates/rue-newthing:newthing-test //crates/rue-newthing:newthing-test-action " ]; then
+  pass "narrow: build-scope with no list drops each deferred action AND its test target"
 else
-  fail "narrow: build-scope with no list kept a corpus action or produced nothing"
+  fail "narrow: build-scope with no list kept a deferred corpus target (got '$unnarrowed')"
+fi
+
+# RUE-1788 head-on, in both spellings: naming the action alone is not a
+# subtraction, because the test target reaches it. A fix that removes only the
+# `-action` label passes every other case in this file and fails these two.
+TESTS=$((TESTS + 1))
+if [ "${unnarrowed#*oracle-diff}" = "$unnarrowed" ]; then
+  pass "narrow: no deferred corpus suite survives the unnarrowed scope in any spelling"
+else
+  fail "narrow: a deferred corpus target survived the unnarrowed scope ('$unnarrowed')"
+fi
+
+printf '%s\n' \
+  //crates/rue-oracle-diff:oracle-diff-test \
+  //crates/rue-oracle-diff:oracle-diff-spec-test \
+  //crates/rue-span:rue-span-test >"$narrow_root/wrappers"
+TESTS=$((TESTS + 1))
+kept_wrappers="$(RUE_AFFECTED_BUCK2="$scope_root/bin/fake-buck" "${AFFECTED[@]}" build-scope "$narrow_root/wrappers" 2>/dev/null | tr '\n' ' ')"
+if [ "$kept_wrappers" = "//crates/rue-span:rue-span-test " ]; then
+  pass "narrow: build-scope drops a deferred corpus test target from an impacted list"
+else
+  fail "narrow: build-scope kept a deferred corpus test target (got '$kept_wrappers')"
 fi
 
 # FAIL CLOSED is the property the whole change rests on: an action whose test
 # target no required lane runs must stay in the build, because a corpus nothing
 # executes is the RUE-924 false green. `newthing-test-action` is owned by no
 # lane in the stub, so it must survive both spellings.
+# Both halves survive, for the same reason: the corpus must still execute
+# somewhere, and it is the action that executes it.
 printf '%s\n' \
   //crates/rue-oracle-diff:oracle-diff-test-action \
   //crates/rue-newthing:newthing-test-action \
+  //crates/rue-newthing:newthing-test \
   //crates/rue-span:rue-span-test >"$narrow_root/unowned"
 TESTS=$((TESTS + 1))
 kept_unowned="$(RUE_AFFECTED_BUCK2="$scope_root/bin/fake-buck" "${AFFECTED[@]}" build-scope "$narrow_root/unowned" 2>/dev/null | tr '\n' ' ')"
-if [ "$kept_unowned" = "//crates/rue-newthing:newthing-test-action //crates/rue-span:rue-span-test " ]; then
+if [ "$kept_unowned" = "//crates/rue-newthing:newthing-test-action //crates/rue-newthing:newthing-test //crates/rue-span:rue-span-test " ]; then
   pass "narrow: build-scope keeps a corpus action no required lane owns"
 else
   fail "narrow: build-scope deferred an action nothing runs (got '$kept_unowned')"
@@ -381,7 +445,7 @@ fi
 # coverage.
 TESTS=$((TESTS + 1))
 degraded="$(RUE_AFFECTED_BUCK2="$scope_root/bin/absent" "${AFFECTED[@]}" build-scope "$narrow_root/unowned" 2>/dev/null | tr '\n' ' ')"
-if [ "$degraded" = "//crates/rue-oracle-diff:oracle-diff-test-action //crates/rue-newthing:newthing-test-action //crates/rue-span:rue-span-test " ]; then
+if [ "$degraded" = "//crates/rue-oracle-diff:oracle-diff-test-action //crates/rue-newthing:newthing-test-action //crates/rue-newthing:newthing-test //crates/rue-span:rue-span-test " ]; then
   pass "narrow: an unanswerable Buck query falls open to the unfiltered scope"
 else
   fail "narrow: a failed query did not fall open (got '$degraded')"


### PR DESCRIPTION
Fixes RUE-1788. Completes what RUE-1511 (PR #2405) set out to do — that issue stays Done; this is the follow-up, not a reopening.

## The bug

RUE-1511 removed the two oracle-diff corpus actions from the premerge build scope, on this acceptance criterion:

> `premerge (linux-x64)` no longer builds either oracle-diff corpus action, on both the narrowed and unnarrowed paths.

It has been building them ever since. `cached_corpus_suite` emits each corpus as a **pair** (corpus.bzl): a `_corpus_action` genrule that runs the harness, and a thin `sh_test` carrying `args = ["$(location :NAME-action)"]`. So `NAME` depends on `NAME-action`, and subtracting only the action leaves the build reaching it through that edge:

```
$ ./buck2 uquery "deps(//crates/rue-oracle-diff:oracle-diff-test, 1)"
root//crates/rue-oracle-diff:oracle-diff-test-action     <-- pulled back in

$ scripts/affected-targets build-scope | grep oracle-diff   # before
//crates/rue-oracle-diff:oracle-diff-test                <-- still in scope
//crates/rue-oracle-diff:oracle-diff-spec-test           <-- still in scope
```

Building the action *runs the corpus*, which is the whole reason the subtraction exists.

## Why nothing caught it

Both the acceptance check and this script's tests asserted that no `-action` label appeared in the output. That stayed true throughout — the leak was a label the assertion did not name.

The stub made it unobservable regardless. Its `//crates/...` answer listed no corpus targets at all and ignored the `except set(...)` it was handed, so the unnarrowed case returned the same two targets no matter what the script subtracted.

## The fix

Emit both halves of each deferred pair. Both call sites keep their shape — the unnarrowed `except set(...)` and the narrowed `grep -Fxv` now subtract the same larger set — so the narrowed and unnarrowed spellings cannot diverge, which is the failure mode RUE-1511 called out.

The pair is the complete closure by construction: the macro is the only producer of a `_corpus_action` and gives each exactly one consumer. `cquery rdeps` confirms it on the current graph.

## Verification

End to end, against the dependency closure rather than the printed list — the latter is what the bug walked around:

```
$ ./buck2 cquery "kind('_corpus_action', deps(set(<203-target scope>)))"
(empty)

# add back the two test targets the old code left in:
$ ./buck2 cquery "kind('_corpus_action', deps(set(<scope> :oracle-diff-test :oracle-diff-spec-test)))"
root//crates/rue-oracle-diff:oracle-diff-spec-test-action
root//crates/rue-oracle-diff:oracle-diff-test-action
```

Gates: `//:affected-targets-tool-tests` 101 checks pass and **4 fail against the previous behavior**; `scripts/rue premerge` 200 passed, 0 failed; `validate-shell-bash-baseline.py` clean; `validate-ci-gate.py` valid.

Coverage is unchanged where it matters: `test (linux-x64-oracle-diff)` and `test (linux-x64-oracle-diff-spec)` both ran and passed on this PR, which also exercised the new determinator code, since the diff is that determinator.

### On the wall-time claim

Not established here, and worth saying plainly. `premerge (linux-x64)` took 103s on this PR against 299s on #2625's green run, but those two diffs invalidate very different amounts of cache — #2625 changed `std/fs.rue`, this one changes shell scripts — so the delta is directional, not a measurement. RUE-1511's ~240s came from a median over 169 cold-compiler runs, and confirming the recovery needs that same methodology rather than one comparison.

## Tests

The stub now models the real graph — each suite as a pair, and an `except set(...)` it actually honours — and the assertions are exact scopes rather than an absent suffix. A fix that removed only the `-action` label passes every other case in the file and fails the two new ones.

The fail-closed property is unchanged and still covered: an action **no** required lane owns keeps both halves, because the corpus must still execute somewhere.

## Docs

AGENTS.md called `scripts/rue premerge` the "canonical required-CI tier". It is a tier — it selects on `rue_test_tier_premerge`, and the oracle-diff corpora are `tier = "slow"` while their lanes gate the merge queue. That gap survives this fix, so the testing section now says what to run when a change touches corpus cases. This is the gap that cost RUE-1711 (#2625) a CI round.

## Known limit

The subtraction still names targets rather than deriving the closure from the graph: a hand-written dependency on a corpus action, outside the macro, would evade it. `rdeps` in `uquery` cannot express the closure here (it fails traversing unconfigured toolchain deps), and `cquery` is too costly for this path — so the construction argument above is what the rule rests on.