### PR TITLE
RUE-1720: persist bounded nightly fuzz corpora

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -5,6 +5,12 @@ on:
     - cron: '0 0 * * *'  # Daily at midnight UTC
   workflow_dispatch:  # Allow manual triggering
 
+concurrency:
+  # A campaign mutates the per-target cache lineage. Schedule and manual runs
+  # must serialize so two immutable generations cannot fork from one restore.
+  group: fuzz-corpus-mutation
+  cancel-in-progress: false
+
 # Crashes are filed in Linear (RUE-802); GitHub Issues is the fallback used when
 # the LINEAR_API_KEY secret is missing. The default GITHUB_TOKEN is read-only,
 # and without issues:write that fallback fails with "Resource not accessible by
@@ -40,7 +46,99 @@ jobs:
             dotslash-linux-x64-
 
       - name: Create seed corpus
-        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --init-corpus crates/rue-fuzz/corpus
+        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --init-corpus crates/rue-fuzz/spec-seeds
+
+      # Evolved bytes are untrusted. Each target has a separate staging path,
+      # immutable generation key, and stable schema+target fallback. The
+      # prepare command validates content-addressed regular files and writes a
+      # clean tree; only that clean tree is ever used or saved.
+      - name: Restore lexer corpus
+        uses: actions/cache/restore@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/lexer
+          key: rue-fuzz-corpus-v3-lexer-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: rue-fuzz-corpus-v3-lexer-
+      - name: Restore parser corpus
+        uses: actions/cache/restore@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/parser
+          key: rue-fuzz-corpus-v3-parser-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: rue-fuzz-corpus-v3-parser-
+      - name: Restore sema corpus
+        uses: actions/cache/restore@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/sema
+          key: rue-fuzz-corpus-v3-sema-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: rue-fuzz-corpus-v3-sema-
+      - name: Restore compiler corpus
+        uses: actions/cache/restore@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/compiler
+          key: rue-fuzz-corpus-v3-compiler-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: rue-fuzz-corpus-v3-compiler-
+      - name: Restore compiler AArch64 corpus
+        uses: actions/cache/restore@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/compiler_aarch64
+          key: rue-fuzz-corpus-v3-compiler_aarch64-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: rue-fuzz-corpus-v3-compiler_aarch64-
+      - name: Restore compiler O1 corpus
+        uses: actions/cache/restore@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/compiler_x86_64_o1
+          key: rue-fuzz-corpus-v3-compiler_x86_64_o1-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: rue-fuzz-corpus-v3-compiler_x86_64_o1-
+      - name: Restore payload schemas corpus
+        uses: actions/cache/restore@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/payload_schemas
+          key: rue-fuzz-corpus-v3-payload_schemas-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: rue-fuzz-corpus-v3-payload_schemas-
+      - name: Restore emitter corpus
+        uses: actions/cache/restore@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/emitter
+          key: rue-fuzz-corpus-v3-emitter-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: rue-fuzz-corpus-v3-emitter-
+      - name: Restore AArch64 emitter corpus
+        uses: actions/cache/restore@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/emitter_aarch64
+          key: rue-fuzz-corpus-v3-emitter_aarch64-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: rue-fuzz-corpus-v3-emitter_aarch64-
+      - name: Restore emitter sequence corpus
+        uses: actions/cache/restore@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/emitter_sequence
+          key: rue-fuzz-corpus-v3-emitter_sequence-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: rue-fuzz-corpus-v3-emitter_sequence-
+      - name: Restore AArch64 emitter sequence corpus
+        uses: actions/cache/restore@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/emitter_sequence_aarch64
+          key: rue-fuzz-corpus-v3-emitter_sequence_aarch64-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: rue-fuzz-corpus-v3-emitter_sequence_aarch64-
+
+      - name: Prepare isolated target corpora
+        run: |
+          set -eu
+          list_out="$(./buck2 run //crates/rue-fuzz:rue-fuzz -- --list 2>&1)"
+          targets=()
+          while IFS= read -r target; do
+            [ -n "$target" ] && targets[${#targets[@]}]="$target"
+          done < <(printf '%s\n' "$list_out" \
+            | awk '/^Available fuzz targets:/{f=1;next} f && /^  [a-z][a-z0-9_]*$/{print $1}')
+          if [ "${#targets[@]}" -eq 0 ]; then
+            echo "::error::could not enumerate fuzz targets for corpus assembly"
+            exit 1
+          fi
+          for target in "${targets[@]}"; do
+            ./buck2 run //crates/rue-fuzz:rue-fuzz -- \
+              --prepare-corpus="crates/rue-fuzz/nightly-restored/$target" \
+              --fresh-corpus=crates/rue-fuzz/spec-seeds \
+              --input-corpus="crates/rue-fuzz/nightly-input/$target" \
+              --output-corpus="crates/rue-fuzz/nightly-corpus/$target"
+          done
 
       # Guard against RUE-515 recurring: `emitter_aarch64` was registered in the
       # fuzzer but never invoked here, so aarch64 codegen got no nightly
@@ -51,7 +149,10 @@ jobs:
         run: |
           NIGHTLY_EXEMPT=""   # none currently exempt
           list_out="$(./buck2 run //crates/rue-fuzz:rue-fuzz -- --list 2>&1 || true)"
-          mapfile -t targets < <(printf '%s\n' "$list_out" \
+          targets=()
+          while IFS= read -r target; do
+            [ -n "$target" ] && targets[${#targets[@]}]="$target"
+          done < <(printf '%s\n' "$list_out" \
             | awk '/^Available fuzz targets:/{f=1;next} f && /^  [a-z][a-z0-9_]*$/{print $1}')
           if [ "${#targets[@]}" -eq 0 ]; then
             echo "::error::could not enumerate fuzz targets from --list"; exit 1
@@ -59,11 +160,16 @@ jobs:
           missing=()
           for t in "${targets[@]}"; do
             case " $NIGHTLY_EXEMPT " in *" $t "*) continue ;; esac
-            grep -qE -- "--max-time=[0-9]+ ${t} " .github/workflows/fuzz.yml || missing+=("$t")
+            grep -qF -- "--mutate --max-time=300 --evolve-corpus=crates/rue-fuzz/nightly-corpus/${t} ${t} crates/rue-fuzz/nightly-input/${t}" .github/workflows/fuzz.yml || missing+=("$t")
+            grep -qF -- "path: crates/rue-fuzz/nightly-restored/${t}" .github/workflows/fuzz.yml || missing+=("${t}:restore-path")
+            restored_paths="$(grep -cF -- "path: crates/rue-fuzz/nightly-restored/${t}" .github/workflows/fuzz.yml || true)"
+            [ "$restored_paths" -ge 2 ] || missing+=("${t}:save-path")
+            grep -qF -- "key: rue-fuzz-corpus-v3-${t}-${{ github.run_id }}-${{ github.run_attempt }}" .github/workflows/fuzz.yml || missing+=("${t}:generation-key")
+            grep -qF -- "restore-keys: rue-fuzz-corpus-v3-${t}-" .github/workflows/fuzz.yml || missing+=("${t}:restore-prefix")
           done
           if [ "${#missing[@]}" -ne 0 ]; then
-            echo "::error::registered fuzz target(s) not scheduled in fuzz.yml: ${missing[*]}"
-            echo "Add a '--max-time' fuzz step (plus the aggregation and notify entries), or add the target to NIGHTLY_EXEMPT."
+            echo "::error::registered fuzz target(s) not scheduled with an isolated five-minute corpus step: ${missing[*]}"
+            echo "Add the exact '--max-time=300' step (plus aggregation, reporting, and cache save entries), or add the target to NIGHTLY_EXEMPT."
             exit 1
           fi
           echo "All ${#targets[@]} registered fuzz targets are scheduled: ${targets[*]}"
@@ -76,25 +182,25 @@ jobs:
         id: fuzz-lexer
         continue-on-error: true
         timeout-minutes: 10
-        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 lexer crates/rue-fuzz/corpus
+        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 --evolve-corpus=crates/rue-fuzz/nightly-corpus/lexer lexer crates/rue-fuzz/nightly-input/lexer
 
       - name: Fuzz parser (5 minutes)
         id: fuzz-parser
         continue-on-error: true
         timeout-minutes: 10
-        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 parser crates/rue-fuzz/corpus
+        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 --evolve-corpus=crates/rue-fuzz/nightly-corpus/parser parser crates/rue-fuzz/nightly-input/parser
 
       - name: Fuzz sema (5 minutes)
         id: fuzz-sema
         continue-on-error: true
         timeout-minutes: 10
-        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 sema crates/rue-fuzz/corpus
+        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 --evolve-corpus=crates/rue-fuzz/nightly-corpus/sema sema crates/rue-fuzz/nightly-input/sema
 
       - name: Fuzz compiler (5 minutes)
         id: fuzz-compiler
         continue-on-error: true
         timeout-minutes: 10
-        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 compiler crates/rue-fuzz/corpus
+        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 --evolve-corpus=crates/rue-fuzz/nightly-corpus/compiler compiler crates/rue-fuzz/nightly-input/compiler
 
       # These source-level variants stay on the x86-64 runner: they compile
       # deterministic source inputs to finished images but never execute the
@@ -105,43 +211,43 @@ jobs:
         id: fuzz-compiler-aarch64
         continue-on-error: true
         timeout-minutes: 10
-        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 compiler_aarch64 crates/rue-fuzz/corpus
+        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 --evolve-corpus=crates/rue-fuzz/nightly-corpus/compiler_aarch64 compiler_aarch64 crates/rue-fuzz/nightly-input/compiler_aarch64
 
       - name: Fuzz compiler (x86-64 Linux O1, 5 minutes)
         id: fuzz-compiler-x86-64-o1
         continue-on-error: true
         timeout-minutes: 10
-        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 compiler_x86_64_o1 crates/rue-fuzz/corpus
+        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 --evolve-corpus=crates/rue-fuzz/nightly-corpus/compiler_x86_64_o1 compiler_x86_64_o1 crates/rue-fuzz/nightly-input/compiler_x86_64_o1
 
       - name: Fuzz payload schemas (5 minutes)
         id: fuzz-payload-schemas
         continue-on-error: true
         timeout-minutes: 10
-        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 payload_schemas crates/rue-fuzz/corpus
+        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 --evolve-corpus=crates/rue-fuzz/nightly-corpus/payload_schemas payload_schemas crates/rue-fuzz/nightly-input/payload_schemas
 
       - name: Fuzz x86-64 emitter (5 minutes)
         id: fuzz-emitter
         continue-on-error: true
         timeout-minutes: 10
-        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 emitter crates/rue-fuzz/corpus
+        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 --evolve-corpus=crates/rue-fuzz/nightly-corpus/emitter emitter crates/rue-fuzz/nightly-input/emitter
 
       - name: Fuzz aarch64 emitter (5 minutes)
         id: fuzz-emitter-aarch64
         continue-on-error: true
         timeout-minutes: 10
-        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 emitter_aarch64 crates/rue-fuzz/corpus
+        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 --evolve-corpus=crates/rue-fuzz/nightly-corpus/emitter_aarch64 emitter_aarch64 crates/rue-fuzz/nightly-input/emitter_aarch64
 
       - name: Fuzz x86-64 emitter sequences (5 minutes)
         id: fuzz-emitter-sequence
         continue-on-error: true
         timeout-minutes: 10
-        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 emitter_sequence crates/rue-fuzz/corpus
+        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 --evolve-corpus=crates/rue-fuzz/nightly-corpus/emitter_sequence emitter_sequence crates/rue-fuzz/nightly-input/emitter_sequence
 
       - name: Fuzz aarch64 emitter sequences (5 minutes)
         id: fuzz-emitter-sequence-aarch64
         continue-on-error: true
         timeout-minutes: 10
-        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 emitter_sequence_aarch64 crates/rue-fuzz/corpus
+        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 --evolve-corpus=crates/rue-fuzz/nightly-corpus/emitter_sequence_aarch64 emitter_sequence_aarch64 crates/rue-fuzz/nightly-input/emitter_sequence_aarch64
 
       # Differential fuzzing: generate valid programs and cross-check the
       # rue-oracle reference interpreter against the compiled native binary
@@ -231,3 +337,104 @@ jobs:
             --crash-dir crates/rue-fuzz/crashes \
             --failed-targets "$failed" \
             --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
+      # Cache restores and saves must use the same workspace path. Publish the
+      # clean output over each staging tree through the bounded Rust copier;
+      # no shell command handles restored filenames. This step is unconditional
+      # so a reporting failure cannot prevent successful evolution from being
+      # persisted.
+      - name: Publish clean fuzz corpora to cache staging
+        id: publish_clean_corpus
+        if: always()
+        run: |
+          set -eu
+          list_out="$(./buck2 run //crates/rue-fuzz:rue-fuzz -- --list 2>&1)"
+          while IFS= read -r target; do
+            [ -n "$target" ] || continue
+            ./buck2 run //crates/rue-fuzz:rue-fuzz -- \
+              --publish-corpus="crates/rue-fuzz/nightly-corpus/$target" \
+              --cache-corpus="crates/rue-fuzz/nightly-restored/$target"
+          done < <(printf '%s\n' "$list_out" \
+            | awk '/^Available fuzz targets:/{f=1;next} f && /^  [a-z][a-z0-9_]*$/{print $1}')
+
+      # Cache entries are immutable. Save a fresh generation for every target
+      # even when fuzzing/reporting failed; cache-service errors stay
+      # non-blocking and cannot mask the aggregate result. Only clean bounded
+      # per-target byte corpora are saved.
+      - name: Save lexer corpus
+        if: always() && steps.publish_clean_corpus.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/lexer
+          key: rue-fuzz-corpus-v3-lexer-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Save parser corpus
+        if: always() && steps.publish_clean_corpus.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/parser
+          key: rue-fuzz-corpus-v3-parser-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Save sema corpus
+        if: always() && steps.publish_clean_corpus.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/sema
+          key: rue-fuzz-corpus-v3-sema-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Save compiler corpus
+        if: always() && steps.publish_clean_corpus.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/compiler
+          key: rue-fuzz-corpus-v3-compiler-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Save compiler AArch64 corpus
+        if: always() && steps.publish_clean_corpus.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/compiler_aarch64
+          key: rue-fuzz-corpus-v3-compiler_aarch64-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Save compiler O1 corpus
+        if: always() && steps.publish_clean_corpus.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/compiler_x86_64_o1
+          key: rue-fuzz-corpus-v3-compiler_x86_64_o1-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Save payload schemas corpus
+        if: always() && steps.publish_clean_corpus.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/payload_schemas
+          key: rue-fuzz-corpus-v3-payload_schemas-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Save emitter corpus
+        if: always() && steps.publish_clean_corpus.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/emitter
+          key: rue-fuzz-corpus-v3-emitter-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Save AArch64 emitter corpus
+        if: always() && steps.publish_clean_corpus.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/emitter_aarch64
+          key: rue-fuzz-corpus-v3-emitter_aarch64-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Save emitter sequence corpus
+        if: always() && steps.publish_clean_corpus.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/emitter_sequence
+          key: rue-fuzz-corpus-v3-emitter_sequence-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Save AArch64 emitter sequence corpus
+        if: always() && steps.publish_clean_corpus.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/emitter_sequence_aarch64
+          key: rue-fuzz-corpus-v3-emitter_sequence_aarch64-${{ github.run_id }}-${{ github.run_attempt }}

--- a/crates/rue-cli-tests/cases/std_net_tcp.toml
+++ b/crates/rue-cli-tests/cases/std_net_tcp.toml
@@ -271,11 +271,15 @@ fn main() -> i32 {
 """ }]
 stdout = "1\n2\n3\n4\n5\n6\n"
 
-# Connecting to a just-released ephemeral port is refused, exercising errno
-# normalization (ECONNREFUSED -> ConnectionRefused) through a real syscall.
+# Keep an un-listened socket bound to the kernel-selected loopback port while
+# connecting to it. A closed listener leaves a port-0 reuse window: another
+# thread/process can claim the port before connect(2), turning this into a
+# flaky success. A bound, never-listened socket reserves the exact 4-tuple and
+# makes Linux return ECONNREFUSED deterministically. The raw syscall setup is
+# test-local and leaves std.net's production/runtime behavior untouched.
 [[case]]
 name = "tcp_connection_refused"
-description = "connect() to a closed loopback port normalizes to ConnectionRefused."
+description = "connect() to a bound but never-listened loopback port normalizes to ConnectionRefused."
 env = { RUE_STD_PATH = "${REAL_STD}" }
 args = ["main.rue", "-o", "prog"]
 only_on = ["x86-64-linux", "aarch64-linux"]
@@ -288,35 +292,110 @@ fn fail(code: i32) -> i32 {
 }
 
 fn main() -> i32 {
-    let RL = std.result.Result(std.net.TcpListener, std.net.NetworkError);
     let RS = std.result.Result(std.net.TcpStream, std.net.NetworkError);
-    let RA = std.result.Result(std.net.SockAddr, std.net.NetworkError);
-    let RUnit = std.result.Result((), std.net.NetworkError);
+    // Linux syscall numbers are stable on the two supported architectures.
+    // This socket is intentionally bound but never passed to listen(2).
+    let socket_nr: u64 = match @target_arch() {
+        Arch.X86_64 => 41,
+        Arch.Aarch64 => 198,
+    };
+    let bind_nr: u64 = match @target_arch() {
+        Arch.X86_64 => 49,
+        Arch.Aarch64 => 200,
+    };
+    let getsockname_nr: u64 = match @target_arch() {
+        Arch.X86_64 => 51,
+        Arch.Aarch64 => 204,
+    };
+    let close_nr: u64 = match @target_arch() {
+        Arch.X86_64 => 3,
+        Arch.Aarch64 => 57,
+    };
 
-    // Learn an ephemeral port, then free it so nothing listens there.
-    let bind_addr = std.net.SockAddr.v4(std.net.Ipv4Addr.localhost(), 0);
-    let mut listener = match std.net.TcpListener.bind(bind_addr) {
-        RL.Ok(l) => l,
-        RL.Err(e) => { return fail(101); },
+    // Linux sockaddr_in: AF_INET (native endian), port (network endian),
+    // 127.0.0.1, and zero padding. The port starts at zero for bind(0).
+    let addr: ptr mut u8 = checked { @alloc(16, 1) };
+    if checked { @ptr_to_int(addr) } == 0 { return fail(101); }
+    checked {
+        @ptr_write(@ptr_offset(addr, 0), 2);
+        @ptr_write(@ptr_offset(addr, 1), 0);
+        @ptr_write(@ptr_offset(addr, 2), 0);
+        @ptr_write(@ptr_offset(addr, 3), 0);
+        @ptr_write(@ptr_offset(addr, 4), 127);
+        @ptr_write(@ptr_offset(addr, 5), 0);
+        @ptr_write(@ptr_offset(addr, 6), 0);
+        @ptr_write(@ptr_offset(addr, 7), 1);
+        @ptr_write(@ptr_offset(addr, 8), 0);
+        @ptr_write(@ptr_offset(addr, 9), 0);
+        @ptr_write(@ptr_offset(addr, 10), 0);
+        @ptr_write(@ptr_offset(addr, 11), 0);
+        @ptr_write(@ptr_offset(addr, 12), 0);
+        @ptr_write(@ptr_offset(addr, 13), 0);
+        @ptr_write(@ptr_offset(addr, 14), 0);
+        @ptr_write(@ptr_offset(addr, 15), 0);
     };
-    let port: u16 = match listener.local_addr() {
-        RA.Ok(a) => a.port,
-        RA.Err(e) => { return fail(102); },
+    let fd_result: i64 = checked { @syscall(socket_nr, 2, 1, 0) };
+    if fd_result < 0 {
+        checked { @free(addr, 16, 1); };
+        return fail(102);
+    }
+    let fd: u64 = @intCast(fd_result);
+    let addr_num: u64 = checked { @ptr_to_int(addr) };
+    let bind_result: i64 = checked { @syscall(bind_nr, fd, addr_num, 16) };
+    if bind_result < 0 {
+        checked { @syscall(close_nr, fd); };
+        checked { @free(addr, 16, 1); };
+        return fail(103);
+    }
+    let length: ptr mut u8 = checked { @alloc(4, 1) };
+    if checked { @ptr_to_int(length) } == 0 {
+        checked { @syscall(close_nr, fd); };
+        checked { @free(addr, 16, 1); };
+        return fail(104);
+    }
+    checked {
+        @ptr_write(@ptr_offset(length, 0), 16);
+        @ptr_write(@ptr_offset(length, 1), 0);
+        @ptr_write(@ptr_offset(length, 2), 0);
+        @ptr_write(@ptr_offset(length, 3), 0);
     };
-    match listener.close() { RUnit.Ok(u) => {}, RUnit.Err(e) => { return fail(103); } }
+    let length_num: u64 = checked { @ptr_to_int(length) };
+    let name_result: i64 = checked { @syscall(getsockname_nr, fd, addr_num, length_num) };
+    if name_result < 0 {
+        checked { @syscall(close_nr, fd); };
+        checked { @free(length, 4, 1); };
+        checked { @free(addr, 16, 1); };
+        return fail(105);
+    }
+    let port_hi: u64 = @intCast(checked { @ptr_read(@ptr_offset(addr, 2)) });
+    let port_lo: u64 = @intCast(checked { @ptr_read(@ptr_offset(addr, 3)) });
+    let port: u16 = @intCast(port_hi * 256 + port_lo);
+    if port == 0 {
+        checked { @syscall(close_nr, fd); };
+        checked { @free(length, 4, 1); };
+        checked { @free(addr, 16, 1); };
+        return fail(106);
+    }
+    checked { @free(length, 4, 1); };
+    checked { @free(addr, 16, 1); };
 
     match std.net.TcpStream.connect(std.net.SockAddr.v4(std.net.Ipv4Addr.localhost(), port)) {
         RS.Ok(s) => {
             let ignored = s.close();
-            return fail(104);
+            checked { @syscall(close_nr, fd); };
+            return fail(107);
         },
         RS.Err(e) => {
             match e {
                 std.net.NetworkError.ConnectionRefused => { @dbg(1); },
-                _ => { return fail(105); },
+                _ => {
+                    checked { @syscall(close_nr, fd); };
+                    return fail(108);
+                },
             }
         },
     }
+    checked { @syscall(close_nr, fd); };
     0
 }
 """ }]

--- a/crates/rue-fuzz/README.md
+++ b/crates/rue-fuzz/README.md
@@ -43,6 +43,9 @@ Fuzz testing infrastructure for the Rue compiler. This crate helps find edge cas
 | `--print-interval=<n>` | Print progress every N runs |
 | `--per-input-timeout=<secs>` | Kill and report inputs running longer than this (default 5) |
 | `--seed=<n>` | Mutation RNG seed; defaults to a per-run value, printed at start for replay |
+| `--evolve-corpus=<dir>` | Save bounded, content-addressed successful mutations for a later run |
+| `--prepare-corpus=<dir> --fresh-corpus=<dir> --input-corpus=<dir> --output-corpus=<dir>` | Validate restored cache bytes and build separate fresh-input and evolved-output trees |
+| `--publish-corpus=<dir> --cache-corpus=<dir>` | Copy the clean bounded tree into the same-path cache generation |
 
 ## Corpus
 
@@ -53,6 +56,14 @@ The fuzzer uses a corpus of source files as seeds. A seed corpus can be automati
 ```
 
 This extracts source code from all `.toml` test files in `crates/rue-spec/cases/`.
+
+Nightly CI restores evolved bytes into a private directory for each target and
+merges fresh spec seeds before every five-minute campaign. Only successful
+mutations are retained, with a bounded content-addressed file set; crashes are
+written only to the redacted crash-artifact path. Cache-restored files are
+treated as untrusted bytes: they are never executed as scripts, followed as
+symlinks, or printed as input contents. The fuzzer prints its randomly chosen
+campaign seed, so a run can be replayed with `--seed=<n>`.
 
 ## Mutation Strategies
 

--- a/crates/rue-fuzz/src/corpus.rs
+++ b/crates/rue-fuzz/src/corpus.rs
@@ -1,35 +1,510 @@
 //! Corpus loading and management.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use rue_test_runner::load_test_files;
+
+/// Corpus files come from an Actions cache and are therefore inputs, not
+/// trusted repository files. Keep one malformed cache entry from consuming a
+/// runner's memory or disk budget before the target gets a chance to reject it.
+pub const MAX_CORPUS_FILES: usize = 8_192;
+pub const MAX_CORPUS_FILE_BYTES: u64 = 4 * 1024 * 1024;
+pub const MAX_CORPUS_BYTES: u64 = 128 * 1024 * 1024;
+pub const MAX_EVOLVED_FILES: usize = 4_096;
+pub const MAX_EVOLVED_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Load all files from a corpus directory.
 pub fn load_corpus(dir: &Path) -> anyhow::Result<Vec<Vec<u8>>> {
     let mut corpus = Vec::new();
+    let mut total_bytes: u64 = 0;
 
     if !dir.exists() {
         anyhow::bail!("corpus directory does not exist: {}", dir.display());
     }
 
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
+    let (mut entries, truncated) = read_entries_limited(dir, MAX_CORPUS_FILES)?;
+    if truncated {
+        eprintln!(
+            "Warning: corpus directory has more than {} entries; ignoring the rest",
+            MAX_CORPUS_FILES
+        );
+    }
+    // Stable ordering makes a fixed --seed replay independent of directory
+    // enumeration order. The bytes are still selected by the seeded RNG.
+    entries.sort_by_key(|entry| entry.file_name());
 
-        if path.is_file() {
-            match std::fs::read(&path) {
-                Ok(data) => corpus.push(data),
-                Err(e) => {
-                    eprintln!("Warning: failed to read {}: {}", path.display(), e);
-                }
+    for entry in entries {
+        let path = entry.path();
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(error) => {
+                eprintln!("Warning: failed to inspect corpus entry: {error}");
+                continue;
+            }
+        };
+        // Do not follow cache-provided symlinks. A cache must never turn the
+        // fuzzer into a reader for arbitrary files on the runner.
+        if file_type.is_symlink() || !file_type.is_file() {
+            continue;
+        }
+        let size = match entry.metadata() {
+            Ok(metadata) => metadata.len(),
+            Err(error) => {
+                eprintln!("Warning: failed to inspect corpus file: {error}");
+                continue;
+            }
+        };
+        if size > MAX_CORPUS_FILE_BYTES {
+            eprintln!(
+                "Warning: ignoring oversized corpus file ({} bytes; limit {})",
+                size, MAX_CORPUS_FILE_BYTES
+            );
+            continue;
+        }
+        if total_bytes.saturating_add(size) > MAX_CORPUS_BYTES {
+            eprintln!(
+                "Warning: ignoring corpus files after the {}-byte limit",
+                MAX_CORPUS_BYTES
+            );
+            break;
+        }
+        match std::fs::read(&path) {
+            Ok(data) => {
+                total_bytes += data.len() as u64;
+                corpus.push(data);
+            }
+            Err(e) => {
+                eprintln!("Warning: failed to read corpus file: {e}");
             }
         }
     }
 
     Ok(corpus)
+}
+
+/// Bounded, content-addressed output for successful mutated inputs.
+///
+/// The writer is deliberately independent from the input directory: a nightly
+/// run can restore old evolved inputs, merge fresh spec seeds, and write only
+/// successful mutations to the target's private cache directory. Crash inputs
+/// are handled by [`crate::harness::CrashReporter`] and never reach this type.
+pub struct EvolvedCorpus {
+    dir: PathBuf,
+    files: BTreeMap<String, u64>,
+    bytes: u64,
+    max_files: usize,
+    max_bytes: u64,
+}
+
+impl EvolvedCorpus {
+    pub fn open(dir: &Path) -> anyhow::Result<Self> {
+        Self::open_with_limits(dir, MAX_EVOLVED_FILES, MAX_EVOLVED_BYTES)
+    }
+
+    fn open_with_limits(dir: &Path, max_files: usize, max_bytes: u64) -> anyhow::Result<Self> {
+        match std::fs::symlink_metadata(dir) {
+            Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+                anyhow::bail!("corpus path is not a regular directory: {}", dir.display())
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                std::fs::create_dir_all(dir)?;
+            }
+            Err(error) => return Err(error.into()),
+        }
+        let mut files = BTreeMap::new();
+        let mut bytes: u64 = 0;
+        let mut loaded_bytes: u64 = 0;
+        let (mut entries, _) = read_entries_limited(dir, max_files.saturating_add(1))?;
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries {
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(_) => continue,
+            };
+            if file_type.is_symlink() || !file_type.is_file() {
+                continue;
+            }
+            let size = match entry.metadata() {
+                Ok(metadata) => metadata.len(),
+                Err(_) => continue,
+            };
+            if size > MAX_CORPUS_FILE_BYTES {
+                continue;
+            }
+            if loaded_bytes.saturating_add(size) > MAX_CORPUS_BYTES {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let Some((expected_hash, expected_len)) = parse_evolved_name(&name) else {
+                continue;
+            };
+            if expected_len != size {
+                continue;
+            }
+            // A cache entry is not trusted merely because its filename looks
+            // right. Verify the content address before allowing it to consume
+            // the bounded retained set.
+            let content = match std::fs::read(entry.path()) {
+                Ok(content) => content,
+                Err(_) => continue,
+            };
+            loaded_bytes = loaded_bytes.saturating_add(size);
+            if fnv1a_64(&content) != expected_hash {
+                continue;
+            }
+            files.insert(name, size);
+            bytes += size;
+        }
+        let mut corpus = Self {
+            dir: dir.to_path_buf(),
+            files,
+            bytes,
+            max_files,
+            max_bytes,
+        };
+        corpus.trim_to_limits()?;
+        Ok(corpus)
+    }
+
+    /// Save an input if it is new and the bounded cache still has room.
+    /// Returns whether a new file was written.
+    pub fn record(&mut self, input: &[u8]) -> std::io::Result<bool> {
+        if input.len() as u64 > MAX_CORPUS_FILE_BYTES {
+            return Ok(false);
+        }
+        let name = evolved_name(input);
+        if self.files.contains_key(&name) {
+            return Ok(false);
+        }
+        if !self.would_retain(&name, input.len() as u64) {
+            return Ok(false);
+        }
+        let path = self.dir.join(&name);
+        // `create_new` preserves content-addressed idempotence even if two
+        // target processes happen to share a cache directory.
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+        {
+            Ok(mut file) => {
+                if let Err(error) = file.write_all(input) {
+                    let _ = std::fs::remove_file(&path);
+                    self.files.remove(&name);
+                    return Err(error);
+                }
+                self.bytes += input.len() as u64;
+                self.files.insert(name.clone(), input.len() as u64);
+                self.trim_to_limits()?;
+                Ok(self.files.contains_key(&name))
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn would_retain(&self, name: &str, size: u64) -> bool {
+        if self.max_files == 0 || size > self.max_bytes {
+            return false;
+        }
+        if self.files.len() < self.max_files && self.bytes.saturating_add(size) <= self.max_bytes {
+            return true;
+        }
+        let mut candidates = self.files.clone();
+        candidates.insert(name.to_owned(), size);
+        let mut bytes = self.bytes.saturating_add(size);
+        while candidates.len() > self.max_files || bytes > self.max_bytes {
+            let Some(evicted) = candidates.keys().next_back().cloned() else {
+                break;
+            };
+            let size = candidates.remove(&evicted).unwrap_or(0);
+            bytes = bytes.saturating_sub(size);
+        }
+        candidates.contains_key(name)
+    }
+
+    fn trim_to_limits(&mut self) -> std::io::Result<()> {
+        while self.files.len() > self.max_files || self.bytes > self.max_bytes {
+            let Some(name) = self.files.keys().next_back().cloned() else {
+                break;
+            };
+            let path = self.dir.join(&name);
+            let size = self.files.get(&name).copied().unwrap_or(0);
+            let _ = std::fs::remove_file(path);
+            self.files.remove(&name);
+            self.bytes = self.bytes.saturating_sub(size);
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn file_count(&self) -> usize {
+        self.files.len()
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct SanitizedCorpusSummary {
+    pub fresh_seeds: usize,
+    pub restored_inputs: usize,
+    pub retained_inputs: usize,
+    pub ignored_inputs: usize,
+    pub bytes: u64,
+}
+
+/// Build a clean target corpus from an untrusted restored cache and fresh
+/// specification seeds. The restored tree is never used as the fuzzer input
+/// or as the cache-save path; only validated, bounded regular files are copied
+/// into `output_dir`. Seed and evolved namespaces cannot overwrite each other.
+pub fn sanitize_corpus(
+    restored_dir: &Path,
+    fresh_seed_dir: &Path,
+    input_dir: &Path,
+    output_dir: &Path,
+) -> anyhow::Result<SanitizedCorpusSummary> {
+    validate_non_overlapping_paths(&[
+        ("restored corpus", restored_dir),
+        ("fresh corpus", fresh_seed_dir),
+        ("input corpus", input_dir),
+        ("output corpus", output_dir),
+    ])?;
+    ensure_directory_or_absent(restored_dir)?;
+    ensure_directory(fresh_seed_dir)?;
+    ensure_absent(input_dir)?;
+    ensure_absent(output_dir)?;
+    std::fs::create_dir_all(input_dir)?;
+    std::fs::create_dir_all(output_dir)?;
+
+    let fresh = load_corpus(fresh_seed_dir)?;
+    let mut summary = SanitizedCorpusSummary::default();
+    let mut total_bytes = 0u64;
+    let mut total_files = 0usize;
+    for seed in fresh {
+        if total_files >= MAX_CORPUS_FILES
+            || total_bytes.saturating_add(seed.len() as u64) > MAX_CORPUS_BYTES
+        {
+            summary.ignored_inputs += 1;
+            continue;
+        }
+        let name = format!("seed-{:016x}-{:08x}.rue", fnv1a_64(&seed), seed.len());
+        let path = input_dir.join(name);
+        if path.exists() {
+            // A same-name/different-content collision is never overwritten.
+            if std::fs::read(&path)? != seed {
+                summary.ignored_inputs += 1;
+                continue;
+            }
+        } else {
+            std::fs::write(path, &seed)?;
+            total_files += 1;
+            total_bytes += seed.len() as u64;
+        }
+        summary.fresh_seeds += 1;
+    }
+
+    let restored = if restored_dir.exists() {
+        EvolvedCorpus::open_with_limits(restored_dir, MAX_EVOLVED_FILES, MAX_EVOLVED_BYTES)?
+    } else {
+        EvolvedCorpus::open_with_limits(restored_dir, 0, 0)?
+    };
+    let mut clean =
+        EvolvedCorpus::open_with_limits(output_dir, MAX_EVOLVED_FILES, MAX_EVOLVED_BYTES)?;
+    for name in restored.files.keys() {
+        let input = match std::fs::read(restored_dir.join(name)) {
+            Ok(input) => input,
+            Err(_) => {
+                summary.ignored_inputs += 1;
+                continue;
+            }
+        };
+        summary.restored_inputs += 1;
+        if clean.record(&input)? {
+            summary.retained_inputs += 1;
+        } else {
+            summary.ignored_inputs += 1;
+        }
+    }
+    for name in clean.files.keys() {
+        let input = std::fs::read(output_dir.join(name))?;
+        if total_files >= MAX_CORPUS_FILES
+            || total_bytes.saturating_add(input.len() as u64) > MAX_CORPUS_BYTES
+        {
+            break;
+        }
+        std::fs::write(input_dir.join(name), &input)?;
+        total_files += 1;
+        total_bytes += input.len() as u64;
+    }
+    summary.bytes = total_bytes;
+    Ok(summary)
+}
+
+/// Publish a clean fuzz input tree into the cache path. GitHub Actions cache
+/// restores and saves a path as the same workspace-relative archive root, so
+/// this explicit, Rust-owned copy keeps the untrusted restore staging tree
+/// separate during fuzzing while ensuring the next cache generation contains
+/// only the sanitized, bounded tree.
+pub fn publish_corpus(source_dir: &Path, cache_dir: &Path) -> anyhow::Result<usize> {
+    validate_non_overlapping_paths(&[("clean corpus", source_dir), ("cache corpus", cache_dir)])?;
+    ensure_directory(source_dir)?;
+    ensure_directory_or_absent(cache_dir)?;
+    let source = read_strict_evolved_entries(source_dir, MAX_EVOLVED_BYTES)?;
+    let cache = if cache_dir.exists() {
+        read_strict_evolved_entries(cache_dir, MAX_EVOLVED_BYTES)?
+    } else {
+        Vec::new()
+    };
+
+    // Both trees have been fully preflighted before any mutation. Replace only
+    // immediate regular files; a nested directory or symlink is rejected above
+    // rather than recursively deleted.
+    for (name, _) in cache {
+        std::fs::remove_file(cache_dir.join(name))?;
+    }
+    if !cache_dir.exists() {
+        std::fs::create_dir_all(cache_dir)?;
+    }
+    for (name, content) in &source {
+        std::fs::write(cache_dir.join(name), content)?;
+    }
+    Ok(source.len())
+}
+
+fn read_strict_evolved_entries(
+    dir: &Path,
+    byte_limit: u64,
+) -> anyhow::Result<Vec<(String, Vec<u8>)>> {
+    let (mut entries, truncated) = read_entries_limited(dir, MAX_EVOLVED_FILES)?;
+    if truncated {
+        anyhow::bail!("corpus exceeds {} files", MAX_EVOLVED_FILES);
+    }
+    entries.sort_by_key(|entry| entry.file_name());
+    let mut total_bytes = 0u64;
+    let mut result = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() || !file_type.is_file() {
+            anyhow::bail!("corpus contains a non-regular immediate entry");
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let Some((hash, length)) = parse_evolved_name(&name) else {
+            anyhow::bail!("corpus contains a nonconforming evolved identity");
+        };
+        let content = std::fs::read(entry.path())?;
+        let size = content.len() as u64;
+        if size != length || fnv1a_64(&content) != hash {
+            anyhow::bail!("corpus contains a spoofed evolved identity");
+        }
+        if size > MAX_CORPUS_FILE_BYTES || total_bytes.saturating_add(size) > byte_limit {
+            anyhow::bail!("corpus exceeds its byte bound");
+        }
+        total_bytes += size;
+        result.push((name, content));
+    }
+    Ok(result)
+}
+
+fn ensure_directory(path: &Path) -> anyhow::Result<()> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        anyhow::bail!("corpus path is not a regular directory: {}", path.display());
+    }
+    Ok(())
+}
+
+fn ensure_directory_or_absent(path: &Path) -> anyhow::Result<()> {
+    if path.exists() || std::fs::symlink_metadata(path).is_ok() {
+        ensure_directory(path)?;
+    }
+    Ok(())
+}
+
+fn ensure_absent(path: &Path) -> anyhow::Result<()> {
+    if std::fs::symlink_metadata(path).is_ok() {
+        anyhow::bail!("corpus output must not already exist: {}", path.display());
+    }
+    Ok(())
+}
+
+fn validate_non_overlapping_paths(paths: &[(&str, &Path)]) -> anyhow::Result<()> {
+    let current = lexical_absolute(Path::new("."))?;
+    let mut absolute = Vec::with_capacity(paths.len());
+    for (label, path) in paths {
+        let normalized = lexical_absolute(path)?;
+        if normalized == current || normalized.parent().is_none() {
+            anyhow::bail!("{label} path is too broad: {}", path.display());
+        }
+        absolute.push((*label, normalized));
+    }
+    for (index, (left_label, left)) in absolute.iter().enumerate() {
+        for (right_label, right) in absolute.iter().skip(index + 1) {
+            if left == right || left.starts_with(right) || right.starts_with(left) {
+                anyhow::bail!(
+                    "{left_label} and {right_label} paths overlap: {} and {}",
+                    left.display(),
+                    right.display()
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn lexical_absolute(path: &Path) -> anyhow::Result<std::path::PathBuf> {
+    if path.as_os_str().is_empty() {
+        anyhow::bail!("corpus path is empty");
+    }
+    let path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    let mut normalized = std::path::PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            component => normalized.push(component.as_os_str()),
+        }
+    }
+    Ok(normalized)
+}
+
+fn read_entries_limited(
+    dir: &Path,
+    limit: usize,
+) -> std::io::Result<(Vec<std::fs::DirEntry>, bool)> {
+    let mut entries = Vec::new();
+    let mut iter = std::fs::read_dir(dir)?;
+    while entries.len() < limit {
+        let Some(entry) = iter.next() else {
+            return Ok((entries, false));
+        };
+        entries.push(entry?);
+    }
+    Ok((entries, iter.next().is_some()))
+}
+
+fn evolved_name(input: &[u8]) -> String {
+    format!("input-{:016x}-{:08x}.bin", fnv1a_64(input), input.len())
+}
+
+fn parse_evolved_name(name: &str) -> Option<(u64, u64)> {
+    let body = name.strip_prefix("input-")?.strip_suffix(".bin")?;
+    let (hash, len) = body.split_once('-')?;
+    if hash.len() != 16 || len.len() != 8 {
+        return None;
+    }
+    Some((
+        u64::from_str_radix(hash, 16).ok()?,
+        u64::from_str_radix(len, 16).ok()?,
+    ))
 }
 
 /// Summary of a seed-corpus build.
@@ -422,5 +897,206 @@ aux_files = { "math.rue" = "pub fn add(a: i32, b: i32) -> i32 { a + b }" }
             result.is_err(),
             "an unreadable test file must fail the build"
         );
+    }
+
+    #[test]
+    fn load_corpus_ignores_symlinks_and_oversized_files() {
+        let dir = scratch("untrusted-inputs");
+        write(&dir, "valid", "not executable, just bytes");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("/etc/passwd", dir.join("outside")).unwrap();
+        write(
+            &dir,
+            "oversized",
+            &"x".repeat((MAX_CORPUS_FILE_BYTES + 1) as usize),
+        );
+
+        let corpus = load_corpus(&dir).unwrap();
+        assert_eq!(corpus, vec![b"not executable, just bytes".to_vec()]);
+    }
+
+    #[test]
+    fn evolved_corpus_is_content_addressed_bounded_and_idempotent() {
+        let dir = scratch("evolved");
+        let mut evolved = EvolvedCorpus::open(&dir).unwrap();
+        assert!(evolved.record(b"one").unwrap());
+        assert!(!evolved.record(b"one").unwrap());
+        assert!(!evolved.record(b"one").unwrap());
+        assert_eq!(evolved.file_count(), 1);
+
+        let entries: Vec<_> = std::fs::read_dir(&dir).unwrap().collect();
+        assert_eq!(entries.len(), 1);
+        assert!(
+            entries[0]
+                .as_ref()
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with("input-")
+        );
+    }
+
+    #[test]
+    fn evolved_corpus_does_not_save_oversized_inputs() {
+        let dir = scratch("evolved-limit");
+        let mut evolved = EvolvedCorpus::open(&dir).unwrap();
+        assert!(
+            !evolved
+                .record(&vec![0u8; (MAX_CORPUS_FILE_BYTES + 1) as usize])
+                .unwrap()
+        );
+        assert_eq!(evolved.file_count(), 0);
+    }
+
+    #[test]
+    fn evolved_corpus_rejects_spoofed_content_addresses() {
+        let dir = scratch("evolved-spoof");
+        std::fs::write(dir.join("input-0000000000000000-00000003.bin"), b"bad").unwrap();
+        std::fs::write(dir.join("input-not-a-hash-00000003.bin"), b"bad").unwrap();
+        let evolved = EvolvedCorpus::open(&dir).unwrap();
+        assert_eq!(evolved.file_count(), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn evolved_corpus_rejects_root_symlink() {
+        let parent = scratch("evolved-root-symlink");
+        let actual = parent.join("actual");
+        let link = parent.join("link");
+        std::fs::create_dir_all(&actual).unwrap();
+        std::os::unix::fs::symlink(&actual, &link).unwrap();
+        assert!(EvolvedCorpus::open(&link).is_err());
+    }
+
+    #[test]
+    fn evolved_corpus_replaces_largest_identity_at_file_cap() {
+        let dir = scratch("evolved-rotation");
+        let inputs: [&[u8]; 4] = [b"first", b"second", b"third", b"fourth"];
+        let mut names: Vec<_> = inputs.iter().map(|input| evolved_name(input)).collect();
+        names.sort();
+
+        let mut evolved = EvolvedCorpus::open_with_limits(&dir, 2, MAX_EVOLVED_BYTES).unwrap();
+        for input in inputs {
+            evolved.record(input).unwrap();
+        }
+
+        let retained: Vec<_> = evolved.files.keys().cloned().collect();
+        assert_eq!(retained, names.into_iter().take(2).collect::<Vec<_>>());
+        assert_eq!(evolved.file_count(), 2);
+    }
+
+    #[test]
+    fn evolved_corpus_enforces_byte_cap_during_replacement() {
+        let dir = scratch("evolved-byte-rotation");
+        let mut evolved = EvolvedCorpus::open_with_limits(&dir, 8, 5).unwrap();
+        evolved.record(b"four").unwrap();
+        evolved.record(b"five!").unwrap();
+        evolved.record(b"sixsix").unwrap();
+
+        assert!(evolved.bytes <= 5);
+        assert!(evolved.files.values().copied().sum::<u64>() <= 5);
+    }
+
+    #[test]
+    fn sanitize_corpus_keeps_fresh_seed_namespace_and_rejects_untrusted_entries() {
+        let parent = scratch("sanitize");
+        let restored = parent.join("restored");
+        let fresh = parent.join("fresh");
+        let input = parent.join("input");
+        let output = parent.join("output");
+        std::fs::create_dir_all(&restored).unwrap();
+        std::fs::create_dir_all(&fresh).unwrap();
+        let evolved = b"restored input";
+        std::fs::write(restored.join(evolved_name(evolved)), evolved).unwrap();
+        write(&restored, "spoof.bin", "not content addressed");
+        write(&fresh, "spec-seed", "fresh source");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("/etc/passwd", restored.join("outside")).unwrap();
+
+        let summary = sanitize_corpus(&restored, &fresh, &input, &output).unwrap();
+        assert_eq!(summary.fresh_seeds, 1);
+        assert_eq!(summary.restored_inputs, 1);
+        assert_eq!(summary.retained_inputs, 1);
+        assert!(input.join(evolved_name(evolved)).is_file());
+        assert!(output.join(evolved_name(evolved)).is_file());
+        assert_eq!(
+            std::fs::read_dir(&input).unwrap().count(),
+            2,
+            "fresh and evolved inputs must be available to the target"
+        );
+        assert_eq!(
+            std::fs::read_dir(&output).unwrap().count(),
+            1,
+            "evolved output must exclude fresh seeds"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sanitize_corpus_rejects_root_symlink() {
+        let parent = scratch("sanitize-symlink");
+        let actual = parent.join("actual");
+        let restored = parent.join("restored");
+        let fresh = parent.join("fresh");
+        let output = parent.join("output");
+        let input = parent.join("input");
+        std::fs::create_dir_all(&actual).unwrap();
+        std::fs::create_dir_all(&fresh).unwrap();
+        std::os::unix::fs::symlink(&actual, &restored).unwrap();
+
+        assert!(sanitize_corpus(&restored, &fresh, &input, &output).is_err());
+    }
+
+    #[test]
+    fn sanitize_corpus_rejects_current_and_overlapping_paths_before_mutation() {
+        let root = scratch("sanitize-paths");
+        let fresh = root.join("fresh");
+        let input = root.join("input");
+        let output = root.join("output");
+        std::fs::create_dir_all(&fresh).unwrap();
+        assert!(sanitize_corpus(Path::new("."), &fresh, &input, &output).is_err());
+        assert!(sanitize_corpus(Path::new("/"), &fresh, &input, &output).is_err());
+        assert!(!input.exists());
+        assert!(!output.exists());
+
+        let parent = scratch("sanitize-paths-overlap");
+        let restored = parent.join("restored");
+        let fresh = parent.join("fresh");
+        let input = parent.join("input");
+        let output = input.join("nested-output");
+        std::fs::create_dir_all(&restored).unwrap();
+        std::fs::create_dir_all(&fresh).unwrap();
+        assert!(sanitize_corpus(&restored, &fresh, &input, &output).is_err());
+        assert!(!input.exists());
+    }
+
+    #[test]
+    fn publish_corpus_replaces_staging_with_only_clean_content() {
+        let clean = scratch("publish-clean");
+        let cache = scratch("publish-cache");
+        let input = b"clean evolved input";
+        std::fs::write(clean.join(evolved_name(input)), input).unwrap();
+        let old = b"old evolved input";
+        std::fs::write(cache.join(evolved_name(old)), old).unwrap();
+
+        assert_eq!(publish_corpus(&clean, &cache).unwrap(), 1);
+        assert!(!cache.join(evolved_name(old)).exists());
+        assert!(cache.join(evolved_name(input)).is_file());
+        assert_eq!(std::fs::read_dir(&cache).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn publish_corpus_rejects_nested_cache_without_partial_deletion() {
+        let clean = scratch("publish-nested-clean");
+        let cache = scratch("publish-nested-cache");
+        let input = b"clean evolved input";
+        let old = b"old evolved input";
+        std::fs::write(clean.join(evolved_name(input)), input).unwrap();
+        std::fs::write(cache.join(evolved_name(old)), old).unwrap();
+        std::fs::create_dir(cache.join("nested")).unwrap();
+
+        assert!(publish_corpus(&clean, &cache).is_err());
+        assert!(cache.join(evolved_name(old)).is_file());
+        assert!(cache.join("nested").is_dir());
     }
 }

--- a/crates/rue-fuzz/src/main.rs
+++ b/crates/rue-fuzz/src/main.rs
@@ -12,6 +12,10 @@
 //! # Generate a seed corpus from test files
 //! ./buck2 run //crates/rue-fuzz:rue-fuzz -- --init-corpus output_dir/
 //!
+//! # Sanitize a restored nightly corpus and merge fresh seeds
+//! ./buck2 run //crates/rue-fuzz:rue-fuzz -- --prepare-corpus=restored \
+//!     --fresh-corpus=spec-seeds --output-corpus=nightly-corpus/lexer
+//!
 //! # List available targets
 //! ./buck2 run //crates/rue-fuzz:rue-fuzz -- --list
 //! ```
@@ -95,6 +99,10 @@ pub struct FuzzConfig {
     /// fresh sequence); the chosen seed is printed so any run can be replayed
     /// with `--seed=`.
     pub seed: Option<u64>,
+    /// Optional per-target directory where successful mutated inputs are
+    /// retained for the next nightly run. Crash inputs are intentionally not
+    /// written here; [`CrashReporter`] owns crash artifacts and redaction.
+    pub evolve_corpus: Option<PathBuf>,
 }
 
 impl Default for FuzzConfig {
@@ -107,6 +115,7 @@ impl Default for FuzzConfig {
             print_interval: 1000,
             per_input_timeout: DEFAULT_PER_INPUT_TIMEOUT,
             seed: None,
+            evolve_corpus: None,
         }
     }
 }
@@ -139,6 +148,11 @@ pub fn run_fuzzer<T: FuzzTarget + ?Sized>(
     // saved once, so a single flooding bug (e.g. the RUE-42 stack overflow)
     // can't bury the crashes dir under thousands of identical files.
     let mut reporter = CrashReporter::new(config.crash_dir.clone());
+    let mut evolved = config
+        .evolve_corpus
+        .as_deref()
+        .map(corpus::EvolvedCorpus::open)
+        .transpose()?;
 
     // A fixed default seed would make every nightly run explore a byte-identical
     // input sequence (a regression re-run, not fuzzing). Default to a per-run
@@ -189,6 +203,15 @@ pub fn run_fuzzer<T: FuzzTarget + ?Sized>(
                 RunOutcome::Ok => unreachable!(),
             }
             reporter.report(target.name(), &input, &outcome);
+        } else if config.mutate {
+            if let Some(evolved) = evolved.as_mut() {
+                if let Err(error) = evolved.record(&input) {
+                    // Persistence is an optimization for the next campaign;
+                    // it must not hide the target result or turn a crash into
+                    // a corpus entry.
+                    eprintln!("Warning: failed to save evolved corpus input: {error}");
+                }
+            }
         }
 
         runs += 1;
@@ -261,6 +284,12 @@ fn main() {
     let mut corpus_dir: Option<PathBuf> = None;
     let mut config = FuzzConfig::default();
     let mut init_corpus = false;
+    let mut prepare_corpus: Option<PathBuf> = None;
+    let mut fresh_corpus: Option<PathBuf> = None;
+    let mut output_corpus: Option<PathBuf> = None;
+    let mut input_corpus: Option<PathBuf> = None;
+    let mut publish_corpus: Option<PathBuf> = None;
+    let mut cache_corpus: Option<PathBuf> = None;
     let mut list_targets = false;
 
     let mut i = 1;
@@ -278,6 +307,48 @@ fn main() {
             if i < args.len() {
                 corpus_dir = Some(PathBuf::from(&args[i]));
             }
+        } else if let Some(val) = arg.strip_prefix("--prepare-corpus=") {
+            if val.is_empty() {
+                eprintln!("Error: --prepare-corpus requires a directory");
+                print_usage(&prog);
+                std::process::exit(1);
+            }
+            prepare_corpus = Some(PathBuf::from(val));
+        } else if let Some(val) = arg.strip_prefix("--fresh-corpus=") {
+            if val.is_empty() {
+                eprintln!("Error: --fresh-corpus requires a directory");
+                print_usage(&prog);
+                std::process::exit(1);
+            }
+            fresh_corpus = Some(PathBuf::from(val));
+        } else if let Some(val) = arg.strip_prefix("--output-corpus=") {
+            if val.is_empty() {
+                eprintln!("Error: --output-corpus requires a directory");
+                print_usage(&prog);
+                std::process::exit(1);
+            }
+            output_corpus = Some(PathBuf::from(val));
+        } else if let Some(val) = arg.strip_prefix("--input-corpus=") {
+            if val.is_empty() {
+                eprintln!("Error: --input-corpus requires a directory");
+                print_usage(&prog);
+                std::process::exit(1);
+            }
+            input_corpus = Some(PathBuf::from(val));
+        } else if let Some(val) = arg.strip_prefix("--publish-corpus=") {
+            if val.is_empty() {
+                eprintln!("Error: --publish-corpus requires a directory");
+                print_usage(&prog);
+                std::process::exit(1);
+            }
+            publish_corpus = Some(PathBuf::from(val));
+        } else if let Some(val) = arg.strip_prefix("--cache-corpus=") {
+            if val.is_empty() {
+                eprintln!("Error: --cache-corpus requires a directory");
+                print_usage(&prog);
+                std::process::exit(1);
+            }
+            cache_corpus = Some(PathBuf::from(val));
         } else if arg == "--mutate" {
             config.mutate = true;
         } else if let Some(val) = arg.strip_prefix("--max-time=") {
@@ -298,6 +369,13 @@ fn main() {
             // seed (which would break the requested replay). Zero is a valid
             // seed, so this does not require positive.
             config.seed = Some(numeric_or_exit(&prog, "--seed", val, false));
+        } else if let Some(val) = arg.strip_prefix("--evolve-corpus=") {
+            if val.is_empty() {
+                eprintln!("Error: --evolve-corpus requires a directory");
+                print_usage(&prog);
+                std::process::exit(1);
+            }
+            config.evolve_corpus = Some(PathBuf::from(val));
         } else if !arg.starts_with('-') {
             if target_name.is_none() {
                 target_name = Some(arg.clone());
@@ -338,6 +416,61 @@ fn main() {
             }
             Err(e) => {
                 eprintln!("Error creating corpus: {}", e);
+                std::process::exit(1);
+            }
+        }
+        return;
+    }
+
+    if let Some(restored_dir) = prepare_corpus {
+        let fresh_dir = fresh_corpus.unwrap_or_else(|| {
+            eprintln!("Error: --prepare-corpus requires --fresh-corpus=<directory>");
+            print_usage(&prog);
+            std::process::exit(1);
+        });
+        let output_dir = output_corpus.unwrap_or_else(|| {
+            eprintln!("Error: --prepare-corpus requires --output-corpus=<directory>");
+            print_usage(&prog);
+            std::process::exit(1);
+        });
+        let input_dir = input_corpus.unwrap_or_else(|| {
+            eprintln!("Error: --prepare-corpus requires --input-corpus=<directory>");
+            print_usage(&prog);
+            std::process::exit(1);
+        });
+        match corpus::sanitize_corpus(&restored_dir, &fresh_dir, &input_dir, &output_dir) {
+            Ok(summary) => {
+                eprintln!(
+                    "Prepared corpus in {}: {} fresh seed(s), {} restored input(s), {} retained, {} ignored, {} bytes",
+                    output_dir.display(),
+                    summary.fresh_seeds,
+                    summary.restored_inputs,
+                    summary.retained_inputs,
+                    summary.ignored_inputs,
+                    summary.bytes,
+                );
+            }
+            Err(error) => {
+                eprintln!("Error preparing corpus: {error}");
+                std::process::exit(1);
+            }
+        }
+        return;
+    }
+
+    if let Some(source_dir) = publish_corpus {
+        let cache_dir = cache_corpus.unwrap_or_else(|| {
+            eprintln!("Error: --publish-corpus requires --cache-corpus=<directory>");
+            print_usage(&prog);
+            std::process::exit(1);
+        });
+        match corpus::publish_corpus(&source_dir, &cache_dir) {
+            Ok(count) => eprintln!(
+                "Published {count} clean corpus file(s) to {}",
+                cache_dir.display()
+            ),
+            Err(error) => {
+                eprintln!("Error publishing corpus: {error}");
                 std::process::exit(1);
             }
         }
@@ -401,6 +534,11 @@ fn print_usage(program: &str) {
         program
     );
     eprintln!(
+        "  {} --prepare-corpus=<dir> --fresh-corpus=<dir> --input-corpus=<dir> --output-corpus=<dir>",
+        program
+    );
+    eprintln!("  {} --publish-corpus=<dir> --cache-corpus=<dir>", program);
+    eprintln!(
         "  {} --list                       List available targets",
         program
     );
@@ -420,6 +558,7 @@ fn print_usage(program: &str) {
     eprintln!("  --print-interval=<n>       Print progress every N runs");
     eprintln!("  --per-input-timeout=<secs> Kill+report inputs running longer (default 5)");
     eprintln!("  --seed=<n>                 Mutation RNG seed (default: per-run, printed)");
+    eprintln!("  --evolve-corpus=<dir>      Save bounded successful mutations for reuse");
     eprintln!();
     eprintln!("Examples:");
     eprintln!("  {} --init-corpus corpus/", program);
@@ -446,6 +585,38 @@ fn find_spec_cases_dir() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::parse_numeric_option;
+    use super::{FuzzConfig, FuzzTarget, run_fuzzer};
+    use std::time::Duration;
+
+    struct SuccessfulTarget;
+
+    impl FuzzTarget for SuccessfulTarget {
+        fn name(&self) -> &'static str {
+            "successful"
+        }
+
+        fn fuzz(&self, _input: &[u8]) {}
+    }
+
+    struct PanickingTarget;
+
+    impl FuzzTarget for PanickingTarget {
+        fn name(&self) -> &'static str {
+            "panicking"
+        }
+
+        fn fuzz(&self, _input: &[u8]) {
+            panic!("test crash");
+        }
+    }
+
+    fn scratch(name: &str) -> std::path::PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("rue-fuzz-runner-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
 
     #[test]
     fn valid_positive_values_parse() {
@@ -486,5 +657,39 @@ mod tests {
         assert!(zero.contains("positive"), "{zero}");
         let bad = parse_numeric_option("--max-runs", "x", true).unwrap_err();
         assert!(bad.contains("integer"), "{bad}");
+    }
+
+    #[test]
+    fn successful_mutations_are_retained_but_crashes_are_not() {
+        let root = scratch("evolution");
+        let input = root.join("inputs");
+        let evolved = root.join("evolved");
+        std::fs::create_dir_all(&input).unwrap();
+        std::fs::write(input.join("seed"), b"fn main() -> i32 { 0 }").unwrap();
+
+        let config = FuzzConfig {
+            max_runs: Some(1),
+            mutate: true,
+            seed: Some(7),
+            evolve_corpus: Some(evolved.clone()),
+            per_input_timeout: Duration::from_secs(1),
+            ..FuzzConfig::default()
+        };
+        let successful = run_fuzzer(&SuccessfulTarget, &input, &config).unwrap();
+        assert_eq!(successful.crashes, 0);
+        assert!(std::fs::read_dir(&evolved).unwrap().next().is_some());
+
+        let crash_evolved = root.join("crash-evolved");
+        let crash_config = FuzzConfig {
+            evolve_corpus: Some(crash_evolved.clone()),
+            ..config
+        };
+        let crashed = run_fuzzer(&PanickingTarget, &input, &crash_config).unwrap();
+        assert_eq!(crashed.crashes, 1);
+        assert!(
+            std::fs::read_dir(&crash_evolved).unwrap().next().is_none(),
+            "crash inputs must remain in crash reporting only"
+        );
+        let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/scripts/test-fuzz-report-failure.py
+++ b/scripts/test-fuzz-report-failure.py
@@ -575,6 +575,99 @@ class WorkflowContractTests(unittest.TestCase):
     def test_reporting_runs_even_when_the_crash_upload_is_all_that_survived(self):
         self.assertIn("if: failure()", self.workflow)
 
+    def test_evolved_corpus_uses_immutable_restore_and_save_keys(self):
+        """Nightly persistence must survive failures without caching code."""
+        self.assertIn("actions/cache/restore@v5", self.workflow)
+        self.assertIn("actions/cache/save@v5", self.workflow)
+        self.assertIn("if: always()", self.workflow)
+        self.assertIn("group: fuzz-corpus-mutation", self.workflow)
+        self.assertIn("cancel-in-progress: false", self.workflow)
+        self.assertIn("rue-fuzz-corpus-v3-", self.workflow)
+        self.assertNotIn("hashFiles('crates/rue-fuzz/src/**'", self.workflow)
+
+    def test_each_registered_mutation_step_has_private_input_and_output(self):
+        # Keep this inventory explicit: deriving it only from output paths
+        # would let a newly registered target silently skip restore or save.
+        targets = (
+            "lexer",
+            "parser",
+            "sema",
+            "compiler",
+            "compiler_aarch64",
+            "compiler_x86_64_o1",
+            "payload_schemas",
+            "emitter",
+            "emitter_aarch64",
+            "emitter_sequence",
+            "emitter_sequence_aarch64",
+        )
+        for target in targets:
+            self.assertIn(
+                f"path: crates/rue-fuzz/nightly-restored/{target}", self.workflow
+            )
+            self.assertIn(
+                f"restore-keys: rue-fuzz-corpus-v3-{target}-", self.workflow
+            )
+            self.assertIn(
+                f"key: rue-fuzz-corpus-v3-{target}-${{{{ github.run_id }}}}-${{{{ github.run_attempt }}}}",
+                self.workflow,
+            )
+            self.assertIn(
+                f"--evolve-corpus=crates/rue-fuzz/nightly-corpus/{target} {target} crates/rue-fuzz/nightly-input/{target}",
+                self.workflow,
+            )
+            self.assertIn(
+                f"--input-corpus=\"crates/rue-fuzz/nightly-input/$target\"",
+                self.workflow,
+            )
+            self.assertIn(
+                f"--output-corpus=\"crates/rue-fuzz/nightly-corpus/$target\"",
+                self.workflow,
+            )
+            self.assertIn(
+                f"path: crates/rue-fuzz/nightly-restored/{target}", self.workflow
+            )
+        self.assertEqual(self.workflow.count("actions/cache/restore@v5"), len(targets))
+        self.assertEqual(self.workflow.count("actions/cache/save@v5"), len(targets))
+        self.assertEqual(set(re.findall(r"--max-time=(\d+)", self.workflow)), {"300"})
+        mutation_steps = re.findall(r"^\s+run: .*--max-time=300", self.workflow, re.MULTILINE)
+        self.assertEqual(len(mutation_steps), len(targets))
+        self.assertEqual(
+            self.workflow.count(
+                "if: always() && steps.publish_clean_corpus.outcome == 'success'"
+            ),
+            len(targets),
+        )
+
+    def test_prepare_operation_is_the_only_corpus_assembly_path(self):
+        self.assertIn("--prepare-corpus=", self.workflow)
+        self.assertIn("--fresh-corpus=crates/rue-fuzz/spec-seeds", self.workflow)
+        self.assertIn("--output-corpus=", self.workflow)
+        self.assertIn("--publish-corpus=", self.workflow)
+        self.assertIn("--cache-corpus=", self.workflow)
+        self.assertIn(
+            "if: always() && steps.publish_clean_corpus.outcome == 'success'",
+            self.workflow,
+        )
+
+    def test_live_target_guard_checks_cache_wiring(self):
+        guard = self.workflow.split("- name: Verify every registered fuzz target is scheduled", 1)[1]
+        self.assertIn(
+            'grep -qF -- "path: crates/rue-fuzz/nightly-restored/${t}"', guard
+        )
+        self.assertIn(
+            'grep -cF -- "path: crates/rue-fuzz/nightly-restored/${t}"', guard
+        )
+        self.assertIn(
+            'key: rue-fuzz-corpus-v3-${t}-${{ github.run_id }}-${{ github.run_attempt }}',
+            guard,
+        )
+        self.assertIn(
+            'restore-keys: rue-fuzz-corpus-v3-${t}-',
+            guard,
+        )
+        self.assertNotRegex(self.workflow, r"\b(?:find|cp)\s+.*nightly-(?:restored|corpus)")
+
     def test_every_aggregated_target_is_also_named_to_the_reporter(self):
         """A target the reporter does not name degrades to `(job-level failure)`.
 
@@ -590,10 +683,10 @@ class WorkflowContractTests(unittest.TestCase):
             "- name: Fail if any fuzz step found crashes"
         )
         pattern = re.compile(r"steps\.([\w-]+)\.outcome")
-        self.assertEqual(
-            set(pattern.findall(aggregation)),
-            set(pattern.findall(reporting)),
-        )
+        aggregated = set(pattern.findall(aggregation))
+        reported = set(pattern.findall(reporting))
+        reported.discard("publish_clean_corpus")
+        self.assertEqual(aggregated, reported)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
- make the Linux connection-refused CLI case deterministic by retaining a bound, never-listened loopback socket
- evolve isolated, bounded, content-addressed corpora across nightly fuzz runs with fail-closed cache sanitization
- validate target/cache wiring, path safety, cold starts, and successful-only retention

Testing:
- scripts/rue unit fuzz
- python3 scripts/test-fuzz-report-failure.py
- scripts/rue cli tcp_connection_refused (platform-skipped on macOS)
- scripts/rue quick
- scripts/rue fmt
- scripts/rue premerge
- Python and Bash baseline validators

Fixes RUE-1720