### PR TITLE
RUE-1731: fail loudly on invalid string IDs

### DIFF
--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -672,7 +672,7 @@ impl<'a> Emitter<'a> {
         }
 
         for inst in self.mir.iter() {
-            self.emit_inst(inst);
+            self.emit_inst(inst)?;
         }
 
         if self.frameless_frame_reference {
@@ -821,7 +821,7 @@ impl<'a> Emitter<'a> {
     }
 
     /// Emit a single instruction.
-    fn emit_inst(&mut self, inst: &Aarch64Inst) {
+    fn emit_inst(&mut self, inst: &Aarch64Inst) -> CompileResult<()> {
         match inst {
             Aarch64Inst::MovImm { dst, imm } => {
                 let rd = dst.as_physical();
@@ -1513,11 +1513,18 @@ impl<'a> Emitter<'a> {
                 let rd = dst.as_physical();
                 let string_id = *string_id as usize;
 
-                let len = if string_id < self.strings.len() {
-                    self.strings[string_id].len() as i64
-                } else {
-                    // Invalid string_id - emit 0
-                    0
+                let len = match self.strings.get(string_id) {
+                    Some(string) => string.len() as i64,
+                    None => {
+                        return Err(ice_error!(
+                            "invalid string constant id",
+                            phase: "codegen/emit",
+                            details: {
+                                "string_id" => string_id.to_string(),
+                                "string_table_len" => self.strings.len().to_string()
+                            }
+                        ));
+                    }
                 };
 
                 // Emit the length as an immediate
@@ -1535,6 +1542,7 @@ impl<'a> Emitter<'a> {
                 end_inst!(self, "mov {}, #0", rd);
             }
         }
+        Ok(())
     }
 
     /// Emit function epilogue (restore SP from FP, restore callee-saved, LDP FP/LR).
@@ -2670,6 +2678,24 @@ mod tests {
             .emit()
             .unwrap()
             .0
+    }
+
+    #[test]
+    fn test_string_const_len_invalid_id_is_ice() {
+        let mut mir = Aarch64Mir::new();
+        mir.push(Aarch64Inst::StringConstLen {
+            dst: Operand::Physical(Reg::X0),
+            string_id: 1,
+        });
+
+        let error = Emitter::new(&mir, 0, 0, 0, &[], &["hello".to_string()])
+            .without_frame()
+            .emit()
+            .expect_err("invalid string IDs must not silently encode zero");
+        let message = error.to_string();
+        assert!(message.contains("internal compiler error: invalid string constant id"));
+        assert!(message.contains("string_id: 1"));
+        assert!(message.contains("string_table_len: 1"));
     }
 
     // --- Move instructions ---

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -527,7 +527,7 @@ impl<'a> Emitter<'a> {
         }
 
         for inst in self.mir.iter() {
-            self.emit_inst(inst);
+            self.emit_inst(inst)?;
         }
         if self.frameless_frame_reference {
             return Err(ice_error!(
@@ -786,7 +786,7 @@ impl<'a> Emitter<'a> {
     }
 
     /// Emit a single instruction.
-    fn emit_inst(&mut self, inst: &X86Inst) {
+    fn emit_inst(&mut self, inst: &X86Inst) -> CompileResult<()> {
         match inst {
             X86Inst::MovRI32 { dst, imm } => {
                 self.begin_inst();
@@ -822,30 +822,6 @@ impl<'a> Emitter<'a> {
                 end_inst!(
                     self,
                     "mov [{}{}], {}",
-                    base,
-                    format_offset(adjusted_offset),
-                    src.as_physical()
-                );
-            }
-            X86Inst::Movzx8RM { dst, base, offset } => {
-                let adjusted_offset = self.adjust_fp_offset(*base, *offset);
-                self.begin_inst();
-                self.emit_movzx8_rm(dst.as_physical(), *base, adjusted_offset);
-                end_inst!(
-                    self,
-                    "movzx {}, byte [{}{}]",
-                    dst.as_physical(),
-                    base,
-                    format_offset(adjusted_offset)
-                );
-            }
-            X86Inst::MovMR8 { base, offset, src } => {
-                let adjusted_offset = self.adjust_fp_offset(*base, *offset);
-                self.begin_inst();
-                self.emit_mov_mr8(*base, adjusted_offset, src.as_physical());
-                end_inst!(
-                    self,
-                    "mov byte [{}{}], {}",
                     base,
                     format_offset(adjusted_offset),
                     src.as_physical()
@@ -1381,11 +1357,19 @@ impl<'a> Emitter<'a> {
 
             X86Inst::StringConstLen { dst, string_id } => {
                 // MOV dst, imm64 - Load string length as immediate
-                let string_len = self
-                    .strings
-                    .get(*string_id as usize)
-                    .map(|s| s.len() as i64)
-                    .unwrap_or(0);
+                let string_len = match self.strings.get(*string_id as usize) {
+                    Some(string) => string.len() as i64,
+                    None => {
+                        return Err(ice_error!(
+                            "invalid string constant id",
+                            phase: "codegen/emit",
+                            details: {
+                                "string_id" => string_id.to_string(),
+                                "string_table_len" => self.strings.len().to_string()
+                            }
+                        ));
+                    }
+                };
                 self.begin_inst();
                 self.emit_mov_ri64(dst.as_physical(), string_len);
                 end_inst!(self, "mov {}, {}", dst.as_physical(), string_len);
@@ -1399,6 +1383,7 @@ impl<'a> Emitter<'a> {
                 end_inst!(self, "mov {}, 0", dst.as_physical());
             }
         }
+        Ok(())
     }
 
     /// Emit LEA with simple [base + disp] addressing.
@@ -1586,15 +1571,6 @@ impl<'a> Emitter<'a> {
 
         // ModR/M and optional SIB/displacement
         self.emit_modrm_memory(src_enc, base_enc, offset);
-    }
-
-    /// Emit `movzx r64, byte [base + offset]` (REX.W 0F B6 /r).
-    fn emit_movzx8_rm(&mut self, dst: Reg, base: Reg, offset: i32) {
-        let rex =
-            0x48 | if dst.needs_rex() { 0x04 } else { 0 } | if base.needs_rex() { 0x01 } else { 0 };
-        self.code.push(rex);
-        self.code.extend_from_slice(&[0x0f, 0xb6]);
-        self.emit_modrm_memory(dst.encoding(), base.encoding(), offset);
     }
 
     /// Emit `mov byte [base + offset], r8` ([REX] 88 /r).
@@ -4103,26 +4079,6 @@ mod tests {
     }
 
     #[test]
-    fn test_physical_byte_load_and_store_encoding() {
-        assert_eq!(
-            emit_single(X86Inst::Movzx8RM {
-                dst: Operand::Physical(Reg::Rax),
-                base: Reg::Rbx,
-                offset: 0,
-            }),
-            vec![0x48, 0x0f, 0xb6, 0x43, 0x00]
-        );
-        assert_eq!(
-            emit_single(X86Inst::MovMR8 {
-                base: Reg::Rbx,
-                offset: 0,
-                src: Operand::Physical(Reg::Rcx),
-            }),
-            vec![0x40, 0x88, 0x4b, 0x00]
-        );
-    }
-
-    #[test]
     fn test_movzx16_to64() {
         let code = emit_single(X86Inst::Movzx16To64 {
             dst: Operand::Physical(Reg::Rax),
@@ -4491,6 +4447,24 @@ mod tests {
             code,
             vec![0x48, 0xB8, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
         );
+    }
+
+    #[test]
+    fn test_string_const_len_invalid_id_is_ice() {
+        let mut mir = X86Mir::new();
+        mir.push(X86Inst::StringConstLen {
+            dst: Operand::Physical(Reg::Rax),
+            string_id: 1,
+        });
+
+        let error = Emitter::new(&mir, 0, 0, 0, &[], &["hello".to_string()])
+            .without_frame()
+            .emit()
+            .expect_err("invalid string IDs must not silently encode zero");
+        let message = error.to_string();
+        assert!(message.contains("internal compiler error: invalid string constant id"));
+        assert!(message.contains("string_id: 1"));
+        assert!(message.contains("string_table_len: 1"));
     }
 
     // --- RSP-based memory addressing (requires SIB byte) ---

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -153,12 +153,10 @@ pub fn uses(inst: &X86Inst) -> VRegList {
         X86Inst::MovRR { src, .. } => {
             add_if_virtual(src, &mut result);
         }
-        X86Inst::MovRM { .. } | X86Inst::Movzx8RM { .. } | X86Inst::NarrowLoadRM { .. } => {
+        X86Inst::MovRM { .. } | X86Inst::NarrowLoadRM { .. } => {
             // Reads from memory (base is physical), defines dst
         }
-        X86Inst::MovMR { src, .. }
-        | X86Inst::MovMR8 { src, .. }
-        | X86Inst::NarrowStoreMR { src, .. } => {
+        X86Inst::MovMR { src, .. } | X86Inst::NarrowStoreMR { src, .. } => {
             add_if_virtual(src, &mut result);
         }
         X86Inst::AddRR { dst, src }
@@ -337,12 +335,10 @@ pub fn defs(inst: &X86Inst) -> VRegList {
         X86Inst::MovRR { dst, .. } => {
             add_if_virtual(dst, &mut result);
         }
-        X86Inst::MovRM { dst, .. }
-        | X86Inst::Movzx8RM { dst, .. }
-        | X86Inst::NarrowLoadRM { dst, .. } => {
+        X86Inst::MovRM { dst, .. } | X86Inst::NarrowLoadRM { dst, .. } => {
             add_if_virtual(dst, &mut result);
         }
-        X86Inst::MovMR { .. } | X86Inst::MovMR8 { .. } | X86Inst::NarrowStoreMR { .. } => {
+        X86Inst::MovMR { .. } | X86Inst::NarrowStoreMR { .. } => {
             // Writes to memory, not to a register
         }
         X86Inst::AddRR { dst, .. }

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -292,20 +292,6 @@ pub enum X86Inst {
         src: Operand,
     },
 
-    /// `movzx dst, byte [base + offset]` - Load one physical byte.
-    Movzx8RM {
-        dst: Operand,
-        base: Reg,
-        offset: i32,
-    },
-
-    /// `mov byte [base + offset], src` - Store one physical byte.
-    MovMR8 {
-        base: Reg,
-        offset: i32,
-        src: Operand,
-    },
-
     // Arithmetic instructions
     /// `add dst, src` - Add src to dst (dst = dst + src).
     AddRR { dst: Operand, src: Operand },
@@ -787,12 +773,6 @@ impl fmt::Display for X86Inst {
                 } else {
                     write!(f, "mov [{}-{}], {}", base, -offset, src)
                 }
-            }
-            X86Inst::Movzx8RM { dst, base, offset } => {
-                write!(f, "movzx {}, byte [{}+{}]", dst, base, offset)
-            }
-            X86Inst::MovMR8 { base, offset, src } => {
-                write!(f, "mov byte [{}+{}], {}", base, offset, src)
             }
             X86Inst::AddRR { dst, src } => write!(f, "add {}, {}", dst, src),
             X86Inst::AddRR64 { dst, src } => write!(f, "addq {}, {}", dst, src),

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -282,30 +282,6 @@ impl RegAlloc {
                 });
             }
 
-            X86Inst::Movzx8RM { dst, base, offset } => {
-                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
-                    emit |dst_op| {
-                        mir.push(X86Inst::Movzx8RM { dst: dst_op, base, offset });
-                    },
-                    store |spill_offset| {
-                        mir.push_after(X86Inst::MovMR {
-                            base: Reg::Rbp,
-                            offset: spill_offset,
-                            src: Operand::Physical(SCRATCH_VALUE),
-                        });
-                    },
-                );
-            }
-
-            X86Inst::MovMR8 { base, offset, src } => {
-                let src_op = Self::load_operand(context, mir, src, SCRATCH_ADDR_BASE)?;
-                mir.push(X86Inst::MovMR8 {
-                    base,
-                    offset,
-                    src: src_op,
-                });
-            }
-
             X86Inst::AddRR { dst, src } => {
                 Self::emit_binop(context, mir, dst, src, |d, s| X86Inst::AddRR {
                     dst: d,

--- a/crates/rue-codegen/src/x86_64/schedule.rs
+++ b/crates/rue-codegen/src/x86_64/schedule.rs
@@ -93,7 +93,6 @@ fn get_latency(inst: &X86Inst) -> u32 {
         X86Inst::MovRM { .. }
         | X86Inst::MovRMIndexed { .. }
         | X86Inst::MovRMSib { .. }
-        | X86Inst::Movzx8RM { .. }
         | X86Inst::NarrowLoadRM { .. }
         | X86Inst::NarrowLoadIndexed { .. } => 4,
 
@@ -101,7 +100,6 @@ fn get_latency(inst: &X86Inst) -> u32 {
         X86Inst::MovMR { .. }
         | X86Inst::MovMRIndexed { .. }
         | X86Inst::MovMRSib { .. }
-        | X86Inst::MovMR8 { .. }
         | X86Inst::NarrowStoreMR { .. }
         | X86Inst::NarrowStoreIndexed { .. } => 1,
 
@@ -254,8 +252,6 @@ fn accesses_memory(inst: &X86Inst) -> bool {
             | X86Inst::MovMRIndexed { .. }
             | X86Inst::MovRMSib { .. }
             | X86Inst::MovMRSib { .. }
-            | X86Inst::Movzx8RM { .. }
-            | X86Inst::MovMR8 { .. }
             | X86Inst::NarrowLoadRM { .. }
             | X86Inst::NarrowStoreMR { .. }
             | X86Inst::NarrowLoadIndexed { .. }
@@ -278,12 +274,8 @@ pub(super) fn regs_read(inst: &X86Inst) -> RegList<Reg> {
     match inst {
         X86Inst::MovRI32 { .. } | X86Inst::MovRI64 { .. } => {}
         X86Inst::MovRR { src, .. } => add_if_phys(src, &mut result),
-        X86Inst::MovRM { base, .. }
-        | X86Inst::Movzx8RM { base, .. }
-        | X86Inst::NarrowLoadRM { base, .. } => result.push(*base),
-        X86Inst::MovMR { base, src, .. }
-        | X86Inst::MovMR8 { base, src, .. }
-        | X86Inst::NarrowStoreMR { base, src, .. } => {
+        X86Inst::MovRM { base, .. } | X86Inst::NarrowLoadRM { base, .. } => result.push(*base),
+        X86Inst::MovMR { base, src, .. } | X86Inst::NarrowStoreMR { base, src, .. } => {
             result.push(*base);
             add_if_phys(src, &mut result);
         }
@@ -444,11 +436,10 @@ pub(super) fn regs_written(inst: &X86Inst) -> RegList<Reg> {
         | X86Inst::MovRI64 { dst, .. }
         | X86Inst::MovRR { dst, .. }
         | X86Inst::MovRM { dst, .. }
-        | X86Inst::Movzx8RM { dst, .. }
         | X86Inst::NarrowLoadRM { dst, .. } => {
             add_if_phys(dst, &mut result);
         }
-        X86Inst::MovMR { .. } | X86Inst::MovMR8 { .. } | X86Inst::NarrowStoreMR { .. } => {}
+        X86Inst::MovMR { .. } | X86Inst::NarrowStoreMR { .. } => {}
         X86Inst::AddRR { dst, .. }
         | X86Inst::AddRR64 { dst, .. }
         | X86Inst::AddRI { dst, .. }


### PR DESCRIPTION
## Summary

- return canonical internal compiler errors for invalid string constant length IDs on x86-64 and AArch64
- delete producer-less x86 byte load/store MIR variants and their parallel plumbing
- retain canonical narrow load/store encoding and focused coverage

## Validation

- `scripts/rue fmt`
- `scripts/rue unit codegen string_const_len`
- `scripts/rue unit codegen narrow_`
- `scripts/rue unit codegen compact_`
- `scripts/rue cli str_type`
- `scripts/rue cli specialization_strings`
- `scripts/rue quick`
- `scripts/rue premerge` (199 targets passed; one unrelated watch timing case timed out under full local load twice and passed in isolation)

Fixes RUE-1731