### PR TITLE
RUE-1774: centralize durable comptime terminals

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -3114,6 +3114,7 @@ fn durable_const_integer_semantics_use_the_shared_kernel() {
 #[test]
 fn durable_comptime_services_are_named_authority_operations() {
     let facade = include_str!("durable_comptime.rs");
+    let database = include_str!("revisioned_query_database.rs");
     let production_facade = facade
         .split("#[cfg(test)]\nmod tests")
         .next()
@@ -3130,6 +3131,16 @@ fn durable_comptime_services_are_named_authority_operations() {
         "DurableComptimeCallTicket",
         "DurableComptimeLifecycleError",
         "DurableComptimeApplicationPolicy",
+        "DurableComptimeDiagnosticSite",
+        "DurableComptimeFailure",
+        "DurableComptimeHostFailure",
+        "into_host_error",
+        "provider_error_as_host",
+        "maximum_depth",
+        "integer_literal_overflow",
+        "arithmetic_overflow",
+        "division_by_zero",
+        "remainder_by_zero",
         "DurableComptimeCallableAdmission",
         "DurableComptimeCallableAdmissionStart",
         "DurableComptimeNamedValueKind",
@@ -3166,6 +3177,84 @@ fn durable_comptime_services_are_named_authority_operations() {
         assert!(
             !facade.contains(forbidden),
             "durable service facade must not become an evaluator: {forbidden}"
+        );
+    }
+    let failure_carrier = production_facade
+        .split("pub(crate) enum DurableComptimeFailure {")
+        .nth(1)
+        .and_then(|source| source.split("}\n\nimpl DurableComptimeFailure").next())
+        .expect("durable failure carrier");
+    for forbidden in [
+        "InstData",
+        "InstRef",
+        "ComptimeFrame",
+        "ComptimeEngine",
+        "Span",
+    ] {
+        assert!(
+            !failure_carrier.contains(forbidden),
+            "durable failure carrier leaked revision/evaluator authority: {forbidden}"
+        );
+    }
+    assert!(failure_carrier.contains("Abort(QueryAbort)"));
+    assert!(failure_carrier.contains("Failure(Box<SemanticNucleusFailure>)"));
+    let terminal_bridge = production_facade
+        .split("/// A revision-independent diagnostic location")
+        .nth(1)
+        .and_then(|source| source.split("/// The ownership-site policy").next())
+        .expect("durable terminal bridge");
+    let bridge_without_future_trap = terminal_bridge.replace(
+        "#[allow(dead_code)] // consumed when the durable AIR host is wired",
+        "",
+    );
+    assert!(
+        !bridge_without_future_trap.contains("allow(dead_code)"),
+        "durable terminal bridge must be live production code except its staged future adapters"
+    );
+    assert!(terminal_bridge.contains("ComptimeHostError::HostFailure"));
+    assert!(terminal_bridge.contains("ComptimeHostError::Abort"));
+    assert_eq!(
+        terminal_bridge
+            .matches("ComptimeHostError::HostFailure(self)")
+            .count(),
+        1,
+        "durable host-failure construction must have one canonical funnel"
+    );
+    assert_eq!(
+        terminal_bridge
+            .matches("ComptimeHostError::Abort(self)")
+            .count(),
+        1,
+        "durable abort construction must have one canonical funnel"
+    );
+    assert!(!database.contains("ComptimeHostError::HostFailure"));
+    assert!(!database.contains("ComptimeHostError::Abort"));
+    for reason in [
+        "division by zero (this operation would panic at runtime)",
+        "remainder by zero (this operation would panic at runtime)",
+    ] {
+        assert_eq!(
+            production_facade.matches(reason).count(),
+            1,
+            "durable arithmetic reason must have one canonical production spelling: {reason}"
+        );
+    }
+    assert!(database.contains(
+        "type EvaluateSemanticConstError = crate::durable_comptime::DurableComptimeFailure;"
+    ));
+    assert!(!database.contains("enum EvaluateSemanticConstError {"));
+    for routed in [
+        "DurableComptimeFailure::maximum_depth(",
+        "DurableComptimeFailure::integer_literal_overflow(",
+        "DurableComptimeFailure::arithmetic_overflow(",
+        "DurableComptimeFailure::division_by_zero()",
+        "DurableComptimeFailure::remainder_by_zero()",
+        "DurableComptimeFailure::provider_error(error)",
+        "DurableComptimeFailure::abort(abort)",
+    ] {
+        assert!(
+            database.contains(routed),
+            "legacy durable evaluator no longer routes {routed} through the canonical bridge"
         );
     }
     assert!(facade.contains("query: crate::semantic_query_nucleus::ComptimeCallQueryKey"));
@@ -3358,7 +3447,6 @@ fn durable_comptime_services_are_named_authority_operations() {
     assert!(consume_at < pop_at && pop_at < context_at && context_at < scope_at);
     assert!(scope_at < known_at && known_at < merge_at);
 
-    let database = include_str!("revisioned_query_database.rs");
     assert_eq!(
         database.matches("SemanticConstEvaluator {").count(),
         2,
@@ -3442,6 +3530,7 @@ fn durable_comptime_services_are_named_authority_operations() {
         .nth(1)
         .and_then(|source| source.split("impl SemanticNucleusTypeProvider<'_>").next())
         .expect("durable evaluator source");
+    assert!(evaluator.contains("EvaluateSemanticConstError::comptime_failure_at("));
     let target_authority = database
         .split("impl crate::durable_comptime::DurableComptimeSemanticAuthority")
         .nth(1)

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -24,6 +24,226 @@ type SemanticDeclarationDependency = crate::semantic_query_nucleus::SemanticDecl
 type DeferredOwnershipGate = crate::semantic_query_nucleus::DeferredOwnershipGate;
 type DeferredOwnershipApplication = crate::semantic_query_nucleus::DeferredOwnershipApplication;
 
+/// A revision-independent diagnostic location owned by the declaration that
+/// produced a durable comptime fact.  Durable failures must carry this
+/// semantic location rather than borrowing a caller span (or an instruction
+/// reference) from the revision that happened to observe them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DurableComptimeDiagnosticSite {
+    producer: DeclarationCandidateKey,
+    start: u32,
+    end: u32,
+}
+
+impl DurableComptimeDiagnosticSite {
+    pub(crate) fn new(producer: DeclarationCandidateKey, start: u32, end: u32) -> Self {
+        Self {
+            producer,
+            start,
+            end,
+        }
+    }
+}
+
+/// The durable boundary distinguishes query control from a committed
+/// semantic failure.  In particular, cancellation and missing inputs remain
+/// aborts and are never converted into diagnostics or memoized failures.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DurableComptimeFailure {
+    Abort(QueryAbort),
+    Failure(Box<SemanticNucleusFailure>),
+}
+
+/// The AIR error channel has one failure type for both tagged branches.  This
+/// opaque payload keeps query aborts and semantic failures distinct; the
+/// canonical constructors below always pair each payload with its matching
+/// AIR outer tag.  AIR's public error enum still permits arbitrary payloads in
+/// principle, so this guarantee is enforced by this durable funnel rather
+/// than claimed as a property of the AIR type itself.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DurableComptimeHostFailure(DurableComptimeHostFailureKind);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DurableComptimeHostFailureKind {
+    Semantic(Box<SemanticNucleusFailure>),
+    QueryAbort(QueryAbort),
+}
+
+impl DurableComptimeHostFailure {
+    fn semantic(failure: Box<SemanticNucleusFailure>) -> Self {
+        Self(DurableComptimeHostFailureKind::Semantic(failure))
+    }
+
+    fn query_abort(abort: QueryAbort) -> Self {
+        Self(DurableComptimeHostFailureKind::QueryAbort(abort))
+    }
+
+    fn into_host_error(self) -> rue_air::ComptimeHostError<Self> {
+        match &self.0 {
+            DurableComptimeHostFailureKind::Semantic(_) => {
+                rue_air::ComptimeHostError::HostFailure(self)
+            }
+            DurableComptimeHostFailureKind::QueryAbort(_) => {
+                rue_air::ComptimeHostError::Abort(self)
+            }
+        }
+    }
+
+    fn into_legacy_failure(self) -> DurableComptimeFailure {
+        match self.0 {
+            DurableComptimeHostFailureKind::Semantic(failure) => {
+                DurableComptimeFailure::Failure(failure)
+            }
+            DurableComptimeHostFailureKind::QueryAbort(_) => {
+                unreachable!("canonical host failure carried a query abort")
+            }
+        }
+    }
+
+    fn into_legacy_abort(self) -> DurableComptimeFailure {
+        match self.0 {
+            DurableComptimeHostFailureKind::QueryAbort(abort) => {
+                DurableComptimeFailure::Abort(abort)
+            }
+            DurableComptimeHostFailureKind::Semantic(_) => {
+                unreachable!("canonical host abort carried a semantic failure")
+            }
+        }
+    }
+}
+
+impl DurableComptimeFailure {
+    pub(crate) fn failure(failure: SemanticNucleusFailure) -> Self {
+        Self::Failure(Box::new(failure))
+    }
+
+    pub(crate) fn abort(abort: QueryAbort) -> Self {
+        Self::Abort(abort)
+    }
+
+    pub(crate) fn resolution(message: impl Into<Arc<str>>) -> Self {
+        Self::failure(SemanticNucleusFailure::Resolution(message.into()))
+    }
+
+    pub(crate) fn comptime_failure(reason: impl Into<String>) -> Self {
+        Self::failure(SemanticNucleusFailure::Diagnostic(
+            rue_error::ErrorKind::ComptimeEvaluationFailed {
+                reason: reason.into(),
+            },
+        ))
+    }
+
+    pub(crate) fn maximum_depth(name: &str, maximum: usize) -> Self {
+        Self::comptime_failure(format!(
+            "specialization of '{name}' exceeded the maximum nesting depth ({maximum}); is a comptime-recursive function missing a compile-time-known base case, or a generic function recursively instantiating itself with new types?"
+        ))
+    }
+
+    pub(crate) fn integer_literal_overflow(type_name: &str, value: i128) -> Self {
+        Self::comptime_failure(format!(
+            "integer overflow evaluating constant at type {type_name}: value {value} is out of range for type {type_name}; {value} does not fit in {type_name} (this operation would panic at runtime)"
+        ))
+    }
+
+    pub(crate) fn arithmetic_overflow(type_name: &str, operation: &str, detail: &str) -> Self {
+        Self::comptime_failure(format!(
+            "integer overflow evaluating {operation} at type {type_name}: {detail} (this operation would panic at runtime)"
+        ))
+    }
+
+    pub(crate) fn division_by_zero() -> Self {
+        Self::arithmetic_trap_failure("division by zero")
+    }
+
+    pub(crate) fn remainder_by_zero() -> Self {
+        Self::arithmetic_trap_failure("remainder by zero")
+    }
+
+    fn arithmetic_trap_failure(operation: &str) -> Self {
+        Self::comptime_failure(
+            arithmetic_trap_reason(operation).expect("unsupported durable arithmetic trap"),
+        )
+    }
+
+    /// Construct a diagnostic anchored to the owning declaration.  The site
+    /// is explicit so nested/foreign evaluation cannot accidentally label the
+    /// failure with the ambient caller's span.
+    pub(crate) fn comptime_failure_at(
+        site: &DurableComptimeDiagnosticSite,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self::diagnostic_at_site(site, reason.into())
+    }
+
+    fn diagnostic_at_site(site: &DurableComptimeDiagnosticSite, reason: String) -> Self {
+        Self::failure(SemanticNucleusFailure::DiagnosticAtProducerRange {
+            kind: rue_error::ErrorKind::ComptimeEvaluationFailed { reason },
+            producer: site.producer.clone(),
+            start: site.start,
+            end: site.end,
+        })
+    }
+
+    /// Adapt a supported AIR arithmetic trap using the owning declaration and
+    /// the trap's own span.  Unsupported operations remain unsupported rather
+    /// than acquiring a new diagnostic spelling.
+    #[allow(dead_code)] // consumed when the durable AIR host is wired
+    pub(crate) fn trap_at(
+        producer: DeclarationCandidateKey,
+        trap: rue_air::ComptimeTrap,
+    ) -> Option<Self> {
+        let site = DurableComptimeDiagnosticSite::new(producer, trap.span.start, trap.span.end);
+        let reason = arithmetic_trap_reason(trap.operation)?;
+        Some(Self::diagnostic_at_site(&site, reason.to_owned()))
+    }
+
+    /// Adapt a durable terminal directly for the future AIR host.  Provider
+    /// errors use `provider_error_as_host` instead, so this seam never creates
+    /// a durable failure only to convert it back into a provider error.
+    #[allow(dead_code)] // consumed when the durable AIR host is wired
+    pub(crate) fn into_host_error(self) -> rue_air::ComptimeHostError<DurableComptimeHostFailure> {
+        match self {
+            Self::Failure(failure) => {
+                DurableComptimeHostFailure::semantic(failure).into_host_error()
+            }
+            Self::Abort(abort) => DurableComptimeHostFailure::query_abort(abort).into_host_error(),
+        }
+    }
+
+    /// Build the AIR error directly from a provider result.  This is the
+    /// future host funnel; the legacy adapter below only unwraps its matching
+    /// outer channel and never normalizes crossed tags.
+    pub(crate) fn provider_error_as_host(
+        error: rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+    ) -> rue_air::ComptimeHostError<DurableComptimeHostFailure> {
+        match error {
+            rue_air::SemanticProviderError::Abort(abort) => {
+                DurableComptimeHostFailure::query_abort(abort).into_host_error()
+            }
+            rue_air::SemanticProviderError::Failure(failure) => {
+                DurableComptimeHostFailure::semantic(Box::new(failure)).into_host_error()
+            }
+        }
+    }
+
+    pub(crate) fn provider_error(
+        error: rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+    ) -> Self {
+        match Self::provider_error_as_host(error) {
+            rue_air::ComptimeHostError::Abort(payload) => payload.into_legacy_abort(),
+            rue_air::ComptimeHostError::HostFailure(payload) => payload.into_legacy_failure(),
+        }
+    }
+}
+
+fn arithmetic_trap_reason(operation: &str) -> Option<&'static str> {
+    match operation {
+        "division by zero" => Some("division by zero (this operation would panic at runtime)"),
+        "remainder by zero" => Some("remainder by zero (this operation would panic at runtime)"),
+        _ => None,
+    }
+}
+
 /// The ownership-site policy is issued with an admitted call rather than
 /// inferred while finishing it. Expression calls may attribute still-deferred
 /// gates to their parent call; structured type calls deliberately preserve
@@ -3042,5 +3262,212 @@ mod effect_lifecycle_tests {
             )
             .unwrap();
         assert!(lifecycle.complete_known().unwrap().is_empty());
+    }
+}
+
+#[cfg(test)]
+mod terminal_adapter_tests {
+    use super::*;
+
+    fn site(name: &str, start: u32, end: u32) -> DurableComptimeDiagnosticSite {
+        DurableComptimeDiagnosticSite::new(
+            DeclarationCandidateKey {
+                module: ModuleId::from_validated_canonical("terminal-tests"),
+                category:
+                    crate::declaration_candidate::DeclarationCandidateCategory::ConstCandidate,
+                name: Arc::from(name),
+                owner: None,
+                duplicate_discriminator: 0,
+            },
+            start,
+            end,
+        )
+    }
+
+    #[test]
+    fn durable_failure_preserves_query_control_and_domain_channels() {
+        let aborts = [
+            QueryAbort::Canceled,
+            QueryAbort::Cycle(Arc::from([])),
+            QueryAbort::ForeignRuntime,
+            QueryAbort::UnpublishedRevision(rue_query::Revision::new(7, 8)),
+            QueryAbort::MissingInput(rue_query::InputIdentity::new("terminal", "missing")),
+        ];
+        for abort in aborts {
+            assert_eq!(
+                DurableComptimeFailure::abort(abort.clone()),
+                DurableComptimeFailure::Abort(abort),
+            );
+        }
+
+        let failure = DurableComptimeFailure::resolution(Arc::<str>::from("not ready"));
+        assert!(matches!(
+            failure,
+            DurableComptimeFailure::Failure(value)
+                if matches!(*value, SemanticNucleusFailure::Resolution(ref message) if message.as_ref() == "not ready")
+        ));
+
+        let provider =
+            DurableComptimeFailure::provider_error(rue_air::SemanticProviderError::Failure(
+                SemanticNucleusFailure::Resolution(Arc::from("provider failure")),
+            ));
+        assert!(matches!(
+            provider,
+            DurableComptimeFailure::Failure(value)
+                if matches!(*value, SemanticNucleusFailure::Resolution(ref message) if message.as_ref() == "provider failure")
+        ));
+
+        assert!(matches!(
+            DurableComptimeFailure::provider_error_as_host(rue_air::SemanticProviderError::Abort(
+                QueryAbort::Canceled
+            )),
+            rue_air::ComptimeHostError::Abort(DurableComptimeHostFailure(
+                DurableComptimeHostFailureKind::QueryAbort(QueryAbort::Canceled)
+            ))
+        ));
+        assert!(matches!(
+            DurableComptimeFailure::provider_error_as_host(
+                rue_air::SemanticProviderError::Failure(SemanticNucleusFailure::Resolution(
+                    Arc::from("host failure")
+                ))
+            ),
+            rue_air::ComptimeHostError::HostFailure(DurableComptimeHostFailure(
+                DurableComptimeHostFailureKind::Semantic(value)
+            ))
+                if matches!(*value, SemanticNucleusFailure::Resolution(ref message) if message.as_ref() == "host failure")
+        ));
+
+        assert!(matches!(
+            DurableComptimeFailure::provider_error_as_host(rue_air::SemanticProviderError::Abort(
+                QueryAbort::Canceled
+            )),
+            rue_air::ComptimeHostError::Abort(DurableComptimeHostFailure(
+                DurableComptimeHostFailureKind::QueryAbort(QueryAbort::Canceled)
+            ))
+        ));
+        assert!(matches!(
+            DurableComptimeFailure::provider_error_as_host(
+                rue_air::SemanticProviderError::Failure(SemanticNucleusFailure::Resolution(
+                    Arc::from("provider failure")
+                ))
+            ),
+            rue_air::ComptimeHostError::HostFailure(DurableComptimeHostFailure(
+                DurableComptimeHostFailureKind::Semantic(value)
+            ))
+                if matches!(value.as_ref(), SemanticNucleusFailure::Resolution(actual) if actual.as_ref() == "provider failure")
+        ));
+        assert!(matches!(
+            DurableComptimeFailure::abort(QueryAbort::Canceled).into_host_error(),
+            rue_air::ComptimeHostError::Abort(DurableComptimeHostFailure(
+                DurableComptimeHostFailureKind::QueryAbort(QueryAbort::Canceled)
+            ))
+        ));
+    }
+
+    #[test]
+    fn named_diagnostic_constructors_preserve_exact_legacy_text() {
+        let cases = [
+            (
+                DurableComptimeFailure::maximum_depth(
+                    "count",
+                    rue_air::specialize::MAX_COMPTIME_CALL_DEPTH,
+                ),
+                format!(
+                    "specialization of 'count' exceeded the maximum nesting depth ({}); is a comptime-recursive function missing a compile-time-known base case, or a generic function recursively instantiating itself with new types?",
+                    rue_air::specialize::MAX_COMPTIME_CALL_DEPTH,
+                ),
+            ),
+            (
+                DurableComptimeFailure::integer_literal_overflow("i8", 128),
+                "integer overflow evaluating constant at type i8: value 128 is out of range for type i8; 128 does not fit in i8 (this operation would panic at runtime)".to_owned(),
+            ),
+            (
+                DurableComptimeFailure::arithmetic_overflow(
+                    "i8",
+                    "addition",
+                    "value 128 is out of range for type i8; 128 does not fit in i8",
+                ),
+                "integer overflow evaluating addition at type i8: value 128 is out of range for type i8; 128 does not fit in i8 (this operation would panic at runtime)".to_owned(),
+            ),
+            (
+                DurableComptimeFailure::division_by_zero(),
+                "division by zero (this operation would panic at runtime)".to_owned(),
+            ),
+            (
+                DurableComptimeFailure::remainder_by_zero(),
+                "remainder by zero (this operation would panic at runtime)".to_owned(),
+            ),
+        ];
+        for (failure, expected) in cases {
+            let DurableComptimeFailure::Failure(value) = failure else {
+                panic!("durable diagnostic must remain a domain failure");
+            };
+            let SemanticNucleusFailure::Diagnostic(
+                rue_error::ErrorKind::ComptimeEvaluationFailed { reason: actual },
+            ) = *value
+            else {
+                panic!("durable diagnostic has the wrong error channel");
+            };
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn stable_trap_site_uses_trap_range_and_distinguishes_colliding_owners() {
+        let root = site("root", 10, 20);
+        let nested = site("nested", 100, 120);
+        let trap = |operation| rue_air::ComptimeTrap {
+            operation,
+            span: rue_span::Span::new(999, 1000),
+        };
+        let root_failure =
+            DurableComptimeFailure::trap_at(root.producer.clone(), trap("division by zero"))
+                .expect("division trap is supported");
+        let nested_failure =
+            DurableComptimeFailure::trap_at(nested.producer.clone(), trap("division by zero"))
+                .expect("division trap is supported");
+        assert!(matches!(
+            root_failure,
+            DurableComptimeFailure::Failure(value)
+                if matches!(*value, SemanticNucleusFailure::DiagnosticAtProducerRange {
+                    ref producer, start: 999, end: 1000, ..
+                } if producer == &root.producer)
+        ));
+        assert!(matches!(
+            nested_failure,
+            DurableComptimeFailure::Failure(value)
+                if matches!(*value, SemanticNucleusFailure::DiagnosticAtProducerRange {
+                    ref producer, start: 999, end: 1000, ..
+                } if producer == &nested.producer)
+        ));
+        let remainder =
+            DurableComptimeFailure::trap_at(nested.producer.clone(), trap("remainder by zero"))
+                .expect("remainder trap is supported");
+        assert!(matches!(
+            remainder,
+            DurableComptimeFailure::Failure(value)
+                if matches!(*value, SemanticNucleusFailure::DiagnosticAtProducerRange {
+                    ref producer,
+                    kind: rue_error::ErrorKind::ComptimeEvaluationFailed { ref reason },
+                    start: 999, end: 1000, ..
+                } if producer == &nested.producer && reason == "remainder by zero (this operation would panic at runtime)"
+            )
+        ));
+        assert!(DurableComptimeFailure::trap_at(nested.producer.clone(), trap("other")).is_none());
+        assert_eq!((root.start, root.end), (10, 20));
+        assert_eq!((nested.start, nested.end), (100, 120));
+    }
+
+    #[test]
+    fn stable_site_constructor_keeps_explicit_non_trap_diagnostics() {
+        let nested = site("nested", 100, 120);
+        let failure = DurableComptimeFailure::comptime_failure_at(&nested, "foreign failure");
+        assert!(matches!(
+            failure,
+            DurableComptimeFailure::Failure(value)
+                if matches!(*value, SemanticNucleusFailure::DiagnosticAtProducerRange {
+                    ref producer, start: 100, end: 120, ..
+                } if producer == &nested.producer)
+        ));
     }
 }

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -4048,16 +4048,7 @@ impl LinearOwnershipFact {
     }
 }
 
-enum EvaluateSemanticConstError {
-    Abort(QueryAbort),
-    Failure(Box<crate::semantic_query_nucleus::SemanticNucleusFailure>),
-}
-
-impl EvaluateSemanticConstError {
-    fn failure(failure: crate::semantic_query_nucleus::SemanticNucleusFailure) -> Self {
-        Self::Failure(Box::new(failure))
-    }
-}
+type EvaluateSemanticConstError = crate::durable_comptime::DurableComptimeFailure;
 
 fn durable_type_diagnostic_name(ty: &crate::durable_semantics::DurableType) -> String {
     use crate::durable_semantics::DurableType as T;
@@ -7474,10 +7465,12 @@ impl SemanticComptimeCallDepthGuard {
         SEMANTIC_COMPTIME_CALL_DEPTH.with(|depth| {
             let current = depth.get();
             if current >= SEMANTIC_COMPTIME_MAX_DEPTH {
-                return Err(SemanticConstEvaluator::comptime_failure_value(format!(
-                    "specialization of '{name}' exceeded the maximum nesting depth ({}); is a comptime-recursive function missing a compile-time-known base case, or a generic function recursively instantiating itself with new types?",
-                    SEMANTIC_COMPTIME_MAX_DEPTH,
-                )));
+                return Err(
+                    crate::durable_comptime::DurableComptimeFailure::maximum_depth(
+                        name,
+                        SEMANTIC_COMPTIME_MAX_DEPTH,
+                    ),
+                );
             }
             depth.set(current + 1);
             Ok(Self(current))
@@ -7497,19 +7490,7 @@ impl SemanticConstEvaluator<'_, '_> {
     }
 
     fn failure_value(message: impl Into<Arc<str>>) -> EvaluateSemanticConstError {
-        EvaluateSemanticConstError::failure(
-            crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(message.into()),
-        )
-    }
-
-    fn comptime_failure_value(reason: impl Into<String>) -> EvaluateSemanticConstError {
-        EvaluateSemanticConstError::failure(
-            crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
-                rue_error::ErrorKind::ComptimeEvaluationFailed {
-                    reason: reason.into(),
-                },
-            ),
-        )
+        crate::durable_comptime::DurableComptimeFailure::resolution(message)
     }
 
     fn provider_error(
@@ -7518,20 +7499,17 @@ impl SemanticConstEvaluator<'_, '_> {
             crate::semantic_query_nucleus::SemanticNucleusFailure,
         >,
     ) -> EvaluateSemanticConstError {
-        match error {
-            rue_air::SemanticProviderError::Abort(abort) => Self::abort(abort),
-            rue_air::SemanticProviderError::Failure(failure) => Self::domain_failure(failure),
-        }
+        crate::durable_comptime::DurableComptimeFailure::provider_error(error)
     }
 
     fn abort(abort: QueryAbort) -> EvaluateSemanticConstError {
-        EvaluateSemanticConstError::Abort(abort)
+        crate::durable_comptime::DurableComptimeFailure::abort(abort)
     }
 
     fn domain_failure(
         failure: crate::semantic_query_nucleus::SemanticNucleusFailure,
     ) -> EvaluateSemanticConstError {
-        EvaluateSemanticConstError::failure(failure)
+        crate::durable_comptime::DurableComptimeFailure::failure(failure)
     }
 
     fn symbol(&self, symbol: &lasso::Spur) -> Arc<str> {
@@ -7655,9 +7633,11 @@ impl SemanticConstEvaluator<'_, '_> {
                 _ => unreachable!(),
             };
             let type_name = durable_type_diagnostic_name(ty);
-            Err(Self::comptime_failure_value(format!(
-                "integer overflow evaluating constant at type {type_name}: value {value} is out of range for type {type_name}; {value} does not fit in {type_name} (this operation would panic at runtime)",
-            )))
+            Err(
+                crate::durable_comptime::DurableComptimeFailure::integer_literal_overflow(
+                    &type_name, value,
+                ),
+            )
         }
     }
 
@@ -7676,9 +7656,11 @@ impl SemanticConstEvaluator<'_, '_> {
                     )
                 },
             );
-            return Err(Self::comptime_failure_value(format!(
-                "integer overflow evaluating {operation} at type {type_name}: {detail} (this operation would panic at runtime)",
-            )));
+            return Err(
+                crate::durable_comptime::DurableComptimeFailure::arithmetic_overflow(
+                    &type_name, operation, &detail,
+                ),
+            );
         };
         Ok(value)
     }
@@ -7767,14 +7749,10 @@ impl SemanticConstEvaluator<'_, '_> {
                 "multiplication",
             )?),
             O::Div if right == 0 => {
-                return Err(Self::comptime_failure_value(
-                    "division by zero (this operation would panic at runtime)",
-                ));
+                return Err(crate::durable_comptime::DurableComptimeFailure::division_by_zero());
             }
             O::Mod if right == 0 => {
-                return Err(Self::comptime_failure_value(
-                    "remainder by zero (this operation would panic at runtime)",
-                ));
+                return Err(crate::durable_comptime::DurableComptimeFailure::remainder_by_zero());
             }
             O::Div => V::Integer(Self::checked_integer_result(
                 &operand_ty,
@@ -8326,22 +8304,21 @@ impl SemanticConstEvaluator<'_, '_> {
                                     "type",
                                 )
                         }) {
-                            return Err(EvaluateSemanticConstError::failure(
-                                crate::semantic_query_nucleus::SemanticNucleusFailure::DiagnosticAtProducerRange {
-                                    kind: rue_error::ErrorKind::ComptimeEvaluationFailed {
-                                        reason: format!(
-                                            "method '{}' declares its own `comptime` type parameter, \
-                                             which is not yet supported (a method cannot be \
-                                             monomorphized over its own type parameter); \
-                                             move the type parameter to the enclosing type \
-                                             constructor instead",
-                                            semantic_candidate_spelling(symbols, name)
-                                        ),
-                                    },
-                                    producer: producer.clone(),
-                                    start: method.span.start,
-                                    end: method.span.end,
-                                },
+                            let site = crate::durable_comptime::DurableComptimeDiagnosticSite::new(
+                                producer.clone(),
+                                method.span.start,
+                                method.span.end,
+                            );
+                            return Err(EvaluateSemanticConstError::comptime_failure_at(
+                                &site,
+                                format!(
+                                    "method '{}' declares its own `comptime` type parameter, \
+                                         which is not yet supported (a method cannot be \
+                                         monomorphized over its own type parameter); \
+                                         move the type parameter to the enclosing type \
+                                         constructor instead",
+                                    semantic_candidate_spelling(symbols, name)
+                                ),
                             ));
                         }
                         let parameters = rir


### PR DESCRIPTION
Relates to RUE-1774

Centralizes the durable evaluator failure carrier, AIR host failure/abort bridge, producer-relative trap adaptation, and the existing depth and arithmetic diagnostic policy in `durable_comptime`. The legacy evaluator consumes these shared constructors now, while both production evaluator roots and their successful projections remain unchanged.

This is a staged migration slice only: it does not wire a production `ComptimeHost`, cut over either root, change the RIR walker, or expand language semantics.

Validation:
- `scripts/rue unit compiler durable_` (67 passed)
- `scripts/rue quick` (31 targets passed)
- `scripts/rue premerge` (200 passed)
- adversarial architectural review: SHIP