### PR TITLE
RUE-1774: establish the durable comptime session

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -3136,6 +3136,7 @@ fn durable_comptime_services_are_named_authority_operations() {
         "DurableComptimeDiagnosticSite",
         "DurableComptimeFailure",
         "DurableComptimeHostFailure",
+        "DurableComptimeSession",
         "into_host_error",
         "provider_error_as_host",
         "maximum_depth",
@@ -3181,6 +3182,38 @@ fn durable_comptime_services_are_named_authority_operations() {
             "durable service facade must not become an evaluator: {forbidden}"
         );
     }
+    let session = production_facade
+        .split("pub(crate) struct DurableComptimeSession {")
+        .nth(1)
+        .and_then(|source| source.split("}\n\nimpl DurableComptimeSession").next())
+        .expect("durable root session");
+    let session_fields = session
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.ends_with(','))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        session_fields,
+        [
+            "lifecycle: DurableComptimeCallLifecycle,",
+            "next_call: u32,"
+        ],
+        "durable session must own exactly lifecycle state and the root call ordinal"
+    );
+    assert!(!session.contains("pub(crate)"));
+    for forbidden in ["InstData", "InstRef", "ComptimeEngine"] {
+        assert!(
+            !session.contains(forbidden),
+            "durable session duplicated AIR frame authority: {forbidden}"
+        );
+    }
+    assert_eq!(
+        production_facade
+            .matches("pub(crate) fn next_call_ordinal(")
+            .count(),
+        1
+    );
+    assert!(production_facade.contains("pub(crate) fn lifecycle_mut("));
     let failure_carrier = production_facade
         .split("pub(crate) enum DurableComptimeFailure {")
         .nth(1)
@@ -3468,6 +3501,8 @@ fn durable_comptime_services_are_named_authority_operations() {
     for root in evaluator_roots {
         assert!(root.contains("effects:"));
         assert!(root.contains("std::mem::take(&mut evaluator.effects)"));
+        assert!(root.contains("session,"));
+        assert!(!root.contains("next_call:"));
         assert!(root.contains("provider.merge_comptime_effects("));
         for forbidden in [
             "DurableComptimeCallLifecycle",
@@ -3621,7 +3656,7 @@ fn durable_comptime_services_are_named_authority_operations() {
         );
     }
     assert!(
-        named_call.contains("let call_ordinal = self.next_call;"),
+        named_call.contains("let call_ordinal = self.session.next_call_ordinal();"),
         "durable call ordinals must be allocated before admission"
     );
     let binding_header = production_facade

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -683,6 +683,41 @@ impl<V, F> DurableComptimeCompletion<V, F> {
     }
 }
 
+/// Per-root durable comptime session.
+///
+/// The AIR frame remains the owner of expression locals, producer identity,
+/// and expected-result context.  This session owns only compiler-side call
+/// lifecycle state and the root-local call ordinal allocator that the future
+/// durable host will use when it issues lifecycle edges.
+#[derive(Debug)]
+pub(crate) struct DurableComptimeSession {
+    lifecycle: DurableComptimeCallLifecycle,
+    next_call: u32,
+}
+
+impl DurableComptimeSession {
+    pub(crate) fn new(
+        parent_producer: crate::StableDefinitionKey,
+        parent_declaration: crate::declaration_candidate::DeclarationCandidateKey,
+    ) -> Result<Self, DurableComptimeLifecycleError> {
+        Ok(Self {
+            lifecycle: DurableComptimeCallLifecycle::new(parent_producer, parent_declaration)?,
+            next_call: 0,
+        })
+    }
+
+    pub(crate) fn next_call_ordinal(&mut self) -> u32 {
+        let ordinal = self.next_call;
+        self.next_call += 1;
+        ordinal
+    }
+
+    #[allow(dead_code)] // activated when the durable AIR host enters call edges
+    pub(crate) fn lifecycle_mut(&mut self) -> &mut DurableComptimeCallLifecycle {
+        &mut self.lifecycle
+    }
+}
+
 /// Root-local call/effect authority for a durable comptime host.
 ///
 /// `finish` consumes an entered ticket and its lifecycle-owned scope. Cleanup
@@ -2425,6 +2460,28 @@ mod effect_lifecycle_tests {
             child_producer,
             ordinal,
         )
+    }
+
+    #[test]
+    fn durable_session_isolates_root_ordinals_and_owns_lifecycle() {
+        let parent = definition("parent");
+        let parent_declaration =
+            crate::revisioned_query_database::declaration_candidate_for_stable_key(&parent)
+                .unwrap();
+        let mut session =
+            DurableComptimeSession::new(parent.clone(), parent_declaration.clone()).unwrap();
+        assert_eq!(session.next_call_ordinal(), 0);
+        assert_eq!(session.next_call_ordinal(), 1);
+
+        let mut ticket = session.lifecycle_mut().prepare(context(0)).unwrap();
+        session.lifecycle_mut().enter(&ticket).unwrap();
+        session
+            .lifecycle_mut()
+            .finish(&mut ticket, &rue_air::ComptimeOutcome::<(), ()>::Known(()))
+            .unwrap();
+
+        let mut sibling = DurableComptimeSession::new(parent, parent_declaration).unwrap();
+        assert_eq!(sibling.next_call_ordinal(), 0);
     }
 
     fn structured_context() -> DurableComptimeCallContext {

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -6762,7 +6762,7 @@ struct SemanticConstEvaluator<'a, 'provider> {
     import_occurrences: BTreeMap<rue_rir::InstRef, (u32, Arc<str>)>,
     locals: BTreeMap<Arc<str>, EvaluatedSemanticConst>,
     producer: crate::StableProducerId,
-    next_call: u32,
+    session: crate::durable_comptime::DurableComptimeSession,
     expected_type: Option<crate::durable_semantics::DurableType>,
     effects: crate::durable_comptime::DurableComptimeEffects,
 }
@@ -7861,8 +7861,7 @@ impl SemanticConstEvaluator<'_, '_> {
             ComptimeCallQueryKey, ComptimeCallResultProjection, SemanticNucleusKey,
             SemanticNucleusValue,
         };
-        let call_ordinal = self.next_call;
-        self.next_call += 1;
+        let call_ordinal = self.session.next_call_ordinal();
         let argument_modes = self
             .rir
             .call_args(arguments)
@@ -13600,6 +13599,11 @@ impl RevisionedQueryDatabase {
                                                 crate::StableProducerId::Definition(
                                                     const_identity.key.clone(),
                                                 );
+                                            let session = crate::durable_comptime::DurableComptimeSession::new(
+                                                const_identity.key.clone(),
+                                                query.declaration.clone(),
+                                            )
+                                            .expect("validated durable const session identity");
                                             let import_occurrences =
                                                 semantic_candidate_import_occurrences(
                                                     &rir,
@@ -13616,7 +13620,7 @@ impl RevisionedQueryDatabase {
                                                     import_occurrences,
                                                     locals: BTreeMap::new(),
                                                     producer: const_producer.clone(),
-                                                    next_call: 0,
+                                                    session,
                                                     expected_type,
                                                     effects: Default::default(),
                                                 };
@@ -14091,11 +14095,16 @@ impl RevisionedQueryDatabase {
                                             let producer = crate::StableProducerId::Function(Node::new(
                                                 crate::FunctionInstanceKey::Specialization {
                                                     base: Node::new(crate::FunctionInstanceKey::Definition(
-                                                        producer_key,
+                                                        producer_key.clone(),
                                                     )),
                                                     arguments: canonical_arguments,
                                                 },
                                             ));
+                                            let session = crate::durable_comptime::DurableComptimeSession::new(
+                                                producer_key.clone(),
+                                                call.declaration.declaration.clone(),
+                                            )
+                                            .expect("validated durable call session identity");
                                             let mut locals = BTreeMap::new();
                                             locals.extend(call.type_arguments.iter().map(
                                                 |(name, value)| {
@@ -14136,7 +14145,7 @@ impl RevisionedQueryDatabase {
                                                     import_occurrences,
                                                     locals,
                                                     producer: producer.clone(),
-                                                    next_call: 0,
+                                                    session,
                                                     expected_type: Some(expected_type),
                                                     effects: Default::default(),
                                                 };


### PR DESCRIPTION
Relates to RUE-1774

This staged slice establishes one compiler-side durable comptime root session around the existing call lifecycle and root-local call ordinal allocator. Both legacy evaluator roots now create that session, and live call ordinal allocation goes through it.

AIR remains authoritative for locals, canonical identity, and expected-result context. Legacy effect accumulation and both evaluator roots remain unchanged until the later cutover. An API inventory guard pins the session to exactly its two host-owned fields so parallel AIR authority cannot creep into it.

Validation:
- scripts/rue unit compiler durable_ (71/71)
- scripts/rue quick (31/31)
- scripts/rue premerge (200/200)
- scripts/rue fmt
- git diff --check