### PR TITLE
RUE-1774: prepare durable foreign frame handoff

### DIFF
--- a/crates/rue-air/src/sema/comptime.rs
+++ b/crates/rue-air/src/sema/comptime.rs
@@ -517,6 +517,14 @@ mod value_domain_tests {
         static NAMED_TYPE_MISSING: Cell<bool> = const { Cell::new(false) };
     }
 
+    #[test]
+    fn entered_frame_runner_remains_engine_private() {
+        let source = include_str!("comptime.rs");
+        assert!(source.contains("pub(crate) fn evaluate_entered_frame("));
+        let public_signature = ["pub", " fn evaluate_entered_frame("].concat();
+        assert!(!source.contains(&public_signature));
+    }
+
     #[derive(Clone, Debug, PartialEq)]
     enum FakeValue {
         Integer(i128),
@@ -5520,6 +5528,10 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
         self.evaluate(frame, &mut env)
     }
 
+    /// Evaluate an owned frame admitted by this engine's host on the current
+    /// engine stack. The caller must pass the exact non-replayable completion
+    /// ticket returned with the frame by `prepare_comptime_call`; this entry
+    /// point never creates a child engine or dispatches a peer RIR walker.
     pub(crate) fn evaluate_entered_frame(
         &mut self,
         frame: ComptimeFrame<

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -3137,6 +3137,9 @@ fn durable_comptime_services_are_named_authority_operations() {
         "DurableComptimeFailure",
         "DurableComptimeHostFailure",
         "DurableComptimeSession",
+        "DurableComptimeForeignCall",
+        "DurableComptimeForeignCallError",
+        "consume_foreign_lookup",
         "into_host_error",
         "provider_error_as_host",
         "maximum_depth",
@@ -3185,7 +3188,7 @@ fn durable_comptime_services_are_named_authority_operations() {
     let session = production_facade
         .split("pub(crate) struct DurableComptimeSession {")
         .nth(1)
-        .and_then(|source| source.split("}\n\nimpl DurableComptimeSession").next())
+        .and_then(|source| source.split("}\n\n/// The result of consuming").next())
         .expect("durable root session");
     let session_fields = session
         .lines()
@@ -3205,6 +3208,49 @@ fn durable_comptime_services_are_named_authority_operations() {
         assert!(
             !session.contains(forbidden),
             "durable session duplicated AIR frame authority: {forbidden}"
+        );
+    }
+    let foreign_adapter = production_facade
+        .split("pub(crate) enum DurableComptimeForeignCall {")
+        .nth(1)
+        .and_then(|source| source.split("impl DurableComptimeSession").next())
+        .expect("foreign lookup adapter");
+    assert!(
+        foreign_adapter
+            .contains("Ready(crate::semantic_query_nucleus::ComptimeCallResultProjection)")
+    );
+    assert!(foreign_adapter.contains("Enter {"));
+    assert!(foreign_adapter.contains("ticket: Box<DurableComptimeCallTicket>"));
+    assert!(foreign_adapter.contains("NotReady"));
+    for required in [
+        "ReadyFailure(crate::semantic_query_nucleus::SemanticNucleusFailure)",
+        "ReadyQueryFailure(rue_query::QueryFailure)",
+        "AdmissionFailure(crate::body_query::ForeignComptimeProgramProjectionFailure)",
+        "UnexpectedReadyProjection",
+    ] {
+        assert!(
+            foreign_adapter.contains(required),
+            "missing explicit lookup error: {required}"
+        );
+    }
+    assert!(!foreign_adapter.contains("Lookup(ForeignComptimeCallLookup)"));
+    assert!(!foreign_adapter.contains("SemanticConstEvaluator"));
+    assert!(!foreign_adapter.contains("ComptimeEngine"));
+    assert!(!production_facade.contains("impl Clone for DurableComptimeForeignCall"));
+    assert!(!production_facade.contains("impl Clone for DurableComptimeCallTicket"));
+    for (kind, non_replayable) in [
+        ("struct", "DurableComptimeCallTicket"),
+        ("enum", "DurableComptimeForeignCall"),
+    ] {
+        let derive = production_facade
+            .split(&format!("pub(crate) {kind} {non_replayable}"))
+            .next()
+            .and_then(|source| source.rsplit("#[derive(").next())
+            .and_then(|source| source.split(")]").next())
+            .expect("non-replayable durable handoff derive");
+        assert!(
+            !derive.split(',').any(|item| item.trim() == "Clone"),
+            "durable handoff capability became replayable: {non_replayable}"
         );
     }
     assert_eq!(
@@ -3341,6 +3387,35 @@ fn durable_comptime_services_are_named_authority_operations() {
     assert!(ready_projection.contains("edge: &mut DurableComptimeCallEdge"));
     assert!(!ready_projection.contains("policy:"));
     assert!(ready_projection.contains("edge.application_policy"));
+    assert_eq!(
+        production_facade
+            .matches("self.validate_ready_edge(edge)?;")
+            .count(),
+        1,
+        "ready-edge validation must have one canonical implementation"
+    );
+    assert_eq!(
+        production_facade.matches("ready.merge_projection(").count(),
+        1,
+        "ready projection observation merging must have one canonical implementation"
+    );
+    assert_eq!(
+        production_facade
+            .matches(".merge_child(ready, &edge.application_policy);")
+            .count(),
+        1,
+        "ready edge policy application must have one canonical implementation"
+    );
+    let owned_ready = production_facade
+        .split("pub(crate) fn merge_ready_projection_owned(")
+        .nth(1)
+        .and_then(|source| {
+            source
+                .split("\n    /// Consume a foreign-call lookup")
+                .next()
+        })
+        .expect("owned ready projection lifecycle operation");
+    assert!(owned_ready.contains("self.merge_ready_projection(edge, &projection)?;"));
     assert!(facade.contains("pub(crate) fn prepare_expression_edge("));
     assert!(facade.contains("pub(crate) fn prepare_structured_edge("));
     let direct_prepare_prefix = facade
@@ -3678,7 +3753,7 @@ fn durable_comptime_services_are_named_authority_operations() {
         "durable named calls must issue the lifecycle edge before query lookup"
     );
     assert!(
-        named_call.contains("finish_ready_expression_edge(&mut edge, &value)"),
+        named_call.contains("finish_ready_expression_edge(edge, value)"),
         "ready comptime projections must publish through the lifecycle edge"
     );
     assert!(
@@ -3692,7 +3767,7 @@ fn durable_comptime_services_are_named_authority_operations() {
         .find("self.provider.query(query)")
         .expect("named-call semantic query");
     let finish_edge = named_call
-        .find("finish_ready_expression_edge(&mut edge, &value)")
+        .find("finish_ready_expression_edge(edge, value)")
         .expect("named-call ready edge completion");
     assert!(
         edge < query && query < finish_edge,

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -694,6 +694,31 @@ pub(crate) struct DurableComptimeSession {
     next_call: u32,
 }
 
+/// The result of consuming one pre-lookup foreign-call edge. A ready fact is
+/// merged into the lifecycle-owned scope, while an admitted body is returned
+/// with the exact ticket that the canonical AIR engine must later enter. The
+/// edge cannot be used for both alternatives.
+#[allow(dead_code)] // consumed by the root-integrated durable AIR host
+#[derive(Debug)]
+pub(crate) enum DurableComptimeForeignCall {
+    Ready(crate::semantic_query_nucleus::ComptimeCallResultProjection),
+    Enter {
+        program: crate::body_query::OwnedForeignComptimeProgram,
+        ticket: Box<DurableComptimeCallTicket>,
+    },
+    NotReady,
+}
+
+#[allow(dead_code)] // preserves exact lookup/lifecycle errors for the host
+#[derive(Debug)]
+pub(crate) enum DurableComptimeForeignCallError {
+    ReadyFailure(crate::semantic_query_nucleus::SemanticNucleusFailure),
+    ReadyQueryFailure(rue_query::QueryFailure),
+    AdmissionFailure(crate::body_query::ForeignComptimeProgramProjectionFailure),
+    UnexpectedReadyProjection,
+    Lifecycle(DurableComptimeLifecycleError),
+}
+
 impl DurableComptimeSession {
     pub(crate) fn new(
         parent_producer: crate::StableDefinitionKey,
@@ -723,10 +748,74 @@ impl DurableComptimeSession {
 
     pub(crate) fn finish_ready_expression_edge(
         &mut self,
-        edge: &mut DurableComptimeCallEdge,
-        projection: &crate::semantic_query_nucleus::ComptimeCallProjection,
-    ) -> Result<(), DurableComptimeLifecycleError> {
-        self.lifecycle.merge_ready_projection(edge, projection)
+        edge: DurableComptimeCallEdge,
+        projection: crate::semantic_query_nucleus::ComptimeCallProjection,
+    ) -> Result<
+        crate::semantic_query_nucleus::ComptimeCallResultProjection,
+        DurableComptimeLifecycleError,
+    > {
+        self.consume_foreign_lookup(edge, ForeignComptimeCallLookup::Ready(projection))
+            .map(|result| match result {
+                DurableComptimeForeignCall::Ready(result) => result,
+                DurableComptimeForeignCall::Enter { .. } | DurableComptimeForeignCall::NotReady => {
+                    unreachable!("finish_ready_expression_edge supplies a ready projection")
+                }
+            })
+            .map_err(|error| match error {
+                DurableComptimeForeignCallError::Lifecycle(error) => error,
+                DurableComptimeForeignCallError::ReadyFailure(_)
+                | DurableComptimeForeignCallError::ReadyQueryFailure(_)
+                | DurableComptimeForeignCallError::AdmissionFailure(_)
+                | DurableComptimeForeignCallError::UnexpectedReadyProjection => {
+                    unreachable!("finish_ready_expression_edge supplies a ready projection")
+                }
+            })
+    }
+
+    /// Consume the one lookup result associated with a pre-lookup edge. This
+    /// is the compiler-side adapter for the RUE-1795 seam: it never evaluates
+    /// a child or demands a terminal. The future durable host will convert the
+    /// returned admitted program and exact ticket into
+    /// `ComptimeCallPreparation::Enter`, which the currently running AIR
+    /// engine consumes through its normal call path.
+    pub(crate) fn consume_foreign_lookup(
+        &mut self,
+        edge: DurableComptimeCallEdge,
+        lookup: ForeignComptimeCallLookup,
+    ) -> Result<DurableComptimeForeignCall, DurableComptimeForeignCallError> {
+        let mut edge = edge;
+        match lookup {
+            ForeignComptimeCallLookup::Ready(projection) => {
+                let result = self
+                    .lifecycle
+                    .merge_ready_projection_owned(&mut edge, projection)
+                    .map_err(DurableComptimeForeignCallError::Lifecycle)?;
+                Ok(DurableComptimeForeignCall::Ready(result))
+            }
+            ForeignComptimeCallLookup::Admitted(program) => {
+                let ticket = self
+                    .lifecycle
+                    .ticket_from_admitted_edge(edge, &program)
+                    .map_err(DurableComptimeForeignCallError::Lifecycle)?;
+                Ok(DurableComptimeForeignCall::Enter {
+                    program,
+                    ticket: Box::new(ticket),
+                })
+            }
+            ForeignComptimeCallLookup::NotReady => Ok(DurableComptimeForeignCall::NotReady),
+            ForeignComptimeCallLookup::ReadyFailure(failure) => {
+                Err(DurableComptimeForeignCallError::ReadyFailure(failure))
+            }
+            ForeignComptimeCallLookup::ReadyQueryFailure(failure) => {
+                Err(DurableComptimeForeignCallError::ReadyQueryFailure(failure))
+            }
+            ForeignComptimeCallLookup::AdmissionFailure(failure) => {
+                Err(DurableComptimeForeignCallError::AdmissionFailure(failure))
+            }
+            ForeignComptimeCallLookup::UnexpectedReadyProjection => {
+                Err(DurableComptimeForeignCallError::UnexpectedReadyProjection)
+            }
+        }
     }
 
     /// Drain observations only after the evaluator has fully unwound. The
@@ -995,6 +1084,18 @@ impl DurableComptimeCallLifecycle {
         self.current_effects_mut()
             .merge_child(ready, &edge.application_policy);
         Ok(())
+    }
+
+    pub(crate) fn merge_ready_projection_owned(
+        &mut self,
+        edge: &mut DurableComptimeCallEdge,
+        projection: crate::semantic_query_nucleus::ComptimeCallProjection,
+    ) -> Result<
+        crate::semantic_query_nucleus::ComptimeCallResultProjection,
+        DurableComptimeLifecycleError,
+    > {
+        self.merge_ready_projection(edge, &projection)?;
+        Ok(projection.result)
     }
 
     /// Consume a foreign-call lookup only when it contains a ready Known
@@ -2526,9 +2627,9 @@ mod effect_lifecycle_tests {
             crate::revisioned_query_database::declaration_candidate_for_stable_key(&parent)
                 .unwrap();
         let mut session = DurableComptimeSession::new(parent, declaration).unwrap();
-        let mut edge = session.prepare_expression_edge(9).unwrap();
+        let edge = session.prepare_expression_edge(9).unwrap();
         session
-            .finish_ready_expression_edge(&mut edge, &ready_projection(9))
+            .finish_ready_expression_edge(edge, ready_projection(9))
             .unwrap();
         let effects = session.drain_root_effects().unwrap();
         assert_eq!(
@@ -2979,6 +3080,116 @@ mod effect_lifecycle_tests {
             structured.application_policy,
             DurableComptimeApplicationPolicy::Preserve
         );
+
+        // The production session adapter consumes one pre-lookup edge and
+        // returns the admitted owned program with the exact ticket; admission
+        // alone does not activate a lifecycle scope.
+        let mut session = DurableComptimeSession::new(
+            definition("parent"),
+            crate::revisioned_query_database::declaration_candidate_for_stable_key(&definition(
+                "parent",
+            ))
+            .unwrap(),
+        )
+        .unwrap();
+        let edge = session.prepare_expression_edge(42).unwrap();
+        let consumed = session
+            .consume_foreign_lookup(edge, ForeignComptimeCallLookup::Admitted(admitted.clone()))
+            .unwrap();
+        let DurableComptimeForeignCall::Enter {
+            program,
+            mut ticket,
+        } = consumed
+        else {
+            panic!("an admitted lookup must return an entered-frame plan");
+        };
+        assert_eq!(program.plan, admitted.plan);
+        assert!(session.lifecycle.active.is_empty());
+        session.lifecycle.enter(&ticket).unwrap();
+        session
+            .lifecycle
+            .finish(&mut ticket, &rue_air::ComptimeOutcome::<(), ()>::Known(()))
+            .unwrap();
+
+        let mut ready_session = DurableComptimeSession::new(
+            definition("parent"),
+            crate::revisioned_query_database::declaration_candidate_for_stable_key(&definition(
+                "parent",
+            ))
+            .unwrap(),
+        )
+        .unwrap();
+        let ready_edge = ready_session.prepare_expression_edge(42).unwrap();
+        assert!(matches!(
+            ready_session
+                .consume_foreign_lookup(
+                    ready_edge,
+                    ForeignComptimeCallLookup::Ready(ready_projection(42)),
+                )
+                .unwrap(),
+            DurableComptimeForeignCall::Ready(
+                crate::semantic_query_nucleus::ComptimeCallResultProjection::Value(
+                    DurableConstValue::Integer(42),
+                )
+            )
+        ));
+        assert!(!ready_session.drain_root_effects().unwrap().is_empty());
+
+        let mut miss_session = DurableComptimeSession::new(
+            definition("parent"),
+            crate::revisioned_query_database::declaration_candidate_for_stable_key(&definition(
+                "parent",
+            ))
+            .unwrap(),
+        )
+        .unwrap();
+        let miss_edge = miss_session.prepare_expression_edge(43).unwrap();
+        assert!(matches!(
+            miss_session.consume_foreign_lookup(miss_edge, ForeignComptimeCallLookup::NotReady),
+            Ok(DurableComptimeForeignCall::NotReady)
+        ));
+        assert!(miss_session.drain_root_effects().unwrap().is_empty());
+
+        let failures = [
+            ForeignComptimeCallLookup::ReadyFailure(
+                crate::semantic_query_nucleus::SemanticNucleusFailure::Shell(Arc::from("shell")),
+            ),
+            ForeignComptimeCallLookup::ReadyQueryFailure(rue_query::QueryFailure::new(
+                "query", "failure",
+            )),
+            ForeignComptimeCallLookup::AdmissionFailure(
+                crate::body_query::ForeignComptimeProgramProjectionFailure::IdentityMismatch,
+            ),
+            ForeignComptimeCallLookup::UnexpectedReadyProjection,
+        ];
+        for lookup in failures {
+            let mut failure_session = DurableComptimeSession::new(
+                definition("parent"),
+                crate::revisioned_query_database::declaration_candidate_for_stable_key(
+                    &definition("parent"),
+                )
+                .unwrap(),
+            )
+            .unwrap();
+            let failure_edge = failure_session.prepare_expression_edge(44).unwrap();
+            let error = failure_session
+                .consume_foreign_lookup(failure_edge, lookup)
+                .expect_err("non-ready lookup must preserve its exact error channel");
+            match error {
+                DurableComptimeForeignCallError::ReadyFailure(
+                    crate::semantic_query_nucleus::SemanticNucleusFailure::Shell(message),
+                ) => assert_eq!(message.as_ref(), "shell"),
+                DurableComptimeForeignCallError::ReadyQueryFailure(failure) => {
+                    assert_eq!(failure.code.as_ref(), "query")
+                }
+                DurableComptimeForeignCallError::AdmissionFailure(
+                    crate::body_query::ForeignComptimeProgramProjectionFailure::IdentityMismatch,
+                )
+                | DurableComptimeForeignCallError::UnexpectedReadyProjection => {}
+                other => panic!("wrong foreign lookup error channel: {other:?}"),
+            }
+            assert!(failure_session.drain_root_effects().unwrap().is_empty());
+        }
 
         // The same pre-lookup edge can choose the admitted branch and derive
         // the child query only from the owned program payload.

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -7938,20 +7938,21 @@ impl SemanticConstEvaluator<'_, '_> {
             value_arguments: value_arguments.into(),
         });
         let _depth = SemanticComptimeCallDepthGuard::enter(&name)?;
-        let mut edge = self
+        let edge = self
             .session
             .prepare_expression_edge(call_ordinal)
             .map_err(|error| Self::failure_value(format!("durable call lifecycle: {error:?}")))?;
         let queried = self.provider.query(query).map_err(Self::provider_error)?;
         match queried {
             SemanticNucleusValue::ComptimeCall(value) => {
-                self.session
-                    .finish_ready_expression_edge(&mut edge, &value)
+                let value = self
+                    .session
+                    .finish_ready_expression_edge(edge, value)
                     .map_err(|error| {
                         Self::failure_value(format!("durable call lifecycle: {error:?}"))
                     })?;
                 Ok(EvaluatedSemanticConst::Value(TypedSemanticConst::typed(
-                    match value.result {
+                    match value {
                         ComptimeCallResultProjection::Type(value) => {
                             crate::durable_semantics::DurableConstValue::Type(value)
                         }


### PR DESCRIPTION
Relates to RUE-1774

This staged prerequisite consumes the existing foreign comptime lookup seam inside the durable session while preserving the legacy evaluator as the live caller.

- Ready results merge effects exactly once and expose only the result payload.
- Admitted calls return the owned program with an exact non-replayable lifecycle ticket for a future host to convert into ComptimeCallPreparation::Enter.
- Misses and each failure channel remain explicit and effect-free.
- ComptimeEngine remains the sole frame-entry and depth authority; this does not add a production host or perform the evaluator cutover.

Validation: scripts/rue premerge (200 passed), focused AIR comptime (62 passed), focused compiler durable comptime (73 passed), and adversarial architectural review.