### PR TITLE
RUE-1774: activate durable ready-call lifecycle

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -3214,6 +3214,8 @@ fn durable_comptime_services_are_named_authority_operations() {
         1
     );
     assert!(production_facade.contains("pub(crate) fn lifecycle_mut("));
+    assert!(production_facade.contains("pub(crate) fn prepare_expression_edge("));
+    assert!(production_facade.contains("pub(crate) fn finish_ready_expression_edge("));
     let failure_carrier = production_facade
         .split("pub(crate) enum DurableComptimeFailure {")
         .nth(1)
@@ -3500,7 +3502,19 @@ fn durable_comptime_services_are_named_authority_operations() {
     assert_eq!(evaluator_roots.len(), 2);
     for root in evaluator_roots {
         assert!(root.contains("effects:"));
+        assert!(root.contains("drain_root_effects()"));
+        assert!(root.contains("evaluator.effects.merge_child("));
         assert!(root.contains("std::mem::take(&mut evaluator.effects)"));
+        let drain = root
+            .find("drain_root_effects()")
+            .expect("root session drain");
+        let merge = root
+            .find("evaluator.effects.merge_child(")
+            .expect("root lifecycle effects merge");
+        let extract = root
+            .find("std::mem::take(&mut evaluator.effects)")
+            .expect("legacy effects extraction");
+        assert!(drain < merge && merge < extract);
         assert!(root.contains("session,"));
         assert!(!root.contains("next_call:"));
         assert!(root.contains("provider.merge_comptime_effects("));
@@ -3658,6 +3672,31 @@ fn durable_comptime_services_are_named_authority_operations() {
     assert!(
         named_call.contains("let call_ordinal = self.session.next_call_ordinal();"),
         "durable call ordinals must be allocated before admission"
+    );
+    assert!(
+        named_call.contains("prepare_expression_edge(call_ordinal)"),
+        "durable named calls must issue the lifecycle edge before query lookup"
+    );
+    assert!(
+        named_call.contains("finish_ready_expression_edge(&mut edge, &value)"),
+        "ready comptime projections must publish through the lifecycle edge"
+    );
+    assert!(
+        !named_call.contains("self.effects.merge_projection("),
+        "named calls must not bypass lifecycle-owned ready projection effects"
+    );
+    let edge = named_call
+        .find("prepare_expression_edge(call_ordinal)")
+        .expect("named-call expression edge issuance");
+    let query = named_call
+        .find("self.provider.query(query)")
+        .expect("named-call semantic query");
+    let finish_edge = named_call
+        .find("finish_ready_expression_edge(&mut edge, &value)")
+        .expect("named-call ready edge completion");
+    assert!(
+        edge < query && query < finish_edge,
+        "named-call edge must surround query lookup and ready projection completion"
     );
     let binding_header = production_facade
         .find("pub(crate) struct DurableComptimeBinding {")
@@ -3995,7 +4034,7 @@ fn durable_comptime_services_are_named_authority_operations() {
         );
     }
     assert!(evaluator.contains("self.effects.observe_dependency("));
-    assert!(evaluator.contains("self.effects.merge_projection("));
+    assert!(!evaluator.contains("self.effects.merge_projection("));
     for forbidden in [
         "self.provider.dependencies",
         "self.provider.anonymous_nominals",

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -309,7 +309,6 @@ impl DurableComptimeEffects {
         self.deferred_ownership.insert(gate);
     }
 
-    #[allow(dead_code)] // used by the root-integrated AIR host in the next slice
     pub(crate) fn merge_child(
         &mut self,
         child: DurableComptimeEffects,
@@ -712,6 +711,33 @@ impl DurableComptimeSession {
         ordinal
     }
 
+    /// Issue the expression edge for an already-known call projection. The
+    /// lifecycle owns the edge policy and retains its root scope until the
+    /// evaluator has fully unwound.
+    pub(crate) fn prepare_expression_edge(
+        &mut self,
+        call_ordinal: u32,
+    ) -> Result<DurableComptimeCallEdge, DurableComptimeLifecycleError> {
+        self.lifecycle.prepare_expression_edge(call_ordinal)
+    }
+
+    pub(crate) fn finish_ready_expression_edge(
+        &mut self,
+        edge: &mut DurableComptimeCallEdge,
+        projection: &crate::semantic_query_nucleus::ComptimeCallProjection,
+    ) -> Result<(), DurableComptimeLifecycleError> {
+        self.lifecycle.merge_ready_projection(edge, projection)
+    }
+
+    /// Drain observations only after the evaluator has fully unwound. The
+    /// lifecycle validates that no entered frame remains before mutating its
+    /// root effects, so a premature drain is recoverable and non-destructive.
+    pub(crate) fn drain_root_effects(
+        &mut self,
+    ) -> Result<DurableComptimeEffects, DurableComptimeLifecycleError> {
+        self.lifecycle.take_root_effects()
+    }
+
     #[allow(dead_code)] // activated when the durable AIR host enters call edges
     pub(crate) fn lifecycle_mut(&mut self) -> &mut DurableComptimeCallLifecycle {
         &mut self.lifecycle
@@ -859,6 +885,15 @@ impl DurableComptimeCallLifecycle {
         } else {
             &mut self.effects
         }
+    }
+
+    fn take_root_effects(
+        &mut self,
+    ) -> Result<DurableComptimeEffects, DurableComptimeLifecycleError> {
+        if !self.active.is_empty() {
+            return Err(DurableComptimeLifecycleError::OutOfOrder);
+        }
+        Ok(std::mem::take(&mut self.effects))
     }
 
     pub(crate) fn observe_dependency(&mut self, dependency: SemanticDeclarationDependency) {
@@ -2484,6 +2519,32 @@ mod effect_lifecycle_tests {
         assert_eq!(sibling.next_call_ordinal(), 0);
     }
 
+    #[test]
+    fn durable_session_routes_ready_projection_through_expression_edge() {
+        let parent = definition("parent");
+        let declaration =
+            crate::revisioned_query_database::declaration_candidate_for_stable_key(&parent)
+                .unwrap();
+        let mut session = DurableComptimeSession::new(parent, declaration).unwrap();
+        let mut edge = session.prepare_expression_edge(9).unwrap();
+        session
+            .finish_ready_expression_edge(&mut edge, &ready_projection(9))
+            .unwrap();
+        let effects = session.drain_root_effects().unwrap();
+        assert_eq!(
+            effects
+                .deferred_ownership()
+                .next()
+                .unwrap()
+                .application
+                .as_ref()
+                .unwrap()
+                .call_ordinal,
+            9
+        );
+        assert!(session.drain_root_effects().unwrap().is_empty());
+    }
+
     fn structured_context() -> DurableComptimeCallContext {
         structured_context_with_parent(definition("parent"))
     }
@@ -3142,6 +3203,42 @@ mod effect_lifecycle_tests {
             )
             .unwrap();
         assert!(lifecycle.complete_known().unwrap().is_empty());
+    }
+
+    #[test]
+    fn premature_root_drain_preserves_nested_ready_effects_until_parent_finishes() {
+        let mut lifecycle = lifecycle();
+        let mut outer = lifecycle.prepare(context(32)).unwrap();
+        lifecycle.enter(&outer).unwrap();
+        let mut inner = lifecycle.prepare_structured_edge().unwrap();
+        lifecycle
+            .merge_ready_projection(&mut inner, &ready_projection(33))
+            .unwrap();
+
+        assert_eq!(
+            lifecycle.take_root_effects(),
+            Err(DurableComptimeLifecycleError::OutOfOrder)
+        );
+        lifecycle
+            .finish_with_effects(
+                &mut outer,
+                &rue_air::ComptimeOutcome::<(), ()>::Known(()),
+                DurableComptimeEffects::default(),
+            )
+            .unwrap();
+        let effects = lifecycle.complete_known().unwrap();
+        assert_eq!(effects.deferred_ownership().count(), 1);
+        assert_eq!(
+            effects
+                .deferred_ownership()
+                .next()
+                .unwrap()
+                .application
+                .as_ref()
+                .unwrap()
+                .call_ordinal,
+            32
+        );
     }
 
     #[test]

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -7938,18 +7938,18 @@ impl SemanticConstEvaluator<'_, '_> {
             value_arguments: value_arguments.into(),
         });
         let _depth = SemanticComptimeCallDepthGuard::enter(&name)?;
+        let mut edge = self
+            .session
+            .prepare_expression_edge(call_ordinal)
+            .map_err(|error| Self::failure_value(format!("durable call lifecycle: {error:?}")))?;
         let queried = self.provider.query(query).map_err(Self::provider_error)?;
         match queried {
             SemanticNucleusValue::ComptimeCall(value) => {
-                self.effects.merge_projection(
-                    &value.anonymous_nominals,
-                    &value.dependencies,
-                    &value.deferred_ownership,
-                    &crate::durable_comptime::DurableComptimeApplicationPolicy::apply_at_parent_call(
-                        self.declaration.declaration.clone(),
-                        call_ordinal,
-                    ),
-                );
+                self.session
+                    .finish_ready_expression_edge(&mut edge, &value)
+                    .map_err(|error| {
+                        Self::failure_value(format!("durable call lifecycle: {error:?}"))
+                    })?;
                 Ok(EvaluatedSemanticConst::Value(TypedSemanticConst::typed(
                     match value.result {
                         ComptimeCallResultProjection::Type(value) => {
@@ -13625,6 +13625,14 @@ impl RevisionedQueryDatabase {
                                                     effects: Default::default(),
                                                 };
                                                 let result = evaluator.eval(*init);
+                                                let session_effects = evaluator
+                                                    .session
+                                                    .drain_root_effects()
+                                                    .expect("durable evaluator must unwind lifecycle edges");
+                                                evaluator.effects.merge_child(
+                                                    session_effects,
+                                                    &crate::durable_comptime::DurableComptimeApplicationPolicy::preserve(),
+                                                );
                                                 let effects = std::mem::take(&mut evaluator.effects);
                                                 (result, effects)
                                             };
@@ -14150,6 +14158,14 @@ impl RevisionedQueryDatabase {
                                                     effects: Default::default(),
                                                 };
                                                 let result = evaluator.eval(*body);
+                                                let session_effects = evaluator
+                                                    .session
+                                                    .drain_root_effects()
+                                                    .expect("durable evaluator must unwind lifecycle edges");
+                                                evaluator.effects.merge_child(
+                                                    session_effects,
+                                                    &crate::durable_comptime::DurableComptimeApplicationPolicy::preserve(),
+                                                );
                                                 let effects = std::mem::take(&mut evaluator.effects);
                                                 (result, effects)
                                             };


### PR DESCRIPTION
Relates to RUE-1774

This staged slice activates the durable comptime session for existing memoized named-call results. Named calls issue lifecycle-owned expression edges around the semantic query, and successful ready projections merge through the lifecycle policy instead of the legacy evaluator directly.

Both legacy roots drain lifecycle observations only after evaluation has fully unwound, merge them into the unchanged publication accumulator, and preserve prior success effects even when a later operation fails. Premature root drains are non-destructive, nested ready effects remain recoverable, and repeat drains cannot replay effects.

No foreign-program loading, body-query, AIR frame authority, evaluator-root deletion, or language expansion is included.

Validation:
- scripts/rue unit compiler durable_ (73/73)
- scripts/rue quick (31/31)
- scripts/rue premerge (200/200)
- scripts/rue fmt
- git diff --check