### PR TITLE
RUE-933: eliminate unreachable functions after inlining

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -692,6 +692,12 @@ impl<'a> CfgBuilder<'a> {
             .all_struct_ids()
             .filter(|id| builder.implicit_named_destructors.contains(id))
             .collect();
+        let implicit_drop_glue_types = builder
+            .implicit_destructor_types
+            .iter()
+            .copied()
+            .filter(|ty| builder.type_needs_drop(*ty))
+            .collect();
 
         // Derive the grouped per-source-parameter ABI descriptors (RUE-1005)
         // from the AIR, which both a fresh analysis and a durable/imported body
@@ -727,6 +733,7 @@ impl<'a> CfgBuilder<'a> {
             warnings: builder.warnings,
             errors: builder.errors,
             implicit_named_destructors,
+            implicit_drop_glue_types,
             anonymous_destructor_dependency_incomplete: builder
                 .anonymous_destructor_dependency_incomplete,
         }

--- a/crates/rue-cfg/src/lib.rs
+++ b/crates/rue-cfg/src/lib.rs
@@ -63,6 +63,9 @@ pub struct CfgOutput {
     pub errors: Vec<CompileError>,
     /// Named user destructors required by implicit drops emitted in this CFG.
     pub implicit_named_destructors: Vec<StructId>,
+    /// Aggregate type instances whose synthesized drop glue is required by
+    /// implicit drops emitted in this CFG, including array and enum wrappers.
+    pub implicit_drop_glue_types: Vec<Type>,
     /// Whether an implicit destructor target was anonymous and therefore has
     /// no stable definition endpoint.
     pub anonymous_destructor_dependency_incomplete: bool,

--- a/crates/rue-cli-tests/cases/differential_opt.toml
+++ b/crates/rue-cli-tests/cases/differential_opt.toml
@@ -7,9 +7,9 @@
 # `cfg(debug_assertions)` divergence — here we catch optimizer passes that
 # change a program's observable behavior.
 #
-# -O2/-O3 currently alias -O1 (const-fold + DCE), so results match today; the
-# point is to set the net now so a FUTURE optimizer change that breaks
-# semantics at a higher level is caught immediately, naming the diverging level.
+# -O2/-O3 include the current whole-program inlining/reachability batch in
+# addition to the local transforms. The net catches any semantic divergence at
+# a higher level immediately, naming the diverging level.
 #
 # Keep this subset SMALL and representative (bounded CI cost): one case each for
 # arithmetic, control flow, an ABI/by-value-aggregate path, and a
@@ -20,6 +20,22 @@
 id = "cli.differential_opt"
 name = "Opt-level differential"
 description = "Marked cases must produce identical results at -O0/-O1/-O2/-O3."
+
+# RUE-933: at -O2/-O3 the single call is consumed by whole-program inlining
+# and the now-unreachable callee is omitted from the backend input. -O0 keeps
+# the source-faithful call boundary; all levels must still agree at runtime.
+[[case]]
+name = "single_use_inlined_callee_is_behaviorally_identical"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+fn add_one(x: i32) -> i32 { x + 1 }
+
+fn main() -> i32 {
+    add_one(41)
+}
+""" }]
+stdout = ""
+exit_code = 42
 
 # Arithmetic: a spread of operators, widths, and folds. Constant-heavy so the
 # const-fold pass has plenty to chew on; the runtime baseline (-O0) must agree.
@@ -1068,3 +1084,61 @@ fn main() -> i32 {
 """ }]
 stdout = "7\n8\n"
 exit_code = 8
+
+# Methods are reachable call edges but are intentionally outside the general
+# free-function inlining policy. Their standalone codegen unit must survive the
+# O2/O3 reachability boundary.
+[[case]]
+name = "reachable_method_survives_optimization_levels"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+struct Counter {
+    value: i32,
+    fn next(self) -> i32 { self.value + 1 }
+}
+
+fn main() -> i32 {
+    Counter { value: 41 }.next()
+}
+""" }]
+stdout = ""
+exit_code = 42
+
+# Accessors are spliced into their caller and have no standalone ABI unit; the
+# differential case keeps that caller's introduced dependency observable.
+[[case]]
+name = "reachable_accessor_splice_survives_optimization_levels"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+struct Point {
+    value: i32,
+    fn read(borrow self) -> borrow i32 { yield self.value; }
+}
+
+fn main() -> i32 {
+    let point = Point { value: 7 };
+    @dbg(point.read());
+    0
+}
+""" }]
+stdout = "7\n"
+exit_code = 0
+
+# Nested aggregate cleanup requires both the outer destructor and the inner
+# drop glue to remain reachable after whole-program inlining/elimination.
+[[case]]
+name = "nested_destructor_drop_glue_survives_optimization_levels"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+struct Inner { value: i32 }
+drop fn Inner(self) { @dbg(self.value); }
+struct Outer { inner: Inner }
+drop fn Outer(self) { @dbg(self.inner.value); }
+
+fn main() -> i32 {
+    let outer = Outer { inner: Inner { value: 7 } };
+    0
+}
+""" }]
+stdout = "7\n7\n"
+exit_code = 0

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -559,6 +559,7 @@ pub(crate) struct CfgRecord {
     pub(crate) body_span: Span,
     pub(crate) warnings: Arc<[rue_error::CompileWarning]>,
     pub(crate) implicit_destructor_targets: Arc<[crate::TypeInstanceKey]>,
+    pub(crate) implicit_drop_glue_targets: Arc<[crate::TypeInstanceKey]>,
     pub(crate) implicit_destructor_dependencies_complete: bool,
     /// General interprocedural inlining changes the caller's CFG in a
     /// whole-program batch. Such a record is a backend result, not a durable
@@ -579,6 +580,17 @@ pub(crate) struct CfgCodegenDomain {
     pub(crate) defined_symbol: Arc<str>,
     pub(crate) symbol_mappings: Arc<std::collections::BTreeMap<String, String>>,
     pub(crate) foreign_symbols: Arc<std::collections::BTreeSet<String>>,
+}
+
+impl CfgCodegenDomain {
+    /// Classify a source spelling using the exact symbol projection already
+    /// consumed by codegen. A target-C callable is a legitimate external edge
+    /// even when its callable identity has no body in this batch.
+    pub(crate) fn is_foreign_source_symbol(&self, source: &str) -> bool {
+        self.symbol_mappings
+            .get(source)
+            .is_some_and(|machine| self.foreign_symbols.contains(machine))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -829,6 +841,7 @@ impl RetainedCharge for CfgRecord {
             .saturating_add(self.materialization_warnings.retained_charge())
             .saturating_add(self.warnings.retained_charge())
             .saturating_add(self.implicit_destructor_targets.retained_charge())
+            .saturating_add(self.implicit_drop_glue_targets.retained_charge())
     }
 }
 
@@ -1636,6 +1649,12 @@ fn build_cfg(
             ));
         }
     };
+    let implicit_destructor_dependencies_complete =
+        output.implicit_named_destructors.iter().all(|id| {
+            materialized
+                .aggregate_types
+                .contains_key(&rue_air::Type::new_struct(*id))
+        });
     let mut implicit_destructor_targets = output
         .implicit_named_destructors
         .iter()
@@ -1646,6 +1665,17 @@ fn build_cfg(
                 .cloned()
         })
         .collect::<std::collections::BTreeSet<_>>();
+    let implicit_drop_glue_dependencies_complete = output
+        .implicit_drop_glue_types
+        .iter()
+        .all(|ty| materialized.aggregate_types.contains_key(ty));
+    let implicit_drop_glue_targets = output
+        .implicit_drop_glue_types
+        .iter()
+        .filter_map(|ty| materialized.aggregate_types.get(ty).cloned())
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
     if let CfgSemanticInput::DropGlue { owner, facts, .. } = &key.semantic_input
         && facts.destructor.is_some()
     {
@@ -1682,7 +1712,10 @@ fn build_cfg(
             .into_iter()
             .collect::<Vec<_>>()
             .into(),
+        implicit_drop_glue_targets: implicit_drop_glue_targets.into(),
         implicit_destructor_dependencies_complete: materialized.completeness.is_complete()
+            && implicit_destructor_dependencies_complete
+            && implicit_drop_glue_dependencies_complete
             && !output.anonymous_destructor_dependency_incomplete,
         durable_reuse_allowed: true,
     }));
@@ -1732,6 +1765,11 @@ pub(crate) fn evaluate_optimized_cfg(
     let mut warnings = record.warnings.to_vec();
     let mut implicit_destructor_targets = record
         .implicit_destructor_targets
+        .iter()
+        .cloned()
+        .collect::<std::collections::BTreeSet<_>>();
+    let mut implicit_drop_glue_targets = record
+        .implicit_drop_glue_targets
         .iter()
         .cloned()
         .collect::<std::collections::BTreeSet<_>>();
@@ -1886,6 +1924,7 @@ pub(crate) fn evaluate_optimized_cfg(
             }
         }
         implicit_destructor_targets.extend(callee.implicit_destructor_targets.iter().cloned());
+        implicit_drop_glue_targets.extend(callee.implicit_drop_glue_targets.iter().cloned());
         implicit_destructor_dependencies_complete &=
             callee.implicit_destructor_dependencies_complete;
         let callee_value_base = current.value_count() as u32;
@@ -1950,6 +1989,10 @@ pub(crate) fn evaluate_optimized_cfg(
                 .into_iter()
                 .collect::<Vec<_>>()
                 .into(),
+            implicit_drop_glue_targets: implicit_drop_glue_targets
+                .into_iter()
+                .collect::<Vec<_>>()
+                .into(),
             implicit_destructor_dependencies_complete,
             durable_reuse_allowed: record.durable_reuse_allowed,
         },
@@ -1992,6 +2035,7 @@ fn optimize_cfg_without_accessors(
             body_span: record.body_span,
             warnings: record.warnings.clone(),
             implicit_destructor_targets: record.implicit_destructor_targets.clone(),
+            implicit_drop_glue_targets: record.implicit_drop_glue_targets.clone(),
             implicit_destructor_dependencies_complete: record
                 .implicit_destructor_dependencies_complete,
             durable_reuse_allowed: record.durable_reuse_allowed,
@@ -2008,9 +2052,11 @@ pub(crate) fn apply_general_inlining(
     context: &QueryContext,
     keys: &[OptimizedCfgQueryKey],
     values: &[CfgValue],
+    roots: &[crate::FunctionInstanceKey],
 ) -> Result<
     (
         Vec<CfgValue>,
+        std::collections::BTreeSet<crate::FunctionInstanceKey>,
         std::collections::BTreeSet<crate::FunctionInstanceKey>,
     ),
     QueryAbort,
@@ -2018,7 +2064,11 @@ pub(crate) fn apply_general_inlining(
     if keys.first().is_none_or(|key| {
         key.opt_level == rue_cfg::OptLevel::O0 || key.opt_level == rue_cfg::OptLevel::O1
     }) {
-        return Ok((values.to_vec(), std::collections::BTreeSet::new()));
+        return Ok((
+            values.to_vec(),
+            std::collections::BTreeSet::new(),
+            std::collections::BTreeSet::new(),
+        ));
     }
     context.check_canceled()?;
 
@@ -2036,7 +2086,11 @@ pub(crate) fn apply_general_inlining(
         })
         .collect::<Option<std::collections::BTreeMap<_, _>>>()
     else {
-        return Ok((values.to_vec(), std::collections::BTreeSet::new()));
+        return Ok((
+            values.to_vec(),
+            std::collections::BTreeSet::new(),
+            std::collections::BTreeSet::new(),
+        ));
     };
 
     // Membership in the batch is asked once per call instruction across every
@@ -2222,6 +2276,11 @@ pub(crate) fn apply_general_inlining(
             .iter()
             .cloned()
             .collect::<std::collections::BTreeSet<_>>();
+        let mut implicit_drop_glue_targets = record
+            .implicit_drop_glue_targets
+            .iter()
+            .cloned()
+            .collect::<std::collections::BTreeSet<_>>();
         let mut implicit_destructor_dependencies_complete =
             record.implicit_destructor_dependencies_complete;
         // Splices run against a plain `Cfg` and the batch is verified once,
@@ -2293,6 +2352,7 @@ pub(crate) fn apply_general_inlining(
             );
             foreign_symbols.extend(callee.codegen.foreign_symbols.iter().cloned());
             implicit_destructor_targets.extend(callee.implicit_destructor_targets.iter().cloned());
+            implicit_drop_glue_targets.extend(callee.implicit_drop_glue_targets.iter().cloned());
             implicit_destructor_dependencies_complete &=
                 callee.implicit_destructor_dependencies_complete;
             let call_block = current
@@ -2379,12 +2439,220 @@ pub(crate) fn apply_general_inlining(
                 .into_iter()
                 .collect::<Vec<_>>()
                 .into(),
+            implicit_drop_glue_targets: implicit_drop_glue_targets
+                .into_iter()
+                .collect::<Vec<_>>()
+                .into(),
             implicit_destructor_dependencies_complete,
             durable_reuse_allowed: false,
         }));
         changed.insert(function.clone());
     }
-    Ok((output, changed))
+    // Phase 5 consumes the post-inline CFGs produced above.  This is kept in
+    // the same batch so the call-site graph and the reachability result share
+    // one canonical domain projection and one deterministic function set.
+    let mut final_records = std::collections::BTreeMap::new();
+    for (key, value) in keys.iter().zip(output.iter()) {
+        if let CfgValue::Available(record) = value {
+            final_records.insert(key.cfg.function.clone(), record.clone());
+        }
+    }
+    let final_keys: ahash::AHashSet<_> = final_records.keys().cloned().collect();
+    let mut graph = std::collections::BTreeMap::<
+        crate::FunctionInstanceKey,
+        Vec<crate::FunctionInstanceKey>,
+    >::new();
+    let key_by_function = keys
+        .iter()
+        .map(|key| (key.cfg.function.clone(), key))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    let mut dependency_complete = true;
+    context.record_work(rue_query::WorkItem::new(
+        "cfg.general-reachability.functions",
+        final_records.len() as u64,
+    ));
+    for (function, record) in &final_records {
+        context.check_canceled()?;
+        if !record.implicit_destructor_dependencies_complete {
+            dependency_complete = false;
+        }
+        let mut dependencies = Vec::new();
+        for block in record.cfg.blocks() {
+            for &value in &block.insts {
+                let rue_cfg::CfgInstData::Call { runtime, name, .. } =
+                    record.cfg.get_inst(value).data
+                else {
+                    continue;
+                };
+                if runtime.is_some() {
+                    continue;
+                }
+                let edge = match record.domains.callable_for_symbol(name) {
+                    Some(callee) => {
+                        let in_batch = final_keys.contains(&callee);
+                        let foreign = record
+                            .codegen
+                            .is_foreign_source_symbol(record.interner.resolve(&name));
+                        classify_reachability_edge(Some(callee), in_batch, foreign, false)
+                    }
+                    None => classify_reachability_edge(
+                        None,
+                        false,
+                        false,
+                        record.domains.is_known_non_callable_symbol(name),
+                    ),
+                };
+                match edge {
+                    ReachabilityEdge::Internal(callee) => dependencies.push(callee),
+                    ReachabilityEdge::External => {}
+                    ReachabilityEdge::Incomplete => {
+                        // An opaque call or a resolved native Rue callable
+                        // missing from this batch makes dependency discovery
+                        // incomplete. Keep every unit rather than treating
+                        // that edge as dead.
+                        dependency_complete = false;
+                    }
+                }
+            }
+        }
+        for owner in record.implicit_destructor_targets.iter() {
+            let drop_glue = crate::FunctionInstanceKey::DropGlue(Node::new(owner.clone()));
+            if final_keys.contains(&drop_glue) {
+                dependencies.push(drop_glue);
+            } else {
+                // A named-destructor edge without its synthesized glue is an
+                // incomplete dependency projection. Keep the whole batch so
+                // an unavailable edge can never turn into removed code.
+                dependency_complete = false;
+            }
+        }
+        for owner in record.implicit_drop_glue_targets.iter() {
+            let drop_glue = crate::FunctionInstanceKey::DropGlue(Node::new(owner.clone()));
+            if final_keys.contains(&drop_glue) {
+                dependencies.push(drop_glue);
+            } else {
+                dependency_complete = false;
+            }
+        }
+        // Drop glue lowers destructor and nested-glue calls through `Drop`
+        // instructions, not ordinary CFG `Call` instructions. Preserve those
+        // implicit edges from the same typed drop-glue facts used to build the
+        // unit, so eliminating an uncalled-looking destructor cannot break a
+        // retained cleanup path.
+        if let Some(CfgSemanticInput::DropGlue { facts, .. }) = key_by_function
+            .get(function)
+            .map(|key| &key.cfg.semantic_input)
+        {
+            if let Some(destructor) = &facts.destructor {
+                if final_keys.contains(destructor) {
+                    dependencies.push(destructor.clone());
+                } else {
+                    dependency_complete = false;
+                }
+            }
+            for owner in facts.nested.iter() {
+                let nested = crate::FunctionInstanceKey::DropGlue(Node::new(owner.clone()));
+                if final_keys.contains(&nested) {
+                    dependencies.push(nested);
+                } else {
+                    dependency_complete = false;
+                }
+            }
+        }
+        dependencies.sort();
+        dependencies.dedup();
+        graph.insert(function.clone(), dependencies);
+    }
+
+    let removed =
+        whole_program_unreachable_checked(&graph, roots, &final_keys, dependency_complete, || {
+            context.check_canceled()
+        })?
+        .unwrap_or_default();
+    Ok((output, changed, removed))
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ReachabilityEdge<K> {
+    Internal(K),
+    External,
+    Incomplete,
+}
+
+/// Classify one scanned call edge before it enters the rooted graph. A
+/// resolved target-C callable is external by ABI contract; a resolved native
+/// callable absent from the batch is an incomplete projection and must fail
+/// closed.
+fn classify_reachability_edge<K>(
+    callee: Option<K>,
+    in_batch: bool,
+    foreign: bool,
+    known_non_callable: bool,
+) -> ReachabilityEdge<K> {
+    match callee {
+        Some(callee) if in_batch => ReachabilityEdge::Internal(callee),
+        Some(_) if foreign => ReachabilityEdge::External,
+        Some(_) => ReachabilityEdge::Incomplete,
+        None if known_non_callable => ReachabilityEdge::External,
+        None => ReachabilityEdge::Incomplete,
+    }
+}
+
+/// Compute the complement of the canonical rooted closure.  `None` means the
+/// graph is incomplete and callers must keep every unit; this explicit result
+/// prevents a missing edge from being mistaken for an unreachable function.
+#[cfg(test)]
+fn whole_program_unreachable<K: Clone + Ord + std::hash::Hash + Eq>(
+    graph: &std::collections::BTreeMap<K, Vec<K>>,
+    roots: &[K],
+    all_functions: &ahash::AHashSet<K>,
+    dependency_complete: bool,
+) -> Option<std::collections::BTreeSet<K>> {
+    match whole_program_unreachable_checked(
+        graph,
+        roots,
+        all_functions,
+        dependency_complete,
+        || Ok(()),
+    ) {
+        Ok(result) => result,
+        Err(_) => None,
+    }
+}
+
+fn whole_program_unreachable_checked<
+    K: Clone + Ord + std::hash::Hash + Eq,
+    F: FnMut() -> Result<(), QueryAbort>,
+>(
+    graph: &std::collections::BTreeMap<K, Vec<K>>,
+    roots: &[K],
+    all_functions: &ahash::AHashSet<K>,
+    dependency_complete: bool,
+    mut checkpoint: F,
+) -> Result<Option<std::collections::BTreeSet<K>>, QueryAbort> {
+    if !dependency_complete || roots.iter().any(|root| !all_functions.contains(root)) {
+        return Ok(None);
+    }
+    let mut reachable = std::collections::BTreeSet::new();
+    let mut pending = roots.to_vec();
+    pending.sort();
+    pending.dedup();
+    while let Some(function) = pending.pop() {
+        checkpoint()?;
+        if !reachable.insert(function.clone()) {
+            continue;
+        }
+        if let Some(dependencies) = graph.get(&function) {
+            pending.extend(dependencies.iter().cloned());
+        }
+    }
+    Ok(Some(
+        all_functions
+            .iter()
+            .filter(|function| !reachable.contains(*function))
+            .cloned()
+            .collect(),
+    ))
 }
 
 const PHASE2_VALUE_CAP: usize = 32;
@@ -2711,6 +2979,66 @@ mod accessor_graph_tests {
             assert_eq!(work.closure_edges, width);
             assert_eq!(output, (1..=width).collect::<Vec<_>>());
         }
+    }
+
+    #[test]
+    fn whole_program_reachability_is_ordered_and_fail_safe() {
+        let graph = std::collections::BTreeMap::from([
+            (1usize, vec![2]),
+            (2, vec![3]),
+            (3, vec![3]),
+            (4, Vec::new()),
+        ]);
+        let all = [1, 2, 3, 4].into_iter().collect();
+        assert_eq!(
+            whole_program_unreachable(&graph, &[1], &all, true),
+            Some(std::collections::BTreeSet::from([4]))
+        );
+        assert_eq!(whole_program_unreachable(&graph, &[1], &all, false), None);
+        assert_eq!(whole_program_unreachable(&graph, &[99], &all, true), None);
+        let mut checkpoints = 0;
+        assert!(matches!(
+            whole_program_unreachable_checked(&graph, &[1], &all, true, || {
+                checkpoints += 1;
+                (checkpoints < 2).then_some(()).ok_or(QueryAbort::Canceled)
+            }),
+            Err(QueryAbort::Canceled)
+        ));
+        assert_eq!(checkpoints, 2);
+    }
+
+    #[test]
+    fn reachability_scanner_classifies_foreign_and_missing_internal_edges() {
+        // Production domain construction rejects a missing live symbol before
+        // the batch scanner can publish it. Exercise the scanner seam directly
+        // for that fail-closed case while using the real codegen-domain foreign
+        // projection for the legitimate external case.
+        let foreign_domain = CfgCodegenDomain {
+            defined_symbol: Arc::from("caller"),
+            symbol_mappings: Arc::new(std::collections::BTreeMap::from([(
+                "foreign".to_owned(),
+                "ffi_symbol".to_owned(),
+            )])),
+            foreign_symbols: Arc::new(std::collections::BTreeSet::from(["ffi_symbol".to_owned()])),
+        };
+        assert!(foreign_domain.is_foreign_source_symbol("foreign"));
+        assert!(!foreign_domain.is_foreign_source_symbol("missing"));
+        assert_eq!(
+            classify_reachability_edge(Some(7usize), false, true, false),
+            ReachabilityEdge::External
+        );
+        assert_eq!(
+            classify_reachability_edge(Some(7usize), false, false, false),
+            ReachabilityEdge::Incomplete
+        );
+        assert_eq!(
+            classify_reachability_edge(None::<usize>, false, false, true),
+            ReachabilityEdge::External
+        );
+        assert_eq!(
+            classify_reachability_edge(Some(7usize), true, true, false),
+            ReachabilityEdge::Internal(7)
+        );
     }
 
     #[test]

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -722,6 +722,22 @@ impl CfgDomainProjection {
         }
     }
 
+    /// Whether this live symbol is explicitly a runtime or intrinsic symbol.
+    /// This is separate from [`Self::callable_for_symbol`], whose `None` also
+    /// covers malformed or absent canonical callable identities.
+    pub(crate) fn is_known_non_callable_symbol(&self, name: Spur) -> bool {
+        let position = self
+            .symbols
+            .partition_point(|(live, _)| live.into_usize() < name.into_usize());
+        self.symbols.get(position).is_some_and(|(live, stable)| {
+            *live == name
+                && matches!(
+                    stable,
+                    StableCfgSymbol::Runtime(_) | StableCfgSymbol::Intrinsic(_)
+                )
+        })
+    }
+
     pub(crate) fn stable_types(&self) -> impl Iterator<Item = &CanonicalType> {
         self.types.iter().map(|(_, stable)| stable)
     }

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -61,6 +61,7 @@ mod tests {
         let optimized_batch = crate::revisioned_query_database::OptimizedCfgBatchKey::new(
             Arc::from([optimized.clone()]),
             0,
+            Arc::from([]),
         );
         let codegen_batch = crate::revisioned_query_database::CodegenUnitBatchKey {
             keys: Arc::from([codegen.clone()]),
@@ -71,8 +72,8 @@ mod tests {
         assert_eq!(
             optimized_batch.stable_identity(),
             format!(
-                "optimized-cfg-batch;units=1\u{1e}{};generation=0",
-                optimized.shared_stable_identity()
+                "optimized-cfg-batch;units=1\u{1e}{};roots=[];generation=0",
+                optimized.shared_stable_identity(),
             )
         );
         assert_eq!(
@@ -2833,7 +2834,7 @@ mod tests {
                     .find(|unit| unit.record.codegen.defined_symbol.ends_with("main"))
                     .is_some_and(|unit| !unit.record.durable_reuse_allowed)
             );
-            assert!(output.cfgs.iter().any(|unit| matches!(
+            assert!(!output.cfgs.iter().any(|unit| matches!(
                 &unit.function,
                 FunctionInstanceKey::Definition(definition) if definition.name() == "add_one"
             )));
@@ -2844,8 +2845,10 @@ mod tests {
             assert!(session
                 .rooted_cfg_executions()
                 .iter()
-                .any(|(function, execution)| matches!(function, FunctionInstanceKey::Definition(definition) if definition.name() == "add_one")
-                    && matches!(execution, rue_query::RequestExecution::Reused | rue_query::RequestExecution::Joined)));
+                .any(|(function, execution)| {
+                matches!(function, FunctionInstanceKey::Definition(definition) if definition.name() == "add_one")
+                    && matches!(execution, rue_query::RequestExecution::Reused | rue_query::RequestExecution::Joined)
+            }));
         }
     }
 
@@ -2861,30 +2864,225 @@ mod tests {
             .update_for_presentation(&snapshot)
             .into_result()
             .unwrap();
-        let output = session
-            .rooted_cfg(&CompileOptions {
-                opt_level: rue_cfg::OptLevel::O2,
+        for opt_level in [rue_cfg::OptLevel::O2, rue_cfg::OptLevel::O3] {
+            let options = CompileOptions {
+                opt_level,
                 ..CompileOptions::default()
-            })
+            };
+            let output = session
+                .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+                .unwrap();
+            assert!(
+                !output.objects.is_empty(),
+                "linked backend objects at {opt_level:?}"
+            );
+            assert!(
+                output.units.iter().any(|unit| matches!(
+                    &unit.function,
+                    FunctionInstanceKey::Definition(definition) if definition.name() == "next"
+                )),
+                "reachable method must retain a standalone codegen unit at {opt_level:?}"
+            );
+            let main = output
+                .cfgs
+                .iter()
+                .find(|unit| unit.record.codegen.defined_symbol.ends_with("main"))
+                .unwrap();
+            assert!(main.record.durable_reuse_allowed);
+            assert!(
+                main.record
+                    .cfg
+                    .blocks()
+                    .iter()
+                    .flat_map(|block| block.insts.iter())
+                    .any(|value| matches!(
+                        main.record.cfg.get_inst(*value).data,
+                        rue_cfg::CfgInstData::Call { .. }
+                    ))
+            );
+            let linked =
+                crate::queries::compile_with_session(&mut session, &snapshot, &options).unwrap();
+            assert!(
+                !linked.elf.is_empty(),
+                "method-containing image at {opt_level:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn phase5_accessor_splice_reaches_backend_and_linker() {
+        let snapshot = SourceSnapshot::single(
+            "<phase5-accessor-backend>",
+            "struct Point { value: i32, fn read(borrow self) -> borrow i32 { yield self.value; } } fn main() -> i32 { let point = Point { value: 7 }; @dbg(point.read()); 0 }",
+        )
+        .unwrap();
+        let mut session = CompilerSession::new();
+        session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+        for opt_level in [rue_cfg::OptLevel::O2, rue_cfg::OptLevel::O3] {
+            let options = CompileOptions {
+                opt_level,
+                ..CompileOptions::default()
+            };
+            let output = session
+                .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+                .unwrap();
+            let main = output
+                .cfgs
+                .iter()
+                .find(|unit| unit.record.codegen.defined_symbol.ends_with("main"))
+                .expect("main reaches the backend");
+            assert!(
+                !main.optimized_cfg_key.accessor_dependencies.is_empty(),
+                "the accessor's raw CFG dependency must remain attached at {opt_level:?}"
+            );
+            assert!(
+                output.units.iter().any(|unit| matches!(
+                    &unit.function,
+                    FunctionInstanceKey::Definition(definition) if definition.name() == "main"
+                )),
+                "the spliced caller must reach codegen at {opt_level:?}"
+            );
+            assert!(
+                !output.units.iter().any(|unit| matches!(
+                    &unit.function,
+                    FunctionInstanceKey::Definition(definition) if definition.name() == "read"
+                )),
+                "mandatory accessors have no standalone ABI unit at {opt_level:?}"
+            );
+            let linked =
+                crate::queries::compile_with_session(&mut session, &snapshot, &options).unwrap();
+            assert!(
+                !linked.elf.is_empty(),
+                "accessor-containing image at {opt_level:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn phase5_nested_drop_glue_reaches_backend_and_linker() {
+        let snapshot = SourceSnapshot::single(
+            "<phase5-nested-drop-glue>",
+            "struct Inner { value: i32 } drop fn Inner(self) { @dbg(self.value); } struct Outer { inner: Inner } drop fn Outer(self) { @dbg(self.inner.value); } fn main() -> i32 { let outer = Outer { inner: Inner { value: 7 } }; 0 }",
+        )
+        .unwrap();
+        let mut session = CompilerSession::new();
+        session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+        for opt_level in [rue_cfg::OptLevel::O2, rue_cfg::OptLevel::O3] {
+            let options = CompileOptions {
+                opt_level,
+                ..CompileOptions::default()
+            };
+            let output = session
+                .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+                .unwrap();
+            let drop_glue_units = output
+                .units
+                .iter()
+                .filter(|unit| matches!(unit.function, FunctionInstanceKey::DropGlue(_)))
+                .count();
+            assert!(
+                drop_glue_units >= 2,
+                "nested aggregate cleanup must retain both glue units at {opt_level:?}: {drop_glue_units}"
+            );
+            let linked =
+                crate::queries::compile_with_session(&mut session, &snapshot, &options).unwrap();
+            assert!(
+                !linked.elf.is_empty(),
+                "nested cleanup image at {opt_level:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn phase5_retains_wrapper_drop_glue_implicit_edge() {
+        let snapshot = SourceSnapshot::single(
+            "<phase5-wrapper-drop-glue>",
+            "struct D { value: i32 } drop fn D(self) { @dbg(self.value); } fn main() -> i32 { let _items: [D; 2] = [D { value: 1 }, D { value: 2 }]; 0 }",
+        )
+        .unwrap();
+        let mut session = CompilerSession::new();
+        session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+        let options = CompileOptions {
+            opt_level: rue_cfg::OptLevel::O2,
+            ..CompileOptions::default()
+        };
+        let output = session
+            .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
             .unwrap();
         let main = output
             .cfgs
             .iter()
-            .find(|unit| unit.record.codegen.defined_symbol.ends_with("main"))
-            .unwrap();
-        assert!(main.record.durable_reuse_allowed);
+            .find(|unit| unit.record.codegen.defined_symbol.as_ref() == "main")
+            .expect("main reaches the backend");
         assert!(
             main.record
+                .implicit_drop_glue_targets
+                .iter()
+                .any(|target| matches!(target, crate::TypeInstanceKey::Array { .. })),
+            "wrapper array drop glue must be an explicit reachability edge"
+        );
+        assert!(
+            output.units.iter().any(|unit| {
+                matches!(unit.function, FunctionInstanceKey::DropGlue(ref owner)
+                    if matches!(owner.as_ref(), crate::TypeInstanceKey::Array { .. }))
+            }),
+            "the wrapper drop-glue unit must survive DFE"
+        );
+    }
+
+    #[test]
+    fn phase5_keeps_exported_and_recursive_functions_reachable() {
+        let snapshot = SourceSnapshot::single(
+            "<phase5-roots>",
+            "pub extern \"C\" fn exported() -> i32 { 7 } fn recurse(n: i32) -> i32 { if n == 0 { 0 } else { recurse(n - 1) } } fn main() -> i32 { recurse(1) }",
+        )
+        .unwrap();
+        let mut session = CompilerSession::new();
+        session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+        let output = session
+            .rooted_cfg(&CompileOptions {
+                opt_level: rue_cfg::OptLevel::O2,
+                preview_features: PreviewFeatures::from([PreviewFeature::CFfi]),
+                ..CompileOptions::default()
+            })
+            .unwrap();
+        assert!(output.cfgs.iter().any(|unit| matches!(
+            &unit.function,
+            FunctionInstanceKey::Definition(definition) if definition.name() == "exported"
+        )));
+        let recurse = output
+            .cfgs
+            .iter()
+            .find(|unit| {
+                matches!(
+                    &unit.function,
+                    FunctionInstanceKey::Definition(definition) if definition.name() == "recurse"
+                )
+            })
+            .expect("the rooted recursive function remains in the program image");
+        assert!(
+            recurse
+                .record
                 .cfg
                 .blocks()
                 .iter()
                 .flat_map(|block| block.insts.iter())
-                .any(|value| {
-                    matches!(
-                        main.record.cfg.get_inst(*value).data,
-                        rue_cfg::CfgInstData::Call { .. }
-                    )
-                })
+                .any(|value| matches!(
+                    recurse.record.cfg.get_inst(*value).data,
+                    rue_cfg::CfgInstData::Call { .. }
+                ))
         );
     }
 
@@ -2938,10 +3136,48 @@ mod tests {
             .unwrap();
         assert_eq!(call_count(&o2), 0);
         assert!(!o2.cfgs.iter().find(|unit| matches!(&unit.function, FunctionInstanceKey::Definition(definition) if definition.name() == "main")).unwrap().record.durable_reuse_allowed);
-        assert!(o2.cfgs.iter().any(|unit| matches!(
+        assert!(!o2.cfgs.iter().any(|unit| matches!(
             &unit.function,
             FunctionInstanceKey::Definition(definition) if definition.name() == "consume"
         )));
+    }
+
+    #[test]
+    fn phase5_inlined_callee_preserves_wrapper_drop_glue() {
+        let snapshot = SourceSnapshot::single(
+            "<phase5-inlined-wrapper-drop-glue>",
+            "struct D { value: i32 } drop fn D(self) { @dbg(self.value); } fn consume(_items: [D; 1]) -> i32 { 0 } fn main() -> i32 { consume([D { value: 1 }]) }",
+        )
+        .unwrap();
+        let mut session = CompilerSession::new();
+        session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+        let options = CompileOptions {
+            opt_level: rue_cfg::OptLevel::O2,
+            ..CompileOptions::default()
+        };
+        let output = session
+            .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+            .unwrap();
+        assert!(
+            !output.cfgs.iter().any(|unit| matches!(
+                &unit.function,
+                FunctionInstanceKey::Definition(definition) if definition.name() == "consume"
+            )),
+            "the single-use callee should be removed after inlining"
+        );
+        assert!(
+            output.units.iter().any(|unit| {
+                matches!(unit.function, FunctionInstanceKey::DropGlue(ref owner)
+                    if matches!(owner.as_ref(), crate::TypeInstanceKey::Array { .. }))
+            }),
+            "the inlined callee's wrapper drop glue must remain reachable"
+        );
+        let linked = crate::queries::compile_with_session(&mut session, &snapshot, &options)
+            .expect("inlined wrapper cleanup must link");
+        assert!(!linked.elf.is_empty());
     }
 
     #[test]
@@ -2967,6 +3203,9 @@ mod tests {
             let first = session
                 .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
                 .unwrap();
+            let root = session.backend_root_metrics();
+            assert_eq!(root.functions, 0, "{target}: {root:?}");
+            assert_eq!(root.optimized_cfg_terminals, 1, "{target}: {root:?}");
             let main_cfg = first
                 .cfgs
                 .iter()
@@ -2990,20 +3229,19 @@ mod tests {
                 .iter()
                 .find(|unit| matches!(&unit.function, FunctionInstanceKey::Definition(definition) if definition.name() == "main"))
                 .unwrap();
-            let callee_unit = first
-                .units
-                .iter()
-                .find(|unit| matches!(&unit.function, FunctionInstanceKey::Definition(definition) if definition.name() == "add_one"))
-                .unwrap();
             assert!(
                 main_unit
                     .unit
                     .relocations
                     .iter()
-                    .all(|relocation| relocation.symbol != callee_unit.unit.defined_symbol),
+                    .all(|relocation| !relocation.symbol.contains("add_one")),
                 "the {target} caller must not retain a relocation to its inlined callee: {:?}",
                 main_unit.unit.relocations
             );
+            assert!(!first.units.iter().any(|unit| matches!(
+                &unit.function,
+                FunctionInstanceKey::Definition(definition) if definition.name() == "add_one"
+            )));
 
             session
                 .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
@@ -3013,9 +3251,8 @@ mod tests {
                 matches!(function, FunctionInstanceKey::Definition(definition) if definition.name() == "main")
                     && *execution == rue_query::RequestExecution::Computed
             }), "{target}: {executions:?}");
-            assert!(executions.iter().any(|(function, execution)| {
+            assert!(!executions.iter().any(|(function, _execution)| {
                 matches!(function, FunctionInstanceKey::Definition(definition) if definition.name() == "add_one")
-                    && matches!(execution, rue_query::RequestExecution::Reused | rue_query::RequestExecution::Joined)
             }), "{target}: {executions:?}");
         }
     }
@@ -3032,6 +3269,49 @@ mod tests {
         assert_eq!(output.warnings.len(), 1);
         assert!(output.warnings[0].to_string().contains("unused variable"));
         assert!(output.warnings[0].to_string().contains("'x'"));
+    }
+
+    #[test]
+    fn optimized_inlined_callee_warnings_match_o0() {
+        let snapshot = SourceSnapshot::single(
+            "<optimized-callee-warning>",
+            "fn warned() -> i32 { return 42; 0 } fn main() -> i32 { warned() }",
+        )
+        .unwrap();
+        let mut session = CompilerSession::new();
+        session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+
+        let mut expected = None;
+        for opt_level in [
+            rue_cfg::OptLevel::O0,
+            rue_cfg::OptLevel::O2,
+            rue_cfg::OptLevel::O3,
+        ] {
+            let output = session
+                .rooted_cfg(&CompileOptions {
+                    opt_level,
+                    ..CompileOptions::default()
+                })
+                .unwrap();
+            assert_eq!(
+                output.warnings.len(),
+                1,
+                "{opt_level:?}: {:?}",
+                output.warnings
+            );
+            assert!(output.warnings[0].to_string().contains("unreachable"));
+            if let Some(expected) = &expected {
+                assert_eq!(
+                    &output.warnings, expected,
+                    "warning parity at {opt_level:?}"
+                );
+            } else {
+                expected = Some(output.warnings.clone());
+            }
+        }
     }
 
     #[test]

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -1426,6 +1426,11 @@ pub(crate) struct BackendRootCandidate {
 #[derive(Debug, Clone)]
 pub(crate) struct OptimizedCfgBatchKey {
     pub(crate) keys: Arc<[crate::cfg_query::OptimizedCfgQueryKey]>,
+    /// Roots supplied by the canonical body closure.  Whole-program CFG
+    /// reachability must use the same roots as semantic body discovery,
+    /// including C-ABI exports, rather than inferring ownership from a CFG
+    /// body's presentation fields.
+    pub(crate) roots: Arc<[crate::FunctionInstanceKey]>,
     /// O2/O3 batches are request-local because their values may contain
     /// rewritten callers. Child CFG terminals remain reusable; this token
     /// prevents a rewritten whole-program result crossing request boundaries.
@@ -1447,17 +1452,20 @@ impl OptimizedCfgBatchKey {
     pub(crate) fn new(
         keys: Arc<[crate::cfg_query::OptimizedCfgQueryKey]>,
         generation: u64,
+        roots: Arc<[crate::FunctionInstanceKey]>,
     ) -> Self {
         let mut hasher = rue_query::StableHasher::new();
         hasher.write_usize(keys.len());
         for key in keys.iter() {
             key.stable_hash(&mut hasher);
         }
+        roots.hash(&mut hasher);
         generation.hash(&mut hasher);
         let digest = hasher.finish128();
         let memo_hash = hasher.finish();
         Self {
             keys,
+            roots,
             generation,
             digest,
             memo_hash,
@@ -1469,6 +1477,7 @@ impl PartialEq for OptimizedCfgBatchKey {
     fn eq(&self, other: &Self) -> bool {
         self.generation == other.generation
             && (Arc::ptr_eq(&self.keys, &other.keys) || self.keys == other.keys)
+            && (Arc::ptr_eq(&self.roots, &other.roots) || self.roots == other.roots)
     }
 }
 
@@ -1488,6 +1497,7 @@ impl QueryKey for OptimizedCfgBatchKey {
             identity.push('\u{1e}');
             identity.push_str(&key.shared_stable_identity());
         }
+        identity.push_str(&format!(";roots={:?}", self.roots));
         identity.push_str(&format!(";generation={}", self.generation));
         identity
     }
@@ -1510,6 +1520,10 @@ pub(crate) struct OptimizedCfgBatchOutput {
     /// and pin these records for codegen; the request-local batch generation
     /// ensures no successor can reuse that whole-program result.
     pub(crate) non_reusable_functions: Arc<[crate::FunctionInstanceKey]>,
+    /// Functions absent from the post-inline whole-program reachability
+    /// closure.  The batch retains value/key alignment; rooted backend
+    /// consumers filter these identities before making codegen requests.
+    pub(crate) unreachable_functions: Arc<[crate::FunctionInstanceKey]>,
     /// Exact child leases acquired while the rooted batch evaluator still owns
     /// every request lease. The memoized root encapsulates these pins so
     /// retaining it also retains the scheduled children through publication.
@@ -15082,6 +15096,7 @@ impl RevisionedQueryDatabase {
                             .zip(right.values.iter())
                             .all(|(left, right)| crate::cfg_query::cfg_value_equal(left, right))
                         && left.non_reusable_functions == right.non_reusable_functions
+                        && left.unreachable_functions == right.unreachable_functions
                 },
                 move |context, _, key: &OptimizedCfgBatchKey| {
                     let fallbacks = backend_retention_fallbacks(
@@ -15111,8 +15126,13 @@ impl RevisionedQueryDatabase {
                             value.clone()
                         })
                         .collect::<Vec<_>>();
-                    let (values, non_reusable_functions) =
-                        crate::cfg_query::apply_general_inlining(context, key.keys.as_ref(), &values)?;
+                    let (values, non_reusable_functions, unreachable_functions) =
+                        crate::cfg_query::apply_general_inlining(
+                            context,
+                            key.keys.as_ref(),
+                            &values,
+                            key.roots.as_ref(),
+                        )?;
                     let kind = if values.iter().all(|value| matches!(value, crate::cfg_query::CfgValue::Available(_))) {
                         QueryTerminalKind::Success
                     } else {
@@ -15120,9 +15140,13 @@ impl RevisionedQueryDatabase {
                     };
                     let retained_terminals = terminals
                         .iter()
+                        .zip(key.keys.iter())
                         .zip(values.iter())
-                        .filter(|(_, value)| matches!(value, crate::cfg_query::CfgValue::Available(record) if record.durable_reuse_allowed))
-                        .map(|(terminal, _)| terminal.clone())
+                        .filter(|((_, key), value)| {
+                            !unreachable_functions.contains(&key.cfg.function)
+                                && matches!(value, crate::cfg_query::CfgValue::Available(record) if record.durable_reuse_allowed)
+                        })
+                        .map(|((terminal, _), _)| terminal.clone())
                         .collect::<Vec<_>>();
                     let retained_children = Arc::new(
                         context
@@ -15133,6 +15157,7 @@ impl RevisionedQueryDatabase {
                     Ok(QueryOutput::success(OptimizedCfgBatchOutput {
                         values,
                         non_reusable_functions: non_reusable_functions.into_iter().collect::<Vec<_>>().into(),
+                        unreachable_functions: unreachable_functions.into_iter().collect::<Vec<_>>().into(),
                         _retained_children: retained_children,
                     })
                     .with_terminal_kind(kind))
@@ -17263,6 +17288,7 @@ impl RevisionedQueryDatabase {
         &self,
         revision: Revision,
         keys: Arc<[crate::cfg_query::OptimizedCfgQueryKey]>,
+        roots: Arc<[crate::FunctionInstanceKey]>,
         cancellation: CancellationToken,
     ) -> (
         OptimizedCfgBatchKey,
@@ -17277,7 +17303,7 @@ impl RevisionedQueryDatabase {
         } else {
             0
         };
-        let key = OptimizedCfgBatchKey::new(keys, generation);
+        let key = OptimizedCfgBatchKey::new(keys, generation, roots);
         let attempt = self.runtime.request_registered(
             &self.optimized_cfg_batches,
             revision,
@@ -17399,18 +17425,26 @@ impl RevisionedQueryDatabase {
             .pin_terminal(terminal)
             .expect("optimized-CFG batch result belongs to the registered family");
         candidate.lease.lease(pin);
-        let non_reusable = match terminal.outcome() {
-            rue_query::QueryOutcome::Success(output) => output
-                .non_reusable_functions
-                .iter()
-                .collect::<std::collections::BTreeSet<_>>(),
-            rue_query::QueryOutcome::Failure(_) => std::collections::BTreeSet::new(),
+        let (non_reusable, unreachable) = match terminal.outcome() {
+            rue_query::QueryOutcome::Success(output) => (
+                output
+                    .non_reusable_functions
+                    .iter()
+                    .collect::<std::collections::BTreeSet<_>>(),
+                output
+                    .unreachable_functions
+                    .iter()
+                    .collect::<std::collections::BTreeSet<_>>(),
+            ),
+            rue_query::QueryOutcome::Failure(_) => (
+                std::collections::BTreeSet::new(),
+                std::collections::BTreeSet::new(),
+            ),
         };
-        for optimized in key
-            .keys
-            .iter()
-            .filter(|optimized| !non_reusable.contains(&optimized.cfg.function))
-        {
+        for optimized in key.keys.iter().filter(|optimized| {
+            !non_reusable.contains(&optimized.cfg.function)
+                && !unreachable.contains(&optimized.cfg.function)
+        }) {
             for cfg_key in
                 std::iter::once(&optimized.cfg).chain(optimized.accessor_dependencies.iter())
             {
@@ -17418,7 +17452,11 @@ impl RevisionedQueryDatabase {
             }
             candidate.functions.insert(optimized.cfg.function.clone());
         }
-        candidate.optimized_cfg_terminals = key.keys.len();
+        candidate.optimized_cfg_terminals = key
+            .keys
+            .iter()
+            .filter(|optimized| !unreachable.contains(&optimized.cfg.function))
+            .count();
     }
 
     /// Retain the registered CodegenUnit batch from result birth until the

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -5438,6 +5438,18 @@ impl CompilerSession {
         let (cfg_batch_key, attempt) = self.queries.revisioned.optimized_cfg_batch(
             graph.revision,
             optimized_keys,
+            std::iter::once(crate::FunctionInstanceKey::Definition(graph.main.clone()))
+                .chain(
+                    graph
+                        .c_export_roots
+                        .iter()
+                        .cloned()
+                        .map(crate::FunctionInstanceKey::Definition),
+                )
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>()
+                .into(),
             cancellation,
         );
         let batch_execution = attempt.execution();
@@ -5533,6 +5545,7 @@ impl CompilerSession {
             unreachable!("OptimizedCfgBatch publishes typed values")
         };
         assert_eq!(batch.values.len(), cfg_requests.len());
+        let unreachable_functions = batch.unreachable_functions.iter().collect::<BTreeSet<_>>();
         for (((function, optimized_cfg_key, body_span), value), _execution) in cfg_requests
             .into_iter()
             .zip(batch.values.iter())
@@ -5585,6 +5598,12 @@ impl CompilerSession {
                 record.body_span,
                 body_span,
             ));
+            // Reachability only controls backend publication. Diagnostics and
+            // completed-work accounting belong to every successfully queried
+            // body, including a callee removed after inlining.
+            if unreachable_functions.contains(&function) {
+                continue;
+            }
             cfgs.push(RootedCfgUnit {
                 function,
                 optimized_cfg_key,

--- a/docs/designs/0044-optimization-levels.md
+++ b/docs/designs/0044-optimization-levels.md
@@ -33,8 +33,8 @@ as separate Linear issues.
 
 Rue exposes the conventional `-O0`/`-O1`/`-O2`/`-O3` optimization levels. This
 ADR fixes what each level *promises* to a user (its cost/benefit contract) and
-which passes populate it, so that `-O2` and `-O3` stop being undefined
-placeholders that silently alias `-O1`. The single non-negotiable rule across
+which passes populate it, so that each level has an explicit current contract
+and future additions have a documented home. The single non-negotiable rule across
 every level is the **observable-behavior invariant**: for any program with
 defined behavior, exit code and I/O are byte-for-byte identical at `-O0`,
 `-O1`, `-O2`, and `-O3`. Levels may trade compile time, code size, and run time
@@ -53,15 +53,16 @@ but the mapping is:
 |-------|------------------|
 | `-O0` | Nothing. CFG passes straight to lowering (plus the always-on structural `verify()`). |
 | `-O1` | Constant folding ⇄ store-to-load constant propagation to a fixpoint, then dead-code elimination. |
-| `-O2` | **Aliases `-O1`.** |
-| `-O3` | **Aliases `-O1`.** |
+| `-O2` | `-O1` plus the conservative whole-program free-function inlining batch (RUE-930) and Phase 5 reachability elimination (RUE-933). |
+| `-O3` | `-O2` plus trap-free LICM (RUE-927) and bounded constant-trip unrolling (RUE-928); broader inlining thresholds and guarded hoisting remain planned. |
 
-So the only behavioral fork is `-O0` vs `-O1+`; `-O2`/`-O3` are reserved names
-with no distinct meaning. RUE-245 asks us to *deliberately decide* what belongs
-at each level rather than leave the top two as accidental synonyms — both so
-users get the contract they expect from `-O` flags, and so that when we do add
-inlining / CSE / peephole / loop passes, there is already a documented home for
-each.
+The levels now have distinct behavior: `-O2`/`-O3` run the compiler's
+conservative whole-program inlining and reachability batch, and `-O3` adds the
+landed LICM and constant-trip unrolling passes. Broader inlining thresholds and
+guarded hoisting remain future work. RUE-245 asks us to *deliberately decide*
+what belongs at each level rather than leave the top two as accidental
+synonyms — both so users get the contract they expect from `-O` flags, and so
+that further passes already have a documented home.
 
 ### The current pipeline (ground truth)
 
@@ -70,7 +71,7 @@ CFG → CFG transforms between CFG construction and MIR lowering. `optimize()` i
 the single choke point every build funnels through:
 
 ```
-AIR -> CfgBuilder -> CFG -> [opt::optimize(level)] -> CfgLower -> MIR -> RegAlloc -> Emit
+AIR -> CfgBuilder -> CFG -> [opt::optimize(level)] -> [whole-program inlining/reachability at -O2/-O3] -> CfgLower -> MIR -> RegAlloc -> Emit
 ```
 
 The passes that exist:
@@ -93,12 +94,11 @@ correctness check, not an optimization, so it is outside the level contract.
 The RUE-236 differential-opt harness (landed, PR #1092) runs a marked subset of
 CLI cases across `["-O0", "-O1", "-O2", "-O3"]` and asserts identical exit code
 and stdout at every level (`run_case_differential` in
-`crates/rue-cli-tests/src/main.rs`, gated by `differential_opt = true`). It was
-deliberately set up *now*, while `-O2`/`-O3` still alias `-O1`, so the results
-already match and any future divergence a new pass introduces is caught the
-moment it appears. The `rue-cfg` review exercised exactly this net when it
-caught the RUE-348 enum-fold miscompile. With that net in place, we can safely
-start populating the higher levels.
+`crates/rue-cli-tests/src/main.rs`, gated by `differential_opt = true`). The
+harness was established before the higher levels had distinct passes; it now
+guards the live O2/O3 inlining and reachability batch as well as the local
+transforms. The `rue-cfg` review exercised exactly this net when it caught the
+RUE-348 enum-fold miscompile.
 
 ## Prior art: how mainstream compilers assign passes to levels
 
@@ -203,8 +203,8 @@ shapes each new pass targets (see Sequencing).
 |-------|----------|----------------|-----------------------|
 | `-O0` | No optimization. Codegen tracks source; fastest compile; best debugging. **Default.** | none (only always-on `verify()`) | stays empty |
 | `-O1` | Cheap, always-safe, compile-time-neutral-or-positive local cleanups. | sparse constfold/constprop (RUE-794) → peephole (RUE-912) → simplify-cfg (RUE-910/911) → DCE | complete for now |
-| `-O2` | **Release default.** All balanced optimizations that reliably help without a size blow-up. Superset of `-O1`. | `-O1` + copy propagation / store-to-load forwarding (RUE-914) → block-local CSE (RUE-913) | + conservative inlining (small/leaf fns); wider GVN; better regalloc |
-| `-O3` | `-O2` plus speculative, size-spending, speed-chasing transforms. Superset of `-O2`. | = `-O2` today | + aggressive inlining (RUE-915, pending); loop opts (LICM, unrolling); later, vectorization |
+| `-O2` | **Release default.** All balanced optimizations that reliably help without a size blow-up. Superset of `-O1`. | `-O1` + copy propagation / store-to-load forwarding (RUE-914) → block-local CSE (RUE-913) → conservative whole-program inlining and Phase 5 reachability (RUE-930, RUE-933) | wider GVN; better regalloc |
+| `-O3` | `-O2` plus speculative, size-spending, speed-chasing transforms. Superset of `-O2`. | current O2 batch + trap-free LICM (RUE-927) + bounded constant-trip unrolling (RUE-928) | aggressive inlining; guarded trapping-op hoisting (RUE-934); later, vectorization |
 
 Rules that make the table a *contract* rather than a wishlist:
 
@@ -221,15 +221,12 @@ Rules that make the table a *contract* rather than a wishlist:
 
 ### How current passes map
 
-The passes that exist (`constfold`, `constprop`, `dce`) are exactly the "cheap,
-always-safe, local" set, so they belong at **`-O1`**, which is where they run
-today. **No code change is required to adopt this ADR**: the present behavior is
-already the correct `-O1` content, and `-O2`/`-O3` legitimately *alias* `-O1`
-until a genuinely `-O2`-class pass exists. Aliasing is the honest state when a
-level has no distinct content yet — it is not a bug, and the differential
-harness confirms the three levels agree. The `mod.rs` doc comment and the
-`OptLevel` variant docs already describe this; they stay accurate under this
-ADR.
+The local passes (`constfold`, `constprop`, `dce`) remain the cheap,
+always-safe set at **`-O1`**. O2/O3 also run the canonical whole-program batch
+owned by `rue-compiler`, which performs conservative free-function inlining and
+post-inline reachability elimination while preserving O0/O1 source-faithful
+behavior. Broader O3 thresholds remain planned; the `mod.rs` level knob and
+these phase-specific additions are the current architecture.
 
 ### How plausible future passes map
 
@@ -271,22 +268,22 @@ than inventing a parallel flag, so there is one dial for the whole pipeline.
 
 ## Implementation Phases
 
-This ADR is the plan; the phases below are *tracking placeholders* to be filed
-as Linear issues under RUE-245. **This ADR implements none of them.**
+This ADR remains the plan for future phases; the checklist records which
+phase-specific pieces are implemented in the current compiler.
 
 - [x] **Phase 0: Differential net** — RUE-236 (done; PR #1092). Prerequisite.
 - [x] **Phase 1: Define the contract** — this ADR (RUE-245).
 - [x] **Phase 2: `-O1` completions** — peephole/strength-reduction + simplify-cfg,
   added at `-O1` with differential coverage. (RUE-910, RUE-911, RUE-912; merged
   2026-07-16)
-- [ ] **Phase 3: `-O2` content** — CSE/GVN, copy prop, conservative inlining;
-  `-O2` stops aliasing `-O1`. Partial: block-local CSE (RUE-913) and copy
-  propagation / store-to-load forwarding (RUE-914, which also keys never-written
-  parameter reads in CSE and lands the shared dominator-tree infrastructure for
-  later LICM/GVN) have landed, so `-O2` no longer aliases `-O1`; conservative
-  inlining (RUE-915) still pending. (file RUE-NNN)
-- [ ] **Phase 4: `-O3` content** — aggressive inlining + loop opts; `-O3` stops
-  aliasing `-O2`. (file RUE-NNN)
+- [ ] **Phase 3: `-O2` content** — CSE/GVN, copy prop, and conservative
+  inlining. Partial: block-local CSE (RUE-913), copy propagation /
+  store-to-load forwarding (RUE-914), and conservative whole-program inlining
+  plus Phase 5 reachability (RUE-930, RUE-933) have landed; broader GVN and
+  other O2 tuning remain. (file RUE-NNN)
+- [ ] **Phase 4: `-O3` content** — partial: trap-free LICM (RUE-927) and bounded
+  constant-trip unrolling (RUE-928) have landed; aggressive inlining and guarded
+  trapping-op hoisting (RUE-934) remain. (file RUE-NNN)
 - [ ] **Phase 5 (optional): size levels** — `-Os`/`-Oz` if a size-sensitive
   target (WASM/embedded) materializes. (file RUE-NNN)
 
@@ -298,14 +295,15 @@ shapes the pass rewrites, and (c) keep the full differential set green.
 
 ### Positive
 
-- **`-O2`/`-O3` gain defined meaning** instead of being accidental `-O1`
-  synonyms; users get the `-O` contract they expect from GCC/Clang/rustc.
+- **`-O2`/`-O3` have an explicit current contract** and a documented path for
+  broader future optimization; users get the `-O` contract they expect from
+  GCC/Clang/rustc.
 - **Every future pass has a documented home** decided by a consistent cost/risk
   rule, so pass placement is not re-litigated case by case.
 - **The invariant is explicit and enforced**, making "optimization" vs
   "miscompile" a bright line the differential harness already polices.
-- **Zero code churn to adopt**: today's behavior is already the correct `-O1`,
-  and aliasing is the honest state for empty upper levels.
+- **Incremental level evolution**: the differential net and phase checklist
+  make each O2/O3 addition explicit while preserving the O0 baseline.
 
 ### Negative
 

--- a/docs/designs/0049-function-inlining.md
+++ b/docs/designs/0049-function-inlining.md
@@ -23,9 +23,11 @@ Accepted on 2026-07-16, closing the RUE-915 design issue and filing the phase
 issues below. Phase 1 shipped in July 2026: the CFG splice primitive landed
 with RUE-929 (`crates/rue-cfg/src/inline.rs`) and is consumed today by the
 compiler's mandatory accessor splices
-(`crates/rue-compiler/src/cfg_query.rs`). The inlining driver phases (RUE-930
-through RUE-933) and the method/destructor extension remain tracked and
-unimplemented, so no general `-O2`/`-O3` inlining runs yet.
+(`crates/rue-compiler/src/cfg_query.rs`). RUE-930's conservative whole-program
+`-O2`/`-O3` free-function inlining batch is implemented in
+`crates/rue-compiler/src/cfg_query.rs`; this implementation also completes the
+accepted Phase 5 reachability step in that same batch. Phase 3/4 and the
+method/destructor extension remain tracked separately.
 
 This note analyzes the architecture of function inlining and records the
 accepted direction. ADR-0044 already fixed the *level*
@@ -604,7 +606,7 @@ already synthesized.
   to simple local/parameter roots), callee-lifetime storage + copied
   parameter-drop handling (§3), and return→block-param wiring. Unit-tested in
   `rue-cfg`. (landed, RUE-929, July 2026)
-- [ ] **Phase 2: Free-function driver at `-O2`** — two-phase construction; build
+- [x] **Phase 2: Free-function driver at `-O2`** — two-phase construction; build
   the call-site graph by CFG scan (§5); conservative leaf/small thresholds;
   single-call-site inlining *without* callee removal; recursion refusal via
   call-site SCC; differential CLI coverage. Inlined callers are **not cached
@@ -614,9 +616,12 @@ already synthesized.
 - [ ] **Phase 4: Durable cache integration for inlined callers** — multi-body
   `CfgDomainProjection` (§4c), callee-body-fingerprint + policy-version cache key
   (§4b); turn caching on for inlined callers. (file RUE-932)
-- [ ] **Phase 5: Whole-program dead-function elimination** — separate pass that
-  removes now-unreachable functions (including single-call-site callees the
-  inliner consumed) under full reachability analysis (§6). (file RUE-933)
+- [x] **Phase 5: Whole-program dead-function elimination** — the canonical
+  deterministic reachability step in the whole-program batch removes
+  now-unreachable functions (including single-call-site callees the inliner
+  consumed) while retaining entry points, exports, calls, cleanup edges, and
+  conservatively all units when dependency completeness is unknown. (file
+  RUE-933)
 - [ ] **Phase 6: Methods/destructors** — extend as the ADR-0050 method/destructor
   caller surfaces complete. (file RUE-NNN — awaits the ADR-0050 method/destructor
   caller surfaces before it can be scoped and filed.)
@@ -668,7 +673,8 @@ already synthesized.
 
 ## Future Work
 
-- Whole-program dead-function elimination (Phase 5) as its own ADR-worthy pass.
+- Broader whole-program reachability roots and method/destructor inlining remain
+  future work as described by Phases 3, 4, and 6.
 - Bounded recursive inlining under a size budget.
 - Profile-guided inlining once any profiling exists.
 


### PR DESCRIPTION
## Summary

- add deterministic post-inlining whole-program reachability to the canonical optimized-CFG batch
- retain entry points, C exports, callable and cleanup edges, and fail closed when dependency discovery is incomplete
- preserve diagnostics and backend retention accounting while filtering unreachable units
- update optimizer architecture notes and add structural plus differential coverage

## Validation

- scripts/rue fmt
- scripts/rue quick
- scripts/rue premerge
- scripts/rue test
- focused compiler, CFG, CLI, warning-parity, and oracle-differential tests

Fixes RUE-933