### PR TITLE
RUE-1296: show friendly constructor type names in diagnostics

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -3482,3 +3482,237 @@ fn retired_source_owned_sema_plane_cannot_return() {
         "the provider host must construct the shared body engine"
     );
 }
+
+#[test]
+fn sema_diagnostics_use_the_friendly_type_display_authority() {
+    // Diagnostic payloads in the ordinary body engine must go through its
+    // presentation authority. This is the complete production sema inventory
+    // (the same Buck-generated manifest used by the broader inventory test),
+    // split below only to make the presentation boundary auditable. The
+    // non-presentation half is checked for raw captures, so adding a new sema
+    // module cannot silently evade this guard.
+    let all_sema_sources = [
+        (
+            "sema/aggregate_resolution",
+            include_str!("sema/aggregate_resolution.rs"),
+        ),
+        ("sema/aggregates", include_str!("sema/aggregates.rs")),
+        ("sema/analysis", include_str!("sema/analysis.rs")),
+        (
+            "sema/analysis/builtin_ops",
+            include_str!("sema/analysis/builtin_ops.rs"),
+        ),
+        (
+            "sema/analysis/calls",
+            include_str!("sema/analysis/calls.rs"),
+        ),
+        (
+            "sema/analysis/instructions",
+            include_str!("sema/analysis/instructions.rs"),
+        ),
+        (
+            "sema/analysis/intrinsics",
+            include_str!("sema/analysis/intrinsics.rs"),
+        ),
+        (
+            "sema/analysis/ownership",
+            include_str!("sema/analysis/ownership.rs"),
+        ),
+        (
+            "sema/analysis/pointers",
+            include_str!("sema/analysis/pointers.rs"),
+        ),
+        (
+            "sema/analysis/type_inference",
+            include_str!("sema/analysis/type_inference.rs"),
+        ),
+        ("sema/analyze_ops", include_str!("sema/analyze_ops.rs")),
+        ("sema/anon_structs", include_str!("sema/anon_structs.rs")),
+        (
+            "sema/binding_manifest",
+            include_str!("sema/binding_manifest.rs"),
+        ),
+        ("sema/body_endpoint", include_str!("sema/body_endpoint.rs")),
+        ("sema/body_identity", include_str!("sema/body_identity.rs")),
+        (
+            "sema/call_resolution",
+            include_str!("sema/call_resolution.rs"),
+        ),
+        ("sema/comptime", include_str!("sema/comptime.rs")),
+        ("sema/comptime_eval", include_str!("sema/comptime_eval.rs")),
+        ("sema/context", include_str!("sema/context.rs")),
+        ("sema/control_flow", include_str!("sema/control_flow.rs")),
+        (
+            "sema/declaration_index",
+            include_str!("sema/declaration_index.rs"),
+        ),
+        ("sema/declarations", include_str!("sema/declarations.rs")),
+        ("sema/fact_mode", include_str!("sema/fact_mode.rs")),
+        ("sema/inference_ctx", include_str!("sema/inference_ctx.rs")),
+        ("sema/info", include_str!("sema/info.rs")),
+        ("sema/known_symbols", include_str!("sema/known_symbols.rs")),
+        ("sema/mod", include_str!("sema/mod.rs")),
+        (
+            "sema/ordinary_engine",
+            include_str!("sema/ordinary_engine.rs"),
+        ),
+        ("sema/output", include_str!("sema/output.rs")),
+        ("sema/provider", include_str!("sema/provider.rs")),
+        (
+            "sema/provider_body_host",
+            include_str!("sema/provider_body_host.rs"),
+        ),
+        (
+            "sema/provider_module_registry",
+            include_str!("sema/provider_module_registry.rs"),
+        ),
+        (
+            "sema/semantic_body_export",
+            include_str!("sema/semantic_body_export.rs"),
+        ),
+        ("sema/typeck", include_str!("sema/typeck.rs")),
+        ("sema/visibility", include_str!("sema/visibility.rs")),
+    ];
+    let manifest = include_str!("rue_air_source_manifest.txt");
+    let test_only_sema_modules = [
+        "sema/consistency_tests",
+        "sema/provider_accessor_tests",
+        "sema/provider_fixture",
+        "sema/provider_fixture_tests",
+        "sema/provider_semantics_tests",
+        "sema/provider_strings_ownership_tests",
+        "sema/tests",
+    ];
+    let manifest_sema_modules = manifest
+        .lines()
+        .map(|path| path.trim_start_matches("./").trim_end_matches(".rs"))
+        .map(|path| path.trim_start_matches("src/"))
+        .filter(|path| path.starts_with("sema/"))
+        .filter(|path| !test_only_sema_modules.contains(path))
+        .map(str::to_owned)
+        .collect::<BTreeSet<_>>();
+    let inventoried_sema_modules = all_sema_sources
+        .iter()
+        .map(|(module, _)| module.to_string())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        manifest_sema_modules, inventoried_sema_modules,
+        "friendly-display inventory must cover every production sema source in Buck's manifest"
+    );
+    let presentation_modules = [
+        "sema/aggregates",
+        "sema/analysis",
+        "sema/analysis/builtin_ops",
+        "sema/analysis/calls",
+        "sema/analysis/instructions",
+        "sema/analysis/intrinsics",
+        "sema/analysis/ownership",
+        "sema/analysis/pointers",
+        "sema/analysis/type_inference",
+        "sema/analyze_ops",
+        "sema/comptime_eval",
+        "sema/control_flow",
+        "sema/typeck",
+    ];
+    for (module, source) in &all_sema_sources {
+        if presentation_modules.contains(module)
+            || matches!(*module, "sema/provider_body_host" | "sema/ordinary_engine")
+        {
+            continue;
+        }
+        assert!(
+            !source.contains("safe_name_with_pool(") && !source.contains("name_with_pool("),
+            "non-presentation sema module captured a raw type name: {module}"
+        );
+    }
+
+    // Keep the raw pool renderer available only to the authority itself and
+    // provider-owned identity/symbol paths; a new direct capture in one of
+    // the presentation modules is an accidental bypass that would leak
+    // anonymous nominal names again.
+    let presentation_sources = [
+        include_str!("sema/aggregates.rs"),
+        include_str!("sema/analysis.rs"),
+        include_str!("sema/analysis/builtin_ops.rs"),
+        include_str!("sema/analysis/calls.rs"),
+        include_str!("sema/analysis/instructions.rs"),
+        include_str!("sema/analysis/intrinsics.rs"),
+        include_str!("sema/analysis/ownership.rs"),
+        include_str!("sema/analysis/pointers.rs"),
+        include_str!("sema/analysis/type_inference.rs"),
+        include_str!("sema/analyze_ops.rs"),
+        include_str!("sema/comptime_eval.rs"),
+        include_str!("sema/control_flow.rs"),
+        include_str!("sema/typeck.rs"),
+    ]
+    .concat();
+    let mut presentation_code = String::with_capacity(presentation_sources.len());
+    let mut chars = presentation_sources.chars().peekable();
+    let mut in_line_comment = false;
+    let mut block_comment_depth = 0usize;
+    let mut in_string = false;
+    while let Some(ch) = chars.next() {
+        if in_line_comment {
+            if ch == '\n' {
+                in_line_comment = false;
+                presentation_code.push(ch);
+            }
+            continue;
+        }
+        if block_comment_depth > 0 {
+            if ch == '/' && chars.peek() == Some(&'*') {
+                chars.next();
+                block_comment_depth += 1;
+            } else if ch == '*' && chars.peek() == Some(&'/') {
+                chars.next();
+                block_comment_depth -= 1;
+            }
+            continue;
+        }
+        if in_string {
+            if ch == '\\' {
+                chars.next();
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        if ch == '/' && chars.peek() == Some(&'/') {
+            chars.next();
+            in_line_comment = true;
+        } else if ch == '/' && chars.peek() == Some(&'*') {
+            chars.next();
+            block_comment_depth = 1;
+        } else if ch == '"' {
+            in_string = true;
+        } else {
+            presentation_code.push(ch);
+        }
+    }
+    assert!(presentation_code.contains("format_type_name"));
+    assert!(
+        !presentation_code.contains("safe_name_with_pool(")
+            && !presentation_code.contains("name_with_pool("),
+        "a sema diagnostic captured a raw type name"
+    );
+    assert!(!presentation_code.contains("struct_def.name"));
+    assert!(!presentation_code.contains("enum_def.name"));
+    let ordinary = include_str!("sema/ordinary_engine.rs");
+    let provider = include_str!("sema/provider_body_host.rs");
+    assert!(ordinary.contains("self.storage.friendly_type_display(ty)"));
+    assert!(
+        ordinary.contains("fn format_internal_type_name")
+            && ordinary.contains("ty.safe_name_with_pool")
+    );
+    assert!(provider.contains("fn friendly_type_display(&self, ty: Type) -> String"));
+    assert!(provider.contains("ctor_displays.get(&ty)"));
+    assert!(provider.contains("crate::format_canonical_application("));
+    let identity = include_str!("semantic_identity.rs");
+    assert_eq!(
+        identity
+            .matches("pub fn format_canonical_application<")
+            .count(),
+        1,
+        "canonical comptime display interleaving must have one AIR owner"
+    );
+}

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -136,10 +136,11 @@ pub use semantic_body::{
 };
 pub use semantic_identity::{
     AnonymousMemberKey, AnonymousMemberKind, AnonymousNominalKey, AnonymousNominalKind,
-    CanonicalArgumentValue, CanonicalArguments, CompilerCallableId, FunctionInstanceKey,
-    LocalAtomId, LocalAtomKind, LocalAtomRecord, Node, NominalInstanceKey, STABLE_DEFINITION_KINDS,
-    STABLE_DEFINITION_NAMESPACES, SemanticBodyLocalAtom, StableCallableId, StableDefinitionKind,
-    StableDefinitionNamespace, StableProducerId, StableSymbolId, TypeInstanceKey,
+    CanonicalArgumentValue, CanonicalArguments, CanonicalDisplayParameter, CompilerCallableId,
+    FunctionInstanceKey, LocalAtomId, LocalAtomKind, LocalAtomRecord, Node, NominalInstanceKey,
+    STABLE_DEFINITION_KINDS, STABLE_DEFINITION_NAMESPACES, SemanticBodyLocalAtom, StableCallableId,
+    StableDefinitionKind, StableDefinitionNamespace, StableProducerId, StableSymbolId,
+    TypeInstanceKey, format_canonical_application,
 };
 pub use semantic_import::{
     SEMANTIC_IMPORT_CONST_KINDS, SEMANTIC_IMPORT_TYPE_KINDS, SemanticImportConstKind,

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -88,8 +88,6 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     ) -> CompileResult<AnalysisResult> {
         let def = self.body_type_pool().enum_def(enum_id);
         let payload_types = def.variant_payload(variant_index as usize).to_vec();
-        let variant_name = def.variants[variant_index as usize].clone();
-        let enum_name = def.name.clone();
 
         // Visibility check, mirroring the bare-path `EnumVariant` handler
         // (E0460, privacy is uniform across item kinds). A comptime-bound enum
@@ -154,9 +152,6 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         let ty = Type::new_enum(enum_id);
 
-        // Suppress unused-variable warnings for names only used in messages.
-        let _ = (&variant_name, &enum_name);
-
         let air_ref = air.add_enum_variant(enum_id, variant_index, &payload_refs, ty, span)?;
         Ok(AnalysisResult::with_continues(air_ref, ty, continues))
     }
@@ -180,7 +175,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         Err(CompileError::new(
             ErrorKind::TypeMismatch {
                 expected: "integer, bool, string, unit, struct, array, or enum".to_string(),
-                found: ty.safe_name_with_pool(Some(self.body_type_pool())),
+                found: self.format_type_name(ty),
             },
             span,
         ))
@@ -344,9 +339,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
                         expected: "a type".to_string(),
-                        found: head_result
-                            .ty
-                            .safe_name_with_pool(Some(self.body_type_pool())),
+                        found: self.format_type_name(head_result.ty),
                     },
                     span,
                 ));
@@ -357,7 +350,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
                             expected: "struct type".to_string(),
-                            found: reduced_ty.safe_name_with_pool(Some(self.body_type_pool())),
+                            found: self.format_type_name(reduced_ty),
                         },
                         span,
                     ));
@@ -370,9 +363,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
                         expected: "module".to_string(),
-                        found: module_result
-                            .ty
-                            .safe_name_with_pool(Some(self.body_type_pool())),
+                        found: self.format_type_name(module_result.ty),
                     },
                     span,
                 ));
@@ -413,7 +404,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         return Err(CompileError::new(
                             ErrorKind::TypeMismatch {
                                 expected: "struct type".to_string(),
-                                found: ty.safe_name_with_pool(Some(self.body_type_pool())),
+                                found: self.format_type_name(ty),
                             },
                             span,
                         ));
@@ -460,7 +451,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             if !field_index_map.contains_key(init_name.as_str()) {
                 return Err(CompileError::new(
                     ErrorKind::UnknownField {
-                        struct_name: struct_def.name.to_string(),
+                        struct_name: self.format_type_name(struct_type),
                         field_name: init_name.to_string(),
                     },
                     span,
@@ -470,7 +461,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             if !seen_fields.insert(init_name.clone()) {
                 return Err(CompileError::new(
                     ErrorKind::DuplicateField {
-                        struct_name: struct_def.name.to_string(),
+                        struct_name: self.format_type_name(struct_type),
                         field_name: init_name.to_string(),
                     },
                     span,
@@ -488,7 +479,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 .collect();
             return Err(CompileError::new(
                 ErrorKind::MissingFields(Box::new(MissingFieldsError {
-                    struct_name: struct_def.name.to_string(),
+                    struct_name: self.format_type_name(struct_type),
                     missing_fields,
                 })),
                 span,
@@ -520,8 +511,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     return Err(CompileError::new(
                         ErrorKind::LiteralOutOfRange {
                             value: *value,
-                            ty: expected_field_type
-                                .safe_name_with_pool(Some(self.body_type_pool())),
+                            ty: self.format_type_name(expected_field_type),
                         },
                         field_inst.span,
                     ));
@@ -580,11 +570,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             if !self.types_compatible(field_result.ty, expected_field_type) {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
-                        expected: expected_field_type
-                            .safe_name_with_pool(Some(self.body_type_pool())),
-                        found: field_result
-                            .ty
-                            .safe_name_with_pool(Some(self.body_type_pool())),
+                        expected: self.format_type_name(expected_field_type),
+                        found: self.format_type_name(field_result.ty),
                     },
                     field_span,
                 )
@@ -592,7 +579,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     format!(
                         "field '{}' expects type {}",
                         init_name,
-                        expected_field_type.safe_name_with_pool(Some(self.body_type_pool()))
+                        self.format_type_name(expected_field_type)
                     ),
                     field_span,
                 ));
@@ -857,7 +844,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
                     expected: "a runtime value".to_string(),
-                    found: elem_ty.safe_name_with_pool(Some(self.body_type_pool())),
+                    found: self.format_type_name(elem_ty),
                 },
                 span,
             ));
@@ -945,7 +932,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let variant_name = self.body_interner().resolve(&method);
             let variant_index = enum_def.find_variant(variant_name).ok_or_compile_error(
                 ErrorKind::UnknownVariant {
-                    enum_name: enum_def.name.to_string(),
+                    enum_name: self.format_type_name(Type::new_enum(enum_id)),
                     variant_name: variant_name.to_string(),
                 },
                 span,
@@ -1046,7 +1033,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let variant_name = self.body_interner().resolve(&variant);
         let variant_index = enum_def.find_variant(variant_name).ok_or_compile_error(
             ErrorKind::UnknownVariant {
-                enum_name: enum_def.name.to_string(),
+                enum_name: self.format_type_name(Type::new_enum(enum_id)),
                 variant_name: variant_name.to_string(),
             },
             span,
@@ -1099,7 +1086,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let variant_name = self.body_interner().resolve(&variant);
         let variant_index = enum_def.find_variant(variant_name).ok_or_compile_error(
             ErrorKind::UnknownVariant {
-                enum_name: enum_def.name.to_string(),
+                enum_name: self.format_type_name(Type::new_enum(enum_id)),
                 variant_name: variant_name.to_string(),
             },
             span,
@@ -1182,7 +1169,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 return Err(CompileError::new(
                     ErrorKind::InternalError(format!(
                         "Array literal inferred as non-array type: {}",
-                        array_type.safe_name_with_pool(Some(self.body_type_pool()))
+                        self.format_internal_type_name(array_type)
                     )),
                     span,
                 ));
@@ -1276,7 +1263,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 return Err(CompileError::new(
                     ErrorKind::InternalError(format!(
                         "Array-repeat literal inferred as non-array type: {}",
-                        array_type.safe_name_with_pool(Some(self.body_type_pool()))
+                        self.format_internal_type_name(array_type)
                     )),
                     span,
                 ));
@@ -1295,7 +1282,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if !self.is_type_copy(elem_type) {
             return Err(CompileError::new(
                 ErrorKind::ArrayRepeatNonCopy {
-                    element_type: elem_type.safe_name_with_pool(Some(self.body_type_pool())),
+                    element_type: self.format_type_name(elem_type),
                 },
                 span,
             ));
@@ -1434,7 +1421,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 let variant_name = self.body_interner().resolve(&*variant);
                 let variant_index = enum_def.find_variant(variant_name).ok_or_compile_error(
                     ErrorKind::UnknownVariant {
-                        enum_name: enum_def.name.to_string(),
+                        enum_name: self.format_type_name(Type::new_enum(enum_id)),
                         variant_name: variant_name.to_string(),
                     },
                     inst.span,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -376,8 +376,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     ) -> CompileError {
         CompileError::new(
             ErrorKind::TypeMismatch {
-                expected: expected.safe_name_with_pool(Some(self.body_type_pool())),
-                found: found.safe_name_with_pool(Some(self.body_type_pool())),
+                expected: self.format_type_name(expected),
+                found: self.format_type_name(found),
             },
             span,
         )

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -84,7 +84,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
                         expected: "StrBuf".to_string(),
-                        found: operand.ty.safe_name_with_pool(Some(self.body_type_pool())),
+                        found: self.format_type_name(operand.ty),
                     },
                     span,
                 ));
@@ -200,9 +200,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
                     expected: "text".to_string(),
-                    found: arg_result
-                        .ty
-                        .safe_name_with_pool(Some(self.body_type_pool())),
+                    found: self.format_type_name(arg_result.ty),
                 },
                 self.body_rir_ref().get(arg_value).span,
             )
@@ -323,9 +321,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
                     expected: "integer type".to_string(),
-                    found: lhs_result
-                        .ty
-                        .safe_name_with_pool(Some(self.body_type_pool())),
+                    found: self.format_type_name(lhs_result.ty),
                 },
                 span,
             ));
@@ -426,7 +422,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
                     expected: "integer".to_string(),
-                    found: lhs_type.safe_name_with_pool(Some(self.body_type_pool())),
+                    found: self.format_type_name(lhs_type),
                 },
                 self.body_rir_ref().get(lhs).span,
             ));

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -716,8 +716,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 if !self.types_compatible(found, expected) && !expected.is_error() {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
-                            expected: expected.safe_name_with_pool(Some(self.body_type_pool())),
-                            found: found.safe_name_with_pool(Some(self.body_type_pool())),
+                            expected: self.format_type_name(expected),
+                            found: self.format_type_name(found),
                         },
                         self.body_rir_ref().get(args.get(i).unwrap().value).span,
                     ));
@@ -1015,7 +1015,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     }
                     return Err(CompileError::new(
                         ErrorKind::UndefinedAssocFn {
-                            type_name: reduced_ty.safe_name_with_pool(Some(self.body_type_pool())),
+                            type_name: self.format_type_name(reduced_ty),
                             function_name: variant_name,
                         },
                         span,
@@ -1042,7 +1042,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             _ => {
                 return Err(CompileError::new(
                     ErrorKind::MethodCallOnNonStruct {
-                        found: receiver_type.safe_name_with_pool(Some(self.body_type_pool())),
+                        found: self.format_type_name(receiver_type),
                         method_name: method_name_str,
                     },
                     span,
@@ -1051,8 +1051,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         };
 
         // Look up the struct name by its ID (for error messages)
-        let struct_def = self.body_type_pool().struct_def(struct_id);
-        let struct_name_str = struct_def.name.to_string();
+        let struct_name_str = self.format_type_name(Type::new_struct(struct_id));
 
         // Look up the method using StructId directly
         let method_key = (struct_id, method);
@@ -1546,7 +1545,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
                             expected: "struct type".to_string(),
-                            found: ty.safe_name_with_pool(Some(self.body_type_pool())),
+                            found: self.format_type_name(ty),
                         },
                         span,
                     ));
@@ -1568,7 +1567,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
                             expected: "struct type".to_string(),
-                            found: ty.safe_name_with_pool(Some(self.body_type_pool())),
+                            found: self.format_type_name(ty),
                         },
                         span,
                     ));

--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -282,7 +282,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                                 Err(CompileError::new(
                                     ErrorKind::LiteralOutOfRange {
                                         value: value as u64,
-                                        ty: ty.safe_name_with_pool(Some(self.body_type_pool())),
+                                        ty: self.format_type_name(ty),
                                     },
                                     inst.span,
                                 ))
@@ -292,7 +292,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                                         reason: format!(
                                             "value {} is out of range for type {}",
                                             value,
-                                            ty.safe_name_with_pool(Some(self.body_type_pool()))
+                                            self.format_type_name(ty)
                                         ),
                                     },
                                     inst.span,

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -228,7 +228,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             None => {
                 return Err(CompileError::new(
                     ErrorKind::UnknownField {
-                        struct_name: struct_def.name.to_string(),
+                        struct_name: self.format_type_name(Type::new_struct(struct_id)),
                         field_name: field_name_str.to_string(),
                     },
                     span,
@@ -583,7 +583,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ErrorKind::IntrinsicTypeMismatch(Box::new(rue_error::IntrinsicTypeMismatchError {
                     name: "place".to_owned(),
                     expected: "a raw pointer".to_owned(),
-                    found: operand.ty.name().to_owned(),
+                    found: self.format_type_name(operand.ty),
                 })),
                 span,
             ));
@@ -739,7 +739,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         Err(CompileError::new(
             ErrorKind::TypeMismatch {
                 expected: "an array or a StrBuf".to_string(),
-                found: coll_type.safe_name_with_pool(Some(self.body_type_pool())),
+                found: self.format_type_name(coll_type),
             },
             span,
         )
@@ -772,9 +772,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
                     expected: "StrBuf".to_string(),
-                    found: coll_result
-                        .ty
-                        .safe_name_with_pool(Some(self.body_type_pool())),
+                    found: self.format_type_name(coll_result.ty),
                 },
                 span,
             )
@@ -916,7 +914,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: "dbg".to_string(),
                     expected: "integer, bool, or String".to_string(),
-                    found: arg_type.safe_name_with_pool(Some(self.body_type_pool())),
+                    found: self.format_type_name(arg_type),
                 })),
                 span,
             ));
@@ -1211,9 +1209,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: "assert".to_string(),
                     expected: "bool condition".to_string(),
-                    found: cond_result
-                        .ty
-                        .safe_name_with_pool(Some(self.body_type_pool())),
+                    found: self.format_type_name(cond_result.ty),
                 })),
                 cond_span,
             ));
@@ -1293,7 +1289,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: intrinsic_name.to_string(),
                     expected: "text message".to_string(),
-                    found: message_ty.safe_name_with_pool(Some(self.body_type_pool())),
+                    found: self.format_type_name(message_ty),
                 })),
                 message_span,
             ));
@@ -1335,7 +1331,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: intrinsic_name.to_string(),
                     expected: "integer".to_string(),
-                    found: from_ty.safe_name_with_pool(Some(self.body_type_pool())),
+                    found: self.format_type_name(from_ty),
                 })),
                 span,
             ));
@@ -1360,7 +1356,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                         name: intrinsic_name.to_string(),
                         expected: "integer".to_string(),
-                        found: ty.safe_name_with_pool(Some(self.body_type_pool())),
+                        found: self.format_type_name(ty),
                     })),
                     span,
                 ));
@@ -1428,7 +1424,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: intrinsic_name.to_string(),
                     expected: "integer".to_string(),
-                    found: from_ty.safe_name_with_pool(Some(self.body_type_pool())),
+                    found: self.format_type_name(from_ty),
                 })),
                 span,
             ));
@@ -1451,7 +1447,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                         name: intrinsic_name.to_string(),
                         expected: "integer".to_string(),
-                        found: ty.safe_name_with_pool(Some(self.body_type_pool())),
+                        found: self.format_type_name(ty),
                     })),
                     span,
                 ));
@@ -1465,8 +1461,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if from_bits != to_bits {
             return Err(CompileError::new(
                 ErrorKind::BitCastWidthMismatch {
-                    from: from_ty.safe_name_with_pool(Some(self.body_type_pool())),
-                    to: target_ty.safe_name_with_pool(Some(self.body_type_pool())),
+                    from: self.format_type_name(from_ty),
+                    to: self.format_type_name(target_ty),
                     from_bits,
                     to_bits,
                 },
@@ -1588,7 +1584,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: intrinsic_display.to_string(),
                     expected: format!("Option({payload_display})"),
-                    found: ty.safe_name_with_pool(Some(self.body_type_pool())),
+                    found: self.format_type_name(ty),
                 })),
                 span,
             ));
@@ -1688,7 +1684,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: "@to_string".to_string(),
                     expected: "integer".to_string(),
-                    found: arg_type.safe_name_with_pool(Some(self.body_type_pool())),
+                    found: self.format_type_name(arg_type),
                 })),
                 span,
             ));
@@ -1779,7 +1775,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: format!("@{}", intrinsic_name_str),
                     expected: "text".to_string(),
-                    found: arg_type.safe_name_with_pool(Some(self.body_type_pool())),
+                    found: self.format_type_name(arg_type),
                 })),
                 span,
             ));
@@ -2015,7 +2011,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                 name: format!("@{display}"),
                 expected: "u64".to_string(),
-                found: found.safe_name_with_pool(Some(self.body_type_pool())),
+                found: self.format_type_name(found),
             })),
             span,
         ))
@@ -2067,7 +2063,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                         name: format!("@{display}"),
                         expected: "integer".to_string(),
-                        found: ty.safe_name_with_pool(Some(self.body_type_pool())),
+                        found: self.format_type_name(ty),
                     })),
                     self.body_rir_ref().get(arg.value).span,
                 ));

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -1099,8 +1099,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                             return Err(CompileError::new(
                                 ErrorKind::TypeMismatch {
                                     expected: "integer type".to_string(),
-                                    found: index_type
-                                        .safe_name_with_pool(Some(self.body_type_pool())),
+                                    found: self.format_type_name(index_type),
                                 },
                                 self.body_rir_ref().get(*index).span,
                             ));
@@ -1418,7 +1417,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if !byref_consumer && self.type_has_drop_glue(ty) {
             return Err(CompileError::new(
                 ErrorKind::AccessorResultMoved {
-                    ty: ty.safe_name_with_pool(Some(self.body_type_pool())),
+                    ty: self.format_type_name(ty),
                 },
                 span,
             )
@@ -2285,7 +2284,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 "consider making parameter `{}` inout: `inout {}: {}`",
                 name_str,
                 name_str,
-                ty.safe_name_with_pool(Some(self.body_type_pool()))
+                self.format_type_name(ty)
             ))
         }
     }
@@ -2402,10 +2401,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
-                            expected: param_ty.safe_name_with_pool(Some(self.body_type_pool())),
-                            found: value_result
-                                .ty
-                                .safe_name_with_pool(Some(self.body_type_pool())),
+                            expected: self.format_type_name(param_ty),
+                            found: self.format_type_name(value_result.ty),
                         },
                         self.body_rir_ref().get(value).span,
                     ));
@@ -2655,20 +2652,16 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let container_type = marker_depth
             .checked_sub(1)
             .map_or(trace.base_type, |i| trace.projections[i].result_type);
-        let container_struct_id = container_type.as_struct().ok_or_else(|| {
-            CompileError::new(
+        if container_type.as_struct().is_none() {
+            return Err(CompileError::new(
                 ErrorKind::InternalError(
                     "declared-linear destructure container is not a struct".to_string(),
                 ),
                 span,
-            )
-        })?;
+            ));
+        }
         let accessed = trace.projections[marker_depth].field_name;
-        let root_name = self
-            .body_type_pool()
-            .struct_def(container_struct_id)
-            .name
-            .to_string();
+        let root_name = self.format_type_name(container_type);
         let mut drops = Vec::new();
         self.emit_declared_linear_residue_drops_at(
             air,
@@ -2765,9 +2758,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 let Some(selected_index) = selected.const_index else {
                     return Err(CompileError::new(
                         ErrorKind::MoveOutOfIndex {
-                            element_type: selected
-                                .result_type
-                                .safe_name_with_pool(Some(self.body_type_pool())),
+                            element_type: self.format_type_name(selected.result_type),
                         },
                         span,
                     )
@@ -2963,10 +2954,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         field_name: String,
         span: Span,
     ) -> CompileError {
-        let struct_def = self.body_type_pool().struct_def(struct_id);
         let mut err = CompileError::new(
             ErrorKind::MoveFieldOutOfDestructorType {
-                struct_name: struct_def.name.to_string(),
+                struct_name: self.format_type_name(Type::new_struct(struct_id)),
                 field_name: field_name.clone(),
             },
             span,
@@ -2976,14 +2966,17 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             "the destructor for '{}' runs on the whole value when it is dropped: it \
              would observe the moved-out field, and the automatic field cleanup after \
              the destructor would drop `{field_name}` a second time",
-            struct_def.name
+            self.format_type_name(Type::new_struct(struct_id))
         ))
         .with_help(format!(
             "borrow the field instead (`borrow value.{field_name}`), or move the whole value"
         ));
         if let Some(drop_span) = self.destructor_span(struct_id).as_ref() {
             err = err.with_label(
-                format!("destructor for '{}' is defined here", struct_def.name),
+                format!(
+                    "destructor for '{}' is defined here",
+                    self.format_type_name(Type::new_struct(struct_id))
+                ),
                 *drop_span,
             );
         }
@@ -3151,7 +3144,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             {
                 return Err(CompileError::new(
                     ErrorKind::MoveOutOfIndex {
-                        element_type: field_type.safe_name_with_pool(Some(self.body_type_pool())),
+                        element_type: self.format_type_name(field_type),
                     },
                     span,
                 )
@@ -3253,8 +3246,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 if trace.has_untrackable_index() {
                     return Err(CompileError::new(
                         ErrorKind::MoveOutOfIndex {
-                            element_type: field_type
-                                .safe_name_with_pool(Some(self.body_type_pool())),
+                            element_type: self.format_type_name(field_type),
                         },
                         span,
                     )
@@ -3445,7 +3437,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             None => {
                 return Err(CompileError::new(
                     ErrorKind::FieldAccessOnNonStruct {
-                        found: base_type.safe_name_with_pool(Some(self.body_type_pool())),
+                        found: self.format_type_name(base_type),
                     },
                     span,
                 ));
@@ -3457,7 +3449,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let Some((field_index, struct_field)) = struct_def.find_field(field_name) else {
             return Err(CompileError::new(
                 ErrorKind::UnknownField {
-                    struct_name: struct_def.name.to_string(),
+                    struct_name: self.format_type_name(Type::new_struct(struct_id)),
                     field_name: field_name.to_string(),
                 },
                 span,
@@ -3664,7 +3656,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     // This shouldn't happen if try_trace_place worked correctly
                     return Err(CompileError::new(
                         ErrorKind::IndexOnNonArray {
-                            found: parent_type.safe_name_with_pool(Some(self.body_type_pool())),
+                            found: self.format_type_name(parent_type),
                         },
                         span,
                     ));
@@ -3712,7 +3704,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             {
                 return Err(CompileError::new(
                     ErrorKind::MoveOutOfIndex {
-                        element_type: elem_type.safe_name_with_pool(Some(self.body_type_pool())),
+                        element_type: self.format_type_name(elem_type),
                     },
                     span,
                 )
@@ -3809,8 +3801,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 if element_move.is_none() {
                     return Err(CompileError::new(
                         ErrorKind::MoveOutOfIndex {
-                            element_type: elem_type
-                                .safe_name_with_pool(Some(self.body_type_pool())),
+                            element_type: self.format_type_name(elem_type),
                         },
                         span,
                     )
@@ -3986,7 +3977,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             None => {
                 return Err(CompileError::new(
                     ErrorKind::IndexOnNonArray {
-                        found: base_type.safe_name_with_pool(Some(self.body_type_pool())),
+                        found: self.format_type_name(base_type),
                     },
                     span,
                 ));
@@ -4002,7 +3993,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
                     expected: "integer type".to_string(),
-                    found: index_type.safe_name_with_pool(Some(self.body_type_pool())),
+                    found: self.format_type_name(index_type),
                 },
                 self.body_rir_ref().get(index).span,
             ));
@@ -4027,7 +4018,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if !self.is_type_copy(elem_type) {
             return Err(CompileError::new(
                 ErrorKind::MoveOutOfIndex {
-                    element_type: elem_type.safe_name_with_pool(Some(self.body_type_pool())),
+                    element_type: self.format_type_name(elem_type),
                 },
                 span,
             )
@@ -4128,9 +4119,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
                     expected: "an integer".to_string(),
-                    found: index_result
-                        .ty
-                        .safe_name_with_pool(Some(self.body_type_pool())),
+                    found: self.format_type_name(index_result.ty),
                 },
                 self.body_rir_ref().get(index).span,
             ));
@@ -4240,9 +4229,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
                     expected: "an integer".to_string(),
-                    found: index_result
-                        .ty
-                        .safe_name_with_pool(Some(self.body_type_pool())),
+                    found: self.format_type_name(index_result.ty),
                 },
                 self.body_rir_ref().get(index).span,
             ));
@@ -4332,9 +4319,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
                     expected: "an integer".to_string(),
-                    found: index_result
-                        .ty
-                        .safe_name_with_pool(Some(self.body_type_pool())),
+                    found: self.format_type_name(index_result.ty),
                 },
                 self.body_rir_ref().get(index).span,
             ));
@@ -4520,11 +4505,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         Err(CompileError::new(
             ErrorKind::UndefinedMethod {
                 method_name: method_name.to_string(),
-                type_name: self
-                    .body_type_pool()
-                    .struct_def(slice_struct_id)
-                    .name
-                    .to_string(),
+                type_name: self.format_type_name(Type::new_struct(slice_struct_id)),
             },
             span,
         ))
@@ -4714,7 +4695,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 None => {
                     return Err(CompileError::new(
                         ErrorKind::FieldAccessOnNonStruct {
-                            found: base_type.safe_name_with_pool(Some(self.body_type_pool())),
+                            found: self.format_type_name(base_type),
                         },
                         span,
                     ));
@@ -4726,7 +4707,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let Some((field_index, struct_field)) = struct_def.find_field(field_name) else {
                 return Err(CompileError::new(
                     ErrorKind::UnknownField {
-                        struct_name: struct_def.name.to_string(),
+                        struct_name: self.format_type_name(Type::new_struct(struct_id)),
                         field_name: field_name.to_string(),
                     },
                     span,
@@ -4913,7 +4894,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 None => {
                     return Err(CompileError::new(
                         ErrorKind::IndexOnNonArray {
-                            found: base_type.safe_name_with_pool(Some(self.body_type_pool())),
+                            found: self.format_type_name(base_type),
                         },
                         span,
                     ));
@@ -4934,9 +4915,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
                         expected: "integer type".to_string(),
-                        found: index_result
-                            .ty
-                            .safe_name_with_pool(Some(self.body_type_pool())),
+                        found: self.format_type_name(index_result.ty),
                     },
                     self.body_rir_ref().get(index).span,
                 ));
@@ -5705,7 +5684,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if !self.type_requires_consumption(dest_ty) || discharged {
             return Ok(());
         }
-        let type_name = dest_ty.safe_name_with_pool(Some(self.body_type_pool()));
+        let type_name = self.format_type_name(dest_ty);
         let err = if through_inout {
             CompileError::new(
                 ErrorKind::LinearValueOverwrittenThroughInout { type_name },
@@ -5805,7 +5784,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
         let err = CompileError::new(
             ErrorKind::LinearValueDiscarded {
-                type_name: ty.safe_name_with_pool(Some(self.body_type_pool())),
+                type_name: self.format_type_name(ty),
             },
             self.body_rir_ref().get(inst_ref).span,
         )
@@ -5835,7 +5814,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         match self.infectious_linear_reason(struct_id).as_ref() {
             Some((field_name, field_type)) => err.with_note(format!(
                 "'{}' is linear because field '{}' of type '{}' carries a linear value",
-                self.body_type_pool().struct_def(struct_id).name,
+                self.format_type_name(Type::new_struct(struct_id)),
                 field_name,
                 field_type
             )),
@@ -6430,7 +6409,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if trace.via_accessor {
             return Err(CompileError::new(
                 ErrorKind::AccessorResultMoved {
-                    ty: moved_type.safe_name_with_pool(Some(self.body_type_pool())),
+                    ty: self.format_type_name(moved_type),
                 },
                 span,
             ));
@@ -6626,7 +6605,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         ctx: &AnalysisContext,
     ) -> CompileResult<()> {
         if self.is_strbuf(found) || self.is_str_fixed_struct(found) {
-            let found_name = found.safe_name_with_pool(Some(self.body_type_pool()));
+            let found_name = self.format_type_name(found);
             let mut err = CompileError::new(
                 ErrorKind::BufferNotFirstClassStr {
                     found: found_name,

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -809,34 +809,34 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let error_kind = match &err.kind {
                 UnifyResult::Ok => unreachable!("UnificationError should never contain Ok"),
                 UnifyResult::TypeMismatch { expected, found } => ErrorKind::TypeMismatch {
-                    expected: expected.name_with_pool(self.body_type_pool()),
-                    found: found.name_with_pool(self.body_type_pool()),
+                    expected: self.format_infer_type_name(expected),
+                    found: self.format_infer_type_name(found),
                 },
                 UnifyResult::IntLiteralNonInteger { found } => ErrorKind::TypeMismatch {
                     expected: "integer type".to_string(),
-                    found: found.safe_name_with_pool(Some(self.body_type_pool())),
+                    found: self.format_type_name(*found),
                 },
                 UnifyResult::StringLiteralNonString { found } => ErrorKind::TypeMismatch {
                     expected: "string type".to_string(),
-                    found: found.name_with_pool(self.body_type_pool()),
+                    found: self.format_infer_type_name(found),
                 },
                 UnifyResult::OccursCheck { var, ty } => ErrorKind::TypeMismatch {
                     expected: "non-recursive type".to_string(),
                     found: format!(
                         "{var} = {} (infinite type)",
-                        ty.name_with_pool(self.body_type_pool())
+                        self.format_infer_type_name(ty)
                     ),
                 },
                 UnifyResult::NotSigned { ty } => {
-                    ErrorKind::CannotNegate(ty.safe_name_with_pool(Some(self.body_type_pool())))
+                    ErrorKind::CannotNegate(self.format_type_name(*ty))
                 }
                 UnifyResult::NotInteger { ty } => ErrorKind::TypeMismatch {
                     expected: "integer type".to_string(),
-                    found: ty.safe_name_with_pool(Some(self.body_type_pool())),
+                    found: self.format_type_name(*ty),
                 },
                 UnifyResult::NotUnsigned { ty } => ErrorKind::TypeMismatch {
                     expected: "unsigned integer type".to_string(),
-                    found: ty.safe_name_with_pool(Some(self.body_type_pool())),
+                    found: self.format_type_name(*ty),
                 },
                 UnifyResult::ArrayLengthMismatch { expected, found } => {
                     ErrorKind::ArrayLengthMismatch {
@@ -1525,7 +1525,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 _ => {
                     return Err(CompileError::new(
                         ErrorKind::FieldAccessOnNonStruct {
-                            found: base_type.safe_name_with_pool(Some(self.body_type_pool())),
+                            found: self.format_type_name(base_type),
                         },
                         field_span,
                     ));
@@ -1537,7 +1537,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let Some((field_index, struct_field)) = struct_def.find_field(field_name) else {
                 return Err(CompileError::new(
                     ErrorKind::UnknownField {
-                        struct_name: struct_def.name.to_string(),
+                        struct_name: self.format_type_name(Type::new_struct(struct_id)),
                         field_name: field_name.to_string(),
                     },
                     field_span,
@@ -1621,7 +1621,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 _ => {
                     return Err(CompileError::new(
                         ErrorKind::IndexOnNonArray {
-                            found: base_type.safe_name_with_pool(Some(self.body_type_pool())),
+                            found: self.format_type_name(base_type),
                         },
                         inst.span,
                     ));
@@ -1643,7 +1643,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
                         expected: "integer type".to_string(),
-                        found: index_type.safe_name_with_pool(Some(self.body_type_pool())),
+                        found: self.format_type_name(index_type),
                     },
                     self.body_rir_ref().get(*index).span,
                 ));

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -61,7 +61,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     return Err(CompileError::new(
                         ErrorKind::LiteralOutOfRange {
                             value: *value,
-                            ty: ty.safe_name_with_pool(Some(self.body_type_pool())),
+                            ty: self.format_type_name(ty),
                         },
                         inst.span,
                     ));
@@ -192,9 +192,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         "unary `-` requires a signed integer operand (i8, i16, i32, i64, isize)"
                     };
                     return Err(CompileError::new(
-                        ErrorKind::CannotNegate(
-                            ty.safe_name_with_pool(Some(self.body_type_pool())),
-                        ),
+                        ErrorKind::CannotNegate(self.format_type_name(ty)),
                         inst.span,
                     )
                     .with_note(note));
@@ -270,7 +268,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
                             expected: "integer type".to_string(),
-                            found: ty.safe_name_with_pool(Some(self.body_type_pool())),
+                            found: self.format_type_name(ty),
                         },
                         inst.span,
                     ));

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -173,12 +173,12 @@ impl ComptimeType for Type {}
 
 pub(super) fn validate_comptime_value_for_type_impl(
     interner: &lasso::ThreadedRodeo,
-    type_pool: &crate::intern_pool::TypeInternPool,
     function_name: Spur,
     param_name: Spur,
     value: ConstValue,
     expected: Type,
     span: Span,
+    friendly_type_display: impl Fn(Type) -> String,
 ) -> CompileResult<()> {
     if matches!(value, ConstValue::Function(_)) {
         return Err(CompileError::new(
@@ -205,7 +205,7 @@ pub(super) fn validate_comptime_value_for_type_impl(
                     interner.resolve(&param_name),
                     interner.resolve(&function_name),
                     integer,
-                    expected.safe_name_with_pool(Some(type_pool))
+                    friendly_type_display(expected)
                 ),
             },
             span,
@@ -215,8 +215,8 @@ pub(super) fn validate_comptime_value_for_type_impl(
     if found != expected {
         return Err(CompileError::new(
             ErrorKind::TypeMismatch {
-                expected: expected.safe_name_with_pool(Some(type_pool)),
-                found: found.safe_name_with_pool(Some(type_pool)),
+                expected: friendly_type_display(expected),
+                found: friendly_type_display(found),
             },
             span,
         )
@@ -541,7 +541,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             Some(ty) => match result.checked() {
                 Some(v) => Ok(Some(ConstValue::Integer(v))),
                 _ => {
-                    let ty_name = ty.safe_name_with_pool(Some(self.body_type_pool()));
+                    let ty_name = self.format_type_name(ty);
                     let detail = match result.raw() {
                         Some(v) => format!("the result {} does not fit in {}", v, ty_name),
                         None => format!("the result does not fit in {}", ty_name),
@@ -1129,12 +1129,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     ) -> CompileResult<()> {
         validate_comptime_value_for_type_impl(
             self.body_interner(),
-            self.body_type_pool(),
             function_name,
             param_name,
             value,
             expected,
             span,
+            |ty| self.format_type_name(ty),
         )
     }
 
@@ -1269,7 +1269,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// the host's constructor-display registry). Named types keep their
     /// declared names;
     /// a partial substitution records nothing rather than a wrong spelling.
-    fn record_ctor_type_display(
+    pub(crate) fn record_ctor_type_display(
         &mut self,
         ctor: Spur,
         ty: Type,
@@ -2282,7 +2282,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeHost for OrdinaryBodyEngine<'h, H>
         OrdinaryBodyEngine::const_expr_type(self, env, inst_ref)
     }
     fn type_name(&self, ty: &Type) -> String {
-        ty.safe_name_with_pool(Some(self.body_type_pool()))
+        self.format_type_name(*ty)
     }
     fn type_is_unsigned(&self, ty: &Type) -> bool {
         ty.is_unsigned()

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -250,7 +250,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         return Err(CompileError::new(
                             ErrorKind::TypeMismatch {
                                 expected: "()".to_string(),
-                                found: result.ty.safe_name_with_pool(Some(self.body_type_pool())),
+                                found: self.format_type_name(result.ty),
                             },
                             self.body_rir_ref().get(block).span,
                         )
@@ -387,17 +387,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     {
                         return Err(CompileError::new(
                             ErrorKind::TypeMismatch {
-                                expected: then_type
-                                    .safe_name_with_pool(Some(self.body_type_pool())),
-                                found: else_type.safe_name_with_pool(Some(self.body_type_pool())),
+                                expected: self.format_type_name(then_type),
+                                found: self.format_type_name(else_type),
                             },
                             else_span,
                         )
                         .with_label(
-                            format!(
-                                "this is of type `{}`",
-                                then_type.safe_name_with_pool(Some(self.body_type_pool()))
-                            ),
+                            format!("this is of type `{}`", self.format_type_name(then_type)),
                             then_span,
                         )
                         .with_note("if and else branches must have compatible types"));
@@ -453,7 +449,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
                         expected: "()".to_string(),
-                        found: then_type.safe_name_with_pool(Some(self.body_type_pool())),
+                        found: self.format_type_name(then_type),
                     },
                     self.body_rir_ref().get(then_block).span,
                 )
@@ -832,7 +828,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         scrutinee_type: Type,
         span: Span,
     ) -> CompileResult<i64> {
-        let ty_name = scrutinee_type.safe_name_with_pool(Some(self.body_type_pool()));
+        let ty_name = self.format_type_name(scrutinee_type);
         if negative {
             if scrutinee_type.is_unsigned() {
                 return Err(
@@ -1102,8 +1098,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         RirPattern::Int { .. } => {
                             return Err(CompileError::new(
                                 ErrorKind::TypeMismatch {
-                                    expected: scrutinee_type
-                                        .safe_name_with_pool(Some(self.body_type_pool())),
+                                    expected: self.format_type_name(scrutinee_type),
                                     found: "integer".to_string(),
                                 },
                                 pattern.span(),
@@ -1112,8 +1107,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         RirPattern::Bool(_, _) if scrutinee_type != Type::BOOL => {
                             return Err(CompileError::new(
                                 ErrorKind::TypeMismatch {
-                                    expected: scrutinee_type
-                                        .safe_name_with_pool(Some(self.body_type_pool())),
+                                    expected: self.format_type_name(scrutinee_type),
                                     found: "bool".to_string(),
                                 },
                                 pattern.span(),
@@ -1188,9 +1182,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if !scrutinee_type.is_integer() && scrutinee_type != Type::BOOL && !scrutinee_type.is_enum()
         {
             return Err(CompileError::new(
-                ErrorKind::InvalidMatchType(
-                    scrutinee_type.safe_name_with_pool(Some(self.body_type_pool())),
-                ),
+                ErrorKind::InvalidMatchType(self.format_type_name(scrutinee_type)),
                 span,
             ));
         }
@@ -1323,8 +1315,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     if !scrutinee_type.is_integer() {
                         return Err(CompileError::new(
                             ErrorKind::TypeMismatch {
-                                expected: scrutinee_type
-                                    .safe_name_with_pool(Some(self.body_type_pool())),
+                                expected: self.format_type_name(scrutinee_type),
                                 found: "integer".to_string(),
                             },
                             pattern_span,
@@ -1364,8 +1355,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     if scrutinee_type != Type::BOOL {
                         return Err(CompileError::new(
                             ErrorKind::TypeMismatch {
-                                expected: scrutinee_type
-                                    .safe_name_with_pool(Some(self.body_type_pool())),
+                                expected: self.format_type_name(scrutinee_type),
                                 found: "bool".to_string(),
                             },
                             pattern_span,
@@ -1434,9 +1424,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     if !self.types_equivalent(scrutinee_type, Type::new_enum(enum_id)) {
                         return Err(CompileError::new(
                             ErrorKind::TypeMismatch {
-                                expected: scrutinee_type
-                                    .safe_name_with_pool(Some(self.body_type_pool())),
-                                found: enum_def.name.to_string(),
+                                expected: self.format_type_name(scrutinee_type),
+                                found: self.format_type_name(Type::new_enum(enum_id)),
                             },
                             pattern_span,
                         ));
@@ -1446,7 +1435,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     let variant_name = self.body_interner().resolve(&*variant);
                     let variant_index = enum_def.find_variant(variant_name).ok_or_compile_error(
                         ErrorKind::UnknownVariant {
-                            enum_name: enum_def.name.to_string(),
+                            enum_name: self.format_type_name(Type::new_enum(enum_id)),
                             variant_name: variant_name.to_string(),
                         },
                         pattern_span,
@@ -1838,7 +1827,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let non_option = |sema: &Self| {
             CompileError::new(
                 ErrorKind::QuestionOnNonOption {
-                    found: operand_ty.safe_name_with_pool(Some(sema.body_type_pool())),
+                    found: sema.format_type_name(operand_ty),
                 },
                 span,
             )
@@ -1880,8 +1869,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     None => {
                         return Err(CompileError::new(
                             ErrorKind::QuestionOutsideOptionFn {
-                                return_type: return_type
-                                    .safe_name_with_pool(Some(self.body_type_pool())),
+                                return_type: self.format_type_name(return_type),
                             },
                             span,
                         ));
@@ -1926,8 +1914,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     None => {
                         return Err(CompileError::new(
                             ErrorKind::QuestionOutsideResultFn {
-                                return_type: return_type
-                                    .safe_name_with_pool(Some(self.body_type_pool())),
+                                return_type: self.format_type_name(return_type),
                             },
                             span,
                         ));
@@ -1936,8 +1923,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 if !self.types_equivalent(err_ty, ret_err_ty) {
                     return Err(CompileError::new(
                         ErrorKind::QuestionErrTypeMismatch {
-                            operand_err: err_ty.safe_name_with_pool(Some(self.body_type_pool())),
-                            fn_err: ret_err_ty.safe_name_with_pool(Some(self.body_type_pool())),
+                            operand_err: self.format_type_name(err_ty),
+                            fn_err: self.format_type_name(ret_err_ty),
                         },
                         span,
                     ));
@@ -2163,12 +2150,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let variant_name = self.body_interner().resolve(&*variant).to_string();
         let variant_index = def.find_variant(&variant_name).ok_or_compile_error(
             ErrorKind::UnknownVariant {
-                enum_name: def.name.to_string(),
+                enum_name: self.format_type_name(Type::new_enum(enum_id)),
                 variant_name: variant_name.clone(),
             },
             pattern_span,
         )? as u32;
-        let enum_name = def.name.to_string();
+        let enum_name = self.format_type_name(Type::new_enum(enum_id));
         let payload = def.variant_payload(variant_index as usize).to_vec();
 
         // The bare-path carve-out (spec 4.7:30, RUE-1592): a payload-carrying
@@ -2251,7 +2238,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 let err = CompileError::new(
                     ErrorKind::LinearPayloadDiscarded {
                         position,
-                        type_name: field_ty.safe_name_with_pool(Some(self.body_type_pool())),
+                        type_name: self.format_type_name(field_ty),
                     },
                     pattern_span,
                 )
@@ -2365,10 +2352,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             if !ctx.return_type.is_error() && !self.types_compatible(pointee, ctx.return_type) {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
-                        expected: ctx
-                            .return_type
-                            .safe_name_with_pool(Some(self.body_type_pool())),
-                        found: pointee.safe_name_with_pool(Some(self.body_type_pool())),
+                        expected: self.format_type_name(ctx.return_type),
+                        found: self.format_type_name(pointee),
                     },
                     span,
                 ));
@@ -2408,10 +2393,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         {
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
-                    expected: ctx
-                        .return_type
-                        .safe_name_with_pool(Some(self.body_type_pool())),
-                    found: read.ty.safe_name_with_pool(Some(self.body_type_pool())),
+                    expected: self.format_type_name(ctx.return_type),
+                    found: self.format_type_name(read.ty),
                 },
                 span,
             ));
@@ -2543,10 +2526,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
-                        expected: ctx
-                            .return_type
-                            .safe_name_with_pool(Some(self.body_type_pool())),
-                        found: inner_ty.safe_name_with_pool(Some(self.body_type_pool())),
+                        expected: self.format_type_name(ctx.return_type),
+                        found: self.format_type_name(inner_ty),
                     },
                     span,
                 ));
@@ -2557,9 +2538,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             if ctx.return_type != Type::UNIT && !ctx.return_type.is_error() {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
-                        expected: ctx
-                            .return_type
-                            .safe_name_with_pool(Some(self.body_type_pool())),
+                        expected: self.format_type_name(ctx.return_type),
                         found: "()".to_string(),
                     },
                     span,

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -318,6 +318,7 @@ pub(crate) trait OrdinaryBodyAnalysisHost: BodyAnalysisReadHost + Sized {
     fn known_drop_glue_during_binding(&self, ty: Type) -> Option<bool>;
     fn has_ctor_type_display(&self, ty: Type) -> bool;
     fn record_body_ctor_type_display(&mut self, ty: Type, display: String);
+    fn friendly_type_display(&self, ty: Type) -> String;
     fn trusted_try_producer(&self, ty: Type) -> Option<super::anon_structs::TrustedTryProducer>;
     fn resolve_canonical_import(
         &self,
@@ -510,6 +511,28 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         self.storage.require_preview(feature, what, span)
     }
     pub(crate) fn format_type_name(&self, ty: Type) -> String {
+        self.storage.friendly_type_display(ty)
+    }
+
+    /// Render an inference type through the same presentation authority as
+    /// concrete body types. Inference arrays and variables are structural
+    /// syntax, but concrete leaves can be anonymous nominals whose friendly
+    /// identity is owned by the provider.
+    pub(crate) fn format_infer_type_name(&self, ty: &InferType) -> String {
+        match ty {
+            InferType::Concrete(ty) => self.format_type_name(*ty),
+            InferType::Var(id) => id.to_string(),
+            InferType::IntLiteral => "{integer}".to_string(),
+            InferType::Array { element, length } => {
+                format!("[{}; {length}]", self.format_infer_type_name(element))
+            }
+        }
+    }
+
+    /// Render a type for an internal invariant message. These messages are
+    /// deliberately excluded from the user-facing display authority: their
+    /// raw nominal spelling helps identify an impossible compiler state.
+    pub(crate) fn format_internal_type_name(&self, ty: Type) -> String {
         ty.safe_name_with_pool(Some(self.body_type_pool()))
     }
     pub(crate) fn comptime_type_param_flags(&self, function: &FunctionCallInfo) -> Vec<bool> {

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -4005,7 +4005,18 @@ where
             }
             crate::SemanticComptimeCallResult::Value(value) => value,
         };
-        Ok(self.materialize_durable_const_value(&value))
+        let materialized = self.materialize_durable_const_value(&value);
+        if let Some(ConstValue::Type(ty)) = materialized.as_ref() {
+            let type_arguments = type_arguments.iter().copied().collect();
+            let value_arguments = value_arguments.iter().copied().collect();
+            OrdinaryBodyEngine::new(self).record_ctor_type_display(
+                head.key,
+                *ty,
+                &type_arguments,
+                &value_arguments,
+            );
+        }
+        Ok(materialized)
     }
 
     fn type_syntax_value_const(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
@@ -4073,6 +4084,139 @@ where
     K: Clone + Eq + Hash + Ord,
     M: Clone + Eq + Hash + Ord,
 {
+    /// Reconstruct a constructor display from the durable producer identity.
+    /// The request-local cache is only an accelerator: imported signatures and
+    /// warm query results may materialize a type without evaluating the call
+    /// in this body, so presentation must remain available from the durable
+    /// anonymous key itself.
+    fn friendly_durable_type_display(&self, ty: &TypeInstanceKey<K, M>) -> Option<String> {
+        use crate::NominalInstanceKey as N;
+        use crate::TypeInstanceKey as T;
+        Some(match ty {
+            T::I8 => "i8".into(),
+            T::I16 => "i16".into(),
+            T::I32 => "i32".into(),
+            T::I64 => "i64".into(),
+            T::U8 => "u8".into(),
+            T::U16 => "u16".into(),
+            T::U32 => "u32".into(),
+            T::U64 => "u64".into(),
+            T::Bool => "bool".into(),
+            T::Unit => "()".into(),
+            T::Never => "!".into(),
+            T::ComptimeType => "type".into(),
+            T::BuiltinNominal { name, .. } => name.to_string(),
+            T::Nominal(N::Builtin { name, .. }) => name.to_string(),
+            T::Nominal(N::Named(key)) => self.source.definition_name(key)?.to_string(),
+            T::Nominal(N::Anonymous(identity)) => {
+                self.friendly_durable_anonymous_display(identity)?
+            }
+            T::Array { element, len } => {
+                format!("[{}; {len}]", self.friendly_durable_type_display(element)?)
+            }
+            T::Slice { element, name } => {
+                let _ = element;
+                name.to_string()
+            }
+            T::PtrConst(element) => {
+                format!("ptr const {}", self.friendly_durable_type_display(element)?)
+            }
+            T::PtrMut(element) => {
+                format!("ptr mut {}", self.friendly_durable_type_display(element)?)
+            }
+            T::Module(module) => self.source.module_path(module),
+            T::GenericParameter(index) => format!("T{index}"),
+        })
+    }
+
+    fn friendly_durable_anonymous_display(
+        &self,
+        identity: &crate::AnonymousNominalKey<K, M>,
+    ) -> Option<String> {
+        let crate::StableProducerId::Function(function) = &identity.producer else {
+            return match &identity.producer {
+                crate::StableProducerId::Definition(definition) => self
+                    .source
+                    .definition_name(definition)
+                    .map(|name| name.to_string()),
+                crate::StableProducerId::Function(_) => None,
+            };
+        };
+        let definition = match function.as_ref() {
+            crate::FunctionInstanceKey::Definition(definition) => definition,
+            crate::FunctionInstanceKey::Specialization { base, .. } => {
+                fn base_definition<K, M>(
+                    function: &crate::FunctionInstanceKey<K, M>,
+                ) -> Option<&K> {
+                    match function {
+                        crate::FunctionInstanceKey::Definition(definition) => Some(definition),
+                        crate::FunctionInstanceKey::Specialization { base, .. } => {
+                            base_definition(base)
+                        }
+                        crate::FunctionInstanceKey::AnonymousMember { .. }
+                        | crate::FunctionInstanceKey::DropGlue(_) => None,
+                    }
+                }
+                base_definition(base)?
+            }
+            crate::FunctionInstanceKey::AnonymousMember { .. }
+            | crate::FunctionInstanceKey::DropGlue(_) => return None,
+        };
+        let name = self.source.definition_name(definition)?;
+        let signature = self.source.function(definition)?;
+        let parameters =
+            signature
+                .parameters
+                .iter()
+                .map(|parameter| crate::CanonicalDisplayParameter {
+                    is_comptime: parameter.is_comptime,
+                    is_type: matches!(parameter.ty, crate::SemanticImportType::ComptimeType),
+                });
+        crate::format_canonical_application(
+            &name,
+            parameters,
+            identity.producer_arguments(),
+            |ty| self.friendly_durable_type_display(ty),
+        )
+    }
+
+    fn friendly_type_display(&self, ty: Type) -> String {
+        if matches!(ty.kind(), TypeKind::Struct(id) if self.type_pool.is_anonymous_struct(id))
+            || matches!(ty.kind(), TypeKind::Enum(id) if self.type_pool.is_anonymous_enum(id))
+        {
+            if let Some(identity) = self.endpoint.durable_anonymous_identity(ty)
+                && let Some(display) = self.friendly_durable_anonymous_display(&identity)
+            {
+                return display;
+            }
+        }
+        // A request-local entry is only an accelerator. For anonymous types,
+        // the durable producer identity above is the portable authority; in
+        // particular it prevents an imported callable's identity spelling
+        // (`path$Wrap`) from escaping into a body diagnostic.
+        if let Some(display) = self.ctor_displays.get(&ty) {
+            return display.clone();
+        }
+        match ty.try_kind() {
+            Some(TypeKind::Array(id)) => self
+                .type_pool
+                .try_array_def(id)
+                .map(|(element, length)| {
+                    format!("[{}; {}]", self.friendly_type_display(element), length)
+                })
+                .unwrap_or_else(|| ty.safe_name_with_pool(Some(&self.type_pool))),
+            Some(TypeKind::PtrConst(id)) => format!(
+                "ptr const {}",
+                self.friendly_type_display(self.type_pool.ptr_const_def(id))
+            ),
+            Some(TypeKind::PtrMut(id)) => format!(
+                "ptr mut {}",
+                self.friendly_type_display(self.type_pool.ptr_mut_def(id))
+            ),
+            _ => ty.safe_name_with_pool(Some(&self.type_pool)),
+        }
+    }
+
     /// Apply the 6.6:3-6.6:5 accessor declaration rules to a free function
     /// whose body this host is about to analyze. Predeclaration already ran
     /// them over every declaration in the program; repeating them at the body
@@ -4740,6 +4884,14 @@ where
                 self.materialize_durable_const_value(&value)
             }
         };
+        if let Some(ConstValue::Type(ty)) = value.as_ref() {
+            OrdinaryBodyEngine::new(self).record_ctor_type_display(
+                name,
+                *ty,
+                callee_types,
+                callee_values,
+            );
+        }
         // A durable result this request cannot materialize is the same kind of
         // representation gap as `NotReduced`, so a value self call keeps its
         // local fallback there too.
@@ -4890,12 +5042,7 @@ where
             .fields
             .iter()
             .find(|field| self.type_pool.type_carries_linear(field.ty))
-            .map(|field| {
-                (
-                    field.name.clone(),
-                    field.ty.safe_name_with_pool(Some(&self.type_pool)),
-                )
-            })
+            .map(|field| (field.name.clone(), self.friendly_type_display(field.ty)))
     }
     fn well_known_option(&self, payload: Type) -> Option<Type> {
         self.endpoint.well_known_option_for_payload(payload)
@@ -4966,6 +5113,10 @@ where
     fn record_body_ctor_type_display(&mut self, ty: Type, display: String) {
         self.ctor_displays.insert(ty, display);
     }
+    fn friendly_type_display(&self, ty: Type) -> String {
+        Self::friendly_type_display(self, ty)
+    }
+
     fn trusted_try_producer(&self, ty: Type) -> Option<super::anon_structs::TrustedTryProducer> {
         match self
             .endpoint

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -1037,7 +1037,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             Some(slots) => Ok(slots as u32),
             None => Err(CompileError::new(
                 ErrorKind::TypeTooLarge {
-                    type_name: ty.safe_name_with_pool(Some(self.body_type_pool())),
+                    type_name: self.format_type_name(ty),
                     max_slots: MAX_TYPE_SLOTS,
                 },
                 span,

--- a/crates/rue-air/src/semantic_identity.rs
+++ b/crates/rue-air/src/semantic_identity.rs
@@ -293,6 +293,66 @@ pub struct CanonicalArguments<D, M> {
     pub values: Arc<[CanonicalArgumentValue<D, M>]>,
 }
 
+/// The declaration-relative shape of one parameter used while presenting a
+/// canonical comptime application. Identity keeps type and value arguments in
+/// separate streams; this tiny schema projection is the shared presentation
+/// authority that interleaves them without changing that identity contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CanonicalDisplayParameter {
+    pub is_comptime: bool,
+    pub is_type: bool,
+}
+
+/// Render a canonical comptime application against its declaration schema.
+///
+/// [`CanonicalArguments`] deliberately stores two streams for compact,
+/// identity-stable keys. Every presentation consumer must use this function
+/// rather than inventing an ordering rule. Exhaustion is validated in both
+/// directions so malformed durable facts never become plausible diagnostics.
+pub fn format_canonical_application<D, M, I, F>(
+    name: &str,
+    parameters: I,
+    arguments: Option<&CanonicalArguments<D, M>>,
+    mut display_type: F,
+) -> Option<String>
+where
+    I: IntoIterator<Item = CanonicalDisplayParameter>,
+    F: FnMut(&TypeInstanceKey<D, M>) -> Option<String>,
+{
+    let Some(arguments) = arguments else {
+        return Some(name.to_owned());
+    };
+
+    let mut types = arguments.types.iter();
+    let mut values = arguments.values.iter();
+    let mut rendered = Vec::new();
+    for parameter in parameters
+        .into_iter()
+        .filter(|parameter| parameter.is_comptime)
+    {
+        if parameter.is_type {
+            rendered.push(display_type(types.next()?)?);
+        } else {
+            rendered.push(match values.next()? {
+                CanonicalArgumentValue::Integer(value) => value.to_string(),
+                CanonicalArgumentValue::Bool(value) => value.to_string(),
+                CanonicalArgumentValue::Type(value) => display_type(value.as_ref())?,
+                CanonicalArgumentValue::Function(_) => "function".to_owned(),
+                CanonicalArgumentValue::Unit => "()".to_owned(),
+                CanonicalArgumentValue::String(value) => format!("\"{value}\""),
+            });
+        }
+    }
+    if types.next().is_some() || values.next().is_some() {
+        return None;
+    }
+    if rendered.is_empty() {
+        Some(name.to_owned())
+    } else {
+        Some(format!("{name}({})", rendered.join(", ")))
+    }
+}
+
 // The two streams deliberately avoid storing a redundant tag per element.
 // Their mixed positional order is reconstructed only against the base
 // function's durable parameter schema (`parameter_comptime` plus the
@@ -857,5 +917,46 @@ mod tests {
             2
         );
         assert_eq!(AHashSet::from([baseline, same, moved]).len(), 2);
+    }
+
+    #[test]
+    fn canonical_application_display_interleaves_type_values_and_unit() {
+        type T = TypeInstanceKey<&'static str, &'static str>;
+        let arguments = CanonicalArguments {
+            types: Arc::from([T::I32]),
+            values: Arc::from([
+                CanonicalArgumentValue::Integer(7),
+                CanonicalArgumentValue::Unit,
+            ]),
+        };
+        let parameters = [
+            CanonicalDisplayParameter {
+                is_comptime: true,
+                is_type: false,
+            },
+            CanonicalDisplayParameter {
+                is_comptime: true,
+                is_type: true,
+            },
+            CanonicalDisplayParameter {
+                is_comptime: true,
+                is_type: false,
+            },
+        ];
+        assert_eq!(
+            format_canonical_application("Mixed", parameters, Some(&arguments), |ty| match ty {
+                T::I32 => Some("i32".to_owned()),
+                _ => None,
+            }),
+            Some("Mixed(7, i32, ())".to_owned())
+        );
+        let empty_arguments: CanonicalArguments<&'static str, &'static str> =
+            CanonicalArguments::default();
+        assert!(
+            format_canonical_application("Mixed", parameters, Some(&empty_arguments), |_| Some(
+                "unused".to_owned()
+            ),)
+            .is_none()
+        );
     }
 }

--- a/crates/rue-cli-tests/cases/friendly_type_diagnostics.toml
+++ b/crates/rue-cli-tests/cases/friendly_type_diagnostics.toml
@@ -1,0 +1,86 @@
+[section]
+id = "cli.friendly_type_diagnostics"
+name = "Friendly anonymous constructor diagnostics"
+description = "Production CLI coverage for durable anonymous-type presentation across query, import, mixed-argument, identity, and JSON paths."
+
+[[case]]
+name = "body_local_nested_enum_deferred_gate"
+description = "A body-local nested enum reaches the deferred E0499 query with its producer spelling intact."
+files = [{ path = "main.rue", source = """
+linear struct Token { v: i32 }
+fn Wrap(comptime T: type) -> type { enum { Some(T), None } }
+fn Gated(comptime T: type) -> type {
+    @require_droppable(T);
+    struct { item: T }
+}
+fn main() -> i32 {
+    let W = Wrap(Token);
+    let G = Gated(W);
+    let _ = G;
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0499", "Wrap(Token)"]
+compile_stderr_not_contains = ["__anon_"]
+
+[[case]]
+name = "mixed_type_value_unit_arguments_preserve_declaration_order"
+description = "A value/type/value constructor keeps declaration order and retains the unit argument in E0499."
+files = [{ path = "main.rue", source = """
+linear struct Token { v: i32 }
+fn Mixed(comptime n: i32, comptime T: type, comptime marker: ()) -> type {
+    @require_droppable(T);
+    struct { item: T }
+}
+const M = Mixed(7, Token, ());
+fn main() -> i32 { let _ = M; 0 }
+""" }]
+compile_fail = true
+error_contains = ["E0499", "Mixed(7, Token, ())"]
+compile_stderr_not_contains = ["__anon_"]
+
+[[case]]
+name = "imported_same_named_constructors_do_not_cross_contaminate"
+description = "Imported constructors with the same name and shape retain identity-specific source arguments rather than path$Ctor or anonymous symbols."
+files = [
+  { path = "main.rue", source = """
+linear struct Token { v: i32 }
+const left = @import("left.rue");
+const right = @import("right.rue");
+fn use_left(value: left.Wrap(Token)) -> i32 { value.missing(); 0 }
+fn use_right(value: right.Wrap(i64)) -> i32 { value.missing(); 0 }
+fn main() -> i32 {
+    use_left(left.Wrap(Token) { item: Token { v: 0 } });
+    use_right(right.Wrap(i64) { item: 0 });
+    0
+}
+""" },
+  { path = "left.rue", source = """
+pub fn Wrap(comptime T: type) -> type { struct { item: T } }
+""" },
+  { path = "right.rue", source = """
+pub fn Wrap(comptime T: type) -> type { struct { item: T } }
+""" },
+]
+compile_fail = true
+error_contains = ["E0411", "Wrap(Token)", "Wrap(i64)", "no method named 'missing'"]
+compile_stderr_not_contains = ["__anon_", "$Wrap"]
+
+[[case]]
+name = "json_method_diagnostic_keeps_friendly_type"
+description = "The JSON diagnostic surface carries the same friendly E0413 message as text rendering."
+files = [{ path = "main.rue", source = """
+linear struct Token { v: i32 }
+fn Wrap(comptime T: type) -> type { enum { Some(T), None } }
+fn use(value: Wrap(Token)) -> i32 { value.missing(); 0 }
+fn main() -> i32 {
+    use(Wrap(Token).Some(Token { v: 0 }));
+    0
+}
+""" }]
+args = ["--error-format", "json", "main.rue", "-o", "prog"]
+compile_fail = true
+json_diagnostics = true
+error_contains = ["\"code\":\"E0413\"", "Wrap(Token)", "no method named 'missing'"]
+compile_stderr_not_contains = ["__anon_"]

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -3546,3 +3546,18 @@ fn import_resolution_remains_discovery_owned() {
         );
     }
 }
+
+#[test]
+fn durable_constructor_diagnostics_use_the_air_interleaver() {
+    let durable = include_str!("durable_comptime.rs");
+    let presenter = durable
+        .split_once("pub(crate) fn durable_type_diagnostic_name_with_parameters")
+        .and_then(|(_, rest)| rest.split_once("pub(crate) fn inferred_durable_const_type_name"))
+        .map(|(body, _)| body)
+        .expect("durable constructor presenter remains an explicit production function");
+    assert!(presenter.contains("rue_air::format_canonical_application("));
+    assert!(!presenter.contains("let mut types ="));
+    assert!(!presenter.contains("let mut values ="));
+    assert!(!presenter.contains("values.next()"));
+    assert!(!presenter.contains("types.next()"));
+}

--- a/crates/rue-compiler/src/durable_comptime.rs
+++ b/crates/rue-compiler/src/durable_comptime.rs
@@ -2685,6 +2685,64 @@ pub(crate) fn durable_type_diagnostic_name(ty: &DurableType) -> String {
     DurableComptimeScalarPolicy::type_name(ty)
 }
 
+/// Render an anonymous producer with the declaration-relative comptime
+/// parameter schema. `CanonicalArguments` intentionally stores type and value
+/// streams separately for identity; the callable schema is the only authority
+/// that can safely interleave those streams for presentation.
+pub(crate) fn durable_type_diagnostic_name_with_parameters(
+    ty: &DurableType,
+    parameters: &[crate::durable_semantics::DurableSemanticParameter],
+) -> String {
+    let DurableType::AnonymousNominal(identity) = ty else {
+        return durable_type_diagnostic_name(ty);
+    };
+    let crate::StableProducerId::Function(function) = &identity.producer else {
+        return durable_type_diagnostic_name(ty);
+    };
+    let definition = match function.as_ref() {
+        crate::FunctionInstanceKey::Definition(definition) => Some(definition),
+        crate::FunctionInstanceKey::Specialization { base, .. } => {
+            fn base_definition(
+                function: &crate::FunctionInstanceKey,
+            ) -> Option<&crate::StableDefinitionKey> {
+                match function {
+                    crate::FunctionInstanceKey::Definition(definition) => Some(definition),
+                    crate::FunctionInstanceKey::Specialization { base, .. } => {
+                        base_definition(base)
+                    }
+                    crate::FunctionInstanceKey::AnonymousMember { .. }
+                    | crate::FunctionInstanceKey::DropGlue(_) => None,
+                }
+            }
+            base_definition(base)
+        }
+        crate::FunctionInstanceKey::AnonymousMember { .. }
+        | crate::FunctionInstanceKey::DropGlue(_) => None,
+    };
+    let Some(definition) = definition else {
+        return durable_type_diagnostic_name(ty);
+    };
+    let parameters = parameters
+        .iter()
+        .map(|parameter| rue_air::CanonicalDisplayParameter {
+            is_comptime: parameter.is_comptime,
+            is_type: matches!(
+                parameter.ty,
+                crate::durable_semantics::DurableType::ComptimeType
+            ),
+        });
+    rue_air::format_canonical_application(
+        definition.name(),
+        parameters,
+        identity.producer_arguments(),
+        |argument| {
+            durable_type_from_instance_key(argument)
+                .map(|argument| durable_type_diagnostic_name(&argument))
+        },
+    )
+    .unwrap_or_else(|| durable_type_diagnostic_name(ty))
+}
+
 pub(crate) fn inferred_durable_const_type_name(value: &DurableConstValue) -> &'static str {
     match value {
         DurableConstValue::Integer(value) if i32::try_from(*value).is_ok() => "i32",

--- a/crates/rue-compiler/src/producer_nominal_acceptance_tests.rs
+++ b/crates/rue-compiler/src/producer_nominal_acceptance_tests.rs
@@ -851,6 +851,40 @@ fn warm_rooted_cfg(
     session.rooted_cfg(options)
 }
 
+#[test]
+fn friendly_anonymous_method_diagnostic_is_warm_fresh_parity_safe() {
+    let source = r#"
+linear struct Token { v: i32 }
+fn Wrap(comptime T: type) -> type { enum { Some(T), None } }
+fn use(value: Wrap(Token)) -> i32 { value.missing(); 0 }
+fn main() -> i32 {
+    use(Wrap(Token).Some(Token { v: 0 }));
+    0
+}
+"#;
+    let prior = "fn main() -> i32 { 0 }";
+    let options = CompileOptions::default();
+    let fresh = fresh_rooted_cfg(source, &options)
+        .expect_err("the focused method diagnostic must fail in a fresh session")
+        .to_string();
+    let warm = warm_rooted_cfg(prior, source, &options)
+        .expect_err("the focused method diagnostic must fail in a warm session")
+        .to_string();
+    assert_eq!(fresh, warm, "warm and fresh diagnostics diverged");
+    assert!(
+        fresh.contains("no method named 'missing'"),
+        "expected method diagnostic: {fresh}"
+    );
+    assert!(
+        fresh.contains("Wrap(Token)"),
+        "lost constructor display: {fresh}"
+    );
+    assert!(
+        !fresh.contains("__anon_"),
+        "raw anonymous name leaked: {fresh}"
+    );
+}
+
 /// The emitted symbol names of a rooted CFG output: every struct/enum symbol and
 /// every function machine name. Two independent cold compiles of one program
 /// must produce identical sets.

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -4411,6 +4411,51 @@ fn durable_type_diagnostic_name(ty: &crate::durable_semantics::DurableType) -> S
     crate::durable_comptime::durable_type_diagnostic_name(ty)
 }
 
+fn deferred_gate_type_diagnostic_name(
+    context: &QueryContext,
+    family: &SemanticNucleusFamily,
+    ty: &crate::durable_semantics::DurableType,
+    configuration: &crate::semantic_query_nucleus::SemanticQueryConfiguration,
+) -> Result<String, QueryAbort> {
+    let crate::durable_semantics::DurableType::AnonymousNominal(identity) = ty else {
+        return Ok(durable_type_diagnostic_name(ty));
+    };
+    let producer = match &identity.producer {
+        crate::StableProducerId::Definition(definition) => definition,
+        crate::StableProducerId::Function(function) => {
+            let Some(definition) = function_definition_key(function) else {
+                return Ok(durable_type_diagnostic_name(ty));
+            };
+            definition
+        }
+    };
+    let Some(declaration) = declaration_candidate_for_stable_key(producer) else {
+        return Ok(durable_type_diagnostic_name(ty));
+    };
+    let signature = context.query_registered(
+        family,
+        crate::semantic_query_nucleus::SemanticNucleusKey::Signature(
+            crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
+                declaration,
+                configuration: configuration.clone(),
+            },
+        ),
+    )?;
+    let rue_query::QueryOutcome::Success(
+        crate::semantic_query_nucleus::SemanticNucleusValue::Signature(signature),
+    ) = signature.outcome()
+    else {
+        return Ok(durable_type_diagnostic_name(ty));
+    };
+    let crate::semantic_query_nucleus::DeclarationSignatureProjection::Callable {
+        parameters, ..
+    } = &signature.signature
+    else {
+        return Ok(durable_type_diagnostic_name(ty));
+    };
+    Ok(crate::durable_comptime::durable_type_diagnostic_name_with_parameters(ty, parameters))
+}
+
 fn foreign_signature_display(
     parameters: &[crate::durable_semantics::DurableSemanticParameter],
     result: &crate::durable_semantics::DurableType,
@@ -13245,19 +13290,25 @@ impl RevisionedQueryDatabase {
                                 deferred_ownership: BTreeSet::new(),
                                 ownership_properties: BTreeMap::new(),
                             };
+                            let gate_type_name = deferred_gate_type_diagnostic_name(
+                                context,
+                                family,
+                                &query.gate.ty,
+                                &query.producer.configuration,
+                            )?;
                             let result = match query.gate.kind {
                                 crate::semantic_query_nucleus::DeferredOwnershipGateKind::RequireDroppable => provider
                                     .type_carries_linear(&query.gate.ty)
                                     .map(|rejected| rejected.then(|| {
                                         rue_error::ErrorKind::ContainerElementIsLinear {
-                                            ty: durable_type_diagnostic_name(&query.gate.ty),
+                                            ty: gate_type_name.clone(),
                                         }
                                     })),
                                 crate::semantic_query_nucleus::DeferredOwnershipGateKind::RequireTriviallyDroppable => provider
                                     .type_has_drop_glue(&query.gate.ty)
                                     .map(|rejected| rejected.then(|| {
                                         rue_error::ErrorKind::ContainerElementNotTriviallyDroppable {
-                                            ty: durable_type_diagnostic_name(&query.gate.ty),
+                                            ty: gate_type_name.clone(),
                                         }
                                     })),
                             };

--- a/crates/rue-ui-tests/cases/diagnostics/anon-struct-methods.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/anon-struct-methods.toml
@@ -3,6 +3,98 @@ id = "diagnostics.anon-struct-methods"
 name = "Anonymous Struct Method Errors"
 description = "Tests for error messages related to anonymous struct methods."
 
+[[case]]
+name = "method_call_on_body_local_anonymous_enum_uses_ctor_display"
+description = "A body-local comptime-produced enum uses its constructor spelling in E0413."
+source = """
+linear struct Token { v: i32 }
+fn Wrap(comptime T: type) -> type { enum { Some(T), None } }
+fn main() -> i32 {
+    let W = Wrap(Token);
+    let value: W = W.Some(Token { v: 0 });
+    value.missing();
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0413", "Wrap(Token)", "no method named 'missing'"]
+
+[[case]]
+name = "method_call_on_direct_signature_anonymous_struct_uses_ctor_display"
+description = "A signature-materialized anonymous struct uses its constructor spelling in a method diagnostic."
+source = """
+linear struct Token { v: i32 }
+fn Wrap(comptime T: type) -> type { struct { item: T } }
+fn use(value: Wrap(Token)) -> i32 {
+    value.missing();
+    0
+}
+fn main() -> i32 {
+    use(Wrap(Token) { item: Token { v: 0 } });
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0411", "Wrap(Token)", "no method named 'missing'"]
+
+[[case]]
+name = "same_shaped_constructors_keep_distinct_display_names"
+description = "Structs with identical shapes do not cross-contaminate their producer display names."
+source = """
+linear struct Token { v: i32 }
+fn Wrap(comptime T: type) -> type { struct { item: T } }
+fn Mirror(comptime T: type) -> type { struct { item: T } }
+fn __anon_struct_deadbeefdeadbeefdeadbeefdeadbeef(comptime T: type) -> type {
+    struct { item: T }
+}
+fn use_wrap(value: Wrap(Token)) -> i32 {
+    value.missing();
+    0
+}
+fn use_mirror(value: Mirror(Token)) -> i32 {
+    value.missing();
+    0
+}
+fn use_counterfeit(value: __anon_struct_deadbeefdeadbeefdeadbeefdeadbeef(Token)) -> i32 {
+    value.missing();
+    0
+}
+fn main() -> i32 {
+    use_wrap(Wrap(Token) { item: Token { v: 0 } });
+    use_mirror(Mirror(Token) { item: Token { v: 0 } });
+    use_counterfeit(__anon_struct_deadbeefdeadbeefdeadbeefdeadbeef(Token) {
+        item: Token { v: 0 }
+    });
+    0
+}
+"""
+compile_fail = true
+error_contains = [
+    "E0411",
+    "Wrap(Token)",
+    "Mirror(Token)",
+    "__anon_struct_deadbeefdeadbeefdeadbeefdeadbeef(Token)",
+    "no method named 'missing'",
+]
+
+[[case]]
+name = "method_call_on_direct_signature_anonymous_enum_uses_ctor_display"
+description = "A signature-materialized anonymous enum retains its producer spelling without body replay."
+source = """
+linear struct Token { v: i32 }
+fn Wrap(comptime T: type) -> type { enum { Some(T), None } }
+fn use(value: Wrap(Token)) -> i32 {
+    value.missing();
+    0
+}
+fn main() -> i32 {
+    use(Wrap(Token).Some(Token { v: 0 }));
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0413", "Wrap(Token)", "no method named 'missing'"]
+
 # =============================================================================
 # Duplicate Method Errors
 # =============================================================================

--- a/crates/rue-ui-tests/cases/diagnostics/droppable_gate.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/droppable_gate.toml
@@ -12,6 +12,9 @@ the container runs their per-element drop glue, so all cases below use a
 `linear` element type.
 """
 
+# E0498 is retired in the current error catalog; this matrix covers its
+# surviving deferred-gate behavior under E0499 instead.
+
 [[case]]
 name = "e0499_names_ctor_spelling_and_user_site"
 description = "A ctor-produced anonymous linear element type prints as Ctor(args) and the rejection labels the user's application site (RUE-610)"
@@ -50,6 +53,26 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = ["E0499", "Token", "required by the type-constructor application here"]
+
+[[case]]
+name = "e0499_body_local_nested_enum_uses_outer_ctor_display"
+description = "A body-local enum passed into a second constructor keeps the first constructor spelling in the deferred E0499 query."
+source = """
+linear struct Token { v: i32 }
+fn Wrap(comptime T: type) -> type { enum { Some(T), None } }
+fn Gated(comptime T: type) -> type {
+    @require_droppable(T);
+    struct { y: T }
+}
+fn main() -> i32 {
+    let W = Wrap(Token);
+    let G = Gated(W);
+    let _ = G;
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0499", "Wrap(Token)"]
 
 [[case]]
 name = "deferred_named_enum_linear_payload_is_rejected"


### PR DESCRIPTION
## Summary
- add one schema-aware formatter for canonical constructor applications
- route ordinary body and durable query diagnostics through the friendly display authority
- preserve raw semantic identities for internal consumers and guard presentation call sites structurally
- cover body-local, declaration, imported, nested, generic, JSON, and warm-query cases

## Validation
- scripts/rue test
- scripts/rue quick
- focused AIR, compiler, UI, and CLI diagnostic suites
- scripts/rue fmt
- git diff --check

Fixes RUE-1296