### PR TITLE
RUE-1774: centralize durable target semantics

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -3106,6 +3106,10 @@ fn durable_const_integer_semantics_use_the_shared_kernel() {
 #[test]
 fn durable_comptime_services_are_named_authority_operations() {
     let facade = include_str!("durable_comptime.rs");
+    let production_facade = facade
+        .split("#[cfg(test)]\nmod tests")
+        .next()
+        .expect("durable comptime production source");
     for required in [
         "DurableImportSite",
         "DurableComptimeSemanticAuthority",
@@ -3118,6 +3122,8 @@ fn durable_comptime_services_are_named_authority_operations() {
         "resolve_candidate",
         "resolve_identity",
         "resolve_const",
+        "resolve_target_intrinsic",
+        "resolve_target_enum_variant",
         "probe_comptime_call",
         "observe_dependency",
         "observe_anonymous_nominal",
@@ -3160,16 +3166,130 @@ fn durable_comptime_services_are_named_authority_operations() {
     assert_eq!(facade.matches("gate.application.is_none()").count(), 1);
 
     let database = include_str!("revisioned_query_database.rs");
+    let target_kernel = facade
+        .split("pub(crate) fn resolve_target_intrinsic_facts")
+        .nth(1)
+        .and_then(|source| {
+            source
+                .split("pub(crate) fn resolve_target_enum_variant_facts")
+                .next()
+        })
+        .expect("canonical target intrinsic kernel");
+    let target_variant_kernel = facade
+        .split("pub(crate) fn resolve_target_enum_variant_facts")
+        .nth(1)
+        .and_then(|source| {
+            source
+                .split("#[derive(Debug, Clone, PartialEq, Eq)]")
+                .next()
+        })
+        .expect("canonical target variant kernel");
+    for required in [
+        "target_arch",
+        "target_os",
+        "target_data_model",
+        "IntrinsicWrongArgCount",
+        "unknown target descriptor intrinsic",
+    ] {
+        assert!(
+            target_kernel.contains(required),
+            "target intrinsic policy must remain in the canonical kernel: {required}"
+        );
+    }
+    for required in [
+        "VARIANTS",
+        "unknown target descriptor enum",
+        "UnknownVariant",
+        "canonical_variant",
+    ] {
+        assert!(
+            target_variant_kernel.contains(required),
+            "target variant policy must remain in the canonical kernel: {required}"
+        );
+    }
+    assert_eq!(production_facade.matches("\"target_arch\"").count(), 1);
+    assert_eq!(production_facade.matches("\"target_os\"").count(), 1);
+    assert_eq!(
+        production_facade.matches("\"target_data_model\"").count(),
+        1
+    );
     let evaluator = database
         .split("impl SemanticConstEvaluator<'_, '_> {")
         .nth(1)
         .and_then(|source| source.split("impl SemanticNucleusTypeProvider<'_>").next())
         .expect("durable evaluator source");
+    let target_authority = database
+        .split("impl crate::durable_comptime::DurableComptimeSemanticAuthority")
+        .nth(1)
+        .and_then(|source| source.split("thread_local! {").next())
+        .expect("durable semantic authority source");
+    for required in [
+        "resolve_target_intrinsic_facts",
+        "resolve_target_enum_variant_facts",
+        "map_err(rue_air::SemanticProviderError::Failure)",
+    ] {
+        assert!(
+            target_authority.contains(required),
+            "target policy must remain in SemanticComptimeAuthority: {required}"
+        );
+    }
+    for forbidden in [
+        "SemanticConstEvaluator",
+        "SEMANTIC_COMPTIME",
+        "ComptimeEngine",
+        "Rir",
+        "ValidatedRir",
+        "program_rir",
+        "child_instructions",
+        "InstData",
+        "InstRef",
+        ".eval(",
+        "evaluate",
+        "eval_const_expr",
+        "SemanticComptimeCallDepthGuard",
+        "callback",
+    ] {
+        assert!(
+            !target_authority.contains(forbidden),
+            "semantic authority must not become an evaluator: {forbidden}"
+        );
+    }
+    for policy in [
+        "\"target_arch\"",
+        "\"target_os\"",
+        "\"target_data_model\"",
+        "IntrinsicWrongArgCount",
+        "UnknownVariant",
+        "unknown target descriptor intrinsic",
+        "unknown target descriptor enum",
+    ] {
+        assert!(
+            !target_authority.contains(policy),
+            "target policy must occur only in the canonical kernel: {policy}"
+        );
+    }
     assert!(evaluator.contains("DurableComptimeServices::new(&authority)"));
     assert!(evaluator.contains(".resolve_import(&site)"));
     assert!(evaluator.contains(".resolve_candidate("));
     assert!(evaluator.contains(".resolve_identity("));
     assert!(evaluator.contains(".resolve_const("));
+    assert!(evaluator.contains(".resolve_target_intrinsic("));
+    assert!(evaluator.contains(".resolve_target_enum_variant("));
+    for forbidden in [
+        "self.provider.configuration.target",
+        "rue_target::Arch",
+        "rue_target::Os",
+        "rue_target::DataModel",
+        "IntrinsicWrongArgCount",
+        "UnknownVariant",
+        "unknown target descriptor intrinsic",
+        "unknown target descriptor enum",
+    ] {
+        assert!(
+            !evaluator.contains(forbidden),
+            "durable evaluator regained target policy beside service calls: {forbidden}"
+        );
+    }
     assert!(evaluator.contains("self.effects.observe_dependency("));
     assert!(evaluator.contains("self.effects.merge_projection("));
     for forbidden in [

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -519,6 +519,23 @@ pub(crate) trait DurableComptimeSemanticAuthority {
         &self,
         site: &DurableImportSite,
     ) -> Result<DurableImportResolution, QueryAbort>;
+
+    /// Resolve a target intrinsic from semantic name/arity facts.  The
+    /// authority owns the configured target and the diagnostic policy; no RIR
+    /// instruction or argument callback crosses this boundary.
+    fn resolve_target_intrinsic(
+        &self,
+        name: &str,
+        argument_count: usize,
+    ) -> Result<TargetEnumValue, rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>>;
+
+    /// Resolve a target descriptor member through the canonical target
+    /// authority, preserving the durable evaluator's exact value shape.
+    fn resolve_target_enum_variant(
+        &self,
+        type_name: &str,
+        variant: &str,
+    ) -> Result<TargetEnumValue, rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>>;
 }
 
 pub(crate) trait DurableComptimeForeignCallAuthority {
@@ -583,6 +600,26 @@ impl<A: DurableComptimeSemanticAuthority + ?Sized> DurableComptimeServices<'_, A
     ) -> Result<DurableImportResolution, QueryAbort> {
         self.authority.resolve_import(site)
     }
+
+    pub(crate) fn resolve_target_intrinsic(
+        &self,
+        name: &str,
+        argument_count: usize,
+    ) -> Result<TargetEnumValue, rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>>
+    {
+        self.authority
+            .resolve_target_intrinsic(name, argument_count)
+    }
+
+    pub(crate) fn resolve_target_enum_variant(
+        &self,
+        type_name: &str,
+        variant: &str,
+    ) -> Result<TargetEnumValue, rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>>
+    {
+        self.authority
+            .resolve_target_enum_variant(type_name, variant)
+    }
 }
 
 impl<A: DurableComptimeForeignCallAuthority + ?Sized> DurableComptimeServices<'_, A> {
@@ -611,6 +648,93 @@ pub(crate) enum EvaluatedSemanticConst {
 pub(crate) struct TargetEnumValue {
     pub(crate) type_name: &'static str,
     pub(crate) variant: &'static str,
+}
+
+/// The canonical pure target-descriptor kernel used by durable semantic
+/// authorities.  It receives only decomposed target facts, so tests and
+/// future query adapters can cover data models not currently exposed by a
+/// concrete compiler target without copying the mapping policy.
+pub(crate) fn resolve_target_intrinsic_facts(
+    name: &str,
+    argument_count: usize,
+    arch: rue_target::Arch,
+    os: rue_target::Os,
+    data_model: rue_target::DataModel,
+) -> Result<TargetEnumValue, SemanticNucleusFailure> {
+    if argument_count != 0 {
+        return Err(SemanticNucleusFailure::Diagnostic(
+            rue_error::ErrorKind::IntrinsicWrongArgCount {
+                name: name.to_owned(),
+                expected: 0,
+                found: argument_count,
+            },
+        ));
+    }
+    let (type_name, variant) = match name {
+        "target_arch" => (
+            "Arch",
+            match arch {
+                rue_target::Arch::X86_64 => "X86_64",
+                rue_target::Arch::Aarch64 => "Aarch64",
+            },
+        ),
+        "target_os" => (
+            "Os",
+            match os {
+                rue_target::Os::Linux => "Linux",
+                rue_target::Os::Macos => "Macos",
+            },
+        ),
+        "target_data_model" => (
+            "DataModel",
+            match data_model {
+                rue_target::DataModel::Ilp32 => "Ilp32",
+                rue_target::DataModel::Lp64 => "Lp64",
+                rue_target::DataModel::Llp64 => "Llp64",
+            },
+        ),
+        _ => {
+            return Err(SemanticNucleusFailure::Resolution(Arc::from(
+                "unknown target descriptor intrinsic",
+            )));
+        }
+    };
+    Ok(TargetEnumValue { type_name, variant })
+}
+
+pub(crate) fn resolve_target_enum_variant_facts(
+    type_name: &str,
+    variant: &str,
+) -> Result<TargetEnumValue, SemanticNucleusFailure> {
+    const VARIANTS: &[(&str, &[&str])] = &[
+        ("Arch", &["X86_64", "Aarch64"]),
+        ("Os", &["Linux", "Macos"]),
+        ("DataModel", &["Ilp32", "Lp64", "Llp64"]),
+    ];
+    let Some((canonical_type, variants)) = VARIANTS
+        .iter()
+        .find(|(candidate, _)| *candidate == type_name)
+    else {
+        return Err(SemanticNucleusFailure::Resolution(Arc::from(
+            "unknown target descriptor enum",
+        )));
+    };
+    let Some(canonical_variant) = variants
+        .iter()
+        .copied()
+        .find(|candidate| *candidate == variant)
+    else {
+        return Err(SemanticNucleusFailure::Diagnostic(
+            rue_error::ErrorKind::UnknownVariant {
+                enum_name: (*canonical_type).to_owned(),
+                variant_name: variant.to_owned(),
+            },
+        ));
+    };
+    Ok(TargetEnumValue {
+        type_name: canonical_type,
+        variant: canonical_variant,
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -851,6 +975,101 @@ mod tests {
             EvaluatedSemanticConst::integer_typed(-12, Some(DurableComptimeType(ty.clone())));
         assert_eq!(original.clone(), original);
         assert_eq!(original.as_integer_type(), Some(DurableComptimeType(ty)));
+    }
+
+    #[test]
+    fn target_kernel_covers_all_facts_and_error_channels() {
+        for arch in [rue_target::Arch::X86_64, rue_target::Arch::Aarch64] {
+            for os in [rue_target::Os::Linux, rue_target::Os::Macos] {
+                for data_model in [
+                    rue_target::DataModel::Ilp32,
+                    rue_target::DataModel::Lp64,
+                    rue_target::DataModel::Llp64,
+                ] {
+                    assert_eq!(
+                        resolve_target_intrinsic_facts("target_arch", 0, arch, os, data_model,)
+                            .unwrap()
+                            .variant,
+                        match arch {
+                            rue_target::Arch::X86_64 => "X86_64",
+                            rue_target::Arch::Aarch64 => "Aarch64",
+                        }
+                    );
+                    assert_eq!(
+                        resolve_target_intrinsic_facts("target_os", 0, arch, os, data_model,)
+                            .unwrap()
+                            .variant,
+                        match os {
+                            rue_target::Os::Linux => "Linux",
+                            rue_target::Os::Macos => "Macos",
+                        }
+                    );
+                    assert_eq!(
+                        resolve_target_intrinsic_facts(
+                            "target_data_model",
+                            0,
+                            arch,
+                            os,
+                            data_model,
+                        )
+                        .unwrap()
+                        .variant,
+                        match data_model {
+                            rue_target::DataModel::Ilp32 => "Ilp32",
+                            rue_target::DataModel::Lp64 => "Lp64",
+                            rue_target::DataModel::Llp64 => "Llp64",
+                        }
+                    );
+                }
+            }
+        }
+        for (type_name, variants) in [
+            ("Arch", ["X86_64", "Aarch64"].as_slice()),
+            ("Os", ["Linux", "Macos"].as_slice()),
+            ("DataModel", ["Ilp32", "Lp64", "Llp64"].as_slice()),
+        ] {
+            for variant in variants {
+                assert_eq!(
+                    resolve_target_enum_variant_facts(type_name, variant).unwrap(),
+                    TargetEnumValue { type_name, variant }
+                );
+            }
+        }
+        assert!(matches!(
+            resolve_target_intrinsic_facts(
+                "target_os",
+                1,
+                rue_target::Arch::X86_64,
+                rue_target::Os::Linux,
+                rue_target::DataModel::Lp64,
+            ),
+            Err(SemanticNucleusFailure::Diagnostic(
+                rue_error::ErrorKind::IntrinsicWrongArgCount { found: 1, .. }
+            ))
+        ));
+        assert!(matches!(
+            resolve_target_intrinsic_facts(
+                "other",
+                0,
+                rue_target::Arch::X86_64,
+                rue_target::Os::Linux,
+                rue_target::DataModel::Lp64,
+            ),
+            Err(SemanticNucleusFailure::Resolution(message))
+                if message.as_ref() == "unknown target descriptor intrinsic"
+        ));
+        assert!(matches!(
+            resolve_target_enum_variant_facts("Target", "X86_64"),
+            Err(SemanticNucleusFailure::Resolution(message))
+                if message.as_ref() == "unknown target descriptor enum"
+        ));
+        assert!(matches!(
+            resolve_target_enum_variant_facts("Arch", "Linux"),
+            Err(SemanticNucleusFailure::Diagnostic(rue_error::ErrorKind::UnknownVariant {
+                enum_name,
+                variant_name,
+            })) if enum_name == "Arch" && variant_name == "Linux"
+        ));
     }
 }
 

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -121,7 +121,7 @@ use crate::{
 use crate::canonical_lower::CandidateModuleRirOutput;
 use crate::parsed_modules::{ParsedModule, ParsedModulesWork, ParsedProgram};
 
-use crate::durable_comptime::{EvaluatedSemanticConst, TargetEnumValue, TypedSemanticConst};
+use crate::durable_comptime::{EvaluatedSemanticConst, TypedSemanticConst};
 use crate::retained_charge::RetainedCharge;
 use crate::session::{AttemptId, QueryStructuralWork};
 use crate::typed_query_store::{
@@ -7150,6 +7150,42 @@ impl crate::durable_comptime::DurableComptimeSemanticAuthority
             }
         })
     }
+
+    fn resolve_target_intrinsic(
+        &self,
+        name: &str,
+        argument_count: usize,
+    ) -> Result<
+        crate::durable_comptime::TargetEnumValue,
+        rue_air::SemanticProviderError<
+            QueryAbort,
+            crate::semantic_query_nucleus::SemanticNucleusFailure,
+        >,
+    > {
+        crate::durable_comptime::resolve_target_intrinsic_facts(
+            name,
+            argument_count,
+            self.provider.configuration.target.arch(),
+            self.provider.configuration.target.os(),
+            self.provider.configuration.target.data_model(),
+        )
+        .map_err(rue_air::SemanticProviderError::Failure)
+    }
+
+    fn resolve_target_enum_variant(
+        &self,
+        type_name: &str,
+        variant: &str,
+    ) -> Result<
+        crate::durable_comptime::TargetEnumValue,
+        rue_air::SemanticProviderError<
+            QueryAbort,
+            crate::semantic_query_nucleus::SemanticNucleusFailure,
+        >,
+    > {
+        crate::durable_comptime::resolve_target_enum_variant_facts(type_name, variant)
+            .map_err(rue_air::SemanticProviderError::Failure)
+    }
 }
 
 thread_local! {
@@ -7259,25 +7295,19 @@ impl SemanticConstEvaluator<'_, '_> {
         &self,
         name: lasso::Spur,
         args: &rue_rir::RirIntrinsicArgsRange,
-        type_name: &'static str,
-        variant: &'static str,
     ) -> Result<EvaluatedSemanticConst, EvaluateSemanticConstError> {
-        let found = self.rir.intrinsic_args(args).len();
-        if found != 0 {
-            return Err(Self::domain_failure(
-                crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
-                    rue_error::ErrorKind::IntrinsicWrongArgCount {
-                        name: self.symbol(&name).to_string(),
-                        expected: 0,
-                        found,
-                    },
-                ),
-            ));
-        }
-        Ok(EvaluatedSemanticConst::TargetEnum(TargetEnumValue {
-            type_name,
-            variant,
-        }))
+        let authority = SemanticComptimeAuthority {
+            provider: &*self.provider,
+            imports: self.imports,
+        };
+        let services = crate::durable_comptime::DurableComptimeServices::new(&authority);
+        services
+            .resolve_target_intrinsic(
+                self.symbol(&name).as_ref(),
+                self.rir.intrinsic_args(args).len(),
+            )
+            .map(|value| EvaluatedSemanticConst::TargetEnum(value))
+            .map_err(Self::provider_error)
     }
 
     fn target_enum_variant(
@@ -7285,42 +7315,15 @@ impl SemanticConstEvaluator<'_, '_> {
         type_name: &str,
         variant: &str,
     ) -> Result<EvaluatedSemanticConst, EvaluateSemanticConstError> {
-        let canonical_type = match type_name {
-            "Arch" => "Arch",
-            "Os" => "Os",
-            "DataModel" => "DataModel",
-            _ => return Self::failure("unknown target descriptor enum"),
+        let authority = SemanticComptimeAuthority {
+            provider: &*self.provider,
+            imports: self.imports,
         };
-        let valid = match canonical_type {
-            "Arch" => matches!(variant, "X86_64" | "Aarch64"),
-            "Os" => matches!(variant, "Linux" | "Macos"),
-            "DataModel" => matches!(variant, "Ilp32" | "Lp64" | "Llp64"),
-            _ => unreachable!(),
-        };
-        if !valid {
-            return Err(Self::domain_failure(
-                crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
-                    rue_error::ErrorKind::UnknownVariant {
-                        enum_name: canonical_type.to_owned(),
-                        variant_name: variant.to_owned(),
-                    },
-                ),
-            ));
-        }
-        let variant = match variant {
-            "X86_64" => "X86_64",
-            "Aarch64" => "Aarch64",
-            "Linux" => "Linux",
-            "Macos" => "Macos",
-            "Ilp32" => "Ilp32",
-            "Lp64" => "Lp64",
-            "Llp64" => "Llp64",
-            _ => unreachable!(),
-        };
-        Ok(EvaluatedSemanticConst::TargetEnum(TargetEnumValue {
-            type_name: canonical_type,
-            variant,
-        }))
+        let services = crate::durable_comptime::DurableComptimeServices::new(&authority);
+        services
+            .resolve_target_enum_variant(type_name, variant)
+            .map(|value| EvaluatedSemanticConst::TargetEnum(value))
+            .map_err(Self::provider_error)
     }
 
     fn bool_value(
@@ -8574,26 +8577,13 @@ impl SemanticConstEvaluator<'_, '_> {
                 self.eval_import(expression)
             }
             E::Intrinsic { name, args } if self.symbol(name).as_ref() == "target_arch" => {
-                let variant = match self.declaration.configuration.target.arch() {
-                    rue_target::Arch::X86_64 => "X86_64",
-                    rue_target::Arch::Aarch64 => "Aarch64",
-                };
-                self.target_intrinsic(*name, args, "Arch", variant)
+                self.target_intrinsic(*name, args)
             }
             E::Intrinsic { name, args } if self.symbol(name).as_ref() == "target_os" => {
-                let variant = match self.declaration.configuration.target.os() {
-                    rue_target::Os::Linux => "Linux",
-                    rue_target::Os::Macos => "Macos",
-                };
-                self.target_intrinsic(*name, args, "Os", variant)
+                self.target_intrinsic(*name, args)
             }
             E::Intrinsic { name, args } if self.symbol(name).as_ref() == "target_data_model" => {
-                let variant = match self.declaration.configuration.target.data_model() {
-                    rue_target::DataModel::Ilp32 => "Ilp32",
-                    rue_target::DataModel::Lp64 => "Lp64",
-                    rue_target::DataModel::Llp64 => "Llp64",
-                };
-                self.target_intrinsic(*name, args, "DataModel", variant)
+                self.target_intrinsic(*name, args)
             }
             E::TypeIntrinsic { name, type_arg }
                 if matches!(


### PR DESCRIPTION
Relates to RUE-1774

Moves declaration-time target semantics behind one canonical durable authority ahead of the evaluator root cutover.

- centralizes target intrinsic selection, arity failures, descriptor enum validation, and canonical target values
- routes the existing durable evaluator through the authority without changing either production root
- exhaustively covers architecture, OS, data-model, and failure mappings through the production kernel
- guards the authority against RIR walking/evaluator recursion and prevents target policy from returning to the legacy evaluator

This is a staged architectural slice. RUE-1774 remains open for the remaining semantic authorities, ticket/program seam corrections, durable host integration, coordinated root cutover, and duplicate interpreter deletion.

Validation:
- scripts/rue premerge (200/200)
- scripts/rue unit compiler durable_ (42/42)
- scripts/rue cli target (17/17)
- scripts/rue quick (31/31 suites)