### PR TITLE
RUE-1323: structure driver source-load diagnostics

### DIFF
--- a/crates/rue-cli-tests/cases/diagnostic_json.toml
+++ b/crates/rue-cli-tests/cases/diagnostic_json.toml
@@ -15,6 +15,66 @@ of that — they pass on malformed JSON as long as the bytes appear somewhere.
 """
 
 [[case]]
+name = "missing_root_source_load_is_json"
+description = "RUE-1323: an ordinary missing-root source-load failure uses the driver code and the same spanless schema as compiler diagnostics."
+files = []
+args = ["--error-format", "json", "missing.rue", "-o", "prog"]
+compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = ["error E1500 -"]
+error_contains = [
+  '"code":"E1500"',
+  '"message":"Error reading ',
+  "missing.rue:",
+  '"spans":[]',
+]
+compile_stderr_not_contains = ["error: [", " --> "]
+
+[[case]]
+name = "missing_root_source_load_text_is_unchanged"
+description = "RUE-1323 control: ordinary source-load failures retain their established human text when JSON is not requested."
+files = []
+args = ["missing.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["Error reading ", "missing.rue:"]
+compile_stderr_not_contains = ['"code":"E1500"', '"severity":"error"']
+
+[[case]]
+name = "missing_trusted_toolchain_input_is_json"
+description = "RUE-1323: a reached fallible intrinsic with a missing trusted std module is classified as toolchain integrity, not ordinary source load or an ICE."
+files = [{ path = "main.rue", source = 'fn main() -> i32 { let _ = @parse_i64("1"); 0 }' }]
+env = { RUE_STD_PATH = "sdk" }
+args = ["--error-format", "json", "main.rue", "-o", "prog"]
+compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = ["error E1501 -"]
+error_contains = [
+  '"code":"E1501"',
+  '"message":"Toolchain integrity error:',
+  '"spans":[]',
+]
+compile_stderr_not_contains = ["E9000", "internal compiler error", "error: [", " --> "]
+
+[[case]]
+name = "hermetic_toolchain_denial_is_json"
+description = "RUE-1323: a source manifest denial while satisfying a trusted std demand is classified as hermetic build policy, distinct from toolchain integrity."
+files = [
+  { path = "sources.manifest", source = "main.rue\n" },
+  { path = "main.rue", source = 'fn main() -> i32 { let _ = @parse_i64("1"); 0 }' },
+]
+env = { RUE_STD_PATH = "sdk" }
+args = ["--error-format", "json", "--source-manifest", "sources.manifest", "main.rue", "-o", "prog"]
+compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = ["error E1502 -"]
+error_contains = [
+  '"code":"E1502"',
+  '"message":"Hermetic build configuration error:',
+  '"spans":[]',
+]
+compile_stderr_not_contains = ["E9000", "internal compiler error", "Toolchain integrity error", "error: [", " --> "]
+
+[[case]]
 name = "empty_call_argument_is_at_comma"
 description = "The CLI JSON surface preserves the dedicated parser diagnostic and its comma span."
 files = [{ path = "main.rue", source = "fn helper() {} fn main() { helper(,); }" }]

--- a/crates/rue-cli-tests/cases/watch.toml
+++ b/crates/rue-cli-tests/cases/watch.toml
@@ -41,6 +41,7 @@ files = [
 
 [case.watch]
 kind = "delete"
+error_format = "json"
 expected_exit_codes = [1, 2]
 
 [[case.watch.edits]]

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -1072,6 +1072,11 @@ struct HardLinkFixture {
 #[serde(deny_unknown_fields)]
 struct WatchScenario {
     kind: WatchScenarioKind,
+    /// Optional diagnostic format passed to the real watch process. JSON
+    /// scenarios additionally assert that every non-empty stderr line is a
+    /// non-empty diagnostic array.
+    #[serde(default)]
+    error_format: Option<String>,
     #[serde(default)]
     source_path: Option<String>,
     #[serde(default)]
@@ -2638,18 +2643,18 @@ fn run_watch_case(
         .ok_or_else(|| TestFailure::assertion("watch scenario has no root source"))?;
     let output_name = case.output.as_deref().unwrap_or("prog");
     let protocol = dir.join("watch.protocol");
-    let mut command = case_compiler_command(
-        rue_binary,
-        &[
-            source.to_string(),
-            "-o".to_string(),
-            output_name.to_string(),
-            "--watch".to_string(),
-        ],
-        dir,
-        &case.env,
-        real_std,
-    );
+    let mut compiler_args = Vec::with_capacity(6);
+    if let Some(error_format) = &scenario.error_format {
+        compiler_args.push("--error-format".to_owned());
+        compiler_args.push(error_format.clone());
+    }
+    compiler_args.extend([
+        source.to_string(),
+        "-o".to_string(),
+        output_name.to_string(),
+        "--watch".to_string(),
+    ]);
+    let mut command = case_compiler_command(rue_binary, &compiler_args, dir, &case.env, real_std);
     command
         .env("RUE_WATCH_TEST_PROTOCOL", &protocol)
         .stdin(Stdio::null())
@@ -2760,6 +2765,17 @@ fn run_watch_case(
     })();
 
     let (status, stdout_bytes, stderr_bytes) = finish_watch_child(child, stdout, stderr, true);
+    let result = result.and_then(|()| {
+        if scenario.error_format.as_deref() == Some("json") {
+            let diagnostics =
+                validate_json_diagnostic_stream(&String::from_utf8_lossy(&stderr_bytes))
+                    .map_err(|error| format!("watch JSON stderr validation failed: {error}"))?;
+            if diagnostics.is_empty() {
+                return Err("watch JSON stderr contained no diagnostics".to_string());
+            }
+        }
+        Ok(())
+    });
     result.map_err(|error| {
         TestFailure::assertion(format!(
             "{error}\nwatch process status: {status:?}\n--- watch stdout ---\n{}\n--- watch stderr ---\n{}",

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -72,6 +72,7 @@ pub fn interner_error_kind(kind: lasso::LassoErrorKind, message: impl Into<Strin
 /// - **E1200-E1299**: Comptime errors
 /// - **E1300-E1399**: Unchecked-code errors (raw pointers, `checked` blocks)
 /// - **E1400-E1499**: Compiler-input errors
+/// - **E1500-E1599**: Driver/host errors (source loading and build environment)
 /// - **E9000-E9999**: Internal compiler errors
 ///
 /// Once assigned, error codes must never change to maintain stability for
@@ -537,6 +538,19 @@ impl ErrorCode {
     pub const COMPILER_RESOURCE_EXHAUSTION: Self = Self(1402);
     pub const OUTPUT_PUBLICATION: Self = Self(1403);
     pub const UNSATISFIED_TRUSTED_TOOLCHAIN_INPUT: Self = Self(1404);
+
+    // ========================================================================
+    // Driver/host errors (E1500-E1599)
+    // ========================================================================
+    // These codes classify failures raised outside the compiler diagnostic
+    // graph. They are used by the CLI/host's machine-readable source-load
+    // boundary and therefore do not map from an ErrorKind variant below.
+    /// An ordinary source-loading or driver I/O failure.
+    pub const DRIVER_SOURCE_LOAD: Self = Self(1500);
+    /// A required trusted toolchain input is missing, unreadable, or malformed.
+    pub const DRIVER_TOOLCHAIN_INTEGRITY: Self = Self(1501);
+    /// Hermetic policy denied a trusted toolchain input during acquisition.
+    pub const DRIVER_HERMETIC_DENIAL: Self = Self(1502);
 
     // ========================================================================
     // Internal compiler errors (E9000-E9999)
@@ -2653,11 +2667,13 @@ mod tests {
         );
     }
 
-    /// `ErrorKind::code()` must cover the declared ErrorCode constants without
+    /// `ErrorKind::code()` must cover the compiler-declared ErrorCode constants without
     /// accidental aliases. Intentional aliases (such as the two E0436
     /// duplicate-definition variants) share one match arm, and every constant
     /// must be used (a constant nobody maps to is dead, and usually a sign that
-    /// a variant was repointed at someone else's code).
+    /// a variant was repointed at someone else's code). Driver/host codes are
+    /// intentionally outside this mapping because they classify `SourceLoadError`
+    /// values at the CLI boundary rather than `ErrorKind` values.
     ///
     /// `test_error_codes_are_unique` (above) guards constant *values*; this
     /// test guards the variant -> constant *mapping*. It scans the body of
@@ -2667,7 +2683,8 @@ mod tests {
     fn test_error_kind_to_code_mapping_is_injective() {
         let src = include_str!("lib.rs");
 
-        // Collect all declared ErrorCode constant names.
+        // Collect all declared ErrorCode constant names. Driver/host codes are
+        // consumed by the CLI's SourceLoadError renderer, not ErrorKind::code().
         let mut declared: std::collections::HashSet<&str> = std::collections::HashSet::new();
         for line in src.lines() {
             let Some(rest) = line.trim().strip_prefix("pub const ") else {
@@ -2682,6 +2699,20 @@ mod tests {
             "expected to find the ErrorCode constants (found {})",
             declared.len()
         );
+        let driver_codes: std::collections::HashSet<_> = declared
+            .iter()
+            .copied()
+            .filter(|name| name.starts_with("DRIVER_"))
+            .collect();
+        assert_eq!(
+            driver_codes,
+            std::collections::HashSet::from([
+                "DRIVER_SOURCE_LOAD",
+                "DRIVER_TOOLCHAIN_INTEGRITY",
+                "DRIVER_HERMETIC_DENIAL",
+            ])
+        );
+        declared.retain(|name| !name.starts_with("DRIVER_"));
 
         // Extract the body of `fn code()` by brace matching.
         let start = src
@@ -3583,6 +3614,21 @@ mod tests {
     fn test_error_code_equality() {
         assert_eq!(ErrorCode::TYPE_MISMATCH, ErrorCode(206));
         assert_ne!(ErrorCode::TYPE_MISMATCH, ErrorCode::UNDEFINED_VARIABLE);
+    }
+
+    #[test]
+    fn driver_error_codes_are_stable_and_distinct() {
+        assert_eq!(ErrorCode::DRIVER_SOURCE_LOAD, ErrorCode(1500));
+        assert_eq!(ErrorCode::DRIVER_TOOLCHAIN_INTEGRITY, ErrorCode(1501));
+        assert_eq!(ErrorCode::DRIVER_HERMETIC_DENIAL, ErrorCode(1502));
+        assert_ne!(
+            ErrorCode::DRIVER_SOURCE_LOAD,
+            ErrorCode::DRIVER_TOOLCHAIN_INTEGRITY
+        );
+        assert_ne!(
+            ErrorCode::DRIVER_TOOLCHAIN_INTEGRITY,
+            ErrorCode::DRIVER_HERMETIC_DENIAL
+        );
     }
 
     #[test]

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -29,7 +29,9 @@ use rue_compiler::unstable::{
 };
 #[cfg(test)]
 use rue_compiler::unstable::{Span, update_for_presentation};
-use rue_driver::{FilesystemCompilerHost, HostOpenRequest, SourceLoadError};
+use rue_driver::{
+    FilesystemCompilerHost, HostOpenRequest, SourceLoadError, ToolchainIntegrityError,
+};
 
 use rue_compiler::{
     CompileErrors, CompileOptions, CompileWarning, FileId, ImportDiscoveryStatus, LinkerMode,
@@ -1522,22 +1524,34 @@ fn get_peak_memory_bytes() -> Option<u64> {
     }
 }
 
-/// Present a source-loading failure and exit. The four classes carry disjoint
-/// presentations: an ordinary message; a broken-toolchain (environmental) error;
-/// a hermetic build-configuration denial (distinct from a broken toolchain — the
-/// remedy is the source manifest, not the installation); and program diagnostics
-/// rendered against the failing snapshot's source views.
-fn report_source_load_error(error: SourceLoadError, error_format: ErrorFormat) -> ! {
+/// Render a source-loading failure through the same one-line diagnostic
+/// contract used by the one-shot and watch consumers. Driver failures have no
+/// source location, so their structured representation uses an empty `spans`
+/// array and no suggestions, notes, or helps. The text arms intentionally keep
+/// the established message byte-for-byte unchanged.
+pub(crate) fn render_source_load_error(
+    error: SourceLoadError,
+    error_format: ErrorFormat,
+) -> String {
     match error {
         SourceLoadError::Message(message) => {
-            eprintln!("{message}");
+            render_driver_error(ErrorCode::DRIVER_SOURCE_LOAD, message, error_format)
         }
-        SourceLoadError::Toolchain(error) => {
-            eprintln!("{error}");
-        }
-        SourceLoadError::HermeticDenial(error) => {
-            eprintln!("{error}");
-        }
+        SourceLoadError::Toolchain(error) => match error {
+            internal @ ToolchainIntegrityError::UnsatisfiedAfterPublish { .. } => {
+                render_internal_error(error_format, internal.to_string())
+            }
+            error => render_driver_error(
+                ErrorCode::DRIVER_TOOLCHAIN_INTEGRITY,
+                error.to_string(),
+                error_format,
+            ),
+        },
+        SourceLoadError::HermeticDenial(error) => render_driver_error(
+            ErrorCode::DRIVER_HERMETIC_DENIAL,
+            error.to_string(),
+            error_format,
+        ),
         SourceLoadError::Compiler { snapshot, errors } => {
             let infos = snapshot
                 .as_ref()
@@ -1548,9 +1562,49 @@ fn report_source_load_error(error: SourceLoadError, error_format: ErrorFormat) -
                         .collect()
                 })
                 .unwrap_or_default();
-            DiagnosticOutput::new(error_format, infos).print_errors(&errors);
+            let diagnostics = DiagnosticOutput::new(error_format, infos);
+            if errors.is_empty() {
+                render_internal_error(
+                    error_format,
+                    "source loader produced an empty compiler diagnostic batch",
+                )
+            } else {
+                diagnostics.render_errors(&errors)
+            }
         }
     }
+}
+
+fn render_driver_error(code: ErrorCode, message: String, format: ErrorFormat) -> String {
+    match format {
+        ErrorFormat::Text => message,
+        ErrorFormat::Json => {
+            let diagnostic = JsonDiagnostic {
+                code: code.to_string(),
+                message,
+                severity: "error",
+                spans: Vec::new(),
+                suggestions: Vec::new(),
+                notes: Vec::new(),
+                helps: Vec::new(),
+            };
+            format!("[{}]", diagnostic.to_json())
+        }
+    }
+}
+
+fn render_internal_error(format: ErrorFormat, message: impl Into<String>) -> String {
+    let diagnostics = DiagnosticOutput::new(format, Vec::new());
+    diagnostics.render_error(&rue_error::ice_error!(message.into()))
+}
+
+/// Present a source-loading failure and exit. The four classes carry disjoint
+/// presentations: an ordinary message; a broken-toolchain (environmental) error;
+/// a hermetic build-configuration denial (distinct from a broken toolchain — the
+/// remedy is the source manifest, not the installation); and program diagnostics
+/// rendered against the failing snapshot's source views.
+fn report_source_load_error(error: SourceLoadError, error_format: ErrorFormat) -> ! {
+    eprintln!("{}", render_source_load_error(error, error_format));
     std::process::exit(1);
 }
 
@@ -3146,6 +3200,80 @@ mod tests {
         let batch = batch.as_array().expect("a JSON array, not a bare object");
         assert_eq!(batch.len(), 1);
         assert_eq!(batch[0]["severity"], "error");
+    }
+
+    #[test]
+    fn source_load_errors_use_stable_driver_codes_in_json() {
+        let message = "Error reading missing.rue: No such file or directory";
+        let rendered = render_source_load_error(
+            SourceLoadError::Message(message.to_owned()),
+            ErrorFormat::Json,
+        );
+        let batch: serde_json::Value = serde_json::from_str(&rendered).expect("valid JSON");
+        let diagnostic = &batch[0];
+        assert_eq!(
+            diagnostic["code"],
+            ErrorCode::DRIVER_SOURCE_LOAD.to_string()
+        );
+        assert_eq!(diagnostic["message"], message);
+        assert_eq!(diagnostic["severity"], "error");
+        assert_eq!(diagnostic["spans"], serde_json::json!([]));
+        assert_eq!(diagnostic["suggestions"], serde_json::json!([]));
+        assert_eq!(diagnostic["notes"], serde_json::json!([]));
+        assert_eq!(diagnostic["helps"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn source_load_text_rendering_preserves_message() {
+        let message = "Error reading missing.rue: No such file or directory";
+        assert_eq!(
+            render_source_load_error(
+                SourceLoadError::Message(message.to_owned()),
+                ErrorFormat::Text,
+            ),
+            message
+        );
+    }
+
+    #[test]
+    fn source_load_internal_paths_use_ice_code_in_json() {
+        let rendered = [
+            render_internal_error(
+                ErrorFormat::Json,
+                "a reached-body toolchain park issued no authorizing continuation",
+            ),
+            render_source_load_error(
+                SourceLoadError::Toolchain(ToolchainIntegrityError::UnsatisfiedAfterPublish {
+                    logical_path: "internal-test".to_owned(),
+                }),
+                ErrorFormat::Json,
+            ),
+        ];
+        for rendered in rendered {
+            let batch: serde_json::Value = if let Ok(batch) = serde_json::from_str(&rendered) {
+                batch
+            } else {
+                panic!("expected valid JSON: {rendered}")
+            };
+            assert_eq!(batch[0]["code"], "E9000");
+            assert_ne!(batch[0]["code"], "E1500");
+            assert_ne!(batch[0]["code"], "E1501");
+            assert_eq!(batch[0]["spans"], serde_json::json!([]));
+        }
+    }
+
+    #[test]
+    fn empty_source_load_compiler_batch_is_a_graceful_ice() {
+        let rendered = render_source_load_error(
+            SourceLoadError::Compiler {
+                snapshot: None,
+                errors: CompileErrors::new(),
+            },
+            ErrorFormat::Json,
+        );
+        let batch: serde_json::Value = serde_json::from_str(&rendered).expect("valid JSON");
+        assert_eq!(batch[0]["code"], "E9000");
+        assert_eq!(batch[0]["spans"], serde_json::json!([]));
     }
 
     /// Two pressures decide diagnostic order, and only one of them picks a

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -766,6 +766,19 @@ pub enum SourceLoadError {
     HermeticDenial(HermeticDenialError),
 }
 
+/// Turn a host-side contradiction into the canonical graceful ICE diagnostic.
+/// These failures are not environmental source-load/toolchain errors: they
+/// mean the compiler's own continuation protocol violated its invariant.
+pub(crate) fn source_load_internal_error(
+    snapshot: Option<SourceSnapshot>,
+    message: impl Into<String>,
+) -> SourceLoadError {
+    SourceLoadError::Compiler {
+        snapshot,
+        errors: CompileErrors::from(rue_error::ice_error!(message.into())),
+    }
+}
+
 pub(crate) fn load(
     request: SourceLoadRequest<'_>,
 ) -> Result<ImportDiscoveryResult, SourceLoadError> {
@@ -1711,8 +1724,9 @@ pub(crate) fn acquire_reached_toolchain_modules(
                 // The park just attached its exact demanded set to the closed
                 // continuation, so an authorizing token must be outstanding.
                 let token = closed_discovery_continuation(&result.session).ok_or_else(|| {
-                    SourceLoadError::Message(
-                        "Error: internal compiler invariant — a reached-body toolchain park issued no authorizing continuation".into(),
+                    source_load_internal_error(
+                        Some(result.source_snapshot.clone()),
+                        "a reached-body toolchain park issued no authorizing continuation",
                     )
                 })?;
                 let delta = publish_trusted_toolchain_successor(
@@ -1760,13 +1774,12 @@ pub(crate) fn acquire_reached_toolchain_modules(
         }
     }
     // Still parking after the bound: acquisition is not converging even though
-    // every round published a successor. Surface as a toolchain-integrity error
-    // rather than spinning.
-    Err(SourceLoadError::Toolchain(
-        ToolchainIntegrityError::UnsatisfiedAfterPublish {
-            logical_path: "<reached-body trusted-toolchain acquisition did not converge>"
-                .to_owned(),
-        },
+    // every round published a successor. This violates the host/compiler
+    // continuation contract, so preserve it as a graceful ICE rather than
+    // misclassifying it as toolchain integrity or spinning forever.
+    Err(source_load_internal_error(
+        Some(result.source_snapshot.clone()),
+        "reached-body trusted-toolchain acquisition did not converge after publishing successors",
     ))
 }
 
@@ -1931,8 +1944,9 @@ pub enum ToolchainIntegrityError {
         errors: CompileErrors,
     },
     /// The host published the successor but the demanded trusted module did not
-    /// appear in it — an internal contradiction, surfaced loudly rather than
-    /// looping forever.
+    /// appear in it — an internal contradiction. Production acquisition routes
+    /// this condition through the graceful E9000 ICE path rather than treating
+    /// it as a toolchain-integrity failure.
     UnsatisfiedAfterPublish { logical_path: String },
 }
 

--- a/crates/rue/src/watch.rs
+++ b/crates/rue/src/watch.rs
@@ -19,7 +19,7 @@ use rue_driver::{
 
 use crate::compile::{CancellableCompileRequest, CompileCycleOutcome, execute_cancellable};
 use crate::output;
-use crate::{DiagnosticOutput, ErrorFormat};
+use crate::{DiagnosticOutput, ErrorFormat, render_source_load_error};
 
 const POLL_INTERVAL: Duration = Duration::from_millis(25);
 const MAX_POLL_INTERVAL: Duration = Duration::from_millis(250);
@@ -137,9 +137,12 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
                 Err(error) => {
                     test_event("reobserve-error");
                     print_source_load_error(error, request.error_format);
-                    eprintln!(
-                        "Watch cycle failed after {} ms; keeping the last successful executable",
-                        cycle_started.elapsed().as_millis()
+                    print_watch_status(
+                        request.error_format,
+                        format!(
+                            "Watch cycle failed after {} ms; keeping the last successful executable",
+                            cycle_started.elapsed().as_millis()
+                        ),
                     );
                     thread::sleep(FAILED_REOBSERVE_RETRY);
                     continue;
@@ -151,9 +154,12 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
             {
                 test_event("acquire-error");
                 print_source_load_error(error, request.error_format);
-                eprintln!(
-                    "Watch cycle failed after {} ms; keeping the last successful executable",
-                    cycle_started.elapsed().as_millis()
+                print_watch_status(
+                    request.error_format,
+                    format!(
+                        "Watch cycle failed after {} ms; keeping the last successful executable",
+                        cycle_started.elapsed().as_millis()
+                    ),
                 );
                 thread::sleep(FAILED_REOBSERVE_RETRY);
                 continue;
@@ -175,9 +181,12 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
         ) {
             Ok(destination) => destination,
             Err(output::PublishError::WouldClobberSource) => {
-                eprintln!(
-                    "Error: output path '{}' is also an input source file; refusing to overwrite it",
-                    request.output_path
+                print_watch_status(
+                    request.error_format,
+                    format!(
+                        "Error: output path '{}' is also an input source file; refusing to overwrite it",
+                        request.output_path
+                    ),
                 );
                 wait_for_change(&inputs);
                 debounce(&inputs);
@@ -209,9 +218,12 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
         let mut publication_changed = false;
         if changed_before_publication {
             test_event("canceled-before-publication");
-            eprintln!(
-                "Watch cycle canceled after {} ms; a newer source revision is available",
-                cycle_started.elapsed().as_millis()
+            print_watch_status(
+                request.error_format,
+                format!(
+                    "Watch cycle canceled after {} ms; a newer source revision is available",
+                    cycle_started.elapsed().as_millis()
+                ),
             );
         } else {
             match outcome {
@@ -230,16 +242,22 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
                                 linker_name(&request.compile_options.linker),
                             );
                         }
-                        Err(output::PublishError::WouldClobberSource) => eprintln!(
-                            "Error: output path '{}' became an input source; keeping the last successful executable",
-                            request.output_path
+                        Err(output::PublishError::WouldClobberSource) => print_watch_status(
+                            request.error_format,
+                            format!(
+                                "Error: output path '{}' became an input source; keeping the last successful executable",
+                                request.output_path
+                            ),
                         ),
                         Err(output::PublishError::InputsChanged) => {
                             publication_changed = true;
                             test_event("canceled-at-publication");
-                            eprintln!(
-                                "Watch cycle canceled after {} ms; a newer source revision is available",
-                                cycle_started.elapsed().as_millis()
+                            print_watch_status(
+                                request.error_format,
+                                format!(
+                                    "Watch cycle canceled after {} ms; a newer source revision is available",
+                                    cycle_started.elapsed().as_millis()
+                                ),
                             );
                         }
                         Err(error) => diagnostics.print_error(&error.into_compile_error()),
@@ -247,17 +265,23 @@ pub(crate) fn run(mut request: WatchRequest) -> ! {
                 }
                 CompileCycleOutcome::Canceled => {
                     test_event("canceled");
-                    eprintln!(
-                        "Watch cycle canceled after {} ms",
-                        cycle_started.elapsed().as_millis()
+                    print_watch_status(
+                        request.error_format,
+                        format!(
+                            "Watch cycle canceled after {} ms",
+                            cycle_started.elapsed().as_millis()
+                        ),
                     );
                 }
                 CompileCycleOutcome::Errors(errors) => {
                     test_event("compile-error");
                     diagnostics.print_errors(&errors);
-                    eprintln!(
-                        "Watch cycle failed after {} ms; keeping the last successful executable",
-                        cycle_started.elapsed().as_millis()
+                    print_watch_status(
+                        request.error_format,
+                        format!(
+                            "Watch cycle failed after {} ms; keeping the last successful executable",
+                            cycle_started.elapsed().as_millis()
+                        ),
                     );
                 }
             }
@@ -293,22 +317,16 @@ fn linker_name(linker: &LinkerMode) -> &str {
 }
 
 fn print_source_load_error(error: SourceLoadError, error_format: ErrorFormat) {
-    match error {
-        SourceLoadError::Message(message) => eprintln!("{message}"),
-        SourceLoadError::Toolchain(error) => eprintln!("{error}"),
-        SourceLoadError::HermeticDenial(error) => eprintln!("{error}"),
-        SourceLoadError::Compiler { snapshot, errors } => {
-            let infos = snapshot
-                .as_ref()
-                .map(|snapshot| {
-                    snapshot
-                        .files()
-                        .map(|source| (source.file_id, SourceInfo::new(source.source, source.path)))
-                        .collect()
-                })
-                .unwrap_or_default();
-            DiagnosticOutput::new(error_format, infos).print_errors(&errors);
-        }
+    eprintln!("{}", render_source_load_error(error, error_format));
+}
+
+/// Watch-cycle status is not a diagnostic. In JSON mode it must not share
+/// stderr with the diagnostic stream, where every non-empty line is a JSON
+/// array; text mode retains the established stderr wording and placement.
+fn print_watch_status(error_format: ErrorFormat, message: impl std::fmt::Display) {
+    match error_format {
+        ErrorFormat::Text => eprintln!("{message}"),
+        ErrorFormat::Json => println!("{message}"),
     }
 }
 

--- a/docs/process/diagnostics.md
+++ b/docs/process/diagnostics.md
@@ -136,14 +136,38 @@ CLI cases pin this with `json_diagnostic_order`, which asserts the exact
 stream (an absent field renders as `-`) — see
 `crates/rue-cli-tests/cases/diagnostic_json.toml`.
 
-## Known gap
+## Driver and host failures
 
-Driver-level failures raised *before* a compilation snapshot exists — a missing
-root file, a broken toolchain, a hermetic-build denial — are still printed as
-plain text (`Error reading main.rue: No such file or directory`) even under
-`--error-format json`. They carry no error code today, so they have no schema
-to be rendered into. Consumers should treat a non-JSON stderr line as such a
-driver failure rather than a parse bug.
+Driver-level failures use the same structured schema and one-array-per-line
+framing as compiler diagnostics. They have no source location in the user's
+program, so they publish `"spans": []`, empty `suggestions`, `notes`, and
+`helps`. In one-shot mode they retain the established human-readable
+source-load or environmental message and exit with status `1`. In `--watch`, a
+failed cycle keeps the last successful executable and the watcher continues;
+the cycle status is progress text, not an additional diagnostic.
+
+Driver failures can occur before the initial compilation snapshot exists, or
+after a snapshot exists while a watch cycle reobserves inputs or acquires a
+reached trusted-toolchain module.
+
+The canonical driver/host registry is the E1500-E1599 range in
+`crates/rue-error`. The currently assigned classifications are:
+
+| Code | Class | Meaning |
+|------|-------|---------|
+| `E1500` | ordinary source load | Root/source discovery, ordinary filesystem I/O, or ordinary root/source policy setup failure. |
+| `E1501` | toolchain integrity | A required trusted standard-library input is missing, unreadable, malformed, or otherwise fails the toolchain contract. |
+| `E1502` | hermetic build denial | `SourceLoadError::HermeticDenial`: trusted toolchain acquisition is denied by the source manifest or canonical containment policy; the remedy is build configuration rather than toolchain repair. |
+
+These codes are stable consumer identifiers and are distinct from compiler
+input errors (`E1400-E1499`) and internal compiler errors
+(`E9000-E9999`). Compiler diagnostics that do have a snapshot continue through
+the normal compiler formatter, including their source spans and existing
+codes. Ordinary root/source manifest handling is not universally E1502: a root
+policy failure is ordinary source loading (E1500), while an import policy
+diagnostic with a source snapshot remains a compiler diagnostic. The one-shot
+and `--watch` source-load paths share one rendering helper, so a given
+`SourceLoadError` has identical JSON framing, code, and message in both modes.
 
 ## Testing the surface
 


### PR DESCRIPTION
## Summary
- allocate stable E1500-E1502 driver and host diagnostic codes
- render missing-root, toolchain-integrity, and hermetic-denial failures through the JSON schema in one-shot and watch modes
- preserve human text behavior and E9000 invariant handling, with public contract documentation and CLI coverage

## Validation
- focused rue-error and rue unit tests
- scripts/rue cli diagnostic_json
- scripts/rue cli watch
- scripts/rue quick
- scripts/rue premerge
- scripts/rue fmt
- git diff --check

Fixes RUE-1323