### PR TITLE
RUE-1755: reject untrackable declared-linear destructures

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -515,7 +515,10 @@ _CLI_TEST_ABSOLUTIZE = _CLI_TEST_BASE_ABSOLUTIZE + ["RUE_CLI_STAGED_PROGRAMS"]
 # flush against it, so restoring the ~100s of headroom 3700 was originally
 # chosen with is what keeps the next case addition from re-failing. Raising it
 # only to the derived value would spend that headroom immediately.
-_CLI_TESTS_TIMEOUT_SECONDS = 3800
+#
+# Raised 3800 -> 3900 after later corpus growth pushed the linux-arm64 derived
+# deadline to 3805, preserving that same headroom policy.
+_CLI_TESTS_TIMEOUT_SECONDS = 3900
 _CLI_SHARD_TIMEOUT_SECONDS = 1200
 
 # The bounded premerge CLI corpus in one invocation: the canonical target that a

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -2608,8 +2608,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     ///
     /// Returns `None` when no declared-linear container encloses the selected
     /// leaf; depth 0 means the root itself is the consumed place. Dynamic
-    /// index paths pass `false` to retain their pre-RUE-614 shallowest-place
-    /// fallback while RUE-1755 owns their future design.
+    /// index paths pass `false` so the shallowest declared-linear prefix can
+    /// still be identified for the E0904 rejection at the use site.
     fn declared_linear_destructure_depth(
         &self,
         trace: &PlaceTrace,
@@ -3137,6 +3137,30 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // path is still a use-after-move.
             let is_byref_arg_use = ctx.byref_arg_root == Some(trace.root_var);
 
+            // A value-context projection through an untrackable index cannot
+            // select a declared-linear place precisely.  Falling back to an
+            // ordinary Copy read would leave the selected sibling unknown to
+            // the linear obligation check, silently discharging it at scope
+            // exit.  Keep by-reference uses and the destructor's own `self`
+            // exemption unchanged, but reject every other declared-linear
+            // dynamic path through the established E0904 family.
+            if !is_byref_arg_use
+                && !is_destructor_self
+                && has_untrackable_index
+                && declared_depth.is_some()
+            {
+                return Err(CompileError::new(
+                    ErrorKind::MoveOutOfIndex {
+                        element_type: field_type.safe_name_with_pool(Some(self.body_type_pool())),
+                    },
+                    span,
+                )
+                .with_help(
+                    "moving a field out through an array index requires a \
+                     compile-time constant index",
+                ));
+            }
+
             // Moving a (non-Copy) field or the whole value out of a `for`-loop
             // element binder over a non-Copy collection would let the new owner
             // AND the collection both drop it (double-free): iteration is a
@@ -3177,10 +3201,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             } else if is_declared_linear {
                 // For a declared-linear struct, field access destructures and
                 // so consumes that struct's whole value (3.8:33).
-                // Dynamic/untrackable index paths intentionally retain the
-                // transitional whole-root fallback. RUE-1755 owns the design
-                // decision for making those paths precise; RUE-614 only adds
-                // residue semantics where the place is statically trackable.
+                // Dynamic/untrackable paths are rejected above when a
+                // declared-linear prefix exists, so this branch only performs
+                // the statically trackable RUE-614 destructure.
                 self.reject_accessor_place_move(&trace, field_type, span)?;
                 self.reject_field_move_out_of_destructor_type(&trace, span)?;
                 self.reject_move_out_of_byref_param(trace.root_var, ctx, span)?;
@@ -3676,10 +3699,32 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let declared_depth = self.declared_linear_destructure_depth(&trace, true);
             let is_destructor_self =
                 ctx.is_destructor && ctx.params.iter().any(|param| param.name == trace.root_var);
-            // Dynamic/untrackable index paths retain their pre-RUE-614
-            // Copy/non-Copy behavior. RUE-1755 owns any future precise
-            // semantics; only constant-index paths enter the new
-            // declared-linear residue plan.
+            // A dynamic index cannot identify which declared-linear place is
+            // being destructured.  Reject value-context reads rather than
+            // treating a Copy leaf as an ordinary read and losing the
+            // selected element's sibling obligation (RUE-1755).  Explicit
+            // by-reference uses and a destructor's own `self` retain their
+            // existing behavior.
+            if !is_byref_arg_use
+                && !is_destructor_self
+                && trace.has_untrackable_index()
+                && declared_depth.is_some()
+            {
+                return Err(CompileError::new(
+                    ErrorKind::MoveOutOfIndex {
+                        element_type: elem_type.safe_name_with_pool(Some(self.body_type_pool())),
+                    },
+                    span,
+                )
+                .with_help(
+                    "moving an element out through an array index requires a \
+                     compile-time constant index",
+                ));
+            }
+            // Only statically trackable paths enter the RUE-614
+            // declared-linear residue plan. Dynamic paths with a
+            // declared-linear prefix were rejected above; other dynamic
+            // paths retain the ordinary Copy/move behavior.
             let trackable_declared_depth =
                 declared_depth.filter(|_| !is_destructor_self && !trace.has_untrackable_index());
             let mut element_move: Option<i64> = None;

--- a/crates/rue-cli-tests/cases/nested_linear_destructure.toml
+++ b/crates/rue-cli-tests/cases/nested_linear_destructure.toml
@@ -585,7 +585,7 @@ error_contains = ["E0456", "cannot move field `value` out of a value of type 'To
 
 [[case]]
 name = "declared_linear_destructor_rejects_dynamic_copy_projection"
-description = "A dynamic-index Copy projection cannot bypass whole-value destructor safety on a declared-linear container (RUE-1755 fallback preserved)."
+description = "A dynamic-index projection on a declared-linear container is rejected before it can bypass whole-value destructor safety (RUE-1755)."
 files = [{ path = "main.rue", source = """
 linear struct Token { values: [i32; 2] }
 drop fn Token(self) { @dbg(self.values[0]); }
@@ -597,7 +597,22 @@ fn main() -> i32 {
 }
 """ }]
 compile_fail = true
-error_contains = ["E0456", "cannot move field `values` out of a value of type 'Token'"]
+error_contains = ["E0904", "cannot move out of indexed position", "moving an element out through an array index requires a compile-time constant index"]
+
+[[case]]
+name = "declared_linear_dynamic_copy_element_rejected_without_destructor"
+description = "A direct dynamic Copy element read on a declared-linear container is rejected even without a custom destructor (RUE-1755 IndexGet pin)."
+files = [{ path = "main.rue", source = """
+linear struct Token { values: [i32; 2] }
+fn pick() -> u64 { 0 }
+fn main() -> i32 {
+    let token = Token { values: [7, 9] };
+    let index = pick();
+    token.values[index]
+}
+""" }]
+compile_fail = true
+error_contains = ["E0904", "cannot move out of indexed position", "moving an element out through an array index requires a compile-time constant index"]
 
 [[case]]
 name = "declared_linear_field_borrow_does_not_destructure"
@@ -629,6 +644,60 @@ fn main() -> i32 {
 exit_code = 8
 
 [[case]]
+name = "declared_linear_dynamic_field_borrow_does_not_destructure"
+description = "Borrowing through a dynamic index with a declared-linear prefix remains a borrow and leaves the owner available."
+files = [{ path = "main.rue", source = """
+struct Cell { value: i32 }
+linear struct Token { entries: [Cell; 2] }
+fn pick() -> u64 { 1 }
+fn read(borrow value: i32) -> i32 { value }
+fn consume(token: Token) -> i32 { token.entries[0].value }
+fn main() -> i32 {
+    let token = Token { entries: [Cell { value: 7 }, Cell { value: 9 }] };
+    let index = pick();
+    read(borrow token.entries[index].value) + consume(token)
+}
+""" }]
+exit_code = 16
+
+[[case]]
+name = "declared_linear_dynamic_element_inout_does_not_destructure"
+description = "An inout use through a dynamic index with a declared-linear prefix remains a mutation and leaves the owner available."
+files = [{ path = "main.rue", source = """
+linear struct Token { values: [i32; 2] }
+fn pick() -> u64 { 1 }
+fn bump(inout value: i32) { value = value + 1; }
+fn consume(token: Token) -> i32 { token.values[1] }
+fn main() -> i32 {
+    let mut token = Token { values: [7, 9] };
+    let index = pick();
+    bump(inout token.values[index]);
+    consume(token)
+}
+""" }]
+exit_code = 10
+
+[[case]]
+name = "declared_linear_destructor_self_dynamic_index_remains_legal"
+description = "A destructor may read its own declared-linear self through a dynamic index without triggering the external value-use rejection."
+files = [{ path = "main.rue", source = """
+linear struct Token { values: [i32; 2] }
+fn pick() -> u64 { 1 }
+drop fn Token(self) {
+    let index = pick();
+    let observed = self.values[index];
+    @dbg(observed);
+}
+fn main() -> i32 {
+    let token = Token { values: [7, 9] };
+    @drop(token);
+    0
+}
+""" }]
+exit_code = 0
+stdout = "9\n"
+
+[[case]]
 name = "declared_linear_field_raw_mut_does_not_destructure"
 description = "Taking a mutable raw pointer to a declared-linear field does not consume or drop the enclosing value."
 files = [{ path = "main.rue", source = """
@@ -645,18 +714,47 @@ fn main() -> i32 {
 exit_code = 8
 
 [[case]]
-name = "declared_linear_dynamic_copy_field_read_keeps_root_live"
-description = "A dynamic Copy field read through a declared-linear ancestor retains the transitional RUE-1755 behavior and does not consume the root."
+name = "declared_linear_dynamic_copy_field_read_rejected"
+description = "A dynamic Copy field read through a declared-linear ancestor is rejected because its declared-linear destructure cannot identify a place precisely (RUE-1755)."
 files = [{ path = "main.rue", source = """
 struct Cell { value: i32 }
 linear struct Token { entries: [Cell; 2] }
 fn pick() -> u64 { 0 }
-fn consume(token: Token) -> i32 { token.entries[0].value }
 fn main() -> i32 {
     let token = Token { entries: [Cell { value: 7 }, Cell { value: 9 }] };
     let index = pick();
-    token.entries[index].value;
-    consume(token)
+    token.entries[index].value
 }
 """ }]
-exit_code = 7
+compile_fail = true
+error_contains = ["E0904", "cannot move out of indexed position", "moving a field out through an array index requires a compile-time constant index"]
+
+[[case]]
+name = "declared_linear_dynamic_root_array_element_rejected"
+description = "A dynamic Copy field read from a root array of declared-linear values is rejected because the selected element cannot be tracked (RUE-1755)."
+files = [{ path = "main.rue", source = """
+linear struct Token { value: i32 }
+fn pick() -> u64 { 0 }
+fn main() -> i32 {
+    let tokens = [Token { value: 7 }, Token { value: 9 }];
+    let index = pick();
+    tokens[index].value
+}
+""" }]
+compile_fail = true
+error_contains = ["E0904", "cannot move out of indexed position", "moving a field out through an array index requires a compile-time constant index"]
+
+[[case]]
+name = "ordinary_dynamic_copy_field_read_remains_legal"
+description = "A dynamic Copy field read with no declared-linear prefix remains an ordinary read (RUE-1755 boundary)."
+files = [{ path = "main.rue", source = """
+struct Cell { value: i32 }
+struct Holder { entries: [Cell; 2] }
+fn pick() -> u64 { 1 }
+fn main() -> i32 {
+    let holder = Holder { entries: [Cell { value: 7 }, Cell { value: 9 }] };
+    let index = pick();
+    holder.entries[index].value
+}
+""" }]
+exit_code = 9

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1839,12 +1839,14 @@ pub enum ErrorKind {
     IndexOutOfBounds { index: i128, length: u64 },
     #[error("type annotation required for empty array")]
     TypeAnnotationRequired,
-    /// Cannot move non-Copy element out of array index position.
-    /// Raised only for moves the per-element tracker cannot follow: dynamic
-    /// (non-constant) indices, and indexing that is not rooted directly at an
-    /// array variable. A constant index into an array variable moves just
-    /// that element out (spec 3.8:68, RUE-186).
-    #[error("cannot move out of indexed position: element type '{element_type}' is not Copy")]
+    /// Cannot move or destructure through an array index position that the
+    /// per-element ownership tracker cannot follow: dynamic (non-constant)
+    /// indices, and indexing that is not rooted directly at an array variable.
+    /// A constant index into an array variable moves just that element out
+    /// (spec 3.8:68, RUE-186). Declared-linear destructuring also uses this
+    /// diagnostic when a dynamic index makes its consumed place untrackable
+    /// (RUE-1755), including when the selected leaf is Copy.
+    #[error("cannot move out of indexed position")]
     MoveOutOfIndex { element_type: String },
     /// Array-repeat literal `[value; count]` whose element type is not Copy.
     /// A repeat literal materializes `count` copies of a single value, so the

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -2276,6 +2276,61 @@ fn main() -> i32 {
 exit_code = 3
 
 [[case]]
+name = "declared_linear_root_array_dynamic_element_rejected"
+spec = ["3.8:33", "3.8:68", "3.8:71"]
+description = "A dynamic index into a root array of declared-linear values cannot identify the destructured element, so the value use is rejected (RUE-1755)"
+source = """
+linear struct MustUse { value: i32 }
+
+fn pick() -> u64 { 0 }
+
+fn main() -> i32 {
+    let a = [MustUse { value: 1 }, MustUse { value: 2 }];
+    let index = pick();
+    a[index].value
+}
+"""
+compile_fail = true
+error_contains = ["cannot move out of indexed position", "moving a field out through an array index requires a compile-time constant index"]
+
+[[case]]
+name = "declared_linear_nested_dynamic_element_rejected"
+spec = ["3.8:33", "3.8:68", "3.8:71"]
+description = "A dynamic index into an array field of declared-linear values cannot identify the destructured element, so the value use is rejected (RUE-1755)"
+source = """
+linear struct MustUse { value: i32 }
+struct Holder { entries: [MustUse; 2] }
+
+fn pick() -> u64 { 0 }
+
+fn main() -> i32 {
+    let h = Holder { entries: [MustUse { value: 1 }, MustUse { value: 2 }] };
+    let index = pick();
+    h.entries[index].value
+}
+"""
+compile_fail = true
+error_contains = ["cannot move out of indexed position", "moving a field out through an array index requires a compile-time constant index"]
+
+[[case]]
+name = "declared_linear_dynamic_copy_element_rejected"
+spec = ["3.8:33", "7.1:26", "7.1:28"]
+description = "A direct dynamic Copy element read with a declared-linear prefix is a destructure whose target cannot be tracked (RUE-1755)"
+source = """
+linear struct Token { values: [i32; 2] }
+
+fn pick() -> u64 { 0 }
+
+fn main() -> i32 {
+    let token = Token { values: [7, 9] };
+    let index = pick();
+    token.values[index]
+}
+"""
+compile_fail = true
+error_contains = ["cannot move out of indexed position", "moving an element out through an array index requires a compile-time constant index"]
+
+[[case]]
 name = "declared_linear_element_destructure_scoped_to_the_element"
 spec = ["3.8:32", "3.8:33"]
 description = "Destructuring one declared-linear array element consumes that element only; the sibling element's obligation stands (RUE-1632)"

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -348,11 +348,10 @@ syntactic contexts:
 > - if the plan is `Declared(d,π)`, the use applies
 >   `(Use-Declared-Linear-Destructure)` (§5.1), consuming `d` and producing the
 >   selected leaf;
-> - if the plan is `Untrackable(ShallowConsume(m))`, the use applies the
->   shallow/root fallback and consumes its recorded marker `m`, even when the
->   selected leaf `T` is `Copy`;
-> - otherwise, if the plan is `Untrackable(CopyRead)` or
->   `Untrackable(OrdinaryDynamic)` and `class(T) = Copy`, the use **copies** —
+> - if the plan is `Untrackable(DeclaredLinearDynamic)`, the use is ill-formed: an
+>   untrackable index cannot identify the declared-linear destructure target;
+> - otherwise, if the plan is `Untrackable(OrdinaryDynamic)` and `class(T) = Copy`,
+>   the use **copies** —
 >   the value at `p` is duplicated and `p` remains in whatever ownership state
 >   it had;
 > - otherwise, if `class(T) ∈ {Affine, Linear}`, the use **moves** (equivalently,
@@ -375,25 +374,21 @@ untracked/dynamic index makes it undefined. Thus `d` is the smallest enclosing
 declared-linear place, not necessarily the root binding. The selected path may
 pass through nested structs and constant-index arrays. The ordinary partial
 move rule remains in force when no declared-linear plan or applicable fallback
-plan is recorded, including for structs that are linear only by infection.
+plan is recorded, including for structs that are linear only by infection. A
+projection rooted at a destructor's own `self` never receives a declared-linear
+plan: Copy reads are ordinary observations, while moves of `self` or its fields
+are rejected by the destructor rules (3.9:33–34).
 
-For an untrackable path, elaboration records an explicit `uf(Γ,p)` fallback
-annotation instead of leaving the dynamic semantics to rediscover `Γ`. It
-contains the shallowest/root declared-linear prefix found by the current
-fallback walk, whether the final immediate parent is declared-linear, and the
-selected action: `CopyRead` (read the selected Copy value and keep the root
-live), `ShallowConsume(m)` (the existing shallowest/root consuming fallback,
-with `m` its consumed marker), or `OrdinaryDynamic` (the ordinary dynamic-index
-path, including its move rejection). If a dynamic prefix makes the intended
-declared place unnameable, `m` is the root place; otherwise `m` is that intended
-place. This is
-the RUE-1755 transitional behavior: a dynamic Copy read
-keeps its root live but still performs the full-prefix destructor check, while
-the consuming fallback is used only where the current ownership analysis
-selects it. The complete use plan is therefore
-`Declared(d,π)`, `Untrackable(uf(Γ,p))`, `Ordinary`, or `Borrowed` (for
-by-reference/equality place reads), and is carried into §6 as elaboration
-metadata.
+For an untrackable path, elaboration records an explicit `uf(Γ,p)` annotation
+instead of leaving the dynamic semantics to rediscover `Γ`. It records whether
+the path has an applicable declared-linear prefix; the destructor's own `self`
+is excluded as above. Such a prefix makes a value-context use ill-formed: the
+selected place cannot be identified precisely, so the existing E0904
+dynamic-index restriction applies. Without an applicable prefix, the path uses
+`OrdinaryDynamic` (including its existing move rejection). The
+complete use plan is therefore `Declared(d,π)`, `Untrackable(uf(Γ,p))`,
+`Ordinary`, or `Borrowed` (for by-reference/equality place reads), and is
+carried into §6 as elaboration metadata.
 
 Two static restrictions bound *which ordinary partial moves* may be made:
 
@@ -589,40 +584,21 @@ by the ordinary `(Use-Copy)` premise.
   Γ ; Σ ; Λ  ⊢  p  ⇒  T  ⊣  Σ[ p ↦ MovedOut,  and every path strictly under p removed ]
 ```
 
-Untrackable uses are typed from their elaborated fallback action. `m` below is
-a recorded place, not a value reconstructed after an index reduces;
-when a dynamic prefix makes the intended declared place unnameable, the
-annotation records `m = root(p)` and consumes that root. `m not loaned` means
-the same root/loan exclusion as the ordinary use rules.
-
-Write `full-prefix-destructor-safe(Γ,p)` when no proper prefix of the complete
-place path `p` has a user-defined destructor. This is the static form of the
-all-enclosing-value restriction in 3.9:34; the result is carried in `μ` for
-dynamic reduction.
-
 ```
-  Γ ⊢ p : T       planΓ(p) = Untrackable(CopyRead,T)
-  Σ(p) = Owned    p not exclusively loaned in Λ    full-prefix-destructor-safe(Γ,p)
-  ─────────────────────────────────────────────────────── (Use-Untrackable-CopyRead)
-  Γ ; Σ ; Λ ⊢ p ⇒ T ⊣ Σ
-
   Γ ⊢ p : T       planΓ(p) = Untrackable(OrdinaryDynamic,T)
   class(T) = Copy  Σ(p) = Owned    p not exclusively loaned in Λ
+  no applicable declared-linear prefix in p
   ─────────────────────────────────────────────────────── (Use-Untrackable-Dynamic-Copy)
   Γ ; Σ ; Λ ⊢ p ⇒ T ⊣ Σ
-
-  Γ ⊢ p : T       planΓ(p) = Untrackable(ShallowConsume(m),T)
-  Γ ⊢ m : U       fully-owned(Σ,m)       m is a statically recorded place
-  m not loaned in Λ       full-prefix-destructor-safe(Γ,p)
-  ─────────────────────────────────────────────────────── (Use-Untrackable-Shallow)
-  Γ ; Σ ; Λ ⊢ p ⇒ T ⊣ Σ[ m ↦ MovedOut, and every path strictly under m removed ]
 ```
 
 There is no successful static rule for `Untrackable(OrdinaryDynamic,T)` when
 `class(T) ∈ {Affine,Linear}`: the existing dynamic-index move restriction
-rejects that use. `Use-Untrackable-CopyRead` carries the full-prefix destructor
-gate required by the current declared-linear dynamic Copy path; the ordinary
-dynamic Copy rule has only the ordinary Copy-read premises.
+rejects that use. There is also no successful static rule when an untrackable
+path has an applicable declared-linear prefix: that use is rejected with E0904
+because its destructure target cannot be tracked without a compile-time index. The
+destructor-`self` exemption above classifies its Copy reads as
+`Untrackable(OrdinaryDynamic)` without a declared-linear plan.
 
 The ordinary rules above are selected only when elaboration records the
 corresponding `Ordinary` plan. They are overridden for a statically trackable projection
@@ -659,14 +635,14 @@ the same all-enclosing-value restriction as 3.9:34 applies even though only
 `d` is consumed. A destructor on a legally droppable unselected residue is run
 by its ordinary drop glue. The `linear-residue` premise rejects the access
 before any residue can be silently dropped. An untrackable path is not treated
-as ordinary merely because `dl` is undefined: its elaborated `Untrackable`
-fallback plan (§4.2) selects the current shallowest/root consuming fallback,
-the Copy-read fallback, or the ordinary dynamic-index rejection. By-reference
-and equality operands are `Borrowed` place uses and do not invoke this rule.
+as ordinary merely because `dl` is undefined: a declared-linear prefix selects
+the E0904 rejection, while a path without one uses
+`Untrackable(OrdinaryDynamic)`. By-reference and equality operands are
+`Borrowed` place uses and do not invoke this rule.
 
 The `(Use-Copy)` and `(Use-Move)` rules are read only with an `Ordinary` plan;
 this prevents overlap when a selected leaf is Copy inside a declared-linear
-destructure or an untrackable fallback.
+destructure or an ordinary untrackable dynamic read.
 The rule is intentionally distinct from infectious linearity: a struct that is
 linear only because a field carries a linear value follows ordinary partial
 move and residual checking.
@@ -1732,10 +1708,9 @@ signedness were resolved by elaboration (§5.8), so the machine stores the concr
 Using a place `p` in value context is the operational side of §4.2 / §5.1. At
 static elaboration, every such use receives a closed annotation `μ`; it is one
 of `Declared(d,π_s,T)`, `Untrackable(f,T)`, or `Ordinary(class(T),T)`. The
-`Untrackable` annotation contains the concrete `uf` fallback data from §4.2 —
-the shallowest/root declared-linear prefix, the immediate-parent flag, and its
-selected action (`CopyRead`, `ShallowConsume(m)`, or `OrdinaryDynamic`) — plus
-the already-checked full-prefix destructor-safety result. A place in a
+`Untrackable` annotation contains the concrete `uf` data from §4.2, including
+whether an applicable declared-linear prefix exists. Such a prefix is rejected
+during static checking; otherwise the action is `OrdinaryDynamic`. A place in a
 by-reference or equality context receives `Borrowed` instead. Thus the dynamic
 rules consume elaboration metadata; they never consult `Γ`, recompute a
 declared-linear prefix, or recover constant-index provenance after reduction.
@@ -1774,27 +1749,14 @@ not a value dropped by `destructure`. An untrackable path follows its closed
 ordinary path after reduction. A by-reference or equality projection is not a
 value-context use and never fires this rule.
 
-For the RUE-1755 fallback, `μ = Untrackable(f,T)` has the following dynamic
-images. `f = CopyRead` keeps the root and all enclosing places live, but its
-carried full-prefix destructor-safety check has already rejected any unsafe
-custom destructor. `f = ShallowConsume(m)` uses the existing shallowest/root
-fallback and consumes its recorded marker `m` without entering the constant-index
-residue plan; the selected value is transferred and `m` becomes `⊘`.
-`f = OrdinaryDynamic`
-retains the ordinary dynamic-index behavior: a Copy read leaves storage live,
-while a non-Copy move is rejected by the static dynamic-index rule.
+For an untrackable path with an applicable declared-linear prefix, static
+checking rejects the use with E0904 before evaluation: no dynamic redex may discharge an
+unidentified linear sibling obligation. Otherwise, `μ =
+Untrackable(OrdinaryDynamic,T)` retains the ordinary dynamic-index behavior: a
+Copy read leaves storage live, while a non-Copy move is rejected by the static
+dynamic-index rule.
 
 ```
-  ρ(root(p)) = ℓ      μ = Untrackable(CopyRead,T)      H(ℓ)@π = v
-  full-prefix-destructor-safe(μ)
-  ─────────────────────────────────────────────── (D-Use-Untrackable-Copy)
-  ⟨ H ; φ ; K ; p ⟩ → ⟨ H ; φ ; K ; v ⟩
-
-  ρ(root(p)) = ℓ      μ = Untrackable(ShallowConsume(m),T)
-  H(ℓ)@π = v          m resolves to ℓ@π_m
-  ─────────────────────────────────────────────── (D-Use-Untrackable-Move)
-  ⟨ H ; φ ; K ; p ⟩ → ⟨ H[ℓ@π_m ↦ ⊘] ; φ ; K ; v ⟩
-
   ρ(root(p)) = ℓ      μ = Untrackable(OrdinaryDynamic,T)
   class(T) = Copy      H(ℓ)@π = v
   ─────────────────────────────────────────────── (D-Use-Untrackable-Dynamic-Copy)
@@ -1944,8 +1906,9 @@ the corresponding aggregate value, owning every component (`StructInit`/
 Projection in value context is subsumed by the place-use rules of §6.3 (a
 projection `p.f` / `p[e]` is a place). A statically trackable projection from a
 declared-linear place uses `(D-Use-Declared-Linear)` there; an untrackable
-projection uses its elaborated RUE-1755 fallback, and only an `Ordinary` plan
-uses the ordinary copy/partial-move rules. An **array index is
+projection with an applicable declared-linear prefix is rejected by the E0904 rule above,
+and only an `OrdinaryDynamic` plan without such a prefix uses the ordinary
+copy/partial-move rules. An **array index is
 bounds-checked** at the moment the path is navigated, and an out-of-range or negative index traps
 (`resolve_path`/`place_read`):
 
@@ -2731,17 +2694,16 @@ neither claims anything about an uninhabited-parameter function such as
   variants `K1..Kn`, and the arms cover exactly those, so some arm always
   matches — a `match` is never stuck on an uncovered tag.
 
-- **No use-after-move.** In a well-typed program, no use redex — ordinary,
-  declared-linear, or untrackable fallback — is applied to a `MovedOut` place.
-  *Because:* the static plan requires `fully-owned(Σ,p)`, `fully-owned(Σ,d)`,
-  or `fully-owned(Σ,m)` for the consumed place, while `Borrowed` place reads
-  require an owned base;
+- **No use-after-move.** In a well-typed program, no ordinary, declared-linear,
+  or untrackable dynamic use redex is applied to a `MovedOut` place. *Because:*
+  the static plan requires `fully-owned(Σ,p)` or `fully-owned(Σ,d)` for a
+  consumed place, while `Borrowed` place reads require an owned base;
   preservation maintains the invariant that Σ faithfully tracks the store's
   initialization. The dynamic declared rule therefore cannot navigate through
   a hole before its `split`.
 
 - **No double-free.** Every stored value's destructor runs at most once. *Because:*
-  an ordinary or fallback move sets its consumed place to `MovedOut`, and the
+  an ordinary move sets its consumed place to `MovedOut`, and the
   declared-linear rule transfers its selected leaf, applies each planned
   droppable residue drop exactly once in order, then sets `d ↦ MovedOut`/`⊘`;
   the Drop rule (§6) skips that consumed place and its moved-out descendants.
@@ -2800,7 +2762,7 @@ neither claims anything about an uninhabited-parameter function such as
   residue before execution, transfers exactly its selected leaf, drops only the
   legally droppable residue once in the elaborated order, and then marks `d`
   `MovedOut`/`⊘`; its selected leaf is consequently the sole new owner. No
-  value is used twice (`Use-Move` or the fallback consuming action consumes it).
+  value is used twice (`Use-Move` consumes an ordinary moved value).
   Hence exactly once. This
   now covers **enums**: `class(E)` is the payload join (§3), so a `Linear`-payload
   enum is itself `Linear` and `carries_linear(E)` holds (§5.3); letting it reach

--- a/docs/spec/src/07-arrays/01-fixed-arrays.md
+++ b/docs/spec/src/07-arrays/01-fixed-arrays.md
@@ -317,7 +317,13 @@ Array indexing operates as a projection. Reading an element does not move the ar
 
 {{ rule(id="7.1:26", cat="normative") }}
 
-When reading an element of a Copy type (e.g., integers, booleans), the element is copied out.
+When reading an element of a Copy type (e.g., integers, booleans), the element
+is copied out unless the value-context projection destructures an enclosing
+place whose struct type is declared `linear` (3.8:33). Such a destructure
+consumes that enclosing place even when the selected element is Copy, and is
+subject to the index-trackability restriction in 7.1:28. A destructor's own
+`self` parameter retains its established exemption (3.8:62): Copy element reads
+inside the destructor observe the value without destructuring it.
 
 {{ rule(id="7.1:27") }}
 
@@ -332,7 +338,21 @@ fn main() -> i32 {
 
 {{ rule(id="7.1:28", cat="legality-rule") }}
 
-When reading an element of a non-Copy type, the read moves the element out of the array only when the index is a compile-time constant and the indexing applies directly to an array variable (per-element move tracking; see Array Element Moves in the Move Semantics chapter). Any other such read — a non-constant index, or an array reached through another projection or computed by an expression — is a compile-time error: with a runtime index the compiler cannot know which element moved, so neither use-after-move checking nor drop elaboration could remain sound.
+When reading an element of a non-Copy type, the read moves the element out of
+the array only when the index is a compile-time constant and the indexing
+applies directly to an array variable (per-element move tracking; see Array
+Element Moves in the Move Semantics chapter). Any other such read — a
+non-constant index, or an array reached through another projection or computed
+by an expression — is a compile-time error: with a runtime index the compiler
+cannot know which element moved, so neither use-after-move checking nor drop
+elaboration could remain sound. A value-context projection with a
+declared-linear prefix (3.8:33) likewise requires every index in its path to be
+a compile-time constant, including when its selected element is Copy: a runtime
+index cannot identify the declared-linear place whose destructure would consume
+and dispose of residue. Such an untrackable projection is rejected with E0904.
+This declared-linear-prefix restriction does not apply to a destructor's own
+`self`: its drop glue owns the value (3.8:62), Copy reads remain observations,
+and moving `self` or one of its fields is separately forbidden by 3.9:33–34.
 
 {{ rule(id="7.1:29") }}
 


### PR DESCRIPTION
## Summary
- reject dynamic-index value uses when their ownership path has an applicable declared-linear prefix
- preserve borrow, inout, destructor-self, ordinary Copy, and constant-index behavior
- align E0904, normative array rules, the formal calculus, and regression coverage
- restore the established CLI action-bound headroom after corpus growth exposed a shared trunk policy mismatch

## Validation
- `scripts/rue cli nested_linear_destructure`
- `scripts/rue spec 7.1`
- `scripts/rue quick`
- `scripts/rue fmt`
- `scripts/rue premerge` (199 relevant targets passed before the shared timeout-policy repair)
- `./buck2 test //:cli-timeout-policy-validation`

Fixes RUE-1755