### PR TITLE
RUE-931: bound O3 inlining growth

### DIFF
--- a/crates/rue-cfg/src/inline.rs
+++ b/crates/rue-cfg/src/inline.rs
@@ -207,6 +207,48 @@ struct Splice<'a> {
     redirects: &'a AHashMap<u32, ParamRedirect>,
 }
 
+/// The read-only shape of a splice. Both the growth preflight and the
+/// mutating splice consume this plan so call parsing, ABI arity, by-reference
+/// place validation, and materialization cannot drift apart.
+struct SpliceShape {
+    call_ty: Type,
+    call_span: Span,
+    call_args: Vec<CfgCallArg>,
+    is_accessor: bool,
+    params: Vec<CalleeParam>,
+    materialized_params: u64,
+}
+
+impl SpliceShape {
+    fn growth(&self, callee: &Cfg) -> Result<crate::opt::CodeGrowth, CfgInlineError> {
+        let callee_values = u64::try_from(callee.value_count()).map_err(|_| {
+            CfgInlineError::Edit(CfgEditError::ResourceLimitExceeded {
+                family: "inline growth",
+            })
+        })?;
+        let continuation_value = u64::from(!self.is_accessor && self.call_ty != Type::NEVER);
+        let storage_values =
+            self.materialized_params
+                .checked_mul(3)
+                .ok_or(CfgInlineError::Edit(CfgEditError::ResourceLimitExceeded {
+                    family: "inline growth",
+                }))?;
+        let values = callee_values
+            .checked_add(continuation_value)
+            .and_then(|growth| growth.checked_add(storage_values))
+            .ok_or(CfgInlineError::Edit(CfgEditError::ResourceLimitExceeded {
+                family: "inline growth",
+            }))?;
+        let blocks = u64::try_from(callee.block_count())
+            .ok()
+            .and_then(|blocks| blocks.checked_add(1))
+            .ok_or(CfgInlineError::Edit(CfgEditError::ResourceLimitExceeded {
+                family: "inline growth",
+            }))?;
+        Ok(crate::opt::CodeGrowth { values, blocks })
+    }
+}
+
 impl Splice<'_> {
     fn value(&self, value: CfgValue) -> CfgValue {
         CfgValue::from_raw(value.as_u32() + self.value_base)
@@ -275,6 +317,70 @@ pub fn inline_call_in_block(
         .map_err(CfgInlineError::Verification)
 }
 
+fn splice_shape(
+    caller: &Cfg,
+    call: CfgValue,
+    call_block: Option<BlockId>,
+    callee: &Cfg,
+) -> Result<SpliceShape, CfgInlineError> {
+    if call.as_u32() as usize >= caller.value_count() {
+        return Err(CfgInlineError::CallSiteNotFound { call });
+    }
+    let (call_ty, call_span, call_args, is_accessor) = {
+        let inst = caller.get_inst(call);
+        match &inst.data {
+            CfgInstData::Call { runtime, args, .. } => {
+                if runtime.is_some() {
+                    return Err(CfgInlineError::RuntimeCall { call });
+                }
+                (inst.ty, inst.span, caller.call_args(args).to_vec(), false)
+            }
+            CfgInstData::AccessorCall { args, .. } => {
+                (inst.ty, inst.span, caller.call_args(args).to_vec(), true)
+            }
+            _ => return Err(CfgInlineError::NotACall { call }),
+        }
+    };
+    if let Some(call_block) = call_block {
+        if call_block.as_u32() as usize >= caller.block_count()
+            || !caller.get_block(call_block).insts.contains(&call)
+        {
+            return Err(CfgInlineError::CallSiteNotFound { call });
+        }
+    }
+    if !callee.get_block(callee.entry).params.is_empty() {
+        return Err(CfgInlineError::CalleeEntryHasParams);
+    }
+    let params = callee_params(callee);
+    if params.len() != call_args.len() {
+        return Err(CfgInlineError::ArityMismatch {
+            call_args: call_args.len(),
+            callee_params: params.len(),
+        });
+    }
+    let mut materialized_params = 0u64;
+    for (index, (param, arg)) in params.iter().zip(&call_args).enumerate() {
+        if callee.is_param_by_ref(param.start_slot) {
+            byref_argument_place(caller, arg.value, index)?;
+        } else {
+            materialized_params =
+                materialized_params
+                    .checked_add(1)
+                    .ok_or(CfgInlineError::Edit(CfgEditError::ResourceLimitExceeded {
+                        family: "inline growth",
+                    }))?;
+        }
+    }
+    Ok(SpliceShape {
+        call_ty,
+        call_span,
+        call_args,
+        is_accessor,
+        params,
+        materialized_params,
+    })
+}
+
 /// Splice one call without minting the proof that the result is well formed.
 ///
 /// [`inline_call_in_block`] is this plus a verification, and a driver inlining
@@ -305,27 +411,12 @@ pub fn splice_call_in_block(
     let mut dst: Cfg = caller.clone();
 
     // -- Locate and validate the call site. ---------------------------------
-    if call.as_u32() as usize >= dst.value_count() {
-        return Err(CfgInlineError::CallSiteNotFound { call });
-    }
-    let (call_ty, call_span, call_args, is_accessor) = {
-        let inst = dst.get_inst(call);
-        match &inst.data {
-            CfgInstData::Call { runtime, args, .. } => {
-                if runtime.is_some() {
-                    return Err(CfgInlineError::RuntimeCall { call });
-                }
-                (inst.ty, inst.span, dst.call_args(args).to_vec(), false)
-            }
-            CfgInstData::AccessorCall { args, .. } => {
-                (inst.ty, inst.span, dst.call_args(args).to_vec(), true)
-            }
-            _ => return Err(CfgInlineError::NotACall { call }),
-        }
-    };
-    if call_block.as_u32() as usize >= dst.block_count() {
-        return Err(CfgInlineError::CallSiteNotFound { call });
-    }
+    let shape = splice_shape(&dst, call, Some(call_block), callee)?;
+    let call_ty = shape.call_ty;
+    let call_span = shape.call_span;
+    let call_args = shape.call_args;
+    let is_accessor = shape.is_accessor;
+    let params = shape.params;
     let Some(call_position) = dst
         .get_block(call_block)
         .insts
@@ -340,18 +431,7 @@ pub fn splice_call_in_block(
             callee_return_type: callee.return_type(),
         });
     }
-    if !callee.get_block(callee.entry).params.is_empty() {
-        return Err(CfgInlineError::CalleeEntryHasParams);
-    }
-
     // -- Lower each parameter by its physical ABI. --------------------------
-    let params = callee_params(callee);
-    if params.len() != call_args.len() {
-        return Err(CfgInlineError::ArityMismatch {
-            call_args: call_args.len(),
-            callee_params: params.len(),
-        });
-    }
     let mut redirects: AHashMap<u32, ParamRedirect> = AHashMap::new();
     // Materialized by-value parameter regions: (base slot, argument, type).
     let mut materialized: Vec<(u32, CfgValue, Type)> = Vec::new();
@@ -405,6 +485,11 @@ pub fn splice_call_in_block(
         };
         redirects.insert(param.start_slot, redirect);
     }
+    assert_eq!(
+        shape.materialized_params,
+        u64::try_from(materialized.len()).unwrap_or(u64::MAX),
+        "splice plan and materialization lowering must agree"
+    );
 
     // -- Rebase the callee's frame onto the caller's. -----------------------
     let local_base = if callee.num_locals() > 0 {
@@ -586,6 +671,22 @@ pub fn splice_call_in_block(
     }
 
     Ok(dst)
+}
+
+/// Return the exact value and basic-block growth that
+/// [`splice_call_in_block`] will append, without cloning or mutating either
+/// CFG. This is the canonical growth calculation for callers that need to
+/// apply a code-growth policy before importing metadata or constructing a
+/// candidate. It is derived from the same read-only splice shape consumed by
+/// the mutating primitive: the callee value arena already includes block
+/// parameters, so only the ordinary continuation value and materialization
+/// storage are added.
+pub fn splice_call_growth(
+    caller: &Cfg,
+    call: CfgValue,
+    callee: &Cfg,
+) -> Result<crate::opt::CodeGrowth, CfgInlineError> {
+    splice_shape(caller, call, None, callee)?.growth(callee)
 }
 
 fn substitute_accessor_places(
@@ -1098,7 +1199,21 @@ mod tests {
 
         fn try_inline(&self, caller: &str, callee: &str) -> Result<ValidatedCfg, CfgInlineError> {
             let call = self.find_call(caller, callee);
-            inline_call(self.cfg(caller), call, self.cfg(callee), &self.type_pool)
+            let caller_cfg = self.cfg(caller);
+            let callee_cfg = self.cfg(callee);
+            let growth = splice_call_growth(caller_cfg, call, callee_cfg)?;
+            let inlined = inline_call(caller_cfg, call, callee_cfg, &self.type_pool)?;
+            assert_eq!(
+                growth.values,
+                (inlined.value_count() - caller_cfg.value_count()) as u64,
+                "growth preflight must match every successful test splice"
+            );
+            assert_eq!(
+                growth.blocks,
+                (inlined.block_count() - caller_cfg.block_count()) as u64,
+                "block growth preflight must match every successful test splice"
+            );
+            Ok(inlined)
         }
     }
 
@@ -1588,6 +1703,179 @@ mod tests {
         );
         assert_eq!(count_calls(&inlined), 0);
         assert_all_blocks_terminated(&inlined);
+    }
+
+    #[test]
+    fn growth_preflight_matches_the_actual_splice_delta() {
+        let mut program = scalar_program();
+        program.add("callee", |_| scalar_increment_callee());
+        program.add("caller", |interner| {
+            let mut cfg = Cfg::new(Type::I64, 0, 0, "caller".to_string(), Vec::<bool>::new());
+            let entry = cfg.new_block();
+            cfg.entry = entry;
+            let argument = cfg.append_inst(entry, inst(CfgInstData::Const(20), Type::I64));
+            cfg.append_call(
+                entry,
+                None,
+                interner.get_or_intern("callee"),
+                [CfgCallArg {
+                    value: argument,
+                    mode: CfgArgMode::Normal,
+                }],
+                Type::I64,
+                Span::new(0, 0),
+            )
+            .unwrap();
+            cfg.set_return(entry, Some(argument));
+            cfg
+        });
+        let caller = program.cfg("caller").clone();
+        let callee = program.cfg("callee").clone();
+        let call = program.find_call("caller", "callee");
+        let call_block = caller
+            .blocks()
+            .iter()
+            .find(|block| block.insts.contains(&call))
+            .map(|block| block.id)
+            .unwrap();
+        let growth = splice_call_growth(&caller, call, &callee).unwrap();
+        let inlined =
+            splice_call_in_block(&caller, call, call_block, &callee, &program.type_pool).unwrap();
+        assert_eq!(
+            growth.values,
+            (inlined.value_count() - caller.value_count()) as u64
+        );
+        assert_eq!(
+            growth.blocks,
+            (inlined.block_count() - caller.block_count()) as u64
+        );
+    }
+
+    #[test]
+    fn growth_plan_counts_block_params_once_and_keeps_boundary_exact() {
+        let mut program = scalar_program();
+        program.add("branch", |_| {
+            let mut cfg = Cfg::new(Type::I64, 0, 1, "branch".to_string(), vec![true]);
+            let entry = cfg.new_block();
+            let then_block = cfg.new_block();
+            let else_block = cfg.new_block();
+            let join = cfg.new_block();
+            cfg.entry = entry;
+            let cond = cfg.append_inst(entry, inst(CfgInstData::Param { index: 0 }, Type::BOOL));
+            cfg.set_branch(entry, cond, then_block, [], else_block, []);
+            let one = cfg.append_inst(then_block, inst(CfgInstData::Const(1), Type::I64));
+            cfg.set_goto(then_block, join, [one]);
+            let zero = cfg.append_inst(else_block, inst(CfgInstData::Const(0), Type::I64));
+            cfg.set_goto(else_block, join, [zero]);
+            let result = cfg.add_block_param(join, Type::I64);
+            cfg.set_return(join, Some(result));
+            cfg
+        });
+        program.add("caller", |interner| {
+            let mut cfg = Cfg::new(Type::I64, 0, 1, "caller".to_string(), vec![false]);
+            let entry = cfg.new_block();
+            cfg.entry = entry;
+            let cond = cfg.append_inst(entry, inst(CfgInstData::Param { index: 0 }, Type::BOOL));
+            let call = cfg
+                .append_call(
+                    entry,
+                    None,
+                    interner.get_or_intern("branch"),
+                    [CfgCallArg {
+                        value: cond,
+                        mode: CfgArgMode::Normal,
+                    }],
+                    Type::I64,
+                    Span::default(),
+                )
+                .unwrap();
+            cfg.set_return(entry, Some(call));
+            cfg
+        });
+        let caller = program.cfg("caller");
+        let callee = program.cfg("branch");
+        let call = program.find_call("caller", "branch");
+        let growth = splice_call_growth(caller, call, callee).unwrap();
+        assert_eq!(growth.values, callee.value_count() as u64 + 1);
+        assert_eq!(growth.blocks, callee.block_count() as u64 + 1);
+        let inlined = inline_call(caller, call, callee, &program.type_pool).unwrap();
+        assert_eq!(
+            inlined.value_count() - caller.value_count(),
+            growth.values as usize
+        );
+        assert_eq!(
+            inlined.block_count() - caller.block_count(),
+            growth.blocks as usize
+        );
+
+        // A branch-heavy body at 255 values must fit exactly after its one
+        // ordinary continuation value; counting block parameters a second
+        // time would incorrectly refuse this 256-value charge.
+        let mut padded = (*callee).clone().into_editor();
+        while padded.value_count() < 255 {
+            let value = padded.append_inst(padded.entry, inst(CfgInstData::Const(0), Type::I64));
+            let _ = value;
+        }
+        let padded = padded.finish(&program.type_pool).unwrap();
+        let exact = splice_call_growth(caller, call, &padded).unwrap();
+        assert_eq!(exact.values, 256);
+        assert_eq!(exact.blocks, padded.block_count() as u64 + 1);
+        let mut budget = crate::opt::CodeGrowthBudget::o3();
+        assert!(budget.try_charge(crate::opt::CodeGrowthBudget::charge_for_growth(exact)));
+        assert!(
+            !budget.try_charge(crate::opt::CodeGrowthBudget::charge_for_growth(
+                crate::opt::CodeGrowth {
+                    values: 1,
+                    blocks: 1,
+                },
+            ))
+        );
+    }
+
+    #[test]
+    fn zero_value_block_heavy_shape_is_refused_before_splice() {
+        let mut program = scalar_program();
+        program.add("never_many_blocks", |_| {
+            let mut cfg = Cfg::new(
+                Type::NEVER,
+                0,
+                0,
+                "never_many_blocks".to_string(),
+                Vec::<bool>::new(),
+            );
+            cfg.entry = cfg.new_block();
+            cfg.set_unreachable(cfg.entry);
+            for _ in 0..257 {
+                cfg.new_block();
+            }
+            cfg
+        });
+        program.add("caller", |interner| {
+            let mut cfg = Cfg::new(Type::NEVER, 0, 0, "caller".to_string(), Vec::<bool>::new());
+            let entry = cfg.new_block();
+            cfg.entry = entry;
+            cfg.append_call(
+                entry,
+                None,
+                interner.get_or_intern("never_many_blocks"),
+                [],
+                Type::NEVER,
+                Span::default(),
+            )
+            .unwrap();
+            cfg.set_unreachable(entry);
+            cfg
+        });
+        let caller = program.cfg("caller");
+        let callee = program.cfg("never_many_blocks");
+        let call = program.find_call("caller", "never_many_blocks");
+        let growth = splice_call_growth(caller, call, callee).unwrap();
+        assert_eq!(growth.values, 0);
+        assert_eq!(growth.blocks, 259);
+        let charged = crate::opt::CodeGrowthBudget::charge_for_growth(growth);
+        assert_eq!(charged.values, 1);
+        assert_eq!(charged.blocks, 259);
+        assert!(!crate::opt::CodeGrowthBudget::o3().can_charge(charged));
     }
 
     // ------------------------------------------------------------------

--- a/crates/rue-cfg/src/lib.rs
+++ b/crates/rue-cfg/src/lib.rs
@@ -29,14 +29,16 @@ mod verify;
 use rue_error::{CompileError, CompileWarning};
 
 pub use build::CfgBuilder;
-pub use inline::{CfgInlineError, inline_call, inline_call_in_block, splice_call_in_block};
+pub use inline::{
+    CfgInlineError, inline_call, inline_call_in_block, splice_call_growth, splice_call_in_block,
+};
 pub use inst::{
     BasicBlock, BlockId, Cfg, CfgArgMode, CfgCallArg, CfgDisplay, CfgEditError,
     CfgEditTransactionError, CfgEditor, CfgInst, CfgInstData, CfgPayloadStorageStats,
     CfgRemapError, CfgValue, MAX_CFG_ENTITIES_PER_FUNCTION, MAX_CFG_PAYLOAD_WORDS_PER_PROGRAM,
     Place, PlaceBase, Projection, Terminator, ValidatedCfg,
 };
-pub use opt::OptLevel;
+pub use opt::{CodeGrowth, CodeGrowthBudget, OptLevel};
 #[doc(hidden)]
 #[cfg(any(test, feature = "fuzz-support"))]
 pub use payload::fuzz_payload_corruption;

--- a/crates/rue-cfg/src/opt/mod.rs
+++ b/crates/rue-cfg/src/opt/mod.rs
@@ -125,6 +125,108 @@ pub struct OptimizationStats {
     pub loops_analyzed: u64,
     pub loops_unrolled: u64,
     pub budget_refusals: u64,
+    /// CFG values cloned by O3 growth transforms in this invocation.
+    pub code_growth_used: u64,
+    /// CFG blocks cloned by O3 growth transforms in this invocation.
+    pub code_growth_blocks_used: u64,
+}
+
+/// Exact growth attributed to one bounded transform operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CodeGrowth {
+    pub values: u64,
+    pub blocks: u64,
+}
+
+/// The per-function budget shared by O3 inlining and constant-trip unrolling.
+///
+/// The budget counts values and basic blocks allocated by growth transforms.
+/// Keeping the consumed amounts in this small value object lets the
+/// whole-program batch carry unrolling's charge into the later inlining phase
+/// and lets the re-optimization after a splice spend only what remains.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CodeGrowthBudget {
+    max_total_values: u64,
+    max_total_blocks: u64,
+    used_values: u64,
+    used_blocks: u64,
+}
+
+impl CodeGrowthBudget {
+    pub const O3_MAX_TOTAL_VALUES: u64 = 256;
+    /// The measured Lattice population has at most 68 blocks per CFG; 256 is
+    /// a conservative bounded-work ceiling that preserves ordinary fixed-loop
+    /// unrolling while bounding block-heavy growth.
+    pub const O3_MAX_TOTAL_BLOCKS: u64 = 256;
+
+    pub const fn o3() -> Self {
+        Self {
+            max_total_values: Self::O3_MAX_TOTAL_VALUES,
+            max_total_blocks: Self::O3_MAX_TOTAL_BLOCKS,
+            used_values: 0,
+            used_blocks: 0,
+        }
+    }
+
+    pub const fn with_used(used_values: u64, used_blocks: u64) -> Self {
+        Self {
+            max_total_values: Self::O3_MAX_TOTAL_VALUES,
+            max_total_blocks: Self::O3_MAX_TOTAL_BLOCKS,
+            used_values,
+            used_blocks,
+        }
+    }
+
+    pub const fn used(self) -> u64 {
+        self.used_values
+    }
+
+    pub const fn used_values(self) -> u64 {
+        self.used_values
+    }
+
+    pub const fn used_blocks(self) -> u64 {
+        self.used_blocks
+    }
+
+    pub const fn remaining(self) -> u64 {
+        self.max_total_values.saturating_sub(self.used_values)
+    }
+
+    pub const fn remaining_blocks(self) -> u64 {
+        self.max_total_blocks.saturating_sub(self.used_blocks)
+    }
+
+    /// Convert an exact splice/unroll delta into a bounded policy charge.
+    /// Ordinary never-returning bodies can have no value delta while still
+    /// copying blocks and terminators, so every accepted zero-value site
+    /// consumes at least one value unit. Accessor calls are not general
+    /// inlining candidates.
+    pub const fn charge_for_growth(growth: CodeGrowth) -> CodeGrowth {
+        CodeGrowth {
+            values: if growth.values == 0 { 1 } else { growth.values },
+            blocks: growth.blocks,
+        }
+    }
+
+    pub const fn can_charge(self, growth: CodeGrowth) -> bool {
+        let Some(new_values) = self.used_values.checked_add(growth.values) else {
+            return false;
+        };
+        let Some(new_blocks) = self.used_blocks.checked_add(growth.blocks) else {
+            return false;
+        };
+        new_values <= self.max_total_values && new_blocks <= self.max_total_blocks
+    }
+
+    pub fn try_charge(&mut self, growth: CodeGrowth) -> bool {
+        if !self.can_charge(growth) {
+            return false;
+        }
+        self.used_values += growth.values;
+        self.used_blocks += growth.blocks;
+        true
+    }
 }
 
 impl std::fmt::Display for CfgOptimizationError {
@@ -217,6 +319,21 @@ pub fn optimize_with_stats(
     level: OptLevel,
     type_pool: &FrozenTypeInternPool,
 ) -> Result<(ValidatedCfg, OptimizationStats), CfgOptimizationError> {
+    let (cfg, stats, _) = optimize_with_budget(cfg, level, type_pool, CodeGrowthBudget::o3())?;
+    Ok((cfg, stats))
+}
+
+/// Optimize with an existing O3 growth budget. The returned budget includes
+/// all growth accepted by this invocation and is used by the batch driver to
+/// coordinate later interprocedural inlining with earlier unrolling.
+pub fn optimize_with_budget(
+    cfg: ValidatedCfg,
+    level: OptLevel,
+    type_pool: &FrozenTypeInternPool,
+    mut budget: CodeGrowthBudget,
+) -> Result<(ValidatedCfg, OptimizationStats, CodeGrowthBudget), CfgOptimizationError> {
+    let initial_values = budget.used_values();
+    let initial_blocks = budget.used_blocks();
     let mut cfg = cfg.into_editor();
     let mut stats = OptimizationStats::default();
 
@@ -287,10 +404,13 @@ pub fn optimize_with_stats(
                     // Full constant-trip unrolling follows LICM and is
                     // followed by a mandatory cleanup fixpoint. Analyses are
                     // recomputed by the pass after every CFG mutation.
-                    let unroll = unroll::run(&mut cfg)?;
+                    let unroll = unroll::run_with_budget(&mut cfg, &mut budget)?;
                     stats.loops_analyzed = unroll.loops_analyzed;
                     stats.loops_unrolled = unroll.loops_unrolled;
                     stats.budget_refusals = unroll.budget_refusals;
+                    stats.code_growth_used = budget.used_values().saturating_sub(initial_values);
+                    stats.code_growth_blocks_used =
+                        budget.used_blocks().saturating_sub(initial_blocks);
                     constopt::run(&mut cfg);
                     simplify::run(&mut cfg)?;
                     dce::run(&mut cfg);
@@ -303,7 +423,7 @@ pub fn optimize_with_stats(
         Ok(())
     })();
 
-    publish_optimization(cfg, pass_result, type_pool).map(|cfg| (cfg, stats))
+    publish_optimization(cfg, pass_result, type_pool).map(|cfg| (cfg, stats, budget))
 }
 
 fn publish_optimization(
@@ -375,5 +495,35 @@ mod tests {
     #[test]
     fn test_opt_level_default() {
         assert_eq!(OptLevel::default(), OptLevel::O0);
+    }
+
+    #[test]
+    fn code_growth_budget_is_checked_and_carries_usage() {
+        let mut budget = CodeGrowthBudget::o3();
+        let growth = CodeGrowth {
+            values: 200,
+            blocks: 20,
+        };
+        assert!(budget.try_charge(growth));
+        assert_eq!(budget.used(), 200);
+        assert_eq!(budget.remaining(), 56);
+        assert_eq!(budget.used_blocks(), 20);
+        assert_eq!(budget.remaining_blocks(), 236);
+        assert!(!budget.try_charge(CodeGrowth {
+            values: 57,
+            blocks: 1,
+        }));
+        assert_eq!(budget.used(), 200);
+        assert!(!budget.try_charge(CodeGrowth {
+            values: 1,
+            blocks: 237,
+        }));
+        assert!(!budget.try_charge(CodeGrowth {
+            values: u64::MAX,
+            blocks: 0,
+        }));
+        let carried = CodeGrowthBudget::with_used(budget.used(), budget.used_blocks());
+        assert_eq!(carried.remaining(), 56);
+        assert_eq!(carried.remaining_blocks(), 236);
     }
 }

--- a/crates/rue-cfg/src/opt/unroll.rs
+++ b/crates/rue-cfg/src/opt/unroll.rs
@@ -17,17 +17,6 @@ use crate::{
 };
 use ahash::{AHashMap, AHashSet};
 
-/// Shared future code-growth policy (ADR-0049). Inlining can consume this same
-/// representation when its growth budget lands; this pass is the first user.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct CodeGrowthBudget {
-    pub max_total_instructions: u64,
-}
-
-pub(crate) const O3_CODE_GROWTH_BUDGET: CodeGrowthBudget = CodeGrowthBudget {
-    max_total_instructions: 256,
-};
-
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct Stats {
     pub forest_computations: u64,
@@ -49,9 +38,17 @@ struct Trip {
     slot: u32,
 }
 
+#[cfg(test)]
 pub fn run(cfg: &mut Cfg) -> Result<Stats, CfgOptimizationError> {
+    let mut budget = super::CodeGrowthBudget::o3();
+    run_with_budget(cfg, &mut budget)
+}
+
+pub fn run_with_budget(
+    cfg: &mut Cfg,
+    budget: &mut super::CodeGrowthBudget,
+) -> Result<Stats, CfgOptimizationError> {
     let mut stats = Stats::default();
-    let mut budget_used = 0u64;
     loop {
         stats.forest_computations += 1;
         let dom = DominatorTree::compute(cfg);
@@ -74,21 +71,38 @@ pub fn run(cfg: &mut Cfg) -> Result<Stats, CfgOptimizationError> {
                 stats.shape_refusals += 1;
                 continue;
             };
+            // Charge the same value axis used by inlining: every cloned
+            // block parameter and instruction consumes one budget unit.
             let body_size: u64 = lp
                 .body
                 .iter()
-                .map(|&b| u64::try_from(cfg.get_block(b).insts.len()).unwrap_or(u64::MAX))
+                .map(|&b| {
+                    let block = cfg.get_block(b);
+                    u64::try_from(block.params.len())
+                        .ok()
+                        .and_then(|params| {
+                            params.checked_add(u64::try_from(block.insts.len()).ok()?)
+                        })
+                        .unwrap_or(u64::MAX)
+                })
                 .try_fold(0u64, |a, b| a.checked_add(b))
                 .unwrap_or(u64::MAX);
-            let Some(growth) = trip.count.checked_mul(body_size) else {
+            let Some(growth_values) = trip.count.checked_mul(body_size) else {
                 stats.budget_refusals += 1;
                 continue;
             };
-            let Some(new_used) = budget_used.checked_add(growth) else {
+            let Some(growth_blocks) = trip
+                .count
+                .checked_mul(u64::try_from(lp.body.len()).unwrap_or(u64::MAX))
+            else {
                 stats.budget_refusals += 1;
                 continue;
             };
-            if new_used > O3_CODE_GROWTH_BUDGET.max_total_instructions {
+            let growth = super::CodeGrowth {
+                values: growth_values,
+                blocks: growth_blocks,
+            };
+            if !budget.try_charge(growth) {
                 stats.budget_refusals += 1;
                 continue;
             }
@@ -96,7 +110,6 @@ pub fn run(cfg: &mut Cfg) -> Result<Stats, CfgOptimizationError> {
             match unroll_one(&mut edited, lp, trip) {
                 Ok((blocks, values, instructions)) => {
                     *cfg = edited;
-                    budget_used = new_used;
                     stats.loops_unrolled += 1;
                     stats.blocks_cloned += blocks;
                     stats.values_cloned += values;
@@ -1155,10 +1168,21 @@ mod tests {
 
     #[test]
     fn budget_is_bounded_and_consumer_neutral() {
-        assert_eq!(O3_CODE_GROWTH_BUDGET.max_total_instructions, 256);
-        let used = 12u64.checked_add(200).unwrap();
-        assert!(used <= O3_CODE_GROWTH_BUDGET.max_total_instructions);
-        assert!(used.checked_add(100).unwrap() > O3_CODE_GROWTH_BUDGET.max_total_instructions);
+        let mut budget = super::super::CodeGrowthBudget::o3();
+        assert!(budget.try_charge(super::super::CodeGrowth {
+            values: 12,
+            blocks: 4,
+        }));
+        assert!(budget.try_charge(super::super::CodeGrowth {
+            values: 200,
+            blocks: 20,
+        }));
+        assert_eq!(budget.used(), 212);
+        assert_eq!(budget.remaining(), 44);
+        assert!(!budget.try_charge(super::super::CodeGrowth {
+            values: 100,
+            blocks: 1,
+        }));
     }
 
     #[test]
@@ -1223,8 +1247,29 @@ mod tests {
     }
 
     #[test]
-    fn instruction_budget_boundary_excludes_block_parameters() {
-        // The fixture has ten body instructions and no block parameters:
+    fn run_respects_budget_carried_from_another_growth_pass() {
+        let mut cfg = slot_loop(0, 3, false);
+        let mut budget = super::super::CodeGrowthBudget::with_used(250, 0);
+        let stats = run_with_budget(&mut cfg, &mut budget).unwrap();
+        assert_eq!(stats.loops_unrolled, 0);
+        assert_eq!(stats.budget_refusals, 1);
+        assert_eq!(budget.used(), 250);
+    }
+
+    #[test]
+    fn run_refuses_block_growth_before_cloning() {
+        let mut cfg = slot_loop(0, 3, false);
+        let mut budget = super::super::CodeGrowthBudget::with_used(0, 256);
+        let stats = run_with_budget(&mut cfg, &mut budget).unwrap();
+        assert_eq!(stats.loops_unrolled, 0);
+        assert_eq!(stats.budget_refusals, 1);
+        assert_eq!(budget.used(), 0);
+        assert_eq!(budget.used_blocks(), 256);
+    }
+
+    #[test]
+    fn value_budget_boundary_includes_block_parameters() {
+        // The fixture has ten body values and no block parameters:
         // 25 iterations fit under 256, while 26 do not.
         let mut accepted = slot_loop(0, 25, false);
         let accepted_stats = run(&mut accepted).unwrap();

--- a/crates/rue-cli-tests/cases/differential_opt.toml
+++ b/crates/rue-cli-tests/cases/differential_opt.toml
@@ -37,6 +37,27 @@ fn main() -> i32 {
 stdout = ""
 exit_code = 42
 
+# RUE-931: -O3 admits `middle` despite its nested `leaf` call, while -O2 keeps
+# the non-leaf boundary. The untaken divide-by-zero arm pins trap preservation;
+# the two calls and debug output pin source evaluation order.
+[[case]]
+name = "o3_non_leaf_inlining_preserves_order_and_traps"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+fn leaf(x: i32) -> i32 { x + 1 }
+
+fn middle(x: i32) -> i32 {
+    if x == 0 { 1 / x } else { leaf(x) }
+}
+
+fn main() -> i32 {
+    @dbg(middle(4));
+    middle(5)
+}
+""" }]
+stdout = "5\n"
+exit_code = 6
+
 # Arithmetic: a spread of operators, widths, and folds. Constant-heavy so the
 # const-fold pass has plenty to chew on; the runtime baseline (-O0) must agree.
 [[case]]

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -66,6 +66,23 @@ pub struct CfgConstructionWork {
     pub optimization_loops_analyzed: usize,
     pub optimization_loops_unrolled: usize,
     pub optimization_budget_refusals: usize,
+    pub optimization_inline_budget_refusals: usize,
+    pub optimization_inline_importability_refusals: usize,
+    pub optimization_inline_importability_checks: usize,
+    pub optimization_inline_import_attempts: usize,
+    pub optimization_inline_interner_stages: usize,
+    pub optimization_inline_growth_preflights: usize,
+    /// Total values charged by the shared O3 growth budget, including both
+    /// local unrolling and accepted general inlining.
+    pub optimization_code_growth_used: usize,
+    /// Total basic blocks charged by the shared O3 growth budget.
+    pub optimization_code_growth_blocks_used: usize,
+    pub optimization_inline_code_growth_used: usize,
+    pub optimization_inline_code_growth_blocks_used: usize,
+    pub optimization_reoptimization_attempts: usize,
+    pub optimization_reoptimization_completions: usize,
+    pub optimization_reoptimization_code_growth_used: usize,
+    pub optimization_reoptimization_code_growth_blocks_used: usize,
     pub cfg_warnings_emitted: usize,
     pub cfg_reuse_candidates: usize,
     pub cfg_reuses: usize,

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -537,6 +537,10 @@ pub(crate) struct CfgRecord {
     pub(crate) num_locals: u32,
     pub(crate) num_param_slots: u32,
     pub(crate) cfg: rue_cfg::ValidatedCfg,
+    /// O3 growth already spent while producing this per-function CFG. The
+    /// whole-program batch carries this charge into general inlining.
+    pub(crate) code_growth_used: u64,
+    pub(crate) code_growth_blocks_used: u64,
     pub(crate) domains: crate::durable_cfg::CfgDomainProjection,
     pub(crate) type_pool: rue_air::FrozenTypeInternPool,
     pub(crate) interner: Arc<lasso::ThreadedRodeo>,
@@ -1696,6 +1700,8 @@ fn build_cfg(
         cfg: output
             .cfg
             .expect("successful CFG construction publishes a validated CFG"),
+        code_growth_used: 0,
+        code_growth_blocks_used: 0,
         domains,
         type_pool: materialized.type_pool,
         interner: materialized.interner,
@@ -1963,12 +1969,14 @@ pub(crate) fn evaluate_optimized_cfg(
         current,
         &record.type_pool,
         record.body_span,
-        move |cfg| CfgRecord {
+        move |cfg, code_growth_used, code_growth_blocks_used| CfgRecord {
             air: record.air.clone(),
             source_name: record.source_name.clone(),
             num_locals: record.num_locals,
             num_param_slots: record.num_param_slots,
             cfg,
+            code_growth_used,
+            code_growth_blocks_used,
             domains,
             type_pool: record.type_pool.clone(),
             interner,
@@ -2016,12 +2024,14 @@ fn optimize_cfg_without_accessors(
         record.cfg.clone(),
         &record.type_pool,
         record.body_span,
-        |cfg| CfgRecord {
+        |cfg, code_growth_used, code_growth_blocks_used| CfgRecord {
             air: record.air.clone(),
             source_name: record.source_name.clone(),
             num_locals: record.num_locals,
             num_param_slots: record.num_param_slots,
             cfg,
+            code_growth_used,
+            code_growth_blocks_used,
             domains: record.domains.clone(),
             type_pool: record.type_pool.clone(),
             interner: record.interner.clone(),
@@ -2173,6 +2183,10 @@ pub(crate) fn apply_general_inlining(
         })
         .collect::<std::collections::BTreeMap<_, _>>();
     let recursive = recursive_scc_nodes(&graph);
+    let batch_opt_level = keys
+        .first()
+        .map(|key| key.opt_level)
+        .unwrap_or(rue_cfg::OptLevel::O0);
     // Membership and by-key lookup only; `records` keeps its ordered iteration
     // above, and `recursive` its ordered construction. Both are probed once per
     // call site below, where a `BTree` probe means walking a recursive identity.
@@ -2192,13 +2206,18 @@ pub(crate) fn apply_general_inlining(
         let Some(record) = record_lookup.get(function).copied() else {
             return false;
         };
-        if recursive_set.contains(function)
-            || has_calls.get(function).copied().unwrap_or(true)
-            || !phase2_size_eligible(record.cfg.value_count())
-        {
+        if recursive_set.contains(function) || !is_true_free_function(function) {
             return false;
         }
-        if !is_true_free_function(function) {
+        let size_eligible = match batch_opt_level {
+            rue_cfg::OptLevel::O2 => {
+                !has_calls.get(function).copied().unwrap_or(true)
+                    && phase2_size_eligible(record.cfg.value_count())
+            }
+            rue_cfg::OptLevel::O3 => phase3_size_eligible(record.cfg.value_count()),
+            rue_cfg::OptLevel::O0 | rue_cfg::OptLevel::O1 => false,
+        };
+        if !size_eligible {
             return false;
         }
         matches!(
@@ -2249,7 +2268,7 @@ pub(crate) fn apply_general_inlining(
         };
         let mut domains = record.domains.clone();
         let mut strings = record.strings.to_vec();
-        let interner = match copy_interner_preserving_ordinals(&record.interner, || {
+        let mut interner = match copy_interner_preserving_ordinals(&record.interner, || {
             context.check_canceled()
         }) {
             Ok(interner) => Arc::new(interner),
@@ -2288,29 +2307,131 @@ pub(crate) fn apply_general_inlining(
         // it through this loop re-proved the whole caller after every splice,
         // over a caller each splice had just made bigger: 2,112 verifications
         // for 760 spliced functions, 150,324,778 instructions on a fresh
-        // Lattice compile. Nothing read those proofs -- `optimize` below
+        // Lattice compile. Nothing read those proofs -- `optimize_with_budget` below
         // demands a `ValidatedCfg` and mints its own, so the graph that
         // reaches a consumer is verified exactly as strictly as before.
         let mut current: rue_cfg::Cfg = (*record.cfg).clone();
+        let mut growth_budget = (key.opt_level == rue_cfg::OptLevel::O3).then(|| {
+            rue_cfg::opt::CodeGrowthBudget::with_used(
+                record.code_growth_used,
+                record.code_growth_blocks_used,
+            )
+        });
         let mut spliced = false;
         let mut failed = None;
+        let mut importability_cache = ahash::AHashMap::<
+            crate::FunctionInstanceKey,
+            Result<(), crate::durable_cfg::CfgDomainFailure>,
+        >::new();
         for (call, callee_function) in selected {
+            context.check_canceled()?;
             let Some(callee) = record_lookup.get(&callee_function).copied() else {
                 continue;
             };
-            let (callee_cfg, string_map) = match domains.import_accessor_cfg(
+            let growth = match rue_cfg::splice_call_growth(&current, call, &callee.cfg) {
+                Ok(growth) => growth,
+                Err(error) => {
+                    failed = Some(format!("general inline growth preflight failed: {error}"));
+                    break;
+                }
+            };
+            let growth_charge = rue_cfg::opt::CodeGrowthBudget::charge_for_growth(growth);
+            context.record_work(rue_query::WorkItem::new(
+                "cfg.general-inline-growth-preflights",
+                1,
+            ));
+            if growth_budget
+                .as_ref()
+                .is_some_and(|budget| !budget.can_charge(growth_charge))
+            {
+                context.record_work(rue_query::WorkItem::new(
+                    "cfg.general-inline-budget-refusals",
+                    1,
+                ));
+                continue;
+            }
+            let importability = if let Some(result) = importability_cache.get(&callee_function) {
+                result.clone()
+            } else {
+                context.record_work(rue_query::WorkItem::new(
+                    "cfg.general-inline-importability-checks",
+                    1,
+                ));
+                let result = domains.check_importable(&callee.domains);
+                importability_cache.insert(callee_function.clone(), result.clone());
+                result
+            };
+            if let Err(error) = importability {
+                if matches!(
+                    error,
+                    crate::durable_cfg::CfgDomainFailure::MissingStableType(_)
+                ) {
+                    context.record_work(rue_query::WorkItem::new(
+                        "cfg.general-inline-importability-refusals",
+                        1,
+                    ));
+                    continue;
+                }
+                failed = Some(format!(
+                    "general inline importability check failed: {error:?}"
+                ));
+                break;
+            }
+            let call_block = current
+                .blocks()
+                .iter()
+                .find(|block| block.insts.contains(&call))
+                .map(|block| block.id)
+                .ok_or_else(|| format!("general inline call site {call} is detached"));
+            let call_block = match call_block {
+                Ok(block) => block,
+                Err(error) => {
+                    failed = Some(error);
+                    break;
+                }
+            };
+            // Domain import allocates symbols/strings and mutates its
+            // projection before remapping the CFG. Keep those mutations in a
+            // candidate projection until the splice itself succeeds; a
+            // malformed or otherwise refused candidate must not publish
+            // metadata for a call that was never accepted.
+            let mut candidate_domains = domains.clone();
+            let mut candidate_strings = strings.clone();
+            // `import_accessor_cfg` interns symbols while it remaps the callee.
+            // Keep that resource mutation transactional too: a later remap or
+            // splice failure must not leave an unused symbol in a caller that
+            // nevertheless publishes an earlier accepted splice.
+            let candidate_interner =
+                match copy_interner_preserving_ordinals(&interner, || context.check_canceled()) {
+                    Ok(interner) => Arc::new(interner),
+                    Err(CfgInternerCopyFailure::Checkpoint(abort)) => return Err(abort),
+                    Err(error) => {
+                        failed = Some(format!("general inlining interner staging failed: {error}"));
+                        break;
+                    }
+                };
+            context.record_work(rue_query::WorkItem::new(
+                "cfg.general-inline-interner-stages",
+                1,
+            ));
+            context.record_work(rue_query::WorkItem::new(
+                "cfg.general-inline-import-attempts",
+                1,
+            ));
+            let (callee_cfg, string_map) = match candidate_domains.import_accessor_cfg(
                 &callee.domains,
                 &callee.cfg,
                 &callee.interner,
-                &interner,
-                &mut strings,
+                &candidate_interner,
+                &mut candidate_strings,
                 callee.body_span,
             ) {
                 Ok(value) => value,
                 Err(crate::durable_cfg::CfgDomainFailure::MissingStableType(_)) => {
                     // A body-local type domain that is not present in the
                     // caller cannot be imported without widening the caller's
-                    // immutable type pool. It is outside conservative Phase 2.
+                    // immutable type pool. It is outside the conservative
+                    // inlining domain.
                     continue;
                 }
                 Err(error) => {
@@ -2329,6 +2450,8 @@ pub(crate) fn apply_general_inlining(
                     break;
                 }
             };
+            let mut imported_atoms = Vec::new();
+            let mut imported_atom_identities = ahash::AHashSet::new();
             for atom in callee.local_atoms.iter() {
                 let Some(dense_id) = string_map.get(&atom.dense_id).copied() else {
                     failed = Some("general inline local atom has no imported string id".to_owned());
@@ -2336,12 +2459,44 @@ pub(crate) fn apply_general_inlining(
                 };
                 let mut atom = atom.clone();
                 atom.dense_id = dense_id;
-                if local_atom_identities.insert(atom.identity.clone()) {
-                    local_atoms.push(atom);
+                if !local_atom_identities.contains(&atom.identity)
+                    && imported_atom_identities.insert(atom.identity.clone())
+                {
+                    imported_atoms.push(atom);
                 }
             }
             if failed.is_some() {
                 break;
+            }
+            let candidate = match rue_cfg::splice_call_in_block(
+                &current,
+                call,
+                call_block,
+                &callee_cfg,
+                &record.type_pool,
+            ) {
+                Ok(cfg) => cfg,
+                Err(error) => {
+                    failed = Some(format!("general inline splice failed: {error}"));
+                    break;
+                }
+            };
+            if let Some(budget) = growth_budget.as_mut() {
+                assert!(
+                    budget.can_charge(growth_charge),
+                    "general inline growth preflight must precede the splice"
+                );
+                if !budget.try_charge(growth_charge) {
+                    failed = Some("general inline growth budget changed during splice".to_owned());
+                    break;
+                }
+            }
+            domains = candidate_domains;
+            strings = candidate_strings;
+            interner = candidate_interner;
+            for atom in imported_atoms {
+                local_atom_identities.insert(atom.identity.clone());
+                local_atoms.push(atom);
             }
             symbol_mappings.extend(
                 callee
@@ -2355,33 +2510,18 @@ pub(crate) fn apply_general_inlining(
             implicit_drop_glue_targets.extend(callee.implicit_drop_glue_targets.iter().cloned());
             implicit_destructor_dependencies_complete &=
                 callee.implicit_destructor_dependencies_complete;
-            let call_block = current
-                .blocks()
-                .iter()
-                .find(|block| block.insts.contains(&call))
-                .map(|block| block.id)
-                .ok_or_else(|| format!("general inline call site {call} is detached"));
-            let call_block = match call_block {
-                Ok(block) => block,
-                Err(error) => {
-                    failed = Some(error);
-                    break;
-                }
-            };
-            current = match rue_cfg::splice_call_in_block(
-                &current,
-                call,
-                call_block,
-                &callee_cfg,
-                &record.type_pool,
-            ) {
-                Ok(cfg) => cfg,
-                Err(error) => {
-                    failed = Some(format!("general inline splice failed: {error}"));
-                    break;
-                }
-            };
+            current = candidate;
             spliced = true;
+            if growth_budget.is_some() {
+                context.record_work(rue_query::WorkItem::new(
+                    "cfg.general-inline-code-growth",
+                    growth_charge.values,
+                ));
+                context.record_work(rue_query::WorkItem::new(
+                    "cfg.general-inline-code-growth-blocks",
+                    growth_charge.blocks,
+                ));
+            }
             context.record_work(rue_query::WorkItem::new("cfg.general-inline-splices", 1));
         }
         if let Some(error) = failed {
@@ -2402,8 +2542,15 @@ pub(crate) fn apply_general_inlining(
                 continue;
             }
         };
-        let current = match rue_cfg::opt::optimize(current, key.opt_level, &record.type_pool) {
-            Ok(cfg) => cfg,
+        let budget = growth_budget.unwrap_or_else(rue_cfg::opt::CodeGrowthBudget::o3);
+        context.record_work(rue_query::WorkItem::new("cfg.reoptimize.attempts", 1));
+        let (current, stats, budget) = match rue_cfg::opt::optimize_with_budget(
+            current,
+            key.opt_level,
+            &record.type_pool,
+            budget,
+        ) {
+            Ok(result) => result,
             Err(error) => {
                 output[index] = internal_failure(
                     format!("general inline reoptimization failed: {error:?}"),
@@ -2412,6 +2559,27 @@ pub(crate) fn apply_general_inlining(
                 continue;
             }
         };
+        context.record_work(rue_query::WorkItem::new(
+            "cfg.optimize.loops-analyzed",
+            stats.loops_analyzed,
+        ));
+        context.record_work(rue_query::WorkItem::new(
+            "cfg.optimize.loops-unrolled",
+            stats.loops_unrolled,
+        ));
+        context.record_work(rue_query::WorkItem::new(
+            "cfg.optimize.budget-refusals",
+            stats.budget_refusals,
+        ));
+        context.record_work(rue_query::WorkItem::new(
+            "cfg.reoptimize.code-growth-used",
+            stats.code_growth_used,
+        ));
+        context.record_work(rue_query::WorkItem::new(
+            "cfg.reoptimize.code-growth-blocks-used",
+            stats.code_growth_blocks_used,
+        ));
+        context.record_work(rue_query::WorkItem::new("cfg.reoptimize.completions", 1));
         let interner_retained_charge = frozen_interner_retained_charge(&interner);
         output[index] = CfgValue::Available(Arc::new(CfgRecord {
             air: record.air.clone(),
@@ -2419,6 +2587,8 @@ pub(crate) fn apply_general_inlining(
             num_locals: record.num_locals,
             num_param_slots: record.num_param_slots,
             cfg: current,
+            code_growth_used: budget.used(),
+            code_growth_blocks_used: budget.used_blocks(),
             domains,
             type_pool: record.type_pool.clone(),
             interner,
@@ -2656,9 +2826,17 @@ fn whole_program_unreachable_checked<
 }
 
 const PHASE2_VALUE_CAP: usize = 32;
+/// O3 admits larger bodies after measuring the checked-in standalone examples:
+/// their O0 CFG bodies range from 23 to 75 values. A 96-value cap covers that
+/// observed set while leaving room below the long-tail helpers.
+const PHASE3_VALUE_CAP: usize = 96;
 
 fn phase2_size_eligible(value_count: usize) -> bool {
     value_count <= PHASE2_VALUE_CAP
+}
+
+fn phase3_size_eligible(value_count: usize) -> bool {
+    value_count <= PHASE3_VALUE_CAP
 }
 
 fn is_true_free_function(function: &crate::FunctionInstanceKey) -> bool {
@@ -2750,15 +2928,20 @@ fn finish_cfg_optimization(
     cfg: rue_cfg::ValidatedCfg,
     type_pool: &rue_air::FrozenTypeInternPool,
     body_span: Span,
-    build_record: impl FnOnce(rue_cfg::ValidatedCfg) -> CfgRecord,
+    build_record: impl FnOnce(rue_cfg::ValidatedCfg, u64, u64) -> CfgRecord,
 ) -> QueryOutput<CfgValue> {
     context.record_work(rue_query::WorkItem::new("cfg.optimize.attempts", 1));
     context.record_work(rue_query::WorkItem::new(
         "cfg.optimize.nonzero-level",
         u64::from(key.opt_level != rue_cfg::OptLevel::O0),
     ));
-    match rue_cfg::opt::optimize_with_stats(cfg, key.opt_level, type_pool) {
-        Ok((cfg, stats)) => {
+    match rue_cfg::opt::optimize_with_budget(
+        cfg,
+        key.opt_level,
+        type_pool,
+        rue_cfg::opt::CodeGrowthBudget::o3(),
+    ) {
+        Ok((cfg, stats, budget)) => {
             context.record_work(rue_query::WorkItem::new("cfg.optimize.successes", 1));
             context.record_work(rue_query::WorkItem::new(
                 "cfg.optimize.loops-analyzed",
@@ -2772,7 +2955,19 @@ fn finish_cfg_optimization(
                 "cfg.optimize.budget-refusals",
                 stats.budget_refusals,
             ));
-            QueryOutput::success(CfgValue::Available(Arc::new(build_record(cfg))))
+            context.record_work(rue_query::WorkItem::new(
+                "cfg.optimize.code-growth-used",
+                stats.code_growth_used,
+            ));
+            context.record_work(rue_query::WorkItem::new(
+                "cfg.optimize.code-growth-blocks-used",
+                stats.code_growth_blocks_used,
+            ));
+            QueryOutput::success(CfgValue::Available(Arc::new(build_record(
+                cfg,
+                budget.used(),
+                budget.used_blocks(),
+            ))))
         }
         Err(error) => {
             context.record_work(rue_query::WorkItem::new("cfg.optimize.failures", 1));
@@ -3101,6 +3296,13 @@ mod accessor_graph_tests {
     fn phase2_policy_keeps_the_32_value_boundary_exact() {
         assert!(phase2_size_eligible(PHASE2_VALUE_CAP));
         assert!(!phase2_size_eligible(PHASE2_VALUE_CAP + 1));
+    }
+
+    #[test]
+    fn phase3_policy_is_larger_and_inclusive_at_96_values() {
+        assert!(phase3_size_eligible(PHASE2_VALUE_CAP + 1));
+        assert!(phase3_size_eligible(PHASE3_VALUE_CAP));
+        assert!(!phase3_size_eligible(PHASE3_VALUE_CAP + 1));
     }
 
     #[test]

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -582,6 +582,25 @@ impl CfgDomainProjection {
     /// an accessor CFG, then remap that CFG into the extended domain. Accessor
     /// splicing preserves the callee's source spans and stable local atoms;
     /// only dense string ids and live type/symbol ids are relocated.
+    pub(crate) fn check_importable(&self, old: &Self) -> Result<(), CfgDomainFailure> {
+        if old.incomplete_epoch.is_some() || self.incomplete_epoch.is_some() {
+            return Err(CfgDomainFailure::Missing);
+        }
+        // Mirror the type-domain portion of import_accessor_cfg without
+        // mutating or allocating for the caller projection. This is
+        // intentionally based on durable stable-type mappings, not live
+        // handles, so a repeated unimportable site can be refused before
+        // cloning staging resources.
+        for (_, stable) in &old.types {
+            if live_primitive(stable).is_none()
+                && !self.types.iter().any(|(_, current)| current == stable)
+            {
+                return Err(CfgDomainFailure::MissingStableType(stable.clone()));
+            }
+        }
+        Ok(())
+    }
+
     pub(crate) fn import_accessor_cfg(
         &mut self,
         old: &Self,

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -2853,6 +2853,367 @@ mod tests {
     }
 
     #[test]
+    fn phase3_admits_non_leaf_inlining_in_one_bounded_wave() {
+        let snapshot = SourceSnapshot::single(
+            "<phase3-non-leaf-inline>",
+            "fn leaf(x: i32) -> i32 { x + 1 } fn middle(x: i32) -> i32 { leaf(x) } fn main() -> i32 { middle(4) }",
+        )
+        .unwrap();
+        let mut session = CompilerSession::new();
+        session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+
+        let main_call_count = |output: &RootedCfgOutput| {
+            output
+                .cfgs
+                .iter()
+                .find(|unit| unit.record.codegen.defined_symbol.ends_with("main"))
+                .map(|unit| {
+                    unit.record
+                        .cfg
+                        .blocks()
+                        .iter()
+                        .flat_map(|block| block.insts.iter())
+                        .filter(|value| {
+                            matches!(
+                                unit.record.cfg.get_inst(**value).data,
+                                rue_cfg::CfgInstData::Call { .. }
+                            )
+                        })
+                        .count()
+                })
+                .unwrap_or_default()
+        };
+        let has_unit = |output: &RootedCfgOutput, name: &str| {
+            output.cfgs.iter().any(|unit| {
+                matches!(
+                    &unit.function,
+                    FunctionInstanceKey::Definition(definition) if definition.name() == name
+                )
+            })
+        };
+
+        let o2 = session
+            .rooted_cfg(&CompileOptions {
+                opt_level: rue_cfg::OptLevel::O2,
+                ..CompileOptions::default()
+            })
+            .unwrap();
+        assert_eq!(main_call_count(&o2), 1);
+        assert!(has_unit(&o2, "middle"));
+        assert_eq!(o2.work().cfg.optimization_code_growth_used, 0);
+        assert_eq!(o2.work().cfg.optimization_inline_code_growth_used, 0);
+
+        let o3 = session
+            .rooted_cfg(&CompileOptions {
+                opt_level: rue_cfg::OptLevel::O3,
+                ..CompileOptions::default()
+            })
+            .unwrap();
+        assert_eq!(main_call_count(&o3), 1);
+        assert!(!has_unit(&o3, "middle"));
+        assert!(has_unit(&o3, "leaf"));
+        assert!(o3.work().cfg.optimization_code_growth_used > 0);
+        assert_eq!(
+            o3.work().cfg.optimization_code_growth_used,
+            o3.work().cfg.optimization_inline_code_growth_used
+        );
+
+        let o3_again = session
+            .rooted_cfg(&CompileOptions {
+                opt_level: rue_cfg::OptLevel::O3,
+                ..CompileOptions::default()
+            })
+            .unwrap();
+        assert_eq!(main_call_count(&o3), main_call_count(&o3_again));
+        assert_eq!(has_unit(&o3, "middle"), has_unit(&o3_again, "middle"));
+    }
+
+    #[test]
+    fn phase3_preflights_many_sites_before_budgeted_splices() {
+        let calls = (0..80)
+            .map(|value| format!("leaf({value})"))
+            .collect::<Vec<_>>()
+            .join(" + ");
+        let source = format!("fn leaf(x: i32) -> i32 {{ x + 1 }} fn main() -> i32 {{ {calls} }}");
+        let snapshot = SourceSnapshot::single("<phase3-budgeted-sites>", source).unwrap();
+        let mut session = CompilerSession::new();
+        session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+        let output = session
+            .rooted_cfg(&CompileOptions {
+                opt_level: rue_cfg::OptLevel::O3,
+                ..CompileOptions::default()
+            })
+            .unwrap();
+        let work = output.work().cfg;
+        assert_eq!(work.optimization_inline_growth_preflights, 80);
+        assert!(work.optimization_inline_budget_refusals > 0);
+        assert!(work.optimization_inline_code_growth_used > 0);
+        assert!(work.optimization_reoptimization_attempts > 0);
+        assert_eq!(
+            work.optimization_reoptimization_attempts,
+            work.optimization_reoptimization_completions
+        );
+        assert!(work.optimization_inline_code_growth_used <= 256);
+        assert!(work.optimization_inline_code_growth_blocks_used > 0);
+        assert!(work.optimization_inline_code_growth_blocks_used <= 256);
+        assert_eq!(
+            work.optimization_code_growth_used, work.optimization_inline_code_growth_used,
+            "this fixture has no loop growth, so total growth must be accepted inline growth"
+        );
+    }
+
+    #[test]
+    fn phase3_non_leaf_inlining_builds_for_both_backends() {
+        let snapshot = SourceSnapshot::single(
+            "<phase3-non-leaf-backends>",
+            "fn leaf(x: i32) -> i32 { x + 1 } fn middle(x: i32) -> i32 { leaf(x) } fn main() -> i32 { middle(4) }",
+        )
+        .unwrap();
+        for target in [Target::X86_64Linux, Target::Aarch64Linux] {
+            let mut session = CompilerSession::new();
+            session
+                .update_for_presentation(&snapshot)
+                .into_result()
+                .unwrap();
+            let output = session
+                .rooted_codegen(
+                    &CompileOptions {
+                        opt_level: rue_cfg::OptLevel::O3,
+                        target,
+                        ..CompileOptions::default()
+                    },
+                    rue_codegen::BackendArtifactRequest::default(),
+                )
+                .unwrap();
+            assert!(
+                !output.objects.is_empty(),
+                "O3 non-leaf backend object: {target}"
+            );
+        }
+    }
+
+    #[test]
+    fn phase3_thresholds_are_real_optimized_cfg_boundaries() {
+        fn source_for(target_values: usize) -> String {
+            let operations = if target_values.is_multiple_of(2) {
+                (target_values - 2) / 2
+            } else {
+                (target_values - 1) / 2
+            };
+            let mut expression = String::from("x");
+            for _ in 0..operations {
+                expression.push_str(" + 1");
+            }
+            if target_values.is_multiple_of(2) {
+                expression = format!("-({expression})");
+            }
+            format!("fn target(x: i32) -> i32 {{ {expression} }} fn main() -> i32 {{ target(1) }}")
+        }
+
+        fn optimized_target_values(snapshot: &SourceSnapshot, level: rue_cfg::OptLevel) -> usize {
+            let mut session = CompilerSession::new();
+            session
+                .update_for_presentation(snapshot)
+                .into_result()
+                .unwrap();
+            let output = session
+                .rooted_cfg(&CompileOptions {
+                    opt_level: level,
+                    ..CompileOptions::default()
+                })
+                .unwrap();
+            output
+                .cfgs
+                .iter()
+                .find(|unit| {
+                    matches!(
+                        &unit.function,
+                        FunctionInstanceKey::Definition(definition) if definition.name() == "target"
+                    )
+                })
+                .map(|unit| unit.record.cfg.value_count())
+                .unwrap_or_default()
+        }
+
+        fn main_calls(snapshot: &SourceSnapshot, level: rue_cfg::OptLevel) -> usize {
+            let mut session = CompilerSession::new();
+            session
+                .update_for_presentation(snapshot)
+                .into_result()
+                .unwrap();
+            let output = session
+                .rooted_cfg(&CompileOptions {
+                    opt_level: level,
+                    ..CompileOptions::default()
+                })
+                .unwrap();
+            output
+                .cfgs
+                .iter()
+                .find(|unit| {
+                    matches!(
+                        &unit.function,
+                        FunctionInstanceKey::Definition(definition) if definition.name() == "main"
+                    )
+                })
+                .map(|unit| {
+                    unit.record
+                        .cfg
+                        .blocks()
+                        .iter()
+                        .flat_map(|block| block.insts.iter())
+                        .filter(|value| {
+                            matches!(
+                                unit.record.cfg.get_inst(**value).data,
+                                rue_cfg::CfgInstData::Call { .. }
+                            )
+                        })
+                        .count()
+                })
+                .unwrap_or_default()
+        }
+
+        for (expected_values, level, accepted) in [
+            (32, rue_cfg::OptLevel::O2, true),
+            (33, rue_cfg::OptLevel::O2, false),
+            (96, rue_cfg::OptLevel::O3, true),
+            (97, rue_cfg::OptLevel::O3, false),
+        ] {
+            let snapshot = SourceSnapshot::single(
+                format!("<phase3-threshold-{expected_values}>"),
+                source_for(expected_values),
+            )
+            .unwrap();
+            assert_eq!(
+                optimized_target_values(&snapshot, rue_cfg::OptLevel::O1),
+                expected_values,
+                "calibrated source must retain the exact optimized CFG size"
+            );
+            assert_eq!(main_calls(&snapshot, level), usize::from(!accepted));
+        }
+    }
+
+    #[test]
+    fn phase3_shared_budget_carries_unrolling_into_inlining() {
+        let snapshot = SourceSnapshot::single(
+            "<phase3-shared-budget>",
+            "fn counted(limit: i32) -> i32 { let mut i: i32 = 0; let mut y: i32 = 0; while i < limit { y = y + 1; i = i + 1; } y } fn main() -> i32 { let mut i: i32 = 0; let mut sum: i32 = 0; while i < 20 { sum = sum + counted(10) + 1; i = i + 1; } sum }",
+        )
+        .unwrap();
+        let mut session = CompilerSession::new();
+        session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+        let output = session
+            .rooted_cfg(&CompileOptions {
+                opt_level: rue_cfg::OptLevel::O3,
+                ..CompileOptions::default()
+            })
+            .unwrap();
+        let work = output.work().cfg;
+        // The caller's 20-iteration loop clones 200 values/40 blocks. The
+        // first two inlined counted-loop bodies each cost 26 values/5 blocks;
+        // the third site is refused with four value units left. Inlining
+        // substitutes the constant `10` for `limit`, making the loop
+        // recognizable only during changed-caller reoptimization. Its exact
+        // 80-value/20-block growth fits a fresh budget but not the four-value
+        // remainder, so reoptimization must refuse it rather than resetting
+        // the shared budget.
+        const EXPECTED_INITIAL_UNROLL_VALUES: usize = 200;
+        const EXPECTED_INITIAL_UNROLL_BLOCKS: usize = 40;
+        const EXPECTED_INLINE_VALUES: usize = 52;
+        const EXPECTED_INLINE_BLOCKS: usize = 10;
+        const EXPECTED_REOPT_VALUES: usize = 0;
+        const EXPECTED_REOPT_BLOCKS: usize = 0;
+        const EXPECTED_REOPT_ATTEMPT_VALUES: u64 = 80;
+        const EXPECTED_REOPT_ATTEMPT_BLOCKS: u64 = 20;
+        const EXPECTED_TOTAL_VALUES: usize = 252;
+        const EXPECTED_TOTAL_BLOCKS: usize = 50;
+        assert_eq!(work.optimization_loops_unrolled, 1);
+        assert_eq!(
+            work.optimization_inline_code_growth_used,
+            EXPECTED_INLINE_VALUES
+        );
+        assert_eq!(
+            work.optimization_inline_code_growth_blocks_used,
+            EXPECTED_INLINE_BLOCKS
+        );
+        assert_eq!(
+            work.optimization_reoptimization_code_growth_used,
+            EXPECTED_REOPT_VALUES
+        );
+        assert_eq!(
+            work.optimization_reoptimization_code_growth_blocks_used,
+            EXPECTED_REOPT_BLOCKS
+        );
+        assert_eq!(work.optimization_code_growth_used, EXPECTED_TOTAL_VALUES);
+        assert_eq!(
+            work.optimization_code_growth_blocks_used,
+            EXPECTED_TOTAL_BLOCKS
+        );
+        assert_eq!(
+            work.optimization_code_growth_used,
+            EXPECTED_INITIAL_UNROLL_VALUES + EXPECTED_INLINE_VALUES + EXPECTED_REOPT_VALUES
+        );
+        assert_eq!(
+            work.optimization_code_growth_blocks_used,
+            EXPECTED_INITIAL_UNROLL_BLOCKS + EXPECTED_INLINE_BLOCKS + EXPECTED_REOPT_BLOCKS
+        );
+        assert_eq!(work.optimization_inline_budget_refusals, 18);
+        assert_eq!(work.optimization_budget_refusals, 2);
+        assert_eq!(work.optimization_loops_analyzed, 4);
+        assert_eq!(work.optimization_reoptimization_attempts, 1);
+        assert_eq!(
+            work.optimization_reoptimization_attempts,
+            work.optimization_reoptimization_completions
+        );
+        let mut fresh_budget = rue_cfg::opt::CodeGrowthBudget::o3();
+        assert!(fresh_budget.try_charge(rue_cfg::opt::CodeGrowth {
+            values: EXPECTED_REOPT_ATTEMPT_VALUES,
+            blocks: EXPECTED_REOPT_ATTEMPT_BLOCKS,
+        }));
+        assert_eq!(fresh_budget.used_values(), EXPECTED_REOPT_ATTEMPT_VALUES);
+        assert_eq!(fresh_budget.used_blocks(), EXPECTED_REOPT_ATTEMPT_BLOCKS);
+    }
+
+    #[test]
+    fn phase3_unimportable_sites_are_rejected_before_staging() {
+        let calls = (0..80)
+            .map(|value| format!("leaf({value})"))
+            .collect::<Vec<_>>()
+            .join(" + ");
+        let source = format!(
+            "struct Hidden {{ value: i32 }} fn leaf(x: i32) -> i32 {{ let hidden = Hidden {{ value: x }}; hidden.value }} fn main() -> i32 {{ {calls} }}"
+        );
+        let snapshot = SourceSnapshot::single("<phase3-unimportable-sites>", source).unwrap();
+        let mut session = CompilerSession::new();
+        session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+        let output = session
+            .rooted_cfg(&CompileOptions {
+                opt_level: rue_cfg::OptLevel::O3,
+                ..CompileOptions::default()
+            })
+            .unwrap();
+        let work = output.work().cfg;
+        assert_eq!(work.optimization_inline_growth_preflights, 80);
+        assert_eq!(work.optimization_inline_importability_refusals, 80);
+        assert_eq!(work.optimization_inline_importability_checks, 1);
+        assert_eq!(work.optimization_inline_import_attempts, 0);
+        assert_eq!(work.optimization_inline_interner_stages, 0);
+        assert_eq!(work.optimization_inline_code_growth_used, 0);
+    }
+
+    #[test]
     fn phase2_excludes_methods_from_general_inlining() {
         let snapshot = SourceSnapshot::single(
             "<phase2-method-exclusion>",

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -5514,6 +5514,38 @@ impl CompilerSession {
         work.cfg.optimization_loops_analyzed += batch_work("cfg.optimize.loops-analyzed");
         work.cfg.optimization_loops_unrolled += batch_work("cfg.optimize.loops-unrolled");
         work.cfg.optimization_budget_refusals += batch_work("cfg.optimize.budget-refusals");
+        work.cfg.optimization_inline_budget_refusals +=
+            batch_work("cfg.general-inline-budget-refusals");
+        work.cfg.optimization_inline_importability_refusals +=
+            batch_work("cfg.general-inline-importability-refusals");
+        work.cfg.optimization_inline_importability_checks +=
+            batch_work("cfg.general-inline-importability-checks");
+        work.cfg.optimization_inline_import_attempts +=
+            batch_work("cfg.general-inline-import-attempts");
+        work.cfg.optimization_inline_interner_stages +=
+            batch_work("cfg.general-inline-interner-stages");
+        work.cfg.optimization_inline_growth_preflights +=
+            batch_work("cfg.general-inline-growth-preflights");
+        let optimizer_code_growth = batch_work("cfg.optimize.code-growth-used");
+        let optimizer_code_growth_blocks = batch_work("cfg.optimize.code-growth-blocks-used");
+        let reoptimization_code_growth = batch_work("cfg.reoptimize.code-growth-used");
+        let reoptimization_code_growth_blocks =
+            batch_work("cfg.reoptimize.code-growth-blocks-used");
+        let inline_code_growth = batch_work("cfg.general-inline-code-growth");
+        let inline_code_growth_blocks = batch_work("cfg.general-inline-code-growth-blocks");
+        work.cfg.optimization_code_growth_used +=
+            optimizer_code_growth + inline_code_growth + reoptimization_code_growth;
+        work.cfg.optimization_code_growth_blocks_used += optimizer_code_growth_blocks
+            + inline_code_growth_blocks
+            + reoptimization_code_growth_blocks;
+        work.cfg.optimization_inline_code_growth_used += inline_code_growth;
+        work.cfg.optimization_inline_code_growth_blocks_used += inline_code_growth_blocks;
+        work.cfg.optimization_reoptimization_attempts += batch_work("cfg.reoptimize.attempts");
+        work.cfg.optimization_reoptimization_completions +=
+            batch_work("cfg.reoptimize.completions");
+        work.cfg.optimization_reoptimization_code_growth_used += reoptimization_code_growth;
+        work.cfg.optimization_reoptimization_code_growth_blocks_used +=
+            reoptimization_code_growth_blocks;
         work.cfg.cfg_warnings_emitted += batch_work("cfg.warnings");
         let optimized_reuses = executions
             .iter()

--- a/docs/designs/0044-optimization-levels.md
+++ b/docs/designs/0044-optimization-levels.md
@@ -54,12 +54,13 @@ but the mapping is:
 | `-O0` | Nothing. CFG passes straight to lowering (plus the always-on structural `verify()`). |
 | `-O1` | Constant folding ⇄ store-to-load constant propagation to a fixpoint, then dead-code elimination. |
 | `-O2` | `-O1` plus the conservative whole-program free-function inlining batch (RUE-930) and Phase 5 reachability elimination (RUE-933). |
-| `-O3` | `-O2` plus trap-free LICM (RUE-927) and bounded constant-trip unrolling (RUE-928); broader inlining thresholds and guarded hoisting remain planned. |
+| `-O3` | `-O2` plus trap-free LICM (RUE-927), bounded constant-trip unrolling (RUE-928), and larger-cap bounded non-leaf free-function inlining (RUE-931); guarded trapping-op hoisting remains planned. |
 
 The levels now have distinct behavior: `-O2`/`-O3` run the compiler's
 conservative whole-program inlining and reachability batch, and `-O3` adds the
-landed LICM and constant-trip unrolling passes. Broader inlining thresholds and
-guarded hoisting remain future work. RUE-245 asks us to *deliberately decide*
+landed LICM, constant-trip unrolling, and larger-cap bounded non-leaf inlining
+passes. Guarded trapping-op hoisting remains future work. RUE-245 asks us to
+*deliberately decide*
 what belongs at each level rather than leave the top two as accidental
 synonyms — both so users get the contract they expect from `-O` flags, and so
 that further passes already have a documented home.
@@ -67,11 +68,13 @@ that further passes already have a documented home.
 ### The current pipeline (ground truth)
 
 The optimizer lives entirely in `crates/rue-cfg/src/opt/` and runs as
-CFG → CFG transforms between CFG construction and MIR lowering. `optimize()` is
-the single choke point every build funnels through:
+CFG → CFG transforms between CFG construction and MIR lowering.
+`optimize_with_budget()` is the single choke point every build funnels through;
+the compiler batch later applies general inlining/DFE and calls it again for
+changed callers:
 
 ```
-AIR -> CfgBuilder -> CFG -> [opt::optimize(level)] -> [whole-program inlining/reachability at -O2/-O3] -> CfgLower -> MIR -> RegAlloc -> Emit
+AIR -> CfgBuilder -> CFG -> [opt::optimize_with_budget(level)] -> [whole-program inline/DFE batch] -> [changed-caller optimize_with_budget] -> CfgLower -> MIR -> RegAlloc -> Emit
 ```
 
 The passes that exist:
@@ -79,9 +82,9 @@ The passes that exist:
 - **`constfold.rs`** — folds arithmetic/comparison/bitwise/unary ops on
   `Const` operands (with overflow and div-by-zero guards). Complements the
   RIR-level `try_evaluate_const` from ADR-0003.
-- **`constprop.rs`** — store-to-load constant propagation for single-assignment
-  local slots, so constants flow through chains of `let`s (RUE-154). Interleaved
-  with `constfold` to a fixpoint.
+- **`constopt.rs`** — sparse store-to-load constant propagation and constant
+  folding for single-assignment local slots, revisiting dependent values to an
+  internal fixpoint (RUE-794).
 - **`dce.rs`** — liveness-based dead-code elimination: drops unused values and
   unreachable blocks, preserving side-effecting instructions (calls, stores,
   intrinsics, drops).
@@ -150,8 +153,9 @@ explicit and separate from the *optimization* dimension.
   reliably help without blowing up code size — CSE, peephole, better regalloc,
   conservative inlining. This is the level real software ships at.
 - **`-O3`** = `-O2` plus the *speculative* transforms that spend code size and
-  compile time to chase speed — aggressive inlining, loop unrolling, and
-  (eventually) vectorization — with no guarantee of a win on every program.
+  compile time to chase speed — bounded larger-cap non-leaf inlining, loop
+  unrolling, and (eventually) vectorization — with no guarantee of a win on
+  every program.
 - The size levels (`-Os`/`-Oz`) are a *separate* axis; Rue does not have them
   yet (see Future Work).
 
@@ -202,9 +206,9 @@ shapes each new pass targets (see Sequencing).
 | Level | Contract | Passes (today) | Passes (planned home) |
 |-------|----------|----------------|-----------------------|
 | `-O0` | No optimization. Codegen tracks source; fastest compile; best debugging. **Default.** | none (only always-on `verify()`) | stays empty |
-| `-O1` | Cheap, always-safe, compile-time-neutral-or-positive local cleanups. | sparse constfold/constprop (RUE-794) → peephole (RUE-912) → simplify-cfg (RUE-910/911) → DCE | complete for now |
+| `-O1` | Cheap, always-safe, compile-time-neutral-or-positive local cleanups. | sparse `constopt` (RUE-794) → peephole (RUE-912) → simplify-cfg (RUE-910/911) → DCE | complete for now |
 | `-O2` | **Release default.** All balanced optimizations that reliably help without a size blow-up. Superset of `-O1`. | `-O1` + copy propagation / store-to-load forwarding (RUE-914) → block-local CSE (RUE-913) → conservative whole-program inlining and Phase 5 reachability (RUE-930, RUE-933) | wider GVN; better regalloc |
-| `-O3` | `-O2` plus speculative, size-spending, speed-chasing transforms. Superset of `-O2`. | current O2 batch + trap-free LICM (RUE-927) + bounded constant-trip unrolling (RUE-928) | aggressive inlining; guarded trapping-op hoisting (RUE-934); later, vectorization |
+| `-O3` | `-O2` plus speculative, size-spending, speed-chasing transforms. Superset of `-O2`. | current O2 batch + trap-free LICM (RUE-927) + bounded constant-trip unrolling (RUE-928) + larger-cap bounded non-leaf inlining (RUE-931) | broader/profile-guided inlining; guarded trapping-op hoisting (RUE-934); later, vectorization |
 
 Rules that make the table a *contract* rather than a wishlist:
 
@@ -221,12 +225,13 @@ Rules that make the table a *contract* rather than a wishlist:
 
 ### How current passes map
 
-The local passes (`constfold`, `constprop`, `dce`) remain the cheap,
+The local passes (`constopt`, `dce`) remain the cheap,
 always-safe set at **`-O1`**. O2/O3 also run the canonical whole-program batch
 owned by `rue-compiler`, which performs conservative free-function inlining and
 post-inline reachability elimination while preserving O0/O1 source-faithful
-behavior. Broader O3 thresholds remain planned; the `mod.rs` level knob and
-these phase-specific additions are the current architecture.
+behavior. O3's larger-cap non-leaf inlining and constant-trip unrolling are
+bounded by their shared per-function growth budget; future profile-guided
+extensions remain separate policy decisions.
 
 ### How plausible future passes map
 
@@ -246,8 +251,8 @@ coverage. Placement follows the cost/risk triage above:
 - **Register-allocation quality improvements** (better spilling, coalescing):
   these live in `rue-codegen` (per-backend, post-CFG), but their *aggressiveness*
   is gated by the same level knob → tuned up at **`-O2`**.
-- **Aggressive inlining** (larger thresholds, hot call sites): may grow code →
-  **`-O3`**.
+- **Bounded larger-cap non-leaf inlining**: may grow code and compile time, so it
+  is gated at **`-O3`** and debited against the shared per-function budget.
 - **Loop optimizations** (invariant hoisting / LICM, unrolling): compile-time and
   size cost, speculative payoff → **`-O3`**.
 - **Range analysis / bounds-check elimination**: removes the dynamic test for
@@ -260,8 +265,8 @@ coverage. Placement follows the cost/risk triage above:
 ### Where the level knob lives
 
 `OptLevel` stays the single source of truth in `crates/rue-cfg/src/opt/mod.rs`,
-threaded through `optimize(cfg, level)`. As passes accrue, the `match` in
-`optimize()` gains per-level arms (e.g. `O2 | O3 => { cse::run(cfg); … }`)
+threaded through `optimize_with_budget(cfg, level, type_pool, budget)`. As passes
+accrue, its level match gains per-level arms (e.g. `O2 | O3 => { cse::run(cfg); … }`).
 layered on top of the `O1` set, preserving the monotonic-superset rule.
 Codegen-side knobs (regalloc aggressiveness) read the same `OptLevel` rather
 than inventing a parallel flag, so there is one dial for the whole pipeline.
@@ -281,9 +286,10 @@ phase-specific pieces are implemented in the current compiler.
   store-to-load forwarding (RUE-914), and conservative whole-program inlining
   plus Phase 5 reachability (RUE-930, RUE-933) have landed; broader GVN and
   other O2 tuning remain. (file RUE-NNN)
-- [ ] **Phase 4: `-O3` content** — partial: trap-free LICM (RUE-927) and bounded
-  constant-trip unrolling (RUE-928) have landed; aggressive inlining and guarded
-  trapping-op hoisting (RUE-934) remain. (file RUE-NNN)
+- [ ] **Phase 4: `-O3` content** — partial: trap-free LICM (RUE-927), bounded
+  constant-trip unrolling (RUE-928), and larger-cap bounded non-leaf inlining
+  (RUE-931) have landed; broader/profile-guided inlining and guarded trapping-op
+  hoisting (RUE-934) remain. (file RUE-NNN)
 - [ ] **Phase 5 (optional): size levels** — `-Os`/`-Oz` if a size-sensitive
   target (WASM/embedded) materializes. (file RUE-NNN)
 

--- a/docs/designs/0049-function-inlining.md
+++ b/docs/designs/0049-function-inlining.md
@@ -26,7 +26,9 @@ compiler's mandatory accessor splices
 (`crates/rue-compiler/src/cfg_query.rs`). RUE-930's conservative whole-program
 `-O2`/`-O3` free-function inlining batch is implemented in
 `crates/rue-compiler/src/cfg_query.rs`; this implementation also completes the
-accepted Phase 5 reachability step in that same batch. Phase 3/4 and the
+accepted Phase 5 reachability step in that same batch. Phase 3 is complete:
+O3 uses a 96-value callee cap, admits bounded non-leaf callees, and shares a
+256-value per-function growth budget with unrolling. Phase 4 and the
 method/destructor extension remain tracked separately.
 
 This note analyzes the architecture of function inlining and records the
@@ -34,12 +36,11 @@ accepted direction. ADR-0044 already fixed the *level*
 placement — conservative small/leaf-function inlining at `-O2`, aggressive
 thresholds at `-O3` — so this note answers the *architecture* questions that
 sit under that placement: where inlining runs, what it does mechanically to the
-CFG IR, how it integrates with the **already-landed durable CFG cache**, how it
+CFG IR, how it integrates with the **revisioned optimized-CFG query**, how it
 handles **parameter ownership and drop**, and how it stays inside the
-observable-behavior invariant. Since the durable CFG cache (`DurableCfgArtifact`)
-and the parameter-mode physical ABI both landed since the first draft, **durable
-caching and parameter ownership are core design constraints here, not deferred
-implementation details**. Tracks RUE-915.
+observable-behavior invariant. The query's terminal/cone retention boundary and
+the parameter-mode physical ABI are core design constraints here. Tracks
+RUE-915.
 
 ## Summary
 
@@ -47,60 +48,60 @@ Inlining replaces a `Call` to a suitable callee with a copy of the callee's body
 spliced into the caller, renumbered onto the caller's frame and value space, so
 that intra-procedural passes (constant folding/propagation, peephole, CFG
 simplification, value forwarding, CSE, DCE, and the future loop passes) can then
-see across the former call boundary. The central tension
-is that Rue's optimizer is today strictly **per-function**: `build_functions_and_cfgs`
-builds and optimizes each function's CFG independently and in parallel
-(`crates/rue-compiler/src/queries.rs:198`, `into_par_iter().map(...)`), whereas
-inlining is inherently **cross-function** — it needs the callee's body while
-optimizing the caller. This note recommends running inlining as a **dedicated
-inter-procedural stage orchestrated by `rue-compiler`, operating on already-built
-callee CFGs**, sequenced between CFG construction and the existing per-function
-`opt::optimize` pass. That choice keeps `rue-cfg`'s passes purely local and
-reuses the CFG the builder already produces.
+see across the former call boundary. The central tension is that Rue's local
+optimizer remains strictly **per-function** while general inlining is
+inherently **cross-function**. Each optimized-CFG query builds (or imports) one
+function, runs its local `rue_cfg::opt::optimize_with_budget`, and publishes that optimized
+record. The compiler then runs one deterministic whole-program batch over those
+records: it discovers call sites, applies the inline/DFE policy, and
+re-optimizes only changed callers with the carried O3 growth budget. The CFG
+splice primitive remains in `rue-cfg`; `rue-compiler` owns the callee map,
+policy, metadata, cache/query boundaries, and batch orchestration. This keeps
+local passes single-function while giving inlining the whole-program view it
+requires.
 
 Two consequences are load-bearing and are given their own decision sections:
 
-- **Durable cache integration is not optional and cannot be deferred.** Rue
-  already retains, imports, and exports optimized `DurableCfgArtifact`s keyed by
-  optimization level and target (`crates/rue-compiler/src/queries.rs:137`,
-  `217-232`, `330-343`). Inlining changes *what* a cached caller artifact
-  contains (foreign callee domains) and *what invalidates it* (callee body
-  edits). The ADR decides now: cached CFGs are **final optimized, post-inlining**
-  CFGs; caller cache keys must incorporate **callee body fingerprints**; and the
-  caller-only domain projection (`CfgDomainProjection::from_body`) must be
-  extended to carry **foreign callee domains** (§4).
-- **The inliner's call-site graph is a separate structure from the semantic
-  dependency manifest** (§5). Call-site multiplicity, leafness, candidate
+- **Durable reuse has an explicit current boundary and an accepted Phase 4
+  design.** The optimized-CFG query retains, imports, and publishes reusable
+  terminals for callers that have not been spliced. A caller changed by general
+  inlining is published with `durable_reuse_allowed: false`; it is recomputed on
+  the next request. Phase 4 will add callee-body fingerprints, policy versioning,
+  and multi-body domain projection before enabling reuse for those records (§4).
+- **The inliner's call-site graph is separate from the per-key body-reference
+  and query dependency graph** (§5). Call-site multiplicity, leafness, candidate
   lookup, and recursion SCCs are answered by **scanning CFG `Call`
-  instructions**; the deduplicated `body_dependencies` manifest
-  (`crates/rue-compiler/src/session.rs:596`, `619`) is used for invalidation and
-  durable reuse. They answer different questions and must not be conflated.
+  instructions**; revisioned query dependencies track which retained terminals
+  must be invalidated when their stable inputs change. They answer different
+  questions and must not be conflated.
 
 ## Context
 
 ### The optimizer is per-function today (ground truth)
 
 The optimizer lives entirely in `crates/rue-cfg/src/opt/` and runs as CFG → CFG
-transforms on **one function at a time**. `opt::optimize(cfg, level, type_pool)`
-(`crates/rue-cfg/src/opt/mod.rs:142`) takes a single `&mut Cfg` and has no access
+transforms on **one function at a time**. `opt::optimize_with_budget` takes one
+CFG and has no access
 to any other function. A `Cfg` is one function: it owns that function's
 `blocks`, `values`, `extra`, `call_args`, `num_locals`, `num_params`, `fn_name`,
 `param_modes`, and `address_taken_slots` (`crates/rue-cfg/src/inst.rs:536`).
 
-The production build seam is `build_functions_and_cfgs`
-(`crates/rue-compiler/src/queries.rs:156`). It:
+The production build seam is the optimized-CFG query and its compiler-owned
+whole-program batch. It:
 
 1. synthesizes drop-glue functions (`drop_glue::synthesize_drop_glue`, line 174);
-2. concatenates user functions + glue and **sorts them by machine symbol name**
-   (`all_functions.sort_by(|left, right| left.name.cmp(&right.name))`, line 194) —
+2. concatenates user functions + glue and sorts them by machine symbol name —
    the machine symbol is the stable semantic identity shared by user, specialized,
    destructor, and glue functions;
-3. maps each function through an **import-or-build-then-optimize** step in a
-   Rayon parallel map (`into_par_iter().map(...)`, lines 198–360): it tries to
-   reuse a cached `DurableCfgArtifact` (below), else runs `CfgBuilder::build`
-   (line 255) then `opt::optimize` (line 282), then exports the optimized CFG as
-   a fresh artifact (line 330). **No cross-function state is threaded through the
-   map** — each function is built and optimized in isolation.
+3. the optimized-CFG query performs import-or-build and local
+   `opt::optimize_with_budget`
+   for one function, then publishes that optimized query terminal (or reuses a
+   matching retained terminal);
+4. the compiler batch scans the complete optimized record set, performs
+   deterministic general inlining and DFE, and re-optimizes changed callers
+   before publishing the final batch results. **No cross-function state is
+   threaded through the local query**; the batch is the sole cross-function
+   orchestration boundary.
 
 A `Call` names its callee purely by interned symbol (`CfgInstData::Call { name:
 Spur, .. }`, `crates/rue-cfg/src/inst.rs:351`; lowered at
@@ -110,111 +111,60 @@ over the already-built function set — cheap to express, but it requires a stag
 that can see the *whole set*, which the current per-function parallel map
 deliberately cannot.
 
-### The durable CFG cache has landed (ground truth — supersedes the first draft)
+### Revisioned optimized-CFG query retention (current architecture)
 
-The first draft asserted "there is no CFG cache to invalidate today — every build
-rebuilds every CFG from AIR." **That is no longer true.** A durable, fail-closed
-CFG cache is now in production:
+The revisioned query database retains successful optimized-CFG query terminals
+and their observed dependency cones across revisions. A terminal is reusable
+only when its query key, target, optimization level, and stable function inputs
+match; otherwise the query rebuilds the function. The optimized-CFG query
+publishes one-function, locally optimized records, while the compiler-owned
+whole-program batch retains its observed terminals and applies general
+inlining/DFE to the batch result.
 
-- **Retention.** `CfgFrontendOutput` carries
-  `durable_cfgs: Arc<[DurableCfgArtifact]>` (`crates/rue-compiler/src/queries.rs:129`),
-  retained across semantic requests on the session as `last_successful_cfg_cache`
-  / `successful_cfg_cache` (`crates/rue-compiler/src/session.rs:1676`, `2243`) and
-  threaded back in as `durable_cfg_candidates`
-  (`crates/rue-compiler/src/canonical_semantic.rs:613`, `688`, `857`).
-- **Import (reuse).** `build_functions_and_cfgs` takes
-  `durable_candidates: &[DurableCfgArtifact]` and
-  `stable_inputs: &[StableCfgInput]` (`queries.rs:161-162`). Per function it
-  binary-searches a candidate by machine symbol (`queries.rs:210`) and reuses it
-  only when **every** key component matches:
-  `candidate.schema_version == DURABLE_CFG_SCHEMA_VERSION && candidate.opt_level
-  == opt_level && candidate.target == target` and the stable input agrees
-  (`input.body == candidate.input.body && input.specialization ==
-  candidate.input.specialization && input.type_inputs ==
-  candidate.input.type_inputs`), after which the stored CFG is re-projected into
-  the current domains via `CfgDomainProjection::import_cfg` (`queries.rs:217-232`).
-  Any mismatch falls back to a full build.
-- **Export.** After `opt::optimize` runs (`queries.rs:282`), the **optimized**
-  CFG is exported as a new `DurableCfgArtifact` — gated on the function producing
-  no warnings, no incomplete implicit-destructor edges, and a successful
-  `domains.validate_cfg(&cfg, input.body_span)` round-trip (`queries.rs:330-343`).
-- **Cache key contents.** `DurableCfgArtifact` (`queries.rs:137`) is
-  `{schema_version, input: StableCfgInput, opt_level, target, cfg, domains}`. The
-  key material is `schema_version`, `opt_level`, `target`, and `StableCfgInput`
-  = `{identity, body_span, body: DurableOrdinaryBodyPayload, specialization,
-  type_inputs}` (`crates/rue-compiler/src/durable_cfg.rs:11-17`). **Crucially,
-  `StableCfgInput` fingerprints only the caller's *own* body** — it has no field
-  for the bodies of callees the caller calls.
+General inlining marks every changed caller
+`durable_reuse_allowed: false`. Such a caller remains available in the current
+batch and codegen request, but is excluded from durable terminal/cone retention;
+the next request recomputes it and reruns the batch. This is the current cache
+boundary. Durable reuse of post-inline callers is specified only in the
+accepted RUE-932 Phase 4 design below.
 
-The consequence for inlining is the opposite of the first draft's: the cache is
-real, the exported CFGs are **already the final optimized CFGs**, and inlining
-must integrate with retention/import/export from day one (§4). A caller that
-inlines callee `f` (a) contains `f`'s domains inside its CFG, which the current
-caller-only projection cannot express, and (b) must be invalidated when `f`'s
-**body** changes, which the current caller-only key cannot detect.
+### Domain projection is caller-only by contract (ground truth)
 
-### `CfgDomainProjection::from_body` is caller-only by contract (ground truth)
+`CfgDomainProjection::from_local_body` builds the type/string/symbol/span
+remapping tables that make a function-local optimized-CFG terminal portable
+across revisions. It derives that mapping solely from the function's own AIR
+body and body span. `import_cfg` and `import_accessor_cfg` remap a retained or
+imported one-function CFG into the current live domain, while rejecting missing
+stable types, symbols, strings, spans, or incomplete domains.
 
-`CfgDomainProjection::from_body` (`crates/rue-compiler/src/durable_cfg.rs:223`)
-builds the type/string/symbol/span remapping tables that make a cached CFG
-portable across compilation sessions. It derives that mapping **solely from the
-caller's AIR body**: it zips `function.air.iter()` against
-`input.body.instructions` one-for-one (`durable_cfg.rs:235`), and it **rejects
-any instruction whose span falls outside the caller body's span range** —
-`current.span.file_id != input.body_span.file_id || current.span.start <
-input.body_span.start || current.span.end > input.body_span.end` returns
-`CfgDomainFailure::Unsupported` (`durable_cfg.rs:237-242`). The symbol table maps
-only `Call`/`Intrinsic` names that appear in the caller's own AIR
-(`durable_cfg.rs:268-278`); the string table maps only string constants in the
-caller's AIR (`durable_cfg.rs:251-260`).
+An inlined callee introduces foreign domains by definition: types, string
+constants, callee `Call`/`Intrinsic` symbols, and instruction spans that point
+into the callee's source range rather than the caller's. The current batch
+therefore marks every changed caller `durable_reuse_allowed: false` and excludes
+it from terminal/cone retention. Section 4 records the accepted Phase 4 design
+for making those post-inline records reusable.
 
-An inlined callee **introduces foreign domains by definition**: types, string
-constants, callee `Call`/`Intrinsic` symbols, and — fatally for the span check —
-instruction spans that point into the *callee's* source range, not the caller's.
-The existing export boundary therefore cannot treat an inlined CFG as an ordinary
-caller artifact: `from_body` would reject it on the span range check, so today
-inlining would simply make every caller *uncacheable*. §4 designs the fix.
+### Per-key body references and query dependencies (current architecture)
 
-### The semantic dependency manifest (ADR-0050) — what it is and is not
+Semantic body analysis publishes a canonical, sorted, duplicate-free
+`BodyReferences` value for each `BodyQueryKey`. A reference identifies the exact
+callable instance, stable definition, nominal type, or drop-glue type selected
+while analyzing that body. The body-closure scheduler consumes those typed
+references to demand callable bodies, type facts, and drop glue; it does not
+infer them from a second CFG scan.
 
-> **Historical architecture:** ADR-0063 superseded ADR-0050 and removed the
-> whole-program manifest and `semantic_invalidation_plan`. An inlining
-> implementation must express these dependencies through the canonical per-key
-> body-reference/query graph. The discussion below explains the distinction
-> that motivated this design; its named APIs and source locations are retired.
+The revisioned query database records the exact query terminals read while each
+body, CFG, and downstream artifact is evaluated. Those per-key dependency edges
+are the invalidation authority: a changed source, stable body input, target, or
+configuration invalidates the affected terminals and their dependents, while
+unchanged terminals remain reusable across revisions. Missing endpoints or
+incomplete observations fail closed. The optimized-CFG query and compiler batch
+therefore use this graph for retention correctness, while the inliner's CFG
+scan remains responsible only for structural call-site decisions (§5).
 
-The dependency-derived invalidation machinery is **ADR-0050 (Stable semantic
-dependency manifests)**, with session support in
-`crates/rue-compiler/src/session.rs`:
-
-- `CompilerSession::semantic_dependency_inputs`
-  (`crates/rue-compiler/src/session.rs:5337`) publishes an ordered definition
-  universe whose per-owner body dependencies are
-  `StableBodyDependencyInputRecord`s (`session.rs:596`). Each record's
-  `direct_dependency_inputs: Arc<[StableDefinitionInputFingerprint]>`
-  (`session.rs:601`, `619`) is the owner's dependency set — **sorted and
-  deduplicated** (`direct_dependencies.sort(); direct_dependencies.dedup();`,
-  `session.rs:6018-6019`) — merging call targets, named-method/destructor edges,
-  and declaration-type edges into one flat set of *definition* fingerprints.
-- `CompilerSession::semantic_invalidation_plan` (`session.rs:6373`) memoizes a
-  comparison of two manifests and computes a deterministic **reverse-dependency
-  closure** over those direct edges (`collect_reverse_dependencies`,
-  `session.rs:6561`; `reverse_closure_nodes_visited`, `session.rs:1455`), failing
-  closed (`IncompleteDependencyGraph`) when any endpoint is missing.
-
-The manifest is a **deduplicated definition-dependency graph**, not a call-site
-multigraph. It records *that* a caller depends on a callee's definition; it
-**cannot distinguish one call from ten**, and it folds calls together with type
-and destructor dependencies. This shape is exactly right for invalidation and
-durable reuse — a callee body edit must invalidate every caller that depends on
-it, regardless of call count — and exactly wrong for the inliner's structural
-questions (call multiplicity, leafness, recursion cycles). §5 makes the
-separation an explicit decision.
-
-The body-fingerprint partition ADR-0050 already draws (declaration/signature
-fingerprints vs body fingerprints) is what inlining's cache key needs: a caller
-that inlines callee `f` must be rebuilt when `f`'s **body** fingerprint changes,
-not merely its signature (§4b).
+The stable body-fingerprint partition is what inlining's future cache key needs:
+a caller that inlines callee `f` must be rebuilt when `f`'s **body** fingerprint
+changes, not merely its signature (§4b).
 
 ### Runtime traps carry no source location today (ground truth)
 
@@ -246,31 +196,31 @@ pre-control-flow IR; inlining there means re-implementing parameter binding,
 scope/drop insertion, and move analysis at the AIR level, duplicating what
 `CfgBuilder` already does (drop elaboration, `StorageLive`/`StorageDead`
 pairing, move pre-scan — `crates/rue-cfg/src/build.rs:292, 1124, 2495`). It also
-fights the durable-cache grain: `StableCfgInput` fingerprints an AIR body and
-`from_body` anchors its projection at AIR body boundaries; splicing AIR bodies
+fights the durable-query grain: stable query inputs fingerprint an AIR body and
+`from_local_body` anchors its projection at AIR body boundaries; splicing AIR bodies
 would disturb those anchors and the cache key. Rejected as the most invasive and
 the worst fit for the incremental model.
 
 **(b) CFG-level inlining as a `rue-cfg` pass with access to other CFGs.** Add a
-pass inside `opt::optimize` that reaches other functions' CFGs. *Cost:* this
+pass inside `opt::optimize_with_budget` that reaches other functions' CFGs. *Cost:* this
 breaks the defining property of `rue-cfg`'s optimizer — that a pass sees exactly
-one function — and forces `opt::optimize`'s signature to take the whole function
+one function — and forces `opt::optimize_with_budget`'s signature to take the whole function
 set, which then has to be threaded through the Rayon per-function map in
-`queries.rs:198`. It puts cross-function orchestration (callee lookup, recursion
+the optimized-CFG batch. It puts cross-function orchestration (callee lookup, recursion
 refusal, threshold policy, cache-key composition) inside `rue-cfg`, which has no
-view of the session, the manifest, or symbol resolution. Rejected:
+  view of the session, the query dependency graph, or symbol resolution. Rejected:
 it pushes orchestration to the wrong layer.
 
 **(c) A dedicated inter-procedural stage orchestrated by `rue-compiler`,
-operating on built CFGs — RECOMMENDED.** Keep `CfgBuilder::build` producing
-per-function CFGs exactly as today. Restructure the map in
-`build_functions_and_cfgs` (`crates/rue-compiler/src/queries.rs`) so that CFG
-**construction** (import-or-build) runs first for all functions, then a new
-inliner stage runs with the full `{symbol → Cfg}` map, then the existing
-per-function `opt::optimize` + export runs. The inliner itself is a self-contained
-CFG→CFG *splice* primitive that can live in `rue-cfg` (it is pure CFG surgery and
-belongs with the IR it edits), but it is *driven* by `rue-compiler`, which owns
-the callee map, the call-site graph, and the manifest.
+operating on optimized CFG records — RECOMMENDED.** Keep `CfgBuilder::build`
+and the local `rue_cfg::opt::optimize_with_budget` query single-function. Once the complete
+optimized record set is available, the compiler batch runs with the full
+`{FunctionInstanceKey → CfgRecord}` map, applies the call-site/recursion/size
+policy, splices accepted calls with the `rue-cfg` primitive, performs DFE, and
+re-optimizes changed callers with the carried budget. Unchanged records are
+retained. The inliner is self-contained CFG→CFG surgery in `rue-cfg`, but it is
+driven by `rue-compiler`, which owns the callee map, call-site graph, metadata,
+cache/query boundaries, and query dependency integration.
 
 Reasoning:
 
@@ -279,22 +229,13 @@ Reasoning:
   where the whole-program view already lives (the session).
 - It reuses the CFGs the builder already produces — no second lowering, no
   AIR-level re-implementation.
-- The one real cost it pays honestly: the per-function step can no longer *also*
-  optimize in the same parallel pass, because inlining needs all callee bodies to
-  exist before any caller is rewritten. Construction and optimization become two
-  phases (build/import-all, then inline+optimize+export) rather than one fused
-  parallel map. Optimization remains embarrassingly parallel *after* the inliner
-  has run (the splice is a batch step; per-caller `optimize` is still
-  independent). At `-O0`/`-O1` the inliner is skipped and the fused single-phase
-  map is retained.
-- Interaction with the cache import path: today import, build, optimize, and
-  export all happen inside the one per-function closure (`queries.rs:206-343`).
-  Two-phasing means **import/build** populates the callee map first; the inliner
-  rewrites callers; then **optimize+export** runs. A caller reused verbatim from
-  the cache (import success) still enters the inliner stage, because its cached
-  form is *already post-inlining* (§4a) — so a reused caller needs no
-  re-splice, and the inliner skips it. Whether that reuse is still valid is a
-  pure cache-key question (§4b).
+- The batch runs after local optimization, so changed callers pay one additional
+  local reoptimization while unchanged callers retain their query result. This
+  makes the shared budget's pass order explicit: local O3 unrolling charges
+  first, then accepted inlining and changed-caller reoptimization consume the
+  remaining budget. At `-O0`/`-O1` the batch is skipped.
+- Durable reuse applies only to the one-function optimized-CFG terminal today;
+  post-inline reuse is a Phase 4 design question (§4).
 
 ### 2. What inlining a call means mechanically in this IR
 
@@ -409,41 +350,34 @@ matrix (moved-out parameter, dropped-at-exit parameter, `Copy` parameter needing
 no drop) is the highest-risk correctness surface and needs a worked elaboration
 example plus differential coverage before Phase 1.
 
-### 4. Durable CFG cache integration — a core section
+### 4. Durable CFG cache integration — accepted Phase 4 design
 
 Inlining touches all three cache operations. The decisions:
 
-**(a) Cached CFGs represent FINAL optimized, post-inlining CFGs.** The export
-point is already *after* `opt::optimize` (`queries.rs:282, 330`), so cached
-artifacts are final optimized CFGs today. With inlining sequenced *before*
-`opt::optimize` (§1c), the exported CFG is naturally **post-inlining and
-post-optimization** — the single fully-transformed artifact. This is the right
-choice: it keeps one artifact per function with no "half-optimized, pre-inline"
-intermediate to store, version, or invalidate separately, and it means an import
-hit reproduces the complete transform for free. The cost is the invalidation
-obligation in (b): a post-inlining artifact depends on its inlined callees'
-bodies, so its key must say so. *Rejected alternative:* caching pre-inlining CFGs
-and re-inlining on every build would make a caller's cache hit useless (the
-expensive cross-function work reruns every time) and would still need the
-callee-body key for the inline decision itself — strictly worse.
+**(a) Future cached CFGs represent FINAL optimized, post-inlining CFGs.** The
+current retention boundary is the unspliced optimized-CFG query terminal; changed
+callers are explicitly excluded with `durable_reuse_allowed: false`. Phase 4
+will retain the post-inline, post-reoptimization CFG only after its callee-body
+dependency set and foreign-domain projection are durable. This keeps one
+artifact per function and avoids silently reusing a caller whose inlined body is
+stale.
 
 **(b) Caller cache keys incorporate callee body fingerprints and inlining
 policy.** `StableCfgInput` (`durable_cfg.rs:11`) today fingerprints only the
 caller's own `body`, `specialization`, and `type_inputs`, and the reuse check
-(`queries.rs:220-224`) compares exactly those. A post-inlining caller artifact is
+compares exactly those. A post-inlining caller artifact is
 invalidated by two more things:
 1. **Every inlined callee's body fingerprint.** The key must gain a set of
    `{callee identity → StableDefinitionInputFingerprint}` for each callee the
-   caller actually inlined, drawn from the ADR-0050 body-fingerprint partition
+   caller actually inlined, drawn from the stable body-fingerprint partition
    (`session.rs`, `StableDefinitionInputFingerprint`). Editing an inlined
    callee's body changes its body fingerprint, which changes the caller's key,
-   which forces a rebuild — exactly the reverse-dependency invalidation
-   `semantic_invalidation_plan` already computes (`session.rs:6373`), now keyed on
-   *body* rather than *signature*.
+   which forces a rebuild — exactly the per-key query dependency invalidation
+   required for a callee *body* change rather than merely a signature change.
 2. **The inlining policy revision.** A change to the threshold table or inlining
    algorithm must invalidate every inlined caller. Bump a coarse
    `inlining_policy_version` (companion to `DURABLE_CFG_SCHEMA_VERSION`,
-   `queries.rs:132`) into the key; the simplest correct form folds it into the
+   into the key; the simplest correct form folds it into the
    schema version so a policy change invalidates the whole CFG cache. A finer
    per-caller policy fingerprint is a later refinement.
 
@@ -452,7 +386,7 @@ whole dependency set — so a caller that inlined nothing keeps today's key
 unchanged and its cache behavior is untouched.
 
 **(c) Durable domain projection must carry foreign callee domains.** This is the
-sharpest constraint. `from_body`'s caller-only contract (Context) rejects any
+sharpest constraint. `from_local_body`'s caller-only contract rejects any
 CFG containing spans, symbols, strings, or types that do not originate in the
 caller's AIR body — which every inlined CFG does. The design:
 
@@ -461,79 +395,91 @@ caller's AIR body — which every inlined CFG does. The design:
   table**: for each callee type, string constant, `Call`/`Intrinsic` symbol, and
   span that lands in the caller CFG, record the callee-side stable identity the
   callee's *own* `CfgDomainProjection` already holds (each callee has one built
-  by `from_body` from its own body). The callee's projection is the authoritative
+  by `from_local_body` from its own body). The callee's projection is the
+  authoritative
   source of stable identities for its domains.
 - Extend `CfgDomainProjection` from a single caller-body projection to a
   **caller projection unioned with the projections of every inlined callee**,
   with callee spans anchored relative to the *callee's* `body_span` (the
-  `DurableBodyAnchor` mechanism `from_body` already uses,
-  `durable_cfg.rs:243-249`) plus a callee-identity tag so import can resolve each
-  foreign span against the right body. Concretely, the span check at
-  `durable_cfg.rs:237-242` must change from "reject spans outside the caller
+  existing stable span-anchor mechanism) plus a callee-identity tag so import can
+  resolve each foreign span against the right body. Concretely, current span
+  validation must change from "reject spans outside the caller
   body" to "resolve each span against the caller body *or* a recorded inlined
   callee body," and `import_cfg`'s span/symbol/string/type remappers
-  (`durable_cfg.rs:351-406`, driving `Cfg::try_remap_domains`,
-  `crates/rue-cfg/src/inst.rs:597`) must consult the unioned table.
+  (driving `Cfg::try_remap_domains`) must consult the unioned table.
 - `import_cfg` already remaps whole-CFG domains through `try_remap_domains`
   (type/struct/enum/symbol/string/span), so the *mechanism* to re-project a
   multi-body CFG exists; what must change is the *table construction*
-  (`from_body`) and the *span-range contract*. Until that lands, the safe
+  (`from_local_body`) and the *span-range contract*. Until that lands, the safe
   fallback is explicit and cheap: a caller that inlined anything **fails the
-  export gate** (`from_body`/`validate_cfg` returns `Unsupported`) and is simply
-  not cached — correct, just slower, and identical to today's behavior for any
-  function that fails validation. Phase 4 turns caching on for inlined callers.
+  export gate** (`from_local_body`/`validate_cfg` returns `Unsupported`) and is simply
+  not cached — correct, just slower, and identical to the current explicit
+  `durable_reuse_allowed: false` policy. Phase 4 turns caching on for inlined
+  callers after the key and projection changes above.
 
-**Sequencing note:** because import happens per-function (`queries.rs:214-249`), a
-cached post-inlining caller can be imported *without* rebuilding its callees — the
-stored CFG already contains the inlined bodies. The callee-body fingerprints in
-the key (4b) are what make that reuse sound; the multi-body projection (4c) is
-what makes it *expressible*.
+**Sequencing note:** Phase 4 may import a post-inlining caller without rebuilding
+its callees once the callee-body fingerprints in the key (4b) and multi-body
+projection (4c) make that reuse sound and expressible.
 
-### 5. Call-site graph vs semantic dependency manifest — an explicit separation
+### 5. Call-site graph and body-reference query roles
 
-The inliner needs a **call-site graph** and must build it by **scanning the CFG's
-`Call` instructions**, not by reading the ADR-0050 `body_dependencies` manifest.
-These are different structures answering different questions:
+The inliner needs a **call-site graph** and builds it by **scanning the CFG's
+`Call` instructions**. This graph and the per-key body-reference/query graph
+answer different questions:
 
 - **Call-site multiplicity** ("is this callee called once or ten times?"): count
-  `CfgInstData::Call` instructions naming a symbol across all caller CFGs. The
-  manifest **cannot** answer this — `direct_dependency_inputs` is deduplicated
-  (`session.rs:6018-6019`), so ten calls to `f` and one call to `f` produce the
-  identical single edge.
+  `CfgInstData::Call` instructions naming a symbol across all caller CFGs. Body
+  references are duplicate-free and cannot answer this, so ten calls to `f` and
+  one call to `f` produce the same callable reference.
 - **Leafness** ("does this callee contain any call?"): scan the callee's
-  `values` for `CfgInstData::Call`. The manifest folds calls together with type
-  and destructor dependencies, so it cannot cleanly report "contains a call."
+  `values` for `CfgInstData::Call`. Body references also include type and
+  drop-glue demands, so they cannot cleanly report "contains a call."
 - **Candidate lookup** ("what is the callee body for this call?"): the `Call`'s
   `name: Spur` is the symbol key into the `{symbol → Cfg}` map. This is
   CFG-native.
 - **Recursion / SCC refusal**: the recursion cycle must be computed over the
-  **actual call-site graph**, not the dependency manifest. Using the whole
-  deduplicated dependency graph for recursion analysis **can produce false
-  cycles**: because it merges calls with type and destructor edges, a
+  **actual call-site graph**, not all query dependency edges. Using the whole
+  dependency graph for recursion analysis **can produce false cycles**: because
+  it includes type and destructor demands, a
   non-recursive function that merely *mentions a type* whose destructor
   transitively references the function's own definition would appear in a cycle
   and be needlessly refused. The call-site graph contains only real call edges,
   so its SCCs are exactly the real recursion cycles.
 
-Conversely, the manifest — not the CFG scan — remains authoritative for
-**invalidation and durable reuse**: the reverse-dependency closure
-(`semantic_invalidation_plan`, `session.rs:6373`) and the caller cache key (§4b)
-consume `body_dependencies`. **Scanning the CFG is not a competing invalidation
-path**; it answers the inliner's structural questions, while the manifest answers
-"what must rebuild when a definition changes." Both exist; neither substitutes
-for the other.
+Conversely, the revisioned query dependency graph — not the CFG scan — remains
+authoritative for **invalidation and durable reuse**. Query keys and their
+recorded terminal reads determine what must rebuild when a stable input changes.
+**Scanning the CFG is not a competing invalidation path**; it answers the
+inliner's structural questions, while query dependencies answer retention
+correctness.
 
 ### 6. Threshold and candidate policy
 
-Initial, deliberately conservative criteria (concrete numbers are the maintainer
-knob to set; these are the proposed starting points):
+The current criteria are deliberately conservative:
 
 - **Callee instruction count** below a small budget. The counter is exact and
-  free: `callee.values.len()`. Proposed initial cap: small (≈ a few dozen
-  instructions) at `-O2`; larger at `-O3` per ADR-0044.
+  free: `callee.values.len()`. O2 keeps its 32-value cap; O3 uses a 96-value
+  cap. The reproducible measurement is an O0 CFG emission with the checked-in
+  compiler, followed by counting each `vN` line between `cfg` headers (for
+  example: `RUE_STD_PATH=$PWD/std $(scripts/rue path) --emit cfg -O0
+  performance/workloads/lattice/main.rue`). The standalone checked-in
+  programs `examples/life.rue`, `examples/collatz.rue`, and
+  `examples/quicksort.rue` produced per-function ranges 23–75 (5 functions),
+  13–43 (3), and 17–61 (4), respectively. The larger checked-in Lattice
+  workload produced 1,282 reachable CFGs ranging from 1–736 values, with
+  median 31, p90 56, p95 120, p99 272, and 1,199/1,282 (93.5%) at or below
+  96. Percentiles use the nearest-rank convention (the smallest sorted value
+  whose one-based rank is at least `ceil(p × 1,282)`); the exact count is
+  retained alongside the rounded percentile labels. Thus 96 is the next
+  conservative 32-value boundary above every small
+  standalone body while retaining the large workload's short-function majority;
+  128 would admit an additional long-tail band without a measurement-backed
+  need.
 - **Leaf-ness** from a CFG scan (§5): a callee containing no `CfgInstData::Call`
-  is a leaf and the safest first target. `-O2` = leaf callees under the small
-  cap; `-O3` relaxes to non-leaf and larger caps.
+  is a leaf and the safest first target. O2 remains leaf-only under its small
+  cap; O3 admits non-leaf callees under the larger cap, while refusing every
+  recursive SCC. The batch expands only the deterministic original call-site
+  set once, so copied non-leaf calls cannot recursively trigger more inlining.
 - **Single-call-site** callees (call multiplicity 1, from the §5 call-site graph)
   are the highest-value case: inlining them removes a call with no code-size cost
   at the inlined site. **But the callee is not deleted by the inliner.** Whether a
@@ -545,12 +491,16 @@ knob to set; these are the proposed starting points):
   reference. The inliner inlines; DFE (a separate, later pass over the whole
   function set) decides removal.
 - **Bounded code growth.** Inlining and `-O3` unrolling (ADR-0054) share one
-  per-function code-growth budget debited by whichever runs, so a function does
-  not both inline heavily and unroll into a size explosion. The budget source is
-  the same `values`-based instruction count.
+  per-function `CodeGrowthBudget` capped at 256 values and 256 cloned blocks,
+  debited by whichever runs. Unrolling's charge includes cloned block
+  parameters and instructions; inlining's charge is the checked value-arena and
+  basic-block delta from the actual splice. Ordinary never-returning bodies get
+  a minimum one-value policy charge even when their exact value delta is zero;
+  general inlining excludes accessor calls. The block ceiling bounds block-heavy
+  zero-value site work, with checked addition and refusal before publication.
 - **Counters' provenance.** Instruction counts and call-site multiplicity and
-  leafness all come from CFG scans (§5); no new counting infrastructure and no
-  manifest read are required for the inline *decision*.
+  leafness all come from CFG scans (§5); query dependency records are not read
+  for the inline *decision*.
 
 **Recursion — must refuse.** Direct recursion is refused by checking callee
 symbol == caller symbol. Mutual recursion is refused by detecting a
@@ -577,7 +527,7 @@ already synthesized.
   `-O2`/`-O3` must (a) place itself at the assigned level, (b) add multi-case
   differential CLI coverage for the shapes it rewrites, and (c) keep the full
   differential set green (`differential_opt = true`, `run_case_differential`,
-  RUE-236, `crates/rue-cli-tests/src/main.rs:802`). Inlining's differential
+  RUE-236, the differential CLI harness). Inlining's differential
   obligations specifically include: callees that trap (overflow / div-by-zero /
   bounds) — the trap must still fire post-inline exactly as pre-inline; callees
   with inout/borrow parameters and write-backs; **slice-borrow parameters passed
@@ -611,8 +561,11 @@ already synthesized.
   single-call-site inlining *without* callee removal; recursion refusal via
   call-site SCC; differential CLI coverage. Inlined callers are **not cached
   yet** (fail the export gate, §4c). (file RUE-930)
-- [ ] **Phase 3: `-O3` thresholds** — larger caps, non-leaf callees, shared
-  code-growth budget with unrolling (ADR-0054). (file RUE-931)
+- [x] **Phase 3: `-O3` thresholds** — a 96-value callee cap admits the measured
+  checked-in program bodies, non-leaf callees are admitted, and inlining shares
+  one 256-value/256-block per-function code-growth budget with unrolling
+  (ADR-0054).
+  (file RUE-931)
 - [ ] **Phase 4: Durable cache integration for inlined callers** — multi-body
   `CfgDomainProjection` (§4c), callee-body-fingerprint + policy-version cache key
   (§4b); turn caching on for inlined callers. (file RUE-932)
@@ -622,9 +575,8 @@ already synthesized.
   consumed) while retaining entry points, exports, calls, cleanup edges, and
   conservatively all units when dependency completeness is unknown. (file
   RUE-933)
-- [ ] **Phase 6: Methods/destructors** — extend as the ADR-0050 method/destructor
-  caller surfaces complete. (file RUE-NNN — awaits the ADR-0050 method/destructor
-  caller surfaces before it can be scoped and filed.)
+- [ ] **Phase 6: Methods/destructors** — extend when the stable body-reference
+  and query surfaces for methods/destructors are complete. (file RUE-NNN)
 
 ## Consequences
 
@@ -634,15 +586,15 @@ already synthesized.
   (CSE, copy-prop, loop opts) become far more effective across former call
   boundaries.
 - The call-site graph (§5) gives the inliner exact multiplicity/leafness/recursion
-  facts the deduplicated manifest cannot, while the manifest keeps one canonical
-  invalidation path.
-- Caching integration is designed up front (§4), so inlined callers become
-  cacheable rather than silently defeating the durable cache.
+  facts that typed body references cannot, while the revisioned query graph keeps
+  one canonical invalidation path.
+- Caching integration has an accepted Phase 4 design (§4); current inlined
+  callers are explicitly uncached rather than silently reused.
 
 ### Negative
 
-- CFG construction and optimization can no longer be one fused parallel map when
-  inlining is on; they split into build/import-all then inline+optimize+export.
+- The whole-program batch adds a deterministic inline/DFE step after local CFG
+  optimization and re-optimizes only changed callers.
 - The multi-body durable projection (§4c) is real work that must land before
   inlined callers cache; until Phase 4 they are recomputed every build.
 - The by-ref place-redirection, materialized-parameter drop rules (§3), and the
@@ -661,10 +613,8 @@ already synthesized.
   policy change) or key it per-caller (finer, more bookkeeping)? Decide when
   Phase 4 lands; the deciding criterion is whether policy changes are frequent
   enough that whole-cache invalidation hurts incremental builds.
-- **Materialized-parameter drop elaboration** — the exact instruction sequence
-  for §3's one-slot/one-live-range/one-drop rule needs a worked example and test
-  before Phase 1; deciding criterion is the differential trap/drop-order suite
-  staying green across moved-out, dropped-at-exit, and `Copy` parameters.
+- **Phase 4 cache policy** — choose the granularity of the policy revision in the
+  durable key when foreign-domain projection and callee-body dependencies land.
 - **Projected by-ref arguments** — excluded initially; the deciding criterion for
   admitting them is a proof that direct place substitution preserves
   address-formation timing and trap behavior.
@@ -674,7 +624,7 @@ already synthesized.
 ## Future Work
 
 - Broader whole-program reachability roots and method/destructor inlining remain
-  future work as described by Phases 3, 4, and 6.
+  future work as described by Phases 4 and 6.
 - Bounded recursive inlining under a size budget.
 - Profile-guided inlining once any profiling exists.
 
@@ -682,11 +632,11 @@ already synthesized.
 
 - [ADR-0044: Optimization Levels](0044-optimization-levels.md) — fixes the level
   placement and the observable-behavior invariant this note operates under.
-- [ADR-0050: Stable semantic dependency manifests](0050-semantic-dependency-manifest.md)
-  — the body-fingerprint partition and reverse-dependency closure inlining's
-  cache key consumes (but whose deduplicated graph is *not* the call-site graph).
+- [ADR-0063: Parallel demand-driven incremental compilation](0063-parallel-demand-driven-incremental-compilation.md)
+  — the per-key body-reference and revisioned query dependency graph inlining's
+  cache boundary consumes (but which is not the call-site graph).
 - [ADR-0053: Typed compiler query state](0053-typed-compiler-query-state.md) — the
-  durable CFG cache (`DurableCfgArtifact`) inlining must integrate with.
+  revisioned query terminals and retention cones inlining must integrate with.
 - [ADR-0012: Compiler Optimization Passes](0012-optimization-passes.md) — the CFG
   opt framework.
 - [ADR-0010: Destructors](0010-destructors.md), [ADR-0013: Borrowing Modes](0013-borrowing-modes.md),

--- a/docs/designs/0054-loop-optimizations.md
+++ b/docs/designs/0054-loop-optimizations.md
@@ -6,7 +6,7 @@ tags: [compiler, codegen, optimization]
 feature-flag: none
 created: 2026-07-16
 accepted:
-implemented: Phase 3 (RUE-928)
+implemented: Phase 3 (RUE-928, RUE-931)
 spec-sections: []
 superseded-by:
 ---
@@ -92,17 +92,16 @@ the CFG level is the correct, target-independent home and avoids a third copy.
 
 ### The passes that exist, and the pass "shape" convention
 
-The `-O1` set has grown well past the original three: `opt::optimize`
-(`crates/rue-cfg/src/opt/mod.rs:142`) runs `constopt::run` (the sparse worklist
+The `-O1` set has grown well past the original three: `opt::optimize_with_budget`
+runs `constopt::run` (the sparse worklist
 that interleaves constant folding — the `constfold` kernel — with store-to-load
 constant propagation to an internal fixpoint, RUE-794), then `peephole::run`
 (RUE-912), then `simplify::run` (CFG simplification, RUE-910/911), then `dce::run`.
 Two more passes are gated to `-O2`/`-O3` inside that same arm: `forward::run`
 (value forwarding / copy propagation, RUE-914) and `cse::run` (block-local CSE,
 RUE-913), each behind `if matches!(level, OptLevel::O2 | OptLevel::O3)`
-(`crates/rue-cfg/src/opt/mod.rs:184, 193`). So `-O2` already differs from `-O1`;
-`-O3` still aliases `-O2` (there is no distinct `O3` arm yet). Loop passes are
-`-O3` content and will be the first passes gated strictly above `-O2`.
+inside the same level match. So `-O2` already differs from `-O1`; `-O3` adds
+LICM, constant-trip unrolling, and bounded larger-cap non-leaf inlining.
 
 ### Work-counter discipline — what the codebase actually does
 
@@ -122,15 +121,15 @@ layers, and loop passes should follow it:
    returns `()` (`crates/rue-cfg/src/opt/dce.rs:77`). The fold/propagate
    **fixpoint now lives inside `constopt`'s sparse worklist** (an instruction is
    revisited only when one of its operands becomes constant, RUE-794); the old
-   outer `folded || propagated` loop in `opt::optimize` is gone. Passes are run
-   once, in the fixed order `opt::optimize` sets.
+   outer `folded || propagated` loop in `opt::optimize_with_budget` is gone.
+   Passes are run once, in the fixed order `opt::optimize_with_budget` sets.
 2. **Structured work counters at the orchestration layer.** The session records
    pass work in `CfgConstructionWork`
-   (`crates/rue-compiler/src/canonical_semantic.rs:282`) — fields like
+   — fields like
    `optimization_attempts`, `optimization_completions`, `optimized_level_attempts`
    (lines 290–292) — aggregated across the parallel function map in
-   `build_functions_and_cfgs` (`crates/rue-compiler/src/queries.rs:279-283`,
-   `382-384`). This is the "wide events / structured completion" discipline
+   the optimized-CFG query and compiler-owned whole-program batch. This is the
+   "wide events / structured completion" discipline
    AGENTS.md describes for `tracing`.
 
 Loop passes should therefore **expose their own `Stats` struct** with
@@ -353,7 +352,7 @@ test, and — once the post-unroll cleanup below runs — it collapses the
 now-constant induction variable.
 
 **Post-unroll cleanup is mandatory (constopt runs *before* unrolling).**
-`constopt` is the *first* pass in `opt::optimize` (`crates/rue-cfg/src/opt/mod.rs:160`),
+`constopt` is the *first* pass in `opt::optimize_with_budget`,
 running before `peephole`, `simplify`, `forward`, `cse`, and `dce`. A loop pass
 gated at `-O3` runs *after* that whole sequence, so the constants and dead
 control flow unrolling exposes — the per-iteration IV values, the now-dead trip
@@ -368,18 +367,26 @@ than the original loop. The cleanest placement is a small fixpoint or a fixed
 second cleanup pass in the `-O3` arm after the loop passes; the exact shape is an
 implementation detail, but the *requirement* is not optional.
 
-- **Budget knob.** A single integer `unroll_budget` = maximum *total instruction
-  count of the unrolled body* (`N × body_size`). Proposed `-O3` default: a modest
-  cap (a few hundred CFG instructions) — enough to unroll small fixed loops,
-  small enough to bound code growth. `-O0`/`-O1`/`-O2` = 0 (disabled). The count
-  source is the same `cfg.values`-based instruction count LICM and inlining use.
+- **Budget knob.** O3 uses one per-function `CodeGrowthBudget` capped at 256
+  values and 256 cloned blocks for both unrolling and general inlining. A charge
+  is the checked arena-value and basic-block count of the cloned body (including
+  block parameters), so the two passes use one growth authority and cannot
+  overflow or spend independently. Ordinary never-returning inlining applies a
+  minimum one-value charge when its exact value delta is zero; accessor calls
+  are excluded from general inlining. The block ceiling bounds block-heavy
+  zero-value site work while preserving ordinary fixed-loop unrolling.
+  Measurement of O0 CFG output with the checked-in compiler found 7/12/18/13/4
+  blocks in `life`, 4/4/7 in `collatz`, and 4/7/7/1 in `quicksort`; the larger
+  Lattice workload had 1,282 CFGs ranging from 1–68 blocks, with nearest-rank
+  p90=11, p95=16, p99=43. The 256-block ceiling is therefore a finite
+  per-function work bound well above the measured population and common fixed
+  loops.
 - **Interaction with inlining's thresholds (ADR-0049).** Both unrolling and
-  aggressive inlining are `-O3` code-growth transforms. They should share **one
-  code-growth budget per function**, debited by whichever runs, so a function
-  that inlines heavily does not *also* unroll into a size explosion (and vice
-  versa). This note proposes a shared per-function growth budget as the
-  coordination point; ADR-0049 Phase 3 is where the two meet. Absent
-  coordination, the two passes can multiply code size.
+  larger-cap bounded non-leaf inlining are `-O3` code-growth transforms. They share one
+  `CodeGrowthBudget` per function, debited by whichever runs. The per-function
+  optimizer carries unrolling's charge into the later whole-program batch;
+  each accepted splice is charged before the caller is re-optimized, so a
+  function cannot inline heavily and then unroll past the same 256-value cap.
 - **Out of scope initially:** partial unrolling, runtime-trip-count unrolling with
   a remainder loop, and unroll-and-jam. Each needs a remainder-loop construction
   and (for trap-safety) the same guard reasoning as LICM §2.
@@ -388,7 +395,7 @@ implementation detail, but the *requirement* is not optional.
 
 - **Differential coverage (ADR-0044).** Each pass lands with multi-case
   `differential_opt` CLI coverage (`run_case_differential`, RUE-236,
-  `crates/rue-cli-tests/src/main.rs:802`) for the shapes it rewrites, and keeps
+  differential CLI harness) for the shapes it rewrites, and keeps
   the full differential set green. For LICM the **mandatory** cases are the
   trap-safety ones: a zero-iteration loop containing an invariant trapping op
   (overflow, div-by-zero, invariant index read) must **not** trap after LICM —
@@ -401,16 +408,15 @@ implementation detail, but the *requirement* is not optional.
   `peephole`; see §"Work-counter discipline") and contributes structured counters
   (loops analyzed, invariants hoisted, loops unrolled, budget-rejected) into the
   `CfgConstructionWork` / session work surface
-  (`crates/rue-compiler/src/canonical_semantic.rs:282`,
-  `crates/rue-compiler/src/queries.rs:279-283`), per AGENTS.md tracing guidance.
-- **Placement.** Gated strictly above `-O2` in `opt::optimize` — today a new `O3`
-  case split out of the shared `O1 | O2 | O3` arm (which already carries the
-  `-O2`/`-O3`-gated forward/CSE passes), preserving ADR-0044's monotonic
-  superset rule. The post-optimization structural recheck
-  (`verify_after_optimization_with_type_pool`, `opt/mod.rs:206`) continues to run
-  after, as the
-  structural safety net for the block cloning and preheader insertion these
-  passes perform.
+  the optimized-CFG query and compiler-owned whole-program batch, per AGENTS.md
+  tracing guidance.
+- **Placement.** Constant-trip full unrolling runs only in the `OptLevel::O3`
+  arm of `rue_cfg::opt::optimize_with_budget`, after the ordinary local cleanup
+  passes. It debits the shared `CodeGrowthBudget`; the whole-program compiler
+  batch carries the remaining budget into general inlining and changed-caller
+  reoptimization. The post-optimization structural recheck
+  (`verify_after_optimization_with_type_pool`) remains the safety net for block
+  cloning and preheader insertion.
 
 ## Implementation Phases
 
@@ -425,9 +431,9 @@ implementation detail, but the *requirement* is not optional.
   July 2026)
 - [x] **Phase 3: Constant-trip full unrolling** — canonical shape only (single
   header, single latch, recognized IV, no unsupported exits); full CFG-subgraph
-  cloning; mandatory post-unroll const-fold/simplify/DCE cleanup; under the size
-  budget; shared code-growth budget with ADR-0049 inlining. `-O3`. (landed,
-  RUE-928, August 2026)
+  cloning; mandatory post-unroll const-fold/simplify/DCE cleanup; under the
+  shared 256-value/256-block code-growth budget with ADR-0049 inlining. `-O3`. (landed,
+  RUE-928, August 2026; budget coordination completed in RUE-931)
 - [ ] **Phase 4 (relaxation): guarded trapping-op hoisting** — after loop
   rotation/guard analysis exists. (file RUE-934)
 
@@ -464,9 +470,6 @@ implementation detail, but the *requirement* is not optional.
 - **Induction-variable recognition** for constant trip counts — how much IV
   analysis is needed, and how much constant folding/propagation (`constopt`) already exposes, before
   unrolling can read a constant `N` reliably.
-- **Shared code-growth budget shape** with ADR-0049 — one budget debited by both
-  passes, or independent caps with a combined ceiling? Resolve jointly with
-  ADR-0049 Phase 3.
 - **When (if ever) to cache dominators across passes** — deferred until profiling
   justifies the incremental-maintenance complexity.
 


### PR DESCRIPTION
## Summary
- give O3 a measured 96-value non-leaf inlining policy while preserving the O2 32-value leaf-only contract
- coordinate inlining and constant-trip unrolling through one per-function 256-value and 256-block growth budget with exact transactional preflight
- publish bounded-work telemetry and structural, differential, threshold, budget, query, and dual-backend coverage
- update ADR-0044, ADR-0049, and ADR-0054 to describe the present architecture and Phase 3 status

## Measurement
- standalone life, collatz, and quicksort CFGs range from 13 to 75 values
- Lattice contains 1,282 CFGs: median 31 values, p90 56, p95 120, p99 272; 1,199 CFGs (93.5%) are at or below 96 values
- measured block counts range from 1 to 68, with p95 16 and p99 43; the 256-value and 256-block shared ceiling bounds cumulative transform work

## Validation
- `scripts/rue fmt`
- focused CFG inlining, Phase-3 compiler, differential CLI, threshold, budget, importability, recursion, and both-backend tests
- `scripts/rue quick` (31/31)
- `scripts/rue premerge` (200/200)
- `scripts/rue test` (234/234)
- `./buck2 test //crates/rue-oracle-diff:oracle-diff-test`
- separate adversarial optimizer, CFG, query, and performance review with no remaining findings

Fixes RUE-931