### PR TITLE
RUE-1718: compare raw and transformed CFG execution

### DIFF
--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -977,6 +977,48 @@ impl ValidatedCfg {
         self.0 = editor;
         Ok(result)
     }
+
+    /// Apply a mutation to an already-optimized graph, whose dead values may
+    /// remain detached, and publish only after the optimizer's full final
+    /// verification contract succeeds.
+    #[doc(hidden)]
+    pub fn try_edit_after_optimization<R>(
+        &mut self,
+        type_pool: &rue_air::FrozenTypeInternPool,
+        edit: impl FnOnce(&mut CfgEditor) -> Result<R, CfgEditError>,
+    ) -> Result<R, CfgEditTransactionError> {
+        let mut editor = self.0.clone();
+        let result = edit(&mut editor).map_err(CfgEditTransactionError::Edit)?;
+        editor
+            .verify_after_optimization_with_type_pool(type_pool)
+            .map_err(CfgEditTransactionError::Verification)?;
+        self.0 = editor;
+        Ok(result)
+    }
+
+    /// Test-support corruption used by the compiler/oracle CFG-boundary
+    /// differential. It reverses one attached equality comparison and
+    /// republishes only if the resulting CFG remains fully verified.
+    #[doc(hidden)]
+    pub fn inject_differential_comparison_fault(
+        &mut self,
+        type_pool: &rue_air::FrozenTypeInternPool,
+    ) -> bool {
+        let candidate = (0..self.value_count())
+            .map(|index| CfgValue::from_raw(index as u32))
+            .find(|value| matches!(self.get_inst(*value).data, CfgInstData::Eq(_, _)));
+        let Some(candidate) = candidate else {
+            return false;
+        };
+        self.try_edit_after_optimization(type_pool, |editor| {
+            let CfgInstData::Eq(lhs, rhs) = editor.get_inst(candidate).data else {
+                unreachable!()
+            };
+            editor.get_inst_mut(candidate).data = CfgInstData::Ne(lhs, rhs);
+            Ok(())
+        })
+        .is_ok()
+    }
 }
 
 impl Clone for Cfg {
@@ -1684,8 +1726,10 @@ impl Cfg {
     /// owner-bound payload range.
     pub fn get_call_args<'a>(&'a self, data: &CfgInstData) -> &'a [CfgCallArg] {
         match data {
-            CfgInstData::Call { args, .. } => self.call_args(args),
-            _ => panic!("get_call_args called on non-Call instruction"),
+            CfgInstData::Call { args, .. } | CfgInstData::AccessorCall { args, .. } => {
+                self.call_args(args)
+            }
+            _ => panic!("get_call_args called on non-call instruction"),
         }
     }
 

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -2263,7 +2263,7 @@ fn unstable_views_do_not_alias_query_engine_records() {
             "pubusecrate::import_discovery::{AcceptedImportSource,DiscoverySourceAssembler,ImportDemandFrontier,ImportDemandMode,ImportDemandRoots,ImportDiscoveryPlan,ImportDiscoveryRequest,ImportDiscoveryWave,ImportInputRevision,ImportObservation,ImportObservationLedger,ImportObservationStatus,};",
             "pubusecrate::warm_fresh_parity::ParityObservation;",
             "pubuserue_span::Span;",
-            "pubusecrate::session::{ClosedDiscoveryContinuation,RootedCfgOutput,RootedCfgUnit,RootedParkOutcome,TrustedSuccessorDelta,};",
+            "pubusecrate::session::{ClosedDiscoveryContinuation,RootedCfgOutput,RootedCfgUnit,RootedParkOutcome,RootedPreOptimizationCfgOutput,RootedPreOptimizationCfgUnit,TrustedSuccessorDelta,};",
         ],
         "unstable may reexport only reviewed presentation, source-assembly, and host discovery-protocol records"
     );

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -31,6 +31,176 @@ mod tests {
     }
 
     #[test]
+    fn pre_optimization_root_has_stable_query_identity_and_reuse() {
+        let snapshot = SourceSnapshot::single(
+            "main.rue",
+            "fn square(x: i32) -> i32 { x * x } fn main() -> i32 { square(3) }",
+        )
+        .unwrap();
+        let mut session = CompilerSession::new();
+        publish_test_snapshot(&mut session, &snapshot).unwrap();
+        let options = CompileOptions::default();
+
+        let first = session.rooted_pre_optimization_cfg(&options).unwrap();
+        assert!(
+            session
+                .rooted_cfg_executions()
+                .iter()
+                .all(|(_, execution)| { *execution == rue_query::RequestExecution::Computed })
+        );
+        let first_cfgs = format!("{:?}", first.functions());
+
+        let second = session.rooted_pre_optimization_cfg(&options).unwrap();
+        assert!(
+            session
+                .rooted_cfg_executions()
+                .iter()
+                .all(|(_, execution)| {
+                    matches!(
+                        execution,
+                        rue_query::RequestExecution::Reused | rue_query::RequestExecution::Joined
+                    )
+                })
+        );
+        assert_eq!(first_cfgs, format!("{:?}", second.functions()));
+
+        let optimized = CompileOptions {
+            opt_level: rue_cfg::OptLevel::O1,
+            ..options.clone()
+        };
+        session.rooted_cfg(&optimized).unwrap();
+        let third = session.rooted_pre_optimization_cfg(&options).unwrap();
+        assert_eq!(first_cfgs, format!("{:?}", third.functions()));
+    }
+
+    #[test]
+    fn raw_root_preserves_accessor_calls_that_post_transform_o0_eliminates() {
+        let snapshot = SourceSnapshot::single(
+            "main.rue",
+            r#"struct Inner {
+                x: i32,
+                fn value(borrow self) -> borrow i32 { yield self.x; }
+            }
+            fn main() -> i32 {
+                let inner = Inner { x: 7 };
+            if inner.value() == 7 { 0 } else { 1 }
+            }"#,
+        )
+        .unwrap();
+        let mut session = CompilerSession::new();
+        publish_test_snapshot(&mut session, &snapshot).unwrap();
+        let options = CompileOptions::default();
+
+        let raw = session.rooted_pre_optimization_cfg(&options).unwrap();
+        let raw_main = raw
+            .functions()
+            .iter()
+            .find(|unit| unit.definition_source_name() == Some("main"))
+            .unwrap();
+        assert!((0..raw_main.cfg().value_count()).any(|index| {
+            matches!(
+                raw_main
+                    .cfg()
+                    .get_inst(rue_cfg::CfgValue::from_raw(index as u32))
+                    .data,
+                rue_cfg::CfgInstData::AccessorCall { .. }
+            )
+        }));
+
+        let post = session.rooted_cfg(&options).unwrap();
+        let post_main = post
+            .functions()
+            .iter()
+            .find(|unit| unit.definition_source_name() == Some("main"))
+            .unwrap();
+        assert!(post_main.cfg().blocks().iter().all(|block| {
+            block.insts.iter().all(|value| {
+                let inst = post_main.cfg().get_inst(*value);
+                !matches!(inst.data, rue_cfg::CfgInstData::AccessorCall { .. })
+                    && !matches!(
+                        &inst.data,
+                        rue_cfg::CfgInstData::PlaceRead { place }
+                            | rue_cfg::CfgInstData::PlaceWrite { place, .. }
+                            if matches!(place.base, rue_cfg::PlaceBase::Accessor(_))
+                    )
+            })
+        }));
+    }
+
+    #[test]
+    fn raw_then_post_hands_off_drop_glue_cones_for_accessor_program() {
+        let mut source = String::from(
+            r#"
+                struct AccessorOwner {
+                    value: i32,
+                    fn view(borrow self) -> borrow i32 { yield self.value; }
+                }
+            "#,
+        );
+        // Exceed the eight-entry body-query retention floor with distinct
+        // destructor owners that all inspect builtin `str` drop glue. This is
+        // the focused analogue of the real-std StrBuf corpus that exposed the
+        // missing raw-to-post fallback handoff.
+        for index in 0..32 {
+            source.push_str(&format!(
+                "struct DropOwner{index} {{ text: str }} drop fn DropOwner{index}(self) {{}} "
+            ));
+        }
+        source.push_str(
+            "fn use_owners(comptime N: i32) -> i32 { let accessor = AccessorOwner { value: 42 }; ",
+        );
+        for index in 0..32 {
+            source.push_str(&format!(
+                "let owner{index} = DropOwner{index} {{ text: \"retained\" }}; "
+            ));
+        }
+        source.push_str(
+            "if accessor.view() == 42 && N == 2 { 0 } else { 1 } } \
+             fn main() -> i32 { use_owners(2) }",
+        );
+        let snapshot = SourceSnapshot::single("<raw-post-drop-glue-handoff>", source).unwrap();
+        let mut session = CompilerSession::new();
+        publish_test_snapshot(&mut session, &snapshot).unwrap();
+        let options = CompileOptions::default();
+
+        // Match the oracle lifecycle: project the raw records, then release
+        // the artifact terminal before asking the same session for the
+        // post-transform root. The raw batch's published handoff must retain
+        // deep validation leaves such as the builtin `str` drop-glue query.
+        let raw_identity = {
+            let raw = session.rooted_pre_optimization_cfg(&options).unwrap();
+            assert!(
+                session.raw_cfg_handoff_is_published(&raw),
+                "the raw batch must publish its exact retained child cones for the post-transform successor"
+            );
+            assert!(raw.functions().iter().any(|unit| {
+                (0..unit.cfg().value_count()).any(|index| {
+                    matches!(
+                        unit.cfg()
+                            .get_inst(rue_cfg::CfgValue::from_raw(index as u32))
+                            .data,
+                        rue_cfg::CfgInstData::AccessorCall { .. }
+                    )
+                })
+            }));
+            raw.query_identity()
+        };
+
+        let post = session.rooted_cfg(&options).unwrap();
+        assert!(!raw_identity.is_empty());
+        assert!(post.functions().iter().all(|unit| {
+            unit.cfg().blocks().iter().all(|block| {
+                block.insts.iter().all(|value| {
+                    !matches!(
+                        unit.cfg().get_inst(*value).data,
+                        rue_cfg::CfgInstData::AccessorCall { .. }
+                    )
+                })
+            })
+        }));
+    }
+
+    #[test]
     fn backend_query_keys_share_exact_batch_and_memo_display_identities() {
         let snapshot = SourceSnapshot::single("main.rue", "fn main() -> i32 { 0 }").unwrap();
         let options = CompileOptions::default();

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -642,6 +642,7 @@ pub(crate) struct RevisionedQueryDatabase {
     drop_glues: QueryFamily<crate::type_queries::TypeQueryKey, crate::type_queries::DropGlueValue>,
     #[allow(dead_code)]
     cfgs: QueryFamily<crate::cfg_query::CfgQueryKey, crate::cfg_query::CfgValue>,
+    raw_cfg_batches: QueryFamily<RawCfgBatchKey, RawCfgBatchOutput>,
     #[allow(dead_code)]
     optimized_cfgs: QueryFamily<crate::cfg_query::OptimizedCfgQueryKey, crate::cfg_query::CfgValue>,
     optimized_cfg_batches: QueryFamily<OptimizedCfgBatchKey, OptimizedCfgBatchOutput>,
@@ -1636,6 +1637,42 @@ pub(crate) struct OptimizedCfgBatchKey {
     /// batch constant-time for every holder.
     digest: rue_query::StableKeyHash,
     memo_hash: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct RawCfgBatchKey {
+    pub(crate) keys: Arc<[crate::cfg_query::CfgQueryKey]>,
+}
+
+impl QueryKey for RawCfgBatchKey {
+    fn stable_identity(&self) -> String {
+        let mut identity = format!("raw-cfg-batch;units={}", self.keys.len());
+        for key in self.keys.iter() {
+            identity.push('\u{1e}');
+            identity.push_str(&key.shared_stable_identity());
+        }
+        identity
+    }
+
+    fn stable_hash(&self, hasher: &mut rue_query::StableHasher) {
+        hasher.write_usize(self.keys.len());
+        for key in self.keys.iter() {
+            key.stable_hash(hasher);
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RawCfgBatchOutput {
+    pub(crate) values: Arc<[crate::cfg_query::CfgValue]>,
+    /// Exact raw-CFG child cones captured while their request leases are live.
+    _retained_children: Arc<rue_query::RetainedPinSet>,
+}
+
+impl RetainedCharge for RawCfgBatchOutput {
+    fn retained_charge(&self) -> u64 {
+        self.values.retained_charge()
+    }
 }
 
 impl OptimizedCfgBatchKey {
@@ -14123,6 +14160,73 @@ impl RevisionedQueryDatabase {
                 },
             )
             .expect("the Cfg family has one canonical name");
+        let backend_root = Arc::new(Mutex::new(PublishedBackendRoot::default()));
+        let cfg_collection_root = Arc::new(Mutex::new(PublishedCollectionRoot::default()));
+        let codegen_collection_root = Arc::new(Mutex::new(PublishedCollectionRoot::default()));
+        let cfgs_for_raw_batch = cfgs.clone();
+        let backend_root_for_raw_cfg_batch = backend_root.clone();
+        let body_closure_root_for_raw_cfg_batch = body_closure_root.clone();
+        let body_reachability_root_for_raw_cfg_batch = body_reachability_root.clone();
+        let cfg_collection_root_for_raw_cfg_batch = cfg_collection_root.clone();
+        let codegen_collection_root_for_raw_cfg_batch = codegen_collection_root.clone();
+        let raw_cfg_batches = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.raw-cfg-batch",
+                0,
+                |left: &RawCfgBatchOutput, right: &RawCfgBatchOutput| {
+                    left.values.len() == right.values.len()
+                        && left
+                            .values
+                            .iter()
+                            .zip(right.values.iter())
+                            .all(|(left, right)| crate::cfg_query::cfg_value_equal(left, right))
+                },
+                move |context, _, key: &RawCfgBatchKey| {
+                    let fallbacks = backend_retention_fallbacks(
+                        &backend_root_for_raw_cfg_batch,
+                        &body_closure_root_for_raw_cfg_batch,
+                        &body_reachability_root_for_raw_cfg_batch,
+                        &cfg_collection_root_for_raw_cfg_batch,
+                        &codegen_collection_root_for_raw_cfg_batch,
+                    );
+                    let _validated_registered = context
+                        .endorse_registered_validations_from(&fallbacks)
+                        .expect("raw CFG retention roots belong to this query runtime");
+                    let _attempts = context.retain_nested_attempts_for(&["compiler.cfg"]);
+                    let terminals = context.query_registered_adaptive_batch_refs(
+                        &cfgs_for_raw_batch,
+                        key.keys.iter(),
+                    )?;
+                    let values = terminals
+                        .iter()
+                        .map(|terminal| {
+                            let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
+                                unreachable!("Cfg publishes typed values")
+                            };
+                            value.clone()
+                        })
+                        .collect::<Vec<_>>();
+                    let retained_children = Arc::new(
+                        context
+                            .retain_observed_terminal_cones_from(&terminals, &fallbacks)
+                            .expect("raw CFG batch observes every child cone"),
+                    );
+                    let kind = if values
+                        .iter()
+                        .all(|value| matches!(value, crate::cfg_query::CfgValue::Available(_)))
+                    {
+                        QueryTerminalKind::Success
+                    } else {
+                        QueryTerminalKind::Failure
+                    };
+                    Ok(QueryOutput::success(RawCfgBatchOutput {
+                        values: values.into(),
+                        _retained_children: retained_children,
+                    })
+                    .with_terminal_kind(kind))
+                },
+            )
+            .expect("the RawCfgBatch family has one canonical name");
         let cfgs_for_optimization = cfgs.clone();
         let optimized_cfgs = runtime
             .family_with_equality_and_evaluator(
@@ -14134,9 +14238,6 @@ impl RevisionedQueryDatabase {
                 },
             )
             .expect("the OptimizedCfg family has one canonical name");
-        let backend_root = Arc::new(Mutex::new(PublishedBackendRoot::default()));
-        let cfg_collection_root = Arc::new(Mutex::new(PublishedCollectionRoot::default()));
-        let codegen_collection_root = Arc::new(Mutex::new(PublishedCollectionRoot::default()));
         // Backend terminals extend the already-published semantic/body graph.
         // Keep those independent roots available as retention fallbacks while
         // each backend batch promotes its exact transitive cone.
@@ -15892,6 +15993,7 @@ impl RevisionedQueryDatabase {
             call_abis,
             drop_glues,
             cfgs,
+            raw_cfg_batches,
             optimized_cfgs,
             optimized_cfg_batches,
             codegen_units,
@@ -16372,6 +16474,41 @@ impl RevisionedQueryDatabase {
             .request_registered(&self.cfgs, revision, key, cancellation)
     }
 
+    /// Request one stable-ordered production root of raw CFG terminals. The
+    /// registered evaluator captures the exact child cones before their
+    /// request leases are released.
+    pub(crate) fn raw_cfg_batch(
+        &self,
+        revision: Revision,
+        keys: Arc<[crate::cfg_query::CfgQueryKey]>,
+        cancellation: CancellationToken,
+    ) -> (RawCfgBatchKey, QueryRequestAttempt<RawCfgBatchOutput>) {
+        let key = RawCfgBatchKey { keys };
+        let attempt = self.runtime.request_registered(
+            &self.raw_cfg_batches,
+            revision,
+            key.clone(),
+            cancellation,
+        );
+        // The pre-optimization artifact can be followed immediately by the
+        // production optimized-CFG batch in the same session. Publish the raw
+        // batch's exact retained child cones as that successor's fallback
+        // authority while the request lease is still live, just as the
+        // optimized batch publishes its cones for codegen below. Without this
+        // handoff, green reuse of a raw compiler.cfg terminal can omit a deep
+        // validation leaf (for example compiler.drop-glue) from the successor
+        // task even though the raw artifact still owns the complete cone.
+        if let Some(terminal) = attempt.terminal() {
+            if let rue_query::QueryOutcome::Success(output) = terminal.outcome() {
+                self.cfg_collection_root
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .lease = output._retained_children.clone();
+            }
+        }
+        (key, attempt)
+    }
+
     #[cfg(test)]
     pub(crate) fn optimized_cfg(
         &self,
@@ -16672,6 +16809,21 @@ impl RevisionedQueryDatabase {
             additions: root.additions,
             deletions: root.deletions,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn raw_cfg_handoff_matches_terminal_for_test(
+        &self,
+        terminal: &Arc<rue_query::QueryTerminal<RawCfgBatchOutput>>,
+    ) -> bool {
+        let rue_query::QueryOutcome::Success(output) = terminal.outcome() else {
+            return false;
+        };
+        let root = self
+            .cfg_collection_root
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        Arc::ptr_eq(&root.lease, &output._retained_children)
     }
 
     #[cfg(test)]

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -881,6 +881,88 @@ pub struct RootedCfgOutput {
     backend_root: crate::revisioned_query_database::BackendRootCandidate,
 }
 
+#[derive(Clone)]
+pub struct RootedPreOptimizationCfgUnit {
+    pub(crate) function: crate::FunctionInstanceKey,
+    pub(crate) cfg_key: crate::cfg_query::CfgQueryKey,
+    pub(crate) record: Arc<crate::cfg_query::CfgRecord>,
+}
+
+impl std::fmt::Debug for RootedPreOptimizationCfgUnit {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RootedPreOptimizationCfgUnit")
+            .field("function", &self.function)
+            .field("source_name", &self.record.source_name)
+            .field("cfg_blocks", &self.record.cfg.blocks())
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub struct RootedPreOptimizationCfgOutput {
+    cfgs: Vec<RootedPreOptimizationCfgUnit>,
+    pub(crate) raw_cfg_batch: crate::revisioned_query_database::RawCfgBatchKey,
+    // The batch terminal owns the exact retained cones of its compiler.cfg
+    // children for as long as this public artifact remains live.
+    _raw_cfg_terminal:
+        Arc<rue_query::QueryTerminal<crate::revisioned_query_database::RawCfgBatchOutput>>,
+    warnings: Vec<CompileWarning>,
+    work: crate::CanonicalSemanticWork,
+}
+
+impl RootedPreOptimizationCfgOutput {
+    pub fn functions(&self) -> &[RootedPreOptimizationCfgUnit] {
+        &self.cfgs
+    }
+
+    pub fn warnings(&self) -> &[CompileWarning] {
+        &self.warnings
+    }
+
+    pub fn metrics(&self) -> crate::unstable::SemanticMetrics {
+        crate::unstable::SemanticMetrics::from_work(self.work)
+    }
+
+    pub fn query_identity(&self) -> String {
+        rue_query::QueryKey::stable_identity(&self.raw_cfg_batch)
+    }
+}
+
+impl RootedPreOptimizationCfgUnit {
+    pub fn definition_source_name(&self) -> Option<&str> {
+        match &self.function {
+            crate::FunctionInstanceKey::Definition(definition) => Some(definition.name()),
+            _ => None,
+        }
+    }
+
+    pub fn source_name(&self) -> &str {
+        self.definition_source_name()
+            .unwrap_or(&self.record.source_name)
+    }
+
+    pub fn cfg(&self) -> &rue_cfg::ValidatedCfg {
+        &self.record.cfg
+    }
+
+    pub fn interner(&self) -> &Arc<lasso::ThreadedRodeo> {
+        &self.record.interner
+    }
+
+    pub fn type_pool(&self) -> &rue_air::FrozenTypeInternPool {
+        &self.record.type_pool
+    }
+
+    pub fn strings(&self) -> &Arc<[String]> {
+        &self.record.strings
+    }
+
+    pub fn query_identity(&self) -> String {
+        rue_query::QueryKey::stable_identity(&self.cfg_key)
+    }
+}
+
 impl RootedCfgOutput {
     pub fn functions(&self) -> &[RootedCfgUnit] {
         &self.cfgs
@@ -1062,6 +1144,34 @@ fn collect_rooted_exports(
             }
         })
         .collect()
+}
+
+fn sort_rooted_warnings(graph: &RootedBodyGraph, warnings: &mut Vec<CompileWarning>) {
+    let mut module_ids: AHashMap<rue_span::FileId, &str> =
+        AHashMap::with_capacity(graph.modules.len());
+    for module in graph.modules.iter() {
+        module_ids
+            .entry(module.file_id())
+            .or_insert_with(|| module.module_id().as_str());
+    }
+    let mut keyed = warnings
+        .drain(..)
+        .map(|warning| {
+            let span = warning.span();
+            let key = (
+                span.and_then(|span| module_ids.get(&span.file_id).copied())
+                    .unwrap_or(""),
+                span.map(|span| span.start).unwrap_or(0),
+                span.map(|span| span.end).unwrap_or(0),
+                warning.to_string(),
+                format!("{:?}", warning.diagnostic()),
+            );
+            (key, warning)
+        })
+        .collect::<Vec<_>>();
+    keyed.sort_by(|left, right| left.0.cmp(&right.0));
+    warnings.extend(keyed.into_iter().map(|(_, warning)| warning));
+    warnings.dedup();
 }
 
 /// An opaque, single-use continuation issued ONLY from a successful close of
@@ -1699,7 +1809,8 @@ impl CompilerSession {
         fault: crate::unstable::DifferentialOracleFault,
     ) -> bool {
         match fault {
-            crate::unstable::DifferentialOracleFault::Semantic => {
+            crate::unstable::DifferentialOracleFault::Semantic
+            | crate::unstable::DifferentialOracleFault::CfgTransformation => {
                 self.oracle_fault = Some(fault);
                 true
             }
@@ -5123,7 +5234,8 @@ impl CompilerSession {
         &mut self,
         options: &CompileOptions,
     ) -> Result<RootedCfgOutput, CompileErrors> {
-        if self.oracle_fault.take() == Some(crate::unstable::DifferentialOracleFault::Semantic) {
+        if self.oracle_fault == Some(crate::unstable::DifferentialOracleFault::Semantic) {
+            self.oracle_fault.take();
             return Err(CompileErrors::from(CompileError::without_span(
                 ErrorKind::InternalError("differential semantic fault".into()),
             )));
@@ -5140,11 +5252,50 @@ impl CompilerSession {
         }
     }
 
+    pub(crate) fn rooted_pre_optimization_cfg(
+        &mut self,
+        options: &CompileOptions,
+    ) -> Result<RootedPreOptimizationCfgOutput, CompileErrors> {
+        match self.rooted_cfg_artifact_with_cancellation(
+            options,
+            rue_query::CancellationToken::new(),
+            true,
+            std::convert::identity,
+            |_| unreachable!("a pre-optimization request cannot publish a post artifact"),
+        ) {
+            Ok(output) => Ok(output),
+            Err(PipelineRequestControl::Compile(errors)) => Err(errors),
+            Err(PipelineRequestControl::Abort(abort)) => {
+                Err(pipeline_abort_errors("pre-optimization rooted CFG", abort))
+            }
+            Err(PipelineRequestControl::Parked(park)) => {
+                Err(unresolved_toolchain_park_errors(&park))
+            }
+        }
+    }
+
     pub(crate) fn rooted_cfg_with_cancellation(
         &mut self,
         options: &CompileOptions,
         cancellation: rue_query::CancellationToken,
     ) -> Result<RootedCfgOutput, PipelineRequestControl> {
+        self.rooted_cfg_artifact_with_cancellation(
+            options,
+            cancellation,
+            false,
+            |_| unreachable!("a post-optimization request cannot publish a raw artifact"),
+            std::convert::identity,
+        )
+    }
+
+    fn rooted_cfg_artifact_with_cancellation<T>(
+        &mut self,
+        options: &CompileOptions,
+        cancellation: rue_query::CancellationToken,
+        pre_optimization: bool,
+        publish_pre: impl FnOnce(RootedPreOptimizationCfgOutput) -> T,
+        publish_post: impl FnOnce(RootedCfgOutput) -> T,
+    ) -> Result<T, PipelineRequestControl> {
         let graph = match self.rooted_body_graph_with_cancellation(options, cancellation.clone()) {
             Ok(graph) => graph,
             Err(SemanticRequestControl::Compile(errors)) => {
@@ -5377,6 +5528,173 @@ impl CompilerSession {
                     semantic_input.clone(),
                 ),
             );
+        }
+        if pre_optimization {
+            let raw_requests = cfg_inputs
+                .iter()
+                .map(|(function, _, body_span)| {
+                    (
+                        function.clone(),
+                        raw_accessor_keys
+                            .get(function)
+                            .expect("every CFG input has one raw key")
+                            .clone(),
+                        *body_span,
+                    )
+                })
+                .collect::<Vec<_>>();
+            let raw_keys = raw_requests
+                .iter()
+                .map(|(_, key, _)| key.clone())
+                .collect::<Vec<_>>()
+                .into();
+            #[cfg(test)]
+            self.rooted_cfg_executions.clear();
+            let (raw_cfg_batch, attempt) =
+                self.queries
+                    .revisioned
+                    .raw_cfg_batch(graph.revision, raw_keys, cancellation);
+            let batch_execution = attempt.execution();
+            let executions = if batch_execution == rue_query::RequestExecution::Computed {
+                let executions = attempt
+                    .nested_attempts()
+                    .iter()
+                    .filter(|attempt| attempt.node().family() == "compiler.cfg")
+                    .map(rue_query::NestedQueryAttempt::execution)
+                    .collect::<Vec<_>>();
+                assert_eq!(executions.len(), raw_requests.len());
+                executions
+            } else {
+                vec![batch_execution; raw_requests.len()]
+            };
+            let batch_work = |name: &str| {
+                attempt
+                    .work()
+                    .iter()
+                    .find_map(|(kind, count)| (kind.as_ref() == name).then_some(*count as usize))
+                    .unwrap_or(0)
+            };
+            work.cfg.prerequisite_stable_types_scanned +=
+                batch_work("cfg.prerequisite.stable-types-scanned");
+            work.cfg.prerequisite_layout_requests += batch_work("cfg.prerequisite.layout-requests");
+            work.cfg.prerequisite_drop_glue_requests +=
+                batch_work("cfg.prerequisite.drop-glue-requests");
+            work.cfg.retained_interner_charge_scans +=
+                batch_work("cfg.retained-interner-charge-scans");
+            work.cfg.retained_interner_entries_scanned +=
+                batch_work("cfg.retained-interner-entries-scanned");
+            work.cfg.retained_interner_utf8_bytes_scanned +=
+                batch_work("cfg.retained-interner-utf8-bytes-scanned");
+            work.cfg.cfg_builds_attempted += batch_work("cfg.build.attempts");
+            work.cfg.cfg_builds_succeeded += batch_work("cfg.build.successes");
+            work.cfg.cfg_builds_failed += batch_work("cfg.build.failures");
+            work.cfg.air_instructions_consumed += batch_work("cfg.air.instructions");
+            work.cfg.cfg_warnings_emitted += batch_work("cfg.warnings");
+            let cfg_reuses = executions
+                .iter()
+                .filter(|execution| {
+                    matches!(
+                        execution,
+                        rue_query::RequestExecution::Reused | rue_query::RequestExecution::Joined
+                    )
+                })
+                .count();
+            work.cfg.cfg_reuse_candidates += cfg_reuses;
+            work.cfg.cfg_reuses += cfg_reuses;
+
+            let batch_terminal = attempt
+                .into_result()
+                .map_err(PipelineRequestControl::Abort)?;
+            let rue_query::QueryOutcome::Success(batch) = batch_terminal.outcome() else {
+                unreachable!("RawCfgBatch publishes typed values")
+            };
+            assert_eq!(batch.values.len(), raw_requests.len());
+            let mut cfgs = Vec::with_capacity(raw_requests.len());
+            for (((function, cfg_key, body_span), value), _execution) in raw_requests
+                .into_iter()
+                .zip(batch.values.iter())
+                .zip(executions)
+            {
+                #[cfg(test)]
+                self.rooted_cfg_executions
+                    .push((function.clone(), _execution));
+                let record = match value {
+                    crate::cfg_query::CfgValue::Available(record) => record.clone(),
+                    crate::cfg_query::CfgValue::Failure {
+                        errors,
+                        body_span: old_span,
+                    } => {
+                        return Err(PipelineRequestControl::Compile(
+                            crate::cfg_query::import_errors(errors, *old_span, body_span),
+                        ));
+                    }
+                    crate::cfg_query::CfgValue::AccessorFailure { .. } => {
+                        unreachable!("raw CFG queries do not publish accessor-splice failures")
+                    }
+                };
+                let local_air_payload = record.air.payload_store_stats();
+                work.cfg.local_epochs += 1;
+                work.cfg.local_air_instructions += record.air.instructions().len();
+                work.cfg.local_air_payload_bytes += local_air_payload
+                    .word_store_logical_bytes
+                    .saturating_add(local_air_payload.projection_store_logical_bytes)
+                    .saturating_add(local_air_payload.place_store_logical_bytes);
+                work.cfg.local_type_entries += record.type_pool.len();
+                work.cfg.local_aggregate_type_aliases += record.local_aggregate_type_aliases;
+                work.cfg.local_materialized_type_handles += record.local_materialized_type_handles;
+                work.cfg.local_interner_entries += record.interner.len();
+                work.cfg.local_interner_utf8_bytes += record.interner.utf8_bytes();
+                work.cfg.local_strings += record.strings.len();
+                work.cfg.local_atoms += record.local_atoms.len();
+                warnings.extend(crate::cfg_query::import_warnings(
+                    &record.materialization_warnings,
+                    record.body_span,
+                    body_span,
+                ));
+                warnings.extend(crate::cfg_query::import_warnings(
+                    &record.warnings,
+                    record.body_span,
+                    body_span,
+                ));
+                cfgs.push(RootedPreOptimizationCfgUnit {
+                    function,
+                    cfg_key,
+                    record,
+                });
+            }
+            drop(_cfg_collection_span);
+            cfgs.sort_by(|left, right| left.function.cmp(&right.function));
+            sort_rooted_warnings(&graph, &mut warnings);
+            let source = self
+                .published_snapshot
+                .clone()
+                .ok_or_else(|| PipelineRequestControl::Compile(no_published_program()))?;
+            let input = CodegenInputDescriptor {
+                semantic: SemanticInputDescriptor::new(
+                    &source,
+                    options.target,
+                    &options.preview_features,
+                ),
+                opt_level: options.opt_level.into(),
+            };
+            let imports = self
+                .accepted_semantic_import_graph()
+                .map_err(PipelineRequestControl::Compile)?;
+            let diagnostics = self.publish_diagnostics(
+                &source,
+                FrontendDiagnosticIdentity::Semantic(semantic_diagnostic_input(&input, imports)),
+                None,
+                &warnings,
+            );
+            self.diagnostics.select_snapshot(&diagnostics);
+            self.refresh_retention_metrics();
+            return Ok(publish_pre(RootedPreOptimizationCfgOutput {
+                cfgs,
+                raw_cfg_batch,
+                _raw_cfg_terminal: batch_terminal,
+                warnings,
+                work,
+            }));
         }
         let accessor_subgraph = crate::cfg_query::accessor_cfg_subgraph(raw_accessor_keys)
             .map_err(|failure| {
@@ -5639,6 +5957,24 @@ impl CompilerSession {
                 body_span,
             });
         }
+        if self.oracle_fault == Some(crate::unstable::DifferentialOracleFault::CfgTransformation) {
+            self.oracle_fault.take();
+            let main = cfgs
+                .iter_mut()
+                .find(|unit| unit.function == main_identity)
+                .expect("successful rooted CFG publishes main");
+            let record = Arc::make_mut(&mut main.record);
+            if !record
+                .cfg
+                .inject_differential_comparison_fault(&record.type_pool)
+            {
+                return Err(CompileError::without_span(ErrorKind::InternalError(
+                    "differential CFG transformation fault had no equality comparison to corrupt"
+                        .into(),
+                ))
+                .into());
+            }
+        }
         drop(_cfg_collection_span);
 
         // Preserve the canonical backend/presentation order independently of
@@ -5707,7 +6043,7 @@ impl CompilerSession {
         self.diagnostics.select_snapshot(&diagnostics);
         self.refresh_retention_metrics();
 
-        Ok(RootedCfgOutput {
+        Ok(publish_post(RootedCfgOutput {
             graph,
             cfgs,
             optimized_cfg_batch: cfg_batch_key,
@@ -5715,7 +6051,7 @@ impl CompilerSession {
             work,
             backend_work,
             backend_root,
-        })
+        }))
     }
 
     pub(crate) fn rooted_codegen(
@@ -6235,6 +6571,16 @@ impl CompilerSession {
         &self,
     ) -> crate::revisioned_query_database::PublishedBackendRootMetrics {
         self.queries.revisioned.backend_root_metrics_for_test()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn raw_cfg_handoff_is_published(
+        &self,
+        output: &RootedPreOptimizationCfgOutput,
+    ) -> bool {
+        self.queries
+            .revisioned
+            .raw_cfg_handoff_matches_terminal_for_test(&output._raw_cfg_terminal)
     }
 
     #[cfg(test)]

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -524,7 +524,7 @@ pub fn committed_successor_sharing(
 
 pub use crate::session::{
     ClosedDiscoveryContinuation, RootedCfgOutput, RootedCfgUnit, RootedParkOutcome,
-    TrustedSuccessorDelta,
+    RootedPreOptimizationCfgOutput, RootedPreOptimizationCfgUnit, TrustedSuccessorDelta,
 };
 
 /// Run the production body-closure root without constructing a presentation
@@ -915,6 +915,16 @@ pub fn rooted_cfg(
     options: &crate::CompileOptions,
 ) -> Result<RootedCfgOutput, crate::CompileErrors> {
     session.rooted_cfg(options)
+}
+
+/// Query the canonical reached raw CFGs before mandatory accessor
+/// materialization and optimization. This unstable endpoint is intended for
+/// differential tests; production codegen continues to consume [`rooted_cfg`].
+pub fn rooted_pre_optimization_cfg(
+    session: &mut crate::CompilerSession,
+    options: &crate::CompileOptions,
+) -> Result<RootedPreOptimizationCfgOutput, crate::CompileErrors> {
+    session.rooted_pre_optimization_cfg(options)
 }
 
 /// Assert warm/fresh parity for one retained source revision. This is an
@@ -2835,6 +2845,7 @@ impl MetricsSnapshot {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DifferentialOracleFault {
     Semantic,
+    CfgTransformation,
     Diagnostic,
     Import,
 }

--- a/crates/rue-fuzz/BUCK
+++ b/crates/rue-fuzz/BUCK
@@ -11,6 +11,7 @@ rue_binary(
         "//crates/rue-compiler:rue-compiler",
         "//crates/rue-error:rue-error",
         "//crates/rue-lexer:rue-lexer",
+        "//crates/rue-oracle:rue-oracle",
         "//crates/rue-parser:rue-parser",
         "//crates/rue-rir:rue-rir",
         "//crates/rue-rir:rue-rir-fuzz-support",

--- a/crates/rue-fuzz/src/targets.rs
+++ b/crates/rue-fuzz/src/targets.rs
@@ -5,8 +5,9 @@
 //! same endpoint (RUE-776):
 //! - `lexer`: tokenization only.
 //! - `parser`: tokenization + AST construction.
-//! - `sema`: frontend through the canonical rooted optimized-CFG artifact,
-//!   including type checking, name resolution, affine checking, and CFG work.
+//! - `sema`: frontend through canonical raw/post-transform CFG execution,
+//!   including type checking, name resolution, affine checking, CFG work, and
+//!   an observable-semantics check across mandatory CFG transformations.
 //! - `compiler`: the *whole* pipeline — frontend, MIR
 //!   lowering, register allocation, machine emission, and internal linking to a
 //!   finished executable. Strictly deeper than `sema`.
@@ -76,15 +77,97 @@ mod ice_classification_tests {
     }
 }
 
-/// Run the canonical frontend root through optimized CFG construction. This is
-/// the endpoint of the `sema` target, with no machine backend or linker work.
-fn query_semantics(source: &str) -> rue_compiler::MultiErrorResult<()> {
+/// Run the canonical frontend root through optimized CFG construction. The
+/// `sema` target pairs this ICE check with observable raw/post-transform CFG
+/// execution, with no machine backend or linker work.
+fn query_semantics(source: &str) -> rue_compiler::MultiErrorResult<rue_compiler::CompilerSession> {
     let snapshot = rue_compiler::SourceSnapshot::single("<fuzz>", source)
         .map_err(rue_compiler::CompileErrors::from)?;
     let mut session = rue_compiler::CompilerSession::new();
     session.update(&snapshot).into_result()?;
-    rue_compiler::unstable::rooted_cfg(&mut session, &rue_compiler::CompileOptions::default())
-        .map(drop)
+    rue_compiler::unstable::rooted_cfg(&mut session, &rue_compiler::CompileOptions::default())?;
+    Ok(session)
+}
+
+fn assert_cfg_boundary_agreement(session: rue_compiler::CompilerSession) {
+    match rue_oracle::run_session_with_cfg_differential(session, &rue_error::PreviewFeatures::new())
+    {
+        Ok(_) => {}
+        Err(rue_oracle::RunSourceError::Unsupported(unsupported)) => {
+            assert_cfg_unsupported_policy(&unsupported);
+        }
+        Err(rue_oracle::RunSourceError::Compile(errors)) => assert_no_ice_errors(&errors),
+        Err(rue_oracle::RunSourceError::CfgTransformationDisagreement {
+            pre_optimization,
+            post_optimization,
+        }) => {
+            panic!(
+                "pre/post CFG execution disagreement: pre={pre_optimization:?}, post={post_optimization:?}"
+            );
+        }
+    }
+}
+
+fn assert_cfg_unsupported_policy(unsupported: &rue_oracle::Unsupported) {
+    if let Some(message) = cfg_unsupported_failure(
+        unsupported.class(),
+        unsupported.kind(),
+        unsupported.detail(),
+    ) {
+        panic!("{message}");
+    }
+}
+
+fn cfg_unsupported_failure(
+    class: rue_oracle::UnsupportedClass,
+    kind: rue_oracle::UnsupportedKind,
+    detail: &str,
+) -> Option<String> {
+    match class {
+        rue_oracle::UnsupportedClass::SemanticGap
+        | rue_oracle::UnsupportedClass::ExternalDependency
+        | rue_oracle::UnsupportedClass::ImplementationDefined
+        | rue_oracle::UnsupportedClass::ResourceLimit => None,
+        rue_oracle::UnsupportedClass::ContractViolation => Some(format!(
+            "oracle contract violation during CFG-boundary fuzz check: kind={kind:?}, detail={detail}"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod cfg_unsupported_policy_tests {
+    use super::cfg_unsupported_failure;
+    use rue_oracle::{
+        ContractViolationKind, ExternalDependencyKind, ImplementationDefinedKind,
+        ResourceLimitKind, SemanticGapKind, UnsupportedClass, UnsupportedKind,
+    };
+
+    #[test]
+    fn contract_violations_fail_closed_with_kind_and_detail() {
+        let message = cfg_unsupported_failure(
+            UnsupportedClass::ContractViolation,
+            UnsupportedKind::ContractViolation(ContractViolationKind::UnsplicedAccessor),
+            "accessor call remained in transformed CFG",
+        )
+        .expect("contract violations must produce a fail-closed fuzz failure");
+        assert!(message.contains("UnsplicedAccessor"));
+        assert!(message.contains("accessor call remained in transformed CFG"));
+    }
+
+    #[test]
+    fn expected_gaps_and_bounded_resource_limits_remain_skippable() {
+        for kind in [
+            UnsupportedKind::SemanticGap(SemanticGapKind::FlattenedParameterSlot),
+            UnsupportedKind::ExternalDependency(ExternalDependencyKind::RandomU32),
+            UnsupportedKind::ImplementationDefined(ImplementationDefinedKind::StringCapacityValue),
+            UnsupportedKind::ResourceLimit(ResourceLimitKind::InterpreterSteps),
+        ] {
+            assert_eq!(
+                cfg_unsupported_failure(kind.class(), kind, "expected unsupported execution"),
+                None
+            );
+        }
+    }
 }
 
 /// Build the explicit options used by source-level compiler fuzz targets.
@@ -208,8 +291,10 @@ impl FuzzTarget for SemaTarget {
             // - Affine type checking (partial moves, linearity)
             // - Name resolution
             // - Multi-error collection
-            let result = query_semantics(source);
-            assert_no_ice(&result);
+            match query_semantics(source) {
+                Ok(session) => assert_cfg_boundary_agreement(session),
+                Err(errors) => assert_no_ice_errors(&errors),
+            }
         }
     }
 }
@@ -221,7 +306,7 @@ impl FuzzTarget for SemaTarget {
 /// finished executable or return ordinary errors.
 ///
 /// This is deliberately a deeper boundary than [`SemaTarget`], which stops at
-/// the canonical optimized-CFG root. Where sema fuzzes type inference, name
+/// canonical CFG execution. Where sema fuzzes type inference, name
 /// resolution, affine checking, and CFG construction, this target additionally exercises MIR
 /// lowering, register allocation, machine emission, and internal linking — the
 /// backend phases where a distinct family of ICEs lives. Keeping the two on
@@ -1793,8 +1878,9 @@ mod tests {
     fn compiler_target_is_deeper_than_sema() {
         let source = "fn main() -> i32 { 42 }";
 
-        // sema endpoint: the rooted optimized-CFG query, no backend artifact.
-        query_semantics(source).expect("sema query succeeds on a valid program");
+        // sema endpoint: rooted CFG queries and execution, no backend artifact.
+        let session = query_semantics(source).expect("sema query succeeds on a valid program");
+        assert_cfg_boundary_agreement(session);
 
         // compiler endpoint: a fully linked executable image. The concrete
         // object format is host-dependent (ELF or Mach-O), so only its presence

--- a/crates/rue-oracle-diff/BUCK
+++ b/crates/rue-oracle-diff/BUCK
@@ -4,7 +4,9 @@ load("//:corpus.bzl", "cached_corpus_suite")
 # The differential harness. Two modes:
 #  * default: runs the concrete rue-cli-tests corpus through the rue-oracle
 #    reference interpreter and checks it agrees with each case's expected exit
-#    code / stdout / stderr (a mismatch localizes to codegen; wired as the sh_test below).
+#    code / stdout / stderr after first checking the canonical raw/post-transform
+#    CFG boundary (a mismatch localizes to CFG transformation or later codegen;
+#    wired as the sh_test below).
 #  * `fuzz`: the differential *fuzzer* (RUE-247) — generates random valid
 #    programs and cross-checks the oracle against the real compiler + native
 #    binary, reporting exit/stdout/stderr disagreements as miscompiles and generated

--- a/crates/rue-oracle-diff/src/fuzz.rs
+++ b/crates/rue-oracle-diff/src/fuzz.rs
@@ -3,7 +3,7 @@
 //! Generate random **valid** Rue programs (see [`crate::gen`]) and run each one
 //! through *both* engines:
 //!
-//! 1. the [`rue_oracle`] reference interpreter (`run_source`), and
+//! 1. the [`rue_oracle`] reference interpreter at both canonical CFG boundaries,
 //! 2. the real compiler + the produced native binary.
 //!
 //! Then compare the observable behavior — process exit code, stdout, stderr,
@@ -25,7 +25,7 @@
 use crate::{generator, trap::native_runtime_trap_kind};
 use rue_oracle::{
     MAX_STDERR_BYTES, MAX_STDOUT_BYTES, RunSourceError, TrapKind, Unsupported, UnsupportedKind,
-    run_source,
+    run_source_cfg_differential,
 };
 use std::io::Read;
 use std::os::unix::process::ExitStatusExt;
@@ -78,6 +78,12 @@ impl GeneratorContractFailure {
         match error {
             RunSourceError::Compile(errors) => Self::Compile(format!("{errors:#?}")),
             RunSourceError::Unsupported(unsupported) => Self::Unsupported(unsupported),
+            RunSourceError::CfgTransformationDisagreement {
+                pre_optimization,
+                post_optimization,
+            } => Self::Invariant(format!(
+                "pre/post CFG execution disagreement: pre={pre_optimization:?}, post={post_optimization:?}"
+            )),
         }
     }
 
@@ -269,7 +275,7 @@ pub fn run(args: &[String]) -> ExitCode {
     for seed in cfg.start..seed_end {
         let source = generator::generate(seed);
 
-        let oracle = match run_source(&source) {
+        let oracle = match run_source_cfg_differential(&source) {
             Err(error) => {
                 // Unlike corpus mode, generated mode has a strong input
                 // contract: every program must compile and remain within the
@@ -1098,7 +1104,8 @@ mod tests {
     fn generated_oracle_errors_remain_typed_contract_failures() {
         // A frontend rejection is a generator compile-contract failure, not an
         // oracle Unsupported skip and not a native `Compiled::CompileFail`.
-        let compile_error = run_source("fn main(").expect_err("invalid Rue must not compile");
+        let compile_error =
+            rue_oracle::run_source("fn main(").expect_err("invalid Rue must not compile");
         let compile_failure = GeneratorContractFailure::from_run_source(compile_error);
         assert!(matches!(
             compile_failure,
@@ -1108,7 +1115,7 @@ mod tests {
         // A compiled-but-unmodeled program is the other distinct contract
         // failure class. Keep the variant typed so summaries/repros cannot
         // collapse it back into the old generic skip path.
-        let unsupported = run_source(
+        let unsupported = rue_oracle::run_source(
             "fn main() -> i32 { let n: u32 = @random_u32(); if n == 0 { 0 } else { 1 } }",
         )
         .expect_err("randomness must remain outside the deterministic oracle");

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -4,11 +4,12 @@
 //! reference interpreter and checks the oracle agrees with each case's expected
 //! exit code / stdout / stderr. Those expectations are what the *compiled binary*
 //! already produces (the CLI suite enforces that), so a disagreement here means
-//! the oracle and the compiler disagree — which, since the oracle is an
-//! independent implementation of the semantics operating *before* codegen,
-//! localizes a miscompile. This is the automated bug-catcher of RUE-50: it
-//! turns "we check the outputs we thought to write down" into "we check that
-//! the semantics and codegen agree on every program in the corpus."
+//! the oracle and the compiler disagree. The harness first executes the
+//! canonical raw CFG before and after mandatory CFG transformations, then
+//! compares the post-transform O0 oracle with expected/native behavior, separating CFG disagreements
+//! from later lowering/codegen disagreements. This is the automated bug-catcher
+//! of RUE-50: it turns "we check the outputs we thought to write down" into "we
+//! check that the semantics and compiler agree on every program in the corpus."
 //!
 //! Modes:
 //!
@@ -57,8 +58,8 @@ use rue_compiler::{
 };
 use rue_error::{PreviewFeature, PreviewFeatures};
 use rue_oracle::{
-    ModelGapKind, Outcome, RunSourceError, TrapKind, run_session_with_preview_features,
-    run_source_with_preview_features,
+    ModelGapKind, Outcome, RunSourceError, TrapKind, run_session_with_cfg_differential,
+    run_source_with_cfg_differential,
 };
 use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
@@ -722,7 +723,7 @@ fn run_source_with_real_std(
         if frontier.requests().is_empty() {
             close_import_input_request(&mut session, revision)
                 .map_err(|errors| format!("{errors:#?}"))?;
-            return Ok(run_session_with_preview_features(session, preview_features));
+            return Ok(run_session_with_cfg_differential(session, preview_features));
         }
         let mut observations = Vec::new();
         for request in frontier.requests().iter().cloned() {
@@ -858,7 +859,7 @@ fn check_spec_case_with_known_gap(
             }
         }
     } else {
-        run_source_with_preview_features(&case.source, &preview_features)
+        run_source_with_cfg_differential(&case.source, &preview_features)
     };
     match oracle_result {
         // Only Unsupported values carrying a registrable ModelGapKind count as
@@ -1105,7 +1106,7 @@ fn check_case(path: &Path, case: &Case) -> CaseOutcome {
             }
         }
     } else {
-        run_source_with_preview_features(source, &preview_features)
+        run_source_with_cfg_differential(source, &preview_features)
     };
     match oracle_result {
         Err(error) => {
@@ -1244,6 +1245,12 @@ fn record_oracle_error(context: &str, error: RunSourceError) -> CaseOutcome {
                 ))
             }
         }
+        RunSourceError::CfgTransformationDisagreement {
+            pre_optimization,
+            post_optimization,
+        } => CaseOutcome::OracleFailure(format!(
+            "{context}\n      pre/post CFG execution disagreement: pre={pre_optimization:?}, post={post_optimization:?}"
+        )),
     }
 }
 
@@ -2314,6 +2321,30 @@ files = [{ path = "probe.rue", source = "not Rue" }]
                 rue_oracle::ExternalDependencyKind::RandomU32
             )))
         );
+    }
+
+    #[test]
+    fn cfg_transformation_disagreement_is_a_hard_oracle_failure() {
+        let pre_optimization = Outcome {
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+            panic: None,
+        };
+        let mut post_optimization = pre_optimization.clone();
+        post_optimization.exit_code = 1;
+
+        let outcome = record_oracle_error(
+            "CFG boundary probe",
+            RunSourceError::CfgTransformationDisagreement {
+                pre_optimization: Ok(pre_optimization),
+                post_optimization: Ok(post_optimization),
+            },
+        );
+        let CaseOutcome::OracleFailure(message) = outcome else {
+            panic!("CFG transformation disagreements must not become model gaps");
+        };
+        assert!(message.contains("pre/post CFG execution disagreement"));
     }
 
     #[test]

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -1,17 +1,20 @@
 //! # rue-oracle — the executable reference semantics
 //!
 //! A tree-walking interpreter over the compiler's **CFG** (the typed
-//! control-flow IR, produced by `CompilerSession`, *before* the
-//! MIR/codegen lowering where every miscompile of the 2026-07 work lived).
+//! control-flow IR, produced by `CompilerSession`, before MIR/codegen). The
+//! native differential retains the canonical post-transform O0 observation,
+//! while the CFG-boundary differential also executes the raw CFG artifact.
+//! This keeps mandatory CFG transformations out of the shared trusted base.
 //! Running a program through this interpreter and through the compiled binary
 //! and comparing the observable behavior (exit code, stdout, stderr, trap cause)
 //! is the differential-testing oracle of RUE-50, and the executable form of the
 //! operational semantics in `docs/formal/01-core-calculus.md` §6.
 //!
-//! Because the interpreter shares the compiler's *front half* (parser + sema +
-//! CFG build) but is an entirely independent *back half*, a disagreement between
-//! it and the compiled binary localizes a bug to lowering/codegen — exactly the
-//! layer that has been buggy.
+//! Because the interpreter shares parsing, semantic analysis, and raw CFG
+//! construction with the compiler, the paired comparisons localize different
+//! regions without adding a second builder: raw/post CFG disagreement identifies
+//! a mandatory CFG transformation, while post-transform/native disagreement
+//! identifies MIR lowering, code generation, or runtime execution.
 //!
 //! ## Coverage
 //!
@@ -167,19 +170,52 @@ fn query_cfg_state_from_session(
     mut session: CompilerSession,
     options: &CompileOptions,
 ) -> Result<CompileState, CompileErrors> {
-    let rooted = rue_compiler::unstable::rooted_cfg(&mut session, options)?;
-    let functions = rooted
-        .functions()
-        .iter()
-        .map(|function| OracleFunction {
-            #[cfg(test)]
-            source_name: function.definition_source_name().map(str::to_owned),
-            cfg: function.cfg().clone(),
-            interner: function.interner().clone(),
-            type_pool: function.type_pool().clone(),
-            strings: function.strings().clone(),
-        })
-        .collect::<Vec<_>>();
+    query_cfg_state_from_session_at_stage(&mut session, options, CfgStage::PostOptimization)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CfgStage {
+    PreOptimization,
+    PostOptimization,
+}
+
+fn query_cfg_state_from_session_at_stage(
+    session: &mut CompilerSession,
+    options: &CompileOptions,
+    stage: CfgStage,
+) -> Result<CompileState, CompileErrors> {
+    let functions = match stage {
+        CfgStage::PreOptimization => {
+            let rooted = rue_compiler::unstable::rooted_pre_optimization_cfg(session, options)?;
+            rooted
+                .functions()
+                .iter()
+                .map(|function| OracleFunction {
+                    #[cfg(test)]
+                    source_name: function.definition_source_name().map(str::to_owned),
+                    cfg: function.cfg().clone(),
+                    interner: function.interner().clone(),
+                    type_pool: function.type_pool().clone(),
+                    strings: function.strings().clone(),
+                })
+                .collect::<Vec<_>>()
+        }
+        CfgStage::PostOptimization => {
+            let rooted = rue_compiler::unstable::rooted_cfg(session, options)?;
+            rooted
+                .functions()
+                .iter()
+                .map(|function| OracleFunction {
+                    #[cfg(test)]
+                    source_name: function.definition_source_name().map(str::to_owned),
+                    cfg: function.cfg().clone(),
+                    interner: function.interner().clone(),
+                    type_pool: function.type_pool().clone(),
+                    strings: function.strings().clone(),
+                })
+                .collect::<Vec<_>>()
+        }
+    };
     let entry = functions
         .iter()
         .position(|function| function.cfg.fn_name() == "main")
@@ -502,6 +538,12 @@ pub enum RunSourceError {
     /// The source compiled, but interpretation ended with a typed model gap,
     /// resource limit, or compiler/oracle contract violation.
     Unsupported(Unsupported),
+    /// The canonical pre- and post-optimization CFGs produced different
+    /// observable behavior under the same interpreter.
+    CfgTransformationDisagreement {
+        pre_optimization: Result<Outcome, Unsupported>,
+        post_optimization: Result<Outcome, Unsupported>,
+    },
 }
 
 impl fmt::Display for RunSourceError {
@@ -511,6 +553,13 @@ impl fmt::Display for RunSourceError {
             RunSourceError::Unsupported(unsupported) => {
                 write!(f, "unsupported by the oracle: {unsupported}")
             }
+            RunSourceError::CfgTransformationDisagreement {
+                pre_optimization,
+                post_optimization,
+            } => write!(
+                f,
+                "pre/post CFG execution disagreement: pre={pre_optimization:?}, post={post_optimization:?}"
+            ),
         }
     }
 }
@@ -520,6 +569,7 @@ impl std::error::Error for RunSourceError {
         match self {
             RunSourceError::Compile(errors) => Some(errors),
             RunSourceError::Unsupported(unsupported) => Some(unsupported),
+            RunSourceError::CfgTransformationDisagreement { .. } => None,
         }
     }
 }
@@ -550,6 +600,30 @@ pub fn run_source_with_preview_features(
     run_state(state).map_err(RunSourceError::Unsupported)
 }
 
+/// Execute both canonical CFG boundaries and require identical observations.
+/// The returned outcome is the raw-CFG result; the comparison side runs the
+/// existing post-transform O0 pipeline without compiling or executing an
+/// additional native artifact.
+pub fn run_source_with_cfg_differential(
+    source: &str,
+    preview_features: &PreviewFeatures,
+) -> Result<Outcome, RunSourceError> {
+    let snapshot = SourceSnapshot::single("<oracle>", source)
+        .map_err(CompileErrors::from)
+        .map_err(RunSourceError::Compile)?;
+    let mut session = CompilerSession::new();
+    session
+        .update(&snapshot)
+        .into_result()
+        .map_err(RunSourceError::Compile)?;
+    run_session_cfg_differential_inner(&mut session, preview_features)
+}
+
+/// Stable-language convenience form of [`run_source_with_cfg_differential`].
+pub fn run_source_cfg_differential(source: &str) -> Result<Outcome, RunSourceError> {
+    run_source_with_cfg_differential(source, &PreviewFeatures::new())
+}
+
 /// Run a compiler session whose caller has already completed any required
 /// import discovery. This keeps filesystem policy in the harness while letting
 /// the oracle consume the same canonical multi-module compiler state.
@@ -566,6 +640,39 @@ pub fn run_session_with_preview_features(
     )
     .map_err(RunSourceError::Compile)?;
     run_state(state).map_err(RunSourceError::Unsupported)
+}
+
+/// Session-aware form of [`run_source_with_cfg_differential`].
+pub fn run_session_with_cfg_differential(
+    mut session: CompilerSession,
+    preview_features: &PreviewFeatures,
+) -> Result<Outcome, RunSourceError> {
+    run_session_cfg_differential_inner(&mut session, preview_features)
+}
+
+fn run_session_cfg_differential_inner(
+    session: &mut CompilerSession,
+    preview_features: &PreviewFeatures,
+) -> Result<Outcome, RunSourceError> {
+    let options = CompileOptions {
+        preview_features: preview_features.clone(),
+        ..CompileOptions::default()
+    };
+    let pre_state =
+        query_cfg_state_from_session_at_stage(session, &options, CfgStage::PreOptimization)
+            .map_err(RunSourceError::Compile)?;
+    let pre = run_state(pre_state);
+    let post_state =
+        query_cfg_state_from_session_at_stage(session, &options, CfgStage::PostOptimization)
+            .map_err(RunSourceError::Compile)?;
+    let post = run_state(post_state);
+    if pre == post {
+        return pre.map_err(RunSourceError::Unsupported);
+    }
+    Err(RunSourceError::CfgTransformationDisagreement {
+        pre_optimization: pre,
+        post_optimization: post,
+    })
 }
 
 fn run_state(state: CompileState) -> Result<Outcome, Unsupported> {
@@ -965,6 +1072,13 @@ struct Frame {
     /// that allocation so a write through the pointer and a direct read agree.
     /// Keyed by [`promotion_key`] over the slot's [`PlaceBase`].
     promoted: HashMap<u64, usize>,
+    /// Physical by-reference parameter slots bound to their caller locations.
+    /// Ordinary calls retain copy-in/copy-out behavior and leave this empty;
+    /// raw accessor execution uses it to preserve the yielded place identity.
+    param_places: HashMap<u32, PtrTarget>,
+    /// The single trailing accessor `yield` returns its place rather than the
+    /// value loaded from that place.
+    place_return: bool,
 }
 
 enum WritebackPlace<'a> {
@@ -1397,6 +1511,12 @@ impl<'a> Interp<'a> {
                 (slot, cfg.num_params(), width, Some(slot))
             }
             PlaceBase::Indirect(_) => return None,
+            PlaceBase::Accessor(call)
+                if (call.as_u32() as usize) < cfg.value_count()
+                    && matches!(cfg.get_inst(call).data, CfgInstData::AccessorCall { .. }) =>
+            {
+                return None;
+            }
             PlaceBase::Accessor(_) => return Some(ContractViolationKind::UnsplicedAccessor),
         };
         let out_of_bounds = if width == 0 {
@@ -1989,10 +2109,47 @@ impl<'a> Interp<'a> {
         result
     }
 
+    fn call_accessor(
+        &mut self,
+        name: &str,
+        args: &[(Value, Type, CfgArgMode)],
+        param_places: HashMap<u32, PtrTarget>,
+    ) -> Step<PtrTarget> {
+        if self.depth >= MAX_DEPTH {
+            return Err(unsupported(
+                UnsupportedKind::ResourceLimit(ResourceLimitKind::RecursionDepth),
+                "recursion depth budget exhausted",
+            ));
+        }
+        self.depth += 1;
+        let caller = self.state.current_function.load(Ordering::Relaxed);
+        let result = self.call_inner_with_places(name, args, param_places, true);
+        self.state.current_function.store(caller, Ordering::Relaxed);
+        self.depth -= 1;
+        let (value, _) = result?;
+        match value {
+            Value::Ptr(Some(target)) => Ok(target),
+            _ => Err(unsupported(
+                UnsupportedKind::ContractViolation(ContractViolationKind::UnsplicedAccessor),
+                "accessor execution did not return a live place",
+            )),
+        }
+    }
+
     fn call_inner(
         &mut self,
         name: &str,
         args: &[(Value, Type, CfgArgMode)],
+    ) -> Step<(Value, Vec<Option<Value>>)> {
+        self.call_inner_with_places(name, args, HashMap::new(), false)
+    }
+
+    fn call_inner_with_places(
+        &mut self,
+        name: &str,
+        args: &[(Value, Type, CfgArgMode)],
+        param_places: HashMap<u32, PtrTarget>,
+        place_return: bool,
     ) -> Step<(Value, Vec<Option<Value>>)> {
         let function = self.find_function(name).ok_or_else(|| {
             unsupported(
@@ -2036,6 +2193,8 @@ impl<'a> Interp<'a> {
             locals: vec![None; cfg.num_locals() as usize],
             cache: HashMap::new(),
             promoted: HashMap::new(),
+            param_places,
+            place_return,
         };
 
         let mut current = cfg.entry;
@@ -2092,9 +2251,20 @@ impl<'a> Interp<'a> {
             let term = &block.terminator;
             match term {
                 Terminator::Return { value } => {
-                    let ret = match value {
-                        Some(v) => self.eval(cfg, &mut frame, *v)?,
-                        None => Value::Unit,
+                    let ret = match (frame.place_return, value) {
+                        (true, Some(v)) => {
+                            Value::Ptr(Some(self.returned_place_target(cfg, &mut frame, *v)?))
+                        }
+                        (true, None) => {
+                            return Err(unsupported(
+                                UnsupportedKind::ContractViolation(
+                                    ContractViolationKind::UnsplicedAccessor,
+                                ),
+                                "accessor returned without a yielded place",
+                            ));
+                        }
+                        (false, Some(v)) => self.eval(cfg, &mut frame, *v)?,
+                        (false, None) => Value::Unit,
                     };
                     return Ok((ret, std::mem::take(&mut frame.params)));
                 }
@@ -2507,6 +2677,16 @@ impl<'a> Interp<'a> {
                     // not read the slot (that would grab the next parameter's
                     // value); materialize the unique ZST value instead.
                     self.zero_sized_value(ty)
+                } else if let Some(target) = frame.param_places.get(index).cloned() {
+                    // Raw accessor execution redirects by-reference parameter
+                    // slots to their caller places, matching canonical
+                    // accessor splicing for whole-parameter reads.
+                    self.ptr_cell_read(
+                        &target,
+                        UnsupportedKind::ContractViolation(
+                            ContractViolationKind::UnsplicedAccessor,
+                        ),
+                    )?
                 } else if let Some(&a) =
                     frame.promoted.get(&promotion_key(PlaceBase::Param(*index)))
                 {
@@ -2719,14 +2899,50 @@ impl<'a> Interp<'a> {
             // caller via copy-out).
             CfgInstData::ParamStore { param_slot, value } => {
                 let val = self.eval(cfg, frame, *value)?;
-                Self::set_param(frame, *param_slot, val);
+                if let Some(target) = frame.param_places.get(param_slot).cloned() {
+                    // A whole-receiver assignment inside an inout accessor is
+                    // an immediate write to the caller's place; the spliced
+                    // CFG performs the same redirection.
+                    self.ptr_cell_write(
+                        &target,
+                        val,
+                        UnsupportedKind::ContractViolation(
+                            ContractViolationKind::UnsplicedAccessor,
+                        ),
+                    )?;
+                } else {
+                    Self::set_param(frame, *param_slot, val);
+                }
                 Value::Unit
             }
-            CfgInstData::AccessorCall { .. } => {
-                return Err(unsupported(
-                    UnsupportedKind::ContractViolation(ContractViolationKind::UnsplicedAccessor),
-                    "accessor call reached the oracle",
-                ));
+            CfgInstData::AccessorCall { name, .. } => {
+                let fname = self.interner().resolve(name).to_string();
+                let call_args = cfg.get_call_args(&inst.data).to_vec();
+                let arg_types = call_args
+                    .iter()
+                    .map(|arg| cfg.get_inst(arg.value).ty)
+                    .collect::<Vec<_>>();
+                let mut argvals = Vec::with_capacity(call_args.len());
+                let mut param_places = HashMap::new();
+                let mut base = 0usize;
+                for (index, argument) in call_args.iter().enumerate() {
+                    let value = match argument.mode {
+                        CfgArgMode::Borrow | CfgArgMode::Inout => {
+                            let target = self.argument_place_target(cfg, frame, argument.value)?;
+                            param_places.insert(base as u32, target.clone());
+                            self.ptr_cell_read(
+                                &target,
+                                UnsupportedKind::ContractViolation(
+                                    ContractViolationKind::UnsplicedAccessor,
+                                ),
+                            )?
+                        }
+                        CfgArgMode::Normal => self.eval(cfg, frame, argument.value)?,
+                    };
+                    argvals.push((value, arg_types[index], argument.mode));
+                    base += self.call_arg_slot_width(arg_types[index], argument.mode);
+                }
+                Value::Ptr(Some(self.call_accessor(&fname, &argvals, param_places)?))
             }
             CfgInstData::Call { runtime, name, .. } => {
                 let fname = self.interner().resolve(name).to_string();
@@ -3217,6 +3433,58 @@ impl<'a> Interp<'a> {
         Ok((place.base, path))
     }
 
+    fn compose_pointer_path(mut target: PtrTarget, path: &[(usize, Projection)]) -> PtrTarget {
+        for (index, _) in path {
+            target.path.push(target.index as usize);
+            target.index = *index as i128;
+        }
+        target
+    }
+
+    fn external_place_target(
+        &mut self,
+        cfg: &'a Cfg,
+        frame: &mut Frame,
+        base: PlaceBase,
+        path: &[(usize, Projection)],
+    ) -> Step<Option<PtrTarget>> {
+        let target = match base {
+            PlaceBase::Param(slot) => frame.param_places.get(&slot).cloned(),
+            PlaceBase::Accessor(call) => match self.eval(cfg, frame, call)? {
+                Value::Ptr(target) => target,
+                _ => {
+                    return Err(unsupported(
+                        UnsupportedKind::ContractViolation(
+                            ContractViolationKind::UnsplicedAccessor,
+                        ),
+                        "accessor call did not yield a place",
+                    ));
+                }
+            },
+            PlaceBase::Indirect(pointer) => match self.eval(cfg, frame, pointer)? {
+                Value::Ptr(target) => target,
+                _ => None,
+            },
+            PlaceBase::Local(_) => None,
+        };
+        Ok(target.map(|target| Self::compose_pointer_path(target, path)))
+    }
+
+    fn returned_place_target(
+        &mut self,
+        cfg: &'a Cfg,
+        frame: &mut Frame,
+        value: CfgValue,
+    ) -> Step<PtrTarget> {
+        let CfgInstData::PlaceRead { place } = &cfg.get_inst(value).data else {
+            return Err(unsupported(
+                UnsupportedKind::ContractViolation(ContractViolationKind::UnsplicedAccessor),
+                "accessor return is not the trailing yielded place",
+            ));
+        };
+        self.promote_place(cfg, frame, place, cfg.get_inst(value).ty)
+    }
+
     fn base_value(frame: &Frame, base: PlaceBase) -> Step<Value> {
         match base {
             PlaceBase::Local(slot) => Self::get_local(frame, slot),
@@ -3246,6 +3514,12 @@ impl<'a> Interp<'a> {
 
     fn place_read(&mut self, cfg: &'a Cfg, frame: &mut Frame, place: &Place) -> Step<Value> {
         let (base, path) = self.resolve_path(cfg, frame, place)?;
+        if let Some(target) = self.external_place_target(cfg, frame, base, &path)? {
+            return self.ptr_cell_read(
+                &target,
+                UnsupportedKind::ContractViolation(ContractViolationKind::UnsplicedAccessor),
+            );
+        }
         let mut cur = match base {
             PlaceBase::Indirect(pointer) => {
                 let pointer = self.eval(cfg, frame, pointer)?;
@@ -3285,6 +3559,13 @@ impl<'a> Interp<'a> {
         val: Value,
     ) -> Step<()> {
         let (base, path) = self.resolve_path(cfg, frame, place)?;
+        if let Some(target) = self.external_place_target(cfg, frame, base, &path)? {
+            return self.ptr_cell_write(
+                &target,
+                val,
+                UnsupportedKind::ContractViolation(ContractViolationKind::UnsplicedAccessor),
+            );
+        }
         if let PlaceBase::Indirect(pointer) = base {
             let pointer = self.eval(cfg, frame, pointer)?;
             let target = self.expect_ptr(pointer, unsupported_intrinsic_kind("ptr_write"))?;
@@ -3455,6 +3736,28 @@ impl<'a> Interp<'a> {
             other => Err(unsupported(
                 UnsupportedKind::ContractViolation(ContractViolationKind::InoutArgumentNotLvalue),
                 format!("inout argument is not an lvalue: {other:?}"),
+            )),
+        }
+    }
+
+    fn argument_place_target(
+        &mut self,
+        cfg: &'a Cfg,
+        frame: &mut Frame,
+        value: CfgValue,
+    ) -> Step<PtrTarget> {
+        let ty = cfg.get_inst(value).ty;
+        match &cfg.get_inst(value).data {
+            CfgInstData::Load { slot } => {
+                self.promote_place(cfg, frame, &Place::local(*slot, ty), ty)
+            }
+            CfgInstData::Param { index } => {
+                self.promote_place(cfg, frame, &Place::param(*index, ty), ty)
+            }
+            CfgInstData::PlaceRead { place } => self.promote_place(cfg, frame, place, ty),
+            other => Err(unsupported(
+                UnsupportedKind::ContractViolation(ContractViolationKind::InoutArgumentNotLvalue),
+                format!("accessor argument is not a place: {other:?}"),
             )),
         }
     }
@@ -3753,6 +4056,9 @@ impl<'a> Interp<'a> {
         pointee: Type,
     ) -> Step<PtrTarget> {
         let (base, path) = self.resolve_path(cfg, frame, place)?;
+        if let Some(target) = self.external_place_target(cfg, frame, base, &path)? {
+            return Ok(target);
+        }
         let key = promotion_key(base);
         let alloc = if let Some(&a) = frame.promoted.get(&key) {
             a

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -60,6 +60,9 @@ fn expect_unsupported(src: &str) -> Unsupported {
         Err(RunSourceError::Compile(errors)) => {
             panic!("expected oracle-unsupported source, but it failed to compile: {errors:#?}")
         }
+        Err(RunSourceError::CfgTransformationDisagreement { .. }) => {
+            panic!("expected one typed unsupported result, but CFG boundaries disagreed")
+        }
         Ok(outcome) => panic!("expected oracle-unsupported source, got {outcome:?}"),
     }
 }
@@ -71,6 +74,80 @@ fn exit(src: &str) -> i32 {
 #[test]
 fn returns_literal() {
     assert_eq!(exit("fn main() -> i32 { 42 }"), 42);
+}
+
+#[test]
+fn cfg_boundary_differential_is_deterministic() {
+    let source = "fn square(x: i32) -> i32 { x * x } fn main() -> i32 { square(3) }";
+    let first = run_source_cfg_differential(source).expect("CFG boundaries agree");
+    let second = run_source_cfg_differential(source).expect("repeated CFG boundaries agree");
+    assert_eq!(first, second);
+}
+
+#[test]
+fn cfg_boundary_differential_catches_a_planted_transformation_fault() {
+    let source = r#"struct Inner {
+        x: i32,
+        fn value(borrow self) -> borrow i32 { yield self.x; }
+    }
+    fn seven() -> i32 { 7 }
+    fn main() -> i32 {
+        let inner = Inner { x: 7 };
+        if inner.value() == seven() { 0 } else { 1 }
+    }"#;
+    let snapshot = SourceSnapshot::single("<oracle-fault>", source).unwrap();
+    let mut session = CompilerSession::new();
+    session.update(&snapshot).into_result().unwrap();
+    assert!(rue_compiler::unstable::inject_stale_query_for_oracle(
+        &mut session,
+        rue_compiler::unstable::DifferentialOracleFault::CfgTransformation,
+    ));
+    let error = run_session_cfg_differential_inner(&mut session, &PreviewFeatures::new())
+        .expect_err("the planted post-CFG fault must disagree");
+    assert!(
+        matches!(error, RunSourceError::CfgTransformationDisagreement { .. }),
+        "unexpected fault result: {error:?}"
+    );
+}
+
+#[test]
+fn cfg_boundary_differential_preserves_accessor_materialization() {
+    let source = r#"struct Inner {
+        x: i64,
+        fn value(borrow self) -> borrow i64 { yield self.x; }
+    }
+    fn main() -> i32 {
+        let inner = Inner { x: 7 };
+        if inner.value() == 7 { 0 } else { 1 }
+    }"#;
+    assert_eq!(
+        run_source_cfg_differential(source)
+            .expect("pre/post CFGs preserve accessor semantics")
+            .exit_code,
+        0
+    );
+}
+
+#[test]
+fn raw_accessor_whole_receiver_reassignment_matches_spliced_cfg() {
+    let source = r#"struct P {
+        x: i32,
+        fn value(inout self) -> inout i32 {
+            self = P { x: 9 };
+            yield self.x;
+        }
+    }
+    fn main() -> i32 {
+        let mut p = P { x: 1 };
+        p.value() = 11;
+        if p.x == 11 { 0 } else { 1 }
+    }"#;
+    assert_eq!(
+        run_source_cfg_differential(source)
+            .expect("raw accessor parameter redirection matches canonical splicing")
+            .exit_code,
+        0
+    );
 }
 
 #[test]
@@ -390,6 +467,9 @@ fn compile_errors_are_distinct_from_unsupported_programs() {
         }
         RunSourceError::Unsupported(unsupported) => {
             panic!("compile failure was misclassified as unsupported: {unsupported}");
+        }
+        RunSourceError::CfgTransformationDisagreement { .. } => {
+            panic!("compile failure was misclassified as a CFG disagreement");
         }
     }
 }

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -456,6 +456,8 @@ fn user_call_layout_is_rejected_before_unmodeled_operands_run() {
             locals: vec![None; cfg.num_locals() as usize],
             cache: HashMap::new(),
             promoted: HashMap::new(),
+            param_places: HashMap::new(),
+            place_return: false,
         };
         let unsupported = expect_flow_unsupported(interp.eval(cfg, &mut frame, call));
         assert_eq!(
@@ -552,6 +554,8 @@ fn abort_intrinsic_static_contracts_precede_unmodeled_operands() {
             locals: vec![None; cfg.num_locals() as usize],
             cache: HashMap::new(),
             promoted: HashMap::new(),
+            param_places: HashMap::new(),
+            place_return: false,
         };
         let unsupported = expect_flow_unsupported(interp.eval(cfg, &mut frame, outer));
         assert_eq!(
@@ -588,6 +592,8 @@ fn abort_intrinsics_require_exact_runtime_value_shapes() {
             locals: vec![None; cfg.num_locals() as usize],
             cache: HashMap::new(),
             promoted: HashMap::new(),
+            param_places: HashMap::new(),
+            place_return: false,
         };
         let corrupted = if name == "panic" { args[0] } else { args[1] };
         frame.cache.insert(corrupted.as_u32(), Value::Int(7));
@@ -617,6 +623,8 @@ fn abort_intrinsics_require_exact_runtime_value_shapes() {
         locals: vec![None; cfg.num_locals() as usize],
         cache: HashMap::new(),
         promoted: HashMap::new(),
+        param_places: HashMap::new(),
+        place_return: false,
     };
     frame.cache.insert(args[0].as_u32(), Value::Int(1));
     let unsupported = expect_flow_unsupported(interp.eval(cfg, &mut frame, assertion));

--- a/crates/rue-oracle/src/tests/place_contracts.rs
+++ b/crates/rue-oracle/src/tests/place_contracts.rs
@@ -33,6 +33,8 @@ fn flattened_parameter_padding_is_a_semantic_gap_but_oob_is_a_contract_failure()
         locals: Vec::new(),
         cache: HashMap::new(),
         promoted: HashMap::new(),
+        param_places: HashMap::new(),
+        place_return: false,
     };
 
     let padding = expect_flow_unsupported(Interp::base_value(&frame, PlaceBase::Param(1)));
@@ -133,6 +135,8 @@ fn matching_cfg_metadata_is_required_before_a_runtime_symptom_is_registrable() {
         locals: vec![None; cfg.num_locals() as usize],
         cache: HashMap::new(),
         promoted: HashMap::new(),
+        param_places: HashMap::new(),
+        place_return: false,
     };
     let projection = expect_flow_unsupported(interp.place_read(cfg, &mut frame, field_place));
     assert_eq!(
@@ -356,6 +360,8 @@ fn validated_cfg_rejects_invalid_owned_text_projection_metadata() {
         locals: vec![None; view_cfg.num_locals() as usize],
         cache: HashMap::new(),
         promoted: HashMap::new(),
+        param_places: HashMap::new(),
+        place_return: false,
     };
     // A non-aggregate value under str projection metadata: reading a field of
     // it must be a contract violation, not a silent success.


### PR DESCRIPTION
## Summary
- publish the canonical pre-optimization CFG batch through the existing query graph
- execute raw accessor-place semantics independently and compare them with post-transform O0
- wire fail-closed CFG-boundary checks through corpus, spec, generated, and sema fuzz modes

## Validation
- focused compiler, CFG, oracle, and fuzz unit tests
- both oracle-diff corpus targets
- scripts/rue quick
- scripts/rue premerge
- scripts/rue test
- scripts/rue fmt
- git diff --check

Fixes RUE-1718