### PR TITLE
RUE-1803: make backend contract explicit

### DIFF
--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -28,16 +28,18 @@ pub(crate) use mir::MAX_ADD_SUB_IMMEDIATE;
 pub use mir::{Aarch64Inst, Aarch64Mir, Cond, Operand, Reg, VReg};
 pub use regalloc::RegAlloc;
 
+use crate::backend::Backend;
 use lasso::ThreadedRodeo;
 use rue_air::FrozenTypeInternPool;
 use rue_cfg::ValidatedCfg;
 use rue_error::CompileResult;
 use rue_target::Target;
-use tracing::info_span;
 
 use crate::MachineCode;
 // Re-export from parent
 pub use super::{EmittedCode, EmittedRelocation};
+
+struct Aarch64CodegenBackend;
 
 pub(crate) fn prepare_backend(
     cfg: &ValidatedCfg,
@@ -46,7 +48,7 @@ pub(crate) fn prepare_backend(
     target: Target,
     symbols: crate::MachineSymbolResolver<'_>,
 ) -> CompileResult<crate::codegen_pipeline::PreparedMir<Aarch64Mir, Reg>> {
-    prepare_backend_with_artifacts(
+    crate::codegen_pipeline::prepare_mir_with_backend::<Aarch64CodegenBackend>(
         cfg,
         type_pool,
         interner,
@@ -54,147 +56,142 @@ pub(crate) fn prepare_backend(
         symbols,
         crate::BackendArtifactRequest::default(),
     )
-    .map(|(prepared, _artifacts)| prepared)
+    .map(|(prepared, _)| prepared)
 }
 
-fn prepare_backend_with_artifacts(
-    cfg: &ValidatedCfg,
-    type_pool: &FrozenTypeInternPool,
-    interner: &ThreadedRodeo,
-    target: Target,
-    symbols: crate::MachineSymbolResolver<'_>,
-    request: crate::BackendArtifactRequest,
-) -> CompileResult<(
-    crate::codegen_pipeline::PreparedMir<Aarch64Mir, Reg>,
-    crate::BackendArtifacts,
-)> {
-    crate::codegen_pipeline::prepare_mir_with_artifacts(
-        cfg,
-        type_pool,
-        interner,
-        cfg_lower::ARG_REGS.len() as u32,
-        cfg_lower::RET_REGS.len() as u32,
-        crate::frame_layout::SavedRegScheme::Aarch64,
-        rue_air::TargetCAbiFlavor::Aapcs64,
-        &|name| symbols.is_foreign(&symbols.resolve(interner.resolve(&name))),
-        |param_storage, local_storage| {
-            let (mir, lowering) = if request.lowering {
-                let (mir, debug) =
-                    CfgLower::new_with_symbols(cfg, type_pool, interner, target, symbols)
-                        .with_param_storage(param_storage)
-                        .with_local_storage(local_storage)
-                        .lower_with_debug()?;
-                (mir, Some(debug))
-            } else {
-                (
-                    CfgLower::new_with_symbols(cfg, type_pool, interner, target, symbols)
-                        .with_param_storage(param_storage)
-                        .with_local_storage(local_storage)
-                        .lower()?,
-                    None,
-                )
-            };
-            let mir_text = request.mir.then(|| mir.to_string());
-            Ok((
-                mir,
-                crate::BackendArtifacts {
-                    lowering,
-                    mir: mir_text,
-                    ..Default::default()
-                },
-            ))
-        },
-        |mir, existing_slots, artifacts| {
-            let (mir, spills, used_callee_saved, liveness, regalloc) =
-                RegAlloc::new_with_artifacts(mir, existing_slots, request.liveness)
-                    .allocate_with_artifacts(request.regalloc)?;
-            artifacts.liveness = liveness.map(|debug| debug.to_string());
-            artifacts.regalloc = regalloc.map(|debug| debug.to_string());
-            Ok((mir, spills, used_callee_saved))
-        },
-        |mir| {
-            peephole::optimize(mir.instructions_vec_mut());
-        },
-        schedule::schedule,
-        verify::verify_stack_alignment,
-        Aarch64Mir::is_leaf,
-    )
-}
+impl Backend for Aarch64CodegenBackend {
+    type Mir = Aarch64Mir;
+    type Reg = Reg;
 
-fn generate_inner(
-    cfg: &ValidatedCfg,
-    type_pool: &FrozenTypeInternPool,
-    strings: &[String],
-    interner: &ThreadedRodeo,
-    target: Target,
-    symbols: crate::MachineSymbolResolver<'_>,
-    atoms: &[crate::LocalAtomProjection<'_>],
-    require_complete_atoms: bool,
-    request: crate::BackendArtifactRequest,
-) -> CompileResult<crate::BackendProduct> {
-    let (mut prepared, mut artifacts) =
-        prepare_backend_with_artifacts(cfg, type_pool, interner, target, symbols, request)?;
-    let referenced_strings = prepared
-        .mir
-        .instructions()
-        .iter()
-        .filter_map(|inst| match inst {
-            Aarch64Inst::StringConstPtr { string_id, .. }
-            | Aarch64Inst::StringConstLen { string_id, .. }
-            | Aarch64Inst::StringConstCap { string_id, .. } => Some(*string_id),
-            _ => None,
-        });
-    let local_strings = {
-        let _span = info_span!("string_table_compaction").entered();
-        let (local_strings, string_id_remap) = crate::compact_string_table(
-            strings,
-            atoms,
-            referenced_strings,
-            require_complete_atoms,
-        )?;
-        for inst in prepared.mir.instructions_vec_mut() {
+    const ARCH: rue_target::Arch = rue_target::Arch::Aarch64;
+    const ARG_REG_COUNT: u32 = cfg_lower::ARG_REGS.len() as u32;
+    const RETURN_REG_COUNT: u32 = cfg_lower::RET_REGS.len() as u32;
+    const SAVED_REG_SCHEME: crate::frame_layout::SavedRegScheme =
+        crate::frame_layout::SavedRegScheme::Aarch64;
+    const TARGET_C_FLAVOR: rue_air::TargetCAbiFlavor = rue_air::TargetCAbiFlavor::Aapcs64;
+
+    fn lower(
+        cfg: &ValidatedCfg,
+        type_pool: &FrozenTypeInternPool,
+        interner: &ThreadedRodeo,
+        target: Target,
+        symbols: crate::MachineSymbolResolver<'_>,
+        request: crate::BackendArtifactRequest,
+        param_storage: &crate::param_storage::ParamStoragePlan,
+        local_storage: &crate::local_storage::LocalSlotPlan,
+    ) -> CompileResult<(Self::Mir, crate::BackendArtifacts)> {
+        let (mir, lowering) = if request.lowering {
+            let (mir, debug) =
+                CfgLower::new_with_symbols(cfg, type_pool, interner, target, symbols)
+                    .with_param_storage(param_storage)
+                    .with_local_storage(local_storage)
+                    .lower_with_debug()?;
+            (mir, Some(debug))
+        } else {
+            (
+                CfgLower::new_with_symbols(cfg, type_pool, interner, target, symbols)
+                    .with_param_storage(param_storage)
+                    .with_local_storage(local_storage)
+                    .lower()?,
+                None,
+            )
+        };
+        let mir_text = request.mir.then(|| mir.to_string());
+        Ok((
+            mir,
+            crate::BackendArtifacts {
+                lowering,
+                mir: mir_text,
+                ..Default::default()
+            },
+        ))
+    }
+
+    fn allocate(
+        mir: Self::Mir,
+        existing_slots: u32,
+        artifacts: &mut crate::BackendArtifacts,
+        request: crate::BackendArtifactRequest,
+    ) -> CompileResult<(Self::Mir, u32, Vec<Self::Reg>)> {
+        let (mir, spills, used, liveness, regalloc) =
+            RegAlloc::new_with_artifacts(mir, existing_slots, request.liveness)
+                .allocate_with_artifacts(request.regalloc)?;
+        artifacts.liveness = liveness.map(|debug| debug.to_string());
+        artifacts.regalloc = regalloc.map(|debug| debug.to_string());
+        Ok((mir, spills, used))
+    }
+
+    fn peephole(mir: &mut Self::Mir) {
+        peephole::optimize(mir.instructions_vec_mut());
+    }
+    fn schedule(mir: &mut Self::Mir) {
+        schedule::schedule(mir);
+    }
+    fn verify(mir: &Self::Mir) -> CompileResult<()> {
+        verify::verify_stack_alignment(mir)
+    }
+    fn is_leaf(mir: &Self::Mir) -> bool {
+        Aarch64Mir::is_leaf(mir)
+    }
+
+    fn referenced_string_ids(mir: &Self::Mir) -> Vec<u32> {
+        mir.instructions()
+            .iter()
+            .filter_map(|inst| match inst {
+                Aarch64Inst::StringConstPtr { string_id, .. }
+                | Aarch64Inst::StringConstLen { string_id, .. }
+                | Aarch64Inst::StringConstCap { string_id, .. } => Some(*string_id),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn remap_string_ids(mir: &mut Self::Mir, remap: &std::collections::BTreeMap<u32, u32>) {
+        for inst in mir.instructions_vec_mut() {
             let string_id = match inst {
                 Aarch64Inst::StringConstPtr { string_id, .. }
                 | Aarch64Inst::StringConstLen { string_id, .. }
                 | Aarch64Inst::StringConstCap { string_id, .. } => string_id,
                 _ => continue,
             };
-            *string_id = string_id_remap[string_id];
+            *string_id = remap[string_id];
         }
-        local_strings
-    };
-    let _emission_span = info_span!("machine_emission").entered();
-    let emitter = Emitter::new(
-        &prepared.mir,
-        prepared.total_locals,
-        prepared.frame_local_slots,
-        prepared.param_storage.homed_area_slots(),
-        &prepared.used_callee_saved,
-        &local_strings,
-    )
-    .with_sret(prepared.has_sret)
-    .with_frame_layout(prepared.frame_layout)
-    .with_param_homing(prepared.param_homing.clone());
-    let machine_code = if request.asm {
-        let emitted = emitter.emit_all()?;
-        artifacts.asm = Some(emitted.to_asm());
-        MachineCode {
-            code: emitted.to_bytes(),
-            relocations: emitted.relocations,
-            strings: local_strings,
+    }
+
+    fn emit(
+        prepared: &crate::codegen_pipeline::PreparedMir<Self::Mir, Self::Reg>,
+        local_strings: &[String],
+        request: crate::BackendArtifactRequest,
+        artifacts: &mut crate::BackendArtifacts,
+    ) -> CompileResult<MachineCode> {
+        let emitter = Emitter::new(
+            &prepared.mir,
+            prepared.total_locals,
+            prepared.frame_local_slots,
+            prepared.param_storage.homed_area_slots(),
+            &prepared.used_callee_saved,
+            local_strings,
+        )
+        .with_sret(prepared.has_sret)
+        .with_frame_layout(prepared.frame_layout)
+        .with_param_homing(prepared.param_homing.clone());
+        if request.asm {
+            let emitted = emitter.emit_all()?;
+            artifacts.asm = Some(emitted.to_asm());
+            Ok(MachineCode {
+                code: emitted.to_bytes(),
+                relocations: emitted.relocations,
+                strings: local_strings.to_vec(),
+            })
+        } else {
+            let (code, relocations) = emitter.emit()?;
+            Ok(MachineCode {
+                code,
+                relocations,
+                strings: local_strings.to_vec(),
+            })
         }
-    } else {
-        let (code, relocations) = emitter.emit()?;
-        MachineCode {
-            code,
-            relocations,
-            strings: local_strings,
-        }
-    };
-    Ok(crate::BackendProduct {
-        machine_code,
-        artifacts,
-    })
+    }
 }
 
 /// Generate machine code from CFG.
@@ -207,18 +204,20 @@ pub fn generate(
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<MachineCode> {
-    Ok(generate_inner(
-        cfg,
-        type_pool,
-        strings,
-        interner,
-        target,
-        crate::MachineSymbolResolver::default(),
-        &[],
-        false,
-        crate::BackendArtifactRequest::default(),
-    )?
-    .machine_code)
+    Ok(
+        crate::codegen_pipeline::generate_with_backend::<Aarch64CodegenBackend>(
+            cfg,
+            type_pool,
+            strings,
+            interner,
+            target,
+            crate::MachineSymbolResolver::default(),
+            &[],
+            false,
+            crate::BackendArtifactRequest::default(),
+        )?
+        .machine_code,
+    )
 }
 
 pub fn generate_with_symbols(
@@ -229,18 +228,20 @@ pub fn generate_with_symbols(
     target: Target,
     symbols: crate::MachineSymbolResolver<'_>,
 ) -> CompileResult<MachineCode> {
-    Ok(generate_inner(
-        cfg,
-        type_pool,
-        strings,
-        interner,
-        target,
-        symbols,
-        &[],
-        false,
-        crate::BackendArtifactRequest::default(),
-    )?
-    .machine_code)
+    Ok(
+        crate::codegen_pipeline::generate_with_backend::<Aarch64CodegenBackend>(
+            cfg,
+            type_pool,
+            strings,
+            interner,
+            target,
+            symbols,
+            &[],
+            false,
+            crate::BackendArtifactRequest::default(),
+        )?
+        .machine_code,
+    )
 }
 
 pub fn generate_with_symbols_and_atoms(
@@ -252,18 +253,20 @@ pub fn generate_with_symbols_and_atoms(
     symbols: crate::MachineSymbolResolver<'_>,
     atoms: &[crate::LocalAtomProjection<'_>],
 ) -> CompileResult<MachineCode> {
-    Ok(generate_inner(
-        cfg,
-        type_pool,
-        strings,
-        interner,
-        target,
-        symbols,
-        atoms,
-        true,
-        crate::BackendArtifactRequest::default(),
-    )?
-    .machine_code)
+    Ok(
+        crate::codegen_pipeline::generate_with_backend::<Aarch64CodegenBackend>(
+            cfg,
+            type_pool,
+            strings,
+            interner,
+            target,
+            symbols,
+            atoms,
+            true,
+            crate::BackendArtifactRequest::default(),
+        )?
+        .machine_code,
+    )
 }
 
 /// Run the production backend and retain requested diagnostic projections.
@@ -277,7 +280,7 @@ pub fn generate_product_with_symbols_and_atoms(
     atoms: &[crate::LocalAtomProjection<'_>],
     request: crate::BackendArtifactRequest,
 ) -> CompileResult<crate::BackendProduct> {
-    generate_inner(
+    crate::codegen_pipeline::generate_with_backend::<Aarch64CodegenBackend>(
         cfg, type_pool, strings, interner, target, symbols, atoms, true, request,
     )
 }

--- a/crates/rue-codegen/src/api_inventory.rs
+++ b/crates/rue-codegen/src/api_inventory.rs
@@ -2,11 +2,49 @@
 
 #[test]
 fn production_generate_entry_points_require_validated_cfg() {
+    let contract = include_str!("backend.rs");
+    assert!(contract.contains("pub(crate) trait Backend"));
+    for required in [
+        "type Mir;",
+        "type Reg;",
+        "const ARCH",
+        "const ARG_REG_COUNT",
+        "const RETURN_REG_COUNT",
+        "fn lower(",
+        "fn allocate(",
+        "fn peephole(",
+        "fn schedule(",
+        "fn verify(",
+        "fn referenced_string_ids(",
+        "fn remap_string_ids(",
+        "fn emit(",
+    ] {
+        assert!(
+            contract.contains(required),
+            "Backend contract lost {required}"
+        );
+    }
+
     for backend in [
         include_str!("x86_64/mod.rs"),
         include_str!("aarch64/mod.rs"),
     ] {
-        for entry_point in ["generate", "generate_product_with_symbols_and_atoms"] {
+        assert!(backend.contains("use crate::backend::Backend;"));
+        assert!(backend.contains("impl Backend for"));
+        assert!(backend.contains("const ARCH: rue_target::Arch"));
+        assert!(backend.contains("generate_with_backend::<"));
+        for removed in ["fn generate_inner(", "fn prepare_backend_with_artifacts("] {
+            assert!(
+                !backend.contains(removed),
+                "backend-local orchestration helper returned: {removed}"
+            );
+        }
+        for entry_point in [
+            "generate",
+            "generate_with_symbols",
+            "generate_with_symbols_and_atoms",
+            "generate_product_with_symbols_and_atoms",
+        ] {
             let signature = backend
                 .split(&format!("pub fn {entry_point}("))
                 .nth(1)
@@ -17,6 +55,14 @@ fn production_generate_entry_points_require_validated_cfg() {
                 "{entry_point} accepts an unvalidated CFG"
             );
             assert!(!signature.contains("cfg: &Cfg,"));
+            let target = signature
+                .find("target: Target")
+                .or_else(|| signature.find("target: rue_target::Target"));
+            assert!(
+                target.is_some(),
+                "{entry_point} must carry the target in both backends"
+            );
+            assert!(signature.find("interner:").unwrap() < target.unwrap());
         }
         for removed in [
             "pub fn generate_with_asm(",
@@ -27,6 +73,17 @@ fn production_generate_entry_points_require_validated_cfg() {
                 "presentation-only backend entry point returned: {removed}"
             );
         }
+    }
+
+    let root = include_str!("lib.rs");
+    for removed in [
+        "pub use x86_64::generate;",
+        "pub use x86_64::{Operand, Reg, X86Inst, X86Mir};",
+    ] {
+        assert!(
+            !root.contains(removed),
+            "crate-root x86 facade returned: {removed}"
+        );
     }
 
     for lowering in [

--- a/crates/rue-codegen/src/backend.rs
+++ b/crates/rue-codegen/src/backend.rs
@@ -1,0 +1,78 @@
+//! The compiler-checked contract between the shared backend driver and a
+//! target's leaf implementation.
+//!
+//! The contract deliberately describes orchestration capabilities, not a
+//! common machine IR. `Mir` and `Reg` stay associated with each target, while
+//! the existing liveness, allocation, slot, place-lowering, scheduling, and
+//! stack-verification adapters remain the authorities that implement the
+//! methods below.
+
+use lasso::ThreadedRodeo;
+use rue_air::FrozenTypeInternPool;
+use rue_cfg::ValidatedCfg;
+use rue_error::CompileResult;
+use rue_target::Target;
+
+use crate::codegen_pipeline::PreparedMir;
+use crate::frame_layout::SavedRegScheme;
+use crate::{BackendArtifactRequest, BackendArtifacts, MachineCode, MachineSymbolResolver};
+
+/// The target backend contract consumed by the one generic code-generation
+/// driver.
+///
+/// Associated types make it impossible to accidentally route one backend's
+/// MIR, registers, or emitter through the other backend. Constants make ABI
+/// facts used by the shared frame budget explicit. The remaining methods are
+/// thin adapters to the target's existing pass authorities; they do not form
+/// a second lowering or optimization path.
+pub(crate) trait Backend {
+    type Mir;
+    type Reg;
+
+    /// Architecture implemented by this backend. The shared driver checks it
+    /// before validating or lowering a CFG, including in release builds.
+    const ARCH: rue_target::Arch;
+    const ARG_REG_COUNT: u32;
+    const RETURN_REG_COUNT: u32;
+    const SAVED_REG_SCHEME: SavedRegScheme;
+    const TARGET_C_FLAVOR: rue_air::TargetCAbiFlavor;
+
+    fn lower(
+        cfg: &ValidatedCfg,
+        type_pool: &FrozenTypeInternPool,
+        interner: &ThreadedRodeo,
+        target: Target,
+        symbols: MachineSymbolResolver<'_>,
+        request: BackendArtifactRequest,
+        param_storage: &crate::param_storage::ParamStoragePlan,
+        local_storage: &crate::local_storage::LocalSlotPlan,
+    ) -> CompileResult<(Self::Mir, BackendArtifacts)>;
+
+    fn allocate(
+        mir: Self::Mir,
+        existing_slots: u32,
+        artifacts: &mut BackendArtifacts,
+        request: BackendArtifactRequest,
+    ) -> CompileResult<(Self::Mir, u32, Vec<Self::Reg>)>;
+
+    fn peephole(mir: &mut Self::Mir);
+    fn schedule(mir: &mut Self::Mir);
+    fn verify(mir: &Self::Mir) -> CompileResult<()>;
+    fn is_leaf(mir: &Self::Mir) -> bool;
+
+    /// Return all global string IDs named by the target MIR.
+    fn referenced_string_ids(mir: &Self::Mir) -> Vec<u32>;
+
+    /// Rewrite the target MIR's string operands after local-table compaction.
+    fn remap_string_ids(mir: &mut Self::Mir, remap: &std::collections::BTreeMap<u32, u32>);
+
+    /// Emit the already-prepared MIR. This is the only target-specific part of
+    /// the generic driver's final step: emitter construction and encoding stay
+    /// in the target module and preserve its ABI and byte-level behavior.
+    fn emit(
+        prepared: &PreparedMir<Self::Mir, Self::Reg>,
+        local_strings: &[String],
+        request: BackendArtifactRequest,
+        artifacts: &mut BackendArtifacts,
+    ) -> CompileResult<MachineCode>;
+}

--- a/crates/rue-codegen/src/codegen_pipeline.rs
+++ b/crates/rue-codegen/src/codegen_pipeline.rs
@@ -6,7 +6,7 @@
 //! emitted-frame locals — is common to every machine-code emission entry point.
 
 use rue_air::{ArgClass, ArgConvention, FrozenTypeInternPool, NativeCallAbi, ReturnClass};
-use rue_cfg::{Cfg, CfgArgMode, CfgInstData, CfgValue};
+use rue_cfg::{Cfg, CfgArgMode, CfgInstData, CfgValue, ValidatedCfg};
 use rue_error::{CompileError, CompileResult, ErrorKind};
 use tracing::info_span;
 
@@ -193,104 +193,71 @@ pub(crate) fn validate_pre_lowering_budget_for_target(
     Ok(has_sret)
 }
 
-/// Run the target-independent backend pipeline around concrete pass hooks.
-///
-/// The closures monomorphize for each backend; there is no dynamic dispatch or
-/// universal backend trait. Keeping the two slot formulas here is deliberate:
-///
-/// - `existing_slots` includes the shared local area (RUE-768), the *homed*
-///   parameters (RUE-1170), and the optional incoming sret pointer so
-///   register-allocation spills cannot overlap any of them.
-/// - `total_locals` includes only the shared local area and new spill slots
-///   because emitters account for parameters and sret separately.
-///
-/// Run the canonical backend pipeline while carrying optional diagnostic
-/// observations alongside the same lowering and allocation execution.
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn prepare_mir_with_artifacts<
-    M,
-    R,
-    D,
-    Lower,
-    Allocate,
-    Peephole,
-    Schedule,
-    Verify,
-    IsLeaf,
->(
-    cfg: &Cfg,
+/// Run the canonical backend pipeline through the compiler-checked backend
+/// contract. Every pass authority and target fact is an associated method or
+/// constant of the selected backend.
+pub(crate) fn prepare_mir_with_backend<B: crate::backend::Backend>(
+    cfg: &ValidatedCfg,
     type_pool: &FrozenTypeInternPool,
     interner: &lasso::ThreadedRodeo,
-    arg_reg_count: u32,
-    return_reg_count: u32,
-    scheme: SavedRegScheme,
-    target_c_flavor: rue_air::TargetCAbiFlavor,
-    is_foreign_symbol: &dyn Fn(lasso::Spur) -> bool,
-    lower: Lower,
-    allocate: Allocate,
-    peephole: Peephole,
-    schedule: Schedule,
-    verify: Verify,
-    is_leaf: IsLeaf,
-) -> CompileResult<(PreparedMir<M, R>, D)>
-where
-    Lower: FnOnce(
-        &crate::param_storage::ParamStoragePlan,
-        &crate::local_storage::LocalSlotPlan,
-    ) -> CompileResult<(M, D)>,
-    Allocate: FnOnce(M, u32, &mut D) -> CompileResult<(M, u32, Vec<R>)>,
-    Peephole: FnOnce(&mut M),
-    Schedule: FnOnce(&mut M),
-    Verify: FnOnce(&M) -> CompileResult<()>,
-    IsLeaf: FnOnce(&M) -> bool,
-{
+    target: rue_target::Target,
+    symbols: crate::MachineSymbolResolver<'_>,
+    request: crate::BackendArtifactRequest,
+) -> CompileResult<(PreparedMir<B::Mir, B::Reg>, crate::BackendArtifacts)> {
+    assert_eq!(
+        target.arch(),
+        B::ARCH,
+        "backend target architecture mismatch: backend is {:?}, target is {:?}",
+        B::ARCH,
+        target.arch()
+    );
     let has_sret = validate_pre_lowering_budget_for_target(
         cfg,
         type_pool,
-        arg_reg_count,
-        return_reg_count,
-        scheme,
-        target_c_flavor,
-        is_foreign_symbol,
+        B::ARG_REG_COUNT,
+        B::RETURN_REG_COUNT,
+        B::SAVED_REG_SCHEME,
+        B::TARGET_C_FLAVOR,
+        &|name| symbols.is_foreign(&symbols.resolve(interner.resolve(&name))),
     )?;
-    // The per-parameter storage decision (RUE-1170) is computed once here and
-    // shared by lowering (body addressing and entry copies), the frame slot
-    // sums below, and the emitter's prologue homing, so they cannot disagree
-    // about which parameters have frame homes.
     let param_storage =
-        crate::param_storage::ParamStoragePlan::plan(cfg, type_pool, has_sret, arg_reg_count);
+        crate::param_storage::ParamStoragePlan::plan(cfg, type_pool, has_sret, B::ARG_REG_COUNT);
     let param_homing = param_storage.homing().to_vec();
     let homed_param_slots = param_storage.homed_area_slots();
-    // The local frame-slot decision (RUE-768) is target-independent and is
-    // likewise computed once: lowering addresses through it, the sums below
-    // place the parameter area and the spill floor above it, and the emitters
-    // size the frame from it.
     let local_storage = crate::local_storage::LocalSlotPlan::plan(cfg, type_pool, interner);
     let frame_local_slots = local_storage.frame_local_slots();
 
     let (mir, mut artifacts) = {
         let _span = info_span!("mir_lowering").entered();
-        lower(&param_storage, &local_storage)?
+        B::lower(
+            cfg,
+            type_pool,
+            interner,
+            target,
+            symbols,
+            request,
+            &param_storage,
+            &local_storage,
+        )?
     };
     let existing_slots =
         checked_slot_sum([frame_local_slots, homed_param_slots, u32::from(has_sret)])
             .ok_or_else(|| frame_budget_error(cfg, None))?;
     let (mut mir, num_spills, used_callee_saved) = {
         let _span = info_span!("register_allocation").entered();
-        allocate(mir, existing_slots, &mut artifacts)?
+        B::allocate(mir, existing_slots, &mut artifacts, request)?
     };
-
     {
         let _span = info_span!("mir_peephole").entered();
-        peephole(&mut mir);
+        B::peephole(&mut mir);
     }
     {
         let _span = info_span!("mir_scheduling").entered();
-        schedule(&mut mir);
+        B::schedule(&mut mir);
     }
     {
         let _span = info_span!("mir_verification").entered();
-        verify(&mir)?;
+        B::verify(&mir)?;
     }
 
     let total_locals = frame_local_slots
@@ -298,13 +265,12 @@ where
         .ok_or_else(|| frame_budget_error(cfg, None))?;
     let total_slots = checked_slot_sum([total_locals, homed_param_slots, u32::from(has_sret)])
         .ok_or_else(|| frame_budget_error(cfg, None))?;
-    // Frame planning is the last thing the pipeline decides: the eligible-leaf
-    // question can only be answered once allocation, peephole, and scheduling
-    // have settled the final instruction stream and the final spill count.
-    let frame_layout = match plan_frame_pointer(total_slots, is_leaf(&mir)) {
-        FramePointer::Omitted => FrameLayout::frameless(scheme, used_callee_saved.len()),
+    let frame_layout = match plan_frame_pointer(total_slots, B::is_leaf(&mir)) {
+        FramePointer::Omitted => {
+            FrameLayout::frameless(B::SAVED_REG_SCHEME, used_callee_saved.len())
+        }
         FramePointer::Established => {
-            FrameLayout::try_new(scheme, used_callee_saved.len(), total_slots)
+            FrameLayout::try_new(B::SAVED_REG_SCHEME, used_callee_saved.len(), total_slots)
                 .map_err(|_| frame_budget_error(cfg, None))?
         }
     };
@@ -325,19 +291,174 @@ where
     ))
 }
 
+/// Complete target-independent orchestration around one backend's leaves.
+pub(crate) fn generate_with_backend<B: crate::backend::Backend>(
+    cfg: &ValidatedCfg,
+    type_pool: &FrozenTypeInternPool,
+    strings: &[String],
+    interner: &lasso::ThreadedRodeo,
+    target: rue_target::Target,
+    symbols: crate::MachineSymbolResolver<'_>,
+    atoms: &[crate::LocalAtomProjection<'_>],
+    require_complete_atoms: bool,
+    request: crate::BackendArtifactRequest,
+) -> CompileResult<crate::BackendProduct> {
+    let (mut prepared, mut artifacts) =
+        prepare_mir_with_backend::<B>(cfg, type_pool, interner, target, symbols, request)?;
+    let local_strings = {
+        let _span = info_span!("string_table_compaction").entered();
+        let (local_strings, remap) = crate::compact_string_table(
+            strings,
+            atoms,
+            B::referenced_string_ids(&prepared.mir),
+            require_complete_atoms,
+        )?;
+        B::remap_string_ids(&mut prepared.mir, &remap);
+        local_strings
+    };
+    let _emission_span = info_span!("machine_emission").entered();
+    let machine_code = B::emit(&prepared, &local_strings, request, &mut artifacts)?;
+    Ok(crate::BackendProduct {
+        machine_code,
+        artifacts,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::cell::RefCell;
 
     use lasso::Spur;
-    use rue_air::{Type, TypeInternPool};
-    use rue_cfg::{Cfg, CfgArgMode, CfgCallArg, CfgInst, CfgInstData};
+    use rue_air::{FrozenTypeInternPool, Type, TypeInternPool};
+    use rue_cfg::{Cfg, CfgArgMode, CfgCallArg, CfgInst, CfgInstData, ValidatedCfg};
     use rue_span::Span;
+    use rue_target::{Arch, Target};
 
     use super::{
-        FramePointer, SavedRegScheme, plan_frame_pointer, prepare_mir_with_artifacts,
+        FramePointer, SavedRegScheme, plan_frame_pointer, prepare_mir_with_backend,
         validate_pre_lowering_budget,
     };
+
+    std::thread_local! {
+        static PIPELINE_EVENTS: RefCell<Vec<&'static str>> = const {
+            RefCell::new(Vec::new())
+        };
+    }
+
+    fn record(event: &'static str) {
+        PIPELINE_EVENTS.with(|events| events.borrow_mut().push(event));
+    }
+
+    struct TestBackend;
+
+    impl crate::backend::Backend for TestBackend {
+        type Mir = u32;
+        type Reg = u8;
+
+        const ARCH: Arch = Arch::X86_64;
+        const ARG_REG_COUNT: u32 = 6;
+        const RETURN_REG_COUNT: u32 = 6;
+        const SAVED_REG_SCHEME: SavedRegScheme = SavedRegScheme::X86_64;
+        const TARGET_C_FLAVOR: rue_air::TargetCAbiFlavor = rue_air::TargetCAbiFlavor::SysVAmd64;
+
+        fn lower(
+            _cfg: &ValidatedCfg,
+            _type_pool: &rue_air::FrozenTypeInternPool,
+            _interner: &lasso::ThreadedRodeo,
+            _target: Target,
+            _symbols: crate::MachineSymbolResolver<'_>,
+            _request: crate::BackendArtifactRequest,
+            _param_storage: &crate::param_storage::ParamStoragePlan,
+            local_storage: &crate::local_storage::LocalSlotPlan,
+        ) -> rue_error::CompileResult<(Self::Mir, crate::BackendArtifacts)> {
+            record("lower");
+            assert_eq!(local_storage.frame_local_slots(), 3);
+            Ok((10, crate::BackendArtifacts::default()))
+        }
+
+        fn allocate(
+            mir: Self::Mir,
+            existing_slots: u32,
+            _artifacts: &mut crate::BackendArtifacts,
+            _request: crate::BackendArtifactRequest,
+        ) -> rue_error::CompileResult<(Self::Mir, u32, Vec<Self::Reg>)> {
+            record("allocate");
+            assert_eq!(existing_slots, 6);
+            Ok((mir + 1, 4, vec![5]))
+        }
+
+        fn peephole(mir: &mut Self::Mir) {
+            record("peephole");
+            *mir += 2;
+        }
+
+        fn schedule(mir: &mut Self::Mir) {
+            record("schedule");
+            *mir += 3;
+        }
+
+        fn verify(mir: &Self::Mir) -> rue_error::CompileResult<()> {
+            record("verify");
+            assert_eq!(*mir, 16);
+            Ok(())
+        }
+
+        fn is_leaf(mir: &Self::Mir) -> bool {
+            record("is_leaf");
+            assert_eq!(*mir, 16, "frame planning sees the final instruction stream");
+            true
+        }
+
+        fn referenced_string_ids(_mir: &Self::Mir) -> Vec<u32> {
+            Vec::new()
+        }
+
+        fn remap_string_ids(_mir: &mut Self::Mir, _remap: &std::collections::BTreeMap<u32, u32>) {}
+
+        fn emit(
+            _prepared: &super::PreparedMir<Self::Mir, Self::Reg>,
+            _local_strings: &[String],
+            _request: crate::BackendArtifactRequest,
+            _artifacts: &mut crate::BackendArtifacts,
+        ) -> rue_error::CompileResult<crate::MachineCode> {
+            panic!("synthetic backend emitter is not part of this preparation test")
+        }
+    }
+
+    fn aggregate_test_cfg() -> (ValidatedCfg, FrozenTypeInternPool, lasso::ThreadedRodeo) {
+        let type_pool = TypeInternPool::new();
+        let array_id = type_pool.intern_array_from_type(Type::I64, 7);
+        let type_pool = type_pool.freeze();
+        let array_ty = Type::new_array(array_id);
+        let mut cfg = Cfg::new(
+            array_ty,
+            3,
+            2,
+            "pipeline_test".to_owned(),
+            vec![false, false],
+        );
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let elements = (0..7)
+            .map(|value| {
+                cfg.append_inst(
+                    entry,
+                    CfgInst {
+                        data: CfgInstData::Const(value),
+                        ty: Type::I64,
+                        span: Span::new(0, 2),
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+        let array = cfg
+            .append_array_init(entry, elements, array_ty, Span::new(0, 2))
+            .unwrap();
+        cfg.set_return(entry, Some(array));
+        let interner = lasso::ThreadedRodeo::new();
+        let cfg = cfg.finish(&type_pool).expect("test CFG must validate");
+        (cfg, type_pool, interner)
+    }
 
     #[test]
     fn only_a_slotless_leaf_omits_the_frame_pointer() {
@@ -353,64 +474,25 @@ mod tests {
 
     #[test]
     fn pass_order_and_frame_slot_formulas_are_single_source() {
-        let type_pool = TypeInternPool::new();
-        let array_id = type_pool.intern_array_from_type(Type::I32, 7);
-        let type_pool = type_pool.freeze();
-        let cfg = Cfg::new(
-            Type::new_array(array_id),
-            3,
-            2,
-            "pipeline_test".to_owned(),
-            vec![false, false],
-        );
-        let events = RefCell::new(Vec::new());
+        let (cfg, type_pool, interner) = aggregate_test_cfg();
+        PIPELINE_EVENTS.with(|events| events.borrow_mut().clear());
 
         // A seven-slot return exceeds the six-register budget, so spill
         // placement sees 3 locals + 2 params + 1 sret-pointer slot. Four
         // spills then produce 3 + 4 emitted locals (not 3 + 2 + 1 + 4).
-        let (prepared, ()) = prepare_mir_with_artifacts(
+        let (prepared, _) = prepare_mir_with_backend::<TestBackend>(
             &cfg,
             &type_pool,
-            &lasso::ThreadedRodeo::new(),
-            6,
-            6,
-            SavedRegScheme::X86_64,
-            rue_air::TargetCAbiFlavor::SysVAmd64,
-            &|_| false,
-            |_param_storage, local_storage| {
-                events.borrow_mut().push("lower");
-                // No storage markers, so the local layout is the identity.
-                assert_eq!(local_storage.frame_local_slots(), 3);
-                Ok((10_u32, ()))
-            },
-            |mir, existing_slots, _artifacts| {
-                events.borrow_mut().push("allocate");
-                assert_eq!(existing_slots, 6);
-                Ok((mir + 1, 4, vec![5_u8]))
-            },
-            |mir| {
-                events.borrow_mut().push("peephole");
-                *mir += 2;
-            },
-            |mir| {
-                events.borrow_mut().push("schedule");
-                *mir += 3;
-            },
-            |mir| {
-                events.borrow_mut().push("verify");
-                assert_eq!(*mir, 16);
-                Ok(())
-            },
-            |mir| {
-                events.borrow_mut().push("is_leaf");
-                assert_eq!(*mir, 16, "frame planning sees the final instruction stream");
-                true
-            },
+            &interner,
+            Target::X86_64Linux,
+            crate::MachineSymbolResolver::default(),
+            crate::BackendArtifactRequest::default(),
         )
         .expect("synthetic pipeline should succeed");
 
+        let events = PIPELINE_EVENTS.with(|events| std::mem::take(&mut *events.borrow_mut()));
         assert_eq!(
-            events.into_inner(),
+            events,
             [
                 "lower", "allocate", "peephole", "schedule", "verify", "is_leaf"
             ]
@@ -421,6 +503,20 @@ mod tests {
         assert_eq!(prepared.param_storage.homed_area_slots(), 2);
         assert!(prepared.has_sret);
         assert_eq!(prepared.used_callee_saved, [5]);
+    }
+
+    #[test]
+    #[should_panic(expected = "backend target architecture mismatch")]
+    fn backend_contract_rejects_mismatched_target_before_lowering() {
+        let (cfg, type_pool, interner) = aggregate_test_cfg();
+        let _ = prepare_mir_with_backend::<TestBackend>(
+            &cfg,
+            &type_pool,
+            &interner,
+            Target::Aarch64Linux,
+            crate::MachineSymbolResolver::default(),
+            crate::BackendArtifactRequest::default(),
+        );
     }
 
     #[test]

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -42,6 +42,7 @@ macro_rules! end_inst {
 }
 
 mod allocation;
+mod backend;
 pub mod call_plan;
 mod codegen_pipeline;
 pub mod export_thunk;
@@ -510,9 +511,6 @@ pub fn format_offset(offset: i32) -> String {
     }
 }
 
-// Re-export the generate function for x86_64 (default)
-pub use x86_64::generate;
-
 // Re-export shared types
 pub use cfg_lower::{
     BlockLoweringInfo, LoweringDebugInfo, LoweringDecision, TerminatorLoweringDecision,
@@ -527,9 +525,6 @@ pub use stack_frame::{
     ArgumentLocation, ReturnLocation, StackFrameInfo, StackSlot, generate_stack_frame_info,
 };
 pub use vreg::{LabelId, VReg};
-
-// Re-export commonly used x86_64 types for convenience
-pub use x86_64::{Operand, Reg, X86Inst, X86Mir};
 
 #[cfg(test)]
 mod tests {
@@ -764,6 +759,42 @@ mod tests {
         }
     }
 
+    /// Exercise the same production artifact path for every supported target.
+    /// The target-specific MIR and emitter remain behind their qualified
+    /// modules; this harness owns only the parity-level entry-point contract.
+    fn generate_product_for_target(
+        cfg: &ValidatedCfg,
+        type_pool: &FrozenTypeInternPool,
+        strings: &[String],
+        interner: &ThreadedRodeo,
+        target: rue_target::Target,
+        request: BackendArtifactRequest,
+    ) -> BackendProduct {
+        match target.arch() {
+            rue_target::Arch::X86_64 => x86_64::generate_product_with_symbols_and_atoms(
+                cfg,
+                type_pool,
+                strings,
+                interner,
+                target,
+                MachineSymbolResolver::default(),
+                &[],
+                request,
+            ),
+            rue_target::Arch::Aarch64 => aarch64::generate_product_with_symbols_and_atoms(
+                cfg,
+                type_pool,
+                strings,
+                interner,
+                target,
+                MachineSymbolResolver::default(),
+                &[],
+                request,
+            ),
+        }
+        .expect("production backend generation should succeed")
+    }
+
     #[test]
     fn emitted_byte_synchronization_handles_labels_and_rejects_gaps() {
         let mut instructions = vec![
@@ -793,7 +824,14 @@ mod tests {
         let (cfg, type_pool, interner) = test_cfg();
 
         // Test the generate function
-        let machine_code = generate(&cfg, &type_pool, &[], &interner).unwrap();
+        let machine_code = x86_64::generate(
+            &cfg,
+            &type_pool,
+            &[],
+            &interner,
+            rue_target::Target::X86_64Linux,
+        )
+        .unwrap();
 
         // Should generate working code
         assert!(!machine_code.code.is_empty());
@@ -821,8 +859,14 @@ mod tests {
         let num_locals = (MAX_ADD_SUB_IMMEDIATE as u64 / SLOT_BYTES + 1) as u32;
         let (cfg, type_pool, interner) = test_cfg_with_locals_named(num_locals, "large_frame");
 
-        let x86 = x86_64::generate(&cfg, &type_pool, &[], &interner)
-            .expect("x86-64 large frame generation should succeed");
+        let x86 = x86_64::generate(
+            &cfg,
+            &type_pool,
+            &[],
+            &interner,
+            rue_target::Target::X86_64Linux,
+        )
+        .expect("x86-64 large frame generation should succeed");
         assert!(!x86.code.is_empty());
 
         let arm = aarch64::generate(
@@ -885,18 +929,22 @@ mod tests {
             asm: true,
         };
 
-        let x86 = x86_64::generate(&cfg, &type_pool, &strings, &interner)
-            .expect("x86 normal generation should succeed");
-        let x86_product = x86_64::generate_product_with_symbols_and_atoms(
+        let x86 = x86_64::generate(
             &cfg,
             &type_pool,
             &strings,
             &interner,
-            MachineSymbolResolver::default(),
-            &[],
-            request,
+            rue_target::Target::X86_64Linux,
         )
-        .expect("x86 diagnostic product should succeed");
+        .expect("x86 normal generation should succeed");
+        let x86_product = generate_product_for_target(
+            &cfg,
+            &type_pool,
+            &strings,
+            &interner,
+            rue_target::Target::X86_64Linux,
+            request,
+        );
         assert_same_machine_code(&x86, &x86_product.machine_code);
         assert!(x86_product.artifacts.lowering.is_some());
         assert!(x86_product.artifacts.mir.is_some());
@@ -920,17 +968,8 @@ mod tests {
         ] {
             let arm = aarch64::generate(&cfg, &type_pool, &strings, &interner, target)
                 .expect("AArch64 normal generation should succeed");
-            let arm_product = aarch64::generate_product_with_symbols_and_atoms(
-                &cfg,
-                &type_pool,
-                &strings,
-                &interner,
-                target,
-                MachineSymbolResolver::default(),
-                &[],
-                request,
-            )
-            .expect("AArch64 diagnostic product should succeed");
+            let arm_product =
+                generate_product_for_target(&cfg, &type_pool, &strings, &interner, target, request);
             assert_same_machine_code(&arm, &arm_product.machine_code);
             assert!(arm_product.artifacts.lowering.is_some());
             assert!(arm_product.artifacts.mir.is_some());

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -319,6 +319,7 @@ fn generate_x86_64_stack_frame(
         cfg,
         type_pool,
         interner,
+        target,
         crate::MachineSymbolResolver::default(),
     )?;
     let has_sret = prepared.has_sret;
@@ -926,6 +927,7 @@ mod tests {
                 &type_pool,
                 &[],
                 &interner,
+                target,
                 crate::MachineSymbolResolver::default(),
                 &[],
                 request,

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -26,166 +26,168 @@ pub use emit::Emitter;
 pub use mir::{LabelId, Operand, Reg, VReg, X86Inst, X86Mir};
 pub use regalloc::RegAlloc;
 
+use crate::backend::Backend;
 use lasso::ThreadedRodeo;
 use rue_air::FrozenTypeInternPool;
 use rue_cfg::ValidatedCfg;
 use rue_error::CompileResult;
-use tracing::info_span;
+use rue_target::Target;
 
 // Re-export from parent
 pub use super::{EmittedCode, EmittedRelocation, MachineCode};
+
+struct X86CodegenBackend;
 
 pub(crate) fn prepare_backend(
     cfg: &ValidatedCfg,
     type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
+    target: Target,
     symbols: crate::MachineSymbolResolver<'_>,
 ) -> CompileResult<crate::codegen_pipeline::PreparedMir<X86Mir, Reg>> {
-    prepare_backend_with_artifacts(
+    crate::codegen_pipeline::prepare_mir_with_backend::<X86CodegenBackend>(
         cfg,
         type_pool,
         interner,
+        target,
         symbols,
         crate::BackendArtifactRequest::default(),
     )
-    .map(|(prepared, _artifacts)| prepared)
+    .map(|(prepared, _)| prepared)
 }
 
-fn prepare_backend_with_artifacts(
-    cfg: &ValidatedCfg,
-    type_pool: &FrozenTypeInternPool,
-    interner: &ThreadedRodeo,
-    symbols: crate::MachineSymbolResolver<'_>,
-    request: crate::BackendArtifactRequest,
-) -> CompileResult<(
-    crate::codegen_pipeline::PreparedMir<X86Mir, Reg>,
-    crate::BackendArtifacts,
-)> {
-    crate::codegen_pipeline::prepare_mir_with_artifacts(
-        cfg,
-        type_pool,
-        interner,
-        cfg_lower::ARG_REGS.len() as u32,
-        cfg_lower::RET_REGS.len() as u32,
-        crate::frame_layout::SavedRegScheme::X86_64,
-        rue_air::TargetCAbiFlavor::SysVAmd64,
-        &|name| symbols.is_foreign(&symbols.resolve(interner.resolve(&name))),
-        |param_storage, local_storage| {
-            let (mir, lowering) = if request.lowering {
-                let (mir, debug) = CfgLower::new_with_symbols(cfg, type_pool, interner, symbols)
+impl Backend for X86CodegenBackend {
+    type Mir = X86Mir;
+    type Reg = Reg;
+
+    const ARCH: rue_target::Arch = rue_target::Arch::X86_64;
+    const ARG_REG_COUNT: u32 = cfg_lower::ARG_REGS.len() as u32;
+    const RETURN_REG_COUNT: u32 = cfg_lower::RET_REGS.len() as u32;
+    const SAVED_REG_SCHEME: crate::frame_layout::SavedRegScheme =
+        crate::frame_layout::SavedRegScheme::X86_64;
+    const TARGET_C_FLAVOR: rue_air::TargetCAbiFlavor = rue_air::TargetCAbiFlavor::SysVAmd64;
+
+    fn lower(
+        cfg: &ValidatedCfg,
+        type_pool: &FrozenTypeInternPool,
+        interner: &ThreadedRodeo,
+        _target: rue_target::Target,
+        symbols: crate::MachineSymbolResolver<'_>,
+        request: crate::BackendArtifactRequest,
+        param_storage: &crate::param_storage::ParamStoragePlan,
+        local_storage: &crate::local_storage::LocalSlotPlan,
+    ) -> CompileResult<(Self::Mir, crate::BackendArtifacts)> {
+        let (mir, lowering) = if request.lowering {
+            let (mir, debug) = CfgLower::new_with_symbols(cfg, type_pool, interner, symbols)
+                .with_param_storage(param_storage)
+                .with_local_storage(local_storage)
+                .lower_with_debug()?;
+            (mir, Some(debug))
+        } else {
+            (
+                CfgLower::new_with_symbols(cfg, type_pool, interner, symbols)
                     .with_param_storage(param_storage)
                     .with_local_storage(local_storage)
-                    .lower_with_debug()?;
-                (mir, Some(debug))
-            } else {
-                (
-                    CfgLower::new_with_symbols(cfg, type_pool, interner, symbols)
-                        .with_param_storage(param_storage)
-                        .with_local_storage(local_storage)
-                        .lower()?,
-                    None,
-                )
-            };
-            let mir_text = request.mir.then(|| mir.to_string());
-            Ok((
-                mir,
-                crate::BackendArtifacts {
-                    lowering,
-                    mir: mir_text,
-                    ..Default::default()
-                },
-            ))
-        },
-        |mir, existing_slots, artifacts| {
-            let (mir, spills, used_callee_saved, liveness, regalloc) =
-                RegAlloc::new_with_artifacts(mir, existing_slots, request.liveness)
-                    .allocate_with_artifacts(request.regalloc)?;
-            artifacts.liveness = liveness.map(|debug| debug.to_string());
-            artifacts.regalloc = regalloc.map(|debug| debug.to_string());
-            Ok((mir, spills, used_callee_saved))
-        },
-        |mir| {
-            peephole::optimize(mir.instructions_vec_mut());
-        },
-        schedule::schedule,
-        verify::verify_stack_alignment,
-        X86Mir::is_leaf,
-    )
-}
+                    .lower()?,
+                None,
+            )
+        };
+        let mir_text = request.mir.then(|| mir.to_string());
+        Ok((
+            mir,
+            crate::BackendArtifacts {
+                lowering,
+                mir: mir_text,
+                ..Default::default()
+            },
+        ))
+    }
 
-fn generate_inner(
-    cfg: &ValidatedCfg,
-    type_pool: &FrozenTypeInternPool,
-    strings: &[String],
-    interner: &ThreadedRodeo,
-    symbols: crate::MachineSymbolResolver<'_>,
-    atoms: &[crate::LocalAtomProjection<'_>],
-    require_complete_atoms: bool,
-    request: crate::BackendArtifactRequest,
-) -> CompileResult<crate::BackendProduct> {
-    let (mut prepared, mut artifacts) =
-        prepare_backend_with_artifacts(cfg, type_pool, interner, symbols, request)?;
-    let referenced_strings = prepared
-        .mir
-        .instructions()
-        .iter()
-        .filter_map(|inst| match inst {
-            X86Inst::StringConstPtr { string_id, .. }
-            | X86Inst::StringConstLen { string_id, .. }
-            | X86Inst::StringConstCap { string_id, .. } => Some(*string_id),
-            _ => None,
-        });
-    let local_strings = {
-        let _span = info_span!("string_table_compaction").entered();
-        let (local_strings, string_id_remap) = crate::compact_string_table(
-            strings,
-            atoms,
-            referenced_strings,
-            require_complete_atoms,
-        )?;
-        for inst in prepared.mir.instructions_vec_mut() {
+    fn allocate(
+        mir: Self::Mir,
+        existing_slots: u32,
+        artifacts: &mut crate::BackendArtifacts,
+        request: crate::BackendArtifactRequest,
+    ) -> CompileResult<(Self::Mir, u32, Vec<Self::Reg>)> {
+        let (mir, spills, used, liveness, regalloc) =
+            RegAlloc::new_with_artifacts(mir, existing_slots, request.liveness)
+                .allocate_with_artifacts(request.regalloc)?;
+        artifacts.liveness = liveness.map(|debug| debug.to_string());
+        artifacts.regalloc = regalloc.map(|debug| debug.to_string());
+        Ok((mir, spills, used))
+    }
+
+    fn peephole(mir: &mut Self::Mir) {
+        peephole::optimize(mir.instructions_vec_mut());
+    }
+    fn schedule(mir: &mut Self::Mir) {
+        schedule::schedule(mir);
+    }
+    fn verify(mir: &Self::Mir) -> CompileResult<()> {
+        verify::verify_stack_alignment(mir)
+    }
+    fn is_leaf(mir: &Self::Mir) -> bool {
+        X86Mir::is_leaf(mir)
+    }
+
+    fn referenced_string_ids(mir: &Self::Mir) -> Vec<u32> {
+        mir.instructions()
+            .iter()
+            .filter_map(|inst| match inst {
+                X86Inst::StringConstPtr { string_id, .. }
+                | X86Inst::StringConstLen { string_id, .. }
+                | X86Inst::StringConstCap { string_id, .. } => Some(*string_id),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn remap_string_ids(mir: &mut Self::Mir, remap: &std::collections::BTreeMap<u32, u32>) {
+        for inst in mir.instructions_vec_mut() {
             let string_id = match inst {
                 X86Inst::StringConstPtr { string_id, .. }
                 | X86Inst::StringConstLen { string_id, .. }
                 | X86Inst::StringConstCap { string_id, .. } => string_id,
                 _ => continue,
             };
-            *string_id = string_id_remap[string_id];
+            *string_id = remap[string_id];
         }
-        local_strings
-    };
-    let _emission_span = info_span!("machine_emission").entered();
-    let emitter = Emitter::new(
-        &prepared.mir,
-        prepared.total_locals,
-        prepared.frame_local_slots,
-        prepared.param_storage.homed_area_slots(),
-        &prepared.used_callee_saved,
-        &local_strings,
-    )
-    .with_sret(prepared.has_sret)
-    .with_frame_layout(prepared.frame_layout)
-    .with_param_homing(prepared.param_homing.clone());
-    let machine_code = if request.asm {
-        let emitted = emitter.emit_all()?;
-        artifacts.asm = Some(emitted.to_asm());
-        MachineCode {
-            code: emitted.to_bytes(),
-            relocations: emitted.relocations,
-            strings: local_strings,
+    }
+
+    fn emit(
+        prepared: &crate::codegen_pipeline::PreparedMir<Self::Mir, Self::Reg>,
+        local_strings: &[String],
+        request: crate::BackendArtifactRequest,
+        artifacts: &mut crate::BackendArtifacts,
+    ) -> CompileResult<MachineCode> {
+        let emitter = Emitter::new(
+            &prepared.mir,
+            prepared.total_locals,
+            prepared.frame_local_slots,
+            prepared.param_storage.homed_area_slots(),
+            &prepared.used_callee_saved,
+            local_strings,
+        )
+        .with_sret(prepared.has_sret)
+        .with_frame_layout(prepared.frame_layout)
+        .with_param_homing(prepared.param_homing.clone());
+        if request.asm {
+            let emitted = emitter.emit_all()?;
+            artifacts.asm = Some(emitted.to_asm());
+            Ok(MachineCode {
+                code: emitted.to_bytes(),
+                relocations: emitted.relocations,
+                strings: local_strings.to_vec(),
+            })
+        } else {
+            let (code, relocations) = emitter.emit()?;
+            Ok(MachineCode {
+                code,
+                relocations,
+                strings: local_strings.to_vec(),
+            })
         }
-    } else {
-        let (code, relocations) = emitter.emit()?;
-        MachineCode {
-            code,
-            relocations,
-            strings: local_strings,
-        }
-    };
-    Ok(crate::BackendProduct {
-        machine_code,
-        artifacts,
-    })
+    }
 }
 
 /// Generate machine code from CFG.
@@ -197,18 +199,22 @@ pub fn generate(
     type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
+    target: rue_target::Target,
 ) -> CompileResult<MachineCode> {
-    Ok(generate_inner(
-        cfg,
-        type_pool,
-        strings,
-        interner,
-        crate::MachineSymbolResolver::default(),
-        &[],
-        false,
-        crate::BackendArtifactRequest::default(),
-    )?
-    .machine_code)
+    Ok(
+        crate::codegen_pipeline::generate_with_backend::<X86CodegenBackend>(
+            cfg,
+            type_pool,
+            strings,
+            interner,
+            target,
+            crate::MachineSymbolResolver::default(),
+            &[],
+            false,
+            crate::BackendArtifactRequest::default(),
+        )?
+        .machine_code,
+    )
 }
 
 pub fn generate_with_symbols(
@@ -216,19 +222,23 @@ pub fn generate_with_symbols(
     type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
+    target: rue_target::Target,
     symbols: crate::MachineSymbolResolver<'_>,
 ) -> CompileResult<MachineCode> {
-    Ok(generate_inner(
-        cfg,
-        type_pool,
-        strings,
-        interner,
-        symbols,
-        &[],
-        false,
-        crate::BackendArtifactRequest::default(),
-    )?
-    .machine_code)
+    Ok(
+        crate::codegen_pipeline::generate_with_backend::<X86CodegenBackend>(
+            cfg,
+            type_pool,
+            strings,
+            interner,
+            target,
+            symbols,
+            &[],
+            false,
+            crate::BackendArtifactRequest::default(),
+        )?
+        .machine_code,
+    )
 }
 
 pub fn generate_with_symbols_and_atoms(
@@ -236,20 +246,24 @@ pub fn generate_with_symbols_and_atoms(
     type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
+    target: rue_target::Target,
     symbols: crate::MachineSymbolResolver<'_>,
     atoms: &[crate::LocalAtomProjection<'_>],
 ) -> CompileResult<MachineCode> {
-    Ok(generate_inner(
-        cfg,
-        type_pool,
-        strings,
-        interner,
-        symbols,
-        atoms,
-        true,
-        crate::BackendArtifactRequest::default(),
-    )?
-    .machine_code)
+    Ok(
+        crate::codegen_pipeline::generate_with_backend::<X86CodegenBackend>(
+            cfg,
+            type_pool,
+            strings,
+            interner,
+            target,
+            symbols,
+            atoms,
+            true,
+            crate::BackendArtifactRequest::default(),
+        )?
+        .machine_code,
+    )
 }
 
 /// Run the production backend and retain requested diagnostic projections.
@@ -258,11 +272,12 @@ pub fn generate_product_with_symbols_and_atoms(
     type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
+    target: rue_target::Target,
     symbols: crate::MachineSymbolResolver<'_>,
     atoms: &[crate::LocalAtomProjection<'_>],
     request: crate::BackendArtifactRequest,
 ) -> CompileResult<crate::BackendProduct> {
-    generate_inner(
-        cfg, type_pool, strings, interner, symbols, atoms, true, request,
+    crate::codegen_pipeline::generate_with_backend::<X86CodegenBackend>(
+        cfg, type_pool, strings, interner, target, symbols, atoms, true, request,
     )
 }

--- a/crates/rue-compiler/src/codegen_query.rs
+++ b/crates/rue-compiler/src/codegen_query.rs
@@ -549,6 +549,7 @@ pub(crate) fn evaluate_codegen_unit(
             &record.type_pool,
             &record.strings,
             &record.interner,
+            key.target,
             symbols,
             &atoms,
             key.request,


### PR DESCRIPTION
Fixes RUE-1803.

## Summary

- add one documented, compiler-checked backend contract over the existing target-specific pass authorities
- route x86-64 and AArch64 through one generic pipeline driver with symmetric target-aware generation entry points
- remove the unqualified x86-64 facade and add shared plan-level parity coverage while retaining backend-specific MIR and encoding assertions

## Validation

- `scripts/rue unit codegen`
- `scripts/rue unit compiler`
- `scripts/rue cli abi`
- `scripts/rue quick`
- focused backend contract and pipeline tests
- `scripts/rue fmt`
- `git diff --check`
- `scripts/rue premerge`
- `scripts/rue test`