### PR TITLE
RUE-1788: exclude corpus dependency closures from premerge builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ scripts/rue build                    # build the compiler and print its path
 scripts/rue exec prog.rue            # compile and run a quick program
 RUE="$(scripts/rue-bin)"; "$RUE" main.rue -o out
 scripts/rue quick                    # fast unit suite
-scripts/rue premerge                 # canonical required-CI tier
+scripts/rue premerge                 # canonical premerge tier (not all required CI)
 scripts/rue slow                     # canonical scheduled slow tier
 scripts/rue stress                   # canonical opt-in stress tier
 scripts/rue all                      # canonical union of all tiers

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,7 +19,7 @@ scripts/rue build                    # build the compiler
 scripts/rue exec program.rue         # compile and run a program
 scripts/rue quick                    # Rust unit tests
 scripts/rue test [pattern]           # full suite, optionally filtered
-scripts/rue premerge                 # required-CI tier: clippy gate + tests
+scripts/rue premerge                 # canonical premerge tier: clippy gate + tests (not all required CI)
 scripts/rue slow                     # scheduled exhaustive tests
 scripts/rue stress                   # opt-in resource stress tests
 scripts/rue all                      # union of every test tier

--- a/scripts/affected-targets
+++ b/scripts/affected-targets
@@ -45,7 +45,7 @@
 #   build-scope        Print the targets a `//crates/...` lane may build, with
 #                      or without an impacted list. Narrowing must stay inside
 #                      the lane's own scope, and neither spelling of that scope
-#                      may name a corpus action (RUE-1511).
+#                      may reach a deferred corpus action (RUE-1788).
 #
 # Deliberately NOT `set -e`: a full run is the safe fallback, so failures are
 # handled explicitly and converted into "full", never into a hard error that
@@ -285,7 +285,14 @@ normalize_cell() {
     sed 's|^root//|//|'
 }
 
-# The crate-scoped corpus actions a build-verification step must not name.
+# `cquery` prints configured labels with a configuration suffix. Keep the
+# unconfigured label before doing exact set subtraction against BTD's list.
+normalize_configured_cell() {
+    sed -E 's/[[:space:]].*$//' | normalize_cell
+}
+
+# The crate-scoped corpus action closures a build-verification step must not
+# reach.
 #
 # `cached_corpus_suite` splits a corpus in two (see corpus.bzl): a
 # `_corpus_action` genrule that RUNS the harness, and a thin `sh_test` that
@@ -316,9 +323,9 @@ normalize_cell() {
 # deliberate reduction, not an oversight: `buck2 build //crates/...` never
 # reached the root-level `//:cli-tests-*`/`//:spec-tests` actions either, so
 # those corpora have had no premerge backstop since RUE-1119, and this makes
-# oracle-diff consistent with them rather than uniquely privileged. The narrowed
-# spelling keeps a stronger guarantee, because `buck.deps` puts the action in
-# its own `sh_test`'s closure: an impacted action drags its test in with it.
+# oracle-diff consistent with them rather than uniquely privileged. Both scope
+# spellings now subtract the complete reverse dependency closure, so an
+# aggregate target cannot reintroduce an eligible action through its wrapper.
 #
 # `SELECTABLE_CORPUS` now has a second consumer with the opposite failure
 # direction from its first. For selection, an unknown entry fails safe toward
@@ -336,13 +343,15 @@ normalize_cell() {
 # platform-corpus inventory above gives a lane of its own. Anything else stays
 # in the build, loudly: over-building costs wall time, and a corpus nothing runs
 # is the RUE-924 false green. `cached_corpus_suite` names the action
-# `NAME-action` for the test `NAME`, so that mapping is the rule's own
-# construction rather than an inference about the graph.
+# `NAME-action` for the test `NAME`, so that mapping identifies which test is
+# covered by a required lane. The reverse-dependency query below then computes
+# the complete crate-scope closure that can reach every eligible action,
+# including aggregate build roots above the thin wrapper.
 #
 # Fails non-zero when Buck cannot answer, and the caller then builds the corpus
 # actions exactly as it did before.
-deferred_corpus_actions() {
-    local buck2 actions covered action test_target query
+deferred_corpus_scope_targets() {
+    local buck2 actions covered action test_target query owned joined scope
     buck2="$(buck2_bin)"
 
     # Buck's own error reaches stderr rather than being discarded. The whole
@@ -380,25 +389,35 @@ deferred_corpus_actions() {
         "$(printf '%s\n' "${SELECTABLE_CORPUS[@]}")" | grep . || true)"
     [[ -n "$actions" ]] || return 0
 
+    owned=""
     while IFS= read -r action; do
         [[ -n "$action" ]] || continue
-        test_target="${action%-action}"
+        test_target="$(printf '%s' "$action" | sed 's/-action$//')"
         if grep -Fxq "$test_target" <<<"$covered"; then
-            printf '%s\n' "$action"
+            owned="$owned $action"
         else
             echo "affected-targets: ${action} runs a corpus no required lane owns;" \
                  "keeping it in the build scope" >&2
         fi
     done <<<"$actions"
+    [[ -n "$owned" ]] || return 0
+    joined="$(printf '%s' "$owned" | sed 's/^ //')"
+    query="rdeps(//crates/..., set($joined))"
+    if ! scope="$("$buck2" cquery "$query")"; then
+        echo "affected-targets: could not query crate-scope corpus dependency closures" >&2
+        return 1
+    fi
+    scope="$(normalize_configured_cell <<<"$scope" | grep . || true)"
+    [[ -n "$scope" ]] && printf '%s\n' "$scope"
     return 0
 }
 
 # The targets a *pattern* lane may build, for lanes whose scope is
 # `//crates/...` rather than a fixed list. With an impacted list it is the
 # narrowed subset; without one it is the whole pattern. Both are the same scope
-# minus the same corpus actions, because both lose independently: fixing only
-# the narrowed spelling leaves the common case — a compiler change, which
-# impacts more than NARROW_LIMIT targets and so is never narrowed — building
+# minus the same corpus dependency closures, because both lose independently:
+# fixing only the narrowed spelling leaves the common case — a compiler change,
+# which impacts more than NARROW_LIMIT targets and so is never narrowed — building
 # the corpora exactly as before.
 #
 # RUE-1130 handed the raw impacted closure to `buck2 build` in linux-premerge.
@@ -411,16 +430,15 @@ deferred_corpus_actions() {
 build_scope() {
     local file="${1:-}"
     local deferred kept buck2 expr scope
-    deferred="$(deferred_corpus_actions)" || deferred=""
+    deferred="$(deferred_corpus_scope_targets)" || deferred=""
 
     if [[ -z "$file" ]]; then
         # The unnarrowed scope. `buck2 build` accepts patterns and target
         # lists but has no kind or label exclusion, so the subtraction has to
         # happen before the pattern reaches it — which means expanding it.
-        # There are 167 targets under `//crates/...` and nothing in that tree
-        # is `compatible_with`-restricted, so the explicit list configures
-        # exactly as the pattern does — verified by `uquery` and `cquery`
-        # returning the same 167.
+        # Nothing under `//crates/...` is `compatible_with`-restricted, so the
+        # explicit list configures exactly as the pattern does — verified by
+        # `uquery` and `cquery` returning the same live target count.
         #
         # The two spellings differ on FAILURE, not on today's result: `buck2
         # build //crates/...` SKIPS an incompatible target, while naming one

--- a/scripts/rue
+++ b/scripts/rue
@@ -8,8 +8,8 @@
 #   scripts/rue exec prog.rue      Compile prog.rue to a temp file AND run it
 #   scripts/rue test [pattern]     Full suite (./test.sh), optional filter
 #   scripts/rue quick              Unit tests only (./quick-test.sh)
-#   scripts/rue premerge           Canonical required tier (incl. the per-crate
-#                                  fmt and clippy gates, RUE-1153)
+#   scripts/rue premerge           Canonical premerge tier (incl. the per-crate
+#                                  fmt and clippy gates; not all required CI)
 #   scripts/rue slow               Canonical scheduled slow tier
 #   scripts/rue stress             Canonical opt-in stress tier
 #   scripts/rue all                Canonical union of every tier

--- a/scripts/test-affected-targets.sh
+++ b/scripts/test-affected-targets.sh
@@ -284,7 +284,10 @@ scope_root="$(mktemp -d)"
 mkdir -p "$scope_root/bin"
 cat >"$scope_root/bin/fake-buck" <<'FAKEBUCK'
 #!/usr/bin/env bash
-# Answers the three queries build_scope() makes, and nothing else.
+# Answers the graph queries build_scope() makes, and nothing else.
+if [ -n "${RUE_AFFECTED_QUERY_LOG:-}" ]; then
+  printf '%s\n' "$2" >>"$RUE_AFFECTED_QUERY_LOG"
+fi
 case "$2" in
   "kind('_corpus_action', //crates/...)")
     printf '%s\n' \
@@ -297,6 +300,18 @@ case "$2" in
     printf '%s\n' \
       root//crates/rue-oracle-diff:oracle-diff-test \
       root//crates/rue-oracle-diff:oracle-diff-spec-test ;;
+  rdeps\(*)
+    # The configured reverse-dependency result models a multi-hop
+    # aggregate -> wrapper -> action path and direct aggregate roots in
+    # addition to the wrappers themselves.
+    printf '%s\n' \
+      root//crates/rue-oracle-diff:oracle-diff-test-action\ \(cfg\) \
+      root//crates/rue-oracle-diff:oracle-diff-test\ \(cfg\) \
+      root//crates/rue-oracle-diff:oracle-diff-test-aggregate\ \(cfg\) \
+      root//crates/rue-oracle-diff:oracle-diff-test-direct-aggregate\ \(cfg\) \
+      root//crates/rue-oracle-diff:oracle-diff-spec-test-action\ \(cfg\) \
+      root//crates/rue-oracle-diff:oracle-diff-spec-test\ \(cfg\) \
+      root//crates/rue-oracle-diff:oracle-diff-spec-test-aggregate\ \(cfg\) ;;
   //crates/...*)
     printf '%s\n' \
       root//crates/rue-compiler:rue-compiler \
@@ -305,6 +320,14 @@ case "$2" in
 esac
 FAKEBUCK
 chmod +x "$scope_root/bin/fake-buck"
+cat >"$scope_root/bin/fail-cquery" <<FAILEDCQUERY
+#!/usr/bin/env bash
+if [ "\$1" = cquery ]; then
+  exit 1
+fi
+exec "$scope_root/bin/fake-buck" "\$@"
+FAILEDCQUERY
+chmod +x "$scope_root/bin/fail-cquery"
 SCOPED=("${AFFECTED[@]}")
 
 # `build-scope` is what keeps a pattern lane's narrowing a SUBSET of what the
@@ -332,32 +355,46 @@ printf '%s\n' \
   //crates/rue-codegen:rue-codegen-test \
   //:spec-tests-action \
   //:cli-tests-shard-2-action \
+  //crates/rue-oracle-diff:oracle-diff-test \
+  //crates/rue-oracle-diff:oracle-diff-spec-test \
+  //crates/rue-oracle-diff:oracle-diff-test-aggregate \
+  //crates/rue-oracle-diff:oracle-diff-test-direct-aggregate \
+  //crates/rue-oracle-diff:oracle-diff-spec-test-aggregate \
   //crates/rue-oracle-diff:oracle-diff-test-action \
   >"$narrow_root/mixed"
 TESTS=$((TESTS + 1))
-if [ "$(RUE_AFFECTED_BUCK2="$scope_root/bin/fake-buck" "${AFFECTED[@]}" build-scope "$narrow_root/mixed" | tr '\n' ' ')" \
+scope_query_log="$scope_root/query.log"
+if [ "$(RUE_AFFECTED_BUCK2="$scope_root/bin/fake-buck" RUE_AFFECTED_QUERY_LOG="$scope_query_log" "${AFFECTED[@]}" build-scope "$narrow_root/mixed" | tr '\n' ' ')" \
      = "//crates/rue-compiler:rue-compiler //crates/rue-codegen:rue-codegen-test " ]; then
-  pass "narrow: build-scope keeps the crate scope and drops every corpus action"
+  pass "narrow: build-scope removes actions, wrappers, and aggregate roots"
 else
   fail "narrow: build-scope did not restore the //crates/... scope"
 fi
+TESTS=$((TESTS + 1))
+if grep -Fq "rdeps(//crates/..., set(//crates/rue-oracle-diff:oracle-diff-test-action" "$scope_query_log" \
+    && grep -Fq "//crates/rue-oracle-diff:oracle-diff-spec-test-action)" "$scope_query_log"; then
+  pass "narrow: build-scope computes the complete corpus reverse-dependency closure"
+else
+  fail "narrow: build-scope did not compute corpus reverse-dependency closure"
+fi
 
-# RUE-1511: `build-scope` asks the live graph which targets are corpus actions,
-# so these cases stub Buck exactly as the end-to-end decision case below does.
+# RUE-1788: `build-scope` asks the live graph for the complete reverse
+# dependency closure of eligible corpus actions, so these cases stub Buck
+# exactly as the end-to-end decision case below does.
 # A real `./buck2` here would be a RECURSIVE Buck invocation — this suite runs
 # as an sh_test under buck2, which refuses the nested query with rc=3 — and the
 # suite's contract is that it needs neither network nor Buck.
 
 # The unnarrowed spelling loses independently of the narrowed one, and it is the
 # common case — a compiler change impacts more than NARROW_LIMIT targets, so it
-# is never narrowed. Both must drop the same actions, or fixing one leaves
-# premerge building the corpora exactly as before.
+# is never narrowed. Both must drop the same complete reverse-dependency
+# closure, or fixing one leaves premerge building the corpora exactly as before.
 TESTS=$((TESTS + 1))
-unnarrowed="$(RUE_AFFECTED_BUCK2="$scope_root/bin/fake-buck" "${AFFECTED[@]}" build-scope 2>/dev/null)"
-if [ -n "$unnarrowed" ] && ! grep -q -- '-action$' <<<"$unnarrowed"; then
-  pass "narrow: build-scope with no list expands the pattern without any corpus action"
+unnarrowed="$(RUE_AFFECTED_BUCK2="$scope_root/bin/fake-buck" RUE_AFFECTED_QUERY_LOG="$scope_query_log" "${AFFECTED[@]}" build-scope 2>/dev/null | tr '\n' ' ')"
+if [ "$unnarrowed" = "//crates/rue-compiler:rue-compiler //crates/rue-span:rue-span-test " ]; then
+  pass "narrow: build-scope with no list excludes the complete corpus closure"
 else
-  fail "narrow: build-scope with no list kept a corpus action or produced nothing"
+  fail "narrow: build-scope with no list kept a corpus closure or produced nothing"
 fi
 
 # FAIL CLOSED is the property the whole change rests on: an action whose test
@@ -385,6 +422,17 @@ if [ "$degraded" = "//crates/rue-oracle-diff:oracle-diff-test-action //crates/ru
   pass "narrow: an unanswerable Buck query falls open to the unfiltered scope"
 else
   fail "narrow: a failed query did not fall open (got '$degraded')"
+fi
+
+# A successful action/ownership query followed by a failed configured closure
+# query must also over-build. Otherwise a new graph-query failure would turn
+# an owned corpus into an accidental omission.
+TESTS=$((TESTS + 1))
+degraded_cquery="$(RUE_AFFECTED_BUCK2="$scope_root/bin/fail-cquery" "${AFFECTED[@]}" build-scope "$narrow_root/unowned" 2>/dev/null | tr '\n' ' ')"
+if [ "$degraded_cquery" = "//crates/rue-oracle-diff:oracle-diff-test-action //crates/rue-newthing:newthing-test-action //crates/rue-span:rue-span-test " ]; then
+  pass "narrow: a failed closure query falls open to the unfiltered scope"
+else
+  fail "narrow: a failed closure query did not fall open (got '$degraded_cquery')"
 fi
 
 # An impacted closure naming only corpora is legitimate — corpus data can change


### PR DESCRIPTION
Fixes RUE-1788

Summary:
- derive the complete configured reverse-dependency closure for corpus actions owned by required dedicated lanes
- remove actions, wrappers, and aggregate roots from narrowed and unnarrowed premerge build scopes
- preserve conservative over-building when graph queries fail or a corpus has no required owner
- correct local premerge documentation without deciding the separate aggregate-CI policy

Validation:
- affected-target tooling tests: 101 checks passed
- Bash 3.2 and Python 3.9 baseline gates passed
- live build scope: 203 roots; no oracle wrappers or actions
- live configured dependency closure: zero reachable corpus actions
- quick suite: 31 targets passed
- premerge tier: 200 targets passed