### PR TITLE
RUE-1821: preserve inline ownership transfers

### DIFF
--- a/crates/rue-cfg/src/inline.rs
+++ b/crates/rue-cfg/src/inline.rs
@@ -475,6 +475,16 @@ pub fn splice_call_in_block(
                 .max(type_pool.abi_slot_count(arg_ty))
                 .max(1);
             let slot = dst.alloc_temp_local_slots(width);
+            // A droppable value is an ownership transfer, not an ordinary
+            // single-assignment temporary. Keep its loads as the callee-owned
+            // value through all post-splice optimization; forwarding them to
+            // `argument` would erase the boundary and can make the caller
+            // drop the moved value a second time. Copy parameters need no
+            // boundary: forwarding those remains semantically and
+            // optimization-wise harmless.
+            if type_pool.type_needs_drop(arg_ty) {
+                dst.mark_ownership_boundary(slot);
+            }
             if callee.is_param_address_taken(param.start_slot) {
                 // The callee took the parameter's address; the escape fact
                 // must carry to the materialized slot (RUE-521).
@@ -490,7 +500,6 @@ pub fn splice_call_in_block(
         u64::try_from(materialized.len()).unwrap_or(u64::MAX),
         "splice plan and materialization lowering must agree"
     );
-
     // -- Rebase the callee's frame onto the caller's. -----------------------
     let local_base = if callee.num_locals() > 0 {
         dst.alloc_temp_local_slots(callee.num_locals())
@@ -500,6 +509,9 @@ pub fn splice_call_in_block(
     for slot in 0..callee.num_locals() {
         if callee.is_address_taken(slot) {
             dst.mark_address_taken(slot + local_base);
+        }
+        if callee.is_ownership_boundary(slot) {
+            dst.mark_ownership_boundary(slot + local_base);
         }
     }
 
@@ -545,11 +557,25 @@ pub fn splice_call_in_block(
         let data = translate_data(&mut dst, callee, &source.data, &splice)?;
         // Spans are copied verbatim so a future location-carrying trap
         // mechanism inherits the callee's real source position (ADR-0049 §7).
+        let translated = splice.value(CfgValue::from_raw(index as u32));
         dst.add_inst(CfgInst {
             data,
             ty: source.ty,
             span: source.span,
         });
+        // A callee may already be the result of an inline splice. Rebase its
+        // per-value ownership facts through the same value map as its code;
+        // otherwise a nested callee's protected transfer Load becomes an
+        // ordinary Load when copied into this caller.
+        if callee.is_ownership_boundary_value(CfgValue::from_raw(index as u32)) {
+            dst.mark_ownership_boundary_value(translated);
+        }
+        if let CfgInstData::Param { index } = source.data
+            && let Some(ParamRedirect::Materialized { slot }) = redirects.get(&index)
+            && dst.is_ownership_boundary(*slot)
+        {
+            dst.mark_ownership_boundary_value(translated);
+        }
     }
 
     // -- Wire the continuation join. ----------------------------------------
@@ -1537,6 +1563,34 @@ mod tests {
             slot >= caller_locals,
             "the dropped value comes from a fresh caller slot, not an original one"
         );
+        assert!(
+            inlined.is_ownership_boundary(slot),
+            "the materialized parameter slot must be marked as an ownership boundary"
+        );
+        assert!(
+            inlined.is_ownership_boundary_value(drop_operand),
+            "the callee-owned parameter Load must be marked as an ownership boundary"
+        );
+
+        // Reoptimization is the production path that used to forward this
+        // single-write slot back to the caller argument. The copied drop must
+        // still read the materialized slot after O3 cleanup.
+        let (optimized, _) = crate::opt::optimize_with_stats(
+            inlined.clone(),
+            crate::opt::OptLevel::O3,
+            &program.type_pool,
+        )
+        .unwrap();
+        let optimized_drop_operand = attached_values(&optimized)
+            .find_map(|value| match optimized.get_inst(value).data {
+                CfgInstData::Drop { value } => Some(value),
+                _ => None,
+            })
+            .unwrap();
+        assert!(matches!(
+            optimized.get_inst(optimized_drop_operand).data,
+            CfgInstData::Load { slot: optimized_slot } if optimized_slot == slot
+        ));
 
         // Callee-lifetime storage bracket for the materialized slot.
         assert_eq!(
@@ -1702,7 +1756,19 @@ mod tests {
             0
         );
         assert_eq!(count_calls(&inlined), 0);
+        let translated_load = attached_values(&inlined)
+            .find(|&value| matches!(inlined.get_inst(value).data, CfgInstData::Load { .. }))
+            .expect("the copied parameter should initially be represented by a Load");
+        assert!(!inlined.is_ownership_boundary_value(translated_load));
         assert_all_blocks_terminated(&inlined);
+        let (optimized, _) =
+            crate::opt::optimize_with_stats(inlined, crate::opt::OptLevel::O3, &program.type_pool)
+                .unwrap();
+        assert!(
+            !attached_values(&optimized)
+                .any(|value| matches!(optimized.get_inst(value).data, CfgInstData::Load { .. })),
+            "copy-only parameter Loads must still forward during O3"
+        );
     }
 
     #[test]
@@ -3255,6 +3321,46 @@ mod tests {
             inlined.is_address_taken(0),
             "the callee's parameter escape fact must pin the materialized slot (RUE-521)"
         );
+        assert!(
+            !inlined.is_ownership_boundary(0),
+            "Copy parameter materialization must remain optimizable"
+        );
+        let translated_load = attached_values(&inlined)
+            .find(|&value| matches!(inlined.get_inst(value).data, CfgInstData::Load { slot: 0 }))
+            .expect("the copied parameter should initially be represented by a Load");
+        assert!(
+            !inlined.is_ownership_boundary_value(translated_load),
+            "copy-only materialization must not acquire an ownership barrier"
+        );
+    }
+
+    #[test]
+    fn preexisting_callee_boundary_value_survives_a_nested_splice() {
+        let pool = synthetic_pool();
+        let interner = ThreadedRodeo::new();
+        let mut callee = Cfg::new(Type::I64, 0, 1, "callee".to_string(), vec![false]);
+        let entry = callee.new_block();
+        callee.entry = entry;
+        let param = callee.append_inst(entry, inst(CfgInstData::Param { index: 0 }, Type::I64));
+        // Simulate a callee that was itself produced by an earlier splice.
+        // This marker is not inferred from the scalar type, so only copying
+        // the callee's value metadata through the splice can preserve it.
+        callee.mark_ownership_boundary_value(param);
+        callee.set_return(entry, Some(param));
+        let callee = callee.finish(&pool).unwrap();
+        let (caller, call) = synthetic_caller(&pool, &interner, crate::CfgArgMode::Normal);
+
+        let inlined = inline_call(&caller, call, &callee, &pool).unwrap();
+        let protected_load = attached_values(&inlined)
+            .find(|&value| {
+                matches!(inlined.get_inst(value).data, CfgInstData::Load { slot: 0 })
+                    && inlined.is_ownership_boundary_value(value)
+            })
+            .expect("nested splice must retain the callee's marked value");
+        assert!(matches!(
+            inlined.get_inst(protected_load).data,
+            CfgInstData::Load { slot: 0 }
+        ));
     }
 
     #[test]

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -748,6 +748,21 @@ pub struct Cfg {
     /// RUE-521 O1+ segfault. By-ref call arguments are the analogous
     /// per-instruction escape, handled directly in constopt's scan.
     address_taken_slots: AHashSet<u32>,
+    /// Local slots that are ownership-transfer boundaries introduced by a
+    /// CFG transform (currently CFG inlining). Values are moved into these
+    /// regions with an `Alloc`; the corresponding translated parameter Loads
+    /// are recorded in `ownership_boundary_values` so only the ownership-
+    /// consuming reads remain tied to the callee-owned region.
+    ///
+    /// This is deliberately separate from `address_taken_slots`: an ownership
+    /// boundary does not imply that a raw pointer escapes, so it must not be
+    /// presented to codegen or alias analysis as an address escape.
+    ownership_boundary_slots: AHashSet<u32>,
+    /// SSA loads that materialize an ownership-transfer parameter. Unlike a
+    /// slot-wide optimizer barrier, this preserves the transfer through
+    /// forwarding while allowing a returned load to continue with the
+    /// caller's owner.
+    ownership_boundary_values: AHashSet<CfgValue>,
     /// Parameter ABI slots whose ADDRESS escapes through an address-taking
     /// intrinsic (`@raw` / `@raw_mut` / `@field_ptr` applied to a parameter),
     /// recorded at construction like `address_taken_slots`. A by-value
@@ -1059,6 +1074,8 @@ impl Clone for Cfg {
             fn_name: self.fn_name.clone(),
             param_modes: self.param_modes.clone(),
             address_taken_slots: self.address_taken_slots.clone(),
+            ownership_boundary_slots: self.ownership_boundary_slots.clone(),
+            ownership_boundary_values: self.ownership_boundary_values.clone(),
             address_taken_params: self.address_taken_params.clone(),
             source_param_abi: self.source_param_abi.clone(),
             capacity_exceeded: self.capacity_exceeded,
@@ -1090,6 +1107,8 @@ impl Cfg {
         );
         cfg.entry = self.entry;
         cfg.address_taken_slots = self.address_taken_slots.clone();
+        cfg.ownership_boundary_slots = self.ownership_boundary_slots.clone();
+        cfg.ownership_boundary_values = self.ownership_boundary_values.clone();
         cfg.address_taken_params = self.address_taken_params.clone();
         // Descriptors carry a type only for a by-value indirect aggregate
         // parameter, remapped across pools like any other CFG type (RUE-1005).
@@ -1372,6 +1391,8 @@ impl Cfg {
             fn_name,
             param_modes: param_modes.into(),
             address_taken_slots: AHashSet::new(),
+            ownership_boundary_slots: AHashSet::new(),
+            ownership_boundary_values: AHashSet::new(),
             address_taken_params: AHashSet::new(),
             source_param_abi: Vec::new(),
             capacity_exceeded: None,
@@ -1398,6 +1419,30 @@ impl Cfg {
     #[inline]
     pub fn is_address_taken(&self, slot: u32) -> bool {
         self.address_taken_slots.contains(&slot)
+    }
+
+    /// Mark a local slot as an ownership-transfer boundary. Optimizations that
+    /// substitute local loads must preserve the load at this boundary so the
+    /// destination local remains the owner of the transferred value.
+    #[inline]
+    pub(crate) fn mark_ownership_boundary(&mut self, slot: u32) {
+        self.ownership_boundary_slots.insert(slot);
+    }
+
+    /// Whether a local slot is an ownership-transfer boundary.
+    #[inline]
+    pub(crate) fn is_ownership_boundary(&self, slot: u32) -> bool {
+        self.ownership_boundary_slots.contains(&slot)
+    }
+
+    #[inline]
+    pub(crate) fn mark_ownership_boundary_value(&mut self, value: CfgValue) {
+        self.ownership_boundary_values.insert(value);
+    }
+
+    #[inline]
+    pub(crate) fn is_ownership_boundary_value(&self, value: CfgValue) -> bool {
+        self.ownership_boundary_values.contains(&value)
     }
 
     /// Record that parameter ABI slot `slot`'s address escapes through an
@@ -2718,8 +2763,17 @@ impl Cfg {
         &mut self,
         map: impl Fn(CfgValue) -> CfgValue,
     ) -> Result<(), CfgEditError> {
+        let boundary_values = self
+            .ownership_boundary_values
+            .iter()
+            .copied()
+            .map(|value| (value, map(value)))
+            .collect::<Vec<_>>();
         let mut rewritten = self.clone();
         rewritten.rewrite_value_uses_in_place(map)?;
+        for (_, replacement) in boundary_values {
+            rewritten.ownership_boundary_values.insert(replacement);
+        }
         *self = rewritten;
         Ok(())
     }
@@ -3746,6 +3800,7 @@ mod tests {
         let else_block = cfg.new_block();
         let exit = cfg.new_block();
         cfg.entry = entry;
+        cfg.mark_ownership_boundary(1);
         let old = cfg.append_inst(
             entry,
             CfgInst {
@@ -3754,6 +3809,7 @@ mod tests {
                 span: Span::new(3, 4),
             },
         );
+        cfg.mark_ownership_boundary_value(old);
         let replacement = cfg.append_inst(
             entry,
             CfgInst {
@@ -3843,6 +3899,8 @@ mod tests {
 
         let cloned = cfg.clone();
         assert_eq!(cloned.to_string(), cfg.to_string());
+        assert!(cloned.is_ownership_boundary(1));
+        assert!(cloned.is_ownership_boundary_value(old));
         assert_eq!(
             cloned.get_call_args(&cloned.get_inst(call).data)[0].mode,
             CfgArgMode::Borrow
@@ -3858,6 +3916,13 @@ mod tests {
             })
             .unwrap();
         assert_eq!(remapped.to_string(), cfg.to_string());
+        assert!(remapped.is_ownership_boundary(1));
+        assert!(remapped.is_ownership_boundary_value(old));
+        let mut rewritten = cfg.clone();
+        rewritten
+            .rewrite_value_uses(|value| if value == old { replacement } else { value })
+            .unwrap();
+        assert!(rewritten.is_ownership_boundary_value(replacement));
         assert_eq!(remapped.get_inst(call).span, Span::new(107, 108));
         assert_eq!(
             remapped.get_array_elements(&remapped.get_inst(array).data),

--- a/crates/rue-cfg/src/opt/constopt.rs
+++ b/crates/rue-cfg/src/opt/constopt.rs
@@ -56,7 +56,9 @@ pub struct Stats {
 }
 
 /// Run sparse constant folding and store-to-load constant propagation to a
-/// fixpoint.
+/// fixpoint. Ownership-boundary values are always preserved: they describe a
+/// semantic transfer across an inline boundary, not an optional optimization
+/// policy.
 pub fn run(cfg: &mut Cfg) -> Stats {
     let value_count = cfg.value_count();
     let num_locals = cfg.num_locals() as usize;
@@ -177,6 +179,9 @@ pub fn run(cfg: &mut Cfg) -> Stats {
             let payload = const_payload(cfg, value)
                 .expect("became_const events carry Const/BoolConst values");
             for &load in &loads_of_slot[slot as usize] {
+                if cfg.is_ownership_boundary_value(load) {
+                    continue;
+                }
                 cfg.get_inst_mut(load).data = payload.duplicate_with_owner();
                 stats.loads_rewritten += 1;
                 became_const.push_back(load);
@@ -323,6 +328,79 @@ mod tests {
         assert!(matches!(
             cfg.get_inst(load).data,
             CfgInstData::Load { slot: 0 }
+        ));
+    }
+
+    #[test]
+    fn test_ownership_boundary_slot_not_propagated() {
+        // An inlined by-value parameter is initialized once, but the Load is
+        // the callee-owned read and must not be folded back to the caller's
+        // initializer during reoptimization.
+        let mut cfg = make_cfg(1);
+        let value = push(&mut cfg, CfgInstData::Const(7), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc {
+                slot: 0,
+                init: value,
+            },
+            Type::UNIT,
+        );
+        let load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
+        cfg.mark_ownership_boundary(0);
+        cfg.mark_ownership_boundary_value(load);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(load) });
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.loads_rewritten, 0);
+        assert!(matches!(
+            cfg.get_inst(load).data,
+            CfgInstData::Load { slot: 0 }
+        ));
+    }
+
+    #[test]
+    fn test_mixed_boundary_and_copy_slots_only_protect_the_boundary_value() {
+        let mut cfg = make_cfg(2);
+        let owned_init = push(&mut cfg, CfgInstData::Const(7), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc {
+                slot: 0,
+                init: owned_init,
+            },
+            Type::UNIT,
+        );
+        let owned_load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
+        cfg.mark_ownership_boundary(0);
+        cfg.mark_ownership_boundary_value(owned_load);
+
+        let copy_init = push(&mut cfg, CfgInstData::Const(9), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc {
+                slot: 1,
+                init: copy_init,
+            },
+            Type::UNIT,
+        );
+        let copy_load = push(&mut cfg, CfgInstData::Load { slot: 1 }, Type::I32);
+        cfg.set_terminator(
+            cfg.entry,
+            Terminator::Return {
+                value: Some(copy_load),
+            },
+        );
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.loads_rewritten, 1);
+        assert!(matches!(
+            cfg.get_inst(owned_load).data,
+            CfgInstData::Load { slot: 0 }
+        ));
+        assert!(matches!(
+            cfg.get_inst(copy_load).data,
+            CfgInstData::Const(9)
         ));
     }
 

--- a/crates/rue-cfg/src/opt/forward.rs
+++ b/crates/rue-cfg/src/opt/forward.rs
@@ -12,6 +12,11 @@
 //! load, so no computation is added, removed, or reordered — only a redundant
 //! memory read is bypassed.
 //!
+//! A translated by-value parameter is the one exception to ordinary
+//! single-write forwarding. Inlining marks the parameter's materialized
+//! `Load` value; that ownership-consuming read stays a load, while later reads
+//! may still forward through it so a returned value keeps the caller's owner.
+//!
 //! ## Rule 1 — global single-write forwarding
 //!
 //! Generalizes constant store-to-load propagation ([`super::constopt`]) from
@@ -90,7 +95,9 @@ pub struct Stats {
 }
 
 /// Run value forwarding. Call at `-O2`/`-O3` after simplification and before
-/// CSE.
+/// CSE. Ownership-boundary values are always preserved: they describe a
+/// semantic transfer across an inline boundary, not an optional optimization
+/// policy.
 pub fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
     let mut stats = Stats::default();
     let num_locals = cfg.num_locals() as usize;
@@ -159,7 +166,8 @@ pub fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
 
             match cfg.get_inst(value).data.duplicate_with_owner() {
                 CfgInstData::Alloc { slot, init } | CfgInstData::Store { slot, value: init } => {
-                    // Address-taken slots stay out of the block-local table.
+                    // Address-taken slots stay out of the block-local table;
+                    // ownership-boundary Loads are filtered by value below.
                     if !cfg.is_address_taken(slot) && (slot as usize) < num_locals {
                         last_store[slot as usize] = Some(init);
                     }
@@ -167,6 +175,13 @@ pub fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
                 CfgInstData::Load { slot } => {
                     // A by-ref argument load must remain a place.
                     if byref_arg_values.contains(&value) {
+                        continue;
+                    }
+                    // Only the Load that crosses into a callee-owned
+                    // parameter is protected. Other loads from that slot may
+                    // still forward to the transfer value, which is how a
+                    // returned value hands ownership back to the caller.
+                    if cfg.is_ownership_boundary_value(value) {
                         continue;
                     }
                     if let Some(SlotWrites::One {
@@ -590,6 +605,36 @@ mod tests {
         );
         cfg.mark_address_taken(0);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(ptr) });
+
+        let stats = run(&mut cfg).unwrap();
+        assert_eq!(stats.loads_forwarded_single_write, 0);
+        assert_eq!(stats.loads_forwarded_block_local, 0);
+        assert!(matches!(
+            cfg.get_inst(load).data,
+            CfgInstData::Load { slot: 0 }
+        ));
+    }
+
+    #[test]
+    fn test_ownership_boundary_slot_never_forwarded() {
+        // Inlining moves the caller value into a fresh callee-owned slot. The
+        // slot has one Alloc, but replacing its Load with the Alloc initializer
+        // would erase that ownership transfer and can double-drop the caller's
+        // value during post-splice reoptimization.
+        let mut cfg = make_cfg(1);
+        let value = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc {
+                slot: 0,
+                init: value,
+            },
+            Type::UNIT,
+        );
+        let load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
+        cfg.mark_ownership_boundary(0);
+        cfg.mark_ownership_boundary_value(load);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(load) });
 
         let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.loads_forwarded_single_write, 0);

--- a/crates/rue-cfg/src/opt/mod.rs
+++ b/crates/rue-cfg/src/opt/mod.rs
@@ -366,7 +366,18 @@ pub fn optimize_with_budget(
                 // reachability, then thread empty forwarding blocks and merge
                 // single-predecessor Goto chains into straight-line blocks
                 // before DCE prunes the leftovers.
-                simplify::run(&mut cfg)?;
+                let simplify_stats = simplify::run(&mut cfg)?;
+                // Folding a control value can expose stores and loads on the
+                // surviving path (notably drop flags). Re-run the sparse
+                // constant/folding cleanup when control flow changed so those
+                // newly unreachable ownership actions are removed before
+                // forwarding and CSE inspect the graph.
+                if simplify_stats.branches_folded > 0 || simplify_stats.switches_folded > 0 {
+                    dce::run(&mut cfg);
+                    constopt::run(&mut cfg);
+                    peephole::run(&mut cfg)?;
+                    simplify::run(&mut cfg)?;
+                }
 
                 // Value forwarding / copy propagation (RUE-914), at -O2/-O3 only.
                 // Runs after simplify and before CSE: it turns redundant `Load`s
@@ -376,7 +387,18 @@ pub fn optimize_with_budget(
                 // Both rules are trap-exact — a load never traps and the forwarded
                 // value is already computed — so the orphaned loads fall to DCE.
                 if matches!(level, OptLevel::O2 | OptLevel::O3) {
-                    forward::run(&mut cfg)?;
+                    let forward_stats = forward::run(&mut cfg)?;
+                    // Forwarding can expose constants in a branch condition
+                    // without changing the Load instruction itself. Fold and
+                    // simplify that newly constant control flow before CSE;
+                    // this is essential for drop-flag stores revealed after a
+                    // selector branch is folded.
+                    if forward_stats.loads_forwarded_single_write > 0
+                        || forward_stats.loads_forwarded_block_local > 0
+                    {
+                        constopt::run(&mut cfg);
+                        simplify::run(&mut cfg)?;
+                    }
                 }
 
                 // Block-local common-subexpression elimination (RUE-913), at

--- a/crates/rue-cfg/src/opt/slot_facts.rs
+++ b/crates/rue-cfg/src/opt/slot_facts.rs
@@ -32,6 +32,11 @@
 //!   dereferenced as an address, and a raw pointer may write the slot behind
 //!   the optimizer's back (RUE-521 O1+ segfault). These slots are
 //!   disqualified upfront, before any write is seen.
+//! - **Ownership-transfer boundaries** are tracked by CFG inlining at the
+//!   translated parameter `Load` values, not here at slot classification. The
+//!   same slot may return ownership to the caller on one path and be dropped
+//!   in the callee on another, so a slot-wide disqualification would be too
+//!   coarse. Constopt and forwarding consult the per-value marker instead.
 //!
 //! ## Dominance
 //!
@@ -98,7 +103,11 @@ pub(super) fn classify_slot_writes(cfg: &Cfg, reachable: Option<&BitSet>) -> Vec
     let num_locals = cfg.num_locals() as usize;
     let mut slot_writes = vec![SlotWrites::None; num_locals];
 
-    // Address-taken slots are disqualified upfront (RUE-521; module docs).
+    // Address-taken slots are disqualified upfront (RUE-521). Ownership
+    // transfer is tracked per materialized Param Load by the callers below:
+    // the same slot can return ownership to the caller on one path and be
+    // dropped in the callee on another, so a slot-wide classification would be
+    // too coarse.
     for (slot, state) in slot_writes.iter_mut().enumerate() {
         if cfg.is_address_taken(slot as u32) {
             *state = SlotWrites::Disqualified;

--- a/crates/rue-cfg/src/opt/unroll.rs
+++ b/crates/rue-cfg/src/opt/unroll.rs
@@ -287,7 +287,16 @@ fn recognize(cfg: &Cfg, lp: &NaturalLoop) -> Option<Trip> {
             }
         }
     }
-    if alloc_count != 1 || initial.is_none() || cfg.is_address_taken(slot) {
+    // An inlined droppable parameter is a one-write slot too, but cloning its
+    // loop body would preserve the wrong caller-owned value if its ownership
+    // transfer were treated as an ordinary induction-variable spill. The
+    // slot marker is separate from the per-value forwarding marker because
+    // unrolling clones the storage region rather than an individual Load.
+    if alloc_count != 1
+        || initial.is_none()
+        || cfg.is_address_taken(slot)
+        || cfg.is_ownership_boundary(slot)
+    {
         return None;
     }
     let initial = initial?;
@@ -709,6 +718,13 @@ fn unroll_one(
             for &(v, ty) in &params {
                 let nv = cfg.add_block_param(block_map[&b], ty);
                 map.insert(v, nv);
+                // Unrolling duplicates the value arena. Preserve the
+                // per-value ownership fact alongside each value mapping;
+                // otherwise a protected transfer Load in the loop body can
+                // become forwardable only in the cloned iteration.
+                if source.is_ownership_boundary_value(v) {
+                    cfg.mark_ownership_boundary_value(nv);
+                }
             }
         }
         let insts: Vec<(CfgValue, BlockId)> = original_blocks
@@ -737,6 +753,9 @@ fn unroll_one(
                 },
             );
             map.insert(v, nv);
+            if source.is_ownership_boundary_value(v) {
+                cfg.mark_ownership_boundary_value(nv);
+            }
         }
         let internal_values = original_blocks
             .iter()
@@ -1400,6 +1419,26 @@ mod tests {
         assert_eq!(stats.loops_unrolled, 1);
         assert!(stats.values_cloned > 0);
         cfg.verify().unwrap();
+    }
+
+    #[test]
+    fn run_copies_boundary_markers_to_each_unrolled_value() {
+        let mut cfg = slot_loop(0, 2, false);
+        let body = BlockId::from_raw(2);
+        let marked = cfg.get_block(body).insts[0];
+        cfg.mark_ownership_boundary_value(marked);
+
+        let stats = run(&mut cfg).unwrap();
+        assert_eq!(stats.loops_unrolled, 1);
+        let marked_attached = cfg
+            .blocks()
+            .iter()
+            .flat_map(|block| block.insts.iter().copied())
+            .filter(|&value| cfg.is_ownership_boundary_value(value))
+            .count();
+        // The original body value and both unrolled clones must carry the
+        // fact. If clone metadata propagation is removed, this remains 1.
+        assert_eq!(marked_attached, 3);
     }
 
     #[test]

--- a/crates/rue-cli-tests/cases/abi.toml
+++ b/crates/rue-cli-tests/cases/abi.toml
@@ -250,6 +250,7 @@ hello
 # ABI slot; callee and caller must agree on the shift.
 [[case]]
 name = "string_return_with_args"
+differential_opt = true
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -269,6 +270,7 @@ stdout = """
 5
 first
 """
+exit_code = 0
 
 # sret + stack-passed args together: a 9-slot struct argument (slots past the
 # arg registers spill to the caller's stack, shifted by the hidden sret

--- a/crates/rue-cli-tests/cases/drop_flags.toml
+++ b/crates/rue-cli-tests/cases/drop_flags.toml
@@ -10,6 +10,7 @@ description = "Branch-divergent moves drop exactly once on every path."
 
 [[case]]
 name = "if_branch_move_drops_once_each_path"
+differential_opt = true
 files = [{ path = "main.rue", source = """
 struct D { v: i32 }
 drop fn D(self) { @dbg(self.v); }
@@ -28,9 +29,11 @@ fn main() -> i32 {
 }
 """ }]
 stdout = "100\n7\n200\n7\n300\n"
+exit_code = 0
 
 [[case]]
 name = "match_arm_move_drops_once_each_path"
+differential_opt = true
 files = [{ path = "main.rue", source = """
 struct D { v: i32 }
 drop fn D(self) { @dbg(self.v); }
@@ -50,9 +53,11 @@ fn main() -> i32 {
 }
 """ }]
 stdout = "9\n555\n9\n"
+exit_code = 0
 
 [[case]]
 name = "loop_break_move_drops_once"
+differential_opt = true
 description = "Conservative loop joins are also corrected at runtime by the flag."
 files = [{ path = "main.rue", source = """
 struct D { v: i32 }
@@ -73,6 +78,7 @@ fn main() -> i32 {
 }
 """ }]
 stdout = "3\n777\n"
+exit_code = 0
 
 # RUE-1737: a partial field move on a break edge must reach the loop exit's
 # MoveState. Joining the move and non-move break paths keeps the enclosing
@@ -180,6 +186,7 @@ stdout = "1\n50\n2\n60\n50\n1\n"
 
 [[case]]
 name = "param_divergent_move_drops_once_each_path"
+differential_opt = true
 description = "Owned by-value params get the same flag treatment."
 files = [{ path = "main.rue", source = """
 struct D { v: i32 }
@@ -196,6 +203,7 @@ fn main() -> i32 {
 }
 """ }]
 stdout = "4\n888\n5\n"
+exit_code = 0
 
 # RUE-67 regression: match arms are SIBLING paths for the move checker. A move
 # in one arm must not leak into the others — using `a` in the `_` arm after
@@ -205,6 +213,7 @@ stdout = "4\n888\n5\n"
 # the drop runs at scope exit.
 [[case]]
 name = "match_sibling_arm_use_after_move_accepted"
+differential_opt = true
 files = [{ path = "main.rue", source = """
 struct D { v: i32 }
 drop fn D(self) { @dbg(self.v); }

--- a/crates/rue-cli-tests/cases/overwrite_drops.toml
+++ b/crates/rue-cli-tests/cases/overwrite_drops.toml
@@ -140,6 +140,7 @@ stdout = "1\n100\n2\n"
 
 [[case]]
 name = "branch_divergent_move_then_assignment_guarded"
+differential_opt = true
 description = "Conditionally moved value: the overwrite drop is guarded by the runtime drop flag — exactly one old-value drop on each path."
 files = [{ path = "main.rue", source = """
 struct D { v: i32 }
@@ -160,6 +161,7 @@ fn main() -> i32 {
 }
 """ }]
 stdout = "1\n100\n2\n500\n1\n100\n2\n"
+exit_code = 0
 
 [[case]]
 name = "partially_moved_struct_overwrite_drops_remaining_fields"


### PR DESCRIPTION
Summary:
- record materialized droppable-parameter ownership transfers in canonical CFG metadata
- preserve the invariant through nested inlining, value remapping, and loop-unroll cloning while leaving Copy parameters optimizable
- run bounded post-control-flow cleanup before ownership verification and cover all seven native optimization-level regressions

Validation:
- scripts/rue unit cfg
- scripts/rue cli abi
- scripts/rue cli drop_flags
- scripts/rue cli overwrite_drops
- scripts/rue quick
- scripts/rue premerge
- scripts/rue test
- scripts/rue fmt
- git diff --check

Fixes RUE-1821