### PR TITLE
RUE-1793: say when the oracle-diff check is needed, not just what it is

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,21 @@ Use proportionate validation:
 3. Run the broad/full suite once when the change is cross-cutting or high-risk.
    CI is the final full-platform authority.
 
+A tier is not a preview of required CI, which is why the quickstart names the
+oracle-diff check separately. `test.sh` selects on `rue_test_tier_premerge`,
+while both oracle-diff corpora are `tier = "slow"` and
+`test (linux-x64-oracle-diff*)` gates the merge queue regardless — so no local
+premerge run can report on them, however green it comes back.
+
+Adding a CLI or spec case is the ordinary way to land in that gap, not an edge
+case: the corpus audit classifies every case, and one reaching a construct the
+oracle does not model is a HARNESS FAILURE until its gap is registered in
+`crates/rue-oracle-diff/src/model_gaps/`. A `StrBuf`-built path reaches the
+unmodeled byte-copy gap immediately, so a new `std.fs` case starts there by
+default. The audit prints the exact `Entry::new(...)` line to add, which is
+the whole fix — read past "unknown oracle model gap" to it rather than reading
+the message as a compiler bug. RUE-1711 cost a red CI round for want of this.
+
 The generated-oracle smoke target has a fixed two-second child-process budget
 and can time out under heavy parallel load on the local macOS host. If failures
 are timeout-only and unrelated tests are competing for the machine, rerun that


### PR DESCRIPTION
Fixes RUE-1793. Follow-up to the docs half of #2645; that work is complete and this does not revisit it.

## What #2645 landed, and what it leaves out

#2645 corrected `AGENTS.md:77` — `scripts/rue premerge` is now "local premerge test tier (not all required CI)" — and added a quickstart pointer:

> When corpus-affecting cases change, use this focused check:
> `./buck2 test //crates/rue-oracle-diff:oracle-diff-test`.

That is the right command, and this PR does not touch it. What is missing is the part that decides whether anyone runs it:

- **When you are in the gap.** "corpus-affecting cases" does not obviously include "I added a CLI test case", which is the common way to get here.
- **What the failure looks like.** The audit prints the exact `Entry::new(...)` line to add. Without knowing that, "unknown rue-cli-tests oracle model gap" reads as a compiler bug rather than a one-line registration.
- **Why a local tier cannot see it.** "not all required CI" says the coverage is incomplete without saying which part or why — so a reader cannot recognize the next tier-versus-lane mismatch from it. The mechanism is one sentence: `test.sh` selects on `rue_test_tier_premerge`, the oracle-diff corpora are `tier = "slow"`, and `test (linux-x64-oracle-diff*)` gates the merge queue regardless.

## Placement

Testing strategy, next to the proportionate-validation guidance it qualifies, rather than in the quickstart — the quickstart is a command list, and this is the reasoning behind one of them.

## Why it earns the space

This is the gap that cost RUE-1711 (#2625) a full red CI round: local premerge passed 200 tests on the commit CI rejected, and the fix was one registry entry the audit had already printed. A `StrBuf`-built path reaches the unmodeled byte-copy gap immediately, so a new `std.fs` case starts there by default rather than exceptionally.

Docs only — no code, no behavior change. Wrapped at the file's 80 columns; `validate-python-baseline.py`, which parses this file, still passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_017DXYUwVgawbtUzfMEpCh3L)_