### PR TITLE
RUE-1786: check the call-loan frame where the mutation happens, not where the argument is

### DIFF
--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -1160,6 +1160,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 // which coexists with the loop's shared borrow, so it is allowed.
                 if receiver_mode == AirArgMode::Inout {
                     self.reject_mutate_iter_borrowed(receiver_root, span, ctx)?;
+                    // An enclosing call may hold a loan of this root that the
+                    // mutation would invalidate. Frame construction only walks
+                    // the outer call's own `inout` arguments, so an argument
+                    // that merely CONTAINS this call -- a block, an `if`, a
+                    // `match` arm -- never reached that check (RUE-1786).
+                    self.reject_exclusive_use_of_call_loaned_root(receiver_root, span, ctx)?;
                 }
 
                 // `inout self` requires a mutable receiver binding (spec 6, reuses

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -5659,6 +5659,82 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         self.reject_accessor_loan_conflict(root, "by value (move)", span, ctx)
     }
 
+    /// Reject an exclusive (`inout`) use of `root` while an enclosing call's
+    /// argument list holds a loan of it that the use would invalidate
+    /// (RUE-1786, sibling of RUE-1696/RUE-1766).
+    ///
+    /// The nested-call form — `f(borrow b, nuke(inout b))` — is caught at
+    /// frame construction, which walks this call's own `inout` ARGUMENTS. That
+    /// walk sees the argument's place, so it only fires when the mutation *is*
+    /// the argument. An argument that merely *contains* a mutation reaches the
+    /// callee by a different route and was never checked:
+    ///
+    /// ```text
+    /// f(borrow b, { b.free(); 0 })          // block
+    /// f(borrow b, if c { b.free(); 0 } ..)  // if
+    /// f(borrow b, match k { _ => { b.free(); 0 } })
+    /// ```
+    ///
+    /// All three compiled and read freed memory, in both loan modes, and so
+    /// did a reallocating `b.push(..)` rather than a free. The argument form
+    /// is incidental: what matters is that the root is exclusively accessed
+    /// while an enclosing frame holds a loan of it. So this is checked where
+    /// the exclusive access is recorded — the `inout` receiver — rather than
+    /// by enumerating argument shapes, which is what let the earlier fixes
+    /// miss these.
+    ///
+    /// The conflict is keyed on VIEW MATERIALIZATION alone, not on loan mode.
+    /// Only a snapshot can dangle: a `borrow`/`inout` argument at a `str` or
+    /// slice parameter is narrowed to a `{ptr, len}` value before the call
+    /// runs, so mutating the root invalidates it. Everything else here is
+    /// address-passed and observes ordinary sequenced mutation -- including a
+    /// `borrow self` / `inout self` RECEIVER, which frame construction records
+    /// with `view_materialized = false` precisely because autoref hands over
+    /// the receiver's address rather than a copy of it.
+    ///
+    /// That distinction is load-bearing, not theoretical. Keying on loan mode
+    /// instead -- treating any enclosing `borrow` as a conflict, the way frame
+    /// construction's argument walk does -- rejects `examples/gazette`:
+    ///
+    /// ```text
+    /// summary.push_str(arena.scalar(arena.map_get_literal(front.root, "title")))
+    /// ```
+    ///
+    /// The outer `arena.scalar(..)` holds a `borrow self` loan of `arena` and
+    /// the inner call takes it `inout`, which is sound because that outer loan
+    /// is an address, not a snapshot. The argument walk gets away with the
+    /// coarser rule only because it runs over `inout` ARGUMENTS -- a far
+    /// narrower set than every exclusive access in the program.
+    pub(crate) fn reject_exclusive_use_of_call_loaned_root(
+        &self,
+        root: Spur,
+        span: Span,
+        ctx: &AnalysisContext,
+    ) -> CompileResult<()> {
+        let conflicting = ctx
+            .call_loaned_roots
+            .iter()
+            .flatten()
+            .find(|(loaned, _kind, view_materialized)| *loaned == root && *view_materialized);
+        let Some((_, kind, _)) = conflicting else {
+            return Ok(());
+        };
+        let variable = self.body_interner().resolve(&root).to_string();
+        let loan_kind = kind.keyword();
+        Err(CompileError::new(
+            ErrorKind::BorrowInoutConflict {
+                variable: variable.clone(),
+            },
+            span,
+        )
+        .with_help(format!(
+            "the enclosing call passes `{variable}` as `{loan_kind}` to a `str`/slice \
+             parameter, which snapshots a view of it before this argument runs; mutating \
+             `{variable}` here would leave that view dangling; evaluate this argument into \
+             its own binding before the call"
+        )))
+    }
+
     /// Reject an exclusive use — `inout`, mutation, or move — of a root with
     /// an active accessor-result loan in the same full expression (ADR-0062,
     /// E0259). Shared and exclusive accessor loans both exclude another

--- a/crates/rue-cli-tests/cases/nested_loan_str_view.toml
+++ b/crates/rue-cli-tests/cases/nested_loan_str_view.toml
@@ -319,3 +319,148 @@ fn main() -> i32 {
 """ }]
 stdout = "17\n11\n"
 exit_code = 0
+
+# RUE-1786. The nested-CALL spelling above is caught at frame construction,
+# which walks the outer call's own `inout` ARGUMENTS. That walk sees the
+# argument's place, so it only fires when the mutation *is* the argument. An
+# argument that merely CONTAINS the mutation reached the callee by a different
+# route and was never checked at all -- so `f(borrow b, { b.free(); 0 })`
+# compiled and read freed memory even after RUE-1696 and RUE-1766 landed.
+#
+# The argument form turned out to be incidental: a block, an `if`, and a
+# `match` arm all leaked, in both loan modes, and a reallocating `push` leaked
+# as surely as a `free`. So the check now sits where the exclusive access is
+# recorded -- the `inout` receiver -- rather than enumerating argument shapes,
+# which is exactly what let the earlier two fixes miss this.
+
+[[case]]
+name = "block_argument_freeing_the_borrowed_root_rejected"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+description = "RUE-1786 repro: a block-expression argument frees the root the sibling `borrow b` argument was already snapshotted into a view over."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn read_first(borrow s: str, k: i64) -> i64 { let l: i64 = @intCast(s.len()); @dbg(l); k }
+fn main() -> i32 {
+    let mut b = StrBuf.new();
+    b.push_str("hello");
+    let r = read_first(borrow b, { b.free(); 0 });
+    @intCast(r)
+}
+""" }]
+compile_fail = true
+compile_stderr_contains = ["E0430", "evaluate this argument into its own binding"]
+
+[[case]]
+name = "block_argument_freeing_the_inout_str_root_rejected"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+description = "The same hole in the other loan mode: `inout str` is view-materialized too, so the snapshot dangles identically."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn read_view(inout s: str, k: i64) -> i64 { let l: i64 = @intCast(s.len()); @dbg(l); k }
+fn main() -> i32 {
+    let mut b = StrBuf.new();
+    b.push_str("hello");
+    let r = read_view(inout b, { b.free(); 0 });
+    @intCast(r)
+}
+""" }]
+compile_fail = true
+compile_stderr_contains = ["E0430"]
+
+# A reallocation is as fatal as a free -- `push` can move the buffer, leaving
+# the snapshot pointing at the old allocation. Pinning this separately because
+# a fix that only looked for `free` would pass the two cases above.
+[[case]]
+name = "block_argument_reallocating_the_borrowed_root_rejected"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+description = "A mutating `push` inside the argument is rejected too, not only a free."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn read_first(borrow s: str, k: i64) -> i64 { let l: i64 = @intCast(s.len()); @dbg(l); k }
+fn main() -> i32 {
+    let mut b = StrBuf.new();
+    b.push_str("hello");
+    let r = read_first(borrow b, { b.push(65); 0 });
+    @intCast(r)
+}
+""" }]
+compile_fail = true
+compile_stderr_contains = ["E0430"]
+
+[[case]]
+name = "if_argument_freeing_the_borrowed_root_rejected"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+description = "An `if` in argument position hides the same mutation; the check is on the receiver, not the argument shape."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn read_first(borrow s: str, k: i64) -> i64 { let l: i64 = @intCast(s.len()); @dbg(l); k }
+fn main() -> i32 {
+    let mut b = StrBuf.new();
+    b.push_str("hello");
+    let r = read_first(borrow b, if true { b.free(); 0 } else { 0 });
+    @intCast(r)
+}
+""" }]
+compile_fail = true
+compile_stderr_contains = ["E0430"]
+
+[[case]]
+name = "match_argument_freeing_the_borrowed_root_rejected"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+description = "And a `match` arm, for the same reason."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn read_first(borrow s: str, k: i64) -> i64 { let l: i64 = @intCast(s.len()); @dbg(l); k }
+fn main() -> i32 {
+    let mut b = StrBuf.new();
+    b.push_str("hello");
+    let r = read_first(borrow b, match 1 { _ => { b.free(); 0 } });
+    @intCast(r)
+}
+""" }]
+compile_fail = true
+compile_stderr_contains = ["E0430"]
+
+# The over-rejection controls. An address-passed `inout StrBuf` hands over the
+# root's address, so a nested mutation is ordinary sequenced mutation and the
+# callee legitimately observes it -- 6, the length AFTER the push, not a stale
+# 5. If this ever starts failing, the fix has become too broad.
+[[case]]
+name = "block_argument_mutating_an_address_passed_inout_root_stays_legal"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+description = "Address-passed `inout StrBuf` is not snapshotted, so a nested mutation inside a block argument is legal and visible to the callee."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn peek(inout s: StrBuf, k: i64) -> i64 { let l: i64 = @intCast(s.len()); @dbg(l); k }
+fn main() -> i32 {
+    let mut b = StrBuf.new();
+    b.push_str("hello");
+    let q = peek(inout b, { b.push(65); 0 });
+    @intCast(q)
+}
+""" }]
+stdout = "6\n"
+
+[[case]]
+name = "block_argument_only_reading_the_borrowed_root_stays_legal"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+description = "A block argument that only READS the borrowed root is two shared accesses and stays legal."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn read_first(borrow s: str, k: i64) -> i64 { let l: i64 = @intCast(s.len()); @dbg(l); k }
+fn main() -> i32 {
+    let mut b = StrBuf.new();
+    b.push_str("hello");
+    let r = read_first(borrow b, { let n: i64 = @intCast(b.len()); n });
+    @intCast(r)
+}
+""" }]
+stdout = "5\n"
+exit_code = 5

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -452,6 +452,22 @@ const ENTRIES: &[Entry] = &[
     // std allocators (`@alloc` in StrBuf, `@int_to_ptr` in ArrayBuf.new()),
     // outside the oracle model.
 
+    // RUE-1786: the two over-rejection controls in this section are the only
+    // ones that RUN -- the rest assert a compile failure and are ineligible.
+    // Both build a real StrBuf, so they reach the same unmodeled bulk byte
+    // copy as every other StrBuf-backed case here.
+    Entry::new(
+        "cli.nested_loan_str_view",
+        "block_argument_mutating_an_address_passed_inout_root_stays_legal",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
+    Entry::new(
+        "cli.nested_loan_str_view",
+        "block_argument_only_reading_the_borrowed_root_stays_legal",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
     // RUE-978: the byte-surface behavior cases allocate through @alloc,
     // which the oracle model does not model.
     Entry::new(


### PR DESCRIPTION
RUE-1696 and RUE-1766 close the nested-**call** shape: an argument that materializes a `{ptr, len}` view of a root, plus a sibling argument whose nested call frees or reallocates that root. Both are caught at frame construction, which walks the outer call's own `inout` **arguments**.

That walk inspects each argument's *place*, so it fires only when the mutation **is** the argument. An argument that merely *contains* the mutation reaches the callee by a different route and was never checked at all.

## The hole is wider than it was filed

I filed this as a block-expression bug. Probing the boundary before writing anything, five spellings leaked:

```rue
read_first(borrow b, { b.free(); 0 })                       // printed 5
read_view(inout b,   { b.free(); 0 })                       // printed 5
read_first(borrow b, { b.push(65); 0 })                     // printed 5
read_first(borrow b, if true { b.free(); 0 } else { 0 })    // printed 5
read_first(borrow b, match 1 { _ => { b.free(); 0 } })      // printed 5
```

Three argument forms, both loan modes — and a *reallocating* `push` leaks as surely as a `free`. std's `free` sets `len = 0` and nulls the buffer, so the printed `5` is the length snapshotted before the free: the callee read through a dangling view. No `unchecked` anywhere in user code.

The argument form is incidental. What they share is an exclusive access to a root some enclosing frame holds a snapshot of.

## The fix

The check now sits where that access is **recorded** — the `inout` receiver — rather than enumerating argument shapes. Enumerating shapes is exactly what let the two prior fixes miss these; one check covers all five spellings and any future one.

## Keyed on view materialization, not loan mode — and why that matters

My first attempt copied frame construction's predicate verbatim: conflict on a shared loan **or** a view-materialized one. **That is wrong**, and the suite caught it — `examples/gazette` stopped compiling:

```rue
summary.push_str(arena.scalar(arena.map_get_literal(front.root, "title")))
```

The outer `arena.scalar(..)` holds a `borrow self` loan of `arena` and the inner call takes it `inout`. That is sound: a **receiver is address-passed** by autoref, not snapshotted, so the nested mutation is ordinary sequenced mutation. Frame construction records receivers with `view_materialized = false` for precisely this reason.

Only a snapshot can dangle. So the conflict is keyed on **view materialization alone** — which is what RUE-1766's own in-source comment already said governs. Frame construction's argument walk gets away with the coarser rule only because it runs over `inout` arguments, a far narrower set than every exclusive access in the program.

This was caught by gazette failing to compile, not by reasoning about it. The doc comment records the counterexample so the rule doesn't get re-broadened later.

## Verification

All by execution on this branch:

| | before | after |
| --- | --- | --- |
| all five leaking spellings | compiled, printed `5` | `E0430` |
| accumulator idiom `add(mul(x, y, inout f), z, inout f)` | 17 / 2 | 17 / 2 |
| `peek(inout b: StrBuf, { b.push(65); 0 })` | 6 | 6 |
| `examples/gazette` | compiles | compiles |
| `examples/harbor` selftest | `checks=180 failures=0` | `checks=180 failures=0` |

The `peek` row is the one that proves the fix is not over-broad: the callee reads **6**, the length *after* the push — live data through an address, not a stale 5.

Harbor's digest is `85530708304687882` both before and after, so behaviour is identical rather than merely passing.

**Mutation-checked** with the check neutered from the inside: all five rejection cases fail, both over-rejection controls still pass.

`./test.sh` → `Tests finished: Pass 234. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0`, exit 0.

## Coverage

Seven cases in `cli.nested_loan_str_view`: five rejections (block/`if`/`match` × both loan modes, plus reallocation-not-just-free) and two over-rejection controls that assert live data is still observed. Two model-gap registrations accompany the controls — they are the only cases in the section that actually run, the rest being compile-failures.

Fixes RUE-1786

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJ13kDoVzYrpTZ7ry3rUaA)_