### PR TITLE
RUE-1730: verify stack joins and edge moves

### DIFF
--- a/crates/rue-codegen/src/aarch64/verify.rs
+++ b/crates/rue-codegen/src/aarch64/verify.rs
@@ -316,6 +316,49 @@ mod tests {
     }
 
     #[test]
+    fn test_backward_jump_with_inconsistent_depth_fails_at_jump() {
+        let mut mir = Aarch64Mir::new();
+        let label = mir.alloc_label();
+        mir.push(Aarch64Inst::Label { id: label });
+        mir.push(Aarch64Inst::SubImm {
+            dst: Operand::Physical(Reg::Sp),
+            src: Operand::Physical(Reg::Sp),
+            imm: 8,
+        });
+        mir.push(Aarch64Inst::B { label });
+
+        let err = verify_stack_alignment(&mir).unwrap_err().to_string();
+        assert!(err.contains("control flow join has inconsistent stack depth: expected 0, got 8"));
+        assert!(err.contains("instruction 2"));
+        assert!(err.contains("b .L"));
+        assert!(err.contains("depth: 8 bytes"));
+    }
+
+    #[test]
+    fn test_repeated_forward_jump_with_inconsistent_depth_fails_at_jump() {
+        let mut mir = Aarch64Mir::new();
+        let label = mir.alloc_label();
+        mir.push(Aarch64Inst::BCond {
+            cond: Cond::Eq,
+            label,
+        });
+        mir.push(Aarch64Inst::SubImm {
+            dst: Operand::Physical(Reg::Sp),
+            src: Operand::Physical(Reg::Sp),
+            imm: 8,
+        });
+        mir.push(Aarch64Inst::B { label });
+        mir.push(Aarch64Inst::Label { id: label });
+        mir.push(Aarch64Inst::Ret);
+
+        let err = verify_stack_alignment(&mir).unwrap_err().to_string();
+        assert!(err.contains("control flow join has inconsistent stack depth: expected 0, got 8"));
+        assert!(err.contains("instruction 2"));
+        assert!(err.contains("b .L"));
+        assert!(err.contains("depth: 8 bytes"));
+    }
+
+    #[test]
     fn test_multiple_calls_aligned() {
         let mut mir = Aarch64Mir::new();
         let sym1 = mir.intern_symbol("func1");

--- a/crates/rue-codegen/src/stack_verify.rs
+++ b/crates/rue-codegen/src/stack_verify.rs
@@ -105,7 +105,7 @@ where
         }
 
         for &target in self.adapter.jump_targets(inst) {
-            self.record_jump_target(target);
+            self.record_jump_target(idx, inst, target)?;
         }
 
         Ok(())
@@ -113,28 +113,46 @@ where
 
     fn verify_label(&mut self, idx: usize, inst: &A::Inst, label: LabelId) -> CompileResult<()> {
         if let Some(&expected_depth) = self.label_depths.get(&label) {
-            if expected_depth != self.current_depth {
-                return Err(self.adapter.error(
-                    idx,
-                    inst,
-                    self.current_depth,
-                    format!(
-                        "control flow join has inconsistent stack depth: expected {}, got {}",
-                        expected_depth, self.current_depth
-                    ),
-                ));
-            }
+            self.verify_join_depth(idx, inst, expected_depth)?;
         } else {
             self.label_depths.insert(label, self.current_depth);
         }
         Ok(())
     }
 
-    fn record_jump_target(&mut self, label: LabelId) {
-        // If this is a forward jump, record the expected depth now and check it
-        // when the label is encountered. If the label was already seen, the
-        // entry preserves that observed depth, matching the previous verifier
-        // behavior.
-        self.label_depths.entry(label).or_insert(self.current_depth);
+    fn verify_join_depth(
+        &self,
+        idx: usize,
+        inst: &A::Inst,
+        expected_depth: i64,
+    ) -> CompileResult<()> {
+        if expected_depth != self.current_depth {
+            return Err(self.adapter.error(
+                idx,
+                inst,
+                self.current_depth,
+                format!(
+                    "control flow join has inconsistent stack depth: expected {}, got {}",
+                    expected_depth, self.current_depth
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    fn record_jump_target(
+        &mut self,
+        idx: usize,
+        inst: &A::Inst,
+        label: LabelId,
+    ) -> CompileResult<()> {
+        if let Some(&expected_depth) = self.label_depths.get(&label) {
+            self.verify_join_depth(idx, inst, expected_depth)?;
+        } else {
+            // If this is a forward jump, record the expected depth now and
+            // check it when the label is encountered.
+            self.label_depths.insert(label, self.current_depth);
+        }
+        Ok(())
     }
 }

--- a/crates/rue-codegen/src/terminator_plan.rs
+++ b/crates/rue-codegen/src/terminator_plan.rs
@@ -6,6 +6,7 @@
 
 use std::ops::Range;
 
+use ahash::AHashSet;
 use rue_cfg::{BasicBlock, BlockId, CfgValue, Terminator, Type};
 
 use crate::call_plan::{self, ReturnPlan};
@@ -350,10 +351,25 @@ fn moves_for_edge<A: TerminatorAdapter>(
         }
     }
 
+    // Edge moves are emitted sequentially, so consuming an earlier
+    // destination would silently change the generated program.
+    assert_sequential_move_safety(&moves);
+
     EdgePlan {
         target,
         moves,
         fallthrough: order.next(source_block) == Some(target),
+    }
+}
+
+fn assert_sequential_move_safety(moves: &[SlotMove]) {
+    let mut earlier_destinations = AHashSet::with_capacity(moves.len());
+    for movement in moves {
+        assert!(
+            !earlier_destinations.contains(&movement.source),
+            "edge move destination must not be used as a later move source"
+        );
+        earlier_destinations.insert(movement.destination);
     }
 }
 
@@ -621,7 +637,7 @@ mod tests {
     use super::*;
     use lasso::ThreadedRodeo;
     use rue_air::{FrozenTypeInternPool, StructDef, StructField, TypeInternPool};
-    use rue_cfg::{Cfg, CfgInst, CfgInstData};
+    use rue_cfg::{Cfg, CfgInst, CfgInstData, CfgValue};
     use rue_span::{FileId, Span};
     use rue_target::Target;
 
@@ -685,6 +701,121 @@ mod tests {
             cfg.fn_name()
         );
         x86_trace
+    }
+
+    struct CollisionAdapter;
+
+    impl TerminatorAdapter for CollisionAdapter {
+        fn materialize_value(&mut self, value: CfgValue, plan: ValuePlan) -> MaterializedValue {
+            match plan.shape {
+                ValueShape::ZeroSized => MaterializedValue {
+                    primary: VReg::new(0),
+                    slots: Vec::new(),
+                },
+                ValueShape::Scalar => MaterializedValue {
+                    primary: VReg::new(value.as_u32()),
+                    slots: Vec::new(),
+                },
+                ValueShape::CompleteAggregate { slot_count } => MaterializedValue {
+                    primary: VReg::new(0),
+                    slots: (0..slot_count).map(VReg::new).collect(),
+                },
+            }
+        }
+
+        fn materialize_block_param(
+            &mut self,
+            _target: BlockId,
+            param_index: u32,
+            _target_value: CfgValue,
+            plan: ValuePlan,
+        ) -> MaterializedValue {
+            match plan.shape {
+                ValueShape::ZeroSized => MaterializedValue {
+                    primary: VReg::new(0),
+                    slots: Vec::new(),
+                },
+                ValueShape::Scalar => MaterializedValue {
+                    primary: VReg::new(param_index + 1),
+                    slots: Vec::new(),
+                },
+                ValueShape::CompleteAggregate { slot_count } => MaterializedValue {
+                    primary: VReg::new(1),
+                    slots: (1..=slot_count).map(VReg::new).collect(),
+                },
+            }
+        }
+
+        fn emit_block_label(&mut self, _block: BlockId) {}
+
+        fn emit_terminator(&mut self, _plan: TerminatorPlan) {}
+    }
+
+    #[test]
+    #[should_panic(expected = "edge move destination must not be used as a later move source")]
+    fn moves_for_edge_rejects_aggregate_slot_collision() {
+        let (pool, aggregate_ty, _interner) =
+            struct_pool("CollisionPair", vec![Type::I32, Type::I32]);
+        let mut cfg = Cfg::new(Type::UNIT, 0, 0, "aggregate_collision".to_string(), vec![]);
+        let source_block = cfg.new_block();
+        let target = cfg.new_block();
+        cfg.entry = source_block;
+        let left = cfg.append_inst(source_block, inst(CfgInstData::Const(1), Type::I32));
+        let right = cfg.append_inst(source_block, inst(CfgInstData::Const(2), Type::I32));
+        let struct_id = match aggregate_ty.kind() {
+            rue_air::TypeKind::Struct(id) => id,
+            _ => panic!("fixture aggregate must be a struct"),
+        };
+        let aggregate = cfg
+            .append_struct_init(
+                source_block,
+                struct_id,
+                [left, right],
+                aggregate_ty,
+                Span::new(0, 0),
+            )
+            .unwrap();
+        cfg.add_block_param(target, aggregate_ty);
+        cfg.set_goto(source_block, target, [aggregate]);
+        cfg.set_return(target, None);
+
+        let ctx = CfgLowerContext::new(&cfg, &pool);
+        let order = BlockOrder::of(&ctx);
+        moves_for_edge(
+            &ctx,
+            &order,
+            &mut CollisionAdapter,
+            &[aggregate],
+            target,
+            source_block,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "edge move destination must not be used as a later move source")]
+    fn moves_for_edge_rejects_cross_argument_collision() {
+        let pool = FrozenTypeInternPool::new();
+        let mut cfg = Cfg::new(Type::UNIT, 0, 0, "argument_collision".to_string(), vec![]);
+        let source_block = cfg.new_block();
+        let target = cfg.new_block();
+        cfg.entry = source_block;
+        let first = cfg.append_inst(source_block, inst(CfgInstData::Const(1), Type::I32));
+        let second = cfg.append_inst(source_block, inst(CfgInstData::Const(2), Type::I32));
+        cfg.add_block_param(target, Type::I32);
+        cfg.add_block_param(target, Type::I32);
+        cfg.set_goto(source_block, target, [first, second]);
+        cfg.set_return(target, None);
+
+        let ctx = CfgLowerContext::new(&cfg, &pool);
+        let order = BlockOrder::of(&ctx);
+        moves_for_edge(
+            &ctx,
+            &order,
+            &mut CollisionAdapter,
+            &[first, second],
+            target,
+            source_block,
+        );
     }
 
     fn struct_pool(name: &str, fields: Vec<Type>) -> (FrozenTypeInternPool, Type, ThreadedRodeo) {

--- a/crates/rue-codegen/src/x86_64/verify.rs
+++ b/crates/rue-codegen/src/x86_64/verify.rs
@@ -279,6 +279,42 @@ mod tests {
     }
 
     #[test]
+    fn test_backward_jump_with_inconsistent_depth_fails_at_jump() {
+        let mut mir = X86Mir::new();
+        let label = mir.alloc_label();
+        mir.push(X86Inst::Label { id: label });
+        mir.push(X86Inst::Push {
+            src: Operand::Physical(Reg::Rax),
+        });
+        mir.push(X86Inst::Jmp { label });
+
+        let err = verify_stack_alignment(&mir).unwrap_err().to_string();
+        assert!(err.contains("control flow join has inconsistent stack depth: expected 0, got 8"));
+        assert!(err.contains("instruction_index: 2"));
+        assert!(err.contains("jmp .L"));
+        assert!(err.contains("stack_depth_bytes: 8"));
+    }
+
+    #[test]
+    fn test_repeated_forward_jump_with_inconsistent_depth_fails_at_jump() {
+        let mut mir = X86Mir::new();
+        let label = mir.alloc_label();
+        mir.push(X86Inst::Jz { label });
+        mir.push(X86Inst::Push {
+            src: Operand::Physical(Reg::Rax),
+        });
+        mir.push(X86Inst::Jmp { label });
+        mir.push(X86Inst::Label { id: label });
+        mir.push(X86Inst::Ret);
+
+        let err = verify_stack_alignment(&mir).unwrap_err().to_string();
+        assert!(err.contains("control flow join has inconsistent stack depth: expected 0, got 8"));
+        assert!(err.contains("instruction_index: 2"));
+        assert!(err.contains("jmp .L"));
+        assert!(err.contains("stack_depth_bytes: 8"));
+    }
+
+    #[test]
     fn test_multiple_calls_aligned() {
         let mut mir = X86Mir::new();
         let sym1 = mir.intern_symbol("func1");


### PR DESCRIPTION
Summary

- Validate every jump into an already-recorded label against its canonical stack depth, including backward and repeated-forward edges on both backends.
- Preserve existing forward-jump and fallthrough behavior while anchoring inconsistent joins to the offending jump.
- Enforce the sequential edge-move disjointness invariant in the shared terminator planner with an expected-linear check.

Testing

- scripts/rue unit codegen: 757 passed
- focused stack-join tests: 4 passed
- focused production-path edge-move tests: 2 passed
- scripts/rue quick: passed
- scripts/rue fmt: passed
- scripts/rue premerge: 199 targets passed; the parallel CLI corpus timed out in cli.watch::change_after_monitor_stops_is_still_announced twice, while that test and the full 2,178-case CLI corpus passed in isolation

Fixes RUE-1730