### PR TITLE
RUE-1774: extract durable comptime services

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -2562,6 +2562,7 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
         if !matches!(
             *name,
             "declaration_candidate"
+                | "durable_comptime"
                 | "parsed_modules"
                 | "revisioned_query_database"
                 | "semantic_query_nucleus"
@@ -3100,6 +3101,43 @@ fn durable_const_integer_semantics_use_the_shared_kernel() {
             "durable evaluator regained local integer policy: {forbidden}"
         );
     }
+}
+
+#[test]
+fn durable_comptime_services_are_named_authority_operations() {
+    let facade = include_str!("durable_comptime.rs");
+    for required in [
+        "DurableImportSite",
+        "DurableComptimeSemanticAuthority",
+        "DurableComptimeForeignCallAuthority",
+        "probe_comptime_call",
+    ] {
+        assert!(
+            facade.contains(required),
+            "durable facade missing {required}"
+        );
+    }
+    for forbidden in ["InstData", "eval_const_expr", "ComptimeEngine", "InstRef"] {
+        assert!(
+            !facade.contains(forbidden),
+            "durable service facade must not become an evaluator: {forbidden}"
+        );
+    }
+
+    let database = include_str!("revisioned_query_database.rs");
+    let evaluator = database
+        .split("impl SemanticConstEvaluator<'_, '_> {")
+        .nth(1)
+        .and_then(|source| source.split("impl SemanticNucleusTypeProvider<'_>").next())
+        .expect("durable evaluator source");
+    assert!(evaluator.contains("DurableComptimeServices::new(&authority)"));
+    assert!(evaluator.contains(".resolve_import(&site)"));
+    let provider = database
+        .split("pub(crate) struct CompilerBodyFactProvider<'a>")
+        .nth(1)
+        .and_then(|source| source.split("impl rue_air::BodyFactProvider").next())
+        .expect("body fact provider source");
+    assert!(provider.contains("DurableComptimeServices::new(self).probe_comptime_call"));
 }
 
 #[test]

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -9,9 +9,91 @@
 use std::sync::Arc;
 
 use rue_air::{ComptimeType, ComptimeValue};
+use rue_query::QueryAbort;
 
 use crate::ModuleId;
+use crate::body_query::ForeignComptimeCallLookup;
+use crate::declaration_candidate::{DeclarationCandidateKey, DeclarationImportFailure};
 use crate::durable_semantics::{DurableConstValue, DurableType};
+
+/// The exact semantic site consumed by the durable import authority.
+///
+/// This intentionally carries the declaration identity, semantic occurrence,
+/// and decoded specifier only. It cannot name or evaluate an RIR instruction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DurableImportSite {
+    pub(crate) declaration: DeclarationCandidateKey,
+    pub(crate) occurrence: u32,
+    pub(crate) specifier: Arc<str>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DurableImportResolution {
+    Resolved(ModuleId),
+    Missing,
+    Failure(DeclarationImportFailure),
+}
+
+/// Canonical semantic services needed by durable comptime entry points.
+///
+/// Implementations live beside the query authorities. This facade is an
+/// operation boundary, not an evaluator: neither trait accepts an instruction
+/// reference, instruction data, or callback capable of evaluating a child.
+pub(crate) trait DurableComptimeSemanticAuthority {
+    fn check_canceled(&self) -> Result<(), QueryAbort>;
+
+    fn resolve_import(
+        &self,
+        site: &DurableImportSite,
+    ) -> Result<DurableImportResolution, QueryAbort>;
+}
+
+pub(crate) trait DurableComptimeForeignCallAuthority {
+    fn probe_comptime_call(
+        &self,
+        producer: &crate::StableDefinitionKey,
+        type_arguments: &[(Arc<str>, DurableType)],
+        value_arguments: &[(Arc<str>, DurableConstValue)],
+    ) -> Result<ForeignComptimeCallLookup, QueryAbort>;
+}
+
+pub(crate) struct DurableComptimeServices<'a, A: ?Sized> {
+    authority: &'a A,
+}
+
+impl<'a, A: ?Sized> DurableComptimeServices<'a, A> {
+    pub(crate) fn new(authority: &'a A) -> Self {
+        Self { authority }
+    }
+}
+
+impl<A: DurableComptimeSemanticAuthority + ?Sized> DurableComptimeServices<'_, A> {
+    pub(crate) fn check_canceled(&self) -> Result<(), QueryAbort> {
+        self.authority.check_canceled()
+    }
+
+    pub(crate) fn resolve_import(
+        &self,
+        site: &DurableImportSite,
+    ) -> Result<DurableImportResolution, QueryAbort> {
+        self.authority.resolve_import(site)
+    }
+}
+
+impl<A: DurableComptimeForeignCallAuthority + ?Sized> DurableComptimeServices<'_, A> {
+    /// Probe only an already-published foreign fact or admit its owned body
+    /// frame. The authority owns dependency observation and cancellation; this
+    /// method never demands a child comptime query.
+    pub(crate) fn probe_comptime_call(
+        &self,
+        producer: &crate::StableDefinitionKey,
+        type_arguments: &[(Arc<str>, DurableType)],
+        value_arguments: &[(Arc<str>, DurableConstValue)],
+    ) -> Result<ForeignComptimeCallLookup, QueryAbort> {
+        self.authority
+            .probe_comptime_call(producer, type_arguments, value_arguments)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum EvaluatedSemanticConst {

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -7065,6 +7065,51 @@ fn semantic_candidate_type_is_named(
         .is_some_and(|symbol| symbols[symbol.into_usize()] == expected)
 }
 
+/// Exact query authorities used by durable comptime services. Keeping this
+/// adapter separate from the evaluator makes cancellation and import-site
+/// resolution reusable by the AIR host without allowing it to inspect RIR.
+struct SemanticComptimeAuthority<'provider, 'db> {
+    provider: &'provider SemanticNucleusTypeProvider<'db>,
+    imports: &'db QueryFamily<DeclarationImportQueryKey, DeclarationImportQueryValue>,
+}
+
+impl crate::durable_comptime::DurableComptimeSemanticAuthority
+    for SemanticComptimeAuthority<'_, '_>
+{
+    fn check_canceled(&self) -> Result<(), QueryAbort> {
+        self.provider.context.check_canceled()
+    }
+
+    fn resolve_import(
+        &self,
+        site: &crate::durable_comptime::DurableImportSite,
+    ) -> Result<crate::durable_comptime::DurableImportResolution, QueryAbort> {
+        let key = crate::declaration_candidate::DeclarationImportSiteKey {
+            declaration: site.declaration.clone(),
+            occurrence: site.occurrence,
+            specifier: site.specifier.clone(),
+        };
+        let terminal = self
+            .provider
+            .context
+            .query_registered(self.imports, DeclarationImportQueryKey(key))?;
+        let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
+            unreachable!("DeclarationImport publishes typed values")
+        };
+        Ok(match value {
+            DeclarationImportQueryValue::Available(crate::CanonicalImportResolution::Resolved(
+                module,
+            )) => crate::durable_comptime::DurableImportResolution::Resolved(module.clone()),
+            DeclarationImportQueryValue::Available(crate::CanonicalImportResolution::Missing) => {
+                crate::durable_comptime::DurableImportResolution::Missing
+            }
+            DeclarationImportQueryValue::Failure(failure) => {
+                crate::durable_comptime::DurableImportResolution::Failure(failure.clone())
+            }
+        })
+    }
+}
+
 thread_local! {
     static SEMANTIC_COMPTIME_CALL_DEPTH: std::cell::Cell<usize> =
         const { std::cell::Cell::new(0) };
@@ -7621,28 +7666,28 @@ impl SemanticConstEvaluator<'_, '_> {
                 "exact const import is absent from its candidate RIR occurrence index",
             );
         };
-        let key = crate::declaration_candidate::DeclarationImportSiteKey {
+        let authority = SemanticComptimeAuthority {
+            provider: &*self.provider,
+            imports: self.imports,
+        };
+        let services = crate::durable_comptime::DurableComptimeServices::new(&authority);
+        let site = crate::durable_comptime::DurableImportSite {
             declaration: self.declaration.declaration.clone(),
             occurrence: *occurrence,
             specifier: specifier.clone(),
         };
-        let terminal = self
-            .provider
-            .context
-            .query_registered(self.imports, DeclarationImportQueryKey(key.clone()))
-            .map_err(EvaluateSemanticConstError::Abort)?;
-        let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
-            unreachable!("DeclarationImport publishes typed values")
-        };
-        match value {
-            DeclarationImportQueryValue::Available(crate::CanonicalImportResolution::Resolved(
-                module,
-            )) => Ok(EvaluatedSemanticConst::Module(module.clone())),
-            DeclarationImportQueryValue::Available(crate::CanonicalImportResolution::Missing) => {
+        match services
+            .resolve_import(&site)
+            .map_err(EvaluateSemanticConstError::Abort)?
+        {
+            crate::durable_comptime::DurableImportResolution::Resolved(module) => {
+                Ok(EvaluatedSemanticConst::Module(module))
+            }
+            crate::durable_comptime::DurableImportResolution::Missing => {
                 Self::failure(format!("cannot find module `{specifier}`"))
             }
-            DeclarationImportQueryValue::Failure(
-                crate::declaration_candidate::DeclarationImportFailure::ResolutionUnavailable(_),
+            crate::durable_comptime::DurableImportResolution::Failure(
+                crate::declaration_candidate::DeclarationImportFailure::ResolutionUnavailable(key),
             ) => Err(EvaluateSemanticConstError::Abort(QueryAbort::MissingInput(
                 InputIdentity::new(
                     "declaration-import-resolution",
@@ -7654,7 +7699,9 @@ impl SemanticConstEvaluator<'_, '_> {
                     ),
                 ),
             ))),
-            DeclarationImportQueryValue::Failure(failure) => Self::failure(format!("{failure:?}")),
+            crate::durable_comptime::DurableImportResolution::Failure(failure) => {
+                Self::failure(format!("{failure:?}"))
+            }
         }
     }
 
@@ -8250,8 +8297,11 @@ impl SemanticConstEvaluator<'_, '_> {
         &mut self,
         expression: rue_rir::InstRef,
     ) -> Result<EvaluatedSemanticConst, EvaluateSemanticConstError> {
-        self.provider
-            .context
+        let authority = SemanticComptimeAuthority {
+            provider: &*self.provider,
+            imports: self.imports,
+        };
+        crate::durable_comptime::DurableComptimeServices::new(&authority)
             .check_canceled()
             .map_err(Self::abort)?;
         use crate::durable_semantics::DurableConstValue as V;
@@ -23571,7 +23621,7 @@ impl<'a> CompilerBodyFactProvider<'a> {
     /// owned foreign-program payload; an in-progress semantic handoff remains
     /// NotReady and never competes with the active evaluator.
     #[allow(dead_code)]
-    fn probe_comptime_call(
+    fn probe_comptime_call_inner(
         &self,
         producer: &crate::StableDefinitionKey,
         type_arguments: &[(Arc<str>, crate::durable_semantics::DurableType)],
@@ -23673,6 +23723,19 @@ impl<'a> CompilerBodyFactProvider<'a> {
                 Ok(crate::body_query::ForeignComptimeCallLookup::NotReady)
             }
         }
+    }
+
+    pub(crate) fn probe_comptime_call(
+        &self,
+        producer: &crate::StableDefinitionKey,
+        type_arguments: &[(Arc<str>, crate::durable_semantics::DurableType)],
+        value_arguments: &[(Arc<str>, crate::durable_semantics::DurableConstValue)],
+    ) -> Result<crate::body_query::ForeignComptimeCallLookup, QueryAbort> {
+        crate::durable_comptime::DurableComptimeServices::new(self).probe_comptime_call(
+            producer,
+            type_arguments,
+            value_arguments,
+        )
     }
 
     fn nucleus(
@@ -23828,6 +23891,17 @@ impl<'a> CompilerBodyFactProvider<'a> {
             });
         }
         found
+    }
+}
+
+impl crate::durable_comptime::DurableComptimeForeignCallAuthority for CompilerBodyFactProvider<'_> {
+    fn probe_comptime_call(
+        &self,
+        producer: &crate::StableDefinitionKey,
+        type_arguments: &[(Arc<str>, crate::durable_semantics::DurableType)],
+        value_arguments: &[(Arc<str>, crate::durable_semantics::DurableConstValue)],
+    ) -> Result<crate::body_query::ForeignComptimeCallLookup, QueryAbort> {
+        self.probe_comptime_call_inner(producer, type_arguments, value_arguments)
     }
 }
 


### PR DESCRIPTION
Relates to RUE-1774.

This is a staged, non-closing migration slice. It extracts a live DurableComptimeServices capability boundary over the existing semantic/query authorities and routes the current evaluator and body fact provider through it.

The facade exposes only named operations for cancellation, exact import-site resolution, and ready-only foreign comptime-call probing. It cannot inspect RIR instructions, invoke an evaluator, or construct a nested engine. Existing import outcomes, cancellation ordering, dependency observation, cold admission, ready hits, and NotReady behavior are preserved.

Validation:
- scripts/rue unit compiler durable_: 30 passed
- focused cold and ready foreign probes: 2 passed
- scripts/rue quick: 31 targets passed
- scripts/rue premerge: 200 passed, zero failures or timeouts
- adversarial architectural review: SHIP