### PR TITLE
RUE-1777: compare a slice index against the length at the length's width

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -508,7 +508,14 @@ _CLI_TEST_ABSOLUTIZE = _CLI_TEST_BASE_ABSOLUTIZE + ["RUE_CLI_STAGED_PROGRAMS"]
 # healthy runs. //:cli-tests sat at 1800s against a 3600s derived deadline (and
 # a 2203s measured expected cost) until //:cli-timeout-policy-validation started
 # comparing the two.
-_CLI_TESTS_TIMEOUT_SECONDS = 3700
+#
+# Raised 3700 -> 3800 when RUE-1777's three new `cli.slices` cases pushed the
+# derived deadline to 3701 and the validation failed by one second. The bound
+# is a single global that every case addition pushes on, and trunk had grown
+# flush against it, so restoring the ~100s of headroom 3700 was originally
+# chosen with is what keeps the next case addition from re-failing. Raising it
+# only to the derived value would spend that headroom immediately.
+_CLI_TESTS_TIMEOUT_SECONDS = 3800
 _CLI_SHARD_TIMEOUT_SECONDS = 1200
 
 # The bounded premerge CLI corpus in one invocation: the canonical target that a

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -3903,8 +3903,34 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         } else {
             None
         };
+        // Compare at the LENGTH's width. The fat pointer's length is `u64`
+        // while the index carries the source expression's own integer type, so
+        // `Lt` of the two was a mixed-width comparison: codegen takes the
+        // comparison width from the left operand, which truncated the length
+        // to the index's width (`cmp ebx, r14d` for an `i32` index). Benign
+        // only while every length stays under the index type's range -- the
+        // same shape as RUE-87, which was a real out-of-bounds read.
+        //
+        // Widening rather than narrowing the length is what keeps the check
+        // sound: a narrow index cannot represent a large length, so narrowing
+        // would compare against a truncated bound. The cast cannot trap: the
+        // signed lower-bound check above has already rejected negatives, and
+        // every non-negative value of every integer type Rue has fits in
+        // `u64` (RUE-1777).
+        let widened_index_ref = if index_result.ty == Type::U64 {
+            index_result.air_ref
+        } else {
+            air.add_inst(AirInst {
+                data: AirInstData::IntCast {
+                    value: index_result.air_ref,
+                    from_ty: index_result.ty,
+                },
+                ty: Type::U64,
+                span,
+            })
+        };
         let upper_bound_ref = air.add_inst(AirInst {
-            data: AirInstData::Lt(index_result.air_ref, len_ref),
+            data: AirInstData::Lt(widened_index_ref, len_ref),
             ty: Type::BOOL,
             span,
         });

--- a/crates/rue-cli-tests/cases/slices_mvp.toml
+++ b/crates/rue-cli-tests/cases/slices_mvp.toml
@@ -603,3 +603,65 @@ fn main() -> i32 {
 args = ["main.rue", "--preview", "slices", "-o", "prog"]
 compile_fail = true
 error_contains = ["unknown preview feature", "slices"]
+
+# RUE-1777. A slice's length is a `u64` in the fat pointer; the index carries
+# the source expression's own integer type. `Lt` of the two was a mixed-width
+# comparison, and codegen takes the comparison width from the LEFT operand, so
+# the length was truncated to the index's width -- `cmp ebx, r14d` for an `i32`
+# index, comparing against the low 32 bits of the length.
+#
+# WHY THESE ASSERT ON EMITTED AIR RATHER THAN ON BEHAVIOR: the truncation is
+# only observable once a length reaches the index type's range, i.e. a slice of
+# 2^32 or more elements. That is not constructible in a test, which is exactly
+# why the bug sat latent -- the same shape as RUE-87, where it was NOT latent
+# and read out of bounds. So the property pinned here is the one that can be:
+# the comparison happens at the length's width.
+[[case]]
+name = "bounds_check_widens_a_narrower_index_to_the_length_width"
+description = "RUE-1777: an `i32` index is widened to the length's `u64` before the bounds comparison, so the length is never truncated to the index's width."
+files = [{ path = "main.rue", source = """
+fn get(borrow s: [i64], i: i32) -> i64 { s[i] }
+fn main() -> i32 {
+    let a: [i64; 3] = [7, 8, 9];
+    @dbg(get(borrow a, 1));
+    0
+}
+""" }]
+args = ["--emit", "air", "main.rue"]
+compile_only = true
+# The program contains no `@intCast`, so the only cast in its AIR is the one
+# the bounds check introduces.
+compile_stdout_contains = ["intcast", "from i32"]
+
+# The counterpart: an index already at the length's width needs no cast, so the
+# fix adds no work to the common `u64` case.
+[[case]]
+name = "bounds_check_does_not_widen_an_index_already_at_length_width"
+description = "RUE-1777: a `u64` index already matches the length's width, so no cast is emitted."
+files = [{ path = "main.rue", source = """
+fn get_u64(borrow s: [i64], i: u64) -> i64 { s[i] }
+fn main() -> i32 {
+    let a: [i64; 3] = [7, 8, 9];
+    @dbg(get_u64(borrow a, 1));
+    0
+}
+""" }]
+args = ["--emit", "air", "main.rue"]
+compile_only = true
+compile_stdout_not_contains = ["intcast"]
+
+# Behavior control: widening must not disturb ordinary indexing, and the signed
+# lower-bound check still runs FIRST -- which is what makes the widening cast
+# infallible, since every non-negative value of every integer type fits in u64.
+[[case]]
+name = "signed_index_still_traps_below_zero_after_widening"
+description = "RUE-1777: `index >= 0` is still checked before the widening cast, so a negative index traps as a bounds violation."
+files = [{ path = "main.rue", source = """
+fn get(borrow s: [i64], i: i32) -> i64 { s[i] }
+fn main() -> i32 {
+    let a: [i64; 3] = [7, 8, 9];
+    @dbg(get(borrow a, 0 - 1));
+    0
+}
+""" }]
+exit_code = 101


### PR DESCRIPTION
A slice's length lives in the fat pointer as `u64`; the index carries whatever integer type the source expression has. The bounds check compared the two directly, and codegen takes a comparison's width from its **left** operand — so the length was truncated to the index's width.

For an `i32` index the emitted check was literally:

```asm
cmp ebx, r14d      ; index vs the LOW 32 BITS of a u64 length
```

The index is now widened to `u64` first, so the comparison happens at the length's width:

```asm
movsxd r11, rbx
cmp r11, r15       ; full 64-bit
```

Widening rather than narrowing is what keeps it sound — a narrow index cannot represent a large length, so narrowing would compare against a truncated bound.

## The cast cannot trap

The signed lower-bound check runs before it and has already rejected negatives, and every non-negative value of every integer type Rue has fits in `u64`. An index already at `u64` skips the cast entirely.

## Cost: measured, not assumed

The obvious worry is that a widening cast adds a range check to every slice index — a hot path. It does not.

`get(borrow s: [i64], i: i32)` is **28 instructions before and after**. Codegen was already sign-extending the index for the pointer offset, so the widening reuses that `movsxd` and the comparison becomes 64-bit at no cost.

## Why the tests assert on AIR rather than behavior

The truncation is only observable once a length reaches the index type's range — a slice of 2^32 or more elements, which is not constructible in a test. That unobservability is exactly why this sat latent, and it is the same shape as RUE-87, where it was **not** latent and read out of bounds.

So the property pinned is the one that can be pinned: the comparison happens at the length's width.

| case | asserts | without the fix |
| --- | --- | --- |
| `bounds_check_widens_a_narrower_index_to_the_length_width` | an `i32` index is widened | **FAILS** |
| `bounds_check_does_not_widen_an_index_already_at_length_width` | no cast for a `u64` index | control |
| `signed_index_still_traps_below_zero_after_widening` | `index >= 0` still checked first | control |

Mutation-checked: exactly the load-bearing assertion fails with the widening disabled; both controls hold either way, as designed.

## Second commit: the `//:cli-tests` action bound

The three new cases pushed a shared global past its limit, and CI caught it.

`//:cli-timeout-policy-validation` (RUE-1163) compares the action bound spelled in `BUCK` against a correctness deadline derived from measured shard weights. These cases moved that derived deadline to **3701s**, one second past the declared **3700s** — meaning a healthy run could be killed inside its own deadline.

Attributed before changing anything, because the first local check *passed*: CI tests the branch merged with current trunk, and this branch was several commits behind. After rebasing, the failure reproduced exactly, and then pure trunk passes / trunk-plus-these-cases fails. It is this PR's.

Raised to **3800**, not 3701. The bound is a single global that every case addition pushes on, and 3700 was originally chosen with roughly 100s of headroom over a 3600s deadline. Matching the derived value exactly would spend that headroom immediately and hand the identical failure to the next PR that adds a case. The rationale is recorded in the `BUCK` comment.

Worth flagging for anyone adding CLI cases: a local `./test.sh` cannot catch this. It runs the default tier; this validation is premerge-tier, so `scripts/rue premerge` is the run that sees it.

## Verification

`./test.sh` → `Tests finished: Pass 234. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0`, exit 0.

Corpus gate (`//:cli-staged-programs`, all ten example programs): builds.

`cli.slices` 29/29; `//crates/rue-oracle/...` green — including `slice_bounds_check_uses_index_trap_category_without_changing_assertions`, which is the oracle case that first surfaced this mismatch. `//:cli-timeout-policy-validation` passes with the new bound.

## What this does *not* do

It does **not** let RUE-1654's operand-agreement rule tighten yet. That guard exempts integer/integer comparisons because of exactly two producers; this fixes one, but the exemption is a single switch and the AIR validator cannot attribute a mismatch to a particular producer.

The other producer is RUE-1778, and it is deliberately not attempted here. The cheap fix for it — resolve the base before giving up — is impossible by architecture: `generate.rs` is a constraint *generator* that runs to completion before solving begins, so there is no `resolve` to call at `FieldGet` time. It genuinely needs the deferred field constraint its description proposes: a new obligation kind, a discharge point in the solver, and a reporting path for one that never discharges, in a `unify.rs` that has no such machinery today. That is a feature, not a patch, and the finding is recorded on the issue so the dead end is not re-explored.

Fixes RUE-1777