### PR TITLE
RUE-1795: make type syntax provider state reborrowable

### DIFF
--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -922,6 +922,10 @@ mod tests {
             "the query-backed body host implements the shared fact host exactly once"
         );
         assert!(TYPECK_SOURCE.contains("pub(super) trait TypeSyntaxHost"));
+        let provider_state = item(TYPECK_SOURCE, "pub(super) struct TypeSyntaxProviderState");
+        assert!(!provider_state.contains("&mut H"));
+        assert!(!provider_state.contains("host:"));
+        assert!(!provider_state.contains("Option<&AHashMap"));
         assert!(TYPECK_SOURCE.contains("pub(super) struct TypeSyntaxProvider"));
         assert!(TYPECK_SOURCE.contains("pub(super) enum SemaTypeResolutionContext"));
         assert!(TYPECK_SOURCE.contains("pub(super) fn resolve_array_length_fact("));
@@ -983,6 +987,10 @@ mod tests {
                 method.contains(provider),
                 "the provider host constructs the generic evaluator"
             );
+            assert!(
+                method.contains("TypeSyntaxProviderState::new"),
+                "the provider host owns state before borrowing the semantic host"
+            );
             assert!(!method.contains("SemaTypeSyntaxProvider"));
         }
         assert!(!TYPECK_SOURCE.contains("SemaTypeSyntaxProvider"));
@@ -992,7 +1000,22 @@ mod tests {
                 .matches("pub fn resolve_structured_semantic_type_syntax_with<")
                 .count(),
             1,
-            "all storage hosts share one recursive structured policy"
+            "all storage hosts share one structured-type machine"
+        );
+        let structured_resolver = item(
+            SEMANTIC_TYPE_RESOLUTION_SOURCE,
+            "pub fn resolve_structured_semantic_type_syntax_with<",
+        );
+        assert!(
+            structured_resolver.contains("StructuredTypeWork::Evaluate"),
+            "the canonical structured resolver must drive its owned work stack"
+        );
+        assert_eq!(
+            structured_resolver
+                .matches("resolve_structured_semantic_type_syntax_with(")
+                .count(),
+            0,
+            "the canonical structured resolver must not self-dispatch recursively"
         );
         for forbidden in [
             "pub fn resolve_semantic_type_syntax",

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -32,7 +32,7 @@ use super::ordinary_engine::{
 use super::semantic_body_export::SemanticBodyExportHost;
 use super::typeck::{
     SemaTypeResolutionContext, TypeRootAuthority, TypeSyntaxHost, TypeSyntaxNamedKind,
-    TypeSyntaxProvider, semantic_type_syntax_compile_error,
+    TypeSyntaxProvider, TypeSyntaxProviderState, semantic_type_syntax_compile_error,
 };
 use super::{
     AnalyzedFunction, BodyAnalysisWork, BodyFactProvider, ConstInfo, ConstValue,
@@ -191,6 +191,188 @@ fn synthetic_argument_names_match_the_canonical_spelling_without_a_heap_buffer()
     for index in [0, 9, 10, 1_024, usize::MAX] {
         let symbol = intern_synthetic_argument_name(&interner, index);
         assert_eq!(interner.resolve(&symbol), format!("arg{index}"));
+    }
+}
+
+#[cfg(test)]
+mod type_syntax_provider_trace_tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct SymbolTrace {
+        symbol_lookups: usize,
+    }
+
+    impl TypeSyntaxHost for SymbolTrace {
+        fn type_syntax_symbol(&mut self, _name: &str) -> Spur {
+            self.symbol_lookups += 1;
+            panic!("the no-substitution path must not intern a symbol")
+        }
+
+        fn type_syntax_module_binding(
+            &mut self,
+            _authority: TypeRootAuthority,
+            _module: Option<ModuleId>,
+            _name: Spur,
+        ) -> CompileResult<Option<crate::SemanticModuleBinding<ModuleId, FileId>>> {
+            panic!("unused test host hook")
+        }
+
+        fn type_syntax_module_display_name(&self, _module: ModuleId) -> Arc<str> {
+            panic!("unused test host hook")
+        }
+
+        fn type_syntax_accessing_domain(
+            &self,
+            _authority: TypeRootAuthority,
+        ) -> crate::SemanticVisibilityDomain {
+            panic!("unused test host hook")
+        }
+
+        fn type_syntax_named_type(
+            &mut self,
+            _authority: TypeRootAuthority,
+            _module: Option<ModuleId>,
+            _name: Spur,
+            _kind: TypeSyntaxNamedKind,
+        ) -> CompileResult<Option<crate::SemanticTypeFact<Type, FileId>>> {
+            panic!("unused test host hook")
+        }
+
+        fn type_syntax_make_str(&mut self, _span: Span) -> CompileResult<Type> {
+            panic!("unused test host hook")
+        }
+
+        fn type_syntax_make_array(
+            &mut self,
+            _element: Type,
+            _length: u64,
+            _span: Span,
+        ) -> CompileResult<Type> {
+            panic!("unused test host hook")
+        }
+
+        fn type_syntax_make_ptr_const(
+            &mut self,
+            _pointee: Type,
+            _span: Span,
+        ) -> CompileResult<Type> {
+            panic!("unused test host hook")
+        }
+
+        fn type_syntax_make_ptr_mut(&mut self, _pointee: Type, _span: Span) -> CompileResult<Type> {
+            panic!("unused test host hook")
+        }
+
+        fn type_syntax_make_slice(
+            &mut self,
+            _syntax: &str,
+            _element: Type,
+            _span: Span,
+        ) -> CompileResult<Type> {
+            panic!("unused test host hook")
+        }
+
+        fn type_syntax_make_fixed_str(
+            &mut self,
+            _capacity: u64,
+            _span: Span,
+        ) -> CompileResult<Type> {
+            panic!("unused test host hook")
+        }
+
+        fn type_syntax_record_builtin_call(&mut self) {
+            panic!("unused test host hook")
+        }
+
+        fn type_syntax_constructor(
+            &mut self,
+            _authority: TypeRootAuthority,
+            _module: Option<ModuleId>,
+            _name: Spur,
+        ) -> CompileResult<Option<crate::SemanticTypeConstructorHead<Spur, Spur, FileId>>> {
+            panic!("unused test host hook")
+        }
+
+        fn type_syntax_reduce_constructor(
+            &mut self,
+            _head: &crate::SemanticTypeConstructorHead<Spur, Spur, FileId>,
+            _type_arguments: &[(Spur, Type)],
+            _value_arguments: &[(Spur, ConstValue)],
+            _span: Span,
+        ) -> CompileResult<Option<ConstValue>> {
+            panic!("unused test host hook")
+        }
+
+        fn type_syntax_value_const(
+            &self,
+            _file: FileId,
+            _name: Spur,
+        ) -> Option<super::super::info::ConstInfo> {
+            panic!("unused test host hook")
+        }
+
+        fn type_syntax_recover_const(
+            &mut self,
+            _file: FileId,
+            _name: Spur,
+        ) -> CompileResult<Option<ConstValue>> {
+            panic!("unused test host hook")
+        }
+
+        fn type_syntax_record_named_const_dependency(&mut self, _file: FileId, _name: String) {
+            panic!("unused test host hook")
+        }
+
+        fn type_syntax_out_of_scope_const_hint(&self, _name: Spur, _exclude: FileId) -> String {
+            panic!("unused test host hook")
+        }
+
+        fn type_syntax_dependencies(
+            &self,
+            _ty: Type,
+        ) -> Vec<(
+            FileId,
+            String,
+            super::super::DeclarationTypeDependencyTargetKind,
+        )> {
+            panic!("unused test host hook")
+        }
+
+        fn type_syntax_flush_dependency(
+            &mut self,
+            _file: FileId,
+            _name: String,
+            _kind: super::super::DeclarationTypeDependencyTargetKind,
+        ) {
+            panic!("unused test host hook")
+        }
+    }
+
+    #[test]
+    fn missing_substitutions_skip_symbol_lookup() {
+        let mut host = SymbolTrace::default();
+        let mut state = TypeSyntaxProviderState::new(
+            Span::new(0, 1),
+            TypeRootAuthority::in_file(FileId::new(0)),
+            SemaTypeResolutionContext::Type,
+            None,
+            None,
+        );
+        let result = {
+            let mut provider = TypeSyntaxProvider::new(&mut host, &mut state);
+            <TypeSyntaxProvider<'_, '_, SymbolTrace> as crate::SemanticTypeSyntaxProvider<
+                FileId,
+                ModuleId,
+                FileId,
+                Spur,
+                Spur,
+                Type,
+                ConstValue,
+            >>::substituted_type(&mut provider, &FileId::new(0), "T")
+        };
+        assert_eq!(result.unwrap(), None);
+        assert_eq!(host.symbol_lookups, 0);
     }
 }
 
@@ -3871,21 +4053,24 @@ where
         crate::SemanticTypeSyntaxError<std::convert::Infallible, CompileError, FileId, Spur>,
     > {
         let interner = Arc::clone(&self.interner);
-        let mut provider = TypeSyntaxProvider::new(
-            self,
+        let mut state = TypeSyntaxProviderState::new(
             request.span,
             TypeRootAuthority::in_file(request.root_file),
             SemaTypeResolutionContext::Type,
             request.type_substitutions,
             request.value_substitutions,
         );
-        let result = crate::resolve_structured_semantic_type_syntax_with(
-            &mut provider,
-            &request.root_file,
-            &request.syntax.arena,
-            request.syntax.root,
-            |symbol| interner.resolve(symbol),
-        );
+        let result = {
+            let mut provider = TypeSyntaxProvider::new(self, &mut state);
+            crate::resolve_structured_semantic_type_syntax_with(
+                &mut provider,
+                &request.root_file,
+                &request.syntax.arena,
+                request.syntax.root,
+                |symbol| interner.resolve(symbol),
+            )
+        };
+        let mut provider = TypeSyntaxProvider::new(self, &mut state);
         provider.flush_observed_type_dependencies();
         result
     }
@@ -3894,22 +4079,21 @@ where
         &mut self,
         request: ModulePrefixRequest<'_>,
     ) -> CompileResult<(ModuleId, Option<FileId>, String)> {
-        let mut provider = TypeSyntaxProvider::new(
-            self,
+        let mut state = TypeSyntaxProviderState::new(
             request.span,
             TypeRootAuthority::in_file(request.root_file),
             SemaTypeResolutionContext::Type,
             None,
             None,
         );
-        let resolved = crate::resolve_semantic_module_path(
-            &mut provider,
-            &request.root_file,
-            request.segments,
-        )
+        let resolved = {
+            let mut provider = TypeSyntaxProvider::new(self, &mut state);
+            crate::resolve_semantic_module_path(&mut provider, &request.root_file, request.segments)
+        }
         .map_err(|failure| {
             super::typeck::module_path_resolution_compile_error(failure, request.span)
         })?;
+        let mut provider = TypeSyntaxProvider::new(self, &mut state);
         provider.flush_observed_type_dependencies();
         let definition = self.calls.module_def(resolved.module).ok_or_else(|| {
             CompileError::new(
@@ -3928,15 +4112,18 @@ where
     }
 
     fn resolve_array_length(&mut self, request: ArrayLengthRequest<'_>) -> CompileResult<u64> {
-        let mut provider = TypeSyntaxProvider::new(
-            self,
+        let mut state = TypeSyntaxProviderState::new(
             request.span,
             TypeRootAuthority::in_file(request.span.file_id),
             SemaTypeResolutionContext::Type,
             None,
             request.value_substitutions,
         );
-        let result = provider.resolve_array_length_fact(request.span.file_id, request.length);
+        let result = {
+            let mut provider = TypeSyntaxProvider::new(self, &mut state);
+            provider.resolve_array_length_fact(request.span.file_id, request.length)
+        };
+        let mut provider = TypeSyntaxProvider::new(self, &mut state);
         provider.flush_observed_type_dependencies();
         result
     }

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -116,17 +116,23 @@ pub(super) enum TypeSyntaxNamedKind {
 
 type ObservedTypeDependency = (FileId, String, super::DeclarationTypeDependencyTargetKind);
 
-pub(super) struct TypeSyntaxProvider<'host, 'c, H: TypeSyntaxHost> {
-    host: &'host mut H,
+pub(super) struct TypeSyntaxProviderState {
     span: Span,
     root_authority: TypeRootAuthority,
     resolution_context: SemaTypeResolutionContext,
-    type_substitutions: Option<&'c AHashMap<Spur, Type>>,
-    value_substitutions: Option<&'c AHashMap<Spur, ConstValue>>,
+    type_substitutions: Option<AHashMap<Spur, Type>>,
+    value_substitutions: Option<AHashMap<Spur, ConstValue>>,
     // Preserve observation order for the host while using a lazy membership
     // index once a resolution grows beyond the allocation-free small case.
     observed_type_dependencies: Vec<ObservedTypeDependency>,
     observed_type_dependency_index: Option<AHashSet<ObservedTypeDependency>>,
+}
+
+/// Short-lived adapter that borrows the semantic host only while a provider
+/// operation is in progress. The reusable state contains no host reference.
+pub(super) struct TypeSyntaxProvider<'host, 'state, H: TypeSyntaxHost> {
+    host: &'host mut H,
+    state: &'state mut TypeSyntaxProviderState,
 }
 
 /// The lexical root a type-syntax resolution walks from.
@@ -184,10 +190,11 @@ impl<H: TypeSyntaxHost> crate::SemanticModulePathProvider<FileId, crate::types::
     ) -> SemaProviderResult<Option<crate::SemanticModuleBinding<crate::types::ModuleId, FileId>>>
     {
         let symbol = self.host.type_syntax_symbol(name);
-        provider_failure(
-            self.host
-                .type_syntax_module_binding(self.root_authority, None, symbol),
-        )
+        provider_failure(self.host.type_syntax_module_binding(
+            self.state.root_authority,
+            None,
+            symbol,
+        ))
     }
 
     fn module_binding(
@@ -198,7 +205,7 @@ impl<H: TypeSyntaxHost> crate::SemanticModulePathProvider<FileId, crate::types::
     {
         let name = self.host.type_syntax_symbol(name);
         provider_failure(self.host.type_syntax_module_binding(
-            self.root_authority,
+            self.state.root_authority,
             Some(*module),
             name,
         ))
@@ -209,7 +216,8 @@ impl<H: TypeSyntaxHost> crate::SemanticModulePathProvider<FileId, crate::types::
     }
 
     fn accessing_domain(&self, _scope: &FileId) -> crate::SemanticVisibilityDomain {
-        self.host.type_syntax_accessing_domain(self.root_authority)
+        self.host
+            .type_syntax_accessing_domain(self.state.root_authority)
     }
 }
 
@@ -229,11 +237,15 @@ impl<H: TypeSyntaxHost>
         _scope: &FileId,
         name: &str,
     ) -> SemaProviderResult<Option<Type>> {
-        let Some(type_substitutions) = self.type_substitutions else {
+        if self.state.type_substitutions.is_none() {
             return Ok(None);
-        };
+        }
         let symbol = self.host.type_syntax_symbol(name);
-        Ok(type_substitutions.get(&symbol).copied())
+        Ok(self
+            .state
+            .type_substitutions
+            .as_ref()
+            .and_then(|substitutions| substitutions.get(&symbol).copied()))
     }
 
     fn primitive_type(&mut self, name: &str) -> SemaProviderResult<Option<Type>> {
@@ -242,7 +254,7 @@ impl<H: TypeSyntaxHost>
 
     fn builtin_type(&mut self, _scope: &FileId, name: &str) -> SemaProviderResult<Option<Type>> {
         if name == "str" {
-            provider_failure(self.host.type_syntax_make_str(self.span).map(Some))
+            provider_failure(self.host.type_syntax_make_str(self.state.span).map(Some))
         } else {
             Ok(None)
         }
@@ -255,7 +267,7 @@ impl<H: TypeSyntaxHost>
     ) -> SemaProviderResult<Option<crate::SemanticTypeFact<Type, FileId>>> {
         let symbol = self.host.type_syntax_symbol(name);
         provider_failure(self.host.type_syntax_named_type(
-            self.root_authority,
+            self.state.root_authority,
             None,
             symbol,
             TypeSyntaxNamedKind::Struct,
@@ -269,7 +281,7 @@ impl<H: TypeSyntaxHost>
     ) -> SemaProviderResult<Option<crate::SemanticTypeFact<Type, FileId>>> {
         let symbol = self.host.type_syntax_symbol(name);
         provider_failure(self.host.type_syntax_named_type(
-            self.root_authority,
+            self.state.root_authority,
             None,
             symbol,
             TypeSyntaxNamedKind::Enum,
@@ -283,7 +295,7 @@ impl<H: TypeSyntaxHost>
     ) -> SemaProviderResult<Option<crate::SemanticTypeFact<Type, FileId>>> {
         let symbol = self.host.type_syntax_symbol(name);
         provider_failure(self.host.type_syntax_named_type(
-            self.root_authority,
+            self.state.root_authority,
             None,
             symbol,
             TypeSyntaxNamedKind::Alias,
@@ -297,7 +309,7 @@ impl<H: TypeSyntaxHost>
     ) -> SemaProviderResult<Option<crate::SemanticTypeFact<Type, FileId>>> {
         let symbol = self.host.type_syntax_symbol(name);
         provider_failure(self.host.type_syntax_named_type(
-            self.root_authority,
+            self.state.root_authority,
             Some(*module),
             symbol,
             TypeSyntaxNamedKind::Struct,
@@ -311,7 +323,7 @@ impl<H: TypeSyntaxHost>
     ) -> SemaProviderResult<Option<crate::SemanticTypeFact<Type, FileId>>> {
         let symbol = self.host.type_syntax_symbol(name);
         provider_failure(self.host.type_syntax_named_type(
-            self.root_authority,
+            self.state.root_authority,
             Some(*module),
             symbol,
             TypeSyntaxNamedKind::Enum,
@@ -325,7 +337,7 @@ impl<H: TypeSyntaxHost>
     ) -> SemaProviderResult<Option<crate::SemanticTypeFact<Type, FileId>>> {
         let symbol = self.host.type_syntax_symbol(name);
         provider_failure(self.host.type_syntax_named_type(
-            self.root_authority,
+            self.state.root_authority,
             Some(*module),
             symbol,
             TypeSyntaxNamedKind::Alias,
@@ -368,7 +380,7 @@ impl<H: TypeSyntaxHost>
         _scope: &FileId,
         expectation: crate::SemanticComptimeCallExpectation,
     ) -> bool {
-        !(self.resolution_context == SemaTypeResolutionContext::ArrayLength
+        !(self.state.resolution_context == SemaTypeResolutionContext::ArrayLength
             && expectation == crate::SemanticComptimeCallExpectation::Value)
     }
 
@@ -384,7 +396,7 @@ impl<H: TypeSyntaxHost>
                         ErrorKind::InvalidArrayLength {
                             reason: format!("array length must be non-negative, got {value}"),
                         },
-                        self.span,
+                        self.state.span,
                     ))
                 })?;
                 ArrayLen::Literal(value)
@@ -405,14 +417,14 @@ impl<H: TypeSyntaxHost>
                     ErrorKind::InvalidArrayLength {
                         reason: format!("array length must be non-negative, got {value}"),
                     },
-                    self.span,
+                    self.state.span,
                 ))
             }),
             _ => provider_failure(Err(CompileError::new(
                 ErrorKind::InvalidArrayLength {
                     reason: "array length must be an integer".to_string(),
                 },
-                self.span,
+                self.state.span,
             ))),
         }
     }
@@ -421,16 +433,19 @@ impl<H: TypeSyntaxHost>
         provider_failure(self.host.type_syntax_make_array(
             element,
             length.expect("concrete type resolution always resolves array lengths"),
-            self.span,
+            self.state.span,
         ))
     }
 
     fn ptr_const_type(&mut self, pointee: Type) -> SemaProviderResult<Type> {
-        provider_failure(self.host.type_syntax_make_ptr_const(pointee, self.span))
+        provider_failure(
+            self.host
+                .type_syntax_make_ptr_const(pointee, self.state.span),
+        )
     }
 
     fn ptr_mut_type(&mut self, pointee: Type) -> SemaProviderResult<Type> {
-        provider_failure(self.host.type_syntax_make_ptr_mut(pointee, self.span))
+        provider_failure(self.host.type_syntax_make_ptr_mut(pointee, self.state.span))
     }
 
     fn slice_type(
@@ -439,7 +454,10 @@ impl<H: TypeSyntaxHost>
         syntax: &str,
         element: Type,
     ) -> SemaProviderResult<Type> {
-        provider_failure(self.host.type_syntax_make_slice(syntax, element, self.span))
+        provider_failure(
+            self.host
+                .type_syntax_make_slice(syntax, element, self.state.span),
+        )
     }
 
     fn builtin_type_call(
@@ -456,7 +474,7 @@ impl<H: TypeSyntaxHost>
                             ErrorKind::InvalidArrayLength {
                                 reason: format!("array length must be non-negative, got {value}"),
                             },
-                            self.span,
+                            self.state.span,
                         ))
                     })?
                 }
@@ -469,14 +487,14 @@ impl<H: TypeSyntaxHost>
                 _ => {
                     return provider_failure(Err(CompileError::new(
                         ErrorKind::UnknownType(format!("{name}(...)")),
-                        self.span,
+                        self.state.span,
                     )));
                 }
             };
             self.host.type_syntax_record_builtin_call();
             provider_failure(
                 self.host
-                    .type_syntax_make_fixed_str(capacity, self.span)
+                    .type_syntax_make_fixed_str(capacity, self.state.span)
                     .map(Some),
             )
         } else {
@@ -492,7 +510,7 @@ impl<H: TypeSyntaxHost>
         let symbol = self.host.type_syntax_symbol(name);
         provider_failure(
             self.host
-                .type_syntax_constructor(self.root_authority, None, symbol),
+                .type_syntax_constructor(self.state.root_authority, None, symbol),
         )
     }
 
@@ -503,7 +521,7 @@ impl<H: TypeSyntaxHost>
     ) -> SemaProviderResult<Option<crate::SemanticTypeConstructorHead<Spur, Spur, FileId>>> {
         let symbol = self.host.type_syntax_symbol(name);
         provider_failure(self.host.type_syntax_constructor(
-            self.root_authority,
+            self.state.root_authority,
             Some(*module),
             symbol,
         ))
@@ -524,7 +542,9 @@ impl<H: TypeSyntaxHost>
         }
         match self.resolve_value_argument_fact(*scope, constructor, syntax) {
             Ok(value) => Ok(value),
-            Err(error) if self.resolution_context == SemaTypeResolutionContext::ArrayLength => {
+            Err(error)
+                if self.state.resolution_context == SemaTypeResolutionContext::ArrayLength =>
+            {
                 let crate::SemanticValueSyntax::Name(name) = syntax else {
                     return provider_failure(Err(error));
                 };
@@ -545,7 +565,12 @@ impl<H: TypeSyntaxHost>
     ) -> SemaProviderResult<Option<crate::SemanticComptimeCallResult<Type, ConstValue>>> {
         provider_failure(
             self.host
-                .type_syntax_reduce_constructor(head, type_arguments, value_arguments, self.span)
+                .type_syntax_reduce_constructor(
+                    head,
+                    type_arguments,
+                    value_arguments,
+                    self.state.span,
+                )
                 .map(|result| match (head.returns_type, result) {
                     (_, None) => None,
                     (true, Some(ConstValue::Type(ty))) => {
@@ -559,35 +584,72 @@ impl<H: TypeSyntaxHost>
 }
 
 impl<'s, 'c, H: TypeSyntaxHost> TypeSyntaxProvider<'s, 'c, H> {
+    pub(super) fn new(host: &'s mut H, state: &'c mut TypeSyntaxProviderState) -> Self {
+        Self { host, state }
+    }
+}
+
+impl TypeSyntaxProviderState {
     pub(super) fn new(
-        host: &'s mut H,
         span: Span,
         root_authority: TypeRootAuthority,
         resolution_context: SemaTypeResolutionContext,
-        type_substitutions: Option<&'c AHashMap<Spur, Type>>,
-        value_substitutions: Option<&'c AHashMap<Spur, ConstValue>>,
+        type_substitutions: Option<&AHashMap<Spur, Type>>,
+        value_substitutions: Option<&AHashMap<Spur, ConstValue>>,
     ) -> Self {
         Self {
-            host,
             span,
             root_authority,
             resolution_context,
-            type_substitutions,
-            value_substitutions,
+            type_substitutions: type_substitutions.cloned(),
+            value_substitutions: value_substitutions.cloned(),
             observed_type_dependencies: Vec::new(),
             observed_type_dependency_index: None,
         }
     }
 
+    fn observe_type_dependency(
+        &mut self,
+        file: FileId,
+        name: String,
+        kind: super::DeclarationTypeDependencyTargetKind,
+    ) {
+        const LINEAR_ADMISSION_LIMIT: usize = 8;
+
+        let dependency = (file, name, kind);
+        if let Some(index) = &mut self.observed_type_dependency_index {
+            if index.insert(dependency.clone()) {
+                self.observed_type_dependencies.push(dependency);
+            }
+            return;
+        }
+        if !self.observed_type_dependencies.contains(&dependency) {
+            self.observed_type_dependencies.push(dependency);
+            if self.observed_type_dependencies.len() == LINEAR_ADMISSION_LIMIT {
+                self.observed_type_dependency_index =
+                    Some(self.observed_type_dependencies.iter().cloned().collect());
+            }
+        }
+    }
+
+    fn take_observed_type_dependencies(&mut self) -> Vec<ObservedTypeDependency> {
+        if let Some(index) = &mut self.observed_type_dependency_index {
+            index.clear();
+        }
+        std::mem::take(&mut self.observed_type_dependencies)
+    }
+}
+
+impl<'s, 'c, H: TypeSyntaxHost> TypeSyntaxProvider<'s, 'c, H> {
     pub(super) fn resolve_array_length_fact(
         &mut self,
         scope: FileId,
         length: &ArrayLen,
     ) -> CompileResult<u64> {
-        let previous_context = self.resolution_context;
-        self.resolution_context = SemaTypeResolutionContext::ArrayLength;
+        let previous_context = self.state.resolution_context;
+        self.state.resolution_context = SemaTypeResolutionContext::ArrayLength;
         let result = self.resolve_array_length_fact_inner(scope, length);
-        self.resolution_context = previous_context;
+        self.state.resolution_context = previous_context;
         result
     }
 
@@ -603,9 +665,11 @@ impl<'s, 'c, H: TypeSyntaxHost> TypeSyntaxProvider<'s, 'c, H> {
             return Ok(*value);
         };
         let symbol = self.host.type_syntax_symbol(name);
-        let root_file = self.root_authority.file();
+        let root_file = self.state.root_authority.file();
         let value = if let Some(value) = self
+            .state
             .value_substitutions
+            .as_ref()
             .and_then(|substitutions| substitutions.get(&symbol))
         {
             *value
@@ -641,7 +705,7 @@ impl<'s, 'c, H: TypeSyntaxHost> TypeSyntaxProvider<'s, 'c, H> {
     }
 
     fn invalid_array_length(&self, reason: String) -> CompileError {
-        CompileError::new(ErrorKind::InvalidArrayLength { reason }, self.span)
+        CompileError::new(ErrorKind::InvalidArrayLength { reason }, self.state.span)
     }
 
     fn observe_materialized_type_fact(&mut self, ty: Type) {
@@ -651,10 +715,7 @@ impl<'s, 'c, H: TypeSyntaxHost> TypeSyntaxProvider<'s, 'c, H> {
     }
 
     pub(super) fn flush_observed_type_dependencies(&mut self) {
-        if let Some(index) = &mut self.observed_type_dependency_index {
-            index.clear();
-        }
-        for (file, name, kind) in std::mem::take(&mut self.observed_type_dependencies) {
+        for (file, name, kind) in self.state.take_observed_type_dependencies() {
             self.host.type_syntax_flush_dependency(file, name, kind);
         }
     }
@@ -665,22 +726,7 @@ impl<'s, 'c, H: TypeSyntaxHost> TypeSyntaxProvider<'s, 'c, H> {
         name: String,
         kind: super::DeclarationTypeDependencyTargetKind,
     ) {
-        const LINEAR_ADMISSION_LIMIT: usize = 8;
-
-        let dependency = (file, name, kind);
-        if let Some(index) = &mut self.observed_type_dependency_index {
-            if index.insert(dependency.clone()) {
-                self.observed_type_dependencies.push(dependency);
-            }
-            return;
-        }
-        if !self.observed_type_dependencies.contains(&dependency) {
-            self.observed_type_dependencies.push(dependency);
-            if self.observed_type_dependencies.len() == LINEAR_ADMISSION_LIMIT {
-                self.observed_type_dependency_index =
-                    Some(self.observed_type_dependencies.iter().cloned().collect());
-            }
-        }
+        self.state.observe_type_dependency(file, name, kind);
     }
 
     fn resolve_value_argument_fact(
@@ -702,19 +748,19 @@ impl<'s, 'c, H: TypeSyntaxHost> TypeSyntaxProvider<'s, 'c, H> {
             return Ok(ConstValue::Bool(false));
         }
         let symbol = self.host.type_syntax_symbol(text);
-        if let Some(value_substitutions) = self.value_substitutions
+        if let Some(value_substitutions) = &self.state.value_substitutions
             && let Some(value) = value_substitutions.get(&symbol)
         {
             return Ok(*value);
         }
-        if let Some(type_substitutions) = self.type_substitutions
+        if let Some(type_substitutions) = &self.state.type_substitutions
             && let Some(ty) = type_substitutions.get(&symbol)
         {
             return Ok(ConstValue::Type(*ty));
         }
         if let Some(info) = self
             .host
-            .type_syntax_value_const(self.root_authority.file(), symbol)
+            .type_syntax_value_const(self.state.root_authority.file(), symbol)
         {
             return Ok(info.value);
         }
@@ -725,7 +771,7 @@ impl<'s, 'c, H: TypeSyntaxHost> TypeSyntaxProvider<'s, 'c, H> {
                     text, constructor
                 ),
             },
-            self.span,
+            self.state.span,
         ))
     }
 }
@@ -1071,5 +1117,57 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// saturated value is never used for real allocation.
     pub(crate) fn abi_slot_count(&self, ty: Type) -> u32 {
         self.body_type_pool().provisional_abi_slot_count(ty)
+    }
+}
+
+#[cfg(test)]
+mod type_syntax_provider_state_tests {
+    use super::*;
+
+    #[test]
+    fn dependencies_survive_reborrows_and_flush_once() {
+        let mut state = TypeSyntaxProviderState::new(
+            Span::new(0, 1),
+            TypeRootAuthority::in_file(FileId::new(0)),
+            SemaTypeResolutionContext::Type,
+            None,
+            None,
+        );
+
+        // These calls model separate short-lived provider borrows. The state
+        // owns ordering and deduplication, so neither borrow can lose
+        // observations before the host flushes them.
+        state.observe_type_dependency(
+            FileId::new(1),
+            "Outer".to_owned(),
+            super::super::DeclarationTypeDependencyTargetKind::Struct,
+        );
+        state.observe_type_dependency(
+            FileId::new(2),
+            "Inner".to_owned(),
+            super::super::DeclarationTypeDependencyTargetKind::Enum,
+        );
+        state.observe_type_dependency(
+            FileId::new(1),
+            "Outer".to_owned(),
+            super::super::DeclarationTypeDependencyTargetKind::Struct,
+        );
+
+        assert_eq!(
+            state.take_observed_type_dependencies(),
+            vec![
+                (
+                    FileId::new(1),
+                    "Outer".to_owned(),
+                    super::super::DeclarationTypeDependencyTargetKind::Struct,
+                ),
+                (
+                    FileId::new(2),
+                    "Inner".to_owned(),
+                    super::super::DeclarationTypeDependencyTargetKind::Enum,
+                ),
+            ]
+        );
+        assert!(state.take_observed_type_dependencies().is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- split type-syntax provider state from its short-lived mutable host adapter
- snapshot substitutions and preserve ordered dependency observations across host reborrows
- strengthen single-machine and host-ownership structural guards
- pin the no-substitution fast path so it performs no symbol interning

This is behavior-neutral Step 3A. Typed resolver suspension and engine orchestration remain separate staged work.

## Validation
- `scripts/rue unit air type_syntax` (5 passed)
- `scripts/rue unit air typeck` (2 passed)
- `scripts/rue unit air consistency` (17 passed)
- `scripts/rue quick` (31 targets passed)
- `scripts/rue fmt`
- `git diff --check`

skip RUE-1795