### PR TITLE
RUE-1759: convert every i64 seek offset to its bit pattern, i64::MIN included

### DIFF
--- a/crates/rue-cli-tests/cases/fs_file_io.toml
+++ b/crates/rue-cli-tests/cases/fs_file_io.toml
@@ -1183,3 +1183,88 @@ fn main() -> i32 {
 """ }]
 stdout = "0\n"
 exit_code = 0
+
+# RUE-1759. `_i64_bits` reinterprets a seek offset as its raw u64 bit pattern
+# for `@syscall`. It spelled `|x| - 1` as `(0 - x) - 1`, and i64::MIN's
+# magnitude is not representable as an i64 -- so negating it trapped.
+#
+# `File.seek` is public and takes an arbitrary i64, so this was a LIVE trap on
+# a legitimate argument, not a latent one: the program died with `integer
+# overflow` (exit 101) before the syscall was ever issued. The in-source comment
+# claimed "no real seek uses it", which is not a property the signature enforces.
+#
+# Same shape and same fix as RUE-1709's `IntMap._key_bits`: spell it
+# `0 - (x + 1)`, which keeps every intermediate in range.
+[[case]]
+name = "fs_seek_i64_min_offset_errors_instead_of_trapping"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+description = "RUE-1759: seeking by i64::MIN reaches the kernel and comes back as an ordinary error, rather than trapping in the offset conversion."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let WR = std.result.Result(u64, FE);
+    let CR = std.result.Result((), FE);
+    let W = std.fs.Whence;
+
+    let mut path = std.strbuf.StrBuf.new();
+    path.push_str("seekmin.dat");
+    let mut f = match F.create(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 81; } };
+
+    // i64::MIN, built without a literal that would itself be out of range.
+    let m: i64 = 0 - 9223372036854775807;
+    let min: i64 = m - 1;
+
+    // Reaching either arm proves the conversion did not trap. The kernel
+    // rejects the offset, so Err is the expected arm.
+    match f.seek(min, W.Cur) {
+        WR.Ok(_p) => { @dbg(1); },
+        WR.Err(_e) => { @dbg(0); },
+    };
+    match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 82; } };
+    0
+}
+""" }]
+stdout = "0\n"
+exit_code = 0
+
+# The control that catches an off-by-one in the rewrite: ordinary negative
+# offsets must still land where they did. `-1` is the edge that matters, since
+# it is where `|x| - 1` is exactly 0.
+[[case]]
+name = "fs_seek_negative_offsets_still_land_correctly"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+description = "RUE-1759 control: the two's-complement rewrite keeps ordinary negative seeks exact, including the -1 edge where |x| - 1 is zero."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let WR = std.result.Result(u64, FE);
+    let CR = std.result.Result((), FE);
+    let Buf = std.arraybuf.ArrayBuf(u8);
+    let W = std.fs.Whence;
+
+    let mut path = std.strbuf.StrBuf.new();
+    path.push_str("negseek.dat");
+    let mut out = Buf.new();
+    let mut k: u64 = 0;
+    while k < 10 { out.push(48 + @intCast(k)); k = k + 1; }
+    let mut f = match F.create(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 81; } };
+    match f.write_all(borrow out) { CR.Ok(_u) => {}, CR.Err(_e) => { return 82; } };
+
+    let back3: i64 = 0 - 3;
+    match f.seek(back3, W.End) { WR.Ok(p) => { let pv: i64 = @intCast(p); @dbg(pv); }, WR.Err(_e) => { return 83; } };
+    let back1: i64 = 0 - 1;
+    match f.seek(back1, W.End) { WR.Ok(p) => { let pv: i64 = @intCast(p); @dbg(pv); }, WR.Err(_e) => { return 84; } };
+    match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 85; } };
+    0
+}
+""" }]
+stdout = "7\n9\n"
+exit_code = 0

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -266,6 +266,23 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
+    // RUE-1759: the seek-offset boundary cases reach the same `@byte_copy` gap
+    // as the rest of the std.fs group -- both build their path through StrBuf.
+    // What they assert (that i64::MIN converts instead of trapping, and that
+    // ordinary negative offsets still land exactly) is pinned by their
+    // exact-stdout assertions, not by the oracle model.
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_seek_i64_min_offset_errors_instead_of_trapping",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_seek_negative_offsets_still_land_correctly",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
     // RUE-1481: directory enumeration (`read_dir`/`walk`) reaches the same
     // `@byte_copy` gap as the rest of the std.fs group — every entry's path is
     // pooled through StrBuf, which copies bytes in bulk. Ungated in the case

--- a/std/fs.rue
+++ b/std/fs.rue
@@ -483,9 +483,15 @@ fn _at_symlink_nofollow() -> u64 {
 // possibly-negative argument (a seek offset) to `@syscall`, whose arguments are
 // u64. `@intCast` PANICS on a negative source (the value is not representable in
 // u64), so it cannot be used for the bit reinterpretation; the low path rebuilds
-// 2^64 + x from the magnitude with non-trapping unsigned arithmetic. (An offset
-// of i64::MIN is not supported — its negation overflows i64 — but no real seek
-// uses it.)
+// 2^64 + x from the magnitude with non-trapping unsigned arithmetic.
+//
+// EVERY i64 is supported, i64::MIN included. Spelling `|x| - 1` as `0 - x - 1`
+// would trap on i64::MIN, whose magnitude is not representable as an i64 --
+// `File.seek` is public and takes an arbitrary i64, so that was a live trap on
+// a legitimate argument, not a latent one (RUE-1759). `0 - (x + 1)` computes
+// the same value with every intermediate in range: for i64::MIN it is
+// `0 - (i64::MIN + 1)` == i64::MAX. This is the shape RUE-1709 established in
+// `IntMap._key_bits` for exactly the same reason.
 fn _i64_bits(x: i64) -> u64 {
     if x >= 0 {
         @intCast(x)
@@ -493,7 +499,7 @@ fn _i64_bits(x: i64) -> u64 {
         // Two's complement of a negative x: 2^64 - |x| == ~(|x| - 1) computed in
         // u64. `~` is a bitwise op (never traps), and |x| - 1 >= 0 for x < 0, so
         // it @intCasts cleanly. This avoids a 2^64-scale decimal literal.
-        let mag_minus_1: u64 = @intCast((0 - x) - 1);
+        let mag_minus_1: u64 = @intCast(0 - (x + 1));
         ~mag_minus_1
     }
 }


### PR DESCRIPTION
`_i64_bits` reinterprets a seek offset as its raw `u64` two's-complement pattern for `@syscall`. It spelled `|x| - 1` as `(0 - x) - 1` — and i64::MIN's magnitude is not representable as an i64, so negating it trapped.

## Live, not latent

The issue asked whether any caller could actually reach `_i64_bits` with i64::MIN. It can: `File.seek` is public and takes an arbitrary `i64`.

```
$ f.seek(i64::MIN, Whence.Cur)
error: integer overflow      (exit 101)
```

The program dies in the offset conversion, before the syscall is ever issued. The in-source comment claimed *"An offset of i64::MIN is not supported — its negation overflows i64 — but no real seek uses it."* That is not a property the signature enforces, and the comment is replaced.

## The fix

`0 - (x + 1)` computes the same value with every intermediate in range — for i64::MIN that is `0 - (i64::MIN + 1)` == i64::MAX.

This is the shape RUE-1709 established in `IntMap._key_bits` for exactly the same reason, which is where this issue came from: a sibling that cluster spotted but did not own.

After the fix the offset reaches the kernel and returns an ordinary `Err`, which is what a public API should do with an out-of-range seek.

## Correctness, not just absence of a trap

Not trapping is not the same as computing the right answer, so the bit pattern was re-checked on ordinary negatives:

| seek | expected | got |
| --- | --- | --- |
| `-3` from `End` on a 10-byte file | 7 | 7 |
| `-1` from `End` | 9 | 9 |

`-1` is the edge that matters: it is where `|x| - 1` is exactly 0, and an off-by-one in the rewrite would surface there rather than on `-3`.

Mutation-checked: the i64::MIN case fails with the old spelling restored; the negative-offset control passes either way, as a control should.

## Verification

`./test.sh` → `Tests finished: Pass 234. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0`, exit 0.

Corpus gate (`//:cli-staged-programs`): builds. `//:cli-timeout-policy-validation`: passes — the headroom raised in the previous round absorbs these two cases. `//crates/rue-oracle-diff/...`: passes with the two registrations below.

## Two model-gap registrations

Both new cases build their path through `StrBuf`, so they reach the same unmodeled `@byte_copy` intrinsic as the rest of the std.fs group. What they actually assert — that i64::MIN converts instead of trapping, and that ordinary negative offsets still land exactly — is pinned by their exact-stdout assertions, not by the oracle model.

Fixes RUE-1759

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJ13kDoVzYrpTZ7ry3rUaA)_