### PR TITLE
RUE-1774: centralize durable scalar policy

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -3038,6 +3038,15 @@ fn durable_const_integer_semantics_use_the_shared_kernel() {
         .and_then(|source| source.split("fn durable_int_width(").next())
         .expect("durable integer fit adapter");
     let durable = include_str!("durable_comptime.rs");
+    let scalar_policy = durable
+        .split("pub(crate) struct DurableComptimeScalarPolicy;")
+        .nth(1)
+        .and_then(|source| {
+            source
+                .split("#[derive(Debug, Clone, PartialEq, Eq)]\npub(crate) enum DurableComptimeValueFitFailure")
+                .next()
+        })
+        .expect("durable scalar policy");
     let canonical_fits = durable
         .split("pub(crate) fn durable_const_fits_type(")
         .nth(1)
@@ -3059,9 +3068,40 @@ fn durable_const_integer_semantics_use_the_shared_kernel() {
         .and_then(|source| source.split("E::Block { instructions }").next())
         .expect("durable unary evaluator");
     let arithmetic_policy = format!("{arithmetic}{unary}");
+    let integer_selector = evaluator
+        .split("fn integer_type(")
+        .nth(1)
+        .and_then(|source| source.split("fn eval_binary(").next())
+        .expect("durable integer selector");
 
     assert!(fits.contains("durable_const_fits_type"));
     assert!(canonical_fits.contains("integer.fits_i128"));
+    for required in [
+        "type_name",
+        "type_is_unsigned",
+        "type_integer_semantics",
+        "integer_operation_type",
+        "unary_integer_type",
+        "require_integer_fits",
+        "checked_integer_result",
+    ] {
+        assert!(
+            scalar_policy.contains(required),
+            "durable scalar policy missing {required}"
+        );
+        assert!(
+            arithmetic_policy.contains(&format!("DurableComptimeScalarPolicy::{required}"))
+                || integer_selector.contains(&format!("DurableComptimeScalarPolicy::{required}"))
+                || required == "type_name"
+                || required == "type_is_unsigned"
+                || required == "type_integer_semantics",
+            "legacy evaluator bypassed durable scalar policy: {required}"
+        );
+    }
+    assert!(
+        source.contains("DurableComptimeScalarPolicy::type_integer_semantics(ty)"),
+        "durable width adapter must route through scalar policy"
+    );
     for duplicated_fit in [
         "i8::try_from",
         "i16::try_from",
@@ -3653,8 +3693,6 @@ fn durable_comptime_services_are_named_authority_operations() {
     assert!(!database.contains("enum EvaluateSemanticConstError {"));
     for routed in [
         "DurableComptimeFailure::maximum_depth(",
-        "DurableComptimeFailure::integer_literal_overflow(",
-        "DurableComptimeFailure::arithmetic_overflow(",
         "DurableComptimeFailure::division_by_zero()",
         "DurableComptimeFailure::remainder_by_zero()",
         "DurableComptimeFailure::provider_error(error)",
@@ -3663,6 +3701,15 @@ fn durable_comptime_services_are_named_authority_operations() {
         assert!(
             database.contains(routed),
             "legacy durable evaluator no longer routes {routed} through the canonical bridge"
+        );
+    }
+    for routed in [
+        "DurableComptimeScalarPolicy::require_integer_fits(",
+        "DurableComptimeScalarPolicy::checked_integer_result(",
+    ] {
+        assert!(
+            database.contains(routed),
+            "legacy durable evaluator no longer routes {routed} through scalar policy"
         );
     }
     assert!(facade.contains("query: crate::semantic_query_nucleus::ComptimeCallQueryKey"));

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -1677,7 +1677,7 @@ pub(crate) fn durable_type_from_instance_key(
     })
 }
 
-pub(crate) fn durable_type_diagnostic_name(ty: &DurableType) -> String {
+fn durable_type_diagnostic_name_kernel(ty: &DurableType) -> String {
     use crate::durable_semantics::DurableType as T;
 
     fn function_name(function: &crate::FunctionInstanceKey) -> Option<&str> {
@@ -1755,6 +1755,10 @@ pub(crate) fn durable_type_diagnostic_name(ty: &DurableType) -> String {
         T::Module(module) => module.to_string(),
         T::GenericParameter(index) => format!("T{index}"),
     }
+}
+
+pub(crate) fn durable_type_diagnostic_name(ty: &DurableType) -> String {
+    DurableComptimeScalarPolicy::type_name(ty)
 }
 
 pub(crate) fn inferred_durable_const_type_name(value: &DurableConstValue) -> &'static str {
@@ -1862,6 +1866,92 @@ pub(crate) fn durable_int_width(
         _ => return None,
     };
     IntegerType::new(bits, signed)
+}
+
+/// Stateless scalar policy shared by declaration-time evaluation and the
+/// future AIR durable host.  It owns no query or RIR state; all inputs are
+/// already-reduced durable values and types.
+pub(crate) struct DurableComptimeScalarPolicy;
+
+impl DurableComptimeScalarPolicy {
+    pub(crate) fn type_name(ty: &DurableType) -> String {
+        durable_type_diagnostic_name_kernel(ty)
+    }
+
+    #[allow(dead_code)] // activated by the staged durable AIR host
+    pub(crate) fn type_is_unsigned(ty: &DurableType) -> bool {
+        Self::type_integer_semantics(ty).is_some_and(|integer| integer.is_unsigned())
+    }
+
+    pub(crate) fn type_integer_semantics(
+        ty: &DurableType,
+    ) -> Option<rue_air::integer_semantics::IntegerType> {
+        durable_int_width(ty)
+    }
+
+    pub(crate) fn integer_operation_type(
+        expected: Option<&DurableType>,
+        left: Option<&DurableType>,
+        right: Option<&DurableType>,
+    ) -> Result<DurableType, DurableComptimeFailure> {
+        let fallback = expected
+            .filter(|ty| durable_int_width(ty).is_some())
+            .cloned()
+            .unwrap_or(DurableType::I32);
+        match (left, right) {
+            (Some(left), Some(right)) if left != right => Err(DurableComptimeFailure::failure(
+                SemanticNucleusFailure::Diagnostic(rue_error::ErrorKind::TypeMismatch {
+                    expected: durable_type_diagnostic_name(left),
+                    found: durable_type_diagnostic_name(right),
+                }),
+            )),
+            (Some(ty), _) | (_, Some(ty)) => Ok(ty.clone()),
+            (None, None) => Ok(fallback),
+        }
+    }
+
+    pub(crate) fn unary_integer_type(
+        expected: Option<&DurableType>,
+        operand: Option<&DurableType>,
+    ) -> Result<DurableType, DurableComptimeFailure> {
+        Self::integer_operation_type(expected, operand, None)
+    }
+
+    pub(crate) fn require_integer_fits(
+        ty: &DurableType,
+        value: i128,
+    ) -> Result<(), DurableComptimeFailure> {
+        let integer = DurableConstValue::Integer(value);
+        if durable_const_fits_type(&integer, ty) {
+            return Ok(());
+        }
+        Err(DurableComptimeFailure::integer_literal_overflow(
+            &durable_type_diagnostic_name(ty),
+            value,
+        ))
+    }
+
+    pub(crate) fn checked_integer_result(
+        ty: &DurableType,
+        result: rue_air::integer_semantics::CheckedIntegerResult,
+        operation: &str,
+    ) -> Result<i128, DurableComptimeFailure> {
+        let Some(value) = result.checked() else {
+            let type_name = durable_type_diagnostic_name(ty);
+            let detail = result.raw().map_or_else(
+                || format!("the result does not fit in {type_name}"),
+                |value| {
+                    format!(
+                        "value {value} is out of range for type {type_name}; {value} does not fit in {type_name}"
+                    )
+                },
+            );
+            return Err(DurableComptimeFailure::arithmetic_overflow(
+                &type_name, operation, &detail,
+            ));
+        };
+        Ok(value)
+    }
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -6173,6 +6263,91 @@ mod terminal_adapter_tests {
                 if matches!(*value, SemanticNucleusFailure::DiagnosticAtProducerRange {
                     ref producer, start: 100, end: 120, ..
                 } if producer == &nested.producer)
+        ));
+    }
+
+    #[test]
+    fn scalar_policy_preserves_integer_precedence_and_fallbacks() {
+        use crate::durable_semantics::DurableType as T;
+
+        assert_eq!(DurableComptimeScalarPolicy::type_name(&T::U16), "u16");
+        for ty in [T::U8, T::U16, T::U32, T::U64] {
+            assert!(DurableComptimeScalarPolicy::type_is_unsigned(&ty));
+        }
+        for ty in [T::I8, T::I16, T::I32, T::I64, T::Bool] {
+            assert!(!DurableComptimeScalarPolicy::type_is_unsigned(&ty));
+        }
+        assert_eq!(
+            DurableComptimeScalarPolicy::type_integer_semantics(&T::I32)
+                .expect("i32 has integer semantics")
+                .bits(),
+            32
+        );
+
+        // A reduced operand type wins over the frame expected type, matching
+        // the legacy evaluator's integer_type(left, right) precedence.
+        assert_eq!(
+            DurableComptimeScalarPolicy::integer_operation_type(Some(&T::U16), Some(&T::I8), None,)
+                .unwrap(),
+            T::I8
+        );
+        assert_eq!(
+            DurableComptimeScalarPolicy::unary_integer_type(Some(&T::U16), Some(&T::I8)).unwrap(),
+            T::I8
+        );
+        assert_eq!(
+            DurableComptimeScalarPolicy::integer_operation_type(Some(&T::U8), None, None).unwrap(),
+            T::U8
+        );
+        assert_eq!(
+            DurableComptimeScalarPolicy::unary_integer_type(None, None).unwrap(),
+            T::I32
+        );
+        assert!(matches!(
+            DurableComptimeScalarPolicy::integer_operation_type(
+                None,
+                Some(&T::I8),
+                Some(&T::U8),
+            ),
+            Err(DurableComptimeFailure::Failure(value))
+                if matches!(*value, SemanticNucleusFailure::Diagnostic(
+                    rue_error::ErrorKind::TypeMismatch { .. }
+                ))
+        ));
+    }
+
+    #[test]
+    fn scalar_policy_preserves_fit_and_arithmetic_diagnostics() {
+        use crate::durable_semantics::DurableType as T;
+
+        DurableComptimeScalarPolicy::require_integer_fits(&T::U8, 255).unwrap();
+        assert!(matches!(
+            DurableComptimeScalarPolicy::require_integer_fits(&T::U8, 256),
+            Err(DurableComptimeFailure::Failure(value))
+                if matches!(*value, SemanticNucleusFailure::Diagnostic(
+                    rue_error::ErrorKind::ComptimeEvaluationFailed { ref reason }
+                ) if reason.contains("does not fit in u8"))
+        ));
+        let integer = rue_air::integer_semantics::IntegerType::new(8, true).unwrap();
+        assert_eq!(
+            DurableComptimeScalarPolicy::checked_integer_result(
+                &T::I8,
+                integer.checked_add_report_i128(1, 2),
+                "addition",
+            )
+            .unwrap(),
+            3
+        );
+        assert!(matches!(
+            DurableComptimeScalarPolicy::checked_integer_result(
+                &T::I8,
+                integer.checked_add_report_i128(127, 1),
+                "addition",
+            ),
+            Err(DurableComptimeFailure::Failure(value))
+                if matches!(*value, SemanticNucleusFailure::Diagnostic(
+                    rue_error::ErrorKind::ComptimeEvaluationFailed { ref reason }
+                ) if reason.contains("integer overflow evaluating addition"))
         ));
     }
 }

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -4193,12 +4193,12 @@ fn durable_literal_array_length_failure(
 /// what `<<` and `~` mean at a given width (RUE-1698, RUE-1750).
 ///
 /// Returns `None` for a non-integer type. The durable evaluator only reaches
-/// the truncating arms after [`SemanticConstEvaluator::require_integer_fits`]
+/// the truncating arms after `DurableComptimeScalarPolicy::require_integer_fits`
 /// has admitted the operands at `ty`, which no non-integer type survives.
 fn durable_int_width(
     ty: &crate::durable_semantics::DurableType,
 ) -> Option<rue_air::integer_semantics::IntegerType> {
-    crate::durable_comptime::durable_int_width(ty)
+    crate::durable_comptime::DurableComptimeScalarPolicy::type_integer_semantics(ty)
 }
 
 fn semantic_nucleus_declaration_name(identity: &str) -> Option<Arc<str>> {
@@ -7475,74 +7475,11 @@ impl SemanticConstEvaluator<'_, '_> {
         left: Option<crate::durable_semantics::DurableType>,
         right: Option<crate::durable_semantics::DurableType>,
     ) -> Result<crate::durable_semantics::DurableType, EvaluateSemanticConstError> {
-        use crate::durable_semantics::DurableType as T;
-        let fallback = self
-            .expected_type
-            .clone()
-            .filter(|ty| {
-                matches!(
-                    ty,
-                    T::I8 | T::I16 | T::I32 | T::I64 | T::U8 | T::U16 | T::U32 | T::U64
-                )
-            })
-            .unwrap_or(T::I32);
-        match (left, right) {
-            (Some(left), Some(right)) if left != right => Err(EvaluateSemanticConstError::failure(
-                crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
-                    rue_error::ErrorKind::TypeMismatch {
-                        expected: durable_type_diagnostic_name(&left),
-                        found: durable_type_diagnostic_name(&right),
-                    },
-                ),
-            )),
-            (Some(ty), _) | (_, Some(ty)) => Ok(ty),
-            (None, None) => Ok(fallback),
-        }
-    }
-
-    fn require_integer_fits(
-        ty: &crate::durable_semantics::DurableType,
-        value: i128,
-    ) -> Result<(), EvaluateSemanticConstError> {
-        let value = crate::durable_semantics::DurableConstValue::Integer(value);
-        if durable_const_fits_type(&value, ty) {
-            Ok(())
-        } else {
-            let value = match value {
-                crate::durable_semantics::DurableConstValue::Integer(value) => value,
-                _ => unreachable!(),
-            };
-            let type_name = durable_type_diagnostic_name(ty);
-            Err(
-                crate::durable_comptime::DurableComptimeFailure::integer_literal_overflow(
-                    &type_name, value,
-                ),
-            )
-        }
-    }
-
-    fn checked_integer_result(
-        ty: &crate::durable_semantics::DurableType,
-        result: rue_air::integer_semantics::CheckedIntegerResult,
-        operation: &str,
-    ) -> Result<i128, EvaluateSemanticConstError> {
-        let Some(value) = result.checked() else {
-            let type_name = durable_type_diagnostic_name(ty);
-            let detail = result.raw().map_or_else(
-                || format!("the result does not fit in {type_name}"),
-                |value| {
-                    format!(
-                        "value {value} is out of range for type {type_name}; {value} does not fit in {type_name}"
-                    )
-                },
-            );
-            return Err(
-                crate::durable_comptime::DurableComptimeFailure::arithmetic_overflow(
-                    &type_name, operation, &detail,
-                ),
-            );
-        };
-        Ok(value)
+        crate::durable_comptime::DurableComptimeScalarPolicy::integer_operation_type(
+            self.expected_type.as_ref(),
+            left.as_ref(),
+            right.as_ref(),
+        )
     }
 
     fn eval_binary(
@@ -7607,43 +7544,59 @@ impl SemanticConstEvaluator<'_, '_> {
             return Self::failure("comptime arithmetic operand is not an integer");
         };
         let operand_ty = self.integer_type(left_ty, right_ty)?;
-        Self::require_integer_fits(&operand_ty, left)?;
-        Self::require_integer_fits(&operand_ty, right)?;
+        crate::durable_comptime::DurableComptimeScalarPolicy::require_integer_fits(
+            &operand_ty,
+            left,
+        )?;
+        crate::durable_comptime::DurableComptimeScalarPolicy::require_integer_fits(
+            &operand_ty,
+            right,
+        )?;
         let Some(integer) = durable_int_width(&operand_ty) else {
             return Self::failure("comptime arithmetic operand is not an integer");
         };
         let value = match op {
-            O::Add => V::Integer(Self::checked_integer_result(
-                &operand_ty,
-                integer.checked_add_report_i128(left, right),
-                "addition",
-            )?),
-            O::Sub => V::Integer(Self::checked_integer_result(
-                &operand_ty,
-                integer.checked_sub_report_i128(left, right),
-                "subtraction",
-            )?),
-            O::Mul => V::Integer(Self::checked_integer_result(
-                &operand_ty,
-                integer.checked_mul_report_i128(left, right),
-                "multiplication",
-            )?),
+            O::Add => V::Integer(
+                crate::durable_comptime::DurableComptimeScalarPolicy::checked_integer_result(
+                    &operand_ty,
+                    integer.checked_add_report_i128(left, right),
+                    "addition",
+                )?,
+            ),
+            O::Sub => V::Integer(
+                crate::durable_comptime::DurableComptimeScalarPolicy::checked_integer_result(
+                    &operand_ty,
+                    integer.checked_sub_report_i128(left, right),
+                    "subtraction",
+                )?,
+            ),
+            O::Mul => V::Integer(
+                crate::durable_comptime::DurableComptimeScalarPolicy::checked_integer_result(
+                    &operand_ty,
+                    integer.checked_mul_report_i128(left, right),
+                    "multiplication",
+                )?,
+            ),
             O::Div if right == 0 => {
                 return Err(crate::durable_comptime::DurableComptimeFailure::division_by_zero());
             }
             O::Mod if right == 0 => {
                 return Err(crate::durable_comptime::DurableComptimeFailure::remainder_by_zero());
             }
-            O::Div => V::Integer(Self::checked_integer_result(
-                &operand_ty,
-                integer.checked_div_report_i128(left, right),
-                "division",
-            )?),
-            O::Mod => V::Integer(Self::checked_integer_result(
-                &operand_ty,
-                integer.checked_rem_report_i128(left, right),
-                "remainder",
-            )?),
+            O::Div => V::Integer(
+                crate::durable_comptime::DurableComptimeScalarPolicy::checked_integer_result(
+                    &operand_ty,
+                    integer.checked_div_report_i128(left, right),
+                    "division",
+                )?,
+            ),
+            O::Mod => V::Integer(
+                crate::durable_comptime::DurableComptimeScalarPolicy::checked_integer_result(
+                    &operand_ty,
+                    integer.checked_rem_report_i128(left, right),
+                    "remainder",
+                )?,
+            ),
             O::Eq => V::Bool(integer.compare_i128(left, right) == std::cmp::Ordering::Equal),
             O::Ne => V::Bool(integer.compare_i128(left, right) != std::cmp::Ordering::Equal),
             O::Lt => V::Bool(integer.compare_i128(left, right) == std::cmp::Ordering::Less),
@@ -8378,7 +8331,10 @@ impl SemanticConstEvaluator<'_, '_> {
             ))),
             E::Neg { operand } | E::BitNot { operand } => {
                 let (operand_value, ty) = self.int_value(*operand)?;
-                let ty = self.integer_type(ty, None)?;
+                let ty = crate::durable_comptime::DurableComptimeScalarPolicy::unary_integer_type(
+                    self.expected_type.as_ref(),
+                    ty.as_ref(),
+                )?;
                 let result = if matches!(&instruction.data, E::Neg { .. }) {
                     let Some(integer) = durable_int_width(&ty) else {
                         return Self::failure("comptime negation operand is not an integer");
@@ -8388,7 +8344,9 @@ impl SemanticConstEvaluator<'_, '_> {
                     } else {
                         integer.checked_neg_report_i128(operand_value)
                     };
-                    Self::checked_integer_result(&ty, report, "negation")?
+                    crate::durable_comptime::DurableComptimeScalarPolicy::checked_integer_result(
+                        &ty, report, "negation",
+                    )?
                 } else {
                     // `~` is closed over the operand width and cannot trap:
                     // `~0u8` is 255, not the i128 -1 this used to compute and


### PR DESCRIPTION
Summary

- centralize durable type naming and integer policy for the future rue-air host
- route the legacy declaration-time evaluator through the same type-selection, range, and overflow policy
- guard the shared rue-air integer kernel and exact precedence/fallback behavior with focused tests and inventory checks

Testing

- scripts/rue fmt
- scripts/rue unit compiler durable_ (86 passed)
- scripts/rue premerge (200 passed)

Relates to RUE-1774