### PR TITLE
RUE-1719: enforce normative spec anchors

### DIFF
--- a/crates/rue-spec/README.md
+++ b/crates/rue-spec/README.md
@@ -249,6 +249,8 @@ included in `./test.sh` and `./buck2 test //...`. It fails if:
 - Any test references a non-existent spec paragraph ID
 - Any normative rule is covered only through a large program (see
   "Focused coverage" above)
+- Any behavior-asserting case cites only informative/example paragraphs. Such a case
+  must cite the matching normative rule.
 - Any case declares an ambiguous platform responsibility (see
   "Platform Responsibility" above)
 

--- a/crates/rue-spec/cases/appendices/implementation-limits.toml
+++ b/crates/rue-spec/cases/appendices/implementation-limits.toml
@@ -99,7 +99,7 @@ exit_code = 141
 
 [[case]]
 name = "many_parameters"
-spec = ["C.6:1"]
+spec = ["C.6:1", "6.1:2", "6.1:4"]
 source = """
 fn add_ten(a: i32, b: i32, c: i32, d: i32, e: i32,
            f: i32, g: i32, h: i32, i: i32, j: i32) -> i32 {
@@ -114,7 +114,7 @@ exit_code = 55
 
 [[case]]
 name = "many_struct_fields"
-spec = ["C.6:1"]
+spec = ["C.6:1", "3.6:2", "3.6:4", "3.6:5"]
 source = """
 struct Large {
     a: i32,
@@ -136,7 +136,7 @@ exit_code = 36
 
 [[case]]
 name = "many_enum_variants"
-spec = ["C.6:1"]
+spec = ["C.6:1", "6.3:2", "6.3:4", "6.3:7", "6.3:8"]
 source = """
 enum Color {
     Red,
@@ -171,7 +171,7 @@ exit_code = 6
 
 [[case]]
 name = "deep_nesting"
-spec = ["C.6:1"]
+spec = ["C.6:1", "C.6:3"]
 source = """
 fn main() -> i32 {
     if true {
@@ -197,7 +197,7 @@ exit_code = 42
 
 [[case]]
 name = "nested_loops"
-spec = ["C.6:1"]
+spec = ["C.6:1", "C.6:3"]
 source = """
 fn main() -> i32 {
     let mut sum: i32 = 0;
@@ -221,7 +221,7 @@ exit_code = 27
 
 [[case]]
 name = "nested_blocks"
-spec = ["C.6:1"]
+spec = ["C.6:1", "C.6:3"]
 source = """
 fn main() -> i32 {
     let a: i32 = {
@@ -368,7 +368,7 @@ exit_code = 0
 
 [[case]]
 name = "wide_element_array_at_slot_ceiling_compiles"
-spec = ["C.4:2"]
+spec = ["C.4:2", "C.4:3"]
 description = "An [i64; N] at the same N is also accepted, so a narrow element type buys no extra headroom"
 source = """
 fn main() -> i32 { if @size_of([i64; 268435455]) == 2147483640 { 0 } else { 1 } }

--- a/crates/rue-spec/cases/expressions/arithmetic.toml
+++ b/crates/rue-spec/cases/expressions/arithmetic.toml
@@ -295,7 +295,7 @@ params = [
 
 [[case]]
 name = "unsigned_division_large_value"
-spec = ["4.2:10"]
+spec = ["4.2:1"]
 source = """
 fn main() -> i32 {
     // 0x80000000 = 2147483648 (would be -2147483648 if signed)
@@ -312,7 +312,7 @@ exit_code = 20
 
 [[case]]
 name = "unsigned_modulo_large_value"
-spec = ["4.2:10"]
+spec = ["4.2:1"]
 source = """
 fn main() -> i32 {
     // 0x80000000 = 2147483648 (would be -2147483648 if signed)
@@ -327,7 +327,7 @@ exit_code = 48
 
 [[case]]
 name = "unsigned_division_max_value"
-spec = ["4.2:10"]
+spec = ["4.2:1"]
 source = """
 fn main() -> i32 {
     // 0xFFFFFFFF = 4294967295 (would be -1 if signed)
@@ -344,7 +344,7 @@ exit_code = 55
 
 [[case]]
 name = "unsigned_modulo_max_value"
-spec = ["4.2:10"]
+spec = ["4.2:1"]
 source = """
 fn main() -> i32 {
     // 0xFFFFFFFF = 4294967295 (would be -1 if signed)

--- a/crates/rue-spec/cases/expressions/comparison.toml
+++ b/crates/rue-spec/cases/expressions/comparison.toml
@@ -46,7 +46,7 @@ params = [
 
 [[case]]
 name = "ordering_{op}_integers"
-spec = ["4.3:4"]
+spec = ["4.3:5"]
 source = """
 fn main() -> i32 {
     if {expr} { 1 } else { 0 }
@@ -194,7 +194,7 @@ params = [
 
 [[case]]
 name = "separate_comparisons_with_and"
-spec = ["4.3:13"]
+spec = ["4.3:5", "4.3:8", "4.3:13"]
 source = """
 fn main() -> i32 {
     if 1 < 2 && 2 < 3 { 1 } else { 0 }

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -70,17 +70,16 @@ fn main() -> i32 {
 compile_fail = true
 
 # =============================================================================
-# Reserved-but-unspecified intrinsics: @panic / @assert / @cast (4.13:5b, RUE-319)
+# Intrinsic behavior and restrictions: @panic / @assert / @cast (4.13:5b-5e, RUE-319)
 #
-# @panic and @assert are not in the normative inventory yet, but they are no
-# longer silent no-ops: they abort the process (message to stderr, exit 101),
-# the same abort discipline as the @intCast overflow trap. @cast is rejected
-# at compile time in favor of @intCast.
+# @panic and @assert abort the process (message to stderr, exit 101), with the
+# same abort discipline as the @intCast overflow trap. @cast is rejected at
+# compile time in favor of @intCast.
 # =============================================================================
 
 [[case]]
 name = "panic_with_message_aborts"
-spec = ["4.13:5b"]
+spec = ["4.13:5c"]
 source = """
 fn main() -> i32 {
     @panic("boom");
@@ -92,7 +91,7 @@ stderr_contains = "panic: boom"
 
 [[case]]
 name = "panic_no_message_aborts"
-spec = ["4.13:5b"]
+spec = ["4.13:5c"]
 source = """
 fn main() -> i32 {
     @panic();
@@ -104,7 +103,7 @@ stderr_contains = "panic"
 
 [[case]]
 name = "assert_false_aborts"
-spec = ["4.13:5b"]
+spec = ["4.13:5d"]
 source = """
 fn main() -> i32 {
     @assert(false);
@@ -116,7 +115,7 @@ stderr_contains = "assertion failed"
 
 [[case]]
 name = "assert_true_passes"
-spec = ["4.13:5b"]
+spec = ["4.13:5d"]
 source = """
 fn main() -> i32 {
     @assert(true);
@@ -127,7 +126,7 @@ exit_code = 42
 
 [[case]]
 name = "assert_false_with_message_aborts"
-spec = ["4.13:5b"]
+spec = ["4.13:5d"]
 source = """
 fn main() -> i32 {
     @assert(1 == 2, "one is not two");
@@ -146,7 +145,7 @@ stderr_contains = "panic: one is not two"
 # @panic in the taken `else` arm of a typed `if`: coerces to i32, then aborts.
 [[case]]
 name = "panic_in_if_else_arm_taken_aborts"
-spec = ["3.4:2", "4.13:5b"]
+spec = ["3.4:2", "4.13:5c"]
 source = """
 fn main() -> i32 {
     let x: i32 = if false { 1 } else { @panic("boom") };
@@ -160,7 +159,7 @@ stderr_contains = "panic: boom"
 # This proves the never-coercion type-checks and leaves the value path intact.
 [[case]]
 name = "panic_in_if_else_arm_untaken_yields_value"
-spec = ["3.4:2", "4.13:5b"]
+spec = ["3.4:2", "4.13:5c"]
 source = """
 fn main() -> i32 {
     let x: i32 = if true { 7 } else { @panic("unreached") };
@@ -172,7 +171,7 @@ exit_code = 7
 # @panic in a typed `match` arm: the non-panic arm still produces a value.
 [[case]]
 name = "panic_in_match_arm_yields_value"
-spec = ["3.4:2", "4.13:5b"]
+spec = ["3.4:2", "4.13:5c"]
 source = """
 fn classify(n: i32) -> i32 {
     let r: i32 = match n {
@@ -188,7 +187,7 @@ exit_code = 100
 # @panic as a typed `let` initializer: coerces to i32, then aborts.
 [[case]]
 name = "panic_in_let_initializer_aborts"
-spec = ["3.4:2", "4.13:5b"]
+spec = ["3.4:2", "4.13:5c"]
 source = """
 fn main() -> i32 {
     let x: i32 = @panic("init");
@@ -202,7 +201,7 @@ stderr_contains = "panic: init"
 # needed, because `!` coerces to the declared return type.
 [[case]]
 name = "panic_as_function_tail_aborts"
-spec = ["3.4:2", "4.13:5b"]
+spec = ["3.4:2", "4.13:5c"]
 source = """
 fn dead() -> i32 { @panic("tail") }
 fn main() -> i32 { dead() }
@@ -212,7 +211,7 @@ stderr_contains = "panic: tail"
 
 [[case]]
 name = "cast_rejected_use_intcast"
-spec = ["4.13:5b"]
+spec = ["4.13:5e"]
 source = """
 fn main() -> i32 {
     let x: i64 = 5;
@@ -651,7 +650,7 @@ exit_code = 0
 # is four, from its i32 fields).
 [[case]]
 name = "align_of_natural_alignments"
-spec = ["4.13:22"]
+spec = ["4.13:18", "4.13:22"]
 source = """
 struct Point { x: i32, y: i32 }
 fn main() -> i32 {

--- a/crates/rue-spec/cases/modules/composition.toml
+++ b/crates/rue-spec/cases/modules/composition.toml
@@ -162,7 +162,7 @@ error_contains = ["E0436", "Thing", "different kind"]
 
 [[case]]
 name = "same_named_functions_qualified_calls_sum"
-spec = ["10.5:3"]
+spec = ["10.5:2", "10.5:3"]
 description = "The 10.5:3 example: same-named functions in two modules, each call resolving in its own module"
 source = """
 fn main() -> i32 {

--- a/crates/rue-spec/cases/statements/assignment.toml
+++ b/crates/rue-spec/cases/statements/assignment.toml
@@ -449,7 +449,7 @@ expected_stdout = """
 
 [[case]]
 name = "compound_assign_place_once_example"
-spec = ["5.2:19"]
+spec = ["5.2:17", "5.2:18", "5.2:19"]
 source = """
 fn tap(n: u64) -> u64 { @dbg(n); n }
 
@@ -466,7 +466,7 @@ expected_stdout = """
 
 [[case]]
 name = "compound_assign_places_example"
-spec = ["5.2:20"]
+spec = ["5.2:17", "5.2:20"]
 source = """
 struct Counter { hits: i32 }
 

--- a/crates/rue-spec/cases/types/mutable-strings.toml
+++ b/crates/rue-spec/cases/types/mutable-strings.toml
@@ -210,7 +210,7 @@ exit_code = 0
 
 [[case]]
 name = "string_query_borrow_valid"
-spec = ["3.10:13"]
+spec = ["3.10:10", "3.10:11", "3.10:12", "3.10:13"]
 description = "Query methods borrow, string remains valid"
 real_std = true
 source = """
@@ -486,7 +486,7 @@ exit_code = 0
 
 [[case]]
 name = "string_clone_borrow"
-spec = ["3.10:27"]
+spec = ["3.10:26", "3.10:27"]
 description = "Clone borrows, original remains valid"
 real_std = true
 source = """
@@ -563,7 +563,7 @@ exit_code = 0
 
 [[case]]
 name = "string_byte_semantics"
-spec = ["3.10:32"]
+spec = ["3.10:16", "3.10:32"]
 description = "Strings are byte sequences"
 real_std = true
 source = """

--- a/crates/rue-spec/cases/types/never.toml
+++ b/crates/rue-spec/cases/types/never.toml
@@ -188,7 +188,7 @@ exit_code = 7
 
 [[case]]
 name = "panic_statement_diverges_has_never_type"
-spec = ["3.4:2", "3.4:6a", "4.13:5b"]
+spec = ["3.4:2", "3.4:6a", "4.13:5c"]
 description = "A semicolon-terminated diverging statement leaves no reachable block tail and gives the block type !"
 source = """
 fn main() -> i32 {
@@ -237,7 +237,7 @@ exit_code = 42
 
 [[case]]
 name = "nested_panic_statement_diverges_has_never_type"
-spec = ["3.4:2", "3.4:6a", "4.13:5b"]
+spec = ["3.4:2", "3.4:6a", "4.13:5c"]
 description = "A nested block preserves bottom propagation from a diverging statement"
 source = """
 fn main() -> i32 {
@@ -251,7 +251,7 @@ stderr_contains = "panic"
 
 [[case]]
 name = "panic_in_let_statement_propagates_bottom"
-spec = ["3.4:2", "3.4:6a", "4.13:5b"]
+spec = ["3.4:2", "3.4:6a", "4.13:5c"]
 description = "A diverging initializer makes its unit-valued let statement non-continuing"
 source = """
 fn main() -> i32 {
@@ -263,7 +263,7 @@ stderr_contains = "panic: initializer"
 
 [[case]]
 name = "panic_in_call_argument_propagates_bottom"
-spec = ["3.4:2", "3.4:6a", "4.13:5b"]
+spec = ["3.4:2", "3.4:6a", "4.13:5c"]
 description = "A diverging call argument prevents the call statement from reaching its end"
 source = """
 fn sink(value: i32) {}
@@ -276,7 +276,7 @@ stderr_contains = "panic: argument"
 
 [[case]]
 name = "panic_in_pointer_intrinsic_operand_propagates_bottom"
-spec = ["3.4:2", "3.4:6a", "4.13:5b"]
+spec = ["3.4:2", "3.4:6a", "4.13:5c"]
 description = "A diverging strict intrinsic operand prevents the unit-valued statement from continuing"
 source = """
 fn main() -> i32 {
@@ -290,7 +290,7 @@ stderr_contains = "panic: pointer operand"
 
 [[case]]
 name = "assert_false_remains_unit"
-spec = ["3.4:6a", "4.13:5b"]
+spec = ["3.4:6a", "4.13:5d"]
 description = "@assert(false) remains unit-typed rather than becoming Never"
 source = """
 fn main() -> i32 {

--- a/crates/rue-spec/cases/types/strings.toml
+++ b/crates/rue-spec/cases/types/strings.toml
@@ -140,7 +140,7 @@ expected_stdout = "foobar\n"
 # it, which this case would have contradicted.
 [[case]]
 name = "string_capacity_is_observable"
-spec = ["3.7:41"]
+spec = ["3.7:41", "3.10:11", "3.10:26"]
 description = "capacity() returns the implementation's chosen capacity: 0 for a literal, a nonzero value after a clone allocates."
 real_std = true
 source = """

--- a/crates/rue-spec/cases/types/structs.toml
+++ b/crates/rue-spec/cases/types/structs.toml
@@ -128,7 +128,7 @@ exit_code = 0
 # observation (3.6:9), not a language guarantee.
 [[case]]
 name = "struct_fields_declaration_order"
-spec = ["3.6:9"]
+spec = ["3.6:8", "3.6:9"]
 source = """
 struct Point { x: i32, y: i32 }
 fn main() -> i32 {
@@ -142,7 +142,7 @@ exit_code = 8
 # documented observation of the current layout (3.6:10), not guaranteed.
 [[case]]
 name = "struct_size_sum_of_fields"
-spec = ["3.6:10"]
+spec = ["3.6:8", "3.6:10"]
 source = """
 struct Triple { a: i32, b: i32, c: i32 }
 fn main() -> i32 {
@@ -154,7 +154,7 @@ exit_code = 12
 
 [[case]]
 name = "nested_struct_size"
-spec = ["3.6:10"]
+spec = ["3.6:8", "3.6:10"]
 source = """
 struct Point { x: i32, y: i32 }
 struct Line { start: Point, end: Point }

--- a/crates/rue-spec/src/main.rs
+++ b/crates/rue-spec/src/main.rs
@@ -103,7 +103,8 @@ fn run_traceability(detailed: bool, json: bool) {
 
     // Exit with error if the gate is failing: an *unexpected* uncovered
     // normative paragraph (one not on the known-gap allowlist), a stale
-    // allowlist entry, or an orphan reference. Rules whose only tests are
+    // allowlist entry, an orphan reference, or a behavior-asserting case whose
+    // citations are all non-normative. Rules whose only tests are
     // skipped/preview-allowed-to-fail no longer count as coverage (RUE-132);
     // the ones tracked in KNOWN_UNCOVERED_NORMATIVE are reported but don't fail
     // the gate. Informative paragraphs never require coverage.

--- a/crates/rue-spec/src/traceability.rs
+++ b/crates/rue-spec/src/traceability.rs
@@ -117,6 +117,20 @@ pub struct TestReference {
     pub source_lines: usize,
 }
 
+/// A behavior-asserting spec case whose citations are all non-normative.
+///
+/// Informative and example paragraphs are useful documentation, but they do
+/// not establish a language requirement. Keeping this finding in the report
+/// makes a case which claims executable behavior without a normative anchor
+/// visible to both humans and machine consumers of the traceability report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NonNormativeCase {
+    /// Full test name in the format `section::case_name`.
+    pub test_name: String,
+    /// Every cited paragraph and its parsed category, in citation order.
+    pub citations: Vec<(String, String)>,
+}
+
 /// A complete traceability report linking specification paragraphs to tests.
 ///
 /// This report provides:
@@ -157,6 +171,9 @@ pub struct TraceabilityReport {
     /// `(test_name, only_on)`. Reported so the exclusion is visible rather than
     /// silent; a rule left uncovered by it fails the gate the ordinary way.
     pub platform_unreachable_cases: Vec<(String, Vec<String>)>,
+    /// Behavior-asserting cases whose citations are all informative/example. These
+    /// fail the gate unless repaired with a normative citation.
+    pub non_normative_cases: Vec<NonNormativeCase>,
 }
 
 /// The headline figures of a [`TraceabilityReport`], for machine consumers.
@@ -303,6 +320,16 @@ pub const KNOWN_UNCOVERED_NORMATIVE: &[(&str, &str)] = &[
     ),
 ];
 
+fn format_non_normative_case(case: &NonNormativeCase) -> String {
+    let citations = case
+        .citations
+        .iter()
+        .map(|(id, category)| format!("{id} [{category}]"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{} cites only {}", case.test_name, citations)
+}
+
 impl TraceabilityReport {
     /// Whether `id` is on the [`KNOWN_UNCOVERED_NORMATIVE`] allowlist.
     fn is_known_uncovered(id: &str) -> bool {
@@ -430,15 +457,16 @@ impl TraceabilityReport {
     }
 
     /// Whether the traceability gate should fail: any *unexpected* uncovered
-    /// normative rule, any stale allowlist entry, any orphan reference, any
-    /// duplicate rule id, or any normative rule covered only through a large
-    /// program.
+    /// normative rule, stale allowlist entry, orphan reference,
+    /// duplicate rule id, unfocused normative coverage, or behavior-asserting case
+    /// whose citations are all non-normative.
     pub fn gate_failing(&self) -> bool {
         !self.unexpected_uncovered_normative_paragraphs().is_empty()
             || !self.stale_known_uncovered().is_empty()
             || !self.orphan_references.is_empty()
             || !self.duplicate_rule_ids.is_empty()
             || !self.unfocused_normative_coverage().is_empty()
+            || !self.non_normative_cases.is_empty()
     }
 
     /// Returns the coverage percentage for normative paragraphs (0.0 to 100.0).
@@ -705,6 +733,17 @@ impl TraceabilityReport {
             );
             for (test_name, ref_id) in &self.orphan_references {
                 println!("  {} references non-existent '{}'", test_name, ref_id);
+            }
+            println!();
+        }
+
+        if !self.non_normative_cases.is_empty() {
+            println!(
+                "Behavior-asserting cases with only non-normative citations ({}):",
+                self.non_normative_cases.len()
+            );
+            for case in &self.non_normative_cases {
+                println!("  {}", format_non_normative_case(case));
             }
             println!();
         }
@@ -1778,6 +1817,20 @@ pub fn parse_spec_paragraphs(
     Ok((paragraphs, duplicates))
 }
 
+/// Whether a case carries a runner assertion that needs a specification anchor.
+/// The runner owns the grouped execution and golden-IR field predicates; the
+/// remaining compile/diagnostic assertions are explicit here. `compile_only`
+/// is included because it asserts compile success even though it does not run
+/// the produced program. Adding a new assertion requires updating the runner's
+/// corresponding predicate and this traceability adapter together.
+fn asserts_executable_behavior(case: &rue_test_runner::Case) -> bool {
+    case.has_execution_assertions()
+        || case.has_golden_ir_assertions()
+        || case.compile_fail
+        || !case.error_contains.is_empty()
+        || case.expected_error.is_some()
+}
+
 /// Generates a complete traceability report linking specification to tests.
 ///
 /// This is the main entry point for the traceability system. It:
@@ -1824,6 +1877,7 @@ pub fn generate_report(spec_dir: &Path, cases_dir: &Path) -> Result<Traceability
     // Process test files
     let mut platform_unreachable_cases = Vec::new();
     let mut responsibility_census = ResponsibilityCensus::default();
+    let mut non_normative_cases = Vec::new();
     for (_, test_file) in &test_files {
         for case in &test_file.case {
             let test_name = format!("{}::{}", test_file.section.id, case.name);
@@ -1838,6 +1892,36 @@ pub fn generate_report(spec_dir: &Path, cases_dir: &Path) -> Result<Traceability
             }
             let counts_as_coverage =
                 !case.skip && (case.preview.is_none() || case.preview_should_pass) && reachable;
+
+            // Citation integrity applies even when a case is skipped, preview-
+            // allowed-to-fail, or unreachable on required CI. Those cases do
+            // not contribute coverage, but their behavior claims must not be
+            // allowed to hide behind the coverage filters.
+            if asserts_executable_behavior(case) && !case.spec.is_empty() {
+                let citations = case
+                    .spec
+                    .iter()
+                    .map(|id| {
+                        (
+                            id.clone(),
+                            paragraphs
+                                .get(id)
+                                .map(|paragraph| paragraph.category.clone())
+                                .unwrap_or_else(|| "orphan".to_string()),
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                if citations.iter().all(|(id, _)| {
+                    paragraphs
+                        .get(id)
+                        .is_none_or(|paragraph| !TraceabilityReport::is_normative(paragraph))
+                }) {
+                    non_normative_cases.push(NonNormativeCase {
+                        test_name: test_name.clone(),
+                        citations,
+                    });
+                }
+            }
 
             for spec_ref in &case.spec {
                 if let Some(tests) = coverage.get_mut(spec_ref) {
@@ -1867,6 +1951,7 @@ pub fn generate_report(spec_dir: &Path, cases_dir: &Path) -> Result<Traceability
         duplicate_rule_ids,
         responsibility_census,
         platform_unreachable_cases,
+        non_normative_cases,
     })
 }
 
@@ -2617,12 +2702,171 @@ fn main() { }
             duplicate_rule_ids: vec![],
             responsibility_census: ResponsibilityCensus::default(),
             platform_unreachable_cases: vec![],
+            non_normative_cases: vec![],
         };
 
         assert_eq!(report.covered_count(), 1);
         // One of the two paragraphs is uncovered.
         assert_eq!(report.paragraphs.len() - report.covered_count(), 1);
         assert_eq!(report.coverage_percentage(), 50.0);
+    }
+
+    #[test]
+    fn executable_cases_with_only_non_normative_citations_fail_with_categories() {
+        let spec_dir = tempfile::tempdir().unwrap();
+        write_test_appendix(spec_dir.path());
+        fs::write(
+            spec_dir.path().join("spec.md"),
+            concat!(
+                "{{ rule(id=\"1.1:1\", cat=\"informative\") }}\nExplanation.\n",
+                "{{ rule(id=\"1.1:2\", cat=\"example\") }}\nExample.\n",
+            ),
+        )
+        .unwrap();
+        let cases_dir = tempfile::tempdir().unwrap();
+        fs::write(
+            cases_dir.path().join("cases.toml"),
+            r#"
+[section]
+id = "test.section"
+name = "Test"
+
+[[case]]
+name = "informative_only"
+spec = ["1.1:1", "1.1:2"]
+source = "fn main() -> i32 { 0 }"
+exit_code = 0
+"#,
+        )
+        .unwrap();
+
+        let report = generate_report(spec_dir.path(), cases_dir.path()).unwrap();
+        assert_eq!(
+            &report.non_normative_cases,
+            &[NonNormativeCase {
+                test_name: "test.section::informative_only".to_string(),
+                citations: vec![
+                    ("1.1:1".to_string(), "informative".to_string()),
+                    ("1.1:2".to_string(), "example".to_string()),
+                ],
+            }]
+        );
+        assert!(report.gate_failing());
+    }
+
+    #[test]
+    fn non_normative_citation_check_includes_non_coverage_cases_and_assertion_kinds() {
+        let spec_dir = tempfile::tempdir().unwrap();
+        write_test_appendix(spec_dir.path());
+        fs::write(
+            spec_dir.path().join("spec.md"),
+            concat!(
+                "{{ rule(id=\"1.1:1\", cat=\"informative\") }}\nInformative.\n",
+                "{{ rule(id=\"1.1:2\", cat=\"example\") }}\nExample.\n",
+                "{{ rule(id=\"1.1:3\", cat=\"informative\") }}\nInformative.\n",
+                "{{ rule(id=\"1.1:4\", cat=\"informative\") }}\nInformative.\n",
+                "{{ rule(id=\"1.1:5\", cat=\"informative\") }}\nInformative.\n",
+                "{{ rule(id=\"1.1:6\", cat=\"informative\") }}\nInformative.\n",
+                "{{ rule(id=\"1.1:7\", cat=\"informative\") }}\nInformative.\n",
+                "{{ rule(id=\"1.1:8\", cat=\"informative\") }}\nInformative.\n",
+            ),
+        )
+        .unwrap();
+        let cases_dir = tempfile::tempdir().unwrap();
+        fs::write(
+            cases_dir.path().join("cases.toml"),
+            r#"
+[section]
+id = "test.section"
+name = "Test"
+
+[[case]]
+name = "normal"
+spec = ["1.1:1", "1.1:2"]
+source = "fn main() -> i32 { 0 }"
+exit_code = 0
+
+[[case]]
+name = "skipped"
+spec = ["1.1:3"]
+skip = true
+source = "fn main() -> i32 { 0 }"
+exit_code = 0
+
+[[case]]
+name = "preview_may_fail"
+spec = ["1.1:4"]
+preview = "floats"
+source = "fn main() -> i32 { 0 }"
+exit_code = 0
+
+[[case]]
+name = "preview_must_pass"
+spec = ["1.1:5"]
+preview = "floats"
+preview_should_pass = true
+source = "fn main() -> i32 { 0 }"
+exit_code = 0
+
+[[case]]
+name = "unreachable"
+spec = ["1.1:6"]
+only_on = ["x86-64-macos"]
+source = "fn main() -> i32 { 0 }"
+exit_code = 0
+
+[[case]]
+name = "golden"
+spec = ["1.1:7"]
+source = "fn main() -> i32 { 0 }"
+expected_ast = "program"
+
+[[case]]
+name = "compile_fail"
+spec = ["1.1:8"]
+source = "fn main() -> i32 { true }"
+compile_fail = true
+error_contains = "type mismatch"
+
+[[case]]
+name = "source_only"
+spec = ["1.1:1"]
+source = "fn main() -> i32 { 0 }"
+"#,
+        )
+        .unwrap();
+
+        let report = generate_report(spec_dir.path(), cases_dir.path()).unwrap();
+        let mut names = report
+            .non_normative_cases
+            .iter()
+            .map(|case| case.test_name.as_str())
+            .collect::<Vec<_>>();
+        names.sort_unstable();
+        assert_eq!(
+            names,
+            vec![
+                "test.section::compile_fail",
+                "test.section::golden",
+                "test.section::normal",
+                "test.section::preview_may_fail",
+                "test.section::preview_must_pass",
+                "test.section::skipped",
+                "test.section::unreachable",
+            ]
+        );
+        assert!(!names.contains(&"test.section::source_only"));
+        assert!(report.gate_failing());
+        assert_eq!(
+            format_non_normative_case(
+                report
+                    .non_normative_cases
+                    .iter()
+                    .find(|case| case.test_name == "test.section::normal")
+                    .unwrap()
+            ),
+            "test.section::normal cites only 1.1:1 [informative], 1.1:2 [example]"
+        );
     }
 
     #[test]
@@ -2848,6 +3092,7 @@ exit_code = 0
                 duplicate_rule_ids: vec![],
                 responsibility_census: ResponsibilityCensus::default(),
                 platform_unreachable_cases: vec![],
+                non_normative_cases: vec![],
             }
         }
 

--- a/docs/spec/src/03-types/04-never-type.md
+++ b/docs/spec/src/03-types/04-never-type.md
@@ -17,7 +17,7 @@ Expressions of type `!` include:
 - `break` expressions
 - `continue` expressions
 - Infinite loops
-- `@panic(msg?)`, which aborts the process and never returns (4.13:5b)
+- `@panic(msg?)`, which aborts the process and never returns (4.13:5c)
 
 ## Type Coercion
 

--- a/docs/spec/src/03-types/10-mutable-strings.md
+++ b/docs/spec/src/03-types/10-mutable-strings.md
@@ -127,7 +127,7 @@ fn main() -> i32 {
 
 `fn reserve(inout self, additional: u64)` ensures the string has capacity for at least `additional` more bytes.
 
-{{ rule(id="3.10:19", cat="informative") }}
+{{ rule(id="3.10:19", cat="legality-rule") }}
 
 Mutation methods use `inout self` to modify the string in place. The variable must be declared with `let mut` to allow mutation.
 

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -41,8 +41,9 @@ This Quick Reference documents every source-spelled intrinsic name the compiler
 recognizes. The tables below group names that may appear in any expression
 position (expression intrinsics), only inside a `checked` block (unchecked
 intrinsics, specified in §9.2), or only as an internal checked bridge. Rule
-4.13:5b separately records frontend-reserved names whose surface syntax is not
-fully stabilized. This inventory is kept in sync with the compiler's
+4.13:5b separately records frontend-reserved names and test infrastructure.
+The contracts for the reserved expression intrinsics are stated in 4.13:5c–e.
+This inventory is kept in sync with the compiler's
 source-intrinsic recognition paths: the RIR type-intrinsic forms, the
 pre-interned names in `crates/rue-air/src/sema/known_symbols.rs`, and the
 semantic dispatch on them. A name absent from those paths is rejected as an
@@ -121,33 +122,32 @@ see rule [6.6:7](@/06-items/06-borrow-accessors.md)):
 
 {{ rule(id="4.13:5b", cat="informative") }}
 
-The compiler frontend additionally reserves the names `@cast`, `@panic`,
-`@assert`, and `@test_preview_gate`. Their surface syntax is not yet fully
-stabilized, so they are listed separately from the signature tables above, but
-they are no longer no-ops (RUE-319):
+The compiler frontend reserves the names `@cast`, `@panic`, `@assert`, and
+`@test_preview_gate`. The expression contracts for `@panic`, `@assert`, and
+`@cast` are specified in 4.13:5c, 4.13:5d, and 4.13:5e respectively. The
+`@test_preview_gate()` intrinsic is a zero-argument no-op used only to test the
+preview-feature gating machinery (`--preview test_infra`); it is test
+infrastructure, not a language feature.
 
-- `@panic(msg?: text)` has type `!` (never): it aborts the process and never
-  returns. The optional message may use any canonical text rung; unrelated
-  aggregates are not accepted. It writes
-  `panic: <msg>` (or just `panic` when called with no
-  argument) to standard error and exits with status 101 — the same abort
-  discipline as the `@intCast` overflow, division-by-zero, and bounds-check
-  traps. As a diverging expression it participates in never coercion (3.4:2),
-  so it may appear wherever a value of any type is expected — a typed `let`
-  initializer, an `if`/`else` or `match` arm whose other arms produce a value,
-  or a bare function tail.
-- `@assert(cond: bool, msg?: text)` requires an exact boolean condition and
-  the same optional text contract as `@panic`. When `cond` is `false` it
-  aborts exactly like `@panic`: with a message it writes `panic: <msg>`,
-  otherwise it writes `assertion failed`, and in both cases exits with status
-  101. When `cond` is `true` it has no effect. The expression has type `()` on
-  both paths.
-- `@cast` is rejected at compile time with a diagnostic directing the programmer
-  to `@intCast`; it never had a working inference rule and is fully redundant
-  with `@intCast`. Use `@intCast` for integer conversions.
-- `@test_preview_gate()` is a zero-argument no-op that exists only to test the
-  preview-feature gating machinery itself (`--preview test_infra`); it is test
-  infrastructure, not a language feature.
+{{ rule(id="4.13:5c", cat="dynamic-semantics") }}
+
+`@panic(msg?: text)` has type `!`, writes `panic: <msg>` (or `panic` without a
+message) to standard error, and terminates with status 101 without returning.
+It participates in never coercion (3.4:2), so it may appear wherever a value
+of any type is expected.
+
+{{ rule(id="4.13:5d", cat="dynamic-semantics") }}
+
+`@assert(cond: bool, msg?: text)` requires a boolean condition and has type
+`()`. A false condition terminates exactly as `@panic` (using `panic: <msg>`
+when a message is supplied, or `assertion failed` otherwise), with status 101;
+a true condition has no effect.
+
+{{ rule(id="4.13:5e", cat="legality-rule") }}
+
+`@cast` is reserved but not a valid conversion intrinsic. A call to it **MUST**
+be rejected at compile time with a diagnostic directing the programmer to
+`@intCast`.
 
 ## `@dbg`
 


### PR DESCRIPTION
## Summary

- fail traceability when a behavior-asserting spec case cites only informative or example paragraphs, with the case and every cited category in the diagnostic
- audit and repair all 34 current expanded cases using matching existing rules, narrowly stated panic/assert/cast rules, and the corrected mutable-string legality category
- keep informative implementation observations informative while pairing their tests with the actual normative behavior they exercise
- preserve the existing JSON summary and normative coverage, known-uncovered, orphan, duplicate, unfocused, and platform accounting contracts

## Validation

- `scripts/rue fmt`
- `./buck2 test //crates/rue-spec:rue-spec-test //:spec-traceability`
- `scripts/rue spec 4.13`
- `scripts/rue quick`
- `scripts/rue premerge`

Fixes RUE-1719