### PR TITLE
RUE-1774: compose the durable AIR host

### DIFF
--- a/crates/rue-air/src/sema/comptime.rs
+++ b/crates/rue-air/src/sema/comptime.rs
@@ -279,6 +279,14 @@ pub trait ComptimeValue: Clone {
     fn as_boolean(&self) -> Option<bool>;
     fn as_type(&self) -> Option<Self::Type>;
 
+    /// Whether a reduced value may participate in an anonymous nominal's
+    /// captured value substitution.  Semantic domains with lexical handles
+    /// (for example modules and target descriptors) can opt out; ordinary
+    /// body values retain the historical all-values behavior.
+    fn eligible_for_comptime_capture(&self) -> bool {
+        true
+    }
+
     /// Recover optional declared integer metadata carried by a host value.
     /// The ordinary body value domain returns `None`; durable hosts may use
     /// this to retain operand typing after a child reduction.
@@ -625,8 +633,11 @@ where
             if let Some(t) = val.as_type() {
                 type_subst.insert(name.clone(), t);
                 value_subst.remove(name);
-            } else {
+            } else if val.eligible_for_comptime_capture() {
                 value_subst.insert(name.clone(), val.clone());
+                type_subst.remove(name);
+            } else {
+                value_subst.remove(name);
                 type_subst.remove(name);
             }
         }
@@ -689,6 +700,7 @@ mod value_domain_tests {
         static TICKET_EVENTS: RefCell<Vec<(usize, bool)>> = const { RefCell::new(Vec::new()) };
         static PRODUCER_CALLS: RefCell<Vec<(usize, usize, u32)>> = const { RefCell::new(Vec::new()) };
         static INTEGER_HINTS: RefCell<Vec<Option<FakeType>>> = const { RefCell::new(Vec::new()) };
+        static FINISH_ARITH_OPERATIONS: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
         static METHOD_FAILURES: RefCell<Vec<&'static str>> = const { RefCell::new(Vec::new()) };
         static TYPE_RESOLUTION_CALLS: Cell<usize> = const { Cell::new(0) };
         static CHECKPOINTS: Cell<usize> = const { Cell::new(0) };
@@ -703,6 +715,7 @@ mod value_domain_tests {
         static EVALUATED_METHOD_EVENTS: RefCell<Vec<&'static str>> = const { RefCell::new(Vec::new()) };
         static EVALUATED_METHOD_ARGUMENT_CALLS: Cell<usize> = const { Cell::new(0) };
         static EVALUATED_METHOD_FAIL_ON_UNIT: Cell<bool> = const { Cell::new(false) };
+        static REJECT_QUALIFIED_ENUM: Cell<bool> = const { Cell::new(false) };
         static REJECT_ADMISSION: Cell<bool> = const { Cell::new(false) };
         static REJECT_BIND_AT: Cell<Option<usize>> = const { Cell::new(None) };
         static NAMED_VALUE_CALLS: Cell<usize> = const { Cell::new(0) };
@@ -2124,9 +2137,10 @@ mod value_domain_tests {
             &self,
             result: CheckedIntegerResult,
             _ty: Option<Self::Type>,
-            _op: &str,
+            op: &str,
             site: &ComptimeDiagnosticSite<Self::ProgramKey>,
         ) -> ComptimeHostResult<Option<Self::Value>, Self::Failure> {
+            FINISH_ARITH_OPERATIONS.with(|operations| operations.borrow_mut().push(op.to_owned()));
             DIAGNOSTIC_SITES.with(|sites| {
                 sites
                     .borrow_mut()
@@ -2603,8 +2617,12 @@ mod value_domain_tests {
             &mut self,
             _type_name: Self::Name,
             _variant: Self::Name,
+            has_module: bool,
             _site: &ComptimeSite<Self::ProgramKey>,
         ) -> ComptimeHostResult<bool, Self::Failure> {
+            if has_module && REJECT_QUALIFIED_ENUM.with(Cell::get) {
+                return Err(ComptimeHostError::HostFailure(FAKE_FAILURE));
+            }
             Ok(self.admits_durable_forms())
         }
 
@@ -3112,6 +3130,53 @@ mod value_domain_tests {
                 .iter()
                 .any(|(file, _)| file.index == 0xFFFF_FFFA)
         );
+    }
+
+    #[test]
+    fn qualified_enum_admission_rejects_before_evaluating_module_child() {
+        clear_named_value_observations();
+        REJECT_QUALIFIED_ENUM.with(|reject| reject.set(true));
+        let mut editor = rue_rir::RirEditor::new();
+        let interner = lasso::ThreadedRodeo::new();
+        let module_name = interner.get_or_intern("module");
+        let module = editor.add_inst(rue_rir::Inst {
+            data: InstData::VarRef {
+                name: module_name,
+                anchor: None,
+            },
+            span: Span::new(0, 6),
+        });
+        let enum_variant = editor.add_inst(rue_rir::Inst {
+            data: InstData::EnumVariant {
+                module: Some(module),
+                type_name: interner.get_or_intern("Arch"),
+                variant: interner.get_or_intern("X86_64"),
+            },
+            span: Span::new(0, 14),
+        });
+        let mut host = FakeHost {
+            programs: vec![editor.finish()],
+            type_symbol: SymbolHandle::new(interner.get_or_intern("T")),
+            constant: None,
+            dependencies: Vec::new(),
+            call_plans: AHashMap::new(),
+            recursive: None,
+            enter_count: 0,
+            finish_outcome: FakeFinishOutcome::Identity,
+            finished: Vec::new(),
+            float_evaluations: Cell::new(0),
+        };
+        let mut env = ComptimeEnv::<FakeValue, FakeType, FakeName, FakeFile, FakeIdentity>::new();
+        let result = ComptimeEngine::new(&mut host)
+            .evaluate(ComptimeFrame::expression(0, enum_variant), &mut env);
+        assert!(matches!(result, ComptimeOutcome::HostFailure(FAKE_FAILURE)));
+        assert_eq!(
+            NAMED_VALUE_CALLS.with(Cell::get),
+            0,
+            "qualified enum rejection must precede module-child evaluation"
+        );
+        REJECT_QUALIFIED_ENUM.with(|reject| reject.set(false));
+        clear_named_value_observations();
     }
 
     #[test]
@@ -3884,6 +3949,48 @@ mod value_domain_tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn direct_negative_literal_uses_the_distinct_negation_operation() {
+        let mut editor = rue_rir::RirEditor::new();
+        let magnitude = editor.add_inst(rue_rir::Inst {
+            data: InstData::IntConst(129),
+            span: Span::new(0, 3),
+        });
+        let negative = editor.add_inst(rue_rir::Inst {
+            data: InstData::Neg { operand: magnitude },
+            span: Span::new(0, 4),
+        });
+        let interner = lasso::ThreadedRodeo::new();
+        let mut host = FakeHost {
+            programs: vec![editor.finish()],
+            type_symbol: SymbolHandle::new(interner.get_or_intern("T")),
+            constant: None,
+            dependencies: Vec::new(),
+            call_plans: AHashMap::new(),
+            recursive: None,
+            enter_count: 0,
+            finish_outcome: FakeFinishOutcome::Identity,
+            finished: Vec::new(),
+            float_evaluations: Cell::new(0),
+        };
+        let mut env = ComptimeEnv::<FakeValue, FakeType, FakeName, FakeFile, FakeIdentity>::new();
+        FINISH_ARITH_OPERATIONS.with(|operations| operations.borrow_mut().clear());
+
+        assert!(matches!(
+            ComptimeEngine::new(&mut host).evaluate(
+                ComptimeFrame {
+                    expected_result: Some(FakeType(8)),
+                    ..ComptimeFrame::expression(0, negative)
+                },
+                &mut env,
+            ),
+            ComptimeOutcome::RuntimeDependent
+        ));
+        FINISH_ARITH_OPERATIONS.with(|operations| {
+            assert_eq!(operations.borrow().as_slice(), ["negation"]);
+        });
     }
 
     #[test]
@@ -6706,6 +6813,17 @@ pub trait ComptimeHost {
         ty: &Self::Type,
         site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> Self::Failure;
+    /// Give a semantic host a chance to preserve a checked-negation policy
+    /// after the operand has been reduced. Ordinary hosts retain the
+    /// historical immediate `CannotNegate` terminal; durable hosts may defer
+    /// to their checked integer-result policy.
+    fn reject_unsigned_negation(
+        &self,
+        ty: &Self::Type,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> Option<Self::Failure> {
+        Some(self.cannot_negate(ty, site))
+    }
     fn unsupported_anon_method_type_param(
         &self,
         method_name: &str,
@@ -7110,6 +7228,7 @@ pub trait ComptimeHost {
         &mut self,
         _type_name: Self::Name,
         _variant: Self::Name,
+        _has_module: bool,
         _site: &ComptimeSite<Self::ProgramKey>,
     ) -> ComptimeHostResult<bool, Self::Failure> {
         Ok(false)
@@ -8330,9 +8449,12 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                         outcome_value!(self.unary_integer_type_for(env, inst_ref, &literal, span,));
                     if let Some(ref ty) = ty {
                         if self.host.type_is_unsigned(ty) {
-                            return ComptimeOutcome::HostFailure(
-                                self.host.cannot_negate(ty, &self.diagnostic_site(span)),
-                            );
+                            if let Some(failure) = self
+                                .host
+                                .reject_unsigned_negation(ty, &self.diagnostic_site(span))
+                            {
+                                return ComptimeOutcome::HostFailure(failure);
+                            }
                         }
                     }
                     // The literal path uses mathematical magnitude semantics:
@@ -8345,7 +8467,7 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                             || CheckedIntegerResult::from_raw((magnitude as i128).checked_neg()),
                             |integer| integer.checked_neg_literal_report_i128(magnitude as i128),
                         );
-                    self.finish_arith_value(result, ty, "-", span)
+                    self.finish_arith_value(result, ty, "negation", span)
                 } else {
                     match self.eval(*operand, env) {
                         ComptimeOutcome::Known(value) => {
@@ -8360,9 +8482,12 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                             );
                             if let Some(ref ty) = ty {
                                 if self.host.type_is_unsigned(ty) {
-                                    return ComptimeOutcome::HostFailure(
-                                        self.host.cannot_negate(ty, &self.diagnostic_site(span)),
-                                    );
+                                    if let Some(failure) = self
+                                        .host
+                                        .reject_unsigned_negation(ty, &self.diagnostic_site(span))
+                                    {
+                                        return ComptimeOutcome::HostFailure(failure);
+                                    }
                                 }
                             }
                             let result = match ty
@@ -8381,7 +8506,7 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                                 }
                                 None => CheckedIntegerResult::from_raw(n.checked_neg()),
                             };
-                            self.finish_arith_value(result, ty, "-", span)
+                            self.finish_arith_value(result, ty, "negation", span)
                         }
                         other => other,
                     }
@@ -9230,6 +9355,7 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                 if !host_value!(self.host.admit_comptime_enum_variant(
                     type_name.clone(),
                     variant.clone(),
+                    module.is_some(),
                     &site,
                 )) {
                     return ComptimeOutcome::RuntimeDependent;

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -2189,7 +2189,17 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeHost for OrdinaryBodyEngine<'h, H>
         op: &str,
         site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> ComptimeHostResult<Option<ConstValue>, Self::Failure> {
-        OrdinaryBodyEngine::finish_arith(self, result, ty, op, site.span()).map_err(Into::into)
+        // The engine uses a distinct semantic token for unary negation so
+        // durable hosts can preserve its operation-specific wording. The
+        // ordinary body diagnostic remains the historical `-` spelling.
+        OrdinaryBodyEngine::finish_arith(
+            self,
+            result,
+            ty,
+            if op == "negation" { "-" } else { op },
+            site.span(),
+        )
+        .map_err(Into::into)
     }
     fn resolve_named_type_value(
         &mut self,

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -4539,7 +4539,7 @@ fn durable_comptime_services_are_named_authority_operations() {
         .and_then(|source| source.split("/// The ownership-site policy").next())
         .expect("durable terminal bridge");
     let bridge_without_future_trap = terminal_bridge.replace(
-        "#[allow(dead_code)] // consumed when the durable AIR host is wired",
+        "#[allow(dead_code)] // consumed after durable query-root cutover",
         "",
     );
     assert!(
@@ -4552,8 +4552,8 @@ fn durable_comptime_services_are_named_authority_operations() {
         terminal_bridge
             .matches("ComptimeHostError::HostFailure(self)")
             .count(),
-        1,
-        "durable host-failure construction must have one canonical funnel"
+        2,
+        "durable semantic/query-failure construction must stay in one canonical funnel"
     );
     assert_eq!(
         terminal_bridge
@@ -5292,10 +5292,37 @@ fn durable_comptime_services_are_named_authority_operations() {
         );
     }
     assert!(evaluator.contains("DurableComptimeServices::new(&mut *self.authority)"));
+    let type_syntax_resolver = evaluator
+        .split("fn resolve_type_syntax(")
+        .nth(1)
+        .and_then(|source| source.split("    fn value(").next())
+        .expect("durable evaluator type-syntax resolver");
     assert!(
-        evaluator.contains("resolve_type_syntax(&self.program, syntax)"),
+        type_syntax_resolver.contains("resolve_type_syntax(&self.program, syntax)"),
         "legacy type syntax consumers must retain their provider-owned substitution view"
     );
+    assert!(
+        type_syntax_resolver
+            .contains("map_err(crate::durable_comptime::durable_comptime_type_syntax_failure)"),
+        "legacy type syntax consumers must use the comptime-evaluation failure adapter"
+    );
+    assert!(!type_syntax_resolver.contains("SemanticTypeSyntaxError::"));
+    assert!(!type_syntax_resolver.contains("format!(\"{other:?}\")"));
+    let signature_type_syntax_adapter = database
+        .split("fn semantic_type_query_failure(")
+        .nth(1)
+        .and_then(|source| source.split("fn resolve_parsed_semantic_signature(").next())
+        .expect("signature type-syntax failure adapter");
+    assert!(
+        signature_type_syntax_adapter.contains("classify_durable_type_syntax_failure(failure)")
+    );
+    for detailed in ["ErrorKind::UnknownType", "ErrorKind::UnknownModuleMember"] {
+        assert!(
+            signature_type_syntax_adapter.contains(detailed),
+            "signature type-syntax adapter must preserve detailed diagnostics: {detailed}"
+        );
+    }
+    assert!(!signature_type_syntax_adapter.contains("durable_comptime_type_syntax_failure"));
     assert!(evaluator.contains("let expected = self.resolve_type_syntax(*annotation)?;"));
     let type_literal = evaluator
         .split("fn eval_type_literal(")
@@ -5906,7 +5933,7 @@ fn match_patterns_have_one_air_decoder_and_one_durable_kernel() {
 
     let durable = include_str!("durable_comptime.rs");
     let kernel = durable
-        .split("pub(crate) fn durable_match_pattern_matches(")
+        .split("pub(crate) fn durable_match_pattern_matches")
         .nth(1)
         .and_then(|source| source.split("\n}\n\n/// The canonical pure target").next())
         .expect("durable match kernel");
@@ -5914,7 +5941,7 @@ fn match_patterns_have_one_air_decoder_and_one_durable_kernel() {
     assert!(kernel.contains("binding_count: 0"));
     assert_eq!(
         durable
-            .matches("pub(crate) fn durable_match_pattern_matches(")
+            .matches("pub(crate) fn durable_match_pattern_matches")
             .count(),
         1
     );
@@ -5952,6 +5979,74 @@ fn match_patterns_have_one_air_decoder_and_one_durable_kernel() {
     assert!(rejection_kernel.contains("module used where a value is required"));
     assert!(
         rejection_kernel.contains("target descriptor used where a durable const value is required")
+    );
+}
+
+#[test]
+fn durable_air_host_is_composition_not_a_peer_interpreter() {
+    let durable = include_str!("durable_comptime.rs");
+    let host = durable
+        .split("pub(crate) struct DurableComptimeHost<")
+        .nth(1)
+        .and_then(|source| {
+            source
+                .split("pub(crate) type DurableComptimeConstFrame =")
+                .next()
+        })
+        .expect("bounded durable AIR host composition");
+    assert!(host.contains("impl<A: DurableComptimeHostAuthority"));
+    assert!(host.contains("rue_air::ComptimeHost"));
+    assert!(host.contains("durable_session_mut()"));
+    assert!(host.contains("DurableComptimeScalarPolicy"));
+    assert!(host.contains("project_durable_anonymous_nominal"));
+    assert!(!host.contains("InstData::"));
+    assert!(!host.contains("fn eval("));
+    assert!(!host.contains("SemanticConstEvaluator"));
+    assert!(!host.contains("SemanticNucleusKey::ComptimeCall"));
+}
+
+#[test]
+fn durable_projection_failures_have_one_shared_semantic_mapping() {
+    let durable = include_str!("durable_comptime.rs");
+    let database = include_str!("revisioned_query_database.rs");
+    assert_eq!(
+        durable
+            .matches("pub(crate) fn durable_candidate_rir_semantic_failure(")
+            .count(),
+        1
+    );
+    assert_eq!(
+        durable
+            .matches("pub(crate) fn durable_materialization_semantic_failure(")
+            .count(),
+        1
+    );
+    let projection = durable
+        .split("fn durable_projection_failure_error(")
+        .nth(1)
+        .and_then(|source| source.split("\n}\n\n").next())
+        .expect("durable projection adapter");
+    assert!(projection.contains("durable_candidate_rir_semantic_failure(&failure)"));
+    assert!(projection.contains("durable_materialization_semantic_failure(failure)"));
+    assert!(!projection.contains("CandidateRirRejected(errors)"));
+    assert!(!projection.contains("Materialization::Build(error)"));
+    let candidate_wrapper = database
+        .split("fn candidate_rir_semantic_failure(")
+        .nth(1)
+        .and_then(|source| source.split("\n}\n\n").next())
+        .expect("legacy candidate failure adapter");
+    assert!(
+        candidate_wrapper
+            .contains("crate::durable_comptime::durable_candidate_rir_semantic_failure(failure)")
+    );
+    let materialization_wrapper = database
+        .split("fn semantic_materialization_failure(")
+        .nth(1)
+        .and_then(|source| source.split("\n}\n\n").next())
+        .expect("legacy materialization failure adapter");
+    assert!(
+        materialization_wrapper
+            .contains("crate::durable_comptime::durable_materialization_semantic_failure(failure)")
     );
 }
 

--- a/crates/rue-compiler/src/body_query.rs
+++ b/crates/rue-compiler/src/body_query.rs
@@ -321,6 +321,31 @@ impl OwnedForeignComptimeProgram {
 }
 
 impl OwnedComptimeProgramCore {
+    #[cfg(test)]
+    pub(crate) fn from_test_rir(
+        plan: DurableComptimeProgramPlan,
+        rir: rue_rir::ValidatedRir,
+        symbols: Arc<[Arc<str>]>,
+        root: rue_rir::InstRef,
+        body: rue_rir::InstRef,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            program: DurableComptimeProgram {
+                rir: Arc::new(rir),
+                symbols,
+                imports: DurableComptimeProgramMetadata {
+                    imports: Arc::from([]),
+                    root: OwnedComptimeProgramRoot::Callable(ForeignComptimeCallable {
+                        body,
+                        context: plan.candidate.module.clone(),
+                        root,
+                    }),
+                },
+            },
+            plan,
+        })
+    }
+
     pub(crate) fn from_callable_body_plan_without_imports(
         plan: DurableComptimeProgramPlan,
         artifacts: &crate::canonical_lower::DeclarationBodyPlanArtifacts,

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -11,10 +11,13 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use ahash::AHashMap;
+use lasso::Key;
 use rue_air::{
     ComptimeFile, ComptimeIdentity, ComptimeMatchPattern, ComptimeName, ComptimeSemanticRejection,
     ComptimeTargetIntrinsic, ComptimeType, ComptimeUnaryOperation, ComptimeValue,
 };
+#[cfg(test)]
+use rue_query::CancellationToken;
 use rue_query::QueryAbort;
 
 use crate::ModuleId;
@@ -70,6 +73,7 @@ pub(crate) struct DurableComptimeHostFailure(DurableComptimeHostFailureKind);
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum DurableComptimeHostFailureKind {
     Semantic(Box<SemanticNucleusFailure>),
+    QueryFailure(rue_query::QueryFailure),
     QueryAbort(QueryAbort),
 }
 
@@ -82,9 +86,16 @@ impl DurableComptimeHostFailure {
         Self(DurableComptimeHostFailureKind::QueryAbort(abort))
     }
 
+    fn query_failure(failure: rue_query::QueryFailure) -> Self {
+        Self(DurableComptimeHostFailureKind::QueryFailure(failure))
+    }
+
     fn into_host_error(self) -> rue_air::ComptimeHostError<Self> {
         match &self.0 {
             DurableComptimeHostFailureKind::Semantic(_) => {
+                rue_air::ComptimeHostError::HostFailure(self)
+            }
+            DurableComptimeHostFailureKind::QueryFailure(_) => {
                 rue_air::ComptimeHostError::HostFailure(self)
             }
             DurableComptimeHostFailureKind::QueryAbort(_) => {
@@ -93,25 +104,12 @@ impl DurableComptimeHostFailure {
         }
     }
 
-    fn into_legacy_failure(self) -> DurableComptimeFailure {
-        match self.0 {
-            DurableComptimeHostFailureKind::Semantic(failure) => {
-                DurableComptimeFailure::Failure(failure)
-            }
-            DurableComptimeHostFailureKind::QueryAbort(_) => {
-                unreachable!("canonical host failure carried a query abort")
-            }
-        }
-    }
-
-    fn into_legacy_abort(self) -> DurableComptimeFailure {
-        match self.0 {
-            DurableComptimeHostFailureKind::QueryAbort(abort) => {
-                DurableComptimeFailure::Abort(abort)
-            }
-            DurableComptimeHostFailureKind::Semantic(_) => {
-                unreachable!("canonical host abort carried a semantic failure")
-            }
+    #[cfg(test)]
+    pub(crate) fn semantic_failure(&self) -> Option<&SemanticNucleusFailure> {
+        match &self.0 {
+            DurableComptimeHostFailureKind::Semantic(failure) => Some(failure),
+            DurableComptimeHostFailureKind::QueryFailure(_)
+            | DurableComptimeHostFailureKind::QueryAbort(_) => None,
         }
     }
 }
@@ -315,7 +313,7 @@ impl DurableComptimeFailure {
     /// Adapt a supported AIR arithmetic trap using the owning declaration and
     /// the trap's own span.  Unsupported operations remain unsupported rather
     /// than acquiring a new diagnostic spelling.
-    #[allow(dead_code)] // consumed when the durable AIR host is wired
+    #[allow(dead_code)] // consumed after durable query-root cutover
     pub(crate) fn trap_at(
         producer: DeclarationCandidateKey,
         trap: rue_air::ComptimeTrap,
@@ -325,10 +323,10 @@ impl DurableComptimeFailure {
         Some(Self::diagnostic_at_site(&site, reason.to_owned()))
     }
 
-    /// Adapt a durable terminal directly for the future AIR host.  Provider
+    /// Adapt a durable terminal directly for the AIR host.  Provider
     /// errors use `provider_error_as_host` instead, so this seam never creates
     /// a durable failure only to convert it back into a provider error.
-    #[allow(dead_code)] // consumed when the durable AIR host is wired
+    #[allow(dead_code)] // consumed after durable query-root cutover
     pub(crate) fn into_host_error(self) -> rue_air::ComptimeHostError<DurableComptimeHostFailure> {
         match self {
             Self::Failure(failure) => {
@@ -339,8 +337,9 @@ impl DurableComptimeFailure {
     }
 
     /// Build the AIR error directly from a provider result.  This is the
-    /// future host funnel; the legacy adapter below only unwraps its matching
+    /// AIR host funnel; the legacy adapter below only unwraps its matching
     /// outer channel and never normalizes crossed tags.
+    #[allow(dead_code)] // consumed after durable query-root cutover
     pub(crate) fn provider_error_as_host(
         error: rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
     ) -> rue_air::ComptimeHostError<DurableComptimeHostFailure> {
@@ -357,9 +356,11 @@ impl DurableComptimeFailure {
     pub(crate) fn provider_error(
         error: rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
     ) -> Self {
-        match Self::provider_error_as_host(error) {
-            rue_air::ComptimeHostError::Abort(payload) => payload.into_legacy_abort(),
-            rue_air::ComptimeHostError::HostFailure(payload) => payload.into_legacy_failure(),
+        match error {
+            rue_air::SemanticProviderError::Abort(abort) => DurableComptimeFailure::Abort(abort),
+            rue_air::SemanticProviderError::Failure(failure) => {
+                DurableComptimeFailure::Failure(Box::new(failure))
+            }
         }
     }
 }
@@ -415,7 +416,7 @@ impl DurableComptimeApplicationPolicy {
 /// the semantic nucleus. Anonymous nominals replace an earlier observation at
 /// the same identity, while dependencies and ownership gates are set-unioned;
 /// this is the existing publication behavior, expressed as one operation
-/// boundary for the future AIR host.
+/// boundary for the AIR host.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct DurableComptimeEffects {
     anonymous_nominals: BTreeMap<crate::AnonymousNominalKey, DurableAnonymousNominal>,
@@ -1944,10 +1945,14 @@ impl DurableComptimeSession {
         self.lifecycle.observe_dependency(dependency);
     }
 
+    pub(crate) fn observe_deferred_ownership(&mut self, gate: DeferredOwnershipGate) {
+        self.lifecycle.observe_deferred_ownership(gate);
+    }
+
     /// Enter one lifecycle ticket through the session-owned funnel.  Keeping
-    /// this operation here prevents future hosts from reaching around the
+    /// this operation here prevents hosts from reaching around the
     /// session and mutating the lifecycle with a mismatched ticket.
-    #[allow(dead_code)] // activated when the durable AIR host enters call edges
+    #[allow(dead_code)] // activated after durable call-edge cutover
     pub(crate) fn enter_call(
         &mut self,
         ticket: &DurableComptimeCallTicket,
@@ -1958,7 +1963,7 @@ impl DurableComptimeSession {
     /// Finish one entered call through the session-owned funnel.  Lifecycle
     /// validation, cleanup, and Known-only effect publication remain a single
     /// operation owned by the session.
-    #[allow(dead_code)] // activated when the durable AIR host finishes calls
+    #[allow(dead_code)] // activated after durable call-edge cutover
     pub(crate) fn finish_call<V, F>(
         &mut self,
         ticket: &mut DurableComptimeCallTicket,
@@ -2797,7 +2802,7 @@ pub(crate) fn durable_int_width(
 }
 
 /// Stateless scalar policy shared by declaration-time evaluation and the
-/// future AIR durable host.  It owns no query or RIR state; all inputs are
+/// AIR durable host.  It owns no query or RIR state; all inputs are
 /// already-reduced durable values and types.
 pub(crate) struct DurableComptimeScalarPolicy;
 
@@ -2981,7 +2986,7 @@ impl DurableComptimeBinding {
 }
 
 /// Opaque ordered call facts produced by the durable binding kernel.  The
-/// typed values and substituted result are private so a future host cannot
+/// typed values and substituted result are private so a host cannot
 /// manufacture arbitrary frame metadata beside the binding policy.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct DurableComptimeBoundCall {
@@ -3260,6 +3265,35 @@ pub(crate) trait DurableComptimeSemanticAuthority {
         >,
     >;
 
+    fn begin_structured_type(
+        &mut self,
+        program: &crate::body_query::DurableComptimeProgramKey,
+        syntax: rue_rir::RirTypeSyntaxRef,
+        type_substitutions: Vec<(Arc<str>, DurableType)>,
+        value_substitutions: Vec<(Arc<str>, DurableConstValue)>,
+    ) -> Result<
+        DurableStructuredTypePoll,
+        DurableStructuredTypeBeginError<QueryAbort, SemanticNucleusFailure>,
+    >;
+
+    fn resume_structured_type(
+        &mut self,
+        job: DurableStructuredTypeJob,
+        reduced: rue_air::SemanticProviderResult<
+            Option<rue_air::SemanticComptimeCallResult<DurableType, DurableConstValue>>,
+            QueryAbort,
+            SemanticNucleusFailure,
+        >,
+    ) -> Result<
+        DurableStructuredTypePoll,
+        rue_air::SemanticTypeSyntaxError<
+            QueryAbort,
+            SemanticNucleusFailure,
+            crate::StableDefinitionKey,
+            Arc<str>,
+        >,
+    >;
+
     fn begin_comptime_call_admission(
         &self,
         accessing_source: &crate::StableDefinitionKey,
@@ -3445,7 +3479,7 @@ impl<A: DurableComptimeSemanticAuthority + ?Sized> DurableComptimeServices<'_, A
 
     /// Begin admission for a method whose receiver has already reduced to an
     /// exact module value.  Keeping this named seam distinct from the
-    /// unqualified call operation makes it impossible for a future AIR host
+    /// unqualified call operation makes it impossible for the AIR host
     /// to recover the method's module from a spelling in the caller.
     pub(crate) fn begin_evaluated_module_call(
         &self,
@@ -3665,7 +3699,7 @@ pub(crate) enum DurableComptimeArrayLengthError {
 }
 
 /// Convert the AIR-owned lexical fact without dropping any value variant.
-/// This is intentionally exhaustive so a future host cannot accidentally
+/// This is intentionally exhaustive so the AIR host cannot accidentally
 /// reinterpret a shadow as an unbound global lookup.
 #[allow(dead_code)] // consumed when the staged durable AIR host is entered
 pub(crate) fn durable_array_length_binding_from_air(
@@ -3687,7 +3721,7 @@ pub(crate) fn durable_array_length_binding_from_air(
 
 /// Apply the canonical named array-length policy to a lexical semantic fact.
 /// Concrete conversion and its semantic failures are shared by the legacy
-/// evaluator and the future AIR host; global lookup remains the caller's
+/// evaluator and the AIR host; global lookup remains the caller's
 /// responsibility so dependency observation happens exactly at the existing
 /// provider point.
 pub(crate) fn classify_durable_named_array_length(
@@ -3707,6 +3741,30 @@ pub(crate) fn classify_durable_named_array_length(
         DurableComptimeArrayLengthBinding::LocalValue(value) => Ok(
             DurableComptimeArrayLengthDecision::Concrete(durable_named_array_length_value(&value)?),
         ),
+    }
+}
+
+pub(crate) fn durable_named_array_length_failure(
+    name: &str,
+    error: DurableComptimeArrayLengthError,
+) -> SemanticNucleusFailure {
+    use DurableComptimeArrayLengthError as E;
+    match error {
+        E::Module => {
+            SemanticNucleusFailure::Resolution(Arc::from("module used where a value is required"))
+        }
+        E::TargetEnum => SemanticNucleusFailure::Resolution(Arc::from(
+            "target descriptor used where a durable const value is required",
+        )),
+        E::NonInteger | E::Negative(_) | E::TooLarge(_) => {
+            SemanticNucleusFailure::Diagnostic(rue_error::ErrorKind::InvalidArrayLength {
+                reason: if matches!(error, E::NonInteger) {
+                    format!("array length expression '{name}' is not an integer")
+                } else {
+                    format!("array length expression '{name}' is negative or too large")
+                },
+            })
+        }
     }
 }
 
@@ -3744,12 +3802,12 @@ pub(crate) fn durable_named_array_length_integer(
     })
 }
 
-/// Match semantics shared by the durable evaluator and its future AIR host.
+/// Match semantics shared by the durable evaluator and the AIR host.
 /// Durable values deliberately remain narrower than the language's runtime
 /// enum algebra: only an exact, unqualified, binding-free target descriptor
 /// path is decidable here.
-pub(crate) fn durable_match_pattern_matches(
-    pattern: &ComptimeMatchPattern<Arc<str>>,
+pub(crate) fn durable_match_pattern_matches<N: AsRef<str>>(
+    pattern: &ComptimeMatchPattern<N>,
     value: &EvaluatedSemanticConst,
 ) -> bool {
     match pattern {
@@ -3919,6 +3977,12 @@ impl From<&str> for DurableComptimeName {
     }
 }
 
+impl AsRef<str> for DurableComptimeName {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
 impl ComptimeName for DurableComptimeName {}
 
 /// The AIR file domain is keyed by the complete owning program identity.
@@ -3933,7 +3997,7 @@ impl DurableComptimeFile {
         Self(program)
     }
 
-    #[allow(dead_code)] // consumed by the staged durable AIR host
+    #[allow(dead_code)] // consumed by the durable query-root host during cutover
     pub(crate) fn program(&self) -> &crate::body_query::DurableComptimeProgramKey {
         &self.0
     }
@@ -3960,6 +4024,1980 @@ impl AsRef<crate::StableProducerId> for DurableComptimeIdentity {
 }
 
 impl ComptimeIdentity for DurableComptimeIdentity {}
+
+/// Anonymous nominal identities are issued by AIR from the active producer
+/// and structural anchor.  This wrapper keeps the canonical compiler key
+/// opaque while satisfying AIR's identity marker at the host boundary.
+#[allow(dead_code)] // consumed after durable query-root cutover
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct DurableComptimeAnonymousIdentity(crate::AnonymousNominalKey);
+
+impl ComptimeIdentity for DurableComptimeAnonymousIdentity {}
+
+impl DurableComptimeAnonymousIdentity {
+    fn new(key: crate::AnonymousNominalKey) -> Self {
+        Self(key)
+    }
+
+    fn key(&self) -> &crate::AnonymousNominalKey {
+        &self.0
+    }
+}
+
+/// The narrow authority required by the production-shaped durable AIR host.
+/// Query roots implement this beside their existing semantic and foreign
+/// authorities; the host never owns a second registry or provider.
+#[allow(dead_code)] // consumed after durable query-root cutover
+pub(crate) trait DurableComptimeHostAuthority:
+    DurableComptimeSemanticAuthority + DurableComptimeForeignCallAuthority
+{
+    fn durable_session(&self) -> &DurableComptimeSession;
+    fn durable_session_mut(&mut self) -> &mut DurableComptimeSession;
+}
+
+#[cfg(test)]
+thread_local! {
+    static ENUM_VARIANT_CHILD_TRIPWIRE: std::cell::RefCell<Option<CancellationToken>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+pub(crate) fn set_enum_variant_child_tripwire(token: Option<CancellationToken>) {
+    ENUM_VARIANT_CHILD_TRIPWIRE.with(|tripwire| *tripwire.borrow_mut() = token);
+}
+
+#[cfg(test)]
+fn arm_enum_variant_child_tripwire() {
+    ENUM_VARIANT_CHILD_TRIPWIRE.with(|tripwire| {
+        if let Some(token) = tripwire.borrow().as_ref() {
+            token.cancel();
+        }
+    });
+}
+
+/// Production host composition boundary.  Its implementation is introduced
+/// separately from query-root cutover so the canonical AIR engine can be
+/// exercised without changing the legacy evaluator's authority.
+#[allow(dead_code)] // consumed after durable query-root cutover
+pub(crate) struct DurableComptimeHost<'a, A: DurableComptimeHostAuthority + ?Sized> {
+    authority: &'a mut A,
+}
+
+impl<'a, A: DurableComptimeHostAuthority + ?Sized> DurableComptimeHost<'a, A> {
+    #[allow(dead_code)] // consumed after durable query-root cutover
+    pub(crate) fn new(authority: &'a mut A) -> Self {
+        Self { authority }
+    }
+
+    #[allow(dead_code)]
+    fn program_rir(
+        &self,
+        program: &crate::body_query::DurableComptimeProgramKey,
+    ) -> &rue_rir::ValidatedRir {
+        &self
+            .authority
+            .durable_session()
+            .registered_program(program)
+            .expect("durable AIR frame must reference a registered program")
+            .rir
+    }
+
+    #[allow(dead_code)]
+    fn name_from_symbol(
+        &self,
+        program: &crate::body_query::DurableComptimeProgramKey,
+        symbol: rue_rir::SymbolHandle,
+    ) -> DurableComptimeName {
+        let registered = self
+            .authority
+            .durable_session()
+            .registered_program(program)
+            .expect("durable AIR frame must reference a registered program");
+        DurableComptimeName::from(
+            registered
+                .symbols
+                .get(symbol.issuing_interner_ordinal())
+                .expect("validated symbol handle")
+                .clone(),
+        )
+    }
+
+    #[allow(dead_code)]
+    fn file_for_program_span(
+        &self,
+        program: &crate::body_query::DurableComptimeProgramKey,
+        span: &rue_span::Span,
+    ) -> DurableComptimeFile {
+        self.authority
+            .durable_session()
+            .file_for_program(program)
+            .unwrap_or_else(|_| panic!("unregistered durable program at {span:?}"))
+    }
+
+    fn diagnostic_site(
+        &self,
+        site: &rue_air::ComptimeDiagnosticSite<crate::body_query::DurableComptimeProgramKey>,
+    ) -> DurableComptimeDiagnosticSite {
+        self.authority
+            .durable_session()
+            .diagnostic_site(site.program(), site.span())
+            .expect("durable AIR diagnostic must reference a registered declaration program")
+    }
+
+    fn admit_call_for_module(
+        &mut self,
+        accessing_source: &crate::StableDefinitionKey,
+        module: &ModuleId,
+        name: &DurableComptimeName,
+        argument_modes: &[rue_air::ComptimeArgMode],
+    ) -> rue_air::ComptimeHostResult<DurableComptimeAdmittedCall, DurableComptimeHostFailure> {
+        let reservation = self
+            .authority
+            .durable_session_mut()
+            .reserve_bound_expression_call();
+        let start = self
+            .authority
+            .begin_comptime_call_admission(accessing_source, module, name.as_str())
+            .map_err(durable_provider_error)?;
+        self.authority
+            .durable_session_mut()
+            .observe_dependency(start.dependency.clone());
+        let modes = argument_modes
+            .iter()
+            .map(|(mode, _)| match mode {
+                rue_rir::RirArgMode::Normal => {
+                    crate::durable_semantics::DurableParameterMode::Value
+                }
+                rue_rir::RirArgMode::Borrow => {
+                    crate::durable_semantics::DurableParameterMode::Borrow
+                }
+                rue_rir::RirArgMode::Inout => crate::durable_semantics::DurableParameterMode::Inout,
+            })
+            .collect::<Vec<_>>();
+        let admission = self
+            .authority
+            .finish_comptime_call_admission(start, &modes)
+            .map_err(durable_provider_error)?;
+        self.authority
+            .durable_session_mut()
+            .admit_bound_expression_call(reservation, admission)
+            .map_err(|error| {
+                durable_host_error(DurableComptimeFailure::resolution(format!(
+                    "durable call lifecycle: {error:?}"
+                )))
+            })
+    }
+}
+
+fn durable_host_failure(error: DurableComptimeFailure) -> DurableComptimeHostFailure {
+    match error {
+        DurableComptimeFailure::Failure(failure) => DurableComptimeHostFailure::semantic(failure),
+        DurableComptimeFailure::Abort(abort) => DurableComptimeHostFailure::query_abort(abort),
+    }
+}
+
+fn durable_diagnostic_failure(
+    site: &DurableComptimeDiagnosticSite,
+    kind: rue_error::ErrorKind,
+) -> DurableComptimeHostFailure {
+    DurableComptimeHostFailure::semantic(Box::new(
+        SemanticNucleusFailure::DiagnosticAtProducerRange {
+            kind,
+            producer: site.producer.clone(),
+            start: site.start,
+            end: site.end,
+        },
+    ))
+}
+
+fn durable_host_error(
+    error: DurableComptimeFailure,
+) -> rue_air::ComptimeHostError<DurableComptimeHostFailure> {
+    error.into_host_error()
+}
+
+fn durable_provider_error(
+    error: rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+) -> rue_air::ComptimeHostError<DurableComptimeHostFailure> {
+    match error {
+        rue_air::SemanticProviderError::Abort(error) => {
+            rue_air::ComptimeHostError::Abort(DurableComptimeHostFailure::query_abort(error))
+        }
+        rue_air::SemanticProviderError::Failure(error) => rue_air::ComptimeHostError::HostFailure(
+            DurableComptimeHostFailure::semantic(Box::new(error)),
+        ),
+    }
+}
+
+fn durable_foreign_call_error(
+    error: DurableComptimeForeignCallError,
+) -> rue_air::ComptimeHostError<DurableComptimeHostFailure> {
+    match error {
+        DurableComptimeForeignCallError::ReadyFailure(failure) => {
+            rue_air::ComptimeHostError::HostFailure(DurableComptimeHostFailure::semantic(Box::new(
+                failure,
+            )))
+        }
+        DurableComptimeForeignCallError::StructuredFrame(
+            DurableComptimeStructuredFrameAdmissionError::ValueFit(failure),
+        ) => rue_air::ComptimeHostError::HostFailure(DurableComptimeHostFailure::semantic(failure)),
+        DurableComptimeForeignCallError::ReadyQueryFailure(failure) => {
+            rue_air::ComptimeHostError::HostFailure(DurableComptimeHostFailure::query_failure(
+                failure,
+            ))
+        }
+        DurableComptimeForeignCallError::AdmissionFailure(failure) => {
+            durable_projection_failure_error(failure)
+        }
+        DurableComptimeForeignCallError::FrameAdmission(failure) => durable_host_error(
+            DurableComptimeFailure::resolution(durable_frame_admission_failure_reason(failure)),
+        ),
+        DurableComptimeForeignCallError::StructuredFrame(failure) => durable_host_error(
+            DurableComptimeFailure::resolution(durable_structured_frame_failure_reason(failure)),
+        ),
+        DurableComptimeForeignCallError::UnexpectedReadyProjection => {
+            durable_host_error(DurableComptimeFailure::resolution(
+                "durable comptime call returned an unexpected projection",
+            ))
+        }
+        DurableComptimeForeignCallError::Lifecycle(failure) => durable_host_error(
+            DurableComptimeFailure::resolution(durable_lifecycle_failure_reason(failure)),
+        ),
+    }
+}
+
+/// Maps candidate-artifact failures into the durable semantic channel.  Query
+/// failures remain an outer query channel; callers must preserve that split.
+pub(crate) fn durable_candidate_rir_semantic_failure(
+    failure: &crate::revisioned_query_database::DeclarationBodyPlanFailure,
+) -> SemanticNucleusFailure {
+    use crate::revisioned_query_database::DeclarationBodyPlanFailure as Artifact;
+
+    match failure {
+        Artifact::Build(kind) => SemanticNucleusFailure::Diagnostic(kind.clone()),
+        Artifact::CandidateRirRejected(errors) => {
+            SemanticNucleusFailure::Syntax(Arc::from(errors.to_string()))
+        }
+        failure => SemanticNucleusFailure::Resolution(Arc::from(format!(
+            "candidate RIR artifact failed: {failure:?}"
+        ))),
+    }
+}
+
+/// Maps candidate materialization failures into the durable semantic channel,
+/// retaining query cancellation as an outer abort.
+pub(crate) fn durable_materialization_semantic_failure(
+    failure: crate::canonical_lower::BodyPlanMaterializationFailure,
+) -> Result<SemanticNucleusFailure, QueryAbort> {
+    use crate::canonical_lower::BodyPlanMaterializationFailure as Materialization;
+
+    match failure {
+        Materialization::Query(abort) => Err(abort),
+        Materialization::Build(error) => Ok(SemanticNucleusFailure::Diagnostic(
+            crate::canonical_lower::rir_build_error_kind(
+                "declaration-time candidate materialization",
+                &error,
+            ),
+        )),
+        Materialization::Invalid(detail) => Ok(SemanticNucleusFailure::Resolution(detail)),
+    }
+}
+
+fn durable_projection_failure_error(
+    failure: crate::body_query::ComptimeProgramProjectionFailure,
+) -> rue_air::ComptimeHostError<DurableComptimeHostFailure> {
+    use crate::body_query::ComptimeProgramProjectionFailure as Projection;
+    use crate::canonical_lower::BodyPlanMaterializationFailure as Materialization;
+    use SemanticNucleusFailure as Failure;
+
+    let failure = match failure {
+        Projection::Materialization(Materialization::Query(abort)) => {
+            return rue_air::ComptimeHostError::Abort(DurableComptimeHostFailure::query_abort(
+                abort,
+            ));
+        }
+        Projection::Materialization(failure) => {
+            match durable_materialization_semantic_failure(failure) {
+                Ok(failure) => failure,
+                Err(abort) => {
+                    return rue_air::ComptimeHostError::Abort(
+                        DurableComptimeHostFailure::query_abort(abort),
+                    );
+                }
+            }
+        }
+        Projection::Artifact(failure) => durable_candidate_rir_semantic_failure(&failure),
+        Projection::ArtifactQueryFailure(failure) => {
+            return rue_air::ComptimeHostError::HostFailure(
+                DurableComptimeHostFailure::query_failure(failure),
+            );
+        }
+        Projection::NotFunction { .. } => Failure::Resolution(Arc::from(
+            "comptime candidate artifact has a non-function root",
+        )),
+        Projection::NotConst { .. } => Failure::Resolution(Arc::from(
+            "constant candidate artifact has a non-constant root",
+        )),
+        Projection::InvalidProducer(producer) => Failure::Resolution(Arc::from(format!(
+            "{:?}",
+            Projection::InvalidProducer(producer)
+        ))),
+        Projection::IdentityMismatch => {
+            Failure::Resolution(Arc::from(format!("{:?}", Projection::IdentityMismatch)))
+        }
+    };
+    DurableComptimeHostFailure::semantic(Box::new(failure)).into_host_error()
+}
+
+fn durable_frame_admission_failure_reason(
+    failure: DurableComptimeForeignFrameAdmissionError,
+) -> &'static str {
+    match failure {
+        DurableComptimeForeignFrameAdmissionError::NotCallable => {
+            "durable comptime call root is not callable"
+        }
+        DurableComptimeForeignFrameAdmissionError::TicketMismatch => {
+            "durable comptime call ticket does not match its program"
+        }
+        DurableComptimeForeignFrameAdmissionError::RegistryMismatch => {
+            "durable comptime call program is not registered"
+        }
+    }
+}
+
+fn durable_structured_frame_failure_reason(
+    failure: DurableComptimeStructuredFrameAdmissionError,
+) -> &'static str {
+    match failure {
+        DurableComptimeStructuredFrameAdmissionError::InvalidContract => {
+            "durable structured comptime call has an invalid contract"
+        }
+        DurableComptimeStructuredFrameAdmissionError::ValueFit(_) => {
+            "durable structured comptime call argument does not fit"
+        }
+        DurableComptimeStructuredFrameAdmissionError::ResultNotType => {
+            "durable structured comptime call result is not a type"
+        }
+    }
+}
+
+fn durable_lifecycle_failure_reason(failure: DurableComptimeLifecycleError) -> &'static str {
+    match failure {
+        DurableComptimeLifecycleError::TicketMismatch => "durable call lifecycle ticket mismatch",
+        DurableComptimeLifecycleError::BindingMismatch => "durable call lifecycle binding mismatch",
+        DurableComptimeLifecycleError::InvalidProgramAuthority => {
+            "durable call lifecycle invalid program authority"
+        }
+        DurableComptimeLifecycleError::NotEntered => "durable call lifecycle call was not entered",
+        DurableComptimeLifecycleError::OutOfOrder => {
+            "durable call lifecycle call finished out of order"
+        }
+        DurableComptimeLifecycleError::TicketReused => "durable call lifecycle ticket was reused",
+        DurableComptimeLifecycleError::InvalidContext => "durable call lifecycle invalid context",
+        DurableComptimeLifecycleError::ReadyProjectionRequired => {
+            "durable call lifecycle requires a ready projection"
+        }
+    }
+}
+
+/// Normalized type-syntax terminal shared by the durable comptime and
+/// signature-query adapters. Nested comptime-call arguments are reduced to
+/// their terminal so each context can apply its own diagnostic policy once.
+#[derive(Debug)]
+pub(crate) enum DurableTypeSyntaxClassification {
+    Abort(QueryAbort),
+    Failure(SemanticNucleusFailure),
+    Semantic(rue_air::SemanticTypeSyntaxFailure<crate::StableDefinitionKey, Arc<str>>),
+}
+
+pub(crate) fn classify_durable_type_syntax_failure(
+    error: rue_air::SemanticTypeSyntaxError<
+        QueryAbort,
+        SemanticNucleusFailure,
+        crate::StableDefinitionKey,
+        Arc<str>,
+    >,
+) -> DurableTypeSyntaxClassification {
+    use rue_air::SemanticResolutionError as E;
+
+    match error {
+        E::ProviderAbort(abort) => DurableTypeSyntaxClassification::Abort(abort),
+        E::ProviderFailure(failure) => DurableTypeSyntaxClassification::Failure(failure),
+        E::Semantic(failure) => DurableTypeSyntaxClassification::Semantic(failure),
+        E::ComptimeCallTypeArgument { error, .. } => classify_durable_type_syntax_failure(*error),
+    }
+}
+
+/// Durable comptime's type-syntax adapter preserves its historical
+/// resolution-shaped debug diagnostic. Signature queries intentionally use a
+/// separate detailed adapter in `revisioned_query_database`.
+pub(crate) fn durable_comptime_type_syntax_failure(
+    error: rue_air::SemanticTypeSyntaxError<
+        QueryAbort,
+        SemanticNucleusFailure,
+        crate::StableDefinitionKey,
+        Arc<str>,
+    >,
+) -> DurableComptimeFailure {
+    match classify_durable_type_syntax_failure(error) {
+        DurableTypeSyntaxClassification::Abort(abort) => DurableComptimeFailure::abort(abort),
+        DurableTypeSyntaxClassification::Failure(failure) => {
+            DurableComptimeFailure::failure(failure)
+        }
+        DurableTypeSyntaxClassification::Semantic(failure) => {
+            DurableComptimeFailure::resolution(format!("Semantic({failure:?})"))
+        }
+    }
+}
+
+fn durable_type_syntax_error(
+    error: rue_air::SemanticTypeSyntaxError<
+        QueryAbort,
+        SemanticNucleusFailure,
+        crate::StableDefinitionKey,
+        Arc<str>,
+    >,
+) -> rue_air::ComptimeHostError<DurableComptimeHostFailure> {
+    durable_comptime_type_syntax_failure(error).into_host_error()
+}
+
+fn durable_host_error_outcome<T>(
+    error: rue_air::ComptimeHostError<DurableComptimeHostFailure>,
+) -> rue_air::ComptimeOutcome<T, DurableComptimeHostFailure> {
+    match error {
+        rue_air::ComptimeHostError::HostFailure(error) => {
+            rue_air::ComptimeOutcome::HostFailure(error)
+        }
+        rue_air::ComptimeHostError::Abort(error) => rue_air::ComptimeOutcome::Abort(error),
+    }
+}
+
+/// AIR supplies compact operator tokens; durable diagnostics use the
+/// operation names from the legacy declaration evaluator.  Unary negation is
+/// passed as its own token by the canonical engine so it cannot be confused
+/// with subtraction.
+fn durable_arithmetic_operation_name(operation: &str) -> &str {
+    match operation {
+        "+" => "addition",
+        "-" => "subtraction",
+        "*" => "multiplication",
+        "/" => "division",
+        "%" => "remainder",
+        "<<" => "left shift",
+        ">>" => "right shift",
+        "negation" => "negation",
+        other => other,
+    }
+}
+
+impl<A: DurableComptimeHostAuthority + ?Sized> rue_air::ComptimeHost
+    for DurableComptimeHost<'_, A>
+{
+    type Type = DurableComptimeType;
+    type Value = EvaluatedSemanticConst;
+    type Name = DurableComptimeName;
+    type File = DurableComptimeFile;
+    type CanonicalIdentity = DurableComptimeIdentity;
+    type AnonymousIdentity = DurableComptimeAnonymousIdentity;
+    type ProgramKey = crate::body_query::DurableComptimeProgramKey;
+    type Failure = DurableComptimeHostFailure;
+    type CallAdmission = DurableComptimeAdmittedCall;
+    type CallBinding = DurableComptimeBinding;
+    type BoundCall = DurableComptimeBoundCall;
+    type CompletionTicket = Box<DurableComptimeCallTicket>;
+    type StructuredTypeSuspension = DurableStructuredTypeJob;
+
+    fn check_canceled(&self) -> rue_air::ComptimeHostResult<(), Self::Failure> {
+        self.authority.check_canceled().map_err(|abort| {
+            rue_air::ComptimeHostError::Abort(DurableComptimeHostFailure::query_abort(abort))
+        })
+    }
+
+    fn program_rir(&self, program: &Self::ProgramKey) -> &rue_rir::Rir {
+        self.program_rir(program)
+    }
+
+    fn name_from_symbol(
+        &self,
+        program: &Self::ProgramKey,
+        symbol: rue_rir::SymbolHandle,
+    ) -> Self::Name {
+        self.name_from_symbol(program, symbol)
+    }
+
+    fn display_name(&self, name: &Self::Name) -> String {
+        name.as_str().to_owned()
+    }
+
+    fn file_for_program_span(
+        &self,
+        program: &Self::ProgramKey,
+        span: &rue_span::Span,
+    ) -> Self::File {
+        self.file_for_program_span(program, span)
+    }
+
+    fn resolve_comptime_named_value(
+        &mut self,
+        file: Self::File,
+        name: Self::Name,
+        _span: rue_span::Span,
+    ) -> rue_air::ComptimeHostResult<
+        rue_air::ComptimeNamedValueResolution<Self::Value>,
+        Self::Failure,
+    > {
+        let program = file.program().clone();
+        let projection = self
+            .authority
+            .resolve_named_value(
+                &program.declaration,
+                program.declaration.module(),
+                name.as_str(),
+            )
+            .map_err(durable_provider_error)?;
+        let Some(projection) = projection else {
+            return Ok(rue_air::ComptimeNamedValueResolution::Missing);
+        };
+        let (value, dependency) = projection.into_parts();
+        self.authority
+            .durable_session_mut()
+            .observe_dependency(dependency);
+        Ok(rue_air::ComptimeNamedValueResolution::Known(value))
+    }
+
+    fn match_pattern(
+        &self,
+        pattern: &rue_air::ComptimeMatchPattern<Self::Name>,
+        value: &Self::Value,
+    ) -> Option<bool> {
+        Some(durable_match_pattern_matches(pattern, value))
+    }
+
+    fn match_no_selected_arm(
+        &self,
+        _site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> rue_air::ComptimeOutcome<Self::Value, Self::Failure> {
+        match durable_host_error(DurableComptimeFailure::comptime_match_no_selected_arm()) {
+            rue_air::ComptimeHostError::HostFailure(error) => {
+                rue_air::ComptimeOutcome::HostFailure(error)
+            }
+            rue_air::ComptimeHostError::Abort(error) => rue_air::ComptimeOutcome::Abort(error),
+        }
+    }
+
+    fn reject_comptime_expression(
+        &self,
+        rejection: rue_air::ComptimeSemanticRejection<Self::Value>,
+        _site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> rue_air::ComptimeOutcome<Self::Value, Self::Failure> {
+        match durable_host_error(DurableComptimeFailure::comptime_rejection(rejection)) {
+            rue_air::ComptimeHostError::HostFailure(error) => {
+                rue_air::ComptimeOutcome::HostFailure(error)
+            }
+            rue_air::ComptimeHostError::Abort(error) => rue_air::ComptimeOutcome::Abort(error),
+        }
+    }
+
+    fn evaluate_binary_rhs_after_rejection(&self) -> bool {
+        true
+    }
+
+    fn require_preview(
+        &self,
+        feature: rue_error::PreviewFeature,
+        what: &str,
+        site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> rue_air::ComptimeHostResult<(), Self::Failure> {
+        if site
+            .program()
+            .configuration
+            .preview_features
+            .contains(feature)
+        {
+            return Ok(());
+        }
+        Err(rue_air::ComptimeHostError::HostFailure(
+            durable_diagnostic_failure(
+                &self.diagnostic_site(site),
+                rue_error::ErrorKind::PreviewFeatureRequired {
+                    feature,
+                    what: what.to_owned(),
+                },
+            ),
+        ))
+    }
+
+    fn depth_exceeded(
+        &self,
+        name: &Self::Name,
+        depth: usize,
+        _site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> Self::Failure {
+        durable_host_failure(DurableComptimeFailure::maximum_depth(name.as_str(), depth))
+    }
+
+    fn literal_out_of_range(
+        &self,
+        value: u64,
+        ty: &Self::Type,
+        site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> Self::Failure {
+        durable_diagnostic_failure(
+            &self.diagnostic_site(site),
+            rue_error::ErrorKind::LiteralOutOfRange {
+                value,
+                ty: DurableComptimeScalarPolicy::type_name(ty.as_ref()),
+            },
+        )
+    }
+
+    fn float_not_implemented(
+        &self,
+        site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> Self::Failure {
+        durable_diagnostic_failure(
+            &self.diagnostic_site(site),
+            rue_error::ErrorKind::FloatNotYetImplemented,
+        )
+    }
+
+    fn cannot_negate(
+        &self,
+        ty: &Self::Type,
+        site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> Self::Failure {
+        durable_diagnostic_failure(
+            &self.diagnostic_site(site),
+            rue_error::ErrorKind::CannotNegate(DurableComptimeScalarPolicy::type_name(ty.as_ref())),
+        )
+    }
+
+    fn unsupported_anon_method_type_param(
+        &self,
+        method_name: &str,
+        site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> Self::Failure {
+        durable_host_failure(DurableComptimeFailure::comptime_failure_at(
+            &self.diagnostic_site(site),
+            format!(
+                "method '{method_name}' declares its own `comptime` type parameter, which is not yet supported (a method cannot be monomorphized over its own type parameter); move the type parameter to the enclosing type constructor instead"
+            ),
+        ))
+    }
+
+    fn non_function_anon_method(
+        &self,
+        site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> Self::Failure {
+        durable_host_failure(DurableComptimeFailure::comptime_failure_at(
+            &self.diagnostic_site(site),
+            "anonymous type carries a non-function method instruction",
+        ))
+    }
+
+    fn resolve_named_array_length(
+        &mut self,
+        name: &Self::Name,
+        site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+        _values: Option<&AHashMap<Self::Name, Self::Value>>,
+        binding: rue_air::ComptimeArrayLengthBinding<Self::Value>,
+    ) -> rue_air::ComptimeOutcome<u64, Self::Failure> {
+        let decision = classify_durable_named_array_length(
+            name.as_str(),
+            durable_array_length_binding_from_air(binding),
+        );
+        let decision = match decision {
+            Ok(decision) => decision,
+            Err(error) => {
+                return rue_air::ComptimeOutcome::HostFailure(durable_diagnostic_failure(
+                    &self.diagnostic_site(site),
+                    match durable_named_array_length_failure(name.as_str(), error) {
+                        SemanticNucleusFailure::Diagnostic(kind) => kind,
+                        failure => {
+                            return rue_air::ComptimeOutcome::HostFailure(
+                                DurableComptimeHostFailure::semantic(Box::new(failure)),
+                            );
+                        }
+                    },
+                ));
+            }
+        };
+        match decision {
+            DurableComptimeArrayLengthDecision::Concrete(value) => {
+                rue_air::ComptimeOutcome::Known(value)
+            }
+            DurableComptimeArrayLengthDecision::RuntimeDependent => {
+                rue_air::ComptimeOutcome::RuntimeDependent
+            }
+            DurableComptimeArrayLengthDecision::Shadowed => {
+                let failure = durable_named_array_length_failure(
+                    name.as_str(),
+                    DurableComptimeArrayLengthError::NonInteger,
+                );
+                rue_air::ComptimeOutcome::HostFailure(DurableComptimeHostFailure::semantic(
+                    Box::new(failure),
+                ))
+            }
+            DurableComptimeArrayLengthDecision::ResolveGlobal => {
+                let program = site.program();
+                let projection = match self.authority.resolve_named_value(
+                    &program.declaration,
+                    program.declaration.module(),
+                    name.as_str(),
+                ) {
+                    Ok(Some(projection)) => projection,
+                    Ok(None) => {
+                        return rue_air::ComptimeOutcome::HostFailure(
+                            DurableComptimeHostFailure::semantic(Box::new(
+                                SemanticNucleusFailure::Resolution(Arc::from(format!(
+                                    "undefined constant `{}`",
+                                    name.as_str()
+                                ))),
+                            )),
+                        );
+                    }
+                    Err(error) => {
+                        return match durable_provider_error(error) {
+                            rue_air::ComptimeHostError::HostFailure(error) => {
+                                rue_air::ComptimeOutcome::HostFailure(error)
+                            }
+                            rue_air::ComptimeHostError::Abort(error) => {
+                                rue_air::ComptimeOutcome::Abort(error)
+                            }
+                        };
+                    }
+                };
+                let (value, dependency) = projection.into_parts();
+                self.authority
+                    .durable_session_mut()
+                    .observe_dependency(dependency);
+                match durable_named_array_length_value(&value) {
+                    Ok(value) => rue_air::ComptimeOutcome::Known(value),
+                    Err(error) => {
+                        rue_air::ComptimeOutcome::HostFailure(DurableComptimeHostFailure::semantic(
+                            Box::new(durable_named_array_length_failure(name.as_str(), error)),
+                        ))
+                    }
+                }
+            }
+        }
+    }
+
+    fn rir_type_named_symbol(
+        &self,
+        program: &Self::ProgramKey,
+        syntax: rue_rir::RirTypeSyntaxRef,
+    ) -> Option<Self::Name> {
+        let registered = self
+            .authority
+            .durable_session()
+            .registered_program(program)?;
+        let rue_rir::RirTypeSyntaxNode::Named(symbol) =
+            registered.rir.type_syntax().node(syntax)?
+        else {
+            return None;
+        };
+        let symbol = registered.rir.type_syntax().symbol(*symbol)?;
+        registered
+            .symbols
+            .get(symbol.into_usize())
+            .cloned()
+            .map(DurableComptimeName::from)
+    }
+
+    fn render_rir_type(
+        &self,
+        program: &Self::ProgramKey,
+        syntax: rue_rir::RirTypeSyntaxRef,
+    ) -> String {
+        let registered = self
+            .authority
+            .durable_session()
+            .registered_program(program)
+            .expect("durable AIR type syntax must reference a registered program");
+        registered
+            .rir
+            .type_syntax()
+            .render_type_with(syntax, |symbol| {
+                registered.symbols[symbol.into_usize()].as_ref()
+            })
+            .expect("validated durable type syntax")
+    }
+
+    fn get_or_create_array_type(&mut self, element: Self::Type, length: u64) -> Self::Type {
+        DurableComptimeType(DurableType::Array {
+            element: Arc::new(element.0),
+            len: length,
+        })
+    }
+
+    fn find_or_create_anon_struct(
+        &mut self,
+        identity: Self::AnonymousIdentity,
+        fields: &[rue_air::ComptimeField<Self::Name, Self::Type>],
+        sigs: &[rue_air::ComptimeMethodDescriptor<Self::Name, Self::Type>],
+        type_subst: &AHashMap<Self::Name, Self::Type>,
+        value_subst: &AHashMap<Self::Name, Self::Value>,
+    ) -> rue_air::ComptimeHostResult<(Self::Type, bool), Self::Failure> {
+        let fields = fields
+            .iter()
+            .map(|field| rue_air::ComptimeField {
+                name: field.name.0.clone(),
+                ty: field.ty.0.clone(),
+            })
+            .collect::<Vec<_>>();
+        let methods = sigs
+            .iter()
+            .map(|method| rue_air::ComptimeMethodDescriptor {
+                name: method.name.0.clone(),
+                has_self: method.has_self,
+                self_mode: method.self_mode,
+                returns_borrow: method.returns_borrow,
+                returns_inout: method.returns_inout,
+                parameters: method
+                    .parameters
+                    .iter()
+                    .map(|parameter| rue_air::ComptimeMethodParameter {
+                        ty: match &parameter.ty {
+                            rue_air::ComptimeMethodType::SelfType => {
+                                rue_air::ComptimeMethodType::SelfType
+                            }
+                            rue_air::ComptimeMethodType::Concrete(ty) => {
+                                rue_air::ComptimeMethodType::Concrete(ty.0.clone())
+                            }
+                            rue_air::ComptimeMethodType::Unsupported(shape) => {
+                                rue_air::ComptimeMethodType::Unsupported(shape.clone())
+                            }
+                        },
+                        mode: parameter.mode,
+                        is_comptime: parameter.is_comptime,
+                        is_comptime_type: parameter.is_comptime_type,
+                    })
+                    .collect(),
+                parameter_names: method
+                    .parameter_names
+                    .iter()
+                    .map(|name| name.0.clone())
+                    .collect(),
+                result: match &method.result {
+                    rue_air::ComptimeMethodType::SelfType => rue_air::ComptimeMethodType::SelfType,
+                    rue_air::ComptimeMethodType::Concrete(ty) => {
+                        rue_air::ComptimeMethodType::Concrete(ty.0.clone())
+                    }
+                    rue_air::ComptimeMethodType::Unsupported(shape) => {
+                        rue_air::ComptimeMethodType::Unsupported(shape.clone())
+                    }
+                },
+                declaration_span: method.declaration_span,
+            })
+            .collect::<Vec<_>>();
+        let type_captures = type_subst
+            .iter()
+            .map(|(name, ty)| (name.0.clone(), ty.0.clone()))
+            .collect::<Vec<_>>();
+        let mut value_captures = Vec::with_capacity(value_subst.len());
+        for (name, value) in value_subst {
+            let EvaluatedSemanticConst::Value(value) = value else {
+                // Module and target locals are lexical context, not captured
+                // durable value parameters. The legacy evaluator excludes
+                // these non-const values from anonymous nominal identity.
+                continue;
+            };
+            value_captures.push((name.0.clone(), value.value.clone()));
+        }
+        let ty = project_durable_anonymous_nominal(
+            self.authority.durable_session_mut(),
+            DurableAnonymousNominalDescriptor {
+                identity: identity.key().clone(),
+                shape: DurableAnonymousNominalDescriptorShape::Struct {
+                    fields: fields.into(),
+                    methods: methods.into(),
+                },
+                type_captures: type_captures.into(),
+                value_captures: value_captures.into(),
+            },
+        )
+        .map_err(durable_host_error)?;
+        Ok((ty.into(), true))
+    }
+
+    fn find_or_create_anon_enum(
+        &mut self,
+        identity: Self::AnonymousIdentity,
+        names: &[String],
+        payloads: &[Vec<Self::Type>],
+        type_subst: &AHashMap<Self::Name, Self::Type>,
+        value_subst: &AHashMap<Self::Name, Self::Value>,
+    ) -> rue_air::ComptimeHostResult<Self::Type, Self::Failure> {
+        let variants = names
+            .iter()
+            .zip(payloads)
+            .map(|(name, payload)| {
+                (
+                    Arc::from(name.as_str()),
+                    payload
+                        .iter()
+                        .map(|ty| ty.0.clone())
+                        .collect::<Vec<_>>()
+                        .into(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let type_captures = type_subst
+            .iter()
+            .map(|(name, ty)| (name.0.clone(), ty.0.clone()))
+            .collect::<Vec<_>>();
+        let mut value_captures = Vec::with_capacity(value_subst.len());
+        for (name, value) in value_subst {
+            let EvaluatedSemanticConst::Value(value) = value else {
+                // Keep module/target locals out of nominal captures just as
+                // the durable evaluator does; they are lexical context, not
+                // value-parameter identity.
+                continue;
+            };
+            value_captures.push((name.0.clone(), value.value.clone()));
+        }
+        project_durable_anonymous_nominal(
+            self.authority.durable_session_mut(),
+            DurableAnonymousNominalDescriptor {
+                identity: identity.key().clone(),
+                shape: DurableAnonymousNominalDescriptorShape::Enum {
+                    variants: variants.into(),
+                },
+                type_captures: type_captures.into(),
+                value_captures: value_captures.into(),
+            },
+        )
+        .map(DurableComptimeType)
+        .map_err(durable_host_error)
+    }
+
+    fn check_require_droppable(
+        &mut self,
+        ty: Self::Type,
+        site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> rue_air::ComptimeHostResult<(), Self::Failure> {
+        let source = self.diagnostic_site(site);
+        self.authority
+            .durable_session_mut()
+            .observe_deferred_ownership(DeferredOwnershipGate {
+                kind: crate::semantic_query_nucleus::DeferredOwnershipGateKind::RequireDroppable,
+                ty: ty.0,
+                source: Arc::new(crate::semantic_query_nucleus::DeferredOwnershipGateSource {
+                    declaration: source.producer,
+                    start: source.start,
+                    end: source.end,
+                }),
+                application: None,
+            });
+        Ok(())
+    }
+
+    fn check_trivially_droppable(
+        &mut self,
+        ty: Self::Type,
+        site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> rue_air::ComptimeHostResult<(), Self::Failure> {
+        let source = self.diagnostic_site(site);
+        self.authority
+            .durable_session_mut()
+            .observe_deferred_ownership(DeferredOwnershipGate {
+            kind:
+                crate::semantic_query_nucleus::DeferredOwnershipGateKind::RequireTriviallyDroppable,
+            ty: ty.0,
+            source: Arc::new(crate::semantic_query_nucleus::DeferredOwnershipGateSource {
+                declaration: source.producer,
+                start: source.start,
+                end: source.end,
+            }),
+            application: None,
+        });
+        Ok(())
+    }
+
+    fn type_name(&self, ty: &Self::Type) -> String {
+        DurableComptimeScalarPolicy::type_name(ty.as_ref())
+    }
+
+    fn type_is_unsigned(&self, ty: &Self::Type) -> bool {
+        DurableComptimeScalarPolicy::type_is_unsigned(ty.as_ref())
+    }
+
+    fn reject_unsigned_negation(
+        &self,
+        _ty: &Self::Type,
+        _site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> Option<Self::Failure> {
+        // Legacy declaration evaluation reports the checked integer overflow
+        // from `finish_arith`, rather than AIR's ordinary CannotNegate policy.
+        None
+    }
+
+    fn type_integer_semantics(
+        &self,
+        ty: &Self::Type,
+    ) -> Option<rue_air::integer_semantics::IntegerType> {
+        DurableComptimeScalarPolicy::type_integer_semantics(ty.as_ref())
+    }
+
+    fn resolve_comptime_type_intrinsic(
+        &mut self,
+        intrinsic: rue_air::ComptimeTypeIntrinsic,
+        ty: Self::Type,
+        site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> rue_air::ComptimeHostResult<Option<Self::Value>, Self::Failure> {
+        match intrinsic {
+            rue_air::ComptimeTypeIntrinsic::RequireDroppable => {
+                self.check_require_droppable(ty, site)?;
+                Ok(Some(EvaluatedSemanticConst::unit()))
+            }
+            rue_air::ComptimeTypeIntrinsic::RequireTriviallyDroppable => {
+                self.check_trivially_droppable(ty, site)?;
+                Ok(Some(EvaluatedSemanticConst::unit()))
+            }
+            rue_air::ComptimeTypeIntrinsic::IntegerBound(bound) => {
+                let value = DurableComptimeTypeIntrinsicPolicy::integer_bound(bound, ty.as_ref())
+                    .map_err(durable_host_error)?;
+                Ok(Some(EvaluatedSemanticConst::integer_typed(value, Some(ty))))
+            }
+        }
+    }
+
+    fn const_expr_type(
+        &self,
+        _program: &Self::ProgramKey,
+        _env: &rue_air::ComptimeEnv<
+            '_,
+            Self::Value,
+            Self::Type,
+            Self::Name,
+            Self::File,
+            Self::CanonicalIdentity,
+        >,
+        _inst_ref: rue_rir::InstRef,
+    ) -> Option<Self::Type> {
+        None
+    }
+
+    fn finish_arith(
+        &self,
+        result: rue_air::integer_semantics::CheckedIntegerResult,
+        ty: Option<Self::Type>,
+        op: &str,
+        _site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> rue_air::ComptimeHostResult<Option<Self::Value>, Self::Failure> {
+        let ty = ty.unwrap_or(DurableComptimeType(DurableType::I32));
+        let value = DurableComptimeScalarPolicy::checked_integer_result(
+            ty.as_ref(),
+            result,
+            durable_arithmetic_operation_name(op),
+        )
+        .map_err(durable_host_error)?;
+        Ok(Some(EvaluatedSemanticConst::integer_typed(value, Some(ty))))
+    }
+
+    fn integer_operation_type(
+        &self,
+        resolved_type: Option<&Self::Type>,
+        lhs: &Self::Value,
+        rhs: &Self::Value,
+        _site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> rue_air::ComptimeHostResult<Option<Self::Type>, Self::Failure> {
+        let lhs_type = lhs.as_integer_type();
+        let rhs_type = rhs.as_integer_type();
+        let ty = DurableComptimeScalarPolicy::integer_operation_type(
+            resolved_type.map(AsRef::as_ref),
+            lhs_type.as_ref().map(AsRef::as_ref),
+            rhs_type.as_ref().map(AsRef::as_ref),
+        )
+        .map_err(durable_host_error)?;
+        if let Some(value) = lhs.as_integer() {
+            DurableComptimeScalarPolicy::require_integer_fits(&ty, value)
+                .map_err(durable_host_error)?;
+        }
+        if let Some(value) = rhs.as_integer() {
+            DurableComptimeScalarPolicy::require_integer_fits(&ty, value)
+                .map_err(durable_host_error)?;
+        }
+        Ok(Some(DurableComptimeType(ty)))
+    }
+
+    fn unary_integer_type(
+        &self,
+        resolved_type: Option<&Self::Type>,
+        operand: &Self::Value,
+        _site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> rue_air::ComptimeHostResult<Option<Self::Type>, Self::Failure> {
+        let operand = operand.as_integer_type();
+        DurableComptimeScalarPolicy::unary_integer_type(
+            resolved_type.map(AsRef::as_ref),
+            operand.as_ref().map(AsRef::as_ref),
+        )
+        .map(|ty| Some(DurableComptimeType(ty)))
+        .map_err(durable_host_error)
+    }
+
+    fn compare_comptime_values(
+        &mut self,
+        lhs: &Self::Value,
+        rhs: &Self::Value,
+        equal: bool,
+        _site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> rue_air::ComptimeOutcome<Self::Value, Self::Failure> {
+        if let (EvaluatedSemanticConst::TargetEnum(lhs), EvaluatedSemanticConst::TargetEnum(rhs)) =
+            (lhs, rhs)
+        {
+            return rue_air::ComptimeOutcome::Known(EvaluatedSemanticConst::boolean(if equal {
+                lhs == rhs
+            } else {
+                lhs != rhs
+            }));
+        }
+        durable_host_error_outcome(durable_host_error(
+            DurableComptimeFailure::comptime_rejection(
+                rue_air::ComptimeSemanticRejection::ArithmeticOperandNotInteger {
+                    operation: rue_air::ComptimeIntegerOperation::Add,
+                    lhs: lhs.clone(),
+                    rhs: Some(rhs.clone()),
+                },
+            ),
+        ))
+    }
+
+    fn resolve_named_type_value(
+        &mut self,
+        _program: &Self::ProgramKey,
+        _name: Self::Name,
+        _span: rue_span::Span,
+    ) -> rue_air::ComptimeHostResult<Option<Self::Type>, Self::Failure> {
+        // Durable TypeConst names are resolved by the canonical keyed
+        // structured-type continuation below. Returning `None` here avoids a
+        // speculative named-value query/dependency before that resolver has
+        // established the exact type-syntax authority.
+        Ok(None)
+    }
+
+    fn resolve_comptime_type_path(
+        &mut self,
+        _file: Self::File,
+        segments: &[Self::Name],
+        _span: rue_span::Span,
+    ) -> rue_air::ComptimeHostResult<Option<Self::Value>, Self::Failure> {
+        // The only qualified enum values supported by declaration-time
+        // evaluation are the target descriptors. Their module/type spelling
+        // is already semantic data from AIR; no RIR inspection or ambient
+        // module inference is needed here.
+        if segments.len() != 2 || !matches!(segments[0].as_str(), "Arch" | "Os" | "DataModel") {
+            return Ok(None);
+        }
+        match self
+            .authority
+            .resolve_target_enum_variant(segments[0].as_str(), segments[1].as_str())
+        {
+            Ok(value) => Ok(Some(EvaluatedSemanticConst::TargetEnum(value))),
+            Err(error) => Err(durable_provider_error(error)),
+        }
+    }
+
+    fn resolve_module_comptime_callable(
+        &mut self,
+        _file_id: Self::File,
+        _segments: &[Self::Name],
+        _method: Self::Name,
+        _span: rue_span::Span,
+    ) -> rue_air::ComptimeHostResult<Option<Self::Name>, Self::Failure> {
+        Ok(None)
+    }
+
+    fn comptime_method_receiver_policy(&self) -> rue_air::ComptimeMethodReceiverPolicy {
+        rue_air::ComptimeMethodReceiverPolicy::EvaluateReceiver
+    }
+
+    fn admit_evaluated_comptime_method(
+        &mut self,
+        receiver: Self::Value,
+        method: Self::Name,
+        argument_count: usize,
+        argument_modes: &[rue_air::ComptimeArgMode],
+        env: &mut rue_air::ComptimeEnv<
+            '_,
+            Self::Value,
+            Self::Type,
+            Self::Name,
+            Self::File,
+            Self::CanonicalIdentity,
+        >,
+        _site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+        _span: rue_span::Span,
+    ) -> rue_air::ComptimeOutcome<
+        Option<rue_air::ComptimeCallAdmission<Self::CallAdmission, Self::Name>>,
+        Self::Failure,
+    > {
+        if argument_count != argument_modes.len() {
+            return rue_air::ComptimeOutcome::HostFailure(durable_host_failure(
+                DurableComptimeFailure::resolution(
+                    "durable comptime call argument metadata is inconsistent",
+                ),
+            ));
+        }
+        let EvaluatedSemanticConst::Module(module) = receiver else {
+            return rue_air::ComptimeOutcome::HostFailure(durable_host_failure(
+                DurableComptimeFailure::resolution(
+                    "method call in declaration-time comptime requires a module receiver",
+                ),
+            ));
+        };
+        let Some(file) = env.defining_file.as_ref() else {
+            return rue_air::ComptimeOutcome::RuntimeDependent;
+        };
+        match self.admit_call_for_module(
+            &file.program().declaration,
+            &module,
+            &method,
+            argument_modes,
+        ) {
+            Ok(admitted) => rue_air::ComptimeOutcome::Known(Some(rue_air::ComptimeCallAdmission {
+                name: method,
+                payload: admitted,
+            })),
+            Err(error) => durable_host_error_outcome(error),
+        }
+    }
+
+    fn admit_comptime_call(
+        &mut self,
+        name: Self::Name,
+        argument_count: usize,
+        argument_modes: &[rue_air::ComptimeArgMode],
+        env: &mut rue_air::ComptimeEnv<
+            '_,
+            Self::Value,
+            Self::Type,
+            Self::Name,
+            Self::File,
+            Self::CanonicalIdentity,
+        >,
+        _name_is_resolved_key: bool,
+    ) -> rue_air::ComptimeHostResult<
+        Option<rue_air::ComptimeCallAdmission<Self::CallAdmission, Self::Name>>,
+        Self::Failure,
+    > {
+        if argument_count != argument_modes.len() {
+            return Err(durable_host_error(DurableComptimeFailure::resolution(
+                "durable comptime call argument metadata is inconsistent",
+            )));
+        }
+        let Some(file) = env.defining_file.as_ref() else {
+            return Ok(None);
+        };
+        let program = file.program().clone();
+        let admitted = self.admit_call_for_module(
+            &program.declaration,
+            program.declaration.module(),
+            &name,
+            argument_modes,
+        )?;
+        Ok(Some(rue_air::ComptimeCallAdmission {
+            name,
+            payload: admitted,
+        }))
+    }
+
+    fn begin_comptime_call_binding(
+        &self,
+        admission: &rue_air::ComptimeCallAdmission<Self::CallAdmission, Self::Name>,
+        argument_count: usize,
+        _span: rue_span::Span,
+    ) -> rue_air::ComptimeHostResult<Self::CallBinding, Self::Failure> {
+        if admission.payload.parameters().len() != argument_count
+            || admission.payload.shell_parameters().len() != argument_count
+        {
+            return Err(durable_host_error(DurableComptimeFailure::resolution(
+                "durable comptime call binding arity mismatch",
+            )));
+        }
+        Ok(DurableComptimeBinding::new(&admission.payload))
+    }
+
+    fn bind_comptime_call_argument(
+        &self,
+        binding: &mut Self::CallBinding,
+        argument: rue_air::ComptimeCallArgument<Self::Value>,
+        index: usize,
+        _span: rue_span::Span,
+    ) -> rue_air::ComptimeHostResult<bool, Self::Failure> {
+        let Some(parameter) = binding.admission.parameters.get(index).cloned() else {
+            return Err(durable_host_error(DurableComptimeFailure::resolution(
+                "durable comptime call argument index is out of bounds",
+            )));
+        };
+        let Some(header) = binding.admission.shell_parameters.get(index).cloned() else {
+            return Err(durable_host_error(DurableComptimeFailure::resolution(
+                "durable comptime call shell argument index is out of bounds",
+            )));
+        };
+        let EvaluatedSemanticConst::Value(value) = argument.value() else {
+            return Err(durable_host_error(DurableComptimeFailure::resolution(
+                match argument.value() {
+                    EvaluatedSemanticConst::Module(_) => "module used where a value is required",
+                    EvaluatedSemanticConst::TargetEnum(_) => {
+                        "target descriptor used where a durable const value is required"
+                    }
+                    EvaluatedSemanticConst::Value(_) => unreachable!(),
+                },
+            )));
+        };
+        bind_durable_comptime_argument(
+            binding,
+            &header.name,
+            &parameter,
+            Arc::unwrap_or_clone(value.clone()),
+            argument.is_direct_unit_literal(),
+        )
+        .map_err(durable_host_error)?;
+        Ok(true)
+    }
+
+    fn finish_comptime_call_binding(
+        &mut self,
+        binding: Self::CallBinding,
+        _span: rue_span::Span,
+    ) -> rue_air::ComptimeHostResult<Option<Self::BoundCall>, Self::Failure> {
+        Ok(Some(binding.finish()))
+    }
+
+    fn prepare_comptime_call(
+        &mut self,
+        admission: rue_air::ComptimeCallAdmission<Self::CallAdmission, Self::Name>,
+        bound: Self::BoundCall,
+        span: rue_span::Span,
+    ) -> rue_air::ComptimeHostResult<
+        Option<
+            rue_air::ComptimeCallPreparation<
+                Self::Value,
+                Self::Type,
+                Self::Name,
+                Self::File,
+                Self::ProgramKey,
+                Self::CanonicalIdentity,
+                Self::Failure,
+                Self::CompletionTicket,
+            >,
+        >,
+        Self::Failure,
+    > {
+        let pending = self
+            .authority
+            .durable_session_mut()
+            .prepare_bound_expression_call(admission.payload, bound)
+            .map_err(|error| {
+                durable_host_error(DurableComptimeFailure::resolution(format!(
+                    "durable call lifecycle: {error:?}"
+                )))
+            })?;
+        let probed = DurableComptimeServices::new(&mut *self.authority)
+            .probe_prepared_call(pending)
+            .map_err(|abort| {
+                rue_air::ComptimeHostError::Abort(DurableComptimeHostFailure::query_abort(abort))
+            })?;
+        let prepared = self
+            .authority
+            .durable_session_mut()
+            .consume_probed_call(probed, span)
+            .map_err(durable_foreign_call_error)?;
+        Ok(Some(match prepared {
+            DurableComptimePreparedCall::Ready {
+                result,
+                expected_result,
+            } => {
+                let value = match result {
+                    crate::semantic_query_nucleus::ComptimeCallResultProjection::Type(value) => {
+                        DurableConstValue::Type(value)
+                    }
+                    crate::semantic_query_nucleus::ComptimeCallResultProjection::Value(value) => {
+                        value
+                    }
+                };
+                rue_air::ComptimeCallPreparation::Memoized(rue_air::ComptimeOutcome::Known(
+                    EvaluatedSemanticConst::Value(TypedSemanticConst::typed(
+                        value,
+                        expected_result,
+                    )),
+                ))
+            }
+            DurableComptimePreparedCall::Enter { frame, ticket } => {
+                rue_air::ComptimeCallPreparation::Enter {
+                    frame: *frame,
+                    ticket,
+                }
+            }
+            DurableComptimePreparedCall::NotReady => {
+                rue_air::ComptimeCallPreparation::Memoized(rue_air::ComptimeOutcome::NotReady)
+            }
+        }))
+    }
+
+    fn finish_comptime_call(
+        &mut self,
+        frame: &rue_air::ComptimeFrame<
+            Self::Value,
+            Self::Type,
+            Self::Name,
+            Self::File,
+            Self::ProgramKey,
+            Self::CanonicalIdentity,
+        >,
+        mut ticket: Self::CompletionTicket,
+        result: rue_air::ComptimeOutcome<Self::Value, Self::Failure>,
+    ) -> rue_air::ComptimeOutcome<Self::Value, Self::Failure> {
+        let result = match (result, frame.expected_result.as_ref()) {
+            (
+                rue_air::ComptimeOutcome::Known(EvaluatedSemanticConst::Value(value)),
+                Some(expected),
+            ) => rue_air::ComptimeOutcome::Known(EvaluatedSemanticConst::Value(
+                TypedSemanticConst::typed(value.value.clone(), expected.0.clone()),
+            )),
+            (result, _) => result,
+        };
+        match self
+            .authority
+            .durable_session_mut()
+            .finish_call(&mut ticket, &result)
+        {
+            Ok(()) => result,
+            Err(error) => rue_air::ComptimeOutcome::HostFailure(durable_host_failure(
+                DurableComptimeFailure::resolution(format!("durable call lifecycle: {error:?}")),
+            )),
+        }
+    }
+
+    fn enter_comptime_call(
+        &mut self,
+        _frame: &rue_air::ComptimeFrame<
+            Self::Value,
+            Self::Type,
+            Self::Name,
+            Self::File,
+            Self::ProgramKey,
+            Self::CanonicalIdentity,
+        >,
+        ticket: &Self::CompletionTicket,
+    ) -> rue_air::ComptimeHostResult<(), Self::Failure> {
+        self.authority
+            .durable_session_mut()
+            .enter_call(ticket)
+            .map_err(|error| {
+                durable_host_error(DurableComptimeFailure::resolution(format!(
+                    "durable call lifecycle: {error:?}"
+                )))
+            })
+    }
+
+    fn label_ctor_instantiation_site(
+        error: Self::Failure,
+        _call_span: rue_span::Span,
+    ) -> Self::Failure {
+        error
+    }
+
+    fn canonical_function_producer(
+        &self,
+        program: &Self::ProgramKey,
+        ticket: &Self::CompletionTicket,
+        _name: Self::Name,
+        _types: &AHashMap<Self::Name, Self::Type>,
+        _values: &AHashMap<Self::Name, Self::Value>,
+        _span: rue_span::Span,
+    ) -> rue_air::ComptimeHostResult<Self::CanonicalIdentity, Self::Failure> {
+        ticket
+            .canonical_function_producer(program)
+            .map(DurableComptimeIdentity)
+            .map_err(|error| {
+                durable_host_error(DurableComptimeFailure::resolution(format!(
+                    "failed to issue canonical comptime producer: {error:?}"
+                )))
+            })
+    }
+
+    fn issue_anonymous_identity(
+        &self,
+        _program: &Self::ProgramKey,
+        kind: rue_air::ComptimeAnonymousKind,
+        producer: &Self::CanonicalIdentity,
+        anchor: &rue_rir::RirStructuralAnchor,
+    ) -> Self::AnonymousIdentity {
+        DurableComptimeAnonymousIdentity::new(crate::AnonymousNominalKey {
+            kind: match kind {
+                rue_air::ComptimeAnonymousKind::Struct => rue_air::AnonymousNominalKind::Struct,
+                rue_air::ComptimeAnonymousKind::Enum => rue_air::AnonymousNominalKind::Enum,
+            },
+            producer: producer.0.clone(),
+            anchor: anchor.clone(),
+        })
+    }
+
+    fn resolve_rir_type_for_comptime_with_subst_and_values_at_span(
+        &mut self,
+        program: &Self::ProgramKey,
+        syntax: rue_rir::RirTypeSyntaxRef,
+        types: &AHashMap<Self::Name, Self::Type>,
+        values: &AHashMap<Self::Name, Self::Value>,
+        _span: rue_span::Span,
+    ) -> Option<Self::Type> {
+        let mut type_substitutions = types
+            .iter()
+            .map(|(name, ty)| (name.0.clone(), ty.0.clone()))
+            .collect::<Vec<_>>();
+        type_substitutions.sort_by(|left, right| left.0.cmp(&right.0));
+        let mut value_substitutions = Vec::with_capacity(values.len());
+        for (name, value) in values {
+            let EvaluatedSemanticConst::Value(value) = value else {
+                return None;
+            };
+            value_substitutions.push((name.0.clone(), value.value.clone()));
+        }
+        value_substitutions.sort_by(|left, right| left.0.cmp(&right.0));
+        self.authority
+            .resolve_type_syntax_with_substitutions(
+                program,
+                syntax,
+                &type_substitutions,
+                &value_substitutions,
+            )
+            .ok()
+            .map(DurableComptimeType)
+    }
+
+    fn begin_comptime_type_syntax(
+        &mut self,
+        program: &Self::ProgramKey,
+        syntax: rue_rir::RirTypeSyntaxRef,
+        types: &AHashMap<Self::Name, Self::Type>,
+        values: &AHashMap<Self::Name, Self::Value>,
+        _span: rue_span::Span,
+    ) -> rue_air::ComptimeOutcome<
+        rue_air::ComptimeStructuredTypeResolution<Self::Type, Self::StructuredTypeSuspension>,
+        Self::Failure,
+    > {
+        let mut type_substitutions = types
+            .iter()
+            .map(|(name, ty)| (name.0.clone(), ty.0.clone()))
+            .collect::<Vec<_>>();
+        type_substitutions.sort_by(|left, right| left.0.cmp(&right.0));
+        let mut value_substitutions = Vec::with_capacity(values.len());
+        for (name, value) in values {
+            let EvaluatedSemanticConst::Value(value) = value else {
+                return rue_air::ComptimeOutcome::RuntimeDependent;
+            };
+            value_substitutions.push((name.0.clone(), value.value.clone()));
+        }
+        value_substitutions.sort_by(|left, right| left.0.cmp(&right.0));
+        match self.authority.begin_structured_type(
+            program,
+            syntax,
+            type_substitutions,
+            value_substitutions,
+        ) {
+            Ok(DurableStructuredTypePoll::Ready(ty)) => rue_air::ComptimeOutcome::Known(
+                rue_air::ComptimeStructuredTypeResolution::Ready(DurableComptimeType(ty)),
+            ),
+            Ok(DurableStructuredTypePoll::Suspended(job)) => rue_air::ComptimeOutcome::Known(
+                rue_air::ComptimeStructuredTypeResolution::Suspended(*job),
+            ),
+            Err(DurableStructuredTypeBeginError::Resolution(error)) => {
+                durable_host_error_outcome(durable_type_syntax_error(error))
+            }
+            Err(DurableStructuredTypeBeginError::UnregisteredProgram) => {
+                durable_host_error_outcome(durable_host_error(DurableComptimeFailure::resolution(
+                    "durable comptime type syntax references an unregistered program",
+                )))
+            }
+            Err(DurableStructuredTypeBeginError::InvalidProgramAuthority) => {
+                durable_host_error_outcome(durable_host_error(DurableComptimeFailure::resolution(
+                    "durable comptime type syntax has invalid program authority",
+                )))
+            }
+        }
+    }
+
+    fn prepare_structured_type_call(
+        &mut self,
+        suspension: &Self::StructuredTypeSuspension,
+        span: rue_span::Span,
+    ) -> rue_air::ComptimeOutcome<
+        Option<
+            rue_air::ComptimeCallPreparation<
+                Self::Value,
+                Self::Type,
+                Self::Name,
+                Self::File,
+                Self::ProgramKey,
+                Self::CanonicalIdentity,
+                Self::Failure,
+                Self::CompletionTicket,
+            >,
+        >,
+        Self::Failure,
+    > {
+        let request = suspension.request_view();
+        let program = request.program().key().clone();
+        let head = request.head().key.clone();
+        let argument_count = request.type_arguments().len() + request.value_arguments().len();
+        let pending = match self
+            .authority
+            .durable_session_mut()
+            .prepare_structured_type_call(suspension, span)
+        {
+            Ok(pending) => pending,
+            Err(error) => {
+                return durable_host_error_outcome(durable_host_error(
+                    DurableComptimeFailure::resolution(format!(
+                        "durable structured call lifecycle: {error:?}"
+                    )),
+                ));
+            }
+        };
+        let start = match self
+            .authority
+            .begin_comptime_call_admission_for_key(&program.declaration, &head)
+        {
+            Ok(start) => start,
+            Err(error) => return durable_host_error_outcome(durable_provider_error(error)),
+        };
+        self.authority
+            .durable_session_mut()
+            .observe_dependency(start.dependency.clone());
+        let admission = match DurableComptimeServices::new(&mut *self.authority)
+            .finish_structured_comptime_call_admission(start, argument_count)
+        {
+            Ok(admission) => admission,
+            Err(error) => return durable_host_error_outcome(durable_provider_error(error)),
+        };
+        let validated = match self
+            .authority
+            .durable_session()
+            .validate_structured_type_call(pending, admission)
+        {
+            Ok(validated) => validated,
+            Err(error) => {
+                return durable_host_error_outcome(durable_foreign_call_error(error));
+            }
+        };
+        let probed = match DurableComptimeServices::new(&mut *self.authority)
+            .probe_structured_type_call(validated)
+        {
+            Ok(probed) => probed,
+            Err(abort) => {
+                return rue_air::ComptimeOutcome::Abort(DurableComptimeHostFailure::query_abort(
+                    abort,
+                ));
+            }
+        };
+        let prepared = match self
+            .authority
+            .durable_session_mut()
+            .consume_structured_type_call(probed)
+        {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                return durable_host_error_outcome(durable_foreign_call_error(error));
+            }
+        };
+        rue_air::ComptimeOutcome::Known(Some(match prepared {
+            DurableStructuredTypeCall::Ready { result } => {
+                let value = match result {
+                    crate::semantic_query_nucleus::ComptimeCallResultProjection::Type(value) => {
+                        DurableConstValue::Type(value)
+                    }
+                    crate::semantic_query_nucleus::ComptimeCallResultProjection::Value(value) => {
+                        value
+                    }
+                };
+                rue_air::ComptimeCallPreparation::Memoized(rue_air::ComptimeOutcome::Known(
+                    EvaluatedSemanticConst::Value(TypedSemanticConst::typed(
+                        value,
+                        DurableType::ComptimeType,
+                    )),
+                ))
+            }
+            DurableStructuredTypeCall::Enter {
+                program: _,
+                frame,
+                ticket,
+            } => rue_air::ComptimeCallPreparation::Enter {
+                frame: *frame,
+                ticket,
+            },
+            DurableStructuredTypeCall::NotReady => {
+                rue_air::ComptimeCallPreparation::Memoized(rue_air::ComptimeOutcome::NotReady)
+            }
+        }))
+    }
+
+    fn resume_structured_type_call(
+        &mut self,
+        suspension: Self::StructuredTypeSuspension,
+        result: rue_air::ComptimeOutcome<Self::Value, Self::Failure>,
+    ) -> rue_air::ComptimeOutcome<
+        rue_air::ComptimeStructuredTypeResolution<Self::Type, Self::StructuredTypeSuspension>,
+        Self::Failure,
+    > {
+        let value = match result {
+            rue_air::ComptimeOutcome::Known(EvaluatedSemanticConst::Value(value)) => {
+                Arc::unwrap_or_clone(value)
+            }
+            rue_air::ComptimeOutcome::Known(EvaluatedSemanticConst::Module(_)) => {
+                return rue_air::ComptimeOutcome::HostFailure(durable_host_failure(
+                    DurableComptimeFailure::resolution("module used where a value is required"),
+                ));
+            }
+            rue_air::ComptimeOutcome::Known(EvaluatedSemanticConst::TargetEnum(_)) => {
+                return rue_air::ComptimeOutcome::HostFailure(durable_host_failure(
+                    DurableComptimeFailure::resolution(
+                        "target descriptor used where a durable const value is required",
+                    ),
+                ));
+            }
+            rue_air::ComptimeOutcome::RuntimeDependent => {
+                return rue_air::ComptimeOutcome::RuntimeDependent;
+            }
+            rue_air::ComptimeOutcome::NotReady => return rue_air::ComptimeOutcome::NotReady,
+            rue_air::ComptimeOutcome::UnsupportedContext => {
+                return rue_air::ComptimeOutcome::UnsupportedContext;
+            }
+            rue_air::ComptimeOutcome::Trap(trap) => {
+                return rue_air::ComptimeOutcome::Trap(trap);
+            }
+            rue_air::ComptimeOutcome::HostFailure(error) => {
+                return rue_air::ComptimeOutcome::HostFailure(error);
+            }
+            rue_air::ComptimeOutcome::Abort(error) => {
+                return rue_air::ComptimeOutcome::Abort(error);
+            }
+        };
+        let reduced = Some(match value.value {
+            DurableConstValue::Type(ty) => rue_air::SemanticComptimeCallResult::Type(ty),
+            value => rue_air::SemanticComptimeCallResult::Value(value),
+        });
+        match self
+            .authority
+            .resume_structured_type(suspension, Ok(reduced))
+        {
+            Ok(DurableStructuredTypePoll::Ready(ty)) => rue_air::ComptimeOutcome::Known(
+                rue_air::ComptimeStructuredTypeResolution::Ready(DurableComptimeType(ty)),
+            ),
+            Ok(DurableStructuredTypePoll::Suspended(job)) => rue_air::ComptimeOutcome::Known(
+                rue_air::ComptimeStructuredTypeResolution::Suspended(*job),
+            ),
+            Err(error) => durable_host_error_outcome(durable_type_syntax_error(error)),
+        }
+    }
+
+    fn resolve_string_const(
+        &mut self,
+        content: Self::Name,
+        _span: rue_span::Span,
+    ) -> rue_air::ComptimeOutcome<Self::Value, Self::Failure> {
+        rue_air::ComptimeOutcome::Known(EvaluatedSemanticConst::Value(Arc::new(
+            TypedSemanticConst {
+                value: DurableConstValue::String(content.0),
+                ty: None,
+            },
+        )))
+    }
+
+    fn resolve_comptime_expression_intrinsic(
+        &mut self,
+        request: rue_air::ComptimeExpressionIntrinsicRequest<Self::Name>,
+        site: &rue_air::ComptimeSite<Self::ProgramKey>,
+    ) -> rue_air::ComptimeOutcome<Self::Value, Self::Failure> {
+        match request {
+            rue_air::ComptimeExpressionIntrinsicRequest::Import {
+                argument_count: 1,
+                sole_string_literal: Some(specifier),
+            } => {
+                let resolution = DurableComptimeServices::new(&mut *self.authority)
+                    .resolve_keyed_import(site, specifier.as_str());
+                let resolution = match resolution {
+                    Ok(resolution) => resolution,
+                    Err(DurableComptimeKeyedImportError::ProviderAbort(abort)) => {
+                        return rue_air::ComptimeOutcome::Abort(
+                            DurableComptimeHostFailure::query_abort(abort),
+                        );
+                    }
+                    Err(_) => {
+                        return rue_air::ComptimeOutcome::HostFailure(durable_host_failure(
+                            DurableComptimeFailure::resolution(
+                                "exact const import is absent from its candidate RIR occurrence index",
+                            ),
+                        ));
+                    }
+                };
+                match resolution {
+                    DurableImportResolution::Resolved(module) => {
+                        rue_air::ComptimeOutcome::Known(EvaluatedSemanticConst::Module(module))
+                    }
+                    DurableImportResolution::Missing => rue_air::ComptimeOutcome::HostFailure(
+                        durable_host_failure(DurableComptimeFailure::resolution(format!(
+                            "cannot find module `{}`",
+                            specifier.as_str()
+                        ))),
+                    ),
+                    DurableImportResolution::Failure(
+                        DeclarationImportFailure::ResolutionUnavailable(key),
+                    ) => rue_air::ComptimeOutcome::Abort(DurableComptimeHostFailure::query_abort(
+                        QueryAbort::MissingInput(rue_query::InputIdentity::new(
+                            "declaration-import-resolution",
+                            format!(
+                                "{}:{}:{}",
+                                key.declaration.stable_identity(),
+                                key.occurrence,
+                                key.specifier
+                            ),
+                        )),
+                    )),
+                    DurableImportResolution::Failure(failure) => {
+                        rue_air::ComptimeOutcome::HostFailure(durable_host_failure(
+                            DurableComptimeFailure::resolution(format!("{failure:?}")),
+                        ))
+                    }
+                }
+            }
+            rue_air::ComptimeExpressionIntrinsicRequest::Import { .. } => {
+                rue_air::ComptimeOutcome::HostFailure(durable_host_failure(
+                    DurableComptimeFailure::resolution(
+                        "exact const import is absent from its candidate RIR occurrence index",
+                    ),
+                ))
+            }
+            rue_air::ComptimeExpressionIntrinsicRequest::Target {
+                intrinsic,
+                argument_count,
+            } => match self
+                .authority
+                .resolve_target_intrinsic(intrinsic, argument_count)
+            {
+                Ok(value) => {
+                    rue_air::ComptimeOutcome::Known(EvaluatedSemanticConst::TargetEnum(value))
+                }
+                Err(error) => durable_host_error_outcome(durable_provider_error(error)),
+            },
+        }
+    }
+
+    fn admit_comptime_enum_variant(
+        &mut self,
+        _type_name: Self::Name,
+        _variant: Self::Name,
+        has_module: bool,
+        _site: &rue_air::ComptimeSite<Self::ProgramKey>,
+    ) -> rue_air::ComptimeHostResult<bool, Self::Failure> {
+        // A qualified enum path is not a durable target descriptor. Reject
+        // it before AIR evaluates the optional module child, preserving the
+        // legacy pre-child policy and avoiding an ambient module lookup.
+        if has_module {
+            #[cfg(test)]
+            arm_enum_variant_child_tripwire();
+            return Err(durable_host_error(
+                DurableComptimeFailure::comptime_rejection(
+                    ComptimeSemanticRejection::UnsupportedExpression,
+                ),
+            ));
+        }
+        Ok(true)
+    }
+
+    fn resolve_comptime_enum_variant(
+        &mut self,
+        module: Option<Self::Value>,
+        type_name: Self::Name,
+        variant: Self::Name,
+        _site: &rue_air::ComptimeSite<Self::ProgramKey>,
+        _span: rue_span::Span,
+    ) -> rue_air::ComptimeOutcome<Self::Value, Self::Failure> {
+        if module.is_some() {
+            return rue_air::ComptimeOutcome::HostFailure(durable_host_failure(
+                DurableComptimeFailure::comptime_rejection(
+                    rue_air::ComptimeSemanticRejection::UnsupportedExpression,
+                ),
+            ));
+        }
+        if !matches!(type_name.as_str(), "Arch" | "Os" | "DataModel") {
+            return rue_air::ComptimeOutcome::HostFailure(durable_host_failure(
+                DurableComptimeFailure::resolution(
+                    "path expression is not supported in declaration-time comptime",
+                ),
+            ));
+        }
+        match self
+            .authority
+            .resolve_target_enum_variant(type_name.as_str(), variant.as_str())
+        {
+            Ok(value) => rue_air::ComptimeOutcome::Known(EvaluatedSemanticConst::TargetEnum(value)),
+            Err(error) => durable_host_error_outcome(durable_provider_error(error)),
+        }
+    }
+
+    fn admit_comptime_member(
+        &mut self,
+        _field: Self::Name,
+        _site: &rue_air::ComptimeSite<Self::ProgramKey>,
+    ) -> rue_air::ComptimeHostResult<bool, Self::Failure> {
+        Ok(true)
+    }
+
+    fn resolve_comptime_member(
+        &mut self,
+        base: Self::Value,
+        field: Self::Name,
+        site: &rue_air::ComptimeSite<Self::ProgramKey>,
+        _span: rue_span::Span,
+    ) -> rue_air::ComptimeOutcome<Self::Value, Self::Failure> {
+        let EvaluatedSemanticConst::Module(module) = base else {
+            return rue_air::ComptimeOutcome::HostFailure(durable_host_failure(
+                DurableComptimeFailure::resolution("member access on a non-module const value"),
+            ));
+        };
+        let projection = self.authority.resolve_module_member(
+            &site.program().declaration,
+            &module,
+            field.as_str(),
+        );
+        let projection = match projection {
+            Ok(projection) => projection,
+            Err(error) => return durable_host_error_outcome(durable_provider_error(error)),
+        };
+        let (value, dependency) = projection.into_parts();
+        self.authority
+            .durable_session_mut()
+            .observe_dependency(dependency);
+        rue_air::ComptimeOutcome::Known(value)
+    }
+
+    fn finish_checked(
+        &mut self,
+        value: Self::Value,
+        _span: rue_span::Span,
+    ) -> rue_air::ComptimeOutcome<Self::Value, Self::Failure> {
+        rue_air::ComptimeOutcome::Known(value)
+    }
+
+    fn reject_non_type_array_repeat(
+        &mut self,
+        _value: Self::Value,
+        _site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> rue_air::ComptimeOutcome<Self::Value, Self::Failure> {
+        rue_air::ComptimeOutcome::HostFailure(durable_host_failure(
+            DurableComptimeFailure::comptime_rejection(
+                rue_air::ComptimeSemanticRejection::AggregateExpression,
+            ),
+        ))
+    }
+
+    fn allow_checked_comptime(&self) -> bool {
+        true
+    }
+}
 
 /// The compiler's ticket-free declaration-root frame. `StableProducerId`
 /// preserves specialized function producers even though a declaration root
@@ -4252,6 +6290,10 @@ impl ComptimeValue for EvaluatedSemanticConst {
             | DurableConstValue::Unit
             | DurableConstValue::String(_) => None,
         }
+    }
+
+    fn eligible_for_comptime_capture(&self) -> bool {
+        matches!(self, Self::Value(_))
     }
 
     fn as_integer_type(&self) -> Option<Self::Type> {
@@ -4609,27 +6651,27 @@ mod tests {
         };
 
         assert!(durable_match_pattern_matches(
-            &ComptimeMatchPattern::Wildcard,
+            &ComptimeMatchPattern::<Arc<str>>::Wildcard,
             &EvaluatedSemanticConst::Module(ModuleId::from_logical_path("m").unwrap()),
         ));
         assert!(durable_match_pattern_matches(
-            &ComptimeMatchPattern::Integer(-7),
+            &ComptimeMatchPattern::<Arc<str>>::Integer(-7),
             &integer,
         ));
         assert!(!durable_match_pattern_matches(
-            &ComptimeMatchPattern::Integer(7),
+            &ComptimeMatchPattern::<Arc<str>>::Integer(7),
             &integer,
         ));
         assert!(durable_match_pattern_matches(
-            &ComptimeMatchPattern::Bool(true),
+            &ComptimeMatchPattern::<Arc<str>>::Bool(true),
             &boolean,
         ));
         assert!(!durable_match_pattern_matches(
-            &ComptimeMatchPattern::Bool(false),
+            &ComptimeMatchPattern::<Arc<str>>::Bool(false),
             &integer,
         ));
         assert!(!durable_match_pattern_matches(
-            &ComptimeMatchPattern::Integer(-7),
+            &ComptimeMatchPattern::<Arc<str>>::Integer(-7),
             &boolean,
         ));
         assert!(durable_match_pattern_matches(
@@ -9350,6 +11392,39 @@ mod structured_type_adapter_tests {
             panic!("not part of keyed import service test")
         }
 
+        fn begin_structured_type(
+            &mut self,
+            _program: &crate::body_query::DurableComptimeProgramKey,
+            _syntax: rue_rir::RirTypeSyntaxRef,
+            _type_substitutions: Vec<(Arc<str>, DurableType)>,
+            _value_substitutions: Vec<(Arc<str>, DurableConstValue)>,
+        ) -> Result<
+            DurableStructuredTypePoll,
+            DurableStructuredTypeBeginError<QueryAbort, SemanticNucleusFailure>,
+        > {
+            panic!("not part of keyed import service test")
+        }
+
+        fn resume_structured_type(
+            &mut self,
+            _job: DurableStructuredTypeJob,
+            _reduced: rue_air::SemanticProviderResult<
+                Option<rue_air::SemanticComptimeCallResult<DurableType, DurableConstValue>>,
+                QueryAbort,
+                SemanticNucleusFailure,
+            >,
+        ) -> Result<
+            DurableStructuredTypePoll,
+            rue_air::SemanticTypeSyntaxError<
+                QueryAbort,
+                SemanticNucleusFailure,
+                crate::StableDefinitionKey,
+                Arc<str>,
+            >,
+        > {
+            panic!("not part of keyed import service test")
+        }
+
         fn begin_comptime_call_admission(
             &self,
             _accessing_source: &crate::StableDefinitionKey,
@@ -10259,6 +12334,135 @@ mod terminal_adapter_tests {
     }
 
     #[test]
+    fn projection_failures_preserve_typed_host_channels_and_legacy_text() {
+        use crate::body_query::ComptimeProgramProjectionFailure as Projection;
+        use crate::canonical_lower::BodyPlanMaterializationFailure as Materialization;
+        use crate::revisioned_query_database::DeclarationBodyPlanFailure as Artifact;
+
+        let producer = site("projection", 1, 2).producer;
+        assert!(matches!(
+            durable_projection_failure_error(Projection::Materialization(Materialization::Query(
+                QueryAbort::Canceled
+            ))),
+            rue_air::ComptimeHostError::Abort(DurableComptimeHostFailure(
+                DurableComptimeHostFailureKind::QueryAbort(QueryAbort::Canceled)
+            ))
+        ));
+
+        let build = rue_rir::RirPayloadBuildError::ResourceLimitExceeded { family: "test" };
+        assert!(matches!(
+            durable_projection_failure_error(Projection::Materialization(
+                Materialization::Build(build)
+            )),
+            rue_air::ComptimeHostError::HostFailure(DurableComptimeHostFailure(
+                DurableComptimeHostFailureKind::Semantic(value)
+            )) if matches!(*value, SemanticNucleusFailure::Diagnostic(
+                rue_error::ErrorKind::CompilerResourceLimit(_)
+            ))
+        ));
+        assert!(matches!(
+            durable_projection_failure_error(Projection::Materialization(
+                Materialization::Invalid(Arc::from("invalid materialization"))
+            )),
+            rue_air::ComptimeHostError::HostFailure(DurableComptimeHostFailure(
+                DurableComptimeHostFailureKind::Semantic(value)
+            )) if matches!(*value, SemanticNucleusFailure::Resolution(ref detail)
+                if detail.as_ref() == "invalid materialization")
+        ));
+
+        let artifact_build = rue_error::ErrorKind::InvalidInteger;
+        assert!(matches!(
+            durable_projection_failure_error(Projection::Artifact(Artifact::Build(
+                artifact_build.clone()
+            ))),
+            rue_air::ComptimeHostError::HostFailure(DurableComptimeHostFailure(
+                DurableComptimeHostFailureKind::Semantic(value)
+            )) if matches!(*value, SemanticNucleusFailure::Diagnostic(
+                rue_error::ErrorKind::InvalidInteger
+            ))
+        ));
+        let mut errors = crate::CompileErrors::new();
+        errors.push(crate::CompileError::without_span(
+            rue_error::ErrorKind::InvalidInteger,
+        ));
+        assert!(matches!(
+            durable_projection_failure_error(Projection::Artifact(
+                Artifact::CandidateRirRejected(errors)
+            )),
+            rue_air::ComptimeHostError::HostFailure(DurableComptimeHostFailure(
+                DurableComptimeHostFailureKind::Semantic(value)
+            )) if matches!(*value, SemanticNucleusFailure::Syntax(_))
+        ));
+        let unavailable = Artifact::CandidateUnavailable(producer.clone());
+        assert!(matches!(
+            durable_projection_failure_error(Projection::Artifact(unavailable.clone())),
+            rue_air::ComptimeHostError::HostFailure(DurableComptimeHostFailure(
+                DurableComptimeHostFailureKind::Semantic(value)
+            )) if matches!(*value, SemanticNucleusFailure::Resolution(ref detail)
+                if detail.as_ref() == format!("candidate RIR artifact failed: {unavailable:?}"))
+        ));
+
+        let query_failure = rue_query::QueryFailure::new("test-query", "payload");
+        assert!(matches!(
+            durable_projection_failure_error(Projection::ArtifactQueryFailure(
+                query_failure.clone()
+            )),
+            rue_air::ComptimeHostError::HostFailure(DurableComptimeHostFailure(
+                DurableComptimeHostFailureKind::QueryFailure(actual)
+            )) if actual == query_failure
+        ));
+
+        for (failure, expected) in [
+            (
+                Projection::NotFunction {
+                    root: rue_rir::InstRef::from_raw(0),
+                },
+                "comptime candidate artifact has a non-function root",
+            ),
+            (
+                Projection::NotConst {
+                    root: rue_rir::InstRef::from_raw(0),
+                },
+                "constant candidate artifact has a non-constant root",
+            ),
+        ] {
+            assert!(matches!(
+                durable_projection_failure_error(failure),
+                rue_air::ComptimeHostError::HostFailure(DurableComptimeHostFailure(
+                    DurableComptimeHostFailureKind::Semantic(value)
+                )) if matches!(*value, SemanticNucleusFailure::Resolution(ref detail)
+                    if detail.as_ref() == expected)
+            ));
+        }
+
+        let invalid_stable_key = crate::StableDefinitionKey::from_stable_parts(
+            producer.module.clone(),
+            crate::StableDefinitionNamespace::Value,
+            crate::StableDefinitionKind::ValueConst,
+            producer.name.clone(),
+            None,
+        );
+        let invalid_producer = Projection::InvalidProducer(invalid_stable_key);
+        let invalid_debug = format!("{invalid_producer:?}");
+        assert!(matches!(
+            durable_projection_failure_error(invalid_producer),
+            rue_air::ComptimeHostError::HostFailure(DurableComptimeHostFailure(
+                DurableComptimeHostFailureKind::Semantic(value)
+            )) if matches!(*value, SemanticNucleusFailure::Resolution(ref detail)
+                if detail.as_ref() == invalid_debug)
+        ));
+        let identity_mismatch = Projection::IdentityMismatch;
+        let identity_debug = format!("{identity_mismatch:?}");
+        assert!(matches!(
+            durable_projection_failure_error(identity_mismatch),
+            rue_air::ComptimeHostError::HostFailure(DurableComptimeHostFailure(
+                DurableComptimeHostFailureKind::Semantic(value)
+            )) if matches!(*value, SemanticNucleusFailure::Resolution(ref detail)
+                if detail.as_ref() == identity_debug)
+        ));
+    }
+
+    #[test]
     fn semantic_rejection_kernel_preserves_each_legacy_channel_and_text() {
         let unit = EvaluatedSemanticConst::unit();
         let cases = [
@@ -10570,6 +12774,17 @@ mod terminal_adapter_tests {
                 if matches!(*value, SemanticNucleusFailure::Diagnostic(
                     rue_error::ErrorKind::ComptimeEvaluationFailed { ref reason }
                 ) if reason.contains("integer overflow evaluating addition"))
+        ));
+        assert!(matches!(
+            DurableComptimeScalarPolicy::checked_integer_result(
+                &T::I8,
+                integer.checked_neg_literal_report_i128(129),
+                "negation",
+            ),
+            Err(DurableComptimeFailure::Failure(value))
+                if matches!(*value, SemanticNucleusFailure::Diagnostic(
+                    rue_error::ErrorKind::ComptimeEvaluationFailed { ref reason }
+                ) if reason.contains("integer overflow evaluating negation"))
         ));
     }
 

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -2391,33 +2391,13 @@ fn candidate_rir_artifact_failure_errors(
 fn candidate_rir_semantic_failure(
     failure: &DeclarationBodyPlanFailure,
 ) -> crate::semantic_query_nucleus::SemanticNucleusFailure {
-    use crate::semantic_query_nucleus::SemanticNucleusFailure as Failure;
-    match failure {
-        DeclarationBodyPlanFailure::Build(kind) => Failure::Diagnostic(kind.clone()),
-        DeclarationBodyPlanFailure::CandidateRirRejected(errors) => {
-            Failure::Syntax(Arc::from(errors.to_string()))
-        }
-        failure => Failure::Resolution(Arc::from(format!(
-            "candidate RIR artifact failed: {failure:?}"
-        ))),
-    }
+    crate::durable_comptime::durable_candidate_rir_semantic_failure(failure)
 }
 
 fn semantic_materialization_failure(
     failure: crate::canonical_lower::BodyPlanMaterializationFailure,
 ) -> Result<crate::semantic_query_nucleus::SemanticNucleusFailure, QueryAbort> {
-    use crate::canonical_lower::BodyPlanMaterializationFailure as Materialization;
-    use crate::semantic_query_nucleus::SemanticNucleusFailure as Failure;
-    match failure {
-        Materialization::Query(abort) => Err(abort),
-        Materialization::Build(error) => Ok(Failure::Diagnostic(
-            crate::canonical_lower::rir_build_error_kind(
-                "declaration-time candidate materialization",
-                &error,
-            ),
-        )),
-        Materialization::Invalid(detail) => Ok(Failure::Resolution(detail)),
-    }
+    crate::durable_comptime::durable_materialization_semantic_failure(failure)
 }
 
 fn candidate_rir_composition_failure_error(
@@ -4177,26 +4157,7 @@ fn durable_legacy_named_array_length_failure(
     name: &str,
     error: crate::durable_comptime::DurableComptimeArrayLengthError,
 ) -> crate::semantic_query_nucleus::SemanticNucleusFailure {
-    use crate::durable_comptime::DurableComptimeArrayLengthError as E;
-    match error {
-        E::Module => crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(
-            "module used where a value is required".into(),
-        ),
-        E::TargetEnum => crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(
-            "target descriptor used where a durable const value is required".into(),
-        ),
-        E::NonInteger | E::Negative(_) | E::TooLarge(_) => {
-            crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
-                rue_error::ErrorKind::InvalidArrayLength {
-                    reason: if matches!(error, E::NonInteger) {
-                        format!("array length expression '{name}' is not an integer")
-                    } else {
-                        format!("array length expression '{name}' is negative or too large")
-                    },
-                },
-            )
-        }
-    }
+    crate::durable_comptime::durable_named_array_length_failure(name, error)
 }
 
 fn durable_provider_named_array_length_failure(
@@ -6982,6 +6943,16 @@ impl crate::durable_comptime::DurableComptimeForeignCallAuthority
     }
 }
 
+impl crate::durable_comptime::DurableComptimeHostAuthority for DurableComptimeRootAuthority<'_> {
+    fn durable_session(&self) -> &crate::durable_comptime::DurableComptimeSession {
+        &self.session
+    }
+
+    fn durable_session_mut(&mut self) -> &mut crate::durable_comptime::DurableComptimeSession {
+        &mut self.session
+    }
+}
+
 fn project_named_value_candidate(
     provider: &SemanticNucleusTypeProvider<'_>,
     accessing_source: &crate::StableDefinitionKey,
@@ -7171,6 +7142,54 @@ impl crate::durable_comptime::DurableComptimeSemanticAuthority
                 |symbol| registered.symbols[symbol.into_usize()].as_ref(),
             )
         })
+    }
+
+    fn begin_structured_type(
+        &mut self,
+        program: &crate::body_query::DurableComptimeProgramKey,
+        syntax: rue_rir::RirTypeSyntaxRef,
+        type_substitutions: Vec<(Arc<str>, crate::durable_semantics::DurableType)>,
+        value_substitutions: Vec<(Arc<str>, crate::durable_semantics::DurableConstValue)>,
+    ) -> Result<
+        crate::durable_comptime::DurableStructuredTypePoll,
+        crate::durable_comptime::DurableStructuredTypeBeginError<
+            QueryAbort,
+            crate::semantic_query_nucleus::SemanticNucleusFailure,
+        >,
+    > {
+        crate::durable_comptime::begin_durable_structured_type(
+            &self.session,
+            program,
+            syntax,
+            type_substitutions,
+            value_substitutions,
+            &mut self.provider,
+        )
+    }
+
+    fn resume_structured_type(
+        &mut self,
+        job: crate::durable_comptime::DurableStructuredTypeJob,
+        reduced: rue_air::SemanticProviderResult<
+            Option<
+                rue_air::SemanticComptimeCallResult<
+                    crate::durable_semantics::DurableType,
+                    crate::durable_semantics::DurableConstValue,
+                >,
+            >,
+            QueryAbort,
+            crate::semantic_query_nucleus::SemanticNucleusFailure,
+        >,
+    ) -> Result<
+        crate::durable_comptime::DurableStructuredTypePoll,
+        rue_air::SemanticTypeSyntaxError<
+            QueryAbort,
+            crate::semantic_query_nucleus::SemanticNucleusFailure,
+            StableDefinitionKey,
+            Arc<str>,
+        >,
+    > {
+        crate::durable_comptime::resume_durable_structured_type(job, &mut self.provider, reduced)
     }
 
     fn begin_comptime_call_admission(
@@ -7670,15 +7689,7 @@ impl SemanticConstEvaluator<'_, '_> {
             crate::durable_comptime::DurableComptimeServices::new(&mut *self.authority);
         services
             .resolve_type_syntax(&self.program, syntax)
-            .map_err(|error| match error {
-                rue_air::SemanticTypeSyntaxError::ProviderAbort(abort) => {
-                    EvaluateSemanticConstError::Abort(abort)
-                }
-                rue_air::SemanticTypeSyntaxError::ProviderFailure(failure) => {
-                    EvaluateSemanticConstError::failure(failure)
-                }
-                other => Self::failure_value(format!("{other:?}")),
-            })
+            .map_err(crate::durable_comptime::durable_comptime_type_syntax_failure)
     }
 
     fn value(
@@ -11051,59 +11062,70 @@ fn semantic_type_query_failure(
         Arc<str>,
     >,
 ) -> ResolveSemanticSignatureError {
-    use rue_air::SemanticResolutionError as E;
     use rue_air::SemanticTypeSyntaxFailure as F;
     use rue_error::ErrorKind;
-    match failure {
-        E::ProviderAbort(abort) => ResolveSemanticSignatureError::Abort(abort),
-        E::ProviderFailure(failure) => ResolveSemanticSignatureError::failure(failure),
-        E::Semantic(F::UnknownType { syntax }) => ResolveSemanticSignatureError::failure(
-            crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
-                ErrorKind::UnknownType(syntax.to_string()),
-            ),
-        ),
-        E::Semantic(F::UnknownModuleMember { module, member, .. }) => {
-            ResolveSemanticSignatureError::failure(
-                crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
-                    ErrorKind::UnknownModuleMember {
-                        module_name: module.to_string(),
-                        member_name: member.to_string(),
-                    },
+
+    match crate::durable_comptime::classify_durable_type_syntax_failure(failure) {
+        crate::durable_comptime::DurableTypeSyntaxClassification::Abort(abort) => {
+            ResolveSemanticSignatureError::Abort(abort)
+        }
+        crate::durable_comptime::DurableTypeSyntaxClassification::Failure(failure) => {
+            ResolveSemanticSignatureError::failure(failure)
+        }
+        crate::durable_comptime::DurableTypeSyntaxClassification::Semantic(failure) => {
+            match failure {
+                F::UnknownType { syntax } => ResolveSemanticSignatureError::failure(
+                    crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+                        ErrorKind::UnknownType(syntax.to_string()),
+                    ),
                 ),
-            )
+                F::UnknownModuleMember { module, member, .. } => {
+                    ResolveSemanticSignatureError::failure(
+                        crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+                            ErrorKind::UnknownModuleMember {
+                                module_name: module.to_string(),
+                                member_name: member.to_string(),
+                            },
+                        ),
+                    )
+                }
+                F::ValueWhereTypeExpected { parameter, .. } => {
+                    ResolveSemanticSignatureError::failure(
+                        crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(
+                            Arc::from(format!(
+                                "argument for comptime parameter `{parameter}` must be a type"
+                            )),
+                        ),
+                    )
+                }
+                F::InvalidConstructorArity {
+                    constructor,
+                    expected,
+                    found,
+                    ..
+                } => ResolveSemanticSignatureError::failure(
+                    crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(Arc::from(
+                        format!(
+                            "type constructor `{constructor}` expects {expected} comptime type argument(s), but {found} provided"
+                        ),
+                    )),
+                ),
+                F::NotTypeConstructor { constructor, .. } => {
+                    ResolveSemanticSignatureError::failure(
+                        crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(
+                            Arc::from(format!("function `{constructor}` is not a type")),
+                        ),
+                    )
+                }
+                other => ResolveSemanticSignatureError::failure(
+                    crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+                        ErrorKind::ComptimeEvaluationFailed {
+                            reason: format!("{other:?}"),
+                        },
+                    ),
+                ),
+            }
         }
-        E::Semantic(F::ValueWhereTypeExpected { parameter, .. }) => {
-            ResolveSemanticSignatureError::failure(
-                crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(Arc::from(
-                    format!("argument for comptime parameter `{parameter}` must be a type"),
-                )),
-            )
-        }
-        E::Semantic(F::InvalidConstructorArity {
-            constructor,
-            expected,
-            found,
-            ..
-        }) => ResolveSemanticSignatureError::failure(
-            crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(Arc::from(format!(
-                "type constructor `{constructor}` expects {expected} comptime type argument(s), but {found} provided"
-            ))),
-        ),
-        E::Semantic(F::NotTypeConstructor { constructor, .. }) => {
-            ResolveSemanticSignatureError::failure(
-                crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(Arc::from(
-                    format!("function `{constructor}` is not a type"),
-                )),
-            )
-        }
-        E::ComptimeCallTypeArgument { error, .. } => semantic_type_query_failure(*error),
-        other => ResolveSemanticSignatureError::failure(
-            crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
-                ErrorKind::ComptimeEvaluationFailed {
-                    reason: format!("{other:?}"),
-                },
-            ),
-        ),
     }
 }
 
@@ -30344,6 +30366,67 @@ fn main() -> i32 {
             || Ok(()),
         )
         .unwrap();
+        // Build a deliberately qualified enum node directly in RIR.  The
+        // source parser's dotted expression is a FieldGet until semantic
+        // resolution, so a source-only fixture cannot exercise AIR's
+        // pre-child EnumVariant admission contract.
+        let mut qualified_editor = rue_rir::RirEditor::new();
+        let qualified_interner = lasso::ThreadedRodeo::new();
+        let module_symbol = qualified_interner.get_or_intern("module");
+        let type_symbol = qualified_interner.get_or_intern("Arch");
+        let variant_symbol = qualified_interner.get_or_intern("X86_64");
+        let module_ref = qualified_editor.add_inst(rue_rir::Inst {
+            data: InstData::VarRef {
+                name: module_symbol,
+                anchor: None,
+            },
+            span: rue_span::Span::new(0, 6),
+        });
+        let qualified_body = qualified_editor.add_inst(rue_rir::Inst {
+            data: InstData::EnumVariant {
+                module: Some(module_ref),
+                type_name: type_symbol,
+                variant: variant_symbol,
+            },
+            span: rue_span::Span::new(0, 14),
+        });
+        let qualified_rir = rue_rir::ValidatedRir::finish(
+            qualified_editor,
+            &rue_rir::RirValidationContext {
+                symbol_count: qualified_interner.len(),
+                source_lengths: &[(FileId::DEFAULT, 32)],
+            },
+        )
+        .unwrap();
+        let qualified_symbols: Arc<[Arc<str>]> = (0..qualified_interner.len())
+            .map(|index| {
+                Arc::from(
+                    qualified_interner
+                        .resolve(&lasso::Spur::try_from_usize(index).unwrap())
+                        .to_owned(),
+                )
+            })
+            .collect();
+        let qualified_key = crate::body_query::DurableComptimeProgramKey {
+            declaration: StableDefinitionKey::from_stable_parts(
+                candidate.module.clone(),
+                crate::StableDefinitionNamespace::Value,
+                crate::StableDefinitionKind::Function,
+                "qualified_test",
+                None,
+            ),
+            configuration: configuration.clone(),
+        };
+        let qualified_core = OwnedComptimeProgramCore::from_test_rir(
+            DurableComptimeProgramPlan {
+                key: qualified_key.clone(),
+                candidate: candidate.clone(),
+            },
+            qualified_rir,
+            qualified_symbols,
+            qualified_body,
+            qualified_body,
+        );
         let root = core.callable().unwrap().root;
         let (type_syntax, value_syntax, abort_syntax, named_syntax) = match &core.rir.get(root).data
         {
@@ -30406,6 +30489,30 @@ fn main() -> i32 {
                     },
                 };
                 authority.session.register_program(&core).unwrap();
+                authority
+                    .session
+                    .register_program(&qualified_core)
+                    .unwrap();
+
+                // Exercise the production host through the canonical AIR
+                // dispatcher, using the exact registered callable body. This
+                // is deliberately a non-root harness: query roots remain on
+                // SemanticConstEvaluator in this staged migration.
+                let callable = core.callable().expect("callable fixture").clone();
+                let mut host = crate::durable_comptime::DurableComptimeHost::new(&mut authority);
+                let mut env = rue_air::ComptimeEnv::new();
+                let outcome = rue_air::ComptimeEngine::new(&mut host).evaluate(
+                    rue_air::ComptimeFrame::expression(program_key.clone(), callable.body),
+                    &mut env,
+                );
+                assert!(matches!(
+                    outcome,
+                    rue_air::ComptimeOutcome::Known(
+                        crate::durable_comptime::EvaluatedSemanticConst::Value(value)
+                    ) if matches!(value.value, crate::durable_semantics::DurableConstValue::Integer(1))
+                ));
+
+                drop(host);
 
                 let expected_types = BTreeMap::from([(Arc::from("OLD"), T::I8)]);
                 let expected_values = BTreeMap::from([(Arc::from("OLD"), V::Integer(7))]);
@@ -30493,6 +30600,41 @@ fn main() -> i32 {
                 assert_eq!(authority.provider.substitutions, expected_types);
                 assert_eq!(authority.provider.value_substitutions, expected_values);
 
+                // The qualified EnumVariant fixture is registered above and
+                // evaluated through the canonical AIR dispatcher. Cancellation
+                // is armed by the host at the admission boundary as a
+                // child-evaluation tripwire: if AIR ever evaluates
+                // `module_ref` before admission rejects the path, its eval
+                // checkpoint must return QueryAbort::Canceled rather than the
+                // expected typed semantic HostFailure.
+                crate::durable_comptime::set_enum_variant_child_tripwire(Some(
+                    cancel_in_closure.clone(),
+                ));
+                let dependencies_before_qualified = authority.provider.dependencies.clone();
+                let mut qualified_env = rue_air::ComptimeEnv::new();
+                let mut qualified_host =
+                    crate::durable_comptime::DurableComptimeHost::new(&mut authority);
+                let qualified_outcome = rue_air::ComptimeEngine::new(&mut qualified_host).evaluate(
+                    rue_air::ComptimeFrame::expression(qualified_key, qualified_body),
+                    &mut qualified_env,
+                );
+                let rue_air::ComptimeOutcome::HostFailure(qualified_failure) = qualified_outcome
+                else {
+                    panic!("qualified enum should be a durable host failure: {qualified_outcome:?}");
+                };
+                assert!(matches!(
+                    qualified_failure.semantic_failure(),
+                    Some(crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(
+                        message
+                    )) if message.as_ref() == "expression is not supported in declaration-time comptime"
+                ));
+                drop(qualified_host);
+                crate::durable_comptime::set_enum_variant_child_tripwire(None);
+                assert_eq!(
+                    authority.provider.dependencies,
+                    dependencies_before_qualified,
+                    "qualified enum admission must not evaluate its module child"
+                );
                 cancel_in_closure.cancel();
                 let aborted = {
                     let mut services =
@@ -45633,5 +45775,36 @@ fn main() -> i32 {
             anonymous_identity_for_digest_test("TooLate", rue_air::AnonymousNominalKind::Struct),
             1,
         );
+    }
+
+    #[test]
+    fn type_syntax_adapters_preserve_comptime_and_signature_diagnostics() {
+        use rue_air::{SemanticResolutionError as E, SemanticTypeSyntaxFailure as F};
+
+        let nested = E::ComptimeCallTypeArgument {
+            constructor: Arc::from("Box"),
+            argument_index: 0,
+            argument: Arc::from("Sef"),
+            error: Box::new(E::Semantic(F::UnknownType {
+                syntax: Arc::from("Sef"),
+            })),
+        };
+        let comptime =
+            crate::durable_comptime::durable_comptime_type_syntax_failure(nested.clone());
+        assert!(matches!(
+            comptime,
+            crate::durable_comptime::DurableComptimeFailure::Failure(value)
+                if matches!(value.as_ref(), crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(reason)
+                    if reason.contains("Semantic(UnknownType"))
+        ));
+
+        let signature = semantic_type_query_failure(nested);
+        assert!(matches!(
+            signature,
+            ResolveSemanticSignatureError::Failure(value)
+                if matches!(value.as_ref(), crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+                    rue_error::ErrorKind::UnknownType(syntax)
+                ) if syntax == "Sef")
+        ));
     }
 }


### PR DESCRIPTION
This staged slice builds the production DurableComptimeHost around the canonical rue-air ComptimeEngine while preserving the existing declaration-time behavior and durable query authorities.

It adds the typed host boundary, shared semantic adapters and kernels, real registered-program engine coverage, and inventory guards that forbid a peer RIR evaluator. Production query roots deliberately remain on SemanticConstEvaluator in this slice; root cutover and legacy deletion follow after this foundation lands.

Validation:
- scripts/rue unit air comptime: 84 passed
- scripts/rue unit compiler durable_: 121 passed
- scripts/rue quick: 31 targets passed
- scripts/rue premerge: 200 passed
- scripts/rue test: 234 passed, including slow and oracle-diff corpora
- final adversarial review: SHIP

Relates to RUE-1774