### PR TITLE
RUE-1820: model stdout observation trace

### DIFF
--- a/crates/rue-oracle-diff/src/fuzz.rs
+++ b/crates/rue-oracle-diff/src/fuzz.rs
@@ -88,7 +88,9 @@ pub(crate) enum Compiled {
     /// compare *which* trap fired, not just that one did (RUE-339).
     Ran {
         exit: i32,
-        stdout: String,
+        /// Exact captured bytes. Diagnostics may render this lossily, but all
+        /// differential comparisons use the raw trace.
+        stdout: Vec<u8>,
         /// More stdout existed beyond [`MAX_STDOUT_BYTES`]; `stdout` is only a prefix.
         stdout_truncated: bool,
         stderr: String,
@@ -412,7 +414,7 @@ pub fn run(args: &[String]) -> ExitCode {
                         timeout_secs: cfg.timeout.as_secs(),
                         source: source.clone(),
                         oracle_exit: oracle.exit_code,
-                        oracle_stdout: oracle.stdout.clone(),
+                        oracle_stdout: oracle.stdout_bytes.clone(),
                         oracle_stderr: oracle.stderr.clone(),
                         oracle_panic: oracle.panic,
                         compiled: describe(&compiled),
@@ -496,7 +498,7 @@ pub(crate) fn classify(oracle: &rue_oracle::Outcome, compiled: &Compiled) -> Ver
                 ));
             }
             let exit_ok = oracle.exit_code == *exit;
-            let stdout_ok = &oracle.stdout == stdout;
+            let stdout_ok = oracle.stdout_bytes == *stdout;
             let stderr_ok = &oracle.stderr == stderr;
             if !exit_ok || !stdout_ok || !stderr_ok {
                 let mut r = String::new();
@@ -506,7 +508,8 @@ pub(crate) fn classify(oracle: &rue_oracle::Outcome, compiled: &Compiled) -> Ver
                 if !stdout_ok {
                     r += &format!(
                         "stdout: oracle {:?} vs compiled {:?}",
-                        oracle.stdout, stdout
+                        display_bytes(&oracle.stdout_bytes),
+                        display_bytes(stdout)
                     );
                 }
                 if !stderr_ok {
@@ -689,7 +692,7 @@ fn plant_test_miscompile(
 enum ProcessOutcome {
     Exited {
         status: ExitStatus,
-        stdout: String,
+        stdout: Vec<u8>,
         stdout_truncated: bool,
         stderr: String,
         stderr_truncated: bool,
@@ -764,9 +767,10 @@ fn wait_for_process(mut child: Child, timeout: Duration) -> std::io::Result<Proc
     // EOF and finish promptly.
     let stdout_capture = stdout_reader.join().unwrap_or_default();
     let stderr_capture = stderr_reader.join().unwrap_or_default();
-    // Lossy decode so garbage bytes from a miscompile surface as a stdout
-    // mismatch rather than silently becoming empty (as `read_to_string` would).
-    let stdout = String::from_utf8_lossy(&stdout_capture.bytes).into_owned();
+    // Keep stdout raw through ProcessOutcome and Compiled. Lossy conversion is
+    // reserved for diagnostics, so invalid bytes cannot collapse into a false
+    // differential agreement.
+    let stdout = stdout_capture.bytes;
     let stderr = String::from_utf8_lossy(&stderr_capture.bytes).into_owned();
 
     match status? {
@@ -856,7 +860,9 @@ struct Disagreement {
     timeout_secs: u64,
     source: String,
     oracle_exit: i32,
-    oracle_stdout: String,
+    /// Exact oracle stdout bytes; persisted diagnostics render escapes so
+    /// invalid sequences remain distinguishable.
+    oracle_stdout: Vec<u8>,
     oracle_stderr: String,
     oracle_panic: Option<TrapKind>,
     compiled: String,
@@ -873,7 +879,7 @@ impl Disagreement {
             reason = self.reason,
             exit = self.oracle_exit,
             panic = self.oracle_panic,
-            stdout = self.oracle_stdout,
+            stdout = display_bytes(&self.oracle_stdout),
             stderr = self.oracle_stderr,
             compiled = self.compiled,
             source = self.source,
@@ -897,8 +903,9 @@ fn describe(c: &Compiled) -> String {
                 "stdout"
             };
             format!(
-                "ran exit={exit} {label}={stdout:?} stdout-truncated={stdout_truncated} \
-                 stderr={stderr:?} stderr-truncated={stderr_truncated}"
+                "ran exit={exit} {label}={displayed_stdout:?} stdout-truncated={stdout_truncated} \
+                 stderr={stderr:?} stderr-truncated={stderr_truncated}",
+                displayed_stdout = display_bytes(stdout),
             )
         }
         Compiled::CompileRejected { exit, stderr } => {
@@ -912,6 +919,26 @@ fn describe(c: &Compiled) -> String {
         Compiled::Crash(sig) => format!("crash signal={sig}"),
         Compiled::Timeout => "timeout".to_string(),
     }
+}
+
+/// Render captured bytes for diagnostics and persisted repro metadata without
+/// losing identity. Printable ASCII stays readable; controls and every
+/// non-ASCII byte use deterministic escapes, so `0xff` and `0xfe` cannot
+/// collapse through lossy UTF-8 decoding.
+fn display_bytes(bytes: &[u8]) -> String {
+    let mut rendered = String::with_capacity(bytes.len());
+    for &byte in bytes {
+        match byte {
+            b'\\' => rendered.push_str("\\\\"),
+            b'"' => rendered.push_str("\\\""),
+            b'\n' => rendered.push_str("\\n"),
+            b'\r' => rendered.push_str("\\r"),
+            b'\t' => rendered.push_str("\\t"),
+            0x20..=0x7e => rendered.push(byte as char),
+            _ => rendered.push_str(&format!("\\x{byte:02x}")),
+        }
+    }
+    rendered
 }
 
 fn first_line(s: &str) -> String {
@@ -958,7 +985,10 @@ fn disagreement_repro_contents(d: &Disagreement) -> String {
         "oracle",
         &format!(
             "exit={} panic={:?} stdout={:?} stderr={:?}",
-            d.oracle_exit, d.oracle_panic, d.oracle_stdout, d.oracle_stderr
+            d.oracle_exit,
+            d.oracle_panic,
+            display_bytes(&d.oracle_stdout),
+            d.oracle_stderr
         ),
     );
     push_repro_comment(&mut contents, "compiled", &d.compiled);
@@ -1064,6 +1094,17 @@ mod tests {
         Outcome {
             exit_code: exit,
             stdout: stdout.to_string(),
+            stdout_bytes: stdout.as_bytes().to_vec(),
+            stderr: String::new(),
+            panic: None,
+        }
+    }
+
+    fn oc_bytes(exit: i32, stdout: &[u8]) -> Outcome {
+        Outcome {
+            exit_code: exit,
+            stdout: String::from_utf8_lossy(stdout).into_owned(),
+            stdout_bytes: stdout.to_vec(),
             stderr: String::new(),
             panic: None,
         }
@@ -1084,6 +1125,7 @@ mod tests {
         Outcome {
             exit_code: 101,
             stdout: String::new(),
+            stdout_bytes: Vec::new(),
             stderr: stderr.to_string(),
             panic: Some(kind),
         }
@@ -1093,7 +1135,7 @@ mod tests {
     fn ran(exit: i32, stdout: &str) -> Compiled {
         Compiled::Ran {
             exit,
-            stdout: stdout.to_string(),
+            stdout: stdout.as_bytes().to_vec(),
             stdout_truncated: false,
             stderr: String::new(),
             stderr_truncated: false,
@@ -1104,7 +1146,7 @@ mod tests {
     fn ran_trap(stderr: &str) -> Compiled {
         Compiled::Ran {
             exit: 101,
-            stdout: String::new(),
+            stdout: Vec::new(),
             stdout_truncated: false,
             stderr: stderr.to_string(),
             stderr_truncated: false,
@@ -1182,7 +1224,7 @@ mod tests {
     fn unexpected_stderr_on_normal_exit_fails_closed() {
         let compiled = Compiled::Ran {
             exit: 42,
-            stdout: "7\n".to_string(),
+            stdout: b"7\n".to_vec(),
             stdout_truncated: false,
             stderr: "unmodeled native diagnostic\n".to_string(),
             stderr_truncated: false,
@@ -1205,7 +1247,7 @@ mod tests {
         // Trap-category agreement cannot hide an earlier stdout mismatch.
         let compiled = Compiled::Ran {
             exit: 101,
-            stdout: "unexpected\n".to_string(),
+            stdout: b"unexpected\n".to_vec(),
             stdout_truncated: false,
             stderr: "error: integer overflow\n".to_string(),
             stderr_truncated: false,
@@ -1214,6 +1256,52 @@ mod tests {
             &trap(TrapKind::ArithmeticOverflow),
             &compiled
         )));
+    }
+
+    #[test]
+    fn invalid_native_stdout_bytes_cannot_agree_or_hide_diagnostics() {
+        let oracle = oc_bytes(0, &[0xff]);
+        let same = Compiled::Ran {
+            exit: 0,
+            stdout: vec![0xff],
+            stdout_truncated: false,
+            stderr: String::new(),
+            stderr_truncated: false,
+        };
+        assert!(matches!(classify(&oracle, &same), Verdict::Agree));
+
+        let compiled = Compiled::Ran {
+            exit: 0,
+            stdout: vec![0xfe],
+            stdout_truncated: false,
+            stderr: String::new(),
+            stderr_truncated: false,
+        };
+        let Verdict::Disagree(reason) = classify(&oracle, &compiled) else {
+            panic!("distinct invalid stdout bytes must disagree")
+        };
+        assert!(reason.contains("stdout:"), "diagnostic: {reason}");
+        assert!(reason.contains("\\xff"), "diagnostic: {reason}");
+        assert!(reason.contains("\\xfe"), "diagnostic: {reason}");
+
+        let disagreement = Disagreement {
+            seed: 1,
+            optimization: OptimizationLevel::O1,
+            timeout_secs: 1,
+            source: "fn main() -> i32 { 0 }\n".to_string(),
+            oracle_exit: oracle.exit_code,
+            oracle_stdout: oracle.stdout_bytes,
+            oracle_stderr: oracle.stderr,
+            oracle_panic: oracle.panic,
+            compiled: describe(&compiled),
+            reason,
+        };
+        let rendered = disagreement.render();
+        assert!(rendered.contains("\\xff"), "rendered: {rendered}");
+        assert!(rendered.contains("\\xfe"), "rendered: {rendered}");
+        let persisted = disagreement_repro_contents(&disagreement);
+        assert!(persisted.contains("\\xff"), "persisted: {persisted}");
+        assert!(persisted.contains("\\xfe"), "persisted: {persisted}");
     }
 
     #[test]
@@ -1282,12 +1370,13 @@ mod tests {
         let oracle = Outcome {
             exit_code: 0,
             stdout: String::new(),
+            stdout_bytes: Vec::new(),
             stderr: "retained prefix".to_string(),
             panic: None,
         };
         let compiled = Compiled::Ran {
             exit: 0,
-            stdout: String::new(),
+            stdout: Vec::new(),
             stdout_truncated: false,
             stderr: oracle.stderr.clone(),
             stderr_truncated: true,
@@ -1474,7 +1563,7 @@ mod tests {
             timeout_secs: 3,
             source: "fn main() -> i32 { 23 }\n".to_string(),
             oracle_exit: 101,
-            oracle_stdout: String::new(),
+            oracle_stdout: Vec::new(),
             oracle_stderr: "error: integer cast overflow\n".to_string(),
             oracle_panic: Some(TrapKind::IntegerCastOverflow),
             compiled: "compile-fail: first\rsecond".to_string(),
@@ -1736,7 +1825,10 @@ mod tests {
                     n,
                     "full stdout must be captured, not truncated"
                 );
-                assert!(matches!(classify(&oc(0, stdout), &result), Verdict::Agree));
+                assert!(matches!(
+                    classify(&oc_bytes(0, stdout), &result),
+                    Verdict::Agree
+                ));
             }
             other => panic!("expected Ran with full stdout, got {}", describe(other)),
         }
@@ -1766,7 +1858,7 @@ mod tests {
 
                 // Even an oracle outcome equal to the retained prefix cannot
                 // agree: additional compiled output was observed and drained.
-                let verdict = classify(&oc(0, stdout), &result);
+                let verdict = classify(&oc_bytes(0, stdout), &result);
                 assert!(
                     matches!(verdict, Verdict::Disagree(reason) if reason.contains("capture limit")),
                     "stdout overflow must disagree before prefix comparison"

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -1097,8 +1097,14 @@ fn check_spec_case_with_known_gap(
             // whitespace-shaped oracle-vs-compiler divergence as agreement
             // (RUE-132's byte-exactness rule applies here too).
             let stdout_ok = case.expected_stdout.as_ref().is_none_or(|s| {
-                rue_test_runner::strip_block_boundary_newlines(&outcome.stdout)
-                    == rue_test_runner::strip_block_boundary_newlines(s)
+                let observed = rue_test_runner::strip_block_boundary_newlines(&outcome.stdout);
+                observed == rue_test_runner::strip_block_boundary_newlines(s)
+                    // The string comparison intentionally strips the fixture's
+                    // formatting boundary.  Raw bytes still have to be a
+                    // valid, lossless representation of the oracle output so
+                    // invalid UTF-8 cannot collapse into agreement through
+                    // `from_utf8_lossy`.
+                    && outcome.stdout_bytes == outcome.stdout.as_bytes()
             });
             // Match the real spec runner's two stderr paths: `runtime_error`
             // checks its own substring and returns early there; otherwise the
@@ -1379,11 +1385,14 @@ fn check_case_with_native(
                 }
             }
             let exit_ok = outcome.exit_code == expected_exit;
-            let stdout_ok = case.stdout.as_ref().is_none_or(|s| &outcome.stdout == s);
-            let missing_stdout = case
-                .stdout_contains
-                .iter()
-                .find(|expected| !outcome.stdout.contains(expected.as_str()));
+            let stdout_ok = case
+                .stdout
+                .as_ref()
+                .is_none_or(|s| outcome.stdout_bytes == s.as_bytes());
+            let missing_stdout = case.stdout_contains.iter().find(|expected| {
+                outcome.stdout_bytes != outcome.stdout.as_bytes()
+                    || !outcome.stdout.contains(expected.as_str())
+            });
             let missing_stderr = case
                 .runtime_error_contains
                 .iter()
@@ -2671,6 +2680,7 @@ files = [{ path = "probe.rue", source = "not Rue" }]
         let pre_optimization = Outcome {
             exit_code: 0,
             stdout: String::new(),
+            stdout_bytes: Vec::new(),
             stderr: String::new(),
             panic: None,
         };

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -1,10 +1,7 @@
 //! Exact model-gap inventory for the `rue-cli-tests` corpus.
 
 use super::{InventoryScope, ModelGapAudit, ModelGapRegistration};
-use rue_oracle::{
-    ExternalDependencyKind, ModelGapKind, SemanticGapKind, UnsupportedIntrinsicKind,
-    UnsupportedRuntimeCallKind,
-};
+use rue_oracle::{ExternalDependencyKind, ModelGapKind, SemanticGapKind, UnsupportedIntrinsicKind};
 use std::fmt;
 
 /// Stable CLI corpus identity. File paths are deliberately excluded: cases
@@ -66,27 +63,15 @@ impl Entry {
 /// Entries are generated from unknown-gap diagnostics emitted by the real
 /// production classifier, then reviewed into this typed list. Dynamic
 /// `Unsupported::detail` text is intentionally absent from the policy key. The
-/// Each entry records the first unsupported semantic boundary observed by the
+/// entries record the first unsupported semantic boundary observed by the
 /// current oracle. Representation-byte support has moved affected heap cases
-/// past byte copying; remaining entries are genuine runtime, syscall, pointer,
-/// or layout boundaries.
+/// past byte copying; remaining entries are genuine syscall, pointer, or
+/// layout boundaries.
 const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.arraybuf_library",
         "arraybuf_zero_sized_element",
         intrinsic(UnsupportedIntrinsicKind::PointerWrite),
-        &[],
-    ),
-    Entry::new(
-        "cli.const_init",
-        "string_const_prints_and_measures",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.enum_payloads",
-        "returned_nested_json_drops_safely",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
         &[],
     ),
     // std.fs File IO v0 (RUE-712, ADR-0057): pure-Rue fs over @syscall. The
@@ -328,47 +313,6 @@ const ENTRIES: &[Entry] = &[
         external(ExternalDependencyKind::SystemCall),
         &[],
     ),
-    // RUE-1758: the inlined-continuation lowering-order cases assert on stdout
-    // rather than an exit code, because lowering a use before its definition
-    // produced a WRONG VALUE — a `None` read as `Some(<uninitialized>)` — not a
-    // trap. `println` is therefore the first thing the oracle model cannot
-    // follow in each, exactly as for the IntMap key-extreme cases below.
-    Entry::new(
-        "cli.inlined_continuation_lowering_order",
-        "hand_written_option_none_survives_an_inlined_call",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.inlined_continuation_lowering_order",
-        "multi_slot_payload_option_keeps_its_none",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.inlined_continuation_lowering_order",
-        "one_byte_payload_option_keeps_its_none",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.inlined_continuation_lowering_order",
-        "present_and_absent_keys_both_answer_correctly",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.inlined_continuation_lowering_order",
-        "std_intmap_missing_key_stays_none_after_an_inlined_call",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    // The RUE-1636 cross-mechanism case builds a `StrBuf` and scans it byte by
-    // byte, so the oracle model stops at the runtime/output boundary like every
-    // other StrBuf-backed case here. The rest of the `cli.integer_class_width`
-    // section is plain integer arithmetic the oracle models directly, which is
-    // why this is the section's only entry.
-
     // RUE-954: the literal-threading regression cases invoke a real dup(2)
     // syscall, which the oracle does not model.
     Entry::new(
@@ -383,24 +327,12 @@ const ENTRIES: &[Entry] = &[
         external(ExternalDependencyKind::SystemCall),
         &["x86-64-linux"],
     ),
-    // RUE-682: only the std.hash cases that route bytes through StrBuf or
-    // ArrayBuf(u8) hit the runtime/output boundary. The three that hash `str` views
-    // directly — including `hash_known_answer_vectors`, which carries the
-    // published FNV-1a/64 vectors — ARE modeled, so the oracle differentially
-    // checks the hash arithmetic itself. That is the coverage worth having here;
-    // the container spellings are asserted to agree with `str` inside the cases.
-
     // ADR-0052 phase 3 (RUE-974): these cases remain registered only for the
     // unsupported target-layout/unaligned outcome they exercise; field
     // projection and allocation are modeled by the oracle.
     // ADR-0052 phase 5.5 (RUE-989): the narrow-access cases retain their
     // genuine target-layout gap, rather than treating field_ptr or alloc as
     // unmodeled operations.
-    // RUE-1786: the two over-rejection controls in this section are the only
-    // ones that RUN -- the rest assert a compile failure and are ineligible.
-    // Both build a real StrBuf, so they reach the same remaining unsupported
-    // boundary as every other StrBuf-backed case here.
-
     // RUE-978: these byte-surface cases depend on the target-specific mapping
     // behavior noted by their registrations; @alloc itself is modeled.
     Entry::new(
@@ -408,42 +340,6 @@ const ENTRIES: &[Entry] = &[
         "ptr_offset_forward_on_mmap_pointer",
         external(ExternalDependencyKind::SystemCall),
         &["x86-64-linux"],
-    ),
-    Entry::new(
-        "cli.print",
-        "print_borrows_string_reusable_after_call",
-        runtime_call(UnsupportedRuntimeCallKind::Print),
-        &[],
-    ),
-    Entry::new(
-        "cli.print",
-        "print_empty_and_println_empty",
-        runtime_call(UnsupportedRuntimeCallKind::Print),
-        &[],
-    ),
-    Entry::new(
-        "cli.print",
-        "print_no_trailing_newline",
-        runtime_call(UnsupportedRuntimeCallKind::Print),
-        &[],
-    ),
-    Entry::new(
-        "cli.print",
-        "print_utf8_bytes_verbatim",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.print",
-        "println_adds_single_newline",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.print",
-        "println_composed_with_to_string_and_concat",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
     ),
     Entry::new(
         "cli.slices",
@@ -459,91 +355,6 @@ const ENTRIES: &[Entry] = &[
         "cli.slices",
         "struct_element_slice_empty_view",
         intrinsic(UnsupportedIntrinsicKind::EmptySlicePointer),
-        &[],
-    ),
-    // std.c C-string export contract (RUE-1710): the buffer and raw-pointer
-    // representation are modeled; these cases remain at the runtime/output
-    // boundary. The FFI-free round-trip case reaches `println` first instead,
-    // which is the runtime-call gap.
-    Entry::new(
-        "cli.std_c_strings",
-        "c_free_c_string_returns_block_to_its_own_size_class",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_c_strings",
-        "c_has_interior_nul_positions",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_c_strings",
-        "c_owned_c_string_roundtrip_without_ffi",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    // IntMap key extremes (RUE-1709). These cases assert on stdout rather than
-    // an exit code, because a hash that mishandles `i64::MIN` or that diverges
-    // between `_slot` and `_grow_to` produces a WRONG VALUE, not a trap — so
-    // `println` is the first thing the oracle model cannot follow in each.
-    Entry::new(
-        "cli.std_collections",
-        "intmap_extreme_keys_survive_growth",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_collections",
-        "intmap_key_i64_min_full_lifecycle",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_collections",
-        "intmap_negative_zero_positive_and_extreme_keys",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    // std.math at the type extremes (RUE-1708). Each case reports per-width
-    // answers on stdout, since the bugs produced traps and wrong booleans
-    // rather than distinguishable exit codes. `math_is_prime_small_and_negative`
-    // accumulates its answer into a `StrBuf` before printing, so the runtime
-    // output boundary is the first unsupported effect.
-    Entry::new(
-        "cli.std_core",
-        "math_gcd_at_type_min",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_core",
-        "math_gcd_signs_zero_and_unsigned",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_core",
-        "math_gcd_unrepresentable_result_panics",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_core",
-        "math_is_prime_at_type_maxima",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_core",
-        "math_is_prime_small_and_negative",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_core",
-        "math_lcm_zero_and_type_min",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
         &[],
     ),
     // std.env (RUE-935): argv/envp are captured process state, so the oracle
@@ -591,43 +402,6 @@ const ENTRIES: &[Entry] = &[
         external(ExternalDependencyKind::SystemCall),
         &[],
     ),
-    // std.fmt.to_radix's base contract (RUE-1707). The three in-contract cases
-    // render digits to stdout, which the oracle model cannot follow past the
-    // `StrBuf` copy or the `println`. `to_radix_base_1000_panics` joins them
-    // because it deliberately prints a line BEFORE the guard fires; the other
-    // out-of-contract cases (base 0/1/17/u64::MAX) produce no stdout at all and
-    // assert only the `@panic` trap, which is a harness observation rather than
-    // oracle debt, so they are absent here by design.
-    Entry::new(
-        "cli.std_fmt_radix",
-        "to_radix_all_bases_2_through_16",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_fmt_radix",
-        "to_radix_base_1000_panics",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_fmt_radix",
-        "to_radix_u64_max_at_contract_edges",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_fmt_radix",
-        "to_radix_zero_at_every_legal_base",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_m3",
-        "std_strbuf_formatting_and_text_consumers",
-        runtime_call(UnsupportedRuntimeCallKind::Print),
-        &[],
-    ),
     Entry::new(
         "cli.std_net_tcp",
         "tcp_connection_refused",
@@ -652,52 +426,18 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::PointerRead),
         &[],
     ),
+    // Output observation is modeled now; this case still reaches its genuine
+    // text parsing boundary while formatting the StrBuf consumers.
     Entry::new(
-        "cli.strbuf_library",
-        "strbuf_new_push_str_len_print",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.strbuf_library",
-        "strbuf_with_capacity_concat",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.string_phase1",
-        "to_string_all_integer_widths",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.string_phase1",
-        "to_string_i32_no_cast_needed",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.try_operator",
-        "try_string_payload",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "cli.try_operator",
-        "try_unwrap_and_short_circuit",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
+        "cli.std_m3",
+        "std_strbuf_formatting_and_text_consumers",
+        intrinsic(UnsupportedIntrinsicKind::ParseI32),
         &[],
     ),
     Entry::new(
         "cli.unit_fields",
         "std_option_and_arraybuf_accept_unit",
         intrinsic(UnsupportedIntrinsicKind::PointerWrite),
-        &[],
-    ),
-    Entry::new(
-        "cli.wildcard_payload_binding",
-        "discarded_non_copy_payload_drops_once",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
         &[],
     ),
     Entry::new(
@@ -794,10 +534,6 @@ fn render_kind(kind: ModelGapKind) -> String {
 
 const fn intrinsic(kind: UnsupportedIntrinsicKind) -> ModelGapKind {
     ModelGapKind::Semantic(SemanticGapKind::Intrinsic(kind))
-}
-
-const fn runtime_call(kind: UnsupportedRuntimeCallKind) -> ModelGapKind {
-    ModelGapKind::Semantic(SemanticGapKind::RuntimeCall(kind))
 }
 
 const fn external(kind: ExternalDependencyKind) -> ModelGapKind {

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -1,10 +1,7 @@
 //! Exact model-gap inventory for the expanded `rue-spec` corpus.
 
 use super::{InventoryScope, ModelGapAudit, ModelGapRegistration};
-use rue_oracle::{
-    ExternalDependencyKind, ModelGapKind, SemanticGapKind, UnsupportedIntrinsicKind,
-    UnsupportedRuntimeCallKind,
-};
+use rue_oracle::{ExternalDependencyKind, ModelGapKind, SemanticGapKind, UnsupportedIntrinsicKind};
 use std::fmt;
 
 /// Stable spec-corpus identity. The case name is the post-template-expansion
@@ -346,36 +343,6 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::ParseI64),
         &[],
     ),
-    Entry::new(
-        "types.strings",
-        "print_borrows_argument_string",
-        runtime_call(UnsupportedRuntimeCallKind::Print),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "print_empty_writes_nothing_println_empty_writes_newline",
-        runtime_call(UnsupportedRuntimeCallKind::Print),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "print_writes_bytes_without_newline",
-        runtime_call(UnsupportedRuntimeCallKind::Print),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "println_appends_single_newline",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "println_composes_with_to_string_and_concat",
-        runtime_call(UnsupportedRuntimeCallKind::Println),
-        &[],
-    ),
 ];
 
 pub(crate) fn audit(scope: InventoryScope) -> ModelGapAudit<CaseId> {
@@ -434,10 +401,6 @@ fn render_kind(kind: ModelGapKind) -> String {
 
 const fn intrinsic(kind: UnsupportedIntrinsicKind) -> ModelGapKind {
     ModelGapKind::Semantic(SemanticGapKind::Intrinsic(kind))
-}
-
-const fn runtime_call(kind: UnsupportedRuntimeCallKind) -> ModelGapKind {
-    ModelGapKind::Semantic(SemanticGapKind::RuntimeCall(kind))
 }
 
 const fn external(kind: ExternalDependencyKind) -> ModelGapKind {

--- a/crates/rue-oracle/BUCK
+++ b/crates/rue-oracle/BUCK
@@ -6,6 +6,7 @@ rue_crate(
         "//crates/rue-compiler:rue-compiler",
         "//crates/rue-cfg:rue-cfg",
         "//crates/rue-air:rue-air",
+        "//crates/rue-runtime-abi:rue-runtime-abi",
         "//third-party:lasso",
     ],
 )

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -55,11 +55,13 @@
 //! Generated-program mode has the stronger promise that no `Unsupported` kind
 //! is valid and reports every one as a generator-contract failure.
 //!
-//! - **All other CFG intrinsics.** The `Intrinsic` arm models `@dbg`, `@panic`,
-//!   `@assert`, compiler-inserted slice bounds checks, and the deterministic
-//!   heap/raw-pointer representation paths. Nondeterministic input and host
-//!   effects (`@read_line`, `@random_*`, and `@syscall`) remain typed gaps, as
-//!   do unsupported layout and external-effect boundaries.
+//! - **CFG intrinsics and runtime output.** The `Intrinsic` arm models `@dbg`,
+//!   `@panic`, `@assert`, compiler-inserted slice bounds checks, deterministic
+//!   heap/raw-pointer representation paths, and the exact target `write(1, ..)`
+//!   syscall shape. Nondeterministic input and host effects (`@read_line`,
+//!   `@random_*`, and all other `@syscall` calls) remain typed gaps, as do
+//!   unsupported layout and external-effect boundaries. String print/println
+//!   runtime calls append to the same ordered fd-1 byte trace as modeled writes.
 //! - **`String::capacity`/`reserve`/`with_capacity` capacity behavior** — the
 //!   exact capacity value is implementation-defined, so `capacity` is reported
 //!   as a typed gap rather than guessed. Specified bounds and growth/preservation
@@ -72,6 +74,7 @@ use rue_cfg::{Cfg, CfgArgMode, CfgInstData, CfgValue, Place, PlaceBase, Projecti
 use rue_compiler::{
     CompileErrors, CompileOptions, CompilerSession, PreviewFeatures, SourceSnapshot,
 };
+use rue_runtime_abi::RuntimeTarget;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
@@ -262,8 +265,13 @@ impl fmt::Display for TrapKind {
 pub struct Outcome {
     /// Process exit code (the OS masks the returned `i32` to a `u8`).
     pub exit_code: i32,
-    /// Everything `@dbg` wrote, in order, newline-terminated per call.
+    /// Everything fd 1 received, in order, decoded lossily at the public
+    /// observation boundary.
     pub stdout: String,
+    /// The exact raw bytes observed on fd 1. Differential callers that need
+    /// byte identity must compare this field, rather than the lossy display
+    /// string above.
+    pub stdout_bytes: Vec<u8>,
     /// Everything the modeled runtime wrote to stderr, decoded with the same
     /// lossy UTF-8 boundary as the native differential runner so the resulting
     /// observation remains exactly comparable.
@@ -281,6 +289,15 @@ pub struct Outcome {
 /// remains exact; crossing it is surfaced explicitly and never accepted by
 /// comparing a truncated prefix.
 pub const MAX_STDOUT_BYTES: usize = 256 * 1024;
+
+/// Maximum size of a raw `write(1, ...)` observation that the differential
+/// oracle treats as deterministic.  The bound is the POSIX minimum `PIPE_BUF`:
+/// Within the controlled blocking stdout capture sink, the native runner drains
+/// concurrently and does not deliver signals to the child; combined with the
+/// POSIX atomicity guarantee for writes of this size or less, that gives a
+/// stable byte trace. Larger writes are retained as external syscall
+/// dependencies rather than guessing about an OS short write.
+pub const MAX_MODELED_STDOUT_WRITE_BYTES: usize = 512;
 
 /// Maximum number of raw bytes accepted from modeled runtime stderr.
 ///
@@ -708,13 +725,14 @@ fn run_state_with_output_limits(
             .spawn_scoped(scope, || {
                 Interp {
                     state: &state,
-                    stdout: String::new(),
+                    stdout_trace: Vec::new(),
                     stdout_bytes: 0,
                     stdout_cap,
                     stderr_cap,
                     budget,
                     depth: 0,
                     heap: Vec::new(),
+                    small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
                     heap_metadata_bytes: 0,
                 }
                 .run()
@@ -749,6 +767,32 @@ const STEP_BUDGET: u64 = 50_000_000;
 /// activations that fit in `WORKER_STACK`, so the bound always wins the race
 /// against stack exhaustion.
 const MAX_DEPTH: u32 = 2_000;
+
+/// The direct-write syscall number for the target executing this oracle. The
+/// oracle only models the ABI it can identify from its own compiled target;
+/// target-specific corpus filters remain authoritative for cross-target cases.
+const fn host_write_syscall_number() -> Option<u64> {
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        Some(RuntimeTarget::X86_64Linux.write_syscall_number())
+    }
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    {
+        Some(RuntimeTarget::Aarch64Linux.write_syscall_number())
+    }
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        Some(RuntimeTarget::Aarch64Macos.write_syscall_number())
+    }
+    #[cfg(not(any(
+        all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "aarch64"),
+        all(target_os = "macos", target_arch = "aarch64"),
+    )))]
+    {
+        None
+    }
+}
 
 /// Byte-address space reserved per abstract heap allocation when synthesizing a
 /// `@ptr_to_int` value. Comfortably larger than [`MAX_ALLOC_BYTES`] so an
@@ -809,6 +853,10 @@ enum Value {
 struct PtrTarget {
     /// Index of the owning [`Allocation`] in [`Interp::heap`].
     alloc: usize,
+    /// Allocation lifetime generation. Recycled storage keeps its synthetic
+    /// address, but every fresh lifetime gets a new generation so stale
+    /// pointers and pointer-derived integers cannot regain provenance.
+    generation: u64,
     /// Physical byte offset from the allocation base. This is the sole
     /// addressing authority for the representation-byte heap.
     byte_offset: u64,
@@ -861,11 +909,70 @@ struct Allocation {
     /// undefined use-after-free remains a typed oracle gap rather than
     /// receiving a deterministic value that native execution does not promise.
     freed: bool,
+    /// Lifetime generation for the synthetic address represented by this cell.
+    generation: u64,
+    /// Next entry in the explicit per-size-class free-list stack. The list is
+    /// linked through allocation cells so its order does not depend on heap
+    /// vector position.
+    free_list_next: Option<usize>,
     /// Allocator family and contract metadata. Promoted stack/text backing is
     /// never eligible for `@free`/`@realloc`/`@resize`.
     origin: AllocationOrigin,
     declared_alignment: u64,
     owner_depth: Option<u32>,
+}
+
+/// The runtime allocator's small-block class identity. The oracle retains
+/// abstract allocation bytes, but reuse must follow the same power-of-two
+/// class policy as `rue-allocator` so pointer-identity observations remain
+/// truthful after a matching `@free`/`@alloc` sequence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SmallAllocationClass {
+    Block(usize),
+}
+
+const ORACLE_PAGE_SIZE: usize = 4096;
+const ORACLE_MAX_SMALL_SIZE: usize = 16 * 1024;
+const ORACLE_MIN_CLASS_SIZE: usize = 8;
+const ORACLE_MIN_CLASS_SHIFT: usize = ORACLE_MIN_CLASS_SIZE.trailing_zeros() as usize;
+const ORACLE_MAX_CLASS_SHIFT: usize = ORACLE_MAX_SMALL_SIZE.trailing_zeros() as usize;
+const ORACLE_SMALL_CLASS_COUNT: usize = ORACLE_MAX_CLASS_SHIFT - ORACLE_MIN_CLASS_SHIFT + 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AllocationKind {
+    Small(usize),
+    Direct(usize),
+}
+
+fn small_allocation_class(size: i128, align: u64) -> Option<SmallAllocationClass> {
+    if size <= 0 || align == 0 || !align.is_power_of_two() || align as usize > ORACLE_PAGE_SIZE {
+        return None;
+    }
+    let size = usize::try_from(size).ok()?;
+    if size > ORACLE_MAX_SMALL_SIZE {
+        return None;
+    }
+    let required = size.max(align as usize).max(ORACLE_MIN_CLASS_SIZE);
+    let block_size = required.next_power_of_two();
+    (block_size <= ORACLE_MAX_SMALL_SIZE).then_some(SmallAllocationClass::Block(block_size))
+}
+
+fn allocation_kind(size: i128, align: u64) -> Option<AllocationKind> {
+    let size = usize::try_from(size).ok()?;
+    if size == 0 {
+        return None;
+    }
+    if let Some(SmallAllocationClass::Block(block_size)) =
+        small_allocation_class(size as i128, align)
+    {
+        return Some(AllocationKind::Small(block_size));
+    }
+    let mapping_size = size.checked_add(ORACLE_PAGE_SIZE - 1)? / ORACLE_PAGE_SIZE;
+    Some(AllocationKind::Direct(mapping_size * ORACLE_PAGE_SIZE))
+}
+
+fn small_class_index(block_size: usize) -> usize {
+    block_size.trailing_zeros() as usize - ORACLE_MIN_CLASS_SHIFT
 }
 
 impl Value {
@@ -1046,9 +1153,9 @@ fn unsupported_runtime_call_kind(kind: RuntimeCallKind) -> Option<UnsupportedRun
 
 struct Interp<'a> {
     state: &'a CompileState,
-    stdout: String,
-    /// Raw emitted byte count. `stdout.len()` can be larger because invalid
-    /// UTF-8 bytes render as the three-byte replacement character.
+    /// Canonical ordered raw-byte observation trace for file descriptor 1.
+    stdout_trace: Vec<u8>,
+    /// Raw emitted byte count, independent of decoded string length.
     stdout_bytes: usize,
     stdout_cap: usize,
     /// Maximum raw bytes retained for the single terminating runtime stderr
@@ -1066,6 +1173,7 @@ struct Interp<'a> {
     /// the interpreter (not a frame) so a pointer read across a call boundary
     /// still resolves after the address is passed to a callee.
     heap: Vec<Allocation>,
+    small_free_heads: [Option<usize>; ORACLE_SMALL_CLASS_COUNT],
     heap_metadata_bytes: usize,
 }
 
@@ -1108,6 +1216,7 @@ impl<'a> Interp<'a> {
     fn canonical_null_marker() -> PtrTarget {
         PtrTarget {
             alloc: usize::MAX,
+            generation: 0,
             byte_offset: 0,
         }
     }
@@ -1227,12 +1336,49 @@ impl<'a> Interp<'a> {
     /// through the same `byte_at` path the runtime's byte helpers model, so a
     /// text read rides entirely on the modeled allocation store.
     fn text_bytes(&self, val: &Value) -> Step<Vec<u8>> {
+        self.text_bytes_bounded(val, None)
+    }
+
+    /// Read a text header while enforcing an output-specific payload bound
+    /// before allocating or walking the claimed range. This keeps malformed
+    /// length words from turning a bounded failure into an unbounded
+    /// allocation or byte loop.
+    fn text_bytes_bounded(&self, val: &Value, max_len: Option<usize>) -> Step<Vec<u8>> {
         let gap = unsupported_intrinsic_kind("ptr_read");
         let Some((target, len)) = Self::text_ptr_len(val) else {
             return Err(unsupported(gap, "text value is not a materialized header"));
         };
         if len <= 0 {
             return Ok(Vec::new());
+        }
+        let len = match usize::try_from(len) {
+            Ok(len) => len,
+            Err(_) if max_len.is_some() => {
+                return Err(unsupported(
+                    UnsupportedKind::ResourceLimit(ResourceLimitKind::StdoutBytes),
+                    format!(
+                        "stdout byte limit exceeded ({}-byte limit)",
+                        self.stdout_cap
+                    ),
+                ));
+            }
+            Err(_) => {
+                return Err(unsupported(
+                    gap,
+                    "text header length exceeds the host addressable range",
+                ));
+            }
+        };
+        if let Some(max_len) = max_len {
+            if len > max_len {
+                return Err(unsupported(
+                    UnsupportedKind::ResourceLimit(ResourceLimitKind::StdoutBytes),
+                    format!(
+                        "stdout byte limit exceeded ({}-byte limit)",
+                        self.stdout_cap
+                    ),
+                ));
+            }
         }
         let Some(target) = target else {
             // A non-null length over a null buffer is a malformed header.
@@ -1241,9 +1387,9 @@ impl<'a> Interp<'a> {
                 "text header has a null buffer with nonzero length",
             ));
         };
-        let mut bytes = Vec::with_capacity(len as usize);
+        let mut bytes = Vec::with_capacity(len);
         for i in 0..len {
-            bytes.push(self.byte_at(&target, i, gap)?);
+            bytes.push(self.byte_at(&target, i as i128, gap)?);
         }
         Ok(bytes)
     }
@@ -1275,6 +1421,7 @@ impl<'a> Interp<'a> {
             );
             Value::Ptr(Some(PtrTarget {
                 alloc,
+                generation: self.heap[alloc].generation,
                 byte_offset: 0,
             }))
         };
@@ -1306,6 +1453,7 @@ impl<'a> Interp<'a> {
         );
         Value::Ptr(Some(PtrTarget {
             alloc,
+            generation: self.heap[alloc].generation,
             byte_offset: 0,
         }))
     }
@@ -1340,6 +1488,9 @@ impl<'a> Interp<'a> {
                         .is_some_and(|(pointee, _)| pointee == Type::U8)
                         && arg_types[1] == Type::U64
                 } else {
+                    // Aggregate helpers are emitted only for the canonical
+                    // `str`/`Str(N)` view ABI. `StrBuf` always takes the
+                    // projected pointer/length route.
                     self.is_str_like_type(arg_types[0])
                 };
                 text_matches && result_ty == Type::UNIT
@@ -1390,6 +1541,184 @@ impl<'a> Interp<'a> {
         } else {
             UnsupportedKind::ContractViolation(ContractViolationKind::RuntimeCallSignature)
         }
+    }
+
+    /// Execute the compiler's string output helpers against the one canonical
+    /// fd-1 byte trace. Aggregate calls carry a materialized text header;
+    /// projected calls carry the same header's byte pointer and length after
+    /// the native lowering has selected the projected ABI. Both routes read
+    /// through the representation-byte heap, preserving provenance,
+    /// initialization, liveness, bounds, and exact byte order.
+    fn eval_runtime_output_call(
+        &mut self,
+        kind: RuntimeCallKind,
+        args: &[Value],
+        arg_types: &[Type],
+    ) -> Step<Value> {
+        let projected = matches!(
+            kind,
+            RuntimeCallKind::StrPrintProjected | RuntimeCallKind::StrPrintlnProjected
+        );
+        let remaining = self.stdout_cap.saturating_sub(self.stdout_bytes);
+        let newline_bytes = if matches!(
+            kind,
+            RuntimeCallKind::StrPrintlnAggregate | RuntimeCallKind::StrPrintlnProjected
+        ) {
+            1
+        } else {
+            0
+        };
+        let max_payload = remaining.saturating_sub(newline_bytes);
+        let (bytes, newline) = if projected {
+            let [Value::Ptr(pointer), Value::Int(length)] = args else {
+                return Err(unsupported(
+                    UnsupportedKind::ContractViolation(ContractViolationKind::RuntimeCallSignature),
+                    "projected output runtime value shape",
+                ));
+            };
+            if *length < 0 {
+                return Err(unsupported(
+                    UnsupportedKind::ContractViolation(ContractViolationKind::RuntimeCallSignature),
+                    "projected output has negative length",
+                ));
+            }
+            let length = usize::try_from(*length).map_err(|_| {
+                unsupported(
+                    UnsupportedKind::ResourceLimit(ResourceLimitKind::StdoutBytes),
+                    format!(
+                        "stdout byte limit exceeded ({}-byte limit)",
+                        self.stdout_cap
+                    ),
+                )
+            })?;
+            if length > max_payload {
+                return Err(unsupported(
+                    UnsupportedKind::ResourceLimit(ResourceLimitKind::StdoutBytes),
+                    format!(
+                        "stdout byte limit exceeded ({}-byte limit)",
+                        self.stdout_cap
+                    ),
+                ));
+            }
+            if arg_types.len() != 2 {
+                return Err(unsupported(
+                    UnsupportedKind::ContractViolation(ContractViolationKind::RuntimeCallArity),
+                    "projected output runtime arity",
+                ));
+            }
+            let bytes = if length == 0 {
+                Vec::new()
+            } else {
+                let Some(pointer) = pointer else {
+                    return Err(unsupported(
+                        unsupported_intrinsic_kind("ptr_read"),
+                        "projected output has a null buffer with nonzero length",
+                    ));
+                };
+                (0..length)
+                    .map(|offset| {
+                        self.byte_at(
+                            pointer,
+                            offset as i128,
+                            unsupported_intrinsic_kind("ptr_read"),
+                        )
+                    })
+                    .collect::<Step<Vec<_>>>()?
+            };
+            (bytes, matches!(kind, RuntimeCallKind::StrPrintlnProjected))
+        } else {
+            let [value] = args else {
+                return Err(unsupported(
+                    UnsupportedKind::ContractViolation(ContractViolationKind::RuntimeCallArity),
+                    "aggregate output runtime arity",
+                ));
+            };
+            let bytes = self.text_bytes_bounded(value, Some(max_payload))?;
+            (bytes, matches!(kind, RuntimeCallKind::StrPrintlnAggregate))
+        };
+
+        self.observe_stdout(&bytes)?;
+        if newline {
+            self.observe_stdout(b"\n")?;
+        }
+        Ok(Value::Unit)
+    }
+
+    /// Model only a direct `write(1, buf, len)` syscall to the controlled,
+    /// blocking stdout capture sink. The native runner concurrently drains
+    /// that blocking pipe and does not deliver signals to the child; together
+    /// with the POSIX `PIPE_BUF` bound, this makes a small write atomic and
+    /// deterministic. Larger writes remain a typed external dependency
+    /// because an arbitrary OS short write is not an oracle contract. The
+    /// syscall number and argument order are target ABI facts; every other
+    /// syscall, descriptor, pointer shape, and target ambiguity remains
+    /// external. A valid pointer is resolved through the representation-byte
+    /// heap before any output is observed.
+    fn eval_stdout_syscall(&mut self, args: &[Value]) -> Step<Value> {
+        let gap = UnsupportedKind::ExternalDependency(ExternalDependencyKind::SystemCall);
+        let Some(write_nr) = host_write_syscall_number() else {
+            return Err(unsupported(
+                gap,
+                "stdout syscall ABI is not modeled for this host",
+            ));
+        };
+        if args.len() != 4 {
+            return Err(unsupported(
+                gap,
+                "syscall is not the target write(fd, buffer, length) shape",
+            ));
+        }
+        let syscall_number = args[0].as_int();
+        let fd = args[1].as_int();
+        if syscall_number != write_nr as i128 {
+            return Err(unsupported(
+                gap,
+                "syscall is not the target stdout write number",
+            ));
+        }
+        if fd != 1 {
+            return Err(unsupported(gap, "syscall write descriptor is not stdout"));
+        }
+        let length = args[3].as_int();
+        if length < 0 {
+            return Err(unsupported(gap, "syscall write length is negative"));
+        }
+        let length = u64::try_from(length)
+            .ok()
+            .and_then(|length| usize::try_from(length).ok())
+            .ok_or_else(|| unsupported(gap, "syscall write length exceeds host range"))?;
+        if length > MAX_MODELED_STDOUT_WRITE_BYTES {
+            return Err(unsupported(
+                gap,
+                "syscall write exceeds the deterministic atomic stdout bound",
+            ));
+        }
+        if length > self.stdout_cap.saturating_sub(self.stdout_bytes) {
+            return Err(unsupported(
+                UnsupportedKind::ResourceLimit(ResourceLimitKind::StdoutBytes),
+                "syscall write exceeds the bounded stdout observation",
+            ));
+        }
+        if length == 0 {
+            return Ok(Value::Int(0));
+        }
+
+        let target = match &args[2] {
+            Value::AddressInt { value, provenance } => self
+                .address_target(*value as u128, &provenance.0)
+                .ok_or_else(|| unsupported(gap, "syscall write pointer has invalid provenance"))?,
+            _ => {
+                return Err(unsupported(
+                    gap,
+                    "syscall write pointer is not pointer-derived",
+                ));
+            }
+        };
+        let bytes = (0..length)
+            .map(|offset| self.byte_at(&target, offset as i128, gap))
+            .collect::<Step<Vec<_>>>()?;
+        self.observe_stdout(&bytes)?;
+        Ok(Value::Int(length as i128))
     }
 
     fn pointer_pointee(&self, ty: Type) -> Option<(Type, bool)> {
@@ -1955,26 +2284,19 @@ impl<'a> Interp<'a> {
         // (RUE-1010 §6.13); every other value uses the scalar `format_dbg`.
         // Reserve one byte for the trailing newline; the comparison form avoids
         // overflowing while computing `len + 1`, and rejecting an oversized
-        // value before decoding also bounds that temporary allocation.
-        let (formatted, emitted_len) = if self.is_text_type(ty) {
-            let bytes = self.text_bytes(val)?;
-            if bytes.len() >= remaining {
-                return Err(unsupported(
-                    UnsupportedKind::ResourceLimit(ResourceLimitKind::StdoutBytes),
-                    format!(
-                        "stdout byte limit exceeded ({}-byte limit)",
-                        self.stdout_cap
-                    ),
-                ));
-            }
-            let len = bytes.len();
-            (String::from_utf8_lossy(&bytes).into_owned(), len)
+        // value before assembling output also bounds that temporary allocation.
+        let output = if self.is_text_type(ty) {
+            let bytes = self.text_bytes_bounded(val, Some(remaining.saturating_sub(1)))?;
+            // Text output is a byte observation, not a string formatting
+            // operation. Preserve invalid UTF-8 and every original byte in
+            // the canonical trace; the public `Outcome.stdout` display may
+            // decode it lossily only after execution has completed.
+            bytes
         } else {
             let formatted = format_dbg(val, ty)?;
-            let len = formatted.len();
-            (formatted.into_owned(), len)
+            formatted.into_owned().into_bytes()
         };
-        if emitted_len >= remaining {
+        if output.len() >= remaining {
             return Err(unsupported(
                 UnsupportedKind::ResourceLimit(ResourceLimitKind::StdoutBytes),
                 format!(
@@ -1984,9 +2306,30 @@ impl<'a> Interp<'a> {
             ));
         }
 
-        self.stdout.push_str(&formatted);
-        self.stdout.push('\n');
-        self.stdout_bytes += emitted_len + 1;
+        let mut observed = Vec::with_capacity(output.len() + 1);
+        observed.extend_from_slice(&output);
+        observed.push(b'\n');
+        self.observe_stdout(&observed)
+    }
+
+    /// Append one ordered fd-1 observation, enforcing the shared raw-byte
+    /// bound. A write crossing the bound records exactly the prefix that fits
+    /// before returning a hard resource failure; callers never compare a
+    /// silently truncated output as agreement.
+    fn observe_stdout(&mut self, bytes: &[u8]) -> Step<()> {
+        let remaining = self.stdout_cap.saturating_sub(self.stdout_bytes);
+        let observed = bytes.len().min(remaining);
+        self.stdout_trace.extend_from_slice(&bytes[..observed]);
+        self.stdout_bytes += observed;
+        if observed != bytes.len() {
+            return Err(unsupported(
+                UnsupportedKind::ResourceLimit(ResourceLimitKind::StdoutBytes),
+                format!(
+                    "stdout byte limit exceeded ({}-byte limit)",
+                    self.stdout_cap
+                ),
+            ));
+        }
         Ok(())
     }
 
@@ -1994,7 +2337,8 @@ impl<'a> Interp<'a> {
         match self.call("main", &[]) {
             Ok((v, _)) => Ok(Outcome {
                 exit_code: (v.as_int() & 0xFF) as i32,
-                stdout: self.stdout,
+                stdout: String::from_utf8_lossy(&self.stdout_trace).into_owned(),
+                stdout_bytes: self.stdout_trace.clone(),
                 stderr: String::new(),
                 panic: None,
             }),
@@ -2010,7 +2354,8 @@ impl<'a> Interp<'a> {
                 }
                 Ok(Outcome {
                     exit_code: 101,
-                    stdout: self.stdout,
+                    stdout: String::from_utf8_lossy(&self.stdout_trace).into_owned(),
+                    stdout_bytes: self.stdout_trace.clone(),
                     stderr: panic.stderr,
                     panic: Some(panic.kind),
                 })
@@ -3108,16 +3453,17 @@ impl<'a> Interp<'a> {
                     )?
                     .expect("preflight recognized this String builtin")
                 } else if missing_call_kind.is_some() {
-                    return Err(unsupported(
-                        self.classify_unsupported_runtime_call(
-                            runtime.expect("typed unsupported runtime call"),
-                            &argvals,
-                            &arg_types,
-                            &arg_modes,
-                            ty,
-                        ),
-                        format!("call to '{fname}'"),
-                    ));
+                    let runtime = runtime.expect("typed runtime output call");
+                    // Static validation above establishes the compiler/runtime
+                    // ABI. Keep the dynamic value check fail-closed before the
+                    // modeled output path executes.
+                    let kind = self.classify_unsupported_runtime_call(
+                        runtime, &argvals, &arg_types, &arg_modes, ty,
+                    );
+                    if kind.model_gap().is_none() {
+                        return Err(unsupported(kind, format!("call to '{fname}'")));
+                    }
+                    self.eval_runtime_output_call(runtime, &argvals, &arg_types)?
                 } else {
                     let typed_args: Vec<(Value, Type, CfgArgMode)> = argvals
                         .into_iter()
@@ -3176,6 +3522,15 @@ impl<'a> Interp<'a> {
                     // reinterpretation is exactly a `to_bits`/`from_bits` round
                     // trip in the value model (RUE-952).
                     self.eval_bit_cast(cfg, frame, &args, ty)?
+                } else if iname == "syscall" {
+                    let kind = self.classify_unsupported_intrinsic(cfg, v, &iname, &args, ty);
+                    if kind
+                        != UnsupportedKind::ExternalDependency(ExternalDependencyKind::SystemCall)
+                    {
+                        return Err(unsupported(kind, format!("intrinsic @{iname}")));
+                    }
+                    let values = self.eval_all(cfg, frame, &args)?;
+                    self.eval_stdout_syscall(&values)?
                 } else if iname != "dbg" {
                     // Classify first: the same static arity/signature validation
                     // that gates a model-gap registration also gates execution, so
@@ -3877,6 +4232,7 @@ impl<'a> Interp<'a> {
                 })?;
             let target = PtrTarget {
                 alloc: a,
+                generation: self.heap[a].generation,
                 byte_offset,
             };
             return self.ptr_cell_write(
@@ -4201,11 +4557,44 @@ impl<'a> Interp<'a> {
             provenance,
             root_ty,
             freed: false,
+            generation: 1,
+            free_list_next: None,
             origin,
             declared_alignment,
             owner_depth: (origin == AllocationOrigin::Promoted).then_some(self.depth),
         });
         self.heap.len() - 1
+    }
+
+    /// Return the head of a size-class free list. Lists are linked through the
+    /// freed allocation cells, while the head itself is stored by class so a
+    /// reuse never scans the abstract heap.
+    fn small_free_list_head(&self, block_size: usize) -> Option<usize> {
+        self.small_free_heads[small_class_index(block_size)]
+    }
+
+    fn push_small_free_list(&mut self, alloc: usize) {
+        let Some(SmallAllocationClass::Block(block_size)) = self
+            .heap
+            .get(alloc)
+            .and_then(|allocation| {
+                (allocation.origin == AllocationOrigin::Heap).then(|| {
+                    small_allocation_class(
+                        allocation.bytes.len() as i128,
+                        allocation.declared_alignment,
+                    )
+                })
+            })
+            .flatten()
+        else {
+            if let Some(allocation) = self.heap.get_mut(alloc) {
+                allocation.free_list_next = None;
+            }
+            return;
+        };
+        let head = self.small_free_list_head(block_size);
+        self.heap[alloc].free_list_next = head;
+        self.small_free_heads[small_class_index(block_size)] = Some(alloc);
     }
 
     /// Encode one typed value using Rue's target representation. All integer
@@ -4846,7 +5235,7 @@ impl<'a> Interp<'a> {
             return None;
         }
         let allocation = self.heap.get(alloc)?;
-        if allocation.freed {
+        if allocation.generation != provenance.generation || allocation.freed {
             return None;
         }
         let byte_off = u64::try_from(n % HEAP_SEG).ok()?;
@@ -4855,8 +5244,41 @@ impl<'a> Interp<'a> {
         }
         Some(PtrTarget {
             alloc,
+            generation: allocation.generation,
             byte_offset: byte_off,
         })
+    }
+
+    fn allocation_for_target(&self, target: &PtrTarget, gap: UnsupportedKind) -> Step<&Allocation> {
+        let allocation = self
+            .heap
+            .get(target.alloc)
+            .ok_or_else(|| unsupported(gap, "pointer to unknown allocation"))?;
+        if allocation.generation != target.generation {
+            return Err(unsupported(gap, "pointer has stale allocation provenance"));
+        }
+        if allocation.freed {
+            return Err(unsupported(gap, "pointer read after free"));
+        }
+        Ok(allocation)
+    }
+
+    fn allocation_for_target_mut(
+        &mut self,
+        target: &PtrTarget,
+        gap: UnsupportedKind,
+    ) -> Step<&mut Allocation> {
+        let allocation = self
+            .heap
+            .get_mut(target.alloc)
+            .ok_or_else(|| unsupported(gap, "pointer to unknown allocation"))?;
+        if allocation.generation != target.generation {
+            return Err(unsupported(gap, "pointer has stale allocation provenance"));
+        }
+        if allocation.freed {
+            return Err(unsupported(gap, "pointer read after free"));
+        }
+        Ok(allocation)
     }
 
     /// Read the typed view at `target` from canonical bytes.
@@ -4880,13 +5302,7 @@ impl<'a> Interp<'a> {
         gap: UnsupportedKind,
         aligned: bool,
     ) -> Step<Value> {
-        let alloc = self
-            .heap
-            .get(target.alloc)
-            .ok_or_else(|| unsupported(gap, "pointer to unknown allocation"))?;
-        if alloc.freed {
-            return Err(unsupported(gap, "pointer read after free"));
-        }
+        let alloc = self.allocation_for_target(target, gap)?;
         let layout = self
             .try_layout(ty)
             .ok_or_else(|| unsupported(gap, "pointee has no target layout"))?;
@@ -4967,13 +5383,7 @@ impl<'a> Interp<'a> {
         if aligned && !target.byte_offset.is_multiple_of(alignment) {
             return Err(unsupported(gap, "misaligned typed write"));
         }
-        let alloc = self
-            .heap
-            .get_mut(target.alloc)
-            .ok_or_else(|| unsupported(gap, "pointer to unknown allocation"))?;
-        if alloc.freed {
-            return Err(unsupported(gap, "pointer write after free"));
-        }
+        let alloc = self.allocation_for_target_mut(target, gap)?;
         let start = usize::try_from(target.byte_offset)
             .map_err(|_| unsupported(gap, "pointer write offset exceeds host range"))?;
         let end = start
@@ -4990,13 +5400,7 @@ impl<'a> Interp<'a> {
 
     /// Read one byte from a byte-store allocation at `target.byte_offset + offset`.
     fn byte_at(&self, target: &PtrTarget, offset: i128, gap: UnsupportedKind) -> Step<u8> {
-        let alloc = self
-            .heap
-            .get(target.alloc)
-            .ok_or_else(|| unsupported(gap, "pointer to unknown allocation"))?;
-        if alloc.freed {
-            return Err(unsupported(gap, "byte read after free"));
-        }
+        let alloc = self.allocation_for_target(target, gap)?;
         let at = (target.byte_offset as i128)
             .checked_add(offset)
             .ok_or_else(|| unsupported(gap, "byte offset overflow"))?;
@@ -5017,13 +5421,7 @@ impl<'a> Interp<'a> {
         count: usize,
         gap: UnsupportedKind,
     ) -> Step<(usize, usize, usize)> {
-        let allocation = self
-            .heap
-            .get(target.alloc)
-            .ok_or_else(|| unsupported(gap, "pointer to unknown allocation"))?;
-        if allocation.freed {
-            return Err(unsupported(gap, "byte access after free"));
-        }
+        let allocation = self.allocation_for_target(target, gap)?;
         let start = usize::try_from(target.byte_offset)
             .map_err(|_| unsupported(gap, "byte offset exceeds host range"))?;
         let end = start
@@ -5098,7 +5496,11 @@ impl<'a> Interp<'a> {
                     "place projection layout",
                 )
             })?;
-        Ok(PtrTarget { alloc, byte_offset })
+        Ok(PtrTarget {
+            alloc,
+            generation: self.heap[alloc].generation,
+            byte_offset,
+        })
     }
 
     /// `@bitCast` (RUE-952, spec 4.13:118): reinterpret the operand's
@@ -5259,13 +5661,7 @@ impl<'a> Interp<'a> {
                 let by = self.eval(cfg, frame, args[1])?.as_int();
                 match p {
                     Value::Ptr(Some(mut t)) => {
-                        let allocation = self
-                            .heap
-                            .get(t.alloc)
-                            .ok_or_else(|| unsupported(gap, "pointer offset allocation missing"))?;
-                        if allocation.freed {
-                            return Err(unsupported(gap, "pointer offset after free"));
-                        }
+                        let allocation = self.allocation_for_target(&t, gap)?;
                         let operand_ty = cfg.get_inst(args[0]).ty;
                         let (pointee_ty, _) = self
                             .pointer_pointee(operand_ty)
@@ -5415,7 +5811,7 @@ impl<'a> Interp<'a> {
     fn checked_alignment(&self, align: i128, gap: UnsupportedKind) -> Step<u64> {
         let align =
             u64::try_from(align).map_err(|_| unsupported(gap, "invalid allocation alignment"))?;
-        if align == 0 || !align.is_power_of_two() {
+        if align == 0 || !align.is_power_of_two() || align > ORACLE_PAGE_SIZE as u64 {
             return Err(unsupported(gap, "invalid allocation alignment"));
         }
         Ok(align)
@@ -5441,10 +5837,7 @@ impl<'a> Interp<'a> {
                 "allocator operation requires base ptr mut u8",
             ));
         }
-        let allocation = self
-            .heap
-            .get(target.alloc)
-            .ok_or_else(|| unsupported(gap, "allocation missing"))?;
+        let allocation = self.allocation_for_target(&target, gap)?;
         if allocation.origin != AllocationOrigin::Heap {
             return Err(unsupported(gap, "allocation is not allocator-owned"));
         }
@@ -5482,10 +5875,13 @@ impl<'a> Interp<'a> {
         }
         self.validate_allocator_contract(p.clone(), size, align, gap)?;
         if let Value::Ptr(Some(target)) = p {
-            self.heap
+            let allocation = self
+                .heap
                 .get_mut(target.alloc)
-                .ok_or_else(|| unsupported(gap, "allocation missing"))?
-                .freed = true;
+                .ok_or_else(|| unsupported(gap, "allocation missing"))?;
+            allocation.freed = true;
+            allocation.free_list_next = None;
+            self.push_small_free_list(target.alloc);
         }
         Ok(())
     }
@@ -5504,6 +5900,47 @@ impl<'a> Interp<'a> {
                 "allocation exceeds host range",
             )
         })?;
+
+        // `rue-allocator` recycles freed small blocks by power-of-two class.
+        // Reuse the abstract cell itself so pointer identity observes the
+        // same LIFO class behavior as native execution. Direct mappings are
+        // intentionally not reused: their OS address identity is not a
+        // deterministic language observation.
+        if let Some(SmallAllocationClass::Block(block_size)) = small_allocation_class(size, align)
+            && let Some(alloc) = self.small_free_list_head(block_size)
+        {
+            let old_len = self.heap[alloc].bytes.len();
+            let generation = self.heap[alloc].generation.checked_add(1).ok_or_else(|| {
+                unsupported(
+                    UnsupportedKind::ResourceLimit(ResourceLimitKind::InterpreterSteps),
+                    "allocation lifetime generation exhausted",
+                )
+            })?;
+            // Reuse replaces the logical extent. Account for any retained
+            // metadata growth before changing the allocation, so reuse cannot
+            // bypass the global heap-resource bound.
+            if count > old_len {
+                self.reserve_heap_metadata(count - old_len)?;
+            }
+            self.small_free_heads[small_class_index(block_size)] = self.heap[alloc].free_list_next;
+            let allocation = &mut self.heap[alloc];
+            allocation.bytes = vec![0; count];
+            allocation.initialized = vec![zeroed; count];
+            allocation.provenance = vec![None; count];
+            allocation.root_ty = None;
+            allocation.freed = false;
+            allocation.generation = generation;
+            allocation.free_list_next = None;
+            allocation.origin = AllocationOrigin::Heap;
+            allocation.declared_alignment = align;
+            allocation.owner_depth = None;
+            return Ok(Value::Ptr(Some(PtrTarget {
+                alloc,
+                generation,
+                byte_offset: 0,
+            })));
+        }
+
         self.reserve_heap_metadata(count)?;
         let alloc = self.heap_alloc_bytes(
             vec![0; count],
@@ -5515,17 +5952,17 @@ impl<'a> Interp<'a> {
         );
         Ok(Value::Ptr(Some(PtrTarget {
             alloc,
+            generation: self.heap[alloc].generation,
             byte_offset: 0,
         })))
     }
 
-    /// `@realloc`: grow/shrink an allocation, preserving the
-    /// first `min(old, new)` representation bytes and leaving growth
-    /// uninitialized. This
-    /// model keeps shrink-in-place and move-on-grow behavior; native pointer
-    /// identity is deliberately unspecified. Returns null on `new == 0` or allocator failure, leaving the
-    /// original allocation valid (spec 8.6:3), and traps on a `new * stride`
-    /// overflow like the compiled size arithmetic (spec 8.6:1).
+    /// `@realloc`: grow/shrink an allocation according to the runtime
+    /// allocator's size-class and page-mapping rules, preserving the first
+    /// `min(old, new)` representation bytes and leaving growth uninitialized.
+    /// Returns null on `new == 0` or allocator failure, leaving the original
+    /// allocation valid (spec 8.6:3), and traps on a `new * stride` overflow
+    /// like the compiled size arithmetic (spec 8.6:1).
     fn do_realloc(&mut self, p: Value, old_size: i128, align: i128, new_size: i128) -> Step<Value> {
         let align = self.checked_alignment(align, unsupported_intrinsic_kind("realloc"))?;
         if old_size < 0 || new_size < 0 {
@@ -5548,16 +5985,7 @@ impl<'a> Interp<'a> {
             }
             _ => return Ok(Value::Ptr(None)),
         };
-        if self
-            .heap
-            .get(target.alloc)
-            .is_some_and(|allocation| allocation.freed)
-        {
-            return Err(unsupported(
-                unsupported_intrinsic_kind("realloc"),
-                "realloc after free",
-            ));
-        }
+        self.allocation_for_target(&target, unsupported_intrinsic_kind("realloc"))?;
         if target.byte_offset != 0 {
             return Err(unsupported(
                 unsupported_intrinsic_kind("realloc"),
@@ -5592,27 +6020,13 @@ impl<'a> Interp<'a> {
         if new_size == 0 {
             if let Some(alloc) = self.heap.get_mut(target.alloc) {
                 alloc.freed = true;
+                alloc.free_list_next = None;
             }
+            self.push_small_free_list(target.alloc);
             return Ok(Value::Ptr(None));
         }
         if self.alloc_byte_size(new_size, 1)?.is_none() {
             return Ok(Value::Ptr(None));
-        }
-        if new_size <= old_size {
-            let new_len = usize::try_from(new_size).map_err(|_| {
-                unsupported(
-                    unsupported_intrinsic_kind("realloc"),
-                    "realloc size exceeds host range",
-                )
-            })?;
-            let allocation = &mut self.heap[target.alloc];
-            allocation.bytes.truncate(new_len);
-            allocation.initialized.truncate(new_len);
-            allocation.provenance.truncate(new_len);
-            return Ok(Value::Ptr(Some(PtrTarget {
-                alloc: target.alloc,
-                byte_offset: 0,
-            })));
         }
         let new_count = usize::try_from(new_size).map_err(|_| {
             unsupported(
@@ -5621,7 +6035,41 @@ impl<'a> Interp<'a> {
             )
         })?;
         self.materialize_cells_guard(new_size)?;
-        self.reserve_heap_metadata(new_count)?;
+        let old_kind = allocation_kind(old_size, align).ok_or_else(|| {
+            unsupported(
+                unsupported_intrinsic_kind("realloc"),
+                "old allocation has no allocator classification",
+            )
+        })?;
+        let new_kind = allocation_kind(new_size, align).ok_or_else(|| {
+            unsupported(
+                unsupported_intrinsic_kind("realloc"),
+                "new allocation has no allocator classification",
+            )
+        })?;
+
+        // The allocator can relabel storage in place only when both layouts
+        // select the same small class or the same page-rounded mapping.
+        if old_kind == new_kind {
+            let old_len = self.heap[target.alloc].bytes.len();
+            if new_count > old_len {
+                self.reserve_heap_metadata(new_count - old_len)?;
+            }
+            let allocation = &mut self.heap[target.alloc];
+            allocation.bytes.resize(new_count, 0);
+            allocation.initialized.resize(new_count, false);
+            allocation.provenance.resize(new_count, None);
+            return Ok(Value::Ptr(Some(PtrTarget {
+                alloc: target.alloc,
+                generation: allocation.generation,
+                byte_offset: 0,
+            })));
+        }
+
+        // A class/mapping change allocates through the canonical path, so the
+        // destination observes the real free-list order. The old allocation
+        // is retired only after destination allocation and copying succeed;
+        // any failure therefore leaves it live and usable.
         let (old_bytes, old_initialized, old_provenance) = {
             let old = self.heap.get(target.alloc).ok_or_else(|| {
                 unsupported(
@@ -5635,27 +6083,24 @@ impl<'a> Interp<'a> {
                 old.provenance.clone(),
             )
         };
-        let keep = old_size.max(0).min(new_size) as usize;
-        let mut bytes = vec![0; new_count];
-        let mut initialized = vec![false; new_count];
-        let mut provenance = vec![None; new_count];
-        let copy = keep.min(old_bytes.len());
-        bytes[..copy].copy_from_slice(&old_bytes[..copy]);
-        initialized[..copy].copy_from_slice(&old_initialized[..copy]);
-        provenance[..copy].clone_from_slice(&old_provenance[..copy]);
-        let alloc = self.heap_alloc_bytes(
-            bytes,
-            initialized,
-            provenance,
-            None,
-            AllocationOrigin::Heap,
-            align,
-        );
+        let new_pointer = self.do_alloc(new_size, false, i128::from(align))?;
+        let Value::Ptr(Some(new_target)) = new_pointer else {
+            return Ok(new_pointer);
+        };
+        let copy = old_bytes.len().min(new_count);
+        let destination = self.heap.get_mut(new_target.alloc).ok_or_else(|| {
+            unsupported(
+                unsupported_intrinsic_kind("realloc"),
+                "new allocation missing",
+            )
+        })?;
+        destination.bytes[..copy].copy_from_slice(&old_bytes[..copy]);
+        destination.initialized[..copy].copy_from_slice(&old_initialized[..copy]);
+        destination.provenance[..copy].clone_from_slice(&old_provenance[..copy]);
         self.heap[target.alloc].freed = true;
-        Ok(Value::Ptr(Some(PtrTarget {
-            alloc,
-            byte_offset: 0,
-        })))
+        self.heap[target.alloc].free_list_next = None;
+        self.push_small_free_list(target.alloc);
+        Ok(Value::Ptr(Some(new_target)))
     }
 
     /// Classify an allocation request by its total byte size:

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -77,6 +77,348 @@ fn returns_literal() {
 }
 
 #[test]
+fn print_and_println_share_an_ordered_byte_trace() {
+    let outcome = run(r#"fn main() -> i32 {
+            print("hé");
+            println("!");
+            print("");
+            0
+        }"#);
+    assert_eq!(outcome.stdout.as_bytes(), "hé!\n".as_bytes());
+}
+
+#[test]
+fn print_output_respects_the_raw_stdout_bound() {
+    let unsupported = run_with_stdout_cap("fn main() -> i32 { print(\"hello\"); 0 }", 3)
+        .expect_err("output crossing the bound must fail closed");
+    assert_eq!(
+        unsupported.kind(),
+        UnsupportedKind::ResourceLimit(ResourceLimitKind::StdoutBytes)
+    );
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn stdout_write_syscall_is_modeled_only_for_fd_one() {
+    let output = run(r#"fn main() -> i32 {
+            let p: ptr mut u8 = checked { @alloc(3, 1) };
+            checked {
+                @ptr_write(p, 65);
+                @ptr_write(@ptr_offset(p, 1), 66);
+                @ptr_write(@ptr_offset(p, 2), 67);
+            };
+            let count: i64 = checked { @syscall(1, 1, @ptr_to_int(p), 3) };
+            checked { @free(p, 3, 1); };
+            @intCast(count)
+        }"#);
+    assert_eq!(output.stdout, "ABC");
+    assert_eq!(output.exit_code, 3);
+
+    // A shorter requested length is the only partial-write behavior the
+    // deterministic model claims: it observes exactly that prefix and returns
+    // the requested count. It does not pretend to simulate an OS short write.
+    let requested_prefix = run(r#"fn main() -> i32 {
+            let p: ptr mut u8 = checked { @alloc(3, 1) };
+            checked {
+                @ptr_write(p, 65);
+                @ptr_write(@ptr_offset(p, 1), 66);
+                @ptr_write(@ptr_offset(p, 2), 67);
+            };
+            let count: i64 = checked { @syscall(1, 1, @ptr_to_int(p), 2) };
+            checked { @free(p, 3, 1); };
+            @intCast(count)
+        }"#);
+    assert_eq!(requested_prefix.stdout, "AB");
+    assert_eq!(requested_prefix.exit_code, 2);
+
+    // Two short atomic requests retain their call order. This tests a
+    // requested prefix, not an arbitrary OS short write.
+    let sequential = run(r#"fn main() -> i32 {
+            let p: ptr mut u8 = checked { @alloc(2, 1) };
+            checked { @ptr_write(p, 65); @ptr_write(@ptr_offset(p, 1), 66); };
+            let first: i64 = checked { @syscall(1, 1, @ptr_to_int(p), 1) };
+            let second: i64 = checked { @syscall(1, 1, @ptr_to_int(@ptr_offset(p, 1)), 1) };
+            checked { @free(p, 2, 1); };
+            @intCast(first + second)
+        }"#);
+    assert_eq!(sequential.stdout, "AB");
+    assert_eq!(sequential.exit_code, 2);
+
+    let cap_crossing = run_with_stdout_cap(
+        r#"fn main() -> i32 {
+            let p: ptr mut u8 = checked { @alloc(2, 1) };
+            checked { @ptr_write(p, 65); @ptr_write(@ptr_offset(p, 1), 66); };
+            let _: i64 = checked { @syscall(1, 1, @ptr_to_int(p), 1) };
+            let _: i64 = checked { @syscall(1, 1, @ptr_to_int(@ptr_offset(p, 1)), 1) };
+            0
+        }"#,
+        1,
+    )
+    .expect_err("a valid write crossing only the stdout cap must fail closed");
+    assert_eq!(
+        cap_crossing.kind(),
+        UnsupportedKind::ResourceLimit(ResourceLimitKind::StdoutBytes)
+    );
+
+    let oversized = expect_unsupported(
+        r#"fn main() -> i32 {
+            let _: i64 = checked { @syscall(1, 1, 0, 513) };
+            0
+        }"#,
+    );
+    assert_eq!(
+        oversized.kind(),
+        UnsupportedKind::ExternalDependency(ExternalDependencyKind::SystemCall)
+    );
+
+    let wrong_fd = expect_unsupported(
+        r#"fn main() -> i32 {
+            let p: ptr mut u8 = checked { @alloc(1, 1) };
+            checked { @ptr_write(p, 65); };
+            let _: i64 = checked { @syscall(1, 2, @ptr_to_int(p), 1) };
+            0
+        }"#,
+    );
+    assert_eq!(
+        wrong_fd.kind(),
+        UnsupportedKind::ExternalDependency(ExternalDependencyKind::SystemCall)
+    );
+
+    let wrong_number = expect_unsupported(
+        r#"fn main() -> i32 {
+            let p: ptr mut u8 = checked { @alloc(1, 1) };
+            checked { @ptr_write(p, 65); };
+            let _: i64 = checked { @syscall(39, 1, @ptr_to_int(p), 1) };
+            0
+        }"#,
+    );
+    assert_eq!(
+        wrong_number.kind(),
+        UnsupportedKind::ExternalDependency(ExternalDependencyKind::SystemCall)
+    );
+
+    let invalid_pointer = expect_unsupported(
+        r#"fn main() -> i32 {
+            let _: i64 = checked { @syscall(1, 1, 123, 1) };
+            0
+        }"#,
+    );
+    assert_eq!(
+        invalid_pointer.kind(),
+        UnsupportedKind::ExternalDependency(ExternalDependencyKind::SystemCall)
+    );
+
+    let freed_pointer = expect_unsupported(
+        r#"fn main() -> i32 {
+            let p: ptr mut u8 = checked { @alloc(1, 1) };
+            checked { @ptr_write(p, 65); @free(p, 1, 1); };
+            let _: i64 = checked { @syscall(1, 1, @ptr_to_int(p), 1) };
+            0
+        }"#,
+    );
+    assert_eq!(
+        freed_pointer.kind(),
+        UnsupportedKind::ExternalDependency(ExternalDependencyKind::SystemCall)
+    );
+
+    let uninitialized_pointer = expect_unsupported(
+        r#"fn main() -> i32 {
+            let p: ptr mut u8 = checked { @alloc(1, 1) };
+            let _: i64 = checked { @syscall(1, 1, @ptr_to_int(p), 1) };
+            0
+        }"#,
+    );
+    assert_eq!(
+        uninitialized_pointer.kind(),
+        UnsupportedKind::ExternalDependency(ExternalDependencyKind::SystemCall)
+    );
+
+    let invalid = run(r#"fn main() -> i32 {
+            let p: ptr mut u8 = checked { @alloc(1, 1) };
+            checked { @byte_set(p, 255, 1); };
+            let _: i64 = checked { @syscall(1, 1, @ptr_to_int(p), 1) };
+            0
+        }"#);
+    let different_invalid = run(r#"fn main() -> i32 {
+            let p: ptr mut u8 = checked { @alloc(1, 1) };
+            checked { @byte_set(p, 254, 1); };
+            let _: i64 = checked { @syscall(1, 1, @ptr_to_int(p), 1) };
+            0
+        }"#);
+    assert_eq!(invalid.stdout, different_invalid.stdout);
+    assert_ne!(invalid.stdout_bytes, different_invalid.stdout_bytes);
+    assert_eq!(invalid.stdout_bytes, [255]);
+}
+
+#[cfg(any(
+    all(target_os = "linux", target_arch = "x86_64"),
+    all(target_os = "linux", target_arch = "aarch64"),
+    all(target_os = "macos", target_arch = "aarch64"),
+))]
+#[test]
+fn modeled_stdout_syscall_crossing_cap_is_a_resource_failure() {
+    let write_nr = host_write_syscall_number().expect("supported host write ABI");
+    let source = format!(
+        r#"fn main() -> i32 {{
+            let p: ptr mut u8 = checked {{ @alloc(2, 1) }};
+            checked {{ @ptr_write(p, 65); @ptr_write(@ptr_offset(p, 1), 66); }};
+            let _: i64 = checked {{ @syscall({write_nr}, 1, @ptr_to_int(p), 1) }};
+            let _: i64 = checked {{ @syscall({write_nr}, 1, @ptr_to_int(@ptr_offset(p, 1)), 1) }};
+            0
+        }}"#
+    );
+    let unsupported = run_with_stdout_cap(&source, 1)
+        .expect_err("a valid write crossing only the stdout cap must fail closed");
+    assert_eq!(
+        unsupported.kind(),
+        UnsupportedKind::ResourceLimit(ResourceLimitKind::StdoutBytes)
+    );
+}
+
+#[test]
+fn allocator_reuses_freed_small_blocks_by_size_class() {
+    let outcome = run(r#"fn main() -> i32 {
+            let first: ptr mut u8 = checked { @alloc(4006, 1) };
+            let first_address: u64 = checked { @ptr_to_int(first) };
+            checked { @free(first, 4006, 1); };
+
+            // 4005 and 4006 both round to the runtime allocator's 4096-byte
+            // small class, so this allocation reuses the freed block.
+            let same_class: ptr mut u8 = checked { @alloc(4005, 1) };
+            let same_address: u64 = checked { @ptr_to_int(same_class) };
+            let different_class: ptr mut u8 = checked { @alloc(8, 1) };
+            let different_address: u64 = checked { @ptr_to_int(different_class) };
+            checked {
+                @free(same_class, 4005, 1);
+                @free(different_class, 8, 1);
+            };
+            if first_address == same_address && first_address != different_address { 42 } else { 1 }
+        }"#);
+    assert_eq!(outcome.exit_code, 42);
+}
+
+#[test]
+fn recycled_storage_keeps_stale_pointer_provenance_dead() {
+    let unsupported = expect_unsupported(
+        r#"fn main() -> i32 {
+        let old: ptr mut u8 = checked { @alloc(8, 1) };
+        checked { @ptr_write(old, 65); @free(old, 8, 1); };
+        let fresh: ptr mut u8 = checked { @alloc(8, 1) };
+        checked { @ptr_read(old); };
+        let old_address: u64 = checked { @ptr_to_int(old) };
+        let fresh_address: u64 = checked { @ptr_to_int(fresh) };
+        if old_address == fresh_address { 0 } else { 1 }
+    }"#,
+    );
+    assert_eq!(
+        unsupported.kind(),
+        UnsupportedKind::SemanticGap(SemanticGapKind::Intrinsic(
+            UnsupportedIntrinsicKind::PointerRead,
+        ))
+    );
+    assert_eq!(
+        unsupported.detail(),
+        "pointer has stale allocation provenance"
+    );
+}
+
+#[test]
+fn recycled_storage_rejects_stale_pointer_derived_integer() {
+    let unsupported = expect_unsupported(
+        r#"fn main() -> i32 {
+        let old: ptr mut u8 = checked { @alloc(8, 1) };
+        let old_address: u64 = checked { @ptr_to_int(old) };
+        checked { @free(old, 8, 1); };
+        let fresh: ptr mut u8 = checked { @alloc(8, 1) };
+        let recovered: ptr mut u8 = checked { @int_to_ptr(old_address) };
+        checked { @ptr_read(recovered); };
+        let fresh_address: u64 = checked { @ptr_to_int(fresh) };
+        if fresh_address == old_address { 0 } else { 1 }
+    }"#,
+    );
+    assert_eq!(
+        unsupported.kind(),
+        UnsupportedKind::SemanticGap(SemanticGapKind::Intrinsic(
+            UnsupportedIntrinsicKind::IntToPointer,
+        ))
+    );
+}
+
+#[test]
+fn small_free_lists_follow_free_order_and_realloc_releases_old_blocks() {
+    let outcome = run(r#"fn main() -> i32 {
+        let a: ptr mut u8 = checked { @alloc(8, 1) };
+        let b: ptr mut u8 = checked { @alloc(8, 1) };
+        let a_address: u64 = checked { @ptr_to_int(a) };
+        let b_address: u64 = checked { @ptr_to_int(b) };
+        checked { @free(b, 8, 1); @free(a, 8, 1); };
+        let first: ptr mut u8 = checked { @alloc(8, 1) };
+        let first_address: u64 = checked { @ptr_to_int(first) };
+
+        let moved: ptr mut u8 = checked { @realloc(first, 8, 1, 16) };
+        let b_again: ptr mut u8 = checked { @alloc(8, 1) };
+        let b_again_address: u64 = checked { @ptr_to_int(b_again) };
+        checked { @free(moved, 16, 1); @free(b_again, 8, 1); };
+        if first_address == a_address
+            && first_address != b_address
+            && b_again_address == first_address
+        { 42 } else { 1 }
+    }"#);
+    assert_eq!(outcome.exit_code, 42);
+}
+
+#[test]
+fn recycled_extent_growth_is_chargeable_heap_metadata() {
+    let state = query_cfg_state("fn main() -> i32 { 0 }").expect("test state compiles");
+    let mut interp = Interp {
+        state: &state,
+        stdout_trace: Vec::new(),
+        stdout_bytes: 0,
+        stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
+        budget: STEP_BUDGET,
+        depth: 0,
+        heap: vec![Allocation {
+            bytes: vec![0; 9],
+            initialized: vec![false; 9],
+            provenance: vec![None; 9],
+            root_ty: None,
+            freed: true,
+            generation: 1,
+            free_list_next: None,
+            origin: AllocationOrigin::Heap,
+            declared_alignment: 1,
+            owner_depth: None,
+        }],
+        small_free_heads: [
+            None,
+            Some(0),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        heap_metadata_bytes: 128 * 1024 * 1024 - 1,
+    };
+    let error = interp
+        .do_alloc(16, false, 1)
+        .expect_err("reused extent growth must charge metadata");
+    assert!(matches!(
+        error,
+        Flow::Unsupported(Unsupported {
+            kind: UnsupportedKind::ResourceLimit(ResourceLimitKind::InterpreterSteps),
+            ..
+        })
+    ));
+}
+
+#[test]
 fn cfg_boundary_differential_is_deterministic() {
     let source = "fn square(x: i32) -> i32 { x * x } fn main() -> i32 { square(3) }";
     let first = run_source_cfg_differential(source).expect("CFG boundaries agree");
@@ -1580,13 +1922,14 @@ fn representation_encode_decode_detects_planted_byte_mutation() {
     let state = query_cfg_state("fn main() -> i32 { 0 }").expect("test state compiles");
     let interp = Interp {
         state: &state,
-        stdout: String::new(),
+        stdout_trace: Vec::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
         stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
         heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
         heap_metadata_bytes: 0,
     };
     let (mut bytes, initialized, provenance) =
@@ -1687,6 +2030,39 @@ fn allocator_contracts_reject_non_heap_and_mismatched_handles() {
             UnsupportedKind::SemanticGap(SemanticGapKind::Intrinsic(kind))
         );
     }
+}
+
+#[test]
+fn allocator_rejects_overaligned_layouts_before_classification() {
+    let unsupported = expect_unsupported(
+        r#"fn main() -> i32 {
+            checked { let p: ptr mut u8 = @alloc(8, 8192); };
+            0
+        }"#,
+    );
+    assert_eq!(
+        unsupported.kind(),
+        UnsupportedKind::SemanticGap(SemanticGapKind::Intrinsic(
+            UnsupportedIntrinsicKind::Allocate,
+        ))
+    );
+    assert_eq!(unsupported.detail(), "invalid allocation alignment");
+
+    let realloc = expect_unsupported(
+        r#"fn main() -> i32 {
+            checked {
+                let p: ptr mut u8 = @alloc(8, 1);
+                let q: ptr mut u8 = @realloc(p, 8, 8192, 16);
+            };
+            0
+        }"#,
+    );
+    assert_eq!(
+        realloc.kind(),
+        UnsupportedKind::SemanticGap(SemanticGapKind::Intrinsic(
+            UnsupportedIntrinsicKind::Reallocate,
+        ))
+    );
 }
 
 #[test]
@@ -1864,6 +2240,58 @@ fn realloc_grows_and_preserves() {
         }
     }"#;
     assert_eq!(run(src).exit_code, 112);
+}
+
+#[test]
+fn realloc_same_small_class_keeps_address() {
+    let src = r#"fn main() -> i32 {
+        checked {
+            let p: ptr mut u8 = @alloc(9, 1);
+            let before: u64 = @ptr_to_int(p);
+            @byte_set(p, 65, 9);
+            let q: ptr mut u8 = @realloc(p, 9, 1, 10);
+            let after: u64 = @ptr_to_int(q);
+            let value: u8 = @ptr_read(q);
+            @free(q, 10, 1);
+            if before == after && value == 65 { 42 } else { 1 }
+        }
+    }"#;
+    assert_eq!(run(src).exit_code, 42);
+}
+
+#[test]
+fn realloc_different_small_class_moves_and_preserves_prefix() {
+    let src = r#"fn main() -> i32 {
+        checked {
+            let p: ptr mut u8 = @alloc(16, 1);
+            let before: u64 = @ptr_to_int(p);
+            @byte_set(p, 7, 16);
+            let q: ptr mut u8 = @realloc(p, 16, 1, 8);
+            let after: u64 = @ptr_to_int(q);
+            let value: u8 = @ptr_read(@ptr_offset(q, 7));
+            @free(q, 8, 1);
+            if before != after && value == 7 { 42 } else { 1 }
+        }
+    }"#;
+    assert_eq!(run(src).exit_code, 42);
+}
+
+#[test]
+fn realloc_destination_uses_freed_small_class_head() {
+    let src = r#"fn main() -> i32 {
+        checked {
+            let released: ptr mut u8 = @alloc(16, 1);
+            let released_address: u64 = @ptr_to_int(released);
+            @free(released, 16, 1);
+
+            let narrow: ptr mut u8 = @alloc(8, 1);
+            let wide: ptr mut u8 = @realloc(narrow, 8, 1, 16);
+            let wide_address: u64 = @ptr_to_int(wide);
+            @free(wide, 16, 1);
+            if released_address == wide_address { 42 } else { 1 }
+        }
+    }"#;
+    assert_eq!(run(src).exit_code, 42);
 }
 
 /// A `@realloc` too large to satisfy returns null; the original allocation and

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -18,6 +18,23 @@ fn expect_modeled_value(result: Step<Option<Value>>) -> Option<Value> {
     }
 }
 
+fn expect_modeled_unit(result: Step<Value>) {
+    match result {
+        Ok(Value::Unit) => {}
+        Ok(value) => panic!("expected a modeled unit, got {value:?}"),
+        Err(Flow::Unsupported(_)) => panic!("expected a modeled unit, got Unsupported"),
+        Err(Flow::Panic(_)) => panic!("expected a modeled unit, got a panic"),
+    }
+}
+
+fn expect_observed(result: Step<()>) {
+    match result {
+        Ok(()) => {}
+        Err(Flow::Unsupported(_)) => panic!("expected a modeled observation, got Unsupported"),
+        Err(Flow::Panic(_)) => panic!("expected a modeled observation, got a panic"),
+    }
+}
+
 fn find_call_metadata(
     state: &CompileState,
     expected_name: &str,
@@ -54,13 +71,14 @@ fn stable_text_runtime_calls_require_exact_metadata() {
         .expect("stable text print probes must compile");
     let interp = Interp {
         state: &state,
-        stdout: String::new(),
+        stdout_trace: Vec::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
         stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
         heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
         heap_metadata_bytes: 0,
     };
     for (runtime, kind) in [
@@ -141,19 +159,200 @@ fn stable_text_runtime_calls_require_exact_metadata() {
 }
 
 #[test]
-fn random_intrinsic_requires_exact_arity_and_result_type() {
-    let state = query_cfg_state("fn main() -> i32 { let n: u32 = @random_u32(); @intCast(n) }")
-        .expect("random probe must compile");
-    let (cfg, inst, args, result) = find_intrinsic_in_function(&state, "main", "random_u32");
+fn text_output_routes_reject_cross_abi_shapes() {
+    let strbuf = r#"pub struct StrBuf {
+            buf: ptr mut u8,
+            len: u64,
+            cap: u64,
+            fn len(borrow self) -> u64 { self.len }
+            fn as_ptr(borrow self) -> ptr mut u8 { self.buf }
+        }
+        drop fn StrBuf(self) { }"#;
+    let state = query_cfg_state_with_trusted_std(
+        "const strbuf = @import(\"std/strbuf.rue\"); const StrBuf = strbuf.StrBuf; fn main() -> i32 { let s: StrBuf = \"x\"; print(s); 0 }",
+        &[(2, "/project/std/strbuf.rue", strbuf)],
+    )
+        .expect("text output probe must compile");
     let interp = Interp {
         state: &state,
-        stdout: String::new(),
+        stdout_trace: Vec::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
         stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
         heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
+        heap_metadata_bytes: 0,
+    };
+    let strbuf = state
+        .type_pool()
+        .lang_item_type(rue_air::LangItem::StrBuf)
+        .expect("text probe must register StrBuf");
+    assert_eq!(
+        interp.classify_unsupported_runtime_call(
+            RuntimeCallKind::StrPrintAggregate,
+            &[Value::str_view("x")],
+            &[strbuf],
+            &[CfgArgMode::Normal],
+            Type::UNIT,
+        ),
+        UnsupportedKind::ContractViolation(ContractViolationKind::RuntimeCallSignature)
+    );
+    assert_eq!(
+        interp.classify_unsupported_runtime_call(
+            RuntimeCallKind::StrPrintProjected,
+            &[Value::Ptr(None), Value::Int(0)],
+            &[Type::U64, Type::U64],
+            &[CfgArgMode::Normal, CfgArgMode::Normal],
+            Type::UNIT,
+        ),
+        UnsupportedKind::ContractViolation(ContractViolationKind::RuntimeCallSignature)
+    );
+}
+
+#[test]
+fn modeled_text_runtime_routes_share_the_ordered_trace() {
+    let state = query_cfg_state("fn main() -> i32 { print(\"x\"); 0 }")
+        .expect("text output probe must compile");
+    let mut interp = Interp {
+        state: &state,
+        stdout_trace: Vec::new(),
+        stdout_bytes: 0,
+        stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
+        budget: STEP_BUDGET,
+        depth: 0,
+        heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
+        heap_metadata_bytes: 0,
+    };
+
+    let aggregate_ptr = interp.test_alloc_str_ptr("hé".as_bytes());
+    let Value::Ptr(Some(aggregate_target)) = aggregate_ptr else {
+        panic!("test text allocation must produce a pointer")
+    };
+    let aggregate = Value::Aggregate(vec![Value::Ptr(Some(aggregate_target)), Value::Int(3)]);
+    expect_modeled_unit(interp.eval_runtime_output_call(
+        RuntimeCallKind::StrPrintAggregate,
+        &[aggregate],
+        &[Type::U64],
+    ));
+
+    let projected_target = interp.test_alloc_str_ptr(b"!");
+    expect_modeled_unit(interp.eval_runtime_output_call(
+        RuntimeCallKind::StrPrintlnProjected,
+        &[projected_target, Value::Int(1)],
+        &[Type::U64, Type::U64],
+    ));
+
+    assert_eq!(interp.stdout_trace, "hé!\n".as_bytes());
+}
+
+#[test]
+fn output_routes_bound_claimed_lengths_before_reading() {
+    let state = query_cfg_state("fn main() -> i32 { print(\"x\"); 0 }")
+        .expect("text output probe must compile");
+    let mut interp = Interp {
+        state: &state,
+        stdout_trace: Vec::new(),
+        stdout_bytes: 0,
+        stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
+        budget: STEP_BUDGET,
+        depth: 0,
+        heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
+        heap_metadata_bytes: 0,
+    };
+    let aggregate_huge = Value::Aggregate(vec![Value::Ptr(None), Value::Int(i128::MAX)]);
+    let aggregate_error = expect_flow_unsupported(interp.eval_runtime_output_call(
+        RuntimeCallKind::StrPrintAggregate,
+        &[aggregate_huge],
+        &[Type::U64],
+    ));
+    assert_eq!(
+        aggregate_error.kind(),
+        UnsupportedKind::ResourceLimit(ResourceLimitKind::StdoutBytes)
+    );
+
+    let projected_error = expect_flow_unsupported(interp.eval_runtime_output_call(
+        RuntimeCallKind::StrPrintProjected,
+        &[Value::Ptr(None), Value::Int(i128::MAX)],
+        &[Type::U64, Type::U64],
+    ));
+    assert_eq!(
+        projected_error.kind(),
+        UnsupportedKind::ResourceLimit(ResourceLimitKind::StdoutBytes)
+    );
+
+    let syscall_error = expect_flow_unsupported(interp.eval_stdout_syscall(&[
+        Value::Int(1),
+        Value::Int(1),
+        Value::Int(0),
+        Value::Int(u64::MAX as i128),
+    ]));
+    assert_eq!(
+        syscall_error.kind(),
+        UnsupportedKind::ExternalDependency(ExternalDependencyKind::SystemCall)
+    );
+
+    let pointer = interp.test_alloc_str_ptr(b"a");
+    let oob = expect_flow_unsupported(interp.eval_runtime_output_call(
+        RuntimeCallKind::StrPrintProjected,
+        &[pointer, Value::Int(2)],
+        &[Type::U64, Type::U64],
+    ));
+    assert_eq!(
+        oob.kind(),
+        UnsupportedKind::SemanticGap(SemanticGapKind::Intrinsic(
+            UnsupportedIntrinsicKind::PointerRead
+        ))
+    );
+}
+
+#[test]
+fn text_dbg_preserves_invalid_bytes_in_the_raw_trace() {
+    let state = query_cfg_state("fn main() -> i32 { print(\"x\"); 0 }")
+        .expect("text output probe must compile");
+    let (types, _, _) = find_call_metadata(&state, "__rue_str_print");
+    let mut interp = Interp {
+        state: &state,
+        stdout_trace: Vec::new(),
+        stdout_bytes: 0,
+        stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
+        budget: STEP_BUDGET,
+        depth: 0,
+        heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
+        heap_metadata_bytes: 0,
+    };
+    let pointer = interp.test_alloc_str_ptr(&[0xff]);
+    let Value::Ptr(Some(target)) = pointer else {
+        panic!("test text allocation must produce a pointer")
+    };
+    let value = Value::Aggregate(vec![Value::Ptr(Some(target)), Value::Int(1)]);
+
+    expect_observed(interp.write_dbg(&value, types[0]));
+    assert_eq!(interp.stdout_trace, [0xff, b'\n']);
+}
+
+#[test]
+fn random_intrinsic_requires_exact_arity_and_result_type() {
+    let state = query_cfg_state("fn main() -> i32 { let n: u32 = @random_u32(); @intCast(n) }")
+        .expect("random probe must compile");
+    let (cfg, inst, args, result) = find_intrinsic_in_function(&state, "main", "random_u32");
+    let interp = Interp {
+        state: &state,
+        stdout_trace: Vec::new(),
+        stdout_bytes: 0,
+        stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
+        budget: STEP_BUDGET,
+        depth: 0,
+        heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
         heap_metadata_bytes: 0,
     };
     assert_eq!(
@@ -213,13 +412,14 @@ fn shared_str_character_builtins_require_and_model_ptr_len_offset() {
     .expect("probe must compile");
     let mut interp = Interp {
         state: &state,
-        stdout: String::new(),
+        stdout_trace: Vec::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
         stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
         heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
         heap_metadata_bytes: 0,
     };
     // The builtin contract only needs the logical pointer kind. Look up the
@@ -321,13 +521,14 @@ fn panic_never_signature_is_an_oracle_contract_for_both_arities() {
     .expect("both panic arities must compile with the never contract");
     let interp = Interp {
         state: &state,
-        stdout: String::new(),
+        stdout_trace: Vec::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
         stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
         heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
         heap_metadata_bytes: 0,
     };
     for function_name in ["panic_no_message", "panic_with_message"] {
@@ -447,13 +648,14 @@ fn user_call_layout_is_rejected_before_unmodeled_operands_run() {
         let cfg = &state.functions[main_index].cfg;
         let mut interp = Interp {
             state: &state,
-            stdout: String::new(),
+            stdout_trace: Vec::new(),
             stdout_bytes: 0,
             stdout_cap: MAX_STDOUT_BYTES,
             stderr_cap: MAX_STDERR_BYTES,
             budget: STEP_BUDGET,
             depth: 0,
             heap: Vec::new(),
+            small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
             heap_metadata_bytes: 0,
         };
         let mut frame = Frame {
@@ -546,13 +748,14 @@ fn abort_intrinsic_static_contracts_precede_unmodeled_operands() {
         let cfg = &state.functions[main_index].cfg;
         let mut interp = Interp {
             state: &state,
-            stdout: String::new(),
+            stdout_trace: Vec::new(),
             stdout_bytes: 0,
             stdout_cap: MAX_STDOUT_BYTES,
             stderr_cap: MAX_STDERR_BYTES,
             budget: STEP_BUDGET,
             depth: 0,
             heap: Vec::new(),
+            small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
             heap_metadata_bytes: 0,
         };
         let mut frame = Frame {
@@ -585,13 +788,14 @@ fn abort_intrinsics_require_exact_runtime_value_shapes() {
         let (cfg, intrinsic, args, _) = find_intrinsic_in_function(&state, "main", name);
         let mut interp = Interp {
             state: &state,
-            stdout: String::new(),
+            stdout_trace: Vec::new(),
             stdout_bytes: 0,
             stdout_cap: MAX_STDOUT_BYTES,
             stderr_cap: MAX_STDERR_BYTES,
             budget: STEP_BUDGET,
             depth: 0,
             heap: Vec::new(),
+            small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
             heap_metadata_bytes: 0,
         };
         let mut frame = Frame {
@@ -617,13 +821,14 @@ fn abort_intrinsics_require_exact_runtime_value_shapes() {
     let (cfg, assertion, args, _) = find_intrinsic_in_function(&state, "main", "assert");
     let mut interp = Interp {
         state: &state,
-        stdout: String::new(),
+        stdout_trace: Vec::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
         stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
         heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
         heap_metadata_bytes: 0,
     };
     let mut frame = Frame {
@@ -668,13 +873,14 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
     let state = query_cfg_state(source).expect("pointer provenance probe must compile");
     let interp = Interp {
         state: &state,
-        stdout: String::new(),
+        stdout_trace: Vec::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
         stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
         heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
         heap_metadata_bytes: 0,
     };
 
@@ -817,13 +1023,14 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
     drift_state.select_source_function("user_pointer");
     let drift_interp = Interp {
         state: &drift_state,
-        stdout: String::new(),
+        stdout_trace: Vec::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
         stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
         heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
         heap_metadata_bytes: 0,
     };
     assert_eq!(
@@ -873,13 +1080,14 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
         find_intrinsic_in_function(&extra_use_state, "main", "int_to_ptr");
     let extra_interp = Interp {
         state: &extra_use_state,
-        stdout: String::new(),
+        stdout_trace: Vec::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
         stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
         heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
         heap_metadata_bytes: 0,
     };
     assert_eq!(
@@ -938,13 +1146,14 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
     assert_eq!(extra_init_cfg.value_use_count(slice_init), 2);
     let extra_init_interp = Interp {
         state: &extra_init_use_state,
-        stdout: String::new(),
+        stdout_trace: Vec::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
         stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
         heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
         heap_metadata_bytes: 0,
     };
     assert_eq!(
@@ -1017,13 +1226,14 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
     assert_eq!(wrong_consumer_cfg.value_use_count(wrong_consumer_init), 1);
     let wrong_consumer_interp = Interp {
         state: &wrong_consumer_state,
-        stdout: String::new(),
+        stdout_trace: Vec::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
         stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
         heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
         heap_metadata_bytes: 0,
     };
     assert_eq!(
@@ -1072,13 +1282,14 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
         find_intrinsic_in_function(&wrong_init_state, "main", "int_to_ptr");
     let wrong_init_interp = Interp {
         state: &wrong_init_state,
-        stdout: String::new(),
+        stdout_trace: Vec::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
         stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
         heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
         heap_metadata_bytes: 0,
     };
     assert_eq!(
@@ -1106,13 +1317,14 @@ fn validated_cfg_rejects_out_of_bounds_field_pointer_projection_metadata() {
         let (cfg, inst, args, result) = find_intrinsic_in_function(&state, "main", "field_ptr");
         let interp = Interp {
             state: &state,
-            stdout: String::new(),
+            stdout_trace: Vec::new(),
             stdout_bytes: 0,
             stdout_cap: MAX_STDOUT_BYTES,
             stderr_cap: MAX_STDERR_BYTES,
             budget: STEP_BUDGET,
             depth: 0,
             heap: Vec::new(),
+            small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
             heap_metadata_bytes: 0,
         };
         assert_eq!(
@@ -1307,13 +1519,14 @@ fn option_returning_intrinsics_require_the_exact_payload_type() {
     .expect("Option intrinsic signature probe must compile");
     let interp = Interp {
         state: &state,
-        stdout: String::new(),
+        stdout_trace: Vec::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
         stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
         heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
         heap_metadata_bytes: 0,
     };
     let (parse32_cfg, parse32_inst, parse32_args, parse32_result) =
@@ -1393,13 +1606,14 @@ fn read_line_requires_trusted_source_strbuf_payload_metadata() {
     .expect("trusted Option(StrBuf) @read_line probe must compile");
     let interp = Interp {
         state: &state,
-        stdout: String::new(),
+        stdout_trace: Vec::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
         stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
         heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
         heap_metadata_bytes: 0,
     };
     let (cfg, inst, args, result) = find_intrinsic_in_function(&state, "line", "read_line");

--- a/crates/rue-oracle/src/tests/place_contracts.rs
+++ b/crates/rue-oracle/src/tests/place_contracts.rs
@@ -65,6 +65,7 @@ fn core_str_length_is_modeled_and_inout_forwarding_threads_through_nested_calls(
         Outcome {
             exit_code: 2,
             stdout: String::new(),
+            stdout_bytes: Vec::new(),
             stderr: String::new(),
             panic: None,
         }
@@ -119,13 +120,14 @@ fn matching_cfg_metadata_is_required_before_a_runtime_symptom_is_registrable() {
     };
     let mut interp = Interp {
         state: &state,
-        stdout: String::new(),
+        stdout_trace: Vec::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
         stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
         heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
         heap_metadata_bytes: 0,
     };
     let mut frame = Frame {
@@ -175,13 +177,14 @@ fn matching_cfg_metadata_is_required_before_a_runtime_symptom_is_registrable() {
         .expect("ordinary by-value Param instruction");
     let ordinary_interp = Interp {
         state: &ordinary_state,
-        stdout: String::new(),
+        stdout_trace: Vec::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
         stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
         heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
         heap_metadata_bytes: 0,
     };
     let inout = expect_flow_unsupported(ordinary_interp.lvalue_of(ordinary_cfg, ordinary_param));
@@ -278,13 +281,14 @@ fn logical_inout_writability_is_distinct_from_the_by_reference_abi() {
     .expect("borrow/inout metadata probe must compile");
     let interp = Interp {
         state: &state,
-        stdout: String::new(),
+        stdout_trace: Vec::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
         stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
         heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
         heap_metadata_bytes: 0,
     };
     let place_read = |name: &str| {
@@ -371,13 +375,14 @@ fn validated_cfg_rejects_invalid_owned_text_projection_metadata() {
     view_frame.locals[view_slot as usize] = Some(Value::Ptr(None));
     let mut view_interp = Interp {
         state: &view_state,
-        stdout: String::new(),
+        stdout_trace: Vec::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
         stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
         heap: Vec::new(),
+        small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
         heap_metadata_bytes: 0,
     };
     let width =
@@ -634,13 +639,14 @@ fn zero_sized_place_base_uses_the_canonical_boundary_slot() {
         let cfg = &state.functions[main_index].cfg;
         let interp = Interp {
             state: &state,
-            stdout: String::new(),
+            stdout_trace: Vec::new(),
             stdout_bytes: 0,
             stdout_cap: MAX_STDOUT_BYTES,
             stderr_cap: MAX_STDERR_BYTES,
             budget: STEP_BUDGET,
             depth: 0,
             heap: Vec::new(),
+            small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
             heap_metadata_bytes: 0,
         };
         let CfgInstData::PlaceRead { place } = &cfg.get_inst(read_value).data else {
@@ -802,13 +808,14 @@ fn validated_cfg_allows_only_the_explicit_str_view_whole_place_read_coercion() {
         };
         let interp = Interp {
             state: &state,
-            stdout: String::new(),
+            stdout_trace: Vec::new(),
             stdout_bytes: 0,
             stdout_cap: MAX_STDOUT_BYTES,
             stderr_cap: MAX_STDERR_BYTES,
             budget: STEP_BUDGET,
             depth: 0,
             heap: Vec::new(),
+            small_free_heads: [None; ORACLE_SMALL_CLASS_COUNT],
             heap_metadata_bytes: 0,
         };
         assert!(interp.is_str_like_type(original_place.base_type));

--- a/crates/rue-runtime-abi/src/lib.rs
+++ b/crates/rue-runtime-abi/src/lib.rs
@@ -123,6 +123,21 @@ pub enum RuntimeTarget {
     Aarch64Macos,
 }
 
+impl RuntimeTarget {
+    /// Direct `write(2)` syscall number for this supported runtime target.
+    ///
+    /// This is a shared ABI fact consumed by both the no-std runtime wrappers
+    /// and the reference oracle; target-specific register placement remains in
+    /// each runtime module.
+    pub const fn write_syscall_number(self) -> u64 {
+        match self {
+            Self::X86_64Linux => 1,
+            Self::Aarch64Linux => 64,
+            Self::Aarch64Macos => 4,
+        }
+    }
+}
+
 /// A composable set of runtime targets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TargetSet(u8);
@@ -1787,6 +1802,13 @@ mod tests {
             }
             assert_eq!(helper.calling_convention, CallingConvention::TargetC);
         }
+    }
+
+    #[test]
+    fn write_syscall_numbers_are_centralized_per_supported_target() {
+        assert_eq!(RuntimeTarget::X86_64Linux.write_syscall_number(), 1);
+        assert_eq!(RuntimeTarget::Aarch64Linux.write_syscall_number(), 64);
+        assert_eq!(RuntimeTarget::Aarch64Macos.write_syscall_number(), 4);
     }
 
     #[test]

--- a/crates/rue-runtime/src/aarch64_linux.rs
+++ b/crates/rue-runtime/src/aarch64_linux.rs
@@ -26,12 +26,13 @@
 compile_error!("aarch64_linux module only supports aarch64 Linux");
 
 use core::arch::asm;
+use rue_runtime_abi::RuntimeTarget;
 
 /// Linux aarch64 syscall number for read (from asm-generic/unistd.h).
 const SYS_READ: u64 = 63;
 
 /// Linux aarch64 syscall number for write (from asm-generic/unistd.h).
-const SYS_WRITE: u64 = 64;
+const SYS_WRITE: u64 = RuntimeTarget::Aarch64Linux.write_syscall_number();
 
 /// Linux aarch64 syscall number for exit (from asm-generic/unistd.h).
 const SYS_EXIT: u64 = 93;

--- a/crates/rue-runtime/src/aarch64_macos.rs
+++ b/crates/rue-runtime/src/aarch64_macos.rs
@@ -27,6 +27,7 @@
 compile_error!("aarch64_macos module only supports aarch64 macOS");
 
 use core::arch::asm;
+use rue_runtime_abi::RuntimeTarget;
 
 /// macOS syscall number for exit (SYS_exit).
 const SYS_EXIT: u64 = 1;
@@ -35,7 +36,7 @@ const SYS_EXIT: u64 = 1;
 const SYS_READ: u64 = 3;
 
 /// macOS syscall number for write (SYS_write).
-const SYS_WRITE: u64 = 4;
+const SYS_WRITE: u64 = RuntimeTarget::Aarch64Macos.write_syscall_number();
 
 /// macOS syscall number for mmap (SYS_mmap).
 const SYS_MMAP: u64 = 197;

--- a/crates/rue-runtime/src/x86_64_linux.rs
+++ b/crates/rue-runtime/src/x86_64_linux.rs
@@ -26,12 +26,13 @@
 compile_error!("rue-runtime only supports x86-64 Linux");
 
 use core::arch::asm;
+use rue_runtime_abi::RuntimeTarget;
 
 /// Linux syscall number for read (see `man 2 read`).
 const SYS_READ: i64 = 0;
 
 /// Linux syscall number for write (see `man 2 write`).
-const SYS_WRITE: i64 = 1;
+const SYS_WRITE: i64 = RuntimeTarget::X86_64Linux.write_syscall_number() as i64;
 
 /// Linux syscall number for mmap (see `man 2 mmap`).
 const SYS_MMAP: i64 = 9;

--- a/crates/rue-spec/cases/runtime/syscall.toml
+++ b/crates/rue-spec/cases/runtime/syscall.toml
@@ -8,6 +8,70 @@ id = "runtime.syscall"
 spec_chapter = "9.2"
 name = "Syscall Intrinsic"
 
+# Direct write(1, ...) is part of the oracle differential observation
+# contract.  Keep one native case per supported target so each target's
+# authoritative syscall number and register ABI are exercised with the same
+# exact bytes and returned count.
+[[case]]
+name = "syscall_write_stdout_x86_64"
+spec = ["9.2:3", "9.2:4"]
+only_on = ["x86-64-linux"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc(3, 1);
+        @ptr_write(@ptr_offset(p, 0), 72);
+        @ptr_write(@ptr_offset(p, 1), 73);
+        @ptr_write(@ptr_offset(p, 2), 10);
+        let result: i64 = @syscall(1, 1, @ptr_to_int(p), 3);
+        @free(p, 3, 1);
+        if result == 3 { 42 } else { 1 }
+    }
+}
+"""
+expected_stdout = "HI\n"
+exit_code = 42
+
+[[case]]
+name = "syscall_write_stdout_aarch64_linux"
+spec = ["9.2:3", "9.2:4"]
+only_on = ["aarch64-linux"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc(3, 1);
+        @ptr_write(@ptr_offset(p, 0), 72);
+        @ptr_write(@ptr_offset(p, 1), 73);
+        @ptr_write(@ptr_offset(p, 2), 10);
+        let result: i64 = @syscall(64, 1, @ptr_to_int(p), 3);
+        @free(p, 3, 1);
+        if result == 3 { 42 } else { 1 }
+    }
+}
+"""
+expected_stdout = "HI\n"
+exit_code = 42
+
+[[case]]
+name = "syscall_write_stdout_aarch64_macos"
+spec = ["9.2:3", "9.2:4"]
+only_on = ["aarch64-macos"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc(3, 1);
+        @ptr_write(@ptr_offset(p, 0), 72);
+        @ptr_write(@ptr_offset(p, 1), 73);
+        @ptr_write(@ptr_offset(p, 2), 10);
+        let result: i64 = @syscall(4, 1, @ptr_to_int(p), 3);
+        @free(p, 3, 1);
+        if result == 3 { 42 } else { 1 }
+    }
+}
+"""
+expected_stdout = "HI\n"
+exit_code = 42
+
 # Test that @syscall works (x86-64 Linux)
 # Note: only_on restricts this test to run only on matching host platforms
 [[case]]


### PR DESCRIPTION
## Summary

- model fd 1 as one bounded ordered byte trace for dbg, print/println, and deterministic atomic write syscalls
- compare exact expected and native stdout bytes across CLI/spec and O1–O3, while retaining genuine external-effect gaps
- centralize write-syscall ABI facts and cover target-specific writes, bounds, provenance, partial requests, and allocator reuse

## Validation

- `scripts/rue fmt`
- `scripts/rue quick`
- `scripts/rue premerge`
- `scripts/rue test`
- all six CLI/spec oracle-diff lanes at O0–O3

Fixes RUE-1820.