### PR TITLE
RUE-1774: preserve comptime match terminal policy

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -75,7 +75,7 @@ fn comptime_match_patterns_have_one_decoder_and_a_semantic_host_boundary() {
     let match_hook = host
         .split("fn match_pattern(")
         .nth(1)
-        .and_then(|source| source.split("fn require_preview(").next())
+        .and_then(|source| source.split("fn match_no_selected_arm(").next())
         .expect("bounded ComptimeHost match hook");
     assert!(match_hook.contains("ComptimeMatchPattern<Self::Name>"));
     assert!(!match_hook.contains("ProgramKey"));
@@ -106,6 +106,7 @@ fn diagnostic_hooks_are_keyed_by_the_engine_program() {
         .and_then(|source| source.split("/// Opaque structured continuations").next())
         .expect("bounded ComptimeHost trait");
     for hook in [
+        "fn match_no_selected_arm(",
         "fn require_preview(",
         "fn depth_exceeded(",
         "fn literal_out_of_range(",
@@ -322,12 +323,32 @@ fn comptime_generic_contract_has_no_local_lexical_or_call_payloads() {
     assert!(contract.contains("type Failure;"));
     assert!(contract.contains("Self::CanonicalIdentity"));
     assert!(contract.contains("Self::File,"));
+    assert!(contract.contains("fn match_no_selected_arm("));
+    assert!(contract.contains("ComptimeOutcome<Self::Value, Self::Failure>"));
     assert!(production.contains("decode_anon_method_descriptors"));
     assert!(production.contains("Root expression frames are intentionally ticket-free"));
     assert!(production.contains("if frame.name.is_none()"));
     assert!(!production.contains("eval_const_expr"));
     assert!(!production.contains("ComptimeEngine::new"));
     assert!(!production.contains("reduce_external_comptime_call"));
+    let match_dispatch = production
+        .split("InstData::Match { scrutinee, arms } => {")
+        .nth(1)
+        .and_then(|source| source.split("InstData::AnonStructType {").next())
+        .expect("match dispatch");
+    assert!(match_dispatch.contains(
+        "}\n                self.host.match_no_selected_arm(&self.diagnostic_site(span))"
+    ));
+    assert!(
+        !match_dispatch
+            .contains("}\n                ComptimeOutcome::RuntimeDependent\n            }")
+    );
+    let ordinary_match = ordinary
+        .split("fn match_no_selected_arm(")
+        .nth(1)
+        .and_then(|source| source.split("\n    fn ").next())
+        .expect("ordinary match terminal hook");
+    assert!(ordinary_match.contains("ComptimeOutcome::RuntimeDependent"));
     let macro_start = production
         .find("macro_rules! host_value")
         .expect("canonical host-value funnel");

--- a/crates/rue-air/src/sema/comptime.rs
+++ b/crates/rue-air/src/sema/comptime.rs
@@ -617,6 +617,10 @@ mod value_domain_tests {
         static TYPE_INTRINSIC_ABORT: Cell<bool> = const { Cell::new(false) };
         static TYPE_INTRINSIC_NAME: RefCell<Option<(u32, &'static str)>> = const { RefCell::new(None) };
         static MATCH_PATTERN_MATCHES: Cell<bool> = const { Cell::new(false) };
+        static MATCH_PATTERN_FORCE_FALSE: Cell<bool> = const { Cell::new(false) };
+        static MATCH_NO_SELECTED_FAILURE: Cell<bool> = const { Cell::new(false) };
+        static MATCH_NO_SELECTED_SITES: RefCell<Vec<(usize, u32, u32)>> =
+            const { RefCell::new(Vec::new()) };
         static MATCH_PATTERN_EVENTS: RefCell<Vec<ComptimeMatchPattern<FakeName>>> =
             const { RefCell::new(Vec::new()) };
         static MATCH_SYMBOL_CALLS: Cell<usize> = const { Cell::new(0) };
@@ -763,6 +767,78 @@ mod value_domain_tests {
         assert_ne!(events[0], events[1], "active program must own symbol names");
         assert_eq!(MATCH_SYMBOL_CALLS.with(Cell::get), 4);
         MATCH_PATTERN_MATCHES.with(|matches| matches.set(false));
+    }
+
+    #[test]
+    fn match_without_a_selected_arm_uses_the_host_terminal_policy() {
+        let make_program = || {
+            let mut editor = RirEditor::new();
+            let scrutinee = editor.add_inst(Inst {
+                data: InstData::BoolConst(false),
+                span: Span::new(0, 1),
+            });
+            let body = editor.add_inst(Inst {
+                data: InstData::UnitConst,
+                span: Span::new(1, 2),
+            });
+            let root = editor
+                .add_match(
+                    scrutinee,
+                    &[(rue_rir::RirPattern::Bool(true, Span::new(0, 1)), body)],
+                    Span::new(0, 2),
+                )
+                .unwrap();
+            (editor.finish(), root)
+        };
+        let (program0, root0) = make_program();
+        let (program1, root1) = make_program();
+        let mut host = FakeHost {
+            programs: vec![program0, program1],
+            type_symbol: SymbolHandle::new(lasso::ThreadedRodeo::new().get_or_intern("T")),
+            constant: None,
+            dependencies: Vec::new(),
+            call_plans: AHashMap::new(),
+            recursive: None,
+            enter_count: 0,
+            finish_outcome: FakeFinishOutcome::Identity,
+            finished: Vec::new(),
+            float_evaluations: Cell::new(0),
+        };
+        let mut env = ComptimeEnv::<FakeValue, FakeType, FakeName, FakeFile, FakeIdentity>::new();
+        MATCH_PATTERN_MATCHES.with(|matches| matches.set(true));
+        MATCH_PATTERN_FORCE_FALSE.with(|force| force.set(true));
+        MATCH_NO_SELECTED_FAILURE.with(|failure| failure.set(true));
+        MATCH_NO_SELECTED_SITES.with(|sites| sites.borrow_mut().clear());
+        assert!(matches!(
+            ComptimeEngine::new(&mut host).evaluate(ComptimeFrame::expression(0, root0), &mut env),
+            ComptimeOutcome::HostFailure(FAKE_FAILURE)
+        ));
+        assert!(matches!(
+            ComptimeEngine::new(&mut host).evaluate(ComptimeFrame::expression(1, root1), &mut env),
+            ComptimeOutcome::HostFailure(FAKE_FAILURE)
+        ));
+        MATCH_NO_SELECTED_SITES.with(|sites| {
+            assert_eq!(sites.borrow().as_slice(), &[(0, 0, 2), (1, 0, 2)]);
+        });
+
+        MATCH_NO_SELECTED_FAILURE.with(|failure| failure.set(false));
+        assert!(matches!(
+            ComptimeEngine::new(&mut host).evaluate(ComptimeFrame::expression(0, root0), &mut env),
+            ComptimeOutcome::RuntimeDependent
+        ));
+
+        MATCH_NO_SELECTED_FAILURE.with(|failure| failure.set(true));
+        MATCH_NO_SELECTED_SITES.with(|sites| sites.borrow_mut().clear());
+        MATCH_PATTERN_MATCHES.with(|matches| matches.set(false));
+        assert!(matches!(
+            ComptimeEngine::new(&mut host).evaluate(ComptimeFrame::expression(0, root0), &mut env),
+            ComptimeOutcome::RuntimeDependent
+        ));
+        MATCH_NO_SELECTED_SITES.with(|sites| assert!(sites.borrow().is_empty()));
+
+        MATCH_PATTERN_FORCE_FALSE.with(|force| force.set(false));
+        MATCH_PATTERN_MATCHES.with(|matches| matches.set(false));
+        MATCH_NO_SELECTED_FAILURE.with(|failure| failure.set(false));
     }
 
     #[derive(Clone, Debug, PartialEq)]
@@ -1340,7 +1416,22 @@ mod value_domain_tests {
                 return None;
             }
             MATCH_PATTERN_EVENTS.with(|events| events.borrow_mut().push(pattern.clone()));
-            Some(true)
+            Some(!MATCH_PATTERN_FORCE_FALSE.with(Cell::get))
+        }
+        fn match_no_selected_arm(
+            &self,
+            site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+        ) -> ComptimeOutcome<Self::Value, Self::Failure> {
+            MATCH_NO_SELECTED_SITES.with(|sites| {
+                sites
+                    .borrow_mut()
+                    .push((*site.program(), site.span().start, site.span().end));
+            });
+            if MATCH_NO_SELECTED_FAILURE.with(Cell::get) {
+                ComptimeOutcome::HostFailure(FAKE_FAILURE)
+            } else {
+                ComptimeOutcome::RuntimeDependent
+            }
         }
         fn require_preview(
             &self,
@@ -5444,6 +5535,13 @@ pub trait ComptimeHost {
         pattern: &ComptimeMatchPattern<Self::Name>,
         value: &Self::Value,
     ) -> Option<bool>;
+    /// Resolve the terminal policy when every reached match arm declined.
+    /// Ordinary body evaluation remains runtime-dependent; durable hosts may
+    /// preserve a declaration-time failure through this semantic hook.
+    fn match_no_selected_arm(
+        &self,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> ComptimeOutcome<Self::Value, Self::Failure>;
     fn require_preview(
         &self,
         feature: rue_error::PreviewFeature,
@@ -7410,9 +7508,7 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                         None => return ComptimeOutcome::RuntimeDependent,
                     }
                 }
-                // No arm matched. Exhaustiveness checking should make this
-                // unreachable for a well-typed match; treat as non-evaluable.
-                ComptimeOutcome::RuntimeDependent
+                self.host.match_no_selected_arm(&self.diagnostic_site(span))
             }
 
             // Anonymous struct type: evaluate to a comptime type value,

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1936,6 +1936,12 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeHost for OrdinaryBodyEngine<'h, H>
     ) -> Option<bool> {
         const_pattern_matches(pattern, value.clone())
     }
+    fn match_no_selected_arm(
+        &self,
+        _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> ComptimeOutcome<Self::Value, Self::Failure> {
+        ComptimeOutcome::RuntimeDependent
+    }
     fn require_preview(
         &self,
         feature: rue_error::PreviewFeature,

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -4889,6 +4889,8 @@ fn match_patterns_have_one_air_decoder_and_one_durable_kernel() {
     assert!(evaluator_match.contains("decode_comptime_match_pattern"));
     assert!(evaluator_match.contains("self.symbol(&symbol.spur())"));
     assert!(evaluator_match.contains("durable_match_pattern_matches"));
+    assert!(evaluator_match.contains("comptime_match_no_selected_arm"));
+    assert!(!evaluator_match.contains("Self::failure(\"comptime match has no selected arm\")"));
     assert!(!evaluator_match.contains("RirPatternView::"));
     assert_eq!(
         evaluator_match

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -136,6 +136,13 @@ impl DurableComptimeFailure {
         ))
     }
 
+    /// The exact durable terminal used when a comptime match reaches no
+    /// selected arm. This remains a resolution failure, matching the legacy
+    /// evaluator's existing `comptime match has no selected arm` policy.
+    pub(crate) fn comptime_match_no_selected_arm() -> Self {
+        Self::resolution("comptime match has no selected arm")
+    }
+
     pub(crate) fn maximum_depth(name: &str, maximum: usize) -> Self {
         Self::comptime_failure(format!(
             "specialization of '{name}' exceeded the maximum nesting depth ({maximum}); is a comptime-recursive function missing a compile-time-known base case, or a generic function recursively instantiating itself with new types?"
@@ -6357,6 +6364,16 @@ mod terminal_adapter_tests {
             };
             assert_eq!(actual, expected);
         }
+    }
+
+    #[test]
+    fn unmatched_comptime_match_uses_the_canonical_legacy_failure() {
+        assert!(matches!(
+            DurableComptimeFailure::comptime_match_no_selected_arm(),
+            DurableComptimeFailure::Failure(value)
+                if matches!(*value, SemanticNucleusFailure::Resolution(ref message)
+                    if message.as_ref() == "comptime match has no selected arm")
+        ));
     }
 
     #[test]

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -8411,7 +8411,10 @@ impl SemanticConstEvaluator<'_, '_> {
                         return self.eval(body);
                     }
                 }
-                Self::failure("comptime match has no selected arm")
+                Err(
+                    crate::durable_comptime::DurableComptimeFailure::comptime_match_no_selected_arm(
+                    ),
+                )
             }
             E::Comptime { expr } | E::Checked { expr } => self.eval(*expr),
             E::TypeConst { .. } | E::AnonStructType { .. } | E::AnonEnumType { .. } => {


### PR DESCRIPTION
Relates to RUE-1774

Make the no-selected-arm comptime match outcome an explicit AIR host policy. Ordinary body evaluation retains RuntimeDependent, while durable evaluation retains the existing resolution failure and exact diagnostic text through one shared constructor.

The dispatch tests cover keyed diagnostic sites across programs with colliding spans and preserve the separate undecidable-pattern path.

Validation:
- scripts/rue fmt
- scripts/rue unit air
- scripts/rue unit compiler durable_
- scripts/rue quick
- scripts/rue premerge (200/200)