### PR TITLE
RUE-1641: keep indirect reads behind loop entry

### DIFF
--- a/crates/rue-cfg/src/opt/classify.rs
+++ b/crates/rue-cfg/src/opt/classify.rs
@@ -1,12 +1,13 @@
 //! Shared trap / speculation classifier for optimizer passes.
 //!
 //! DCE, LICM (RUE-927), and unrolling (RUE-928) all need to reason about whether
-//! a CFG instruction can *trap* — abort the program with a runtime panic that
-//! ADR-0044 counts as defined, observable behavior no optimization level may add
-//! or remove. Historically that knowledge lived only inside DCE's private
-//! `has_side_effects` predicate, which conflated two independent axes. ADR-0054
-//! §2 makes this module the single place that names the trapping set, so the two
-//! axes cannot drift apart across the passes that consult them.
+//! a CFG instruction can *trap* — either abort with a Rue-defined runtime panic
+//! or fault during an unsafe memory access. The latter is a conservative
+//! classification for speculation and DCE safety, not a statement about Rue's
+//! raw-pointer semantics. Historically that knowledge lived only inside DCE's
+//! private `has_side_effects` predicate, which conflated two independent axes.
+//! ADR-0054 §2 makes this module the single place that names the trapping set,
+//! so the two axes cannot drift apart across the passes that consult them.
 //!
 //! ## Why a module in `opt` (not `CfgInstData` methods)
 //!
@@ -15,19 +16,20 @@
 //! optimizer-facing analyses in `opt/` (`dce`, `forward`, `cse`, …) and its
 //! `inst` module deliberately free of pass policy — what "traps" is an optimizer
 //! concern, not an intrinsic property of the instruction enum. The classifier
-//! also needs the `Cfg` (an indexed `PlaceRead` is only trap-carrying when its
-//! projection list contains an `Index`, which lives in `Cfg::projections`), so a
-//! free function taking `(&Cfg, CfgValue)` matches DCE's existing call shape
-//! exactly and lets LICM/unrolling reuse it verbatim.
+//! also needs the `Cfg` (a `PlaceRead` may trap based on both its base and its
+//! indexed projection list, which lives in `Cfg::projections`), so a free
+//! function taking `(&Cfg, CfgValue)` matches DCE's existing call shape exactly
+//! and lets LICM/unrolling reuse it verbatim.
 //!
 //! ## The two axes (defined independently)
 //!
-//! - [`may_trap`]: the instruction can panic at runtime — overflow-checked
+//! - [`may_trap`]: the instruction can panic or fault at runtime — overflow-checked
 //!   arithmetic (`Add`/`Sub`/`Mul`/`Neg`), division checks (`Div`/`Mod`), the
 //!   `IntCast` range check (`__rue_intcast_overflow`), and the bounds check of a
-//!   `PlaceRead` whose place contains an `Index` projection. This is the axis
-//!   LICM and unrolling need on its own: hoisting a `may_trap` op into a
-//!   zero-trip preheader would manufacture a trap out of thin air.
+//!   `PlaceRead` through an indirect base or an `Index` projection. The indirect
+//!   case is conservatively included for fault safety; this is the axis LICM and
+//!   unrolling need on its own: hoisting a `may_trap` op into a zero-trip
+//!   preheader would manufacture a trap or fault out of thin air.
 //! - [`has_observable_side_effect`]: the instruction is visible beyond its
 //!   result value — `Call`, `Intrinsic`, `Alloc`, `Store`, `ParamStore`,
 //!   `PlaceWrite`, `Drop`, `StorageLive`/`StorageDead`. This is the axis DCE
@@ -50,18 +52,20 @@
 //! ```
 //!
 //! Bitwise ops, shifts (counts are masked per spec, so they never trap),
-//! comparisons, `Not`/`BitNot`, constants, non-indexed `PlaceRead`/`Load`, and
-//! the aggregate constructors are the speculatable set — the ops LICM may hoist.
+//! comparisons, `Not`/`BitNot`, constants, direct non-indexed `PlaceRead`/`Load`,
+//! and the aggregate constructors are the speculatable set — the ops LICM may
+//! hoist.
 
 use crate::{Cfg, CfgInstData, CfgValue, Projection};
 
-/// Returns `true` if evaluating `value` can trap (panic) at runtime.
+/// Returns `true` if evaluating `value` can trap or fault at runtime.
 ///
 /// The trapping set, named once here per ADR-0054 §2:
 /// - overflow-checked arithmetic: `Add`, `Sub`, `Mul`, `Neg`;
 /// - division checks: `Div`, `Mod` (divide-by-zero / `INT_MIN / -1`);
 /// - `IntCast` (range check, panics via `__rue_intcast_overflow`);
-/// - `PlaceRead` through an `Index` projection (array bounds check).
+/// - `PlaceRead` through an indirect base (a conservatively classified pointer
+///   dereference) or an `Index` projection (array bounds check).
 ///
 /// Bitwise ops and shifts do **not** trap (shift counts are masked per spec).
 pub(crate) fn may_trap(cfg: &Cfg, value: CfgValue) -> bool {
@@ -78,15 +82,18 @@ pub(crate) fn may_trap(cfg: &Cfg, value: CfgValue) -> bool {
         // value is out of range for the target type.
         CfgInstData::IntCast { .. } => true,
 
-        // A PlaceRead is pure for field projections, but an array index read
-        // performs a bounds check that panics when out of range. Only a place
-        // containing an Index projection can trap (RUE-57).
-        CfgInstData::PlaceRead { place } => cfg
-            .get_place_projections(place)
-            .iter()
-            .any(|p| matches!(p, Projection::Index { .. })),
+        // A direct PlaceRead is pure for field projections, but an indirect
+        // base dereferences a pointer and an array index performs a bounds
+        // check. Either can trap or fault before the read produces its result.
+        CfgInstData::PlaceRead { place } => {
+            matches!(place.base, crate::PlaceBase::Indirect(_))
+                || cfg
+                    .get_place_projections(place)
+                    .iter()
+                    .any(|p| matches!(p, Projection::Index { .. }))
+        }
 
-        // Everything else evaluates without a runtime trap.
+        // Everything else is outside this conservative trapping set.
         _ => false,
     }
 }
@@ -246,6 +253,43 @@ mod tests {
             is_speculatable(&cfg, read),
             "non-indexed PlaceRead is speculatable"
         );
+    }
+
+    #[test]
+    fn indirect_place_read_may_trap() {
+        // Dereferencing an indirect base can fault even without projections;
+        // classifying only Index projections would let LICM speculate it.
+        let mut cfg = make_cfg();
+        let type_pool = rue_air::TypeInternPool::new();
+        let pointer = add(
+            &mut cfg,
+            CfgInstData::Const(0),
+            Type::new_ptr_const(type_pool.intern_ptr_const_from_type(Type::I32)),
+        );
+        let place = cfg
+            .make_place(PlaceBase::Indirect(pointer), Type::I32, std::iter::empty())
+            .unwrap();
+        let read_place = place.duplicate_with_owner();
+        let read = add(
+            &mut cfg,
+            CfgInstData::PlaceRead { place: read_place },
+            Type::I32,
+        );
+        assert!(may_trap(&cfg, read), "indirect PlaceRead must be may_trap");
+        assert!(!is_speculatable(&cfg, read));
+        assert!(!has_observable_side_effect(&cfg, read));
+
+        // PlaceWrite remains on the observable-effect axis; the indirect-base
+        // trap classification is intentionally specific to PlaceRead.
+        let value = konst(&mut cfg, 1);
+        let write = add(
+            &mut cfg,
+            CfgInstData::PlaceWrite { place, value },
+            Type::UNIT,
+        );
+        assert!(!may_trap(&cfg, write));
+        assert!(has_observable_side_effect(&cfg, write));
+        assert!(!is_speculatable(&cfg, write));
     }
 
     // --- The side-effect axis: every observable op reports the effect and is

--- a/crates/rue-cfg/src/opt/dce.rs
+++ b/crates/rue-cfg/src/opt/dce.rs
@@ -24,8 +24,10 @@
 //!   calls, intrinsics, `Store`/`ParamStore`/`PlaceWrite`, `Alloc`, `Drop`,
 //!   `StorageLive`/`StorageDead`.
 //! - May trap (`classify::may_trap`): overflow-checked arithmetic and division
-//!   checks, `IntCast` (range check), and an indexed `PlaceRead` (bounds check)
-//!   — the mandatory runtime traps DCE must preserve (RUE-57).
+//!   checks, `IntCast` (range check), and an indirect or indexed `PlaceRead`
+//!   (pointer fault or bounds check). DCE preserves these operations even when
+//!   their result is unused; the indirect case is a conservative fault-safety
+//!   classification rather than a Rue-defined panic guarantee (RUE-57).
 
 use super::classify;
 use crate::{BlockId, Cfg, CfgInstData, CfgValue, Projection, Terminator};
@@ -147,10 +149,11 @@ fn compute_live_values(cfg: &Cfg) -> BitSet {
 /// - `classify::has_observable_side_effect` — `Call`, `Intrinsic`, `Alloc`,
 ///   `Store`, `ParamStore`, `PlaceWrite`, `Drop`, `StorageLive`/`StorageDead`.
 /// - `classify::may_trap` — overflow-checked arithmetic and division checks,
-///   `IntCast` (range check), and an indexed `PlaceRead` (bounds check). These
-///   are the mandatory runtime traps DCE must preserve even when the result is
-///   unused (RUE-57). Bitwise ops and shifts do not trap (shift counts are
-///   masked per spec), so they remain eligible for elimination.
+///   `IntCast` (range check), and an indirect or indexed `PlaceRead` (pointer
+///   fault or bounds check). DCE preserves these even when the result is unused
+///   (RUE-57); the indirect case is a conservative fault-safety classification,
+///   not a Rue-defined panic guarantee. Bitwise ops and shifts do not trap
+///   (shift counts are masked per spec), so they remain eligible for elimination.
 ///
 /// This is exactly `classify::is_speculatable`'s negation, expressed positively.
 fn has_side_effects(cfg: &Cfg, value: CfgValue) -> bool {

--- a/crates/rue-cfg/src/opt/licm.rs
+++ b/crates/rue-cfg/src/opt/licm.rs
@@ -13,9 +13,10 @@
 //! invents a trap out of thin air — the exact inverse of RUE-57, where DCE
 //! *deleted* a mandatory trap. So **only [`classify::is_speculatable`] ops move**
 //! (neither `may_trap` nor observable). Every trapping invariant op —
-//! `Add`/`Sub`/`Mul`/`Div`/`Mod`/`Neg`, `IntCast`, an indexed `PlaceRead` — stays
-//! in the loop body even when invariant. Guarded hoisting of trapping ops is
-//! RUE-934, after loop rotation lands; there is no cleverness here.
+//! `Add`/`Sub`/`Mul`/`Div`/`Mod`/`Neg`, `IntCast`, an indirect or indexed
+//! `PlaceRead` — stays in the loop body even when invariant. Guarded hoisting of
+//! trapping ops is RUE-934, after loop rotation lands; there is no cleverness
+//! here.
 //!
 //! ## Invariance
 //!
@@ -31,10 +32,11 @@
 //!
 //! ### Memory reads — phase-2 conservatism
 //!
-//! A non-indexed `Load`/`PlaceRead` is speculatable per the classifier (it never
-//! traps), but its *result* is only invariant if no store inside the loop can
-//! change the memory it reads. Rue has no memory-versioning / alias analysis
-//! today, so this phase is maximally conservative: a memory read is treated as
+//! A direct, non-indexed `Load`/`PlaceRead` is speculatable per the classifier,
+//! but its *result* is only invariant if no store inside the loop can change the
+//! memory it reads. Indirect `PlaceRead`s remain non-speculatable because the
+//! dereference can fault. Rue has no memory-versioning / alias analysis today,
+//! so this phase is maximally conservative: a memory read is treated as
 //! **non-invariant whenever the loop body contains any instruction with an
 //! observable side effect** (`Call`, `Intrinsic`, `Store`, `ParamStore`,
 //! `PlaceWrite`, `Alloc`, `Drop`) — everything
@@ -316,8 +318,8 @@ fn hoist_loop(
 /// parameter, and — for a memory read — only when the loop body is effect-free.
 fn is_hoist_candidate(cfg: &Cfg, value: CfgValue, body_has_effect: bool) -> bool {
     // Trapping or observable ops never move (ADR-0054 §2). This already excludes
-    // arithmetic, IntCast, indexed PlaceRead, calls, stores, allocs, drops, and
-    // the storage markers.
+    // arithmetic, IntCast, indirect/indexed PlaceRead, calls, stores, allocs,
+    // drops, and the storage markers.
     if !classify::is_speculatable(cfg, value) {
         return false;
     }
@@ -447,6 +449,10 @@ mod tests {
     }
 
     fn single_loop() -> LoopShape {
+        single_loop_with_condition(true)
+    }
+
+    fn single_loop_with_condition(condition: bool) -> LoopShape {
         let mut cfg = make_cfg();
         let entry = cfg.new_block();
         cfg.entry = entry;
@@ -460,7 +466,12 @@ mod tests {
         // body then contains exactly the op each test adds.
         let a = push(&mut cfg, entry, CfgInstData::Const(6), Type::I32);
         let b = push(&mut cfg, entry, CfgInstData::Const(7), Type::I32);
-        let cond = bool_const(&mut cfg, entry);
+        let cond = push(
+            &mut cfg,
+            entry,
+            CfgInstData::BoolConst(condition),
+            Type::BOOL,
+        );
         cfg.set_terminator(entry, goto(header));
 
         cfg.set_terminator(header, branch(cond, body, exit));
@@ -708,6 +719,57 @@ mod tests {
         let stats = run(&mut s.cfg, &test_type_pool()).unwrap();
         assert_eq!(stats.invariants_hoisted, 0, "body has a store: Load stays");
         assert_eq!(block_of(&s.cfg, load), Some(s.body));
+    }
+
+    #[test]
+    fn indirect_place_read_stays_in_loop_but_direct_read_hoists() {
+        // A direct local read remains safe to speculate. An indirect read with
+        // no projections can fault on a bad pointer, so it must stay behind the
+        // explicitly false loop condition and cannot manufacture a zero-trip
+        // fault.
+        let mut s = single_loop_with_condition(false);
+        let direct_place = s
+            .cfg
+            .make_place(crate::PlaceBase::Local(0), Type::I32, std::iter::empty())
+            .unwrap();
+        let direct = push(
+            &mut s.cfg,
+            s.body,
+            CfgInstData::PlaceRead {
+                place: direct_place,
+            },
+            Type::I32,
+        );
+        let type_pool = rue_air::TypeInternPool::new();
+        let pointer = push(
+            &mut s.cfg,
+            s.entry,
+            CfgInstData::Const(0),
+            Type::new_ptr_const(type_pool.intern_ptr_const_from_type(Type::I32)),
+        );
+        let indirect_place = s
+            .cfg
+            .make_place(
+                crate::PlaceBase::Indirect(pointer),
+                Type::I32,
+                std::iter::empty(),
+            )
+            .unwrap();
+        let indirect = push(
+            &mut s.cfg,
+            s.body,
+            CfgInstData::PlaceRead {
+                place: indirect_place,
+            },
+            Type::I32,
+        );
+        s.cfg.verify().unwrap();
+
+        let stats = run(&mut s.cfg, &test_type_pool()).unwrap();
+        assert_eq!(stats.invariants_hoisted, 1, "only the direct read hoists");
+        assert_eq!(block_of(&s.cfg, direct), Some(s.entry));
+        assert_eq!(block_of(&s.cfg, indirect), Some(s.body));
+        s.cfg.verify().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- classify indirect-base `PlaceRead` operations as unsafe to speculate
- keep projection-free pointer reads behind zero-trip loop entry checks
- preserve hoisting for safe direct reads and leave `PlaceWrite` on the observable-effect axis

## Verification

- `scripts/rue unit cfg indirect_place_read`
- `scripts/rue unit cfg opt::licm::tests`
- `scripts/rue quick`
- `scripts/rue fmt`
- `scripts/rue premerge` (199 targets passed; the existing `cli.watch::change_after_monitor_stops_is_still_announced` timeout reproduces on untouched `origin/trunk`)

Fixes RUE-1641