### PR TITLE
RUE-1669: index rooted codegen batch lookups

### DIFF
--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -358,6 +358,22 @@ pub(crate) fn validate_production_call_relocations(
     relocations: &[rue_codegen::EmittedRelocation],
     symbol_mappings: &std::collections::BTreeMap<String, String>,
 ) -> CompileResult<()> {
+    // Resolve the canonical machine-name domain once. Relocation validation is
+    // then independent of the number of source/glue mappings, rather than
+    // rescanning every mapping for every emitted call.
+    let canonical_machine_symbols = symbol_mappings
+        .values()
+        .map(String::as_str)
+        .collect::<ahash::AHashSet<_>>();
+    validate_production_call_relocations_with_membership(relocations, |symbol| {
+        canonical_machine_symbols.contains(symbol)
+    })
+}
+
+fn validate_production_call_relocations_with_membership(
+    relocations: &[rue_codegen::EmittedRelocation],
+    is_canonical_machine_symbol: impl Fn(&str) -> bool,
+) -> CompileResult<()> {
     for relocation in relocations {
         let is_call = matches!(
             relocation.kind,
@@ -365,9 +381,7 @@ pub(crate) fn validate_production_call_relocations(
         );
         if !is_call
             || rue_runtime_abi::classify_export(&relocation.symbol).is_some()
-            || symbol_mappings
-                .values()
-                .any(|machine_name| machine_name == &relocation.symbol)
+            || is_canonical_machine_symbol(&relocation.symbol)
         {
             continue;
         }
@@ -429,37 +443,102 @@ fn main() -> i32 {
             "legacy".to_owned(),
             "__rue_sem_v1_projected".to_owned(),
         )]);
-        let relocation = |symbol: &str| rue_codegen::EmittedRelocation {
+        let relocation = |symbol: &str, kind| rue_codegen::EmittedRelocation {
             offset: 0,
             symbol: symbol.to_owned(),
-            kind: RelocationKind::X86Plt32,
+            kind,
             addend: -4,
         };
 
+        for kind in [RelocationKind::X86Plt32, RelocationKind::Aarch64Call26] {
+            assert!(
+                validate_production_call_relocations(
+                    &[relocation("__rue_sem_v1_projected", kind)],
+                    &mappings,
+                )
+                .is_ok()
+            );
+            assert!(
+                validate_production_call_relocations(
+                    &[relocation(
+                        rue_runtime_abi::RuntimeHelperId::DebugBool.symbol(),
+                        kind,
+                    )],
+                    &mappings,
+                )
+                .is_ok()
+            );
+            assert!(
+                validate_production_call_relocations(&[relocation("legacy", kind)], &mappings)
+                    .is_err()
+            );
+            assert!(
+                validate_production_call_relocations(
+                    &[relocation("__rue_drop_unprojected", kind)],
+                    &mappings,
+                )
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn production_relocation_validation_keeps_one_canonical_membership_authority() {
+        let source = include_str!("backend.rs");
+        let production = source
+            .split_once("pub(crate) fn validate_production_call_relocations(")
+            .expect("production validator remains present")
+            .1
+            .split_once("fn validate_production_call_relocations_with_membership(")
+            .expect("membership loop remains separated from set construction")
+            .0;
+        assert!(production.contains("collect::<ahash::AHashSet<_>>()"));
+        assert!(production.contains("canonical_machine_symbols.contains(symbol)"));
         assert!(
-            validate_production_call_relocations(
-                &[relocation("__rue_sem_v1_projected")],
-                &mappings,
-            )
-            .is_ok()
+            !production.contains(".any("),
+            "the production path must not restore a per-relocation mapping scan"
         );
-        assert!(
-            validate_production_call_relocations(
-                &[relocation(
-                    rue_runtime_abi::RuntimeHelperId::DebugBool.symbol(),
-                )],
-                &mappings,
-            )
-            .is_ok()
-        );
-        assert!(validate_production_call_relocations(&[relocation("legacy")], &mappings).is_err());
-        assert!(
-            validate_production_call_relocations(
-                &[relocation("__rue_drop_unprojected")],
-                &mappings,
-            )
-            .is_err()
-        );
+    }
+
+    #[test]
+    fn production_call_symbol_validation_scales_with_relocation_count() {
+        const SYMBOLS: usize = 2048;
+        let mappings = (0..SYMBOLS)
+            .map(|index| {
+                (
+                    format!("source_{index}"),
+                    format!("__rue_sem_v1_projected_{index}"),
+                )
+            })
+            .collect::<std::collections::BTreeMap<_, _>>();
+        let relocations = (0..SYMBOLS)
+            .map(|index| rue_codegen::EmittedRelocation {
+                offset: index as u64,
+                symbol: format!("__rue_sem_v1_projected_{index}"),
+                kind: RelocationKind::X86Plt32,
+                addend: 0,
+            })
+            .collect::<Vec<_>>();
+
+        validate_production_call_relocations(&relocations, &mappings)
+            .expect("every canonical machine symbol must validate");
+
+        // The validation loop performs one membership operation per emitted
+        // call. Keeping the membership operation injectable makes the
+        // scaling contract observable without relying on wall-clock timing:
+        // a mapping-wide scan would perform SYMBOLS comparisons for each
+        // relocation instead.
+        let canonical = mappings
+            .values()
+            .map(String::as_str)
+            .collect::<ahash::AHashSet<_>>();
+        let membership_calls = std::cell::Cell::new(0usize);
+        validate_production_call_relocations_with_membership(&relocations, |symbol| {
+            membership_calls.set(membership_calls.get() + 1);
+            canonical.contains(symbol)
+        })
+        .expect("every canonical machine symbol must validate through the membership helper");
+        assert_eq!(membership_calls.get(), SYMBOLS);
     }
 
     fn projection_section(kind: SectionKind, atoms: &[&[u8]]) -> CodegenSection {

--- a/crates/rue-compiler/src/codegen_query.rs
+++ b/crates/rue-compiler/src/codegen_query.rs
@@ -15,6 +15,17 @@ use rue_query::{QueryAbort, QueryContext, QueryFamily, QueryKey, QueryOutcome, Q
 
 use crate::retained_charge::RetainedCharge;
 
+/// Internal bridge for the rooted backend's batch-slot authority. The
+/// implementation lives with `OptimizedCfgBatchKey` so its source guard can
+/// inspect the private authority while codegen remains the sole consumer.
+pub(crate) trait OptimizedCfgBatchLookup {
+    fn optimized_cfg_position(
+        &self,
+        source: &Arc<[crate::cfg_query::OptimizedCfgQueryKey]>,
+        key: &crate::cfg_query::OptimizedCfgQueryKey,
+    ) -> Option<usize>;
+}
+
 #[cfg(test)]
 use std::cell::Cell;
 
@@ -474,10 +485,7 @@ pub(crate) fn evaluate_codegen_unit(
             .optimized_cfg_batch
             .as_ref()
             .and_then(|batch_key| {
-                batch_key
-                    .keys
-                    .iter()
-                    .position(|candidate| candidate == &key.optimized_cfg)
+                batch_key.optimized_cfg_position(&batch_key.keys, &key.optimized_cfg)
             })
             .expect("codegen optimized-CFG key belongs to its batch");
         let value = batch.values[index].clone();

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -544,6 +544,127 @@ mod tests {
         );
     }
 
+    #[test]
+    fn optimized_cfg_batch_index_is_stable_source_guarded_and_drives_wide_codegen() {
+        let snapshot = wide_reached_program(64, 7);
+        let mut session = CompilerSession::new();
+        publish_test_snapshot(&mut session, &snapshot).unwrap();
+        let options = CompileOptions {
+            opt_level: rue_cfg::OptLevel::O2,
+            ..CompileOptions::default()
+        };
+        let rooted = session.rooted_cfg(&options).unwrap();
+        let batch = rooted.optimized_cfg_batch.clone();
+
+        // Every reached key resolves to its exact value slot without a
+        // program-wide positional scan.
+        for (position, key) in batch.keys.iter().enumerate() {
+            assert_eq!(
+                crate::codegen_query::OptimizedCfgBatchLookup::optimized_cfg_position(
+                    &batch,
+                    &batch.keys,
+                    key,
+                ),
+                Some(position)
+            );
+        }
+
+        // Equivalent contents from a different source allocation are not a
+        // valid authority, and a key absent from the batch is rejected.
+        let foreign_source: Arc<[_]> = batch.keys.iter().cloned().collect();
+        assert_eq!(
+            crate::codegen_query::OptimizedCfgBatchLookup::optimized_cfg_position(
+                &batch,
+                &foreign_source,
+                &batch.keys[0],
+            ),
+            None,
+            "a position authority cannot cross source slices"
+        );
+        let mut counterfeit = batch.keys[0].clone();
+        counterfeit.opt_level = rue_cfg::OptLevel::O0;
+        assert_eq!(
+            crate::codegen_query::OptimizedCfgBatchLookup::optimized_cfg_position(
+                &batch,
+                &batch.keys,
+                &counterfeit,
+            ),
+            None
+        );
+
+        // Reconstructing an equal query key creates a different transport
+        // authority, but must not change any public query identity plane.
+        let equivalent = crate::revisioned_query_database::OptimizedCfgBatchKey::new(
+            batch.keys.iter().cloned().collect(),
+            batch.generation,
+            batch.roots.iter().cloned().collect(),
+        );
+        assert_eq!(batch, equivalent);
+        assert_eq!(batch.stable_identity(), equivalent.stable_identity());
+        let stable_digest = |key: &crate::revisioned_query_database::OptimizedCfgBatchKey| {
+            let mut hasher = rue_query::StableHasher::new();
+            key.stable_hash(&mut hasher);
+            hasher.finish128()
+        };
+        assert_eq!(stable_digest(&batch), stable_digest(&equivalent));
+        let memo_hash = |key: &crate::revisioned_query_database::OptimizedCfgBatchKey| {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            std::hash::Hash::hash(key, &mut hasher);
+            std::hash::Hasher::finish(&hasher)
+        };
+        assert_eq!(memo_hash(&batch), memo_hash(&equivalent));
+
+        // Exercise the actual rooted consumer across all representative units;
+        // the source-shape guard below makes the lookup complexity observable
+        // without a wall-clock threshold.
+        drop(rooted);
+        session
+            .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+            .expect("the wide rooted codegen batch must use its validated slots");
+    }
+
+    #[test]
+    #[should_panic(expected = "optimized-CFG batch contains duplicate query keys")]
+    fn optimized_cfg_batch_index_rejects_duplicate_keys() {
+        let snapshot = wide_reached_program(2, 7);
+        let mut session = CompilerSession::new();
+        publish_test_snapshot(&mut session, &snapshot).unwrap();
+        let rooted = session.rooted_cfg(&CompileOptions::default()).unwrap();
+        let batch = rooted.optimized_cfg_batch;
+        let _duplicate = crate::revisioned_query_database::OptimizedCfgBatchKey::new(
+            Arc::from([batch.keys[0].clone(), batch.keys[0].clone()]),
+            batch.generation,
+            batch.roots,
+        );
+    }
+
+    #[test]
+    fn rooted_codegen_batch_lookup_keeps_the_constant_time_authority() {
+        let codegen = include_str!("codegen_query.rs");
+        assert!(
+            codegen
+                .contains("batch_key.optimized_cfg_position(&batch_key.keys, &key.optimized_cfg)")
+        );
+        assert!(
+            !codegen.contains(".position(|candidate| candidate == &key.optimized_cfg)"),
+            "rooted codegen must not restore the program-wide position scan"
+        );
+
+        let backend = include_str!("revisioned_query_database/backend.rs");
+        let authority = backend
+            .split_once("impl OptimizedCfgBatchIndex {")
+            .expect("optimized-CFG batch index authority remains present")
+            .1
+            .split_once("#[derive(Debug, Clone, PartialEq, Eq, Hash)]")
+            .expect("index authority remains before the raw batch key")
+            .0;
+        assert!(authority.contains("self.positions.get(key).copied()?"));
+        assert!(
+            !authority.contains(".position("),
+            "the canonical authority must not degrade to a positional scan"
+        );
+    }
+
     #[cfg(unix)]
     fn execute_compiled_output(output: &CompileOutput, label: &str) -> std::process::Output {
         use std::os::unix::fs::PermissionsExt;

--- a/crates/rue-compiler/src/revisioned_query_database/backend.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/backend.rs
@@ -845,6 +845,48 @@ pub(crate) struct OptimizedCfgBatchKey {
     /// batch constant-time for every holder.
     pub(super) digest: rue_query::StableKeyHash,
     pub(super) memo_hash: u64,
+    /// The validated positional authority for this batch. This is transport
+    /// data only: it is deliberately absent from equality, memo hashing, and
+    /// the stable digest so equivalent query keys retain their identity.
+    index: Arc<OptimizedCfgBatchIndex>,
+}
+
+/// Constant-time lookup authority for the values published by an optimized
+/// CFG batch.
+///
+/// The source slice is retained alongside the map and checked by identity at
+/// lookup time. That guard makes a position from an equivalent-but-different
+/// batch (or a stale position after a source slice is replaced) unusable while
+/// keeping the hot per-codegen-unit lookup O(1) on average.
+#[derive(Debug)]
+struct OptimizedCfgBatchIndex {
+    source: Arc<[crate::cfg_query::OptimizedCfgQueryKey]>,
+    positions: AHashMap<crate::cfg_query::OptimizedCfgQueryKey, usize>,
+}
+
+impl OptimizedCfgBatchIndex {
+    fn new(source: Arc<[crate::cfg_query::OptimizedCfgQueryKey]>) -> Self {
+        let mut positions = AHashMap::with_capacity(source.len());
+        for (position, key) in source.iter().enumerate() {
+            assert!(
+                positions.insert(key.clone(), position).is_none(),
+                "optimized-CFG batch contains duplicate query keys"
+            );
+        }
+        Self { source, positions }
+    }
+
+    fn position_of(
+        &self,
+        source: &Arc<[crate::cfg_query::OptimizedCfgQueryKey]>,
+        key: &crate::cfg_query::OptimizedCfgQueryKey,
+    ) -> Option<usize> {
+        if !Arc::ptr_eq(&self.source, source) {
+            return None;
+        }
+        let position = self.positions.get(key).copied()?;
+        (self.source.get(position) == Some(key)).then_some(position)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -899,12 +941,23 @@ impl OptimizedCfgBatchKey {
         let digest = hasher.finish128();
         let memo_hash = hasher.finish();
         Self {
+            index: Arc::new(OptimizedCfgBatchIndex::new(keys.clone())),
             keys,
             roots,
             generation,
             digest,
             memo_hash,
         }
+    }
+}
+
+impl crate::codegen_query::OptimizedCfgBatchLookup for OptimizedCfgBatchKey {
+    fn optimized_cfg_position(
+        &self,
+        source: &Arc<[crate::cfg_query::OptimizedCfgQueryKey]>,
+        key: &crate::cfg_query::OptimizedCfgQueryKey,
+    ) -> Option<usize> {
+        self.index.position_of(source, key)
     }
 }
 


### PR DESCRIPTION
## Summary

- establish one validated optimized-CFG batch index for rooted codegen unit lookup
- validate production relocation symbols through one canonical machine-symbol set per unit
- preserve query identity and add source, counterfeit, duplicate, backend-parity, and scaling guards

## Validation

- focused compiler tests for batch identity and relocation membership
- `scripts/rue quick`
- `scripts/rue fmt`
- `scripts/rue premerge`
- adversarial compiler-query/codegen review

The full local suite was also attempted. Its oracle corpus actions reached an unrelated host-wide thread limit while creating the existing 256 MiB interpreter worker; clean-host CI remains the corpus authority.

Fixes RUE-1669