### PR TITLE
RUE-1539: contextualize enum fixed-string payload literals

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -384,6 +384,13 @@ pub struct ConstraintGenerator<'a> {
     string_literal_vars: Vec<TypeVarId>,
     /// Concrete default for an otherwise-unconstrained string literal.
     string_literal_default: Type,
+    /// Fixed-string nominal identities used while generating constraints.
+    ///
+    /// These are carried separately from expression types because a provider
+    /// can materialize a fixed-string enum payload only while a construction
+    /// is being constrained. The identity must reach unification even when
+    /// the declaration is not present in the body's generated-name map.
+    fixed_string_types: Vec<Type>,
     /// Trusted standard-library growable string identity, when imported.
     strbuf_type: Option<Type>,
     /// Type substitutions for Self and type parameters (used in method bodies).
@@ -590,6 +597,7 @@ impl<'a> ConstraintGenerator<'a> {
             int_literal_vars: Vec::new(),
             string_literal_vars: Vec::new(),
             string_literal_default,
+            fixed_string_types: Vec::new(),
             strbuf_type,
             type_subst,
             const_types: None,
@@ -651,6 +659,7 @@ impl<'a> ConstraintGenerator<'a> {
             int_literal_vars: Vec::new(),
             string_literal_vars: Vec::new(),
             string_literal_default,
+            fixed_string_types: Vec::new(),
             strbuf_type,
             type_subst,
             const_types: None,
@@ -1205,7 +1214,39 @@ impl<'a> ConstraintGenerator<'a> {
 
     /// Add a constraint.
     pub fn add_constraint(&mut self, constraint: Constraint) {
+        self.record_fixed_string_types(&constraint);
         self.constraints.push(constraint);
+    }
+
+    /// Record every fixed-string nominal occurring in a constraint's type
+    /// shapes. The walk follows structural arrays so enum payloads such as
+    /// `[Str(8); 2]` carry the exact pool identity into unification.
+    fn record_fixed_string_types(&mut self, constraint: &Constraint) {
+        fn record_type(types: &mut Vec<Type>, pool: &TypeInternPool, ty: &InferType) {
+            match ty {
+                InferType::Concrete(ty) => {
+                    if let TypeKind::Struct(id) = ty.kind()
+                        && crate::types::fixed_string_struct_capacity(&pool.struct_def(id))
+                            .is_some()
+                    {
+                        types.push(*ty);
+                    }
+                }
+                InferType::Array { element, .. } => record_type(types, pool, element),
+                _ => {}
+            }
+        }
+        match constraint {
+            Constraint::Equal(lhs, rhs, _) => {
+                record_type(&mut self.fixed_string_types, self.type_pool, lhs);
+                record_type(&mut self.fixed_string_types, self.type_pool, rhs);
+            }
+            Constraint::IsInteger(ty, _)
+            | Constraint::IsSigned(ty, _)
+            | Constraint::IsUnsigned(ty, _) => {
+                record_type(&mut self.fixed_string_types, self.type_pool, ty)
+            }
+        }
     }
 
     /// Record the type of an expression.
@@ -1229,7 +1270,8 @@ impl<'a> ConstraintGenerator<'a> {
     }
 
     /// Consume the constraint generator and return its generated constraints,
-    /// literal variables, expression types, and allocated variable count.
+    /// literal variables, expression types, fixed-string identities, and
+    /// allocated variable count.
     ///
     /// This is useful when you need ownership of the expression types map.
     /// The `type_var_count` can be used to pre-size the unifier's substitution for better performance.
@@ -1243,6 +1285,7 @@ impl<'a> ConstraintGenerator<'a> {
         std::collections::HashMap<InstRef, InferType>,
         AHashMap<InstRef, bool>,
         u32,
+        Vec<Type>,
     ) {
         (
             self.constraints,
@@ -1252,6 +1295,7 @@ impl<'a> ConstraintGenerator<'a> {
             self.expr_types,
             self.expr_continues,
             self.type_vars.count(),
+            self.fixed_string_types,
         )
     }
 

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -602,6 +602,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             expr_types,
             expr_continues,
             type_var_count,
+            fixed_string_types,
         ) = {
             let facts = self.inference_facts(infer_ctx);
 
@@ -735,6 +736,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 expr_types,
                 expr_continues,
                 type_var_count,
+                fixed_string_types,
             ) = cgen.into_parts();
             (
                 constraints,
@@ -744,6 +746,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 expr_types,
                 expr_continues,
                 type_var_count,
+                fixed_string_types,
             )
         };
         let constraint_generation_ns = elapsed_ns(constraint_generation_started);
@@ -778,6 +781,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             InferType::Concrete(ty) if self.is_str_fixed_struct(*ty) => Some(*ty),
             _ => None,
         }));
+        // Provider-backed constraint generation may consult a generated
+        // fixed-string identity only through a structural payload shape (for
+        // example `Message.Text(Str(8))`). Carry those exact identities from
+        // the constraints into unification; the generated-name map is not a
+        // complete authority for demand-populated declarations.
+        string_literal_types.extend(fixed_string_types);
         string_literal_types.sort_unstable_by_key(Type::as_u32);
         string_literal_types.dedup();
         unifier.mark_string_literal_vars(&string_literal_vars, &string_literal_types);

--- a/crates/rue-air/src/sema/provider_strings_ownership_tests.rs
+++ b/crates/rue-air/src/sema/provider_strings_ownership_tests.rs
@@ -961,13 +961,58 @@ fn provider_bodies_expected_string_type_reaches_only_structural_result_positions
     );
 }
 
-// Migrated from `tests::declared_enum_payload_and_ptr_write_pointee_contextualize_fixed_strings`,
-// reduced to the pointer-write half: a pointer write's pointee type
-// contextualizes its literal operand. The retired test's other half — a
-// declared enum's `Str(8)` payload contextualizing a construction literal —
-// currently fails on the provider path (the durable enum payload's fixed
-// string is not admitted into the string-literal contextualization set) and
-// is recorded as a migration finding instead of being weakened here.
+// Migrated from `tests::declared_enum_payload_and_ptr_write_pointee_contextualize_fixed_strings`.
+// A durable enum payload's fixed-string identity must contextualize the literal
+// passed to its variant constructor even when the provider materializes that
+// generated nominal during constraint generation.
+#[test]
+fn provider_body_enum_fixed_string_payload_contextualizes_literal() {
+    let mut fixture = ProviderFixture::new();
+    let message = fixture.declare_enum(
+        "Message",
+        vec![("Text", vec![fixed_str(8)]), ("Empty", vec![])],
+    );
+    fixture.declare_function("make", Vec::new(), SemanticImportType::Nominal(message));
+
+    fixture
+        .analyze(
+            r#"fn make() -> Message {
+    Message.Text("hello")
+}"#,
+            "make",
+        )
+        .expect("enum fixed-string payload contextualizes its construction literal");
+}
+
+#[test]
+fn provider_body_source_nominal_cannot_counterfeit_fixed_string_payload() {
+    let mut fixture = ProviderFixture::new();
+    let counterfeit = fixture.declare_struct("Str(8)", Vec::new(), true);
+    let message = fixture.declare_enum(
+        "Message",
+        vec![("Text", vec![SemanticImportType::Nominal(counterfeit)])],
+    );
+    fixture.declare_function("make", Vec::new(), SemanticImportType::Nominal(message));
+
+    let error = fixture
+        .analyze(
+            r#"fn make() -> Message {
+    Message.Text("hello")
+}"#,
+            "make",
+        )
+        .map(|_| ())
+        .expect_err("a source-defined Str(8) nominal must not accept a string literal");
+    assert!(
+        matches!(
+            &error.kind,
+            ErrorKind::TypeMismatch { expected, found }
+                if expected == "string type" && found == "Str(8)"
+        ),
+        "unexpected counterfeit fixed-string diagnostic: {error:?}"
+    );
+}
+
 #[test]
 fn provider_body_ptr_write_pointee_contextualizes_fixed_strings() {
     let mut fixture = ProviderFixture::new();

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -997,19 +997,18 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     }
 
     /// Is `ty` a fixed-capacity string `Str(N)` (ADR-0043 Phase 5, RUE-326)?
-    /// Detected by the struct name matching `Str(<digits>)`, mirroring the
-    /// name-keyed detection used for `str` and slices.
+    /// Only compiler-generated builtin structs with the canonical `Str(N)`
+    /// spelling qualify; source-defined nominals cannot counterfeit one.
     pub(crate) fn is_str_fixed_struct(&self, ty: Type) -> bool {
         self.str_fixed_capacity(ty).is_some()
     }
 
     /// If `ty` is a fixed-capacity string `Str(N)`, return its capacity `N`
-    /// (ADR-0043 Phase 5, RUE-326); otherwise `None`. The capacity is parsed
-    /// back out of the canonical struct name `Str(<N>)`.
+    /// (ADR-0043 Phase 5, RUE-326); otherwise `None`. The builtin bit and
+    /// canonical spelling are checked by one shared classifier.
     pub(crate) fn str_fixed_capacity(&self, ty: Type) -> Option<u64> {
         if let TypeKind::Struct(struct_id) = ty.kind() {
-            let name = &self.body_type_pool().struct_def(struct_id).name;
-            crate::types::fixed_string_capacity(name)
+            crate::types::fixed_string_struct_capacity(&self.body_type_pool().struct_def(struct_id))
         } else {
             None
         }

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -2050,8 +2050,7 @@ where
                         name: name.clone(),
                         kind: *kind,
                     }
-                } else if def.is_builtin && crate::types::fixed_string_capacity(&def.name).is_some()
-                {
+                } else if crate::types::fixed_string_struct_capacity(&def).is_some() {
                     // `Str(N)` is registered lazily in the exact transaction
                     // pool. Its compiler-builtin bit plus canonical capacity
                     // spelling is the durable classification; unrelated source

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -24,6 +24,17 @@ pub fn fixed_string_capacity(name: &str) -> Option<u64> {
     (capacity.to_string() == digits).then_some(capacity)
 }
 
+/// Return the capacity of a compiler-generated fixed-string struct.
+///
+/// The spelling alone is not sufficient for nominal classification: a
+/// source-defined struct must not counterfeit `Str(N)`. Keep the builtin bit
+/// check beside the canonical spelling parser so semantic consumers agree.
+pub(crate) fn fixed_string_struct_capacity(def: &StructDef) -> Option<u64> {
+    def.is_builtin
+        .then(|| fixed_string_capacity(&def.name))
+        .flatten()
+}
+
 /// Whether `name` is the canonical spelling of a synthetic slice struct.
 pub fn is_slice_struct_name(name: &str) -> bool {
     name.starts_with('[') && name.ends_with(']') && !name.contains(';')

--- a/crates/rue-cli-tests/cases/enum_payloads.toml
+++ b/crates/rue-cli-tests/cases/enum_payloads.toml
@@ -486,3 +486,22 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["must be consumed"]
+
+# RUE-1539: provider-demanded generated fixed-string identities must flow from
+# an enum payload constraint into literal contextualization. The executable
+# path constructs and extracts Message.Text(Str(8)) and returns its length.
+[[case]]
+name = "enum_fixed_string_payload_contextualizes_literal"
+description = "A fixed-string enum payload contextualizes its construction literal and round-trips through a match: Text(hello) -> 5."
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Message { Text(Str(8)), Empty }
+fn main() -> i32 {
+    let message = Message.Text("hello");
+    match message {
+        Message.Text(value) => @intCast(value.len()),
+        Message.Empty => 0,
+    }
+}
+""" }]
+exit_code = 5

--- a/crates/rue-compiler/src/integration_tests.rs
+++ b/crates/rue-compiler/src/integration_tests.rs
@@ -727,6 +727,21 @@ mod integration_tests {
         }
 
         #[test]
+        fn fixed_string_enum_payload_contextualizes_literal() {
+            let src = r#"
+                enum Message { Text(Str(8)), Empty }
+                fn main() -> i32 {
+                    let message = Message.Text("hello");
+                    match message {
+                        Message.Text(value) => @intCast(value.len()),
+                        Message.Empty => 0,
+                    }
+                }
+            "#;
+            assert!(test_air(src).is_ok());
+        }
+
+        #[test]
         fn enum_match() {
             let src = r#"
                 enum Color { Red, Green, Blue }


### PR DESCRIPTION
Summary:
- carry exact compiler-owned fixed-string identities from generated constraints into string-literal unification
- share nominal classification across inference, type checking, and durable semantic import
- cover provider, counterfeit nominal, compiler, and executable enum-payload behavior

Validation:
- scripts/rue fmt
- scripts/rue quick
- scripts/rue premerge
- scripts/rue test
- focused provider, compiler, CLI, pointer-write, and call-result tests
- adversarial sema/inference/query-identity review: ship

Fixes RUE-1539