### PR TITLE
RUE-1788: exclude deferred corpus dependency closures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ scripts/rue build                    # build the compiler and print its path
 scripts/rue exec prog.rue            # compile and run a quick program
 RUE="$(scripts/rue-bin)"; "$RUE" main.rue -o out
 scripts/rue quick                    # fast unit suite
-scripts/rue premerge                 # canonical required-CI tier
+scripts/rue premerge                 # local premerge test tier (not all required CI)
 scripts/rue slow                     # canonical scheduled slow tier
 scripts/rue stress                   # canonical opt-in stress tier
 scripts/rue all                      # canonical union of all tiers
@@ -89,6 +89,9 @@ scripts/rue storage clean            # reclaim stale Buck2 artifacts host-wide
 scripts/rue cache install            # securely install the shared cache config
 scripts/rue cache apply --all        # provision current Git/Codex worktrees
 ```
+
+When corpus-affecting cases change, use this focused check:
+`./buck2 test //crates/rue-oracle-diff:oracle-diff-test`.
 
 Use `scripts/rue-bin` to obtain an absolute compiler path. Do not reconstruct
 one from Buck output with `--show-output` and `awk`.

--- a/scripts/affected-targets
+++ b/scripts/affected-targets
@@ -278,14 +278,16 @@ buck2_bin() {
     printf '%s\n' "${RUE_AFFECTED_BUCK2:-$repo_root/buck2}"
 }
 
-# `buck2` prints the cell (`root//:foo`); parse-btd-impacted.py has already
-# stripped it from the impacted list. One spelling, so set membership below is
-# exact rather than a match across two forms.
+# `buck2` prints the cell (`root//:foo`); configured queries may also append a
+# configuration (`root//:foo (cfg)`). parse-btd-impacted.py has already stripped
+# the cell from impacted lists. Normalize all three spellings so set membership
+# below is exact rather than a match across graph-query output formats.
 normalize_cell() {
-    sed 's|^root//|//|'
+    sed -E 's|^root//|//|; s| \([^()]*\)$||'
 }
 
-# The crate-scoped corpus actions a build-verification step must not name.
+# The crate-scoped targets a build-verification step must not name when their
+# dependency closure reaches a corpus action owned by a required lane.
 #
 # `cached_corpus_suite` splits a corpus in two (see corpus.bzl): a
 # `_corpus_action` genrule that RUNS the harness, and a thin `sh_test` that
@@ -303,9 +305,11 @@ normalize_cell() {
 # `test (linux-x64-oracle-diff*)` lanes that exist to own them, on a second
 # runner, at the same execution configuration (RUE-1511).
 #
-# The property is the rule kind, so the rule kind is what this asks the live
-# graph. Any corpus added anywhere is covered, including one added after this
-# was written.
+# The invariant is two graph operations: `_corpus_action` nodes in
+# `deps(required selection)` establish the owned actions, then
+# `rdeps(//crates/..., owned actions)` establishes the exact crate exclusion
+# set. Any corpus added anywhere is covered, including one added after this was
+# written; no `NAME-action` convention is involved.
 #
 # WHAT THIS GIVES UP, stated plainly. The lanes deferred to are themselves
 # gated by this determinator, while the unnarrowed premerge build was not: it
@@ -316,9 +320,9 @@ normalize_cell() {
 # deliberate reduction, not an oversight: `buck2 build //crates/...` never
 # reached the root-level `//:cli-tests-*`/`//:spec-tests` actions either, so
 # those corpora have had no premerge backstop since RUE-1119, and this makes
-# oracle-diff consistent with them rather than uniquely privileged. The narrowed
-# spelling keeps a stronger guarantee, because `buck.deps` puts the action in
-# its own `sh_test`'s closure: an impacted action drags its test in with it.
+# oracle-diff consistent with them rather than uniquely privileged. The same
+# reverse-dependency exclusion set applies to both scope spellings: it removes
+# every impacted wrapper, carrier, and action that reaches an owned action.
 #
 # `SELECTABLE_CORPUS` now has a second consumer with the opposite failure
 # direction from its first. For selection, an unknown entry fails safe toward
@@ -329,44 +333,23 @@ normalize_cell() {
 #
 # FAIL-CLOSED ON COVERAGE, like every other decision in this file. Today the
 # premerge build step is accidentally the thing that *executes* these corpora,
-# so dropping them is only safe where some required lane demonstrably runs the
-# corpus instead. An action is deferred only when its test target is one
-# `test.sh` runs in this same lane (premerge tier, and not held back by the
-# dedicated-lane or CLI-shard filters that invocation applies), or one the
-# platform-corpus inventory above gives a lane of its own. Anything else stays
-# in the build, loudly: over-building costs wall time, and a corpus nothing runs
-# is the RUE-924 false green. `cached_corpus_suite` names the action
-# `NAME-action` for the test `NAME`, so that mapping is the rule's own
-# construction rather than an inference about the graph.
+# so dropping them is only safe where the required selection demonstrably owns
+# the action. The configured dependency query derives that ownership from
+# `deps(required selection)`; anything outside it stays safely in the build.
+# Over-building costs wall time, and a corpus nothing runs is the RUE-924 false
+# green.
 #
 # Fails non-zero when Buck cannot answer, and the caller then builds the corpus
 # actions exactly as it did before.
-deferred_corpus_actions() {
-    local buck2 actions covered action test_target query
+deferred_corpus_targets() {
+    local buck2 covered query covered_expr joined
     buck2="$(buck2_bin)"
 
-    # Buck's own error reaches stderr rather than being discarded. The whole
-    # design is "fail open loudly", and swallowing the one line that explains
-    # why leaves a CI log saying only that something did not work — a nested
-    # `buck2` invocation, a cold daemon, and a syntax error read identically.
-    if ! actions="$("$buck2" uquery "kind('_corpus_action', //crates/...)")"; then
-        echo "affected-targets: could not query crate-scoped corpus actions" >&2
-        return 1
-    fi
-    # The query lives in its own variable rather than inline, because the
-    # inline spelling ran several lines and lost its closing `"`: the `)`
-    # ending the command substitution was followed by `; then` instead of `)"`,
-    # so the quote opened before `$(` never closed and bash read to end of file
-    # looking for it — "unexpected EOF while looking for matching `\"'",
-    # reported several lines later at an innocent line.
-    #
-    # Correcting the note left here when that was repaired: this is not a Bash
-    # 3.2 limit. A `$(...)` whose body spans a line continuation and contains a
-    # quoted argument with parentheses parses on 3.2.57 and on 5.2.15 alike;
-    # the missing quote was the whole defect, and every bash rejects it. Hence
-    # RUE-1512 — `scripts/validate-shell-bash-baseline.py` now runs `bash -n`
-    # over every script, because its construct table could not see this: a
-    # syntax error is not a construct to name.
+    # Build the required-lane ownership expression from the same live graph
+    # inventories used by selection. A covered test's transitive deps include
+    # its cached `_corpus_action`; cquery then computes every //crates target
+    # reverse-dependent on those actions. This catches wrappers and transitive
+    # carriers even when their names do not end in `-action` or match the test.
     query="attrfilter(labels, rue_test_tier_premerge, //crates/...)"
     query="$query except (attrfilter(labels, rue_ci_dedicated_lane, //crates/...)"
     query="$query + attrfilter(labels, rue_cli_shard, //crates/...))"
@@ -375,28 +358,32 @@ deferred_corpus_actions() {
         return 1
     fi
 
-    actions="$(normalize_cell <<<"$actions" | grep . || true)"
     covered="$(printf '%s\n%s\n' "$(normalize_cell <<<"$covered")" \
         "$(printf '%s\n' "${SELECTABLE_CORPUS[@]}")" | grep . || true)"
-    [[ -n "$actions" ]] || return 0
+    [[ -n "$covered" ]] || return 0
 
-    while IFS= read -r action; do
-        [[ -n "$action" ]] || continue
-        test_target="${action%-action}"
-        if grep -Fxq "$test_target" <<<"$covered"; then
-            printf '%s\n' "$action"
-        else
-            echo "affected-targets: ${action} runs a corpus no required lane owns;" \
-                 "keeping it in the build scope" >&2
-        fi
-    done <<<"$actions"
+    # cquery takes a set expression, not newline-delimited shell input. Keep
+    # the construction separate from command substitution for Bash 3.2, which
+    # is the system shell on macOS.
+    joined="${covered//$'\n'/ }"
+    covered_expr="set($joined)"
+    query="rdeps(//crates/..., kind('_corpus_action', deps($covered_expr)))"
+    if ! covered="$("$buck2" cquery "$query")"; then
+        # Buck's own error reaches stderr rather than being discarded. The
+        # caller turns this non-zero result into the prior unfiltered scope;
+        # over-building costs wall time, never coverage.
+        echo "affected-targets: could not query deferred corpus dependency closure" >&2
+        return 1
+    fi
+    covered="$(normalize_cell <<<"$covered" | grep . || true)"
+    [[ -n "$covered" ]] && printf '%s\n' "$covered"
     return 0
 }
 
 # The targets a *pattern* lane may build, for lanes whose scope is
 # `//crates/...` rather than a fixed list. With an impacted list it is the
 # narrowed subset; without one it is the whole pattern. Both are the same scope
-# minus the same corpus actions, because both lose independently: fixing only
+# minus the same deferred targets, because both lose independently: fixing only
 # the narrowed spelling leaves the common case — a compiler change, which
 # impacts more than NARROW_LIMIT targets and so is never narrowed — building
 # the corpora exactly as before.
@@ -411,7 +398,7 @@ deferred_corpus_actions() {
 build_scope() {
     local file="${1:-}"
     local deferred kept buck2 expr scope
-    deferred="$(deferred_corpus_actions)" || deferred=""
+    deferred="$(deferred_corpus_targets)" || deferred=""
 
     if [[ -z "$file" ]]; then
         # The unnarrowed scope. `buck2 build` accepts patterns and target

--- a/scripts/test-affected-targets.sh
+++ b/scripts/test-affected-targets.sh
@@ -284,28 +284,99 @@ scope_root="$(mktemp -d)"
 mkdir -p "$scope_root/bin"
 cat >"$scope_root/bin/fake-buck" <<'FAKEBUCK'
 #!/usr/bin/env bash
-# Answers the three queries build_scope() makes, and nothing else.
-case "$2" in
-  "kind('_corpus_action', //crates/...)")
-    printf '%s\n' \
-      root//crates/rue-oracle-diff:oracle-diff-test-action \
-      root//crates/rue-oracle-diff:oracle-diff-spec-test-action \
-      root//crates/rue-newthing:newthing-test-action ;;
-  attrfilter*)
-    # The premerge-tier selection. Deliberately omits `newthing-test`, so that
-    # action is owned by no lane.
-    printf '%s\n' \
-      root//crates/rue-oracle-diff:oracle-diff-test \
-      root//crates/rue-oracle-diff:oracle-diff-spec-test ;;
-  //crates/...*)
-    printf '%s\n' \
-      root//crates/rue-compiler:rue-compiler \
-      root//crates/rue-span:rue-span-test ;;
-  *) echo "fake-buck: unexpected query: $2" >&2; exit 1 ;;
+# Answers the ownership and closure queries build_scope() makes, and nothing
+# else. The cquery result is a reverse-dependency closure, not a name-derived
+# action/test pair: `corpus-carrier` intentionally has no matching suffix.
+contains_target() {
+  local query="$1" target="$2" tokenized
+  tokenized="${query//set(/ }"
+  tokenized="${tokenized//)/ }"
+  case " $tokenized " in
+    *" $target "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+case "$1" in
+  uquery)
+    case "$2" in
+      attrfilter*)
+        # The premerge-tier selection. Deliberately omits `newthing-test`, so
+        # that action is owned by no lane.
+        printf '%s\n' \
+          root//crates/rue-oracle-diff:oracle-diff-test \
+          root//crates/rue-oracle-diff:oracle-diff-spec-test ;;
+      //crates/...*)
+        if [[ "$2" == *' except set('* ]] \
+            && contains_target "$2" '//crates/rue-oracle-diff:oracle-diff-test-action' \
+            && contains_target "$2" '//crates/rue-oracle-diff:oracle-diff-test' \
+            && contains_target "$2" '//crates/rue-oracle-diff:corpus-carrier' \
+            && contains_target "$2" '//crates/rue-oracle-diff:oracle-diff-spec-test-action' \
+            && contains_target "$2" '//crates/rue-oracle-diff:oracle-diff-spec-test'; then
+          # The production query must subtract every reverse-dependent target
+          # returned by cquery. If it drops the except/set expression, this
+          # branch deliberately returns the pre-fix full crate scope instead.
+          printf '%s\n' \
+            root//crates/rue-compiler:rue-compiler \
+            root//crates/rue-newthing:newthing-test-action \
+            root//crates/rue-span:rue-span-test
+        else
+          printf '%s\n' \
+            root//crates/rue-compiler:rue-compiler \
+            root//crates/rue-oracle-diff:oracle-diff-test-action \
+            root//crates/rue-oracle-diff:oracle-diff-test \
+            root//crates/rue-oracle-diff:corpus-carrier \
+            root//crates/rue-newthing:newthing-test-action \
+            root//crates/rue-span:rue-span-test
+        fi
+        ;;
+      *) echo "fake-buck: unexpected uquery: $2" >&2; exit 1 ;;
+    esac
+    ;;
+  cquery)
+    case "$2" in
+      deps\(set\(*\))
+        # Model the graph when the test asks whether a produced scope still
+        # reaches a deferred action. A scope containing the carrier or wrapper
+        # would expose the action here; a clean scope returns no deferred
+        # action at all.
+        if [[ "$2" == *'rue-oracle-diff:oracle-diff-test'* \
+            || "$2" == *'rue-oracle-diff:corpus-carrier'* ]]; then
+          printf '%s\n' root//crates/rue-oracle-diff:oracle-diff-test-action
+        fi
+        if [[ "$2" == *'rue-oracle-diff:oracle-diff-spec-test'* ]]; then
+          printf '%s\n' root//crates/rue-oracle-diff:oracle-diff-spec-test-action
+        fi
+        ;;
+      rdeps\(//crates/...,\ kind\(\'_corpus_action\',\ deps\(set\(*\)\)\)\))
+        # Include configured labels to pin normalization and a transitive
+        # carrier whose spelling is unrelated to its action.
+        printf '%s\n' \
+          'root//crates/rue-oracle-diff:oracle-diff-test-action (linux)' \
+          'root//crates/rue-oracle-diff:oracle-diff-test (linux)' \
+          'root//crates/rue-oracle-diff:corpus-carrier (linux)' \
+          'root//crates/rue-oracle-diff:oracle-diff-spec-test-action (linux)' \
+          'root//crates/rue-oracle-diff:oracle-diff-spec-test (linux)' ;;
+      *) echo "fake-buck: unexpected cquery: $2" >&2; exit 1 ;;
+    esac
+    ;;
+  *) echo "fake-buck: unexpected command: $1" >&2; exit 1 ;;
 esac
 FAKEBUCK
 chmod +x "$scope_root/bin/fake-buck"
 SCOPED=("${AFFECTED[@]}")
+
+assert_scope_closure_clear() { # assert_scope_closure_clear <description> <scope>
+  local desc="$1" scope="$2" labels closure
+  labels="${scope//$'\n'/ }"
+  closure="$("$scope_root/bin/fake-buck" cquery "deps(set($labels))")"
+  TESTS=$((TESTS + 1))
+  if grep -Fq -- '//crates/rue-oracle-diff:oracle-diff-test-action' <<<"$closure" \
+      || grep -Fq -- '//crates/rue-oracle-diff:oracle-diff-spec-test-action' <<<"$closure"; then
+    fail "narrow: $desc still reaches a deferred corpus action"
+  else
+    pass "narrow: $desc dependency closure has no deferred corpus action"
+  fi
+}
 
 # `build-scope` is what keeps a pattern lane's narrowing a SUBSET of what the
 # lane built before: exactly `//crates/...`, the scope linux-premerge built
@@ -323,8 +394,9 @@ SCOPED=("${AFFECTED[@]}")
 # whose median is 304s — concurrently with the dedicated
 # `test (linux-x64-oracle-diff*)` lanes that exist to own them. The exclusion no
 # longer needs labels on the action, which is what "tracked separately" was
-# waiting for: it asks the live graph for `kind('_corpus_action', ...)` and
-# defers only actions whose test target a required lane demonstrably runs.
+# waiting for: it derives owned `_corpus_action` nodes from
+# `deps(required selection)` and excludes the same `rdeps(//crates/..., owned)`
+# closure from either build-scope spelling.
 printf '%s\n' \
   //crates/rue-compiler:rue-compiler \
   //:cli-tests \
@@ -333,37 +405,45 @@ printf '%s\n' \
   //:spec-tests-action \
   //:cli-tests-shard-2-action \
   //crates/rue-oracle-diff:oracle-diff-test-action \
+  //crates/rue-oracle-diff:corpus-carrier \
   >"$narrow_root/mixed"
 TESTS=$((TESTS + 1))
-if [ "$(RUE_AFFECTED_BUCK2="$scope_root/bin/fake-buck" "${AFFECTED[@]}" build-scope "$narrow_root/mixed" | tr '\n' ' ')" \
+narrowed_scope="$(RUE_AFFECTED_BUCK2="$scope_root/bin/fake-buck" "${AFFECTED[@]}" build-scope "$narrow_root/mixed")"
+if [ "$(tr '\n' ' ' <<<"$narrowed_scope")" \
      = "//crates/rue-compiler:rue-compiler //crates/rue-codegen:rue-codegen-test " ]; then
   pass "narrow: build-scope keeps the crate scope and drops every corpus action"
 else
   fail "narrow: build-scope did not restore the //crates/... scope"
 fi
+assert_scope_closure_clear "narrowed build-scope" "$narrowed_scope"
 
-# RUE-1511: `build-scope` asks the live graph which targets are corpus actions,
-# so these cases stub Buck exactly as the end-to-end decision case below does.
+# RUE-1788: `build-scope` applies one configured live-graph reverse-dependency
+# closure to both narrowed and unnarrowed scopes, so these cases stub Buck
+# exactly as the end-to-end decision case below does.
 # A real `./buck2` here would be a RECURSIVE Buck invocation — this suite runs
 # as an sh_test under buck2, which refuses the nested query with rc=3 — and the
 # suite's contract is that it needs neither network nor Buck.
 
 # The unnarrowed spelling loses independently of the narrowed one, and it is the
 # common case — a compiler change impacts more than NARROW_LIMIT targets, so it
-# is never narrowed. Both must drop the same actions, or fixing one leaves
-# premerge building the corpora exactly as before.
+# is never narrowed. Both must apply the same reverse-dependency exclusion, or
+# fixing one leaves premerge building the corpora exactly as before.
 TESTS=$((TESTS + 1))
 unnarrowed="$(RUE_AFFECTED_BUCK2="$scope_root/bin/fake-buck" "${AFFECTED[@]}" build-scope 2>/dev/null)"
-if [ -n "$unnarrowed" ] && ! grep -q -- '-action$' <<<"$unnarrowed"; then
-  pass "narrow: build-scope with no list expands the pattern without any corpus action"
+if [ -n "$unnarrowed" ] \
+    && grep -Fxq -- '//crates/rue-newthing:newthing-test-action' <<<"$unnarrowed" \
+    && ! grep -Fq -- '//crates/rue-oracle-diff:oracle-diff-test-action' <<<"$unnarrowed" \
+    && ! grep -Fq -- '//crates/rue-oracle-diff:corpus-carrier' <<<"$unnarrowed"; then
+  pass "narrow: build-scope with no list excludes the deferred dependency closure"
 else
-  fail "narrow: build-scope with no list kept a corpus action or produced nothing"
+  fail "narrow: build-scope with no list kept a deferred closure or dropped an unowned action"
 fi
+assert_scope_closure_clear "unnarrowed build-scope" "$unnarrowed"
 
-# FAIL CLOSED is the property the whole change rests on: an action whose test
-# target no required lane runs must stay in the build, because a corpus nothing
-# executes is the RUE-924 false green. `newthing-test-action` is owned by no
-# lane in the stub, so it must survive both spellings.
+# FAIL CLOSED is the property the whole change rests on: an action no required
+# lane runs must stay in the build, because a corpus nothing executes is the
+# RUE-924 false green. `newthing-test-action` is owned by no lane in the stub,
+# so it must survive both spellings.
 printf '%s\n' \
   //crates/rue-oracle-diff:oracle-diff-test-action \
   //crates/rue-newthing:newthing-test-action \
@@ -385,6 +465,52 @@ if [ "$degraded" = "//crates/rue-oracle-diff:oracle-diff-test-action //crates/ru
   pass "narrow: an unanswerable Buck query falls open to the unfiltered scope"
 else
   fail "narrow: a failed query did not fall open (got '$degraded')"
+fi
+
+# A successful ownership query followed by a failed configured closure query
+# must have the same conservative result. Exercise both scope spellings: the
+# narrowed list remains intact, and the unnarrowed pattern remains expanded.
+cat >"$scope_root/bin/closure-fail-buck" <<'FAILING_CLOSURE'
+#!/usr/bin/env bash
+case "$1" in
+  uquery)
+    case "$2" in
+      attrfilter*)
+        printf '%s\n' \
+          root//crates/rue-oracle-diff:oracle-diff-test \
+          root//crates/rue-oracle-diff:oracle-diff-spec-test ;;
+      //crates/...*)
+        printf '%s\n' \
+          root//crates/rue-compiler:rue-compiler \
+          root//crates/rue-oracle-diff:oracle-diff-test-action \
+          root//crates/rue-newthing:newthing-test-action \
+          root//crates/rue-span:rue-span-test ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  cquery)
+    echo "closure-fail-buck: configured closure unavailable" >&2
+    exit 1
+    ;;
+  *) exit 1 ;;
+esac
+FAILING_CLOSURE
+chmod +x "$scope_root/bin/closure-fail-buck"
+TESTS=$((TESTS + 1))
+closure_failed_narrow="$(RUE_AFFECTED_BUCK2="$scope_root/bin/closure-fail-buck" \
+  "${AFFECTED[@]}" build-scope "$narrow_root/unowned" 2>/dev/null | tr '\n' ' ')"
+if [ "$closure_failed_narrow" = "//crates/rue-oracle-diff:oracle-diff-test-action //crates/rue-newthing:newthing-test-action //crates/rue-span:rue-span-test " ]; then
+  pass "narrow: a failed configured closure keeps the narrowed scope"
+else
+  fail "narrow: a failed configured closure changed the narrowed scope (got '$closure_failed_narrow')"
+fi
+TESTS=$((TESTS + 1))
+closure_failed_unnarrowed="$(RUE_AFFECTED_BUCK2="$scope_root/bin/closure-fail-buck" \
+  "${AFFECTED[@]}" build-scope 2>/dev/null | tr '\n' ' ')"
+if [ "$closure_failed_unnarrowed" = "//crates/rue-compiler:rue-compiler //crates/rue-oracle-diff:oracle-diff-test-action //crates/rue-newthing:newthing-test-action //crates/rue-span:rue-span-test " ]; then
+  pass "narrow: a failed configured closure keeps the unnarrowed scope"
+else
+  fail "narrow: a failed configured closure changed the unnarrowed scope (got '$closure_failed_unnarrowed')"
 fi
 
 # An impacted closure naming only corpora is legitimate — corpus data can change


### PR DESCRIPTION
## Summary

- derive required-lane-owned corpus actions from the configured Buck dependency graph
- exclude the full crate reverse-dependency closure from both narrowed and unnarrowed linux-premerge build scopes
- fail open to the prior build scope when either graph query is unavailable
- correct the local premerge documentation and name the focused oracle-diff command

## Evidence

At base 6784806a7cef, the unnarrowed/narrowed scopes contained 205/204 direct targets and each still reached 2 deferred corpus actions. With this change they contain 203/202 direct targets and each reaches 0 deferred corpus actions. The excluded reverse closure is exactly the two oracle-diff wrappers plus their two corpus actions.

The PR premerge job Build all targets step ran the unnarrowed path and completed in 23.374s (02:42:51.642–02:43:15.016 UTC): 1,007 commands, 977 cached, 30 local, 97% cache hits. This is the available cold-ish runner evidence, though the cache rate makes it explicitly not a controlled cold benchmark. The issue baseline was 304s at the median with the two corpus actions accounting for about 240s.

## Validation

- scripts/test-affected-targets.sh (103 checks)
- CI policy, tier-selector, and shell-baseline Buck tests
- /bin/bash 3.2 baseline validation
- scripts/rue fmt
- scripts/rue quick
- scripts/rue premerge: all Buck tests passed except the unrelated cli.watch::change_after_monitor_stops_is_still_announced event timeout; the focused case passes in isolation
- required PR CI: all checks passed, including both dedicated oracle-diff lanes and linux premerge

Fixes RUE-1788