### PR TITLE
RUE-1102: codify callable-body inference boundary

### DIFF
--- a/docs/designs/0007-hindley-milner-inference.md
+++ b/docs/designs/0007-hindley-milner-inference.md
@@ -7,7 +7,7 @@ feature-flag: hm-inference
 created: 2025-12-24
 accepted: 2025-12-24
 implemented: 2025-12-24
-spec-sections: []
+spec-sections: ["3.11:2", "3.11:4"]
 supersedes: 0002
 superseded-by:
 ---
@@ -50,12 +50,38 @@ HM inference:
 - Handles **all** type decisions uniformly through constraint solving
 - Is **principal**: finds the most general type
 - Is **decidable**: Algorithm W has proven termination
-- Scales to **generics/polymorphism** if we add them later
+- Provides a constraint-solving foundation for future type-system work
 - Is **well-understood**: decades of research and implementations
 
-Note: We're implementing HM for **inference consistency**, not for polymorphism. Rue currently has no generics, and this ADR doesn't add them.
+Note: We're implementing HM for **inference consistency within a callable
+body**, not for polymorphism. Rue currently has no generics, and this ADR does
+not add them. Future type-system features require their own language-design
+decision and do not inherit a wider inference scope from this ADR.
 
 ## Decision
+
+### Inference scope and semantic firebreaks
+
+Whole callable-body inference is Rue's permanent maximum inference scope. The
+compiler solves all constraints produced by one callable body together, in
+isolation. No inference variable, unsolved literal, or body-local constraint
+crosses a callable boundary.
+
+Explicit parameter types, explicit return types, and explicit value-constant
+types are semantic firebreaks. A call site cannot refine a callee's signature,
+and a callee's body cannot refine a caller's argument or result type. The same
+boundary applies to every callable body currently in the language and to any
+future callable form. Closures, traits, overloads, and generics therefore MUST
+NOT infer across callable boundaries unless a new language-design decision
+explicitly changes or scopes this contract.
+
+Statement-level inference reuse is a non-goal. An implementation may reuse
+intermediate results only when it proves that they are equivalent to solving
+the complete owning body, including its order-independent types and
+diagnostics. A stable public-interface or `BodyReferences` projection may remain
+green when body-internal inference results change without affecting that
+projection; that is an incremental projection property, not permission to
+publish body inference across a callable boundary.
 
 ### Architecture Overview
 
@@ -287,7 +313,8 @@ Code that compiled before will compile after with the same types.
 - **Consistent inference**: No more scattered i32 defaults
 - **Principled approach**: Well-understood algorithm with proven properties
 - **Better errors**: Full constraint context for diagnostics
-- **Foundation for generics**: If we add polymorphism later, the infrastructure exists
+- **Foundation for future type-system work**: Any polymorphism or other
+  cross-callable feature still requires an explicit language-design decision
 - **Simpler mental model**: One algorithm handles all inference
 
 ### Negative
@@ -312,9 +339,12 @@ Code that compiled before will compile after with the same types.
 
 ## Future Work
 
-- **Polymorphic functions**: `fn identity<T>(x: T) -> T` - this ADR lays groundwork
+- **Polymorphic functions**: `fn identity<T>(x: T) -> T` require a separate
+  language-design decision; this ADR does not widen inference across callable
+  boundaries
 - **Type aliases**: `type Int = i32` - straightforward extension
-- **Trait bounds**: `fn print<T: Display>(x: T)` - requires trait system first
+- **Trait bounds**: `fn print<T: Display>(x: T)` require a trait system and a
+  separate inference-scope decision
 - **Associated types**: Complex, depends on traits
 
 ## References

--- a/docs/designs/0066-producer-nominal-anonymous-types-and-incremental-locality.md
+++ b/docs/designs/0066-producer-nominal-anonymous-types-and-incremental-locality.md
@@ -148,9 +148,20 @@ obtains exact raw body, lookup, declaration, anonymous-producer, and trusted
 toolchain facts through registered queries, and invokes rue-air's
 provider-native body analyzer.
 
-Each body analysis owns its mutable inference and compact type state. It
-publishes a durable body result, diagnostics, and independently queryable
-`BodyReferences`. A body-specific anonymous producer or trusted
+Each body analysis owns its mutable inference and compact type state. This is
+the query implementation of ADR-0007's permanent callable-body inference
+boundary, not a temporary implementation-local choice: constraints are solved
+for the complete owning body, and explicit parameter, return, and
+value-constant types remain semantic firebreaks. No callable body may infer
+through another callable's boundary without a new language-design decision;
+statement-level inference reuse is out of scope unless equivalence to the
+complete body solution is proven.
+
+The analysis publishes a durable body result, diagnostics, and independently
+queryable `BodyReferences`. A stable public-interface or `BodyReferences`
+projection may remain green when body-internal inference results change without
+affecting that projection; that projection stability does not widen the
+inference boundary. A body-specific anonymous producer or trusted
 standard-library demand is materialized only for the body that observes it.
 
 Provider lookups record the exact positive, negative, ambiguous, visibility,

--- a/docs/spec/src/03-types/11-type-inference.md
+++ b/docs/spec/src/03-types/11-type-inference.md
@@ -25,14 +25,17 @@ of.
 
 {{ rule(id="3.11:2", cat="normative") }}
 
-Type inference operates on one function body in isolation. Type information does
-not flow across a function boundary: a callee's parameter and return types are
-not inferred from its call sites, and a caller does not observe inference
-variables of a callee. To make each boundary self-describing, every function
-parameter, every function return type, and every value constant (6.5) **MUST**
-carry an explicit type annotation. A `let` binding (5.1) **MAY** omit its
-annotation, in which case its type is determined by inference from its
-initializer and later uses.
+Type inference operates on one function body in isolation. This one-body scope
+is the permanent maximum inference scope, not merely an implementation or
+query-locality choice. Type information does not flow across a function
+boundary: a callee's parameter and return types are not inferred from its call
+sites, and a caller does not observe inference variables of a callee. To make
+each boundary self-describing, every function parameter, every function return
+type, and every value constant (6.5) **MUST** carry an explicit type
+annotation; these annotations are semantic firebreaks. A `let` binding (5.1)
+**MAY** omit its annotation, in which case its type is determined by inference
+from its initializer and later uses. Future closures, trait systems, overloads,
+and generics do not widen this boundary without a new language-design decision.
 
 {{ rule(id="3.11:3") }}
 


### PR DESCRIPTION
## Summary

- make one callable body the permanent maximum inference scope
- define parameter, return, and value-constant annotations as semantic firebreaks for present and future callable features
- reconcile ADR-0007, ADR-0066, and specification rules 3.11:2 and 3.11:4 with whole-body invalidation and stable projections

## Validation

- `scripts/rue fmt`
- `python3 scripts/validate-adrs.py`
- `python3 scripts/validate-doc-links.py`
- `./buck2 test //:adr-registry-validation //:spec-traceability`
- `scripts/rue quick` (31 passed)
- `scripts/rue premerge` (200 passed)

Fixes RUE-1102