### PR TITLE
RUE-1292: gate narrowed CI scopes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,13 +335,15 @@ jobs:
               echo "premerge test scope unavailable; running the full test pattern" >&2
             fi
           else
-            echo '- `linux-premerge-tests`: **DECLINED**; saved share **not applicable** (full scope used).' >>"$GITHUB_STEP_SUMMARY"
+            echo "- \`linux-premerge-tests\`: **DECLINED**; saved share **not applicable** (full scope used)." >>"$GITHUB_STEP_SUMMARY"
           fi
           count="$(wc -l <"$file" | tr -d ' ')"
-          echo "file=$file" >>"$GITHUB_OUTPUT"
-          echo "test_file=$test_file" >>"$GITHUB_OUTPUT"
-          echo "test_status=$test_status" >>"$GITHUB_OUTPUT"
-          echo "count=$count" >>"$GITHUB_OUTPUT"
+          {
+            echo "file=$file"
+            echo "test_file=$test_file"
+            echo "test_status=$test_status"
+            echo "count=$count"
+          } >>"$GITHUB_OUTPUT"
           echo "impacted targets for this lane: $count"
 
       # Uses hermetic Rust toolchain downloaded by Buck2
@@ -370,13 +372,13 @@ jobs:
             # as the narrowed one. `buck2 build` has no kind or label
             # exclusion, so build-scope expands the pattern and subtracts.
             if scope="$(scripts/affected-targets scope-targets linux-premerge-build)"; then
-              echo '- `linux-premerge-build`: **DECLINED**; saved share **not applicable** (full scope used).' >>"$GITHUB_STEP_SUMMARY"
+              echo "- \`linux-premerge-build\`: **DECLINED**; saved share **not applicable** (full scope used)." >>"$GITHUB_STEP_SUMMARY"
               mapfile -t targets <<<"$scope"
               scripts/ci-timed "linux-x64 build" -- ./buck2 build "${targets[@]}"
             else
               # Fail open, as below: over-building costs wall time, never coverage.
               echo "crate build scope unavailable; building the full crate pattern" >&2
-              echo '- `linux-premerge-build`: **DEGRADED**; saved share **not applicable** (scope query unavailable; full crate scope used).' >>"$GITHUB_STEP_SUMMARY"
+              echo "- \`linux-premerge-build\`: **DEGRADED**; saved share **not applicable** (scope query unavailable; full crate scope used)." >>"$GITHUB_STEP_SUMMARY"
               scripts/ci-timed "linux-x64 build" -- ./buck2 build //crates/...
             fi
           elif ! scope="$(scripts/affected-targets narrow-scope linux-premerge-build "$NARROW_FILE")"; then
@@ -877,7 +879,7 @@ jobs:
               targets+=("$target")
             done <<< "$narrowed"
           else
-            echo '- `native-platforms-units`: **DECLINED**; saved share **not applicable** (full scope used).' >>"$GITHUB_STEP_SUMMARY"
+            echo "- \`native-platforms-units\`: **DECLINED**; saved share **not applicable** (full scope used)." >>"$GITHUB_STEP_SUMMARY"
           fi
           scripts/ci-timed "$LANE_NAME native units" -- ./buck2 test "${targets[@]}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,13 +320,27 @@ jobs:
           RUE_AFFECTED_IMPACTED: ${{ needs.affected-targets.outputs.impacted }}
         run: |
           set -euo pipefail
-          file="${RUNNER_TEMP}/impacted-targets.txt"
+          file="${RUNNER_TEMP}/impacted-targets-raw.txt"
+          test_file="${RUNNER_TEMP}/impacted-premerge-test-targets.txt"
           : >"$file"
+          : >"$test_file"
+          test_status=DECLINED
           if [ "${RUE_AFFECTED_NARROWED:-}" = "true" ]; then
             printf '%s\n' "$RUE_AFFECTED_IMPACTED" | sed '/^$/d' >"$file"
+            if scripts/affected-targets narrow-scope linux-premerge-tests "$file" >"$test_file"; then
+              test_status=VERIFIED
+            else
+              : >"$test_file"
+              test_status=DEGRADED
+              echo "premerge test scope unavailable; running the full test pattern" >&2
+            fi
+          else
+            echo '- `linux-premerge-tests`: **DECLINED**; saved share **not applicable** (full scope used).' >>"$GITHUB_STEP_SUMMARY"
           fi
           count="$(wc -l <"$file" | tr -d ' ')"
           echo "file=$file" >>"$GITHUB_OUTPUT"
+          echo "test_file=$test_file" >>"$GITHUB_OUTPUT"
+          echo "test_status=$test_status" >>"$GITHUB_OUTPUT"
           echo "count=$count" >>"$GITHUB_OUTPUT"
           echo "impacted targets for this lane: $count"
 
@@ -355,15 +369,17 @@ jobs:
             # narrowed — so it needs the corpus-action subtraction just as much
             # as the narrowed one. `buck2 build` has no kind or label
             # exclusion, so build-scope expands the pattern and subtracts.
-            if scope="$(scripts/affected-targets build-scope)"; then
+            if scope="$(scripts/affected-targets scope-targets linux-premerge-build)"; then
+              echo '- `linux-premerge-build`: **DECLINED**; saved share **not applicable** (full scope used).' >>"$GITHUB_STEP_SUMMARY"
               mapfile -t targets <<<"$scope"
               scripts/ci-timed "linux-x64 build" -- ./buck2 build "${targets[@]}"
             else
               # Fail open, as below: over-building costs wall time, never coverage.
               echo "crate build scope unavailable; building the full crate pattern" >&2
+              echo '- `linux-premerge-build`: **DEGRADED**; saved share **not applicable** (scope query unavailable; full crate scope used).' >>"$GITHUB_STEP_SUMMARY"
               scripts/ci-timed "linux-x64 build" -- ./buck2 build //crates/...
             fi
-          elif ! scope="$(scripts/affected-targets build-scope "$NARROW_FILE")"; then
+          elif ! scope="$(scripts/affected-targets narrow-scope linux-premerge-build "$NARROW_FILE")"; then
             # Fail open: an unreadable list costs wall time, never coverage.
             echo "narrowed build scope unavailable; building the full crate pattern" >&2
             scripts/ci-timed "linux-x64 build" -- ./buck2 build //crates/...
@@ -406,7 +422,8 @@ jobs:
         # on the failure path and keep the complete record as an artifact.
         env:
           RUE_TEST_TIER: premerge
-          RUE_TEST_TARGETS_FILE: ${{ steps.narrow.outputs.file }}
+          RUE_TEST_TARGETS_FILE: ${{ steps.narrow.outputs.test_file }}
+          RUE_TEST_TARGETS_STATUS: ${{ steps.narrow.outputs.test_status }}
           RUE_PREMERGE_TEST_RESULTS: ${{ runner.temp }}/premerge-test-results.txt
         run: |
           # The default step shell runs with `-e`; the suite's status has to
@@ -847,7 +864,10 @@ jobs:
             # on empty-array expansion under `set -u`. Read the intersection
             # into a string, early-exit while `targets` is still non-empty,
             # and only then rebuild the array.
-            narrowed="$(scripts/affected-targets intersect "$NARROW_FILE" "${targets[@]}")"
+            if ! narrowed="$(scripts/affected-targets narrow-scope native-platforms-units "$NARROW_FILE")"; then
+              echo "native narrowing unavailable; running the full graph-owned native unit scope" >&2
+              narrowed="$native_targets"
+            fi
             if [ -z "$narrowed" ]; then
               echo "native units: no impacted unit targets on this diff; the merge-queue run covers them."
               exit 0
@@ -856,6 +876,8 @@ jobs:
             while IFS= read -r target; do
               targets+=("$target")
             done <<< "$narrowed"
+          else
+            echo '- `native-platforms-units`: **DECLINED**; saved share **not applicable** (full scope used).' >>"$GITHUB_STEP_SUMMARY"
           fi
           scripts/ci-timed "$LANE_NAME native units" -- ./buck2 test "${targets[@]}"
 
@@ -1018,6 +1040,9 @@ jobs:
       # nothing".
       narrowed: ${{ steps.decide.outputs.narrowed }}
       impacted: ${{ steps.decide.outputs.impacted }}
+      narrowing_status: ${{ steps.decide.outputs.narrowing_status }}
+      head_target_count: ${{ steps.decide.outputs.head_target_count }}
+      impacted_target_count: ${{ steps.decide.outputs.impacted_target_count }}
     steps:
       - uses: actions/checkout@v6
         # BTD compares the graph at the merge-base and at the head, so the base

--- a/BUCK
+++ b/BUCK
@@ -1220,6 +1220,7 @@ rue_sh_test(
         "--structural-only",
     ],
     resources = [
+        "scripts/affected-targets",
         "scripts/ci-required-results.py",
         # The gate pins the bounded apt timeout/retry/lock policy as well as
         # the workflow wiring, so installer-only edits must invalidate it.
@@ -1300,6 +1301,7 @@ rue_sh_test(
     name = "ci-gate-validator-tool-tests",
     test = "scripts/test-validate-ci-gate.py",
     resources = [
+        "scripts/affected-targets",
         "scripts/ci-required-results.py",
         "scripts/run-native-platform-corpus.sh",
         "scripts/validate-ci-gate.py",
@@ -1506,6 +1508,7 @@ rue_sh_test(
         "scripts/ci-corpus-decision",
         "scripts/ci-corpus-selected",
         "scripts/parse-btd-impacted.py",
+        "test.sh",
     ],
 )
 

--- a/docs/designs/0069-ci-work-scheduling.md
+++ b/docs/designs/0069-ci-work-scheduling.md
@@ -399,6 +399,7 @@ from the graph later, or gated so that drift fails closed rather than silently:
 | `SELECTABLE_CORPUS` | a new corpus job is ungated, so it always runs | fails open (runs); not yet gated |
 | `SELECTABLE_LANES` / `lane_targets` | a lane's job runs a target selection cannot see | **gated** (`lane_target_drift`) |
 | the native lanes' platform unit list | new platform-sensitive tests are not enrolled | graph-owned `rue_platform_native` query (RUE-1266) |
+| narrowed-lane scope registry and subset check | a narrowed lane silently widens beyond its unnarrowed work, or a new consumer bypasses the contract | **gated** (`narrowing_contract_errors`); every distinct build/test consumer is registered, its runnable list is an exact live-set intersection, and `VERIFIED`, `DECLINED`, or `DEGRADED` is reported only after the scope query |
 | `RUE_AFFECTED_NARROW_LIMIT` (600) | a threshold nobody revisits | unmeasured; should follow measurement |
 | the platform responsibility matrix | a responsibility silently moves | gated (`validate-ci-gate.py`) |
 | `shard-weights.json` refresh | weights go stale, shards skew | manual (RUE-1222); guard is vacuous (§6) |
@@ -422,13 +423,32 @@ completely.
       56–59% of the critical path, no new machinery, needs one coverage ruling.
 - [x] **Phase 2: Determination on every lane, by gating or by narrowing** —
       RUE-1130, whose "make it discriminate or remove it" question this ADR
-      answers with "keep it and extend it to everything." Six lanes are gated
-      (`native` ×2, `release`, `valgrind`, `asan`, `compiler-reproducibility`),
+      answers with "keep it and extend it to everything." Seven lanes are gated
+      (`native` ×2, `release`, `valgrind`, `asan`, `compiler-reproducibility`,
+      `rue-program-digests`),
       freeing **905–1034s of runner time** on each of four measured peripheral
       runs. `linux-premerge` and the native unit targets are narrowed to the
       impacted closure instead, so an unimpacted test binary is neither built
-      nor run. Reporting the saved share per run is still to do, and is what
-      turns the change-mix question from an argument into a measurement.
+      nor run. The narrowed-lane contract now makes each narrowed scope an
+      intersection with its declared unnarrowed scope; unavailable graph or
+      closure queries fall open and report `DEGRADED`, never a verified subset.
+      The determinator reports the head-graph denominator, live impacted
+      closure, and selected/deselected lanes and corpora. Each registered
+      consumer then reports its exact selected/unnarrowed target counts and
+      unweighted saved share in the step summary (explicitly not runner-time
+      savings); a planner candidate is not reported as verified. Dorian's recorded
+      post-#2160 real-run measurements are: compiler-touching run
+      `31348880780`, impacted closure **67**, build **4.5m**, premerge **7.9m**
+      versus **12.1m** pre-narrow baseline and **41.5m** regressed; **31** local
+      actions after versus **76** regressed, and zero root-level corpus actions
+      after. Peripheral run `31348882324` had **0** impacted targets, no corpora
+      or lanes, and a **1.7m** cache-served premerge; it does not measure the
+      cold full-pattern cost. Phases 5 and 6 remain, and these measurements do
+      not establish cold full-pattern cost or native-host wall-time savings.
+      A structural negative consequence remains: CI/workflow changes are
+      force-full, so a PR changing narrowing cannot exercise narrowing itself;
+      correctness therefore relies on hermetic contract tests and subsequent
+      real selective runs.
 - [x] **Phase 3: Duplication gate** — RUE-1265.
       `scripts/validate-test-duplication.py` enumerates each lane from the live
       graph, collects identities with `--list`, and fails on any test scheduled
@@ -620,12 +640,14 @@ premerge, because the canary measures a cold graph premerge never has.
 
 ### 3. The lever this evaluation found instead, worth ~8× what RE offers
 
-`crates/rue-oracle-diff/BUCK` declares both suites `tier = "slow"` and
-`rue_heavy_suite`, and `ci.yml` gives each its own dedicated lane. **Premerge
-builds them anyway**, on both branches of its build step: unnarrowed,
-`./buck2 build //crates/...` reaches them; narrowed,
-`scripts/affected-targets`' `build_scope()` filters with `grep '^//crates/'`,
-and these targets live at `//crates/rue-oracle-diff:…`.
+At the time of this evaluation, `crates/rue-oracle-diff/BUCK` declared both
+suites `tier = "slow"` and `rue_heavy_suite`, and `ci.yml` gave each its own
+dedicated lane, but **premerge built them anyway**. Its unnarrowed
+`./buck2 build //crates/...` reached them, while its narrowed `build_scope()`
+used a crate-prefix filter that also admitted them. RUE-1511 subsequently
+removed the owned corpus-action closure from both build-scope branches, and
+RUE-1292 made the narrowed result an exact intersection with that live
+unnarrowed scope so a deleted or base-only label cannot reintroduce widening.
 
 The comment directly above `build_scope()` explains that the filter exists
 precisely because building a `cached_corpus_suite` action *runs its corpus*, and
@@ -747,11 +769,12 @@ Adopting or declining RE neither enables nor pressures that decision.
   the cold premerge build *and* run twice per run against their dedicated lanes,
   with a 75s median overlap. The duplication gate cannot see it, because the
   gate compares test identities while this is a build action racing a lane.
-- **The accepted §5's remedies need correcting for this case.** These suites are *already*
-  re-tiered to `slow` with dedicated lanes; the defect is that premerge builds
-  them regardless, because `build_scope()`'s crate-prefix filter only excludes
-  root-level corpus actions. The remaining remedy is to fix the scope filter or
-  split the suites — not to re-tier something already tiered.
+- **The accepted §5's remedies needed correcting for this case.** These suites
+  were *already* re-tiered to `slow` with dedicated lanes; the defect was that
+  premerge built them regardless. RUE-1511 fixed the corpus-action exclusion,
+  and RUE-1292 now proves narrowed consumers are subsets of their registered
+  live scopes. Splitting the suites remains a future optimization, not a
+  correctness remedy and not part of Phase 2.
 - **The "compiler build is 286–317s" open question is refined.** That figure was
   the whole `Build all targets` step. The compiler *binary* is ~74s cold and
   locally built; the entire rue-crate chain is ~21% of the step.

--- a/scripts/affected-targets
+++ b/scripts/affected-targets
@@ -547,7 +547,7 @@ emit_scope_summary() {
     if [[ "$status" == "VERIFIED" && -n "$selected_count" && -n "$total_count" && "$total_count" -gt 0 ]]; then
         local saved_count=$((total_count - selected_count))
         local saved_share=$((saved_count * 10000 / total_count))
-        printf -- '- `%s`: **VERIFIED** subset; selected **%s/%s** targets; unweighted saved share **%s.%02s%%** (not runner-time savings).\n' \
+        printf -- '- `%s`: **VERIFIED** subset; selected **%s/%s** targets; unweighted saved share **%s.%02d%%** (not runner-time savings).\n' \
             "$consumer" "$selected_count" "$total_count" "$((saved_share / 100))" "$((saved_share % 100))" >>"$GITHUB_STEP_SUMMARY"
     else
         printf -- '- `%s`: **%s**; saved share **not applicable**%s.\n' \
@@ -616,7 +616,7 @@ emit_manifest() {
         echo
         if [[ "$narrowing_status" == "CANDIDATE" && -n "$head_count" && -n "$impacted_count" && "$head_count" -gt 0 ]]; then
             printf -- '- Head graph target denominator: **%s**\n' "$head_count"
-            printf -- '- Live impacted closure: **%s** targets (**%s.%02s%%** of denominator)\n' \
+            printf -- '- Live impacted closure: **%s** targets (**%s.%02d%%** of denominator)\n' \
                 "$impacted_count" "$((impacted_count * 100 / head_count))" "$(((impacted_count * 10000 / head_count) % 100))"
             echo '- This is planner reach only; exact saved share is reported after each registered lane scope is queried.'
         else

--- a/scripts/affected-targets
+++ b/scripts/affected-targets
@@ -46,6 +46,9 @@
 #                      or without an impacted list. Narrowing must stay inside
 #                      the lane's own scope, and neither spelling of that scope
 #                      may name a corpus action (RUE-1511).
+#   scope-registry     Print the auditable narrowed-lane scope contract.
+#   scope-targets      Print a lane's unnarrowed scope from that contract.
+#   narrow-scope       Intersect an impacted closure with a registered scope.
 #
 # Deliberately NOT `set -e`: a full run is the safe fallback, so failures are
 # handled explicitly and converted into "full", never into a hard error that
@@ -111,6 +114,25 @@ SELECTABLE_LANES=(
     compiler-reproducibility
     rue-program-digests
 )
+
+# Narrowing consumers are deliberately registered here rather than in the
+# workflow.  The registry is the contract: a consumer must name its
+# unnarrowed scope here, and `narrow-scope` can only produce an intersection
+# with that scope.  Keep the output machine-readable so validate-ci-gate.py
+# can reject a workflow that grows a second, unreviewed narrowing path.
+scope_registry() {
+    printf '%s\n' \
+        'linux-premerge-build|pattern|//crates/...' \
+        'linux-premerge-tests|graph|rue_test_tier_premerge-minus-dedicated' \
+        'native-platforms-units|graph|rue_platform_native'
+}
+
+is_scope_consumer() {
+    case "$1" in
+        linux-premerge-build|linux-premerge-tests|native-platforms-units) return 0 ;;
+        *) return 1 ;;
+    esac
+}
 
 # Representative targets per lane, mirroring what each job executes in ci.yml.
 # An unknown lane prints nothing, and the gate treats that as "run".
@@ -266,10 +288,17 @@ NARROW_LIMIT="${RUE_AFFECTED_NARROW_LIMIT:-600}"
 # list in the workflow rather than a pattern.
 intersect_impacted() {
     local file="$1"; shift
-    [[ -r "$file" ]] || return 0
-    local target
+    [[ -r "$file" && ! -d "$file" ]] || return 1
+    local target status
     for target in "$@"; do
-        grep -Fxq "$target" "$file" && printf '%s\n' "$target"
+        if grep -Fxq -- "$target" "$file"; then
+            printf '%s\n' "$target"
+        else
+            status=$?
+            # grep 1 means the target is absent; anything else means the
+            # intersection could not be proved and must fail open upstream.
+            [[ "$status" -eq 1 ]] || return "$status"
+        fi
     done
     return 0
 }
@@ -397,8 +426,43 @@ deferred_corpus_targets() {
 # the determinator happens to name.
 build_scope() {
     local file="${1:-}"
-    local deferred kept buck2 expr scope
-    deferred="$(deferred_corpus_targets)" || deferred=""
+    local strict="${2:-compat}"
+    local deferred buck2 expr scope target
+    if [[ -n "$file" ]]; then
+        if [[ ! -r "$file" || -d "$file" ]]; then
+            echo "affected-targets: impacted list '$file' is unreadable" >&2
+            return 1
+        fi
+        if ! scope="$(build_scope "" "$strict")"; then
+            return 1
+        fi
+        if [[ "$scope" == "//crates/..." ]]; then
+            printf '%s\n' "$scope"
+            return 0
+        fi
+        local targets=()
+        while IFS= read -r target; do
+            [[ -n "$target" ]] && targets+=("$target")
+        done <<<"$scope"
+        intersect_impacted "$file" "${targets[@]}"
+        return $?
+    fi
+
+    # An unavailable ownership/closure query must not turn a narrowed request
+    # into a smaller guessed list.  Returning non-zero lets the workflow fall
+    # back to the complete historical `//crates/...` scope.
+    if ! deferred="$(deferred_corpus_targets)"; then
+        if [[ "$strict" != "strict" ]]; then
+            # Preserve the historical standalone helper contract for callers
+            # that cannot inspect a status: an unavailable ownership query
+            # returns the complete pattern, never a guessed subset. The
+            # workflow uses narrow_scope(..., strict) so it can report the
+            # degraded state and select its own fallback explicitly.
+            printf '%s\n' '//crates/...'
+            return 0
+        fi
+        return 1
+    fi
 
     if [[ -z "$file" ]]; then
         # The unnarrowed scope. `buck2 build` accepts patterns and target
@@ -442,17 +506,83 @@ build_scope() {
         return 0
     fi
 
-    if [[ ! -r "$file" ]]; then
-        echo "affected-targets: impacted list '$file' is unreadable" >&2
+    return 1
+}
+
+workflow_test_targets() {
+    local buck2 targets base query
+    buck2="$(buck2_bin)"
+    base="set(//... toolchains//...)"
+    query="attrfilter(labels, rue_test_tier_premerge, $base)"
+    query="$query except (attrfilter(labels, rue_ci_dedicated_lane, $base)"
+    query="$query + attrfilter(labels, rue_cli_shard, $base))"
+    if ! targets="$("$buck2" uquery "$query")"; then
+        echo "affected-targets: could not expand the premerge test scope" >&2
         return 1
     fi
-    # Labels arrive normalized by parse-btd-impacted.py ("root//" stripped), so
-    # this prefix is exact rather than a heuristic over spellings.
-    kept="$(grep '^//crates/' "$file" || true)"
-    if [[ -n "$kept" && -n "$deferred" ]]; then
-        kept="$(grep -Fxv -f <(printf '%s\n' "$deferred") <<<"$kept" || true)"
+    targets="$(normalize_cell <<<"$targets" | grep . || true)"
+    if [[ -z "$targets" ]]; then
+        echo "affected-targets: the premerge test scope came back empty" >&2
+        return 1
     fi
-    [[ -n "$kept" ]] && printf '%s\n' "$kept"
+    printf '%s\n' "$targets"
+}
+
+# Resolve the registered unnarrowed scope.  This is the only place a narrowing
+# consumer obtains its scope, so adding a lane requires an explicit registry
+# row and corresponding validator coverage.
+scope_targets() {
+    local consumer="$1"
+    is_scope_consumer "$consumer" || return 1
+    case "$consumer" in
+        linux-premerge-build) build_scope "" strict ;;
+        linux-premerge-tests) workflow_test_targets ;;
+        native-platforms-units) native_platform_targets ;;
+    esac
+}
+
+emit_scope_summary() {
+    local consumer="$1" status="$2" selected_count="${3:-}" total_count="${4:-}" detail="${5:-}"
+    [[ -n "${GITHUB_STEP_SUMMARY:-}" ]] || return 0
+    if [[ "$status" == "VERIFIED" && -n "$selected_count" && -n "$total_count" && "$total_count" -gt 0 ]]; then
+        local saved_count=$((total_count - selected_count))
+        local saved_share=$((saved_count * 10000 / total_count))
+        printf -- '- `%s`: **VERIFIED** subset; selected **%s/%s** targets; unweighted saved share **%s.%02s%%** (not runner-time savings).\n' \
+            "$consumer" "$selected_count" "$total_count" "$((saved_share / 100))" "$((saved_share % 100))" >>"$GITHUB_STEP_SUMMARY"
+    else
+        printf -- '- `%s`: **%s**; saved share **not applicable**%s.\n' \
+            "$consumer" "$status" "${detail:+ (${detail})}" >>"$GITHUB_STEP_SUMMARY"
+    fi
+}
+
+# Produce a narrowed scope by construction.  Pattern lanes use their own
+# scope-aware query; graph lanes first obtain their live allowlist and then
+# intersect it.  A query failure is non-zero so callers retain the full
+# unnarrowed scope rather than claiming a verified subset.
+narrow_scope() {
+    local consumer="$1" file="$2" scope narrowed target total_count selected_count
+    is_scope_consumer "$consumer" || return 1
+    if [[ ! -r "$file" || -d "$file" ]]; then
+        emit_scope_summary "$consumer" DEGRADED "" "" "impacted list unavailable; full scope used"
+        return 1
+    fi
+    if ! scope="$(scope_targets "$consumer")"; then
+        emit_scope_summary "$consumer" DEGRADED "" "" "scope query unavailable; full scope used"
+        return 1
+    fi
+    local targets=()
+    while IFS= read -r target; do
+        [[ -n "$target" ]] && targets+=("$target")
+    done <<<"$scope"
+    total_count="${#targets[@]}"
+    if ! narrowed="$(intersect_impacted "$file" "${targets[@]}")"; then
+        emit_scope_summary "$consumer" DEGRADED "" "$total_count" "intersection unavailable; full scope used"
+        return 1
+    fi
+    selected_count=0
+    [[ -n "$narrowed" ]] && selected_count="$(grep -c . <<<"$narrowed" || echo 0)"
+    emit_scope_summary "$consumer" VERIFIED "$selected_count" "$total_count"
+    [[ -n "$narrowed" ]] && printf '%s\n' "$narrowed"
     return 0
 }
 
@@ -461,12 +591,41 @@ build_scope() {
 # with a silent drop.
 emit_manifest() {
     local mode="$1" reason="$2" selected="$3" lanes="${4:-}"
+    local narrowing_status="${5:-DECLINED}" head_count="${6:-}" impacted_count="${7:-}"
     [[ -n "${GITHUB_STEP_SUMMARY:-}" ]] || return 0
+    local selected_corpus_count=0 selected_lane_count=0
+    local target lane
+    for target in "${SELECTABLE_CORPUS[@]}"; do
+        if [[ "$mode" == "full" || " ${selected} " == *" ${target} "* ]]; then
+            selected_corpus_count=$((selected_corpus_count + 1))
+        fi
+    done
+    for lane in "${SELECTABLE_LANES[@]}"; do
+        if [[ "$mode" == "full" || " ${lanes} " == *" ${lane} "* ]]; then
+            selected_lane_count=$((selected_lane_count + 1))
+        fi
+    done
     {
         echo "### Affected-corpus selection (RUE-1119)"
         echo
         echo "- Decision: **${mode}**"
         echo "- Reason: ${reason}"
+        echo "- Narrowing planner status: **${narrowing_status}**"
+        echo
+        echo "### Work-selection visibility"
+        echo
+        if [[ "$narrowing_status" == "CANDIDATE" && -n "$head_count" && -n "$impacted_count" && "$head_count" -gt 0 ]]; then
+            printf -- '- Head graph target denominator: **%s**\n' "$head_count"
+            printf -- '- Live impacted closure: **%s** targets (**%s.%02s%%** of denominator)\n' \
+                "$impacted_count" "$((impacted_count * 100 / head_count))" "$(((impacted_count * 10000 / head_count) % 100))"
+            echo '- This is planner reach only; exact saved share is reported after each registered lane scope is queried.'
+        else
+            echo '- Planner reach: **not applicable** (full run or narrowing declined)'
+        fi
+        printf -- '- Corpus lanes selected: **%s/%s**; deselected: **%s**\n' \
+            "$selected_corpus_count" "${#SELECTABLE_CORPUS[@]}" "$(( ${#SELECTABLE_CORPUS[@]} - selected_corpus_count ))"
+        printf -- '- Gated lanes selected: **%s/%s**; deselected: **%s**\n' \
+            "$selected_lane_count" "${#SELECTABLE_LANES[@]}" "$(( ${#SELECTABLE_LANES[@]} - selected_lane_count ))"
         echo
         echo "| Corpus target | Selection |"
         echo "| --- | --- |"
@@ -498,19 +657,22 @@ emit_manifest() {
 }
 
 decide_full() {
-    local reason="$1"
+    local reason="$1" status="${2:-DEGRADED}"
     echo "affected-targets: FULL run — ${reason}"
     emit_output full "true"
     emit_output selected ""
     emit_output selected_lanes ""
     emit_output_multiline impacted ""
     emit_output narrowed "false"
-    emit_manifest "full" "$reason" "" ""
+    emit_output narrowing_status "$status"
+    emit_output head_target_count ""
+    emit_output impacted_target_count ""
+    emit_manifest "full" "$reason" "" "" "$status"
     exit 0
 }
 
 decide_select() {
-    local selected="$1" reason="$2" lanes="${3:-}" impacted_file="${4:-}"
+    local selected="$1" reason="$2" lanes="${3:-}" impacted_file="${4:-}" head_count="${5:-}" closure_count="${6:-}" live_count="${7:-0}"
     echo "affected-targets: SELECTIVE run — ${reason}"
     echo "affected-targets: selected corpus targets: ${selected:-<none>}"
     echo "affected-targets: selected lanes: ${lanes:-<none>}"
@@ -522,10 +684,11 @@ decide_select() {
     # mean the lane keeps its ordinary pattern. `narrowed` is the single flag
     # consumers check, so an absent or oversized list can never be mistaken for
     # "narrow to nothing".
-    local impacted_count=0
-    [[ -n "$impacted_file" && -s "$impacted_file" ]] && impacted_count="$(grep -c . "$impacted_file" || echo 0)"
-    if [[ "$impacted_count" -gt 0 && "$impacted_count" -le "$NARROW_LIMIT" ]]; then
-        echo "affected-targets: narrowing lanes to ${impacted_count} impacted targets"
+    local impacted_count="${closure_count:-0}"
+    local narrowing_status="DECLINED"
+    if [[ "$impacted_count" -gt 0 && "$impacted_count" -le "$NARROW_LIMIT" && "$live_count" -gt 0 ]]; then
+        narrowing_status="CANDIDATE"
+        echo "affected-targets: ${live_count} live impacted targets are eligible for registered scope verification"
         emit_output_multiline impacted "$impacted_file"
         emit_output narrowed "true"
     else
@@ -533,14 +696,17 @@ decide_select() {
         emit_output_multiline impacted ""
         emit_output narrowed "false"
     fi
-    emit_manifest "select" "$reason" "$selected" "$lanes"
+    emit_output narrowing_status "$narrowing_status"
+    emit_output head_target_count "$head_count"
+    emit_output impacted_target_count "$live_count"
+    emit_manifest "select" "$reason" "$selected" "$lanes" "$narrowing_status" "$head_count" "$live_count"
     exit 0
 }
 
 cmd_decide() {
     local event="${RUE_AFFECTED_EVENT:-pull_request}"
     if [[ "$event" != "pull_request" ]]; then
-        decide_full "authoritative full run for event '${event}'"
+        decide_full "authoritative full run for event '${event}'" "DECLINED"
     fi
 
     # Resolve base and head. In Actions these come from the pull_request event;
@@ -576,7 +742,7 @@ cmd_decide() {
 
     local reason
     if reason="$(force_full_match <"$paths_file")"; then
-        decide_full "changed path forces a full run: ${reason}"
+        decide_full "changed path forces a full run: ${reason}" "DECLINED"
     fi
 
     # From here on, a full run is still the fallback for any tooling failure.
@@ -630,10 +796,18 @@ cmd_decide() {
 
     # Extract impacted target labels and intersect with the selectable corpus.
     # `root//:foo` and `//:foo` are the same target; normalize the `root` cell.
-    local impacted
+    local impacted head_count
     if ! impacted="$(python3 "$repo_root/scripts/parse-btd-impacted.py" <"$btd_out")"; then
         decide_full "could not parse btd output"
     fi
+    local head_targets_file="$work/head-targets.txt"
+    if ! python3 "$repo_root/scripts/parse-btd-impacted.py" <"$work/head.jsonl" >"$head_targets_file"; then
+        decide_full "could not parse the head graph"
+    fi
+    if [[ ! -s "$head_targets_file" ]]; then
+        decide_full "head graph came back empty"
+    fi
+    head_count="$(grep -c . "$head_targets_file" || echo 0)"
 
     local selected="" target
     for target in "${SELECTABLE_CORPUS[@]}"; do
@@ -657,10 +831,25 @@ cmd_decide() {
         done <<<"$lane_inventory"
     done
 
-    local impacted_file="$work/impacted-targets.txt"
-    printf '%s\n' "$impacted" | grep . >"$impacted_file" || true
+    # BTD compares base and head dumps, so its closure may name a target that
+    # existed only at the base. Such a label is evidence for lane selection but
+    # is not runnable at the head. Publish only the exact intersection with the
+    # live head graph to narrowing consumers; their own registered scope then
+    # applies a second exact intersection before any command executes.
+    local impacted_file="$work/impacted-head-targets.txt"
+    grep -Fxf "$head_targets_file" <<<"$impacted" >"$impacted_file"
+    local intersection_status=$?
+    if [[ "$intersection_status" -ne 0 ]]; then
+        if [[ "$intersection_status" -ne 1 ]]; then
+            decide_full "could not intersect the impacted closure with the head graph"
+        fi
+        : >"$impacted_file"
+    fi
 
-    decide_select "$selected" "btd affected-target closure over the PR diff" "$lanes" "$impacted_file"
+    local impacted_count=0 live_count=0
+    [[ -n "$impacted" ]] && impacted_count="$(grep -c . <<<"$impacted" || echo 0)"
+    [[ -s "$impacted_file" ]] && live_count="$(grep -c . "$impacted_file" || echo 0)"
+    decide_select "$selected" "btd affected-target closure over the PR diff" "$lanes" "$impacted_file" "$head_count" "$impacted_count" "$live_count"
 }
 
 main() {
@@ -691,6 +880,15 @@ main() {
             # actions, so both reach the same function (RUE-1511).
             [[ $# -le 2 ]] || { echo "usage: scripts/affected-targets build-scope [FILE]" >&2; exit 2; }
             build_scope "${2:-}" ;;
+        scope-registry)
+            [[ $# -eq 1 ]] || { echo "usage: scripts/affected-targets scope-registry" >&2; exit 2; }
+            scope_registry ;;
+        scope-targets)
+            [[ $# -eq 2 ]] || { echo "usage: scripts/affected-targets scope-targets LANE" >&2; exit 2; }
+            scope_targets "$2" ;;
+        narrow-scope)
+            [[ $# -eq 3 ]] || { echo "usage: scripts/affected-targets narrow-scope LANE FILE" >&2; exit 2; }
+            narrow_scope "$2" "$3" ;;
         lane-targets)
             [[ $# -eq 2 ]] || { echo "usage: scripts/affected-targets lane-targets LANE" >&2; exit 2; }
             lane_targets "$2" ;;
@@ -702,7 +900,7 @@ main() {
         lanes)
             lanes ;;
         *)
-            echo "usage: scripts/affected-targets [decide|force-full-match|status-paths|is-selectable|is-selectable-lane|lane-targets|native-targets|corpus-targets|lanes|intersect|build-scope]" >&2
+            echo "usage: scripts/affected-targets [decide|force-full-match|status-paths|is-selectable|is-selectable-lane|lane-targets|native-targets|corpus-targets|lanes|intersect|build-scope|scope-registry|scope-targets|narrow-scope]" >&2
             exit 2 ;;
     esac
 }

--- a/scripts/test-affected-targets.sh
+++ b/scripts/test-affected-targets.sh
@@ -246,6 +246,21 @@ expect_full "crates/rue-runtime-asan/Cargo.toml"
 
 # --- RUE-1130: narrowing a lane to the impacted closure ---------------------
 
+# The registry is the one source of truth for every narrowed-lane scope.
+TESTS=$((TESTS + 1))
+if [ "$(${AFFECTED[@]} scope-registry | tr '\n' ' ')" = \
+     "linux-premerge-build|pattern|//crates/... linux-premerge-tests|graph|rue_test_tier_premerge-minus-dedicated native-platforms-units|graph|rue_platform_native " ]; then
+  pass "narrow: scope registry declares every consumer"
+else
+  fail "narrow: scope registry drifted"
+fi
+TESTS=$((TESTS + 1))
+if ! "${AFFECTED[@]}" scope-targets future-lane >/dev/null 2>&1; then
+  pass "narrow: an unregistered future lane is rejected"
+else
+  fail "narrow: an unregistered future lane was accepted"
+fi
+
 # `intersect` is what turns a lane's fixed target list into the impacted subset.
 # Order follows the lane's own list so the runner's output stays stable.
 narrow_root="$(mktemp -d)"
@@ -272,12 +287,72 @@ else
   fail "narrow: empty impacted list did not intersect to nothing"
 fi
 
-# A missing file must not abort the caller mid-pipeline.
+# The graph lane is narrowed by intersecting its registered live allowlist.
+printf '%s\n' //crates/rue-codegen:rue-codegen-test //crates/rue-other:other-test >"$narrow_root/native-impacted"
 TESTS=$((TESTS + 1))
-if "${AFFECTED[@]}" intersect "$narrow_root/absent" //crates/rue-target:rue-target-test >/dev/null 2>&1; then
-  pass "narrow: missing impacted file exits cleanly"
+native_subset="$(RUE_AFFECTED_BUCK2="$native_graph_stub" "${AFFECTED[@]}" narrow-scope native-platforms-units "$narrow_root/native-impacted")"
+if [ "$native_subset" = "//crates/rue-codegen:rue-codegen-test" ]; then
+  pass "narrow: native output is an intersection of its registered scope"
 else
-  fail "narrow: missing impacted file did not exit cleanly"
+  fail "narrow: native output escaped its registered scope"
+fi
+TESTS=$((TESTS + 1))
+if ! RUE_AFFECTED_BUCK2="$narrow_root/absent" "${AFFECTED[@]}" narrow-scope native-platforms-units "$narrow_root/native-impacted" >/dev/null 2>&1; then
+  pass "narrow: unavailable native graph is not reported as verified"
+else
+  fail "narrow: unavailable native graph unexpectedly verified a subset"
+fi
+
+cat >"$narrow_root/native-two-buck" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' \
+  root//crates/rue-codegen:rue-codegen-test \
+  root//crates/rue-target:rue-target-test
+EOF
+chmod +x "$narrow_root/native-two-buck"
+scope_summary="$narrow_root/native-scope-summary"
+TESTS=$((TESTS + 1))
+if GITHUB_STEP_SUMMARY="$scope_summary" RUE_AFFECTED_BUCK2="$narrow_root/native-two-buck" \
+    "${AFFECTED[@]}" narrow-scope native-platforms-units "$narrow_root/native-impacted" >/dev/null && \
+    grep -Fq '**VERIFIED** subset; selected **1/2** targets; unweighted saved share **50.00%**' "$scope_summary"; then
+  pass "narrow: verified scope summary reports exact selected and saved shares"
+else
+  fail "narrow: verified scope summary omitted exact saved-share math"
+fi
+
+degraded_scope_summary="$narrow_root/degraded-scope-summary"
+TESTS=$((TESTS + 1))
+if ! GITHUB_STEP_SUMMARY="$degraded_scope_summary" RUE_AFFECTED_BUCK2="$narrow_root/absent" \
+    "${AFFECTED[@]}" narrow-scope native-platforms-units "$narrow_root/native-impacted" >/dev/null 2>&1 && \
+    grep -Fq '**DEGRADED**; saved share **not applicable**' "$degraded_scope_summary" && \
+    ! grep -Fq '**VERIFIED**' "$degraded_scope_summary"; then
+  pass "narrow: degraded scope summary cannot masquerade as verified"
+else
+  fail "narrow: degraded scope summary is missing or contradictory"
+fi
+
+# A missing file is an unavailable intersection, never a verified empty one.
+TESTS=$((TESTS + 1))
+if ! "${AFFECTED[@]}" intersect "$narrow_root/absent" //crates/rue-target:rue-target-test >/dev/null 2>&1; then
+  pass "narrow: missing impacted file rejects the intersection"
+else
+  fail "narrow: missing impacted file masqueraded as an empty intersection"
+fi
+
+# grep rc=1 is an ordinary non-member, but rc>1 means the intersection was not
+# computed. Pin that distinction without depending on a real filesystem fault.
+mkdir -p "$narrow_root/failing-grep-bin"
+cat >"$narrow_root/failing-grep-bin/grep" <<'EOF'
+#!/usr/bin/env bash
+exit 2
+EOF
+chmod +x "$narrow_root/failing-grep-bin/grep"
+TESTS=$((TESTS + 1))
+if ! PATH="$narrow_root/failing-grep-bin:$PATH" "${AFFECTED[@]}" intersect \
+    "$narrow_root/native-impacted" //crates/rue-codegen:rue-codegen-test >/dev/null 2>&1; then
+  pass "narrow: an intersection read error is not reported as verified empty"
+else
+  fail "narrow: an intersection read error was treated as an ordinary non-member"
 fi
 
 scope_root="$(mktemp -d)"
@@ -299,6 +374,12 @@ contains_target() {
 case "$1" in
   uquery)
     case "$2" in
+      set\(//...\ toolchains//...\))
+        printf '%s\n' \
+          root//:cli-tests-action \
+          root//:spec-tests-action \
+          root//crates/rue-compiler:rue-compiler \
+          root//crates/rue-span:rue-span-test ;;
       attrfilter*)
         # The premerge-tier selection. Deliberately omits `newthing-test`, so
         # that action is owned by no lane.
@@ -410,8 +491,8 @@ printf '%s\n' \
 TESTS=$((TESTS + 1))
 narrowed_scope="$(RUE_AFFECTED_BUCK2="$scope_root/bin/fake-buck" "${AFFECTED[@]}" build-scope "$narrow_root/mixed")"
 if [ "$(tr '\n' ' ' <<<"$narrowed_scope")" \
-     = "//crates/rue-compiler:rue-compiler //crates/rue-codegen:rue-codegen-test " ]; then
-  pass "narrow: build-scope keeps the crate scope and drops every corpus action"
+     = "//crates/rue-compiler:rue-compiler " ]; then
+  pass "narrow: build-scope is the exact impacted/live-scope intersection"
 else
   fail "narrow: build-scope did not restore the //crates/... scope"
 fi
@@ -461,15 +542,15 @@ fi
 # coverage.
 TESTS=$((TESTS + 1))
 degraded="$(RUE_AFFECTED_BUCK2="$scope_root/bin/absent" "${AFFECTED[@]}" build-scope "$narrow_root/unowned" 2>/dev/null | tr '\n' ' ')"
-if [ "$degraded" = "//crates/rue-oracle-diff:oracle-diff-test-action //crates/rue-newthing:newthing-test-action //crates/rue-span:rue-span-test " ]; then
-  pass "narrow: an unanswerable Buck query falls open to the unfiltered scope"
+if [ "$degraded" = "//crates/... " ]; then
+  pass "narrow: an unanswerable Buck query falls open to the full scope"
 else
   fail "narrow: a failed query did not fall open (got '$degraded')"
 fi
 
 # A successful ownership query followed by a failed configured closure query
-# must have the same conservative result. Exercise both scope spellings: the
-# narrowed list remains intact, and the unnarrowed pattern remains expanded.
+# must still fail open. Exercise both scope spellings: the narrowed request
+# falls back to the complete pattern, just like the unnarrowed request.
 cat >"$scope_root/bin/closure-fail-buck" <<'FAILING_CLOSURE'
 #!/usr/bin/env bash
 case "$1" in
@@ -499,16 +580,16 @@ chmod +x "$scope_root/bin/closure-fail-buck"
 TESTS=$((TESTS + 1))
 closure_failed_narrow="$(RUE_AFFECTED_BUCK2="$scope_root/bin/closure-fail-buck" \
   "${AFFECTED[@]}" build-scope "$narrow_root/unowned" 2>/dev/null | tr '\n' ' ')"
-if [ "$closure_failed_narrow" = "//crates/rue-oracle-diff:oracle-diff-test-action //crates/rue-newthing:newthing-test-action //crates/rue-span:rue-span-test " ]; then
-  pass "narrow: a failed configured closure keeps the narrowed scope"
+if [ "$closure_failed_narrow" = "//crates/... " ]; then
+  pass "narrow: a failed configured closure falls open to the full scope"
 else
   fail "narrow: a failed configured closure changed the narrowed scope (got '$closure_failed_narrow')"
 fi
 TESTS=$((TESTS + 1))
 closure_failed_unnarrowed="$(RUE_AFFECTED_BUCK2="$scope_root/bin/closure-fail-buck" \
   "${AFFECTED[@]}" build-scope 2>/dev/null | tr '\n' ' ')"
-if [ "$closure_failed_unnarrowed" = "//crates/rue-compiler:rue-compiler //crates/rue-oracle-diff:oracle-diff-test-action //crates/rue-newthing:newthing-test-action //crates/rue-span:rue-span-test " ]; then
-  pass "narrow: a failed configured closure keeps the unnarrowed scope"
+if [ "$closure_failed_unnarrowed" = "//crates/... " ]; then
+  pass "narrow: a failed configured closure falls open to the full unnarrowed scope"
 else
   fail "narrow: a failed configured closure changed the unnarrowed scope (got '$closure_failed_unnarrowed')"
 fi
@@ -522,6 +603,36 @@ if [ -z "$(RUE_AFFECTED_BUCK2="$scope_root/bin/fake-buck" "${AFFECTED[@]}" build
   pass "narrow: build-scope on a corpus-only closure yields nothing to build"
 else
   fail "narrow: build-scope invented crate targets from a corpus-only closure"
+fi
+
+corpus_scope_summary="$narrow_root/corpus-scope-summary"
+TESTS=$((TESTS + 1))
+if [ -z "$(GITHUB_STEP_SUMMARY="$corpus_scope_summary" RUE_AFFECTED_BUCK2="$scope_root/bin/fake-buck" \
+    "${AFFECTED[@]}" narrow-scope linux-premerge-build "$narrow_root/corpora-only")" ] && \
+    grep -Fq '**VERIFIED** subset; selected **0/3** targets; unweighted saved share **100.00%**' "$corpus_scope_summary"; then
+  pass "narrow: corpus-only closure takes the registered empty build subset"
+else
+  fail "narrow: corpus-only registered build subset or summary is wrong"
+fi
+
+TESTS=$((TESTS + 1))
+test_subset="$(RUE_AFFECTED_BUCK2="$scope_root/bin/fake-buck" "${AFFECTED[@]}" \
+  narrow-scope linux-premerge-tests "$narrow_root/corpora-only")"
+if [ -z "$test_subset" ]; then
+  pass "narrow: corpus-only closure takes the registered empty premerge test subset"
+else
+  fail "narrow: corpus-only premerge test scope invented a runnable test"
+fi
+
+strict_scope_summary="$narrow_root/strict-scope-summary"
+TESTS=$((TESTS + 1))
+if ! GITHUB_STEP_SUMMARY="$strict_scope_summary" RUE_AFFECTED_BUCK2="$scope_root/bin/absent" \
+    "${AFFECTED[@]}" narrow-scope linux-premerge-build "$narrow_root/unowned" >/dev/null 2>&1 && \
+    grep -Fq '`linux-premerge-build`: **DEGRADED**' "$strict_scope_summary" && \
+    ! grep -Fq '**VERIFIED**' "$strict_scope_summary"; then
+  pass "narrow: strict linux scope failure reports degraded full-scope fallback"
+else
+  fail "narrow: strict linux scope failure did not report an unverified fallback"
 fi
 
 # An unreadable list must fail loudly so the caller can fall open to the full
@@ -566,6 +677,12 @@ check_narrow "a readable list narrows the suite" \
 check_narrow "an empty list runs the full pattern" \
   "ARGS: //... toolchains//..." \
   "RUE_TEST_TARGETS_FILE=$narrow_root/none"
+TESTS=$((TESTS + 1))
+if [ -z "$(run_test_sh_args "RUE_TEST_TARGETS_FILE=$narrow_root/none" "RUE_TEST_TARGETS_STATUS=VERIFIED")" ]; then
+  pass "narrow: a verified empty test scope runs no tests"
+else
+  fail "narrow: a verified empty test scope fell back to the full pattern"
+fi
 check_narrow "an unreadable list runs the full pattern" \
   "ARGS: //... toolchains//..." \
   "RUE_TEST_TARGETS_FILE=$narrow_root/absent"
@@ -596,6 +713,10 @@ printf '   \n\t\n' >"$narrow_root/whitespace"
 check_narrow "a whitespace-only list runs the full pattern" \
   "ARGS: //... toolchains//..." \
   "RUE_TEST_TARGETS_FILE=$narrow_root/whitespace"
+check_narrow "a VERIFIED whitespace-only list still runs the full pattern" \
+  "ARGS: //... toolchains//..." \
+  "RUE_TEST_TARGETS_FILE=$narrow_root/whitespace" \
+  "RUE_TEST_TARGETS_STATUS=VERIFIED"
 
 # A file whose last line has no newline. `mapfile` keeps that line; a plain
 # `while read` loop silently drops it, dropping a target from the run.
@@ -701,7 +822,7 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 [ -n "$output" ]
-printf '{"target":"root//:spec-tests"}\n' >"$output"
+printf '%s\n' '{"target":"root//:spec-tests"}' '{"target":"root//:unimpacted"}' >"$output"
 EOF
 cat >"$integration_root/bin/fake-btd" <<'EOF'
 #!/usr/bin/env bash
@@ -713,7 +834,9 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 cmp -s "$changes" "${RUE_AFFECTED_EXPECTED_CHANGES:?}"
-printf '{"target":"root//:spec-tests"}\n'
+printf '%s\n' \
+  '{"target":"root//:spec-tests"}' \
+  '{"target":"root//crates/deleted:base-only"}'
 EOF
 chmod +x "$integration_root/bin/fake-buck" "$integration_root/bin/fake-btd"
 git -C "$integration_root" init -q
@@ -733,9 +856,17 @@ if (
   RUE_AFFECTED_BTD_ARGS="$integration_root/btd-args" \
   RUE_AFFECTED_EXPECTED_CHANGES="$integration_root/expected-changes" \
   GITHUB_OUTPUT="$integration_root/output" \
+  GITHUB_STEP_SUMMARY="$integration_root/summary" \
   scripts/affected-targets decide >/dev/null
 ) && grep -Fxq 'full=false' "$integration_root/output" && \
     grep -Fxq 'selected=//:spec-tests' "$integration_root/output" && \
+    grep -Fxq 'narrowing_status=CANDIDATE' "$integration_root/output" && \
+    grep -Fxq 'head_target_count=2' "$integration_root/output" && \
+    grep -Fxq 'impacted_target_count=1' "$integration_root/output" && \
+    ! grep -Fq '//crates/deleted:base-only' "$integration_root/output" && \
+    grep -Fq 'Live impacted closure: **1** targets (**50.00%' "$integration_root/summary" && \
+    grep -Fq 'exact saved share is reported after each registered lane scope' "$integration_root/summary" && \
+    grep -Fq 'Corpus lanes selected:' "$integration_root/summary" && \
     grep -Fxq -- '--vcs' "$integration_root/btd-args" && \
     grep -Fxq -- 'git' "$integration_root/btd-args" && \
     grep -Fxq -- '--buck' "$integration_root/btd-args" && \
@@ -774,11 +905,67 @@ if (
   RUE_AFFECTED_BTD_ARGS="$integration_root/failure-btd-args" \
   RUE_AFFECTED_EXPECTED_CHANGES="$integration_root/expected-changes" \
   GITHUB_OUTPUT="$failure_output" \
+  GITHUB_STEP_SUMMARY="$integration_root/degraded-summary" \
   scripts/affected-targets decide >/dev/null 2>&1
-) && grep -Fxq 'full=true' "$failure_output"; then
+) && grep -Fxq 'full=true' "$failure_output" && \
+    grep -Fxq 'narrowing_status=DEGRADED' "$failure_output" && \
+    grep -Fq 'Planner reach: **not applicable**' "$integration_root/degraded-summary"; then
   pass "decision: native graph query failure runs full suite"
 else
   fail "decision: native graph query failure did not fail open to full suite"
+fi
+
+cat >"$integration_root/bin/empty-head-buck" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "uquery" ]; then
+  printf 'root//:spec-tests\n'
+  exit 0
+fi
+output=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--output" ]; then output="$2"; shift 2; continue; fi
+  shift
+done
+[ -n "$output" ]
+: >"$output"
+EOF
+chmod +x "$integration_root/bin/empty-head-buck"
+TESTS=$((TESTS + 1))
+empty_head_output="$integration_root/empty-head-output"
+if (
+  cd "$integration_root" &&
+  RUE_AFFECTED_BASE_SHA=HEAD~1 \
+  RUE_AFFECTED_HEAD_SHA=HEAD \
+  RUE_AFFECTED_BTD="$integration_root/bin/fake-btd" \
+  RUE_AFFECTED_BUCK2="$integration_root/bin/empty-head-buck" \
+  RUE_AFFECTED_BTD_ARGS="$integration_root/empty-head-btd-args" \
+  RUE_AFFECTED_EXPECTED_CHANGES="$integration_root/expected-changes" \
+  GITHUB_OUTPUT="$empty_head_output" \
+  GITHUB_STEP_SUMMARY="$integration_root/empty-head-summary" \
+  scripts/affected-targets decide >/dev/null 2>&1
+) && grep -Fxq 'full=true' "$empty_head_output" && \
+    grep -Fxq 'narrowing_status=DEGRADED' "$empty_head_output"; then
+  pass "decision: an empty successful head dump degrades to full"
+else
+  fail "decision: an empty successful head dump was treated as selective"
+fi
+
+TESTS=$((TESTS + 1))
+full_output="$integration_root/full-output"
+full_summary="$integration_root/full-summary"
+if (
+  cd "$integration_root" &&
+  RUE_AFFECTED_EVENT=merge_group \
+  GITHUB_OUTPUT="$full_output" \
+  GITHUB_STEP_SUMMARY="$full_summary" \
+  scripts/affected-targets decide >/dev/null 2>&1
+) && grep -Fxq 'full=true' "$full_output" && \
+    grep -Fxq 'narrowing_status=DECLINED' "$full_output" && \
+    grep -Fq 'Planner reach: **not applicable**' "$full_summary"; then
+  pass "decision: authoritative full run reports no saved share"
+else
+  fail "decision: authoritative full run fabricated a saved share"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/test-validate-ci-gate.py
+++ b/scripts/test-validate-ci-gate.py
@@ -341,6 +341,112 @@ class GateValidatorTests(unittest.TestCase):
     def test_declared_need_outputs_pass(self):
         self.assertEqual(self.validate_text(SOURCE.read_text()), [])
 
+    def test_future_narrowing_consumer_must_be_registered(self):
+        changed = SOURCE.read_text() + (
+            "\n  future-narrowed-lane:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    needs: affected-targets\n"
+            "    steps:\n"
+            "      - run: echo ${{ needs.affected-targets.outputs.impacted }}\n"
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("future-narrowed-lane consumes impacted narrowing", errors)
+
+    def test_direct_scope_operation_cannot_bypass_registry(self):
+        changed = SOURCE.read_text().replace(
+            "scripts/affected-targets narrow-scope linux-premerge-build \"$NARROW_FILE\"",
+            "scripts/affected-targets intersect \"$NARROW_FILE\" \"${targets[@]}\"",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("must use the registry-backed narrow-scope command", errors)
+
+    def test_second_raw_impacted_consumer_fails_closed(self):
+        changed = SOURCE.read_text().replace(
+            "RUE_TEST_TARGETS_FILE: ${{ steps.narrow.outputs.test_file }}",
+            'RUE_TEST_TARGETS_FILE: "$RUE_AFFECTED_IMPACTED"',
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("raw impacted-closure consumer", errors)
+        self.assertIn("registry-intersected target file", errors)
+
+    def test_second_raw_impacted_file_consumer_fails_closed(self):
+        changed = SOURCE.read_text().replace(
+            "NARROW_FILE: ${{ steps.narrow.outputs.file }}",
+            "NARROW_FILE: ${{ steps.narrow.outputs.file }}\n"
+            "          SECOND_RAW_FILE: ${{ steps.narrow.outputs.file }}",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("raw impacted file", errors)
+
+    def test_second_narrow_file_use_fails_closed(self):
+        changed = SOURCE.read_text().replace(
+            'elif ! scope="$(scripts/affected-targets narrow-scope '
+            'linux-premerge-build "$NARROW_FILE")"; then',
+            'head -n1 "$NARROW_FILE"\n'
+            '          elif ! scope="$(scripts/affected-targets narrow-scope '
+            'linux-premerge-build "$NARROW_FILE")"; then',
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("expose $NARROW_FILE only", errors)
+
+    def test_second_local_raw_file_use_fails_closed(self):
+        changed = SOURCE.read_text().replace(
+            'if scripts/affected-targets narrow-scope linux-premerge-tests '
+            '"$file" >"$test_file"; then',
+            'head -n1 "$file"\n'
+            '            if scripts/affected-targets narrow-scope linux-premerge-tests '
+            '"$file" >"$test_file"; then',
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("local raw impacted file only", errors)
+
+    def test_second_native_local_raw_file_use_fails_closed(self):
+        marker = 'file="${RUNNER_TEMP}/impacted-targets.txt"'
+        changed = SOURCE.read_text().replace(
+            marker,
+            marker + '\n          head -n1 "$file" >/dev/null',
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("native-platforms must use its local raw impacted file only", errors)
+
+    def test_each_registered_consumer_must_intersect(self):
+        changed = SOURCE.read_text().replace(
+            'scripts/affected-targets narrow-scope linux-premerge-tests "$file"',
+            'printf "%s\\n" "$RUE_AFFECTED_IMPACTED"',
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("linux-premerge-tests", errors)
+
+    def test_degraded_build_fallback_cannot_be_removed(self):
+        changed = SOURCE.read_text().replace(
+            'scripts/ci-timed "linux-x64 build" -- ./buck2 build //crates/...',
+            "echo './buck2 build //crates/...'",
+            2,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("full-scope degraded fallback", errors)
+
+    def test_saved_share_summary_cannot_be_removed(self):
+        changed = SOURCE.read_text().replace("saved share", "scope share")
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("saved-share visibility", errors)
+
+    def test_impacted_reference_in_comment_is_not_a_consumer(self):
+        changed = SOURCE.read_text().replace(
+            "  ci-success:\n",
+            "  # needs.affected-targets.outputs.impacted is documented only\n"
+            "  ci-success:\n",
+            1,
+        )
+        self.assertEqual(self.validate_text(changed), [])
+
     def test_need_output_from_unknown_job_fails(self):
         self.assertIn(
             "references unknown job",

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -263,7 +263,7 @@ def narrowing_contract_errors(
                 'printf \'%s\\n\' "$RUE_AFFECTED_IMPACTED" | sed \'/^$/d\' >"$file"',
                 expected_command_lines["linux-premerge-tests"],
                 'count="$(wc -l <"$file" | tr -d \' \')"',
-                'echo "file=$file" >>"$GITHUB_OUTPUT"',
+                'echo "file=$file"',
             },
             "native-platforms": {
                 ': >"$file"',

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -161,6 +161,189 @@ def undeclared_need_outputs(workflow: str, jobs: dict[str, str]) -> list[str]:
 AFFECTED_TARGETS_SCRIPT = Path(__file__).with_name("affected-targets")
 
 
+def narrowing_scope_registry(script: Path = AFFECTED_TARGETS_SCRIPT) -> dict[str, tuple[str, str]]:
+    """Read the single registry that owns every impacted-lane scope."""
+    result = subprocess.run(
+        ["bash", str(script), "scope-registry"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return {}
+    registry: dict[str, tuple[str, str]] = {}
+    for line in result.stdout.splitlines():
+        fields = line.split("|")
+        if len(fields) != 3 or not all(fields):
+            return {}
+        lane, kind, scope = fields
+        if lane in registry:
+            return {}
+        registry[lane] = (kind, scope)
+    return registry
+
+
+def narrowing_contract_errors(
+    workflow: str, script: Path = AFFECTED_TARGETS_SCRIPT
+) -> list[str]:
+    """Require every impacted-closure consumer to use a registered scope.
+
+    The workflow may gate many jobs, but only jobs that consume the
+    determinator's ``narrowed``/``impacted`` outputs are narrowing consumers.
+    Their scope must be resolved by the registry-backed commands; direct
+    ``build-scope``/``intersect`` calls are deliberately rejected because they
+    can widen or drift without changing the registry.
+    """
+    registry = narrowing_scope_registry(script)
+    if not registry:
+        return ["narrowing scope registry is unavailable or malformed"]
+    jobs = job_blocks(workflow)
+    errors: list[str] = []
+    expected_by_job = {
+        "linux-premerge": {"linux-premerge-build", "linux-premerge-tests"},
+        "native-platforms": {"native-platforms-units"},
+    }
+    expected_command_lines = {
+        "linux-premerge-build": (
+            'elif ! scope="$(scripts/affected-targets narrow-scope '
+            'linux-premerge-build "$NARROW_FILE")"; then'
+        ),
+        "linux-premerge-tests": (
+            'if scripts/affected-targets narrow-scope linux-premerge-tests '
+            '"$file" >"$test_file"; then'
+        ),
+        "native-platforms-units": (
+            'if ! narrowed="$(scripts/affected-targets narrow-scope '
+            'native-platforms-units "$NARROW_FILE")"; then'
+        ),
+    }
+    used_scopes: set[str] = set()
+    for consumer, (kind, scope) in registry.items():
+        if kind not in {"pattern", "graph"} or not scope.strip():
+            errors.append(f"registered scope {consumer!r} has invalid metadata")
+
+    for job, block in jobs.items():
+        if job in {"affected-targets", "ci-success"}:
+            continue
+        executable = [line.split("#", 1)[0] for line in block.splitlines()]
+        stripped_lines = [line.strip() for line in executable if line.strip()]
+        executable_text = "\n".join(executable)
+        consumes_impacted = "needs.affected-targets.outputs.impacted" in executable_text
+        consumes_narrowed = "needs.affected-targets.outputs.narrowed" in executable_text
+        if not (consumes_narrowed or consumes_impacted):
+            continue
+        expected_scopes = expected_by_job.get(job)
+        if expected_scopes is None:
+            errors.append(
+                f"{job} consumes impacted narrowing but is absent from the scope registry"
+            )
+            continue
+        if executable_text.count("needs.affected-targets.outputs.impacted") != 1:
+            errors.append(f"{job} must materialize the impacted output exactly once")
+        raw_file_ref = "${{ steps.narrow.outputs.file }}"
+        if executable_text.count(raw_file_ref) != 1:
+            errors.append(f"{job} must expose its raw impacted file to exactly one scope preparer")
+        for line in executable:
+            if raw_file_ref in line and f"NARROW_FILE: {raw_file_ref}" not in line:
+                errors.append(
+                    f"{job} has a raw impacted-file consumer outside a registered narrow-scope preparer"
+                )
+        expected_narrow_file_line = {
+            "linux-premerge": expected_command_lines["linux-premerge-build"],
+            "native-platforms": expected_command_lines["native-platforms-units"],
+        }[job]
+        narrow_file_uses = [line for line in stripped_lines if "$NARROW_FILE" in line]
+        if narrow_file_uses != [expected_narrow_file_line]:
+            errors.append(
+                f"{job} must expose $NARROW_FILE only to its registered narrow-scope command"
+            )
+        allowed_local_file_uses = {
+            "linux-premerge": {
+                ': >"$file"',
+                'printf \'%s\\n\' "$RUE_AFFECTED_IMPACTED" | sed \'/^$/d\' >"$file"',
+                expected_command_lines["linux-premerge-tests"],
+                'count="$(wc -l <"$file" | tr -d \' \')"',
+                'echo "file=$file" >>"$GITHUB_OUTPUT"',
+            },
+            "native-platforms": {
+                ': >"$file"',
+                'printf \'%s\\n\' "$RUE_AFFECTED_IMPACTED" | sed \'/^$/d\' >"$file"',
+                'count="$(wc -l <"$file" | tr -d \' \')"',
+                'echo "file=$file" >>"$GITHUB_OUTPUT"',
+            },
+        }[job]
+        local_file_uses = [line for line in stripped_lines if "$file" in line]
+        if len(local_file_uses) != len(allowed_local_file_uses) or set(
+            local_file_uses
+        ) != allowed_local_file_uses:
+            errors.append(
+                f"{job} must use its local raw impacted file only for "
+                "materialization and registered scope preparation"
+            )
+        for line in executable:
+            if "$RUE_AFFECTED_IMPACTED" not in line:
+                continue
+            if "printf '%s\\n' \"$RUE_AFFECTED_IMPACTED\"" not in line:
+                errors.append(
+                    f"{job} has a raw impacted-closure consumer outside its materialization step"
+                )
+        if any(
+            "affected-targets build-scope" in line
+            or "affected-targets intersect" in line
+            for line in executable
+        ):
+            errors.append(
+                f"{job} must use the registry-backed narrow-scope command, not a direct scope operation"
+            )
+        for consumer in expected_scopes:
+            if consumer not in registry:
+                errors.append(f"{job} requires missing registered scope {consumer!r}")
+                continue
+            required_line = expected_command_lines[consumer]
+            if stripped_lines.count(required_line) != 1:
+                errors.append(
+                    f"{job} narrowing is not computed by registered scope {consumer!r}"
+                )
+            else:
+                used_scopes.add(consumer)
+        if job == "linux-premerge":
+            if stripped_lines.count(
+                'if scope="$(scripts/affected-targets scope-targets linux-premerge-build)"; then'
+            ) != 1:
+                errors.append(
+                    "linux-premerge must declare its unnarrowed build scope through the registry"
+                )
+            if "RUE_TEST_TARGETS_FILE: ${{ steps.narrow.outputs.test_file }}" not in executable_text:
+                errors.append(
+                    "linux-premerge tests must consume the registry-intersected target file"
+                )
+            if "RUE_TEST_TARGETS_STATUS: ${{ steps.narrow.outputs.test_status }}" not in executable_text:
+                errors.append(
+                    "linux-premerge tests must consume the final scope-verification status"
+                )
+            if stripped_lines.count(
+                'scripts/ci-timed "linux-x64 build" -- ./buck2 build //crates/...'
+            ) != 2:
+                errors.append("linux-premerge must retain its full-scope degraded fallback")
+        elif job == "native-platforms":
+            # native-targets is the compatibility spelling for the graph
+            # allowlist; its implementation is registry-backed by the script.
+            if stripped_lines.count(
+                'native_targets="$(scripts/affected-targets native-targets)" || exit 1'
+            ) != 1:
+                errors.append(
+                    "native-platforms must declare its graph-owned scope through native-targets"
+                )
+            if stripped_lines.count('narrowed="$native_targets"') != 1:
+                errors.append("native-platforms must retain its full-scope degraded fallback")
+        if "GITHUB_STEP_SUMMARY" not in executable_text or "saved share" not in executable_text:
+            errors.append(f"{job} must publish final per-scope saved-share visibility")
+    unused = set(registry) - used_scopes
+    for consumer in sorted(unused):
+        errors.append(f"registered scope {consumer!r} has no workflow narrow-scope consumer")
+    return errors
+
+
 def lane_targets(lane: str, script: Path = AFFECTED_TARGETS_SCRIPT) -> set[str]:
     """The Buck targets the determinator believes a gated lane executes."""
     result = subprocess.run(
@@ -190,7 +373,7 @@ def lane_target_drift(workflow: str, script: Path = AFFECTED_TARGETS_SCRIPT) -> 
     # so explanatory target labels cannot become false positives.
     unit_invocation = './buck2 test "${targets[@]}"'
     native_query = 'native_targets="$(scripts/affected-targets native-targets)" || exit 1'
-    intersect_query = 'scripts/affected-targets intersect "$NARROW_FILE" "${targets[@]}"'
+    intersect_query = 'scripts/affected-targets narrow-scope native-platforms-units "$NARROW_FILE"'
     native_query_count = 0
     test_invocations = []
     direct_targets = set()
@@ -199,7 +382,10 @@ def lane_target_drift(workflow: str, script: Path = AFFECTED_TARGETS_SCRIPT) -> 
         code = line.split("#", 1)[0]
         stripped = code.strip()
         is_native_query = stripped == native_query
-        is_intersect_query = stripped == f'narrowed="$({intersect_query})"'
+        is_intersect_query = (
+            stripped == f'narrowed="$({intersect_query})"'
+            or stripped == f'if ! narrowed="$({intersect_query})"; then'
+        )
         if is_native_query:
             native_query_count += 1
         if "scripts/affected-targets" in code:
@@ -638,6 +824,7 @@ def validate(
 
     errors.extend(undeclared_need_outputs(workflow, jobs))
     errors.extend(lane_target_drift(workflow))
+    errors.extend(narrowing_contract_errors(workflow))
 
     if "  pull_request:\n" not in workflow or "  merge_group:\n" not in workflow:
         errors.append("CI must run on both pull_request and merge_group")

--- a/test.sh
+++ b/test.sh
@@ -142,9 +142,10 @@ if [[ $# -eq 0 ]]; then
     # changing what membership means.
     #
     # FAIL-OPEN, in the same direction as the determinator: an unset variable,
-    # an unreadable file, or a file the determinator declined to narrow (empty)
-    # all fall back to the full pattern. Only a readable, non-empty list
-    # narrows, and merge_group never narrows because it never runs selectively.
+    # an unreadable file, or an empty file without an explicit VERIFIED status
+    # all fall back to the full pattern. A verified empty intersection means
+    # the registered live test scope has no impacted members, so it runs no
+    # tests rather than letting the empty-file fallback erase that proof.
     #
     # An explicit list that filters down to no tests is a legitimate outcome
     # (impacted libraries with no premerge tests of their own) and buck2 exits 0
@@ -153,6 +154,8 @@ if [[ $# -eq 0 ]]; then
     # left to be inferred from a silent green.
     local_targets=(//... toolchains//...)
     narrow_file="${RUE_TEST_TARGETS_FILE:-}"
+    narrow_status="${RUE_TEST_TARGETS_STATUS:-}"
+    skip_narrowed_tests=0
     if [[ -n "$narrow_file" ]]; then
         # A directory passes both -r and -s, and `read` fails on it without
         # assigning, so it is classified as unreadable here rather than left to
@@ -160,7 +163,12 @@ if [[ $# -eq 0 ]]; then
         if [[ ! -r "$narrow_file" || -d "$narrow_file" ]]; then
             echo "test.sh: RUE_TEST_TARGETS_FILE='$narrow_file' is unreadable; running the full pattern" >&2
         elif [[ ! -s "$narrow_file" ]]; then
-            echo "test.sh: no narrowed target list supplied; running the full pattern"
+            if [[ "$narrow_status" == "VERIFIED" ]]; then
+                skip_narrowed_tests=1
+                echo "test.sh: verified narrowed test scope is empty; no premerge tests are impacted"
+            else
+                echo "test.sh: no verified narrowed target list supplied; running the full pattern"
+            fi
         else
             # Read with `while read`, not `mapfile`: macOS ships Bash 3.2 as
             # /bin/bash, which has no `mapfile` builtin, so a narrowed run on a
@@ -192,7 +200,11 @@ if [[ $# -eq 0 ]]; then
                 narrowed+=("$narrowed_target")
             done <"$narrow_file"
             if [[ ${#narrowed[@]} -eq 0 ]]; then
-                echo "test.sh: no narrowed target list supplied; running the full pattern"
+                # Only the producer's genuinely zero-byte VERIFIED output is
+                # proof of an empty intersection. A non-empty file that yields
+                # no labels is malformed, so it fails open even if its status
+                # was accidentally left VERIFIED.
+                echo "test.sh: narrowed target list contained no valid labels; running the full pattern"
             else
                 local_targets=("${narrowed[@]}")
                 echo "test.sh: narrowed to ${#local_targets[@]} impacted target(s) by the affected-targets determinator"
@@ -200,21 +212,25 @@ if [[ $# -eq 0 ]]; then
         fi
     fi
 
-    test_args=("${local_targets[@]}" --always-exclude --ignore-tests-attribute --exclude rue_cli_shard)
-    if [[ "$test_tier" == standard ]]; then
-        test_args+=(--exclude rue_test_tier_stress)
-    elif [[ "$test_tier" != all ]]; then
-        test_args+=(--include "rue_test_tier_$test_tier")
-    fi
-    # Required CI gives these corpora their own platform-corpus job; the label
-    # is the only place that set is written down (scripts/validate-ci-gate.py
-    # fails if a labeled corpus has no job).
-    if [[ "${CI:-}" == "true" ]]; then
-        test_args+=(--exclude rue_ci_dedicated_lane)
-    fi
+    if [[ "$skip_narrowed_tests" -eq 1 ]]; then
+        echo "Running the $test_tier tier: NO TESTS RAN (verified empty intersection)"
+    else
+        test_args=("${local_targets[@]}" --always-exclude --ignore-tests-attribute --exclude rue_cli_shard)
+        if [[ "$test_tier" == standard ]]; then
+            test_args+=(--exclude rue_test_tier_stress)
+        elif [[ "$test_tier" != all ]]; then
+            test_args+=(--include "rue_test_tier_$test_tier")
+        fi
+        # Required CI gives these corpora their own platform-corpus job; the label
+        # is the only place that set is written down (scripts/validate-ci-gate.py
+        # fails if a labeled corpus has no job).
+        if [[ "${CI:-}" == "true" ]]; then
+            test_args+=(--exclude rue_ci_dedicated_lane)
+        fi
 
-    echo "Running the $test_tier tier..."
-    ./buck2 test "${test_args[@]}"
+        echo "Running the $test_tier tier..."
+        ./buck2 test "${test_args[@]}"
+    fi
 else
     # Unit tests live under //crates/...; the suite sh_tests are at the repo
     # root, so this scope keeps them out of the filtered unit step below. Keep


### PR DESCRIPTION
Summary
- register every narrowed CI consumer under one live-scope contract and enforce exact subset intersections
- distinguish candidate, verified, declined, and degraded selection while publishing per-scope target counts and saved share
- harden workflow validation against raw-scope bypasses and document the recorded Phase 2 evidence and remaining limits

Testing
- focused affected-target, workflow-validator, Python-floor, and Bash-floor Buck gates
- live CI ownership validation
- scripts/rue fmt
- scripts/rue quick
- scripts/rue premerge
- scripts/rue test
- git diff --check

Closes RUE-1292