### PR TITLE
RUE-1774: share durable comptime program authority

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -3177,6 +3177,8 @@ fn durable_comptime_services_are_named_authority_operations() {
         "ticket_from_admitted_edge",
         "merge_child",
         "complete_root",
+        "begin_durable_structured_type",
+        "resume_durable_structured_type",
     ] {
         assert!(
             facade.contains(required),
@@ -3189,6 +3191,89 @@ fn durable_comptime_services_are_named_authority_operations() {
             "durable service facade must not become an evaluator: {forbidden}"
         );
     }
+    let body_query = include_str!("body_query.rs");
+    for required in [
+        "OwnedComptimeProgramCore",
+        "OwnedComptimeProgramRoot",
+        "type DurableComptimeProgramKey = rue_air::ComptimeProgramKey",
+        "rue_air::ComptimeProgram<Arc<str>",
+        "impl Deref for OwnedForeignComptimeProgram",
+        "from_const_body_plan",
+    ] {
+        assert!(
+            body_query.contains(required),
+            "shared program core missing {required}"
+        );
+    }
+    let core = body_query
+        .split("pub(crate) struct OwnedComptimeProgramCore {")
+        .nth(1)
+        .and_then(|source| source.split("}\n\n/// Owned compiler/query-side").next())
+        .expect("shared durable program core");
+    assert!(core.contains("program: DurableComptimeProgram,"));
+    for forbidden in [
+        "ValidatedRir",
+        "symbols:",
+        "import_occurrences:",
+        "registry:",
+    ] {
+        assert!(
+            !core.contains(forbidden),
+            "compiler core duplicated AIR program authority: {forbidden}"
+        );
+    }
+    let admission = body_query
+        .split("fn from_body_plan(")
+        .nth(2)
+        .and_then(|source| source.split("/// Materialize a const declaration").next())
+        .expect("shared comptime program admission kernel");
+    assert_eq!(
+        admission
+            .matches("materialize_semantic_candidate_rir")
+            .count(),
+        1
+    );
+    assert_eq!(
+        admission
+            .matches("semantic_candidate_import_occurrences")
+            .count(),
+        1
+    );
+    let call_payload = body_query
+        .split("pub(crate) struct OwnedForeignComptimeProgram {")
+        .nth(1)
+        .and_then(|source| source.split("}\n\nimpl Deref").next())
+        .expect("foreign program payload");
+    for forbidden in [
+        "ValidatedRir",
+        "symbols:",
+        "import_occurrences:",
+        "pub(crate) plan:",
+        "from_const_body_plan",
+    ] {
+        assert!(
+            !call_payload.contains(forbidden),
+            "foreign payload duplicated shared program ownership: {forbidden}"
+        );
+    }
+    let structured_adapter = production_facade
+        .split("pub(crate) fn begin_durable_structured_type")
+        .nth(1)
+        .and_then(|source| source.split("impl ComptimeValue").next())
+        .expect("durable structured adapter");
+    for forbidden in [
+        "InstData",
+        "eval(",
+        "ComptimeEngine",
+        "SemanticConstEvaluator",
+        "from_registered",
+    ] {
+        assert!(
+            !structured_adapter.contains(forbidden),
+            "structured adapter gained evaluator authority: {forbidden}"
+        );
+    }
+    assert!(structured_adapter.contains(".structured_type_authority("));
     let session = production_facade
         .split("pub(crate) struct DurableComptimeSession {")
         .nth(1)
@@ -3203,9 +3288,10 @@ fn durable_comptime_services_are_named_authority_operations() {
         session_fields,
         [
             "lifecycle: DurableComptimeCallLifecycle,",
-            "next_call: u32,"
+            "next_call: u32,",
+            "programs: crate::body_query::DurableComptimeProgramRegistry,"
         ],
-        "durable session must own exactly lifecycle state and the root call ordinal"
+        "durable session owns one root-local AIR program registry beside lifecycle state"
     );
     assert!(!session.contains("pub(crate)"));
     for forbidden in ["InstData", "InstRef", "ComptimeEngine"] {
@@ -3229,7 +3315,7 @@ fn durable_comptime_services_are_named_authority_operations() {
     for required in [
         "ReadyFailure(crate::semantic_query_nucleus::SemanticNucleusFailure)",
         "ReadyQueryFailure(rue_query::QueryFailure)",
-        "AdmissionFailure(crate::body_query::ForeignComptimeProgramProjectionFailure)",
+        "AdmissionFailure(crate::body_query::ComptimeProgramProjectionFailure)",
         "UnexpectedReadyProjection",
     ] {
         assert!(

--- a/crates/rue-compiler/src/body_query.rs
+++ b/crates/rue-compiler/src/body_query.rs
@@ -126,20 +126,27 @@ pub(crate) struct OwnedBodyInput {
     pub(crate) artifacts: Arc<crate::canonical_lower::DeclarationBodyPlanArtifacts>,
 }
 
-/// Stable identity of an admitted foreign comptime producer. The producer is
-/// the canonical semantic owner; the configuration is the other part of the
-/// durable identity. Candidate syntax is retained separately as lookup
-/// provenance and is never used as an alternate owner key.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct ForeignComptimeProgramKey {
-    pub(crate) producer: crate::StableDefinitionKey,
-    pub(crate) configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
-}
+/// Stable AIR identity of an admitted durable comptime program. Candidate
+/// syntax is retained separately as lookup provenance and is never used as an
+/// alternate owner key.
+pub(crate) type DurableComptimeProgramKey = rue_air::ComptimeProgramKey<
+    crate::StableDefinitionKey,
+    crate::semantic_query_nucleus::SemanticQueryConfiguration,
+>;
+
+pub(crate) type DurableComptimeProgram =
+    rue_air::ComptimeProgram<Arc<str>, Arc<[DurableComptimeImportOccurrence]>>;
+pub(crate) type DurableComptimeProgramRegistry = rue_air::ComptimeProgramRegistry<
+    crate::StableDefinitionKey,
+    crate::semantic_query_nucleus::SemanticQueryConfiguration,
+    Arc<str>,
+    Arc<[DurableComptimeImportOccurrence]>,
+>;
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ForeignComptimeProgramPlan {
-    pub(crate) key: ForeignComptimeProgramKey,
+pub(crate) struct DurableComptimeProgramPlan {
+    pub(crate) key: DurableComptimeProgramKey,
     /// Compiler-private syntax provenance used to fetch the canonical body
     /// plan. It is not part of the stable program identity.
     pub(crate) candidate: crate::declaration_candidate::DeclarationCandidateKey,
@@ -155,7 +162,18 @@ pub(crate) struct ForeignComptimeCallable {
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ForeignComptimeImportOccurrence {
+pub(crate) enum OwnedComptimeProgramRoot {
+    Callable(ForeignComptimeCallable),
+    Const {
+        init: rue_rir::InstRef,
+        declared_type: Option<rue_rir::RirTypeSyntaxRef>,
+        root: rue_rir::InstRef,
+    },
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DurableComptimeImportOccurrence {
     /// Owner-local instruction in the admitted RIR. The future host must use
     /// this only with the `rir` retained by the same program payload.
     pub(crate) inst: rue_rir::InstRef,
@@ -165,7 +183,7 @@ pub(crate) struct ForeignComptimeImportOccurrence {
 
 #[allow(dead_code)]
 #[derive(Debug)]
-pub(crate) enum ForeignComptimeProgramProjectionFailure {
+pub(crate) enum ComptimeProgramProjectionFailure {
     Materialization(crate::canonical_lower::BodyPlanMaterializationFailure),
     Artifact(crate::revisioned_query_database::DeclarationBodyPlanFailure),
     ArtifactQueryFailure(rue_query::QueryFailure),
@@ -175,7 +193,7 @@ pub(crate) enum ForeignComptimeProgramProjectionFailure {
 }
 
 impl From<crate::canonical_lower::BodyPlanMaterializationFailure>
-    for ForeignComptimeProgramProjectionFailure
+    for ComptimeProgramProjectionFailure
 {
     fn from(error: crate::canonical_lower::BodyPlanMaterializationFailure) -> Self {
         Self::Materialization(error)
@@ -189,19 +207,75 @@ pub(crate) struct ForeignComptimeCallSeed {
     pub(crate) value_arguments: Arc<[(Arc<str>, crate::durable_semantics::DurableConstValue)]>,
 }
 
-/// Owned compiler/query-side admission payload for a future durable comptime
-/// host. It is projected from the canonical declaration body plan and owns all
-/// data that would otherwise be borrowed from a revision-local source artifact.
-/// This slice only admits the payload; no evaluator consumes it yet.
+/// One owning durable program core shared by const roots and admitted foreign
+/// callables. Dense instruction references are meaningful only through this
+/// exact core, so colliding references from different programs cannot alias.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub(crate) struct OwnedComptimeProgramCore {
+    pub(crate) plan: DurableComptimeProgramPlan,
+    program: DurableComptimeProgram,
+    pub(crate) root: OwnedComptimeProgramRoot,
+}
+
+/// Owned compiler/query-side admission payload for a durable comptime call.
+/// The program core is shared with const-root payloads; the seed is
+/// call-specific and preserves ordered argument substitutions.
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub(crate) struct OwnedForeignComptimeProgram {
-    pub(crate) plan: ForeignComptimeProgramPlan,
-    pub(crate) rir: Arc<rue_rir::ValidatedRir>,
-    pub(crate) symbols: Arc<[Arc<str>]>,
-    pub(crate) import_occurrences: Arc<[ForeignComptimeImportOccurrence]>,
-    pub(crate) callable: ForeignComptimeCallable,
+    pub(crate) core: Arc<OwnedComptimeProgramCore>,
     pub(crate) seed: ForeignComptimeCallSeed,
+}
+
+impl Deref for OwnedForeignComptimeProgram {
+    type Target = OwnedComptimeProgramCore;
+
+    fn deref(&self) -> &Self::Target {
+        &self.core
+    }
+}
+
+impl Deref for OwnedComptimeProgramCore {
+    type Target = DurableComptimeProgram;
+
+    fn deref(&self) -> &Self::Target {
+        &self.program
+    }
+}
+
+impl OwnedComptimeProgramCore {
+    pub(crate) fn callable(&self) -> Option<&ForeignComptimeCallable> {
+        match &self.root {
+            OwnedComptimeProgramRoot::Callable(callable) => Some(callable),
+            OwnedComptimeProgramRoot::Const { .. } => None,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn const_root(
+        &self,
+    ) -> Option<(
+        rue_rir::InstRef,
+        Option<rue_rir::RirTypeSyntaxRef>,
+        rue_rir::InstRef,
+    )> {
+        match self.root {
+            OwnedComptimeProgramRoot::Const {
+                init,
+                declared_type,
+                root,
+            } => Some((init, declared_type, root)),
+            OwnedComptimeProgramRoot::Callable(_) => None,
+        }
+    }
+
+    pub(crate) fn register_into(
+        &self,
+        registry: &mut DurableComptimeProgramRegistry,
+    ) -> Result<(), rue_air::ComptimeProgramRegistrationError> {
+        registry.register(self.plan.key.clone(), self.program.clone())
+    }
 }
 
 #[allow(dead_code)]
@@ -211,7 +285,7 @@ pub(crate) enum ForeignComptimeCallLookup {
     ReadyFailure(crate::semantic_query_nucleus::SemanticNucleusFailure),
     ReadyQueryFailure(rue_query::QueryFailure),
     Admitted(OwnedForeignComptimeProgram),
-    AdmissionFailure(ForeignComptimeProgramProjectionFailure),
+    AdmissionFailure(ComptimeProgramProjectionFailure),
     NotReady,
     UnexpectedReadyProjection,
 }
@@ -219,66 +293,119 @@ pub(crate) enum ForeignComptimeCallLookup {
 impl OwnedForeignComptimeProgram {
     #[allow(dead_code)]
     pub(crate) fn from_body_plan(
-        plan: ForeignComptimeProgramPlan,
+        plan: DurableComptimeProgramPlan,
         artifacts: &crate::canonical_lower::DeclarationBodyPlanArtifacts,
         seed: ForeignComptimeCallSeed,
+        checkpoint: impl FnMut() -> Result<(), rue_query::QueryAbort>,
+    ) -> Result<Self, ComptimeProgramProjectionFailure> {
+        let core = OwnedComptimeProgramCore::from_body_plan(
+            plan,
+            artifacts,
+            OwnedComptimeRootExpectation::Callable,
+            checkpoint,
+        )?;
+        Ok(Self { core, seed })
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum OwnedComptimeRootExpectation {
+    Callable,
+    Const,
+}
+
+impl OwnedComptimeProgramCore {
+    fn from_body_plan(
+        plan: DurableComptimeProgramPlan,
+        artifacts: &crate::canonical_lower::DeclarationBodyPlanArtifacts,
+        expectation: OwnedComptimeRootExpectation,
         mut checkpoint: impl FnMut() -> Result<(), rue_query::QueryAbort>,
-    ) -> Result<Self, ForeignComptimeProgramProjectionFailure> {
+    ) -> Result<Arc<Self>, ComptimeProgramProjectionFailure> {
         if artifacts.candidate != plan.candidate {
-            return Err(ForeignComptimeProgramProjectionFailure::IdentityMismatch);
+            return Err(ComptimeProgramProjectionFailure::IdentityMismatch);
         }
         let (rir, spellings, root) = artifacts
             .plan
             .materialize_semantic_candidate_rir(&mut checkpoint)
-            .map_err(|error| ForeignComptimeProgramProjectionFailure::Materialization(error))?;
+            .map_err(ComptimeProgramProjectionFailure::Materialization)?;
         let Some(expected_candidate) =
             crate::revisioned_query_database::declaration_candidate_for_stable_key(
-                &plan.key.producer,
+                &plan.key.declaration,
             )
         else {
-            return Err(ForeignComptimeProgramProjectionFailure::IdentityMismatch);
+            return Err(ComptimeProgramProjectionFailure::IdentityMismatch);
         };
         if expected_candidate != plan.candidate {
-            return Err(ForeignComptimeProgramProjectionFailure::IdentityMismatch);
+            return Err(ComptimeProgramProjectionFailure::IdentityMismatch);
         }
-        let body = match &rir.get(root).data {
-            rue_rir::InstData::FnDecl { body, .. } => *body,
-            _ => {
-                return Err(ForeignComptimeProgramProjectionFailure::NotFunction { root });
+        let program_root = match (expectation, &rir.get(root).data) {
+            (OwnedComptimeRootExpectation::Callable, rue_rir::InstData::FnDecl { body, .. }) => {
+                OwnedComptimeProgramRoot::Callable(ForeignComptimeCallable {
+                    body: *body,
+                    context: plan.candidate.module.clone(),
+                    root,
+                })
             }
-        };
-        let import_occurrences =
-            crate::revisioned_query_database::semantic_candidate_import_occurrences(
-                &rir,
-                &spellings,
-                &mut checkpoint,
-            )
-            .map_err(|error| {
-                ForeignComptimeProgramProjectionFailure::Materialization(
-                    crate::canonical_lower::BodyPlanMaterializationFailure::Query(error),
-                )
-            })?
-            .into_iter()
-            .map(
-                |(inst, (occurrence, specifier))| ForeignComptimeImportOccurrence {
-                    inst,
-                    occurrence,
-                    specifier,
-                },
-            )
-            .collect::<Vec<_>>();
-        Ok(Self {
-            plan: plan.clone(),
-            rir: Arc::new(rir),
-            symbols: spellings.into_iter().map(Arc::from).collect(),
-            import_occurrences: import_occurrences.into(),
-            callable: ForeignComptimeCallable {
-                body,
-                context: plan.candidate.module.clone(),
+            (OwnedComptimeRootExpectation::Callable, _) => {
+                return Err(ComptimeProgramProjectionFailure::NotFunction { root });
+            }
+            (
+                OwnedComptimeRootExpectation::Const,
+                rue_rir::InstData::ConstDecl { ty, init, .. },
+            ) => OwnedComptimeProgramRoot::Const {
+                init: *init,
+                declared_type: *ty,
                 root,
             },
-            seed,
-        })
+            (OwnedComptimeRootExpectation::Const, _) => {
+                return Err(ComptimeProgramProjectionFailure::IdentityMismatch);
+            }
+        };
+        let imports = crate::revisioned_query_database::semantic_candidate_import_occurrences(
+            &rir,
+            &spellings,
+            &mut checkpoint,
+        )
+        .map_err(|error| {
+            ComptimeProgramProjectionFailure::Materialization(
+                crate::canonical_lower::BodyPlanMaterializationFailure::Query(error),
+            )
+        })?
+        .into_iter()
+        .map(
+            |(inst, (occurrence, specifier))| DurableComptimeImportOccurrence {
+                inst,
+                occurrence,
+                specifier,
+            },
+        )
+        .collect::<Vec<_>>();
+        Ok(Arc::new(Self {
+            plan,
+            program: DurableComptimeProgram {
+                rir: Arc::new(rir),
+                symbols: spellings.into_iter().map(Arc::from).collect(),
+                imports: imports.into(),
+            },
+            root: program_root,
+        }))
+    }
+
+    /// Materialize a const declaration into the shared owning program core.
+    /// This validates identity and owns the init/type syntax, but deliberately
+    /// does not evaluate either expression.
+    #[allow(dead_code)]
+    pub(crate) fn from_const_body_plan(
+        plan: DurableComptimeProgramPlan,
+        artifacts: &crate::canonical_lower::DeclarationBodyPlanArtifacts,
+        checkpoint: impl FnMut() -> Result<(), rue_query::QueryAbort>,
+    ) -> Result<Arc<Self>, ComptimeProgramProjectionFailure> {
+        Self::from_body_plan(
+            plan,
+            artifacts,
+            OwnedComptimeRootExpectation::Const,
+            checkpoint,
+        )
     }
 }
 
@@ -1071,8 +1198,8 @@ impl BodyTransaction {
 #[cfg(test)]
 mod tests {
     use super::{
-        BodyQueryKey, ForeignComptimeCallSeed, ForeignComptimeProgramKey,
-        ForeignComptimeProgramPlan, OwnedForeignComptimeProgram, merge_ordered_unique,
+        BodyQueryKey, DurableComptimeProgramKey, DurableComptimeProgramPlan,
+        ForeignComptimeCallSeed, OwnedForeignComptimeProgram, merge_ordered_unique,
     };
     use rue_air::Node;
     use std::collections::BTreeSet;
@@ -1163,9 +1290,9 @@ mod tests {
             candidate.name.clone(),
             None,
         );
-        let plan = ForeignComptimeProgramPlan {
-            key: ForeignComptimeProgramKey {
-                producer,
+        let plan = DurableComptimeProgramPlan {
+            key: DurableComptimeProgramKey {
+                declaration: producer,
                 configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration {
                     target: rue_target::Target::X86_64Linux,
                     preview_features: crate::StablePreviewFeatures::new(
@@ -1201,11 +1328,11 @@ mod tests {
                 seed.clone(),
                 || Ok(()),
             ),
-            Err(super::ForeignComptimeProgramProjectionFailure::IdentityMismatch)
+            Err(super::ComptimeProgramProjectionFailure::IdentityMismatch)
         ));
         let mut wrong_candidate = program.plan.candidate.clone();
         wrong_candidate.name = Arc::from("sibling");
-        let wrong_plan = ForeignComptimeProgramPlan {
+        let wrong_plan = DurableComptimeProgramPlan {
             key: program.plan.key.clone(),
             candidate: wrong_candidate,
         };
@@ -1216,14 +1343,17 @@ mod tests {
                 seed.clone(),
                 || Ok(())
             ),
-            Err(super::ForeignComptimeProgramProjectionFailure::IdentityMismatch)
+            Err(super::ComptimeProgramProjectionFailure::IdentityMismatch)
         ));
         drop(artifacts);
 
         assert_eq!(program.seed, seed, "argument order is request order");
-        assert_eq!(program.callable.context, program.plan.candidate.module);
         assert_eq!(
-            program.callable.root,
+            program.callable().expect("callable root").context,
+            program.plan.candidate.module
+        );
+        assert_eq!(
+            program.callable().expect("callable root").root,
             program
                 .rir
                 .iter()
@@ -1232,18 +1362,67 @@ mod tests {
                 })
                 .unwrap()
         );
-        let rue_rir::InstData::FnDecl { body, .. } = &program.rir.get(program.callable.root).data
+        let rue_rir::InstData::FnDecl { body, .. } = &program
+            .rir
+            .get(program.callable().expect("callable root").root)
+            .data
         else {
             panic!("the admitted callable root must remain a function declaration");
         };
-        assert_eq!(program.callable.body, *body);
-        assert_eq!(program.import_occurrences.len(), 1);
-        let import = &program.import_occurrences[0];
+        assert_eq!(program.callable().expect("callable root").body, *body);
+        assert_eq!(program.imports.len(), 1);
+        let import = &program.imports[0];
         assert_eq!(import.specifier.as_ref(), "dep");
         assert!(matches!(
             &program.rir.get(import.inst).data,
             rue_rir::InstData::Intrinsic { .. }
         ));
+
+        let const_snapshot =
+            crate::SourceSnapshot::single("<const-program>", "const target: i32 = 1;").unwrap();
+        let const_module = crate::parsed_modules::parse_source_snapshot_modules(&const_snapshot)
+            .unwrap()
+            .modules()[0]
+            .clone();
+        let const_candidate = const_module
+            .definitions()
+            .declaration_keys_in_source_order()
+            .find(|candidate| candidate.name.as_ref() == "target")
+            .unwrap()
+            .clone();
+        let const_artifacts = crate::canonical_lower::lower_parsed_declaration_body_plan(
+            &const_module,
+            &const_candidate,
+            || Ok(()),
+        )
+        .unwrap();
+        let const_plan = DurableComptimeProgramPlan {
+            key: DurableComptimeProgramKey {
+                declaration: crate::StableDefinitionKey::from_stable_parts(
+                    const_candidate.module.clone(),
+                    crate::StableDefinitionNamespace::Value,
+                    crate::StableDefinitionKind::ValueConst,
+                    "target",
+                    None,
+                ),
+                configuration: program.plan.key.configuration.clone(),
+            },
+            candidate: const_candidate,
+        };
+        let const_program = crate::body_query::OwnedComptimeProgramCore::from_const_body_plan(
+            const_plan,
+            &const_artifacts,
+            || Ok(()),
+        )
+        .unwrap();
+        assert!(const_program.callable().is_none());
+        assert!(const_program.const_root().is_some());
+        assert!(!const_program.symbols.is_empty());
+        assert!(!const_program.rir.type_syntax().symbols().is_empty());
+        assert!(
+            !Arc::ptr_eq(&program.core, &const_program),
+            "different stable producers must not share program identity"
+        );
     }
 }
 

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -422,7 +422,7 @@ pub(crate) struct DurableComptimeCallContext {
     parent_producer: crate::StableDefinitionKey,
     parent_declaration: crate::declaration_candidate::DeclarationCandidateKey,
     child_producer: crate::StableDefinitionKey,
-    program: crate::body_query::ForeignComptimeProgramKey,
+    program: crate::body_query::DurableComptimeProgramKey,
     application_policy: DurableComptimeApplicationPolicy,
 }
 
@@ -463,14 +463,16 @@ impl DurableComptimeCallContext {
         parent_declaration: crate::declaration_candidate::DeclarationCandidateKey,
         application_policy: DurableComptimeApplicationPolicy,
     ) -> Result<Self, DurableComptimeLifecycleError> {
-        let child_producer = admitted.plan.key.producer.clone();
+        let child_producer = admitted.plan.key.declaration.clone();
         let Some(child_declaration) =
             crate::revisioned_query_database::declaration_candidate_for_stable_key(&child_producer)
         else {
             return Err(DurableComptimeLifecycleError::InvalidContext);
         };
         if child_declaration != admitted.plan.candidate
-            || admitted.callable.context != child_declaration.module
+            || admitted
+                .callable()
+                .is_none_or(|callable| callable.context != child_declaration.module)
         {
             return Err(DurableComptimeLifecycleError::InvalidContext);
         }
@@ -498,8 +500,8 @@ impl DurableComptimeCallContext {
             parent_producer,
             parent_declaration,
             child_producer: child_producer.clone(),
-            program: crate::body_query::ForeignComptimeProgramKey {
-                producer: child_producer,
+            program: crate::body_query::DurableComptimeProgramKey {
+                declaration: child_producer,
                 configuration,
             },
             application_policy,
@@ -560,8 +562,8 @@ impl DurableComptimeCallContext {
             parent_producer,
             parent_declaration,
             child_producer: child_producer.clone(),
-            program: crate::body_query::ForeignComptimeProgramKey {
-                producer: child_producer,
+            program: crate::body_query::DurableComptimeProgramKey {
+                declaration: child_producer,
                 configuration,
             },
             application_policy,
@@ -685,13 +687,14 @@ impl<V, F> DurableComptimeCompletion<V, F> {
 /// Per-root durable comptime session.
 ///
 /// The AIR frame remains the owner of expression locals, producer identity,
-/// and expected-result context.  This session owns only compiler-side call
-/// lifecycle state and the root-local call ordinal allocator that the future
-/// durable host will use when it issues lifecycle edges.
+/// and expected-result context. This session owns compiler-side call lifecycle
+/// state, the root-local call ordinal allocator, and the one AIR program
+/// registry shared by every root and foreign frame in the evaluation.
 #[derive(Debug)]
 pub(crate) struct DurableComptimeSession {
     lifecycle: DurableComptimeCallLifecycle,
     next_call: u32,
+    programs: crate::body_query::DurableComptimeProgramRegistry,
 }
 
 /// Engine-shaped semantic input for one anonymous nominal.
@@ -851,7 +854,7 @@ pub(crate) enum DurableComptimeForeignCall {
 pub(crate) enum DurableComptimeForeignCallError {
     ReadyFailure(crate::semantic_query_nucleus::SemanticNucleusFailure),
     ReadyQueryFailure(rue_query::QueryFailure),
-    AdmissionFailure(crate::body_query::ForeignComptimeProgramProjectionFailure),
+    AdmissionFailure(crate::body_query::ComptimeProgramProjectionFailure),
     UnexpectedReadyProjection,
     Lifecycle(DurableComptimeLifecycleError),
 }
@@ -864,7 +867,16 @@ impl DurableComptimeSession {
         Ok(Self {
             lifecycle: DurableComptimeCallLifecycle::new(parent_producer, parent_declaration)?,
             next_call: 0,
+            programs: crate::body_query::DurableComptimeProgramRegistry::new(),
         })
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn register_program(
+        &mut self,
+        core: &crate::body_query::OwnedComptimeProgramCore,
+    ) -> Result<(), rue_air::ComptimeProgramRegistrationError> {
+        core.register_into(&mut self.programs)
     }
 
     pub(crate) fn next_call_ordinal(&mut self) -> u32 {
@@ -2151,6 +2163,107 @@ impl AsRef<DurableType> for DurableComptimeType {
 }
 
 impl ComptimeType for DurableComptimeType {}
+
+/// The canonical structured-type job owned by one durable program core. The
+/// job retains the cloned type arena and symbol authority internally; callers
+/// can only resume the exact continuation returned by the AIR resolver.
+#[allow(dead_code)]
+pub(crate) type DurableStructuredTypeJob = rue_air::ComptimeStructuredTypeJob<
+    crate::body_query::DurableComptimeProgramKey,
+    ModuleId,
+    crate::StableDefinitionKey,
+    Arc<str>,
+    crate::StableDefinitionKey,
+    DurableType,
+    DurableConstValue,
+    lasso::Spur,
+    Arc<[Arc<str>]>,
+>;
+
+#[allow(dead_code)]
+pub(crate) type DurableStructuredTypePoll = rue_air::ComptimeStructuredTypePoll<
+    crate::body_query::DurableComptimeProgramKey,
+    ModuleId,
+    crate::StableDefinitionKey,
+    Arc<str>,
+    crate::StableDefinitionKey,
+    DurableType,
+    DurableConstValue,
+    lasso::Spur,
+    Arc<[Arc<str>]>,
+>;
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(crate) enum DurableStructuredTypeBeginError<E, F> {
+    UnregisteredProgram,
+    InvalidProgramAuthority,
+    Resolution(rue_air::SemanticTypeSyntaxError<E, F, crate::StableDefinitionKey, Arc<str>>),
+}
+
+/// Begin the canonical AIR structured resolver against an owning program.
+/// This is deliberately generic over the existing semantic provider so the
+/// adapter adds no second type-syntax traversal or query authority.
+#[allow(dead_code)]
+pub(crate) fn begin_durable_structured_type<Q>(
+    session: &DurableComptimeSession,
+    key: &crate::body_query::DurableComptimeProgramKey,
+    root: rue_rir::RirTypeSyntaxRef,
+    provider: &mut Q,
+) -> Result<DurableStructuredTypePoll, DurableStructuredTypeBeginError<Q::Abort, Q::Failure>>
+where
+    Q: rue_air::SemanticTypeSyntaxProvider<
+            ModuleId,
+            ModuleId,
+            crate::StableDefinitionKey,
+            crate::StableDefinitionKey,
+            Arc<str>,
+            DurableType,
+            DurableConstValue,
+        >,
+{
+    if !session.programs.contains_key(key) {
+        return Err(DurableStructuredTypeBeginError::UnregisteredProgram);
+    }
+    let Some(authority) =
+        session
+            .programs
+            .structured_type_authority(key, key.declaration.module().clone(), root)
+    else {
+        return Err(DurableStructuredTypeBeginError::InvalidProgramAuthority);
+    };
+    DurableStructuredTypeJob::begin::<ModuleId, Q>(provider, authority)
+        .map_err(DurableStructuredTypeBeginError::Resolution)
+}
+
+/// Resume one consuming canonical structured continuation. The reduced call
+/// result is supplied by the same engine that owns the enclosing expression.
+#[allow(dead_code)]
+pub(crate) fn resume_durable_structured_type<Q>(
+    job: DurableStructuredTypeJob,
+    provider: &mut Q,
+    reduced: rue_air::SemanticProviderResult<
+        Option<rue_air::SemanticComptimeCallResult<DurableType, DurableConstValue>>,
+        Q::Abort,
+        Q::Failure,
+    >,
+) -> Result<
+    DurableStructuredTypePoll,
+    rue_air::SemanticTypeSyntaxError<Q::Abort, Q::Failure, crate::StableDefinitionKey, Arc<str>>,
+>
+where
+    Q: rue_air::SemanticTypeSyntaxProvider<
+            ModuleId,
+            ModuleId,
+            crate::StableDefinitionKey,
+            crate::StableDefinitionKey,
+            Arc<str>,
+            DurableType,
+            DurableConstValue,
+        >,
+{
+    job.resume::<ModuleId, Q>(provider, reduced)
+}
 
 impl ComptimeValue for EvaluatedSemanticConst {
     type Type = DurableComptimeType;
@@ -3517,9 +3630,9 @@ mod effect_lifecycle_tests {
             ]),
         };
         let admitted = crate::body_query::OwnedForeignComptimeProgram::from_body_plan(
-            crate::body_query::ForeignComptimeProgramPlan {
-                key: crate::body_query::ForeignComptimeProgramKey {
-                    producer: producer.clone(),
+            crate::body_query::DurableComptimeProgramPlan {
+                key: crate::body_query::DurableComptimeProgramKey {
+                    declaration: producer.clone(),
                     configuration: configuration.clone(),
                 },
                 candidate: candidate.clone(),
@@ -3649,7 +3762,7 @@ mod effect_lifecycle_tests {
                 "query", "failure",
             )),
             ForeignComptimeCallLookup::AdmissionFailure(
-                crate::body_query::ForeignComptimeProgramProjectionFailure::IdentityMismatch,
+                crate::body_query::ComptimeProgramProjectionFailure::IdentityMismatch,
             ),
             ForeignComptimeCallLookup::UnexpectedReadyProjection,
         ];
@@ -3674,7 +3787,7 @@ mod effect_lifecycle_tests {
                     assert_eq!(failure.code.as_ref(), "query")
                 }
                 DurableComptimeForeignCallError::AdmissionFailure(
-                    crate::body_query::ForeignComptimeProgramProjectionFailure::IdentityMismatch,
+                    crate::body_query::ComptimeProgramProjectionFailure::IdentityMismatch,
                 )
                 | DurableComptimeForeignCallError::UnexpectedReadyProjection => {}
                 other => panic!("wrong foreign lookup error channel: {other:?}"),
@@ -3703,7 +3816,7 @@ mod effect_lifecycle_tests {
         lifecycle.complete_known().unwrap();
 
         let mut inconsistent = admitted.clone();
-        inconsistent.plan.candidate = sibling;
+        Arc::make_mut(&mut inconsistent.core).plan.candidate = sibling;
         assert!(matches!(
             DurableComptimeCallContext::from_admitted_expression(
                 &inconsistent,
@@ -4571,6 +4684,473 @@ mod effect_lifecycle_tests {
             )
             .unwrap();
         assert!(lifecycle.complete_known().unwrap().is_empty());
+    }
+}
+
+#[cfg(test)]
+mod structured_type_adapter_tests {
+    use super::*;
+    use std::convert::Infallible;
+
+    struct Provider {
+        scope: ModuleId,
+    }
+
+    impl rue_air::SemanticModulePathProvider<ModuleId, ModuleId, crate::StableDefinitionKey>
+        for Provider
+    {
+        type Abort = Infallible;
+        type Failure = Infallible;
+
+        fn root_module_binding(
+            &mut self,
+            _scope: &ModuleId,
+            _name: &str,
+        ) -> rue_air::SemanticProviderResult<
+            Option<rue_air::SemanticModuleBinding<ModuleId, crate::StableDefinitionKey>>,
+            Self::Abort,
+            Self::Failure,
+        > {
+            Ok(None)
+        }
+
+        fn module_binding(
+            &mut self,
+            _module: &ModuleId,
+            _name: &str,
+        ) -> rue_air::SemanticProviderResult<
+            Option<rue_air::SemanticModuleBinding<ModuleId, crate::StableDefinitionKey>>,
+            Self::Abort,
+            Self::Failure,
+        > {
+            Ok(None)
+        }
+
+        fn module_display_name(&self, module: &ModuleId) -> Arc<str> {
+            Arc::from(module.as_str())
+        }
+
+        fn accessing_domain(&self, scope: &ModuleId) -> rue_air::SemanticVisibilityDomain {
+            assert_eq!(
+                scope, &self.scope,
+                "the registry key supplies the exact root scope"
+            );
+            rue_air::SemanticVisibilityDomain::from_file_path(Some(scope.as_str()))
+        }
+    }
+
+    #[rustfmt::skip]
+    impl rue_air::SemanticTypeSyntaxProvider<ModuleId, ModuleId, crate::StableDefinitionKey, crate::StableDefinitionKey, Arc<str>, DurableType, DurableConstValue> for Provider {
+        fn substituted_type(
+            &mut self,
+            scope: &ModuleId,
+            _name: &str,
+        ) -> rue_air::SemanticProviderResult<Option<DurableType>, Self::Abort, Self::Failure>
+        {
+            assert_eq!(scope, &self.scope);
+            Ok(None)
+        }
+
+        fn primitive_type(
+            &mut self,
+            name: &str,
+        ) -> rue_air::SemanticProviderResult<Option<DurableType>, Self::Abort, Self::Failure>
+        {
+            Ok(match name {
+                "i32" => Some(DurableType::I32),
+                "i64" => Some(DurableType::I64),
+                _ => None,
+            })
+        }
+
+        fn builtin_type(
+            &mut self,
+            _scope: &ModuleId,
+            _name: &str,
+        ) -> rue_air::SemanticProviderResult<Option<DurableType>, Self::Abort, Self::Failure>
+        {
+            Ok(None)
+        }
+
+        fn root_struct_type(
+            &mut self,
+            _scope: &ModuleId,
+            _name: &str,
+        ) -> rue_air::SemanticProviderResult<
+            Option<rue_air::SemanticTypeFact<DurableType, crate::StableDefinitionKey>>,
+            Self::Abort,
+            Self::Failure,
+        > {
+            Ok(None)
+        }
+
+        fn root_enum_type(
+            &mut self,
+            _scope: &ModuleId,
+            _name: &str,
+        ) -> rue_air::SemanticProviderResult<
+            Option<rue_air::SemanticTypeFact<DurableType, crate::StableDefinitionKey>>,
+            Self::Abort,
+            Self::Failure,
+        > {
+            Ok(None)
+        }
+
+        fn root_type_alias(
+            &mut self,
+            _scope: &ModuleId,
+            _name: &str,
+        ) -> rue_air::SemanticProviderResult<
+            Option<rue_air::SemanticTypeFact<DurableType, crate::StableDefinitionKey>>,
+            Self::Abort,
+            Self::Failure,
+        > {
+            Ok(None)
+        }
+
+        fn module_struct_type(
+            &mut self,
+            _module: &ModuleId,
+            _name: &str,
+        ) -> rue_air::SemanticProviderResult<
+            Option<rue_air::SemanticTypeFact<DurableType, crate::StableDefinitionKey>>,
+            Self::Abort,
+            Self::Failure,
+        > {
+            Ok(None)
+        }
+
+        fn module_enum_type(
+            &mut self,
+            _module: &ModuleId,
+            _name: &str,
+        ) -> rue_air::SemanticProviderResult<
+            Option<rue_air::SemanticTypeFact<DurableType, crate::StableDefinitionKey>>,
+            Self::Abort,
+            Self::Failure,
+        > {
+            Ok(None)
+        }
+
+        fn module_type_alias(
+            &mut self,
+            _module: &ModuleId,
+            _name: &str,
+        ) -> rue_air::SemanticProviderResult<
+            Option<rue_air::SemanticTypeFact<DurableType, crate::StableDefinitionKey>>,
+            Self::Abort,
+            Self::Failure,
+        > {
+            Ok(None)
+        }
+
+        fn resolve_array_length(
+            &mut self,
+            _scope: &ModuleId,
+            _length: rue_air::SemanticValueSyntax<'_>,
+        ) -> rue_air::SemanticProviderResult<Option<u64>, Self::Abort, Self::Failure> {
+            unreachable!("fixture has no array syntax")
+        }
+
+        fn array_length_from_value(
+            &mut self,
+            _scope: &ModuleId,
+            _value: &DurableConstValue,
+        ) -> rue_air::SemanticProviderResult<Option<u64>, Self::Abort, Self::Failure> {
+            unreachable!("fixture has no array syntax")
+        }
+
+        fn array_type(
+            &mut self,
+            _element: DurableType,
+            _length: Option<u64>,
+        ) -> rue_air::SemanticProviderResult<DurableType, Self::Abort, Self::Failure> {
+            unreachable!("fixture has no array syntax")
+        }
+
+        fn ptr_const_type(
+            &mut self,
+            _pointee: DurableType,
+        ) -> rue_air::SemanticProviderResult<DurableType, Self::Abort, Self::Failure> {
+            unreachable!("fixture has no pointer syntax")
+        }
+
+        fn ptr_mut_type(
+            &mut self,
+            _pointee: DurableType,
+        ) -> rue_air::SemanticProviderResult<DurableType, Self::Abort, Self::Failure> {
+            unreachable!("fixture has no pointer syntax")
+        }
+
+        fn slice_type(
+            &mut self,
+            _scope: &ModuleId,
+            _syntax: &str,
+            _element: DurableType,
+        ) -> rue_air::SemanticProviderResult<DurableType, Self::Abort, Self::Failure> {
+            unreachable!("fixture has no slice syntax")
+        }
+
+        fn builtin_type_call(
+            &mut self,
+            _scope: &ModuleId,
+            _name: &str,
+            _arguments: &[rue_air::SemanticValueSyntax<'_>],
+        ) -> rue_air::SemanticProviderResult<Option<DurableType>, Self::Abort, Self::Failure>
+        {
+            Ok(None)
+        }
+
+        fn root_constructor(
+            &mut self,
+            scope: &ModuleId,
+            name: &str,
+        ) -> rue_air::SemanticProviderResult<
+            Option<
+                rue_air::SemanticTypeConstructorHead<
+                    crate::StableDefinitionKey,
+                    Arc<str>,
+                    crate::StableDefinitionKey,
+                >,
+            >,
+            Self::Abort,
+            Self::Failure,
+        > {
+            assert_eq!(scope, &self.scope);
+            if name != "Wrap" {
+                return Ok(None);
+            }
+            let constructor = crate::StableDefinitionKey::from_stable_parts(
+                scope.clone(),
+                crate::StableDefinitionNamespace::Value,
+                crate::StableDefinitionKind::Function,
+                name,
+                None,
+            );
+            Ok(Some(rue_air::SemanticTypeConstructorHead {
+                key: constructor.clone(),
+                site: constructor,
+                parameters: Arc::from([rue_air::SemanticTypeConstructorParameter {
+                    name: Arc::from("T"),
+                    is_comptime: true,
+                    is_type: true,
+                }]),
+                returns_type: true,
+                is_public: true,
+                defining_domain: rue_air::SemanticVisibilityDomain::from_file_path(Some(
+                    scope.as_str(),
+                )),
+                defining_file: Arc::from(scope.as_str()),
+            }))
+        }
+
+        fn module_constructor(
+            &mut self,
+            _module: &ModuleId,
+            _name: &str,
+        ) -> rue_air::SemanticProviderResult<
+            Option<
+                rue_air::SemanticTypeConstructorHead<
+                    crate::StableDefinitionKey,
+                    Arc<str>,
+                    crate::StableDefinitionKey,
+                >,
+            >,
+            Self::Abort,
+            Self::Failure,
+        > {
+            Ok(None)
+        }
+
+        fn resolve_value_argument(
+            &mut self,
+            _scope: &ModuleId,
+            _constructor: &str,
+            _head: &rue_air::SemanticTypeConstructorHead<
+                crate::StableDefinitionKey,
+                Arc<str>,
+                crate::StableDefinitionKey,
+            >,
+            _parameter_index: usize,
+            _type_arguments: &[(Arc<str>, DurableType)],
+            _value_arguments: &[(Arc<str>, DurableConstValue)],
+            _syntax: rue_air::SemanticValueSyntax<'_>,
+        ) -> rue_air::SemanticProviderResult<DurableConstValue, Self::Abort, Self::Failure>
+        {
+            unreachable!("fixture constructor has no value argument")
+        }
+
+        fn reduce_comptime_call(
+            &mut self,
+            _head: &rue_air::SemanticTypeConstructorHead<
+                crate::StableDefinitionKey,
+                Arc<str>,
+                crate::StableDefinitionKey,
+            >,
+            _type_arguments: &[(Arc<str>, DurableType)],
+            _value_arguments: &[(Arc<str>, DurableConstValue)],
+        ) -> rue_air::SemanticProviderResult<
+            Option<rue_air::SemanticComptimeCallResult<DurableType, DurableConstValue>>,
+            Self::Abort,
+            Self::Failure,
+        > {
+            unreachable!("the durable host supplies the reduced call result on resume")
+        }
+    }
+
+    fn const_program(
+        path: &str,
+        argument: &str,
+    ) -> Arc<crate::body_query::OwnedComptimeProgramCore> {
+        let snapshot =
+            crate::SourceSnapshot::single(path, format!("const target: Wrap({argument}) = 1;"))
+                .unwrap();
+        let module = crate::parsed_modules::parse_source_snapshot_modules(&snapshot)
+            .unwrap()
+            .modules()[0]
+            .clone();
+        let candidate = module
+            .definitions()
+            .declaration_keys_in_source_order()
+            .find(|candidate| candidate.name.as_ref() == "target")
+            .unwrap()
+            .clone();
+        let artifacts =
+            crate::canonical_lower::lower_parsed_declaration_body_plan(&module, &candidate, || {
+                Ok(())
+            })
+            .unwrap();
+        let key = crate::body_query::DurableComptimeProgramKey {
+            declaration: crate::StableDefinitionKey::from_stable_parts(
+                candidate.module.clone(),
+                crate::StableDefinitionNamespace::Value,
+                crate::StableDefinitionKind::ValueConst,
+                "target",
+                None,
+            ),
+            configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration {
+                target: rue_target::Target::X86_64Linux,
+                preview_features: crate::StablePreviewFeatures::new(
+                    &crate::PreviewFeatures::default(),
+                ),
+            },
+        };
+        crate::body_query::OwnedComptimeProgramCore::from_const_body_plan(
+            crate::body_query::DurableComptimeProgramPlan { key, candidate },
+            &artifacts,
+            || Ok(()),
+        )
+        .unwrap()
+    }
+
+    fn session() -> DurableComptimeSession {
+        let module = ModuleId::from_logical_path("structured-parent.rue").unwrap();
+        let producer = crate::StableDefinitionKey::from_stable_parts(
+            module,
+            crate::StableDefinitionNamespace::Value,
+            crate::StableDefinitionKind::Function,
+            "parent",
+            None,
+        );
+        let declaration =
+            crate::revisioned_query_database::declaration_candidate_for_stable_key(&producer)
+                .unwrap();
+        DurableComptimeSession::new(producer, declaration).unwrap()
+    }
+
+    #[test]
+    fn durable_registry_owns_structured_jobs_across_colliding_programs() {
+        let first = const_program("first.rue", "i32");
+        let second = const_program("second.rue", "i64");
+        let mut session = session();
+        session.register_program(&first).unwrap();
+        session.register_program(&second).unwrap();
+        assert_eq!(
+            session.register_program(&first),
+            Err(rue_air::ComptimeProgramRegistrationError::AlreadyRegistered)
+        );
+
+        let (_, Some(first_root), _) = first.const_root().unwrap() else {
+            panic!("first const retains its declared type root");
+        };
+        let (_, Some(second_root), _) = second.const_root().unwrap() else {
+            panic!("second const retains its declared type root");
+        };
+        assert_eq!(first_root, second_root, "fixture uses colliding dense refs");
+
+        let mut first_provider = Provider {
+            scope: first.plan.candidate.module.clone(),
+        };
+        let first_poll = begin_durable_structured_type(
+            &session,
+            &first.plan.key,
+            first_root,
+            &mut first_provider,
+        )
+        .unwrap();
+        let DurableStructuredTypePoll::Suspended(first_job) = first_poll else {
+            panic!("Wrap(i32) suspends for the durable call result");
+        };
+        assert_eq!(first_job.program(), &first.plan.key);
+        assert_eq!(
+            first_job.type_arguments(),
+            &[(Arc::from("T"), DurableType::I32)]
+        );
+        let first_ready = resume_durable_structured_type(
+            *first_job,
+            &mut first_provider,
+            Ok(Some(rue_air::SemanticComptimeCallResult::Type(
+                DurableType::I64,
+            ))),
+        )
+        .unwrap();
+        assert!(matches!(
+            first_ready,
+            DurableStructuredTypePoll::Ready(DurableType::I64)
+        ));
+
+        let mut second_provider = Provider {
+            scope: second.plan.candidate.module.clone(),
+        };
+        let second_poll = begin_durable_structured_type(
+            &session,
+            &second.plan.key,
+            second_root,
+            &mut second_provider,
+        )
+        .unwrap();
+        let DurableStructuredTypePoll::Suspended(second_job) = second_poll else {
+            panic!("colliding program independently suspends");
+        };
+        assert_eq!(second_job.program(), &second.plan.key);
+        assert_ne!(second_job.program(), &first.plan.key);
+        assert_eq!(
+            second_job.type_arguments(),
+            &[(Arc::from("T"), DurableType::I64)],
+            "the second key selects the second arena despite its colliding root ref"
+        );
+
+        let mut missing_key = first.plan.key.clone();
+        missing_key.declaration = crate::StableDefinitionKey::from_stable_parts(
+            ModuleId::from_logical_path("missing.rue").unwrap(),
+            crate::StableDefinitionNamespace::Value,
+            crate::StableDefinitionKind::ValueConst,
+            "target",
+            None,
+        );
+        assert!(matches!(
+            begin_durable_structured_type(&session, &missing_key, first_root, &mut first_provider),
+            Err(DurableStructuredTypeBeginError::UnregisteredProgram)
+        ));
+        assert!(matches!(
+            begin_durable_structured_type(
+                &session,
+                &first.plan.key,
+                rue_rir::RirTypeSyntaxRef::from_u32(u32::MAX),
+                &mut first_provider
+            ),
+            Err(DurableStructuredTypeBeginError::InvalidProgramAuthority)
+        ));
     }
 }
 

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -23540,7 +23540,7 @@ impl<'a> CompilerBodyFactProvider<'a> {
         let Some(declaration) = declaration_candidate_for_stable_key(producer) else {
             return Ok(
                 crate::body_query::ForeignComptimeCallLookup::AdmissionFailure(
-                    crate::body_query::ForeignComptimeProgramProjectionFailure::InvalidProducer(
+                    crate::body_query::ComptimeProgramProjectionFailure::InvalidProducer(
                         producer.clone(),
                     ),
                 ),
@@ -23551,9 +23551,9 @@ impl<'a> CompilerBodyFactProvider<'a> {
             type_arguments: type_arguments.to_vec().into(),
             value_arguments: value_arguments.to_vec().into(),
         };
-        let foreign_plan = crate::body_query::ForeignComptimeProgramPlan {
-            key: crate::body_query::ForeignComptimeProgramKey {
-                producer: producer.clone(),
+        let foreign_plan = crate::body_query::DurableComptimeProgramPlan {
+            key: crate::body_query::DurableComptimeProgramKey {
+                declaration: producer.clone(),
                 configuration: self.queries.configuration.clone(),
             },
             candidate: declaration,
@@ -23592,15 +23592,17 @@ impl<'a> CompilerBodyFactProvider<'a> {
                     rue_query::QueryOutcome::Success(
                         DeclarationBodyPlanArtifactsValue::Failure(failure),
                     ) => {
-                        return Ok(crate::body_query::ForeignComptimeCallLookup::AdmissionFailure(
-                            crate::body_query::ForeignComptimeProgramProjectionFailure::Artifact(
-                                failure.clone(),
+                        return Ok(
+                            crate::body_query::ForeignComptimeCallLookup::AdmissionFailure(
+                                crate::body_query::ComptimeProgramProjectionFailure::Artifact(
+                                    failure.clone(),
+                                ),
                             ),
-                        ));
+                        );
                     }
                     rue_query::QueryOutcome::Failure(failure) => {
                         return Ok(crate::body_query::ForeignComptimeCallLookup::AdmissionFailure(
-                            crate::body_query::ForeignComptimeProgramProjectionFailure::ArtifactQueryFailure(
+                            crate::body_query::ComptimeProgramProjectionFailure::ArtifactQueryFailure(
                                 failure.clone(),
                             ),
                         ));
@@ -23619,11 +23621,9 @@ impl<'a> CompilerBodyFactProvider<'a> {
                     Ok(program) => Ok(crate::body_query::ForeignComptimeCallLookup::Admitted(
                         program,
                     )),
-                    Err(
-                        crate::body_query::ForeignComptimeProgramProjectionFailure::Materialization(
-                            crate::canonical_lower::BodyPlanMaterializationFailure::Query(abort),
-                        ),
-                    ) => Err(abort),
+                    Err(crate::body_query::ComptimeProgramProjectionFailure::Materialization(
+                        crate::canonical_lower::BodyPlanMaterializationFailure::Query(abort),
+                    )) => Err(abort),
                     Err(error) => {
                         Ok(crate::body_query::ForeignComptimeCallLookup::AdmissionFailure(error))
                     }
@@ -28226,9 +28226,12 @@ fn main() -> i32 {
         let crate::body_query::ForeignComptimeCallLookup::Admitted(program) = probe else {
             panic!("cold foreign comptime lookup should admit its owned body plan");
         };
-        assert_eq!(program.plan.key.producer, producer);
-        assert_eq!(program.callable.context.as_str(), "main.rue");
-        assert_eq!(program.import_occurrences.len(), 1);
+        assert_eq!(program.plan.key.declaration, producer);
+        assert_eq!(
+            program.callable().expect("callable root").context.as_str(),
+            "main.rue"
+        );
+        assert_eq!(program.imports.len(), 1);
         assert_eq!(
             database
                 .declaration_body_plan_astgen_evaluations


### PR DESCRIPTION
Relates to RUE-1774

This staged prerequisite gives const roots and admitted foreign comptime callables one AIR-owned program representation and one compiler admission kernel. A durable session now owns the keyed AIR registry and exposes typed begin/resume operations for structured-type jobs, including collision and authority regression coverage.

The production SemanticConstEvaluator is deliberately unchanged in this slice; there is no evaluator/root cutover and no language-semantic expansion.

Validation:
- scripts/rue premerge (200 passed)
- targeted compiler Clippy
- durable comptime, API inventory, and AIR keyed-job tests