### PR TITLE
RUE-1774: route durable identifier services

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -3110,6 +3110,9 @@ fn durable_comptime_services_are_named_authority_operations() {
         "DurableImportSite",
         "DurableComptimeSemanticAuthority",
         "DurableComptimeForeignCallAuthority",
+        "resolve_candidate",
+        "resolve_identity",
+        "resolve_const",
         "probe_comptime_call",
     ] {
         assert!(
@@ -3132,6 +3135,9 @@ fn durable_comptime_services_are_named_authority_operations() {
         .expect("durable evaluator source");
     assert!(evaluator.contains("DurableComptimeServices::new(&authority)"));
     assert!(evaluator.contains(".resolve_import(&site)"));
+    assert!(evaluator.contains(".resolve_candidate("));
+    assert!(evaluator.contains(".resolve_identity("));
+    assert!(evaluator.contains(".resolve_const("));
     let provider = database
         .split("pub(crate) struct CompilerBodyFactProvider<'a>")
         .nth(1)

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -15,6 +15,7 @@ use crate::ModuleId;
 use crate::body_query::ForeignComptimeCallLookup;
 use crate::declaration_candidate::{DeclarationCandidateKey, DeclarationImportFailure};
 use crate::durable_semantics::{DurableConstValue, DurableType};
+use crate::semantic_query_nucleus::SemanticNucleusFailure;
 
 /// The exact semantic site consumed by the durable import authority.
 ///
@@ -41,6 +42,35 @@ pub(crate) enum DurableImportResolution {
 /// reference, instruction data, or callback capable of evaluating a child.
 pub(crate) trait DurableComptimeSemanticAuthority {
     fn check_canceled(&self) -> Result<(), QueryAbort>;
+
+    /// Resolve a declaration through the canonical name/shell authority.
+    /// Visibility and shell disagreement diagnostics are produced by the
+    /// authority; the facade only carries the semantic request and result.
+    fn resolve_candidate(
+        &self,
+        module: &ModuleId,
+        name: &str,
+        kind: crate::DefinitionKind,
+    ) -> Result<
+        Option<DeclarationCandidateKey>,
+        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+    >;
+
+    fn resolve_identity(
+        &self,
+        declaration: DeclarationCandidateKey,
+    ) -> Result<
+        crate::semantic_query_nucleus::DeclarationIdentityProjection,
+        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+    >;
+
+    fn resolve_const(
+        &self,
+        declaration: DeclarationCandidateKey,
+    ) -> Result<
+        crate::semantic_query_nucleus::ConstResolutionProjection,
+        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+    >;
 
     fn resolve_import(
         &self,
@@ -70,6 +100,38 @@ impl<'a, A: ?Sized> DurableComptimeServices<'a, A> {
 impl<A: DurableComptimeSemanticAuthority + ?Sized> DurableComptimeServices<'_, A> {
     pub(crate) fn check_canceled(&self) -> Result<(), QueryAbort> {
         self.authority.check_canceled()
+    }
+
+    pub(crate) fn resolve_candidate(
+        &self,
+        module: &ModuleId,
+        name: &str,
+        kind: crate::DefinitionKind,
+    ) -> Result<
+        Option<DeclarationCandidateKey>,
+        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+    > {
+        self.authority.resolve_candidate(module, name, kind)
+    }
+
+    pub(crate) fn resolve_identity(
+        &self,
+        declaration: DeclarationCandidateKey,
+    ) -> Result<
+        crate::semantic_query_nucleus::DeclarationIdentityProjection,
+        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+    > {
+        self.authority.resolve_identity(declaration)
+    }
+
+    pub(crate) fn resolve_const(
+        &self,
+        declaration: DeclarationCandidateKey,
+    ) -> Result<
+        crate::semantic_query_nucleus::ConstResolutionProjection,
+        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+    > {
+        self.authority.resolve_const(declaration)
     }
 
     pub(crate) fn resolve_import(

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -7080,6 +7080,47 @@ impl crate::durable_comptime::DurableComptimeSemanticAuthority
         self.provider.context.check_canceled()
     }
 
+    fn resolve_candidate(
+        &self,
+        module: &ModuleId,
+        name: &str,
+        kind: DefinitionKind,
+    ) -> Result<
+        Option<crate::declaration_candidate::DeclarationCandidateKey>,
+        rue_air::SemanticProviderError<
+            QueryAbort,
+            crate::semantic_query_nucleus::SemanticNucleusFailure,
+        >,
+    > {
+        self.provider.candidate(module, name, kind)
+    }
+
+    fn resolve_identity(
+        &self,
+        declaration: crate::declaration_candidate::DeclarationCandidateKey,
+    ) -> Result<
+        crate::semantic_query_nucleus::DeclarationIdentityProjection,
+        rue_air::SemanticProviderError<
+            QueryAbort,
+            crate::semantic_query_nucleus::SemanticNucleusFailure,
+        >,
+    > {
+        self.provider.identity(declaration)
+    }
+
+    fn resolve_const(
+        &self,
+        declaration: crate::declaration_candidate::DeclarationCandidateKey,
+    ) -> Result<
+        crate::semantic_query_nucleus::ConstResolutionProjection,
+        rue_air::SemanticProviderError<
+            QueryAbort,
+            crate::semantic_query_nucleus::SemanticNucleusFailure,
+        >,
+    > {
+        self.provider.const_resolution(declaration)
+    }
+
     fn resolve_import(
         &self,
         site: &crate::durable_comptime::DurableImportSite,
@@ -7712,19 +7753,8 @@ impl SemanticConstEvaluator<'_, '_> {
         if let Some(value) = self.locals.get(&name) {
             return Ok(value.clone());
         }
-        if let Some(candidate) = self
-            .provider
-            .candidate(
-                &self.declaration.declaration.module,
-                &name,
-                DefinitionKind::Const,
-            )
-            .map_err(Self::provider_error)?
-        {
-            let resolution = self
-                .provider
-                .const_resolution(candidate)
-                .map_err(Self::provider_error)?;
+        if let Some(candidate) = self.resolve_candidate(&name, DefinitionKind::Const)? {
+            let resolution = self.resolve_const(candidate)?;
             let key = match &resolution {
                 crate::semantic_query_nucleus::ConstResolutionProjection::Value { key, .. }
                 | crate::semantic_query_nucleus::ConstResolutionProjection::ModuleBinding {
@@ -7753,19 +7783,8 @@ impl SemanticConstEvaluator<'_, '_> {
                 } => EvaluatedSemanticConst::Module(target),
             });
         }
-        if let Some(candidate) = self
-            .provider
-            .candidate(
-                &self.declaration.declaration.module,
-                &name,
-                DefinitionKind::Function,
-            )
-            .map_err(Self::provider_error)?
-        {
-            let identity = self
-                .provider
-                .identity(candidate)
-                .map_err(Self::provider_error)?;
+        if let Some(candidate) = self.resolve_candidate(&name, DefinitionKind::Function)? {
+            let identity = self.resolve_identity(candidate)?;
             self.provider.dependencies.insert(
                 crate::semantic_query_nucleus::SemanticDeclarationDependency {
                     source: self.provider.dependency_source.clone(),
@@ -7781,15 +7800,8 @@ impl SemanticConstEvaluator<'_, '_> {
             )));
         }
         for kind in [DefinitionKind::Struct, DefinitionKind::Enum] {
-            if let Some(candidate) = self
-                .provider
-                .candidate(&self.declaration.declaration.module, &name, kind)
-                .map_err(Self::provider_error)?
-            {
-                let identity = self
-                    .provider
-                    .identity(candidate)
-                    .map_err(Self::provider_error)?;
+            if let Some(candidate) = self.resolve_candidate(&name, kind)? {
+                let identity = self.resolve_identity(candidate)?;
                 self.provider.dependencies.insert(
                     crate::semantic_query_nucleus::SemanticDeclarationDependency {
                         source: self.provider.dependency_source.clone(),
@@ -7808,6 +7820,56 @@ impl SemanticConstEvaluator<'_, '_> {
             }
         }
         Self::failure(format!("undefined constant `{name}`"))
+    }
+
+    fn resolve_candidate(
+        &self,
+        name: &str,
+        kind: DefinitionKind,
+    ) -> Result<
+        Option<crate::declaration_candidate::DeclarationCandidateKey>,
+        EvaluateSemanticConstError,
+    > {
+        let authority = SemanticComptimeAuthority {
+            provider: &*self.provider,
+            imports: self.imports,
+        };
+        let services = crate::durable_comptime::DurableComptimeServices::new(&authority);
+        services
+            .resolve_candidate(&self.declaration.declaration.module, name, kind)
+            .map_err(Self::provider_error)
+    }
+
+    fn resolve_identity(
+        &self,
+        declaration: crate::declaration_candidate::DeclarationCandidateKey,
+    ) -> Result<
+        crate::semantic_query_nucleus::DeclarationIdentityProjection,
+        EvaluateSemanticConstError,
+    > {
+        let authority = SemanticComptimeAuthority {
+            provider: &*self.provider,
+            imports: self.imports,
+        };
+        let services = crate::durable_comptime::DurableComptimeServices::new(&authority);
+        services
+            .resolve_identity(declaration)
+            .map_err(Self::provider_error)
+    }
+
+    fn resolve_const(
+        &self,
+        declaration: crate::declaration_candidate::DeclarationCandidateKey,
+    ) -> Result<crate::semantic_query_nucleus::ConstResolutionProjection, EvaluateSemanticConstError>
+    {
+        let authority = SemanticComptimeAuthority {
+            provider: &*self.provider,
+            imports: self.imports,
+        };
+        let services = crate::durable_comptime::DurableComptimeServices::new(&authority);
+        services
+            .resolve_const(declaration)
+            .map_err(Self::provider_error)
     }
 
     fn eval_call(


### PR DESCRIPTION
Relates to RUE-1774.

This is a staged, non-closing migration slice. It extends the live DurableComptimeServices boundary with canonical candidate, identity, and const-resolution operations, then routes the current durable evaluator through those operations for constants, functions, structs, and enums.

All computation remains in SemanticNucleusTypeProvider. Identifier precedence, visibility diagnostics, provider errors, module bindings, dependency kinds, and dependency timing are unchanged. The facade still cannot inspect RIR instructions, invoke an evaluator, or construct a nested engine.

Validation:
- scripts/rue unit compiler durable_: 30 passed
- scripts/rue unit compiler comptime: 21 passed, 1 platform-native ignored
- scripts/rue quick: 31 targets passed
- scripts/rue premerge: 200 passed, zero failures or timeouts
- adversarial architectural review: SHIP