### PR TITLE
RUE-1767: name the depth limit when a comptime block overruns it

### DIFF
--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -4562,15 +4562,33 @@ where
         let Some(value_arguments) = value_arguments else {
             return Some(Ok(None));
         };
-        // A self call reached this point only because the caller already bound
-        // every parameter to a constant, so a durable failure is a real
-        // evaluation failure and must surface rather than be swallowed into
-        // "not compile-time known" — that swallowing is what let direction 2 of
-        // RUE-1700 compile. When the durable evaluator cannot represent the
-        // callable at all it reports `NotReduced`, and the request-local
-        // evaluator remains the fallback for the value self call so no shape
-        // that reduced before stops reducing.
-        let report_diagnostic = required_type_reduction || self_call;
+        // Every call reaching this point already bound every parameter to a
+        // constant, so a durable `Diagnostic` is a real evaluation failure and
+        // must surface rather than be swallowed into "not compile-time known"
+        // — that swallowing is what let direction 2 of RUE-1700 compile.
+        //
+        // RUE-1700 narrowed the swallow to non-self, non-type calls; RUE-1767
+        // removes what was left of it. The remnant was why a `comptime { }`
+        // block that overran the comptime nesting depth reported E1200
+        // "expression contains values that cannot be known at compile time"
+        // — pointing at 4.14:4, a runtime-value problem — instead of naming
+        // the depth limit as 4.14:18 requires. The depth guard fires and
+        // produces the right diagnostic; only this arm discarded it, because
+        // `count(49)` inside a block is neither a self call nor a `-> type`
+        // call. The `const` position, which routes around this host, reported
+        // the depth message correctly all along.
+        //
+        // Suppressing a diagnostic here can only ever downgrade a specific
+        // message to a vaguer one: the call is already fully bound, so there
+        // is no runtime reading of it left to preserve. Measured on the three
+        // comptime positions, the depth at which each accepts or rejects is
+        // unchanged — only the message the block position prints improves.
+        //
+        // When the durable evaluator cannot represent the callable at all it
+        // reports `NotReduced`, which is a representation gap rather than a
+        // diagnosis; the request-local evaluator remains the fallback for the
+        // value self call there, so no shape that reduced before stops
+        // reducing.
         let reduced =
             match self
                 .source
@@ -4579,13 +4597,12 @@ where
                 DurableComptimeCallOutcome::Reduced(reduced) => reduced,
                 DurableComptimeCallOutcome::NotReduced if value_self_call => return None,
                 DurableComptimeCallOutcome::NotReduced => return Some(Ok(None)),
-                DurableComptimeCallOutcome::Diagnostic(diagnostic) if report_diagnostic => {
+                DurableComptimeCallOutcome::Diagnostic(diagnostic) => {
                     return Some(Err(CompileError::new(
                         diagnostic.kind,
                         diagnostic.span.unwrap_or(span),
                     )));
                 }
-                DurableComptimeCallOutcome::Diagnostic(_) => return Some(Ok(None)),
             };
         let producer = (|| {
             Some(FunctionInstanceKey::Specialization {

--- a/crates/rue-cli-tests/cases/comptime_const_position_parity.toml
+++ b/crates/rue-cli-tests/cases/comptime_const_position_parity.toml
@@ -64,3 +64,50 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 compile_stderr_contains = ["E1200", "exceeded the maximum nesting depth"]
+
+# RUE-1767: a `comptime { }` block that overruns the depth budget must name the
+# depth limit, as 4.14:18 requires. It used to report the generic E1200 reason
+# "expression contains values that cannot be known at compile time", which
+# points at 4.14:4 -- a runtime-value problem -- and tells the programmer
+# nothing about the real cause.
+#
+# The two positions above route around the body host; a call written directly
+# in a block goes through `reduce_external_comptime_call`, whose diagnostic arm
+# discarded the depth failure for any call that was neither a self call nor a
+# `-> type` call. The guard always fired and always produced the right message;
+# only the arm that received it threw it away.
+[[case]]
+name = "block_position_overrun_names_the_depth_limit"
+files = [{ path = "main.rue", source = """
+fn count(comptime n: i64) -> i64 {
+    if n <= 0 { 0 } else { 1 + count(n - 1) }
+}
+
+fn main() -> i32 {
+    let x: i64 = comptime { count(4000) };
+    @dbg(x);
+    0
+}
+""" }]
+compile_fail = true
+compile_stderr_contains = ["E1200", "exceeded the maximum nesting depth"]
+
+# The companion control: the fix changes which message an overrun prints, not
+# where the budget sits. A depth the block position accepted before must still
+# compile and still produce the right value -- otherwise "better diagnostic"
+# would have quietly become "stricter compiler".
+[[case]]
+name = "block_position_accepts_a_depth_within_budget"
+files = [{ path = "main.rue", source = """
+fn count(comptime n: i64) -> i64 {
+    if n <= 0 { 0 } else { 1 + count(n - 1) }
+}
+
+fn main() -> i32 {
+    let x: i64 = comptime { count(40) };
+    @dbg(x);
+    0
+}
+""" }]
+stdout = "40\n"
+exit_code = 0


### PR DESCRIPTION
A `comptime { }` block whose call exceeded the comptime nesting depth reported:

```
error: [E1200]: comptime evaluation failed: expression contains values that cannot be known at compile time
 --> main.rue:6:18
  |
6 |     let x: i64 = comptime { count(49) };
```

That reason points at 4.14:4 — a runtime-value problem — when the actual cause is the depth limit, which 4.14:18 requires be diagnosed as such. The `const` position named the depth correctly all along.

## The guard was never the problem

The obvious reading is that the block position has a different (or broken) depth guard. It does not, and this is the part worth recording, because it is where I was wrong first.

I instrumented the guard I assumed was responsible — `enter_prepared_call`'s `MAX_COMPTIME_CALL_DEPTH` check in `rue-air/src/sema/comptime.rs`, the one that calls `host.depth_exceeded`. **It never fires**, in any of the three comptime positions. The live guard is `SemanticComptimeCallDepthGuard` in the query database, and instrumenting *that* showed it firing identically in both positions:

```
=== CONST n=49 ===
RUE1767-PROBE: semantic depth guard fired at 48 for 'count'
error: [E1200]: ... exceeded the maximum nesting depth (48) ...
=== BLOCK n=49 ===
RUE1767-PROBE: semantic depth guard fired at 48 for 'count'
error: [E1200]: ... expression contains values that cannot be known at compile time
```

Same guard, same depth, same correct message produced — and then discarded on one of the two paths.

## Where it was discarded

`reduce_external_comptime_call` in `provider_body_host.rs`:

```rust
let report_diagnostic = required_type_reduction || self_call;
...
DurableComptimeCallOutcome::Diagnostic(diagnostic) if report_diagnostic => { /* report */ }
DurableComptimeCallOutcome::Diagnostic(_) => return Some(Ok(None)),   // <-- here
```

`count(49)` written inside a block is neither a self call nor a `-> type` call, so the diagnostic was dropped and `Ok(None)` — "not compile-time known" — took its place. Traced by probe to `Memoized(RuntimeDependent)`, which is what the generic reason is printed from.

RUE-1700 had already narrowed this swallow for self calls, with a comment saying a durable failure there "must surface rather than be swallowed". This removes what was left of it: the call is fully bound by the time it reaches this point, so suppressing the diagnostic can only downgrade a specific message to a vaguer one — there is no runtime reading of it left to preserve. `NotReduced`, the genuine "cannot represent this callable" signal, is untouched, so the value-self-call fallback still works and no shape that reduced before stops reducing.

## Boundaries measured before and after

The risk in this change is that "better diagnostic" quietly becomes "stricter compiler", so every position was measured on both binaries:

| position | before | after |
| --- | --- | --- |
| `let x = comptime { count(N) }` | accepts 48, rejects 49 *(generic reason)* | accepts 48, rejects 49 *(names the depth)* |
| `const X = count(N)` | accepts 47, rejects 48 | accepts 47, rejects 48 |
| `let x = count(N)` (body) | accepts 63, rejects 64 | accepts 63, rejects 64 |

The body row is the one that matters: byte-identical, including the message. Nothing that compiled stops compiling.

I also checked shapes where a suppressed diagnostic might have been load-bearing — a deep call in a never-taken branch, in an uncalled function, an ordinary runtime call, and a mixed shallow comptime/body program. The never-taken branch errors, but it errored before this change too: a `comptime { }` block that cannot be evaluated is always an error, and only the reason differs.

## Verification

Two CLI cases in `comptime_const_position_parity.toml`, beside the existing const/body pair: the overrun names the depth limit, and a within-budget block still compiles to the same value.

Mutation-checked — restoring the old arm fails the overrun case with exactly the old generic reason, while the within-budget control passes either way, as a control should.

`./test.sh` → `Tests finished: Pass 234. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0`, exit 0.

Corpus gate (`//:cli-staged-programs`): builds. `//crates/rue-oracle-diff/...`: `Pass 6. Fail 0` — no new model-gap registrations needed. `//:cli-timeout-policy-validation`: `Pass 1. Fail 0`.

## What this does not close

RUE-1767's other half — the depth-cap parity, where `const` stops at 47 and a body at 63, both under 4.14:18's "at least 64" floor — is untouched. Closing it means either cutting the durable evaluator's per-level stack cost, raising the worker stack, or amending the floor; that is a language ruling, not a code change, so it stays open.

One correction to the issue's table while measuring: it records the `const` position as rejecting at 49. It rejects at 48 (accepts 47). The block position is the one that rejects at 49. The one-level gap between the two is part of the parity half.

Part of RUE-1767

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJ13kDoVzYrpTZ7ry3rUaA)_