### PR TITLE
RUE-1774: key durable import semantics by AIR site

### DIFF
--- a/crates/rue-air/src/sema/comptime.rs
+++ b/crates/rue-air/src/sema/comptime.rs
@@ -442,6 +442,25 @@ impl<P> ComptimeDiagnosticSite<P> {
 }
 
 impl<P: Clone> ComptimeSite<P> {
+    /// Constructs a semantic site from an operation kind and source-order
+    /// occurrence. The occurrence is never an instruction reference.
+    pub fn from_occurrence(
+        program: P,
+        kind: ComptimeSiteKind,
+        occurrence: u32,
+        span: Span,
+    ) -> Self {
+        Self::new(program, kind, occurrence, span)
+    }
+
+    /// Constructs an import site from its semantic source-order occurrence.
+    ///
+    /// The occurrence is an operation-order fact, not an `InstRef`; callers
+    /// must obtain it from the owning program's semantic import metadata.
+    pub fn from_import_occurrence(program: P, occurrence: u32, span: Span) -> Self {
+        Self::from_occurrence(program, ComptimeSiteKind::Import, occurrence, span)
+    }
+
     fn new(program: P, kind: ComptimeSiteKind, occurrence: u32, span: Span) -> Self {
         Self {
             program,

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -3410,6 +3410,9 @@ fn durable_comptime_services_are_named_authority_operations() {
         "DurableComptimeNamedValueProjection",
         "resolve_named_value",
         "resolve_module_member",
+        "resolve_keyed_import",
+        "import_site_for_instruction",
+        "DurableComptimeKeyedImportError",
         "resolve_target_intrinsic",
         "resolve_target_enum_variant",
         "probe_comptime_call",
@@ -3559,10 +3562,45 @@ fn durable_comptime_services_are_named_authority_operations() {
             "const frame adapter gained evaluation authority: {forbidden}"
         );
     }
-    for forbidden in ["InstData", "eval_const_expr", "ComptimeEngine", "InstRef"] {
+    for forbidden in ["InstData", "eval_const_expr", "ComptimeEngine"] {
         assert!(
             !facade.contains(forbidden),
             "durable service facade must not become an evaluator: {forbidden}"
+        );
+    }
+    let keyed_import_kernel = production_facade
+        .split("pub(crate) fn import_site_for_instruction(")
+        .nth(1)
+        .and_then(|source| {
+            source
+                .split("/// Resolve an engine-created diagnostic")
+                .next()
+        })
+        .expect("keyed import-site pairing kernel");
+    assert!(
+        keyed_import_kernel.contains("self.programs.get(key)"),
+        "keyed import adapter must obtain program metadata from the session registry"
+    );
+    for required in [
+        "occurrence.inst == instruction",
+        "occurrence.specifier.as_ref() != specifier",
+        "ComptimeSite::from_import_occurrence",
+    ] {
+        assert!(
+            keyed_import_kernel.contains(required),
+            "keyed import kernel lost exact registered-program validation: {required}"
+        );
+    }
+    for forbidden in [
+        "import_occurrences",
+        "InstData",
+        "ComptimeEngine",
+        "SemanticConstEvaluator",
+        "query_registered(",
+    ] {
+        assert!(
+            !keyed_import_kernel.contains(forbidden),
+            "keyed import kernel gained ambient/evaluator authority: {forbidden}"
         );
     }
     let body_query = include_str!("body_query.rs");
@@ -3872,7 +3910,11 @@ fn durable_comptime_services_are_named_authority_operations() {
     let registry_accessor = production_facade
         .split("pub(crate) fn registered_program(")
         .nth(1)
-        .and_then(|source| source.split("\n    fn observe_anonymous_nominal").next())
+        .and_then(|source| {
+            source
+                .split("\n    pub(crate) fn import_site_for_instruction(")
+                .next()
+        })
         .expect("keyed durable program registry accessor");
     assert!(registry_accessor.contains("self.programs.get(key)"));
     assert!(!registry_accessor.contains("ComptimeEngine"));
@@ -4486,6 +4528,10 @@ fn durable_comptime_services_are_named_authority_operations() {
             );
         }
     }
+    assert!(
+        !service_impl.contains("InstRef"),
+        "semantic service facade must accept semantic sites, not raw instruction references"
+    );
     let target_kernel = facade
         .split("pub(crate) fn resolve_target_intrinsic_facts")
         .nth(1)
@@ -4593,13 +4639,13 @@ fn durable_comptime_services_are_named_authority_operations() {
     }
     for forbidden in [
         "SemanticConstEvaluator",
+        "InstRef",
         "SEMANTIC_COMPTIME",
         "ComptimeEngine",
         "ValidatedRir",
         "program_rir",
         "child_instructions",
         "InstData",
-        "InstRef",
         ".eval(",
         "evaluate",
         "eval_const_expr",
@@ -4611,6 +4657,22 @@ fn durable_comptime_services_are_named_authority_operations() {
             "semantic authority must not become an evaluator: {forbidden}"
         );
     }
+    let keyed_import_authority = target_authority
+        .split("fn resolve_keyed_import(")
+        .nth(1)
+        .and_then(|source| source.split("fn resolve_target_intrinsic(").next())
+        .expect("root keyed import authority");
+    for required in [
+        "self.session.registered_program(program)",
+        "occurrence.occurrence == site.occurrence()",
+        "self.resolve_import(&durable_site)",
+    ] {
+        assert!(
+            keyed_import_authority.contains(required),
+            "root keyed import authority lost operation ordering: {required}"
+        );
+    }
+    assert!(!keyed_import_authority.contains("import_occurrences"));
     let keyed_type_resolver = target_authority
         .split("fn resolve_type_syntax(")
         .nth(1)
@@ -4929,7 +4991,33 @@ fn durable_comptime_services_are_named_authority_operations() {
         1,
         "durable value-fit policy must have one structured-reducer consumer"
     );
-    assert!(evaluator.contains(".resolve_import(&site)"));
+    assert!(evaluator.contains("import_site_for_instruction("));
+    assert!(evaluator.contains("&self.program"));
+    assert!(!evaluator.contains(".resolve_import(&site)"));
+    assert!(!evaluator.contains("import_occurrences"));
+    let import_eval = evaluator
+        .split("fn eval_import(")
+        .nth(1)
+        .and_then(|source| source.split("fn eval_identifier(").next())
+        .expect("durable import evaluator");
+    assert_eq!(import_eval.matches("resolve_keyed_import(").count(), 1);
+    assert!(import_eval.contains("&self.program"));
+    assert!(import_eval.contains("import_site_for_instruction"));
+    assert!(import_eval.contains("instruction"));
+    assert!(import_eval.contains("specifier"));
+    for forbidden in [
+        "import_occurrences",
+        "resolve_import(&site)",
+        "query_registered(",
+        "DeclarationImportQueryKey",
+        "ComptimeEngine",
+        "SemanticConstEvaluator",
+    ] {
+        assert!(
+            !import_eval.contains(forbidden),
+            "legacy import evaluator retained an ambient/import authority bypass: {forbidden}"
+        );
+    }
     let named_value = evaluator
         .split("fn eval_identifier(")
         .nth(1)

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -1188,6 +1188,41 @@ impl DurableComptimeSession {
         self.programs.get(key)
     }
 
+    /// Build the canonical AIR import site from one registered program.  The
+    /// raw instruction is accepted only at this legacy evaluator adapter;
+    /// lookup, occurrence, span, and program identity are paired here from
+    /// the same registry entry before a semantic site escapes.
+    pub(crate) fn import_site_for_instruction(
+        &self,
+        key: &crate::body_query::DurableComptimeProgramKey,
+        instruction: rue_rir::InstRef,
+        specifier: &str,
+    ) -> Result<
+        rue_air::ComptimeSite<crate::body_query::DurableComptimeProgramKey>,
+        DurableComptimeKeyedImportError,
+    > {
+        let Some(program) = self.programs.get(key) else {
+            return Err(DurableComptimeKeyedImportError::UnknownProgram);
+        };
+        let Some(occurrence) = program
+            .imports
+            .imports
+            .iter()
+            .find(|occurrence| occurrence.inst == instruction)
+        else {
+            return Err(DurableComptimeKeyedImportError::UnknownInstruction);
+        };
+        if occurrence.specifier.as_ref() != specifier {
+            return Err(DurableComptimeKeyedImportError::SpecifierMismatch);
+        }
+        let span = program.rir.get(instruction).span;
+        Ok(rue_air::ComptimeSite::from_import_occurrence(
+            key.clone(),
+            occurrence.occurrence,
+            span,
+        ))
+    }
+
     /// Resolve an engine-created diagnostic range against the exact
     /// registered program key, without observing effects or query state.
     #[allow(dead_code)] // consumed by the staged durable AIR host
@@ -1827,6 +1862,20 @@ pub(crate) enum DurableImportResolution {
     Resolved(ModuleId),
     Missing,
     Failure(DeclarationImportFailure),
+}
+
+/// Failure while pairing an engine import instruction with the occurrence
+/// owned by its exact registered program.  The provider/query abort variant
+/// remains separate so the evaluator cannot turn cancellation into a
+/// declaration-time diagnostic.
+#[derive(Debug)]
+pub(crate) enum DurableComptimeKeyedImportError {
+    UnknownProgram,
+    UnknownInstruction,
+    WrongSiteKind,
+    SpecifierMismatch,
+    UnknownDeclaration,
+    ProviderAbort(QueryAbort),
 }
 
 /// The identity and dependency facts established before signature admission.
@@ -2519,6 +2568,16 @@ pub(crate) trait DurableComptimeSemanticAuthority {
         site: &DurableImportSite,
     ) -> Result<DurableImportResolution, QueryAbort>;
 
+    /// Resolve an import occurrence through the exact registered program
+    /// authority. The semantic site already carries the owning program and
+    /// source-order occurrence; implementations must not consult an ambient
+    /// occurrence map.
+    fn resolve_keyed_import(
+        &self,
+        site: &rue_air::ComptimeSite<crate::body_query::DurableComptimeProgramKey>,
+        specifier: &str,
+    ) -> Result<DurableImportResolution, DurableComptimeKeyedImportError>;
+
     /// Resolve a target intrinsic from semantic name/arity facts.  The
     /// authority owns the configured target and the diagnostic policy; no RIR
     /// instruction or argument callback crosses this boundary.
@@ -2685,11 +2744,18 @@ impl<A: DurableComptimeSemanticAuthority + ?Sized> DurableComptimeServices<'_, A
         self.resolve_module_member(accessing_source, receiver_module, member)
     }
 
-    pub(crate) fn resolve_import(
+    /// Resolve an import against the registered program selected by `program`.
+    /// This is the only evaluator-facing import path; occurrence metadata and
+    /// declaration identity are paired atomically before querying imports.
+    pub(crate) fn resolve_keyed_import(
         &self,
-        site: &DurableImportSite,
-    ) -> Result<DurableImportResolution, QueryAbort> {
-        self.authority.resolve_import(site)
+        site: &rue_air::ComptimeSite<crate::body_query::DurableComptimeProgramKey>,
+        specifier: &str,
+    ) -> Result<DurableImportResolution, DurableComptimeKeyedImportError> {
+        if site.kind() != rue_air::ComptimeSiteKind::Import {
+            return Err(DurableComptimeKeyedImportError::WrongSiteKind);
+        }
+        self.authority.resolve_keyed_import(site, specifier)
     }
 
     pub(crate) fn resolve_target_intrinsic(
@@ -5886,6 +5952,7 @@ mod effect_lifecycle_tests {
 #[cfg(test)]
 mod structured_type_adapter_tests {
     use super::*;
+    use std::cell::Cell;
     use std::convert::Infallible;
 
     fn assert_frame_domains<
@@ -6518,6 +6585,295 @@ mod structured_type_adapter_tests {
             ),
             Err(DurableStructuredTypeBeginError::InvalidProgramAuthority)
         ));
+    }
+
+    #[test]
+    fn keyed_import_sites_preserve_program_local_occurrences_and_reject_mismatches() {
+        let first = const_program("first-import.rue", "i32");
+        let second = const_program("second-import.rue", "i64");
+        let mut session = session();
+        session.register_program(&first).unwrap();
+        session.register_program(&second).unwrap();
+
+        let first_registered = session.registered_program(&first.plan.key).unwrap();
+        let second_registered = session.registered_program(&second.plan.key).unwrap();
+        let first_occurrence = first_registered.imports.imports[0].inst;
+        let second_occurrence = second_registered.imports.imports[0].inst;
+        assert_eq!(first_occurrence, second_occurrence);
+
+        let first_site = session
+            .import_site_for_instruction(&first.plan.key, first_occurrence, "first-import.rue")
+            .unwrap();
+        assert_eq!(first_site.occurrence(), 0);
+        assert_eq!(first_site.kind(), rue_air::ComptimeSiteKind::Import);
+        assert_eq!(first_site.program(), &first.plan.key);
+
+        let second_site = session
+            .import_site_for_instruction(&second.plan.key, second_occurrence, "second-import.rue")
+            .unwrap();
+        assert_eq!(second_site.occurrence(), 0);
+        assert_eq!(second_site.kind(), rue_air::ComptimeSiteKind::Import);
+        assert_eq!(second_site.program(), &second.plan.key);
+        assert_ne!(first_site.program(), second_site.program());
+
+        assert!(matches!(
+            session.import_site_for_instruction(
+                &first.plan.key,
+                first_occurrence,
+                "second-import.rue",
+            ),
+            Err(DurableComptimeKeyedImportError::SpecifierMismatch)
+        ));
+        assert!(matches!(
+            session.import_site_for_instruction(
+                &first.plan.key,
+                rue_rir::InstRef::from_raw(u32::MAX),
+                "first-import.rue",
+            ),
+            Err(DurableComptimeKeyedImportError::UnknownInstruction)
+        ));
+        let mut wrong_key = first.plan.key.clone();
+        wrong_key.configuration.target = rue_target::Target::Aarch64Linux;
+        assert!(matches!(
+            session.import_site_for_instruction(&wrong_key, first_occurrence, "first-import.rue",),
+            Err(DurableComptimeKeyedImportError::UnknownProgram)
+        ));
+
+        // A caller cannot pair the first key with the second program: the
+        // second instruction is interpreted only against the first registry
+        // entry and therefore fails before any import query/effect exists.
+        assert!(matches!(
+            session.import_site_for_instruction(
+                &first.plan.key,
+                second_occurrence,
+                "second-import.rue",
+            ),
+            Err(DurableComptimeKeyedImportError::SpecifierMismatch)
+                | Err(DurableComptimeKeyedImportError::UnknownInstruction)
+        ));
+    }
+
+    enum ImportServiceMode {
+        Missing,
+        Failure(crate::declaration_candidate::DeclarationImportFailure),
+        Abort,
+    }
+
+    struct ImportServiceAuthority {
+        calls: Cell<usize>,
+        mode: ImportServiceMode,
+    }
+
+    impl DurableComptimeSemanticAuthority for ImportServiceAuthority {
+        fn check_canceled(&self) -> Result<(), QueryAbort> {
+            panic!("not part of keyed import service test")
+        }
+
+        fn resolve_type_syntax(
+            &mut self,
+            _program: &crate::body_query::DurableComptimeProgramKey,
+            _syntax: rue_rir::RirTypeSyntaxRef,
+        ) -> Result<
+            DurableType,
+            rue_air::SemanticTypeSyntaxError<
+                QueryAbort,
+                SemanticNucleusFailure,
+                crate::StableDefinitionKey,
+                Arc<str>,
+            >,
+        > {
+            panic!("not part of keyed import service test")
+        }
+
+        fn resolve_type_syntax_with_substitutions(
+            &mut self,
+            _program: &crate::body_query::DurableComptimeProgramKey,
+            _syntax: rue_rir::RirTypeSyntaxRef,
+            _type_substitutions: &[(Arc<str>, DurableType)],
+            _value_substitutions: &[(Arc<str>, DurableConstValue)],
+        ) -> Result<
+            DurableType,
+            rue_air::SemanticTypeSyntaxError<
+                QueryAbort,
+                SemanticNucleusFailure,
+                crate::StableDefinitionKey,
+                Arc<str>,
+            >,
+        > {
+            panic!("not part of keyed import service test")
+        }
+
+        fn begin_comptime_call_admission(
+            &self,
+            _accessing_source: &crate::StableDefinitionKey,
+            _module: &ModuleId,
+            _name: &str,
+        ) -> Result<
+            DurableComptimeCallableAdmissionStart,
+            rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+        > {
+            panic!("not part of keyed import service test")
+        }
+
+        fn finish_comptime_call_admission(
+            &self,
+            _start: DurableComptimeCallableAdmissionStart,
+            _argument_modes: &[crate::durable_semantics::DurableParameterMode],
+        ) -> Result<
+            DurableComptimeCallableAdmission,
+            rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+        > {
+            panic!("not part of keyed import service test")
+        }
+
+        fn resolve_named_value(
+            &self,
+            _accessing_source: &crate::StableDefinitionKey,
+            _module: &ModuleId,
+            _name: &str,
+        ) -> Result<
+            Option<DurableComptimeNamedValueProjection>,
+            rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+        > {
+            panic!("not part of keyed import service test")
+        }
+
+        fn resolve_module_member(
+            &self,
+            _accessing_source: &crate::StableDefinitionKey,
+            _module: &ModuleId,
+            _member: &str,
+        ) -> Result<
+            DurableComptimeNamedValueProjection,
+            rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+        > {
+            panic!("not part of keyed import service test")
+        }
+
+        fn resolve_import(
+            &self,
+            _site: &DurableImportSite,
+        ) -> Result<DurableImportResolution, QueryAbort> {
+            panic!("keyed import service must not use the unkeyed import operation")
+        }
+
+        fn resolve_keyed_import(
+            &self,
+            _site: &rue_air::ComptimeSite<crate::body_query::DurableComptimeProgramKey>,
+            _specifier: &str,
+        ) -> Result<DurableImportResolution, DurableComptimeKeyedImportError> {
+            self.calls.set(self.calls.get() + 1);
+            match &self.mode {
+                ImportServiceMode::Missing => Ok(DurableImportResolution::Missing),
+                ImportServiceMode::Failure(failure) => {
+                    Ok(DurableImportResolution::Failure(failure.clone()))
+                }
+                ImportServiceMode::Abort => Err(DurableComptimeKeyedImportError::ProviderAbort(
+                    QueryAbort::Canceled,
+                )),
+            }
+        }
+
+        fn resolve_target_intrinsic(
+            &self,
+            _name: &str,
+            _argument_count: usize,
+        ) -> Result<
+            TargetEnumValue,
+            rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+        > {
+            panic!("not part of keyed import service test")
+        }
+
+        fn resolve_target_enum_variant(
+            &self,
+            _type_name: &str,
+            _variant: &str,
+        ) -> Result<
+            TargetEnumValue,
+            rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+        > {
+            panic!("not part of keyed import service test")
+        }
+    }
+
+    #[test]
+    fn keyed_import_service_preserves_terminals_and_skips_structural_rejections() {
+        let first = const_program("service-import.rue", "i32");
+        let mut session = session();
+        session.register_program(&first).unwrap();
+        let instruction = session
+            .registered_program(&first.plan.key)
+            .unwrap()
+            .imports
+            .imports[0]
+            .inst;
+        let site = session
+            .import_site_for_instruction(&first.plan.key, instruction, "service-import.rue")
+            .unwrap();
+        let import_key = crate::declaration_candidate::DeclarationImportSiteKey {
+            declaration: first.plan.candidate.clone(),
+            occurrence: 0,
+            specifier: Arc::from("service-import.rue"),
+        };
+
+        for (mode, expected) in [
+            (ImportServiceMode::Missing, DurableImportResolution::Missing),
+            (
+                ImportServiceMode::Failure(
+                    crate::declaration_candidate::DeclarationImportFailure::ResolutionUnavailable(
+                        import_key.clone(),
+                    ),
+                ),
+                DurableImportResolution::Failure(
+                    crate::declaration_candidate::DeclarationImportFailure::ResolutionUnavailable(
+                        import_key.clone(),
+                    ),
+                ),
+            ),
+        ] {
+            let calls = Cell::new(0);
+            let mut authority = ImportServiceAuthority { calls, mode };
+            let services = DurableComptimeServices::new(&mut authority);
+            assert_eq!(
+                services
+                    .resolve_keyed_import(&site, "service-import.rue")
+                    .unwrap(),
+                expected
+            );
+            assert_eq!(authority.calls.get(), 1);
+        }
+
+        let calls = Cell::new(0);
+        let mut authority = ImportServiceAuthority {
+            calls,
+            mode: ImportServiceMode::Abort,
+        };
+        let services = DurableComptimeServices::new(&mut authority);
+        assert!(matches!(
+            services.resolve_keyed_import(&site, "service-import.rue"),
+            Err(DurableComptimeKeyedImportError::ProviderAbort(
+                QueryAbort::Canceled
+            ))
+        ));
+        assert_eq!(authority.calls.get(), 1);
+
+        let wrong_kind = rue_air::ComptimeSite::from_occurrence(
+            first.plan.key.clone(),
+            rue_air::ComptimeSiteKind::Intrinsic,
+            site.occurrence(),
+            site.span(),
+        );
+        let mut authority = ImportServiceAuthority {
+            calls: Cell::new(0),
+            mode: ImportServiceMode::Missing,
+        };
+        let services = DurableComptimeServices::new(&mut authority);
+        assert!(matches!(
+            services.resolve_keyed_import(&wrong_kind, "service-import.rue"),
+            Err(DurableComptimeKeyedImportError::WrongSiteKind)
+        ));
+        assert_eq!(authority.calls.get(), 0);
     }
 
     #[test]

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -6817,7 +6817,6 @@ struct SemanticConstEvaluator<'a, 'provider> {
     declaration: &'a crate::semantic_query_nucleus::DeclarationSemanticQueryKey,
     rir: &'a rue_rir::ValidatedRir,
     symbols: &'a [&'a str],
-    import_occurrences: BTreeMap<rue_rir::InstRef, (u32, Arc<str>)>,
     locals: BTreeMap<Arc<str>, EvaluatedSemanticConst>,
     producer: crate::StableProducerId,
     expected_type: Option<crate::durable_semantics::DurableType>,
@@ -7389,6 +7388,54 @@ impl crate::durable_comptime::DurableComptimeSemanticAuthority
                 crate::durable_comptime::DurableImportResolution::Failure(failure.clone())
             }
         })
+    }
+
+    fn resolve_keyed_import(
+        &self,
+        site: &rue_air::ComptimeSite<crate::body_query::DurableComptimeProgramKey>,
+        specifier: &str,
+    ) -> Result<
+        crate::durable_comptime::DurableImportResolution,
+        crate::durable_comptime::DurableComptimeKeyedImportError,
+    > {
+        if site.kind() != rue_air::ComptimeSiteKind::Import {
+            return Err(crate::durable_comptime::DurableComptimeKeyedImportError::WrongSiteKind);
+        }
+        let program = site.program();
+        let Some(registered) = self.session.registered_program(program) else {
+            return Err(crate::durable_comptime::DurableComptimeKeyedImportError::UnknownProgram);
+        };
+        let Some(occurrence) = registered
+            .imports
+            .imports
+            .iter()
+            .find(|occurrence| occurrence.occurrence == site.occurrence())
+        else {
+            return Err(
+                crate::durable_comptime::DurableComptimeKeyedImportError::UnknownInstruction,
+            );
+        };
+        if occurrence.specifier.as_ref() != specifier {
+            return Err(
+                crate::durable_comptime::DurableComptimeKeyedImportError::SpecifierMismatch,
+            );
+        }
+        let Some(declaration) =
+            crate::revisioned_query_database::declaration_candidate_for_stable_key(
+                &program.declaration,
+            )
+        else {
+            return Err(
+                crate::durable_comptime::DurableComptimeKeyedImportError::UnknownDeclaration,
+            );
+        };
+        let durable_site = crate::durable_comptime::DurableImportSite {
+            declaration,
+            occurrence: occurrence.occurrence,
+            specifier: occurrence.specifier.clone(),
+        };
+        self.resolve_import(&durable_site)
+            .map_err(crate::durable_comptime::DurableComptimeKeyedImportError::ProviderAbort)
     }
 
     fn resolve_target_intrinsic(
@@ -7971,21 +8018,57 @@ impl SemanticConstEvaluator<'_, '_> {
         &mut self,
         instruction: rue_rir::InstRef,
     ) -> Result<EvaluatedSemanticConst, EvaluateSemanticConstError> {
-        let Some((occurrence, specifier)) = self.import_occurrences.get(&instruction) else {
-            return Self::failure(
-                "exact const import is absent from its candidate RIR occurrence index",
-            );
+        let specifier = match &self.rir.get(instruction).data {
+            rue_rir::InstData::Intrinsic { args, .. } => {
+                let Some(argument) = self.rir.intrinsic_args(args).get(0) else {
+                    return Self::failure(
+                        "exact const import is absent from its candidate RIR occurrence index",
+                    );
+                };
+                let rue_rir::InstData::StringConst { content, .. } = &self.rir.get(argument).data
+                else {
+                    return Self::failure(
+                        "exact const import is absent from its candidate RIR occurrence index",
+                    );
+                };
+                self.symbol(content)
+            }
+            _ => {
+                return Self::failure(
+                    "exact const import is absent from its candidate RIR occurrence index",
+                );
+            }
+        };
+        // This is the sole legacy RIR adapter: after decoding the string
+        // operand, pair the instruction with the exact registered program
+        // before crossing into the semantic AIR-site service.
+        let site = self.authority.session.import_site_for_instruction(
+            &self.program,
+            instruction,
+            &specifier,
+        );
+        let site = match site {
+            Ok(site) => site,
+            Err(_) => {
+                return Self::failure(
+                    "exact const import is absent from its candidate RIR occurrence index",
+                );
+            }
         };
         let services = crate::durable_comptime::DurableComptimeServices::new(&mut *self.authority);
-        let site = crate::durable_comptime::DurableImportSite {
-            declaration: self.declaration.declaration.clone(),
-            occurrence: *occurrence,
-            specifier: specifier.clone(),
+        let resolution = services.resolve_keyed_import(&site, &specifier);
+        let resolution = match resolution {
+            Ok(resolution) => resolution,
+            Err(crate::durable_comptime::DurableComptimeKeyedImportError::ProviderAbort(abort)) => {
+                return Err(EvaluateSemanticConstError::Abort(abort));
+            }
+            Err(_) => {
+                return Self::failure(
+                    "exact const import is absent from its candidate RIR occurrence index",
+                );
+            }
         };
-        match services
-            .resolve_import(&site)
-            .map_err(EvaluateSemanticConstError::Abort)?
-        {
+        match resolution {
             crate::durable_comptime::DurableImportResolution::Resolved(module) => {
                 Ok(EvaluatedSemanticConst::Module(module))
             }
@@ -13931,20 +14014,6 @@ impl RevisionedQueryDatabase {
                                                 crate::StableProducerId::Definition(
                                                     const_identity.key.clone(),
                                                 );
-                                            let import_occurrences =
-                                        core.imports
-                                            .imports
-                                            .iter()
-                                            .map(|occurrence| {
-                                                (
-                                                    occurrence.inst,
-                                                    (
-                                                        occurrence.occurrence,
-                                                        occurrence.specifier.clone(),
-                                                    ),
-                                                )
-                                            })
-                                            .collect::<BTreeMap<_, _>>();
                                             let (result, provider) = {
                                                 let mut evaluator = SemanticConstEvaluator {
                                                     authority: &mut authority,
@@ -13952,7 +14021,6 @@ impl RevisionedQueryDatabase {
                                                     declaration: query,
                                             rir,
                                                     symbols: &symbols,
-                                                    import_occurrences,
                                                     locals: BTreeMap::new(),
                                                     producer: const_producer.clone(),
                                                     expected_type,
@@ -14485,20 +14553,6 @@ impl RevisionedQueryDatabase {
                                         .iter()
                                         .map(AsRef::as_ref)
                                         .collect::<Vec<_>>();
-                                    let import_occurrences = core
-                                        .imports
-                                        .imports
-                                        .iter()
-                                        .map(|occurrence| {
-                                            (
-                                                occurrence.inst,
-                                                (
-                                                    occurrence.occurrence,
-                                                    occurrence.specifier.clone(),
-                                                ),
-                                            )
-                                        })
-                                        .collect::<BTreeMap<_, _>>();
                                             let (result, provider) = {
                                                 let mut authority = DurableComptimeRootAuthority {
                                                     provider,
@@ -14523,7 +14577,6 @@ impl RevisionedQueryDatabase {
                                                     declaration: &call.declaration,
                                             rir,
                                                     symbols: &symbols,
-                                                    import_occurrences,
                                                     locals,
                                                     producer: producer.clone(),
                                                     expected_type: Some(expected_type),


### PR DESCRIPTION
Relates to RUE-1774

This staged slice moves durable const-import resolution behind the semantic AIR site boundary. The future rue-air host now passes a program-keyed `ComptimeSite`; raw RIR instruction references remain confined to the temporary legacy adapter.

It also removes ambient import-occurrence maps, validates registered program/occurrence/specifier identity before provider queries, preserves missing/failure/abort terminals, and adds inventory and collision coverage.

Validation:
- `scripts/rue unit compiler durable_` (100 passed)
- `scripts/rue quick` (31 targets passed)