### PR TITLE
RUE-1807: fuzz retained-session edit sequences

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -76,6 +76,12 @@ jobs:
           path: crates/rue-fuzz/nightly-restored/compiler
           key: rue-fuzz-corpus-v3-compiler-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: rue-fuzz-corpus-v3-compiler-
+      - name: Restore warm-session corpus
+        uses: actions/cache/restore@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/warm_session
+          key: rue-fuzz-corpus-v3-warm_session-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: rue-fuzz-corpus-v3-warm_session-
       - name: Restore compiler AArch64 corpus
         uses: actions/cache/restore@v5
         with:
@@ -202,6 +208,12 @@ jobs:
         timeout-minutes: 10
         run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 --evolve-corpus=crates/rue-fuzz/nightly-corpus/compiler compiler crates/rue-fuzz/nightly-input/compiler
 
+      - name: Fuzz warm session (5 minutes)
+        id: fuzz-warm-session
+        continue-on-error: true
+        timeout-minutes: 10
+        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 --evolve-corpus=crates/rue-fuzz/nightly-corpus/warm_session warm_session crates/rue-fuzz/nightly-input/warm_session
+
       # These source-level variants stay on the x86-64 runner: they compile
       # deterministic source inputs to finished images but never execute the
       # generated AArch64 bytes. Keeping each configuration as its own target
@@ -283,6 +295,7 @@ jobs:
           steps.fuzz-parser.outcome == 'failure' ||
           steps.fuzz-sema.outcome == 'failure' ||
           steps.fuzz-compiler.outcome == 'failure' ||
+          steps.fuzz-warm-session.outcome == 'failure' ||
           steps.fuzz-compiler-aarch64.outcome == 'failure' ||
           steps.fuzz-compiler-x86-64-o1.outcome == 'failure' ||
           steps.fuzz-payload-schemas.outcome == 'failure' ||
@@ -325,6 +338,7 @@ jobs:
           record parser '${{ steps.fuzz-parser.outcome }}'
           record sema '${{ steps.fuzz-sema.outcome }}'
           record compiler '${{ steps.fuzz-compiler.outcome }}'
+          record warm_session '${{ steps.fuzz-warm-session.outcome }}'
           record compiler_aarch64 '${{ steps.fuzz-compiler-aarch64.outcome }}'
           record compiler_x86_64_o1 '${{ steps.fuzz-compiler-x86-64-o1.outcome }}'
           record payload_schemas '${{ steps.fuzz-payload-schemas.outcome }}'
@@ -389,6 +403,13 @@ jobs:
         with:
           path: crates/rue-fuzz/nightly-restored/compiler
           key: rue-fuzz-corpus-v3-compiler-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Save warm-session corpus
+        if: always() && steps.publish_clean_corpus.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: crates/rue-fuzz/nightly-restored/warm_session
+          key: rue-fuzz-corpus-v3-warm_session-${{ github.run_id }}-${{ github.run_attempt }}
       - name: Save compiler AArch64 corpus
         if: always() && steps.publish_clean_corpus.outcome == 'success'
         continue-on-error: true

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -259,6 +259,7 @@ const PRODUCTION_MODULES: &[(&str, &str)] = &[
     ("type_queries", include_str!("type_queries.rs")),
     ("typed_query_store", include_str!("typed_query_store.rs")),
     ("unstable", include_str!("unstable.rs")),
+    ("warm_fresh_parity", include_str!("warm_fresh_parity.rs")),
     ("well_known_option", include_str!("well_known_option.rs")),
 ];
 
@@ -2260,6 +2261,7 @@ fn unstable_views_do_not_alias_query_engine_records() {
         [
             "pubusecrate::diagnostic::{ColorChoice,DiagnosticFormatter,JsonDiagnostic,JsonDiagnosticFormatter,JsonSpan,JsonSuggestion,MultiFileFormatter,MultiFileJsonFormatter,SourceInfo,};",
             "pubusecrate::import_discovery::{AcceptedImportSource,DiscoverySourceAssembler,ImportDemandFrontier,ImportDemandMode,ImportDemandRoots,ImportDiscoveryPlan,ImportDiscoveryRequest,ImportDiscoveryWave,ImportInputRevision,ImportObservation,ImportObservationLedger,ImportObservationStatus,};",
+            "pubusecrate::warm_fresh_parity::ParityObservation;",
             "pubuserue_span::Span;",
             "pubusecrate::session::{ClosedDiscoveryContinuation,RootedCfgOutput,RootedCfgUnit,RootedParkOutcome,TrustedSuccessorDelta,};",
         ],

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -97,6 +97,7 @@ mod integration_tests;
 mod scaling_harness;
 #[cfg(test)]
 mod supported_api_inventory;
+mod warm_fresh_parity;
 
 // Supported source, identity, option, session, and diagnostic surface.
 pub use artifact_views::{
@@ -169,7 +170,6 @@ pub(crate) use import_discovery::IMPORT_DISCOVERY_POLICY_VERSION;
 #[allow(unused_imports)]
 pub(crate) use parsed_modules::{ParseInvalidationSummary, ParsedModulesWork};
 pub(crate) use queries::{PipelineWork, SourceStats};
-#[cfg(test)]
 pub(crate) use session::RootedCfgOutput;
 #[allow(unused_imports)]
 pub(crate) use session::{
@@ -184,7 +184,6 @@ pub(crate) use source_identity::{
 };
 
 // Immutable query artifacts and stable identities returned by CompilerSession.
-#[cfg(test)]
 pub(crate) use body_query::{BodyTransaction, transaction_equal};
 pub(crate) use bound_definitions::{
     StableDefinitionKey, StableDefinitionKind, StableDefinitionNamespace,

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -18829,7 +18829,6 @@ impl RevisionedQueryDatabase {
     /// read-only terminal request records whether that key still has a current
     /// success or deterministic failure. The supplied computation is never
     /// entered, so this hook cannot become a second semantic computation path.
-    #[cfg(test)]
     #[allow(dead_code)]
     pub(crate) fn retained_body_identity_states_for_test(
         &self,
@@ -18891,7 +18890,6 @@ impl RevisionedQueryDatabase {
     /// Test-only lookup of one retained body transaction by its complete
     /// function-instance identity, including specializations and anonymous
     /// members.
-    #[cfg(test)]
     pub(crate) fn retained_body_transaction_for_test(
         &self,
         revision: Revision,

--- a/crates/rue-compiler/src/scaling_harness.rs
+++ b/crates/rue-compiler/src/scaling_harness.rs
@@ -319,107 +319,6 @@ impl Report {
 }
 
 // ---------------------------------------------------------------------------
-// Full-parity warm/fresh oracle (single shared helper)
-// ---------------------------------------------------------------------------
-
-/// Render a full-fidelity diagnostic string for a failed compile: every error in
-/// natural order, each with its kind, span, labels, notes, helps, and
-/// suggestions (the `Debug` of `CompileError` is the diagnostic presentation
-/// state). Comparing this warm-vs-fresh catches divergence in success/failure,
-/// diagnostic ordering, spans, and labels.
-fn render_diagnostics(errors: &CompileErrors) -> String {
-    errors
-        .iter()
-        .map(|error| format!("{error:?}"))
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
-fn assert_successful_output_body_presence(
-    label: &str,
-    output: &RootedCfgOutput,
-    states: &BTreeMap<String, Option<crate::BodyTransaction>>,
-) {
-    for function in output.functions() {
-        let prefix = format!("{:?}:", function.function);
-        let matching = states
-            .iter()
-            .filter(|(identity, _)| identity.starts_with(&prefix))
-            .collect::<Vec<_>>();
-        assert_eq!(
-            matching.len(),
-            1,
-            "{label}: successful output body identity is absent or ambiguous: {:?}",
-            function.function
-        );
-        assert!(
-            matching[0].1.is_some(),
-            "{label}: successful output body has no observable retained transaction: {:?}",
-            function.function
-        );
-    }
-}
-
-fn body_query_identity(instance: &crate::FunctionInstanceKey, options: &CompileOptions) -> String {
-    format!(
-        "{:?}:{:?}",
-        instance,
-        crate::semantic_query_nucleus::SemanticQueryConfiguration {
-            target: options.target,
-            preview_features: crate::StablePreviewFeatures::new(&options.preview_features),
-        }
-    )
-}
-
-fn reachable_successful_body_identities(
-    label: &str,
-    output: &RootedCfgOutput,
-    states: &BTreeMap<String, Option<crate::BodyTransaction>>,
-    options: &CompileOptions,
-) -> BTreeSet<String> {
-    let mut pending = output
-        .functions()
-        .iter()
-        .map(|function| body_query_identity(&function.function, options))
-        .collect::<Vec<_>>();
-    let mut reachable = BTreeSet::new();
-    while let Some(identity) = pending.pop() {
-        if !reachable.insert(identity.clone()) {
-            continue;
-        }
-        let Some(Some(transaction)) = states.get(&identity) else {
-            panic!("{label}: reachable successful body identity has no transaction: {identity}");
-        };
-        for reference in transaction.references().0.iter() {
-            if let crate::body_query::BodyReference::Callable(instance) = reference {
-                pending.push(body_query_identity(instance, options));
-            }
-        }
-    }
-    reachable
-}
-
-fn assert_reachable_body_key_set_parity(
-    label: &str,
-    warm_bodies: &BTreeMap<String, Option<crate::BodyTransaction>>,
-    fresh_bodies: &BTreeMap<String, Option<crate::BodyTransaction>>,
-) {
-    assert_eq!(
-        warm_bodies.keys().collect::<Vec<_>>(),
-        fresh_bodies.keys().collect::<Vec<_>>(),
-        "{label}: successful warm/fresh body-key sets differ"
-    );
-}
-
-/// The one shared warm-vs-fresh oracle every edit row uses. Built on the exact
-/// canonical rooted CFG values, it asserts full parity between a warm
-/// (incremental) rev2 compile and a fresh rev2 compile:
-///
-/// * success vs failure agreement;
-/// * on success, the full parity snapshot: functions, strings, type pool, bound
-///   definitions, anonymous-nominal associations, every dependency surface,
-///   full warnings (kind/spans/labels/order/presentation), and durable status;
-/// * on failure, the full ordered diagnostic presentation.
 fn assert_warm_fresh_parity(
     label: &str,
     warm_session: &mut CompilerSession,
@@ -429,173 +328,15 @@ fn assert_warm_fresh_parity(
     warm: &Result<RootedCfgOutput, CompileErrors>,
     fresh: &Result<RootedCfgOutput, CompileErrors>,
 ) {
-    // The body-transaction family is the canonical production cache. Its
-    // test-only snapshot includes stale keys as well as current terminals, so
-    // successful parity must first narrow it to the identities reachable from
-    // each output and its transaction edges.
-    let warm_bodies = warm_session.retained_body_identity_states_for_test(options);
-    let fresh_bodies = fresh_session.retained_body_identity_states_for_test(options);
-    // A failed rooted body/CFG query may stop before an unchanged helper is
-    // requested. Such a helper can remain observable from the warm cache while
-    // having no fresh-side retained key; that is cache reachability, not a
-    match (warm, fresh) {
-        (Ok(warm), Ok(fresh)) => {
-            // Successful results must expose the same complete reachable
-            // identity universe. This includes output functions and every
-            // callable body demanded by their transaction edges, while
-            // ignoring retained but unreachable stale keys.
-            let warm_reachable =
-                reachable_successful_body_identities("warm", warm, &warm_bodies, options);
-            let fresh_reachable =
-                reachable_successful_body_identities("fresh", fresh, &fresh_bodies, options);
-            let warm_reachable_states = warm_reachable
-                .iter()
-                .map(|identity| {
-                    (
-                        identity.clone(),
-                        warm_bodies.get(identity).cloned().unwrap_or(None),
-                    )
-                })
-                .collect::<BTreeMap<_, _>>();
-            let fresh_reachable_states = fresh_reachable
-                .iter()
-                .map(|identity| {
-                    (
-                        identity.clone(),
-                        fresh_bodies.get(identity).cloned().unwrap_or(None),
-                    )
-                })
-                .collect::<BTreeMap<_, _>>();
-            assert_reachable_body_key_set_parity(
-                label,
-                &warm_reachable_states,
-                &fresh_reachable_states,
-            );
-            for identity in warm_reachable.iter() {
-                let warm_transaction = warm_bodies.get(identity).and_then(Option::as_ref);
-                let fresh_transaction = fresh_bodies.get(identity).and_then(Option::as_ref);
-                assert_eq!(
-                    warm_transaction.is_some(),
-                    fresh_transaction.is_some(),
-                    "{label}: warm/fresh body identity presence diverged for {identity}\n"
-                );
-                if let (Some(warm_transaction), Some(fresh_transaction)) =
-                    (warm_transaction, fresh_transaction)
-                {
-                    assert!(
-                        crate::transaction_equal(warm_transaction, fresh_transaction),
-                        "{label}: exact BodyTransaction diverged for {identity}\n warm={warm_transaction:?}\n fresh={fresh_transaction:?}"
-                    );
-                }
-            }
-            crate::test_support::assert_rooted_cfg_value_parity(label, warm, fresh);
-
-            // Keep the public output check as a consistency assertion, not as
-            // the identity enumeration source. Every emitted function must
-            // also have exactly one observable retained body transaction.
-            assert_successful_output_body_presence(label, warm, &warm_bodies);
-            assert_successful_output_body_presence(label, fresh, &fresh_bodies);
-
-            assert_eq!(
-                format!("{:?}", warm.functions()),
-                format!("{:?}", fresh.functions()),
-                "{label}: full AIR/CFG public artifacts diverged"
-            );
-            assert_eq!(
-                format!("{:?}", warm.warnings()),
-                format!("{:?}", fresh.warnings()),
-                "{label}: ordered semantic warnings diverged"
-            );
-            assert_eq!(
-                format!("{:?}", warm_session.latest_diagnostics_for_test()),
-                format!("{:?}", fresh_session.latest_diagnostics_for_test()),
-                "{label}: ordered diagnostic snapshots diverged"
-            );
-
-            let warm_executable = warm_session.oracle_executable(source, options);
-            let fresh_executable = fresh_session.oracle_executable(source, options);
-            match (warm_executable, fresh_executable) {
-                (Ok(warm), Ok(fresh)) => {
-                    assert_eq!(warm.elf, fresh.elf, "{label}: executable bytes diverged");
-                    assert_eq!(
-                        format!("{:?}", warm.warnings),
-                        format!("{:?}", fresh.warnings),
-                        "{label}: executable warnings diverged"
-                    );
-                }
-                (Err(warm), Err(fresh)) => assert_eq!(
-                    render_diagnostics(&warm),
-                    render_diagnostics(&fresh),
-                    "{label}: executable failure diagnostics diverged"
-                ),
-                (Ok(_), Err(fresh)) => panic!(
-                    "{label}: warm executable succeeded but fresh failed:\n{}",
-                    render_diagnostics(&fresh)
-                ),
-                (Err(warm), Ok(_)) => panic!(
-                    "{label}: warm executable failed but fresh succeeded:\n{}",
-                    render_diagnostics(&warm)
-                ),
-            }
-        }
-        (Err(warm), Err(fresh)) => {
-            assert_eq!(
-                render_diagnostics(warm),
-                render_diagnostics(fresh),
-                "{label}: warm/fresh failure diagnostics diverged"
-            );
-            assert_eq!(
-                format!("{:?}", warm_session.latest_diagnostics_for_test()),
-                format!("{:?}", fresh_session.latest_diagnostics_for_test()),
-                "{label}: ordered failure diagnostic snapshots diverged"
-            );
-            // A failed rooted body/CFG query may stop before unchanged helper
-            // bodies are requested. Compare deterministic failures demanded
-            // by both sides, preserving early-stop behavior for helpers that
-            // exist only in one retained family.
-            let warm_failures = warm_bodies
-                .iter()
-                .filter(|(_, transaction)| {
-                    matches!(
-                        transaction,
-                        Some(crate::BodyTransaction::DeterministicFailure { .. })
-                    )
-                })
-                .map(|(identity, transaction)| {
-                    (identity.clone(), transaction.as_ref().unwrap().clone())
-                })
-                .collect::<BTreeMap<_, _>>();
-            let fresh_failures = fresh_bodies
-                .iter()
-                .filter(|(_, transaction)| {
-                    matches!(
-                        transaction,
-                        Some(crate::BodyTransaction::DeterministicFailure { .. })
-                    )
-                })
-                .map(|(identity, transaction)| {
-                    (identity.clone(), transaction.as_ref().unwrap().clone())
-                })
-                .collect::<BTreeMap<_, _>>();
-            for identity in warm_failures
-                .keys()
-                .filter(|identity| fresh_failures.contains_key(*identity))
-            {
-                assert!(
-                    crate::transaction_equal(&warm_failures[identity], &fresh_failures[identity]),
-                    "{label}: exact failed BodyTransaction diverged for {identity}"
-                );
-            }
-        }
-        (Ok(_), Err(fresh)) => panic!(
-            "{label}: warm compiled but fresh failed:\n{}",
-            render_diagnostics(fresh)
-        ),
-        (Err(warm), Ok(_)) => panic!(
-            "{label}: warm failed but fresh compiled:\n{}",
-            render_diagnostics(warm)
-        ),
-    }
+    crate::warm_fresh_parity::assert_rooted_parity(
+        label,
+        warm_session,
+        fresh_session,
+        source,
+        options,
+        warm,
+        fresh,
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -1753,7 +1494,11 @@ fn correctness_oracle_rejects_missing_successful_body_transaction() {
         .cloned()
         .expect("main body identity is retained");
     states.remove(&main_identity);
-    assert_successful_output_body_presence("missing retained body regression", &output, &states);
+    crate::warm_fresh_parity::assert_successful_output_body_presence(
+        "missing retained body regression",
+        &output,
+        &states,
+    );
 }
 
 #[test]
@@ -1774,7 +1519,11 @@ fn correctness_oracle_rejects_asymmetric_successful_body_key_sets() {
         ("warm-only".to_owned(), Some(transaction.clone())),
     ]);
     let fresh = BTreeMap::from([("reachable".to_owned(), Some(transaction))]);
-    assert_reachable_body_key_set_parity("asymmetric successful body keys", &warm, &fresh);
+    crate::warm_fresh_parity::assert_reachable_body_key_set_parity(
+        "asymmetric successful body keys",
+        &warm,
+        &fresh,
+    );
 }
 
 #[test]
@@ -1809,7 +1558,49 @@ fn correctness_oracle_rejects_missing_reachable_transaction_on_both_sides() {
     );
     let mut omitted = BTreeMap::new();
     omitted.insert(root_identity, Some(root_transaction));
-    reachable_successful_body_identities("both-missing", &output, &omitted, &options);
+    crate::warm_fresh_parity::reachable_body_identities(
+        "both-missing",
+        &output,
+        &omitted,
+        &options,
+    );
+}
+
+#[test]
+#[should_panic(expected = "exact failed BodyTransaction diverged")]
+fn correctness_oracle_rejects_divergent_deterministic_failure_transactions() {
+    let options = CompileOptions::default();
+    let warm_source = SourceSnapshot::single("main.rue", "fn main() -> i32 { true }\n").unwrap();
+    let fresh_source = SourceSnapshot::single("main.rue", "fn main() -> i32 { false }\n").unwrap();
+    let mut warm_session = CompilerSession::new();
+    let mut fresh_session = CompilerSession::new();
+    warm_session.update(&warm_source).into_result().unwrap();
+    fresh_session.update(&fresh_source).into_result().unwrap();
+    assert!(warm_session.rooted_cfg(&options).is_err());
+    assert!(fresh_session.rooted_cfg(&options).is_err());
+    let warm_failure = warm_session
+        .retained_body_identity_states_for_test(&options)
+        .into_values()
+        .find_map(|transaction| match transaction {
+            Some(crate::BodyTransaction::DeterministicFailure { .. }) => Some(transaction),
+            _ => None,
+        })
+        .expect("warm invalid body retains a deterministic failure");
+    let fresh_failure = fresh_session
+        .retained_body_identity_states_for_test(&options)
+        .into_values()
+        .find_map(|transaction| match transaction {
+            Some(crate::BodyTransaction::DeterministicFailure { .. }) => Some(transaction),
+            _ => None,
+        })
+        .expect("fresh invalid body retains a deterministic failure");
+    let warm = BTreeMap::from([("shared-invalid-body".to_owned(), warm_failure)]);
+    let fresh = BTreeMap::from([("shared-invalid-body".to_owned(), fresh_failure)]);
+    crate::warm_fresh_parity::assert_deterministic_failure_body_transaction_parity(
+        "divergent deterministic failure",
+        &warm,
+        &fresh,
+    );
 }
 
 #[test]

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -899,12 +899,10 @@ impl RootedCfgOutput {
         &self.work
     }
 
-    #[cfg(test)]
     pub(crate) fn declarations(&self) -> &[crate::DurableDeclarationSemantic] {
         &self.graph.declarations
     }
 
-    #[cfg(test)]
     pub(crate) fn anonymous_nominals(
         &self,
     ) -> &[crate::durable_semantics::DurableAnonymousNominal] {
@@ -923,7 +921,6 @@ impl RootedCfgOutput {
         self.type_pools().map(|pool| pool.stats()).collect()
     }
 
-    #[cfg(test)]
     pub(crate) fn string_domains(&self) -> impl ExactSizeIterator<Item = &[String]> {
         self.cfgs
             .iter()
@@ -3528,7 +3525,6 @@ impl CompilerSession {
     /// Diagnostic snapshot from the most recently attempted query, whether it
     /// succeeded or failed. In-tree warm/fresh parity oracles compare this
     /// retained selection; it is not part of the stable facade.
-    #[cfg(test)]
     pub(crate) fn latest_diagnostics_for_test(&self) -> Option<&Arc<FrontendDiagnosticSnapshot>> {
         self.diagnostics.latest()
     }
@@ -7003,7 +6999,6 @@ fn continues_discovery_lifecycle(
         .all(|observation| carried_ledger.get(observation.request()) == Some(observation))
 }
 
-#[cfg(test)]
 impl CompilerSession {
     /// Return the producer request that owns each currently retained ordinary
     /// body terminal named by `names`. A missing declaration or a declaration
@@ -7013,6 +7008,7 @@ impl CompilerSession {
     /// revisions to prove the exact recomputed body set. Equal work counts alone
     /// cannot distinguish recomputing the intended consumers from recomputing
     /// the same number of unrelated bodies.
+    #[cfg(test)]
     pub(crate) fn retained_body_transaction_origins_for_test(
         &self,
         names: &[String],

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -19,6 +19,7 @@ pub use crate::import_discovery::{
     ImportDemandRoots, ImportDiscoveryPlan, ImportDiscoveryRequest, ImportDiscoveryWave,
     ImportInputRevision, ImportObservation, ImportObservationLedger, ImportObservationStatus,
 };
+pub use crate::warm_fresh_parity::ParityObservation;
 /// A diagnostic's source location, as the diagnostic types already hand it out.
 ///
 /// `CompileError::span` is public and returns one of these, so a consumer that
@@ -914,6 +915,19 @@ pub fn rooted_cfg(
     options: &crate::CompileOptions,
 ) -> Result<RootedCfgOutput, crate::CompileErrors> {
     session.rooted_cfg(options)
+}
+
+/// Assert warm/fresh parity for one retained source revision. This is an
+/// explicitly unstable fuzz/test-support surface: it compares the canonical
+/// semantic query graph, deterministic diagnostics, retained body identities,
+/// and linked executable bytes.
+pub fn assert_warm_fresh_parity(
+    label: &str,
+    warm_session: &mut crate::CompilerSession,
+    source: &crate::SourceSnapshot,
+    options: &crate::CompileOptions,
+) -> crate::warm_fresh_parity::ParityObservation {
+    crate::warm_fresh_parity::assert_warm_fresh_parity(label, warm_session, source, options)
 }
 
 pub fn rir_payload_storage_stats(view: &crate::RirView) -> rue_rir::RirPayloadStorageStats {

--- a/crates/rue-compiler/src/warm_fresh_parity.rs
+++ b/crates/rue-compiler/src/warm_fresh_parity.rs
@@ -1,0 +1,451 @@
+//! Unstable adapter exposing the compiler's canonical warm/fresh parity oracle
+//! to fuzz targets. Scaling rows and fuzz sequences both call this one
+//! compiler-owned implementation.
+
+use crate::{CompileErrors, CompileOptions, CompilerSession, RootedCfgOutput, SourceSnapshot};
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+fn close_fuzz_discovery(session: &mut CompilerSession, source: &SourceSnapshot, epoch: u64) {
+    use crate::unstable::{
+        AcceptedImportSource, DiscoverySourceAssembler, ImportDemandMode, ImportObservation,
+        begin_import_input_request, close_import_input_request, import_demand_frontier_for_roots,
+        publish_import_observation_batch, stage_import_input_request,
+    };
+
+    let context = crate::ImportDiscoveryContext::new(epoch, "/p", None, "warm-session-fuzz")
+        .expect("fuzz discovery context is valid");
+    let root = source.metadata().root_file_id();
+    let root_path = source
+        .metadata()
+        .physical_path(root)
+        .expect("snapshot root has a physical path")
+        .to_owned();
+    let root_source = source
+        .shared_source_text(root)
+        .expect("snapshot root has source text");
+    let mut assembler = DiscoverySourceAssembler::new(
+        context.clone(),
+        root_path.clone(),
+        root_path,
+        crate::PhysicalFileIdentity::new(1807, root.index() as u64 + 1),
+        crate::FileMetadataFingerprint::new(root_source.len() as u64, epoch, epoch),
+        root_source,
+    )
+    .expect("fuzz root is accepted");
+    for file in source.files().filter(|file| file.file_id != root) {
+        let path = source
+            .metadata()
+            .physical_path(file.file_id)
+            .expect("snapshot file has a physical path");
+        assembler
+            .add_explicit(
+                path,
+                path,
+                crate::PhysicalFileIdentity::new(1807, file.file_id.index() as u64 + 1),
+                crate::FileMetadataFingerprint::new(file.source.len() as u64, epoch, epoch),
+                Arc::new(file.source.to_owned()),
+            )
+            .expect("fuzz import source is accepted");
+    }
+    let discovered = assembler.snapshot().expect("fuzz snapshot assembles");
+    let accepted_reads = assembler.accepted_read_manifest();
+    let mut revision = begin_import_input_request(
+        session,
+        &discovered,
+        context.clone(),
+        accepted_reads.clone(),
+    )
+    .expect("fuzz import request begins");
+    loop {
+        let plan = stage_import_input_request(session, revision).expect("fuzz plan stages");
+        let frontier = import_demand_frontier_for_roots(
+            session,
+            revision,
+            &plan,
+            ImportDemandMode::Rooted,
+            &plan.demand_roots(),
+        )
+        .expect("fuzz demand frontier roots");
+        if frontier.requests().is_empty() {
+            close_import_input_request(session, revision).expect("fuzz discovery closes");
+            return;
+        }
+        let observations = frontier
+            .requests()
+            .iter()
+            .map(|request| {
+                let read = accepted_reads
+                    .iter()
+                    .find(|read| read.requested_path() == request.requested_path())
+                    .expect("fuzz accepts every demanded read");
+                let module = discovered
+                    .files()
+                    .find(|file| discovered.module_id(file.file_id) == Some(read.module()))
+                    .expect("fuzz accepted module exists");
+                ImportObservation::accepted(
+                    request.clone(),
+                    AcceptedImportSource::new(
+                        request.requested_path(),
+                        read.canonical_path(),
+                        read.metadata_identity(),
+                        read.metadata_fingerprint(),
+                        Arc::new(module.source.to_owned()),
+                    )
+                    .expect("fuzz accepted source is valid"),
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .expect("fuzz observations are valid");
+        revision = publish_import_observation_batch(
+            session,
+            &frontier,
+            &discovered,
+            accepted_reads.clone(),
+            observations,
+        )
+        .expect("fuzz discovery publishes");
+    }
+}
+
+fn render_diagnostics(errors: &CompileErrors) -> String {
+    errors
+        .iter()
+        .map(|error| format!("{error:?}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn render_diagnostic_snapshot(snapshot: Option<&Arc<crate::FrontendDiagnosticSnapshot>>) -> String {
+    snapshot.map_or_else(
+        || "<none>".to_owned(),
+        |snapshot| {
+            // Do not Debug-render the whole snapshot: its SourceMetadata contains
+            // hash maps whose iteration order is intentionally not a parity
+            // contract. These are the deterministic diagnostic inputs and output.
+            format!(
+                "stage={:?}\nrevision={:?}\nerrors={:?}\nwarnings={:?}",
+                snapshot.stage(),
+                snapshot.source_revision(),
+                snapshot.errors(),
+                snapshot.warnings()
+            )
+        },
+    )
+}
+
+fn assert_no_graceful_ice(errors: &CompileErrors) {
+    for error in errors.iter() {
+        if matches!(
+            error.kind,
+            crate::ErrorKind::CompilerProducerInvariant(_)
+                | crate::ErrorKind::InternalError(_)
+                | crate::ErrorKind::InternalCodegenError(_)
+        ) {
+            panic!("graceful ICE: {error:?}");
+        }
+    }
+}
+
+fn body_query_identity(instance: &crate::FunctionInstanceKey, options: &CompileOptions) -> String {
+    format!(
+        "{:?}:{:?}",
+        instance,
+        crate::semantic_query_nucleus::SemanticQueryConfiguration {
+            target: options.target,
+            preview_features: crate::StablePreviewFeatures::new(&options.preview_features),
+        }
+    )
+}
+
+pub(crate) fn reachable_body_identities(
+    label: &str,
+    output: &RootedCfgOutput,
+    states: &BTreeMap<String, Option<crate::BodyTransaction>>,
+    options: &CompileOptions,
+) -> BTreeSet<String> {
+    let mut pending = output
+        .functions()
+        .iter()
+        .map(|function| body_query_identity(&function.function, options))
+        .collect::<Vec<_>>();
+    let mut reachable = BTreeSet::new();
+    while let Some(identity) = pending.pop() {
+        if !reachable.insert(identity.clone()) {
+            continue;
+        }
+        let Some(Some(transaction)) = states.get(&identity) else {
+            panic!("{label}: reachable successful body identity has no transaction: {identity}");
+        };
+        for reference in transaction.references().0.iter() {
+            if let crate::body_query::BodyReference::Callable(instance) = reference {
+                pending.push(body_query_identity(instance, options));
+            }
+        }
+    }
+    reachable
+}
+
+pub(crate) fn assert_successful_output_body_presence(
+    label: &str,
+    output: &RootedCfgOutput,
+    states: &BTreeMap<String, Option<crate::BodyTransaction>>,
+) {
+    for function in output.functions() {
+        let prefix = format!("{:?}:", function.function);
+        let matching = states
+            .iter()
+            .filter(|(identity, _)| identity.starts_with(&prefix))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            matching.len(),
+            1,
+            "{label}: successful output body identity is absent or ambiguous"
+        );
+        assert!(
+            matching[0].1.is_some(),
+            "{label}: output body has no retained transaction"
+        );
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn assert_reachable_body_key_set_parity(
+    label: &str,
+    warm_bodies: &BTreeMap<String, Option<crate::BodyTransaction>>,
+    fresh_bodies: &BTreeMap<String, Option<crate::BodyTransaction>>,
+) {
+    assert_eq!(
+        warm_bodies.keys().collect::<Vec<_>>(),
+        fresh_bodies.keys().collect::<Vec<_>>(),
+        "{label}: successful warm/fresh body-key sets differ"
+    );
+}
+
+/// Compare deterministic-failure body terminals that both sessions requested.
+/// A failed rooted query may stop before requesting an unchanged helper, so
+/// only overlapping failure identities are authoritative for this check.
+pub(crate) fn assert_deterministic_failure_body_transaction_parity(
+    label: &str,
+    warm_bodies: &BTreeMap<String, Option<crate::BodyTransaction>>,
+    fresh_bodies: &BTreeMap<String, Option<crate::BodyTransaction>>,
+) {
+    let warm_failures = warm_bodies
+        .iter()
+        .filter(|(_, transaction)| {
+            matches!(
+                transaction,
+                Some(crate::BodyTransaction::DeterministicFailure { .. })
+            )
+        })
+        .map(|(identity, transaction)| (identity.clone(), transaction.as_ref().unwrap().clone()))
+        .collect::<BTreeMap<_, _>>();
+    let fresh_failures = fresh_bodies
+        .iter()
+        .filter(|(_, transaction)| {
+            matches!(
+                transaction,
+                Some(crate::BodyTransaction::DeterministicFailure { .. })
+            )
+        })
+        .map(|(identity, transaction)| (identity.clone(), transaction.as_ref().unwrap().clone()))
+        .collect::<BTreeMap<_, _>>();
+    for identity in warm_failures
+        .keys()
+        .filter(|identity| fresh_failures.contains_key(*identity))
+    {
+        assert!(
+            crate::transaction_equal(&warm_failures[identity], &fresh_failures[identity]),
+            "{label}: exact failed BodyTransaction diverged for {identity}"
+        );
+    }
+}
+
+/// The single warm/fresh oracle for incremental correctness. It compares the
+/// reachable retained body/key set, exact body transactions, public semantic
+/// artifacts, diagnostics, warnings, and linked executable bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParityObservation {
+    pub rooted_success: bool,
+    pub executable_success: bool,
+}
+
+pub(crate) fn assert_rooted_parity(
+    label: &str,
+    warm_session: &mut CompilerSession,
+    fresh_session: &mut CompilerSession,
+    _source: &SourceSnapshot,
+    options: &CompileOptions,
+    warm: &Result<RootedCfgOutput, CompileErrors>,
+    fresh: &Result<RootedCfgOutput, CompileErrors>,
+) -> ParityObservation {
+    let warm_bodies = warm_session.retained_body_identity_states_for_test(options);
+    let fresh_bodies = fresh_session.retained_body_identity_states_for_test(options);
+    let rooted_success = warm.is_ok();
+    let mut executable_success = false;
+    match (warm, fresh) {
+        (Ok(warm), Ok(fresh)) => {
+            let warm_reachable = reachable_body_identities(label, warm, &warm_bodies, options);
+            let fresh_reachable = reachable_body_identities(label, fresh, &fresh_bodies, options);
+            assert_eq!(
+                warm_reachable, fresh_reachable,
+                "{label}: reachable body-key sets diverged"
+            );
+            for identity in &warm_reachable {
+                let warm_transaction = warm_bodies.get(identity).and_then(Option::as_ref);
+                let fresh_transaction = fresh_bodies.get(identity).and_then(Option::as_ref);
+                assert_eq!(
+                    warm_transaction.is_some(),
+                    fresh_transaction.is_some(),
+                    "{label}: body presence diverged for {identity}"
+                );
+                if let (Some(warm_transaction), Some(fresh_transaction)) =
+                    (warm_transaction, fresh_transaction)
+                {
+                    assert!(
+                        crate::transaction_equal(warm_transaction, fresh_transaction),
+                        "{label}: BodyTransaction diverged for {identity}"
+                    );
+                }
+            }
+            assert_successful_output_body_presence(label, warm, &warm_bodies);
+            assert_successful_output_body_presence(label, fresh, &fresh_bodies);
+            assert_eq!(
+                format!("{:?}", warm.functions()),
+                format!("{:?}", fresh.functions()),
+                "{label}: functions diverged"
+            );
+            assert_eq!(
+                format!("{:?}", warm.warnings()),
+                format!("{:?}", fresh.warnings()),
+                "{label}: warnings diverged"
+            );
+            assert_eq!(
+                warm.string_domains().collect::<Vec<_>>(),
+                fresh.string_domains().collect::<Vec<_>>(),
+                "{label}: string domains diverged"
+            );
+            assert_eq!(
+                format!("{:?}", warm.declarations()),
+                format!("{:?}", fresh.declarations()),
+                "{label}: declarations diverged"
+            );
+            assert_eq!(
+                format!("{:?}", warm.anonymous_nominals()),
+                format!("{:?}", fresh.anonymous_nominals()),
+                "{label}: anonymous nominals diverged"
+            );
+            assert_eq!(
+                render_diagnostic_snapshot(warm_session.latest_diagnostics_for_test()),
+                render_diagnostic_snapshot(fresh_session.latest_diagnostics_for_test()),
+                "{label}: diagnostics diverged"
+            );
+            // The discovery protocol may canonicalize file identities and
+            // metadata. Use the exact snapshots that each session published;
+            // passing the pre-discovery host snapshot would intentionally fail
+            // the compiler's exact-snapshot guard and skip executable parity.
+            let warm_snapshot = warm_session.committed_snapshot_for_executable();
+            let fresh_snapshot = fresh_session.committed_snapshot_for_executable();
+            let warm_executable = warm_snapshot
+                .and_then(|snapshot| warm_session.oracle_executable(&snapshot, options));
+            let fresh_executable = fresh_snapshot
+                .and_then(|snapshot| fresh_session.oracle_executable(&snapshot, options));
+            if let Err(errors) = &warm_executable {
+                assert_no_graceful_ice(errors);
+            }
+            if let Err(errors) = &fresh_executable {
+                assert_no_graceful_ice(errors);
+            }
+            match (warm_executable, fresh_executable) {
+                (Ok(warm), Ok(fresh)) => {
+                    assert_eq!(warm.elf, fresh.elf, "{label}: executable bytes diverged");
+                    assert_eq!(
+                        format!("{:?}", warm.warnings),
+                        format!("{:?}", fresh.warnings),
+                        "{label}: executable warnings diverged"
+                    );
+                    executable_success = true;
+                }
+                (Err(warm), Err(fresh)) => assert_eq!(
+                    render_diagnostics(&warm),
+                    render_diagnostics(&fresh),
+                    "{label}: executable diagnostics diverged"
+                ),
+                (Ok(_), Err(fresh)) => panic!(
+                    "{label}: warm executable succeeded but fresh failed: {}",
+                    render_diagnostics(&fresh)
+                ),
+                (Err(warm), Ok(_)) => panic!(
+                    "{label}: warm executable failed but fresh succeeded: {}",
+                    render_diagnostics(&warm)
+                ),
+            }
+        }
+        (Err(warm), Err(fresh)) => {
+            assert_no_graceful_ice(warm);
+            assert_no_graceful_ice(fresh);
+            assert_eq!(
+                render_diagnostics(warm),
+                render_diagnostics(fresh),
+                "{label}: failure diagnostics diverged"
+            );
+            assert_eq!(
+                render_diagnostic_snapshot(warm_session.latest_diagnostics_for_test()),
+                render_diagnostic_snapshot(fresh_session.latest_diagnostics_for_test()),
+                "{label}: failure snapshots diverged"
+            );
+            // A failed rooted body/CFG query may stop before unchanged helper
+            // bodies are requested. Compare deterministic failures demanded
+            // by both sides, preserving early-stop behavior for helpers that
+            // exist only in one retained family.
+            assert_deterministic_failure_body_transaction_parity(
+                label,
+                &warm_bodies,
+                &fresh_bodies,
+            );
+        }
+        (Ok(_), Err(fresh)) => panic!(
+            "{label}: warm compiled but fresh failed: {}",
+            render_diagnostics(fresh)
+        ),
+        (Err(warm), Ok(_)) => panic!(
+            "{label}: warm failed but fresh compiled: {}",
+            render_diagnostics(warm)
+        ),
+    }
+    ParityObservation {
+        rooted_success,
+        executable_success,
+    }
+}
+
+/// Compile one already-adopted revision on the retained session and compare it
+/// with a fresh session through the canonical full artifact/oracle path.
+pub fn assert_warm_fresh_parity(
+    label: &str,
+    warm_session: &mut CompilerSession,
+    source: &SourceSnapshot,
+    options: &CompileOptions,
+) -> ParityObservation {
+    // Run every revision through the canonical in-memory discovery protocol,
+    // including import-free revisions. The latter are important topology
+    // removals: leaving the predecessor's closed graph selected would make a
+    // warm removal look like a discovery failure rather than a real edit.
+    close_fuzz_discovery(warm_session, source, 1);
+    let warm = warm_session.rooted_cfg(options);
+    let mut fresh_session = CompilerSession::new();
+    // Invalid revisions are intentionally retained by the session. Their
+    // rooted query returns deterministic diagnostics, which the shared oracle
+    // compares; update errors therefore must not short-circuit this call.
+    close_fuzz_discovery(&mut fresh_session, source, 1);
+    let fresh = fresh_session.rooted_cfg(options);
+    assert_rooted_parity(
+        label,
+        warm_session,
+        &mut fresh_session,
+        source,
+        options,
+        &warm,
+        &fresh,
+    )
+}

--- a/crates/rue-fuzz/BUCK
+++ b/crates/rue-fuzz/BUCK
@@ -16,6 +16,7 @@ rue_binary(
         "//crates/rue-rir:rue-rir-fuzz-support",
         "//crates/rue-test-runner:rue-test-runner",
         "//third-party:anyhow",
+        "//third-party:ahash",
         "//third-party:libc",
         "//third-party:proptest",
     ],

--- a/crates/rue-fuzz/README.md
+++ b/crates/rue-fuzz/README.md
@@ -26,6 +26,7 @@ Fuzz testing infrastructure for the Rue compiler. This crate helps find edge cas
 | `parser` | Lexing + parsing | ~6,500 exec/s |
 | `sema` | Semantic analysis (type checking, inference) | ~4,000-8,000 exec/s |
 | `compiler` | Full frontend (through sema) | ~4,000-8,000 exec/s |
+| `warm_session` | Bounded retained-session edit sequences with warm/fresh parity | bounded |
 | `payload_schemas` | Production RIR/AIR/CFG payload validation path | ~4,000-8,000 exec/s |
 | `emitter` | x86-64 instruction encoding | ~15,000 exec/s |
 | `emitter_sequence` | Instruction sequences with labels/jumps | ~10,000 exec/s |
@@ -144,7 +145,7 @@ To run fuzzing locally for a limited time:
 
 ```bash
 # Run each target for 5 minutes
-for target in lexer parser sema compiler payload_schemas emitter emitter_sequence; do
+for target in lexer parser sema compiler warm_session payload_schemas emitter emitter_sequence; do
     ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 $target crates/rue-fuzz/corpus
 done
 ```

--- a/crates/rue-fuzz/src/targets.rs
+++ b/crates/rue-fuzz/src/targets.rs
@@ -38,10 +38,14 @@ use rue_codegen::x86_64::{Emitter as X86Emitter, Operand, Reg, X86Inst, X86Mir};
 /// dedup signature. Legitimate user-facing errors pass through silently.
 fn assert_no_ice<T>(result: &rue_compiler::MultiErrorResult<T>) {
     if let Err(errors) = result {
-        for e in errors.iter() {
-            if is_ice(&e.kind) {
-                panic!("graceful ICE: {e}");
-            }
+        assert_no_ice_errors(errors);
+    }
+}
+
+fn assert_no_ice_errors(errors: &rue_compiler::CompileErrors) {
+    for e in errors.iter() {
+        if is_ice(&e.kind) {
+            panic!("graceful ICE: {e}");
         }
     }
 }
@@ -238,6 +242,229 @@ impl FuzzTarget for CompilerTarget {
             let result = query_full_compile(source);
             assert_no_ice(&result);
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SequenceMutation {
+    Body(u8),
+    Signature(u8),
+    Declaration(u8),
+    ImportGraph(u8),
+    Rename(u8),
+    Invalid,
+    NoOp,
+    Revert,
+}
+
+impl SequenceMutation {
+    fn decode(kind: u8, parameter: u8) -> Self {
+        match kind % 8 {
+            0 => Self::Body(parameter),
+            1 => Self::Signature(parameter),
+            2 => Self::Declaration(parameter),
+            3 => Self::ImportGraph(parameter),
+            4 => Self::Rename(parameter),
+            5 => Self::Invalid,
+            6 => Self::NoOp,
+            _ => Self::Revert,
+        }
+    }
+
+    #[cfg(test)]
+    fn label(self) -> &'static str {
+        match self {
+            Self::Body(_) => "body",
+            Self::Signature(_) => "signature",
+            Self::Declaration(_) => "declaration",
+            Self::ImportGraph(_) => "import-graph",
+            Self::Rename(_) => "rename",
+            Self::Invalid => "invalid",
+            Self::NoOp => "no-op",
+            Self::Revert => "revert",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct EditSequence(Vec<SequenceMutation>);
+
+impl EditSequence {
+    const MAX_STEPS: usize = 12;
+
+    fn decode(input: &[u8]) -> Self {
+        if input.is_empty() {
+            return Self(Vec::new());
+        }
+        let count = (input[0] as usize % (Self::MAX_STEPS + 1)).max(1);
+        Self(
+            (0..count)
+                .map(|step| {
+                    let offset = 1 + step * 3;
+                    SequenceMutation::decode(
+                        input.get(offset).copied().unwrap_or(step as u8),
+                        input.get(offset + 1).copied().unwrap_or(0)
+                            ^ input.get(offset + 2).copied().unwrap_or(0),
+                    )
+                })
+                .collect(),
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SequenceSources {
+    main: String,
+    helper: String,
+    has_helper: bool,
+}
+
+impl SequenceSources {
+    fn initial(value: u8) -> Self {
+        Self {
+            main: "const helper = @import(\"helper.rue\");\nfn main() -> i32 { helper.value() }\n"
+                .into(),
+            helper: format!("pub fn value() -> i32 {{ {} }}\n", value % 9),
+            has_helper: true,
+        }
+    }
+
+    fn snapshot(&self) -> rue_compiler::SourceSnapshot {
+        let root = rue_compiler::FileId::DEFAULT;
+        let helper = rue_compiler::FileId::new(1);
+        let mut physical = ahash::AHashMap::new();
+        let mut logical = ahash::AHashMap::new();
+        physical.insert(root, "/p/main.rue".into());
+        logical.insert(root, "main.rue".into());
+        if self.has_helper {
+            physical.insert(helper, "/p/helper.rue".into());
+            logical.insert(helper, "helper.rue".into());
+        }
+        let metadata = rue_compiler::SourceMetadata::new(root, physical, logical)
+            .expect("warm-session metadata is valid");
+        let mut contents = vec![(root, std::sync::Arc::new(self.main.clone()))];
+        if self.has_helper {
+            contents.push((helper, std::sync::Arc::new(self.helper.clone())));
+        }
+        rue_compiler::SourceSnapshot::new(metadata, contents)
+            .expect("warm-session snapshot is valid")
+    }
+
+    fn apply(&mut self, mutation: SequenceMutation, baseline: &Self) {
+        match mutation {
+            SequenceMutation::Body(value) => {
+                self.helper = format!("pub fn value() -> i32 {{ {} }}\n", value % 9);
+            }
+            SequenceMutation::Signature(value) => {
+                self.helper = if value % 2 == 0 {
+                    format!("pub fn value(x: i32) -> i32 {{ x + {} }}\n", value % 3)
+                } else {
+                    "pub fn value() -> bool { true }\n".into()
+                };
+            }
+            SequenceMutation::Declaration(value) => {
+                self.helper
+                    .push_str(&format!("pub const extra{}: i32 = {};\n", value % 5, value))
+            }
+            SequenceMutation::ImportGraph(value) => {
+                self.has_helper = value % 3 != 1;
+                self.main = if self.has_helper && value % 2 == 0 {
+                    "const helper = @import(\"helper.rue\");\nfn main() -> i32 { helper.value() }\n"
+                        .into()
+                } else {
+                    "fn main() -> i32 { 0 }\n".into()
+                };
+            }
+            SequenceMutation::Rename(value) => {
+                if value % 2 == 0 {
+                    self.main = self.main.replace("value", "renamed");
+                    self.helper = self.helper.replace("value", "renamed");
+                } else {
+                    self.main = self.main.replace("renamed", "value");
+                    self.helper = self.helper.replace("renamed", "value");
+                }
+            }
+            // Keep the syntax valid so discovery adopts the revision; the
+            // rooted semantic query then publishes a typed deterministic
+            // failure that can transition back to success.
+            SequenceMutation::Invalid => {
+                self.main = "fn main() -> i32 { let x: i32 = true; x }\n".into()
+            }
+            SequenceMutation::NoOp => {}
+            SequenceMutation::Revert => *self = baseline.clone(),
+        }
+    }
+}
+
+/// Deterministic bounded edit-sequence fuzzing over one retained session.
+pub struct WarmSessionTarget;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SequenceRunObservation {
+    adopted_revisions: usize,
+    parity_checks: usize,
+    successful_revisions: usize,
+    executable_parity_checks: usize,
+    warm_session_updates: usize,
+}
+
+fn run_edit_sequence(input: &[u8]) -> SequenceRunObservation {
+    let sequence = EditSequence::decode(input);
+    if sequence.0.is_empty() {
+        return SequenceRunObservation {
+            adopted_revisions: 0,
+            parity_checks: 0,
+            successful_revisions: 0,
+            executable_parity_checks: 0,
+            warm_session_updates: 0,
+        };
+    }
+    let options = source_compile_options(
+        rue_compiler::Target::host().expect("supported fuzz host"),
+        rue_compiler::OptLevel::O0,
+    );
+    let initial_sources = SequenceSources::initial(input.get(1).copied().unwrap_or(0));
+    let mut sources = initial_sources.clone();
+    let mut warm = rue_compiler::CompilerSession::new();
+    let initial = sources.snapshot();
+    let initial_parity = rue_compiler::unstable::assert_warm_fresh_parity(
+        "warm_session step=0 mutation=initial",
+        &mut warm,
+        &initial,
+        &options,
+    );
+    let mut observation = SequenceRunObservation {
+        adopted_revisions: 1,
+        parity_checks: 1,
+        successful_revisions: usize::from(initial_parity.rooted_success),
+        executable_parity_checks: usize::from(initial_parity.executable_success),
+        warm_session_updates: 0,
+    };
+    for (step, mutation) in sequence.0.iter().copied().enumerate() {
+        sources.apply(mutation, &initial_sources);
+        let snapshot = sources.snapshot();
+        let parity = rue_compiler::unstable::assert_warm_fresh_parity(
+            &format!("warm_session step={} mutation={mutation:?}", step + 1),
+            &mut warm,
+            &snapshot,
+            &options,
+        );
+        observation.adopted_revisions += 1;
+        observation.parity_checks += 1;
+        observation.successful_revisions += usize::from(parity.rooted_success);
+        observation.executable_parity_checks += usize::from(parity.executable_success);
+    }
+    observation.warm_session_updates = warm.unstable_metrics().updates();
+    observation
+}
+
+impl FuzzTarget for WarmSessionTarget {
+    fn name(&self) -> &'static str {
+        "warm_session"
+    }
+
+    fn fuzz(&self, input: &[u8]) {
+        let _ = std::hint::black_box(run_edit_sequence(input));
     }
 }
 
@@ -1184,6 +1411,7 @@ pub fn all_targets() -> Vec<Box<dyn FuzzTarget>> {
         Box::new(ParserTarget),
         Box::new(SemaTarget),
         Box::new(CompilerTarget),
+        Box::new(WarmSessionTarget),
         Box::new(CompilerAarch64Target),
         Box::new(CompilerX86_64O1Target),
         Box::new(PayloadSchemasTarget),
@@ -1201,6 +1429,7 @@ pub fn get_target(name: &str) -> Option<Box<dyn FuzzTarget>> {
         "parser" => Some(Box::new(ParserTarget)),
         "sema" => Some(Box::new(SemaTarget)),
         "compiler" => Some(Box::new(CompilerTarget)),
+        "warm_session" => Some(Box::new(WarmSessionTarget)),
         "compiler_aarch64" => Some(Box::new(CompilerAarch64Target)),
         "compiler_x86_64_o1" => Some(Box::new(CompilerX86_64O1Target)),
         "payload_schemas" => Some(Box::new(PayloadSchemasTarget)),
@@ -1270,6 +1499,209 @@ mod tests {
     fn test_compiler_target_type_error() {
         let target = CompilerTarget;
         target.fuzz(b"fn main() -> i32 { true }");
+    }
+
+    #[test]
+    fn warm_session_decoder_is_deterministic_and_bounded() {
+        let input = [17, 0, 4, 0, 1, 7, 0, 2, 6, 0, 3, 5, 0];
+        let first = EditSequence::decode(&input);
+        assert_eq!(first, EditSequence::decode(&input));
+        assert!(!first.0.is_empty());
+        assert!(first.0.len() <= EditSequence::MAX_STEPS);
+    }
+
+    #[test]
+    fn warm_session_decoder_reaches_every_invalidation_family() {
+        let input = [
+            8, 0, 0, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0, 4, 4, 0, 5, 5, 0, 6, 6, 0, 7, 7, 0,
+        ];
+        let sequence = EditSequence::decode(&input);
+        let labels = sequence
+            .0
+            .iter()
+            .map(|mutation| mutation.label())
+            .collect::<Vec<_>>();
+        for family in [
+            "body",
+            "signature",
+            "declaration",
+            "import-graph",
+            "rename",
+            "invalid",
+            "no-op",
+            "revert",
+        ] {
+            assert!(
+                labels.contains(&family),
+                "decoder omitted {family}: {labels:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn warm_session_revert_returns_to_the_baseline_revision() {
+        let baseline = SequenceSources::initial(3);
+        let mut changed = baseline.clone();
+        changed.apply(SequenceMutation::Body(8), &baseline);
+        assert_ne!(changed.helper, baseline.helper);
+        assert_ne!(
+            changed.snapshot().source_text(rue_compiler::FileId::new(1)),
+            baseline
+                .snapshot()
+                .source_text(rue_compiler::FileId::new(1))
+        );
+        changed.apply(SequenceMutation::Revert, &baseline);
+        assert_eq!(changed, baseline);
+    }
+
+    #[test]
+    fn warm_session_mutation_table_proves_each_state_transition() {
+        let baseline = SequenceSources::initial(3);
+        let cases = [
+            ("body", SequenceMutation::Body(8), [0, 8, 0], 2),
+            ("signature", SequenceMutation::Signature(2), [1, 2, 0], 1),
+            (
+                "declaration",
+                SequenceMutation::Declaration(4),
+                [2, 4, 0],
+                2,
+            ),
+            (
+                "import-graph-removal",
+                SequenceMutation::ImportGraph(1),
+                [3, 1, 0],
+                2,
+            ),
+            ("rename", SequenceMutation::Rename(2), [4, 2, 0], 2),
+            ("invalid", SequenceMutation::Invalid, [5, 0, 0], 1),
+        ];
+        for (label, mutation, bytes, successful_revisions) in cases {
+            let mut after = baseline.clone();
+            after.apply(mutation, &baseline);
+            match mutation {
+                SequenceMutation::Body(_) => {
+                    assert_ne!(after.helper, baseline.helper, "{label} must edit the body");
+                }
+                SequenceMutation::Signature(_) => {
+                    assert!(after.helper.contains("value(x: i32)"));
+                    assert_ne!(
+                        after.helper, baseline.helper,
+                        "{label} must edit the signature"
+                    );
+                }
+                SequenceMutation::Declaration(value) => {
+                    assert!(
+                        after
+                            .helper
+                            .contains(&format!("pub const extra{}", value % 5))
+                    );
+                    assert_ne!(
+                        after.helper, baseline.helper,
+                        "{label} must add a declaration"
+                    );
+                }
+                SequenceMutation::ImportGraph(_) => {
+                    assert!(!after.has_helper, "{label} must remove the helper file");
+                    assert!(
+                        !after.main.contains("@import"),
+                        "{label} must remove the import"
+                    );
+                }
+                SequenceMutation::Rename(_) => {
+                    assert!(after.main.contains("renamed()"));
+                    assert!(after.helper.contains("fn renamed"));
+                    assert!(
+                        after.has_helper,
+                        "{label} must keep the imported file reachable"
+                    );
+                }
+                SequenceMutation::Invalid => {
+                    assert!(after.main.contains("let x: i32 = true"));
+                    assert_ne!(
+                        after.main, baseline.main,
+                        "{label} must leave the valid state"
+                    );
+                }
+                SequenceMutation::NoOp | SequenceMutation::Revert => unreachable!(),
+            }
+            // The first byte is the step count, so the first mutation triplet
+            // begins at byte one; its selector also deterministically seeds
+            // the initial helper body.
+            let input = vec![1, bytes[0], bytes[1], bytes[2]];
+            let observation = run_edit_sequence(&input);
+            assert_eq!(
+                observation.successful_revisions, successful_revisions,
+                "{label} must preserve its expected semantic validity"
+            );
+            assert_eq!(
+                observation.executable_parity_checks, successful_revisions,
+                "{label} must exercise executable parity for every successful revision"
+            );
+            assert_eq!(
+                observation.warm_session_updates, 2,
+                "{label} must adopt both revisions"
+            );
+        }
+
+        let mut removed = baseline.clone();
+        removed.apply(SequenceMutation::ImportGraph(1), &baseline);
+        assert!(!removed.has_helper);
+        removed.apply(SequenceMutation::Revert, &baseline);
+        assert_eq!(
+            removed, baseline,
+            "revert must add the removed topology back"
+        );
+        let observation = run_edit_sequence(&[2, 3, 1, 0, 7, 0, 0]);
+        assert_eq!(observation.successful_revisions, 3);
+        assert_eq!(observation.executable_parity_checks, 3);
+        assert_eq!(observation.warm_session_updates, 3);
+    }
+
+    #[test]
+    fn warm_session_observes_initial_and_every_mutation_step() {
+        let input = [
+            8, 0, 0, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0, 4, 4, 0, 5, 5, 0, 6, 6, 0, 7, 7, 0,
+        ];
+        let observation = run_edit_sequence(&input);
+        assert_eq!(observation.adopted_revisions, 9);
+        assert_eq!(observation.parity_checks, observation.adopted_revisions);
+        assert_eq!(observation.successful_revisions, 5);
+        assert_eq!(observation.executable_parity_checks, 5);
+        assert_eq!(
+            observation.warm_session_updates,
+            observation.adopted_revisions
+        );
+    }
+
+    #[test]
+    fn warm_session_fixture_has_semantic_invalid_transition_and_recovery() {
+        let baseline = SequenceSources::initial(2);
+        let mut invalid = baseline.clone();
+        invalid.apply(SequenceMutation::Invalid, &baseline);
+        assert!(invalid.main.contains("let x: i32 = true"));
+        assert_ne!(invalid.main, baseline.main);
+        invalid.apply(SequenceMutation::Revert, &baseline);
+        assert_eq!(invalid, baseline);
+        // The integration fixture runs this exact valid -> semantic-invalid ->
+        // valid sequence through the retained-session parity path.
+        let observation = run_edit_sequence(&[2, 5, 0, 0, 7, 0, 0]);
+        assert_eq!(observation.adopted_revisions, 3);
+        assert_eq!(observation.parity_checks, 3);
+        assert_eq!(observation.successful_revisions, 2);
+        assert_eq!(observation.executable_parity_checks, 2);
+        assert_eq!(
+            observation.warm_session_updates,
+            observation.adopted_revisions
+        );
+    }
+
+    #[test]
+    fn warm_session_target_runs_stepwise_parity_over_valid_invalid_and_reverted_edits() {
+        // The first byte selects eight steps; selectors cover body, signature,
+        // declaration, import graph, rename, invalid, no-op, and revert.
+        WarmSessionTarget.fuzz(&[
+            8, 0, 0, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0, 4, 4, 0, 5, 5, 0, 6, 6, 0, 7, 7, 0,
+        ]);
     }
 
     #[test]
@@ -1608,7 +2040,7 @@ mod tests {
     #[test]
     fn test_all_targets() {
         let targets = all_targets();
-        assert_eq!(targets.len(), 11);
+        assert_eq!(targets.len(), 12);
     }
 
     #[test]
@@ -1617,6 +2049,7 @@ mod tests {
         assert!(get_target("parser").is_some());
         assert!(get_target("sema").is_some());
         assert!(get_target("compiler").is_some());
+        assert!(get_target("warm_session").is_some());
         assert!(get_target("compiler_aarch64").is_some());
         assert!(get_target("compiler_x86_64_o1").is_some());
         assert!(get_target("payload_schemas").is_some());

--- a/scripts/test-fuzz-report-failure.py
+++ b/scripts/test-fuzz-report-failure.py
@@ -593,6 +593,7 @@ class WorkflowContractTests(unittest.TestCase):
             "parser",
             "sema",
             "compiler",
+            "warm_session",
             "compiler_aarch64",
             "compiler_x86_64_o1",
             "payload_schemas",


### PR DESCRIPTION
## Summary\n\n- add deterministic bounded edit-sequence fuzzing over one retained CompilerSession\n- compare warm and fresh semantic artifacts, retained body transactions, diagnostics, and executable bytes after every mutation\n- cover body, signature, declaration, import topology, rename, invalid/recovery, no-op, and revert transitions\n- register the target in the fuzz inventory and nightly corpus workflow\n\n## Validation\n\n- scripts/rue unit fuzz warm_session\n- scripts/rue unit compiler correctness_oracle\n- scripts/rue unit compiler api_inventory\n- python3 scripts/test-fuzz-report-failure.py WorkflowContractTests\n- scripts/rue quick\n- scripts/rue premerge\n- scripts/rue test\n- scripts/rue fmt\n- git diff --check\n\nFixes RUE-1807