### PR TITLE
RUE-1774: bind comptime calls incrementally

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -148,6 +148,18 @@ fn comptime_generic_contract_has_no_local_lexical_or_call_payloads() {
         );
     }
     assert!(contract.contains("type CallAdmission;"));
+    assert!(contract.contains("type CallBinding;"));
+    assert!(contract.contains("type BoundCall;"));
+    assert!(contract.contains("fn begin_comptime_call_binding("));
+    assert!(contract.contains("fn bind_comptime_call_argument("));
+    assert!(contract.contains("fn finish_comptime_call_binding("));
+    let binding_contract = contract
+        .split("fn begin_comptime_call_binding(")
+        .nth(1)
+        .and_then(|source| source.split("fn finish_comptime_call_binding(").next())
+        .expect("incremental binding contract");
+    assert!(binding_contract.contains("&self"));
+    assert!(!binding_contract.contains("&mut self"));
     assert!(contract.contains("type CompletionTicket;"));
     assert!(!contract.contains("type CompletionTicket: Clone"));
     assert!(!contract.contains("pub completion_ticket"));
@@ -218,7 +230,9 @@ fn comptime_generic_contract_has_no_local_lexical_or_call_payloads() {
     let argument_impl = &production[argument_impl_start..argument_impl_end];
     assert!(argument_impl.contains("fn new("));
     assert!(!argument_impl.contains("pub fn new("));
-    assert!(production.contains("values: &[ComptimeCallArgument<Self::Value>]"));
+    assert!(production.contains("argument: ComptimeCallArgument<Self::Value>"));
+    assert!(production.contains("fn begin_comptime_call_binding("));
+    assert!(production.contains("fn finish_comptime_call_binding("));
     let producer_hook = host_contract
         .split("fn canonical_function_producer(")
         .nth(1)
@@ -313,7 +327,7 @@ fn comptime_generic_contract_has_no_local_lexical_or_call_payloads() {
     );
     assert_eq!(
         production
-            .matches("self.evaluate_call_arguments(&args, env)")
+            .matches("self.evaluate_call_arguments(&args, env, &mut binding, span)")
             .count(),
         2,
         "direct and qualified calls must share argument provenance"
@@ -344,16 +358,30 @@ fn comptime_generic_contract_has_no_local_lexical_or_call_payloads() {
         !ordinary.contains("is_direct_unit_literal"),
         "ordinary hosts must consume provenance, never recover it from RIR"
     );
-    let ordinary_bind_start = ordinary
-        .find("fn bind_comptime_call(")
-        .expect("ordinary call binding implementation");
-    let ordinary_bind_end = ordinary[ordinary_bind_start..]
-        .find("\n    fn ")
-        .map(|offset| ordinary_bind_start + offset)
-        .unwrap_or(ordinary.len());
-    let ordinary_bind = &ordinary[ordinary_bind_start..ordinary_bind_end];
-    assert!(ordinary_bind.contains("argument.value()"));
-    assert!(!ordinary_bind.contains("program_rir"));
+    assert!(ordinary.contains("fn bind_comptime_call_argument("));
+    let ordinary_argument_binding = ordinary
+        .split("fn bind_comptime_call_argument(")
+        .nth(1)
+        .and_then(|source| source.split("\n    fn ").next())
+        .expect("ordinary argument binding implementation");
+    assert!(ordinary_argument_binding.contains("argument.value()"));
+    assert!(!ordinary_argument_binding.contains("program_rir"));
+    assert!(ordinary.contains("type CallBinding = OrdinaryComptimeCallBinding"));
+    assert!(ordinary.contains("type BoundCall = OrdinaryComptimeBoundCall"));
+    let binding_state = ordinary
+        .split("struct OrdinaryComptimeCallBinding")
+        .nth(1)
+        .and_then(|source| {
+            source
+                .split("impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeHost")
+                .next()
+        })
+        .expect("ordinary binding state");
+    assert!(!binding_state.contains("derive(Clone"));
+    assert!(!binding_state.contains("impl Clone"));
+    assert!(production.contains("begin_comptime_call_binding"));
+    assert!(production.contains("bind_comptime_call_argument"));
+    assert!(production.contains("finish_comptime_call_binding"));
     assert!(production.contains("self.frames.push(frame)"));
     assert!(production.contains("self.frames.pop()"));
     assert!(production.contains("ComptimeCallPreparation::Memoized(outcome)"));

--- a/crates/rue-air/src/sema/comptime.rs
+++ b/crates/rue-air/src/sema/comptime.rs
@@ -506,8 +506,11 @@ mod value_domain_tests {
         static CHECKPOINTS: Cell<usize> = const { Cell::new(0) };
         static ABORT_AT_CHECKPOINT: Cell<Option<usize>> = const { Cell::new(None) };
         static CALL_ARGUMENTS: RefCell<Vec<(FakeValue, bool)>> = const { RefCell::new(Vec::new()) };
+        static BINDING_FINISHES: Cell<usize> = const { Cell::new(0) };
+        static PREPARE_CALLS: Cell<usize> = const { Cell::new(0) };
         static ALLOW_MODULE_CALLS: Cell<bool> = const { Cell::new(false) };
         static REJECT_ADMISSION: Cell<bool> = const { Cell::new(false) };
+        static REJECT_BIND_AT: Cell<Option<usize>> = const { Cell::new(None) };
     }
 
     #[derive(Clone, Debug, PartialEq)]
@@ -647,6 +650,14 @@ mod value_domain_tests {
         index: usize,
     }
 
+    struct FakeCallBinding {
+        arguments: Vec<(FakeValue, bool)>,
+    }
+
+    struct FakeBoundCall {
+        arguments: Vec<(FakeValue, bool)>,
+    }
+
     impl super::structured_type_seal::Sealed for FakeStructuredSuspension {}
     impl ComptimeStructuredTypeSuspension for FakeStructuredSuspension {}
 
@@ -682,6 +693,9 @@ mod value_domain_tests {
         CALL_ARGUMENTS.with(|arguments| arguments.borrow_mut().clear());
         ALLOW_MODULE_CALLS.with(|allowed| allowed.set(false));
         REJECT_ADMISSION.with(|rejected| rejected.set(false));
+        REJECT_BIND_AT.with(|rejected| rejected.set(None));
+        BINDING_FINISHES.with(|count| count.set(0));
+        PREPARE_CALLS.with(|count| count.set(0));
     }
 
     impl ComptimeHost for FakeHost {
@@ -694,6 +708,8 @@ mod value_domain_tests {
         type ProgramKey = usize;
         type Failure = FakeFailure;
         type CallAdmission = ();
+        type CallBinding = FakeCallBinding;
+        type BoundCall = FakeBoundCall;
         type CompletionTicket = usize;
         type AnonymousStructId = u32;
         type StructuredTypeSuspension = FakeStructuredSuspension;
@@ -965,32 +981,45 @@ mod value_domain_tests {
             }
             Ok(Some(ComptimeCallAdmission { name, payload: () }))
         }
-        fn bind_comptime_call(
+        fn begin_comptime_call_binding(
             &self,
             _admission: &ComptimeCallAdmission<Self::CallAdmission, Self::Name>,
-            values: &[ComptimeCallArgument<Self::Value>],
+            _argument_count: usize,
             _span: Span,
-        ) -> ComptimeHostResult<
-            Option<(
-                AHashMap<Self::Name, Self::Type>,
-                AHashMap<Self::Name, Self::Value>,
-            )>,
-            Self::Failure,
-        > {
-            CALL_ARGUMENTS.with(|observed| {
-                observed.borrow_mut().extend(
-                    values.iter().map(|argument| {
-                        (argument.value().clone(), argument.is_direct_unit_literal())
-                    }),
-                );
-            });
-            Ok(Some((AHashMap::new(), AHashMap::new())))
+        ) -> ComptimeHostResult<Self::CallBinding, Self::Failure> {
+            Ok(FakeCallBinding {
+                arguments: Vec::new(),
+            })
+        }
+        fn bind_comptime_call_argument(
+            &self,
+            binding: &mut Self::CallBinding,
+            argument: ComptimeCallArgument<Self::Value>,
+            index: usize,
+            _span: Span,
+        ) -> ComptimeHostResult<bool, Self::Failure> {
+            if REJECT_BIND_AT.with(|rejected| rejected.get() == Some(index)) {
+                return Ok(false);
+            }
+            binding
+                .arguments
+                .push((argument.value().clone(), argument.is_direct_unit_literal()));
+            Ok(true)
+        }
+        fn finish_comptime_call_binding(
+            &mut self,
+            _binding: Self::CallBinding,
+            _span: Span,
+        ) -> ComptimeHostResult<Option<Self::BoundCall>, Self::Failure> {
+            BINDING_FINISHES.with(|count| count.set(count.get() + 1));
+            let arguments = _binding.arguments;
+            CALL_ARGUMENTS.with(|observed| observed.borrow_mut().extend(arguments.iter().cloned()));
+            Ok(Some(FakeBoundCall { arguments }))
         }
         fn prepare_comptime_call(
             &mut self,
             admission: ComptimeCallAdmission<Self::CallAdmission, Self::Name>,
-            _types: AHashMap<Self::Name, Self::Type>,
-            _values: AHashMap<Self::Name, Self::Value>,
+            bound: Self::BoundCall,
             _span: Span,
         ) -> ComptimeHostResult<
             Option<
@@ -1007,6 +1036,8 @@ mod value_domain_tests {
             >,
             Self::Failure,
         > {
+            PREPARE_CALLS.with(|count| count.set(count.get() + 1));
+            let _bound_argument_count = bound.arguments.len();
             if matches!(self.finish_outcome, FakeFinishOutcome::AbortFromPrepare) {
                 return Err(ComptimeHostError::Abort(FAKE_FAILURE));
             }
@@ -2977,7 +3008,129 @@ mod value_domain_tests {
         assert_eq!(checkpoint_count(), 2);
         assert_eq!(engine.provenance_classification_count(), 0);
         CALL_ARGUMENTS.with(|observed| assert!(observed.borrow().is_empty()));
+        assert_eq!(BINDING_FINISHES.with(Cell::get), 0);
+        assert_eq!(PREPARE_CALLS.with(Cell::get), 0);
         configure_checkpoint_abort(None);
+    }
+
+    #[test]
+    fn incremental_binding_rejects_before_evaluating_later_arguments() {
+        let interner = lasso::ThreadedRodeo::new();
+        let symbol = interner.get_or_intern("f");
+        let mut editor = rue_rir::RirEditor::new();
+        let first = editor.add_inst(rue_rir::Inst {
+            data: InstData::IntConst(7),
+            span: Span::new(0, 0),
+        });
+        let later_trap = editor.add_inst(rue_rir::Inst {
+            data: InstData::FloatConst {
+                text: interner.get_or_intern("2.0"),
+            },
+            span: Span::new(0, 0),
+        });
+        let call = editor
+            .add_call(
+                symbol,
+                &[
+                    rue_rir::RirCallArg {
+                        value: first,
+                        mode: rue_rir::RirArgMode::Normal,
+                    },
+                    rue_rir::RirCallArg {
+                        value: later_trap,
+                        mode: rue_rir::RirArgMode::Normal,
+                    },
+                ],
+                Span::new(0, 0),
+            )
+            .unwrap();
+        let mut host = FakeHost {
+            programs: vec![editor.finish()],
+            type_symbol: SymbolHandle::new(interner.get_or_intern("T")),
+            constant: None,
+            dependencies: Vec::new(),
+            call_plans: AHashMap::new(),
+            recursive: None,
+            enter_count: 0,
+            finish_outcome: FakeFinishOutcome::Identity,
+            finished: Vec::new(),
+            float_evaluations: Cell::new(0),
+        };
+        clear_call_argument_observations();
+        REJECT_BIND_AT.with(|rejected| rejected.set(Some(0)));
+        configure_checkpoint_abort(None);
+        let mut env = ComptimeEnv::<FakeValue, FakeType, FakeName, FakeFile, FakeIdentity>::new();
+        let result =
+            ComptimeEngine::new(&mut host).evaluate(ComptimeFrame::expression(0, call), &mut env);
+        assert!(matches!(result, ComptimeOutcome::RuntimeDependent));
+        assert_eq!(host.float_evaluations.get(), 0);
+        CALL_ARGUMENTS.with(|observed| assert!(observed.borrow().is_empty()));
+        assert_eq!(BINDING_FINISHES.with(Cell::get), 0);
+        assert_eq!(PREPARE_CALLS.with(Cell::get), 0);
+        clear_call_argument_observations();
+    }
+
+    #[test]
+    fn ordinary_binding_shape_mismatch_does_not_mask_later_terminal() {
+        let interner = lasso::ThreadedRodeo::new();
+        let symbol = interner.get_or_intern("f");
+        let type_symbol = interner.get_or_intern("i32");
+        let mut editor = rue_rir::RirEditor::new();
+        let type_syntax = editor.add_named_type(type_symbol).unwrap();
+        // A type value is deliberately supplied where an ordinary value
+        // parameter would reject it. Ordinary binding stores that shape in
+        // its owned transaction; the later terminal must still win before
+        // finish performs whole-batch validation.
+        let invalid_for_value = editor.add_inst(rue_rir::Inst {
+            data: InstData::TypeConst {
+                type_name: type_syntax,
+            },
+            span: Span::new(0, 0),
+        });
+        let later_terminal = editor.add_inst(rue_rir::Inst {
+            data: InstData::FloatConst {
+                text: interner.get_or_intern("2.0"),
+            },
+            span: Span::new(0, 0),
+        });
+        let call = editor
+            .add_call(
+                symbol,
+                &[
+                    rue_rir::RirCallArg {
+                        value: invalid_for_value,
+                        mode: rue_rir::RirArgMode::Normal,
+                    },
+                    rue_rir::RirCallArg {
+                        value: later_terminal,
+                        mode: rue_rir::RirArgMode::Normal,
+                    },
+                ],
+                Span::new(0, 0),
+            )
+            .unwrap();
+        let mut host = FakeHost {
+            programs: vec![editor.finish()],
+            type_symbol: SymbolHandle::new(type_symbol),
+            constant: None,
+            dependencies: Vec::new(),
+            call_plans: AHashMap::new(),
+            recursive: None,
+            enter_count: 0,
+            finish_outcome: FakeFinishOutcome::Identity,
+            finished: Vec::new(),
+            float_evaluations: Cell::new(0),
+        };
+        clear_call_argument_observations();
+        configure_checkpoint_abort(None);
+        let mut env = ComptimeEnv::<FakeValue, FakeType, FakeName, FakeFile, FakeIdentity>::new();
+        let result =
+            ComptimeEngine::new(&mut host).evaluate(ComptimeFrame::expression(0, call), &mut env);
+        assert!(matches!(result, ComptimeOutcome::HostFailure(FAKE_FAILURE)));
+        assert_eq!(host.float_evaluations.get(), 1);
+        CALL_ARGUMENTS.with(|observed| assert!(observed.borrow().is_empty()));
+        assert_eq!(BINDING_FINISHES.with(Cell::get), 0);
+        assert_eq!(PREPARE_CALLS.with(Cell::get), 0);
     }
 
     #[test]
@@ -3078,6 +3231,8 @@ mod value_domain_tests {
         assert_eq!(terminal_host.float_evaluations.get(), 1);
         assert_eq!(checkpoint_count(), 3);
         CALL_ARGUMENTS.with(|observed| assert!(observed.borrow().is_empty()));
+        assert_eq!(BINDING_FINISHES.with(Cell::get), 0);
+        assert_eq!(PREPARE_CALLS.with(Cell::get), 0);
     }
 
     #[test]
@@ -4220,6 +4375,13 @@ pub trait ComptimeHost {
     type ProgramKey: Clone;
     type Failure;
     type CallAdmission;
+    /// Host-owned, non-replayable binding state. The engine creates one state
+    /// immediately after admission and feeds it source-order arguments before
+    /// evaluating the next child.
+    type CallBinding;
+    /// Opaque, host-owned completed binding. The engine does not reconstruct
+    /// ordered arguments or couple preparation to a map representation.
+    type BoundCall;
     /// Opaque host-owned completion state issued during ordered preparation.
     type CompletionTicket;
     type AnonymousStructId: Clone;
@@ -4418,23 +4580,30 @@ pub trait ComptimeHost {
         Option<ComptimeCallAdmission<Self::CallAdmission, Self::Name>>,
         Self::Failure,
     >;
-    fn bind_comptime_call(
+    fn begin_comptime_call_binding(
         &self,
         admission: &ComptimeCallAdmission<Self::CallAdmission, Self::Name>,
-        values: &[ComptimeCallArgument<Self::Value>],
+        argument_count: usize,
         span: Span,
-    ) -> ComptimeHostResult<
-        Option<(
-            AHashMap<Self::Name, Self::Type>,
-            AHashMap<Self::Name, Self::Value>,
-        )>,
-        Self::Failure,
-    >;
+    ) -> ComptimeHostResult<Self::CallBinding, Self::Failure>;
+    /// Push one already-evaluated argument. `false` rejects the call as
+    /// runtime-dependent and stops the engine before the next child runs.
+    fn bind_comptime_call_argument(
+        &self,
+        binding: &mut Self::CallBinding,
+        argument: ComptimeCallArgument<Self::Value>,
+        index: usize,
+        span: Span,
+    ) -> ComptimeHostResult<bool, Self::Failure>;
+    fn finish_comptime_call_binding(
+        &mut self,
+        binding: Self::CallBinding,
+        span: Span,
+    ) -> ComptimeHostResult<Option<Self::BoundCall>, Self::Failure>;
     fn prepare_comptime_call(
         &mut self,
         admission: ComptimeCallAdmission<Self::CallAdmission, Self::Name>,
-        types: AHashMap<Self::Name, Self::Type>,
-        values: AHashMap<Self::Name, Self::Value>,
+        bound: Self::BoundCall,
         span: Span,
     ) -> ComptimeHostResult<
         Option<
@@ -5072,17 +5241,17 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
         let Some(admission) = admission else {
             return ComptimeOutcome::RuntimeDependent;
         };
-        let values = outcome_value!(self.evaluate_call_arguments(&args, env));
-        let bound = host_value!(self.host.bind_comptime_call(&admission, &values, span));
-        let Some((callee_types, callee_values)) = bound else {
+        let mut binding = host_value!(self.host.begin_comptime_call_binding(
+            &admission,
+            args.len(),
+            span,
+        ));
+        outcome_value!(self.evaluate_call_arguments(&args, env, &mut binding, span));
+        let bound = host_value!(self.host.finish_comptime_call_binding(binding, span));
+        let Some(bound) = bound else {
             return ComptimeOutcome::RuntimeDependent;
         };
-        let preparation = host_value!(self.host.prepare_comptime_call(
-            admission,
-            callee_types,
-            callee_values,
-            span
-        ));
+        let preparation = host_value!(self.host.prepare_comptime_call(admission, bound, span));
         let Some(preparation) = preparation else {
             return ComptimeOutcome::RuntimeDependent;
         };
@@ -5103,9 +5272,10 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
         &mut self,
         args: &[rue_rir::RirCallArg],
         env: &mut ComptimeEnv<'_, H::Value, H::Type, H::Name, H::File, H::CanonicalIdentity>,
-    ) -> ComptimeOutcome<Vec<ComptimeCallArgument<H::Value>>, H::Failure> {
-        let mut values = Vec::with_capacity(args.len());
-        for arg in args {
+        binding: &mut H::CallBinding,
+        span: Span,
+    ) -> ComptimeOutcome<(), H::Failure> {
+        for (index, arg) in args.iter().enumerate() {
             let program = self.program_key();
             let value = outcome_value!(self.eval(arg.value, env));
             let direct_unit_literal = matches!(
@@ -5116,9 +5286,17 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
             {
                 self.provenance_classifications += 1;
             }
-            values.push(ComptimeCallArgument::new(value, direct_unit_literal));
+            let accepted = host_value!(self.host.bind_comptime_call_argument(
+                binding,
+                ComptimeCallArgument::new(value, direct_unit_literal),
+                index,
+                span,
+            ));
+            if !accepted {
+                return ComptimeOutcome::RuntimeDependent;
+            }
         }
-        ComptimeOutcome::Known(values)
+        ComptimeOutcome::Known(())
     }
 
     #[inline(never)]
@@ -5288,17 +5466,17 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
         let Some(admission) = admission else {
             return ComptimeOutcome::RuntimeDependent;
         };
-        let values = outcome_value!(self.evaluate_call_arguments(&args, env));
-        let bound = host_value!(self.host.bind_comptime_call(&admission, &values, span));
-        let Some((callee_types, callee_values)) = bound else {
+        let mut binding = host_value!(self.host.begin_comptime_call_binding(
+            &admission,
+            args.len(),
+            span,
+        ));
+        outcome_value!(self.evaluate_call_arguments(&args, env, &mut binding, span));
+        let bound = host_value!(self.host.finish_comptime_call_binding(binding, span));
+        let Some(bound) = bound else {
             return ComptimeOutcome::RuntimeDependent;
         };
-        let preparation = host_value!(self.host.prepare_comptime_call(
-            admission,
-            callee_types,
-            callee_values,
-            span
-        ));
+        let preparation = host_value!(self.host.prepare_comptime_call(admission, bound, span));
         let Some(preparation) = preparation else {
             return ComptimeOutcome::RuntimeDependent;
         };

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -79,6 +79,63 @@ pub(crate) type ComptimeEnv<'a> = GenericComptimeEnv<
     super::anon_structs::IssuedStableProducerId,
 >;
 
+/// Incremental ordinary-body binding state. It is intentionally not Clone:
+/// each admitted call owns one source-order binding transaction, and the
+/// engine must not replay already validated arguments.
+pub struct OrdinaryComptimeCallBinding {
+    parameter_names: Vec<Spur>,
+    parameter_is_type: Vec<bool>,
+    arguments: Vec<ConstValue>,
+}
+
+/// Completed ordinary binding kept opaque until call preparation. The maps
+/// remain an ordinary-body detail; the AIR engine never reconstructs them.
+pub struct OrdinaryComptimeBoundCall {
+    pub(crate) callee_types: AHashMap<Spur, Type>,
+    pub(crate) callee_values: AHashMap<Spur, ConstValue>,
+}
+
+fn push_ordinary_comptime_call_argument(
+    binding: &mut OrdinaryComptimeCallBinding,
+    value: ConstValue,
+) -> bool {
+    binding.arguments.push(value);
+    true
+}
+
+fn finish_ordinary_comptime_call_binding(
+    binding: OrdinaryComptimeCallBinding,
+) -> Option<OrdinaryComptimeBoundCall> {
+    let mut callee_types = AHashMap::new();
+    let mut callee_values = AHashMap::new();
+    for (index, value) in binding.arguments.into_iter().enumerate() {
+        let is_comptime_type = binding
+            .parameter_is_type
+            .get(index)
+            .copied()
+            .unwrap_or(matches!(value, ConstValue::Type(_)));
+        let parameter_name = binding.parameter_names.get(index).copied()?;
+        match (is_comptime_type, value) {
+            (true, ConstValue::Type(ty)) => {
+                callee_types.insert(parameter_name, ty);
+            }
+            // Ordinary body semantics deliberately ignore direct-unit
+            // provenance: computed Unit remains a valid body type argument.
+            (true, ConstValue::Unit) => {
+                callee_types.insert(parameter_name, Type::UNIT);
+            }
+            (true, _) => return None,
+            (false, value) => {
+                callee_values.insert(parameter_name, value);
+            }
+        }
+    }
+    Some(OrdinaryComptimeBoundCall {
+        callee_types,
+        callee_values,
+    })
+}
+
 impl super::comptime::ComptimeValue for ConstValue {
     type Type = Type;
     fn integer(value: i128) -> Self {
@@ -890,42 +947,43 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         Ok(())
     }
 
-    /// Bind already-evaluated values to an admitted call. This has no body
-    /// lookup or substitution validation, allowing external/provider results
-    /// to remain authoritative before local-only checks run.
-    fn bind_comptime_call(
+    /// Start an incremental binding transaction immediately after admission.
+    fn begin_comptime_call_binding(
         &self,
         admission: &ComptimeCallAdmission<FunctionCallInfo, Spur>,
-        values: &[ComptimeCallArgument<ConstValue>],
+        _argument_count: usize,
         _span: Span,
-    ) -> CompileResult<Option<(AHashMap<Spur, Type>, AHashMap<Spur, ConstValue>)>> {
+    ) -> CompileResult<OrdinaryComptimeCallBinding> {
         let param_data = self.body_param_data(admission.payload.params);
-        let param_names = param_data.names().to_vec();
-        let param_comptime_type = self.comptime_type_param_flags(&admission.payload);
-        let mut callee_types: AHashMap<Spur, Type> = AHashMap::new();
-        let mut callee_values: AHashMap<Spur, ConstValue> = AHashMap::new();
-        for (i, argument) in values.iter().enumerate() {
-            let v = *argument.value();
-            let is_comptime_type = param_comptime_type
-                .get(i)
-                .copied()
-                .unwrap_or(matches!(v, ConstValue::Type(_)));
-            match (is_comptime_type, v) {
-                (true, ConstValue::Type(t)) => {
-                    callee_types.insert(param_names[i], t);
-                }
-                (true, ConstValue::Unit) => {
-                    callee_types.insert(param_names[i], Type::UNIT);
-                }
-                (true, _) => {
-                    return Ok(None);
-                }
-                (false, value) => {
-                    callee_values.insert(param_names[i], value);
-                }
-            }
-        }
-        Ok(Some((callee_types, callee_values)))
+        Ok(OrdinaryComptimeCallBinding {
+            parameter_names: param_data.names().to_vec(),
+            parameter_is_type: self.comptime_type_param_flags(&admission.payload),
+            arguments: Vec::with_capacity(_argument_count),
+        })
+    }
+
+    fn bind_comptime_call_argument(
+        &self,
+        binding: &mut OrdinaryComptimeCallBinding,
+        argument: ComptimeCallArgument<ConstValue>,
+        _index: usize,
+        _span: Span,
+    ) -> CompileResult<bool> {
+        // Ordinary semantics validate the complete batch only at finish. This
+        // owned transaction therefore cannot publish an early mismatch or
+        // let it mask a later child trap/abort.
+        Ok(push_ordinary_comptime_call_argument(
+            binding,
+            *argument.value(),
+        ))
+    }
+
+    fn finish_comptime_call_binding(
+        &mut self,
+        binding: OrdinaryComptimeCallBinding,
+        _span: Span,
+    ) -> CompileResult<Option<OrdinaryComptimeBoundCall>> {
+        Ok(finish_ordinary_comptime_call_binding(binding))
     }
 
     /// Finish an admitted local call after its arguments have been evaluated.
@@ -1107,14 +1165,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             name,
             payload: info,
         };
-        let preparation = <Self as ComptimeHost>::prepare_comptime_call(
-            self,
-            admission,
-            callee_types.clone(),
-            callee_values.clone(),
-            span,
-        )
-        .map_err(super::comptime::ComptimeHostError::into_failure)?;
+        let bound = OrdinaryComptimeBoundCall {
+            callee_types: callee_types.clone(),
+            callee_values: callee_values.clone(),
+        };
+        let preparation =
+            <Self as ComptimeHost>::prepare_comptime_call(self, admission, bound, span)
+                .map_err(super::comptime::ComptimeHostError::into_failure)?;
         let Some(preparation) = preparation else {
             return Ok(None);
         };
@@ -1748,6 +1805,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeHost for OrdinaryBodyEngine<'h, H>
     type ProgramKey = ();
     type Failure = CompileError;
     type CallAdmission = super::info::FunctionCallInfo;
+    type CallBinding = OrdinaryComptimeCallBinding;
+    type BoundCall = OrdinaryComptimeBoundCall;
     type CompletionTicket = ();
     type AnonymousStructId = crate::types::StructId;
     type StructuredTypeSuspension = crate::semantic_type_resolution::ComptimeStructuredTypeJob<
@@ -2144,20 +2203,36 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeHost for OrdinaryBodyEngine<'h, H>
         OrdinaryBodyEngine::admit_comptime_call(self, name, count, modes, env, resolved)
             .map_err(Into::into)
     }
-    fn bind_comptime_call(
+    fn begin_comptime_call_binding(
         &self,
         admission: &ComptimeCallAdmission<FunctionCallInfo, Spur>,
-        values: &[ComptimeCallArgument<ConstValue>],
+        argument_count: usize,
         span: Span,
-    ) -> ComptimeHostResult<Option<(AHashMap<Spur, Type>, AHashMap<Spur, ConstValue>)>, Self::Failure>
-    {
-        OrdinaryBodyEngine::bind_comptime_call(self, admission, values, span).map_err(Into::into)
+    ) -> ComptimeHostResult<Self::CallBinding, Self::Failure> {
+        OrdinaryBodyEngine::begin_comptime_call_binding(self, admission, argument_count, span)
+            .map_err(Into::into)
+    }
+    fn bind_comptime_call_argument(
+        &self,
+        binding: &mut Self::CallBinding,
+        argument: ComptimeCallArgument<ConstValue>,
+        index: usize,
+        span: Span,
+    ) -> ComptimeHostResult<bool, Self::Failure> {
+        OrdinaryBodyEngine::bind_comptime_call_argument(self, binding, argument, index, span)
+            .map_err(Into::into)
+    }
+    fn finish_comptime_call_binding(
+        &mut self,
+        binding: Self::CallBinding,
+        span: Span,
+    ) -> ComptimeHostResult<Option<Self::BoundCall>, Self::Failure> {
+        OrdinaryBodyEngine::finish_comptime_call_binding(self, binding, span).map_err(Into::into)
     }
     fn prepare_comptime_call(
         &mut self,
         admission: ComptimeCallAdmission<FunctionCallInfo, Spur>,
-        types: AHashMap<Spur, Type>,
-        values: AHashMap<Spur, ConstValue>,
+        bound: Self::BoundCall,
         span: Span,
     ) -> ComptimeHostResult<
         Option<
@@ -2177,8 +2252,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeHost for OrdinaryBodyEngine<'h, H>
         if let Some(result) = OrdinaryBodyEngine::reduce_external_comptime_call(
             self,
             admission.name,
-            &types,
-            &values,
+            &bound.callee_types,
+            &bound.callee_values,
             span,
         ) {
             return result
@@ -2190,8 +2265,14 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeHost for OrdinaryBodyEngine<'h, H>
                 })
                 .map_err(Into::into);
         }
-        OrdinaryBodyEngine::prepare_comptime_call(self, admission, types, values, span)
-            .map_err(Into::into)
+        OrdinaryBodyEngine::prepare_comptime_call(
+            self,
+            admission,
+            bound.callee_types,
+            bound.callee_values,
+            span,
+        )
+        .map_err(Into::into)
     }
     fn finish_comptime_call(
         &mut self,
@@ -2265,5 +2346,36 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeHost for OrdinaryBodyEngine<'h, H>
         subst: AHashMap<Spur, Type>,
     ) {
         OrdinaryBodyEngine::set_anon_struct_type_subst(self, *id, subst)
+    }
+}
+
+#[cfg(test)]
+mod binding_tests {
+    use super::*;
+
+    #[test]
+    fn ordinary_binding_stores_invalid_shape_then_rejects_only_at_finish() {
+        let interner = lasso::ThreadedRodeo::new();
+        let value_name = interner.get_or_intern("value");
+        let later_name = interner.get_or_intern("later");
+        let mut binding = OrdinaryComptimeCallBinding {
+            parameter_names: vec![value_name, later_name],
+            parameter_is_type: vec![true, false],
+            arguments: Vec::new(),
+        };
+
+        // Push is the ordinary host's transactional operation: it records
+        // the shape without publishing an early mismatch. The whole batch
+        // policy is applied exactly once by finish.
+        assert!(push_ordinary_comptime_call_argument(
+            &mut binding,
+            ConstValue::Integer(7),
+        ));
+        assert!(push_ordinary_comptime_call_argument(
+            &mut binding,
+            ConstValue::Integer(7),
+        ));
+        assert_eq!(binding.arguments.len(), 2);
+        assert!(finish_ordinary_comptime_call_binding(binding).is_none());
     }
 }

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -374,7 +374,11 @@ mod tests {
         );
         assert!(
             source.contains("fn admit_comptime_call")
-                && source.contains("fn bind_comptime_call")
+                && source.contains("type CallBinding")
+                && source.contains("type BoundCall")
+                && source.contains("fn begin_comptime_call_binding")
+                && source.contains("fn bind_comptime_call_argument")
+                && source.contains("fn finish_comptime_call_binding")
                 && source.contains("fn prepare_comptime_call")
                 && source.contains("fn finish_comptime_call"),
             "call admission, binding, preparation, and completion must be named hooks"
@@ -400,7 +404,9 @@ mod tests {
         }
         for signature in [
             "fn admit_comptime_call(",
-            "fn bind_comptime_call(",
+            "fn begin_comptime_call_binding(",
+            "fn bind_comptime_call_argument(",
+            "fn finish_comptime_call_binding(",
             "fn prepare_comptime_call(",
             "fn resolve_comptime_type_path(",
             "fn resolve_module_comptime_callable(",

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -3042,6 +3042,12 @@ fn durable_const_integer_semantics_use_the_shared_kernel() {
         .nth(1)
         .and_then(|source| source.split("fn durable_int_width(").next())
         .expect("durable integer fit adapter");
+    let durable = include_str!("durable_comptime.rs");
+    let canonical_fits = durable
+        .split("pub(crate) fn durable_const_fits_type(")
+        .nth(1)
+        .and_then(|source| source.split("pub(crate) fn durable_int_width(").next())
+        .expect("canonical durable integer fit kernel");
     let evaluator = source
         .split("impl SemanticConstEvaluator<'_, '_> {")
         .nth(1)
@@ -3059,7 +3065,8 @@ fn durable_const_integer_semantics_use_the_shared_kernel() {
         .expect("durable unary evaluator");
     let arithmetic_policy = format!("{arithmetic}{unary}");
 
-    assert!(fits.contains("integer.fits_i128"));
+    assert!(fits.contains("durable_const_fits_type"));
+    assert!(canonical_fits.contains("integer.fits_i128"));
     for duplicated_fit in [
         "i8::try_from",
         "i16::try_from",
@@ -3336,7 +3343,7 @@ fn durable_comptime_services_are_named_authority_operations() {
         .nth(1)
         .and_then(|source| source.split("}\n\n/// The exact durable projection").next())
         .expect("durable callable admission projection");
-    for forbidden in ["InstData", "InstRef", "Rir", "callback", "evaluate"] {
+    for forbidden in ["InstData", "InstRef", "Rir", "callback", "evaluate("] {
         assert!(
             !callable_authority.contains(forbidden),
             "callable admission projection leaked evaluator authority: {forbidden}"
@@ -3621,6 +3628,112 @@ fn durable_comptime_services_are_named_authority_operations() {
     assert!(
         named_call.contains("let call_ordinal = self.next_call;"),
         "durable call ordinals must be allocated before admission"
+    );
+    let binding_header = production_facade
+        .find("pub(crate) struct DurableComptimeBinding {")
+        .and_then(|start| production_facade[..start].rfind("#[derive("))
+        .expect("durable binding derive header");
+    let binding_kernel = production_facade
+        .get(binding_header..)
+        .and_then(|source| {
+            source
+                .split("/// Match one already-evaluated durable argument")
+                .next()
+        })
+        .expect("durable incremental binding kernel");
+    let binding_start = production_facade
+        .find("pub(crate) fn bind_durable_comptime_argument(")
+        .expect("durable binding function");
+    let binding_policy = production_facade
+        .get(binding_start..)
+        .and_then(|source| source.split("/// The exact durable projection").next())
+        .expect("durable incremental binding policy");
+    let value_fit_kernel = production_facade
+        .split("pub(crate) fn durable_value_fit_failure(")
+        .nth(1)
+        .and_then(|source| source.split("pub(crate) fn durable_int_width").next())
+        .expect("durable value-fit kernel");
+    assert!(
+        !binding_kernel.contains("Clone")
+            && !production_facade.contains("impl Clone for DurableComptimeBinding"),
+        "durable binding state must remain non-Clone"
+    );
+    for required in ["type_arguments", "value_arguments"] {
+        assert!(
+            binding_kernel.contains(required),
+            "durable binding kernel missing {required}"
+        );
+    }
+    for forbidden in ["InstData", "InstRef", "Rir", "ComptimeEngine", "callback"] {
+        assert!(
+            !binding_kernel.contains(forbidden),
+            "durable binding kernel leaked evaluator authority: {forbidden}"
+        );
+        assert!(
+            !binding_policy.contains(forbidden),
+            "durable binding policy leaked evaluator authority: {forbidden}"
+        );
+        assert!(
+            !value_fit_kernel.contains(forbidden),
+            "durable value-fit kernel leaked evaluator authority: {forbidden}"
+        );
+    }
+    for required in [
+        "direct_unit_literal",
+        "substitute_durable_generics",
+        "durable_type_diagnostic_name",
+    ] {
+        assert!(
+            binding_policy.contains(required),
+            "durable binding policy missing {required}"
+        );
+    }
+    for required in [
+        "DurableComptimeValueFitFailure",
+        "durable_const_fits_type",
+        "durable_type_diagnostic_name",
+    ] {
+        assert!(
+            value_fit_kernel.contains(required),
+            "durable value-fit kernel missing {required}"
+        );
+    }
+    for forbidden in [
+        "DurableComptimeCallLifecycle",
+        "DurableComptimeEffects",
+        "DurableComptimeServices",
+        "QueryAbort",
+        "SemanticConstEvaluator",
+    ] {
+        assert!(
+            !binding_policy.contains(forbidden),
+            "durable binding policy gained query/effect authority: {forbidden}"
+        );
+    }
+    let binding_calls = named_call
+        .matches("bind_durable_comptime_argument(")
+        .count();
+    assert_eq!(
+        binding_calls, 2,
+        "durable argument binding must route both parameter paths through one kernel"
+    );
+    let first_eval = named_call
+        .find("let evaluated = self.eval(argument.value)?")
+        .expect("durable call evaluates each argument before binding");
+    let first_bind = named_call
+        .find("bind_durable_comptime_argument(")
+        .expect("durable call uses incremental binding kernel");
+    assert!(first_eval < first_bind);
+    let structured_reducer = database
+        .split("fn reduce_comptime_call(")
+        .nth(1)
+        .and_then(|source| source.split("fn resolve_value_argument(").next())
+        .expect("durable structured comptime reducer");
+    assert!(structured_reducer.contains("durable_value_fit_failure("));
+    assert_eq!(
+        database.matches("durable_value_fit_failure(").count(),
+        1,
+        "durable value-fit policy must have one structured-reducer consumer"
     );
     assert!(evaluator.contains(".resolve_import(&site)"));
     let named_value = evaluator

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -1084,6 +1084,334 @@ pub(crate) struct DurableComptimeCallableAdmission {
     pub(crate) shell_parameters: Arc<[crate::declaration_candidate::DeclarationParameterHeader]>,
 }
 
+/// Convert the canonical type-instance representation into the durable type
+/// domain used by call binding. This is kept beside the binding policy so
+/// diagnostics and substitution never acquire a second local conversion.
+pub(crate) fn durable_type_from_instance_key(
+    value: &crate::TypeInstanceKey,
+) -> Option<DurableType> {
+    use crate::TypeInstanceKey as T;
+    use crate::durable_semantics::DurableType as D;
+    Some(match value {
+        T::I8 => D::I8,
+        T::I16 => D::I16,
+        T::I32 => D::I32,
+        T::I64 => D::I64,
+        T::U8 => D::U8,
+        T::U16 => D::U16,
+        T::U32 => D::U32,
+        T::U64 => D::U64,
+        T::Bool => D::Bool,
+        T::Unit => D::Unit,
+        T::Never => D::Never,
+        T::ComptimeType => D::ComptimeType,
+        T::BuiltinNominal { kind, name } => D::BuiltinNominal {
+            name: name.clone(),
+            kind: match kind {
+                crate::AnonymousNominalKind::Struct => rue_air::SemanticImportNominalKind::Struct,
+                crate::AnonymousNominalKind::Enum => rue_air::SemanticImportNominalKind::Enum,
+            },
+        },
+        T::Nominal(crate::NominalInstanceKey::Builtin { kind, name }) => D::BuiltinNominal {
+            name: name.clone(),
+            kind: match kind {
+                crate::AnonymousNominalKind::Struct => rue_air::SemanticImportNominalKind::Struct,
+                crate::AnonymousNominalKind::Enum => rue_air::SemanticImportNominalKind::Enum,
+            },
+        },
+        T::Nominal(crate::NominalInstanceKey::Named(key)) => D::Nominal(key.clone()),
+        T::Nominal(crate::NominalInstanceKey::Anonymous(key)) => {
+            D::AnonymousNominal((**key).clone())
+        }
+        T::Array { element, len } => D::Array {
+            element: Arc::new(durable_type_from_instance_key(element)?),
+            len: *len,
+        },
+        T::Slice { element, name } => D::Slice {
+            element: Arc::new(durable_type_from_instance_key(element)?),
+            name: name.clone(),
+        },
+        T::PtrConst(value) => D::PtrConst(Arc::new(durable_type_from_instance_key(value)?)),
+        T::PtrMut(value) => D::PtrMut(Arc::new(durable_type_from_instance_key(value)?)),
+        T::Module(value) => D::Module(value.clone()),
+        T::GenericParameter(index) => D::GenericParameter(*index),
+    })
+}
+
+pub(crate) fn durable_type_diagnostic_name(ty: &DurableType) -> String {
+    use crate::durable_semantics::DurableType as T;
+
+    fn function_name(function: &crate::FunctionInstanceKey) -> Option<&str> {
+        match function {
+            crate::FunctionInstanceKey::Definition(key) => Some(key.name()),
+            crate::FunctionInstanceKey::Specialization { base, .. } => function_name(base),
+            crate::FunctionInstanceKey::AnonymousMember { .. }
+            | crate::FunctionInstanceKey::DropGlue(_) => None,
+        }
+    }
+
+    match ty {
+        T::I8 => "i8".to_owned(),
+        T::I16 => "i16".to_owned(),
+        T::I32 => "i32".to_owned(),
+        T::I64 => "i64".to_owned(),
+        T::U8 => "u8".to_owned(),
+        T::U16 => "u16".to_owned(),
+        T::U32 => "u32".to_owned(),
+        T::U64 => "u64".to_owned(),
+        T::Bool => "bool".to_owned(),
+        T::Unit => "()".to_owned(),
+        T::Never => "!".to_owned(),
+        T::ComptimeType => "type".to_owned(),
+        T::BuiltinNominal { name, .. } => name.to_string(),
+        T::Nominal(key) => key.name().to_owned(),
+        T::AnonymousNominal(key) => match &key.producer {
+            crate::StableProducerId::Definition(key) => key.name().to_owned(),
+            crate::StableProducerId::Function(function) => {
+                let name = function_name(function).unwrap_or("anonymous");
+                let applied = key.producer_arguments();
+                let mut arguments = applied
+                    .map(|applied| {
+                        applied
+                            .types
+                            .iter()
+                            .filter_map(durable_type_from_instance_key)
+                            .map(|ty| durable_type_diagnostic_name(&ty))
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                arguments.extend(
+                    applied
+                        .into_iter()
+                        .flat_map(|applied| applied.values.iter())
+                        .map(|value| match value {
+                            crate::CanonicalArgumentValue::Integer(value) => value.to_string(),
+                            crate::CanonicalArgumentValue::Bool(value) => value.to_string(),
+                            crate::CanonicalArgumentValue::Type(value) => {
+                                durable_type_from_instance_key(value.as_ref()).map_or_else(
+                                    || "type".to_owned(),
+                                    |ty| durable_type_diagnostic_name(&ty),
+                                )
+                            }
+                            crate::CanonicalArgumentValue::Function(_) => "function".to_owned(),
+                            crate::CanonicalArgumentValue::Unit => "()".to_owned(),
+                            crate::CanonicalArgumentValue::String(value) => format!("\"{value}\""),
+                        }),
+                );
+                if arguments.is_empty() {
+                    name.to_owned()
+                } else {
+                    format!("{name}({})", arguments.join(", "))
+                }
+            }
+        },
+        T::Array { element, len } => {
+            format!("[{}; {len}]", durable_type_diagnostic_name(element))
+        }
+        T::Slice { name, .. } => name.to_string(),
+        T::PtrConst(pointee) => {
+            format!("ptr const {}", durable_type_diagnostic_name(pointee))
+        }
+        T::PtrMut(pointee) => format!("ptr mut {}", durable_type_diagnostic_name(pointee)),
+        T::Module(module) => module.to_string(),
+        T::GenericParameter(index) => format!("T{index}"),
+    }
+}
+
+pub(crate) fn inferred_durable_const_type_name(value: &DurableConstValue) -> &'static str {
+    match value {
+        DurableConstValue::Integer(value) if i32::try_from(*value).is_ok() => "i32",
+        DurableConstValue::Integer(value) if i64::try_from(*value).is_ok() => "i64",
+        DurableConstValue::Integer(_) => "u64",
+        DurableConstValue::Bool(_) => "bool",
+        DurableConstValue::Unit => "()",
+        DurableConstValue::String(_) => "str",
+        DurableConstValue::Type(_) | DurableConstValue::Function(_) => "type",
+    }
+}
+
+pub(crate) fn substitute_durable_generics(
+    ty: &DurableType,
+    type_arguments: &[DurableType],
+) -> DurableType {
+    use crate::durable_semantics::DurableType as T;
+    match ty {
+        T::GenericParameter(index) => type_arguments
+            .get(*index as usize)
+            .cloned()
+            .unwrap_or_else(|| ty.clone()),
+        T::Array { element, len } => T::Array {
+            element: Arc::new(substitute_durable_generics(element, type_arguments)),
+            len: *len,
+        },
+        T::Slice { element, name } => T::Slice {
+            element: Arc::new(substitute_durable_generics(element, type_arguments)),
+            name: name.clone(),
+        },
+        T::PtrConst(pointee) => T::PtrConst(Arc::new(substitute_durable_generics(
+            pointee,
+            type_arguments,
+        ))),
+        T::PtrMut(pointee) => T::PtrMut(Arc::new(substitute_durable_generics(
+            pointee,
+            type_arguments,
+        ))),
+        _ => ty.clone(),
+    }
+}
+
+pub(crate) fn durable_const_fits_type(value: &DurableConstValue, ty: &DurableType) -> bool {
+    use crate::durable_semantics::{DurableConstValue as V, DurableType as T};
+    match (ty, value) {
+        (_, V::Integer(value)) => {
+            durable_int_width(ty).is_some_and(|integer| integer.fits_i128(*value))
+        }
+        (T::Bool, V::Bool(_)) | (T::Unit, V::Unit) => true,
+        (T::ComptimeType, V::Type(_)) => true,
+        _ => false,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DurableComptimeValueFitFailure {
+    CallableAlias,
+    IntegerOutOfRange { value: i128, type_name: String },
+    TypeMismatch { expected: String, found: String },
+}
+
+/// Return the canonical durable value-fit classification, if a reduced value
+/// cannot satisfy its declared comptime parameter type. Both expression
+/// binding and structured type-constructor reduction consume this policy so
+/// callable aliases, integer ranges, and mismatch diagnostics cannot drift.
+pub(crate) fn durable_value_fit_failure(
+    value: &DurableConstValue,
+    expected: &DurableType,
+) -> Option<DurableComptimeValueFitFailure> {
+    if durable_const_fits_type(value, expected) {
+        return None;
+    }
+    if matches!(value, DurableConstValue::Function(_)) {
+        return Some(DurableComptimeValueFitFailure::CallableAlias);
+    }
+    if let DurableConstValue::Integer(value) = value
+        && durable_int_width(expected).is_some()
+    {
+        return Some(DurableComptimeValueFitFailure::IntegerOutOfRange {
+            value: *value,
+            type_name: durable_type_diagnostic_name(expected),
+        });
+    }
+    Some(DurableComptimeValueFitFailure::TypeMismatch {
+        expected: durable_type_diagnostic_name(expected),
+        found: inferred_durable_const_type_name(value).to_owned(),
+    })
+}
+
+pub(crate) fn durable_int_width(
+    ty: &DurableType,
+) -> Option<rue_air::integer_semantics::IntegerType> {
+    use rue_air::integer_semantics::IntegerType;
+    let (bits, signed) = match ty {
+        DurableType::I8 => (8, true),
+        DurableType::I16 => (16, true),
+        DurableType::I32 => (32, true),
+        DurableType::I64 => (64, true),
+        DurableType::U8 => (8, false),
+        DurableType::U16 => (16, false),
+        DurableType::U32 => (32, false),
+        DurableType::U64 => (64, false),
+        _ => return None,
+    };
+    IntegerType::new(bits, signed)
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct DurableComptimeBinding {
+    type_arguments: Vec<(Arc<str>, DurableType)>,
+    value_arguments: Vec<(Arc<str>, DurableConstValue)>,
+}
+
+impl DurableComptimeBinding {
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        Vec<(Arc<str>, DurableType)>,
+        Vec<(Arc<str>, DurableConstValue)>,
+    ) {
+        (self.type_arguments, self.value_arguments)
+    }
+}
+
+/// Match one already-evaluated durable argument immediately. The binding is
+/// mutated in source order, so a later value parameter sees all preceding
+/// concrete type substitutions and no earlier argument is replayed.
+pub(crate) fn bind_durable_comptime_argument(
+    binding: &mut DurableComptimeBinding,
+    parameter_name: &str,
+    parameter: &crate::durable_semantics::DurableSemanticParameter,
+    argument: TypedSemanticConst,
+    direct_unit_literal: bool,
+) -> Result<(), DurableComptimeFailure> {
+    let TypedSemanticConst { value, ty } = argument;
+    if parameter.ty == DurableType::ComptimeType {
+        let value = match value {
+            DurableConstValue::Type(ty) => ty,
+            DurableConstValue::Unit if direct_unit_literal => DurableType::Unit,
+            _ => {
+                return Err(DurableComptimeFailure::comptime_failure(format!(
+                    "argument for comptime parameter `{parameter_name}` must be a type"
+                )));
+            }
+        };
+        binding
+            .type_arguments
+            .push((Arc::from(parameter_name), value));
+        return Ok(());
+    }
+
+    let expected = substitute_durable_generics(
+        &parameter.ty,
+        &binding
+            .type_arguments
+            .iter()
+            .map(|(_, ty)| ty.clone())
+            .collect::<Vec<_>>(),
+    );
+    if let Some(found) = ty
+        && found != expected
+    {
+        return Err(DurableComptimeFailure::failure(
+            SemanticNucleusFailure::Diagnostic(rue_error::ErrorKind::TypeMismatch {
+                expected: durable_type_diagnostic_name(&expected),
+                found: durable_type_diagnostic_name(&found),
+            }),
+        ));
+    }
+    if let Some(failure) = durable_value_fit_failure(&value, &expected) {
+        return Err(match failure {
+            DurableComptimeValueFitFailure::CallableAlias => {
+                DurableComptimeFailure::comptime_failure(
+                    "a callable alias cannot be passed as a comptime value argument",
+                )
+            }
+            DurableComptimeValueFitFailure::IntegerOutOfRange { value, type_name } => {
+                DurableComptimeFailure::comptime_failure(format!(
+                    "value {value} is outside the range of type {type_name}"
+                ))
+            }
+            DurableComptimeValueFitFailure::TypeMismatch { expected, found } => {
+                DurableComptimeFailure::failure(SemanticNucleusFailure::Diagnostic(
+                    rue_error::ErrorKind::TypeMismatch { expected, found },
+                ))
+            }
+        });
+    }
+    binding
+        .value_arguments
+        .push((Arc::from(parameter_name), value));
+    Ok(())
+}
+
 /// The exact durable projection of one named value lookup.  The dependency is
 /// deliberately direct: resolving a const, callable, or nominal observes the
 /// resolved declaration only, while any transitive const effects remain owned
@@ -1606,9 +1934,26 @@ impl ComptimeValue for EvaluatedSemanticConst {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::durable_semantics::{DurableParameterMode, DurableSemanticParameter};
 
     fn value(value: DurableConstValue, ty: Option<DurableType>) -> EvaluatedSemanticConst {
         EvaluatedSemanticConst::Value(Arc::new(TypedSemanticConst { value, ty }))
+    }
+
+    fn typed(value: DurableConstValue, ty: DurableType) -> TypedSemanticConst {
+        TypedSemanticConst {
+            value,
+            ty: Some(ty),
+        }
+    }
+
+    fn parameter(name: &str, ty: DurableType) -> DurableSemanticParameter {
+        DurableSemanticParameter {
+            name: Arc::from(name),
+            ty,
+            mode: DurableParameterMode::Value,
+            is_comptime: true,
+        }
     }
 
     #[test]
@@ -1696,6 +2041,114 @@ mod tests {
             EvaluatedSemanticConst::integer_typed(-12, Some(DurableComptimeType(ty.clone())));
         assert_eq!(original.clone(), original);
         assert_eq!(original.as_integer_type(), Some(DurableComptimeType(ty)));
+    }
+
+    #[test]
+    fn incremental_binding_preserves_type_then_value_order_and_substitution() {
+        let mut binding = DurableComptimeBinding::default();
+        bind_durable_comptime_argument(
+            &mut binding,
+            "T",
+            &parameter("T", DurableType::ComptimeType),
+            typed(
+                DurableConstValue::Type(DurableType::I16),
+                DurableType::ComptimeType,
+            ),
+            false,
+        )
+        .unwrap();
+        bind_durable_comptime_argument(
+            &mut binding,
+            "value",
+            &parameter("value", DurableType::GenericParameter(0)),
+            typed(DurableConstValue::Integer(12), DurableType::I16),
+            false,
+        )
+        .unwrap();
+        let (types, values) = binding.into_parts();
+        assert_eq!(types, vec![(Arc::from("T"), DurableType::I16)]);
+        assert_eq!(
+            values,
+            vec![(Arc::from("value"), DurableConstValue::Integer(12))]
+        );
+    }
+
+    #[test]
+    fn incremental_binding_preserves_early_type_and_range_failures() {
+        let mut mismatch = DurableComptimeBinding::default();
+        let failure = bind_durable_comptime_argument(
+            &mut mismatch,
+            "value",
+            &parameter("value", DurableType::I16),
+            typed(DurableConstValue::Bool(true), DurableType::Bool),
+            false,
+        )
+        .unwrap_err();
+        match failure {
+            DurableComptimeFailure::Failure(failure) => assert!(matches!(
+                failure.as_ref(),
+                SemanticNucleusFailure::Diagnostic(rue_error::ErrorKind::TypeMismatch { .. })
+            )),
+            other => panic!("unexpected binding failure: {other:?}"),
+        }
+
+        let mut range = DurableComptimeBinding::default();
+        let failure = bind_durable_comptime_argument(
+            &mut range,
+            "value",
+            &parameter("value", DurableType::I8),
+            TypedSemanticConst {
+                value: DurableConstValue::Integer(300),
+                ty: None,
+            },
+            false,
+        )
+        .unwrap_err();
+        match failure {
+            DurableComptimeFailure::Failure(failure) => match failure.as_ref() {
+                SemanticNucleusFailure::Diagnostic(
+                    rue_error::ErrorKind::ComptimeEvaluationFailed { reason },
+                ) => assert_eq!(reason, "value 300 is outside the range of type i8"),
+                other => panic!("unexpected range failure: {other:?}"),
+            },
+            other => panic!("unexpected binding failure: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn incremental_binding_requires_direct_unit_for_type_arguments() {
+        let mut direct = DurableComptimeBinding::default();
+        bind_durable_comptime_argument(
+            &mut direct,
+            "T",
+            &parameter("T", DurableType::ComptimeType),
+            typed(DurableConstValue::Unit, DurableType::Unit),
+            true,
+        )
+        .unwrap();
+        assert_eq!(
+            direct.into_parts().0,
+            vec![(Arc::from("T"), DurableType::Unit)]
+        );
+
+        let mut computed = DurableComptimeBinding::default();
+        let failure = bind_durable_comptime_argument(
+            &mut computed,
+            "T",
+            &parameter("T", DurableType::ComptimeType),
+            typed(DurableConstValue::Unit, DurableType::Unit),
+            false,
+        )
+        .unwrap_err();
+        match failure {
+            DurableComptimeFailure::Failure(failure) => match failure.as_ref() {
+                SemanticNucleusFailure::Diagnostic(
+                    rue_error::ErrorKind::ComptimeEvaluationFailed { reason },
+                ) => assert_eq!(reason, "argument for comptime parameter `T` must be a type"),
+                other => panic!("unexpected type failure: {other:?}"),
+            },
+            other => panic!("unexpected binding failure: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -4051,85 +4051,7 @@ impl LinearOwnershipFact {
 type EvaluateSemanticConstError = crate::durable_comptime::DurableComptimeFailure;
 
 fn durable_type_diagnostic_name(ty: &crate::durable_semantics::DurableType) -> String {
-    use crate::durable_semantics::DurableType as T;
-
-    fn function_name(function: &crate::FunctionInstanceKey) -> Option<&str> {
-        match function {
-            crate::FunctionInstanceKey::Definition(key) => Some(key.name()),
-            crate::FunctionInstanceKey::Specialization { base, .. } => function_name(base),
-            crate::FunctionInstanceKey::AnonymousMember { .. }
-            | crate::FunctionInstanceKey::DropGlue(_) => None,
-        }
-    }
-
-    match ty {
-        T::I8 => "i8".to_owned(),
-        T::I16 => "i16".to_owned(),
-        T::I32 => "i32".to_owned(),
-        T::I64 => "i64".to_owned(),
-        T::U8 => "u8".to_owned(),
-        T::U16 => "u16".to_owned(),
-        T::U32 => "u32".to_owned(),
-        T::U64 => "u64".to_owned(),
-        T::Bool => "bool".to_owned(),
-        T::Unit => "()".to_owned(),
-        T::Never => "!".to_owned(),
-        T::ComptimeType => "type".to_owned(),
-        T::BuiltinNominal { name, .. } => name.to_string(),
-        T::Nominal(key) => key.name().to_owned(),
-        T::AnonymousNominal(key) => match &key.producer {
-            crate::StableProducerId::Definition(key) => key.name().to_owned(),
-            crate::StableProducerId::Function(function) => {
-                let name = function_name(function).unwrap_or("anonymous");
-                // The comptime arguments live inside the producer
-                // specialization; the key carries no second copy (RUE-1699).
-                let applied = key.producer_arguments();
-                let mut arguments = applied
-                    .map(|applied| {
-                        applied
-                            .types
-                            .iter()
-                            .filter_map(durable_type_from_instance_key)
-                            .map(|ty| durable_type_diagnostic_name(&ty))
-                            .collect::<Vec<_>>()
-                    })
-                    .unwrap_or_default();
-                arguments.extend(
-                    applied
-                        .into_iter()
-                        .flat_map(|applied| applied.values.iter())
-                        .map(|value| match value {
-                            crate::CanonicalArgumentValue::Integer(value) => value.to_string(),
-                            crate::CanonicalArgumentValue::Bool(value) => value.to_string(),
-                            crate::CanonicalArgumentValue::Type(value) => {
-                                durable_type_from_instance_key(value.as_ref()).map_or_else(
-                                    || "type".to_owned(),
-                                    |ty| durable_type_diagnostic_name(&ty),
-                                )
-                            }
-                            crate::CanonicalArgumentValue::Function(_) => "function".to_owned(),
-                            crate::CanonicalArgumentValue::Unit => "()".to_owned(),
-                            crate::CanonicalArgumentValue::String(value) => format!("\"{value}\""),
-                        }),
-                );
-                if arguments.is_empty() {
-                    name.to_owned()
-                } else {
-                    format!("{name}({})", arguments.join(", "))
-                }
-            }
-        },
-        T::Array { element, len } => {
-            format!("[{}; {len}]", durable_type_diagnostic_name(element))
-        }
-        T::Slice { name, .. } => name.to_string(),
-        T::PtrConst(pointee) => {
-            format!("ptr const {}", durable_type_diagnostic_name(pointee))
-        }
-        T::PtrMut(pointee) => format!("ptr mut {}", durable_type_diagnostic_name(pointee)),
-        T::Module(module) => module.to_string(),
-        T::GenericParameter(index) => format!("T{index}"),
-    }
+    crate::durable_comptime::durable_type_diagnostic_name(ty)
 }
 
 fn foreign_signature_display(
@@ -4184,61 +4106,21 @@ fn foreign_signatures_agree(
 }
 
 fn inferred_const_type_name(value: &crate::durable_semantics::DurableConstValue) -> &'static str {
-    use crate::durable_semantics::DurableConstValue as V;
-    match value {
-        V::Integer(value) if i32::try_from(*value).is_ok() => "i32",
-        V::Integer(value) if i64::try_from(*value).is_ok() => "i64",
-        V::Integer(_) => "u64",
-        V::Bool(_) => "bool",
-        V::Unit => "()",
-        V::String(_) => "str",
-        V::Type(_) | V::Function(_) => "type",
-    }
+    crate::durable_comptime::inferred_durable_const_type_name(value)
 }
 
 fn substitute_durable_generics(
     ty: &crate::durable_semantics::DurableType,
     type_arguments: &[crate::durable_semantics::DurableType],
 ) -> crate::durable_semantics::DurableType {
-    use crate::durable_semantics::DurableType as T;
-    match ty {
-        T::GenericParameter(index) => type_arguments
-            .get(*index as usize)
-            .cloned()
-            .unwrap_or_else(|| ty.clone()),
-        T::Array { element, len } => T::Array {
-            element: Arc::new(substitute_durable_generics(element, type_arguments)),
-            len: *len,
-        },
-        T::Slice { element, name } => T::Slice {
-            element: Arc::new(substitute_durable_generics(element, type_arguments)),
-            name: name.clone(),
-        },
-        T::PtrConst(pointee) => T::PtrConst(Arc::new(substitute_durable_generics(
-            pointee,
-            type_arguments,
-        ))),
-        T::PtrMut(pointee) => T::PtrMut(Arc::new(substitute_durable_generics(
-            pointee,
-            type_arguments,
-        ))),
-        _ => ty.clone(),
-    }
+    crate::durable_comptime::substitute_durable_generics(ty, type_arguments)
 }
 
 fn durable_const_fits_type(
     value: &crate::durable_semantics::DurableConstValue,
     ty: &crate::durable_semantics::DurableType,
 ) -> bool {
-    use crate::durable_semantics::{DurableConstValue as V, DurableType as T};
-    match (ty, value) {
-        (_, V::Integer(value)) => {
-            durable_int_width(ty).is_some_and(|integer| integer.fits_i128(*value))
-        }
-        (T::Bool, V::Bool(_)) | (T::Unit, V::Unit) => true,
-        (T::ComptimeType, V::Type(_)) => true,
-        _ => false,
-    }
+    crate::durable_comptime::durable_const_fits_type(value, ty)
 }
 
 /// Build the E0481 for an array length that is already *fully concrete* and
@@ -4294,20 +4176,7 @@ fn durable_literal_array_length_failure(
 fn durable_int_width(
     ty: &crate::durable_semantics::DurableType,
 ) -> Option<rue_air::integer_semantics::IntegerType> {
-    use crate::durable_semantics::DurableType as T;
-    use rue_air::integer_semantics::IntegerType;
-    let (bits, signed) = match ty {
-        T::I8 => (8, true),
-        T::I16 => (16, true),
-        T::I32 => (32, true),
-        T::I64 => (64, true),
-        T::U8 => (8, false),
-        T::U16 => (16, false),
-        T::U32 => (32, false),
-        T::U64 => (64, false),
-        _ => return None,
-    };
-    IntegerType::new(bits, signed)
+    crate::durable_comptime::durable_int_width(ty)
 }
 
 fn semantic_nucleus_declaration_name(identity: &str) -> Option<Arc<str>> {
@@ -6567,52 +6436,7 @@ fn schedule_body_instance<V>(
 pub(crate) fn durable_type_from_instance_key(
     value: &crate::TypeInstanceKey,
 ) -> Option<crate::durable_semantics::DurableType> {
-    use crate::TypeInstanceKey as T;
-    use crate::durable_semantics::DurableType as D;
-    Some(match value {
-        T::I8 => D::I8,
-        T::I16 => D::I16,
-        T::I32 => D::I32,
-        T::I64 => D::I64,
-        T::U8 => D::U8,
-        T::U16 => D::U16,
-        T::U32 => D::U32,
-        T::U64 => D::U64,
-        T::Bool => D::Bool,
-        T::Unit => D::Unit,
-        T::Never => D::Never,
-        T::ComptimeType => D::ComptimeType,
-        T::BuiltinNominal { kind, name } => D::BuiltinNominal {
-            name: name.clone(),
-            kind: match kind {
-                crate::AnonymousNominalKind::Struct => rue_air::SemanticImportNominalKind::Struct,
-                crate::AnonymousNominalKind::Enum => rue_air::SemanticImportNominalKind::Enum,
-            },
-        },
-        T::Nominal(crate::NominalInstanceKey::Builtin { kind, name }) => D::BuiltinNominal {
-            name: name.clone(),
-            kind: match kind {
-                crate::AnonymousNominalKind::Struct => rue_air::SemanticImportNominalKind::Struct,
-                crate::AnonymousNominalKind::Enum => rue_air::SemanticImportNominalKind::Enum,
-            },
-        },
-        T::Nominal(crate::NominalInstanceKey::Named(key)) => D::Nominal(key.clone()),
-        T::Nominal(crate::NominalInstanceKey::Anonymous(key)) => {
-            D::AnonymousNominal((**key).clone())
-        }
-        T::Array { element, len } => D::Array {
-            element: Arc::new(durable_type_from_instance_key(element)?),
-            len: *len,
-        },
-        T::Slice { element, name } => D::Slice {
-            element: Arc::new(durable_type_from_instance_key(element)?),
-            name: name.clone(),
-        },
-        T::PtrConst(value) => D::PtrConst(Arc::new(durable_type_from_instance_key(value)?)),
-        T::PtrMut(value) => D::PtrMut(Arc::new(durable_type_from_instance_key(value)?)),
-        T::Module(value) => D::Module(value.clone()),
-        T::GenericParameter(index) => D::GenericParameter(*index),
-    })
+    crate::durable_comptime::durable_type_from_instance_key(value)
 }
 
 pub(crate) fn durable_value_from_argument(
@@ -8070,8 +7894,7 @@ impl SemanticConstEvaluator<'_, '_> {
         let parameters = admission.parameters;
         let result = admission.result;
         let shell_parameters = admission.shell_parameters;
-        let mut type_arguments = Vec::new();
-        let mut value_arguments = Vec::new();
+        let mut binding = crate::durable_comptime::DurableComptimeBinding::default();
         for (index, (header, parameter)) in
             shell_parameters.iter().zip(parameters.iter()).enumerate()
         {
@@ -8083,93 +7906,30 @@ impl SemanticConstEvaluator<'_, '_> {
             if parameter.ty == crate::durable_semantics::DurableType::ComptimeType {
                 let evaluated = self.eval(argument.value)?;
                 let evaluated = self.value(evaluated)?;
-                let ty = match evaluated.value {
-                    crate::durable_semantics::DurableConstValue::Type(ty) => ty,
-                    // `()` is the one surface spelling shared by a unit value
-                    // and the unit type. The parameter's `type` expectation is
-                    // therefore the canonical disambiguating context.
-                    crate::durable_semantics::DurableConstValue::Unit
-                        if matches!(
-                            &self.rir.get(argument.value).data,
-                            rue_rir::InstData::UnitConst
-                        ) =>
-                    {
-                        crate::durable_semantics::DurableType::Unit
-                    }
-                    _ => {
-                        return Self::failure(format!(
-                            "argument for comptime parameter `{}` must be a type",
-                            header.name
-                        ));
-                    }
-                };
-                type_arguments.push((header.name.clone(), ty));
+                let direct_unit_literal = matches!(
+                    &self.rir.get(argument.value).data,
+                    rue_rir::InstData::UnitConst
+                );
+                crate::durable_comptime::bind_durable_comptime_argument(
+                    &mut binding,
+                    &header.name,
+                    parameter,
+                    evaluated,
+                    direct_unit_literal,
+                )?;
             } else {
                 let evaluated = self.eval(argument.value)?;
                 let typed = self.value(evaluated)?;
-                let value = typed.value;
-                let concrete_type_arguments = type_arguments
-                    .iter()
-                    .map(|(_, ty)| ty.clone())
-                    .collect::<Vec<_>>();
-                let expected = substitute_durable_generics(&parameter.ty, &concrete_type_arguments);
-                if let Some(found) = typed.ty
-                    && found != expected
-                {
-                    return Err(EvaluateSemanticConstError::failure(
-                        crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
-                            rue_error::ErrorKind::TypeMismatch {
-                                expected: durable_type_diagnostic_name(&expected),
-                                found: durable_type_diagnostic_name(&found),
-                            },
-                        ),
-                    ));
-                }
-                if !durable_const_fits_type(&value, &expected) {
-                    if matches!(
-                        &value,
-                        crate::durable_semantics::DurableConstValue::Function(_)
-                    ) {
-                        return Self::failure(
-                            "a callable alias cannot be passed as a comptime value argument",
-                        );
-                    }
-                    if matches!(
-                        &value,
-                        crate::durable_semantics::DurableConstValue::Integer(_)
-                    ) && matches!(
-                        &expected,
-                        crate::durable_semantics::DurableType::I8
-                            | crate::durable_semantics::DurableType::I16
-                            | crate::durable_semantics::DurableType::I32
-                            | crate::durable_semantics::DurableType::I64
-                            | crate::durable_semantics::DurableType::U8
-                            | crate::durable_semantics::DurableType::U16
-                            | crate::durable_semantics::DurableType::U32
-                            | crate::durable_semantics::DurableType::U64
-                    ) {
-                        return Self::failure(format!(
-                            "value {} is outside the range of type {}",
-                            match &value {
-                                crate::durable_semantics::DurableConstValue::Integer(value) =>
-                                    value,
-                                _ => unreachable!(),
-                            },
-                            durable_type_diagnostic_name(&expected),
-                        ));
-                    }
-                    return Err(EvaluateSemanticConstError::failure(
-                        crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
-                            rue_error::ErrorKind::TypeMismatch {
-                                expected: durable_type_diagnostic_name(&expected),
-                                found: inferred_const_type_name(&value).to_owned(),
-                            },
-                        ),
-                    ));
-                }
-                value_arguments.push((header.name.clone(), value));
+                crate::durable_comptime::bind_durable_comptime_argument(
+                    &mut binding,
+                    &header.name,
+                    parameter,
+                    typed,
+                    false,
+                )?;
             }
         }
+        let (type_arguments, value_arguments) = binding.into_parts();
         let query = SemanticNucleusKey::ComptimeCall(ComptimeCallQueryKey {
             declaration: crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
                 declaration: candidate,
@@ -10810,41 +10570,25 @@ impl rue_air::SemanticTypeSyntaxProvider<ModuleId, ModuleId, StableDefinitionKey
                 return Self::provider_failure("comptime value argument has no parameter");
             };
             let expected = substitute_durable_generics(&parameter.ty, &concrete_type_arguments);
-            if !durable_const_fits_type(value, &expected) {
-                if matches!(
-                    value,
-                    crate::durable_semantics::DurableConstValue::Function(_)
-                ) {
-                    return Self::provider_failure(
+            if let Some(failure) = crate::durable_comptime::durable_value_fit_failure(
+                value, &expected,
+            ) {
+                use crate::durable_comptime::DurableComptimeValueFitFailure as Fit;
+                return match failure {
+                    Fit::CallableAlias => Self::provider_failure(
                         "a callable alias cannot be passed as a comptime value argument",
-                    );
-                }
-                if let crate::durable_semantics::DurableConstValue::Integer(value) = value
-                    && matches!(
-                        &expected,
-                        crate::durable_semantics::DurableType::I8
-                            | crate::durable_semantics::DurableType::I16
-                            | crate::durable_semantics::DurableType::I32
-                            | crate::durable_semantics::DurableType::I64
-                            | crate::durable_semantics::DurableType::U8
-                            | crate::durable_semantics::DurableType::U16
-                            | crate::durable_semantics::DurableType::U32
-                            | crate::durable_semantics::DurableType::U64
-                    )
-                {
-                    return Self::provider_failure(format!(
-                        "value {value} is outside the range of type {}",
-                        durable_type_diagnostic_name(&expected),
-                    ));
-                }
-                return Self::provider_domain_failure(
-                    crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
-                        rue_error::ErrorKind::TypeMismatch {
-                            expected: durable_type_diagnostic_name(&expected),
-                            found: inferred_const_type_name(value).to_owned(),
-                        },
                     ),
-                );
+                    Fit::IntegerOutOfRange { value, type_name } => {
+                        Self::provider_failure(format!(
+                            "value {value} is outside the range of type {type_name}"
+                        ))
+                    }
+                    Fit::TypeMismatch { expected, found } => Self::provider_domain_failure(
+                        crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+                            rue_error::ErrorKind::TypeMismatch { expected, found },
+                        ),
+                    ),
+                };
             }
         }
         let query = K::ComptimeCall(ComptimeCallQueryKey {


### PR DESCRIPTION
Relates to RUE-1774

This staged migration prerequisite adds transactional source-order call binding to the shared AIR comptime engine while preserving ordinary and durable evaluator semantics. It carries an opaque completed binding into preparation, extracts the durable binding/value-fit policy, and routes the structured reducer through the same fit classification.

Validation: `scripts/rue premerge` (200 passed), focused AIR comptime (59 passed), focused durable compiler tests (70 passed), and `scripts/rue quick` (31 suites passed).