### PR TITLE
RUE-1774: centralize durable named-value resolution

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -3131,11 +3131,12 @@ fn durable_comptime_services_are_named_authority_operations() {
         "DurableComptimeApplicationPolicy",
         "DurableComptimeCallableAdmission",
         "DurableComptimeCallableAdmissionStart",
+        "DurableComptimeNamedValueKind",
+        "resolve_named_value_in_order",
         "begin_comptime_call_admission",
         "finish_comptime_call_admission",
-        "resolve_candidate",
-        "resolve_identity",
-        "resolve_const",
+        "DurableComptimeNamedValueProjection",
+        "resolve_named_value",
         "resolve_target_intrinsic",
         "resolve_target_enum_variant",
         "probe_comptime_call",
@@ -3239,7 +3240,7 @@ fn durable_comptime_services_are_named_authority_operations() {
     let callable_authority = facade
         .split("pub(crate) struct DurableComptimeCallableAdmission {")
         .nth(1)
-        .and_then(|source| source.split("}\n\n/// Canonical semantic services").next())
+        .and_then(|source| source.split("}\n\n/// The exact durable projection").next())
         .expect("durable callable admission projection");
     for forbidden in ["InstData", "InstRef", "Rir", "callback", "evaluate"] {
         assert!(
@@ -3420,9 +3421,41 @@ fn durable_comptime_services_are_named_authority_operations() {
         "durable call ordinals must be allocated before admission"
     );
     assert!(evaluator.contains(".resolve_import(&site)"));
-    assert!(evaluator.contains(".resolve_candidate("));
-    assert!(evaluator.contains(".resolve_identity("));
-    assert!(evaluator.contains(".resolve_const("));
+    let named_value = evaluator
+        .split("fn eval_identifier(")
+        .nth(1)
+        .and_then(|source| source.split("\n    fn eval_call(").next())
+        .expect("durable identifier evaluator");
+    assert_eq!(named_value.matches("resolve_named_value(").count(), 1);
+    let locals = named_value
+        .find("self.locals.get(")
+        .expect("identifier lookup keeps locals-first behavior");
+    let service = named_value
+        .find("resolve_named_value(")
+        .expect("identifier lookup uses the named-value service");
+    let parts = named_value
+        .find("projection.into_parts()")
+        .expect("identifier lookup destructures a successful projection");
+    let observed = named_value
+        .find("self.effects.observe_dependency(dependency)")
+        .expect("identifier lookup observes its direct dependency");
+    assert!(locals < service && service < parts && parts < observed);
+    assert!(named_value.contains("&self.provider.dependency_source"));
+    for forbidden in [
+        "DefinitionKind::Const",
+        "DefinitionKind::Function",
+        "DefinitionKind::Struct",
+        "DefinitionKind::Enum",
+        "SemanticDeclarationDependency {",
+        "fn resolve_candidate(",
+        "fn resolve_identity(",
+        "fn resolve_const(",
+    ] {
+        assert!(
+            !named_value.contains(forbidden),
+            "named-value evaluator retained local lookup policy: {forbidden}"
+        );
+    }
     assert!(evaluator.contains(".resolve_target_intrinsic("));
     assert!(evaluator.contains(".resolve_target_enum_variant("));
     let admission_authority = target_authority
@@ -3444,9 +3477,78 @@ fn durable_comptime_services_are_named_authority_operations() {
     let admission_finish_authority = target_authority
         .split("fn finish_comptime_call_admission(")
         .nth(1)
-        .and_then(|source| source.split("\n    fn resolve_candidate(").next())
+        .and_then(|source| source.split("\n    fn resolve_named_value(").next())
         .expect("call admission completion authority source");
     assert!(!admission_finish_authority.contains("provider.dependency_source"));
+    let named_value_authority = target_authority
+        .split("fn resolve_named_value(")
+        .nth(1)
+        .and_then(|source| source.split("\n    fn resolve_import(").next())
+        .expect("named-value authority source");
+    for required in [
+        "resolve_named_value_in_order",
+        "DefinitionKind::Const",
+        "DefinitionKind::Function",
+        "DefinitionKind::Struct",
+        "DefinitionKind::Enum",
+        "candidate_from(",
+        "const_resolution(",
+        "identity(",
+        "source: accessing_source.clone()",
+        "DurableComptimeNamedValueProjection::new",
+    ] {
+        assert!(
+            named_value_authority.contains(required),
+            "named-value policy missing from authority: {required}"
+        );
+    }
+    assert_eq!(named_value_authority.matches("candidate_from(").count(), 3);
+    assert_eq!(
+        named_value_authority
+            .matches("identity(candidate)?")
+            .count(),
+        2
+    );
+    assert!(named_value_authority.contains("const_resolution(candidate)?"));
+    assert!(named_value_authority.contains("DurableComptimeNamedValueKind::Const"));
+    assert!(named_value_authority.contains("DurableComptimeNamedValueKind::Function"));
+    assert!(named_value_authority.contains("DurableComptimeNamedValueKind::Struct"));
+    assert!(named_value_authority.contains("DurableComptimeNamedValueKind::Enum"));
+    let named_value_kernel = production_facade
+        .split("const DURABLE_COMPTIME_NAMED_VALUE_KINDS")
+        .nth(1)
+        .and_then(|source| {
+            source
+                .split("impl DurableComptimeNamedValueProjection")
+                .next()
+        })
+        .expect("named-value ordering kernel");
+    let kind_positions = [
+        "DurableComptimeNamedValueKind::Const",
+        "DurableComptimeNamedValueKind::Function",
+        "DurableComptimeNamedValueKind::Struct",
+        "DurableComptimeNamedValueKind::Enum",
+    ]
+    .map(|kind| {
+        named_value_kernel
+            .find(kind)
+            .unwrap_or_else(|| panic!("named-value kernel missing {kind}"))
+    });
+    assert!(kind_positions.windows(2).all(|pair| pair[0] < pair[1]));
+    for forbidden in [
+        "InstData",
+        "InstRef",
+        "ComptimeEngine",
+        "SemanticConstEvaluator",
+        "callback",
+        "query_demand",
+        ".eval(",
+    ] {
+        assert!(
+            !named_value_authority.contains(forbidden),
+            "named-value authority leaked evaluator surface: {forbidden}"
+        );
+    }
     for forbidden in [
         "self.provider.configuration.target",
         "rue_target::Arch",

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -796,6 +796,61 @@ pub(crate) struct DurableComptimeCallableAdmission {
     pub(crate) shell_parameters: Arc<[crate::declaration_candidate::DeclarationParameterHeader]>,
 }
 
+/// The exact durable projection of one named value lookup.  The dependency is
+/// deliberately direct: resolving a const, callable, or nominal observes the
+/// resolved declaration only, while any transitive const effects remain owned
+/// by the const query that produced its value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DurableComptimeNamedValueProjection {
+    value: EvaluatedSemanticConst,
+    dependency: SemanticDeclarationDependency,
+}
+
+/// The only declaration kinds considered by durable named-value lookup, in
+/// the same order as the legacy evaluator's semantic lookup policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DurableComptimeNamedValueKind {
+    Const,
+    Function,
+    Struct,
+    Enum,
+}
+
+const DURABLE_COMPTIME_NAMED_VALUE_KINDS: [DurableComptimeNamedValueKind; 4] = [
+    DurableComptimeNamedValueKind::Const,
+    DurableComptimeNamedValueKind::Function,
+    DurableComptimeNamedValueKind::Struct,
+    DurableComptimeNamedValueKind::Enum,
+];
+
+/// Run the canonical named-value candidate order.  The probe is semantic
+/// candidate/identity work only; it cannot evaluate an instruction or demand
+/// a child query.  Errors stop the order immediately, and the first value
+/// stops it without probing later declaration kinds.
+pub(crate) fn resolve_named_value_in_order<T, E>(
+    mut probe: impl FnMut(DurableComptimeNamedValueKind) -> Result<Option<T>, E>,
+) -> Result<Option<T>, E> {
+    for kind in DURABLE_COMPTIME_NAMED_VALUE_KINDS {
+        if let Some(value) = probe(kind)? {
+            return Ok(Some(value));
+        }
+    }
+    Ok(None)
+}
+
+impl DurableComptimeNamedValueProjection {
+    pub(crate) fn new(
+        value: EvaluatedSemanticConst,
+        dependency: SemanticDeclarationDependency,
+    ) -> Self {
+        Self { value, dependency }
+    }
+
+    pub(crate) fn into_parts(self) -> (EvaluatedSemanticConst, SemanticDeclarationDependency) {
+        (self.value, self.dependency)
+    }
+}
+
 /// Canonical semantic services needed by durable comptime entry points.
 ///
 /// Implementations live beside the query authorities. This facade is an
@@ -823,32 +878,15 @@ pub(crate) trait DurableComptimeSemanticAuthority {
         rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
     >;
 
-    /// Resolve a declaration through the canonical name/shell authority.
-    /// Visibility and shell disagreement diagnostics are produced by the
-    /// authority; the facade only carries the semantic request and result.
-    fn resolve_candidate(
+    /// Resolve a named const, module binding, callable, or nominal in the
+    /// canonical order used by durable identifier evaluation.
+    fn resolve_named_value(
         &self,
+        accessing_source: &crate::StableDefinitionKey,
         module: &ModuleId,
         name: &str,
-        kind: crate::DefinitionKind,
     ) -> Result<
-        Option<DeclarationCandidateKey>,
-        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
-    >;
-
-    fn resolve_identity(
-        &self,
-        declaration: DeclarationCandidateKey,
-    ) -> Result<
-        crate::semantic_query_nucleus::DeclarationIdentityProjection,
-        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
-    >;
-
-    fn resolve_const(
-        &self,
-        declaration: DeclarationCandidateKey,
-    ) -> Result<
-        crate::semantic_query_nucleus::ConstResolutionProjection,
+        Option<DurableComptimeNamedValueProjection>,
         rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
     >;
 
@@ -924,36 +962,17 @@ impl<A: DurableComptimeSemanticAuthority + ?Sized> DurableComptimeServices<'_, A
             .finish_comptime_call_admission(start, argument_modes)
     }
 
-    pub(crate) fn resolve_candidate(
+    pub(crate) fn resolve_named_value(
         &self,
+        accessing_source: &crate::StableDefinitionKey,
         module: &ModuleId,
         name: &str,
-        kind: crate::DefinitionKind,
     ) -> Result<
-        Option<DeclarationCandidateKey>,
+        Option<DurableComptimeNamedValueProjection>,
         rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
     > {
-        self.authority.resolve_candidate(module, name, kind)
-    }
-
-    pub(crate) fn resolve_identity(
-        &self,
-        declaration: DeclarationCandidateKey,
-    ) -> Result<
-        crate::semantic_query_nucleus::DeclarationIdentityProjection,
-        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
-    > {
-        self.authority.resolve_identity(declaration)
-    }
-
-    pub(crate) fn resolve_const(
-        &self,
-        declaration: DeclarationCandidateKey,
-    ) -> Result<
-        crate::semantic_query_nucleus::ConstResolutionProjection,
-        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
-    > {
-        self.authority.resolve_const(declaration)
+        self.authority
+            .resolve_named_value(accessing_source, module, name)
     }
 
     pub(crate) fn resolve_import(
@@ -1337,6 +1356,83 @@ mod tests {
             EvaluatedSemanticConst::integer_typed(-12, Some(DurableComptimeType(ty.clone())));
         assert_eq!(original.clone(), original);
         assert_eq!(original.as_integer_type(), Some(DurableComptimeType(ty)));
+    }
+
+    #[test]
+    fn named_value_kernel_is_ordered_and_short_circuits() {
+        let mut all_missing = Vec::new();
+        assert_eq!(
+            resolve_named_value_in_order(|kind| {
+                all_missing.push(kind);
+                Ok::<Option<()>, ()>(None)
+            })
+            .unwrap(),
+            None
+        );
+        assert_eq!(
+            all_missing,
+            vec![
+                DurableComptimeNamedValueKind::Const,
+                DurableComptimeNamedValueKind::Function,
+                DurableComptimeNamedValueKind::Struct,
+                DurableComptimeNamedValueKind::Enum,
+            ]
+        );
+
+        let mut early_success = Vec::new();
+        assert_eq!(
+            resolve_named_value_in_order(|kind| {
+                early_success.push(kind);
+                Ok::<Option<&str>, ()>(
+                    (kind == DurableComptimeNamedValueKind::Struct).then_some("struct"),
+                )
+            })
+            .unwrap(),
+            Some("struct")
+        );
+        assert_eq!(
+            early_success,
+            vec![
+                DurableComptimeNamedValueKind::Const,
+                DurableComptimeNamedValueKind::Function,
+                DurableComptimeNamedValueKind::Struct,
+            ]
+        );
+
+        let mut const_failure = Vec::new();
+        assert_eq!(
+            resolve_named_value_in_order(|kind| {
+                const_failure.push(kind);
+                if kind == DurableComptimeNamedValueKind::Const {
+                    Err::<Option<()>, _>("const failure")
+                } else {
+                    Ok(None)
+                }
+            }),
+            Err("const failure")
+        );
+        assert_eq!(const_failure, vec![DurableComptimeNamedValueKind::Const]);
+
+        let mut middle_failure = Vec::new();
+        assert_eq!(
+            resolve_named_value_in_order(|kind| {
+                middle_failure.push(kind);
+                if kind == DurableComptimeNamedValueKind::Struct {
+                    Err::<Option<()>, _>("struct failure")
+                } else {
+                    Ok(None)
+                }
+            }),
+            Err("struct failure")
+        );
+        assert_eq!(
+            middle_failure,
+            vec![
+                DurableComptimeNamedValueKind::Const,
+                DurableComptimeNamedValueKind::Function,
+                DurableComptimeNamedValueKind::Struct,
+            ]
+        );
     }
 
     #[test]

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -7220,45 +7220,132 @@ impl crate::durable_comptime::DurableComptimeSemanticAuthority
         })
     }
 
-    fn resolve_candidate(
+    fn resolve_named_value(
         &self,
+        accessing_source: &crate::StableDefinitionKey,
         module: &ModuleId,
         name: &str,
-        kind: DefinitionKind,
     ) -> Result<
-        Option<crate::declaration_candidate::DeclarationCandidateKey>,
+        Option<crate::durable_comptime::DurableComptimeNamedValueProjection>,
         rue_air::SemanticProviderError<
             QueryAbort,
             crate::semantic_query_nucleus::SemanticNucleusFailure,
         >,
     > {
-        self.provider.candidate(module, name, kind)
-    }
+        let dependency = |key: crate::StableDefinitionKey| {
+            crate::semantic_query_nucleus::SemanticDeclarationDependency {
+                source: accessing_source.clone(),
+                kind: rue_air::DeclarationTypeDependencyKind::Body,
+                target:
+                    crate::semantic_query_nucleus::SemanticDeclarationDependencyTarget::NamedValue(
+                        key,
+                    ),
+            }
+        };
 
-    fn resolve_identity(
-        &self,
-        declaration: crate::declaration_candidate::DeclarationCandidateKey,
-    ) -> Result<
-        crate::semantic_query_nucleus::DeclarationIdentityProjection,
-        rue_air::SemanticProviderError<
-            QueryAbort,
-            crate::semantic_query_nucleus::SemanticNucleusFailure,
-        >,
-    > {
-        self.provider.identity(declaration)
-    }
-
-    fn resolve_const(
-        &self,
-        declaration: crate::declaration_candidate::DeclarationCandidateKey,
-    ) -> Result<
-        crate::semantic_query_nucleus::ConstResolutionProjection,
-        rue_air::SemanticProviderError<
-            QueryAbort,
-            crate::semantic_query_nucleus::SemanticNucleusFailure,
-        >,
-    > {
-        self.provider.const_resolution(declaration)
+        crate::durable_comptime::resolve_named_value_in_order(|kind| match kind {
+            crate::durable_comptime::DurableComptimeNamedValueKind::Const => {
+                let Some(candidate) = self.provider.candidate_from(
+                    accessing_source,
+                    module,
+                    name,
+                    DefinitionKind::Const,
+                )?
+                else {
+                    return Ok(None);
+                };
+                let resolution = self.provider.const_resolution(candidate)?;
+                let (value, key) = match resolution {
+                    crate::semantic_query_nucleus::ConstResolutionProjection::Value {
+                        key,
+                        ty,
+                        value,
+                        ..
+                    } => (
+                        crate::durable_comptime::EvaluatedSemanticConst::Value(
+                            crate::durable_comptime::TypedSemanticConst::typed(*value, ty),
+                        ),
+                        key,
+                    ),
+                    crate::semantic_query_nucleus::ConstResolutionProjection::ModuleBinding {
+                        key,
+                        target,
+                    } => (
+                        crate::durable_comptime::EvaluatedSemanticConst::Module(target),
+                        key,
+                    ),
+                };
+                Ok(Some(
+                    crate::durable_comptime::DurableComptimeNamedValueProjection::new(
+                        value,
+                        dependency(key),
+                    ),
+                ))
+            }
+            crate::durable_comptime::DurableComptimeNamedValueKind::Function => {
+                let Some(candidate) = self.provider.candidate_from(
+                    accessing_source,
+                    module,
+                    name,
+                    DefinitionKind::Function,
+                )?
+                else {
+                    return Ok(None);
+                };
+                let identity = self.provider.identity(candidate)?;
+                let key = identity.key.clone();
+                Ok(Some(
+                    crate::durable_comptime::DurableComptimeNamedValueProjection::new(
+                        crate::durable_comptime::EvaluatedSemanticConst::Value(
+                            crate::durable_comptime::TypedSemanticConst::typed(
+                                crate::durable_semantics::DurableConstValue::Function(key),
+                                crate::durable_semantics::DurableType::ComptimeType,
+                            ),
+                        ),
+                        dependency(identity.key),
+                    ),
+                ))
+            }
+            crate::durable_comptime::DurableComptimeNamedValueKind::Struct
+            | crate::durable_comptime::DurableComptimeNamedValueKind::Enum => {
+                let definition_kind = match kind {
+                    crate::durable_comptime::DurableComptimeNamedValueKind::Struct => {
+                        DefinitionKind::Struct
+                    }
+                    crate::durable_comptime::DurableComptimeNamedValueKind::Enum => {
+                        DefinitionKind::Enum
+                    }
+                    crate::durable_comptime::DurableComptimeNamedValueKind::Const
+                    | crate::durable_comptime::DurableComptimeNamedValueKind::Function => {
+                        unreachable!("scalar named-value kinds handled above")
+                    }
+                };
+                let Some(candidate) = self.provider.candidate_from(
+                    accessing_source,
+                    module,
+                    name,
+                    definition_kind,
+                )?
+                else {
+                    return Ok(None);
+                };
+                let identity = self.provider.identity(candidate)?;
+                let key = identity.key.clone();
+                Ok(Some(
+                    crate::durable_comptime::DurableComptimeNamedValueProjection::new(
+                        crate::durable_comptime::EvaluatedSemanticConst::Value(
+                            crate::durable_comptime::TypedSemanticConst::typed(
+                                crate::durable_semantics::DurableConstValue::Type(
+                                    crate::durable_semantics::DurableType::Nominal(key),
+                                ),
+                                crate::durable_semantics::DurableType::ComptimeType,
+                            ),
+                        ),
+                        dependency(identity.key),
+                    ),
+                ))
+            }
+        })
     }
 
     fn resolve_import(
@@ -7896,123 +7983,24 @@ impl SemanticConstEvaluator<'_, '_> {
         if let Some(value) = self.locals.get(&name) {
             return Ok(value.clone());
         }
-        if let Some(candidate) = self.resolve_candidate(&name, DefinitionKind::Const)? {
-            let resolution = self.resolve_const(candidate)?;
-            let key = match &resolution {
-                crate::semantic_query_nucleus::ConstResolutionProjection::Value { key, .. }
-                | crate::semantic_query_nucleus::ConstResolutionProjection::ModuleBinding {
-                    key,
-                    ..
-                } => key.clone(),
-            };
-            self.effects.observe_dependency(
-                crate::semantic_query_nucleus::SemanticDeclarationDependency {
-                    source: self.provider.dependency_source.clone(),
-                    kind: rue_air::DeclarationTypeDependencyKind::Body,
-                    target: crate::semantic_query_nucleus::SemanticDeclarationDependencyTarget::NamedValue(
-                        key,
-                    ),
-                },
-            );
-            return Ok(match resolution {
-                crate::semantic_query_nucleus::ConstResolutionProjection::Value {
-                    value,
-                    ty,
-                    ..
-                } => EvaluatedSemanticConst::Value(TypedSemanticConst::typed(*value, ty)),
-                crate::semantic_query_nucleus::ConstResolutionProjection::ModuleBinding {
-                    target,
-                    ..
-                } => EvaluatedSemanticConst::Module(target),
-            });
-        }
-        if let Some(candidate) = self.resolve_candidate(&name, DefinitionKind::Function)? {
-            let identity = self.resolve_identity(candidate)?;
-            self.effects.observe_dependency(
-                crate::semantic_query_nucleus::SemanticDeclarationDependency {
-                    source: self.provider.dependency_source.clone(),
-                    kind: rue_air::DeclarationTypeDependencyKind::Body,
-                    target: crate::semantic_query_nucleus::SemanticDeclarationDependencyTarget::NamedValue(
-                        identity.key.clone(),
-                    ),
-                },
-            );
-            return Ok(EvaluatedSemanticConst::Value(TypedSemanticConst::typed(
-                crate::durable_semantics::DurableConstValue::Function(identity.key),
-                crate::durable_semantics::DurableType::ComptimeType,
-            )));
-        }
-        for kind in [DefinitionKind::Struct, DefinitionKind::Enum] {
-            if let Some(candidate) = self.resolve_candidate(&name, kind)? {
-                let identity = self.resolve_identity(candidate)?;
-                self.effects.observe_dependency(
-                    crate::semantic_query_nucleus::SemanticDeclarationDependency {
-                        source: self.provider.dependency_source.clone(),
-                        kind: rue_air::DeclarationTypeDependencyKind::Body,
-                        target: crate::semantic_query_nucleus::SemanticDeclarationDependencyTarget::NamedValue(
-                            identity.key.clone(),
-                        ),
-                    },
-                );
-                return Ok(EvaluatedSemanticConst::Value(TypedSemanticConst::typed(
-                    crate::durable_semantics::DurableConstValue::Type(
-                        crate::durable_semantics::DurableType::Nominal(identity.key),
-                    ),
-                    crate::durable_semantics::DurableType::ComptimeType,
-                )));
-            }
-        }
-        Self::failure(format!("undefined constant `{name}`"))
-    }
-
-    fn resolve_candidate(
-        &self,
-        name: &str,
-        kind: DefinitionKind,
-    ) -> Result<
-        Option<crate::declaration_candidate::DeclarationCandidateKey>,
-        EvaluateSemanticConstError,
-    > {
         let authority = SemanticComptimeAuthority {
             provider: &*self.provider,
             imports: self.imports,
         };
         let services = crate::durable_comptime::DurableComptimeServices::new(&authority);
-        services
-            .resolve_candidate(&self.declaration.declaration.module, name, kind)
-            .map_err(Self::provider_error)
-    }
-
-    fn resolve_identity(
-        &self,
-        declaration: crate::declaration_candidate::DeclarationCandidateKey,
-    ) -> Result<
-        crate::semantic_query_nucleus::DeclarationIdentityProjection,
-        EvaluateSemanticConstError,
-    > {
-        let authority = SemanticComptimeAuthority {
-            provider: &*self.provider,
-            imports: self.imports,
+        let Some(projection) = services
+            .resolve_named_value(
+                &self.provider.dependency_source,
+                &self.declaration.declaration.module,
+                &name,
+            )
+            .map_err(Self::provider_error)?
+        else {
+            return Self::failure(format!("undefined constant `{name}`"));
         };
-        let services = crate::durable_comptime::DurableComptimeServices::new(&authority);
-        services
-            .resolve_identity(declaration)
-            .map_err(Self::provider_error)
-    }
-
-    fn resolve_const(
-        &self,
-        declaration: crate::declaration_candidate::DeclarationCandidateKey,
-    ) -> Result<crate::semantic_query_nucleus::ConstResolutionProjection, EvaluateSemanticConstError>
-    {
-        let authority = SemanticComptimeAuthority {
-            provider: &*self.provider,
-            imports: self.imports,
-        };
-        let services = crate::durable_comptime::DurableComptimeServices::new(&authority);
-        services
-            .resolve_const(declaration)
-            .map_err(Self::provider_error)
+        let (value, dependency) = projection.into_parts();
+        self.effects.observe_dependency(dependency);
+        Ok(value)
     }
 
     fn eval_call(
@@ -29601,6 +29589,274 @@ fn main() -> i32 {
             ),
             "ordered parameters and exact published dependency should survive admission: {value:?}"
         );
+    }
+
+    #[test]
+    fn durable_named_value_projection_covers_each_lookup_kind_and_dependency() {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Category;
+        use crate::semantic_query_nucleus::{
+            ConstResolutionProjection, SemanticDeclarationDependencyTarget,
+            SemanticNucleusKey as Key, SemanticNucleusValue as Value,
+        };
+
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "const SCALAR: i32 = 7;\
+                 fn Callable() -> i32 { 1 }\
+                 struct StructValue { field: i32 }\
+                 enum EnumValue { One }\
+                 const INNER: i32 = 5;\
+                 const SOURCE: i32 = INNER;\
+                 const OUT_CHAIN: i32 = SOURCE;\
+                 const OUT_SCALAR: i32 = SCALAR;\
+                 const OUT_CALLABLE = Callable;\
+                 const OUT_STRUCT = StructValue;\
+                 const OUT_ENUM = EnumValue;\
+                 const OUT_LOCAL: i32 = { let SCALAR: i32 = 9; SCALAR };\
+                 const OUT_UNDEFINED: i32 = MISSING;",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&source),
+            &source,
+        );
+        let query = |name: &str| {
+            let declaration =
+                declaration_candidate(&database, revision, &module, Category::ConstCandidate, name);
+            request_semantic_nucleus(
+                &database,
+                revision,
+                Key::ConstResolution(crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
+                    declaration,
+                    configuration: semantic_configuration(),
+                }),
+            )
+        };
+        let identity = |name: &str| {
+            let declaration =
+                declaration_candidate(&database, revision, &module, Category::ConstCandidate, name);
+            let Value::Identity(identity) = request_semantic_nucleus(
+                &database,
+                revision,
+                Key::Identity(crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
+                    declaration,
+                    configuration: semantic_configuration(),
+                }),
+            ) else {
+                panic!("expected an identity for {name}");
+            };
+            identity.key
+        };
+
+        let stable_key = |namespace, kind, name| {
+            crate::StableDefinitionKey::from_stable_parts(
+                module.clone(),
+                namespace,
+                kind,
+                name,
+                None,
+            )
+        };
+        let assert_value =
+            |name: &str,
+             expected_value: crate::durable_semantics::DurableConstValue,
+             expected_type: crate::durable_semantics::DurableType,
+             expected_target: crate::StableDefinitionKey| {
+                let Value::ConstResolution(ConstResolutionProjection::Value {
+                    value,
+                    ty,
+                    dependencies,
+                    ..
+                }) = query(name)
+                else {
+                    panic!("expected a durable value projection for {name}");
+                };
+                assert_eq!(*value, expected_value);
+                assert_eq!(ty, expected_type);
+                assert_eq!(dependencies.len(), 1);
+                assert_eq!(dependencies[0].source, identity(name));
+                assert_eq!(
+                    dependencies[0].kind,
+                    rue_air::DeclarationTypeDependencyKind::Body
+                );
+                assert_eq!(
+                    dependencies[0].target,
+                    SemanticDeclarationDependencyTarget::NamedValue(expected_target)
+                );
+            };
+        assert_value(
+            "OUT_SCALAR",
+            crate::durable_semantics::DurableConstValue::Integer(7),
+            crate::durable_semantics::DurableType::I32,
+            stable_key(
+                crate::StableDefinitionNamespace::Value,
+                crate::StableDefinitionKind::ValueConst,
+                "SCALAR",
+            ),
+        );
+        assert_value(
+            "OUT_CALLABLE",
+            crate::durable_semantics::DurableConstValue::Function(stable_key(
+                crate::StableDefinitionNamespace::Value,
+                crate::StableDefinitionKind::Function,
+                "Callable",
+            )),
+            crate::durable_semantics::DurableType::ComptimeType,
+            stable_key(
+                crate::StableDefinitionNamespace::Value,
+                crate::StableDefinitionKind::Function,
+                "Callable",
+            ),
+        );
+        for (name, nominal_kind, nominal_name) in [
+            (
+                "OUT_STRUCT",
+                crate::StableDefinitionKind::Struct,
+                "StructValue",
+            ),
+            ("OUT_ENUM", crate::StableDefinitionKind::Enum, "EnumValue"),
+        ] {
+            let Value::ConstResolution(ConstResolutionProjection::Value {
+                value,
+                ty,
+                dependencies,
+                ..
+            }) = query(name)
+            else {
+                panic!("expected a durable nominal projection for {name}");
+            };
+            let nominal_key = stable_key(
+                crate::StableDefinitionNamespace::Type,
+                nominal_kind,
+                nominal_name,
+            );
+            assert_eq!(
+                *value,
+                crate::durable_semantics::DurableConstValue::Type(
+                    crate::durable_semantics::DurableType::Nominal(nominal_key.clone())
+                )
+            );
+            assert_eq!(ty, crate::durable_semantics::DurableType::ComptimeType);
+            assert_eq!(dependencies.len(), 1);
+            assert_eq!(dependencies[0].source, identity(name));
+            assert_eq!(
+                dependencies[0].kind,
+                rue_air::DeclarationTypeDependencyKind::Body
+            );
+            assert_eq!(
+                dependencies[0].target,
+                SemanticDeclarationDependencyTarget::NamedValue(nominal_key)
+            );
+        }
+        assert_value(
+            "OUT_CHAIN",
+            crate::durable_semantics::DurableConstValue::Integer(5),
+            crate::durable_semantics::DurableType::I32,
+            stable_key(
+                crate::StableDefinitionNamespace::Value,
+                crate::StableDefinitionKind::ValueConst,
+                "SOURCE",
+            ),
+        );
+        let Value::ConstResolution(ConstResolutionProjection::Value {
+            value,
+            ty,
+            dependencies,
+            ..
+        }) = query("OUT_LOCAL")
+        else {
+            panic!("expected a local shadowing projection");
+        };
+        assert_eq!(
+            *value,
+            crate::durable_semantics::DurableConstValue::Integer(9)
+        );
+        assert_eq!(ty, crate::durable_semantics::DurableType::I32);
+        assert!(
+            dependencies.is_empty(),
+            "locals must not become named-value dependencies"
+        );
+        let undefined = format!("{:?}", query("OUT_UNDEFINED"));
+        assert!(undefined.contains("undefined constant"), "{undefined}");
+    }
+
+    #[test]
+    fn durable_named_value_projection_preserves_real_module_binding_identity() {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Category;
+        use crate::semantic_query_nucleus::{
+            ConstResolutionProjection, SemanticNucleusKey as Key, SemanticNucleusValue as Value,
+        };
+
+        let context =
+            ImportDiscoveryContext::new(902, "/project", Some("/sdk"), "test-policy").unwrap();
+        let mut assembler = DiscoverySourceAssembler::new(
+            context.clone(),
+            "/project/main.rue",
+            "/project/main.rue",
+            PhysicalFileIdentity::new(1, 1),
+            FileMetadataFingerprint::new(1, 2, 3),
+            Arc::new(
+                "const M = @import(\"dep.rue\");\
+                 const OUT_MODULE = M;"
+                    .to_owned(),
+            ),
+        )
+        .unwrap();
+        assembler
+            .add_explicit(
+                "/project/dep.rue",
+                "/project/dep.rue",
+                PhysicalFileIdentity::new(2, 1),
+                FileMetadataFingerprint::new(4, 5, 6),
+                Arc::new("const INNER: i32 = 1;".to_owned()),
+            )
+            .unwrap();
+        let mut database = RevisionedQueryDatabase::default();
+        let (snapshot, reads, import_revision, plan) =
+            begin_database_plan(&mut database, &mut assembler, context);
+        let import_revision =
+            publish_manifest_observations(&mut database, &snapshot, reads, &plan, import_revision);
+        let revision = Revision::new(
+            import_revision.revision_id,
+            import_revision.compatibility_token,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let declaration = declaration_candidate(
+            &database,
+            revision,
+            &module,
+            Category::ConstCandidate,
+            "OUT_MODULE",
+        );
+        let Value::ConstResolution(ConstResolutionProjection::ModuleBinding { key, target }) =
+            request_semantic_nucleus(
+                &database,
+                revision,
+                Key::ConstResolution(crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
+                    declaration,
+                    configuration: semantic_configuration(),
+                }),
+            )
+        else {
+            panic!("expected a real imported module binding projection");
+        };
+        assert_eq!(
+            key,
+            crate::StableDefinitionKey::from_stable_parts(
+                module,
+                crate::StableDefinitionNamespace::Value,
+                crate::StableDefinitionKind::ModuleBinding,
+                "OUT_MODULE",
+                None,
+            )
+        );
+        assert_eq!(target, ModuleId::from_logical_path("dep.rue").unwrap());
     }
 
     #[test]


### PR DESCRIPTION
Relates to RUE-1774

This staged interpreter-convergence slice moves durable identifier policy behind one semantic authority operation while leaving both evaluator roots unchanged.

- preserves locals-first lookup and Const → Function → Struct → Enum resolution
- returns exact typed value, module, function, and nominal projections
- publishes only the direct Body/NamedValue dependency
- removes evaluator-owned candidate/identity/const lookup policy
- adds real-pipeline and API-boundary coverage

Validation:
- scripts/rue unit compiler durable_ (59 passed)
- scripts/rue quick (31 targets passed)
- scripts/rue premerge (200 passed)
- independent adversarial review: SHIP