### PR TITLE
RUE-1684: preserve derived accessor loans through joins

### DIFF
--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -1332,34 +1332,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     span,
                 ));
             }
-            if let Some((_, exclusive_span)) = ctx
-                .expression_exclusive_uses
-                .iter()
-                .find(|(used_root, _)| *used_root == root)
-            {
-                return Err(CompileError::new(
-                    ErrorKind::AccessorLoanConflict {
-                        variable: self.body_interner().resolve(&root).to_string(),
-                        conflict: "for an accessor result after an exclusive use",
-                    },
-                    span,
-                )
-                .with_label("exclusive use here", *exclusive_span));
-            }
-            if loan_kind == CallLoanKind::Inout
-                && ctx
-                    .expression_shared_reads
-                    .iter()
-                    .any(|(read_root, _)| *read_root == root)
-            {
-                return Err(CompileError::new(
-                    ErrorKind::AccessorLoanConflict {
-                        variable: self.body_interner().resolve(&root).to_string(),
-                        conflict: "for an exclusive accessor result after a shared read",
-                    },
-                    span,
-                ));
-            }
+            self.reject_accessor_loan_against_expression_ledgers(root, loan_kind, span, ctx)?;
             ctx.expression_loans.push((root, span, loan_kind));
         }
         ctx.accessor_call_insts.insert(inst_ref, (method, root));
@@ -5761,6 +5734,47 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         Ok(())
     }
 
+    /// Check the completed-use ledgers that a nested full-expression boundary
+    /// temporarily hides. Direct accessor calls and arm-loan readmission both
+    /// use this check so evaluation order has one conflict rule.
+    fn reject_accessor_loan_against_expression_ledgers(
+        &self,
+        root: Spur,
+        kind: CallLoanKind,
+        span: Span,
+        ctx: &AnalysisContext,
+    ) -> CompileResult<()> {
+        if let Some((_, exclusive_span)) = ctx
+            .expression_exclusive_uses
+            .iter()
+            .find(|(used_root, _)| *used_root == root)
+        {
+            return Err(CompileError::new(
+                ErrorKind::AccessorLoanConflict {
+                    variable: self.body_interner().resolve(&root).to_string(),
+                    conflict: "for an accessor result after an exclusive use",
+                },
+                span,
+            )
+            .with_label("exclusive use here", *exclusive_span));
+        }
+        if kind == CallLoanKind::Inout
+            && ctx
+                .expression_shared_reads
+                .iter()
+                .any(|(read_root, _)| *read_root == root)
+        {
+            return Err(CompileError::new(
+                ErrorKind::AccessorLoanConflict {
+                    variable: self.body_interner().resolve(&root).to_string(),
+                    conflict: "for an exclusive accessor result after a shared read",
+                },
+                span,
+            ));
+        }
+        Ok(())
+    }
+
     /// Remember an exclusive use after its operation has completed. A
     /// nested call's live loan frame disappears when that call returns, but
     /// its exclusive use still conflicts with a later accessor result in the
@@ -5893,38 +5907,38 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         found
     }
 
-    /// Does the value of `operand` carry an accessor result out of a join
-    /// (ADR-0062, RUE-1678)? Used by the `if`/`match` arm analyses to decide
-    /// whether an arm's accessor loan outlives the arm's nested-full-expression
-    /// boundary; see [`Self::accessor_results_of`].
-    fn yields_accessor_result(&self, operand: InstRef, ctx: &AnalysisContext) -> bool {
-        !self.accessor_results_of(operand, ctx).is_empty()
-    }
-
     /// Carry an `if`/`match` arm's accessor loans into the join's enclosing
-    /// full expression, when the arm's value is what the join yields
+    /// full expression when the arm's tail is the join's value
     /// (ADR-0062 6.6:10, RUE-1678).
     ///
     /// Each arm is analyzed as a nested full expression, so `loans` — taken
     /// with `nested_expression_loans` just before that boundary closed — has
-    /// already been discarded by the time this runs. For an arm whose value
-    /// is an accessor result the discard is wrong: the loan's extent is the
-    /// full expression the JOIN belongs to, so an exclusive use of the same
-    /// root anywhere in it is still E0259 (`using(if c { g.at(0) } else { 0 },
-    /// inout g)`). Arms are alternatives rather than siblings, so every arm's
-    /// loans are readmitted only after the last arm has been analyzed —
-    /// readmitting earlier would make one arm's loan conflict with the next
-    /// arm's accessor call on the same root.
+    /// already been discarded by the time this runs. A loan still active at
+    /// the arm's tail belongs to the full expression the JOIN belongs to,
+    /// even when that tail consumes the accessor result into an ordinary
+    /// value: an exclusive use of the same root anywhere in it is still E0259
+    /// (`using(if c { g.at(0) + 1 } else { 0 }, inout g)`).
+    /// Arms are alternatives rather than siblings, so every arm's loans are
+    /// readmitted only after the last arm has been analyzed — readmitting
+    /// earlier would make one arm's loan conflict with the next arm's
+    /// accessor call on the same root.
+    /// `value_continues` is false for diverging arms, unreachable joins, and
+    /// comptime-selected unit-valued `if` bodies; those paths carry no value
+    /// loan into the enclosing full expression.
     pub(crate) fn readmit_arm_accessor_loans(
         &self,
         ctx: &mut AnalysisContext,
-        arm: InstRef,
         loans: Vec<(Spur, Span, CallLoanKind)>,
-    ) {
-        if loans.is_empty() || !self.yields_accessor_result(arm, ctx) {
-            return;
+        value_continues: bool,
+    ) -> CompileResult<()> {
+        if loans.is_empty() || !value_continues {
+            return Ok(());
+        }
+        for (root, span, kind) in &loans {
+            self.reject_accessor_loan_against_expression_ledgers(*root, *kind, *span, ctx)?;
         }
         ctx.readmit_expression_loans(loans);
+        Ok(())
     }
 
     /// Reject the escape of an accessor result (ADR-0062): `operand` is the

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -210,11 +210,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         ctx.exit_full_expression(boundary);
                         let result = result?;
                         ctx.pop_scope();
-                        // The selected branch IS this `if`'s value, so an
-                        // accessor result it yields keeps its loan for the
+                        // With an `else`, the selected branch is this `if`'s
+                        // value, so loans surviving its tail belong to the
                         // enclosing full expression (RUE-1678), exactly as on
                         // the ordinary two-armed path below.
-                        self.readmit_arm_accessor_loans(ctx, block, loans);
+                        self.readmit_arm_accessor_loans(
+                            ctx,
+                            loans,
+                            else_block.is_some() && result.continues,
+                        )?;
                         // An `if` without `else` is unit-typed, so its (taken)
                         // then-branch must still be unit (spec 4.6:5).
                         if else_block.is_none()
@@ -263,10 +267,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // Save move state before entering branches.
             let saved_moves = ctx.moved_vars.clone();
 
-            // Analyze then branch with its own scope. An arm's accessor loan
-            // is harvested before the arm's boundary closes: if the arm's
-            // value is the `if`'s value, that loan belongs to the enclosing
-            // full expression and is readmitted once both arms are analyzed
+            // Analyze then branch with its own scope. Loans surviving the
+            // arm's tail are harvested before its boundary closes and belong
+            // to the enclosing full expression once both arms are analyzed
             // (ADR-0062 6.6:10, RUE-1678).
             ctx.push_scope();
             let boundary = ctx.enter_full_expression();
@@ -297,12 +300,19 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let else_span = self.body_rir_ref().get(else_b).span;
             ctx.pop_scope();
 
-            // Both arms are analyzed, so an arm's accessor loan can no longer
-            // be mistaken for a conflicting sibling of the other arm's
-            // accessor call. Readmit the loans of whichever arms yield the
-            // `if`'s value as an accessor result (RUE-1678).
-            self.readmit_arm_accessor_loans(ctx, then_block, then_loans);
-            self.readmit_arm_accessor_loans(ctx, else_b, else_loans);
+            // Both arms are analyzed, so one arm's loan cannot be mistaken for
+            // a conflicting sibling of the other arm's accessor call. Readmit
+            // the loans that survived each arm's tail (RUE-1678).
+            self.readmit_arm_accessor_loans(
+                ctx,
+                then_loans,
+                cond_result.continues && then_continues,
+            )?;
+            self.readmit_arm_accessor_loans(
+                ctx,
+                else_loans,
+                cond_result.continues && else_continues,
+            )?;
 
             // Capture else-branch's move state
             let else_moves = ctx.moved_vars.clone();
@@ -1031,10 +1041,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         ctx.exit_full_expression(boundary);
                         let result = result?;
                         ctx.pop_scope();
-                        // The selected arm IS this `match`'s value, so an
-                        // accessor result it yields keeps its loan for the
-                        // enclosing full expression (RUE-1678).
-                        self.readmit_arm_accessor_loans(ctx, body, loans);
+                        // The selected arm is this `match`'s value, so loans
+                        // surviving its tail belong to the enclosing full
+                        // expression (RUE-1678).
+                        self.readmit_arm_accessor_loans(ctx, loans, result.continues)?;
                         return Ok(result);
                     }
                 }
@@ -1408,10 +1418,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // Analyze arm body
             let boundary = ctx.enter_full_expression();
             let body_result = self.analyze_inst(air, *body, ctx);
-            arm_accessor_loans.push((*body, ctx.nested_expression_loans(&boundary)));
+            let body_loans = ctx.nested_expression_loans(&boundary);
             ctx.exit_full_expression(boundary);
             let body_result = body_result?;
             let body_type = body_result.ty;
+            arm_accessor_loans.push((*body, body_loans, body_result.continues));
 
             // Payload bindings are ordinary locals living in the ARM scope,
             // not in the body's own block scope, so the block-exit
@@ -1523,12 +1534,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             air_arms.push((air_pattern, arm_body_ref));
         }
 
-        // Every arm is analyzed, so an arm's accessor loan can no longer be
-        // mistaken for a conflicting sibling of a later arm's accessor call.
-        // Readmit the loans of whichever arms yield the `match`'s value as an
-        // accessor result (ADR-0062 6.6:10, RUE-1678).
-        for (body, loans) in arm_accessor_loans {
-            self.readmit_arm_accessor_loans(ctx, body, loans);
+        // Every arm is analyzed, so one arm's loan cannot be mistaken for a
+        // conflicting sibling of a later arm's accessor call. Readmit the
+        // loans that survived each arm's tail (ADR-0062 6.6:10, RUE-1678).
+        for (_, loans, body_continues) in arm_accessor_loans {
+            self.readmit_arm_accessor_loans(
+                ctx,
+                loans,
+                scrutinee_result.continues && body_continues,
+            )?;
         }
 
         // Join the arms' move states (union of non-diverging arms;

--- a/crates/rue-spec/cases/items/borrow-accessors.toml
+++ b/crates/rue-spec/cases/items/borrow-accessors.toml
@@ -1896,3 +1896,340 @@ fn main() -> i32 {
 """
 expected_stdout = "12\n"
 exit_code = 0
+
+[[case]]
+name = "derived_joined_accessor_result_conflicts_with_inout"
+spec = ["6.6:10"]
+description = "An accessor result consumed by a copy-read in an if arm still conflicts with a sibling exclusive use (E0259)."
+source = """
+struct Grid {
+    cells: [i64; 4],
+
+    fn at(borrow self, i: u64) -> borrow i64 {
+        yield self.cells[i];
+    }
+}
+fn using(a: i64, b: i64) -> i64 { a + b }
+fn bump(inout g: Grid) -> i64 {
+    g.cells[0] = 9;
+    0
+}
+fn main() -> i32 {
+    let mut g = Grid { cells: [1, 2, 3, 4] };
+    using(if true { g.at(0) + 1 } else { 0 }, bump(inout g));
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0259", "while an accessor result borrows it"]
+
+[[case]]
+name = "derived_joined_accessor_result_conflicts_with_prior_inout"
+spec = ["6.6:10"]
+description = "A completed exclusive sibling use is checked when a derived accessor loan is readmitted from a later if arm (E0259)."
+source = """
+struct Grid {
+    cells: [i64; 4],
+
+    fn at(borrow self, i: u64) -> borrow i64 {
+        yield self.cells[i];
+    }
+}
+fn using(a: i64, b: i64) -> i64 { a + b }
+fn bump(inout g: Grid) -> i64 {
+    g.cells[0] = 9;
+    0
+}
+fn main() -> i32 {
+    let mut g = Grid { cells: [1, 2, 3, 4] };
+    using(bump(inout g), if true { g.at(0) + 1 } else { 0 });
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0259", "after an exclusive use"]
+
+[[case]]
+name = "derived_joined_accessor_result_diverging_if_arm_is_not_readmitted"
+spec = ["6.6:10"]
+description = "A diverging if arm has no continuing accessor-loan path, so a later sibling inout remains legal."
+source = """
+struct Grid {
+    cells: [i64; 4],
+
+    fn at(borrow self, i: u64) -> borrow i64 { yield self.cells[i]; }
+}
+fn using(a: i64, b: i64) -> i64 { a + b }
+fn bump(inout g: Grid) -> i64 { g.cells[0] = 9; 0 }
+fn stop() -> ! { loop {} }
+fn choose(c: bool, inout g: Grid) -> i64 {
+    using(if c { g.at(0) + stop() } else { 0 }, bump(inout g))
+}
+fn main() -> i32 {
+    let mut g = Grid { cells: [1, 2, 3, 4] };
+    choose(false, inout g);
+    0
+}
+"""
+compile_only = true
+
+[[case]]
+name = "derived_joined_accessor_result_diverging_if_condition_is_not_readmitted"
+spec = ["6.6:10"]
+description = "A diverging if condition has no continuing accessor-loan path, so later sibling analysis stays isolated."
+source = """
+struct Grid {
+    cells: [i64; 4],
+
+    fn at(borrow self, i: u64) -> borrow i64 { yield self.cells[i]; }
+}
+fn using(a: i64, b: i64) -> i64 { a + b }
+fn bump(inout g: Grid) -> i64 { g.cells[0] = 9; 0 }
+fn stop() -> ! { loop {} }
+fn choose(inout g: Grid) -> i64 {
+    using(if stop() { g.at(0) + 1 } else { 0 }, bump(inout g))
+}
+fn main() -> i32 {
+    let mut g = Grid { cells: [1, 2, 3, 4] };
+    choose(inout g);
+    0
+}
+"""
+compile_only = true
+
+[[case]]
+name = "derived_joined_accessor_result_diverging_match_arm_is_not_readmitted"
+spec = ["6.6:10"]
+description = "A diverging match arm has no continuing accessor-loan path, so a later sibling inout remains legal."
+source = """
+struct Grid {
+    cells: [i64; 4],
+
+    fn at(borrow self, i: u64) -> borrow i64 { yield self.cells[i]; }
+}
+fn using(a: i64, b: i64) -> i64 { a + b }
+fn bump(inout g: Grid) -> i64 { g.cells[0] = 9; 0 }
+fn stop() -> ! { loop {} }
+fn choose(n: i32, inout g: Grid) -> i64 {
+    using(match n { 0 => g.at(0) + stop(), _ => 0 }, bump(inout g))
+}
+fn main() -> i32 {
+    let mut g = Grid { cells: [1, 2, 3, 4] };
+    choose(1, inout g);
+    0
+}
+"""
+compile_only = true
+
+[[case]]
+name = "derived_joined_accessor_result_comptime_if_without_else_is_unit"
+spec = ["4.14:17", "6.6:10"]
+description = "A comptime-selected if without else remains unit-valued and does not carry its body loan into a sibling."
+source = """
+struct Grid {
+    cells: [i64; 4],
+
+    fn at(borrow self, i: u64) -> borrow i64 { yield self.cells[i]; }
+}
+fn consume(v: i64) -> () {}
+fn using(a: (), b: i64) -> i64 { b }
+fn bump(inout g: Grid) -> i64 { g.cells[0] = 9; 0 }
+fn choose(comptime c: bool, inout g: Grid) -> i64 {
+    using(if c { consume(g.at(0) + 1) }, bump(inout g))
+}
+fn main() -> i32 {
+    let mut g = Grid { cells: [1, 2, 3, 4] };
+    choose(true, inout g);
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "derived_joined_accessor_result_comptime_if_divergence_is_not_readmitted"
+spec = ["4.14:17", "6.6:10"]
+description = "A diverging comptime-selected if arm has no continuing accessor-loan path, so a later sibling inout remains legal."
+source = """
+struct Grid {
+    cells: [i64; 4],
+    fn at(borrow self, i: u64) -> borrow i64 { yield self.cells[i]; }
+}
+fn using(a: i64, b: i64) -> i64 { a + b }
+fn bump(inout g: Grid) -> i64 { g.cells[0] = 9; 0 }
+fn stop() -> ! { loop {} }
+fn choose(comptime c: bool, inout g: Grid) -> i64 {
+    using(if c { g.at(0) + stop() } else { 0 }, bump(inout g))
+}
+fn main() -> i32 {
+    let mut g = Grid { cells: [1, 2, 3, 4] };
+    choose(true, inout g);
+    0
+}
+"""
+compile_only = true
+
+[[case]]
+name = "derived_joined_accessor_result_comptime_match_divergence_is_not_readmitted"
+spec = ["4.14:19", "6.6:10"]
+description = "A diverging comptime-selected match arm has no continuing accessor-loan path, so a later sibling inout remains legal."
+source = """
+struct Grid {
+    cells: [i64; 4],
+    fn at(borrow self, i: u64) -> borrow i64 { yield self.cells[i]; }
+}
+fn using(a: i64, b: i64) -> i64 { a + b }
+fn bump(inout g: Grid) -> i64 { g.cells[0] = 9; 0 }
+fn stop() -> ! { loop {} }
+fn choose(comptime n: i32, inout g: Grid) -> i64 {
+    using(match n { 0 => g.at(0) + stop(), _ => 0 }, bump(inout g))
+}
+fn main() -> i32 {
+    let mut g = Grid { cells: [1, 2, 3, 4] };
+    choose(0, inout g);
+    0
+}
+"""
+compile_only = true
+
+[[case]]
+name = "derived_joined_accessor_result_diverging_match_scrutinee_is_not_readmitted"
+spec = ["6.6:10"]
+description = "A diverging match scrutinee has no continuing accessor-loan path, so its arm loans do not reach a later sibling inout."
+source = """
+struct Grid {
+    cells: [i64; 4],
+    fn at(borrow self, i: u64) -> borrow i64 { yield self.cells[i]; }
+}
+fn using(a: i64, b: i64) -> i64 { a + b }
+fn bump(inout g: Grid) -> i64 { g.cells[0] = 9; 0 }
+fn choose(inout g: Grid) -> i64 {
+    using(
+        match if @panic(\"stop\") { 0 } else { 1 } {
+            0 => g.at(0) + 1,
+            _ => 0,
+        },
+        bump(inout g),
+    )
+}
+fn main() -> i32 {
+    let mut g = Grid { cells: [1, 2, 3, 4] };
+    choose(inout g);
+    0
+}
+"""
+compile_only = true
+
+[[case]]
+name = "derived_joined_accessor_result_conflicts_through_match_arm"
+spec = ["6.6:10"]
+description = "A match arm that consumes an accessor result by copy-read carries its loan to the enclosing full expression (E0259)."
+source = """
+struct Grid {
+    cells: [i64; 4],
+
+    fn at(borrow self, i: u64) -> borrow i64 {
+        yield self.cells[i];
+    }
+}
+fn using(a: i64, b: i64) -> i64 { a + b }
+fn bump(inout g: Grid) -> i64 {
+    g.cells[0] = 9;
+    0
+}
+fn main() -> i32 {
+    let mut g = Grid { cells: [1, 2, 3, 4] };
+    let n = 0;
+    using(match n { 0 => g.at(0) + 1, _ => 0 }, bump(inout g));
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0259", "while an accessor result borrows it"]
+
+[[case]]
+name = "derived_joined_accessor_result_alternative_arms_are_legal"
+spec = ["6.6:8", "6.6:10"]
+description = "Accessor loans from alternative if arms do not conflict with one another when each is consumed by a copy-read."
+source = """
+struct P {
+    x: i64,
+    y: i64,
+
+    fn xr(borrow self) -> borrow i64 { yield self.x; }
+    fn yr(borrow self) -> borrow i64 { yield self.y; }
+}
+fn main() -> i32 {
+    let p = P { x: 7, y: 3 };
+    let value = if true { p.xr() + 1 } else { p.yr() + 1 };
+    if value == 8 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "derived_joined_accessor_result_child_statement_does_not_escape"
+spec = ["6.6:8", "6.6:10"]
+description = "An accessor result in a discarded nested-block statement remains isolated from the enclosing sibling inout."
+source = """
+struct P {
+    value: i64,
+
+    fn f(borrow self) -> borrow i64 { yield self.value; }
+}
+fn g(inout p: P) -> i64 { p.value = p.value + 1; 0 }
+fn use_two(a: i64, b: i64) -> i64 { a + b }
+fn main() -> i32 {
+    let mut p = P { value: 2 };
+    use_two({ p.f() == 2; 0 }, g(inout p));
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "derived_joined_accessor_result_comptime_if_conflicts"
+spec = ["4.14:17", "6.6:10"]
+description = "A comptime-selected if arm carries a derived accessor loan to the enclosing full expression (E0259)."
+source = """
+struct Grid {
+    cells: [i64; 4],
+
+    fn at(borrow self, i: u64) -> borrow i64 { yield self.cells[i]; }
+}
+fn using(a: i64, b: i64) -> i64 { a + b }
+fn bump(inout g: Grid) -> i64 { g.cells[0] = 9; 0 }
+fn choose(comptime c: bool, inout g: Grid) -> i64 {
+    using(bump(inout g), if c { g.at(0) + 1 } else { 0 })
+}
+fn main() -> i32 {
+    let mut g = Grid { cells: [1, 2, 3, 4] };
+    choose(true, inout g);
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0259", "after an exclusive use"]
+
+[[case]]
+name = "derived_joined_accessor_result_comptime_match_conflicts"
+spec = ["4.14:19", "6.6:10"]
+description = "A comptime-selected match arm carries a derived accessor loan to the enclosing full expression (E0259)."
+source = """
+struct Grid {
+    cells: [i64; 4],
+
+    fn at(borrow self, i: u64) -> borrow i64 { yield self.cells[i]; }
+}
+fn using(a: i64, b: i64) -> i64 { a + b }
+fn bump(inout g: Grid) -> i64 { g.cells[0] = 9; 0 }
+fn choose(comptime n: i32, inout g: Grid) -> i64 {
+    using(bump(inout g), match n { 0 => g.at(0) + 1, _ => 0 })
+}
+fn main() -> i32 {
+    let mut g = Grid { cells: [1, 2, 3, 4] };
+    choose(0, inout g);
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0259", "after an exclusive use"]


### PR DESCRIPTION
## Summary

- carry accessor loans from continuing `if` and `match` arm tails through the surrounding full expression after copy reads
- use the canonical expression ledgers to catch earlier exclusive sibling uses in either evaluation order
- preserve child-expression isolation, divergence, comptime pruning, and alternative-arm legality

## Testing

- `scripts/rue spec borrow-accessors` (103 passed)
- `scripts/rue quick` (31 targets passed)
- `scripts/rue fmt`
- `scripts/rue premerge` (200 passed)
- adversarial branch/join/evaluation-order probes

Fixes RUE-1684