### PR TITLE
RUE-1104: add non-exhaustive public enums

### DIFF
--- a/crates/rue-air/src/drop_glue_names.rs
+++ b/crates/rue-air/src/drop_glue_names.rs
@@ -129,6 +129,7 @@ mod tests {
                     variants: Arc::from(["Only".into()]),
                     variant_payloads: vec![vec![]],
                     is_pub: false,
+                    is_non_exhaustive: false,
                     file_id,
                 },
             )

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -4786,6 +4786,7 @@ mod tests {
                 variants: Arc::from(["Only".into()]),
                 variant_payloads: Vec::new(),
                 is_pub: false,
+                is_non_exhaustive: false,
                 file_id: rue_span::FileId::DEFAULT,
             },
         );
@@ -4830,6 +4831,7 @@ mod tests {
                 variants: Arc::from(["Only".into()]),
                 variant_payloads: Vec::new(),
                 is_pub: false,
+                is_non_exhaustive: false,
                 file_id: rue_span::FileId::DEFAULT,
             },
         );

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -486,6 +486,7 @@ pub(crate) struct EnumDeclarationMetadata {
     pub name: Arc<str>,
     pub variants: Arc<[Arc<str>]>,
     pub is_pub: bool,
+    pub is_non_exhaustive: bool,
     pub file_id: FileId,
 }
 
@@ -747,6 +748,7 @@ static ALIASED_ENUM_DEF: LazyLock<EnumDefEntry> = LazyLock::new(|| {
         variants: Arc::from([] as [Arc<str>; 0]),
         variant_payloads: Vec::new(),
         is_pub: false,
+        is_non_exhaustive: false,
         file_id: FileId::DEFAULT,
     })
 });
@@ -1719,6 +1721,7 @@ impl TypeInternPoolInner {
                 name: data.def.name.clone(),
                 variants: data.def.variants.clone(),
                 is_pub: data.def.is_pub,
+                is_non_exhaustive: data.def.is_non_exhaustive,
                 file_id: data.def.file_id,
             }),
             _ => None,
@@ -1731,6 +1734,7 @@ impl TypeInternPoolInner {
                 name: data.def.name.clone(),
                 variants: data.def.variants.clone(),
                 is_pub: data.def.is_pub,
+                is_non_exhaustive: data.def.is_non_exhaustive,
                 file_id: data.def.file_id,
             }),
             _ => None,
@@ -4223,6 +4227,7 @@ mod tests {
             variants: Arc::from([]),
             variant_payloads: vec![],
             is_pub: false,
+            is_non_exhaustive: false,
             file_id: FileId::DEFAULT,
         }
     }
@@ -4999,6 +5004,7 @@ mod tests {
             variants: Arc::from(["Some".into(), "None".into()]),
             variant_payloads: vec![vec![one_array], vec![pointer]],
             is_pub: false,
+            is_non_exhaustive: false,
             file_id: FileId::DEFAULT,
         };
         let (choice, _) = pool.register_enum(declarations.get_or_intern("Choice"), choice);
@@ -5120,6 +5126,7 @@ mod tests {
             variants: Arc::from(["Many".into(), "One".into()]),
             variant_payloads: vec![vec![pairs, Type::I8], vec![pointer]],
             is_pub: false,
+            is_non_exhaustive: false,
             file_id: FileId::DEFAULT,
         };
         let (choice, _) = pool.register_enum(declarations.get_or_intern("Choice"), choice);
@@ -5310,6 +5317,7 @@ mod tests {
             variants: Arc::from(["Red".into(), "Green".into(), "Blue".into()]),
             variant_payloads: Vec::new(),
             is_pub: false,
+            is_non_exhaustive: false,
             file_id: rue_span::FileId::DEFAULT,
         };
 
@@ -5396,6 +5404,7 @@ mod tests {
             variants: Arc::from(["Active".into(), "Inactive".into()]),
             variant_payloads: Vec::new(),
             is_pub: false,
+            is_non_exhaustive: false,
             file_id: rue_span::FileId::DEFAULT,
         };
 
@@ -5484,6 +5493,7 @@ mod tests {
             variants: Arc::from(["Red".into()]),
             variant_payloads: Vec::new(),
             is_pub: false,
+            is_non_exhaustive: false,
             file_id: rue_span::FileId::DEFAULT,
         };
         let (enum_id, _) = pool.register_enum(enum_name, enum_def);
@@ -5558,6 +5568,7 @@ mod tests {
             variants: Arc::from(["A".into(), "B".into()]),
             variant_payloads: Vec::new(),
             is_pub: false,
+            is_non_exhaustive: false,
             file_id: rue_span::FileId::DEFAULT,
         };
         let (enum_id, _) = pool.register_enum(name, def.clone());
@@ -5652,6 +5663,7 @@ mod tests {
                 variants: Arc::from([]),
                 variant_payloads: Vec::new(),
                 is_pub: false,
+                is_non_exhaustive: false,
                 file_id: rue_span::FileId::DEFAULT,
             },
         );
@@ -5906,6 +5918,7 @@ mod tests {
             variants: Arc::from(["A".into()]),
             variant_payloads: vec![vec![]],
             is_pub: true,
+            is_non_exhaustive: false,
             file_id: rue_span::FileId::new(file),
         };
         let source_enum_sym = interner.get_or_intern("__anon_enum_5");
@@ -6000,6 +6013,7 @@ mod tests {
             variants: Arc::from(["Value".into()]),
             variant_payloads: vec![vec![]],
             is_pub: true,
+            is_non_exhaustive: false,
             file_id,
         };
         let (left_enum, _) = pool.register_enum(choice, enum_def(left_id));
@@ -6293,6 +6307,7 @@ mod tests {
             variants: Arc::from(["A".into(), "B".into()]),
             variant_payloads: vec![vec![Type::U8, Type::I32], vec![]],
             is_pub: false,
+            is_non_exhaustive: false,
             file_id: FileId::DEFAULT,
         };
         let (id, _) = pool.register_enum(interner.get_or_intern("Wide"), def);
@@ -6365,6 +6380,7 @@ mod tests {
             variants: Arc::from(["Pair".into(), "One".into()]),
             variant_payloads: vec![vec![Type::I32, Type::I64], vec![Type::I32]],
             is_pub: false,
+            is_non_exhaustive: false,
             file_id: FileId::DEFAULT,
         };
         let (id, _) = pool.register_enum(interner.get_or_intern("Shape"), def);

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -1353,7 +1353,26 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         };
 
         match &inst.data {
-            InstData::EnumDecl { .. } => {
+            InstData::EnumDecl {
+                is_pub,
+                is_non_exhaustive,
+                ..
+            } => {
+                if *is_non_exhaustive {
+                    self.require_preview(
+                        rue_error::PreviewFeature::NonExhaustiveEnums,
+                        "@non_exhaustive enums",
+                        inst.span,
+                    )?;
+                    if !*is_pub {
+                        return Err(CompileError::new(
+                            ErrorKind::ParseError(
+                                "@non_exhaustive can only be applied to public enums".to_string(),
+                            ),
+                            inst.span,
+                        ));
+                    }
+                }
                 // Enum declarations are processed during collection phase
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::UnitConst,

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -115,6 +115,7 @@ pub enum DurableNominalBody<K, M> {
         /// Canonically shared variants in declaration order: source name and
         /// durable payload types.
         variants: Arc<[(Arc<str>, Arc<[SemanticImportType<K, M>]>)]>,
+        is_non_exhaustive: bool,
     },
 }
 
@@ -963,6 +964,7 @@ where
                     variants: builtin.variants.iter().map(|v| Arc::from(*v)).collect(),
                     variant_payloads: Vec::new(),
                     is_pub: true,
+                    is_non_exhaustive: false,
                     file_id: FileId::DEFAULT,
                 },
             );
@@ -1475,7 +1477,10 @@ where
                 );
                 Ok(Type::new_struct(id))
             }
-            DurableNominalBody::Enum { variants } => {
+            DurableNominalBody::Enum {
+                variants,
+                is_non_exhaustive,
+            } => {
                 let variant_names = variants
                     .iter()
                     .map(|(name, _)| Arc::from(name.as_ref()))
@@ -1487,6 +1492,7 @@ where
                         variants: variant_names.clone(),
                         variant_payloads: Vec::new(),
                         is_pub: is_public,
+                        is_non_exhaustive,
                         file_id,
                     },
                 );
@@ -1512,6 +1518,7 @@ where
                         variants: variant_names,
                         variant_payloads,
                         is_pub: is_public,
+                        is_non_exhaustive,
                         file_id,
                     },
                 );
@@ -1632,7 +1639,10 @@ where
                 );
                 Ok(Type::new_struct(id))
             }
-            DurableNominalBody::Enum { variants } => {
+            DurableNominalBody::Enum {
+                variants,
+                is_non_exhaustive,
+            } => {
                 let variant_names: Arc<[Arc<str>]> = variants
                     .iter()
                     .map(|(name, _)| Arc::from(name.as_ref()))
@@ -1644,6 +1654,7 @@ where
                         variants: variant_names.clone(),
                         variant_payloads: Vec::new(),
                         is_pub: is_public,
+                        is_non_exhaustive,
                         file_id,
                     },
                 );
@@ -1670,6 +1681,7 @@ where
                         variants: variant_names,
                         variant_payloads,
                         is_pub: is_public,
+                        is_non_exhaustive,
                         file_id,
                     },
                 );
@@ -2194,6 +2206,7 @@ where
                 variants: variant_names,
                 variant_payloads,
                 is_pub: false,
+                is_non_exhaustive: false,
                 file_id: FileId::DEFAULT,
             },
         );
@@ -3898,6 +3911,7 @@ mod tests {
                 .into_iter()
                 .map(|(name, payload)| (Arc::from(name), payload.into()))
                 .collect(),
+            is_non_exhaustive: false,
         }
     }
 
@@ -4070,6 +4084,7 @@ mod tests {
                 variants: variant_names.clone(),
                 variant_payloads: Vec::new(),
                 is_pub,
+                is_non_exhaustive: false,
                 file_id: TWIN_FILE,
             },
         );
@@ -4080,6 +4095,7 @@ mod tests {
                 variants: variant_names,
                 variant_payloads: variants.into_iter().map(|(_, p)| p).collect(),
                 is_pub,
+                is_non_exhaustive: false,
                 file_id: TWIN_FILE,
             },
         );

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -1193,8 +1193,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         let fully_covered = if scrutinee_type == Type::BOOL {
                             bool_true_span.is_some() && bool_false_span.is_some()
                         } else if let Some(enum_id) = pattern_enum_id {
-                            covered_variants.len()
-                                == self.body_type_pool().enum_def(enum_id).variant_count()
+                            let def = self.body_type_pool().enum_def(enum_id);
+                            let external_non_exhaustive =
+                                def.is_non_exhaustive && def.file_id != ctx.current_file_id;
+                            !external_non_exhaustive
+                                && covered_variants.len() == def.variant_count()
                         } else {
                             false
                         };
@@ -1562,7 +1565,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             has_wildcard || (bool_true_covered && bool_false_covered)
         } else if let Some(enum_id) = pattern_enum_id {
             let enum_def = self.body_type_pool().enum_def(enum_id);
-            has_wildcard || covered_variants.len() == enum_def.variant_count()
+            let external_non_exhaustive =
+                enum_def.is_non_exhaustive && enum_def.file_id != ctx.current_file_id;
+            has_wildcard
+                || (!external_non_exhaustive && covered_variants.len() == enum_def.variant_count())
         } else {
             // For integers, must have wildcard
             has_wildcard

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -1073,6 +1073,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             variants: names.iter().map(|n| Arc::from(n.as_str())).collect(),
             variant_payloads: payloads.to_vec(),
             is_pub: false,
+            is_non_exhaustive: false,
             file_id: FileId::new(0),
         };
         let (id, _) = self.storage.body_type_pool().register_enum(name_spur, def);

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -2441,7 +2441,7 @@ where
                             self.install_anonymous_dependencies(field, visited_named)?;
                         }
                     }
-                    crate::DurableNominalBody::Enum { variants } => {
+                    crate::DurableNominalBody::Enum { variants, .. } => {
                         for (_, payload) in variants.iter() {
                             for field in payload.iter() {
                                 self.install_anonymous_dependencies(field, visited_named)?;
@@ -2542,7 +2542,7 @@ where
                                 self.register_import_nominal_identities_inner(field)?;
                             }
                         }
-                        crate::DurableNominalBody::Enum { variants } => {
+                        crate::DurableNominalBody::Enum { variants, .. } => {
                             for (_, payload) in variants.iter() {
                                 for field in payload.iter() {
                                     self.provider_body_work

--- a/crates/rue-air/src/sema/provider_fixture.rs
+++ b/crates/rue-air/src/sema/provider_fixture.rs
@@ -571,6 +571,7 @@ impl ProviderFixture {
                         .into_iter()
                         .map(|(variant, payloads)| (Arc::from(variant), payloads.into()))
                         .collect(),
+                    is_non_exhaustive: false,
                 },
             },
         );

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -37,6 +37,7 @@ pub struct SemanticImportNominal<K> {
     pub name: Arc<str>,
     pub kind: SemanticImportNominalKind,
     pub is_public: bool,
+    pub is_non_exhaustive: bool,
     pub lang_item: Option<crate::LangItem>,
 }
 
@@ -420,6 +421,7 @@ pub enum SemanticLocalNominalShape<K, M> {
     },
     Enum {
         variants: Arc<[(Arc<str>, Arc<[SemanticImportType<K, M>]>)]>,
+        is_non_exhaustive: bool,
     },
 }
 
@@ -1226,6 +1228,7 @@ where
                     variants: builtin.variants.iter().map(|v| Arc::from(*v)).collect(),
                     variant_payloads: Vec::new(),
                     is_pub: true,
+                    is_non_exhaustive: false,
                     file_id: FileId::DEFAULT,
                 },
             );
@@ -1323,6 +1326,7 @@ where
                             variants: Arc::from([]),
                             variant_payloads: vec![],
                             is_pub: nominal.is_public,
+                            is_non_exhaustive: nominal.is_non_exhaustive,
                             file_id,
                         },
                     );
@@ -1538,6 +1542,12 @@ where
                             variants: Arc::from([]),
                             variant_payloads: Vec::new(),
                             is_pub: nominal.is_public,
+                            is_non_exhaustive: match &nominal.shape {
+                                SemanticLocalNominalShape::Enum {
+                                    is_non_exhaustive, ..
+                                } => *is_non_exhaustive,
+                                SemanticLocalNominalShape::Struct { .. } => false,
+                            },
                             file_id,
                         },
                     );
@@ -2264,6 +2274,7 @@ where
                 variants: variants.iter().map(|(name, _)| name.clone()).collect(),
                 variant_payloads,
                 is_pub: metadata.is_pub,
+                is_non_exhaustive: metadata.is_non_exhaustive,
                 file_id: metadata.file_id,
             },
         );
@@ -2314,7 +2325,7 @@ where
                             );
                         }
                     }
-                    SemanticLocalNominalShape::Enum { variants } => {
+                    SemanticLocalNominalShape::Enum { variants, .. } => {
                         self.complete_nominal_enum_in_pool(type_pool, &nominal.key, variants)?;
                     }
                 }
@@ -2353,6 +2364,7 @@ mod tests {
             name: Arc::from(name),
             kind,
             is_public: true,
+            is_non_exhaustive: false,
             lang_item: None,
         }
     }
@@ -2680,6 +2692,18 @@ mod tests {
             epoch.complete_enum(&"choice", &variants),
             Err(SemanticImportFailure::NominalAlreadyComplete)
         );
+    }
+
+    #[test]
+    fn imported_enum_shell_preserves_non_exhaustive_metadata() {
+        let mut imported = nominal("colors", "Color", SemanticImportNominalKind::Enum);
+        imported.is_non_exhaustive = true;
+        let epoch = Epoch::new(vec![imported], vec![], vec![]).unwrap();
+        let LocalNominal::Enum(id) = epoch.nominals[&NominalInstanceKey::Named("colors")] else {
+            panic!("colors must be an enum")
+        };
+        epoch.complete_enum(&"colors", &[]).unwrap();
+        assert!(epoch.type_pool().enum_def(id).is_non_exhaustive);
     }
 
     #[test]
@@ -3460,6 +3484,7 @@ mod tests {
                 lang_item: None,
                 shape: SemanticLocalNominalShape::Enum {
                     variants: Arc::new([]),
+                    is_non_exhaustive: false,
                 },
             }],
             vec![],
@@ -3790,6 +3815,7 @@ mod tests {
                 lang_item: None,
                 shape: SemanticLocalNominalShape::Enum {
                     variants: Arc::new([]),
+                    is_non_exhaustive: false,
                 },
             },
         ];

--- a/crates/rue-air/src/type_properties.rs
+++ b/crates/rue-air/src/type_properties.rs
@@ -43,6 +43,7 @@ fn empty_enum(name: &str) -> EnumDef {
         variants: Arc::from(["Only".into()]),
         variant_payloads: vec![vec![]],
         is_pub: false,
+        is_non_exhaustive: false,
         file_id: FileId::DEFAULT,
     }
 }

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -465,6 +465,8 @@ pub struct EnumDef {
     pub variant_payloads: Vec<Vec<Type>>,
     /// Whether this enum is public (visible outside its directory)
     pub is_pub: bool,
+    /// Whether matches in importing modules must include a wildcard arm.
+    pub is_non_exhaustive: bool,
     /// File ID this enum was declared in (for visibility checking)
     pub file_id: rue_span::FileId,
 }
@@ -1645,6 +1647,7 @@ mod tests {
             variants: Arc::from([]),
             variant_payloads: Vec::new(),
             is_pub: false,
+            is_non_exhaustive: false,
             file_id: rue_span::FileId::DEFAULT,
         };
         assert_eq!(empty.variant_count(), 0);
@@ -1654,6 +1657,7 @@ mod tests {
             variants: Arc::from(["Red".into(), "Green".into(), "Blue".into()]),
             variant_payloads: Vec::new(),
             is_pub: false,
+            is_non_exhaustive: false,
             file_id: rue_span::FileId::DEFAULT,
         };
         assert_eq!(color.variant_count(), 3);
@@ -1666,6 +1670,7 @@ mod tests {
             variants: Arc::from(["Red".into(), "Green".into(), "Blue".into()]),
             variant_payloads: Vec::new(),
             is_pub: false,
+            is_non_exhaustive: false,
             file_id: rue_span::FileId::DEFAULT,
         };
 
@@ -1683,6 +1688,7 @@ mod tests {
             variants: Arc::from([]),
             variant_payloads: Vec::new(),
             is_pub: false,
+            is_non_exhaustive: false,
             file_id: rue_span::FileId::DEFAULT,
         };
         assert_eq!(empty.discriminant_type(), Type::NEVER);
@@ -1696,6 +1702,7 @@ mod tests {
             variants: Arc::from(["A".into()]),
             variant_payloads: Vec::new(),
             is_pub: false,
+            is_non_exhaustive: false,
             file_id: rue_span::FileId::DEFAULT,
         };
         assert_eq!(small.discriminant_type(), Type::U8);
@@ -1707,6 +1714,7 @@ mod tests {
                 .collect(),
             variant_payloads: Vec::new(),
             is_pub: false,
+            is_non_exhaustive: false,
             file_id: rue_span::FileId::DEFAULT,
         };
         assert_eq!(max_u8.discriminant_type(), Type::U8);
@@ -1722,6 +1730,7 @@ mod tests {
                 .collect(),
             variant_payloads: Vec::new(),
             is_pub: false,
+            is_non_exhaustive: false,
             file_id: rue_span::FileId::DEFAULT,
         };
         assert_eq!(medium.discriminant_type(), Type::U16);

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -3871,6 +3871,7 @@ mod tests {
                         .iter()
                         .map(|(variant, payload)| (Arc::from(*variant), Arc::from(*payload)))
                         .collect(),
+                    is_non_exhaustive: false,
                 },
             });
         }

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -3686,6 +3686,7 @@ mod tests {
                 variants: Arc::from(["None".into(), "Some".into()]),
                 variant_payloads: vec![vec![], vec![Type::I32]],
                 is_pub: false,
+                is_non_exhaustive: false,
                 file_id: FileId::DEFAULT,
             },
         );

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -1018,6 +1018,50 @@ args = ["main.rue", "-o", "prog"]
 exit_code = 2
 
 [[case]]
+name = "non_exhaustive_enum_import_requires_wildcard"
+description = "A public @non_exhaustive enum requires a wildcard in a match from an importing module, even when all current variants are named."
+files = [
+    { path = "main.rue", source = """
+const colors = @import("colors.rue");
+fn main() -> i32 {
+    match colors.pick() {
+        colors.Color.Red => 1,
+        colors.Color.Green => 2,
+    }
+}
+""" },
+    { path = "colors.rue", source = """
+@non_exhaustive pub enum Color { Red, Green }
+pub fn pick() -> Color { Color.Green }
+""" },
+]
+args = ["main.rue", "-o", "prog", "--preview", "non_exhaustive_enums"]
+compile_fail = true
+error_contains = ["E0600", "not exhaustive"]
+
+[[case]]
+name = "non_exhaustive_enum_import_wildcard_executes"
+files = [
+    { path = "main.rue", source = """
+const colors = @import("colors.rue");
+fn main() -> i32 {
+    match colors.pick() {
+        colors.Color.Red => 1,
+        colors.Color.Green => 2,
+        _ => 3,
+    }
+}
+""" },
+    { path = "colors.rue", source = """
+@non_exhaustive pub enum Color { Red, Green }
+pub fn pick() -> Color { Color.Green }
+""" },
+]
+args = ["main.rue", "-o", "prog", "--preview", "non_exhaustive_enums"]
+exit_code = 2
+compile_stderr_not_contains = ["unreachable"]
+
+[[case]]
 name = "same_named_structs_in_sibling_modules"
 description = "RUE-454: module-local type identity allows sibling modules to export same-named structs."
 files = [

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -3953,6 +3953,7 @@ mod tests {
                     .map(|(_, payload)| payload.clone())
                     .collect(),
                 is_pub: false,
+                is_non_exhaustive: false,
                 file_id: FileId::DEFAULT,
             },
         );

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -779,6 +779,7 @@ mod tests {
                     .map(|(_, payload)| payload.clone())
                     .collect(),
                 is_pub: false,
+                is_non_exhaustive: false,
                 file_id: FileId::DEFAULT,
             },
         );

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -2486,6 +2486,7 @@ mod tests {
                 variants: Arc::from(["None".into(), "Some".into()]),
                 variant_payloads: vec![vec![], vec![Type::I32]],
                 is_pub: false,
+                is_non_exhaustive: false,
                 file_id: FileId::DEFAULT,
             },
         );
@@ -2719,6 +2720,7 @@ mod tests {
                 variants: Arc::from(["First".into(), "Second".into()]),
                 variant_payloads: vec![vec![], vec![]],
                 is_pub: false,
+                is_non_exhaustive: false,
                 file_id: FileId::DEFAULT,
             },
         );

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -3730,6 +3730,7 @@ mod tests {
                     .map(|(_, payload)| payload.clone())
                     .collect(),
                 is_pub: false,
+                is_non_exhaustive: false,
                 file_id: FileId::DEFAULT,
             },
         );

--- a/crates/rue-compiler/src/artifact_views.rs
+++ b/crates/rue-compiler/src/artifact_views.rs
@@ -711,11 +711,13 @@ fn syntax_item_record(
             )
         }
         rue_parser::Item::Enum(enumeration) => {
-            let mut children = vec![modifier_record(
+            let mut children =
+                directive_records(owner, &enumeration.directives).collect::<Vec<_>>();
+            children.push(modifier_record(
                 enumeration.span,
                 "visibility",
                 visibility_name(enumeration.visibility),
-            )];
+            ));
             children.extend(enumeration.variants.iter().map(|variant| {
                 syntax_record(
                     "enum_variant",

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -917,6 +917,7 @@ mod tests {
                     variants,
                     variant_payloads: payloads,
                     is_pub: false,
+                    is_non_exhaustive: false,
                     file_id: rue_span::FileId::DEFAULT,
                 },
             )
@@ -1162,6 +1163,7 @@ mod tests {
             variants: Arc::from(["Only".into()]),
             variant_payloads: vec![vec![]],
             is_pub: false,
+            is_non_exhaustive: false,
             file_id,
         };
         let (left, _) = type_pool.register_enum(symbol, make_enum(rue_span::FileId::new(1)));

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -198,6 +198,7 @@ pub enum DurableDeclarationPayload {
     },
     Enum {
         variants: Arc<[(Arc<str>, Arc<[DurableType]>)]>,
+        is_non_exhaustive: bool,
     },
     Const {
         ty: DurableType,
@@ -234,7 +235,7 @@ impl RetainedCharge for DurableAnonymousNominalShape {
             Self::Struct { fields, methods } => fields
                 .retained_charge()
                 .saturating_add(methods.retained_charge()),
-            Self::Enum { variants } => variants.retained_charge(),
+            Self::Enum { variants, .. } => variants.retained_charge(),
         }
     }
 }
@@ -280,7 +281,7 @@ impl RetainedCharge for DurableDeclarationPayload {
                 .retained_charge()
                 .saturating_add(result.retained_charge()),
             Self::Struct { fields, .. } => fields.retained_charge(),
-            Self::Enum { variants } => variants.retained_charge(),
+            Self::Enum { variants, .. } => variants.retained_charge(),
             Self::Const { ty, value } => {
                 ty.retained_charge().saturating_add(value.retained_charge())
             }

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -84,7 +84,7 @@ impl SharedDeclarationFactIndex {
                         collect_slice_sources(ty, &mut slice_sources, &mut work);
                     }
                 }
-                DurableDeclarationPayload::Enum { variants } => {
+                DurableDeclarationPayload::Enum { variants, .. } => {
                     for (_, fields) in variants.iter() {
                         for ty in fields.iter() {
                             collect_slice_sources(ty, &mut slice_sources, &mut work);
@@ -1034,10 +1034,14 @@ pub(crate) fn materialize_semantic_body_with_indexes_in_space(
                     destructor: destructor_for(&declaration.key),
                 },
             ),
-            DurableDeclarationPayload::Enum { variants } => (
+            DurableDeclarationPayload::Enum {
+                variants,
+                is_non_exhaustive,
+            } => (
                 rue_air::SemanticImportNominalKind::Enum,
                 rue_air::SemanticLocalNominalShape::Enum {
                     variants: variants.clone(),
+                    is_non_exhaustive: *is_non_exhaustive,
                 },
             ),
             _ => continue,
@@ -1090,10 +1094,11 @@ pub(crate) fn materialize_semantic_body_with_indexes_in_space(
                     },
                 )
             }
-            DurableAnonymousNominalShape::Enum { variants } => (
+            DurableAnonymousNominalShape::Enum { variants, .. } => (
                 rue_air::SemanticImportNominalKind::Enum,
                 rue_air::SemanticLocalNominalShape::Enum {
                     variants: variants.clone(),
+                    is_non_exhaustive: false,
                 },
             ),
         };
@@ -1158,6 +1163,7 @@ pub(crate) fn materialize_semantic_body_with_indexes_in_space(
                         })
                         .collect::<Vec<_>>()
                         .into(),
+                    is_non_exhaustive: false,
                 },
             ),
             (
@@ -1521,7 +1527,7 @@ pub(crate) fn select_materialization_facts(
                                     ));
                                 }
                             }
-                            DurableDeclarationPayload::Enum { variants } => {
+                            DurableDeclarationPayload::Enum { variants, .. } => {
                                 for (_, fields) in variants.iter() {
                                     for ty in fields.iter() {
                                         self.semantic_type(ty);
@@ -1605,6 +1611,7 @@ pub(crate) fn select_materialization_facts(
                             DurableDeclarationPayload::Enum { .. } => {
                                 DurableDeclarationPayload::Enum {
                                     variants: Arc::new([]),
+                                    is_non_exhaustive: false,
                                 }
                             }
                             _ => continue,

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -228,7 +228,8 @@ fn item_charge(item: &ast::Item) -> u64 {
                 type_charge(&field.ty)
             }))
             .saturating_add(owned_slice_charge(&value.methods, method_charge)),
-        ast::Item::Enum(value) => owned_slice_charge(&value.variants, enum_variant_charge),
+        ast::Item::Enum(value) => directives_charge(&value.directives)
+            .saturating_add(owned_slice_charge(&value.variants, enum_variant_charge)),
         ast::Item::DropFn(value) => expr_charge(&value.body),
         ast::Item::Extern(value) => value
             .abi
@@ -1042,6 +1043,7 @@ impl RetainedCharge for crate::semantic_query_nucleus::ParsedSemanticSignature {
                 syntax,
                 variants,
                 payloads,
+                ..
             } => type_syntax_arena_charge(syntax)
                 .saturating_add(variants.retained_charge())
                 .saturating_add(payloads.retained_charge()),

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -4732,7 +4732,7 @@ fn evaluate_type_shape(
                                 .collect::<Vec<_>>()
                                 .into(),
                         }),
-                        S::Enum { variants } => TypeShapeValue::Available(TypeShape::Enum {
+                        S::Enum { variants, .. } => TypeShapeValue::Available(TypeShape::Enum {
                             variants: variants
                                 .iter()
                                 .map(|(name, fields)| {
@@ -4781,7 +4781,7 @@ fn evaluate_type_shape(
                         .collect::<Vec<_>>()
                         .into(),
                 },
-                S::Enum { variants } => TypeShape::Enum {
+                S::Enum { variants, .. } => TypeShape::Enum {
                     variants: variants
                         .iter()
                         .map(|(name, fields)| {
@@ -6928,7 +6928,7 @@ fn collect_durable_anonymous_nominal_dependencies(
                 }
             }
         }
-        S::Enum { variants } => {
+        S::Enum { variants, .. } => {
             for (_, fields) in variants.iter() {
                 for ty in fields.iter() {
                     collect_anonymous_nominal_type_dependencies(ty, output);
@@ -9193,7 +9193,7 @@ impl SemanticNucleusTypeProvider<'_> {
                         }
                         carries
                     }
-                    P::Enum { variants } => {
+                    P::Enum { variants, .. } => {
                         let mut carries = LinearOwnershipFact::DoesNotCarry;
                         for (_, payload) in variants.iter() {
                             for field in payload.iter() {
@@ -9228,7 +9228,7 @@ impl SemanticNucleusTypeProvider<'_> {
                         }
                         Ok(carries)
                     }
-                    S::Enum { variants } => {
+                    S::Enum { variants, .. } => {
                         let mut carries = LinearOwnershipFact::DoesNotCarry;
                         for (_, payload) in variants.iter() {
                             for field in payload.iter() {
@@ -9376,7 +9376,7 @@ impl SemanticNucleusTypeProvider<'_> {
                         }
                         has_glue
                     }
-                    P::Enum { variants } => {
+                    P::Enum { variants, .. } => {
                         let mut has_glue = false;
                         for (_, payload) in variants.iter() {
                             for field in payload.iter() {
@@ -9404,7 +9404,7 @@ impl SemanticNucleusTypeProvider<'_> {
                             }
                         }
                     }
-                    S::Enum { variants } => {
+                    S::Enum { variants, .. } => {
                         for (_, payload) in variants.iter() {
                             for field in payload.iter() {
                                 if self.type_has_drop_glue_inner(field, walk)? {
@@ -9545,7 +9545,7 @@ impl SemanticNucleusTypeProvider<'_> {
                 );
                 let is_copy = match resolved.signature {
                     P::Struct { is_copy, .. } => is_copy,
-                    P::Enum { variants } => {
+                    P::Enum { variants, .. } => {
                         let mut is_copy = true;
                         for (_, payload) in variants.iter() {
                             for field in payload.iter() {
@@ -9579,7 +9579,7 @@ impl SemanticNucleusTypeProvider<'_> {
                             }
                         }
                     }
-                    S::Enum { variants } => {
+                    S::Enum { variants, .. } => {
                         for (_, payload) in variants.iter() {
                             for field in payload.iter() {
                                 if !self.type_is_copy_inner(field, walk)? {
@@ -9832,7 +9832,7 @@ impl SemanticNucleusTypeProvider<'_> {
                                 S::Struct { fields, .. } => {
                                     pending.extend(fields.iter().map(|(_, ty)| ty));
                                 }
-                                S::Enum { variants } => {
+                                S::Enum { variants, .. } => {
                                     pending.extend(
                                         variants.iter().flat_map(|(_, payload)| payload.iter()),
                                     );
@@ -9909,7 +9909,7 @@ impl SemanticNucleusTypeProvider<'_> {
                         collect_type(ty, &anonymous, &mut neighbors);
                     }
                 }
-                P::Enum { variants } => {
+                P::Enum { variants, .. } => {
                     for (_, payload) in variants.iter() {
                         for ty in payload.iter() {
                             collect_type(ty, &anonymous, &mut neighbors);
@@ -11446,8 +11446,55 @@ fn resolve_parsed_semantic_signature(
             syntax,
             variants,
             payloads,
+            is_non_exhaustive,
+            is_public,
+            non_exhaustive_range,
             ..
         } => {
+            if *is_non_exhaustive && !*is_public {
+                let kind = rue_error::ErrorKind::ParseError(
+                    "@non_exhaustive can only be applied to public enums".to_string(),
+                );
+                return Err(match non_exhaustive_range {
+                    Some((start, end)) => ResolveSemanticSignatureError::failure(
+                        crate::semantic_query_nucleus::SemanticNucleusFailure::DiagnosticAtProducerRange {
+                            kind,
+                            producer: declaration_candidate_for_stable_key(
+                                &provider.dependency_source,
+                            )
+                            .expect("enum signature has a declaration candidate"),
+                            start: *start,
+                            end: *end,
+                        },
+                    ),
+                    None => diagnostic(kind),
+                });
+            }
+            if *is_non_exhaustive
+                && !provider
+                    .configuration
+                    .preview_features
+                    .contains(rue_error::PreviewFeature::NonExhaustiveEnums)
+            {
+                let kind = rue_error::ErrorKind::PreviewFeatureRequired {
+                    feature: rue_error::PreviewFeature::NonExhaustiveEnums,
+                    what: "@non_exhaustive enums".to_owned(),
+                };
+                return Err(match non_exhaustive_range {
+                    Some((start, end)) => ResolveSemanticSignatureError::failure(
+                        crate::semantic_query_nucleus::SemanticNucleusFailure::DiagnosticAtProducerRange {
+                            kind,
+                            producer: declaration_candidate_for_stable_key(
+                                &provider.dependency_source,
+                            )
+                            .expect("enum signature has a declaration candidate"),
+                            start: *start,
+                            end: *end,
+                        },
+                    ),
+                    None => diagnostic(kind),
+                });
+            }
             if let Some(kind) = rue_air::declaration_validation::duplicate_variant(
                 provider.dependency_source.name(),
                 variants.iter().map(|variant| parsed.symbol(variant.name)),
@@ -11486,6 +11533,7 @@ fn resolve_parsed_semantic_signature(
             }
             Ok(Output::Enum {
                 variants: variants.into(),
+                is_non_exhaustive: *is_non_exhaustive,
             })
         }
         Input::Destructor => Ok(Output::Destructor),
@@ -22901,7 +22949,13 @@ impl rue_air::DurableNominalSource<crate::StableDefinitionKey, ModuleId>
                 is_copy,
                 is_linear,
             },
-            Projection::Enum { variants } => rue_air::DurableNominalBody::Enum { variants },
+            Projection::Enum {
+                variants,
+                is_non_exhaustive,
+            } => rue_air::DurableNominalBody::Enum {
+                variants,
+                is_non_exhaustive,
+            },
             _ => return None,
         };
         let nominal = rue_air::DurableNominal {
@@ -25657,7 +25711,11 @@ pub(crate) mod test_support {
                     is_copy: *is_copy,
                     is_linear: *is_linear,
                 },
-                Payload::Enum { variants } => rue_air::DurableNominalBody::Enum {
+                Payload::Enum {
+                    variants,
+                    is_non_exhaustive,
+                } => rue_air::DurableNominalBody::Enum {
+                    is_non_exhaustive: *is_non_exhaustive,
                     variants: variants
                         .iter()
                         .map(|(n, payload)| (n.clone(), payload.clone().into()))
@@ -28005,7 +28063,7 @@ fn main() -> i32 {
                     assert!(!is_linear && !is_repr_c);
                 }
                 (crate::StableDefinitionKind::Enum, "E") => {
-                    let Sig::Enum { variants } = signature else {
+                    let Sig::Enum { variants, .. } = signature else {
                         panic!("E must project an enum signature: {signature:?}")
                     };
                     let rendered = variants
@@ -33824,6 +33882,7 @@ fn main() -> i32 {
                         vec![Type::U32, Type::U16, Type::U64],
                     ],
                     is_pub: false,
+                    is_non_exhaustive: false,
                     file_id: rue_span::FileId::DEFAULT,
                 },
             )
@@ -34388,6 +34447,7 @@ fn main() -> i32 {
                     variants: Arc::from(["A".into(), "B".into()]),
                     variant_payloads: vec![vec![], vec![]],
                     is_pub: false,
+                    is_non_exhaustive: false,
                     file_id: rue_span::FileId::DEFAULT,
                 },
             )
@@ -34404,6 +34464,7 @@ fn main() -> i32 {
                         vec![Type::U32, Type::U16, Type::U64],
                     ],
                     is_pub: false,
+                    is_non_exhaustive: false,
                     file_id: rue_span::FileId::DEFAULT,
                 },
             )

--- a/crates/rue-compiler/src/semantic_query_nucleus.rs
+++ b/crates/rue-compiler/src/semantic_query_nucleus.rs
@@ -88,6 +88,11 @@ pub(crate) enum ParsedSemanticSignature {
         syntax: rue_rir::RirTypeSyntaxArena<Arc<str>>,
         variants: Arc<[ParsedSemanticVariant]>,
         payloads: Arc<[rue_rir::RirTypeSyntaxRef]>,
+        is_non_exhaustive: bool,
+        is_public: bool,
+        /// Directive range relative to the declaration span, retained so
+        /// declaration diagnostics can point at `@non_exhaustive` itself.
+        non_exhaustive_range: Option<(u32, u32)>,
     },
     Destructor,
 }
@@ -551,6 +556,21 @@ pub(crate) fn project_semantic_signature(
                 syntax: syntax.finish(),
                 variants: variants.into(),
                 payloads: payloads.into(),
+                is_non_exhaustive: value
+                    .directives
+                    .iter()
+                    .any(|directive| resolve(directive.name.name) == "non_exhaustive"),
+                is_public: value.visibility == rue_parser::ast::Visibility::Public,
+                non_exhaustive_range: value
+                    .directives
+                    .iter()
+                    .find(|directive| resolve(directive.name.name) == "non_exhaustive")
+                    .and_then(|directive| {
+                        Some((
+                            directive.span.start.checked_sub(value.span.start)?,
+                            directive.span.end.checked_sub(value.span.start)?,
+                        ))
+                    }),
             })
         }
         ParsedDeclarationAstRef::Destructor(_) => Ok(ParsedSemanticSignature::Destructor),
@@ -852,6 +872,7 @@ pub(crate) enum DeclarationSignatureProjection {
     },
     Enum {
         variants: Arc<[(Arc<str>, Arc<[DurableType]>)]>,
+        is_non_exhaustive: bool,
     },
     Destructor,
 }
@@ -1001,7 +1022,7 @@ impl RetainedCharge for DeclarationSignatureProjection {
                 .retained_charge()
                 .saturating_add(result.retained_charge()),
             Self::Struct { fields, .. } => fields.retained_charge(),
-            Self::Enum { variants } => variants.retained_charge(),
+            Self::Enum { variants, .. } => variants.retained_charge(),
             Self::Destructor => 0,
         }
     }
@@ -1121,9 +1142,13 @@ impl DeclarationSemanticValue {
                 is_copy,
                 is_linear,
             },
-            DeclarationSignatureProjection::Enum { variants } => {
-                DurableDeclarationPayload::Enum { variants }
-            }
+            DeclarationSignatureProjection::Enum {
+                variants,
+                is_non_exhaustive,
+            } => DurableDeclarationPayload::Enum {
+                variants,
+                is_non_exhaustive,
+            },
             DeclarationSignatureProjection::Destructor => DurableDeclarationPayload::Destructor,
         };
         Self { identity, payload }

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -7338,6 +7338,38 @@ mod tests {
     }
 
     #[test]
+    fn syntax_artifact_retains_enum_directive_child() {
+        let source = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "@non_exhaustive pub enum Color { Red, Green }",
+            )],
+            1,
+        );
+        let mut session = CompilerSession::new();
+        let syntax = session.update(&source).into_result().unwrap();
+        let item = syntax
+            .modules()
+            .next()
+            .expect("the syntax view has one module")
+            .nodes()
+            .next()
+            .expect("the module has one item");
+        assert_eq!(item.kind(), "enum");
+        let children = item.children().collect::<Vec<_>>();
+        assert_eq!(
+            children.first().map(|child| child.kind()),
+            Some("directive")
+        );
+        assert_eq!(
+            children.first().and_then(|child| child.name()),
+            Some("non_exhaustive")
+        );
+    }
+
+    #[test]
     fn o3_publishes_unrolled_work_for_canonical_slot_loop() {
         let source = snapshot(
             &[(
@@ -12872,6 +12904,99 @@ fn main() -> i32 {
         let terminal = fresh_result.expect("fresh duplicate publishes a typed body failure");
         assert!(matches!(
             terminal.outcome(),
+            rue_query::QueryOutcome::Success(
+                crate::body_query::BodyTransaction::DeterministicFailure { .. }
+            )
+        ));
+    }
+
+    #[test]
+    fn non_exhaustive_directive_invalidates_external_match_body() {
+        let root = r#"const colors = @import("colors.rue");
+fn main() -> i32 {
+    match colors.pick() {
+        colors.Color.Red => 1,
+        colors.Color.Green => 2,
+    }
+}"#;
+        let closed = snapshot(
+            &[
+                (1, "/p/main.rue", "main.rue", root),
+                (
+                    2,
+                    "/p/colors.rue",
+                    "colors.rue",
+                    "pub enum Color { Red, Green }\n\
+                     pub fn pick() -> Color { Color.Green }",
+                ),
+            ],
+            1,
+        );
+        let open = snapshot(
+            &[
+                (1, "/p/main.rue", "main.rue", root),
+                (
+                    2,
+                    "/p/colors.rue",
+                    "colors.rue",
+                    "@non_exhaustive pub enum Color { Red, Green }\n\
+                     pub fn pick() -> Color { Color.Green }",
+                ),
+            ],
+            1,
+        );
+        let options = CompileOptions {
+            preview_features: PreviewFeatures::from([PreviewFeature::NonExhaustiveEnums]),
+            ..CompileOptions::default()
+        };
+        let mut session = CompilerSession::new();
+        publish_with_test_imports(&mut session, &closed);
+        session
+            .rooted_cfg(&options)
+            .expect("a closed imported enum remains exhaustive");
+        let key = body_query_key(&mut session, &options, "main");
+        let revision = session
+            .queries
+            .revisioned
+            .current_semantic_revision()
+            .expect("the closed match publishes a semantic revision");
+        let first = session
+            .queries
+            .revisioned
+            .body_transaction(revision, key.clone(), rue_query::CancellationToken::new())
+            .expect("the closed match publishes a body terminal");
+        assert!(matches!(
+            first.outcome(),
+            rue_query::QueryOutcome::Success(crate::body_query::BodyTransaction::Success { .. })
+        ));
+
+        publish_with_test_imports(&mut session, &open);
+        let errors = session
+            .rooted_cfg(&options)
+            .expect_err("an external match must require a wildcard after the directive is added");
+        assert!(
+            errors
+                .iter()
+                .any(|error| matches!(error.kind, ErrorKind::NonExhaustiveMatch)),
+            "unexpected diagnostics: {errors:?}"
+        );
+        let revision = session
+            .queries
+            .revisioned
+            .current_semantic_revision()
+            .expect("the failed match publishes a semantic revision");
+        let second = session
+            .queries
+            .revisioned
+            .body_transaction(revision, key, rue_query::CancellationToken::new())
+            .expect("the non-exhaustive match publishes a deterministic body failure");
+        assert_ne!(
+            second.stamp(),
+            first.stamp(),
+            "changing @non_exhaustive must invalidate the external match body terminal"
+        );
+        assert!(matches!(
+            second.outcome(),
             rue_query::QueryOutcome::Success(
                 crate::body_query::BodyTransaction::DeterministicFailure { .. }
             )

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -701,6 +701,8 @@ pub enum PreviewFeature {
     /// so an enabled float literal still stops at
     /// [`ErrorKind::FloatNotYetImplemented`].
     Floats,
+    /// Public enums may promise that importing matches include a wildcard.
+    NonExhaustiveEnums,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -723,6 +725,7 @@ impl PreviewFeature {
             PreviewFeature::TestInfra => "test_infra",
             PreviewFeature::CFfi => "c_ffi",
             PreviewFeature::Floats => "floats",
+            PreviewFeature::NonExhaustiveEnums => "non_exhaustive_enums",
         }
     }
 
@@ -733,6 +736,7 @@ impl PreviewFeature {
             PreviewFeature::TestInfra => "ADR-0005",
             PreviewFeature::CFfi => "ADR-0064",
             PreviewFeature::Floats => "ADR-0065",
+            PreviewFeature::NonExhaustiveEnums => "ADR-0005",
         }
     }
 
@@ -742,6 +746,7 @@ impl PreviewFeature {
             PreviewFeature::TestInfra,
             PreviewFeature::CFfi,
             PreviewFeature::Floats,
+            PreviewFeature::NonExhaustiveEnums,
         ]
     }
 
@@ -767,6 +772,7 @@ impl std::str::FromStr for PreviewFeature {
             "test_infra" => Ok(PreviewFeature::TestInfra),
             "c_ffi" => Ok(PreviewFeature::CFfi),
             "floats" => Ok(PreviewFeature::Floats),
+            "non_exhaustive_enums" => Ok(PreviewFeature::NonExhaustiveEnums),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }
@@ -3149,7 +3155,7 @@ mod tests {
     #[test]
     fn test_preview_feature_all_names() {
         let names = PreviewFeature::all_names();
-        assert_eq!(names, "test_infra, c_ffi, floats");
+        assert_eq!(names, "test_infra, c_ffi, floats, non_exhaustive_enums");
     }
 
     #[test]

--- a/crates/rue-frontend-diff/src/main.rs
+++ b/crates/rue-frontend-diff/src/main.rs
@@ -43,6 +43,10 @@ const SYNTAX_PROBES: &[(&str, &str)] = &[
         "enum Maybe { None, Some(u64) } fn f(value: Maybe) -> u64 { match value { Maybe.Some(_) => 1, Maybe.None => 0 } }",
     ),
     (
+        "enum-directives.rue",
+        "@non_exhaustive pub enum Color { Red, Green }",
+    ),
+    (
         "qualified-type-arguments.rue",
         "fn f(value: outer.Result(inner.Value, inner.Error)) { match value { outer.Result(inner.Value, inner.Error).Ok(v) => {} } }",
     ),
@@ -921,8 +925,8 @@ impl Shapes<'_> {
             Item::Enum(v) => node(
                 "enum",
                 &format!(" flags={}", u8::from(v.visibility == Visibility::Public)),
+                self.directives(&v.directives),
                 self.variants(&v.variants),
-                "_".into(),
                 "_".into(),
                 "_".into(),
             ),
@@ -1447,6 +1451,19 @@ mod tests {
         ] {
             assert!(shape.contains(needle), "missing {needle} in {shape}");
         }
+    }
+
+    #[test]
+    fn normalization_retains_enum_directives() {
+        let shape = rust_shape("@non_exhaustive pub enum Color { Red, Green }").unwrap();
+        assert!(
+            shape.contains("(enum flags=1"),
+            "enum shape missing: {shape}"
+        );
+        assert!(
+            shape.contains("(directive"),
+            "enum directive missing from normalized shape: {shape}"
+        );
     }
 
     #[test]

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -168,6 +168,8 @@ pub struct FieldDecl {
 /// An enum declaration.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnumDecl {
+    /// Directives applied to this enum (currently `@non_exhaustive`).
+    pub directives: Directives,
     /// Visibility of this enum
     pub visibility: Visibility,
     /// Enum name
@@ -1540,6 +1542,7 @@ fn rebind_item(item: &mut Item, file_id: FileId) {
             rebind_span(&mut structure.span, file_id);
         }
         Item::Enum(enumeration) => {
+            rebind_directives(&mut enumeration.directives, file_id);
             rebind_ident(&mut enumeration.name, file_id);
             for variant in &mut enumeration.variants {
                 rebind_enum_variant(variant, file_id);
@@ -1993,6 +1996,9 @@ fn fmt_struct(f: &mut fmt::Formatter<'_>, s: &StructDecl, level: usize) -> fmt::
 
 fn fmt_enum(f: &mut fmt::Formatter<'_>, e: &EnumDecl, level: usize) -> fmt::Result {
     indent(f, level)?;
+    for directive in &e.directives {
+        write!(f, "@sym:{} ", directive.name.name.into_usize())?;
+    }
     writeln!(f, "Enum sym:{}", e.name.name.into_usize())?;
     for variant in &e.variants {
         indent(f, level + 1)?;

--- a/crates/rue-parser/src/parser.rs
+++ b/crates/rue-parser/src/parser.rs
@@ -303,6 +303,17 @@ mod tests {
     }
 
     #[test]
+    fn enum_display_retains_declaration_directives() {
+        let (ast, _) = parse_source("@non_exhaustive pub enum Color { Red, Green }").unwrap();
+        let rendered = ast.to_string();
+        let enum_start = rendered.find("Enum sym:").expect("enum is rendered");
+        assert!(
+            rendered[..enum_start].contains("@sym:"),
+            "enum directives must remain visible before the declaration: {rendered}"
+        );
+    }
+
+    #[test]
     fn representative_language_surface_parses() {
         for source in [
             "fn main(a: i32, borrow xs: [i32]) -> i32 { let mut x: i32 = a + 2 * 3; x = x - 1; if x > 0 { x } else { 0 } }",

--- a/crates/rue-parser/src/parser/declarations.rs
+++ b/crates/rue-parser/src/parser/declarations.rs
@@ -39,9 +39,9 @@ impl Parser {
             TokenKind::Linear | TokenKind::Struct => self
                 .struct_decl(start, directives, visibility)
                 .map(Item::Struct),
-            TokenKind::Enum if directives.is_empty() => {
-                self.enum_decl(start, visibility).map(Item::Enum)
-            }
+            TokenKind::Enum => self
+                .enum_decl(start, directives, visibility)
+                .map(Item::Enum),
             TokenKind::Drop if directives.is_empty() && visibility == Visibility::Private => {
                 self.drop_fn(start).map(Item::DropFn)
             }
@@ -308,11 +308,17 @@ impl Parser {
         })
     }
 
-    fn enum_decl(&mut self, start: u32, visibility: Visibility) -> PResult<EnumDecl> {
+    fn enum_decl(
+        &mut self,
+        start: u32,
+        directives: Directives,
+        visibility: Visibility,
+    ) -> PResult<EnumDecl> {
         self.expect(TokenKind::Enum)?;
         let name = self.ident()?;
         let variants = self.enum_variants()?;
         Ok(EnumDecl {
+            directives,
             visibility,
             name,
             variants,

--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -27,7 +27,9 @@ use rue_error::{CompileError, ErrorKind};
 /// - `copy`   — marks a struct as a copy type (see `has_copy_directive`)
 /// - `repr`   — the C representation guarantee marker `@repr(c)` on a struct
 ///   (ADR-0064 Amendment 1; see `has_repr_c_directive` in rue-air)
-pub const KNOWN_DIRECTIVES: &[&str] = &["allow", "copy", "repr"];
+/// - `non_exhaustive` — opts a public enum into the source/API compatibility
+///   contract for matches in importing modules.
+pub const KNOWN_DIRECTIVES: &[&str] = &["allow", "copy", "repr", "non_exhaustive"];
 
 /// Representation arguments accepted by `@repr(...)`.
 ///
@@ -67,6 +69,7 @@ struct Validator<'a> {
 enum DirectiveSite {
     Function,
     Struct,
+    Enum,
     Method,
     Const,
     Let,
@@ -77,6 +80,7 @@ impl DirectiveSite {
         match self {
             DirectiveSite::Function => "functions",
             DirectiveSite::Struct => "structs",
+            DirectiveSite::Enum => "enums",
             DirectiveSite::Method => "methods",
             DirectiveSite::Const => "const declarations",
             DirectiveSite::Let => "let statements",
@@ -91,7 +95,7 @@ impl Validator<'_> {
             if !KNOWN_DIRECTIVES.contains(&name) {
                 self.errors.push(CompileError::new(
                     ErrorKind::ParseError(format!(
-                        "unknown directive '@{}'; known directives are @allow, @copy, and @repr",
+                        "unknown directive '@{}'; known directives are @allow, @copy, @repr, and @non_exhaustive",
                         name
                     )),
                     directive.span,
@@ -100,6 +104,22 @@ impl Validator<'_> {
             }
 
             match name {
+                "non_exhaustive" => {
+                    if !matches!(site, DirectiveSite::Enum) {
+                        self.errors.push(CompileError::new(
+                            ErrorKind::ParseError(format!(
+                                "@non_exhaustive can only be applied to enums, not {}",
+                                site.description()
+                            )),
+                            directive.span,
+                        ));
+                    } else if !directive.args.is_empty() {
+                        self.errors.push(CompileError::new(
+                            ErrorKind::ParseError("@non_exhaustive takes no arguments".to_string()),
+                            directive.span,
+                        ));
+                    }
+                }
                 "copy" => {
                     if !matches!(site, DirectiveSite::Struct) {
                         self.errors.push(CompileError::new(
@@ -201,7 +221,21 @@ impl Validator<'_> {
                     self.check_method(method);
                 }
             }
-            Item::Enum(_) => {}
+            Item::Enum(e) => {
+                self.check_directives(&e.directives, DirectiveSite::Enum);
+                if e.visibility != crate::ast::Visibility::Public
+                    && let Some(directive) = e.directives.iter().find(|directive| {
+                        self.interner.resolve(&directive.name.name) == "non_exhaustive"
+                    })
+                {
+                    self.errors.push(CompileError::new(
+                        ErrorKind::ParseError(
+                            "@non_exhaustive can only be applied to public enums".to_string(),
+                        ),
+                        directive.span,
+                    ));
+                }
+            }
             Item::DropFn(d) => self.check_expr(&d.body),
             Item::Extern(_) => {}
             Item::Const(c) => {

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -683,6 +683,9 @@ impl<'a> AstGen<'a> {
         self.rir
             .add_enum_decl(
                 enum_decl.visibility == Visibility::Public,
+                enum_decl.directives.iter().any(|directive| {
+                    self.interner.resolve(&directive.name.name) == "non_exhaustive"
+                }),
                 name,
                 &variants,
                 &payload_types,

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -1574,6 +1574,7 @@ impl RirEditor {
     pub fn add_enum_decl(
         &mut self,
         is_pub: bool,
+        is_non_exhaustive: bool,
         name: Spur,
         variants: &[Spur],
         payloads: &[Vec<RirTypeSyntaxRef>],
@@ -1591,6 +1592,7 @@ impl RirEditor {
             Ok(rir.add_inst(Inst {
                 data: InstData::EnumDecl {
                     is_pub,
+                    is_non_exhaustive,
                     name,
                     variants,
                     payloads,
@@ -2418,6 +2420,7 @@ impl RirEditor {
                     }
                     InstData::EnumDecl {
                         is_pub,
+                        is_non_exhaustive,
                         name,
                         variants: variant_range,
                         payloads,
@@ -2431,7 +2434,14 @@ impl RirEditor {
                             .enum_payloads(payloads, variant_range)
                             .map(|payload| payload.values().map(remap_type).collect())
                             .collect::<Vec<Vec<_>>>();
-                        self.add_enum_decl(*is_pub, symbol(*name), &variants, &payloads, span)?
+                        self.add_enum_decl(
+                            *is_pub,
+                            *is_non_exhaustive,
+                            symbol(*name),
+                            &variants,
+                            &payloads,
+                            span,
+                        )?
                     }
                     InstData::EnumVariant {
                         module,
@@ -5626,6 +5636,8 @@ pub enum InstData {
     EnumDecl {
         /// Whether this enum is public (requires --preview modules)
         is_pub: bool,
+        /// Whether importing modules must include a wildcard when matching.
+        is_non_exhaustive: bool,
         /// Enum name
         name: Spur,
         /// Index into extra data where variants start
@@ -6499,11 +6511,17 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 // Enums
                 InstData::EnumDecl {
                     is_pub,
+                    is_non_exhaustive,
                     name,
                     variants,
                     payloads,
                 } => {
                     let pub_str = if *is_pub { "pub " } else { "" };
+                    let marker = if *is_non_exhaustive {
+                        "@non_exhaustive "
+                    } else {
+                        ""
+                    };
                     let name_str = self.interner.resolve(&*name);
                     let payload_arities: Vec<usize> = self
                         .rir
@@ -6524,7 +6542,8 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         .collect();
                     writeln!(
                         out,
-                        "{}enum {} {{ {} }}",
+                        "{}{}enum {} {{ {} }}",
+                        marker,
                         pub_str,
                         name_str,
                         variants_str.join(", ")
@@ -7027,7 +7046,7 @@ mod typed_payload_tests {
             )
             .unwrap();
         editor
-            .add_enum_decl(true, a, &[a, b], &[vec![type_b], vec![]], span())
+            .add_enum_decl(true, false, a, &[a, b], &[vec![type_b], vec![]], span())
             .unwrap();
         editor.add_array_init(&[value, block], span()).unwrap();
         editor
@@ -8350,6 +8369,7 @@ mod typed_payload_tests {
         cardinality.add_inst(Inst {
             data: InstData::EnumDecl {
                 is_pub: false,
+                is_non_exhaustive: false,
                 name: Spur::default(),
                 variants,
                 payloads,
@@ -8551,6 +8571,7 @@ mod typed_payload_tests {
         bad_symbol_word.rir.add_inst(Inst {
             data: InstData::EnumDecl {
                 is_pub: false,
+                is_non_exhaustive: false,
                 name: symbol,
                 variants: RirEnumVariantsRange::from_parts(0, 1),
                 payloads: RirEnumPayloadsRange::payload_fallback(),
@@ -8791,6 +8812,7 @@ mod typed_payload_tests {
             |rir: &mut Rir| rir.add_enum_variants(&[a]).unwrap(),
             |variants| InstData::EnumDecl {
                 is_pub: false,
+                is_non_exhaustive: false,
                 name: a,
                 variants,
                 payloads: RirEnumPayloadsRange::payload_fallback(),

--- a/crates/rue-rir/src/inst/packed.rs
+++ b/crates/rue-rir/src/inst/packed.rs
@@ -1583,12 +1583,14 @@ impl<E, C: FnMut() -> Result<(), E>, P: FnMut(RirSpanSlot, Span) -> Result<(u32,
             }
             InstData::EnumDecl {
                 is_pub,
+                is_non_exhaustive,
                 name,
                 variants,
                 payloads,
             } => {
                 self.byte(50)?;
                 self.boolean(*is_pub)?;
+                self.boolean(*is_non_exhaustive)?;
                 self.symbol(*name)?;
                 self.enum_payload(
                     rir.enum_variants(variants),
@@ -3009,10 +3011,17 @@ impl<
             }
             50 => {
                 let is_pub = reader.boolean("enum visibility")?;
+                let is_non_exhaustive = reader.boolean("enum non-exhaustive marker")?;
                 let name = self.symbol(reader)?;
                 let (variants, payloads) = self.enum_payload(reader)?;
-                self.destination
-                    .add_enum_decl(is_pub, name, &variants, &payloads, span)?
+                self.destination.add_enum_decl(
+                    is_pub,
+                    is_non_exhaustive,
+                    name,
+                    &variants,
+                    &payloads,
+                    span,
+                )?
             }
             51 => {
                 let module = self.optional_ref(reader)?;
@@ -4319,7 +4328,7 @@ mod tests {
         });
         refs.push(
             editor
-                .add_enum_decl(true, a, &[a, b], &[vec![type_a], vec![]], span)
+                .add_enum_decl(true, false, a, &[a, b], &[vec![type_a], vec![]], span)
                 .unwrap(),
         );
         add!(InstData::EnumVariant {
@@ -4817,6 +4826,7 @@ mod tests {
         let enumeration_payload = named_type(&mut enumeration, b);
         let enum_root = enumeration
             .add_enum_decl(
+                false,
                 false,
                 a,
                 &[a],

--- a/crates/rue-spec/cases/items/enums.toml
+++ b/crates/rue-spec/cases/items/enums.toml
@@ -171,6 +171,64 @@ compile_fail = true
 error_contains = "exhaustive"
 
 [[case]]
+name = "non_exhaustive_enum_requires_preview"
+spec = ["6.3:21"]
+source = """
+@non_exhaustive pub enum Color { Red, Green }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E1100", "non_exhaustive_enums"]
+
+[[case]]
+name = "non_exhaustive_enum_private_rejected"
+spec = ["6.3:21"]
+preview = "non_exhaustive_enums"
+preview_should_pass = true
+source = """
+@non_exhaustive enum Color { Red, Green }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "public enums"
+
+[[case]]
+name = "non_exhaustive_enum_internal_match_remains_exhaustive"
+spec = ["6.3:21"]
+preview = "non_exhaustive_enums"
+preview_should_pass = true
+source = """
+@non_exhaustive pub enum Color { Red, Green }
+fn classify(c: Color) -> i32 {
+    match c { Color.Red => 1, Color.Green => 2 }
+}
+fn main() -> i32 { classify(Color.Red) }
+"""
+exit_code = 1
+
+[[case]]
+name = "non_exhaustive_enum_external_match_keeps_wildcard_reachable"
+spec = ["6.3:21", "6.3:22"]
+preview = "non_exhaustive_enums"
+preview_should_pass = true
+source = """
+const colors = @import("colors.rue");
+fn main() -> i32 {
+    match colors.pick() {
+        colors.Color.Red => 1,
+        colors.Color.Green => 2,
+        _ => 3,
+    }
+}
+"""
+aux_files = { "colors.rue" = """
+@non_exhaustive pub enum Color { Red, Green }
+pub fn pick() -> Color { Color.Green }
+""" }
+exit_code = 2
+no_warnings = true
+
+[[case]]
 name = "match_enum_first_variant"
 spec = ["4.7:7", "4.7:10", "6.3:7"]
 source = """

--- a/crates/rue-ui-tests/cases/diagnostics/directives.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/directives.toml
@@ -3,7 +3,7 @@
 # Unknown @-directives in item/statement position used to be silently
 # accepted and ignored, so a typo like `@alllow(...)` was a no-op. They are
 # now a compile error naming the directive. The known set lives in
-# rue-parser's `validate::KNOWN_DIRECTIVES` (allow, copy, repr); the cases
+# rue-parser's `validate::KNOWN_DIRECTIVES` (allow, copy, repr, non_exhaustive); the cases
 # below pin both the rejection and that every known directive still works.
 # (Expression-position intrinsics like @dbg/@intCast and the fused @import
 # token are separate mechanisms and unaffected.)
@@ -23,7 +23,37 @@ source = """
 fn main() -> i32 { 42 }
 """
 compile_fail = true
-error_contains = ["unknown directive '@important'", "@allow, @copy, and @repr"]
+error_contains = ["unknown directive '@important'", "@allow, @copy, @repr, and @non_exhaustive"]
+
+[[case]]
+name = "non_exhaustive_directive_private_enum_rejected"
+preview = "non_exhaustive_enums"
+source = """
+@non_exhaustive enum E { A }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["@non_exhaustive can only be applied to public enums", "1:1"]
+
+[[case]]
+name = "non_exhaustive_directive_function_rejected"
+preview = "non_exhaustive_enums"
+source = """
+@non_exhaustive
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["@non_exhaustive can only be applied to enums"]
+
+[[case]]
+name = "non_exhaustive_directive_arguments_rejected"
+preview = "non_exhaustive_enums"
+source = """
+@non_exhaustive(foo) pub enum E { A }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["@non_exhaustive takes no arguments"]
 
 [[case]]
 name = "unknown_directive_typo_of_allow"
@@ -187,7 +217,7 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = ["unknown directive '@handle'", "@allow, @copy, and @repr"]
+error_contains = ["unknown directive '@handle'", "@allow, @copy, @repr, and @non_exhaustive"]
 
 [[case]]
 name = "ordinary_handle_method_still_works"

--- a/crates/rue-ui-tests/cases/diagnostics/match_diagnostics.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/match_diagnostics.toml
@@ -102,3 +102,12 @@ fn main() -> i32 {
 """
 exit_code = 42
 no_warnings = true
+
+[[case]]
+name = "non_exhaustive_enum_preview_gate"
+source = """
+@non_exhaustive pub enum Color { Red, Blue }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["requires preview feature", "non_exhaustive_enums", "1:1"]

--- a/crates/rue-ui-tests/cases/warnings/unreachable.toml
+++ b/crates/rue-ui-tests/cases/warnings/unreachable.toml
@@ -410,6 +410,24 @@ warning_contains = ["unreachable pattern", "'_'", "already cover every possible 
 expected_warning_count = 1
 
 [[case]]
+name = "wildcard_after_full_internal_non_exhaustive_enum_coverage"
+description = "The non-exhaustive contract affects importing modules only; a defining-module wildcard remains unreachable."
+preview = "non_exhaustive_enums"
+source = """
+@non_exhaustive pub enum Color { Red, Green }
+fn main() -> i32 {
+    match Color.Red {
+        Color.Red => 1,
+        Color.Green => 2,
+        _ => 3,
+    }
+}
+"""
+exit_code = 1
+warning_contains = ["unreachable pattern", "'_'", "already cover every possible value"]
+expected_warning_count = 1
+
+[[case]]
 name = "wildcard_after_full_bool_coverage"
 source = """
 fn main() -> i32 {

--- a/docs/designs/0005-preview-features.md
+++ b/docs/designs/0005-preview-features.md
@@ -7,7 +7,7 @@ feature-flag: preview-features
 created: 2025-01-01
 accepted: 2025-01-01
 implemented: 2025-12-27
-spec-sections: []
+spec-sections: ["6.3:21", "6.3:22"]
 superseded-by:
 ---
 
@@ -183,6 +183,15 @@ The following preview features completed this process and are now stable (their
 
 `test_infra` remains permanently unstable (it exists only to exercise the gating
 mechanism), so the `PreviewFeature` enum is not empty.
+
+### Active preview features
+
+- `non_exhaustive_enums` — `@non_exhaustive` public enums (RUE-1104). The
+  directive is an opt-in source/API compatibility promise: matches from an
+  importing module must include a wildcard, while matches in the defining
+  module remain exhaustively checked against the variants known there. Adding
+  variants can still change layout, ABI, or runtime behavior, so the promise
+  does not provide a binary compatibility guarantee.
 
 ## Implementation Phases
 

--- a/docs/spec/src/06-items/03-enums.md
+++ b/docs/spec/src/06-items/03-enums.md
@@ -13,7 +13,7 @@ An enum is defined using the `enum` keyword.
 {{ rule(id="6.3:2", cat="normative") }}
 
 ```ebnf
-enum_def = "enum" IDENT "{" [ enum_variants ] "}" ;
+enum_def = directives [ "pub" ] "enum" IDENT "{" [ enum_variants ] "}" ;
 enum_variants = enum_variant { "," enum_variant } [ "," ] ;
 enum_variant = IDENT [ "(" type { "," type } [ "," ] ")" ] ;
 ```
@@ -56,6 +56,25 @@ fn main() -> i32 {
 ```
 
 ## Match on Enums
+
+{{ rule(id="6.3:21", cat="normative") }}
+
+`@non_exhaustive` is an opt-in preview-gated declaration directive. It **MUST**
+appear only on a `pub enum`; applying it to a private enum is a compile-time
+error. The directive promises source/API compatibility: a match written in a
+module other than the enum's defining module **MUST** contain a wildcard arm,
+even when it names every variant currently known to the compiler. The defining
+module keeps ordinary exhaustive checking and ordinary unreachable-pattern
+diagnostics. A wildcard in an importing module remains reachable under this
+rule because a future enum variant may select it.
+
+{{ rule(id="6.3:22", cat="normative") }}
+
+Adding a variant to a `@non_exhaustive` enum does not promise stable layout,
+ABI, or runtime behavior. Such an addition may change enum representation,
+size, alignment, generated code, or other target-level behavior; the promise
+is limited to source compatibility of importing matches that include a
+wildcard.
 
 {{ rule(id="6.3:7", cat="normative") }}
 

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -79,7 +79,7 @@ method         = directives "fn" IDENT
                  [ result ] "{" block "}" ;
 
 (* Enums *)
-enum_def       = [ "pub" ] "enum" IDENT "{" [ enum_variants ] "}" ;
+enum_def       = directives [ "pub" ] "enum" IDENT "{" [ enum_variants ] "}" ;
 enum_variants  = enum_variant { "," enum_variant } [ "," ] ;
 enum_variant   = IDENT [ "(" type { "," type } [ "," ] ")" ] ;  (* optional tuple payload; at least one type inside the parens *)
 

--- a/examples/ruelex/parse.rue
+++ b/examples/ruelex/parse.rue
@@ -801,7 +801,7 @@ pub struct Parser {
         self.add(ast.ANON_ENUM_TYPE, 0, start, close.end, variants, 0, 0)
     }
 
-    fn parse_enum(inout self, flags: u64) -> u64 {
+    fn parse_enum(inout self, directives: u64, flags: u64) -> u64 {
         let start = self.expect(token.ENUM).start;
         let name = self.expect(token.IDENT);
         let _ = self.expect(token.LBRACE);
@@ -820,7 +820,7 @@ pub struct Parser {
             if !self.eat(token.COMMA) { break; }
         }
         let close = self.expect(token.RBRACE);
-        self.add_meta(ast.ENUM_DEF, name.value, flags, start, close.end, variants, 0, 0, 0)
+        self.add_meta(ast.ENUM_DEF, name.value, flags, start, close.end, directives, variants, 0, 0)
     }
 
     fn parse_const(inout self, directives: u64, flags: u64) -> u64 {
@@ -852,7 +852,7 @@ pub struct Parser {
         if self.eat(token.LINEAR) { flags += 4; }
         if self.at(token.FN) { self.parse_function(directives, flags, false) }
         else if self.at(token.STRUCT) { self.parse_struct(directives, flags) }
-        else if self.at(token.ENUM) { self.parse_enum(flags) }
+        else if self.at(token.ENUM) { self.parse_enum(directives, flags) }
         else if self.at(token.DROP) { self.parse_drop(false) }
         else if self.at(token.CONST) { self.parse_const(directives, flags) }
         else {


### PR DESCRIPTION
## Summary

- add preview-gated @non_exhaustive declaration support for public enums
- preserve defining-module exhaustiveness while requiring a reachable wildcard in importing modules
- carry the contract through canonical syntax, RIR, semantic imports, durable queries, diagnostics, specification, and frontend parity
- document the source-compatibility promise and its layout, ABI, and runtime caveats

## Validation

- scripts/rue fmt
- scripts/rue test non_exhaustive
- scripts/rue quick
- scripts/rue spec 6.3
- focused parser, AIR, compiler incremental, UI, CLI, and frontend differential tests
- scripts/rue premerge: 199 targets passed; tutorial snippets hit their existing 10-second child budget under aggregate host load and passed 1/1 in isolation
- scripts/rue test: 233 targets passed; same tutorial timeout only, with isolated target green

Fixes RUE-1104