### PR TITLE
RUE-1723: make shell tooling portable on macOS

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -982,12 +982,20 @@ rue_sh_test(
     },
 )
 
+# Keep the mechanism test's wrapper input explicit: under Buck it must not
+# reach back through the validator's source symlink into the checkout.
+filegroup(
+    name = "shell-bash-baseline-inputs",
+    srcs = {"buck2": "buck2"},
+)
+
 rue_sh_test(
     name = "shell-bash-baseline-tool-tests",
     test = "scripts/test-validate-shell-bash-baseline.py",
     resources = ["scripts/validate-shell-bash-baseline.py"] +
         [":gatelib-sources"],
     env = {
+        "RUE_BASH_BASELINE_ROOT": "$(location :shell-bash-baseline-inputs)",
         "PYTHONDONTWRITEBYTECODE": "1",
     },
 )

--- a/buck2
+++ b/buck2
@@ -24,12 +24,14 @@ fi
 
 execution_command=0
 explicit_preference=0
-for arg in "${args[@]}"; do
-    case "$arg" in
-        build|test|run|install) execution_command=1 ;;
-        --prefer-local|--prefer-remote|--local-only|--remote-only) explicit_preference=1 ;;
-    esac
-done
+if [[ "${#args[@]}" -gt 0 ]]; then
+    for arg in "${args[@]}"; do
+        case "$arg" in
+            build|test|run|install) execution_command=1 ;;
+            --prefer-local|--prefer-remote|--local-only|--remote-only) explicit_preference=1 ;;
+        esac
+    done
+fi
 
 # Starting another disk-heavy command while the host is near ENOSPC is unsafe.
 # The guard is normally just one portable `df` read. When free space is both at
@@ -58,4 +60,8 @@ if [[ "$uses_remote_cache" -eq 1 ]] && [[ "$execution_command" -eq 1 ]] && [[ "$
     [[ "$inserted" -eq 1 ]] || args+=(--prefer-local)
 fi
 
-exec dotslash "$repo_root/buck2-bin" "${args[@]}"
+if [[ "${#args[@]}" -gt 0 ]]; then
+    exec dotslash "$repo_root/buck2-bin" "${args[@]}"
+else
+    exec dotslash "$repo_root/buck2-bin"
+fi

--- a/crates/clippy-gate.sh
+++ b/crates/clippy-gate.sh
@@ -35,7 +35,8 @@ if [ ! -e "$DIAGNOSTICS" ]; then
 fi
 
 # Strip ANSI colour codes so CI logs stay readable and grep stays reliable.
-CLEANED="$(sed -E 's/\x1b\[[0-9;]*m//g' "$DIAGNOSTICS")"
+ESCAPE="$(printf '\033')"
+CLEANED="$(sed -E "s/${ESCAPE}\\[[0-9;]*m//g" "$DIAGNOSTICS")"
 
 # Herestring, not a pipe: under `pipefail` a matching `grep -q` exits early
 # and kills the producer with EPIPE, failing the pipeline (RUE-1155).

--- a/scripts/test-validate-shell-bash-baseline.py
+++ b/scripts/test-validate-shell-bash-baseline.py
@@ -21,6 +21,7 @@ SCRIPT = Path(__file__).with_name("validate-shell-bash-baseline.py")
 policy = load_script("validate-shell-bash-baseline.py", __file__)
 
 BASELINE_BASH = "/bin/bash"
+WRAPPER_ROOT_ENV = "RUE_BASH_BASELINE_ROOT"
 
 # The RUE-1511 break, as it shipped: the `"` opened after `covered=` is never
 # closed, because the `)` ending the command substitution is followed by
@@ -790,6 +791,47 @@ class MechanismTests(unittest.TestCase):
         result = self.run_bash('a=()\necho "${a[@]}"\n')
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("unbound variable", result.stderr)
+
+    def test_buck_wrapper_accepts_no_arguments(self) -> None:
+        # Exercise the real wrapper with the supported interpreter and a fake
+        # dotslash. Bash 3.2 rejects an empty "${args[@]}" expansion under
+        # `set -u`; the wrapper must still reach its normal executable handoff
+        # with no Buck arguments.
+        wrapper_input_root = os.environ.get(WRAPPER_ROOT_ENV)
+        if wrapper_input_root:
+            wrapper_input = Path(wrapper_input_root) / "buck2"
+        else:
+            # Direct invocation from a checkout has no Buck materialization;
+            # this fallback keeps the focused probe runnable by developers.
+            wrapper_input = SCRIPT.resolve().parent.parent / "buck2"
+        self.assertTrue(wrapper_input.is_file(), wrapper_input)
+        with tempfile.TemporaryDirectory() as directory:
+            sandbox = Path(directory)
+            wrapper = sandbox / "buck2"
+            wrapper.write_text(wrapper_input.read_text())
+            wrapper.chmod(0o755)
+            fakebin = sandbox / "bin"
+            fakebin.mkdir()
+            dotslash = fakebin / "dotslash"
+            dotslash.write_text(
+                "#!/bin/sh\nprintf '%s\\n' \"$#\" >\"$DOTSLASH_ARGC\"\n"
+            )
+            dotslash.chmod(0o755)
+
+            environment = os.environ.copy()
+            environment["PATH"] = f"{fakebin}:{environment.get('PATH', '')}"
+            environment["DOTSLASH_ARGC"] = str(sandbox / "dotslash-argc")
+            result = subprocess.run(
+                [BASELINE_BASH, str(wrapper)],
+                cwd=sandbox,
+                env=environment,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual((sandbox / "dotslash-argc").read_text().strip(), "1")
 
     def test_read_assigns_nothing_when_it_fails(self) -> None:
         # The third: `read` clears its variable at EOF but leaves it untouched

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -337,23 +337,29 @@ test_clippy_gate_reads_diagnostics_and_fails_closed() {
 
   # rustc prints some warnings unconditionally (e.g. -Ctarget-feature notes);
   # with deny_lints=["warnings"] every real finding is an error, so warnings
-  # must not gate.
+  # must not gate. Keep the colour escape here: it is a clean control for the
+  # same portability path as the failing diagnostic below.
   rc=0
-  printf 'warning: unstable feature note\n' >"$sb/warn.txt"
+  esc="$(printf '\033')"
+  printf '%s\n' "${esc}[33mwarning: unstable feature note${esc}[0m" >"$sb/warn.txt"
   bash "$gate" "$sb/warn.txt" >/dev/null 2>&1 || rc=$?
-  check "clippy-gate.sh: warning-only diagnostics pass" \
+  check "clippy-gate.sh: clean ANSI diagnostics pass" \
     "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
 
   # A real finding fails, and the diagnostics are surfaced — including when
   # clippy wrote them with ANSI colour codes.
   rc=0
   local out
-  printf '\x1b[31merror\x1b[0m: used `len` on a `str`\n' >"$sb/lint.txt"
+  printf '%s\n' "${esc}[31merror${esc}[0m: used \`len\` on a \`str\`" >"$sb/lint.txt"
   out="$(bash "$gate" "$sb/lint.txt" 2>&1)" || rc=$?
   check "clippy-gate.sh: an error line fails the gate" \
     "$([ "$rc" -eq 1 ] && echo 0 || echo 1)"
   check "clippy-gate.sh: the violation is surfaced in the output" \
     "$(grep -Fq 'used `len` on a `str`' <<<"$out" && echo 0 || echo 1)"
+  local colorless=0
+  [[ "$out" == *"$esc"* ]] && colorless=1
+  check "clippy-gate.sh: surfaced diagnostics are colorless" \
+    "$colorless"
 
   # A missing diagnostics file is not an empty one; refusing to certify what
   # cannot be read is the whole point of the gate (RUE-1152).


### PR DESCRIPTION
## Summary

- guard empty argument-array expansion in the Buck wrapper under Bash 3.2 while preserving normal argument handling
- strip ANSI color codes in the clippy gate with a GNU/BSD sed-compatible literal escape
- add registered hermetic coverage for zero-argument wrapper execution and colored clean/error diagnostics

## Verification

- `./buck2 test //:shell-bash-baseline-tool-tests //:wrapper-script-tests`
- `scripts/validate-shell-bash-baseline.py --require-baseline-bash`
- `scripts/rue quick`
- `scripts/rue fmt`
- `scripts/rue premerge` reported one unrelated CLI watch-event timeout; the same isolated case fails identically on unchanged `origin/trunk` at `f3affc3ef`

Fixes RUE-1723