### PR TITLE
RUE-1797: centralize verifier ABI slot widths

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -3838,9 +3838,17 @@ impl FrozenTypeInternPool {
 
     /// Return the flattened runtime ABI width of `ty` in eight-byte slots.
     pub fn abi_slot_count(&self, ty: Type) -> u32 {
-        self.validate_complete_type(ty)
-            .expect("backend layout requires a complete, non-recovery type graph");
-        self.inner.abi_slot_count(ty)
+        self.try_abi_slot_count(ty)
+            .expect("backend layout requires a complete, non-recovery type graph")
+    }
+
+    /// Return the flattened runtime ABI width of `ty`, or explain why the
+    /// handle cannot be read from this frozen pool.
+    pub fn try_abi_slot_count(&self, ty: Type) -> Result<u32, TypeValidationError> {
+        self.validate_complete_type(ty)?;
+        self.inner
+            .stored_abi_slot_count(ty)
+            .ok_or(TypeValidationError::IncompleteDefinition)
     }
 
     /// Canonical physical [`Layout`] of `ty`: the one authority code generation
@@ -5162,9 +5170,84 @@ mod tests {
         assert_eq!(frozen.inner.stored_abi_slot_count(pointer), Some(1));
         assert_eq!(frozen.inner.stored_abi_slot_count(choice_ty), Some(8));
         assert_eq!(frozen.inner.stored_abi_slot_count(wrapper_ty), Some(9));
+        assert_eq!(frozen.try_abi_slot_count(pair_ty), Ok(2));
+        assert_eq!(frozen.try_abi_slot_count(pairs), Ok(6));
+        assert_eq!(frozen.try_abi_slot_count(saturated), Ok(u32::MAX));
+        assert_eq!(frozen.try_abi_slot_count(choice_ty), Ok(8));
+        assert_eq!(frozen.try_abi_slot_count(wrapper_ty), Ok(9));
         assert_eq!(frozen.abi_slot_count(wrapper_ty), 9);
         assert_eq!(frozen.struct_field_slot_offset(wrapper, 1), 8);
         assert_eq!(frozen.enum_payload_slot_offset(choice, 0, 1), 7);
+    }
+
+    #[test]
+    fn frozen_try_abi_slot_count_rejects_malformed_handles_without_reading_storage() {
+        let declarations = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let (owner, _) = pool.register_struct(
+            declarations.get_or_intern("Owner"),
+            struct_def(
+                "Owner",
+                vec![StructField {
+                    name: "value".into(),
+                    ty: Type::I64,
+                }],
+            ),
+        );
+        let frozen = pool.freeze();
+
+        assert_eq!(
+            frozen.try_abi_slot_count(Type::new_array(ArrayTypeId::from_pool_index(
+                owner.pool_index(),
+            ))),
+            Err(TypeValidationError::KindMismatch)
+        );
+        assert_eq!(
+            frozen.try_abi_slot_count(Type::new_struct(StructId::from_pool_index(99))),
+            Err(TypeValidationError::PoolIndexOutOfRange)
+        );
+        assert_eq!(
+            frozen.try_abi_slot_count(Type::ERROR),
+            Err(TypeValidationError::RecoveryType)
+        );
+        assert_eq!(
+            frozen.try_abi_slot_count(Type::from_u32(0x100)),
+            Err(TypeValidationError::InvalidEncoding)
+        );
+    }
+
+    #[test]
+    fn frozen_abi_slot_query_reads_the_stored_canonical_width() {
+        let declarations = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let (owner, _) = pool.register_struct(
+            declarations.get_or_intern("Owner"),
+            struct_def(
+                "Owner",
+                vec![
+                    StructField {
+                        name: "left".into(),
+                        ty: Type::I64,
+                    },
+                    StructField {
+                        name: "right".into(),
+                        ty: Type::I64,
+                    },
+                ],
+            ),
+        );
+        let owner_ty = Type::new_struct(owner);
+        let mut frozen = pool.freeze();
+        assert_eq!(frozen.try_abi_slot_count(owner_ty), Ok(2));
+
+        // Deliberately perturb only the stored derived field. A verifier-local
+        // declaration walk cannot reproduce this mutation, so this test stays
+        // sensitive to a consumer that starts recomputing widths locally.
+        Arc::get_mut(&mut frozen.inner)
+            .expect("a freshly frozen pool has one owner")
+            .set_entry_abi_slots(owner.pool_index() as usize, 7);
+        assert_eq!(frozen.try_abi_slot_count(owner_ty), Ok(7));
+        assert_eq!(frozen.abi_slot_count(owner_ty), 7);
     }
 
     #[test]

--- a/crates/rue-cfg/src/api_inventory.rs
+++ b/crates/rue-cfg/src/api_inventory.rs
@@ -90,6 +90,41 @@ fn cfg_uses_air_synthetic_type_identity_policy() {
 }
 
 #[test]
+fn cfg_abi_width_checks_have_one_frozen_pool_authority() {
+    let source = include_str!("verify.rs");
+    assert_eq!(
+        source.matches("    fn abi_slot_count(").count(),
+        1,
+        "CFG verifier must have exactly one ABI-width decision helper"
+    );
+    assert_eq!(
+        source.matches("pool.try_abi_slot_count(ty)").count(),
+        1,
+        "CFG verifier must contain exactly one frozen-pool ABI-width query"
+    );
+    assert!(source.contains("fn verify_slot_ranges_consume_the_frozen_pool_authority()"));
+    let width_check = source
+        .split("    fn abi_slot_count(")
+        .nth(1)
+        .and_then(|rest| rest.split("\n    fn ").next())
+        .expect("CFG verifier ABI-width helper");
+    assert!(width_check.contains("pool.try_abi_slot_count(ty)"));
+    for local_authority in [
+        "abi_slot_cache",
+        "try_struct_def(struct_id)",
+        "try_array_def(array_id)",
+        "try_enum_def(enum_id)",
+        "saturating_add(self.abi_slot_count",
+        "compute_abi_slot_count",
+    ] {
+        assert!(
+            !width_check.contains(local_authority),
+            "CFG verifier regained a local ABI-width authority: {local_authority}"
+        );
+    }
+}
+
+#[test]
 fn slot_write_classification_has_one_owner() {
     // The RUE-521 knowledge of which local slots may be store-to-load
     // forwarded (write counting, address escapes, by-ref call arguments,

--- a/crates/rue-cfg/src/verify.rs
+++ b/crates/rue-cfg/src/verify.rs
@@ -367,15 +367,12 @@ struct Verifier<'a> {
     /// may only be built once targets are known to be in bounds and payload
     /// slices are known to be valid.
     dominators: Option<DominatorTree>,
-    /// Memo for [`Verifier::abi_slot_count`], which is a pure function of the
-    /// type against this verifier's fixed pool: `block`, `value`, and `role`
-    /// only name the site in an error message.
-    ///
-    /// The count recurses through struct fields, array elements, and enum
-    /// payloads, and the same types recur constantly across a function's
-    /// slots. Uncached, a fresh Lattice build called it about two million
-    /// times for 406M instructions, 4.8% of the whole compile.
-    abi_slot_cache: std::cell::RefCell<ahash::AHashMap<Type, u32>>,
+    /// Test-only authority injection. A deliberately divergent answer proves
+    /// the verifier's slot-range decisions consume the frozen-pool query
+    /// instead of a shadow decomposition.
+    #[cfg(test)]
+    abi_slot_query_override:
+        Option<fn(&FrozenTypeInternPool, Type) -> Result<u32, rue_air::TypeValidationError>>,
 }
 
 impl<'a> Verifier<'a> {
@@ -391,7 +388,8 @@ impl<'a> Verifier<'a> {
             skip_unreachable_blocks: false,
             attachments: vec![None; cfg.value_count()],
             dominators: None,
-            abi_slot_cache: std::cell::RefCell::new(ahash::AHashMap::new()),
+            #[cfg(test)]
+            abi_slot_query_override: None,
         }
     }
 
@@ -1706,78 +1704,60 @@ impl<'a> Verifier<'a> {
         value: CfgValue,
         role: &str,
     ) -> Result<u32, CfgVerificationError> {
-        let cached = self.abi_slot_cache.borrow().get(&ty).copied();
-        if let Some(width) = cached {
-            return Ok(width);
-        }
-        let width = match ty.kind() {
-            TypeKind::I8
-            | TypeKind::I16
-            | TypeKind::I32
-            | TypeKind::I64
-            | TypeKind::U8
-            | TypeKind::U16
-            | TypeKind::U32
-            | TypeKind::U64
-            | TypeKind::Bool
-            | TypeKind::Error
-            | TypeKind::PtrConst(_)
-            | TypeKind::PtrMut(_) => 1,
-            TypeKind::Unit | TypeKind::Never | TypeKind::ComptimeType | TypeKind::Module(_) => 0,
-            TypeKind::Struct(struct_id) => {
-                let Some(pool) = self.type_pool else {
-                    return Ok(0);
-                };
-                let Some(def) = pool.try_struct_def(struct_id) else {
-                    return Err(self.error(format_args!(
-                        "{} instruction {} in block {} references invalid struct type {:?}",
-                        role, value, block, struct_id
-                    )));
-                };
-                let mut width = 0u32;
-                for field in &def.fields {
-                    width =
-                        width.saturating_add(self.abi_slot_count(field.ty, block, value, role)?);
-                }
-                width
-            }
-            TypeKind::Array(array_id) => {
-                let Some(pool) = self.type_pool else {
-                    return Ok(0);
-                };
-                let Some((element, len)) = pool.try_array_def(array_id) else {
-                    return Err(self.error(format_args!(
-                        "{} instruction {} in block {} references invalid array type {:?}",
-                        role, value, block, array_id
-                    )));
-                };
-                let element_width = u64::from(self.abi_slot_count(element, block, value, role)?);
-                u32::try_from(element_width.saturating_mul(len)).unwrap_or(u32::MAX)
-            }
-            TypeKind::Enum(enum_id) => {
-                let Some(pool) = self.type_pool else {
-                    return Ok(0);
-                };
-                let Some(def) = pool.try_enum_def(enum_id) else {
-                    return Err(self.error(format_args!(
-                        "{} instruction {} in block {} references invalid enum type {:?}",
-                        role, value, block, enum_id
-                    )));
-                };
-                let mut payload_width = 0;
-                for index in 0..def.variant_count() {
-                    let mut variant_width = 0u32;
-                    for &payload_ty in def.variant_payload(index) {
-                        variant_width = variant_width
-                            .saturating_add(self.abi_slot_count(payload_ty, block, value, role)?);
-                    }
-                    payload_width = payload_width.max(variant_width);
-                }
-                1u32.saturating_add(payload_width)
-            }
+        let Some(pool) = self.type_pool else {
+            return Ok(match ty.try_kind() {
+                Some(TypeKind::I8)
+                | Some(TypeKind::I16)
+                | Some(TypeKind::I32)
+                | Some(TypeKind::I64)
+                | Some(TypeKind::U8)
+                | Some(TypeKind::U16)
+                | Some(TypeKind::U32)
+                | Some(TypeKind::U64)
+                | Some(TypeKind::Bool)
+                | Some(TypeKind::Error)
+                | Some(TypeKind::PtrConst(_))
+                | Some(TypeKind::PtrMut(_)) => 1,
+                Some(TypeKind::Unit)
+                | Some(TypeKind::Never)
+                | Some(TypeKind::ComptimeType)
+                | Some(TypeKind::Module(_))
+                | Some(TypeKind::Struct(_))
+                | Some(TypeKind::Array(_))
+                | Some(TypeKind::Enum(_))
+                | None => 0,
+            });
         };
-        self.abi_slot_cache.borrow_mut().insert(ty, width);
-        Ok(width)
+
+        let canonical_width = || pool.try_abi_slot_count(ty);
+        #[cfg(test)]
+        let width = self
+            .abi_slot_query_override
+            .map_or_else(canonical_width, |query| query(pool, ty));
+        #[cfg(not(test))]
+        let width = canonical_width();
+
+        width.map_err(|error| {
+            let kind = ty.try_kind();
+            match kind {
+                Some(TypeKind::Struct(id)) => self.error(format_args!(
+                    "{} instruction {} in block {} references invalid struct type {:?}",
+                    role, value, block, id
+                )),
+                Some(TypeKind::Array(id)) => self.error(format_args!(
+                    "{} instruction {} in block {} references invalid array type {:?}",
+                    role, value, block, id
+                )),
+                Some(TypeKind::Enum(id)) => self.error(format_args!(
+                    "{} instruction {} in block {} references invalid enum type {:?}",
+                    role, value, block, id
+                )),
+                _ => self.error(format_args!(
+                    "{} instruction {} in block {} references invalid type ({error:?})",
+                    role, value, block
+                )),
+            }
+        })
     }
 
     fn is_fixed_str_to_view_coercion(&self, source: Type, result: Type) -> bool {
@@ -2238,6 +2218,7 @@ impl<'a> Verifier<'a> {
 
 #[cfg(test)]
 mod tests {
+    use super::Verifier;
     use crate::inst::{
         BlockId, Cfg, CfgInst, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator,
     };
@@ -4539,6 +4520,72 @@ mod tests {
         );
         cfg.set_terminator(entry, Terminator::Unreachable);
         cfg.verify_with_type_pool(&pool).unwrap();
+    }
+
+    #[test]
+    fn verify_slot_ranges_consume_the_frozen_pool_authority() {
+        fn divergent_width(
+            _pool: &FrozenTypeInternPool,
+            _ty: Type,
+        ) -> Result<u32, rue_air::TypeValidationError> {
+            Ok(7)
+        }
+
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let pair = register_struct(&pool, &interner, "Pair", &[Type::I32, Type::I32]);
+        let pool = pool.freeze();
+        let mut cfg = Cfg::new(Type::UNIT, 2, 0, "canonical_width".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Load { slot: 0 },
+                ty: Type::new_struct(pair),
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Unreachable);
+
+        let mut verifier = Verifier::new(&cfg, Some(&pool), true);
+        verifier.abi_slot_query_override = Some(divergent_width);
+        let error = verifier.verify().unwrap_err();
+        assert!(error.to_string().contains("local slot range 0..7"));
+    }
+
+    #[test]
+    fn verify_reports_invalid_type_encoding_without_unwinding() {
+        let mut cfg = Cfg::new(
+            Type::UNIT,
+            1,
+            0,
+            "invalid_type_encoding".to_string(),
+            vec![],
+        );
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Load { slot: 0 },
+                // SAFETY: Type is one u32 field and every u32 is memory-valid;
+                // malformedness is semantic. The raw constructor is
+                // intentionally AIR-private, so reproduce packed-storage
+                // corruption at this verifier boundary.
+                ty: unsafe { std::mem::transmute::<u32, Type>(0x100) },
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Unreachable);
+
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            cfg.finish(&FrozenTypeInternPool::new())
+        }));
+        let error = outcome
+            .expect("malformed type verification must not unwind")
+            .unwrap_err();
+        assert!(error.to_string().contains("InvalidEncoding"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- route CFG verifier ABI width checks through the frozen type pool's fallible canonical query
- remove verifier-local recursive aggregate decomposition and cache while preserving pool-less structural verification
- add malformed-input and mutation/rejection-power coverage

## Validation

- `scripts/rue fmt`
- `scripts/rue quick`
- `scripts/rue premerge`
- `scripts/rue test`
- focused rue-air, rue-cfg, and compiler CFG suites
- `git diff --check`

Fixes RUE-1797
