### PR TITLE
RUE-1774: key comptime diagnostic sites

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -98,6 +98,68 @@ fn comptime_match_patterns_have_one_decoder_and_a_semantic_host_boundary() {
 }
 
 #[test]
+fn diagnostic_hooks_are_keyed_by_the_engine_program() {
+    let comptime = include_str!("sema/comptime.rs");
+    let host = comptime
+        .split("pub trait ComptimeHost {")
+        .nth(1)
+        .and_then(|source| source.split("/// Opaque structured continuations").next())
+        .expect("bounded ComptimeHost trait");
+    for hook in [
+        "fn require_preview(",
+        "fn depth_exceeded(",
+        "fn literal_out_of_range(",
+        "fn float_not_implemented(",
+        "fn cannot_negate(",
+        "fn unsupported_anon_method_type_param(",
+        "fn non_function_anon_method(",
+        "fn resolve_named_array_length(",
+        "fn check_require_droppable(",
+        "fn check_trivially_droppable(",
+        "fn resolve_comptime_type_intrinsic(",
+        "fn integer_operation_type(",
+        "fn unary_integer_type(",
+        "fn compare_comptime_values(",
+        "fn reject_non_type_array_repeat(",
+        "fn finish_arith(",
+    ] {
+        let body = host
+            .split(hook)
+            .nth(1)
+            .and_then(|source| source.split("\n    fn ").next())
+            .unwrap_or_else(|| panic!("missing diagnostic hook {hook}"));
+        assert!(
+            body.contains("ComptimeDiagnosticSite<Self::ProgramKey>"),
+            "diagnostic hook is not producer-keyed: {hook}"
+        );
+        assert!(!body.contains("span: Span"), "raw span leaked into {hook}");
+    }
+    let site = comptime
+        .split("pub struct ComptimeDiagnosticSite<P>")
+        .nth(1)
+        .and_then(|source| source.split("\n}\n\nimpl<P> ComptimeDiagnosticSite").next())
+        .expect("diagnostic site fields");
+    assert!(site.contains("program: P"));
+    assert!(site.contains("span: Span"));
+    assert!(!site.contains("pub program"));
+    assert!(!site.contains("pub span"));
+
+    let run_frame = comptime
+        .split("fn run_frame(")
+        .nth(1)
+        .and_then(|source| source.split("fn diagnostic_site(").next())
+        .expect("bounded frame runner");
+    let depth = run_frame
+        .find("depth_exceeded(")
+        .expect("depth diagnostic call");
+    let rejected = run_frame[..depth].rfind("frame.program.clone()");
+    assert!(
+        rejected.is_some(),
+        "depth site must use rejected frame program"
+    );
+}
+
+#[test]
 fn comptime_generic_contract_has_no_local_lexical_or_call_payloads() {
     let comptime = include_str!("sema/comptime.rs");
     let ordinary = include_str!("sema/comptime_eval.rs");
@@ -390,7 +452,7 @@ fn comptime_generic_contract_has_no_local_lexical_or_call_payloads() {
             .map(|offset| start + hook.len() + offset)
             .unwrap_or(host_contract.len());
         let signature = &host_contract[start..end];
-        for forbidden in ["ProgramKey", "ComptimeEnv", "InstRef"] {
+        for forbidden in ["ComptimeEnv", "InstRef"] {
             assert!(
                 !signature.contains(forbidden),
                 "{hook} leaked evaluator authority: {forbidden}"

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -112,7 +112,7 @@ pub use sema::{
     SemanticProducedAnonymousNominalShape, SourceParamAbi, analyze_provider_anonymous_body,
     analyze_provider_ordinary_body, analyze_provider_specialized_body,
 };
-pub use sema::{ComptimeMatchPattern, decode_comptime_match_pattern};
+pub use sema::{ComptimeDiagnosticSite, ComptimeMatchPattern, decode_comptime_match_pattern};
 pub use semantic_body::{
     SEMANTIC_BODY_INST_KINDS, SemanticAnonymousBodyExport, SemanticBody, SemanticBodyAnchor,
     SemanticBodyCallArg, SemanticBodyCandidate, SemanticBodyCandidateInstallWork,

--- a/crates/rue-air/src/sema/comptime.rs
+++ b/crates/rue-air/src/sema/comptime.rs
@@ -403,6 +403,34 @@ pub struct ComptimeSite<P> {
     span: Span,
 }
 
+/// The exact owning program and source range for an engine-created diagnostic.
+/// Unlike `ComptimeSite`, this carries no semantic occurrence classification:
+/// terminal hooks need only the active program and the span supplied by the
+/// engine.
+#[derive(Debug, Clone)]
+pub struct ComptimeDiagnosticSite<P> {
+    program: P,
+    span: Span,
+}
+
+impl<P> ComptimeDiagnosticSite<P> {
+    /// Constructs the producer-keyed site for the active engine frame.
+    ///
+    /// Kept private so hosts cannot manufacture a site for an unrelated
+    /// program authority.
+    fn new(program: P, span: Span) -> Self {
+        Self { program, span }
+    }
+
+    pub fn program(&self) -> &P {
+        &self.program
+    }
+
+    pub fn span(&self) -> Span {
+        self.span
+    }
+}
+
 impl<P: Clone> ComptimeSite<P> {
     fn new(program: P, kind: ComptimeSiteKind, occurrence: u32, span: Span) -> Self {
         Self {
@@ -571,6 +599,8 @@ mod value_domain_tests {
         static MATCH_PATTERN_EVENTS: RefCell<Vec<ComptimeMatchPattern<FakeName>>> =
             const { RefCell::new(Vec::new()) };
         static MATCH_SYMBOL_CALLS: Cell<usize> = const { Cell::new(0) };
+        static DIAGNOSTIC_SITES: RefCell<Vec<(usize, u32, u32)>> =
+            const { RefCell::new(Vec::new()) };
     }
 
     #[test]
@@ -1039,47 +1069,64 @@ mod value_domain_tests {
             &self,
             _feature: rue_error::PreviewFeature,
             _what: &str,
-            _span: Span,
+            _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
         ) -> ComptimeHostResult<(), Self::Failure> {
             Ok(())
         }
-        fn depth_exceeded(&self, _name: &Self::Name, _depth: usize, _span: Span) -> Self::Failure {
+        fn depth_exceeded(
+            &self,
+            _name: &Self::Name,
+            _depth: usize,
+            site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+        ) -> Self::Failure {
+            DIAGNOSTIC_SITES.with(|sites| {
+                sites
+                    .borrow_mut()
+                    .push((*site.program(), site.span().start, site.span().end))
+            });
             FAKE_FAILURE
         }
         fn literal_out_of_range(
             &self,
             _value: u64,
             _ty: &Self::Type,
-            _span: Span,
+            _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
         ) -> Self::Failure {
             FAKE_FAILURE
         }
-        fn float_not_implemented(&self, _span: Span) -> Self::Failure {
+        fn float_not_implemented(
+            &self,
+            _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+        ) -> Self::Failure {
             self.float_evaluations.set(self.float_evaluations.get() + 1);
             FAKE_FAILURE
         }
-        fn cannot_negate(&self, _ty: &Self::Type, _span: Span) -> Self::Failure {
-            FAKE_FAILURE
-        }
-        fn comptime_panic(&self, _reason: String, _span: Span) -> Self::Failure {
+        fn cannot_negate(
+            &self,
+            _ty: &Self::Type,
+            _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+        ) -> Self::Failure {
             FAKE_FAILURE
         }
         fn unsupported_anon_method_type_param(
             &self,
-            _method_span: Span,
             _method_name: &str,
+            _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
         ) -> Self::Failure {
             METHOD_FAILURES.with(|failures| failures.borrow_mut().push("own_type"));
             FakeFailure::OwnComptimeTypeParameter
         }
-        fn non_function_anon_method(&self, _method_span: Span) -> Self::Failure {
+        fn non_function_anon_method(
+            &self,
+            _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+        ) -> Self::Failure {
             METHOD_FAILURES.with(|failures| failures.borrow_mut().push("non_function"));
             FakeFailure::NonFunctionMethod
         }
         fn resolve_named_array_length(
             &mut self,
             _name: &Self::Name,
-            _span: Span,
+            _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
             _values: Option<&AHashMap<Self::Name, Self::Value>>,
         ) -> ComptimeHostResult<u64, Self::Failure> {
             Ok(0)
@@ -1144,14 +1191,14 @@ mod value_domain_tests {
         fn check_require_droppable(
             &mut self,
             _ty: Self::Type,
-            _span: Span,
+            _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
         ) -> ComptimeHostResult<(), Self::Failure> {
             Ok(())
         }
         fn check_trivially_droppable(
             &mut self,
             _ty: Self::Type,
-            _span: Span,
+            _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
         ) -> ComptimeHostResult<(), Self::Failure> {
             Ok(())
         }
@@ -1168,7 +1215,7 @@ mod value_domain_tests {
             resolved_type: Option<&Self::Type>,
             lhs: &Self::Value,
             rhs: &Self::Value,
-            _span: Span,
+            _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
         ) -> ComptimeHostResult<Option<Self::Type>, Self::Failure> {
             INTEGER_HINTS.with(|hints| hints.borrow_mut().push(resolved_type.copied()));
             if let (Some(lhs), Some(rhs)) = (lhs.as_integer_type(), rhs.as_integer_type()) {
@@ -1186,8 +1233,13 @@ mod value_domain_tests {
             result: CheckedIntegerResult,
             _ty: Option<Self::Type>,
             _op: &str,
-            _span: Span,
+            site: &ComptimeDiagnosticSite<Self::ProgramKey>,
         ) -> ComptimeHostResult<Option<Self::Value>, Self::Failure> {
+            DIAGNOSTIC_SITES.with(|sites| {
+                sites
+                    .borrow_mut()
+                    .push((*site.program(), site.span().start, site.span().end))
+            });
             if matches!(self.finish_outcome, FakeFinishOutcome::AbortFromArithmetic) {
                 return Err(ComptimeHostError::Abort(FAKE_FAILURE));
             }
@@ -1206,7 +1258,7 @@ mod value_domain_tests {
             &mut self,
             intrinsic: ComptimeTypeIntrinsic,
             ty: Self::Type,
-            _span: Span,
+            _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
         ) -> ComptimeHostResult<Option<Self::Value>, Self::Failure> {
             TYPE_INTRINSIC_EVENTS.with(|events| events.borrow_mut().push((intrinsic, ty)));
             if TYPE_INTRINSIC_ABORT.with(Cell::get) {
@@ -1627,7 +1679,7 @@ mod value_domain_tests {
         fn reject_non_type_array_repeat(
             &mut self,
             _value: Self::Value,
-            _span: Span,
+            _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
         ) -> ComptimeOutcome<Self::Value, Self::Failure> {
             self.dependencies
                 .push((FakeFile { index: 0xFFFF_FFFA }, FakeName { ordinal: 0 }));
@@ -1643,7 +1695,7 @@ mod value_domain_tests {
             lhs: &Self::Value,
             rhs: &Self::Value,
             equal: bool,
-            _span: Span,
+            _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
         ) -> ComptimeOutcome<Self::Value, Self::Failure> {
             let (Some(lhs), Some(rhs)) = (lhs.as_type(), rhs.as_type()) else {
                 return ComptimeOutcome::RuntimeDependent;
@@ -3962,6 +4014,82 @@ mod value_domain_tests {
     }
 
     #[test]
+    fn nested_child_and_parent_diagnostics_use_the_active_program_in_one_evaluation() {
+        let interner = lasso::ThreadedRodeo::new();
+        let symbol = interner.get_or_intern("diagnostic_child");
+        let symbol_handle = SymbolHandle::new(symbol);
+        let base = symbol_handle.issuing_interner_ordinal() as u32;
+
+        let mut root = RirEditor::new();
+        let call = root.add_call(symbol, &[], Span::new(1, 2)).unwrap();
+        let root_rhs = root.add_inst(Inst {
+            data: InstData::IntConst(2),
+            span: Span::new(2, 3),
+        });
+        let root_add = root.add_inst(Inst {
+            data: InstData::Add {
+                lhs: call,
+                rhs: root_rhs,
+            },
+            span: Span::new(3, 4),
+        });
+
+        let mut child = RirEditor::new();
+        let child_lhs = child.add_inst(Inst {
+            data: InstData::IntConst(4),
+            span: Span::new(10, 11),
+        });
+        let child_rhs = child.add_inst(Inst {
+            data: InstData::IntConst(5),
+            span: Span::new(11, 12),
+        });
+        let child_add = child.add_inst(Inst {
+            data: InstData::Add {
+                lhs: child_lhs,
+                rhs: child_rhs,
+            },
+            span: Span::new(12, 13),
+        });
+        let mut call_plans = AHashMap::new();
+        call_plans.insert(
+            base,
+            FakePreparedCall::Enter {
+                program: 1,
+                body: child_add,
+                expected: None,
+                name_bindings: AHashMap::new(),
+            },
+        );
+        let mut host = FakeHost {
+            programs: vec![root.finish(), child.finish()],
+            type_symbol: symbol_handle,
+            constant: None,
+            dependencies: Vec::new(),
+            call_plans,
+            recursive: None,
+            enter_count: 0,
+            finish_outcome: FakeFinishOutcome::Identity,
+            finished: Vec::new(),
+            float_evaluations: Cell::new(0),
+        };
+        DIAGNOSTIC_SITES.with(|sites| sites.borrow_mut().clear());
+        let mut env = ComptimeEnv::<FakeValue, FakeType, FakeName, FakeFile, FakeIdentity>::new();
+        assert!(matches!(
+            ComptimeEngine::new(&mut host)
+                .evaluate(ComptimeFrame::expression(0, root_add), &mut env),
+            ComptimeOutcome::Known(FakeValue::Integer(11))
+        ));
+        DIAGNOSTIC_SITES.with(|sites| {
+            let programs = sites
+                .borrow()
+                .iter()
+                .map(|(program, _, _)| *program)
+                .collect::<Vec<_>>();
+            assert_eq!(programs, vec![1, 0]);
+        });
+    }
+
+    #[test]
     fn entered_frames_use_the_real_48_frame_budget_and_memoized_bypasses_it() {
         let mut editor = rue_rir::RirEditor::new();
         let interner = lasso::ThreadedRodeo::new();
@@ -4014,6 +4142,7 @@ mod value_domain_tests {
         let mut engine = ComptimeEngine::new(&mut host);
         let mut env = ComptimeEnv::<FakeValue, FakeType, FakeName, FakeFile, FakeIdentity>::new();
         TICKET_EVENTS.with(|events| events.borrow_mut().clear());
+        DIAGNOSTIC_SITES.with(|sites| sites.borrow_mut().clear());
         assert!(matches!(
             engine.evaluate(ComptimeFrame::expression(0, root_call), &mut env),
             ComptimeOutcome::HostFailure(FAKE_FAILURE)
@@ -4021,6 +4150,13 @@ mod value_domain_tests {
         assert_eq!(host.enter_count, MAX_COMPTIME_CALL_DEPTH + 1);
         TICKET_EVENTS.with(|events| {
             assert_eq!(events.borrow().len(), MAX_COMPTIME_CALL_DEPTH * 2);
+        });
+        DIAGNOSTIC_SITES.with(|sites| {
+            assert_eq!(
+                sites.borrow().as_slice(),
+                &[(1, 0, 0)],
+                "depth rejection uses the rejected child program"
+            );
         });
 
         let mut editor = rue_rir::RirEditor::new();
@@ -5004,23 +5140,42 @@ pub trait ComptimeHost {
         &self,
         feature: rue_error::PreviewFeature,
         what: &str,
-        span: Span,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> ComptimeHostResult<(), Self::Failure>;
-    fn depth_exceeded(&self, name: &Self::Name, depth: usize, span: Span) -> Self::Failure;
-    fn literal_out_of_range(&self, value: u64, ty: &Self::Type, span: Span) -> Self::Failure;
-    fn float_not_implemented(&self, span: Span) -> Self::Failure;
-    fn cannot_negate(&self, ty: &Self::Type, span: Span) -> Self::Failure;
-    fn comptime_panic(&self, reason: String, span: Span) -> Self::Failure;
+    fn depth_exceeded(
+        &self,
+        name: &Self::Name,
+        depth: usize,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> Self::Failure;
+    fn literal_out_of_range(
+        &self,
+        value: u64,
+        ty: &Self::Type,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> Self::Failure;
+    fn float_not_implemented(
+        &self,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> Self::Failure;
+    fn cannot_negate(
+        &self,
+        ty: &Self::Type,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> Self::Failure;
     fn unsupported_anon_method_type_param(
         &self,
-        method_span: Span,
         method_name: &str,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> Self::Failure;
-    fn non_function_anon_method(&self, method_span: Span) -> Self::Failure;
+    fn non_function_anon_method(
+        &self,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> Self::Failure;
     fn resolve_named_array_length(
         &mut self,
         name: &Self::Name,
-        span: Span,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
         values: Option<&AHashMap<Self::Name, Self::Value>>,
     ) -> ComptimeHostResult<u64, Self::Failure>;
     fn rir_type_named_symbol(
@@ -5063,12 +5218,12 @@ pub trait ComptimeHost {
     fn check_require_droppable(
         &mut self,
         ty: Self::Type,
-        span: Span,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> ComptimeHostResult<(), Self::Failure>;
     fn check_trivially_droppable(
         &mut self,
         ty: Self::Type,
-        span: Span,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> ComptimeHostResult<(), Self::Failure>;
     fn type_name(&self, ty: &Self::Type) -> String;
     fn type_is_unsigned(&self, ty: &Self::Type) -> bool;
@@ -5081,15 +5236,15 @@ pub trait ComptimeHost {
         &mut self,
         intrinsic: ComptimeTypeIntrinsic,
         ty: Self::Type,
-        span: Span,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> ComptimeHostResult<Option<Self::Value>, Self::Failure> {
         match intrinsic {
             ComptimeTypeIntrinsic::RequireDroppable => {
-                self.check_require_droppable(ty, span)?;
+                self.check_require_droppable(ty, site)?;
                 Ok(Some(Self::Value::unit()))
             }
             ComptimeTypeIntrinsic::RequireTriviallyDroppable => {
-                self.check_trivially_droppable(ty, span)?;
+                self.check_trivially_droppable(ty, site)?;
                 Ok(Some(Self::Value::unit()))
             }
             ComptimeTypeIntrinsic::IntegerBound(bound) => {
@@ -5126,7 +5281,7 @@ pub trait ComptimeHost {
         resolved_type: Option<&Self::Type>,
         lhs: &Self::Value,
         rhs: &Self::Value,
-        _span: Span,
+        _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> ComptimeHostResult<Option<Self::Type>, Self::Failure> {
         Ok(resolved_type
             .cloned()
@@ -5141,7 +5296,7 @@ pub trait ComptimeHost {
         &self,
         resolved_type: Option<&Self::Type>,
         operand: &Self::Value,
-        _span: Span,
+        _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> ComptimeHostResult<Option<Self::Type>, Self::Failure> {
         Ok(resolved_type.cloned().or_else(|| operand.as_integer_type()))
     }
@@ -5154,7 +5309,7 @@ pub trait ComptimeHost {
         _lhs: &Self::Value,
         _rhs: &Self::Value,
         _equal: bool,
-        _span: Span,
+        _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> ComptimeOutcome<Self::Value, Self::Failure> {
         ComptimeOutcome::RuntimeDependent
     }
@@ -5163,7 +5318,7 @@ pub trait ComptimeHost {
         result: CheckedIntegerResult,
         ty: Option<Self::Type>,
         op: &str,
-        span: Span,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> ComptimeHostResult<Option<Self::Value>, Self::Failure>;
     fn resolve_named_type_value(
         &mut self,
@@ -5441,7 +5596,7 @@ pub trait ComptimeHost {
     fn reject_non_type_array_repeat(
         &mut self,
         _value: Self::Value,
-        _span: Span,
+        _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> ComptimeOutcome<Self::Value, Self::Failure> {
         ComptimeOutcome::RuntimeDependent
     }
@@ -5627,9 +5782,8 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                 ..
             } = instruction_data
             else {
-                return ComptimeOutcome::HostFailure(
-                    self.host.non_function_anon_method(method_span),
-                );
+                let site = ComptimeDiagnosticSite::new(program.clone(), method_span);
+                return ComptimeOutcome::HostFailure(self.host.non_function_anon_method(&site));
             };
             let method_name = self.host.name_from_symbol(program, name.into());
             let parameter_data = self.host.program_rir(program).params(&params).to_vec();
@@ -5647,9 +5801,10 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                         .rir_type_named_symbol(program, parameter.ty)
                         .is_some_and(|name| self.host.display_name(&name) == "type")
             }) {
+                let site = ComptimeDiagnosticSite::new(program.clone(), method_span);
                 return ComptimeOutcome::HostFailure(self.host.unsupported_anon_method_type_param(
-                    method_span,
                     &self.host.display_name(&method_name),
+                    &site,
                 ));
             }
             let mut parameters = Vec::with_capacity(parameter_data.len());
@@ -5761,6 +5916,10 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
             .expect("comptime evaluation requires an active frame")
             .program
             .clone()
+    }
+
+    fn diagnostic_site(&self, span: Span) -> ComptimeDiagnosticSite<H::ProgramKey> {
+        ComptimeDiagnosticSite::new(self.program_key(), span)
     }
 
     fn semantic_site(
@@ -6025,10 +6184,11 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
             .filter(|frame| frame.name.is_some())
             .count();
         if frame.name.is_some() && entered_depth >= MAX_COMPTIME_CALL_DEPTH {
+            let site = ComptimeDiagnosticSite::new(frame.program.clone(), frame.function_span);
             return ComptimeOutcome::HostFailure(self.host.depth_exceeded(
                 frame.name.as_ref().expect("named frame"),
                 MAX_COMPTIME_CALL_DEPTH,
-                frame.function_span,
+                &site,
             ));
         }
         if let Some(name) = frame.name.clone() {
@@ -6235,11 +6395,12 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                     .filter(|ty| self.host.type_integer_semantics(ty).is_some())
                     .cloned()
             });
+        let site = self.diagnostic_site(span);
         ComptimeOutcome::Known(host_value!(self.host.integer_operation_type(
             hint.as_ref(),
             lhs,
             rhs,
-            span
+            &site,
         )))
     }
 
@@ -6259,10 +6420,11 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                     .filter(|ty| self.host.type_integer_semantics(ty).is_some())
                     .cloned()
             });
+        let site = self.diagnostic_site(span);
         ComptimeOutcome::Known(host_value!(self.host.unary_integer_type(
             hint.as_ref(),
             operand,
-            span
+            &site,
         )))
     }
 
@@ -6273,7 +6435,8 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
         op: &str,
         span: Span,
     ) -> ComptimeOutcome<H::Value, H::Failure> {
-        let Some(value) = host_value!(self.host.finish_arith(result, ty, op, span)) else {
+        let site = self.diagnostic_site(span);
+        let Some(value) = host_value!(self.host.finish_arith(result, ty, op, &site)) else {
             return ComptimeOutcome::RuntimeDependent;
         };
         ComptimeOutcome::Known(value)
@@ -6412,9 +6575,11 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                         .type_integer_semantics(ty)
                         .is_some_and(|integer| integer.fits_i128(v))
                     {
-                        return ComptimeOutcome::HostFailure(
-                            self.host.literal_out_of_range(*value, ty, span),
-                        );
+                        return ComptimeOutcome::HostFailure(self.host.literal_out_of_range(
+                            *value,
+                            ty,
+                            &self.diagnostic_site(span),
+                        ));
                     }
                 }
                 ComptimeOutcome::Known(H::Value::integer_typed(v, ty))
@@ -6431,9 +6596,11 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                 host_value!(self.host.require_preview(
                     rue_error::PreviewFeature::Floats,
                     "a floating-point literal",
-                    span,
+                    &self.diagnostic_site(span),
                 ));
-                ComptimeOutcome::HostFailure(self.host.float_not_implemented(span))
+                ComptimeOutcome::HostFailure(
+                    self.host.float_not_implemented(&self.diagnostic_site(span)),
+                )
             }
 
             // String constants are intentionally routed through the host:
@@ -6459,7 +6626,9 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                         outcome_value!(self.unary_integer_type_for(env, inst_ref, &literal, span,));
                     if let Some(ref ty) = ty {
                         if self.host.type_is_unsigned(ty) {
-                            return ComptimeOutcome::HostFailure(self.host.cannot_negate(ty, span));
+                            return ComptimeOutcome::HostFailure(
+                                self.host.cannot_negate(ty, &self.diagnostic_site(span)),
+                            );
                         }
                     }
                     // The literal path uses mathematical magnitude semantics:
@@ -6482,7 +6651,7 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                             if let Some(ref ty) = ty {
                                 if self.host.type_is_unsigned(ty) {
                                     return ComptimeOutcome::HostFailure(
-                                        self.host.cannot_negate(ty, span),
+                                        self.host.cannot_negate(ty, &self.diagnostic_site(span)),
                                     );
                                 }
                             }
@@ -6659,7 +6828,10 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                             (_, _, Some(lhs), Some(rhs)) => {
                                 ComptimeOutcome::Known(H::Value::boolean(lhs == rhs))
                             }
-                            _ => self.host.compare_comptime_values(&lhs, &rhs, true, span),
+                            _ => {
+                                let site = self.diagnostic_site(span);
+                                self.host.compare_comptime_values(&lhs, &rhs, true, &site)
+                            }
                         }
                     }
                     other => other,
@@ -6697,7 +6869,10 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                             (_, _, Some(lhs), Some(rhs)) => {
                                 ComptimeOutcome::Known(H::Value::boolean(lhs != rhs))
                             }
-                            _ => self.host.compare_comptime_values(&lhs, &rhs, false, span),
+                            _ => {
+                                let site = self.diagnostic_site(span);
+                                self.host.compare_comptime_values(&lhs, &rhs, false, &site)
+                            }
                         }
                     }
                     other => other,
@@ -7082,15 +7257,17 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                 let (value, count) = (*value, count.clone());
                 let value = outcome_value!(self.eval(value, env));
                 let Some(elem_ty) = value.as_type() else {
-                    return self.host.reject_non_type_array_repeat(value, span);
+                    let site = self.diagnostic_site(span);
+                    return self.host.reject_non_type_array_repeat(value, &site);
                 };
                 let len = match count {
                     RepeatCount::Literal(n) => n,
                     RepeatCount::Named(sym) => {
                         let name = self.name_from_rir(sym.into());
+                        let site = self.diagnostic_site(span);
                         host_value!(self.host.resolve_named_array_length(
                             &name,
-                            span,
+                            &site,
                             Some(&env.value_subst),
                         ))
                     }
@@ -7287,7 +7464,7 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                 match host_value!(self.host.resolve_comptime_type_intrinsic(
                     intrinsic,
                     intrinsic_ty,
-                    span,
+                    &self.diagnostic_site(span),
                 )) {
                     Some(value) => ComptimeOutcome::Known(value),
                     None => ComptimeOutcome::RuntimeDependent,

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -56,10 +56,11 @@ use rue_span::{FileId, Span};
 
 use super::comptime::{
     ComptimeAnonymousKind, ComptimeArgMode, ComptimeCallAdmission, ComptimeCallArgument,
-    ComptimeCallPreparation, ComptimeEngine, ComptimeEnv as GenericComptimeEnv, ComptimeFile,
-    ComptimeFrame, ComptimeHost, ComptimeHostError, ComptimeHostResult, ComptimeIdentity,
-    ComptimeMatchPattern, ComptimeMethodDescriptor, ComptimeName, ComptimeNamedValueResolution,
-    ComptimeOutcome, ComptimeStructuredTypeResolution, ComptimeTrap, ComptimeType,
+    ComptimeCallPreparation, ComptimeDiagnosticSite, ComptimeEngine,
+    ComptimeEnv as GenericComptimeEnv, ComptimeFile, ComptimeFrame, ComptimeHost,
+    ComptimeHostError, ComptimeHostResult, ComptimeIdentity, ComptimeMatchPattern,
+    ComptimeMethodDescriptor, ComptimeName, ComptimeNamedValueResolution, ComptimeOutcome,
+    ComptimeStructuredTypeResolution, ComptimeTrap, ComptimeType,
 };
 use super::context::{AnalysisContext, ConstValue};
 use super::info::FunctionCallInfo;
@@ -1940,11 +1941,16 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeHost for OrdinaryBodyEngine<'h, H>
         &self,
         feature: rue_error::PreviewFeature,
         what: &str,
-        span: Span,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> ComptimeHostResult<(), Self::Failure> {
-        OrdinaryBodyEngine::require_preview(self, feature, what, span).map_err(Into::into)
+        OrdinaryBodyEngine::require_preview(self, feature, what, site.span()).map_err(Into::into)
     }
-    fn depth_exceeded(&self, name: &Spur, depth: usize, span: Span) -> Self::Failure {
+    fn depth_exceeded(
+        &self,
+        name: &Spur,
+        depth: usize,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> Self::Failure {
         CompileError::new(
             ErrorKind::ComptimeEvaluationFailed {
                 reason: format!(
@@ -1956,31 +1962,40 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeHost for OrdinaryBodyEngine<'h, H>
                     depth
                 ),
             },
-            span,
+            site.span(),
         )
     }
-    fn literal_out_of_range(&self, value: u64, ty: &Type, span: Span) -> Self::Failure {
+    fn literal_out_of_range(
+        &self,
+        value: u64,
+        ty: &Type,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> Self::Failure {
         CompileError::new(
             ErrorKind::LiteralOutOfRange {
                 value,
                 ty: self.type_name(ty),
             },
-            span,
+            site.span(),
         )
     }
-    fn float_not_implemented(&self, span: Span) -> Self::Failure {
-        CompileError::new(ErrorKind::FloatNotYetImplemented, span)
+    fn float_not_implemented(
+        &self,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> Self::Failure {
+        CompileError::new(ErrorKind::FloatNotYetImplemented, site.span())
     }
-    fn cannot_negate(&self, ty: &Type, span: Span) -> Self::Failure {
-        CompileError::new(ErrorKind::CannotNegate(self.type_name(ty)), span)
-    }
-    fn comptime_panic(&self, reason: String, span: Span) -> Self::Failure {
-        comptime_panic_err(reason, span)
+    fn cannot_negate(
+        &self,
+        ty: &Type,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> Self::Failure {
+        CompileError::new(ErrorKind::CannotNegate(self.type_name(ty)), site.span())
     }
     fn unsupported_anon_method_type_param(
         &self,
-        method_span: Span,
         method_name: &str,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> Self::Failure {
         CompileError::new(
             ErrorKind::ComptimeEvaluationFailed {
@@ -1993,25 +2008,28 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeHost for OrdinaryBodyEngine<'h, H>
                     method_name
                 ),
             },
-            method_span,
+            site.span(),
         )
     }
-    fn non_function_anon_method(&self, method_span: Span) -> Self::Failure {
+    fn non_function_anon_method(
+        &self,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> Self::Failure {
         CompileError::new(
             ErrorKind::ComptimeEvaluationFailed {
                 reason: "anonymous type carries a non-function method instruction".to_owned(),
             },
-            method_span,
+            site.span(),
         )
     }
     fn resolve_named_array_length(
         &mut self,
         name: &Spur,
-        span: Span,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
         values: Option<&AHashMap<Spur, ConstValue>>,
     ) -> ComptimeHostResult<u64, Self::Failure> {
         let name = self.body_interner().resolve(name).to_owned();
-        OrdinaryBodyEngine::resolve_array_length(self, &ArrayLen::Named(name), span, values)
+        OrdinaryBodyEngine::resolve_array_length(self, &ArrayLen::Named(name), site.span(), values)
             .map_err(Into::into)
     }
     fn rir_type_named_symbol(
@@ -2126,16 +2144,16 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeHost for OrdinaryBodyEngine<'h, H>
     fn check_require_droppable(
         &mut self,
         ty: Type,
-        span: Span,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> ComptimeHostResult<(), Self::Failure> {
-        OrdinaryBodyEngine::check_require_droppable(self, ty, span).map_err(Into::into)
+        OrdinaryBodyEngine::check_require_droppable(self, ty, site.span()).map_err(Into::into)
     }
     fn check_trivially_droppable(
         &mut self,
         ty: Type,
-        span: Span,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> ComptimeHostResult<(), Self::Failure> {
-        OrdinaryBodyEngine::check_trivially_droppable(self, ty, span).map_err(Into::into)
+        OrdinaryBodyEngine::check_trivially_droppable(self, ty, site.span()).map_err(Into::into)
     }
     fn const_expr_type(
         &self,
@@ -2159,9 +2177,9 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeHost for OrdinaryBodyEngine<'h, H>
         result: CheckedIntegerResult,
         ty: Option<Type>,
         op: &str,
-        span: Span,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> ComptimeHostResult<Option<ConstValue>, Self::Failure> {
-        OrdinaryBodyEngine::finish_arith(self, result, ty, op, span).map_err(Into::into)
+        OrdinaryBodyEngine::finish_arith(self, result, ty, op, site.span()).map_err(Into::into)
     }
     fn resolve_named_type_value(
         &mut self,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -71,7 +71,7 @@ pub use comptime::{
     ComptimeStructuredTypeResolution, ComptimeStructuredTypeSuspension, ComptimeTrap, ComptimeType,
     ComptimeTypeIntrinsic, ComptimeValue, MAX_COMPTIME_CALL_DEPTH,
 };
-pub use comptime::{ComptimeMatchPattern, decode_comptime_match_pattern};
+pub use comptime::{ComptimeDiagnosticSite, ComptimeMatchPattern, decode_comptime_match_pattern};
 pub use context::ConstValue;
 pub use declaration_index::RirDeclarationIndexWork;
 pub(crate) use fact_mode::StructuredTypeSyntax;

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -10,10 +10,11 @@
 mod comptime_public_contract_tests {
     use rue_air::{
         ComptimeAnonymousKind, ComptimeArgMode, ComptimeCallAdmission, ComptimeCallArgument,
-        ComptimeCallKey, ComptimeCallMemoLookup, ComptimeCompletedCallMemo, ComptimeEngine,
-        ComptimeEnv, ComptimeField, ComptimeFile, ComptimeFrame, ComptimeHost, ComptimeHostResult,
-        ComptimeIdentity, ComptimeMemoizedOutcome, ComptimeName, ComptimeOutcome, ComptimeProgram,
-        ComptimeProgramKey, ComptimeProgramRegistry, ComptimeType, ComptimeValue,
+        ComptimeCallKey, ComptimeCallMemoLookup, ComptimeCompletedCallMemo, ComptimeDiagnosticSite,
+        ComptimeEngine, ComptimeEnv, ComptimeField, ComptimeFile, ComptimeFrame, ComptimeHost,
+        ComptimeHostResult, ComptimeIdentity, ComptimeMemoizedOutcome, ComptimeName,
+        ComptimeOutcome, ComptimeProgram, ComptimeProgramKey, ComptimeProgramRegistry,
+        ComptimeType, ComptimeValue,
     };
     use rue_rir::{Inst, InstData, InstRef, RirEditor, RirValidationContext, ValidatedRir};
     use rue_span::Span;
@@ -103,6 +104,12 @@ mod comptime_public_contract_tests {
     fn generic_call_argument_contract<V>(argument: &ComptimeCallArgument<V>) {
         let _value = argument.value();
         let _direct_unit_literal = argument.is_direct_unit_literal();
+    }
+
+    #[allow(dead_code)]
+    fn generic_diagnostic_site_contract<P>(site: &ComptimeDiagnosticSite<P>) {
+        let _program = site.program();
+        let _span = site.span();
     }
 
     #[test]
@@ -4904,6 +4911,42 @@ fn match_patterns_have_one_air_decoder_and_one_durable_kernel() {
             .matches("pub(crate) fn durable_match_pattern_matches(")
             .count(),
         1
+    );
+}
+
+#[test]
+fn durable_diagnostic_sites_use_only_registered_program_provenance() {
+    let durable = include_str!("durable_comptime.rs");
+    let method = durable
+        .split("pub(crate) fn diagnostic_site(")
+        .nth(1)
+        .and_then(|source| {
+            source
+                .split("    /// Atomically admit an already-prepared")
+                .next()
+        })
+        .expect("bounded durable diagnostic-site method");
+    assert!(method.contains("self.programs.get(key)"));
+    assert!(method.contains("declaration_candidate_for_stable_key"));
+    assert!(method.contains("DurableComptimeDiagnosticSite::new"));
+    for forbidden in [
+        "self.lifecycle",
+        "self.next_call",
+        "effects",
+        "query_registered",
+        "InstData",
+        "ComptimeEngine",
+        "SemanticConstEvaluator",
+    ] {
+        assert!(
+            !method.contains(forbidden),
+            "diagnostic-site lookup acquired unrelated authority: {forbidden}"
+        );
+    }
+    assert_eq!(
+        durable.matches("pub(crate) fn diagnostic_site(").count(),
+        1,
+        "the session must expose one immutable diagnostic-site lookup"
     );
 }
 

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -875,6 +875,16 @@ pub(crate) enum DurableComptimeProgramFinalizationError {
     AuthorityMismatch,
 }
 
+/// Failure to turn a registered program identity and source range into a
+/// durable diagnostic site. Unknown keys never fall back to the session's
+/// parent provenance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)] // consumed by the staged durable AIR host
+pub(crate) enum DurableComptimeDiagnosticSiteError {
+    UnknownProgram,
+    UnknownDeclaration,
+}
+
 /// Failure before a foreign AIR frame is handed to the engine.  Admission is
 /// intentionally separate from lifecycle activation: the engine still owns
 /// the depth check, `enter`, and cleanup after it receives this frame.
@@ -974,6 +984,26 @@ impl DurableComptimeSession {
         key: &crate::body_query::DurableComptimeProgramKey,
     ) -> Option<&crate::body_query::DurableComptimeProgram> {
         self.programs.get(key)
+    }
+
+    /// Resolve an engine-created diagnostic range against the exact
+    /// registered program key, without observing effects or query state.
+    #[allow(dead_code)] // consumed by the staged durable AIR host
+    pub(crate) fn diagnostic_site(
+        &self,
+        key: &crate::body_query::DurableComptimeProgramKey,
+        span: rue_span::Span,
+    ) -> Result<DurableComptimeDiagnosticSite, DurableComptimeDiagnosticSiteError> {
+        if self.programs.get(key).is_none() {
+            return Err(DurableComptimeDiagnosticSiteError::UnknownProgram);
+        }
+        let producer = crate::revisioned_query_database::declaration_candidate_for_stable_key(
+            &key.declaration,
+        )
+        .ok_or(DurableComptimeDiagnosticSiteError::UnknownDeclaration)?;
+        Ok(DurableComptimeDiagnosticSite::new(
+            producer, span.start, span.end,
+        ))
     }
 
     /// Atomically admit an already-prepared foreign callable into the keyed
@@ -5586,7 +5616,7 @@ mod structured_type_adapter_tests {
         }
     }
 
-    fn const_program(
+    pub(super) fn const_program(
         path: &str,
         argument: &str,
     ) -> Arc<crate::body_query::OwnedComptimeProgramCore> {
@@ -5680,7 +5710,7 @@ mod structured_type_adapter_tests {
         .unwrap()
     }
 
-    fn callable_program(path: &str) -> Arc<crate::body_query::OwnedComptimeProgramCore> {
+    pub(super) fn callable_program(path: &str) -> Arc<crate::body_query::OwnedComptimeProgramCore> {
         let snapshot = crate::SourceSnapshot::single(path, "fn target() -> i32 { 1 }").unwrap();
         let module = crate::parsed_modules::parse_source_snapshot_modules(&snapshot)
             .unwrap()
@@ -5728,7 +5758,7 @@ mod structured_type_adapter_tests {
         program.core
     }
 
-    fn session() -> DurableComptimeSession {
+    pub(super) fn session() -> DurableComptimeSession {
         let module = ModuleId::from_logical_path("structured-parent.rue").unwrap();
         let producer = crate::StableDefinitionKey::from_stable_parts(
             module,
@@ -6530,5 +6560,30 @@ mod terminal_adapter_tests {
                 && mismatch.expected == "an integer type"
                 && mismatch.found == "bool"
         ));
+    }
+
+    #[test]
+    fn diagnostic_sites_are_keyed_and_reject_unknown_programs() {
+        let first =
+            super::structured_type_adapter_tests::const_program("diagnostic-first.rue", "i32");
+        let second =
+            super::structured_type_adapter_tests::const_program("diagnostic-second.rue", "i64");
+        let mut session = super::structured_type_adapter_tests::session();
+        session.register_program(&first).unwrap();
+        session.register_program(&second).unwrap();
+
+        let span = rue_span::Span::with_file(rue_span::FileId::DEFAULT, 11, 19);
+        let first_site = session.diagnostic_site(&first.plan.key, span).unwrap();
+        let second_site = session.diagnostic_site(&second.plan.key, span).unwrap();
+        assert_eq!((first_site.start, first_site.end), (11, 19));
+        assert_eq!((second_site.start, second_site.end), (11, 19));
+        assert_ne!(first_site.producer, second_site.producer);
+
+        let unknown =
+            super::structured_type_adapter_tests::callable_program("diagnostic-unknown.rue");
+        assert_eq!(
+            session.diagnostic_site(&unknown.plan.key, span),
+            Err(DurableComptimeDiagnosticSiteError::UnknownProgram)
+        );
     }
 }


### PR DESCRIPTION
## Summary

- carry the active AIR program key with every engine-created diagnostic-policy site
- preserve ordinary evaluator diagnostics by adapting through the original span
- map registered durable program keys to exact producer-relative diagnostic sites without ambient fallback
- cover nested child-to-parent restoration, rejected-depth provenance, and the complete keyed-hook inventory

## Validation

- scripts/rue fmt
- scripts/rue unit air (740 passed)
- scripts/rue unit compiler durable_ (91 passed)
- scripts/rue quick
- scripts/rue premerge (200 passed)

Relates to RUE-1774