### PR TITLE
RUE-1799: centralize builtin universe bootstrap

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -3,8 +3,10 @@
 use std::collections::BTreeSet;
 
 use syn::{
-    BinOp, Expr, ExprCall, ExprField, ExprIf, ExprLet, ExprMatch, ExprMethodCall, ExprPath,
-    ExprStruct, File, ImplItem, Item, ItemFn, ItemImpl, ItemMod, PatStruct, PatTupleStruct,
+    BinOp, Expr, ExprCall, ExprField, ExprIf, ExprLet, ExprLit, ExprMatch, ExprMethodCall,
+    ExprPath, ExprStruct, File, ImplItem, Item, ItemFn, ItemImpl, ItemMod, Lit, PatStruct,
+    PatTupleStruct,
+    parse::Parser,
     visit::{self, Visit},
 };
 
@@ -570,6 +572,495 @@ fn ast_functions(module: &str, source: &str) -> Option<Vec<AstFunction>> {
     Some(collector.functions)
 }
 
+fn is_test_only_attrs(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        attr.path().is_ident("test")
+            || (attr.path().is_ident("cfg")
+                && attr
+                    .parse_args::<syn::Path>()
+                    .is_ok_and(|path| path.is_ident("test")))
+    })
+}
+
+/// Identify a hand-spelled core string definition by its semantic shape, not
+/// by the spelling `str`.  Generated `Str(N)` and slice views deliberately use
+/// this same fat-pointer shape, so their canonical names are exempted.
+fn has_core_str_definition(module: &str, source: &str) -> bool {
+    fn string_literal(expression: &Expr) -> Option<String> {
+        match expression {
+            Expr::Lit(ExprLit {
+                lit: Lit::Str(value),
+                ..
+            }) => Some(value.value()),
+            Expr::Call(call) => call.args.first().and_then(string_literal),
+            Expr::MethodCall(call) => string_literal(&call.receiver),
+            Expr::Macro(expression) if expression.mac.path.is_ident("format") => expression
+                .mac
+                .tokens
+                .clone()
+                .into_iter()
+                .next()
+                .and_then(|token| syn::parse_str::<syn::LitStr>(&token.to_string()).ok())
+                .map(|value| value.value()),
+            Expr::Paren(paren) => string_literal(&paren.expr),
+            Expr::Reference(reference) => string_literal(&reference.expr),
+            _ => None,
+        }
+    }
+    fn literal_name(expression: &Expr, bindings: &BTreeSet<(String, String)>) -> Option<String> {
+        string_literal(expression).or_else(|| {
+            let Expr::Path(path) = expression else {
+                return None;
+            };
+            let mut segments = path.path.segments.iter();
+            let Some(ident) = segments.next() else {
+                return None;
+            };
+            if segments.next().is_some() {
+                return None;
+            }
+            let name = ident.ident.to_string();
+            bindings
+                .iter()
+                .find(|(binding, _)| binding == &name)
+                .map(|(_, value)| value.clone())
+        })
+    }
+    fn field_expressions(expression: &Expr) -> Option<Vec<Expr>> {
+        match expression {
+            Expr::Array(array) => Some(array.elems.iter().cloned().collect()),
+            Expr::Macro(expression) if expression.mac.path.is_ident("vec") => {
+                syn::punctuated::Punctuated::<Expr, syn::Token![,]>::parse_terminated
+                    .parse2(expression.mac.tokens.clone())
+                    .ok()
+                    .map(|fields| fields.into_iter().collect())
+            }
+            _ => None,
+        }
+    }
+    struct Visitor {
+        found: bool,
+        test_only: bool,
+        bindings: BTreeSet<(String, String)>,
+        module: String,
+        owner: Option<String>,
+        function: Option<String>,
+    }
+    impl<'ast> Visit<'ast> for Visitor {
+        fn visit_item_fn(&mut self, item: &'ast ItemFn) {
+            let was_test_only = self.test_only;
+            let previous_function = self.function.replace(item.sig.ident.to_string());
+            let previous_owner = self.owner.take();
+            self.test_only |= is_test_only_attrs(&item.attrs);
+            visit::visit_item_fn(self, item);
+            self.test_only = was_test_only;
+            self.function = previous_function;
+            self.owner = previous_owner;
+        }
+
+        fn visit_item_impl(&mut self, item: &'ast ItemImpl) {
+            let previous_owner = self.owner.take();
+            self.owner = match &*item.self_ty {
+                syn::Type::Path(path) => path
+                    .path
+                    .segments
+                    .last()
+                    .map(|segment| segment.ident.to_string()),
+                _ => None,
+            };
+            visit::visit_item_impl(self, item);
+            self.owner = previous_owner;
+        }
+
+        fn visit_impl_item_fn(&mut self, item: &'ast syn::ImplItemFn) {
+            let previous_function = self.function.replace(item.sig.ident.to_string());
+            visit::visit_impl_item_fn(self, item);
+            self.function = previous_function;
+        }
+
+        fn visit_local(&mut self, local: &'ast syn::Local) {
+            if !self.test_only {
+                if let syn::Pat::Ident(pattern) = &local.pat {
+                    if let Some(value) = local
+                        .init
+                        .as_ref()
+                        .and_then(|init| literal_name(&init.expr, &self.bindings))
+                    {
+                        self.bindings.replace((pattern.ident.to_string(), value));
+                    }
+                }
+            }
+            visit::visit_local(self, local);
+        }
+
+        fn visit_item_mod(&mut self, item: &'ast ItemMod) {
+            let was_test_only = self.test_only;
+            self.test_only |= is_test_only_attrs(&item.attrs);
+            visit::visit_item_mod(self, item);
+            self.test_only = was_test_only;
+        }
+
+        fn visit_expr_struct(&mut self, expression: &'ast ExprStruct) {
+            if self.test_only
+                || self.found
+                || !expression
+                    .path
+                    .segments
+                    .last()
+                    .is_some_and(|segment| segment.ident == "StructDef")
+            {
+                visit::visit_expr_struct(self, expression);
+                return;
+            }
+            let field = |name: &str| {
+                expression
+                    .fields
+                    .iter()
+                    .find(|field| {
+                        matches!(&field.member, syn::Member::Named(member) if member == name)
+                    })
+                    .map(|field| &field.expr)
+            };
+            let Some(Expr::Lit(lit)) = field("is_builtin") else {
+                visit::visit_expr_struct(self, expression);
+                return;
+            };
+            let syn::Lit::Bool(is_builtin) = &lit.lit else {
+                visit::visit_expr_struct(self, expression);
+                return;
+            };
+            if !is_builtin.value {
+                visit::visit_expr_struct(self, expression);
+                return;
+            }
+            let Some(fields) = field("fields").and_then(field_expressions) else {
+                visit::visit_expr_struct(self, expression);
+                return;
+            };
+            let names = fields
+                .iter()
+                .filter_map(|field| {
+                    let Expr::Struct(field) = field else {
+                        return None;
+                    };
+                    let name = field
+                        .fields
+                        .iter()
+                        .find(|field| {
+                            matches!(&field.member, syn::Member::Named(member) if member == "name")
+                        })?;
+                    string_literal(&name.expr)
+                })
+                .collect::<Vec<_>>();
+            if names != ["ptr", "len"] {
+                visit::visit_expr_struct(self, expression);
+                return;
+            }
+            let generated =
+                field("name").and_then(|expression| literal_name(expression, &self.bindings));
+            // A computed name is how generated `Str(N)` and slice views are
+            // built; only the four production constructors below may emit
+            // that shape. A literal (including `Arc::from("...")`) is a
+            // hand-spelled candidate and is rejected everywhere else.
+            let legitimate_generated_owner = matches!(
+                (
+                    self.module.as_str(),
+                    self.owner.as_deref(),
+                    self.function.as_deref()
+                ),
+                (
+                    "sema/body_identity",
+                    Some("BodyIdentityPool"),
+                    Some("get_or_create_str_fixed")
+                ) | (
+                    "sema/body_identity",
+                    Some("BodyIdentityPool"),
+                    Some("resolve")
+                ) | (
+                    "semantic_import",
+                    Some("SemanticImportEpoch"),
+                    Some("resolve_builtin_nominal_in_pool")
+                ) | (
+                    "semantic_import",
+                    Some("SemanticImportEpoch"),
+                    Some("import_type_local_with")
+                )
+            );
+            let generated_view_name = generated.as_ref().is_some_and(|name| {
+                name.starts_with("Str(") || (name.starts_with('[') && name.ends_with(']'))
+            });
+            let exempt = legitimate_generated_owner && (generated_view_name || generated.is_none());
+            self.found = !exempt;
+            visit::visit_expr_struct(self, expression);
+        }
+    }
+    let parsed = if let Ok(file) = syn::parse_file(source) {
+        let mut visitor = Visitor {
+            found: false,
+            test_only: false,
+            bindings: BTreeSet::new(),
+            module: normalize_manifest_module(module),
+            owner: None,
+            function: None,
+        };
+        visitor.visit_file(&file);
+        if visitor.found {
+            return true;
+        }
+        true
+    } else {
+        false
+    };
+    if parsed {
+        return false;
+    }
+    // For malformed fixture text that cannot be parsed, keep a conservative
+    // lexical fallback for a direct literal definition: this is the spelling
+    // variation an authority guard must reject, and it also makes the
+    // adversarial fixture independent of formatting details in syn's
+    // expression representation.
+    let compact = source.split_whitespace().collect::<String>();
+    compact.contains("StructDef{name:")
+        && compact.contains("is_builtin:true")
+        && compact.contains("name:\"ptr\"")
+        && compact.contains("name:\"len\"")
+}
+
+fn has_builtin_enum_membership(source: &str) -> bool {
+    struct Visitor {
+        found: bool,
+    }
+    impl<'ast> Visit<'ast> for Visitor {
+        fn visit_path(&mut self, path: &'ast syn::Path) {
+            self.found |= path.segments.last().is_some_and(|segment| {
+                segment.ident == "BUILTIN_ENUMS"
+                    || segment.ident == "get_builtin_enum"
+                    || segment.ident == "is_reserved_enum_name"
+            });
+            visit::visit_path(self, path);
+        }
+    }
+    let Ok(file) = syn::parse_file(source) else {
+        return false;
+    };
+    let mut visitor = Visitor { found: false };
+    visitor.visit_file(&file);
+    visitor.found
+}
+
+/// Identify a production bootstrap of the target builtin-enum universe by its
+/// definition shape. Ordinary source/anonymous enums use non-public or
+/// non-empty payload metadata, while the target universe is public,
+/// exhaustive, and payload-free. The registration evidence is tracked per
+/// function, so an unrelated `register_enum` elsewhere cannot turn a source
+/// declaration into a bootstrap match.
+fn has_builtin_enum_bootstrap(source: &str) -> bool {
+    struct Visitor {
+        found: bool,
+        test_only: bool,
+        function: Option<(bool, bool)>,
+    }
+    impl<'ast> Visit<'ast> for Visitor {
+        fn visit_item_fn(&mut self, item: &'ast ItemFn) {
+            let was_test_only = self.test_only;
+            let previous_function = self.function.take();
+            self.test_only |= is_test_only_attrs(&item.attrs);
+            self.function = Some((false, false));
+            visit::visit_item_fn(self, item);
+            let (candidate, registered) = self.function.take().unwrap();
+            self.found |= !self.test_only && candidate && registered;
+            self.test_only = was_test_only;
+            self.function = previous_function;
+        }
+
+        fn visit_impl_item_fn(&mut self, item: &'ast syn::ImplItemFn) {
+            let previous_function = self.function.take();
+            let was_test_only = self.test_only;
+            self.test_only |= is_test_only_attrs(&item.attrs);
+            self.function = Some((false, false));
+            visit::visit_impl_item_fn(self, item);
+            let (candidate, registered) = self.function.take().unwrap();
+            self.found |= !self.test_only && candidate && registered;
+            self.test_only = was_test_only;
+            self.function = previous_function;
+        }
+
+        fn visit_item_mod(&mut self, item: &'ast ItemMod) {
+            let was_test_only = self.test_only;
+            self.test_only |= is_test_only_attrs(&item.attrs);
+            visit::visit_item_mod(self, item);
+            self.test_only = was_test_only;
+        }
+
+        fn visit_expr_struct(&mut self, expression: &'ast ExprStruct) {
+            if self.test_only
+                || !expression
+                    .path
+                    .segments
+                    .last()
+                    .is_some_and(|segment| segment.ident == "EnumDef")
+            {
+                visit::visit_expr_struct(self, expression);
+                return;
+            }
+            let field = |name: &str| {
+                expression
+                    .fields
+                    .iter()
+                    .find(|field| {
+                        matches!(&field.member, syn::Member::Named(member) if member == name)
+                    })
+                    .map(|field| &field.expr)
+            };
+            let bool_field = |name: &str, expected: bool| {
+                matches!(
+                    field(name),
+                    Some(Expr::Lit(ExprLit {
+                        lit: Lit::Bool(value),
+                        ..
+                    })) if value.value == expected
+                )
+            };
+            let empty_payloads = match field("variant_payloads") {
+                Some(Expr::Array(array)) => array.elems.is_empty(),
+                Some(Expr::Call(call)) => {
+                    call.args.is_empty()
+                        && matches!(&*call.func, Expr::Path(path)
+                            if path.path.segments.last().is_some_and(|segment| segment.ident == "new"))
+                }
+                _ => false,
+            };
+            if bool_field("is_pub", true)
+                && bool_field("is_non_exhaustive", false)
+                && empty_payloads
+            {
+                if let Some((candidate, _)) = &mut self.function {
+                    *candidate = true;
+                }
+            }
+            visit::visit_expr_struct(self, expression);
+        }
+
+        fn visit_expr_call(&mut self, expression: &'ast ExprCall) {
+            if matches!(&*expression.func, Expr::Path(path)
+                if path.path.segments.last().is_some_and(|segment| segment.ident == "register_enum"))
+            {
+                if let Some((_, registered)) = &mut self.function {
+                    *registered = true;
+                }
+            }
+            visit::visit_expr_call(self, expression);
+        }
+
+        fn visit_expr_method_call(&mut self, expression: &'ast ExprMethodCall) {
+            if expression.method == "register_enum" {
+                if let Some((_, registered)) = &mut self.function {
+                    *registered = true;
+                }
+            }
+            visit::visit_expr_method_call(self, expression);
+        }
+    }
+    let Ok(file) = syn::parse_file(source) else {
+        return false;
+    };
+    let mut visitor = Visitor {
+        found: false,
+        test_only: false,
+        function: None,
+    };
+    visitor.visit_file(&file);
+    visitor.found
+}
+
+fn builtin_authority_call_sites(
+    module: &str,
+    source: &str,
+) -> Vec<(String, Option<String>, String, String)> {
+    let Some(functions) = ast_functions(module, source) else {
+        return Vec::new();
+    };
+    let mut sites = Vec::new();
+    for function in functions.into_iter().filter(|function| !function.test_only) {
+        for call in function.calls {
+            let AstCall::Path {
+                segments, method, ..
+            } = call;
+            let Some(name) = segments.last() else {
+                continue;
+            };
+            let qualified_authority = !method
+                && segments
+                    .iter()
+                    .rev()
+                    .nth(1)
+                    .is_some_and(|segment| segment == "BuiltinUniverse");
+            let target = if qualified_authority {
+                matches!(
+                    name.as_str(),
+                    "begin" | "finish_core_str" | "register_core_str_with_symbol"
+                )
+                .then(|| name.clone())
+            } else if method && name == "finish_core_str" {
+                Some(name.clone())
+            } else {
+                None
+            };
+            if let Some(target) = target {
+                sites.push((
+                    function.module.clone(),
+                    function.owner.clone(),
+                    function.name.clone(),
+                    target,
+                ));
+            }
+        }
+    }
+    sites
+}
+
+fn has_exact_builtin_authority_inventory(sources: &[(&str, &str)]) -> bool {
+    let mut actual = sources
+        .iter()
+        .flat_map(|(module, source)| builtin_authority_call_sites(module, source))
+        .collect::<Vec<_>>();
+    actual.sort();
+    let mut expected = vec![
+        (
+            "sema/body_identity".to_owned(),
+            Some("BodyIdentityPool".to_owned()),
+            "try_new".to_owned(),
+            "begin".to_owned(),
+        ),
+        (
+            "sema/body_identity".to_owned(),
+            Some("BodyIdentityPool".to_owned()),
+            "try_new".to_owned(),
+            "finish_core_str".to_owned(),
+        ),
+        (
+            "semantic_import".to_owned(),
+            Some("SemanticImportEpoch".to_owned()),
+            "new_in_space".to_owned(),
+            "begin".to_owned(),
+        ),
+        (
+            "semantic_import".to_owned(),
+            Some("SemanticImportEpoch".to_owned()),
+            "new_in_space".to_owned(),
+            "finish_core_str".to_owned(),
+        ),
+        (
+            "sema/ordinary_engine".to_owned(),
+            Some("OrdinaryBodyEngine".to_owned()),
+            "get_or_create_str_struct".to_owned(),
+            "register_core_str_with_symbol".to_owned(),
+        ),
+    ];
+    expected.sort();
+    actual == expected
+}
+
 /// Convert a Buck source path to the semantic Rust module it contributes to.
 /// `lib.rs` is the crate root and `mod.rs` contributes to its parent; retaining
 /// those filenames as module segments makes `crate::`, `super::`, and
@@ -941,6 +1432,7 @@ fn comptime_instdata_evaluation_has_one_production_authority() {
     // so nested matches/closures cannot hide a peer evaluator.
     let production = [
         ("api_inventory", include_str!("api_inventory.rs")),
+        ("builtin_universe", include_str!("builtin_universe.rs")),
         ("call_abi", include_str!("call_abi.rs")),
         (
             "declaration_validation",
@@ -1110,6 +1602,121 @@ fn comptime_instdata_evaluation_has_one_production_authority() {
         !has_peer_comptime_evaluator_in_sources(&production),
         "transitive peer comptime evaluator/selector in the manifest"
     );
+
+    // Builtin nominal construction has one authority.  Scan the complete
+    // Buck inventory by semantic shape so a renamed `str` definition cannot
+    // evade the guard, while generated `Str(N)` and slice fat pointers remain
+    // legitimate consumers of the same shape.
+    for (module, source) in &production {
+        if *module != "builtin_universe" {
+            assert!(
+                !has_core_str_definition(module, source),
+                "core str StructDef construction escaped builtin_universe: {module}"
+            );
+            assert!(
+                !has_builtin_enum_bootstrap(source),
+                "builtin enum bootstrap escaped builtin_universe: {module}"
+            );
+            assert!(
+                !has_builtin_enum_membership(source),
+                "builtin enum membership escaped builtin_universe: {module}"
+            );
+        }
+    }
+    assert!(
+        has_exact_builtin_authority_inventory(&production),
+        "builtin universe authority calls must have exactly one owner-qualified site per phase"
+    );
+    assert!(has_core_str_definition(
+        "fixture",
+        "let value = StructDef { name: \"StringView\", fields: [StructField { name: \"ptr\", ty: Type::U8 }, StructField { name: \"len\", ty: Type::U64 }], is_builtin: true };"
+    ));
+    assert!(has_core_str_definition(
+        "fixture",
+        "let value = StructDef { name: \"Str(32)\", fields: [StructField { name: \"ptr\", ty: Type::U8 }, StructField { name: \"len\", ty: Type::U64 }], is_builtin: true };"
+    ));
+    assert!(has_core_str_definition(
+        "fixture",
+        "let value = StructDef { name: \"[i32]\", fields: [StructField { name: \"ptr\", ty: Type::U8 }, StructField { name: \"len\", ty: Type::U64 }], is_builtin: true };"
+    ));
+    assert!(has_core_str_definition(
+        "fixture",
+        "fn fixture() { let hidden = helper(); let value = StructDef { name: hidden, fields: vec![StructField { name: \"ptr\", ty: Type::U8 }, StructField { name: \"len\", ty: Type::U64 }], is_builtin: true }; }"
+    ));
+    assert!(has_core_str_definition(
+        "fixture",
+        "fn fixture() { let hidden = helper(); let value = crate::types::StructDef { name: hidden, fields: vec![crate::types::StructField { name: \"ptr\", ty: Type::U8 }, crate::types::StructField { name: \"len\", ty: Type::U64 }], is_builtin: true }; }"
+    ));
+    assert!(has_core_str_definition(
+        "fixture",
+        "fn fixture() { let value = crate::types::StructDef { name: \"Str(32)\", fields: vec![crate::types::StructField { name: \"ptr\", ty: Type::U8 }, crate::types::StructField { name: \"len\", ty: Type::U64 }], is_builtin: true }; }"
+    ));
+    assert!(has_builtin_enum_bootstrap(
+        "fn fixture() { let value = EnumDef { name: \"RenamedArch\", variants: vec![\"X\"], variant_payloads: Vec::new(), is_pub: true, is_non_exhaustive: false, file_id: FileId::DEFAULT }; type_pool.register_enum(symbol, value); }"
+    ));
+    assert!(has_builtin_enum_bootstrap(
+        "fn fixture() { let value = EnumDef { name: \"RenamedArch\", variants: [\"X\"], variant_payloads: [], is_pub: true, is_non_exhaustive: false, file_id: FileId::DEFAULT }; type_pool.register_enum(symbol, value); }"
+    ));
+    assert!(has_builtin_enum_bootstrap(
+        "fn fixture() { let value = crate::EnumDef { name: \"RenamedArch\", variants: vec![\"X\"], variant_payloads: Vec::new(), is_pub: true, is_non_exhaustive: false, file_id: FileId::DEFAULT }; type_pool.register_enum(symbol, value); }"
+    ));
+    assert!(!has_builtin_enum_bootstrap(
+        "fn fixture() { let value = EnumDef { name: \"PublicSourceEnum\", variants: vec![\"X\"], variant_payloads: Vec::new(), is_pub: true, is_non_exhaustive: false, file_id: FileId::DEFAULT }; }"
+    ));
+    assert!(!has_builtin_enum_bootstrap(
+        "fn candidate() { let value = EnumDef { name: \"PublicSourceEnum\", variants: vec![\"X\"], variant_payloads: Vec::new(), is_pub: true, is_non_exhaustive: false, file_id: FileId::DEFAULT }; } fn unrelated() { type_pool.register_enum(symbol, value); }"
+    ));
+    assert!(has_builtin_enum_membership(
+        "fn fixture() { alias::get_builtin_enum(name); let _ = alias::BUILTIN_ENUMS; alias::is_reserved_enum_name(name); }"
+    ));
+    assert!(!has_exact_builtin_authority_inventory(&[(
+        "sema/body_identity",
+        "impl BodyIdentityPool { fn try_new() { BuiltinUniverse::begin(pool, space); BuiltinUniverse::begin(pool, space); let mut universe = BuiltinUniverse::begin(pool, space); universe.finish_core_str(pool, space); } }"
+    ),]));
+    assert!(!has_exact_builtin_authority_inventory(&[
+        (
+            "sema/body_identity",
+            "impl BodyIdentityPool { fn try_new() { let mut universe = BuiltinUniverse::begin(pool, space); universe.finish_core_str(pool, space); } }"
+        ),
+        (
+            "semantic_import",
+            "impl SemanticImportEpoch { fn new_in_space() { let mut universe = BuiltinUniverse::begin(pool, space); universe.finish_core_str(pool, space); universe.finish_core_str(pool, space); } }"
+        ),
+        (
+            "sema/ordinary_engine",
+            "impl OrdinaryBodyEngine { fn get_or_create_str_struct() { BuiltinUniverse::register_core_str_with_symbol(pool, symbols, symbol); } }"
+        ),
+    ]));
+    let qualified_exact = [
+        (
+            "sema/body_identity",
+            "impl BodyIdentityPool { fn try_new() { let mut universe = crate::builtin_universe::BuiltinUniverse::begin(pool, space); universe.finish_core_str(pool, space); } }",
+        ),
+        (
+            "semantic_import",
+            "impl SemanticImportEpoch { fn new_in_space() { let mut universe = crate::builtin_universe::BuiltinUniverse::begin(pool, space); universe.finish_core_str(pool, space); } }",
+        ),
+        (
+            "sema/ordinary_engine",
+            "impl OrdinaryBodyEngine { fn get_or_create_str_struct() { crate::builtin_universe::BuiltinUniverse::register_core_str_with_symbol(pool, symbols, symbol); } }",
+        ),
+    ];
+    assert!(has_exact_builtin_authority_inventory(&qualified_exact));
+    let qualified_exact = [
+        (
+            "sema/body_identity",
+            "impl BodyIdentityPool { fn try_new() { crate::builtin_universe::BuiltinUniverse::begin(pool, space); let mut universe = crate::builtin_universe::BuiltinUniverse::begin(pool, space); universe.finish_core_str(pool, space); } }",
+        ),
+        (
+            "semantic_import",
+            "impl SemanticImportEpoch { fn new_in_space() { crate::builtin_universe::BuiltinUniverse::begin(pool, space); let mut universe = crate::builtin_universe::BuiltinUniverse::begin(pool, space); universe.finish_core_str(pool, space); } }",
+        ),
+        (
+            "sema/ordinary_engine",
+            "impl OrdinaryBodyEngine { fn get_or_create_str_struct() { crate::builtin_universe::BuiltinUniverse::register_core_str_with_symbol(pool, symbols, symbol); } }",
+        ),
+    ];
+    assert!(!has_exact_builtin_authority_inventory(&qualified_exact));
 
     // A renamed peer must fail the same semantic guard; this protects the
     // invariant independently of the retired helper names above.

--- a/crates/rue-air/src/builtin_universe.rs
+++ b/crates/rue-air/src/builtin_universe.rs
@@ -1,0 +1,289 @@
+//! The one AIR authority for compiler-injected builtin nominals.
+//!
+//! Builtin enums and the core `str` view are synthetic declarations, but they
+//! still live in the ordinary [`TypeInternPool`].  Keeping their construction
+//! here makes allocation order, provenance, and lookup semantics explicit for
+//! every semantic consumer.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use lasso::{LassoErrorKind, Spur, ThreadedRodeo};
+use rue_rir::SharedSymbolSpace;
+use rue_span::FileId;
+
+use crate::{
+    EnumDef, EnumId, SemanticImportNominalKind, StructDef, StructField, StructId, Type,
+    TypeInternPool,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BuiltinNominalId {
+    Enum(EnumId),
+    Struct(StructId),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CoreStrRegistrationError {
+    WrongSymbol,
+}
+
+/// A staged builtin bootstrap.  Enum registration is deliberately separate
+/// from core `str`: semantic import epochs insert source nominal shells between
+/// those phases, and their stable pool IDs are part of the import contract.
+#[derive(Debug)]
+pub(crate) struct BuiltinUniverse {
+    lookup: BTreeMap<(Arc<str>, SemanticImportNominalKind), BuiltinNominalId>,
+}
+
+impl BuiltinUniverse {
+    pub(crate) const CORE_STR_NAME: &'static str = "str";
+
+    /// Register the deterministic target-enum prefix of a builtin universe.
+    pub(crate) fn begin(
+        type_pool: &TypeInternPool,
+        symbol_space: &SharedSymbolSpace,
+    ) -> Result<Self, LassoErrorKind> {
+        let mut lookup = BTreeMap::new();
+        for builtin in rue_builtins::BUILTIN_ENUMS {
+            let symbol = symbol_space.try_intern(builtin.name)?;
+            let (id, _) = type_pool.register_enum(
+                symbol,
+                EnumDef {
+                    name: Arc::from(builtin.name),
+                    variants: builtin.variants.iter().map(|v| Arc::from(*v)).collect(),
+                    variant_payloads: Vec::new(),
+                    is_pub: true,
+                    is_non_exhaustive: false,
+                    file_id: FileId::DEFAULT,
+                },
+            );
+            lookup.insert(
+                (Arc::from(builtin.name), SemanticImportNominalKind::Enum),
+                BuiltinNominalId::Enum(id),
+            );
+        }
+        Ok(Self { lookup })
+    }
+
+    /// Register the core `str` identity after source nominals, when required
+    /// by the importing epoch. Body identity pools call it immediately after
+    /// [`Self::begin`].
+    pub(crate) fn finish_core_str(
+        &mut self,
+        type_pool: &TypeInternPool,
+        symbol_space: &SharedSymbolSpace,
+    ) -> Result<StructId, LassoErrorKind> {
+        let symbol = symbol_space.try_intern(Self::CORE_STR_NAME)?;
+        let id = Self::register_core_str_with_symbol(type_pool, symbol_space.interner(), symbol)
+            .expect("the canonical core-str symbol must resolve in its owning space");
+        self.lookup.insert(
+            (
+                Arc::from(Self::CORE_STR_NAME),
+                SemanticImportNominalKind::Struct,
+            ),
+            BuiltinNominalId::Struct(id),
+        );
+        Ok(id)
+    }
+
+    /// The ordinary body path already owns/interns its symbol and may only
+    /// materialize `str`; it must not bootstrap the whole builtin universe.
+    pub(crate) fn register_core_str_with_symbol(
+        type_pool: &TypeInternPool,
+        symbols: &ThreadedRodeo,
+        symbol: Spur,
+    ) -> Result<StructId, CoreStrRegistrationError> {
+        if symbols.resolve(&symbol) != Self::CORE_STR_NAME {
+            return Err(CoreStrRegistrationError::WrongSymbol);
+        }
+        let ptr_id = type_pool.intern_ptr_const_from_type(Type::U8);
+        let (id, _) = type_pool.register_struct(
+            symbol,
+            StructDef {
+                name: Arc::from(Self::CORE_STR_NAME),
+                fields: vec![
+                    StructField {
+                        name: "ptr".to_owned(),
+                        ty: Type::new_ptr_const(ptr_id),
+                    },
+                    StructField {
+                        name: "len".to_owned(),
+                        ty: Type::U64,
+                    },
+                ],
+                is_copy: true,
+                is_linear: false,
+                declared_linear: false,
+                destructor: None,
+                is_builtin: true,
+                is_pub: true,
+                file_id: FileId::DEFAULT,
+            },
+        );
+        Ok(id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn lookup(
+        &self,
+        name: &str,
+        kind: SemanticImportNominalKind,
+    ) -> Option<BuiltinNominalId> {
+        self.lookup.get(&(Arc::from(name), kind)).copied()
+    }
+
+    pub(crate) fn enum_entries(&self) -> impl Iterator<Item = (&Arc<str>, EnumId)> {
+        self.lookup
+            .iter()
+            .filter(|((_, kind), _)| *kind == SemanticImportNominalKind::Enum)
+            .map(|((name, _), nominal)| {
+                let BuiltinNominalId::Enum(id) = *nominal else {
+                    unreachable!("builtin enum lookup kind invariant")
+                };
+                (name, id)
+            })
+    }
+
+    /// Return the canonical core `str` lookup entry after the staged bootstrap
+    /// has finished. Consumers use this entry rather than rebuilding its
+    /// spelling/kind pair independently.
+    pub(crate) fn core_str_entry(&self) -> Option<(Arc<str>, StructId)> {
+        self.lookup.iter().find_map(|((name, kind), nominal)| {
+            (*kind == SemanticImportNominalKind::Struct && name.as_ref() == Self::CORE_STR_NAME)
+                .then(|| {
+                    let BuiltinNominalId::Struct(id) = *nominal else {
+                        unreachable!("core str lookup kind invariant")
+                    };
+                    (Arc::clone(name), id)
+                })
+        })
+    }
+
+    pub(crate) fn builtin_enum_name(name: &str) -> bool {
+        rue_builtins::BUILTIN_ENUMS
+            .iter()
+            .any(|builtin| builtin.name == name)
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn bootstrap_symbol_count() -> usize {
+        rue_builtins::BUILTIN_ENUMS.len() + 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bootstrap_is_exact_and_staged() {
+        let space = SharedSymbolSpace::private();
+        let pool = TypeInternPool::new();
+        let mut universe = BuiltinUniverse::begin(&pool, &space).unwrap();
+        assert_eq!(BuiltinUniverse::bootstrap_symbol_count(), 4);
+        assert_eq!(
+            universe.lookup("Arch", SemanticImportNominalKind::Enum),
+            Some(BuiltinNominalId::Enum(EnumId(0)))
+        );
+        assert_eq!(
+            universe.lookup("Os", SemanticImportNominalKind::Enum),
+            Some(BuiltinNominalId::Enum(EnumId(1)))
+        );
+        assert_eq!(
+            universe.lookup("DataModel", SemanticImportNominalKind::Enum),
+            Some(BuiltinNominalId::Enum(EnumId(2)))
+        );
+        let str_id = universe.finish_core_str(&pool, &space).unwrap();
+        assert_eq!(str_id, StructId(4));
+        assert_eq!(
+            universe.lookup("str", SemanticImportNominalKind::Struct),
+            Some(BuiltinNominalId::Struct(str_id))
+        );
+        assert_eq!(
+            universe.lookup("str", SemanticImportNominalKind::Enum),
+            None
+        );
+        assert_eq!(
+            universe.lookup("Arch", SemanticImportNominalKind::Struct),
+            None
+        );
+        let def = pool.struct_def(str_id);
+        assert_eq!(def.name.as_ref(), "str");
+        assert_eq!(
+            def.fields
+                .iter()
+                .map(|field| field.name.as_str())
+                .collect::<Vec<_>>(),
+            ["ptr", "len"]
+        );
+        assert!(def.is_copy && def.is_builtin && def.is_pub);
+        assert!(!def.is_linear && !def.declared_linear && def.destructor.is_none());
+        assert_eq!(def.file_id, FileId::DEFAULT);
+        assert_eq!(pool.struct_lang_item(str_id), None);
+        assert_eq!(
+            def.fields[0].ty,
+            Type::new_ptr_const(pool.intern_ptr_const_from_type(Type::U8))
+        );
+        assert_eq!(def.fields[1].ty, Type::U64);
+        for (name, variants) in [
+            ("Arch", ["X86_64", "Aarch64"].as_slice()),
+            ("Os", ["Linux", "Macos"].as_slice()),
+            ("DataModel", ["Ilp32", "Lp64", "Llp64"].as_slice()),
+        ] {
+            let BuiltinNominalId::Enum(id) = universe
+                .lookup(name, SemanticImportNominalKind::Enum)
+                .unwrap()
+            else {
+                unreachable!()
+            };
+            let def = pool.enum_def(id);
+            assert_eq!(
+                def.variants
+                    .iter()
+                    .map(|variant| variant.as_ref())
+                    .collect::<Vec<_>>(),
+                variants
+            );
+            assert!(def.variant_payloads.is_empty() && def.is_pub && !def.is_non_exhaustive);
+            assert_eq!(def.file_id, FileId::DEFAULT);
+        }
+    }
+
+    #[test]
+    fn ordinary_helper_is_idempotent_for_one_pool() {
+        let space = SharedSymbolSpace::private();
+        let pool = TypeInternPool::new();
+        let symbol = space.try_intern(BuiltinUniverse::CORE_STR_NAME).unwrap();
+        let first = BuiltinUniverse::register_core_str_with_symbol(&pool, space.interner(), symbol)
+            .unwrap();
+        let second =
+            BuiltinUniverse::register_core_str_with_symbol(&pool, space.interner(), symbol)
+                .unwrap();
+        assert_eq!(first, second);
+
+        let wrong = space.try_intern("not-str").unwrap();
+        assert_eq!(
+            BuiltinUniverse::register_core_str_with_symbol(&pool, space.interner(), wrong),
+            Err(CoreStrRegistrationError::WrongSymbol)
+        );
+    }
+
+    #[test]
+    fn bootstrap_projects_interner_failures_without_partial_success() {
+        let pool = TypeInternPool::new();
+        let space = SharedSymbolSpace::with_owner_bound(0);
+        assert!(matches!(
+            BuiltinUniverse::begin(&pool, &space),
+            Err(LassoErrorKind::KeySpaceExhaustion)
+        ));
+
+        let pool = TypeInternPool::new();
+        let space = SharedSymbolSpace::with_owner_bound(3);
+        let mut universe = BuiltinUniverse::begin(&pool, &space).unwrap();
+        assert_eq!(
+            universe.finish_core_str(&pool, &space),
+            Err(LassoErrorKind::KeySpaceExhaustion)
+        );
+    }
+}

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -33,6 +33,7 @@ use std::sync::{Arc, LazyLock, PoisonError, RwLock};
 use lasso::Spur;
 use rue_span::FileId;
 
+use crate::builtin_universe::BuiltinUniverse;
 use crate::layout::{Layout, LayoutKind, PaddingRange};
 use crate::path_norm::{mangle_symbol_component, normalize_module_path};
 use crate::type_encoding;
@@ -2423,7 +2424,7 @@ impl TypeInternPoolInner {
         // See `struct_symbol_name`: unconditional qualification, with the
         // reserved built-in enums and the registry-marked generated anonymous
         // enums (`__anon_enum_<digest>`) keeping their bare names.
-        if rue_builtins::is_reserved_enum_name(&data.def.name) || self.is_anonymous_enum(id) {
+        if BuiltinUniverse::builtin_enum_name(&data.def.name) || self.is_anonymous_enum(id) {
             return data.def.name.to_string();
         }
         format!(

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -12,6 +12,7 @@
 
 #[cfg(test)]
 mod api_inventory;
+mod builtin_universe;
 pub mod call_abi;
 pub mod declaration_validation;
 pub mod drop_glue_names;

--- a/crates/rue-air/src/sema/aggregate_resolution.rs
+++ b/crates/rue-air/src/sema/aggregate_resolution.rs
@@ -472,8 +472,7 @@ where
         AggregateFacts::aggregate_builtin_struct(self, symbol).map(Type::new_struct)
     }
 
-    /// (P) The builtin enum for a bare name (one of `BUILTIN_ENUMS`), as a pool
-    /// [`Type`].
+    /// (P) The builtin target enum for a bare name, as a pool [`Type`].
     pub fn builtin_enum(&self, name: &str) -> Option<Type> {
         let Ok(symbol) = self.identity.pool().intern_name(name) else {
             return None;

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -87,6 +87,7 @@ use super::ConstValue;
 use super::declaration_index::{RirDeclarationIndex, RirDestructorDeclaration};
 use super::info::{ConstInfo, FunctionInfo, MethodInfo};
 use super::provider_module_registry::ProviderModuleRegistry;
+use crate::builtin_universe::BuiltinUniverse;
 use crate::types::{EnumDef, EnumId, LangItem, StructDef, StructField, StructId, Type};
 use crate::{
     AnonymousNominalKey, FunctionInstanceKey, ParamArena, ParamRange, SemanticImportConstValue,
@@ -953,57 +954,20 @@ where
     ) -> Result<Self, lasso::LassoErrorKind> {
         let interner = Arc::clone(space.interner());
         let type_pool = Rc::new(TypeInternPool::new());
+        let mut universe = BuiltinUniverse::begin(&type_pool, &space)?;
         let mut builtins = AHashMap::new();
-
-        for builtin in rue_builtins::BUILTIN_ENUMS {
-            let symbol = space.try_intern(builtin.name)?;
-            let (id, _) = type_pool.register_enum(
-                symbol,
-                EnumDef {
-                    name: Arc::from(builtin.name),
-                    variants: builtin.variants.iter().map(|v| Arc::from(*v)).collect(),
-                    variant_payloads: Vec::new(),
-                    is_pub: true,
-                    is_non_exhaustive: false,
-                    file_id: FileId::DEFAULT,
-                },
-            );
+        for (name, id) in universe.enum_entries() {
             builtins.insert(
-                (Arc::from(builtin.name), SemanticImportNominalKind::Enum),
+                (Arc::clone(name), SemanticImportNominalKind::Enum),
                 PoolNominal::Enum(id),
             );
         }
-
-        // The core `str` identity: an ordinary builtin struct paired with a
-        // runtime definition. Registered exactly as `SemanticImportedProgram::new`
-        // registers it.
-        let str_symbol = space.try_intern("str")?;
-        let ptr_id = type_pool.intern_ptr_const_from_type(Type::U8);
-        let (str_id, _) = type_pool.register_struct(
-            str_symbol,
-            StructDef {
-                name: Arc::from("str"),
-                fields: vec![
-                    StructField {
-                        name: "ptr".to_owned(),
-                        ty: Type::new_ptr_const(ptr_id),
-                    },
-                    StructField {
-                        name: "len".to_owned(),
-                        ty: Type::U64,
-                    },
-                ],
-                is_copy: true,
-                is_linear: false,
-                declared_linear: false,
-                destructor: None,
-                is_builtin: true,
-                is_pub: true,
-                file_id: FileId::DEFAULT,
-            },
-        );
+        universe.finish_core_str(&type_pool, &space)?;
+        let (str_name, str_id) = universe
+            .core_str_entry()
+            .expect("builtin universe always finishes core str");
         builtins.insert(
-            (Arc::from("str"), SemanticImportNominalKind::Struct),
+            (str_name, SemanticImportNominalKind::Struct),
             PoolNominal::Struct(str_id),
         );
 
@@ -4564,7 +4528,7 @@ mod tests {
         let mut pool = pool([]);
 
         // The three `@target_*` builtin enums (`Arch`/`Os`/`DataModel`, the
-        // `rue_builtins::BUILTIN_ENUMS` set the `@target_arch`/`@target_os`/
+        // The builtin target-enum set drives the `@target_arch`/`@target_os`/
         // `@target_data_model` intrinsics consume) all resolve to the
         // pre-registered enum — the provider-era answer for the target-config
         // family is the pre-registered builtin plus body-local target
@@ -4600,6 +4564,27 @@ mod tests {
             "str",
             "builtin keeps its bare name"
         );
+        let str_id = str_ty.as_struct().unwrap();
+        assert_eq!(str_id, StructId(4));
+        let str_def = pool.type_pool().struct_def(str_id);
+        assert_eq!(str_def.name.as_ref(), "str");
+        assert_eq!(
+            str_def
+                .fields
+                .iter()
+                .map(|field| field.name.as_str())
+                .collect::<Vec<_>>(),
+            ["ptr", "len"]
+        );
+        assert!(str_def.is_copy && str_def.is_builtin && str_def.is_pub);
+        assert!(!str_def.is_linear && !str_def.declared_linear);
+        assert_eq!(str_def.file_id, FileId::DEFAULT);
+        assert_eq!(pool.type_pool().struct_lang_item(str_id), None);
+        assert_eq!(str_def.fields[1].ty, Type::U64);
+        assert!(matches!(
+            str_def.fields[0].ty.kind(),
+            crate::TypeKind::PtrConst(_)
+        ));
 
         // Wrong kind and unknown builtin fail closed.
         assert_eq!(
@@ -4616,6 +4601,108 @@ mod tests {
             }),
             Err(IdentityMintError::UnknownBuiltinNominal)
         );
+    }
+
+    #[test]
+    fn builtin_universe_parity_holds_between_body_and_import_consumers() {
+        let mut body = pool([]);
+        let epoch = crate::SemanticImportEpoch::<Key, Module>::new(vec![], vec![], vec![]).unwrap();
+
+        for (id, (name, variants)) in [
+            (EnumId(0), ("Arch", ["X86_64", "Aarch64"].as_slice())),
+            (EnumId(1), ("Os", ["Linux", "Macos"].as_slice())),
+            (
+                EnumId(2),
+                ("DataModel", ["Ilp32", "Lp64", "Llp64"].as_slice()),
+            ),
+        ] {
+            let fact = DType::BuiltinNominal {
+                name: Arc::from(name),
+                kind: SemanticImportNominalKind::Enum,
+            };
+            let body_ty = body.resolve(&fact).unwrap();
+            let imported = epoch.import_type(&fact).unwrap();
+            assert_eq!(epoch.export_type(imported).unwrap(), fact);
+            assert_eq!(body_ty, Type::new_enum(id));
+            let body_def = body.type_pool().enum_def(id);
+            let epoch_def = epoch.type_pool().enum_def(id);
+            assert_eq!(body_def.name, epoch_def.name);
+            assert_eq!(body_def.variants, epoch_def.variants);
+            assert_eq!(
+                body_def
+                    .variants
+                    .iter()
+                    .map(|variant| variant.as_ref())
+                    .collect::<Vec<_>>(),
+                variants
+            );
+            assert_eq!(body_def.variant_payloads, epoch_def.variant_payloads);
+            assert!(body_def.variant_payloads.is_empty());
+            assert_eq!(body_def.is_pub, epoch_def.is_pub);
+            assert_eq!(body_def.is_non_exhaustive, epoch_def.is_non_exhaustive);
+            assert_eq!(body_def.file_id, epoch_def.file_id);
+            assert_eq!(body_def.file_id, FileId::DEFAULT);
+        }
+
+        let str_fact = DType::BuiltinNominal {
+            name: Arc::from("str"),
+            kind: SemanticImportNominalKind::Struct,
+        };
+        let body_str = body.resolve(&str_fact).unwrap();
+        let imported_str = epoch.import_type(&str_fact).unwrap();
+        assert_eq!(epoch.export_type(imported_str).unwrap(), str_fact);
+        assert_eq!(body_str, Type::new_struct(StructId(4)));
+        let body_def = body.type_pool().struct_def(StructId(4));
+        let epoch_def = epoch.type_pool().struct_def(StructId(4));
+        assert_eq!(body_def.name, epoch_def.name);
+        assert_eq!(body_def.fields.len(), epoch_def.fields.len());
+        for (body_field, epoch_field) in body_def.fields.iter().zip(&epoch_def.fields) {
+            assert_eq!(body_field.name, epoch_field.name);
+            assert_eq!(body_field.ty, epoch_field.ty);
+        }
+        assert_eq!(body_def.is_copy, epoch_def.is_copy);
+        assert_eq!(body_def.is_linear, epoch_def.is_linear);
+        assert_eq!(body_def.declared_linear, epoch_def.declared_linear);
+        assert_eq!(body_def.destructor, epoch_def.destructor);
+        assert_eq!(body_def.is_builtin, epoch_def.is_builtin);
+        assert_eq!(body_def.is_pub, epoch_def.is_pub);
+        assert_eq!(body_def.file_id, epoch_def.file_id);
+        assert_eq!(body_def.file_id, FileId::DEFAULT);
+        assert_eq!(body.type_pool().struct_lang_item(StructId(4)), None);
+        assert_eq!(epoch.type_pool().struct_lang_item(StructId(4)), None);
+
+        let wrong_kind_facts = [
+            DType::BuiltinNominal {
+                name: Arc::from("Arch"),
+                kind: SemanticImportNominalKind::Struct,
+            },
+            DType::BuiltinNominal {
+                name: Arc::from("str"),
+                kind: SemanticImportNominalKind::Enum,
+            },
+        ];
+        for fact in wrong_kind_facts {
+            assert_eq!(
+                body.resolve(&fact),
+                Err(IdentityMintError::BuiltinNominalKindMismatch)
+            );
+            assert!(matches!(
+                epoch.import_type(&fact),
+                Err(crate::SemanticImportFailure::BuiltinNominalKindMismatch)
+            ));
+        }
+        let unknown = DType::BuiltinNominal {
+            name: Arc::from("UnknownBuiltin"),
+            kind: SemanticImportNominalKind::Enum,
+        };
+        assert_eq!(
+            body.resolve(&unknown),
+            Err(IdentityMintError::UnknownBuiltinNominal)
+        );
+        assert!(matches!(
+            epoch.import_type(&unknown),
+            Err(crate::SemanticImportFailure::UnknownBuiltinNominal)
+        ));
     }
 
     #[test]
@@ -4761,7 +4848,7 @@ mod tests {
         };
         let mut durable = source([]);
         durable.anonymous_shapes.insert(key.clone(), shape);
-        let bootstrap_entries = rue_builtins::BUILTIN_ENUMS.len() + 1; // + core `str`
+        let bootstrap_entries = BuiltinUniverse::bootstrap_symbol_count();
         let mut pool = BodyIdentityPool::new(
             durable,
             SharedSymbolSpace::with_owner_bound(bootstrap_entries),

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -733,39 +733,21 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         self.body_type_pool().type_carries_linear(ty)
     }
     pub(crate) fn get_or_create_str_struct(&mut self, _span: Span) -> CompileResult<Type> {
-        use crate::types::{StructDef, StructField};
-        let type_sym = self.intern_body_symbol("str")?;
+        use crate::builtin_universe::BuiltinUniverse;
+        let type_sym = self.intern_body_symbol(BuiltinUniverse::CORE_STR_NAME)?;
         if let Some(struct_id) = self.storage.struct_id_for_name(type_sym) {
             return Ok(Type::new_struct(struct_id));
         }
-        let ptr_type_id = self
-            .storage
-            .body_type_pool()
-            .intern_ptr_const_from_type(Type::U8);
-        let struct_def = StructDef {
-            name: Arc::from("str"),
-            fields: vec![
-                StructField {
-                    name: "ptr".to_owned(),
-                    ty: Type::new_ptr_const(ptr_type_id),
-                },
-                StructField {
-                    name: "len".to_owned(),
-                    ty: Type::U64,
-                },
-            ],
-            is_copy: true,
-            is_linear: false,
-            declared_linear: false,
-            destructor: None,
-            is_builtin: true,
-            is_pub: true,
-            file_id: FileId::new(0),
-        };
-        let (struct_id, _) = self
-            .storage
-            .body_type_pool()
-            .register_struct(type_sym, struct_def);
+        let struct_id = BuiltinUniverse::register_core_str_with_symbol(
+            self.storage.body_type_pool(),
+            self.body_interner(),
+            type_sym,
+        )
+        .map_err(|error| {
+            CompileError::without_span(ErrorKind::InternalError(format!(
+                "builtin core str registration failed: {error:?}"
+            )))
+        })?;
         self.storage
             .generated_structs_mut()
             .insert(type_sym, struct_id);

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -1019,10 +1019,7 @@ where
                 let def = self.type_pool.enum_def(id);
                 if let Some(identity) = self.issued_anonymous_identity_for_type(ty) {
                     T::AnonymousNominal(identity)
-                } else if rue_builtins::BUILTIN_ENUMS
-                    .iter()
-                    .any(|builtin| builtin.name == &*def.name)
-                {
+                } else if crate::builtin_universe::BuiltinUniverse::builtin_enum_name(&def.name) {
                     T::BuiltinNominal {
                         name: def.name.clone(),
                         kind: crate::SemanticImportNominalKind::Enum,
@@ -1076,10 +1073,7 @@ where
     > {
         let ty = Type::new_enum(id);
         let def = self.type_pool.enum_def(id);
-        if rue_builtins::BUILTIN_ENUMS
-            .iter()
-            .any(|builtin| builtin.name == &*def.name)
-        {
+        if crate::builtin_universe::BuiltinUniverse::builtin_enum_name(&def.name) {
             return Ok(crate::NominalInstanceKey::Builtin {
                 kind: crate::AnonymousNominalKind::Enum,
                 name: def.name.clone(),

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -14,6 +14,7 @@ use lasso::{LassoErrorKind, Spur, ThreadedRodeo};
 use rue_span::FileId;
 
 use crate::Node;
+use crate::builtin_universe::BuiltinUniverse;
 use crate::{
     Air, AirCallArg, AirInst, AirInstData, AirPattern, AirProjection, AirRef, AnonymousNominalKey,
     ConstValue, EnumDef, EnumId, FunctionInstanceKey, ModuleId, ModuleRegistry, NominalInstanceKey,
@@ -1216,24 +1217,12 @@ where
         let interner = symbol_space.interner().clone();
         let type_pool = TypeInternPool::new();
         let module_registry = ModuleRegistry::new();
+        let mut universe = BuiltinUniverse::begin(&type_pool, &symbol_space)
+            .map_err(SemanticImportFailure::Interner)?;
         let mut builtins = BTreeMap::new();
-        for builtin in rue_builtins::BUILTIN_ENUMS {
-            let symbol = symbol_space
-                .try_intern(builtin.name)
-                .map_err(SemanticImportFailure::Interner)?;
-            let (id, _) = type_pool.register_enum(
-                symbol,
-                EnumDef {
-                    name: Arc::from(builtin.name),
-                    variants: builtin.variants.iter().map(|v| Arc::from(*v)).collect(),
-                    variant_payloads: Vec::new(),
-                    is_pub: true,
-                    is_non_exhaustive: false,
-                    file_id: FileId::DEFAULT,
-                },
-            );
+        for (name, id) in universe.enum_entries() {
             builtins.insert(
-                (Arc::from(builtin.name), SemanticImportNominalKind::Enum),
+                (Arc::clone(name), SemanticImportNominalKind::Enum),
                 LocalNominal::Enum(id),
             );
         }
@@ -1339,35 +1328,14 @@ where
         // stable core `str` identity. Preserve that order so a fresh epoch's
         // packed nominal IDs match exported AIR exactly. StrBuf is deliberately
         // absent: it is an ordinary source nominal supplied by std.
-        let str_symbol = symbol_space
-            .try_intern("str")
+        universe
+            .finish_core_str(&type_pool, &symbol_space)
             .map_err(SemanticImportFailure::Interner)?;
-        let ptr_id = type_pool.intern_ptr_const_from_type(Type::U8);
-        let (str_id, _) = type_pool.register_struct(
-            str_symbol,
-            StructDef {
-                name: Arc::from("str"),
-                fields: vec![
-                    StructField {
-                        name: "ptr".to_owned(),
-                        ty: Type::new_ptr_const(ptr_id),
-                    },
-                    StructField {
-                        name: "len".to_owned(),
-                        ty: Type::U64,
-                    },
-                ],
-                is_copy: true,
-                is_linear: false,
-                declared_linear: false,
-                destructor: None,
-                is_builtin: true,
-                is_pub: true,
-                file_id: FileId::DEFAULT,
-            },
-        );
+        let (str_name, str_id) = universe
+            .core_str_entry()
+            .expect("builtin universe always finishes core str");
         builtins.insert(
-            (Arc::from("str"), SemanticImportNominalKind::Struct),
+            (str_name, SemanticImportNominalKind::Struct),
             LocalNominal::Struct(str_id),
         );
         let mut epoch = Self {
@@ -1429,8 +1397,8 @@ where
             let NominalInstanceKey::Builtin { name, .. } = &nominal.key else {
                 return false;
             };
-            name.as_ref() == "str"
-                || rue_builtins::get_builtin_enum(name).is_some()
+            name.as_ref() == BuiltinUniverse::CORE_STR_NAME
+                || BuiltinUniverse::builtin_enum_name(name)
                 || crate::types::fixed_string_capacity(name).is_some()
         }) {
             return Err(SemanticImportFailure::BuiltinNominalShadow);
@@ -4097,7 +4065,55 @@ mod tests {
             kind: SemanticImportNominalKind::Struct,
         };
         let local = epoch.import_type(&str_ty).unwrap();
+        let str_id = local.value.as_struct().expect("builtin str is a struct");
         assert_eq!(epoch.export_type(local).unwrap(), str_ty);
+        assert_eq!(str_id, crate::StructId(4));
+        let str_def = epoch.type_pool().struct_def(str_id);
+        assert_eq!(str_def.name.as_ref(), "str");
+        assert_eq!(
+            str_def
+                .fields
+                .iter()
+                .map(|field| field.name.as_str())
+                .collect::<Vec<_>>(),
+            ["ptr", "len"]
+        );
+        assert!(str_def.is_copy && str_def.is_builtin && str_def.is_pub);
+        assert!(!str_def.is_linear && !str_def.declared_linear);
+        assert_eq!(str_def.file_id, FileId::DEFAULT);
+        assert_eq!(epoch.type_pool().struct_lang_item(str_id), None);
+        assert_eq!(str_def.fields[1].ty, Type::U64);
+        assert!(matches!(
+            str_def.fields[0].ty.kind(),
+            crate::TypeKind::PtrConst(_)
+        ));
+
+        for (id, (name, variants)) in [
+            (crate::EnumId(0), ("Arch", ["X86_64", "Aarch64"].as_slice())),
+            (crate::EnumId(1), ("Os", ["Linux", "Macos"].as_slice())),
+            (
+                crate::EnumId(2),
+                ("DataModel", ["Ilp32", "Lp64", "Llp64"].as_slice()),
+            ),
+        ] {
+            let enum_ty = epoch
+                .import_type(&SemanticImportType::BuiltinNominal {
+                    name: Arc::from(name),
+                    kind: SemanticImportNominalKind::Enum,
+                })
+                .unwrap();
+            assert_eq!(enum_ty.value.as_enum(), Some(id));
+            let def = epoch.type_pool().enum_def(id);
+            assert_eq!(
+                def.variants
+                    .iter()
+                    .map(|variant| variant.as_ref())
+                    .collect::<Vec<_>>(),
+                variants
+            );
+            assert!(def.variant_payloads.is_empty() && def.is_pub);
+            assert_eq!(def.file_id, FileId::DEFAULT);
+        }
 
         assert!(matches!(
             epoch.import_type(&SemanticImportType::BuiltinNominal {


### PR DESCRIPTION
## Summary

- centralize AIR builtin-enum and core str registration in one authority
- make body identity, semantic import, and ordinary sema thin consumers
- add consumer parity, rejection, and full-inventory structural guards

## Validation

- scripts/rue unit air
- scripts/rue unit compiler local_semantic_materialization
- scripts/rue quick
- scripts/rue premerge
- scripts/rue test
- scripts/rue fmt
- git diff --check

Fixes RUE-1799