### PR TITLE
RUE-1314: splice call batches in place without per-call graph clones

### DIFF
--- a/crates/rue-cfg/src/inline.rs
+++ b/crates/rue-cfg/src/inline.rs
@@ -434,10 +434,10 @@ pub struct AccessorPlaceIndex {
 }
 
 impl AccessorPlaceIndex {
-    /// Index every accessor-rooted place currently in `cfg`.
-    pub fn build(cfg: &Cfg) -> Self {
+    /// Index every accessor-rooted place currently in `caller`.
+    pub fn build(caller: &Cfg) -> Self {
         let mut index = Self::default();
-        index.note_appended(cfg, 0);
+        index.note_appended(caller, 0);
         index
     }
 

--- a/crates/rue-cfg/src/inline.rs
+++ b/crates/rue-cfg/src/inline.rs
@@ -409,9 +409,102 @@ pub fn splice_call_in_block(
     type_pool: &FrozenTypeInternPool,
 ) -> Result<Cfg, CfgInlineError> {
     let mut dst: Cfg = caller.clone();
+    if let Some(replacement) =
+        splice_call_in_block_in_place(&mut dst, call, call_block, callee, type_pool, None)?
+    {
+        dst.rewrite_value_uses_in_place(|value| if value == call { replacement } else { value })?;
+    }
+    Ok(dst)
+}
 
+/// Index of attached place instructions whose base names an accessor
+/// producer ([`PlaceBase::Accessor`]), keyed by producer, plus the count of
+/// values visited to maintain it.
+///
+/// A batch driver builds this once from the pre-splice caller and hands it to
+/// every [`splice_call_in_block_in_place`]: each splice then indexes only its
+/// appended value range and substitutes only the recorded consumers of the
+/// spliced producer, so index maintenance visits each value the caller ever
+/// holds exactly once across the batch — instead of one whole-graph consumer
+/// scan per splice. A splice given no index falls back to that scan.
+#[derive(Debug, Default)]
+pub struct AccessorPlaceIndex {
+    consumers: AHashMap<CfgValue, Vec<CfgValue>>,
+    values_scanned: u64,
+}
+
+impl AccessorPlaceIndex {
+    /// Index every accessor-rooted place currently in `cfg`.
+    pub fn build(cfg: &Cfg) -> Self {
+        let mut index = Self::default();
+        index.note_appended(cfg, 0);
+        index
+    }
+
+    /// Total values visited to build and maintain this index. A batch that
+    /// scans each appended range once keeps this equal to the final value
+    /// count — the scaling contract batch drivers rely on (RUE-1314).
+    pub fn values_scanned(&self) -> u64 {
+        self.values_scanned
+    }
+
+    fn note_appended(&mut self, cfg: &Cfg, from: u32) {
+        for raw in from..cfg.value_count() as u32 {
+            self.values_scanned += 1;
+            let value = CfgValue::from_raw(raw);
+            let (CfgInstData::PlaceRead { place } | CfgInstData::PlaceWrite { place, .. }) =
+                &cfg.get_inst(value).data
+            else {
+                continue;
+            };
+            if let PlaceBase::Accessor(producer) = place.base {
+                self.consumers.entry(producer).or_default().push(value);
+            }
+        }
+    }
+}
+
+/// Splice one call into `dst` itself, without copying the caller.
+///
+/// This is the batch-driver primitive (RUE-1314): [`splice_call_in_block`]
+/// pays one whole-caller clone per call so its input survives a failed
+/// splice, which makes a driver splicing A call sites into one growing
+/// caller O(A × V) in copying alone. This entry point mutates the caller the
+/// driver already owns. The contracts a batch driver builds on:
+///
+/// - **Stable append offsets.** Existing values, blocks, and locals keep
+///   their indices. Callee arena value `v` lands at `dst.value_count() + v`
+///   and callee block `b` at `dst.block_count() + b` (counts as of entry);
+///   the continuation block follows the copied callee blocks. Drivers use
+///   these offsets to find work introduced by the splice.
+/// - **Deferred use rewrite.** The replaced call is left as a detached husk
+///   and its uses are NOT rewritten here; the returned value, when present,
+///   is what every use of `call` must read instead (the continuation's join
+///   parameter, or the unit constant). The driver applies its accumulated
+///   replacements in one [`Cfg::rewrite_value_uses_in_place`] sweep before
+///   the batch verification; until then the graph intentionally reads
+///   through husks. An accessor splice substitutes its yielded place here
+///   (producer order matters for nested chains) and returns `None`.
+/// - **Worklist ordering.** The driver owns splice order. Within one block,
+///   call sites must be spliced in instruction order: a splice moves the
+///   instructions after its call into the continuation block, so a
+///   block→continuation redirect map resolves the current block of any
+///   later call originally in that block.
+/// - **Atomic failure at the batch boundary.** On `Err` the caller may be
+///   partially spliced; the driver discards the whole batch (its input
+///   `ValidatedCfg` is untouched), which is the same atomicity the cloning
+///   primitive gave per call, settled at the batch boundary instead.
+pub fn splice_call_in_block_in_place(
+    dst: &mut Cfg,
+    call: CfgValue,
+    call_block: BlockId,
+    callee: &Cfg,
+    type_pool: &FrozenTypeInternPool,
+    mut accessor_uses: Option<&mut AccessorPlaceIndex>,
+) -> Result<Option<CfgValue>, CfgInlineError> {
+    let appended_values_from = dst.value_count() as u32;
     // -- Locate and validate the call site. ---------------------------------
-    let shape = splice_shape(&dst, call, Some(call_block), callee)?;
+    let shape = splice_shape(dst, call, Some(call_block), callee)?;
     let call_ty = shape.call_ty;
     let call_span = shape.call_span;
     let call_args = shape.call_args;
@@ -439,7 +532,7 @@ pub fn splice_call_in_block(
         let redirect = if callee.is_param_by_ref(param.start_slot) {
             // The argument is a place; only a simple local/parameter root is
             // redirectable in this phase (module docs, ADR-0049 §2/§3).
-            let place = byref_argument_place(&dst, arg.value, index)?;
+            let place = byref_argument_place(dst, arg.value, index)?;
             match place.base {
                 PlaceBase::Local(slot) => {
                     if callee.is_param_address_taken(param.start_slot) {
@@ -546,7 +639,7 @@ pub fn splice_call_in_block(
             });
         };
         Some((
-            translate_place(&mut dst, callee, place, &splice)?,
+            translate_place(dst, callee, place, &splice)?,
             splice.value(returned),
         ))
     } else {
@@ -554,7 +647,7 @@ pub fn splice_call_in_block(
     };
     for index in 0..callee.value_count() {
         let source = callee.get_inst(CfgValue::from_raw(index as u32));
-        let data = translate_data(&mut dst, callee, &source.data, &splice)?;
+        let data = translate_data(dst, callee, &source.data, &splice)?;
         // Spans are copied verbatim so a future location-carrying trap
         // mechanism inherits the callee's real source position (ADR-0049 §7).
         let translated = splice.value(CfgValue::from_raw(index as u32));
@@ -600,7 +693,7 @@ pub fn splice_call_in_block(
     // -- Attach the copied blocks. ------------------------------------------
     for source in callee.blocks() {
         let terminator = translate_terminator(
-            &mut dst,
+            dst,
             callee,
             &source.terminator,
             &splice,
@@ -639,12 +732,12 @@ pub fn splice_call_in_block(
     // continuation join (ADR-0049 §3).
     for &(slot, argument, ty) in &materialized {
         let live = storage_inst(
-            &mut dst,
+            dst,
             CfgInstData::StorageLive { slot, local_ty: ty },
             call_span,
         );
         let init = storage_inst(
-            &mut dst,
+            dst,
             CfgInstData::Alloc {
                 slot,
                 init: argument,
@@ -664,7 +757,7 @@ pub fn splice_call_in_block(
     let mut dead_materialized = Vec::with_capacity(materialized.len());
     for &(slot, _, ty) in &materialized {
         dead_materialized.push(storage_inst(
-            &mut dst,
+            dst,
             CfgInstData::StorageDead { slot, local_ty: ty },
             call_span,
         ));
@@ -687,16 +780,31 @@ pub fn splice_call_in_block(
         block.terminator = original_terminator;
     }
 
-    // Every use of the former call result now reads the continuation's join
-    // value (or the unit constant).
-    if let Some(replacement) = replacement {
-        dst.rewrite_value_uses(|value| if value == call { replacement } else { value })?;
+    // Uses of the former call result are NOT rewritten here: the returned
+    // replacement is the batch driver's to apply in one sweep before the
+    // batch verification (see the function contract above).
+    debug_assert_eq!(
+        splice.value_base, appended_values_from,
+        "nothing may enter the value arena before the callee copy"
+    );
+    // Accessor-rooted places introduced by this splice live only in the
+    // appended value range; index them before substitution so later producer
+    // splices find their consumers without rescanning the caller.
+    if let Some(index) = accessor_uses.as_deref_mut() {
+        index.note_appended(dst, appended_values_from);
     }
     if let Some((yielded_place, yielded_value)) = yielded {
-        substitute_accessor_places(&mut dst, call, &yielded_place, yielded_value)?;
+        substitute_accessor_places(
+            dst,
+            call,
+            &yielded_place,
+            yielded_value,
+            accessor_uses,
+            block_base..block_base + callee.block_count() as u32,
+        )?;
     }
 
-    Ok(dst)
+    Ok(replacement)
 }
 
 /// Return the exact value and basic-block growth that
@@ -720,10 +828,22 @@ fn substitute_accessor_places(
     call: CfgValue,
     yielded: &Place,
     yielded_value: CfgValue,
+    index: Option<&mut AccessorPlaceIndex>,
+    appended_blocks: std::ops::Range<u32>,
 ) -> Result<(), CfgInlineError> {
+    // With an index, only the recorded consumers of this producer are
+    // visited; without one, the whole arena is scanned. Both paths apply the
+    // same base filter, so a stale index entry (a place an earlier
+    // substitution already recomposed onto another root) is skipped exactly
+    // like a non-consumer.
+    let candidates: Vec<CfgValue> = match &index {
+        Some(index) => index.consumers.get(&call).cloned().unwrap_or_default(),
+        None => (0..cfg.value_count() as u32)
+            .map(CfgValue::from_raw)
+            .collect(),
+    };
     let mut replacements = Vec::new();
-    for index in 0..cfg.value_count() {
-        let value = CfgValue::from_raw(index as u32);
+    for value in candidates {
         let place = match &cfg.get_inst(value).data {
             CfgInstData::PlaceRead { place } | CfgInstData::PlaceWrite { place, .. }
                 if place.base == PlaceBase::Accessor(call) =>
@@ -737,11 +857,24 @@ fn substitute_accessor_places(
         let composed = cfg.make_place(yielded.base, yielded.base_type, projections)?;
         replacements.push((value, composed));
     }
+    let mut still_accessor_rooted = Vec::new();
     for (value, place) in replacements {
+        // A consumer whose composed root is itself an accessor producer (the
+        // yielded place of a not-yet-spliced nested accessor) stays a live
+        // consumer of THAT producer; keep the index complete for its splice.
+        if let PlaceBase::Accessor(producer) = place.base {
+            still_accessor_rooted.push((producer, value));
+        }
         match &mut cfg.get_inst_mut(value).data {
             CfgInstData::PlaceRead { place: target }
             | CfgInstData::PlaceWrite { place: target, .. } => *target = place,
             _ => unreachable!(),
+        }
+    }
+    if let Some(index) = index {
+        index.consumers.remove(&call);
+        for (producer, value) in still_accessor_rooted {
+            index.consumers.entry(producer).or_default().push(value);
         }
     }
 
@@ -751,9 +884,11 @@ fn substitute_accessor_places(
     // Detaching this structural read is also required for nested accessors:
     // otherwise its indirect pointer can be lazily materialized in an
     // earlier-numbered continuation block and then used before definition in
-    // the appended inner guard blocks.
-    for block_index in 0..cfg.block_count() {
-        let block = BlockId::from_raw(block_index as u32);
+    // the appended inner guard blocks. The read is a copied callee
+    // instruction, so it is attached in exactly one of this splice's appended
+    // callee blocks.
+    for block_index in appended_blocks {
+        let block = BlockId::from_raw(block_index);
         cfg.get_block_mut(block)
             .insts
             .retain(|value| *value != yielded_value);
@@ -1462,7 +1597,9 @@ mod tests {
         cfg.set_return(entry, users.last().copied());
 
         let yielded = Place::local(0, Type::I64);
-        substitute_accessor_places(&mut cfg, call, &yielded, yielded_value).unwrap();
+        let all_blocks = 0..cfg.block_count() as u32;
+        substitute_accessor_places(&mut cfg, call, &yielded, yielded_value, None, all_blocks)
+            .unwrap();
 
         for (read, user) in reads.iter().copied().zip(users) {
             assert!(matches!(
@@ -1815,6 +1952,120 @@ mod tests {
             growth.blocks,
             (inlined.block_count() - caller.block_count()) as u64
         );
+    }
+
+    /// The RUE-1314 scaling regression: a batch of A splices into one caller
+    /// through the in-place primitive must (1) produce exactly the graph the
+    /// per-call cloning primitive produces, splice for splice, with one
+    /// deferred use-rewrite sweep at the end; (2) resolve every site's
+    /// current block through the block→continuation redirect contract
+    /// without rescanning; and (3) keep index maintenance at one visit per
+    /// value the caller ever holds — the bound that replaces the old
+    /// O(splices × values) rescans.
+    #[test]
+    fn in_place_batch_matches_cloning_splices_and_visits_each_value_once() {
+        const CALLS: usize = 8;
+        let mut program = scalar_program();
+        program.add("callee", |_| scalar_increment_callee());
+        program.add("caller", |interner| {
+            // `fn caller() -> i64 { callee(callee(...callee(1)...)) }` as a
+            // chain of CALLS call sites in one block, so every later site
+            // both consumes an earlier call's result and gets moved into a
+            // continuation by an earlier splice.
+            let mut cfg = Cfg::new(Type::I64, 0, 0, "caller".to_string(), Vec::<bool>::new());
+            let entry = cfg.new_block();
+            cfg.entry = entry;
+            let mut current = cfg.append_inst(entry, inst(CfgInstData::Const(1), Type::I64));
+            for _ in 0..CALLS {
+                current = cfg
+                    .append_call(
+                        entry,
+                        None,
+                        interner.get_or_intern("callee"),
+                        [CfgCallArg {
+                            value: current,
+                            mode: CfgArgMode::Normal,
+                        }],
+                        Type::I64,
+                        Span::new(0, 0),
+                    )
+                    .unwrap();
+            }
+            cfg.set_return(entry, Some(current));
+            cfg
+        });
+        let caller = program.cfg("caller");
+        let callee = program.cfg("callee");
+        let sites: Vec<(CfgValue, BlockId)> = caller
+            .blocks()
+            .iter()
+            .flat_map(|block| {
+                block
+                    .insts
+                    .iter()
+                    .copied()
+                    .filter(|&value| {
+                        matches!(caller.get_inst(value).data, CfgInstData::Call { .. })
+                    })
+                    .map(|value| (value, block.id))
+            })
+            .collect();
+        assert_eq!(sites.len(), CALLS);
+
+        // Reference: the per-call cloning primitive, block found by rescan.
+        let mut reference: Cfg = caller.clone().into_editor();
+        for &(call, _) in &sites {
+            let block = reference
+                .blocks()
+                .iter()
+                .find(|block| block.insts.contains(&call))
+                .map(|block| block.id)
+                .unwrap();
+            reference =
+                splice_call_in_block(&reference, call, block, callee, &program.type_pool).unwrap();
+        }
+
+        // Batch: in-place splices with the index, redirect-resolved blocks,
+        // and one deferred use-rewrite sweep.
+        let mut batched: Cfg = caller.clone().into_editor();
+        let mut index = AccessorPlaceIndex::build(&batched);
+        let mut redirects: AHashMap<BlockId, BlockId> = AHashMap::new();
+        let mut replacements: AHashMap<CfgValue, CfgValue> = AHashMap::new();
+        for &(call, original_block) in &sites {
+            let mut block = original_block;
+            while let Some(next) = redirects.get(&block).copied() {
+                block = next;
+            }
+            let block_base = batched.block_count() as u32;
+            let replacement = splice_call_in_block_in_place(
+                &mut batched,
+                call,
+                block,
+                callee,
+                &program.type_pool,
+                Some(&mut index),
+            )
+            .unwrap();
+            redirects.insert(
+                block,
+                BlockId::from_raw(block_base + callee.block_count() as u32),
+            );
+            if let Some(replacement) = replacement {
+                replacements.insert(call, replacement);
+            }
+        }
+        assert_eq!(replacements.len(), CALLS);
+        batched
+            .rewrite_value_uses_in_place(|value| replacements.get(&value).copied().unwrap_or(value))
+            .unwrap();
+
+        // (3): one index visit per value the caller ever held, exactly.
+        assert_eq!(index.values_scanned(), batched.value_count() as u64);
+        // (1): the same graph, then the same single whole-batch proof.
+        assert_eq!(format!("{reference}"), format!("{batched}"));
+        batched
+            .finish_after_optimization(&program.type_pool)
+            .unwrap();
     }
 
     #[test]

--- a/crates/rue-cfg/src/inline.rs
+++ b/crates/rue-cfg/src/inline.rs
@@ -783,7 +783,7 @@ pub fn splice_call_in_block_in_place(
     // Uses of the former call result are NOT rewritten here: the returned
     // replacement is the batch driver's to apply in one sweep before the
     // batch verification (see the function contract above).
-    debug_assert_eq!(
+    assert_eq!(
         splice.value_base, appended_values_from,
         "nothing may enter the value arena before the callee copy"
     );

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -2763,26 +2763,31 @@ impl Cfg {
         &mut self,
         map: impl Fn(CfgValue) -> CfgValue,
     ) -> Result<(), CfgEditError> {
-        let boundary_values = self
-            .ownership_boundary_values
-            .iter()
-            .copied()
-            .map(|value| (value, map(value)))
-            .collect::<Vec<_>>();
         let mut rewritten = self.clone();
         rewritten.rewrite_value_uses_in_place(map)?;
-        for (_, replacement) in boundary_values {
-            rewritten.ownership_boundary_values.insert(replacement);
-        }
         *self = rewritten;
         Ok(())
     }
 
-    fn rewrite_value_uses_in_place(
+    /// The in-place variant of [`Self::rewrite_value_uses`]: one sweep over
+    /// every use site, without the transactional whole-CFG copy. On failure
+    /// the CFG may be partially rewritten, so this is for callers that
+    /// discard the CFG on error — batch splice drivers discard the whole
+    /// batch, and the transactional wrapper discards its own clone.
+    pub fn rewrite_value_uses_in_place(
         &mut self,
         map: impl Fn(CfgValue) -> CfgValue,
     ) -> Result<(), CfgEditError> {
         use CfgInstData::*;
+        // Per-value ownership facts follow the values they describe: a
+        // replaced value's boundary fact carries to its replacement (the
+        // detached original keeps its stale entry harmlessly).
+        let boundary_replacements = self
+            .ownership_boundary_values
+            .iter()
+            .copied()
+            .map(&map)
+            .collect::<Vec<_>>();
         let old_extra = std::mem::replace(&mut self.extra, payload::Values::new());
         let old_call_args = std::mem::replace(&mut self.call_args, payload::CallArgs::new());
         let old_projections = std::mem::replace(&mut self.projections, payload::Projections::new());
@@ -2963,6 +2968,9 @@ impl Cfg {
                 Terminator::Return { value: None } | Terminator::Unreachable | Terminator::None => {
                 }
             }
+        }
+        for replacement in boundary_replacements {
+            self.ownership_boundary_values.insert(replacement);
         }
         Ok(())
     }

--- a/crates/rue-cfg/src/lib.rs
+++ b/crates/rue-cfg/src/lib.rs
@@ -30,7 +30,8 @@ use rue_error::{CompileError, CompileWarning};
 
 pub use build::CfgBuilder;
 pub use inline::{
-    CfgInlineError, inline_call, inline_call_in_block, splice_call_growth, splice_call_in_block,
+    AccessorPlaceIndex, CfgInlineError, inline_call, inline_call_in_block, splice_call_growth,
+    splice_call_in_block, splice_call_in_block_in_place,
 };
 pub use inst::{
     BasicBlock, BlockId, Cfg, CfgArgMode, CfgCallArg, CfgDisplay, CfgEditError,

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -1755,12 +1755,6 @@ enum SpliceWarningPolicy {
     Ignore,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SpliceVerificationPolicy {
-    Immediate,
-    Deferred,
-}
-
 #[derive(Debug)]
 enum SpliceCalleeFailure {
     Canceled(QueryAbort),
@@ -1773,7 +1767,6 @@ enum SpliceCalleeFailure {
     ConflictingMachineSymbol,
     ConflictingForeignSymbol,
     Splice(rue_cfg::CfgInlineError),
-    Verification(rue_cfg::CfgVerificationError),
 }
 
 impl std::fmt::Display for SpliceCalleeFailure {
@@ -1799,40 +1792,16 @@ impl std::fmt::Display for SpliceCalleeFailure {
                 formatter.write_str("machine symbol has conflicting foreign classification")
             }
             Self::Splice(error) => write!(formatter, "CFG splice failed: {error}"),
-            Self::Verification(error) => {
-                write!(formatter, "spliced CFG failed verification: {error}")
-            }
-        }
-    }
-}
-
-#[derive(Debug)]
-enum SpliceCfg {
-    Verified(rue_cfg::ValidatedCfg),
-    Deferred(rue_cfg::Cfg),
-}
-
-impl SpliceCfg {
-    fn as_cfg(&self) -> &rue_cfg::Cfg {
-        match self {
-            Self::Verified(cfg) => cfg,
-            Self::Deferred(cfg) => cfg,
-        }
-    }
-
-    fn into_validated(
-        self,
-        type_pool: &rue_air::FrozenTypeInternPool,
-    ) -> Result<rue_cfg::ValidatedCfg, rue_cfg::CfgVerificationError> {
-        match self {
-            Self::Verified(cfg) => Ok(cfg),
-            Self::Deferred(cfg) => cfg.finish_after_optimization(type_pool),
         }
     }
 }
 
 struct CfgSpliceState {
-    cfg: SpliceCfg,
+    // The batch's editable caller: one copy of the published record's CFG,
+    // spliced in place and verified once when the batch completes. Failed
+    // batches are discarded whole, so a partially spliced editor is never
+    // observable (RUE-1314).
+    cfg: rue_cfg::Cfg,
     domains: crate::durable_cfg::CfgDomainProjection,
     interner: Arc<lasso::ThreadedRodeo>,
     pending_interner_strings: Vec<String>,
@@ -1853,10 +1822,7 @@ struct CfgSpliceState {
 }
 
 impl CfgSpliceState {
-    fn new(
-        record: &CfgRecord,
-        verification_policy: SpliceVerificationPolicy,
-    ) -> Result<Self, SpliceCalleeFailure> {
+    fn new(record: &CfgRecord) -> Result<Self, SpliceCalleeFailure> {
         let mut symbol_by_spelling = AHashMap::with_capacity(record.interner.len());
         for (symbol, spelling) in record.interner.iter() {
             symbol_by_spelling.insert(spelling.to_owned(), symbol);
@@ -1881,11 +1847,7 @@ impl CfgSpliceState {
             }
         }
         Ok(Self {
-            cfg: if verification_policy == SpliceVerificationPolicy::Immediate {
-                SpliceCfg::Verified(record.cfg.clone())
-            } else {
-                SpliceCfg::Deferred(record.cfg.clone().into_editor())
-            },
+            cfg: record.cfg.clone().into_editor(),
             domains: record.domains.clone(),
             interner: record.interner.clone(),
             pending_interner_strings: Vec::new(),
@@ -1926,6 +1888,13 @@ struct SpliceCalleeOutcome {
     callee_cfg: rue_cfg::ValidatedCfg,
     callee_value_base: u32,
     callee_block_base: u32,
+    /// The value every use of the spliced call must read instead (the
+    /// continuation's join parameter, or the unit constant). The splice
+    /// leaves the call as a detached husk; the driver applies its collected
+    /// replacements in ONE use-rewrite sweep before the batch verification.
+    /// Always `None` for accessor splices, whose yielded place is
+    /// substituted inside the splice.
+    replacement: Option<rue_cfg::CfgValue>,
 }
 
 fn plan_codegen_symbol_mappings(
@@ -1972,9 +1941,6 @@ fn accessor_splice_failure_message(error: SpliceCalleeFailure) -> String {
         SpliceCalleeFailure::Splice(error) => {
             format!("mandatory accessor CFG splice failed: {error}")
         }
-        SpliceCalleeFailure::Verification(error) => {
-            format!("mandatory accessor CFG splice failed: {error}")
-        }
         error => format!("accessor CFG splice merge failed: {error}"),
     }
 }
@@ -1991,9 +1957,6 @@ fn general_splice_failure_message(error: SpliceCalleeFailure) -> String {
             "general inline local atom has no imported string id".to_owned()
         }
         SpliceCalleeFailure::Splice(error) => format!("general inline splice failed: {error}"),
-        SpliceCalleeFailure::Verification(error) => {
-            format!("general inline splice failed: {error}")
-        }
         error => format!("general inline splice merge failed: {error}"),
     }
 }
@@ -2009,7 +1972,7 @@ fn splice_callee(
     current_callee_body_span: Span,
     type_pool: &rue_air::FrozenTypeInternPool,
     warning_policy: SpliceWarningPolicy,
-    verification_policy: SpliceVerificationPolicy,
+    accessor_uses: Option<&mut rue_cfg::AccessorPlaceIndex>,
     mut checkpoint: impl FnMut() -> Result<(), QueryAbort>,
 ) -> Result<SpliceCalleeOutcome, SpliceCalleeFailure> {
     checkpoint().map_err(SpliceCalleeFailure::Canceled)?;
@@ -2166,20 +2129,21 @@ fn splice_callee(
     let dependencies_complete = state.implicit_destructor_dependencies_complete
         && callee.implicit_destructor_dependencies_complete;
 
-    let callee_value_base = state.cfg.as_cfg().value_count() as u32;
-    let callee_block_base = state.cfg.as_cfg().block_count() as u32;
-    let spliced =
-        rue_cfg::splice_call_in_block(state.cfg.as_cfg(), call, call_block, &callee_cfg, type_pool)
-            .map_err(SpliceCalleeFailure::Splice)?;
-    let spliced = if verification_policy == SpliceVerificationPolicy::Immediate {
-        SpliceCfg::Verified(
-            spliced
-                .finish_after_optimization(type_pool)
-                .map_err(SpliceCalleeFailure::Verification)?,
-        )
-    } else {
-        SpliceCfg::Deferred(spliced)
-    };
+    let callee_value_base = state.cfg.value_count() as u32;
+    let callee_block_base = state.cfg.block_count() as u32;
+    // The in-place splice is the first mutation of `state`: every failure
+    // before this point leaves the state reusable (the general driver skips
+    // unimportable callees and continues), while a failure from here on
+    // poisons the batch and its driver discards the whole state.
+    let replacement = rue_cfg::splice_call_in_block_in_place(
+        &mut state.cfg,
+        call,
+        call_block,
+        &callee_cfg,
+        type_pool,
+        accessor_uses,
+    )
+    .map_err(SpliceCalleeFailure::Splice)?;
 
     state.domains.apply_splice_plan(domain_plan);
     for spelling in added_interner_strings {
@@ -2214,11 +2178,11 @@ fn splice_callee(
         .extend(destructor_additions);
     state.implicit_drop_glue_targets.extend(drop_glue_additions);
     state.implicit_destructor_dependencies_complete = dependencies_complete;
-    state.cfg = spliced;
     Ok(SpliceCalleeOutcome {
         callee_cfg,
         callee_value_base,
         callee_block_base,
+        replacement,
     })
 }
 
@@ -2292,7 +2256,7 @@ pub(crate) fn evaluate_optimized_cfg(
             (callee.clone(), dependency_body_span),
         );
     }
-    let mut state = match CfgSpliceState::new(record, SpliceVerificationPolicy::Immediate) {
+    let mut state = match CfgSpliceState::new(record) {
         Ok(state) => state,
         Err(error) => {
             return Ok(QueryOutput::success(internal_failure(
@@ -2302,14 +2266,17 @@ pub(crate) fn evaluate_optimized_cfg(
             .with_terminal_kind(rue_query::QueryTerminalKind::Failure));
         }
     };
+    // One consumer index for the whole batch: each splice extends it over its
+    // appended value range and substitutes only recorded consumers, so index
+    // maintenance visits every value the caller ever holds exactly once
+    // instead of rescanning the growing caller per splice (RUE-1314).
+    let mut accessor_uses = rue_cfg::AccessorPlaceIndex::build(&state.cfg);
     let mut accessor_calls: std::collections::VecDeque<_> =
-        attached_accessor_calls(state.cfg.as_cfg(), 0, 0).into();
+        attached_accessor_calls(&state.cfg, 0, 0).into();
     let mut splice_block_redirects = AHashMap::new();
     while let Some((call, call_block)) = accessor_calls.pop_front() {
         let call_block = resolve_splice_block(call_block, &mut splice_block_redirects);
-        let rue_cfg::CfgInstData::AccessorCall { name, .. } =
-            state.cfg.as_cfg().get_inst(call).data
-        else {
+        let rue_cfg::CfgInstData::AccessorCall { name, .. } = state.cfg.get_inst(call).data else {
             unreachable!()
         };
         let Some(source_name) = state.resolve_symbol(name) else {
@@ -2341,7 +2308,7 @@ pub(crate) fn evaluate_optimized_cfg(
             *callee_body_span,
             &record.type_pool,
             SpliceWarningPolicy::Import,
-            SpliceVerificationPolicy::Immediate,
+            Some(&mut accessor_uses),
             || context.check_canceled(),
         ) {
             Ok(outcome) => outcome,
@@ -2354,6 +2321,16 @@ pub(crate) fn evaluate_optimized_cfg(
                 .with_terminal_kind(rue_query::QueryTerminalKind::Failure));
             }
         };
+        if splice.replacement.is_some() {
+            // An accessor splice substitutes its yielded place itself and
+            // never defers a call replacement; a deferred value here would
+            // be silently dropped, so refuse the batch instead.
+            return Ok(QueryOutput::success(internal_failure(
+                "mandatory accessor splice deferred a call replacement",
+                record.body_span,
+            ))
+            .with_terminal_kind(rue_query::QueryTerminalKind::Failure));
+        }
         let continuation = rue_cfg::BlockId::from_raw(
             splice.callee_block_base + splice.callee_cfg.block_count() as u32,
         );
@@ -2389,7 +2366,9 @@ pub(crate) fn evaluate_optimized_cfg(
         record.interner.len() as u64,
     ));
     let interner_retained_charge = frozen_interner_retained_charge(&interner);
-    let current = match state.cfg.into_validated(&record.type_pool) {
+    // The whole accessor batch is proved here, once: `optimize` below still
+    // demands a `ValidatedCfg`, so no graph reaches a consumer unverified.
+    let current = match state.cfg.finish_after_optimization(&record.type_pool) {
         Ok(cfg) => cfg,
         Err(error) => {
             return Ok(QueryOutput::success(internal_failure(
@@ -2561,9 +2540,16 @@ pub(crate) fn apply_general_inlining(
     // through call-site selection and SCC detection.
     let mut edges: ahash::AHashMap<crate::FunctionInstanceKey, Vec<crate::FunctionInstanceKey>> =
         ahash::AHashMap::new();
+    // Each site carries the block that held the call in the published record,
+    // so the driver can track blocks split by earlier splices through a
+    // redirect map instead of rescanning the whole grown caller per site.
     let mut callsites: ahash::AHashMap<
         crate::FunctionInstanceKey,
-        Vec<(rue_cfg::CfgValue, crate::FunctionInstanceKey)>,
+        Vec<(
+            rue_cfg::CfgValue,
+            crate::FunctionInstanceKey,
+            rue_cfg::BlockId,
+        )>,
     > = ahash::AHashMap::new();
     let mut has_calls: ahash::AHashMap<crate::FunctionInstanceKey, bool> = ahash::AHashMap::new();
     for (function, record) in &records {
@@ -2591,7 +2577,7 @@ pub(crate) fn apply_general_inlining(
                 };
                 function_edges.push(callee.clone());
                 if record_keys.contains(&callee) {
-                    calls.push((value, callee));
+                    calls.push((value, callee, block.id));
                 }
             }
         }
@@ -2680,7 +2666,7 @@ pub(crate) fn apply_general_inlining(
         let caller_record = record_lookup.get(function).copied();
         let selected = sites
             .iter()
-            .filter(|(call, callee)| {
+            .filter(|(call, callee, _)| {
                 eligible(callee)
                     && record_lookup.get(callee).copied().is_some_and(|callee| {
                         // CFG calls carry physical argument values. A
@@ -2705,7 +2691,7 @@ pub(crate) fn apply_general_inlining(
         let CfgValue::Available(record) = &output[index] else {
             continue;
         };
-        let mut state = match CfgSpliceState::new(record, SpliceVerificationPolicy::Deferred) {
+        let mut state = match CfgSpliceState::new(record) {
             Ok(state) => state,
             Err(error) => {
                 output[index] = internal_failure(
@@ -2735,12 +2721,21 @@ pub(crate) fn apply_general_inlining(
             crate::FunctionInstanceKey,
             Result<(), crate::durable_cfg::CfgDomainFailure>,
         >::new();
-        for (call, callee_function) in selected {
+        // Selected sites run in instruction order per block, so a splice's
+        // block split moves every later same-block site into its continuation:
+        // the redirect map resolves each site's current block without
+        // rescanning the grown caller (RUE-1314).
+        let mut splice_block_redirects = AHashMap::new();
+        // Each splice defers its call-result replacement; the batch applies
+        // them in ONE use-rewrite sweep before verification.
+        let mut deferred_replacements =
+            ahash::AHashMap::<rue_cfg::CfgValue, rue_cfg::CfgValue>::new();
+        for (call, callee_function, original_block) in selected {
             context.check_canceled()?;
             let Some(callee) = record_lookup.get(&callee_function).copied() else {
                 continue;
             };
-            let growth = match rue_cfg::splice_call_growth(state.cfg.as_cfg(), call, &callee.cfg) {
+            let growth = match rue_cfg::splice_call_growth(&state.cfg, call, &callee.cfg) {
                 Ok(growth) => growth,
                 Err(error) => {
                     failed = Some(format!("general inline growth preflight failed: {error}"));
@@ -2789,21 +2784,10 @@ pub(crate) fn apply_general_inlining(
                 ));
                 break;
             }
-            let call_block = state
-                .cfg
-                .as_cfg()
-                .blocks()
-                .iter()
-                .find(|block| block.insts.contains(&call))
-                .map(|block| block.id)
-                .ok_or_else(|| format!("general inline call site {call} is detached"));
-            let call_block = match call_block {
-                Ok(block) => block,
-                Err(error) => {
-                    failed = Some(error);
-                    break;
-                }
-            };
+            // The splice itself validates that `call` is attached to this
+            // block, so a stale redirect still fails closed with a
+            // per-site CallSiteNotFound rather than splicing elsewhere.
+            let call_block = resolve_splice_block(original_block, &mut splice_block_redirects);
             context.record_work(rue_query::WorkItem::new(
                 "cfg.general-inline-interner-stages",
                 1,
@@ -2825,10 +2809,18 @@ pub(crate) fn apply_general_inlining(
                 current_callee_body_span,
                 &record.type_pool,
                 SpliceWarningPolicy::Ignore,
-                SpliceVerificationPolicy::Deferred,
+                None,
                 || context.check_canceled(),
             ) {
-                Ok(_) => {}
+                Ok(outcome) => {
+                    let continuation = rue_cfg::BlockId::from_raw(
+                        outcome.callee_block_base + outcome.callee_cfg.block_count() as u32,
+                    );
+                    splice_block_redirects.insert(call_block, continuation);
+                    if let Some(replacement) = outcome.replacement {
+                        deferred_replacements.insert(call, replacement);
+                    }
+                }
                 Err(SpliceCalleeFailure::Canceled(abort)) => return Err(abort),
                 Err(SpliceCalleeFailure::Domain(
                     crate::durable_cfg::CfgDomainFailure::MissingStableType(_),
@@ -2874,6 +2866,20 @@ pub(crate) fn apply_general_inlining(
         if !spliced {
             continue;
         }
+        // Every splice left its replaced call as a detached husk; route all
+        // its uses to the recorded replacement in one sweep for the whole
+        // batch, instead of one whole-graph rewrite per splice.
+        if !deferred_replacements.is_empty()
+            && let Err(error) = state.cfg.rewrite_value_uses_in_place(|value| {
+                deferred_replacements.get(&value).copied().unwrap_or(value)
+            })
+        {
+            output[index] = internal_failure(
+                format!("general inline use rewrite failed: {error:?}"),
+                record.body_span,
+            );
+            continue;
+        }
         let interner = match materialize_splice_interner(&state, || context.check_canceled()) {
             Ok(interner) => interner,
             Err(CfgInternerCopyFailure::Checkpoint(abort)) => return Err(abort),
@@ -2886,7 +2892,7 @@ pub(crate) fn apply_general_inlining(
             }
         };
         // The whole batch is proved here, once.
-        let current = match state.cfg.into_validated(&record.type_pool) {
+        let current = match state.cfg.finish_after_optimization(&record.type_pool) {
             Ok(cfg) => cfg,
             Err(error) => {
                 output[index] = internal_failure(
@@ -3439,7 +3445,7 @@ mod accessor_graph_tests {
             .clone();
         assert!(main.interner.len() >= 16, "fixture must exercise many keys");
 
-        let state = CfgSpliceState::new(&main, SpliceVerificationPolicy::Deferred).unwrap();
+        let state = CfgSpliceState::new(&main).unwrap();
         assert_eq!(state.symbol_by_spelling.len(), main.interner.len());
         for (symbol, spelling) in main.interner.iter() {
             assert_eq!(main.interner.get(spelling), Some(symbol));
@@ -3505,7 +3511,7 @@ mod accessor_graph_tests {
             .into_iter()
             .next()
             .unwrap();
-        let mut state = CfgSpliceState::new(&main, SpliceVerificationPolicy::Immediate).unwrap();
+        let mut state = CfgSpliceState::new(&main).unwrap();
         let base_string_len = state.strings.len();
 
         let outer_splice = splice_callee(
@@ -3516,7 +3522,7 @@ mod accessor_graph_tests {
             outer.body_span,
             &main.type_pool,
             SpliceWarningPolicy::Import,
-            SpliceVerificationPolicy::Immediate,
+            None,
             || Ok(()),
         )
         .unwrap();
@@ -3535,8 +3541,7 @@ mod accessor_graph_tests {
         );
         assert_eq!(introduced.len(), 1);
         let (inner_call, inner_block) = introduced[0];
-        let rue_cfg::CfgInstData::AccessorCall { name, .. } =
-            state.cfg.as_cfg().get_inst(inner_call).data
+        let rue_cfg::CfgInstData::AccessorCall { name, .. } = state.cfg.get_inst(inner_call).data
         else {
             panic!("nested call must remain an accessor call")
         };
@@ -3555,7 +3560,7 @@ mod accessor_graph_tests {
             inner.body_span,
             &main.type_pool,
             SpliceWarningPolicy::Import,
-            SpliceVerificationPolicy::Immediate,
+            None,
             || Ok(()),
         )
         .unwrap();
@@ -3715,7 +3720,7 @@ mod accessor_graph_tests {
                 })
             })
             .unwrap();
-        let mut state = CfgSpliceState::new(&main, SpliceVerificationPolicy::Deferred).unwrap();
+        let mut state = CfgSpliceState::new(&main).unwrap();
         let cfg_before = format!("{:?}", state.cfg);
         let domains_before = state.domains.stable_debug_snapshot(&main.air);
         let interner_before = state
@@ -3772,7 +3777,7 @@ mod accessor_graph_tests {
                 poisoned.body_span,
                 &main.type_pool,
                 SpliceWarningPolicy::Import,
-                SpliceVerificationPolicy::Deferred,
+                None,
                 || Ok(()),
             ),
             Err(SpliceCalleeFailure::ConflictingSourceSymbol)
@@ -3834,7 +3839,7 @@ mod accessor_graph_tests {
                 poisoned.body_span,
                 &main.type_pool,
                 SpliceWarningPolicy::Ignore,
-                SpliceVerificationPolicy::Deferred,
+                None,
                 || Ok(()),
             ),
             Err(SpliceCalleeFailure::ConflictingForeignSymbol)
@@ -3858,7 +3863,7 @@ mod accessor_graph_tests {
                     poisoned.body_span,
                     &main.type_pool,
                     SpliceWarningPolicy::Ignore,
-                    SpliceVerificationPolicy::Deferred,
+                    None,
                     || Ok(()),
                 ),
                 Err(SpliceCalleeFailure::Domain(
@@ -4100,19 +4105,56 @@ mod accessor_graph_tests {
             .0;
         assert_eq!(
             accessor_driver
-                .matches("attached_accessor_calls(state.cfg.as_cfg(), 0, 0)")
+                .matches("attached_accessor_calls(&state.cfg, 0, 0)")
                 .count(),
             1
         );
         assert!(accessor_driver.contains("accessor_calls.pop_front()"));
         assert!(accessor_driver.contains("accessor_calls.extend(introduced_calls)"));
         assert!(accessor_driver.contains("resolve_splice_block("));
+        assert!(accessor_driver.contains("AccessorPlaceIndex::build("));
         assert_eq!(accessor_driver.matches("splice_callee(").count(), 1);
         assert_eq!(general_driver.matches("splice_callee(").count(), 1);
+        assert!(general_driver.contains("resolve_splice_block("));
         assert_eq!(production.matches("fn splice_callee(").count(), 1);
         assert_eq!(production.matches(".import_accessor_cfg(").count(), 1);
+        // The batch drivers splice in place through the helper: exactly one
+        // in-place splice site, no per-splice caller clone or verification
+        // (RUE-1314), and exactly one deferred use-rewrite sweep, in the
+        // general driver, applied before the batch verification.
+        assert_eq!(
+            production
+                .matches("rue_cfg::splice_call_in_block_in_place(")
+                .count(),
+            1
+        );
         assert_eq!(
             production.matches("rue_cfg::splice_call_in_block(").count(),
+            0
+        );
+        assert_eq!(
+            production.matches("rewrite_value_uses_in_place(").count(),
+            1
+        );
+        assert_eq!(
+            general_driver
+                .matches("rewrite_value_uses_in_place(")
+                .count(),
+            1
+        );
+        // The helper still verifies each IMPORTED CALLEE (callee-sized); the
+        // grown caller is proved once per batch, in each driver.
+        assert!(!helper.contains("state.cfg.finish_after_optimization"));
+        assert_eq!(
+            accessor_driver
+                .matches("state.cfg.finish_after_optimization")
+                .count(),
+            1
+        );
+        assert_eq!(
+            general_driver
+                .matches("state.cfg.finish_after_optimization")
+                .count(),
             1
         );
         assert!(helper.contains("plan_codegen_symbol_mappings("));
@@ -4126,6 +4168,7 @@ mod accessor_graph_tests {
             for bypass in [
                 ".import_accessor_cfg(",
                 "rue_cfg::splice_call_in_block(",
+                "rue_cfg::splice_call_in_block_in_place(",
                 "rue_cfg::inline_call_in_block(",
                 "symbol_mappings.extend(",
                 "foreign_symbols.extend(",


### PR DESCRIPTION
Fixes RUE-1314

Both CFG splice drivers copied the complete growing caller once per call site, an O(sites × values) floor on the mandatory accessor path and the general-inline path: `splice_call_in_block` began with a whole-caller clone, the accessor driver additionally verified the whole caller after every individual splice, and the general driver re-located each call site with a linear blocks×insts rescan of the grown graph.

## What changed

- **`rue-cfg`: in-place splice primitive.** `splice_call_in_block_in_place` mutates the caller the batch driver already owns — no per-splice clone — and returns the deferred call-result replacement instead of performing a whole-graph use rewrite per splice. Its doc comment records the batch contracts: stable value/block append offsets, driver-owned worklist ordering (instruction order within a block, resolved through a block→continuation redirect map), and failure atomicity settled at the batch boundary the drivers already discard. The cloning `splice_call_in_block` remains as the single-call wrapper with unchanged behavior.
- **`rue-cfg`: accessor-place consumer index.** `AccessorPlaceIndex` bounds yielded-place substitution to the actual consumers of the spliced producer; maintenance scans exactly each splice's appended value range, so batch-total index work is one visit per value the caller ever holds. The yielded-read detach is likewise restricted to the splice's appended callee blocks.
- **`rue-cfg`: public in-place use rewrite.** `Cfg::rewrite_value_uses_in_place` (with the ownership-boundary fact carry folded in) lets a batch apply all its call replacements in ONE sweep; the transactional cloning wrapper stays for existing callers.
- **`rue-compiler`: both drivers batch in place.** The mandatory-accessor driver drops its per-splice clone and per-splice whole-caller verification (one `finish_after_optimization` per batch — no graph reaches a consumer unverified), and passes the consumer index. The general-inline driver drops the per-splice clone, replaces the per-site rescan with the redirect map captured at call-site collection, and applies deferred replacements in one sweep before the batch verification. The now-constant `SpliceVerificationPolicy`/`SpliceCfg` plumbing is removed.

## Failure semantics

Recoverable, typed refusals (budget, importability, missing stable type) all occur before the first state mutation and still skip per site. Any failure from the splice onward poisons the batch and the driver discards it whole — the published record is untouched, which is the same atomicity the cloning primitive provided per call, settled at the batch boundary.

## Tests

- New scaling regression in `rue-cfg`: a chained 8-call batch through the in-place path (index, redirects, single sweep) must produce a **byte-identical graph** to the sequential per-call cloning primitive, verify cleanly, and keep index maintenance at exactly one visit per value.
- The driver source-structure test now rejects reintroduced per-splice clones, per-splice caller verification, and per-site rescans, and pins the single in-place splice site and single sweep.
- Existing coverage retained: multi-call blocks, nested accessor chains, drop glue, by-ref parameters, and projected yields (rue-cfg suite 342, rue-compiler suite 1090, borrow-accessor and string spec suites all green; full local premerge tier run before marking ready).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhLu5tyWdwrL8RywUZqaQc)_