### PR TITLE
RUE-1805: make token presentation lazy

### DIFF
--- a/crates/rue-compiler/src/artifact_views.rs
+++ b/crates/rue-compiler/src/artifact_views.rs
@@ -4,7 +4,11 @@
 //! do not reveal phase storage, interners, type pools, owner-relative handles,
 //! or the phases' textual debug formats.
 
-use std::{borrow::Cow, fmt, sync::Arc};
+use std::{
+    borrow::Cow,
+    fmt,
+    sync::{Arc, OnceLock},
+};
 
 use crate::{CanonicalRirOutput, ParsedProgram};
 
@@ -153,16 +157,39 @@ impl fmt::Debug for SourceLocationView {
     }
 }
 
+/// Lazily materialized token storage tied to one immutable syntax owner.
+struct TokenPresentation {
+    module: Arc<crate::parsed_modules::ParsedModule>,
+    tokens: Arc<[rue_lexer::Token]>,
+    resolver: Arc<lasso::RodeoResolver>,
+}
+
+impl TokenPresentation {
+    fn new(module: Arc<crate::parsed_modules::ParsedModule>) -> Self {
+        let source = crate::SourceView::new(
+            module.physical_path(),
+            module.source_text(),
+            module.file_id(),
+        );
+        let (tokens, resolver) = crate::syntax::token_presentation(source);
+        Self {
+            module,
+            tokens,
+            resolver,
+        }
+    }
+}
+
 /// One resolved token tied to an immutable syntax owner.
 #[derive(Clone)]
 pub struct TokenView {
-    owner: Arc<crate::parsed_modules::ParsedModule>,
+    owner: Arc<TokenPresentation>,
     index: usize,
 }
 
 impl TokenView {
     fn token(&self) -> &rue_lexer::Token {
-        &self.owner.tokens()[self.index]
+        &self.owner.tokens[self.index]
     }
 
     pub fn kind(&self) -> &str {
@@ -270,7 +297,7 @@ impl TokenView {
             rue_lexer::TokenKind::Ident(symbol)
             | rue_lexer::TokenKind::String(symbol)
             | rue_lexer::TokenKind::Float(symbol) => {
-                Some(Cow::Borrowed(self.owner.resolve_raw_symbol(symbol)))
+                Some(Cow::Borrowed(self.owner.resolver.resolve(&symbol)))
             }
             rue_lexer::TokenKind::Int(value) => Some(Cow::Owned(value.to_string())),
             _ => None,
@@ -286,7 +313,7 @@ impl TokenView {
     }
 
     pub fn location(&self) -> SourceLocationView {
-        SourceLocationView::syntax(self.owner.clone(), self.token().span)
+        SourceLocationView::syntax(self.owner.module.clone(), self.token().span)
     }
 }
 
@@ -367,6 +394,7 @@ impl fmt::Debug for SyntaxNodeView {
 #[derive(Clone)]
 pub struct SyntaxModuleView {
     owner: Arc<crate::parsed_modules::ParsedModule>,
+    token_presentation: Arc<OnceLock<Arc<TokenPresentation>>>,
 }
 
 impl SyntaxModuleView {
@@ -383,8 +411,12 @@ impl SyntaxModuleView {
     }
 
     pub fn tokens(&self) -> impl ExactSizeIterator<Item = TokenView> + '_ {
-        (0..self.owner.tokens().len()).map(|index| TokenView {
-            owner: self.owner.clone(),
+        let owner = self
+            .token_presentation
+            .get_or_init(|| Arc::new(TokenPresentation::new(self.owner.clone())))
+            .clone();
+        (0..owner.tokens.len()).map(move |index| TokenView {
+            owner: owner.clone(),
             index,
         })
     }
@@ -412,7 +444,7 @@ impl fmt::Debug for SyntaxModuleView {
             .debug_struct("SyntaxModuleView")
             .field("file_id", &self.file_id())
             .field("path", &self.path())
-            .field("token_count", &self.owner.tokens().len())
+            .field("token_count", &self.owner.token_count())
             .field("item_count", &self.item_count())
             .finish()
     }
@@ -422,11 +454,19 @@ impl fmt::Debug for SyntaxModuleView {
 #[derive(Clone)]
 pub struct SyntaxView {
     owner: Arc<ParsedProgram>,
+    token_presentations: Arc<[Arc<OnceLock<Arc<TokenPresentation>>>]>,
 }
 
 impl SyntaxView {
     pub(crate) fn new(owner: Arc<ParsedProgram>) -> Self {
-        Self { owner }
+        let token_presentations = (0..owner.modules().len())
+            .map(|_| Arc::new(OnceLock::new()))
+            .collect::<Vec<_>>()
+            .into();
+        Self {
+            owner,
+            token_presentations,
+        }
     }
 
     pub fn modules(&self) -> impl ExactSizeIterator<Item = SyntaxModuleView> + '_ {
@@ -434,7 +474,11 @@ impl SyntaxView {
             .modules()
             .iter()
             .cloned()
-            .map(|owner| SyntaxModuleView { owner })
+            .zip(self.token_presentations.iter().cloned())
+            .map(|(owner, token_presentation)| SyntaxModuleView {
+                owner,
+                token_presentation,
+            })
     }
 
     pub fn source_revision(&self) -> &crate::SourceRevision {

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -589,8 +589,10 @@ struct ParsedModuleProjectionCollector {
 struct ParsedSyntaxPayload {
     source: SourceId,
     source_text: Arc<String>,
+    file_id: FileId,
     token_count: usize,
-    tokens: Arc<[rue_lexer::Token]>,
+    #[cfg(test)]
+    token_buffer_lifetime: std::sync::Weak<()>,
     ast: ProvenancedAst,
     resolver: FrozenSymbolResolver,
     definitions: ParsedDefinitionIndex,
@@ -608,7 +610,6 @@ pub struct ParsedModule {
     file_id: FileId,
     physical_path: Arc<str>,
     payload: Arc<ParsedSyntaxPayload>,
-    tokens: Arc<[rue_lexer::Token]>,
     ast: Arc<Ast>,
     definitions: ParsedDefinitionIndex,
     imports: Arc<[ImportDirective]>,
@@ -683,7 +684,6 @@ impl ParsedModule {
 
     fn walk_retained_allocation_charge(&self) -> u64 {
         let ast_charge = |ast: &Arc<Ast>| ast.retained_charge();
-        let tokens_charge = |tokens: &[rue_lexer::Token]| std::mem::size_of_val(tokens) as u64;
         let imports_charge = |imports: &[ImportDirective]| {
             imports
                 .iter()
@@ -695,7 +695,6 @@ impl ParsedModule {
         let payload = (std::mem::size_of::<ParsedSyntaxPayload>() as u64)
             .saturating_add(self.payload.source.retained_charge())
             .saturating_add(self.payload.source_text.retained_charge())
-            .saturating_add(tokens_charge(&self.payload.tokens))
             .saturating_add(ast_charge(&self.payload.ast.ast))
             .saturating_add(std::mem::size_of::<SymbolProvenance>() as u64)
             .saturating_add(self.payload.ast.source.retained_charge())
@@ -728,7 +727,6 @@ impl ParsedModule {
             .retained_charge()
             .saturating_add(self.physical_path.retained_charge())
             .saturating_add(payload)
-            .saturating_add(tokens_charge(&self.tokens))
             .saturating_add(ast_charge(&self.ast))
             .saturating_add(self.definitions.retained_allocation_charge())
             .saturating_add(imports_charge(&self.imports))
@@ -980,7 +978,6 @@ impl ParsedModule {
             file_id: self.file_id,
             physical_path: self.physical_path.clone(),
             payload: self.payload.clone(),
-            tokens: self.tokens.clone(),
             ast: Arc::new(ast),
             definitions: self.definitions.clone(),
             imports: self.imports.clone(),
@@ -1024,9 +1021,6 @@ impl ParsedModule {
     pub(crate) fn token_count(&self) -> usize {
         self.payload.token_count
     }
-    pub(crate) fn tokens(&self) -> &[rue_lexer::Token] {
-        &self.tokens
-    }
     pub(crate) fn resolve_raw_symbol(&self, symbol: Spur) -> &str {
         self.payload.resolver.resolver.resolve(&symbol)
     }
@@ -1036,6 +1030,19 @@ impl ParsedModule {
     #[cfg(test)]
     pub(crate) fn shared_source_text(&self) -> Arc<String> {
         self.payload.source_text.clone()
+    }
+    #[cfg(test)]
+    pub(crate) fn transient_token_buffer_was_released(&self) -> bool {
+        self.payload.token_buffer_lifetime.upgrade().is_none()
+    }
+    #[cfg(test)]
+    pub(crate) fn presented_tokens_for_test(&self) -> Arc<[rue_lexer::Token]> {
+        crate::syntax::token_presentation(crate::SourceView::new(
+            self.physical_path(),
+            self.source_text(),
+            self.file_id(),
+        ))
+        .0
     }
     pub fn ast(&self) -> &Ast {
         &self.ast
@@ -1497,7 +1504,7 @@ pub(crate) struct StagedModuleParse {
     source_text: Arc<String>,
     ast: Arc<Ast>,
     interner: ThreadedRodeo,
-    tokens: Arc<[rue_lexer::Token]>,
+    tokens: crate::syntax::TransientTokenBuffer,
     work: SyntaxWork,
 }
 
@@ -1569,15 +1576,10 @@ fn build_module_from_staged(
         work,
         ..
     } = staged;
-    let tokens: Arc<[rue_lexer::Token]> = tokens
-        .iter()
-        .cloned()
-        .map(|mut token| {
-            token.span = Span::with_file(file_id, token.span.start, token.span.end);
-            token
-        })
-        .collect::<Vec<_>>()
-        .into();
+    let mut tokens = tokens;
+    for token in tokens.iter_mut() {
+        token.span = Span::with_file(file_id, token.span.start, token.span.end);
+    }
     // The stage normally owns the last reference, so the rebind mutates the
     // wave's tree in place rather than copying it.
     let ast = match Arc::try_unwrap(ast) {
@@ -1645,7 +1647,7 @@ fn build_module(
     ast: Arc<Ast>,
     interner: ThreadedRodeo,
     token_count: usize,
-    tokens: Arc<[rue_lexer::Token]>,
+    tokens: crate::syntax::TransientTokenBuffer,
 ) -> CompileResult<Arc<ParsedModule>> {
     let token = Arc::new(SymbolProvenance);
     let module = snapshot.module_id(file_id).expect("snapshot membership");
@@ -1671,7 +1673,7 @@ fn build_module_with_resolver(
     token: Arc<SymbolProvenance>,
     projections: ParsedModuleProjectionCollector,
     token_count: usize,
-    tokens: Arc<[rue_lexer::Token]>,
+    tokens: crate::syntax::TransientTokenBuffer,
 ) -> CompileResult<Arc<ParsedModule>> {
     let module = snapshot
         .module_id(file_id)
@@ -1702,17 +1704,21 @@ fn build_module_with_resolver(
         revision.module.clone(),
         file_id,
         &source_text,
-        &tokens,
+        tokens.as_slice(),
         &provenanced_ast.ast,
         &resolver,
         &projections.imports.valid,
         &projections.warning_call_heads,
     )?;
+    #[cfg(test)]
+    let token_buffer_lifetime = tokens.lifetime_probe();
     let payload = Arc::new(ParsedSyntaxPayload {
         source,
         source_text,
+        file_id,
         token_count,
-        tokens,
+        #[cfg(test)]
+        token_buffer_lifetime,
         ast: provenanced_ast,
         resolver,
         definitions,
@@ -1737,28 +1743,12 @@ fn bind_payload(
         source: payload.source.clone(),
     };
     let remap_span = |span: Span| Span::with_file(file_id, span.start, span.end);
-    let payload_file_id = payload
-        .tokens
-        .first()
-        .expect("the lexer always emits EOF")
-        .span
-        .file_id;
-    let (tokens, ast) = if payload_file_id == file_id {
-        (payload.tokens.clone(), payload.ast.ast.clone())
+    let ast = if payload.file_id == file_id {
+        payload.ast.ast.clone()
     } else {
-        let tokens = payload
-            .tokens
-            .iter()
-            .cloned()
-            .map(|mut token| {
-                token.span = remap_span(token.span);
-                token
-            })
-            .collect::<Vec<_>>()
-            .into();
         let mut ast = (*payload.ast.ast).clone();
         ast.rebind_file_id(file_id);
-        (tokens, Arc::new(ast))
+        Arc::new(ast)
     };
     let definitions = ParsedDefinitionIndex {
         candidates: payload
@@ -1839,7 +1829,6 @@ fn bind_payload(
         file_id,
         physical_path: Arc::from(snapshot.metadata().physical_path(file_id).unwrap()),
         payload,
-        tokens,
         ast,
         definitions,
         imports: imports.into(),
@@ -3906,19 +3895,26 @@ extern "C" { fn getpid() -> i32; }
             hit_work.lexed_bytes, 424_242,
             "the staged parse was consumed"
         );
+        assert!(
+            fresh.transient_token_buffer_was_released()
+                && hit.transient_token_buffer_was_released(),
+            "published fresh and staged modules must not retain their transient token buffers"
+        );
 
         // The staged build is indistinguishable from the fresh parse: same
         // revision, real file id on every retained span, and identical
         // definition provenance.
         assert_eq!(hit.revision(), fresh.revision());
         assert_eq!(hit.file_id(), fresh.file_id());
-        assert_eq!(hit.tokens().len(), fresh.tokens().len());
+        let hit_tokens = hit.presented_tokens_for_test();
+        let fresh_tokens = fresh.presented_tokens_for_test();
+        assert_eq!(hit_tokens.len(), fresh_tokens.len());
         assert!(
-            hit.tokens()
+            hit_tokens
                 .iter()
-                .zip(fresh.tokens())
-                .all(|(staged, fresh)| staged.span == fresh.span),
-            "token spans must be rebound to the snapshot's file id"
+                .zip(fresh_tokens.iter())
+                .all(|(staged, fresh)| staged.kind == fresh.kind && staged.span == fresh.span),
+            "staged token order, kinds, and rebound spans must match a fresh parse"
         );
         assert_eq!(hit.imports().len(), fresh.imports().len());
         assert_eq!(

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -32418,9 +32418,10 @@ fn main() -> i32 {
         assert_eq!(parse_work.modules_rebound, 2);
         let projected_a = program.module(&a).unwrap();
         assert_eq!(projected_a.file_id(), FileId::new(2));
+        assert!(projected_a.transient_token_buffer_was_released());
         assert!(
             projected_a
-                .tokens()
+                .presented_tokens_for_test()
                 .iter()
                 .all(|token| token.span.file_id == FileId::new(2))
         );

--- a/crates/rue-compiler/src/syntax.rs
+++ b/crates/rue-compiler/src/syntax.rs
@@ -7,6 +7,47 @@ use tracing::{info, info_span};
 
 use crate::{Lexer, MultiErrorResult, Parser, SourceView, ThreadedRodeo};
 
+#[derive(Debug)]
+pub(crate) struct TransientTokenBuffer {
+    tokens: Vec<rue_lexer::Token>,
+    #[cfg(test)]
+    lifetime: std::sync::Arc<()>,
+    #[cfg(test)]
+    parser_reused_allocation: bool,
+}
+
+impl TransientTokenBuffer {
+    fn new(tokens: Vec<rue_lexer::Token>, parser_reused_allocation: bool) -> Self {
+        #[cfg(not(test))]
+        let _ = parser_reused_allocation;
+        Self {
+            tokens,
+            #[cfg(test)]
+            lifetime: std::sync::Arc::new(()),
+            #[cfg(test)]
+            parser_reused_allocation,
+        }
+    }
+
+    pub(crate) fn as_slice(&self) -> &[rue_lexer::Token] {
+        &self.tokens
+    }
+
+    pub(crate) fn iter_mut(&mut self) -> impl Iterator<Item = &mut rue_lexer::Token> {
+        self.tokens.iter_mut()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn lifetime_probe(&self) -> std::sync::Weak<()> {
+        std::sync::Arc::downgrade(&self.lifetime)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn parser_reused_allocation(&self) -> bool {
+        self.parser_reused_allocation
+    }
+}
+
 /// Work performed while lexing and parsing source files.
 ///
 /// Token counts include the EOF token emitted by the lexer. A file contributes
@@ -32,7 +73,7 @@ pub struct SyntaxWork {
 pub(crate) struct FileParseOutcome {
     pub(crate) result: MultiErrorResult<std::sync::Arc<rue_parser::Ast>>,
     pub(crate) interner: ThreadedRodeo,
-    pub(crate) tokens: std::sync::Arc<[rue_lexer::Token]>,
+    pub(crate) tokens: TransientTokenBuffer,
     pub(crate) work: SyntaxWork,
 }
 
@@ -53,7 +94,7 @@ pub(crate) fn parse_file(source: SourceView<'_>, interner: ThreadedRodeo) -> Fil
                 return FileParseOutcome {
                     result: Err(errors),
                     interner,
-                    tokens: std::sync::Arc::from([]),
+                    tokens: TransientTokenBuffer::new(Vec::new(), true),
                     work,
                 };
             }
@@ -63,30 +104,53 @@ pub(crate) fn parse_file(source: SourceView<'_>, interner: ThreadedRodeo) -> Fil
     work.parser_invocations = 1;
     work.tokens = tokens.len();
     info!(token_count = tokens.len(), "lexing complete");
-    let retained_tokens: std::sync::Arc<[rue_lexer::Token]> = tokens.clone().into();
+    let token_allocation = tokens.as_ptr() as usize;
 
-    let (ast, interner) = {
+    let (ast, interner, tokens) = {
         let _span = info_span!("parser").entered();
         let parser = Parser::new(tokens, interner);
-        match parser.parse_preserving_interner() {
+        match parser.parse_preserving_interner_and_tokens() {
             Ok(output) => output,
-            Err((errors, interner)) => {
+            Err((errors, interner, tokens)) => {
+                let parser_reused_allocation = tokens.as_ptr() as usize == token_allocation;
                 return FileParseOutcome {
                     result: Err(errors),
                     interner,
-                    tokens: retained_tokens,
+                    tokens: TransientTokenBuffer::new(tokens, parser_reused_allocation),
                     work,
                 };
             }
         }
     };
 
+    let parser_reused_allocation = tokens.as_ptr() as usize == token_allocation;
+
     FileParseOutcome {
         result: Ok(std::sync::Arc::new(ast)),
         interner,
-        tokens: retained_tokens,
+        tokens: TransientTokenBuffer::new(tokens, parser_reused_allocation),
         work,
     }
+}
+
+/// Re-lex one immutable parsed source for token presentation.
+///
+/// This projection is intentionally outside [`SyntaxWork`]: it neither parses
+/// nor publishes compiler input and must not masquerade as canonical frontend
+/// work. Callers scope the returned allocation to their retainable view or
+/// presentation request.
+pub(crate) fn token_presentation(
+    source: SourceView<'_>,
+) -> (
+    std::sync::Arc<[rue_lexer::Token]>,
+    std::sync::Arc<lasso::RodeoResolver>,
+) {
+    let lexer =
+        Lexer::with_interner_and_file_id(source.source, ThreadedRodeo::new(), source.file_id);
+    let (tokens, interner) = lexer
+        .tokenize_preserving_interner()
+        .expect("a published parsed source must lex identically for presentation");
+    (tokens.into(), std::sync::Arc::new(interner.into_resolver()))
 }
 
 #[cfg(test)]
@@ -254,22 +318,40 @@ mod tests {
     #[test]
     fn work_uses_utf8_bytes_and_successful_lexer_token_vectors() {
         let valid = "fn main() { // café\n}";
-        let FileParseOutcome { result, work, .. } = parse_file(
+        let FileParseOutcome {
+            result,
+            tokens,
+            work,
+            ..
+        } = parse_file(
             SourceView::new("valid.rue", valid, FileId::new(1)),
             ThreadedRodeo::new(),
         );
         result.unwrap();
+        assert!(
+            tokens.parser_reused_allocation(),
+            "the parser must return the lexer's original token allocation"
+        );
         assert!(valid.len() > valid.chars().count());
         assert_eq!(work.lexed_bytes, valid.len());
         assert_eq!(work.tokens, 7);
         assert_eq!(work.parser_invocations, 1);
 
         let parse_error = "fn broken( {";
-        let FileParseOutcome { result, work, .. } = parse_file(
+        let FileParseOutcome {
+            result,
+            tokens,
+            work,
+            ..
+        } = parse_file(
             SourceView::new("parse.rue", parse_error, FileId::new(2)),
             ThreadedRodeo::new(),
         );
         assert!(result.is_err());
+        assert!(
+            tokens.parser_reused_allocation(),
+            "parse diagnostics must return the lexer's original token allocation"
+        );
         assert_eq!(work.lexed_bytes, parse_error.len());
         assert_eq!(work.tokens, 5);
         assert_eq!(work.parser_invocations, 1);

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -999,7 +999,13 @@ impl crate::CompilerSession {
                                 "presentation order contains unknown file id {file_id:?}"
                             ))
                         })?;
-                    for token in module.tokens() {
+                    let source = crate::SourceView::new(
+                        module.physical_path(),
+                        module.source_text(),
+                        module.file_id(),
+                    );
+                    let (tokens, _resolver) = crate::syntax::token_presentation(source);
+                    for token in tokens.iter() {
                         writeln!(&mut text, "{token}").expect("write to String");
                     }
                 }

--- a/crates/rue-compiler/tests/public_api.rs
+++ b/crates/rue-compiler/tests/public_api.rs
@@ -9,7 +9,7 @@ use rue_compiler::{
     CompileErrors, CompileOptions, CompileOutput, CompilerSession, CompilerSessionUpdate,
     DependencyEnvelope, DiagnosticStage, FileId, FrontendDiagnosticSnapshot, ImportDiscoveryStatus,
     ImportDiscoveryView, MultiErrorResult, RirView, SourceLocationView, SourceMetadata,
-    SourceRevision, SourceSnapshot, SourceView, SyntaxNodeView, compile_snapshot,
+    SourceRevision, SourceSnapshot, SourceView, SyntaxModuleView, SyntaxNodeView, compile_snapshot,
 };
 use rue_error::ErrorKind;
 
@@ -144,6 +144,172 @@ fn syntax_nodes_resolve_names_and_retain_their_owner_across_updates() {
     let debug = format!("{function:?}");
     assert!(!debug.contains("ParsedModule"));
     assert!(!debug.contains("Ast"));
+}
+
+fn snapshot_at(file_id: FileId, source: &str) -> SourceSnapshot {
+    let physical_paths = [(file_id, "/project/main.rue".to_owned())]
+        .into_iter()
+        .collect();
+    let logical_paths = [(file_id, "main.rue".to_owned())].into_iter().collect();
+    let metadata = SourceMetadata::new(file_id, physical_paths, logical_paths).unwrap();
+    SourceSnapshot::new(metadata, vec![(file_id, Arc::new(source.to_owned()))]).unwrap()
+}
+
+fn token_records(module: &SyntaxModuleView) -> Vec<(String, Option<String>, u32, u32)> {
+    module
+        .tokens()
+        .map(|token| {
+            (
+                token.kind().to_owned(),
+                token.value().map(|value| value.into_owned()),
+                token.start(),
+                token.end(),
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn token_views_are_exact_deterministic_and_retain_their_old_source() {
+    let source = "fn main() -> i32 { let value = \"old\"; value }";
+    let first = snapshot_at(FileId::new(7), source);
+    let edited = snapshot_at(
+        FileId::new(11),
+        "fn replacement() -> i32 { let value = \"new\"; value }",
+    );
+    let expected_kinds = [
+        "FN",
+        "IDENT",
+        "LPAREN",
+        "RPAREN",
+        "ARROW",
+        "TYPE(i32)",
+        "LBRACE",
+        "LET",
+        "IDENT",
+        "EQ",
+        "STRING",
+        "SEMI",
+        "IDENT",
+        "RBRACE",
+        "EOF",
+    ];
+    let expected_lexemes = [
+        "fn", "main", "(", ")", "->", "i32", "{", "let", "value", "=", "\"old\"", ";", "value",
+        "}", "",
+    ];
+
+    let mut warm_session = CompilerSession::new();
+    let retained = warm_session.update(&first).into_result().unwrap();
+    let module = retained.modules().next().unwrap();
+    assert_eq!(module.file_id(), FileId::new(7));
+    let records = token_records(&module);
+    assert_eq!(
+        records
+            .iter()
+            .map(|(kind, _, _, _)| kind.as_str())
+            .collect::<Vec<_>>(),
+        expected_kinds
+    );
+    assert_eq!(
+        records
+            .iter()
+            .map(|(_, _, start, end)| &source[*start as usize..*end as usize])
+            .collect::<Vec<_>>(),
+        expected_lexemes
+    );
+    assert_eq!(records[1].1.as_deref(), Some("main"));
+    assert_eq!(records[8].1.as_deref(), Some("value"));
+    assert_eq!(records[10].1.as_deref(), Some("old"));
+
+    let old_token = module.tokens().nth(1).unwrap();
+    let old_location = old_token.location();
+    let metrics_before_presentation = warm_session.unstable_metrics().parse_metrics();
+    let _ = token_records(&module);
+    assert_eq!(
+        warm_session.unstable_metrics().parse_metrics(),
+        metrics_before_presentation,
+        "lazy token presentation is not canonical syntax work"
+    );
+
+    warm_session.update(&edited).into_result().unwrap();
+    let current = warm_session.published().unwrap().modules().next().unwrap();
+    let current_location = current.tokens().nth(1).unwrap().location();
+    assert_eq!(old_token.value().as_deref(), Some("main"));
+    assert_eq!(
+        &module.source()[old_token.start() as usize..old_token.end() as usize],
+        "main"
+    );
+    assert!(old_location.is_valid());
+    assert!(
+        !old_location
+            .source_identity()
+            .same_source(&current_location.source_identity()),
+        "a retained token view must keep the old immutable source identity"
+    );
+
+    let warm = warm_session.update(&first).into_result().unwrap();
+    let warm_records = token_records(&warm.modules().next().unwrap());
+    let warm_again = warm_session.update(&first);
+    assert_eq!(warm_again.unstable_metrics().lexer_invocations, 0);
+    let warm_again_records =
+        token_records(&warm_again.into_result().unwrap().modules().next().unwrap());
+    let mut fresh_session = CompilerSession::new();
+    let fresh_records = token_records(
+        &fresh_session
+            .update(&first)
+            .into_result()
+            .unwrap()
+            .modules()
+            .next()
+            .unwrap(),
+    );
+    assert_eq!(warm_records, fresh_records);
+    assert_eq!(warm_again_records, fresh_records);
+
+    let options = CompileOptions::default();
+    let order = [FileId::new(7)];
+    let warm_parse_metrics = warm_session.unstable_metrics().parse_metrics();
+    let warm_presentation = warm_session
+        .unstable_present(PresentationRequest {
+            stage: PresentationStage::Tokens,
+            options: &options,
+            file_order: &order,
+        })
+        .unwrap();
+    assert_eq!(
+        warm_session.unstable_metrics().parse_metrics(),
+        warm_parse_metrics,
+        "unstable token presentation must not increment canonical parse work"
+    );
+    let fresh_presentation = fresh_session
+        .unstable_present(PresentationRequest {
+            stage: PresentationStage::Tokens,
+            options: &options,
+            file_order: &order,
+        })
+        .unwrap();
+    assert_eq!(warm_presentation.as_str(), fresh_presentation.as_str());
+    assert_eq!(
+        warm_presentation.as_str().lines().count(),
+        expected_kinds.len()
+    );
+    assert!(
+        warm_presentation
+            .as_str()
+            .lines()
+            .next()
+            .unwrap()
+            .ends_with("FN")
+    );
+    assert!(
+        warm_presentation
+            .as_str()
+            .lines()
+            .last()
+            .unwrap()
+            .ends_with("EOF")
+    );
 }
 
 fn find_syntax_node(

--- a/crates/rue-parser/src/parser.rs
+++ b/crates/rue-parser/src/parser.rs
@@ -160,8 +160,22 @@ impl Parser {
 
     /// Parse while retaining the shared interner when this file is malformed.
     pub fn parse_preserving_interner(
-        mut self,
+        self,
     ) -> Result<(Ast, ThreadedRodeo), (CompileErrors, ThreadedRodeo)> {
+        self.parse_preserving_interner_and_tokens()
+            .map(|(ast, interner, _tokens)| (ast, interner))
+            .map_err(|(errors, interner, _tokens)| (errors, interner))
+    }
+
+    /// Parse while returning the exact input token allocation to the caller.
+    ///
+    /// Compiler consumers that need tokens for a transient post-parse
+    /// projection can borrow this returned vector without cloning it. The
+    /// ordinary [`Self::parse`] and [`Self::parse_preserving_interner`] entry
+    /// points discard it after parsing.
+    pub fn parse_preserving_interner_and_tokens(
+        mut self,
+    ) -> Result<(Ast, ThreadedRodeo, Vec<Token>), (CompileErrors, ThreadedRodeo, Vec<Token>)> {
         if let Some(kind) = self.interner_error {
             return Err((
                 CompileErrors::from(CompileError::without_span(rue_lexer::interner_error_kind(
@@ -169,6 +183,7 @@ impl Parser {
                     "the parser could not intern a required primitive spelling",
                 ))),
                 self.interner,
+                self.tokens,
             ));
         }
         let input_token_count = self.tokens.len();
@@ -192,7 +207,7 @@ impl Parser {
                 validation_error_count = 0,
                 "parser complete"
             );
-            return Err((CompileErrors::from(vec![error]), self.interner));
+            return Err((CompileErrors::from(vec![error]), self.interner, self.tokens));
         }
 
         let items = {
@@ -226,7 +241,7 @@ impl Parser {
                 validation_error_count = 0,
                 "parser complete"
             );
-            return Err((CompileErrors::from(errors), self.interner));
+            return Err((CompileErrors::from(errors), self.interner, self.tokens));
         }
 
         let ast = Ast { items };
@@ -245,7 +260,7 @@ impl Parser {
                 validation_error_count = validation.len(),
                 "parser complete"
             );
-            return Err((CompileErrors::from(validation), self.interner));
+            return Err((CompileErrors::from(validation), self.interner, self.tokens));
         }
 
         info!(
@@ -258,7 +273,7 @@ impl Parser {
             validation_error_count = 0,
             "parser complete"
         );
-        Ok((ast, self.interner))
+        Ok((ast, self.interner, self.tokens))
     }
 }
 


### PR DESCRIPTION
Fixes RUE-1805.

## Summary
- return the lexer’s original token allocation from parsing and release it after transient syntax indexing
- remove token buffers from published parsed modules and retained-allocation accounting
- lazily reproduce token views and `--emit tokens` from immutable source through the canonical lexer
- preserve staged rebinds, FileId provenance, warm-session determinism, and parse-work accounting

## Validation
- `scripts/rue quick`
- `scripts/rue test`
- `scripts/rue cli emit_tokens`
- focused parser, lexer, staged-parse, FileId-rebind, and public artifact-view tests
- `scripts/rue fmt`
- `git diff --check`