### PR TITLE
RUE-1774: centralize durable producer issuance

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -3199,6 +3199,109 @@ fn durable_const_integer_semantics_use_the_shared_kernel() {
 }
 
 #[test]
+fn durable_specialized_producer_issuance_has_one_ordered_kernel() {
+    let durable = include_str!("durable_comptime.rs");
+    let producer_kernel = durable
+        .split("pub(crate) fn canonical_specialized_function_producer(")
+        .nth(1)
+        .and_then(|source| {
+            source
+                .split("\n}\n\npub(crate) fn canonical_specialized_function_instance(")
+                .next()
+        })
+        .expect("durable producer issuance kernel");
+    let instance_kernel = durable
+        .split("pub(crate) fn canonical_specialized_function_instance(")
+        .nth(1)
+        .and_then(|source| {
+            source
+                .split("\n}\n\nimpl DurableComptimeCallContext")
+                .next()
+        })
+        .expect("durable specialization conversion kernel");
+    assert_eq!(
+        durable
+            .matches("pub(crate) fn canonical_specialized_function_producer(")
+            .count(),
+        1
+    );
+    for required in [
+        "type_arguments",
+        "value_arguments",
+        "canonical_specialized_function_instance",
+    ] {
+        assert!(producer_kernel.contains(required));
+    }
+    assert!(instance_kernel.contains("function_instance_from_canonical_arguments"));
+    assert!(!instance_kernel.contains("FunctionInstanceKey::Specialization"));
+    for forbidden in [
+        "InstData",
+        "ComptimeEngine",
+        "SemanticConstEvaluator",
+        "query_registered",
+        "self.effects",
+    ] {
+        assert!(!producer_kernel.contains(forbidden));
+        assert!(!instance_kernel.contains(forbidden));
+    }
+    let source = include_str!("revisioned_query_database.rs");
+    let identity = include_str!("semantic_identity.rs");
+    let identity_production = identity
+        .split("\n#[cfg(test)]\nmod tests")
+        .next()
+        .expect("semantic identity production source");
+    let identity_kernel = identity_production
+        .split("pub(crate) fn function_instance_from_canonical_arguments(")
+        .nth(1)
+        .and_then(|source| source.split("\n}\n\nfn tag(").next())
+        .expect("canonical specialization identity kernel");
+    assert_eq!(
+        identity_production
+            .matches("pub(crate) fn function_instance_from_canonical_arguments(")
+            .count(),
+        1
+    );
+    assert!(identity_kernel.contains("FunctionInstanceKey::Specialization"));
+    let call_root = source
+        .split("Key::ComptimeCall(call) => {")
+        .nth(1)
+        .and_then(|source| {
+            source
+                .split("\n                    let kind = if matches!(value, Value::Failure(_))")
+                .next()
+        })
+        .expect("legacy comptime-call root");
+    assert!(call_root.contains("canonical_specialized_function_producer"));
+    assert!(!call_root.contains("FunctionInstanceKey::Specialization"));
+    assert!(!call_root.contains("let canonical_arguments = crate::CanonicalArguments"));
+    assert!(!call_root.contains("type_instance_from_semantic("));
+    assert!(!call_root.contains("argument_value_from_semantic("));
+    let body_provider = source
+        .split("impl rue_air::DurableBodyLookupSource")
+        .nth(1)
+        .and_then(|source| source.split("impl rue_air::DurableConstSource").next())
+        .expect("body-provider comptime reduction");
+    assert!(body_provider.contains("canonical_specialized_function_instance"));
+    assert!(!body_provider.contains("let producer = crate::FunctionInstanceKey::Specialization"));
+    assert!(!body_provider.contains("type_instance_from_semantic"));
+    assert!(!body_provider.contains("argument_value_from_semantic"));
+    let context = durable
+        .split("impl DurableComptimeCallContext {")
+        .nth(1)
+        .and_then(|source| source.split("impl DurableComptimeCallTicket").next())
+        .expect("durable call context implementation");
+    assert!(context.contains("fn canonical_function_producer("));
+    assert!(!context.contains("pub(crate) fn canonical_function_producer("));
+    let ticket = durable
+        .split("impl DurableComptimeCallTicket {")
+        .nth(1)
+        .and_then(|source| source.split("\n}\n\n#[allow(dead_code)]").next())
+        .expect("durable call ticket implementation");
+    assert!(ticket.contains("pub(crate) fn canonical_function_producer("));
+    assert!(ticket.contains("self.context.canonical_function_producer("));
+}
+
+#[test]
 fn durable_comptime_services_are_named_authority_operations() {
     let facade = include_str!("durable_comptime.rs");
     let database = include_str!("revisioned_query_database.rs");
@@ -3781,7 +3884,7 @@ fn durable_comptime_services_are_named_authority_operations() {
     let context_block = facade
         .split("pub(crate) struct DurableComptimeCallContext {")
         .nth(1)
-        .and_then(|source| source.split("}\n\nimpl DurableComptimeCallContext").next())
+        .and_then(|source| source.split("}\n\n/// Failure while turning").next())
         .expect("durable call context block");
     assert!(
         !context_block.contains("pub(crate)"),

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -554,7 +554,74 @@ pub(crate) struct DurableComptimeCallContext {
     application_policy: DurableComptimeApplicationPolicy,
 }
 
+/// Failure while turning the ordered durable call arguments into a stable
+/// specialization identity.  This kernel is semantic-only: it owns no RIR,
+/// evaluator, query, or lifecycle authority.
+#[allow(dead_code)] // consumed by the root-integrated durable AIR host
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DurableComptimeProducerIssuanceError {
+    ProgramMismatch,
+    InvalidTypeArgument,
+    InvalidValueArgument,
+}
+
+pub(crate) fn canonical_specialized_function_producer(
+    base: &crate::StableDefinitionKey,
+    type_arguments: &[(Arc<str>, DurableType)],
+    value_arguments: &[(Arc<str>, DurableConstValue)],
+) -> Result<crate::StableProducerId, DurableComptimeProducerIssuanceError> {
+    let function = canonical_specialized_function_instance(base, type_arguments, value_arguments)?;
+    Ok(crate::StableProducerId::Function(rue_air::Node::new(
+        function,
+    )))
+}
+
+pub(crate) fn canonical_specialized_function_instance(
+    base: &crate::StableDefinitionKey,
+    type_arguments: &[(Arc<str>, DurableType)],
+    value_arguments: &[(Arc<str>, DurableConstValue)],
+) -> Result<crate::FunctionInstanceKey, DurableComptimeProducerIssuanceError> {
+    let types = type_arguments
+        .iter()
+        .map(|(_, value)| crate::semantic_identity::type_instance_from_semantic(value))
+        .collect::<Option<Vec<_>>>()
+        .ok_or(DurableComptimeProducerIssuanceError::InvalidTypeArgument)?
+        .into();
+    let values = value_arguments
+        .iter()
+        .map(|(_, value)| crate::semantic_identity::argument_value_from_semantic(value))
+        .collect::<Option<Vec<_>>>()
+        .ok_or(DurableComptimeProducerIssuanceError::InvalidValueArgument)?
+        .into();
+    Ok(
+        crate::semantic_identity::function_instance_from_canonical_arguments(
+            base.clone(),
+            types,
+            values,
+        ),
+    )
+}
+
 impl DurableComptimeCallContext {
+    #[allow(dead_code)] // consumed by the root-integrated durable AIR host
+    fn canonical_function_producer(
+        &self,
+        program: &crate::body_query::DurableComptimeProgramKey,
+    ) -> Result<crate::StableProducerId, DurableComptimeProducerIssuanceError> {
+        if &self.program != program
+            || self.child_producer != program.declaration
+            || self.query.declaration.declaration.module != *program.declaration.module()
+            || self.query.declaration.configuration != program.configuration
+        {
+            return Err(DurableComptimeProducerIssuanceError::ProgramMismatch);
+        }
+        canonical_specialized_function_producer(
+            &self.child_producer,
+            &self.query.type_arguments,
+            &self.query.value_arguments,
+        )
+    }
+
     #[cfg(test)]
     #[allow(dead_code)]
     pub(crate) fn from_admitted_expression(
@@ -741,6 +808,16 @@ pub(crate) struct DurableComptimeCallTicket {
     context: DurableComptimeCallContext,
     expected_parent: Option<(u64, u64)>,
     consumed: bool,
+}
+
+impl DurableComptimeCallTicket {
+    #[allow(dead_code)] // consumed by the root-integrated durable AIR host
+    pub(crate) fn canonical_function_producer(
+        &self,
+        program: &crate::body_query::DurableComptimeProgramKey,
+    ) -> Result<crate::StableProducerId, DurableComptimeProducerIssuanceError> {
+        self.context.canonical_function_producer(program)
+    }
 }
 
 #[allow(dead_code)]
@@ -4440,6 +4517,95 @@ mod effect_lifecycle_tests {
         };
         assert_eq!(program.plan, admitted.plan);
         assert!(session.lifecycle.active.is_empty());
+
+        // Producer issuance is a ticket capability, not a context helper.
+        // This uses the exact ticket returned by lifecycle admission before
+        // activation, so an unordered AIR binding map cannot participate.
+        let issued = ticket
+            .canonical_function_producer(&program.plan.key)
+            .unwrap();
+        assert_eq!(
+            issued,
+            canonical_specialized_function_producer(
+                &producer,
+                &seed.type_arguments,
+                &seed.value_arguments,
+            )
+            .unwrap()
+        );
+        let renamed = canonical_specialized_function_producer(
+            &producer,
+            &seed
+                .type_arguments
+                .iter()
+                .map(|(_, value)| (Arc::from("renamed"), value.clone()))
+                .collect::<Vec<_>>(),
+            &seed
+                .value_arguments
+                .iter()
+                .map(|(_, value)| (Arc::from("renamed"), value.clone()))
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+        assert_eq!(issued, renamed, "argument names are not identity inputs");
+        let type_reordered = canonical_specialized_function_producer(
+            &producer,
+            &seed
+                .type_arguments
+                .iter()
+                .rev()
+                .cloned()
+                .collect::<Vec<_>>(),
+            &seed.value_arguments,
+        )
+        .unwrap();
+        assert_ne!(issued, type_reordered, "type stream order affects identity");
+        let value_reordered = canonical_specialized_function_producer(
+            &producer,
+            &seed.type_arguments,
+            &seed
+                .value_arguments
+                .iter()
+                .rev()
+                .cloned()
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+        assert_ne!(
+            issued, value_reordered,
+            "value stream order affects identity"
+        );
+        let empty = canonical_specialized_function_producer(&producer, &[], &[]).unwrap();
+        assert!(matches!(
+            empty,
+            crate::StableProducerId::Function(ref function)
+                if matches!(function.as_ref(), crate::FunctionInstanceKey::Specialization { arguments, .. } if arguments.types.is_empty() && arguments.values.is_empty())
+        ));
+        let wrong_program = crate::body_query::DurableComptimeProgramKey {
+            declaration: crate::StableDefinitionKey::from_stable_parts(
+                sibling.module.clone(),
+                crate::StableDefinitionNamespace::Value,
+                crate::StableDefinitionKind::Function,
+                sibling.name.clone(),
+                None,
+            ),
+            configuration: configuration.clone(),
+        };
+        assert_eq!(
+            ticket.canonical_function_producer(&wrong_program),
+            Err(DurableComptimeProducerIssuanceError::ProgramMismatch)
+        );
+        let wrong_configuration = crate::body_query::DurableComptimeProgramKey {
+            declaration: program.plan.key.declaration.clone(),
+            configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration {
+                target: rue_target::Target::Aarch64Linux,
+                preview_features: configuration.preview_features.clone(),
+            },
+        };
+        assert_eq!(
+            ticket.canonical_function_producer(&wrong_configuration),
+            Err(DurableComptimeProducerIssuanceError::ProgramMismatch)
+        );
         session.lifecycle.enter(&ticket).unwrap();
         session
             .lifecycle

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -14226,34 +14226,12 @@ impl RevisionedQueryDatabase {
                                                 deferred_ownership: BTreeSet::new(),
                                                 ownership_properties: BTreeMap::new(),
                                             };
-                                            let canonical_arguments = crate::CanonicalArguments {
-                                                types: call
-                                                    .type_arguments
-                                                    .iter()
-                                                    .map(|(_, value)| {
-                                                        crate::semantic_identity::type_instance_from_semantic(value)
-                                                    })
-                                                    .collect::<Option<Vec<_>>>()
-                                                    .expect("durable type arguments have canonical identities")
-                                                    .into(),
-                                                values: call
-                                                    .value_arguments
-                                                    .iter()
-                                                    .map(|(_, value)| {
-                                                        crate::semantic_identity::argument_value_from_semantic(value)
-                                                    })
-                                                    .collect::<Option<Vec<_>>>()
-                                                    .expect("durable value arguments have canonical identities")
-                                                    .into(),
-                                            };
-                                            let producer = crate::StableProducerId::Function(Node::new(
-                                                crate::FunctionInstanceKey::Specialization {
-                                                    base: Node::new(crate::FunctionInstanceKey::Definition(
-                                                        producer_key.clone(),
-                                                    )),
-                                                    arguments: canonical_arguments,
-                                                },
-                                            ));
+                                            let producer = crate::durable_comptime::canonical_specialized_function_producer(
+                                                &producer_key,
+                                                &call.type_arguments,
+                                                &call.value_arguments,
+                                            )
+                                            .expect("durable type/value arguments have canonical identities");
                                             let session = crate::durable_comptime::DurableComptimeSession::new(
                                                 producer_key.clone(),
                                                 call.declaration.declaration.clone(),
@@ -22763,27 +22741,13 @@ impl rue_air::DurableBodyLookupSource<crate::StableDefinitionKey, ModuleId>
             }
         }
         if !projection.anonymous_nominals.is_empty() {
-            let Some(types) = type_arguments
-                .iter()
-                .map(|(_, value)| crate::semantic_identity::type_instance_from_semantic(value))
-                .collect::<Option<Vec<_>>>()
-            else {
-                return rue_air::DurableComptimeCallOutcome::NotReduced;
-            };
-            let Some(values) = value_arguments
-                .iter()
-                .map(|(_, value)| crate::semantic_identity::argument_value_from_semantic(value))
-                .collect::<Option<Vec<_>>>()
-            else {
-                return rue_air::DurableComptimeCallOutcome::NotReduced;
-            };
-            let arguments = crate::CanonicalArguments {
-                types: types.into(),
-                values: values.into(),
-            };
-            let producer = crate::FunctionInstanceKey::Specialization {
-                base: Node::new(crate::FunctionInstanceKey::Definition(definition.clone())),
-                arguments,
+            let producer = match crate::durable_comptime::canonical_specialized_function_instance(
+                definition,
+                type_arguments,
+                value_arguments,
+            ) {
+                Ok(producer) => producer,
+                Err(_) => return rue_air::DurableComptimeCallOutcome::NotReduced,
             };
             self.provider
                 .queries

--- a/crates/rue-compiler/src/semantic_identity.rs
+++ b/crates/rue-compiler/src/semantic_identity.rs
@@ -383,13 +383,29 @@ pub(crate) fn function_instance_from_specialization(
         .iter()
         .map(argument_value_from_semantic)
         .collect::<Option<Vec<_>>>()?;
-    Some(FunctionInstanceKey::Specialization {
-        base: Node::new(FunctionInstanceKey::Definition(value.base.clone())),
+    Some(function_instance_from_canonical_arguments(
+        value.base.clone(),
+        types,
+        values,
+    ))
+}
+
+/// Build the one canonical specialized-function identity from already
+/// canonical argument streams.  Durable callers perform semantic conversion
+/// before reaching this kernel; no caller may spell the specialization shape
+/// independently.
+pub(crate) fn function_instance_from_canonical_arguments(
+    base: StableDefinitionKey,
+    types: Vec<TypeInstanceKey>,
+    values: Vec<CanonicalArgumentValue>,
+) -> FunctionInstanceKey {
+    FunctionInstanceKey::Specialization {
+        base: Node::new(FunctionInstanceKey::Definition(base)),
         arguments: CanonicalArguments {
             types: types.into(),
             values: values.into(),
         },
-    })
+    }
 }
 
 fn tag(output: &mut String, value: u32) {


### PR DESCRIPTION
Relates to RUE-1774

Centralize durable specialized-function producer issuance from the exact ordered type/value argument streams owned by admitted call tickets. Both existing durable production consumers now use the same lower identity kernel; the body-provider path preserves `NotReduced` on conversion failure and the durable root preserves its invariant failure behavior.

This is a behavior-preserving staged prerequisite. Durable roots still use the legacy evaluator; RUE-1774 remains open for production host composition, MethodCall receiver parity, root cutover, and `SemanticConstEvaluator` deletion.

Validation:
- `scripts/rue fmt`
- `scripts/rue unit compiler durable_` (95/95)
- `scripts/rue quick`
- `scripts/rue premerge` (200/200)
- adversarial architectural review: SHIP