### PR TITLE
RUE-1702: harden import trust boundaries

### DIFF
--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -265,6 +265,27 @@ compile_stdout_contains = [
 compile_stderr_not_contains = ["undefined variable", "nope", "E0201"]
 
 [[case]]
+name = "ordinary_project_deps_use_nonescaping_identities"
+description = "RUE-1702: ordinary project-relative imports retain complete deps topology without trusted or escaping identities."
+files = [
+    { path = "main.rue", source = """
+const helper = @import("helper.rue");
+fn main() -> i32 { helper.answer() }
+""" },
+    { path = "helper.rue", source = """
+pub fn answer() -> i32 { 42 }
+""" },
+]
+args = ["--emit", "deps", "main.rue"]
+compile_only = true
+compile_stdout_contains = [
+    "\"status\": \"complete\"",
+    "\"module\": \"helper.rue\"",
+    "\"status\": \"resolved\"",
+]
+compile_stdout_not_contains = ["rue-std", "../"]
+
+[[case]]
 name = "emit_deps_rejects_unresolved_import"
 description = "RUE-810: --emit deps preserves a closed unresolved graph in an incomplete envelope and exits unsuccessfully."
 files = [
@@ -666,6 +687,69 @@ env = { RUE_STD_PATH = "${REAL_STD}" }
 compile_stderr_not_contains = ["unused function", "exit_syscall_number"]
 stdout = "5\n"
 
+# A project rooted beneath the configured toolchain must fail before import
+# discovery can mint trusted identities or write a dependency envelope.
+[[case]]
+name = "project_root_inside_std_root_is_configuration_error"
+description = "RUE-1702: a project nested beneath RUE_STD_PATH is rejected before deps output can contain trusted or escaping identities."
+env = { RUE_STD_PATH = "sdk" }
+files = [{ path = "sdk/project/main.rue", source = """
+fn main() -> i32 {
+    0
+}
+""" }]
+args = ["--emit", "deps", "sdk/project/main.rue"]
+compile_fail = true
+error_contains = ["project root", "inside the configured standard-library root"]
+compile_stdout_not_contains = ["rue-std", ".."]
+compile_stderr_not_contains = ["rue-std", ".."]
+
+[[case]]
+name = "project_root_inside_std_denies_std_only_intrinsic"
+description = "RUE-1702: configuration failure preempts a std-only intrinsic in a project nested beneath RUE_STD_PATH."
+env = { RUE_STD_PATH = "sdk" }
+files = [{ path = "sdk/project/main.rue", source = """
+const bridge = @import("bridge.rue");
+
+fn main() -> i32 {
+    let value: i64 = 7;
+    let pointer: ptr const i64 = checked { @raw(value) };
+    let P = bridge.Buf(i64);
+    let p = P { buf: pointer, value };
+    @intCast(p.get_ref(pointer))
+}
+""" },
+    { path = "sdk/project/bridge.rue", source = """
+pub fn Buf(comptime T: type) -> type {
+    struct {
+        buf: ptr const T,
+        value: T,
+
+        fn get_ref(borrow self, other: ptr const T) -> borrow T {
+            yield checked { @place(@ptr_offset(self.buf, 0)) };
+        }
+    }
+}
+""" },
+]
+args = ["sdk/project/main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["project root", "inside the configured standard-library root"]
+compile_stderr_not_contains = ["trusted standard-library", "rue-std", ".."]
+
+[[case]]
+name = "symlink_spelled_project_inside_std_root_is_configuration_error"
+description = "RUE-1702: canonical physical roots reject a project reached through a symlink into RUE_STD_PATH."
+env = { RUE_STD_PATH = "sdk" }
+files = [{ path = "sdk/main.rue", source = """
+fn main() -> i32 { 0 }
+""" }]
+symlinks = [{ link = "project", target = "sdk" }]
+args = ["project/main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["project root", "inside the configured standard-library root"]
+compile_stderr_not_contains = ["rue-std", ".."]
+
 # A trusted standard-library module may not use a relative import to leave the
 # captured SDK root. The rejected target exists so this exercises the lexical
 # escape decision rather than an absent-file diagnostic (RUE-1738).
@@ -735,6 +819,66 @@ pub fn answer() -> i32 {
 """ },
 ]
 exit_code = 42
+
+[[case]]
+name = "trusted_std_deps_use_safe_module_identities"
+description = "RUE-1702: valid captured std imports retain their physical closure while deps output contains no escaping identities or paths."
+env = { RUE_STD_PATH = "sdk" }
+files = [
+    { path = "main.rue", source = """
+const std = @import("std");
+fn main() -> i32 { std.nested.answer() }
+""" },
+    { path = "sdk/_std.rue", source = """
+pub const nested = @import("nested/helper.rue");
+""" },
+    { path = "sdk/nested/helper.rue", source = """
+pub fn answer() -> i32 { 42 }
+""" },
+]
+args = ["--emit", "deps", "main.rue"]
+compile_only = true
+compile_stdout_contains = [
+    "\"status\": \"complete\"",
+    "std/nested/helper.rue",
+    "\"status\": \"resolved\"",
+]
+compile_stdout_not_contains = ["../"]
+
+[[case]]
+name = "trusted_std_place_bridge_exact_shape_compiles"
+description = "RUE-1702: the exact receiver-rooted place bridge is admissible for a captured trusted std module."
+env = { RUE_STD_PATH = "sdk" }
+files = [
+    { path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let value: i64 = 7;
+    let pointer: ptr const i64 = checked { @raw(value) };
+    let P = std.bridge.Buf(i64);
+    let p = P { buf: pointer, value };
+    @intCast(p.get_ref(pointer))
+}
+""" },
+    { path = "sdk/_std.rue", source = """
+pub const bridge = @import("bridge.rue");
+""" },
+    { path = "sdk/bridge.rue", source = """
+pub fn Buf(comptime T: type) -> type {
+    struct {
+        buf: ptr const T,
+        value: T,
+
+        fn get_ref(borrow self, other: ptr const T) -> borrow T {
+            yield checked { @place(@ptr_offset(self.buf, 0)) };
+        }
+    }
+}
+""" },
+]
+args = ["main.rue", "-o", "prog"]
+exit_code = 7
 
 [[case]]
 name = "program_anchored_std_import_precedes_sdk"

--- a/crates/rue-cli-tests/cases/watch.toml
+++ b/crates/rue-cli-tests/cases/watch.toml
@@ -88,9 +88,9 @@ symlink_target = "target_b.rue"
 # inside it every run: without the fix this case times out after 30s with
 # `timed out waiting for watch event "change-detected"`, exactly as CI reported.
 #
-# `compile_delay_ms` is deliberately 0 here -- this case is about the boundary
-# window, not the in-flight one, and leaving the compile fast keeps the edit
-# from being caught by the monitor instead.
+# A bounded in-flight delay makes the second edit land after compile-started
+# but before publication, independently of host load. The first edit still
+# exercises the widened post-monitor boundary above.
 [[case]]
 name = "change_after_monitor_stops_is_still_announced"
 files = [{ path = "main.rue", source = "fn main() -> i32 { 1 }\n" }]
@@ -98,6 +98,7 @@ files = [{ path = "main.rue", source = "fn main() -> i32 { 1 }\n" }]
 [case.watch]
 kind = "cancel"
 boundary_delay_ms = 400
+compile_delay_ms = 100
 expected_exit_codes = [1, 3]
 
 [[case.watch.edits]]

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -44,6 +44,15 @@ impl ImportDiscoveryContext {
     ) -> CompileResult<Self> {
         let project_root = normalize_absolute(project_root.as_ref())?;
         let std_root = std_root.map(normalize_absolute).transpose()?.map(Arc::from);
+        if std_root
+            .as_deref()
+            .is_some_and(|std_root| Path::new(&project_root).starts_with(std_root))
+        {
+            return Err(invalid_input(format!(
+                "project root {:?} is inside the configured standard-library root",
+                project_root
+            )));
+        }
         Ok(Self {
             epoch,
             project_root: Arc::from(project_root),
@@ -1506,6 +1515,7 @@ fn canonicalize_accepted(mut accepted: Vec<&AcceptedImportSource>) -> Vec<&Accep
 pub(crate) fn escaping_import_candidate(
     context: &ImportDiscoveryContext,
     specifier: &str,
+    importer: &ModuleId,
     importer_requested_path: &str,
 ) -> CompileResult<Option<String>> {
     if specifier == "std" {
@@ -1518,10 +1528,18 @@ pub(crate) fn escaping_import_candidate(
         return Ok(None);
     }
     let importer_path = normalize_absolute(importer_requested_path)?;
-    let boundary_root = context
-        .std_root()
-        .filter(|std_root| Path::new(&importer_path).starts_with(std_root))
-        .unwrap_or(context.project_root());
+    // The trusted-standard-library boundary belongs to the module's accepted
+    // provenance, not to whatever filesystem spelling happened to accompany
+    // the read. A project source may live beneath a misconfigured std root;
+    // treating that lexical fact as authority would grant it std-only
+    // semantics and let it mint trusted identities.
+    let boundary_root = if importer.is_trusted_standard_library() {
+        context.std_root().ok_or_else(|| {
+            invalid_input("trusted standard-library module has no captured std root")
+        })?
+    } else {
+        context.project_root()
+    };
     let importer_dir = parent_dir(&importer_path);
     let groups = discovery_candidate_groups(
         specifier,
@@ -1613,8 +1631,13 @@ pub(crate) fn discovery_groups_for_occurrence(
     // decided lexically from the importer anchor and its project or captured
     // standard-library root, and the diagnostic projection recomputes the same
     // check (`escape_diagnostics`).
-    if escaping_import_candidate(context, occurrence.specifier(), importer_requested_path)?
-        .is_some()
+    if escaping_import_candidate(
+        context,
+        occurrence.specifier(),
+        occurrence.importer(),
+        importer_requested_path,
+    )?
+    .is_some()
     {
         return Ok(Vec::new());
     }
@@ -1750,7 +1773,8 @@ pub(crate) fn escape_diagnostics(
                 continue;
             }
         };
-        match escaping_import_candidate(context, site.specifier(), &importer_path) {
+        match escaping_import_candidate(context, site.specifier(), site.importer(), &importer_path)
+        {
             Ok(Some(candidate)) => {
                 let file_id = program
                     .module(site.importer())
@@ -3033,9 +3057,17 @@ fn classify_module(
                     requested, std_root
                 )));
             }
-            return ModuleId::from_trusted_standard_library_path(
-                Path::new("\0rue-std").join(relative).to_string_lossy(),
-            );
+            let logical = Path::new("\0rue-std").join(relative);
+            if logical
+                .components()
+                .any(|component| matches!(component, Component::ParentDir))
+            {
+                return Err(invalid_input(format!(
+                    "trusted standard-library source {:?} would receive an escaping identity",
+                    requested
+                )));
+            }
+            return ModuleId::from_trusted_standard_library_path(logical.to_string_lossy());
         }
     }
     let project_root = Path::new(context.project_root());
@@ -3045,6 +3077,15 @@ fn classify_module(
             requested
         ))
     })?;
+    if logical
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err(invalid_input(format!(
+            "project source {:?} would receive an escaping identity",
+            requested
+        )));
+    }
     ModuleId::from_logical_path(logical.to_string_lossy())
 }
 
@@ -3103,6 +3144,12 @@ fn lexical_relative_path(base: &Path, target: &Path) -> Option<PathBuf> {
             result.push(part);
         }
     }
+    if result
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return None;
+    }
     Some(result)
 }
 pub(crate) fn source_fingerprint(source: &str) -> u64 {
@@ -3120,6 +3167,43 @@ mod tests {
 
     fn context(epoch: u64) -> ImportDiscoveryContext {
         ImportDiscoveryContext::new(epoch, "/project", Some("/sdk"), "all").unwrap()
+    }
+
+    #[test]
+    fn project_root_inside_or_equal_to_std_root_is_rejected() {
+        for (project, std_root) in [("/sdk/project", "/sdk"), ("/sdk", "/sdk")] {
+            let error = ImportDiscoveryContext::new(1, project, Some(std_root), "all")
+                .expect_err("a project rooted inside std must fail closed");
+            assert!(
+                error
+                    .to_string()
+                    .contains("inside the configured standard-library root")
+            );
+        }
+        // The supported layout remains valid: the captured std tree is a
+        // child of the project, so project-relative and trusted identities have
+        // disjoint roots.
+        ImportDiscoveryContext::new(1, "/project", Some("/project/std"), "all")
+            .expect("std nested inside the project is valid");
+    }
+
+    #[test]
+    fn project_provenance_does_not_inherit_std_boundary_from_its_path() {
+        let context =
+            ImportDiscoveryContext::new(1, "/project", Some("/project/std"), "all").unwrap();
+        let importer = ModuleId::from_logical_path("std/main.rue").unwrap();
+        // The spelling is beneath std, but the accepted module provenance is a
+        // caller module. Its escape is measured against the project root.
+        assert_eq!(
+            escaping_import_candidate(
+                &context,
+                "../outside.rue",
+                &importer,
+                "/project/std/main.rue",
+            )
+            .unwrap(),
+            None
+        );
     }
 
     fn occurrence(importer: &str, specifier: &str) -> ImportOccurrenceKey {
@@ -3148,9 +3232,14 @@ mod tests {
             (&facade, "/sdk/nested/mod.rue", "/outside/_outside.rue"),
         ] {
             assert_eq!(
-                escaping_import_candidate(&context, occurrence.specifier(), importer)
-                    .unwrap()
-                    .as_deref(),
+                escaping_import_candidate(
+                    &context,
+                    occurrence.specifier(),
+                    occurrence.importer(),
+                    importer
+                )
+                .unwrap()
+                .as_deref(),
                 Some(expected)
             );
             assert!(
@@ -3212,7 +3301,13 @@ mod tests {
             // One mistake, one diagnostic: the escape check declines these so
             // they are not also reported as leaving the project root.
             assert_eq!(
-                escaping_import_candidate(&context, specifier, "/project/main.rue").unwrap(),
+                escaping_import_candidate(
+                    &context,
+                    specifier,
+                    &ModuleId::from_logical_path("main.rue").unwrap(),
+                    "/project/main.rue",
+                )
+                .unwrap(),
                 None,
                 "{specifier} also reported as escaping"
             );
@@ -3238,8 +3333,13 @@ mod tests {
         let context = context(1);
         let in_root = occurrence("/sdk/nested/mod.rue", "../nested/helper.rue");
         assert_eq!(
-            escaping_import_candidate(&context, in_root.specifier(), "/sdk/nested/mod.rue")
-                .unwrap(),
+            escaping_import_candidate(
+                &context,
+                in_root.specifier(),
+                in_root.importer(),
+                "/sdk/nested/mod.rue",
+            )
+            .unwrap(),
             None
         );
         assert!(
@@ -3250,7 +3350,13 @@ mod tests {
 
         let std = occurrence("/sdk/nested/mod.rue", "std");
         assert_eq!(
-            escaping_import_candidate(&context, std.specifier(), "/sdk/nested/mod.rue").unwrap(),
+            escaping_import_candidate(
+                &context,
+                std.specifier(),
+                std.importer(),
+                "/sdk/nested/mod.rue",
+            )
+            .unwrap(),
             None
         );
         assert!(
@@ -3315,7 +3421,6 @@ mod tests {
                 // The production path normalizer resolves nested and parent-relative
                 // spellings before classify_module assigns the durable identity.
                 project.join("./left/nested/../entry.rue"),
-                root.join("dep.rue"),
                 project.join("right/shared.rue"),
             ]
             .iter()
@@ -3323,21 +3428,24 @@ mod tests {
             .collect()
         }
 
+        fn rejects_external_source(root: &Path) {
+            let project = root.join("project");
+            let context =
+                ImportDiscoveryContext::new(1, project.to_string_lossy(), None, "all").unwrap();
+            let path = normalize_path(&root.join("dep.rue").to_string_lossy());
+            assert!(classify_module(&context, &path, &path).is_err());
+        }
+
         let base = if cfg!(windows) {
             PathBuf::from(r"C:\rue-import-discovery-relocation")
         } else {
             PathBuf::from("/tmp/rue-import-discovery-relocation")
         };
-        let expected = [
-            "main.rue",
-            "left/entry.rue",
-            "../dep.rue",
-            "right/shared.rue",
-        ]
-        .into_iter()
-        .map(ModuleId::from_logical_path)
-        .map(Result::unwrap)
-        .collect::<Vec<_>>();
+        let expected = ["main.rue", "left/entry.rue", "right/shared.rue"]
+            .into_iter()
+            .map(ModuleId::from_logical_path)
+            .map(Result::unwrap)
+            .collect::<Vec<_>>();
 
         assert_eq!(
             identities(&base.join("a")),
@@ -3349,6 +3457,7 @@ mod tests {
             expected,
             "moving the physical project root does not change module identities"
         );
+        rejects_external_source(&base.join("a"));
     }
 
     #[test]

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -314,6 +314,22 @@ fn capture_std_root(std_root: &Path) -> PathBuf {
     fs::canonicalize(std_root).unwrap_or_else(|_| normalize_lexical_path(std_root))
 }
 
+fn reject_project_root_inside_std(
+    root_canonical: &Path,
+    std_root: Option<&Path>,
+) -> Result<(), SourceLoadError> {
+    let Some(project_root) = root_canonical.parent() else {
+        return Ok(());
+    };
+    if std_root.is_some_and(|std_root| project_root.starts_with(std_root)) {
+        return Err(SourceLoadError::Message(format!(
+            "Error: project root {:?} is inside the configured standard-library root",
+            project_root
+        )));
+    }
+    Ok(())
+}
+
 #[derive(Debug)]
 enum StableReadError {
     Io(std::io::Error),
@@ -1416,7 +1432,30 @@ pub(crate) fn discover_and_load_imports(
         .parent()
         .unwrap_or_else(|| Path::new("/"))
         .to_path_buf();
-    let std_root = std_root.map(capture_std_root);
+    // The CLI's empty RUE_STD_PATH spelling means that no toolchain std is
+    // configured. Preserve that established contract before canonicalization:
+    // canonicalizing `""` would otherwise turn it into the current project
+    // directory and make the physical overlap guard reject ordinary projects.
+    let std_root = std_root
+        .filter(|path| !path.as_os_str().is_empty())
+        .map(capture_std_root);
+    let canonicalize_root = || {
+        fs::canonicalize(&root_path).map_err(|error| {
+            SourceLoadError::Message(format!("Error reading {}: {error}", root_path.display()))
+        })
+    };
+    // The compiler context retains the lexical project spelling for durable
+    // caller identities, but the trust boundary is physical. When a toolchain
+    // root is configured, validate that boundary before discovery can classify
+    // any source. Keep the no-std path's established context-before-root-read
+    // order so watch cycles do not change their fast publication timing.
+    let root_canonical = if std_root.is_some() {
+        let root_canonical = canonicalize_root()?;
+        reject_project_root_inside_std(&root_canonical, std_root.as_deref())?;
+        Some(root_canonical)
+    } else {
+        None
+    };
     let policy_revision = source_manifest
         .as_ref()
         .map(SourceManifest::policy_revision)
@@ -1431,9 +1470,10 @@ pub(crate) fn discover_and_load_imports(
         policy_revision,
     )
     .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
-    let root_canonical = fs::canonicalize(&root_path).map_err(|error| {
-        SourceLoadError::Message(format!("Error reading {}: {error}", root_path.display()))
-    })?;
+    let root_canonical = match root_canonical {
+        Some(root_canonical) => root_canonical,
+        None => canonicalize_root()?,
+    };
     if source_manifest
         .as_ref()
         .is_some_and(|manifest| !manifest.allows_canonical(&root_canonical))
@@ -1548,6 +1588,13 @@ pub(crate) fn reload_from_filesystem(
             root_entry.requested_path()
         ))
     })?;
+    // The retained root may have been retargeted since the previous close. Run
+    // the same physical containment guard after reobservation, before the new
+    // assembler can classify or publish the retargeted source.
+    reject_project_root_inside_std(
+        Path::new(root.canonical_path()),
+        context.std_root().map(Path::new),
+    )?;
     let mut assembler = DiscoverySourceAssembler::new_with_symlink_route(
         context.clone(),
         root.requested_path(),
@@ -2907,6 +2954,19 @@ mod tests {
         );
     }
 
+    #[test]
+    fn empty_std_root_remains_unconfigured_across_reload() {
+        let dir = TestDir::new("empty-std-root");
+        let main = dir.write("main.rue", "fn main() -> i32 { 0 }");
+        let mut result =
+            discover_and_load_imports(main.to_str().unwrap(), None, Some(Path::new("")))
+                .expect("an empty std path means no configured toolchain");
+
+        assert!(result.std_root.is_none());
+        reload_from_filesystem(&mut result).expect("reload preserves the empty-path contract");
+        assert!(result.std_root.is_none());
+    }
+
     /// ADR-0075 stamp atomicity: a wave publishes one revision covering reads
     /// taken across its whole closure, so a source rewritten after it was read
     /// and before the wave publishes must be caught as a batch, fail-closed.
@@ -3250,6 +3310,37 @@ mod tests {
             entry.requested_path() == alias.to_string_lossy()
                 && entry.canonical_path() == second_canonical.to_string_lossy()
         }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn retained_project_symlink_retarget_into_std_fails_closed() {
+        let dir = TestDir::new("retained-project-symlink-std-boundary");
+        let std_dir = dir.path.join("std");
+        fs::create_dir(&std_dir).unwrap();
+        let project_dir = dir.path.join("project");
+        fs::create_dir(&project_dir).unwrap();
+        let first = project_dir.join("main.rue");
+        fs::write(&first, "fn main() -> i32 { 1 }").unwrap();
+        fs::write(std_dir.join("main.rue"), "fn main() -> i32 { 2 }").unwrap();
+        let alias = dir.path.join("project-alias");
+        std::os::unix::fs::symlink(&project_dir, &alias).unwrap();
+        let std_root = fs::canonicalize(&std_dir).unwrap();
+        let root = alias.join("main.rue");
+
+        let mut result = discover_and_load_imports(root.to_str().unwrap(), None, Some(&std_root))
+            .expect("the initial root is outside std");
+        fs::remove_file(&alias).unwrap();
+        std::os::unix::fs::symlink(&std_dir, &alias).unwrap();
+
+        let error = reload_from_filesystem(&mut result)
+            .expect_err("a retained project retarget into std must fail closed");
+        assert!(matches!(
+            error,
+            SourceLoadError::Message(message)
+                if message.contains("project root")
+                    && message.contains("inside the configured standard-library root")
+        ));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- choose relative-import escape boundaries from accepted module provenance
- reject canonical project/std-root overlap on cold open and reload, including symlink retargets, while preserving an empty RUE_STD_PATH
- refuse escaping module identities and cover trusted/project dependency output plus std-only intrinsic controls
- make the existing watch-boundary fixture deterministic without changing production watch behavior

## Validation

- scripts/rue fmt
- focused compiler import-discovery unit tests: 51 passed
- focused CLI import/watch regressions and positive controls
- scripts/rue quick: 31 targets passed
- scripts/rue premerge: passed
- scripts/rue test: 234 targets passed
- adversarial trust-boundary/filesystem-identity review: SHIP

Fixes RUE-1702