### PR TITLE
RUE-1815: execute optimized oracle lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1147,9 +1147,29 @@ jobs:
             check_name: linux-x64-oracle-diff
           - os: ubuntu-latest
             cache_name: linux-x64
+            target: //crates/rue-oracle-diff:oracle-diff-test-o2
+            name: oracle-diff-o2
+            check_name: linux-x64-oracle-diff-o2
+          - os: ubuntu-latest
+            cache_name: linux-x64
+            target: //crates/rue-oracle-diff:oracle-diff-test-o3
+            name: oracle-diff-o3
+            check_name: linux-x64-oracle-diff-o3
+          - os: ubuntu-latest
+            cache_name: linux-x64
             target: //crates/rue-oracle-diff:oracle-diff-spec-test
             name: oracle-diff-spec
             check_name: linux-x64-oracle-diff-spec
+          - os: ubuntu-latest
+            cache_name: linux-x64
+            target: //crates/rue-oracle-diff:oracle-diff-spec-test-o2
+            name: oracle-diff-spec-o2
+            check_name: linux-x64-oracle-diff-spec-o2
+          - os: ubuntu-latest
+            cache_name: linux-x64
+            target: //crates/rue-oracle-diff:oracle-diff-spec-test-o3
+            name: oracle-diff-spec-o3
+            check_name: linux-x64-oracle-diff-spec-o3
     runs-on: ${{ matrix.os }}
     name: test (${{ matrix.check_name }})
     steps:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -25,8 +25,12 @@ jobs:
   fuzz:
     runs-on: ubuntu-latest
     # A wedged step can otherwise burn a runner to GitHub's 6h job cap.
-    # Generous vs the ~40min expected total, tight vs the 6h default.
-    timeout-minutes: 90
+    # Twelve fixed five-minute campaigns plus the 60-minute differential have
+    # a 120-minute bounded sum. Thirty minutes of headroom leaves setup, crash
+    # upload/aggregation/reporting, and corpus publication able to run even
+    # when every campaign consumes its full budget, while staying well below
+    # the 6h default.
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@v6
 
@@ -267,14 +271,15 @@ jobs:
       # miscompile. A compiler rejection or oracle Unsupported result is a
       # generator-contract failure. Either class exits non-zero and writes a
       # self-contained seed/source repro to crates/rue-fuzz/crashes/.
-      # Keep this native differential target host-only: its fixed 500-seed
-      # budget and executable replay contract are deliberately unchanged. The
-      # source compiler_x86_64_o1 target above supplies bounded optimization
-      # coverage with the same replayable target on every developer host.
-      - name: Differential fuzz (oracle vs compiled, 500 seeds)
+      # Keep this native differential target host-only. Its fixed 500-program
+      # window now executes all four O0/O1/O2/O3 lanes (2,000 native lanes),
+      # each with the harness's independent 10-second compiler and runtime
+      # guards. The 60-minute step deadline is the outer CI bound; no seed or
+      # optimization lane is dropped to meet it.
+      - name: Differential fuzz (oracle vs compiled, 500 programs / 2,000 lanes)
         id: fuzz-differential
         continue-on-error: true
-        timeout-minutes: 20
+        timeout-minutes: 60
         run: |
           RUE_BINARY="$(scripts/rue-bin)" ./buck2 run //crates/rue-oracle-diff:rue-oracle-diff -- \
             fuzz --seeds 500 --crash-dir crates/rue-fuzz/crashes

--- a/crates/rue-cfg/src/inline.rs
+++ b/crates/rue-cfg/src/inline.rs
@@ -114,6 +114,14 @@ pub enum CfgInlineError {
     /// A physically by-reference argument is not a place read at all — a
     /// violated sema/CFG invariant at the call site (RUE-760).
     NonPlaceByRefArgument { arg_index: usize },
+    /// A physically by-reference argument was loaded from a local storage
+    /// epoch that ended before the call. The SSA value remains valid, but an
+    /// inline redirect back to that local would access dead storage.
+    ByRefArgumentStorageEnded { arg_index: usize },
+    /// The call can repeat through a backedge without re-executing the SSA
+    /// place read. A later iteration may observe a replacement storage epoch,
+    /// so redirecting the argument to the local is not proven sound.
+    ByRefArgumentCallCycle { arg_index: usize },
     /// The copied callee references a parameter ABI slot that is not the
     /// start slot of any of its source parameters.
     UnmappedCalleeParamSlot { slot: u32 },
@@ -157,6 +165,14 @@ impl std::fmt::Display for CfgInlineError {
             Self::NonPlaceByRefArgument { arg_index } => {
                 write!(f, "by-ref argument {arg_index} is not a place read")
             }
+            Self::ByRefArgumentStorageEnded { arg_index } => write!(
+                f,
+                "by-ref argument {arg_index} was loaded from storage whose lifetime ended before the call"
+            ),
+            Self::ByRefArgumentCallCycle { arg_index } => write!(
+                f,
+                "by-ref argument {arg_index} reaches a repeated call without re-executing its place read"
+            ),
             Self::UnmappedCalleeParamSlot { slot } => write!(
                 f,
                 "callee references parameter slot {slot}, which is not a source-parameter start slot"
@@ -341,12 +357,19 @@ fn splice_shape(
             _ => return Err(CfgInlineError::NotACall { call }),
         }
     };
-    if let Some(call_block) = call_block {
-        if call_block.as_u32() as usize >= caller.block_count()
-            || !caller.get_block(call_block).insts.contains(&call)
-        {
-            return Err(CfgInlineError::CallSiteNotFound { call });
-        }
+    let call_block = call_block
+        .or_else(|| {
+            caller
+                .blocks()
+                .iter()
+                .find(|block| block.insts.contains(&call))
+                .map(|block| block.id)
+        })
+        .ok_or(CfgInlineError::CallSiteNotFound { call })?;
+    if call_block.as_u32() as usize >= caller.block_count()
+        || !caller.get_block(call_block).insts.contains(&call)
+    {
+        return Err(CfgInlineError::CallSiteNotFound { call });
     }
     if !callee.get_block(callee.entry).params.is_empty() {
         return Err(CfgInlineError::CalleeEntryHasParams);
@@ -361,7 +384,12 @@ fn splice_shape(
     let mut materialized_params = 0u64;
     for (index, (param, arg)) in params.iter().zip(&call_args).enumerate() {
         if callee.is_param_by_ref(param.start_slot) {
-            byref_argument_place(caller, arg.value, index)?;
+            let place = byref_argument_place(caller, arg.value, index)?;
+            if !is_accessor {
+                ensure_byref_storage_epoch_reaches_call(
+                    caller, arg.value, index, call, call_block, &place,
+                )?;
+            }
         } else {
             materialized_params =
                 materialized_params
@@ -798,6 +826,178 @@ fn byref_argument_place(
         CfgInstData::Param { index } => Ok(Place::param(*index, caller.get_inst(argument).ty)),
         CfgInstData::PlaceRead { place } => Ok(place.duplicate_with_owner()),
         _ => Err(CfgInlineError::NonPlaceByRefArgument { arg_index }),
+    }
+}
+
+/// Prove that redirecting a by-reference SSA argument back to a caller local
+/// preserves the exact storage epoch from which the value was read.
+///
+/// A `Load`/local-rooted `PlaceRead` remains a valid SSA value after its local
+/// storage dies, so the ordinary CFG verifier accepts passing that value to a
+/// call. Inlining is stricter: parameter accesses become direct accesses to
+/// the original place. If a `StorageDead` (or a new `StorageLive`) for that
+/// region lies on any path between the read and the call, the redirect would
+/// resurrect dead storage. Refuse that optional optimization and retain the
+/// original call instead.
+fn ensure_byref_storage_epoch_reaches_call(
+    caller: &Cfg,
+    argument: CfgValue,
+    arg_index: usize,
+    call: CfgValue,
+    call_block: BlockId,
+    place: &Place,
+) -> Result<(), CfgInlineError> {
+    let PlaceBase::Local(slot) = place.base else {
+        return Ok(());
+    };
+    let key = (slot, place.base_type);
+    let argument_location = caller.blocks().iter().find_map(|block| {
+        block
+            .insts
+            .iter()
+            .position(|value| *value == argument)
+            .map(|position| (block.id, position))
+    });
+    let Some((argument_block, argument_position)) = argument_location else {
+        return Err(CfgInlineError::NonPlaceByRefArgument { arg_index });
+    };
+    let call_position = caller
+        .get_block(call_block)
+        .insts
+        .iter()
+        .position(|value| *value == call)
+        .ok_or(CfgInlineError::CallSiteNotFound { call })?;
+
+    if argument_block != call_block
+        && call_reenters_without_argument(caller, call_block, argument_block)
+    {
+        return Err(CfgInlineError::ByRefArgumentCallCycle { arg_index });
+    }
+
+    if argument_block == call_block {
+        return caller.get_block(call_block).insts[argument_position + 1..call_position]
+            .iter()
+            .try_for_each(|value| match caller.get_inst(*value).data {
+                CfgInstData::StorageLive { slot, local_ty }
+                | CfgInstData::StorageDead { slot, local_ty }
+                    if (slot, local_ty) == key =>
+                {
+                    Err(CfgInlineError::ByRefArgumentStorageEnded { arg_index })
+                }
+                _ => Ok(()),
+            });
+    }
+
+    // Walk forward from the argument's block, but stop at the call. This
+    // excludes unreachable predecessors of the call and gives a loop
+    // backedge the same suffix-after-definition bounds as its first pass.
+    // Intersecting with reverse reachability keeps dead-end branches out of
+    // the scan without losing either side of a diamond.
+    let predecessors = caller.compute_predecessors();
+    let mut can_reach_call = vec![false; caller.block_count()];
+    let mut reverse = vec![call_block];
+    while let Some(block) = reverse.pop() {
+        let block_index = block.as_u32() as usize;
+        if can_reach_call[block_index] {
+            continue;
+        }
+        can_reach_call[block_index] = true;
+        reverse.extend(predecessors[block_index].iter().copied());
+    }
+
+    let mut pending = vec![argument_block];
+    let mut visited = vec![false; caller.block_count()];
+    while let Some(block) = pending.pop() {
+        let block_index = block.as_u32() as usize;
+        if visited[block_index] || !can_reach_call[block_index] {
+            continue;
+        }
+        visited[block_index] = true;
+        let start = if block == argument_block {
+            argument_position + 1
+        } else {
+            0
+        };
+        let end = if block == call_block {
+            call_position
+        } else {
+            caller.get_block(block).insts.len()
+        };
+        for value in &caller.get_block(block).insts[start..end] {
+            match caller.get_inst(*value).data {
+                CfgInstData::StorageLive { slot, local_ty }
+                | CfgInstData::StorageDead { slot, local_ty }
+                    if (slot, local_ty) == key =>
+                {
+                    return Err(CfgInlineError::ByRefArgumentStorageEnded { arg_index });
+                }
+                _ => {}
+            }
+        }
+        if block == call_block {
+            continue;
+        }
+        match &caller.get_block(block).terminator {
+            Terminator::Goto { target, .. } => pending.push(*target),
+            Terminator::Branch {
+                then_block,
+                else_block,
+                ..
+            } => {
+                pending.push(*then_block);
+                pending.push(*else_block);
+            }
+            Terminator::Switch { cases, default, .. } => {
+                pending.push(*default);
+                pending.extend(caller.switch_cases(cases).iter().map(|(_, target)| *target));
+            }
+            Terminator::Return { .. } | Terminator::Unreachable | Terminator::None => {}
+        }
+    }
+    Ok(())
+}
+
+/// Whether a successor path from the call reaches the call block again before
+/// the argument-defining block. Re-entering the definition refreshes the SSA
+/// place read; re-entering only the call can pair that old read with a new
+/// local storage epoch.
+fn call_reenters_without_argument(cfg: &Cfg, call_block: BlockId, argument_block: BlockId) -> bool {
+    let mut pending = Vec::new();
+    push_successors(cfg, call_block, &mut pending);
+    let mut visited = vec![false; cfg.block_count()];
+    while let Some(block) = pending.pop() {
+        if block == call_block {
+            return true;
+        }
+        if block == argument_block {
+            continue;
+        }
+        let block_index = block.as_u32() as usize;
+        if visited[block_index] {
+            continue;
+        }
+        visited[block_index] = true;
+        push_successors(cfg, block, &mut pending);
+    }
+    false
+}
+
+fn push_successors(cfg: &Cfg, block: BlockId, pending: &mut Vec<BlockId>) {
+    match &cfg.get_block(block).terminator {
+        Terminator::Goto { target, .. } => pending.push(*target),
+        Terminator::Branch {
+            then_block,
+            else_block,
+            ..
+        } => {
+            pending.push(*then_block);
+            pending.push(*else_block);
+        }
+        Terminator::Switch { cases, default, .. } => {
+            pending.push(*default);
+            pending.extend(cfg.switch_cases(cases).iter().map(|(_, target)| *target));
+        }
+        Terminator::Return { .. } | Terminator::Unreachable | Terminator::None => {}
     }
 }
 
@@ -2177,6 +2377,324 @@ mod tests {
             inlined.block_count(),
             caller.block_count() + callee.block_count() + 1
         );
+        assert_all_blocks_terminated(&inlined);
+    }
+
+    #[test]
+    fn by_ref_local_root_whose_storage_epoch_ended_is_not_inlineable() {
+        // A view temporary may be loaded into an SSA call argument and have
+        // its backing slot ended before the call. The SSA value remains
+        // available, but an inline redirect must not turn the callee's
+        // parameter accesses back into accesses to the dead slot.
+        let mut program = scalar_program();
+        program.add("bump", |_| by_ref_bump_callee());
+        program.add("caller", |interner| {
+            let mut cfg = Cfg::new(Type::UNIT, 1, 0, "caller".to_string(), Vec::<bool>::new());
+            let entry = cfg.new_block();
+            cfg.entry = entry;
+            cfg.append_inst(
+                entry,
+                inst(
+                    CfgInstData::StorageLive {
+                        slot: 0,
+                        local_ty: Type::I64,
+                    },
+                    Type::UNIT,
+                ),
+            );
+            let one = cfg.append_inst(entry, inst(CfgInstData::Const(1), Type::I64));
+            cfg.append_inst(
+                entry,
+                inst(CfgInstData::Alloc { slot: 0, init: one }, Type::UNIT),
+            );
+            let argument = cfg.append_inst(entry, inst(CfgInstData::Load { slot: 0 }, Type::I64));
+            cfg.append_inst(
+                entry,
+                inst(
+                    CfgInstData::StorageDead {
+                        slot: 0,
+                        local_ty: Type::I64,
+                    },
+                    Type::UNIT,
+                ),
+            );
+            cfg.append_call(
+                entry,
+                None,
+                interner.get_or_intern("bump"),
+                [CfgCallArg {
+                    value: argument,
+                    mode: CfgArgMode::Inout,
+                }],
+                Type::UNIT,
+                Span::new(0, 0),
+            )
+            .unwrap();
+            cfg.set_return(entry, None);
+            cfg
+        });
+
+        assert!(matches!(
+            program.try_inline("caller", "bump"),
+            Err(CfgInlineError::ByRefArgumentStorageEnded { arg_index: 0 })
+        ));
+    }
+
+    #[test]
+    fn by_ref_local_root_refuses_an_epoch_change_around_a_backedge() {
+        // The call is reachable either directly or after the loop replaces
+        // the local's storage epoch. A block-only visited set must not let the
+        // backedge hide that alternate path.
+        let mut program = scalar_program();
+        program.add("bump", |_| by_ref_bump_callee());
+        program.add("caller", |interner| {
+            let mut cfg = Cfg::new(Type::UNIT, 1, 0, "caller".to_string(), Vec::<bool>::new());
+            let entry = cfg.new_block();
+            let header = cfg.new_block();
+            let body = cfg.new_block();
+            let invoke = cfg.new_block();
+            cfg.entry = entry;
+            cfg.append_inst(
+                entry,
+                inst(
+                    CfgInstData::StorageLive {
+                        slot: 0,
+                        local_ty: Type::I64,
+                    },
+                    Type::UNIT,
+                ),
+            );
+            let one = cfg.append_inst(entry, inst(CfgInstData::Const(1), Type::I64));
+            cfg.append_inst(
+                entry,
+                inst(CfgInstData::Alloc { slot: 0, init: one }, Type::UNIT),
+            );
+            let argument = cfg.append_inst(entry, inst(CfgInstData::Load { slot: 0 }, Type::I64));
+            cfg.set_goto(entry, header, vec![]);
+
+            let iterate = cfg.append_inst(header, inst(CfgInstData::BoolConst(false), Type::BOOL));
+            cfg.set_branch(header, iterate, body, [], invoke, []);
+
+            cfg.append_inst(
+                body,
+                inst(
+                    CfgInstData::StorageDead {
+                        slot: 0,
+                        local_ty: Type::I64,
+                    },
+                    Type::UNIT,
+                ),
+            );
+            cfg.append_inst(
+                body,
+                inst(
+                    CfgInstData::StorageLive {
+                        slot: 0,
+                        local_ty: Type::I64,
+                    },
+                    Type::UNIT,
+                ),
+            );
+            let two = cfg.append_inst(body, inst(CfgInstData::Const(2), Type::I64));
+            cfg.append_inst(
+                body,
+                inst(CfgInstData::Alloc { slot: 0, init: two }, Type::UNIT),
+            );
+            cfg.set_goto(body, header, vec![]);
+
+            cfg.append_call(
+                invoke,
+                None,
+                interner.get_or_intern("bump"),
+                [CfgCallArg {
+                    value: argument,
+                    mode: CfgArgMode::Inout,
+                }],
+                Type::UNIT,
+                Span::new(0, 0),
+            )
+            .unwrap();
+            cfg.append_inst(
+                invoke,
+                inst(
+                    CfgInstData::StorageDead {
+                        slot: 0,
+                        local_ty: Type::I64,
+                    },
+                    Type::UNIT,
+                ),
+            );
+            cfg.set_return(invoke, None);
+            cfg
+        });
+
+        assert!(matches!(
+            program.try_inline("caller", "bump"),
+            Err(CfgInlineError::ByRefArgumentStorageEnded { arg_index: 0 })
+        ));
+    }
+
+    #[test]
+    fn by_ref_call_loop_without_reexecuting_place_read_is_not_inlineable() {
+        // The first call sees the storage epoch from entry. The recycle block
+        // replaces that epoch and jumps directly back to the call, without
+        // re-executing the SSA place read that supplied its argument.
+        let mut program = scalar_program();
+        program.add("bump", |_| by_ref_bump_callee());
+        program.add("caller", |interner| {
+            let mut cfg = Cfg::new(Type::UNIT, 1, 0, "caller".to_string(), Vec::<bool>::new());
+            let entry = cfg.new_block();
+            let invoke = cfg.new_block();
+            let recycle = cfg.new_block();
+            let exit = cfg.new_block();
+            cfg.entry = entry;
+            cfg.append_inst(
+                entry,
+                inst(
+                    CfgInstData::StorageLive {
+                        slot: 0,
+                        local_ty: Type::I64,
+                    },
+                    Type::UNIT,
+                ),
+            );
+            let one = cfg.append_inst(entry, inst(CfgInstData::Const(1), Type::I64));
+            cfg.append_inst(
+                entry,
+                inst(CfgInstData::Alloc { slot: 0, init: one }, Type::UNIT),
+            );
+            let argument = cfg.append_inst(entry, inst(CfgInstData::Load { slot: 0 }, Type::I64));
+            cfg.set_goto(entry, invoke, []);
+
+            cfg.append_call(
+                invoke,
+                None,
+                interner.get_or_intern("bump"),
+                [CfgCallArg {
+                    value: argument,
+                    mode: CfgArgMode::Inout,
+                }],
+                Type::UNIT,
+                Span::new(0, 0),
+            )
+            .unwrap();
+            let repeat = cfg.append_inst(invoke, inst(CfgInstData::BoolConst(false), Type::BOOL));
+            cfg.set_branch(invoke, repeat, recycle, [], exit, []);
+
+            cfg.append_inst(
+                recycle,
+                inst(
+                    CfgInstData::StorageDead {
+                        slot: 0,
+                        local_ty: Type::I64,
+                    },
+                    Type::UNIT,
+                ),
+            );
+            cfg.append_inst(
+                recycle,
+                inst(
+                    CfgInstData::StorageLive {
+                        slot: 0,
+                        local_ty: Type::I64,
+                    },
+                    Type::UNIT,
+                ),
+            );
+            let two = cfg.append_inst(recycle, inst(CfgInstData::Const(2), Type::I64));
+            cfg.append_inst(
+                recycle,
+                inst(CfgInstData::Alloc { slot: 0, init: two }, Type::UNIT),
+            );
+            cfg.set_goto(recycle, invoke, []);
+
+            cfg.append_inst(
+                exit,
+                inst(
+                    CfgInstData::StorageDead {
+                        slot: 0,
+                        local_ty: Type::I64,
+                    },
+                    Type::UNIT,
+                ),
+            );
+            cfg.set_return(exit, None);
+            cfg
+        });
+
+        assert!(matches!(
+            program.try_inline("caller", "bump"),
+            Err(CfgInlineError::ByRefArgumentCallCycle { arg_index: 0 })
+        ));
+    }
+
+    #[test]
+    fn unreachable_epoch_marker_does_not_refuse_a_safe_by_ref_inline() {
+        let mut program = scalar_program();
+        program.add("bump", |_| by_ref_bump_callee());
+        program.add("caller", |interner| {
+            let mut cfg = Cfg::new(Type::UNIT, 1, 0, "caller".to_string(), Vec::<bool>::new());
+            let entry = cfg.new_block();
+            let unreachable = cfg.new_block();
+            let invoke = cfg.new_block();
+            cfg.entry = entry;
+            cfg.append_inst(
+                entry,
+                inst(
+                    CfgInstData::StorageLive {
+                        slot: 0,
+                        local_ty: Type::I64,
+                    },
+                    Type::UNIT,
+                ),
+            );
+            let one = cfg.append_inst(entry, inst(CfgInstData::Const(1), Type::I64));
+            cfg.append_inst(
+                entry,
+                inst(CfgInstData::Alloc { slot: 0, init: one }, Type::UNIT),
+            );
+            let argument = cfg.append_inst(entry, inst(CfgInstData::Load { slot: 0 }, Type::I64));
+            cfg.set_goto(entry, invoke, vec![]);
+
+            cfg.append_inst(
+                unreachable,
+                inst(
+                    CfgInstData::StorageDead {
+                        slot: 0,
+                        local_ty: Type::I64,
+                    },
+                    Type::UNIT,
+                ),
+            );
+            cfg.set_goto(unreachable, invoke, vec![]);
+
+            cfg.append_call(
+                invoke,
+                None,
+                interner.get_or_intern("bump"),
+                [CfgCallArg {
+                    value: argument,
+                    mode: CfgArgMode::Inout,
+                }],
+                Type::UNIT,
+                Span::new(0, 0),
+            )
+            .unwrap();
+            cfg.append_inst(
+                invoke,
+                inst(
+                    CfgInstData::StorageDead {
+                        slot: 0,
+                        local_ty: Type::I64,
+                    },
+                    Type::UNIT,
+                ),
+            );
+            cfg.set_return(invoke, None);
+            cfg
+        });
+
+        let inlined = program.inline("caller", "bump");
         assert_all_blocks_terminated(&inlined);
     }
 

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -2742,6 +2742,16 @@ pub(crate) fn apply_general_inlining(
             };
             let growth = match rue_cfg::splice_call_growth(state.cfg.as_cfg(), call, &callee.cfg) {
                 Ok(growth) => growth,
+                Err(
+                    rue_cfg::CfgInlineError::ByRefArgumentStorageEnded { .. }
+                    | rue_cfg::CfgInlineError::ByRefArgumentCallCycle { .. },
+                ) => {
+                    // The call's SSA argument remains valid after its source
+                    // temporary dies, but redirecting an inlined by-reference
+                    // parameter back to that dead local would be invalid. Keep
+                    // the original call; general inlining is optional.
+                    continue;
+                }
                 Err(error) => {
                     failed = Some(format!("general inline growth preflight failed: {error}"));
                     break;

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -3269,6 +3269,120 @@ mod tests {
         assert_eq!(has_unit(&o3, "middle"), has_unit(&o3_again, "middle"));
     }
 
+    #[cfg(unix)]
+    #[test]
+    #[ignore = "platform_native_ host coverage; run by rue-compiler-platform-native-test"]
+    fn platform_native_o3_retains_byref_call_after_view_storage_epoch_ends() {
+        let context = ImportDiscoveryContext::new(1, "/project", Some("/sdk"), "test")
+            .expect("discovery context should be valid");
+        let mut assembler = DiscoverySourceAssembler::new(
+            context,
+            "/project/main.rue",
+            "/project/main.rue",
+            PhysicalFileIdentity::new(1, 1),
+            FileMetadataFingerprint::new(1, 1, 1),
+            Arc::new(
+                r#"
+                    const std = @import("std/_std.rue");
+                    const StrBuf = std.strbuf.StrBuf;
+                    fn leaf(inout s: str) -> i32 { @intCast(s.len()) }
+                    fn read_view(inout s: str, x: i32) -> i32 {
+                        @intCast(s.len()) + x
+                    }
+                    fn outer(inout s: str) -> i32 {
+                        read_view(inout s, leaf(inout s))
+                    }
+                    fn main() -> i32 {
+                        let mut text: StrBuf = "hello";
+                        let expected = @intCast(text.len()) * 2;
+                        if outer(inout text) == expected { 0 } else { 1 }
+                    }
+                "#
+                .to_owned(),
+            ),
+        )
+        .unwrap();
+        assembler
+            .add_explicit(
+                "/sdk/_std.rue",
+                "/sdk/_std.rue",
+                PhysicalFileIdentity::new(2, 2),
+                FileMetadataFingerprint::new(2, 2, 2),
+                Arc::new("pub const strbuf = @import(\"strbuf.rue\");".to_owned()),
+            )
+            .unwrap();
+        assembler
+            .add_explicit(
+                "/sdk/strbuf.rue",
+                "/sdk/strbuf.rue",
+                PhysicalFileIdentity::new(3, 3),
+                FileMetadataFingerprint::new(3, 3, 3),
+                Arc::new(
+                    r#"
+                    pub struct StrBuf {
+                        buf: ptr mut u8,
+                        len: u64,
+                        cap: u64,
+                        fn len(borrow self) -> u64 { self.len }
+                        fn as_ptr(borrow self) -> ptr mut u8 { self.buf }
+                    }
+                    drop fn StrBuf(self) {}
+                    "#
+                    .to_owned(),
+                ),
+            )
+            .unwrap();
+        let snapshot = assembler.snapshot().unwrap();
+
+        for opt_level in [OptLevel::O0, OptLevel::O2, OptLevel::O3] {
+            let options = CompileOptions {
+                opt_level,
+                ..CompileOptions::default()
+            };
+            let mut session = CompilerSession::new();
+            let published = publish_test_snapshot(&mut session, &snapshot).unwrap();
+            let rooted = session.rooted_cfg(&options).unwrap();
+            let main = rooted
+                .cfgs
+                .iter()
+                .find(|unit| {
+                    matches!(
+                        &unit.function,
+                        FunctionInstanceKey::Definition(definition) if definition.name() == "main"
+                    )
+                })
+                .expect("main reaches the optimized CFG batch");
+            assert!(
+                main.record.cfg.blocks().iter().any(|block| {
+                    block
+                        .insts
+                        .iter()
+                        .any(|value| match main.record.cfg.get_inst(*value).data {
+                            rue_cfg::CfgInstData::Call {
+                                runtime: None,
+                                name,
+                                ..
+                            } => main.record.interner.resolve(&name).ends_with("outer"),
+                            _ => false,
+                        })
+                }),
+                "{opt_level:?}: the unsafe by-ref view call must remain uninlined"
+            );
+
+            let output =
+                crate::queries::compile_with_session(&mut session, &published, &options).unwrap();
+            let execution =
+                execute_compiled_output(&output, &format!("byref-storage-epoch-{opt_level:?}"));
+            assert_eq!(
+                execution.status.code(),
+                Some(0),
+                "{opt_level:?}: retained source call did not execute consistently: {execution:?}"
+            );
+            assert!(execution.stdout.is_empty());
+            assert!(execution.stderr.is_empty());
+        }
+    }
+
     #[test]
     fn phase3_preflights_many_sites_before_budgeted_splices() {
         let calls = (0..80)

--- a/crates/rue-fuzz/README.md
+++ b/crates/rue-fuzz/README.md
@@ -122,24 +122,29 @@ input back to the target named in the filename:
 
 A separate, complementary fuzzer lives in `crates/rue-oracle-diff`: it generates
 random **valid, well-typed** programs (in the subset the `rue-oracle` reference
-interpreter models) and runs each through *both* the oracle and the real
-compiler + native binary, comparing exit code and `@dbg` stdout. A disagreement
+interpreter models) and runs each through *both* the oracle and native binaries
+compiled at O0, O1, O2, and O3, comparing exit code and `@dbg` stdout. A disagreement
 is an automatically-discovered **miscompile** with a deterministic, seed-based
 repro (not a crash — a *wrong answer*). Because the generator promises valid
 programs inside the oracle's modeled subset, compiler rejection and
 `Unsupported` are also fail-closed generator-contract findings with the same
-seed/source repro format. Repros land in this crate's `crashes/` directory as
-`oracle-diff-seed-<seed>.rue` and are uploaded by the same CI artifact step.
+seed/source repro format. Generator-contract repros land in this crate's
+`crashes/` directory as `oracle-diff-seed-<seed>.rue`; native disagreements add
+the failing lane as `oracle-diff-seed-<seed>-O<level>.rue`. Both are uploaded by
+the same CI artifact step.
 
 ```bash
 RUE_BINARY="$(scripts/rue-bin)" ./buck2 run //crates/rue-oracle-diff:rue-oracle-diff -- \
-    fuzz --seeds 500                 # cross-check 500 generated programs
+    fuzz --seeds 500                 # 500 programs × O0/O1/O2/O3 = 2,000 lanes
 ./buck2 run //crates/rue-oracle-diff:rue-oracle-diff -- dump 42   # inspect seed 42's program
 ```
 
 ## Integration with CI
 
-Fuzzing runs automatically in CI via `.github/workflows/fuzz.yml`. Each target runs for 5 minutes daily; the differential fuzzer (above) runs a bounded 500-seed batch in the same workflow.
+Fuzzing runs automatically in CI via `.github/workflows/fuzz.yml`. Each mutation
+target runs for 5 minutes daily; the differential fuzzer runs a fixed 500-program
+batch across all four optimization levels (2,000 native lanes) under a 60-minute
+outer job bound and independent per-phase child-process timeouts.
 
 To run fuzzing locally for a limited time:
 

--- a/crates/rue-oracle-diff/BUCK
+++ b/crates/rue-oracle-diff/BUCK
@@ -1,17 +1,20 @@
 load("//crates:defs.bzl", "rue_binary")
 load("//:corpus.bzl", "cached_corpus_suite")
+load("//:test_defs.bzl", "rue_sh_test")
 
 # The differential harness. Two modes:
 #  * default: runs the concrete rue-cli-tests corpus through the rue-oracle
-#    reference interpreter and checks it agrees with each case's expected exit
-#    code / stdout / stderr after first checking the canonical raw/post-transform
-#    CFG boundary (a mismatch localizes to CFG transformation or later codegen;
-#    wired as the sh_test below).
+#    reference interpreter, checks it agrees with each case's expected exit
+#    code / stdout / stderr, and executes each eligible case at O1, O2, and O3
+#    across the level-sharded actions below. It first checks the canonical
+#    raw/post-transform CFG boundary, so a mismatch localizes to CFG
+#    transformation or later codegen.
 #  * `fuzz`: the differential *fuzzer* (RUE-247) — generates random valid
-#    programs and cross-checks the oracle against the real compiler + native
-#    binary, reporting exit/stdout/stderr disagreements as miscompiles and generated
-#    compile/Unsupported results as contract failures, all with seed-based
-#    repros. Driven by `.github/workflows/fuzz.yml` nightly; needs `RUE_BINARY`.
+#    programs and cross-checks the oracle against native binaries at O0, O1,
+#    O2, and O3, reporting exit/stdout/stderr disagreements as miscompiles and
+#    generated compile/Unsupported results as contract failures, all with
+#    seed-based repros. Driven by `.github/workflows/fuzz.yml` nightly; needs
+#    `RUE_BINARY`.
 # The harness driver itself has no #[test] functions — it IS the harness — but
 # the `generator` module carries unit tests (determinism + always-emits-main),
 # so the rust_test target (`:rue-oracle-diff-test`) is kept enabled.
@@ -39,6 +42,29 @@ rue_binary(
     ],
 )
 
+export_file(
+    name = "planted-fake-compiler",
+    src = "testdata/planted-fake-rue.sh",
+)
+
+export_file(
+    name = "planted-fake-program",
+    src = "testdata/planted-fake-program.sh",
+)
+
+# Expected-failure integration proof: drive the real harness argument parser
+# and all four generated native lanes with a deterministic compiler/program.
+# The wrapper succeeds only when the guarded mutation makes O2 alone disagree.
+rue_sh_test(
+    name = "oracle-diff-planted-miscompile-test",
+    test = "test-planted-miscompile.sh",
+    env = {
+        "RUE_ORACLE_DIFF_BINARY": "$(exe_target :rue-oracle-diff)",
+        "RUE_ORACLE_DIFF_FAKE_COMPILER": "$(location :planted-fake-compiler)",
+        "RUE_ORACLE_DIFF_FAKE_PROGRAM": "$(location :planted-fake-program)",
+    },
+)
+
 # Run the differential harness under `buck2 test //...` (and hence CI): the
 # harness reads the rue-cli-tests `cases` filegroup via RUE_ORACLE_DIFF_CASES
 # and exits non-zero on ANY oracle/compiler disagreement, so a codegen change
@@ -50,27 +76,57 @@ rue_binary(
 # violations fail the harness; only typed model gaps remain coverage debt.
 # Preview-gated cases run when their declared preview flags can be mapped onto
 # the single-source oracle.
-# RUE-1163: a cached action like its peer corpora. Both inputs reach the harness
-# through declared env paths, and it drives the reference interpreter in-process
-# rather than spawning the compiler, so the cases filegroup and std/ are the
-# whole contract.
+# RUE-1163: a cached action like its peer corpora. Every runtime input reaches
+# the harness through a declared env path. The optimized native lane compiles
+# one complete optimization-level shard per action, so the compiler is part of
+# the cache key alongside the cases and std inputs. The three actions load the
+# authoritative inventory but own disjoint O1/O2/O3 native lanes; together they
+# cover the full modeled case×optimization matrix.
 cached_corpus_suite(
     name = "oracle-diff-test",
     tier = "slow",
-    # RUE-1117: `rue_heavy_suite` gives the differential the same execution
-    # contract as the other opaque corpus harnesses — its own CI lane through
-    # `scripts/ci-heavy-suite` (which fails closed if Buck reports no result for
-    # it), and exclusion from any broad pass that would otherwise absorb it.
     labels = ["rue_not_quick", "rue_heavy_suite"],
     harness = ":rue-oracle-diff",
     env = {
+        "RUE_BINARY": "$(exe_target //crates/rue:rue)",
         "RUE_ORACLE_DIFF_CASES": "$(location //crates/rue-cli-tests:cases)/cases",
+        "RUE_ORACLE_DIFF_EXECUTION_CONTRACTS": "$(location //crates/rue-cli-tests:cases)/cases/execution_contracts.toml",
+        "RUE_ORACLE_DIFF_OPT_LEVEL": "O1",
         "RUE_ORACLE_DIFF_STD": "$(location root//:std)/std",
     },
-    absolutize = [
-        "RUE_ORACLE_DIFF_CASES",
-        "RUE_ORACLE_DIFF_STD",
-    ],
+    absolutize = ["RUE_BINARY", "RUE_ORACLE_DIFF_CASES", "RUE_ORACLE_DIFF_EXECUTION_CONTRACTS", "RUE_ORACLE_DIFF_STD"],
+    timeout_seconds = 3600,
+)
+
+cached_corpus_suite(
+    name = "oracle-diff-test-o2",
+    tier = "slow",
+    labels = ["rue_not_quick", "rue_heavy_suite"],
+    harness = ":rue-oracle-diff",
+    env = {
+        "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_ORACLE_DIFF_CASES": "$(location //crates/rue-cli-tests:cases)/cases",
+        "RUE_ORACLE_DIFF_EXECUTION_CONTRACTS": "$(location //crates/rue-cli-tests:cases)/cases/execution_contracts.toml",
+        "RUE_ORACLE_DIFF_OPT_LEVEL": "O2",
+        "RUE_ORACLE_DIFF_STD": "$(location root//:std)/std",
+    },
+    absolutize = ["RUE_BINARY", "RUE_ORACLE_DIFF_CASES", "RUE_ORACLE_DIFF_EXECUTION_CONTRACTS", "RUE_ORACLE_DIFF_STD"],
+    timeout_seconds = 3600,
+)
+
+cached_corpus_suite(
+    name = "oracle-diff-test-o3",
+    tier = "slow",
+    labels = ["rue_not_quick", "rue_heavy_suite"],
+    harness = ":rue-oracle-diff",
+    env = {
+        "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_ORACLE_DIFF_CASES": "$(location //crates/rue-cli-tests:cases)/cases",
+        "RUE_ORACLE_DIFF_EXECUTION_CONTRACTS": "$(location //crates/rue-cli-tests:cases)/cases/execution_contracts.toml",
+        "RUE_ORACLE_DIFF_OPT_LEVEL": "O3",
+        "RUE_ORACLE_DIFF_STD": "$(location root//:std)/std",
+    },
+    absolutize = ["RUE_BINARY", "RUE_ORACLE_DIFF_CASES", "RUE_ORACLE_DIFF_EXECUTION_CONTRACTS", "RUE_ORACLE_DIFF_STD"],
     timeout_seconds = 3600,
 )
 
@@ -87,12 +143,43 @@ cached_corpus_suite(
     harness = ":rue-oracle-diff",
     args = ["spec"],
     env = {
+        "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_ORACLE_DIFF_OPT_LEVEL": "O1",
         "RUE_ORACLE_DIFF_SPEC_CASES": "$(location //crates/rue-spec:cases)/cases",
         "RUE_ORACLE_DIFF_STD": "$(location root//:std)/std",
     },
-    absolutize = [
-        "RUE_ORACLE_DIFF_SPEC_CASES",
-        "RUE_ORACLE_DIFF_STD",
-    ],
+    absolutize = ["RUE_BINARY", "RUE_ORACLE_DIFF_SPEC_CASES", "RUE_ORACLE_DIFF_STD"],
+    timeout_seconds = 3600,
+)
+
+cached_corpus_suite(
+    name = "oracle-diff-spec-test-o2",
+    tier = "slow",
+    labels = ["rue_not_quick", "rue_heavy_suite"],
+    harness = ":rue-oracle-diff",
+    args = ["spec"],
+    env = {
+        "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_ORACLE_DIFF_OPT_LEVEL": "O2",
+        "RUE_ORACLE_DIFF_SPEC_CASES": "$(location //crates/rue-spec:cases)/cases",
+        "RUE_ORACLE_DIFF_STD": "$(location root//:std)/std",
+    },
+    absolutize = ["RUE_BINARY", "RUE_ORACLE_DIFF_SPEC_CASES", "RUE_ORACLE_DIFF_STD"],
+    timeout_seconds = 3600,
+)
+
+cached_corpus_suite(
+    name = "oracle-diff-spec-test-o3",
+    tier = "slow",
+    labels = ["rue_not_quick", "rue_heavy_suite"],
+    harness = ":rue-oracle-diff",
+    args = ["spec"],
+    env = {
+        "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_ORACLE_DIFF_OPT_LEVEL": "O3",
+        "RUE_ORACLE_DIFF_SPEC_CASES": "$(location //crates/rue-spec:cases)/cases",
+        "RUE_ORACLE_DIFF_STD": "$(location root//:std)/std",
+    },
+    absolutize = ["RUE_BINARY", "RUE_ORACLE_DIFF_SPEC_CASES", "RUE_ORACLE_DIFF_STD"],
     timeout_seconds = 3600,
 )

--- a/crates/rue-oracle-diff/src/fuzz.rs
+++ b/crates/rue-oracle-diff/src/fuzz.rs
@@ -4,7 +4,7 @@
 //! through *both* engines:
 //!
 //! 1. the [`rue_oracle`] reference interpreter at both canonical CFG boundaries,
-//! 2. the real compiler + the produced native binary.
+//! 2. the real compiler + produced native binaries at O0, O1, O2, and O3.
 //!
 //! Then compare the observable behavior — process exit code, stdout, stderr,
 //! and typed trap cause.
@@ -27,17 +27,59 @@ use rue_oracle::{
     MAX_STDERR_BYTES, MAX_STDOUT_BYTES, RunSourceError, TrapKind, Unsupported, UnsupportedKind,
     run_source_cfg_differential,
 };
+use std::fmt;
 use std::io::Read;
 use std::os::unix::process::ExitStatusExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitCode, ExitStatus, Stdio};
 use std::time::{Duration, Instant};
 
+/// Compiler optimization lanes covered by the native differential.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OptimizationLevel {
+    O0,
+    O1,
+    O2,
+    O3,
+}
+
+impl OptimizationLevel {
+    pub(crate) const OPTIMIZED: [Self; 3] = [Self::O1, Self::O2, Self::O3];
+
+    fn flag(self) -> &'static str {
+        match self {
+            Self::O0 => "-O0",
+            Self::O1 => "-O1",
+            Self::O2 => "-O2",
+            Self::O3 => "-O3",
+        }
+    }
+}
+
+impl fmt::Display for OptimizationLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.flag().trim_start_matches('-'))
+    }
+}
+
+pub(crate) struct CompileOptions<'a> {
+    pub(crate) optimization: OptimizationLevel,
+    pub(crate) previews: &'a [String],
+    pub(crate) std_path: Option<&'a Path>,
+    pub(crate) compile_timeout: Duration,
+    pub(crate) runtime_timeout: Duration,
+}
+
 /// Outcome of compiling and running a generated program natively.
-enum Compiled {
-    /// The compiler rejected a program the oracle's frontend accepted — an ICE
-    /// or backend gap (carries the compiler's stderr, truncated).
-    CompileFail(String),
+#[derive(Debug)]
+pub(crate) enum Compiled {
+    /// The compiler rejected a program the oracle's frontend accepted — a
+    /// front/backend gap distinct from an ICE (carries truncated stderr).
+    CompileRejected { exit: i32, stderr: String },
+    /// The compiler terminated by signal rather than rejecting the source.
+    CompileCrash { signal: i32, stderr: String },
+    /// The compiler reported an internal panic/ICE with an ordinary exit code.
+    CompileIce(String),
     /// The compiler did not terminate within the per-phase timeout.
     CompileTimeout,
     /// The binary ran to completion: process exit code + captured stdout +
@@ -152,6 +194,9 @@ struct Config {
     timeout: Duration,
     crash_dir: PathBuf,
     verbose: bool,
+    /// Test-harness-only observation mutation proving a selected optimized
+    /// lane detects a wrong result. It never changes compiler production code.
+    planted_miscompile: Option<OptimizationLevel>,
 }
 
 impl Default for Config {
@@ -162,6 +207,7 @@ impl Default for Config {
             timeout: Duration::from_secs(10),
             crash_dir: PathBuf::from("crates/rue-fuzz/crashes"),
             verbose: false,
+            planted_miscompile: None,
         }
     }
 }
@@ -192,6 +238,19 @@ fn parse_args(args: &[String]) -> Result<Config, String> {
             }
             "--crash-dir" => cfg.crash_dir = PathBuf::from(value()?),
             "--verbose" | "-v" => cfg.verbose = true,
+            "--test-plant-miscompile" => {
+                if std::env::var_os("RUE_ORACLE_DIFF_TESTING").is_none() {
+                    return Err(
+                        "--test-plant-miscompile requires RUE_ORACLE_DIFF_TESTING".to_string()
+                    );
+                }
+                cfg.planted_miscompile = Some(match value()?.as_str() {
+                    "O1" | "1" => OptimizationLevel::O1,
+                    "O2" | "2" => OptimizationLevel::O2,
+                    "O3" | "3" => OptimizationLevel::O3,
+                    _ => return Err("bad --test-plant-miscompile (expected O1, O2, or O3)".into()),
+                });
+            }
             other => return Err(format!("unknown argument: {other}")),
         }
     }
@@ -289,7 +348,7 @@ pub fn run(args: &[String]) -> ExitCode {
                 };
                 eprintln!("{}", finding.render());
                 if let Err(error) = save_generator_contract_repro(&cfg.crash_dir, &finding) {
-                    report_repro_write_error(&cfg.crash_dir, seed, &error);
+                    report_repro_write_error(&cfg.crash_dir, seed, None, &error);
                 }
                 generator_contract_failures.push(finding);
                 continue;
@@ -305,53 +364,76 @@ pub fn run(args: &[String]) -> ExitCode {
             };
             eprintln!("{}", finding.render());
             if let Err(error) = save_generator_contract_repro(&cfg.crash_dir, &finding) {
-                report_repro_write_error(&cfg.crash_dir, seed, &error);
+                report_repro_write_error(&cfg.crash_dir, seed, None, &error);
             }
             generator_contract_failures.push(finding);
             continue;
         }
 
-        let compiled = match compile_and_run(&rue, workdir.path(), &source, cfg.timeout) {
-            Ok(c) => c,
-            Err(e) => {
-                // An infrastructure failure (couldn't invoke the tools) is fatal
-                // — better to stop loudly than silently pass.
-                eprintln!("seed {seed}: harness error: {e}");
-                return ExitCode::FAILURE;
-            }
-        };
+        for level in [
+            OptimizationLevel::O0,
+            OptimizationLevel::O1,
+            OptimizationLevel::O2,
+            OptimizationLevel::O3,
+        ] {
+            let mut compiled = match compile_and_run(
+                &rue,
+                workdir.path(),
+                &source,
+                CompileOptions {
+                    optimization: level,
+                    previews: &[],
+                    std_path: None,
+                    compile_timeout: cfg.timeout,
+                    runtime_timeout: cfg.timeout,
+                },
+            ) {
+                Ok(c) => c,
+                Err(e) => {
+                    // An infrastructure failure (couldn't invoke the tools) is fatal
+                    // — better to stop loudly than silently pass.
+                    eprintln!("seed {seed} [{level}]: harness error: {e}");
+                    return ExitCode::FAILURE;
+                }
+            };
+            plant_test_miscompile(&mut compiled, level, cfg.planted_miscompile);
 
-        match classify(&oracle, &compiled) {
-            Verdict::Agree => {
-                agree += 1;
-                if cfg.verbose {
-                    println!("  seed {seed}: agree (exit {})", oracle.exit_code);
+            match classify(&oracle, &compiled) {
+                Verdict::Agree => {
+                    agree += 1;
+                    if cfg.verbose {
+                        println!("  seed {seed} [{level}]: agree (exit {})", oracle.exit_code);
+                    }
                 }
-            }
-            Verdict::Disagree(reason) => {
-                let d = Disagreement {
-                    seed,
-                    timeout_secs: cfg.timeout.as_secs(),
-                    source: source.clone(),
-                    oracle_exit: oracle.exit_code,
-                    oracle_stdout: oracle.stdout.clone(),
-                    oracle_stderr: oracle.stderr.clone(),
-                    oracle_panic: oracle.panic.clone(),
-                    compiled: describe(&compiled),
-                    reason,
-                };
-                eprintln!("{}", d.render());
-                if let Err(error) = save_repro(&cfg.crash_dir, &d) {
-                    report_repro_write_error(&cfg.crash_dir, seed, &error);
+                Verdict::Disagree(reason) => {
+                    let d = Disagreement {
+                        seed,
+                        optimization: level,
+                        timeout_secs: cfg.timeout.as_secs(),
+                        source: source.clone(),
+                        oracle_exit: oracle.exit_code,
+                        oracle_stdout: oracle.stdout.clone(),
+                        oracle_stderr: oracle.stderr.clone(),
+                        oracle_panic: oracle.panic,
+                        compiled: describe(&compiled),
+                        reason,
+                    };
+                    eprintln!("{}", d.render());
+                    if let Err(error) = save_repro(&cfg.crash_dir, &d) {
+                        report_repro_write_error(&cfg.crash_dir, seed, Some(level), &error);
+                    }
+                    disagreements.push(d);
                 }
-                disagreements.push(d);
             }
         }
     }
 
-    let total = agree + generator_contract_failures.len() as u32 + disagreements.len() as u32;
-    println!("\n=== summary over {total} generated programs ===");
-    println!("  agree:            {agree}");
+    let total_lanes = agree + disagreements.len() as u32;
+    println!(
+        "\n=== summary over {} generated programs / {total_lanes} native lanes ===",
+        cfg.seeds
+    );
+    println!("  agreeing lanes:   {agree}");
     println!(
         "  GENERATOR CONTRACT FAILURES: {}",
         generator_contract_failures.len()
@@ -384,12 +466,12 @@ fn generated_batch_passes(contract_failures: usize, disagreements: usize) -> boo
 }
 
 /// The comparison verdict.
-enum Verdict {
+pub(crate) enum Verdict {
     Agree,
     Disagree(String),
 }
 
-fn classify(oracle: &rue_oracle::Outcome, compiled: &Compiled) -> Verdict {
+pub(crate) fn classify(oracle: &rue_oracle::Outcome, compiled: &Compiled) -> Verdict {
     match compiled {
         Compiled::Ran {
             exit,
@@ -475,10 +557,17 @@ fn classify(oracle: &rue_oracle::Outcome, compiled: &Compiled) -> Verdict {
             }
             Verdict::Agree
         }
-        Compiled::CompileFail(stderr) => Verdict::Disagree(format!(
-            "compiler rejected a program the oracle accepted (possible ICE/backend gap): {}",
+        Compiled::CompileRejected { exit, stderr } => Verdict::Disagree(format!(
+            "compiler rejected a program the oracle accepted (exit {exit}): {}",
             first_line(stderr)
         )),
+        Compiled::CompileCrash { signal, stderr } => Verdict::Disagree(format!(
+            "compiler crashed with signal {signal}: {}",
+            first_line(stderr)
+        )),
+        Compiled::CompileIce(detail) => {
+            Verdict::Disagree(format!("internal compiler error: {}", first_line(detail)))
+        }
         Compiled::CompileTimeout => Verdict::Disagree(
             "compiler did not terminate within the per-phase timeout (oracle ran cleanly)"
                 .to_string(),
@@ -492,21 +581,27 @@ fn classify(oracle: &rue_oracle::Outcome, compiled: &Compiled) -> Verdict {
     }
 }
 
-fn compile_and_run(
+pub(crate) fn compile_and_run(
     rue: &Path,
     dir: &Path,
     source: &str,
-    timeout: Duration,
+    options: CompileOptions<'_>,
 ) -> std::io::Result<Compiled> {
     let src_path = dir.join("prog.rue");
     std::fs::write(&src_path, source)?;
     let bin_path = dir.join("prog");
-    // Best-effort remove of a stale binary so a compile failure can't run last
-    // iteration's executable.
-    let _ = std::fs::remove_file(&bin_path);
+    // Remove a stale binary so a compile failure cannot run the previous
+    // iteration's executable. Only absence is benign: a permission or file
+    // type error means the harness cannot establish artifact freshness.
+    match std::fs::remove_file(&bin_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
 
     let mut compile_cmd = Command::new(rue);
     compile_cmd
+        .arg(options.optimization.flag())
         .arg("prog.rue")
         .arg("-o")
         .arg("prog")
@@ -514,12 +609,55 @@ fn compile_and_run(
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
-    match run_process_with_timeout(compile_cmd, timeout)? {
+    compile_cmd.env_remove("RUE_STD_PATH");
+    if let Some(std_path) = options.std_path {
+        compile_cmd.env("RUE_STD_PATH", std_path);
+    }
+    for preview in options.previews {
+        compile_cmd.arg("--preview").arg(preview);
+    }
+    match run_process_with_timeout(compile_cmd, options.compile_timeout)? {
         ProcessOutcome::TimedOut => return Ok(Compiled::CompileTimeout),
-        ProcessOutcome::Exited { status, stderr, .. } if !status.success() => {
-            return Ok(Compiled::CompileFail(stderr));
+        ProcessOutcome::Exited { status, stderr, .. } => {
+            if let Some(signal) = status.signal() {
+                return Ok(Compiled::CompileCrash { signal, stderr });
+            }
+            if let Some(failure) = rue_test_runner::ice_message(&status, &stderr) {
+                return Ok(Compiled::CompileIce(failure.to_string()));
+            }
+            if !status.success() {
+                return Ok(Compiled::CompileRejected {
+                    exit: status.code().unwrap_or(-1),
+                    stderr,
+                });
+            }
         }
-        ProcessOutcome::Exited { .. } => {}
+    }
+
+    let metadata = std::fs::metadata(&bin_path).map_err(|error| {
+        std::io::Error::new(
+            error.kind(),
+            format!(
+                "compiler succeeded without producing {}: {error}",
+                bin_path.display()
+            ),
+        )
+    })?;
+    if !metadata.is_file() {
+        return Err(std::io::Error::other(format!(
+            "compiler output {} is not a regular file",
+            bin_path.display()
+        )));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if metadata.permissions().mode() & 0o111 == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                format!("compiler output {} is not executable", bin_path.display()),
+            ));
+        }
     }
 
     // Run the produced binary directly with a manual timeout so we can read the
@@ -528,7 +666,23 @@ fn compile_and_run(
     // `classify` for panic-category comparison (RUE-339).
     let mut cmd = Command::new(&bin_path);
     cmd.current_dir(dir);
-    run_with_timeout(cmd, timeout)
+    run_with_timeout(cmd, options.runtime_timeout)
+}
+
+/// Mutate only the harness's captured observation, and only when the guarded
+/// negative-test flag selected this exact optimized lane. Wrapping makes the
+/// planted wrong exit deterministic for every native result, including 255.
+fn plant_test_miscompile(
+    compiled: &mut Compiled,
+    level: OptimizationLevel,
+    selected: Option<OptimizationLevel>,
+) {
+    if selected != Some(level) {
+        return;
+    }
+    if let Compiled::Ran { exit, .. } = compiled {
+        *exit = (*exit + 1).rem_euclid(256);
+    }
 }
 
 /// Result of one child process whose stdout/stderr were drained while it ran.
@@ -559,6 +713,7 @@ fn run_process_with_timeout(
     mut cmd: Command,
     timeout: Duration,
 ) -> std::io::Result<ProcessOutcome> {
+    rue_test_runner::configure_process_group(&mut cmd);
     let child = cmd.spawn()?;
     wait_for_process(child, timeout)
 }
@@ -583,7 +738,15 @@ fn wait_for_process(mut child: Child, timeout: Duration) -> std::io::Result<Proc
     let start = Instant::now();
     let status: std::io::Result<Option<ExitStatus>> = loop {
         match child.try_wait() {
-            Ok(Some(status)) => break Ok(Some(status)),
+            Ok(Some(status)) => {
+                // The direct child is authoritative for success even if it
+                // crossed the deadline concurrently with this poll. Tear down
+                // any descendants it left in its private process group before
+                // joining readers, because an inherited pipe fd would
+                // otherwise keep those joins blocked forever.
+                terminate_and_reap(&mut child);
+                break Ok(Some(status));
+            }
             Ok(None) if start.elapsed() >= timeout => {
                 terminate_and_reap(&mut child);
                 break Ok(None);
@@ -619,11 +782,10 @@ fn wait_for_process(mut child: Child, timeout: Duration) -> std::io::Result<Proc
 }
 
 fn terminate_and_reap(child: &mut Child) {
-    // `kill` can race with a natural exit; `wait` still reaps either way. The
-    // harness executes direct compiler/program children, not shell process
-    // trees, so terminating this one process closes every captured write end.
-    let _ = child.kill();
-    let _ = child.wait();
+    // The canonical helper signals the child's private process group before
+    // reaping the direct child. This closes pipe fds inherited by compiler
+    // linkers or native grandchildren as well as handling a natural-exit race.
+    rue_test_runner::kill_process_group(child);
 }
 
 /// Run one generated native binary using the shared bounded subprocess path.
@@ -689,6 +851,7 @@ fn read_capped<R: Read>(mut r: R, cap: usize) -> CappedRead {
 
 struct Disagreement {
     seed: u64,
+    optimization: OptimizationLevel,
     /// Per-phase compiler/native execution budget needed to replay timeouts.
     timeout_secs: u64,
     source: String,
@@ -703,8 +866,9 @@ struct Disagreement {
 impl Disagreement {
     fn render(&self) -> String {
         format!(
-            "\n\u{2717} DISAGREEMENT (seed {seed})\n  {reason}\n  oracle:   exit={exit} panic={panic:?} stdout={stdout:?} stderr={stderr:?}\n  compiled: {compiled}\n  --- source (regenerate with `fuzz --start {seed} --seeds 1 --timeout {timeout_secs}`) ---\n{source}",
+            "\n\u{2717} DISAGREEMENT (seed {seed}, {optimization})\n  {reason}\n  oracle:   exit={exit} panic={panic:?} stdout={stdout:?} stderr={stderr:?}\n  compiled: {compiled}\n  --- source (regenerate with `fuzz --start {seed} --seeds 1 --timeout {timeout_secs}`) ---\n{source}",
             seed = self.seed,
+            optimization = self.optimization,
             timeout_secs = self.timeout_secs,
             reason = self.reason,
             exit = self.oracle_exit,
@@ -737,7 +901,13 @@ fn describe(c: &Compiled) -> String {
                  stderr={stderr:?} stderr-truncated={stderr_truncated}"
             )
         }
-        Compiled::CompileFail(e) => format!("compile-fail: {}", first_line(e)),
+        Compiled::CompileRejected { exit, stderr } => {
+            format!("compile-rejected exit={exit}: {}", first_line(stderr))
+        }
+        Compiled::CompileCrash { signal, stderr } => {
+            format!("compiler-crash signal={signal}: {}", first_line(stderr))
+        }
+        Compiled::CompileIce(detail) => format!("compiler-ice: {}", first_line(detail)),
         Compiled::CompileTimeout => "compile-timeout".to_string(),
         Compiled::Crash(sig) => format!("crash signal={sig}"),
         Compiled::Timeout => "timeout".to_string(),
@@ -753,8 +923,11 @@ fn first_line(s: &str) -> String {
         .collect()
 }
 
-fn repro_path(dir: &Path, seed: u64) -> PathBuf {
-    dir.join(format!("oracle-diff-seed-{seed}.rue"))
+fn repro_path(dir: &Path, seed: u64, optimization: Option<OptimizationLevel>) -> PathBuf {
+    match optimization {
+        Some(level) => dir.join(format!("oracle-diff-seed-{seed}-{level}.rue")),
+        None => dir.join(format!("oracle-diff-seed-{seed}.rue")),
+    }
 }
 
 /// Escape dynamic diagnostic text onto one physical `//` line. Diagnostics may
@@ -778,6 +951,7 @@ fn disagreement_repro_contents(d: &Disagreement) -> String {
         "// rue-oracle-diff differential miscompile (seed {})\n",
         d.seed
     );
+    push_repro_comment(&mut contents, "optimization", &d.optimization.to_string());
     push_repro_comment(&mut contents, "reason", &d.reason);
     push_repro_comment(
         &mut contents,
@@ -821,21 +995,36 @@ fn generator_contract_repro_contents(finding: &GeneratorContractFinding) -> Stri
     contents
 }
 
-fn write_repro(dir: &Path, seed: u64, contents: &str) -> std::io::Result<()> {
+fn write_repro(
+    dir: &Path,
+    seed: u64,
+    optimization: Option<OptimizationLevel>,
+    contents: &str,
+) -> std::io::Result<()> {
     std::fs::create_dir_all(dir)?;
-    std::fs::write(repro_path(dir, seed), contents)
+    std::fs::write(repro_path(dir, seed, optimization), contents)
 }
 
-fn report_repro_write_error(dir: &Path, seed: u64, error: &std::io::Error) {
+fn report_repro_write_error(
+    dir: &Path,
+    seed: u64,
+    optimization: Option<OptimizationLevel>,
+    error: &std::io::Error,
+) {
     eprintln!(
         "seed {seed}: failed to save repro at {}: {error}",
-        repro_path(dir, seed).display()
+        repro_path(dir, seed, optimization).display()
     );
 }
 
 /// Persist a repro so a CI failure uploads a concrete, self-contained program.
 fn save_repro(dir: &Path, d: &Disagreement) -> std::io::Result<()> {
-    write_repro(dir, d.seed, &disagreement_repro_contents(d))
+    write_repro(
+        dir,
+        d.seed,
+        Some(d.optimization),
+        &disagreement_repro_contents(d),
+    )
 }
 
 fn save_generator_contract_repro(
@@ -845,6 +1034,7 @@ fn save_generator_contract_repro(
     write_repro(
         dir,
         finding.seed,
+        None,
         &generator_contract_repro_contents(finding),
     )
 }
@@ -923,6 +1113,63 @@ mod tests {
 
     fn is_disagree(v: Verdict) -> bool {
         matches!(v, Verdict::Disagree(_))
+    }
+
+    #[test]
+    fn planted_miscompile_mutates_only_the_selected_optimized_lane() {
+        let mut o0 = ran(42, "");
+        let mut o1 = ran(42, "");
+        let mut o2 = ran(42, "");
+        let mut o3 = ran(42, "");
+        for (compiled, level) in [
+            (&mut o0, OptimizationLevel::O0),
+            (&mut o1, OptimizationLevel::O1),
+            (&mut o2, OptimizationLevel::O2),
+            (&mut o3, OptimizationLevel::O3),
+        ] {
+            plant_test_miscompile(compiled, level, Some(OptimizationLevel::O2));
+        }
+        let oracle = oc(42, "");
+        assert!(matches!(classify(&oracle, &o0), Verdict::Agree));
+        assert!(matches!(classify(&oracle, &o1), Verdict::Agree));
+        assert!(is_disagree(classify(&oracle, &o2)));
+        assert!(matches!(classify(&oracle, &o3), Verdict::Agree));
+    }
+
+    #[test]
+    fn native_compile_preserves_optimization_preview_and_real_std_settings() {
+        let workdir = create_workdir().expect("temporary workdir");
+        let std_path = workdir.path().join("std-fixture");
+        std::fs::create_dir(&std_path).expect("create std fixture");
+        let compiler = fake_compiler(
+            workdir.path(),
+            "#!/bin/sh\n\
+             [ \"$1\" = -O3 ] || exit 21\n\
+             [ \"$5\" = --preview ] || exit 22\n\
+             [ \"$6\" = test_infra ] || exit 23\n\
+             [ -d \"$RUE_STD_PATH\" ] || exit 24\n\
+             printf '#!/bin/sh\\nexit 0\\n' > prog\n\
+             chmod +x prog\n",
+        );
+        let previews = vec!["test_infra".to_string()];
+        let result = compile_and_run(
+            &compiler,
+            workdir.path(),
+            "fn main() -> i32 { 0 }",
+            CompileOptions {
+                optimization: OptimizationLevel::O3,
+                previews: &previews,
+                std_path: Some(&std_path),
+                compile_timeout: Duration::from_secs(5),
+                runtime_timeout: Duration::from_secs(5),
+            },
+        )
+        .expect("run fake compiler");
+        assert!(
+            matches!(result, Compiled::Ran { exit: 0, .. }),
+            "{}",
+            describe(&result)
+        );
     }
 
     #[test]
@@ -1082,7 +1329,21 @@ mod tests {
         // divergence worth reporting.
         assert!(is_disagree(classify(
             &oc(0, ""),
-            &Compiled::CompileFail("boom".into())
+            &Compiled::CompileRejected {
+                exit: 1,
+                stderr: "boom".into(),
+            }
+        )));
+        assert!(is_disagree(classify(
+            &oc(0, ""),
+            &Compiled::CompileCrash {
+                signal: 6,
+                stderr: String::new(),
+            }
+        )));
+        assert!(is_disagree(classify(
+            &oc(0, ""),
+            &Compiled::CompileIce("compiler panicked".into())
         )));
         assert!(is_disagree(classify(&oc(0, ""), &Compiled::CompileTimeout)));
         assert!(is_disagree(classify(&oc(0, ""), &Compiled::Crash(11))));
@@ -1103,7 +1364,7 @@ mod tests {
     #[test]
     fn generated_oracle_errors_remain_typed_contract_failures() {
         // A frontend rejection is a generator compile-contract failure, not an
-        // oracle Unsupported skip and not a native `Compiled::CompileFail`.
+        // oracle Unsupported skip and not a native `Compiled::CompileRejected`.
         let compile_error =
             rue_oracle::run_source("fn main(").expect_err("invalid Rue must not compile");
         let compile_failure = GeneratorContractFailure::from_run_source(compile_error);
@@ -1209,6 +1470,7 @@ mod tests {
     fn disagreement_repro_also_escapes_multiline_metadata() {
         let disagreement = Disagreement {
             seed: 23,
+            optimization: OptimizationLevel::O2,
             timeout_secs: 3,
             source: "fn main() -> i32 { 23 }\n".to_string(),
             oracle_exit: 101,
@@ -1249,7 +1511,13 @@ mod tests {
             &compiler,
             workdir.path(),
             "fn main() -> i32 { 0 }",
-            Duration::from_millis(200),
+            CompileOptions {
+                optimization: OptimizationLevel::O2,
+                previews: &[],
+                std_path: None,
+                compile_timeout: Duration::from_millis(200),
+                runtime_timeout: Duration::from_secs(5),
+            },
         )
         .expect("spawn fake compiler");
 
@@ -1270,6 +1538,125 @@ mod tests {
     }
 
     #[test]
+    fn compiler_timeout_kills_descendants_holding_captured_pipes() {
+        let workdir = create_workdir().expect("temporary workdir");
+        let compiler = fake_compiler(
+            workdir.path(),
+            "#!/bin/sh\n(sh -c 'trap \"\" TERM; sleep 30') &\nsleep 30\n",
+        );
+
+        let start = Instant::now();
+        let result = compile_and_run(
+            &compiler,
+            workdir.path(),
+            "fn main() -> i32 { 0 }",
+            CompileOptions {
+                optimization: OptimizationLevel::O1,
+                previews: &[],
+                std_path: None,
+                compile_timeout: Duration::from_millis(200),
+                runtime_timeout: Duration::from_secs(5),
+            },
+        )
+        .expect("spawn descendant compiler fixture");
+
+        assert!(matches!(result, Compiled::CompileTimeout));
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "process-group kill must close descendant-held pipes before reader joins"
+        );
+    }
+
+    #[test]
+    fn successful_leader_exit_cleans_descendants_without_becoming_a_timeout() {
+        let mut command = Command::new("sh");
+        command.arg("-c").arg("(trap '' TERM; sleep 30) & exit 7");
+        let started = Instant::now();
+        let result = run_with_timeout(command, Duration::from_secs(5))
+            .expect("run successful leader with a pipe-holding descendant");
+
+        assert!(matches!(result, Compiled::Ran { exit: 7, .. }));
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "a successful direct child remains authoritative while its process group is cleaned"
+        );
+    }
+
+    #[test]
+    fn stale_artifact_errors_and_missing_or_non_executable_outputs_fail_closed() {
+        let workdir = create_workdir().expect("temporary workdir");
+        std::fs::create_dir(workdir.path().join("prog")).expect("create stale directory");
+        let compiler = fake_compiler(workdir.path(), "#!/bin/sh\nexit 0\n");
+        let options = || CompileOptions {
+            optimization: OptimizationLevel::O1,
+            previews: &[],
+            std_path: None,
+            compile_timeout: Duration::from_secs(5),
+            runtime_timeout: Duration::from_secs(5),
+        };
+        let error = compile_and_run(
+            &compiler,
+            workdir.path(),
+            "fn main() -> i32 { 0 }",
+            options(),
+        )
+        .expect_err("a stale directory cannot be ignored as a missing artifact");
+        assert_ne!(error.kind(), std::io::ErrorKind::NotFound);
+
+        std::fs::remove_dir(workdir.path().join("prog")).expect("remove stale directory");
+        let error = compile_and_run(
+            &compiler,
+            workdir.path(),
+            "fn main() -> i32 { 0 }",
+            options(),
+        )
+        .expect_err("compiler success without output must fail");
+        assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+
+        let compiler = fake_compiler(
+            workdir.path(),
+            "#!/bin/sh\nprintf 'not executable\\n' > prog\n",
+        );
+        let error = compile_and_run(
+            &compiler,
+            workdir.path(),
+            "fn main() -> i32 { 0 }",
+            options(),
+        )
+        .expect_err("non-executable compiler output must fail");
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn compiler_crashes_and_ices_are_not_compile_rejections() {
+        let workdir = create_workdir().expect("temporary workdir");
+        let options = || CompileOptions {
+            optimization: OptimizationLevel::O1,
+            previews: &[],
+            std_path: None,
+            compile_timeout: Duration::from_secs(5),
+            runtime_timeout: Duration::from_secs(5),
+        };
+        let crashing = fake_compiler(workdir.path(), "#!/bin/sh\nkill -TERM $$\n");
+        let crash = compile_and_run(
+            &crashing,
+            workdir.path(),
+            "fn main() -> i32 { 0 }",
+            options(),
+        )
+        .expect("run crashing compiler");
+        assert!(matches!(crash, Compiled::CompileCrash { signal: 15, .. }));
+
+        let icing = fake_compiler(
+            workdir.path(),
+            "#!/bin/sh\necho 'internal compiler error: planted' 1>&2\nexit 0\n",
+        );
+        let ice = compile_and_run(&icing, workdir.path(), "fn main() -> i32 { 0 }", options())
+            .expect("run ICE compiler");
+        assert!(matches!(ice, Compiled::CompileIce(_)));
+    }
+
+    #[test]
     fn compiler_stderr_is_drained_while_retention_stays_bounded() {
         let workdir = create_workdir().expect("temporary workdir");
         let compiler = fake_compiler(
@@ -1281,12 +1668,18 @@ mod tests {
             &compiler,
             workdir.path(),
             "fn main() -> i32 { 0 }",
-            Duration::from_secs(30),
+            CompileOptions {
+                optimization: OptimizationLevel::O3,
+                previews: &[],
+                std_path: None,
+                compile_timeout: Duration::from_secs(30),
+                runtime_timeout: Duration::from_secs(5),
+            },
         )
         .expect("run fake compiler");
 
         match result {
-            Compiled::CompileFail(stderr) => {
+            Compiled::CompileRejected { exit: 9, stderr } => {
                 assert!(!stderr.is_empty(), "some compiler stderr is retained");
                 assert_eq!(
                     stderr.len(),

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -2,12 +2,11 @@
 //!
 //! Runs the concrete [`rue-cli-tests`] corpus through the [`rue_oracle`]
 //! reference interpreter and checks the oracle agrees with each case's expected
-//! exit code / stdout / stderr. Those expectations are what the *compiled binary*
-//! already produces (the CLI suite enforces that), so a disagreement here means
-//! the oracle and the compiler disagree. The harness first executes the
-//! canonical raw CFG before and after mandatory CFG transformations, then
-//! compares the post-transform O0 oracle with expected/native behavior, separating CFG disagreements
-//! from later lowering/codegen disagreements. This is the automated bug-catcher
+//! exit code / stdout / stderr, then checks the same observation from native
+//! binaries compiled at O1, O2, and O3. The harness first executes the canonical
+//! raw CFG before and after mandatory CFG transformations, then compares the
+//! post-transform O0 oracle with expected/native behavior, separating CFG
+//! disagreements from later lowering/codegen disagreements. This is the automated bug-catcher
 //! of RUE-50: it turns "we check the outputs we thought to write down" into "we
 //! check that the semantics and compiler agree on every program in the corpus."
 //!
@@ -32,7 +31,7 @@
 //!   `crates/rue-spec/cases`.
 //! - **fuzz** (`rue-oracle-diff fuzz [...]`): the differential *fuzzer* of
 //!   RUE-247 — generate random valid programs and cross-check the oracle
-//!   against the real compiler + native binary. See [`fuzz`]. A `dump <seed>`
+//!   against native binaries compiled at O0, O1, O2, and O3. See [`fuzz`]. A `dump <seed>`
 //!   subcommand prints a generated program for inspection.
 //!
 //! Every mode exits non-zero if an eligible program is rejected by the front
@@ -69,10 +68,13 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 #[derive(Deserialize)]
 struct TestFile {
     section: Section,
+    #[serde(default, rename = "timeout_profile")]
+    timeout_profiles: HashMap<String, HangTimeoutProfile>,
     #[serde(default, rename = "case")]
     cases: Vec<Case>,
 }
@@ -82,6 +84,21 @@ struct TestFile {
 #[derive(Deserialize)]
 struct Section {
     id: String,
+    #[serde(default)]
+    contract: Option<String>,
+}
+
+#[derive(Clone, Copy, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HangTimeoutProfile {
+    compile_hang_timeout_ms: u64,
+    runtime_hang_timeout_ms: u64,
+}
+
+#[derive(Clone, Copy)]
+struct CliExecutionTimeouts {
+    compile: Duration,
+    runtime: Duration,
 }
 
 /// A permissive subset of the rue-cli-tests case schema — only the fields the
@@ -90,6 +107,8 @@ struct Section {
 #[derive(Deserialize)]
 struct Case {
     name: String,
+    #[serde(default)]
+    contract: Option<String>,
     #[serde(default)]
     files: Vec<SourceFile>,
     #[serde(default)]
@@ -100,6 +119,10 @@ struct Case {
     stdin: Option<String>,
     #[serde(default)]
     env: HashMap<String, String>,
+    #[serde(default)]
+    program_args: Vec<String>,
+    #[serde(default)]
+    program_env: HashMap<String, String>,
     #[serde(default)]
     compile_fail: bool,
     #[serde(default)]
@@ -168,6 +191,9 @@ enum IneligibleReason {
     WatchOrchestration,
     StandardInput,
     CompilerEnvironment,
+    RuntimeArguments,
+    RuntimeEnvironment,
+    NamedExecutionContract,
     ExternalSourcePath,
     NoInlineSource,
     MultipleSourceFiles,
@@ -191,6 +217,9 @@ impl fmt::Display for IneligibleReason {
             Self::WatchOrchestration => f.write_str("watch orchestration"),
             Self::StandardInput => f.write_str("standard input required"),
             Self::CompilerEnvironment => f.write_str("compiler environment"),
+            Self::RuntimeArguments => f.write_str("runtime command-line arguments"),
+            Self::RuntimeEnvironment => f.write_str("runtime environment"),
+            Self::NamedExecutionContract => f.write_str("named execution contract"),
             Self::ExternalSourcePath => f.write_str("external source path"),
             Self::NoInlineSource => f.write_str("no inline source"),
             Self::MultipleSourceFiles => f.write_str("multiple source files"),
@@ -217,6 +246,88 @@ enum CaseOutcome {
     OracleFailure(String),
     /// The oracle ran but disagreed with the expected behavior.
     Disagreement(String),
+}
+
+/// Shared native-execution state for corpus and spec modes. The work directory
+/// is unique to this harness process and reused sequentially; `compile_and_run`
+/// removes the previous output before every compilation.
+struct NativeRunner {
+    rue: PathBuf,
+    workdir: tempfile::TempDir,
+    std_path: PathBuf,
+    optimizations: Vec<fuzz::OptimizationLevel>,
+}
+
+impl NativeRunner {
+    fn from_env() -> Result<Self, String> {
+        let rue = std::env::var_os("RUE_BINARY")
+            .map(PathBuf::from)
+            .ok_or_else(|| "RUE_BINARY must point to the Rue compiler".to_string())?;
+        let std_path = std::env::var_os("RUE_ORACLE_DIFF_STD")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("std"));
+        let optimizations = match std::env::var("RUE_ORACLE_DIFF_OPT_LEVEL").as_deref() {
+            Ok("O1" | "1") => vec![fuzz::OptimizationLevel::O1],
+            Ok("O2" | "2") => vec![fuzz::OptimizationLevel::O2],
+            Ok("O3" | "3") => vec![fuzz::OptimizationLevel::O3],
+            Ok(value) => {
+                return Err(format!(
+                    "RUE_ORACLE_DIFF_OPT_LEVEL must be O1, O2, or O3, got {value:?}"
+                ));
+            }
+            Err(std::env::VarError::NotPresent) => fuzz::OptimizationLevel::OPTIMIZED.to_vec(),
+            Err(error) => return Err(format!("invalid RUE_ORACLE_DIFF_OPT_LEVEL: {error}")),
+        };
+        let workdir = tempfile::Builder::new()
+            .prefix("rue-oracle-corpus-")
+            .tempdir()
+            .map_err(|error| format!("cannot create native differential work dir: {error}"))?;
+        Ok(Self {
+            rue,
+            workdir,
+            std_path,
+            optimizations,
+        })
+    }
+
+    fn compare(
+        &self,
+        context: &str,
+        source: &str,
+        oracle: &Outcome,
+        previews: &[String],
+        real_std: bool,
+        compile_timeout: Duration,
+        runtime_timeout: Duration,
+    ) -> CaseOutcome {
+        for optimization in &self.optimizations {
+            let compiled = match fuzz::compile_and_run(
+                &self.rue,
+                self.workdir.path(),
+                source,
+                fuzz::CompileOptions {
+                    optimization: *optimization,
+                    previews,
+                    std_path: real_std.then_some(self.std_path.as_path()),
+                    compile_timeout,
+                    runtime_timeout,
+                },
+            ) {
+                Ok(compiled) => compiled,
+                Err(error) => {
+                    return CaseOutcome::OracleFailure(format!(
+                        "{context} [{optimization}]\n      native harness error: {error}"
+                    ));
+                }
+            };
+            if let fuzz::Verdict::Disagree(reason) = fuzz::classify(oracle, &compiled) {
+                return CaseOutcome::Disagreement(format!(
+                    "{context} [{optimization}]\n      optimized native observation: {reason}"
+                ));
+            }
+        }
+        CaseOutcome::Agree
+    }
 }
 
 /// Why an otherwise executable case could not be fully judged.
@@ -403,6 +514,13 @@ fn corpus_mode(raw_args: Vec<String>) -> ExitCode {
     };
 
     let mut report = Report::default();
+    let native = match NativeRunner::from_env() {
+        Ok(native) => Some(native),
+        Err(error) => {
+            report.harness_failures.push(error);
+            None
+        }
+    };
     let mut gap_audit = model_gaps::cli::audit(inventory_scope);
     let (toml_files, discovery_failures) = discover_toml(&dirs);
     let mut inventory_complete = discovery_failures.is_empty();
@@ -414,6 +532,7 @@ fn corpus_mode(raw_args: Vec<String>) -> ExitCode {
         ));
     }
 
+    let mut loaded_files = Vec::new();
     for path in &toml_files {
         let file = match load_cli_test_file(path) {
             Ok(file) => file,
@@ -423,8 +542,29 @@ fn corpus_mode(raw_args: Vec<String>) -> ExitCode {
                 continue;
             }
         };
+        loaded_files.push((path, file));
+    }
+    let execution_timeouts = match cli_execution_timeouts(&loaded_files) {
+        Ok(timeouts) => Some(timeouts),
+        Err(error) => {
+            inventory_complete = false;
+            report.harness_failures.push(error);
+            None
+        }
+    };
+
+    for (path, file) in &loaded_files {
         for case in &file.cases {
-            let outcome = check_case(path, case);
+            let identity = format!("{}::{}", file.section.id, case.name);
+            let outcome = check_case_with_native(
+                path,
+                case,
+                file.section.contract.as_deref(),
+                native
+                    .as_ref()
+                    .zip(execution_timeouts)
+                    .map(|(runner, timeouts)| (runner, identity.as_str(), timeouts)),
+            );
             gap_audit.observe(
                 model_gaps::cli::CaseId::new(&file.section.id, &case.name),
                 &case.only_on,
@@ -439,6 +579,40 @@ fn corpus_mode(raw_args: Vec<String>) -> ExitCode {
     report.harness_failures.sort();
 
     finish_report(&report, "rue-cli-tests")
+}
+
+fn cli_execution_timeouts(files: &[(&PathBuf, TestFile)]) -> Result<CliExecutionTimeouts, String> {
+    let mut profiles = files
+        .iter()
+        .filter_map(|(_, file)| file.timeout_profiles.get("ordinary").copied())
+        .collect::<Vec<_>>();
+    if profiles.is_empty() {
+        // A partial focused run may not include execution_contracts.toml in
+        // its requested roots. Resolve the same declared authority explicitly
+        // instead of falling back to a hard-coded timeout.
+        let path = std::env::var_os("RUE_ORACLE_DIFF_EXECUTION_CONTRACTS")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                PathBuf::from("crates/rue-cli-tests/cases/execution_contracts.toml")
+            });
+        let authority = load_cli_test_file(&path).map_err(|error| {
+            format!("cannot load authoritative CLI execution contracts: {error}")
+        })?;
+        if let Some(profile) = authority.timeout_profiles.get("ordinary") {
+            profiles.push(*profile);
+        }
+    }
+    if profiles.len() != 1 {
+        return Err("CLI corpus must declare timeout_profile.ordinary exactly once".to_string());
+    }
+    let profile = profiles[0];
+    if profile.compile_hang_timeout_ms == 0 || profile.runtime_hang_timeout_ms == 0 {
+        return Err("CLI timeout_profile.ordinary budgets must be non-zero".to_string());
+    }
+    Ok(CliExecutionTimeouts {
+        compile: Duration::from_millis(profile.compile_hang_timeout_ms),
+        runtime: Duration::from_millis(profile.runtime_hang_timeout_ms),
+    })
 }
 
 /// Translate the closed corpus classification into equally closed registry
@@ -567,6 +741,13 @@ fn spec_mode(raw_args: Vec<String>) -> ExitCode {
     };
 
     let mut report = Report::default();
+    let native = match NativeRunner::from_env() {
+        Ok(native) => Some(native),
+        Err(error) => {
+            report.harness_failures.push(error);
+            None
+        }
+    };
     let mut gap_audit = model_gaps::spec::audit(inventory_scope);
     let mut inventory_complete = true;
     for dir in &dirs {
@@ -599,7 +780,12 @@ fn spec_mode(raw_args: Vec<String>) -> ExitCode {
         }
         for (ident, file) in files {
             for case in &file.case {
-                let outcome = check_spec_case(&ident, case);
+                let identity = format!("{}::{}", file.section.id, case.name);
+                let outcome = check_spec_case_with_native(
+                    &ident,
+                    case,
+                    native.as_ref().map(|runner| (runner, identity.as_str())),
+                );
                 gap_audit.observe(
                     model_gaps::spec::CaseId::new(&file.section.id, &case.name),
                     &case.only_on,
@@ -661,11 +847,23 @@ fn spec_model_gap_observation(
 /// compiler/oracle contract violation fails the harness. [`RunSourceError::Compile`]
 /// for a case that survived these shape filters is likewise a hard front-end
 /// failure.
+#[cfg(test)]
 fn check_spec_case(ident: &str, case: &rue_test_runner::Case) -> CaseOutcome {
     let is_known_gap = KNOWN_ORACLE_GAPS
         .iter()
         .any(|(i, n, _)| *i == ident && *n == case.name);
-    check_spec_case_with_known_gap(ident, case, is_known_gap)
+    check_spec_case_with_known_gap(ident, case, is_known_gap, None)
+}
+
+fn check_spec_case_with_native(
+    ident: &str,
+    case: &rue_test_runner::Case,
+    native: Option<(&NativeRunner, &str)>,
+) -> CaseOutcome {
+    let is_known_gap = KNOWN_ORACLE_GAPS
+        .iter()
+        .any(|(i, n, _)| *i == ident && *n == case.name);
+    check_spec_case_with_known_gap(ident, case, is_known_gap, native)
 }
 
 fn run_source_with_real_std(
@@ -782,6 +980,7 @@ fn check_spec_case_with_known_gap(
     ident: &str,
     case: &rue_test_runner::Case,
     is_known_gap: bool,
+    native: Option<(&NativeRunner, &str)>,
 ) -> CaseOutcome {
     // Mirror the real rue-spec wrapper before classifying case shapes. Preview
     // cases without `preview_should_pass` use xfail semantics there, so they do
@@ -950,7 +1149,26 @@ fn check_spec_case_with_known_gap(
             }
 
             if modeled_observations_agree {
-                CaseOutcome::Agree
+                if let Some((runner, identity)) = native {
+                    let previews: Vec<String> = case.preview.iter().cloned().collect();
+                    runner.compare(
+                        &format!("rue-spec {identity}"),
+                        &case.source,
+                        &outcome,
+                        &previews,
+                        case.real_std,
+                        Duration::from_millis(
+                            case.timeout_ms
+                                .unwrap_or(rue_test_runner::DEFAULT_TIMEOUT_MS),
+                        ),
+                        Duration::from_millis(
+                            case.timeout_ms
+                                .unwrap_or(rue_test_runner::DEFAULT_TIMEOUT_MS),
+                        ),
+                    )
+                } else {
+                    CaseOutcome::Agree
+                }
             } else {
                 let mut msg = format!("{ident} :: {}", case.name);
                 if !exit_ok {
@@ -1008,7 +1226,17 @@ const KNOWN_ORACLE_GAPS: &[(&str, &str, &str)] = &[
     // run as normal three-way-agreement checks again.
 ];
 
+#[cfg(test)]
 fn check_case(path: &Path, case: &Case) -> CaseOutcome {
+    check_case_with_native(path, case, None, None)
+}
+
+fn check_case_with_native(
+    path: &Path,
+    case: &Case,
+    section_contract: Option<&str>,
+    native: Option<(&NativeRunner, &str, CliExecutionTimeouts)>,
+) -> CaseOutcome {
     // Mirror the real CLI runner's wrapper order: explicit and host-filtered
     // cases never reach invocation parsing or execution.
     if case.skip {
@@ -1033,6 +1261,9 @@ fn check_case(path: &Path, case: &Case) -> CaseOutcome {
     }
     if known_bug_applies {
         return CaseOutcome::Ineligible(IneligibleReason::ApplicableKnownBug);
+    }
+    if case.contract.as_deref().or(section_contract).is_some() {
+        return CaseOutcome::Ineligible(IneligibleReason::NamedExecutionContract);
     }
     // A watch case is an imperative sequence of filesystem edits and driver
     // publications, not one concrete source execution the in-process oracle
@@ -1114,6 +1345,16 @@ fn check_case(path: &Path, case: &Case) -> CaseOutcome {
             record_oracle_error(&context, error)
         }
         Ok(outcome) => {
+            // Runtime argv/env are external effects the current oracle cannot
+            // inject. Keep typed oracle model gaps authoritative when source
+            // evaluation reaches those intrinsics; otherwise classify the
+            // declared process inputs explicitly before any native execution.
+            if !case.program_args.is_empty() {
+                return CaseOutcome::Ineligible(IneligibleReason::RuntimeArguments);
+            }
+            if !case.program_env.is_empty() {
+                return CaseOutcome::Ineligible(IneligibleReason::RuntimeEnvironment);
+            }
             let trap_comparison = compare_trap_expectation(expected_trap, outcome.panic);
             // A case whose only observable contract is the runtime-error exit
             // code (101) — no `runtime_error_contains` trap declaration — is
@@ -1187,7 +1428,20 @@ fn check_case(path: &Path, case: &Case) -> CaseOutcome {
                 && missing_stderr.is_none()
                 && trap_ok
             {
-                CaseOutcome::Agree
+                if let Some((runner, identity, timeouts)) = native {
+                    let previews = corpus_preview_names(case);
+                    runner.compare(
+                        &format!("rue-cli-tests {identity}"),
+                        source,
+                        &outcome,
+                        &previews,
+                        real_std,
+                        timeouts.compile,
+                        timeouts.runtime,
+                    )
+                } else {
+                    CaseOutcome::Agree
+                }
             } else {
                 let mut msg = format!("{} :: {}", rel(path), case.name);
                 if !exit_ok {
@@ -1304,6 +1558,16 @@ fn corpus_preview_features(case: &Case) -> Result<PreviewFeatures, CliInvocation
     }
 }
 
+fn corpus_preview_names(case: &Case) -> Vec<String> {
+    let Some(args) = &case.args else {
+        return Vec::new();
+    };
+    args.windows(2)
+        .filter(|pair| pair[0] == "--preview")
+        .map(|pair| pair[1].clone())
+        .collect()
+}
+
 fn rel(path: &Path) -> String {
     path.file_name()
         .map(|f| f.to_string_lossy().into_owned())
@@ -1378,6 +1642,7 @@ mod tests {
     fn corpus_case(source: &str, compile_fail: bool) -> Case {
         Case {
             name: "classification probe".to_string(),
+            contract: None,
             files: vec![SourceFile {
                 path: "probe.rue".to_string(),
                 source: source.to_string(),
@@ -1386,6 +1651,8 @@ mod tests {
             args: None,
             stdin: None,
             env: HashMap::new(),
+            program_args: Vec::new(),
+            program_env: HashMap::new(),
             compile_fail,
             compile_only: false,
             watch: None,
@@ -1405,6 +1672,42 @@ mod tests {
             check_case(Path::new("classification.toml"), case),
             CaseOutcome::Ineligible(expected)
         );
+    }
+
+    #[test]
+    fn cli_execution_timeout_mapping_uses_authoritative_corpus_profile() {
+        let path = PathBuf::from("execution_contracts.toml");
+        let file: TestFile = toml::from_str(
+            r#"
+            [section]
+            id = "cli.execution_contracts"
+
+            [timeout_profile.ordinary]
+            compile_hang_timeout_ms = 180000
+            runtime_hang_timeout_ms = 120000
+            "#,
+        )
+        .expect("parse execution contracts fixture");
+        let files = vec![(&path, file)];
+        let timeouts = cli_execution_timeouts(&files).expect("resolve ordinary profile");
+        assert_eq!(timeouts.compile, Duration::from_millis(180_000));
+        assert_eq!(timeouts.runtime, Duration::from_millis(120_000));
+    }
+
+    #[test]
+    fn cli_runtime_inputs_and_named_contracts_are_explicitly_ineligible() {
+        let mut case = corpus_case("fn main() -> i32 { 0 }", false);
+        case.program_args.push("external".to_string());
+        assert_cli_ineligible(&case, IneligibleReason::RuntimeArguments);
+
+        case.program_args.clear();
+        case.program_env
+            .insert("EXTERNAL_MARKER".to_string(), "value".to_string());
+        assert_cli_ineligible(&case, IneligibleReason::RuntimeEnvironment);
+
+        case.program_env.clear();
+        case.contract = Some("heavyweight".to_string());
+        assert_cli_ineligible(&case, IneligibleReason::NamedExecutionContract);
     }
 
     fn assert_spec_ineligible(case: &rue_test_runner::Case, expected: IneligibleReason) {
@@ -1838,17 +2141,17 @@ files = [{ path = "probe.rue", source = "not Rue" }]
         };
 
         assert_eq!(
-            check_spec_case_with_known_gap("test:1", &case, true),
+            check_spec_case_with_known_gap("test:1", &case, true, None),
             CaseOutcome::Ineligible(IneligibleReason::KnownOracleGap)
         );
         assert!(matches!(
-            check_spec_case_with_known_gap("test:1", &case, false),
+            check_spec_case_with_known_gap("test:1", &case, false, None),
             CaseOutcome::Disagreement(_)
         ));
 
         case.exit_code = Some(0);
         let CaseOutcome::Disagreement(message) =
-            check_spec_case_with_known_gap("test:1", &case, true)
+            check_spec_case_with_known_gap("test:1", &case, true, None)
         else {
             panic!("a stale known-gap entry did not fail");
         };
@@ -1858,7 +2161,7 @@ files = [{ path = "probe.rue", source = "not Rue" }]
             "fn probe() -> u32 { let value: u32 = @random_u32(); value } fn main() { probe(); }"
                 .to_string();
         assert_eq!(
-            check_spec_case_with_known_gap("test:1", &case, true),
+            check_spec_case_with_known_gap("test:1", &case, true, None),
             CaseOutcome::Unmodeled(UnmodeledReason::ModelGap(ModelGapKind::ExternalDependency(
                 rue_oracle::ExternalDependencyKind::RandomU32
             ))),
@@ -1867,7 +2170,7 @@ files = [{ path = "probe.rue", source = "not Rue" }]
 
         case.source = "fn main() -> i32 { missing_name }".to_string();
         assert!(matches!(
-            check_spec_case_with_known_gap("test:1", &case, true),
+            check_spec_case_with_known_gap("test:1", &case, true, None),
             CaseOutcome::FrontendFailure(_)
         ));
     }
@@ -2111,18 +2414,18 @@ files = [{ path = "probe.rue", source = "not Rue" }]
         case.runtime_error = None;
         case.exit_code = Some(1);
         assert_eq!(
-            check_spec_case_with_known_gap("test:1", &case, true),
+            check_spec_case_with_known_gap("test:1", &case, true, None),
             CaseOutcome::Ineligible(IneligibleReason::KnownOracleGap)
         );
 
         case.exit_code = Some(0);
         assert_eq!(
-            check_spec_case_with_known_gap("test:1", &case, true),
+            check_spec_case_with_known_gap("test:1", &case, true, None),
             CaseOutcome::Ineligible(IneligibleReason::KnownOracleGap),
             "the remaining stderr mismatch keeps the tracked wrong-result entry live"
         );
         assert!(matches!(
-            check_spec_case_with_known_gap("test:1", &case, false),
+            check_spec_case_with_known_gap("test:1", &case, false, None),
             CaseOutcome::Disagreement(_)
         ));
     }

--- a/crates/rue-oracle-diff/test-planted-miscompile.sh
+++ b/crates/rue-oracle-diff/test-planted-miscompile.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${RUE_ORACLE_DIFF_BINARY:?missing differential harness}"
+: "${RUE_ORACLE_DIFF_FAKE_COMPILER:?missing fake compiler}"
+: "${RUE_ORACLE_DIFF_FAKE_PROGRAM:?missing fake compiled program}"
+
+scratch="$(mktemp -d)"
+cleanup() {
+    rm -rf "$scratch"
+}
+trap cleanup EXIT
+
+set +e
+RUE_BINARY="$RUE_ORACLE_DIFF_FAKE_COMPILER" \
+RUE_ORACLE_DIFF_FAKE_PROGRAM="$RUE_ORACLE_DIFF_FAKE_PROGRAM" \
+RUE_ORACLE_DIFF_OPT_LOG="$scratch/optimizations" \
+RUE_ORACLE_DIFF_TESTING=1 \
+    "$RUE_ORACLE_DIFF_BINARY" fuzz \
+        --start 0 \
+        --seeds 1 \
+        --timeout 5 \
+        --crash-dir "$scratch/crashes" \
+        --test-plant-miscompile O2 >"$scratch/output" 2>&1
+status=$?
+set -e
+
+if [ "$status" -eq 0 ]; then
+    echo "planted miscompile unexpectedly passed"
+    cat "$scratch/output"
+    exit 1
+fi
+
+if [ "$(grep -c 'DISAGREEMENT (seed 0, O2)' "$scratch/output")" -ne 1 ]; then
+    echo "expected exactly one O2 disagreement"
+    cat "$scratch/output"
+    exit 1
+fi
+if grep -E 'DISAGREEMENT \(seed 0, O(0|1|3)\)' "$scratch/output" >/dev/null; then
+    echo "the planted observation mutation escaped its selected lane"
+    cat "$scratch/output"
+    exit 1
+fi
+grep -F 'agreeing lanes:   3' "$scratch/output" >/dev/null
+grep -F 'DISAGREEMENTS:    1' "$scratch/output" >/dev/null
+
+if [ ! -f "$scratch/optimizations" ]; then
+    echo "fake compiler did not record optimization arguments"
+    cat "$scratch/output"
+    exit 1
+fi
+if [ "$(wc -l <"$scratch/optimizations" | tr -d ' ')" -ne 4 ]; then
+    echo "expected exactly four compiler optimization arguments"
+    cat "$scratch/optimizations"
+    exit 1
+fi
+for optimization in -O0 -O1 -O2 -O3; do
+    if [ "$(grep -Fxc -- "$optimization" "$scratch/optimizations")" -ne 1 ]; then
+        echo "expected exactly one compiler invocation with $optimization"
+        cat "$scratch/optimizations"
+        exit 1
+    fi
+done
+if grep -Ev '^-O[0-3]$' "$scratch/optimizations" >/dev/null; then
+    echo "fake compiler received an unsupported optimization argument"
+    cat "$scratch/optimizations"
+    exit 1
+fi

--- a/crates/rue-oracle-diff/testdata/planted-fake-program.sh
+++ b/crates/rue-oracle-diff/testdata/planted-fake-program.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+printf 'x\n1\n'
+exit 1

--- a/crates/rue-oracle-diff/testdata/planted-fake-rue.sh
+++ b/crates/rue-oracle-diff/testdata/planted-fake-rue.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${RUE_ORACLE_DIFF_FAKE_PROGRAM:?missing fake compiled program}"
+: "${RUE_ORACLE_DIFF_OPT_LOG:?missing optimization log}"
+
+output=""
+optimization=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -O0|-O1|-O2|-O3)
+            [ -z "$optimization" ] || exit 2
+            optimization="$1"
+            shift
+            ;;
+        -o)
+            [ "$#" -ge 2 ] || exit 2
+            output="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+[ -n "$output" ] || exit 2
+[ -n "$optimization" ] || exit 2
+printf '%s\n' "$optimization" >>"$RUE_ORACLE_DIFF_OPT_LOG"
+cp "$RUE_ORACLE_DIFF_FAKE_PROGRAM" "$output"
+chmod +x "$output"

--- a/scripts/affected-targets
+++ b/scripts/affected-targets
@@ -86,7 +86,11 @@ SELECTABLE_CORPUS=(
     //:cli-tests-shard-3
     //:spec-tests
     //crates/rue-oracle-diff:oracle-diff-test
+    //crates/rue-oracle-diff:oracle-diff-test-o2
+    //crates/rue-oracle-diff:oracle-diff-test-o3
     //crates/rue-oracle-diff:oracle-diff-spec-test
+    //crates/rue-oracle-diff:oracle-diff-spec-test-o2
+    //crates/rue-oracle-diff:oracle-diff-spec-test-o3
 )
 
 # RUE-1130. The corpus jobs above were the only gated lanes, and measurement

--- a/scripts/fuzz-report-failure.py
+++ b/scripts/fuzz-report-failure.py
@@ -208,7 +208,8 @@ def collect_crashes(crash_dir: Path) -> list[Crash]:
     """Read every reproducer under `crash_dir`, deduplicated by fingerprint.
 
     Both producers are handled: `rue-fuzz` (`crash-<target>-...txt` plus a
-    `.txt.meta` sibling) and `rue-oracle-diff` (`oracle-diff-seed-N.rue`).
+    `.txt.meta` sibling) and `rue-oracle-diff`
+    (`oracle-diff-seed-N[-O<level>].rue`).
     A reproducer whose metadata is missing still reports — with a degraded
     signature — because an unexplained crash file is still a crash.
     """

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -757,7 +757,11 @@ def validate(
         "linux-x64-cli-shard-3",
         "linux-x64-spec",
         "linux-x64-oracle-diff",
+        "linux-x64-oracle-diff-o2",
+        "linux-x64-oracle-diff-o3",
         "linux-x64-oracle-diff-spec",
+        "linux-x64-oracle-diff-spec-o2",
+        "linux-x64-oracle-diff-spec-o3",
     }
     if check_names != expected_checks:
         errors.append(

--- a/scripts/validate-test-duplication.py
+++ b/scripts/validate-test-duplication.py
@@ -230,6 +230,18 @@ NOT_LISTABLE = {
         "harness-owned, making a --list inventory non-authoritative; keeping it "
         "opaque avoids running the corpus merely to classify it."
     ),
+    "//crates/rue-oracle-diff:oracle-diff-test-o2": (
+        "distinct-assertion opaque target: the O2 shard runs the complete modeled CLI "
+        "corpus through the reference interpreter and optimized native compiler. Its "
+        "case inventory is harness-owned, and the separate optimization result is a "
+        "distinct assertion rather than duplicate execution."
+    ),
+    "//crates/rue-oracle-diff:oracle-diff-test-o3": (
+        "distinct-assertion opaque target: the O3 shard runs the complete modeled CLI "
+        "corpus through the reference interpreter and optimized native compiler. Its "
+        "case inventory is harness-owned, and the separate optimization result is a "
+        "distinct assertion rather than duplicate execution."
+    ),
     "//crates/rue-oracle-diff:oracle-diff-spec-test": (
         "distinct-assertion opaque target: the harness drives the specification "
         "corpus through the reference interpreter and compares compiler behavior. "
@@ -237,6 +249,18 @@ NOT_LISTABLE = {
         "coverage, and therefore is not ordinary duplicate accounting. The "
         "harness owns runtime eligibility and argument grammar, so --list would "
         "not provide an authoritative inventory; it remains intentionally opaque."
+    ),
+    "//crates/rue-oracle-diff:oracle-diff-spec-test-o2": (
+        "distinct-assertion opaque target: the O2 shard runs the complete modeled spec "
+        "corpus through the reference interpreter and optimized native compiler. Its "
+        "case inventory is harness-owned, and the separate optimization result is a "
+        "distinct assertion rather than duplicate execution."
+    ),
+    "//crates/rue-oracle-diff:oracle-diff-spec-test-o3": (
+        "distinct-assertion opaque target: the O3 shard runs the complete modeled spec "
+        "corpus through the reference interpreter and optimized native compiler. Its "
+        "case inventory is harness-owned, and the separate optimization result is a "
+        "distinct assertion rather than duplicate execution."
     ),
     "//:spec-traceability": (
         "rue-spec's `--traceability` is a reporting mode, not a filter: handed "


### PR DESCRIPTION
## Summary

- execute eligible oracle corpus and specification programs at O1, O2, and O3 and compare typed native observations
- extend generated differential coverage through O0, O1, O2, and O3 with bounded process execution and deterministic repros
- add cached CI shards and a guarded planted-miscompile proof

## Validation

- complete O1-O3 corpus/spec matrix, generated smoke, and planted proof
- `scripts/rue quick`
- `scripts/rue premerge`
- `scripts/rue test`
- `scripts/rue fmt`
- `git diff --check`

Fixes RUE-1815