### PR TITLE
RUE-1789: read a by-reference argument through its place

### DIFF
--- a/crates/rue-cli-tests/cases/by_ref_argument_aliasing.toml
+++ b/crates/rue-cli-tests/cases/by_ref_argument_aliasing.toml
@@ -1,0 +1,116 @@
+# A by-reference argument is a PLACE, not a snapshot (RUE-1789).
+#
+# `docs/formal/01-core-calculus.md` §6.2's evaluation-context grammar admits
+# only a by-VALUE argument as a redex; a by-reference argument is not reduced
+# (§6.9), so nothing about it is observed until the callee reads through it.
+# Concretely: when one argument of a call is passed by reference and a LATER
+# argument mutates the same root, the callee sees the mutation.
+#
+# These cases exist for the differential oracle, not for codegen. The compiler
+# has always been right here — it passes an address. The oracle copied each
+# by-reference argument in at that argument's own position in the list, which
+# is a snapshot, so it computed the pre-mutation value and DISAGREED with the
+# compiled binary without reporting a model gap. Every case below diverged
+# before the fix; the last one is the control that agreed both ways.
+#
+# Ordering is what makes these bite: the aliasing must run AFTER the by-ref
+# argument's position. The accumulator idiom in `nested_loan_str_view.toml`
+# (`add(mul(3, 4, inout flags), 5, inout flags)`) puts the mutation first, so
+# it never exercised this.
+#
+# Note the shapes that are absent: an enclosing SHARED loan (a `borrow self`
+# receiver, say) with a nested exclusive loan of the same root is rejected by
+# the call-loan rule (spec 6.1:30), so it cannot be pinned here.
+
+[section]
+id = "cli.by_ref_argument_aliasing"
+name = "By-reference arguments observe a later argument's mutation"
+description = "A by-reference argument is read through its place when the callee receives it, not snapshotted at its position in the argument list (RUE-1789)."
+
+[[case]]
+name = "inout_self_receiver_reads_nested_write"
+description = "RUE-1789 repro: the `inout self` receiver is address-passed, so `bump` reads the 1 that `grow` wrote during argument evaluation, not the 0 the root held when the receiver was named."
+files = [{ path = "main.rue", source = """
+struct Arena {
+    n: i32,
+
+    fn bump(inout self, x: i32) -> i32 { self.n + x }
+}
+fn grow(inout a: Arena) -> i32 { a.n = 1; 0 }
+fn main() -> i32 {
+    let mut a = Arena { n: 0 };
+    @dbg(a.bump(grow(inout a)));
+    0
+}
+""" }]
+stdout = "1\n"
+exit_code = 0
+
+[[case]]
+name = "inout_argument_before_mutating_sibling"
+description = "The same rule without a receiver: `flags` is passed `inout` in argument position 0 and mutated by argument position 1, so the callee reads 1 + 12."
+files = [{ path = "main.rue", source = """
+fn mul(a: i32, b: i32, inout flags: i32) -> i32 { flags = flags + 1; a * b }
+fn add(inout flags: i32, x: i32) -> i32 { flags + x }
+fn main() -> i32 {
+    let mut flags = 0;
+    @dbg(add(inout flags, mul(3, 4, inout flags)));
+    0
+}
+""" }]
+stdout = "13\n"
+exit_code = 0
+
+[[case]]
+name = "inout_field_projection_reads_nested_write"
+description = "The place can be a projection: `inout h.a` is a field of the root the sibling argument mutates through."
+files = [{ path = "main.rue", source = """
+struct Inner { n: i32 }
+struct Holder { a: Inner, b: i32 }
+fn read(inout i: Inner, x: i32) -> i32 { i.n + x }
+fn grow(inout h: Holder) -> i32 { h.a.n = 5; 0 }
+fn main() -> i32 {
+    let mut h = Holder { a: Inner { n: 0 }, b: 0 };
+    @dbg(read(inout h.a, grow(inout h)));
+    0
+}
+""" }]
+stdout = "5\n"
+exit_code = 0
+
+[[case]]
+name = "inout_array_element_reads_nested_write"
+description = "And an index projection: `inout xs[0]` observes the write the sibling argument makes to the same element."
+files = [{ path = "main.rue", source = """
+fn read(inout v: i32, x: i32) -> i32 { v + x }
+fn grow(inout xs: [i32; 3]) -> i32 { xs[0] = 9; 0 }
+fn main() -> i32 {
+    let mut xs: [i32; 3] = [0, 0, 0];
+    @dbg(read(inout xs[0], grow(inout xs)));
+    0
+}
+""" }]
+stdout = "9\n"
+exit_code = 0
+
+# The over-correction control. Re-reading the place must not pick up a write to
+# a DIFFERENT root: `a` still reads 3 even though `b` was mutated to 7 during
+# the same argument list. This case agreed before the fix and must keep
+# agreeing after it.
+[[case]]
+name = "unaliased_inout_argument_is_unaffected"
+description = "Control: a by-reference argument whose root no other argument touches reads its own value, and the other root's mutation still lands."
+files = [{ path = "main.rue", source = """
+struct Arena { n: i32 }
+fn read(inout a: Arena, x: i32) -> i32 { a.n + x }
+fn grow(inout b: Arena) -> i32 { b.n = 7; 0 }
+fn main() -> i32 {
+    let mut a = Arena { n: 3 };
+    let mut b = Arena { n: 0 };
+    @dbg(read(inout a, grow(inout b)));
+    @dbg(b.n);
+    0
+}
+""" }]
+stdout = "3\n7\n"
+exit_code = 0

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -22,12 +22,15 @@
 //! `@assert`, and the defined panics (overflow, divide/remainder-by-zero,
 //! int-cast overflow);
 //! aggregates (structs/arrays) with nested place projections and bounds traps;
-//! `inout`/`borrow` parameters (copy-in / copy-out, observably identical to
-//! by-reference under the law of exclusivity); and drop/destructors, executed in
-//! spec-3.9 order (user destructor, then fields in declaration order / elements
-//! ascending) so the oracle validates drop *order* and drop-exactly-once, not
-//! just final values; and text values — source-defined `StrBuf` algorithms,
-//! `@to_string`, core `str` byte indexing, and strict/lossy scalar iteration.
+//! `inout`/`borrow` parameters (copy-in / copy-out, with the copy-in taken at
+//! the moment the callee receives the argument rather than at the argument's
+//! position in the list, so an alias mutated later in the same argument list is
+//! observed — see [`Interp::reread_by_ref_operand`]); and drop/destructors,
+//! executed in spec-3.9 order (user destructor, then fields in declaration
+//! order / elements ascending) so the oracle validates drop *order* and
+//! drop-exactly-once, not just final values; and text values — source-defined
+//! `StrBuf` algorithms, `@to_string`, core `str` byte indexing, and
+//! strict/lossy scalar iteration.
 //! Text content is modeled as raw bytes, matching the runtime's packed view:
 //! strict `.chars()` traps on invalid UTF-8, while `.chars_lossy()` substitutes
 //! U+FFFD.
@@ -2776,7 +2779,12 @@ impl<'a> Interp<'a> {
                 let mut writebacks: Vec<(usize, WritebackPlace<'a>)> = Vec::new();
                 let mut base = 0usize;
                 for (index, a) in call_args.iter().enumerate() {
-                    let v = self.eval(cfg, frame, a.value)?;
+                    let v = match a.mode {
+                        CfgArgMode::Borrow | CfgArgMode::Inout => {
+                            self.reread_by_ref_operand(cfg, frame, a.value)?
+                        }
+                        CfgArgMode::Normal => self.eval(cfg, frame, a.value)?,
+                    };
                     // Derive both callee packing and copy-back bases from the
                     // same static type + physical passing-mode contract.
                     let w = self.call_arg_slot_width(arg_types[index], a.mode);
@@ -3361,6 +3369,59 @@ impl<'a> Interp<'a> {
         }
         *cur = val;
         Ok(())
+    }
+
+    /// Copy in a by-reference argument by reading its place *now*, at the point
+    /// the callee receives it, rather than reusing the value the operand
+    /// instruction produced at its own position in the block.
+    ///
+    /// `docs/formal/01-core-calculus.md` §6.2 admits only a by-VALUE argument as
+    /// a redex; a by-reference argument is a place and is not reduced (§6.9), so
+    /// nothing about it is observed until the callee reads through it. The
+    /// interpreter still hands the callee a value, but taking that value at the
+    /// operand's own evaluation point makes it a snapshot — and a later argument
+    /// in the same list that mutates the same root then goes unobserved. That is
+    /// RUE-1789: `a.bump(grow(inout a))` computed 0 where the compiler, which
+    /// passes `a`'s address, computes 1.
+    ///
+    /// Only a re-readable *place* operand is re-read. Anything else keeps its
+    /// original value, which is not a fallback but the matching behavior: an
+    /// operand the compiler materializes into a value at argument-evaluation
+    /// time (a `borrow str` view over a `StrBuf`, say) really is snapshotted
+    /// there, and a program that could observe the difference is rejected by the
+    /// call-loan rule (spec 6.1:30) before it ever reaches the oracle.
+    fn reread_by_ref_operand(
+        &mut self,
+        cfg: &'a Cfg,
+        frame: &mut Frame,
+        v: CfgValue,
+    ) -> Step<Value> {
+        if !Self::is_rereadable_place_operand(cfg, v) {
+            return self.eval(cfg, frame, v);
+        }
+        // Drop only this instruction's memo. Its operands (a dynamic index, say)
+        // keep the values they took at their own evaluation points, so the place
+        // being read is still the one argument evaluation selected; only its
+        // contents are re-read. The memo is then restored, so an unrelated
+        // consumer of the same SSA value still sees its own snapshot — the
+        // property `Frame::cache` documents for dominated blocks.
+        let saved = frame.cache.remove(&v.as_u32());
+        let fresh = self.eval(cfg, frame, v);
+        match saved {
+            Some(prev) => frame.cache.insert(v.as_u32(), prev),
+            None => frame.cache.remove(&v.as_u32()),
+        };
+        fresh
+    }
+
+    /// Whether re-evaluating this operand is a pure re-read of storage: a local
+    /// slot, a parameter slot, or a place projection. Every other instruction
+    /// may compute or allocate, so re-running it is not a read.
+    fn is_rereadable_place_operand(cfg: &Cfg, v: CfgValue) -> bool {
+        matches!(
+            cfg.get_inst(v).data,
+            CfgInstData::Load { .. } | CfgInstData::Param { .. } | CfgInstData::PlaceRead { .. }
+        )
     }
 
     /// Recover the caller place an `inout` argument was loaded from, so its

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -1228,17 +1228,20 @@ fn main() -> i32 {
 compile_fail = true
 error_contains = "cannot borrow 'a'"
 
-# Compile-only: this case turns on the receiver reading the value the nested
-# call wrote, and the oracle models by-reference parameters as copy-in /
-# copy-out, so it reads the receiver before the nested mutation and computes
-# 0 where the compiler computes 1 (RUE-1789). The core calculus sides with the
-# compiler: a by-reference argument is a place, not reduced. What 6.1:30 needs
-# from this case is that the shape is ACCEPTED, which compile_only still pins;
-# restore the exit_code assertion when the oracle models aliased by-ref args.
+# The `exit_code` here is the load-bearing half: it asserts the receiver reads
+# the value the nested call WROTE (1), not the value the root held when the
+# receiver was evaluated (0). It ran compile-only until RUE-1789, because the
+# oracle copied by-reference arguments in at their own position in the argument
+# list and so computed 0.
+#
+# That makes it the first case to exercise 4.10:9's by-reference half — that a
+# by-reference argument binds "the argument place itself" rather than an
+# evaluated value. 4.10:9's two existing cases both cover only its return-value
+# half, so nothing distinguished a place from a snapshot taken at the argument's
+# position.
 [[case]]
 name = "nested_inout_under_address_passed_inout_self_receiver_ok"
-compile_only = true
-spec = ["6.1:30"]
+spec = ["6.1:30", "4.10:9"]
 description = "The receiver counterpart that stays legal: an `inout self` receiver is passed as an address, not a view, so the nested write is ordinary sequenced mutation and the callee reads the mutated value (RUE-1762)"
 source = """
 struct Arena {
@@ -1255,6 +1258,7 @@ fn main() -> i32 {
     if a.bump(grow(inout a)) == 1 { 0 } else { 1 }
 }
 """
+exit_code = 0
 
 [[case]]
 name = "nested_inout_inside_block_argument_rejected"


### PR DESCRIPTION
The oracle copied every argument in at that argument's own position in the list. For a by-reference argument that is a snapshot, so a later argument mutating the same root went unobserved — and the oracle returned a different answer from the compiled binary **without reporting a model gap**. Fail-open behavior in the one mechanism whose whole value is failing closed.

```rue
struct Arena {
    n: i32,

    fn bump(inout self, x: i32) -> i32 { self.n + x }
}
fn grow(inout a: Arena) -> i32 { a.n = 1; 0 }
fn main() -> i32 {
    let mut a = Arena { n: 0 };
    @dbg(a.bump(grow(inout a)));   // compiler: 1   oracle: 0
    0
}
```

The compiler prints `1` at `-O0`, `-O1`, `-O2` and `-O3`. The oracle printed `0`.

## Two corrections to the ticket, found before writing any code

**The ticket's own repro no longer compiles.** `a.scalar(a.bump())` puts a nested exclusive loan under a *shared* `borrow self` receiver, which RUE-1786 now rejects with `E0430`. Reproducing the defect needs the enclosing loan to be address-passed exclusive, as above — anyone following the ticket verbatim gets a compile error, not a divergence.

**The payoff was overstated.** The ticket names four cases downgraded to `compile_only` in cycle 833 and an `examples/gazette` canary. Those cases exist only in `16ef1d91f`, a worker-worktree commit that was never merged — RUE-1766 landed as `299e8931` with a different case set. Exactly **one** case on trunk is suppressed by this defect, and it is the only spec case that diverges pre-fix (confirmed by running the pre-fix binary against the spec corpus).

Both corrections narrow the blast radius rather than widening it, but they change what "done" means here, so the case work below is sized to what is actually on trunk.

## The core calculus settles which side is right

`docs/formal/01-core-calculus.md` §6.2's evaluation-context grammar admits only a by-VALUE argument as a redex; §6.9 makes a by-reference argument a **place**, not reduced, so nothing about it is observed until the callee reads through it. The prose agrees — 4.10:9 binds an `inout`/`borrow` parameter to "the argument place itself (6.1:18)". (The ticket suggests the prose is weaker than the core here. It isn't; it just had no case exercising that half of the rule — see below.)

## The fix

`Interp::call`'s argument loop now re-reads a by-reference argument's place at the point the callee receives it.

The subtlety is that `Frame::cache` memoizes each instruction along the executed path, and that memo is load-bearing: block instructions are evaluated in block order, so by the time the call is reached, the receiver's `Load` was already evaluated and memoized *before* the sibling argument ran. The re-read therefore drops **only that instruction's** memo — its operands (a dynamic index, say) keep the values they took at their own evaluation points, so the place being read is still the one argument evaluation selected, and only its *contents* are re-read. The memo is then restored, so an unrelated consumer of the same SSA value still sees its own snapshot, which is the property `Frame::cache` documents for dominated blocks.

**Not everything is re-read, and that is deliberate.** Only a re-readable place operand (`Load` / `Param` / `PlaceRead`) is. An operand the compiler materializes into a *value* at argument-evaluation time — a `borrow str` view over a `StrBuf`, say — really is snapshotted there, so keeping its original value is the matching behavior rather than a fallback, and a program that could observe the difference is rejected by the call-loan rule (6.1:30) before it ever reaches the oracle. Re-running a non-place instruction would also mean re-running whatever it computes or allocates, which is not a read.

## Cases

`nested_inout_under_address_passed_inout_self_receiver_ok` gets its `exit_code` assertion back — the half that pins the receiver reading the value the nested call **wrote**, rather than only that the shape compiles. It now also cites **4.10:9**, whose two existing cases both cover only its return-value half; nothing in the corpus distinguished "the argument place itself" from a snapshot taken at the argument's position. No new rule ids, so traceability is unchanged.

`crates/rue-cli-tests/cases/by_ref_argument_aliasing.toml` adds five cases: the receiver repro, the plain-argument spelling, a field projection, an index projection, and an unaliased control. Ordering is what makes them bite — the existing accumulator case (`add(mul(3, 4, inout flags), 5, inout flags)`) puts the mutation *first*, so it never exercised this.

Measured against the pre-fix binary:

| case | pre-fix | post-fix |
|---|---|---|
| `inout_self_receiver_reads_nested_write` | ✗ diverged | ✓ |
| `inout_argument_before_mutating_sibling` | ✗ diverged | ✓ |
| `inout_field_projection_reads_nested_write` | ✗ diverged | ✓ |
| `inout_array_element_reads_nested_write` | ✗ diverged | ✓ |
| `unaliased_inout_argument_is_unaffected` | ✓ agreed | ✓ |
| `nested_inout_under_address_passed_inout_self_receiver_ok` (spec) | ✗ diverged | ✓ |

The control is the over-correction guard: re-reading the place must not pick up a write to a *different* root.

An enclosing **shared** loan with a nested exclusive loan of the same root cannot be pinned here at all — 6.1:30 rejects it — which is noted in the case file so the absence doesn't read as an oversight.

## Verification

- `rue-oracle-diff` corpus mode — 1066 agree, **0 disagreements**, 0 harness/frontend/oracle failures, gap inventory authoritative.
- `rue-oracle-diff spec` mode — 1667 agree, **0 disagreements**.
- `scripts/rue spec 6.1` — 153 passed; `scripts/rue spec 4.10` — 46 passed; `scripts/rue cli by_ref_argument_aliasing` — 5 passed.
- `//:spec-traceability` — passes.
- `scripts/rue fmt` — clean.
- Full `./test.sh` — **exit 0, Pass 234, Fail 0**.

One note on the run before that one: `//:affected-targets-tool-tests` failed a single check with `failed to call MCP server … context deadline exceeded` while other builds were competing for the daemon. It passes 103/103 on its own, and it shells out to buck2 without touching the oracle. The 234/234 result above is a clean run with nothing else competing.

`differential_opt` is deliberately not set on these cases: the subject is the oracle, which does not optimize. The compiler's answer was checked by hand at all four levels instead (all print `1`).

Fixes: RUE-1789

---
_Generated by [Claude Code](https://claude.ai/code/session_01JekaZ8oUGSZPXQeodh3sy8)_