### PR TITLE
RUE-1822: make query scheduler tests deterministic

### DIFF
--- a/crates/rue-compiler/src/revisioned_query_database/tests.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/tests.rs
@@ -7048,12 +7048,7 @@ fn invalid_undemanded_module_is_neither_parsed_nor_lowered() {
 #[test]
 fn parse_module_frontier_parallelizes_and_reports_exact_work() {
     let texts = (0..8)
-        .map(|index| {
-            format!(
-                "// {}\nfn f{index}() -> i32 {{ {index} }}\n",
-                "x".repeat(64_000)
-            )
-        })
+        .map(|index| format!("fn f{index}() -> i32 {{ {index} }}\n"))
         .collect::<Vec<_>>();
     let paths = (0..8)
         .map(|index| format!("/m{index}.rue"))
@@ -7076,20 +7071,22 @@ fn parse_module_frontier_parallelizes_and_reports_exact_work() {
         .iter()
         .map(|path| ModuleId::from_logical_path(path).unwrap())
         .collect::<Vec<_>>();
-    let root = modules[0].clone();
-    let mut database = RevisionedQueryDatabase::with_query_concurrency(4);
-    let revision = revision_for(&mut database, &snapshot);
-    let (program, work) = database.parse_program(revision, &root, modules);
-    assert!(program.is_ok());
-    assert_eq!(work.frontier_items, 8);
-    assert_eq!(work.frontier_batches, 1);
-    assert_eq!(work.frontier_batch_overhead, 1);
-    assert_eq!(work.modules_reparsed, 8);
-    assert_eq!(work.modules_reused, 0);
-    assert!(
-        database.runtime_metrics_for_test().peak_query_workers > 1,
-        "a cold independent module frontier must occupy multiple workers"
-    );
+    for _ in 0..16 {
+        let root = modules[0].clone();
+        let mut database = RevisionedQueryDatabase::with_query_concurrency(4);
+        let revision = revision_for(&mut database, &snapshot);
+        let (program, work) = database.parse_program(revision, &root, modules.clone());
+        assert!(program.is_ok());
+        assert_eq!(work.frontier_items, 8);
+        assert_eq!(work.frontier_batches, 1);
+        assert_eq!(work.frontier_batch_overhead, 1);
+        assert_eq!(work.modules_reparsed, 8);
+        assert_eq!(work.modules_reused, 0);
+        let scheduling = database.runtime_metrics_for_test();
+        assert_eq!(scheduling.batch_worker_slots_requested, 7);
+        assert_eq!(scheduling.batch_worker_slots_granted, 3);
+        assert_eq!(scheduling.batch_worker_lanes_entered, 4);
+    }
 }
 
 #[test]
@@ -7166,7 +7163,9 @@ fn parse_module_frontier_one_and_many_workers_preserve_error_order() {
             .0
             .unwrap_err()
     };
-    assert_eq!(run(1), run(4));
+    for _ in 0..16 {
+        assert_eq!(run(1), run(4));
+    }
 }
 
 #[test]
@@ -7185,57 +7184,66 @@ fn warning_reference_frontier_parallelizes_and_reports_exact_work() {
         })
         .collect::<Vec<_>>()
         .into();
-    let mut database = RevisionedQueryDatabase::with_query_concurrency(4);
-    let revision = revision_for(&mut database, &snapshot);
-    database
-        .parse_program(revision, &module, [module.clone()])
-        .0
-        .unwrap();
-    assert_eq!(database.runtime_metrics_for_test().peak_query_workers, 1);
-    let (attempt, executions) =
-        database.warning_body_reference_frontier(revision, keys.clone(), CancellationToken::new());
-    assert!(attempt.terminal().is_some());
-    assert_eq!(
-        executions
-            .iter()
-            .flatten()
-            .filter(|execution| execution.execution == RequestExecution::Computed)
-            .count(),
-        32
-    );
-    assert_eq!(
-        attempt
-            .work()
-            .iter()
-            .find(|(name, _)| name.as_ref() == "warning-reference.frontier.items")
-            .map(|(_, amount)| *amount),
-        Some(32)
-    );
-    assert_eq!(
-        attempt
-            .work()
-            .iter()
-            .find(|(name, _)| name.as_ref() == "warning-reference.frontier.batches")
-            .map(|(_, amount)| *amount),
-        Some(1)
-    );
-    assert_eq!(
-        attempt
-            .work()
-            .iter()
-            .find(|(name, _)| name.as_ref() == "warning-reference.frontier.overhead")
-            .map(|(_, amount)| *amount),
-        Some(1)
-    );
-    assert_eq!(
-        attempt
-            .nested_attempts()
-            .iter()
-            .filter(|attempt| attempt.node().family() == "compiler.warning-body-references")
-            .count(),
-        32
-    );
-    assert!(database.runtime_metrics_for_test().peak_query_workers > 1);
+    for _ in 0..16 {
+        let mut database = RevisionedQueryDatabase::with_query_concurrency(4);
+        let revision = revision_for(&mut database, &snapshot);
+        database
+            .parse_program(revision, &module, [module.clone()])
+            .0
+            .unwrap();
+        let (attempt, executions) = database.warning_body_reference_frontier(
+            revision,
+            keys.clone(),
+            CancellationToken::new(),
+        );
+        assert!(attempt.terminal().is_some());
+        assert_eq!(
+            executions
+                .iter()
+                .flatten()
+                .filter(|execution| execution.execution == RequestExecution::Computed)
+                .count(),
+            32
+        );
+        assert_eq!(
+            attempt
+                .work()
+                .iter()
+                .find(|(name, _)| name.as_ref() == "warning-reference.frontier.items")
+                .map(|(_, amount)| *amount),
+            Some(32)
+        );
+        assert_eq!(
+            attempt
+                .work()
+                .iter()
+                .find(|(name, _)| name.as_ref() == "warning-reference.frontier.batches")
+                .map(|(_, amount)| *amount),
+            Some(1)
+        );
+        assert_eq!(
+            attempt
+                .work()
+                .iter()
+                .find(|(name, _)| name.as_ref() == "warning-reference.frontier.overhead")
+                .map(|(_, amount)| *amount),
+            Some(1)
+        );
+        assert_eq!(
+            attempt
+                .nested_attempts()
+                .iter()
+                .filter(|attempt| attempt.node().family() == "compiler.warning-body-references")
+                .count(),
+            32
+        );
+        let scheduling = database.runtime_metrics_for_test();
+        // The warning aggregate schedules three prerequisite projections and
+        // the final body-reference frontier over the same 32 cold bodies.
+        assert_eq!(scheduling.batch_worker_slots_requested, 4 * 31);
+        assert_eq!(scheduling.batch_worker_slots_granted, 4 * 3);
+        assert_eq!(scheduling.batch_worker_lanes_entered, 4 * 4);
+    }
 }
 
 #[test]
@@ -7605,11 +7613,10 @@ fn warning_reference_frontier_inflight_cancellation_publishes_no_aggregate() {
                 child_gate.changed.notify_all();
                 while !state.1 {
                     context.check_canceled()?;
-                    let (next, _) = child_gate
+                    state = child_gate
                         .changed
-                        .wait_timeout(state, std::time::Duration::from_millis(1))
+                        .wait(state)
                         .unwrap_or_else(std::sync::PoisonError::into_inner);
-                    state = next;
                 }
                 Ok(QueryOutput::success(key.0))
             },
@@ -7673,20 +7680,33 @@ fn warning_reference_frontier_inflight_cancellation_publishes_no_aggregate() {
         .state
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    while state.0 == 0 {
+    while state.0 < 4 {
         let now = std::time::Instant::now();
         assert!(
             now < deadline,
-            "no warning child reached the in-flight evaluator gate"
+            "only {} of four warning children reached the evaluator rendezvous",
+            state.0
         );
-        let (next, _) = gate
+        let (next, timed_out) = gate
             .changed
             .wait_timeout(state, deadline.saturating_duration_since(now))
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         state = next;
+        assert!(
+            !timed_out.timed_out() || state.0 >= 4,
+            "only {} of four warning children reached the evaluator rendezvous",
+            state.0
+        );
     }
     drop(state);
-    assert!(database.runtime_metrics_for_test().peak_query_workers > 1);
+    let scheduling = database.runtime_metrics_for_test();
+    assert_eq!(scheduling.batch_worker_slots_requested, 31);
+    assert_eq!(scheduling.batch_worker_slots_granted, 3);
+    assert_eq!(scheduling.batch_worker_lanes_entered, 4);
+    assert_eq!(
+        scheduling.peak_query_workers, 4,
+        "four gated child evaluators guarantee exact worker overlap"
+    );
     cancellation.cancel();
     gate.changed.notify_all();
     let canceled = request

--- a/crates/rue-query/src/context.rs
+++ b/crates/rue-query/src/context.rs
@@ -101,6 +101,11 @@ where
     V: Clone + Send + Sync + 'static,
 {
     tracing::dispatcher::with_default(&tracing_dispatch, || {
+        parent
+            .core
+            .metrics
+            .batch_worker_lanes_entered
+            .fetch_add(1, Ordering::Relaxed);
         let parent_span = tracing_parent.enter();
         let mut ready_items = 0u64;
         let mut ready_wait_ns = 0u64;

--- a/crates/rue-query/src/metrics.rs
+++ b/crates/rue-query/src/metrics.rs
@@ -155,6 +155,21 @@ pub struct RuntimeMetrics {
     pub query_worker_active_ns: u64,
     /// Registered batch items observed in the ready queue.
     pub ready_items: u64,
+    /// Extra registered-batch worker slots requested from the shared scheduler.
+    ///
+    /// This is structural scheduling evidence: it counts desired logical slots,
+    /// not operating-system thread creation. A batch with N items requests
+    /// N - 1 extra slots because the donating parent supplies the remaining
+    /// scheduler lane.
+    pub batch_worker_slots_requested: u64,
+    /// Extra registered-batch worker slots granted from the shared scheduler.
+    pub batch_worker_slots_granted: u64,
+    /// Registered-batch scheduler lanes which entered their worker loop.
+    ///
+    /// This includes the donating parent's inline lane. It deliberately says
+    /// nothing about whether a lane maps to a newly created operating-system
+    /// thread; it proves that every granted logical lane reached execution.
+    pub batch_worker_lanes_entered: u64,
     /// Sum and maximum of ready-to-start delay for registered batch items.
     pub ready_wait_ns: u64,
     pub max_ready_wait_ns: u64,
@@ -226,6 +241,9 @@ pub(crate) struct Metrics {
     pub(crate) donated_permits: AtomicU64,
     pub(crate) query_worker_active_ns: AtomicU64,
     pub(crate) ready_items: AtomicU64,
+    pub(crate) batch_worker_slots_requested: AtomicU64,
+    pub(crate) batch_worker_slots_granted: AtomicU64,
+    pub(crate) batch_worker_lanes_entered: AtomicU64,
     pub(crate) ready_wait_ns: AtomicU64,
     pub(crate) max_ready_wait_ns: AtomicU64,
     pub(crate) longest_query_dependency_chain: AtomicU64,
@@ -319,6 +337,9 @@ impl Metrics {
             donated_permits: self.donated_permits.load(Ordering::Relaxed),
             query_worker_active_ns: self.query_worker_active_ns.load(Ordering::Relaxed),
             ready_items: self.ready_items.load(Ordering::Relaxed),
+            batch_worker_slots_requested: self.batch_worker_slots_requested.load(Ordering::Relaxed),
+            batch_worker_slots_granted: self.batch_worker_slots_granted.load(Ordering::Relaxed),
+            batch_worker_lanes_entered: self.batch_worker_lanes_entered.load(Ordering::Relaxed),
             ready_wait_ns: self.ready_wait_ns.load(Ordering::Relaxed),
             max_ready_wait_ns: self.max_ready_wait_ns.load(Ordering::Relaxed),
             longest_query_dependency_chain: self

--- a/crates/rue-query/src/registered_batch_tests.rs
+++ b/crates/rue-query/src/registered_batch_tests.rs
@@ -132,6 +132,17 @@ fn run_registered_batch(worker_count: usize) -> QueryRequestAttempt<Arc<[u64]>> 
         .unwrap();
     let attempt =
         runtime.request_registered(&root, revision(1), Key("root"), CancellationToken::new());
+    let metrics = runtime.metrics();
+    assert_eq!(metrics.batch_worker_slots_requested, 3);
+    assert_eq!(
+        metrics.batch_worker_slots_granted,
+        worker_count.saturating_sub(1).min(3) as u64
+    );
+    assert_eq!(
+        metrics.batch_worker_lanes_entered,
+        metrics.batch_worker_slots_granted + 1,
+        "every granted logical worker slot and the donating parent lane must execute"
+    );
     assert_eq!(
         peak.load(Ordering::Acquire),
         worker_count.min(4),

--- a/crates/rue-query/src/task.rs
+++ b/crates/rue-query/src/task.rs
@@ -312,6 +312,9 @@ pub(crate) struct BatchWorkerClaim {
 
 impl BatchWorkerClaim {
     pub(crate) fn new(core: Arc<RuntimeCore>, desired: usize) -> Self {
+        core.metrics
+            .batch_worker_slots_requested
+            .fetch_add(desired as u64, Ordering::Relaxed);
         let limit = core.permits.maximum.saturating_sub(1);
         let mut current = core.batch_workers.load(Ordering::Acquire);
         let count = loop {
@@ -326,6 +329,9 @@ impl BatchWorkerClaim {
                 Err(actual) => current = actual,
             }
         };
+        core.metrics
+            .batch_worker_slots_granted
+            .fetch_add(count as u64, Ordering::Relaxed);
         Self { core, count }
     }
 }

--- a/crates/rue-query/src/tests.rs
+++ b/crates/rue-query/src/tests.rs
@@ -4949,8 +4949,14 @@ fn adaptive_registered_batch_stays_inline_when_parallelism_is_impossible() {
     assert_eq!(dependency_keys(&serial), dependency_keys(&parallel));
     assert_eq!(serial_metrics.donated_permits, 0);
     assert_eq!(serial_metrics.ready_items, 0);
+    assert_eq!(serial_metrics.batch_worker_slots_requested, 0);
+    assert_eq!(serial_metrics.batch_worker_slots_granted, 0);
+    assert_eq!(serial_metrics.batch_worker_lanes_entered, 0);
     assert_eq!(parallel_metrics.donated_permits, 1);
     assert_eq!(parallel_metrics.ready_items, 2);
+    assert_eq!(parallel_metrics.batch_worker_slots_requested, 1);
+    assert_eq!(parallel_metrics.batch_worker_slots_granted, 1);
+    assert_eq!(parallel_metrics.batch_worker_lanes_entered, 2);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- record deterministic registered-batch worker slots requested, granted, and logical lanes entered
- replace load-dependent compiler overlap assertions with exact scheduler accounting and repeated determinism coverage
- retain peak worker coverage behind a constructed cancellation rendezvous with a bounded failure fuse

## Validation

- `scripts/rue unit query registered_batch`
- `scripts/rue unit compiler parse_module_frontier`
- `scripts/rue unit compiler warning_reference_frontier`
- `scripts/rue quick`
- `scripts/rue fmt`
- `scripts/rue test`

Fixes RUE-1822.