### PR TITLE
RUE-1666: chunk runtime memory primitives

### DIFF
--- a/crates/rue-runtime/BUCK
+++ b/crates/rue-runtime/BUCK
@@ -54,6 +54,11 @@ runtime_staticlib(
     visibility = ["PUBLIC"],
 )
 
+export_file(
+    name = "runtime-str-eq-source",
+    src = "src/string.rs",
+)
+
 rue_sh_test(
     name = "runtime-archives-test",
     platform = "native",
@@ -63,7 +68,14 @@ rue_sh_test(
         "RUNTIME_X86_64_LINUX": "$(location :rue-runtime-x86_64-unknown-linux-gnu)",
         "RUNTIME_AARCH64_LINUX": "$(location :rue-runtime-aarch64-unknown-linux-gnu)",
         "RUNTIME_AARCH64_MACOS": "$(location :rue-runtime-aarch64-apple-darwin)",
+        "RUNTIME_STRING_SOURCE": "$(location :runtime-str-eq-source)",
     },
+)
+
+rue_sh_test(
+    name = "runtime-archive-parser-test",
+    test = "tests/test_validate_runtime_archives.py",
+    resources = ["tests/validate_runtime_archives.py"],
 )
 
 # Unit tests for the runtime, compiled natively for the host WITHOUT the

--- a/crates/rue-runtime/BUCK
+++ b/crates/rue-runtime/BUCK
@@ -59,6 +59,11 @@ export_file(
     src = "src/string.rs",
 )
 
+export_file(
+    name = "runtime-lib-source",
+    src = "src/lib.rs",
+)
+
 rue_sh_test(
     name = "runtime-archives-test",
     platform = "native",
@@ -75,7 +80,10 @@ rue_sh_test(
 rue_sh_test(
     name = "runtime-archive-parser-test",
     test = "tests/test_validate_runtime_archives.py",
-    resources = ["tests/validate_runtime_archives.py"],
+    resources = ["tests/validate_runtime_archives.py", "src/lib.rs"],
+    env = {
+        "RUNTIME_LIB_SOURCE": "$(location :runtime-lib-source)",
+    },
 )
 
 # Unit tests for the runtime, compiled natively for the host WITHOUT the

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -249,6 +249,7 @@ macro_rules! declare_runtime_helpers {
 
 rue_runtime_abi::for_each_runtime_helper!(declare_runtime_helpers);
 
+#[allow(unused_macros)]
 macro_rules! call_reserved_export_implementation {
     (memcpy($($argument:expr),*)) => { crate::memory::memcpy($($argument),*) };
     (memmove($($argument:expr),*)) => { crate::memory::memmove($($argument),*) };
@@ -269,6 +270,10 @@ macro_rules! declare_reserved_function {
         all unsafe $function:ident($($argument:ident : $rust_type:ty),* $(,)?)
         $(-> $result:ty)?
     ) => {
+        // These libc-shaped names must not be present in a libtest binary:
+        // the host test harness and its standard library may call them while
+        // starting up. Production staticlibs still expose the ABI boundary.
+        #[cfg(not(test))]
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn $function($($argument: $rust_type),*) $(-> $result)? {
             // SAFETY: The reserved-export manifest records the complete caller

--- a/crates/rue-runtime/src/memory.rs
+++ b/crates/rue-runtime/src/memory.rs
@@ -92,6 +92,220 @@ unsafe fn write_chunk(dst: *mut u8, value: u64) {
     unsafe { core::ptr::write_unaligned(dst.cast::<u64>(), value) }
 }
 
+#[inline(never)]
+unsafe fn copy_forward_tail(dst: *mut u8, src: *const u8, remaining: usize) {
+    match remaining {
+        0 => {}
+        1 => unsafe { *dst = *src },
+        2 => unsafe {
+            *dst = *src;
+            *dst.add(1) = *src.add(1);
+        },
+        3 => unsafe {
+            *dst = *src;
+            *dst.add(1) = *src.add(1);
+            *dst.add(2) = *src.add(2);
+        },
+        4 => unsafe {
+            *dst = *src;
+            *dst.add(1) = *src.add(1);
+            *dst.add(2) = *src.add(2);
+            *dst.add(3) = *src.add(3);
+        },
+        5 => unsafe {
+            *dst = *src;
+            *dst.add(1) = *src.add(1);
+            *dst.add(2) = *src.add(2);
+            *dst.add(3) = *src.add(3);
+            *dst.add(4) = *src.add(4);
+        },
+        6 => unsafe {
+            *dst = *src;
+            *dst.add(1) = *src.add(1);
+            *dst.add(2) = *src.add(2);
+            *dst.add(3) = *src.add(3);
+            *dst.add(4) = *src.add(4);
+            *dst.add(5) = *src.add(5);
+        },
+        7 => unsafe {
+            *dst = *src;
+            *dst.add(1) = *src.add(1);
+            *dst.add(2) = *src.add(2);
+            *dst.add(3) = *src.add(3);
+            *dst.add(4) = *src.add(4);
+            *dst.add(5) = *src.add(5);
+            *dst.add(6) = *src.add(6);
+        },
+        _ => unsafe { core::hint::unreachable_unchecked() },
+    }
+}
+
+#[inline(never)]
+unsafe fn copy_backward_tail(dst: *mut u8, src: *const u8, remaining: usize) {
+    match remaining {
+        0 => {}
+        1 => unsafe { *dst = *src },
+        2 => unsafe {
+            *dst.add(1) = *src.add(1);
+            *dst = *src;
+        },
+        3 => unsafe {
+            *dst.add(2) = *src.add(2);
+            *dst.add(1) = *src.add(1);
+            *dst = *src;
+        },
+        4 => unsafe {
+            *dst.add(3) = *src.add(3);
+            *dst.add(2) = *src.add(2);
+            *dst.add(1) = *src.add(1);
+            *dst = *src;
+        },
+        5 => unsafe {
+            *dst.add(4) = *src.add(4);
+            *dst.add(3) = *src.add(3);
+            *dst.add(2) = *src.add(2);
+            *dst.add(1) = *src.add(1);
+            *dst = *src;
+        },
+        6 => unsafe {
+            *dst.add(5) = *src.add(5);
+            *dst.add(4) = *src.add(4);
+            *dst.add(3) = *src.add(3);
+            *dst.add(2) = *src.add(2);
+            *dst.add(1) = *src.add(1);
+            *dst = *src;
+        },
+        7 => unsafe {
+            *dst.add(6) = *src.add(6);
+            *dst.add(5) = *src.add(5);
+            *dst.add(4) = *src.add(4);
+            *dst.add(3) = *src.add(3);
+            *dst.add(2) = *src.add(2);
+            *dst.add(1) = *src.add(1);
+            *dst = *src;
+        },
+        _ => unsafe { core::hint::unreachable_unchecked() },
+    }
+}
+
+#[inline(never)]
+unsafe fn set_tail(dst: *mut u8, value: u8, remaining: usize) {
+    match remaining {
+        0 => {}
+        1 => unsafe { *dst = value },
+        2 => unsafe {
+            *dst = value;
+            *dst.add(1) = value;
+        },
+        3 => unsafe {
+            *dst = value;
+            *dst.add(1) = value;
+            *dst.add(2) = value;
+        },
+        4 => unsafe {
+            *dst = value;
+            *dst.add(1) = value;
+            *dst.add(2) = value;
+            *dst.add(3) = value;
+        },
+        5 => unsafe {
+            *dst = value;
+            *dst.add(1) = value;
+            *dst.add(2) = value;
+            *dst.add(3) = value;
+            *dst.add(4) = value;
+        },
+        6 => unsafe {
+            *dst = value;
+            *dst.add(1) = value;
+            *dst.add(2) = value;
+            *dst.add(3) = value;
+            *dst.add(4) = value;
+            *dst.add(5) = value;
+        },
+        7 => unsafe {
+            *dst = value;
+            *dst.add(1) = value;
+            *dst.add(2) = value;
+            *dst.add(3) = value;
+            *dst.add(4) = value;
+            *dst.add(5) = value;
+            *dst.add(6) = value;
+        },
+        _ => unsafe { core::hint::unreachable_unchecked() },
+    }
+}
+
+#[inline(never)]
+unsafe fn compare_bounded(a: *const u8, b: *const u8, remaining: usize) -> i32 {
+    macro_rules! compare_byte {
+        ($offset:expr) => {{
+            // SAFETY: The caller established that the bounded range contains
+            // every byte in this explicitly unrolled comparison.
+            let left = unsafe { *a.add($offset) };
+            let right = unsafe { *b.add($offset) };
+            if left != right {
+                return i32::from(left) - i32::from(right);
+            }
+        }};
+    }
+    match remaining {
+        0 => {}
+        1 => compare_byte!(0),
+        2 => {
+            compare_byte!(0);
+            compare_byte!(1);
+        }
+        3 => {
+            compare_byte!(0);
+            compare_byte!(1);
+            compare_byte!(2);
+        }
+        4 => {
+            compare_byte!(0);
+            compare_byte!(1);
+            compare_byte!(2);
+            compare_byte!(3);
+        }
+        5 => {
+            compare_byte!(0);
+            compare_byte!(1);
+            compare_byte!(2);
+            compare_byte!(3);
+            compare_byte!(4);
+        }
+        6 => {
+            compare_byte!(0);
+            compare_byte!(1);
+            compare_byte!(2);
+            compare_byte!(3);
+            compare_byte!(4);
+            compare_byte!(5);
+        }
+        7 => {
+            compare_byte!(0);
+            compare_byte!(1);
+            compare_byte!(2);
+            compare_byte!(3);
+            compare_byte!(4);
+            compare_byte!(5);
+            compare_byte!(6);
+        }
+        8 => {
+            compare_byte!(0);
+            compare_byte!(1);
+            compare_byte!(2);
+            compare_byte!(3);
+            compare_byte!(4);
+            compare_byte!(5);
+            compare_byte!(6);
+            compare_byte!(7);
+        }
+        _ => unsafe { core::hint::unreachable_unchecked() },
+    }
+    0
+}
+
 #[inline(always)]
 unsafe fn copy_forward(mut dst: *mut u8, mut src: *const u8, mut remaining: usize) {
     while remaining >= CHUNK_SIZE {
@@ -106,13 +320,8 @@ unsafe fn copy_forward(mut dst: *mut u8, mut src: *const u8, mut remaining: usiz
         remaining -= CHUNK_SIZE;
     }
 
-    while remaining != 0 {
-        // SAFETY: The tail byte is within both caller-provided ranges.
-        unsafe { *dst = *src };
-        dst = unsafe { dst.add(1) };
-        src = unsafe { src.add(1) };
-        remaining -= 1;
-    }
+    // SAFETY: The remaining tail is smaller than one chunk.
+    unsafe { copy_forward_tail(dst, src, remaining) };
 }
 
 #[inline(always)]
@@ -125,11 +334,8 @@ unsafe fn copy_backward(dst: *mut u8, src: *const u8, mut remaining: usize) {
         unsafe { write_chunk(dst.add(remaining), value) };
     }
 
-    while remaining != 0 {
-        remaining -= 1;
-        // SAFETY: The tail byte is within both caller-provided ranges.
-        unsafe { *dst.add(remaining) = *src.add(remaining) };
-    }
+    // SAFETY: The remaining tail is smaller than one chunk.
+    unsafe { copy_backward_tail(dst, src, remaining) };
 }
 
 /// Copy `n` bytes from `src` to `dst`. The memory regions must not overlap.
@@ -184,12 +390,8 @@ pub unsafe fn memset(dst: *mut u8, c: i32, n: usize) -> *mut u8 {
         cursor = unsafe { cursor.add(CHUNK_SIZE) };
         remaining -= CHUNK_SIZE;
     }
-    while remaining != 0 {
-        // SAFETY: The tail byte is within the caller-provided destination range.
-        unsafe { *cursor = byte };
-        cursor = unsafe { cursor.add(1) };
-        remaining -= 1;
-    }
+    // SAFETY: The remaining tail is smaller than one chunk.
+    unsafe { set_tail(cursor, byte, remaining) };
     dst
 }
 
@@ -252,31 +454,17 @@ pub unsafe fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
         if a != b {
             // Locate the first differing byte to preserve memcmp's ordering
             // and sign contract rather than comparing whole machine words.
-            let mut index = 0;
-            while index < CHUNK_SIZE {
-                // SAFETY: The byte is within the differing chunk.
-                let left = unsafe { *s1.add(offset + index) };
-                let right = unsafe { *s2.add(offset + index) };
-                if left != right {
-                    return i32::from(left) - i32::from(right);
-                }
-                index += 1;
-            }
+            // SAFETY: The complete differing chunk is valid.
+            return unsafe { compare_bounded(s1.add(offset), s2.add(offset), CHUNK_SIZE) };
         }
         offset += CHUNK_SIZE;
         remaining -= CHUNK_SIZE;
     }
-    while remaining != 0 {
-        // SAFETY: The tail byte is within both caller-provided ranges.
-        let a = unsafe { *s1.add(offset) };
-        let b = unsafe { *s2.add(offset) };
-        if a != b {
-            return i32::from(a) - i32::from(b);
-        }
-        offset += 1;
-        remaining -= 1;
+    if remaining == 0 {
+        return 0;
     }
-    0
+    // SAFETY: The remaining tail is smaller than one chunk.
+    unsafe { compare_bounded(s1.add(offset), s2.add(offset), remaining) }
 }
 
 /// Compare `n` bytes of memory at `s1` and `s2` for equality.
@@ -303,15 +491,11 @@ pub unsafe fn bcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
         offset += CHUNK_SIZE;
         remaining -= CHUNK_SIZE;
     }
-    while remaining != 0 {
-        // SAFETY: The tail byte is within both caller-provided ranges.
-        if unsafe { *s1.add(offset) != *s2.add(offset) } {
-            return 1;
-        }
-        offset += 1;
-        remaining -= 1;
+    if remaining == 0 {
+        return 0;
     }
-    0
+    // SAFETY: The remaining tail is smaller than one chunk.
+    unsafe { (compare_bounded(s1.add(offset), s2.add(offset), remaining) != 0) as i32 }
 }
 
 #[cfg(test)]

--- a/crates/rue-runtime/src/memory.rs
+++ b/crates/rue-runtime/src/memory.rs
@@ -320,8 +320,10 @@ unsafe fn copy_forward(mut dst: *mut u8, mut src: *const u8, mut remaining: usiz
         remaining -= CHUNK_SIZE;
     }
 
-    // SAFETY: The remaining tail is smaller than one chunk.
-    unsafe { copy_forward_tail(dst, src, remaining) };
+    if remaining != 0 {
+        // SAFETY: The remaining tail is smaller than one chunk.
+        unsafe { copy_forward_tail(dst, src, remaining) };
+    }
 }
 
 #[inline(always)]
@@ -334,8 +336,10 @@ unsafe fn copy_backward(dst: *mut u8, src: *const u8, mut remaining: usize) {
         unsafe { write_chunk(dst.add(remaining), value) };
     }
 
-    // SAFETY: The remaining tail is smaller than one chunk.
-    unsafe { copy_backward_tail(dst, src, remaining) };
+    if remaining != 0 {
+        // SAFETY: The remaining tail is smaller than one chunk.
+        unsafe { copy_backward_tail(dst, src, remaining) };
+    }
 }
 
 /// Copy `n` bytes from `src` to `dst`. The memory regions must not overlap.
@@ -390,8 +394,10 @@ pub unsafe fn memset(dst: *mut u8, c: i32, n: usize) -> *mut u8 {
         cursor = unsafe { cursor.add(CHUNK_SIZE) };
         remaining -= CHUNK_SIZE;
     }
-    // SAFETY: The remaining tail is smaller than one chunk.
-    unsafe { set_tail(cursor, byte, remaining) };
+    if remaining != 0 {
+        // SAFETY: The remaining tail is smaller than one chunk.
+        unsafe { set_tail(cursor, byte, remaining) };
+    }
     dst
 }
 

--- a/crates/rue-runtime/src/memory.rs
+++ b/crates/rue-runtime/src/memory.rs
@@ -9,7 +9,10 @@ const CHUNK_SIZE: usize = core::mem::size_of::<u64>();
 // below permit arbitrary byte alignment, while `read_unaligned` and
 // `write_unaligned` are defined for every alignment and do not call the
 // reserved memcpy/memmove/memset symbols on the supported targets.
-#[inline(always)]
+// Keep the accessors out of the surrounding loops: otherwise an optimized
+// test binary can recognize the loop idiom and lower it back to an exported
+// reserved primitive, recursively re-entering its wrapper.
+#[inline(never)]
 unsafe fn read_chunk(src: *const u8) -> u64 {
     // SAFETY: Every caller has established that the complete chunk is inside
     // its valid input range. `read_unaligned` places no alignment requirement
@@ -17,7 +20,7 @@ unsafe fn read_chunk(src: *const u8) -> u64 {
     unsafe { core::ptr::read_unaligned(src.cast::<u64>()) }
 }
 
-#[inline(always)]
+#[inline(never)]
 unsafe fn write_chunk(dst: *mut u8, value: u64) {
     // SAFETY: Every caller has established that the complete chunk is inside
     // its valid output range. `write_unaligned` places no alignment

--- a/crates/rue-runtime/src/memory.rs
+++ b/crates/rue-runtime/src/memory.rs
@@ -3,6 +3,68 @@
 //! These functions provide the same functionality as libc (memcpy, memmove, etc.)
 //! but are implemented in pure Rust without external dependencies.
 
+const CHUNK_SIZE: usize = core::mem::size_of::<u64>();
+
+// These helpers deliberately use unaligned u64 accesses. The caller contracts
+// below permit arbitrary byte alignment, while `read_unaligned` and
+// `write_unaligned` are defined for every alignment and do not call the
+// reserved memcpy/memmove/memset symbols on the supported targets.
+#[inline(always)]
+unsafe fn read_chunk(src: *const u8) -> u64 {
+    // SAFETY: Every caller has established that the complete chunk is inside
+    // its valid input range. `read_unaligned` places no alignment requirement
+    // on the pointer.
+    unsafe { core::ptr::read_unaligned(src.cast::<u64>()) }
+}
+
+#[inline(always)]
+unsafe fn write_chunk(dst: *mut u8, value: u64) {
+    // SAFETY: Every caller has established that the complete chunk is inside
+    // its valid output range. `write_unaligned` places no alignment
+    // requirement on the pointer.
+    unsafe { core::ptr::write_unaligned(dst.cast::<u64>(), value) }
+}
+
+#[inline(always)]
+unsafe fn copy_forward(mut dst: *mut u8, mut src: *const u8, mut remaining: usize) {
+    while remaining >= CHUNK_SIZE {
+        // SAFETY: The chunk is within both caller-provided ranges.
+        let value = unsafe { read_chunk(src) };
+        // SAFETY: The chunk is within the caller-provided destination range.
+        unsafe { write_chunk(dst, value) };
+        // SAFETY: The remaining range is valid, so advancing by one chunk
+        // stays within the allocation (or one-past its end).
+        dst = unsafe { dst.add(CHUNK_SIZE) };
+        src = unsafe { src.add(CHUNK_SIZE) };
+        remaining -= CHUNK_SIZE;
+    }
+
+    while remaining != 0 {
+        // SAFETY: The tail byte is within both caller-provided ranges.
+        unsafe { *dst = *src };
+        dst = unsafe { dst.add(1) };
+        src = unsafe { src.add(1) };
+        remaining -= 1;
+    }
+}
+
+#[inline(always)]
+unsafe fn copy_backward(dst: *mut u8, src: *const u8, mut remaining: usize) {
+    while remaining >= CHUNK_SIZE {
+        remaining -= CHUNK_SIZE;
+        // SAFETY: The chunk is within both caller-provided ranges.
+        let value = unsafe { read_chunk(src.add(remaining)) };
+        // SAFETY: The chunk is within the caller-provided destination range.
+        unsafe { write_chunk(dst.add(remaining), value) };
+    }
+
+    while remaining != 0 {
+        remaining -= 1;
+        // SAFETY: The tail byte is within both caller-provided ranges.
+        unsafe { *dst.add(remaining) = *src.add(remaining) };
+    }
+}
+
 /// Copy `n` bytes from `src` to `dst`. The memory regions must not overlap.
 ///
 /// # Safety
@@ -12,17 +74,9 @@
 /// - Either pointer may be null when `n == 0`
 /// - The memory regions must not overlap
 pub unsafe fn memcpy(dst: *mut u8, src: *const u8, n: usize) -> *mut u8 {
-    let mut i = 0;
-    while i < n {
-        // SAFETY: We are within bounds because:
-        // - `i < n` is our loop invariant
-        // - Caller guarantees `dst` is valid for writes of `n` bytes
-        // - Caller guarantees `src` is valid for reads of `n` bytes
-        // - Caller guarantees the regions don't overlap
-        // The byte-by-byte copy is safe because u8 has no alignment requirements.
-        unsafe { *dst.add(i) = *src.add(i) };
-        i += 1;
-    }
+    // SAFETY: The caller upholds the validity and non-overlap requirements;
+    // copy_forward performs alignment-safe chunk and tail accesses.
+    unsafe { copy_forward(dst, src, n) };
     dst
 }
 
@@ -35,31 +89,13 @@ pub unsafe fn memcpy(dst: *mut u8, src: *const u8, n: usize) -> *mut u8 {
 /// - Either pointer may be null when `n == 0`
 pub unsafe fn memmove(dst: *mut u8, src: *const u8, n: usize) -> *mut u8 {
     if (dst as usize) < (src as usize) {
-        // Copy forwards when dst is before src (or they don't overlap)
-        let mut i = 0;
-        while i < n {
-            // SAFETY: We are within bounds because:
-            // - `i < n` is our loop invariant
-            // - Caller guarantees `dst` is valid for writes of `n` bytes
-            // - Caller guarantees `src` is valid for reads of `n` bytes
-            // Forward copy is correct when dst < src because we write to lower
-            // addresses before reading from them.
-            unsafe { *dst.add(i) = *src.add(i) };
-            i += 1;
-        }
+        // SAFETY: The caller upholds the validity requirements. Forward copy
+        // is overlap-safe when the destination starts below the source.
+        unsafe { copy_forward(dst, src, n) };
     } else {
-        // Copy backwards to handle overlap when dst >= src
-        let mut i = n;
-        while i > 0 {
-            i -= 1;
-            // SAFETY: We are within bounds because:
-            // - After decrement, `i < n` (we started at n and decremented before use)
-            // - Caller guarantees `dst` is valid for writes of `n` bytes
-            // - Caller guarantees `src` is valid for reads of `n` bytes
-            // Backward copy is correct when dst >= src because we write to higher
-            // addresses before reading from them.
-            unsafe { *dst.add(i) = *src.add(i) };
-        }
+        // SAFETY: The caller upholds the validity requirements. Backward copy
+        // is overlap-safe when the destination starts at or above the source.
+        unsafe { copy_backward(dst, src, n) };
     }
     dst
 }
@@ -72,14 +108,20 @@ pub unsafe fn memmove(dst: *mut u8, src: *const u8, n: usize) -> *mut u8 {
 /// - `dst` may be null when `n == 0`
 pub unsafe fn memset(dst: *mut u8, c: i32, n: usize) -> *mut u8 {
     let byte = c as u8;
-    let mut i = 0;
-    while i < n {
-        // SAFETY: We are within bounds because:
-        // - `i < n` is our loop invariant
-        // - Caller guarantees `dst` is valid for writes of `n` bytes
-        // The byte write is safe because u8 has no alignment requirements.
-        unsafe { *dst.add(i) = byte };
-        i += 1;
+    let chunk = u64::from_ne_bytes([byte; CHUNK_SIZE]);
+    let mut remaining = n;
+    let mut cursor = dst;
+    while remaining >= CHUNK_SIZE {
+        // SAFETY: The chunk is within the caller-provided destination range.
+        unsafe { write_chunk(cursor, chunk) };
+        cursor = unsafe { cursor.add(CHUNK_SIZE) };
+        remaining -= CHUNK_SIZE;
+    }
+    while remaining != 0 {
+        // SAFETY: The tail byte is within the caller-provided destination range.
+        unsafe { *cursor = byte };
+        cursor = unsafe { cursor.add(1) };
+        remaining -= 1;
     }
     dst
 }
@@ -134,19 +176,38 @@ pub unsafe fn __rue_byte_move(dst: *mut u8, src: *const u8, size: u64) {
 /// - When `n > 0`, both pointers must be non-null and valid for reads of `n` bytes
 /// - Either pointer may be null when `n == 0`
 pub unsafe fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
-    let mut i = 0;
-    while i < n {
-        // SAFETY: We are within bounds because:
-        // - `i < n` is our loop invariant
-        // - Caller guarantees `s1` is valid for reads of `n` bytes
-        // - Caller guarantees `s2` is valid for reads of `n` bytes
-        // The byte reads are safe because u8 has no alignment requirements.
-        let a = unsafe { *s1.add(i) };
-        let b = unsafe { *s2.add(i) };
+    let mut offset = 0;
+    let mut remaining = n;
+    while remaining >= CHUNK_SIZE {
+        // SAFETY: The complete chunk is within both caller-provided ranges.
+        let a = unsafe { read_chunk(s1.add(offset)) };
+        let b = unsafe { read_chunk(s2.add(offset)) };
         if a != b {
-            return (a as i32) - (b as i32);
+            // Locate the first differing byte to preserve memcmp's ordering
+            // and sign contract rather than comparing whole machine words.
+            let mut index = 0;
+            while index < CHUNK_SIZE {
+                // SAFETY: The byte is within the differing chunk.
+                let left = unsafe { *s1.add(offset + index) };
+                let right = unsafe { *s2.add(offset + index) };
+                if left != right {
+                    return i32::from(left) - i32::from(right);
+                }
+                index += 1;
+            }
         }
-        i += 1;
+        offset += CHUNK_SIZE;
+        remaining -= CHUNK_SIZE;
+    }
+    while remaining != 0 {
+        // SAFETY: The tail byte is within both caller-provided ranges.
+        let a = unsafe { *s1.add(offset) };
+        let b = unsafe { *s2.add(offset) };
+        if a != b {
+            return i32::from(a) - i32::from(b);
+        }
+        offset += 1;
+        remaining -= 1;
     }
     0
 }
@@ -163,27 +224,278 @@ pub unsafe fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
 ///
 /// - When `n > 0`, both pointers must be non-null and valid for reads of `n` bytes
 /// - Either pointer may be null when `n == 0`
+#[inline(always)]
 pub unsafe fn bcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
-    let mut i = 0;
-    while i < n {
-        // SAFETY: We are within bounds because:
-        // - `i < n` is our loop invariant
-        // - Caller guarantees `s1` is valid for reads of `n` bytes
-        // - Caller guarantees `s2` is valid for reads of `n` bytes
-        // The byte reads are safe because u8 has no alignment requirements.
-        let a = unsafe { *s1.add(i) };
-        let b = unsafe { *s2.add(i) };
-        if a != b {
+    let mut offset = 0;
+    let mut remaining = n;
+    while remaining >= CHUNK_SIZE {
+        // SAFETY: The complete chunk is within both caller-provided ranges.
+        if unsafe { read_chunk(s1.add(offset)) != read_chunk(s2.add(offset)) } {
             return 1;
         }
-        i += 1;
+        offset += CHUNK_SIZE;
+        remaining -= CHUNK_SIZE;
+    }
+    while remaining != 0 {
+        // SAFETY: The tail byte is within both caller-provided ranges.
+        if unsafe { *s1.add(offset) != *s2.add(offset) } {
+            return 1;
+        }
+        offset += 1;
+        remaining -= 1;
     }
     0
 }
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
+
+    use self::std::vec;
+    use self::std::vec::Vec;
     use super::*;
+
+    #[test]
+    fn memcpy_handles_lengths_tails_and_all_alignments() {
+        for length in 0..=(CHUNK_SIZE * 4 + 3) {
+            for source_offset in 0..CHUNK_SIZE {
+                for destination_offset in 0..CHUNK_SIZE {
+                    let source = (0..128).map(|index| index as u8).collect::<Vec<_>>();
+                    let mut destination = vec![0xa5; 128];
+                    let destination_ptr =
+                        unsafe { destination.as_mut_ptr().add(destination_offset) };
+                    // SAFETY: Both slices contain the requested ranges and do
+                    // not overlap.
+                    let returned = unsafe {
+                        memcpy(destination_ptr, source.as_ptr().add(source_offset), length)
+                    };
+                    assert_eq!(returned, destination_ptr);
+                    assert!(
+                        destination[..destination_offset]
+                            .iter()
+                            .all(|&byte| byte == 0xa5)
+                    );
+                    assert_eq!(
+                        &destination[destination_offset..destination_offset + length],
+                        &source[source_offset..source_offset + length]
+                    );
+                    assert!(
+                        destination[destination_offset + length..]
+                            .iter()
+                            .all(|&byte| byte == 0xa5)
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn memset_handles_lengths_tails_and_all_alignments() {
+        for length in 0..=(CHUNK_SIZE * 4 + 3) {
+            for destination_offset in 0..CHUNK_SIZE {
+                let mut destination = vec![0xa5; 128];
+                // SAFETY: The destination contains the requested range.
+                let destination_ptr = unsafe { destination.as_mut_ptr().add(destination_offset) };
+                let returned = unsafe { memset(destination_ptr, -0x12, length) };
+                assert_eq!(returned, destination_ptr);
+                assert!(
+                    destination[..destination_offset]
+                        .iter()
+                        .all(|&byte| byte == 0xa5)
+                );
+                assert!(
+                    destination[destination_offset..destination_offset + length]
+                        .iter()
+                        .all(|&byte| byte == 0xee)
+                );
+                assert!(
+                    destination[destination_offset + length..]
+                        .iter()
+                        .all(|&byte| byte == 0xa5)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn memmove_handles_overlap_directions_distances_and_tails() {
+        for length in 0..=(CHUNK_SIZE * 4 + 3) {
+            for distance in 1..=(CHUNK_SIZE + 2) {
+                for destination_after_source in [false, true] {
+                    let source_start = CHUNK_SIZE + 8;
+                    let destination_start = if destination_after_source {
+                        source_start + distance
+                    } else {
+                        source_start - distance
+                    };
+                    let mut actual = (0..192).map(|index| index as u8).collect::<Vec<_>>();
+                    let mut expected = actual.clone();
+                    expected.copy_within(source_start..source_start + length, destination_start);
+                    let destination_ptr = unsafe { actual.as_mut_ptr().add(destination_start) };
+                    // SAFETY: Both ranges are within the backing allocation.
+                    let returned = unsafe {
+                        memmove(destination_ptr, actual.as_ptr().add(source_start), length)
+                    };
+                    assert_eq!(returned, destination_ptr);
+                    assert_eq!(actual, expected);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn memmove_handles_same_pointer_and_disjoint_allocations() {
+        for length in 0..=(CHUNK_SIZE * 4 + 3) {
+            let source_start = CHUNK_SIZE + 3;
+            let mut same = (0..128).map(|index| index as u8).collect::<Vec<_>>();
+            let expected = same.clone();
+            let pointer = unsafe { same.as_mut_ptr().add(source_start) };
+            // SAFETY: A zero-length or identical source/destination range is
+            // valid under the memmove contract.
+            let returned = unsafe { memmove(pointer, pointer, length) };
+            assert_eq!(returned, pointer);
+            assert_eq!(same, expected);
+
+            let source = (0..128).map(|index| index as u8).collect::<Vec<_>>();
+            let mut destination = vec![0xa5; 128];
+            let destination_start = CHUNK_SIZE * 2 + 1;
+            let destination_ptr = unsafe { destination.as_mut_ptr().add(destination_start) };
+            // SAFETY: These are distinct allocations and both ranges are in bounds.
+            let returned =
+                unsafe { memmove(destination_ptr, source.as_ptr().add(source_start), length) };
+            assert_eq!(returned, destination_ptr);
+            assert_eq!(
+                &destination[destination_start..destination_start + length],
+                &source[source_start..source_start + length]
+            );
+            assert!(
+                destination[..destination_start]
+                    .iter()
+                    .all(|&byte| byte == 0xa5)
+            );
+            assert!(
+                destination[destination_start + length..]
+                    .iter()
+                    .all(|&byte| byte == 0xa5)
+            );
+        }
+    }
+
+    #[test]
+    fn memcmp_preserves_first_mismatch_order_and_sign() {
+        for length in 0..=(CHUNK_SIZE * 4 + 3) {
+            for left_offset in 0..CHUNK_SIZE {
+                for right_offset in 0..CHUNK_SIZE {
+                    let mut left = vec![0x55; length + CHUNK_SIZE * 2];
+                    let mut right = left.clone();
+                    // SAFETY: Both pointers name valid ranges of `length` bytes.
+                    assert_eq!(
+                        unsafe {
+                            memcmp(
+                                left.as_ptr().add(left_offset),
+                                right.as_ptr().add(right_offset),
+                                length,
+                            )
+                        },
+                        0
+                    );
+                    // SAFETY: The same pointer names a valid range, including
+                    // the zero-length case.
+                    assert_eq!(
+                        unsafe {
+                            memcmp(
+                                left.as_ptr().add(left_offset),
+                                left.as_ptr().add(left_offset),
+                                length,
+                            )
+                        },
+                        0
+                    );
+                    for mismatch in 0..length {
+                        left[left_offset + mismatch] = 0x00;
+                        right[right_offset + mismatch] = 0xff;
+                        // SAFETY: Both pointers name valid ranges of `length` bytes.
+                        let result = unsafe {
+                            memcmp(
+                                left.as_ptr().add(left_offset),
+                                right.as_ptr().add(right_offset),
+                                length,
+                            )
+                        };
+                        assert!(result < 0, "length={length}, mismatch={mismatch}");
+
+                        left[left_offset + mismatch] = 0xff;
+                        right[right_offset + mismatch] = 0x00;
+                        // SAFETY: Both pointers name valid ranges of `length` bytes.
+                        let result = unsafe {
+                            memcmp(
+                                left.as_ptr().add(left_offset),
+                                right.as_ptr().add(right_offset),
+                                length,
+                            )
+                        };
+                        assert!(result > 0, "length={length}, mismatch={mismatch}");
+                        left[left_offset + mismatch] = 0x55;
+                        right[right_offset + mismatch] = 0x55;
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn bcmp_handles_chunks_tails_and_all_alignments() {
+        for length in 0..=(CHUNK_SIZE * 4 + 3) {
+            for left_offset in 0..CHUNK_SIZE {
+                for right_offset in 0..CHUNK_SIZE {
+                    let mut left = vec![0xa5; 128];
+                    let mut right = vec![0x5a; 128];
+                    for index in 0..=(CHUNK_SIZE * 4 + 3) {
+                        let value = (index as u8).wrapping_mul(29).wrapping_add(7);
+                        left[left_offset + index] = value;
+                        right[right_offset + index] = value;
+                    }
+                    // SAFETY: Both pointers name valid ranges of `length` bytes.
+                    assert_eq!(
+                        unsafe {
+                            bcmp(
+                                left.as_ptr().add(left_offset),
+                                right.as_ptr().add(right_offset),
+                                length,
+                            )
+                        },
+                        0
+                    );
+                    // SAFETY: The same pointer names a valid range.
+                    assert_eq!(
+                        unsafe {
+                            bcmp(
+                                left.as_ptr().add(left_offset),
+                                left.as_ptr().add(left_offset),
+                                length,
+                            )
+                        },
+                        0
+                    );
+                    for mismatch in 0..length {
+                        left[left_offset + mismatch] ^= 1;
+                        // SAFETY: The changed byte remains within the compared range.
+                        assert_ne!(
+                            unsafe {
+                                bcmp(
+                                    left.as_ptr().add(left_offset),
+                                    right.as_ptr().add(right_offset),
+                                    length,
+                                )
+                            },
+                            0
+                        );
+                        left[left_offset + mismatch] ^= 1;
+                    }
+                }
+            }
+        }
+    }
 
     #[test]
     fn test_bcmp_equal() {
@@ -207,6 +519,46 @@ mod tests {
         let b = b"";
         let result = unsafe { bcmp(a.as_ptr(), b.as_ptr(), 0) };
         assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn zero_length_accepts_null_and_distinct_pointers() {
+        let byte = 0u8;
+        let pointer = &byte as *const u8;
+        // SAFETY: All operations have zero length, so null pointers are valid
+        // under their documented contracts.
+        unsafe {
+            assert!(memcpy(core::ptr::null_mut(), pointer, 0).is_null());
+            assert!(memmove(pointer as *mut u8, core::ptr::null(), 0) == pointer as *mut u8);
+            assert!(memset(core::ptr::null_mut(), 0, 0).is_null());
+            assert_eq!(memcmp(core::ptr::null(), pointer, 0), 0);
+            assert_eq!(bcmp(pointer, core::ptr::null(), 0), 0);
+        }
+    }
+
+    #[test]
+    fn rue_memory_wrappers_preserve_primitive_behavior() {
+        let source = (0..64).map(|index| index as u8).collect::<Vec<_>>();
+        let mut destination = vec![0xa5; 72];
+        // SAFETY: Every wrapper range is valid, and the copy ranges do not overlap.
+        unsafe {
+            __rue_byte_copy(destination.as_mut_ptr().add(3), source.as_ptr().add(5), 35);
+        }
+        assert_eq!(&destination[3..38], &source[5..40]);
+        let mut expected = destination.clone();
+        expected.copy_within(3..38, 8);
+        // SAFETY: Both ranges are within this allocation and may overlap.
+        unsafe {
+            __rue_byte_move(
+                destination.as_mut_ptr().add(8),
+                destination.as_ptr().add(3),
+                35,
+            )
+        };
+        assert_eq!(destination, expected);
+        // SAFETY: The wrapper writes only within the destination range.
+        unsafe { __rue_byte_set(destination.as_mut_ptr().add(11), 0x1ee, 17) };
+        assert!(destination[11..28].iter().all(|&byte| byte == 0xee));
     }
 
     #[test]

--- a/crates/rue-runtime/src/memory.rs
+++ b/crates/rue-runtime/src/memory.rs
@@ -6,13 +6,76 @@
 const CHUNK_SIZE: usize = core::mem::size_of::<u64>();
 
 // These helpers deliberately use unaligned u64 accesses. The caller contracts
-// below permit arbitrary byte alignment, while `read_unaligned` and
-// `write_unaligned` are defined for every alignment and do not call the
-// reserved memcpy/memmove/memset symbols on the supported targets.
-// Keep the accessors out of the surrounding loops: otherwise an optimized
-// test binary can recognize the loop idiom and lower it back to an exported
-// reserved primitive, recursively re-entering its wrapper.
-#[inline(never)]
+// below permit arbitrary byte alignment. Inline assembly keeps the individual
+// accesses in the surrounding loops while making them opaque to LLVM's
+// loop-idiom lowering; otherwise an optimized test binary can lower a byte
+// loop back to an exported reserved primitive and recursively re-enter it.
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+unsafe fn read_chunk(src: *const u8) -> u64 {
+    let value;
+    // SAFETY: Every caller has established that the complete chunk is inside
+    // its valid input range. x86 permits an unaligned integer load.
+    unsafe {
+        core::arch::asm!(
+            "mov {value}, [{src}]",
+            value = out(reg) value,
+            src = in(reg) src,
+            options(nostack, preserves_flags, readonly),
+        );
+    }
+    value
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+unsafe fn write_chunk(dst: *mut u8, value: u64) {
+    // SAFETY: Every caller has established that the complete chunk is inside
+    // its valid output range. x86 permits an unaligned integer store.
+    unsafe {
+        core::arch::asm!(
+            "mov [{dst}], {value}",
+            dst = in(reg) dst,
+            value = in(reg) value,
+            options(nostack, preserves_flags),
+        );
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[inline(always)]
+unsafe fn read_chunk(src: *const u8) -> u64 {
+    let value;
+    // SAFETY: Every caller has established that the complete chunk is inside
+    // its valid input range. AArch64 permits an unaligned integer load.
+    unsafe {
+        core::arch::asm!(
+            "ldr {value}, [{src}]",
+            value = out(reg) value,
+            src = in(reg) src,
+            options(nostack, preserves_flags, readonly),
+        );
+    }
+    value
+}
+
+#[cfg(target_arch = "aarch64")]
+#[inline(always)]
+unsafe fn write_chunk(dst: *mut u8, value: u64) {
+    // SAFETY: Every caller has established that the complete chunk is inside
+    // its valid output range. AArch64 permits an unaligned integer store.
+    unsafe {
+        core::arch::asm!(
+            "str {value}, [{dst}]",
+            dst = in(reg) dst,
+            value = in(reg) value,
+            options(nostack, preserves_flags),
+        );
+    }
+}
+
+#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+#[inline(always)]
 unsafe fn read_chunk(src: *const u8) -> u64 {
     // SAFETY: Every caller has established that the complete chunk is inside
     // its valid input range. `read_unaligned` places no alignment requirement
@@ -20,7 +83,8 @@ unsafe fn read_chunk(src: *const u8) -> u64 {
     unsafe { core::ptr::read_unaligned(src.cast::<u64>()) }
 }
 
-#[inline(never)]
+#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+#[inline(always)]
 unsafe fn write_chunk(dst: *mut u8, value: u64) {
     // SAFETY: Every caller has established that the complete chunk is inside
     // its valid output range. `write_unaligned` places no alignment

--- a/crates/rue-runtime/src/string.rs
+++ b/crates/rue-runtime/src/string.rs
@@ -32,8 +32,8 @@ crate::define_runtime_implementation! {
     /// # Implementation
     ///
     /// Fast path: If lengths differ, strings cannot be equal (returns 0).
-    /// Slow path: Compare bytes one by one until a difference is found or
-    /// all bytes match.
+    /// Slow path: Compare through the runtime's alignment-safe chunked byte
+    /// equality primitive.
     ///
     /// # Safety
     ///
@@ -56,22 +56,12 @@ crate::define_runtime_implementation! {
             return 1;
         }
 
-        // Slow path: compare bytes one by one
-        // We avoid slice comparison (==) because it generates a call to bcmp,
-        // which is a libc function not available in our no_std runtime.
-        for i in 0..len1 as usize {
-            // SAFETY: Reading from both pointers is safe because:
-            // - `i < len1` (which equals len2) is our loop invariant
-            // - Caller guarantees `ptr1` is valid for reads of `len1` bytes
-            // - Caller guarantees `ptr2` is valid for reads of `len2` bytes
-            // - u8 has no alignment requirements
-            let b1 = unsafe { *ptr1.add(i) };
-            let b2 = unsafe { *ptr2.add(i) };
-            if b1 != b2 {
-                return 0;
-            }
-        }
-        1
+        // Use the canonical runtime comparison authority. This avoids Rust
+        // slice equality, which can lower to an external libc bcmp symbol,
+        // while retaining the same pointer-validity contract.
+        // SAFETY: Equal lengths and the caller's contract make both ranges
+        // valid for the comparison.
+        (unsafe { crate::memory::bcmp(ptr1, ptr2, len1 as usize) == 0 }) as u64
     }
 }
 
@@ -662,9 +652,68 @@ mod tests {
         // SAFETY: every pointer/length pair names a live byte array.
         unsafe {
             assert_eq!(__rue_str_eq(a.as_ptr(), 4, b.as_ptr(), 4), 1);
+            assert_eq!(__rue_str_eq(a.as_ptr(), 4, a.as_ptr(), 4), 1);
             assert_eq!(__rue_str_eq(a.as_ptr(), 4, c.as_ptr(), 5), 0);
             assert_eq!(__rue_str_eq(a.as_ptr(), 4, d.as_ptr(), 4), 0);
             assert_eq!(__rue_str_eq(a.as_ptr(), 0, d.as_ptr(), 0), 1);
+        }
+    }
+
+    #[test]
+    fn str_eq_zero_length_accepts_null_and_distinct_pointers() {
+        let byte = 0u8;
+        // SAFETY: Both views have zero length, so null pointers are valid.
+        unsafe {
+            assert_eq!(__rue_str_eq(core::ptr::null(), 0, &byte, 0), 1);
+            assert_eq!(__rue_str_eq(&byte, 0, core::ptr::null(), 0), 1);
+        }
+    }
+
+    #[test]
+    fn str_eq_handles_chunk_boundaries_and_unaligned_slices() {
+        let chunk_size = core::mem::size_of::<u64>();
+        for length in 0..=(chunk_size * 4 + 3) {
+            for left_offset in 0..chunk_size {
+                for right_offset in 0..chunk_size {
+                    let mut left = self::std::vec![0xa5; 128];
+                    let mut right = self::std::vec![0x5a; 128];
+                    for index in 0..=(chunk_size * 4 + 3) {
+                        let value = (index as u8).wrapping_mul(37).wrapping_add(11);
+                        left[left_offset + index] = value;
+                        right[right_offset + index] = value;
+                    }
+                    // SAFETY: Both pointers name valid buffers for `length`
+                    // bytes; offsets intentionally cover every byte alignment.
+                    unsafe {
+                        assert_eq!(
+                            __rue_str_eq(
+                                left.as_ptr().add(left_offset),
+                                length as u64,
+                                right.as_ptr().add(right_offset),
+                                length as u64,
+                            ),
+                            1
+                        );
+                    }
+                    for mismatch in 0..length {
+                        left[left_offset + mismatch] ^= 1;
+                        // SAFETY: The changed byte remains within the valid
+                        // string range and the two ranges have equal lengths.
+                        unsafe {
+                            assert_eq!(
+                                __rue_str_eq(
+                                    left.as_ptr().add(left_offset),
+                                    length as u64,
+                                    right.as_ptr().add(right_offset),
+                                    length as u64,
+                                ),
+                                0
+                            );
+                        }
+                        left[left_offset + mismatch] ^= 1;
+                    }
+                }
+            }
         }
     }
 

--- a/crates/rue-runtime/tests/test_validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/test_validate_runtime_archives.py
@@ -34,8 +34,27 @@ class InstructionShapeTests(unittest.TestCase):
         self.assertFalse(validator.has_non_stack_word_access((0xF94003A0).to_bytes(4, "little"), 183))
 
     def test_control_transfer_offsets(self):
-        self.assertEqual(validator.relocation_is_control_transfer(bytes.fromhex("e900000000"), 1, 62), "branch")
-        self.assertEqual(validator.relocation_is_control_transfer((0x14000000).to_bytes(4, "little"), 0, 183), "branch")
+        self.assertEqual(
+            validator.relocation_is_control_transfer(bytes.fromhex("e900000000"), 1, 62, 2, "elf"),
+            "branch",
+        )
+        self.assertEqual(
+            validator.relocation_is_control_transfer(
+                (0x14000000).to_bytes(4, "little"), 0, 183, 282, "elf"
+            ),
+            "branch",
+        )
+
+    def test_data_relocations_are_not_control_transfers(self):
+        # movq (%rdi), %rax; subq $external_data, %rax; ret. The R_X86_64_32S
+        # relocation starts at the subq immediate, not at a call instruction.
+        x86 = bytes.fromhex("488b07482b0500000000c3")
+        self.assertIsNone(validator.relocation_is_control_transfer(x86, 6, 62, 11, "elf"))
+        self.assertIsNone(
+            validator.relocation_is_control_transfer(
+                (0x90000000).to_bytes(4, "little"), 0, 183, 275, "elf"
+            )
+        )
 
 
 class BodyValidationTests(unittest.TestCase):
@@ -97,13 +116,25 @@ class BodyValidationTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(AssertionError, "unresolved reachable control transfer"):
             validator._validate_bodies(
-                Path("synthetic.a:member.o"), {"_memcpy": root}, "macho", 183
+                Path("synthetic.a:member.o"), {"_memcpy": root}, "macho", validator.MACHO_CPU_ARM64
             )
 
     def test_non_control_external_relocation_is_ignored(self):
         # Data relocations do not establish a callable edge and remain valid.
         root = body("memcpy", bytes.fromhex("488b07"), [(0, "external_data", 1)])
         validator._validate_bodies(Path("synthetic"), {"memcpy": root}, "elf", 62)
+
+    def test_valid_x86_data_relocation_does_not_hide_a_call(self):
+        root = body("memcpy", bytes.fromhex("488b07482b0500000000c3"), [(6, "external_data", 11)])
+        validator._validate_bodies(Path("synthetic"), {"memcpy": root}, "elf", 62)
+
+    def test_valid_aarch64_adrp_data_relocation_is_not_a_call(self):
+        root = body(
+            "memcpy",
+            (0x90000000).to_bytes(4, "little") + (0xF9400020).to_bytes(4, "little"),
+            [(0, "external_data", 275)],
+        )
+        validator._validate_bodies(Path("synthetic"), {"memcpy": root}, "elf", 183)
 
     def test_wrapper_skips_unrelated_outlined_helper(self):
         wrapper = body(

--- a/crates/rue-runtime/tests/test_validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/test_validate_runtime_archives.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Host-independent unit tests for the runtime archive shape guard."""
 
+import os
+import re
 import sys
 import unittest
 from pathlib import Path
@@ -140,6 +142,25 @@ class BodyValidationTests(unittest.TestCase):
         root = body("memcpy", bytes.fromhex("488b07ff142500000000"), [(6, ".rodata.function_pointer", 11)])
         with self.assertRaisesRegex(AssertionError, "unresolved reachable control transfer"):
             validator._validate_bodies(Path("synthetic"), {"memcpy": root}, "elf", 62)
+
+
+class TestConfigurationTests(unittest.TestCase):
+    def test_libtest_disables_libc_shaped_reserved_exports(self):
+        declared_source = os.environ.get("RUNTIME_LIB_SOURCE")
+        source_path = Path(declared_source) if declared_source else None
+        if source_path is None or not source_path.is_file():
+            source_path = Path(__file__).parents[1] / "src" / "lib.rs"
+        source = source_path.read_text()
+        arm = re.search(
+            r"macro_rules! declare_reserved_function \{.*?\n    \(\n        aarch64_macos",
+            source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(arm)
+        self.assertRegex(
+            arm.group(0),
+            r"(?s)all unsafe .*?#\[cfg\(not\(test\)\)\]\s+#\[unsafe\(no_mangle\)\]",
+        )
 
     def test_unresolved_macho_cross_member_control_transfer_is_rejected(self):
         root = body(

--- a/crates/rue-runtime/tests/test_validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/test_validate_runtime_archives.py
@@ -46,7 +46,10 @@ class BodyValidationTests(unittest.TestCase):
 
     def test_local_backedge_with_chunk_access_is_valid(self):
         loop = body("memcpy", bytes.fromhex("488b07e900000000"), [(4, "local_loop", 4)])
-        validator._validate_bodies(Path("synthetic"), {"memcpy": loop}, "elf", 62)
+        local_loop = body("local_loop", bytes.fromhex("c3"))
+        validator._validate_bodies(
+            Path("synthetic"), {"memcpy": loop, "local_loop": local_loop}, "elf", 62
+        )
 
     def test_wrapper_follows_canonical_body(self):
         wrapper = body("memcpy", bytes.fromhex("e900000000"), [(1, "canonical", 4)])
@@ -78,6 +81,29 @@ class BodyValidationTests(unittest.TestCase):
                 "elf",
                 62,
             )
+
+    def test_unresolved_elf_control_transfer_is_rejected(self):
+        # A chunk access must not make an unresolved call look safe: a helper
+        # in another archive member could conceal a reserved-symbol cycle.
+        root = body("memcpy", bytes.fromhex("488b07e800000000"), [(4, "unknown_helper", 4)])
+        with self.assertRaisesRegex(AssertionError, "unresolved reachable control transfer"):
+            validator._validate_bodies(Path("synthetic.a:member.o"), {"memcpy": root}, "elf", 62)
+
+    def test_unresolved_macho_cross_member_control_transfer_is_rejected(self):
+        root = body(
+            "_memcpy",
+            (0xF9400020).to_bytes(4, "little") + (0x14000000).to_bytes(4, "little"),
+            [(4, "_cross_member_helper", 2)],
+        )
+        with self.assertRaisesRegex(AssertionError, "unresolved reachable control transfer"):
+            validator._validate_bodies(
+                Path("synthetic.a:member.o"), {"_memcpy": root}, "macho", 183
+            )
+
+    def test_non_control_external_relocation_is_ignored(self):
+        # Data relocations do not establish a callable edge and remain valid.
+        root = body("memcpy", bytes.fromhex("488b07"), [(0, "external_data", 1)])
+        validator._validate_bodies(Path("synthetic"), {"memcpy": root}, "elf", 62)
 
     def test_wrapper_skips_unrelated_outlined_helper(self):
         wrapper = body(

--- a/crates/rue-runtime/tests/test_validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/test_validate_runtime_archives.py
@@ -128,6 +128,12 @@ class BodyValidationTests(unittest.TestCase):
             with self.assertRaisesRegex(AssertionError, "unresolved reachable control transfer"):
                 validator._validate_bodies(Path("synthetic.a:member.o"), {"memcpy": root}, "elf", 62)
 
+    def test_x86_rodata_jump_table_is_not_a_helper_edge(self):
+        # FF /4 through a SIB no-base address is also how LLVM emits a local
+        # jump table. Its resolved .rodata target is not a callable body.
+        root = body("memcpy", bytes.fromhex("488b07ff24d500000000"), [(6, ".rodata.table", 11)])
+        validator._validate_bodies(Path("synthetic"), {"memcpy": root}, "elf", 62)
+
     def test_unresolved_macho_cross_member_control_transfer_is_rejected(self):
         root = body(
             "_memcpy",

--- a/crates/rue-runtime/tests/test_validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/test_validate_runtime_archives.py
@@ -134,6 +134,13 @@ class BodyValidationTests(unittest.TestCase):
         root = body("memcpy", bytes.fromhex("488b07ff24d500000000"), [(6, ".rodata.table", 11)])
         validator._validate_bodies(Path("synthetic"), {"memcpy": root}, "elf", 62)
 
+    def test_x86_rodata_function_pointer_is_still_a_call_edge(self):
+        # FF /2 through the same SIB encoding is an indirect call, even when
+        # its function-pointer storage happens to reside in .rodata.
+        root = body("memcpy", bytes.fromhex("488b07ff142500000000"), [(6, ".rodata.function_pointer", 11)])
+        with self.assertRaisesRegex(AssertionError, "unresolved reachable control transfer"):
+            validator._validate_bodies(Path("synthetic"), {"memcpy": root}, "elf", 62)
+
     def test_unresolved_macho_cross_member_control_transfer_is_rejected(self):
         root = body(
             "_memcpy",

--- a/crates/rue-runtime/tests/test_validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/test_validate_runtime_archives.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Host-independent unit tests for the runtime archive shape guard."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+import validate_runtime_archives as validator  # noqa: E402
+
+
+def body(name, code, relocs=()):
+    return {"name": name, "code": bytes(code), "relocs": list(relocs)}
+
+
+class InstructionShapeTests(unittest.TestCase):
+    def test_stack_spill_is_not_word_access(self):
+        self.assertFalse(validator.has_non_stack_word_access(bytes.fromhex("488b442408"), 62))
+        self.assertFalse(validator.has_non_stack_word_access((0xF94003E0).to_bytes(4, "little"), 183))
+
+    def test_non_stack_word_access_is_detected(self):
+        self.assertTrue(validator.has_non_stack_word_access(bytes.fromhex("488b07"), 62))
+        self.assertTrue(validator.has_non_stack_word_access((0xF9400020).to_bytes(4, "little"), 183))
+
+    def test_immediate_bytes_and_frame_pointer_spills_are_not_accesses(self):
+        # movabs rax, 0x00000000078b4801; the embedded 48 8b 07 is data.
+        self.assertFalse(validator.has_non_stack_word_access(bytes.fromhex("48b801488b0700000000c3"), 62))
+        # lea rax, [abs 0x00000000078b4801]; SIB no-base consumes disp32.
+        self.assertFalse(validator.has_non_stack_word_access(bytes.fromhex("488d0425488b0700c3"), 62))
+        # test al, 0x48; its immediate contains the start of a fake REX.W load.
+        self.assertFalse(validator.has_non_stack_word_access(bytes.fromhex("f6c0488b07c3"), 62))
+        # test eax, 0x00078b48; F7 /0 consumes a four-byte immediate.
+        self.assertFalse(validator.has_non_stack_word_access(bytes.fromhex("f7c0488b0700c3"), 62))
+        self.assertFalse(validator.has_non_stack_word_access((0xF94003A0).to_bytes(4, "little"), 183))
+
+    def test_control_transfer_offsets(self):
+        self.assertEqual(validator.relocation_is_control_transfer(bytes.fromhex("e900000000"), 1, 62), "branch")
+        self.assertEqual(validator.relocation_is_control_transfer((0x14000000).to_bytes(4, "little"), 0, 183), "branch")
+
+
+class BodyValidationTests(unittest.TestCase):
+    def test_tail_recursion_with_spill_is_rejected(self):
+        recursive = body("memcpy", bytes.fromhex("488b442408e900000000"), [(6, "memcpy", 4)])
+        with self.assertRaisesRegex(AssertionError, "recursively transfers"):
+            validator._validate_bodies(Path("synthetic"), {"memcpy": recursive}, "elf", 62)
+
+    def test_local_backedge_with_chunk_access_is_valid(self):
+        loop = body("memcpy", bytes.fromhex("488b07e900000000"), [(4, "local_loop", 4)])
+        validator._validate_bodies(Path("synthetic"), {"memcpy": loop}, "elf", 62)
+
+    def test_wrapper_follows_canonical_body(self):
+        wrapper = body("memcpy", bytes.fromhex("e900000000"), [(1, "impl", 4)])
+        impl = body("impl", bytes.fromhex("488b07"))
+        validator._validate_bodies(Path("synthetic"), {"memcpy": wrapper, "impl": impl}, "elf", 62)
+
+    def test_str_eq_wrapper_follows_bcmp(self):
+        wrapper = body("__rue_str_eq", bytes.fromhex("e900000000"), [(1, "bcmp", 4)])
+        impl = body("bcmp", bytes.fromhex("488b07"))
+        validator._validate_bodies(
+            Path("synthetic"), {"__rue_str_eq": wrapper, "bcmp": impl}, "elf", 62
+        )
+
+    def test_str_eq_source_requires_canonical_delegation(self):
+        import tempfile
+
+        positive = """
+        pub unsafe extern \"C\" fn __rue_str_eq(a: *const u8, b: *const u8) -> u64 {
+            /* Formatting and comments do not change the authority. */
+            ( unsafe {
+                crate::memory::bcmp( // canonical comparison
+                    a, b, 1
+                ) /* result */ == 0
+            } ) as u64;
+        }
+        """
+        with tempfile.NamedTemporaryFile("w", delete=False) as file:
+            file.write(positive)
+            path = Path(file.name)
+        try:
+            validator.validate_str_eq_source(path)
+        finally:
+            path.unlink()
+
+    def test_str_eq_source_rejects_independent_loop_and_unrelated_helper(self):
+        import tempfile
+
+        sources = [
+            """
+            fn __rue_str_eq(a: *const u8, b: *const u8) -> u64 {
+                while false { let _ = crate::memory::bcmp(a, b, 1); }
+                0
+            }
+            """,
+            """
+            fn __rue_str_eq(a: *const u8, b: *const u8) -> u64 {
+                (crate::memory::memcmp(a, b, 1) == 0) as u64
+            }
+            """,
+            """
+            fn __rue_str_eq(a: *const u8, b: *const u8) -> u64 {
+                let _ = crate::memory::bcmp(a, b, 1);
+                (crate::memory::memcmp(a, b, 1) == 0) as u64
+            }
+            """,
+            """
+            fn __rue_str_eq(a: *const u8, b: *const u8) -> u64 {
+                let _ = crate::memory::bcmp(a, b, 1);
+                1
+            }
+            """,
+        ]
+        for source in sources:
+            with tempfile.NamedTemporaryFile("w", delete=False) as file:
+                file.write(source)
+                path = Path(file.name)
+            try:
+                with self.assertRaises(AssertionError):
+                    validator.validate_str_eq_source(path)
+            finally:
+                path.unlink()
+
+    def test_elf_fixture_skips_undefined_then_keeps_defined_function(self):
+        sections = [{}, {"flags": 0x4, "name": ".text.memcpy"}]
+        entries = [
+            {"name": "memcpy", "section": 0, "info": 2},
+            {"name": "memcpy", "section": 1, "info": 2},
+        ]
+        defined = validator._defined_elf_functions(entries, sections)
+        self.assertEqual([entry["section"] for entry in defined], [1])
+
+    def test_defined_duplicate_functions_are_rejected(self):
+        sections = [{}, {"flags": 0x4, "name": ".text.memcpy"}]
+        entries = [
+            {"name": "memcpy", "section": 1, "info": 2},
+            {"name": "memcpy", "section": 1, "info": 2},
+        ]
+        with self.assertRaisesRegex(AssertionError, "ambiguous"):
+            validator._defined_elf_functions(entries, sections)
+
+    def test_macho_fixture_skips_undefined_then_keeps_defined_function(self):
+        sections = [{"name": "__text", "flags": 0x80000000}]
+        entries = [
+            {"name": "_memcpy", "section": 0, "type": 0},
+            {"name": "_memcpy", "section": 1, "type": validator.N_SECT},
+        ]
+        defined = validator._defined_macho_functions(entries, sections)
+        self.assertEqual([entry["section"] for entry in defined], [1])
+
+    def test_macho_duplicate_functions_are_rejected(self):
+        sections = [{"name": "__text", "flags": 0x80000000}]
+        entries = [
+            {"name": "_memcpy", "section": 1, "type": validator.N_SECT},
+            {"name": "_memcpy", "section": 1, "type": validator.N_SECT},
+        ]
+        with self.assertRaisesRegex(AssertionError, "ambiguous"):
+            validator._defined_macho_functions(entries, sections)
+
+    def test_cross_member_duplicate_definitions_are_rejected(self):
+        one = {"memcpy": body("memcpy", bytes.fromhex("488b07"))}
+        two = {"memcpy": body("memcpy", bytes.fromhex("488b07"))}
+        with self.assertRaisesRegex(AssertionError, "ambiguous definition of memcpy"):
+            validator._collect_archive_definitions(
+                Path("synthetic.a"), [("one.o", one), ("two.o", two)], "elf"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/crates/rue-runtime/tests/test_validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/test_validate_runtime_archives.py
@@ -53,6 +53,21 @@ class BodyValidationTests(unittest.TestCase):
         impl = body("impl", bytes.fromhex("488b07"))
         validator._validate_bodies(Path("synthetic"), {"memcpy": wrapper, "impl": impl}, "elf", 62)
 
+    def test_wrapper_skips_unrelated_outlined_helper(self):
+        wrapper = body(
+            "memset",
+            bytes.fromhex("e800000000e800000000"),
+            [(1, "outlined", 4), (6, "chunk", 4)],
+        )
+        outlined = body("outlined", bytes.fromhex("c3"))
+        chunk = body("chunk", bytes.fromhex("488b07"))
+        validator._validate_bodies(
+            Path("synthetic"),
+            {"memset": wrapper, "outlined": outlined, "chunk": chunk},
+            "elf",
+            62,
+        )
+
     def test_str_eq_wrapper_follows_bcmp(self):
         wrapper = body("__rue_str_eq", bytes.fromhex("e900000000"), [(1, "bcmp", 4)])
         impl = body("bcmp", bytes.fromhex("488b07"))

--- a/crates/rue-runtime/tests/test_validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/test_validate_runtime_archives.py
@@ -49,9 +49,35 @@ class BodyValidationTests(unittest.TestCase):
         validator._validate_bodies(Path("synthetic"), {"memcpy": loop}, "elf", 62)
 
     def test_wrapper_follows_canonical_body(self):
-        wrapper = body("memcpy", bytes.fromhex("e900000000"), [(1, "impl", 4)])
-        impl = body("impl", bytes.fromhex("488b07"))
-        validator._validate_bodies(Path("synthetic"), {"memcpy": wrapper, "impl": impl}, "elf", 62)
+        wrapper = body("memcpy", bytes.fromhex("e900000000"), [(1, "canonical", 4)])
+        canonical = body("_ZN11rue_runtime6memory6memcpy17h1234567890abcdefE", bytes.fromhex("488b07"))
+        validator._validate_bodies(
+            Path("synthetic"), {"memcpy": wrapper, "canonical": canonical}, "elf", 62
+        )
+
+    def test_unrelated_word_access_helper_is_not_chunk_proof(self):
+        wrapper = body("memcpy", bytes.fromhex("e900000000"), [(1, "helper", 4)])
+        helper = body("helper", bytes.fromhex("488b07"))
+        with self.assertRaisesRegex(AssertionError, "no non-stack machine-word access"):
+            validator._validate_bodies(
+                Path("synthetic"), {"memcpy": wrapper, "helper": helper}, "elf", 62
+            )
+
+    def test_later_branch_indirect_recursion_is_rejected(self):
+        wrapper = body(
+            "memcpy",
+            bytes.fromhex("e800000000e800000000"),
+            [(1, "good", 4), (6, "later", 4)],
+        )
+        good = body("good", bytes.fromhex("488b07"))
+        later = body("later", bytes.fromhex("e900000000"), [(1, "memcpy", 4)])
+        with self.assertRaisesRegex(AssertionError, "recursively transfers"):
+            validator._validate_bodies(
+                Path("synthetic"),
+                {"memcpy": wrapper, "good": good, "later": later},
+                "elf",
+                62,
+            )
 
     def test_wrapper_skips_unrelated_outlined_helper(self):
         wrapper = body(
@@ -60,7 +86,7 @@ class BodyValidationTests(unittest.TestCase):
             [(1, "outlined", 4), (6, "chunk", 4)],
         )
         outlined = body("outlined", bytes.fromhex("c3"))
-        chunk = body("chunk", bytes.fromhex("488b07"))
+        chunk = body("_ZN11rue_runtime6memory11write_chunk17h1234567890abcdefE", bytes.fromhex("488b07"))
         validator._validate_bodies(
             Path("synthetic"),
             {"memset": wrapper, "outlined": outlined, "chunk": chunk},

--- a/crates/rue-runtime/tests/test_validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/test_validate_runtime_archives.py
@@ -48,8 +48,14 @@ class InstructionShapeTests(unittest.TestCase):
     def test_data_relocations_are_not_control_transfers(self):
         # movq (%rdi), %rax; subq $external_data, %rax; ret. The R_X86_64_32S
         # relocation starts at the subq immediate, not at a call instruction.
-        x86 = bytes.fromhex("488b07482b0500000000c3")
+        x86 = bytes.fromhex("488b074881e800000000c3")
         self.assertIsNone(validator.relocation_is_control_transfer(x86, 6, 62, 11, "elf"))
+        # The RIP-relative memory form is a data relocation as well.
+        self.assertIsNone(
+            validator.relocation_is_control_transfer(
+                bytes.fromhex("482b0500000000c3"), 3, 62, 2, "elf"
+            )
+        )
         self.assertIsNone(
             validator.relocation_is_control_transfer(
                 (0x90000000).to_bytes(4, "little"), 0, 183, 275, "elf"
@@ -108,6 +114,20 @@ class BodyValidationTests(unittest.TestCase):
         with self.assertRaisesRegex(AssertionError, "unresolved reachable control transfer"):
             validator._validate_bodies(Path("synthetic.a:member.o"), {"memcpy": root}, "elf", 62)
 
+    def test_unresolved_x86_indirect_transfers_are_rejected(self):
+        fixtures = [
+            # call *external_helper: SIB no-base absolute disp32 (R_X86_64_32S).
+            ("488b07ff142500000000", 6, 11),
+            # call *external_helper(%rax): base + disp32 (R_X86_64_32S).
+            ("488b07ff90" + "00000000", 5, 11),
+            # call *external_helper@GOTPCREL(%rip): RIP-relative disp32 (GOTPCREL).
+            ("488b07ff1500000000", 5, 9),
+        ]
+        for encoded, offset, kind in fixtures:
+            root = body("memcpy", bytes.fromhex(encoded), [(offset, "unknown_helper", kind)])
+            with self.assertRaisesRegex(AssertionError, "unresolved reachable control transfer"):
+                validator._validate_bodies(Path("synthetic.a:member.o"), {"memcpy": root}, "elf", 62)
+
     def test_unresolved_macho_cross_member_control_transfer_is_rejected(self):
         root = body(
             "_memcpy",
@@ -125,8 +145,11 @@ class BodyValidationTests(unittest.TestCase):
         validator._validate_bodies(Path("synthetic"), {"memcpy": root}, "elf", 62)
 
     def test_valid_x86_data_relocation_does_not_hide_a_call(self):
-        root = body("memcpy", bytes.fromhex("488b07482b0500000000c3"), [(6, "external_data", 11)])
+        root = body("memcpy", bytes.fromhex("488b074881e800000000c3"), [(6, "external_data", 11)])
         validator._validate_bodies(Path("synthetic"), {"memcpy": root}, "elf", 62)
+
+        rip_data = body("memcpy", bytes.fromhex("488b07482b0500000000c3"), [(6, "external_data", 2)])
+        validator._validate_bodies(Path("synthetic"), {"memcpy": rip_data}, "elf", 62)
 
     def test_valid_aarch64_adrp_data_relocation_is_not_a_call(self):
         root = body(

--- a/crates/rue-runtime/tests/validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/validate_runtime_archives.py
@@ -560,32 +560,82 @@ def has_non_stack_word_access(code: bytes, machine: int) -> bool:
     return False
 
 
-def relocation_is_control_transfer(code: bytes, offset: int, machine: int):
-    if machine == 62:
-        for opcode_offset in (offset - 1, offset):
-            if 0 <= opcode_offset < len(code) and code[opcode_offset] in (0xE8, 0xE9, 0xEB):
-                return "call" if code[opcode_offset] == 0xE8 else "branch"
-        # Indirect calls/jumps use FF /2 or FF /4. Relocations are attached
-        # to the displacement/immediate, so account for the opcode and ModRM
-        # immediately before the relocation rather than treating every REX
-        # prefix as a transfer.
-        for opcode_offset in (offset - 2, offset - 1, offset):
-            if 0 <= opcode_offset + 1 < len(code):
-                opcode = code[opcode_offset]
-                if 0x40 <= opcode <= 0x4F and opcode_offset + 2 < len(code):
-                    opcode, modrm = code[opcode_offset + 1], code[opcode_offset + 2]
-                else:
-                    modrm = code[opcode_offset + 1]
-                if opcode == 0xFF and ((modrm >> 3) & 7) in (2, 4):
-                    return "call-or-branch"
+def _x86_control_transfer_at(code: bytes, index: int, offset: int):
+    """Classify a direct or RIP-relative indirect transfer at instruction index."""
+    cursor = index
+    while cursor < len(code) and 0x40 <= code[cursor] <= 0x4F:
+        cursor += 1
+    if cursor >= len(code):
         return None
-    if offset < 0 or offset + 4 > len(code):
+    opcode = code[cursor]
+    if opcode in (0xE8, 0xE9):
+        return ("call" if opcode == 0xE8 else "branch") if offset == cursor + 1 else None
+    if opcode != 0xFF or cursor + 1 >= len(code):
         return None
-    word = struct.unpack_from("<I", code, offset)[0]
-    if word & 0xfc000000 == 0x94000000:
-        return "call"
-    if word & 0xfc000000 == 0x14000000:
-        return "branch"
+    modrm = code[cursor + 1]
+    if ((modrm >> 3) & 7) not in (2, 4) or modrm >> 6 == 3:
+        return None
+    # Relocations on indirect calls/jumps name the memory displacement. Find
+    # that exact field rather than looking at bytes immediately before offset.
+    parsed = _x86_modrm_end(code, cursor + 2, modrm, code[cursor - 1] if cursor > index else 0)
+    if parsed is None:
+        return None
+    end, _ = parsed
+    mod = modrm >> 6
+    rm = modrm & 7
+    displacement = cursor + 2
+    if rm == 4:
+        displacement += 1
+        sib = code[cursor + 2]
+        if mod == 0 and (sib & 7) == 5:
+            return "call-or-branch" if offset == displacement else None
+    if mod == 0 and rm == 5:
+        return "call-or-branch" if offset == displacement else None
+    if mod == 1:
+        displacement += 1
+    elif mod == 2:
+        displacement += 4
+    else:
+        return None
+    return "call-or-branch" if offset == displacement else None
+
+
+def relocation_is_control_transfer(code: bytes, offset: int, machine: int,
+                                    relocation_kind: int, expected_format: str):
+    """Recognize only allowlisted relocations attached to decoded transfers."""
+    if expected_format == "elf" and machine == 62:
+        if relocation_kind not in (2, 4, 41, 42):  # PC32, PLT32, GOTPCRELX variants
+            return None
+        index = 0
+        while index < len(code):
+            decoded = _decode_x86_instruction(code, index)
+            if decoded is None:
+                return None
+            if _x86_control_transfer_at(code, index, offset) is not None:
+                return _x86_control_transfer_at(code, index, offset)
+            index = decoded[0]
+        return None
+    if expected_format == "elf" and machine == 183:
+        if relocation_kind not in (282, 283):  # JUMP26, CALL26
+            return None
+        if offset < 0 or offset + 4 > len(code):
+            return None
+        word = struct.unpack_from("<I", code, offset)[0]
+        if word & 0xfc000000 == 0x94000000:
+            return "call"
+        if word & 0xfc000000 == 0x14000000:
+            return "branch"
+        return None
+    if expected_format == "macho" and machine == MACHO_CPU_ARM64:
+        if relocation_kind != 2:  # ARM64_RELOC_BRANCH26
+            return None
+        if offset < 0 or offset + 4 > len(code):
+            return None
+        word = struct.unpack_from("<I", code, offset)[0]
+        if word & 0xfc000000 == 0x94000000:
+            return "call"
+        if word & 0xfc000000 == 0x14000000:
+            return "branch"
     return None
 
 
@@ -621,9 +671,10 @@ def _validate_bodies(path: Path, bodies: dict, expected_format: str,
         # A reserved export must never call/jump to another reserved export,
         # even when it also contains a word access. This catches accidental
         # compiler-builtins recursion and tail recursion.
-        for offset, target, _ in current["relocs"]:
+        for offset, target, kind in current["relocs"]:
             if not relocation_is_control_transfer(current["code"], offset,
-                                                   expected_machine):
+                                                   expected_machine, kind,
+                                                   expected_format):
                 continue
             normalized = _normalized_target(target, expected_format)
             if normalized in RESERVED_SYMBOLS and symbol in RESERVED_SYMBOLS:
@@ -657,9 +708,10 @@ def _validate_bodies(path: Path, bodies: dict, expected_format: str,
         # leaving the real chunk accessor as another relocation. Explore all
         # local control-transfer candidates, but only accept a canonical body or
         # the named chunk accessors as proof of the required implementation.
-        for offset, target, _ in current["relocs"]:
+        for offset, target, kind in current["relocs"]:
             if not relocation_is_control_transfer(current["code"], offset,
-                                                   expected_machine) or not target:
+                                                   expected_machine, kind,
+                                                   expected_format) or not target:
                 continue
             target_body = _target_body(bodies, target, expected_format)
             if target_body is not None and reaches_accessor(

--- a/crates/rue-runtime/tests/validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/validate_runtime_archives.py
@@ -573,8 +573,10 @@ def _x86_control_transfer_at(code: bytes, index: int, offset: int):
     if opcode != 0xFF or cursor + 1 >= len(code):
         return None
     modrm = code[cursor + 1]
-    if ((modrm >> 3) & 7) not in (2, 4) or modrm >> 6 == 3:
+    operation = (modrm >> 3) & 7
+    if operation not in (2, 4) or modrm >> 6 == 3:
         return None
+    transfer = "indirect-call" if operation == 2 else "indirect-branch"
     # Relocations on indirect calls/jumps name the memory displacement. Find
     # that exact field rather than looking at bytes immediately before offset.
     parsed = _x86_modrm_end(code, cursor + 2, modrm, code[cursor - 1] if cursor > index else 0)
@@ -587,13 +589,13 @@ def _x86_control_transfer_at(code: bytes, index: int, offset: int):
         displacement += 1
         sib = code[cursor + 2]
         if mod == 0 and (sib & 7) == 5:
-            return "call-or-branch" if offset == displacement else None
+            return transfer if offset == displacement else None
     if mod == 0 and rm == 5:
-        return "call-or-branch" if offset == displacement else None
+        return transfer if offset == displacement else None
     if mod == 1:
-        return "call-or-branch" if offset == displacement else None
+        return transfer if offset == displacement else None
     elif mod == 2:
-        return "call-or-branch" if offset == displacement else None
+        return transfer if offset == displacement else None
     else:
         return None
 
@@ -615,7 +617,7 @@ def relocation_is_control_transfer(code: bytes, offset: int, machine: int,
                 # memory displacement and may use absolute/GOT relocations.
                 direct_kinds = (2, 4)
                 indirect_kinds = (2, 9, 10, 11, 41, 42)
-                if transfer == "call-or-branch":
+                if transfer in ("indirect-call", "indirect-branch"):
                     return transfer if relocation_kind in indirect_kinds else None
                 return transfer if relocation_kind in direct_kinds else None
             index = decoded[0]
@@ -691,7 +693,7 @@ def _validate_bodies(path: Path, bodies: dict, expected_format: str,
             # jump table, not a callable edge. It is resolved data even though
             # the machine instruction is an indirect branch; do not mistake it
             # for an unresolved helper call.
-            if transfer == "call-or-branch" and _is_local_data_target(target, expected_format):
+            if transfer == "indirect-branch" and _is_local_data_target(target, expected_format):
                 continue
             normalized = _normalized_target(target, expected_format)
             if normalized in RESERVED_SYMBOLS and symbol in RESERVED_SYMBOLS:

--- a/crates/rue-runtime/tests/validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/validate_runtime_archives.py
@@ -631,8 +631,13 @@ def _validate_bodies(path: Path, bodies: dict, expected_format: str,
                     f"{path}: {symbol} recursively transfers to reserved symbol {normalized}"
                 )
             target_body = _target_body(bodies, target, expected_format)
-            if target_body is not None:
-                audit_reachable(target_body, seen, symbol)
+            if target_body is None:
+                destination = normalized or "<unnamed relocation>"
+                raise AssertionError(
+                    f"{path}: {symbol} has unresolved reachable control transfer "
+                    f"to {destination}"
+                )
+            audit_reachable(target_body, seen, symbol)
 
     def reaches_accessor(current, seen, root_name, symbol):
         if current["name"] in seen:

--- a/crates/rue-runtime/tests/validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/validate_runtime_archives.py
@@ -596,12 +596,27 @@ def _normalized_target(target: str, expected_format: str) -> str:
     return target
 
 
+def _target_body(bodies: dict, target: str, expected_format: str):
+    normalized = _normalized_target(target, expected_format)
+    return bodies.get(target) or bodies.get(normalized) or bodies.get(
+        ".text." + normalized if expected_format == "elf" else "_" + normalized
+    )
+
+
+def _is_chunk_accessor(name: str) -> bool:
+    return bool(re.search(r"memory\d+(?:read_chunk|write_chunk)", name))
+
+
+def _is_canonical_body(name: str, symbol: str) -> bool:
+    return bool(re.search(r"memory\d+" + re.escape(symbol) + r"\d+h[0-9a-f]+E$", name))
+
+
 def _validate_bodies(path: Path, bodies: dict, expected_format: str,
                      expected_machine: int):
     """Validate symbol bodies and wrapper targets in one object."""
-    def reaches_chunk(current, seen):
+    def audit_reachable(current, seen, symbol):
         if current["name"] in seen:
-            return False
+            return
         seen = seen | {current["name"]}
         # A reserved export must never call/jump to another reserved export,
         # even when it also contains a word access. This catches accidental
@@ -615,21 +630,35 @@ def _validate_bodies(path: Path, bodies: dict, expected_format: str,
                 raise AssertionError(
                     f"{path}: {symbol} recursively transfers to reserved symbol {normalized}"
                 )
-        if has_non_stack_word_access(current["code"], expected_machine):
+            target_body = _target_body(bodies, target, expected_format)
+            if target_body is not None:
+                audit_reachable(target_body, seen, symbol)
+
+    def reaches_accessor(current, seen, root_name, symbol):
+        if current["name"] in seen:
+            return False
+        seen = seen | {current["name"]}
+        is_approved_body = (
+            current["name"] == root_name
+            or _is_canonical_body(current["name"], symbol)
+            or _is_chunk_accessor(current["name"])
+            or (symbol == "__rue_str_eq" and current["name"] in ("bcmp", "_bcmp"))
+        )
+        if is_approved_body and has_non_stack_word_access(current["code"], expected_machine):
             return True
+        if has_non_stack_word_access(current["code"], expected_machine):
+            return False
         # Optimizers may outline an unrelated check into a local helper while
         # leaving the real chunk accessor as another relocation. Explore all
-        # local control-transfer candidates instead of choosing the first
-        # outlined helper and treating its byte-free body as canonical.
+        # local control-transfer candidates, but only accept a canonical body or
+        # the named chunk accessors as proof of the required implementation.
         for offset, target, _ in current["relocs"]:
             if not relocation_is_control_transfer(current["code"], offset,
                                                    expected_machine) or not target:
                 continue
-            normalized = _normalized_target(target, expected_format)
-            target_body = bodies.get(target) or bodies.get(normalized) or bodies.get(
-                ".text." + normalized if expected_format == "elf" else "_" + normalized
-            )
-            if target_body is not None and reaches_chunk(target_body, seen):
+            target_body = _target_body(bodies, target, expected_format)
+            if target_body is not None and reaches_accessor(
+                    target_body, seen, root_name, symbol):
                 return True
         return False
 
@@ -638,7 +667,8 @@ def _validate_bodies(path: Path, bodies: dict, expected_format: str,
         body = bodies.get(lookup)
         if body is None:
             continue
-        if not reaches_chunk(body, set()):
+        audit_reachable(body, set(), symbol)
+        if not reaches_accessor(body, set(), body["name"], symbol):
             raise AssertionError(f"{path}: {symbol} body has no non-stack machine-word access")
 
 

--- a/crates/rue-runtime/tests/validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/validate_runtime_archives.py
@@ -599,45 +599,47 @@ def _normalized_target(target: str, expected_format: str) -> str:
 def _validate_bodies(path: Path, bodies: dict, expected_format: str,
                      expected_machine: int):
     """Validate symbol bodies and wrapper targets in one object."""
+    def reaches_chunk(current, seen):
+        if current["name"] in seen:
+            return False
+        seen = seen | {current["name"]}
+        # A reserved export must never call/jump to another reserved export,
+        # even when it also contains a word access. This catches accidental
+        # compiler-builtins recursion and tail recursion.
+        for offset, target, _ in current["relocs"]:
+            if not relocation_is_control_transfer(current["code"], offset,
+                                                   expected_machine):
+                continue
+            normalized = _normalized_target(target, expected_format)
+            if normalized in RESERVED_SYMBOLS and symbol in RESERVED_SYMBOLS:
+                raise AssertionError(
+                    f"{path}: {symbol} recursively transfers to reserved symbol {normalized}"
+                )
+        if has_non_stack_word_access(current["code"], expected_machine):
+            return True
+        # Optimizers may outline an unrelated check into a local helper while
+        # leaving the real chunk accessor as another relocation. Explore all
+        # local control-transfer candidates instead of choosing the first
+        # outlined helper and treating its byte-free body as canonical.
+        for offset, target, _ in current["relocs"]:
+            if not relocation_is_control_transfer(current["code"], offset,
+                                                   expected_machine) or not target:
+                continue
+            normalized = _normalized_target(target, expected_format)
+            target_body = bodies.get(target) or bodies.get(normalized) or bodies.get(
+                ".text." + normalized if expected_format == "elf" else "_" + normalized
+            )
+            if target_body is not None and reaches_chunk(target_body, seen):
+                return True
+        return False
+
     for symbol in CHUNKED_SYMBOLS:
         lookup = symbol if expected_format == "elf" else "_" + symbol
         body = bodies.get(lookup)
         if body is None:
             continue
-        current = body
-        seen = set()
-        while True:
-            # A reserved export must never call/jump to another reserved
-            # export, even when it also contains a word access. This catches
-            # accidental compiler-builtins recursion and tail recursion.
-            for offset, target, _ in current["relocs"]:
-                if not relocation_is_control_transfer(current["code"], offset,
-                                                       expected_machine):
-                    continue
-                normalized = _normalized_target(target, expected_format)
-                if normalized in RESERVED_SYMBOLS and symbol in RESERVED_SYMBOLS:
-                    raise AssertionError(
-                        f"{path}: {symbol} recursively transfers to reserved symbol {normalized}"
-                    )
-            if has_non_stack_word_access(current["code"], expected_machine):
-                break
-            target_body = None
-            for offset, target, _ in current["relocs"]:
-                if not relocation_is_control_transfer(current["code"], offset,
-                                                       expected_machine) or not target:
-                    continue
-                normalized = _normalized_target(target, expected_format)
-                target_body = bodies.get(target) or bodies.get(normalized) or bodies.get(
-                    ".text." + normalized if expected_format == "elf" else "_" + normalized
-                )
-                if target_body is not None:
-                    break
-            if target_body is None or target_body["name"] in seen:
-                raise AssertionError(
-                    f"{path}: {symbol} body has no non-stack machine-word access"
-                )
-            seen.add(current["name"])
-            current = target_body
+        if not reaches_chunk(body, set()):
+            raise AssertionError(f"{path}: {symbol} body has no non-stack machine-word access")
 
 
 def validate_chunked_primitives(path: Path, expected_format: str, expected_machine: int):

--- a/crates/rue-runtime/tests/validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/validate_runtime_archives.py
@@ -651,6 +651,11 @@ def _normalized_target(target: str, expected_format: str) -> str:
     return target
 
 
+def _is_local_data_target(target: str, expected_format: str) -> bool:
+    normalized = _normalized_target(target, expected_format)
+    return normalized.startswith(".rodata") or normalized.startswith("rodata")
+
+
 def _target_body(bodies: dict, target: str, expected_format: str):
     normalized = _normalized_target(target, expected_format)
     return bodies.get(target) or bodies.get(normalized) or bodies.get(
@@ -677,9 +682,16 @@ def _validate_bodies(path: Path, bodies: dict, expected_format: str,
         # even when it also contains a word access. This catches accidental
         # compiler-builtins recursion and tail recursion.
         for offset, target, kind in current["relocs"]:
-            if not relocation_is_control_transfer(current["code"], offset,
-                                                   expected_machine, kind,
-                                                   expected_format):
+            transfer = relocation_is_control_transfer(
+                current["code"], offset, expected_machine, kind, expected_format
+            )
+            if not transfer:
+                continue
+            # An x86 FF /4 relocation to a local .rodata symbol is a compiler
+            # jump table, not a callable edge. It is resolved data even though
+            # the machine instruction is an indirect branch; do not mistake it
+            # for an unresolved helper call.
+            if transfer == "call-or-branch" and _is_local_data_target(target, expected_format):
                 continue
             normalized = _normalized_target(target, expected_format)
             if normalized in RESERVED_SYMBOLS and symbol in RESERVED_SYMBOLS:

--- a/crates/rue-runtime/tests/validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/validate_runtime_archives.py
@@ -580,7 +580,6 @@ def _x86_control_transfer_at(code: bytes, index: int, offset: int):
     parsed = _x86_modrm_end(code, cursor + 2, modrm, code[cursor - 1] if cursor > index else 0)
     if parsed is None:
         return None
-    end, _ = parsed
     mod = modrm >> 6
     rm = modrm & 7
     displacement = cursor + 2
@@ -592,27 +591,33 @@ def _x86_control_transfer_at(code: bytes, index: int, offset: int):
     if mod == 0 and rm == 5:
         return "call-or-branch" if offset == displacement else None
     if mod == 1:
-        displacement += 1
+        return "call-or-branch" if offset == displacement else None
     elif mod == 2:
-        displacement += 4
+        return "call-or-branch" if offset == displacement else None
     else:
         return None
-    return "call-or-branch" if offset == displacement else None
 
 
 def relocation_is_control_transfer(code: bytes, offset: int, machine: int,
                                     relocation_kind: int, expected_format: str):
     """Recognize only allowlisted relocations attached to decoded transfers."""
     if expected_format == "elf" and machine == 62:
-        if relocation_kind not in (2, 4, 41, 42):  # PC32, PLT32, GOTPCRELX variants
+        if relocation_kind not in (2, 4, 9, 10, 11, 41, 42):  # PC/PLT/GOT/absolute
             return None
         index = 0
         while index < len(code):
             decoded = _decode_x86_instruction(code, index)
             if decoded is None:
                 return None
-            if _x86_control_transfer_at(code, index, offset) is not None:
-                return _x86_control_transfer_at(code, index, offset)
+            transfer = _x86_control_transfer_at(code, index, offset)
+            if transfer is not None:
+                # E8/E9 carry PC-relative relocations; FF /2,/4 carry a
+                # memory displacement and may use absolute/GOT relocations.
+                direct_kinds = (2, 4)
+                indirect_kinds = (2, 9, 10, 11, 41, 42)
+                if transfer == "call-or-branch":
+                    return transfer if relocation_kind in indirect_kinds else None
+                return transfer if relocation_kind in direct_kinds else None
             index = decoded[0]
         return None
     if expected_format == "elf" and machine == 183:

--- a/crates/rue-runtime/tests/validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/validate_runtime_archives.py
@@ -2,6 +2,7 @@
 """Validate the object format and architecture of each runtime archive."""
 
 import os
+import re
 import struct
 from pathlib import Path
 
@@ -14,6 +15,13 @@ N_EXT = 0x01
 N_TYPE = 0x0E
 N_SECT = 0x0E
 N_PEXT = 0x10
+CHUNKED_SYMBOLS = ("memcpy", "memmove", "memset", "memcmp", "bcmp", "__rue_str_eq")
+RESERVED_SYMBOLS = ("memcpy", "memmove", "memset", "memcmp", "bcmp")
+ELF_SHT_RELA = 4
+ELF_SHT_REL = 9
+ELF_SHT_SYMTAB = 2
+MACHO_LC_SEGMENT_64 = 0x19
+MACHO_CPU_ARM64 = 0x0100000C
 
 
 def archive_members(path: Path):
@@ -125,6 +133,550 @@ def macho_symbols(payload: bytes):
     return symbols
 
 
+def _bounded_slice(data: bytes, start: int, size: int, description: str) -> bytes:
+    end = start + size
+    if start < 0 or size < 0 or end > len(data):
+        raise AssertionError(f"{description}: range [{start}, {end}) is outside object")
+    return data[start:end]
+
+
+def _function_body(source: str, function_name: str) -> str:
+    marker = f"fn {function_name}"
+    start = source.find(marker)
+    if start < 0:
+        raise AssertionError(f"source is missing {function_name}")
+    opening = source.find("{", start)
+    if opening < 0:
+        raise AssertionError(f"source has no body for {function_name}")
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1:index]
+    raise AssertionError(f"source has an unterminated body for {function_name}")
+
+
+def _strip_rust_comments(source: str) -> str:
+    """Remove comments for the narrow source-shape check.
+
+    The runtime body contains no string literals relevant to this invariant;
+    stripping both Rust comment forms keeps formatting/comment changes from
+    changing the ownership check while leaving the expression structure intact.
+    """
+    source = re.sub(r"/\*.*?\*/", "", source, flags=re.DOTALL)
+    return re.sub(r"//[^\n]*", "", source)
+
+
+def validate_str_eq_source(path: Path):
+    """Enforce the source-level ownership contract for string equality.
+
+    LTO can inline the comparison authority, so object shape alone cannot
+    prove provenance. The source contract requires a direct call to bcmp and
+    forbids an independent loop or chunk primitive in the exported body.
+    """
+    code = _strip_rust_comments(path.read_text())
+    body = _function_body(code, "__rue_str_eq")
+    bcmp_calls = re.findall(r"crate::memory::bcmp\s*\(", body)
+    if len(bcmp_calls) != 1:
+        raise AssertionError(f"{path}: __rue_str_eq must delegate to crate::memory::bcmp")
+    if re.search(r"\b(?:memcpy|memmove|memset|memcmp|bcmp)\s*\(", body.replace(
+            "crate::memory::bcmp", "")):
+        raise AssertionError(f"{path}: __rue_str_eq uses another memory authority")
+    if not re.search(
+            r"(?:return\s+)?\(\s*unsafe\s*\{\s*crate::memory::bcmp\s*"
+            r"\([^;]*\)\s*==\s*0\s*\}\s*\)\s*as\s+u64\s*;?\s*\Z",
+            body,
+            re.DOTALL,
+    ):
+        raise AssertionError(f"{path}: bcmp result is not the returned equality")
+    if re.search(r"\b(?:while|for)\b|read_chunk|write_chunk|read_unaligned|write_unaligned", body):
+        raise AssertionError(f"{path}: __rue_str_eq contains an independent comparison loop")
+
+
+def parse_elf_object(payload: bytes):
+    """Parse the ELF64 sections, symbols, and relocations needed by the guard."""
+    if len(payload) < 64 or not payload.startswith(ELF_MAGIC) or payload[4] != 2:
+        raise AssertionError("runtime archive member is not ELF64")
+    endian = "<" if payload[5] == 1 else ">" if payload[5] == 2 else None
+    if endian is None:
+        raise AssertionError("ELF object has invalid endianness")
+    section_offset = struct.unpack_from(endian + "Q", payload, 40)[0]
+    section_entry_size, section_count, string_index = struct.unpack_from(
+        endian + "HHH", payload, 58
+    )
+    if section_entry_size < 64:
+        raise AssertionError("ELF object has short section headers")
+    sections = []
+    for index in range(section_count):
+        base = section_offset + index * section_entry_size
+        values = struct.unpack_from(endian + "IIQQQQIIQQ", payload, base)
+        _, section_type, flags, address, offset, size, link, info, _, entry_size = values
+        sections.append(
+            {"type": section_type, "address": address, "offset": offset, "size": size,
+             "flags": flags, "link": link, "info": info, "entry_size": entry_size,
+             "relocs": []}
+        )
+    section_names = _bounded_slice(
+        payload, sections[string_index]["offset"], sections[string_index]["size"], "ELF section names"
+    )
+    for index, section in enumerate(sections):
+        name_offset = struct.unpack_from(
+            endian + "I", payload, section_offset + index * section_entry_size
+        )[0]
+        end = section_names.find(b"\0", name_offset)
+        if end < 0:
+            raise AssertionError("ELF section has invalid name")
+        section["name"] = section_names[name_offset:end].decode("ascii", errors="replace")
+
+    symbol_tables = {}
+    for index, section in enumerate(sections):
+        if section["type"] != ELF_SHT_SYMTAB:
+            continue
+        if section["entry_size"] < 24:
+            raise AssertionError("ELF symbol table has short entries")
+        strings = sections[section["link"]]
+        string_data = _bounded_slice(payload, strings["offset"], strings["size"], "ELF symbol strings")
+        entries = []
+        count = section["size"] // section["entry_size"]
+        for symbol_index in range(count):
+            base = section["offset"] + symbol_index * section["entry_size"]
+            name_offset, info, _, section_index, value, size = struct.unpack_from(
+                endian + "IBBHQQ", payload, base
+            )
+            name_end = string_data.find(b"\0", name_offset)
+            if name_end < 0:
+                raise AssertionError("ELF symbol has invalid name")
+            entries.append({"name": string_data[name_offset:name_end].decode("utf-8", errors="replace"),
+                            "section": section_index, "value": value, "size": size, "info": info})
+        symbol_tables[index] = entries
+
+    for section in sections:
+        if section["type"] not in (ELF_SHT_RELA, ELF_SHT_REL):
+            continue
+        symbols = symbol_tables.get(section["link"], [])
+        entry_size = section["entry_size"] or (24 if section["type"] == ELF_SHT_RELA else 16)
+        for index in range(section["size"] // entry_size):
+            base = section["offset"] + index * entry_size
+            reloc_offset, info = struct.unpack_from(endian + "QQ", payload, base)
+            symbol_index = info >> 32
+            target_entry = symbols[symbol_index] if symbol_index < len(symbols) else None
+            target = target_entry["name"] if target_entry else ""
+            # Local ELF relocations commonly refer to a section symbol. Its
+            # empty name still identifies the exact section/function body.
+            if not target and target_entry and target_entry["section"] < len(sections):
+                target = sections[target_entry["section"]]["name"]
+            sections[section["info"]]["relocs"].append((reloc_offset, target, info & 0xffffffff))
+
+    bodies = {}
+    for entries in symbol_tables.values():
+        by_section = {}
+        for entry in _defined_elf_functions(entries, sections):
+            by_section.setdefault(entry["section"], []).append(entry)
+        for section_index, section_entries in by_section.items():
+            section = sections[section_index]
+            section_entries.sort(key=lambda entry: entry["value"])
+            names = [entry["name"] for entry in section_entries]
+            if len(names) != len(set(names)):
+                raise AssertionError(
+                    f"ELF section {section['name']}: ambiguous function definition"
+                )
+            for position, entry in enumerate(section_entries):
+                relative = entry["value"] - section["address"]
+                size = entry["size"]
+                if size == 0:
+                    next_value = section_entries[position + 1]["value"] if position + 1 < len(section_entries) else section["address"] + section["size"]
+                    size = next_value - entry["value"]
+                code = _bounded_slice(payload, section["offset"] + relative, size, f"ELF symbol {entry['name']}")
+                relocs = [(offset - relative, target, kind) for offset, target, kind in section["relocs"] if relative <= offset < relative + size]
+                body = {"name": entry["name"], "code": code, "relocs": relocs,
+                        "machine": struct.unpack_from(endian + "H", payload, 18)[0]}
+                bodies.setdefault(entry["name"], body)
+                if entry["name"].startswith(".text."):
+                    bodies.setdefault(entry["name"][6:], body)
+    return bodies
+
+
+def _defined_elf_functions(entries, sections):
+    """Keep only defined STT_FUNC symbols in executable ELF sections."""
+    result = []
+    for entry in entries:
+        symbol_type = entry["info"] & 0x0F
+        section_index = entry["section"]
+        if (not entry["name"] or symbol_type != 2 or section_index == 0
+                or section_index >= len(sections)
+                or not sections[section_index]["flags"] & 0x4):
+            continue
+        result.append(entry)
+    names = [entry["name"] for entry in result]
+    if len(names) != len(set(names)):
+        raise AssertionError("ELF symbol table has an ambiguous function definition")
+    return result
+
+
+def parse_macho_object(payload: bytes):
+    """Parse 64-bit little-endian Mach-O symbols, text, and relocations."""
+    if len(payload) < 32 or not payload.startswith(MACHO_64_LE_MAGIC):
+        raise AssertionError("runtime archive member is not 64-bit little-endian Mach-O")
+    ncmds, sizeofcmds = struct.unpack_from("<II", payload, 16)
+    commands_end = 32 + sizeofcmds
+    if commands_end > len(payload):
+        raise AssertionError("Mach-O load commands exceed object")
+    sections = []
+    symtab = None
+    offset = 32
+    for _ in range(ncmds):
+        cmd, cmdsize = struct.unpack_from("<II", payload, offset)
+        if cmdsize < 8 or offset + cmdsize > commands_end:
+            raise AssertionError("Mach-O has invalid load command")
+        if cmd == MACHO_LC_SEGMENT_64:
+            nsects = struct.unpack_from("<I", payload, offset + 64)[0]
+            for section_index in range(nsects):
+                base = offset + 72 + section_index * 80
+                name = payload[base:base + 16].split(b"\0", 1)[0].decode("ascii", errors="replace")
+                address, size, file_offset, _, reloc_offset, reloc_count = struct.unpack_from(
+                    "<QQIIII", payload, base + 32
+                )
+                flags = struct.unpack_from("<I", payload, base + 64)[0]
+                sections.append({"name": name, "address": address, "size": size,
+                                 "offset": file_offset, "flags": flags,
+                                 "reloc_offset": reloc_offset, "reloc_count": reloc_count,
+                                 "relocs": []})
+        elif cmd == LC_SYMTAB:
+            symtab = struct.unpack_from("<IIII", payload, offset + 8)
+        offset += cmdsize
+    if symtab is None:
+        raise AssertionError("Mach-O object has no symbol table")
+    symoff, nsyms, stroff, strsize = symtab
+    string_data = _bounded_slice(payload, stroff, strsize, "Mach-O symbol strings")
+    entries = []
+    for index in range(nsyms):
+        base = symoff + index * 16
+        name_offset, n_type, section_index, _, value = struct.unpack_from(
+            "<IBBHQ", payload, base
+        )
+        name_end = string_data.find(b"\0", name_offset)
+        if name_end < 0:
+            raise AssertionError("Mach-O symbol has invalid name")
+        entries.append({"name": string_data[name_offset:name_end].decode("utf-8", errors="replace"), "section": section_index, "value": value, "size": 0, "type": n_type})
+    for section in sections:
+        for index in range(section["reloc_count"]):
+            base = section["reloc_offset"] + index * 8
+            address, info = struct.unpack_from("<iI", payload, base)
+            symbol_index = info & 0x00ffffff
+            target = entries[symbol_index]["name"] if info & 0x08000000 and symbol_index < len(entries) else ""
+            section["relocs"].append((address, target, info >> 28))
+    bodies = {}
+    by_section = {}
+    for entry in _defined_macho_functions(entries, sections):
+        by_section.setdefault(entry["section"] - 1, []).append(entry)
+    for section_index, section_entries in by_section.items():
+        section = sections[section_index]
+        section_entries.sort(key=lambda entry: entry["value"])
+        names = [entry["name"] for entry in section_entries]
+        if len(names) != len(set(names)):
+            raise AssertionError(
+                f"Mach-O section {section['name']}: ambiguous function definition"
+            )
+        for position, entry in enumerate(section_entries):
+            next_value = section_entries[position + 1]["value"] if position + 1 < len(section_entries) else section["address"] + section["size"]
+            size = next_value - entry["value"]
+            relative = entry["value"] - section["address"]
+            code = _bounded_slice(payload, section["offset"] + relative, size, f"Mach-O symbol {entry['name']}")
+            relocs = [(address - relative, target, kind) for address, target, kind in section["relocs"] if relative <= address < relative + size]
+            bodies.setdefault(entry["name"], {"name": entry["name"], "code": code, "relocs": relocs, "machine": MACHO_CPU_ARM64})
+    return bodies
+
+
+def _defined_macho_functions(entries, sections):
+    """Keep only defined section symbols in the executable __text section."""
+    result = []
+    for entry in entries:
+        section_index = entry["section"]
+        if (not section_index or section_index > len(sections)
+                or sections[section_index - 1]["name"] != "__text"
+                or not sections[section_index - 1]["flags"] & 0x80000000
+                or entry["type"] & N_TYPE != N_SECT):
+            continue
+        result.append(entry)
+    names = [entry["name"] for entry in result]
+    if len(names) != len(set(names)):
+        raise AssertionError("Mach-O symbol table has an ambiguous function definition")
+    return result
+
+
+def _x86_modrm_end(code: bytes, index: int, modrm: int, rex: int):
+    """Return (end, base-register-or-None) for a ModRM memory operand."""
+    mod = modrm >> 6
+    if mod == 3:
+        return index, None
+    rm = modrm & 7
+    end = index
+    base = rm | ((rex & 1) << 3)
+    if rm == 4:
+        if end >= len(code):
+            return None
+        sib = code[end]
+        end += 1
+        sib_base = sib & 7
+        if sib_base == 5 and mod == 0:
+            base = None
+            end += 4
+        else:
+            base = sib_base | ((rex & 1) << 3)
+    elif rm == 5 and mod == 0:
+        base = None
+    if mod == 1:
+        end += 1
+    elif mod == 2:
+        end += 4
+    elif mod == 0 and rm == 5:
+        end += 4
+    if end > len(code):
+        return None
+    return end, base
+
+
+def _decode_x86_instruction(code: bytes, index: int):
+    """Decode common x86-64 forms emitted by the optimized runtime.
+
+    This is intentionally a small decoder, not a general disassembler.
+    Unknown instructions terminate validation conservatively instead of
+    scanning their immediate bytes for instruction-shaped substrings.
+    """
+    rex = 0
+    operand_size = 4
+    while index < len(code):
+        byte = code[index]
+        if 0x40 <= byte <= 0x4F:
+            rex = byte
+            index += 1
+        elif byte == 0x66:
+            operand_size = 2
+            index += 1
+        elif byte in (0xF2, 0xF3, 0xF0, 0x67):
+            index += 1
+        else:
+            break
+    if index >= len(code):
+        return None
+    opcode = code[index]
+    index += 1
+    if opcode in (0xC3, 0x90, 0xCC) or 0x50 <= opcode <= 0x5F:
+        return index, False
+    if 0x70 <= opcode <= 0x7F or opcode in (0xEB, 0x6A):
+        end = index + 1
+        return (end, False) if end <= len(code) else None
+    if opcode in (0xE8, 0xE9):
+        end = index + 4
+        return (end, False) if end <= len(code) else None
+    if opcode == 0x68:
+        end = index + 4
+        return (end, False) if end <= len(code) else None
+    if 0xB0 <= opcode <= 0xB7:
+        end = index + 1
+        return (end, False) if end <= len(code) else None
+    if 0xB8 <= opcode <= 0xBF:
+        immediate_size = 8 if rex & 8 else operand_size
+        end = index + immediate_size
+        return (end, False) if end <= len(code) else None
+    if opcode == 0x0F:
+        if index >= len(code):
+            return None
+        extended = code[index]
+        index += 1
+        if 0x80 <= extended <= 0x8F:
+            end = index + 4
+            return (end, False) if end <= len(code) else None
+        if index >= len(code):
+            return None
+        modrm = code[index]
+        index += 1
+        parsed = _x86_modrm_end(code, index, modrm, rex)
+        if parsed is None:
+            return None
+        end, _ = parsed
+        return end, False
+    modrm_opcodes = {
+        0x01, 0x03, 0x09, 0x0B, 0x21, 0x23, 0x29, 0x2B, 0x31, 0x33,
+        0x39, 0x3B, 0x69, 0x6B, 0x80, 0x81, 0x83, 0x84, 0x85, 0x88,
+        0x89, 0x8A, 0x8B, 0x8D, 0x8F, 0xC0, 0xC1, 0xC6, 0xC7, 0xD1,
+        0xD3, 0xF6, 0xF7, 0xFE, 0xFF,
+    }
+    if opcode not in modrm_opcodes or index >= len(code):
+        return None
+    modrm = code[index]
+    index += 1
+    parsed = _x86_modrm_end(code, index, modrm, rex)
+    if parsed is None:
+        return None
+    end, base = parsed
+    access = opcode in (0x89, 0x8B) and rex & 8 and modrm >> 6 != 3
+    if access:
+        # RSP/RBP (and their extended forms) are stack bases. A frame-pointer
+        # spill cannot satisfy the non-stack chunk-access guard.
+        access = base not in (4, 5, 12, 13)
+    immediate_size = {
+        0x69: operand_size,
+        0x6B: 1,
+        0x80: 1,
+        0x81: operand_size,
+        0x83: 1,
+        0xC0: 1,
+        0xC1: 1,
+        0xC6: 1,
+        0xC7: operand_size,
+    }.get(opcode, 0)
+    # F6/F7 group /0 is TEST with an immediate. Consume it explicitly so
+    # bytes such as 48 8b 07 inside that immediate cannot be rescanned as a
+    # REX.W load. Other F6/F7 groups have no immediate relevant to this guard.
+    if opcode == 0xF6 and (modrm >> 3) & 7 == 0:
+        immediate_size = 1
+    elif opcode == 0xF7 and (modrm >> 3) & 7 == 0:
+        immediate_size = operand_size
+    end += immediate_size
+    return (end, access) if end <= len(code) else None
+
+
+def has_non_stack_word_access(code: bytes, machine: int) -> bool:
+    if machine == 62:
+        index = 0
+        while index < len(code):
+            decoded = _decode_x86_instruction(code, index)
+            if decoded is None:
+                return False
+            index, access = decoded
+            if access:
+                return True
+        return False
+    for index in range(0, len(code) - 3, 4):
+        word = struct.unpack_from("<I", code, index)[0]
+        if (word & 0xffc00000) in (0xf9400000, 0xf9000000, 0xf8400000, 0xf8000000, 0xa9400000, 0xa9000000):
+            # SP (31) and the conventional frame pointer X29 are stack bases.
+            if (word >> 5) & 31 not in (29, 31):
+                return True
+    return False
+
+
+def relocation_is_control_transfer(code: bytes, offset: int, machine: int):
+    if machine == 62:
+        for opcode_offset in (offset - 1, offset):
+            if 0 <= opcode_offset < len(code) and code[opcode_offset] in (0xE8, 0xE9, 0xEB):
+                return "call" if code[opcode_offset] == 0xE8 else "branch"
+        # Indirect calls/jumps use FF /2 or FF /4. Relocations are attached
+        # to the displacement/immediate, so account for the opcode and ModRM
+        # immediately before the relocation rather than treating every REX
+        # prefix as a transfer.
+        for opcode_offset in (offset - 2, offset - 1, offset):
+            if 0 <= opcode_offset + 1 < len(code):
+                opcode = code[opcode_offset]
+                if 0x40 <= opcode <= 0x4F and opcode_offset + 2 < len(code):
+                    opcode, modrm = code[opcode_offset + 1], code[opcode_offset + 2]
+                else:
+                    modrm = code[opcode_offset + 1]
+                if opcode == 0xFF and ((modrm >> 3) & 7) in (2, 4):
+                    return "call-or-branch"
+        return None
+    if offset < 0 or offset + 4 > len(code):
+        return None
+    word = struct.unpack_from("<I", code, offset)[0]
+    if word & 0xfc000000 == 0x94000000:
+        return "call"
+    if word & 0xfc000000 == 0x14000000:
+        return "branch"
+    return None
+
+
+def _normalized_target(target: str, expected_format: str) -> str:
+    target = target[6:] if target.startswith(".text.") else target
+    if expected_format == "macho" and target.startswith("_"):
+        target = target[1:]
+    return target
+
+
+def _validate_bodies(path: Path, bodies: dict, expected_format: str,
+                     expected_machine: int):
+    """Validate symbol bodies and wrapper targets in one object."""
+    for symbol in CHUNKED_SYMBOLS:
+        lookup = symbol if expected_format == "elf" else "_" + symbol
+        body = bodies.get(lookup)
+        if body is None:
+            continue
+        current = body
+        seen = set()
+        while True:
+            # A reserved export must never call/jump to another reserved
+            # export, even when it also contains a word access. This catches
+            # accidental compiler-builtins recursion and tail recursion.
+            for offset, target, _ in current["relocs"]:
+                if not relocation_is_control_transfer(current["code"], offset,
+                                                       expected_machine):
+                    continue
+                normalized = _normalized_target(target, expected_format)
+                if normalized in RESERVED_SYMBOLS and symbol in RESERVED_SYMBOLS:
+                    raise AssertionError(
+                        f"{path}: {symbol} recursively transfers to reserved symbol {normalized}"
+                    )
+            if has_non_stack_word_access(current["code"], expected_machine):
+                break
+            target_body = None
+            for offset, target, _ in current["relocs"]:
+                if not relocation_is_control_transfer(current["code"], offset,
+                                                       expected_machine) or not target:
+                    continue
+                normalized = _normalized_target(target, expected_format)
+                target_body = bodies.get(target) or bodies.get(normalized) or bodies.get(
+                    ".text." + normalized if expected_format == "elf" else "_" + normalized
+                )
+                if target_body is not None:
+                    break
+            if target_body is None or target_body["name"] in seen:
+                raise AssertionError(
+                    f"{path}: {symbol} body has no non-stack machine-word access"
+                )
+            seen.add(current["name"])
+            current = target_body
+
+
+def validate_chunked_primitives(path: Path, expected_format: str, expected_machine: int):
+    """Inspect exact symbol bodies without depending on host disassembly tools."""
+    objects = []
+    for name, payload in archive_members(path):
+        machine = elf_machine(payload) if expected_format == "elf" else macho_cpu(payload)
+        if machine != expected_machine:
+            continue
+        bodies = parse_elf_object(payload) if expected_format == "elf" else parse_macho_object(payload)
+        objects.append((name, bodies))
+    definitions = _collect_archive_definitions(path, objects, expected_format)
+    for symbol, found in definitions.items():
+        if not found:
+            raise AssertionError(f"{path}: could not locate required symbol body {symbol}")
+        if len(found) != 1:
+            members = ", ".join(repr(name) for name, _ in found)
+            raise AssertionError(f"{path}: ambiguous definition of {symbol} in {members}")
+        member, bodies = found[0]
+        _validate_bodies(
+            f"{path}: member {member!r}", bodies, expected_format, expected_machine
+        )
+
+
+def _collect_archive_definitions(path: Path, objects, expected_format: str):
+    """Collect every required definition so duplicate members fail closed."""
+    definitions = {symbol: [] for symbol in CHUNKED_SYMBOLS}
+    for name, bodies in objects:
+        for symbol in CHUNKED_SYMBOLS:
+            lookup = symbol if expected_format == "elf" else "_" + symbol
+            if lookup in bodies:
+                definitions[symbol].append((name, bodies))
+    for symbol, found in definitions.items():
+        if len(found) > 1:
+            members = ", ".join(repr(name) for name, _ in found)
+            raise AssertionError(f"{path}: ambiguous definition of {symbol} in {members}")
+    return definitions
+
+
 def validate_archive(path: Path, expected_format: str, expected_machine: int):
     object_count = 0
     for name, payload in archive_members(path):
@@ -179,8 +731,13 @@ def validate_archive(path: Path, expected_format: str, expected_machine: int):
                 f"(n_type={n_type:#x})"
             )
 
+    validate_chunked_primitives(path, expected_format, expected_machine)
+
 
 def main():
+    source = os.environ.get("RUNTIME_STRING_SOURCE")
+    if source:
+        validate_str_eq_source(Path(source))
     validate_archive(Path(os.environ["RUNTIME_X86_64_LINUX"]), "elf", 62)
     validate_archive(Path(os.environ["RUNTIME_AARCH64_LINUX"]), "elf", 183)
     validate_archive(Path(os.environ["RUNTIME_AARCH64_MACOS"]), "macho", 0x0100000C)


### PR DESCRIPTION
## Summary

- replace byte-at-a-time runtime memory primitives with alignment-safe 8-byte chunked paths and loop-free exact tail handling
- keep chunk loads/stores opaque to loop-idiom lowering without changing exported symbols or ABI
- route string equality through the canonical equality primitive and add exhaustive semantics plus fail-closed cross-target archive guards

## Evidence

On native arm64 macOS with rustc 1.92, `-Copt-level=z -Clto=true -Ccodegen-units=1`, 500 warmups, seven samples, and identical 16-size/four-offset baseline and candidate harnesses, aggregate geometric speedups were 2.18x for memcpy, 2.00x for memmove, and 1.85x for memset. Memcmp early/equal/late cases measured 1.02x/2.46x/2.31x; bcmp measured 0.91x/1.69x/1.72x; string equality measured 0.98x/1.69x/1.64x. At 1 KiB, equal and late comparisons improved by approximately 4.7-8.7x, while 0-7-byte cases remained near parity. Runtime archive growth was 5,256 bytes on x86-64 Linux, 4,552 bytes on AArch64 Linux, and 2,112 bytes on AArch64 macOS.

Focused runtime and runtime-ABI tests, optimized native semantics, native CLI coverage, all-three-target archive validation, 27 parser mutation tests, `scripts/rue quick`, `scripts/rue premerge`, formatting, Python 3.9 baseline validation, and `git diff --check` pass. The independent unsafe-runtime review has no remaining findings.

Fixes RUE-1666