### PR TITLE
Clarify local premerge scope in developer documentation

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -19,7 +19,7 @@ scripts/rue build                    # build the compiler
 scripts/rue exec program.rue         # compile and run a program
 scripts/rue quick                    # Rust unit tests
 scripts/rue test [pattern]           # full suite, optionally filtered
-scripts/rue premerge                 # required-CI tier: clippy gate + tests
+scripts/rue premerge                 # local premerge tier: clippy gate + tests (not all required CI)
 scripts/rue slow                     # scheduled exhaustive tests
 scripts/rue stress                   # opt-in resource stress tests
 scripts/rue all                      # union of every test tier

--- a/scripts/rue
+++ b/scripts/rue
@@ -8,8 +8,8 @@
 #   scripts/rue exec prog.rue      Compile prog.rue to a temp file AND run it
 #   scripts/rue test [pattern]     Full suite (./test.sh), optional filter
 #   scripts/rue quick              Unit tests only (./quick-test.sh)
-#   scripts/rue premerge           Canonical required tier (incl. the per-crate
-#                                  fmt and clippy gates, RUE-1153)
+#   scripts/rue premerge           Local premerge tier (incl. the per-crate fmt
+#                                  and clippy gates; not all required CI)
 #   scripts/rue slow               Canonical scheduled slow tier
 #   scripts/rue stress             Canonical opt-in stress tier
 #   scripts/rue all                Canonical union of every tier


### PR DESCRIPTION
Relates to RUE-1788

The main fix merged before these two documentation corrections could enter its queued branch. Align the developer guide and wrapper help with AGENTS.md: scripts/rue premerge is the local premerge tier, not the aggregate of every required CI lane.

Validation:
- wrapper-script tests: 162 checks passed
- no stale required-CI tier wording remains
- git diff --check