### PR TITLE
RUE-1736: consolidate the trusted-std namespace mapping in the compiler

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -1535,6 +1535,12 @@ fn root_export_metadata(owner: &str, symbol: &str) -> (&'static str, &'static st
             | "ImportDiscoveryContext"
             | "ImportOccurrenceKey"
             | "PhysicalFileIdentity" => ("dependency-artifact", "source-loaders+embedders"),
+            // Requested-path → trusted-namespace classification (RUE-1736): the
+            // one derivation the driver may use for error attribution, so it
+            // cannot re-derive the mapping with its own namespace spelling.
+            "trusted_logical_path_for_requested" => {
+                ("one-shot-operation", "source-loaders+embedders")
+            }
             // The host discovery-protocol records (AcceptedImportSource,
             // ImportDiscoveryPlan/Request, ImportObservation*) live under
             // `unstable` with the protocol functions that consume them. Any

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -11,11 +11,13 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
 use ahash::AHashMap;
+use rue_air::normalize_module_path;
 use rue_error::{CompileError, CompileErrors, CompileResult, ErrorKind};
 use rue_span::FileId;
 
 use crate::{
     ImportDirective, ModuleId, ParsedProgram, SourceMetadata, SourceRevision, SourceSnapshot,
+    TRUSTED_STANDARD_LIBRARY_NAMESPACE,
 };
 
 /// Version of the target-independent candidate policy represented by plans.
@@ -3017,8 +3019,10 @@ fn requested_path_for_module(
     context: &ImportDiscoveryContext,
     module: &ModuleId,
 ) -> CompileResult<String> {
-    const STD_PREFIX: &str = "\0rue-std/";
-    if let Some(relative) = module.as_str().strip_prefix(STD_PREFIX) {
+    if let Some(relative) = module
+        .as_str()
+        .strip_prefix(TRUSTED_STANDARD_LIBRARY_NAMESPACE)
+    {
         let std_root = context
             .std_root()
             .ok_or_else(|| invalid_input("standard-library module has no captured std root"))?;
@@ -3033,8 +3037,30 @@ fn requested_path_for_module(
     ))
 }
 
+/// Derive the trusted logical path (`\0rue-std/<relative>`) the compiler
+/// assigns to a standard-library source requested at `requested` — the same
+/// lexical classification `classify_module` applies against the context's
+/// captured std root, in the same normalized spelling `ModuleId` publishes.
+/// Returns `None` when the context has no std root or the requested path is
+/// outside it, so callers attribute such paths as themselves rather than
+/// inventing a trusted spelling.
+pub fn trusted_logical_path_for_requested(
+    context: &ImportDiscoveryContext,
+    requested: &str,
+) -> Option<String> {
+    let std_root = context.std_root()?;
+    let relative = Path::new(requested).strip_prefix(std_root).ok()?;
+    Some(normalize_module_path(&format!(
+        "{TRUSTED_STANDARD_LIBRARY_NAMESPACE}{}",
+        relative.to_string_lossy()
+    )))
+}
+
 fn display_path_for_module(module: &ModuleId, entry: &AssembledSource) -> String {
-    if module.as_str().starts_with("\0rue-std/") {
+    if module
+        .as_str()
+        .starts_with(TRUSTED_STANDARD_LIBRARY_NAMESPACE)
+    {
         entry.requested_path.to_string()
     } else {
         module.as_str().to_owned()
@@ -3057,8 +3083,10 @@ fn classify_module(
                     requested, std_root
                 )));
             }
-            let logical = Path::new("\0rue-std").join(relative);
-            if logical
+            // Escape checks run on the unnormalized relative path: the shared
+            // derivation below collapses `..` lexically, so a traversal must be
+            // refused before it can normalize into an in-namespace identity.
+            if relative
                 .components()
                 .any(|component| matches!(component, Component::ParentDir))
             {
@@ -3067,7 +3095,9 @@ fn classify_module(
                     requested
                 )));
             }
-            return ModuleId::from_trusted_standard_library_path(logical.to_string_lossy());
+            let logical = trusted_logical_path_for_requested(context, &requested.to_string_lossy())
+                .expect("the requested path was just stripped against this context's std root");
+            return ModuleId::from_trusted_standard_library_path(logical);
         }
     }
     let project_root = Path::new(context.project_root());
@@ -3507,6 +3537,44 @@ mod tests {
         assert_eq!(second, expected);
         assert!(first[1].is_trusted_standard_library());
         assert!(!first[3].is_trusted_standard_library());
+    }
+
+    #[test]
+    fn trusted_logical_path_matches_classified_module_identity() {
+        let (project, std_root) = if cfg!(windows) {
+            (r"C:\rue-parity\project", r"C:\rue-parity\toolchain\std")
+        } else {
+            ("/rue-parity/project", "/rue-parity/toolchain/std")
+        };
+        let context = ImportDiscoveryContext::new(1, project, Some(std_root), "all").unwrap();
+
+        // The attribution helper must publish exactly the identity spelling
+        // classification mints for the same requested std path, including the
+        // normalized form of a non-canonical spelling.
+        for relative in ["_std.rue", "math/float.rue", "math/./float.rue"] {
+            let requested = Path::new(std_root).join(relative);
+            let requested = requested.to_string_lossy();
+            let module = classify_module(&context, &requested, &requested).unwrap();
+            assert!(module.is_trusted_standard_library());
+            assert_eq!(
+                trusted_logical_path_for_requested(&context, &requested).as_deref(),
+                Some(module.as_str())
+            );
+        }
+
+        // A path outside the std root has no trusted spelling, and neither does
+        // any path when the context captured no std root.
+        let outside = Path::new(project).join("main.rue");
+        assert_eq!(
+            trusted_logical_path_for_requested(&context, &outside.to_string_lossy()),
+            None
+        );
+        let rootless = ImportDiscoveryContext::new(1, project, None, "all").unwrap();
+        let inside = Path::new(std_root).join("_std.rue");
+        assert_eq!(
+            trusted_logical_path_for_requested(&rootless, &inside.to_string_lossy()),
+            None
+        );
     }
 
     #[cfg(windows)]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -115,6 +115,7 @@ pub use diagnostic_attempt_store::{DiagnosticStage, FrontendDiagnosticSnapshot};
 pub use import_discovery::{
     AcceptedReadManifest, AcceptedReadManifestEntry, FileMetadataFingerprint, ImportCandidateRole,
     ImportDiscoveryContext, ImportOccurrenceKey, PhysicalFileIdentity,
+    trusted_logical_path_for_requested,
 };
 // Host discovery-protocol records are published through `unstable` only; the
 // crate-local paths keep the session and its tests on one spelling.
@@ -141,7 +142,10 @@ pub(crate) use semantic_identity::{
     StableSymbolEncoder, StableSymbolId, StructuralAnchor, StructuralPathSegment, TypeInstanceKey,
 };
 pub use session::{CanonicalImportGraphOutput, CompilerSession, CompilerSessionUpdate};
-pub use source_identity::{ModuleId, ModuleRevision, SourceId, SourceIdVersion, SourceRevision};
+pub use source_identity::{
+    ModuleId, ModuleRevision, SourceId, SourceIdVersion, SourceRevision,
+    TRUSTED_STANDARD_LIBRARY_NAMESPACE,
+};
 pub use source_metadata::SourceMetadata;
 pub use source_snapshot::{MAX_SOURCE_BYTES, MAX_SOURCE_FILES, SourceSnapshot};
 pub use toolchain_module_demand::{

--- a/crates/rue-compiler/src/source_identity.rs
+++ b/crates/rue-compiler/src/source_identity.rs
@@ -303,6 +303,15 @@ impl fmt::Display for SourceId {
     }
 }
 
+/// Logical-path namespace prefix for trusted standard-library modules.
+///
+/// The leading NUL byte keeps the namespace disjoint from every expressible
+/// filesystem path, so a project file named `@rue-std/...` can never collide
+/// with a trusted identity. This constant is the single authority for the
+/// spelling: classification mints identities under it, `ModuleId` validates
+/// against it, and the driver derives error-attribution paths from it.
+pub const TRUSTED_STANDARD_LIBRARY_NAMESPACE: &str = "\0rue-std/";
+
 /// Canonical logical identity of one module.
 #[derive(Debug, Clone)]
 pub struct ModuleId {
@@ -373,7 +382,7 @@ impl ModuleId {
     }
     pub(crate) fn from_trusted_standard_library_path(path: impl AsRef<str>) -> CompileResult<Self> {
         let path = normalize_module_path(path.as_ref());
-        if !path.starts_with("\0rue-std/") {
+        if !path.starts_with(TRUSTED_STANDARD_LIBRARY_NAMESPACE) {
             return Err(CompileError::without_span(ErrorKind::InvalidCompilerInput(
                 "trusted standard-library module is outside the standard-library namespace".into(),
             )));
@@ -384,7 +393,7 @@ impl ModuleId {
         })
     }
     pub(crate) fn from_trusted_validated_canonical(path: &str) -> Self {
-        debug_assert!(path.starts_with("\0rue-std/"));
+        debug_assert!(path.starts_with(TRUSTED_STANDARD_LIBRARY_NAMESPACE));
         debug_assert_eq!(normalize_module_path(path), path);
         Self {
             logical_path: Arc::from(path),

--- a/crates/rue-compiler/src/source_metadata.rs
+++ b/crates/rue-compiler/src/source_metadata.rs
@@ -571,7 +571,7 @@ impl MetadataSegment {
                     "trusted standard-library file is absent from metadata",
                 ));
             };
-            if !path.starts_with("\0rue-std/") {
+            if !path.starts_with(crate::TRUSTED_STANDARD_LIBRARY_NAMESPACE) {
                 return Err(invalid_input(
                     "trusted standard-library file has a non-standard logical path",
                 ));

--- a/crates/rue-compiler/src/supported_api_inventory.rs
+++ b/crates/rue-compiler/src/supported_api_inventory.rs
@@ -39,6 +39,7 @@ stable|import_discovery|dependency-artifact|source-loaders+embedders|ImportCandi
 stable|import_discovery|dependency-artifact|source-loaders+embedders|ImportDiscoveryContext|pub use import_discovery::ImportDiscoveryContext
 stable|import_discovery|dependency-artifact|source-loaders+embedders|ImportOccurrenceKey|pub use import_discovery::ImportOccurrenceKey
 stable|import_discovery|dependency-artifact|source-loaders+embedders|PhysicalFileIdentity|pub use import_discovery::PhysicalFileIdentity
+stable|import_discovery|one-shot-operation|source-loaders+embedders|trusted_logical_path_for_requested|pub use import_discovery::trusted_logical_path_for_requested
 stable|import_graph|dependency-artifact|source-loaders+embedders|CanonicalImportCycle|pub use import_graph::CanonicalImportCycle
 stable|import_graph|dependency-artifact|source-loaders+embedders|CanonicalImportGraph|pub use import_graph::CanonicalImportGraph
 stable|import_graph|dependency-artifact|source-loaders+embedders|CanonicalImportGraphProblem|pub use import_graph::CanonicalImportGraphProblem
@@ -71,6 +72,7 @@ stable|source_identity|source-input|cli+embedders|ModuleRevision|pub use source_
 stable|source_identity|source-input|cli+embedders|SourceId|pub use source_identity::SourceId
 stable|source_identity|source-input|cli+embedders|SourceIdVersion|pub use source_identity::SourceIdVersion
 stable|source_identity|source-input|cli+embedders|SourceRevision|pub use source_identity::SourceRevision
+stable|source_identity|source-input|cli+embedders|TRUSTED_STANDARD_LIBRARY_NAMESPACE|pub use source_identity::TRUSTED_STANDARD_LIBRARY_NAMESPACE
 stable|source_metadata|source-input|cli+embedders|SourceMetadata|pub use source_metadata::SourceMetadata
 stable|source_snapshot|source-input|cli+embedders|MAX_SOURCE_BYTES|pub use source_snapshot::MAX_SOURCE_BYTES
 stable|source_snapshot|source-input|cli+embedders|MAX_SOURCE_FILES|pub use source_snapshot::MAX_SOURCE_FILES

--- a/crates/rue-compiler/src/test_support.rs
+++ b/crates/rue-compiler/src/test_support.rs
@@ -287,7 +287,7 @@ pub(crate) struct TestDiscoveryHost {
 /// name modules logically, so the tree needs a root but never a real directory.
 const FIXTURE_PROJECT_ROOT: &str = "/rue-fixture";
 const FIXTURE_STD_ROOT: &str = "/rue-fixture/std";
-const TRUSTED_MODULE_PREFIX: &str = "\0rue-std/";
+const TRUSTED_MODULE_PREFIX: &str = crate::TRUSTED_STANDARD_LIBRARY_NAMESPACE;
 
 impl TestDiscoveryHost {
     pub(crate) fn new(snapshot: &SourceSnapshot) -> MultiErrorResult<Self> {

--- a/crates/rue-compiler/src/toolchain_module_demand.rs
+++ b/crates/rue-compiler/src/toolchain_module_demand.rs
@@ -101,7 +101,7 @@ impl TrustedToolchainModuleDemand {
     /// against the toolchain's std path.
     pub fn std_relative_path(&self) -> &str {
         self.logical_path
-            .strip_prefix("\0rue-std/")
+            .strip_prefix(crate::TRUSTED_STANDARD_LIBRARY_NAMESPACE)
             .unwrap_or(&self.logical_path)
     }
 }

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -34,7 +34,7 @@ use rue_compiler::{
     AcceptedReadManifest, CompileErrors, CompileOptions, CompilerSession, DependencyEnvelope,
     FileId, FileMetadataFingerprint, ImportDiscoveryContext, ImportDiscoveryStatus,
     ImportDiscoveryView, PhysicalFileIdentity, SourceMetadata, SourceSnapshot,
-    TrustedToolchainModuleDemand,
+    TrustedToolchainModuleDemand, trusted_logical_path_for_requested,
 };
 
 /// The content fingerprint used by the long-lived filesystem observer.
@@ -1783,21 +1783,6 @@ pub(crate) fn acquire_reached_toolchain_modules(
     ))
 }
 
-/// Derive the trusted logical path (`\0rue-std/<relative>`) for a std file the
-/// re-close read against the configured std root, falling back to the requested
-/// filesystem path when it lies outside the root's lexical prefix. Used only to
-/// name the exact failing transitive leaf in an environmental error.
-fn trusted_logical_path_for_requested(context: &ImportDiscoveryContext, requested: &str) -> String {
-    const STD_NAMESPACE: &str = "\0rue-std/";
-    match context.std_root() {
-        Some(root) => match Path::new(requested).strip_prefix(root) {
-            Ok(relative) => format!("{STD_NAMESPACE}{}", relative.to_string_lossy()),
-            Err(_) => requested.to_owned(),
-        },
-        None => requested.to_owned(),
-    }
-}
-
 /// Attribute a non-accepted observation for a toolchain-internal `@import` edge
 /// (a transitive trusted leaf reached during the re-close) to the exact failing
 /// module. A policy/containment denial is a hermetic build-configuration failure;
@@ -1809,7 +1794,10 @@ fn classify_trusted_transitive_failure(
 ) -> Option<SourceLoadError> {
     for observation in observations {
         let requested = observation.request().requested_path().to_owned();
-        let logical = trusted_logical_path_for_requested(context, &requested);
+        // The compiler owns requested-path → trusted-namespace classification;
+        // a path outside the captured std root is named as itself.
+        let logical = trusted_logical_path_for_requested(context, &requested)
+            .unwrap_or_else(|| requested.clone());
         let path = PathBuf::from(&requested);
         let error = match observation.status() {
             ImportObservationStatus::PresentReadable { .. } => continue,


### PR DESCRIPTION
Closes RUE-1736.

The driver re-implemented requested-path → `\0rue-std/<rel>` classification with its own hardcoded namespace literal and a lexical `strip_prefix` against the driver's std-root spelling, used to name failing transitive std leaves in toolchain-integrity and hermetic-denial errors. Because that copy could strip against a differently-spelled root than the compiler's captured one, a namespace rename or spelling divergence would silently degrade error attribution to raw filesystem paths instead of failing a test.

Changes:

- `rue-compiler::source_identity` now exports `TRUSTED_STANDARD_LIBRARY_NAMESPACE` as the single authority for the `\0rue-std/` spelling; `ModuleId` validation, import classification, toolchain module demands, source-metadata validation, and the fixture host all consume it.
- `rue-compiler::import_discovery` gains `trusted_logical_path_for_requested(context, requested)`: the one requested-path → trusted-logical-path derivation, publishing the same normalized spelling `ModuleId` mints. `classify_module`'s std branch now routes through it, so classification and error attribution cannot drift; escape checks still run on the unnormalized relative path so `..` traversals are refused before normalization could collapse them.
- The driver's duplicate `trusted_logical_path_for_requested` is deleted; `classify_trusted_transitive_failure` calls the compiler helper and names a path outside the captured std root as itself.
- A parity test pins the helper's output to the exact identity spelling `classify_module` mints (including normalization of non-canonical requested paths) and its `None` behavior outside the root or without a captured root. The two new exports are classified in the reviewed API inventory.

Validation: `scripts/rue fmt`, focused import-discovery/classification unit tests, the API-inventory suite, and the full `rue-compiler` unit target locally; `scripts/rue premerge` in progress.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhLu5tyWdwrL8RywUZqaQc)_