### PR TITLE
RUE-1668: link retained codegen units directly

### DIFF
--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -61,85 +61,7 @@ pub(crate) fn project_backend_object(
     // Object serialization runs after code generation, so it is a sibling leaf
     // of `codegen` rather than one of its subphases (RUE-786).
     let _span = info_span!("object_serialization", phase = "object_generation").entered();
-    use crate::codegen_query::{CodegenSection, SectionKind};
-    let mut text: Option<&CodegenSection> = None;
-    let mut rodata: Option<&CodegenSection> = None;
-    let mut data: Option<&CodegenSection> = None;
-    let mut bss: Option<&CodegenSection> = None;
-    for section in unit.sections.iter() {
-        let slot = match section.kind {
-            SectionKind::Text => &mut text,
-            SectionKind::Rodata => &mut rodata,
-            SectionKind::Data => &mut data,
-            SectionKind::Bss => &mut bss,
-        };
-        if slot.replace(section).is_some() {
-            return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
-                format!(
-                    "object projection requires exactly one {:?} section, found multiple",
-                    section.kind
-                ),
-            )));
-        }
-    }
-    let text = text.ok_or_else(|| {
-        CompileError::without_span(ErrorKind::InternalCodegenError(
-            "object projection requires exactly one Text section, found 0".into(),
-        ))
-    })?;
-    if (text.alignment, text.executable, text.writable) != (16, true, false) {
-        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
-            "object projection found non-canonical Text metadata".into(),
-        )));
-    }
-    if text.atoms.len() != 1 {
-        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
-            format!(
-                "object projection requires exactly one text atom, found {}",
-                text.atoms.len()
-            ),
-        )));
-    }
-    let rodata = rodata.ok_or_else(|| {
-        CompileError::without_span(ErrorKind::InternalCodegenError(
-            "object projection requires exactly one Rodata section, found 0".into(),
-        ))
-    })?;
-    if (rodata.alignment, rodata.executable, rodata.writable) != (1, false, false) {
-        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
-            "object projection found non-canonical Rodata metadata".into(),
-        )));
-    }
-    let data = data.ok_or_else(|| {
-        CompileError::without_span(ErrorKind::InternalCodegenError(
-            "object projection requires exactly one Data section, found 0".into(),
-        ))
-    })?;
-    if (data.alignment, data.executable, data.writable) != (1, false, true) {
-        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
-            "object projection found non-canonical Data metadata".into(),
-        )));
-    }
-    if !data.atoms.is_empty() {
-        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
-            "object projection does not support Data atoms".into(),
-        )));
-    }
-    let bss = bss.ok_or_else(|| {
-        CompileError::without_span(ErrorKind::InternalCodegenError(
-            "object projection requires exactly one Bss section, found 0".into(),
-        ))
-    })?;
-    if (bss.alignment, bss.executable, bss.writable) != (1, false, true) {
-        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
-            "object projection found non-canonical Bss metadata".into(),
-        )));
-    }
-    if !bss.atoms.is_empty() {
-        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
-            "object projection does not support Bss atoms".into(),
-        )));
-    }
+    let [text, rodata, _data, _bss] = canonical_codegen_sections(unit)?;
     let strings = rodata
         .atoms
         .iter()
@@ -156,18 +78,7 @@ pub(crate) fn project_backend_object(
         .strings(strings);
 
     for reloc in unit.relocations.iter() {
-        let rel_type = match (target.arch(), reloc.kind) {
-            (Arch::X86_64, RelocationKind::X86Pc32) => RelocationType::Pc32,
-            (Arch::X86_64, RelocationKind::X86Plt32) => RelocationType::Plt32,
-            (Arch::Aarch64, RelocationKind::Aarch64AdrpPage21) => RelocationType::AdrpPage21,
-            (Arch::Aarch64, RelocationKind::Aarch64AddLo12) => RelocationType::AddLo12,
-            (Arch::Aarch64, RelocationKind::Aarch64Call26) => RelocationType::Call26,
-            (arch, kind) => {
-                return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
-                    format!("{arch:?} codegen emitted incompatible relocation {kind:?}"),
-                )));
-            }
-        };
+        let rel_type = map_linker_relocation(target, reloc.kind)?;
         obj_builder = obj_builder.relocation(CodeRelocation {
             offset: reloc.offset,
             symbol: reloc.symbol.to_string(),
@@ -176,6 +87,136 @@ pub(crate) fn project_backend_object(
         });
     }
     Ok(obj_builder.build())
+}
+
+fn map_linker_relocation(
+    target: Target,
+    kind: RelocationKind,
+) -> CompileResult<rue_linker::RelocationType> {
+    match (target.arch(), kind) {
+        (Arch::X86_64, RelocationKind::X86Pc32) => Ok(rue_linker::RelocationType::Pc32),
+        (Arch::X86_64, RelocationKind::X86Plt32) => Ok(rue_linker::RelocationType::Plt32),
+        (Arch::Aarch64, RelocationKind::Aarch64AdrpPage21) => {
+            Ok(rue_linker::RelocationType::AdrpPage21)
+        }
+        (Arch::Aarch64, RelocationKind::Aarch64AddLo12) => Ok(rue_linker::RelocationType::AddLo12),
+        (Arch::Aarch64, RelocationKind::Aarch64Call26) => Ok(rue_linker::RelocationType::Call26),
+        (arch, kind) => Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+            format!("{arch:?} codegen emitted incompatible relocation {kind:?}"),
+        ))),
+    }
+}
+
+fn canonical_codegen_sections(
+    unit: &crate::codegen_query::CodegenUnit,
+) -> CompileResult<[&crate::codegen_query::CodegenSection; 4]> {
+    use crate::codegen_query::{CodegenSection, SectionKind};
+    let mut sections: [Option<&CodegenSection>; 4] = [None, None, None, None];
+    for section in unit.sections.iter() {
+        let index = match section.kind {
+            SectionKind::Text => 0,
+            SectionKind::Rodata => 1,
+            SectionKind::Data => 2,
+            SectionKind::Bss => 3,
+        };
+        if sections[index].replace(section).is_some() {
+            return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+                format!(
+                    "object projection requires exactly one {:?} section, found multiple",
+                    section.kind
+                ),
+            )));
+        }
+    }
+    let text = sections[0].ok_or_else(|| {
+        CompileError::without_span(ErrorKind::InternalCodegenError(
+            "object projection requires exactly one Text section, found 0".into(),
+        ))
+    })?;
+    let rodata = sections[1].ok_or_else(|| {
+        CompileError::without_span(ErrorKind::InternalCodegenError(
+            "object projection requires exactly one Rodata section, found 0".into(),
+        ))
+    })?;
+    let data = sections[2].ok_or_else(|| {
+        CompileError::without_span(ErrorKind::InternalCodegenError(
+            "object projection requires exactly one Data section, found 0".into(),
+        ))
+    })?;
+    let bss = sections[3].ok_or_else(|| {
+        CompileError::without_span(ErrorKind::InternalCodegenError(
+            "object projection requires exactly one Bss section, found 0".into(),
+        ))
+    })?;
+    if (text.alignment, text.executable, text.writable) != (16, true, false) {
+        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+            "object projection found non-canonical Text metadata".into(),
+        )));
+    }
+    if text.atoms.len() != 1 {
+        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+            format!(
+                "object projection requires exactly one text atom, found {}",
+                text.atoms.len()
+            ),
+        )));
+    }
+    if (rodata.alignment, rodata.executable, rodata.writable) != (1, false, false) {
+        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+            "object projection found non-canonical Rodata metadata".into(),
+        )));
+    }
+    if (data.alignment, data.executable, data.writable) != (1, false, true) {
+        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+            "object projection found non-canonical Data metadata".into(),
+        )));
+    }
+    if !data.atoms.is_empty() {
+        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+            "object projection does not support Data atoms".into(),
+        )));
+    }
+    if (bss.alignment, bss.executable, bss.writable) != (1, false, true) {
+        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+            "object projection found non-canonical Bss metadata".into(),
+        )));
+    }
+    if !bss.atoms.is_empty() {
+        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+            "object projection does not support Bss atoms".into(),
+        )));
+    }
+    Ok([text, rodata, data, bss])
+}
+
+/// Adapt one retained codegen terminal directly to the linker's structured
+/// input. Atom `Arc`s are passed through unchanged; only the final merged
+/// executable receives a contiguous copy.
+pub(crate) fn project_backend_structured_object(
+    unit: &crate::codegen_query::CodegenUnit,
+    target: Target,
+) -> CompileResult<rue_linker::StructuredObject> {
+    let [text, rodata, data, bss] = canonical_codegen_sections(unit)?;
+    let _ = (data, bss);
+    let relocations = unit
+        .relocations
+        .iter()
+        .map(|relocation| {
+            Ok(rue_linker::StructuredRelocation {
+                offset: relocation.offset,
+                symbol: relocation.symbol.to_string(),
+                rel_type: map_linker_relocation(target, relocation.kind)?,
+                addend: relocation.addend,
+            })
+        })
+        .collect::<CompileResult<Vec<_>>>()?;
+    Ok(rue_linker::StructuredObject::function(
+        target,
+        unit.defined_symbol.to_string(),
+        text.atoms.clone(),
+        rodata.atoms.clone(),
+        relocations,
+    ))
 }
 
 /// Emit the C-ABI entry thunk objects for every `pub extern "C" fn` export
@@ -417,11 +458,20 @@ fn main() -> i32 {
         ])
     }
 
-    fn assert_projection_rejects(unit: CodegenUnit, expected: &str) {
-        let error = project_backend_object(&unit, Target::X86_64Linux).unwrap_err();
+    fn assert_byte_projection_rejects(unit: &CodegenUnit, expected: &str) {
+        let error = project_backend_object(unit, Target::X86_64Linux).unwrap_err();
         assert!(
             matches!(&error.kind, ErrorKind::InternalCodegenError(message) if message.contains(expected)),
             "unexpected projection error: {error}"
+        );
+    }
+
+    fn assert_projection_rejects(unit: CodegenUnit, expected: &str) {
+        assert_byte_projection_rejects(&unit, expected);
+        let error = project_backend_structured_object(&unit, Target::X86_64Linux).unwrap_err();
+        assert!(
+            matches!(&error.kind, ErrorKind::InternalCodegenError(message) if message.contains(expected)),
+            "unexpected structured projection error: {error}"
         );
     }
 
@@ -455,8 +505,8 @@ fn main() -> i32 {
                 &format!("exactly one {kind:?} section"),
             );
         }
-        assert_projection_rejects(
-            canonical_projection_unit(b"text", &[&[0xff]]),
+        assert_byte_projection_rejects(
+            &canonical_projection_unit(b"text", &[&[0xff]]),
             "non-UTF-8 rodata",
         );
         for kind in [SectionKind::Data, SectionKind::Bss] {
@@ -604,6 +654,32 @@ fn main() -> i32 {
             }
             assert_eq!(actual, expected.build(), "{target:?}");
         }
+    }
+
+    #[test]
+    fn structured_projection_reuses_codegen_atoms() {
+        let unit = canonical_projection_unit(b"\xC3", &[b"literal"]);
+        let object = project_backend_structured_object(&unit, Target::X86_64Linux).unwrap();
+        assert!(std::sync::Arc::ptr_eq(
+            &object.section_atoms(0).unwrap()[0],
+            &unit.sections[0].atoms[0]
+        ));
+        assert!(std::sync::Arc::ptr_eq(
+            &object.section_atoms(1).unwrap()[0],
+            &unit.sections[1].atoms[0]
+        ));
+        let serialized = project_backend_object(&unit, Target::X86_64Linux).unwrap();
+        let parsed = ObjectFile::parse(&serialized).unwrap();
+        assert_eq!(
+            parsed.sections[parsed.section_map[".text"]].data.as_slice(),
+            b"\xC3"
+        );
+        assert_eq!(
+            parsed.sections[parsed.section_map[".rodata"]]
+                .data
+                .as_slice(),
+            b"literal"
+        );
     }
 
     fn frontend() -> SourceSnapshot {

--- a/crates/rue-compiler/src/linking.rs
+++ b/crates/rue-compiler/src/linking.rs
@@ -478,14 +478,13 @@ fn validate_runtime_archive(runtime_bytes: &[u8], target: Target) -> Result<Arch
     Ok(archive)
 }
 
+#[allow(dead_code)] // retained for byte-container linker callers and focused tests
 pub(crate) fn link_internal_with_warnings(
     options: &CompileOptions,
     object_files: &[Vec<u8>],
     warnings: &[CompileWarning],
 ) -> MultiErrorResult<CompileOutput> {
     let _span = info_span!("linker", mode = "internal", phase = "linking").entered();
-
-    let runtime_bytes = runtime_for_target(options.target);
 
     let mut linker = Linker::new(options.target);
 
@@ -503,24 +502,22 @@ pub(crate) fn link_internal_with_warnings(
         }
     }
 
-    // Determine the entry point symbol based on target.
-    // ELF: _start (runtime's entry point that calls main)
-    // Mach-O: __main (runtime's entry point that calls _main)
+    finish_internal_link(linker, options, object_files.len(), warnings)
+}
+
+fn finish_internal_link(
+    mut linker: Linker,
+    options: &CompileOptions,
+    object_count: usize,
+    warnings: &[CompileWarning],
+) -> MultiErrorResult<CompileOutput> {
+    let runtime_bytes = runtime_for_target(options.target);
     let entry_point = if options.target.is_macho() {
         "__main"
     } else {
         "_start"
     };
-
-    // Mark the entry point as required so it gets pulled from the archive.
-    // The entry point must be marked before adding the archive because
-    // archive linking only includes objects that define needed symbols.
     linker.require_symbol(entry_point);
-
-    // Add user-supplied static archives (`--link-archive`, ADR-0064 C FFI)
-    // before the runtime so a foreign member that itself depends on a runtime
-    // symbol can still be satisfied. Each archive resolves the undefined
-    // `extern "C"` symbols referenced by the compiled objects.
     {
         let _span = info_span!("link_archive_resolve").entered();
         for archive_path in &options.link_archives {
@@ -532,8 +529,6 @@ pub(crate) fn link_internal_with_warnings(
                 .map_err(link_error)
                 .map_err(CompileErrors::from)?;
         }
-
-        // Add the runtime library
         let runtime = validate_runtime_archive(runtime_bytes, options.target)
             .map_err(link_error)
             .map_err(CompileErrors::from)?;
@@ -542,10 +537,6 @@ pub(crate) fn link_internal_with_warnings(
             .map_err(link_error)
             .map_err(CompileErrors::from)?;
     }
-
-    // Link to executable. An undefined symbol at this point is an unresolved
-    // `extern "C"` import (or a runtime gap); name the symbol and the archives
-    // that were searched (ADR-0064 C FFI).
     let executable = linker
         .link(entry_point)
         .map_err(|err| match &err {
@@ -564,11 +555,10 @@ pub(crate) fn link_internal_with_warnings(
         })
         .map_err(CompileErrors::from)?;
     info!(
-        object_count = object_files.len(),
+        object_count,
         output_bytes = executable.len(),
         "linking complete"
     );
-
     Ok(CompileOutput {
         elf: executable,
         warnings: warnings.to_vec(),
@@ -579,6 +569,104 @@ pub(crate) fn link_internal_with_warnings(
         provider_observations: crate::unstable::ProviderObservationMetrics::default(),
         publication: crate::unstable::PublicationMetrics::default(),
     })
+}
+
+/// Link retained compiler units directly. Export thunks remain serialized
+/// because they are synthesized outside the retained CodegenUnit query.
+pub(crate) fn link_internal_structured_with_warnings(
+    options: &CompileOptions,
+    objects: &[crate::object_query::CollectedObjectProjection],
+    export_thunk_objects: &[Vec<u8>],
+    warnings: &[CompileWarning],
+) -> MultiErrorResult<CompileOutput> {
+    link_internal_structured_admission(
+        options,
+        objects.len(),
+        export_thunk_objects,
+        warnings,
+        |linker| {
+            objects.iter().try_for_each(|collected| {
+                admit_structured_unit(linker, &collected.unit, options.target)
+            })
+        },
+    )
+}
+
+pub(crate) fn link_internal_structured_units_with_warnings(
+    options: &CompileOptions,
+    units: &[crate::codegen_query::CollectedCodegenUnit],
+    export_thunk_objects: &[Vec<u8>],
+    warnings: &[CompileWarning],
+) -> MultiErrorResult<CompileOutput> {
+    link_internal_structured_admission(
+        options,
+        units.len(),
+        export_thunk_objects,
+        warnings,
+        |linker| {
+            units.iter().try_for_each(|collected| {
+                admit_structured_unit(linker, &collected.unit, options.target)
+            })
+        },
+    )
+}
+
+fn link_internal_structured_admission(
+    options: &CompileOptions,
+    object_count: usize,
+    export_thunk_objects: &[Vec<u8>],
+    warnings: &[CompileWarning],
+    mut admit: impl FnMut(&mut Linker) -> MultiErrorResult<()>,
+) -> MultiErrorResult<CompileOutput> {
+    let _span = info_span!("linker", mode = "internal", phase = "linking").entered();
+    let mut linker = Linker::new(options.target);
+    {
+        let _span = info_span!(
+            "link_structured_admission",
+            object_count = object_count,
+            export_thunk_count = export_thunk_objects.len()
+        )
+        .entered();
+        admit(&mut linker)?;
+        add_export_thunks(&mut linker, export_thunk_objects)?;
+    }
+    finish_internal_link(
+        linker,
+        options,
+        object_count + export_thunk_objects.len(),
+        warnings,
+    )
+}
+
+fn add_export_thunks(
+    linker: &mut Linker,
+    export_thunk_objects: &[Vec<u8>],
+) -> MultiErrorResult<()> {
+    // C-ABI entry thunks are not retained CodegenUnits; preserve their
+    // established byte-container path and diagnostics.
+    for bytes in export_thunk_objects {
+        let object = ObjectFile::parse(bytes)
+            .map_err(link_error)
+            .map_err(CompileErrors::from)?;
+        linker
+            .add_object(object)
+            .map_err(link_error)
+            .map_err(CompileErrors::from)?;
+    }
+    Ok(())
+}
+
+fn admit_structured_unit(
+    linker: &mut Linker,
+    unit: &crate::codegen_query::CodegenUnit,
+    target: Target,
+) -> MultiErrorResult<()> {
+    let object = crate::backend::project_backend_structured_object(unit, target)
+        .map_err(CompileErrors::from)?;
+    linker
+        .add_structured_object(object)
+        .map_err(link_error)
+        .map_err(CompileErrors::from)
 }
 
 /// Link using an external system linker.

--- a/crates/rue-compiler/src/object_query.rs
+++ b/crates/rue-compiler/src/object_query.rs
@@ -1,9 +1,9 @@
 //! Retained target-object projections of canonical codegen terminals.
 //!
 //! Object serialization is a typed query downstream of one exact
-//! `CodegenUnit` key. The fresh linker remains deliberately stateless: it
-//! consumes these stable bytes on every link, while unchanged units reuse the
-//! retained projection owned by the compiler query graph.
+//! `CodegenUnit` key. The byte projection remains the canonical boundary for
+//! object emission and system linking; ordinary internal links consume the
+//! retained CodegenUnit beside it through the linker's structured adapter.
 
 use std::{
     hash::{Hash, Hasher},
@@ -122,9 +122,8 @@ impl QueryKey for ObjectProjectionQueryKey {
 }
 
 /// Retained object-container bytes and their stable content identity for one
-/// codegen unit. Fresh linking consumes only the immutable bytes, so the
-/// durable digest is computed once on demand if a later plan comparison needs
-/// it.
+/// codegen unit. The immutable projection is still used for public object
+/// output, system linking, and durable plan identity.
 #[derive(Debug, Clone)]
 pub(crate) struct ObjectProjection {
     pub(crate) bytes: Arc<[u8]>,

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -1522,6 +1522,46 @@ mod tests {
     }
 
     #[test]
+    fn ordinary_internal_compile_skips_object_projection() {
+        let snapshot = SourceSnapshot::single(
+            "<structured-compile>",
+            "fn helper() -> i32 { 41 } fn main() -> i32 { helper() + 1 }",
+        )
+        .unwrap();
+        let options = CompileOptions::default();
+        let mut internal = CompilerSession::new();
+        crate::publish_test_snapshot(&mut internal, &snapshot).unwrap();
+        crate::queries::compile_with_session(&mut internal, &snapshot, &options).unwrap();
+        assert!(internal.object_projection_executions().is_empty());
+        assert_eq!(internal.object_projection_collections(), 0);
+
+        crate::queries::compile_with_session(&mut internal, &snapshot, &options).unwrap();
+        assert_eq!(internal.codegen_executions().len(), 2);
+        assert!(
+            internal
+                .codegen_executions()
+                .iter()
+                .all(|(_, execution)| *execution == rue_query::RequestExecution::Reused)
+        );
+        assert!(internal.object_projection_executions().is_empty());
+        assert_eq!(internal.object_projection_collections(), 0);
+
+        let mut byte_consumer = CompilerSession::new();
+        crate::publish_test_snapshot(&mut byte_consumer, &snapshot).unwrap();
+        let system_options = CompileOptions {
+            linker: LinkerMode::System("ld".into()),
+            ..options
+        };
+        byte_consumer
+            .rooted_codegen(
+                &system_options,
+                rue_codegen::BackendArtifactRequest::default(),
+            )
+            .unwrap();
+        assert_eq!(byte_consumer.object_projection_collections(), 2);
+    }
+
+    #[test]
     fn retained_endpoint_capabilities_reject_another_session_or_revision() {
         let snapshot =
             SourceSnapshot::single("<retained-endpoint-owner>", "fn main() -> i32 { 42 }").unwrap();

--- a/crates/rue-compiler/src/program_image_plan.rs
+++ b/crates/rue-compiler/src/program_image_plan.rs
@@ -11,6 +11,8 @@ use std::{
 use tracing::{info, info_span};
 
 #[cfg(test)]
+use crate::codegen_query::CollectedCodegenUnit;
+#[cfg(test)]
 use crate::session::RootedCfgUnit;
 
 use crate::{
@@ -20,9 +22,6 @@ use crate::{
     linking,
     object_query::CollectedObjectProjection,
 };
-
-#[cfg(test)]
-use crate::codegen_query::CollectedCodegenUnit;
 
 /// Stable, link-relevant identity for one reached codegen terminal.
 #[derive(Debug, Clone)]
@@ -172,9 +171,14 @@ impl ProgramImagePlan {
 /// lowering, allocation, or emission.
 pub(crate) struct ProgramImage {
     pub(crate) plan: ProgramImagePlan,
-    objects: Vec<CollectedObjectProjection>,
+    inputs: ProgramImageInputs,
     export_thunk_objects: Vec<Vec<u8>>,
 }
+
+/// The durable image remains byte-backed for object consumers and future
+/// stateful plans. Ordinary internal compilation links the rooted CodegenUnit
+/// collection directly before constructing this image.
+type ProgramImageInputs = Vec<CollectedObjectProjection>;
 
 impl ProgramImage {
     /// Construct the production image directly from rooted codegen terminals
@@ -209,7 +213,7 @@ impl ProgramImage {
         )?;
         Ok(Self {
             plan,
-            objects,
+            inputs: objects,
             export_thunk_objects,
         })
     }
@@ -268,14 +272,13 @@ impl ProgramImage {
         )?;
         Ok(Self {
             plan,
-            objects,
+            inputs: objects,
             export_thunk_objects,
         })
     }
 
-    /// Collect the already-projected per-unit bytes for the fresh linker.
-    /// Object serialization happened in the registered query graph; this
-    /// adapter only materializes the linker's existing owned byte-vector API.
+    /// Collect the already-projected per-unit bytes for system linking and
+    /// object-output consumers. Internal links use `units` directly.
     pub(crate) fn fresh_objects(&self, options: &CompileOptions) -> MultiErrorResult<Vec<Vec<u8>>> {
         let _span =
             info_span!("fresh_object_materialization", phase = "object_generation").entered();
@@ -287,12 +290,12 @@ impl ProgramImage {
             )));
         }
         let mut objects = self
-            .objects
+            .inputs
             .iter()
             .map(|collected| collected.object.bytes.to_vec())
             .collect::<Vec<_>>();
         info!(
-            function_count = self.objects.len(),
+            function_count = self.inputs.len(),
             object_bytes = objects.iter().map(Vec::len).sum::<usize>(),
             "codegen complete"
         );
@@ -307,12 +310,22 @@ impl ProgramImage {
         options: &CompileOptions,
         warnings: &[CompileWarning],
     ) -> MultiErrorResult<CompileOutput> {
-        let objects = self.fresh_objects(options)?;
+        if self.plan.target != options.target {
+            return Err(CompileErrors::from(CompileError::without_span(
+                ErrorKind::InvalidCompilerInput(
+                    "program image target differs from the fresh-link target".into(),
+                ),
+            )));
+        }
         match &options.linker {
-            LinkerMode::Internal => {
-                linking::link_internal_with_warnings(options, &objects, warnings)
-            }
+            LinkerMode::Internal => linking::link_internal_structured_with_warnings(
+                options,
+                &self.inputs,
+                &self.export_thunk_objects,
+                warnings,
+            ),
             LinkerMode::System(command) => {
+                let objects = self.fresh_objects(options)?;
                 linking::link_system_with_warnings(options, &objects, command, warnings)
             }
         }
@@ -970,6 +983,32 @@ mod tests {
         assert_eq!(
             image.plan.export_thunks[0].native_symbol,
             exported.record.codegen.defined_symbol.as_ref()
+        );
+
+        let byte_objects = image.fresh_objects(&options).unwrap();
+        let byte_link = linking::link_internal_with_warnings(&options, &byte_objects, &[])
+            .unwrap()
+            .elf;
+        let structured_link = image.fresh_link(&options, &[]).unwrap().elf;
+        assert_eq!(
+            structured_link, byte_link,
+            "retained units plus a serialized export thunk must match the byte-container link"
+        );
+    }
+
+    #[test]
+    fn structured_fresh_link_rejects_a_target_mismatch_before_admission() {
+        let (units, functions, options) = session_inputs("fn main() -> i32 { 0 }");
+        let image = ProgramImage::new(units, &functions, &options, &[]).unwrap();
+        let mismatched = CompileOptions {
+            target: Target::Aarch64Linux,
+            ..options
+        };
+        let error = image.fresh_link(&mismatched, &[]).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("program image target differs from the fresh-link target")
         );
     }
 

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -243,7 +243,25 @@ pub(crate) fn compile_with_session(
     options: &CompileOptions,
 ) -> MultiErrorResult<CompileOutput> {
     let _span = info_span!("compile_pipeline").entered();
-    let rooted = session.rooted_codegen(options, rue_codegen::BackendArtifactRequest::default())?;
+    let rooted = if matches!(options.linker, LinkerMode::Internal) {
+        session
+            .rooted_codegen_internal_with_cancellation(
+                options,
+                rue_codegen::BackendArtifactRequest::default(),
+                rue_query::CancellationToken::new(),
+            )
+            .map_err(|control| match control {
+                crate::session::PipelineRequestControl::Compile(errors) => errors,
+                crate::session::PipelineRequestControl::Abort(abort) => {
+                    crate::session::pipeline_abort_errors("internal codegen", abort)
+                }
+                crate::session::PipelineRequestControl::Parked(park) => {
+                    crate::session::unresolved_toolchain_park_errors(&park)
+                }
+            })?
+    } else {
+        session.rooted_codegen(options, rue_codegen::BackendArtifactRequest::default())?
+    };
     compile_rooted_with_session(session, snapshot, options, rooted)
 }
 
@@ -259,11 +277,19 @@ pub(crate) fn compile_with_session_with_cancellation(
             rue_query::QueryAbort::Canceled,
         ));
     }
-    let rooted = session.rooted_codegen_with_cancellation(
-        options,
-        rue_codegen::BackendArtifactRequest::default(),
-        cancellation.clone(),
-    )?;
+    let rooted = if matches!(options.linker, LinkerMode::Internal) {
+        session.rooted_codegen_internal_with_cancellation(
+            options,
+            rue_codegen::BackendArtifactRequest::default(),
+            cancellation.clone(),
+        )?
+    } else {
+        session.rooted_codegen_with_cancellation(
+            options,
+            rue_codegen::BackendArtifactRequest::default(),
+            cancellation.clone(),
+        )?
+    };
     if cancellation.is_canceled() {
         return Err(crate::session::PipelineRequestControl::Abort(
             rue_query::QueryAbort::Canceled,
@@ -304,12 +330,36 @@ pub(crate) fn compile_rooted_with_session(
     let query_runtime = metrics.query_runtime();
     let semantic_reachability = metrics.semantic_reachability();
     let provider_observations = crate::unstable::provider_observation_metrics(session);
-    let image = crate::program_image_plan::ProgramImage::from_rooted(
-        rooted.objects,
-        rooted.exports,
-        options,
-    )?;
-    let mut output = image.fresh_link(options, &rooted.warnings)?;
+    let mut output = match rooted.input {
+        crate::session::RootedCodegenInput::Structured => {
+            let export_thunk_objects = rooted
+                .exports
+                .iter()
+                .map(|export| {
+                    crate::backend::generate_export_thunk_object(
+                        options.target,
+                        &export.exported_symbol,
+                        &export.native_symbol,
+                        &export.param_types,
+                    )
+                })
+                .collect::<Vec<_>>();
+            crate::linking::link_internal_structured_units_with_warnings(
+                options,
+                &rooted.units,
+                &export_thunk_objects,
+                &rooted.warnings,
+            )?
+        }
+        crate::session::RootedCodegenInput::Projected => {
+            let image = crate::program_image_plan::ProgramImage::from_rooted(
+                rooted.objects,
+                rooted.exports,
+                options,
+            )?;
+            image.fresh_link(options, &rooted.warnings)?
+        }
+    };
     output.source_stats = SourceStats {
         files: snapshot.len(),
         bytes: total_source_bytes,

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -1598,9 +1598,17 @@ impl RetainedCharge for ObjectProjectionBatchOutput {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct BackendRootPublicationKey {
     epoch: u64,
-    objects: ObjectProjectionBatchKey,
+    input: BackendRootPublicationInput,
     functions: Arc<[crate::FunctionInstanceKey]>,
     cfg_terminals: usize,
+    optimized_cfg_terminals: usize,
+    codegen_unit_terminals: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum BackendRootPublicationInput {
+    Codegen(CodegenUnitBatchKey),
+    Objects(ObjectProjectionBatchKey),
 }
 
 #[derive(Debug, Default)]
@@ -1619,15 +1627,29 @@ impl QueryKey for BackendRootPublicationKey {
         format!(
             "backend-root;epoch={};units={}",
             self.epoch,
-            self.objects.keys.len()
+            match &self.input {
+                BackendRootPublicationInput::Codegen(key) => key.keys.len(),
+                BackendRootPublicationInput::Objects(key) => key.keys.len(),
+            }
         )
     }
 
     fn stable_hash(&self, hasher: &mut rue_query::StableHasher) {
         self.epoch.hash(hasher);
-        self.objects.stable_hash(hasher);
+        match &self.input {
+            BackendRootPublicationInput::Codegen(key) => {
+                0_u8.hash(hasher);
+                key.stable_hash(hasher);
+            }
+            BackendRootPublicationInput::Objects(key) => {
+                1_u8.hash(hasher);
+                key.stable_hash(hasher);
+            }
+        }
         self.functions.hash(hasher);
         self.cfg_terminals.hash(hasher);
+        self.optimized_cfg_terminals.hash(hasher);
+        self.codegen_unit_terminals.hash(hasher);
     }
 }
 
@@ -14843,6 +14865,7 @@ impl RevisionedQueryDatabase {
         let provider_observation_meter = Arc::new(ProviderObservationCounters::default());
         let lookup_root_lease = Arc::new(Mutex::new(PublishedRootLookupLease::default()));
         let object_projections_for_backend_publication = object_projections.clone();
+        let codegen_units_for_backend_publication = codegen_units.clone();
         let backend_root_for_publication = backend_root.clone();
         let cfg_collection_root_for_backend_publication = cfg_collection_root.clone();
         let codegen_collection_root_for_backend_publication = codegen_collection_root.clone();
@@ -14864,34 +14887,58 @@ impl RevisionedQueryDatabase {
                     let _validated_registered = context
                         .endorse_registered_validations_from(&fallbacks)
                         .expect("backend retention roots belong to this query runtime");
-                    let terminals = context.query_registered_adaptive_batch_refs(
-                        &object_projections_for_backend_publication,
-                        key.objects.keys.iter(),
-                    )?;
-                    if terminals.iter().any(|terminal| {
-                        matches!(
-                            terminal.outcome(),
-                            rue_query::QueryOutcome::Success(
-                                crate::object_query::ObjectProjectionValue::Failure(_)
-                            )
-                        )
-                    }) {
-                        return Ok(QueryOutput::success(false)
-                            .with_terminal_kind(QueryTerminalKind::Failure));
-                    }
-                    let pending = context
-                        .retain_observed_terminal_cones_from(&terminals, &fallbacks)
-                        .expect(
-                            "registered backend-root validation observes every final ObjectProjection dependency cone",
-                        );
+                    let (pending, object_projection_terminals) = match &key.input {
+                        BackendRootPublicationInput::Codegen(batch) => {
+                            let terminals = context.query_registered_adaptive_batch_refs(
+                                &codegen_units_for_backend_publication,
+                                batch.keys.iter(),
+                            )?;
+                            if terminals.iter().any(|terminal| {
+                                matches!(
+                                    terminal.outcome(),
+                                    rue_query::QueryOutcome::Success(
+                                        crate::codegen_query::CodegenUnitValue::Failure(_)
+                                    )
+                                )
+                            }) {
+                                return Ok(QueryOutput::success(false)
+                                    .with_terminal_kind(QueryTerminalKind::Failure));
+                            }
+                            let pending = context
+                                .retain_observed_terminal_cones_from(&terminals, &fallbacks)
+                                .expect("backend-root validation observes CodegenUnit cones");
+                            (pending, 0)
+                        }
+                        BackendRootPublicationInput::Objects(batch) => {
+                            let terminals = context.query_registered_adaptive_batch_refs(
+                                &object_projections_for_backend_publication,
+                                batch.keys.iter(),
+                            )?;
+                            if terminals.iter().any(|terminal| {
+                                matches!(
+                                    terminal.outcome(),
+                                    rue_query::QueryOutcome::Success(
+                                        crate::object_query::ObjectProjectionValue::Failure(_)
+                                    )
+                                )
+                            }) {
+                                return Ok(QueryOutput::success(false)
+                                    .with_terminal_kind(QueryTerminalKind::Failure));
+                            }
+                            let pending = context
+                                .retain_observed_terminal_cones_from(&terminals, &fallbacks)
+                                .expect("backend-root validation observes ObjectProjection cones");
+                            (pending, batch.keys.len())
+                        }
+                    };
                     context.register_attempt_handoff(PublishedBackendRootHandoff {
                         root: backend_root_for_publication.clone(),
                         pending: Some(Arc::new(pending)),
                         functions: Some(key.functions.iter().cloned().collect()),
                         cfg_terminals: key.cfg_terminals,
-                        optimized_cfg_terminals: key.objects.keys.len(),
-                        codegen_unit_terminals: key.objects.keys.len(),
-                        object_projection_terminals: key.objects.keys.len(),
+                        optimized_cfg_terminals: key.optimized_cfg_terminals,
+                        codegen_unit_terminals: key.codegen_unit_terminals,
+                        object_projection_terminals,
                         previous: None,
                         installed: false,
                     });
@@ -16945,7 +16992,7 @@ impl RevisionedQueryDatabase {
         &self,
         revision: Revision,
         candidate: BackendRootCandidate,
-        objects: ObjectProjectionBatchKey,
+        input: BackendRootPublicationInput,
     ) -> Result<(), QueryAbort> {
         // A root-publication request is transactional through its handoff
         // callbacks. Serialize only these short, whole-program swaps so a
@@ -16957,9 +17004,11 @@ impl RevisionedQueryDatabase {
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let key = BackendRootPublicationKey {
             epoch,
-            objects,
+            input,
             functions: candidate.functions.iter().cloned().collect(),
             cfg_terminals: candidate.cfg_keys.len(),
+            optimized_cfg_terminals: candidate.optimized_cfg_terminals,
+            codegen_unit_terminals: candidate.codegen_unit_terminals,
         };
         let attempt = self.runtime.request_registered(
             &self.backend_root_publications,

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -826,7 +826,7 @@ impl From<CompileError> for PipelineRequestControl {
     }
 }
 
-fn pipeline_abort_errors(context: &str, abort: rue_query::QueryAbort) -> CompileErrors {
+pub(crate) fn pipeline_abort_errors(context: &str, abort: rue_query::QueryAbort) -> CompileErrors {
     CompileError::without_span(ErrorKind::InternalError(format!(
         "{context} query aborted: {abort:?}"
     )))
@@ -981,6 +981,7 @@ impl RootedCfgUnit {
 }
 
 pub(crate) struct RootedCodegenOutput {
+    pub(crate) input: RootedCodegenInput,
     pub(crate) units: Vec<crate::codegen_query::CollectedCodegenUnit>,
     pub(crate) objects: Vec<crate::object_query::CollectedObjectProjection>,
     #[allow(dead_code)]
@@ -991,6 +992,11 @@ pub(crate) struct RootedCodegenOutput {
     pub(crate) cfg_work: BackendQueryWork,
     pub(crate) codegen_work: BackendQueryWork,
     pub(crate) object_projection_work: BackendQueryWork,
+}
+
+pub(crate) enum RootedCodegenInput {
+    Structured,
+    Projected,
 }
 
 /// Opaque in-crate continuation between the canonical codegen-ready and
@@ -1022,6 +1028,43 @@ struct RootedBodyGraph {
     main: crate::StableDefinitionKey,
     closure: crate::body_query::BodyClosureOutput,
     work: crate::CanonicalSemanticWork,
+}
+
+fn collect_rooted_exports(
+    graph: &RootedBodyGraph,
+    cfgs: &[RootedCfgUnit],
+) -> Vec<crate::program_image_plan::RootedExportThunk> {
+    let export_roots = graph
+        .c_export_roots
+        .iter()
+        .cloned()
+        .map(crate::FunctionInstanceKey::Definition)
+        .collect::<BTreeSet<_>>();
+    cfgs.iter()
+        .filter(|cfg| export_roots.contains(&cfg.function))
+        .map(|cfg| {
+            let mut param_types = vec![rue_air::Type::I64; cfg.record.cfg.num_params() as usize];
+            for block in cfg.record.cfg.blocks() {
+                for &value in &block.insts {
+                    let instruction = cfg.record.cfg.get_inst(value);
+                    if let rue_cfg::CfgInstData::Param { index } = instruction.data
+                        && let Some(slot) = param_types.get_mut(index as usize)
+                    {
+                        *slot = instruction.ty;
+                    }
+                }
+            }
+            crate::program_image_plan::RootedExportThunk {
+                function: cfg.function.clone(),
+                exported_symbol: match &cfg.function {
+                    crate::FunctionInstanceKey::Definition(key) => key.name().to_owned(),
+                    _ => unreachable!("C export roots are source definitions"),
+                },
+                native_symbol: cfg.record.codegen.defined_symbol.to_string(),
+                param_types,
+            }
+        })
+        .collect()
 }
 
 /// An opaque, single-use continuation issued ONLY from a successful close of
@@ -5660,6 +5703,59 @@ impl CompilerSession {
         self.rooted_objects_ready_with_cancellation(ready, cancellation)
     }
 
+    /// Complete the retained codegen boundary for an ordinary internal link.
+    /// ObjectProjectionBatch is intentionally not requested: the linker
+    /// consumes the retained CodegenUnits directly. Byte consumers continue
+    /// through `rooted_objects_ready_with_cancellation` below.
+    pub(crate) fn rooted_codegen_internal_with_cancellation(
+        &mut self,
+        options: &CompileOptions,
+        request: rue_codegen::BackendArtifactRequest,
+        cancellation: rue_query::CancellationToken,
+    ) -> Result<RootedCodegenOutput, PipelineRequestControl> {
+        let ready =
+            self.rooted_codegen_ready_with_cancellation(options, request, cancellation.clone())?;
+        let RootedCodegenReadyOutput {
+            graph,
+            units,
+            cfgs,
+            warnings,
+            work,
+            cfg_work,
+            codegen_work,
+            backend_root,
+            codegen_batch_key,
+        } = ready;
+        let exports = collect_rooted_exports(&graph, &cfgs);
+        if cancellation.is_canceled() {
+            return Err(PipelineRequestControl::Abort(
+                rue_query::QueryAbort::Canceled,
+            ));
+        }
+        self.queries
+            .revisioned
+            .publish_backend_root(
+                graph.revision,
+                backend_root,
+                crate::revisioned_query_database::BackendRootPublicationInput::Codegen(
+                    codegen_batch_key,
+                ),
+            )
+            .map_err(PipelineRequestControl::Abort)?;
+        Ok(RootedCodegenOutput {
+            input: RootedCodegenInput::Structured,
+            units,
+            objects: Vec::new(),
+            cfgs,
+            exports,
+            warnings,
+            work,
+            cfg_work,
+            codegen_work,
+            object_projection_work: BackendQueryWork::default(),
+        })
+    }
+
     /// Collect the rooted reached set's canonical CodegenUnits while retaining
     /// the exact unpublished backend-root candidate for object projection.
     pub(crate) fn rooted_codegen_ready(
@@ -5929,39 +6025,7 @@ impl CompilerSession {
                 }
             }
         }
-        let export_roots = graph
-            .c_export_roots
-            .iter()
-            .cloned()
-            .map(crate::FunctionInstanceKey::Definition)
-            .collect::<BTreeSet<_>>();
-        let exports = cfgs
-            .iter()
-            .filter(|cfg| export_roots.contains(&cfg.function))
-            .map(|cfg| {
-                let mut param_types =
-                    vec![rue_air::Type::I64; cfg.record.cfg.num_params() as usize];
-                for block in cfg.record.cfg.blocks() {
-                    for &value in &block.insts {
-                        let instruction = cfg.record.cfg.get_inst(value);
-                        if let rue_cfg::CfgInstData::Param { index } = instruction.data
-                            && let Some(slot) = param_types.get_mut(index as usize)
-                        {
-                            *slot = instruction.ty;
-                        }
-                    }
-                }
-                crate::program_image_plan::RootedExportThunk {
-                    function: cfg.function.clone(),
-                    exported_symbol: match &cfg.function {
-                        crate::FunctionInstanceKey::Definition(key) => key.name().to_owned(),
-                        _ => unreachable!("C export roots are source definitions"),
-                    },
-                    native_symbol: cfg.record.codegen.defined_symbol.to_string(),
-                    param_types,
-                }
-            })
-            .collect();
+        let exports = collect_rooted_exports(&graph, &cfgs);
         if cancellation.is_canceled() {
             return Err(PipelineRequestControl::Abort(
                 rue_query::QueryAbort::Canceled,
@@ -5969,9 +6033,16 @@ impl CompilerSession {
         }
         self.queries
             .revisioned
-            .publish_backend_root(graph.revision, backend_root, object_batch_key)
+            .publish_backend_root(
+                graph.revision,
+                backend_root,
+                crate::revisioned_query_database::BackendRootPublicationInput::Objects(
+                    object_batch_key,
+                ),
+            )
             .map_err(PipelineRequestControl::Abort)?;
         Ok(RootedCodegenOutput {
+            input: RootedCodegenInput::Projected,
             units,
             objects,
             cfgs,

--- a/crates/rue-linker/src/elf.rs
+++ b/crates/rue-linker/src/elf.rs
@@ -82,6 +82,7 @@ use crate::constants::{
     STT_SECTION,
 };
 use ahash::AHashMap;
+use std::sync::Arc;
 
 /// Helper to read a u16 from a byte slice at a given offset.
 /// Panics if offset + 2 > slice.len(), so caller must ensure bounds.
@@ -159,6 +160,47 @@ pub struct ObjectFile {
     pub format: ObjectFormat,
 }
 
+/// A compiler-owned link input whose section atoms remain shared with the
+/// code-generation query.  Unlike [`ObjectFile`], this representation has no
+/// object-container bytes to parse and each atom can be consumed without a
+/// transient flattening allocation.
+#[derive(Debug, Clone)]
+pub struct StructuredObject {
+    /// Sections in object-local order.
+    pub(crate) sections: Vec<StructuredSection>,
+    /// Symbols use the section indices in `sections` and relocation symbol
+    /// indices use this vector, just like [`ObjectFile`].
+    pub(crate) symbols: Vec<Symbol>,
+    /// The machine architecture of this input.
+    pub(crate) machine: ElfMachine,
+    /// The logical object format selected by the target.
+    pub(crate) format: ObjectFormat,
+}
+
+/// One section of a [`StructuredObject`].  Atoms are deliberately retained as
+/// independent `Arc` byte containers so the linker only copies into its final
+/// merged image.
+#[derive(Debug, Clone)]
+pub(crate) struct StructuredSection {
+    pub(crate) name: String,
+    pub(crate) atoms: Arc<[Arc<[u8]>]>,
+    pub(crate) size: u64,
+    pub(crate) flags: SectionFlags,
+    pub(crate) relocations: Vec<Relocation>,
+    pub(crate) align: u64,
+}
+
+/// A relocation in a retained compiler function object. The compiler maps its
+/// backend relocation enum to this linker-owned enum before calling the
+/// function-object constructor; section and symbol conventions stay here.
+#[derive(Debug, Clone)]
+pub struct StructuredRelocation {
+    pub offset: u64,
+    pub symbol: String,
+    pub rel_type: RelocationType,
+    pub addend: i64,
+}
+
 /// Relocatable object container format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ObjectFormat {
@@ -181,6 +223,141 @@ pub struct Section {
     pub relocations: Vec<Relocation>,
     /// Alignment requirement.
     pub align: u64,
+}
+
+impl StructuredObject {
+    /// Expose the retained atom containers for linker-owned consumers without
+    /// exposing the object-construction representation itself.
+    pub fn section_atoms(&self, index: usize) -> Option<&[Arc<[u8]>]> {
+        self.sections
+            .get(index)
+            .map(|section| section.atoms.as_ref())
+    }
+
+    /// Construct the canonical structured object emitted for one retained Rue
+    /// function. The linker owns section names, local string-symbol naming,
+    /// symbol indices, target format, and Mach-O alignment conventions.
+    #[must_use]
+    pub fn function(
+        target: rue_target::Target,
+        defined_symbol: impl Into<String>,
+        text_atoms: Arc<[Arc<[u8]>]>,
+        rodata_atoms: Arc<[Arc<[u8]>]>,
+        relocations: Vec<StructuredRelocation>,
+    ) -> Self {
+        let machine = match target {
+            rue_target::Target::X86_64Linux => ElfMachine::X86_64,
+            rue_target::Target::Aarch64Linux | rue_target::Target::Aarch64Macos => {
+                ElfMachine::Aarch64
+            }
+        };
+        let format = if target.is_macho() {
+            ObjectFormat::MachO
+        } else {
+            ObjectFormat::Elf
+        };
+        let text_size = atoms_size(&text_atoms);
+        let rodata_size = atoms_size(&rodata_atoms);
+        let mut symbols = vec![Symbol {
+            name: defined_symbol.into(),
+            section_index: Some(0),
+            value: 0,
+            size: text_size,
+            binding: SymbolBinding::Global,
+            sym_type: SymbolType::Func,
+        }];
+        let mut symbol_indices = AHashMap::new();
+        let mut rodata_offset = 0_u64;
+        for (index, atom) in rodata_atoms.iter().enumerate() {
+            if !(target.is_macho() && atom.is_empty()) {
+                let name = format!(".rodata.str{index}");
+                symbol_indices.insert(name.clone(), symbols.len());
+                symbols.push(Symbol {
+                    name,
+                    section_index: Some(1),
+                    value: rodata_offset,
+                    size: 0,
+                    binding: SymbolBinding::Local,
+                    sym_type: SymbolType::None,
+                });
+            }
+            rodata_offset += atom.len() as u64;
+        }
+        let linker_relocations = relocations
+            .into_iter()
+            .filter_map(|relocation| {
+                if target.is_macho()
+                    && relocation.symbol.starts_with(".rodata.str")
+                    && relocation
+                        .symbol
+                        .strip_prefix(".rodata.str")
+                        .and_then(|index| index.parse::<usize>().ok())
+                        .and_then(|index| rodata_atoms.get(index))
+                        .is_some_and(|atom| atom.is_empty())
+                {
+                    return None;
+                }
+                let symbol_index = if relocation.symbol == symbols[0].name {
+                    0
+                } else if let Some(&index) = symbol_indices.get(&relocation.symbol) {
+                    index
+                } else {
+                    let index = symbols.len();
+                    symbol_indices.insert(relocation.symbol.clone(), index);
+                    symbols.push(Symbol {
+                        name: relocation.symbol,
+                        section_index: None,
+                        value: 0,
+                        size: 0,
+                        binding: SymbolBinding::Global,
+                        sym_type: SymbolType::None,
+                    });
+                    index
+                };
+                Some(Relocation {
+                    offset: relocation.offset,
+                    symbol_index,
+                    rel_type: relocation.rel_type,
+                    addend: relocation.addend,
+                })
+            })
+            .collect();
+        let mut sections = vec![StructuredSection {
+            name: ".text".into(),
+            atoms: text_atoms,
+            size: text_size,
+            flags: SectionFlags::ALLOC | SectionFlags::EXEC,
+            relocations: linker_relocations,
+            align: if target.is_macho() { 4 } else { 16 },
+        }];
+        let has_rodata = if target.is_macho() {
+            rodata_size != 0
+        } else {
+            !rodata_atoms.is_empty()
+        };
+        if has_rodata {
+            sections.push(StructuredSection {
+                name: ".rodata".into(),
+                atoms: rodata_atoms,
+                size: rodata_size,
+                flags: SectionFlags::ALLOC,
+                relocations: Vec::new(),
+                // ObjectBuilder emits both ELF and Mach-O rodata at 8-byte
+                // alignment; structured admission must preserve that layout.
+                align: 8,
+            });
+        }
+        Self {
+            sections,
+            symbols,
+            machine,
+            format,
+        }
+    }
+}
+
+fn atoms_size(atoms: &[Arc<[u8]>]) -> u64 {
+    atoms.iter().map(|atom| atom.len() as u64).sum()
 }
 
 /// Section flags.
@@ -1398,6 +1575,26 @@ impl ObjectFile {
 mod tests {
     use super::*;
     use crate::constants::{EI_CLASS, EI_DATA, EI_VERSION, ELF64_SHDR_SIZE as TEST_SHDR_SIZE};
+
+    #[test]
+    fn structured_object_preserves_arc_atom_ownership() {
+        let text = Arc::<[u8]>::from(*b"ret");
+        let object = StructuredObject {
+            sections: vec![StructuredSection {
+                name: ".text".into(),
+                atoms: Arc::from([text.clone()]),
+                size: text.len() as u64,
+                flags: SectionFlags::ALLOC | SectionFlags::EXEC,
+                relocations: Vec::new(),
+                align: 16,
+            }],
+            symbols: Vec::new(),
+            machine: ElfMachine::X86_64,
+            format: ObjectFormat::Elf,
+        };
+        assert!(Arc::ptr_eq(&object.sections[0].atoms[0], &text));
+        assert_eq!(object.sections[0].size, 3);
+    }
 
     #[test]
     fn test_parse_error_display() {

--- a/crates/rue-linker/src/lib.rs
+++ b/crates/rue-linker/src/lib.rs
@@ -21,7 +21,7 @@ mod util;
 pub use archive::{Archive, ArchiveError};
 pub use elf::{
     ElfMachine, ObjectFile, ObjectFormat, Relocation, RelocationType, Section, SectionFlags,
-    Symbol, SymbolBinding, SymbolType,
+    StructuredObject, StructuredRelocation, Symbol, SymbolBinding, SymbolType,
 };
 pub use emit::{CodeRelocation, ObjectBuilder};
 pub use linker::{LinkError, Linker};

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -11,9 +11,11 @@ use crate::constants::{
     ELF_MAGIC, ELF64_EHDR_SIZE, ELF64_PHDR_SIZE, ELFCLASS64, ELFDATA2LSB, ET_EXEC, EV_CURRENT,
     PF_R, PF_W, PF_X, PT_LOAD,
 };
-use crate::elf::Section;
-use crate::elf::{ObjectFile, RelocationType, SectionFlags, Symbol, SymbolBinding};
+use crate::elf::{ObjectFile, Relocation, RelocationType, SectionFlags, Symbol, SymbolBinding};
 use crate::util::align_up;
+
+#[cfg(test)]
+use crate::elf::Section;
 
 /// Which merged output buffer a relocation's patch site lives in.
 ///
@@ -212,7 +214,7 @@ fn checked_relocation_offset(
 /// A zero-size symbol may point exactly one byte past the final section byte
 /// (the conventional end-marker position). Any nonzero extent must remain
 /// wholly inside the defining section.
-fn validate_defined_symbols(obj: &ObjectFile) -> Result<(), LinkError> {
+fn validate_defined_symbols(obj: &LinkObject) -> Result<(), LinkError> {
     for sym in &obj.symbols {
         let Some(section_index) = sym.section_index else {
             continue;
@@ -704,8 +706,8 @@ struct PendingRelocation {
 /// indices and skipping null-symbol relocations and relocations against
 /// sections we don't link (debug/unwind).
 fn collect_section_relocations(
-    obj: &ObjectFile,
-    section: &Section,
+    obj: &LinkObject,
+    section: &LinkSection,
     merged_offset: u64,
     obj_idx: usize,
     home: PatchHome,
@@ -758,7 +760,12 @@ fn collect_section_relocations(
         }
 
         let patch_size = relocation_patch_size(reloc.rel_type)?;
-        checked_patch_range(reloc.offset, patch_size, section.data.len(), reloc.rel_type)?;
+        checked_patch_range(
+            reloc.offset,
+            patch_size,
+            section.content_len(),
+            reloc.rel_type,
+        )?;
         let offset = checked_relocation_offset(merged_offset, reloc.offset, reloc.rel_type)?;
 
         pending.push(PendingRelocation {
@@ -956,6 +963,94 @@ impl std::fmt::Display for LinkError {
 
 impl std::error::Error for LinkError {}
 
+#[derive(Debug, Clone)]
+enum LinkSectionContent {
+    Bytes(Vec<u8>),
+    Atoms(std::sync::Arc<[std::sync::Arc<[u8]>]>),
+}
+
+#[derive(Debug, Clone)]
+struct LinkSection {
+    name: String,
+    content: LinkSectionContent,
+    /// The number of initialized bytes represented by `content`.
+    ///
+    /// Structured sections are atom-backed, so calculating this by walking
+    /// every atom at each relocation site would turn admission into an
+    /// O(atoms * relocations) operation. Cache it at the normalized admission
+    /// boundary instead.
+    content_len: usize,
+    size: u64,
+    flags: SectionFlags,
+    relocations: Vec<Relocation>,
+    align: u64,
+}
+
+impl LinkSection {
+    fn content_len(&self) -> usize {
+        self.content_len
+    }
+
+    fn extend_contents(&self, output: &mut Vec<u8>) {
+        match &self.content {
+            LinkSectionContent::Bytes(bytes) => output.extend_from_slice(bytes),
+            LinkSectionContent::Atoms(atoms) => {
+                for atom in atoms.iter() {
+                    output.extend_from_slice(atom);
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct LinkObject {
+    sections: Vec<LinkSection>,
+    symbols: Vec<Symbol>,
+}
+
+impl From<ObjectFile> for LinkObject {
+    fn from(object: ObjectFile) -> Self {
+        Self {
+            sections: object
+                .sections
+                .into_iter()
+                .map(|section| LinkSection {
+                    name: section.name,
+                    content_len: section.data.len(),
+                    content: LinkSectionContent::Bytes(section.data),
+                    size: section.size,
+                    flags: section.flags,
+                    relocations: section.relocations,
+                    align: section.align,
+                })
+                .collect(),
+            symbols: object.symbols,
+        }
+    }
+}
+
+impl From<crate::elf::StructuredObject> for LinkObject {
+    fn from(object: crate::elf::StructuredObject) -> Self {
+        Self {
+            sections: object
+                .sections
+                .into_iter()
+                .map(|section| LinkSection {
+                    name: section.name,
+                    content_len: section.atoms.iter().map(|atom| atom.len()).sum(),
+                    content: LinkSectionContent::Atoms(section.atoms),
+                    size: section.size,
+                    flags: section.flags,
+                    relocations: section.relocations,
+                    align: section.align,
+                })
+                .collect(),
+            symbols: object.symbols,
+        }
+    }
+}
+
 /// The linker.
 pub struct Linker {
     /// The target architecture and OS.
@@ -967,7 +1062,7 @@ pub struct Linker {
     /// Symbol table: name -> (object_index, symbol).
     global_symbols: AHashMap<String, (usize, Symbol)>,
     /// All object files we're linking.
-    objects: Vec<ObjectFile>,
+    objects: Vec<LinkObject>,
     /// Symbols that must be resolved (e.g., entry point).
     /// These are treated as undefined during archive linking.
     required_symbols: Vec<String>,
@@ -1013,6 +1108,10 @@ impl Linker {
             });
         }
 
+        self.add_link_object(LinkObject::from(obj))
+    }
+
+    fn add_link_object(&mut self, obj: LinkObject) -> Result<(), LinkError> {
         validate_defined_symbols(&obj)?;
 
         let obj_index = self.objects.len();
@@ -1044,6 +1143,38 @@ impl Linker {
 
         self.objects.push(obj);
         Ok(())
+    }
+
+    /// Add a compiler-owned object without serializing it into an object
+    /// container first. The structured sections are converted into the same
+    /// stateless object table used by parsed inputs; their `Arc` atoms remain
+    /// shared until the final merged image is built.
+    pub fn add_structured_object(
+        &mut self,
+        obj: crate::elf::StructuredObject,
+    ) -> Result<(), LinkError> {
+        let expected = match self.target {
+            Target::X86_64Linux => crate::elf::ElfMachine::X86_64,
+            Target::Aarch64Linux | Target::Aarch64Macos => crate::elf::ElfMachine::Aarch64,
+        };
+        let expected_format = if self.target.is_macho() {
+            crate::elf::ObjectFormat::MachO
+        } else {
+            crate::elf::ObjectFormat::Elf
+        };
+        if obj.format != expected_format {
+            return Err(LinkError::ArchMismatch {
+                object_machine: format!("format {:?}", obj.format),
+                target: format!("format {:?}", expected_format),
+            });
+        }
+        if obj.machine != expected {
+            return Err(LinkError::ArchMismatch {
+                object_machine: format!("{:?}", obj.machine),
+                target: format!("{:?}", self.target),
+            });
+        }
+        self.add_link_object(LinkObject::from(obj))
     }
 
     /// Add objects from an ar archive selectively based on symbol resolution.
@@ -1214,7 +1345,7 @@ impl Linker {
         // Merge code sections (.text* / __text)
         for (obj_idx, obj) in self.objects.iter().enumerate() {
             for (sec_idx, section) in obj.sections.iter().enumerate() {
-                if !is_text_section(&section.name) || section.data.is_empty() {
+                if !is_text_section(&section.name) || section.content_len() == 0 {
                     continue;
                 }
 
@@ -1234,7 +1365,7 @@ impl Linker {
 
                 let offset = merged_text.len() as u64;
                 section_offsets.insert((obj_idx, sec_idx), offset);
-                merged_text.extend_from_slice(&section.data);
+                section.extend_contents(&mut merged_text);
 
                 collect_section_relocations(
                     obj,
@@ -1267,7 +1398,7 @@ impl Linker {
 
                 let offset = merged_text.len() as u64;
                 section_offsets.insert((obj_idx, sec_idx), offset);
-                merged_text.extend_from_slice(&section.data);
+                section.extend_contents(&mut merged_text);
 
                 collect_section_relocations(
                     obj,
@@ -1285,7 +1416,7 @@ impl Linker {
         // RUE-131 item 8; the ELF side got the same fix via PatchHome in #928)
         for (obj_idx, obj) in self.objects.iter().enumerate() {
             for (sec_idx, section) in obj.sections.iter().enumerate() {
-                if !is_data_section(&section.name) || section.data.is_empty() {
+                if !is_data_section(&section.name) || section.content_len() == 0 {
                     continue;
                 }
 
@@ -1295,7 +1426,7 @@ impl Linker {
 
                 let offset = merged_data.len() as u64;
                 section_offsets.insert((obj_idx, sec_idx), offset);
-                merged_data.extend_from_slice(&section.data);
+                section.extend_contents(&mut merged_data);
 
                 collect_section_relocations(
                     obj,
@@ -1643,7 +1774,9 @@ impl Linker {
         // Merge code sections (.text*)
         for (obj_idx, obj) in self.objects.iter().enumerate() {
             for (sec_idx, section) in obj.sections.iter().enumerate() {
-                if classify_section(&section.name) != SectionKind::Text || section.data.is_empty() {
+                if classify_section(&section.name) != SectionKind::Text
+                    || section.content_len() == 0
+                {
                     continue;
                 }
 
@@ -1662,7 +1795,7 @@ impl Linker {
                 let offset = merged_text.len() as u64;
                 section_offsets.insert((obj_idx, sec_idx), offset);
 
-                merged_text.extend_from_slice(&section.data);
+                section.extend_contents(&mut merged_text);
 
                 collect_section_relocations(
                     obj,
@@ -1694,7 +1827,7 @@ impl Linker {
                 let offset = merged_rodata.len() as u64;
                 section_offsets.insert((obj_idx, sec_idx), offset);
 
-                merged_rodata.extend_from_slice(&section.data);
+                section.extend_contents(&mut merged_rodata);
 
                 collect_section_relocations(
                     obj,
@@ -1714,7 +1847,7 @@ impl Linker {
                     continue;
                 }
                 // Skip empty .data sections
-                if section.data.is_empty() {
+                if section.content_len() == 0 {
                     continue;
                 }
 
@@ -1725,7 +1858,7 @@ impl Linker {
                 let offset = merged_data.len() as u64;
                 section_offsets.insert((obj_idx, sec_idx), offset);
 
-                merged_data.extend_from_slice(&section.data);
+                section.extend_contents(&mut merged_data);
 
                 collect_section_relocations(
                     obj,
@@ -2166,6 +2299,7 @@ mod tests {
     };
     use crate::elf::{ObjectFile, ObjectFormat, SectionFlags};
     use crate::emit::{CodeRelocation, ObjectBuilder};
+    use std::sync::Arc;
 
     // Use X86_64Linux explicitly for ELF tests since ObjectFile only parses ELF
     // and the Linker produces ELF executables
@@ -2186,7 +2320,7 @@ mod tests {
         ObjectFile {
             sections: vec![Section {
                 name: ".text".into(),
-                data: vec![0xC3; section_size],
+                data: vec![0xC3; section_size].into(),
                 size: section_size as u64,
                 flags: crate::elf::SectionFlags::ALLOC | crate::elf::SectionFlags::EXEC,
                 relocations: vec![],
@@ -2197,6 +2331,190 @@ mod tests {
             machine: crate::elf::ElfMachine::X86_64,
             format: ObjectFormat::Elf,
         }
+    }
+
+    #[test]
+    fn structured_function_matches_serialized_executable_on_all_targets() {
+        for target in [
+            Target::X86_64Linux,
+            Target::Aarch64Linux,
+            Target::Aarch64Macos,
+        ] {
+            let serialized = ObjectBuilder::new(target, "main")
+                .code(match target {
+                    Target::X86_64Linux => vec![0xC3],
+                    Target::Aarch64Linux | Target::Aarch64Macos => vec![0xC0, 0x03, 0x5F, 0xD6],
+                })
+                .strings(vec!["literal".into(), String::new()])
+                .build();
+            let parsed = ObjectFile::parse(&serialized).unwrap();
+            let mut byte_linker = Linker::new(target);
+            byte_linker.add_object(parsed).unwrap();
+            let byte_output = byte_linker.link("main").unwrap();
+
+            let text = match target {
+                Target::X86_64Linux => Arc::<[u8]>::from(*b"\xC3"),
+                Target::Aarch64Linux | Target::Aarch64Macos => {
+                    Arc::<[u8]>::from(*b"\xC0\x03\x5F\xD6")
+                }
+            };
+            let structured = crate::StructuredObject::function(
+                target,
+                "main",
+                Arc::from([text]),
+                Arc::from([Arc::from(*b"literal"), Arc::from(*b"")]),
+                Vec::new(),
+            );
+            let mut structured_linker = Linker::new(target);
+            structured_linker.add_structured_object(structured).unwrap();
+            assert_eq!(
+                byte_output,
+                structured_linker.link("main").unwrap(),
+                "{target:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn structured_relocations_and_rodata_layout_match_serialized_objects() {
+        for target in [
+            Target::X86_64Linux,
+            Target::Aarch64Linux,
+            Target::Aarch64Macos,
+        ] {
+            let callee_code = match target {
+                Target::X86_64Linux => vec![0xC3],
+                Target::Aarch64Linux | Target::Aarch64Macos => {
+                    vec![0xC0, 0x03, 0x5F, 0xD6]
+                }
+            };
+            let (main_code, relocations) = match target {
+                Target::X86_64Linux => (
+                    vec![0xE8, 0, 0, 0, 0, 0, 0, 0, 0, 0xC3],
+                    vec![
+                        CodeRelocation {
+                            offset: 1,
+                            symbol: "callee".into(),
+                            rel_type: RelocationType::Plt32,
+                            addend: -4,
+                        },
+                        CodeRelocation {
+                            offset: 5,
+                            symbol: ".rodata.str0".into(),
+                            rel_type: RelocationType::Pc32,
+                            addend: -4,
+                        },
+                    ],
+                ),
+                Target::Aarch64Linux | Target::Aarch64Macos => (
+                    vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xC0, 0x03, 0x5F, 0xD6],
+                    vec![
+                        CodeRelocation {
+                            offset: 0,
+                            symbol: ".rodata.str0".into(),
+                            rel_type: RelocationType::AdrpPage21,
+                            addend: 0,
+                        },
+                        CodeRelocation {
+                            offset: 4,
+                            symbol: ".rodata.str0".into(),
+                            rel_type: RelocationType::AddLo12,
+                            addend: 0,
+                        },
+                        CodeRelocation {
+                            offset: 8,
+                            symbol: "callee".into(),
+                            rel_type: RelocationType::Call26,
+                            addend: 0,
+                        },
+                    ],
+                ),
+            };
+
+            let mut byte_linker = Linker::new(target);
+            for bytes in [
+                ObjectBuilder::new(target, "callee")
+                    .code(callee_code.clone())
+                    .strings(vec!["pad".into()])
+                    .build(),
+                {
+                    let mut builder = ObjectBuilder::new(target, "main")
+                        .code(main_code.clone())
+                        .strings(vec!["literal".into()]);
+                    for relocation in &relocations {
+                        builder = builder.relocation(relocation.clone());
+                    }
+                    builder.build()
+                },
+            ] {
+                byte_linker
+                    .add_object(ObjectFile::parse(&bytes).unwrap())
+                    .unwrap();
+            }
+            let byte_output = byte_linker.link("main").unwrap();
+
+            let mut structured_linker = Linker::new(target);
+            structured_linker
+                .add_structured_object(crate::StructuredObject::function(
+                    target,
+                    "callee",
+                    Arc::from([Arc::from(callee_code)]),
+                    Arc::from([Arc::from(*b"pad")]),
+                    Vec::new(),
+                ))
+                .unwrap();
+            structured_linker
+                .add_structured_object(crate::StructuredObject::function(
+                    target,
+                    "main",
+                    Arc::from([Arc::from(main_code)]),
+                    Arc::from([Arc::from(*b"literal")]),
+                    relocations
+                        .into_iter()
+                        .map(|relocation| crate::StructuredRelocation {
+                            offset: relocation.offset,
+                            symbol: relocation.symbol,
+                            rel_type: relocation.rel_type,
+                            addend: relocation.addend,
+                        })
+                        .collect(),
+                ))
+                .unwrap();
+            assert_eq!(
+                byte_output,
+                structured_linker.link("main").unwrap(),
+                "{target:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn structured_macho_all_empty_rodata_matches_serialized_object() {
+        let target = Target::Aarch64Macos;
+        let code = vec![0xC0, 0x03, 0x5F, 0xD6];
+        let serialized = ObjectBuilder::new(target, "main")
+            .code(code.clone())
+            .strings(vec![String::new(), String::new()])
+            .build();
+        let mut byte_linker = Linker::new(target);
+        byte_linker
+            .add_object(ObjectFile::parse(&serialized).unwrap())
+            .unwrap();
+
+        let structured = crate::StructuredObject::function(
+            target,
+            "main",
+            Arc::from([Arc::from(code)]),
+            Arc::from([Arc::from(*b""), Arc::from(*b"")]),
+            Vec::new(),
+        );
+        assert_eq!(structured.sections.len(), 1);
+        let mut structured_linker = Linker::new(target);
+        structured_linker.add_structured_object(structured).unwrap();
+        assert_eq!(
+            byte_linker.link("main").unwrap(),
+            structured_linker.link("main").unwrap()
+        );
     }
 
     #[test]
@@ -2301,13 +2619,13 @@ mod tests {
     fn defined_symbol_extents_accept_boundaries_and_reject_escape() {
         for (value, size) in [(0, 4), (3, 1), (4, 0)] {
             let obj = object_with_defined_symbols(4, vec![defined_symbol("valid", value, size)]);
-            validate_defined_symbols(&obj)
+            validate_defined_symbols(&LinkObject::from(obj))
                 .unwrap_or_else(|error| panic!("valid extent {value}+{size}: {error}"));
         }
 
         for (value, size) in [(5, 0), (4, 1), (3, 2), (u64::MAX, 2)] {
             let obj = object_with_defined_symbols(4, vec![defined_symbol("bad", value, size)]);
-            let error = validate_defined_symbols(&obj).unwrap_err();
+            let error = validate_defined_symbols(&LinkObject::from(obj)).unwrap_err();
             assert!(matches!(
                 error,
                 LinkError::SymbolOutsideSection {
@@ -2610,7 +2928,7 @@ mod tests {
 
         let text = Section {
             name: ".text".into(),
-            data: vec![0xC3], // ret
+            data: vec![0xC3].into(), // ret
             size: 1,
             flags: SectionFlags::ALLOC | SectionFlags::EXEC,
             relocations: vec![],
@@ -2619,7 +2937,7 @@ mod tests {
         let extra = Section {
             name: name.into(),
             // 8 zero bytes — the unrelocated pointer slot
-            data: vec![0u8; 8],
+            data: vec![0u8; 8].into(),
             size: 8,
             flags,
             relocations: vec![Relocation {
@@ -2813,7 +3131,7 @@ mod tests {
 
         let text = Section {
             name: ".text".into(),
-            data: vec![0xC3], // ret
+            data: vec![0xC3].into(), // ret
             size: 1,
             flags: SectionFlags::ALLOC | SectionFlags::EXEC,
             relocations: vec![],
@@ -2823,7 +3141,7 @@ mod tests {
         // at 8 mod 16.
         let data = Section {
             name: ".data".into(),
-            data: vec![0u8; 8],
+            data: vec![0u8; 8].into(),
             size: 8,
             flags: SectionFlags::ALLOC | SectionFlags::WRITE,
             relocations: vec![Relocation {
@@ -2837,7 +3155,7 @@ mod tests {
         // NOBITS: no bytes in the file, `size` is the memory it needs.
         let bss = Section {
             name: ".bss".into(),
-            data: vec![],
+            data: vec![].into(),
             size: 8,
             flags: SectionFlags::ALLOC | SectionFlags::WRITE,
             relocations: vec![],
@@ -3025,7 +3343,7 @@ mod tests {
         let make_obj = |name: &str, code: Vec<u8>, binding: SymbolBinding| ObjectFile {
             sections: vec![Section {
                 name: ".text".into(),
-                data: code,
+                data: code.into(),
                 size: 1,
                 flags: SectionFlags::ALLOC | SectionFlags::EXEC,
                 relocations: vec![],
@@ -3116,7 +3434,7 @@ mod tests {
         ObjectFile {
             sections: vec![Section {
                 name: ".text".into(),
-                data: vec![0xC3],
+                data: vec![0xC3].into(),
                 size: 1,
                 flags: SectionFlags::ALLOC | SectionFlags::EXEC,
                 relocations: vec![],
@@ -3455,7 +3773,7 @@ mod tests {
             sections: vec![Section {
                 name: ".text".into(),
                 // mov rax, imm64 (placeholder patched by Abs64); ret
-                data: vec![0x48, 0xB8, 0, 0, 0, 0, 0, 0, 0, 0, 0xC3],
+                data: vec![0x48, 0xB8, 0, 0, 0, 0, 0, 0, 0, 0, 0xC3].into(),
                 size: 11,
                 flags: SectionFlags::ALLOC | SectionFlags::EXEC,
                 relocations: vec![Relocation {
@@ -3804,7 +4122,8 @@ mod tests {
             data: vec![
                 0xE8, 0x00, 0x00, 0x00, 0x00, // call <placeholder>
                 0xC3, // ret
-            ],
+            ]
+            .into(),
             size: 6,
             flags: SectionFlags::ALLOC | SectionFlags::EXEC,
             relocations: vec![Relocation {
@@ -3888,7 +4207,8 @@ mod tests {
             data: vec![
                 0xE8, 0x00, 0x00, 0x00, 0x00, // call <placeholder>
                 0xC3, // ret
-            ],
+            ]
+            .into(),
             size: 6,
             flags: SectionFlags::ALLOC | SectionFlags::EXEC,
             relocations: vec![Relocation {
@@ -4813,7 +5133,7 @@ mod tests {
 
         let text_section = Section {
             name: "__text".to_string(),
-            data: code,
+            data: code.into(),
             size: 8,
             flags: SectionFlags::ALLOC | SectionFlags::EXEC,
             relocations: vec![],
@@ -4872,7 +5192,7 @@ mod tests {
 
         let text_section = Section {
             name: "__text".to_string(),
-            data: code,
+            data: code.into(),
             size: 4,
             flags: SectionFlags::ALLOC | SectionFlags::EXEC,
             relocations: vec![],
@@ -4913,7 +5233,7 @@ mod tests {
 
         let text_section = Section {
             name: "__text".to_string(),
-            data: code,
+            data: code.into(),
             size: 4,
             flags: SectionFlags::ALLOC | SectionFlags::EXEC,
             relocations: vec![],
@@ -4981,7 +5301,7 @@ mod tests {
         Section {
             name: name.into(),
             size: data.len() as u64,
-            data,
+            data: data.into(),
             flags: SectionFlags::ALLOC | SectionFlags::EXEC,
             relocations,
             align: 16,
@@ -5172,7 +5492,7 @@ mod tests {
         };
         let rodata = Section {
             name: "__TEXT,__const".into(),
-            data: vec![0u8; 8], // unrelocated pointer slot
+            data: vec![0u8; 8].into(), // unrelocated pointer slot
             size: 8,
             flags: SectionFlags::ALLOC,
             relocations: vec![Relocation {
@@ -5234,7 +5554,7 @@ mod tests {
         };
         let data = Section {
             name: "__DATA,__data".into(),
-            data: vec![0u8; 16],
+            data: vec![0u8; 16].into(),
             size: 16,
             flags: SectionFlags::ALLOC | SectionFlags::WRITE,
             relocations: vec![Relocation {
@@ -5414,7 +5734,7 @@ mod tests {
         };
         let data = Section {
             name: "__DATA,__data".into(),
-            data: vec![0u8; 16],
+            data: vec![0u8; 16].into(),
             size: 16,
             flags: SectionFlags::ALLOC | SectionFlags::WRITE,
             relocations: vec![],
@@ -5500,7 +5820,7 @@ mod tests {
         };
         let data = Section {
             name: "__DATA,__data".into(),
-            data: vec![0u8; 16],
+            data: vec![0u8; 16].into(),
             size: 16,
             flags: SectionFlags::ALLOC | SectionFlags::WRITE,
             relocations: vec![],
@@ -5571,7 +5891,7 @@ mod tests {
         };
         let data = Section {
             name: "__DATA,__data".into(),
-            data: vec![0u8; 16],
+            data: vec![0u8; 16].into(),
             size: 16,
             flags: SectionFlags::ALLOC | SectionFlags::WRITE,
             relocations: vec![],
@@ -5762,7 +6082,7 @@ mod tests {
             ".text",
             Section {
                 name: ".init_array".into(),
-                data: vec![0u8; 8],
+                data: vec![0u8; 8].into(),
                 size: 8,
                 flags: SectionFlags::ALLOC | SectionFlags::WRITE,
                 relocations: Vec::new(),
@@ -5791,7 +6111,7 @@ mod tests {
             ".text",
             Section {
                 name: ".debug_info".into(),
-                data: vec![0u8; 8],
+                data: vec![0u8; 8].into(),
                 size: 8,
                 flags: SectionFlags::empty(),
                 relocations: Vec::new(),
@@ -5832,7 +6152,7 @@ mod tests {
                 "__TEXT,__text",
                 Section {
                     name: name.into(),
-                    data: marker.to_vec(),
+                    data: marker.to_vec().into(),
                     size: marker.len() as u64,
                     flags: SectionFlags::ALLOC,
                     relocations: Vec::new(),
@@ -5883,7 +6203,7 @@ mod tests {
         };
         let data = Section {
             name: data_name.into(),
-            data: vec![0u8; 17],
+            data: vec![0u8; 17].into(),
             size: 17,
             flags: SectionFlags::ALLOC | SectionFlags::WRITE,
             relocations: vec![
@@ -5904,7 +6224,7 @@ mod tests {
         };
         let bss8 = Section {
             name: bss_name.into(),
-            data: Vec::new(),
+            data: Vec::new().into(),
             size: 4,
             flags: SectionFlags::ALLOC | SectionFlags::WRITE,
             relocations: Vec::new(),
@@ -5926,7 +6246,7 @@ mod tests {
 
         let bss16 = Section {
             name: bss_name.into(),
-            data: Vec::new(),
+            data: Vec::new().into(),
             size: 8,
             flags: SectionFlags::ALLOC | SectionFlags::WRITE,
             relocations: Vec::new(),
@@ -6006,7 +6326,7 @@ mod tests {
                     machine,
                     vec![Section {
                         name: ".text".into(),
-                        data: vec![byte, byte.wrapping_add(1), byte.wrapping_add(2)],
+                        data: vec![byte, byte.wrapping_add(1), byte.wrapping_add(2)].into(),
                         size: 3,
                         flags: SectionFlags::ALLOC | SectionFlags::EXEC,
                         relocations: Vec::new(),

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -2023,11 +2023,11 @@ mod tests {
             ("codegen_unit", "mir_lowering"),
             ("codegen_unit", "register_allocation"),
             ("codegen_unit", "machine_emission"),
-            // Object serialization runs after collecting the query units, so
-            // it remains a sibling of those backend leaves.
-            ("compile_pipeline", "object_serialization"),
+            // Object serialization remains a sibling of the backend leaves
+            // for object output and system linking. The ordinary internal
+            // link admits the retained units through the structured adapter.
             ("compile_pipeline", "linker"),
-            ("linker", "link_parse_objects"),
+            ("linker", "link_structured_admission"),
             ("linker", "link_layout"),
             ("linker", "link_emit"),
         ] {


### PR DESCRIPTION
## Summary\n- link retained CodegenUnits through a structured Arc-backed linker input\n- keep object-container projection for object emission, system linking, archives, runtime, and export thunks\n- preserve canonical retained-root publication and add cross-target equivalence and copy-path coverage\n\n## Validation\n- scripts/rue fmt\n- scripts/rue unit linker\n- scripts/rue unit compiler\n- scripts/rue quick\n- scripts/rue premerge\n- scripts/rue test\n\nFixes RUE-1668