### PR TITLE
RUE-1774: admit structured callable facts by key

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -3420,7 +3420,9 @@ fn durable_comptime_services_are_named_authority_operations() {
         "resolve_named_value_in_order",
         "resolve_module_member_in_order",
         "begin_comptime_call_admission",
+        "begin_comptime_call_admission_for_key",
         "finish_comptime_call_admission",
+        "finish_structured_comptime_call_admission",
         "reserve_bound_expression_call",
         "admit_bound_expression_call",
         "prepare_bound_expression_call",
@@ -4221,6 +4223,34 @@ fn durable_comptime_services_are_named_authority_operations() {
             "durable session duplicated AIR frame authority: {forbidden}"
         );
     }
+    let session_impl = production_facade
+        .split("impl DurableComptimeSession {")
+        .nth(1)
+        .and_then(|source| source.split("/// Compare the immutable metadata").next())
+        .expect("durable session implementation");
+    let observe_dependency = session_impl
+        .split("pub(crate) fn observe_dependency(")
+        .nth(1)
+        .and_then(|source| {
+            source
+                .split("pub(crate) fn observe_anonymous_nominal(")
+                .next()
+        })
+        .expect("session dependency observer");
+    assert!(observe_dependency.contains("self.lifecycle.observe_dependency(dependency)"));
+    let structured_finish = production_facade
+        .split("pub(crate) fn finish_structured_comptime_call_admission(")
+        .nth(1)
+        .and_then(|source| source.split("pub(crate) fn resolve_named_value(").next())
+        .expect("structured callable finish service");
+    assert!(structured_finish.contains("DurableParameterMode::Value"));
+    assert!(
+        structured_finish.contains("self.finish_comptime_call_admission(start, &argument_modes)")
+    );
+    assert!(!structured_finish.contains("begin_comptime_call_admission"));
+    assert!(!structured_finish.contains("resolve_named_value"));
+    assert!(!structured_finish.contains("InstData"));
+    assert!(!structured_finish.contains("InstRef"));
     let foreign_adapter = production_facade
         .split("pub(crate) enum DurableComptimeForeignCall {")
         .nth(1)
@@ -5630,6 +5660,42 @@ fn durable_comptime_services_are_named_authority_operations() {
         .and_then(|source| source.split("\n    fn resolve_named_value(").next())
         .expect("call admission completion authority source");
     assert!(!admission_finish_authority.contains("provider.dependency_source"));
+    let keyed_admission_authority = target_authority
+        .split("fn begin_comptime_call_admission_for_key(")
+        .nth(1)
+        .and_then(|source| {
+            source
+                .split("\n    fn finish_comptime_call_admission(")
+                .next()
+        })
+        .expect("exact keyed call admission authority source");
+    for required in [
+        "declaration_candidate_for_stable_key(head)",
+        "identity(candidate.clone())",
+        "if identity.key != *head",
+        "name: Arc::from(head.name())",
+        "source: accessing_source.clone()",
+        "identity.key,",
+    ] {
+        assert!(
+            keyed_admission_authority.contains(required),
+            "keyed call admission lost exact-head validation: {required}"
+        );
+    }
+    for forbidden in [
+        "candidate_from(",
+        "module,",
+        "query_registered(",
+        "resolve_named_value",
+        "SemanticConstEvaluator",
+        "InstData",
+        "InstRef",
+    ] {
+        assert!(
+            !keyed_admission_authority.contains(forbidden),
+            "keyed call admission must not rediscover or evaluate: {forbidden}"
+        );
+    }
     let named_value_authority = format!(
         "{}{}",
         target_authority

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -1745,6 +1745,14 @@ impl DurableComptimeSession {
         self.lifecycle.take_root_effects()
     }
 
+    /// Record a semantic dependency in the current lifecycle scope.  Service
+    /// callers use this funnel between keyed admission's begin and finish
+    /// phases so a later admission failure cannot erase the begin observation.
+    #[allow(dead_code)] // consumed by the staged structured-frame adapter
+    pub(crate) fn observe_dependency(&mut self, dependency: SemanticDeclarationDependency) {
+        self.lifecycle.observe_dependency(dependency);
+    }
+
     /// Enter one lifecycle ticket through the session-owned funnel.  Keeping
     /// this operation here prevents future hosts from reaching around the
     /// session and mutating the lifecycle with a mismatched ticket.
@@ -3045,6 +3053,24 @@ pub(crate) trait DurableComptimeSemanticAuthority {
         rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
     >;
 
+    /// Begin admission from the exact stable callable head supplied by a
+    /// structured-type continuation.  Unlike the spelling-based operation,
+    /// this operation must not rediscover a declaration through module/name
+    /// lookup: the implementation reconstructs the canonical syntax candidate
+    /// for the stable key with discriminator zero, then verifies the projected
+    /// identity key. A stable key does not carry duplicate-discriminator
+    /// information, so this operation must not claim to preserve duplicate
+    /// candidates; it never infers identity from a spelling.
+    #[allow(dead_code)] // consumed by the staged structured-frame adapter
+    fn begin_comptime_call_admission_for_key(
+        &self,
+        accessing_source: &crate::StableDefinitionKey,
+        head: &crate::StableDefinitionKey,
+    ) -> Result<
+        DurableComptimeCallableAdmissionStart,
+        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+    >;
+
     fn finish_comptime_call_admission(
         &self,
         start: DurableComptimeCallableAdmissionStart,
@@ -3187,6 +3213,19 @@ impl<A: DurableComptimeSemanticAuthority + ?Sized> DurableComptimeServices<'_, A
             .begin_comptime_call_admission(accessing_source, module, name)
     }
 
+    #[allow(dead_code)] // consumed by the staged structured-frame adapter
+    pub(crate) fn begin_comptime_call_admission_for_key(
+        &self,
+        accessing_source: &crate::StableDefinitionKey,
+        head: &crate::StableDefinitionKey,
+    ) -> Result<
+        DurableComptimeCallableAdmissionStart,
+        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+    > {
+        self.authority
+            .begin_comptime_call_admission_for_key(accessing_source, head)
+    }
+
     /// Begin admission for a method whose receiver has already reduced to an
     /// exact module value.  Keeping this named seam distinct from the
     /// unqualified call operation makes it impossible for a future AIR host
@@ -3213,6 +3252,25 @@ impl<A: DurableComptimeSemanticAuthority + ?Sized> DurableComptimeServices<'_, A
     > {
         self.authority
             .finish_comptime_call_admission(start, argument_modes)
+    }
+
+    /// Finish admission for a structured-type call.  Structured syntax has
+    /// already supplied the ordered arguments, so every argument is a value;
+    /// the begin phase remains separate so its dependency can be observed
+    /// before signature/arity policy is allowed to fail.
+    #[allow(dead_code)] // consumed by the staged structured-frame adapter
+    pub(crate) fn finish_structured_comptime_call_admission(
+        &self,
+        start: DurableComptimeCallableAdmissionStart,
+        argument_count: usize,
+    ) -> Result<
+        DurableComptimeCallableAdmission,
+        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+    > {
+        let argument_modes = (0..argument_count)
+            .map(|_| crate::durable_semantics::DurableParameterMode::Value)
+            .collect::<Vec<_>>();
+        self.finish_comptime_call_admission(start, &argument_modes)
     }
 
     pub(crate) fn resolve_named_value(
@@ -8467,9 +8525,19 @@ mod structured_type_adapter_tests {
         Abort,
     }
 
+    #[derive(Clone, Copy)]
+    enum CallFinishMode {
+        Success,
+        Failure,
+        Abort,
+    }
+
     struct ImportServiceAuthority {
         calls: Cell<usize>,
         mode: ImportServiceMode,
+        keyed_heads: RefCell<Vec<crate::StableDefinitionKey>>,
+        finish_modes: RefCell<Vec<Vec<crate::durable_semantics::DurableParameterMode>>>,
+        finish_mode: CallFinishMode,
     }
 
     impl DurableComptimeSemanticAuthority for ImportServiceAuthority {
@@ -8523,15 +8591,100 @@ mod structured_type_adapter_tests {
             panic!("not part of keyed import service test")
         }
 
+        fn begin_comptime_call_admission_for_key(
+            &self,
+            accessing_source: &crate::StableDefinitionKey,
+            head: &crate::StableDefinitionKey,
+        ) -> Result<
+            DurableComptimeCallableAdmissionStart,
+            rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+        > {
+            self.keyed_heads.borrow_mut().push(head.clone());
+            let candidate =
+                crate::revisioned_query_database::declaration_candidate_for_stable_key(head)
+                    .expect("test keyed head has a canonical candidate");
+            let identity = crate::semantic_query_nucleus::DeclarationIdentityProjection {
+                key: head.clone(),
+                is_public: true,
+            };
+            Ok(DurableComptimeCallableAdmissionStart {
+                candidate,
+                identity,
+                configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration {
+                    target: rue_target::Target::X86_64Linux,
+                    preview_features: crate::StablePreviewFeatures::new(
+                        &crate::PreviewFeatures::default(),
+                    ),
+                },
+                name: Arc::from(head.name()),
+                dependency: SemanticDeclarationDependency {
+                    source: accessing_source.clone(),
+                    kind: rue_air::DeclarationTypeDependencyKind::Body,
+                    target: crate::semantic_query_nucleus::SemanticDeclarationDependencyTarget::NamedValue(
+                        head.clone(),
+                    ),
+                },
+            })
+        }
+
         fn finish_comptime_call_admission(
             &self,
-            _start: DurableComptimeCallableAdmissionStart,
-            _argument_modes: &[crate::durable_semantics::DurableParameterMode],
+            start: DurableComptimeCallableAdmissionStart,
+            argument_modes: &[crate::durable_semantics::DurableParameterMode],
         ) -> Result<
             DurableComptimeCallableAdmission,
             rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
         > {
-            panic!("not part of keyed import service test")
+            self.finish_modes.borrow_mut().push(argument_modes.to_vec());
+            match self.finish_mode {
+                CallFinishMode::Success => {
+                    let parameters: Arc<[crate::durable_semantics::DurableSemanticParameter]> =
+                        Arc::from([
+                            crate::durable_semantics::DurableSemanticParameter {
+                                name: Arc::from("first"),
+                                ty: DurableType::I32,
+                                mode: crate::durable_semantics::DurableParameterMode::Value,
+                                is_comptime: true,
+                            },
+                            crate::durable_semantics::DurableSemanticParameter {
+                                name: Arc::from("second"),
+                                ty: DurableType::I64,
+                                mode: crate::durable_semantics::DurableParameterMode::Value,
+                                is_comptime: true,
+                            },
+                        ]);
+                    let shell_parameters: Arc<
+                        [crate::declaration_candidate::DeclarationParameterHeader],
+                    > = Arc::from([
+                        crate::declaration_candidate::DeclarationParameterHeader {
+                            name: Arc::from("first"),
+                            mode: crate::declaration_candidate::DeclarationParameterMode::Value,
+                            is_comptime: true,
+                            is_type_parameter: false,
+                        },
+                        crate::declaration_candidate::DeclarationParameterHeader {
+                            name: Arc::from("second"),
+                            mode: crate::declaration_candidate::DeclarationParameterMode::Value,
+                            is_comptime: true,
+                            is_type_parameter: false,
+                        },
+                    ]);
+                    Ok(DurableComptimeCallableAdmission {
+                        candidate: start.candidate,
+                        identity: start.identity,
+                        configuration: start.configuration,
+                        parameters,
+                        result: DurableType::ComptimeType,
+                        shell_parameters,
+                    })
+                }
+                CallFinishMode::Failure => Err(rue_air::SemanticProviderError::Failure(
+                    SemanticNucleusFailure::Resolution(Arc::from("structured finish failed")),
+                )),
+                CallFinishMode::Abort => {
+                    Err(rue_air::SemanticProviderError::Abort(QueryAbort::Canceled))
+                }
+            }
         }
 
         fn resolve_named_value(
@@ -8606,6 +8759,168 @@ mod structured_type_adapter_tests {
     }
 
     #[test]
+    fn keyed_callable_admission_uses_exact_head_without_spelling_lookup() {
+        let first = super::structured_type_adapter_tests::callable_program("structured-head-a.rue");
+        let second =
+            super::structured_type_adapter_tests::callable_program("structured-head-b.rue");
+        let first_head = first.plan.key.declaration.clone();
+        let second_head = second.plan.key.declaration.clone();
+        assert_ne!(first_head, second_head);
+        let accessing_source = crate::StableDefinitionKey::from_stable_parts(
+            first_head.module().clone(),
+            crate::StableDefinitionNamespace::Value,
+            crate::StableDefinitionKind::Function,
+            "caller",
+            None,
+        );
+        let mut authority = ImportServiceAuthority {
+            calls: Cell::new(0),
+            mode: ImportServiceMode::Missing,
+            keyed_heads: RefCell::new(Vec::new()),
+            finish_modes: RefCell::new(Vec::new()),
+            finish_mode: CallFinishMode::Success,
+        };
+        let services = DurableComptimeServices::new(&mut authority);
+        let first_admission = services
+            .begin_comptime_call_admission_for_key(&accessing_source, &first_head)
+            .unwrap();
+        let second_admission = services
+            .begin_comptime_call_admission_for_key(&accessing_source, &second_head)
+            .unwrap();
+
+        assert_eq!(first_admission.identity.key, first_head);
+        assert_eq!(second_admission.identity.key, second_head);
+        assert_eq!(
+            first_admission.candidate.module,
+            first_head.module().clone()
+        );
+        assert_eq!(
+            second_admission.candidate.module,
+            second_head.module().clone()
+        );
+        assert_eq!(
+            authority.keyed_heads.borrow().as_slice(),
+            &[first_head, second_head]
+        );
+        // This test authority intentionally has no module/name candidate path;
+        // reaching both starts proves the structured seam carries the exact
+        // canonical head through the services facade.
+    }
+
+    #[test]
+    fn structured_callable_finish_uses_all_value_modes_and_preserves_begin_effects() {
+        let program = callable_program("structured-finish.rue");
+        let head = program.plan.key.declaration.clone();
+        let source = crate::StableDefinitionKey::from_stable_parts(
+            head.module().clone(),
+            crate::StableDefinitionNamespace::Value,
+            crate::StableDefinitionKind::Function,
+            "structured-caller",
+            None,
+        );
+        let dependency = |start: &DurableComptimeCallableAdmissionStart| start.dependency.clone();
+        let mut authority = ImportServiceAuthority {
+            calls: Cell::new(0),
+            mode: ImportServiceMode::Missing,
+            keyed_heads: RefCell::new(Vec::new()),
+            finish_modes: RefCell::new(Vec::new()),
+            finish_mode: CallFinishMode::Success,
+        };
+        let mut session = session();
+        let initial_serial = session.lifecycle.next_serial;
+        let initial_active = session.lifecycle.active.clone();
+        let initial_programs = session.programs.len();
+        let start = {
+            let services = DurableComptimeServices::new(&mut authority);
+            services
+                .begin_comptime_call_admission_for_key(&source, &head)
+                .unwrap()
+        };
+        session.observe_dependency(dependency(&start));
+        let admission = {
+            let services = DurableComptimeServices::new(&mut authority);
+            services
+                .finish_structured_comptime_call_admission(start, 2)
+                .unwrap()
+        };
+        assert_eq!(admission.identity.key, head);
+        assert_eq!(admission.result, DurableType::ComptimeType);
+        assert_eq!(admission.parameters[0].name.as_ref(), "first");
+        assert_eq!(admission.parameters[0].ty, DurableType::I32);
+        assert_eq!(admission.parameters[1].name.as_ref(), "second");
+        assert_eq!(admission.parameters[1].ty, DurableType::I64);
+        assert_eq!(
+            admission
+                .shell_parameters
+                .iter()
+                .map(|parameter| parameter.name.clone())
+                .collect::<Vec<_>>(),
+            vec![Arc::from("first"), Arc::from("second")]
+        );
+        assert_eq!(
+            authority.finish_modes.borrow().as_slice(),
+            &[[
+                crate::durable_semantics::DurableParameterMode::Value,
+                crate::durable_semantics::DurableParameterMode::Value,
+            ]]
+        );
+        assert_eq!(
+            session.drain_root_effects().unwrap().dependencies().count(),
+            1
+        );
+        assert!(session.drain_root_effects().unwrap().is_empty());
+        assert_eq!(session.lifecycle.next_serial, initial_serial);
+        assert_eq!(session.lifecycle.active, initial_active);
+        assert_eq!(session.programs.len(), initial_programs);
+
+        for finish_mode in [CallFinishMode::Failure, CallFinishMode::Abort] {
+            let mut authority = ImportServiceAuthority {
+                calls: Cell::new(0),
+                mode: ImportServiceMode::Missing,
+                keyed_heads: RefCell::new(Vec::new()),
+                finish_modes: RefCell::new(Vec::new()),
+                finish_mode,
+            };
+            let start = {
+                let services = DurableComptimeServices::new(&mut authority);
+                services
+                    .begin_comptime_call_admission_for_key(&source, &head)
+                    .unwrap()
+            };
+            let mut session = fresh_session();
+            let initial_serial = session.lifecycle.next_serial;
+            let initial_active = session.lifecycle.active.clone();
+            let initial_programs = session.programs.len();
+            session.observe_dependency(start.dependency.clone());
+            let result = {
+                let services = DurableComptimeServices::new(&mut authority);
+                services.finish_structured_comptime_call_admission(start, 2)
+            };
+            match finish_mode {
+                CallFinishMode::Failure => assert!(matches!(
+                    result,
+                    Err(rue_air::SemanticProviderError::Failure(
+                        SemanticNucleusFailure::Resolution(_)
+                    ))
+                )),
+                CallFinishMode::Abort => assert!(matches!(
+                    result,
+                    Err(rue_air::SemanticProviderError::Abort(QueryAbort::Canceled))
+                )),
+                CallFinishMode::Success => unreachable!(),
+            }
+            assert_eq!(
+                session.drain_root_effects().unwrap().dependencies().count(),
+                1
+            );
+            assert!(session.drain_root_effects().unwrap().is_empty());
+            assert_eq!(session.lifecycle.next_serial, initial_serial);
+            assert_eq!(session.lifecycle.active, initial_active);
+            assert_eq!(session.programs.len(), initial_programs);
+        }
+    }
+
+    #[test]
     fn keyed_import_service_preserves_terminals_and_skips_structural_rejections() {
         let first = const_program("service-import.rue", "i32");
         let mut session = session();
@@ -8641,7 +8956,13 @@ mod structured_type_adapter_tests {
             ),
         ] {
             let calls = Cell::new(0);
-            let mut authority = ImportServiceAuthority { calls, mode };
+            let mut authority = ImportServiceAuthority {
+                calls,
+                mode,
+                keyed_heads: RefCell::new(Vec::new()),
+                finish_modes: RefCell::new(Vec::new()),
+                finish_mode: CallFinishMode::Success,
+            };
             let services = DurableComptimeServices::new(&mut authority);
             assert_eq!(
                 services
@@ -8656,6 +8977,9 @@ mod structured_type_adapter_tests {
         let mut authority = ImportServiceAuthority {
             calls,
             mode: ImportServiceMode::Abort,
+            keyed_heads: RefCell::new(Vec::new()),
+            finish_modes: RefCell::new(Vec::new()),
+            finish_mode: CallFinishMode::Success,
         };
         let services = DurableComptimeServices::new(&mut authority);
         assert!(matches!(
@@ -8675,6 +8999,9 @@ mod structured_type_adapter_tests {
         let mut authority = ImportServiceAuthority {
             calls: Cell::new(0),
             mode: ImportServiceMode::Missing,
+            keyed_heads: RefCell::new(Vec::new()),
+            finish_modes: RefCell::new(Vec::new()),
+            finish_mode: CallFinishMode::Success,
         };
         let services = DurableComptimeServices::new(&mut authority);
         assert!(matches!(

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -4415,6 +4415,13 @@ fn publish_body_plan_materialization_attribution(
     );
 }
 
+/// Reconstruct the canonical syntax candidate represented by a stable key.
+///
+/// Stable definition keys identify the canonical declaration spelling and
+/// owner, but intentionally do not encode a duplicate-discriminator.  This
+/// helper therefore reconstructs discriminator zero; callers must use the
+/// projected identity check rather than treating the result as proof that a
+/// duplicate candidate was preserved.
 pub(crate) fn declaration_candidate_for_stable_key(
     key: &StableDefinitionKey,
 ) -> Option<crate::declaration_candidate::DeclarationCandidateKey> {
@@ -7197,6 +7204,53 @@ impl crate::durable_comptime::DurableComptimeSemanticAuthority
             identity: identity.clone(),
             configuration: self.provider.configuration.clone(),
             name: Arc::from(name),
+            dependency: crate::semantic_query_nucleus::SemanticDeclarationDependency {
+                source: accessing_source.clone(),
+                kind: rue_air::DeclarationTypeDependencyKind::Body,
+                target:
+                    crate::semantic_query_nucleus::SemanticDeclarationDependencyTarget::NamedValue(
+                        identity.key,
+                    ),
+            },
+        })
+    }
+
+    fn begin_comptime_call_admission_for_key(
+        &self,
+        accessing_source: &crate::StableDefinitionKey,
+        head: &crate::StableDefinitionKey,
+    ) -> Result<
+        crate::durable_comptime::DurableComptimeCallableAdmissionStart,
+        rue_air::SemanticProviderError<
+            QueryAbort,
+            crate::semantic_query_nucleus::SemanticNucleusFailure,
+        >,
+    > {
+        type Failure = crate::semantic_query_nucleus::SemanticNucleusFailure;
+
+        let Some(candidate) =
+            crate::revisioned_query_database::declaration_candidate_for_stable_key(head)
+        else {
+            return Err(rue_air::SemanticProviderError::Failure(
+                Failure::Resolution(Arc::from(format!(
+                    "undefined comptime function `{}`",
+                    head.name()
+                ))),
+            ));
+        };
+        let identity = self.provider.identity(candidate.clone())?;
+        if identity.key != *head {
+            return Err(rue_air::SemanticProviderError::Failure(
+                Failure::Resolution(Arc::from(
+                    "comptime function identity does not match requested key",
+                )),
+            ));
+        }
+        Ok(crate::durable_comptime::DurableComptimeCallableAdmissionStart {
+            candidate,
+            identity: identity.clone(),
+            configuration: self.provider.configuration.clone(),
+            name: Arc::from(head.name()),
             dependency: crate::semantic_query_nucleus::SemanticDeclarationDependency {
                 source: accessing_source.clone(),
                 kind: rue_air::DeclarationTypeDependencyKind::Body,
@@ -30517,6 +30571,245 @@ fn main() -> i32 {
             restored_values,
             BTreeMap::from([(Arc::from("OLD"), V::Integer(7))])
         );
+    }
+
+    #[test]
+    fn production_root_authority_keyed_admission_preserves_identity_and_dependency() {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Category;
+        use crate::semantic_query_nucleus::{
+            SemanticDeclarationDependency, SemanticDeclarationDependencyTarget as Target,
+            SemanticNucleusFailure as Failure,
+        };
+
+        let source = source_snapshot(
+            &[
+                (1, "/left.rue", "left.rue", "fn target() -> i32 { 1 }\n"),
+                (2, "/right.rue", "right.rue", "fn target() -> i32 { 2 }\n"),
+            ],
+            1,
+        );
+        let left_module = ModuleId::from_logical_path("left.rue").unwrap();
+        let right_module = ModuleId::from_logical_path("right.rue").unwrap();
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&source),
+            &source,
+        );
+        let left_candidate = declaration_candidate(
+            &database,
+            revision,
+            &left_module,
+            Category::Function,
+            "target",
+        );
+        let right_candidate = declaration_candidate(
+            &database,
+            revision,
+            &right_module,
+            Category::Function,
+            "target",
+        );
+        let configuration = semantic_configuration();
+        let left_head = StableDefinitionKey::from_stable_parts(
+            left_module.clone(),
+            crate::StableDefinitionNamespace::Value,
+            crate::StableDefinitionKind::Function,
+            "target",
+            None,
+        );
+        let right_head = StableDefinitionKey::from_stable_parts(
+            right_module,
+            crate::StableDefinitionNamespace::Value,
+            crate::StableDefinitionKind::Function,
+            "target",
+            None,
+        );
+        let accessing_source = StableDefinitionKey::from_stable_parts(
+            left_module,
+            crate::StableDefinitionNamespace::Value,
+            crate::StableDefinitionKind::Function,
+            "caller",
+            None,
+        );
+        let unknown_head = StableDefinitionKey::from_stable_parts(
+            accessing_source.module().clone(),
+            crate::StableDefinitionNamespace::Value,
+            crate::StableDefinitionKind::Function,
+            "missing",
+            None,
+        );
+        let mismatched_head = StableDefinitionKey::from_stable_parts(
+            accessing_source.module().clone(),
+            crate::StableDefinitionNamespace::Type,
+            crate::StableDefinitionKind::Function,
+            "target",
+            None,
+        );
+
+        let captured = std::cell::RefCell::new(None);
+        let attempt = database.runtime.query(
+            &database.provider_probe,
+            revision,
+            ProviderProbeKey {
+                label: Arc::from("production-keyed-call-admission"),
+            },
+            CancellationToken::new(),
+            |context| {
+                let provider = SemanticNucleusTypeProvider {
+                    context,
+                    family: &database.semantic_nucleus,
+                    shells: &database.declaration_shells,
+                    names: &database.lookup_names,
+                    configuration: configuration.clone(),
+                    substitutions: BTreeMap::new(),
+                    value_substitutions: BTreeMap::new(),
+                    deferred_value_parameters: BTreeMap::new(),
+                    anonymous_nominals: BTreeMap::new(),
+                    dependency_source: accessing_source.clone(),
+                    dependency_kind: rue_air::DeclarationTypeDependencyKind::Body,
+                    dependencies: BTreeSet::new(),
+                    deferred_ownership: BTreeSet::new(),
+                    ownership_properties: BTreeMap::new(),
+                };
+                let session = crate::durable_comptime::DurableComptimeSession::new(
+                    left_head.clone(),
+                    left_candidate.clone(),
+                )
+                .unwrap();
+                let mut authority = DurableComptimeRootAuthority {
+                    provider,
+                    imports: database.declaration_imports.clone(),
+                    session,
+                    legacy_effects: Default::default(),
+                    foreign: DurableComptimeForeignQueryAuthority {
+                        context,
+                        semantic_nucleus: &database.semantic_nucleus,
+                        declaration_body_plan_artifacts: &database.declaration_body_plan_artifacts,
+                        configuration: &configuration,
+                    },
+                };
+                let first = {
+                    let services =
+                        crate::durable_comptime::DurableComptimeServices::new(&mut authority);
+                    services.begin_comptime_call_admission_for_key(&accessing_source, &left_head)
+                };
+                let second = {
+                    let services =
+                        crate::durable_comptime::DurableComptimeServices::new(&mut authority);
+                    services.begin_comptime_call_admission_for_key(&accessing_source, &right_head)
+                };
+                let unknown = {
+                    let services =
+                        crate::durable_comptime::DurableComptimeServices::new(&mut authority);
+                    services.begin_comptime_call_admission_for_key(&accessing_source, &unknown_head)
+                };
+                let mismatched = {
+                    let services =
+                        crate::durable_comptime::DurableComptimeServices::new(&mut authority);
+                    services
+                        .begin_comptime_call_admission_for_key(&accessing_source, &mismatched_head)
+                };
+                *captured.borrow_mut() = Some((first, second, unknown, mismatched));
+                Ok(rue_query::QueryOutput::success(ProviderProbeValue))
+            },
+        );
+        assert!(
+            attempt.is_ok(),
+            "production authority probe should complete"
+        );
+        let (first, second, unknown, mismatched) = captured.into_inner().unwrap();
+        let first = first.unwrap();
+        let second = second.unwrap();
+        assert_eq!(first.candidate, left_candidate);
+        assert_eq!(second.candidate, right_candidate);
+        assert_eq!(first.identity.key, left_head);
+        assert_eq!(second.identity.key, right_head);
+        assert_eq!(first.configuration, configuration);
+        assert_eq!(second.configuration, configuration);
+        for (admission, head) in [(&first, &left_head), (&second, &right_head)] {
+            assert_eq!(
+                admission.dependency,
+                SemanticDeclarationDependency {
+                    source: accessing_source.clone(),
+                    kind: rue_air::DeclarationTypeDependencyKind::Body,
+                    target: Target::NamedValue(head.clone()),
+                }
+            );
+        }
+        assert!(
+            matches!(&unknown, Err(rue_air::SemanticProviderError::Failure(_))),
+            "unexpected unknown-head result: {unknown:?}"
+        );
+        assert!(
+            format!("{unknown:?}").contains("missing"),
+            "unknown-head failure lost its requested spelling: {unknown:?}"
+        );
+        assert!(matches!(
+            &mismatched,
+            Err(rue_air::SemanticProviderError::Failure(Failure::Resolution(reason)))
+                if reason.as_ref() == "comptime function identity does not match requested key"
+        ));
+
+        let cancellation = CancellationToken::new();
+        let cancel_in_closure = cancellation.clone();
+        let aborted = std::cell::RefCell::new(None);
+        let _attempt = database.runtime.query(
+            &database.provider_probe,
+            revision,
+            ProviderProbeKey {
+                label: Arc::from("production-keyed-call-admission-abort"),
+            },
+            cancellation,
+            |context| {
+                cancel_in_closure.cancel();
+                let provider = SemanticNucleusTypeProvider {
+                    context,
+                    family: &database.semantic_nucleus,
+                    shells: &database.declaration_shells,
+                    names: &database.lookup_names,
+                    configuration: configuration.clone(),
+                    substitutions: BTreeMap::new(),
+                    value_substitutions: BTreeMap::new(),
+                    deferred_value_parameters: BTreeMap::new(),
+                    anonymous_nominals: BTreeMap::new(),
+                    dependency_source: accessing_source.clone(),
+                    dependency_kind: rue_air::DeclarationTypeDependencyKind::Body,
+                    dependencies: BTreeSet::new(),
+                    deferred_ownership: BTreeSet::new(),
+                    ownership_properties: BTreeMap::new(),
+                };
+                let session = crate::durable_comptime::DurableComptimeSession::new(
+                    left_head.clone(),
+                    left_candidate.clone(),
+                )
+                .unwrap();
+                let mut authority = DurableComptimeRootAuthority {
+                    provider,
+                    imports: database.declaration_imports.clone(),
+                    session,
+                    legacy_effects: Default::default(),
+                    foreign: DurableComptimeForeignQueryAuthority {
+                        context,
+                        semantic_nucleus: &database.semantic_nucleus,
+                        declaration_body_plan_artifacts: &database.declaration_body_plan_artifacts,
+                        configuration: &configuration,
+                    },
+                };
+                let result = {
+                    let services =
+                        crate::durable_comptime::DurableComptimeServices::new(&mut authority);
+                    services.begin_comptime_call_admission_for_key(&accessing_source, &left_head)
+                };
+                *aborted.borrow_mut() = Some(result);
+                Ok(rue_query::QueryOutput::success(ProviderProbeValue))
+            },
+        );
+        assert!(matches!(
+            aborted.into_inner(),
+            Some(Err(rue_air::SemanticProviderError::Abort(
+                QueryAbort::Canceled
+            )))
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Relates to RUE-1774

This prerequisite gives structured AIR suspensions an exact-key callable admission path without module/name rediscovery. The begin phase preserves the canonical Body-to-NamedValue dependency and remains separate from finish so dependency effects survive signature failure or cancellation. The finish phase delegates to the existing callable policy with all arguments in source-order Value mode and returns the canonical typed parameter, result, and shell facts needed by the next frame-admission slice.

Validation:
- production RootAuthority keyed-admission regression (passed)
- scripts/rue unit compiler durable_ (113 passed)
- scripts/rue quick (31 targets passed)
- final adversarial architecture review: SHIP