### PR TITLE
RUE-1774: reuse keyed const type resolution

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -4003,6 +4003,34 @@ fn durable_comptime_services_are_named_authority_operations() {
         finalize_imports_at < const_eval_at,
         "const registry must receive finalized imports before evaluation"
     );
+    let const_root_start = database
+        .find("Key::ConstResolution(query) =>")
+        .expect("const evaluator root");
+    let const_root_end = database[const_root_start..]
+        .find("Key::AnonymousNominal(query) =>")
+        .map(|offset| const_root_start + offset)
+        .expect("end of const evaluator root");
+    assert!(const_root_start < const_root_end);
+    let const_root = &database[const_root_start..const_root_end];
+    assert!(
+        const_root.contains("let declared_type_resolution = declared_type.as_ref().map(|syntax|")
+            && const_root.contains("resolve_type_syntax(&program_key, *syntax)")
+            && const_root.contains("match declared_type_resolution"),
+        "const completion must validate its declared type from the keyed resolution"
+    );
+    assert_eq!(
+        const_root
+            .matches("resolve_type_syntax(&program_key, *syntax)")
+            .count(),
+        1,
+        "const completion must reuse one exact keyed declared-type resolution"
+    );
+    assert!(
+        !const_root.contains("resolve_semantic_candidate_type(")
+            && !const_root.contains("resolve_structured_semantic_type_syntax_with("),
+        "const completion must not re-pair declared syntax with loose evaluator authority"
+    );
+    assert!(!database.contains("fn resolve_semantic_candidate_type("));
     for root in evaluator_roots {
         assert!(root.contains("authority: &mut authority"));
         for operation in [

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -6863,30 +6863,6 @@ fn semantic_candidate_spelling<'a>(symbols: &'a [&'a str], symbol: &lasso::Spur)
     symbols[symbol.into_usize()]
 }
 
-fn resolve_semantic_candidate_type(
-    provider: &mut SemanticNucleusTypeProvider<'_>,
-    module: &ModuleId,
-    rir: &rue_rir::ValidatedRir,
-    symbols: &[&str],
-    syntax: rue_rir::RirTypeSyntaxRef,
-) -> Result<
-    crate::durable_semantics::DurableType,
-    rue_air::SemanticTypeSyntaxError<
-        QueryAbort,
-        crate::semantic_query_nucleus::SemanticNucleusFailure,
-        StableDefinitionKey,
-        Arc<str>,
-    >,
-> {
-    rue_air::resolve_structured_semantic_type_syntax_with(
-        provider,
-        module,
-        rir.type_syntax(),
-        syntax,
-        |symbol| symbols[symbol.into_usize()],
-    )
-}
-
 fn semantic_candidate_type_is_named(
     rir: &rue_rir::ValidatedRir,
     symbols: &[&str],
@@ -13733,15 +13709,22 @@ impl RevisionedQueryDatabase {
                                         .session
                                         .register_program(&core)
                                         .expect("const root program must register once");
-                                    let expected_type = declared_type.as_ref().and_then(|syntax| {
+                                    // Resolve the declaration annotation once through the keyed
+                                    // registered program.  The same owned result is used both as
+                                    // AIR's expected-result hint and for the post-evaluation
+                                    // declaration check; this avoids re-pairing a dense syntax
+                                    // reference with the legacy evaluator's ambient arena.
+                                    let declared_type_resolution = declared_type.as_ref().map(|syntax| {
                                         let mut services =
                                             crate::durable_comptime::DurableComptimeServices::new(
                                                 &mut authority,
                                             );
-                                        services
-                                            .resolve_type_syntax(&program_key, *syntax)
-                                            .ok()
+                                        services.resolve_type_syntax(&program_key, *syntax)
                                     });
+                                    let expected_type = declared_type_resolution
+                                        .as_ref()
+                                        .and_then(|result| result.as_ref().ok())
+                                        .cloned();
                                             if matches!(
                                                 expected_type,
                                                 Some(crate::durable_semantics::DurableType::Slice { .. })
@@ -13806,7 +13789,7 @@ impl RevisionedQueryDatabase {
                                                 )
                                             })
                                             .collect::<BTreeMap<_, _>>();
-                                            let (result, mut provider) = {
+                                            let (result, provider) = {
                                                 let mut evaluator = SemanticConstEvaluator {
                                                     authority: &mut authority,
                                             program: program_key.clone(),
@@ -13844,14 +13827,9 @@ impl RevisionedQueryDatabase {
                                                 Ok(EvaluatedSemanticConst::Value(typed)) => {
                                                     let typed = Arc::unwrap_or_clone(typed);
                                                     let value = typed.value;
-                                                    let resolved_type = match declared_type.as_ref() {
-                                                        Some(type_syntax) => resolve_semantic_candidate_type(
-                                                            &mut provider,
-                                                            &query.declaration.module,
-                                                            rir,
-                                                            &symbols,
-                                                            *type_syntax,
-                                                        ),
+                                                    let resolved_type = match declared_type_resolution {
+                                                        Some(Ok(ty)) => Ok(ty),
+                                                        Some(Err(error)) => Err(error),
                                                         None if matches!(
                                                             value,
                                                             crate::durable_semantics::DurableConstValue::Type(_)


### PR DESCRIPTION
## Summary

- Resolve a const declaration annotation once through its exact registered durable program.
- Reuse the owned result for both the evaluator expected-type hint and post-evaluation completion validation.
- Delete the loose provider/module/RIR/symbol resolver and add inventory guards against reintroducing it.

## Scope

This is a staged migration prerequisite. Durable roots still execute `SemanticConstEvaluator`; no language behavior or evaluator cutover is included.

## Validation

- `scripts/rue unit compiler durable_` (84/84)
- `scripts/rue cli comptime` (178/178)
- `scripts/rue quick`
- `scripts/rue premerge` on the exact rebased commit
- adversarial architecture review: no findings

Relates to RUE-1774