### PR TITLE
Spec: rule that an uncategorised paragraph is informative, and fix two false claims

### DIFF
--- a/crates/rue-spec/cases/appendices/implementation-limits.toml
+++ b/crates/rue-spec/cases/appendices/implementation-limits.toml
@@ -408,3 +408,40 @@ fn main() -> i32 { (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
 """
 compile_fail = true
 error_contains = "nests too deeply"
+
+# =============================================================================
+# ABI-slot ceiling (C.4:3)
+# =============================================================================
+# C.4:3 publishes the 268,435,455-slot object ceiling and states that a type
+# needing more slots is rejected with E0906 wherever a value of it would be
+# materialized — including a `@size_of` query. RUE-1768 gave the paragraph an
+# explicit category; these are the cases that category requires.
+#
+# The boundary is checked from both sides, because a one-sided case would pass
+# against a ceiling set anywhere below the published number. The check is on
+# the layout, not on allocated storage, so neither case materializes an array.
+
+[[case]]
+name = "object_at_the_abi_slot_ceiling_is_accepted"
+spec = ["C.4:3"]
+description = "A type of exactly 268,435,455 ABI slots is within the ceiling and reports its size"
+source = """
+fn main() -> i32 {
+    let n: i32 = @size_of([i8; 268435455]);
+    if n == 268435455 { 42 } else { 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "object_one_slot_over_the_ceiling_is_rejected"
+spec = ["C.4:3"]
+description = "One element more than the ceiling is rejected with E0906, and the diagnostic names the slot ceiling as C.1:2 requires"
+source = """
+fn main() -> i32 {
+    let n: i32 = @size_of([i8; 268435456]);
+    if n > 0 { 1 } else { 0 }
+}
+"""
+compile_fail = true
+error_contains = ["E0906", "268435455 ABI slots"]

--- a/crates/rue-spec/cases/lexical/tokens.toml
+++ b/crates/rue-spec/cases/lexical/tokens.toml
@@ -763,3 +763,49 @@ fn main() -> i32 { ﻿42 }
 """
 compile_fail = true
 error_contains = ["E0001"]
+
+# =============================================================================
+# Decomposition into tokens (2.0:1)
+# =============================================================================
+# 2.0:1 states the basis of this chapter: source text is decomposed into a
+# sequence of tokens, and comments and whitespace may separate tokens without
+# being tokens themselves. RUE-1768 gave the paragraph an explicit category —
+# it had none, so nothing tracked it — and these cases are the coverage that
+# category now requires.
+#
+# "Separates but is not itself a token" has two observable halves, and both are
+# pinned below: a separator may stand between two tokens without becoming one,
+# and where a separator is the only thing between two tokens, removing it joins
+# them into a different token rather than leaving the sequence unchanged.
+
+[[case]]
+name = "line_comment_separates_two_tokens"
+spec = ["2.0:1"]
+description = "A line comment may stand between two tokens; it separates them without contributing a token of its own"
+source = """
+fn main() -> i32 {
+    let // a comment may stand between two tokens
+        x: i32 = 42;
+    x
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "whitespace_is_not_a_token"
+spec = ["2.0:1"]
+description = "Whitespace that is not needed as a separator may be removed entirely: it contributes no token, so the sequence is unchanged"
+source = """
+fn main()->i32{let x:i32=42;x}
+"""
+exit_code = 42
+
+[[case]]
+name = "whitespace_as_sole_separator_cannot_be_removed"
+spec = ["2.0:1"]
+description = "Where whitespace is the only separator between two tokens, removing it lexes one different token instead: 'let x' becomes the identifier 'letx'"
+source = """
+fn main() -> i32 { letx: i32 = 42; x }
+"""
+compile_fail = true
+error_contains = ["E0102", "expected semicolon after expression"]

--- a/crates/rue-spec/cases/modules/directory.toml
+++ b/crates/rue-spec/cases/modules/directory.toml
@@ -187,3 +187,36 @@ pub fn f() -> i32 { 1 }
 """ }
 compile_fail = true
 error_contains = "cannot find module"
+
+# =============================================================================
+# The two module forms coexist for one name (10.1:5)
+# =============================================================================
+# 10.1:5 states that a file module `shape.rue` and a directory module
+# `shape/_shape.rue` may both exist for the same name without ambiguity: the
+# extensionless path names the directory module alone, and the file module is
+# reached only by its extensioned spelling. The former ambiguity rejection
+# (E0708) is retired, so the absence of a diagnostic is itself the rule.
+#
+# RUE-1768 gave the paragraph an explicit category — it had none, so nothing
+# tracked it. This case builds both forms at once and distinguishes them by
+# return value, which is what makes it evidence for the rule rather than for
+# directory resolution alone: a case importing only one form would pass even if
+# the two spellings collapsed onto the same module.
+
+[[case]]
+name = "file_and_directory_forms_coexist_for_one_name"
+spec = ["10.1:5"]
+description = "With both shape.rue and shape/_shape.rue present, the extensionless import names the directory module and the extensioned one names the file module"
+source = """
+fn main() -> i32 {
+    let dir = @import("shape");
+    let file = @import("shape.rue");
+    dir.tag() * 10 + file.tag()
+}
+"""
+aux_files = { "shape.rue" = """
+pub fn tag() -> i32 { 1 }
+""", "shape/_shape.rue" = """
+pub fn tag() -> i32 { 2 }
+""" }
+exit_code = 21

--- a/crates/rue-spec/cases/runtime/traps.toml
+++ b/crates/rue-spec/cases/runtime/traps.toml
@@ -1,0 +1,83 @@
+[section]
+id = "runtime.traps"
+spec_chapter = "8.0"
+name = "Trap Discipline"
+description = "The shared discipline every trap category obeys: a trap abandons the evaluation and halts with exit code 101 (spec 8.0:1, B.2:5)."
+
+# =============================================================================
+# The shared trap discipline (8.0:1, B.2:5)
+# =============================================================================
+# The individual categories are pinned by their own sections — overflow.toml,
+# division.toml, bounds.toml. What 8.0:1 and B.2:5 state is the property those
+# sections have in *common*: whichever category fires, the program halts with
+# exit code 101, and no surrounding expression can consume the trap as a value.
+#
+# Both paragraphs carried no `cat=` marker until RUE-1768, so neither was
+# tracked by the coverage gate even though a normative MUST in 8.2:9 grounds
+# itself on 8.0:1. These cases are the coverage their categories now require.
+#
+# One case per category rather than one representative case: the claim is that
+# the exit code is uniform *across* categories, and a single case cannot be
+# evidence for uniformity.
+
+[[case]]
+name = "overflow_trap_halts_with_101"
+spec = ["8.0:1", "B.2:5"]
+description = "An integer overflow trap halts the program with the panic exit code"
+source = """
+fn main() -> i32 {
+    let a: i32 = 2147483647;
+    let b: i32 = 1;
+    a + b
+}
+"""
+runtime_error = "integer overflow"
+runtime_exit_code = 101
+
+[[case]]
+name = "division_by_zero_trap_halts_with_101"
+spec = ["8.0:1", "B.2:5"]
+description = "A division-by-zero trap halts the program with the same exit code as every other category"
+source = """
+fn main() -> i32 {
+    let a: i32 = 1;
+    let b: i32 = 0;
+    a / b
+}
+"""
+runtime_error = "division by zero"
+runtime_exit_code = 101
+
+[[case]]
+name = "bounds_trap_halts_with_101"
+spec = ["8.0:1", "B.2:5"]
+description = "An out-of-range array index traps with the same exit code as every other category"
+source = """
+fn main() -> i32 {
+    let arr: [i32; 3] = [10, 20, 30];
+    let i: u64 = 7;
+    arr[i]
+}
+"""
+runtime_error = "index out of bounds"
+runtime_exit_code = 101
+
+# `user` is the category 8.0:1 omitted before RUE-1776: the prose claimed the
+# core fixes "exactly" four categories while the core states five. An explicit
+# @panic is the fifth, and it obeys the same discipline as the other four.
+[[case]]
+name = "user_panic_trap_halts_with_101"
+spec = ["8.0:1", "B.2:5"]
+description = "An explicit @panic is the core's fifth trap category and halts with the same exit code"
+source = """
+fn main() -> i32 {
+    @panic("boom");
+}
+"""
+# Asserted as a plain exit code rather than `runtime_error`, matching how every
+# other @panic case in the corpus is written. A `runtime_error` expectation on
+# an explicit panic classifies in rue-oracle-diff as an unmodeled "runtime trap
+# expectation", which is harness coverage rather than typed oracle model debt
+# and cannot be registered as a model gap. The three modeled trap categories
+# above keep their `runtime_error` assertions.
+exit_code = 101

--- a/crates/rue-spec/cases/statements/expression-statements.toml
+++ b/crates/rue-spec/cases/statements/expression-statements.toml
@@ -168,3 +168,42 @@ fn main() -> i32 {
 }
 """
 exit_code = 5
+
+# =============================================================================
+# Every statement has type () (5.0:1)
+# =============================================================================
+# 5.0:1 is the chapter's basis: a statement is evaluated for its effect, every
+# statement has type `()`, and none of the three forms delivers a value to the
+# block containing it. RUE-1768 gave the paragraph an explicit category — it
+# had none — and these are the cases that category requires.
+#
+# The negative case is the load-bearing one: it is what distinguishes "the
+# statement's value is unit" from "the statement has no value at all", and it
+# fails with the unit type named in the diagnostic.
+
+[[case]]
+name = "block_ending_in_a_statement_is_unit"
+spec = ["5.0:1"]
+description = "A function body whose final item is a `let` statement types as (), so a unit-returning function accepts it"
+source = """
+fn effect_only() { let x: i32 = 1; }
+
+fn main() -> i32 {
+    effect_only();
+    7
+}
+"""
+exit_code = 7
+
+[[case]]
+name = "a_statement_delivers_no_value_to_its_block"
+spec = ["5.0:1"]
+description = "A block whose last item is a `let` statement has type (), not the type of the bound value: binding it to i32 is a type error naming ()"
+source = """
+fn main() -> i32 {
+    let y: i32 = { let x: i32 = 1; };
+    y
+}
+"""
+compile_fail = true
+error_contains = ["found ()"]

--- a/crates/rue-spec/src/traceability.rs
+++ b/crates/rue-spec/src/traceability.rs
@@ -241,11 +241,18 @@ impl ResponsibilityCensus {
 pub const FOCUSED_CASE_MAX_SOURCE_LINES: usize = 40;
 
 /// Normative paragraphs that currently have no *running* test, tracked as known
-/// gaps pending compiler-feature implementation.
+/// gaps — either pending compiler-feature implementation, or not reachable by a
+/// test at all.
 ///
-/// Each entry is `(paragraph_id, reason)`. These are rules whose only spec tests
+/// Each entry is `(paragraph_id, reason)`. Most are rules whose only spec tests
 /// are `skip = true` because the behavior they pin isn't implemented yet — the
-/// tests are written and ready to un-skip the moment the feature lands. Before
+/// tests are written and ready to un-skip the moment the feature lands. A few
+/// pin something no test can positively exercise: undefined behavior, a
+/// boundary that needs a harness the spec corpus cannot build, or a limit whose
+/// counterexample is too large to construct. Both kinds belong here for the
+/// same reason — the gate stays green while the report names the gap instead of
+/// counting it as covered. Neither kind is a place to park a rule that is
+/// merely inconvenient to test. Before
 /// RUE-132, such a skipped test silently *counted* as coverage, so the report
 /// falsely claimed 100%. Now skipped tests don't count, and these genuine gaps
 /// are listed here explicitly: the gate stays green while the report tells the
@@ -262,6 +269,18 @@ pub const KNOWN_UNCOVERED_NORMATIVE: &[(&str, &str)] = &[
     // linked to a Rue export (a harness only the preview-gated `c_ffi` CLI suite
     // provides), and the other two describe undefined / programmer-responsibility
     // behavior that is not positively testable.
+    // C.3:1's counterexample is a source file one byte under 4 GiB. Constructing
+    // it is not a feature gap — the check is implemented and rejects with E1401
+    // — but a 4 GiB fixture cannot live in the corpus or run in a CI lane.
+    (
+        "C.3:1",
+        "Maximum source-file length (4,294,967,295 bytes, rejected with E1401 \
+         before lexing): positively testing the rejection needs a source file of \
+         that size, which cannot be committed to the corpus or generated within a \
+         test lane's time and disk budget. The sibling limit C.3:2 (file count) \
+         has the same shape. The check itself is implemented and runs on every \
+         source the compiler accepts.",
+    ),
     (
         "9.3:2",
         "Abort-at-boundary for a trapping `pub extern \"C\" fn` export: verified by \
@@ -796,7 +815,11 @@ impl TraceabilityReport {
 /// Parse a spec marker from a line.
 /// Format: {{ rule(id="X.Y:Z") }} or {{ rule(id="X.Y:Z", cat="category") }} (Zola shortcode)
 /// Category can be: normative, informative, syntax, example
-/// Default category (no cat) is informative.
+/// Default category (no cat) is informative — this is the spec's own rule
+/// (1.3:2, restated by B.1:5), not a tooling convention: normativity is opted
+/// into explicitly. Before RUE-1768, 1.3:2 said the opposite of B.1:5 and this
+/// default silently picked the winner, so 239 uncategorised paragraphs sat
+/// outside the coverage gate while the report claimed full coverage.
 /// Returns (id, category) if found.
 fn parse_spec_comment(line: &str) -> Result<Option<(String, String)>, String> {
     let line = line.trim();

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -913,12 +913,29 @@ dynamically. Note the `attr(T) = linear` case: a **declared**-`linear` struct's
 obligation belongs to the value itself, not its contents (`3.8:74` — "must be
 consumed regardless of what its fields hold"; the empty
 `linear struct MustUse` of `3.8:75` is the motivating case), so a husk whose
-linear field was moved out is still ill-formed to drop. The compiler currently
-diverges on exactly that husk case and accepts the drop (RUE-614): it models a
-field access on a declared-`linear` struct as a whole-value destructure, so the
-husk is `MovedOut` before this clause is ever consulted. The core states the
-prose rule. RUE-1591 confined that whole-value destructure to the declared case
-and left this divergence untouched.
+linear field was moved out is still ill-formed to drop.
+
+> **Open disagreement (RUE-614, RUE-1769).** This clause states a *different*
+> rule from the prose, and the disagreement is genuine rather than a matter of
+> precision. Prose `3.8:33` (`cat="normative"`) says that moving a field out of
+> a declared-`linear` value *destructures* it: "the field access consumes the
+> whole value, and the other fields are dropped with it". `3.8:60` repeats that
+> model independently. Under the prose the husk is consumed at the access, so
+> nothing is left unconsumed and the program is well-formed; under this clause
+> `Σ(husk) = Owned` with `attr = linear`, so `residual-linear` holds and the
+> leak check fires. The compiler implements the prose model — it treats the
+> field access as a whole-value destructure, leaving the husk `MovedOut` before
+> this clause is consulted — so it is the core, not the compiler, that stands
+> apart here. An earlier revision of this note described that as "the compiler
+> diverging" and claimed the core states the prose rule; both were wrong.
+>
+> Per `1.3:1a` the three views MUST agree where they overlap, so this is a
+> specification defect awaiting the RUE-614 ruling on what consumes a
+> declared-`linear` struct after a field access. Whichever way it rules, one of
+> the two must move: either this clause drops its `attr(T) = linear` case (the
+> prose model) or `3.8:33`/`3.8:60` change (this clause's model). RUE-1591
+> confined the whole-value destructure to the declared case and deliberately
+> left the divergence untouched.
 
 Parameters passed `inout`/`borrow`, and a destructor's own `self`, are exempt from
 the must-consume and drop obligations here (`3.8:62`): the caller (resp. the drop

--- a/docs/spec/src/01-introduction.md
+++ b/docs/spec/src/01-introduction.md
@@ -46,15 +46,30 @@ This specification has a companion **formal core** (`docs/formal/`) that states 
 
 {{ rule(id="1.3:2") }}
 
-Paragraphs marked with rule categories are normative unless explicitly marked as informative. The following categories are used:
+A paragraph's `cat=` marker classifies it. A paragraph carrying **no** `cat=`
+marker is **informative**: normativity is opted into explicitly, never inherited
+by default. B.1:5 states the same default, and the traceability tooling
+(`crates/rue-spec/src/traceability.rs`) applies it when computing normative
+coverage.
 
-| Category | Description |
-|----------|-------------|
-| `legality-rule` | Compile-time requirements that must be enforced |
-| `syntax` | Grammar rules defining valid program structure |
-| `dynamic-semantics` | Runtime behavior requirements |
-| `informative` | Explanatory text that is not normative |
-| `example` | Code examples that are not normative |
+It follows that a paragraph stating a requirement **MUST** carry an explicit
+normative category. An uncategorised paragraph cannot be relied on by a
+normative rule elsewhere: it imposes no requirement and the coverage gate does
+not track it. Where a normative rule needs to ground itself on such a
+paragraph, the paragraph is given its own category rather than borrowing
+normativity from the rule that cites it.
+
+The following categories are used:
+
+| Category | Description | Normative? |
+|----------|-------------|------------|
+| `normative` | A general requirement on a conforming implementation | Yes |
+| `legality-rule` | Compile-time requirements that must be enforced | Yes |
+| `syntax` | Grammar rules defining valid program structure | Yes |
+| `dynamic-semantics` | Runtime behavior requirements | Yes |
+| `undefined-behavior` | A condition whose behavior is undefined (imposes no requirement, but identifies the hazard) | Yes |
+| `informative` | Explanatory text that is not normative | No |
+| `example` | Code examples that are not normative | No |
 
 ## Behavior Categories
 

--- a/docs/spec/src/02-lexical-structure/_index.md
+++ b/docs/spec/src/02-lexical-structure/_index.md
@@ -10,7 +10,7 @@ page_template = "spec/page.html"
 
 This chapter describes the lexical structure of Rue programs, including tokens, comments, and whitespace.
 
-{{ rule(id="2.0:1") }}
+{{ rule(id="2.0:1", cat="normative") }}
 
 The text of a source file is decomposed into a sequence of tokens. Comments and whitespace may separate tokens but are not themselves tokens.
 

--- a/docs/spec/src/05-statements/_index.md
+++ b/docs/spec/src/05-statements/_index.md
@@ -15,6 +15,6 @@ This chapter describes statements in Rue.
 > is the normative grammar; where a fragment here differs from it, Appendix A
 > governs.
 
-{{ rule(id="5.0:1") }}
+{{ rule(id="5.0:1", cat="normative") }}
 
 A statement is a construct evaluated for its effect rather than for a value delivered to its context; every statement has type `()` (unit). The three statement forms — `let` bindings, assignments, and expression statements — elaborate in the core calculus (`docs/formal/01-core-calculus.md`) to a binding sequence `let x = e1 ; e2`, an `assign p = e`, and a discarding sequence `e1 ; e2` respectively, and none of these delivers a value to the block that contains it (core §6.7, §6.8).

--- a/docs/spec/src/08-runtime-behavior/_index.md
+++ b/docs/spec/src/08-runtime-behavior/_index.md
@@ -10,16 +10,23 @@ page_template = "spec/page.html"
 
 This chapter describes runtime behavior in Rue, including error conditions and panics.
 
-{{ rule(id="8.0:1") }}
+{{ rule(id="8.0:1", cat="dynamic-semantics") }}
 
-A small, fixed set of primitive operations can **trap** at runtime: integer
-overflow, division or remainder by zero, and an out-of-range array index. A trap
-is not a value, and no surrounding expression can consume it; it abandons the rest
-of the evaluation and halts the program with exit code 101 (the panic exit code of
-Appendix B). The core calculus fixes exactly these trap categories — `overflow`,
-`div-zero`, `rem-zero`, and `bounds` — together with their propagation and exit
-code (core calculus `docs/formal/01-core-calculus.md` §6.12, and the `(Panic-Lift)`
+Certain operations **trap** at runtime. A trap is not a value, and no surrounding
+expression can consume it; it abandons the rest of the evaluation and halts the
+program with exit code 101 (the panic exit code of Appendix B). The core calculus
+fixes five trap categories — `overflow` (arithmetic, negation, and `min_T / -1`),
+`div-zero`, `rem-zero`, `bounds` (a negative or out-of-range array index), and
+`user` (an explicit `@panic`) — together with their propagation and exit code
+(core calculus `docs/formal/01-core-calculus.md` §6.12, and the `(Panic-Lift)`
 rule of §6.2 by which a trap in any subexpression aborts the whole evaluation).
+
+Two further operations trap under the same discipline but are not yet carried by
+the core's taxonomy: decoding a byte sequence that is not well-formed UTF-8
+(4.8:28) and an out-of-range `@intCast` (4.13:28). The core records this gap
+itself. The set above is therefore the core's, not an exhaustive enumeration of
+every operation in this language that can trap; a rule needing the complete set
+must state it rather than cite this paragraph as closed.
 Each is total, deterministic, and observable, so a conforming compiler reproduces
 the same trap on the same input. The following sections state each category
 normatively.

--- a/docs/spec/src/10-modules/01-module-forms.md
+++ b/docs/spec/src/10-modules/01-module-forms.md
@@ -35,7 +35,7 @@ A file `_{name}.rue` is a facade only when its enclosing directory is named
 file named `{name}` — it is an ordinary source file with no special meaning,
 and it does not make `{name}` importable.
 
-{{ rule(id="10.1:5") }}
+{{ rule(id="10.1:5", cat="normative") }}
 
 Both module forms may coexist for the same name: an extensionless import
 path names the directory module `{path}/_{basename}.rue` alone, and the

--- a/docs/spec/src/appendices/B-undefined-behavior.md
+++ b/docs/spec/src/appendices/B-undefined-behavior.md
@@ -139,7 +139,7 @@ Accessing an array element with an index outside the valid range `[0, length)`
 | Division by zero | 101 |
 | Array out of bounds | 101 |
 
-{{ rule(id="B.2:5") }}
+{{ rule(id="B.2:5", cat="dynamic-semantics") }}
 
 All runtime panics produce exit code 101, matching Rust's convention for
 unwinding panics.

--- a/docs/spec/src/appendices/C-implementation-limits.md
+++ b/docs/spec/src/appendices/C-implementation-limits.md
@@ -41,7 +41,7 @@ The following integer types have the specified ranges:
 
 ## Source File Limits
 
-{{ rule(id="C.3:1") }}
+{{ rule(id="C.3:1", cat="normative") }}
 
 A single source file is limited to 4,294,967,295 bytes — one byte short of 4 GiB. Source positions are byte offsets stored as 32-bit unsigned integers, so this is the largest length whose end-of-file position is still representable. The compiler checks the length of every source it accepts and rejects an oversized one with a resource-limit diagnostic (E1401) before lexing, so no span can be formed from a truncated offset.
 
@@ -59,7 +59,7 @@ An array length is a compile-time value of type `u64`, so the language itself ad
 
 An array whose element count is legal for the type system may still be rejected: the binding constraint is the number of ABI slots the array type's layout occupies (C.4:3), not available memory. A layout spends one 8-byte slot per scalar, per struct field, and per array element, *whatever the element's own width* — so for an array the slot count is exactly the element count times the element type's own slot count, and for an array of scalars it is exactly the element count. A narrow element type therefore buys no extra headroom: `[i8; N]` and `[i64; N]` reach the ceiling at the same `N`.
 
-{{ rule(id="C.4:3") }}
+{{ rule(id="C.4:3", cat="normative") }}
 
 The current implementation limits any single object (including an array type) to 268,435,455 ABI slots. That ceiling is the code generator's frame-offset addressing range (`i32::MAX`, 2,147,483,647 bytes) divided by the 8-byte slot width, so a layout that fits it is always addressable by a signed 32-bit displacement. A type whose layout needs more slots is rejected with a diagnostic (E0906) wherever a value of the type would be materialized — a variable, a parameter, or a `@size_of`/`@align_of` query — and the diagnostic names the slot ceiling, as C.1:2 requires.
 


### PR DESCRIPTION
Three spec defects from the recurring audit. The first needed a ruling; the other two were factually wrong under any ruling, so they are corrections rather than decisions.

## RUE-1768 — the ruling: unmarked means informative

Two live, opposite defaults:

- **1.3:2** — "Paragraphs marked with rule categories are normative unless explicitly marked as informative."
- **B.1:5** — "Paragraphs without an explicit `cat=` marker are informative."

239 of 1,268 markers carry no `cat=`. `traceability.rs` silently picked informative, so those 239 sat outside the normative coverage gate while the report claimed full coverage — and a `cat="normative"` **MUST** in 8.2:9 grounded itself on 8.0:1, one of the uncategorised paragraphs.

**Ruled: default informative.** Normativity is opted into explicitly, never inherited. That is what the tooling already did, so no coverage changes hands. The alternative would have moved 239 paragraphs into the gate in one step, most of them code examples.

1.3:2 is corrected and now also states the consequence: a paragraph stating a requirement must carry an explicit category, and a normative rule may not ground itself on one that does not. Its category table gains the two rows it was missing (`normative`, `undefined-behavior`) so it matches B.1:5's.

### The seven load-bearing paragraphs

| paragraph | category | coverage |
| --- | --- | --- |
| 8.0:1, B.2:5 | `dynamic-semantics` | 4 new trap-discipline cases |
| 2.0:1 | `normative` | 3 new token-decomposition cases |
| 5.0:1 | `normative` | 2 new statement-typing cases |
| 10.1:5 | `normative` | 1 new module-form coexistence case |
| C.4:3 | `normative` | 2 new ABI-slot-ceiling cases |
| C.3:1 | `normative` | allowlisted — see below |

Twelve cases, each verified by execution before being written as an assertion. Two are worth calling out:

- **10.1:5** builds *both* module forms at once (`shape.rue` and `shape/_shape.rue`) and distinguishes them by return value, exiting 21. A case importing only one form would pass even if the two spellings collapsed onto the same module, so it would not be evidence for the rule.
- **C.4:3** checks the ceiling from both sides — `[i8; 268435455]` accepted, `[i8; 268435456]` rejected with E0906. A one-sided case would pass against a ceiling set anywhere below the published number. The check is on the layout, so neither case materializes an array.

**C.3:1 is allowlisted**, not tested: its counterexample is a source file one byte under 4 GiB, which cannot be committed to the corpus or generated in a lane. The allowlist's doc comment described itself as being for features pending implementation; two of its three existing entries were already "not positively testable" instead, so the comment is widened to describe both kinds — while saying explicitly that neither is a place to park a rule that is merely inconvenient to test.

### The recategorization is enforced, not cosmetic

Removing the C.3:1 allowlist entry fails the gate:

```
Uncovered normative paragraphs (1):
  C.3:1 [normative]: A single source file is limited to 4,294,967,295 bytes — ...
```

Counts move as predicted: normative 548 → 553, dynamic-semantics 107 → 109, informative 318 → 311.

## RUE-1776 — 8.0:1 claimed "exactly" four trap categories

The core states **five**. `user` (an explicit `@panic`) was missing, and the claim was one of exhaustiveness *about the artifact it cites* — the kind an alternate implementer would build a trap taxonomy from.

8.0:1 now states the core's five, and records that two further operations trap under the same discipline without being carried by the core's taxonomy: UTF-8 decode (4.8:28) and out-of-range `@intCast`. It says so explicitly rather than silently dropping "exactly", because the core itself flags the UTF-8 category as one it "does not yet carry" — folding those two into a claim about what the core fixes would have replaced one false statement with another.

**One correction to the issue:** it cites 4.13:5b for the `@intCast` trap. That paragraph is about reserved intrinsic names (`@cast`, `@panic`, `@assert`, `@test_preview_gate`). The rule is **4.13:28**, and that is what is cited here.

## RUE-1769 — the core claimed to state a rule it contradicts

Core §5.6 ended with "The core states the prose rule", about a clause that states the opposite of prose 3.8:33, and attributed the prose's own whole-value-destructure model to the compiler diverging. Both halves were false: it is the core that stands apart, and the compiler implements the prose.

The gloss now states the disagreement plainly and marks it as awaiting the RUE-614 ruling, which is what 1.3:1a requires of a genuine three-view disagreement. **The clause itself is unchanged** — which of the two models wins is RUE-614's to decide, and this PR does not pre-empt it. RUE-1769 therefore stays open for its second stage.

## Verification

`./test.sh` → `Tests finished: Pass 234. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0`, exit 0, banner `PASSED`.

Spec corpus (`scripts/rue spec`, a dedicated CI lane that `./test.sh` does not run): `2594 passed; 0 failed`.

`//:spec-traceability`: passes. `//crates/rue-oracle-diff:oracle-diff-spec-test`: passes.

Two gates caught real defects in my first draft, both fixed here rather than worked around:

1. The corpus rejected a `compile_fail` case with no error assertion — it would have passed on any rejection. It now pins `E0102` and the message; the diagnostic's caret spans `letx` as a single token, which is the actual evidence for 2.0:1.
2. The oracle-diff audit rejected the `@panic` case: a `runtime_error` expectation on an explicit panic classifies as an unmodeled "runtime trap expectation", which is harness coverage rather than typed model debt and cannot be registered. It now asserts `exit_code = 101`, matching how every other `@panic` case in the corpus is written. The three modeled trap categories keep their `runtime_error` assertions.

Fixes RUE-1768
Fixes RUE-1776
Part of RUE-1769

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJ13kDoVzYrpTZ7ry3rUaA)_