### PR TITLE
RUE-1794: fetch only the data-branch tip in the staleness job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -630,7 +630,15 @@ jobs:
           scripts/ci-timed "rue-bench build" -- ./buck2 build //crates/rue-bench:rue-bench
           BENCH="$(./buck2 build //crates/rue-bench:rue-bench --show-simple-output 2>/dev/null | tail -1)"
           git fetch --no-tags origin trunk
-          git fetch --no-tags origin performance-data-v1
+          # Tip only (RUE-1794). This job materializes index.json and the
+          # selected live-epoch records, all present in the tip commit; the
+          # branch's full history still carries the 3.8 GiB pre-compaction
+          # store behind the performance-data-v1-pre-compaction tag, and
+          # fetching it here cost a measured 70s and ~143 MiB of pack against
+          # depth-1's 7s and ~30 MiB. A blob:none partial fetch was measured
+          # too and rejected: the checkouts below lazy-fetch one blob per
+          # round trip, which is slower than either.
+          git fetch --no-tags --depth=1 origin performance-data-v1
           DATA="$(mktemp -d)"
           # Read the live epoch, not the whole store. performance-data-v1 is
           # append-only and now grows by hundreds of megabytes a day, while


### PR DESCRIPTION
Refs RUE-1794, the post-compaction follow-up. One line plus its comment: the staleness job's data-branch fetch becomes `--depth=1`.

**Why depth-1 and not `--filter=blob:none`**: both were measured against the live remote before choosing. The partial-clone route turned out to lazy-fetch one blob per round trip during the pathspec checkouts (~0.8s each — minutes for a live epoch, not seconds) and tripped a promisor-remote error mid-batch. Depth-1 is one round trip, no lazy machinery, and everything the job reads — `index.json` plus the selected live-epoch records — is in the tip commit by construction.

**Measured, fresh clones against the live remote:**

| | fetch time | pack transferred |
| --- | ---: | ---: |
| today (full history) | 70.2s | ~143 MiB |
| `--depth=1` | 7.1s | ~30 MiB |

The full tip then checks out locally in 0.4s. Expected steady-state staleness job: **~88s → ~25s**, on top of the compaction's 800s → 88s. The trunk fetch for commit counting is untouched, and the website build's fetch is already `--depth=50`-shallow and near-optimal post-compaction, so it is deliberately not changed here.

`validate-ci-gate` and its test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPBpmZU3DpwkumLHNwHsgu