### PR TITLE
RUE-1653: document JSON diagnostic column units

### DIFF
--- a/crates/rue-cli-tests/cases/diagnostic_json.toml
+++ b/crates/rue-cli-tests/cases/diagnostic_json.toml
@@ -54,25 +54,24 @@ compile_stderr_not_contains = [
 
 [[case]]
 name = "struct_field_mismatch_uses_value_span"
-description = "RUE-1640: a struct field assignment mismatch points at the RHS expression, including its JSON primary span."
+description = "RUE-1640: a struct field assignment mismatch points at the RHS expression, including its JSON primary span; RUE-1653: the column counts Unicode scalar values, not UTF-8 bytes or UTF-16 code units."
 files = [{ path = "main.rue", source = """
 struct Pair { flag: bool }
 fn give() -> i32 { 1 }
 fn main() -> i32 {
     let mut p = Pair { flag: true };
-    p.flag = give();
+    let _s = "é😀"; p.flag = give();
     0
 }
 """ }]
 args = ["--error-format", "json", "main.rue", "-o", "prog"]
 compile_fail = true
 json_diagnostics = true
-json_diagnostic_order = ["error E0206 main.rue:5:14"]
+json_diagnostic_order = ["error E0206 main.rue:5:29"]
 error_contains = [
   '"code":"E0206"',
   '"message":"type mismatch: expected bool, found i32"',
-  '"start":119',
-  '"end":125',
+  '''"spans":[{"column":29,"end":144,"file":"main.rue","label":null,"line":5,"primary":true,"start":138}]''',
   '"primary":true',
 ]
 

--- a/docs/process/diagnostics.md
+++ b/docs/process/diagnostics.md
@@ -63,7 +63,7 @@ are serialized in alphabetical order; consumers must not depend on key order.
 | `start` | integer | Start byte offset into that file, 0-indexed. |
 | `end` | integer | End byte offset, exclusive. Never less than `start`. |
 | `line` | integer | Line of `start`, **1-indexed**. |
-| `column` | integer | Column of `start`, **1-indexed**. |
+| `column` | integer | Column of `start`, **1-indexed**, counting Unicode scalar values (not bytes or UTF-16 code units). |
 | `label` | string \| `null` | Label text for a secondary span; `null` on the primary. |
 | `primary` | boolean | Whether this is the diagnostic's primary span. |
 


### PR DESCRIPTION
## Summary

- specify that JSON diagnostic columns count 1-indexed Unicode scalar values
- pin the public value with a multibyte CLI diagnostic span that distinguishes scalars from UTF-8 bytes and UTF-16 code units
- preserve byte offsets, schema shape, rendering, and position computation

## Validation

- `scripts/rue cli diagnostic_json change_after_monitor_stops_is_still_announced`
- `scripts/rue quick`
- `scripts/rue fmt`
- `scripts/rue premerge`

Fixes RUE-1653