### PR TITLE
RUE-1727: preserve accessor CFG failure spans

### DIFF
--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -61,6 +61,8 @@ pub(crate) struct CfgBodyInput {
     pub(crate) body_span: Span,
     #[cfg(test)]
     pub(crate) interner_limit: Option<usize>,
+    #[cfg(test)]
+    pub(crate) force_failure: bool,
 }
 
 impl PartialEq for CfgBodyInput {
@@ -69,6 +71,7 @@ impl PartialEq for CfgBodyInput {
             #[cfg(test)]
             {
                 self.interner_limit == other.interner_limit
+                    && self.force_failure == other.force_failure
             }
             #[cfg(not(test))]
             {
@@ -585,6 +588,19 @@ pub(crate) enum CfgValue {
         errors: crate::CompileErrors,
         body_span: Span,
     },
+    /// A caller's optimized CFG observed a raw accessor failure. `origin`
+    /// keeps the callee basis needed to re-anchor retained diagnostics on
+    /// reuse; the value itself is published under the caller's optimized key.
+    AccessorFailure {
+        errors: crate::CompileErrors,
+        origin: CfgFailureOrigin,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CfgFailureOrigin {
+    pub(crate) accessor: crate::FunctionInstanceKey,
+    pub(crate) body_span: Span,
 }
 
 impl RetainedCharge for lasso::ThreadedRodeo {
@@ -821,6 +837,9 @@ impl RetainedCharge for CfgValue {
         match self {
             Self::Available(record) => record.retained_charge(),
             Self::Failure { errors, .. } => errors.retained_charge(),
+            Self::AccessorFailure { errors, origin } => errors
+                .retained_charge()
+                .saturating_add(origin.accessor.retained_charge()),
         }
     }
 }
@@ -841,6 +860,22 @@ pub(crate) fn cfg_value_equal(left: &CfgValue, right: &CfgValue) -> bool {
                 ..
             },
         ) => left_errors == right_errors,
+        (
+            CfgValue::AccessorFailure {
+                errors: left_errors,
+                origin: left_origin,
+                ..
+            },
+            CfgValue::AccessorFailure {
+                errors: right_errors,
+                origin: right_origin,
+                ..
+            },
+        ) => {
+            // Position-only edits keep this terminal reusable; consumers
+            // reproject the retained basis through `origin.accessor`.
+            left_errors == right_errors && left_origin.accessor == right_origin.accessor
+        }
         _ => false,
     }
 }
@@ -868,6 +903,23 @@ pub(crate) fn import_errors(
         .map(|error| error.map_spans(|span| map_span(span, old, new)))
         .collect::<Vec<_>>()
         .into()
+}
+
+pub(crate) fn import_accessor_failure(
+    errors: &crate::CompileErrors,
+    origin: &CfgFailureOrigin,
+    key: &OptimizedCfgQueryKey,
+) -> crate::CompileErrors {
+    let current_accessor_span = key
+        .accessor_dependencies
+        .iter()
+        .find(|dependency| dependency.function == origin.accessor)
+        .map(|dependency| match &dependency.semantic_input {
+            CfgSemanticInput::Body { input, .. } => input.body_span,
+            CfgSemanticInput::DropGlue { body_span, .. } => *body_span,
+        })
+        .expect("published accessor failure must name a dependency");
+    import_errors(errors, origin.body_span, current_accessor_span)
 }
 
 pub(crate) fn import_warnings(
@@ -1009,6 +1061,20 @@ pub(crate) fn evaluate_cfg(
     key: &CfgQueryKey,
 ) -> Result<QueryOutput<CfgValue>, QueryAbort> {
     let _span = tracing::info_span!("cfg_construction", phase = "cfg_and_optimization").entered();
+    #[cfg(test)]
+    if let CfgSemanticInput::Body { input, .. } = &key.semantic_input {
+        if input.force_failure {
+            return Ok(QueryOutput::success(CfgValue::Failure {
+                errors: crate::CompileError::new(
+                    rue_error::ErrorKind::InternalError("test CFG accessor failure".to_owned()),
+                    input.body_span,
+                )
+                .into(),
+                body_span: input.body_span,
+            })
+            .with_terminal_kind(rue_query::QueryTerminalKind::Failure));
+        }
+    }
     let value =
         materialize_and_build_cfg(context, layouts, type_facts, drop_glues, call_abis, key)?;
     let kind = if matches!(value, CfgValue::Failure { .. }) {
@@ -1678,15 +1744,31 @@ pub(crate) fn evaluate_optimized_cfg(
         let QueryOutcome::Success(value) = terminal.outcome() else {
             unreachable!("Cfg publishes typed values")
         };
-        let CfgValue::Available(callee) = value else {
-            return Ok(QueryOutput::success(value.clone())
-                .with_terminal_kind(rue_query::QueryTerminalKind::Failure));
-        };
-        let body_span = match &dependency.semantic_input {
+        let dependency_body_span = match &dependency.semantic_input {
             CfgSemanticInput::Body { input, .. } => input.body_span,
             CfgSemanticInput::DropGlue { body_span, .. } => *body_span,
         };
-        accessor_cfgs.insert(dependency.function.clone(), (callee.clone(), body_span));
+        let CfgValue::Available(callee) = value else {
+            let CfgValue::Failure {
+                errors,
+                body_span: old_span,
+            } = value
+            else {
+                unreachable!("Cfg publishes typed values")
+            };
+            return Ok(QueryOutput::success(CfgValue::AccessorFailure {
+                errors: import_errors(errors, *old_span, dependency_body_span),
+                origin: CfgFailureOrigin {
+                    accessor: dependency.function.clone(),
+                    body_span: dependency_body_span,
+                },
+            })
+            .with_terminal_kind(rue_query::QueryTerminalKind::Failure));
+        };
+        accessor_cfgs.insert(
+            dependency.function.clone(),
+            (callee.clone(), dependency_body_span),
+        );
     }
     let interner =
         match copy_interner_preserving_ordinals(&record.interner, || context.check_canceled()) {

--- a/crates/rue-compiler/src/codegen_query.rs
+++ b/crates/rue-compiler/src/codegen_query.rs
@@ -496,6 +496,13 @@ pub(crate) fn evaluate_codegen_unit(
     if let crate::cfg_query::CfgValue::Failure { errors, .. } = optimized {
         return Ok(codegen_failure(errors.clone()));
     }
+    if let crate::cfg_query::CfgValue::AccessorFailure { errors, origin } = optimized {
+        return Ok(codegen_failure(crate::cfg_query::import_accessor_failure(
+            &errors,
+            &origin,
+            &key.optimized_cfg,
+        )));
+    }
     let crate::cfg_query::CfgValue::Available(record) = optimized else {
         unreachable!("failure handled above")
     };

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -39935,6 +39935,8 @@ fn main() -> i32 {
                         body_span,
                         #[cfg(test)]
                         interner_limit: None,
+                        #[cfg(test)]
+                        force_failure: false,
                     }),
                     materialization: Arc::new(facts),
                 },

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -673,6 +673,10 @@ pub struct CompilerSession {
     /// Test-only bound for the request-local CFG symbol universe.
     #[cfg(test)]
     cfg_interner_limit: Option<usize>,
+    /// Test-only deterministic CFG terminal failure for accessor propagation
+    /// diagnostics. Production never sets this hook.
+    #[cfg(test)]
+    cfg_accessor_failure: bool,
     /// Test-only differential-oracle perturbation requested through the
     /// unstable test bridge. It corrupts a canonical projection at the next
     /// observation point without reviving a retired selected-result store.
@@ -1502,6 +1506,13 @@ impl CompilerSession {
     pub(crate) fn with_cfg_interner_limit(max_entries: usize) -> Self {
         let mut session = Self::default();
         session.cfg_interner_limit = Some(max_entries);
+        session
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_cfg_accessor_failure() -> Self {
+        let mut session = Self::default();
+        session.cfg_accessor_failure = true;
         session
     }
 
@@ -5257,6 +5268,8 @@ impl CompilerSession {
                         body_span,
                         #[cfg(test)]
                         interner_limit: self.cfg_interner_limit,
+                        #[cfg(test)]
+                        force_failure: self.cfg_accessor_failure && semantic_body.is_accessor,
                     }),
                     materialization: Arc::new(materialization),
                 },
@@ -5493,6 +5506,15 @@ impl CompilerSession {
                 } => {
                     return Err(PipelineRequestControl::Compile(
                         crate::cfg_query::import_errors(errors, *old_span, body_span),
+                    ));
+                }
+                crate::cfg_query::CfgValue::AccessorFailure { errors, origin, .. } => {
+                    return Err(PipelineRequestControl::Compile(
+                        crate::cfg_query::import_accessor_failure(
+                            errors,
+                            origin,
+                            &optimized_cfg_key,
+                        ),
                     ));
                 }
             };
@@ -10301,6 +10323,122 @@ mod tests {
         assert!(
             observed,
             "the production CFG query must classify request-local symbol exhaustion"
+        );
+    }
+
+    #[test]
+    fn accessor_cfg_failure_preserves_callee_source_span() {
+        let main = r#"const lib = @import("lib.rue");
+fn main() -> i32 {
+    let value = lib.Box { value: 7 };
+    if value.get() == 7 { 0 } else { 1 }
+}"#;
+        let lib = r#"pub struct Box {
+    value: i32,
+    fn get(borrow self) -> borrow i32 { yield self.value; }
+}"#;
+        let source = snapshot(
+            &[
+                (1, "/p/main.rue", "main.rue", main),
+                (2, "/p/lib.rue", "lib.rue", lib),
+            ],
+            1,
+        );
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::with_cfg_accessor_failure();
+        publish_with_test_imports(&mut session, &source);
+        let errors = session
+            .rooted_cfg(&options)
+            .expect_err("the accessor CFG hook must publish a failure");
+        assert_eq!(errors.len(), 1, "unexpected diagnostics: {errors:?}");
+        assert!(
+            matches!(
+                errors.first().map(|error| &error.kind),
+                Some(ErrorKind::InternalError(message)) if message == "test CFG accessor failure"
+            ),
+            "unexpected diagnostics: {errors:?}"
+        );
+        assert_eq!(
+            errors
+                .first()
+                .and_then(CompileError::span)
+                .map(|span| span.file_id),
+            Some(FileId::new(2)),
+            "accessor failure must remain anchored in the callee module: {errors:?}"
+        );
+
+        let first_span = errors.first().and_then(CompileError::span).unwrap();
+        let shifted_lib = format!("// shift the callee body\n{lib}");
+        let shifted = snapshot(
+            &[
+                (1, "/p/main.rue", "main.rue", main),
+                (2, "/p/lib.rue", "lib.rue", shifted_lib.as_str()),
+            ],
+            1,
+        );
+        publish_with_test_imports(&mut session, &shifted);
+        let shifted_errors = session
+            .rooted_cfg(&options)
+            .expect_err("the shifted accessor CFG must still publish a failure");
+        let shifted_span = shifted_errors
+            .first()
+            .and_then(CompileError::span)
+            .expect("the shifted failure must retain its span");
+        assert_eq!(shifted_span.file_id, FileId::new(2));
+        assert_eq!(
+            shifted_span.start,
+            first_span.start + "// shift the callee body\n".len() as u32,
+            "a reused accessor failure must be remapped to the current callee body"
+        );
+        assert_ne!(shifted_span, first_span);
+        assert!(
+            session
+                .rooted_cfg_executions()
+                .iter()
+                .any(|(function, execution)| {
+                    matches!(
+                        function,
+                        crate::FunctionInstanceKey::Definition(definition)
+                            if definition.name() == "main"
+                    ) && *execution == rue_query::RequestExecution::Reused
+                }),
+            "the shifted diagnostic must come from the retained caller optimized-CFG terminal"
+        );
+    }
+
+    #[test]
+    fn same_file_accessor_cfg_failure_reprojects_without_caller_remap() {
+        let program = r#"struct Box {
+    value: i32,
+    fn get(borrow self) -> borrow i32 { yield self.value; }
+}
+fn main() -> i32 {
+    let value = Box { value: 7 };
+    if value.get() == 7 { 0 } else { 1 }
+}"#;
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::with_cfg_accessor_failure();
+        let source = SourceSnapshot::single("main.rue", program).unwrap();
+        session.update(&source).into_result().unwrap();
+        let first = session
+            .rooted_cfg(&options)
+            .expect_err("the accessor CFG hook must publish a same-file failure");
+        let first_span = first.first().and_then(CompileError::span).unwrap();
+        assert_eq!(first_span.file_id, FileId::new(0));
+
+        let prefix = "// shift the accessor\n";
+        let shifted_source =
+            SourceSnapshot::single("main.rue", format!("{prefix}{program}").as_str()).unwrap();
+        session.update(&shifted_source).into_result().unwrap();
+        let shifted = session
+            .rooted_cfg(&options)
+            .expect_err("the shifted same-file accessor must still fail");
+        let shifted_span = shifted.first().and_then(CompileError::span).unwrap();
+        assert_eq!(shifted_span.file_id, FileId::new(0));
+        assert_eq!(
+            shifted_span.start,
+            first_span.start + prefix.len() as u32,
+            "same-file retained failures must not be remapped into the caller"
         );
     }
 


### PR DESCRIPTION
## Summary

- preserve accessor diagnostic ownership when a raw CFG failure is republished through a caller optimized-CFG key
- reproject retained accessor failures through the current callee span without invalidating position-only query reuse
- cover cross-module reuse and same-file remapping, including direct codegen failure forwarding

## Testing

- `scripts/rue fmt`
- `scripts/rue unit compiler accessor_cfg_failure` (2 passed)
- `scripts/rue quick` (31 targets passed)
- `scripts/rue premerge` (199 targets passed; the CLI watch case `change_after_monitor_stops_is_still_announced` timed out and reproduced in isolation on clean current `origin/trunk`)

Fixes RUE-1727