### PR TITLE
RUE-1644: compare enum marshal tags without truncation

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -3382,6 +3382,52 @@ fn aarch64_narrow_offset_encodable(byte_offset: i32, width: u8) -> bool {
     byte_offset >= 0 && byte_offset % width == 0 && byte_offset / width <= 0xFFF
 }
 
+/// Return the direct CMP-immediate form for a tag, if AArch64 can encode it.
+/// The compact layout's tag is an unsigned u8/u16/u32 at offset zero, so this
+/// test is shared by all tag-dispatch lowering and never truncates a u64 value.
+fn marshal_tag_cmp_imm(discriminant: u64) -> Option<i32> {
+    let encodable =
+        discriminant <= 0xFFF || (discriminant & 0xFFF == 0 && discriminant >> 12 <= 0xFFF);
+    encodable.then(|| {
+        i32::try_from(discriminant).expect("encodable enum discriminant must fit the MIR immediate")
+    })
+}
+
+fn compact_tag_discriminant(discriminant: u64) -> u32 {
+    u32::try_from(discriminant)
+        .expect("enum discriminant exceeds the compact u32 tag representation")
+}
+
+/// Emit the compare and skip branch used by every heterogeneous enum image
+/// dispatch. Keeping this sequence in one helper lets the MIR boundary tests
+/// exercise the same path as [`SlotBackend::emit_marshal_branch_if_tag_ne`].
+fn emit_marshal_tag_ne(mir: &mut Aarch64Mir, tag: VReg, discriminant: u32, label: LabelId) {
+    // Compact enum tags are zero-extended u8/u16/u32 values in their
+    // slot-shaped vregs. CMP's immediate encoding has only a plain or
+    // <<12 12-bit form; retain either fast path and materialize every
+    // other representable tag before the 64-bit register compare.
+    if let Some(imm) = marshal_tag_cmp_imm(u64::from(discriminant)) {
+        mir.push(Aarch64Inst::CmpImm {
+            src: Operand::Virtual(tag),
+            imm,
+        });
+    } else {
+        let constant = mir.alloc_vreg();
+        mir.push(Aarch64Inst::MovImm {
+            dst: Operand::Virtual(constant),
+            imm: i64::from(discriminant),
+        });
+        mir.push(Aarch64Inst::Cmp64RR {
+            src1: Operand::Virtual(tag),
+            src2: Operand::Virtual(constant),
+        });
+    }
+    mir.push(Aarch64Inst::BCond {
+        cond: Cond::Ne,
+        label,
+    });
+}
+
 impl crate::agg_slots::SlotBackend for CfgLower<'_> {
     fn ctx(&self) -> &crate::cfg_lower::CfgLowerContext<'_> {
         &self.ctx
@@ -3504,14 +3550,8 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
         self.mir.alloc_label()
     }
     fn emit_marshal_branch_if_tag_ne(&mut self, tag: VReg, discriminant: u64, label: LabelId) {
-        self.mir.push(Aarch64Inst::CmpImm {
-            src: Operand::Virtual(tag),
-            imm: discriminant as i32,
-        });
-        self.mir.push(Aarch64Inst::BCond {
-            cond: Cond::Ne,
-            label,
-        });
+        let discriminant = compact_tag_discriminant(discriminant);
+        emit_marshal_tag_ne(&mut self.mir, tag, discriminant, label);
     }
     fn emit_marshal_jump(&mut self, label: LabelId) {
         self.mir.push(Aarch64Inst::B { label });
@@ -3769,6 +3809,87 @@ mod tests {
     };
     use rue_cfg::{CfgArgMode, CfgCallArg, CfgInst, CfgInstData, PlaceBase, Projection};
     use rue_span::{FileId, Span};
+
+    #[test]
+    fn marshal_tag_cmp_imm_covers_aarch64_boundaries() {
+        assert_eq!(marshal_tag_cmp_imm(4095), Some(4095));
+        assert_eq!(marshal_tag_cmp_imm(4096), Some(4096));
+        assert_eq!(marshal_tag_cmp_imm(4097), None);
+        assert_eq!(marshal_tag_cmp_imm(0xFFF000), Some(0xFFF000));
+        assert_eq!(marshal_tag_cmp_imm(0xFFF001), None);
+        assert_eq!(marshal_tag_cmp_imm(i32::MAX as u64), None);
+        assert_eq!(marshal_tag_cmp_imm(i32::MAX as u64 + 1), None);
+        assert_eq!(marshal_tag_cmp_imm(u32::MAX as u64), None);
+    }
+
+    #[test]
+    fn marshal_tag_emits_immediate_and_fallback_mir_sequences() {
+        for (discriminant, expected) in [(4095, 4095), (4096, 4096)] {
+            let mut mir = Aarch64Mir::new();
+            let tag = mir.alloc_vreg();
+            let label = LabelId::new(17);
+            emit_marshal_tag_ne(&mut mir, tag, discriminant, label);
+            assert_eq!(mir.vreg_count(), 1, "immediate compare must not allocate");
+            assert!(matches!(
+                mir.instructions(),
+                [
+                    Aarch64Inst::CmpImm {
+                        src: Operand::Virtual(src),
+                        imm,
+                    },
+                    Aarch64Inst::BCond {
+                        cond: Cond::Ne,
+                        label: branch_label,
+                    },
+                ] if *src == tag && *imm == expected && *branch_label == label
+            ));
+        }
+
+        for discriminant in [4097, u32::MAX] {
+            let mut mir = Aarch64Mir::new();
+            let tag = mir.alloc_vreg();
+            let label = LabelId::new(18);
+            emit_marshal_tag_ne(&mut mir, tag, discriminant, label);
+            assert_eq!(
+                mir.vreg_count(),
+                2,
+                "fallback compare must allocate its constant"
+            );
+            let constant = match mir.instructions() {
+                [
+                    Aarch64Inst::MovImm {
+                        dst: Operand::Virtual(constant),
+                        imm,
+                    },
+                    ..,
+                ] => {
+                    assert_eq!(*imm, i64::from(discriminant));
+                    *constant
+                }
+                _ => panic!("fallback compare must materialize its constant first"),
+            };
+            assert!(matches!(
+                mir.instructions(),
+                [
+                    Aarch64Inst::MovImm { .. },
+                    Aarch64Inst::Cmp64RR {
+                        src1: Operand::Virtual(src1),
+                        src2: Operand::Virtual(src2),
+                    },
+                    Aarch64Inst::BCond {
+                        cond: Cond::Ne,
+                        label: branch_label,
+                    },
+                ] if *src1 == tag && *src2 == constant && *branch_label == label
+            ));
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "compact u32 tag representation")]
+    fn marshal_tag_rejects_unrepresentable_discriminant() {
+        let _ = compact_tag_discriminant(u32::MAX as u64 + 1);
+    }
 
     #[test]
     fn physical_return_register_roster_matches_the_abi_kernel_budget() {

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -2374,7 +2374,8 @@ impl<'a> Emitter<'a> {
         // destination is XZR), so an immediate that fits neither the plain nor
         // the shifted 12-bit form must be materialized by the caller. Guard
         // against silent truncation (was a bare `imm & 0xFFF`, the RUE-45
-        // class); every current caller passes < 4096.
+        // class). Callers prevalidate the plain/shifted forms; a value that
+        // fits neither form must be materialized before reaching this encoder.
         let inst = if imm <= 0xFFF {
             OPCODE_CMP_IMM_X | ((imm & 0xFFF) << 10)
         } else if imm & 0xFFF == 0 && (imm >> 12) <= 0xFFF {
@@ -3261,6 +3262,20 @@ mod tests {
         let inst = u32::from_le_bytes(code[0..4].try_into().unwrap());
         assert_eq!(inst & 0xFF000000, 0xF1000000, "Should be SUBS immediate");
         // Rd should be XZR (31)
+        assert_eq!(inst & 0x1F, 31, "Rd should be XZR");
+    }
+
+    #[test]
+    fn test_cmp_imm_shifted_12_bit_form() {
+        let code = emit_single(Aarch64Inst::CmpImm {
+            src: Operand::Physical(Reg::X0),
+            imm: 4096,
+        });
+        let inst = u32::from_le_bytes(code[0..4].try_into().unwrap());
+        assert_eq!(code.len(), 4);
+        assert_eq!((inst >> 22) & 1, 1, "CMP should select the shifted form");
+        assert_eq!((inst >> 10) & 0xFFF, 1, "CMP should encode 4096 as 1 << 12");
+        assert_eq!((inst >> 5) & 0x1F, 0, "Rn should be X0");
         assert_eq!(inst & 0x1F, 31, "Rd should be XZR");
     }
 

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -3149,6 +3149,47 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
     }
 }
 
+/// Return the immediate form usable for a full-width enum-tag comparison.
+/// x86-64 sign-extends the compare immediate, so only non-negative i32 values
+/// preserve the zero-extended u32 tag representation.
+fn marshal_tag_cmp_imm(discriminant: u64) -> Option<i32> {
+    i32::try_from(discriminant).ok()
+}
+
+fn compact_tag_discriminant(discriminant: u64) -> u32 {
+    u32::try_from(discriminant)
+        .expect("enum discriminant exceeds the compact u32 tag representation")
+}
+
+/// Emit the compare and skip branch used by every heterogeneous enum image
+/// dispatch. Keeping this sequence in one helper lets the MIR boundary tests
+/// exercise the same path as [`SlotBackend::emit_marshal_branch_if_tag_ne`].
+fn emit_marshal_tag_ne(mir: &mut X86Mir, tag: VReg, discriminant: u32, label: LabelId) {
+    // Compact enum tags are zero-extended u8/u16/u32 values in their
+    // slot-shaped vregs. Keep the compare 64-bit so a tag above i32::MAX
+    // cannot be changed by an unchecked u64-to-i32 cast. The immediate
+    // form is sign-extended by x86, so it is valid only for values that fit
+    // i32; larger (still representable u32) tags use the existing full-
+    // width constant materialization and register compare.
+    if let Some(imm) = marshal_tag_cmp_imm(u64::from(discriminant)) {
+        mir.push(X86Inst::Cmp64RI {
+            src: Operand::Virtual(tag),
+            imm,
+        });
+    } else {
+        let constant = mir.alloc_vreg();
+        mir.push(X86Inst::MovRI64 {
+            dst: Operand::Virtual(constant),
+            imm: i64::from(discriminant),
+        });
+        mir.push(X86Inst::Cmp64RR {
+            src1: Operand::Virtual(tag),
+            src2: Operand::Virtual(constant),
+        });
+    }
+    mir.push(X86Inst::Jnz { label });
+}
+
 impl crate::agg_slots::SlotBackend for CfgLower<'_> {
     fn ctx(&self) -> &crate::cfg_lower::CfgLowerContext<'_> {
         &self.ctx
@@ -3249,11 +3290,8 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
         self.new_label()
     }
     fn emit_marshal_branch_if_tag_ne(&mut self, tag: VReg, discriminant: u64, label: LabelId) {
-        self.mir.push(X86Inst::CmpRI {
-            src: Operand::Virtual(tag),
-            imm: discriminant as i32,
-        });
-        self.mir.push(X86Inst::Jnz { label });
+        let discriminant = compact_tag_discriminant(discriminant);
+        emit_marshal_tag_ne(&mut self.mir, tag, discriminant, label);
     }
     fn emit_marshal_jump(&mut self, label: LabelId) {
         self.mir.push(X86Inst::Jmp { label });
@@ -3552,6 +3590,83 @@ mod tests {
     };
     use rue_cfg::{CfgArgMode, CfgCallArg, CfgInst, CfgInstData, PlaceBase, Projection};
     use rue_span::{FileId, Span};
+
+    #[test]
+    fn marshal_tag_cmp_imm_covers_i32_boundary() {
+        assert_eq!(marshal_tag_cmp_imm(4095), Some(4095));
+        assert_eq!(marshal_tag_cmp_imm(4096), Some(4096));
+        assert_eq!(marshal_tag_cmp_imm(i32::MAX as u64), Some(i32::MAX));
+        assert_eq!(marshal_tag_cmp_imm(i32::MAX as u64 + 1), None);
+        assert_eq!(marshal_tag_cmp_imm(u32::MAX as u64), None);
+    }
+
+    #[test]
+    fn marshal_tag_emits_immediate_and_full_width_fallback_mir_sequences() {
+        for (discriminant, expected) in [(4095, 4095), (4096, 4096), (i32::MAX as u32, i32::MAX)] {
+            let mut mir = X86Mir::new();
+            let tag = mir.alloc_vreg();
+            let label = LabelId::new(19);
+            emit_marshal_tag_ne(&mut mir, tag, discriminant, label);
+            assert_eq!(mir.vreg_count(), 1, "immediate compare must not allocate");
+            assert!(matches!(
+                mir.instructions(),
+                [
+                    X86Inst::Cmp64RI {
+                        src: Operand::Virtual(src),
+                        imm,
+                    },
+                    X86Inst::Jnz { label: branch_label },
+                ] if *src == tag && *imm == expected && *branch_label == label
+            ));
+        }
+
+        for discriminant in [i32::MAX as u64 + 1, u32::MAX as u64] {
+            let mut mir = X86Mir::new();
+            let tag = mir.alloc_vreg();
+            let label = LabelId::new(19);
+            emit_marshal_tag_ne(
+                &mut mir,
+                tag,
+                u32::try_from(discriminant).expect("test discriminant must fit the compact tag"),
+                label,
+            );
+            assert_eq!(
+                mir.vreg_count(),
+                2,
+                "fallback compare must allocate its constant"
+            );
+            let constant = match mir.instructions() {
+                [
+                    X86Inst::MovRI64 {
+                        dst: Operand::Virtual(constant),
+                        imm,
+                    },
+                    ..,
+                ] => {
+                    assert_eq!(*imm, i64::try_from(discriminant).unwrap());
+                    *constant
+                }
+                _ => panic!("fallback compare must materialize its constant first"),
+            };
+            assert!(matches!(
+                mir.instructions(),
+                [
+                    X86Inst::MovRI64 { .. },
+                    X86Inst::Cmp64RR {
+                        src1: Operand::Virtual(src1),
+                        src2: Operand::Virtual(src2),
+                    },
+                    X86Inst::Jnz { label: branch_label },
+                ] if *src1 == tag && *src2 == constant && *branch_label == label
+            ));
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "compact u32 tag representation")]
+    fn marshal_tag_rejects_unrepresentable_discriminant() {
+        let _ = compact_tag_discriminant(u32::MAX as u64 + 1);
+    }
 
     #[test]
     fn physical_return_register_roster_matches_the_abi_kernel_budget() {
@@ -4407,7 +4522,7 @@ mod tests {
         assert!(
             mir.instructions()
                 .iter()
-                .any(|inst| matches!(inst, X86Inst::CmpRI { .. })),
+                .any(|inst| matches!(inst, X86Inst::Cmp64RI { .. })),
             "the nested heterogeneous enum store must dispatch on the embedded tag"
         );
     }
@@ -4517,7 +4632,7 @@ mod tests {
         assert!(
             mir.instructions()
                 .iter()
-                .any(|inst| matches!(inst, X86Inst::CmpRI { .. })),
+                .any(|inst| matches!(inst, X86Inst::Cmp64RI { .. })),
             "the heterogeneous store must compare the tag to dispatch on the variant"
         );
         assert!(
@@ -4893,7 +5008,7 @@ mod tests {
         assert!(
             mir.instructions()
                 .iter()
-                .any(|inst| matches!(inst, X86Inst::CmpRI { .. })),
+                .any(|inst| matches!(inst, X86Inst::Cmp64RI { .. })),
             "the heterogeneous enum store must dispatch on the tag"
         );
     }


### PR DESCRIPTION
## Summary

- enforce the compact enum tag's zero-extended u8/u16/u32 contract before backend lowering
- retain AArch64 immediate compares when encodable and materialize other tags for register comparison
- use full-width x86-64 compares without unchecked u64-to-i32 casts
- cover immediate, shifted-immediate, fallback, i32, u32, and rejection boundaries in both backends

## Verification

- scripts/rue fmt
- scripts/rue unit codegen marshal_tag
- scripts/rue unit codegen test_cmp_imm
- scripts/rue quick
- scripts/rue premerge: 199 targets passed; the unrelated CLI watch cancellation case timed out twice under suite load and passed in isolation

Fixes RUE-1644