### PR TITLE
RUE-1774: centralize durable call admission

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -3117,9 +3117,14 @@ fn durable_comptime_services_are_named_authority_operations() {
         "DurableComptimeEffects",
         "DurableComptimeCallLifecycle",
         "DurableComptimeCallEdge",
+        "accessing_source",
         "DurableComptimeCallTicket",
         "DurableComptimeLifecycleError",
         "DurableComptimeApplicationPolicy",
+        "DurableComptimeCallableAdmission",
+        "DurableComptimeCallableAdmissionStart",
+        "begin_comptime_call_admission",
+        "finish_comptime_call_admission",
         "resolve_candidate",
         "resolve_identity",
         "resolve_const",
@@ -3179,11 +3184,7 @@ fn durable_comptime_services_are_named_authority_operations() {
     let edge_fields = facade
         .split("pub(crate) struct DurableComptimeCallEdge {")
         .nth(1)
-        .and_then(|source| {
-            source
-                .split("}\n\n/// Non-clone lifecycle capability")
-                .next()
-        })
+        .and_then(|source| source.split("}\n\nimpl DurableComptimeCallEdge").next())
         .expect("durable call edge block");
     assert!(!edge_fields.contains("pub(crate)"));
     assert!(!edge_fields.contains("context:"));
@@ -3227,6 +3228,30 @@ fn durable_comptime_services_are_named_authority_operations() {
         );
     }
     assert!(facade.contains("ticket_from_admitted_edge"));
+    let callable_authority = facade
+        .split("pub(crate) struct DurableComptimeCallableAdmission {")
+        .nth(1)
+        .and_then(|source| source.split("}\n\n/// Canonical semantic services").next())
+        .expect("durable callable admission projection");
+    for forbidden in ["InstData", "InstRef", "Rir", "callback", "evaluate"] {
+        assert!(
+            !callable_authority.contains(forbidden),
+            "callable admission projection leaked evaluator authority: {forbidden}"
+        );
+    }
+    let callable_start = facade
+        .split("pub(crate) struct DurableComptimeCallableAdmissionStart {")
+        .nth(1)
+        .and_then(|source| source.split("}\n\n/// The immutable").next())
+        .expect("durable callable admission start projection");
+    assert!(!callable_start.contains("Clone"));
+    assert!(facade.contains(
+        "#[derive(Debug, PartialEq, Eq)]\npub(crate) struct DurableComptimeCallableAdmissionStart"
+    ));
+    assert!(!facade.contains(
+        "#[derive(Debug, Clone, PartialEq, Eq)]\npub(crate) struct DurableComptimeCallableAdmissionStart"
+    ));
+    assert!(!facade.contains("impl Clone for DurableComptimeCallableAdmissionStart"));
     assert_eq!(
         production_facade
             .matches("gate.application.is_none()")
@@ -3346,12 +3371,74 @@ fn durable_comptime_services_are_named_authority_operations() {
         );
     }
     assert!(evaluator.contains("DurableComptimeServices::new(&authority)"));
+    let named_call = evaluator
+        .split("fn eval_named_call(")
+        .nth(1)
+        .and_then(|source| source.split("fn eval_type_literal(").next())
+        .expect("durable named-call evaluator");
+    assert!(
+        named_call.contains("begin_comptime_call_admission("),
+        "durable named calls must consume the canonical admission projection"
+    );
+    let begin = named_call
+        .find("begin_comptime_call_admission(")
+        .expect("named-call begin admission");
+    let observed = named_call
+        .find("observe_dependency(admission_start.dependency.clone())")
+        .expect("named-call dependency observation");
+    let finish = named_call
+        .find("finish_comptime_call_admission(admission_start")
+        .expect("named-call finish admission");
+    assert!(begin < observed && observed < finish);
+    for forbidden in [
+        ".provider.candidate(",
+        ".provider.identity(",
+        ".provider.signature(",
+        "DeclarationShellQueryKey",
+        "query_registered(",
+        "DeclarationSignatureProjection::Callable",
+        "ConstExprNotSupported",
+        "BorrowKeywordMissing",
+        "InoutKeywordMissing",
+        "UnexpectedCallArgumentMode",
+    ] {
+        assert!(
+            !named_call.contains(forbidden),
+            "durable named-call evaluator regained admission policy: {forbidden}"
+        );
+    }
+    assert!(
+        named_call.contains("let call_ordinal = self.next_call;"),
+        "durable call ordinals must be allocated before admission"
+    );
     assert!(evaluator.contains(".resolve_import(&site)"));
     assert!(evaluator.contains(".resolve_candidate("));
     assert!(evaluator.contains(".resolve_identity("));
     assert!(evaluator.contains(".resolve_const("));
     assert!(evaluator.contains(".resolve_target_intrinsic("));
     assert!(evaluator.contains(".resolve_target_enum_variant("));
+    let admission_authority = target_authority
+        .split("fn begin_comptime_call_admission(")
+        .nth(1)
+        .and_then(|source| {
+            source
+                .split("\n    fn finish_comptime_call_admission(")
+                .next()
+        })
+        .expect("call admission authority source");
+    assert!(admission_authority.contains("candidate_from("));
+    assert!(admission_authority.contains("accessing_source"));
+    assert!(admission_authority.contains("source: accessing_source.clone()"));
+    assert!(
+        !admission_authority.contains("provider.dependency_source"),
+        "call admission must not use root-fixed provider source"
+    );
+    let admission_finish_authority = target_authority
+        .split("fn finish_comptime_call_admission(")
+        .nth(1)
+        .and_then(|source| source.split("\n    fn resolve_candidate(").next())
+        .expect("call admission completion authority source");
+    assert!(!admission_finish_authority.contains("provider.dependency_source"));
     for forbidden in [
         "self.provider.configuration.target",
         "rue_target::Arch",

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -369,6 +369,18 @@ pub(crate) struct DurableComptimeCallEdge {
     consumed: bool,
 }
 
+impl DurableComptimeCallEdge {
+    /// The exact declaration source captured when this edge was issued.
+    ///
+    /// Future hosts use this opaque identity for lookup visibility and
+    /// dependency attribution; they do not reconstruct it from call
+    /// bindings or ambient provider state.
+    #[allow(dead_code)] // consumed by the root-integrated durable host
+    pub(crate) fn accessing_source(&self) -> &crate::StableDefinitionKey {
+        &self.parent_producer
+    }
+}
+
 /// Non-clone lifecycle capability issued only after an edge is admitted.
 /// Its fields remain private so a host cannot reconstruct a ticket from an
 /// unordered binding map or use a ticket for another call.
@@ -756,6 +768,34 @@ pub(crate) enum DurableImportResolution {
     Failure(DeclarationImportFailure),
 }
 
+/// The identity and dependency facts established before signature admission.
+///
+/// Callers observe `dependency` immediately after this phase succeeds, before
+/// any signature, shell, arity, or mode work can fail.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct DurableComptimeCallableAdmissionStart {
+    pub(crate) candidate: DeclarationCandidateKey,
+    pub(crate) identity: crate::semantic_query_nucleus::DeclarationIdentityProjection,
+    pub(crate) name: Arc<str>,
+    pub(crate) dependency: SemanticDeclarationDependency,
+}
+
+/// The immutable, ordered facts admitted for one durable comptime callable.
+///
+/// The projection contains both the keyed signature and the declaration-shell
+/// headers because argument binding must preserve their canonical order and
+/// names. It deliberately carries no RIR handles or evaluation callback; the
+/// caller remains responsible for evaluating argument expressions and fitting
+/// their resulting values to these descriptors.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DurableComptimeCallableAdmission {
+    pub(crate) candidate: DeclarationCandidateKey,
+    pub(crate) identity: crate::semantic_query_nucleus::DeclarationIdentityProjection,
+    pub(crate) parameters: Arc<[crate::durable_semantics::DurableSemanticParameter]>,
+    pub(crate) result: DurableType,
+    pub(crate) shell_parameters: Arc<[crate::declaration_candidate::DeclarationParameterHeader]>,
+}
+
 /// Canonical semantic services needed by durable comptime entry points.
 ///
 /// Implementations live beside the query authorities. This facade is an
@@ -763,6 +803,25 @@ pub(crate) enum DurableImportResolution {
 /// reference, instruction data, or callback capable of evaluating a child.
 pub(crate) trait DurableComptimeSemanticAuthority {
     fn check_canceled(&self) -> Result<(), QueryAbort>;
+
+    fn begin_comptime_call_admission(
+        &self,
+        accessing_source: &crate::StableDefinitionKey,
+        module: &ModuleId,
+        name: &str,
+    ) -> Result<
+        DurableComptimeCallableAdmissionStart,
+        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+    >;
+
+    fn finish_comptime_call_admission(
+        &self,
+        start: DurableComptimeCallableAdmissionStart,
+        argument_modes: &[crate::durable_semantics::DurableParameterMode],
+    ) -> Result<
+        DurableComptimeCallableAdmission,
+        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+    >;
 
     /// Resolve a declaration through the canonical name/shell authority.
     /// Visibility and shell disagreement diagnostics are produced by the
@@ -838,6 +897,31 @@ impl<'a, A: ?Sized> DurableComptimeServices<'a, A> {
 impl<A: DurableComptimeSemanticAuthority + ?Sized> DurableComptimeServices<'_, A> {
     pub(crate) fn check_canceled(&self) -> Result<(), QueryAbort> {
         self.authority.check_canceled()
+    }
+
+    pub(crate) fn begin_comptime_call_admission(
+        &self,
+        accessing_source: &crate::StableDefinitionKey,
+        module: &ModuleId,
+        name: &str,
+    ) -> Result<
+        DurableComptimeCallableAdmissionStart,
+        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+    > {
+        self.authority
+            .begin_comptime_call_admission(accessing_source, module, name)
+    }
+
+    pub(crate) fn finish_comptime_call_admission(
+        &self,
+        start: DurableComptimeCallableAdmissionStart,
+        argument_modes: &[crate::durable_semantics::DurableParameterMode],
+    ) -> Result<
+        DurableComptimeCallableAdmission,
+        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+    > {
+        self.authority
+            .finish_comptime_call_admission(start, argument_modes)
     }
 
     pub(crate) fn resolve_candidate(
@@ -1663,6 +1747,7 @@ mod effect_lifecycle_tests {
         // the child query only from the owned program payload.
         let mut lifecycle = lifecycle();
         let edge = lifecycle.prepare_expression_edge(42).unwrap();
+        assert_eq!(edge.accessing_source(), &definition("parent"));
         let mut ticket = lifecycle
             .ticket_from_admitted_edge(edge, &admitted)
             .unwrap();
@@ -1811,6 +1896,7 @@ mod effect_lifecycle_tests {
         let mut outer = expression_outer.prepare(context(20)).unwrap();
         expression_outer.enter(&outer).unwrap();
         let mut inner_edge = expression_outer.prepare_structured_edge().unwrap();
+        assert_eq!(inner_edge.accessing_source(), &definition("child"));
         expression_outer
             .merge_ready_projection(&mut inner_edge, &ready_projection(21))
             .unwrap();
@@ -1838,6 +1924,7 @@ mod effect_lifecycle_tests {
         let mut outer = structured_outer.prepare(structured_context()).unwrap();
         structured_outer.enter(&outer).unwrap();
         let mut inner_edge = structured_outer.prepare_expression_edge(22).unwrap();
+        assert_eq!(inner_edge.accessing_source(), &definition("child"));
         structured_outer
             .merge_ready_projection(&mut inner_edge, &ready_projection(22))
             .unwrap();

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -7081,6 +7081,145 @@ impl crate::durable_comptime::DurableComptimeSemanticAuthority
         self.provider.context.check_canceled()
     }
 
+    fn begin_comptime_call_admission(
+        &self,
+        accessing_source: &crate::StableDefinitionKey,
+        module: &ModuleId,
+        name: &str,
+    ) -> Result<
+        crate::durable_comptime::DurableComptimeCallableAdmissionStart,
+        rue_air::SemanticProviderError<
+            QueryAbort,
+            crate::semantic_query_nucleus::SemanticNucleusFailure,
+        >,
+    > {
+        type Failure = crate::semantic_query_nucleus::SemanticNucleusFailure;
+
+        let candidate = self.provider.candidate_from(
+            accessing_source,
+            module,
+            name,
+            DefinitionKind::Function,
+        )?;
+        let Some(candidate) = candidate else {
+            return Err(rue_air::SemanticProviderError::Failure(
+                Failure::Resolution(Arc::from(format!("undefined comptime function `{name}`"))),
+            ));
+        };
+        let identity = self.provider.identity(candidate.clone())?;
+        Ok(crate::durable_comptime::DurableComptimeCallableAdmissionStart {
+            candidate,
+            identity: identity.clone(),
+            name: Arc::from(name),
+            dependency: crate::semantic_query_nucleus::SemanticDeclarationDependency {
+                source: accessing_source.clone(),
+                kind: rue_air::DeclarationTypeDependencyKind::Body,
+                target:
+                    crate::semantic_query_nucleus::SemanticDeclarationDependencyTarget::NamedValue(
+                        identity.key,
+                    ),
+            },
+        })
+    }
+
+    fn finish_comptime_call_admission(
+        &self,
+        start: crate::durable_comptime::DurableComptimeCallableAdmissionStart,
+        argument_modes: &[crate::durable_semantics::DurableParameterMode],
+    ) -> Result<
+        crate::durable_comptime::DurableComptimeCallableAdmission,
+        rue_air::SemanticProviderError<
+            QueryAbort,
+            crate::semantic_query_nucleus::SemanticNucleusFailure,
+        >,
+    > {
+        type Failure = crate::semantic_query_nucleus::SemanticNucleusFailure;
+        let crate::durable_comptime::DurableComptimeCallableAdmissionStart {
+            candidate,
+            identity,
+            name,
+            dependency: _,
+        } = start;
+        let signature = self.provider.signature(candidate.clone())?;
+        let crate::semantic_query_nucleus::DeclarationSignatureProjection::Callable {
+            parameters,
+            result,
+            ..
+        } = signature
+        else {
+            return Err(rue_air::SemanticProviderError::Failure(
+                Failure::Resolution(Arc::from(format!("`{name}` is not callable"))),
+            ));
+        };
+        let shell = self
+            .provider
+            .context
+            .query_registered(
+                self.provider.shells,
+                DeclarationShellQueryKey(candidate.clone()),
+            )
+            .map_err(rue_air::SemanticProviderError::Abort)?;
+        let rue_query::QueryOutcome::Success(DeclarationShellQueryValue::Available(shell)) =
+            shell.outcome()
+        else {
+            return Err(rue_air::SemanticProviderError::Failure(
+                Failure::Resolution(Arc::from("comptime call shell became unavailable")),
+            ));
+        };
+        if shell.parameters.len() != argument_modes.len()
+            || parameters.len() != argument_modes.len()
+        {
+            return Err(rue_air::SemanticProviderError::Failure(
+                Failure::Resolution(Arc::from(format!(
+                    "comptime call `{name}` has the wrong arity"
+                ))),
+            ));
+        }
+        for (parameter, argument_mode) in parameters.iter().zip(argument_modes.iter().copied()) {
+            use crate::durable_semantics::DurableParameterMode as ParameterMode;
+            let failure = match (parameter.mode, argument_mode) {
+                (ParameterMode::Value, ParameterMode::Value)
+                | (ParameterMode::Borrow, ParameterMode::Borrow)
+                | (ParameterMode::Inout, ParameterMode::Inout) => None,
+                (ParameterMode::Inout, _) => Some(rue_error::ErrorKind::InoutKeywordMissing),
+                (ParameterMode::Borrow, _) => Some(rue_error::ErrorKind::BorrowKeywordMissing),
+                (ParameterMode::Value, ParameterMode::Borrow) => {
+                    Some(rue_error::ErrorKind::UnexpectedCallArgumentMode { mode: "borrow" })
+                }
+                (ParameterMode::Value, ParameterMode::Inout) => {
+                    Some(rue_error::ErrorKind::UnexpectedCallArgumentMode { mode: "inout" })
+                }
+            };
+            if let Some(kind) = failure {
+                return Err(rue_air::SemanticProviderError::Failure(
+                    Failure::Diagnostic(kind),
+                ));
+            }
+        }
+        let all_parameters_comptime =
+            !parameters.is_empty() && parameters.iter().all(|parameter| parameter.is_comptime);
+        let is_type_function = result == crate::durable_semantics::DurableType::ComptimeType;
+        let eligible = if is_type_function {
+            parameters.is_empty() || all_parameters_comptime
+        } else {
+            all_parameters_comptime
+        };
+        if !eligible {
+            return Err(rue_air::SemanticProviderError::Failure(
+                Failure::Diagnostic(rue_error::ErrorKind::ConstExprNotSupported {
+                    expr_kind: format!("call to `{name}`"),
+                }),
+            ));
+        }
+        Ok(crate::durable_comptime::DurableComptimeCallableAdmission {
+            candidate,
+            identity,
+            parameters,
+            result,
+            shell_parameters: shell.parameters.clone(),
+        })
+    }
+
     fn resolve_candidate(
         &self,
         module: &ModuleId,
@@ -7898,104 +8037,41 @@ impl SemanticConstEvaluator<'_, '_> {
         };
         let call_ordinal = self.next_call;
         self.next_call += 1;
-        let Some(candidate) = self
-            .provider
-            .candidate(module, &name, DefinitionKind::Function)
-            .map_err(Self::provider_error)?
-        else {
-            return Self::failure(format!("undefined comptime function `{name}`"));
-        };
-        let identity = self
-            .provider
-            .identity(candidate.clone())
-            .map_err(Self::provider_error)?;
-        self.effects.observe_dependency(
-            crate::semantic_query_nucleus::SemanticDeclarationDependency {
-                source: self.provider.dependency_source.clone(),
-                kind: rue_air::DeclarationTypeDependencyKind::Body,
-                target:
-                    crate::semantic_query_nucleus::SemanticDeclarationDependencyTarget::NamedValue(
-                        identity.key,
-                    ),
-            },
-        );
-        let signature = self
-            .provider
-            .signature(candidate.clone())
-            .map_err(Self::provider_error)?;
-        let crate::semantic_query_nucleus::DeclarationSignatureProjection::Callable {
-            parameters,
-            result,
-            ..
-        } = signature
-        else {
-            return Self::failure(format!("`{name}` is not callable"));
-        };
-        let shell = self
-            .provider
-            .context
-            .query_registered(
-                self.provider.shells,
-                DeclarationShellQueryKey(candidate.clone()),
-            )
-            .map_err(EvaluateSemanticConstError::Abort)?;
-        let rue_query::QueryOutcome::Success(DeclarationShellQueryValue::Available(shell)) =
-            shell.outcome()
-        else {
-            return Self::failure("comptime call shell became unavailable");
-        };
-        let argument_count = self.rir.call_args(arguments).len();
-        if shell.parameters.len() != argument_count || parameters.len() != argument_count {
-            return Self::failure(format!("comptime call `{name}` has the wrong arity"));
-        }
-        for (index, parameter) in parameters.iter().enumerate() {
-            use crate::durable_semantics::DurableParameterMode as ParameterMode;
-            use rue_rir::RirArgMode as ArgMode;
-            let argument = self
-                .rir
-                .call_args(arguments)
-                .get(index)
-                .expect("validated call argument index");
-            let failure = match (parameter.mode, argument.mode) {
-                (ParameterMode::Value, ArgMode::Normal)
-                | (ParameterMode::Borrow, ArgMode::Borrow)
-                | (ParameterMode::Inout, ArgMode::Inout) => None,
-                (ParameterMode::Inout, _) => Some(rue_error::ErrorKind::InoutKeywordMissing),
-                (ParameterMode::Borrow, _) => Some(rue_error::ErrorKind::BorrowKeywordMissing),
-                (ParameterMode::Value, ArgMode::Borrow) => {
-                    Some(rue_error::ErrorKind::UnexpectedCallArgumentMode { mode: "borrow" })
+        let argument_modes = self
+            .rir
+            .call_args(arguments)
+            .iter()
+            .map(|argument| match argument.mode {
+                rue_rir::RirArgMode::Normal => {
+                    crate::durable_semantics::DurableParameterMode::Value
                 }
-                (ParameterMode::Value, ArgMode::Inout) => {
-                    Some(rue_error::ErrorKind::UnexpectedCallArgumentMode { mode: "inout" })
+                rue_rir::RirArgMode::Borrow => {
+                    crate::durable_semantics::DurableParameterMode::Borrow
                 }
-            };
-            if let Some(kind) = failure {
-                return Err(EvaluateSemanticConstError::failure(
-                    crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(kind),
-                ));
-            }
-        }
-        let all_parameters_comptime =
-            !parameters.is_empty() && parameters.iter().all(|parameter| parameter.is_comptime);
-        let is_type_function = result == crate::durable_semantics::DurableType::ComptimeType;
-        let eligible = if is_type_function {
-            parameters.is_empty() || all_parameters_comptime
-        } else {
-            all_parameters_comptime
+                rue_rir::RirArgMode::Inout => crate::durable_semantics::DurableParameterMode::Inout,
+            })
+            .collect::<Vec<_>>();
+        let authority = SemanticComptimeAuthority {
+            provider: &*self.provider,
+            imports: self.imports,
         };
-        if !eligible {
-            return Err(EvaluateSemanticConstError::failure(
-                crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
-                    rue_error::ErrorKind::ConstExprNotSupported {
-                        expr_kind: format!("call to `{name}`"),
-                    },
-                ),
-            ));
-        }
+        let services = crate::durable_comptime::DurableComptimeServices::new(&authority);
+        let admission_start = services
+            .begin_comptime_call_admission(&self.provider.dependency_source, module, &name)
+            .map_err(Self::provider_error)?;
+        self.effects
+            .observe_dependency(admission_start.dependency.clone());
+        let admission = services
+            .finish_comptime_call_admission(admission_start, &argument_modes)
+            .map_err(Self::provider_error)?;
+        let candidate = admission.candidate;
+        let parameters = admission.parameters;
+        let result = admission.result;
+        let shell_parameters = admission.shell_parameters;
         let mut type_arguments = Vec::new();
         let mut value_arguments = Vec::new();
         for (index, (header, parameter)) in
-            shell.parameters.iter().zip(parameters.iter()).enumerate()
+            shell_parameters.iter().zip(parameters.iter()).enumerate()
         {
             let argument = self
                 .rir
@@ -9594,6 +9670,22 @@ impl SemanticNucleusTypeProvider<'_> {
             crate::semantic_query_nucleus::SemanticNucleusFailure,
         >,
     > {
+        self.candidate_from(&self.dependency_source, module, name, kind)
+    }
+
+    fn candidate_from(
+        &self,
+        accessing_source: &crate::StableDefinitionKey,
+        module: &ModuleId,
+        name: &str,
+        kind: DefinitionKind,
+    ) -> Result<
+        Option<crate::declaration_candidate::DeclarationCandidateKey>,
+        rue_air::SemanticProviderError<
+            QueryAbort,
+            crate::semantic_query_nucleus::SemanticNucleusFailure,
+        >,
+    > {
         let terminal = self
             .context
             .query_registered(
@@ -9626,7 +9718,7 @@ impl SemanticNucleusTypeProvider<'_> {
         }
         let defining = rue_air::SemanticVisibilityDomain::from_file_path(Some(module.as_str()));
         let accessing = rue_air::SemanticVisibilityDomain::from_file_path(Some(
-            self.dependency_source.module().as_str(),
+            accessing_source.module().as_str(),
         ));
         let is_public = entry.visibility == Some(rue_parser::ast::Visibility::Public);
         if !defining.is_visible_from(&accessing, is_public) {
@@ -29319,6 +29411,196 @@ fn main() -> i32 {
                 ..
             }) if matches!(*value, crate::durable_semantics::DurableConstValue::Bool(true))
         ));
+    }
+
+    #[test]
+    fn durable_callable_admission_pipeline_preserves_policy_table() {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Category;
+        use crate::semantic_query_nucleus::{
+            ComptimeCallQueryKey, SemanticNucleusKey as Key, SemanticNucleusValue as Value,
+        };
+
+        let cases = [
+            (
+                "undefined",
+                "fn outer() -> i32 { missing() }",
+                "undefined comptime function `missing`",
+            ),
+            (
+                "arity",
+                "fn target(comptime x: i32) -> i32 { x } fn outer() -> i32 { target(1 / 0, 2) }",
+                "wrong arity",
+            ),
+            (
+                "borrow mode",
+                "fn target(borrow x: i32) -> i32 { x } fn outer() -> i32 { target(1) }",
+                "BorrowKeywordMissing",
+            ),
+            (
+                "inout mode",
+                "fn target(inout x: i32) -> i32 { x } fn outer() -> i32 { target(1) }",
+                "InoutKeywordMissing",
+            ),
+            (
+                "unexpected borrow",
+                "fn target(x: i32) -> i32 { x } fn outer() -> i32 { target(borrow 1) }",
+                "UnexpectedCallArgumentMode",
+            ),
+            (
+                "unexpected inout",
+                "fn target(x: i32) -> i32 { x } fn outer() -> i32 { target(inout 1) }",
+                "UnexpectedCallArgumentMode",
+            ),
+            (
+                "nullary value",
+                "fn target() -> i32 { 1 } fn outer() -> i32 { target() }",
+                "ConstExprNotSupported",
+            ),
+            (
+                "mixed comptime/runtime",
+                "fn target(comptime x: i32, y: i32) -> i32 { x + y } fn outer() -> i32 { target(1, 2) }",
+                "ConstExprNotSupported",
+            ),
+        ];
+
+        for (label, source_text, expected) in cases {
+            let source = source_snapshot(&[(1, "/main.rue", "main.rue", source_text)], 1);
+            let module = ModuleId::from_logical_path("main.rue").unwrap();
+            let mut database = RevisionedQueryDatabase::default();
+            let revision = database.source_revision(
+                &super::super::session::ExactSourceInput::new(&source),
+                &source,
+            );
+            let declaration =
+                declaration_candidate(&database, revision, &module, Category::Function, "outer");
+            let value = request_semantic_nucleus(
+                &database,
+                revision,
+                Key::ComptimeCall(ComptimeCallQueryKey {
+                    declaration: crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
+                        declaration,
+                        configuration: semantic_configuration(),
+                    },
+                    type_arguments: Arc::from([]),
+                    value_arguments: Arc::from([]),
+                }),
+            );
+            let diagnostic = format!("{value:?}");
+            assert!(
+                diagnostic.contains(expected),
+                "{label} lost its canonical admission diagnostic: {diagnostic}"
+            );
+        }
+
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn target() -> type { i32 } fn outer() -> type { target() }",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&source),
+            &source,
+        );
+        let declaration =
+            declaration_candidate(&database, revision, &module, Category::Function, "outer");
+        let value = request_semantic_nucleus(
+            &database,
+            revision,
+            Key::ComptimeCall(ComptimeCallQueryKey {
+                declaration: crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
+                    declaration,
+                    configuration: semantic_configuration(),
+                },
+                type_arguments: Arc::from([]),
+                value_arguments: Arc::from([]),
+            }),
+        );
+        assert!(
+            matches!(
+                value,
+                Value::ComptimeCall(crate::semantic_query_nucleus::ComptimeCallProjection {
+                    result: crate::semantic_query_nucleus::ComptimeCallResultProjection::Type(
+                        crate::durable_semantics::DurableType::I32
+                    ),
+                    ..
+                })
+            ),
+            "nullary type function should remain an admitted callable: {value:?}"
+        );
+
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn target(comptime x: i32, comptime y: i32) -> i32 { x * 10 + y } fn outer() -> i32 { target(1, 2) }",
+            )],
+            1,
+        );
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&source),
+            &source,
+        );
+        let declaration =
+            declaration_candidate(&database, revision, &module, Category::Function, "outer");
+        let target =
+            declaration_candidate(&database, revision, &module, Category::Function, "target");
+        let identity = |candidate: crate::declaration_candidate::DeclarationCandidateKey| {
+            let value = request_semantic_nucleus(
+                &database,
+                revision,
+                Key::Identity(crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
+                    declaration: candidate,
+                    configuration: semantic_configuration(),
+                }),
+            );
+            let Value::Identity(identity) = value else {
+                panic!("expected callable identity, got {value:?}")
+            };
+            identity.key
+        };
+        let outer_identity = identity(declaration.clone());
+        let target_identity = identity(target);
+        let value = request_semantic_nucleus(
+            &database,
+            revision,
+            Key::ComptimeCall(ComptimeCallQueryKey {
+                declaration: crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
+                    declaration,
+                    configuration: semantic_configuration(),
+                },
+                type_arguments: Arc::from([]),
+                value_arguments: Arc::from([]),
+            }),
+        );
+        assert!(
+            matches!(
+                value,
+                Value::ComptimeCall(crate::semantic_query_nucleus::ComptimeCallProjection {
+                    result: crate::semantic_query_nucleus::ComptimeCallResultProjection::Value(
+                        crate::durable_semantics::DurableConstValue::Integer(12)
+                    ),
+                    ref dependencies,
+                    ..
+                })
+                if dependencies.as_ref()
+                    == [crate::semantic_query_nucleus::SemanticDeclarationDependency {
+                        source: outer_identity,
+                        kind: rue_air::DeclarationTypeDependencyKind::Body,
+                        target: crate::semantic_query_nucleus::SemanticDeclarationDependencyTarget::NamedValue(
+                            target_identity,
+                        ),
+                    }]
+            ),
+            "ordered parameters and exact published dependency should survive admission: {value:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Relates to RUE-1774

Extracts durable comptime callable admission into one two-phase semantic authority and routes the legacy evaluator through it. The staged boundary preserves the existing candidate → identity → dependency → signature → shell → arity → modes → eligibility → argument-evaluation order, while accepting an explicit lifecycle-compatible source for visibility and dependency attribution.

The admission start is one-shot and owns stable facts. The authority exposes no RIR instructions, evaluator callbacks, or recursive query-demand surface. Neither production root moves in this slice.

Validation:
- scripts/rue unit compiler durable_ (56 passed)
- scripts/rue quick (31 suites passed)
- scripts/rue premerge (200 passed)