### PR TITLE
RUE-1774: centralize comptime match semantics

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -33,6 +33,71 @@ fn integer_consumers_use_one_representation_independent_kernel() {
 }
 
 #[test]
+fn comptime_match_patterns_have_one_decoder_and_a_semantic_host_boundary() {
+    let comptime = include_str!("sema/comptime.rs");
+    let production = comptime
+        .split("#[derive(Debug)]\npub struct ComptimeFrame")
+        .nth(1)
+        .expect("bounded production comptime source");
+    let (before_decoder, decoder_and_after) = production
+        .split_once("pub fn decode_comptime_match_pattern")
+        .expect("canonical production decoder");
+    let (decoder_body, after_decoder) = decoder_and_after
+        .split_once("/// An already-evaluated call argument")
+        .expect("decoder body boundary");
+    let outside_decoder = format!("{before_decoder}{after_decoder}");
+    assert!(before_decoder.contains("pub enum ComptimeMatchPattern"));
+    for variant in [
+        "RirPatternView::Wildcard",
+        "RirPatternView::Bool",
+        "RirPatternView::Int",
+        "RirPatternView::Path",
+    ] {
+        assert!(decoder_body.contains(variant), "decoder misses {variant}");
+        assert!(
+            !outside_decoder.contains(variant),
+            "raw pattern decoding escaped the canonical decoder: {variant}"
+        );
+    }
+    assert_eq!(
+        comptime
+            .matches("pub fn decode_comptime_match_pattern")
+            .count(),
+        1,
+        "AIR must have one production pattern decoder"
+    );
+
+    let host = comptime
+        .split("pub trait ComptimeHost {")
+        .nth(1)
+        .and_then(|source| source.split("/// Opaque structured continuations").next())
+        .expect("bounded ComptimeHost trait");
+    let match_hook = host
+        .split("fn match_pattern(")
+        .nth(1)
+        .and_then(|source| source.split("fn require_preview(").next())
+        .expect("bounded ComptimeHost match hook");
+    assert!(match_hook.contains("ComptimeMatchPattern<Self::Name>"));
+    assert!(!match_hook.contains("ProgramKey"));
+    assert!(!match_hook.contains("RirPatternView"));
+
+    let engine_match = comptime
+        .rsplit("InstData::Match { scrutinee, arms } => {")
+        .next()
+        .and_then(|source| source.split("InstData::AnonStructType {").next())
+        .expect("bounded canonical match dispatch");
+    let decode = engine_match
+        .find("self.decode_match_pattern")
+        .expect("engine decodes reached patterns");
+    let host_match = engine_match
+        .find("self.host.match_pattern")
+        .expect("engine offers semantic patterns to host");
+    assert!(decode < host_match, "decode must precede the host hook");
+    assert!(engine_match.contains("for (pattern, body) in arms.iter()"));
+    assert!(!engine_match.contains("RirPatternView::"));
+}
+
+#[test]
 fn comptime_generic_contract_has_no_local_lexical_or_call_payloads() {
     let comptime = include_str!("sema/comptime.rs");
     let ordinary = include_str!("sema/comptime_eval.rs");

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -112,6 +112,7 @@ pub use sema::{
     SemanticProducedAnonymousNominalShape, SourceParamAbi, analyze_provider_anonymous_body,
     analyze_provider_ordinary_body, analyze_provider_specialized_body,
 };
+pub use sema::{ComptimeMatchPattern, decode_comptime_match_pattern};
 pub use semantic_body::{
     SEMANTIC_BODY_INST_KINDS, SemanticAnonymousBodyExport, SemanticBody, SemanticBodyAnchor,
     SemanticBodyCallArg, SemanticBodyCandidate, SemanticBodyCandidateInstallWork,

--- a/crates/rue-air/src/sema/comptime.rs
+++ b/crates/rue-air/src/sema/comptime.rs
@@ -567,6 +567,10 @@ mod value_domain_tests {
         static TYPE_INTRINSIC_FAILURE: Cell<bool> = const { Cell::new(false) };
         static TYPE_INTRINSIC_ABORT: Cell<bool> = const { Cell::new(false) };
         static TYPE_INTRINSIC_NAME: RefCell<Option<(u32, &'static str)>> = const { RefCell::new(None) };
+        static MATCH_PATTERN_MATCHES: Cell<bool> = const { Cell::new(false) };
+        static MATCH_PATTERN_EVENTS: RefCell<Vec<ComptimeMatchPattern<FakeName>>> =
+            const { RefCell::new(Vec::new()) };
+        static MATCH_SYMBOL_CALLS: Cell<usize> = const { Cell::new(0) };
     }
 
     #[test]
@@ -575,6 +579,139 @@ mod value_domain_tests {
         assert!(source.contains("pub(crate) fn evaluate_entered_frame("));
         let public_signature = ["pub", " fn evaluate_entered_frame("].concat();
         assert!(!source.contains(&public_signature));
+    }
+
+    #[test]
+    fn semantic_pattern_decoder_uses_the_supplied_program_name_authority() {
+        let mut editor = RirEditor::new();
+        let unit = editor.add_inst(Inst {
+            data: InstData::UnitConst,
+            span: Span::new(0, 1),
+        });
+        let interner = lasso::ThreadedRodeo::new();
+        let type_name = interner.get_or_intern("Os");
+        let variant = interner.get_or_intern("Macos");
+        let matched = editor
+            .add_match(
+                unit,
+                &[(
+                    rue_rir::RirPattern::Path {
+                        module: None,
+                        ctor_head: None,
+                        type_name,
+                        variant,
+                        bindings: Vec::new(),
+                        span: Span::new(0, 1),
+                    },
+                    unit,
+                )],
+                Span::new(0, 1),
+            )
+            .unwrap();
+        let rir = editor.finish();
+        let InstData::Match { arms, .. } = &rir.get(matched).data else {
+            panic!("expected match instruction");
+        };
+        let (pattern, _) = rir.match_arms(arms).iter().next().unwrap();
+        let first = decode_comptime_match_pattern(&pattern, |symbol| {
+            format!("program-1-{}", symbol.issuing_interner_ordinal())
+        });
+        let second = decode_comptime_match_pattern(&pattern, |symbol| {
+            format!("program-2-{}", symbol.issuing_interner_ordinal())
+        });
+        assert_ne!(first, second);
+        assert!(matches!(
+            first,
+            ComptimeMatchPattern::Path {
+                module_qualified: false,
+                ctor_qualified: false,
+                binding_count: 0,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn engine_decodes_match_patterns_lazily_per_active_program() {
+        let interner = lasso::ThreadedRodeo::new();
+        let type_name = interner.get_or_intern("Os");
+        let variant = interner.get_or_intern("Macos");
+        let later_type = interner.get_or_intern("Arch");
+        let later_variant = interner.get_or_intern("X86_64");
+        let make_program = || {
+            let mut editor = RirEditor::new();
+            let unit = editor.add_inst(Inst {
+                data: InstData::UnitConst,
+                span: Span::new(0, 1),
+            });
+            let root = editor
+                .add_match(
+                    unit,
+                    &[
+                        (
+                            rue_rir::RirPattern::Path {
+                                module: None,
+                                ctor_head: None,
+                                type_name,
+                                variant,
+                                bindings: Vec::new(),
+                                span: Span::new(0, 1),
+                            },
+                            unit,
+                        ),
+                        (
+                            rue_rir::RirPattern::Path {
+                                module: None,
+                                ctor_head: None,
+                                type_name: later_type,
+                                variant: later_variant,
+                                bindings: vec![type_name],
+                                span: Span::new(0, 1),
+                            },
+                            unit,
+                        ),
+                    ],
+                    Span::new(0, 1),
+                )
+                .unwrap();
+            (editor.finish(), root)
+        };
+        let (program0, root0) = make_program();
+        let (program1, root1) = make_program();
+        MATCH_PATTERN_MATCHES.with(|matches| matches.set(true));
+        MATCH_PATTERN_EVENTS.with(|events| events.borrow_mut().clear());
+        MATCH_SYMBOL_CALLS.with(|calls| calls.set(0));
+        let mut host = FakeHost {
+            programs: vec![program0, program1],
+            type_symbol: SymbolHandle::new(interner.get_or_intern("T")),
+            constant: None,
+            dependencies: Vec::new(),
+            call_plans: AHashMap::new(),
+            recursive: None,
+            enter_count: 0,
+            finish_outcome: FakeFinishOutcome::Identity,
+            finished: Vec::new(),
+            float_evaluations: Cell::new(0),
+        };
+        let mut env = ComptimeEnv::<FakeValue, FakeType, FakeName, FakeFile, FakeIdentity>::new();
+        let mut engine = ComptimeEngine::new(&mut host);
+        assert!(matches!(
+            engine.evaluate(ComptimeFrame::expression(0, root0), &mut env),
+            ComptimeOutcome::Known(FakeValue::Unit)
+        ));
+        assert!(matches!(
+            engine.evaluate(ComptimeFrame::expression(1, root1), &mut env),
+            ComptimeOutcome::Known(FakeValue::Unit)
+        ));
+        let events = MATCH_PATTERN_EVENTS.with(|events| events.borrow().clone());
+        assert_eq!(
+            events.len(),
+            2,
+            "the later arm must not be decoded or offered"
+        );
+        assert_ne!(events[0], events[1], "active program must own symbol names");
+        assert_eq!(MATCH_SYMBOL_CALLS.with(Cell::get), 4);
+        MATCH_PATTERN_MATCHES.with(|matches| matches.set(false));
     }
 
     #[derive(Clone, Debug, PartialEq)]
@@ -812,6 +949,9 @@ mod value_domain_tests {
             &self.programs[*program]
         }
         fn name_from_symbol(&self, program: &Self::ProgramKey, symbol: SymbolHandle) -> Self::Name {
+            if MATCH_PATTERN_MATCHES.with(Cell::get) {
+                MATCH_SYMBOL_CALLS.with(|calls| calls.set(calls.get() + 1));
+            }
             FakeName {
                 ordinal: symbol.issuing_interner_ordinal() as u32 + (*program as u32) * 1000,
             }
@@ -886,11 +1026,14 @@ mod value_domain_tests {
         }
         fn match_pattern(
             &self,
-            _program: &Self::ProgramKey,
-            _pattern: &rue_rir::RirPatternView<'_>,
+            pattern: &ComptimeMatchPattern<Self::Name>,
             _value: &Self::Value,
         ) -> Option<bool> {
-            None
+            if !MATCH_PATTERN_MATCHES.with(Cell::get) {
+                return None;
+            }
+            MATCH_PATTERN_EVENTS.with(|events| events.borrow_mut().push(pattern.clone()));
+            Some(true)
         }
         fn require_preview(
             &self,
@@ -4677,6 +4820,57 @@ pub struct ComptimeTrap {
 
 pub type ComptimeArgMode = (rue_rir::RirArgMode, Span);
 
+/// A match pattern decoded by the canonical AIR engine into semantic facts.
+/// The compact RIR representation, including symbol handles and instruction
+/// references used by qualified paths, never crosses the host boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ComptimeMatchPattern<N> {
+    Wildcard,
+    Bool(bool),
+    Integer(i128),
+    Path {
+        module_qualified: bool,
+        ctor_qualified: bool,
+        type_name: N,
+        variant: N,
+        binding_count: usize,
+    },
+}
+
+/// Decode one compact RIR pattern into semantic facts.  Callers supply the
+/// owning-program symbol mapping; the pattern itself is never exposed beyond
+/// this canonical decoder.
+pub fn decode_comptime_match_pattern<N>(
+    pattern: &rue_rir::RirPatternView<'_>,
+    mut name_from_symbol: impl FnMut(SymbolHandle) -> N,
+) -> ComptimeMatchPattern<N> {
+    match pattern {
+        rue_rir::RirPatternView::Wildcard(_) => ComptimeMatchPattern::Wildcard,
+        rue_rir::RirPatternView::Bool(value, _) => ComptimeMatchPattern::Bool(*value),
+        rue_rir::RirPatternView::Int {
+            value, negative, ..
+        } => ComptimeMatchPattern::Integer(if *negative {
+            -(*value as i128)
+        } else {
+            *value as i128
+        }),
+        rue_rir::RirPatternView::Path {
+            module,
+            ctor_head,
+            type_name,
+            variant,
+            bindings,
+            ..
+        } => ComptimeMatchPattern::Path {
+            module_qualified: module.is_some(),
+            ctor_qualified: ctor_head.is_some(),
+            type_name: name_from_symbol((*type_name).into()),
+            variant: name_from_symbol((*variant).into()),
+            binding_count: bindings.len(),
+        },
+    }
+}
+
 /// An already-evaluated call argument together with the engine-derived fact
 /// that its source node was an immediate `UnitConst`. The source instruction
 /// and owning program remain engine-private; hosts receive only this semantic
@@ -4803,8 +4997,7 @@ pub trait ComptimeHost {
     ) -> ComptimeHostResult<ComptimeNamedValueResolution<Self::Value>, Self::Failure>;
     fn match_pattern(
         &self,
-        program: &Self::ProgramKey,
-        pattern: &rue_rir::RirPatternView<'_>,
+        pattern: &ComptimeMatchPattern<Self::Name>,
         value: &Self::Value,
     ) -> Option<bool>;
     fn require_preview(
@@ -5307,6 +5500,16 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
             #[cfg(test)]
             provenance_classifications: 0,
         }
+    }
+
+    fn decode_match_pattern(
+        &self,
+        program: &H::ProgramKey,
+        pattern: &rue_rir::RirPatternView<'_>,
+    ) -> ComptimeMatchPattern<H::Name> {
+        decode_comptime_match_pattern(pattern, |symbol| {
+            self.host.name_from_symbol(program, symbol)
+        })
     }
 
     #[cfg(test)]
@@ -6693,10 +6896,8 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                 let scrut = outcome_value!(self.eval(scrutinee, env));
                 let arms = self.program_rir().match_arms(arms).to_vec();
                 for (pattern, body) in arms.iter() {
-                    match self
-                        .host
-                        .match_pattern(&self.program_key(), pattern, &scrut)
-                    {
+                    let semantic_pattern = self.decode_match_pattern(&self.program_key(), pattern);
+                    match self.host.match_pattern(&semantic_pattern, &scrut) {
                         Some(true) => return self.eval(*body, env),
                         Some(false) => continue,
                         // Undecidable pattern (e.g. an enum-variant `Path`

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -58,8 +58,8 @@ use super::comptime::{
     ComptimeAnonymousKind, ComptimeArgMode, ComptimeCallAdmission, ComptimeCallArgument,
     ComptimeCallPreparation, ComptimeEngine, ComptimeEnv as GenericComptimeEnv, ComptimeFile,
     ComptimeFrame, ComptimeHost, ComptimeHostError, ComptimeHostResult, ComptimeIdentity,
-    ComptimeMethodDescriptor, ComptimeName, ComptimeNamedValueResolution, ComptimeOutcome,
-    ComptimeStructuredTypeResolution, ComptimeTrap, ComptimeType,
+    ComptimeMatchPattern, ComptimeMethodDescriptor, ComptimeName, ComptimeNamedValueResolution,
+    ComptimeOutcome, ComptimeStructuredTypeResolution, ComptimeTrap, ComptimeType,
 };
 use super::context::{AnalysisContext, ConstValue};
 use super::info::FunctionCallInfo;
@@ -269,28 +269,20 @@ impl<'a>
 ///   `Path` pattern, or a scrutinee whose kind the pattern can't compare
 ///   against), so the caller treats the whole `match` as non-evaluable.
 pub(crate) fn const_pattern_matches(
-    pattern: &rue_rir::RirPatternView<'_>,
+    pattern: &ComptimeMatchPattern<impl ComptimeName>,
     scrut: ConstValue,
 ) -> Option<bool> {
     match pattern {
-        rue_rir::RirPatternView::Wildcard(_) => Some(true),
-        rue_rir::RirPatternView::Bool(b, _) => match scrut {
+        ComptimeMatchPattern::Wildcard => Some(true),
+        ComptimeMatchPattern::Bool(b) => match scrut {
             ConstValue::Bool(sb) => Some(sb == *b),
             _ => None,
         },
-        rue_rir::RirPatternView::Int {
-            value, negative, ..
-        } => match scrut {
-            ConstValue::Integer(n) => {
-                let pv = *value as i128;
-                let pv = if *negative { -pv } else { pv };
-                Some(n == pv)
-            }
+        ComptimeMatchPattern::Integer(pattern) => match scrut {
+            ConstValue::Integer(n) => Some(n == *pattern),
             _ => None,
         },
-        // Enum-variant patterns aren't representable as a `ConstValue` (there
-        // is no comptime enum-value form), so they can't be decided here.
-        rue_rir::RirPatternView::Path { .. } => None,
+        ComptimeMatchPattern::Path { .. } => None,
     }
 }
 
@@ -1939,8 +1931,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeHost for OrdinaryBodyEngine<'h, H>
     }
     fn match_pattern(
         &self,
-        _program: &Self::ProgramKey,
-        pattern: &rue_rir::RirPatternView<'_>,
+        pattern: &ComptimeMatchPattern<Spur>,
         value: &ConstValue,
     ) -> Option<bool> {
         const_pattern_matches(pattern, value.clone())
@@ -2359,6 +2350,42 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeHost for OrdinaryBodyEngine<'h, H>
 #[cfg(test)]
 mod binding_tests {
     use super::*;
+
+    #[test]
+    fn ordinary_pattern_policy_keeps_unknown_paths_undecidable() {
+        let interner = lasso::ThreadedRodeo::<lasso::Spur>::new();
+        let type_name = interner.get_or_intern("Os");
+        let variant = interner.get_or_intern("Macos");
+        let target = ComptimeMatchPattern::Path {
+            module_qualified: false,
+            ctor_qualified: false,
+            type_name,
+            variant,
+            binding_count: 0,
+        };
+        assert_eq!(
+            const_pattern_matches(
+                &ComptimeMatchPattern::<lasso::Spur>::Wildcard,
+                ConstValue::Unit
+            ),
+            Some(true)
+        );
+        assert_eq!(
+            const_pattern_matches(
+                &ComptimeMatchPattern::<lasso::Spur>::Integer(-3),
+                ConstValue::Integer(-3)
+            ),
+            Some(true)
+        );
+        assert_eq!(
+            const_pattern_matches(
+                &ComptimeMatchPattern::<lasso::Spur>::Bool(true),
+                ConstValue::Integer(1)
+            ),
+            None
+        );
+        assert_eq!(const_pattern_matches(&target, ConstValue::Unit), None);
+    }
 
     #[test]
     fn ordinary_binding_stores_invalid_shape_then_rejects_only_at_finish() {

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -71,6 +71,7 @@ pub use comptime::{
     ComptimeStructuredTypeResolution, ComptimeStructuredTypeSuspension, ComptimeTrap, ComptimeType,
     ComptimeTypeIntrinsic, ComptimeValue, MAX_COMPTIME_CALL_DEPTH,
 };
+pub use comptime::{ComptimeMatchPattern, decode_comptime_match_pattern};
 pub use context::ConstValue;
 pub use declaration_index::RirDeclarationIndexWork;
 pub(crate) use fact_mode::StructuredTypeSyntax;

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -4872,6 +4872,42 @@ fn durable_comptime_services_are_named_authority_operations() {
 }
 
 #[test]
+fn match_patterns_have_one_air_decoder_and_one_durable_kernel() {
+    let database = include_str!("revisioned_query_database.rs");
+    let evaluator_match = database
+        .split("E::Match { scrutinee, arms } => {")
+        .nth(1)
+        .and_then(|source| source.split("E::Comptime { expr }").next())
+        .expect("bounded durable evaluator match arm");
+    assert!(evaluator_match.contains("decode_comptime_match_pattern"));
+    assert!(evaluator_match.contains("self.symbol(&symbol.spur())"));
+    assert!(evaluator_match.contains("durable_match_pattern_matches"));
+    assert!(!evaluator_match.contains("RirPatternView::"));
+    assert_eq!(
+        evaluator_match
+            .matches("decode_comptime_match_pattern")
+            .count(),
+        1,
+        "legacy evaluator must have one AIR decoder call"
+    );
+
+    let durable = include_str!("durable_comptime.rs");
+    let kernel = durable
+        .split("pub(crate) fn durable_match_pattern_matches(")
+        .nth(1)
+        .and_then(|source| source.split("\n}\n\n/// The canonical pure target").next())
+        .expect("durable match kernel");
+    assert!(kernel.contains("ComptimeMatchPattern::Path"));
+    assert!(kernel.contains("binding_count: 0"));
+    assert_eq!(
+        durable
+            .matches("pub(crate) fn durable_match_pattern_matches(")
+            .count(),
+        1
+    );
+}
+
+#[test]
 fn import_resolution_remains_discovery_owned() {
     let production = PRODUCTION_MODULES
         .iter()

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -11,7 +11,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use ahash::AHashMap;
-use rue_air::{ComptimeFile, ComptimeIdentity, ComptimeName, ComptimeType, ComptimeValue};
+use rue_air::{
+    ComptimeFile, ComptimeIdentity, ComptimeMatchPattern, ComptimeName, ComptimeType, ComptimeValue,
+};
 use rue_query::QueryAbort;
 
 use crate::ModuleId;
@@ -2433,6 +2435,41 @@ pub(crate) struct TargetEnumValue {
     pub(crate) variant: &'static str,
 }
 
+/// Match semantics shared by the durable evaluator and its future AIR host.
+/// Durable values deliberately remain narrower than the language's runtime
+/// enum algebra: only an exact, unqualified, binding-free target descriptor
+/// path is decidable here.
+pub(crate) fn durable_match_pattern_matches(
+    pattern: &ComptimeMatchPattern<Arc<str>>,
+    value: &EvaluatedSemanticConst,
+) -> bool {
+    match pattern {
+        ComptimeMatchPattern::Wildcard => true,
+        ComptimeMatchPattern::Integer(pattern) => matches!(
+            value,
+            EvaluatedSemanticConst::Value(value)
+                if matches!(value.value, DurableConstValue::Integer(actual) if actual == *pattern)
+        ),
+        ComptimeMatchPattern::Bool(pattern) => matches!(
+            value,
+            EvaluatedSemanticConst::Value(value)
+                if matches!(value.value, DurableConstValue::Bool(actual) if actual == *pattern)
+        ),
+        ComptimeMatchPattern::Path {
+            module_qualified: false,
+            ctor_qualified: false,
+            type_name,
+            variant,
+            binding_count: 0,
+        } => matches!(
+            value,
+            EvaluatedSemanticConst::TargetEnum(target)
+                if type_name.as_ref() == target.type_name && variant.as_ref() == target.variant
+        ),
+        ComptimeMatchPattern::Path { .. } => false,
+    }
+}
+
 /// The canonical pure target-descriptor kernel used by durable semantic
 /// authorities.  It receives only decomposed target facts, so tests and
 /// future query adapters can cover data models not currently exposed by a
@@ -2943,6 +2980,63 @@ mod tests {
             EvaluatedSemanticConst::integer_typed(-12, Some(DurableComptimeType(ty.clone())));
         assert_eq!(original.clone(), original);
         assert_eq!(original.as_integer_type(), Some(DurableComptimeType(ty)));
+    }
+
+    #[test]
+    fn durable_match_kernel_preserves_scalar_and_target_pattern_policy() {
+        let integer = value(DurableConstValue::Integer(-7), Some(DurableType::I16));
+        let boolean = value(DurableConstValue::Bool(true), Some(DurableType::Bool));
+        let target = EvaluatedSemanticConst::TargetEnum(TargetEnumValue {
+            type_name: "Os",
+            variant: "Macos",
+        });
+        let path = |module_qualified, ctor_qualified, type_name, variant, binding_count| {
+            ComptimeMatchPattern::Path {
+                module_qualified,
+                ctor_qualified,
+                type_name: Arc::from(type_name),
+                variant: Arc::from(variant),
+                binding_count,
+            }
+        };
+
+        assert!(durable_match_pattern_matches(
+            &ComptimeMatchPattern::Wildcard,
+            &EvaluatedSemanticConst::Module(ModuleId::from_logical_path("m").unwrap()),
+        ));
+        assert!(durable_match_pattern_matches(
+            &ComptimeMatchPattern::Integer(-7),
+            &integer,
+        ));
+        assert!(!durable_match_pattern_matches(
+            &ComptimeMatchPattern::Integer(7),
+            &integer,
+        ));
+        assert!(durable_match_pattern_matches(
+            &ComptimeMatchPattern::Bool(true),
+            &boolean,
+        ));
+        assert!(!durable_match_pattern_matches(
+            &ComptimeMatchPattern::Bool(false),
+            &integer,
+        ));
+        assert!(!durable_match_pattern_matches(
+            &ComptimeMatchPattern::Integer(-7),
+            &boolean,
+        ));
+        assert!(durable_match_pattern_matches(
+            &path(false, false, "Os", "Macos", 0),
+            &target,
+        ));
+        for pattern in [
+            path(false, false, "Os", "Linux", 0),
+            path(false, false, "Arch", "Macos", 0),
+            path(true, false, "Os", "Macos", 0),
+            path(false, true, "Os", "Macos", 0),
+            path(false, false, "Os", "Macos", 1),
+        ] {
+            assert!(!durable_match_pattern_matches(&pattern, &target));
+        }
     }
 
     #[test]

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -8399,51 +8399,14 @@ impl SemanticConstEvaluator<'_, '_> {
             E::Match { scrutinee, arms } => {
                 let evaluated = self.eval(*scrutinee)?;
                 for (pattern, body) in self.rir.match_arms(arms).iter() {
-                    let matches = match (&pattern, &evaluated) {
-                        (rue_rir::RirPatternView::Wildcard(_), _) => true,
-                        (
-                            rue_rir::RirPatternView::Int {
-                                value: pattern,
-                                negative: false,
-                                ..
-                            },
-                            EvaluatedSemanticConst::Value(value),
-                        ) => {
-                            matches!(&value.value, V::Integer(value) if *value == *pattern as i128)
-                        }
-                        (
-                            rue_rir::RirPatternView::Int {
-                                value: pattern,
-                                negative: true,
-                                ..
-                            },
-                            EvaluatedSemanticConst::Value(value),
-                        ) => {
-                            matches!(&value.value, V::Integer(value) if *value == -(*pattern as i128))
-                        }
-                        (
-                            rue_rir::RirPatternView::Bool(pattern, _),
-                            EvaluatedSemanticConst::Value(value),
-                        ) => {
-                            matches!(&value.value, V::Bool(value) if *value == *pattern)
-                        }
-                        (
-                            rue_rir::RirPatternView::Path {
-                                module: None,
-                                ctor_head: None,
-                                type_name,
-                                variant,
-                                bindings,
-                                ..
-                            },
-                            EvaluatedSemanticConst::TargetEnum(target),
-                        ) if bindings.is_empty() => {
-                            semantic_candidate_spelling(self.symbols, type_name) == target.type_name
-                                && semantic_candidate_spelling(self.symbols, variant)
-                                    == target.variant
-                        }
-                        _ => false,
-                    };
+                    let semantic_pattern =
+                        rue_air::decode_comptime_match_pattern(&pattern, |symbol| {
+                            self.symbol(&symbol.spur())
+                        });
+                    let matches = crate::durable_comptime::durable_match_pattern_matches(
+                        &semantic_pattern,
+                        &evaluated,
+                    );
                     if matches {
                         return self.eval(body);
                     }


### PR DESCRIPTION
Relates to RUE-1774

This staged interpreter-unification slice moves match-pattern decoding behind one AIR-owned semantic boundary and routes durable declaration evaluation through one pure durable policy kernel.

- adds ComptimeMatchPattern and lazily decodes only reached arms against the active program
- preserves ordinary Some/None semantics and durable false/match semantics exactly
- removes compiler-side raw RIR pattern matching from SemanticConstEvaluator
- pins one AIR decoder, the semantic-only host hook, owning symbol mapping, and one durable kernel with inventory tests

No evaluator root cutover or language feature expansion is included.

Validation:
- scripts/rue fmt
- scripts/rue premerge (200 passed, 0 failed)
- adversarial architectural review: SHIP