### PR TITLE
RUE-1540: stabilize deferred value-call diagnostics

### DIFF
--- a/crates/rue-air/src/semantic_type_resolution.rs
+++ b/crates/rue-air/src/semantic_type_resolution.rs
@@ -779,15 +779,6 @@ where
                 site: head.site,
             }));
         }
-        if head.parameters.len() != argument_count {
-            return Err(E::Semantic(F::InvalidConstructorArity {
-                constructor,
-                site: head.site,
-                expected: head.parameters.len(),
-                found: argument_count,
-                expectation,
-            }));
-        }
         let eligible = head
             .parameters
             .iter()
@@ -795,6 +786,15 @@ where
             && (head.returns_type || !head.parameters.is_empty());
         if !eligible {
             return Err(E::Semantic(F::RuntimeConstructorParameter {
+                constructor,
+                site: head.site,
+                expected: head.parameters.len(),
+                found: argument_count,
+                expectation,
+            }));
+        }
+        if head.parameters.len() != argument_count {
+            return Err(E::Semantic(F::InvalidConstructorArity {
                 constructor,
                 site: head.site,
                 expected: head.parameters.len(),

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -9964,10 +9964,31 @@ fn semantic_type_query_failure(
                         ),
                     )
                 }
+                F::UnknownConstructor {
+                    constructor,
+                    expectation: rue_air::SemanticComptimeCallExpectation::Type,
+                } => ResolveSemanticSignatureError::failure(
+                    crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+                        ErrorKind::UnknownType(format!("{constructor}(...)")),
+                    ),
+                ),
+                F::UnknownConstructor {
+                    constructor,
+                    expectation: rue_air::SemanticComptimeCallExpectation::Value,
+                } => ResolveSemanticSignatureError::failure(
+                    crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+                        ErrorKind::ComptimeEvaluationFailed {
+                            reason: format!(
+                                "`{constructor}` is not a function; a compile-time value call requires a value-returning comptime function"
+                            ),
+                        },
+                    ),
+                ),
                 F::InvalidConstructorArity {
                     constructor,
                     expected,
                     found,
+                    expectation: rue_air::SemanticComptimeCallExpectation::Type,
                     ..
                 } => ResolveSemanticSignatureError::failure(
                     crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(Arc::from(
@@ -9976,6 +9997,27 @@ fn semantic_type_query_failure(
                         ),
                     )),
                 ),
+                F::InvalidConstructorArity {
+                    constructor,
+                    expected,
+                    found,
+                    expectation: rue_air::SemanticComptimeCallExpectation::Value,
+                    ..
+                } => ResolveSemanticSignatureError::failure(
+                    crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+                        ErrorKind::ComptimeEvaluationFailed {
+                            reason: format!(
+                                "value-returning comptime function `{constructor}` expects {expected} comptime {}, but {found} {} provided",
+                                if expected == 1 {
+                                    "argument"
+                                } else {
+                                    "arguments"
+                                },
+                                if found == 1 { "was" } else { "were" },
+                            ),
+                        },
+                    ),
+                ),
                 F::NotTypeConstructor { constructor, .. } => {
                     ResolveSemanticSignatureError::failure(
                         crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(
@@ -9983,13 +10025,121 @@ fn semantic_type_query_failure(
                         ),
                     )
                 }
-                other => ResolveSemanticSignatureError::failure(
+                F::TypeWhereValueExpected { constructor, .. } => {
+                    ResolveSemanticSignatureError::failure(
+                        crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+                            ErrorKind::ComptimeEvaluationFailed {
+                                reason: format!(
+                                    "`{constructor}` returns `type` and cannot be used where a compile-time value is required"
+                                ),
+                            },
+                        ),
+                    )
+                }
+                F::RuntimeConstructorParameter {
+                    constructor,
+                    expectation: rue_air::SemanticComptimeCallExpectation::Type,
+                    ..
+                } => ResolveSemanticSignatureError::failure(
+                    crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(Arc::from(
+                        format!(
+                            "type constructor `{constructor}` cannot have runtime parameters; all parameters must be `comptime`"
+                        ),
+                    )),
+                ),
+                F::RuntimeConstructorParameter {
+                    constructor,
+                    expectation: rue_air::SemanticComptimeCallExpectation::Value,
+                    expected,
+                    ..
+                } => ResolveSemanticSignatureError::failure(
                     crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
                         ErrorKind::ComptimeEvaluationFailed {
-                            reason: format!("{other:?}"),
+                            reason: if expected == 0 {
+                                format!(
+                                    "call `{constructor}(...)` is not a compile-time value because its callee must declare at least one `comptime` parameter"
+                                )
+                            } else {
+                                format!(
+                                    "call `{constructor}(...)` is not a compile-time value because all parameters must be `comptime`"
+                                )
+                            },
                         },
                     ),
                 ),
+                F::ConstructorDidNotReduce { constructor, .. } => {
+                    ResolveSemanticSignatureError::failure(
+                        crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+                            ErrorKind::ComptimeEvaluationFailed {
+                                reason: format!(
+                                    "the type constructor `{constructor}` did not reduce to a concrete type at compile time"
+                                ),
+                            },
+                        ),
+                    )
+                }
+                F::PrivateItem {
+                    kind,
+                    name,
+                    defining_file,
+                    ..
+                } => ResolveSemanticSignatureError::failure(
+                    crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+                        ErrorKind::PrivateUnqualifiedAccess(Box::new(
+                            rue_error::PrivateUnqualifiedAccessData {
+                                item_kind: kind.diagnostic_name().to_owned(),
+                                name: name.to_string(),
+                                defining_file: defining_file.to_string(),
+                            },
+                        )),
+                    ),
+                ),
+                F::AmbiguousItem { name, .. } => ResolveSemanticSignatureError::failure(
+                    crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+                        ErrorKind::ComptimeEvaluationFailed {
+                            reason: format!("type resolution is ambiguous for `{name}`"),
+                        },
+                    ),
+                ),
+                F::Path(path) => match path {
+                    rue_air::SemanticModulePathFailure::Empty => {
+                        ResolveSemanticSignatureError::failure(
+                            crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+                                ErrorKind::ComptimeEvaluationFailed {
+                                    reason: "type path is empty".to_owned(),
+                                },
+                            ),
+                        )
+                    }
+                    rue_air::SemanticModulePathFailure::UnknownRoot { name } => {
+                        ResolveSemanticSignatureError::failure(
+                            crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+                                ErrorKind::UnknownType(name.to_string()),
+                            ),
+                        )
+                    }
+                    rue_air::SemanticModulePathFailure::UnknownMember {
+                        module, member, ..
+                    } => ResolveSemanticSignatureError::failure(
+                        crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+                            ErrorKind::UnknownModuleMember {
+                                module_name: module.to_string(),
+                                member_name: member.to_string(),
+                            },
+                        ),
+                    ),
+                    rue_air::SemanticModulePathFailure::PrivateMember { member, .. } => {
+                        ResolveSemanticSignatureError::failure(
+                            crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+                                ErrorKind::ComptimeEvaluationFailed {
+                                    reason: format!(
+                                        "private module member `{member}` cannot be used in a type path"
+                                    ),
+                                },
+                            ),
+                        )
+                    }
+                },
             }
         }
     }
@@ -45608,6 +45758,144 @@ fn main() -> i32 {
                 if matches!(value.as_ref(), crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
                     rue_error::ErrorKind::UnknownType(syntax)
                 ) if syntax == "Sef")
+        ));
+    }
+
+    #[test]
+    fn deferred_value_call_diagnostics_are_stable_and_keep_query_channels() {
+        use rue_air::{
+            SemanticComptimeCallExpectation as Expectation, SemanticResolutionError as E,
+            SemanticTypeSyntaxFailure as F,
+        };
+
+        let site = StableDefinitionKey::from_stable_parts(
+            ModuleId::from_logical_path("test.rue").unwrap(),
+            crate::StableDefinitionNamespace::Value,
+            crate::StableDefinitionKind::Function,
+            Arc::from("callee"),
+            None,
+        );
+        let classify = |failure| semantic_type_query_failure(E::Semantic(failure));
+        let value_arity = classify(F::InvalidConstructorArity {
+            constructor: Arc::from("value"),
+            site: site.clone(),
+            expected: 1,
+            found: 0,
+            expectation: Expectation::Value,
+        });
+        let ResolveSemanticSignatureError::Failure(value_arity) = value_arity else {
+            panic!("value-call arity must be a stable diagnostic")
+        };
+        let crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+            ErrorKind::ComptimeEvaluationFailed { reason },
+        ) = *value_arity
+        else {
+            panic!("value-call arity must preserve E1200")
+        };
+        assert_eq!(
+            reason,
+            "value-returning comptime function `value` expects 1 comptime argument, but 0 were provided"
+        );
+        assert!(!reason.contains("type constructor"));
+        assert!(!reason.contains("InvalidConstructorArity"));
+
+        let runtime = classify(F::RuntimeConstructorParameter {
+            constructor: Arc::from("runtime"),
+            site: site.clone(),
+            expected: 1,
+            found: 1,
+            expectation: Expectation::Value,
+        });
+        let ResolveSemanticSignatureError::Failure(runtime) = runtime else {
+            panic!("runtime value-call rejection must be a stable diagnostic")
+        };
+        let crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+            ErrorKind::ComptimeEvaluationFailed { reason },
+        ) = *runtime
+        else {
+            panic!("runtime value-call rejection must preserve E1200")
+        };
+        assert_eq!(
+            reason,
+            "call `runtime(...)` is not a compile-time value because all parameters must be `comptime`"
+        );
+        assert!(!reason.contains("RuntimeConstructorParameter"));
+
+        let type_arity = classify(F::InvalidConstructorArity {
+            constructor: Arc::from("Box"),
+            site,
+            expected: 1,
+            found: 0,
+            expectation: Expectation::Type,
+        });
+        assert!(matches!(
+            type_arity,
+            ResolveSemanticSignatureError::Failure(value)
+                if matches!(
+                    value.as_ref(),
+                    crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(reason)
+                        if reason.as_ref() == "type constructor `Box` expects 1 comptime type argument(s), but 0 provided"
+                )
+        ));
+
+        let type_runtime = classify(F::RuntimeConstructorParameter {
+            constructor: Arc::from("RuntimeBox"),
+            site: StableDefinitionKey::from_stable_parts(
+                ModuleId::from_logical_path("test.rue").unwrap(),
+                crate::StableDefinitionNamespace::Value,
+                crate::StableDefinitionKind::Function,
+                Arc::from("RuntimeBox"),
+                None,
+            ),
+            expected: 1,
+            found: 1,
+            expectation: Expectation::Type,
+        });
+        assert!(matches!(
+            type_runtime,
+            ResolveSemanticSignatureError::Failure(value)
+                if matches!(
+                    value.as_ref(),
+                    crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(reason)
+                        if reason.as_ref() == "type constructor `RuntimeBox` cannot have runtime parameters; all parameters must be `comptime`"
+                )
+        ));
+
+        let zero_parameter = classify(F::RuntimeConstructorParameter {
+            constructor: Arc::from("zero"),
+            site: StableDefinitionKey::from_stable_parts(
+                ModuleId::from_logical_path("test.rue").unwrap(),
+                crate::StableDefinitionNamespace::Value,
+                crate::StableDefinitionKind::Function,
+                Arc::from("zero"),
+                None,
+            ),
+            expected: 0,
+            found: 0,
+            expectation: Expectation::Value,
+        });
+        assert!(matches!(
+            zero_parameter,
+            ResolveSemanticSignatureError::Failure(value)
+                if matches!(
+                    value.as_ref(),
+                    crate::semantic_query_nucleus::SemanticNucleusFailure::Diagnostic(
+                        ErrorKind::ComptimeEvaluationFailed { reason }
+                    ) if reason == "call `zero(...)` is not a compile-time value because its callee must declare at least one `comptime` parameter"
+                )
+        ));
+
+        let provider_failure = crate::semantic_query_nucleus::SemanticNucleusFailure::Resolution(
+            Arc::from("provider"),
+        );
+        let preserved = semantic_type_query_failure(E::ProviderFailure(provider_failure.clone()));
+        assert!(matches!(
+            preserved,
+            ResolveSemanticSignatureError::Failure(value) if *value == provider_failure
+        ));
+        assert!(matches!(
+            semantic_type_query_failure(E::ProviderAbort(rue_query::QueryAbort::Canceled)),
+            ResolveSemanticSignatureError::Abort(rue_query::QueryAbort::Canceled)
         ));
     }
 }

--- a/crates/rue-ui-tests/cases/diagnostics/comptime_value_call_diagnostics.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/comptime_value_call_diagnostics.toml
@@ -1,0 +1,95 @@
+[section]
+id = "diagnostics.comptime_value_call"
+name = "Deferred comptime value-call diagnostics"
+description = "Value-returning comptime calls used in type signatures retain stable, value-oriented diagnostics (RUE-1540)."
+
+[[case]]
+name = "runtime_value_callee_in_array_length"
+source = """
+fn runtime(n: i32) -> i32 { n }
+fn make() -> [i32; runtime(3)] { [0; 3] }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = [
+  "E1200",
+  "call `runtime(...)` is not a compile-time value",
+  "all parameters must be `comptime`",
+  "2:1",
+]
+
+[[case]]
+name = "missing_arity_value_returning_callee"
+source = """
+fn value(comptime n: i32) -> i32 { n }
+fn make() -> [i32; value()] { [0; 3] }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = [
+  "E1200",
+  "value-returning comptime function `value` expects 1 comptime argument, but 0 were provided",
+  "2:1",
+]
+
+[[case]]
+name = "generic_value_callee_missing_value_argument"
+source = """
+fn generic(comptime T: type, comptime value: T) -> T { value }
+fn Buffer(comptime n: i32) -> type { struct { data: [i32; n] } }
+fn make() -> Buffer(generic(i32)) { Buffer(3) { data: [0; 3] } }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = [
+  "E1200",
+  "value-returning comptime function `generic` expects 2 comptime arguments, but 1 was provided",
+  "3:1",
+]
+
+[[case]]
+name = "nested_imported_runtime_value_callee"
+source = """
+const lib = @import("lib.rue");
+fn Buffer(comptime n: i32) -> type { struct { data: [i32; n] } }
+fn make() -> Buffer(lib.runtime(3)) { Buffer(3) { data: [0; 3] } }
+fn main() -> i32 { 0 }
+"""
+aux_files = { "lib.rue" = "pub fn runtime(n: i32) -> i32 { n }\n" }
+compile_fail = true
+error_contains = [
+  "E1200",
+  "call `lib.runtime(...)` is not a compile-time value",
+  "all parameters must be `comptime`",
+  "3:1",
+]
+
+[[case]]
+name = "mixed_parameter_callee_wrong_arity"
+source = """
+fn mixed(comptime n: i32, runtime: i32) -> i32 { n + runtime }
+fn make() -> [i32; mixed(3)] { [0; 3] }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = [
+  "E1200",
+  "call `mixed(...)` is not a compile-time value",
+  "all parameters must be `comptime`",
+  "2:1",
+]
+
+[[case]]
+name = "zero_parameter_value_callee"
+source = """
+fn zero() -> i32 { 3 }
+fn make() -> [i32; zero()] { [0; 3] }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = [
+  "E1200",
+  "call `zero(...)` is not a compile-time value",
+  "must declare at least one `comptime` parameter",
+  "2:1",
+]


### PR DESCRIPTION
## Summary

- render every deferred semantic type-query failure with stable user-facing diagnostics instead of internal Debug text
- classify value-returning comptime calls independently from type constructors, including arity, runtime-parameter, mixed, zero-parameter, and nested imported cases
- preserve E1200 spans, query cancellation/provider-failure channels, and language acceptance policy

## Validation

- focused compiler unit test
- focused UI diagnostics suite: 6 passed
- scripts/rue quick
- scripts/rue fmt
- scripts/rue premerge
- git diff --check
- independent adversarial diagnostics/comptime/query review

Fixes RUE-1540