### PR TITLE
RUE-1774: centralize evaluated module seams

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -3436,6 +3436,96 @@ fn durable_comptime_services_are_named_authority_operations() {
             "durable facade missing {required}"
         );
     }
+    let service_impl = production_facade
+        .split(
+            "impl<A: DurableComptimeSemanticAuthority + ?Sized> DurableComptimeServices<'_, A> {",
+        )
+        .nth(1)
+        .and_then(|source| {
+            source
+                .split("impl<A: DurableComptimeForeignCallAuthority")
+                .next()
+        })
+        .expect("durable semantic services implementation");
+    let evaluated_call = service_impl
+        .split("pub(crate) fn begin_evaluated_module_call(")
+        .nth(1)
+        .and_then(|source| {
+            source
+                .split("\n    pub(crate) fn finish_comptime_call_admission(")
+                .next()
+        })
+        .expect("evaluated-module call service seam");
+    assert_eq!(
+        evaluated_call
+            .matches("self.begin_comptime_call_admission(")
+            .count(),
+        1,
+        "evaluated-module call must delegate through exactly one canonical admission"
+    );
+    for required in ["receiver_module", "method"] {
+        assert!(
+            evaluated_call.contains(required),
+            "evaluated-module call must preserve exact receiver input: {required}"
+        );
+    }
+    for forbidden in [
+        "resolve_named_value(",
+        "resolve_module_member(",
+        "begin_evaluated_module_call(",
+        "finish_comptime_call_admission(",
+    ] {
+        assert!(
+            !evaluated_call.contains(forbidden),
+            "evaluated-module call gained a second semantic operation: {forbidden}"
+        );
+    }
+    let evaluated_member = service_impl
+        .split("pub(crate) fn resolve_evaluated_module_member(")
+        .nth(1)
+        .and_then(|source| source.split("\n    pub(crate) fn resolve_import(").next())
+        .expect("evaluated-module member service seam");
+    assert_eq!(
+        evaluated_member
+            .matches("self.resolve_module_member(")
+            .count(),
+        1,
+        "evaluated-module member must delegate through exactly one canonical member lookup"
+    );
+    for required in ["receiver_module", "member"] {
+        assert!(
+            evaluated_member.contains(required),
+            "evaluated-module member must preserve exact receiver input: {required}"
+        );
+    }
+    for forbidden in [
+        "resolve_named_value(",
+        "begin_comptime_call_admission(",
+        "begin_evaluated_module_call(",
+        "resolve_evaluated_module_member(",
+        "finish_comptime_call_admission(",
+    ] {
+        assert!(
+            !evaluated_member.contains(forbidden),
+            "evaluated-module member gained a second semantic operation: {forbidden}"
+        );
+    }
+    for seam in [evaluated_call, evaluated_member] {
+        for forbidden in [
+            "InstData",
+            "InstRef",
+            "SemanticConstEvaluator",
+            "ComptimeEngine",
+            "query_registered(",
+            "candidate(",
+            "identity(",
+        ] {
+            assert!(
+                !seam.contains(forbidden),
+                "evaluated-module semantic seam gained policy or evaluator authority: {forbidden}"
+            );
+        }
+    }
     let frame_adapter = production_facade
         .split("pub(crate) fn admit_const_root(")
         .nth(1)
@@ -4656,12 +4746,22 @@ fn durable_comptime_services_are_named_authority_operations() {
         .nth(1)
         .and_then(|source| source.split("fn eval_type_literal(").next())
         .expect("durable named-call evaluator");
+    assert_eq!(
+        named_call.matches("begin_evaluated_module_call(").count(),
+        1,
+        "durable named calls must have one evaluated-module admission"
+    );
+    assert_eq!(
+        named_call.matches("begin_comptime_call_admission(").count(),
+        0,
+        "durable named calls must not bypass evaluated-module admission"
+    );
     assert!(
-        named_call.contains("begin_comptime_call_admission("),
-        "durable named calls must consume the canonical admission projection"
+        named_call.contains("begin_evaluated_module_call("),
+        "durable named calls must consume the evaluated-module admission projection"
     );
     let begin = named_call
-        .find("begin_comptime_call_admission(")
+        .find("begin_evaluated_module_call(")
         .expect("named-call begin admission");
     let observed = named_call
         .find("observe_dependency(admission_start.dependency.clone())")
@@ -4872,7 +4972,22 @@ fn durable_comptime_services_are_named_authority_operations() {
         .nth(1)
         .and_then(|source| source.split("E::StructInit").next())
         .expect("durable field-get evaluator");
-    assert_eq!(field_get.matches("resolve_module_member(").count(), 1);
+    assert_eq!(
+        field_get
+            .matches("resolve_evaluated_module_member(")
+            .count(),
+        1
+    );
+    assert_eq!(
+        field_get.matches("resolve_module_member(").count(),
+        0,
+        "durable FieldGet must not bypass evaluated-module member lookup"
+    );
+    assert_eq!(
+        field_get.matches("resolve_named_value(").count(),
+        0,
+        "durable FieldGet must not fall back to unqualified named lookup"
+    );
     let target_special = field_get
         .find("if let E::VarRef { name, .. }")
         .expect("field-get target descriptor special case");
@@ -4883,7 +4998,7 @@ fn durable_comptime_services_are_named_authority_operations() {
         .find("member access on a non-module const value")
         .expect("field-get non-module rejection");
     let service = field_get
-        .find("resolve_module_member(")
+        .find("resolve_evaluated_module_member(")
         .expect("field-get module-member service");
     let field_projection = field_get
         .find("projection.into_parts()")

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -2615,6 +2615,22 @@ impl<A: DurableComptimeSemanticAuthority + ?Sized> DurableComptimeServices<'_, A
             .begin_comptime_call_admission(accessing_source, module, name)
     }
 
+    /// Begin admission for a method whose receiver has already reduced to an
+    /// exact module value.  Keeping this named seam distinct from the
+    /// unqualified call operation makes it impossible for a future AIR host
+    /// to recover the method's module from a spelling in the caller.
+    pub(crate) fn begin_evaluated_module_call(
+        &self,
+        accessing_source: &crate::StableDefinitionKey,
+        receiver_module: &ModuleId,
+        method: &str,
+    ) -> Result<
+        DurableComptimeCallableAdmissionStart,
+        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+    > {
+        self.begin_comptime_call_admission(accessing_source, receiver_module, method)
+    }
+
     pub(crate) fn finish_comptime_call_admission(
         &self,
         start: DurableComptimeCallableAdmissionStart,
@@ -2651,6 +2667,22 @@ impl<A: DurableComptimeSemanticAuthority + ?Sized> DurableComptimeServices<'_, A
     > {
         self.authority
             .resolve_module_member(accessing_source, module, member)
+    }
+
+    /// Resolve a member from an already-evaluated module value.  This is the
+    /// durable counterpart of AIR's evaluated receiver path: it preserves the
+    /// module identity and returns the direct dependency projection exactly
+    /// once to the caller, with no unqualified fallback.
+    pub(crate) fn resolve_evaluated_module_member(
+        &self,
+        accessing_source: &crate::StableDefinitionKey,
+        receiver_module: &ModuleId,
+        member: &str,
+    ) -> Result<
+        DurableComptimeNamedValueProjection,
+        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+    > {
+        self.resolve_module_member(accessing_source, receiver_module, member)
     }
 
     pub(crate) fn resolve_import(

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -8071,7 +8071,7 @@ impl SemanticConstEvaluator<'_, '_> {
             let services =
                 crate::durable_comptime::DurableComptimeServices::new(&mut *self.authority);
             services
-                .begin_comptime_call_admission(&source, module, &name)
+                .begin_evaluated_module_call(&source, module, &name)
                 .map_err(Self::provider_error)?
         };
         self.authority
@@ -8820,7 +8820,7 @@ impl SemanticConstEvaluator<'_, '_> {
                 let services =
                     crate::durable_comptime::DurableComptimeServices::new(&mut *self.authority);
                 let projection = services
-                    .resolve_module_member(&source, &module, &name)
+                    .resolve_evaluated_module_member(&source, &module, &name)
                     .map_err(Self::provider_error)?;
                 let (value, dependency) = projection.into_parts();
                 self.authority.legacy_effects.observe_dependency(dependency);


### PR DESCRIPTION
Relates to RUE-1774.

## Summary
- add named durable services for calls and member lookups on already-evaluated module identities
- route the legacy durable evaluator through those same semantic seams
- enforce exact-one delegation and forbid unqualified/direct fallback paths in the API inventory

This is a staged prerequisite. It does not switch durable declaration roots or delete `SemanticConstEvaluator`.

## Validation
- `scripts/rue fmt`
- focused API inventory test
- `scripts/rue unit compiler durable_` (98/98)
- `scripts/rue quick` (31 targets, 0 failures)
- adversarial review: SHIP