### PR TITLE
RUE-1705: diagnose conflicting import spellings

### DIFF
--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -375,6 +375,100 @@ error_contains = ["E0714", "the specifier is empty"]
 compile_stderr_not_contains = ["E0713", "/_.rue"]
 
 [[case]]
+name = "hard_link_import_alias_is_e0715"
+description = "RUE-1705: distinct logical imports backed by one hard-linked file produce a coded import-site diagnostic; hard-link creation failure is reported explicitly by the harness."
+files = [
+    { path = "main.rue", source = """
+const a = @import("a.rue");
+const b = @import("b.rue");
+fn main() -> i32 { 0 }
+""" },
+    { path = "real.rue", source = "pub fn value() -> i32 { 1 }" },
+]
+hard_links = [
+    { link = "a.rue", target = "real.rue" },
+    { link = "b.rue", target = "real.rue" },
+]
+compile_fail = true
+error_contains = ["E0715", "a.rue", "b.rue", "same physical file", "under one name"]
+
+[[case]]
+name = "hard_link_import_alias_is_e0715_json"
+description = "RUE-1705: the hard-link alias diagnostic keeps its import-site span and stable code in JSON presentation."
+files = [
+    { path = "main.rue", source = """
+const a = @import("a.rue");
+const b = @import("b.rue");
+fn main() -> i32 { 0 }
+""" },
+    { path = "real.rue", source = "pub fn value() -> i32 { 1 }" },
+]
+hard_links = [
+    { link = "a.rue", target = "real.rue" },
+    { link = "b.rue", target = "real.rue" },
+]
+args = ["--error-format", "json", "main.rue"]
+compile_fail = true
+json_diagnostics = true
+error_contains = ["E0715"]
+json_diagnostic_order = ["error E0715 main.rue:2:11"]
+
+[[case]]
+name = "hard_link_import_to_root_is_e0715"
+description = "RUE-1705 control path: an imported hard link to the root is rejected at its import site while the root remains the assembled representative."
+files = [
+    { path = "main.rue", source = """
+const alias = @import("alias.rue");
+fn main() -> i32 { 0 }
+""" },
+]
+hard_links = [{ link = "alias.rue", target = "main.rue" }]
+compile_fail = true
+error_contains = ["E0715", "main.rue", "alias.rue", "same physical file"]
+
+[[case]]
+name = "symlink_import_alias_remains_deduplicated"
+description = "RUE-1705 control: a symlink alias canonicalizes to the same path and remains a valid repeated import."
+files = [
+    { path = "main.rue", source = """
+const real = @import("real.rue");
+const alias = @import("alias.rue");
+fn main() -> i32 { 0 }
+""" },
+    { path = "real.rue", source = "pub fn value() -> i32 { 1 }" },
+]
+symlinks = [{ link = "alias.rue", target = "real.rue" }]
+compile_only = true
+
+[[case]]
+name = "repeated_logical_import_remains_valid"
+description = "RUE-1705 control: repeated imports under one logical identity remain valid."
+files = [
+    { path = "main.rue", source = """
+const first = @import("real.rue");
+const second = @import("real.rue");
+fn main() -> i32 { 0 }
+""" },
+    { path = "real.rue", source = "pub fn value() -> i32 { 1 }" },
+]
+compile_only = true
+
+[[case]]
+name = "case_alias_import_is_e0715_on_case_insensitive_fs"
+description = "RUE-1705: distinct non-symlink case spellings of one file produce a coded import-site diagnostic; the harness explicitly ignores this case on case-sensitive filesystems."
+files = [
+    { path = "main.rue", source = """
+const lower = @import("real.rue");
+const upper = @import("REAL.rue");
+fn main() -> i32 { 0 }
+""" },
+    { path = "real.rue", source = "pub fn value() -> i32 { 1 }" },
+]
+requires_case_insensitive_fs = true
+compile_fail = true
+error_contains = ["E0715", "real.rue", "REAL.rue", "same physical file"]
+
+[[case]]
 name = "emit_deps_malformed_import_has_no_envelope"
 description = "RUE-810: malformed import shape has no canonical unresolved topology and emits diagnostics without JSON."
 files = [

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -64,6 +64,11 @@
 //!   is the only way a case can set up a symlink — a `files` entry always
 //!   produces a regular file — which filesystem-facing cases need in order to
 //!   pin symlink behavior (`std.fs` cannot create one either)
+//! - `hard_links`: regular hard links created after `files`, as
+//!   `[{ link = "alias.rue", target = "real.rue" }]`; the harness reports a
+//!   fixture error explicitly if the host cannot create hard links
+//! - `requires_case_insensitive_fs`: report the case as ignored with an
+//!   explicit capability reason when the host preserves case-sensitive names
 //! - `env`: extra env vars for the compiler; the value `"${REAL_STD}"`
 //!   expands to the absolute path of the repo's `std/` directory
 //! - `program_args`: command-line arguments for the compiled program's run
@@ -1050,6 +1055,16 @@ struct SymlinkFixture {
     target: String,
 }
 
+/// A regular hard link staged after the source files. Hard-link support is a
+/// filesystem capability of the test host, so failure is reported rather than
+/// silently turning a regression case into an ordinary-file control.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct HardLinkFixture {
+    link: String,
+    target: String,
+}
+
 /// Imperative end-to-end watch scenario. These cases use the watch protocol
 /// seam in `rue` to synchronize edits and then terminate the watch process;
 /// ordinary CLI cases remain declarative and use the normal compile/run path.
@@ -1112,6 +1127,14 @@ struct Case {
     /// symlink behavior.
     #[serde(default)]
     symlinks: Vec<SymlinkFixture>,
+    /// Hard links staged in the temp directory alongside `files`.
+    #[serde(default)]
+    hard_links: Vec<HardLinkFixture>,
+    /// Run only when distinct path spellings differing by case resolve to one
+    /// file. Hosts without that filesystem capability report an explicit
+    /// ignored result rather than dropping the regression.
+    #[serde(default)]
+    requires_case_insensitive_fs: bool,
     /// Repo-root-relative source file to compile directly instead of copying
     /// inline source into the temp directory. Use this when a CLI case should
     /// pin a checked-in example/program rather than duplicating its source.
@@ -2021,6 +2044,8 @@ fn case_runs_prebuilt_program(case: &Case) -> bool {
         // environment as the compile path, so all of these carry over.
         files: _,
         symlinks: _,
+        hard_links: _,
+        requires_case_insensitive_fs: _,
         program_args: _,
         program_env: _,
         stdin: _,
@@ -2171,6 +2196,27 @@ fn run_case(
             TestFailure::fatal(format!(
                 "failed to symlink {} -> {}: {}",
                 symlink.link, symlink.target, e
+            ))
+        })?;
+    }
+
+    // Staged hard links. Created after regular files so each target is known
+    // to exist; unsupported filesystems fail the case explicitly.
+    for hard_link in &case.hard_links {
+        let link = dir.join(&hard_link.link);
+        let target = dir.join(&hard_link.target);
+        if let Some(parent) = link.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                TestFailure::fatal(format!(
+                    "failed to create dir for hard link {}: {}",
+                    hard_link.link, e
+                ))
+            })?;
+        }
+        std::fs::hard_link(&target, &link).map_err(|e| {
+            TestFailure::fatal(format!(
+                "hard-link capability unavailable for {} -> {}: {}",
+                hard_link.link, hard_link.target, e
             ))
         })?;
     }
@@ -2567,6 +2613,23 @@ fn run_watch_case(
             TestFailure::fatal(format!("failed to create watch symlink: {error}"))
         })?;
     }
+    for hard_link in &case.hard_links {
+        let link = dir.join(&hard_link.link);
+        let target = dir.join(&hard_link.target);
+        if let Some(parent) = link.parent() {
+            std::fs::create_dir_all(parent).map_err(|error| {
+                TestFailure::fatal(format!(
+                    "failed to create watch hard-link directory: {error}"
+                ))
+            })?;
+        }
+        std::fs::hard_link(&target, &link).map_err(|error| {
+            TestFailure::fatal(format!(
+                "hard-link capability unavailable for watch fixture {} -> {}: {error}",
+                hard_link.link, hard_link.target
+            ))
+        })?;
+    }
 
     let source = scenario
         .source_path
@@ -2897,6 +2960,22 @@ fn run_case_wrapper(
         return ctx.ignore_for("no system `cc` linker driver on PATH");
     }
 
+    if case.requires_case_insensitive_fs {
+        match case_insensitive_filesystem_available() {
+            Ok(true) => {}
+            Ok(false) => {
+                return ctx.ignore_for(
+                    "requires a case-insensitive filesystem for distinct case aliases",
+                );
+            }
+            Err(error) => {
+                return Err(RunError::fail(format!(
+                    "could not probe case-insensitive filesystem capability: {error}"
+                )));
+            }
+        }
+    }
+
     // Host-dependent cases: only run on the listed platforms.
     if !case.only_on.is_empty()
         && !case
@@ -2940,6 +3019,22 @@ fn run_case_wrapper(
             KnownBugDisposition::Ignore(reason) => ctx.ignore_for(reason),
             KnownBugDisposition::Fail(reason) => Err(RunError::fail(reason)),
         },
+    }
+}
+
+fn case_insensitive_filesystem_available() -> Result<bool, String> {
+    let directory = tempfile::tempdir().map_err(|error| error.to_string())?;
+    let upper = directory.path().join("RueCaseProbe");
+    let lower = directory.path().join("ruecaseprobe");
+    std::fs::write(&upper, b"probe").map_err(|error| error.to_string())?;
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&lower)
+    {
+        Ok(_) => Ok(false),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(true),
+        Err(error) => Err(error.to_string()),
     }
 }
 

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -328,6 +328,7 @@ impl ImportObservationStatus {
 pub struct AcceptedImportSource {
     requested_path: Arc<str>,
     canonical_path: Arc<str>,
+    symlink_route: Arc<[PhysicalFileIdentity]>,
     metadata_identity: PhysicalFileIdentity,
     metadata_fingerprint: FileMetadataFingerprint,
     content_fingerprint: u64,
@@ -349,6 +350,7 @@ impl AcceptedImportSource {
         Ok(Self {
             requested_path,
             canonical_path,
+            symlink_route: Arc::from([]),
             metadata_identity,
             metadata_fingerprint,
             content_fingerprint,
@@ -360,6 +362,17 @@ impl AcceptedImportSource {
     }
     pub fn canonical_path(&self) -> &str {
         &self.canonical_path
+    }
+    /// Record the ordered physical identities of symlink components traversed
+    /// below the host's captured logical boundary. This is host evidence, not
+    /// part of the physical observation identity: two routes are aliases only
+    /// when they resolve through different symlink components.
+    pub fn with_symlink_route(mut self, route: Arc<[PhysicalFileIdentity]>) -> Self {
+        self.symlink_route = route;
+        self
+    }
+    pub fn symlink_route(&self) -> &[PhysicalFileIdentity] {
+        &self.symlink_route
     }
     pub fn content_fingerprint(&self) -> u64 {
         self.content_fingerprint
@@ -1100,6 +1113,11 @@ pub struct ImportDiscoveryWave {
     /// Modules whose occurrences are already accounted for — the revision's own
     /// modules plus everything the wave has read.
     known_modules: BTreeSet<ModuleId>,
+    /// Physical representatives already assembled before this wave. This
+    /// prevents a hard-link import of the root (or another carried source)
+    /// from manufacturing a second parsed module that the assembler will not
+    /// publish.
+    known_physical: BTreeMap<PhysicalFileIdentity, ModuleId>,
     /// This hop's deduplicated host operations and the occurrence requests each
     /// one answers.
     requests: Vec<ImportDiscoveryRequest>,
@@ -1124,10 +1142,11 @@ pub struct ImportDiscoveryWave {
 impl ImportDiscoveryWave {
     /// Begin a wave from a round's starting frontier. `ledger` is the revision's
     /// carried ledger; `frontier` is the batch the host is about to answer.
-    pub(crate) fn begin(
+    pub(crate) fn begin_with_accepted_reads(
         plan: &ImportDiscoveryPlan,
         frontier: &ImportDemandFrontier,
         ledger: ImportObservationLedger,
+        accepted_reads: Option<&AcceptedReadManifest>,
     ) -> CompileResult<Self> {
         if frontier.mode != ImportDemandMode::Rooted {
             return Err(invalid_input(
@@ -1142,12 +1161,18 @@ impl ImportDiscoveryWave {
             .iter()
             .map(|revision| revision.module.clone())
             .collect();
+        let known_physical = accepted_reads
+            .into_iter()
+            .flat_map(AcceptedReadManifest::iter)
+            .map(|entry| (entry.metadata_identity(), entry.module().clone()))
+            .collect();
         Ok(Self {
             revision: frontier.revision,
             context: plan.context().clone(),
             ledger,
             open,
             known_modules,
+            known_physical,
             requests: frontier.requests.to_vec(),
             fanout: frontier.fanout.to_vec(),
             batch_requests: Vec::new(),
@@ -1224,6 +1249,18 @@ impl ImportDiscoveryWave {
                 source.requested_path(),
                 source.canonical_path(),
             )?;
+            if self
+                .known_physical
+                .contains_key(&source.metadata_identity())
+            {
+                // The physical representative is already known. Its import
+                // occurrence remains in the ledger for close-time diagnostics,
+                // but parsing it as a second logical module would create a
+                // successor source the assembler intentionally does not carry.
+                continue;
+            }
+            self.known_physical
+                .insert(source.metadata_identity(), module.clone());
             if !self.known_modules.insert(module.clone()) {
                 continue;
             }
@@ -1445,7 +1482,15 @@ fn canonicalize_accepted(mut accepted: Vec<&AcceptedImportSource>) -> Vec<&Accep
             .then(left.canonical_path.cmp(&right.canonical_path))
     });
     accepted.dedup_by(|left, right| {
-        left.canonical_path == right.canonical_path
+        // A hard link has a distinct canonical path but is still one physical
+        // source. Keep the first source in canonical request order as the
+        // representative; the complete observation ledger remains available
+        // to the close-time diagnostic projection, which can report the
+        // incompatible logical identities at their import sites. Do not
+        // collapse unlike observations: a changed stamp must still reach the
+        // assembler's fail-closed guard.
+        left.metadata_identity == right.metadata_identity
+            && left.metadata_fingerprint == right.metadata_fingerprint
             && left.content_fingerprint == right.content_fingerprint
     });
     accepted
@@ -1733,6 +1778,7 @@ pub(crate) fn exact_import_diagnostics(
     context: &ImportDiscoveryContext,
     groups: &[Arc<[ImportDiscoveryRequest]>],
     ledger: &ImportObservationLedger,
+    accepted_reads: &AcceptedReadManifest,
 ) -> CompileErrors {
     let mut errors = ImportDiscoveryPlan::shape_diagnostics(program);
     errors.extend(specifier_diagnostics(program));
@@ -1783,6 +1829,27 @@ pub(crate) fn exact_import_diagnostics(
             failed_sites.insert((*site).clone());
         }
     }
+    // The assembler receives one physical representative so that an alias
+    // conflict can reach this canonical close-time projection with the exact
+    // import occurrence spans still available in the ledger. Seed the identity
+    // map with the assembled manifest (including the root), then compare every
+    // winning import under that identity in deterministic occurrence order.
+    let mut physical_modules = BTreeMap::<
+        PhysicalFileIdentity,
+        (ModuleId, Arc<str>, Arc<str>, Arc<[PhysicalFileIdentity]>),
+    >::new();
+    for entry in accepted_reads.iter() {
+        physical_modules
+            .entry(entry.metadata_identity())
+            .or_insert_with(|| {
+                (
+                    entry.module().clone(),
+                    Arc::from(entry.canonical_path()),
+                    safe_import_display(context, entry.requested_path()),
+                    Arc::from(entry.symlink_route().to_vec()),
+                )
+            });
+    }
     for (site, groups) in groups_by_site {
         if failed_sites.contains(site) {
             continue;
@@ -1820,8 +1887,59 @@ pub(crate) fn exact_import_diagnostics(
                 span,
             )),
         }
+        if let Some(source) = winning.as_ref().and_then(|sources| sources.first()) {
+            let module =
+                match classify_module(context, source.requested_path(), source.canonical_path()) {
+                    Ok(module) => module,
+                    Err(error) => {
+                        errors.push(error);
+                        continue;
+                    }
+                };
+            if let Some((previous, previous_canonical, previous_spelling, previous_route)) =
+                physical_modules.get(&source.metadata_identity())
+            {
+                let different_symlink_routes = previous_canonical.as_ref()
+                    == source.canonical_path()
+                    && previous_route.as_ref() != source.symlink_route();
+                if previous != &module && !different_symlink_routes {
+                    errors.push(CompileError::new(
+                        ErrorKind::ImportSpellingsSameFile {
+                            first: previous_spelling.to_string(),
+                            second: site.specifier().to_owned(),
+                        },
+                        span,
+                    ));
+                }
+            } else {
+                physical_modules.insert(
+                    source.metadata_identity(),
+                    (
+                        module,
+                        Arc::from(source.canonical_path()),
+                        Arc::from(site.specifier()),
+                        Arc::from(source.symlink_route().to_vec()),
+                    ),
+                );
+            }
+        }
     }
     errors
+}
+
+/// Render an accepted manifest path without exposing compiler-only logical
+/// module namespaces (notably the NUL-prefixed trusted standard-library IDs).
+fn safe_import_display(context: &ImportDiscoveryContext, path: &str) -> Arc<str> {
+    let path = Path::new(path);
+    if let Some(std_root) = context.std_root()
+        && let Ok(relative) = path.strip_prefix(std_root)
+    {
+        return Arc::from(format!("std/{}", relative.to_string_lossy()));
+    }
+    if let Ok(relative) = path.strip_prefix(context.project_root()) {
+        return Arc::from(relative.to_string_lossy().into_owned());
+    }
+    Arc::from(path.to_string_lossy().into_owned())
 }
 
 pub(crate) fn reduce_exact_import_graph(
@@ -2266,6 +2384,7 @@ pub struct AcceptedReadManifestEntry {
     module: ModuleId,
     requested_path: Arc<str>,
     canonical_path: Arc<str>,
+    symlink_route: Arc<[PhysicalFileIdentity]>,
     metadata_identity: PhysicalFileIdentity,
     metadata_fingerprint: FileMetadataFingerprint,
     content_fingerprint: u64,
@@ -2280,6 +2399,9 @@ impl AcceptedReadManifestEntry {
     }
     pub fn canonical_path(&self) -> &str {
         &self.canonical_path
+    }
+    pub fn symlink_route(&self) -> &[PhysicalFileIdentity] {
+        &self.symlink_route
     }
     pub fn content_fingerprint(&self) -> u64 {
         self.content_fingerprint
@@ -2300,6 +2422,26 @@ impl DiscoverySourceAssembler {
         metadata_identity: PhysicalFileIdentity,
         metadata_fingerprint: FileMetadataFingerprint,
         root_source: Arc<String>,
+    ) -> CompileResult<Self> {
+        Self::new_with_symlink_route(
+            context,
+            root_requested_path,
+            root_canonical_path,
+            metadata_identity,
+            metadata_fingerprint,
+            root_source,
+            Arc::from([]),
+        )
+    }
+
+    pub fn new_with_symlink_route(
+        context: ImportDiscoveryContext,
+        root_requested_path: impl Into<Arc<str>>,
+        root_canonical_path: impl Into<Arc<str>>,
+        metadata_identity: PhysicalFileIdentity,
+        metadata_fingerprint: FileMetadataFingerprint,
+        root_source: Arc<String>,
+        symlink_route: Arc<[PhysicalFileIdentity]>,
     ) -> CompileResult<Self> {
         let requested_path = Arc::from(normalize_absolute(&root_requested_path.into())?);
         let canonical_path = Arc::from(normalize_absolute(&root_canonical_path.into())?);
@@ -2327,6 +2469,7 @@ impl DiscoverySourceAssembler {
                 module: module.clone(),
                 requested_path,
                 canonical_path: canonical_path.clone(),
+                symlink_route,
                 metadata_identity,
                 metadata_fingerprint,
                 content_fingerprint: source_fingerprint(&root_source),
@@ -2359,13 +2502,35 @@ impl DiscoverySourceAssembler {
         metadata_fingerprint: FileMetadataFingerprint,
         source: Arc<String>,
     ) -> CompileResult<bool> {
-        self.add_source(&AcceptedImportSource::new(
-            Arc::from(normalize_absolute(requested_path)?),
-            Arc::from(canonical_path),
+        self.add_explicit_with_symlink_route(
+            requested_path,
+            canonical_path,
             metadata_identity,
             metadata_fingerprint,
             source,
-        )?)
+            Arc::from([]),
+        )
+    }
+
+    pub fn add_explicit_with_symlink_route(
+        &mut self,
+        requested_path: &str,
+        canonical_path: &str,
+        metadata_identity: PhysicalFileIdentity,
+        metadata_fingerprint: FileMetadataFingerprint,
+        source: Arc<String>,
+        symlink_route: Arc<[PhysicalFileIdentity]>,
+    ) -> CompileResult<bool> {
+        self.add_source(
+            &AcceptedImportSource::new(
+                Arc::from(normalize_absolute(requested_path)?),
+                Arc::from(canonical_path),
+                metadata_identity,
+                metadata_fingerprint,
+                source,
+            )?
+            .with_symlink_route(symlink_route),
+        )
     }
 
     pub fn add_plan_reads(
@@ -2382,7 +2547,7 @@ impl DiscoverySourceAssembler {
         self.plan_reads_reduced = self.plan_reads_reduced.saturating_add(reduced.len() as u64);
         let mut added = 0;
         for source in reduced {
-            added += usize::from(self.add_source(source)?);
+            added += usize::from(self.add_reduced_source(source)?);
         }
         Ok(added)
     }
@@ -2403,7 +2568,7 @@ impl DiscoverySourceAssembler {
         self.plan_reads_reduced = self.plan_reads_reduced.saturating_add(reduced.len() as u64);
         let mut added = 0;
         for source in reduced {
-            added += usize::from(self.add_source(source)?);
+            added += usize::from(self.add_reduced_source(source)?);
         }
         Ok(added)
     }
@@ -2425,9 +2590,61 @@ impl DiscoverySourceAssembler {
         self.plan_reads_reduced = self.plan_reads_reduced.saturating_add(reduced.len() as u64);
         let mut added = 0;
         for source in reduced {
-            added += usize::from(self.add_source(source)?);
+            added += usize::from(self.add_reduced_source(source)?);
         }
         Ok(added)
+    }
+
+    /// Reduce a canonical accepted-source projection against sources already
+    /// assembled in this lineage. A root/import alias can share a physical
+    /// identity before the wave's own projection sees both entries; retain the
+    /// existing representative so the assembler backstop remains reserved for
+    /// malformed direct input, while close-time diagnostics reject the alias.
+    fn add_reduced_source(&mut self, source: &AcceptedImportSource) -> CompileResult<bool> {
+        let module = classify_module(
+            &self.context,
+            source.requested_path(),
+            source.canonical_path(),
+        )?;
+        if let Some(previous_identity) = self.canonical_identities.get(source.canonical_path())
+            && previous_identity != &source.metadata_identity
+        {
+            return Err(invalid_input(format!(
+                "canonical source {:?} changed physical identity during discovery epoch",
+                source.canonical_path()
+            )));
+        }
+        if let Some(owner) = self.physical.get(&source.metadata_identity()) {
+            let existing = self
+                .entries
+                .get(&owner.module)
+                .expect("physical map references entry");
+            if source_fingerprint(&existing.source) != source.content_fingerprint {
+                return Err(invalid_input(format!(
+                    "physical source {:?} changed during discovery epoch",
+                    source.canonical_path()
+                )));
+            }
+            let provenance = self
+                .accepted_reads
+                .get(&owner.module)
+                .expect("accepted source retains provenance");
+            if provenance.metadata_identity != source.metadata_identity
+                || provenance.metadata_fingerprint != source.metadata_fingerprint
+            {
+                return Err(invalid_input(format!(
+                    "physical source {:?} metadata changed during discovery epoch",
+                    source.canonical_path()
+                )));
+            }
+            if owner.module != module {
+                // The close-time diagnostic projection owns the user-facing
+                // conflict. All source and observation invariants were checked
+                // above before retaining the existing representative.
+                return Ok(false);
+            }
+        }
+        self.add_source(source)
     }
 
     fn add_source(&mut self, source: &AcceptedImportSource) -> CompileResult<bool> {
@@ -2496,6 +2713,10 @@ impl DiscoverySourceAssembler {
                         .get_mut(&owner.module)
                         .unwrap()
                         .canonical_path = source.canonical_path.clone();
+                    self.accepted_reads
+                        .get_mut(&owner.module)
+                        .unwrap()
+                        .symlink_route = source.symlink_route.clone();
                     self.physical
                         .get_mut(&source.metadata_identity)
                         .unwrap()
@@ -2539,6 +2760,7 @@ impl DiscoverySourceAssembler {
                 module,
                 requested_path: source.requested_path.clone(),
                 canonical_path: source.canonical_path.clone(),
+                symlink_route: source.symlink_route.clone(),
                 metadata_identity: source.metadata_identity,
                 metadata_fingerprint: source.metadata_fingerprint,
                 content_fingerprint: source.content_fingerprint,
@@ -3260,6 +3482,7 @@ mod tests {
                 module: snapshot.module_id(source.file_id).unwrap().clone(),
                 requested_path: Arc::from(source.path),
                 canonical_path: Arc::from(source.path),
+                symlink_route: Arc::from([]),
                 metadata_identity: PhysicalFileIdentity::new(1, source.file_id.index() as u64),
                 metadata_fingerprint: metadata_fingerprint(),
                 content_fingerprint: source_fingerprint(source.source),
@@ -3273,6 +3496,7 @@ mod tests {
             module: ModuleId::from_logical_path(format!("module_{index:04}.rue")).unwrap(),
             requested_path: Arc::from(format!("/project/module_{index:04}.rue").as_str()),
             canonical_path: Arc::from(format!("/project/module_{index:04}.rue").as_str()),
+            symlink_route: Arc::from([]),
             metadata_identity: PhysicalFileIdentity::new(1, identity),
             metadata_fingerprint: metadata_fingerprint(),
             content_fingerprint: index,
@@ -3587,6 +3811,383 @@ mod tests {
                 )
                 .unwrap_err();
             assert!(error.to_string().contains("incompatible logical IDs"));
+        }
+    }
+
+    #[test]
+    fn reduced_alias_conflicts_remain_fail_closed_before_suppression() {
+        let mut assembler = assembler_for_physical_identity_test();
+        assembler
+            .add_explicit(
+                "/project/a.rue",
+                "/real/a.rue",
+                PhysicalFileIdentity::new(9, 9),
+                metadata_fingerprint(),
+                Arc::new("same inode".into()),
+            )
+            .unwrap();
+
+        let mismatched_content = AcceptedImportSource::new(
+            "/project/b.rue",
+            "/real/b.rue",
+            PhysicalFileIdentity::new(9, 9),
+            metadata_fingerprint(),
+            Arc::new("changed content".into()),
+        )
+        .unwrap();
+        assert!(
+            assembler
+                .add_reduced_source(&mismatched_content)
+                .unwrap_err()
+                .to_string()
+                .contains("changed during discovery epoch")
+        );
+
+        let mismatched_metadata = AcceptedImportSource::new(
+            "/project/b.rue",
+            "/real/b.rue",
+            PhysicalFileIdentity::new(9, 9),
+            FileMetadataFingerprint::new(2, 3, 4),
+            Arc::new("same inode".into()),
+        )
+        .unwrap();
+        assert!(
+            assembler
+                .add_reduced_source(&mismatched_metadata)
+                .unwrap_err()
+                .to_string()
+                .contains("metadata changed during discovery epoch")
+        );
+
+        let mismatched_canonical_identity = AcceptedImportSource::new(
+            "/project/a.rue",
+            "/real/a.rue",
+            PhysicalFileIdentity::new(9, 10),
+            metadata_fingerprint(),
+            Arc::new("same inode".into()),
+        )
+        .unwrap();
+        assert!(
+            assembler
+                .add_reduced_source(&mismatched_canonical_identity)
+                .unwrap_err()
+                .to_string()
+                .contains("changed physical identity during discovery epoch")
+        );
+    }
+
+    #[test]
+    fn accepted_projection_deduplicates_hard_links_but_keeps_distinct_logicals_for_diagnostics() {
+        let first = AcceptedImportSource::new(
+            "/project/a.rue",
+            "/real/a.rue",
+            PhysicalFileIdentity::new(9, 9),
+            metadata_fingerprint(),
+            Arc::new("same inode".into()),
+        )
+        .unwrap();
+        let second = AcceptedImportSource::new(
+            "/project/b.rue",
+            "/real/b.rue",
+            PhysicalFileIdentity::new(9, 9),
+            metadata_fingerprint(),
+            Arc::new("same inode".into()),
+        )
+        .unwrap();
+        let reduced = canonicalize_accepted(vec![&second, &first]);
+        assert_eq!(reduced.len(), 1);
+        assert_eq!(reduced[0].requested_path(), "/project/a.rue");
+    }
+
+    #[test]
+    fn hard_link_logical_conflict_is_reported_at_the_later_import_site() {
+        let source = snapshot(
+            &[
+                (
+                    1,
+                    "/project/main.rue",
+                    "main.rue",
+                    "const a = @import(\"a.rue\");\nconst b = @import(\"b.rue\");\nfn main() -> i32 { 0 }",
+                ),
+                (2, "/project/a.rue", "a.rue", "pub fn value() -> i32 { 1 }"),
+            ],
+            1,
+        );
+        let mut session = crate::CompilerSession::new();
+        let plan = session
+            .stage_import_discovery(
+                &source,
+                context(51),
+                accepted_reads(&source),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let mut ledger = ImportObservationLedger::default();
+        for request in plan.pending_requests(&ledger) {
+            let (canonical, source_text) = if request.requested_path().ends_with("/a.rue") {
+                ("/real/a.rue", "pub fn value() -> i32 { 1 }")
+            } else if request.requested_path().ends_with("/b.rue") {
+                ("/real/b.rue", "pub fn value() -> i32 { 1 }")
+            } else {
+                continue;
+            };
+            ledger
+                .record(
+                    ImportObservation::accepted(
+                        request.clone(),
+                        AcceptedImportSource::new(
+                            request.requested_path(),
+                            canonical,
+                            PhysicalFileIdentity::new(1, 2),
+                            metadata_fingerprint(),
+                            Arc::new(source_text.into()),
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                )
+                .unwrap();
+        }
+        let errors = session.close_import_discovery(ledger).unwrap_err();
+        assert!(matches!(
+            &errors.as_slice()[0].kind,
+            ErrorKind::ImportSpellingsSameFile { first, second }
+                if first == "a.rue" && second == "b.rue"
+        ));
+        assert_eq!(errors.as_slice()[0].span().unwrap().start, 38);
+    }
+
+    #[test]
+    fn case_alias_conflict_is_reported_but_symlink_alias_is_deduplicated() {
+        let source = snapshot(
+            &[
+                (
+                    1,
+                    "/project/main.rue",
+                    "main.rue",
+                    "const lower = @import(\"real.rue\");\nconst upper = @import(\"REAL.rue\");\nfn main() -> i32 { 0 }",
+                ),
+                (
+                    2,
+                    "/project/real.rue",
+                    "real.rue",
+                    "pub fn value() -> i32 { 1 }",
+                ),
+            ],
+            1,
+        );
+        let mut session = crate::CompilerSession::new();
+        let plan = session
+            .stage_import_discovery(
+                &source,
+                context(52),
+                accepted_reads(&source),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let mut ledger = ImportObservationLedger::default();
+        for request in plan.pending_requests(&ledger) {
+            ledger
+                .record(
+                    ImportObservation::accepted(
+                        request.clone(),
+                        AcceptedImportSource::new(
+                            request.requested_path(),
+                            "/real/shared.rue",
+                            PhysicalFileIdentity::new(1, 2),
+                            metadata_fingerprint(),
+                            Arc::new("pub fn value() -> i32 { 1 }".into()),
+                        )
+                        .unwrap()
+                        .with_symlink_route(Arc::from([])),
+                    )
+                    .unwrap(),
+                )
+                .unwrap();
+        }
+        let errors = session.close_import_discovery(ledger).unwrap_err();
+        assert!(
+            errors.iter().any(|error| {
+                matches!(
+                    &error.kind,
+                    ErrorKind::ImportSpellingsSameFile { first, second }
+                        if first == "real.rue" && second == "REAL.rue"
+                )
+            }),
+            "{errors:?}"
+        );
+
+        let mut symlink_ledger = ImportObservationLedger::default();
+        for request in plan.pending_requests(&ImportObservationLedger::default()) {
+            let route = request
+                .requested_path()
+                .ends_with("REAL.rue")
+                .then(|| PhysicalFileIdentity::new(9, 99))
+                .map_or_else(|| Arc::from([]), |identity| Arc::from([identity]));
+            symlink_ledger
+                .record(
+                    ImportObservation::accepted(
+                        request.clone(),
+                        AcceptedImportSource::new(
+                            request.requested_path(),
+                            "/real/shared.rue",
+                            PhysicalFileIdentity::new(1, 2),
+                            metadata_fingerprint(),
+                            Arc::new("pub fn value() -> i32 { 1 }".into()),
+                        )
+                        .unwrap()
+                        .with_symlink_route(route),
+                    )
+                    .unwrap(),
+                )
+                .unwrap();
+        }
+        let mut symlink_session = crate::CompilerSession::new();
+        let mut symlink_manifest = accepted_reads(&source).to_vec();
+        symlink_manifest[1].canonical_path = Arc::from("/real/shared.rue");
+        symlink_manifest[1].symlink_route = Arc::from([]);
+        let symlink_plan = symlink_session
+            .stage_import_discovery(
+                &source,
+                context(52),
+                Arc::from(symlink_manifest),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        assert_eq!(symlink_plan.groups(), plan.groups());
+        if let Err(symlink_errors) = symlink_session.close_import_discovery(symlink_ledger) {
+            assert!(
+                !symlink_errors.iter().any(|error| {
+                    matches!(error.kind, ErrorKind::ImportSpellingsSameFile { .. })
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn trusted_manifest_conflict_uses_safe_spellings_at_the_import_site() {
+        let root = FileId::new(1);
+        let trusted_std = FileId::new(2);
+        let trusted_option = FileId::new(3);
+        let metadata = SourceMetadata::new_with_trusted_standard_library(
+            root,
+            AHashMap::from([
+                (root, "/project/main.rue".to_owned()),
+                (trusted_std, "/sdk/_std.rue".to_owned()),
+                (trusted_option, "/sdk/option.rue".to_owned()),
+            ]),
+            AHashMap::from([
+                (root, "main.rue".to_owned()),
+                (trusted_std, "\0rue-std/_std.rue".to_owned()),
+                (trusted_option, "\0rue-std/option.rue".to_owned()),
+            ]),
+            ahash::AHashSet::from([trusted_std, trusted_option]),
+        )
+        .unwrap();
+        let main_text = "const std = @import(\"std\"); fn main() -> i32 { 0 }";
+        let std_text = "pub const lower = @import(\"option.rue\");\npub const upper = @import(\"OPTION.rue\");";
+        let option_text = "pub fn value() -> i32 { 1 }";
+        let source = SourceSnapshot::new(
+            metadata,
+            vec![
+                (root, Arc::new(main_text.into())),
+                (trusted_std, Arc::new(std_text.into())),
+                (trusted_option, Arc::new(option_text.into())),
+            ],
+        )
+        .unwrap();
+        let manifest = AcceptedReadManifest::from_entries(vec![
+            AcceptedReadManifestEntry {
+                module: ModuleId::from_logical_path("main.rue").unwrap(),
+                requested_path: Arc::from("/project/main.rue"),
+                canonical_path: Arc::from("/project/main.rue"),
+                symlink_route: Arc::from([]),
+                metadata_identity: PhysicalFileIdentity::new(1, 1),
+                metadata_fingerprint: metadata_fingerprint(),
+                content_fingerprint: source_fingerprint(main_text),
+            },
+            AcceptedReadManifestEntry {
+                module: ModuleId::from_trusted_standard_library_path("\0rue-std/_std.rue").unwrap(),
+                requested_path: Arc::from("/sdk/_std.rue"),
+                canonical_path: Arc::from("/sdk/_std.rue"),
+                symlink_route: Arc::from([]),
+                metadata_identity: PhysicalFileIdentity::new(1, 2),
+                metadata_fingerprint: metadata_fingerprint(),
+                content_fingerprint: source_fingerprint(std_text),
+            },
+            AcceptedReadManifestEntry {
+                module: ModuleId::from_trusted_standard_library_path("\0rue-std/option.rue")
+                    .unwrap(),
+                requested_path: Arc::from("/sdk/option.rue"),
+                canonical_path: Arc::from("/sdk/option.rue"),
+                symlink_route: Arc::from([]),
+                metadata_identity: PhysicalFileIdentity::new(1, 3),
+                metadata_fingerprint: metadata_fingerprint(),
+                content_fingerprint: source_fingerprint(option_text),
+            },
+        ]);
+        let mut session = crate::CompilerSession::new();
+        let plan = session
+            .stage_import_discovery(
+                &source,
+                context(54),
+                manifest.shared_slice(),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let mut ledger = ImportObservationLedger::default();
+        loop {
+            let pending = plan.pending_requests(&ledger);
+            if pending.is_empty() {
+                break;
+            }
+            for request in pending {
+                let requested = request.requested_path();
+                let observation = if requested.starts_with("/project/") {
+                    ImportObservation::absent(request)
+                } else if requested.ends_with("/option.rue") || requested.ends_with("/OPTION.rue") {
+                    ImportObservation::accepted(
+                        request.clone(),
+                        AcceptedImportSource::new(
+                            requested,
+                            "/sdk/option.rue",
+                            PhysicalFileIdentity::new(1, 3),
+                            metadata_fingerprint(),
+                            Arc::new(option_text.into()),
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap()
+                } else {
+                    ImportObservation::accepted(
+                        request.clone(),
+                        AcceptedImportSource::new(
+                            requested,
+                            "/sdk/_std.rue",
+                            PhysicalFileIdentity::new(1, 2),
+                            metadata_fingerprint(),
+                            Arc::new(std_text.into()),
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap()
+                };
+                ledger.record(observation).unwrap();
+            }
+        }
+        let errors = session.close_import_discovery(ledger).unwrap_err();
+        let diagnostic = errors
+            .iter()
+            .find(|error| matches!(error.kind, ErrorKind::ImportSpellingsSameFile { .. }))
+            .expect("trusted standard-library alias has E0715");
+        match &diagnostic.kind {
+            ErrorKind::ImportSpellingsSameFile { first, second } => {
+                assert_eq!(first, "std/option.rue");
+                assert_eq!(second, "OPTION.rue");
+                assert!(!first.contains('\0'));
+                assert!(!second.contains('\0'));
+            }
+            _ => unreachable!(),
         }
     }
 

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -1537,6 +1537,9 @@ impl RetainedCharge for rue_error::ErrorKind {
                 .retained_charge()
                 .saturating_add(candidate.retained_charge()),
             E::ImportSpecifierAbsolute { path } => path.retained_charge(),
+            E::ImportSpellingsSameFile { first, second } => first
+                .retained_charge()
+                .saturating_add(second.retained_charge()),
             E::MissingFields(value) => (std::mem::size_of_val(value.as_ref()) as u64)
                 .saturating_add(value.struct_name.retained_charge())
                 .saturating_add(value.missing_fields.retained_charge()),

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -1808,13 +1808,28 @@ impl CompilerSession {
         plan: &crate::ImportDiscoveryPlan,
         frontier: &crate::ImportDemandFrontier,
     ) -> crate::CompileResult<crate::ImportDiscoveryWave> {
+        self.begin_import_wave_with_accepted_reads(revision, plan, frontier, None)
+    }
+
+    pub(crate) fn begin_import_wave_with_accepted_reads(
+        &mut self,
+        revision: crate::ImportInputRevision,
+        plan: &crate::ImportDiscoveryPlan,
+        frontier: &crate::ImportDemandFrontier,
+        accepted_reads: Option<&crate::AcceptedReadManifest>,
+    ) -> crate::CompileResult<crate::ImportDiscoveryWave> {
         if frontier.revision() != revision {
             return Err(CompileError::without_span(ErrorKind::InvalidCompilerInput(
                 "discovery wave frontier belongs to a stale immutable revision".into(),
             )));
         }
         let ledger = self.queries.revisioned.import_ledger(revision)?;
-        crate::ImportDiscoveryWave::begin(plan, frontier, ledger)
+        crate::ImportDiscoveryWave::begin_with_accepted_reads(
+            plan,
+            frontier,
+            ledger,
+            accepted_reads,
+        )
     }
 
     /// Record one wave hop's answers and derive the next hop's operations.
@@ -1836,7 +1851,19 @@ impl CompilerSession {
         snapshot: &SourceSnapshot,
         accepted_reads: crate::AcceptedReadManifest,
     ) -> crate::CompileResult<(crate::ImportInputRevision, crate::ImportDemandFrontier)> {
-        let staged_parses = wave.take_staged_parses();
+        // A wave may have parsed a source whose physical identity was already
+        // assembled under another logical module (for example an import hard
+        // link to the root). The assembler retains one representative, so do
+        // not stage a tree for a module absent from the published snapshot.
+        let staged_parses = wave
+            .take_staged_parses()
+            .into_iter()
+            .filter(|staged| {
+                snapshot
+                    .files()
+                    .any(|source| snapshot.module_id(source.file_id) == Some(staged.module()))
+            })
+            .collect();
         let (frontier, observations) = wave.into_batch();
         let revision = self.queries.revisioned.publish_import_batch(
             &frontier,
@@ -2914,6 +2941,7 @@ impl CompilerSession {
             plan.context(),
             &exact_groups,
             check_ledger,
+            &open.accepted_reads,
         );
         if crate::import_discovery::exact_import_has_failures(&exact_groups, check_ledger) {
             self.publish_failed_import_attempt(

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -99,6 +99,18 @@ pub fn begin_import_wave(
     session.begin_import_wave(revision, plan, frontier)
 }
 
+/// Open a discovery wave while seeding it with the physical representatives
+/// already assembled by the filesystem host.
+pub fn begin_import_wave_with_accepted_reads(
+    session: &mut crate::CompilerSession,
+    revision: ImportInputRevision,
+    plan: &crate::ImportDiscoveryPlan,
+    frontier: &ImportDemandFrontier,
+    accepted_reads: &crate::AcceptedReadManifest,
+) -> crate::CompileResult<ImportDiscoveryWave> {
+    session.begin_import_wave_with_accepted_reads(revision, plan, frontier, Some(accepted_reads))
+}
+
 /// Record one wave hop's answers and derive the next hop's operations. The host
 /// supplies only results for the exact batch [`ImportDiscoveryWave::requests`]
 /// named, in that order.

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -438,6 +438,10 @@ impl ErrorCode {
     /// and an absolute specifier would additionally bind the program to one
     /// machine's layout, which project-root-relative identity exists to avoid.
     pub const IMPORT_SPECIFIER_NOT_RELATIVE: Self = Self(714);
+    /// Two logical import spellings resolve to one physical file. Importing a
+    /// physical file under more than one logical identity would make the
+    /// source graph ambiguous (RUE-1705).
+    pub const IMPORT_SPELLINGS_SAME_FILE: Self = Self(715);
 
     // ========================================================================
     // Literal/operator errors (E0800-E0899)
@@ -1790,6 +1794,11 @@ pub enum ErrorKind {
          relative to the importing file"
     )]
     ImportSpecifierAbsolute { path: String },
+    #[error(
+        "import spellings '{first}' and '{second}' refer to the same physical file; \
+         import it under one name"
+    )]
+    ImportSpellingsSameFile { first: String, second: String },
     #[error("standard library not found")]
     StdLibNotFound,
     #[error("{item_kind} `{name}` is private")]
@@ -2258,6 +2267,7 @@ impl ErrorKind {
             ErrorKind::ImportSpecifierEmpty | ErrorKind::ImportSpecifierAbsolute { .. } => {
                 ErrorCode::IMPORT_SPECIFIER_NOT_RELATIVE
             }
+            ErrorKind::ImportSpellingsSameFile { .. } => ErrorCode::IMPORT_SPELLINGS_SAME_FILE,
             ErrorKind::StdLibNotFound => ErrorCode::STD_LIB_NOT_FOUND,
             ErrorKind::PrivateMemberAccess { .. } => ErrorCode::PRIVATE_MEMBER_ACCESS,
             ErrorKind::PrivateUnqualifiedAccess(_) => ErrorCode::PRIVATE_UNQUALIFIED_ACCESS,

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -10,12 +10,12 @@ use rue_compiler::unstable::{
     AcceptedImportSource, DiscoverySourceAssembler, ImportDemandFrontier, ImportDemandMode,
     ImportDiscoveryPlan, ImportDiscoveryRequest, ImportDiscoveryWave, ImportInputRevision,
     ImportObservation, ImportObservationStatus, RootedParkOutcome, TrustedSuccessorDelta,
-    begin_import_input_request, begin_import_wave, close_import_discovery_successor,
-    close_import_input_request, closed_discovery_continuation, discovery_attempt,
-    extend_import_wave, import_demand_frontier_for_roots, import_observation_ledger,
-    plan_delta_roots, plan_round_roots, publish_import_observation_batch, publish_import_wave,
-    publish_trusted_toolchain_successor, rooted_or_toolchain_park,
-    stage_import_discovery_successor, stage_import_input_request,
+    begin_import_input_request, begin_import_wave_with_accepted_reads,
+    close_import_discovery_successor, close_import_input_request, closed_discovery_continuation,
+    discovery_attempt, extend_import_wave, import_demand_frontier_for_roots,
+    import_observation_ledger, plan_delta_roots, plan_round_roots,
+    publish_import_observation_batch, publish_import_wave, publish_trusted_toolchain_successor,
+    rooted_or_toolchain_park, stage_import_discovery_successor, stage_import_input_request,
 };
 #[cfg(test)]
 use rue_compiler::unstable::{
@@ -438,12 +438,58 @@ fn cached_source_for_module(
     })
 }
 
+/// Capture the ordered physical identities of symlink components traversed
+/// below a spelling's logical boundary. Ancestors shared by the host's path
+/// layout (for example `/var -> /private/var`) are deliberately outside the
+/// evidence: only project/std leaf or directory aliases are spelling-specific.
+fn symlink_route(path: &Path, boundary: &Path) -> Arc<[PhysicalFileIdentity]> {
+    let Ok(relative) = path.strip_prefix(boundary) else {
+        return Arc::from([]);
+    };
+    let mut current = boundary.to_path_buf();
+    let mut route = Vec::new();
+    for component in relative.components() {
+        current.push(component.as_os_str());
+        let Ok(metadata) = fs::symlink_metadata(&current) else {
+            continue;
+        };
+        if metadata.file_type().is_symlink()
+            && let Some(identity) = symlink_component_identity(&metadata)
+        {
+            route.push(identity);
+        }
+    }
+    route.into()
+}
+
+#[cfg(unix)]
+fn symlink_component_identity(metadata: &fs::Metadata) -> Option<PhysicalFileIdentity> {
+    use std::os::unix::fs::MetadataExt;
+
+    Some(PhysicalFileIdentity::new(metadata.dev(), metadata.ino()))
+}
+
+#[cfg(not(unix))]
+fn symlink_component_identity(_: &fs::Metadata) -> Option<PhysicalFileIdentity> {
+    None
+}
+
+fn spelling_boundary(context: &ImportDiscoveryContext, requested: &Path) -> PathBuf {
+    context
+        .std_root()
+        .filter(|std_root| requested.starts_with(std_root))
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(context.project_root()))
+}
+
 fn accepted_source_from_read(
     entry: &rue_compiler::AcceptedReadManifestEntry,
     canonical_path: &Path,
     read: StableRead,
     cached_source: Option<Arc<String>>,
+    boundary: &Path,
 ) -> Result<AcceptedImportSource, SourceLoadError> {
+    let symlink_route = symlink_route(Path::new(entry.requested_path()), boundary);
     let observed = AcceptedImportSource::new(
         Arc::from(entry.requested_path()),
         Arc::from(canonical_path.to_string_lossy().into_owned()),
@@ -451,6 +497,7 @@ fn accepted_source_from_read(
         read.fingerprint,
         Arc::new(read.source),
     )
+    .map(|source| source.with_symlink_route(symlink_route.clone()))
     .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
     let source = cached_source
         .filter(|_| observed.content_fingerprint() == entry.content_fingerprint())
@@ -462,6 +509,7 @@ fn accepted_source_from_read(
         read.fingerprint,
         source,
     )
+    .map(|source| source.with_symlink_route(symlink_route))
     .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))
 }
 
@@ -469,6 +517,7 @@ fn reobserve_accepted_reads(
     snapshot: &SourceSnapshot,
     manifest: &AcceptedReadManifest,
     source_manifest: Option<&SourceManifest>,
+    context: &ImportDiscoveryContext,
 ) -> Result<AHashMap<String, AcceptedImportSource>, SourceLoadError> {
     let now = SystemTime::now();
     let mut observed = AHashMap::with_capacity(manifest.len());
@@ -481,6 +530,7 @@ fn reobserve_accepted_reads(
                 ))
             })?;
         let requested_path = Path::new(entry.requested_path());
+        let boundary = spelling_boundary(context, requested_path);
         if source_manifest.is_some_and(|policy| !policy.declares_path_without_probe(requested_path))
         {
             continue;
@@ -517,6 +567,7 @@ fn reobserve_accepted_reads(
                 entry.metadata_fingerprint(),
                 cached_source,
             )
+            .map(|source| source.with_symlink_route(symlink_route(requested_path, &boundary)))
             .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?
         } else {
             let read = match stable_read_to_string(&canonical_path) {
@@ -528,6 +579,7 @@ fn reobserve_accepted_reads(
                 &canonical_path,
                 read,
                 canonical_unchanged.then_some(cached_source.clone()),
+                &boundary,
             )?
         };
         observed.insert(entry.requested_path().to_owned(), accepted);
@@ -589,6 +641,12 @@ fn execute_import_request(
                     read.fingerprint,
                     Arc::new(read.source),
                 )
+                .map(|source| {
+                    source.with_symlink_route(symlink_route(
+                        candidate,
+                        &spelling_boundary(request.context(), candidate),
+                    ))
+                })
                 .expect("stable file reads satisfy accepted import invariants");
                 ImportObservation::accepted(request, accepted)
                     .expect("accepted source matches its compiler request")
@@ -993,8 +1051,15 @@ fn run_import_wave(
     reobserved_reads: Option<&AHashMap<String, AcceptedImportSource>>,
 ) -> Result<(ImportInputRevision, ImportDemandFrontier), SourceLoadError> {
     for attempt in 0..=WAVE_STAMP_RETRIES {
-        let mut wave = begin_import_wave(staging, input_revision, plan, frontier)
-            .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+        let accepted_reads = assembler.accepted_read_manifest();
+        let mut wave = begin_import_wave_with_accepted_reads(
+            staging,
+            input_revision,
+            plan,
+            frontier,
+            &accepted_reads,
+        )
+        .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
         while !wave.is_complete() {
             let observations = wave
                 .requests()
@@ -1386,13 +1451,17 @@ pub(crate) fn discover_and_load_imports(
             ),
         })
     })?;
-    let mut assembler = DiscoverySourceAssembler::new(
+    let mut assembler = DiscoverySourceAssembler::new_with_symlink_route(
         context.clone(),
         root_path.to_string_lossy(),
         root_canonical.to_string_lossy(),
         root_read.identity,
         root_read.fingerprint,
         Arc::new(root_read.source),
+        symlink_route(
+            &root_path,
+            root_path.parent().unwrap_or_else(|| Path::new("/")),
+        ),
     )
     .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
 
@@ -1465,6 +1534,7 @@ pub(crate) fn reload_from_filesystem(
         &result.source_snapshot,
         &result.read_manifest,
         source_manifest.as_ref(),
+        &context,
     )?;
     let root_module = result.source_snapshot.source_revision().root();
     let root_entry = result
@@ -1478,13 +1548,14 @@ pub(crate) fn reload_from_filesystem(
             root_entry.requested_path()
         ))
     })?;
-    let mut assembler = DiscoverySourceAssembler::new(
+    let mut assembler = DiscoverySourceAssembler::new_with_symlink_route(
         context.clone(),
         root.requested_path(),
         root.canonical_path(),
         root.metadata_identity(),
         root.metadata_fingerprint(),
         root.source().clone(),
+        Arc::from(root.symlink_route().to_vec()),
     )
     .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
     // Seed only the root. Reobserved predecessor reads are an observation cache
@@ -2049,12 +2120,13 @@ fn satisfy_toolchain_module_demand(
     })?;
 
     assembler
-        .add_explicit(
+        .add_explicit_with_symlink_route(
             requested.to_string_lossy().as_ref(),
             canonical.to_string_lossy().as_ref(),
             read.identity,
             read.fingerprint,
             Arc::new(read.source),
+            symlink_route(&requested, std_root),
         )
         .map_err(|error| ToolchainIntegrityError::Unreadable {
             logical_path: demand.logical_path().to_owned(),
@@ -2205,6 +2277,55 @@ mod tests {
             parse_source_manifest_entry("dir/trailing-backslash\\"),
             "dir/trailing-backslash\\"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_routes_are_boundary_scoped_and_pair_distinguishing() {
+        let dir = TestDir::new("symlink-evidence-boundary");
+        let actual_project = dir.path.join("actual").join("project");
+        fs::create_dir_all(&actual_project).unwrap();
+        fs::write(actual_project.join("real.rue"), "source").unwrap();
+        let shared = dir.path.join("shared");
+        std::os::unix::fs::symlink(dir.path.join("actual"), &shared).unwrap();
+        let boundary = shared.join("project");
+
+        // The shared prefix is outside the captured project boundary. Direct
+        // spellings, including a case-only alias on a case-insensitive host,
+        // must not inherit symlink evidence from that ancestor.
+        assert!(symlink_route(&boundary.join("real.rue"), &boundary).is_empty());
+        assert!(symlink_route(&boundary.join("REAL.rue"), &boundary).is_empty());
+
+        // A symlink introduced below the boundary remains spelling-specific.
+        let leaf = boundary.join("alias.rue");
+        std::os::unix::fs::symlink("real.rue", &leaf).unwrap();
+        let leaf_route = symlink_route(&leaf, &boundary);
+        assert_eq!(leaf_route.len(), 1);
+        assert_ne!(leaf_route.as_ref(), &[]);
+
+        // Direct and leaf-alias routes differ, so they are aliases that can
+        // safely deduplicate. Two distinct leaf aliases also have distinct
+        // route identities even when they target the same canonical file.
+        let leaf_two = boundary.join("alias-two.rue");
+        std::os::unix::fs::symlink("real.rue", &leaf_two).unwrap();
+        let leaf_two_route = symlink_route(&leaf_two, &boundary);
+        assert_ne!(leaf_route.as_ref(), leaf_two_route.as_ref());
+
+        // A directory symlink below the captured boundary is part of both
+        // spellings' route. This is the case-only alias shape on a
+        // case-insensitive filesystem: both routes are identical and must be
+        // diagnosed rather than treated as distinct symlink aliases.
+        let below_boundary = dir.path.join("below");
+        fs::create_dir_all(below_boundary.join("project")).unwrap();
+        fs::write(below_boundary.join("project").join("real.rue"), "source").unwrap();
+        let project_alias = below_boundary.join("project-alias");
+        std::os::unix::fs::symlink(below_boundary.join("project"), &project_alias).unwrap();
+        let lower = project_alias.join("real.rue");
+        let upper = project_alias.join("REAL.rue");
+        let lower_route = symlink_route(&lower, &below_boundary);
+        let upper_route = symlink_route(&upper, &below_boundary);
+        assert_eq!(lower_route, upper_route);
+        assert_eq!(lower_route.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- report distinct logical import spellings backed by one physical file as spanned `E0715`
- retain symlink and repeated-import deduplication, incremental observation identity, and defensive assembler validation
- add hermetic hard-link text/JSON coverage plus symlink, repeated-import, root-alias, and case-alias controls

## Testing

- `scripts/rue fmt`
- `scripts/rue unit compiler import_discovery` (49 passed)
- `scripts/rue cli modules` (137 passed)
- `scripts/rue quick` (31 targets passed)
- `scripts/rue premerge` (199 targets passed; the full CLI corpus hit an existing watch-protocol timeout also reproduced under contention on clean `origin/trunk`)

Fixes RUE-1705