### PR TITLE
RUE-1800: centralize transient frame arithmetic

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -14,6 +14,9 @@ use super::mir::{Aarch64Inst, Aarch64Mir, Cond, LabelId, Operand, Reg, VReg};
 use crate::agg_slots::SlotBackend;
 use crate::allocation;
 use crate::cfg_lower::CfgLowerContext;
+use crate::frame_layout::{
+    checked_aligned_cell_region_bytes, checked_cell_byte_offset, checked_displacement_bytes,
+};
 
 /// Argument passing registers per AAPCS64. ABI arg slots beyond these are
 /// passed on the caller's stack (slot `k >= 8` at `[fp+16+(k-8)*8]` in the
@@ -68,11 +71,6 @@ const _: () = {
     }
 };
 
-/// Round `value` up to a multiple of `alignment` (a power of two ≥ 1).
-const fn align_up_u32(value: u32, alignment: u32) -> u32 {
-    value.div_ceil(alignment) * alignment
-}
-
 /// CFG to Aarch64Mir lowering.
 pub struct CfgLower<'a> {
     /// Shared context with type helpers and chain tracing.
@@ -120,7 +118,8 @@ impl crate::call_plan::CallMaterializer for CfgLower<'_> {
         self.mir.push(Aarch64Inst::SubImm {
             dst: Operand::Physical(Reg::Sp),
             src: Operand::Physical(Reg::Sp),
-            imm: storage_bytes as i32,
+            imm: checked_displacement_bytes(u64::from(storage_bytes))
+                .expect("sret storage must fit displacement"),
         });
         let pointer = self.mir.alloc_vreg();
         self.mir.push(Aarch64Inst::MovRR {
@@ -145,7 +144,8 @@ impl crate::call_plan::CallMaterializer for CfgLower<'_> {
         self.mir.push(Aarch64Inst::SubImm {
             dst: Operand::Physical(Reg::Sp),
             src: Operand::Physical(Reg::Sp),
-            imm: storage_bytes as i32,
+            imm: checked_displacement_bytes(u64::from(storage_bytes))
+                .expect("indirect argument storage must fit displacement"),
         });
         let pointer = self.mir.alloc_vreg();
         self.mir.push(Aarch64Inst::MovRR {
@@ -168,7 +168,8 @@ impl crate::call_plan::CallMaterializer for CfgLower<'_> {
         self.mir.push(Aarch64Inst::SubImm {
             dst: Operand::Physical(Reg::Sp),
             src: Operand::Physical(Reg::Sp),
-            imm: storage_bytes as i32,
+            imm: checked_displacement_bytes(u64::from(storage_bytes))
+                .expect("indirect argument storage must fit displacement"),
         });
         let pointer = self.mir.alloc_vreg();
         self.mir.push(Aarch64Inst::MovRR {
@@ -300,7 +301,16 @@ impl<'a> CfgLower<'a> {
 
         let out_shape = plan.out_shape();
         let out_bytes = out_shape
-            .map(|shape| (shape.shape().slots.len() as i32 * 8 + 15) & !15)
+            .map(|shape| {
+                i32::try_from(
+                    checked_aligned_cell_region_bytes(
+                        u64::try_from(shape.shape().slots.len())
+                            .expect("runtime out slot count must fit u64"),
+                    )
+                    .expect("runtime out area must pass frame-budget preflight"),
+                )
+                .expect("runtime out area must fit displacement")
+            })
             .unwrap_or(0);
         if out_bytes > 0 {
             self.mir.push(Aarch64Inst::SubImm {
@@ -399,7 +409,8 @@ impl<'a> CfgLower<'a> {
                         self.mir.push(Aarch64Inst::Ldr {
                             dst: Operand::Virtual(slot),
                             base: Reg::Sp,
-                            offset: (index * 8) as i32,
+                            offset: checked_cell_byte_offset(index as u64)
+                                .expect("runtime out slot offset must fit displacement"),
                         });
                         slot
                     })
@@ -876,14 +887,16 @@ impl<'a> CfgLower<'a> {
             self.mir.push(Aarch64Inst::SubImm {
                 dst: Operand::Physical(Reg::Sp),
                 src: Operand::Physical(Reg::Sp),
-                imm: plan.stack_bytes as i32,
+                imm: checked_displacement_bytes(u64::from(plan.stack_bytes))
+                    .expect("call stack area must fit displacement"),
             });
         }
         for (index, arg) in plan.abi_slots.iter().skip(ARG_REGS.len()).enumerate() {
             self.mir.push(Aarch64Inst::Str {
                 src: Operand::Virtual(*arg),
                 base: Reg::Sp,
-                offset: (index * 8) as i32,
+                offset: checked_cell_byte_offset(index as u64)
+                    .expect("call stack slot offset must fit displacement"),
             });
         }
         for (index, arg) in plan.abi_slots.iter().take(num_reg_args).enumerate() {
@@ -898,7 +911,8 @@ impl<'a> CfgLower<'a> {
             self.mir.push(Aarch64Inst::AddImm {
                 dst: Operand::Physical(Reg::Sp),
                 src: Operand::Physical(Reg::Sp),
-                imm: plan.stack_bytes as i32,
+                imm: checked_displacement_bytes(u64::from(plan.stack_bytes))
+                    .expect("call stack area must fit displacement"),
             });
         }
         // Free the by-value indirect argument buffers (RUE-1005), restoring sp
@@ -908,7 +922,8 @@ impl<'a> CfgLower<'a> {
             self.mir.push(Aarch64Inst::AddImm {
                 dst: Operand::Physical(Reg::Sp),
                 src: Operand::Physical(Reg::Sp),
-                imm: plan.caller_indirect_bytes as i32,
+                imm: checked_displacement_bytes(u64::from(plan.caller_indirect_bytes))
+                    .expect("indirect argument area must fit displacement"),
             });
         }
         let slots = match plan.return_plan {
@@ -942,7 +957,8 @@ impl<'a> CfgLower<'a> {
                             self.mir.push(Aarch64Inst::Ldr {
                                 dst: Operand::Virtual(slot),
                                 base: Reg::Sp,
-                                offset: (index * 8) as i32,
+                                offset: checked_cell_byte_offset(index as u64)
+                                    .expect("sret slot offset must fit displacement"),
                             });
                             slot
                         })
@@ -951,7 +967,8 @@ impl<'a> CfgLower<'a> {
                 self.mir.push(Aarch64Inst::AddImm {
                     dst: Operand::Physical(Reg::Sp),
                     src: Operand::Physical(Reg::Sp),
-                    imm: storage_bytes as i32,
+                    imm: checked_displacement_bytes(u64::from(storage_bytes))
+                        .expect("sret storage must fit displacement"),
                 });
                 slots
             }
@@ -1060,7 +1077,8 @@ impl<'a> CfgLower<'a> {
             self.mir.push(Aarch64Inst::SubImm {
                 dst: Operand::Physical(Reg::Sp),
                 src: Operand::Physical(Reg::Sp),
-                imm: sret_storage as i32,
+                imm: checked_displacement_bytes(u64::from(sret_storage))
+                    .expect("foreign sret storage must fit displacement"),
             });
             let p = self.mir.alloc_vreg();
             self.mir.push(Aarch64Inst::MovRR {
@@ -1101,9 +1119,12 @@ impl<'a> CfgLower<'a> {
                     self.mir.push(Aarch64Inst::SubImm {
                         dst: Operand::Physical(Reg::Sp),
                         src: Operand::Physical(Reg::Sp),
-                        imm: image.storage_bytes as i32,
+                        imm: checked_displacement_bytes(u64::from(image.storage_bytes))
+                            .expect("foreign result storage must fit displacement"),
                     });
-                    byref_bytes += image.storage_bytes;
+                    byref_bytes = byref_bytes
+                        .checked_add(image.storage_bytes)
+                        .expect("foreign argument storage must fit u32");
                     let ptr = self.mir.alloc_vreg();
                     self.mir.push(Aarch64Inst::MovRR {
                         dst: Operand::Virtual(ptr),
@@ -1133,19 +1154,22 @@ impl<'a> CfgLower<'a> {
         }
 
         let num_stack = stack_ops.len();
-        let stack_bytes = align_up_u32((num_stack * 8) as u32, 16);
+        let stack_bytes = checked_aligned_cell_region_bytes(num_stack as u64)
+            .expect("foreign stack area must pass frame-budget preflight");
         if stack_bytes > 0 {
             self.mir.push(Aarch64Inst::SubImm {
                 dst: Operand::Physical(Reg::Sp),
                 src: Operand::Physical(Reg::Sp),
-                imm: stack_bytes as i32,
+                imm: checked_displacement_bytes(u64::from(stack_bytes))
+                    .expect("foreign stack area must fit displacement"),
             });
         }
         for (index, v) in stack_ops.iter().enumerate() {
             self.mir.push(Aarch64Inst::Str {
                 src: Operand::Virtual(*v),
                 base: Reg::Sp,
-                offset: (index * 8) as i32,
+                offset: checked_cell_byte_offset(index as u64)
+                    .expect("foreign stack slot offset must fit displacement"),
             });
         }
         for (index, v) in int_ops.iter().enumerate() {
@@ -1171,14 +1195,16 @@ impl<'a> CfgLower<'a> {
             self.mir.push(Aarch64Inst::AddImm {
                 dst: Operand::Physical(Reg::Sp),
                 src: Operand::Physical(Reg::Sp),
-                imm: stack_bytes as i32,
+                imm: checked_displacement_bytes(u64::from(stack_bytes))
+                    .expect("foreign stack area must fit displacement"),
             });
         }
         if byref_bytes > 0 {
             self.mir.push(Aarch64Inst::AddImm {
                 dst: Operand::Physical(Reg::Sp),
                 src: Operand::Physical(Reg::Sp),
-                imm: byref_bytes as i32,
+                imm: checked_displacement_bytes(u64::from(byref_bytes))
+                    .expect("foreign argument storage must fit displacement"),
             });
         }
 
@@ -1205,7 +1231,8 @@ impl<'a> CfgLower<'a> {
                 self.mir.push(Aarch64Inst::SubImm {
                     dst: Operand::Physical(Reg::Sp),
                     src: Operand::Physical(Reg::Sp),
-                    imm: image.storage_bytes as i32,
+                    imm: checked_displacement_bytes(u64::from(image.storage_bytes))
+                        .expect("foreign argument storage must fit displacement"),
                 });
                 let buf = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::MovRR {
@@ -1226,7 +1253,8 @@ impl<'a> CfgLower<'a> {
                 self.mir.push(Aarch64Inst::AddImm {
                     dst: Operand::Physical(Reg::Sp),
                     src: Operand::Physical(Reg::Sp),
-                    imm: image.storage_bytes as i32,
+                    imm: checked_displacement_bytes(u64::from(image.storage_bytes))
+                        .expect("foreign argument storage must fit displacement"),
                 });
                 native
             }
@@ -1236,7 +1264,8 @@ impl<'a> CfgLower<'a> {
                 self.mir.push(Aarch64Inst::AddImm {
                     dst: Operand::Physical(Reg::Sp),
                     src: Operand::Physical(Reg::Sp),
-                    imm: sret_storage as i32,
+                    imm: checked_displacement_bytes(u64::from(sret_storage))
+                        .expect("foreign sret storage must fit displacement"),
                 });
                 native
             }
@@ -1262,7 +1291,8 @@ impl<'a> CfgLower<'a> {
         self.mir.push(Aarch64Inst::SubImm {
             dst: Operand::Physical(Reg::Sp),
             src: Operand::Physical(Reg::Sp),
-            imm: image.storage_bytes as i32,
+            imm: checked_displacement_bytes(u64::from(image.storage_bytes))
+                .expect("foreign argument storage must fit displacement"),
         });
         let buf = self.mir.alloc_vreg();
         self.mir.push(Aarch64Inst::MovRR {
@@ -1281,7 +1311,8 @@ impl<'a> CfgLower<'a> {
         self.mir.push(Aarch64Inst::AddImm {
             dst: Operand::Physical(Reg::Sp),
             src: Operand::Physical(Reg::Sp),
-            imm: image.storage_bytes as i32,
+            imm: checked_displacement_bytes(u64::from(image.storage_bytes))
+                .expect("foreign argument storage must fit displacement"),
         });
         ebs
     }
@@ -2223,7 +2254,14 @@ impl<'a> CfgLower<'a> {
                     .primary
             }
             crate::value_plan::IntrinsicOperation::Syscall => {
-                let stack_space = ((plan.args.len() * 8 + 15) & !15) as i32;
+                let stack_space = i32::try_from(
+                    checked_aligned_cell_region_bytes(
+                        u64::try_from(plan.args.len())
+                            .expect("syscall stack slot count must fit u64"),
+                    )
+                    .expect("syscall stack area must fit displacement"),
+                )
+                .expect("syscall stack area must fit i32");
                 if stack_space > 0 {
                     self.mir.push(Aarch64Inst::SubImm {
                         dst: Operand::Physical(Reg::Sp),
@@ -2235,7 +2273,8 @@ impl<'a> CfgLower<'a> {
                     self.mir.push(Aarch64Inst::Str {
                         src: Operand::Virtual(arg.primary),
                         base: Reg::Sp,
-                        offset: (index * 8) as i32,
+                        offset: checked_cell_byte_offset(index as u64)
+                            .expect("syscall slot offset must fit displacement"),
                     });
                 }
                 let syscall_reg = if self.target.is_macho() {
@@ -2256,7 +2295,8 @@ impl<'a> CfgLower<'a> {
                         self.mir.push(Aarch64Inst::Ldr {
                             dst: Operand::Physical(*reg),
                             base: Reg::Sp,
-                            offset: ((index + 1) * 8) as i32,
+                            offset: checked_cell_byte_offset((index + 1) as u64)
+                                .expect("syscall argument offset must fit displacement"),
                         });
                     }
                 }
@@ -5274,6 +5314,67 @@ mod tests {
                 ARG_REGS.len()
             );
         }
+    }
+
+    #[test]
+    fn ordinary_call_uses_checked_aligned_stack_area() {
+        // Nine scalar arguments leave one stack cell. AAPCS64 reserves the
+        // checked 16-byte outgoing area and addresses its first slot at zero.
+        let interner = ThreadedRodeo::new();
+        let pool = FrozenTypeInternPool::new();
+        let mut fixture = FixtureCfg::new(
+            Type::I64,
+            0,
+            "caller",
+            ParamSlotModes::new(vec![], vec![]),
+            vec![],
+            &pool,
+            &interner,
+        );
+        let args = (0..9)
+            .map(|value| CfgCallArg {
+                value: fixture.konst(value, Type::I64),
+                mode: CfgArgMode::Normal,
+            })
+            .collect();
+        let result = fixture.call("callee", args, Type::I64);
+        fixture.ret(Some(result));
+        let mir = fixture.lower().expect("ordinary call must lower");
+        let call_index = mir
+            .instructions()
+            .iter()
+            .position(|inst| matches!(inst, Aarch64Inst::Bl { .. }))
+            .expect("ordinary call must emit a branch-with-link");
+        assert!(mir.instructions()[..call_index].iter().any(|inst| {
+            matches!(
+                inst,
+                Aarch64Inst::SubImm {
+                    dst: Operand::Physical(Reg::Sp),
+                    src: Operand::Physical(Reg::Sp),
+                    imm: 16,
+                }
+            )
+        }));
+        assert!(mir.instructions()[..call_index].iter().any(|inst| {
+            matches!(
+                inst,
+                Aarch64Inst::Str {
+                    base: Reg::Sp,
+                    offset: 0,
+                    ..
+                }
+            )
+        }));
+        assert!(mir.instructions()[call_index + 1..].iter().any(|inst| {
+            matches!(
+                inst,
+                Aarch64Inst::AddImm {
+                    dst: Operand::Physical(Reg::Sp),
+                    src: Operand::Physical(Reg::Sp),
+                    imm: 16,
+                }
+            )
+        }));
     }
 
     #[test]

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -827,7 +827,13 @@ impl<'a> Emitter<'a> {
                     end_inst!(self, "str {}, [x29, #{}]", param_regs[abi_index], offset);
                 } else {
                     // Stack-passed arg: copy from above the frame into the param area
-                    let src_offset = 16 + (abi_index as i32 - param_regs.len() as i32) * 8;
+                    let src_offset = crate::frame_layout::checked_incoming_stack_arg_offset(
+                        16,
+                        u32::try_from(abi_index).expect("ABI index must fit u32"),
+                        u32::try_from(param_regs.len())
+                            .expect("argument register count must fit u32"),
+                    )
+                    .expect("incoming stack argument offset must fit displacement");
                     self.begin_inst();
                     self.emit_ldr(Reg::X9, Reg::Fp, src_offset);
                     end_inst!(self, "ldr x9, [x29, #{}]", src_offset);
@@ -2721,6 +2727,21 @@ mod tests {
             .emit()
             .unwrap()
             .0
+    }
+
+    #[test]
+    fn incoming_stack_argument_homing_uses_aapcs64_entry_offset() {
+        let mut mir = Aarch64Mir::new();
+        mir.push(Aarch64Inst::Ret);
+        let emitted = Emitter::new(&mir, 0, 0, 1, &[], &[])
+            .with_param_homing(vec![crate::codegen_pipeline::ParamHoming {
+                start_slot: 0,
+                reg_count: 1,
+                abi_start: 8,
+            }])
+            .emit_all()
+            .expect("stack argument homing must emit");
+        assert!(emitted.to_asm().contains("ldr x9, [x29, #16]"));
     }
 
     fn emit_single_with_callee_saved(inst: Aarch64Inst, callee_saved: &[Reg]) -> Vec<u8> {

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -75,6 +75,8 @@ fn prepare_backend_with_artifacts(
         cfg_lower::ARG_REGS.len() as u32,
         cfg_lower::RET_REGS.len() as u32,
         crate::frame_layout::SavedRegScheme::Aarch64,
+        rue_air::TargetCAbiFlavor::Aapcs64,
+        &|name| symbols.is_foreign(&symbols.resolve(interner.resolve(&name))),
         |param_storage, local_storage| {
             let (mir, lowering) = if request.lowering {
                 let (mir, debug) =

--- a/crates/rue-codegen/src/call_plan.rs
+++ b/crates/rue-codegen/src/call_plan.rs
@@ -14,6 +14,8 @@ use rue_runtime_abi::{ReservedExportClass, ReservedExportId};
 use crate::types;
 use crate::vreg::VReg;
 
+use crate::frame_layout::checked_aligned_cell_region_bytes;
+
 /// The source ABI expected by a call target.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CalleeAbi {
@@ -296,8 +298,10 @@ impl CallInputs {
                         ArgClass::Indirect
                     )
                 {
-                    let storage_bytes =
-                        align_up(types::type_size_bytes(type_pool, arg_ty) as u32, 16);
+                    let storage_bytes = crate::frame_layout::checked_aligned_region_bytes(
+                        types::type_size_bytes(type_pool, arg_ty),
+                    )
+                    .expect("indirect argument storage must pass frame-budget preflight");
                     // A heterogeneous compact aggregate has no single map; it
                     // marshals its buffer with a per-variant tag dispatch (RUE-1037).
                     if let Some(image) = types::aggregate_physical_slot_map(type_pool, arg_ty) {
@@ -489,7 +493,9 @@ impl CallPlan {
                     // own buffer and passes one pointer (RUE-1005). The buffers
                     // are reserved below the sret storage and freed together
                     // after the call.
-                    caller_indirect_bytes += *storage_bytes;
+                    caller_indirect_bytes = caller_indirect_bytes
+                        .checked_add(*storage_bytes)
+                        .expect("indirect argument area must fit u32");
                     let pointer = materializer.materialize_indirect_value_arg(
                         *value,
                         image,
@@ -505,7 +511,9 @@ impl CallPlan {
                 } => {
                     // As IndirectValue, but the buffer is written with a per-variant
                     // tag dispatch (RUE-1037).
-                    caller_indirect_bytes += *storage_bytes;
+                    caller_indirect_bytes = caller_indirect_bytes
+                        .checked_add(*storage_bytes)
+                        .expect("indirect argument area must fit u32");
                     let pointer = materializer.materialize_indirect_value_arg_dispatch(
                         *value,
                         image,
@@ -544,7 +552,10 @@ impl CallPlan {
         }
 
         let stack_slot_count = abi_slots.len().saturating_sub(arg_reg_budget);
-        let stack_bytes = align_up((stack_slot_count * 8) as u32, 16);
+        let stack_bytes = checked_aligned_cell_region_bytes(
+            u64::try_from(stack_slot_count).expect("call stack slot count must fit u64"),
+        )
+        .expect("call stack area must pass frame-budget preflight");
 
         Self {
             target,
@@ -583,7 +594,10 @@ impl CallPlan {
             compact_return_dispatch: None,
             result: None,
             stack_slot_count,
-            stack_bytes: align_up((stack_slot_count * 8) as u32, 16),
+            stack_bytes: checked_aligned_cell_region_bytes(
+                u64::try_from(stack_slot_count).expect("call stack slot count must fit u64"),
+            )
+            .expect("call stack area must pass frame-budget preflight"),
             caller_indirect_bytes: 0,
             foreign_return_extension: None,
         }
@@ -603,13 +617,10 @@ pub fn return_plan(type_pool: &FrozenTypeInternPool, ty: Type, ret_reg_budget: u
         ReturnClass::Registers { slot_count } => ReturnPlan::Registers { slot_count },
         ReturnClass::Indirect { slot_count } => ReturnPlan::Sret {
             slot_count,
-            storage_bytes: align_up(slot_count * 8, 16),
+            storage_bytes: checked_aligned_cell_region_bytes(u64::from(slot_count))
+                .expect("sret storage must pass frame-budget preflight"),
         },
     }
-}
-
-const fn align_up(value: u32, alignment: u32) -> u32 {
-    (value + alignment - 1) / alignment * alignment
 }
 
 #[cfg(test)]
@@ -758,7 +769,7 @@ mod tests {
         // This checks the normalized shape independently of a target register
         // enum; type-pool-backed sret selection is exercised by backend ABI
         // tests through `return_plan`.
-        assert_eq!(align_up(24, 16), 32);
+        assert_eq!(checked_aligned_cell_region_bytes(3), Ok(32));
         assert_eq!(
             ReturnPlan::Sret {
                 slot_count: 3,

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -270,7 +270,8 @@ fn format_cfg_inst_data_impl(
 ///   `__rue_to_string` take an out-pointer first, and source-defined `StrBuf`
 ///   functions use the same type-wide convention. (RUE-92)
 /// - Any other aggregate with more slots than `ret_reg_budget` also returns
-///   via sret: the caller allocates `slot_count * 8` bytes (16-aligned) on
+///   via sret: the caller allocates `slot_count * frame_cell_bytes()` bytes
+///   (16-aligned) on
 ///   its stack and passes the buffer address as a hidden first argument
 ///   (shifting all user arguments by one ABI slot); the callee stores every
 ///   slot through that pointer before returning. (RUE-13/78/91)

--- a/crates/rue-codegen/src/codegen_pipeline.rs
+++ b/crates/rue-codegen/src/codegen_pipeline.rs
@@ -98,12 +98,33 @@ pub(crate) fn checked_slot_sum(parts: impl IntoIterator<Item = u32>) -> Option<u
 
 /// Reject every base-frame and outgoing-call calculation before lowering can
 /// narrow it to a backend immediate or allocate proportional metadata.
+#[cfg(test)]
 pub(crate) fn validate_pre_lowering_budget(
     cfg: &Cfg,
     type_pool: &FrozenTypeInternPool,
     arg_reg_count: u32,
     return_reg_count: u32,
     scheme: SavedRegScheme,
+) -> CompileResult<bool> {
+    validate_pre_lowering_budget_for_target(
+        cfg,
+        type_pool,
+        arg_reg_count,
+        return_reg_count,
+        scheme,
+        rue_air::TargetCAbiFlavor::SysVAmd64,
+        &|_| false,
+    )
+}
+
+pub(crate) fn validate_pre_lowering_budget_for_target(
+    cfg: &Cfg,
+    type_pool: &FrozenTypeInternPool,
+    arg_reg_count: u32,
+    return_reg_count: u32,
+    scheme: SavedRegScheme,
+    target_c_flavor: rue_air::TargetCAbiFlavor,
+    is_foreign_symbol: &dyn Fn(lasso::Spur) -> bool,
 ) -> CompileResult<bool> {
     let return_class =
         NativeCallAbi::new(type_pool, return_reg_count).classify_return(cfg.return_type());
@@ -116,23 +137,37 @@ pub(crate) fn validate_pre_lowering_budget(
     for raw in 0..cfg.value_count() {
         let value = CfgValue::from_raw(raw as u32);
         let inst = cfg.get_inst(value);
-        let CfgInstData::Call { .. } = &inst.data else {
+        let CfgInstData::Call { name, .. } = &inst.data else {
             continue;
         };
+        let call_args = cfg.get_call_args(&inst.data);
+        if is_foreign_symbol(*name)
+            && crate::foreign_call::ForeignCallInputs::call_touches_aggregate(
+                cfg, inst.ty, call_args,
+            )
+        {
+            crate::foreign_call::ForeignCallInputs::checked_call_area_bytes(
+                cfg,
+                type_pool,
+                inst.ty,
+                call_args,
+                target_c_flavor,
+            )
+            .map_err(|_| frame_budget_error(cfg, Some(value)))?;
+            continue;
+        }
         let return_class = NativeCallAbi::new(type_pool, return_reg_count).classify_return(inst.ty);
         let (mut abi_slots, sret_bytes) = match return_class {
             ReturnClass::Indirect { slot_count } => {
-                let bytes = u64::from(slot_count)
-                    .checked_mul(rue_air::layout::SLOT_BYTES)
-                    .ok_or_else(|| frame_budget_error(cfg, Some(value)))?;
-                let bytes = crate::frame_layout::checked_aligned_region_bytes(bytes)
-                    .map_err(|_| frame_budget_error(cfg, Some(value)))?;
+                let bytes =
+                    crate::frame_layout::checked_aligned_cell_region_bytes(u64::from(slot_count))
+                        .map_err(|_| frame_budget_error(cfg, Some(value)))?;
                 (1_u32, u64::from(bytes))
             }
             _ => (0_u32, 0),
         };
         let mut indirect_bytes = 0_u64;
-        for arg in cfg.get_call_args(&inst.data) {
+        for arg in call_args {
             let ty = cfg.get_inst(arg.value).ty;
             let convention = match arg.mode {
                 CfgArgMode::Normal => ArgConvention::ByValue,
@@ -189,6 +224,8 @@ pub(crate) fn prepare_mir_with_artifacts<
     arg_reg_count: u32,
     return_reg_count: u32,
     scheme: SavedRegScheme,
+    target_c_flavor: rue_air::TargetCAbiFlavor,
+    is_foreign_symbol: &dyn Fn(lasso::Spur) -> bool,
     lower: Lower,
     allocate: Allocate,
     peephole: Peephole,
@@ -207,8 +244,15 @@ where
     Verify: FnOnce(&M) -> CompileResult<()>,
     IsLeaf: FnOnce(&M) -> bool,
 {
-    let has_sret =
-        validate_pre_lowering_budget(cfg, type_pool, arg_reg_count, return_reg_count, scheme)?;
+    let has_sret = validate_pre_lowering_budget_for_target(
+        cfg,
+        type_pool,
+        arg_reg_count,
+        return_reg_count,
+        scheme,
+        target_c_flavor,
+        is_foreign_symbol,
+    )?;
     // The per-parameter storage decision (RUE-1170) is computed once here and
     // shared by lowering (body addressing and entry copies), the frame slot
     // sums below, and the emitter's prologue homing, so they cannot disagree
@@ -331,6 +375,8 @@ mod tests {
             6,
             6,
             SavedRegScheme::X86_64,
+            rue_air::TargetCAbiFlavor::SysVAmd64,
+            &|_| false,
             |_param_storage, local_storage| {
                 events.borrow_mut().push("lower");
                 // No storage markers, so the local layout is the identity.
@@ -391,6 +437,13 @@ mod tests {
             "AArch64's mandatory FP/LR save must count against the same budget"
         );
 
+        let over_boundary = Cfg::new(Type::UNIT, max_slots + 1, 0, "over_boundary".into(), vec![]);
+        assert!(
+            validate_pre_lowering_budget(&over_boundary, &type_pool, 6, 6, SavedRegScheme::X86_64,)
+                .is_err(),
+            "an oversized production CFG must be rejected before backend lowering"
+        );
+
         let param_boundary = Cfg::new(Type::UNIT, 0, max_slots, "param_boundary".into(), vec![]);
         assert!(
             validate_pre_lowering_budget(
@@ -405,7 +458,7 @@ mod tests {
     }
 
     #[test]
-    fn aggregate_argument_buffers_and_sret_share_one_call_area_budget() {
+    fn foreign_argument_buffers_and_sret_share_one_call_area_budget() {
         let type_pool = TypeInternPool::new();
         let array_id = type_pool.intern_array_from_type(Type::I32, 134_217_728);
         let huge = Type::new_array(array_id);
@@ -432,16 +485,110 @@ mod tests {
         cfg.append_call(entry, None, Spur::default(), args, huge, Span::default())
             .unwrap();
 
-        for (arg_regs, ret_regs, scheme) in [
-            (6, 6, SavedRegScheme::X86_64),
-            (8, 8, SavedRegScheme::Aarch64),
+        for (arg_regs, ret_regs, scheme, flavor) in [
+            (
+                6,
+                6,
+                SavedRegScheme::X86_64,
+                rue_air::TargetCAbiFlavor::SysVAmd64,
+            ),
+            (
+                8,
+                8,
+                SavedRegScheme::Aarch64,
+                rue_air::TargetCAbiFlavor::Aapcs64,
+            ),
         ] {
-            let error = validate_pre_lowering_budget(&cfg, &type_pool, arg_regs, ret_regs, scheme)
-                .unwrap_err();
+            let error = super::validate_pre_lowering_budget_for_target(
+                &cfg,
+                &type_pool,
+                arg_regs,
+                ret_regs,
+                scheme,
+                flavor,
+                &|_| true,
+            )
+            .unwrap_err();
             assert!(matches!(
                 error.kind,
                 rue_error::ErrorKind::FunctionFrameTooLarge { .. }
             ));
+        }
+
+        // Keep the native planner's cumulative indirect+sret guard covered as
+        // well; the target-C cases above exercise the distinct foreign shapes.
+        let error = validate_pre_lowering_budget(&cfg, &type_pool, 6, 6, SavedRegScheme::X86_64)
+            .unwrap_err();
+        assert!(matches!(
+            error.kind,
+            rue_error::ErrorKind::FunctionFrameTooLarge { .. }
+        ));
+    }
+
+    #[test]
+    fn foreign_image_scratch_shares_the_live_sret_budget() {
+        let type_pool = TypeInternPool::new();
+        let max_array = type_pool
+            .intern_array_from_type(Type::I32, rue_air::layout::MAX_FUNCTION_FRAME_BYTES / 4);
+        let small_array = type_pool.intern_array_from_type(Type::I32, 4);
+        let huge = Type::new_array(max_array);
+        let small = Type::new_array(small_array);
+        let type_pool = type_pool.freeze();
+        let mut cfg = Cfg::new(Type::UNIT, 0, 0, "scratch_budget".into(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let arg = cfg.append_inst(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(0),
+                ty: small,
+                span: Span::default(),
+            },
+        );
+        cfg.append_call(
+            entry,
+            None,
+            Spur::default(),
+            [CfgCallArg {
+                value: arg,
+                mode: CfgArgMode::Normal,
+            }],
+            huge,
+            Span::default(),
+        )
+        .unwrap();
+
+        // The final call area contains only the max-sized sret buffer, but the
+        // aggregate argument's 16-byte image scratch is live alongside it
+        // during lowering. Both target-C lowerers must reject that peak before
+        // their stack adjustments are emitted.
+        for (arg_regs, ret_regs, scheme, flavor) in [
+            (
+                6,
+                6,
+                SavedRegScheme::X86_64,
+                rue_air::TargetCAbiFlavor::SysVAmd64,
+            ),
+            (
+                8,
+                8,
+                SavedRegScheme::Aarch64,
+                rue_air::TargetCAbiFlavor::Aapcs64,
+            ),
+        ] {
+            assert!(
+                super::validate_pre_lowering_budget_for_target(
+                    &cfg,
+                    &type_pool,
+                    arg_regs,
+                    ret_regs,
+                    scheme,
+                    flavor,
+                    &|_| true,
+                )
+                .is_err(),
+                "foreign scratch must count against the {flavor:?} live sret area"
+            );
         }
     }
 }

--- a/crates/rue-codegen/src/foreign_call.rs
+++ b/crates/rue-codegen/src/foreign_call.rs
@@ -25,6 +25,7 @@ use rue_air::{
 };
 use rue_cfg::{Cfg, CfgCallArg, CfgValue};
 
+use crate::frame_layout::{checked_aligned_region_bytes, checked_call_area_bytes};
 use crate::types::{self, PhysicalEnumSlot};
 
 /// The compact physical memory image of an aggregate crossing the C boundary —
@@ -63,9 +64,11 @@ impl AggregateImage {
             map,
             padding: type_pool.compact_image_padding_ranges(ty),
             slot_count: types::type_slot_count(type_pool, ty),
-            size: layout.size as u32,
-            align: layout.alignment as u32,
-            storage_bytes: align_up(layout.size as u32, 16),
+            size: u32::try_from(layout.size).expect("foreign aggregate size must fit u32"),
+            align: u32::try_from(layout.alignment)
+                .expect("foreign aggregate alignment must fit u32"),
+            storage_bytes: checked_aligned_region_bytes(layout.size)
+                .expect("foreign aggregate storage must pass frame-budget preflight"),
         }
     }
 
@@ -150,6 +153,126 @@ impl ForeignCallInputs {
                 .any(|arg| is_aggregate(cfg.get_inst(arg.value).ty))
     }
 
+    /// Compute the simultaneous transient area of an aggregate foreign call
+    /// using the target-C classifier that the lowerers consume. This accounts
+    /// for hidden sret storage, SysV by-value stack cells, AAPCS64 caller-owned
+    /// by-reference copies, and argument-register exhaustion that spills
+    /// pointers/eightbytes to the outgoing stack area.
+    pub(crate) fn checked_call_area_bytes(
+        cfg: &Cfg,
+        type_pool: &FrozenTypeInternPool,
+        return_ty: Type,
+        args: &[CfgCallArg],
+        flavor: TargetCAbiFlavor,
+    ) -> Result<u32, crate::frame_layout::FrameBudgetExceeded> {
+        let abi = TargetCCallAbi::new(flavor);
+        let register_budget = u64::from(abi.int_arg_register_budget());
+        let sret_storage_bytes = if is_aggregate(return_ty) {
+            let layout = type_pool.layout(return_ty);
+            match abi.classify_aggregate_return(layout.size, layout.alignment) {
+                AggregateReturnClass::Indirect { .. } => {
+                    u64::from(checked_aligned_region_bytes(layout.size)?)
+                }
+                _ => 0,
+            }
+        } else {
+            0
+        };
+        let mut used_registers =
+            if sret_storage_bytes > 0 && !abi.sret_pointer_in_dedicated_register() {
+                1_u64
+            } else {
+                0
+            };
+        let mut stack_cells = 0_u64;
+        let mut indirect_bytes = 0_u64;
+
+        for arg in args {
+            let ty = cfg.get_inst(arg.value).ty;
+            if !is_aggregate(ty) {
+                if used_registers < register_budget {
+                    used_registers += 1;
+                } else {
+                    stack_cells = stack_cells
+                        .checked_add(1)
+                        .ok_or(crate::frame_layout::FrameBudgetExceeded)?;
+                }
+                continue;
+            }
+
+            let layout = type_pool.layout(ty);
+            match abi.classify_aggregate_arg(layout.size, layout.alignment) {
+                AggregateArgClass::IntegerRegisters { eightbytes } => {
+                    // The backend marshals every register-packed aggregate
+                    // through a temporary image buffer. It is short-lived, but
+                    // can overlap the hidden sret area and any earlier AAPCS64
+                    // caller-owned copies.
+                    let scratch = checked_aligned_region_bytes(layout.size)?;
+                    checked_call_area_bytes(
+                        0,
+                        sret_storage_bytes,
+                        indirect_bytes
+                            .checked_add(u64::from(scratch))
+                            .ok_or(crate::frame_layout::FrameBudgetExceeded)?,
+                    )?;
+                    let eightbytes = u64::from(eightbytes);
+                    if used_registers
+                        .checked_add(eightbytes)
+                        .is_some_and(|used| used <= register_budget)
+                    {
+                        used_registers += eightbytes;
+                    } else {
+                        stack_cells = stack_cells
+                            .checked_add(eightbytes)
+                            .ok_or(crate::frame_layout::FrameBudgetExceeded)?;
+                    }
+                }
+                AggregateArgClass::ByValueStack { .. } => {
+                    // SysV still needs a temporary C image before its
+                    // eightbytes are copied into the outgoing stack area.
+                    let scratch = checked_aligned_region_bytes(layout.size)?;
+                    checked_call_area_bytes(
+                        0,
+                        sret_storage_bytes,
+                        indirect_bytes
+                            .checked_add(u64::from(scratch))
+                            .ok_or(crate::frame_layout::FrameBudgetExceeded)?,
+                    )?;
+                    stack_cells = stack_cells
+                        .checked_add(layout.size.div_ceil(8))
+                        .ok_or(crate::frame_layout::FrameBudgetExceeded)?;
+                }
+                AggregateArgClass::ByReferenceCopy { .. } => {
+                    indirect_bytes = indirect_bytes
+                        .checked_add(u64::from(checked_aligned_region_bytes(layout.size)?))
+                        .ok_or(crate::frame_layout::FrameBudgetExceeded)?;
+                    if used_registers < register_budget {
+                        used_registers += 1;
+                    } else {
+                        stack_cells = stack_cells
+                            .checked_add(1)
+                            .ok_or(crate::frame_layout::FrameBudgetExceeded)?;
+                    }
+                }
+            }
+        }
+
+        if is_aggregate(return_ty) {
+            let layout = type_pool.layout(return_ty);
+            match abi.classify_aggregate_return(layout.size, layout.alignment) {
+                AggregateReturnClass::IntegerRegisters { .. } => {
+                    // Return-image scratch is allocated after outgoing stack
+                    // and AAPCS64 by-reference areas are released, so it is a
+                    // separate peak from the call-boundary reservation.
+                    let scratch = checked_aligned_region_bytes(layout.size)?;
+                    checked_call_area_bytes(0, 0, u64::from(scratch))?;
+                }
+                AggregateReturnClass::Indirect { .. } => {}
+            }
+        }
+        checked_call_area_bytes(stack_cells, sret_storage_bytes, indirect_bytes)
+    }
+
     /// Classify a foreign call through the shared [`TargetCCallAbi`] authority.
     pub(crate) fn from_cfg(
         symbol: String,
@@ -221,8 +344,4 @@ fn is_aggregate(ty: Type) -> bool {
         ty.kind(),
         rue_air::TypeKind::Struct(_) | rue_air::TypeKind::Array(_)
     )
-}
-
-const fn align_up(value: u32, alignment: u32) -> u32 {
-    value.div_ceil(alignment) * alignment
 }

--- a/crates/rue-codegen/src/frame_layout.rs
+++ b/crates/rue-codegen/src/frame_layout.rs
@@ -36,7 +36,91 @@ pub fn checked_aligned_region_bytes(bytes: u64) -> Result<u32, FrameBudgetExceed
     if aligned > MAX_FUNCTION_FRAME_BYTES {
         return Err(FrameBudgetExceeded);
     }
-    Ok(aligned as u32)
+    u32::try_from(aligned).map_err(|_| FrameBudgetExceeded)
+}
+
+/// Byte span of `num_cells` contiguous frame cells, before call-boundary
+/// alignment. The checked conversion is shared by transient ABI areas and
+/// their per-cell addressing so a future cell width cannot be re-derived at a
+/// call site.
+#[inline]
+pub fn checked_cell_region_bytes(num_cells: u64) -> Result<u32, FrameBudgetExceeded> {
+    num_cells
+        .checked_mul(frame_cell_bytes())
+        .ok_or(FrameBudgetExceeded)
+        .and_then(|bytes| {
+            if bytes > MAX_FUNCTION_FRAME_BYTES {
+                Err(FrameBudgetExceeded)
+            } else {
+                Ok(bytes)
+            }
+        })
+        .and_then(|bytes| u32::try_from(bytes).map_err(|_| FrameBudgetExceeded))
+}
+
+/// Byte span of `num_cells` contiguous frame cells, rounded to the call-boundary
+/// alignment and checked against the displacement-sized frame budget.
+#[inline]
+pub fn checked_aligned_cell_region_bytes(num_cells: u64) -> Result<u32, FrameBudgetExceeded> {
+    checked_cell_region_bytes(num_cells)
+        .and_then(|bytes| checked_aligned_region_bytes(u64::from(bytes)))
+}
+
+/// Byte padding needed to round `num_cells` up to the call-boundary alignment.
+/// Both sides come from the same cell-width authority, so an x86 push-based
+/// call cannot retain an 8-byte padding assumption when cell width changes.
+#[inline]
+pub fn checked_cell_region_padding_bytes(num_cells: u64) -> Result<u32, FrameBudgetExceeded> {
+    let raw = checked_cell_region_bytes(num_cells)?;
+    let aligned = checked_aligned_cell_region_bytes(num_cells)?;
+    aligned.checked_sub(raw).ok_or(FrameBudgetExceeded)
+}
+
+/// Checked byte offset of cell `cell_index` in an ascending cell region.
+#[inline]
+pub fn checked_cell_byte_offset(cell_index: u64) -> Result<i32, FrameBudgetExceeded> {
+    i32::try_from(
+        cell_index
+            .checked_mul(frame_cell_bytes())
+            .ok_or(FrameBudgetExceeded)?,
+    )
+    .map_err(|_| FrameBudgetExceeded)
+}
+
+/// Convert a byte count used as a machine displacement or immediate without
+/// allowing a narrowing conversion to wrap.
+#[inline]
+pub fn checked_displacement_bytes(bytes: u64) -> Result<i32, FrameBudgetExceeded> {
+    i32::try_from(bytes).map_err(|_| FrameBudgetExceeded)
+}
+
+/// Checked positive FP-relative offset of an incoming stack argument.
+///
+/// `entry_base_bytes` is the ABI-specific distance from the frame pointer to
+/// the first stack argument, while `register_arg_count` is the number of ABI
+/// argument registers. Keeping those two inputs explicit preserves the x86
+/// return-address base (16) and the AArch64 entry base (16) without
+/// duplicating cell-width arithmetic. Both backend emitters and the
+/// `--emit stackframe` reporter pass their target's entry base here, so the
+/// reported FP-relative location is the one the prologue actually reads.
+#[inline]
+pub fn checked_incoming_stack_arg_offset(
+    entry_base_bytes: u64,
+    abi_index: u32,
+    register_arg_count: u32,
+) -> Result<i32, FrameBudgetExceeded> {
+    let stack_index = u64::from(
+        abi_index
+            .checked_sub(register_arg_count)
+            .ok_or(FrameBudgetExceeded)?,
+    );
+    let cell_offset = checked_cell_byte_offset(stack_index)?;
+    i32::try_from(
+        entry_base_bytes
+            .checked_add(u64::try_from(cell_offset).map_err(|_| FrameBudgetExceeded)?)
+            .ok_or(FrameBudgetExceeded)?,
+    )
+    .map_err(|_| FrameBudgetExceeded)
 }
 
 /// Validate one outgoing call's simultaneous stack reservation: hidden return
@@ -46,10 +130,7 @@ pub fn checked_call_area_bytes(
     sret_storage_bytes: u64,
     indirect_argument_bytes: u64,
 ) -> Result<u32, FrameBudgetExceeded> {
-    let stack_bytes = stack_slots
-        .checked_mul(frame_cell_bytes())
-        .ok_or(FrameBudgetExceeded)?;
-    let stack_bytes = u64::from(checked_aligned_region_bytes(stack_bytes)?);
+    let stack_bytes = u64::from(checked_aligned_cell_region_bytes(stack_slots)?);
     let total = sret_storage_bytes
         .checked_add(indirect_argument_bytes)
         .and_then(|bytes| bytes.checked_add(stack_bytes))
@@ -77,7 +158,10 @@ pub const fn frame_cell_bytes() -> u64 {
 /// backends add the saved-register offset via their own adjustment.
 #[inline]
 pub fn slot_offset_pre_saved(slot: u32) -> i32 {
-    -(frame_cell_bytes() as i32 * (slot as i32 + 1))
+    checked_cell_byte_offset(u64::from(slot) + 1)
+        .expect("frame slot offset must fit displacement")
+        .checked_neg()
+        .expect("frame slot offset must fit displacement")
 }
 
 /// Total byte span of `num_slots` contiguous frame cells.
@@ -456,5 +540,47 @@ mod tests {
             "alignment plus one stack slot must exceed the displacement budget"
         );
         assert!(checked_call_area_bytes(u64::MAX, 0, 0).is_err());
+    }
+
+    #[test]
+    fn checked_cell_regions_cover_zero_alignment_boundary_and_overflow() {
+        assert_eq!(checked_cell_region_bytes(0), Ok(0));
+        assert_eq!(checked_cell_region_bytes(1), Ok(8));
+        assert_eq!(checked_aligned_cell_region_bytes(0), Ok(0));
+        assert_eq!(checked_aligned_cell_region_bytes(1), Ok(16));
+        assert_eq!(checked_cell_region_padding_bytes(0), Ok(0));
+        assert_eq!(checked_cell_region_padding_bytes(1), Ok(8));
+        assert_eq!(checked_cell_region_padding_bytes(2), Ok(0));
+        assert_eq!(
+            checked_cell_region_padding_bytes(MAX_FUNCTION_FRAME_BYTES / SLOT_BYTES),
+            Ok(0)
+        );
+        assert_eq!(
+            checked_aligned_cell_region_bytes(MAX_FUNCTION_FRAME_BYTES / SLOT_BYTES),
+            Ok(MAX_FUNCTION_FRAME_BYTES as u32)
+        );
+        assert!(checked_cell_region_bytes(MAX_FUNCTION_FRAME_BYTES / SLOT_BYTES + 1).is_err());
+        assert!(
+            checked_cell_region_padding_bytes(MAX_FUNCTION_FRAME_BYTES / SLOT_BYTES + 1).is_err()
+        );
+        assert!(checked_cell_region_bytes(u64::MAX).is_err());
+        assert!(
+            checked_aligned_cell_region_bytes(MAX_FUNCTION_FRAME_BYTES / SLOT_BYTES + 1).is_err()
+        );
+    }
+
+    #[test]
+    fn checked_cell_offsets_preserve_current_abi_values() {
+        assert_eq!(checked_cell_byte_offset(0), Ok(0));
+        assert_eq!(checked_cell_byte_offset(3), Ok(24));
+        assert_eq!(checked_incoming_stack_arg_offset(16, 6, 6), Ok(16));
+        assert_eq!(checked_incoming_stack_arg_offset(16, 8, 6), Ok(32));
+        // AArch64's reporter and emitter share the FP/LR entry base.
+        assert_eq!(checked_incoming_stack_arg_offset(16, 8, 8), Ok(16));
+        assert_eq!(checked_incoming_stack_arg_offset(16, 10, 8), Ok(32));
+        assert!(checked_incoming_stack_arg_offset(16, 5, 6).is_err());
+        assert!(checked_cell_byte_offset(u64::MAX).is_err());
+        assert_eq!(checked_displacement_bytes(i32::MAX as u64), Ok(i32::MAX));
+        assert!(checked_displacement_bytes(i32::MAX as u64 + 1).is_err());
     }
 }

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -424,7 +424,12 @@ fn generate_x86_64_stack_frame(
         } else {
             // Stack arguments are at positive offsets from rbp
             // ABI slot 6 at [rbp+16], slot 7 at [rbp+24], etc.
-            let offset = 16 + ((abi_index - 6) as i32) * 8;
+            let offset = crate::frame_layout::checked_incoming_stack_arg_offset(
+                16,
+                u32::try_from(abi_index).expect("ABI index must fit u32"),
+                6,
+            )
+            .expect("reported incoming stack argument offset must fit displacement");
             ArgPassingLocation::Stack { offset }
         };
         arguments.push(ArgumentLocation {
@@ -609,7 +614,12 @@ fn generate_aarch64_stack_frame(
             ArgPassingLocation::Register(arg_regs[abi_index].to_string())
         } else {
             // Stack arguments on AArch64
-            let offset = ((abi_index - 8) as i32) * 8;
+            let offset = crate::frame_layout::checked_incoming_stack_arg_offset(
+                16,
+                u32::try_from(abi_index).expect("ABI index must fit u32"),
+                8,
+            )
+            .expect("reported incoming stack argument offset must fit displacement");
             ArgPassingLocation::Stack { offset }
         };
         arguments.push(ArgumentLocation {
@@ -959,6 +969,56 @@ mod tests {
             pool,
             interner,
         )
+    }
+
+    /// `fn stack_arg(a0..a8: i32) -> i32 { a8 }`: the ninth ABI argument is
+    /// loaded from the incoming stack area by both emitters. The reporter's
+    /// FP-relative location must describe that same entry cell.
+    fn incoming_stack_arg_cfg() -> (ValidatedCfg, FrozenTypeInternPool, ThreadedRodeo) {
+        let interner = ThreadedRodeo::new();
+        let pool = FrozenTypeInternPool::new();
+        let mut cfg = Cfg::new(
+            Type::I32,
+            0,
+            9,
+            "stack_arg".to_string(),
+            ParamSlotModes::new(vec![false; 9], vec![false; 9]),
+        );
+        cfg.set_source_param_abi(scalar_param_abi(9));
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let ninth = value(&mut cfg, entry, CfgInstData::Param { index: 8 }, Type::I32);
+        cfg.set_return(entry, Some(ninth));
+        (
+            cfg.finish(&pool).expect("test CFG must verify"),
+            pool,
+            interner,
+        )
+    }
+
+    #[test]
+    fn incoming_stack_argument_report_matches_emitter_entry_offset() {
+        let (cfg, type_pool, interner) = incoming_stack_arg_cfg();
+        for target in [Target::X86_64Linux, Target::Aarch64Linux] {
+            let (asm, info) = frame_projection(&cfg, &type_pool, &interner, target);
+            let argument_index = match target.arch() {
+                Arch::X86_64 => 6,
+                Arch::Aarch64 => 8,
+            };
+            let offset = match &info.arguments[argument_index].location {
+                ArgPassingLocation::Stack { offset } => *offset,
+                location => panic!("selected stack argument unexpectedly uses {location:?}"),
+            };
+            assert_eq!(offset, 16, "{target:?} uses the first ABI entry stack cell");
+            let entry_load = match target.arch() {
+                Arch::X86_64 => format!("[rbp+{offset}]"),
+                Arch::Aarch64 => format!("[x29, #{offset}]"),
+            };
+            assert!(
+                asm.contains(&entry_load),
+                "reported incoming argument offset is not emitted at {entry_load}:\n{asm}"
+            );
+        }
     }
 
     /// `fn framed() -> i32 { let mut total = 41; bump(inout total); total }`:

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -35,6 +35,10 @@ use super::mir::{LabelId, Operand, Reg, VReg, X86Inst, X86Mir};
 use crate::agg_slots::SlotBackend;
 use crate::allocation;
 use crate::cfg_lower::CfgLowerContext;
+use crate::frame_layout::{
+    checked_aligned_cell_region_bytes, checked_cell_byte_offset, checked_cell_region_bytes,
+    checked_cell_region_padding_bytes, checked_displacement_bytes,
+};
 use crate::vreg::BLOCK_LABEL_BASE;
 
 /// Argument passing registers per System V AMD64 ABI. ABI arg slots beyond
@@ -71,11 +75,6 @@ const _: () = {
         index += 1;
     }
 };
-
-/// Round `value` up to a multiple of `alignment` (a power of two ≥ 1).
-const fn align_up_u32(value: u32, alignment: u32) -> u32 {
-    value.div_ceil(alignment) * alignment
-}
 
 /// CFG to X86Mir lowering.
 pub struct CfgLower<'a> {
@@ -126,7 +125,8 @@ impl crate::call_plan::CallMaterializer for CfgLower<'_> {
     fn materialize_sret_pointer(&mut self, storage_bytes: u32) -> VReg {
         self.mir.push(X86Inst::AddRI {
             dst: Operand::Physical(Reg::Rsp),
-            imm: -(storage_bytes as i32),
+            imm: -checked_displacement_bytes(u64::from(storage_bytes))
+                .expect("sret storage must fit displacement"),
         });
         let pointer = self.mir.alloc_vreg();
         self.mir.push(X86Inst::MovRR {
@@ -150,7 +150,8 @@ impl crate::call_plan::CallMaterializer for CfgLower<'_> {
         // zeroed first (ADR-0052 ruling 5) so the buffer is fully initialized.
         self.mir.push(X86Inst::AddRI {
             dst: Operand::Physical(Reg::Rsp),
-            imm: -(storage_bytes as i32),
+            imm: -checked_displacement_bytes(u64::from(storage_bytes))
+                .expect("indirect argument storage must fit displacement"),
         });
         let pointer = self.mir.alloc_vreg();
         self.mir.push(X86Inst::MovRR {
@@ -172,7 +173,8 @@ impl crate::call_plan::CallMaterializer for CfgLower<'_> {
         // written with a per-variant tag dispatch (RUE-1037).
         self.mir.push(X86Inst::AddRI {
             dst: Operand::Physical(Reg::Rsp),
-            imm: -(storage_bytes as i32),
+            imm: -checked_displacement_bytes(u64::from(storage_bytes))
+                .expect("indirect argument storage must fit displacement"),
         });
         let pointer = self.mir.alloc_vreg();
         self.mir.push(X86Inst::MovRR {
@@ -298,7 +300,16 @@ impl<'a> CfgLower<'a> {
 
         let out_shape = plan.out_shape();
         let out_bytes = out_shape
-            .map(|shape| (shape.shape().slots.len() as i32 * 8 + 15) & !15)
+            .map(|shape| {
+                i32::try_from(
+                    checked_aligned_cell_region_bytes(
+                        u64::try_from(shape.shape().slots.len())
+                            .expect("runtime out slot count must fit u64"),
+                    )
+                    .expect("runtime out area must pass frame-budget preflight"),
+                )
+                .expect("runtime out area must fit displacement")
+            })
             .unwrap_or(0);
         if out_bytes > 0 {
             self.mir.push(X86Inst::AddRI {
@@ -406,7 +417,8 @@ impl<'a> CfgLower<'a> {
                         self.mir.push(X86Inst::MovRM {
                             dst: Operand::Virtual(slot),
                             base: Reg::Rsp,
-                            offset: (index * 8) as i32,
+                            offset: checked_cell_byte_offset(index as u64)
+                                .expect("runtime out slot offset must fit displacement"),
                         });
                         slot
                     })
@@ -1057,11 +1069,21 @@ impl<'a> CfgLower<'a> {
         let primary = plan.result.unwrap_or_else(|| self.mir.alloc_vreg());
         let num_reg_args = plan.abi_slots.len().min(ARG_REGS.len());
         let num_stack_args = plan.stack_slot_count;
-        let needs_alignment = plan.stack_bytes > (num_stack_args * 8) as u32;
+        let stack_cell_bytes = checked_cell_region_bytes(
+            u64::try_from(num_stack_args).expect("call stack slot count must fit u64"),
+        )
+        .expect("call stack area must fit displacement");
+        let needs_alignment = plan.stack_bytes > stack_cell_bytes;
         if needs_alignment {
             self.mir.push(X86Inst::AddRI {
                 dst: Operand::Physical(Reg::Rsp),
-                imm: -8,
+                imm: -i32::try_from(
+                    checked_cell_region_padding_bytes(
+                        u64::try_from(num_stack_args).expect("call stack slot count must fit u64"),
+                    )
+                    .expect("call stack alignment padding must fit displacement"),
+                )
+                .expect("call stack alignment padding must fit i32"),
             });
         }
         for arg in plan.abi_slots.iter().skip(ARG_REGS.len()).rev() {
@@ -1092,7 +1114,8 @@ impl<'a> CfgLower<'a> {
         if num_stack_args > 0 || needs_alignment {
             self.mir.push(X86Inst::AddRI {
                 dst: Operand::Physical(Reg::Rsp),
-                imm: plan.stack_bytes as i32,
+                imm: checked_displacement_bytes(u64::from(plan.stack_bytes))
+                    .expect("call stack area must fit displacement"),
             });
         }
         // Free the by-value indirect argument buffers (RUE-1005), restoring rsp
@@ -1101,7 +1124,8 @@ impl<'a> CfgLower<'a> {
         if plan.caller_indirect_bytes > 0 {
             self.mir.push(X86Inst::AddRI {
                 dst: Operand::Physical(Reg::Rsp),
-                imm: plan.caller_indirect_bytes as i32,
+                imm: checked_displacement_bytes(u64::from(plan.caller_indirect_bytes))
+                    .expect("indirect argument area must fit displacement"),
             });
         }
         let slots = match plan.return_plan {
@@ -1135,7 +1159,8 @@ impl<'a> CfgLower<'a> {
                             self.mir.push(X86Inst::MovRM {
                                 dst: Operand::Virtual(slot),
                                 base: Reg::Rsp,
-                                offset: (index * 8) as i32,
+                                offset: checked_cell_byte_offset(index as u64)
+                                    .expect("sret slot offset must fit displacement"),
                             });
                             slot
                         })
@@ -1143,7 +1168,8 @@ impl<'a> CfgLower<'a> {
                 };
                 self.mir.push(X86Inst::AddRI {
                     dst: Operand::Physical(Reg::Rsp),
-                    imm: storage_bytes as i32,
+                    imm: checked_displacement_bytes(u64::from(storage_bytes))
+                        .expect("sret storage must fit displacement"),
                 });
                 slots
             }
@@ -1248,7 +1274,8 @@ impl<'a> CfgLower<'a> {
             sret_storage = image.storage_bytes;
             self.mir.push(X86Inst::AddRI {
                 dst: Operand::Physical(Reg::Rsp),
-                imm: -(sret_storage as i32),
+                imm: -checked_displacement_bytes(u64::from(sret_storage))
+                    .expect("foreign sret storage must fit displacement"),
             });
             let p = self.mir.alloc_vreg();
             self.mir.push(X86Inst::MovRR {
@@ -1312,12 +1339,25 @@ impl<'a> CfgLower<'a> {
         // arg lands at the lowest address), then the integer args pushed and popped
         // into ARG_REGS, matching the native `lower_call_plan` idiom.
         let num_stack = stack_ops.len();
-        let stack_bytes = align_up_u32((num_stack * 8) as u32, 16);
-        let needs_alignment = stack_bytes > (num_stack * 8) as u32;
+        let stack_cell_bytes = checked_cell_region_bytes(
+            u64::try_from(num_stack).expect("foreign stack slot count must fit u64"),
+        )
+        .expect("foreign stack area must fit displacement");
+        let stack_bytes = checked_aligned_cell_region_bytes(
+            u64::try_from(num_stack).expect("foreign stack slot count must fit u64"),
+        )
+        .expect("foreign stack area must pass frame-budget preflight");
+        let needs_alignment = stack_bytes > stack_cell_bytes;
         if needs_alignment {
             self.mir.push(X86Inst::AddRI {
                 dst: Operand::Physical(Reg::Rsp),
-                imm: -8,
+                imm: -i32::try_from(
+                    checked_cell_region_padding_bytes(
+                        u64::try_from(num_stack).expect("foreign stack slot count must fit u64"),
+                    )
+                    .expect("foreign stack alignment padding must fit displacement"),
+                )
+                .expect("foreign stack alignment padding must fit i32"),
             });
         }
         for v in stack_ops.iter().rev() {
@@ -1348,7 +1388,8 @@ impl<'a> CfgLower<'a> {
         if num_stack > 0 || needs_alignment {
             self.mir.push(X86Inst::AddRI {
                 dst: Operand::Physical(Reg::Rsp),
-                imm: stack_bytes as i32,
+                imm: checked_displacement_bytes(u64::from(stack_bytes))
+                    .expect("foreign stack area must fit displacement"),
             });
         }
 
@@ -1376,7 +1417,8 @@ impl<'a> CfgLower<'a> {
                 let eb = image.eightbytes();
                 self.mir.push(X86Inst::AddRI {
                     dst: Operand::Physical(Reg::Rsp),
-                    imm: -(image.storage_bytes as i32),
+                    imm: -checked_displacement_bytes(u64::from(image.storage_bytes))
+                        .expect("foreign result storage must fit displacement"),
                 });
                 let buf = self.mir.alloc_vreg();
                 self.mir.push(X86Inst::MovRR {
@@ -1396,7 +1438,8 @@ impl<'a> CfgLower<'a> {
                 let native = crate::agg_slots::load_enum_slots_through_ptr(self, buf, &image.map);
                 self.mir.push(X86Inst::AddRI {
                     dst: Operand::Physical(Reg::Rsp),
-                    imm: image.storage_bytes as i32,
+                    imm: checked_displacement_bytes(u64::from(image.storage_bytes))
+                        .expect("foreign result storage must fit displacement"),
                 });
                 native
             }
@@ -1405,7 +1448,8 @@ impl<'a> CfgLower<'a> {
                 let native = crate::agg_slots::load_enum_slots_through_ptr(self, p, &image.map);
                 self.mir.push(X86Inst::AddRI {
                     dst: Operand::Physical(Reg::Rsp),
-                    imm: sret_storage as i32,
+                    imm: checked_displacement_bytes(u64::from(sret_storage))
+                        .expect("foreign sret storage must fit displacement"),
                 });
                 native
             }
@@ -1431,7 +1475,8 @@ impl<'a> CfgLower<'a> {
     ) -> Vec<VReg> {
         self.mir.push(X86Inst::AddRI {
             dst: Operand::Physical(Reg::Rsp),
-            imm: -(image.storage_bytes as i32),
+            imm: -checked_displacement_bytes(u64::from(image.storage_bytes))
+                .expect("foreign argument storage must fit displacement"),
         });
         let buf = self.mir.alloc_vreg();
         self.mir.push(X86Inst::MovRR {
@@ -1449,7 +1494,8 @@ impl<'a> CfgLower<'a> {
         let ebs = crate::agg_slots::load_slots_through_ptr(self, buf, image.eightbytes());
         self.mir.push(X86Inst::AddRI {
             dst: Operand::Physical(Reg::Rsp),
-            imm: image.storage_bytes as i32,
+            imm: checked_displacement_bytes(u64::from(image.storage_bytes))
+                .expect("foreign argument storage must fit displacement"),
         });
         ebs
     }
@@ -5128,6 +5174,62 @@ mod tests {
                 ARG_REGS.len()
             );
         }
+    }
+
+    #[test]
+    fn ordinary_call_uses_checked_aligned_stack_area() {
+        // Seven scalar arguments leave one stack cell. The x86 lowering must
+        // reserve 8 bytes of checked alignment padding, then restore the full
+        // 16-byte aligned outgoing area after the call.
+        let interner = ThreadedRodeo::new();
+        let pool = FrozenTypeInternPool::new();
+        let mut fixture = FixtureCfg::new(
+            Type::I64,
+            0,
+            "caller",
+            ParamSlotModes::new(vec![], vec![]),
+            vec![],
+            &pool,
+            &interner,
+        );
+        let args = (0..7)
+            .map(|value| CfgCallArg {
+                value: fixture.konst(value, Type::I64),
+                mode: CfgArgMode::Normal,
+            })
+            .collect();
+        let result = fixture.call("callee", args, Type::I64);
+        fixture.ret(Some(result));
+        let mir = fixture.lower().expect("ordinary call must lower");
+        let expected_padding = -i32::try_from(
+            crate::frame_layout::checked_cell_region_padding_bytes(1)
+                .expect("test call padding must fit the frame budget"),
+        )
+        .expect("test call padding must fit i32");
+        let call_index = mir
+            .instructions()
+            .iter()
+            .position(|inst| matches!(inst, X86Inst::CallRel { .. }))
+            .expect("ordinary call must emit a call");
+        assert!(mir.instructions()[..call_index].iter().any(|inst| {
+            matches!(
+                inst,
+                X86Inst::AddRI {
+                    dst: Operand::Physical(Reg::Rsp),
+                    imm,
+                }
+                if *imm == expected_padding
+            )
+        }));
+        assert!(mir.instructions()[call_index + 1..].iter().any(|inst| {
+            matches!(
+                inst,
+                X86Inst::AddRI {
+                    dst: Operand::Physical(Reg::Rsp),
+                    imm: 16,
+                }
+            )
+        }));
     }
 
     #[test]

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -683,7 +683,13 @@ impl<'a> Emitter<'a> {
                     end_inst!(self, "mov [rbp{}], {}", offset, reg);
                 } else {
                     // Stack-passed arg: copy from above the frame into the param area
-                    let src_offset = 16 + (abi_index as i32 - ARG_REGS.len() as i32) * 8;
+                    let src_offset = crate::frame_layout::checked_incoming_stack_arg_offset(
+                        16,
+                        abi_index,
+                        u32::try_from(ARG_REGS.len())
+                            .expect("argument register count must fit u32"),
+                    )
+                    .expect("incoming stack argument offset must fit displacement");
                     self.begin_inst();
                     self.emit_mov_rm(Reg::Rax, Reg::Rbp, src_offset);
                     end_inst!(self, "mov rax, [rbp+{}]", src_offset);
@@ -3001,6 +3007,21 @@ mod tests {
             .emit()
             .unwrap()
             .0
+    }
+
+    #[test]
+    fn incoming_stack_argument_homing_uses_sysv_entry_offset() {
+        let mut mir = X86Mir::new();
+        mir.push(X86Inst::Ret);
+        let emitted = Emitter::new(&mir, 0, 0, 1, &[], &[])
+            .with_param_homing(vec![crate::codegen_pipeline::ParamHoming {
+                start_slot: 0,
+                reg_count: 1,
+                abi_start: 6,
+            }])
+            .emit_all()
+            .expect("stack argument homing must emit");
+        assert!(emitted.to_asm().contains("mov rax, [rbp+16]"));
     }
 
     #[test]

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -68,6 +68,8 @@ fn prepare_backend_with_artifacts(
         cfg_lower::ARG_REGS.len() as u32,
         cfg_lower::RET_REGS.len() as u32,
         crate::frame_layout::SavedRegScheme::X86_64,
+        rue_air::TargetCAbiFlavor::SysVAmd64,
+        &|name| symbols.is_foreign(&symbols.resolve(interner.resolve(&name))),
         |param_storage, local_storage| {
             let (mir, lowering) = if request.lowering {
                 let (mir, debug) = CfgLower::new_with_symbols(cfg, type_pool, interner, symbols)


### PR DESCRIPTION
## Summary

- centralize checked cell-region, alignment, displacement, and incoming stack-argument arithmetic in frame layout
- route native, foreign, runtime, syscall, and emitter call-area consumers through those authorities on x86-64 and AArch64
- add symmetric lowering/emission coverage plus overflow and cumulative transient-area rejection tests

## Validation

- `scripts/rue fmt`
- `scripts/rue unit codegen` (777 passed)
- `scripts/rue quick` (31 targets passed)
- `scripts/rue premerge` (200 targets passed)
- `scripts/rue test` (234 targets passed)
- `git diff --check origin/trunk`

Fixes RUE-1800.