### PR TITLE
RUE-1672: share foreign-call lowering state

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1052,233 +1052,6 @@ impl<'a> CfgLower<'a> {
         }
     }
 
-    /// Lower an `extern "C"` foreign call that crosses one or more aggregates by
-    /// value under AAPCS64 (ADR-0064 P3). The classification comes from the shared
-    /// [`ForeignCallInputs`](crate::foreign_call::ForeignCallInputs) authority;
-    /// every aggregate is marshaled through its compact physical image (C field
-    /// order). Differs from SysV in two documented ways: a >16-byte aggregate is
-    /// passed **by reference to a caller-owned copy** (not byval-on-stack), and
-    /// the sret pointer uses the dedicated `x8` (not the first argument register)
-    /// and is not echoed.
-    fn lower_foreign_call(
-        &mut self,
-        inputs: crate::foreign_call::ForeignCallInputs,
-        primary: VReg,
-    ) -> crate::value_plan::MaterializedValue {
-        use crate::foreign_call::{ForeignArg, ForeignReturn};
-        let abi = rue_air::TargetCCallAbi::new(inputs.flavor);
-        let budget = ARG_REGS.len();
-
-        // sret storage first (survives the call); its pointer goes in x8.
-        let mut sret_ptr: Option<VReg> = None;
-        let mut sret_storage: u32 = 0;
-        if let ForeignReturn::AggregateSret { image } = &inputs.ret {
-            sret_storage = image.storage_bytes;
-            self.mir.push(Aarch64Inst::SubImm {
-                dst: Operand::Physical(Reg::Sp),
-                src: Operand::Physical(Reg::Sp),
-                imm: checked_displacement_bytes(u64::from(sret_storage))
-                    .expect("foreign sret storage must fit displacement"),
-            });
-            let p = self.mir.alloc_vreg();
-            self.mir.push(Aarch64Inst::MovRR {
-                dst: Operand::Virtual(p),
-                src: Operand::Physical(Reg::Sp),
-            });
-            sret_ptr = Some(p);
-        }
-
-        let mut int_ops: Vec<VReg> = Vec::new();
-        let mut stack_ops: Vec<VReg> = Vec::new();
-        // Caller-owned by-reference copies (AAPCS64 >16-byte composites) are
-        // allocated below the sret storage and must survive the call; freed
-        // together after the outgoing stack area.
-        let mut byref_bytes: u32 = 0;
-
-        for arg in &inputs.args {
-            match arg {
-                ForeignArg::Scalar { value } => {
-                    let v = self.get_vreg(*value);
-                    if int_ops.len() < budget {
-                        int_ops.push(v);
-                    } else {
-                        stack_ops.push(v);
-                    }
-                }
-                ForeignArg::AggregateRegisters { value, image } => {
-                    let ebs = self.image_arg_eightbytes(*value, image);
-                    if int_ops.len() + ebs.len() <= budget {
-                        int_ops.extend(ebs);
-                    } else {
-                        stack_ops.extend(ebs);
-                    }
-                }
-                ForeignArg::AggregateByRefCopy { value, image } => {
-                    // Copy the struct into a caller-owned buffer and pass its
-                    // address in one integer register (AAPCS64 §6.8.2 C.12).
-                    self.mir.push(Aarch64Inst::SubImm {
-                        dst: Operand::Physical(Reg::Sp),
-                        src: Operand::Physical(Reg::Sp),
-                        imm: checked_displacement_bytes(u64::from(image.storage_bytes))
-                            .expect("foreign result storage must fit displacement"),
-                    });
-                    byref_bytes = byref_bytes
-                        .checked_add(image.storage_bytes)
-                        .expect("foreign argument storage must fit u32");
-                    let ptr = self.mir.alloc_vreg();
-                    self.mir.push(Aarch64Inst::MovRR {
-                        dst: Operand::Virtual(ptr),
-                        src: Operand::Physical(Reg::Sp),
-                    });
-                    let slots = self.require_aggregate_slots(*value);
-                    crate::agg_slots::store_enum_slots_through_ptr(
-                        self,
-                        &slots,
-                        ptr,
-                        &image.map,
-                        &image.padding,
-                    );
-                    if int_ops.len() < budget {
-                        int_ops.push(ptr);
-                    } else {
-                        stack_ops.push(ptr);
-                    }
-                }
-                ForeignArg::AggregateByvalStack { .. } => {
-                    panic!(
-                        "AAPCS64 passes a >16-byte aggregate by reference to a caller copy, not \
-                         byval-on-stack; ByValueStack is a SysV-only class"
-                    )
-                }
-            }
-        }
-
-        let num_stack = stack_ops.len();
-        let stack_bytes = checked_aligned_cell_region_bytes(num_stack as u64)
-            .expect("foreign stack area must pass frame-budget preflight");
-        if stack_bytes > 0 {
-            self.mir.push(Aarch64Inst::SubImm {
-                dst: Operand::Physical(Reg::Sp),
-                src: Operand::Physical(Reg::Sp),
-                imm: checked_displacement_bytes(u64::from(stack_bytes))
-                    .expect("foreign stack area must fit displacement"),
-            });
-        }
-        for (index, v) in stack_ops.iter().enumerate() {
-            self.mir.push(Aarch64Inst::Str {
-                src: Operand::Virtual(*v),
-                base: Reg::Sp,
-                offset: checked_cell_byte_offset(index as u64)
-                    .expect("foreign stack slot offset must fit displacement"),
-            });
-        }
-        for (index, v) in int_ops.iter().enumerate() {
-            self.mir.push(Aarch64Inst::MovRR {
-                dst: Operand::Physical(ARG_REGS[index]),
-                src: Operand::Virtual(*v),
-            });
-        }
-        // The dedicated indirect-result register x8 holds the sret pointer.
-        if let Some(p) = sret_ptr {
-            assert!(
-                abi.sret_pointer_in_dedicated_register(),
-                "AAPCS64 must pass the sret pointer in dedicated register x8"
-            );
-            self.mir.push(Aarch64Inst::MovRR {
-                dst: Operand::Physical(Reg::X8),
-                src: Operand::Virtual(p),
-            });
-        }
-        let symbol_id = self.intern_symbol(inputs.symbol_ref());
-        self.mir.push(Aarch64Inst::call(symbol_id));
-        if stack_bytes > 0 {
-            self.mir.push(Aarch64Inst::AddImm {
-                dst: Operand::Physical(Reg::Sp),
-                src: Operand::Physical(Reg::Sp),
-                imm: checked_displacement_bytes(u64::from(stack_bytes))
-                    .expect("foreign stack area must fit displacement"),
-            });
-        }
-        if byref_bytes > 0 {
-            self.mir.push(Aarch64Inst::AddImm {
-                dst: Operand::Physical(Reg::Sp),
-                src: Operand::Physical(Reg::Sp),
-                imm: checked_displacement_bytes(u64::from(byref_bytes))
-                    .expect("foreign argument storage must fit displacement"),
-            });
-        }
-
-        let slots = match &inputs.ret {
-            ForeignReturn::ZeroSized => {
-                self.mir.push(Aarch64Inst::MovImm {
-                    dst: Operand::Virtual(primary),
-                    imm: 0,
-                });
-                Vec::new()
-            }
-            ForeignReturn::Scalar { ext } => {
-                self.mir.push(Aarch64Inst::MovRR {
-                    dst: Operand::Virtual(primary),
-                    src: Operand::Physical(Reg::X0),
-                });
-                self.emit_c_return_extension(primary, *ext);
-                Vec::new()
-            }
-            ForeignReturn::AggregateRegisters { image } => {
-                // x0:x1 hold the return eightbytes (C field order). Bridge them
-                // through a scratch buffer to reconstruct the native slots.
-                let eb = image.eightbytes();
-                self.mir.push(Aarch64Inst::SubImm {
-                    dst: Operand::Physical(Reg::Sp),
-                    src: Operand::Physical(Reg::Sp),
-                    imm: checked_displacement_bytes(u64::from(image.storage_bytes))
-                        .expect("foreign argument storage must fit displacement"),
-                });
-                let buf = self.mir.alloc_vreg();
-                self.mir.push(Aarch64Inst::MovRR {
-                    dst: Operand::Virtual(buf),
-                    src: Operand::Physical(Reg::Sp),
-                });
-                let mut eb_vals = Vec::with_capacity(eb as usize);
-                for index in 0..eb as usize {
-                    let v = self.mir.alloc_vreg();
-                    self.mir.push(Aarch64Inst::MovRR {
-                        dst: Operand::Virtual(v),
-                        src: Operand::Physical(RET_REGS[index]),
-                    });
-                    eb_vals.push(v);
-                }
-                crate::agg_slots::store_slots_through_ptr(self, &eb_vals, buf, 0);
-                let native = crate::agg_slots::load_enum_slots_through_ptr(self, buf, &image.map);
-                self.mir.push(Aarch64Inst::AddImm {
-                    dst: Operand::Physical(Reg::Sp),
-                    src: Operand::Physical(Reg::Sp),
-                    imm: checked_displacement_bytes(u64::from(image.storage_bytes))
-                        .expect("foreign argument storage must fit displacement"),
-                });
-                native
-            }
-            ForeignReturn::AggregateSret { image } => {
-                let p = sret_ptr.expect("an sret return reserved its storage pointer");
-                let native = crate::agg_slots::load_enum_slots_through_ptr(self, p, &image.map);
-                self.mir.push(Aarch64Inst::AddImm {
-                    dst: Operand::Physical(Reg::Sp),
-                    src: Operand::Physical(Reg::Sp),
-                    imm: checked_displacement_bytes(u64::from(sret_storage))
-                        .expect("foreign sret storage must fit displacement"),
-                });
-                native
-            }
-        };
-        if let Some(&slot) = slots.first() {
-            self.mir.push(Aarch64Inst::MovRR {
-                dst: Operand::Virtual(primary),
-                src: Operand::Virtual(slot),
-            });
-        }
-        crate::value_plan::MaterializedValue { primary, slots }
-    }
-
     /// Materialize an aggregate argument's eightbytes (ADR-0064 P3): write its
     /// native slots into a scratch buffer as the compact C image, then load the
     /// whole eightbytes back so they pack in ascending C field order. rsp-neutral
@@ -3362,7 +3135,9 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
         inputs: crate::foreign_call::ForeignCallInputs,
         result: VReg,
     ) -> crate::value_plan::ValueResult {
-        crate::value_plan::ValueResult::Materialized(self.lower_foreign_call(inputs, result))
+        crate::value_plan::ValueResult::Materialized(crate::foreign_call::lower_foreign_call(
+            self, inputs, result,
+        ))
     }
     fn emit_runtime_call(
         &mut self,
@@ -3466,6 +3241,214 @@ fn emit_marshal_tag_ne(mir: &mut Aarch64Mir, tag: VReg, discriminant: u32, label
         cond: Cond::Ne,
         label,
     });
+}
+
+impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
+    fn target_c_flavor(&self) -> rue_air::TargetCAbiFlavor {
+        rue_air::TargetCAbiFlavor::Aapcs64
+    }
+
+    fn foreign_int_arg_register_count(&self) -> usize {
+        ARG_REGS.len()
+    }
+
+    fn foreign_reserve_sret(&mut self, image: &crate::foreign_call::AggregateImage) -> VReg {
+        self.mir.push(Aarch64Inst::SubImm {
+            dst: Operand::Physical(Reg::Sp),
+            src: Operand::Physical(Reg::Sp),
+            imm: checked_displacement_bytes(u64::from(image.storage_bytes))
+                .expect("foreign sret storage must fit displacement"),
+        });
+        let ptr = self.mir.alloc_vreg();
+        self.mir.push(Aarch64Inst::MovRR {
+            dst: Operand::Virtual(ptr),
+            src: Operand::Physical(Reg::Sp),
+        });
+        ptr
+    }
+
+    fn foreign_get_vreg(&mut self, value: CfgValue) -> VReg {
+        self.get_vreg(value)
+    }
+
+    fn foreign_image_arg_eightbytes(
+        &mut self,
+        value: CfgValue,
+        image: &crate::foreign_call::AggregateImage,
+    ) -> Vec<VReg> {
+        self.image_arg_eightbytes(value, image)
+    }
+
+    fn foreign_byref_copy(
+        &mut self,
+        value: CfgValue,
+        image: &crate::foreign_call::AggregateImage,
+    ) -> VReg {
+        self.mir.push(Aarch64Inst::SubImm {
+            dst: Operand::Physical(Reg::Sp),
+            src: Operand::Physical(Reg::Sp),
+            imm: checked_displacement_bytes(u64::from(image.storage_bytes))
+                .expect("foreign result storage must fit displacement"),
+        });
+        let ptr = self.mir.alloc_vreg();
+        self.mir.push(Aarch64Inst::MovRR {
+            dst: Operand::Virtual(ptr),
+            src: Operand::Physical(Reg::Sp),
+        });
+        let slots = self.require_aggregate_slots(value);
+        crate::agg_slots::store_enum_slots_through_ptr(
+            self,
+            &slots,
+            ptr,
+            &image.map,
+            &image.padding,
+        );
+        ptr
+    }
+
+    fn foreign_emit_stack_args(&mut self, stack_ops: &[VReg]) {
+        let stack_bytes = checked_aligned_cell_region_bytes(
+            u64::try_from(stack_ops.len()).expect("foreign stack slot count must fit u64"),
+        )
+        .expect("foreign stack area must pass frame-budget preflight");
+        if stack_bytes > 0 {
+            self.mir.push(Aarch64Inst::SubImm {
+                dst: Operand::Physical(Reg::Sp),
+                src: Operand::Physical(Reg::Sp),
+                imm: checked_displacement_bytes(u64::from(stack_bytes))
+                    .expect("foreign stack area must fit displacement"),
+            });
+        }
+        for (index, v) in stack_ops.iter().enumerate() {
+            self.mir.push(Aarch64Inst::Str {
+                src: Operand::Virtual(*v),
+                base: Reg::Sp,
+                offset: checked_cell_byte_offset(index as u64)
+                    .expect("foreign stack slot offset must fit displacement"),
+            });
+        }
+    }
+
+    fn foreign_emit_register_args(&mut self, int_ops: &[VReg]) {
+        for (index, v) in int_ops.iter().enumerate() {
+            self.mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(ARG_REGS[index]),
+                src: Operand::Virtual(*v),
+            });
+        }
+    }
+
+    fn foreign_assign_sret(&mut self, sret_ptr: VReg) {
+        self.mir.push(Aarch64Inst::MovRR {
+            dst: Operand::Physical(Reg::X8),
+            src: Operand::Virtual(sret_ptr),
+        });
+    }
+
+    fn foreign_issue_call(&mut self, symbol: &str) {
+        let symbol_id = self.intern_symbol(symbol);
+        self.mir.push(Aarch64Inst::call(symbol_id));
+    }
+
+    fn foreign_cleanup_stack(&mut self, stack_count: usize) {
+        if stack_count > 0 {
+            let stack_bytes = checked_aligned_cell_region_bytes(
+                u64::try_from(stack_count).expect("foreign stack slot count must fit u64"),
+            )
+            .expect("foreign stack area must pass frame-budget preflight");
+            self.mir.push(Aarch64Inst::AddImm {
+                dst: Operand::Physical(Reg::Sp),
+                src: Operand::Physical(Reg::Sp),
+                imm: checked_displacement_bytes(u64::from(stack_bytes))
+                    .expect("foreign stack area must fit displacement"),
+            });
+        }
+    }
+
+    fn foreign_cleanup_byref(&mut self, byref_bytes: u32) {
+        if byref_bytes > 0 {
+            self.mir.push(Aarch64Inst::AddImm {
+                dst: Operand::Physical(Reg::Sp),
+                src: Operand::Physical(Reg::Sp),
+                imm: checked_displacement_bytes(u64::from(byref_bytes))
+                    .expect("foreign argument storage must fit displacement"),
+            });
+        }
+    }
+
+    fn foreign_zero_result(&mut self, primary: VReg) {
+        self.mir.push(Aarch64Inst::MovImm {
+            dst: Operand::Virtual(primary),
+            imm: 0,
+        });
+    }
+
+    fn foreign_scalar_result(&mut self, primary: VReg, ext: rue_air::ScalarAbiExtension) {
+        self.mir.push(Aarch64Inst::MovRR {
+            dst: Operand::Virtual(primary),
+            src: Operand::Physical(Reg::X0),
+        });
+        self.emit_c_return_extension(primary, ext);
+    }
+
+    fn foreign_register_result(
+        &mut self,
+        _primary: VReg,
+        image: &crate::foreign_call::AggregateImage,
+    ) -> Vec<VReg> {
+        self.mir.push(Aarch64Inst::SubImm {
+            dst: Operand::Physical(Reg::Sp),
+            src: Operand::Physical(Reg::Sp),
+            imm: checked_displacement_bytes(u64::from(image.storage_bytes))
+                .expect("foreign result storage must fit displacement"),
+        });
+        let buf = self.mir.alloc_vreg();
+        self.mir.push(Aarch64Inst::MovRR {
+            dst: Operand::Virtual(buf),
+            src: Operand::Physical(Reg::Sp),
+        });
+        let mut eb_vals = Vec::with_capacity(image.eightbytes() as usize);
+        for index in 0..image.eightbytes() as usize {
+            let v = self.mir.alloc_vreg();
+            self.mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Virtual(v),
+                src: Operand::Physical(RET_REGS[index]),
+            });
+            eb_vals.push(v);
+        }
+        crate::agg_slots::store_slots_through_ptr(self, &eb_vals, buf, 0);
+        let native = crate::agg_slots::load_enum_slots_through_ptr(self, buf, &image.map);
+        self.mir.push(Aarch64Inst::AddImm {
+            dst: Operand::Physical(Reg::Sp),
+            src: Operand::Physical(Reg::Sp),
+            imm: checked_displacement_bytes(u64::from(image.storage_bytes))
+                .expect("foreign result storage must fit displacement"),
+        });
+        native
+    }
+
+    fn foreign_sret_result(
+        &mut self,
+        _primary: VReg,
+        image: &crate::foreign_call::AggregateImage,
+        sret_ptr: VReg,
+    ) -> Vec<VReg> {
+        let native = crate::agg_slots::load_enum_slots_through_ptr(self, sret_ptr, &image.map);
+        self.mir.push(Aarch64Inst::AddImm {
+            dst: Operand::Physical(Reg::Sp),
+            src: Operand::Physical(Reg::Sp),
+            imm: checked_displacement_bytes(u64::from(image.storage_bytes))
+                .expect("foreign sret storage must fit displacement"),
+        });
+        native
+    }
+
+    fn foreign_move_primary(&mut self, primary: VReg, slot: VReg) {
+        self.mir.push(Aarch64Inst::MovRR {
+            dst: Operand::Virtual(primary),
+            src: Operand::Virtual(slot),
+        });
+    }
 }
 
 impl crate::agg_slots::SlotBackend for CfgLower<'_> {

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -27,7 +27,6 @@
 //! any realistic function. The separation is handled automatically by the
 //! respective methods.
 
-use ahash::AHashMap;
 use std::fmt;
 
 pub use rue_runtime_abi::ReturnBehavior;
@@ -41,6 +40,7 @@ pub use rue_runtime_abi::ReturnBehavior;
 const _: () = assert!(std::mem::size_of::<Aarch64Inst>() <= 48);
 
 pub use crate::reg_class::{RegClass, VRegClasses};
+use crate::vreg::MirState;
 pub use crate::vreg::{BLOCK_LABEL_BASE, LabelId, VReg};
 
 /// A physical AArch64 register.
@@ -1332,25 +1332,13 @@ impl fmt::Display for Aarch64Inst {
 pub struct Aarch64Mir {
     /// The instructions in this function.
     instructions: Vec<Aarch64Inst>,
-    /// The next virtual register index.
-    next_vreg: u32,
-    /// The register class of each virtual register, one entry per register
-    /// minted by [`Aarch64Mir::alloc_vreg_in`] and indexed by vreg index.
-    vreg_classes: VRegClasses,
+    /// Shared virtual-register and symbol-interning state.
+    state: MirState,
     /// Next inline label ID for generating unique labels.
     ///
     /// Inline labels (for overflow checks, bounds checks, etc.) use IDs from
     /// the lower half of the `u32` space. See module docs for namespace details.
     next_label: u32,
-    /// Symbol table for call targets.
-    ///
-    /// Stores symbol names indexed by `symbol_id` in `Bl` instructions.
-    /// This avoids heap-allocating a String for every call instruction.
-    symbols: Vec<String>,
-    /// Index for O(1) symbol lookup during interning.
-    ///
-    /// Maps symbol names to their indices in the `symbols` vector.
-    symbol_index: AHashMap<String, u32>,
 }
 
 impl Aarch64Mir {
@@ -1358,11 +1346,8 @@ impl Aarch64Mir {
     pub fn new() -> Self {
         Self {
             instructions: Vec::new(),
-            next_vreg: 0,
-            vreg_classes: VRegClasses::new(),
+            state: MirState::new(),
             next_label: 0,
-            symbols: Vec::new(),
-            symbol_index: AHashMap::new(),
         }
     }
 
@@ -1371,16 +1356,7 @@ impl Aarch64Mir {
     /// If the symbol already exists, returns its existing ID.
     /// Otherwise, adds it to the table and returns the new ID.
     pub fn intern_symbol(&mut self, symbol: &str) -> u32 {
-        // O(1) lookup via AHashMap
-        if let Some(&idx) = self.symbol_index.get(symbol) {
-            return idx;
-        }
-        // Add new symbol
-        let idx = self.symbols.len() as u32;
-        let owned = symbol.to_string();
-        self.symbol_index.insert(owned.clone(), idx);
-        self.symbols.push(owned);
-        idx
+        self.state.intern_symbol(symbol)
     }
 
     /// Get a symbol name by its ID.
@@ -1389,33 +1365,27 @@ impl Aarch64Mir {
     /// Panics if the symbol_id is out of bounds.
     #[inline]
     pub fn get_symbol(&self, symbol_id: u32) -> &str {
-        &self.symbols[symbol_id as usize]
+        self.state.get_symbol(symbol_id)
     }
 
     /// Get the symbol table.
     #[inline]
     pub fn symbols(&self) -> &[String] {
-        &self.symbols
+        self.state.symbols()
     }
 
     /// Take ownership of the symbol table.
     ///
     /// Used during register allocation to transfer symbols to the rewritten MIR.
     pub fn take_symbols(&mut self) -> Vec<String> {
-        self.symbol_index.clear();
-        std::mem::take(&mut self.symbols)
+        self.state.take_symbols()
     }
 
     /// Set the symbol table.
     ///
     /// Used during register allocation to restore symbols from the pre-rewrite MIR.
     pub fn set_symbols(&mut self, symbols: Vec<String>) {
-        // Rebuild the index from the symbol table
-        self.symbol_index.clear();
-        for (idx, sym) in symbols.iter().enumerate() {
-            self.symbol_index.insert(sym.clone(), idx as u32);
-        }
-        self.symbols = symbols;
+        self.state.set_symbols(symbols);
     }
 
     /// Allocate a new general-purpose virtual register.
@@ -1434,22 +1404,19 @@ impl Aarch64Mir {
     /// liveness hand allocation a table that covers every virtual register the
     /// function has.
     pub fn alloc_vreg_in(&mut self, class: RegClass) -> VReg {
-        let vreg = VReg::new(self.next_vreg);
-        self.next_vreg += 1;
-        self.vreg_classes.push(class);
-        vreg
+        self.state.alloc_vreg(class)
     }
 
     /// The register class of each virtual register.
     #[inline]
     pub fn vreg_classes(&self) -> &VRegClasses {
-        &self.vreg_classes
+        self.state.vreg_classes()
     }
 
     /// The register class of one virtual register.
     #[inline]
     pub fn vreg_class(&self, vreg: VReg) -> RegClass {
-        self.vreg_classes.class_of(vreg)
+        self.state.vreg_class(vreg)
     }
 
     /// Allocate a new inline label ID.
@@ -1480,7 +1447,7 @@ impl Aarch64Mir {
     /// Get the number of virtual registers allocated.
     #[inline]
     pub fn vreg_count(&self) -> u32 {
-        self.next_vreg
+        self.state.vreg_count()
     }
 
     /// Get the number of instructions.

--- a/crates/rue-codegen/src/api_inventory.rs
+++ b/crates/rue-codegen/src/api_inventory.rs
@@ -160,3 +160,129 @@ fn value_planning_uses_the_air_integer_semantics_kernel() {
     assert!(!source.contains("(8, true) => (i8::MIN"));
     assert!(!source.contains("type_bits(ty) - 1"));
 }
+
+#[test]
+fn foreign_call_and_mir_state_have_one_shared_authority() {
+    let foreign = include_str!("foreign_call.rs");
+    assert!(foreign.contains("pub(crate) struct ForeignCallPlan"));
+    assert!(foreign.contains("pub(crate) trait ForeignCallLoweringBackend"));
+    assert!(foreign.contains("pub(crate) fn lower_foreign_call<B: ForeignCallLoweringBackend>"));
+    assert!(foreign.contains("backend.foreign_reserve_sret"));
+    assert!(foreign.contains("backend.foreign_emit_stack_args"));
+    assert!(foreign.contains("backend.foreign_cleanup_byref"));
+    assert!(foreign.contains("backend.foreign_register_result"));
+    let driver = foreign
+        .split("pub(crate) fn lower_foreign_call<B: ForeignCallLoweringBackend>")
+        .nth(1)
+        .expect("shared foreign-call driver");
+    let event_order = [
+        "foreign_reserve_sret",
+        "foreign_emit_stack_args",
+        "foreign_emit_register_args",
+        "foreign_assign_sret",
+        "foreign_issue_call",
+        "foreign_cleanup_stack",
+        "foreign_cleanup_byref",
+        "foreign_zero_result",
+        "foreign_scalar_result",
+        "foreign_register_result",
+        "foreign_sret_result",
+    ];
+    let mut previous = 0;
+    for event in event_order {
+        let offset = driver
+            .find(event)
+            .unwrap_or_else(|| panic!("driver event {event}"));
+        assert!(offset >= previous, "driver event order changed at {event}");
+        previous = offset;
+    }
+
+    for lowering in [
+        include_str!("x86_64/cfg_lower.rs"),
+        include_str!("aarch64/cfg_lower.rs"),
+    ] {
+        let production = lowering
+            .split("\n#[cfg(test)]\nmod ")
+            .next()
+            .expect("foreign lowering production prefix");
+        assert_eq!(
+            production.matches("fn emit_foreign_call(").count(),
+            1,
+            "each backend must expose exactly one foreign-call adapter"
+        );
+        let emit_start = production
+            .find("fn emit_foreign_call(")
+            .expect("foreign-call adapter signature");
+        let emit_end = production[emit_start..]
+            .find("fn emit_runtime_call(")
+            .map(|offset| emit_start + offset)
+            .expect("foreign-call adapter terminator");
+        let emit = &production[emit_start..emit_end];
+        let compact = |source: &str| source.split_whitespace().collect::<String>();
+        let expected_emit = concat!(
+            "fn emit_foreign_call(\n",
+            "    &mut self,\n",
+            "    inputs: crate::foreign_call::ForeignCallInputs,\n",
+            "    result: VReg,\n",
+            ") -> crate::value_plan::ValueResult {\n",
+            "    crate::value_plan::ValueResult::Materialized(",
+            "crate::foreign_call::lower_foreign_call(self, inputs, result,)",
+            ")\n",
+            "}\n"
+        );
+        assert_eq!(
+            compact(emit),
+            compact(expected_emit),
+            "backend emit_foreign_call must remain an exact shared-driver wrapper"
+        );
+        assert_eq!(
+            emit.matches("crate::foreign_call::lower_foreign_call(")
+                .count(),
+            1,
+            "the backend adapter must directly delegate to the shared driver"
+        );
+        for forbidden in [
+            "ForeignArg",
+            "ForeignReturn",
+            "ForeignCallPlan",
+            "TargetCCallAbi",
+            "ForeignArgPlacement",
+            "used_registers",
+            "register_budget",
+            "stack_cells",
+            "int_ops",
+            "stack_ops",
+        ] {
+            assert!(
+                !emit.contains(forbidden),
+                "backend emit_foreign_call contains shared foreign-call sequencing or placement: {forbidden}"
+            );
+        }
+        assert!(
+            !production.contains("fn lower_foreign_call("),
+            "backend must not define a local foreign-call sequencer"
+        );
+        for forbidden in ["ForeignArg", "ForeignReturn", "TargetCCallAbi"] {
+            assert!(
+                !production.contains(forbidden),
+                "backend production source must not own foreign-call classification: {forbidden}"
+            );
+        }
+        let adapter = production
+            .split("impl crate::foreign_call::ForeignCallLoweringBackend")
+            .next()
+            .expect("foreign lowering adapter split");
+        assert!(adapter.contains("crate::foreign_call::lower_foreign_call("));
+    }
+
+    let state = include_str!("vreg.rs");
+    assert!(state.contains("pub struct MirState"));
+    for mir in [
+        include_str!("x86_64/mir.rs"),
+        include_str!("aarch64/mir.rs"),
+    ] {
+        assert!(mir.contains("state: MirState"));
+        assert!(!mir.contains("symbol_index: AHashMap"));
+        assert!(!mir.contains("next_vreg: u32"));
+    }
+}

--- a/crates/rue-codegen/src/foreign_call.rs
+++ b/crates/rue-codegen/src/foreign_call.rs
@@ -11,12 +11,11 @@
 //! image** (which, for a `@repr(c)` struct of scalar/pointer fields, is exactly
 //! the C object layout under the compact-layout default).
 //!
-//! This module only *classifies*: it names, per argument and for the return,
-//! which target-C class ([`rue_air::AggregateArgClass`] /
-//! [`rue_air::AggregateReturnClass`]) governs the crossing and carries the
-//! aggregate's compact image map. The two backends' `emit_foreign_call` own the
-//! physical register/stack/sret sequence — the only genuinely per-architecture
-//! part — consuming this shared authority so neither makes a local ABI decision.
+//! This module classifies each argument and return with the target-C authority,
+//! carries the aggregate's compact image map, and drives the shared
+//! register/stack/sret event sequence. The two backends implement only the
+//! physical register, stack, instruction, and image-operation leaves, so
+//! neither can grow a second ABI sequence.
 
 use rue_air::layout::PaddingRange;
 use rue_air::{
@@ -27,6 +26,7 @@ use rue_cfg::{Cfg, CfgCallArg, CfgValue};
 
 use crate::frame_layout::{checked_aligned_region_bytes, checked_call_area_bytes};
 use crate::types::{self, PhysicalEnumSlot};
+use crate::vreg::VReg;
 
 /// The compact physical memory image of an aggregate crossing the C boundary —
 /// its C object layout under the compact-layout default. Every by-value
@@ -141,6 +141,342 @@ impl ForeignCallInputs {
     }
 }
 
+/// The target-independent placement portion of foreign-call lowering.
+///
+/// Backends still own how a placed value is materialized and how the call
+/// frame is adjusted (pushes on SysV versus stores on AAPCS64). They consume
+/// this plan for the decisions which must be identical: aggregate pieces are
+/// all-or-nothing with respect to the remaining integer registers, by-value
+/// images consume their full eightbyte width, and by-reference copies consume
+/// one pointer argument. Keeping those decisions here prevents the two
+/// instruction-selection adapters from drifting while preserving their
+/// target-specific MIR.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ForeignArgPlacement {
+    Register { arg_index: usize },
+    Stack { arg_index: usize },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ForeignArgShape {
+    /// Number of integer eightbytes (or one pointer) consumed by the argument.
+    pieces: u64,
+    /// Storage retained for a by-reference argument copy.
+    byref_bytes: u64,
+    /// Whether this argument may use integer argument registers.
+    can_register: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ForeignPlacementPlan {
+    placements: Vec<ForeignArgPlacement>,
+    byref_bytes: u64,
+    stack_cells: u64,
+    sret_in_argument_register: bool,
+}
+
+fn place_foreign_args(
+    shapes: &[ForeignArgShape],
+    int_register_budget: u64,
+    sret_in_argument_register: bool,
+) -> Result<ForeignPlacementPlan, crate::frame_layout::FrameBudgetExceeded> {
+    let mut used_registers = u64::from(sret_in_argument_register);
+    let mut placements = Vec::with_capacity(shapes.len());
+    let mut byref_bytes = 0_u64;
+    let mut stack_cells = 0_u64;
+
+    for (arg_index, shape) in shapes.iter().enumerate() {
+        byref_bytes = byref_bytes
+            .checked_add(shape.byref_bytes)
+            .ok_or(crate::frame_layout::FrameBudgetExceeded)?;
+        let placement = if shape.can_register {
+            let register_end = used_registers
+                .checked_add(shape.pieces)
+                .ok_or(crate::frame_layout::FrameBudgetExceeded)?;
+            if register_end <= int_register_budget {
+                used_registers = register_end;
+                ForeignArgPlacement::Register { arg_index }
+            } else {
+                let stack_end = stack_cells
+                    .checked_add(shape.pieces)
+                    .ok_or(crate::frame_layout::FrameBudgetExceeded)?;
+                stack_cells = stack_end;
+                ForeignArgPlacement::Stack { arg_index }
+            }
+        } else {
+            let stack_end = stack_cells
+                .checked_add(shape.pieces)
+                .ok_or(crate::frame_layout::FrameBudgetExceeded)?;
+            stack_cells = stack_end;
+            ForeignArgPlacement::Stack { arg_index }
+        };
+        placements.push(placement);
+    }
+
+    Ok(ForeignPlacementPlan {
+        placements,
+        byref_bytes,
+        stack_cells,
+        sret_in_argument_register,
+    })
+}
+
+fn shape_from_foreign_arg(arg: &ForeignArg) -> ForeignArgShape {
+    match arg {
+        ForeignArg::Scalar { .. } => ForeignArgShape {
+            pieces: 1,
+            byref_bytes: 0,
+            can_register: true,
+        },
+        ForeignArg::AggregateRegisters { image, .. } => ForeignArgShape {
+            pieces: u64::from(image.eightbytes()),
+            byref_bytes: 0,
+            can_register: true,
+        },
+        ForeignArg::AggregateByvalStack { image, .. } => ForeignArgShape {
+            pieces: u64::from(image.eightbytes()),
+            byref_bytes: 0,
+            can_register: false,
+        },
+        ForeignArg::AggregateByRefCopy { image, .. } => ForeignArgShape {
+            pieces: 1,
+            byref_bytes: u64::from(image.storage_bytes),
+            can_register: true,
+        },
+    }
+}
+
+fn shape_from_cfg_arg(
+    cfg: &Cfg,
+    type_pool: &FrozenTypeInternPool,
+    abi: TargetCCallAbi,
+    arg: &CfgCallArg,
+) -> Result<ForeignArgShape, crate::frame_layout::FrameBudgetExceeded> {
+    let ty = cfg.get_inst(arg.value).ty;
+    if !is_aggregate(ty) {
+        return Ok(ForeignArgShape {
+            pieces: 1,
+            byref_bytes: 0,
+            can_register: true,
+        });
+    }
+
+    let layout = type_pool.layout(ty);
+    let copy_bytes = || checked_aligned_region_bytes(layout.size).map(u64::from);
+    Ok(
+        match abi.classify_aggregate_arg(layout.size, layout.alignment) {
+            AggregateArgClass::IntegerRegisters { eightbytes } => ForeignArgShape {
+                pieces: u64::from(eightbytes),
+                byref_bytes: 0,
+                can_register: true,
+            },
+            AggregateArgClass::ByValueStack { .. } => ForeignArgShape {
+                pieces: layout.size.div_ceil(8),
+                byref_bytes: 0,
+                can_register: false,
+            },
+            AggregateArgClass::ByReferenceCopy { .. } => ForeignArgShape {
+                pieces: 1,
+                byref_bytes: copy_bytes()?,
+                can_register: true,
+            },
+        },
+    )
+}
+
+impl ForeignArgPlacement {
+    #[inline]
+    pub const fn arg_index(self) -> usize {
+        match self {
+            Self::Register { arg_index } | Self::Stack { arg_index } => arg_index,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ForeignCallPlan {
+    /// Classified call consumed by the backend adapters.
+    inputs: ForeignCallInputs,
+    /// Every user argument's placement, retaining source order for lowering
+    /// side effects and deterministic virtual-register numbering.
+    placements: Vec<ForeignArgPlacement>,
+    /// Total storage reserved for AAPCS64 by-reference argument copies.
+    byref_bytes: u32,
+    /// SysV consumes the hidden sret pointer from the integer argument budget;
+    /// AAPCS64 puts it in the dedicated x8 register instead.
+    sret_in_argument_register: bool,
+}
+
+impl ForeignCallPlan {
+    /// Plan argument placement after classification, preserving aggregate
+    /// all-or-nothing register allocation and source ordering.
+    pub fn new(inputs: ForeignCallInputs, int_register_budget: usize) -> Self {
+        let abi = TargetCCallAbi::new(inputs.flavor);
+        let sret_in_argument_register = matches!(&inputs.ret, ForeignReturn::AggregateSret { .. })
+            && !abi.sret_pointer_in_dedicated_register();
+        let shapes = inputs
+            .args
+            .iter()
+            .map(shape_from_foreign_arg)
+            .collect::<Vec<_>>();
+        let placement = place_foreign_args(
+            &shapes,
+            u64::try_from(int_register_budget).expect("foreign register budget must fit u64"),
+            sret_in_argument_register,
+        )
+        .expect("foreign argument placement must pass frame-budget preflight");
+
+        Self {
+            inputs,
+            placements: placement.placements,
+            byref_bytes: u32::try_from(placement.byref_bytes)
+                .expect("foreign argument storage must fit u32"),
+            sret_in_argument_register,
+        }
+    }
+}
+
+/// Target-specific leaves for the shared foreign-call lowering driver.
+///
+/// The driver below owns the call's event order and all target-independent
+/// decisions. Implementations only select concrete registers/instructions and
+/// perform the target's stack and image operations.
+pub(crate) trait ForeignCallLoweringBackend {
+    fn target_c_flavor(&self) -> TargetCAbiFlavor;
+    fn foreign_int_arg_register_count(&self) -> usize;
+    fn foreign_reserve_sret(&mut self, image: &AggregateImage) -> VReg;
+    fn foreign_get_vreg(&mut self, value: CfgValue) -> VReg;
+    fn foreign_image_arg_eightbytes(
+        &mut self,
+        value: CfgValue,
+        image: &AggregateImage,
+    ) -> Vec<VReg>;
+    fn foreign_byref_copy(&mut self, value: CfgValue, image: &AggregateImage) -> VReg;
+    fn foreign_emit_stack_args(&mut self, stack_ops: &[VReg]);
+    fn foreign_emit_register_args(&mut self, int_ops: &[VReg]);
+    fn foreign_assign_sret(&mut self, sret_ptr: VReg);
+    fn foreign_issue_call(&mut self, symbol: &str);
+    fn foreign_cleanup_stack(&mut self, stack_count: usize);
+    fn foreign_cleanup_byref(&mut self, byref_bytes: u32);
+    fn foreign_zero_result(&mut self, primary: VReg);
+    fn foreign_scalar_result(&mut self, primary: VReg, ext: ScalarAbiExtension);
+    fn foreign_register_result(&mut self, primary: VReg, image: &AggregateImage) -> Vec<VReg>;
+    fn foreign_sret_result(
+        &mut self,
+        primary: VReg,
+        image: &AggregateImage,
+        sret_ptr: VReg,
+    ) -> Vec<VReg>;
+    fn foreign_move_primary(&mut self, primary: VReg, slot: VReg);
+}
+
+/// Lower one aggregate-crossing foreign call through the single shared event
+/// sequence. Concrete backends provide only instruction-selection leaves via
+/// [`ForeignCallLoweringBackend`].
+pub(crate) fn lower_foreign_call<B: ForeignCallLoweringBackend>(
+    backend: &mut B,
+    inputs: ForeignCallInputs,
+    primary: VReg,
+) -> crate::value_plan::MaterializedValue {
+    assert_eq!(
+        inputs.flavor,
+        backend.target_c_flavor(),
+        "foreign call ABI flavor disagrees with the selected backend"
+    );
+    let abi = TargetCCallAbi::new(backend.target_c_flavor());
+    let budget = usize::try_from(abi.int_arg_register_budget())
+        .expect("target-C integer argument budget must fit usize");
+    assert_eq!(
+        budget,
+        backend.foreign_int_arg_register_count(),
+        "backend argument-register roster disagrees with target-C ABI"
+    );
+    let plan = ForeignCallPlan::new(inputs, budget);
+    let inputs = &plan.inputs;
+
+    // Establish indirect-result storage first; it remains live through the
+    // call and is released only after its native slots have been reconstructed.
+    let sret_ptr = match &inputs.ret {
+        ForeignReturn::AggregateSret { image } => Some(backend.foreign_reserve_sret(image)),
+        _ => None,
+    };
+
+    let mut int_ops = Vec::new();
+    let mut stack_ops = Vec::new();
+    if plan.sret_in_argument_register {
+        int_ops.push(sret_ptr.expect("SysV sret placement requires storage"));
+    }
+    for placement in &plan.placements {
+        let to_register = matches!(placement, ForeignArgPlacement::Register { .. });
+        let arg = &inputs.args[placement.arg_index()];
+        let mut placed = |values: Vec<VReg>| {
+            if to_register {
+                int_ops.extend(values);
+            } else {
+                stack_ops.extend(values);
+            }
+        };
+        match arg {
+            ForeignArg::Scalar { value } => placed(vec![backend.foreign_get_vreg(*value)]),
+            ForeignArg::AggregateRegisters { value, image }
+            | ForeignArg::AggregateByvalStack { value, image } => {
+                if matches!(arg, ForeignArg::AggregateByvalStack { .. })
+                    && inputs.flavor != TargetCAbiFlavor::SysVAmd64
+                {
+                    panic!(
+                        "AAPCS64 passes a >16-byte aggregate by reference to a caller copy, not \
+                         byval-on-stack; ByValueStack is a SysV-only class"
+                    );
+                }
+                placed(backend.foreign_image_arg_eightbytes(*value, image));
+            }
+            ForeignArg::AggregateByRefCopy { value, image } => {
+                if inputs.flavor != TargetCAbiFlavor::Aapcs64 {
+                    panic!("SysV AMD64 does not pass foreign aggregates by reference");
+                }
+                placed(vec![backend.foreign_byref_copy(*value, image)]);
+            }
+        }
+    }
+
+    // The adapters own concrete stack layout and register moves, but the
+    // driver fixes the shared boundary order: outgoing stack, integer args,
+    // hidden sret assignment, call, then stack/byref cleanup.
+    backend.foreign_emit_stack_args(&stack_ops);
+    backend.foreign_emit_register_args(&int_ops);
+    if let Some(sret_ptr) = sret_ptr {
+        if !plan.sret_in_argument_register {
+            backend.foreign_assign_sret(sret_ptr);
+        }
+    }
+    backend.foreign_issue_call(inputs.symbol_ref());
+    backend.foreign_cleanup_stack(stack_ops.len());
+    backend.foreign_cleanup_byref(plan.byref_bytes);
+
+    let slots = match &inputs.ret {
+        ForeignReturn::ZeroSized => {
+            backend.foreign_zero_result(primary);
+            Vec::new()
+        }
+        ForeignReturn::Scalar { ext } => {
+            backend.foreign_scalar_result(primary, *ext);
+            Vec::new()
+        }
+        ForeignReturn::AggregateRegisters { image } => {
+            backend.foreign_register_result(primary, image)
+        }
+        ForeignReturn::AggregateSret { image } => backend.foreign_sret_result(
+            primary,
+            image,
+            sret_ptr.expect("sret return requires storage"),
+        ),
+    };
+    if let Some(&slot) = slots.first() {
+        backend.foreign_move_primary(primary, slot);
+    }
+    crate::value_plan::MaterializedValue { primary, slots }
+}
+
 impl ForeignCallInputs {
     /// Whether a foreign call to `return_ty` with `args` needs the aggregate
     /// path at all: true when the return or any argument is an aggregate
@@ -178,31 +514,24 @@ impl ForeignCallInputs {
         } else {
             0
         };
-        let mut used_registers =
-            if sret_storage_bytes > 0 && !abi.sret_pointer_in_dedicated_register() {
-                1_u64
-            } else {
-                0
-            };
-        let mut stack_cells = 0_u64;
+        let sret_in_argument_register =
+            sret_storage_bytes > 0 && !abi.sret_pointer_in_dedicated_register();
+        let shapes = args
+            .iter()
+            .map(|arg| shape_from_cfg_arg(cfg, type_pool, abi, arg))
+            .collect::<Result<Vec<_>, _>>()?;
+        let placement = place_foreign_args(&shapes, register_budget, sret_in_argument_register)?;
         let mut indirect_bytes = 0_u64;
 
-        for arg in args {
+        for (arg, shape) in args.iter().zip(&shapes) {
             let ty = cfg.get_inst(arg.value).ty;
             if !is_aggregate(ty) {
-                if used_registers < register_budget {
-                    used_registers += 1;
-                } else {
-                    stack_cells = stack_cells
-                        .checked_add(1)
-                        .ok_or(crate::frame_layout::FrameBudgetExceeded)?;
-                }
                 continue;
             }
 
             let layout = type_pool.layout(ty);
             match abi.classify_aggregate_arg(layout.size, layout.alignment) {
-                AggregateArgClass::IntegerRegisters { eightbytes } => {
+                AggregateArgClass::IntegerRegisters { .. } => {
                     // The backend marshals every register-packed aggregate
                     // through a temporary image buffer. It is short-lived, but
                     // can overlap the hidden sret area and any earlier AAPCS64
@@ -215,17 +544,6 @@ impl ForeignCallInputs {
                             .checked_add(u64::from(scratch))
                             .ok_or(crate::frame_layout::FrameBudgetExceeded)?,
                     )?;
-                    let eightbytes = u64::from(eightbytes);
-                    if used_registers
-                        .checked_add(eightbytes)
-                        .is_some_and(|used| used <= register_budget)
-                    {
-                        used_registers += eightbytes;
-                    } else {
-                        stack_cells = stack_cells
-                            .checked_add(eightbytes)
-                            .ok_or(crate::frame_layout::FrameBudgetExceeded)?;
-                    }
                 }
                 AggregateArgClass::ByValueStack { .. } => {
                     // SysV still needs a temporary C image before its
@@ -238,24 +556,19 @@ impl ForeignCallInputs {
                             .checked_add(u64::from(scratch))
                             .ok_or(crate::frame_layout::FrameBudgetExceeded)?,
                     )?;
-                    stack_cells = stack_cells
-                        .checked_add(layout.size.div_ceil(8))
-                        .ok_or(crate::frame_layout::FrameBudgetExceeded)?;
                 }
                 AggregateArgClass::ByReferenceCopy { .. } => {
                     indirect_bytes = indirect_bytes
-                        .checked_add(u64::from(checked_aligned_region_bytes(layout.size)?))
+                        .checked_add(shape.byref_bytes)
                         .ok_or(crate::frame_layout::FrameBudgetExceeded)?;
-                    if used_registers < register_budget {
-                        used_registers += 1;
-                    } else {
-                        stack_cells = stack_cells
-                            .checked_add(1)
-                            .ok_or(crate::frame_layout::FrameBudgetExceeded)?;
-                    }
                 }
             }
         }
+
+        assert_eq!(
+            indirect_bytes, placement.byref_bytes,
+            "foreign-call preflight and placement disagree on by-reference storage"
+        );
 
         if is_aggregate(return_ty) {
             let layout = type_pool.layout(return_ty);
@@ -270,7 +583,7 @@ impl ForeignCallInputs {
                 AggregateReturnClass::Indirect { .. } => {}
             }
         }
-        checked_call_area_bytes(stack_cells, sret_storage_bytes, indirect_bytes)
+        checked_call_area_bytes(placement.stack_cells, sret_storage_bytes, indirect_bytes)
     }
 
     /// Classify a foreign call through the shared [`TargetCCallAbi`] authority.
@@ -344,4 +657,373 @@ fn is_aggregate(ty: Type) -> bool {
         ty.kind(),
         rue_air::TypeKind::Struct(_) | rue_air::TypeKind::Array(_)
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rue_cfg::CfgValue;
+
+    fn image(size: u32) -> AggregateImage {
+        AggregateImage {
+            map: Vec::new(),
+            padding: Vec::new(),
+            slot_count: 0,
+            size,
+            align: 8,
+            storage_bytes: size.div_ceil(16) * 16,
+        }
+    }
+
+    fn scalar(index: u32) -> ForeignArg {
+        ForeignArg::Scalar {
+            value: CfgValue::from_raw(index),
+        }
+    }
+
+    #[test]
+    fn sysv_hidden_sret_and_aggregate_placement_are_shared_decisions() {
+        let inputs = ForeignCallInputs {
+            symbol: "f".into(),
+            flavor: TargetCAbiFlavor::SysVAmd64,
+            args: vec![
+                scalar(0),
+                ForeignArg::AggregateRegisters {
+                    value: CfgValue::from_raw(1),
+                    image: image(16),
+                },
+                scalar(2),
+                scalar(3),
+                scalar(4),
+            ],
+            ret: ForeignReturn::AggregateSret { image: image(24) },
+        };
+        let plan = ForeignCallPlan::new(inputs, 6);
+
+        assert!(plan.sret_in_argument_register);
+        assert_eq!(plan.placements.len(), 5);
+        assert!(matches!(
+            plan.placements[0],
+            ForeignArgPlacement::Register { .. }
+        ));
+        assert!(matches!(
+            plan.placements[1],
+            ForeignArgPlacement::Register { .. }
+        ));
+        assert!(matches!(
+            plan.placements[2],
+            ForeignArgPlacement::Register { .. }
+        ));
+        assert!(matches!(
+            plan.placements[3],
+            ForeignArgPlacement::Register { .. }
+        ));
+        assert!(matches!(
+            plan.placements[4],
+            ForeignArgPlacement::Stack { .. }
+        ));
+    }
+
+    #[test]
+    fn aapcs_byref_storage_does_not_consume_a_register_per_byte() {
+        let inputs = ForeignCallInputs {
+            symbol: "f".into(),
+            flavor: TargetCAbiFlavor::Aapcs64,
+            args: vec![ForeignArg::AggregateByRefCopy {
+                value: CfgValue::from_raw(0),
+                image: image(24),
+            }],
+            ret: ForeignReturn::ZeroSized,
+        };
+        let plan = ForeignCallPlan::new(inputs, 8);
+
+        assert!(!plan.sret_in_argument_register);
+        assert_eq!(plan.byref_bytes, 32);
+        assert!(matches!(
+            plan.placements[0],
+            ForeignArgPlacement::Register { .. }
+        ));
+    }
+
+    #[test]
+    fn placement_arithmetic_reports_budget_overflow_without_panicking() {
+        let byref_overflow = place_foreign_args(
+            &[
+                ForeignArgShape {
+                    pieces: 0,
+                    byref_bytes: u64::MAX,
+                    can_register: false,
+                },
+                ForeignArgShape {
+                    pieces: 0,
+                    byref_bytes: 1,
+                    can_register: false,
+                },
+            ],
+            0,
+            false,
+        );
+        assert!(byref_overflow.is_err());
+
+        let stack_overflow = place_foreign_args(
+            &[
+                ForeignArgShape {
+                    pieces: u64::MAX,
+                    byref_bytes: 0,
+                    can_register: false,
+                },
+                ForeignArgShape {
+                    pieces: 1,
+                    byref_bytes: 0,
+                    can_register: false,
+                },
+            ],
+            0,
+            false,
+        );
+        assert!(stack_overflow.is_err());
+
+        let register_overflow = place_foreign_args(
+            &[
+                ForeignArgShape {
+                    pieces: u64::MAX,
+                    byref_bytes: 0,
+                    can_register: true,
+                },
+                ForeignArgShape {
+                    pieces: 1,
+                    byref_bytes: 0,
+                    can_register: true,
+                },
+            ],
+            u64::MAX,
+            false,
+        );
+        assert!(register_overflow.is_err());
+    }
+
+    #[derive(Debug)]
+    struct TraceBackend {
+        flavor: TargetCAbiFlavor,
+        register_count: usize,
+        next_vreg: u32,
+        events: Vec<String>,
+    }
+
+    impl TraceBackend {
+        fn new(flavor: TargetCAbiFlavor, register_count: usize) -> Self {
+            Self {
+                flavor,
+                register_count,
+                next_vreg: 100,
+                events: Vec::new(),
+            }
+        }
+
+        fn vreg(&mut self) -> VReg {
+            let vreg = VReg::new(self.next_vreg);
+            self.next_vreg += 1;
+            vreg
+        }
+
+        fn record(&mut self, event: impl Into<String>) {
+            self.events.push(event.into());
+        }
+    }
+
+    impl ForeignCallLoweringBackend for TraceBackend {
+        fn target_c_flavor(&self) -> TargetCAbiFlavor {
+            self.flavor
+        }
+
+        fn foreign_int_arg_register_count(&self) -> usize {
+            self.register_count
+        }
+
+        fn foreign_reserve_sret(&mut self, _image: &AggregateImage) -> VReg {
+            self.record("reserve_sret");
+            self.vreg()
+        }
+
+        fn foreign_get_vreg(&mut self, value: CfgValue) -> VReg {
+            self.record(format!("get:{value:?}"));
+            self.vreg()
+        }
+
+        fn foreign_image_arg_eightbytes(
+            &mut self,
+            _value: CfgValue,
+            image: &AggregateImage,
+        ) -> Vec<VReg> {
+            self.record(format!("image:{}", image.eightbytes()));
+            (0..image.eightbytes()).map(|_| self.vreg()).collect()
+        }
+
+        fn foreign_byref_copy(&mut self, _value: CfgValue, image: &AggregateImage) -> VReg {
+            self.record(format!("byref:{}", image.storage_bytes));
+            self.vreg()
+        }
+
+        fn foreign_emit_stack_args(&mut self, stack_ops: &[VReg]) {
+            self.record(format!("stack:{stack_ops:?}"));
+        }
+
+        fn foreign_emit_register_args(&mut self, int_ops: &[VReg]) {
+            self.record(format!("registers:{int_ops:?}"));
+        }
+
+        fn foreign_assign_sret(&mut self, _sret_ptr: VReg) {
+            self.record("assign_sret");
+        }
+
+        fn foreign_issue_call(&mut self, symbol: &str) {
+            self.record(format!("call:{symbol}"));
+        }
+
+        fn foreign_cleanup_stack(&mut self, stack_count: usize) {
+            self.record(format!("cleanup_stack:{stack_count}"));
+        }
+
+        fn foreign_cleanup_byref(&mut self, byref_bytes: u32) {
+            self.record(format!("cleanup_byref:{byref_bytes}"));
+        }
+
+        fn foreign_zero_result(&mut self, _primary: VReg) {
+            self.record("zero_result");
+        }
+
+        fn foreign_scalar_result(&mut self, _primary: VReg, _ext: ScalarAbiExtension) {
+            self.record("scalar_result");
+        }
+
+        fn foreign_register_result(&mut self, _primary: VReg, image: &AggregateImage) -> Vec<VReg> {
+            self.record(format!("register_result:{}", image.eightbytes()));
+            vec![self.vreg()]
+        }
+
+        fn foreign_sret_result(
+            &mut self,
+            _primary: VReg,
+            image: &AggregateImage,
+            _sret_ptr: VReg,
+        ) -> Vec<VReg> {
+            self.record(format!("sret_result:{}", image.eightbytes()));
+            vec![self.vreg()]
+        }
+
+        fn foreign_move_primary(&mut self, _primary: VReg, _slot: VReg) {
+            self.record("move_primary");
+        }
+    }
+
+    #[test]
+    fn shared_driver_preserves_sysv_and_aapcs_event_order() {
+        let sysv_inputs = ForeignCallInputs {
+            symbol: "sysv_fn".into(),
+            flavor: TargetCAbiFlavor::SysVAmd64,
+            args: vec![
+                scalar(0),
+                ForeignArg::AggregateRegisters {
+                    value: CfgValue::from_raw(1),
+                    image: image(16),
+                },
+                scalar(2),
+                scalar(3),
+                scalar(4),
+            ],
+            ret: ForeignReturn::AggregateSret { image: image(24) },
+        };
+        let mut sysv = TraceBackend::new(TargetCAbiFlavor::SysVAmd64, 6);
+        let sysv_result = lower_foreign_call(&mut sysv, sysv_inputs, VReg::new(0));
+        assert_eq!(sysv_result.slots.len(), 1);
+        assert_eq!(
+            sysv.events,
+            vec![
+                "reserve_sret",
+                "get:CfgValue(0)",
+                "image:2",
+                "get:CfgValue(2)",
+                "get:CfgValue(3)",
+                "get:CfgValue(4)",
+                "stack:[VReg(106)]",
+                "registers:[VReg(100), VReg(101), VReg(102), VReg(103), VReg(104), VReg(105)]",
+                "call:sysv_fn",
+                "cleanup_stack:1",
+                "cleanup_byref:0",
+                "sret_result:3",
+                "move_primary",
+            ]
+        );
+
+        let aapcs_inputs = ForeignCallInputs {
+            symbol: "aapcs_fn".into(),
+            flavor: TargetCAbiFlavor::Aapcs64,
+            args: vec![
+                scalar(0),
+                ForeignArg::AggregateByRefCopy {
+                    value: CfgValue::from_raw(1),
+                    image: image(24),
+                },
+                scalar(2),
+                scalar(3),
+                scalar(4),
+                scalar(5),
+                scalar(6),
+                scalar(7),
+                scalar(8),
+                scalar(9),
+            ],
+            ret: ForeignReturn::AggregateSret { image: image(24) },
+        };
+        let mut aapcs = TraceBackend::new(TargetCAbiFlavor::Aapcs64, 8);
+        let aapcs_result = lower_foreign_call(&mut aapcs, aapcs_inputs, VReg::new(0));
+        assert_eq!(aapcs_result.slots.len(), 1);
+        assert_eq!(
+            aapcs.events,
+            vec![
+                "reserve_sret",
+                "get:CfgValue(0)",
+                "byref:32",
+                "get:CfgValue(2)",
+                "get:CfgValue(3)",
+                "get:CfgValue(4)",
+                "get:CfgValue(5)",
+                "get:CfgValue(6)",
+                "get:CfgValue(7)",
+                "get:CfgValue(8)",
+                "get:CfgValue(9)",
+                "stack:[VReg(109), VReg(110)]",
+                "registers:[VReg(101), VReg(102), VReg(103), VReg(104), VReg(105), VReg(106), VReg(107), VReg(108)]",
+                "assign_sret",
+                "call:aapcs_fn",
+                "cleanup_stack:2",
+                "cleanup_byref:32",
+                "sret_result:3",
+                "move_primary",
+            ]
+        );
+
+        let register_return_inputs = ForeignCallInputs {
+            symbol: "aapcs_register_fn".into(),
+            flavor: TargetCAbiFlavor::Aapcs64,
+            args: Vec::new(),
+            ret: ForeignReturn::AggregateRegisters { image: image(16) },
+        };
+        let mut register_return = TraceBackend::new(TargetCAbiFlavor::Aapcs64, 8);
+        let register_result =
+            lower_foreign_call(&mut register_return, register_return_inputs, VReg::new(0));
+        assert_eq!(register_result.slots.len(), 1);
+        assert_eq!(
+            register_return.events,
+            vec![
+                "stack:[]",
+                "registers:[]",
+                "call:aapcs_register_fn",
+                "cleanup_stack:0",
+                "cleanup_byref:0",
+                "register_result:2",
+                "move_primary",
+            ]
+        );
+    }
 }

--- a/crates/rue-codegen/src/vreg.rs
+++ b/crates/rue-codegen/src/vreg.rs
@@ -6,6 +6,10 @@
 
 use std::fmt;
 
+use ahash::AHashMap;
+
+use crate::reg_class::{RegClass, VRegClasses};
+
 /// Base ID for block labels in the partitioned label ID space.
 ///
 /// During codegen, we need labels for two purposes:
@@ -83,5 +87,115 @@ impl LabelId {
 impl fmt::Display for LabelId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, ".L{}", self.0)
+    }
+}
+
+/// Target-independent mutable state shared by both MIR implementations.
+///
+/// Virtual-register numbering and callable-symbol interning are properties of
+/// a MIR function, rather than of an instruction set. Keeping their authority
+/// here makes the x86-64 and AArch64 adapters preserve the same ordering and
+/// class-table invariants without maintaining parallel implementations.
+#[derive(Debug, Default)]
+pub struct MirState {
+    next_vreg: u32,
+    vreg_classes: VRegClasses,
+    symbols: Vec<String>,
+    symbol_index: AHashMap<String, u32>,
+}
+
+impl MirState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn intern_symbol(&mut self, symbol: &str) -> u32 {
+        if let Some(&idx) = self.symbol_index.get(symbol) {
+            return idx;
+        }
+        let idx = self.symbols.len() as u32;
+        let owned = symbol.to_owned();
+        self.symbol_index.insert(owned.clone(), idx);
+        self.symbols.push(owned);
+        idx
+    }
+
+    #[inline]
+    pub fn get_symbol(&self, symbol_id: u32) -> &str {
+        &self.symbols[symbol_id as usize]
+    }
+
+    #[inline]
+    pub fn symbols(&self) -> &[String] {
+        &self.symbols
+    }
+
+    pub fn take_symbols(&mut self) -> Vec<String> {
+        self.symbol_index.clear();
+        std::mem::take(&mut self.symbols)
+    }
+
+    pub fn set_symbols(&mut self, symbols: Vec<String>) {
+        self.symbol_index.clear();
+        for (idx, sym) in symbols.iter().enumerate() {
+            self.symbol_index.insert(sym.clone(), idx as u32);
+        }
+        self.symbols = symbols;
+    }
+
+    #[inline]
+    pub fn alloc_vreg(&mut self, class: RegClass) -> VReg {
+        let vreg = VReg::new(self.next_vreg);
+        self.next_vreg += 1;
+        self.vreg_classes.push(class);
+        vreg
+    }
+
+    #[inline]
+    pub fn vreg_classes(&self) -> &VRegClasses {
+        &self.vreg_classes
+    }
+
+    #[inline]
+    pub fn vreg_class(&self, vreg: VReg) -> RegClass {
+        self.vreg_classes.class_of(vreg)
+    }
+
+    #[inline]
+    pub fn vreg_count(&self) -> u32 {
+        self.next_vreg
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_state_preserves_symbol_ids_and_vreg_classes() {
+        let mut state = MirState::new();
+        assert_eq!(state.intern_symbol("alpha"), 0);
+        assert_eq!(state.intern_symbol("beta"), 1);
+        assert_eq!(state.intern_symbol("alpha"), 0);
+
+        let gp = state.alloc_vreg(RegClass::Gp);
+        let fp = state.alloc_vreg(RegClass::Fp);
+        assert_eq!(gp.index(), 0);
+        assert_eq!(fp.index(), 1);
+        assert_eq!(state.vreg_count(), 2);
+        assert_eq!(state.vreg_class(gp), RegClass::Gp);
+        assert_eq!(state.vreg_class(fp), RegClass::Fp);
+        assert_eq!(state.vreg_classes().len(), 2);
+    }
+
+    #[test]
+    fn shared_state_symbol_transfer_rebuilds_lookup() {
+        let mut state = MirState::new();
+        assert_eq!(state.intern_symbol("before"), 0);
+        let symbols = state.take_symbols();
+        assert_eq!(symbols, vec!["before"]);
+        state.set_symbols(vec!["restored".into(), "other".into()]);
+        assert_eq!(state.intern_symbol("restored"), 0);
+        assert_eq!(state.intern_symbol("new"), 2);
     }
 }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1251,218 +1251,6 @@ impl<'a> CfgLower<'a> {
         }
     }
 
-    /// Lower an `extern "C"` foreign call that crosses one or more aggregates by
-    /// value under SysV AMD64 (ADR-0064 P3). The classification comes from the
-    /// shared [`ForeignCallInputs`](crate::foreign_call::ForeignCallInputs)
-    /// authority; every aggregate is marshaled through its compact physical image
-    /// (C field order), so the native reversed-slot packing is never used.
-    fn lower_foreign_call(
-        &mut self,
-        inputs: crate::foreign_call::ForeignCallInputs,
-        primary: VReg,
-    ) -> crate::value_plan::MaterializedValue {
-        use crate::foreign_call::{ForeignArg, ForeignReturn};
-        let abi = rue_air::TargetCCallAbi::new(inputs.flavor);
-        let budget = ARG_REGS.len();
-
-        // Reserve sret storage first: a >16-byte aggregate return writes here and
-        // the buffer must survive the call. Its size is 16-aligned, preserving
-        // the call site's 16-byte stack alignment.
-        let mut sret_ptr: Option<VReg> = None;
-        let mut sret_storage: u32 = 0;
-        if let ForeignReturn::AggregateSret { image } = &inputs.ret {
-            sret_storage = image.storage_bytes;
-            self.mir.push(X86Inst::AddRI {
-                dst: Operand::Physical(Reg::Rsp),
-                imm: -checked_displacement_bytes(u64::from(sret_storage))
-                    .expect("foreign sret storage must fit displacement"),
-            });
-            let p = self.mir.alloc_vreg();
-            self.mir.push(X86Inst::MovRR {
-                dst: Operand::Virtual(p),
-                src: Operand::Physical(Reg::Rsp),
-            });
-            sret_ptr = Some(p);
-        }
-
-        // Physical argument operands: `int_ops` fill ARG_REGS in order, `stack_ops`
-        // are 8-byte outgoing-stack slots (ascending). The SysV sret pointer is the
-        // hidden first integer argument (rdi); AAPCS64's dedicated x8 never reaches
-        // this x86 path.
-        let mut int_ops: Vec<VReg> = Vec::new();
-        let mut stack_ops: Vec<VReg> = Vec::new();
-        if let Some(p) = sret_ptr {
-            assert!(
-                !abi.sret_pointer_in_dedicated_register(),
-                "x86-64 SysV must pass the sret pointer as the first integer argument"
-            );
-            int_ops.push(p);
-        }
-
-        for arg in &inputs.args {
-            match arg {
-                ForeignArg::Scalar { value } => {
-                    let v = self.get_vreg(*value);
-                    if int_ops.len() < budget {
-                        int_ops.push(v);
-                    } else {
-                        stack_ops.push(v);
-                    }
-                }
-                ForeignArg::AggregateRegisters { value, image } => {
-                    let ebs = self.image_arg_eightbytes(*value, image);
-                    // All-or-nothing: an aggregate uses registers only if all its
-                    // eightbytes fit in the remaining integer registers (SysV).
-                    if int_ops.len() + ebs.len() <= budget {
-                        int_ops.extend(ebs);
-                    } else {
-                        stack_ops.extend(ebs);
-                    }
-                }
-                ForeignArg::AggregateByvalStack { value, image } => {
-                    // SysV MEMORY class: the whole struct image sits in the
-                    // outgoing stack area (contiguous, ascending), consuming no
-                    // integer registers.
-                    let ebs = self.image_arg_eightbytes(*value, image);
-                    stack_ops.extend(ebs);
-                }
-                ForeignArg::AggregateByRefCopy { .. } => {
-                    panic!(
-                        "SysV AMD64 passes a >16-byte aggregate byval-on-stack, not by reference; \
-                         ByReferenceCopy is an AAPCS64-only class"
-                    )
-                }
-            }
-        }
-
-        // Emit the call frame: stack args first (reverse push so the first stack
-        // arg lands at the lowest address), then the integer args pushed and popped
-        // into ARG_REGS, matching the native `lower_call_plan` idiom.
-        let num_stack = stack_ops.len();
-        let stack_cell_bytes = checked_cell_region_bytes(
-            u64::try_from(num_stack).expect("foreign stack slot count must fit u64"),
-        )
-        .expect("foreign stack area must fit displacement");
-        let stack_bytes = checked_aligned_cell_region_bytes(
-            u64::try_from(num_stack).expect("foreign stack slot count must fit u64"),
-        )
-        .expect("foreign stack area must pass frame-budget preflight");
-        let needs_alignment = stack_bytes > stack_cell_bytes;
-        if needs_alignment {
-            self.mir.push(X86Inst::AddRI {
-                dst: Operand::Physical(Reg::Rsp),
-                imm: -i32::try_from(
-                    checked_cell_region_padding_bytes(
-                        u64::try_from(num_stack).expect("foreign stack slot count must fit u64"),
-                    )
-                    .expect("foreign stack alignment padding must fit displacement"),
-                )
-                .expect("foreign stack alignment padding must fit i32"),
-            });
-        }
-        for v in stack_ops.iter().rev() {
-            self.mir.push(X86Inst::MovRR {
-                dst: Operand::Physical(Reg::Rax),
-                src: Operand::Virtual(*v),
-            });
-            self.mir.push(X86Inst::Push {
-                src: Operand::Physical(Reg::Rax),
-            });
-        }
-        for v in int_ops.iter().rev() {
-            self.mir.push(X86Inst::MovRR {
-                dst: Operand::Physical(Reg::Rax),
-                src: Operand::Virtual(*v),
-            });
-            self.mir.push(X86Inst::Push {
-                src: Operand::Physical(Reg::Rax),
-            });
-        }
-        for index in 0..int_ops.len() {
-            self.mir.push(X86Inst::Pop {
-                dst: Operand::Physical(ARG_REGS[index]),
-            });
-        }
-        let symbol_id = self.intern_symbol(inputs.symbol_ref());
-        self.mir.push(X86Inst::call(symbol_id));
-        if num_stack > 0 || needs_alignment {
-            self.mir.push(X86Inst::AddRI {
-                dst: Operand::Physical(Reg::Rsp),
-                imm: checked_displacement_bytes(u64::from(stack_bytes))
-                    .expect("foreign stack area must fit displacement"),
-            });
-        }
-
-        // Reconstruct the Rue value from the C result.
-        let slots = match &inputs.ret {
-            ForeignReturn::ZeroSized => {
-                self.mir.push(X86Inst::MovRI32 {
-                    dst: Operand::Virtual(primary),
-                    imm: 0,
-                });
-                Vec::new()
-            }
-            ForeignReturn::Scalar { ext } => {
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Virtual(primary),
-                    src: Operand::Physical(Reg::Rax),
-                });
-                self.emit_c_return_extension(primary, *ext);
-                Vec::new()
-            }
-            ForeignReturn::AggregateRegisters { image } => {
-                // rax:rdx hold the return eightbytes (C field order). Store them to
-                // a scratch buffer, then read the native slots back through the
-                // compact image map so downstream sees the ascending decomposition.
-                let eb = image.eightbytes();
-                self.mir.push(X86Inst::AddRI {
-                    dst: Operand::Physical(Reg::Rsp),
-                    imm: -checked_displacement_bytes(u64::from(image.storage_bytes))
-                        .expect("foreign result storage must fit displacement"),
-                });
-                let buf = self.mir.alloc_vreg();
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Virtual(buf),
-                    src: Operand::Physical(Reg::Rsp),
-                });
-                let mut eb_vals = Vec::with_capacity(eb as usize);
-                for index in 0..eb as usize {
-                    let v = self.mir.alloc_vreg();
-                    self.mir.push(X86Inst::MovRR {
-                        dst: Operand::Virtual(v),
-                        src: Operand::Physical(RET_REGS[index]),
-                    });
-                    eb_vals.push(v);
-                }
-                crate::agg_slots::store_slots_through_ptr(self, &eb_vals, buf, 0);
-                let native = crate::agg_slots::load_enum_slots_through_ptr(self, buf, &image.map);
-                self.mir.push(X86Inst::AddRI {
-                    dst: Operand::Physical(Reg::Rsp),
-                    imm: checked_displacement_bytes(u64::from(image.storage_bytes))
-                        .expect("foreign result storage must fit displacement"),
-                });
-                native
-            }
-            ForeignReturn::AggregateSret { image } => {
-                let p = sret_ptr.expect("an sret return reserved its storage pointer");
-                let native = crate::agg_slots::load_enum_slots_through_ptr(self, p, &image.map);
-                self.mir.push(X86Inst::AddRI {
-                    dst: Operand::Physical(Reg::Rsp),
-                    imm: checked_displacement_bytes(u64::from(sret_storage))
-                        .expect("foreign sret storage must fit displacement"),
-                });
-                native
-            }
-        };
-        if let Some(&slot) = slots.first() {
-            self.mir.push(X86Inst::MovRR {
-                dst: Operand::Virtual(primary),
-                src: Operand::Virtual(slot),
-            });
-        }
-        crate::value_plan::MaterializedValue { primary, slots }
-    }
-
     /// Materialize an aggregate argument's eightbytes (ADR-0064 P3): write its
     /// native slots into a scratch buffer as the compact C image, then load the
     /// whole eightbytes back so they pack in ascending C field order. The scratch
@@ -3164,7 +2952,9 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
         inputs: crate::foreign_call::ForeignCallInputs,
         result: VReg,
     ) -> crate::value_plan::ValueResult {
-        crate::value_plan::ValueResult::Materialized(self.lower_foreign_call(inputs, result))
+        crate::value_plan::ValueResult::Materialized(crate::foreign_call::lower_foreign_call(
+            self, inputs, result,
+        ))
     }
     fn emit_runtime_call(
         &mut self,
@@ -3234,6 +3024,190 @@ fn emit_marshal_tag_ne(mir: &mut X86Mir, tag: VReg, discriminant: u32, label: La
         });
     }
     mir.push(X86Inst::Jnz { label });
+}
+
+impl crate::foreign_call::ForeignCallLoweringBackend for CfgLower<'_> {
+    fn target_c_flavor(&self) -> rue_air::TargetCAbiFlavor {
+        rue_air::TargetCAbiFlavor::SysVAmd64
+    }
+
+    fn foreign_int_arg_register_count(&self) -> usize {
+        ARG_REGS.len()
+    }
+
+    fn foreign_reserve_sret(&mut self, image: &crate::foreign_call::AggregateImage) -> VReg {
+        self.mir.push(X86Inst::AddRI {
+            dst: Operand::Physical(Reg::Rsp),
+            imm: -checked_displacement_bytes(u64::from(image.storage_bytes))
+                .expect("foreign sret storage must fit displacement"),
+        });
+        let ptr = self.mir.alloc_vreg();
+        self.mir.push(X86Inst::MovRR {
+            dst: Operand::Virtual(ptr),
+            src: Operand::Physical(Reg::Rsp),
+        });
+        ptr
+    }
+
+    fn foreign_get_vreg(&mut self, value: CfgValue) -> VReg {
+        self.get_vreg(value)
+    }
+
+    fn foreign_image_arg_eightbytes(
+        &mut self,
+        value: CfgValue,
+        image: &crate::foreign_call::AggregateImage,
+    ) -> Vec<VReg> {
+        self.image_arg_eightbytes(value, image)
+    }
+
+    fn foreign_byref_copy(
+        &mut self,
+        _value: CfgValue,
+        _image: &crate::foreign_call::AggregateImage,
+    ) -> VReg {
+        panic!("SysV AMD64 does not pass foreign aggregates by reference")
+    }
+
+    fn foreign_emit_stack_args(&mut self, stack_ops: &[VReg]) {
+        let count = u64::try_from(stack_ops.len()).expect("foreign stack slot count must fit u64");
+        let cell_bytes =
+            checked_cell_region_bytes(count).expect("foreign stack area must fit displacement");
+        let stack_bytes = checked_aligned_cell_region_bytes(count)
+            .expect("foreign stack area must pass frame-budget preflight");
+        if stack_bytes > cell_bytes {
+            self.mir.push(X86Inst::AddRI {
+                dst: Operand::Physical(Reg::Rsp),
+                imm: -i32::try_from(
+                    checked_cell_region_padding_bytes(count)
+                        .expect("foreign stack alignment padding must fit displacement"),
+                )
+                .expect("foreign stack alignment padding must fit i32"),
+            });
+        }
+        for v in stack_ops.iter().rev() {
+            self.mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rax),
+                src: Operand::Virtual(*v),
+            });
+            self.mir.push(X86Inst::Push {
+                src: Operand::Physical(Reg::Rax),
+            });
+        }
+    }
+
+    fn foreign_emit_register_args(&mut self, int_ops: &[VReg]) {
+        for v in int_ops.iter().rev() {
+            self.mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rax),
+                src: Operand::Virtual(*v),
+            });
+            self.mir.push(X86Inst::Push {
+                src: Operand::Physical(Reg::Rax),
+            });
+        }
+        for (index, _) in int_ops.iter().enumerate() {
+            self.mir.push(X86Inst::Pop {
+                dst: Operand::Physical(ARG_REGS[index]),
+            });
+        }
+    }
+
+    fn foreign_assign_sret(&mut self, _sret_ptr: VReg) {
+        panic!("SysV AMD64 assigns sret through the first integer argument")
+    }
+
+    fn foreign_issue_call(&mut self, symbol: &str) {
+        let symbol_id = self.intern_symbol(symbol);
+        self.mir.push(X86Inst::call(symbol_id));
+    }
+
+    fn foreign_cleanup_stack(&mut self, stack_count: usize) {
+        if stack_count > 0 {
+            let stack_bytes = checked_aligned_cell_region_bytes(
+                u64::try_from(stack_count).expect("foreign stack slot count must fit u64"),
+            )
+            .expect("foreign stack area must pass frame-budget preflight");
+            self.mir.push(X86Inst::AddRI {
+                dst: Operand::Physical(Reg::Rsp),
+                imm: checked_displacement_bytes(u64::from(stack_bytes))
+                    .expect("foreign stack area must fit displacement"),
+            });
+        }
+    }
+
+    fn foreign_cleanup_byref(&mut self, _byref_bytes: u32) {}
+
+    fn foreign_zero_result(&mut self, primary: VReg) {
+        self.mir.push(X86Inst::MovRI32 {
+            dst: Operand::Virtual(primary),
+            imm: 0,
+        });
+    }
+
+    fn foreign_scalar_result(&mut self, primary: VReg, ext: rue_air::ScalarAbiExtension) {
+        self.mir.push(X86Inst::MovRR {
+            dst: Operand::Virtual(primary),
+            src: Operand::Physical(Reg::Rax),
+        });
+        self.emit_c_return_extension(primary, ext);
+    }
+
+    fn foreign_register_result(
+        &mut self,
+        _primary: VReg,
+        image: &crate::foreign_call::AggregateImage,
+    ) -> Vec<VReg> {
+        self.mir.push(X86Inst::AddRI {
+            dst: Operand::Physical(Reg::Rsp),
+            imm: -checked_displacement_bytes(u64::from(image.storage_bytes))
+                .expect("foreign result storage must fit displacement"),
+        });
+        let buf = self.mir.alloc_vreg();
+        self.mir.push(X86Inst::MovRR {
+            dst: Operand::Virtual(buf),
+            src: Operand::Physical(Reg::Rsp),
+        });
+        let mut eb_vals = Vec::with_capacity(image.eightbytes() as usize);
+        for index in 0..image.eightbytes() as usize {
+            let v = self.mir.alloc_vreg();
+            self.mir.push(X86Inst::MovRR {
+                dst: Operand::Virtual(v),
+                src: Operand::Physical(RET_REGS[index]),
+            });
+            eb_vals.push(v);
+        }
+        crate::agg_slots::store_slots_through_ptr(self, &eb_vals, buf, 0);
+        let native = crate::agg_slots::load_enum_slots_through_ptr(self, buf, &image.map);
+        self.mir.push(X86Inst::AddRI {
+            dst: Operand::Physical(Reg::Rsp),
+            imm: checked_displacement_bytes(u64::from(image.storage_bytes))
+                .expect("foreign result storage must fit displacement"),
+        });
+        native
+    }
+
+    fn foreign_sret_result(
+        &mut self,
+        _primary: VReg,
+        image: &crate::foreign_call::AggregateImage,
+        sret_ptr: VReg,
+    ) -> Vec<VReg> {
+        let native = crate::agg_slots::load_enum_slots_through_ptr(self, sret_ptr, &image.map);
+        self.mir.push(X86Inst::AddRI {
+            dst: Operand::Physical(Reg::Rsp),
+            imm: checked_displacement_bytes(u64::from(image.storage_bytes))
+                .expect("foreign sret storage must fit displacement"),
+        });
+        native
+    }
+
+    fn foreign_move_primary(&mut self, primary: VReg, slot: VReg) {
+        self.mir.push(X86Inst::MovRR {
+            dst: Operand::Virtual(primary),
+            src: Operand::Virtual(slot),
+        });
+    }
 }
 
 impl crate::agg_slots::SlotBackend for CfgLower<'_> {

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -5,7 +5,6 @@
 //! - Uses virtual registers (unlimited) that are later allocated to physical registers
 //! - Can be emitted to machine code or assembly text
 
-use ahash::AHashMap;
 use std::fmt;
 
 pub use rue_runtime_abi::ReturnBehavior;
@@ -19,6 +18,7 @@ pub use rue_runtime_abi::ReturnBehavior;
 const _: () = assert!(std::mem::size_of::<X86Inst>() <= 40);
 
 pub use crate::reg_class::{RegClass, VRegClasses};
+use crate::vreg::MirState;
 pub use crate::vreg::{LabelId, VReg};
 
 /// A physical x86-64 register.
@@ -995,22 +995,10 @@ impl fmt::Display for X86Inst {
 pub struct X86Mir {
     /// The instructions in this function.
     instructions: Vec<X86Inst>,
-    /// The next virtual register index.
-    next_vreg: u32,
-    /// The register class of each virtual register, one entry per register
-    /// minted by [`X86Mir::alloc_vreg_in`] and indexed by vreg index.
-    vreg_classes: VRegClasses,
+    /// Shared virtual-register and symbol-interning state.
+    state: MirState,
     /// The next label index.
     next_label: u32,
-    /// Symbol table for call targets.
-    ///
-    /// Stores symbol names indexed by `symbol_id` in `CallRel` instructions.
-    /// This avoids heap-allocating a String for every call instruction.
-    symbols: Vec<String>,
-    /// Index for O(1) symbol lookup during interning.
-    ///
-    /// Maps symbol names to their indices in the `symbols` vector.
-    symbol_index: AHashMap<String, u32>,
 }
 
 impl X86Mir {
@@ -1018,11 +1006,8 @@ impl X86Mir {
     pub fn new() -> Self {
         Self {
             instructions: Vec::new(),
-            next_vreg: 0,
-            vreg_classes: VRegClasses::new(),
+            state: MirState::new(),
             next_label: 0,
-            symbols: Vec::new(),
-            symbol_index: AHashMap::new(),
         }
     }
 
@@ -1031,16 +1016,7 @@ impl X86Mir {
     /// If the symbol already exists, returns its existing ID.
     /// Otherwise, adds it to the table and returns the new ID.
     pub fn intern_symbol(&mut self, symbol: &str) -> u32 {
-        // O(1) lookup via AHashMap
-        if let Some(&idx) = self.symbol_index.get(symbol) {
-            return idx;
-        }
-        // Add new symbol
-        let idx = self.symbols.len() as u32;
-        let owned = symbol.to_string();
-        self.symbol_index.insert(owned.clone(), idx);
-        self.symbols.push(owned);
-        idx
+        self.state.intern_symbol(symbol)
     }
 
     /// Get a symbol name by its ID.
@@ -1049,33 +1025,27 @@ impl X86Mir {
     /// Panics if the symbol_id is out of bounds.
     #[inline]
     pub fn get_symbol(&self, symbol_id: u32) -> &str {
-        &self.symbols[symbol_id as usize]
+        self.state.get_symbol(symbol_id)
     }
 
     /// Get the symbol table.
     #[inline]
     pub fn symbols(&self) -> &[String] {
-        &self.symbols
+        self.state.symbols()
     }
 
     /// Take ownership of the symbol table.
     ///
     /// Used during register allocation to transfer symbols to the rewritten MIR.
     pub fn take_symbols(&mut self) -> Vec<String> {
-        self.symbol_index.clear();
-        std::mem::take(&mut self.symbols)
+        self.state.take_symbols()
     }
 
     /// Set the symbol table.
     ///
     /// Used during register allocation to restore symbols from the pre-rewrite MIR.
     pub fn set_symbols(&mut self, symbols: Vec<String>) {
-        // Rebuild the index from the symbol table
-        self.symbol_index.clear();
-        for (idx, sym) in symbols.iter().enumerate() {
-            self.symbol_index.insert(sym.clone(), idx as u32);
-        }
-        self.symbols = symbols;
+        self.state.set_symbols(symbols);
     }
 
     /// Allocate a new general-purpose virtual register.
@@ -1094,22 +1064,19 @@ impl X86Mir {
     /// liveness hand allocation a table that covers every virtual register the
     /// function has.
     pub fn alloc_vreg_in(&mut self, class: RegClass) -> VReg {
-        let vreg = VReg::new(self.next_vreg);
-        self.next_vreg += 1;
-        self.vreg_classes.push(class);
-        vreg
+        self.state.alloc_vreg(class)
     }
 
     /// The register class of each virtual register.
     #[inline]
     pub fn vreg_classes(&self) -> &VRegClasses {
-        &self.vreg_classes
+        self.state.vreg_classes()
     }
 
     /// The register class of one virtual register.
     #[inline]
     pub fn vreg_class(&self, vreg: VReg) -> RegClass {
-        self.vreg_classes.class_of(vreg)
+        self.state.vreg_class(vreg)
     }
 
     /// Allocate a new label ID.
@@ -1122,7 +1089,7 @@ impl X86Mir {
     /// Get the number of virtual registers allocated.
     #[inline]
     pub fn vreg_count(&self) -> u32 {
-        self.next_vreg
+        self.state.vreg_count()
     }
 
     /// Get the number of instructions.


### PR DESCRIPTION
## Summary

- centralize aggregate foreign-call placement and lifecycle sequencing behind one shared backend contract
- share MIR symbol interning and virtual-register state across x86-64 and AArch64
- add parity traces and structural guards against duplicate authorities

## Validation

- scripts/rue fmt
- scripts/rue quick
- scripts/rue cli c_ffi
- scripts/rue premerge
- scripts/rue test

Fixes RUE-1672