### PR TITLE
RUE-1795: add ready-only comptime admission

### DIFF
--- a/crates/rue-compiler/src/body_query.rs
+++ b/crates/rue-compiler/src/body_query.rs
@@ -126,6 +126,162 @@ pub(crate) struct OwnedBodyInput {
     pub(crate) artifacts: Arc<crate::canonical_lower::DeclarationBodyPlanArtifacts>,
 }
 
+/// Stable identity of an admitted foreign comptime producer. The producer is
+/// the canonical semantic owner; the configuration is the other part of the
+/// durable identity. Candidate syntax is retained separately as lookup
+/// provenance and is never used as an alternate owner key.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ForeignComptimeProgramKey {
+    pub(crate) producer: crate::StableDefinitionKey,
+    pub(crate) configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ForeignComptimeProgramPlan {
+    pub(crate) key: ForeignComptimeProgramKey,
+    /// Compiler-private syntax provenance used to fetch the canonical body
+    /// plan. It is not part of the stable program identity.
+    pub(crate) candidate: crate::declaration_candidate::DeclarationCandidateKey,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ForeignComptimeCallable {
+    pub(crate) body: rue_rir::InstRef,
+    pub(crate) context: crate::ModuleId,
+    pub(crate) root: rue_rir::InstRef,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ForeignComptimeImportOccurrence {
+    /// Owner-local instruction in the admitted RIR. The future host must use
+    /// this only with the `rir` retained by the same program payload.
+    pub(crate) inst: rue_rir::InstRef,
+    pub(crate) occurrence: u32,
+    pub(crate) specifier: Arc<str>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(crate) enum ForeignComptimeProgramProjectionFailure {
+    Materialization(crate::canonical_lower::BodyPlanMaterializationFailure),
+    Artifact(crate::revisioned_query_database::DeclarationBodyPlanFailure),
+    ArtifactQueryFailure(rue_query::QueryFailure),
+    NotFunction { root: rue_rir::InstRef },
+    InvalidProducer(crate::StableDefinitionKey),
+    IdentityMismatch,
+}
+
+impl From<crate::canonical_lower::BodyPlanMaterializationFailure>
+    for ForeignComptimeProgramProjectionFailure
+{
+    fn from(error: crate::canonical_lower::BodyPlanMaterializationFailure) -> Self {
+        Self::Materialization(error)
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ForeignComptimeCallSeed {
+    pub(crate) type_arguments: Arc<[(Arc<str>, crate::durable_semantics::DurableType)]>,
+    pub(crate) value_arguments: Arc<[(Arc<str>, crate::durable_semantics::DurableConstValue)]>,
+}
+
+/// Owned compiler/query-side admission payload for a future durable comptime
+/// host. It is projected from the canonical declaration body plan and owns all
+/// data that would otherwise be borrowed from a revision-local source artifact.
+/// This slice only admits the payload; no evaluator consumes it yet.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub(crate) struct OwnedForeignComptimeProgram {
+    pub(crate) plan: ForeignComptimeProgramPlan,
+    pub(crate) rir: Arc<rue_rir::ValidatedRir>,
+    pub(crate) symbols: Arc<[Arc<str>]>,
+    pub(crate) import_occurrences: Arc<[ForeignComptimeImportOccurrence]>,
+    pub(crate) callable: ForeignComptimeCallable,
+    pub(crate) seed: ForeignComptimeCallSeed,
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(crate) enum ForeignComptimeCallLookup {
+    Ready(crate::semantic_query_nucleus::ComptimeCallProjection),
+    ReadyFailure(crate::semantic_query_nucleus::SemanticNucleusFailure),
+    ReadyQueryFailure(rue_query::QueryFailure),
+    Admitted(OwnedForeignComptimeProgram),
+    AdmissionFailure(ForeignComptimeProgramProjectionFailure),
+    NotReady,
+    UnexpectedReadyProjection,
+}
+
+impl OwnedForeignComptimeProgram {
+    #[allow(dead_code)]
+    pub(crate) fn from_body_plan(
+        plan: ForeignComptimeProgramPlan,
+        artifacts: &crate::canonical_lower::DeclarationBodyPlanArtifacts,
+        seed: ForeignComptimeCallSeed,
+        mut checkpoint: impl FnMut() -> Result<(), rue_query::QueryAbort>,
+    ) -> Result<Self, ForeignComptimeProgramProjectionFailure> {
+        if artifacts.candidate != plan.candidate {
+            return Err(ForeignComptimeProgramProjectionFailure::IdentityMismatch);
+        }
+        let (rir, spellings, root) = artifacts
+            .plan
+            .materialize_semantic_candidate_rir(&mut checkpoint)
+            .map_err(|error| ForeignComptimeProgramProjectionFailure::Materialization(error))?;
+        let Some(expected_candidate) =
+            crate::revisioned_query_database::declaration_candidate_for_stable_key(
+                &plan.key.producer,
+            )
+        else {
+            return Err(ForeignComptimeProgramProjectionFailure::IdentityMismatch);
+        };
+        if expected_candidate != plan.candidate {
+            return Err(ForeignComptimeProgramProjectionFailure::IdentityMismatch);
+        }
+        let body = match &rir.get(root).data {
+            rue_rir::InstData::FnDecl { body, .. } => *body,
+            _ => {
+                return Err(ForeignComptimeProgramProjectionFailure::NotFunction { root });
+            }
+        };
+        let import_occurrences =
+            crate::revisioned_query_database::semantic_candidate_import_occurrences(
+                &rir,
+                &spellings,
+                &mut checkpoint,
+            )
+            .map_err(|error| {
+                ForeignComptimeProgramProjectionFailure::Materialization(
+                    crate::canonical_lower::BodyPlanMaterializationFailure::Query(error),
+                )
+            })?
+            .into_iter()
+            .map(
+                |(inst, (occurrence, specifier))| ForeignComptimeImportOccurrence {
+                    inst,
+                    occurrence,
+                    specifier,
+                },
+            )
+            .collect::<Vec<_>>();
+        Ok(Self {
+            plan: plan.clone(),
+            rir: Arc::new(rir),
+            symbols: spellings.into_iter().map(Arc::from).collect(),
+            import_occurrences: import_occurrences.into(),
+            callable: ForeignComptimeCallable {
+                body,
+                context: plan.candidate.module.clone(),
+                root,
+            },
+            seed,
+        })
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum BodyInputIncomplete {
     UnsupportedInstance,
@@ -914,7 +1070,10 @@ impl BodyTransaction {
 
 #[cfg(test)]
 mod tests {
-    use super::{BodyQueryKey, merge_ordered_unique};
+    use super::{
+        BodyQueryKey, ForeignComptimeCallSeed, ForeignComptimeProgramKey,
+        ForeignComptimeProgramPlan, OwnedForeignComptimeProgram, merge_ordered_unique,
+    };
     use rue_air::Node;
     use std::collections::BTreeSet;
     use std::sync::Arc;
@@ -961,6 +1120,130 @@ mod tests {
             &*merge_ordered_unique(Arc::from([1, 2, 3]), selected),
             &[1, 2, 3]
         );
+    }
+
+    #[test]
+    fn foreign_program_projection_owns_rir_imports_and_preserves_seed_order() {
+        let snapshot = crate::SourceSnapshot::single(
+            "<foreign-program>",
+            "fn target() -> i32 { @import(\"dep\"); 1 } fn sibling() -> i32 { 2 }",
+        )
+        .unwrap();
+        let module = crate::parsed_modules::parse_source_snapshot_modules(&snapshot)
+            .unwrap()
+            .modules()[0]
+            .clone();
+        let candidate = module
+            .definitions()
+            .declaration_keys_in_source_order()
+            .find(|candidate| candidate.name.as_ref() == "target")
+            .unwrap()
+            .clone();
+        let sibling_candidate = module
+            .definitions()
+            .declaration_keys_in_source_order()
+            .find(|candidate| candidate.name.as_ref() == "sibling")
+            .unwrap()
+            .clone();
+        let artifacts =
+            crate::canonical_lower::lower_parsed_declaration_body_plan(&module, &candidate, || {
+                Ok(())
+            })
+            .unwrap();
+        let sibling_artifacts = crate::canonical_lower::lower_parsed_declaration_body_plan(
+            &module,
+            &sibling_candidate,
+            || Ok(()),
+        )
+        .unwrap();
+        let producer = crate::StableDefinitionKey::from_stable_parts(
+            candidate.module.clone(),
+            crate::StableDefinitionNamespace::Value,
+            crate::StableDefinitionKind::Function,
+            candidate.name.clone(),
+            None,
+        );
+        let plan = ForeignComptimeProgramPlan {
+            key: ForeignComptimeProgramKey {
+                producer,
+                configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration {
+                    target: rue_target::Target::X86_64Linux,
+                    preview_features: crate::StablePreviewFeatures::new(
+                        &crate::PreviewFeatures::default(),
+                    ),
+                },
+            },
+            candidate,
+        };
+        let seed = ForeignComptimeCallSeed {
+            type_arguments: Arc::from([
+                (Arc::from("z"), crate::durable_semantics::DurableType::I32),
+                (Arc::from("a"), crate::durable_semantics::DurableType::I64),
+            ]),
+            value_arguments: Arc::from([
+                (
+                    Arc::from("z"),
+                    crate::durable_semantics::DurableConstValue::Integer(9),
+                ),
+                (
+                    Arc::from("a"),
+                    crate::durable_semantics::DurableConstValue::Integer(1),
+                ),
+            ]),
+        };
+        let program =
+            OwnedForeignComptimeProgram::from_body_plan(plan, &artifacts, seed.clone(), || Ok(()))
+                .unwrap();
+        assert!(matches!(
+            OwnedForeignComptimeProgram::from_body_plan(
+                program.plan.clone(),
+                &sibling_artifacts,
+                seed.clone(),
+                || Ok(()),
+            ),
+            Err(super::ForeignComptimeProgramProjectionFailure::IdentityMismatch)
+        ));
+        let mut wrong_candidate = program.plan.candidate.clone();
+        wrong_candidate.name = Arc::from("sibling");
+        let wrong_plan = ForeignComptimeProgramPlan {
+            key: program.plan.key.clone(),
+            candidate: wrong_candidate,
+        };
+        assert!(matches!(
+            OwnedForeignComptimeProgram::from_body_plan(
+                wrong_plan,
+                &artifacts,
+                seed.clone(),
+                || Ok(())
+            ),
+            Err(super::ForeignComptimeProgramProjectionFailure::IdentityMismatch)
+        ));
+        drop(artifacts);
+
+        assert_eq!(program.seed, seed, "argument order is request order");
+        assert_eq!(program.callable.context, program.plan.candidate.module);
+        assert_eq!(
+            program.callable.root,
+            program
+                .rir
+                .iter()
+                .find_map(|(inst, instruction)| {
+                    matches!(&instruction.data, rue_rir::InstData::FnDecl { .. }).then_some(inst)
+                })
+                .unwrap()
+        );
+        let rue_rir::InstData::FnDecl { body, .. } = &program.rir.get(program.callable.root).data
+        else {
+            panic!("the admitted callable root must remain a function declaration");
+        };
+        assert_eq!(program.callable.body, *body);
+        assert_eq!(program.import_occurrences.len(), 1);
+        let import = &program.import_occurrences[0];
+        assert_eq!(import.specifier.as_ref(), "dep");
+        assert!(matches!(
+            &program.rir.get(import.inst).data,
+            rue_rir::InstData::Intrinsic { .. }
+        ));
     }
 }
 

--- a/crates/rue-compiler/src/canonical_lower.rs
+++ b/crates/rue-compiler/src/canonical_lower.rs
@@ -498,6 +498,7 @@ impl DeclarationBodyPlan {
 
 #[derive(Debug)]
 pub(crate) struct DeclarationBodyPlanArtifacts {
+    pub(crate) candidate: crate::declaration_candidate::DeclarationCandidateKey,
     pub(crate) plan: DeclarationBodyPlan,
 }
 
@@ -520,7 +521,9 @@ impl RetainedCharge for DeclarationBodyPlan {
 
 impl RetainedCharge for DeclarationBodyPlanArtifacts {
     fn retained_charge(&self) -> u64 {
-        self.plan.retained_charge()
+        self.candidate
+            .retained_charge()
+            .saturating_add(self.plan.retained_charge())
     }
 }
 
@@ -707,6 +710,7 @@ fn lower_parsed_declaration_body_plan_internal(
     finish_declaration_body_plan(
         editor,
         symbols,
+        candidate.clone(),
         declaration,
         method_owner,
         module.file_id(),
@@ -778,6 +782,7 @@ fn validate_candidate_root(
 fn finish_declaration_body_plan(
     extracted: RirEditor,
     symbols: lasso::ThreadedRodeo,
+    candidate: crate::declaration_candidate::DeclarationCandidateKey,
     declaration: InstRef,
     method_owner: Option<PackedRirMethodOwner>,
     file_id: FileId,
@@ -850,6 +855,7 @@ fn finish_declaration_body_plan(
             other => DeclarationBodyPlanBuildFailure::Validation(Arc::from(format!("{other:?}"))),
         })?;
     Ok(DeclarationBodyPlanArtifacts {
+        candidate,
         plan: DeclarationBodyPlan { packed },
     })
 }
@@ -2107,7 +2113,8 @@ fn target(inout values: [i32; 4]) -> type {
             Arc::new(lower_parsed_declaration_body_plan(&module, &key, || Ok(())).unwrap());
         assert_eq!(
             artifact.retained_charge(),
-            std::mem::size_of::<DeclarationBodyPlanArtifacts>() as u64
+            artifact.candidate.retained_charge()
+                + std::mem::size_of::<DeclarationBodyPlanArtifacts>() as u64
                 + artifact.plan.packed.retained_allocation_charge(),
         );
     }

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -2342,7 +2342,7 @@ fn declaration_body_plan_artifacts_equal(
         (
             DeclarationBodyPlanArtifactsValue::Available(left),
             DeclarationBodyPlanArtifactsValue::Available(right),
-        ) => left.plan.structurally_eq(&right.plan),
+        ) => left.candidate == right.candidate && left.plan.structurally_eq(&right.plan),
         (
             DeclarationBodyPlanArtifactsValue::Failure(left),
             DeclarationBodyPlanArtifactsValue::Failure(right),
@@ -4538,7 +4538,7 @@ fn publish_body_plan_materialization_attribution(
     );
 }
 
-fn declaration_candidate_for_stable_key(
+pub(crate) fn declaration_candidate_for_stable_key(
     key: &StableDefinitionKey,
 ) -> Option<crate::declaration_candidate::DeclarationCandidateKey> {
     stable_syntax_candidate_set(key)?[0].clone()
@@ -7014,15 +7014,15 @@ enum SemanticBinaryOp {
     Shr,
 }
 
-fn semantic_candidate_import_occurrences(
+pub(crate) fn semantic_candidate_import_occurrences(
     rir: &rue_rir::ValidatedRir,
     symbols: &[&str],
-    context: &QueryContext,
+    mut checkpoint: impl FnMut() -> Result<(), QueryAbort>,
 ) -> Result<BTreeMap<rue_rir::InstRef, (u32, Arc<str>)>, QueryAbort> {
     let mut sites = Vec::new();
     for (instruction_ref, instruction) in rir.iter() {
         if instruction_ref.as_u32() % 64 == 0 {
-            context.check_canceled()?;
+            checkpoint()?;
         }
         let rue_rir::InstData::Intrinsic { name, args } = &instruction.data else {
             continue;
@@ -13734,7 +13734,7 @@ impl RevisionedQueryDatabase {
                                                 semantic_candidate_import_occurrences(
                                                     &rir,
                                                     &symbols,
-                                                    context,
+                                                    || context.check_canceled(),
                                                 )?;
                                             let result = {
                                                 let mut evaluator = SemanticConstEvaluator {
@@ -14246,7 +14246,7 @@ impl RevisionedQueryDatabase {
                                                 semantic_candidate_import_occurrences(
                                                     &rir,
                                                     &symbols,
-                                                    context,
+                                                    || context.check_canceled(),
                                                 )?;
                                             let result = {
                                                 let mut evaluator = SemanticConstEvaluator {
@@ -17635,6 +17635,10 @@ impl BodyTransactionEvaluator {
             module_source_bases: self.module_source_bases.clone(),
             lookup_names: self.lookup_names.clone(),
             lookup_imports: self.lookup_imports.clone(),
+            declaration_body_plan_artifacts: self
+                .body_input
+                .declaration_body_plan_artifacts
+                .clone(),
             semantic_nucleus: self.semantic_nucleus.clone(),
             body_produced_anonymous: self.body_produced_anonymous.clone(),
             body_toolchain_demands: self.body_toolchain_demands.clone(),
@@ -21564,6 +21568,8 @@ pub(crate) struct CompilerBodyProviderQueries<'a> {
     module_source_bases: QueryFamily<ModuleQueryKey, Option<rue_air::DurableBodySourceLocator>>,
     lookup_names: QueryFamily<LookupNameKey, LookupNameValue>,
     lookup_imports: QueryFamily<LookupImportKey, LookupImportValue>,
+    declaration_body_plan_artifacts:
+        QueryFamily<DeclarationBodyPlanQueryKey, DeclarationBodyPlanArtifactsValue>,
     semantic_nucleus: QueryFamily<
         crate::semantic_query_nucleus::SemanticNucleusKey,
         crate::semantic_query_nucleus::SemanticNucleusValue,
@@ -23601,6 +23607,115 @@ impl<'a> CompilerBodyFactProvider<'a> {
             .query_registered(&self.queries.semantic_nucleus, key)
     }
 
+    /// Probe the already-published comptime-call fact without demanding the
+    /// semantic nucleus. A true miss admits the canonical body plan into an
+    /// owned foreign-program payload; an in-progress semantic handoff remains
+    /// NotReady and never competes with the active evaluator.
+    #[allow(dead_code)]
+    fn probe_comptime_call(
+        &self,
+        producer: &crate::StableDefinitionKey,
+        type_arguments: &[(Arc<str>, crate::durable_semantics::DurableType)],
+        value_arguments: &[(Arc<str>, crate::durable_semantics::DurableConstValue)],
+    ) -> Result<crate::body_query::ForeignComptimeCallLookup, QueryAbort> {
+        let Some(declaration) = declaration_candidate_for_stable_key(producer) else {
+            return Ok(
+                crate::body_query::ForeignComptimeCallLookup::AdmissionFailure(
+                    crate::body_query::ForeignComptimeProgramProjectionFailure::InvalidProducer(
+                        producer.clone(),
+                    ),
+                ),
+            );
+        };
+        let key = crate::semantic_query_nucleus::ComptimeCallQueryKey {
+            declaration: self.declaration_query_key(&declaration),
+            type_arguments: type_arguments.to_vec().into(),
+            value_arguments: value_arguments.to_vec().into(),
+        };
+        let foreign_plan = crate::body_query::ForeignComptimeProgramPlan {
+            key: crate::body_query::ForeignComptimeProgramKey {
+                producer: producer.clone(),
+                configuration: self.queries.configuration.clone(),
+            },
+            candidate: declaration,
+        };
+        match self.queries.context.probe_registered_ready(
+            &self.queries.semantic_nucleus,
+            crate::semantic_query_nucleus::SemanticNucleusKey::ComptimeCall(key.clone()),
+        )? {
+            rue_query::ReadyQueryProbe::Ready(terminal) => match terminal.outcome() {
+                rue_query::QueryOutcome::Success(
+                    crate::semantic_query_nucleus::SemanticNucleusValue::ComptimeCall(value),
+                ) => Ok(crate::body_query::ForeignComptimeCallLookup::Ready(
+                    value.clone(),
+                )),
+                rue_query::QueryOutcome::Success(
+                    crate::semantic_query_nucleus::SemanticNucleusValue::Failure(failure),
+                ) => Ok(crate::body_query::ForeignComptimeCallLookup::ReadyFailure(
+                    failure.clone(),
+                )),
+                rue_query::QueryOutcome::Failure(failure) => Ok(
+                    crate::body_query::ForeignComptimeCallLookup::ReadyQueryFailure(
+                        failure.clone(),
+                    ),
+                ),
+                _ => Ok(crate::body_query::ForeignComptimeCallLookup::UnexpectedReadyProjection),
+            },
+            rue_query::ReadyQueryProbe::Miss => {
+                let artifacts = self.queries.context.query_registered(
+                    &self.queries.declaration_body_plan_artifacts,
+                    DeclarationBodyPlanQueryKey(foreign_plan.candidate.clone()),
+                )?;
+                let artifacts = match artifacts.outcome() {
+                    rue_query::QueryOutcome::Success(
+                        DeclarationBodyPlanArtifactsValue::Available(artifacts),
+                    ) => artifacts,
+                    rue_query::QueryOutcome::Success(
+                        DeclarationBodyPlanArtifactsValue::Failure(failure),
+                    ) => {
+                        return Ok(crate::body_query::ForeignComptimeCallLookup::AdmissionFailure(
+                            crate::body_query::ForeignComptimeProgramProjectionFailure::Artifact(
+                                failure.clone(),
+                            ),
+                        ));
+                    }
+                    rue_query::QueryOutcome::Failure(failure) => {
+                        return Ok(crate::body_query::ForeignComptimeCallLookup::AdmissionFailure(
+                            crate::body_query::ForeignComptimeProgramProjectionFailure::ArtifactQueryFailure(
+                                failure.clone(),
+                            ),
+                        ));
+                    }
+                };
+                let seed = crate::body_query::ForeignComptimeCallSeed {
+                    type_arguments: type_arguments.to_vec().into(),
+                    value_arguments: value_arguments.to_vec().into(),
+                };
+                match crate::body_query::OwnedForeignComptimeProgram::from_body_plan(
+                    foreign_plan,
+                    artifacts,
+                    seed,
+                    || self.queries.context.check_canceled(),
+                ) {
+                    Ok(program) => Ok(crate::body_query::ForeignComptimeCallLookup::Admitted(
+                        program,
+                    )),
+                    Err(
+                        crate::body_query::ForeignComptimeProgramProjectionFailure::Materialization(
+                            crate::canonical_lower::BodyPlanMaterializationFailure::Query(abort),
+                        ),
+                    ) => Err(abort),
+                    Err(error) => {
+                        Ok(crate::body_query::ForeignComptimeCallLookup::AdmissionFailure(error))
+                    }
+                }
+            }
+            rue_query::ReadyQueryProbe::NotReady => {
+                Ok(crate::body_query::ForeignComptimeCallLookup::NotReady)
+            }
+        }
+    }
+
     fn nucleus(
         &self,
         key: crate::semantic_query_nucleus::SemanticNucleusKey,
@@ -25093,6 +25208,7 @@ impl RevisionedQueryDatabase {
             module_source_bases: self.module_source_bases.clone(),
             lookup_names: self.lookup_names.clone(),
             lookup_imports: self.lookup_imports.clone(),
+            declaration_body_plan_artifacts: self.declaration_body_plan_artifacts.clone(),
             semantic_nucleus: self.semantic_nucleus.clone(),
             body_produced_anonymous: self.body_produced_anonymous.clone(),
             body_toolchain_demands: self.body_toolchain_demands.clone(),
@@ -28124,6 +28240,194 @@ fn main() -> i32 {
             materialized_option,
             "Option(i64) must materialize a real Some(i64)/None nominal: {:?}",
             projection.anonymous_nominals
+        );
+    }
+
+    #[test]
+    fn cold_foreign_comptime_probe_admits_owned_program_without_value_evaluation() {
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn target() -> i32 { @import(\"dep\"); 1 }",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let producer = StableDefinitionKey::from_stable_parts(
+            module,
+            crate::StableDefinitionNamespace::Value,
+            crate::StableDefinitionKind::Function,
+            "target",
+            None,
+        );
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&source),
+            &source,
+        );
+        let astgen_before = database
+            .declaration_body_plan_astgen_evaluations
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let probe = database
+            .probe_ready_body_facts(
+                revision,
+                semantic_configuration(),
+                "cold-foreign-comptime-probe",
+                |provider| provider.probe_comptime_call(&producer, &[], &[]),
+            )
+            .result
+            .unwrap();
+        let crate::body_query::ForeignComptimeCallLookup::Admitted(program) = probe else {
+            panic!("cold foreign comptime lookup should admit its owned body plan");
+        };
+        assert_eq!(program.plan.key.producer, producer);
+        assert_eq!(program.callable.context.as_str(), "main.rue");
+        assert_eq!(program.import_occurrences.len(), 1);
+        assert_eq!(
+            database
+                .declaration_body_plan_astgen_evaluations
+                .load(std::sync::atomic::Ordering::Relaxed),
+            astgen_before + 1
+        );
+        let candidate = declaration_candidate_for_stable_key(&producer).unwrap();
+        let comptime_key = crate::semantic_query_nucleus::SemanticNucleusKey::ComptimeCall(
+            crate::semantic_query_nucleus::ComptimeCallQueryKey {
+                declaration: crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
+                    declaration: candidate,
+                    configuration: semantic_configuration(),
+                },
+                type_arguments: Arc::from([]),
+                value_arguments: Arc::from([]),
+            },
+        );
+        assert!(
+            !database
+                .semantic_nucleus
+                .contains_retained_key(&comptime_key),
+            "a cold ready-only probe must not demand or evaluate its comptime value"
+        );
+    }
+
+    #[test]
+    fn ready_foreign_comptime_probe_reuses_full_projection_without_body_materialization() {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Category;
+        use crate::semantic_query_nucleus::{
+            ComptimeCallQueryKey, ComptimeCallResultProjection, SemanticNucleusKey,
+            SemanticNucleusValue,
+        };
+
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn selected(comptime seed: i32) -> i32 { seed + 64 }",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&source),
+            &source,
+        );
+        let producer = StableDefinitionKey::from_stable_parts(
+            module.clone(),
+            crate::StableDefinitionNamespace::Value,
+            crate::StableDefinitionKind::Function,
+            "selected",
+            None,
+        );
+        let declaration =
+            declaration_candidate(&database, revision, &module, Category::Function, "selected");
+        let key = SemanticNucleusKey::ComptimeCall(ComptimeCallQueryKey {
+            declaration: crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
+                declaration,
+                configuration: semantic_configuration(),
+            },
+            type_arguments: Arc::from([]),
+            value_arguments: Arc::from([(
+                Arc::from("seed"),
+                crate::durable_semantics::DurableConstValue::Integer(0),
+            )]),
+        });
+        let value = request_semantic_nucleus(&database, revision, key.clone());
+        let SemanticNucleusValue::ComptimeCall(projection) = value else {
+            panic!("the setup comptime call must publish a projection");
+        };
+        assert!(matches!(
+            &projection.result,
+            ComptimeCallResultProjection::Value(
+                crate::durable_semantics::DurableConstValue::Integer(64)
+            )
+        ));
+        let astgen_after_setup = database
+            .declaration_body_plan_astgen_evaluations
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let probe = database.probe_ready_body_facts(
+            revision,
+            semantic_configuration(),
+            "ready-foreign-comptime-probe",
+            |provider| {
+                provider.probe_comptime_call(
+                    &producer,
+                    &[],
+                    &[(
+                        Arc::from("seed"),
+                        crate::durable_semantics::DurableConstValue::Integer(0),
+                    )],
+                )
+            },
+        );
+        let outcome = probe.result.unwrap();
+        let crate::body_query::ForeignComptimeCallLookup::Ready(observed) = outcome else {
+            panic!("the ready probe must retain the published projection");
+        };
+        assert_eq!(observed, projection);
+        assert!(
+            probe
+                .dependencies
+                .iter()
+                .any(|dependency| dependency.family() == "compiler.semantic-nucleus")
+        );
+        assert!(
+            database
+                .declaration_body_plan_astgen_evaluations
+                .load(std::sync::atomic::Ordering::Relaxed)
+                == astgen_after_setup,
+            "a ready hit must not materialize the body-plan artifact"
+        );
+        assert!(
+            database.semantic_nucleus.contains_retained_key(&key),
+            "the exact semantic nucleus key remains the observed dependency"
+        );
+    }
+
+    #[test]
+    fn not_ready_foreign_probe_arm_is_unit_and_non_admitting() {
+        assert!(matches!(
+            crate::body_query::ForeignComptimeCallLookup::NotReady,
+            crate::body_query::ForeignComptimeCallLookup::NotReady
+        ));
+        let source = include_str!("revisioned_query_database.rs");
+        let not_ready = source
+            .find("ReadyQueryProbe::NotReady =>")
+            .expect("the canonical provider must handle NotReady");
+        let arm_end = source[not_ready..]
+            .find("\n            }")
+            .map(|offset| not_ready + offset)
+            .expect("the NotReady arm must have a bounded match body");
+        let arm = &source[not_ready..arm_end];
+        assert!(
+            arm.contains("ForeignComptimeCallLookup::NotReady"),
+            "NotReady must return its non-admissible unit variant"
+        );
+        assert!(
+            !arm.contains("declaration_body_plan_artifacts")
+                && !arm.contains("materialize_semantic_candidate_rir"),
+            "the NotReady arm must not query or materialize a body plan"
         );
     }
 

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -3109,6 +3109,20 @@ pub enum RequestExecution {
     Aborted,
 }
 
+/// Result of a non-evaluating registered-query observation.
+///
+/// A ready hit returns the exact retained terminal and records the same
+/// dependency/lease as an ordinary observed reuse. `Miss` means the key has no
+/// retained node or current terminal; `NotReady` means a retained node exists
+/// but its current-revision result is still being published or has an unsafe
+/// handoff. Neither negative result creates a node or starts work.
+#[derive(Debug, Clone)]
+pub enum ReadyQueryProbe<V> {
+    Ready(Arc<QueryTerminal<V>>),
+    Miss,
+    NotReady,
+}
+
 /// Runtime-owned immutable record of one nested query request.
 ///
 /// The value remains owned by its typed terminal. This type-erased lifecycle
@@ -6635,6 +6649,21 @@ where
         })
     }
 
+    /// Lease only an already-indexed node. Unlike `node`, this path never
+    /// mints an incarnation, so a ready-only observation cannot create a
+    /// competing admission authority on a cold key. The shard guard covers
+    /// lookup and the users increment together with retirement's re-check.
+    fn existing_node(&self, key: &K) -> Option<NodeLease<K, V>> {
+        let nodes = self.inner.nodes.shard(key);
+        let node = nodes.get(key)?.clone();
+        node.users.fetch_add(1, Ordering::AcqRel);
+        Some(NodeLease {
+            family: Arc::downgrade(&self.inner),
+            key: key.clone(),
+            node,
+        })
+    }
+
     fn query_task<F>(
         &self,
         task: Arc<Task>,
@@ -6665,6 +6694,130 @@ where
             None,
             true,
         )
+    }
+
+    fn probe_task_registered_ready(
+        &self,
+        task: &Arc<Task>,
+        key: &K,
+        origin_request: u64,
+    ) -> Result<ReadyQueryProbe<V>, QueryAbort> {
+        if task.cancellation.is_canceled() {
+            self.core
+                .metrics
+                .cancellations
+                .fetch_add(1, Ordering::Relaxed);
+            return Err(QueryAbort::Canceled);
+        }
+
+        if let Some(terminal) = task.cached_query(self.inner.token, key) {
+            let exact_node = ExactNodeIdentity {
+                display: terminal.node.clone(),
+                incarnation: terminal.node_incarnation,
+            };
+            if let Some(cycle) = task.stack_cycle(&exact_node) {
+                self.core.metrics.cycles.fetch_add(1, Ordering::Relaxed);
+                return Err(QueryAbort::Cycle(cycle));
+            }
+            if task.cancellation.is_canceled() {
+                self.core
+                    .metrics
+                    .cancellations
+                    .fetch_add(1, Ordering::Relaxed);
+                return Err(QueryAbort::Canceled);
+            }
+            self.core.metrics.reuses.fetch_add(1, Ordering::Relaxed);
+            task.observe(&terminal);
+            let result = TaskQueryResult::Terminal {
+                terminal: terminal.clone(),
+                execution: RequestExecution::Reused,
+                work: Vec::new(),
+            };
+            task.record_nested(origin_request, || terminal.node.clone(), &result);
+            return Ok(ReadyQueryProbe::Ready(terminal));
+        }
+
+        // Probe the existing memo index directly. In particular, do not call
+        // `node`: a miss must not mint a node or enter the evaluator path.
+        // The lease pins the exact incarnation across state inspection and
+        // terminal observation, preventing ABA retirement/recreation races.
+        let Some(node_lease) = self.existing_node(key) else {
+            return Ok(ReadyQueryProbe::Miss);
+        };
+        let node = &node_lease.node;
+
+        let candidate = {
+            let state = lock(&node.state);
+            let mut current = None;
+            let mut in_progress = false;
+            for attempt in state.attempts.iter().rev() {
+                if attempt.revision != task.revision {
+                    continue;
+                }
+                match &attempt.state {
+                    AttemptState::Computing { .. } => in_progress = true,
+                    AttemptState::Terminal {
+                        terminal, handoffs, ..
+                    } => {
+                        if current.is_none() {
+                            current = Some((terminal.clone(), handoffs.clone()));
+                        }
+                    }
+                }
+            }
+            if in_progress {
+                None
+            } else {
+                current.map(|(terminal, handoffs)| {
+                    let pin = self
+                        .pin_terminal(&terminal)
+                        .expect("a family pins its own retained terminal");
+                    (terminal, handoffs, pin)
+                })
+            }
+        };
+        let Some((terminal, handoffs, pin)) = candidate else {
+            let state = lock(&node.state);
+            let current_revision_exists = state.attempts.iter().any(|attempt| {
+                attempt.revision == task.revision
+                    && matches!(
+                        &attempt.state,
+                        AttemptState::Computing { .. } | AttemptState::Terminal { .. }
+                    )
+            });
+            return Ok(if current_revision_exists {
+                ReadyQueryProbe::NotReady
+            } else {
+                ReadyQueryProbe::Miss
+            });
+        };
+
+        // A terminal with a pending/invalid handoff is not safe to expose yet.
+        // Leave it untouched so the ordinary request path can retry and own
+        // the handoff lifecycle later.
+        if !task.observe_handoff(handoffs) {
+            drop(pin);
+            return Ok(ReadyQueryProbe::NotReady);
+        }
+        if task.cancellation.is_canceled() {
+            drop(pin);
+            self.core
+                .metrics
+                .cancellations
+                .fetch_add(1, Ordering::Relaxed);
+            return Err(QueryAbort::Canceled);
+        }
+        self.core.metrics.reuses.fetch_add(1, Ordering::Relaxed);
+        task.observe(&terminal);
+        self.lease_observed_pin(task, pin);
+        task.cache_query(self.inner.token, key, &terminal);
+        let result = TaskQueryResult::Terminal {
+            terminal: terminal.clone(),
+            execution: RequestExecution::Reused,
+            work: Vec::new(),
+        };
+        task.record_nested(origin_request, || terminal.node.clone(), &result);
+        Ok(ReadyQueryProbe::Ready(terminal))
     }
 
     fn query_task_registered_for_validation(
@@ -8441,6 +8594,30 @@ impl QueryContext {
             &result,
         );
         result.into_result()
+    }
+
+    /// Observes an already-published exact-current-revision terminal without
+    /// creating a node, evaluating, joining, or waiting. A miss or not-ready
+    /// result is intentionally typed so callers can materialize a separate
+    /// plan without accidentally demanding this registered family.
+    pub fn probe_registered_ready<K, V>(
+        &self,
+        family: &QueryFamily<K, V>,
+        key: K,
+    ) -> Result<ReadyQueryProbe<V>, QueryAbort>
+    where
+        K: QueryKey,
+        V: Clone + Send + Sync + 'static,
+    {
+        assert!(
+            family.inner.evaluator.is_some(),
+            "ready probes require a registered evaluator"
+        );
+        if !Arc::ptr_eq(&self.task_runtime(), &family.core) {
+            return Err(QueryAbort::ForeignRuntime);
+        }
+        let request_id = self.task.next_nested_request();
+        family.probe_task_registered_ready(&self.task, &key, request_id)
     }
 
     fn query_registered_ref<K, V>(
@@ -13349,6 +13526,240 @@ mod tests {
             64,
             "predicate enumeration visits the retained-key population"
         );
+    }
+
+    #[test]
+    fn ready_probe_observes_exact_terminal_without_demanding_a_miss() {
+        let runtime = QueryRuntime::new(1);
+        let first = revision(1);
+        publish_empty(&runtime, [first]);
+        let runs = Arc::new(AtomicUsize::new(0));
+        let runs_for_family = runs.clone();
+        let family = runtime
+            .family_with_evaluator::<Key, u64, _>("ready-probe", 8, move |_, _, _| {
+                runs_for_family.fetch_add(1, Ordering::Relaxed);
+                Ok(QueryOutput::success(7))
+            })
+            .unwrap();
+
+        let computed = runtime
+            .request_registered(&family, first, Key("ready"), CancellationToken::new())
+            .into_result()
+            .unwrap();
+        assert_eq!(runs.load(Ordering::Relaxed), 1);
+        drop(computed);
+
+        let root = runtime
+            .family_with_evaluator::<Key, u64, _>("ready-probe-root", 8, {
+                let family = family.clone();
+                move |context, _, _| {
+                    let ReadyQueryProbe::Ready(terminal) =
+                        context.probe_registered_ready(&family, Key("ready"))?
+                    else {
+                        unreachable!("the setup terminal is current and retained")
+                    };
+                    assert_eq!(terminal.outcome(), &QueryOutcome::Success(7));
+                    Ok(QueryOutput::success(8))
+                }
+            })
+            .unwrap();
+        let root_attempt =
+            runtime.request_registered(&root, first, Key("root"), CancellationToken::new());
+        assert!(root_attempt.abort().is_none());
+        assert_eq!(runs.load(Ordering::Relaxed), 1);
+        assert_eq!(root_attempt.terminal().unwrap().dependencies().len(), 1);
+        assert_eq!(
+            root_attempt
+                .nested_attempts()
+                .iter()
+                .filter(|attempt| attempt.node().family() == "ready-probe")
+                .count(),
+            1
+        );
+
+        drop(root_attempt);
+        drop(root);
+        drop(family);
+    }
+
+    #[test]
+    fn ready_probe_miss_and_stale_do_not_create_or_execute_work() {
+        let runtime = QueryRuntime::new(1);
+        let first = revision(1);
+        let second = revision(2);
+        publish_empty(&runtime, [first, second]);
+        let runs = Arc::new(AtomicUsize::new(0));
+        let runs_for_family = runs.clone();
+        let family = runtime
+            .family_with_evaluator::<Key, u64, _>("ready-probe-negative", 8, move |_, _, _| {
+                runs_for_family.fetch_add(1, Ordering::Relaxed);
+                Ok(QueryOutput::success(1))
+            })
+            .unwrap();
+        let root = runtime
+            .family_with_evaluator::<Key, u64, _>("ready-probe-negative-root", 8, {
+                let family = family.clone();
+                move |context, _, _| {
+                    assert!(matches!(
+                        context.probe_registered_ready(&family, Key("absent"))?,
+                        ReadyQueryProbe::Miss
+                    ));
+                    Ok(QueryOutput::success(0))
+                }
+            })
+            .unwrap();
+        runtime
+            .request_registered(&root, first, Key("root"), CancellationToken::new())
+            .into_result()
+            .unwrap();
+        assert_eq!(runs.load(Ordering::Relaxed), 0);
+        assert!(!family.contains_retained_key(&Key("absent")));
+
+        runtime
+            .request_registered(&family, first, Key("stale"), CancellationToken::new())
+            .into_result()
+            .unwrap();
+        assert_eq!(runs.load(Ordering::Relaxed), 1);
+        let stale_root = runtime
+            .family_with_evaluator::<Key, u64, _>("ready-probe-stale-root", 8, {
+                let family = family.clone();
+                move |context, _, _| {
+                    assert!(matches!(
+                        context.probe_registered_ready(&family, Key("stale"))?,
+                        ReadyQueryProbe::Miss
+                    ));
+                    Ok(QueryOutput::success(0))
+                }
+            })
+            .unwrap();
+        runtime
+            .request_registered(&stale_root, second, Key("root"), CancellationToken::new())
+            .into_result()
+            .unwrap();
+        assert_eq!(runs.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn ready_probe_reuses_task_cache_after_indexed_terminal_is_retired() {
+        let runtime = QueryRuntime::new(2);
+        let current = revision(1);
+        publish_empty(&runtime, [current]);
+        let family = runtime
+            .family_with_evaluator::<Key, u64, _>("ready-probe-task-cache", 1, |_, _, key| {
+                Ok(QueryOutput::success(if key.0 == "first" { 1 } else { 2 }))
+            })
+            .unwrap();
+        runtime
+            .request_registered(&family, current, Key("first"), CancellationToken::new())
+            .into_result()
+            .unwrap();
+        let root = runtime
+            .family_with_evaluator::<Key, u64, _>("ready-probe-task-cache-root", 1, {
+                let family = family.clone();
+                let runtime = runtime.clone();
+                move |context, _, _| {
+                    assert!(matches!(
+                        context.probe_registered_ready(&family, Key("first"))?,
+                        ReadyQueryProbe::Ready(_)
+                    ));
+                    let node_lease = family
+                        .existing_node(&Key("first"))
+                        .expect("the first memo incarnation remains indexed");
+                    let attempt_id = lock(&node_lease.node.state)
+                        .attempts
+                        .iter()
+                        .find_map(|attempt| {
+                            matches!(attempt.state, AttemptState::Terminal { .. })
+                                .then_some(attempt.id)
+                        })
+                        .expect("the first incarnation has a terminal attempt");
+                    family.detach_terminal_attempt(&node_lease.node, attempt_id);
+                    assert!(
+                        family.contains_retained_key(&Key("first")),
+                        "the exact-node lease must keep the retired incarnation indexed"
+                    );
+                    drop(node_lease);
+                    assert!(
+                        !family.contains_retained_key(&Key("first")),
+                        "the indexed first incarnation should be retired"
+                    );
+                    runtime
+                        .request_registered(
+                            &family,
+                            current,
+                            Key("first"),
+                            CancellationToken::new(),
+                        )
+                        .into_result()?;
+                    assert!(family.contains_retained_key(&Key("first")));
+                    assert!(matches!(
+                        context.probe_registered_ready(&family, Key("first"))?,
+                        ReadyQueryProbe::Ready(_)
+                    ));
+                    Ok(QueryOutput::success(0))
+                }
+            })
+            .unwrap();
+        runtime
+            .request_registered(&root, current, Key("root"), CancellationToken::new())
+            .into_result()
+            .unwrap();
+    }
+
+    #[test]
+    fn ready_probe_reports_in_progress_without_joining_or_waiting() {
+        let runtime = QueryRuntime::new(2);
+        let current = revision(1);
+        publish_empty(&runtime, [current]);
+        let claimed = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let runs = Arc::new(AtomicUsize::new(0));
+        let family = runtime
+            .family_with_evaluator::<Key, u64, _>("ready-probe-progress", 8, {
+                let claimed = claimed.clone();
+                let release = release.clone();
+                let runs = runs.clone();
+                move |_, _, _| {
+                    runs.fetch_add(1, Ordering::SeqCst);
+                    claimed.wait();
+                    release.wait();
+                    Ok(QueryOutput::success(1))
+                }
+            })
+            .unwrap();
+        let owner = thread::spawn({
+            let family = family.clone();
+            let runtime = runtime.clone();
+            move || {
+                runtime
+                    .request_registered(&family, current, Key("busy"), CancellationToken::new())
+                    .into_result()
+                    .unwrap()
+            }
+        });
+        claimed.wait();
+
+        let root = runtime
+            .family_with_evaluator::<Key, u64, _>("ready-probe-progress-root", 8, {
+                let family = family.clone();
+                move |context, _, _| {
+                    assert!(matches!(
+                        context.probe_registered_ready(&family, Key("busy"))?,
+                        ReadyQueryProbe::NotReady
+                    ));
+                    Ok(QueryOutput::success(2))
+                }
+            })
+            .unwrap();
+        let root_attempt =
+            runtime.request_registered(&root, current, Key("root"), CancellationToken::new());
+        assert_eq!(runs.load(Ordering::SeqCst), 1);
+        assert!(root_attempt.terminal().unwrap().dependencies().is_empty());
+        assert!(root_attempt.nested_attempts().is_empty());
+        root_attempt.into_result().unwrap();
+
+        release.wait();
+        owner.join().unwrap();
     }
 
     fn publish_empty(runtime: &QueryRuntime, revisions: impl IntoIterator<Item = Revision>) {


### PR DESCRIPTION
## Summary

- add a non-evaluating registered-query ready probe with exact-node leases, task-cache authority, and dependency recording
- project cold comptime misses into owned validated RIR programs with stable identity, ordered arguments, symbols, imports, and callable metadata
- preserve query aborts and make NotReady structurally non-admissible
- bind declaration body-plan artifacts to their exact candidate and cover ready, miss, in-progress, retirement/reincarnation, and identity mismatch paths

This is the final staged prerequisite for the durable host cutover. It does not change language semantics or call the existing durable evaluator from the new seam.

## Validation

- scripts/rue fmt
- scripts/rue unit query (189 passed)
- compiler revisioned-query suite (198 passed, 2 ignored)
- scripts/rue quick (31 targets; compiler 925 passed, 37 ignored after rebase)
- scripts/rue premerge (199 targets passed; combined CLI corpus had the known load-sensitive watch timeout after 2,157 passes)
- scripts/rue cli change_after_monitor_stops_is_still_announced (isolated rerun: 1 passed)
- adversarial architecture review: SHIP

Fixes RUE-1795