### PR TITLE
RUE-1774: compose durable foreign authority

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -4005,8 +4005,9 @@ fn durable_comptime_services_are_named_authority_operations() {
             "imports: QueryFamily<DeclarationImportQueryKey, DeclarationImportQueryValue>,",
             "session: crate::durable_comptime::DurableComptimeSession,",
             "legacy_effects: crate::durable_comptime::DurableComptimeEffects,",
+            "foreign: DurableComptimeForeignQueryAuthority<'db>,",
         ],
-        "durable root authority must own exactly the four canonical service fields"
+        "durable root authority must own exactly the five canonical service fields"
     );
     assert_eq!(
         database
@@ -4015,6 +4016,41 @@ fn durable_comptime_services_are_named_authority_operations() {
         1,
         "one root authority must own the durable semantic service implementation"
     );
+    assert_eq!(
+        database
+            .matches(
+                "impl crate::durable_comptime::DurableComptimeForeignCallAuthority\n    for DurableComptimeRootAuthority"
+            )
+            .count(),
+        1,
+        "the root must delegate foreign calls through one owned authority"
+    );
+    let root_foreign_impl = database
+        .split(
+            "impl crate::durable_comptime::DurableComptimeForeignCallAuthority\n    for DurableComptimeRootAuthority<'_>\n{",
+        )
+        .nth(1)
+        .and_then(|source| source.split("\n}\n\nfn project_named_value_candidate").next())
+        .expect("bounded root foreign authority implementation");
+    assert_eq!(root_foreign_impl.matches("self.foreign").count(), 1);
+    assert_eq!(
+        root_foreign_impl.matches(".probe_comptime_call(").count(),
+        1
+    );
+    for forbidden in [
+        "query_registered(",
+        "ReadyQueryProbe",
+        "OwnedForeignComptimeProgram",
+        "ComptimeEngine",
+        "SemanticConstEvaluator",
+        "InstData",
+        "InstRef",
+    ] {
+        assert!(
+            !root_foreign_impl.contains(forbidden),
+            "root foreign delegation gained policy or walker authority: {forbidden}"
+        );
+    }
     assert!(
         !database.contains("struct SemanticComptimeAuthority"),
         "the ephemeral durable semantic authority must stay deleted"
@@ -4026,6 +4062,27 @@ fn durable_comptime_services_are_named_authority_operations() {
         2,
         "both durable evaluator roots must construct the root authority"
     );
+    let root_constructions = database
+        .split("let mut authority = DurableComptimeRootAuthority {")
+        .skip(1)
+        .take(2)
+        .map(|source| {
+            source
+                .split("};")
+                .next()
+                .expect("bounded root authority construction")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(root_constructions.len(), 2);
+    for root in &root_constructions {
+        assert!(root.contains("foreign: DurableComptimeForeignQueryAuthority {"));
+        assert!(root.contains("context,"));
+        assert!(root.contains("semantic_nucleus: family"));
+        assert!(root.contains("declaration_body_plan_artifacts:"));
+        assert!(root.contains("&artifacts_for_semantic_nucleus"));
+    }
+    assert!(root_constructions[0].contains("configuration: &query.configuration"));
+    assert!(root_constructions[1].contains("configuration: &call.declaration.configuration"));
     let root_authority_impl = database
         .split("impl<'db> DurableComptimeRootAuthority<'db> {")
         .nth(1)

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -6885,6 +6885,7 @@ struct DurableComptimeRootAuthority<'db> {
     imports: QueryFamily<DeclarationImportQueryKey, DeclarationImportQueryValue>,
     session: crate::durable_comptime::DurableComptimeSession,
     legacy_effects: crate::durable_comptime::DurableComptimeEffects,
+    foreign: DurableComptimeForeignQueryAuthority<'db>,
 }
 
 impl<'db> DurableComptimeRootAuthority<'db> {
@@ -6902,6 +6903,20 @@ impl<'db> DurableComptimeRootAuthority<'db> {
             &crate::durable_comptime::DurableComptimeApplicationPolicy::preserve(),
         );
         self.provider
+    }
+}
+
+impl crate::durable_comptime::DurableComptimeForeignCallAuthority
+    for DurableComptimeRootAuthority<'_>
+{
+    fn probe_comptime_call(
+        &self,
+        producer: &crate::StableDefinitionKey,
+        type_arguments: &[(Arc<str>, crate::durable_semantics::DurableType)],
+        value_arguments: &[(Arc<str>, crate::durable_semantics::DurableConstValue)],
+    ) -> Result<crate::body_query::ForeignComptimeCallLookup, QueryAbort> {
+        self.foreign
+            .probe_comptime_call(producer, type_arguments, value_arguments)
     }
 }
 
@@ -13630,6 +13645,13 @@ impl RevisionedQueryDatabase {
                                         imports: imports_for_semantic_nucleus.clone(),
                                         session,
                                         legacy_effects: Default::default(),
+                                        foreign: DurableComptimeForeignQueryAuthority {
+                                            context,
+                                            semantic_nucleus: family,
+                                            declaration_body_plan_artifacts:
+                                                &artifacts_for_semantic_nucleus,
+                                            configuration: &query.configuration,
+                                        },
                                     };
                                     authority
                                         .session
@@ -14297,6 +14319,13 @@ impl RevisionedQueryDatabase {
                                                     imports: imports_for_semantic_nucleus.clone(),
                                                     session,
                                                     legacy_effects: Default::default(),
+                                                    foreign: DurableComptimeForeignQueryAuthority {
+                                                        context,
+                                                        semantic_nucleus: family,
+                                                        declaration_body_plan_artifacts:
+                                                            &artifacts_for_semantic_nucleus,
+                                                        configuration: &call.declaration.configuration,
+                                                    },
                                                 };
                                         authority
                                             .session


### PR DESCRIPTION
Relates to RUE-1774

## Summary

- make the durable comptime root own the existing foreign query authority
- implement the foreign-call authority through thin delegation only
- pin exact context, query-family, artifact-family, and configuration wiring at both roots

## Validation

- focused compiler inventory and foreign-probe tests
- `scripts/rue unit compiler durable_` (87 passed)
- `scripts/rue quick` (31 targets, 0 failures)
- `scripts/rue premerge` (200 passed, 0 failures)