### PR TITLE
RUE-1774: preserve structured substitution scope

### DIFF
--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -1107,6 +1107,7 @@ mod tests {
             "enum StructuredTypePoll<",
             "struct StructuredTypeSuspension<",
             "struct SemanticComptimeCallRequestView<",
+            "pub struct ComptimeStructuredTypeJob<",
         ] {
             let offset = SEMANTIC_TYPE_RESOLUTION_SOURCE
                 .find(declaration)
@@ -1161,6 +1162,59 @@ mod tests {
             1,
             "the keyed resolver job has one declaration"
         );
+        let semantic_type_production = SEMANTIC_TYPE_RESOLUTION_SOURCE
+            .split("#[cfg(test)]")
+            .next()
+            .expect("structured resolver production precedes its tests");
+        let job = item(
+            semantic_type_production,
+            "pub struct ComptimeStructuredTypeJob<",
+        );
+        let job_fields = job
+            .split_once('{')
+            .and_then(|(_, body)| body.strip_suffix('}'))
+            .expect("structured resolver job fields");
+        for required in [
+            "type_substitutions: Vec<(N, T)>",
+            "value_substitutions: Vec<(N, V)>",
+        ] {
+            assert!(
+                job_fields.contains(required),
+                "the consuming job must own its substitution scope: {required}"
+            );
+        }
+        assert!(
+            !job_fields.contains("pub "),
+            "substitution scope must remain private to the consuming job"
+        );
+        assert_eq!(
+            semantic_type_production
+                .matches("fn with_comptime_substitutions<R>(")
+                .count(),
+            1,
+            "the production type provider has one substitution-scoping seam"
+        );
+        let keyed_begin = item(semantic_type_production, "pub fn begin<M, Q>(");
+        for required in [
+            "type_substitutions: Vec<(N, T)>",
+            "value_substitutions: Vec<(N, V)>",
+            "with_comptime_substitutions(",
+        ] {
+            assert!(
+                keyed_begin.contains(required),
+                "structured begin must capture and install its scope once: {required}"
+            );
+        }
+        let job_resume = item(semantic_type_production, "pub fn resume<M, Q>(");
+        let keyed_resume_signature = job_resume
+            .split_once('{')
+            .map_or(job_resume, |(signature, _)| signature);
+        for forbidden in ["type_substitutions", "value_substitutions"] {
+            assert!(
+                !keyed_resume_signature.contains(forbidden),
+                "structured resume must not accept a replacement scope: {forbidden}"
+            );
+        }
         assert!(
             !SEMANTIC_TYPE_RESOLUTION_SOURCE.contains("Clone for ComptimeStructuredTypeJob"),
             "the keyed resolver job must remain consuming"

--- a/crates/rue-air/src/semantic_type_resolution.rs
+++ b/crates/rue-air/src/semantic_type_resolution.rs
@@ -283,6 +283,20 @@ pub enum SemanticValueSyntax<'a> {
 pub trait SemanticTypeSyntaxProvider<S, M, A, K, N, T, V>:
     SemanticModulePathProvider<S, M, A>
 {
+    /// Run one structured-type poll with the exact substitution scope owned
+    /// by its continuation. Ordinary providers already carry all relevant
+    /// state in their own value, so the default keeps their behavior intact.
+    /// Providers with ambient substitution maps may install and restore this
+    /// scope around the canonical poll.
+    fn with_comptime_substitutions<R>(
+        &mut self,
+        _type_substitutions: &[(N, T)],
+        _value_substitutions: &[(N, V)],
+        operation: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        operation(self)
+    }
+
     fn substituted_type(
         &mut self,
         scope: &S,
@@ -1118,8 +1132,12 @@ impl<'a, P, C, N, A, T, V> ComptimeStructuredTypeRequest<'a, P, C, N, A, T, V> {
 /// `RirTypeSyntaxRef` from being interpreted against another program's local
 /// arena, even when the two programs happen to use colliding indices.
 pub struct ComptimeStructuredTypeJob<P, S, C, N, A, T, V, Sym, R> {
+    // These scopes travel with the consuming continuation. A resumed poll
+    // therefore cannot accidentally observe another call's ambient maps.
     authority: ComptimeStructuredTypeAuthority<P, S, Sym, R>,
     suspension: StructuredTypeSuspension<C, N, A, T, V>,
+    type_substitutions: Vec<(N, T)>,
+    value_substitutions: Vec<(N, V)>,
 }
 
 impl<P, S, C, N, A, T, V, Sym, R> ComptimeStructuredTypeJob<P, S, C, N, A, T, V, Sym, R>
@@ -1181,10 +1199,14 @@ where
     fn from_suspension(
         authority: ComptimeStructuredTypeAuthority<P, S, Sym, R>,
         suspension: StructuredTypeSuspension<C, N, A, T, V>,
+        type_substitutions: Vec<(N, T)>,
+        value_substitutions: Vec<(N, V)>,
     ) -> Self {
         Self {
             authority,
             suspension,
+            type_substitutions,
+            value_substitutions,
         }
     }
 
@@ -1194,6 +1216,8 @@ where
     pub fn begin<M, Q>(
         provider: &mut Q,
         authority: ComptimeStructuredTypeAuthority<P, S, Sym, R>,
+        type_substitutions: Vec<(N, T)>,
+        value_substitutions: Vec<(N, V)>,
     ) -> Result<
         ComptimeStructuredTypePoll<P, S, C, N, A, T, V, Sym, R>,
         SemanticTypeSyntaxError<Q::Abort, Q::Failure, A, N>,
@@ -1212,15 +1236,21 @@ where
             symbols,
             root,
         } = authority;
-        let poll = poll_structured_type_machine(
-            StructuredTypeMachine::<C, N, A, T, V>::new(root),
-            provider,
-            &root_scope,
-            &arena,
-            |symbol: &Sym| {
-                symbols
-                    .resolve_symbol(symbol)
-                    .expect("structured type authority was admitted with all symbols")
+        let poll = provider.with_comptime_substitutions(
+            &type_substitutions,
+            &value_substitutions,
+            |provider| {
+                poll_structured_type_machine(
+                    StructuredTypeMachine::<C, N, A, T, V>::new(root),
+                    provider,
+                    &root_scope,
+                    &arena,
+                    |symbol: &Sym| {
+                        symbols
+                            .resolve_symbol(symbol)
+                            .expect("structured type authority was admitted with all symbols")
+                    },
+                )
             },
         )?;
         Ok(match poll {
@@ -1231,6 +1261,8 @@ where
                         program, root_scope, arena, symbols, root,
                     ),
                     *suspension,
+                    type_substitutions,
+                    value_substitutions,
                 )))
             }
         })
@@ -1261,6 +1293,8 @@ where
         let Self {
             authority,
             suspension,
+            type_substitutions,
+            value_substitutions,
         } = self;
         let ComptimeStructuredTypeAuthority {
             program,
@@ -1269,16 +1303,22 @@ where
             symbols,
             root,
         } = authority;
-        let poll = suspension.resume(
-            provider,
-            &root_scope,
-            &arena,
-            |symbol: &Sym| {
-                symbols
-                    .resolve_symbol(symbol)
-                    .expect("structured type authority was admitted with all symbols")
+        let poll = provider.with_comptime_substitutions(
+            &type_substitutions,
+            &value_substitutions,
+            |provider| {
+                suspension.resume(
+                    provider,
+                    &root_scope,
+                    &arena,
+                    |symbol: &Sym| {
+                        symbols
+                            .resolve_symbol(symbol)
+                            .expect("structured type authority was admitted with all symbols")
+                    },
+                    reduced,
+                )
             },
-            reduced,
         )?;
         Ok(match poll {
             StructuredTypePoll::Ready(value) => ComptimeStructuredTypePoll::Ready(value),
@@ -1288,6 +1328,8 @@ where
                         program, root_scope, arena, symbols, root,
                     ),
                     *suspension,
+                    type_substitutions,
+                    value_substitutions,
                 )))
             }
         })
@@ -1899,6 +1941,9 @@ mod tests {
     struct Fixture {
         calls: Vec<String>,
         reduced_arguments: Vec<String>,
+        active_type_substitutions: BTreeMap<&'static str, &'static str>,
+        active_value_substitutions: BTreeMap<&'static str, i64>,
+        scope_observations: Vec<(Vec<(&'static str, &'static str)>, Vec<(&'static str, i64)>)>,
         bindings: BTreeMap<(&'static str, &'static str), Binding>,
         root_structs: BTreeMap<(&'static str, &'static str), Fact>,
         root_enums: BTreeMap<(&'static str, &'static str), Fact>,
@@ -1917,6 +1962,19 @@ mod tests {
         array_type_error: Option<SemanticProviderError<&'static str, &'static str>>,
         allow_qualified_paths: Option<bool>,
         allow_qualified_value_heads: Option<bool>,
+    }
+
+    struct FixtureScopeRestore<'a> {
+        fixture: &'a mut Fixture,
+        previous_types: BTreeMap<&'static str, &'static str>,
+        previous_values: BTreeMap<&'static str, i64>,
+    }
+
+    impl Drop for FixtureScopeRestore<'_> {
+        fn drop(&mut self) {
+            self.fixture.active_type_substitutions = std::mem::take(&mut self.previous_types);
+            self.fixture.active_value_substitutions = std::mem::take(&mut self.previous_values);
+        }
     }
 
     impl Fixture {
@@ -1967,13 +2025,39 @@ mod tests {
             i64,
         > for Fixture
     {
+        fn with_comptime_substitutions<R>(
+            &mut self,
+            type_substitutions: &[(&'static str, &'static str)],
+            value_substitutions: &[(&'static str, i64)],
+            operation: impl FnOnce(&mut Self) -> R,
+        ) -> R {
+            let previous_types = std::mem::replace(
+                &mut self.active_type_substitutions,
+                type_substitutions.iter().copied().collect(),
+            );
+            let previous_values = std::mem::replace(
+                &mut self.active_value_substitutions,
+                value_substitutions.iter().copied().collect(),
+            );
+            self.scope_observations
+                .push((type_substitutions.to_vec(), value_substitutions.to_vec()));
+            let restore = FixtureScopeRestore {
+                fixture: self,
+                previous_types,
+                previous_values,
+            };
+            let result = operation(restore.fixture);
+            drop(restore);
+            result
+        }
+
         fn substituted_type(
             &mut self,
             scope: &&'static str,
             name: &str,
         ) -> FixtureResult<Option<&'static str>> {
             self.call("substitution", scope, name);
-            Ok(None)
+            Ok(self.active_type_substitutions.get(name).copied())
         }
 
         fn primitive_type(&mut self, name: &str) -> FixtureResult<Option<&'static str>> {
@@ -2071,9 +2155,12 @@ mod tests {
             self.call("array_length", scope, &format!("{length:?}"));
             match length {
                 SemanticValueSyntax::Integer(value) => Ok(u64::try_from(value).ok()),
-                SemanticValueSyntax::Name(_) => {
-                    Err(SemanticProviderError::Failure("unknown length"))
-                }
+                SemanticValueSyntax::Name(name) => self
+                    .active_value_substitutions
+                    .get(name)
+                    .copied()
+                    .map(|value| u64::try_from(value).ok())
+                    .ok_or(SemanticProviderError::Failure("unknown length")),
             }
         }
 
@@ -3084,8 +3171,13 @@ mod tests {
             Arc::from(arena.symbols()),
             root,
         );
-        let poll =
-            ComptimeStructuredTypeJob::begin::<&'static str, _>(&mut fixture, authority).unwrap();
+        let poll = ComptimeStructuredTypeJob::begin::<&'static str, _>(
+            &mut fixture,
+            authority,
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap();
         let ComptimeStructuredTypePoll::Suspended(job) = poll else {
             panic!("constructor call must suspend before reduction");
         };
@@ -3116,14 +3208,269 @@ mod tests {
             Arc::from([Arc::<str>::from("Outer"), Arc::<str>::from("i32")]),
             root,
         );
-        let poll_b =
-            ComptimeStructuredTypeJob::begin::<&'static str, _>(&mut fixture_b, authority_b)
-                .unwrap();
+        let poll_b = ComptimeStructuredTypeJob::begin::<&'static str, _>(
+            &mut fixture_b,
+            authority_b,
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap();
         let ComptimeStructuredTypePoll::Suspended(job_b) = poll_b else {
             panic!("colliding program must suspend before reduction");
         };
         assert_eq!(job_b.program(), &"program-b");
         assert_eq!(job_b.request_view().program(), &"program-b");
+    }
+
+    #[test]
+    fn structured_jobs_restore_and_reinstall_their_owned_scopes_when_interleaved() {
+        let (arena, root) = structured_type("Outer(Inner(i32), T, [i32; N])");
+        let mut fixture = Fixture::default();
+        configure_nested_calls(&mut fixture);
+        fixture.constructors.insert(
+            ("app/main.rue", "Outer"),
+            head(
+                "outer-site",
+                true,
+                true,
+                vec![
+                    SemanticTypeConstructorParameter {
+                        name: "InnerT",
+                        is_comptime: true,
+                        is_type: true,
+                    },
+                    SemanticTypeConstructorParameter {
+                        name: "ScopedT",
+                        is_comptime: true,
+                        is_type: true,
+                    },
+                    SemanticTypeConstructorParameter {
+                        name: "ArrayT",
+                        is_comptime: true,
+                        is_type: true,
+                    },
+                ],
+            ),
+        );
+        let poll_a = ComptimeStructuredTypeJob::begin::<&'static str, _>(
+            &mut fixture,
+            ComptimeStructuredTypeAuthority::from_registered(
+                "program-a",
+                "app/main.rue",
+                arena.clone(),
+                Arc::from(arena.symbols()),
+                root,
+            ),
+            vec![("T", "scope-a")],
+            vec![("N", 11)],
+        )
+        .unwrap();
+        let ComptimeStructuredTypePoll::Suspended(job_a) = poll_a else {
+            panic!("first constructor call must suspend");
+        };
+        let poll_b = ComptimeStructuredTypeJob::begin::<&'static str, _>(
+            &mut fixture,
+            ComptimeStructuredTypeAuthority::from_registered(
+                "program-b",
+                "app/main.rue",
+                arena.clone(),
+                Arc::from(arena.symbols()),
+                root,
+            ),
+            vec![("T", "scope-b")],
+            vec![("N", 22)],
+        )
+        .unwrap();
+        let ComptimeStructuredTypePoll::Suspended(job_b) = poll_b else {
+            panic!("second constructor call must suspend");
+        };
+
+        // A caller may have unrelated ambient state while a continuation is
+        // polled; the job's exact scope temporarily wins and is then restored.
+        fixture
+            .active_type_substitutions
+            .insert("ambient", "ambient-type");
+        fixture.active_value_substitutions.insert("ambient", 99);
+        let next_a = job_a
+            .resume::<&'static str, _>(
+                &mut fixture,
+                Ok(Some(SemanticComptimeCallResult::Type("inner-a"))),
+            )
+            .unwrap();
+        let ComptimeStructuredTypePoll::Suspended(outer_a) = next_a else {
+            panic!("first outer call must suspend after consuming its captured scope");
+        };
+        assert_eq!(
+            outer_a.type_arguments(),
+            &[
+                ("InnerT", "inner-a"),
+                ("ScopedT", "scope-a"),
+                ("ArrayT", "array"),
+            ]
+        );
+        assert_eq!(
+            fixture.active_type_substitutions.get("ambient"),
+            Some(&"ambient-type")
+        );
+        assert_eq!(fixture.active_value_substitutions.get("ambient"), Some(&99));
+
+        let next_b = job_b
+            .resume::<&'static str, _>(
+                &mut fixture,
+                Ok(Some(SemanticComptimeCallResult::Type("inner-b"))),
+            )
+            .unwrap();
+        let ComptimeStructuredTypePoll::Suspended(outer_b) = next_b else {
+            panic!("second outer call must suspend after consuming its captured scope");
+        };
+        assert_eq!(
+            outer_b.type_arguments(),
+            &[
+                ("InnerT", "inner-b"),
+                ("ScopedT", "scope-b"),
+                ("ArrayT", "array"),
+            ]
+        );
+
+        let ready_a = outer_a
+            .resume::<&'static str, _>(
+                &mut fixture,
+                Ok(Some(SemanticComptimeCallResult::Type("constructed"))),
+            )
+            .unwrap();
+        assert!(matches!(
+            ready_a,
+            ComptimeStructuredTypePoll::Ready("constructed")
+        ));
+        let ready_b = outer_b
+            .resume::<&'static str, _>(
+                &mut fixture,
+                Ok(Some(SemanticComptimeCallResult::Type("constructed"))),
+            )
+            .unwrap();
+        assert!(matches!(
+            ready_b,
+            ComptimeStructuredTypePoll::Ready("constructed")
+        ));
+        assert_eq!(
+            fixture.scope_observations,
+            [
+                (vec![("T", "scope-a")], vec![("N", 11)]),
+                (vec![("T", "scope-b")], vec![("N", 22)]),
+                (vec![("T", "scope-a")], vec![("N", 11)]),
+                (vec![("T", "scope-b")], vec![("N", 22)]),
+                (vec![("T", "scope-a")], vec![("N", 11)]),
+                (vec![("T", "scope-b")], vec![("N", 22)]),
+            ]
+        );
+        assert_eq!(
+            fixture.active_type_substitutions,
+            BTreeMap::from([("ambient", "ambient-type")])
+        );
+        assert_eq!(
+            fixture.active_value_substitutions,
+            BTreeMap::from([("ambient", 99)])
+        );
+    }
+
+    #[test]
+    fn structured_scope_restores_ambient_maps_after_failure_and_abort() {
+        let (arena, root) = structured_type("[i32; N]");
+        let mut fixture = Fixture {
+            active_type_substitutions: BTreeMap::from([("ambient", "old-type")]),
+            active_value_substitutions: BTreeMap::from([("ambient", 23)]),
+            array_type_error: Some(SemanticProviderError::Failure("array failure")),
+            ..Fixture::default()
+        };
+        let failed = ComptimeStructuredTypeJob::begin::<&'static str, _>(
+            &mut fixture,
+            ComptimeStructuredTypeAuthority::from_registered(
+                "failure-program",
+                "app/main.rue",
+                arena.clone(),
+                Arc::from(arena.symbols()),
+                root,
+            ),
+            vec![("T", "transient-type")],
+            vec![("N", 7)],
+        );
+        assert!(matches!(
+            failed,
+            Err(SemanticTypeSyntaxError::ProviderFailure("array failure"))
+        ));
+        assert_eq!(
+            fixture.active_type_substitutions,
+            BTreeMap::from([("ambient", "old-type")])
+        );
+        assert_eq!(
+            fixture.active_value_substitutions,
+            BTreeMap::from([("ambient", 23)])
+        );
+
+        fixture.array_type_error = Some(SemanticProviderError::Abort("cancelled"));
+        let aborted = ComptimeStructuredTypeJob::begin::<&'static str, _>(
+            &mut fixture,
+            ComptimeStructuredTypeAuthority::from_registered(
+                "abort-program",
+                "app/main.rue",
+                arena.clone(),
+                Arc::from(arena.symbols()),
+                root,
+            ),
+            vec![("T", "transient-type")],
+            vec![("N", 8)],
+        );
+        assert!(matches!(
+            aborted,
+            Err(SemanticTypeSyntaxError::ProviderAbort("cancelled"))
+        ));
+        assert_eq!(
+            fixture.active_type_substitutions,
+            BTreeMap::from([("ambient", "old-type")])
+        );
+        assert_eq!(
+            fixture.active_value_substitutions,
+            BTreeMap::from([("ambient", 23)])
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "scoped poll panic")]
+    fn structured_scope_restores_ambient_maps_after_panic() {
+        use std::cell::RefCell;
+        use std::rc::Rc;
+
+        struct RestorationAssertion {
+            fixture: Rc<RefCell<Fixture>>,
+        }
+
+        impl Drop for RestorationAssertion {
+            fn drop(&mut self) {
+                let fixture = self.fixture.borrow();
+                assert_eq!(
+                    fixture.active_type_substitutions,
+                    BTreeMap::from([("ambient", "old-type")])
+                );
+                assert_eq!(
+                    fixture.active_value_substitutions,
+                    BTreeMap::from([("ambient", 23)])
+                );
+            }
+        }
+
+        let fixture = Rc::new(RefCell::new(Fixture {
+            active_type_substitutions: BTreeMap::from([("ambient", "old-type")]),
+            active_value_substitutions: BTreeMap::from([("ambient", 23)]),
+            ..Fixture::default()
+        }));
+        let _assertion = RestorationAssertion {
+            fixture: Rc::clone(&fixture),
+        };
+        fixture.borrow_mut().with_comptime_substitutions(
+            &[("T", "panic-type")],
+            &[("N", 9)],
+            |_| -> () { panic!("scoped poll panic") },
+        );
     }
 
     #[test]

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -3231,7 +3231,7 @@ fn durable_named_array_length_consumers_share_one_conversion_kernel() {
     let provider = database
         .split("impl rue_air::SemanticTypeSyntaxProvider<ModuleId")
         .nth(1)
-        .and_then(|source| source.split("impl ").next())
+        .and_then(|source| source.split("\n}\n\nimpl ").next())
         .expect("durable type provider");
     let provider_length = provider
         .split("fn resolve_array_length(")
@@ -3239,7 +3239,7 @@ fn durable_named_array_length_consumers_share_one_conversion_kernel() {
         .and_then(|source| source.split("fn array_length_from_value(").next())
         .expect("provider array-length operation");
     let named_provider = provider_length
-        .split("SemanticValueSyntax::Name(name)")
+        .split("rue_air::SemanticValueSyntax::Name(name)")
         .nth(1)
         .expect("provider named-length branch");
     assert_eq!(
@@ -5019,10 +5019,10 @@ fn durable_comptime_services_are_named_authority_operations() {
         "program: &crate::body_query::DurableComptimeProgramKey",
         "type_substitutions: &[(Arc<str>, crate::durable_semantics::DurableType)]",
         "value_substitutions: &[(Arc<str>, crate::durable_semantics::DurableConstValue)]",
-        "with_restored_state(",
-        "authority.resolve_type_syntax(program, syntax)",
-        "authority.provider.substitutions",
-        "authority.provider.value_substitutions",
+        "provider.with_comptime_substitutions(",
+        "resolve_structured_semantic_type_syntax_with(",
+        "registered.rir.type_syntax()",
+        "registered.symbols[symbol.into_usize()]",
     ] {
         assert!(
             substituted_type_resolver.contains(required),

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -3617,6 +3617,8 @@ pub(crate) fn begin_durable_structured_type<Q>(
     session: &DurableComptimeSession,
     key: &crate::body_query::DurableComptimeProgramKey,
     root: rue_rir::RirTypeSyntaxRef,
+    type_substitutions: Vec<(Arc<str>, DurableType)>,
+    value_substitutions: Vec<(Arc<str>, DurableConstValue)>,
     provider: &mut Q,
 ) -> Result<DurableStructuredTypePoll, DurableStructuredTypeBeginError<Q::Abort, Q::Failure>>
 where
@@ -3640,8 +3642,13 @@ where
     else {
         return Err(DurableStructuredTypeBeginError::InvalidProgramAuthority);
     };
-    DurableStructuredTypeJob::begin::<ModuleId, Q>(provider, authority)
-        .map_err(DurableStructuredTypeBeginError::Resolution)
+    DurableStructuredTypeJob::begin::<ModuleId, Q>(
+        provider,
+        authority,
+        type_substitutions,
+        value_substitutions,
+    )
+    .map_err(DurableStructuredTypeBeginError::Resolution)
 }
 
 /// Resume one consuming canonical structured continuation. The reduced call
@@ -7759,6 +7766,8 @@ mod structured_type_adapter_tests {
             &session,
             &first.plan.key,
             first_root,
+            Vec::new(),
+            Vec::new(),
             &mut first_provider,
         )
         .unwrap();
@@ -7790,6 +7799,8 @@ mod structured_type_adapter_tests {
             &session,
             &second.plan.key,
             second_root,
+            Vec::new(),
+            Vec::new(),
             &mut second_provider,
         )
         .unwrap();
@@ -7813,7 +7824,14 @@ mod structured_type_adapter_tests {
             None,
         );
         assert!(matches!(
-            begin_durable_structured_type(&session, &missing_key, first_root, &mut first_provider),
+            begin_durable_structured_type(
+                &session,
+                &missing_key,
+                first_root,
+                Vec::new(),
+                Vec::new(),
+                &mut first_provider,
+            ),
             Err(DurableStructuredTypeBeginError::UnregisteredProgram)
         ));
         assert!(matches!(
@@ -7821,6 +7839,8 @@ mod structured_type_adapter_tests {
                 &session,
                 &first.plan.key,
                 rue_rir::RirTypeSyntaxRef::from_u32(u32::MAX),
+                Vec::new(),
+                Vec::new(),
                 &mut first_provider
             ),
             Err(DurableStructuredTypeBeginError::InvalidProgramAuthority)

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -7,7 +7,7 @@
 //! 12 registers each family directly with the runtime; native selection roots
 //! retain the current and last-good terminals.
 
-use rue_air::Node;
+use rue_air::{Node, SemanticTypeSyntaxProvider};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
@@ -7146,26 +7146,24 @@ impl crate::durable_comptime::DurableComptimeSemanticAuthority
             Arc<str>,
         >,
     > {
-        // Keep the provider's ordinary root view intact after this operation.
-        // The keyed program still supplies the only syntax arena and symbol
-        // authority; substitutions are semantic inputs, not alternate syntax
-        // ownership.
-        let new_types = type_substitutions.iter().cloned().collect();
-        let new_values = value_substitutions.iter().cloned().collect();
-        with_restored_state(
-            self,
-            |authority| {
-                (
-                    std::mem::replace(&mut authority.provider.substitutions, new_types),
-                    std::mem::replace(&mut authority.provider.value_substitutions, new_values),
-                )
-            },
-            |authority| authority.resolve_type_syntax(program, syntax),
-            |authority, (previous_types, previous_values)| {
-                authority.provider.substitutions = previous_types;
-                authority.provider.value_substitutions = previous_values;
-            },
-        )
+        let (provider, session) = (&mut self.provider, &self.session);
+        let Some(registered) = session.registered_program(program) else {
+            return Err(rue_air::SemanticResolutionError::ProviderFailure(
+                crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(Arc::from(
+                    "durable comptime type syntax references an unregistered program",
+                )),
+            ));
+        };
+        let module = program.declaration.module();
+        provider.with_comptime_substitutions(type_substitutions, value_substitutions, |provider| {
+            rue_air::resolve_structured_semantic_type_syntax_with(
+                provider,
+                module,
+                registered.rir.type_syntax(),
+                syntax,
+                |symbol| registered.symbols[symbol.into_usize()].as_ref(),
+            )
+        })
     }
 
     fn begin_comptime_call_admission(
@@ -10347,6 +10345,30 @@ impl rue_air::SemanticModulePathProvider<ModuleId, ModuleId, StableDefinitionKey
 
 #[rustfmt::skip]
 impl rue_air::SemanticTypeSyntaxProvider<ModuleId, ModuleId, StableDefinitionKey, StableDefinitionKey, Arc<str>, crate::durable_semantics::DurableType, crate::durable_semantics::DurableConstValue> for SemanticNucleusTypeProvider<'_> {
+    fn with_comptime_substitutions<R>(
+        &mut self,
+        type_substitutions: &[(Arc<str>, crate::durable_semantics::DurableType)],
+        value_substitutions: &[(Arc<str>, crate::durable_semantics::DurableConstValue)],
+        operation: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        let new_types = type_substitutions.iter().cloned().collect();
+        let new_values = value_substitutions.iter().cloned().collect();
+        with_restored_state(
+            self,
+            |provider| {
+                (
+                    std::mem::replace(&mut provider.substitutions, new_types),
+                    std::mem::replace(&mut provider.value_substitutions, new_values),
+                )
+            },
+            operation,
+            |provider, (previous_types, previous_values)| {
+                provider.substitutions = previous_types;
+                provider.value_substitutions = previous_values;
+            },
+        )
+    }
+
     fn observe_selected_named_type(
         &mut self,
         _name: &str,


### PR DESCRIPTION
Relates to RUE-1774

## Summary

- make the consuming AIR structured-type job own exact type and value substitution scopes across suspension
- install and restore those scopes through one AIR provider seam, including failure, abort, and panic paths
- keep the durable adapter keyed while preventing callers from replacing scope on resume
- add interleaved post-suspension coverage and no-replay architecture guards

## Validation

- `scripts/rue unit air semantic_type` (27 passed)
- `scripts/rue unit air consistency` (17 passed)
- `scripts/rue unit compiler durable_` (108 passed)
- `scripts/rue quick` (31 targets passed)
- `./buck2 test //crates/rue-air:rue-air-clippy //crates/rue-compiler:rue-compiler-clippy` (2 passed)