### PR TITLE
RUE-1810: carry cancellation through object generation and linking

### DIFF
--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -192,24 +192,66 @@ fn canonical_codegen_sections(
 /// Adapt one retained codegen terminal directly to the linker's structured
 /// input. Atom `Arc`s are passed through unchanged; only the final merged
 /// executable receives a contiguous copy.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn project_backend_structured_object(
     unit: &crate::codegen_query::CodegenUnit,
     target: Target,
 ) -> CompileResult<rue_linker::StructuredObject> {
+    match project_backend_structured_object_with_cancellation(
+        unit,
+        target,
+        &rue_query::CancellationToken::new(),
+    ) {
+        Ok(object) => Ok(object),
+        Err(crate::session::PipelineRequestControl::Compile(errors)) => {
+            Err(errors.into_iter().next().unwrap_or_else(|| {
+                CompileError::without_span(ErrorKind::InternalCodegenError(
+                    "structured object projection failed without a diagnostic".into(),
+                ))
+            }))
+        }
+        Err(crate::session::PipelineRequestControl::Abort(abort)) => {
+            Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+                format!("uncancellable structured object projection aborted: {abort:?}"),
+            )))
+        }
+        Err(crate::session::PipelineRequestControl::Parked(_)) => {
+            unreachable!("structured object projection does not demand toolchain modules")
+        }
+    }
+}
+
+pub(crate) fn project_backend_structured_object_with_cancellation(
+    unit: &crate::codegen_query::CodegenUnit,
+    target: Target,
+    cancellation: &rue_query::CancellationToken,
+) -> Result<rue_linker::StructuredObject, crate::session::PipelineRequestControl> {
+    if cancellation.is_canceled() {
+        return Err(crate::session::PipelineRequestControl::Abort(
+            rue_query::QueryAbort::Canceled,
+        ));
+    }
     let [text, rodata, data, bss] = canonical_codegen_sections(unit)?;
     let _ = (data, bss);
-    let relocations = unit
-        .relocations
-        .iter()
-        .map(|relocation| {
-            Ok(rue_linker::StructuredRelocation {
-                offset: relocation.offset,
-                symbol: relocation.symbol.to_string(),
-                rel_type: map_linker_relocation(target, relocation.kind)?,
-                addend: relocation.addend,
-            })
-        })
-        .collect::<CompileResult<Vec<_>>>()?;
+    let mut relocations = Vec::with_capacity(unit.relocations.len());
+    for relocation in unit.relocations.iter() {
+        if cancellation.is_canceled() {
+            return Err(crate::session::PipelineRequestControl::Abort(
+                rue_query::QueryAbort::Canceled,
+            ));
+        }
+        relocations.push(rue_linker::StructuredRelocation {
+            offset: relocation.offset,
+            symbol: relocation.symbol.to_string(),
+            rel_type: map_linker_relocation(target, relocation.kind)?,
+            addend: relocation.addend,
+        });
+    }
+    if cancellation.is_canceled() {
+        return Err(crate::session::PipelineRequestControl::Abort(
+            rue_query::QueryAbort::Canceled,
+        ));
+    }
     Ok(rue_linker::StructuredObject::function(
         target,
         unit.defined_symbol.to_string(),

--- a/crates/rue-compiler/src/linking.rs
+++ b/crates/rue-compiler/src/linking.rs
@@ -28,6 +28,79 @@ fn io_link_error(context: &str, err: std::io::Error) -> CompileError {
     CompileError::without_span(ErrorKind::LinkError(format!("{}: {}", context, err)))
 }
 
+type CancellableLinkResult<T> = Result<T, crate::session::PipelineRequestControl>;
+
+#[cfg(test)]
+thread_local! {
+    static LINK_CANCELLATION_TRIPWIRE: std::cell::RefCell<Option<(rue_query::CancellationToken, usize)>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+pub(crate) fn set_link_cancellation_tripwire(
+    cancellation: Option<(rue_query::CancellationToken, usize)>,
+) {
+    LINK_CANCELLATION_TRIPWIRE.with(|slot| *slot.borrow_mut() = cancellation);
+}
+
+fn check_cancellation(cancellation: &rue_query::CancellationToken) -> CancellableLinkResult<()> {
+    #[cfg(test)]
+    LINK_CANCELLATION_TRIPWIRE.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        let Some((token, remaining)) = slot.as_mut() else {
+            return;
+        };
+        *remaining = remaining.saturating_sub(1);
+        if *remaining == 0 {
+            token.cancel();
+            *slot = None;
+        }
+    });
+    if cancellation.is_canceled() {
+        Err(crate::session::PipelineRequestControl::Abort(
+            rue_query::QueryAbort::Canceled,
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn compile_control(errors: impl Into<CompileErrors>) -> crate::session::PipelineRequestControl {
+    crate::session::PipelineRequestControl::Compile(errors.into())
+}
+
+fn map_linker_control(err: rue_linker::LinkError) -> crate::session::PipelineRequestControl {
+    if matches!(err, rue_linker::LinkError::Canceled) {
+        crate::session::PipelineRequestControl::Abort(rue_query::QueryAbort::Canceled)
+    } else {
+        compile_control(link_error(err))
+    }
+}
+
+fn uncancellable<T>(result: CancellableLinkResult<T>, context: &str) -> MultiErrorResult<T> {
+    result.map_err(|control| match control {
+        crate::session::PipelineRequestControl::Compile(errors) => errors,
+        crate::session::PipelineRequestControl::Abort(abort) => {
+            crate::session::pipeline_abort_errors(context, abort)
+        }
+        crate::session::PipelineRequestControl::Parked(park) => {
+            crate::session::unresolved_toolchain_park_errors(&park)
+        }
+    })
+}
+
+fn clone_warnings_with_cancellation(
+    warnings: &[CompileWarning],
+    cancellation: &rue_query::CancellationToken,
+) -> CancellableLinkResult<Vec<CompileWarning>> {
+    let mut cloned = Vec::with_capacity(warnings.len());
+    for warning in warnings {
+        check_cancellation(cancellation)?;
+        cloned.push(warning.clone());
+    }
+    Ok(cloned)
+}
+
 /// A temporary directory for linking that automatically cleans up on drop.
 ///
 /// The `TempDir` is the ownership token for the workspace: it is created
@@ -80,10 +153,19 @@ impl TempLinkDir {
         options.open(path).map_err(|e| io_link_error(context, e))
     }
 
+    fn create_capture_leaf(path: &Path, context: &str) -> CompileResult<std::fs::File> {
+        let mut options = std::fs::OpenOptions::new();
+        options.read(true).write(true).create_new(true);
+        #[cfg(unix)]
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+        options.open(path).map_err(|e| io_link_error(context, e))
+    }
+
     /// Write object files to the temporary directory.
     ///
     /// Each object file is written to a file named `obj{N}.o` where N is
     /// the index. The paths are stored in `self.obj_paths`.
+    #[cfg_attr(not(test), allow(dead_code))]
     fn write_object_files(&mut self, object_files: &[Vec<u8>]) -> CompileResult<()> {
         for (i, obj_bytes) in object_files.iter().enumerate() {
             let obj_path = self.directory.path().join(format!("obj{}.o", i));
@@ -95,11 +177,49 @@ impl TempLinkDir {
         Ok(())
     }
 
+    fn write_object_files_with_cancellation(
+        &mut self,
+        object_files: &[Vec<u8>],
+        cancellation: &rue_query::CancellationToken,
+    ) -> CancellableLinkResult<()> {
+        for (i, obj_bytes) in object_files.iter().enumerate() {
+            check_cancellation(cancellation)?;
+            let obj_path = self.directory.path().join(format!("obj{}.o", i));
+            let mut file = Self::create_leaf(&obj_path, "failed to create temp object file")
+                .map_err(compile_control)?;
+            write_all_with_cancellation(
+                &mut file,
+                obj_bytes,
+                cancellation,
+                "failed to write temp object file",
+            )?;
+            self.obj_paths.push(obj_path);
+        }
+        Ok(())
+    }
+
     /// Write the runtime archive to the temporary directory.
+    #[cfg_attr(not(test), allow(dead_code))]
     fn write_runtime(&self, runtime_bytes: &[u8]) -> CompileResult<()> {
         let mut file = Self::create_leaf(&self.runtime_path, "failed to create runtime archive")?;
         file.write_all(runtime_bytes)
             .map_err(|e| io_link_error("failed to write runtime archive", e))
+    }
+
+    fn write_runtime_with_cancellation(
+        &self,
+        runtime_bytes: &[u8],
+        cancellation: &rue_query::CancellationToken,
+    ) -> CancellableLinkResult<()> {
+        check_cancellation(cancellation)?;
+        let mut file = Self::create_leaf(&self.runtime_path, "failed to create runtime archive")
+            .map_err(compile_control)?;
+        write_all_with_cancellation(
+            &mut file,
+            runtime_bytes,
+            cancellation,
+            "failed to write runtime archive",
+        )
     }
 
     /// Reserve the output leaf so a pre-existing file of any kind is rejected.
@@ -109,6 +229,7 @@ impl TempLinkDir {
     }
 
     /// Read the linked executable from the output path.
+    #[cfg_attr(not(test), allow(dead_code))]
     fn read_output(&self) -> CompileResult<Vec<u8>> {
         let mut options = std::fs::OpenOptions::new();
         options.read(true);
@@ -130,6 +251,186 @@ impl TempLinkDir {
         file.read_to_end(&mut output)
             .map_err(|e| io_link_error("failed to read linked executable", e))?;
         Ok(output)
+    }
+
+    fn read_output_with_cancellation(
+        &self,
+        cancellation: &rue_query::CancellationToken,
+    ) -> CancellableLinkResult<Vec<u8>> {
+        check_cancellation(cancellation)?;
+        let mut options = std::fs::OpenOptions::new();
+        options.read(true);
+        #[cfg(unix)]
+        options.custom_flags(libc::O_NOFOLLOW);
+        let mut file = options
+            .open(&self.output_path)
+            .map_err(|e| compile_control(io_link_error("failed to open linked executable", e)))?;
+        if !file
+            .metadata()
+            .map_err(|e| compile_control(io_link_error("failed to inspect linked executable", e)))?
+            .is_file()
+        {
+            return Err(compile_control(CompileError::without_span(
+                ErrorKind::LinkError("linked executable is not a regular file".to_string()),
+            )));
+        }
+        let mut output = Vec::new();
+        let mut chunk = [0_u8; 64 * 1024];
+        loop {
+            check_cancellation(cancellation)?;
+            let read = file.read(&mut chunk).map_err(|e| {
+                compile_control(io_link_error("failed to read linked executable", e))
+            })?;
+            if read == 0 {
+                break;
+            }
+            output.extend_from_slice(&chunk[..read]);
+        }
+        Ok(output)
+    }
+}
+
+fn write_all_with_cancellation(
+    file: &mut std::fs::File,
+    bytes: &[u8],
+    cancellation: &rue_query::CancellationToken,
+    context: &str,
+) -> CancellableLinkResult<()> {
+    for chunk in bytes.chunks(64 * 1024) {
+        check_cancellation(cancellation)?;
+        file.write_all(chunk)
+            .map_err(|e| compile_control(io_link_error(context, e)))?;
+    }
+    Ok(())
+}
+
+fn read_capture_with_cancellation(
+    file: &mut std::fs::File,
+    cancellation: &rue_query::CancellationToken,
+    context: &str,
+) -> CancellableLinkResult<Vec<u8>> {
+    check_cancellation(cancellation)?;
+    file.seek(std::io::SeekFrom::Start(0))
+        .map_err(|error| compile_control(io_link_error(context, error)))?;
+    let mut bytes = Vec::new();
+    let mut chunk = [0_u8; 64 * 1024];
+    loop {
+        check_cancellation(cancellation)?;
+        let read = file
+            .read(&mut chunk)
+            .map_err(|error| compile_control(io_link_error(context, error)))?;
+        if read == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&chunk[..read]);
+    }
+    Ok(bytes)
+}
+
+struct LinkerJob {
+    child: std::process::Child,
+    reaped: bool,
+}
+
+impl LinkerJob {
+    fn spawn(command: &mut Command) -> std::io::Result<Self> {
+        // Rue's supported compiler hosts are Unix. A fresh process group makes
+        // the driver and every normally spawned ld/lld descendant one owned
+        // job that can be terminated before TempLinkDir is dropped. Keep the
+        // direct-child fallback narrowly cfg'd for other hosts where std does
+        // not expose a portable process-tree/job primitive.
+        #[cfg(unix)]
+        command.process_group(0);
+        Ok(Self {
+            child: command.spawn()?,
+            reaped: false,
+        })
+    }
+
+    fn try_wait(&mut self) -> std::io::Result<Option<std::process::ExitStatus>> {
+        let status = self.child.try_wait()?;
+        if status.is_some() {
+            self.reaped = true;
+        }
+        Ok(status)
+    }
+
+    fn terminate_and_reap(&mut self) -> std::io::Result<std::process::ExitStatus> {
+        let mut termination_error = None;
+        #[cfg(unix)]
+        {
+            let process_group = -(self.child.id() as libc::pid_t);
+            if unsafe { libc::kill(process_group, libc::SIGKILL) } != 0 {
+                let error = std::io::Error::last_os_error();
+                if error.raw_os_error() != Some(libc::ESRCH) {
+                    termination_error = Some(error);
+                    let _ = self.child.kill();
+                }
+            }
+        }
+        #[cfg(not(unix))]
+        if let Err(error) = self.child.kill() {
+            if error.kind() != std::io::ErrorKind::InvalidInput {
+                termination_error = Some(error);
+            }
+        }
+
+        let status = self.child.wait();
+        if status.is_ok() {
+            self.reaped = true;
+        }
+        let status = status?;
+        if let Some(error) = termination_error {
+            return Err(error);
+        }
+        Ok(status)
+    }
+}
+
+impl Drop for LinkerJob {
+    fn drop(&mut self) {
+        if !self.reaped {
+            let _ = self.terminate_and_reap();
+        }
+    }
+}
+
+fn wait_for_linker(
+    job: &mut LinkerJob,
+    cancellation: &rue_query::CancellationToken,
+) -> CancellableLinkResult<std::process::ExitStatus> {
+    loop {
+        // An already-observed exit wins the child-lifecycle race. Overall
+        // compilation still checks cancellation while constructing and before
+        // publishing the final bytes.
+        match job.try_wait() {
+            Ok(Some(status)) => return Ok(status),
+            Ok(None) if cancellation.is_canceled() => {
+                job.terminate_and_reap().map_err(|e| {
+                    compile_control(io_link_error(
+                        "failed to terminate and reap canceled linker job",
+                        e,
+                    ))
+                })?;
+                return Err(crate::session::PipelineRequestControl::Abort(
+                    rue_query::QueryAbort::Canceled,
+                ));
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(10)),
+            Err(err) => {
+                if let Err(cleanup_error) = job.terminate_and_reap() {
+                    return Err(compile_control(CompileError::without_span(
+                        ErrorKind::LinkError(format!(
+                            "failed to wait for linker: {err}; also failed to terminate and reap linker job: {cleanup_error}"
+                        )),
+                    )));
+                }
+                return Err(compile_control(io_link_error(
+                    "failed to wait for linker",
+                    err,
+                )));
+            }
+        }
     }
 }
 
@@ -159,6 +460,7 @@ pub(crate) fn validate_runtime(target: Target) -> Result<(), String> {
     validate_runtime_archive(runtime_for_target(target), target).map(|_| ())
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn parse_runtime_archive(runtime_bytes: &[u8]) -> Result<Archive, String> {
     let archive = Archive::parse_strict_objects(runtime_bytes)
         .map_err(|e| format!("embedded rue-runtime archive is invalid: {}", e))?;
@@ -170,21 +472,44 @@ pub(crate) fn parse_runtime_archive(runtime_bytes: &[u8]) -> Result<Archive, Str
     Ok(archive)
 }
 
-/// Read and parse a user-supplied static archive passed with `--link-archive`
-/// (ADR-0064 C FFI). Its object members satisfy undefined `extern "C"` symbols.
-fn read_user_archive(path: &Path) -> Result<Archive, ErrorKind> {
-    let bytes = std::fs::read(path).map_err(|e| {
-        ErrorKind::LinkError(format!(
+fn read_user_archive_with_cancellation(
+    path: &Path,
+    cancellation: &rue_query::CancellationToken,
+) -> CancellableLinkResult<Archive> {
+    check_cancellation(cancellation)?;
+    let mut file = std::fs::File::open(path).map_err(|e| {
+        compile_control(CompileError::without_span(ErrorKind::LinkError(format!(
             "failed to read link archive `{}`: {e}",
             path.display()
-        ))
+        ))))
     })?;
-    Archive::parse_strict_objects(&bytes).map_err(|e| {
-        ErrorKind::LinkError(format!(
-            "failed to parse link archive `{}`: {e}",
-            path.display()
-        ))
-    })
+    let mut bytes = Vec::new();
+    let mut chunk = [0_u8; 64 * 1024];
+    loop {
+        check_cancellation(cancellation)?;
+        let read = file.read(&mut chunk).map_err(|e| {
+            compile_control(CompileError::without_span(ErrorKind::LinkError(format!(
+                "failed to read link archive `{}`: {e}",
+                path.display()
+            ))))
+        })?;
+        if read == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&chunk[..read]);
+    }
+    Archive::parse_strict_objects_with_cancellation(&bytes, || cancellation.is_canceled()).map_err(
+        |error| {
+            if matches!(error, rue_linker::ArchiveError::Canceled) {
+                crate::session::PipelineRequestControl::Abort(rue_query::QueryAbort::Canceled)
+            } else {
+                compile_control(CompileError::without_span(ErrorKind::LinkError(format!(
+                    "failed to parse link archive `{}`: {error}",
+                    path.display()
+                ))))
+            }
+        },
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -210,6 +535,47 @@ struct RuntimeDefinedSymbol {
 struct RuntimeArchiveInventory {
     object_targets: Vec<rue_runtime_abi::RuntimeTarget>,
     symbols: Vec<RuntimeDefinedSymbol>,
+}
+
+#[derive(Debug)]
+enum RuntimeArchiveWorkError {
+    Canceled,
+    Invalid(String),
+}
+
+#[cfg(test)]
+thread_local! {
+    static RUNTIME_ARCHIVE_CANCELLATION_TRIPWIRE: std::cell::RefCell<Option<(rue_query::CancellationToken, usize)>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+fn set_runtime_archive_cancellation_tripwire(
+    cancellation: Option<(rue_query::CancellationToken, usize)>,
+) {
+    RUNTIME_ARCHIVE_CANCELLATION_TRIPWIRE.with(|slot| *slot.borrow_mut() = cancellation);
+}
+
+fn check_runtime_archive_work(
+    cancellation: &rue_query::CancellationToken,
+) -> Result<(), RuntimeArchiveWorkError> {
+    #[cfg(test)]
+    RUNTIME_ARCHIVE_CANCELLATION_TRIPWIRE.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        let Some((token, remaining)) = slot.as_mut() else {
+            return;
+        };
+        *remaining = remaining.saturating_sub(1);
+        if *remaining == 0 {
+            token.cancel();
+            *slot = None;
+        }
+    });
+    if cancellation.is_canceled() {
+        Err(RuntimeArchiveWorkError::Canceled)
+    } else {
+        Ok(())
+    }
 }
 
 fn runtime_target(target: Target) -> rue_runtime_abi::RuntimeTarget {
@@ -238,14 +604,30 @@ fn parsed_object_target(
 }
 
 fn runtime_archive_inventory(archive: &Archive) -> Result<RuntimeArchiveInventory, String> {
+    match runtime_archive_inventory_with_cancellation(archive, &rue_query::CancellationToken::new())
+    {
+        Ok(inventory) => Ok(inventory),
+        Err(RuntimeArchiveWorkError::Invalid(error)) => Err(error),
+        Err(RuntimeArchiveWorkError::Canceled) => unreachable!("fresh token cannot be canceled"),
+    }
+}
+
+fn runtime_archive_inventory_with_cancellation(
+    archive: &Archive,
+    cancellation: &rue_query::CancellationToken,
+) -> Result<RuntimeArchiveInventory, RuntimeArchiveWorkError> {
+    check_runtime_archive_work(cancellation)?;
     use rue_linker::{ObjectFormat, SectionFlags, SymbolBinding, SymbolType};
 
     let mut inventory = RuntimeArchiveInventory::default();
     for (object_index, object) in archive.objects.iter().enumerate() {
-        let object_target = parsed_object_target(object, object_index)?;
+        check_runtime_archive_work(cancellation)?;
+        let object_target =
+            parsed_object_target(object, object_index).map_err(RuntimeArchiveWorkError::Invalid)?;
         inventory.object_targets.push(object_target);
 
         for symbol in &object.symbols {
+            check_runtime_archive_work(cancellation)?;
             if symbol.section_index.is_none()
                 || matches!(symbol.binding, SymbolBinding::Local)
                 || symbol.name.is_empty()
@@ -255,10 +637,10 @@ fn runtime_archive_inventory(archive: &Archive) -> Result<RuntimeArchiveInventor
 
             let section_index = symbol.section_index.expect("checked above");
             let section = object.sections.get(section_index).ok_or_else(|| {
-                format!(
+                RuntimeArchiveWorkError::Invalid(format!(
                     "embedded rue-runtime archive symbol `{}` has invalid section index {}",
                     symbol.name, section_index
-                )
+                ))
             })?;
             let bytes_from_symbol = u64::try_from(section.data.len())
                 .unwrap_or(u64::MAX)
@@ -266,16 +648,15 @@ fn runtime_archive_inventory(archive: &Archive) -> Result<RuntimeArchiveInventor
             let format_size = match object.format {
                 ObjectFormat::Elf => symbol.size,
                 ObjectFormat::MachO => {
-                    let next_symbol = object
-                        .symbols
-                        .iter()
-                        .filter(|candidate| {
-                            candidate.section_index == symbol.section_index
-                                && candidate.value > symbol.value
-                        })
-                        .map(|candidate| candidate.value)
-                        .min()
-                        .unwrap_or(section.size);
+                    let mut next_symbol = section.size;
+                    for candidate in &object.symbols {
+                        check_runtime_archive_work(cancellation)?;
+                        if candidate.section_index == symbol.section_index
+                            && candidate.value > symbol.value
+                        {
+                            next_symbol = next_symbol.min(candidate.value);
+                        }
+                    }
                     next_symbol.saturating_sub(symbol.value)
                 }
             };
@@ -304,9 +685,7 @@ fn runtime_archive_inventory(archive: &Archive) -> Result<RuntimeArchiveInventor
             });
         }
     }
-    inventory
-        .symbols
-        .sort_by(|left, right| left.name.cmp(&right.name));
+    check_runtime_archive_work(cancellation)?;
     Ok(inventory)
 }
 
@@ -314,49 +693,79 @@ fn validate_runtime_inventory(
     inventory: &RuntimeArchiveInventory,
     target: rue_runtime_abi::RuntimeTarget,
 ) -> Result<(), String> {
+    match validate_runtime_inventory_with_cancellation(
+        inventory,
+        target,
+        &rue_query::CancellationToken::new(),
+    ) {
+        Ok(()) => Ok(()),
+        Err(RuntimeArchiveWorkError::Invalid(error)) => Err(error),
+        Err(RuntimeArchiveWorkError::Canceled) => unreachable!("fresh token cannot be canceled"),
+    }
+}
+
+fn runtime_definitions_with_cancellation<'a>(
+    inventory: &'a RuntimeArchiveInventory,
+    name: &str,
+    cancellation: &rue_query::CancellationToken,
+) -> Result<Vec<&'a RuntimeDefinedSymbol>, RuntimeArchiveWorkError> {
+    let mut definitions = Vec::new();
+    for symbol in &inventory.symbols {
+        check_runtime_archive_work(cancellation)?;
+        if symbol.name == name {
+            definitions.push(symbol);
+        }
+    }
+    Ok(definitions)
+}
+
+fn validate_runtime_inventory_with_cancellation(
+    inventory: &RuntimeArchiveInventory,
+    target: rue_runtime_abi::RuntimeTarget,
+    cancellation: &rue_query::CancellationToken,
+) -> Result<(), RuntimeArchiveWorkError> {
+    check_runtime_archive_work(cancellation)?;
     use rue_runtime_abi::{
         RUNTIME_ABI_VERSION_SYMBOL, ReservedExportId, ReservedExportKind, RuntimeHelperId,
         classify_export,
     };
 
-    let mut errors = Vec::new();
+    let mut errors = std::collections::BTreeSet::new();
     for (object_index, object_target) in inventory.object_targets.iter().copied().enumerate() {
+        check_runtime_archive_work(cancellation)?;
         if object_target != target {
-            errors.push(format!(
+            errors.insert(format!(
                 "object {object_index} targets {object_target:?}, expected {target:?}"
             ));
         }
     }
 
-    let definitions = |name: &str| {
-        inventory
-            .symbols
-            .iter()
-            .filter(|symbol| symbol.name == name)
-            .collect::<Vec<_>>()
-    };
-
     for id in RuntimeHelperId::ALL {
+        check_runtime_archive_work(cancellation)?;
         let helper = id.helper();
-        let found = definitions(helper.symbol);
+        let found = runtime_definitions_with_cancellation(inventory, helper.symbol, cancellation)?;
         if helper.availability.contains(target) {
             match found.len() {
-                0 => errors.push(format!("missing runtime helper `{}`", helper.symbol)),
+                0 => {
+                    errors.insert(format!("missing runtime helper `{}`", helper.symbol));
+                }
                 1 => {
                     if found[0].kind != RuntimeSymbolKind::Function {
-                        errors.push(format!(
+                        errors.insert(format!(
                             "runtime helper `{}` is not callable code",
                             helper.symbol
                         ));
                     }
                 }
-                count => errors.push(format!(
-                    "runtime helper `{}` is defined {count} times",
-                    helper.symbol
-                )),
+                count => {
+                    errors.insert(format!(
+                        "runtime helper `{}` is defined {count} times",
+                        helper.symbol
+                    ));
+                }
             }
         } else if !found.is_empty() {
-            errors.push(format!(
+            errors.insert(format!(
                 "runtime helper `{}` is not available for {target:?}",
                 helper.symbol
             ));
@@ -364,18 +773,21 @@ fn validate_runtime_inventory(
     }
 
     for id in ReservedExportId::ALL {
+        check_runtime_archive_work(cancellation)?;
         let export = id.export();
-        let found = definitions(export.symbol);
+        let found = runtime_definitions_with_cancellation(inventory, export.symbol, cancellation)?;
         if export.availability.contains(target) {
             match found.len() {
-                0 => errors.push(format!(
-                    "missing reserved runtime export `{}`",
-                    export.symbol
-                )),
+                0 => {
+                    errors.insert(format!(
+                        "missing reserved runtime export `{}`",
+                        export.symbol
+                    ));
+                }
                 1 => match export.kind {
                     ReservedExportKind::Function(_) => {
                         if found[0].kind != RuntimeSymbolKind::Function {
-                            errors.push(format!(
+                            errors.insert(format!(
                                 "reserved runtime export `{}` is not callable code",
                                 export.symbol
                             ));
@@ -384,13 +796,13 @@ fn validate_runtime_inventory(
                     ReservedExportKind::ReadOnlyData { size } => {
                         let marker = found[0];
                         if marker.kind != RuntimeSymbolKind::Data {
-                            errors.push(format!(
+                            errors.insert(format!(
                                 "runtime ABI marker `{}` is not an object symbol",
                                 export.symbol
                             ));
                         }
                         if marker.size != u64::from(size) {
-                            errors.push(format!(
+                            errors.insert(format!(
                                 "runtime ABI marker `{}` has size {}, expected {} byte",
                                 export.symbol, marker.size, size
                             ));
@@ -399,32 +811,34 @@ fn validate_runtime_inventory(
                             || marker.section_writable
                             || marker.section_executable
                         {
-                            errors.push(format!(
+                            errors.insert(format!(
                                 "runtime ABI marker `{}` is not retained read-only data",
                                 export.symbol
                             ));
                         }
                         if marker.bytes_from_symbol < u64::from(size) {
-                            errors.push(format!(
+                            errors.insert(format!(
                                 "runtime ABI marker `{}` has no accessible marker byte",
                                 export.symbol
                             ));
                         }
                         if marker.first_byte != Some(0) {
-                            errors.push(format!(
+                            errors.insert(format!(
                                 "runtime ABI marker `{}` does not contain the required zero byte",
                                 export.symbol
                             ));
                         }
                     }
                 },
-                count => errors.push(format!(
-                    "reserved runtime export `{}` is defined {count} times",
-                    export.symbol
-                )),
+                count => {
+                    errors.insert(format!(
+                        "reserved runtime export `{}` is defined {count} times",
+                        export.symbol
+                    ));
+                }
             }
         } else if !found.is_empty() {
-            errors.push(format!(
+            errors.insert(format!(
                 "reserved runtime export `{}` is not available for {target:?}",
                 export.symbol
             ));
@@ -432,6 +846,7 @@ fn validate_runtime_inventory(
     }
 
     for symbol in &inventory.symbols {
+        check_runtime_archive_work(cancellation)?;
         let abi_owned_name = symbol.name.starts_with("__rue_");
         if abi_owned_name && classify_export(&symbol.name).is_none() {
             let message = if symbol.name.starts_with("__rue_runtime_abi_v") {
@@ -442,24 +857,115 @@ fn validate_runtime_inventory(
             } else {
                 format!("unknown runtime ABI export `{}`", symbol.name)
             };
-            errors.push(message);
+            errors.insert(message);
         }
     }
 
-    errors.sort();
-    errors.dedup();
     if errors.is_empty() {
         Ok(())
     } else {
-        Err(format!(
+        Err(RuntimeArchiveWorkError::Invalid(format!(
             "embedded rue-runtime archive does not match the typed ABI manifest:\n  - {}",
-            errors.join("\n  - ")
-        ))
+            errors.into_iter().collect::<Vec<_>>().join("\n  - ")
+        )))
     }
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 fn validate_runtime_archive(runtime_bytes: &[u8], target: Target) -> Result<Archive, String> {
     let archive = parse_runtime_archive(runtime_bytes)?;
+    validate_parsed_runtime_archive(archive, runtime_bytes, target)
+}
+
+fn validate_runtime_archive_with_cancellation(
+    runtime_bytes: &[u8],
+    target: Target,
+    cancellation: &rue_query::CancellationToken,
+) -> CancellableLinkResult<Archive> {
+    check_cancellation(cancellation)?;
+    let archive = Archive::parse_strict_objects_with_cancellation(runtime_bytes, || {
+        cancellation.is_canceled()
+    })
+    .map_err(|error| {
+        if matches!(error, rue_linker::ArchiveError::Canceled) {
+            crate::session::PipelineRequestControl::Abort(rue_query::QueryAbort::Canceled)
+        } else {
+            compile_control(link_error(format!(
+                "embedded rue-runtime archive is invalid: {error}"
+            )))
+        }
+    })?;
+    if archive.is_empty() {
+        return Err(compile_control(link_error(
+            "embedded rue-runtime archive contains no object files",
+        )));
+    }
+    check_cancellation(cancellation)?;
+    let embedded_runtime = runtime_for_target(target);
+    let embedded_validation = match target {
+        Target::X86_64Linux => &RUNTIME_X86_64_LINUX_VALIDATION,
+        Target::Aarch64Linux => &RUNTIME_AARCH64_LINUX_VALIDATION,
+        Target::Aarch64Macos => &RUNTIME_AARCH64_MACOS_VALIDATION,
+    };
+    if std::ptr::eq(runtime_bytes, embedded_runtime) {
+        if let Some(validation) = embedded_validation.get() {
+            validation
+                .clone()
+                .map_err(|error| compile_control(link_error(error)))?;
+        } else {
+            let validation = (|| {
+                let inventory =
+                    runtime_archive_inventory_with_cancellation(&archive, cancellation)?;
+                validate_runtime_inventory_with_cancellation(
+                    &inventory,
+                    runtime_target(target),
+                    cancellation,
+                )
+            })();
+            let validation = match validation {
+                Ok(()) => Ok(()),
+                Err(RuntimeArchiveWorkError::Invalid(error)) => Err(error),
+                Err(RuntimeArchiveWorkError::Canceled) => {
+                    return Err(crate::session::PipelineRequestControl::Abort(
+                        rue_query::QueryAbort::Canceled,
+                    ));
+                }
+            };
+            embedded_validation
+                .get_or_init(|| validation)
+                .clone()
+                .map_err(|error| compile_control(link_error(error)))?;
+        }
+    } else {
+        let inventory = runtime_archive_inventory_with_cancellation(&archive, cancellation)
+            .map_err(map_runtime_archive_work_control)?;
+        validate_runtime_inventory_with_cancellation(
+            &inventory,
+            runtime_target(target),
+            cancellation,
+        )
+        .map_err(map_runtime_archive_work_control)?;
+    }
+    check_cancellation(cancellation)?;
+    Ok(archive)
+}
+
+fn map_runtime_archive_work_control(
+    error: RuntimeArchiveWorkError,
+) -> crate::session::PipelineRequestControl {
+    match error {
+        RuntimeArchiveWorkError::Canceled => {
+            crate::session::PipelineRequestControl::Abort(rue_query::QueryAbort::Canceled)
+        }
+        RuntimeArchiveWorkError::Invalid(error) => compile_control(link_error(error)),
+    }
+}
+
+fn validate_parsed_runtime_archive(
+    archive: Archive,
+    runtime_bytes: &[u8],
+    target: Target,
+) -> Result<Archive, String> {
     let validate = || {
         let inventory = runtime_archive_inventory(&archive)?;
         validate_runtime_inventory(&inventory, runtime_target(target))
@@ -506,11 +1012,31 @@ pub(crate) fn link_internal_with_warnings(
 }
 
 fn finish_internal_link(
-    mut linker: Linker,
+    linker: Linker,
     options: &CompileOptions,
     object_count: usize,
     warnings: &[CompileWarning],
 ) -> MultiErrorResult<CompileOutput> {
+    uncancellable(
+        finish_internal_link_with_cancellation(
+            linker,
+            options,
+            object_count,
+            warnings,
+            &rue_query::CancellationToken::new(),
+        ),
+        "internal link",
+    )
+}
+
+fn finish_internal_link_with_cancellation(
+    mut linker: Linker,
+    options: &CompileOptions,
+    object_count: usize,
+    warnings: &[CompileWarning],
+    cancellation: &rue_query::CancellationToken,
+) -> CancellableLinkResult<CompileOutput> {
+    check_cancellation(cancellation)?;
     let runtime_bytes = runtime_for_target(options.target);
     let entry_point = if options.target.is_macho() {
         "__main"
@@ -521,39 +1047,42 @@ fn finish_internal_link(
     {
         let _span = info_span!("link_archive_resolve").entered();
         for archive_path in &options.link_archives {
-            let archive = read_user_archive(archive_path)
-                .map_err(CompileError::without_span)
-                .map_err(CompileErrors::from)?;
+            check_cancellation(cancellation)?;
+            let archive = read_user_archive_with_cancellation(archive_path, cancellation)?;
             linker
-                .add_archive(archive)
-                .map_err(link_error)
-                .map_err(CompileErrors::from)?;
+                .add_archive_with_cancellation(archive, &mut || cancellation.is_canceled())
+                .map_err(map_linker_control)?;
         }
-        let runtime = validate_runtime_archive(runtime_bytes, options.target)
-            .map_err(link_error)
-            .map_err(CompileErrors::from)?;
+        check_cancellation(cancellation)?;
+        let runtime = validate_runtime_archive_with_cancellation(
+            runtime_bytes,
+            options.target,
+            cancellation,
+        )?;
         linker
-            .add_archive(runtime)
-            .map_err(link_error)
-            .map_err(CompileErrors::from)?;
+            .add_archive_with_cancellation(runtime, &mut || cancellation.is_canceled())
+            .map_err(map_linker_control)?;
     }
     let executable = linker
-        .link(entry_point)
+        .link_with_cancellation(entry_point, || cancellation.is_canceled())
         .map_err(|err| match &err {
+            rue_linker::LinkError::Canceled => {
+                crate::session::PipelineRequestControl::Abort(rue_query::QueryAbort::Canceled)
+            }
             rue_linker::LinkError::UndefinedSymbol(symbol) => {
                 let mut searched = vec!["the bundled rue-runtime archive".to_string()];
                 for archive_path in &options.link_archives {
                     searched.push(format!("`{}`", archive_path.display()));
                 }
-                CompileError::without_span(ErrorKind::LinkError(format!(
+                compile_control(CompileError::without_span(ErrorKind::LinkError(format!(
                     "undefined symbol `{symbol}`: no supplied archive defines it \
                      (searched {})",
                     searched.join(", ")
-                )))
+                ))))
             }
-            _ => link_error(err),
-        })
-        .map_err(CompileErrors::from)?;
+            _ => compile_control(link_error(err)),
+        })?;
+    check_cancellation(cancellation)?;
     info!(
         object_count,
         output_bytes = executable.len(),
@@ -561,7 +1090,7 @@ fn finish_internal_link(
     );
     Ok(CompileOutput {
         elf: executable,
-        warnings: warnings.to_vec(),
+        warnings: clone_warnings_with_cancellation(warnings, cancellation)?,
         source_stats: SourceStats::default(),
         work: PipelineWork::default(),
         query_runtime: crate::unstable::QueryRuntimeMetrics::default(),
@@ -573,51 +1102,61 @@ fn finish_internal_link(
 
 /// Link retained compiler units directly. Export thunks remain serialized
 /// because they are synthesized outside the retained CodegenUnit query.
-pub(crate) fn link_internal_structured_with_warnings(
+pub(crate) fn link_internal_structured_with_warnings_and_cancellation(
     options: &CompileOptions,
     objects: &[crate::object_query::CollectedObjectProjection],
     export_thunk_objects: &[Vec<u8>],
     warnings: &[CompileWarning],
-) -> MultiErrorResult<CompileOutput> {
-    link_internal_structured_admission(
+    cancellation: &rue_query::CancellationToken,
+) -> CancellableLinkResult<CompileOutput> {
+    link_internal_structured_admission_with_cancellation(
         options,
         objects.len(),
         export_thunk_objects,
         warnings,
+        cancellation,
         |linker| {
-            objects.iter().try_for_each(|collected| {
-                admit_structured_unit(linker, &collected.unit, options.target)
-            })
+            for collected in objects {
+                check_cancellation(cancellation)?;
+                admit_structured_unit(linker, &collected.unit, options.target, cancellation)?;
+            }
+            Ok(())
         },
     )
 }
 
-pub(crate) fn link_internal_structured_units_with_warnings(
+pub(crate) fn link_internal_structured_units_with_warnings_and_cancellation(
     options: &CompileOptions,
     units: &[crate::codegen_query::CollectedCodegenUnit],
     export_thunk_objects: &[Vec<u8>],
     warnings: &[CompileWarning],
-) -> MultiErrorResult<CompileOutput> {
-    link_internal_structured_admission(
+    cancellation: &rue_query::CancellationToken,
+) -> CancellableLinkResult<CompileOutput> {
+    link_internal_structured_admission_with_cancellation(
         options,
         units.len(),
         export_thunk_objects,
         warnings,
+        cancellation,
         |linker| {
-            units.iter().try_for_each(|collected| {
-                admit_structured_unit(linker, &collected.unit, options.target)
-            })
+            for collected in units {
+                check_cancellation(cancellation)?;
+                admit_structured_unit(linker, &collected.unit, options.target, cancellation)?;
+            }
+            Ok(())
         },
     )
 }
 
-fn link_internal_structured_admission(
+fn link_internal_structured_admission_with_cancellation(
     options: &CompileOptions,
     object_count: usize,
     export_thunk_objects: &[Vec<u8>],
     warnings: &[CompileWarning],
-    mut admit: impl FnMut(&mut Linker) -> MultiErrorResult<()>,
-) -> MultiErrorResult<CompileOutput> {
+    cancellation: &rue_query::CancellationToken,
+    mut admit: impl FnMut(&mut Linker) -> CancellableLinkResult<()>,
+) -> CancellableLinkResult<CompileOutput> {
+    check_cancellation(cancellation)?;
     let _span = info_span!("linker", mode = "internal", phase = "linking").entered();
     let mut linker = Linker::new(options.target);
     {
@@ -628,30 +1167,32 @@ fn link_internal_structured_admission(
         )
         .entered();
         admit(&mut linker)?;
-        add_export_thunks(&mut linker, export_thunk_objects)?;
+        add_export_thunks(&mut linker, export_thunk_objects, cancellation)?;
     }
-    finish_internal_link(
+    finish_internal_link_with_cancellation(
         linker,
         options,
         object_count + export_thunk_objects.len(),
         warnings,
+        cancellation,
     )
 }
 
 fn add_export_thunks(
     linker: &mut Linker,
     export_thunk_objects: &[Vec<u8>],
-) -> MultiErrorResult<()> {
+    cancellation: &rue_query::CancellationToken,
+) -> CancellableLinkResult<()> {
     // C-ABI entry thunks are not retained CodegenUnits; preserve their
     // established byte-container path and diagnostics.
     for bytes in export_thunk_objects {
+        check_cancellation(cancellation)?;
         let object = ObjectFile::parse(bytes)
             .map_err(link_error)
-            .map_err(CompileErrors::from)?;
+            .map_err(compile_control)?;
         linker
-            .add_object(object)
-            .map_err(link_error)
-            .map_err(CompileErrors::from)?;
+            .add_object_with_cancellation(object, &mut || cancellation.is_canceled())
+            .map_err(map_linker_control)?;
     }
     Ok(())
 }
@@ -660,22 +1201,46 @@ fn admit_structured_unit(
     linker: &mut Linker,
     unit: &crate::codegen_query::CodegenUnit,
     target: Target,
-) -> MultiErrorResult<()> {
-    let object = crate::backend::project_backend_structured_object(unit, target)
-        .map_err(CompileErrors::from)?;
+    cancellation: &rue_query::CancellationToken,
+) -> CancellableLinkResult<()> {
+    let object = crate::backend::project_backend_structured_object_with_cancellation(
+        unit,
+        target,
+        cancellation,
+    )?;
     linker
-        .add_structured_object(object)
-        .map_err(link_error)
-        .map_err(CompileErrors::from)
+        .add_structured_object_with_cancellation(object, &mut || cancellation.is_canceled())
+        .map_err(map_linker_control)
 }
 
 /// Link using an external system linker.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn link_system_with_warnings(
     options: &CompileOptions,
     object_files: &[Vec<u8>],
     linker_cmd: &str,
     warnings: &[CompileWarning],
 ) -> MultiErrorResult<CompileOutput> {
+    uncancellable(
+        link_system_with_warnings_and_cancellation(
+            options,
+            object_files,
+            linker_cmd,
+            warnings,
+            &rue_query::CancellationToken::new(),
+        ),
+        "system link",
+    )
+}
+
+pub(crate) fn link_system_with_warnings_and_cancellation(
+    options: &CompileOptions,
+    object_files: &[Vec<u8>],
+    linker_cmd: &str,
+    warnings: &[CompileWarning],
+    cancellation: &rue_query::CancellationToken,
+) -> CancellableLinkResult<CompileOutput> {
+    check_cancellation(cancellation)?;
     let _span = info_span!(
         "linker",
         mode = "system",
@@ -687,19 +1252,15 @@ pub(crate) fn link_system_with_warnings(
     let runtime_bytes = runtime_for_target(options.target);
     // The system linker consumes the archive bytes directly, so validate the
     // embedded target and typed ABI before writing them to disk.
-    validate_runtime_archive(runtime_bytes, options.target)
-        .map_err(link_error)
-        .map_err(CompileErrors::from)?;
+    validate_runtime_archive_with_cancellation(runtime_bytes, options.target, cancellation)?;
+    check_cancellation(cancellation)?;
 
     // Set up temporary directory with object files and runtime
-    let mut temp_dir = TempLinkDir::new().map_err(CompileErrors::from)?;
-    temp_dir
-        .write_object_files(object_files)
-        .map_err(CompileErrors::from)?;
-    temp_dir
-        .write_runtime(runtime_bytes)
-        .map_err(CompileErrors::from)?;
-    temp_dir.create_output().map_err(CompileErrors::from)?;
+    let mut temp_dir = TempLinkDir::new().map_err(compile_control)?;
+    temp_dir.write_object_files_with_cancellation(object_files, cancellation)?;
+    temp_dir.write_runtime_with_cancellation(runtime_bytes, cancellation)?;
+    temp_dir.create_output().map_err(compile_control)?;
+    check_cancellation(cancellation)?;
 
     // Build the linker command
     let mut cmd = Command::new(linker_cmd);
@@ -738,24 +1299,54 @@ pub(crate) fn link_system_with_warnings(
         cmd.arg("-lSystem");
     }
 
-    // Run the linker
-    let output = cmd.output().map_err(|e| {
-        CompileErrors::from(CompileError::without_span(ErrorKind::LinkError(format!(
+    // Redirect output into owner-only workspace leaves. This preserves
+    // `Command::output` diagnostics without risking a full pipe blocking the
+    // child while the parent polls its lifecycle.
+    let stdout_path = temp_dir.directory.path().join("linker.stdout");
+    let stderr_path = temp_dir.directory.path().join("linker.stderr");
+    let stdout = TempLinkDir::create_leaf(&stdout_path, "failed to create linker stdout")
+        .map_err(compile_control)?;
+    let mut stderr =
+        TempLinkDir::create_capture_leaf(&stderr_path, "failed to create linker stderr")
+            .map_err(compile_control)?;
+    let stderr_for_child = stderr.try_clone().map_err(|error| {
+        compile_control(io_link_error(
+            "failed to duplicate linker stderr capture",
+            error,
+        ))
+    })?;
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::from(stdout));
+    cmd.stderr(Stdio::from(stderr_for_child));
+
+    let mut job = LinkerJob::spawn(&mut cmd).map_err(|e| {
+        compile_control(CompileError::without_span(ErrorKind::LinkError(format!(
             "failed to execute linker '{}': {}",
             linker_cmd, e
         ))))
     })?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+    let status = wait_for_linker(&mut job, cancellation)?;
+
+    check_cancellation(cancellation)?;
+    if !status.success() {
+        // Read the capture inode we created, not the pathname the arbitrary
+        // linker could have unlinked and replaced while it owned the workspace.
+        let stderr_bytes = read_capture_with_cancellation(
+            &mut stderr,
+            cancellation,
+            "failed to read linker stderr",
+        )?;
+        let stderr = String::from_utf8_lossy(&stderr_bytes);
         // temp_dir is dropped here, cleaning up automatically
-        return Err(CompileErrors::from(CompileError::without_span(
+        return Err(compile_control(CompileError::without_span(
             ErrorKind::LinkError(format!("linker '{}' failed: {}", linker_cmd, stderr)),
         )));
     }
 
     // Read the resulting executable
-    let elf = temp_dir.read_output().map_err(CompileErrors::from)?;
+    let elf = temp_dir.read_output_with_cancellation(cancellation)?;
+    check_cancellation(cancellation)?;
     info!(
         object_count = object_files.len(),
         output_bytes = elf.len(),
@@ -765,7 +1356,7 @@ pub(crate) fn link_system_with_warnings(
     // temp_dir is dropped here, cleaning up automatically
     Ok(CompileOutput {
         elf,
-        warnings: warnings.to_vec(),
+        warnings: clone_warnings_with_cancellation(warnings, cancellation)?,
         source_stats: SourceStats::default(),
         work: PipelineWork::default(),
         query_runtime: crate::unstable::QueryRuntimeMetrics::default(),
@@ -774,12 +1365,15 @@ pub(crate) fn link_system_with_warnings(
         publication: crate::unstable::PublicationMetrics::default(),
     })
 }
-use std::io::{Read, Write};
+use std::io::{Read, Seek, Write};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::time::Duration;
 
 #[cfg(unix)]
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 
 use tracing::{info, info_span};
 
@@ -790,6 +1384,171 @@ mod temp_link_dir_tests {
     use std::os::unix::fs::{PermissionsExt, symlink};
 
     use super::*;
+
+    fn write_mock_linker(directory: &tempfile::TempDir, body: &str) -> PathBuf {
+        let path = directory.path().join("mock-linker");
+        std::fs::write(&path, format!("#!/bin/sh\nset -eu\n{body}\n")).unwrap();
+        let mut permissions = path.metadata().unwrap().permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&path, permissions).unwrap();
+        path
+    }
+
+    fn mock_output_argument() -> &'static str {
+        "out=''\nprev=''\nfor arg in \"$@\"; do\n  if [ \"$prev\" = '-o' ]; then out=$arg; break; fi\n  prev=$arg\ndone\n"
+    }
+
+    #[test]
+    #[ignore = "platform_native_ host coverage; run by rue-compiler-platform-native-test"]
+    fn platform_native_system_link_cancellation_reaps_child_and_cleans_workspace() {
+        let directory = tempfile::tempdir().unwrap();
+        let ready = directory.path().join("ready");
+        let pid_path = directory.path().join("pid");
+        let descendant_pid_path = directory.path().join("descendant-pid");
+        let workspace_path = directory.path().join("workspace");
+        let body = format!(
+            "{}printf '%s\\n' \"$$\" > '{}'\nsleep 30 &\nprintf '%s\\n' \"$!\" > '{}'\nprintf '%s\\n' \"$(dirname \"$out\")\" > '{}'\n: > '{}'\nwait",
+            mock_output_argument(),
+            pid_path.display(),
+            descendant_pid_path.display(),
+            workspace_path.display(),
+            ready.display(),
+        );
+        let linker = write_mock_linker(&directory, &body);
+        let cancellation = rue_query::CancellationToken::new();
+        let canceler = cancellation.clone();
+        let ready_for_thread = ready.clone();
+        let cancel_thread = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + Duration::from_secs(10);
+            while !ready_for_thread.exists() {
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "mock linker never started"
+                );
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            canceler.cancel();
+        });
+        let mut options = CompileOptions::default();
+        options.target = Target::host().unwrap();
+        let started = std::time::Instant::now();
+        let result = link_system_with_warnings_and_cancellation(
+            &options,
+            &[],
+            linker.to_str().unwrap(),
+            &[],
+            &cancellation,
+        );
+        cancel_thread.join().unwrap();
+
+        assert!(matches!(
+            result,
+            Err(crate::session::PipelineRequestControl::Abort(
+                rue_query::QueryAbort::Canceled
+            ))
+        ));
+        assert!(started.elapsed() < Duration::from_secs(2));
+        let workspace = std::fs::read_to_string(&workspace_path).unwrap();
+        assert!(!Path::new(workspace.trim()).exists());
+        for pid_path in [&pid_path, &descendant_pid_path] {
+            let pid: libc::pid_t = std::fs::read_to_string(pid_path)
+                .unwrap()
+                .trim()
+                .parse()
+                .unwrap();
+            let deadline = std::time::Instant::now() + Duration::from_secs(2);
+            loop {
+                if unsafe { libc::kill(pid, 0) } == -1
+                    && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
+                {
+                    break;
+                }
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "linker process {pid} survived process-group termination"
+                );
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        }
+    }
+
+    #[test]
+    #[ignore = "platform_native_ host coverage; run by rue-compiler-platform-native-test"]
+    fn platform_native_system_link_preserves_ordinary_success_and_failure() {
+        let directory = tempfile::tempdir().unwrap();
+        let success = write_mock_linker(
+            &directory,
+            &format!("{}printf 'linked' > \"$out\"", mock_output_argument()),
+        );
+        let mut options = CompileOptions::default();
+        options.target = Target::host().unwrap();
+        let output =
+            link_system_with_warnings(&options, &[], success.to_str().unwrap(), &[]).unwrap();
+        assert_eq!(output.elf, b"linked");
+
+        let failure_dir = tempfile::tempdir().unwrap();
+        let failure = write_mock_linker(&failure_dir, "printf 'ordinary failure\\n' >&2\nexit 23");
+        let error =
+            link_system_with_warnings(&options, &[], failure.to_str().unwrap(), &[]).unwrap_err();
+        assert!(error.to_string().contains("ordinary failure"));
+    }
+
+    #[test]
+    #[ignore = "platform_native_ host coverage; run by rue-compiler-platform-native-test"]
+    fn platform_native_system_link_reads_only_the_owned_stderr_capture() {
+        for replacement in ["symlink", "fifo"] {
+            let directory = tempfile::tempdir().unwrap();
+            let secret = directory.path().join("secret");
+            std::fs::write(&secret, "pathname replacement must not be read").unwrap();
+            let replacement_command = if replacement == "symlink" {
+                format!("ln -s '{}' \"$workspace/linker.stderr\"", secret.display())
+            } else {
+                "mkfifo \"$workspace/linker.stderr\"".to_owned()
+            };
+            let linker = write_mock_linker(
+                &directory,
+                &format!(
+                    "{}workspace=$(dirname \"$out\")\nprintf 'retained diagnostic\\n' >&2\nrm \"$workspace/linker.stderr\"\n{}\nexit 23",
+                    mock_output_argument(),
+                    replacement_command,
+                ),
+            );
+            let mut options = CompileOptions::default();
+            options.target = Target::host().unwrap();
+            let started = std::time::Instant::now();
+            let error = link_system_with_warnings(&options, &[], linker.to_str().unwrap(), &[])
+                .unwrap_err();
+            assert!(
+                started.elapsed() < Duration::from_secs(2),
+                "{replacement} replacement blocked stderr capture"
+            );
+            let diagnostic = error.to_string();
+            assert!(diagnostic.contains("retained diagnostic"));
+            assert!(!diagnostic.contains("pathname replacement must not be read"));
+        }
+    }
+
+    #[test]
+    #[ignore = "platform_native_ host coverage; run by rue-compiler-platform-native-test"]
+    fn platform_native_observed_system_link_exit_wins_child_lifecycle_race() {
+        let mut command = Command::new("/bin/sh");
+        command.args(["-c", "exit 0"]);
+        let mut job = LinkerJob::spawn(&mut command).unwrap();
+        while job.try_wait().unwrap().is_none() {
+            std::thread::yield_now();
+        }
+        let cancellation = rue_query::CancellationToken::new();
+        cancellation.cancel();
+
+        let status = wait_for_linker(&mut job, &cancellation).unwrap();
+        assert!(status.success());
+        assert!(matches!(
+            check_cancellation(&cancellation),
+            Err(crate::session::PipelineRequestControl::Abort(
+                rue_query::QueryAbort::Canceled
+            ))
+        ));
+    }
 
     #[test]
     #[ignore = "platform_native_ host coverage; run by rue-compiler-platform-native-test"]
@@ -931,6 +1690,28 @@ mod runtime_archive_validation_tests {
 
     fn error(inventory: &RuntimeArchiveInventory, target: RuntimeTarget) -> String {
         validate_runtime_inventory(inventory, target).expect_err("inventory must be rejected")
+    }
+
+    #[test]
+    fn large_runtime_inventory_cancellation_maps_to_query_abort() {
+        let target = RuntimeTarget::X86_64Linux;
+        let mut inventory = valid_inventory(target, 1);
+        inventory
+            .symbols
+            .extend((0..4_096).map(|index| function(&format!("foreign_{index}"))));
+        let cancellation = rue_query::CancellationToken::new();
+        set_runtime_archive_cancellation_tripwire(Some((cancellation.clone(), 128)));
+
+        let result =
+            validate_runtime_inventory_with_cancellation(&inventory, target, &cancellation);
+
+        let error = result.unwrap_err();
+        assert!(matches!(error, RuntimeArchiveWorkError::Canceled));
+        assert!(matches!(
+            map_runtime_archive_work_control(error),
+            crate::session::PipelineRequestControl::Abort(rue_query::QueryAbort::Canceled)
+        ));
+        set_runtime_archive_cancellation_tripwire(None);
     }
 
     fn archive_with_member(name: &str, member: &[u8]) -> Vec<u8> {

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -545,6 +545,47 @@ mod tests {
     }
 
     #[test]
+    fn in_progress_internal_link_cancellation_aborts_without_poisoning_reuse() {
+        let snapshot = wide_reached_program(64, 7);
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+        let rooted = session
+            .rooted_codegen_internal_with_cancellation(
+                &options,
+                rue_codegen::BackendArtifactRequest::default(),
+                rue_query::CancellationToken::new(),
+            )
+            .unwrap();
+        let cancellation = rue_query::CancellationToken::new();
+        crate::linking::set_link_cancellation_tripwire(Some((cancellation.clone(), 8)));
+
+        let canceled = crate::queries::compile_rooted_with_session_with_cancellation(
+            &mut session,
+            &snapshot,
+            &options,
+            rooted,
+            &cancellation,
+        );
+
+        assert!(matches!(
+            canceled,
+            Err(crate::session::PipelineRequestControl::Abort(
+                rue_query::QueryAbort::Canceled
+            ))
+        ));
+        assert!(cancellation.is_canceled());
+        crate::linking::set_link_cancellation_tripwire(None);
+
+        let recovered = crate::queries::compile_with_session(&mut session, &snapshot, &options)
+            .expect("a canceled final link must not poison retained compiler terminals");
+        assert!(!recovered.elf.is_empty());
+    }
+
+    #[test]
     fn failed_wide_batches_release_their_unpublished_child_cones_under_pressure() {
         const CHAIN_FUNCTIONS: usize = 33;
         // RUE-1262 ruling on what the pressure compiles buy. They are a witness

--- a/crates/rue-compiler/src/program_image_plan.rs
+++ b/crates/rue-compiler/src/program_image_plan.rs
@@ -23,6 +23,97 @@ use crate::{
     object_query::CollectedObjectProjection,
 };
 
+type CancellableImageResult<T> = Result<T, crate::session::PipelineRequestControl>;
+
+fn check_cancellation(cancellation: &rue_query::CancellationToken) -> CancellableImageResult<()> {
+    if cancellation.is_canceled() {
+        Err(crate::session::PipelineRequestControl::Abort(
+            rue_query::QueryAbort::Canceled,
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn cancellable_sort_by<T>(
+    values: &mut Vec<T>,
+    cancellation: &rue_query::CancellationToken,
+    mut compare: impl FnMut(&T, &T) -> std::cmp::Ordering,
+) -> CancellableImageResult<()> {
+    const RUN: usize = 256;
+    let mut source = Vec::with_capacity(values.len());
+    for index in 0..values.len() {
+        if index % RUN == 0 {
+            check_cancellation(cancellation)?;
+        }
+        source.push(index);
+    }
+    for chunk in source.chunks_mut(RUN) {
+        check_cancellation(cancellation)?;
+        chunk.sort_by(|left, right| compare(&values[*left], &values[*right]));
+        check_cancellation(cancellation)?;
+    }
+
+    let mut destination = Vec::with_capacity(source.len());
+    let mut width = RUN;
+    while width < source.len() {
+        check_cancellation(cancellation)?;
+        destination.clear();
+        for start in (0..source.len()).step_by(width.saturating_mul(2)) {
+            let middle = source.len().min(start.saturating_add(width));
+            let end = source
+                .len()
+                .min(start.saturating_add(width.saturating_mul(2)));
+            let (mut left, mut right) = (start, middle);
+            while left < middle || right < end {
+                check_cancellation(cancellation)?;
+                if right == end
+                    || (left < middle
+                        && compare(&values[source[left]], &values[source[right]])
+                            != std::cmp::Ordering::Greater)
+                {
+                    destination.push(source[left]);
+                    left += 1;
+                } else {
+                    destination.push(source[right]);
+                    right += 1;
+                }
+            }
+        }
+        std::mem::swap(&mut source, &mut destination);
+        width = width.saturating_mul(2);
+    }
+
+    check_cancellation(cancellation)?;
+    let original = std::mem::take(values);
+    let mut slots = Vec::with_capacity(original.len());
+    for (index, value) in original.into_iter().enumerate() {
+        if index % RUN == 0 {
+            check_cancellation(cancellation)?;
+        }
+        slots.push(Some(value));
+    }
+    values.reserve(slots.len());
+    for index in source {
+        check_cancellation(cancellation)?;
+        values.push(slots[index].take().expect("sort permutation is unique"));
+    }
+    check_cancellation(cancellation)
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn uncancellable<T>(result: CancellableImageResult<T>, context: &str) -> MultiErrorResult<T> {
+    result.map_err(|control| match control {
+        crate::session::PipelineRequestControl::Compile(errors) => errors,
+        crate::session::PipelineRequestControl::Abort(abort) => {
+            crate::session::pipeline_abort_errors(context, abort)
+        }
+        crate::session::PipelineRequestControl::Parked(park) => {
+            crate::session::unresolved_toolchain_park_errors(&park)
+        }
+    })
+}
+
 /// Stable, link-relevant identity for one reached codegen terminal.
 #[derive(Debug, Clone)]
 pub(crate) struct ProgramImageUnit {
@@ -183,33 +274,55 @@ type ProgramImageInputs = Vec<CollectedObjectProjection>;
 impl ProgramImage {
     /// Construct the production image directly from rooted codegen terminals
     /// and their exact C-export projections.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn from_rooted(
         objects: Vec<CollectedObjectProjection>,
         exports: Vec<RootedExportThunk>,
         options: &CompileOptions,
     ) -> MultiErrorResult<Self> {
+        uncancellable(
+            Self::from_rooted_with_cancellation(
+                objects,
+                exports,
+                options,
+                &rue_query::CancellationToken::new(),
+            ),
+            "program image",
+        )
+    }
+
+    pub(crate) fn from_rooted_with_cancellation(
+        objects: Vec<CollectedObjectProjection>,
+        exports: Vec<RootedExportThunk>,
+        options: &CompileOptions,
+        cancellation: &rue_query::CancellationToken,
+    ) -> CancellableImageResult<Self> {
         // Aggregating link inputs is compiler-root work like any other pass. It
         // stayed outside every phase span until RUE-1257, so ADR-0067's
         // taxonomy could only report its cost as `unattributed`.
         let _span = info_span!("program_image_plan", phase = "object_generation").entered();
-        let unit_identities = validate_rooted_program_image_inputs(&objects, &exports)?;
-        let export_thunk_objects: Vec<Vec<u8>> = exports
-            .iter()
-            .map(|export| {
-                backend::generate_export_thunk_object(
-                    options.target,
-                    &export.exported_symbol,
-                    &export.native_symbol,
-                    &export.param_types,
-                )
-            })
-            .collect();
-        let plan = ProgramImagePlan::from_rooted_inputs(
+        let unit_identities = validate_rooted_program_image_inputs_with_cancellation(
+            &objects,
+            &exports,
+            cancellation,
+        )?;
+        let mut export_thunk_objects = Vec::with_capacity(exports.len());
+        for export in &exports {
+            check_cancellation(cancellation)?;
+            export_thunk_objects.push(backend::generate_export_thunk_object(
+                options.target,
+                &export.exported_symbol,
+                &export.native_symbol,
+                &export.param_types,
+            ));
+        }
+        let plan = ProgramImagePlan::from_rooted_inputs_with_cancellation(
             &objects,
             unit_identities,
             &exports,
             options,
             &export_thunk_objects,
+            cancellation,
         )?;
         Ok(Self {
             plan,
@@ -279,98 +392,160 @@ impl ProgramImage {
 
     /// Collect the already-projected per-unit bytes for system linking and
     /// object-output consumers. Internal links use `units` directly.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn fresh_objects(&self, options: &CompileOptions) -> MultiErrorResult<Vec<Vec<u8>>> {
+        uncancellable(
+            self.fresh_objects_with_cancellation(options, &rue_query::CancellationToken::new()),
+            "fresh object materialization",
+        )
+    }
+
+    pub(crate) fn fresh_objects_with_cancellation(
+        &self,
+        options: &CompileOptions,
+        cancellation: &rue_query::CancellationToken,
+    ) -> CancellableImageResult<Vec<Vec<u8>>> {
+        check_cancellation(cancellation)?;
         let _span =
             info_span!("fresh_object_materialization", phase = "object_generation").entered();
         if self.plan.target != options.target {
-            return Err(CompileErrors::from(CompileError::without_span(
-                ErrorKind::InvalidCompilerInput(
+            return Err(crate::session::PipelineRequestControl::Compile(
+                CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
                     "program image target differs from the fresh-link target".into(),
-                ),
-            )));
+                ))),
+            ));
         }
-        let mut objects = self
-            .inputs
-            .iter()
-            .map(|collected| collected.object.bytes.to_vec())
-            .collect::<Vec<_>>();
+        let mut objects = Vec::with_capacity(self.inputs.len() + self.export_thunk_objects.len());
+        for collected in &self.inputs {
+            check_cancellation(cancellation)?;
+            objects.push(clone_bytes_with_cancellation(
+                &collected.object.bytes,
+                cancellation,
+            )?);
+        }
         info!(
             function_count = self.inputs.len(),
             object_bytes = objects.iter().map(Vec::len).sum::<usize>(),
             "codegen complete"
         );
-        objects.extend(self.export_thunk_objects.iter().cloned());
+        for thunk in &self.export_thunk_objects {
+            check_cancellation(cancellation)?;
+            objects.push(clone_bytes_with_cancellation(thunk, cancellation)?);
+        }
         Ok(objects)
     }
 
     /// Invoke the existing fresh linker. Warnings are intentionally attached
     /// only here, after the diagnostic-free plan has been constructed.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn fresh_link(
         &self,
         options: &CompileOptions,
         warnings: &[CompileWarning],
     ) -> MultiErrorResult<CompileOutput> {
+        uncancellable(
+            self.fresh_link_with_cancellation(
+                options,
+                warnings,
+                &rue_query::CancellationToken::new(),
+            ),
+            "fresh link",
+        )
+    }
+
+    pub(crate) fn fresh_link_with_cancellation(
+        &self,
+        options: &CompileOptions,
+        warnings: &[CompileWarning],
+        cancellation: &rue_query::CancellationToken,
+    ) -> CancellableImageResult<CompileOutput> {
+        check_cancellation(cancellation)?;
         if self.plan.target != options.target {
-            return Err(CompileErrors::from(CompileError::without_span(
-                ErrorKind::InvalidCompilerInput(
+            return Err(crate::session::PipelineRequestControl::Compile(
+                CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
                     "program image target differs from the fresh-link target".into(),
-                ),
-            )));
+                ))),
+            ));
         }
         match &options.linker {
-            LinkerMode::Internal => linking::link_internal_structured_with_warnings(
-                options,
-                &self.inputs,
-                &self.export_thunk_objects,
-                warnings,
-            ),
+            LinkerMode::Internal => {
+                linking::link_internal_structured_with_warnings_and_cancellation(
+                    options,
+                    &self.inputs,
+                    &self.export_thunk_objects,
+                    warnings,
+                    cancellation,
+                )
+            }
             LinkerMode::System(command) => {
-                let objects = self.fresh_objects(options)?;
-                linking::link_system_with_warnings(options, &objects, command, warnings)
+                let objects = self.fresh_objects_with_cancellation(options, cancellation)?;
+                linking::link_system_with_warnings_and_cancellation(
+                    options,
+                    &objects,
+                    command,
+                    warnings,
+                    cancellation,
+                )
             }
         }
     }
 }
 
+fn clone_bytes_with_cancellation(
+    bytes: &[u8],
+    cancellation: &rue_query::CancellationToken,
+) -> CancellableImageResult<Vec<u8>> {
+    let mut cloned = Vec::with_capacity(bytes.len());
+    for chunk in bytes.chunks(64 * 1024) {
+        check_cancellation(cancellation)?;
+        cloned.extend_from_slice(chunk);
+    }
+    Ok(cloned)
+}
+
 impl ProgramImagePlan {
-    fn from_rooted_inputs(
+    fn from_rooted_inputs_with_cancellation(
         units: &[CollectedObjectProjection],
         unit_identities: Vec<String>,
         exports: &[RootedExportThunk],
         options: &CompileOptions,
         export_thunk_objects: &[Vec<u8>],
-    ) -> MultiErrorResult<Self> {
-        let mut plan_units = units
-            .iter()
-            .zip(unit_identities)
-            .map(|(collected, identity)| ProgramImageUnit {
+        cancellation: &rue_query::CancellationToken,
+    ) -> CancellableImageResult<Self> {
+        let mut plan_units = Vec::with_capacity(units.len());
+        for (collected, identity) in units.iter().zip(unit_identities) {
+            check_cancellation(cancellation)?;
+            plan_units.push(ProgramImageUnit {
                 function: collected.function.clone(),
                 identity,
                 defined_symbol: collected.unit.defined_symbol.clone(),
                 object: Arc::clone(&collected.object),
-            })
-            .collect::<Vec<_>>();
-        plan_units.sort_by(|left, right| left.identity.cmp(&right.identity));
+            });
+        }
+        cancellable_sort_by(&mut plan_units, cancellation, |left, right| {
+            left.identity.cmp(&right.identity)
+        })?;
 
-        let mut export_thunks = exports
-            .iter()
-            .zip(export_thunk_objects)
-            .map(|(export, bytes)| ProgramImageExportThunk {
+        let mut export_thunks = Vec::with_capacity(exports.len());
+        for (export, bytes) in exports.iter().zip(export_thunk_objects) {
+            check_cancellation(cancellation)?;
+            export_thunks.push(ProgramImageExportThunk {
                 exported_symbol: export.exported_symbol.clone(),
                 native_symbol: export.native_symbol.clone(),
                 content_digest: bytes_digest(b"rue.program-image.export-thunk\0v1\0", bytes),
-            })
-            .collect::<Vec<_>>();
-        export_thunks.sort_by(|left, right| {
+            });
+        }
+        cancellable_sort_by(&mut export_thunks, cancellation, |left, right| {
             left.exported_symbol
                 .cmp(&right.exported_symbol)
                 .then_with(|| left.native_symbol.cmp(&right.native_symbol))
-        });
-        Self::finish(
+        })?;
+        Self::finish_with_cancellation(
             plan_units,
             export_thunks,
             units.iter().map(|unit| unit.unit.as_ref()),
             options,
+            cancellation,
         )
     }
 
@@ -428,12 +603,33 @@ impl ProgramImagePlan {
         )
     }
 
+    #[cfg_attr(not(test), allow(dead_code))]
     fn finish<'a>(
         plan_units: Vec<ProgramImageUnit>,
         export_thunks: Vec<ProgramImageExportThunk>,
         units: impl IntoIterator<Item = &'a crate::codegen_query::CodegenUnit>,
         options: &CompileOptions,
     ) -> MultiErrorResult<Self> {
+        uncancellable(
+            Self::finish_with_cancellation(
+                plan_units,
+                export_thunks,
+                units,
+                options,
+                &rue_query::CancellationToken::new(),
+            ),
+            "program image plan",
+        )
+    }
+
+    fn finish_with_cancellation<'a>(
+        plan_units: Vec<ProgramImageUnit>,
+        export_thunks: Vec<ProgramImageExportThunk>,
+        units: impl IntoIterator<Item = &'a crate::codegen_query::CodegenUnit>,
+        options: &CompileOptions,
+        cancellation: &rue_query::CancellationToken,
+    ) -> CancellableImageResult<Self> {
+        check_cancellation(cancellation)?;
         let entry_point = if options.target.is_macho() {
             "__main"
         } else {
@@ -443,7 +639,9 @@ impl ProgramImagePlan {
         required_runtime_symbols.insert(entry_point.to_owned());
         required_runtime_symbols.insert(rue_runtime_abi::RUNTIME_ABI_VERSION_SYMBOL.to_owned());
         for unit in units {
+            check_cancellation(cancellation)?;
             for relocation in unit.relocations.iter() {
+                check_cancellation(cancellation)?;
                 let symbol = &relocation.symbol;
                 if rue_runtime_abi::classify_export(symbol).is_some() {
                     required_runtime_symbols.insert(symbol.to_string());
@@ -469,6 +667,7 @@ impl ProgramImagePlan {
         // Both private construction paths validate their raw unit and export
         // identities before translating them into this canonical plan.
         // Retained-plan deltas independently validate both compared plans.
+        check_cancellation(cancellation)?;
         Ok(plan)
     }
 }
@@ -551,24 +750,40 @@ fn validate_program_image_inputs(
     Ok(())
 }
 
-fn validate_rooted_program_image_inputs(
+fn validate_rooted_program_image_inputs_with_cancellation(
     units: &[CollectedObjectProjection],
     exports: &[RootedExportThunk],
-) -> MultiErrorResult<Vec<String>> {
+    cancellation: &rue_query::CancellationToken,
+) -> CancellableImageResult<Vec<String>> {
+    check_cancellation(cancellation)?;
     let mut units_by_identity = BTreeMap::new();
     let mut defined_symbols = BTreeSet::new();
     let mut unit_identities = Vec::with_capacity(units.len());
     for collected in units {
+        check_cancellation(cancellation)?;
         let identity = stable_function_identity(&collected.function);
         if units_by_identity
             .insert(identity.clone(), collected.unit.defined_symbol.as_ref())
             .is_some()
         {
-            return duplicate_plan_input("codegen unit identity", &identity);
+            return Err(
+                CompileErrors::from(CompileError::without_span(ErrorKind::InternalError(
+                    format!("program image has duplicate codegen unit identity `{identity}`"),
+                )))
+                .into(),
+            );
         }
         unit_identities.push(identity);
         if !defined_symbols.insert(collected.unit.defined_symbol.as_ref()) {
-            return duplicate_plan_input("defined symbol", &collected.unit.defined_symbol);
+            return Err(
+                CompileErrors::from(CompileError::without_span(ErrorKind::InternalError(
+                    format!(
+                        "program image has duplicate defined symbol `{}`",
+                        collected.unit.defined_symbol
+                    ),
+                )))
+                .into(),
+            );
         }
     }
     if !units
@@ -579,25 +794,36 @@ fn validate_rooted_program_image_inputs(
     }
     let mut exported_symbols = BTreeSet::new();
     for export in exports {
+        check_cancellation(cancellation)?;
         if !exported_symbols.insert(export.exported_symbol.as_str()) {
-            return duplicate_plan_input("C-ABI export symbol", &export.exported_symbol);
+            return Err(duplicate_plan_input_errors(
+                "C-ABI export symbol",
+                &export.exported_symbol,
+            )
+            .into());
         }
         let identity = stable_function_identity(&export.function);
         let Some(defined) = units_by_identity.get(&identity) else {
-            return Err(CompileErrors::from(CompileError::without_span(
-                ErrorKind::InternalError(format!(
-                    "C-ABI export `{}` has no rooted codegen unit",
-                    export.exported_symbol
-                )),
-            )));
+            return Err(
+                CompileErrors::from(CompileError::without_span(ErrorKind::InternalError(
+                    format!(
+                        "C-ABI export `{}` has no rooted codegen unit",
+                        export.exported_symbol
+                    ),
+                )))
+                .into(),
+            );
         };
         if **defined != export.native_symbol {
-            return Err(CompileErrors::from(CompileError::without_span(
-                ErrorKind::InternalError(format!(
-                    "C-ABI export `{}` names a foreign native symbol",
-                    export.exported_symbol
-                )),
-            )));
+            return Err(
+                CompileErrors::from(CompileError::without_span(ErrorKind::InternalError(
+                    format!(
+                        "C-ABI export `{}` names a foreign native symbol",
+                        export.exported_symbol
+                    ),
+                )))
+                .into(),
+            );
         }
     }
     Ok(unit_identities)
@@ -615,8 +841,12 @@ fn stable_function_identity(function: &crate::FunctionInstanceKey) -> String {
 }
 
 fn duplicate_plan_input<T>(kind: &str, identity: &str) -> MultiErrorResult<T> {
-    Err(CompileErrors::from(CompileError::without_span(
-        ErrorKind::InternalError(format!("program image has duplicate {kind} `{identity}`")),
+    Err(duplicate_plan_input_errors(kind, identity))
+}
+
+fn duplicate_plan_input_errors(kind: &str, identity: &str) -> CompileErrors {
+    CompileErrors::from(CompileError::without_span(ErrorKind::InternalError(
+        format!("program image has duplicate {kind} `{identity}`"),
     )))
 }
 
@@ -697,6 +927,62 @@ impl RuntimeArchiveIdentity {
 mod tests {
     use super::*;
     use rue_air::Node;
+
+    #[test]
+    fn plan_sort_is_stable_and_cancels_after_a_bounded_run() {
+        let input = (0..2_048)
+            .map(|index| (index % 17, index))
+            .rev()
+            .collect::<Vec<_>>();
+        let mut expected = input.clone();
+        expected.sort_by_key(|value| value.0);
+
+        let mut actual = input.clone();
+        cancellable_sort_by(
+            &mut actual,
+            &rue_query::CancellationToken::new(),
+            |left, right| left.0.cmp(&right.0),
+        )
+        .unwrap();
+        assert_eq!(actual, expected);
+
+        let cancellation = rue_query::CancellationToken::new();
+        let cancellation_from_compare = cancellation.clone();
+        let comparisons = std::cell::Cell::new(0_usize);
+        let mut canceled = input;
+        let result = cancellable_sort_by(&mut canceled, &cancellation, |left, right| {
+            let next = comparisons.get() + 1;
+            comparisons.set(next);
+            if next == 300 {
+                cancellation_from_compare.cancel();
+            }
+            left.0.cmp(&right.0)
+        });
+        assert!(matches!(
+            result,
+            Err(crate::session::PipelineRequestControl::Abort(
+                rue_query::QueryAbort::Canceled
+            ))
+        ));
+        assert!(comparisons.get() >= 300);
+        assert!(comparisons.get() < 4_096);
+
+        let precanceled = rue_query::CancellationToken::new();
+        precanceled.cancel();
+        let mut untouched = expected.clone();
+        let comparisons = std::cell::Cell::new(0_usize);
+        let result = cancellable_sort_by(&mut untouched, &precanceled, |left, right| {
+            comparisons.set(comparisons.get() + 1);
+            left.0.cmp(&right.0)
+        });
+        assert!(matches!(
+            result,
+            Err(crate::session::PipelineRequestControl::Abort(
+                rue_query::QueryAbort::Canceled
+            ))
+        ));
+        assert_eq!(comparisons.get(), 0);
+    }
 
     fn image_for(
         source: &str,

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -295,8 +295,13 @@ pub(crate) fn compile_with_session_with_cancellation(
             rue_query::QueryAbort::Canceled,
         ));
     }
-    let output = compile_rooted_with_session(session, snapshot, options, rooted)
-        .map_err(crate::session::PipelineRequestControl::Compile)?;
+    let output = compile_rooted_with_session_with_cancellation(
+        session,
+        snapshot,
+        options,
+        rooted,
+        &cancellation,
+    )?;
     if cancellation.is_canceled() {
         return Err(crate::session::PipelineRequestControl::Abort(
             rue_query::QueryAbort::Canceled,
@@ -315,6 +320,41 @@ pub(crate) fn compile_rooted_with_session(
     options: &CompileOptions,
     rooted: crate::session::RootedCodegenOutput,
 ) -> MultiErrorResult<CompileOutput> {
+    compile_rooted_with_session_with_cancellation(
+        session,
+        snapshot,
+        options,
+        rooted,
+        &rue_query::CancellationToken::new(),
+    )
+    .map_err(|control| match control {
+        crate::session::PipelineRequestControl::Compile(errors) => errors,
+        crate::session::PipelineRequestControl::Abort(abort) => {
+            crate::session::pipeline_abort_errors("compile finalization", abort)
+        }
+        crate::session::PipelineRequestControl::Parked(park) => {
+            crate::session::unresolved_toolchain_park_errors(&park)
+        }
+    })
+}
+
+pub(crate) fn compile_rooted_with_session_with_cancellation(
+    session: &mut CompilerSession,
+    snapshot: &SourceSnapshot,
+    options: &CompileOptions,
+    rooted: crate::session::RootedCodegenOutput,
+    cancellation: &rue_query::CancellationToken,
+) -> Result<CompileOutput, crate::session::PipelineRequestControl> {
+    let check_cancellation = || {
+        if cancellation.is_canceled() {
+            Err(crate::session::PipelineRequestControl::Abort(
+                rue_query::QueryAbort::Canceled,
+            ))
+        } else {
+            Ok(())
+        }
+    };
+    check_cancellation()?;
     let source_tokens = session
         .published_owner()
         .filter(|program| program.belongs_to_exact_snapshot(snapshot))
@@ -323,8 +363,23 @@ pub(crate) fn compile_rooted_with_session(
             CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
                 "compilation snapshot differs from the published parsed program".into(),
             )))
-        })?;
-    let total_source_bytes: usize = snapshot.files().map(|source| source.source.len()).sum();
+        })
+        .map_err(crate::session::PipelineRequestControl::Compile)?;
+    let mut total_source_bytes = 0_usize;
+    let mut total_source_lines = 0_usize;
+    for source in snapshot.files() {
+        check_cancellation()?;
+        total_source_bytes = total_source_bytes.saturating_add(source.source.len());
+        let bytes = source.source.as_bytes();
+        for chunk in bytes.chunks(64 * 1024) {
+            check_cancellation()?;
+            total_source_lines = total_source_lines
+                .saturating_add(chunk.iter().filter(|&&byte| byte == b'\n').count());
+        }
+        if !bytes.is_empty() && !bytes.ends_with(b"\n") {
+            total_source_lines = total_source_lines.saturating_add(1);
+        }
+    }
     let session_work = session.work().clone();
     let metrics = session.unstable_metrics();
     let query_runtime = metrics.query_runtime();
@@ -332,41 +387,39 @@ pub(crate) fn compile_rooted_with_session(
     let provider_observations = crate::unstable::provider_observation_metrics(session);
     let mut output = match rooted.input {
         crate::session::RootedCodegenInput::Structured => {
-            let export_thunk_objects = rooted
-                .exports
-                .iter()
-                .map(|export| {
-                    crate::backend::generate_export_thunk_object(
-                        options.target,
-                        &export.exported_symbol,
-                        &export.native_symbol,
-                        &export.param_types,
-                    )
-                })
-                .collect::<Vec<_>>();
-            crate::linking::link_internal_structured_units_with_warnings(
+            let mut export_thunk_objects = Vec::with_capacity(rooted.exports.len());
+            for export in &rooted.exports {
+                check_cancellation()?;
+                export_thunk_objects.push(crate::backend::generate_export_thunk_object(
+                    options.target,
+                    &export.exported_symbol,
+                    &export.native_symbol,
+                    &export.param_types,
+                ));
+            }
+            crate::linking::link_internal_structured_units_with_warnings_and_cancellation(
                 options,
                 &rooted.units,
                 &export_thunk_objects,
                 &rooted.warnings,
+                cancellation,
             )?
         }
         crate::session::RootedCodegenInput::Projected => {
-            let image = crate::program_image_plan::ProgramImage::from_rooted(
+            let image = crate::program_image_plan::ProgramImage::from_rooted_with_cancellation(
                 rooted.objects,
                 rooted.exports,
                 options,
+                cancellation,
             )?;
-            image.fresh_link(options, &rooted.warnings)?
+            image.fresh_link_with_cancellation(options, &rooted.warnings, cancellation)?
         }
     };
+    check_cancellation()?;
     output.source_stats = SourceStats {
         files: snapshot.len(),
         bytes: total_source_bytes,
-        lines: snapshot
-            .files()
-            .map(|source| source.source.lines().count())
-            .sum(),
+        lines: total_source_lines,
         tokens: source_tokens,
     };
     output.work = PipelineWork {
@@ -381,5 +434,6 @@ pub(crate) fn compile_rooted_with_session(
     output.publication = crate::unstable::PublicationMetrics {
         cone_retention_failures: session.publication_cone_retention_failures(),
     };
+    check_cancellation()?;
     Ok(output)
 }

--- a/crates/rue-linker/src/archive.rs
+++ b/crates/rue-linker/src/archive.rs
@@ -21,6 +21,8 @@ pub struct Archive {
 /// Error type for archive parsing.
 #[derive(Debug)]
 pub enum ArchiveError {
+    /// Cooperative cancellation was requested by the caller.
+    Canceled,
     /// Invalid ar magic number.
     InvalidMagic,
     /// Archive is too short.
@@ -38,6 +40,7 @@ pub enum ArchiveError {
 impl std::fmt::Display for ArchiveError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            ArchiveError::Canceled => write!(f, "archive parsing canceled"),
             ArchiveError::InvalidMagic => write!(f, "invalid ar archive magic"),
             ArchiveError::TooShort => write!(f, "archive too short"),
             ArchiveError::InvalidHeader(s) => write!(f, "invalid archive header: {}", s),
@@ -74,7 +77,7 @@ impl Archive {
     /// Special entries like symbol tables (`/`, `//`, `__.SYMDEF`) are skipped.
     #[must_use = "parsing returns a Result that must be checked"]
     pub fn parse(data: &[u8]) -> Result<Self, ArchiveError> {
-        Self::parse_impl(data, false)
+        Self::parse_impl(data, false, &mut || false)
     }
 
     /// Parse an archive while rejecting malformed members that advertise a
@@ -86,10 +89,25 @@ impl Archive {
     /// however, must parse successfully instead of silently disappearing.
     #[must_use = "parsing returns a Result that must be checked"]
     pub fn parse_strict_objects(data: &[u8]) -> Result<Self, ArchiveError> {
-        Self::parse_impl(data, true)
+        Self::parse_impl(data, true, &mut || false)
     }
 
-    fn parse_impl(data: &[u8], strict_objects: bool) -> Result<Self, ArchiveError> {
+    /// Parse a strict archive with bounded caller-owned cancellation checks.
+    pub fn parse_strict_objects_with_cancellation(
+        data: &[u8],
+        mut cancellation: impl FnMut() -> bool,
+    ) -> Result<Self, ArchiveError> {
+        Self::parse_impl(data, true, &mut cancellation)
+    }
+
+    fn parse_impl(
+        data: &[u8],
+        strict_objects: bool,
+        cancellation: &mut impl FnMut() -> bool,
+    ) -> Result<Self, ArchiveError> {
+        if cancellation() {
+            return Err(ArchiveError::Canceled);
+        }
         // Check magic
         if data.len() < AR_MAGIC.len() {
             return Err(ArchiveError::TooShort);
@@ -102,6 +120,9 @@ impl Archive {
         let mut offset = AR_MAGIC.len();
 
         loop {
+            if cancellation() {
+                return Err(ArchiveError::Canceled);
+            }
             let header_end = checked_offset_add(offset, HEADER_SIZE)?;
             if header_end > data.len() {
                 if strict_objects && offset != data.len() {
@@ -192,8 +213,9 @@ impl Archive {
 
             // Try to parse as object file (ELF or Mach-O).
             // Non-object members (e.g., LLVM bitcode files from LTO builds) are skipped.
-            match ObjectFile::parse(member_data) {
+            match ObjectFile::parse_with_cancellation(member_data, &mut *cancellation) {
                 Ok(obj) => objects.push(obj),
+                Err(crate::elf::ParseError::Canceled) => return Err(ArchiveError::Canceled),
                 Err(source) if strict_objects && looks_like_native_object(member_data) => {
                     return Err(ArchiveError::ObjectMemberParse {
                         member: actual_name,
@@ -249,6 +271,51 @@ fn looks_like_native_object(data: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rue_target::Target;
+
+    #[test]
+    fn strict_archive_parse_observes_cancellation_between_members() {
+        let mut checks = 0_usize;
+        let result = Archive::parse_strict_objects_with_cancellation(AR_MAGIC, || {
+            checks += 1;
+            checks == 2
+        });
+
+        assert!(matches!(result, Err(ArchiveError::Canceled)));
+        assert_eq!(checks, 2);
+    }
+
+    #[test]
+    fn strict_single_large_member_parse_has_byte_bounded_cancellation() {
+        let object = crate::ObjectBuilder::new(Target::X86_64Linux, "large")
+            .code(vec![0_u8; 4 * 1024 * 1024])
+            .build();
+        let header = format!(
+            "{:<16}{:<12}{:<6}{:<6}{:<8}{:<10}`\n",
+            "large.o/",
+            "0",
+            "0",
+            "0",
+            "644",
+            object.len()
+        );
+        assert_eq!(header.len(), HEADER_SIZE);
+        let mut archive = AR_MAGIC.to_vec();
+        archive.extend_from_slice(header.as_bytes());
+        archive.extend_from_slice(&object);
+        if archive.len() % 2 == 1 {
+            archive.push(b'\n');
+        }
+
+        let mut checkpoints = 0_usize;
+        let result = Archive::parse_strict_objects_with_cancellation(&archive, || {
+            checkpoints += 1;
+            checkpoints == 32
+        });
+
+        assert!(matches!(result, Err(ArchiveError::Canceled)));
+        assert_eq!(checkpoints, 32);
+    }
 
     #[test]
     fn test_invalid_magic() {

--- a/crates/rue-linker/src/elf.rs
+++ b/crates/rue-linker/src/elf.rs
@@ -143,6 +143,126 @@ fn read_cstring(data: &[u8]) -> String {
     String::from_utf8_lossy(&data[..end]).to_string()
 }
 
+fn check_parse_cancellation(cancellation: &mut impl FnMut() -> bool) -> Result<(), ParseError> {
+    if cancellation() {
+        Err(ParseError::Canceled)
+    } else {
+        Ok(())
+    }
+}
+
+fn clone_bytes_with_cancellation(
+    data: &[u8],
+    cancellation: &mut impl FnMut() -> bool,
+) -> Result<Vec<u8>, ParseError> {
+    let mut bytes = Vec::with_capacity(data.len());
+    for chunk in data.chunks(64 * 1024) {
+        check_parse_cancellation(cancellation)?;
+        bytes.extend_from_slice(chunk);
+    }
+    Ok(bytes)
+}
+
+fn read_cstring_with_cancellation(
+    data: &[u8],
+    cancellation: &mut impl FnMut() -> bool,
+) -> Result<String, ParseError> {
+    let mut end = 0;
+    for chunk in data.chunks(64 * 1024) {
+        check_parse_cancellation(cancellation)?;
+        if let Some(relative) = chunk.iter().position(|&byte| byte == 0) {
+            end += relative;
+            break;
+        }
+        end += chunk.len();
+    }
+    let bytes = &data[..end];
+    let mut output = String::with_capacity(bytes.len());
+    let mut offset = 0_usize;
+    while offset < bytes.len() {
+        check_parse_cancellation(cancellation)?;
+        let mut chunk_end = bytes.len().min(offset.saturating_add(64 * 1024));
+        loop {
+            match std::str::from_utf8(&bytes[offset..chunk_end]) {
+                Ok(valid) => {
+                    output.push_str(valid);
+                    offset = chunk_end;
+                    break;
+                }
+                Err(error) => {
+                    let valid_end = offset + error.valid_up_to();
+                    if let Some(error_len) = error.error_len() {
+                        // SAFETY: `valid_up_to` identifies the valid UTF-8 prefix.
+                        output.push_str(unsafe {
+                            std::str::from_utf8_unchecked(&bytes[offset..valid_end])
+                        });
+                        output.push('\u{FFFD}');
+                        offset = valid_end + error_len;
+                        break;
+                    }
+                    if chunk_end == bytes.len() {
+                        // SAFETY: `valid_up_to` identifies the valid UTF-8 prefix.
+                        output.push_str(unsafe {
+                            std::str::from_utf8_unchecked(&bytes[offset..valid_end])
+                        });
+                        output.push('\u{FFFD}');
+                        offset = bytes.len();
+                        break;
+                    }
+                    // Complete a scalar split at the artificial chunk edge.
+                    // Rechecking at most a few extra bytes preserves the exact
+                    // whole-slice lossy conversion while remaining bounded.
+                    chunk_end = bytes.len().min(chunk_end.saturating_add(3));
+                }
+            }
+        }
+    }
+    Ok(output)
+}
+
+fn read_utf8_cstring_with_cancellation(
+    data: &[u8],
+    offset: usize,
+    cancellation: &mut impl FnMut() -> bool,
+) -> Result<String, ParseError> {
+    if offset > data.len() {
+        return Err(ParseError::InvalidStringTable);
+    }
+    let mut end = offset;
+    for chunk in data[offset..].chunks(64 * 1024) {
+        check_parse_cancellation(cancellation)?;
+        if let Some(relative) = chunk.iter().position(|&byte| byte == 0) {
+            end += relative;
+            break;
+        }
+        end += chunk.len();
+    }
+    let bytes = clone_bytes_with_cancellation(&data[offset..end], cancellation)?;
+    let mut validated = 0_usize;
+    while validated < bytes.len() {
+        check_parse_cancellation(cancellation)?;
+        let mut chunk_end = bytes.len().min(validated.saturating_add(64 * 1024));
+        loop {
+            match std::str::from_utf8(&bytes[validated..chunk_end]) {
+                Ok(_) => break,
+                Err(error) if error.error_len().is_some() || chunk_end == bytes.len() => {
+                    return Err(ParseError::InvalidStringTable);
+                }
+                Err(_) => {
+                    // The chunk ended inside a valid scalar. Extend by at most
+                    // the UTF-8 continuation width so validation remains
+                    // byte-bounded without changing whole-string semantics.
+                    chunk_end = bytes.len().min(chunk_end.saturating_add(3));
+                }
+            }
+        }
+        validated = chunk_end;
+    }
+    check_parse_cancellation(cancellation)?;
+    // Every byte range above was validated from a scalar boundary.
+    Ok(unsafe { String::from_utf8_unchecked(bytes) })
+}
+
 /// A parsed ELF64 relocatable object file.
 #[derive(Debug)]
 pub struct ObjectFile {
@@ -545,6 +665,8 @@ impl RelocationType {
 /// Error type for object file parsing.
 #[derive(Debug)]
 pub enum ParseError {
+    /// Cooperative cancellation was requested by the caller.
+    Canceled,
     /// File is too short.
     TooShort,
     /// Invalid ELF magic number.
@@ -580,6 +702,7 @@ pub enum ParseError {
 impl std::fmt::Display for ParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            ParseError::Canceled => write!(f, "object parsing canceled"),
             ParseError::TooShort => write!(f, "file is too short to be a valid object file"),
             ParseError::InvalidMagic => write!(f, "invalid ELF magic number"),
             ParseError::Not64Bit => write!(f, "not a 64-bit ELF file"),
@@ -614,6 +737,15 @@ impl ObjectFile {
     /// to the appropriate parser.
     #[must_use = "parsing returns a Result that must be checked"]
     pub fn parse(data: &[u8]) -> Result<Self, ParseError> {
+        Self::parse_with_cancellation(data, || false)
+    }
+
+    /// Parse an object with bounded caller-owned cancellation checkpoints.
+    pub fn parse_with_cancellation(
+        data: &[u8],
+        mut cancellation: impl FnMut() -> bool,
+    ) -> Result<Self, ParseError> {
+        check_parse_cancellation(&mut cancellation)?;
         // Need at least 4 bytes to check magic
         if data.len() < 4 {
             return Err(ParseError::TooShort);
@@ -621,9 +753,9 @@ impl ObjectFile {
 
         // Dispatch based on magic bytes
         if data[0..4] == ELF_MAGIC {
-            Self::parse_elf(data)
+            Self::parse_elf(data, &mut cancellation)
         } else if data.len() >= 4 && read_u32(data, 0) == MH_MAGIC_64 {
-            Self::parse_macho(data)
+            Self::parse_macho(data, &mut cancellation)
         } else {
             Err(ParseError::UnknownFormat)
         }
@@ -632,7 +764,10 @@ impl ObjectFile {
     /// Parse a Mach-O 64-bit relocatable object file.
     ///
     /// Extracts sections, symbols, and relocations from a Mach-O object file.
-    fn parse_macho(data: &[u8]) -> Result<Self, ParseError> {
+    fn parse_macho(
+        data: &[u8],
+        cancellation: &mut impl FnMut() -> bool,
+    ) -> Result<Self, ParseError> {
         // Minimum size check for Mach-O header
         if data.len() < MACHO64_HEADER_SIZE {
             return Err(ParseError::TooShort);
@@ -681,6 +816,7 @@ impl ObjectFile {
 
         let mut cmd_offset = MACHO64_HEADER_SIZE;
         for _ in 0..ncmds {
+            check_parse_cancellation(cancellation)?;
             if cmd_offset + 8 > data.len() {
                 return Err(ParseError::TooShort);
             }
@@ -704,6 +840,7 @@ impl ObjectFile {
                     // Parse sections in this segment
                     let mut sect_offset = cmd_offset + MACHO64_SEGMENT_CMD_SIZE;
                     for _ in 0..nsects {
+                        check_parse_cancellation(cancellation)?;
                         if sect_offset + MACHO64_SECTION_SIZE > data.len() {
                             return Err(ParseError::TooShort);
                         }
@@ -777,7 +914,7 @@ impl ObjectFile {
                             if end > data.len() {
                                 return Err(ParseError::SectionOutOfBounds(full_name.clone()));
                             }
-                            data[offset..end].to_vec()
+                            clone_bytes_with_cancellation(&data[offset..end], cancellation)?
                         } else {
                             Vec::new()
                         };
@@ -852,6 +989,7 @@ impl ObjectFile {
             let strtab = &data[strtab_offset..strtab_end];
 
             for i in 0..symtab_count {
+                check_parse_cancellation(cancellation)?;
                 let sym_offset = symtab_offset + i * MACHO64_NLIST_SIZE;
 
                 // nlist_64 structure:
@@ -868,7 +1006,7 @@ impl ObjectFile {
 
                 // Read symbol name from string table
                 let mut name = if n_strx < strtab.len() {
-                    read_cstring(&strtab[n_strx..])
+                    read_cstring_with_cancellation(&strtab[n_strx..], cancellation)?
                 } else {
                     String::new()
                 };
@@ -966,6 +1104,7 @@ impl ObjectFile {
 
         // Parse relocations for each section
         for (section_index, nreloc, reloff) in section_reloc_info {
+            check_parse_cancellation(cancellation)?;
             if nreloc == 0 {
                 continue;
             }
@@ -989,6 +1128,7 @@ impl ObjectFile {
             let mut pending_addend: i64 = 0;
 
             for i in 0..nreloc {
+                check_parse_cancellation(cancellation)?;
                 let rel_offset = reloff + i * MACHO64_RELOC_SIZE;
 
                 // relocation_info structure:
@@ -1144,7 +1284,8 @@ impl ObjectFile {
     }
 
     /// Parse an ELF64 relocatable object file.
-    fn parse_elf(data: &[u8]) -> Result<Self, ParseError> {
+    fn parse_elf(data: &[u8], cancellation: &mut impl FnMut() -> bool) -> Result<Self, ParseError> {
+        check_parse_cancellation(cancellation)?;
         // Check minimum size for ELF header
         if data.len() < ELF64_EHDR_SIZE {
             return Err(ParseError::TooShort);
@@ -1221,6 +1362,7 @@ impl ObjectFile {
         let mut raw_sections = Vec::with_capacity(section_capacity);
 
         for i in 0..e_shnum {
+            check_parse_cancellation(cancellation)?;
             let sh_offset = e_shoff + i * e_shentsize;
             if sh_offset + e_shentsize > data.len() {
                 return Err(ParseError::InvalidSection(
@@ -1273,29 +1415,14 @@ impl ObjectFile {
         }
         let shstrtab_data = &data[shstrtab.offset as usize..shstrtab_end as usize];
 
-        // Helper to read null-terminated string.
-        //
-        // `offset` is a file-controlled u32 (a symbol's `st_name` or a section's
-        // `sh_name`), so it must be checked against the table before slicing:
-        // Rust panics on a range whose START is past the slice, and a malformed
-        // object must produce an Err, not a panic (RUE-1645). An offset exactly
-        // at the end is the empty name and stays valid.
-        let read_string = |strtab: &[u8], offset: usize| -> Result<String, ParseError> {
-            if offset > strtab.len() {
-                return Err(ParseError::InvalidStringTable);
-            }
-            let start = offset;
-            let mut end = start;
-            while end < strtab.len() && strtab[end] != 0 {
-                end += 1;
-            }
-            String::from_utf8(strtab[start..end].to_vec())
-                .map_err(|_| ParseError::InvalidStringTable)
-        };
-
         // Second pass: create sections with names
         for (i, raw) in raw_sections.iter().enumerate() {
-            let name = read_string(shstrtab_data, raw.name_offset as usize)?;
+            check_parse_cancellation(cancellation)?;
+            let name = read_utf8_cstring_with_cancellation(
+                shstrtab_data,
+                raw.name_offset as usize,
+                cancellation,
+            )?;
 
             // Skip null section, symtab, strtab, rela sections (we'll handle them separately)
             if raw.sh_type == SHT_NULL
@@ -1329,7 +1456,10 @@ impl ObjectFile {
                 if section_end as usize > data.len() {
                     return Err(ParseError::SectionOutOfBounds(name.clone()));
                 }
-                data[raw.offset as usize..section_end as usize].to_vec()
+                clone_bytes_with_cancellation(
+                    &data[raw.offset as usize..section_end as usize],
+                    cancellation,
+                )?
             } else {
                 Vec::new()
             };
@@ -1409,6 +1539,7 @@ impl ObjectFile {
                 }
             }
             for i in 0..sym_count {
+                check_parse_cancellation(cancellation)?;
                 let sym_offset = (i * symtab.entsize) as usize;
                 if sym_offset + ELF64_SYM_SIZE > symtab_data.len() {
                     return Err(ParseError::InvalidSymbol(
@@ -1425,7 +1556,11 @@ impl ObjectFile {
                 let st_value = read_u64(sym, 8);
                 let st_size = read_u64(sym, 16);
 
-                let mut name = read_string(strtab_data, st_name as usize)?;
+                let mut name = read_utf8_cstring_with_cancellation(
+                    strtab_data,
+                    st_name as usize,
+                    cancellation,
+                )?;
 
                 // For section symbols (STT_SECTION), the name in the string table is empty.
                 // Use the section name instead, which is needed for resolving relocations
@@ -1438,7 +1573,11 @@ impl ObjectFile {
                 {
                     // Get the section name
                     let sec = &raw_sections[st_shndx as usize];
-                    if let Ok(section_name) = read_string(shstrtab_data, sec.name_offset as usize) {
+                    if let Ok(section_name) = read_utf8_cstring_with_cancellation(
+                        shstrtab_data,
+                        sec.name_offset as usize,
+                        cancellation,
+                    ) {
                         name = section_name;
                     }
                 }
@@ -1486,6 +1625,7 @@ impl ObjectFile {
 
         // Parse relocations
         for raw in raw_sections.iter() {
+            check_parse_cancellation(cancellation)?;
             if raw.sh_type != SHT_RELA {
                 continue;
             }
@@ -1518,6 +1658,7 @@ impl ObjectFile {
             }
 
             for j in 0..rela_count {
+                check_parse_cancellation(cancellation)?;
                 let rela_offset = (j * raw.entsize) as usize;
                 if rela_offset + ELF64_RELA_SIZE > rela_data.len() {
                     return Err(ParseError::RelocationOutOfBounds);
@@ -1575,6 +1716,46 @@ impl ObjectFile {
 mod tests {
     use super::*;
     use crate::constants::{EI_CLASS, EI_DATA, EI_VERSION, ELF64_SHDR_SIZE as TEST_SHDR_SIZE};
+
+    #[test]
+    fn chunked_cstring_conversion_matches_whole_slice_at_utf8_boundaries() {
+        const CHUNK: usize = 64 * 1024;
+        for suffix in [
+            "€tail".as_bytes(),
+            &[0xE2, 0x28, 0xA1, b'x'][..],
+            &[0xF0, 0x9F, 0x92][..],
+        ] {
+            let mut data = vec![b'a'; CHUNK - 1];
+            data.extend_from_slice(suffix);
+            data.push(0);
+            data.extend_from_slice(b"ignored");
+            let expected_end = data.iter().position(|byte| *byte == 0).unwrap();
+            let expected = String::from_utf8_lossy(&data[..expected_end]);
+            assert_eq!(
+                read_cstring_with_cancellation(&data, &mut || false).unwrap(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn strict_chunked_cstring_preserves_utf8_boundary_validation() {
+        const CHUNK: usize = 64 * 1024;
+        let mut valid = vec![b'a'; CHUNK - 1];
+        valid.extend_from_slice("€tail".as_bytes());
+        valid.push(0);
+        assert_eq!(
+            read_utf8_cstring_with_cancellation(&valid, 0, &mut || false).unwrap(),
+            std::str::from_utf8(&valid[..valid.len() - 1]).unwrap()
+        );
+
+        let mut invalid = vec![b'a'; CHUNK - 1];
+        invalid.extend_from_slice(&[0xE2, 0x28, 0xA1, 0]);
+        assert!(matches!(
+            read_utf8_cstring_with_cancellation(&invalid, 0, &mut || false),
+            Err(ParseError::InvalidStringTable)
+        ));
+    }
 
     #[test]
     fn structured_object_preserves_arc_atom_ownership() {

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -214,8 +214,12 @@ fn checked_relocation_offset(
 /// A zero-size symbol may point exactly one byte past the final section byte
 /// (the conventional end-marker position). Any nonzero extent must remain
 /// wholly inside the defining section.
-fn validate_defined_symbols(obj: &LinkObject) -> Result<(), LinkError> {
+fn validate_defined_symbols(
+    obj: &LinkObject,
+    cancellation: &mut impl FnMut() -> bool,
+) -> Result<(), LinkError> {
     for sym in &obj.symbols {
+        check_cancellation(cancellation)?;
         let Some(section_index) = sym.section_index else {
             continue;
         };
@@ -712,8 +716,10 @@ fn collect_section_relocations(
     obj_idx: usize,
     home: PatchHome,
     pending: &mut Vec<PendingRelocation>,
+    cancellation: &mut impl FnMut() -> bool,
 ) -> Result<(), LinkError> {
     for reloc in &section.relocations {
+        check_cancellation(cancellation)?;
         // Validate symbol index before accessing
         if reloc.symbol_index >= obj.symbols.len() {
             return Err(LinkError::InvalidSymbolIndex {
@@ -808,9 +814,19 @@ impl SymbolAddresses {
     }
 }
 
+fn check_cancellation(cancellation: &mut impl FnMut() -> bool) -> Result<(), LinkError> {
+    if cancellation() {
+        Err(LinkError::Canceled)
+    } else {
+        Ok(())
+    }
+}
+
 /// Linker errors.
 #[derive(Debug)]
 pub enum LinkError {
+    /// Cooperative cancellation was requested by the caller.
+    Canceled,
     /// Undefined symbol reference.
     UndefinedSymbol(String),
     /// Duplicate symbol definition.
@@ -870,6 +886,7 @@ pub enum LinkError {
 impl std::fmt::Display for LinkError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            LinkError::Canceled => write!(f, "link canceled"),
             LinkError::UndefinedSymbol(s) => write!(f, "undefined symbol: {}", s),
             LinkError::DuplicateSymbol(s) => write!(f, "duplicate symbol: {}", s),
             LinkError::ArchMismatch {
@@ -991,16 +1008,67 @@ impl LinkSection {
         self.content_len
     }
 
-    fn extend_contents(&self, output: &mut Vec<u8>) {
+    fn extend_contents(
+        &self,
+        output: &mut Vec<u8>,
+        cancellation: &mut impl FnMut() -> bool,
+    ) -> Result<(), LinkError> {
         match &self.content {
-            LinkSectionContent::Bytes(bytes) => output.extend_from_slice(bytes),
+            LinkSectionContent::Bytes(bytes) => {
+                extend_bytes_with_cancellation(output, bytes, cancellation)?
+            }
             LinkSectionContent::Atoms(atoms) => {
                 for atom in atoms.iter() {
-                    output.extend_from_slice(atom);
+                    extend_bytes_with_cancellation(output, atom, cancellation)?;
                 }
             }
         }
+        Ok(())
     }
+}
+
+fn extend_bytes_with_cancellation(
+    output: &mut Vec<u8>,
+    bytes: &[u8],
+    cancellation: &mut impl FnMut() -> bool,
+) -> Result<(), LinkError> {
+    for chunk in bytes.chunks(64 * 1024) {
+        check_cancellation(cancellation)?;
+        output.extend_from_slice(chunk);
+    }
+    Ok(())
+}
+
+fn resize_with_cancellation(
+    output: &mut Vec<u8>,
+    new_len: usize,
+    value: u8,
+    cancellation: &mut impl FnMut() -> bool,
+) -> Result<(), LinkError> {
+    while output.len() < new_len {
+        check_cancellation(cancellation)?;
+        let chunk_end = new_len.min(output.len().saturating_add(64 * 1024));
+        output.resize(chunk_end, value);
+    }
+    Ok(())
+}
+
+fn extend_pattern_with_cancellation(
+    output: &mut Vec<u8>,
+    pattern: &[u8],
+    byte_count: usize,
+    cancellation: &mut impl FnMut() -> bool,
+) -> Result<(), LinkError> {
+    let mut remaining = byte_count;
+    while remaining > 0 {
+        check_cancellation(cancellation)?;
+        let chunk = remaining.min(64 * 1024);
+        for index in 0..chunk {
+            output.push(pattern[index % pattern.len()]);
+        }
+        remaining -= chunk;
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone)]
@@ -1093,6 +1161,16 @@ impl Linker {
 
     /// Add an object file to be linked.
     pub fn add_object(&mut self, obj: ObjectFile) -> Result<(), LinkError> {
+        self.add_object_with_cancellation(obj, &mut || false)
+    }
+
+    /// Add a parsed object with bounded cooperative cancellation checkpoints.
+    pub fn add_object_with_cancellation(
+        &mut self,
+        obj: ObjectFile,
+        cancellation: &mut impl FnMut() -> bool,
+    ) -> Result<(), LinkError> {
+        check_cancellation(cancellation)?;
         // Refuse objects compiled for a different architecture — without this
         // check an "aarch64" binary could silently embed x86 machine code
         // (confirmed during the linker review: 22 x86 syscalls linked into an
@@ -1108,16 +1186,21 @@ impl Linker {
             });
         }
 
-        self.add_link_object(LinkObject::from(obj))
+        self.add_link_object(LinkObject::from(obj), cancellation)
     }
 
-    fn add_link_object(&mut self, obj: LinkObject) -> Result<(), LinkError> {
-        validate_defined_symbols(&obj)?;
+    fn add_link_object(
+        &mut self,
+        obj: LinkObject,
+        cancellation: &mut impl FnMut() -> bool,
+    ) -> Result<(), LinkError> {
+        validate_defined_symbols(&obj, cancellation)?;
 
         let obj_index = self.objects.len();
 
         // Collect global symbols
         for sym in &obj.symbols {
+            check_cancellation(cancellation)?;
             if provides_definition(sym) {
                 if let Some((_, existing)) = self.global_symbols.get(&sym.name) {
                     // Two strong definitions collide; weak symbols defer.
@@ -1153,6 +1236,16 @@ impl Linker {
         &mut self,
         obj: crate::elf::StructuredObject,
     ) -> Result<(), LinkError> {
+        self.add_structured_object_with_cancellation(obj, &mut || false)
+    }
+
+    /// Add a compiler-owned structured object with bounded cancellation.
+    pub fn add_structured_object_with_cancellation(
+        &mut self,
+        obj: crate::elf::StructuredObject,
+        cancellation: &mut impl FnMut() -> bool,
+    ) -> Result<(), LinkError> {
+        check_cancellation(cancellation)?;
         let expected = match self.target {
             Target::X86_64Linux => crate::elf::ElfMachine::X86_64,
             Target::Aarch64Linux | Target::Aarch64Macos => crate::elf::ElfMachine::Aarch64,
@@ -1174,7 +1267,7 @@ impl Linker {
                 target: format!("{:?}", self.target),
             });
         }
-        self.add_link_object(LinkObject::from(obj))
+        self.add_link_object(LinkObject::from(obj), cancellation)
     }
 
     /// Add objects from an ar archive selectively based on symbol resolution.
@@ -1209,6 +1302,16 @@ impl Linker {
     /// single-function objects, so a per-round walk of every linked symbol table
     /// was quadratic in the size of the link.
     pub fn add_archive(&mut self, archive: Archive) -> Result<(), LinkError> {
+        self.add_archive_with_cancellation(archive, &mut || false)
+    }
+
+    /// Add an archive while observing caller-owned cooperative cancellation.
+    pub fn add_archive_with_cancellation(
+        &mut self,
+        archive: Archive,
+        cancellation: &mut impl FnMut() -> bool,
+    ) -> Result<(), LinkError> {
+        check_cancellation(cancellation)?;
         // Convert to a Vec we can index into
         let archive_objects: Vec<ObjectFile> = archive.objects.into_iter().collect();
 
@@ -1226,7 +1329,9 @@ impl Linker {
             // independent of hash iteration order.
             let mut symbol_providers: AHashMap<&str, Vec<usize>> = AHashMap::new();
             for (obj_idx, obj) in archive_objects.iter().enumerate() {
+                check_cancellation(cancellation)?;
                 for sym in &obj.symbols {
+                    check_cancellation(cancellation)?;
                     if provides_definition(sym) {
                         symbol_providers.entry(&sym.name).or_default().push(obj_idx);
                     }
@@ -1257,7 +1362,9 @@ impl Linker {
                 enqueue_undefined(name, &mut pending, &mut queued);
             }
             for obj in &self.objects {
+                check_cancellation(cancellation)?;
                 for sym in &obj.symbols {
+                    check_cancellation(cancellation)?;
                     if references_undefined(sym) {
                         enqueue_undefined(&sym.name, &mut pending, &mut queued);
                     }
@@ -1265,6 +1372,7 @@ impl Linker {
             }
 
             while let Some(name) = pending.pop_front() {
+                check_cancellation(cancellation)?;
                 // A member pulled in for an earlier reference may have defined
                 // this symbol in the meantime; an already-satisfied symbol
                 // extracts nothing (RUE-848).
@@ -1287,6 +1395,7 @@ impl Linker {
                 // own references join the worklist — the transitive step the
                 // fixed-point rescan used to perform.
                 for sym in &archive_objects[obj_idx].symbols {
+                    check_cancellation(cancellation)?;
                     if provides_definition(sym) {
                         defined.insert(&sym.name);
                     }
@@ -1301,8 +1410,9 @@ impl Linker {
 
         // Now actually add the selected objects
         for (idx, obj) in archive_objects.into_iter().enumerate() {
+            check_cancellation(cancellation)?;
             if selected[idx] {
-                self.add_object(obj)?;
+                self.add_object_with_cancellation(obj, cancellation)?;
             }
         }
 
@@ -1315,10 +1425,21 @@ impl Linker {
     /// the target platform.
     #[must_use = "linking returns a Result that must be checked"]
     pub fn link(self, entry_point: &str) -> Result<Vec<u8>, LinkError> {
+        self.link_with_cancellation(entry_point, || false)
+    }
+
+    /// Link all objects with bounded cooperative cancellation checkpoints.
+    #[must_use = "linking returns a Result that must be checked"]
+    pub fn link_with_cancellation(
+        self,
+        entry_point: &str,
+        mut cancellation: impl FnMut() -> bool,
+    ) -> Result<Vec<u8>, LinkError> {
+        check_cancellation(&mut cancellation)?;
         if self.target.is_macho() {
-            self.link_macho(entry_point)
+            self.link_macho(entry_point, &mut cancellation)
         } else {
-            self.link_elf(entry_point)
+            self.link_elf(entry_point, &mut cancellation)
         }
     }
 
@@ -1326,7 +1447,11 @@ impl Linker {
     ///
     /// This generates a dynamic executable using LC_MAIN that can run on macOS
     /// after ad-hoc code signing with `codesign -s - <binary>`.
-    fn link_macho(self, entry_point: &str) -> Result<Vec<u8>, LinkError> {
+    fn link_macho(
+        self,
+        entry_point: &str,
+        cancellation: &mut impl FnMut() -> bool,
+    ) -> Result<Vec<u8>, LinkError> {
         use crate::constants::{VM_PROT_EXECUTE, VM_PROT_READ};
         use crate::macho::{ImageSizes, MachOBuilder, Section64, Segment64, VM_BASE};
 
@@ -1344,6 +1469,7 @@ impl Linker {
 
         // Merge code sections (.text* / __text)
         for (obj_idx, obj) in self.objects.iter().enumerate() {
+            check_cancellation(cancellation)?;
             for (sec_idx, section) in obj.sections.iter().enumerate() {
                 if !is_text_section(&section.name) || section.content_len() == 0 {
                     continue;
@@ -1355,17 +1481,16 @@ impl Linker {
                 let aligned_len = align_up(current_len, align);
                 let padding = (aligned_len - current_len) as usize;
                 // Use BRK #0 (0x00, 0x00, 0x20, 0xD4) as padding for ARM64
-                for _ in 0..padding / 4 {
-                    merged_text.extend_from_slice(&[0x00, 0x00, 0x20, 0xD4]);
-                }
-                // Handle non-aligned padding
-                for _ in 0..(padding % 4) {
-                    merged_text.push(0x00);
-                }
+                extend_pattern_with_cancellation(
+                    &mut merged_text,
+                    &[0x00, 0x00, 0x20, 0xD4],
+                    padding,
+                    cancellation,
+                )?;
 
                 let offset = merged_text.len() as u64;
                 section_offsets.insert((obj_idx, sec_idx), offset);
-                section.extend_contents(&mut merged_text);
+                section.extend_contents(&mut merged_text, cancellation)?;
 
                 collect_section_relocations(
                     obj,
@@ -1374,6 +1499,7 @@ impl Linker {
                     obj_idx,
                     PatchHome::Text,
                     &mut pending_relocations,
+                    cancellation,
                 )?;
             }
         }
@@ -1384,6 +1510,7 @@ impl Linker {
         // is Text and their relocations are applied against that base.
         // (RUE-131 items 8 and 11)
         for (obj_idx, obj) in self.objects.iter().enumerate() {
+            check_cancellation(cancellation)?;
             for (sec_idx, section) in obj.sections.iter().enumerate() {
                 if !is_rodata_section(&section.name) {
                     continue;
@@ -1394,11 +1521,12 @@ impl Linker {
                 // Align rodata (8-byte alignment is common for data)
                 let align = section.align.max(8);
                 let padding = align_up(merged_text.len() as u64, align) - merged_text.len() as u64;
-                merged_text.resize(merged_text.len() + padding as usize, 0);
+                let new_len = merged_text.len() + padding as usize;
+                resize_with_cancellation(&mut merged_text, new_len, 0, cancellation)?;
 
                 let offset = merged_text.len() as u64;
                 section_offsets.insert((obj_idx, sec_idx), offset);
-                section.extend_contents(&mut merged_text);
+                section.extend_contents(&mut merged_text, cancellation)?;
 
                 collect_section_relocations(
                     obj,
@@ -1407,6 +1535,7 @@ impl Linker {
                     obj_idx,
                     PatchHome::Text,
                     &mut pending_relocations,
+                    cancellation,
                 )?;
             }
         }
@@ -1415,6 +1544,7 @@ impl Linker {
         // buffer — patching them against merged_text bounds/contents was
         // RUE-131 item 8; the ELF side got the same fix via PatchHome in #928)
         for (obj_idx, obj) in self.objects.iter().enumerate() {
+            check_cancellation(cancellation)?;
             for (sec_idx, section) in obj.sections.iter().enumerate() {
                 if !is_data_section(&section.name) || section.content_len() == 0 {
                     continue;
@@ -1422,11 +1552,12 @@ impl Linker {
 
                 let align = section.align.max(1);
                 let padding = align_up(merged_data.len() as u64, align) - merged_data.len() as u64;
-                merged_data.resize(merged_data.len() + padding as usize, 0);
+                let new_len = merged_data.len() + padding as usize;
+                resize_with_cancellation(&mut merged_data, new_len, 0, cancellation)?;
 
                 let offset = merged_data.len() as u64;
                 section_offsets.insert((obj_idx, sec_idx), offset);
-                section.extend_contents(&mut merged_data);
+                section.extend_contents(&mut merged_data, cancellation)?;
 
                 collect_section_relocations(
                     obj,
@@ -1435,6 +1566,7 @@ impl Linker {
                     obj_idx,
                     PatchHome::Data,
                     &mut pending_relocations,
+                    cancellation,
                 )?;
             }
         }
@@ -1444,6 +1576,7 @@ impl Linker {
         // at least as strictly as the strictest section in it (RUE-1646).
         let mut max_bss_align: u64 = 1;
         for (obj_idx, obj) in self.objects.iter().enumerate() {
+            check_cancellation(cancellation)?;
             for (sec_idx, section) in obj.sections.iter().enumerate() {
                 if !is_bss_section(&section.name) {
                     continue;
@@ -1469,7 +1602,8 @@ impl Linker {
             let bss_base_align = max_bss_align.max(8);
             let bss_base_padding =
                 align_up(merged_data.len() as u64, bss_base_align) - merged_data.len() as u64;
-            merged_data.resize(merged_data.len() + bss_base_padding as usize, 0);
+            let new_len = merged_data.len() + bss_base_padding as usize;
+            resize_with_cancellation(&mut merged_data, new_len, 0, cancellation)?;
         }
 
         // Compute the final file/VM layout before placing symbols, using the
@@ -1527,6 +1661,7 @@ impl Linker {
         let mut symbol_addresses = SymbolAddresses::default();
 
         for (obj_idx, obj) in self.objects.iter().enumerate() {
+            check_cancellation(cancellation)?;
             for sym in &obj.symbols {
                 if sym.name.is_empty() {
                     continue;
@@ -1612,6 +1747,7 @@ impl Linker {
             home,
         } in pending_relocations
         {
+            check_cancellation(cancellation)?;
             // Pick the buffer the patch site lives in and its base vaddr.
             // (PatchHome::Rodata is unused here: Mach-O merges rodata into
             // the text buffer.)
@@ -1697,6 +1833,7 @@ impl Linker {
         }
 
         drop(relocate_span);
+        check_cancellation(cancellation)?;
         let _emit_span = info_span!("link_emit").entered();
 
         // Now build the binary with the relocated code.
@@ -1722,7 +1859,9 @@ impl Linker {
         builder.add_segment(text_segment);
 
         // Build as dynamic executable (uses LC_MAIN + dyld)
-        let (bytes, calculated_offset, _data_vm_addr) = builder.build_dynamic();
+        let (bytes, calculated_offset, _data_vm_addr) = builder
+            .build_dynamic_with_cancellation(cancellation)
+            .ok_or(LinkError::Canceled)?;
 
         // Verify our pre-calculated offset matches (sanity check)
         if text_file_offset != calculated_offset {
@@ -1737,7 +1876,11 @@ impl Linker {
     }
 
     /// Link all objects and produce an ELF executable.
-    fn link_elf(self, entry_point: &str) -> Result<Vec<u8>, LinkError> {
+    fn link_elf(
+        self,
+        entry_point: &str,
+        cancellation: &mut impl FnMut() -> bool,
+    ) -> Result<Vec<u8>, LinkError> {
         // Layout constants - use separate program headers for proper W^X security:
         // - Segment 1: .text (R+X) - executable code
         // - Segment 2: .rodata (R) - read-only data (only if rodata exists)
@@ -1773,6 +1916,7 @@ impl Linker {
 
         // Merge code sections (.text*)
         for (obj_idx, obj) in self.objects.iter().enumerate() {
+            check_cancellation(cancellation)?;
             for (sec_idx, section) in obj.sections.iter().enumerate() {
                 if classify_section(&section.name) != SectionKind::Text
                     || section.content_len() == 0
@@ -1790,12 +1934,13 @@ impl Linker {
                 };
                 let align = section.align.max(minimum_alignment);
                 let padding = align_up(merged_text.len() as u64, align) - merged_text.len() as u64;
-                merged_text.resize(merged_text.len() + padding as usize, 0xCC); // INT3 padding
+                let new_len = merged_text.len() + padding as usize;
+                resize_with_cancellation(&mut merged_text, new_len, 0xCC, cancellation)?;
 
                 let offset = merged_text.len() as u64;
                 section_offsets.insert((obj_idx, sec_idx), offset);
 
-                section.extend_contents(&mut merged_text);
+                section.extend_contents(&mut merged_text, cancellation)?;
 
                 collect_section_relocations(
                     obj,
@@ -1804,6 +1949,7 @@ impl Linker {
                     obj_idx,
                     PatchHome::Text,
                     &mut pending_relocations,
+                    cancellation,
                 )?;
             }
         }
@@ -1812,6 +1958,7 @@ impl Linker {
         // We need page alignment between code and rodata so they can have different
         // memory protections at runtime.
         for (obj_idx, obj) in self.objects.iter().enumerate() {
+            check_cancellation(cancellation)?;
             for (sec_idx, section) in obj.sections.iter().enumerate() {
                 if classify_section(&section.name) != SectionKind::Rodata {
                     continue;
@@ -1822,12 +1969,13 @@ impl Linker {
                 let align = section.align.max(1);
                 let padding =
                     align_up(merged_rodata.len() as u64, align) - merged_rodata.len() as u64;
-                merged_rodata.resize(merged_rodata.len() + padding as usize, 0);
+                let new_len = merged_rodata.len() + padding as usize;
+                resize_with_cancellation(&mut merged_rodata, new_len, 0, cancellation)?;
 
                 let offset = merged_rodata.len() as u64;
                 section_offsets.insert((obj_idx, sec_idx), offset);
 
-                section.extend_contents(&mut merged_rodata);
+                section.extend_contents(&mut merged_rodata, cancellation)?;
 
                 collect_section_relocations(
                     obj,
@@ -1836,12 +1984,14 @@ impl Linker {
                     obj_idx,
                     PatchHome::Rodata,
                     &mut pending_relocations,
+                    cancellation,
                 )?;
             }
         }
 
         // Merge .data sections (initialized data - placed in data segment)
         for (obj_idx, obj) in self.objects.iter().enumerate() {
+            check_cancellation(cancellation)?;
             for (sec_idx, section) in obj.sections.iter().enumerate() {
                 if classify_section(&section.name) != SectionKind::Data {
                     continue;
@@ -1853,12 +2003,13 @@ impl Linker {
 
                 let align = section.align.max(1);
                 let padding = align_up(merged_data.len() as u64, align) - merged_data.len() as u64;
-                merged_data.resize(merged_data.len() + padding as usize, 0);
+                let new_len = merged_data.len() + padding as usize;
+                resize_with_cancellation(&mut merged_data, new_len, 0, cancellation)?;
 
                 let offset = merged_data.len() as u64;
                 section_offsets.insert((obj_idx, sec_idx), offset);
 
-                section.extend_contents(&mut merged_data);
+                section.extend_contents(&mut merged_data, cancellation)?;
 
                 collect_section_relocations(
                     obj,
@@ -1867,6 +2018,7 @@ impl Linker {
                     obj_idx,
                     PatchHome::Data,
                     &mut pending_relocations,
+                    cancellation,
                 )?;
             }
         }
@@ -1882,6 +2034,7 @@ impl Linker {
         let mut max_bss_align: u64 = 1;
 
         for (obj_idx, obj) in self.objects.iter().enumerate() {
+            check_cancellation(cancellation)?;
             for (sec_idx, section) in obj.sections.iter().enumerate() {
                 if classify_section(&section.name) != SectionKind::Bss {
                     continue;
@@ -1915,7 +2068,8 @@ impl Linker {
         // alignment up to a page — every alignment a real object requests.
         let bss_base_padding =
             align_up(merged_data.len() as u64, max_bss_align) - merged_data.len() as u64;
-        merged_data.resize(merged_data.len() + bss_base_padding as usize, 0);
+        let new_len = merged_data.len() + bss_base_padding as usize;
+        resize_with_cancellation(&mut merged_data, new_len, 0, cancellation)?;
         let bss_offset_in_data = merged_data.len() as u64;
 
         // Determine which optional segments are needed
@@ -1950,6 +2104,7 @@ impl Linker {
         let mut symbol_addresses = SymbolAddresses::default();
 
         for (obj_idx, obj) in self.objects.iter().enumerate() {
+            check_cancellation(cancellation)?;
             for sym in &obj.symbols {
                 if sym.name.is_empty() {
                     continue;
@@ -2003,6 +2158,7 @@ impl Linker {
         // (e.g., .text._ZN11rue_runtime4heap5alloc... for Rust runtime internal calls).
         // Section symbols are local to their object, so key them per object.
         for (obj_idx, obj) in self.objects.iter().enumerate() {
+            check_cancellation(cancellation)?;
             for (sec_idx, section) in obj.sections.iter().enumerate() {
                 if let Some(&offset) = section_offsets.get(&(obj_idx, sec_idx)) {
                     let addr = match classify_section(&section.name) {
@@ -2042,6 +2198,7 @@ impl Linker {
             home,
         } in pending_relocations
         {
+            check_cancellation(cancellation)?;
             // Pick the buffer the patch site lives in and its base vaddr.
             // PC-relative relocations in rodata/data measure from their own
             // section's address, not the code segment's.
@@ -2110,6 +2267,7 @@ impl Linker {
         }
 
         drop(relocate_span);
+        check_cancellation(cancellation)?;
         let _emit_span = info_span!("link_emit").entered();
 
         // Build the ELF with proper W^X segment separation
@@ -2250,31 +2408,34 @@ impl Linker {
         // it is reachable via the Linker API with a code-only / code+rodata
         // object.
         if (elf.len() as u64) < code_file_offset {
-            elf.resize(code_file_offset as usize, 0);
+            resize_with_cancellation(&mut elf, code_file_offset as usize, 0, cancellation)?;
         }
 
         // Write code section
-        elf.extend_from_slice(&merged_text);
+        extend_bytes_with_cancellation(&mut elf, &merged_text, cancellation)?;
 
         // Pad to rodata file offset if needed
         if has_rodata {
             let padding_needed = rodata_file_offset as usize - elf.len();
-            elf.resize(elf.len() + padding_needed, 0);
+            let new_len = elf.len() + padding_needed;
+            resize_with_cancellation(&mut elf, new_len, 0, cancellation)?;
 
             // Write rodata section
-            elf.extend_from_slice(&merged_rodata);
+            extend_bytes_with_cancellation(&mut elf, &merged_rodata, cancellation)?;
         }
 
         // Pad to data segment file offset if needed
         if has_data_segment {
             let current_size = elf.len();
             let padding_needed = data_file_offset as usize - current_size;
-            elf.resize(elf.len() + padding_needed, 0);
+            let new_len = elf.len() + padding_needed;
+            resize_with_cancellation(&mut elf, new_len, 0, cancellation)?;
 
             // Write data segment
-            elf.extend_from_slice(&merged_data);
+            extend_bytes_with_cancellation(&mut elf, &merged_data, cancellation)?;
         }
 
+        check_cancellation(cancellation)?;
         Ok(elf)
     }
 }
@@ -2304,6 +2465,96 @@ mod tests {
     // Use X86_64Linux explicitly for ELF tests since ObjectFile only parses ELF
     // and the Linker produces ELF executables
     const ELF_TARGET: Target = Target::X86_64Linux;
+
+    #[test]
+    fn large_structured_link_observes_bounded_cancellation_checkpoints() {
+        let empty_atoms: Arc<[Arc<[u8]>]> = Arc::from([]);
+        let text_atoms: Arc<[Arc<[u8]>]> = Arc::from([Arc::from([0xC3_u8])]);
+        let mut linker = Linker::new(ELF_TARGET);
+        for index in 0..2_048 {
+            linker
+                .add_structured_object(crate::StructuredObject::function(
+                    ELF_TARGET,
+                    if index == 0 {
+                        "main".to_owned()
+                    } else {
+                        format!("function_{index}")
+                    },
+                    Arc::clone(&text_atoms),
+                    Arc::clone(&empty_atoms),
+                    Vec::new(),
+                ))
+                .unwrap();
+        }
+
+        let mut checkpoints = 0_usize;
+        let result = linker.link_with_cancellation("main", || {
+            checkpoints += 1;
+            checkpoints == 128
+        });
+
+        assert!(matches!(result, Err(LinkError::Canceled)));
+        assert_eq!(checkpoints, 128);
+    }
+
+    #[test]
+    fn ordinary_structured_link_uses_the_same_successful_path() {
+        let mut linker = Linker::new(ELF_TARGET);
+        linker
+            .add_structured_object(crate::StructuredObject::function(
+                ELF_TARGET,
+                "main",
+                Arc::from([Arc::from([0xC3_u8])]),
+                Arc::from([]),
+                Vec::new(),
+            ))
+            .unwrap();
+
+        let executable = linker.link("main").unwrap();
+        assert_eq!(&executable[..4], &ELF_MAGIC);
+    }
+
+    #[test]
+    fn large_single_section_final_emission_is_bounded_and_byte_identical() {
+        for (target, entry) in [
+            (Target::X86_64Linux, "main"),
+            (Target::Aarch64Macos, "__main"),
+        ] {
+            let make_linker = || {
+                let mut linker = Linker::new(target);
+                linker
+                    .add_structured_object(crate::StructuredObject::function(
+                        target,
+                        entry,
+                        Arc::from([Arc::<[u8]>::from(vec![0_u8; 4 * 1024 * 1024])]),
+                        Arc::from([]),
+                        Vec::new(),
+                    ))
+                    .unwrap();
+                linker
+            };
+
+            let ordinary = make_linker().link(entry).unwrap();
+            let mut total_checkpoints = 0_usize;
+            let cancellable = make_linker()
+                .link_with_cancellation(entry, || {
+                    total_checkpoints += 1;
+                    false
+                })
+                .unwrap();
+            assert_eq!(ordinary, cancellable);
+            assert!(total_checkpoints > 2 * (4 * 1024 * 1024 / (64 * 1024)));
+
+            let cancel_at = total_checkpoints - 8;
+            let mut checkpoints = 0_usize;
+            let canceled = make_linker().link_with_cancellation(entry, || {
+                checkpoints += 1;
+                checkpoints == cancel_at
+            });
+            assert!(matches!(canceled, Err(LinkError::Canceled)));
+            assert_eq!(checkpoints, cancel_at);
+        }
+    }
 
     fn defined_symbol(name: &str, value: u64, size: u64) -> Symbol {
         Symbol {
@@ -2619,13 +2870,14 @@ mod tests {
     fn defined_symbol_extents_accept_boundaries_and_reject_escape() {
         for (value, size) in [(0, 4), (3, 1), (4, 0)] {
             let obj = object_with_defined_symbols(4, vec![defined_symbol("valid", value, size)]);
-            validate_defined_symbols(&LinkObject::from(obj))
+            validate_defined_symbols(&LinkObject::from(obj), &mut || false)
                 .unwrap_or_else(|error| panic!("valid extent {value}+{size}: {error}"));
         }
 
         for (value, size) in [(5, 0), (4, 1), (3, 2), (u64::MAX, 2)] {
             let obj = object_with_defined_symbols(4, vec![defined_symbol("bad", value, size)]);
-            let error = validate_defined_symbols(&LinkObject::from(obj)).unwrap_err();
+            let error =
+                validate_defined_symbols(&LinkObject::from(obj), &mut || false).unwrap_err();
             assert!(matches!(
                 error,
                 LinkError::SymbolOutsideSection {

--- a/crates/rue-linker/src/macho.rs
+++ b/crates/rue-linker/src/macho.rs
@@ -901,7 +901,18 @@ impl MachOBuilder {
     /// Returns `(bytes, text_file_offset, data_vm_addr)` where:
     /// - `text_file_offset` is the file offset where code starts (needed for relocation calculation)
     /// - `data_vm_addr` is the virtual address of the __DATA segment (or 0 if no data segment)
-    pub fn build_dynamic(mut self) -> (Vec<u8>, u64, u64) {
+    pub fn build_dynamic(self) -> (Vec<u8>, u64, u64) {
+        self.build_dynamic_with_cancellation(&mut || false)
+            .expect("the ordinary Mach-O builder cannot be canceled")
+    }
+
+    pub(crate) fn build_dynamic_with_cancellation(
+        mut self,
+        cancellation: &mut impl FnMut() -> bool,
+    ) -> Option<(Vec<u8>, u64, u64)> {
+        if cancellation() {
+            return None;
+        }
         // For dynamic executables, we need:
         // 1. LC_LOAD_DYLINKER - loads /usr/lib/dyld
         // 2. LC_LOAD_DYLIB - loads libSystem
@@ -957,6 +968,9 @@ impl MachOBuilder {
 
         // Update segments with actual values
         for seg in &mut self.segments {
+            if cancellation() {
+                return None;
+            }
             if &seg.segname[..6] == b"__TEXT" {
                 seg.vmaddr = VM_BASE;
                 seg.vmsize = text_segment_file_size as u64;
@@ -1081,6 +1095,9 @@ impl MachOBuilder {
         // Load commands - segments first (in order: __PAGEZERO, __TEXT, __DATA, __LINKEDIT)
         // Write segments in the order they were added, but insert __DATA before __LINKEDIT
         for seg in &self.segments {
+            if cancellation() {
+                return None;
+            }
             let is_linkedit = &seg.segname[..10] == b"__LINKEDIT";
             if is_linkedit {
                 // Write __DATA segment first if it exists
@@ -1093,13 +1110,14 @@ impl MachOBuilder {
 
         // Other commands
         for cmd in &self.commands {
+            if cancellation() {
+                return None;
+            }
             cmd.write(&mut buf);
         }
 
         // Pad to text offset (includes codesign padding)
-        while buf.len() < text_file_offset {
-            buf.push(0);
-        }
+        resize_with_cancellation(&mut buf, text_file_offset, cancellation)?;
 
         // Code
         tracing::trace!(
@@ -1107,7 +1125,7 @@ impl MachOBuilder {
             buf_len_before = format_args!("0x{:x}", buf.len()),
             "MachOBuilder writing code"
         );
-        buf.extend_from_slice(&self.code);
+        extend_with_cancellation(&mut buf, &self.code, cancellation)?;
         tracing::trace!(
             buf_len_after = format_args!("0x{:x}", buf.len()),
             "MachOBuilder wrote code"
@@ -1116,45 +1134,73 @@ impl MachOBuilder {
         // Pad and write data segment content if present
         if has_data {
             // Pad to data offset
-            while buf.len() < data_file_offset {
-                buf.push(0);
-            }
+            resize_with_cancellation(&mut buf, data_file_offset, cancellation)?;
 
             // Write rodata with alignment padding
-            buf.extend_from_slice(&self.rodata);
+            extend_with_cancellation(&mut buf, &self.rodata, cancellation)?;
             let rodata_padding = align_up(self.rodata.len() as u64, 8) as usize - self.rodata.len();
-            for _ in 0..rodata_padding {
-                buf.push(0);
-            }
+            let rodata_end = buf.len() + rodata_padding;
+            resize_with_cancellation(&mut buf, rodata_end, cancellation)?;
 
             // Write data with alignment padding
-            buf.extend_from_slice(&self.data);
+            extend_with_cancellation(&mut buf, &self.data, cancellation)?;
             let data_padding = align_up(self.data.len() as u64, 8) as usize - self.data.len();
-            for _ in 0..data_padding {
-                buf.push(0);
-            }
+            let data_end = buf.len() + data_padding;
+            resize_with_cancellation(&mut buf, data_end, cancellation)?;
             // Note: BSS is not written to file (it's zero-filled at runtime)
         }
 
         // Pad to LINKEDIT offset
-        while buf.len() < linkedit_file_offset {
-            buf.push(0);
-        }
+        resize_with_cancellation(&mut buf, linkedit_file_offset, cancellation)?;
 
         // LINKEDIT content (minimal string table)
         buf.push(0); // null byte for empty string table
 
         // Pad LINKEDIT to declared size
-        while buf.len() < linkedit_file_offset + linkedit_file_size {
-            buf.push(0);
-        }
+        resize_with_cancellation(
+            &mut buf,
+            linkedit_file_offset + linkedit_file_size,
+            cancellation,
+        )?;
 
         tracing::trace!(
             final_buf_len = format_args!("0x{:x}", buf.len()),
             "MachOBuilder finished"
         );
-        (buf, text_file_offset as u64, data_vm_addr)
+        if cancellation() {
+            return None;
+        }
+        Some((buf, text_file_offset as u64, data_vm_addr))
     }
+}
+
+fn extend_with_cancellation(
+    output: &mut Vec<u8>,
+    bytes: &[u8],
+    cancellation: &mut impl FnMut() -> bool,
+) -> Option<()> {
+    for chunk in bytes.chunks(64 * 1024) {
+        if cancellation() {
+            return None;
+        }
+        output.extend_from_slice(chunk);
+    }
+    Some(())
+}
+
+fn resize_with_cancellation(
+    output: &mut Vec<u8>,
+    new_len: usize,
+    cancellation: &mut impl FnMut() -> bool,
+) -> Option<()> {
+    while output.len() < new_len {
+        if cancellation() {
+            return None;
+        }
+        let chunk_end = new_len.min(output.len().saturating_add(64 * 1024));
+        output.resize(chunk_end, 0);
+    }
+    Some(())
 }
 
 impl Default for MachOBuilder {


### PR DESCRIPTION
## Summary

- carry the retained compile cancellation token through object projection, archive resolution, internal linking, and final image construction
- manage system linkers as cancellable process jobs that terminate descendants, reap the child, and clean temporary state
- preserve successful link and watch publication semantics with deterministic race behavior and bounded large-link checkpoints

## Validation

- `scripts/rue quick`
- `scripts/rue test`
- `scripts/rue cli watch`
- `./buck2 test //crates/rue-compiler:rue-compiler-platform-native-test //crates/rue-linker:rue-linker-test`
- `scripts/rue fmt`
- `git diff --check`

Fixes RUE-1810
