### PR TITLE
RUE-1664: borrow liveness clobber tables

### DIFF
--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -59,8 +59,8 @@ impl LivenessAdapter for Aarch64LivenessAdapter<'_> {
         defs(inst)
     }
 
-    fn clobbers(&self, inst: &Self::Inst) -> Vec<Self::Reg> {
-        inst.clobbers().to_vec()
+    fn clobbers(&self, inst: &Self::Inst) -> &'static [Self::Reg] {
+        inst.clobbers()
     }
 
     fn is_non_returning(&self, inst: &Self::Inst) -> bool {
@@ -413,6 +413,97 @@ pub(crate) fn defs(inst: &Aarch64Inst) -> VRegList {
 mod tests {
     use super::*;
     use crate::aarch64::mir::Cond;
+
+    #[test]
+    fn clobbers_are_borrowed_static_slices() {
+        let mir = Aarch64Mir::new();
+        let adapter = Aarch64LivenessAdapter { mir: &mir };
+        let empty = Aarch64Inst::Ret;
+        let call = Aarch64Inst::call(7);
+        let div = Aarch64Inst::SdivRR {
+            dst: Operand::Physical(Reg::X0),
+            src1: Operand::Physical(Reg::X1),
+            src2: Operand::Physical(Reg::X2),
+        };
+        let syscall = Aarch64Inst::Svc { imm: 0 };
+
+        // This compile-time signature check protects the ownership contract:
+        // the adapter cannot satisfy it by returning a temporary Vec.
+        fn require_static(_: &'static [Reg]) {}
+        require_static(adapter.clobbers(&empty));
+        require_static(adapter.clobbers(&call));
+        require_static(adapter.clobbers(&div));
+        require_static(adapter.clobbers(&syscall));
+
+        assert!(adapter.clobbers(&empty).is_empty());
+        let call_clobbers = adapter.clobbers(&call);
+        assert_eq!(
+            call_clobbers,
+            &[
+                Reg::X0,
+                Reg::X1,
+                Reg::X2,
+                Reg::X3,
+                Reg::X4,
+                Reg::X5,
+                Reg::X6,
+                Reg::X7,
+                Reg::X8,
+                Reg::X9,
+                Reg::X10,
+                Reg::X11,
+                Reg::X12,
+                Reg::X13,
+                Reg::X14,
+                Reg::X15,
+                Reg::X16,
+                Reg::X17,
+                Reg::Lr,
+            ]
+        );
+        assert!(!call_clobbers.contains(&Reg::X18));
+        assert!(!call_clobbers.contains(&Reg::Fp));
+        assert!(!call_clobbers.contains(&Reg::Sp));
+        assert!(adapter.clobbers(&div).is_empty());
+        let syscall_clobbers = adapter.clobbers(&syscall);
+        assert_eq!(
+            syscall_clobbers,
+            &[
+                Reg::X0,
+                Reg::X8,
+                Reg::X9,
+                Reg::X10,
+                Reg::X11,
+                Reg::X12,
+                Reg::X13,
+                Reg::X14,
+                Reg::X15,
+                Reg::X16,
+                Reg::X17,
+            ]
+        );
+        assert!(!syscall_clobbers.contains(&Reg::X1));
+        assert!(!syscall_clobbers.contains(&Reg::X18));
+        assert!(!syscall_clobbers.contains(&Reg::Fp));
+        assert!(!syscall_clobbers.contains(&Reg::Sp));
+
+        let mut mir = Aarch64Mir::new();
+        mir.push(empty);
+        mir.push(call);
+        mir.push(div);
+        mir.push(syscall);
+        let info = analyze(&mir);
+        assert!(info.clobbers_at(0).is_empty());
+        assert!(std::ptr::eq(
+            info.clobbers_at(1),
+            mir.instructions()[1].clobbers()
+        ));
+        assert!(info.clobbers_at(2).is_empty());
+        assert!(std::ptr::eq(
+            info.clobbers_at(3),
+            mir.instructions()[3].clobbers()
+        ));
+    }
 
     #[test]
     fn test_simple_liveness() {

--- a/crates/rue-codegen/src/liveness.rs
+++ b/crates/rue-codegen/src/liveness.rs
@@ -151,7 +151,7 @@ pub trait LivenessAdapter {
     /// Backend MIR instruction type.
     type Inst;
     /// Backend physical register type.
-    type Reg: Copy + Eq + std::hash::Hash;
+    type Reg: Copy + Eq + std::hash::Hash + 'static;
 
     /// Instruction sequence to analyze.
     fn instructions(&self) -> &[Self::Inst];
@@ -185,7 +185,7 @@ pub trait LivenessAdapter {
     fn defs(&self, inst: &Self::Inst) -> VRegList;
 
     /// Return physical registers clobbered by `inst`.
-    fn clobbers(&self, inst: &Self::Inst) -> Vec<Self::Reg>;
+    fn clobbers(&self, inst: &Self::Inst) -> &'static [Self::Reg];
 
     /// Whether `inst` never returns control to the instruction after it.
     ///
@@ -333,11 +333,11 @@ pub fn analyze<I, R>(
     get_successors: impl Fn(usize, &I, &AHashMap<LabelId, usize>) -> SuccessorList,
     get_uses: impl Fn(&I) -> VRegList,
     get_defs: impl Fn(&I) -> VRegList,
-    get_clobbers: impl Fn(&I) -> Vec<R>,
+    get_clobbers: impl Fn(&I) -> &'static [R],
     get_non_returning: impl Fn(&I) -> bool,
 ) -> LivenessInfo<R>
 where
-    R: Copy + Eq + std::hash::Hash,
+    R: Copy + Eq + std::hash::Hash + 'static,
 {
     analyze_inner(
         instructions,
@@ -365,11 +365,11 @@ pub fn analyze_with_debug<I, R>(
     get_successors: impl Fn(usize, &I, &AHashMap<LabelId, usize>) -> SuccessorList,
     get_uses: impl Fn(&I) -> VRegList,
     get_defs: impl Fn(&I) -> VRegList,
-    get_clobbers: impl Fn(&I) -> Vec<R>,
+    get_clobbers: impl Fn(&I) -> &'static [R],
     get_non_returning: impl Fn(&I) -> bool,
 ) -> (LivenessInfo<R>, LivenessDebugInfo)
 where
-    R: Copy + Eq + std::hash::Hash,
+    R: Copy + Eq + std::hash::Hash + 'static,
 {
     let (liveness, debug) = analyze_inner(
         instructions,
@@ -398,12 +398,12 @@ fn analyze_inner<I, R>(
     get_successors: impl Fn(usize, &I, &AHashMap<LabelId, usize>) -> SuccessorList,
     get_uses: impl Fn(&I) -> VRegList,
     get_defs: impl Fn(&I) -> VRegList,
-    get_clobbers: impl Fn(&I) -> Vec<R>,
+    get_clobbers: impl Fn(&I) -> &'static [R],
     get_non_returning: impl Fn(&I) -> bool,
     collect_debug: bool,
 ) -> (LivenessInfo<R>, Option<LivenessDebugInfo>)
 where
-    R: Copy + Eq + std::hash::Hash,
+    R: Copy + Eq + std::hash::Hash + 'static,
 {
     let num_insts = instructions.len();
 
@@ -502,7 +502,7 @@ where
     });
 
     // Step 6: Collect clobbers and the never-returning call sites (RUE-1224)
-    let clobbers_at: Vec<Vec<R>> = instructions.iter().map(|i| get_clobbers(i)).collect();
+    let clobbers_at: Vec<&'static [R]> = instructions.iter().map(&get_clobbers).collect();
     let non_returning_at: Vec<bool> = instructions.iter().map(&get_non_returning).collect();
 
     (
@@ -530,7 +530,7 @@ pub fn analyze_debug<I, R>(
     get_defs: impl Fn(&I) -> VRegList,
 ) -> LivenessDebugInfo
 where
-    R: Copy + Eq + std::hash::Hash,
+    R: Copy + Eq + std::hash::Hash + 'static,
 {
     analyze_with_debug(
         instructions,
@@ -540,7 +540,7 @@ where
         get_successors,
         get_uses,
         get_defs,
-        |_| Vec::<R>::new(),
+        |_| &[] as &'static [R],
         |_| false,
     )
     .1
@@ -990,6 +990,41 @@ mod tests {
         let _: VRegList = (0..5).map(VReg::new).collect();
     }
 
+    #[test]
+    fn large_mir_clobber_table_uses_one_borrowed_slice_pointer_per_instruction() {
+        const NUM_INSTRUCTIONS: usize = 4096;
+        static REPRESENTATIVE_CLOBBERS: [u32; 3] = [3, 5, 8];
+        let instructions = vec![TestInst::Ret; NUM_INSTRUCTIONS];
+
+        let info: LivenessInfo<u32> = analyze(
+            &instructions,
+            0,
+            VRegClasses::all_gp(0),
+            test_get_label,
+            |idx, inst, label_to_idx| {
+                test_get_successors(idx, inst, label_to_idx, NUM_INSTRUCTIONS)
+            },
+            test_get_uses,
+            test_get_defs,
+            |_| &REPRESENTATIVE_CLOBBERS,
+            |_| false,
+        );
+
+        // A clobber entry is only a fat pointer; the instruction table owns
+        // no per-entry register vectors or copied register elements.
+        assert_eq!(
+            std::mem::size_of::<&'static [u32]>(),
+            2 * std::mem::size_of::<usize>()
+        );
+        assert_eq!(info.clobbers_at.len(), NUM_INSTRUCTIONS);
+        assert!(info.clobbers_at.capacity() >= NUM_INSTRUCTIONS);
+        assert!(
+            info.clobbers_at
+                .iter()
+                .all(|clobbers| std::ptr::eq(*clobbers, &REPRESENTATIVE_CLOBBERS[..]))
+        );
+    }
+
     // Simple test instruction type
     #[derive(Debug, Clone)]
     enum TestInst {
@@ -1052,8 +1087,8 @@ mod tests {
         }
     }
 
-    fn test_get_clobbers(_inst: &TestInst) -> Vec<u32> {
-        Vec::new()
+    fn test_get_clobbers(_inst: &TestInst) -> &'static [u32] {
+        &[]
     }
 
     fn reset_dataflow_call_count() {

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -379,13 +379,13 @@ impl LiveRange {
 /// This struct is target-independent and holds all the information needed
 /// by the register allocator. Each backend's `analyze()` function populates
 /// an instance of this type.
-pub struct LivenessInfo<Reg: Copy + Eq + std::hash::Hash> {
+pub struct LivenessInfo<Reg: Copy + Eq + std::hash::Hash + 'static> {
     /// Live range for each virtual register (indexed by vreg index).
     /// Uses dense Vec storage since VReg indices are contiguous.
     pub ranges: IndexMap<VReg, Option<LiveRange>>,
     /// For each instruction index, the physical registers clobbered by that instruction.
     /// This is used to prevent allocating vregs to registers that would be clobbered.
-    pub clobbers_at: Vec<Vec<Reg>>,
+    pub clobbers_at: Vec<&'static [Reg]>,
     /// For each instruction index, whether control can reach the instruction
     /// after it once it executes.
     ///
@@ -404,7 +404,7 @@ pub struct LivenessInfo<Reg: Copy + Eq + std::hash::Hash> {
     pub vreg_classes: VRegClasses,
 }
 
-impl<Reg: Copy + Eq + std::hash::Hash> LivenessInfo<Reg> {
+impl<Reg: Copy + Eq + std::hash::Hash + 'static> LivenessInfo<Reg> {
     /// Create a new empty liveness info.
     pub fn new() -> Self {
         Self {
@@ -460,7 +460,7 @@ impl<Reg: Copy + Eq + std::hash::Hash> LivenessInfo<Reg> {
 
     /// Get the physical registers clobbered at a given instruction index.
     pub fn clobbers_at(&self, inst_idx: usize) -> &[Reg] {
-        &self.clobbers_at[inst_idx]
+        self.clobbers_at[inst_idx]
     }
 
     /// Whether the instruction at `inst_idx` never returns control to the
@@ -2652,6 +2652,68 @@ mod tests {
         );
     }
 
+    #[test]
+    fn rewrite_buffer_reuses_each_lane_after_drain_and_clear() {
+        let mut buffer = RewriteBuffer::new();
+        buffer.push_before("before-1");
+        buffer.push_main("main-1");
+        buffer.push_after("after-1");
+        let capacities = (
+            buffer.before.capacity(),
+            buffer.main.capacity(),
+            buffer.after.capacity(),
+        );
+
+        assert_eq!(
+            buffer.drain_ordered().collect::<Vec<_>>(),
+            ["before-1", "main-1", "after-1"]
+        );
+        assert_eq!(
+            (
+                buffer.before.len(),
+                buffer.main.len(),
+                buffer.after.len(),
+                buffer.before.capacity(),
+                buffer.main.capacity(),
+                buffer.after.capacity(),
+            ),
+            (0, 0, 0, capacities.0, capacities.1, capacities.2),
+        );
+
+        buffer.push_after("after-2");
+        buffer.push_before("before-2");
+        buffer.push_main("main-2");
+        assert_eq!(
+            (
+                buffer.before.capacity(),
+                buffer.main.capacity(),
+                buffer.after.capacity(),
+            ),
+            capacities,
+        );
+        assert_eq!(
+            buffer.drain_ordered().collect::<Vec<_>>(),
+            ["before-2", "main-2", "after-2"]
+        );
+
+        buffer.push_before("before-3");
+        buffer.push_main("main-3");
+        buffer.push_after("after-3");
+        buffer.clear();
+        assert_eq!(
+            (buffer.before.len(), buffer.main.len(), buffer.after.len()),
+            (0, 0, 0)
+        );
+        assert_eq!(
+            (
+                buffer.before.capacity(),
+                buffer.main.capacity(),
+                buffer.after.capacity(),
+            ),
+            capacities,
+        );
+    }
+
     // ========================================
     // LiveRange tests
     // ========================================
@@ -2701,6 +2763,53 @@ mod tests {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     struct TestReg(u32);
 
+    static NO_CLOBBERS: &[TestReg] = &[];
+    static CLOBBERS_REG0: &[TestReg] = &[TestReg(0)];
+    static CLOBBERS_REG9: &[TestReg] = &[TestReg(9)];
+    static CLOBBERS_REG9_REG8: &[TestReg] = &[TestReg(9), TestReg(8)];
+
+    static REG0_AT_2: &[&'static [TestReg]] = &[
+        NO_CLOBBERS,
+        NO_CLOBBERS,
+        CLOBBERS_REG0,
+        NO_CLOBBERS,
+        NO_CLOBBERS,
+    ];
+    static REG0_AT_1_AND_3: &[&'static [TestReg]] = &[
+        NO_CLOBBERS,
+        CLOBBERS_REG0,
+        NO_CLOBBERS,
+        CLOBBERS_REG0,
+        NO_CLOBBERS,
+    ];
+    static REG0_AT_1: &[&'static [TestReg]] = &[NO_CLOBBERS, CLOBBERS_REG0];
+    static REG9_REG8_AT_2: &[&'static [TestReg]] = &[
+        NO_CLOBBERS,
+        NO_CLOBBERS,
+        CLOBBERS_REG9_REG8,
+        NO_CLOBBERS,
+        NO_CLOBBERS,
+    ];
+    static REG9_AT_2: &[&'static [TestReg]] = &[
+        NO_CLOBBERS,
+        NO_CLOBBERS,
+        CLOBBERS_REG9,
+        NO_CLOBBERS,
+        NO_CLOBBERS,
+    ];
+    static REG9_AT_2_AND_7: &[&'static [TestReg]] = &[
+        NO_CLOBBERS,
+        NO_CLOBBERS,
+        CLOBBERS_REG9,
+        NO_CLOBBERS,
+        NO_CLOBBERS,
+        NO_CLOBBERS,
+        NO_CLOBBERS,
+        CLOBBERS_REG9,
+        NO_CLOBBERS,
+        NO_CLOBBERS,
+    ];
+
     fn make_liveness(ranges: Vec<(u32, usize, usize)>) -> LivenessInfo<TestReg> {
         // Find max vreg index and max instruction index
         let max_vreg = ranges.iter().map(|(v, _, _)| *v).max().unwrap_or(0);
@@ -2712,18 +2821,21 @@ mod tests {
         }
 
         // Initialize clobbers_at based on max instruction index
-        info.clobbers_at = vec![Vec::new(); max_inst + 1];
+        info.clobbers_at = vec![&[]; max_inst + 1];
         info
     }
 
     fn make_liveness_with_clobbers(
         ranges: Vec<(u32, usize, usize)>,
-        clobbers: Vec<(usize, TestReg)>,
+        clobbers: &'static [&'static [TestReg]],
     ) -> LivenessInfo<TestReg> {
         let mut info = make_liveness(ranges);
-        for (idx, reg) in clobbers {
-            info.clobbers_at[idx].push(reg);
-        }
+        assert_eq!(
+            info.clobbers_at.len(),
+            clobbers.len(),
+            "static clobber table must cover the liveness instruction range"
+        );
+        info.clobbers_at = clobbers.to_vec();
         info
     }
 
@@ -2768,7 +2880,7 @@ mod tests {
         // before the guard branch and used after the label, so the trap call at
         // instruction 2 sits textually inside its range — but the trap aborts,
         // so on the path reaching the later use the call never ran.
-        let mut liveness = make_liveness_with_clobbers(vec![(0, 0, 4)], vec![(2, TestReg(0))]);
+        let mut liveness = make_liveness_with_clobbers(vec![(0, 0, 4)], REG0_AT_2);
         mark_non_returning(&mut liveness, &[2]);
         let index = ClobberIndex::build(&liveness, &[TestReg(0)]);
 
@@ -2780,8 +2892,7 @@ mod tests {
     fn clobber_index_still_sees_a_returning_call_beside_a_trap() {
         // A returning call at 1 and a trap at 3: only the returning one can
         // destroy a value whose later uses execute.
-        let mut liveness =
-            make_liveness_with_clobbers(vec![(0, 0, 4)], vec![(1, TestReg(0)), (3, TestReg(0))]);
+        let mut liveness = make_liveness_with_clobbers(vec![(0, 0, 4)], REG0_AT_1_AND_3);
         mark_non_returning(&mut liveness, &[3]);
         let index = ClobberIndex::build(&liveness, &[TestReg(0)]);
 
@@ -2798,10 +2909,7 @@ mod tests {
         // Same allocation shape as `caller_saved_is_preferred_...`, except the
         // clobber site is a never-returning call: now both intervals fit in the
         // caller-saved class and the prologue saves nothing.
-        let mut liveness = make_liveness_with_clobbers(
-            vec![(0, 0, 4), (1, 3, 4)],
-            vec![(2, TestReg(9)), (2, TestReg(8))],
-        );
+        let mut liveness = make_liveness_with_clobbers(vec![(0, 0, 4), (1, 3, 4)], REG9_REG8_AT_2);
         mark_non_returning(&mut liveness, &[2]);
         let file = RegisterFile::gp_only(SaveClasses {
             caller_saved: &[TestReg(9), TestReg(8)],
@@ -2978,7 +3086,7 @@ mod tests {
 
     #[test]
     fn clobber_index_answers_only_for_tracked_registers() {
-        let liveness = make_liveness_with_clobbers(vec![(0, 0, 4)], vec![(2, TestReg(0))]);
+        let liveness = make_liveness_with_clobbers(vec![(0, 0, 4)], REG0_AT_2);
         let index = ClobberIndex::build(&liveness, &[TestReg(0)]);
 
         assert!(index.is_clobbered_during(TestReg(0), &LiveRange::new(0, 4)));
@@ -2991,7 +3099,7 @@ mod tests {
 
     #[test]
     fn clobber_index_tolerates_ranges_past_the_last_instruction() {
-        let liveness = make_liveness_with_clobbers(vec![(0, 0, 1)], vec![(1, TestReg(0))]);
+        let liveness = make_liveness_with_clobbers(vec![(0, 0, 1)], REG0_AT_1);
         let index = ClobberIndex::build(&liveness, &[TestReg(0)]);
 
         assert!(index.is_clobbered_during(TestReg(0), &LiveRange::new(0, usize::MAX)));
@@ -3001,10 +3109,7 @@ mod tests {
     #[test]
     fn caller_saved_is_preferred_and_call_crossing_intervals_avoid_it() {
         // v0 spans the clobber at instruction 2, v1 does not.
-        let liveness = make_liveness_with_clobbers(
-            vec![(0, 0, 4), (1, 3, 4)],
-            vec![(2, TestReg(9)), (2, TestReg(8))],
-        );
+        let liveness = make_liveness_with_clobbers(vec![(0, 0, 4), (1, 3, 4)], REG9_REG8_AT_2);
         let file = RegisterFile::gp_only(SaveClasses {
             caller_saved: &[TestReg(9), TestReg(8)],
             callee_saved: &[TestReg(0)],
@@ -3046,10 +3151,7 @@ mod tests {
         // its own. Because v0's save is paid either way and TestReg(0) encodes
         // better, the second pass gives v1 the callee-saved register instead
         // (RUE-1227) — at no cost, since the prologue is unchanged.
-        let liveness = make_liveness_with_clobbers(
-            vec![(0, 0, 2), (1, 3, 4)],
-            vec![(2, TestReg(9)), (2, TestReg(8))],
-        );
+        let liveness = make_liveness_with_clobbers(vec![(0, 0, 2), (1, 3, 4)], REG9_REG8_AT_2);
         let file = RegisterFile::gp_only(SaveClasses {
             caller_saved: &[TestReg(9), TestReg(8)],
             callee_saved: &[TestReg(0)],
@@ -3085,8 +3187,7 @@ mod tests {
         // spans the clobber, so the first pass commits no callee-saved
         // register at all, there is no sunk cost to reuse, and the second pass
         // is skipped outright. The prologue stays empty.
-        let liveness =
-            make_liveness_with_clobbers(vec![(0, 0, 1), (1, 3, 4)], vec![(2, TestReg(9))]);
+        let liveness = make_liveness_with_clobbers(vec![(0, 0, 1), (1, 3, 4)], REG9_AT_2);
         let file = RegisterFile::gp_only(SaveClasses {
             caller_saved: &[TestReg(9)],
             callee_saved: &[TestReg(0)],
@@ -3130,10 +3231,8 @@ mod tests {
         // This is exactly why the tiebreak cannot be a one-pass rule that
         // reuses whatever is in the save set so far: at v1 the allocator has
         // not yet seen v2.
-        let liveness = make_liveness_with_clobbers(
-            vec![(0, 0, 2), (1, 3, 5), (2, 4, 9)],
-            vec![(2, TestReg(9)), (7, TestReg(9))],
-        );
+        let liveness =
+            make_liveness_with_clobbers(vec![(0, 0, 2), (1, 3, 5), (2, 4, 9)], REG9_AT_2_AND_7);
         let file = RegisterFile::gp_only(SaveClasses {
             caller_saved: &[TestReg(9)],
             callee_saved: &[TestReg(0), TestReg(1)],
@@ -3170,10 +3269,8 @@ mod tests {
     fn eviction_never_hands_a_clobbered_caller_saved_register_to_a_spanning_interval() {
         // Only a caller-saved register exists, and every interval spans the
         // clobber, so nothing can hold a value: all three must spill.
-        let liveness = make_liveness_with_clobbers(
-            vec![(0, 0, 4), (1, 0, 4), (2, 0, 4)],
-            vec![(2, TestReg(9))],
-        );
+        let liveness =
+            make_liveness_with_clobbers(vec![(0, 0, 4), (1, 0, 4), (2, 0, 4)], REG9_AT_2);
         let file = RegisterFile::gp_only(SaveClasses {
             caller_saved: &[TestReg(9)],
             callee_saved: &[],

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -59,8 +59,8 @@ impl LivenessAdapter for X86LivenessAdapter<'_> {
         defs(inst)
     }
 
-    fn clobbers(&self, inst: &Self::Inst) -> Vec<Self::Reg> {
-        inst.clobbers().to_vec()
+    fn clobbers(&self, inst: &Self::Inst) -> &'static [Self::Reg] {
+        inst.clobbers()
     }
 
     fn is_non_returning(&self, inst: &Self::Inst) -> bool {
@@ -469,6 +469,72 @@ pub fn defs(inst: &X86Inst) -> VRegList {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn clobbers_are_borrowed_static_slices() {
+        let mir = X86Mir::new();
+        let adapter = X86LivenessAdapter { mir: &mir };
+        let empty = X86Inst::Ret;
+        let call = X86Inst::call(7);
+        let div = X86Inst::IdivR {
+            src: Operand::Physical(Reg::Rcx),
+        };
+        let syscall = X86Inst::Syscall;
+
+        // This compile-time signature check protects the ownership contract:
+        // the adapter cannot satisfy it by returning a temporary Vec.
+        fn require_static(_: &'static [Reg]) {}
+        require_static(adapter.clobbers(&empty));
+        require_static(adapter.clobbers(&call));
+        require_static(adapter.clobbers(&div));
+        require_static(adapter.clobbers(&syscall));
+
+        assert!(adapter.clobbers(&empty).is_empty());
+        let call_clobbers = adapter.clobbers(&call);
+        assert_eq!(
+            call_clobbers,
+            &[
+                Reg::Rax,
+                Reg::Rcx,
+                Reg::Rdx,
+                Reg::Rsi,
+                Reg::Rdi,
+                Reg::R8,
+                Reg::R9,
+                Reg::R10,
+                Reg::R11,
+            ]
+        );
+        assert!(!call_clobbers.contains(&Reg::Rsp));
+        assert!(!call_clobbers.contains(&Reg::Rbp));
+        assert!(!call_clobbers.contains(&Reg::R12));
+        assert_eq!(adapter.clobbers(&div), &[Reg::Rax, Reg::Rdx]);
+        let syscall_clobbers = adapter.clobbers(&syscall);
+        assert_eq!(syscall_clobbers, &[Reg::Rax, Reg::Rcx, Reg::R11]);
+        assert!(!syscall_clobbers.contains(&Reg::Rsp));
+        assert!(!syscall_clobbers.contains(&Reg::Rbp));
+        assert!(!syscall_clobbers.contains(&Reg::R12));
+
+        let mut mir = X86Mir::new();
+        mir.push(empty);
+        mir.push(call);
+        mir.push(div);
+        mir.push(syscall);
+        let info = analyze(&mir);
+        assert!(info.clobbers_at(0).is_empty());
+        assert!(std::ptr::eq(
+            info.clobbers_at(1),
+            mir.instructions()[1].clobbers()
+        ));
+        assert!(std::ptr::eq(
+            info.clobbers_at(2),
+            mir.instructions()[2].clobbers()
+        ));
+        assert!(std::ptr::eq(
+            info.clobbers_at(3),
+            mir.instructions()[3].clobbers()
+        ));
+    }
 
     #[test]
     fn test_simple_liveness() {


### PR DESCRIPTION
## Summary

- keep backend clobber authorities as borrowed static slices through liveness and regalloc
- preserve the existing reusable rewrite buffer and pin its before/main/after drain order and capacity reuse
- add x86-64/AArch64 parity, negative clobber-set, pointer-identity, and large-MIR allocation-shape coverage

## Evidence

- a 4,096-instruction clobber table now stores 65,536 bytes of slice references instead of 98,304 bytes of Vec headers plus 49,152 bytes of copied registers on a 64-bit host: 81,920 bytes and 4,096 inner allocations avoided, excluding allocator metadata
- Lattice O2 regalloc and assembly output are byte-for-byte identical to origin/trunk for x86-64 Linux and AArch64 Linux; compared 12,808,389/8,288,474 bytes on x86-64 and 13,112,976/7,481,772 bytes on AArch64
- rewrite-buffer tests preserve before/main/after order and demonstrate unchanged lane capacities across drain and clear cycles

## Validation

- full rue-codegen unit suite: 789 passed
- focused borrowed-clobber, large-MIR, and rewrite-buffer tests
- codegen clippy
- scripts/rue quick: 32 targets passed
- scripts/rue premerge: 202 targets passed
- scripts/rue fmt
- git diff --check
- scripts/rue test: 234 tests passed; six oracle corpus build actions hit macOS OS error 35 while spawning threads under host-wide user-thread exhaustion (5,205 visible user threads against a 4,000 process/thread limit); the O1 corpus reproduced the same infrastructure failure in isolation, so CI remains the authoritative corpus rerun

Fixes RUE-1664