### PR TITLE
RUE-1774: isolate durable foreign comptime admission

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -3368,10 +3368,80 @@ fn durable_comptime_services_are_named_authority_operations() {
     assert!(!foreign_adapter.contains("SemanticConstEvaluator"));
     assert!(!foreign_adapter.contains("ComptimeEngine"));
     let comptime_probe = database
-        .split("fn probe_comptime_call_inner(")
+        .split("struct DurableComptimeForeignQueryAuthority<'a> {")
         .nth(1)
-        .and_then(|source| source.split("pub(crate) fn probe_comptime_call(").next())
-        .expect("compiler comptime probe adapter");
+        .and_then(|source| source.split("impl CompilerBodyFactProvider").next())
+        .expect("canonical compiler comptime probe authority");
+    let probe_fields = database
+        .split("struct DurableComptimeForeignQueryAuthority<'a> {")
+        .nth(1)
+        .and_then(|source| {
+            source
+                .split("}\n\n#[allow(dead_code)] // activated by the staged durable AIR host\nimpl")
+                .next()
+        })
+        .expect("foreign probe authority fields");
+    let probe_field_lines = probe_fields
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.ends_with(','))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        probe_field_lines,
+        [
+            "context: &'a QueryContext,",
+            "semantic_nucleus: &'a SemanticNucleusFamily,",
+            "&'a QueryFamily<DeclarationBodyPlanQueryKey, DeclarationBodyPlanArtifactsValue>,",
+            "configuration: &'a crate::semantic_query_nucleus::SemanticQueryConfiguration,",
+        ],
+        "foreign probe authority must retain exactly four narrow query authorities"
+    );
+    assert!(probe_fields.contains(
+        "declaration_body_plan_artifacts:\n        &'a QueryFamily<DeclarationBodyPlanQueryKey, DeclarationBodyPlanArtifactsValue>,"
+    ));
+    assert_eq!(
+        comptime_probe
+            .matches("join_registered_noncomputing(")
+            .count(),
+        1
+    );
+    assert_eq!(comptime_probe.matches("query_registered(").count(), 1);
+    assert_eq!(
+        comptime_probe
+            .matches("OwnedForeignComptimeProgram::from_body_plan")
+            .count(),
+        1
+    );
+    let join_at = comptime_probe
+        .find("join_registered_noncomputing(")
+        .expect("foreign probe begins with a non-computing semantic lookup");
+    let artifact_at = comptime_probe
+        .find("query_registered(")
+        .expect("foreign probe may query only the declaration body-plan family");
+    let admission_at = comptime_probe
+        .find("OwnedForeignComptimeProgram::from_body_plan")
+        .expect("a cold foreign probe admits the owned body plan");
+    assert!(join_at < artifact_at && artifact_at < admission_at);
+    assert!(comptime_probe.contains("self.declaration_body_plan_artifacts"));
+    assert!(!comptime_probe.contains("query_registered(self.semantic_nucleus"));
+    assert_eq!(
+        database
+            .matches(
+                "impl crate::durable_comptime::DurableComptimeForeignCallAuthority\n    for DurableComptimeForeignQueryAuthority"
+            )
+            .count(),
+        1,
+        "one narrow query authority must own foreign-call probe policy"
+    );
+    assert_eq!(
+        database
+            .matches(
+                "impl crate::durable_comptime::DurableComptimeForeignCallAuthority for CompilerBodyFactProvider"
+            )
+            .count(),
+        0,
+        "the broad body provider must not implement foreign-call policy"
+    );
     assert!(
         comptime_probe.contains("join_registered_noncomputing(")
             && !comptime_probe.contains("probe_registered_ready("),
@@ -3382,6 +3452,45 @@ fn durable_comptime_services_are_named_authority_operations() {
             && !comptime_probe.contains("query_task_registered"),
         "comptime probe must not validate retained candidates or demand a peer query body"
     );
+    for forbidden in [
+        "SemanticConstEvaluator",
+        "ComptimeEngine",
+        "InstData",
+        "InstRef",
+        "query(&self.queries.semantic_nucleus",
+        "query(&self.semantic_nucleus",
+        "query_task_registered",
+        "valid_for_revision",
+    ] {
+        assert!(
+            !comptime_probe.contains(forbidden),
+            "foreign probe authority gained forbidden computation authority: {forbidden}"
+        );
+    }
+    for required in [
+        "context: &'a QueryContext",
+        "semantic_nucleus: &'a SemanticNucleusFamily",
+        "declaration_body_plan_artifacts:",
+        "configuration: &'a crate::semantic_query_nucleus::SemanticQueryConfiguration",
+        "ReadyQueryProbe::Miss | rue_query::ReadyQueryProbe::NotReady",
+        "OwnedForeignComptimeProgram::from_body_plan",
+    ] {
+        assert!(
+            comptime_probe.contains(required),
+            "foreign probe authority lost an exact query-side operation: {required}"
+        );
+    }
+    assert!(database.contains("DurableComptimeServices::new(&authority).probe_comptime_call("));
+    assert!(production_facade.contains("pub(crate) fn registered_program("));
+    let registry_accessor = production_facade
+        .split("pub(crate) fn registered_program(")
+        .nth(1)
+        .and_then(|source| source.split("\n    fn observe_anonymous_nominal").next())
+        .expect("keyed durable program registry accessor");
+    assert!(registry_accessor.contains("self.programs.get(key)"));
+    assert!(!registry_accessor.contains("ComptimeEngine"));
+    assert!(!registry_accessor.contains("InstData"));
+    assert!(!registry_accessor.contains("InstRef"));
     assert!(!production_facade.contains("impl Clone for DurableComptimeForeignCall"));
     assert!(!production_facade.contains("impl Clone for DurableComptimeCallTicket"));
     for (kind, non_replayable) in [
@@ -4377,7 +4486,26 @@ fn durable_comptime_services_are_named_authority_operations() {
         .nth(1)
         .and_then(|source| source.split("impl rue_air::BodyFactProvider").next())
         .expect("body fact provider source");
-    assert!(provider.contains("DurableComptimeServices::new(self).probe_comptime_call"));
+    let provider_probe = provider
+        .split("pub(crate) fn probe_comptime_call(")
+        .nth(1)
+        .and_then(|source| source.split("\n    fn nucleus(").next())
+        .expect("broad provider probe adapter");
+    assert!(provider_probe.contains("DurableComptimeForeignQueryAuthority {"));
+    assert!(
+        provider_probe.contains("DurableComptimeServices::new(&authority).probe_comptime_call")
+    );
+    for forbidden in [
+        "join_registered_noncomputing(",
+        "query_registered(",
+        "OwnedForeignComptimeProgram::from_body_plan",
+    ] {
+        assert!(
+            !provider_probe.contains(forbidden),
+            "broad provider must not retain foreign probe policy: {forbidden}"
+        );
+    }
+    assert!(provider.contains("DurableComptimeServices::new(&authority).probe_comptime_call"));
 }
 
 #[test]

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -924,6 +924,18 @@ impl DurableComptimeSession {
         ordinal
     }
 
+    /// Read one already-registered program by its complete stable key. Dense
+    /// instruction references remain meaningful only through the returned
+    /// owning program, so callers cannot accidentally pair a reference with a
+    /// colliding program.
+    #[allow(dead_code)] // consumed by the staged durable AIR host
+    pub(crate) fn registered_program(
+        &self,
+        key: &crate::body_query::DurableComptimeProgramKey,
+    ) -> Option<&crate::body_query::DurableComptimeProgram> {
+        self.programs.get(key)
+    }
+
     fn observe_anonymous_nominal(&mut self, nominal: DurableAnonymousNominal) {
         self.lifecycle.observe_anonymous_nominal(nominal);
     }
@@ -1931,6 +1943,7 @@ pub(crate) trait DurableComptimeSemanticAuthority {
     ) -> Result<TargetEnumValue, rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>>;
 }
 
+#[allow(dead_code)] // activated by the staged durable AIR host
 pub(crate) trait DurableComptimeForeignCallAuthority {
     fn probe_comptime_call(
         &self,
@@ -2034,10 +2047,12 @@ impl<A: DurableComptimeSemanticAuthority + ?Sized> DurableComptimeServices<'_, A
     }
 }
 
+#[allow(dead_code)] // activated by the staged durable AIR host
 impl<A: DurableComptimeForeignCallAuthority + ?Sized> DurableComptimeServices<'_, A> {
     /// Probe only an already-published foreign fact or admit its owned body
     /// frame. The authority owns dependency observation and cancellation; this
     /// method never demands a child comptime query.
+    #[allow(dead_code)] // activated by the staged durable AIR host
     pub(crate) fn probe_comptime_call(
         &self,
         producer: &crate::StableDefinitionKey,
@@ -5114,9 +5129,11 @@ mod structured_type_adapter_tests {
         path: &str,
         argument: &str,
     ) -> Arc<crate::body_query::OwnedComptimeProgramCore> {
-        let snapshot =
-            crate::SourceSnapshot::single(path, format!("const target: Wrap({argument}) = 1;"))
-                .unwrap();
+        let snapshot = crate::SourceSnapshot::single(
+            path,
+            format!("const target: Wrap({argument}) = @import(\"{path}\");"),
+        )
+        .unwrap();
         let module = crate::parsed_modules::parse_source_snapshot_modules(&snapshot)
             .unwrap()
             .modules()[0]
@@ -5237,6 +5254,29 @@ mod structured_type_adapter_tests {
             panic!("second const retains its declared type root");
         };
         assert_eq!(first_root, second_root, "fixture uses colliding dense refs");
+
+        let first_registered = session.registered_program(&first.plan.key).unwrap();
+        let second_registered = session.registered_program(&second.plan.key).unwrap();
+        assert!(std::sync::Arc::ptr_eq(&first_registered.rir, &first.rir));
+        assert!(std::sync::Arc::ptr_eq(&second_registered.rir, &second.rir));
+        assert_ne!(first_registered.symbols, second_registered.symbols);
+        assert_eq!(first_registered.imports.len(), 1);
+        assert_eq!(second_registered.imports.len(), 1);
+        assert_eq!(
+            first_registered.imports[0].specifier,
+            Arc::<str>::from("first.rue")
+        );
+        assert_eq!(
+            second_registered.imports[0].specifier,
+            Arc::<str>::from("second.rue")
+        );
+        let mut wrong_configuration = first.plan.key.configuration.clone();
+        wrong_configuration.target = rue_target::Target::Aarch64Linux;
+        let wrong_key = rue_air::ComptimeProgramKey {
+            declaration: first.plan.key.declaration.clone(),
+            configuration: wrong_configuration,
+        };
+        assert!(session.registered_program(&wrong_key).is_none());
 
         let mut first_provider = Provider {
             scope: first.plan.candidate.module.clone(),

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -21478,6 +21478,7 @@ pub(crate) struct CompilerBodyProviderQueries<'a> {
     module_source_bases: QueryFamily<ModuleQueryKey, Option<rue_air::DurableBodySourceLocator>>,
     lookup_names: QueryFamily<LookupNameKey, LookupNameValue>,
     lookup_imports: QueryFamily<LookupImportKey, LookupImportValue>,
+    #[allow(dead_code)] // consumed by the staged durable AIR probe authority
     declaration_body_plan_artifacts:
         QueryFamily<DeclarationBodyPlanQueryKey, DeclarationBodyPlanArtifactsValue>,
     semantic_nucleus: QueryFamily<
@@ -23522,14 +23523,25 @@ impl<'a> CompilerBodyFactProvider<'a> {
             .context
             .query_registered(&self.queries.semantic_nucleus, key)
     }
+}
 
-    /// Reuse or join the exact-current comptime-call fact without claiming a
-    /// semantic-nucleus attempt. A cold miss or a non-ready handoff admits the
-    /// canonical body plan into an owned foreign-program payload without
-    /// claiming or publishing a SemanticNucleus attempt; a current owner is
-    /// still joined whenever it can safely publish.
-    #[allow(dead_code)]
-    fn probe_comptime_call_inner(
+/// The single query-side authority for non-computing foreign comptime
+/// admission. Every caller supplies the exact query context and registered
+/// families; this authority never owns a database or invokes a query body.
+#[allow(dead_code)] // activated by the staged durable AIR host
+struct DurableComptimeForeignQueryAuthority<'a> {
+    context: &'a QueryContext,
+    semantic_nucleus: &'a SemanticNucleusFamily,
+    declaration_body_plan_artifacts:
+        &'a QueryFamily<DeclarationBodyPlanQueryKey, DeclarationBodyPlanArtifactsValue>,
+    configuration: &'a crate::semantic_query_nucleus::SemanticQueryConfiguration,
+}
+
+#[allow(dead_code)] // activated by the staged durable AIR host
+impl crate::durable_comptime::DurableComptimeForeignCallAuthority
+    for DurableComptimeForeignQueryAuthority<'_>
+{
+    fn probe_comptime_call(
         &self,
         producer: &crate::StableDefinitionKey,
         type_arguments: &[(Arc<str>, crate::durable_semantics::DurableType)],
@@ -23545,19 +23557,22 @@ impl<'a> CompilerBodyFactProvider<'a> {
             );
         };
         let key = crate::semantic_query_nucleus::ComptimeCallQueryKey {
-            declaration: self.declaration_query_key(&declaration),
+            declaration: crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
+                declaration: declaration.clone(),
+                configuration: self.configuration.clone(),
+            },
             type_arguments: type_arguments.to_vec().into(),
             value_arguments: value_arguments.to_vec().into(),
         };
         let foreign_plan = crate::body_query::DurableComptimeProgramPlan {
             key: crate::body_query::DurableComptimeProgramKey {
                 declaration: producer.clone(),
-                configuration: self.queries.configuration.clone(),
+                configuration: self.configuration.clone(),
             },
             candidate: declaration,
         };
-        match self.queries.context.join_registered_noncomputing(
-            &self.queries.semantic_nucleus,
+        match self.context.join_registered_noncomputing(
+            self.semantic_nucleus,
             crate::semantic_query_nucleus::SemanticNucleusKey::ComptimeCall(key.clone()),
         )? {
             rue_query::ReadyQueryProbe::Ready(terminal) => match terminal.outcome() {
@@ -23579,8 +23594,8 @@ impl<'a> CompilerBodyFactProvider<'a> {
                 _ => Ok(crate::body_query::ForeignComptimeCallLookup::UnexpectedReadyProjection),
             },
             rue_query::ReadyQueryProbe::Miss | rue_query::ReadyQueryProbe::NotReady => {
-                let artifacts = self.queries.context.query_registered(
-                    &self.queries.declaration_body_plan_artifacts,
+                let artifacts = self.context.query_registered(
+                    self.declaration_body_plan_artifacts,
                     DeclarationBodyPlanQueryKey(foreign_plan.candidate.clone()),
                 )?;
                 let artifacts = match artifacts.outcome() {
@@ -23614,7 +23629,7 @@ impl<'a> CompilerBodyFactProvider<'a> {
                     foreign_plan,
                     artifacts,
                     seed,
-                    || self.queries.context.check_canceled(),
+                    || self.context.check_canceled(),
                 ) {
                     Ok(program) => Ok(crate::body_query::ForeignComptimeCallLookup::Admitted(
                         program,
@@ -23629,14 +23644,23 @@ impl<'a> CompilerBodyFactProvider<'a> {
             }
         }
     }
+}
 
+impl CompilerBodyFactProvider<'_> {
+    #[allow(dead_code)] // activated by the staged durable AIR host
     pub(crate) fn probe_comptime_call(
         &self,
         producer: &crate::StableDefinitionKey,
         type_arguments: &[(Arc<str>, crate::durable_semantics::DurableType)],
         value_arguments: &[(Arc<str>, crate::durable_semantics::DurableConstValue)],
     ) -> Result<crate::body_query::ForeignComptimeCallLookup, QueryAbort> {
-        crate::durable_comptime::DurableComptimeServices::new(self).probe_comptime_call(
+        let authority = DurableComptimeForeignQueryAuthority {
+            context: self.queries.context,
+            semantic_nucleus: &self.queries.semantic_nucleus,
+            declaration_body_plan_artifacts: &self.queries.declaration_body_plan_artifacts,
+            configuration: &self.queries.configuration,
+        };
+        crate::durable_comptime::DurableComptimeServices::new(&authority).probe_comptime_call(
             producer,
             type_arguments,
             value_arguments,
@@ -23796,17 +23820,6 @@ impl<'a> CompilerBodyFactProvider<'a> {
             });
         }
         found
-    }
-}
-
-impl crate::durable_comptime::DurableComptimeForeignCallAuthority for CompilerBodyFactProvider<'_> {
-    fn probe_comptime_call(
-        &self,
-        producer: &crate::StableDefinitionKey,
-        type_arguments: &[(Arc<str>, crate::durable_semantics::DurableType)],
-        value_arguments: &[(Arc<str>, crate::durable_semantics::DurableConstValue)],
-    ) -> Result<crate::body_query::ForeignComptimeCallLookup, QueryAbort> {
-        self.probe_comptime_call_inner(producer, type_arguments, value_arguments)
     }
 }
 
@@ -28226,6 +28239,11 @@ fn main() -> i32 {
         };
         assert_eq!(program.plan.key.declaration, producer);
         assert_eq!(
+            program.plan.key.configuration,
+            semantic_configuration(),
+            "owned admission must retain the exact requested configuration"
+        );
+        assert_eq!(
             program.callable().expect("callable root").context.as_str(),
             "main.rue"
         );
@@ -28358,9 +28376,9 @@ fn main() -> i32 {
         ));
         let source = include_str!("revisioned_query_database.rs");
         let probe = source
-            .split("fn probe_comptime_call_inner(")
+            .split("struct DurableComptimeForeignQueryAuthority<'a> {")
             .nth(1)
-            .and_then(|source| source.split("pub(crate) fn probe_comptime_call(").next())
+            .and_then(|source| source.split("impl CompilerBodyFactProvider").next())
             .expect("the canonical comptime probe");
         let not_ready = probe
             .find("rue_query::ReadyQueryProbe::Miss | rue_query::ReadyQueryProbe::NotReady =>")
@@ -28376,7 +28394,7 @@ fn main() -> i32 {
             "Miss and NotReady must use the owned foreign-plan admission path"
         );
         assert!(
-            !arm.contains("query_registered(&self.queries.semantic_nucleus")
+            !arm.contains("query_registered(&self.semantic_nucleus")
                 && !arm.contains("probe_registered_ready("),
             "owned-plan admission must not demand or evaluate the semantic nucleus"
         );


### PR DESCRIPTION
Summary:
- extract foreign comptime probing into one four-authority, non-computing query adapter
- expose one immutable keyed durable program view while keeping the registry private
- pin collision isolation and join-before-admission ordering with focused tests and inventory guards

This is a semantics-preserving prerequisite for the staged evaluator migration. It does not switch either evaluator root to the AIR engine.

Testing:
- scripts/rue fmt
- scripts/rue unit compiler durable_ (81 passed)
- scripts/rue unit compiler foreign_comptime_probe (2 passed)
- scripts/rue unit compiler not_ready_foreign_probe (1 passed)
- scripts/rue quick (31 targets passed)
- scripts/rue premerge (200 targets passed)

Relates to RUE-1774